### PR TITLE
fix(plugins): keep default slots implicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Plugin slot persistence:** keep default memory and context-engine selections implicit during install, uninstall, and update recovery so redundant default pins cannot fail validation while their plugin lifecycle commit is in progress.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Plugin slot persistence:** keep default memory and context-engine selections implicit during install, uninstall, and update recovery so redundant default pins cannot fail validation while their plugin lifecycle commit is in progress.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.

--- a/src/plugins/plugin-package-update.test.ts
+++ b/src/plugins/plugin-package-update.test.ts
@@ -116,7 +116,6 @@ describe("plugin package update policy reconciliation", () => {
       deny: ["other-denied"],
       entries: { "pack/one": { enabled: true }, other: { enabled: true } },
       load: { paths: ["/plugins/unrelated.js"] },
-      slots: { memory: "memory-core", contextEngine: "legacy" },
     });
     expect(result.config.channels).toEqual({
       shared: { enabled: true },

--- a/src/plugins/slots.test.ts
+++ b/src/plugins/slots.test.ts
@@ -16,7 +16,7 @@ describe("resetPluginSlotsToDefaults", () => {
         { memory: "dual-plugin", contextEngine: "dual-plugin" },
         "dual-plugin",
       ),
-    ).toEqual({ memory: "memory-core", contextEngine: "legacy" });
+    ).toBeUndefined();
   });
 
   it("preserves slot state when the plugin owns no slot", () => {
@@ -86,6 +86,47 @@ describe("applyExclusiveSlotSelection", () => {
     expect(result.changed).toBe(false);
     expect(result.warnings).toHaveLength(0);
   }
+
+  it("keeps the default memory selection implicit", () => {
+    const config: OpenClawConfig = {
+      plugins: { entries: { "memory-core": { enabled: true } } },
+    };
+
+    const result = applyExclusiveSlotSelection({
+      config,
+      selectedId: "memory-core",
+      selectedKind: "memory",
+      registry: { plugins: [{ id: "memory-core", kind: "memory" }] },
+    });
+
+    expectUnchangedSelection(result);
+    expect(result.config).toBe(config);
+  });
+
+  it("removes an explicit override when selecting the default memory plugin", () => {
+    const config: OpenClawConfig = {
+      plugins: {
+        slots: { memory: "memory" },
+        entries: { memory: { enabled: true }, "memory-core": { enabled: true } },
+      },
+    };
+
+    const result = applyExclusiveSlotSelection({
+      config,
+      selectedId: "memory-core",
+      selectedKind: "memory",
+      registry: {
+        plugins: [
+          { id: "memory", kind: "memory" },
+          { id: "memory-core", kind: "memory" },
+        ],
+      },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.slots?.memory).toBeUndefined();
+    expect(result.config.plugins?.entries?.memory?.enabled).toBe(false);
+  });
 
   function buildSelectionRegistry(
     plugins: ReadonlyArray<{ id: string; kind?: PluginKind | PluginKind[] }>,

--- a/src/plugins/slots.ts
+++ b/src/plugins/slots.ts
@@ -94,7 +94,7 @@ export function resolveSlotSelection(slotKey: PluginSlotKey, value: unknown): Sl
   return normalized === null ? { kind: "off" } : { kind: "pinned", pluginId: normalized };
 }
 
-/** Resets every slot currently owned by a plugin to that slot's implicit default. */
+/** Resets every slot currently owned by a plugin to its implicit default. */
 export function resetPluginSlotsToDefaults(
   slots: PluginSlotsConfig | undefined,
   pluginId: string,
@@ -108,10 +108,13 @@ export function resetPluginSlotsToDefaults(
     if (slots[slotKey] !== pluginId) {
       continue;
     }
-    next[slotKey] = defaultSlotIdForKey(slotKey);
+    delete next[slotKey];
     changed = true;
   }
-  return changed ? next : slots;
+  if (!changed) {
+    return slots;
+  }
+  return Object.keys(next).length === 0 ? undefined : next;
 }
 
 type SlotSelectionResult = {
@@ -140,7 +143,13 @@ export function applyExclusiveSlotSelection(params: {
 
   for (const slotKey of slotKeys) {
     const prevSlot = slots[slotKey];
-    slots[slotKey] = params.selectedId;
+    const nextSlot =
+      params.selectedId === defaultSlotIdForKey(slotKey) ? undefined : params.selectedId;
+    if (nextSlot === undefined) {
+      delete slots[slotKey];
+    } else {
+      slots[slotKey] = nextSlot;
+    }
 
     const inferredPrevSlot = prevSlot ?? defaultSlotIdForKey(slotKey);
     if (inferredPrevSlot && inferredPrevSlot !== params.selectedId) {
@@ -183,7 +192,7 @@ export function applyExclusiveSlotSelection(params: {
       );
     }
 
-    if (prevSlot !== params.selectedId || disabledIds.length > 0) {
+    if (prevSlot !== nextSlot || disabledIds.length > 0) {
       anyChanged = true;
     }
   }

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -389,7 +389,6 @@ describe("planPluginUninstall package ownership", () => {
     expect(result.config.plugins).toEqual({
       allow: ["other"],
       entries: { other: { enabled: true } },
-      slots: { memory: "memory-core" },
     });
     expect(result.actions).toMatchObject({
       entry: true,
@@ -586,7 +585,7 @@ describe("removePluginFromConfig", () => {
         },
       }),
       pluginId: "memory-plugin",
-      expectedMemory: "memory-core",
+      expectedMemory: undefined,
       expectedChanged: true,
     },
     {
@@ -620,7 +619,7 @@ describe("removePluginFromConfig", () => {
 
     const { config: result, actions } = removePluginFromConfig(config, "context-plugin");
 
-    expect(result.plugins?.slots?.contextEngine).toBe("legacy");
+    expect(result.plugins?.slots?.contextEngine).toBeUndefined();
     expect(actions.contextEngineSlot).toBe(true);
   });
 
@@ -979,7 +978,7 @@ describe("uninstallPlugin", () => {
     });
     expect(successfulResult.config.plugins?.allow).toEqual(["other-plugin"]);
     expect(successfulResult.config.plugins?.deny).toBeUndefined();
-    expect(successfulResult.config.plugins?.slots?.memory).toBe("memory-core");
+    expect(successfulResult.config.plugins?.slots?.memory).toBeUndefined();
     expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
   });
 
@@ -1090,10 +1089,6 @@ describe("uninstallPlugin", () => {
       expectedConfig: {
         plugins: {
           allow: ["other-plugin"],
-          slots: {
-            memory: "memory-core",
-            contextEngine: "legacy",
-          },
         },
       },
     },

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2374,10 +2374,7 @@ describe("updateNpmInstalledPlugins", () => {
     });
     expect(result.config.plugins?.allow).toEqual(["lossless-claw", "keep"]);
     expect(result.config.plugins?.deny).toEqual(["lossless-claw", "blocked"]);
-    expect(result.config.plugins?.slots).toEqual({
-      memory: "memory-core",
-      contextEngine: "legacy",
-    });
+    expect(result.config.plugins?.slots).toBeUndefined();
     expect(result.outcomes).toEqual([
       {
         pluginId: "lossless-claw",
@@ -3002,10 +2999,7 @@ describe("updateNpmInstalledPlugins", () => {
     });
     expect(result.config.plugins?.allow).toEqual(["demo", "other"]);
     expect(result.config.plugins?.deny).toEqual(["blocked"]);
-    expect(result.config.plugins?.slots).toEqual({
-      memory: "memory-core",
-      contextEngine: "legacy",
-    });
+    expect(result.config.plugins?.slots).toBeUndefined();
     expect(result.config.plugins?.installs?.demo).toEqual(config.plugins.installs.demo);
     expect(result.outcomes).toEqual([
       {
@@ -3173,9 +3167,7 @@ describe("updateNpmInstalledPlugins", () => {
       config: { preserved: true },
     });
     expect(result.config.plugins?.allow).toEqual(["demo"]);
-    expect(result.config.plugins?.slots).toEqual({
-      memory: "memory-core",
-    });
+    expect(result.config.plugins?.slots).toBeUndefined();
     const message =
       'Disabled "demo" after plugin update failure; OpenClaw will continue without it. Failed to update demo: ClawHub blocked this release; update was not started. (ClawHub clawhub:demo).';
     expect(warn).toHaveBeenCalledWith(message);

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2474,7 +2474,7 @@ describe("updateNpmInstalledPlugins", () => {
     });
     expect(result.config.plugins?.allow).toEqual(["demo", "other"]);
     expect(result.config.plugins?.deny).toEqual(["demo", "blocked"]);
-    expect(result.config.plugins?.slots?.memory).toBe("memory-core");
+    expect(result.config.plugins?.slots?.memory).toBeUndefined();
     expect(result.outcomes).toEqual([
       {
         pluginId: "demo",
@@ -3140,7 +3140,7 @@ describe("updateNpmInstalledPlugins", () => {
       config: { preserved: true },
     });
     expect(result.config.plugins?.allow).toEqual(["demo"]);
-    expect(result.config.plugins?.slots?.memory).toBe("memory-core");
+    expect(result.config.plugins?.slots?.memory).toBeUndefined();
     expect(result.outcomes).toEqual([
       {
         pluginId: "demo",


### PR DESCRIPTION
## Summary

- keep default memory and context-engine plugin selections in their canonical implicit form
- remove explicit slot overrides when uninstall/update recovery returns to a default
- cover fresh default selection and switching back from an explicit alternative

## Root cause

Slot policy defines an omitted slot as owned by its default plugin (`memory-core` for memory and `legacy` for context engine), but selection/reset paths persisted those same defaults as explicit config values. During bundled `memory-core` install, slot selection therefore introduced `plugins.slots.memory: memory-core` before the config/install lifecycle commit had completed. Strict validation treated that redundant pin as a user-authored dependency and failed the install with `plugins.slots.memory: plugin not found: memory-core`.

The canonical owner fix is to avoid materializing an inferred default. Selecting a non-default remains explicit; selecting or resetting to the default deletes the override. This also removes the same redundant pins from uninstall and failed-update recovery instead of leaving future startup dependent on discovery of an implicit default.

## Evidence

The deterministic failure reproduced independently at the same selected source SHA in two workflows:

- plugin prerelease shard 4: https://github.com/openclaw/openclaw/actions/runs/32173558917/job/95833804051
- full release plugins/runtime install B: https://github.com/openclaw/openclaw/actions/runs/32173561938/job/95832527481
- selected source SHA: `97a4d324f5c8f32b9c106d6a6e9ed33c180a5fcb`

Both pass the preceding Azure Speech lifecycle and fail at `plugins install memory-core` with the exact explicit-slot validation error. The regression tests protect the observable config invariant and fail against pre-fix slot policy.

No local tests, builds, formatting, or dependency setup were run, per release-validation policy. Exact-head GitHub CI and targeted bundled-plugin shard 4 are the proof path.

## Scope

- production: +14/-5, net +9 in the canonical slot-policy owner
- tests: +47/-12 across slot, uninstall, update, and package-update behavior
- changelog: 0 (the release-owned entry was removed per review)
- no new config, protocol, storage, or public API surface

Agent transcript omitted.

Exact-head targeted bundled-plugin shard 4 proof for `09afd8c56d185b97f76d155d9c782571df1e6eed`: https://github.com/openclaw/openclaw/actions/runs/32188259509. The same lane passed on the immediately preceding behavior-identical head before the review-requested changelog-only cleanup: https://github.com/openclaw/openclaw/actions/runs/32186431092. An intervening dispatch used a mistyped non-existent SHA and never reached tests.
