### PR TITLE
fix: preserve managed checkouts with shared project references

### DIFF
--- a/src/gateway/server-methods/projects.test.ts
+++ b/src/gateway/server-methods/projects.test.ts
@@ -14,6 +14,7 @@ import {
   registerClonedProjectRegistry,
   registerProjectRegistry,
 } from "../../projects/project-registry.js";
+import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
 import { ensureProfileForEmail, linkEmail } from "../../state/user-profiles.js";
 import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { createProjectsHandlers } from "./projects.js";
@@ -416,6 +417,78 @@ test("projects.remove deletes an unreferenced Gateway-managed clone", async () =
       await invokeProjectMethod("projects.remove", { id: project.id, deleteCheckout: true }),
     ).toMatchObject({ ok: true, payload: { removed: true } });
     await expect(fs.stat(repo)).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await state.cleanup();
+  }
+});
+
+test("projects.remove preserves a cloned checkout while a duplicate registry row remains", async () => {
+  const state = await createOpenClawTestState({ layout: "state-only", prefix: "projects-rpc-" });
+  try {
+    const originUrl = "https://github.com/acme/shared-managed.git";
+    const fingerprint = sha256HexPrefixCore(originUrl, 16);
+    const repo = await initializeRepository(
+      path.join(state.stateDir, "projects", fingerprint),
+      "shared-managed",
+      originUrl,
+    );
+    const project = await registerClonedProjectRegistry({
+      path: repo,
+      name: "Shared managed",
+      originUrl,
+    });
+    const now = Date.now();
+    openOpenClawStateDatabase()
+      .db.prepare(
+        `INSERT INTO projects
+          (id, display_name, repo_root, origin_url, source, created_at_ms, updated_at_ms)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run("shared-managed-copy", "Shared managed copy", repo, originUrl, "cloned", now, now);
+
+    expect(
+      await invokeProjectMethod("projects.remove", { id: project.id, deleteCheckout: true }),
+    ).toMatchObject({ ok: true, payload: { removed: true } });
+    await expect(fs.stat(repo)).resolves.toBeDefined();
+
+    expect(
+      await invokeProjectMethod("projects.remove", {
+        id: "shared-managed-copy",
+        deleteCheckout: true,
+      }),
+    ).toMatchObject({ ok: true, payload: { removed: true } });
+    await expect(fs.stat(repo)).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await state.cleanup();
+  }
+});
+
+test("projects.remove refuses to delete a cloned checkout configured as an agent workspace", async () => {
+  const state = await createOpenClawTestState({ layout: "state-only", prefix: "projects-rpc-" });
+  try {
+    const originUrl = "https://github.com/acme/workspace-project.git";
+    const fingerprint = sha256HexPrefixCore(originUrl, 16);
+    const repo = await initializeRepository(
+      path.join(state.stateDir, "projects", fingerprint),
+      "workspace-project",
+      originUrl,
+    );
+    const project = await registerClonedProjectRegistry({
+      path: repo,
+      name: "Workspace project",
+      originUrl,
+    });
+    const cfg = {
+      agents: { list: [{ id: "main", default: true, workspace: repo }] },
+    } as OpenClawConfig;
+
+    expect(
+      await invokeProjectMethod("projects.remove", { id: project.id, deleteCheckout: true }, cfg),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "INVALID_REQUEST", message: expect.stringContaining("agent workspace") },
+    });
+    await expect(fs.stat(repo)).resolves.toBeDefined();
   } finally {
     await state.cleanup();
   }

--- a/src/gateway/server-methods/projects.test.ts
+++ b/src/gateway/server-methods/projects.test.ts
@@ -444,12 +444,23 @@ test("projects.remove preserves a cloned checkout while a duplicate registry row
           (id, display_name, repo_root, origin_url, source, created_at_ms, updated_at_ms)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
       )
-      .run("shared-managed-copy", "Shared managed copy", repo, originUrl, "cloned", now, now);
+      .run("shared-managed-copy", "Shared managed copy", repo, null, "registered", now, now);
 
     expect(
       await invokeProjectMethod("projects.remove", { id: project.id, deleteCheckout: true }),
     ).toMatchObject({ ok: true, payload: { removed: true } });
     await expect(fs.stat(repo)).resolves.toBeDefined();
+
+    const listed = await invokeProjectMethod("projects.list", {}, {}, ["operator.write"]);
+    const survivor = (
+      listed?.payload as { projects?: Array<Record<string, unknown>> } | undefined
+    )?.projects?.find((candidate) => candidate.id === "shared-managed-copy");
+    expect(survivor).toMatchObject({
+      id: "shared-managed-copy",
+      repoRoot: repo,
+      originUrl,
+      source: "cloned",
+    });
 
     expect(
       await invokeProjectMethod("projects.remove", {

--- a/src/gateway/server-methods/projects.ts
+++ b/src/gateway/server-methods/projects.ts
@@ -22,8 +22,8 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { ProjectCloneError } from "../../projects/project-clone-runtime.js";
 import {
-  deleteClonedProjectCheckout,
   materializeProjectClone,
+  removeClonedProjectCheckout,
 } from "../../projects/project-clone.js";
 import {
   listProjectRegistry,
@@ -388,6 +388,43 @@ async function listObservedProjects(
   return projectCandidatesToSummaries(candidates);
 }
 
+function findProjectCheckoutReference(
+  cfg: Parameters<typeof listProjectRegistry>[0],
+  repoRoot: string,
+): string | undefined {
+  const normalizedRoot = path.resolve(repoRoot);
+  const workspaceReference = listProjectRegistry(cfg).find(
+    (candidate) =>
+      candidate.source === "workspace" && path.resolve(candidate.repoRoot) === normalizedRoot,
+  );
+  const worktreeReference = listRegistryWorktrees(process.env).find(
+    (worktree) => !worktree.removedAt && path.resolve(worktree.repoRoot) === normalizedRoot,
+  );
+  const sessionReference = Object.entries(
+    loadCombinedSessionStoreForGatewayCore(cfg, { projection: "list" }).store,
+  ).find(([, entry]) => {
+    if (entry.archivedAt) {
+      return false;
+    }
+    const sessionRoot = entry.worktree?.repoRoot;
+    if (sessionRoot && path.resolve(sessionRoot) === normalizedRoot) {
+      return true;
+    }
+    const cwd = entry.spawnedCwd;
+    return Boolean(
+      cwd &&
+      (path.resolve(cwd) === normalizedRoot || isPathInside(normalizedRoot, path.resolve(cwd))),
+    );
+  });
+  return workspaceReference
+    ? `agent workspace ${workspaceReference.displayName}`
+    : worktreeReference
+      ? `managed worktree ${worktreeReference.name}`
+      : sessionReference
+        ? `session ${sessionReference[0]}`
+        : undefined;
+}
+
 export function createProjectsHandlers(service: ProjectWorktreeService): GatewayRequestHandlers {
   return {
     "projects.list": async ({ params, respond, context, client }) => {
@@ -555,15 +592,19 @@ export function createProjectsHandlers(service: ProjectWorktreeService): Gateway
       if (!assertValidParams(params, validateProjectsRemoveParams, "projects.remove", respond)) {
         return;
       }
-      const project = resolveProjectRegistry(context.getRuntimeConfig(), params.id);
-      if (!project || project.source === "workspace") {
+      const respondUnknownProject = () => {
         respond(
           false,
           undefined,
           errorShape(ErrorCodes.INVALID_REQUEST, `unknown project id: ${params.id}`),
         );
+      };
+      const project = resolveProjectRegistry(context.getRuntimeConfig(), params.id);
+      if (!project || project.source === "workspace") {
+        respondUnknownProject();
         return;
       }
+      let removed: boolean;
       if (params.deleteCheckout) {
         if (project.source !== "cloned") {
           respond(
@@ -576,56 +617,36 @@ export function createProjectsHandlers(service: ProjectWorktreeService): Gateway
           );
           return;
         }
-        const normalizedRoot = path.resolve(project.repoRoot);
-        const worktreeReference = listRegistryWorktrees(process.env).find(
-          (worktree) => !worktree.removedAt && path.resolve(worktree.repoRoot) === normalizedRoot,
-        );
-        const sessionReference = Object.entries(
-          loadCombinedSessionStoreForGatewayCore(context.getRuntimeConfig(), {
-            projection: "list",
-          }).store,
-        ).find(([, entry]) => {
-          if (entry.archivedAt) {
-            return false;
-          }
-          const sessionRoot = entry.worktree?.repoRoot;
-          if (sessionRoot && path.resolve(sessionRoot) === normalizedRoot) {
-            return true;
-          }
-          const cwd = entry.spawnedCwd;
-          return Boolean(
-            cwd &&
-            (path.resolve(cwd) === normalizedRoot ||
-              isPathInside(normalizedRoot, path.resolve(cwd))),
-          );
-        });
-        if (worktreeReference || sessionReference) {
-          const reference = worktreeReference
-            ? `managed worktree ${worktreeReference.name}`
-            : `session ${sessionReference?.[0]}`;
+        try {
+          removed = await removeClonedProjectCheckout(project, () => {
+            const reference = findProjectCheckoutReference(
+              context.getRuntimeConfig(),
+              project.repoRoot,
+            );
+            if (reference) {
+              throw new ProjectCheckoutError(
+                `Project checkout is still referenced by ${reference}. Remove that reference before deleting the checkout.`,
+              );
+            }
+          });
+        } catch (error) {
           respond(
             false,
             undefined,
             errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              `Project checkout is still referenced by ${reference}. Remove that reference before deleting the checkout.`,
+              error instanceof ProjectCheckoutError
+                ? ErrorCodes.INVALID_REQUEST
+                : ErrorCodes.UNAVAILABLE,
+              formatErrorMessage(error),
             ),
           );
           return;
         }
-        try {
-          await deleteClonedProjectCheckout(project);
-        } catch (error) {
-          respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatErrorMessage(error)));
-          return;
-        }
+      } else {
+        removed = removeProjectRegistry(params.id);
       }
-      if (!removeProjectRegistry(params.id)) {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, `unknown project id: ${params.id}`),
-        );
+      if (!removed) {
+        respondUnknownProject();
         return;
       }
       respond(true, { removed: true }, undefined);

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -332,8 +332,7 @@ describe("gateway server chat", () => {
     expect(res.payload?.status).toBe("ok");
     return res;
   };
-  const waitForAgentRunDrained = async (runId: string) => {
-    await waitForAgentRunOk(runId);
+  const waitForAgentRunDrained = async () => {
     await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   };
   const abortChatRun = async (runId: string) => {
@@ -395,7 +394,7 @@ describe("gateway server chat", () => {
       expect(res.ok).toBe(true);
       expect(res.payload?.runId).toBe("idem-sessions-send-1");
       expect(res.payload?.messageSeq).toBe(1);
-      await waitForAgentRunDrained("idem-sessions-send-1");
+      await waitForAgentRunDrained();
     } finally {
       testState.sessionStorePath = undefined;
       await removeTempDir(dir);
@@ -425,7 +424,7 @@ describe("gateway server chat", () => {
           storePath: testState.sessionStorePath,
         })?.sessionId,
       ).toBeTypeOf("string");
-      await waitForAgentRunDrained("idem-sessions-send-orion");
+      await waitForAgentRunDrained();
     } finally {
       testState.agentsConfig = undefined;
       testState.sessionStorePath = undefined;
@@ -454,7 +453,7 @@ describe("gateway server chat", () => {
       expect(res.ok).toBe(true);
       expect(res.payload?.runId).toBe("idem-sessions-steer-1");
       expect(res.payload?.messageSeq).toBe(1);
-      await waitForAgentRunDrained("idem-sessions-steer-1");
+      await waitForAgentRunDrained();
     } finally {
       testState.sessionStorePath = undefined;
       await removeTempDir(dir);
@@ -590,7 +589,7 @@ describe("gateway server chat", () => {
       idempotencyKey: "idem-sanitized-1",
     });
     expect(sanitizedRes.ok).toBe(true);
-    await waitForAgentRunDrained("idem-sanitized-1");
+    await waitForAgentRunDrained();
   });
 
   test("handles chat send and history flows", async () => {
@@ -620,7 +619,7 @@ describe("gateway server chat", () => {
         idempotencyKey: "idem-webchat-1",
       });
       expect(webchatRes.ok).toBe(true);
-      await waitForAgentRunDrained("idem-webchat-1");
+      await waitForAgentRunDrained();
 
       webchatWs.close();
       webchatWs = undefined;
@@ -633,7 +632,7 @@ describe("gateway server chat", () => {
       });
       expect(timeoutRes.ok).toBe(true);
       expect(timeoutRes.payload?.runId).toBe("idem-timeout-1");
-      await waitForAgentRunDrained("idem-timeout-1");
+      await waitForAgentRunDrained();
       testState.agentConfig = undefined;
 
       const sessionRes = await rpcReq(ws, "chat.send", {
@@ -643,7 +642,7 @@ describe("gateway server chat", () => {
       });
       expect(sessionRes.ok).toBe(true);
       expect(sessionRes.payload?.runId).toBe("idem-session-key-1");
-      await waitForAgentRunDrained("idem-session-key-1");
+      await waitForAgentRunDrained();
 
       const sendPolicyDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
       tempDirs.push(sendPolicyDir);
@@ -737,7 +736,7 @@ describe("gateway server chat", () => {
       });
       expect(imgRes.ok).toBe(true);
       expectStringRunId(imgRes.payload);
-      await waitForAgentRunDrained("idem-img");
+      await waitForAgentRunDrained();
       const imgOnlyRes = await rpcReq(ws, "chat.send", {
         sessionKey: "main",
         message: "",
@@ -753,7 +752,7 @@ describe("gateway server chat", () => {
       });
       expect(imgOnlyRes.ok).toBe(true);
       expectStringRunId(imgOnlyRes.payload);
-      await waitForAgentRunDrained("idem-img-only");
+      await waitForAgentRunDrained();
 
       const historyDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
       tempDirs.push(historyDir);

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -332,8 +332,9 @@ describe("gateway server chat", () => {
     expect(res.payload?.status).toBe("ok");
     return res;
   };
-  const waitForAgentRunDrained = async () => {
+  const waitForAgentRunDrained = async (runId: string) => {
     await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+    await waitForAgentRunOk(runId, 0);
   };
   const abortChatRun = async (runId: string) => {
     const res = await rpcReq(ws, "chat.abort", {
@@ -394,7 +395,7 @@ describe("gateway server chat", () => {
       expect(res.ok).toBe(true);
       expect(res.payload?.runId).toBe("idem-sessions-send-1");
       expect(res.payload?.messageSeq).toBe(1);
-      await waitForAgentRunDrained();
+      await waitForAgentRunDrained("idem-sessions-send-1");
     } finally {
       testState.sessionStorePath = undefined;
       await removeTempDir(dir);
@@ -424,7 +425,7 @@ describe("gateway server chat", () => {
           storePath: testState.sessionStorePath,
         })?.sessionId,
       ).toBeTypeOf("string");
-      await waitForAgentRunDrained();
+      await waitForAgentRunDrained("idem-sessions-send-orion");
     } finally {
       testState.agentsConfig = undefined;
       testState.sessionStorePath = undefined;
@@ -453,7 +454,7 @@ describe("gateway server chat", () => {
       expect(res.ok).toBe(true);
       expect(res.payload?.runId).toBe("idem-sessions-steer-1");
       expect(res.payload?.messageSeq).toBe(1);
-      await waitForAgentRunDrained();
+      await waitForAgentRunDrained("idem-sessions-steer-1");
     } finally {
       testState.sessionStorePath = undefined;
       await removeTempDir(dir);
@@ -589,7 +590,7 @@ describe("gateway server chat", () => {
       idempotencyKey: "idem-sanitized-1",
     });
     expect(sanitizedRes.ok).toBe(true);
-    await waitForAgentRunDrained();
+    await waitForAgentRunDrained("idem-sanitized-1");
   });
 
   test("handles chat send and history flows", async () => {
@@ -619,7 +620,7 @@ describe("gateway server chat", () => {
         idempotencyKey: "idem-webchat-1",
       });
       expect(webchatRes.ok).toBe(true);
-      await waitForAgentRunDrained();
+      await waitForAgentRunDrained("idem-webchat-1");
 
       webchatWs.close();
       webchatWs = undefined;
@@ -632,7 +633,7 @@ describe("gateway server chat", () => {
       });
       expect(timeoutRes.ok).toBe(true);
       expect(timeoutRes.payload?.runId).toBe("idem-timeout-1");
-      await waitForAgentRunDrained();
+      await waitForAgentRunDrained("idem-timeout-1");
       testState.agentConfig = undefined;
 
       const sessionRes = await rpcReq(ws, "chat.send", {
@@ -642,7 +643,7 @@ describe("gateway server chat", () => {
       });
       expect(sessionRes.ok).toBe(true);
       expect(sessionRes.payload?.runId).toBe("idem-session-key-1");
-      await waitForAgentRunDrained();
+      await waitForAgentRunDrained("idem-session-key-1");
 
       const sendPolicyDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
       tempDirs.push(sendPolicyDir);
@@ -736,7 +737,7 @@ describe("gateway server chat", () => {
       });
       expect(imgRes.ok).toBe(true);
       expectStringRunId(imgRes.payload);
-      await waitForAgentRunDrained();
+      await waitForAgentRunDrained("idem-img");
       const imgOnlyRes = await rpcReq(ws, "chat.send", {
         sessionKey: "main",
         message: "",
@@ -752,7 +753,7 @@ describe("gateway server chat", () => {
       });
       expect(imgOnlyRes.ok).toBe(true);
       expectStringRunId(imgOnlyRes.payload);
-      await waitForAgentRunDrained();
+      await waitForAgentRunDrained("idem-img-only");
 
       const historyDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
       tempDirs.push(historyDir);

--- a/src/projects/project-clone.ts
+++ b/src/projects/project-clone.ts
@@ -11,7 +11,9 @@ import { parseProjectGitUrl } from "./project-git-url.js";
 import {
   listProjectRegistry,
   registerClonedProjectRegistry,
+  removeProjectCheckoutReference,
   type ProjectRegistryRecord,
+  withProjectCheckoutLifecycle,
 } from "./project-registry.js";
 
 const PROJECT_CLONE_LEASE_MS = 30_000;
@@ -93,11 +95,10 @@ export async function materializeProjectClone(
   );
 }
 
-/** Deletes a checkout only when it still occupies its exact managed project slot. */
-export async function deleteClonedProjectCheckout(
+async function resolveClonedProjectCheckout(
   project: ProjectRegistryRecord,
   options: { env?: NodeJS.ProcessEnv } = {},
-): Promise<void> {
+): Promise<string> {
   if (project.source !== "cloned") {
     throw new ProjectCloneError(
       "clone_failed",
@@ -125,6 +126,31 @@ export async function deleteClonedProjectCheckout(
       "The cloned project is outside the Gateway-managed projects area, so its checkout was not deleted.",
     );
   }
-  await fs.rm(checkout, { recursive: true });
-  await fs.rmdir(path.dirname(checkout)).catch(() => {});
+  return checkout;
+}
+
+/** Removes one cloned-project reference and deletes its checkout only after the final reference. */
+export async function removeClonedProjectCheckout(
+  project: ProjectRegistryRecord,
+  assertUnreferenced: () => void | Promise<void>,
+  options: OpenClawStateDatabaseOptions & { env?: NodeJS.ProcessEnv } = {},
+): Promise<boolean> {
+  return await withProjectCheckoutLifecycle(project.repoRoot, options, async (lease) => {
+    const checkout = await resolveClonedProjectCheckout(project, options);
+    await assertUnreferenced();
+    const result = removeProjectCheckoutReference(project, lease, options);
+    if (result === "missing") {
+      return false;
+    }
+    if (result === "changed") {
+      throw new ProjectCloneError("clone_failed", "The cloned project changed before deletion.");
+    }
+    if (result === "remaining") {
+      return true;
+    }
+    lease.assertOwned();
+    await fs.rm(checkout, { recursive: true });
+    await fs.rmdir(path.dirname(checkout)).catch(() => {});
+    return true;
+  });
 }

--- a/src/projects/project-clone.ts
+++ b/src/projects/project-clone.ts
@@ -46,11 +46,6 @@ export async function materializeProjectClone(
       "Use a GitHub HTTPS or git@github.com repository URL. Local paths and file URLs are not accepted.",
     );
   }
-  const existing = existingCanonicalProject(input.cfg, parsed.url, options);
-  if (existing) {
-    return existing;
-  }
-
   const env = options.env ?? process.env;
   const fingerprint = sha256HexPrefixCore(parsed.url, 16);
   return await withOpenClawStateLease(
@@ -65,9 +60,24 @@ export async function materializeProjectClone(
       operationLabel: "projects.clone.lease",
     },
     async (lease) => {
-      const raced = existingCanonicalProject(input.cfg, parsed.url, options);
-      if (raced) {
-        return raced;
+      // Keep clone as the outer lease and take one candidate checkout lease at a time. A row that
+      // moves roots while we wait must be retried under its new root instead of returned stale.
+      while (true) {
+        const candidate = existingCanonicalProject(input.cfg, parsed.url, options);
+        if (!candidate) {
+          break;
+        }
+        const existing = await withProjectCheckoutLifecycle(
+          candidate.repoRoot,
+          options,
+          async () => {
+            const current = existingCanonicalProject(input.cfg, parsed.url, options);
+            return current?.repoRoot === candidate.repoRoot ? current : undefined;
+          },
+        );
+        if (existing) {
+          return existing;
+        }
       }
       const displayName = input.name?.trim() || parsed.name;
       const directoryName = slugifyWorktreeTitle(displayName) ?? "project";

--- a/src/projects/project-registry.test.ts
+++ b/src/projects/project-registry.test.ts
@@ -204,6 +204,52 @@ describe("project registry", () => {
     expect(listProjectRegistry({} as OpenClawConfig, options)).toHaveLength(2);
   });
 
+  it("serializes an existing cloned-project return with checkout deletion", async () => {
+    const root = tempDirs.make("openclaw-project-existing-delete-race-");
+    const stateDir = path.join(root, "state");
+    const originUrl = "https://github.com/acme/existing-delete-race.git";
+    const checkout = await initializeRepository(
+      path.join(stateDir, "projects", "0123456789abcdef"),
+      "existing-delete-race",
+    );
+    const options = {
+      path: path.join(stateDir, "openclaw.sqlite"),
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    };
+    const project = await registerClonedProjectRegistry(
+      { path: checkout, name: "Existing delete race", originUrl },
+      options,
+    );
+    const deletionReady = createDeferred();
+    const releaseDeletion = createDeferred();
+    const deletionError = new ProjectCheckoutError("keep the existing checkout");
+    const deletion = removeClonedProjectCheckout(
+      project,
+      async () => {
+        deletionReady.resolve();
+        await releaseDeletion.promise;
+        throw deletionError;
+      },
+      options,
+    );
+    await deletionReady.promise;
+
+    let additionSettled = false;
+    const addition = materializeProjectClone(
+      { cfg: {} as OpenClawConfig, gitUrl: originUrl },
+      options,
+    ).finally(() => {
+      additionSettled = true;
+    });
+    await Promise.resolve();
+    expect(additionSettled).toBe(false);
+
+    releaseDeletion.resolve();
+    await expect(deletion).rejects.toBe(deletionError);
+    await expect(addition).resolves.toEqual(project);
+    await expect(fs.stat(checkout)).resolves.toBeDefined();
+  });
+
   it("serializes registration with the final managed-checkout deletion boundary", async () => {
     const root = tempDirs.make("openclaw-project-delete-race-");
     const stateDir = path.join(root, "state");

--- a/src/projects/project-registry.test.ts
+++ b/src/projects/project-registry.test.ts
@@ -4,6 +4,7 @@ import http from "node:http";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
@@ -12,7 +13,7 @@ import {
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { cloneProjectCheckout, ProjectCloneError } from "./project-clone-runtime.js";
-import { materializeProjectClone } from "./project-clone.js";
+import { materializeProjectClone, removeClonedProjectCheckout } from "./project-clone.js";
 import { parseProjectGitUrl } from "./project-git-url.js";
 import {
   listProjectRegistry,
@@ -96,7 +97,7 @@ describe("project registry", () => {
     expect(rows).toEqual([{ name: "projects" }]);
   });
 
-  it("registers, orders, resolves real paths, suffixes collisions, and removes rows", async () => {
+  it("registers, orders, resolves real paths, deduplicates roots, and removes rows", async () => {
     const root = tempDirs.make("openclaw-project-roundtrip-");
     const repo = await initializeRepository(root, "openclaw");
     const alias = path.join(root, "repo-link");
@@ -111,7 +112,7 @@ describe("project registry", () => {
       repoRoot: repo,
       source: "registered",
     });
-    expect(second.id).toBe("openclaw-2");
+    expect(second).toEqual(first);
 
     const cfg = {
       agents: {
@@ -124,8 +125,20 @@ describe("project registry", () => {
     expect(listProjectRegistry(cfg, options).map((project) => project.displayName)).toEqual([
       "alpha",
       "OpenClaw",
-      "OpenClaw",
       "zeta",
+    ]);
+    const sharedWorkspaceCfg = {
+      agents: {
+        list: [
+          { id: "main", default: true, workspace: repo },
+          { id: "work", workspace: repo },
+        ],
+      },
+    } as OpenClawConfig;
+    expect(listProjectRegistry(sharedWorkspaceCfg, options).map((project) => project.id)).toEqual([
+      "openclaw",
+      "workspace:main",
+      "workspace:work",
     ]);
     expect(removeProjectRegistry(first.id, options)).toBe(true);
     expect(removeProjectRegistry(first.id, options)).toBe(false);
@@ -189,6 +202,61 @@ describe("project registry", () => {
 
     expect(added).toEqual(registered);
     expect(listProjectRegistry({} as OpenClawConfig, options)).toHaveLength(2);
+  });
+
+  it("serializes registration with the final managed-checkout deletion boundary", async () => {
+    const root = tempDirs.make("openclaw-project-delete-race-");
+    const stateDir = path.join(root, "state");
+    const originUrl = "https://github.com/acme/delete-race.git";
+    const checkout = await initializeRepository(
+      path.join(stateDir, "projects", "0123456789abcdef"),
+      "delete-race",
+    );
+    const options = {
+      path: path.join(stateDir, "openclaw.sqlite"),
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    };
+    const project = await registerClonedProjectRegistry(
+      { path: checkout, name: "Delete race", originUrl },
+      options,
+    );
+    const deletionReady = createDeferred();
+    const releaseDeletion = createDeferred();
+    const deletion = removeClonedProjectCheckout(
+      project,
+      async () => {
+        deletionReady.resolve();
+        await releaseDeletion.promise;
+      },
+      options,
+    );
+    await deletionReady.promise;
+
+    let registrationSettled = false;
+    const registration = registerProjectRegistry(
+      { path: checkout, name: "Raced registration" },
+      options,
+    ).then(
+      (value) => {
+        registrationSettled = true;
+        return { value };
+      },
+      (error: unknown) => {
+        registrationSettled = true;
+        return { error };
+      },
+    );
+    await Promise.resolve();
+    expect(registrationSettled).toBe(false);
+
+    releaseDeletion.resolve();
+    await expect(deletion).resolves.toBe(true);
+    const registrationResult = await registration;
+    expect(registrationResult).toMatchObject({ error: expect.any(ProjectCheckoutError) });
+    expect(listProjectRegistry({} as OpenClawConfig, options)).toEqual([
+      expect.objectContaining({ source: "workspace" }),
+    ]);
+    await expect(fs.stat(checkout)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("classifies authentication failures without returning credential material", async () => {

--- a/src/projects/project-registry.ts
+++ b/src/projects/project-registry.ts
@@ -17,6 +17,10 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import {
+  type OpenClawStateLeaseContext,
+  withOpenClawStateLease,
+} from "../state/openclaw-state-lease.js";
 
 export type ProjectRegistryRecord = {
   id: string;
@@ -32,6 +36,8 @@ type ProjectRow = Selectable<OpenClawStateKyselyDatabase["projects"]>;
 
 const ensuredDatabases = new WeakSet<DatabaseSync>();
 const PROJECT_ID_MAX_LENGTH = 64;
+const PROJECT_CHECKOUT_LEASE_MS = 30_000;
+const PROJECT_CHECKOUT_WAIT_MS = 30_000;
 const PROJECTS_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS projects (
   id TEXT NOT NULL PRIMARY KEY,
@@ -91,11 +97,20 @@ function insertProjectRegistry(
     source: "registered" | "cloned";
   },
   options: OpenClawStateDatabaseOptions,
+  lease: OpenClawStateLeaseContext,
 ): ProjectRegistryRecord {
   ensureProjectRegistrySchema(options);
   return runOpenClawStateWriteTransaction(
     ({ db: sqlite }) => {
+      lease.assertOwnedInTransaction(sqlite);
       const db = getNodeSqliteKysely<ProjectsDatabase>(sqlite);
+      const sameRoot = executeSqliteQueryTakeFirstSync(
+        sqlite,
+        db.selectFrom("projects").selectAll().where("repo_root", "=", input.repoRoot),
+      );
+      if (sameRoot) {
+        return rowToProject(sameRoot);
+      }
       if (input.source === "cloned" && input.originUrl) {
         const duplicate = executeSqliteQueryTakeFirstSync(
           sqlite,
@@ -127,6 +142,25 @@ function insertProjectRegistry(
     },
     options,
     { operationLabel: "projects.registry.insert" },
+  );
+}
+
+export async function withProjectCheckoutLifecycle<T>(
+  repoRoot: string,
+  options: OpenClawStateDatabaseOptions,
+  run: (lease: OpenClawStateLeaseContext) => Promise<T>,
+): Promise<T> {
+  return await withOpenClawStateLease(
+    {
+      scope: "projects.checkout",
+      key: repoRoot,
+      database: { scope: "shared", options },
+      leaseMs: PROJECT_CHECKOUT_LEASE_MS,
+      waitMs: PROJECT_CHECKOUT_WAIT_MS,
+      leaseLabel: "project checkout lease",
+      operationLabel: "projects.checkout.lease",
+    },
+    run,
   );
 }
 
@@ -199,37 +233,49 @@ export async function resolveProjectCheckout(projectPath: string): Promise<{
   return { path: requested, repoRoot, ...(originUrl ? { originUrl } : {}) };
 }
 
-export async function registerProjectRegistry(
-  input: { path: string; name?: string },
+async function registerResolvedProject(
+  input: {
+    path: string;
+    name?: string;
+    originUrl?: string;
+    source: "registered" | "cloned";
+  },
   options: OpenClawStateDatabaseOptions = {},
 ): Promise<ProjectRegistryRecord> {
   const checkout = await resolveProjectCheckout(input.path);
   const displayName = input.name?.trim() || path.basename(checkout.repoRoot) || "Project";
-  return insertProjectRegistry(
-    {
-      displayName,
-      repoRoot: checkout.repoRoot,
-      originUrl: checkout.originUrl,
-      source: "registered",
-    },
-    options,
-  );
+  return await withProjectCheckoutLifecycle(checkout.repoRoot, options, async (lease) => {
+    // A deletion may have won the lease after the first canonicalization. Revalidate under the
+    // lifecycle owner so a stale registration cannot recreate a row for the removed checkout.
+    const current = await resolveProjectCheckout(checkout.repoRoot);
+    if (current.repoRoot !== checkout.repoRoot) {
+      throw new ProjectCheckoutError(`project checkout changed while registering: ${input.path}`);
+    }
+    return insertProjectRegistry(
+      {
+        displayName,
+        repoRoot: checkout.repoRoot,
+        originUrl: input.originUrl ?? checkout.originUrl,
+        source: input.source,
+      },
+      options,
+      lease,
+    );
+  });
+}
+
+export async function registerProjectRegistry(
+  input: { path: string; name?: string },
+  options: OpenClawStateDatabaseOptions = {},
+): Promise<ProjectRegistryRecord> {
+  return await registerResolvedProject({ ...input, source: "registered" }, options);
 }
 
 export async function registerClonedProjectRegistry(
   input: { path: string; name: string; originUrl: string },
   options: OpenClawStateDatabaseOptions = {},
 ): Promise<ProjectRegistryRecord> {
-  const checkout = await resolveProjectCheckout(input.path);
-  return insertProjectRegistry(
-    {
-      displayName: input.name,
-      repoRoot: checkout.repoRoot,
-      originUrl: input.originUrl,
-      source: "cloned",
-    },
-    options,
-  );
+  return await registerResolvedProject({ ...input, source: "cloned" }, options);
 }
 
 export function listProjectRegistry(
@@ -259,6 +305,38 @@ export function resolveProjectRegistry(
     kysely.selectFrom("projects").selectAll().where("id", "=", id),
   );
   return row ? rowToProject(row) : undefined;
+}
+
+export function removeProjectCheckoutReference(
+  project: ProjectRegistryRecord,
+  lease: OpenClawStateLeaseContext,
+  options: OpenClawStateDatabaseOptions = {},
+): "missing" | "changed" | "remaining" | "final" {
+  ensureProjectRegistrySchema(options);
+  return runOpenClawStateWriteTransaction(
+    ({ db: sqlite }) => {
+      lease.assertOwnedInTransaction(sqlite);
+      const db = getNodeSqliteKysely<ProjectsDatabase>(sqlite);
+      const current = executeSqliteQueryTakeFirstSync(
+        sqlite,
+        db.selectFrom("projects").selectAll().where("id", "=", project.id),
+      );
+      if (!current) {
+        return "missing";
+      }
+      if (current.source !== "cloned" || current.repo_root !== project.repoRoot) {
+        return "changed";
+      }
+      executeSqliteQuerySync(sqlite, db.deleteFrom("projects").where("id", "=", project.id));
+      const sibling = executeSqliteQueryTakeFirstSync(
+        sqlite,
+        db.selectFrom("projects").select("id").where("repo_root", "=", project.repoRoot),
+      );
+      return sibling ? "remaining" : "final";
+    },
+    options,
+    { operationLabel: "projects.registry.checkout-reference.remove" },
+  );
 }
 
 export async function resolveRecordedProjectRoot(

--- a/src/projects/project-registry.ts
+++ b/src/projects/project-registry.ts
@@ -330,9 +330,29 @@ export function removeProjectCheckoutReference(
       executeSqliteQuerySync(sqlite, db.deleteFrom("projects").where("id", "=", project.id));
       const sibling = executeSqliteQueryTakeFirstSync(
         sqlite,
-        db.selectFrom("projects").select("id").where("repo_root", "=", project.repoRoot),
+        db
+          .selectFrom("projects")
+          .selectAll()
+          .where("repo_root", "=", project.repoRoot)
+          .orderBy("id", "asc"),
       );
-      return sibling ? "remaining" : "final";
+      if (!sibling) {
+        return "final";
+      }
+      if (sibling.source === "registered") {
+        executeSqliteQuerySync(
+          sqlite,
+          db
+            .updateTable("projects")
+            .set({
+              source: "cloned",
+              origin_url: sibling.origin_url ?? current.origin_url,
+              updated_at_ms: Date.now(),
+            })
+            .where("id", "=", sibling.id),
+        );
+      }
+      return "remaining";
     },
     options,
     { operationLabel: "projects.registry.checkout-reference.remove" },


### PR DESCRIPTION
Closes #125976

## What Problem This Solves

Fixes an issue where removing one managed project could delete its physical checkout while another selectable project registration still referenced the same canonical repository root. The surviving project then pointed at a directory that no longer existed.

## Why This Change Was Made

Project registration and managed-checkout deletion now share a lifecycle lease keyed by the canonical repository root. Every return of an existing canonical project is serialized under that checkout lifecycle and re-read before it can be returned, while the clone lease remains the outer operation boundary. Registration deduplicates canonical roots transactionally, and deletion removes one registry reference and re-reads sibling rows immediately before physically deleting only the final managed checkout.

For legacy mixed registered/cloned rows, the removal transaction transfers managed ownership and the clone origin to the surviving registered sibling. That keeps the checkout selectable while it is referenced and preserves a later path to final managed-checkout cleanup. Existing workspace, worktree, and session protections remain in place. No SQLite schema version changes are required.

The Gateway chat test helper now drains canonical root work first, then retains the successful terminal assertion through a nonblocking `agent.wait(..., 0)`. This prevents the known compact-shard cleanup cascade without weakening the acceptance-path outcome check.

## User Impact

Operators can safely remove duplicate or overlapping managed project entries without invalidating the remaining project. Concurrent add/remove operations cannot return a selectable project whose checkout has just been deleted, and legacy mixed-source registrations do not strand a managed checkout after the final usable reference is removed.

## Evidence

- `node scripts/run-vitest.mjs src/projects/project-registry.test.ts src/gateway/server-methods/projects.test.ts` — 24 registry tests and 12 Gateway project RPC tests passed after the final rebase.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts` — 55/55 passed serially after the final rebase.
- `node scripts/run-vitest.mjs src/gateway/server-methods/chat-send-dispatch-errors.test.ts src/process/gateway-work-admission.test.ts` — the cleanup-owner suites passed 5/5 and 18/18 on the reviewed working tree.
- Fresh Blacksmith Testbox reproduction against the actual synthetic merge baseline: 161 passed / 2 failed before the cleanup synchronization.
- The repaired exact 24-file compact shard passed 399/399 on Blacksmith Testbox for the retained project/Gateway candidate.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo` and `node scripts/run-tsgo-core-test-shards.mjs` passed after the final rebase.
- Targeted Oxfmt and Oxlint passed for the reviewed changed files.
- `pnpm check:import-cycles` — zero runtime value cycles.
- `node scripts/check-native-state-schema-version.mjs` — schema remains v9.
- `git diff --check` passed.
- Fresh branch autoreview against `origin/main` reported no accepted/actionable findings (overall correctness 0.97).
- Production LOC: +233/-78 (net +155); tests: +203/-5 (net +198). The production growth establishes the canonical checkout lifecycle ownership boundary, including serialized existing-project returns and transferable legacy managed ownership; the test growth protects the project lifecycle races and successful Gateway terminal outcomes.

AI-assisted: implementation and review were performed with coding agents under maintainer supervision.
