### PR TITLE
fix(plugins): restore shipped channel compatibility

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -156,15 +156,17 @@ review date; removal still requires the reader condition in the final column.
 ### Published channel setup compatibility
 
 Slack, Discord, Signal, and Microsoft Teams packages published through
-`2026.7.1` imported channel-specific config schemas from
+`2026.7.1` import channel-specific config schemas from
 `openclaw/plugin-sdk/bundled-channel-config-schema`. The published Slack and
-Discord packages also imported `createLegacyCompatChannelDmPolicy` and
+Discord packages also import `createLegacyCompatChannelDmPolicy` and
 `promptLegacyChannelAllowFromForAccount` from
 `openclaw/plugin-sdk/setup-runtime`.
 
-Those compatibility exports were removed in August 2026. Channel plugins must
-own their config schemas and setup policy locally, using generic primitives
-from `channel-config-schema` and `setup-runtime`.
+Those exports remain available as deprecated runtime compatibility adapters.
+New and republished plugins should own their config schemas and setup policy
+locally, using generic primitives from `channel-config-schema` and
+`setup-runtime`. The compatibility exports can be removed only after the
+minimum supported published package versions no longer import them.
 
 ### Channel setup input field compatibility
 

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -310,7 +310,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: OpenAI-compatible video execution in the existing media-understanding owner.
       // -2: retire the uncalled secret-plan target resolver and its result type.
       // +2: conversation-binding inspection result and runtime inspector.
-      4337,
+      // +2: restore shipped channel setup helpers until stable packages migrate.
+      4339,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -400,8 +401,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: OpenAI-compatible video execution in the existing media-understanding owner.
       // -1: retire the uncalled secret-plan target resolver.
       // +1: read-only authoritative conversation-binding inspector.
-      // +6: restore shipped channel config schemas and setup helpers until stable packages migrate.
-      2584,
+      // +2: restore shipped channel setup helpers until stable packages migrate.
+      2580,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -408,7 +408,6 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       // +3: canonical incognito classifier projected through deprecated compatibility barrels.
-      // +6: shipped channel config schemas and setup helpers retained during package migration.
       // +10: named media legacy projection deprecations across public compatibility barrels.
       // +2: channel prompt-context type and metadata builder compatibility aliases.
       // +1: shared ingress error factory projected through channel-message.
@@ -422,7 +421,7 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       //     (voice-call/matrix runtime-doctor repair names, WhatsApp ack policy,
       //     Slack progress-draft render) so installed plugins survive upgrade (#124041 class).
       // -18: retire the expired August compatibility exports and messaging-targets subpath.
-      1140,
+      1134,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -170,7 +170,8 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "reply-runtime": 1,
   "security-runtime": 1,
   "session-store-runtime": 4,
-  "setup-runtime": 0,
+  // +2: shipped Slack and Discord setup helpers retained through their package migration window.
+  "setup-runtime": 2,
   "reply-history": 6,
   "provider-auth": 19,
   "telegram-account": 3,
@@ -399,12 +400,14 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: OpenAI-compatible video execution in the existing media-understanding owner.
       // -1: retire the uncalled secret-plan target resolver.
       // +1: read-only authoritative conversation-binding inspector.
-      2578,
+      // +6: restore shipped channel config schemas and setup helpers until stable packages migrate.
+      2584,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       // +3: canonical incognito classifier projected through deprecated compatibility barrels.
+      // +6: shipped channel config schemas and setup helpers retained during package migration.
       // +10: named media legacy projection deprecations across public compatibility barrels.
       // +2: channel prompt-context type and metadata builder compatibility aliases.
       // +1: shared ingress error factory projected through channel-message.
@@ -418,7 +421,7 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       //     (voice-call/matrix runtime-doctor repair names, WhatsApp ack policy,
       //     Slack progress-draft render) so installed plugins survive upgrade (#124041 class).
       // -18: retire the expired August compatibility exports and messaging-targets subpath.
-      1134,
+      1140,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -170,7 +170,8 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "reply-runtime": 1,
   "security-runtime": 1,
   "session-store-runtime": 4,
-  "setup-runtime": 0,
+  // +2: shipped Slack and Discord setup helpers retained through their package migration window.
+  "setup-runtime": 2,
   "reply-history": 6,
   "provider-auth": 19,
   "telegram-account": 3,
@@ -396,12 +397,14 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // -1: remove the test-only channel activity reset export.
       // +1: OpenAI-compatible video execution in the existing media-understanding owner.
       // -1: retire the uncalled secret-plan target resolver.
