### PR TITLE
fix(workshop): make collection restore ownership retryable

### DIFF
--- a/src/skills/workshop/collection-reconcile.ts
+++ b/src/skills/workshop/collection-reconcile.ts
@@ -430,15 +430,18 @@ export async function restoreLatestSkillCollectionBackup(params: {
           backupDir,
           skillDirs: manifest.skillDirs,
           resultSkillDirs: manifest.resultSkillDirs,
+          commit: () =>
+            restoreWorkshopOwnershipClaims(
+              workspaceDir,
+              manifest.skillDirs.map((relativeDir) => path.join(workspaceDir, relativeDir)),
+              manifest.resultSkillDirs.map((relativeDir) => path.join(workspaceDir, relativeDir)),
+              Date.now(),
+              params.env ? { env: params.env } : {},
+            ),
         });
       } finally {
         bumpSkillsSnapshotVersion({ reason: "workshop" });
       }
-      restoreWorkshopOwnershipClaims(
-        workspaceDir,
-        manifest.skillDirs.map((relativeDir) => path.join(workspaceDir, relativeDir)),
-        params.env ? { env: params.env } : {},
-      );
       const changes: SkillCollectionChange[] = [];
       if (shouldDispatch) {
         for (const relativeDir of affectedDirs) {

--- a/src/skills/workshop/collection-restore.test.ts
+++ b/src/skills/workshop/collection-restore.test.ts
@@ -235,21 +235,45 @@ describe("skill collection backup and restore", () => {
     );
   });
 
-  it("restores ownership for a dropped Workshop skill", async () => {
+  it("restores original ownership and releases result-only ownership", async () => {
     await writeWorkshopOwnedSkills([
-      { name: "foo", description: "Workshop procedure", body: "# Original\n" },
+      { name: "updated", description: "Updated procedure", body: "# Updated original\n" },
+      { name: "dropped", description: "Dropped procedure", body: "# Dropped original\n" },
     ]);
     await reconcileSkillCollection({
       workspaceDir,
       env: testState.env,
       ...(await readCollectionReceipt()),
-      plan: [{ action: "drop", name: "foo", reason: "Temporarily removed" }],
+      plan: [
+        {
+          action: "write",
+          name: "updated",
+          description: "Updated procedure",
+          content: "# Updated result\n",
+        },
+        { action: "drop", name: "dropped", reason: "Temporarily removed" },
+        {
+          action: "write",
+          name: "created",
+          description: "Created procedure",
+          content: "# Created result\n",
+        },
+      ],
     });
 
     await restoreLatestSkillCollectionBackup({ workspaceDir, env: testState.env });
 
     expect(listWritableSkillCollection(workspaceDir, { env: testState.env })).toEqual([
-      expect.objectContaining({ name: "foo", workshopOwned: true }),
+      expect.objectContaining({ name: "dropped", workshopOwned: true }),
+      expect.objectContaining({ name: "updated", workshopOwned: true }),
+    ]);
+    await writeWorkspaceSkills(workspaceDir, [
+      { name: "created", description: "Operator procedure", body: "# Operator\n" },
+    ]);
+    expect(listWritableSkillCollection(workspaceDir, { env: testState.env })).toEqual([
+      expect.objectContaining({ name: "created", workshopOwned: false }),
+      expect.objectContaining({ name: "dropped", workshopOwned: true }),
+      expect.objectContaining({ name: "updated", workshopOwned: true }),
     ]);
     await expect(
       reconcileSkillCollection({
@@ -257,15 +281,68 @@ describe("skill collection backup and restore", () => {
         env: testState.env,
         ...(await readCollectionReceipt()),
         plan: [
+          { action: "keep", name: "created" },
+          { action: "keep", name: "dropped" },
           {
             action: "write",
-            name: "foo",
+            name: "updated",
             description: "Restored procedure",
             content: "# Restored and mutable\n",
           },
         ],
       }),
-    ).resolves.toMatchObject({ written: ["foo"] });
+    ).resolves.toMatchObject({ written: ["updated"] });
+  });
+
+  it("keeps restore retryable when ownership persistence fails", async () => {
+    await writeWorkshopOwnedSkills([
+      { name: "original", description: "Original procedure", body: "# Original\n" },
+    ]);
+    await reconcileSkillCollection({
+      workspaceDir,
+      env: testState.env,
+      ...(await readCollectionReceipt()),
+      plan: [
+        {
+          action: "write",
+          name: "original",
+          description: "Updated procedure",
+          content: "# Updated\n",
+        },
+        {
+          action: "write",
+          name: "created",
+          description: "Created procedure",
+          content: "# Created\n",
+        },
+      ],
+    });
+    const database = openOpenClawStateDatabase({ env: testState.env }).db;
+    database.exec(`
+      CREATE TRIGGER fail_collection_restore_claims
+      BEFORE UPDATE OF claim_released_time ON skill_workshop_proposals
+      BEGIN
+        SELECT RAISE(FAIL, 'forced ownership persistence failure');
+      END;
+    `);
+
+    await expect(
+      restoreLatestSkillCollectionBackup({ workspaceDir, env: testState.env }),
+    ).rejects.toThrow("forced ownership persistence failure");
+    await expect(
+      fs.readFile(path.join(workspaceDir, "skills", "original", "SKILL.md"), "utf8"),
+    ).resolves.toContain("# Updated");
+    await expect(
+      fs.readFile(path.join(workspaceDir, "skills", "created", "SKILL.md"), "utf8"),
+    ).resolves.toContain("# Created");
+
+    database.exec("DROP TRIGGER fail_collection_restore_claims;");
+    await restoreLatestSkillCollectionBackup({ workspaceDir, env: testState.env });
+
+    await expect(
+      fs.readFile(path.join(workspaceDir, "skills", "original", "SKILL.md"), "utf8"),
+    ).resolves.toContain("# Original");
+    await expect(fs.access(path.join(workspaceDir, "skills", "created"))).rejects.toThrow();
   });
 
   it("restores a legacy backup that predates ownership narrowing", async () => {

--- a/src/skills/workshop/collection-rollback.ts
+++ b/src/skills/workshop/collection-rollback.ts
@@ -86,6 +86,7 @@ export async function restoreSkillCollectionBackupTransaction(params: {
   backupDir: string;
   skillDirs: readonly string[];
   resultSkillDirs: readonly string[];
+  commit: () => void;
 }): Promise<void> {
   const rollbackDir = path.join(params.backupDir, `.restore-${randomUUID()}`);
   try {
@@ -104,6 +105,9 @@ export async function restoreSkillCollectionBackupTransaction(params: {
   let discardSnapshot = false;
   try {
     await restoreSkillCollectionBackup(params);
+    // Ownership is the durable commit for this filesystem transition. Keep the
+    // snapshot until it succeeds so a failed commit can restore the retryable result.
+    params.commit();
     discardSnapshot = true;
   } catch (error) {
     try {

--- a/src/skills/workshop/ownership.ts
+++ b/src/skills/workshop/ownership.ts
@@ -48,20 +48,25 @@ function setWorkshopOwnershipClaimRelease(
   );
 }
 
-function writeWorkshopOwnershipClaimRelease(
+function writeWorkshopOwnershipClaims(
   workspaceDir: string,
-  skillDirs: readonly string[],
-  releaseTime: number | null,
+  claimedSkillDirs: readonly string[],
+  releasedSkillDirs: readonly string[],
+  releaseTime: number,
   options: SkillWorkshopStoreOptions,
 ): void {
-  if (skillDirs.length === 0) {
+  const claimedDirs = new Set(claimedSkillDirs.map((skillDir) => path.resolve(skillDir)));
+  const releasedDirs = releasedSkillDirs.filter(
+    (skillDir) => !claimedDirs.has(path.resolve(skillDir)),
+  );
+  if (claimedDirs.size === 0 && releasedDirs.length === 0) {
     return;
   }
   ensureSkillWorkshopSchema(options);
-  runOpenClawStateWriteTransaction(
-    ({ db }) => setWorkshopOwnershipClaimRelease(db, workspaceDir, skillDirs, releaseTime),
-    databaseOptions(options),
-  );
+  runOpenClawStateWriteTransaction(({ db }) => {
+    setWorkshopOwnershipClaimRelease(db, workspaceDir, releasedDirs, releaseTime);
+    setWorkshopOwnershipClaimRelease(db, workspaceDir, [...claimedDirs], null);
+  }, databaseOptions(options));
 }
 
 export function releaseWorkshopOwnershipClaims(
@@ -70,15 +75,17 @@ export function releaseWorkshopOwnershipClaims(
   releaseTime: number,
   options: SkillWorkshopStoreOptions = {},
 ): void {
-  writeWorkshopOwnershipClaimRelease(workspaceDir, skillDirs, releaseTime, options);
+  writeWorkshopOwnershipClaims(workspaceDir, [], skillDirs, releaseTime, options);
 }
 
 export function restoreWorkshopOwnershipClaims(
   workspaceDir: string,
   skillDirs: readonly string[],
+  resultSkillDirs: readonly string[],
+  releaseTime: number,
   options: SkillWorkshopStoreOptions = {},
 ): void {
-  writeWorkshopOwnershipClaimRelease(workspaceDir, skillDirs, null, options);
+  writeWorkshopOwnershipClaims(workspaceDir, skillDirs, resultSkillDirs, releaseTime, options);
 }
 
 export function restoreWorkshopOwnershipClaimsBestEffort(
@@ -87,7 +94,7 @@ export function restoreWorkshopOwnershipClaimsBestEffort(
   options: SkillWorkshopStoreOptions = {},
 ): void {
   try {
-    restoreWorkshopOwnershipClaims(workspaceDir, skillDirs, options);
+    writeWorkshopOwnershipClaims(workspaceDir, skillDirs, [], 0, options);
   } catch (error) {
     logWarn(`skill-workshop: failed to reclaim ownership after rollback: ${String(error)}`);
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where restoring a Skill Workshop collection left result-only applied-create ownership claims active after removing those skill directories. If ownership persistence failed, the filesystem restore had already discarded its rollback artifacts, so the restore could not be retried safely.

## Why This Change Was Made

Filesystem restore and ownership mutation now share one compensation/commit boundary. The existing shared-state SQLite transaction atomically releases result-only claims and reclaims every original skill directory, with originals winning when the sets overlap; an ownership failure compensates the filesystem back to the pre-restore result.

### Persistent state / owner review

This changes existing `skill_workshop_proposals.claim_released_time` values only. It does not add or alter a schema version, protocol, or configuration surface. The explicit owner-authorized land request covers this guarded existing-state transition.

## User Impact

Paths manually recreated after a collection restore no longer appear Workshop-owned, and operators can retry restore after an ownership-persistence failure without losing the unchanged result needed by the restore guard.

## Evidence

- Pre-fix regressions failed for the intended reasons: the result-only `created` path remained Workshop-owned after restore, and a forced `claim_released_time` update failure left the restored filesystem in place so the same backup was no longer retryable.
- `node scripts/run-vitest.mjs src/skills/workshop/collection-restore.test.ts src/skills/workshop/collection-reconcile.test.ts --reporter=verbose` — 29/29 passed.
- Changed checks passed. The aggregate `node scripts/check-changed.mjs` wrapper reached its 10-minute external timeout only after entering core test typechecking; `node scripts/run-tsgo-core-test-shards.mjs` then passed, as did every remaining lint, schema, database-first, and import-cycle guard from the changed plan.
- `git diff --check` — passed.
- Fresh `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings.
- Production LOC: +30/-16 (net +14). Tests: +83/-6.
