### PR TITLE
fix(codex): report native project docs truthfully

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -266,6 +266,10 @@ This byte budget is separate from the character-based workspace bootstrap
 limits configured through `agents.defaults.bootstrapMaxChars` and
 `agents.defaults.bootstrapTotalMaxChars`.
 
+`/context` reports native project documents as unverified because app-server
+exposes their source paths but not the retained byte counts needed to tell
+whether any individual file was fully loaded or truncated.
+
 ### Compaction
 
 Do not set `compaction.model` or `compaction.provider` on Codex-backed

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -459,12 +459,23 @@ function buildCodexBootstrapInjectionStats(params: {
       ? undefined
       : (readCodexIndexedContextFileContent(injectedIndex, pathValue, fileName) ??
         readCodexIndexedContextFileContent(developerInstructionIndex, pathValue, fileName));
-    let injectedChars = memoryToolRoutedFile ? 0 : (injected?.length ?? 0);
-    let truncated = memoryToolRoutedFile ? false : !file.missing && injectedChars < rawChars;
-    if (injected === undefined && CODEX_NATIVE_PROJECT_DOC_BASENAMES.has(baseName)) {
-      injectedChars = rawChars;
-      truncated = false;
+    if (
+      !file.missing &&
+      injected === undefined &&
+      CODEX_NATIVE_PROJECT_DOC_BASENAMES.has(baseName)
+    ) {
+      return {
+        name: displayName,
+        path: pathValue,
+        missing: false,
+        rawChars,
+        injectionStatus: "native_unverified",
+        injectedChars: null,
+        truncated: null,
+      };
     }
+    const injectedChars = memoryToolRoutedFile ? 0 : (injected?.length ?? 0);
+    const truncated = memoryToolRoutedFile ? false : !file.missing && injectedChars < rawChars;
     return {
       name: displayName,
       path: pathValue,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3879,8 +3879,9 @@ describe("runCodexAppServerAttempt", () => {
     });
     expect(fileStats.get("AGENTS.md")).toMatchObject({
       rawChars: agentsGuidance.length,
-      injectedChars: agentsGuidance.length,
-      truncated: false,
+      injectionStatus: "native_unverified",
+      injectedChars: null,
+      truncated: null,
     });
   });
   it("adds memory recall guidance when dated memory notes exist without root MEMORY.md", async () => {
@@ -4012,7 +4013,7 @@ describe("runCodexAppServerAttempt", () => {
     const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("turn/start");
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await run;
+    const result = await run;
 
     const threadStart = harness.requests.find((request) => request.method === "thread/start");
     if (!threadStart) {
@@ -4037,6 +4038,14 @@ describe("runCodexAppServerAttempt", () => {
       ).collaborationMode?.settings?.developer_instructions ?? "";
     expect(collaborationInstructions).toContain(soulGuidance);
     expect(collaborationInstructions).not.toContain(agentsGuidance);
+    const agentWorkspaceStats = result.systemPromptReport?.injectedWorkspaceFiles.find(
+      (file) => file.path === path.join(agentWorkspaceDir, "AGENTS.md"),
+    );
+    expect(agentWorkspaceStats).toMatchObject({
+      rawChars: agentsGuidance.length,
+      injectedChars: agentsGuidance.length,
+      truncated: false,
+    });
 
     const updatedGuidance = "Updated AGENTS guidance must wait for a new session.";
     await fs.writeFile(path.join(agentWorkspaceDir, "AGENTS.md"), updatedGuidance);

--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -30,6 +30,7 @@ function makeParams(
     storePath?: string;
     agentId?: string;
     currentTurn?: NonNullable<SessionEntry["systemPromptReport"]>["currentTurn"];
+    nativeUnverified?: boolean;
   },
 ): HandleCommandsParams {
   const totalTokensFresh = options?.totalTokensFresh ?? true;
@@ -68,16 +69,28 @@ function makeParams(
           nonProjectContextChars: 500,
         },
         ...(options?.currentTurn ? { currentTurn: options.currentTurn } : {}),
-        injectedWorkspaceFiles: [
-          {
-            name: "AGENTS.md",
-            path: "/tmp/workspace/AGENTS.md",
-            missing: false,
-            rawChars: truncated ? 200_000 : 10_000,
-            injectedChars: truncated ? 12_000 : 10_000,
-            truncated,
-          },
-        ],
+        injectedWorkspaceFiles: options?.nativeUnverified
+          ? [
+              {
+                name: "AGENTS.md",
+                path: "/tmp/workspace/AGENTS.md",
+                missing: false,
+                rawChars: 10_000,
+                injectionStatus: "native_unverified",
+                injectedChars: null,
+                truncated: null,
+              },
+            ]
+          : [
+              {
+                name: "AGENTS.md",
+                path: "/tmp/workspace/AGENTS.md",
+                missing: false,
+                rawChars: truncated ? 200_000 : 10_000,
+                injectedChars: truncated ? 12_000 : 10_000,
+                truncated,
+              },
+            ],
         skills: {
           promptChars: 10,
           entries: [{ name: "checks", blockChars: 10 }],
@@ -155,6 +168,21 @@ describe("buildContextReply", () => {
   it("does not show bootstrap truncation warning when there is no truncation", async () => {
     const result = await buildContextReply(makeParams("/context list", false));
     expect(result.text).not.toContain("Bootstrap context is over configured limits");
+  });
+
+  it("reports native Codex project docs as unverified without OpenClaw limit advice", async () => {
+    const result = await buildContextReply(
+      makeParams("/context detail", false, { nativeUnverified: true }),
+    );
+
+    expect(result.text).toContain(
+      "- AGENTS.md: NATIVE/UNVERIFIED | raw(local) 10,000 chars (~2,500 tok) | injected unknown",
+    );
+    expect(result.text).toContain("one aggregate root-to-CWD byte budget");
+    expect(result.text).toContain("later AGENTS.md files can be partial");
+    expect(result.text).toContain("read the relevant scoped file directly");
+    expect(result.text).not.toContain("Bootstrap context is over configured limits");
+    expect(result.text).not.toContain("agents.entries.*.bootstrapMaxChars");
   });
 
   it("falls back to config defaults when legacy reports are missing bootstrap limits", async () => {
@@ -352,6 +380,24 @@ describe("buildContextReply", () => {
       expect(png.subarray(12, 16).toString("ascii")).toBe("IHDR");
       expect(png.readUInt32BE(16)).toBe(1280);
       expect(png.readUInt32BE(20)).toBe(860);
+    } finally {
+      await unlink(result.mediaUrl);
+    }
+  });
+
+  it("omits unknown native project-document bytes from context maps", async () => {
+    const result = await buildContextReply(
+      makeParams("/context map", false, {
+        contextTokens: 8_192,
+        totalTokens: 900,
+        nativeUnverified: true,
+      }),
+    );
+    if (!result.mediaUrl) {
+      throw new Error("missing context map media path");
+    }
+    try {
+      expect(result.text).toContain("Tracked: 1,020 chars");
     } finally {
       await unlink(result.mediaUrl);
     }

--- a/src/auto-reply/reply/commands-context-report.ts
+++ b/src/auto-reply/reply/commands-context-report.ts
@@ -273,10 +273,21 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
   }
 
   const fileLines = report.injectedWorkspaceFiles.map((f) => {
-    const status = f.missing ? "MISSING" : f.truncated ? "TRUNCATED" : "OK";
+    const nativeUnverified = f.injectionStatus === "native_unverified";
+    const status = nativeUnverified
+      ? "NATIVE/UNVERIFIED"
+      : f.missing
+        ? "MISSING"
+        : f.truncated
+          ? "TRUNCATED"
+          : "OK";
     const raw = f.missing ? "0" : formatCharsAndTokens(f.rawChars);
-    const injected = f.missing ? "0" : formatCharsAndTokens(f.injectedChars);
-    return `- ${f.name}: ${status} | raw ${raw} | injected ${injected}`;
+    const injected = nativeUnverified
+      ? "unknown"
+      : f.missing
+        ? "0"
+        : formatCharsAndTokens(f.injectedChars);
+    return `- ${f.name}: ${status} | raw${nativeUnverified ? "(local)" : ""} ${raw} | injected ${injected}`;
   });
 
   const sandboxLine = `Sandbox: mode=${report.sandbox?.mode ?? "unknown"} sandboxed=${report.sandbox?.sandboxed ?? false}`;
@@ -314,7 +325,9 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
   const bootstrapMaxLabel = `${formatInt(bootstrapMaxChars)} chars`;
   const bootstrapTotalLabel = `${formatInt(bootstrapTotalMaxChars)} chars`;
   const bootstrapAnalysis = analyzeBootstrapBudget({
-    files: report.injectedWorkspaceFiles,
+    files: report.injectedWorkspaceFiles.filter(
+      (file) => file.injectionStatus !== "native_unverified",
+    ),
     bootstrapMaxChars,
     bootstrapTotalMaxChars,
   });
@@ -346,6 +359,15 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
           "Tip: increase this agent's `agents.entries.*.bootstrapMaxChars` / `agents.entries.*.bootstrapTotalMaxChars` override, or the matching `agents.defaults.*` fallback, if this truncation is not intentional.",
         ]
       : [];
+  const hasNativeUnverifiedFiles = report.injectedWorkspaceFiles.some(
+    (file) => file.injectionStatus === "native_unverified",
+  );
+  const nativeUnverifiedWarningLines = hasNativeUnverifiedFiles
+    ? [
+        "⚠ Native Codex project instructions are unverified: Codex applies one aggregate root-to-CWD byte budget, and app-server does not report exact per-file retained bytes, so later AGENTS.md files can be partial.",
+        "Keep earlier/root files concise and read the relevant scoped file directly if guidance appears missing.",
+      ]
+    : [];
 
   const contextWindowLabel = session.contextTokens != null ? formatInt(session.contextTokens) : "?";
   const totalsLine =
@@ -359,6 +381,7 @@ export async function buildContextReply(params: HandleCommandsParams): Promise<R
     sandboxLine,
     systemPromptLine,
     ...(bootstrapWarningLines.length ? ["", ...bootstrapWarningLines] : []),
+    ...(nativeUnverifiedWarningLines.length ? ["", ...nativeUnverifiedWarningLines] : []),
     "",
     "Injected workspace files:",
     ...fileLines,

--- a/src/auto-reply/reply/context-treemap.ts
+++ b/src/auto-reply/reply/context-treemap.ts
@@ -341,7 +341,7 @@ function buildGroups(params: {
 }): TreemapGroup[] {
   const { report } = params;
   const injectedTotal = report.injectedWorkspaceFiles.reduce(
-    (sum, file) => sum + file.injectedChars,
+    (sum, file) => (file.injectionStatus === "native_unverified" ? sum : sum + file.injectedChars),
     0,
   );
   const projectFrameChars = Math.max(0, report.systemPrompt.projectContextChars - injectedTotal);
@@ -360,10 +360,12 @@ function buildGroups(params: {
       name: "Workspace files",
       color: rgba(58, 145, 91),
       leaves: [
-        ...report.injectedWorkspaceFiles.map((file) => ({
-          name: file.name,
-          value: file.injectedChars,
-        })),
+        ...report.injectedWorkspaceFiles
+          .filter((file) => file.injectionStatus !== "native_unverified")
+          .map((file) => ({
+            name: file.name,
+            value: file.injectedChars,
+          })),
         { name: "Project context frame", value: projectFrameChars },
       ],
     }),

--- a/src/config/sessions/session-system-prompt-report.ts
+++ b/src/config/sessions/session-system-prompt-report.ts
@@ -36,14 +36,25 @@ export type SessionSystemPromptReport = {
     // persisted transcript prompt; consumers add it on top of transcript sums.
     modelOnlyPromptChars?: number;
   };
-  injectedWorkspaceFiles: Array<{
-    name: string;
-    path: string;
-    missing: boolean;
-    rawChars: number;
-    injectedChars: number;
-    truncated: boolean;
-  }>;
+  injectedWorkspaceFiles: Array<
+    {
+      name: string;
+      path: string;
+      missing: boolean;
+      rawChars: number;
+    } & (
+      | {
+          injectionStatus?: "verified";
+          injectedChars: number;
+          truncated: boolean;
+        }
+      | {
+          injectionStatus: "native_unverified";
+          injectedChars: null;
+          truncated: null;
+        }
+    )
+  >;
   skills: {
     promptChars: number;
     hash?: string;

--- a/ui/src/pages/usage/view-details.test.ts
+++ b/ui/src/pages/usage/view-details.test.ts
@@ -376,6 +376,15 @@ describe("renderSessionDetailPanel filtered usage", () => {
           injectedChars: 30,
           truncated: false,
         },
+        {
+          name: "AGENTS.md",
+          path: "/AGENTS.md",
+          missing: false,
+          rawChars: 100,
+          injectionStatus: "native_unverified",
+          injectedChars: null,
+          truncated: null,
+        },
       ],
     };
     const onToggleContextExpanded = vi.fn();
@@ -397,7 +406,7 @@ describe("renderSessionDetailPanel filtered usage", () => {
     const cards = [...container.querySelectorAll(".context-breakdown-card")];
     expect(
       cards.map((card) => card.querySelector(".context-breakdown-title")?.textContent?.trim()),
-    ).toEqual(["Skills (5)", "Tools (2)", "Files (2)"]);
+    ).toEqual(["Skills (5)", "Tools (2)", "Files (3)"]);
     expect(
       [...(cards[0]?.querySelectorAll(".context-breakdown-item .mono") ?? [])].map(
         (entry) => entry.textContent,
@@ -406,7 +415,13 @@ describe("renderSessionDetailPanel filtered usage", () => {
     expect(cards[1]?.querySelector(".context-breakdown-item .mono")?.textContent).toBe(
       "larger-tool",
     );
-    expect(cards[2]?.querySelector(".context-breakdown-item .mono")?.textContent).toBe("large.md");
+    const fileEntries = [...(cards[2]?.querySelectorAll(".context-breakdown-item") ?? [])];
+    expect(fileEntries.map((entry) => entry.querySelector(".mono")?.textContent)).toEqual([
+      "large.md",
+      "small.md",
+      "AGENTS.md",
+    ]);
+    expect(fileEntries[2]?.querySelector(".muted")?.textContent).toBe("unknown");
     expect(cards[0]?.querySelector(".context-breakdown-more")?.textContent).toContain("1 more");
     container.querySelector<HTMLButtonElement>(".context-breakdown-header button")?.click();
     expect(onToggleContextExpanded).toHaveBeenCalledOnce();

--- a/ui/src/pages/usage/view-details.ts
+++ b/ui/src/pages/usage/view-details.ts
@@ -832,7 +832,11 @@ function renderContextPanel(
       className: "files",
       labelKey: "usage.details.files",
       tokens: charsToTokens(
-        contextWeight.injectedWorkspaceFiles.reduce((sum, file) => sum + file.injectedChars, 0),
+        contextWeight.injectedWorkspaceFiles.reduce(
+          (sum, file) =>
+            file.injectionStatus === "native_unverified" ? sum : sum + file.injectedChars,
+          0,
+        ),
       ),
       entries: contextWeight.injectedWorkspaceFiles.map(({ name, injectedChars }) => ({
         name,
@@ -843,7 +847,12 @@ function renderContextPanel(
     className,
     labelKey,
     tokens,
-    entries: entries.toSorted((left, right) => right.chars - left.chars),
+    entries: entries.toSorted((left, right) => {
+      if (left.chars === null) {
+        return right.chars === null ? 0 : 1;
+      }
+      return right.chars === null ? -1 : right.chars - left.chars;
+    }),
   }));
   const categories = [
     {
@@ -915,7 +924,11 @@ function renderContextPanel(
                     ({ name, chars }) => html`
                       <div class="context-breakdown-item">
                         <span class="mono" title=${name}>${name}</span>
-                        <span class="muted">~${formatUsageTokens(charsToTokens(chars))}</span>
+                        <span class="muted"
+                          >${chars === null
+                            ? t("usage.common.unknown")
+                            : `~${formatUsageTokens(charsToTokens(chars))}`}</span
+                        >
                       </div>
                     `,
                   )}


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #125966. Native Codex turns load project `AGENTS.md` files under one aggregate root-to-working-directory byte budget, so a later file can be partially retained. OpenClaw's context accounting instead treated every native `AGENTS.md` as fully injected whenever OpenClaw had not injected it itself.

That made `/context`, context maps, and Usage details report a precise value that the Codex app-server cannot actually provide.

## Why This Change Was Made

Codex 0.147 exposes the loaded instruction source paths on thread start, resume, and fork, but it does not expose per-file retained byte counts or completeness. A listed source can still have been truncated by the aggregate budget.

This change gives native project documents an explicit `native_unverified` accounting state with unknown injected/truncated values. OpenClaw-injected workspace files remain precisely measured. `/context` explains the distinction and keeps native files out of the separate OpenClaw character-budget analysis; context maps and the Control UI omit unknown bytes rather than inventing a value.

The 128 KiB normal-thread default landed by #125966 is unchanged. Lightweight and restricted zero-document behavior is unchanged. Normal runs emit no new messages; the warning is visible only when an operator explicitly opens `/context` reporting or Usage details.

## User Impact

Operators inspecting context diagnostics now see native `AGENTS.md` files as `NATIVE/UNVERIFIED` / `unknown` instead of a false full-injection count. The report explains that earlier/root project documents consume the shared byte budget and recommends reading the relevant scoped file directly when guidance appears missing.

Measured OpenClaw workspace files, memory routing, normal Codex execution, and restricted/lightweight turn behavior are unchanged.

## Evidence

- Pinned Codex `rust-v0.147.0` (`3ed6f04f6bf8b7c46299d1cb1ff99c74ce21a51d`) inspected directly:
  - `codex-rs/core/src/agents_md.rs:94-143` applies one byte budget across root-to-CWD project documents and truncates a later file to the remaining bytes.
  - `codex-rs/core/src/agents_md.rs:403-412` retains source paths, not retained-byte counts.
  - `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:175-208,408-459,600-633` exposes `instructionSources` on start/resume/fork without completeness metadata.
- Regression coverage: native `AGENTS.md` reports `native_unverified` with null retained counts; an agent-workspace `AGENTS.md` injected by OpenClaw remains exactly measured.
- `/context` boundary coverage verifies `NATIVE/UNVERIFIED`, actionable aggregate-budget guidance, and no incorrect OpenClaw bootstrap-limit advice.
- Control UI coverage verifies measured files remain sorted by size while native `AGENTS.md` renders as `unknown` and contributes no invented token count.
- Focused exact-head Vitest: 173/173 passed.
- Changed-file checks passed formatting, lint, typechecks, plugin boundaries, dead exports, import cycles, and Control UI i18n verification.
- `pnpm docs:check-mdx`: 777 files passed.
- `git diff --check origin/main...HEAD`: clean.
- Fresh exact-head Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +85/-25; tests: +85/-15; docs: +4/-0.

Visual proof:

![Control UI Usage details showing native AGENTS.md accounting as unknown](https://github.com/user-attachments/assets/5cb859fd-a221-4bf0-ad73-b677344d9b10)

Known proof boundary: current app-server responses do not expose the exact retained bytes, which is the reason this report is intentionally unverified rather than reconstructed from local file contents.

AI-assisted; implementation and final diff were reviewed and verified by Peter Steinberger.
