### PR TITLE
fix(test): restore packaged Doctor E2E fixture

### DIFF
--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -506,7 +506,7 @@ describe("cli json stdout contract", () => {
         const memoryCoreDir = path.join(bundledPluginsDir, "memory-core");
         await fs.mkdir(memoryCoreDir, { recursive: true });
         await fs.writeFile(
-          path.join(memoryCoreDir, "api.js"),
+          path.join(memoryCoreDir, "doctor-health-api.js"),
           [
             "export function registerMemoryCoreDoctorChecks(host) {",
             "  host.registerHealthCheck({",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the packaged CLI Doctor E2E failed before it could verify structured JSON output, because its synthetic Memory Core package no longer exposed the public surface Doctor loads.

## Why This Change Was Made

#125492 narrowed Memory Core health-check loading from the broad `api.js` surface to `doctor-health-api.js`. The E2E fixture now publishes its existing `registerMemoryCoreDoctorChecks` stub under that same documented public artifact name.

No production behavior, compatibility path, or plugin package output changes.

## User Impact

No runtime behavior changes. Release repo-E2E validation once again exercises packaged Doctor JSON output instead of failing on a stale synthetic package layout.

## Evidence

- Before: [release repo-E2E job](https://github.com/openclaw/openclaw/actions/runs/32173561938/job/95832020762) failed `test/cli-json-stdout.e2e.test.ts` with `Unable to resolve bundled plugin public surface memory-core/doctor-health-api.js`.
- Runtime owner: `src/flows/bundled-health-checks.ts` has required `doctor-health-api.js` since #125492; the fixture still wrote `api.js`.
- Exact-head GitHub CI: [run 32185184377](https://github.com/openclaw/openclaw/actions/runs/32185184377) passed at `76994f2c9d90c5a9ffdc894b09c3057061d0f7c6`.
- Exact-head packaged OpenShell repo E2E: [run 32186571978](https://github.com/openclaw/openclaw/actions/runs/32186571978), [target job 95874115759](https://github.com/openclaw/openclaw/actions/runs/32186571978/job/95874115759) passed at the same head.
- Local validation was intentionally not run per release-validation instructions.
- Production LOC delta: 0. Test delta: +1/-1.
