### PR TITLE
fix(codex): prevent one-shot approvals from appearing persistent

### DIFF
--- a/docs/gateway/audit.md
+++ b/docs/gateway/audit.md
@@ -30,6 +30,14 @@ inspection adapts their existing first-answer-wins rows directly into decision
 receipts; it does not copy approvals into the audit ledger or the generic
 decision-fact table.
 
+This includes operator-routed native Codex command and file prompts. The Codex
+bridge carries the admitted agent, session key, run, tool, context, and
+execution binding into the same approval owner, then returns only the approved
+native scope. Auto-review, full-access policy, native hook decisions, and
+requests rejected before operator routing have no operator-owned row and remain
+unsupported as operator-approval evidence; later tool events never manufacture
+one.
+
 Shared outbound delivery is another owner-native source. Queue admission and
 platform-send start use a lazy progress companion, while terminal message rows
 remain in the activity ledger. Run inspection merges both sources directly;

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -736,6 +736,28 @@ permissions, see [Permission modes](/tools/permission-modes). For every
 app-server field, auth order, environment isolation, and timeout behavior,
 see [Codex harness reference](/plugins/codex-harness-reference).
 
+### Native approval audit evidence
+
+With `tools.exec.mode: "ask"` and the Codex user reviewer, native command and
+file prompts use OpenClaw's two-phase operator approval route. The prompt shows
+only decisions that the native request can preserve. For example, a command
+that permits one execution but not session trust offers allow-once and deny;
+byte-bound script approvals also remain one-shot. File prompts support both
+one-shot and session approval.
+
+Terminal operator decisions reuse the Gateway's authoritative approval row and
+its exact execution binding. When execution identity collection is enabled,
+inspect the admitted run with
+[`openclaw audit --run <run-id> --explain`](/cli/audit). The resulting receipt
+can report allow-once, allow-always, denial, no-route, expiry, or cancellation
+without exposing command text, patch content, paths, or native request ids.
+
+Codex auto-review, full-access policy, and native hook or OpenClaw policy
+decisions do not create an operator approval row. Missing or stale native turn
+context is rejected before routing. These cases therefore do not produce an
+enforced operator-approval receipt; audit inspection does not reconstruct one
+from later tool events.
+
 ## Commands and diagnostics
 
 The `codex` plugin registers `/codex` as a slash command on any channel that

--- a/extensions/codex/src/app-server/approval-bridge.test.ts
+++ b/extensions/codex/src/app-server/approval-bridge.test.ts
@@ -214,6 +214,139 @@ describe("Codex app-server approval bridge", () => {
     expect(codexApprovalTimeoutText(kind)).toBe(expected);
   });
 