-      2577,
+      // +6: restore shipped channel config schemas and setup helpers until stable packages migrate.
+      2583,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(
       "OPENCLAW_PLUGIN_SDK_MAX_PUBLIC_DEPRECATED_EXPORTS",
       // +3: canonical incognito classifier projected through deprecated compatibility barrels.
+      // +6: shipped channel config schemas and setup helpers retained during package migration.
       // +10: named media legacy projection deprecations across public compatibility barrels.
       // +2: channel prompt-context type and metadata builder compatibility aliases.
       // +1: shared ingress error factory projected through channel-message.
@@ -415,7 +418,7 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       //     (voice-call/matrix runtime-doctor repair names, WhatsApp ack policy,
       //     Slack progress-draft render) so installed plugins survive upgrade (#124041 class).
       // -18: retire the expired August compatibility exports and messaging-targets subpath.
-      1134,
+      1140,
       env,
     ),
     publicWildcardReexports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -308,7 +308,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: named bounded structured-input surface for native harness protocol adapters.
       // +1: OpenAI-compatible video execution in the existing media-understanding owner.
       // -2: retire the uncalled secret-plan target resolver and its result type.
-      4335,
+      // +2: restore shipped channel setup helpers until stable packages migrate.
+      4337,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -397,8 +398,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // -1: remove the test-only channel activity reset export.
       // +1: OpenAI-compatible video execution in the existing media-understanding owner.
       // -1: retire the uncalled secret-plan target resolver.
