### PR TITLE
feat(skills): bind Skill Workshop approvals to the reviewed revision

### DIFF
--- a/src/agents/agent-tools.before-tool-call.approval.ts
+++ b/src/agents/agent-tools.before-tool-call.approval.ts
@@ -561,6 +561,15 @@ export async function resolveSkillWorkshopApprovalForFinalParams(params: {
     ...(params.ctx?.config ? { config: params.ctx.config } : {}),
     ...(params.ctx?.workspaceDir ? { workspaceDir: params.ctx.workspaceDir } : {}),
   });
+  if (result?.block) {
+    return {
+      blocked: true,
+      kind: "veto",
+      deniedReason: "plugin-before-tool-call",
+      reason: result.blockReason || "Skill Workshop lifecycle action blocked",
+      params: params.params,
+    };
+  }
   return await resolveBeforeToolCallApprovalOutcome({
     result,
     approvalMode: params.approvalMode,

--- a/src/skills/workshop/policy.test.ts
+++ b/src/skills/workshop/policy.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../test-utils/openclaw-test-state.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 import { resolveSkillWorkshopToolApproval } from "./policy.js";
-import { proposeCreateSkill } from "./service.js";
+import { proposeCreateSkill, reviseSkillProposal } from "./service.js";
 
 const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
@@ -64,7 +64,15 @@ describe("resolveSkillWorkshopToolApproval", () => {
       timeoutMs: 70_000,
       allowedDecisions: ["allow-once", "deny"],
     });
+    expect(result?.params).toEqual({
+      action: "apply",
+      proposal_id: proposal.record.id,
+      expected_revision_hash: proposal.revisionHash,
+    });
     expect(result?.requireApproval?.description).toContain(`Proposal ID: ${proposal.record.id}`);
+    expect(result?.requireApproval?.description).toContain(
+      `Revision hash: ${proposal.revisionHash}`,
+    );
     expect(result?.requireApproval?.description).toContain("Target skill: Weather Helper");
     expect(result?.requireApproval?.description).toContain(`Description: ${description}`);
     expect(result?.requireApproval?.description).toContain("Support files: 2");
@@ -74,6 +82,19 @@ describe("resolveSkillWorkshopToolApproval", () => {
     expect(result?.requireApproval?.timeoutReason).toContain(
       `left Proposal ${proposal.record.id} unchanged and pending`,
     );
+    for (const action of ["reject", "quarantine"] as const) {
+      const lifecycleResult = await resolveSkillWorkshopToolApproval({
+        toolName: "skill_workshop",
+        toolParams: { action, proposal_id: proposal.record.id },
+        workspaceDir,
+        config: pendingApprovalConfig,
+      });
+      expect(lifecycleResult?.params).toEqual({
+        action,
+        proposal_id: proposal.record.id,
+        expected_revision_hash: proposal.revisionHash,
+      });
+    }
     const resolvedByName = await resolveSkillWorkshopToolApproval({
       toolName: "skill_workshop",
       toolParams: { action: "reject", name: "weather-helper" },
@@ -83,6 +104,12 @@ describe("resolveSkillWorkshopToolApproval", () => {
     expect(resolvedByName?.requireApproval?.description).toContain(
       `Proposal ID: ${proposal.record.id}`,
     );
+    expect(resolvedByName?.params).toEqual({
+      action: "reject",
+      name: "weather-helper",
+      proposal_id: proposal.record.id,
+      expected_revision_hash: proposal.revisionHash,
+    });
   });
 
   it("bounds approval metadata without splitting UTF-16 surrogates", async () => {
@@ -92,6 +119,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
     const proposalIdLength = 60 + 1 + 8 + 1 + 10;
     const fixedLines = [
       `Proposal ID: ${"p".repeat(proposalIdLength)}`,
+      `Revision hash: ${"a".repeat(64)}`,
       `Description: ${description}`,
       "Support files: 0",
       `Body size: ${(Buffer.byteLength(content, "utf8") / 1024).toFixed(1)} KB`,
@@ -120,6 +148,7 @@ describe("resolveSkillWorkshopToolApproval", () => {
 
     expect(approvalDescription.length).toBeLessThanOrEqual(PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH);
     expect(approvalDescription).toContain(`Proposal ID: ${proposal.record.id}`);
+    expect(approvalDescription).toContain(`Revision hash: ${proposal.revisionHash}`);
     expect(approvalDescription).toContain(`Description: ${description}`);
     expect(approvalDescription).toContain("Support files: 0");
     expect(approvalDescription).toContain(
@@ -131,6 +160,39 @@ describe("resolveSkillWorkshopToolApproval", () => {
     expect(approvalDescription).not.toMatch(
       /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
     );
+  });
+
+  it("blocks a stale revision before approval can outlive a concurrent revision", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-policy-version-race-");
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      name: "Version Race",
+      description: "Bind approval to the proposal snapshot",
+      content: "# Version Race\n\nVersion one.\n",
+    });
+
+    const result = await resolveSkillWorkshopToolApproval({
+      toolName: "skill_workshop",
+      toolParams: {
+        action: "apply",
+        proposal_id: proposal.record.id,
+        expected_revision_hash: "f".repeat(64),
+      },
+      workspaceDir,
+      config: pendingApprovalConfig,
+    });
+
+    expect(result).toEqual({
+      block: true,
+      blockReason: `Skill proposal revision ${"f".repeat(64)} does not match the current approval snapshot ${proposal.revisionHash}. Review it again before continuing.`,
+    });
+    const revised = await reviseSkillProposal({
+      workspaceDir,
+      proposalId: proposal.record.id,
+      content: "# Version Race\n\nVersion two.\n",
+    });
+    expect(revised.record.proposedVersion).toBe("v2");
+    expect(result?.requireApproval).toBeUndefined();
   });
 
   it("renders proposal-controlled fields without approval-line injection", async () => {
@@ -151,15 +213,16 @@ describe("resolveSkillWorkshopToolApproval", () => {
     });
     const lines = result?.requireApproval?.description.split("\n") ?? [];
 
-    expect(lines).toHaveLength(5);
+    expect(lines).toHaveLength(6);
     expect(lines[1]).toContain("Target skill: Line↵Break�Spoof");
-    expect(lines[2]).toBe(
+    expect(lines[2]).toBe(`Revision hash: ${proposal.revisionHash}`);
+    expect(lines[3]).toBe(
       "Description: Real description↵Support files: 999�Body size: 999 KB↵Target skill: fake�",
     );
     for (const line of lines) {
       expect(line).not.toMatch(/[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u);
     }
-    expect(lines[3]).toBe("Support files: 0");
+    expect(lines[4]).toBe("Support files: 0");
   });
 
   it("falls back to the action description when the proposal cannot be resolved", async () => {

--- a/src/skills/workshop/policy.ts
+++ b/src/skills/workshop/policy.ts
@@ -79,6 +79,7 @@ function formatApprovalField(value: string): string {
 
 function buildLifecycleApprovalDescription(params: {
   proposalId: string;
+  revisionHash: string;
   skillName: string;
   description: string;
   supportFileCount: number;
@@ -88,6 +89,7 @@ function buildLifecycleApprovalDescription(params: {
   const requestedSkillName = formatApprovalField(params.skillName);
   const fixedLines = [
     `Proposal ID: ${params.proposalId}`,
+    `Revision hash: ${formatApprovalField(params.revisionHash)}`,
     `Description: ${description}`,
     `Support files: ${params.supportFileCount}`,
     `Body size: ${params.bodySizeKb} KB`,
@@ -112,6 +114,7 @@ async function resolveLifecycleApprovalDescription(params: {
 }): Promise<{
   description: string;
   proposalId?: string;
+  revisionHash?: string;
 }> {
   if (!params.workspaceDir) {
     return { description: params.fallback };
@@ -127,12 +130,14 @@ async function resolveLifecycleApprovalDescription(params: {
     return {
       description: buildLifecycleApprovalDescription({
         proposalId: record.id,
+        revisionHash: proposal.revisionHash,
         skillName: record.target.skillName,
         description: record.description,
         supportFileCount: record.supportFiles?.length ?? 0,
         bodySizeKb: formatBodySizeKb(proposal.content),
       }),
       proposalId: record.id,
+      revisionHash: proposal.revisionHash,
     };
   } catch (error) {
     // Approving blind is the failure this record exists to make diagnosable:
@@ -163,6 +168,10 @@ function lifecycleApprovalTimeoutReason(params: {
     "Decide in the Skill Workshop UI or run `openclaw skills workshop apply|reject|quarantine <id>`.",
     "Do not retry this tool call in a loop.",
   ].join(" ");
+}
+
+function lifecycleRevisionMismatchReason(expected: string, current: string): string {
+  return `Skill proposal revision ${formatApprovalField(expected)} does not match the current approval snapshot ${formatApprovalField(current)}. Review it again before continuing.`;
 }
 
 function resolveApprovalConfig(config?: OpenClawConfig): OpenClawConfig | undefined {
@@ -205,7 +214,34 @@ export async function resolveSkillWorkshopToolApproval(params: {
           workspaceDir: params.workspaceDir,
           fallback: text.description,
         });
+  const toolParams = asNullableRecord(params.toolParams);
+  const requestedRevisionHash = normalizeOptionalString(toolParams?.expected_revision_hash);
+  if (
+    approvalDescription.revisionHash &&
+    requestedRevisionHash &&
+    requestedRevisionHash !== approvalDescription.revisionHash
+  ) {
+    return {
+      block: true,
+      blockReason: lifecycleRevisionMismatchReason(
+        requestedRevisionHash,
+        approvalDescription.revisionHash,
+      ),
+    };
+  }
+  // The prompt describes this proposal snapshot, so execution must stay on the
+  // same version or a revision during the approval wait could change the action.
+  const bindProposalSnapshot = approvalDescription.proposalId && approvalDescription.revisionHash;
   return {
+    ...(bindProposalSnapshot
+      ? {
+          params: {
+            ...toolParams,
+            proposal_id: approvalDescription.proposalId,
+            expected_revision_hash: approvalDescription.revisionHash,
+          },
+        }
+      : {}),
     requireApproval: {
       ...text,
       description: approvalDescription.description,


### PR DESCRIPTION
Related: #103871
Related: #103872

## What Problem This Solves

Resolves a problem where an operator can approve one version of a Skill Workshop
proposal and have a different version written to the workspace.

The lifecycle approval prompt describes a specific proposal snapshot — its id,
description, support-file count, body size, and target skill. Nothing tied the
approved action to that snapshot. If the proposal was revised while the prompt was
waiting for a human, the approval still executed, applying content the operator never
saw. The gate reads as "approve this proposal," but it behaved as "approve whatever
this proposal id points at when you click."

## Why This Change Was Made

The approval description now carries the reviewed revision hash, and the approved
action is pinned to that snapshot: `proposal_id` and `expected_revision_hash` are
written into the executed params. When a caller supplies an `expected_revision_hash`
that no longer matches the current proposal, the policy blocks the action and the
before-tool-call path surfaces it as a veto rather than a silent pass.

`expected_revision_hash` already existed as an optional parameter on
evaluate/apply/reject/quarantine; this change makes the approval gate populate and
enforce it instead of leaving it to callers.

**This is deliberately a behavior change, and it is the whole point of the PR:** an
approval that was displayed for revision A can no longer apply revision B. The operator
is told the expected and current revisions and reviews the new version explicitly.

Non-goals: this does not change how proposals are created, revised, or rendered, and
it does not add any configuration surface. It is intentionally separated from the
read-only preview in #103872 so the approval contract can be judged on its own; the two
are independent and can land in either order.

## User Impact

- An approval can no longer apply content the operator did not see.
- Operators see the reviewed revision hash directly in the approval prompt.
- A proposal revised during the approval wait fails closed with a message naming the
  expected and current revisions, instead of applying silently.
- Existing approvals that are not raced are unaffected; no config, command, or default
  changes.

Upgrade note for maintainers: automation that displays an approval prompt, revises the
proposal, and then executes the original approval will now be rejected. That flow is the
exact hazard this closes, but it is a real behavior change on the approval path and is
why this is not folded into the preview PR.

## Evidence

Focused regression coverage in `src/skills/workshop/policy.test.ts`, including a test
that fails on pre-change code: it asserts the executed params carry
`proposal_id` + `expected_revision_hash` for apply/reject/quarantine, and that a
mismatched hash returns a block with both revisions named.

Local verification against current `main` (`5301fb5e7f3`):

| Check | Result |
|---|---|
| `tsgo -p tsconfig.core.json` | pass |
| `oxfmt --check` (repo-wide) | pass |
| `check-max-lines-ratchet` / `check-assertion-safety-ratchet` | pass |
| `src/skills/workshop/policy.test.ts` | 10 passed |
| `agent-tools.before-tool-call.{embedded-mode,network-error}.test.ts` | 30 passed |
| `autoreview` (Codex `gpt-5.6-sol`, high) | clean — no accepted/actionable findings, `patch is correct (0.95)`; TruffleHog clean |

Production delta is +112/-4 across 3 files, of which the test file is the majority; the
production change is the revision-hash plumbing in `policy.ts` plus the veto propagation
in `agent-tools.before-tool-call.approval.ts`.
