### PR TITLE
fix(release): scope optional survivor assertions

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -429,7 +429,7 @@ function assertConfigSurvived() {
     const pluginAllow = config.plugins?.allow ?? [];
     assert(pluginAllow.includes("discord"), "discord plugin allow entry missing");
     assert(pluginAllow.includes("telegram"), "telegram plugin allow entry missing");
-    if (acceptsIntent(coverage, "configured-plugin-installs")) {
+    if (hasCoverage(coverage) && acceptsIntent(coverage, "configured-plugin-installs")) {
       assert(pluginAllow.includes("matrix"), "matrix plugin allow entry missing");
     } else {
       assert(pluginAllow.includes("whatsapp"), "whatsapp plugin allow entry missing");


### PR DESCRIPTION
## Summary

- require an explicit published-scenario coverage plan before asserting optional configured plugin installs
- keep the base prepublish upgrade survivor on its canonical WhatsApp fixture

## Root cause

The prepublish `upgrade-survivor` path seeds the base fixture directly and does not write a published-scenario coverage file. `hasCoverage(...)` intentionally returns true for baseline assertions, but the optional Matrix branch used it without the sibling `hasCoverage(coverage)` guard. The base fixture therefore failed before update with `matrix plugin allow entry missing`, even though Matrix belongs only to the `configured-plugin-installs` published scenario.

## Evidence

Pre-fix exact-source failures:

- full release package/update core: https://github.com/openclaw/openclaw/actions/runs/32173561938/job/95832527169
- full release package acceptance: https://github.com/openclaw/openclaw/actions/runs/32173561938/job/95835644534
- selected source SHA: `97a4d324f5c8f32b9c106d6a6e9ed33c180a5fcb`

The same assertion module already requires `hasCoverage(coverage)` for the later configured-plugin-install details and other optional published scenarios. This change applies that owner rule to the allowlist branch.

No local tests or builds were run, per release-validation policy. Exact-head GitHub CI is the proof path.

## Scope

- production LOC: 0
- release harness: +1/-1
- no runtime, config, protocol, storage, or public API change

Agent transcript omitted.

Exact-head targeted upgrade-survivor proof for `1a0521d4bae9521db9e08b6de7d4485144ed87fc`: https://github.com/openclaw/openclaw/actions/runs/32187977956. The first focused run used main's trusted harness SHA `39b39ca6eec684f0675cd93500646b578f6e7021`, so its `/app/scripts/e2e/lib/upgrade-survivor/assertions.mjs` was the old harness and repeated the pre-fix failure; the corrected run uses SHA-pinned base-repo workflow ref `release-ci/1a0521d4bae9-1787088530`, whose workflow and candidate both resolve to the PR head.