-      // +6: restore shipped channel config schemas and setup helpers until stable packages migrate.
-      2583,
+      // +2: restore shipped channel setup helpers until stable packages migrate.
+      2579,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/channels/plugins/setup-wizard-legacy-compat.test.ts
+++ b/src/channels/plugins/setup-wizard-legacy-compat.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { WizardPrompter } from "../../wizard/prompts.js";
+import {
+  createLegacyCompatChannelDmPolicy,
+  promptLegacyChannelAllowFromForAccount,
+} from "./setup-wizard-legacy-compat.js";
+
+describe("legacy channel setup compatibility", () => {
+  it("preserves legacy DM policy behavior for shipped setup plugins", () => {
+    const policy = createLegacyCompatChannelDmPolicy({ label: "Slack", channel: "slack" });
+    const initial = {
+      channels: {
+        slack: {
+          dm: { policy: "allowlist" },
+          accounts: { work: { dmPolicy: "disabled", allowFrom: ["U1"] } },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(policy.getCurrent(initial, "work")).toBe("disabled");
+    expect(policy.setPolicy(initial, "open", "work")).toMatchObject({
+      channels: {
+        slack: {
+          accounts: {
+            work: { dmPolicy: "open", allowFrom: ["U1", "*"] },
+          },
+        },
+      },
+    });
+    expect(policy.setPolicy(initial, "open", "default")).toMatchObject({
+      channels: {
+        slack: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          dm: { policy: "allowlist", enabled: true },
+        },
+      },
+    });
+  });
+
+  it("preserves the legacy allowlist prompt contract", async () => {
+    const note = vi.fn(async () => undefined);
+    const text = vi.fn(async () => "U2");
+    const prompter = { note, text } as unknown as WizardPrompter;
+    const cfg = {
+      channels: { slack: { allowFrom: ["U1"] } },
+    } as OpenClawConfig;
+
+    const next = await promptLegacyChannelAllowFromForAccount({
+      cfg,
+      channel: "slack",
+      prompter,
+      defaultAccountId: "default",
+      resolveAccount: () => ({ allowFrom: ["U1"] }),
+      resolveExisting: (account) => account.allowFrom,
+      resolveToken: () => null,
+      noteTitle: "Slack allowlist",
+      noteLines: ["Enter Slack user ids"],
+      message: "Allowed users",
+      placeholder: "U123",
+      parseId: (value) => (/^U\d+$/.test(value) ? value : null),
+      invalidWithoutTokenNote: "Use an id",
+      resolveEntries: async () => [],
+    });
+
+    expect(note).toHaveBeenCalledWith("Enter Slack user ids", "Slack allowlist");
+    expect(next).toMatchObject({
+      channels: {
+        slack: { allowFrom: ["U1", "U2"], dm: { enabled: true } },
+      },
+    });
+  });
+});

--- a/src/channels/plugins/setup-wizard-legacy-compat.test.ts
+++ b/src/channels/plugins/setup-wizard-legacy-compat.test.ts
@@ -46,28 +46,48 @@ describe("legacy channel setup compatibility", () => {
     const cfg = {
       channels: { slack: { allowFrom: ["U1"] } },
     } as OpenClawConfig;
-
-    const next = await promptLegacyChannelAllowFromForAccount({
-      cfg,
+    const promptParams = {
       channel: "slack",
       prompter,
       defaultAccountId: "default",
       resolveAccount: () => ({ allowFrom: ["U1"] }),
-      resolveExisting: (account) => account.allowFrom,
+      resolveExisting: (account: { allowFrom: string[] }) => account.allowFrom,
       resolveToken: () => null,
       noteTitle: "Slack allowlist",
       noteLines: ["Enter Slack user ids"],
       message: "Allowed users",
       placeholder: "U123",
-      parseId: (value) => (/^U\d+$/.test(value) ? value : null),
+      parseId: (value: string) => (/^U\d+$/.test(value) ? value : null),
       invalidWithoutTokenNote: "Use an id",
       resolveEntries: async () => [],
-    });
+    };
+
+    const next = await promptLegacyChannelAllowFromForAccount({ cfg, ...promptParams });
 
     expect(note).toHaveBeenCalledWith("Enter Slack user ids", "Slack allowlist");
     expect(next).toMatchObject({
       channels: {
         slack: { allowFrom: ["U1", "U2"], dm: { enabled: true } },
+      },
+    });
+
+    const accountNext = await promptLegacyChannelAllowFromForAccount({
+      cfg: {
+        channels: {
+          slack: { allowFrom: ["U1"], accounts: { work: { allowFrom: ["U3"] } } },
+        },
+      } as OpenClawConfig,
+      ...promptParams,
+      defaultAccountId: "work",
+      resolveAccount: () => ({ allowFrom: ["U3"] }),
+    });
+
+    expect(accountNext).toMatchObject({
+      channels: {
+        slack: {
+          allowFrom: ["U1"],
+          accounts: { work: { allowFrom: ["U3", "U2"] } },
+        },
       },
     });
   });

--- a/src/channels/plugins/setup-wizard-legacy-compat.ts
+++ b/src/channels/plugins/setup-wizard-legacy-compat.ts
@@ -173,9 +173,16 @@ export async function promptLegacyChannelAllowFromForAccount<TAccount>(params: {
     invalidWithoutTokenNote: params.invalidWithoutTokenNote,
     resolveEntries: params.resolveEntries,
   });
-  return patchLegacyChannelConfig({
-    cfg: params.cfg,
-    channel: params.channel,
-    patch: { allowFrom },
-  });
+  return accountId !== DEFAULT_ACCOUNT_ID
+    ? patchChannelConfigForAccount({
+        cfg: params.cfg,
+        channel: params.channel,
+        accountId,
+        patch: { allowFrom },
+      })
+    : patchLegacyChannelConfig({
+        cfg: params.cfg,
+        channel: params.channel,
+        patch: { allowFrom },
+      });
 }

--- a/src/channels/plugins/setup-wizard-legacy-compat.ts
+++ b/src/channels/plugins/setup-wizard-legacy-compat.ts
@@ -19,10 +19,7 @@ type AllowFromResolution = {
   id?: string | null;
 };
 
-function resolveLegacyChannelConfig(
-  cfg: OpenClawConfig,
-  channel: string,
-): Record<string, unknown> {
+function resolveLegacyChannelConfig(cfg: OpenClawConfig, channel: string): Record<string, unknown> {
   return asObjectRecord(cfg.channels?.[channel]) ?? {};
 }
 

--- a/src/channels/plugins/setup-wizard-legacy-compat.ts
+++ b/src/channels/plugins/setup-wizard-legacy-compat.ts
@@ -1,0 +1,180 @@
+import type { DmPolicy } from "../../config/types.base.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
+import type { WizardPrompter } from "../../wizard/prompts.js";
+import { resolveChannelDmAllowFrom, resolveChannelDmPolicy } from "./dm-access.js";
+import {
+  addWildcardAllowFrom,
+  patchChannelConfigForAccount,
+  promptResolvedAllowFrom,
+  resolveSetupAccountId,
+  splitSetupEntries,
+} from "./setup-wizard-helpers.js";
+import type { ChannelSetupDmPolicy } from "./setup-wizard-types.js";
+
+type AllowFromResolution = {
+  input: string;
+  resolved: boolean;
+  id?: string | null;
+};
+
+function patchLegacyChannelConfig(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  patch: Record<string, unknown>;
+}): OpenClawConfig {
+  const channelConfig =
+    (params.cfg.channels?.[params.channel] as Record<string, unknown> | undefined) ?? {};
+  const dmConfig = (channelConfig.dm as Record<string, unknown> | undefined) ?? {};
+  return {
+    ...params.cfg,
+    channels: {
+      ...params.cfg.channels,
+      [params.channel]: {
+        ...channelConfig,
+        ...params.patch,
+        dm: {
+          ...dmConfig,
+          enabled: typeof dmConfig.enabled === "boolean" ? dmConfig.enabled : true,
+        },
+      },
+    },
+  };
+}
+function setLegacyChannelDmPolicy(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  dmPolicy: DmPolicy;
+}): OpenClawConfig {
+  const channelConfig =
+    (params.cfg.channels?.[params.channel] as Record<string, unknown> | undefined) ?? {};
+  const existingAllowFrom = resolveChannelDmAllowFrom({ account: channelConfig });
+  const allowFrom =
+    params.dmPolicy === "open" ? addWildcardAllowFrom(existingAllowFrom) : undefined;
+  return patchLegacyChannelConfig({
+    cfg: params.cfg,
+    channel: params.channel,
+    patch: {
+      dmPolicy: params.dmPolicy,
+      ...(allowFrom ? { allowFrom } : {}),
+    },
+  });
+}
+
+/** @deprecated Compatibility for plugins published before setup policy became plugin-owned. */
+export function createLegacyCompatChannelDmPolicy(params: {
+  label: string;
+  channel: string;
+  promptAllowFrom?: ChannelSetupDmPolicy["promptAllowFrom"];
+}): ChannelSetupDmPolicy {
+  return {
+    label: params.label,
+    channel: params.channel,
+    policyKey: `channels.${params.channel}.dmPolicy`,
+    allowFromKey: `channels.${params.channel}.allowFrom`,
+    resolveConfigKeys: (_cfg, accountId) =>
+      accountId && accountId !== DEFAULT_ACCOUNT_ID
+        ? {
+            policyKey: `channels.${params.channel}.accounts.${accountId}.dmPolicy`,
+            allowFromKey: `channels.${params.channel}.accounts.${accountId}.allowFrom`,
+          }
+        : {
+            policyKey: `channels.${params.channel}.dmPolicy`,
+            allowFromKey: `channels.${params.channel}.allowFrom`,
+          },
+    getCurrent: (cfg, accountId) => {
+      const channelConfig =
+        (cfg.channels?.[params.channel] as
+          | {
+              dmPolicy?: DmPolicy;
+              dm?: { policy?: DmPolicy };
+              accounts?: Record<string, { dmPolicy?: DmPolicy; dm?: { policy?: DmPolicy } }>;
+            }
+          | undefined) ?? {};
+      const accountConfig =
+        accountId && accountId !== DEFAULT_ACCOUNT_ID
+          ? channelConfig.accounts?.[accountId]
+          : undefined;
+      return resolveChannelDmPolicy({
+        account: accountConfig as Record<string, unknown> | undefined,
+        parent: channelConfig as Record<string, unknown>,
+        defaultPolicy: "pairing",
+      }) as DmPolicy;
+    },
+    setPolicy: (cfg, policy, accountId) =>
+      accountId && accountId !== DEFAULT_ACCOUNT_ID
+        ? patchChannelConfigForAccount({
+            cfg,
+            channel: params.channel,
+            accountId,
+            patch: {
+              dmPolicy: policy,
+              ...(policy === "open"
+                ? {
+                    allowFrom: addWildcardAllowFrom(
+                      resolveChannelDmAllowFrom({
+                        account: (
+                          cfg.channels?.[params.channel] as
+                            | { accounts?: Record<string, Record<string, unknown>> }
+                            | undefined
+                        )?.accounts?.[accountId],
+                        parent: cfg.channels?.[params.channel] as
+                          | Record<string, unknown>
+                          | undefined,
+                      }),
+                    ),
+                  }
+                : {}),
+            },
+          })
+        : setLegacyChannelDmPolicy({
+            cfg,
+            channel: params.channel,
+            dmPolicy: policy,
+          }),
+    ...(params.promptAllowFrom ? { promptAllowFrom: params.promptAllowFrom } : {}),
+  };
+}
+
+/** @deprecated Compatibility for plugins published before setup allowlists became plugin-owned. */
+export async function promptLegacyChannelAllowFromForAccount<TAccount>(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  prompter: WizardPrompter;
+  accountId?: string;
+  defaultAccountId: string;
+  resolveAccount: (cfg: OpenClawConfig, accountId: string) => TAccount;
+  resolveExisting: (account: TAccount, cfg: OpenClawConfig) => Array<string | number>;
+  resolveToken: (account: TAccount) => string | null | undefined;
+  noteTitle: string;
+  noteLines: string[];
+  message: string;
+  placeholder: string;
+  parseId: (value: string) => string | null;
+  invalidWithoutTokenNote: string;
+  resolveEntries: (params: { token: string; entries: string[] }) => Promise<AllowFromResolution[]>;
+}): Promise<OpenClawConfig> {
+  const accountId = resolveSetupAccountId({
+    accountId: params.accountId,
+    defaultAccountId: params.defaultAccountId,
+  });
+  const account = params.resolveAccount(params.cfg, accountId);
+  await params.prompter.note(params.noteLines.join("\n"), params.noteTitle);
+  const allowFrom = await promptResolvedAllowFrom({
+    prompter: params.prompter,
+    existing: params.resolveExisting(account, params.cfg),
+    token: params.resolveToken(account),
+    message: params.message,
+    placeholder: params.placeholder,
+    label: params.noteTitle,
+    parseInputs: splitSetupEntries,
+    parseId: params.parseId,
+    invalidWithoutTokenNote: params.invalidWithoutTokenNote,
+    resolveEntries: params.resolveEntries,
+  });
+  return patchLegacyChannelConfig({
+    cfg: params.cfg,
+    channel: params.channel,
+    patch: { allowFrom },
+  });
+}

