### PR TITLE
refactor(gateway): remove workspace plugin generation projections

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1991,7 +1991,6 @@ src/agents/plugin-model-catalog.ts	4
 src/agents/plugin-text-transforms.ts	5
 src/agents/prepared-model-catalog.ts	1
 src/agents/prepared-model-catalog.worker.ts	1
-src/agents/prepared-model-runtime-lease.ts	1
 src/agents/prepared-model-runtime.configured.ts	2
 src/agents/prepared-model-runtime.facts.ts	1
 src/agents/prepared-model-runtime.plugin-context.ts	2

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -28,6 +28,7 @@ type RunAgentAttempt = typeof runAgentAttempt;
 type CaptureSessionDiffBaseline =
   (typeof import("../sessions/session-diff.js"))["captureSessionDiffBaseline"];
 type CliCompactionParams = {
+  pluginGeneration?: unknown;
   sessionId: string;
   sessionEntry?: SessionEntry;
   sessionKey: string;
@@ -224,9 +225,7 @@ let agentCommand: typeof import("./agent-command.js").agentCommand;
 let agentCommandFromGatewayIngress: typeof import("./agent-command.js").agentCommandFromGatewayIngress;
 
 beforeAll(async () => {
-  const command = await import("./agent-command.js");
-  agentCommand = command.agentCommand;
-  agentCommandFromGatewayIngress = command.agentCommandFromGatewayIngress;
+  ({ agentCommand, agentCommandFromGatewayIngress } = await import("./agent-command.js"));
 });
 
 beforeEach(async () => {
@@ -345,6 +344,7 @@ function readLifecyclePhases(): Array<string | undefined> {
 
 const COMPACTION_ERROR =
   "CLI transcript compaction failed for openai/gpt-5.5: Summarization failed: Connection error.";
+const GATEWAY_INGRESS_ARGS = [defaultRuntime, undefined, {}] as const;
 
 describe("agentCommand compaction transcript rotation", () => {
   it.each([
@@ -583,9 +583,7 @@ describe("agentCommand compaction transcript rotation", () => {
         cwd: state.workspaceDir,
         allowModelOverride: false,
       },
-      defaultRuntime,
-      undefined,
-      {},
+      ...GATEWAY_INGRESS_ARGS,
     );
 
     const events = (await loadTranscriptEvents({
@@ -614,41 +612,37 @@ describe("agentCommand compaction transcript rotation", () => {
     );
   });
 
-  it("persists the pending final before CLI compaction failure and still delivers", async () => {
+  it("carries Gateway plugin generation through failed post-turn compaction and still delivers", async () => {
     const sessionId = "cli-compaction-failure";
     const sessionKey = `agent:main:explicit:${sessionId}`;
     const text = "cli reply generated before compaction";
-    let compactionSessionEntry: SessionEntry | undefined;
+    const pluginGeneration = {
+      pluginMetadataSnapshot: { workspaceDir: state.workspaceDir },
+    } as never;
     let storedEntryBeforeCompaction: SessionEntry | undefined;
     state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text, runner: "cli" }));
     state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
-      compactionSessionEntry = params.sessionEntry;
+      expect(params.pluginGeneration).toBe(pluginGeneration);
       storedEntryBeforeCompaction = findStoredSessionEntry(sessionKey);
       throw new Error(COMPACTION_ERROR);
     });
 
-    const result = await agentCommand({
-      message: "room message",
-      sessionId,
-      sessionKey,
-      cwd: state.workspaceDir,
-      channel: "discord",
-      to: "discord:dm:123",
-      accountId: "main",
-      deliver: true,
-    });
-
-    expect(compactionSessionEntry).toMatchObject({
-      pendingFinalDelivery: {
-        kind: "replayable",
-        text,
-        context: {
-          channel: "discord",
-          to: "discord:dm:123",
-          accountId: "main",
-        },
+    const result = await agentCommandFromGatewayIngress(
+      {
+        message: "room message",
+        sessionId,
+        sessionKey,
+        cwd: state.workspaceDir,
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        deliver: true,
+        allowModelOverride: false,
       },
-    });
+      ...GATEWAY_INGRESS_ARGS,
+      { config: state.cfg ?? {}, pluginGeneration },
+    );
+
     expect(storedEntryBeforeCompaction).toMatchObject({
       pendingFinalDelivery: { kind: "replayable", text },
     });

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -610,7 +610,18 @@ describe("runCliTurnCompactionLifecycle", () => {
       agentDir: tmpDir,
       workspaceDir: tmpDir,
     });
-    const acquirePreparedModelRuntime = vi.fn(async () => preparedRuntimeLease);
+    const pluginGeneration = {
+      configuredCatalogEntries: [],
+      inlineProviderModels: [],
+      pluginMetadataSnapshot: preparedRuntimeLease.snapshot.metadataSnapshot,
+      pluginRegistry: preparedRuntimeLease.snapshot.pluginRegistry,
+    } as never;
+    const acquirePreparedModelRuntime = vi.fn<
+      NonNullable<CliCompactionTestDeps["acquirePreparedModelRuntime"]>
+    >(async (_input, options) => {
+      expect(options?.pluginGeneration).toBe(pluginGeneration);
+      return preparedRuntimeLease;
+    });
     const ensureSelectedAgentHarnessPlugin = vi.fn(async () => undefined);
     const compactAgentHarnessSession = vi.fn(async () => ({
       ok: true,
@@ -647,7 +658,7 @@ describe("runCliTurnCompactionLifecycle", () => {
       },
     });
     const { sessionId, sessionKey } = scenario;
-    const updatedEntry = await scenario.run();
+    const updatedEntry = await scenario.run({ pluginGeneration });
 
     expect(resolveContextEngine).toHaveBeenCalledTimes(1);
     expect(applyAgentAutoCompactionGuard).toHaveBeenCalledWith(
@@ -664,16 +675,7 @@ describe("runCliTurnCompactionLifecycle", () => {
         pluginRegistry: preparedRuntimeLease.snapshot.pluginRegistry,
       }),
     );
-    expect(acquirePreparedModelRuntime).toHaveBeenCalledWith({
-      config: {},
-      agentId: "main",
-      agentDir: tmpDir,
-      workspaceDir: tmpDir,
-      allowGatewaySubagentBinding: true,
-      runtimePluginSelections: [
-        { agentId: "main", modelId: "gpt-5.5", provider: "openai", runtime: "codex" },
-      ],
-    });
+    expect(acquirePreparedModelRuntime).toHaveBeenCalledOnce();
     expect(applyAgentAutoCompactionGuard.mock.invocationCallOrder[0] ?? 0).toBeLessThan(
       compactAgentHarnessSession.mock.invocationCallOrder[0] ?? 0,
     );

--- a/src/agents/command/cli-compaction.ts
+++ b/src/agents/command/cli-compaction.ts
@@ -42,6 +42,7 @@ import { isRecoverableNativeHarnessBindingFailure } from "../harness/compaction-
 import { maybeCompactAgentHarnessSession as maybeCompactAgentHarnessSessionImpl } from "../harness/compaction.js";
 import { ensureSelectedAgentHarnessPlugin as ensureSelectedAgentHarnessPluginImpl } from "../harness/runtime-plugin.js";
 import { acquireAgentRunPreparedModelRuntime } from "../prepared-model-runtime.js";
+import type { PreparedModelRuntimePluginGeneration } from "../prepared-model-runtime.types.js";
 import { SessionManager } from "../sessions/session-manager.js";
 import {
   clearCliSessionInStore as clearCliSessionInStoreImpl,
@@ -420,6 +421,7 @@ async function compactNativeHarnessCliTranscript(params: {
   senderIsOwner?: boolean;
   thinkLevel?: Parameters<typeof buildEmbeddedCompactionRuntimeContext>[0]["thinkLevel"];
   extraSystemPrompt?: string;
+  pluginGeneration?: PreparedModelRuntimePluginGeneration;
 }): Promise<NativeHarnessCliCompactionOutcome> {
   let result: EmbeddedAgentCompactResult | undefined;
   try {
@@ -427,21 +429,24 @@ async function compactNativeHarnessCliTranscript(params: {
     const nativeHarnessId = params.sessionEntry.agentHarnessId?.trim();
     const modelSelectionLocked = params.sessionEntry.modelSelectionLocked === true;
     const authProfileId = params.sessionEntry.authProfileOverride?.trim() || undefined;
-    const preparedRuntimeLease = await cliCompactionDeps.acquirePreparedModelRuntime({
-      config: params.cfg,
-      ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
-      agentDir: params.agentDir,
-      workspaceDir: params.workspaceDir,
-      allowGatewaySubagentBinding: true,
-      runtimePluginSelections: [
-        {
-          provider: params.provider,
-          modelId: params.model,
-          ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
-          ...(nativeHarnessId ? { runtime: nativeHarnessId } : {}),
-        },
-      ],
-    });
+    const preparedRuntimeLease = await cliCompactionDeps.acquirePreparedModelRuntime(
+      {
+        config: params.cfg,
+        ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
+        agentDir: params.agentDir,
+        workspaceDir: params.workspaceDir,
+        allowGatewaySubagentBinding: true,
+        runtimePluginSelections: [
+          {
+            provider: params.provider,
+            modelId: params.model,
+            ...(sessionAgentId ? { agentId: sessionAgentId } : {}),
+            ...(nativeHarnessId ? { runtime: nativeHarnessId } : {}),
+          },
+        ],
+      },
+      params.pluginGeneration ? { pluginGeneration: params.pluginGeneration } : {},
+    );
     try {
       const preparedModelRuntime = preparedRuntimeLease.snapshot;
       result = await withPluginRuntimeGenerationScope(preparedModelRuntime, async () => {
@@ -586,6 +591,7 @@ export async function runCliTurnCompactionLifecycle(params: {
   senderIsOwner?: boolean;
   thinkLevel?: Parameters<typeof buildEmbeddedCompactionRuntimeContext>[0]["thinkLevel"];
   extraSystemPrompt?: string;
+  pluginGeneration?: PreparedModelRuntimePluginGeneration;
 }): Promise<SessionEntry | undefined> {
   const contextTokenBudget = resolvePositiveInteger(params.sessionEntry?.contextTokens);
   if (!params.storePath || !contextTokenBudget) {
@@ -691,6 +697,7 @@ export async function runCliTurnCompactionLifecycle(params: {
       senderIsOwner: params.senderIsOwner,
       thinkLevel: params.thinkLevel,
       extraSystemPrompt: params.extraSystemPrompt,
+      pluginGeneration: params.pluginGeneration,
     });
     if (nativeOutcome.compacted) {
       compactionKind = "native-harness";

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -355,6 +355,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
           senderIsOwner: params.opts.senderIsOwner,
           thinkLevel: effectiveTurnThinkLevel,
           extraSystemPrompt: params.opts.extraSystemPrompt,
+          pluginGeneration: params.prepared.commandRuntimeContext?.pluginGeneration,
         });
         throwAgentRunRestartAbortReason(params.opts.abortSignal?.reason);
         assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -1,6 +1,4 @@
 /** Agent-run lease admission for lifecycle-owned prepared model runtimes. */
-import fsp from "node:fs/promises";
-import path from "node:path";
 import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
@@ -10,7 +8,6 @@ import {
   normalizePreparedModelRuntimeInput,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
-  resolveCommittedConfiguredOwner,
   type PreparedModelRuntimeInput,
   type PreparedModelRuntimeLease,
   type PreparedModelRuntimeOwner,
@@ -23,7 +20,6 @@ import type { PreparedModelRuntimeCatalogMode } from "./prepared-model-runtime.t
 type PreparedModelRuntimeLeaseContext = {
   owners: Map<string, PreparedModelRuntimeOwner>;
   agentBuildCompletions: Map<string, Promise<void>>;
-  workspacePluginRootPresenceResolutions: Map<string, Promise<boolean | undefined>>;
   retainedDirectRunOwners: PreparedModelRuntimeOwnerRetention;
   retainedGatewayRunOwners: PreparedModelRuntimeOwnerRetention;
   getBuildTimeoutMs(): number;
@@ -31,66 +27,6 @@ type PreparedModelRuntimeLeaseContext = {
   getPendingReplacement(): PreparedModelRuntimeReplacement | undefined;
   prepareSnapshot(input: PreparedModelRuntimeInput): Promise<PreparedModelRuntimeSnapshot>;
 };
-
-function resolveReusableConfiguredPluginGeneration(
-  input: PreparedModelRuntimeInput,
-  workspacePluginRootPresent: boolean | undefined,
-  context: PreparedModelRuntimeLeaseContext,
-) {
-  if (workspacePluginRootPresent !== false) {
-    return undefined;
-  }
-  const owner = resolveCommittedConfiguredOwner(context.owners, input);
-  const generation = owner?.pluginGeneration;
-  if (
-    !owner ||
-    !generation ||
-    JSON.stringify(owner.input.runtimePluginSelections) !==
-      JSON.stringify(input.runtimePluginSelections) ||
-    generation.pluginMetadataSnapshot.index.plugins.some((plugin) => plugin.origin === "workspace")
-  ) {
-    return undefined;
-  }
-  return generation;
-}
-
-async function resolveCoalescedWorkspacePluginRootPresence(
-  input: PreparedModelRuntimeInput,
-  context: PreparedModelRuntimeLeaseContext,
-): Promise<boolean | undefined> {
-  const key = ownerKey(input);
-  const existing = context.workspacePluginRootPresenceResolutions.get(key);
-  if (existing) {
-    return await existing;
-  }
-  const pending = resolveWorkspacePluginRootPresence(input);
-  context.workspacePluginRootPresenceResolutions.set(key, pending);
-  try {
-    return await pending;
-  } finally {
-    if (context.workspacePluginRootPresenceResolutions.get(key) === pending) {
-      context.workspacePluginRootPresenceResolutions.delete(key);
-    }
-  }
-}
-
-export async function resolveWorkspacePluginRootPresence(
-  input: PreparedModelRuntimeInput,
-): Promise<boolean | undefined> {
-  if (input.workspacePluginRootPresent !== undefined || !input.workspaceDir) {
-    return input.workspacePluginRootPresent;
-  }
-  return await fsp
-    .stat(path.join(input.workspaceDir, ".openclaw", "extensions"))
-    .then(() => true)
-    .catch((error: unknown) => {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === "ENOENT" || code === "ENOTDIR") {
-        return false;
-      }
-      throw error;
-    });
-}
 
 export async function acquirePreparedModelRuntimeLeaseFromOwners(
   rawInput: PreparedModelRuntimeInput,
@@ -121,18 +57,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
       }
     }
   }
-  const retainedWorkspacePluginRootPresent = context.owners.get(ownerKey(normalizedInput))?.input
-    .workspacePluginRootPresent;
-  const workspacePluginRootPresent =
-    rawInput.workspacePluginRootPresent ??
-    retainedWorkspacePluginRootPresent ??
-    (provenance === "run"
-      ? await resolveCoalescedWorkspacePluginRootPresence(normalizedInput, context)
-      : undefined);
-  let input = normalizePreparedModelRuntimeInput({
-    ...normalizedInput,
-    ...(workspacePluginRootPresent === undefined ? {} : { workspacePluginRootPresent }),
-  });
+  let input = normalizedInput;
   let key = ownerKey(input);
   let owner: PreparedModelRuntimeOwner;
   let snapshot: PreparedModelRuntimeSnapshot;
@@ -187,9 +112,6 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
       }
     }
     try {
-      const reusablePluginGeneration =
-        options.pluginGeneration ??
-        resolveReusableConfiguredPluginGeneration(input, workspacePluginRootPresent, context);
       if (existing && !staleDynamicOwner) {
         snapshot = await context.prepareSnapshot(input);
       } else {
@@ -204,7 +126,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
           undefined,
           provenance,
           options.catalogMode,
-          reusablePluginGeneration,
+          options.pluginGeneration,
         );
       }
     } catch (error) {

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -172,6 +172,9 @@ describe("prepared reply dispatch runtime", () => {
     const configuredRuntimeBefore = await loadPublishedGatewayReplyDispatchRuntime({
       agentId: "default",
     });
+    if (!configuredRuntimeBefore) {
+      throw new Error("expected configured reply runtime");
+    }
     const configuredInput = {
       agentId: "default",
       agentDir: "/tmp/unused-agent",
@@ -188,7 +191,9 @@ describe("prepared reply dispatch runtime", () => {
         { provider: "openai", modelId: "gpt-5.5", runtime: "codex" as const },
       ],
     };
-    const dynamicLease = await acquireAgentRunPreparedModelRuntime(dynamicInput);
+    const dynamicLease = await acquireAgentRunPreparedModelRuntime(dynamicInput, {
+      pluginGeneration: configuredRuntimeBefore.pluginGeneration,
+    });
     const dynamicSelectedBefore = dynamicLease.snapshot.pluginRegistry;
     dynamicLease.release();
     expect(mocks.loadAgentRuntimePluginRegistryHandle).toHaveBeenCalledTimes(2);

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -5,8 +5,6 @@ import {
   getPreparedModelRuntimeTestApi,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
-import fsp from "node:fs/promises";
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import {
@@ -243,9 +241,6 @@ describe("prepared model runtime snapshots", () => {
       gatewayLifecycle: true,
       defaultWorkspaceDir: "/tmp/gateway-launch-workspace",
     });
-    const workspacePluginRoot = path.join(workspaceDir, ".openclaw", "extensions");
-    const statSpy = vi.spyOn(fsp, "stat");
-
     const acquireDynamicLease = () =>
       acquireAgentRunPreparedModelRuntime({
         agentId: "default",
@@ -273,10 +268,6 @@ describe("prepared model runtime snapshots", () => {
     expect(retainedLease.snapshot).toBe(firstLease.snapshot);
     retainedLease.release();
     expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
-    expect(
-      statSpy.mock.calls.filter(([target]) => String(target) === workspacePluginRoot),
-    ).toHaveLength(1);
-    statSpy.mockRestore();
   });
 
   it("joins an in-flight dynamic owner publication", async () => {

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -148,7 +148,7 @@ export function hasConfiguredOwnerMatching(
   return findConfiguredOwnerCandidates(owners, rawInput).length > 0;
 }
 
-export function resolveCommittedConfiguredOwner(
+function resolveCommittedConfiguredOwner(
   owners: Map<string, PreparedModelRuntimeOwner>,
   rawInput: PreparedModelRuntimeInput,
 ): PreparedModelRuntimeOwner | undefined {

--- a/src/agents/prepared-model-runtime.plugin-context.test.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.test.ts
@@ -30,7 +30,6 @@ describe("prepared model runtime plugin metadata ownership", () => {
       agentDir: `/tmp/${name}-agent`,
       config,
       workspaceDir: `/tmp/${name}-workspace`,
-      workspacePluginRootPresent: false,
     }));
     const pluginGeneration = {
       configuredCatalogEntries: [],
@@ -80,7 +79,6 @@ describe("prepared model runtime plugin metadata ownership", () => {
             agentDir: "/tmp/direct-agent",
             config,
             workspaceDir,
-            workspacePluginRootPresent: false,
           },
           process.env,
           undefined,

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -3,10 +3,7 @@ import { toStringifiedError } from "@openclaw/normalization-core/error-coercion"
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles/runtime-snapshots.js";
-import {
-  acquirePreparedModelRuntimeLeaseFromOwners,
-  resolveWorkspacePluginRootPresence,
-} from "./prepared-model-runtime-lease.js";
+import { acquirePreparedModelRuntimeLeaseFromOwners } from "./prepared-model-runtime-lease.js";
 import { registerPreparedRuntimeAuthMaterializationPublisher } from "./prepared-model-runtime-materializations.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
@@ -64,7 +61,6 @@ let modelRuntimeBuildTimeoutMs = DEFAULT_MODEL_RUNTIME_BUILD_TIMEOUT_MS;
 
 const owners = new Map<string, PreparedModelRuntimeOwner>();
 const agentBuildCompletions = new Map<string, Promise<void>>();
-const workspacePluginRootPresenceResolutions = new Map<string, Promise<boolean | undefined>>();
 const standaloneActivationTails = new Map<string, Promise<void>>();
 const retainedDirectRunOwners = new PreparedModelRuntimeOwnerRetention(1);
 const retainedGatewayRunOwners = new PreparedModelRuntimeOwnerRetention(8);
@@ -275,7 +271,6 @@ async function activateStandalonePreparedModelRuntimeNow(
 const preparedModelRuntimeLeaseContext = {
   owners,
   agentBuildCompletions,
-  workspacePluginRootPresenceResolutions,
   retainedDirectRunOwners,
   retainedGatewayRunOwners,
   getBuildTimeoutMs: () => modelRuntimeBuildTimeoutMs,
@@ -436,10 +431,6 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
   const knownKeys = new Set<string>();
   for (const rawInput of listConfiguredOwnerInputs(config, workspace, bindings)) {
     let input = normalizePreparedModelRuntimeInput(rawInput);
-    const workspacePluginRootPresent = await resolveWorkspacePluginRootPresence(input);
-    if (workspacePluginRootPresent !== undefined) {
-      input = normalizePreparedModelRuntimeInput({ ...input, workspacePluginRootPresent });
-    }
     const preservedOwner = [...owners.values()].find(
       (owner) =>
         owner.provenance === "configured" &&
@@ -663,7 +654,6 @@ function resetPreparedModelRuntimeSnapshotsForTest(): void {
   pendingModelRuntimeReplacement = undefined;
   owners.clear();
   agentBuildCompletions.clear();
-  workspacePluginRootPresenceResolutions.clear();
   standaloneActivationTails.clear();
   retainedGatewayRunOwners.clear(owners);
   gatewayLifecycleActive = false;

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -72,7 +72,7 @@ export type PreparedReplyDispatchRuntime = Readonly<{
   config: OpenClawConfig;
   modelCatalog: ModelCatalogSnapshot;
   inboundPluginRegistry: PluginRegistry;
-  pluginGeneration?: PreparedModelRuntimePluginGeneration;
+  pluginGeneration: PreparedModelRuntimePluginGeneration;
 }>;
 
 export type PreparedModelRuntimeStores = {
@@ -85,8 +85,6 @@ export type PreparedModelRuntimeInput = {
   agentDir: string;
   inheritedAuthDir?: string;
   workspaceDir?: string;
-  /** Admission-owned fact; plugin root changes require the normal reload/restart lifecycle. */
-  workspacePluginRootPresent?: boolean;
   preserveWorkspaceDirOnRefresh?: boolean;
   readOnly?: boolean;
   /** Load the exact runtime plugin generation for an isolated executable probe. */

--- a/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
@@ -158,6 +158,7 @@ describe("dispatchReplyFromConfig", () => {
       config: cfg,
       modelCatalog: { entries: [], routeVariants: [] },
       inboundPluginRegistry: preparedRegistry,
+      pluginGeneration: {} as never,
     });
     const preparedLookup = vi
       .spyOn(preparedRuntimeModule, "loadPublishedGatewayReplyDispatchRuntime")

--- a/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.delivery-and-tts.test-utils.ts
@@ -1089,6 +1089,7 @@ describe("dispatchReplyFromConfig", () => {
           config: runtimeCfg,
           modelCatalog: { entries: [], routeVariants: [] },
           inboundPluginRegistry: createTestRegistry([]),
+          pluginGeneration: {} as never,
         }),
       );
 
@@ -1230,6 +1231,7 @@ describe("dispatchReplyFromConfig", () => {
           config: runtimeCfg,
           modelCatalog: { entries: [], routeVariants: [] },
           inboundPluginRegistry: createTestRegistry([]),
+          pluginGeneration: {} as never,
         }),
       );
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/get-reply-run.prepared-metadata.test.ts
+++ b/src/auto-reply/reply/get-reply-run.prepared-metadata.test.ts
@@ -34,26 +34,38 @@ describe("runPreparedReply prepared metadata", () => {
     vi.clearAllMocks();
   });
 
-  it("keeps the dynamic workspace metadata generation active through reply admission and execution", async () => {
+  it("keeps the admitted Gateway generation active through a different reply workspace", async () => {
     const config = {};
     const workspaceDir = "/tmp/openclaw-reply-workspace";
+    const gatewayWorkspaceDir = "/tmp/openclaw-configured-workspace";
     const metadataSnapshot = {
       index: { plugins: [] },
       pluginIds: undefined,
       policyHash: resolveInstalledPluginIndexPolicyHash(config),
-      workspaceDir,
+      workspaceDir: gatewayWorkspaceDir,
     } as never;
     const pluginRegistry = { registrations: [] } as never;
+    const pluginGeneration = {
+      configuredCatalogEntries: [],
+      inlineProviderModels: [],
+      pluginMetadataSnapshot: metadataSnapshot,
+      pluginRegistry,
+    } as never;
     const release = vi.fn();
     mocks.prepareContext.mockResolvedValue({
       kind: "run",
       params: { cfg: config },
       workspaceDir,
     });
-    mocks.acquireRuntime.mockResolvedValue({
-      snapshot: { config, metadataSnapshot, pluginRegistry, workspaceDir },
+    mocks.acquireRuntime.mockImplementation(async (_input, options) => ({
+      snapshot: {
+        config,
+        metadataSnapshot: options.pluginGeneration.pluginMetadataSnapshot,
+        pluginRegistry: options.pluginGeneration.pluginRegistry,
+        workspaceDir,
+      },
       release,
-    });
+    }));
     let admissionSnapshot: unknown;
     let admissionRegistry: unknown;
     mocks.prepareAdmission.mockImplementation(async () => {
@@ -73,19 +85,23 @@ describe("runPreparedReply prepared metadata", () => {
       {
         agentId: "main",
         agentDir: "/tmp/openclaw-reply-agent",
-        workspaceDir: "/tmp/openclaw-configured-workspace",
+        workspaceDir: gatewayWorkspaceDir,
         config,
+        pluginGeneration,
       } as never,
       async () => await runPreparedReply({} as never),
     );
 
     await expect(run()).resolves.toEqual({ text: "ok" });
-    expect(mocks.acquireRuntime).toHaveBeenCalledWith({
-      config,
-      agentId: "main",
-      agentDir: "/tmp/openclaw-reply-agent",
-      workspaceDir,
-    });
+    expect(mocks.acquireRuntime).toHaveBeenCalledWith(
+      {
+        config,
+        agentId: "main",
+        agentDir: "/tmp/openclaw-reply-agent",
+        workspaceDir,
+      },
+      { pluginGeneration },
+    );
     expect(admissionSnapshot).toBe(metadataSnapshot);
     expect(executionSnapshot).toBe(metadataSnapshot);
     expect(admissionRegistry).toBe(pluginRegistry);

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -34,12 +34,15 @@ export async function runPreparedReply(
 
   const { acquireAgentRunPreparedModelRuntime } =
     await import("../../agents/prepared-model-runtime.js");
-  const lease = await acquireAgentRunPreparedModelRuntime({
-    config: dispatchRuntime.config,
-    agentId: dispatchRuntime.agentId,
-    agentDir: dispatchRuntime.agentDir,
-    workspaceDir: context.workspaceDir,
-  });
+  const lease = await acquireAgentRunPreparedModelRuntime(
+    {
+      config: dispatchRuntime.config,
+      agentId: dispatchRuntime.agentId,
+      agentDir: dispatchRuntime.agentDir,
+      workspaceDir: context.workspaceDir,
+    },
+    { pluginGeneration: dispatchRuntime.pluginGeneration },
+  );
   try {
     return await withPluginRuntimeGenerationScope(lease.snapshot, () =>
       executePreparedReplyContext(context),

--- a/src/auto-reply/reply/get-reply.config-override.test.ts
+++ b/src/auto-reply/reply/get-reply.config-override.test.ts
@@ -103,6 +103,7 @@ function createPreparedDispatchRuntime(
     },
     modelCatalog: { entries: [], routeVariants: [] },
     inboundPluginRegistry: createEmptyPluginRegistry(),
+    pluginGeneration: {} as never,
     ...overrides,
   });
 }

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -157,60 +157,7 @@ describe("plugin metadata snapshot", () => {
     expect(loadPluginManifestRegistryForInstalledIndex).not.toHaveBeenCalled();
   });
 
-  it("reuses workspace-independent lifecycle metadata for a new workspace", () => {
-    const config = {};
-    const sourceWorkspace = "/workspace/source";
-    const targetWorkspace = "/workspace/target";
-    const index = makeIndex();
-    index.policyHash = resolveInstalledPluginIndexPolicyHash(config);
-    index.workspaceDir = sourceWorkspace;
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "provided",
-      snapshot: index,
-      diagnostics: [],
-    });
-    const source = loadPluginMetadataSnapshot({
-      config,
-      env: {},
-      index,
-      workspaceDir: sourceWorkspace,
-    });
-    setCurrentPluginMetadataSnapshot(source, {
-      config,
-      env: {},
-      workspaceDir: sourceWorkspace,
-    });
-    loadPluginRegistrySnapshotWithMetadata.mockClear();
-    loadPluginManifestRegistryForInstalledIndex.mockClear();
-
-    const resolved = resolvePluginMetadataSnapshot({
-      config,
-      env: {},
-      workspaceDir: targetWorkspace,
-      workspacePluginRootPresent: false,
-    });
-
-    expect(resolved).not.toBe(source);
-    expect(resolved.workspaceDir).toBe(targetWorkspace);
-    expect(resolved.index.workspaceDir).toBe(targetWorkspace);
-    expect(resolved.plugins).toBe(source.plugins);
-    expect(loadPluginRegistrySnapshotWithMetadata).not.toHaveBeenCalled();
-    expect(loadPluginManifestRegistryForInstalledIndex).not.toHaveBeenCalled();
-
-    resolvePluginMetadataSnapshot({
-      config,
-      env: {},
-      workspaceDir: targetWorkspace,
-      workspacePluginRootPresent: true,
-    });
-    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledOnce();
-  });
-
-  it("loads a fresh graph when no caller asserted workspace plugin-root absence", () => {
-    // Startup config validation never resolves workspace plugin-root presence, so it must keep
-    // loading. Projecting the published graph instead would serve whatever inventory happened to
-    // be current, and startup convergence rewrites that inventory between the two reads that
-    // form the migration checkpoint identity — the gateway then refuses to report ready.
+  it("cold-loads the requested workspace instead of reusing a different lifecycle graph", () => {
     const config = {};
     const sourceWorkspace = "/workspace/source";
     const targetWorkspace = "/workspace/target";

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -337,37 +337,6 @@ export function completePluginMetadataSnapshot(params: {
   });
 }
 
-/** Reuses process-stable plugin facts for a workspace proven to have no plugin root. */
-function projectPluginMetadataSnapshotWorkspace(params: {
-  snapshot: PluginMetadataSnapshot;
-  config: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-  workspaceDir: string;
-}): PluginMetadataSnapshot {
-  if (params.snapshot.workspaceDir === params.workspaceDir) {
-    return params.snapshot;
-  }
-  if (params.snapshot.index.plugins.some((plugin) => plugin.origin === "workspace")) {
-    throw new Error("Workspace plugin metadata cannot be projected to another workspace");
-  }
-  const index = Object.freeze({
-    ...params.snapshot.index,
-    workspaceDir: params.workspaceDir,
-  });
-  return Object.freeze({
-    ...params.snapshot,
-    configFingerprint: resolvePluginControlPlaneFingerprint({
-      config: params.config,
-      env: params.env,
-      index,
-      policyHash: params.snapshot.policyHash,
-      workspaceDir: params.workspaceDir,
-    }),
-    index,
-    workspaceDir: params.workspaceDir,
-  });
-}
-
 export function resolvePluginMetadataSnapshot(
   params: ResolvePluginMetadataSnapshotParams,
 ): PluginMetadataSnapshot {
@@ -388,37 +357,6 @@ export function resolvePluginMetadataSnapshot(
         : {}),
     });
     if (!current) {
-      const lifecycleSnapshot = getCurrentPluginMetadataSnapshot({
-        config: params.config,
-        env: params.env,
-        ...(params.pluginIds !== undefined ? { pluginIds: params.pluginIds } : {}),
-        ...(params.pluginIdScope !== undefined ? { pluginIdScope: params.pluginIdScope } : {}),
-        allowWorkspaceScopedSnapshot: true,
-      });
-      const targetWorkspace = params.workspaceDir;
-      const hasWorkspacePlugin = lifecycleSnapshot?.index.plugins.some(
-        (plugin) => plugin.origin === "workspace",
-      );
-      // Gateway metadata is lifecycle-stable. A workspace with no plugin root can reuse the
-      // published graph without polling every bundled/global artifact on its first turn.
-      // Only the run owner that resolved workspace plugin-root presence may claim it: this
-      // projection derives configFingerprint from the published graph instead of a real load,
-      // so synthesizing the fact here would make startup-migration identity depend on whether
-      // a lifecycle snapshot happened to be published at that moment.
-      if (
-        lifecycleSnapshot &&
-        targetWorkspace &&
-        targetWorkspace !== lifecycleSnapshot.workspaceDir &&
-        !hasWorkspacePlugin &&
-        params.workspacePluginRootPresent === false
-      ) {
-        return projectPluginMetadataSnapshotWorkspace({
-          snapshot: lifecycleSnapshot,
-          config: params.config ?? {},
-          env: params.env,
-          workspaceDir: targetWorkspace,
-        });
-      }
       return loadPluginMetadataSnapshot(params);
     }
     if (!params.index || isCurrentPluginMetadataSnapshotRuntimeGeneration(current)) {

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -84,5 +84,4 @@ export type LoadPluginMetadataSnapshotParams = {
 
 export type ResolvePluginMetadataSnapshotParams = LoadPluginMetadataSnapshotParams & {
   allowWorkspaceScopedCurrent?: boolean;
-  workspacePluginRootPresent?: boolean;
 };


### PR DESCRIPTION
Related: #125595
Follow-up to #125596

## What Problem This Solves

Fixes the remaining ownership ambiguity after the Gateway event-loop stall repair: reply and post-turn compaction paths could still infer or project plugin metadata from an agent workspace instead of carrying the Gateway generation that admitted the turn.

## Why This Change Was Made

Gateway reply execution and native-harness compaction now receive the exact published plugin generation explicitly. With those callers migrated, this deletes the workspace-root probe, cross-workspace metadata projection, and configured-owner inference fallback while preserving standalone cold discovery, including the shipped workspace plugin contract.

This is an AI-assisted maintainer follow-up to the active production incident repair.

## User Impact

No new configuration or user workflow is introduced. Gateway turns keep one lifecycle-owned plugin generation through reply execution and compaction, and request-time code has fewer paths that can rediscover plugin metadata on the event loop.

Production code shrinks by 142 lines; tests and support shrink by 44 lines.

## Evidence

- Focused branch Vitest: 9 files across 4 shards, 502 tests passed.
- `pnpm build`: passed in 6m03.8s; the subsequent commit changed only the retained regression test.
- `pnpm lint:core`: passed.
- Database-first, media-download, runtime-sidecar, import-cycle, webhook-body, and pairing-scope guards: passed.
- Changed-gate typechecks, formatting, dead-export scan, plugin boundaries, assertion ratchet, and dependency guards: passed. The monolithic wrapper exceeded the 10-minute harness ceiling after those completed, so the remaining guards were run directly and passed.
- Fresh branch autoreview: clean, no accepted/actionable findings.
- Exact-head CI caught one retained test still acquiring a dynamic Gateway runtime without the explicit generation; the test now models the real admitted caller and passes the published generation.
- Diff: production +37/-179 (net -142); test/support +77/-121 (net -44).
