### PR TITLE
fix: large base64 attachments on /v1/responses crash the gateway with heap OOM

### DIFF
--- a/packages/media-core/src/base64.test.ts
+++ b/packages/media-core/src/base64.test.ts
@@ -13,6 +13,28 @@ describe("base64 helpers", () => {
     expect(canonicalizeBase64(encoded)).toBe(encoded);
   });
 
+  it("canonicalizeBase64 handles attachment-sized payloads without heap blow-up", () => {
+    // Regression guard: the previous per-character append built one cons-string
+    // node per input character (~25 bytes each, all live at once), so this
+    // 16 MiB payload (21.3 M base64 chars) transiently needed >500 MB of heap.
+    // The threshold is deliberately generous; the run-slicing implementation
+    // allocates nothing for already-canonical input.
+    const encoded = Buffer.alloc(16 * 1024 * 1024, 0xab).toString("base64");
+    const before = process.memoryUsage().heapUsed;
+
+    expect(canonicalizeBase64(encoded)).toBe(encoded);
+
+    const delta = process.memoryUsage().heapUsed - before;
+    expect(delta).toBeLessThan(100 * 1024 * 1024);
+  });
+
+  it("canonicalizeBase64 cleans whitespace inside large payloads", () => {
+    const encoded = Buffer.alloc(1_000_000, 0xab).toString("base64");
+    const wrapped = encoded.replace(/(.{76})/g, "$1\r\n");
+
+    expect(canonicalizeBase64(wrapped)).toBe(encoded);
+  });
+
   it.each([
     {
       name: "canonicalizeBase64 normalizes whitespace and keeps valid base64",
@@ -37,6 +59,36 @@ describe("base64 helpers", () => {
     {
       name: "canonicalizeBase64 rejects nonzero pad bits",
       actual: canonicalizeBase64("ZE=="),
+      expected: undefined,
+    },
+    {
+      name: "canonicalizeBase64 rejects nonzero pad bits on auto-padded input",
+      actual: canonicalizeBase64("ZE"),
+      expected: undefined,
+    },
+    {
+      name: "canonicalizeBase64 trims leading and trailing whitespace",
+      actual: canonicalizeBase64("\n\tSGVsbG8=  "),
+      expected: "SGVsbG8=",
+    },
+    {
+      name: "canonicalizeBase64 rejects data chars after padding",
+      actual: canonicalizeBase64("QQ==QQ=="),
+      expected: undefined,
+    },
+    {
+      name: "canonicalizeBase64 rejects more than two padding chars",
+      actual: canonicalizeBase64("===="),
+      expected: undefined,
+    },
+    {
+      name: "canonicalizeBase64 rejects a data: URL prefix",
+      actual: canonicalizeBase64("data:image/png;base64,QUJD"),
+      expected: undefined,
+    },
+    {
+      name: "canonicalizeBase64 rejects whitespace-only input",
+      actual: canonicalizeBase64(" \r\n\t"),
       expected: undefined,
     },
     {

--- a/packages/media-core/src/base64.test.ts
+++ b/packages/media-core/src/base64.test.ts
@@ -35,6 +35,27 @@ describe("base64 helpers", () => {
     expect(canonicalizeBase64(wrapped)).toBe(encoded);
   });
 
+  it("canonicalizeBase64 handles one whitespace per character without heap blow-up", () => {
+    // Worst case for any run-collecting cleanup strategy: every data character
+    // is its own whitespace-delimited run (2.7 M runs here). The whole cleanup
+    // must stay bounded by the input length — one output buffer — not by the
+    // number of runs.
+    const encoded = Buffer.alloc(2 * 1024 * 1024, 0xab).toString("base64");
+    const shredded = encoded.split("").join("\n");
+    // heapUsed catches per-run JS objects (slices, rope nodes); arrayBuffers
+    // catches Buffer-backed strategies — bound both.
+    const usedBytes = () => {
+      const usage = process.memoryUsage();
+      return usage.heapUsed + usage.arrayBuffers;
+    };
+    const before = usedBytes();
+
+    expect(canonicalizeBase64(shredded)).toBe(encoded);
+
+    const delta = usedBytes() - before;
+    expect(delta).toBeLessThan(64 * 1024 * 1024);
+  });
+
   it.each([
     {
       name: "canonicalizeBase64 normalizes whitespace and keeps valid base64",

--- a/packages/media-core/src/base64.test.ts
+++ b/packages/media-core/src/base64.test.ts
@@ -17,8 +17,8 @@ describe("base64 helpers", () => {
     // Regression guard: the previous per-character append built one cons-string
     // node per input character (~25 bytes each, all live at once), so this
     // 16 MiB payload (21.3 M base64 chars) transiently needed >500 MB of heap.
-    // The threshold is deliberately generous; the run-slicing implementation
-    // allocates nothing for already-canonical input.
+    // The threshold is deliberately generous; the bounded-buffer implementation
+    // returns already-canonical input unchanged.
     const encoded = Buffer.alloc(16 * 1024 * 1024, 0xab).toString("base64");
     const before = process.memoryUsage().heapUsed;
 

--- a/packages/media-core/src/base64.ts
+++ b/packages/media-core/src/base64.ts
@@ -37,8 +37,6 @@ export function estimateBase64DecodedBytes(base64: string): number {
   return Math.max(0, estimated);
 }
 
-const CANONICALIZE_BASE64_CHUNK_SIZE = 8192;
-
 function isBase64DataChar(code: number): boolean {
   return (
     (code >= 0x41 && code <= 0x5a) ||
@@ -67,25 +65,24 @@ function base64DataValue(code: number): number {
  * base64 only when the input has valid alphabet, padding, and length.
  */
 export function canonicalizeBase64(base64: string): string | undefined {
-  const chunks: string[] = [];
-  let current = "";
+  // Validate in a single pass and collect contiguous non-whitespace runs as
+  // slices. Appending per character instead (`current += char`) allocates one
+  // V8 cons-string node (~25 bytes) per input character, all live at once —
+  // enough to OOM the process on multi-megabyte attachment payloads.
+  const runs: string[] = [];
+  let runStart = -1;
   let cleanedLength = 0;
   let padding = 0;
   let sawPadding = false;
   let lastDataCode = 0;
 
-  const append = (char: string): void => {
-    current += char;
-    cleanedLength += 1;
-    if (current.length >= CANONICALIZE_BASE64_CHUNK_SIZE) {
-      chunks.push(current);
-      current = "";
-    }
-  };
-
   for (let i = 0; i < base64.length; i += 1) {
     const code = base64.charCodeAt(i);
     if (code <= 0x20) {
+      if (runStart >= 0) {
+        runs.push(base64.slice(runStart, i));
+        runStart = -1;
+      }
       continue;
     }
     if (code === 0x3d) {
@@ -94,32 +91,33 @@ export function canonicalizeBase64(base64: string): string | undefined {
         return undefined;
       }
       sawPadding = true;
-      append("=");
-      continue;
-    }
-    if (sawPadding || !isBase64DataChar(code)) {
+    } else if (sawPadding || !isBase64DataChar(code)) {
       return undefined;
+    } else {
+      lastDataCode = code;
     }
-    lastDataCode = code;
-    append(base64[i] ?? "");
+    if (runStart < 0) {
+      runStart = i;
+    }
+    cleanedLength += 1;
+  }
+  if (runStart >= 0) {
+    runs.push(runStart === 0 ? base64 : base64.slice(runStart));
   }
   if (cleanedLength === 0) {
     return undefined;
   }
   const remainder = cleanedLength % 4;
-  if (remainder !== 0) {
-    if (sawPadding || remainder === 1) {
-      return undefined;
-    }
-    current += "=".repeat(4 - remainder);
+  if (remainder !== 0 && (sawPadding || remainder === 1)) {
+    return undefined;
   }
   const effectivePadding = remainder === 0 ? padding : 4 - remainder;
   const padBitMask = effectivePadding === 2 ? 0x0f : effectivePadding === 1 ? 0x03 : 0;
   if (padBitMask !== 0 && (base64DataValue(lastDataCode) & padBitMask) !== 0) {
     return undefined;
   }
-  if (current) {
-    chunks.push(current);
-  }
-  return chunks.join("");
+  // Already-canonical input (the common case: encoder output with no
+  // whitespace) is returned as-is without copying.
+  const cleaned = runs.length === 1 ? (runs[0] ?? "") : runs.join("");
+  return remainder === 0 ? cleaned : cleaned + "=".repeat(4 - remainder);
 }

--- a/packages/media-core/src/base64.ts
+++ b/packages/media-core/src/base64.ts
@@ -65,13 +65,18 @@ function base64DataValue(code: number): number {
  * base64 only when the input has valid alphabet, padding, and length.
  */
 export function canonicalizeBase64(base64: string): string | undefined {
-  // Validate in a single pass and collect contiguous non-whitespace runs as
-  // slices. Appending per character instead (`current += char`) allocates one
-  // V8 cons-string node (~25 bytes) per input character, all live at once —
-  // enough to OOM the process on multi-megabyte attachment payloads.
-  const runs: string[] = [];
-  let runStart = -1;
-  let cleanedLength = 0;
+  // Single validating pass. An output buffer is materialized only after the
+  // first whitespace character is seen: already-canonical input (any standard
+  // encoder's output) is returned unchanged with zero allocations, and input
+  // containing whitespace costs exactly one buffer bounded by the input
+  // length, regardless of how the whitespace is distributed. (Appending per
+  // character instead — `current += char` — allocated one V8 cons-string node
+  // per input character, all live at once: hundreds of MB of transient heap
+  // for attachment-sized payloads. Collecting whitespace-delimited runs as
+  // string slices is not bounded either: input alternating data characters
+  // and whitespace retains one slice object per run.)
+  let out: Buffer | undefined;
+  let outLen = 0;
   let padding = 0;
   let sawPadding = false;
   let lastDataCode = 0;
@@ -79,9 +84,13 @@ export function canonicalizeBase64(base64: string): string | undefined {
   for (let i = 0; i < base64.length; i += 1) {
     const code = base64.charCodeAt(i);
     if (code <= 0x20) {
-      if (runStart >= 0) {
-        runs.push(base64.slice(runStart, i));
-        runStart = -1;
+      if (out === undefined) {
+        // First whitespace: backfill the validated prefix [0, i).
+        out = Buffer.allocUnsafe(base64.length - 1);
+        for (let j = 0; j < i; j += 1) {
+          out[j] = base64.charCodeAt(j);
+        }
+        outLen = i;
       }
       continue;
     }
@@ -96,14 +105,12 @@ export function canonicalizeBase64(base64: string): string | undefined {
     } else {
       lastDataCode = code;
     }
-    if (runStart < 0) {
-      runStart = i;
+    if (out !== undefined) {
+      out[outLen] = code;
+      outLen += 1;
     }
-    cleanedLength += 1;
   }
-  if (runStart >= 0) {
-    runs.push(runStart === 0 ? base64 : base64.slice(runStart));
-  }
+  const cleanedLength = out === undefined ? base64.length : outLen;
   if (cleanedLength === 0) {
     return undefined;
   }
@@ -116,8 +123,8 @@ export function canonicalizeBase64(base64: string): string | undefined {
   if (padBitMask !== 0 && (base64DataValue(lastDataCode) & padBitMask) !== 0) {
     return undefined;
   }
-  // Already-canonical input (the common case: encoder output with no
-  // whitespace) is returned as-is without copying.
-  const cleaned = runs.length === 1 ? (runs[0] ?? "") : runs.join("");
+  // Every kept character was validated against the base64 alphabet (ASCII),
+  // so a latin1 decode reproduces them exactly.
+  const cleaned = out === undefined ? base64 : out.subarray(0, outLen).toString("latin1");
   return remainder === 0 ? cleaned : cleaned + "=".repeat(4 - remainder);
 }

--- a/packages/media-core/src/base64.ts
+++ b/packages/media-core/src/base64.ts
@@ -65,16 +65,9 @@ function base64DataValue(code: number): number {
  * base64 only when the input has valid alphabet, padding, and length.
  */
 export function canonicalizeBase64(base64: string): string | undefined {
-  // Single validating pass. An output buffer is materialized only after the
-  // first whitespace character is seen: already-canonical input (any standard
-  // encoder's output) is returned unchanged with zero allocations, and input
-  // containing whitespace costs exactly one buffer bounded by the input
-  // length, regardless of how the whitespace is distributed. (Appending per
-  // character instead — `current += char` — allocated one V8 cons-string node
-  // per input character, all live at once: hundreds of MB of transient heap
-  // for attachment-sized payloads. Collecting whitespace-delimited runs as
-  // string slices is not bounded either: input alternating data characters
-  // and whitespace retains one slice object per run.)
+  // Single validating pass; the output buffer is allocated lazily on the first
+  // whitespace and bounded by the input length, so canonical input returns
+  // unchanged with zero allocations and no input shape multiplies intermediates.
   let out: Buffer | undefined;
   let outLen = 0;
   let padding = 0;


### PR DESCRIPTION
Closes #126015

## What Problem This Solves

Fixes an issue where clients sending a large base64 `input_file`/`input_image` attachment to the gateway's `POST /v1/responses` endpoint would crash the whole gateway process with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` when the deployment runs under a memory cap (containers, small VPSes). In a 1 GB container (V8 heap ≈ 560 MB), attachments from ~10 MiB reliably killed the gateway even though they were within the configured `files.maxBytes`/`images.maxBytes` limits — the connection dropped, the in-flight turn was lost, and the container restarted.

## Why This Change Was Made

`canonicalizeBase64()` built its cleaned output by appending one character at a time (`current += char`), which allocates one V8 cons-string node (~25 bytes) per input character, all live at once until the final `join` — ~700–900 MB of transient heap for a 20 MiB attachment. The rewrite validates in the same single pass and materializes an output buffer only when the first whitespace character is seen: already-canonical input (the overwhelmingly common case — any standard encoder's output) is returned unchanged with zero allocations, and input containing whitespace costs at most **one buffer bounded by the input length, regardless of how the whitespace is distributed** (this addresses the review finding that a run-slicing cleanup retains one slice object per whitespace-delimited run and is therefore unbounded for adversarial char/whitespace-alternating input). Validation semantics are unchanged: same whitespace handling, padding rules, pad-bit rejection, and auto-padding, verified against the previous implementation on a 22,000-case differential fuzz (0 mismatches).

## User Impact

Deployments can actually use attachment limits up to and beyond 20 MB without over-provisioning memory: peak gateway memory for `/v1/responses` attachment handling drops by ~25× the base64 length (e.g. −659 MB for a 15 MiB attachment), canonicalization time drops ~20×, and no accepted input shape — including whitespace-shredded base64 — can force more than one input-length-bounded intermediate buffer. Requests that previously killed the process now just work; nothing else changes.

## Evidence

**Real `/v1/responses` behavior under a bounded heap (after fix).** Production-shaped deployment: the gateway runs inside a Docker container with a hard 1 GB memory limit (`NODE_OPTIONS` unset → V8 `heap_size_limit` ≈ 560 MB), `images.maxBytes`/`files.maxBytes` = 20 MiB, `maxBodyBytes` = 32 MiB. Probes are sent from the host into the container's network namespace; bodies are generated host-side so the gateway's own heap is not disturbed; peak RSS sampled via `docker stats` at 1 Hz. Terminal output (verbatim, container/response ids redacted only in name):

```
== probe: 15 MiB input_image (body 20971762 bytes) ==
HTTP 200 in 5.368159s
peak RSS during request: 477.9MiB
response head: {"id":"resp_…","object":"response","created_at":…,"status":"completed",
  "model":"openclaw","output":[{"type":"message","id":"msg_…","role":"assistant",
  "content":[{"type":"output_text","text":"OK"}],"phase":"final_answer",…
RestartCount now: 0
== probe: 20 MiB input_file (body 27962293 bytes) ==
HTTP 200 in 6.915621s
peak RSS during request: 636.2MiB
RestartCount now: 0
== final ==
RestartCount after all probes: 0 (before: 0)
```

Before the fix, on the same host/container configuration, the 15 MiB `input_image` probe (and any file ≥ 10 MiB) produced a dropped connection, `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` in the container log, and a Docker restart (`RestartCount` incremented):

```
$ node --max-old-space-size=560 repro.mjs   # 20 MiB attachment, old implementation
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

**Helper benchmarks** (Node v24.14, `--expose-gc`, transient = `heapUsed`+`arrayBuffers` delta across the call before GC):

| Input | old (per-char append) | run slices (first PR revision) | **bounded buffer (this PR)** |
|---|---|---|---|
| 15 MiB attachment, canonical | 659 MB, 4283 ms | 0 MB (same string returned) | **0 MB (same string returned), ~190 ms** |
| 20 MiB, canonical, 560 MB heap cap | fatal OOM | 0 MB, 287 ms | **0 MB, ~290 ms, exit 0** |
| 8 MiB shredded to one run per char (10.7 M runs) | fatal OOM territory | 421 MB, 1268 ms | **≤ 1 input-length buffer, 0 MB JS-heap delta, 210 ms** |

- Differential fuzz old-vs-new: 22,023 inputs (random alphabet soup incl. whitespace/`=`/invalid chars, plus valid base64 of random bytes with injected whitespace and stripped padding) — 0 mismatches.
- `packages/media-core/src/base64.test.ts`: all existing cases pass unchanged; added a 16 MiB heap-regression guard, a MIME-wrapped large payload case, the **many-short-runs case from the review** (2.7 M single-char runs, guarding `heapUsed` + `arrayBuffers` — fails on both the per-char-append and the run-slicing strategies), and edge cases locking the semantics (leading/trailing whitespace, `data:` URL rejection, data-after-padding rejection, `====`, pad-bit rejection on auto-padded input, whitespace-only input). 17/17 pass.
- `tsc --noEmit --strict --noUncheckedIndexedAccess` clean on both changed files.

## Maintainer validation

- Exact head `def20b1943ab7ba1c0d2c7db7963b9a1c01e7521`: Media Core focused tests 17/17; repaired Vitest ownership audit 18/18; package build, formatting, oxlint, and `git diff --check` pass.
- Bounded built-code proof: a 20 MiB attachment (27,962,028 base64 characters) returns the canonical input unchanged under `--max-old-space-size=560`, exit 0, 130 ms, ~98 MiB RSS. The reviewed main implementation fails the same bounded child with a V8 heap OOM.
- The local Docker socket is unavailable, so the full gateway probes were not repeated after the comment-only maintainer edit. The production file is byte-identical to the contributor-tested revision; the 15 MiB image and 20 MiB file HTTP 200/no-restart evidence above remains code-identical. Exact-head hosted CI, ClawSweeper, and Testbox are the final landing gates.

Punchcard-Session: frost-cedar-willow-ae