--- a/src/channels/plugins/setup-wizard-legacy-compat.ts
+++ b/src/channels/plugins/setup-wizard-legacy-compat.ts
@@ -1,3 +1,4 @@
+import { asNullableRecord as asObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import type { DmPolicy } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
@@ -18,14 +19,29 @@ type AllowFromResolution = {
   id?: string | null;
 };
 
+function resolveLegacyChannelConfig(
+  cfg: OpenClawConfig,
+  channel: string,
+): Record<string, unknown> {
+  return asObjectRecord(cfg.channels?.[channel]) ?? {};
+}
+
+function resolveLegacyChannelAccount(
+  cfg: OpenClawConfig,
+  channel: string,
+  accountId: string,
+): Record<string, unknown> | null {
+  const channelConfig = resolveLegacyChannelConfig(cfg, channel);
+  return asObjectRecord(asObjectRecord(channelConfig.accounts)?.[accountId]);
+}
+
 function patchLegacyChannelConfig(params: {
   cfg: OpenClawConfig;
   channel: string;
   patch: Record<string, unknown>;
 }): OpenClawConfig {
-  const channelConfig =
-    (params.cfg.channels?.[params.channel] as Record<string, unknown> | undefined) ?? {};
-  const dmConfig = (channelConfig.dm as Record<string, unknown> | undefined) ?? {};
+  const channelConfig = resolveLegacyChannelConfig(params.cfg, params.channel);
+  const dmConfig = asObjectRecord(channelConfig.dm) ?? {};
   return {
     ...params.cfg,
     channels: {
@@ -46,8 +62,7 @@ function setLegacyChannelDmPolicy(params: {
   channel: string;
   dmPolicy: DmPolicy;
 }): OpenClawConfig {
-  const channelConfig =
-    (params.cfg.channels?.[params.channel] as Record<string, unknown> | undefined) ?? {};
+  const channelConfig = resolveLegacyChannelConfig(params.cfg, params.channel);
   const existingAllowFrom = resolveChannelDmAllowFrom({ account: channelConfig });
   const allowFrom =
     params.dmPolicy === "open" ? addWildcardAllowFrom(existingAllowFrom) : undefined;
@@ -83,23 +98,18 @@ export function createLegacyCompatChannelDmPolicy(params: {
             allowFromKey: `channels.${params.channel}.allowFrom`,
           },
     getCurrent: (cfg, accountId) => {
-      const channelConfig =
-        (cfg.channels?.[params.channel] as
-          | {
-              dmPolicy?: DmPolicy;
-              dm?: { policy?: DmPolicy };
-              accounts?: Record<string, { dmPolicy?: DmPolicy; dm?: { policy?: DmPolicy } }>;
-            }
-          | undefined) ?? {};
+      const channelConfig = resolveLegacyChannelConfig(cfg, params.channel);
       const accountConfig =
         accountId && accountId !== DEFAULT_ACCOUNT_ID
-          ? channelConfig.accounts?.[accountId]
+          ? resolveLegacyChannelAccount(cfg, params.channel, accountId)
           : undefined;
-      return resolveChannelDmPolicy({
-        account: accountConfig as Record<string, unknown> | undefined,
-        parent: channelConfig as Record<string, unknown>,
-        defaultPolicy: "pairing",
-      }) as DmPolicy;
+      return (
+        resolveChannelDmPolicy({
+          account: accountConfig,
+          parent: channelConfig,
+          defaultPolicy: "pairing",
+        }) ?? "pairing"
+      );
     },
     setPolicy: (cfg, policy, accountId) =>
       accountId && accountId !== DEFAULT_ACCOUNT_ID
@@ -113,14 +123,8 @@ export function createLegacyCompatChannelDmPolicy(params: {
                 ? {
                     allowFrom: addWildcardAllowFrom(
                       resolveChannelDmAllowFrom({
-                        account: (
-                          cfg.channels?.[params.channel] as
-                            | { accounts?: Record<string, Record<string, unknown>> }
-                            | undefined
-                        )?.accounts?.[accountId],
-                        parent: cfg.channels?.[params.channel] as
-                          | Record<string, unknown>
-                          | undefined,
+                        account: resolveLegacyChannelAccount(cfg, params.channel, accountId),
+                        parent: resolveLegacyChannelConfig(cfg, params.channel),
                       }),
                     ),
                   }

--- a/src/plugin-sdk/bundled-channel-config-schema.ts
+++ b/src/plugin-sdk/bundled-channel-config-schema.ts
@@ -6,7 +6,7 @@
  * bundled channel schemas. Internal callers use this subpath only for the
  * bundled provider schemas; generic primitives come from channel-config-schema.
  */
-import type { ZodObject, ZodOptional, ZodType } from "zod";
+import { z, type ZodObject, type ZodOptional, type ZodType } from "zod";
 import type { OpenClawConfig } from "./config-contracts.js";
 import {
   createLazyFacadeObjectValue,
@@ -32,6 +32,23 @@ export {
   requireOpenAllowFrom,
   ToolPolicySchema,
 } from "./channel-config-schema.js";
+
+function createLegacyExternalChannelConfigSchema() {
+  return z.object({}).passthrough();
+}
+
+/**
+ * @deprecated Compatibility for external channel packages published through 2026.7.1.
+ * Their package manifests remain the validation owner. Remove after the minimum supported
+ * Slack, Discord, Signal, and Teams packages use plugin-owned config schemas.
+ */
+export const SlackConfigSchema = createLegacyExternalChannelConfigSchema();
+/** @deprecated See SlackConfigSchema. */
+export const DiscordConfigSchema = createLegacyExternalChannelConfigSchema();
+/** @deprecated See SlackConfigSchema. */
+export const SignalConfigSchema = createLegacyExternalChannelConfigSchema();
+/** @deprecated See SlackConfigSchema. */
+export const MSTeamsConfigSchema = createLegacyExternalChannelConfigSchema();
 
 type ChannelConfig = NonNullable<OpenClawConfig["channels"]>;
 type ConfigSchemaShape<TOutput extends object> = {

--- a/src/plugin-sdk/setup-runtime.ts
+++ b/src/plugin-sdk/setup-runtime.ts
@@ -43,6 +43,11 @@ export {
   splitSetupEntries,
 } from "../channels/plugins/setup-wizard-helpers.js";
 
+export {
+  createLegacyCompatChannelDmPolicy,
+  promptLegacyChannelAllowFromForAccount,
+} from "../channels/plugins/setup-wizard-legacy-compat.js";
+
 export { createAllowlistSetupWizardProxy } from "../channels/plugins/setup-wizard-proxy.js";
 export {
   createCliPathTextInput,

--- a/src/plugin-sdk/shipped-channel-compat.test.ts
+++ b/src/plugin-sdk/shipped-channel-compat.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  DiscordConfigSchema,
+  MSTeamsConfigSchema,
+  SignalConfigSchema,
+  SlackConfigSchema,
+} from "./bundled-channel-config-schema.js";
+import {
+  createLegacyCompatChannelDmPolicy,
+  promptLegacyChannelAllowFromForAccount,
+} from "./setup-runtime.js";
+
+describe("shipped external channel compatibility", () => {
+  it("retains named config schema exports used by published channel packages", () => {
+    for (const schema of [
+      SlackConfigSchema,
+      DiscordConfigSchema,
+      SignalConfigSchema,
+      MSTeamsConfigSchema,
+    ]) {
+      expect(schema.safeParse({ legacySetting: true })).toMatchObject({ success: true });
+      expect(schema.toJSONSchema({ target: "draft-07" })).toMatchObject({ type: "object" });
+    }
+  });
+
+  it("retains setup helpers used by published Slack and Discord packages", () => {
+    expect(createLegacyCompatChannelDmPolicy).toBeTypeOf("function");
+    expect(promptLegacyChannelAllowFromForAccount).toBeTypeOf("function");
+  });
+});

--- a/src/plugins/compat/registry-records.ts
+++ b/src/plugins/compat/registry-records.ts
@@ -476,9 +476,8 @@ export const PLUGIN_COMPAT_RECORDS = [
     introduced: "2026-07-23",
     deprecated: "2026-07-23",
     warningStarts: "2026-07-23",
-    removeAfter: "2026-08-30",
     replacement:
-      "plugin-owned config schemas plus generic `openclaw/plugin-sdk/channel-config-schema` and `openclaw/plugin-sdk/setup-runtime` primitives",
+      "retain until supported published packages migrate to plugin-owned config schemas plus generic `openclaw/plugin-sdk/channel-config-schema` and `openclaw/plugin-sdk/setup-runtime` primitives",
     docsPath: "/plugins/sdk-migration#published-channel-setup-compatibility",
     surfaces: [
       "openclaw/plugin-sdk/bundled-channel-config-schema SlackConfigSchema",

--- a/src/plugins/compat/registry-records.ts
+++ b/src/plugins/compat/registry-records.ts
@@ -471,9 +471,12 @@ export const PLUGIN_COMPAT_RECORDS = [
   },
   {
     code: "plugin-sdk-shipped-channel-setup-exports",
-    status: "removed",
+    status: "deprecated",
     owner: "channel",
     introduced: "2026-07-23",
+    deprecated: "2026-07-23",
+    warningStarts: "2026-07-23",
+    removeAfter: "2026-08-30",
     replacement:
       "plugin-owned config schemas plus generic `openclaw/plugin-sdk/channel-config-schema` and `openclaw/plugin-sdk/setup-runtime` primitives",
     docsPath: "/plugins/sdk-migration#published-channel-setup-compatibility",
@@ -485,10 +488,12 @@ export const PLUGIN_COMPAT_RECORDS = [
       "openclaw/plugin-sdk/setup-runtime createLegacyCompatChannelDmPolicy",
       "openclaw/plugin-sdk/setup-runtime promptLegacyChannelAllowFromForAccount",
     ],
-    diagnostics: ["plugin compatibility registry and migration guide"],
-    tests: ["src/plugins/compat/registry.test.ts"],
+    diagnostics: [
+      "repository deprecated API usage guard for core and bundled plugins; no external runtime import warning",
+    ],
+    tests: ["src/plugin-sdk/shipped-channel-compat.test.ts", "src/plugins/compat/registry.test.ts"],
     releaseNote:
-      "The shipped channel setup compatibility schemas and helpers were removed; channel plugins must own their config schemas and setup policy.",
+      "Published OpenClaw channel packages through 2026.7.1 remain loadable while they migrate to plugin-owned config and setup helpers.",
   },
   {
     code: "generated-bundled-channel-config-fallback",

--- a/src/plugins/compat/registry.test.ts
+++ b/src/plugins/compat/registry.test.ts
@@ -215,17 +215,17 @@ describe("plugin compatibility registry", () => {
     expect(record?.removeAfter).toBeUndefined();
   });
 
-  it("keeps removed shipped channel setup exports as a migration tombstone", () => {
+  it("keeps shipped channel setup exports until published packages migrate", () => {
     const record = listPluginCompatRecords().find(
       (candidate) => candidate.code === "plugin-sdk-shipped-channel-setup-exports",
     );
 
     expect(record).toMatchObject({
-      status: "removed",
+      status: "deprecated",
       replacement:
         "plugin-owned config schemas plus generic `openclaw/plugin-sdk/channel-config-schema` and `openclaw/plugin-sdk/setup-runtime` primitives",
     });
-    expect(record?.removeAfter).toBeUndefined();
+    expect(record?.removeAfter).toBe("2026-08-30");
   });
 
   it("keeps the removed memory embedding registrar as a migration tombstone", () => {

--- a/src/plugins/compat/registry.test.ts
+++ b/src/plugins/compat/registry.test.ts
@@ -7,6 +7,7 @@ const datePattern = /^\d{4}-\d{2}-\d{2}$/u;
 const removalDatePendingCompatCodes = new Set<PluginCompatCode>([
   "plugin-sdk-tool-plugin-public-demotion",
   "agent-harness-sdk-alias",
+  "plugin-sdk-shipped-channel-setup-exports",
 ]);
 const retiredPluginSdkSubpathCodes = [
   "plugin-sdk-channel-streaming-subpath",
@@ -223,9 +224,9 @@ describe("plugin compatibility registry", () => {
     expect(record).toMatchObject({
       status: "deprecated",
       replacement:
-        "plugin-owned config schemas plus generic `openclaw/plugin-sdk/channel-config-schema` and `openclaw/plugin-sdk/setup-runtime` primitives",
+        "retain until supported published packages migrate to plugin-owned config schemas plus generic `openclaw/plugin-sdk/channel-config-schema` and `openclaw/plugin-sdk/setup-runtime` primitives",
     });
-    expect(record?.removeAfter).toBe("2026-08-30");
+    expect(record?.removeAfter).toBeUndefined();
   });
 
   it("keeps the removed memory embedding registrar as a migration tombstone", () => {

--- a/src/plugins/contracts/config-footprint-guardrails.test.ts
+++ b/src/plugins/contracts/config-footprint-guardrails.test.ts
@@ -188,7 +188,7 @@ describe("config footprint guardrails", () => {
     );
   });
 
-  it("keeps current channel schemas plugin-owned", () => {
+  it("keeps current channel schemas plugin-owned behind shipped compatibility exports", () => {
     const source = readSource("src/plugin-sdk/channel-config-schema.ts");
     const bundledSource = readSource("src/plugin-sdk/bundled-channel-config-schema.ts");
     const bundledSection = bundledSource.slice(
@@ -215,8 +215,12 @@ describe("config footprint guardrails", () => {
     ].toSorted((left, right) => left.localeCompare(right));
 
     expect(exportedSchemaNames).toEqual([
+      "DiscordConfigSchema",
       "GoogleChatConfigSchema",
       "IMessageConfigSchema",
+      "MSTeamsConfigSchema",
+      "SignalConfigSchema",
+      "SlackConfigSchema",
       "TelegramConfigSchema",
       "WhatsAppConfigSchema",
     ]);
@@ -247,6 +251,7 @@ describe("config footprint guardrails", () => {
     const allowedShellImporters = new Set([
       // The facade's focused regression tests are its only internal consumers.
       "src/plugin-sdk/bundled-channel-config-schema.test.ts",
+      "src/plugin-sdk/shipped-channel-compat.test.ts",
       // This guardrail file embeds facade specifiers in shell-shape assertions.
       "src/plugins/contracts/config-footprint-guardrails.test.ts",
     ]);


### PR DESCRIPTION
## Summary

- restore the deprecated channel config schemas still imported by published stable Slack, Discord, Signal, and Microsoft Teams packages
- restore the two setup helpers still imported by published stable Slack and Discord packages
- put the shipped compatibility record back into its reader-gated migration window

## Root cause

PR #124416 removed the compatibility exports restored by #113101 before their stated reader condition was true. The current source/candidate channel packages have migrated to plugin-owned schemas and setup policy, but the latest published stable `@openclaw/*@2026.7.1` packages still import the deprecated host exports. A current host can therefore install them successfully and then fail their setup entry with `Cannot read properties of undefined (reading 'toJSONSchema')`.

The owner-level fix is to restore the exact public Plugin SDK compatibility adapters and their contract tests until the minimum supported published versions no longer import them. The adapters do not add new policy: package manifests remain schema owners, and new/republished plugins continue to use plugin-local schemas and generic setup primitives.

## Evidence

Pre-fix exact-source failures:

- Discord published-package onboarding: https://github.com/openclaw/openclaw/actions/runs/32173561938/job/95832527169
- Slack published-package onboarding: https://github.com/openclaw/openclaw/actions/runs/32173561938/job/95832527169
- selected source SHA: `97a4d324f5c8f32b9c106d6a6e9ed33c180a5fcb`

In the plugin prerelease run at the same SHA, both candidate-package onboarding lanes pass, separating current package behavior from the published stable compatibility break. PR #113101 previously proved the exact stable-package reader set and restored these same adapters; PR #124416 removed them on August 15.

No local tests, builds, docs commands, formatting, or dependency setup were run, per release-validation policy. Exact-head GitHub CI and targeted published-package onboarding are the proof path.

## Scope

- production compatibility adapters: +205/-1 (181-line setup adapter + 24 schema/export lines)
- tests: +104/-6
- docs/registry/surface budgets: +27/-9
- positive production LOC is required to preserve the shipped public Plugin SDK contract; this is the exact prior adapter implementation, not new behavior
- no config, protocol, storage, or plugin-owned schema change

Agent transcript omitted.

Exact-head targeted published-package onboarding proof for rebased head `ef03150a2889a084856f7b9037f636e6e74fb264`: https://github.com/openclaw/openclaw/actions/runs/32188399071. Both target lanes passed on the pre-rebase branch head in https://github.com/openclaw/openclaw/actions/runs/32186975818; the final run re-proves the same behavior after resolving current-main SDK budget changes and removing the release-owned changelog entry.