+  it("only offers operator decisions that the native command request can enforce", async () => {
+    const params = createParams();
+    params.hostCapabilities = {
+      ...params.hostCapabilities,
+      prepareMutableFileApproval: prepareApprovalWithoutMutableFile,
+    };
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-native-once", status: "accepted" })
+      .mockResolvedValueOnce({
+        id: "plugin:approval-native-once",
+        decision: "allow-once",
+      });
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        ...codexTestTurnIds(),
+        itemId: "cmd-native-once",
+        command: "git status",
+        availableDecisions: ["accept", "cancel"],
+      },
+      paramsForRun: params,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ decision: "accept" });
+    expect(gatewayRequestPayload().allowedDecisions).toEqual(["allow-once", "deny"]);
+  });
+
+  it("offers session approval only when the native command request can preserve it", async () => {
+    const params = createParams();
+    params.hostCapabilities = {
+      ...params.hostCapabilities,
+      prepareMutableFileApproval: prepareApprovalWithoutMutableFile,
+    };
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-native-session", status: "accepted" })
+      .mockResolvedValueOnce({
+        id: "plugin:approval-native-session",
+        decision: "allow-always",
+      });
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        ...codexTestTurnIds(),
+        itemId: "cmd-native-session",
+        command: "git status",
+        availableDecisions: ["accept", "acceptForSession", "decline", "cancel"],
+      },
+      paramsForRun: params,
+      ...codexTestTurnIds(),
+    });
+
+    expect(result).toEqual({ decision: "acceptForSession" });
+    expect(gatewayRequestPayload().allowedDecisions).toEqual([
+      "allow-once",
+      "allow-always",
+      "deny",
+    ]);
+  });
+
+  it.each([
+    ["operator denial", false, "decline"],
+    ["run cancellation", true, "cancel"],
+  ] as const)("maps %s to a native command rejection", async (_label, abortRun, expected) => {
+    const params = createParams();
+    params.hostCapabilities = {
+      ...params.hostCapabilities,
+      prepareMutableFileApproval: prepareApprovalWithoutMutableFile,
+    };
+    const controller = new AbortController();
+    mockCallGatewayTool
+      .mockResolvedValueOnce({ id: "plugin:approval-native-cancel", status: "accepted" })
+      .mockImplementationOnce(async () => {
+        if (abortRun) {
+          controller.abort("client_closed");
+        }
+        return { id: "plugin:approval-native-cancel", decision: "deny" };
+      });
+
+    const result = await handleCodexAppServerApprovalRequest({
+      method: "item/commandExecution/requestApproval",
+      requestParams: {
+        ...codexTestTurnIds(),
+        itemId: "cmd-native-cancel",
+        command: "git status",
+        availableDecisions: ["accept", "cancel"],
+      },
+      paramsForRun: params,
+      ...codexTestTurnIds(),
+      signal: controller.signal,
+    });
+
+    expect(result).toEqual({ decision: expected });
+    expect(gatewayRequestPayload().allowedDecisions).toEqual(["allow-once", "deny"]);
+  });
+
+  it.each([
+    ["allow-once", "accept"],
+    ["allow-always", "acceptForSession"],
+    ["deny", "decline"],
+  ] as const)(
+    "maps file operator decision %s to native %s",
+    async (gatewayDecision, nativeDecision) => {
+      const params = createParams();
+      mockCallGatewayTool
+        .mockResolvedValueOnce({ id: `plugin:file-${gatewayDecision}`, status: "accepted" })
+        .mockResolvedValueOnce({
+          id: `plugin:file-${gatewayDecision}`,
+          decision: gatewayDecision,
+        });
+
+      const result = await handleCodexAppServerApprovalRequest({
+        method: "item/fileChange/requestApproval",
+        requestParams: {
+          ...codexTestTurnIds(),
+          itemId: `file-${gatewayDecision}`,
+          reason: "update generated output",
+        },
+        paramsForRun: params,
+        ...codexTestTurnIds(),
+      });
+
+      expect(result).toEqual({ decision: nativeDecision });
+      expect(gatewayRequestPayload().allowedDecisions).toEqual([
+        "allow-once",
+        "allow-always",
+        "deny",
+      ]);
+    },
+  );
+
   it("keeps unrelated command approval policy unchanged for scheduled app authority", async () => {
     const params = {
       ...createParams(),
@@ -456,7 +589,7 @@ describe("Codex app-server approval bridge", () => {
       };
       mockCallGatewayTool
         .mockResolvedValueOnce({ id: "plugin:script-stable", status: "accepted" })
-        .mockResolvedValueOnce({ id: "plugin:script-stable", decision: "allow-always" });
+        .mockResolvedValueOnce({ id: "plugin:script-stable", decision: "allow-once" });
 
       const result = await handleCodexAppServerApprovalRequest({
         method: "item/commandExecution/requestApproval",
@@ -465,16 +598,18 @@ describe("Codex app-server approval bridge", () => {
           itemId: "cmd-script-stable",
           command: `sh ${scriptPath}`,
           cwd: tempDir,
+          availableDecisions: ["accept", "acceptForSession", "cancel"],
         },
         paramsForRun: params,
         ...codexTestTurnIds(),
       });
 
       expect(result).toEqual({ decision: "accept" });
+      expect(gatewayRequestPayload().allowedDecisions).toEqual(["allow-once", "deny"]);
       findApprovalEvent(params, {
         status: "approved",
         approvalId: "plugin:script-stable",
-        message: "Codex app-server approval granted for this byte-bound command only.",
+        message: "Codex app-server approval granted for this turn.",
       });
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });

--- a/extensions/codex/src/app-server/approval-bridge.ts
+++ b/extensions/codex/src/app-server/approval-bridge.ts
@@ -31,6 +31,7 @@ import {
   truncateCodexApprovalDisplayText as truncate,
   type AppServerApprovalOutcome,
   type CodexApprovalKind,
+  type ExecApprovalDecision,
   waitForPluginApprovalDecision,
 } from "./plugin-approval-roundtrip.js";
 import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
@@ -188,6 +189,11 @@ export async function handleCodexAppServerApprovalRequest(params: {
       severity: context.severity,
       toolName: context.toolName,
       toolCallId: context.approvalId,
+      allowedDecisions: nativeApprovalAllowedDecisions({
+        method: params.method,
+        requestParams,
+        requiresOneShot: mutableFileApprovalRequiresOneShot,
+      }),
     });
 
     const approvalId = requestResult?.id;
@@ -809,16 +815,38 @@ function commandApprovalDecision(
   if (outcome === "denied" || outcome === "unavailable") {
     return "decline";
   }
-  if (outcome === "approved-session") {
-    if (hasAvailableDecision(requestParams, "acceptForSession")) {
-      return "acceptForSession";
-    }
-    const amendmentDecision = findAvailableCommandAmendmentDecision(requestParams);
-    if (amendmentDecision) {
-      return amendmentDecision;
-    }
+  const capabilities = commandApprovalCapabilities(requestParams);
+  if (outcome === "approved-session" && capabilities.sessionDecision !== undefined) {
+    return capabilities.sessionDecision;
   }
-  return hasAvailableDecision(requestParams, "accept") ? "accept" : "decline";
+  return capabilities.once ? "accept" : "decline";
+}
+
+function nativeApprovalAllowedDecisions(params: {
+  method: string;
+  requestParams: JsonObject | undefined;
+  requiresOneShot: boolean;
+}): ExecApprovalDecision[] | undefined {
+  if (params.method === "item/fileChange/requestApproval") {
+    return ["allow-once", "allow-always", "deny"];
+  }
+  if (params.method !== "item/commandExecution/requestApproval") {
+    return undefined;
+  }
+  const available = params.requestParams?.availableDecisions;
+  if (!Array.isArray(available)) {
+    return undefined;
+  }
+  const capabilities = commandApprovalCapabilities(params.requestParams);
+  const decisions: ExecApprovalDecision[] = [];
+  if (capabilities.once) {
+    decisions.push("allow-once");
+  }
+  if (!params.requiresOneShot && capabilities.sessionDecision !== undefined) {
+    decisions.push("allow-always");
+  }
+  decisions.push("deny");
+  return decisions;
 }
 
 function fileChangeApprovalDecision(outcome: AppServerApprovalOutcome): JsonValue {
@@ -1167,9 +1195,20 @@ function isPrivateNetworkHostPattern(value: string): boolean {
   return /^172\.(1[6-9]|2\d|3[0-1])\./.test(wildcardStripped);
 }
 
-function hasAvailableDecision(requestParams: JsonObject | undefined, decision: string): boolean {
+function commandApprovalCapabilities(requestParams: JsonObject | undefined): {
+  once: boolean;
+  sessionDecision?: JsonValue;
+} {
   const available = requestParams?.availableDecisions;
-  return !Array.isArray(available) || available.includes(decision);
+  if (!Array.isArray(available)) {
+    return { once: true, sessionDecision: "acceptForSession" };
+  }
+  return {
+    once: available.includes("accept"),
+    ...(available.includes("acceptForSession")
+      ? { sessionDecision: "acceptForSession" }
+      : { sessionDecision: findAvailableCommandAmendmentDecision(requestParams) }),
+  };
 }
 
 function findAvailableCommandAmendmentDecision(

--- a/test/e2e/qa-lab/runtime/codex-native-approval-app-server.fixture.mjs
+++ b/test/e2e/qa-lab/runtime/codex-native-approval-app-server.fixture.mjs
@@ -1,0 +1,168 @@
+// Deterministic Codex app-server boundary for native approval receipt proof.
+import fs from "node:fs";
+import readline from "node:readline";
+import {
+  createFakeInitializeResponse,
+  createFakeThreadStartResponse,
+} from "../../../../scripts/e2e/lib/codex-app-server-fixture.mjs";
+
+const requestLog = process.env.OPENCLAW_QA_CODEX_NATIVE_APPROVAL_LOG;
+const appServerVersion = process.env.OPENCLAW_QA_CODEX_APP_SERVER_VERSION;
+if (!requestLog || !appServerVersion) {
+  throw new Error("missing Codex native approval fixture environment");
+}
+
+const threadId = "thread-private-native-approval";
+const turnId = "turn-private-native-approval";
+const itemId = "item-private-native-approval";
+const approvalRequestId = "approval-private-native-approval";
+const command = "printf PRIVATE_CODEX_NATIVE_APPROVAL_COMMAND";
+let activeTurn = false;
+
+function log(message) {
+  fs.appendFileSync(requestLog, `${JSON.stringify(message)}\n`);
+}
+
+function emit(message) {
+  log(message);
+  process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+function sendResult(id, result) {
+  emit({ id, result });
+}
+
+function completeTurn() {
+  const completedAtMs = Date.now();
+  const message = {
+    type: "agentMessage",
+    id: "message-codex-native-approval",
+    text: "CODEX_NATIVE_APPROVAL_RECEIPT_OK",
+  };
+  emit({
+    method: "item/completed",
+    params: { item: message, threadId, turnId, completedAtMs },
+  });
+  emit({
+    method: "turn/completed",
+    params: {
+      threadId,
+      turn: {
+        id: turnId,
+        items: [message],
+        itemsView: "full",
+        status: "completed",
+        error: null,
+        startedAt: Math.floor(completedAtMs / 1000),
+        completedAt: Math.floor(completedAtMs / 1000),
+        durationMs: 0,
+      },
+    },
+  });
+}
+
+const input = readline.createInterface({ input: process.stdin });
+input.on("line", (line) => {
+  if (!line.trim()) {
+    return;
+  }
+  const message = JSON.parse(line);
+  log(message);
+
+  if (message.id === approvalRequestId && message.method === undefined) {
+    activeTurn = false;
+    completeTurn();
+    return;
+  }
+  if (message.id === undefined || typeof message.method !== "string") {
+    return;
+  }
+
+  switch (message.method) {
+    case "initialize":
+      sendResult(
+        message.id,
+        createFakeInitializeResponse({
+          name: "openclaw-qa-codex-native-approval",
+          version: appServerVersion,
+          userAgent: `openclaw/${appServerVersion} (test)`,
+        }),
+      );
+      return;
+    case "account/login/start":
+      sendResult(message.id, { type: message.params?.type });
+      return;
+    case "account/read":
+      sendResult(message.id, {
+        account: {
+          type: "chatgpt",
+          email: "qa-codex-native-approval@example.com",
+          planType: "pro",
+        },
+        requiresOpenaiAuth: true,
+      });
+      return;
+    case "account/rateLimits/read":
+      sendResult(message.id, {
+        rateLimits: {
+          limitId: "codex",
+          limitName: "Codex",
+          primary: null,
+          secondary: null,
+          credits: null,
+          individualLimit: null,
+          spendControlReached: null,
+          planType: "pro",
+          rateLimitReachedType: null,
+        },
+        rateLimitsByLimitId: null,
+      });
+      return;
+    case "thread/start":
+      sendResult(
+        message.id,
+        createFakeThreadStartResponse({
+          params: message.params,
+          threadId,
+          sessionId: "session-private-native-approval",
+          version: appServerVersion,
+        }),
+      );
+      return;
+    case "turn/start":
+      activeTurn = true;
+      sendResult(message.id, {
+        turn: {
+          id: turnId,
+          items: [],
+          itemsView: "notLoaded",
+          status: "inProgress",
+          error: null,
+          startedAt: null,
+          completedAt: null,
+          durationMs: null,
+        },
+      });
+      setImmediate(() => {
+        if (!activeTurn) {
+          return;
+        }
+        emit({
+          id: approvalRequestId,
+          method: "item/commandExecution/requestApproval",
+          params: {
+            threadId,
+            turnId,
+            itemId,
+            startedAtMs: Date.now(),
+            command,
+            cwd: process.cwd(),
+            availableDecisions: ["accept", "cancel"],
+          },
+        });
+      });
+      return;
+    default:
+      sendResult(message.id, {});
+  }
+});

--- a/test/e2e/qa-lab/runtime/codex-native-approval-receipt.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-native-approval-receipt.e2e.test.ts
@@ -1,0 +1,369 @@
+// QA Lab proves a Codex-native approval decision through Gateway receipt restart.
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AuditRunInspectResult } from "../../../../packages/gateway-protocol/src/index.js";
+import { writePersistedAuthProfileStoreRaw } from "../../../../src/agents/auth-profiles/sqlite.js";
+import {
+  GatewayClient,
+  startGatewayClientWhenEventLoopReady,
+} from "../../../../src/plugin-sdk/gateway-runtime.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../../../src/state/openclaw-agent-db.js";
+import { loadBundledPluginFacade } from "../../../../src/test-utils/bundled-plugin-public-surface.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../../../helpers/openclaw-test-instance.js";
+
+const MODEL = "openai/gpt-5.6-luna";
+const REQUEST_TIMEOUT_MS = 60_000;
+const PRIVATE_COMMAND = "printf PRIVATE_CODEX_NATIVE_APPROVAL_COMMAND";
+const PRIVATE_THREAD_ID = "thread-private-native-approval";
+const PRIVATE_ITEM_ID = "item-private-native-approval";
+
+let instance: OpenClawTestInstance | undefined;
+
+type AppServerLogEntry = {
+  id?: number | string;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+};
+
+type PendingApproval = {
+  id: string;
+  request?: {
+    allowedDecisions?: string[];
+    toolCallId?: string;
+    toolName?: string;
+  };
+};
+
+type ApprovalIdentityRow = {
+  source_agent_id: string | null;
+  source_session_key: string | null;
+  source_run_id: string | null;
+  source_tool_call_id: string | null;
+  source_tool_name: string | null;
+  source_context_id: string | null;
+  source_execution_id: string | null;
+};
+
+afterEach(async () => {
+  closeOpenClawAgentDatabasesForTest();
+  await instance?.cleanup();
+  instance = undefined;
+});
+
+function readJsonLines(filePath: string): AppServerLogEntry[] {
+  try {
+    return readFileSync(filePath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line: string) => JSON.parse(line) as AppServerLogEntry);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function readApprovalIdentity(testInstance: OpenClawTestInstance, approvalId: string) {
+  const database = new DatabaseSync(path.join(testInstance.stateDir, "state", "openclaw.sqlite"), {
+    readOnly: true,
+  });
+  try {
+    return database
+      .prepare(
+        `SELECT approval.source_agent_id,
+                approval.source_session_key,
+                approval.source_run_id,
+                approval.source_tool_call_id,
+                approval.source_tool_name,
+                binding.source_context_id,
+                binding.source_execution_id
+           FROM operator_approvals AS approval
+           LEFT JOIN operator_approval_execution_identities AS binding
+             ON binding.approval_id = approval.approval_id
+          WHERE approval.approval_id = ?`,
+      )
+      .get(approvalId) as ApprovalIdentityRow | undefined;
+  } finally {
+    database.close();
+  }
+}
+
+function assertNoGenericDuplicate(testInstance: OpenClawTestInstance, approvalId: string) {
+  const database = new DatabaseSync(path.join(testInstance.stateDir, "state", "openclaw.sqlite"), {
+    readOnly: true,
+  });
+  try {
+    const table = database
+      .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+      .get("execution_decision_facts");
+    if (table) {
+      const row = database
+        .prepare(
+          `SELECT COUNT(*) AS count
+             FROM execution_decision_facts
+            WHERE owner = 'operator_approvals'
+               OR source_ref = (
+                    SELECT resolution_ref
+                      FROM operator_approvals
+                     WHERE approval_id = ?
+                  )`,
+        )
+        .get(approvalId) as { count: number };
+      expect(row.count).toBe(0);
+    }
+  } finally {
+    database.close();
+  }
+}
+
+function requireAllowedOnceReceipt(result: AuditRunInspectResult) {
+  const receipt = result.decisions.find(
+    (candidate) => candidate.source.owner === "operator_approvals",
+  );
+  expect(receipt).toMatchObject({
+    decision: {
+      outcome: "allowed",
+      reasonCode: "operator_approval_allowed_once",
+    },
+    enforcement: {
+      coverageState: "enforced",
+      contextFieldsUsed: ["contextId", "executionId", "runId"],
+    },
+    source: { owner: "operator_approvals" },
+  });
+  if (!receipt) {
+    throw new Error("audit inspection omitted the operator approval receipt");
+  }
+  return receipt;
+}
+
+function summarizeAppServerLog(filePath: string) {
+  return readJsonLines(filePath).map((entry) => ({
+    id: entry.id,
+    method: entry.method,
+    ...(entry.id === "approval-private-native-approval" ? { result: entry.result } : {}),
+  }));
+}
+
+async function connectApprovalReviewer(testInstance: OpenClawTestInstance) {
+  let resolveConnected!: () => void;
+  let rejectConnected!: (error: Error) => void;
+  const connected = new Promise<void>((resolve, reject) => {
+    resolveConnected = resolve;
+    rejectConnected = reject;
+  });
+  const client = new GatewayClient({
+    url: `ws://127.0.0.1:${testInstance.port}`,
+    token: testInstance.gatewayToken,
+    clientName: "gateway-client",
+    clientDisplayName: "Codex native approval reviewer",
+    deviceIdentity: null,
+    mode: "backend",
+    caps: ["plugin-approvals"],
+    scopes: ["operator.admin"],
+    onHelloOk: resolveConnected,
+    onConnectError: rejectConnected,
+    onClose: (code, reason) =>
+      rejectConnected(new Error(`approval reviewer closed (${code}): ${reason}`)),
+  });
+  const readiness = await startGatewayClientWhenEventLoopReady(client, { timeoutMs: 20_000 });
+  if (!readiness.ready) {
+    client.stop();
+    throw new Error("approval reviewer did not reach event-loop readiness");
+  }
+  await connected;
+  return client;
+}
+
+describe("Codex native approval receipt", () => {
+  it(
+    "preserves a native command approval and its exact receipt across Gateway restart",
+    { timeout: 180_000 },
+    async () => {
+      const { CODEX_APP_SERVER_VERSION } = await loadBundledPluginFacade<{
+        CODEX_APP_SERVER_VERSION: string;
+      }>({ pluginId: "codex", artifactBasename: "test-api.js" });
+      const fixture = fileURLToPath(
+        new URL("./codex-native-approval-app-server.fixture.mjs", import.meta.url),
+      );
+      instance = await createOpenClawTestInstance({
+        name: "qa-codex-native-approval-receipt",
+        env: {
+          OPENCLAW_AGENT_HARNESS_FALLBACK: "none",
+          OPENCLAW_QA_CODEX_APP_SERVER_VERSION: CODEX_APP_SERVER_VERSION,
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+        },
+        config: {
+          logging: { audit: { enabled: true, executionIdentity: true } },
+          tools: { exec: { mode: "ask" } },
+          plugins: {
+            enabled: true,
+            allow: ["codex"],
+            entries: {
+              codex: {
+                enabled: true,
+                config: {
+                  appServer: {
+                    mode: "guardian",
+                    command: process.execPath,
+                    args: [fixture],
+                    requestTimeoutMs: REQUEST_TIMEOUT_MS,
+                    turnCompletionIdleTimeoutMs: REQUEST_TIMEOUT_MS,
+                  },
+                },
+              },
+            },
+          },
+          agents: {
+            defaults: {
+              model: { primary: MODEL, fallbacks: [] },
+              models: { [MODEL]: { agentRuntime: { id: "codex" } } },
+              workspace: "~/workspace",
+              skipBootstrap: true,
+              timeoutSeconds: 60,
+              sandbox: { mode: "off" },
+            },
+          },
+        },
+      });
+
+      const appServerLogPath = instance.state.path("codex-native-approval-app-server.jsonl");
+      instance.env.OPENCLAW_QA_CODEX_NATIVE_APPROVAL_LOG = appServerLogPath;
+      writePersistedAuthProfileStoreRaw(
+        {
+          version: 1,
+          profiles: {
+            "openai:qa-oauth": {
+              type: "oauth",
+              provider: "openai",
+              access: "test-native-approval-oauth",
+              refresh: "test-refresh",
+              expires: Date.UTC(2036, 0, 1),
+              accountId: "qa-codex-native-approval",
+            },
+          },
+          order: { openai: ["openai:qa-oauth"] },
+        },
+        instance.state.agentDir(),
+      );
+      await instance.startGateway();
+      const reviewer = await connectApprovalReviewer(instance);
+
+      try {
+        const started = await reviewer.request<{ runId?: string; status?: string }>(
+          "chat.send",
+          {
+            sessionKey: "agent:main:c03-native-approval",
+            message: "Complete the deterministic native approval fixture.",
+            deliver: false,
+            idempotencyKey: randomUUID(),
+          },
+          { timeoutMs: 30_000 },
+        );
+        expect(started.status).toBe("started");
+        expect(started.runId).toEqual(expect.any(String));
+
+        let approval: PendingApproval;
+        try {
+          approval = await vi.waitFor(
+            async () => {
+              const pending = await reviewer.request<PendingApproval[]>("plugin.approval.list", {});
+              const match = pending[0];
+              expect(match).toBeDefined();
+              if (!match) {
+                throw new Error("native approval is not pending yet");
+              }
+              return match;
+            },
+            { interval: 50, timeout: REQUEST_TIMEOUT_MS },
+          );
+        } catch (error) {
+          throw new Error(
+            `native approval did not become pending; app-server=${JSON.stringify(summarizeAppServerLog(appServerLogPath))}\n${instance.logs()}`,
+            { cause: error },
+          );
+        }
+        expect(approval.request).toMatchObject({
+          allowedDecisions: ["allow-once", "deny"],
+          toolCallId: PRIVATE_ITEM_ID,
+          toolName: "codex_command_approval",
+        });
+
+        await reviewer.request("plugin.approval.resolve", {
+          id: approval.id,
+          decision: "allow-once",
+        });
+        await vi.waitFor(
+          () => {
+            const response = readJsonLines(appServerLogPath).find(
+              (entry) =>
+                entry.id === "approval-private-native-approval" && entry.result !== undefined,
+            );
+            expect(response?.result).toEqual({ decision: "accept" });
+          },
+          { interval: 25, timeout: REQUEST_TIMEOUT_MS },
+        );
+        await expect(
+          reviewer.request(
+            "agent.wait",
+            { runId: started.runId, timeoutMs: REQUEST_TIMEOUT_MS },
+            { timeoutMs: REQUEST_TIMEOUT_MS + 5_000 },
+          ),
+        ).resolves.toMatchObject({ status: "ok" });
+
+        const identity = readApprovalIdentity(instance, approval.id);
+        expect(identity).toMatchObject({
+          source_agent_id: "main",
+          source_tool_call_id: PRIVATE_ITEM_ID,
+          source_tool_name: "codex_command_approval",
+        });
+        expect(identity?.source_session_key).toBe("agent:main:c03-native-approval");
+        expect(identity?.source_run_id).toBe(started.runId);
+        expect(identity?.source_context_id).toEqual(expect.any(String));
+        expect(identity?.source_execution_id).toEqual(expect.any(String));
+        if (!identity?.source_run_id) {
+          throw new Error("operator approval omitted the admitted run id");
+        }
+        const sourceRunId = identity.source_run_id;
+
+        const beforeCli = await instance.cli([
+          "audit",
+          "--run",
+          sourceRunId,
+          "--explain",
+          "--json",
+        ]);
+        expect(beforeCli.code, beforeCli.stderr).toBe(0);
+        const before = JSON.parse(beforeCli.stdout) as AuditRunInspectResult;
+        requireAllowedOnceReceipt(before);
+        const serialized = JSON.stringify(before);
+        expect(serialized).not.toContain(PRIVATE_COMMAND);
+        expect(serialized).not.toContain(PRIVATE_THREAD_ID);
+        expect(serialized).not.toContain(PRIVATE_ITEM_ID);
+        expect(serialized).not.toContain(process.cwd());
+        assertNoGenericDuplicate(instance, approval.id);
+
+        reviewer.stop();
+        await instance.stopGateway();
+        await instance.startGateway();
+        const afterCli = await instance.cli(["audit", "--run", sourceRunId, "--explain", "--json"]);
+        expect(afterCli.code, afterCli.stderr).toBe(0);
+        const after = JSON.parse(afterCli.stdout) as AuditRunInspectResult;
+        requireAllowedOnceReceipt(after);
+        expect(JSON.stringify(after)).toBe(serialized);
+        assertNoGenericDuplicate(instance, approval.id);
+      } finally {
+        reviewer.stop();
+      }
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an operator could be offered persistent approval for a Codex command even when the native Codex request could preserve only one-shot approval. The Gateway's authoritative approval receipt could therefore say `allow-always` while Codex received `accept` for one execution.

## Why This Change Was Made

The Codex approval bridge now derives one canonical capability set from the native request and uses it for both the Gateway operator choices and the final Codex response. Command prompts expose session approval only when Codex advertises `acceptForSession` or a native amendment; byte-bound scripts remain one-shot. File prompts retain their native once/session/deny contract.

The existing `operator_approvals` row remains the sole durable decision owner. No SDK, protocol, schema, config, provider route, or fallback was added.

## User Impact

Operators see only approval scopes that Codex can actually enforce. With execution-identity auditing enabled, native command and file approvals retain the admitted agent, session key, run, tool, context, and execution binding and remain inspectable after Gateway restart without exposing command text, patch content, paths, or native request identifiers.

## Root Cause and Best Fix

`extensions/codex/src/app-server/approval-bridge.ts` previously omitted `allowedDecisions` from the two-phase Gateway request. Gateway therefore defaulted to once/session/deny even when the upstream command request advertised only `accept` and `cancel`; the final bridge then downgraded `allow-always` to `accept`.

The best owner-boundary fix is the shared native capability projection now consumed by both phases. It removes the former split decision test and prevents the operator record and upstream response from diverging. Sibling coverage includes command, file, amendment/session, mutable-script, denial, cancellation, unavailable/no-route, missing/stale context, duplicate prevention, and redaction paths.

## Dependency Contract Evidence

Directly inspected `openai/codex@1f41cc5d92722748e45cae9cecc6d883a4e7cbb1`:

- command/file decision enums and conversions: [`codex-rs/app-server-protocol/src/protocol/v2/item.rs:57-118`](https://github.com/openai/codex/blob/1f41cc5d92722748e45cae9cecc6d883a4e7cbb1/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L57-L118)
- command request `availableDecisions` and file request/decision contract: [`item.rs:1444-1546`](https://github.com/openai/codex/blob/1f41cc5d92722748e45cae9cecc6d883a4e7cbb1/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1444-L1546)
- request emission with explicit available decisions: [`codex-rs/app-server/src/bespoke_event_handling.rs:681-696`](https://github.com/openai/codex/blob/1f41cc5d92722748e45cae9cecc6d883a4e7cbb1/codex-rs/app-server/src/bespoke_event_handling.rs#L681-L696)
- response mappings: [`bespoke_event_handling.rs:1915-2092`](https://github.com/openai/codex/blob/1f41cc5d92722748e45cae9cecc6d883a4e7cbb1/codex-rs/app-server/src/bespoke_event_handling.rs#L1915-L2092)
- command approval defaults/capabilities: [`codex-rs/protocol/src/approvals.rs:283-347`](https://github.com/openai/codex/blob/1f41cc5d92722748e45cae9cecc6d883a4e7cbb1/codex-rs/protocol/src/approvals.rs#L283-L347)

The upstream contract is sufficient; no custom protocol or replacement service is needed.

## Evidence Map

- changed surface: `extensions/codex/src/app-server/approval-bridge.ts`
- entry point: `handleCodexAppServerApprovalRequest`
- caller: `extensions/codex/src/app-server/run-attempt-server-requests.ts`
- owner/callee: Codex plugin bridge → existing `requestPluginApproval` / `waitForPluginApprovalDecision`
- invariant-sharing siblings: native command, file change, command amendments, mutable file/script binding, rejection/cancellation
- focused tests: `extensions/codex/src/app-server/approval-bridge.test.ts`
- deterministic product proof: `test/e2e/qa-lab/runtime/codex-native-approval-receipt.e2e.test.ts`
- current-main defect: Gateway choices were not constrained by the native command request, allowing an authoritative session receipt for a one-shot Codex response

## Evidence

- Pre-fix regression: expected `allowedDecisions: ["allow-once", "deny"]`; current main returned no constraint.
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/approval-bridge.test.ts` — 102 passed.
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/codex-native-approval-receipt.e2e.test.ts` — full dist rebuild; 1 passed. An actual embedded app-server emitted a native approval request, Gateway resolved it once, `operator_approvals` retained exact identity, no generic receipt duplicated it, public JSON was redacted, and restart inspection was byte-identical.
- `node scripts/check-changed.mjs -- <six changed paths>` — passed, including formatting, typechecks, plugin boundaries, lint, database-first, dependency, and import-cycle gates.
- `pnpm docs:check-mdx` — passed.
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm docs:check-links:anchors` — reached link validation; reported two existing unrelated `/gateway/cloud-workers#desktop-interactive` references in `docs/concepts/experimental-features.md` and `docs/gateway/protocol.md`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — exact-head clean, no accepted/actionable finding.
- `pnpm test:extension codex` — 3,814 passed / 8 unrelated local-environment failures. The failures reproduce independently in native skill discovery, app-isolation, and session-catalog tests and expose installed host skills or pre-existing app-isolation state; none enters the changed bridge or receipt assertion path.

## Privacy and Risk

- Public audit output is asserted not to contain command text, cwd/path, native thread ID, or item ID.
- `enforced` comes only from the exact operator-owned decision bound to context/execution/run.
- Auto-review, policy/full-access, hook decisions, missing/stale context, and pre-route rejection remain unsupported rather than inferred.
- No raw patch, command, path, auth value, provider credential, or upstream request ID is persisted or returned.

## Review Metrics

- production: +48 / -14, net +34. The growth is the explicit native capability owner shared by both approval phases; no equivalent existing public seam can encode the upstream decision contract.
- tests/test support: +674 / -2, net +672, including the app-server/Gateway/restart E2E fixture.
- docs: +30 / -0.
- config/default surfaces: 0 added, changed, or removed.

## ClawSweeper Rank-up Dispositions

Hosted exact-head review is conclusive for `cc4d0905d5fec458115585b05819f3b6ff9017bb`: [review comment](https://github.com/openclaw/openclaw/pull/125995#issuecomment-5334246490). It reported no actionable findings and no security findings; the PR remains draft for the required maintainer decision.

- Rank-up: inspect and cite the exact sibling Codex protocol source — applied. The direct `openai/codex@1f41cc5d92722748e45cae9cecc6d883a4e7cbb1` files and lines are cited above. ClawSweeper could not access the sibling checkout in its read-only runner; that runner limitation does not replace the packet worker's direct inspection.
- Rank-up: run the focused Gateway-restart E2E on the exact head — applied. The exact `cc4d0905d5f` full-rebuild run passed 1/1 in 262 seconds with redaction assertions. ClawSweeper's 30-second output observer expired while the build was still progressing; its log shows no test assertion failure.
- Merge-risk compatibility/security boundary — accepted for maintainer review. Narrowing choices to upstream-advertised scope is the repair; denial, cancellation, timeout, file, amendment, missing-context, and no-route siblings are covered.
- Positive production LOC — justified. Net +39 creates the one shared capability projection consumed by both Gateway presentation and native response; no existing mapper owns both phases.
- Protected maintainer draft — retained. Exact next action is maintainer protocol/evidence review and manual landing decision; no automerge is enabled.

AI-assisted: yes. I understand and directly inspected the changed owner, callers/callees, sibling paths, tests, current behavior, and upstream Codex contract.