### PR TITLE
fix(copilot): restore OpenClaw guidance to agent turns

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -293,7 +293,7 @@ extensions/copilot/src/provider-bridge.ts	1
 extensions/copilot/src/replay-shim.ts	3
 extensions/copilot/src/runtime.ts	1
 extensions/copilot/src/sdk-loader.ts	2
-extensions/copilot/src/tool-bridge.ts	7
+extensions/copilot/src/tool-bridge.ts	6
 extensions/copilot/src/workspace-bootstrap.ts	1
 extensions/crabbox/src/crabbox-worker-inspect.ts	3
 extensions/crabbox/src/crabbox-worker-provider.ts	1
@@ -1853,7 +1853,6 @@ src/agents/embedded-agent-runner/run/attempt-normalization.ts	1
 src/agents/embedded-agent-runner/run/attempt-prompt-build.ts	2
 src/agents/embedded-agent-runner/run/attempt-prompt-helpers.ts	4
 src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts	2
-src/agents/embedded-agent-runner/run/attempt-prompt-support.ts	2
 src/agents/embedded-agent-runner/run/attempt-queue-message.ts	7
 src/agents/embedded-agent-runner/run/attempt-session-prepare.ts	4
 src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts	1

--- a/extensions/codex/src/app-server/thread-prompt.ts
+++ b/extensions/codex/src/app-server/thread-prompt.ts
@@ -1,5 +1,6 @@
 import {
   buildDelegationGuidanceSection,
+  buildHarnessVisibleReplyGuidance,
   buildSkillWorkshopPromptSection,
   resolveMainSessionDelegationMode,
   SKILL_WORKSHOP_TOOL_NAME,
@@ -104,23 +105,13 @@ export function buildDeveloperInstructions(
           hasSessionsSend,
         }).join("\n")
       : undefined,
-    buildVisibleReplyInstruction(params, messageToolAvailable),
+    buildHarnessVisibleReplyGuidance({
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+      messageToolAvailable,
+    }),
     TRANSCRIPT_CREDENTIAL_SAFETY_PROMPT,
     nativeCommandGuidance,
     params.extraSystemPrompt,
   ];
   return sections.filter((section) => typeof section === "string" && section.trim()).join("\n\n");
-}
-
-function buildVisibleReplyInstruction(
-  params: EmbeddedRunAttemptParams,
-  messageToolAvailable: boolean,
-): string {
-  if (params.sourceReplyDeliveryMode === "message_tool_only" && messageToolAvailable) {
-    return "Visible source replies are not automatically delivered for this run. Use `message(action=send)` for user-visible source-channel output. For progress, set `final=false`. Set `final=true`, or omit it, for the completed reply to the current source conversation; OpenClaw stops after confirming delivery. Do not repeat visible message content in your final answer.";
-  }
-  if (messageToolAvailable) {
-    return "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation. Use `message` for supported non-text actions in the current conversation, such as reacting to its current message. Reserve other `message` actions for explicit out-of-band sends or media/file delivery. Reactions are not delivered automatically.";
-  }
-  return "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation.";
 }

--- a/extensions/copilot/src/attempt-config.ts
+++ b/extensions/copilot/src/attempt-config.ts
@@ -4,7 +4,6 @@ import {
   detectAndLoadAgentHarnessPromptImages,
   getModelProviderRequestTransport,
   resolveUserPath,
-  TRANSCRIPT_CREDENTIAL_SAFETY_PROMPT,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { toStringifiedError as toCopilotError } from "openclaw/plugin-sdk/error-runtime";
 import { readNonEmptyStringPreservingWhitespace as readNonEmptyString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -317,27 +316,9 @@ function resolveImageCapabilityModel(params: AttemptParamsLike): { input?: strin
   }
   return { input: ["image"] };
 }
-export function createSystemMessageContent(
-  params: AttemptParamsLike,
-  workspaceBootstrapInstructions: string | undefined,
-): string | undefined {
-  if (isRawCopilotModelRun(params)) {
-    return undefined;
-  }
-  const sections: string[] = [TRANSCRIPT_CREDENTIAL_SAFETY_PROMPT];
-  const bootstrap = workspaceBootstrapInstructions?.trim();
-  if (bootstrap) {
-    sections.push(bootstrap);
-  }
-  const extraSystemPrompt = readNonEmptyString(params.extraSystemPrompt)?.trim();
-  if (extraSystemPrompt) {
-    const contextHeader =
-      params.promptMode === "minimal" ? "## Subagent Context" : "## Conversation Context";
-    sections.push(`${contextHeader}\n${extraSystemPrompt}`);
-  }
-  return sections.length > 0 ? sections.join("\n\n") : undefined;
-}
-export function isRawCopilotModelRun(params: AttemptParamsLike): boolean {
+export function isRawCopilotModelRun(
+  params: Pick<AttemptParamsLike, "modelRun" | "promptMode">,
+): boolean {
   return params.modelRun === true || params.promptMode === "none";
 }
 export { readNonEmptyString };

--- a/extensions/copilot/src/attempt-config.ts
+++ b/extensions/copilot/src/attempt-config.ts
@@ -316,11 +316,6 @@ function resolveImageCapabilityModel(params: AttemptParamsLike): { input?: strin
   }
   return { input: ["image"] };
 }
-export function isRawCopilotModelRun(
-  params: Pick<AttemptParamsLike, "modelRun" | "promptMode">,
-): boolean {
-  return params.modelRun === true || params.promptMode === "none";
-}
 export { readNonEmptyString };
 export function readResolvedAttemptPath(value: unknown): string | undefined {
   const raw = readNonEmptyString(value)?.trim();

--- a/extensions/copilot/src/attempt-execution.ts
+++ b/extensions/copilot/src/attempt-execution.ts
@@ -1,4 +1,3 @@
-import type { Tool as SdkTool } from "@github/copilot-sdk";
 import type {
   AgentMessage,
   AnyAgentTool,
@@ -253,8 +252,10 @@ export async function runCopilotExecution(context: {
     frameImageIdentity?: string;
   } = { value: 0 };
   let codeModeEngaged: boolean | undefined;
+  let promptToolPolicy:
+    | Awaited<ReturnType<typeof createToolBridge>>["promptToolPolicy"]
+    | undefined;
   try {
-    let sdkTools: SdkTool[] = [];
     let resultContentSourceByToolName = new Map<
       string,
       NonNullable<AnyAgentTool["resultContentSource"]>
@@ -299,7 +300,7 @@ export async function runCopilotExecution(context: {
         });
         cleanupToolBridge = toolBridge.cleanup;
         codeModeEngaged = toolBridge.codeModeEngaged;
-        sdkTools = toolBridge.sdkTools;
+        promptToolPolicy = toolBridge.promptToolPolicy;
         resultContentSourceByToolName = new Map(
           toolBridge.sourceTools.flatMap((tool) =>
             tool.resultContentSource ? [[tool.name, tool.resultContentSource] as const] : [],
@@ -333,7 +334,7 @@ export async function runCopilotExecution(context: {
       operation: deps.operation,
       poolAcquire,
       ringZeroSystemAgentRun,
-      sdkTools,
+      promptToolPolicy,
       sessionProvider,
       settledToolFinalization,
       signal: params.abortSignal,

--- a/extensions/copilot/src/attempt-mode.ts
+++ b/extensions/copilot/src/attempt-mode.ts
@@ -1,0 +1,3 @@
+export function isRawCopilotModelRun(params: { modelRun?: boolean; promptMode?: string }): boolean {
+  return params.modelRun === true || params.promptMode === "none";
+}

--- a/extensions/copilot/src/attempt-session-setup.ts
+++ b/extensions/copilot/src/attempt-session-setup.ts
@@ -3,11 +3,8 @@ import {
   resolveAgentHarnessBeforePromptBuildResult,
   runAgentHarnessLlmInputHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import {
-  createSessionConfig,
-  isRawCopilotModelRun,
-  type resolvePoolAcquire,
-} from "./attempt-config.js";
+import { createSessionConfig, type resolvePoolAcquire } from "./attempt-config.js";
+import { isRawCopilotModelRun } from "./attempt-mode.js";
 import { assertCopilotAttemptHostCapabilities } from "./attempt-types.js";
 import type {
   AttemptParamsLike,

--- a/extensions/copilot/src/attempt-session-setup.ts
+++ b/extensions/copilot/src/attempt-session-setup.ts
@@ -1,4 +1,3 @@
-import type { Tool as SdkTool } from "@github/copilot-sdk";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   resolveAgentHarnessBeforePromptBuildResult,
@@ -6,7 +5,6 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
   createSessionConfig,
-  createSystemMessageContent,
   isRawCopilotModelRun,
   type resolvePoolAcquire,
 } from "./attempt-config.js";
@@ -17,8 +15,9 @@ import type {
   CopilotAttemptDeps,
   ModelRef,
 } from "./attempt-types.js";
+import { buildCopilotPromptGuidance } from "./prompt-guidance.js";
 import type { ResolvedCopilotProvider } from "./provider-bridge.js";
-import { filterCopilotToolsForAllowlist, shouldForceCopilotMessageTool } from "./tool-bridge.js";
+import { shouldForceCopilotMessageTool, type createCopilotToolBridge } from "./tool-bridge.js";
 import { createCopilotUserInputBridge } from "./user-input-bridge.js";
 import { resolveCopilotWorkspaceBootstrapContext } from "./workspace-bootstrap.js";
 export async function createCopilotSessionSetup(params: {
@@ -32,7 +31,7 @@ export async function createCopilotSessionSetup(params: {
   operation: CopilotAttemptDeps["operation"];
   poolAcquire: ReturnType<typeof resolvePoolAcquire>;
   ringZeroSystemAgentRun: boolean;
-  sdkTools: SdkTool[];
+  promptToolPolicy?: Awaited<ReturnType<typeof createCopilotToolBridge>>["promptToolPolicy"];
   sessionProvider: ResolvedCopilotProvider;
   settledToolFinalization: boolean;
   signal: AbortSignal | undefined;
@@ -48,7 +47,7 @@ export async function createCopilotSessionSetup(params: {
     operation,
     poolAcquire,
     ringZeroSystemAgentRun,
-    sdkTools,
+    promptToolPolicy,
     sessionProvider,
     settledToolFinalization,
     signal,
@@ -66,31 +65,42 @@ export async function createCopilotSessionSetup(params: {
         warn: (message) => console.warn(message),
       })
     : { instructions: undefined };
-  const originalDeveloperInstructions = settledToolFinalization
-    ? ""
-    : (createSystemMessageContent(input, workspaceBootstrap.instructions) ?? "");
-  const promptBuild =
-    settledToolFinalization || isRawCopilotModelRun(input)
-      ? {
-          prompt: input.prompt,
-          developerInstructions: originalDeveloperInstructions,
-        }
-      : await resolveAgentHarnessBeforePromptBuildResult({
-          prompt: input.prompt,
-          developerInstructions: originalDeveloperInstructions,
-          messages,
-          ctx: hookContext,
-          bootstrapContextRunKind: input.bootstrapContextRunKind,
-        });
+  const forceToolNames =
+    ordinaryAttemptInput && shouldForceCopilotMessageTool(ordinaryAttemptInput)
+      ? (["message"] as const)
+      : undefined;
+  let promptPolicyResult: ReturnType<NonNullable<typeof promptToolPolicy>["apply"]> | undefined;
+  let promptBuild: Awaited<ReturnType<typeof resolveAgentHarnessBeforePromptBuildResult>>;
+  if (settledToolFinalization) {
+    promptBuild = { prompt: input.prompt, developerInstructions: "" };
+  } else if (isRawCopilotModelRun(input)) {
+    promptPolicyResult = promptToolPolicy?.apply();
+    promptBuild = { prompt: input.prompt, developerInstructions: "" };
+  } else {
+    if (!promptToolPolicy) {
+      throw new Error("Copilot ordinary attempts require a prompt tool policy.");
+    }
+    promptBuild = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: input.prompt,
+      developerInstructions: {
+        build: ({ toolsAllow }) => {
+          promptPolicyResult = promptToolPolicy.apply({ toolsAllow, forceToolNames });
+          return buildCopilotPromptGuidance({
+            attempt: input,
+            callableToolNames: promptPolicyResult.callableToolNames,
+            workspaceBootstrapInstructions: workspaceBootstrap.instructions,
+          });
+        },
+      },
+      messages,
+      ctx: hookContext,
+      bootstrapContextRunKind: input.bootstrapContextRunKind,
+    });
+  }
   const attemptInput =
     promptBuild.prompt === input.prompt ? input : { ...input, prompt: promptBuild.prompt };
-  const promptTools = filterCopilotToolsForAllowlist(
-    sdkTools,
-    promptBuild.toolsAllow,
-    ordinaryAttemptInput && shouldForceCopilotMessageTool(ordinaryAttemptInput)
-      ? { forceToolNames: ["message"] }
-      : undefined,
-  );
+  const promptTools = promptPolicyResult?.tools ?? [];
+  const finalDeveloperInstructions = promptBuild.developerInstructions;
   // Restricted turns may expose native ask_user only when its policy-filtered
   // OpenClaw equivalent survived the canonical tool catalog.
   const includeAskUser =
@@ -108,9 +118,7 @@ export async function createCopilotSessionSetup(params: {
         sessionId: input.sessionId,
         provider: modelRef.provider,
         model: modelRef.id,
-        ...(promptBuild.developerInstructions
-          ? { systemPrompt: promptBuild.developerInstructions }
-          : {}),
+        ...(finalDeveloperInstructions ? { systemPrompt: finalDeveloperInstructions } : {}),
         prompt: additionalContext ? `${prompt}\n\n${additionalContext}` : prompt,
         historyMessages: [],
         imagesCount: promptImagesCount,
@@ -133,7 +141,7 @@ export async function createCopilotSessionSetup(params: {
     promptTools,
     poolAcquire.auth,
     sessionProvider,
-    promptBuild.developerInstructions || undefined,
+    finalDeveloperInstructions || undefined,
     effectiveWorkspaceDir,
     effectiveCwd,
     userInputBridge?.onUserInputRequest,
@@ -155,7 +163,7 @@ export async function createCopilotSessionSetup(params: {
         promptTools,
         poolAcquire.auth,
         poolAcquire.provider,
-        promptBuild.developerInstructions || undefined,
+        finalDeveloperInstructions || undefined,
         effectiveWorkspaceDir,
         effectiveCwd,
         userInputBridge?.onUserInputRequest,

--- a/extensions/copilot/src/attempt.live.test.ts
+++ b/extensions/copilot/src/attempt.live.test.ts
@@ -1,15 +1,17 @@
 // Copilot tests cover attempt plugin behavior.
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { CopilotClient } from "@github/copilot-sdk";
 import type { SessionConfig } from "@github/copilot-sdk";
 import type {
+  AgentMessage,
   AgentHarnessAttemptParamsV2 as AgentHarnessAttemptParams,
   AgentHarnessV2,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
-import { describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import { createCopilotAgentHarness } from "../harness.js";
 import { createCopilotTestHostCapabilities } from "./host-capability.test-support.js";
 
@@ -23,11 +25,41 @@ const liveToolState = vi.hoisted(() => ({
   expectedText: "phase-1-green",
   permissionRequests: 0,
   sentinelPrefix: "copilot-live-smoke:",
+  spawnCalls: [] as Array<{ task: string; visible: boolean }>,
+  spawnToolName: "sessions_spawn",
   toolName: "live_echo",
   userInputRequests: 0,
 }));
 
 const LIVE_MODEL_PREFERENCES = ["gpt-5.4-mini", "gpt-5.4", "gpt-5.6-luna"] as const;
+const OPENAI_BASE_URL = "https://api.openai.com/v1";
+const OPENAI_DEFAULT_MODEL = "gpt-5.6-luna";
+const OPENAI_AUTH_PROFILE_ID = "openai:copilot-agent-live";
+
+type LiveAuthMode =
+  | { kind: "github-copilot"; gitHubToken: string }
+  | { apiKey: string; kind: "openai-byok"; modelId: string };
+
+type LiveAttemptFacts =
+  | {
+      auth: { gitHubToken: string; profileId: string; profileVersion: string };
+      authProfileId: string;
+      kind: "github-copilot";
+      model: { api: "openai-responses"; id: string; provider: "github-copilot" };
+      provider: "github-copilot";
+    }
+  | {
+      authProfileId: string;
+      kind: "openai-byok";
+      model: {
+        api: "openai-responses";
+        baseUrl: typeof OPENAI_BASE_URL;
+        id: string;
+        provider: "openai";
+      };
+      provider: "openai";
+      resolvedApiKey: string;
+    };
 
 vi.mock("openclaw/plugin-sdk/agent-harness", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/agent-harness")>();
@@ -67,17 +99,79 @@ vi.mock("openclaw/plugin-sdk/agent-harness", async (importOriginal) => {
           };
         },
       },
+      {
+        name: liveToolState.spawnToolName,
+        label: liveToolState.spawnToolName,
+        description: "Spawn an OpenClaw session for delegated work.",
+        parameters: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            task: { type: "string", description: "The delegated objective." },
+            visible: {
+              type: "boolean",
+              description: "Whether the user can follow the session in the sidebar.",
+            },
+          },
+          required: ["task"],
+        },
+        async execute(_toolCallId: string, params: unknown) {
+          const input =
+            params && typeof params === "object" && !Array.isArray(params)
+              ? (params as { task?: unknown; visible?: unknown })
+              : {};
+          const call = {
+            task: typeof input.task === "string" ? input.task : "",
+            visible: input.visible === true,
+          };
+          liveToolState.spawnCalls.push(call);
+          return {
+            content: [
+              {
+                type: "text",
+                text: "Visible delegated session created: https://example.test/session/live-proof",
+              },
+            ],
+            details: {
+              sessionKey: "agent:copilot-live-smoke:subagent:live-proof",
+              url: "https://example.test/session/live-proof",
+              visible: call.visible,
+            },
+          };
+        },
+      },
     ]),
   };
 });
 
 const LIVE = isLiveTestEnabled(["OPENCLAW_COPILOT_AGENT_LIVE_TEST"]);
-const TOKEN =
-  process.env.OPENCLAW_COPILOT_AGENT_LIVE_TOKEN ||
-  process.env.GITHUB_TOKEN ||
-  process.env.GH_TOKEN ||
-  "";
-const describeLive = LIVE && TOKEN ? describe : describe.skip;
+const AUTH_MODE = resolveLiveAuthMode();
+const describeLive = LIVE && AUTH_MODE ? describe : describe.skip;
+let liveAttemptFacts: LiveAttemptFacts;
+
+function readNonEmptyEnv(name: string): string | undefined {
+  const value = process.env[name];
+  return value?.trim() ? value : undefined;
+}
+
+function resolveLiveAuthMode(): LiveAuthMode | undefined {
+  const explicitCopilotToken = readNonEmptyEnv("OPENCLAW_COPILOT_AGENT_LIVE_TOKEN");
+  if (explicitCopilotToken) {
+    return { kind: "github-copilot", gitHubToken: explicitCopilotToken };
+  }
+  const apiKey = readNonEmptyEnv("OPENAI_API_KEY");
+  if (apiKey) {
+    return {
+      apiKey,
+      kind: "openai-byok",
+      modelId: readNonEmptyEnv("OPENCLAW_COPILOT_AGENT_LIVE_MODEL") ?? OPENAI_DEFAULT_MODEL,
+    };
+  }
+  const fallbackCopilotToken = readNonEmptyEnv("GITHUB_TOKEN") ?? readNonEmptyEnv("GH_TOKEN");
+  return fallbackCopilotToken
+    ? { kind: "github-copilot", gitHubToken: fallbackCopilotToken }
+    : undefined;
+}
 
 function wrapLiveSessionConfig(config: SessionConfig): SessionConfig {
   const onPermissionRequest = config.onPermissionRequest;
@@ -143,8 +237,29 @@ function createLivePool(): CopilotClientPool {
   };
 }
 
-async function resolveLiveModelId(copilotHome: string): Promise<string> {
-  const client = new CopilotClient({ baseDirectory: copilotHome, gitHubToken: TOKEN });
+async function resolveLiveAttemptFacts(
+  authMode: LiveAuthMode,
+  copilotHome: string,
+): Promise<LiveAttemptFacts> {
+  if (authMode.kind === "openai-byok") {
+    return {
+      authProfileId: OPENAI_AUTH_PROFILE_ID,
+      kind: authMode.kind,
+      model: {
+        api: "openai-responses",
+        baseUrl: OPENAI_BASE_URL,
+        id: authMode.modelId,
+        provider: "openai",
+      },
+      provider: "openai",
+      resolvedApiKey: authMode.apiKey,
+    };
+  }
+
+  const client = new CopilotClient({
+    baseDirectory: copilotHome,
+    gitHubToken: authMode.gitHubToken,
+  });
   try {
     await client.start();
     const available = (await client.listModels()).filter(
@@ -152,58 +267,110 @@ async function resolveLiveModelId(copilotHome: string): Promise<string> {
     );
     for (const preferred of LIVE_MODEL_PREFERENCES) {
       if (available.some((model) => model.id === preferred)) {
-        return preferred;
+        return createGitHubAttemptFacts(authMode.gitHubToken, preferred);
       }
     }
     const fallback = available[0]?.id;
     if (!fallback) {
       throw new Error("Copilot live smoke found no enabled models");
     }
-    return fallback;
+    return createGitHubAttemptFacts(authMode.gitHubToken, fallback);
   } finally {
     await client.stop();
   }
 }
 
-function createAttemptParams(params: {
+function createGitHubAttemptFacts(gitHubToken: string, modelId: string): LiveAttemptFacts {
+  const profileId = "live-smoke-profile";
+  return {
+    auth: { gitHubToken, profileId, profileVersion: "v1" },
+    authProfileId: profileId,
+    kind: "github-copilot",
+    model: { api: "openai-responses", id: modelId, provider: "github-copilot" },
+    provider: "github-copilot",
+  };
+}
+
+function createLiveUserTurnRecorder(
+  message: Extract<AgentMessage, { role: "user" }>,
+): NonNullable<AgentHarnessAttemptParams["userTurnTranscriptRecorder"]> {
+  let blocked = false;
+  let persisted = false;
+  return {
+    message,
+    resolveMessage: async () => message,
+    markRuntimePersistencePending() {},
+    markRuntimePersisted() {
+      persisted = true;
+    },
+    markBlocked() {
+      blocked = true;
+    },
+    hasPersisted: () => persisted,
+    isBlocked: () => blocked,
+    hasRuntimePersistencePending: () => false,
+    getAdmissionReceipt: () => undefined,
+    waitForRuntimePersistence: async () => undefined,
+    persistApproved: async () => undefined,
+    persistBlocked: async () => undefined,
+    persistFallback: async () => undefined,
+  };
+}
+
+async function createTempDir(prefix: string): Promise<string> {
+  return await mkdtemp(join(await realpath(tmpdir()), prefix));
+}
+
+async function createAttemptParams(params: {
   copilotHome: string;
-  modelId: string;
+  facts: LiveAttemptFacts;
   onAgentEvent?: (event: unknown) => void | Promise<void>;
   onAssistantDelta: (payload: { text: string }) => void | Promise<void>;
   prompt: string;
-}): AgentHarnessAttemptParams {
-  const profileId = "live-smoke-profile";
+}): Promise<AgentHarnessAttemptParams> {
   const profileVersion = "v1";
   const now = Date.now();
+  const sessionId = `copilot-live-smoke-session-${now}`;
+  const sessionKey = "agent:copilot-live-smoke:main";
+  const storePath = join(params.copilotHome, "openclaw-agent.sqlite");
+  const userMessage = { content: params.prompt, role: "user", timestamp: now } as const;
+  await upsertSessionEntry({
+    agentId: "copilot-live-smoke",
+    entry: { sessionId, updatedAt: now },
+    sessionKey,
+    storePath,
+  });
 
   return {
     agentDir: params.copilotHome,
     agentId: "copilot-live-smoke",
-    auth: {
-      gitHubToken: TOKEN,
-      profileId,
-      profileVersion,
-    },
-    authProfileId: profileId,
+    ...(params.facts.kind === "github-copilot"
+      ? { auth: params.facts.auth }
+      : { resolvedApiKey: params.facts.resolvedApiKey }),
+    authProfileId: params.facts.authProfileId,
     copilotHome: params.copilotHome,
     cwd: process.cwd(),
     hostCapabilities: createCopilotTestHostCapabilities(),
-    messages: [{ content: params.prompt, role: "user", timestamp: now }],
-    model: {
-      api: "openai-responses",
-      id: params.modelId,
-      provider: "github-copilot",
-    },
-    modelId: params.modelId,
+    messages: [userMessage],
+    model: params.facts.model,
+    modelId: params.facts.model.id,
     onAgentEvent: params.onAgentEvent,
     onAssistantDelta: params.onAssistantDelta,
     profileVersion,
     prompt: params.prompt,
-    provider: "github-copilot",
+    provider: params.facts.provider,
     runId: `copilot-live-smoke-${now}`,
     sessionFile: join(params.copilotHome, "copilot-live-smoke.session.json"),
-    sessionId: `copilot-live-smoke-session-${now}`,
+    sessionId,
+    sessionKey,
+    sessionTarget: {
+      agentId: "copilot-live-smoke",
+      sessionId,
+      sessionKey,
+      storePath,
+    },
     timeoutMs: 90_000,
+    userTurnTranscriptRecorder: createLiveUserTurnRecorder(userMessage),
     workspaceDir: process.cwd(),
   } as unknown as AgentHarnessAttemptParams;
 }
@@ -220,6 +387,18 @@ function createFinalizationAttempt(
 }
 
 describeLive("copilot agent runtime live smoke", () => {
+  beforeAll(async () => {
+    if (!AUTH_MODE) {
+      throw new Error("Copilot live smoke requires a Copilot token or OPENAI_API_KEY");
+    }
+    const modelHome = await createTempDir("openclaw-copilot-live-model-");
+    try {
+      liveAttemptFacts = await resolveLiveAttemptFacts(AUTH_MODE, modelHome);
+    } finally {
+      await rm(modelHome, { recursive: true, force: true });
+    }
+  });
+
   it("uses one custom tool, then resumes with an isolated finalization turn", async () => {
     liveToolState.calls.length = 0;
     liveToolState.permissionRequests = 0;
@@ -227,22 +406,30 @@ describeLive("copilot agent runtime live smoke", () => {
     const streamedTexts: string[] = [];
     const finalEventTypes: string[] = [];
     const prompt = `Use the ${liveToolState.toolName} tool exactly once with text '${liveToolState.expectedText}', then reply with one short sentence.`;
-    const copilotHome = await mkdtemp(join(tmpdir(), "openclaw-copilot-live-"));
-    const modelId = await resolveLiveModelId(copilotHome);
+    const copilotHome = await createTempDir("openclaw-copilot-live-");
+    const facts = liveAttemptFacts;
+    const modelId = facts.model.id;
     const harness = createCopilotAgentHarness({ pool: createLivePool() });
 
     try {
       expect(
         harness.supports({
-          provider: "github-copilot",
+          provider: facts.provider,
           modelId,
+          ...(facts.kind === "openai-byok"
+            ? {
+                modelProvider: { api: facts.model.api, baseUrl: facts.model.baseUrl },
+                providerOwnerPluginIds: [],
+                providerOwnerStatus: "unowned" as const,
+              }
+            : {}),
           requestedRuntime: "copilot",
         }),
       ).toEqual({ supported: true, priority: 100 });
 
-      const attempt = createAttemptParams({
+      const attempt = await createAttemptParams({
         copilotHome,
-        modelId,
+        facts,
         onAssistantDelta: ({ text }) => {
           if (text.trim()) {
             streamedTexts.push(text);
@@ -320,6 +507,53 @@ describeLive("copilot agent runtime live smoke", () => {
       expect(finalCapabilityEvents).toEqual([]);
       expect(liveToolState.permissionRequests).toBe(0);
       expect(liveToolState.userInputRequests).toBe(0);
+    } finally {
+      await harness.dispose?.();
+      await rm(copilotHome, { recursive: true, force: true });
+    }
+  }, 180_000);
+
+  it("delegates user-followed deliverable work through a visible OpenClaw session", async () => {
+    liveToolState.spawnCalls.length = 0;
+    const streamedTexts: string[] = [];
+    const copilotHome = await createTempDir("openclaw-copilot-live-delegation-");
+    const facts = liveAttemptFacts;
+    const modelId = facts.model.id;
+    const harness = createCopilotAgentHarness({ pool: createLivePool() });
+
+    try {
+      const prompt =
+        "Investigate how prompt-hook tool narrowing is implemented in this codebase. Delegate exactly one user-followed codebase investigation that produces its own report, then reply with the returned report link.";
+      const result = await harness.runAttempt(
+        await createAttemptParams({
+          copilotHome,
+          facts,
+          onAssistantDelta: ({ text }) => {
+            if (text.trim()) {
+              streamedTexts.push(text);
+            }
+          },
+          prompt,
+        }),
+      );
+      if (!("terminal" in result)) {
+        throw new Error("Copilot harness returned the deprecated attempt result shape");
+      }
+
+      const assistantText = result.assistantTexts.join("\n");
+      console.info(
+        "[copilot-live-delegation] summary",
+        JSON.stringify(
+          { assistantText, modelId, spawnCalls: liveToolState.spawnCalls, streamedTexts },
+          null,
+          2,
+        ),
+      );
+      expect(result.terminal).toEqual({ kind: "ok" });
+      expect(liveToolState.spawnCalls).toHaveLength(1);
+      expect(liveToolState.spawnCalls[0]?.visible).toBe(true);
+      expect(liveToolState.spawnCalls[0]?.task).not.toBe("");
+      expect(assistantText).toContain("https://example.test/session/live-proof");
     } finally {
       await harness.dispose?.();
       await rm(copilotHome, { recursive: true, force: true });

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -6,12 +6,14 @@ import type { CopilotClient, Tool as SdkTool } from "@github/copilot-sdk";
 import { expectDefined } from "@openclaw/normalization-core";
 import {
   abortAgentHarnessRun,
+  applyEmbeddedAttemptToolsAllow,
   attachModelProviderRequestTransport,
   queueAgentHarnessMessage,
   type AgentHarnessAttemptParamsV2 as AgentHarnessAttemptParams,
   type AgentHarnessAttemptResult as AgentHarnessAttemptResultContract,
   type AgentHarnessV2,
   type AgentMessage,
+  type AnyAgentTool,
   type SandboxContext,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { toErrorObject as toLintErrorObject } from "openclaw/plugin-sdk/error-runtime";
@@ -113,6 +115,28 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
 });
 
 type CopilotToolBridgeInput = Parameters<typeof createCopilotToolBridge>[0];
+
+function createStubToolBridge(
+  sdkTools: SdkTool[] = [],
+  sourceTools: AnyAgentTool[] = [],
+  extras: { cleanup?: () => void; codeModeEngaged?: boolean } = {},
+) {
+  return {
+    ...extras,
+    promptToolPolicy: {
+      apply: (params: { toolsAllow?: string[]; forceToolNames?: readonly string[] } = {}) => {
+        const allowed = applyEmbeddedAttemptToolsAllow(sdkTools, params.toolsAllow);
+        const names = new Set([
+          ...allowed.map((tool) => tool.name),
+          ...(params.forceToolNames ?? []),
+        ]);
+        const tools = sdkTools.filter((tool) => names.has(tool.name));
+        return { tools, callableToolNames: tools.map((tool) => tool.name) };
+      },
+    },
+    sourceTools,
+  };
+}
 
 const TINY_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAsTAAALEwEAmpwYAAAADUlEQVR4nGP4////KwAJ5gPoxLp9owAAAABJRU5ErkJggg==";
@@ -569,7 +593,7 @@ describe("runCopilotAttempt", () => {
         arguments: { summary: "ok" },
         outcome: "success",
       });
-      return { sdkTools: [], sourceTools: [] };
+      return createStubToolBridge();
     });
     const sdk = makeFakeSdk({
       onCreateSession: (session) => {
@@ -615,11 +639,7 @@ describe("runCopilotAttempt", () => {
     });
 
     const result = await runCopilotAttempt(makeParams(), {
-      createToolBridge: vi.fn(async () => ({
-        codeModeEngaged: true,
-        sdkTools: [],
-        sourceTools: [],
-      })),
+      createToolBridge: vi.fn(async () => createStubToolBridge([], [], { codeModeEngaged: true })),
       pool: makeFakePool(sdk),
     });
 
@@ -658,7 +678,7 @@ describe("runCopilotAttempt", () => {
         arguments: args,
         outcome: "success",
       });
-      return { sdkTools: [], sourceTools: [] };
+      return createStubToolBridge();
     });
     const sdk = makeFakeSdk({
       onCreateSession: (session) => {
@@ -707,7 +727,7 @@ describe("runCopilotAttempt", () => {
         toolCallId: "tool-call-1",
         toolName: "read",
       });
-      return { sdkTools: [], sourceTools: [] };
+      return createStubToolBridge();
     });
 
     await runCopilotAttempt(makeParams(), {
@@ -767,7 +787,7 @@ describe("runCopilotAttempt", () => {
     let computerContextEpoch: CopilotToolBridgeInput["computerContextEpoch"];
     const createToolBridge = vi.fn(async (input: CopilotToolBridgeInput) => {
       computerContextEpoch = input.computerContextEpoch;
-      return { sdkTools: [], sourceTools: [] };
+      return createStubToolBridge();
     });
     initializeGlobalHookRunner(
       createMockPluginRegistry([
@@ -1356,7 +1376,7 @@ describe("runCopilotAttempt", () => {
       },
     });
     const pool = makeFakePool(sdk);
-    const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+    const createToolBridge = vi.fn(async () => createStubToolBridge());
 
     const runPromise = runCopilotAttempt(makeParams({ onAssistantDelta }), {
       createToolBridge,
@@ -1393,7 +1413,7 @@ describe("runCopilotAttempt", () => {
       },
     });
     const pool = makeFakePool(sdk);
-    const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+    const createToolBridge = vi.fn(async () => createStubToolBridge());
 
     const runPromise = runCopilotAttempt(makeParams(), { createToolBridge, pool });
     await flushAsync();
@@ -1592,7 +1612,7 @@ describe("runCopilotAttempt", () => {
       },
     });
     const pool = makeFakePool(sdk);
-    const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+    const createToolBridge = vi.fn(async () => createStubToolBridge());
 
     const runPromise = runCopilotAttempt(makeParams({ abortSignal: controller.signal }), {
       createToolBridge,
@@ -1624,7 +1644,7 @@ describe("runCopilotAttempt", () => {
       },
     });
     const pool = makeFakePool(sdk);
-    const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+    const createToolBridge = vi.fn(async () => createStubToolBridge());
 
     const runPromise = runCopilotAttempt(makeParams(), {
       createToolBridge,
@@ -1704,7 +1724,7 @@ describe("runCopilotAttempt", () => {
         parameters: { type: "object" },
       },
     ];
-    const createToolBridge = vi.fn(async () => ({ sdkTools, sourceTools: [] }));
+    const createToolBridge = vi.fn(async () => createStubToolBridge(sdkTools));
 
     await runCopilotAttempt(makeParams(), { createToolBridge, pool });
 
@@ -1733,7 +1753,7 @@ describe("runCopilotAttempt", () => {
     expect(
       ((sdk.createSession.mock.calls[0] as unknown[] | undefined)![0] as { tools?: unknown[] })
         .tools,
-    ).toBe(sdkTools);
+    ).toStrictEqual(sdkTools);
   });
 
   it("applies before_prompt_build toolsAllow to the submitted SDK tool surface", async () => {
@@ -1746,21 +1766,23 @@ describe("runCopilotAttempt", () => {
       ]),
     );
     const sdk = makeFakeSdk();
-    const sdkTools: SdkTool[] = [
-      {
-        description: "Fake SDK tool",
-        handler: async () => ({ resultType: "success", textResultForLlm: "ok" }),
-        name: "fake_sdk_tool",
-        parameters: { type: "object" },
-      },
-    ];
 
-    await runCopilotAttempt(makeParams(), {
-      createToolBridge: vi.fn(async () => ({ sdkTools, sourceTools: [] })),
+    await runCopilotAttempt(makeParams({ agentId: "main", sessionKey: "agent:main:main" }), {
+      createToolBridge: vi.fn(async () => ({
+        codeModeEngaged: true,
+        promptToolPolicy: {
+          apply: () => ({ tools: [], callableToolNames: [] }),
+        },
+        sourceTools: [],
+      })),
       pool: makeFakePool(sdk),
     });
 
     expect((requireCreateSessionConfig(sdk) as { tools?: SdkTool[] }).tools).toEqual([]);
+    const content = (requireCreateSessionConfig(sdk) as { systemMessage?: { content?: string } })
+      .systemMessage?.content;
+    expect(content).not.toContain("## Delegation");
+    expect(content).not.toContain("## Skill Workshop");
   });
 
   it("preserves the required message tool through before_prompt_build toolsAllow", async () => {
@@ -1781,10 +1803,9 @@ describe("runCopilotAttempt", () => {
     });
 
     await runCopilotAttempt(makeParams({ sourceReplyDeliveryMode: "message_tool_only" }), {
-      createToolBridge: vi.fn(async () => ({
-        sdkTools: [makeTool("message"), makeTool("read")],
-        sourceTools: [],
-      })),
+      createToolBridge: vi.fn(async () =>
+        createStubToolBridge([makeTool("message"), makeTool("read")]),
+      ),
       pool: makeFakePool(sdk),
     });
 
@@ -1793,6 +1814,10 @@ describe("runCopilotAttempt", () => {
         (tool) => tool.name,
       ),
     ).toEqual(["message"]);
+    expect(
+      (requireCreateSessionConfig(sdk) as { systemMessage?: { content?: string } }).systemMessage
+        ?.content,
+    ).toContain("Visible source replies are not automatically delivered");
   });
 
   it("F6: sessionRef is populated after createSession so the tool bridge's onYield can abort the live SDK session", async () => {
@@ -1802,7 +1827,7 @@ describe("runCopilotAttempt", () => {
     const createToolBridge = vi.fn(
       async (input: { sessionRef?: { current: { abort?: () => unknown } | undefined } }) => {
         capturedRef = input.sessionRef;
-        return { sdkTools: [], sourceTools: [] };
+        return createStubToolBridge();
       },
     );
 
@@ -1822,7 +1847,7 @@ describe("runCopilotAttempt", () => {
     const createToolBridge = vi.fn(
       async (input: { sessionRef?: { current: { abort?: () => unknown } | undefined } }) => {
         capturedRef = input.sessionRef;
-        return { sdkTools: [], sourceTools: [] };
+        return createStubToolBridge();
       },
     );
 
@@ -1844,7 +1869,7 @@ describe("runCopilotAttempt", () => {
     let capturedParams: unknown;
     const createToolBridge = vi.fn(async (input: { attemptParams?: unknown }) => {
       capturedParams = input.attemptParams;
-      return { sdkTools: [], sourceTools: [] };
+      return createStubToolBridge();
     });
 
     const params = makeParams({
@@ -1870,7 +1895,7 @@ describe("runCopilotAttempt", () => {
         // flag (parent runner uses it to mark liveness paused /
         // stop_reason end_turn). Mirrors PI/codex parity.
         input.onYieldDetected?.("private continuation", "Research started; results will follow.");
-        return { sdkTools: [], sourceTools: [] };
+        return createStubToolBridge();
       },
     );
 
@@ -1889,7 +1914,7 @@ describe("runCopilotAttempt", () => {
     // Default createToolBridge in deps falls back to the real one,
     // which only fires onYieldDetected when a wrapped tool yields. We
     // pass a bridge that never yields and assert the flag stays false.
-    const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+    const createToolBridge = vi.fn(async () => createStubToolBridge());
 
     const result = await runCopilotAttempt(makeParams(), {
       createToolBridge,
@@ -1935,7 +1960,7 @@ describe("runCopilotAttempt", () => {
     );
     const sdk = makeFakeSdk();
     const pool = makeFakePool(sdk);
-    const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+    const createToolBridge = vi.fn(async () => createStubToolBridge());
 
     const result = await runCopilotAttempt(
       makeParams({
@@ -2442,6 +2467,56 @@ describe("runCopilotAttempt", () => {
       expectTranscriptCredentialSafety(cfg.systemMessage?.content ?? "");
     });
 
+    it("sends the final appended developer instructions to the SDK and llm_input", async () => {
+      const sdk = makeFakeSdk();
+      const llmInput = vi.fn();
+      initializeGlobalHookRunner(
+        createMockPluginRegistry([{ hookName: "llm_input", handler: llmInput }]),
+      );
+      const makeTool = (name: string): SdkTool => ({
+        description: name,
+        handler: async () => ({ resultType: "success", textResultForLlm: "ok" }),
+        name,
+        parameters: { type: "object" },
+      });
+      const toolNames = [
+        "message",
+        "sessions_send",
+        "sessions_spawn",
+        "sessions_yield",
+        "skill_workshop",
+        "subagents",
+      ];
+
+      await runCopilotAttempt(
+        makeParams({
+          agentId: "main",
+          disableTools: false,
+          sessionKey: "agent:main:main",
+        }),
+        {
+          createToolBridge: vi.fn(async () => createStubToolBridge(toolNames.map(makeTool))),
+          pool: makeFakePool(sdk),
+        },
+      );
+      await waitForEventLoopTurn();
+
+      const content = expectDefined(
+        (requireCreateSessionConfig(sdk) as { systemMessage?: { content?: string } }).systemMessage
+          ?.content,
+        "Copilot appended developer instructions",
+      );
+      expect(content).toContain("You are a personal agent running inside OpenClaw.");
+      expect(content).toContain("## Skill Workshop");
+      expect(content).toContain("## Delegation");
+      expect(content).toContain("spawn `sessions_spawn` with `visible=true`");
+      expect(content).toContain("For the current source conversation, reply normally");
+      expect(llmInput).toHaveBeenCalledWith(
+        expect.objectContaining({ systemPrompt: content }),
+        expect.any(Object),
+      );
+    });
+
     it("forwards extraSystemPrompt into SDK SessionConfig.systemMessage", async () => {
       const sdk = makeFakeSdk();
       const pool = makeFakePool(sdk);
@@ -2728,11 +2803,9 @@ describe("runCopilotAttempt", () => {
         );
       },
     });
-    const createToolBridge = vi.fn(async () => ({
-      cleanup: cleanupToolBridge,
-      sdkTools: [],
-      sourceTools: [],
-    }));
+    const createToolBridge = vi.fn(async () =>
+      createStubToolBridge([], [], { cleanup: cleanupToolBridge }),
+    );
 
     const result = await runCopilotAttempt(makeParams(), {
       createToolBridge,
@@ -2909,7 +2982,7 @@ describe("runCopilotAttempt", () => {
       },
     });
     const pool = makeFakePool(sdk);
-    const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+    const createToolBridge = vi.fn(async () => createStubToolBridge());
 
     const runPromise = runCopilotAttempt(makeParams({ onAssistantDelta }), {
       createToolBridge,
@@ -4054,7 +4127,7 @@ describe("runCopilotAttempt", () => {
         },
       });
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const resolveSandboxContextOverride = vi.fn(async () => null);
 
       await runCopilotAttempt(makeParams(), {
@@ -4081,7 +4154,7 @@ describe("runCopilotAttempt", () => {
         },
       });
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const resolveSandboxContextOverride = vi.fn(async () => null);
 
       await runCopilotAttempt(makeParams(), {
@@ -4103,7 +4176,7 @@ describe("runCopilotAttempt", () => {
         },
       });
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const resolveSandboxContextOverride = vi.fn(async () => null);
 
       await runCopilotAttempt(
@@ -4144,7 +4217,7 @@ describe("runCopilotAttempt", () => {
         },
       });
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const resolveSandboxContextOverride = vi.fn(async () => null);
 
       try {
@@ -4186,7 +4259,7 @@ describe("runCopilotAttempt", () => {
         },
       });
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const resolveSandboxContextOverride = vi.fn(async () => sandbox);
 
       await runCopilotAttempt(makeParams(), {
@@ -4214,7 +4287,7 @@ describe("runCopilotAttempt", () => {
         },
       });
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const resolveSandboxContextOverride = vi.fn(async () => sandbox);
 
       await runCopilotAttempt(makeParams(), {
@@ -4238,7 +4311,7 @@ describe("runCopilotAttempt", () => {
         },
       });
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const resolveSandboxContextOverride = vi.fn(async () => sandbox);
 
       const workspaceDir = `${tmpdir()}/copilot-orig-${Date.now()}`;
@@ -4299,7 +4372,7 @@ describe("runCopilotAttempt", () => {
       } as never);
       const sdk = makeFakeSdk();
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const resolveSandboxContextOverride = vi.fn(async () => sandbox);
 
       try {
@@ -4341,7 +4414,7 @@ describe("runCopilotAttempt", () => {
       );
       const sdk = makeFakeSdk();
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const resolveSandboxContextOverride = vi.fn(async () => sandbox);
 
       const result = await runCopilotAttempt(
@@ -4376,7 +4449,7 @@ describe("runCopilotAttempt", () => {
         },
       });
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const resolveSandboxContextOverride = vi.fn(async () => {
         throw new Error("sandbox provisioning boom");
       });
@@ -4406,7 +4479,7 @@ describe("runCopilotAttempt", () => {
         },
       });
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
       const blockingFile = path.join(tmpdir(), `copilot-sandbox-block-${Date.now()}`);
       await fsp.writeFile(blockingFile, "not a directory");
       const sandbox = makeSandboxStub({
@@ -4437,7 +4510,7 @@ describe("runCopilotAttempt", () => {
   describe("settled tool finalization isolation", () => {
     it("requires an existing SDK session before constructing any capability surface", async () => {
       const sdk = makeFakeSdk();
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
 
       const result = await runCopilotAttempt(makeFinalizationParams(), {
         createToolBridge,
@@ -4482,7 +4555,7 @@ describe("runCopilotAttempt", () => {
         name: "unsafe_tool",
         parameters: { type: "object" },
       } satisfies SdkTool;
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [sdkTool], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge([sdkTool]));
       const workspaceBootstrapCalls =
         workspaceBootstrapMock.resolveCopilotWorkspaceBootstrapContext.mock.calls.length;
 
@@ -4634,7 +4707,7 @@ describe("runCopilotAttempt", () => {
       const sdk = makeFakeSdk();
       const pool = makeFakePool(sdk);
       const sdkTools = [makeFakeSdkTool("read"), makeFakeSdkTool("edit")];
-      const createToolBridge = vi.fn(async () => ({ sdkTools, sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge(sdkTools));
 
       await runCopilotAttempt(makeParams(), { createToolBridge, pool });
 
@@ -4649,7 +4722,7 @@ describe("runCopilotAttempt", () => {
       const sdk = makeFakeSdk();
       const pool = makeFakePool(sdk);
       const sdkTools = [makeFakeSdkTool("read")];
-      const createToolBridge = vi.fn(async () => ({ sdkTools, sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge(sdkTools));
 
       await runCopilotAttempt(makeParams({ pluginHarnessToolPolicyRestricted: true }), {
         createToolBridge,
@@ -4663,7 +4736,7 @@ describe("runCopilotAttempt", () => {
       const sdk = makeFakeSdk();
       const pool = makeFakePool(sdk);
       const sdkTools = [makeFakeSdkTool("read"), makeFakeSdkTool("ask_user")];
-      const createToolBridge = vi.fn(async () => ({ sdkTools, sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge(sdkTools));
 
       await runCopilotAttempt(makeParams({ pluginHarnessToolPolicyRestricted: true }), {
         createToolBridge,
@@ -4681,7 +4754,7 @@ describe("runCopilotAttempt", () => {
       const sdk = makeFakeSdk();
       const pool = makeFakePool(sdk);
       const sdkTools = [makeFakeSdkTool("openclaw")];
-      const createToolBridge = vi.fn(async () => ({ sdkTools, sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge(sdkTools));
 
       await runCopilotAttempt(makeParams({ toolsAllow: ["openclaw"] }), {
         createToolBridge,
@@ -4701,7 +4774,7 @@ describe("runCopilotAttempt", () => {
       // Whatever the upstream reason, `availableTools` must be the same
       // ask_user-only list so the SDK cannot fall back to its native
       // catalog while the registered user-input handler remains usable.
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
 
       await runCopilotAttempt(makeParams(), { createToolBridge, pool });
 
@@ -4718,7 +4791,7 @@ describe("runCopilotAttempt", () => {
         makeFakeSdkTool("exec"),
         makeFakeSdkTool("message"),
       ];
-      const createToolBridge = vi.fn(async () => ({ sdkTools, sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge(sdkTools));
 
       await runCopilotAttempt(makeParams(), { createToolBridge, pool });
 
@@ -4748,7 +4821,7 @@ describe("runCopilotAttempt", () => {
       });
       const pool = makeFakePool(sdk);
       const sdkTools = [makeFakeSdkTool("read")];
-      const createToolBridge = vi.fn(async () => ({ sdkTools, sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge(sdkTools));
 
       await runCopilotAttempt(
         makeParams({ initialReplayState: { sdkSessionId: "sess-resume-1" } } as never),
@@ -4768,7 +4841,7 @@ describe("runCopilotAttempt", () => {
       });
       const pool = makeFakePool(sdk);
       const sdkTools = [makeFakeSdkTool("read")];
-      const createToolBridge = vi.fn(async () => ({ sdkTools, sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge(sdkTools));
 
       await runCopilotAttempt(
         makeParams({
@@ -4789,7 +4862,7 @@ describe("runCopilotAttempt", () => {
       });
       const pool = makeFakePool(sdk);
       const sdkTools = [makeFakeSdkTool("openclaw")];
-      const createToolBridge = vi.fn(async () => ({ sdkTools, sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge(sdkTools));
 
       await runCopilotAttempt(
         makeParams({
@@ -4815,7 +4888,7 @@ describe("runCopilotAttempt", () => {
         },
       });
       const pool = makeFakePool(sdk);
-      const createToolBridge = vi.fn(async () => ({ sdkTools: [], sourceTools: [] }));
+      const createToolBridge = vi.fn(async () => createStubToolBridge());
 
       await runCopilotAttempt(
         makeParams({ initialReplayState: { sdkSessionId: "sess-resume-2" } } as never),
@@ -4876,7 +4949,7 @@ describe("runCopilotAttempt", () => {
           // Bypass the real plugin-bridge wiring; with a sandbox in play
           // attempt.ts would otherwise call the real createToolBridge which
           // requires plugin SDK fixtures we do not stand up here.
-          createToolBridge: vi.fn(async () => ({ sdkTools: [], sourceTools: [] })),
+          createToolBridge: vi.fn(async () => createStubToolBridge()),
           // Drive the sandbox resolution branch deterministically so the
           // test asserts the exact wiring rather than the orchestrator's
           // real sandbox discovery path. Include every SandboxContext

--- a/extensions/copilot/src/prompt-guidance.test.ts
+++ b/extensions/copilot/src/prompt-guidance.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import type { AttemptParamsLike } from "./attempt-types.js";
+import { buildCopilotPromptGuidance } from "./prompt-guidance.js";
+
+const fullDelegationTools = [
+  "message",
+  "sessions_send",
+  "sessions_spawn",
+  "sessions_yield",
+  "skill_workshop",
+  "subagents",
+];
+
+function buildGuidance(
+  attempt: Partial<AttemptParamsLike> = {},
+  callableToolNames: Iterable<string> = fullDelegationTools,
+): string | undefined {
+  return buildCopilotPromptGuidance({
+    attempt: {
+      agentId: "main",
+      config: {},
+      sessionKey: "agent:main:main",
+      sourceReplyDeliveryMode: "automatic",
+      ...attempt,
+    } as AttemptParamsLike,
+    callableToolNames,
+  });
+}
+
+describe("buildCopilotPromptGuidance", () => {
+  it("composes ordered OpenClaw policy from the final callable capabilities", () => {
+    const guidance = buildGuidance();
+
+    expect(guidance).toContain("policy-filtered for this turn");
+    expect(guidance).toContain("## Skill Workshop");
+    expect(guidance).toContain("## Delegation");
+    expect(guidance).toContain("delegate via `sessions_spawn`");
+    expect(guidance).toContain("spawn `sessions_spawn` with `visible=true`");
+    expect(guidance).toContain("Need results before reply: `sessions_yield`; never poll.");
+    expect(guidance).toContain("`subagents(action=list)` only for requested status/debug.");
+    expect(guidance).toContain("For the current source conversation, reply normally");
+    expect(guidance?.indexOf("## Skill Workshop")).toBeLessThan(
+      guidance?.indexOf("## Delegation") ?? 0,
+    );
+    expect(guidance?.indexOf("## Delegation")).toBeLessThan(
+      guidance?.indexOf("For the current source conversation") ?? 0,
+    );
+  });
+
+  it.each([
+    {
+      name: "explicit suggest mode",
+      attempt: {
+        config: { agents: { defaults: { subagents: { delegationMode: "suggest" as const } } } },
+      },
+    },
+    {
+      name: "non-main session",
+      attempt: { sessionKey: "agent:main:slack:channel:C01234567" },
+    },
+    { name: "minimal prompt", attempt: { promptMode: "minimal" as const } },
+    { name: "report-only delegation", attempt: { delegationCapability: "report_only" as const } },
+  ])("suppresses delegation for $name but keeps visible-reply guidance", ({ attempt }) => {
+    const guidance = buildGuidance(attempt);
+
+    expect(guidance).not.toContain("## Delegation");
+    expect(guidance).toContain("For the current source conversation, reply normally");
+  });
+
+  it.each([
+    { name: "prompt mode none", attempt: { promptMode: "none" as const } },
+    { name: "raw model run", attempt: { modelRun: true } },
+  ])("omits the appended developer instructions for $name", ({ attempt }) => {
+    expect(buildGuidance(attempt)).toBeUndefined();
+  });
+
+  it("uses the message tool only when it remains callable", () => {
+    expect(
+      buildGuidance({ sourceReplyDeliveryMode: "message_tool_only" }, [
+        "message",
+        "sessions_spawn",
+      ]),
+    ).toContain("Visible source replies are not automatically delivered");
+    expect(
+      buildGuidance({ sourceReplyDeliveryMode: "message_tool_only" }, ["sessions_spawn"]),
+    ).toContain("reply normally in your final assistant message");
+  });
+
+  it("renders only the delegation operations present in the callable inventory", () => {
+    const guidance = buildGuidance({}, [" sessions_spawn ", "sessions_spawn"]);
+
+    expect(guidance).toContain("## Delegation");
+    expect(guidance).toContain("Completion is push-based; never poll.");
+    expect(guidance).not.toContain("sessions_yield");
+    expect(guidance).not.toContain("subagents(action=list)");
+    expect(buildGuidance({}, ["sessions_yield", "subagents"])).not.toContain("## Delegation");
+  });
+
+  it("wraps conversation and subagent context without adding workspace prompt sections", () => {
+    expect(buildGuidance({ extraSystemPrompt: "Conversation policy." })).toContain(
+      "## Conversation Context\nConversation policy.",
+    );
+    const minimal = buildGuidance({ extraSystemPrompt: "Child policy.", promptMode: "minimal" });
+    expect(minimal).toContain("## Subagent Context\nChild policy.");
+    expect(minimal).not.toContain("## Workspace");
+  });
+});

--- a/extensions/copilot/src/prompt-guidance.ts
+++ b/extensions/copilot/src/prompt-guidance.ts
@@ -10,7 +10,7 @@ import {
   normalizeUniqueStringEntries,
   readNonEmptyStringPreservingWhitespace as readNonEmptyString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { isRawCopilotModelRun } from "./attempt-config.js";
+import { isRawCopilotModelRun } from "./attempt-mode.js";
 import type { AttemptParamsLike } from "./attempt-types.js";
 
 const COPILOT_HARNESS_IDENTITY =

--- a/extensions/copilot/src/prompt-guidance.ts
+++ b/extensions/copilot/src/prompt-guidance.ts
@@ -1,0 +1,64 @@
+import {
+  buildDelegationGuidanceSection,
+  buildHarnessVisibleReplyGuidance,
+  buildSkillWorkshopPromptSection,
+  resolveMainSessionDelegationMode,
+  SKILL_WORKSHOP_TOOL_NAME,
+  TRANSCRIPT_CREDENTIAL_SAFETY_PROMPT,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  normalizeUniqueStringEntries,
+  readNonEmptyStringPreservingWhitespace as readNonEmptyString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { isRawCopilotModelRun } from "./attempt-config.js";
+import type { AttemptParamsLike } from "./attempt-types.js";
+
+const COPILOT_HARNESS_IDENTITY =
+  "You are a personal agent running inside OpenClaw. Your available OpenClaw capabilities are policy-filtered for this turn; use only the exact tools exposed to you.";
+
+export function buildCopilotPromptGuidance(params: {
+  attempt: AttemptParamsLike;
+  callableToolNames: Iterable<string>;
+  workspaceBootstrapInstructions?: string;
+}): string | undefined {
+  if (isRawCopilotModelRun(params.attempt)) {
+    return undefined;
+  }
+  const callableTools = new Set(normalizeUniqueStringEntries(params.callableToolNames));
+  const hasSessionsSpawn = callableTools.has("sessions_spawn");
+  const isMinimal = params.attempt.promptMode === "minimal";
+  const extraSystemPrompt = readNonEmptyString(params.attempt.extraSystemPrompt)?.trim();
+  const delegationGuidance =
+    params.attempt.disableTools !== true && params.attempt.delegationCapability !== "report_only"
+      ? buildDelegationGuidanceSection({
+          mode: resolveMainSessionDelegationMode({
+            config: params.attempt.config,
+            agentId: params.attempt.agentId,
+            sessionKey: params.attempt.sessionKey,
+          }),
+          isMinimal,
+          hiddenDelegationTool: hasSessionsSpawn ? "`sessions_spawn`" : "",
+          hasVisibleSessionSpawn: hasSessionsSpawn,
+          hasSessionsYield: callableTools.has("sessions_yield"),
+          hasSubagentsList: callableTools.has("subagents"),
+          hasSessionsSend: callableTools.has("sessions_send"),
+        }).join("\n")
+      : undefined;
+  const sections = [
+    COPILOT_HARNESS_IDENTITY,
+    callableTools.has(SKILL_WORKSHOP_TOOL_NAME)
+      ? buildSkillWorkshopPromptSection().join("\n")
+      : undefined,
+    delegationGuidance,
+    buildHarnessVisibleReplyGuidance({
+      sourceReplyDeliveryMode: params.attempt.sourceReplyDeliveryMode,
+      messageToolAvailable: callableTools.has("message"),
+    }),
+    TRANSCRIPT_CREDENTIAL_SAFETY_PROMPT,
+    params.workspaceBootstrapInstructions?.trim(),
+    extraSystemPrompt
+      ? `${isMinimal ? "## Subagent Context" : "## Conversation Context"}\n${extraSystemPrompt}`
+      : undefined,
+  ];
+  return sections.filter((section) => section?.trim()).join("\n\n") || undefined;
+}

--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -132,7 +132,7 @@ async function convertOpenClawToolToSdkToolForTest(
     onToolCompleted: options.onToolCompleted,
     sessionId: "session-1",
   });
-  return expectDefined(bridge.sdkTools[0], "Copilot SDK tool");
+  return expectDefined(bridge.promptToolPolicy.apply().tools[0], "Copilot SDK tool");
 }
 
 afterEach(() => {
@@ -181,7 +181,7 @@ describe("createCopilotToolBridge", () => {
       sessionId: "session-1",
     });
     const source = expectDefined(bridge.sourceTools[0], "bound Copilot source tool");
-    const sdk = expectDefined(bridge.sdkTools[0], "bound Copilot SDK tool");
+    const sdk = expectDefined(bridge.promptToolPolicy.apply().tools[0], "bound Copilot SDK tool");
     const copiedSourceExecute = source.execute;
     const copiedSdkHandler = sdk.handler;
     active = false;
@@ -209,7 +209,9 @@ describe("createCopilotToolBridge", () => {
       sessionId: "session-1",
     });
 
-    expect(result).toEqual({ codeModeEngaged: false, sdkTools: [], sourceTools: [] });
+    expect(result.codeModeEngaged).toBe(false);
+    expect(result.promptToolPolicy.apply()).toEqual({ tools: [], callableToolNames: [] });
+    expect(result.sourceTools).toEqual([]);
     expect(createOpenClawCodingTools).toHaveBeenCalledTimes(0);
   });
 
@@ -233,7 +235,7 @@ describe("createCopilotToolBridge", () => {
       }),
     );
     expect(result.sourceTools).toEqual(sourceTools);
-    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool-a"]);
+    expect(result.promptToolPolicy.apply().tools.map((tool) => tool.name)).toEqual(["tool-a"]);
   });
 
   it("forwards supported fields to injected createOpenClawCodingTools", async () => {
@@ -443,7 +445,7 @@ describe("createCopilotToolBridge", () => {
     });
   });
 
-  it("returns sdkTools and sourceTools with matching lengths", async () => {
+  it("returns prompt-policy and source tools with matching direct surfaces", async () => {
     const sourceTools = [makeTool(), makeTool({ name: "tool-b" })];
 
     const result = await createCopilotToolBridge({
@@ -455,8 +457,11 @@ describe("createCopilotToolBridge", () => {
     });
 
     expect(result.sourceTools).toEqual(sourceTools);
-    expect(result.sdkTools).toHaveLength(2);
-    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool-a", "tool-b"]);
+    expect(result.promptToolPolicy.apply().tools).toHaveLength(2);
+    expect(result.promptToolPolicy.apply().tools.map((tool) => tool.name)).toEqual([
+      "tool-a",
+      "tool-b",
+    ]);
   });
 
   it("preserves direct-only OpenClaw through the exact Copilot allowlist", async () => {
@@ -479,7 +484,7 @@ describe("createCopilotToolBridge", () => {
     });
 
     expect(result.sourceTools).toEqual([systemAgentTool]);
-    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["openclaw"]);
+    expect(result.promptToolPolicy.apply().tools.map((tool) => tool.name)).toEqual(["openclaw"]);
   });
 
   it("compacts the Copilot tool surface behind tool_search controls when enabled", async () => {
@@ -517,7 +522,19 @@ describe("createCopilotToolBridge", () => {
       }),
     );
     expect(result.sourceTools.map((tool) => tool.name)).toEqual(["tool_search_code", "read"]);
-    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool_search_code", "read"]);
+    expect(result.promptToolPolicy.apply().tools.map((tool) => tool.name)).toEqual([
+      "tool_search_code",
+      "read",
+    ]);
+    expect(result.promptToolPolicy.apply().callableToolNames).toEqual([
+      "tool_search_code",
+      "read",
+      "fake_hidden",
+    ]);
+    expect(result.promptToolPolicy.apply({ toolsAllow: ["fake_hidden"] })).toMatchObject({
+      callableToolNames: ["tool_search_code", "fake_hidden"],
+      tools: [expect.objectContaining({ name: "tool_search_code" })],
+    });
   });
 
   it("keeps tool_search controls visible when a narrow allowlist is active", async () => {
@@ -545,7 +562,10 @@ describe("createCopilotToolBridge", () => {
     });
 
     expect(result.sourceTools.map((tool) => tool.name)).toEqual(["tool_search_code", "read"]);
-    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["tool_search_code", "read"]);
+    expect(result.promptToolPolicy.apply().tools.map((tool) => tool.name)).toEqual([
+      "tool_search_code",
+      "read",
+    ]);
   });
 
   it("filters the hidden tool_search catalog before compacting narrowed tools", async () => {
@@ -605,7 +625,16 @@ describe("createCopilotToolBridge", () => {
     );
     expect(result.codeModeEngaged).toBe(true);
     expect(result.sourceTools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
-    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
+    expect(result.promptToolPolicy.apply().tools.map((tool) => tool.name)).toEqual([
+      "exec",
+      "wait",
+    ]);
+    expect(result.promptToolPolicy.apply().callableToolNames).toEqual([
+      "exec",
+      "wait",
+      "fake_hidden",
+      "read",
+    ]);
   });
 
   it("binds retained code-mode source and SDK controls exactly once", async () => {
@@ -645,7 +674,7 @@ describe("createCopilotToolBridge", () => {
       "bound code-mode source control",
     );
     const sdk = expectDefined(
-      bridge.sdkTools.find((tool) => tool.name === "exec"),
+      bridge.promptToolPolicy.apply().tools.find((tool) => tool.name === "exec"),
       "bound code-mode SDK control",
     );
     const copiedSourceExecute = source.execute;
@@ -711,7 +740,10 @@ describe("createCopilotToolBridge", () => {
     });
 
     expect(result.sourceTools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
-    expect(result.sdkTools.map((tool) => tool.name)).toEqual(["exec", "wait"]);
+    expect(result.promptToolPolicy.apply().tools.map((tool) => tool.name)).toEqual([
+      "exec",
+      "wait",
+    ]);
   });
 
   it("filters the hidden code-mode catalog before compacting narrowed tools", async () => {
@@ -1010,7 +1042,7 @@ describe("createCopilotToolBridge", () => {
         });
         const tool = (name: string) =>
           expectDefined(
-            bridge.sdkTools.find((candidate) => candidate.name === name),
+            bridge.promptToolPolicy.apply().tools.find((candidate) => candidate.name === name),
             `Copilot ${name} tool`,
           );
         await runSdkTool(tool("write"), {
@@ -1067,7 +1099,9 @@ describe("createCopilotToolBridge", () => {
         });
         await runSdkTool(
           expectDefined(
-            freshBridge.sdkTools.find((candidate) => candidate.name === "write"),
+            freshBridge.promptToolPolicy
+              .apply()
+              .tools.find((candidate) => candidate.name === "write"),
             "fresh Copilot write tool",
           ),
           { path: "memory/fresh.md", content: "fresh owner note\n" },
@@ -1487,7 +1521,7 @@ describe("createCopilotToolBridge", () => {
           sessionKey: "agent:agent-1:policy-session",
           workspaceDir,
         });
-        const names = result.sdkTools.map((tool) => tool.name);
+        const names = result.promptToolPolicy.apply().tools.map((tool) => tool.name);
 
         expect(names).toContain("read");
         expect(names).toContain("apply_patch");
@@ -1509,7 +1543,9 @@ describe("createCopilotToolBridge", () => {
         modelProvider: "github-copilot",
         sessionId: "session-1",
       });
-      expect(result).toEqual({ codeModeEngaged: false, sdkTools: [], sourceTools: [] });
+      expect(result.codeModeEngaged).toBe(false);
+      expect(result.promptToolPolicy.apply()).toEqual({ tools: [], callableToolNames: [] });
+      expect(result.sourceTools).toEqual([]);
       expect(createOpenClawCodingTools).toHaveBeenCalledTimes(0);
     });
 
@@ -1523,7 +1559,9 @@ describe("createCopilotToolBridge", () => {
         modelProvider: "github-copilot",
         sessionId: "session-1",
       });
-      expect(result).toEqual({ codeModeEngaged: false, sdkTools: [], sourceTools: [] });
+      expect(result.codeModeEngaged).toBe(false);
+      expect(result.promptToolPolicy.apply()).toEqual({ tools: [], callableToolNames: [] });
+      expect(result.sourceTools).toEqual([]);
       expect(createOpenClawCodingTools).toHaveBeenCalledTimes(0);
     });
 
@@ -1537,7 +1575,9 @@ describe("createCopilotToolBridge", () => {
         modelProvider: "github-copilot",
         sessionId: "session-1",
       });
-      expect(result).toEqual({ codeModeEngaged: false, sdkTools: [], sourceTools: [] });
+      expect(result.codeModeEngaged).toBe(false);
+      expect(result.promptToolPolicy.apply()).toEqual({ tools: [], callableToolNames: [] });
+      expect(result.sourceTools).toEqual([]);
       expect(createOpenClawCodingTools).toHaveBeenCalledTimes(0);
     });
 
@@ -1556,7 +1596,7 @@ describe("createCopilotToolBridge", () => {
         sessionId: "session-1",
       });
       expect(result.sourceTools.map((tool) => tool.name)).toEqual(["read"]);
-      expect(result.sdkTools.map((tool) => tool.name)).toEqual(["read"]);
+      expect(result.promptToolPolicy.apply().tools.map((tool) => tool.name)).toEqual(["read"]);
     });
 
     it("returns no tools when toolsAllow is an empty list and nothing is forced", async () => {
@@ -1573,7 +1613,7 @@ describe("createCopilotToolBridge", () => {
         sessionId: "session-1",
       });
       expect(result.sourceTools).toEqual([]);
-      expect(result.sdkTools).toEqual([]);
+      expect(result.promptToolPolicy.apply().tools).toEqual([]);
     });
 
     it('merges "message" into an empty allowlist when forceMessageTool is true', async () => {

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -25,7 +25,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { createAgentHarnessToolSurfaceRuntime } from "openclaw/plugin-sdk/agent-harness-tool-runtime";
 import { toStringifiedError as toCopilotToolError } from "openclaw/plugin-sdk/error-runtime";
-import { isRawCopilotModelRun } from "./attempt-config.js";
+import { isRawCopilotModelRun } from "./attempt-mode.js";
 
 type CreateOpenClawCodingTools =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -25,6 +25,7 @@ import {
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { createAgentHarnessToolSurfaceRuntime } from "openclaw/plugin-sdk/agent-harness-tool-runtime";
 import { toStringifiedError as toCopilotToolError } from "openclaw/plugin-sdk/error-runtime";
+import { isRawCopilotModelRun } from "./attempt-config.js";
 
 type CreateOpenClawCodingTools =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
@@ -151,35 +152,36 @@ interface CopilotToolBridgeInput {
 
 interface CopilotToolBridge {
   cleanup?: () => void;
-  /**
-   * Resolved code-mode gate for the run, so the attempt result can report it.
-   * Optional because a stubbed bridge simply leaves engagement unreported.
-   */
   codeModeEngaged?: boolean;
-  sdkTools: SdkTool[];
+  promptToolPolicy: {
+    apply: (params?: { toolsAllow?: string[]; forceToolNames?: readonly string[] }) => {
+      tools: SdkTool[];
+      callableToolNames: string[];
+    };
+  };
   sourceTools: AnyAgentTool[];
 }
+
+const EMPTY_PROMPT_TOOL_POLICY: CopilotToolBridge["promptToolPolicy"] = {
+  apply: () => ({ tools: [], callableToolNames: [] }),
+};
 
 const SUPPORTED_TOOL_PROVIDERS: ReadonlySet<string> = new Set(["github-copilot"]);
 const BASE_COPILOT_CODING_TOOL_NAMES = new Set(["edit", "read", "write"]);
 const SHELL_COPILOT_CODING_TOOL_NAMES = new Set(["apply_patch", "exec", "process"]);
 
-function supportsModelTools(modelProvider: string): boolean {
-  return SUPPORTED_TOOL_PROVIDERS.has(modelProvider);
-}
-
 export async function createCopilotToolBridge(
   input: CopilotToolBridgeInput,
 ): Promise<CopilotToolBridge> {
-  if (!input.allowModelTools && !supportsModelTools(input.modelProvider)) {
-    return { codeModeEngaged: false, sdkTools: [], sourceTools: [] };
+  if (!input.allowModelTools && !SUPPORTED_TOOL_PROVIDERS.has(input.modelProvider)) {
+    return { codeModeEngaged: false, promptToolPolicy: EMPTY_PROMPT_TOOL_POLICY, sourceTools: [] };
   }
 
   const attemptParams = input.attemptParams;
   const toolPlan = resolveEmbeddedAttemptToolConstructionPlan({
     disableTools: attemptParams.disableTools,
     forceMessageTool: shouldForceCopilotMessageTool(attemptParams),
-    isRawModelRun: isCopilotRawModelRun(attemptParams),
+    isRawModelRun: isRawCopilotModelRun(attemptParams),
     toolsAllow: attemptParams.toolsAllow,
   });
   const effectiveToolPlan = hasNonWildcardGlobAllowlist(toolPlan.runtimeToolAllowlist)
@@ -197,7 +199,7 @@ export async function createCopilotToolBridge(
       }
     : toolPlan;
   if (!effectiveToolPlan.constructTools) {
-    return { codeModeEngaged: false, sdkTools: [], sourceTools: [] };
+    return { codeModeEngaged: false, promptToolPolicy: EMPTY_PROMPT_TOOL_POLICY, sourceTools: [] };
   }
 
   const createOpenClawCodingTools =
@@ -211,7 +213,7 @@ export async function createCopilotToolBridge(
     disableTools: attemptParams.disableTools,
     executeTool: (toolParams) => executeCatalogTool(input, toolParams),
     forceMessageTool: shouldForceCopilotMessageTool(attemptParams),
-    isRawModelRun: isCopilotRawModelRun(attemptParams),
+    isRawModelRun: isRawCopilotModelRun(attemptParams),
     // Carries catalog compat so `tools.codeMode.enabled: "auto"` can resolve per model.
     model: attemptParams.model,
     modelId: input.modelId,
@@ -261,26 +263,23 @@ export async function createCopilotToolBridge(
     );
   }
 
-  const allowedSourceTools = filterCopilotToolsForAllowlist(
+  const allowedSourceTools = applyEmbeddedAttemptToolsAllow(
     sourceTools,
     toolSurfaceRuntime.runtimeToolAllowlist,
+    { toolMeta: (tool) => getPluginToolMeta(tool) ?? readInlinePluginToolMeta(tool) },
   );
-  const compactedTools = toolSurfaceRuntime.compactTools(allowedSourceTools, {
-    localModelLeanApplied: true,
-  });
-  const plannedTools = filterCopilotToolsForConstructionPlan(
-    compactedTools.tools,
+  const plannedSourceTools = filterCopilotToolsForConstructionPlan(
+    allowedSourceTools,
     effectiveToolPlan.codingToolConstructionPlan,
     { preserveToolNames: toolSurfaceRuntime.runtimeToolAllowlist },
   );
-  const filteredTools = filterCopilotToolsForAllowlist(
-    plannedTools,
-    toolSurfaceRuntime.runtimeToolAllowlist,
-  );
+  const compactedTools = toolSurfaceRuntime.compactTools(plannedSourceTools, {
+    localModelLeanApplied: true,
+  });
   // The constructor output is bound before catalog compaction so hidden tools
   // cannot outlive the attempt. Bind only controls created by compaction here;
   // rebinding retained tools would stack the before-tool hook.
-  const newlyConstructedTools = filteredTools.filter((tool) => !boundSourceTools.has(tool));
+  const newlyConstructedTools = compactedTools.tools.filter((tool) => !boundSourceTools.has(tool));
   const boundNewlyConstructedTools =
     newlyConstructedTools.length > 0
       ? hostCapabilities.bindToolSurface(newlyConstructedTools, bindingOptions)
@@ -292,7 +291,7 @@ export async function createCopilotToolBridge(
   for (let index = 0; index < newlyConstructedTools.length; index += 1) {
     newlyBoundTools.set(newlyConstructedTools[index]!, boundNewlyConstructedTools[index]!);
   }
-  const exposedTools = filteredTools.map((tool) => newlyBoundTools.get(tool) ?? tool);
+  const exposedTools = compactedTools.tools.map((tool) => newlyBoundTools.get(tool) ?? tool);
 
   // Run duplicate detection after filtering so a duplicate in a
   // suppressed tool does not fail a narrow run (PI parity: PI never
@@ -302,6 +301,15 @@ export async function createCopilotToolBridge(
     throw new Error(`[copilot-tool-bridge] duplicate tool names: ${duplicateNames.join(", ")}`);
   }
 
+  const sdkTools = exposedTools.map((sourceTool) =>
+    convertOpenClawToolToSdkTool(sourceTool, {
+      abortSignal: input.abortSignal,
+      beforeExecute: input.beforeExecute,
+      onAgentToolResult: input.attemptParams?.onAgentToolResult,
+      onToolCompleted: input.onToolCompleted,
+      observeToolTerminal: input.attemptParams?.observeToolTerminal,
+    }),
+  );
   return {
     cleanup: toolSurfaceRuntime.cleanup,
     // Harness runs resolve `tools.codeMode: "auto"` inside the tool surface
@@ -309,15 +317,16 @@ export async function createCopilotToolBridge(
     // got code-mode controls. Without it the run reports `codeModeEngaged`
     // as unset and telemetry cannot tell "off" from "harness did not report".
     codeModeEngaged: toolSurfaceRuntime.codeModeControlsEnabled,
-    sdkTools: exposedTools.map((sourceTool) =>
-      convertOpenClawToolToSdkTool(sourceTool, {
-        abortSignal: input.abortSignal,
-        beforeExecute: input.beforeExecute,
-        onAgentToolResult: input.attemptParams?.onAgentToolResult,
-        onToolCompleted: input.onToolCompleted,
-        observeToolTerminal: input.attemptParams?.observeToolTerminal,
-      }),
-    ),
+    promptToolPolicy: {
+      apply: (params: { toolsAllow?: string[]; forceToolNames?: readonly string[] } = {}) => {
+        const result = compactedTools.promptToolPolicy.apply(params);
+        const directToolNames = new Set(result.tools.map((tool) => tool.name));
+        return {
+          tools: sdkTools.filter((tool) => directToolNames.has(tool.name)),
+          callableToolNames: result.callableToolNames,
+        };
+      },
+    },
     sourceTools: exposedTools,
   };
 }
@@ -826,18 +835,6 @@ function createError(message: string, cause: unknown): Error {
 }
 
 /**
- * Returns true when the attempt was launched as a raw-model run, which
- * suppresses tool construction in PI
- * (`src/agents/pi-embedded-runner/run/attempt.ts:1305-1310` and
- * `attempt-tool-construction-plan.ts:165-184`). A run is raw when the
- * caller explicitly sets `modelRun: true` or asks for no system prompt
- * via `promptMode: "none"`.
- */
-function isCopilotRawModelRun(params: CopilotToolAttemptParams): boolean {
-  return params.modelRun === true || params.promptMode === "none";
-}
-
-/**
  * Mirrors PI's `shouldForceMessageTool` semantics: a message tool is
  * forced when the caller asked for it explicitly or when the source
  * reply delivery mode is `message_tool_only`, but never when
@@ -851,28 +848,6 @@ export function shouldForceCopilotMessageTool(params: CopilotToolAttemptParams):
     return false;
   }
   return params.forceMessageTool === true || params.sourceReplyDeliveryMode === "message_tool_only";
-}
-
-/**
- * Mirrors PI's `applyEmbeddedAttemptToolsAllow`
- * (`src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts`)
- * so final filtering keeps aliases, groups, plugin policies, and glob
- * semantics identical to the in-tree embedded runner.
- */
-export function filterCopilotToolsForAllowlist<T extends { name: string }>(
-  tools: T[],
-  toolsAllow?: string[],
-  options?: { forceToolNames?: readonly string[] },
-): T[] {
-  const filtered = applyEmbeddedAttemptToolsAllow(tools, toolsAllow, {
-    toolMeta: (tool) =>
-      getPluginToolMeta(tool as unknown as AnyAgentTool) ?? readInlinePluginToolMeta(tool),
-  });
-  if (!options?.forceToolNames?.length) {
-    return filtered;
-  }
-  const allowedNames = new Set([...filtered.map((tool) => tool.name), ...options.forceToolNames]);
-  return tools.filter((tool) => allowedNames.has(tool.name));
 }
 
 function filterCopilotToolsForConstructionPlan<T extends { name: string }>(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -300,7 +300,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: account-scoped model catalog discovery for native agent harnesses.
       // +2: shared delegation policy (mode resolver + section builder) so harness
       //     runtimes render the same guidance instead of diverging prompt copies.
-      4334,
+      // +1: shared harness visible-source-reply guidance.
+      4335,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -385,7 +386,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: canonical sensitive-URL redactor so plugin CLI errors never print URL userinfo.
       // +2: shared delegation policy (mode resolver + section builder) so harness
       //     runtimes render the same guidance instead of diverging prompt copies.
-      2577,
+      // +1: shared harness visible-source-reply guidance.
+      2578,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-support.ts
@@ -14,33 +14,19 @@ import {
 } from "../../../plugins/hook-agent-context.js";
 import type { PluginHookLlmInputEvent } from "../../../plugins/hook-types.js";
 import type { HookRunner } from "../../../plugins/hooks.js";
-import { getPluginToolMeta } from "../../../plugins/tools.js";
 import {
   type createTrajectoryRuntimeRecorder,
   toTrajectoryToolDefinitions,
 } from "../../../trajectory/runtime.js";
 import type { createCacheTrace } from "../../cache-trace.js";
-import {
-  CODE_MODE_EXEC_TOOL_NAME,
-  CODE_MODE_WAIT_TOOL_NAME,
-} from "../../code-mode-control-tools.js";
+import { createAgentHarnessPromptToolPolicy } from "../../harness/prompt-tool-policy.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { normalizeToolPolicyName } from "../../tool-policy.js";
-import { TOOL_SEARCH_CONTROL_TOOL_NAMES } from "../../tool-search-types.js";
-import {
-  restrictToolSearchCatalog,
-  type ToolSearchCatalogEntry,
-  type ToolSearchCatalogRef,
-} from "../../tool-search.js";
-import type { AnyAgentTool } from "../../tools/common.js";
+import type { ToolSearchCatalogEntry, ToolSearchCatalogRef } from "../../tool-search.js";
 import { log } from "../logger.js";
 import { summarizeSessionContext } from "./attempt-context-summary.js";
 import { resolvePromptSubmissionSkipReason } from "./attempt-prompt-submit.js";
-import {
-  applyEmbeddedAttemptToolsAllow,
-  mergeForcedEmbeddedAttemptToolsAllow,
-} from "./attempt-tool-construction-plan.js";
 import type { ResolvedToolPromptFinalizer } from "./params.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
@@ -51,13 +37,6 @@ type PromptBuildToolPolicyBaseline = {
   activeToolNames: readonly string[];
   catalogEntries: readonly ToolSearchCatalogEntry[];
 };
-
-function readNamedToolPluginMeta(tool: NamedTool): { pluginId: string } | undefined {
-  if (!("execute" in tool) || typeof tool.execute !== "function") {
-    return undefined;
-  }
-  return getPluginToolMeta(tool as AnyAgentTool);
-}
 
 export function applyResolvedToolPromptFinalizer(params: {
   prompt: string;
@@ -73,24 +52,6 @@ export function applyResolvedToolPromptFinalizer(params: {
       (toolName) => normalizeToolPolicyName(toolName) === "message",
     ),
   });
-}
-
-function filterTools<T extends NamedTool>(
-  tools: readonly T[],
-  toolsAllow: string[],
-  toolMeta: (tool: T) => { pluginId: string } | undefined = readNamedToolPluginMeta,
-): T[] {
-  return applyEmbeddedAttemptToolsAllow([...tools], toolsAllow, {
-    toolMeta,
-  });
-}
-
-function applyToolsAllow<T extends NamedTool>(
-  tools: readonly T[],
-  toolsAllow: string[] | undefined,
-  toolMeta?: (tool: T) => { pluginId: string } | undefined,
-): T[] {
-  return toolsAllow === undefined ? [...tools] : filterTools(tools, toolsAllow, toolMeta);
 }
 
 function sameToolNames(left: readonly string[], right: readonly string[]): boolean {
@@ -122,45 +83,38 @@ export function applyPromptBuildToolsAllow<
   uncompactedEffectiveTools: TUncompactedTool[];
   tools: TTool[];
 } {
-  const toolsAllow = mergeForcedEmbeddedAttemptToolsAllow(params.toolsAllow, {
+  const policyInput = {
+    toolsAllow: params.toolsAllow,
     forceToolNames: params.forceToolNames,
-  });
-  const allowedCatalogEntries = applyToolsAllow<ToolSearchCatalogEntry>(
-    params.baseline.catalogEntries,
-    toolsAllow,
-    (entry) => getPluginToolMeta(entry.tool as AnyAgentTool),
-  );
-  const catalogToolCount = restrictToolSearchCatalog({
+  };
+  const promptPolicy = createAgentHarnessPromptToolPolicy({
+    tools: params.effectiveTools,
     catalogRef: params.catalogRef,
-    allowedToolNames: new Set(allowedCatalogEntries.map((entry) => entry.name)),
-    baselineEntries: params.baseline.catalogEntries,
-  });
-  const allowedEffectiveTools = applyToolsAllow(params.effectiveTools, toolsAllow);
-  const allowedUncompactedTools = applyToolsAllow(params.uncompactedEffectiveTools, toolsAllow);
-  const allowedTools = applyToolsAllow(params.tools, toolsAllow);
+    catalogEntries: params.baseline.catalogEntries,
+    codeModeControlsEnabled: params.codeModeControlsEnabled,
+  }).apply(policyInput);
+  const allowedUncompactedTools = createAgentHarnessPromptToolPolicy({
+    tools: params.uncompactedEffectiveTools,
+    codeModeControlsEnabled: false,
+  }).apply(policyInput).tools;
+  const allowedTools = createAgentHarnessPromptToolPolicy({
+    tools: params.tools,
+    codeModeControlsEnabled: false,
+  }).apply(policyInput).tools;
   const allowedActiveNames = new Set(
-    applyToolsAllow(
-      params.baseline.activeToolNames.map((name) => ({ name })),
-      toolsAllow,
-    ).map((tool) => normalizeToolPolicyName(tool.name)),
+    createAgentHarnessPromptToolPolicy({
+      tools: params.baseline.activeToolNames.map((name) => ({ name })),
+      codeModeControlsEnabled: false,
+    })
+      .apply(policyInput)
+      .tools.map((tool) => normalizeToolPolicyName(tool.name)),
   );
-  for (const tool of [...allowedEffectiveTools, ...allowedUncompactedTools, ...allowedTools]) {
+  for (const tool of [...promptPolicy.tools, ...allowedUncompactedTools, ...allowedTools]) {
     allowedActiveNames.add(normalizeToolPolicyName(tool.name));
   }
 
-  const catalogControlNames = params.codeModeControlsEnabled
-    ? new Set([CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME])
-    : TOOL_SEARCH_CONTROL_TOOL_NAMES;
-  const keepVisibleTool = (tool: NamedTool) => {
-    const normalized = normalizeToolPolicyName(tool.name);
-    return (
-      allowedActiveNames.has(normalized) ||
-      (catalogToolCount > 0 && catalogControlNames.has(normalized))
-    );
-  };
-  const effectiveTools = params.effectiveTools.filter(keepVisibleTool);
   const activeToolNames = params.baseline.activeToolNames.filter((name) =>
-    keepVisibleTool({ name }),
+    allowedActiveNames.has(normalizeToolPolicyName(name)),
   );
   if (!sameToolNames(params.session.getActiveToolNames(), activeToolNames)) {
     params.session.setActiveToolsByName(activeToolNames);
@@ -168,7 +122,7 @@ export function applyPromptBuildToolsAllow<
 
   return {
     activeToolNames,
-    effectiveTools,
+    effectiveTools: promptPolicy.tools,
     uncompactedEffectiveTools: allowedUncompactedTools,
     tools: allowedTools,
   };

--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -11,24 +11,36 @@ afterEach(() => {
 });
 
 describe("resolveAgentHarnessBeforePromptBuildResult", () => {
-  it("forwards a per-turn tool restriction to native harness adapters", async () => {
+  it("runs a lazy builder with hook tool policy while preserving replacement order", async () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([
         {
           hookName: "before_prompt_build",
-          handler: () => ({ toolsAllow: [] }),
+          handler: () => ({
+            appendSystemContext: "after replacement",
+            prependSystemContext: "before replacement",
+            systemPrompt: "hook replacement",
+            toolsAllow: ["read"],
+          }),
         },
       ]),
     );
+    const build = vi.fn(() => "policy-filtered base");
 
     const result = await resolveAgentHarnessBeforePromptBuildResult({
       prompt: "answer directly",
-      developerInstructions: "base instructions",
+      developerInstructions: { build },
       messages: [],
       ctx: {},
     });
 
-    expect(result.toolsAllow).toEqual([]);
+    expect(build).toHaveBeenCalledWith({ toolsAllow: ["read"] });
+    expect(result).toMatchObject({
+      toolsAllow: ["read"],
+      developerInstructions:
+        "---\n\nOpenClaw plugin-injected system context. This block is not workspace file content.\n\nbefore replacement\n\n---\n\nhook replacement\n\n---\n\nOpenClaw plugin-injected system context. This block is not workspace file content.\n\nafter replacement\n\n---",
+    });
+    expect(result.developerInstructions).not.toContain("policy-filtered base");
   });
 
   it("retains an empty prompt range without hooks", async () => {

--- a/src/agents/harness/prompt-compaction-hook-helpers.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.ts
@@ -25,10 +25,14 @@ type AgentHarnessPromptBuildResult = {
   promptInputRange?: { start: number; end: number };
 };
 
+type AgentHarnessDeveloperInstructionBuilder = {
+  build: (params: { toolsAllow?: string[] }) => string | undefined;
+};
+
 /** Runs before-prompt hooks and returns the adjusted prompt fields. */
 export async function resolveAgentHarnessBeforePromptBuildResult(params: {
   prompt: string;
-  developerInstructions: string;
+  developerInstructions: string | AgentHarnessDeveloperInstructionBuilder;
   messages: unknown[];
   ctx: AgentHarnessHookContext;
   bootstrapContextRunKind?: BootstrapContextRunKind;
@@ -42,9 +46,10 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
   const hasHeartbeatContribution =
     isHeartbeatTurn && Boolean(hookRunner?.hasHooks("heartbeat_prompt_contribution"));
   if (!hasHeartbeatContribution && !hookRunner?.hasHooks("before_prompt_build")) {
+    const developerInstructions = resolveDeveloperInstructions(params.developerInstructions);
     return {
       prompt: params.prompt,
-      developerInstructions: params.developerInstructions,
+      developerInstructions,
       promptInputRange: { start: 0, end: params.prompt.length },
     };
   }
@@ -79,8 +84,12 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
         return undefined;
       })
     : undefined;
+  const developerInstructions = resolveDeveloperInstructions(
+    params.developerInstructions,
+    promptBuildResult?.toolsAllow,
+  );
   const systemPrompt = resolvePromptBuildSystemPrompt({
-    developerInstructions: params.developerInstructions,
+    developerInstructions,
     promptBuildResult,
   });
   const promptPrefix = joinPresentTextSegments([
@@ -115,6 +124,15 @@ export async function resolveAgentHarnessBeforePromptBuildResult(params: {
       end: promptInputStart + params.prompt.length,
     },
   };
+}
+
+function resolveDeveloperInstructions(
+  instructions: string | AgentHarnessDeveloperInstructionBuilder,
+  toolsAllow?: string[],
+): string {
+  return typeof instructions === "string"
+    ? instructions
+    : (instructions.build({ toolsAllow }) ?? "");
 }
 
 function resolvePromptBuildSystemPrompt(params: {

--- a/src/agents/harness/prompt-tool-policy.ts
+++ b/src/agents/harness/prompt-tool-policy.ts
@@ -1,0 +1,89 @@
+import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { getPluginToolMeta } from "../../plugins/tools.js";
+import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "../code-mode-control-tools.js";
+import {
+  applyEmbeddedAttemptToolsAllow,
+  mergeForcedEmbeddedAttemptToolsAllow,
+} from "../embedded-agent-runner/run/attempt-tool-construction-plan.js";
+import { normalizeToolPolicyName } from "../tool-policy.js";
+import { TOOL_SEARCH_CONTROL_TOOL_NAMES } from "../tool-search-types.js";
+import {
+  restrictToolSearchCatalog,
+  type ToolSearchCatalogEntry,
+  type ToolSearchCatalogRef,
+} from "../tool-search.js";
+import type { AnyAgentTool } from "../tools/common.js";
+
+type NamedTool = { name: string };
+
+function isAgentTool(tool: NamedTool): tool is AnyAgentTool {
+  return "execute" in tool && typeof tool.execute === "function";
+}
+
+function filterTools<T extends NamedTool>(
+  tools: readonly T[],
+  toolsAllow?: string[],
+  toolMeta: (tool: T) => { pluginId: string } | undefined = (tool) =>
+    isAgentTool(tool) ? getPluginToolMeta(tool) : undefined,
+): T[] {
+  return toolsAllow === undefined
+    ? [...tools]
+    : applyEmbeddedAttemptToolsAllow([...tools], toolsAllow, { toolMeta });
+}
+
+export function createAgentHarnessPromptToolPolicy<T extends NamedTool>(params: {
+  tools: readonly T[];
+  catalogRef?: ToolSearchCatalogRef;
+  catalogEntries?: readonly ToolSearchCatalogEntry[];
+  codeModeControlsEnabled: boolean;
+}) {
+  const baselineTools = [...params.tools];
+  const currentCatalog = params.catalogRef?.current;
+  const catalog =
+    currentCatalog && params.catalogRef
+      ? {
+          ref: params.catalogRef,
+          entries: [...(params.catalogEntries ?? currentCatalog.entries)],
+          controlNames: params.codeModeControlsEnabled
+            ? new Set([CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME])
+            : TOOL_SEARCH_CONTROL_TOOL_NAMES,
+        }
+      : undefined;
+  return {
+    apply: (input: { toolsAllow?: string[]; forceToolNames?: readonly string[] } = {}) => {
+      const toolsAllow = mergeForcedEmbeddedAttemptToolsAllow(input.toolsAllow, {
+        forceToolNames: input.forceToolNames,
+      });
+      const allowedTools = filterTools(baselineTools, toolsAllow);
+      if (!catalog) {
+        return {
+          tools: allowedTools,
+          callableToolNames: normalizeUniqueStringEntries(allowedTools.map((tool) => tool.name)),
+        };
+      }
+      const allowedEntries = filterTools(catalog.entries, toolsAllow, (entry) =>
+        isAgentTool(entry.tool) ? getPluginToolMeta(entry.tool) : undefined,
+      );
+      const catalogCount = restrictToolSearchCatalog({
+        catalogRef: catalog.ref,
+        allowedToolNames: new Set(allowedEntries.map((entry) => entry.name)),
+        baselineEntries: catalog.entries,
+      });
+      const allowedNames = new Set(allowedTools.map((tool) => normalizeToolPolicyName(tool.name)));
+      const tools = baselineTools.filter((tool) => {
+        const name = normalizeToolPolicyName(tool.name);
+        return allowedNames.has(name) || (catalogCount > 0 && catalog.controlNames.has(name));
+      });
+      const catalogReachable =
+        catalogCount > 0 &&
+        tools.some((tool) => catalog.controlNames.has(normalizeToolPolicyName(tool.name)));
+      return {
+        tools,
+        callableToolNames: normalizeUniqueStringEntries([
+          ...tools.map((tool) => tool.name),
+          ...(catalogReachable ? allowedEntries.map((entry) => entry.name) : []),
+        ]),
+      };
+    },
+  };
+}

--- a/src/agents/harness/tool-surface-bridge.test.ts
+++ b/src/agents/harness/tool-surface-bridge.test.ts
@@ -197,6 +197,55 @@ describe("createAgentHarnessToolSurfaceRuntime", () => {
     }
   });
 
+  it("atomically filters and restores direct tools plus the hidden catalog", () => {
+    const runtime = createRuntime({ tools: { toolSearch: true } });
+    const compacted = runtime.compactTools(
+      tools([TOOL_SEARCH_CODE_MODE_TOOL_NAME, "read", "hidden_alpha", "hidden_beta"]),
+    );
+
+    try {
+      const alpha = compacted.promptToolPolicy.apply({ toolsAllow: ["hidden_alpha"] });
+      expect(alpha.tools.map((tool) => tool.name)).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME]);
+      expect(alpha.callableToolNames).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME, "hidden_alpha"]);
+
+      const beta = compacted.promptToolPolicy.apply({ toolsAllow: ["hidden_beta"] });
+      expect(beta.tools.map((tool) => tool.name)).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME]);
+      expect(beta.callableToolNames).toEqual([TOOL_SEARCH_CODE_MODE_TOOL_NAME, "hidden_beta"]);
+
+      const restored = compacted.promptToolPolicy.apply();
+      expect(restored.tools).toEqual(compacted.tools);
+      expect(restored.callableToolNames).toEqual([
+        TOOL_SEARCH_CODE_MODE_TOOL_NAME,
+        "read",
+        "hidden_alpha",
+        "hidden_beta",
+      ]);
+    } finally {
+      runtime.cleanup();
+    }
+  });
+
+  it("derives callable inventory after runtime schema projection", () => {
+    const runtime = createRuntime({ tools: { toolSearch: true } });
+    const invalid = {
+      ...createStubTool("invalid_hidden"),
+      parameters: { type: "array", items: { type: "number" } },
+    };
+    const compacted = runtime.compactTools([
+      ...tools([TOOL_SEARCH_CODE_MODE_TOOL_NAME, "valid_hidden"]),
+      invalid,
+    ]);
+
+    try {
+      expect(compacted.promptToolPolicy.apply().callableToolNames).toEqual([
+        TOOL_SEARCH_CODE_MODE_TOOL_NAME,
+        "valid_hidden",
+      ]);
+    } finally {
+      runtime.cleanup();
+    }
+  });
+
   it.each([
     { name: "message-only delivery", sourceReplyDeliveryMode: "message_tool_only" as const },
     { name: "forced message delivery", forceMessageTool: true },

--- a/src/agents/harness/tool-surface-bridge.ts
+++ b/src/agents/harness/tool-surface-bridge.ts
@@ -25,6 +25,7 @@ import {
 } from "../tool-search.js";
 import { applyAgentToolSurfaceCatalog, resolveAgentToolSurfacePlan } from "../tool-surface-plan.js";
 import type { AnyAgentTool } from "../tools/common.js";
+import { createAgentHarnessPromptToolPolicy } from "./prompt-tool-policy.js";
 
 const TOOL_SEARCH_CONTROL_ALLOWLIST_NAMES = [
   TOOL_SEARCH_CODE_MODE_TOOL_NAME,
@@ -41,6 +42,7 @@ export type AgentHarnessToolSurfaceRuntime = {
     options?: { hookContext?: HookContext; localModelLeanApplied?: boolean },
   ) => {
     tools: AnyAgentTool[];
+    promptToolPolicy: ReturnType<typeof createAgentHarnessPromptToolPolicy<AnyAgentTool>>;
   };
   config: OpenClawConfig | undefined;
   includeToolSearchControls: boolean;
@@ -125,7 +127,7 @@ export function createAgentHarnessToolSurfaceRuntimeCore(params: {
   const compactTools = (
     tools: AnyAgentTool[],
     options: { hookContext?: HookContext; localModelLeanApplied?: boolean } = {},
-  ): { tools: AnyAgentTool[] } => {
+  ) => {
     // Native harness callers may supply raw tools, while the bundled tool constructor
     // already applied the full prepared policy and must not be filtered a second time.
     const projectedUncompactedTools = options.localModelLeanApplied
@@ -178,7 +180,14 @@ export function createAgentHarnessToolSurfaceRuntimeCore(params: {
           preserveToolNames,
         });
     effectiveTools = [...filterRuntimeCompatibleTools(projectedCompactedTools).tools];
-    return { tools: effectiveTools };
+    return {
+      tools: effectiveTools,
+      promptToolPolicy: createAgentHarnessPromptToolPolicy({
+        tools: effectiveTools,
+        catalogRef: toolSearchCatalogRef,
+        codeModeControlsEnabled,
+      }),
+    };
   };
   return {
     codeModeControlsEnabled,

--- a/src/auto-reply/source-reply-delivery-mode.ts
+++ b/src/auto-reply/source-reply-delivery-mode.ts
@@ -13,3 +13,15 @@ export function messageToolOwnsVisibleReply(params: {
 }): boolean {
   return params.forceMessageTool === true || params.sourceReplyDeliveryMode === "message_tool_only";
 }
+
+export function buildHarnessVisibleReplyGuidance(params: {
+  sourceReplyDeliveryMode?: string;
+  messageToolAvailable: boolean;
+}): string {
+  if (messageToolOwnsVisibleReply(params) && params.messageToolAvailable) {
+    return "Visible source replies are not automatically delivered for this run. Use `message(action=send)` for user-visible source-channel output. For progress, set `final=false`. Set `final=true`, or omit it, for the completed reply to the current source conversation; OpenClaw stops after confirming delivery. Do not repeat visible message content in your final answer.";
+  }
+  return params.messageToolAvailable
+    ? "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation. Use `message` for supported non-text actions in the current conversation, such as reacting to its current message. Reserve other `message` actions for explicit out-of-band sends or media/file delivery. Reactions are not delivered automatically."
+    : "For the current source conversation, reply normally in your final assistant message; OpenClaw will deliver it through the active source conversation.";
+}

--- a/src/plugin-sdk/agent-harness-runtime.ts
+++ b/src/plugin-sdk/agent-harness-runtime.ts
@@ -262,6 +262,7 @@ export {
   buildDelegationGuidanceSection,
   resolveMainSessionDelegationMode,
 } from "../agents/delegation-guidance.js";
+export { buildHarnessVisibleReplyGuidance } from "../auto-reply/source-reply-delivery-mode.js";
 export { TRANSCRIPT_CREDENTIAL_SAFETY_PROMPT } from "../agents/transcript-credential-safety.js";
 export { resolveAttemptFsWorkspaceOnly } from "../agents/embedded-agent-runner/run/attempt-prompt-helpers.js";
 export { resolveAttemptSpawnWorkspaceDir } from "../agents/embedded-agent-runner/run/attempt-thread-helpers.js";


### PR DESCRIPTION
Closes #125996

AI-assisted: prepared with Codex; the maintainer reviewed the implementation, tests, dependency contract, and live behavior.

## What Problem This Solves

Fixes an issue where Copilot-runtime users could receive bridged OpenClaw tools without the matching OpenClaw tool, delegation, visible-reply, or Skill Workshop policy on ordinary agent turns. The capability existed, but the prompt did not tell the model how to use it, creating silent or incorrect routing risk for delegated work and source replies.

## Why This Change Was Made

Copilot's `createSystemMessageContent` appended only credential safety, workspace bootstrap, and extra context. The fix keeps the Copilot SDK's `systemMessage.mode=append` contract and does not inject the full OpenClaw system prompt.

The shared harness owner now atomically applies prompt-time tool filtering to both direct tools and the hidden Tool Search/Code Mode catalog after schema projection. Prompt hooks lazily build guidance from the final callable capabilities, while a hook-provided `systemPrompt` replacement remains authoritative. Copilot-specific guidance then composes OpenClaw identity, Skill Workshop, delegation, visible-reply, credential-safety, workspace, and extra-context sections. Codex and Copilot reuse the same visible-source reply wording.

Copilot-native task and agent tools remain hard-disabled through `SessionConfig.availableTools`; `sessions_spawn` remains the delegation mechanism.

Provenance: the omission was introduced with the Copilot attempt split in #114035 (`299f5a4941d2`) by @steipete and merged by @steipete on 2026-07-26. Later prompt edits carried the limited append content forward.

### Alternatives rejected

- Injecting the full `buildAgentSystemPrompt` would duplicate OpenClaw's complete system prompt inside the Copilot SDK's native prompt instead of supplying only the missing append policy.
- Relying on tool descriptions would not provide delegation or delivery policy and would not describe capabilities reachable through the hidden catalog.
- Building from the raw or pre-hook inventory would advertise tools removed by schema projection or `before_prompt_build.toolsAllow`.
- Using Copilot-native task guidance would contradict the hard-disabled native task/agent tool catalog and create a second delegation path.

## User Impact

Copilot agent turns now receive guidance that matches the exact capabilities callable on that turn. User-followed delegated work is directed to a visible session and returns its link; hidden work, source replies, message-tool delivery, and Skill Workshop guidance follow the same OpenClaw policy boundaries as the Codex harness.

## Evidence

### Regression and focused proof

- Pre-fix prompt regression: 1/1 failed because the canonical Copilot session message lacked OpenClaw identity, delegation, visible-reply, and Skill Workshop guidance.
- After rebasing onto `a57d9b506081505476d899af9b2073d57b0bd674`: the eight-file focused suite passed 299/299 tests across Copilot prompt/attempt/tool bridge, shared prompt tool policy and hook composition, Codex thread prompting, and delegation guidance.
- Complete `node scripts/check-changed.mjs -- <all changed files>` passed before publication, including production/test types, formatting, lint, guards, cycles, and Plugin SDK surface checks. The conflict-free rebase changed no behavior.
- `pnpm build` passed on the exact production tree: 146 Plugin SDK subpaths and 61 plugins.
- Plugin SDK surface: 4,335 public exports and 2,578 callable exports. The assertion baseline change is shrink-only.
- Fresh autoreview on the frozen uncommitted bundle: TruffleHog clean, no accepted/actionable findings, overall correct 0.97.

### Live behavior

Real OpenAI BYOK execution through the GitHub Copilot SDK on `gpt-5.6-luna` passed. The prompt requested a user-followed codebase investigation/report without naming `sessions_spawn` or `visible`. The model made exactly one spawn with `visible=true`, described a standalone report deliverable, and returned exactly `https://example.test/session/live-proof`. Result: 1 passed, 1 skipped; no credentials appeared in output.

### Dependency and sibling contract

Direct inspection of `openai/codex@b5ea64a203ce1b04629010d3ef0a0d18c3c870a9` confirms `developerInstructions` is an opaque optional string carried into developer context:

- [`codex-rs/app-server-protocol/src/protocol/v2/thread.rs:103,392,580`](https://github.com/openai/codex/blob/b5ea64a203ce1b04629010d3ef0a0d18c3c870a9/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L103)
- [`codex-rs/app-server/src/request_processors/thread_processor.rs:1056-1141`](https://github.com/openai/codex/blob/b5ea64a203ce1b04629010d3ef0a0d18c3c870a9/codex-rs/app-server/src/request_processors/thread_processor.rs#L1056)
- [`codex-rs/core/src/session/turn_context.rs:680`](https://github.com/openai/codex/blob/b5ea64a203ce1b04629010d3ef0a0d18c3c870a9/codex-rs/core/src/session/turn_context.rs#L680)
- [`codex-rs/core/src/session/mod.rs:3494-3500`](https://github.com/openai/codex/blob/b5ea64a203ce1b04629010d3ef0a0d18c3c870a9/codex-rs/core/src/session/mod.rs#L3494)

Codex and Copilot are the only production AgentHarness plugins. The sibling sweep found no other `extensions/*` harness sharing this omission.

### Size

- Production: +323/-220 (net +103). The unavoidable growth adds one canonical final-capability policy owner and Copilot guidance composition while deleting duplicated filtering and visible-reply text.
- Tests: +641/-126 (net +515).
- Tooling/ratchets: +5/-4 (net +1).

### Known separate gap

The existing settled-finalizer live smoke can report capability activity after a successful tool turn. This is a separate pre-existing finalization issue and is intentionally not weakened or changed here; the prompt behavior above is independently green, and a separate follow-up has been recorded.
