### PR TITLE
fix: direct Gateway stops wait for active work

### DIFF
--- a/scripts/bench-agent-concurrency-worker.ts
+++ b/scripts/bench-agent-concurrency-worker.ts
@@ -86,15 +86,18 @@ async function waitForCondition(check: () => boolean): Promise<boolean> {
   return check();
 }
 
-async function drainSpawnSampleRootWork(
-  waitForRootWork?: (timeoutMs: number) => Promise<{ drained: boolean; active: number }>,
+async function drainSpawnSampleActiveWork(
+  waitForActiveWork?: (
+    timeoutMs: number,
+  ) => Promise<{ drained: boolean; snapshot: { counts: { totalActive: number } } }>,
 ): Promise<void> {
   const wait =
-    waitForRootWork ??
-    (await import("../src/process/gateway-work-admission.js")).waitForActiveGatewayRootWork;
+    waitForActiveWork ??
+    (await import("../src/infra/gateway-active-work.js")).waitForGatewayActiveWork;
   const result = await wait(30_000);
-  if (!result.drained || result.active !== 0) {
-    throw new Error(`spawn sample left ${result.active} active gateway root work items`);
+  const active = result.snapshot.counts.totalActive;
+  if (!result.drained || active !== 0) {
+    throw new Error(`spawn sample left ${active} active gateway work items`);
   }
 }
 
@@ -443,7 +446,7 @@ async function runSpawnSample(
     }
     // Terminal rows can settle before detached cleanup and requester-wake roots.
     // Drain before reset so leaked work stays visible and cannot reach the next sample.
-    await drainSpawnSampleRootWork();
+    await drainSpawnSampleActiveWork();
     result = {
       durationMs,
       invariant: {
@@ -816,7 +819,7 @@ async function main(): Promise<void> {
   process.stdout.write(`${WORKER_RESULT_SENTINEL}${JSON.stringify(result)}\n`);
 }
 
-export const testing = { drainSpawnSampleRootWork };
+export const testing = { drainSpawnSampleActiveWork };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   try {

--- a/src/agents/embedded-agent-runner/runs.lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/runs.lifecycle.test.ts
@@ -19,7 +19,6 @@ import {
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
   setActiveEmbeddedRun,
   updateActiveEmbeddedRunSnapshot,
-  waitForActiveEmbeddedRuns,
   waitForEmbeddedAgentRunEnd,
 } from "./runs.js";
 import { testing } from "./runs.test-support.js";
@@ -174,63 +173,6 @@ describe("embedded-agent runner run lifecycle", () => {
 
     clearActiveEmbeddedRun("session-replaced", replacementHandle);
     await expect(waitPromise).resolves.toBe(true);
-  });
-
-  it("waits for active runs to drain", async () => {
-    vi.useFakeTimers();
-    try {
-      const handle = createRunHandle();
-      setActiveEmbeddedRun("session-a", handle);
-      setTimeout(() => {
-        clearActiveEmbeddedRun("session-a", handle);
-      }, 500);
-
-      const waitPromise = waitForActiveEmbeddedRuns(1_000, { pollMs: 100 });
-      await vi.advanceTimersByTimeAsync(500);
-      const result = await waitPromise;
-
-      expect(result.drained).toBe(true);
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
-  });
-
-  it("returns drained=false when timeout elapses", async () => {
-    vi.useFakeTimers();
-    try {
-      setActiveEmbeddedRun("session-a", createRunHandle());
-
-      const waitPromise = waitForActiveEmbeddedRuns(1_000, { pollMs: 100 });
-      await vi.advanceTimersByTimeAsync(1_000);
-      const result = await waitPromise;
-      expect(result.drained).toBe(false);
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
-  });
-
-  it("clamps oversized active-run drain poll intervals", async () => {
-    vi.useFakeTimers();
-    try {
-      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
-      const handle = createRunHandle();
-      setActiveEmbeddedRun("session-a", handle);
-
-      const waitPromise = waitForActiveEmbeddedRuns(undefined, {
-        pollMs: Number.MAX_SAFE_INTEGER,
-      });
-      await Promise.resolve();
-
-      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
-      clearActiveEmbeddedRun("session-a", handle);
-      await vi.advanceTimersByTimeAsync(MAX_TIMER_TIMEOUT_MS);
-      await expect(waitPromise).resolves.toEqual({ drained: true });
-    } finally {
-      await vi.runOnlyPendingTimersAsync();
-      vi.useRealTimers();
-    }
   });
 
   it("shares active run state across distinct module instances", async () => {

--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -56,7 +56,6 @@ import {
   ABANDONED_EMBEDDED_RUN_SESSION_IDS_BY_KEY,
   EMBEDDED_RUN_FORCED_TERMINAL_SETTLEMENTS,
   EMBEDDED_RUN_WAITERS,
-  getActiveEmbeddedRunCount,
   RETAINED_EMBEDDED_RUN_ABORTABILITY_RUN_IDS,
   setActiveEmbeddedRunLifecycleGeneration,
   type ActiveEmbeddedRunSnapshot,
@@ -859,44 +858,6 @@ export function getActiveEmbeddedRunSnapshot(
   sessionId: string,
 ): ActiveEmbeddedRunSnapshot | undefined {
   return ACTIVE_EMBEDDED_RUN_SNAPSHOTS.get(sessionId);
-}
-
-/**
- * Wait for active embedded runs to drain.
- *
- * Used during restarts so in-flight runs can finish transcript writes before the
- * next lifecycle starts. If no timeout is passed, waits indefinitely.
- */
-export async function waitForActiveEmbeddedRuns(
-  timeoutMs?: number,
-  opts?: { pollMs?: number },
-): Promise<{ drained: boolean }> {
-  const pollMsRaw = opts?.pollMs ?? 250;
-  const pollMs = resolveTimerTimeoutMs(pollMsRaw, 250, 10);
-  if (timeoutMs !== undefined && timeoutMs <= 0) {
-    return { drained: getActiveEmbeddedRunCount() === 0 };
-  }
-  const maxWaitMs =
-    typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
-      ? Math.max(pollMs, Math.floor(timeoutMs))
-      : undefined;
-
-  const startedAt = Date.now();
-  while (true) {
-    if (getActiveEmbeddedRunCount() === 0) {
-      return { drained: true };
-    }
-    const elapsedMs = Date.now() - startedAt;
-    if (maxWaitMs !== undefined && elapsedMs >= maxWaitMs) {
-      diag.warn(
-        `wait for active embedded runs timed out: activeRuns=${getActiveEmbeddedRunCount()} timeoutMs=${maxWaitMs}`,
-      );
-      return { drained: false };
-    }
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, pollMs);
-    });
-  }
 }
 
 function waitForCurrentEmbeddedAgentRunEnd(

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -14,7 +14,6 @@ import {
   resetGatewayWorkAdmission,
   runWithGatewayIndependentRootWorkAdmission,
   tryBeginGatewaySuspendAdmission,
-  waitForActiveGatewayRootWork,
 } from "../../../process/gateway-work-admission.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "../../../tasks/detached-task-runtime-contract.js";
 import {
@@ -4147,7 +4146,7 @@ describe("requester settle wake trigger", () => {
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 0);
     });
-    await waitForActiveGatewayRootWork(1_000);
+    await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
 
     expect(internalSessionEffectsMocks.removeInternalSessionEffectsSession).not.toHaveBeenCalled();
     expect(bundleMcpRuntimeMocks.retireSessionMcpRuntimeForSessionKey).not.toHaveBeenCalled();
@@ -4288,7 +4287,7 @@ describe("requester settle wake trigger", () => {
     });
     runs.set(successor.runId, successor);
     expect(suspension?.release()).toBe(true);
-    await waitForActiveGatewayRootWork(1_000);
+    await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
 
     expect(internalSessionEffectsMocks.removeInternalSessionEffectsSession).not.toHaveBeenCalled();
     expect(bundleMcpRuntimeMocks.retireSessionMcpRuntimeForSessionKey).not.toHaveBeenCalled();
@@ -4735,7 +4734,7 @@ describe("requester settle wake trigger", () => {
     });
     runs.set(successor.runId, successor);
     expect(suspension?.release()).toBe(true);
-    await waitForActiveGatewayRootWork(1_000);
+    await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
 
     expect(internalSessionEffectsMocks.removeInternalSessionEffectsSession).not.toHaveBeenCalled();
     expect(bundleMcpRuntimeMocks.retireSessionMcpRuntimeForSessionKey).not.toHaveBeenCalled();
@@ -5037,11 +5036,10 @@ describe("requester settle wake trigger", () => {
       // A restart drain arriving between scheduling and the wake's gateway
       // turn must wait for the wake instead of reporting quiescence.
       markGatewayRestartDraining();
-      expect((await waitForActiveGatewayRootWork(25)).drained).toBe(false);
+      expect(getActiveGatewayRootWorkCount()).toBe(1);
 
       releaseWake?.();
       await waitForLifecycleState(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
-      expect((await waitForActiveGatewayRootWork(1_000)).drained).toBe(true);
     } finally {
       resetGatewayWorkAdmission();
     }

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -4,10 +4,8 @@
 // a facade also evaluates its siblings and drags their graphs onto cold start.
 export {
   abortEmbeddedAgentRun,
-  getActiveEmbeddedRunCount,
   listActiveEmbeddedRunSessionIds,
   listActiveEmbeddedRunSessionKeys,
-  waitForActiveEmbeddedRuns,
 } from "../../agents/embedded-agent-runner/runs.js";
 export { markRestartAbortedMainSessions } from "../../agents/main-session-recovery/main-session-restart-recovery-marking.js";
 export { getRuntimeConfig } from "../../config/config.js";
@@ -41,6 +39,10 @@ export {
 } from "../../infra/supervisor-markers.js";
 export { writeDiagnosticStabilityBundleForFailureSync } from "../../logging/diagnostic-stability-bundle.js";
 export {
+  createGatewayActiveWorkSnapshot,
+  waitForGatewayActiveWork,
+} from "../../infra/gateway-active-work.js";
+export {
   advanceCronActiveJobGeneration,
   resetCronActiveJobs,
   waitForActiveCronJobs,
@@ -50,13 +52,6 @@ export {
   retireActiveCronTaskRunTracking,
   waitForActiveCronTaskRuns,
 } from "../../cron/service/active-run-cancellation.js";
-export {
-  getActiveTaskCount,
-  markGatewayDraining,
-  resetAllLanes,
-  waitForActiveTasks,
-} from "../../process/command-queue.js";
-export { waitForActiveGatewayRootWork } from "../../process/gateway-work-admission.js";
-export { getInspectableActiveTaskRestartBlockers } from "../../tasks/task-registry.maintenance.js";
+export { markGatewayDraining, resetAllLanes } from "../../process/command-queue.js";
 export { reloadTaskRuntimeStateFromStore } from "../../tasks/runtime-internal.js";
 export { abortPendingChannelReloads } from "../../gateway/server-reload-contracts.js";

--- a/src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts
+++ b/src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts
@@ -1,0 +1,189 @@
+// Process-boundary proof for direct-stop draining after durable channel-turn adoption.
+import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+
+const CHILD_READY_TIMEOUT_MS = 45_000;
+const TEST_TIMEOUT_MS = 60_000;
+const RELEASE_DELAY_MS = 400;
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const children = new Set<ChildProcess>();
+
+afterEach(() => {
+  for (const child of children) {
+    child.kill("SIGKILL");
+  }
+  children.clear();
+});
+
+const moduleUrl = (relativePath: string) => pathToFileURL(path.resolve(relativePath)).href;
+
+const childScript = `
+  import fs from "node:fs";
+  import path from "node:path";
+  import { createChannelIngressDrain } from ${JSON.stringify(moduleUrl("src/channels/message/ingress-drain.ts"))};
+  import { createChannelIngressQueue } from ${JSON.stringify(moduleUrl("src/channels/message/ingress-queue.ts"))};
+  import {
+    clearActiveEmbeddedRun,
+    getActiveEmbeddedRunCount,
+    setActiveEmbeddedRun,
+  } from ${JSON.stringify(moduleUrl("src/agents/embedded-agent-runner/runs.ts"))};
+  import { runGatewayLoop } from ${JSON.stringify(moduleUrl("src/cli/gateway-cli/run-loop.ts"))};
+  import { getActiveGatewayRootWorkCount } from ${JSON.stringify(moduleUrl("src/process/gateway-work-admission.ts"))};
+
+  const tracePath = process.argv[1];
+  const stateDir = process.argv[2];
+  const trace = (line) => fs.appendFileSync(tracePath, line + "\\n");
+  const keepAlive = setInterval(() => {}, 1_000);
+  const queue = createChannelIngressQueue({
+    channelId: "process-proof",
+    accountId: "direct-stop",
+    stateDir,
+  });
+  let releaseEmbedded;
+  const embeddedMaySettle = new Promise((resolve) => {
+    releaseEmbedded = resolve;
+  });
+  let resolveAdopted;
+  const adopted = new Promise((resolve) => {
+    resolveAdopted = resolve;
+  });
+  const sessionId = "direct-stop-active-work";
+  const sessionKey = "agent:main:process-proof:direct-stop-active-work";
+  const handle = {
+    runId: "run-direct-stop-active-work",
+    queueMessage: async () => {},
+    isStreaming: () => true,
+    isCompacting: () => false,
+    abort: () => trace("embedded-aborted"),
+  };
+  const drain = createChannelIngressDrain({
+    queue,
+    dispatchClaimedEvent: async (_event, lifecycle) => {
+      setActiveEmbeddedRun(sessionId, handle, sessionKey);
+      await lifecycle.onAdopted();
+      trace(
+        "adopted:roots=" +
+          getActiveGatewayRootWorkCount() +
+          ":embedded=" +
+          getActiveEmbeddedRunCount(),
+      );
+      resolveAdopted();
+      await embeddedMaySettle;
+      clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+      trace("embedded-completed");
+    },
+  });
+
+  await queue.enqueue("event-direct-stop", { text: "hello" }, { laneKey: sessionKey });
+  process.prependOnceListener("SIGTERM", () => {
+    trace("signal:SIGTERM");
+    setTimeout(() => releaseEmbedded(), ${RELEASE_DELAY_MS});
+  });
+
+  await runGatewayLoop({
+    start: async () => {
+      await drain.drainOnce();
+      await adopted;
+      setImmediate(() => trace("gateway-ready"));
+      return {
+        getTailscaleIngressEndpoint: () => undefined,
+        startupSettled: Promise.resolve(),
+        close: async () => {
+          trace("gateway-close");
+          drain.dispose();
+        },
+      };
+    },
+    runtime: {
+      log: () => {},
+      error: () => {},
+      exit: (code) => {
+        clearInterval(keepAlive);
+        trace("process-exit:" + code);
+        process.exit(code);
+      },
+    },
+    lockPort: 19473,
+  });
+`;
+
+function readTrace(tracePath: string): string[] {
+  try {
+    return fs.readFileSync(tracePath, "utf8").split("\n").filter(Boolean);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+describe("runGatewayLoop direct-stop active work", () => {
+  const posixIt = process.platform === "win32" ? it.skip : it;
+
+  posixIt(
+    "waits for a rootless adopted channel run before close after an OS SIGTERM",
+    async () => {
+      const fixtureDir = tempDirs.make("openclaw-direct-stop-active-work-");
+      const stateDir = path.join(fixtureDir, "state");
+      const homeDir = path.join(fixtureDir, "home");
+      const tracePath = path.join(fixtureDir, "trace.log");
+      fs.mkdirSync(stateDir, { recursive: true });
+      fs.mkdirSync(homeDir, { recursive: true });
+      const child = spawn(
+        process.execPath,
+        ["--import", "tsx", "--input-type=module", "--eval", childScript, tracePath, stateDir],
+        {
+          cwd: path.resolve("."),
+          env: {
+            ...process.env,
+            HOME: homeDir,
+            NODE_ENV: undefined,
+            NODE_DISABLE_COMPILE_CACHE: "1",
+            NODE_OPTIONS: undefined,
+            OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+            OPENCLAW_STATE_DIR: stateDir,
+            VITEST: undefined,
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      children.add(child);
+      const stderr: Buffer[] = [];
+      child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
+
+      await vi.waitFor(
+        () => {
+          expect(readTrace(tracePath), Buffer.concat(stderr).toString("utf8")).toContain(
+            "gateway-ready",
+          );
+        },
+        { timeout: CHILD_READY_TIMEOUT_MS, interval: 25 },
+      );
+      const exited = once(child, "exit") as Promise<
+        [code: number | null, signal: NodeJS.Signals | null]
+      >;
+      expect(child.kill("SIGTERM")).toBe(true);
+
+      const exit = await exited;
+      expect(
+        exit,
+        `${readTrace(tracePath).join(" -> ")}\n${Buffer.concat(stderr).toString("utf8")}`,
+      ).toEqual([0, null]);
+      children.delete(child);
+      const trace = readTrace(tracePath);
+      expect(trace).toContain("adopted:roots=0:embedded=1");
+      expect(trace).not.toContain("embedded-aborted");
+      expect(trace.indexOf("signal:SIGTERM")).toBeLessThan(trace.indexOf("embedded-completed"));
+      expect(trace.indexOf("embedded-completed")).toBeLessThan(trace.indexOf("gateway-close"));
+      expect(trace.indexOf("gateway-close")).toBeLessThan(trace.indexOf("process-exit:0"));
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayServer } from "../../gateway/server-public.js";
 import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
+import type { GatewayActiveWorkSnapshot } from "../../infra/gateway-active-work.js";
 import { resolveGlobalMap } from "../../shared/global-singleton.js";
 import {
   GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
@@ -61,23 +62,45 @@ const scheduleGatewaySigusr1Restart = vi.fn((_opts?: { delayMs?: number; reason?
   coalesced: false,
   cooldownMsApplied: 0,
 }));
-const getActiveTaskCount = vi.fn(() => 0);
-const getInspectableActiveTaskRestartBlockers = vi.fn(
-  () =>
-    [] as Array<{
-      taskId: string;
-      status: "queued" | "running";
-      runtime: "subagent" | "acp" | "cli" | "cron";
-      runId?: string;
-      label?: string;
-      title?: string;
-    }>,
+const createActiveWorkSnapshot = (
+  counts: Partial<GatewayActiveWorkSnapshot["counts"]> = {},
+  blockers: GatewayActiveWorkSnapshot["blockers"] = [],
+): GatewayActiveWorkSnapshot => {
+  const resolvedCounts = {
+    queueSize: 0,
+    pendingReplies: 0,
+    embeddedRuns: 0,
+    backgroundExecSessions: 0,
+    cronRuns: 0,
+    activeTasks: 0,
+    rootRequests: 0,
+    sessionAdmissions: 0,
+    sessionMutations: 0,
+    chatRuns: 0,
+    queuedTurns: 0,
+    terminalPersistence: 0,
+    terminalSessions: 0,
+    totalActive: 0,
+    ...counts,
+  };
+  resolvedCounts.totalActive = Object.entries(resolvedCounts).reduce(
+    (total, [key, count]) => total + (key === "totalActive" ? 0 : count),
+    0,
+  );
+  return { idle: resolvedCounts.totalActive === 0, counts: resolvedCounts, blockers };
+};
+const idleActiveWorkSnapshot = createActiveWorkSnapshot();
+const createGatewayActiveWorkSnapshot = vi.fn(() => idleActiveWorkSnapshot);
+const waitForGatewayActiveWork = vi.fn(
+  async (
+    _timeoutMs?: number,
+    options?: { onSnapshot?: (snapshot: GatewayActiveWorkSnapshot) => void },
+  ) => {
+    const snapshot = createGatewayActiveWorkSnapshot();
+    options?.onSnapshot?.(snapshot);
+    return { drained: snapshot.idle, snapshot };
+  },
 );
-const waitForActiveTasks = vi.fn(async (_timeoutMs?: number) => ({ drained: true }));
-const waitForActiveGatewayRootWork = vi.fn(async (_timeoutMs?: number) => ({
-  drained: true,
-  active: 0,
-}));
 const advanceCronActiveJobGeneration = vi.fn();
 const resetCronActiveJobs = vi.fn();
 const abortActiveCronTaskRuns = vi.fn((_reason?: string) => 0);
@@ -116,17 +139,12 @@ const abortPendingChannelReloads = vi.fn();
 const abortEmbeddedAgentRun = vi.fn(
   (_sessionId?: string, _opts?: { mode?: "all" | "compacting"; reason?: "restart" }) => false,
 );
-const getActiveEmbeddedRunCount = vi.fn(() => 0);
 const listActiveEmbeddedRunSessionIds = vi.fn(() => [] as string[]);
 const listActiveEmbeddedRunSessionKeys = vi.fn(() => [] as string[]);
 const markRestartAbortedMainSessions = vi.fn(async (_params: unknown) => ({
   marked: 1,
   skipped: 0,
 }));
-const waitForActiveEmbeddedRuns = vi.fn(async (_timeoutMs?: number) => ({ drained: true }));
-const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart";
-const ACTIVE_RUN_DRAIN_TIMEOUT_LOG =
-  "active embedded run drain timeout reached; aborting active run(s) before restart";
 const DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS = 300_000;
 const loadConfig = vi.fn(() => ({}));
 const gatewayLog = {
@@ -190,18 +208,12 @@ vi.mock("../../infra/restart-handoff.js", () => ({
   writeGatewayRestartHandoffSync: (opts: unknown) => writeGatewayRestartHandoffSync(opts),
 }));
 
-vi.mock("../../process/command-queue.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../process/command-queue.js")>();
-  return {
-    ...actual,
-    getActiveTaskCount: () => getActiveTaskCount(),
-    waitForActiveTasks: (timeoutMs?: number) => waitForActiveTasks(timeoutMs),
-  };
-});
-
-vi.mock("../../process/gateway-work-admission.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../process/gateway-work-admission.js")>()),
-  waitForActiveGatewayRootWork: (timeoutMs?: number) => waitForActiveGatewayRootWork(timeoutMs),
+vi.mock("../../infra/gateway-active-work.js", () => ({
+  createGatewayActiveWorkSnapshot: () => createGatewayActiveWorkSnapshot(),
+  waitForGatewayActiveWork: (
+    timeoutMs?: number,
+    options?: { onSnapshot?: (snapshot: GatewayActiveWorkSnapshot) => void },
+  ) => waitForGatewayActiveWork(timeoutMs, options),
 }));
 
 vi.mock("../../cron/active-jobs.js", () => ({
@@ -225,19 +237,13 @@ vi.mock("../../config/runtime-snapshot.js", () => ({
   registerRuntimeConfigSnapshotPreparer: vi.fn(),
 }));
 
-vi.mock("../../tasks/task-registry.maintenance.js", () => ({
-  getInspectableActiveTaskRestartBlockers: () => getInspectableActiveTaskRestartBlockers(),
-}));
-
 vi.mock("../../agents/embedded-agent-runner/runs.js", () => ({
   abortEmbeddedAgentRun: (
     sessionId?: string,
     opts?: { mode?: "all" | "compacting"; reason?: "restart" },
   ) => abortEmbeddedAgentRun(sessionId, opts),
-  getActiveEmbeddedRunCount: () => getActiveEmbeddedRunCount(),
   listActiveEmbeddedRunSessionIds: () => listActiveEmbeddedRunSessionIds(),
   listActiveEmbeddedRunSessionKeys: () => listActiveEmbeddedRunSessionKeys(),
-  waitForActiveEmbeddedRuns: (timeoutMs?: number) => waitForActiveEmbeddedRuns(timeoutMs),
 }));
 
 vi.mock("../../agents/main-session-recovery/main-session-restart-recovery-marking.js", () => ({
@@ -470,6 +476,14 @@ let gatewayWorkAdmissionActual: typeof import("../../process/gateway-work-admiss
 beforeEach(async () => {
   gatewayWorkAdmissionActual = await vi.importActual("../../process/gateway-work-admission.js");
   gatewayWorkAdmissionActual.resetGatewayWorkAdmission();
+  createGatewayActiveWorkSnapshot.mockReset();
+  createGatewayActiveWorkSnapshot.mockReturnValue(idleActiveWorkSnapshot);
+  waitForGatewayActiveWork.mockReset();
+  waitForGatewayActiveWork.mockImplementation(async (_timeoutMs, options) => {
+    const snapshot = createGatewayActiveWorkSnapshot();
+    options?.onSnapshot?.(snapshot);
+    return { drained: snapshot.idle, snapshot };
+  });
 });
 
 describe("runGatewayLoop", () => {
@@ -688,7 +702,7 @@ describe("runGatewayLoop", () => {
   });
 
   it.each(["SIGTERM", "SIGINT"] as const)(
-    "drains admitted root work before closing on %s",
+    "drains rootless embedded work before closing on direct %s stop",
     async (signal) => {
       vi.clearAllMocks();
 
@@ -698,22 +712,28 @@ describe("runGatewayLoop", () => {
         const pendingDrain = new Promise<void>((resolve) => {
           releaseDrain = resolve;
         });
-        waitForActiveGatewayRootWork.mockImplementationOnce(async () => {
+        const activeSnapshot = createActiveWorkSnapshot({ embeddedRuns: 1 }, [
+          { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
+        ]);
+        waitForGatewayActiveWork.mockImplementationOnce(async (_timeoutMs, options) => {
+          options?.onSnapshot?.(activeSnapshot);
           await pendingDrain;
-          return { drained: true, active: 0 };
+          return { drained: true, snapshot: idleActiveWorkSnapshot };
         });
 
         try {
           captureSignal(signal)();
           await waitForLoopCondition(
-            () => waitForActiveGatewayRootWork.mock.calls.length === 1,
-            `expected ${signal} to drain admitted gateway root work`,
+            () => waitForGatewayActiveWork.mock.calls.length === 1,
+            `expected ${signal} to drain canonical active work`,
           );
 
           expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(true);
-          expect(waitForActiveGatewayRootWork).toHaveBeenCalledWith(15_000);
+          expect(waitForGatewayActiveWork).toHaveBeenCalledWith(15_000, undefined);
           expect(close).not.toHaveBeenCalled();
           expect(runtime.exit).not.toHaveBeenCalled();
+          expect(abortEmbeddedAgentRun).not.toHaveBeenCalled();
+          expect(markRestartAbortedMainSessions).not.toHaveBeenCalled();
 
           releaseDrain?.();
 
@@ -725,68 +745,64 @@ describe("runGatewayLoop", () => {
         } finally {
           releaseDrain?.();
           await exited;
-          waitForActiveGatewayRootWork.mockReset();
-          waitForActiveGatewayRootWork.mockResolvedValue({ drained: true, active: 0 });
         }
       });
     },
   );
 
-  it("continues direct shutdown when the bounded root-work drain times out", async () => {
+  it("continues direct shutdown when the bounded active-work drain times out", async () => {
     vi.clearAllMocks();
 
     await withIsolatedSignals(async ({ captureSignal }) => {
-      waitForActiveGatewayRootWork.mockResolvedValueOnce({ drained: false, active: 2 });
+      const timedOutSnapshot = createActiveWorkSnapshot({ embeddedRuns: 2 }, [
+        { kind: "embedded-run", count: 2, message: "2 active embedded run(s)" },
+      ]);
+      waitForGatewayActiveWork.mockResolvedValueOnce({
+        drained: false,
+        snapshot: timedOutSnapshot,
+      });
       const { close, runtime, exited } = await createSignaledLoopHarness();
 
-      try {
-        captureSignal("SIGTERM")();
+      captureSignal("SIGTERM")();
 
-        await expect(exited).resolves.toBe(0);
-        expect(waitForActiveGatewayRootWork).toHaveBeenCalledWith(15_000);
-        expect(gatewayLog.warn).toHaveBeenCalledWith(
-          "gateway root transaction drain timeout reached with 2 root(s) still active; proceeding with shutdown",
-        );
-        expect(close).toHaveBeenCalledWith({
-          reason: "gateway stopping",
-          restartExpectedMs: null,
-        });
-        expect(runtime.exit).toHaveBeenCalledWith(0);
-      } finally {
-        waitForActiveGatewayRootWork.mockReset();
-        waitForActiveGatewayRootWork.mockResolvedValue({ drained: true, active: 0 });
-      }
+      await expect(exited).resolves.toBe(0);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(15_000, undefined);
+      expect(gatewayLog.warn).toHaveBeenCalledWith(
+        "gateway active-work drain timeout reached; proceeding with shutdown: 2 active embedded run(s)",
+      );
+      expect(close).toHaveBeenCalledWith({
+        reason: "gateway stopping",
+        restartExpectedMs: null,
+      });
+      expect(runtime.exit).toHaveBeenCalledWith(0);
+      expect(abortEmbeddedAgentRun).not.toHaveBeenCalled();
+      expect(markRestartAbortedMainSessions).not.toHaveBeenCalled();
     });
   });
 
-  it("still closes and exits when the direct-shutdown root-work drain fails", async () => {
+  it("still closes and exits when the direct-shutdown active-work drain fails", async () => {
     vi.clearAllMocks();
 
     await withIsolatedSignals(async ({ captureSignal }) => {
-      waitForActiveGatewayRootWork.mockRejectedValueOnce(new Error("root drain unavailable"));
+      waitForGatewayActiveWork.mockRejectedValueOnce(new Error("active-work drain unavailable"));
       const { close, runtime, exited } = await createSignaledLoopHarness();
 
-      try {
-        captureSignal("SIGTERM")();
+      captureSignal("SIGTERM")();
 
-        await expect(exited).resolves.toBe(0);
-        expect(waitForActiveGatewayRootWork).toHaveBeenCalledWith(15_000);
-        expect(gatewayLog.warn).toHaveBeenCalledWith(
-          "gateway root transaction drain failed; proceeding with shutdown: root drain unavailable",
-        );
-        expect(close).toHaveBeenCalledWith({
-          reason: "gateway stopping",
-          restartExpectedMs: null,
-        });
-        expect(runtime.exit).toHaveBeenCalledWith(0);
-      } finally {
-        waitForActiveGatewayRootWork.mockReset();
-        waitForActiveGatewayRootWork.mockResolvedValue({ drained: true, active: 0 });
-      }
+      await expect(exited).resolves.toBe(0);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(15_000, undefined);
+      expect(gatewayLog.warn).toHaveBeenCalledWith(
+        "gateway active-work drain failed; proceeding with shutdown: active-work drain unavailable",
+      );
+      expect(close).toHaveBeenCalledWith({
+        reason: "gateway stopping",
+        restartExpectedMs: null,
+      });
+      expect(runtime.exit).toHaveBeenCalledWith(0);
     });
   });
 
-  it("does not start a second root-work drain for repeated shutdown signals", async () => {
+  it("does not start a second active-work drain for repeated shutdown signals", async () => {
     vi.clearAllMocks();
 
     await withIsolatedSignals(async ({ captureSignal }) => {
@@ -795,9 +811,9 @@ describe("runGatewayLoop", () => {
       const pendingDrain = new Promise<void>((resolve) => {
         releaseDrain = resolve;
       });
-      waitForActiveGatewayRootWork.mockImplementationOnce(async () => {
+      waitForGatewayActiveWork.mockImplementationOnce(async () => {
         await pendingDrain;
-        return { drained: true, active: 0 };
+        return { drained: true, snapshot: idleActiveWorkSnapshot };
       });
 
       try {
@@ -805,13 +821,13 @@ describe("runGatewayLoop", () => {
         const sigint = captureSignal("SIGINT");
         sigterm();
         await waitForLoopCondition(
-          () => waitForActiveGatewayRootWork.mock.calls.length === 1,
-          "expected first shutdown signal to begin the root-work drain",
+          () => waitForGatewayActiveWork.mock.calls.length === 1,
+          "expected first shutdown signal to begin the active-work drain",
         );
 
         sigint();
 
-        expect(waitForActiveGatewayRootWork).toHaveBeenCalledOnce();
+        expect(waitForGatewayActiveWork).toHaveBeenCalledOnce();
         expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(true);
         expect(gatewayLog.info).toHaveBeenCalledWith("received SIGINT during shutdown; ignoring");
 
@@ -820,8 +836,6 @@ describe("runGatewayLoop", () => {
       } finally {
         releaseDrain?.();
         await exited;
-        waitForActiveGatewayRootWork.mockReset();
-        waitForActiveGatewayRootWork.mockResolvedValue({ drained: true, active: 0 });
       }
     });
   });
@@ -852,7 +866,13 @@ describe("runGatewayLoop", () => {
   it("treats SIGTERM with a restart intent as a draining restart", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({});
-    getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
+    createGatewayActiveWorkSnapshot
+      .mockReturnValueOnce(
+        createActiveWorkSnapshot({ activeTasks: 1 }, [
+          { kind: "task", count: 1, message: "1 active background task run(s)" },
+        ]),
+      )
+      .mockReturnValue(idleActiveWorkSnapshot);
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       const closeFirst = createCloseMock();
@@ -889,7 +909,10 @@ describe("runGatewayLoop", () => {
       });
 
       expect(consumeGatewayRestartIntentPayloadSync).toHaveBeenCalledOnce();
-      expect(waitForActiveTasks).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledOnce();
+      expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(
+        DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS,
+      );
       expectRestartCloseCall(closeFirst, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       await startedSecond;
       expect(start).toHaveBeenCalledTimes(2);
@@ -909,8 +932,14 @@ describe("runGatewayLoop", () => {
   it("uses restart intent wait overrides for SIGTERM drain", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ waitMs: 2_500 });
-    getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
-    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    createGatewayActiveWorkSnapshot
+      .mockReturnValueOnce(
+        createActiveWorkSnapshot({ activeTasks: 1, embeddedRuns: 1 }, [
+          { kind: "task", count: 1, message: "1 active background task run(s)" },
+          { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
+        ]),
+      )
+      .mockReturnValue(idleActiveWorkSnapshot);
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { start, exited } = await createSignaledLoopHarness();
@@ -925,8 +954,8 @@ describe("runGatewayLoop", () => {
         setImmediate(resolve);
       });
 
-      expect(waitForActiveTasks).toHaveBeenCalledWith(2_500);
-      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(2_500);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledOnce();
+      expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(2_500);
       expect(start).toHaveBeenCalledTimes(2);
 
       sigint();
@@ -962,8 +991,13 @@ describe("runGatewayLoop", () => {
   it("waits indefinitely for active embedded runs on unbounded restarts", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ waitMs: 0 });
-    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
-    waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
+    createGatewayActiveWorkSnapshot
+      .mockReturnValueOnce(
+        createActiveWorkSnapshot({ embeddedRuns: 1 }, [
+          { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
+        ]),
+      )
+      .mockReturnValue(idleActiveWorkSnapshot);
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { close, start, exited } = await createSignaledLoopHarness();
@@ -978,7 +1012,7 @@ describe("runGatewayLoop", () => {
         setImmediate(resolve);
       });
 
-      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(undefined);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(undefined, expect.any(Object));
       expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
         mode: "compacting",
         reason: "restart",
@@ -998,12 +1032,17 @@ describe("runGatewayLoop", () => {
   it("uses the restart drain timeout for active embedded runs before aborting", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({});
-    getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
-    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    const timedOutSnapshot = createActiveWorkSnapshot({ activeTasks: 1, embeddedRuns: 1 }, [
+      { kind: "task", count: 1, message: "1 active background task run(s)" },
+      { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
+    ]);
+    createGatewayActiveWorkSnapshot.mockReturnValue(timedOutSnapshot);
     listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-embedded-timeout"]);
     listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:embedded-timeout"]);
-    waitForActiveTasks.mockResolvedValueOnce({ drained: false });
-    waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: false });
+    waitForGatewayActiveWork.mockResolvedValueOnce({
+      drained: false,
+      snapshot: timedOutSnapshot,
+    });
     markRestartAbortedMainSessions.mockRejectedValueOnce(new Error("store read-only"));
 
     await withIsolatedSignals(async ({ captureSignal }) => {
@@ -1019,10 +1058,8 @@ describe("runGatewayLoop", () => {
         setImmediate(resolve);
       });
 
-      expect(waitForActiveTasks).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
-      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
-      expect(waitForActiveGatewayRootWork).toHaveBeenCalledOnce();
-      expect(waitForActiveGatewayRootWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(
+      expect(waitForGatewayActiveWork).toHaveBeenCalledOnce();
+      expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(
         DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS,
       );
       expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
@@ -1033,8 +1070,9 @@ describe("runGatewayLoop", () => {
         mode: "all",
         reason: "restart",
       });
-      expect(gatewayLog.warn).toHaveBeenCalledWith(ACTIVE_RUN_DRAIN_TIMEOUT_LOG);
-      expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
+      expect(gatewayLog.warn).toHaveBeenCalledWith(
+        "active-work drain timeout reached; proceeding with restart: 1 active background task run(s); 1 active embedded run(s)",
+      );
       expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
         cfg: {},
         sessionIds: new Set(["session-embedded-timeout"]),
@@ -1058,8 +1096,12 @@ describe("runGatewayLoop", () => {
       force: true,
       reason: "config reload forced restart",
     });
-    getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
-    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    createGatewayActiveWorkSnapshot.mockReturnValue(
+      createActiveWorkSnapshot({ activeTasks: 1, embeddedRuns: 1 }, [
+        { kind: "task", count: 1, message: "1 active background task run(s)" },
+        { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
+      ]),
+    );
     listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-deferral-timeout"]);
     listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:deferral-timeout"]);
     markRestartAbortedMainSessions.mockRejectedValueOnce(new Error("store read-only"));
@@ -1077,9 +1119,7 @@ describe("runGatewayLoop", () => {
         setImmediate(resolve);
       });
 
-      expect(waitForActiveTasks).not.toHaveBeenCalled();
-      expect(waitForActiveEmbeddedRuns).not.toHaveBeenCalled();
-      expect(waitForActiveGatewayRootWork).not.toHaveBeenCalled();
+      expect(waitForGatewayActiveWork).not.toHaveBeenCalled();
       expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
         mode: "compacting",
         reason: "restart",
@@ -1116,24 +1156,18 @@ describe("runGatewayLoop", () => {
   it("forces SIGTERM restarts without waiting for active task drain", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ force: true });
-    getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
-    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    createGatewayActiveWorkSnapshot.mockReturnValue(
+      createActiveWorkSnapshot({ activeTasks: 1, embeddedRuns: 1 }, [
+        {
+          kind: "task",
+          count: 1,
+          message: "taskId=task-force runId=run-force status=running runtime=cron label=forced",
+        },
+        { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
+      ]),
+    );
     listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-forced-task"]);
     listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:forced-task"]);
-    const forceTaskBlockers = [
-      {
-        taskId: "task-force",
-        runId: "run-force",
-        status: "running" as const,
-        runtime: "cron" as const,
-        label: "forced",
-      },
-    ];
-    getInspectableActiveTaskRestartBlockers
-      .mockReturnValueOnce(forceTaskBlockers)
-      .mockReturnValueOnce(forceTaskBlockers)
-      .mockReturnValueOnce(forceTaskBlockers);
-
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { start, exited } = await createSignaledLoopHarness();
       const sigterm = captureSignal("SIGTERM");
@@ -1147,8 +1181,7 @@ describe("runGatewayLoop", () => {
         setImmediate(resolve);
       });
 
-      expect(waitForActiveTasks).not.toHaveBeenCalled();
-      expect(waitForActiveEmbeddedRuns).not.toHaveBeenCalled();
+      expect(waitForGatewayActiveWork).not.toHaveBeenCalled();
       expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
         mode: "all",
         reason: "restart",
@@ -1160,8 +1193,10 @@ describe("runGatewayLoop", () => {
         reason: "gateway restart drain",
       });
       expect(markRestartAbortedMainSessions).toHaveBeenCalledTimes(1);
-      expect(gatewayLog.warn).toHaveBeenCalledWith(
-        "restart blocked by active background task run(s): taskId=task-force runId=run-force status=running runtime=cron label=forced",
+      expect(gatewayLog.info).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "taskId=task-force runId=run-force status=running runtime=cron label=forced",
+        ),
       );
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "forced restart requested; skipping active work drain",
@@ -1183,12 +1218,19 @@ describe("runGatewayLoop", () => {
     markUpdateRestartSentinelFailure.mockClear();
 
     await withIsolatedSignals(async ({ captureSignal }) => {
-      getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0);
-      getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValueOnce(0);
+      const timedOutSnapshot = createActiveWorkSnapshot({ activeTasks: 2, embeddedRuns: 1 }, [
+        { kind: "task", count: 2, message: "2 active background task run(s)" },
+        { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
+      ]);
+      createGatewayActiveWorkSnapshot
+        .mockReturnValueOnce(timedOutSnapshot)
+        .mockReturnValue(idleActiveWorkSnapshot);
       listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-issue-82433"]);
       listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:issue-82433"]);
-      waitForActiveTasks.mockResolvedValueOnce({ drained: false });
-      waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
+      waitForGatewayActiveWork.mockResolvedValueOnce({
+        drained: false,
+        snapshot: timedOutSnapshot,
+      });
 
       type StartServer = () => Promise<{
         close: GatewayCloseFn;
@@ -1267,8 +1309,10 @@ describe("runGatewayLoop", () => {
         mode: "compacting",
         reason: "restart",
       });
-      expect(waitForActiveTasks).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
-      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledOnce();
+      expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(
+        DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS,
+      );
       expect(abortEmbeddedAgentRun).toHaveBeenCalledWith(undefined, {
         mode: "all",
         reason: "restart",
@@ -1279,7 +1323,9 @@ describe("runGatewayLoop", () => {
         sessionKeys: new Set(["agent:main:issue-82433"]),
         reason: "gateway restart drain",
       });
-      expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
+      expect(gatewayLog.warn).toHaveBeenCalledWith(
+        "active-work drain timeout reached; proceeding with restart: 2 active background task run(s); 1 active embedded run(s)",
+      );
       expectRestartCloseCall(closeFirst, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
       expect(abortActiveCronTaskRuns).toHaveBeenCalledWith("Gateway restarting.");
@@ -1812,8 +1858,14 @@ describe("runGatewayLoop", () => {
     });
 
     await withIsolatedSignals(async ({ captureSignal }) => {
-      getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
-      getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+      createGatewayActiveWorkSnapshot
+        .mockReturnValueOnce(
+          createActiveWorkSnapshot({ activeTasks: 1, embeddedRuns: 1 }, [
+            { kind: "task", count: 1, message: "1 active background task run(s)" },
+            { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
+          ]),
+        )
+        .mockReturnValue(idleActiveWorkSnapshot);
 
       const { start } = await createSignaledLoopHarness();
       const sigusr1 = captureSignal("SIGUSR1");
@@ -1826,8 +1878,10 @@ describe("runGatewayLoop", () => {
         setImmediate(resolve);
       });
 
-      expect(waitForActiveTasks).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
-      expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
+      expect(waitForGatewayActiveWork).toHaveBeenCalledOnce();
+      expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(
+        DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS,
+      );
       expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(false);
       expect(start).toHaveBeenCalledTimes(2);
     });
@@ -1897,7 +1951,11 @@ describe("runGatewayLoop", () => {
       force: true,
       reason: "file-intent restart",
     });
-    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    createGatewayActiveWorkSnapshot.mockReturnValue(
+      createActiveWorkSnapshot({ embeddedRuns: 1 }, [
+        { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
+      ]),
+    );
     listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-file-intent"]);
     listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:file-intent"]);
 
@@ -1937,7 +1995,11 @@ describe("runGatewayLoop", () => {
       reason: "file-intent restart",
     });
     consumeGatewaySigusr1RestartAuthorization.mockReturnValueOnce(false);
-    getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    createGatewayActiveWorkSnapshot.mockReturnValue(
+      createActiveWorkSnapshot({ embeddedRuns: 1 }, [
+        { kind: "embedded-run", count: 1, message: "1 active embedded run(s)" },
+      ]),
+    );
     listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-file-intent"]);
     listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:file-intent"]);
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -27,7 +27,6 @@ import {
   findOpenClawAgentDatabaseMediaMigrationRequiredError,
   GATEWAY_AGENT_MEDIA_MIGRATION_REQUIRED_REASON,
 } from "../../state/openclaw-agent-db-migration-required.js";
-import { formatActiveTaskRestartBlocker } from "../../tasks/task-restart-blocker.js";
 import {
   armShutdownHardExitWatchdog,
   type ShutdownHardExitWatchdog,
@@ -139,8 +138,8 @@ export async function runGatewayLoop(params: {
   // and leave restart.ts's emittedRestartToken permanently unconsumed.
   // From that point every scheduleGatewaySigusr1Restart() returns
   // { coalesced: true } and the gateway never restarts. Priming the loader
-  // here pulls the whole re-export graph (lifecycle.runtime.ts is a 36-line
-  // re-export hub) into memory, immune to later disk rotation.
+  // here pulls the lifecycle re-export graph into memory, immune to later disk
+  // rotation.
   const eagerLifecycleRuntime = await loadGatewayLifecycleRuntimeModule();
   let lock = await acquireGatewayLock({ port: params.lockPort });
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
@@ -593,10 +592,10 @@ export async function runGatewayLoop(params: {
       };
 
       try {
-        // On restart, wait for in-flight agent turns to finish before
-        // tearing down the server so buffered messages are delivered.
+        // On restart, wait for the canonical process activity inventory before
+        // tearing down the server so active work can settle.
         if (isRestart) {
-          let activeTasksAtDrainStart = 0;
+          let activeWorkAtDrainStart = 0;
           let activeRunsAtDrainStart = 0;
           let drainTimedOut = false;
           await measureGatewayRestartTrace(
@@ -604,16 +603,12 @@ export async function runGatewayLoop(params: {
             async () => {
               const {
                 abortEmbeddedAgentRun,
+                createGatewayActiveWorkSnapshot,
                 getRuntimeConfig,
-                getInspectableActiveTaskRestartBlockers,
-                getActiveEmbeddedRunCount,
-                getActiveTaskCount,
                 listActiveEmbeddedRunSessionIds,
                 listActiveEmbeddedRunSessionKeys,
                 markRestartAbortedMainSessions,
-                waitForActiveGatewayRootWork,
-                waitForActiveEmbeddedRuns,
-                waitForActiveTasks,
+                waitForGatewayActiveWork,
               } = await loadGatewayLifecycleRuntimeModule();
               const collectActiveRestartSessionKeys = () => {
                 return new Set<string>(listActiveEmbeddedRunSessionKeys());
@@ -657,111 +652,74 @@ export async function runGatewayLoop(params: {
                   );
                 }
               };
-              const formatTaskBlockers = () => {
-                const blockers = getInspectableActiveTaskRestartBlockers();
-                if (blockers.length === 0) {
-                  return null;
-                }
-                const shown = blockers.slice(0, 8).map(formatActiveTaskRestartBlocker);
-                const omitted = blockers.length - shown.length;
-                return omitted > 0 ? `${shown.join("; ")}; +${omitted} more` : shown.join("; ");
-              };
-              const createStillPendingDrainLogger = () =>
-                setInterval(() => {
-                  gatewayLog.warn(
-                    `still draining ${getActiveTaskCount()} active task(s) and ${getActiveEmbeddedRunCount()} active embedded run(s) before restart`,
-                  );
-                }, RESTART_DRAIN_STILL_PENDING_WARN_MS);
+              const formatBlockers = (
+                snapshot: ReturnType<typeof createGatewayActiveWorkSnapshot>,
+              ) => snapshot.blockers.map((blocker) => blocker.message).join("; ");
 
               // Reject new enqueues immediately during the drain window so
               // sessions get an explicit restart error instead of silent task loss.
               markRestartDraining();
-              const rootDrainTimeoutMs =
-                restartDrainDeadlineAt === undefined
-                  ? undefined
-                  : Math.max(0, restartDrainDeadlineAt - Date.now());
-              const rootDrainPromise = restartIntent?.force
-                ? Promise.resolve({ drained: true, active: 0 })
-                : waitForActiveGatewayRootWork(rootDrainTimeoutMs);
-              const activeTasks = getActiveTaskCount();
-              const activeRuns = getActiveEmbeddedRunCount();
-              activeTasksAtDrainStart = activeTasks;
-              activeRunsAtDrainStart = activeRuns;
+              const initialSnapshot = createGatewayActiveWorkSnapshot();
+              activeWorkAtDrainStart = initialSnapshot.counts.totalActive;
+              activeRunsAtDrainStart = initialSnapshot.counts.embeddedRuns;
               activeRestartSessionKeysAtDrainStart = collectActiveRestartSessionKeys();
               activeRestartSessionIdsAtDrainStart = collectActiveRestartSessionIds();
 
               // Best-effort abort for compacting runs so transcript settlement does
               // not remain pending across restart boundaries.
-              if (activeRuns > 0) {
+              if (activeRunsAtDrainStart > 0) {
                 await markActiveMainSessionsForRestart("gateway restart drain");
                 abortEmbeddedAgentRun(undefined, { mode: "compacting", reason: "restart" });
               }
 
-              if (activeTasks > 0 || activeRuns > 0) {
-                const taskBlockers = formatTaskBlockers();
+              if (!initialSnapshot.idle) {
                 gatewayLog.info(
-                  `draining ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before restart ${formatRestartDrainBudget()}`,
-                );
-                if (taskBlockers) {
-                  gatewayLog.warn(
-                    `restart blocked by active background task run(s): ${taskBlockers}`,
-                  );
-                }
-                if (restartIntent?.force) {
-                  gatewayLog.warn("forced restart requested; skipping active work drain");
-                  await markActiveMainSessionsForRestart(
-                    restartIntent.reason ?? "forced gateway restart",
-                  );
-                  abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" });
-                } else {
-                  const stillPendingDrainLogger = createStillPendingDrainLogger();
-                  let abortedAfterRunTimeout = false;
-                  let tasksDrain: { drained: boolean } = { drained: true };
-                  let runsDrain: { drained: boolean } = { drained: true };
-                  try {
-                    const tasksDrainPromise =
-                      activeTasks > 0
-                        ? waitForActiveTasks(restartDrainTimeoutMs)
-                        : Promise.resolve({ drained: true });
-                    runsDrain =
-                      activeRuns > 0
-                        ? await waitForActiveEmbeddedRuns(restartDrainTimeoutMs)
-                        : { drained: true };
-                    if (!runsDrain.drained && activeRuns > 0) {
-                      gatewayLog.warn(
-                        "active embedded run drain timeout reached; aborting active run(s) before restart",
-                      );
-                      abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" });
-                      abortedAfterRunTimeout = true;
-                    }
-                    tasksDrain = await tasksDrainPromise;
-                  } finally {
-                    clearInterval(stillPendingDrainLogger);
-                  }
-                  if (tasksDrain.drained && runsDrain.drained) {
-                    gatewayLog.info("all active work drained");
-                  } else {
-                    drainTimedOut = true;
-                    gatewayLog.warn("drain timeout reached; proceeding with restart");
-                    await markActiveMainSessionsForRestart("gateway restart drain timeout");
-                    // Final best-effort abort to avoid carrying active runs into the
-                    // next lifecycle when drain time budget is exhausted.
-                    if (!abortedAfterRunTimeout) {
-                      abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" });
-                    }
-                  }
-                }
-              }
-              const rootDrain = await rootDrainPromise;
-              if (!rootDrain.drained) {
-                drainTimedOut = true;
-                gatewayLog.warn(
-                  `gateway root transaction drain timeout reached with ${rootDrain.active} root(s) still active; proceeding with restart`,
+                  `draining active work before restart ${formatRestartDrainBudget()}: ${formatBlockers(initialSnapshot)}`,
                 );
               }
+              if (restartIntent?.force) {
+                gatewayLog.warn("forced restart requested; skipping active work drain");
+                await markActiveMainSessionsForRestart(
+                  restartIntent.reason ?? "forced gateway restart",
+                );
+                abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" });
+                return;
+              }
+
+              let lastPendingWarningAt = Date.now();
+              const remainingDrainTimeoutMs =
+                restartDrainDeadlineAt === undefined
+                  ? undefined
+                  : Math.max(0, restartDrainDeadlineAt - Date.now());
+              const drain = await waitForGatewayActiveWork(remainingDrainTimeoutMs, {
+                onSnapshot: (snapshot) => {
+                  const now = Date.now();
+                  if (
+                    !snapshot.idle &&
+                    now - lastPendingWarningAt >= RESTART_DRAIN_STILL_PENDING_WARN_MS
+                  ) {
+                    lastPendingWarningAt = now;
+                    gatewayLog.warn(
+                      `still draining active work before restart: ${formatBlockers(snapshot)}`,
+                    );
+                  }
+                },
+              });
+              if (drain.drained) {
+                if (!initialSnapshot.idle) {
+                  gatewayLog.info("all active work drained");
+                }
+                return;
+              }
+              drainTimedOut = true;
+              gatewayLog.warn(
+                `active-work drain timeout reached; proceeding with restart: ${formatBlockers(drain.snapshot)}`,
+              );
+              await markActiveMainSessionsForRestart("gateway restart drain timeout");
+              abortEmbeddedAgentRun(undefined, { mode: "all", reason: "restart" });
             },
             () => [
-              ["activeTasks", activeTasksAtDrainStart],
+              ["activeWork", activeWorkAtDrainStart],
               ["activeRuns", activeRunsAtDrainStart],
               ["timedOut", drainTimedOut],
               ["force", restartIntent?.force === true],
@@ -770,20 +728,20 @@ export async function runGatewayLoop(params: {
         }
 
         if (!isRestart) {
-          // Keep reset-started finalizers alive without spending the shutdown
-          // reserve that server teardown and the supervisor watchdog need.
+          // Keep all process-owned work alive without spending the shutdown reserve
+          // that server teardown and the supervisor watchdog need.
           try {
-            const rootDrain = await eagerLifecycleRuntime.waitForActiveGatewayRootWork(
+            const activeWorkDrain = await eagerLifecycleRuntime.waitForGatewayActiveWork(
               Math.max(0, SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS),
             );
-            if (!rootDrain.drained) {
+            if (!activeWorkDrain.drained) {
               gatewayLog.warn(
-                `gateway root transaction drain timeout reached with ${rootDrain.active} root(s) still active; proceeding with shutdown`,
+                `gateway active-work drain timeout reached; proceeding with shutdown: ${activeWorkDrain.snapshot.blockers.map((blocker) => blocker.message).join("; ")}`,
               );
             }
           } catch (err) {
             gatewayLog.warn(
-              `gateway root transaction drain failed; proceeding with shutdown: ${formatErrorMessage(err)}`,
+              `gateway active-work drain failed; proceeding with shutdown: ${formatErrorMessage(err)}`,
             );
           }
         }

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -12,8 +12,8 @@ import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../../config/cron-limits.js";
 import {
   clearCommandLane,
   enqueueCommandInLane,
+  getTotalQueueSize,
   setCommandLaneConcurrency,
-  waitForActiveTasks,
 } from "../../process/command-queue.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -138,7 +138,7 @@ describe("cron service ops regressions", () => {
 
       enterRunner.resolve();
       await finished.promise;
-      await waitForActiveTasks(5_000);
+      await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0), { timeout: 5_000 });
       expect(terminalEvent).toMatchObject({ status: "ok" });
       await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
     } finally {
@@ -296,7 +296,7 @@ describe("cron service ops regressions", () => {
 
     releaseBlocker.resolve();
     await blocker;
-    await waitForActiveTasks(5_000);
+    await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0), { timeout: 5_000 });
     expect(runIsolatedAgentJob).toHaveBeenCalledTimes(1);
     expect(events).toContainEqual(
       expect.objectContaining({
@@ -706,7 +706,7 @@ describe("cron service ops regressions", () => {
 
     secondRun.resolve({ status: "ok", summary: "second queued run" });
     await bothFinished.promise;
-    await waitForActiveTasks(5_000);
+    await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0), { timeout: 5_000 });
     const jobs = state.store?.jobs ?? [];
     expect(jobs.find((job) => job.id === first.id)?.state.lastStatus).toBe("ok");
     expect(jobs.find((job) => job.id === second.id)?.state.lastStatus).toBe("ok");
@@ -762,7 +762,7 @@ describe("cron service ops regressions", () => {
       const ack = await enqueueRun(state, job.id, "due");
       const runId = expectQueuedRunAck(ack);
       await terminal.promise;
-      await waitForActiveTasks(5_000);
+      await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0), { timeout: 5_000 });
 
       expect(runIsolatedAgentJob).not.toHaveBeenCalled();
       expect(events.map((event) => event.action)).toEqual(["started", "scheduled", "finished"]);
@@ -821,7 +821,7 @@ describe("cron service ops regressions", () => {
     state.stopped = true;
     releaseBlocker.resolve();
     await blocker;
-    await waitForActiveTasks(5_000);
+    await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0), { timeout: 5_000 });
 
     expect(runIsolatedAgentJob).not.toHaveBeenCalled();
     expect(
@@ -914,7 +914,7 @@ describe("cron service ops regressions", () => {
       expect(abortSignal.aborted).toBe(true);
       expect(abortSignal.reason).toBe(testCase.reason);
       await providerExited.promise;
-      await waitForActiveTasks(5_000);
+      await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0), { timeout: 5_000 });
 
       const terminalEvents = events.filter(
         (evt) => evt.action === "finished" && evt.runId === runId,
@@ -958,7 +958,7 @@ describe("cron service ops regressions", () => {
       }
     } finally {
       releaseProvider.resolve();
-      await waitForActiveTasks(5_000);
+      await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0), { timeout: 5_000 });
       clearCommandLane(CommandLane.Cron);
     }
   });

--- a/src/cron/service/ops.run-admission-cleanup.test.ts
+++ b/src/cron/service/ops.run-admission-cleanup.test.ts
@@ -11,8 +11,8 @@ import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../../config/cron-limits.js";
 import {
   clearCommandLane,
   enqueueCommandInLane,
+  getTotalQueueSize,
   setCommandLaneConcurrency,
-  waitForActiveTasks,
 } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
@@ -191,7 +191,7 @@ describe("cron service run admission cleanup", () => {
     authorityActive = false;
     releaseBlocker.resolve();
     await blocker;
-    await waitForActiveTasks(5_000);
+    await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0), { timeout: 5_000 });
 
     expect(runIsolatedAgentJob).not.toHaveBeenCalled();
     expect((await loadCronStore(store.storePath)).jobs[0]?.state.queuedAtMs).toBeUndefined();

--- a/src/cron/service/ops.run-admission.test.ts
+++ b/src/cron/service/ops.run-admission.test.ts
@@ -10,8 +10,8 @@ import { DEFAULT_CRON_MAX_CONCURRENT_RUNS } from "../../config/cron-limits.js";
 import {
   clearCommandLane,
   enqueueCommandInLane,
+  getTotalQueueSize,
   setCommandLaneConcurrency,
-  waitForActiveTasks,
 } from "../../process/command-queue.js";
 import { CommandLane } from "../../process/lanes.js";
 import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
@@ -93,7 +93,7 @@ describe("cron service run admission", () => {
     await update(state, job.id, { enabled: false });
     releaseBlocker.resolve();
     await blocker;
-    await waitForActiveTasks(5_000);
+    await vi.waitFor(() => expect(getTotalQueueSize()).toBe(0), { timeout: 5_000 });
 
     expect(runIsolatedAgentJob).not.toHaveBeenCalled();
     expect(onEvent).toHaveBeenCalledWith(

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -21,7 +21,6 @@ import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
-  waitForActiveGatewayRootWork,
 } from "../process/gateway-work-admission.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
@@ -2498,10 +2497,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     "separates streamed content from the terminal finish for an official SDK $name",
     async ({ fail, providerTerminal, expected, protocolError }) => {
       const idleRootCount = getActiveGatewayRootWorkCount();
-      const terminalAdmission = createDeferred<{
-        active: number;
-        drained: { drained: boolean; active: number };
-      }>();
+      const terminalAdmission = createDeferred<{ active: number }>();
       const wireResponse = createDeferred<string>();
       const continueAgent = createDeferred();
       const lifecycleTerminals: string[] = [];
@@ -2518,9 +2514,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         // Agent settlement schedules the terminal in a later microtask. The
         // request must remain admitted until Node finishes the actual stream.
         const active = getActiveGatewayRootWorkCount();
-        void waitForActiveGatewayRootWork(0).then((drained) => {
-          terminalAdmission.resolve({ active, drained });
-        });
+        terminalAdmission.resolve({ active });
       });
       agentCommandMock.mockClear();
       agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
@@ -2593,7 +2587,6 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           wireResponse.promise,
         ]);
         expect(admission.active).toBe(idleRootCount + 1);
-        expect(admission.drained).toEqual({ drained: false, active: idleRootCount + 1 });
         expect(parseSseDataLines(wire).at(-1)).toBe("[DONE]");
         expect(lifecycleTerminals).toEqual([fail ? "error" : "end"]);
 
@@ -3718,10 +3711,6 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       });
       expect(await cleanupAdmissionClosed.promise).toBe(false);
       expect(getActiveGatewayRootWorkCount()).toBe(idleRootCount + 1);
-      expect(await waitForActiveGatewayRootWork(0)).toEqual({
-        drained: false,
-        active: idleRootCount + 1,
-      });
     } finally {
       finishAgentCleanup.resolve();
     }

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -16,7 +16,6 @@ import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
-  waitForActiveGatewayRootWork,
 } from "../process/gateway-work-admission.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { IMAGE_ONLY_USER_MESSAGE } from "./agent-prompt.js";
@@ -1680,10 +1679,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
     "keeps the $label admitted until its deferred SSE terminal is written",
     async ({ name, failed, providerTerminal, reject }) => {
       const idleRootCount = getActiveGatewayRootWorkCount();
-      const terminalAdmission = createDeferred<{
-        active: number;
-        drained: { drained: boolean; active: number };
-      }>();
+      const terminalAdmission = createDeferred<{ active: number }>();
       const wireResponse = createDeferred<string>();
       const continueAgent = createDeferred();
       const lifecycleTerminals: string[] = [];
@@ -1701,9 +1697,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         // root owner at that boundary instead of observing eventual client delivery.
         queueMicrotask(() => {
           const active = getActiveGatewayRootWorkCount();
-          void waitForActiveGatewayRootWork(0).then((drained) => {
-            terminalAdmission.resolve({ active, drained });
-          });
+          terminalAdmission.resolve({ active });
         });
       });
 
@@ -1764,7 +1758,6 @@ describe("OpenResponses HTTP API (e2e)", () => {
         ]);
 
         expect(admission.active).toBe(idleRootCount + 1);
-        expect(admission.drained).toEqual({ drained: false, active: idleRootCount + 1 });
         expect(response.status).toBe(name);
         expect(terminalEvents).toEqual([`response.${name}`]);
         expect(lifecycleTerminals).toEqual([failed ? "error" : "end"]);
@@ -3178,10 +3171,6 @@ describe("OpenResponses HTTP API (e2e)", () => {
       });
       expect(await cleanupAdmissionClosed.promise).toBe(false);
       expect(getActiveGatewayRootWorkCount()).toBe(idleRootCount + 1);
-      expect(await waitForActiveGatewayRootWork(0)).toEqual({
-        drained: false,
-        active: idleRootCount + 1,
-      });
     } finally {
       finishAgentCleanup.resolve();
     }

--- a/src/gateway/server-http.mcp-app-admission.test.ts
+++ b/src/gateway/server-http.mcp-app-admission.test.ts
@@ -7,7 +7,6 @@ import {
   markGatewayRestartDraining,
   resetGatewayWorkAdmission,
   tryBeginGatewaySuspendAdmission,
-  waitForActiveGatewayRootWork,
 } from "../process/gateway-work-admission.js";
 
 const mocks = vi.hoisted(() => ({
@@ -113,10 +112,7 @@ describe("standalone MCP App HTTP admission", () => {
       try {
         expect(getActiveGatewayRootWorkCount()).toBe(1);
         markGatewayRestartDraining();
-        await expect(waitForActiveGatewayRootWork(0)).resolves.toEqual({
-          drained: false,
-          active: 1,
-        });
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
       } finally {
         finish.resolve();
       }
@@ -125,10 +121,6 @@ describe("standalone MCP App HTTP admission", () => {
       // The response mock resolves from res.end(), immediately before the
       // admission wrapper's finally block releases the request root.
       await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
-      await expect(waitForActiveGatewayRootWork(0)).resolves.toEqual({
-        drained: true,
-        active: 0,
-      });
     });
   });
 

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -8,7 +8,7 @@ import {
   restoreActivePluginRegistrySnapshot,
   stageActivePluginRegistry,
 } from "../plugins/runtime.js";
-import { waitForActiveGatewayRootWork } from "../process/gateway-work-admission.js";
+import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { captureAgentTurnPrincipal } from "./agent-turn/principal.js";
@@ -325,7 +325,7 @@ describe("createGatewayInstanceRuntime", () => {
         expect((caught as Error).message).toContain("gateway request timeout for send");
       } finally {
         finishHandler();
-        await waitForActiveGatewayRootWork();
+        await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
         runtime.close();
       }
     } finally {

--- a/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
+++ b/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
@@ -21,8 +21,8 @@ import {
   resumeGatewaySuspend,
 } from "../../infra/gateway-suspend-coordinator.js";
 import {
+  getActiveGatewayRootWorkCount,
   resetGatewayWorkAdmission,
-  waitForActiveGatewayRootWork,
 } from "../../process/gateway-work-admission.js";
 import { getDetachedTaskLifecycleRuntime } from "../../tasks/detached-task-runtime.js";
 import { findTaskByRunId } from "../../tasks/task-registry.js";
@@ -117,7 +117,7 @@ describe("gateway agent handler", () => {
         phase: "continuing",
         ownerRunId: "cron-media-release-rotates",
       });
-      await expect(waitForActiveGatewayRootWork()).resolves.toEqual({ drained: true, active: 0 });
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
       const readyPrepare = await invokeGatewaySuspendPrepare(
         context,
         "cron-media-release-rotation-complete",

--- a/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
+++ b/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
@@ -9,8 +9,8 @@ import {
   resumeGatewaySuspend,
 } from "../../infra/gateway-suspend-coordinator.js";
 import {
+  getActiveGatewayRootWorkCount,
   resetGatewayWorkAdmission,
-  waitForActiveGatewayRootWork,
 } from "../../process/gateway-work-admission.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { registerSubagentCompletionToolHandoff } from "../subagent-completion-tool-handoff.js";
@@ -1982,7 +1982,7 @@ describe("gateway agent handler", () => {
         phase: "ready",
         basePersisted: true,
       });
-      await expect(waitForActiveGatewayRootWork()).resolves.toEqual({ drained: true, active: 0 });
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
       const readyPrepare = await invokeGatewaySuspendPrepare(
         context,
         "cron-media-release-recovered",
@@ -2071,7 +2071,7 @@ describe("gateway agent handler", () => {
       expect(context.logGateway.warn).toHaveBeenCalledWith(
         "cron continuation release recovery exhausted for cron-media-release-exhausts",
       );
-      await expect(waitForActiveGatewayRootWork()).resolves.toEqual({ drained: true, active: 0 });
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
       const readyPrepare = await invokeGatewaySuspendPrepare(
         context,
         "cron-media-release-exhausted",

--- a/src/infra/gateway-active-work.test.ts
+++ b/src/infra/gateway-active-work.test.ts
@@ -1,0 +1,41 @@
+// Canonical Gateway active-work waiting must report the owners that block shutdown.
+import { afterEach, describe, expect, it } from "vitest";
+import type { EmbeddedAgentQueueHandle } from "../agents/embedded-agent-runner/run-state.js";
+import {
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+} from "../agents/embedded-agent-runner/runs.js";
+import { waitForGatewayActiveWork } from "./gateway-active-work.js";
+
+const activeRuns = new Map<string, EmbeddedAgentQueueHandle>();
+
+afterEach(() => {
+  for (const [sessionId, handle] of activeRuns) {
+    clearActiveEmbeddedRun(sessionId, handle);
+  }
+  activeRuns.clear();
+});
+
+describe("waitForGatewayActiveWork", () => {
+  it("returns the final canonical blockers when its deadline expires", async () => {
+    const sessionId = "probe-gateway-active-work-timeout";
+    const handle: EmbeddedAgentQueueHandle = {
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: () => {},
+    };
+    activeRuns.set(sessionId, handle);
+    setActiveEmbeddedRun(sessionId, handle);
+
+    const result = await waitForGatewayActiveWork(0);
+
+    expect(result.drained).toBe(false);
+    expect(result.snapshot.counts.embeddedRuns).toBe(1);
+    expect(result.snapshot.blockers).toContainEqual({
+      kind: "embedded-run",
+      count: 1,
+      message: "1 active embedded run(s)",
+    });
+  });
+});

--- a/src/infra/gateway-active-work.ts
+++ b/src/infra/gateway-active-work.ts
@@ -60,6 +60,11 @@ export type GatewayActiveWorkSnapshot = {
   blockers: GatewayActiveWorkBlocker[];
 };
 
+type GatewayActiveWorkWaitResult = {
+  drained: boolean;
+  snapshot: GatewayActiveWorkSnapshot;
+};
+
 export type GatewayActiveWorkInspectors = {
   getQueueSize: () => number;
   getPendingReplies: () => number;
@@ -198,4 +203,33 @@ export function createGatewayActiveWorkSnapshot(
   }
 
   return { idle: counts.totalActive === 0, counts, blockers };
+}
+
+const GATEWAY_ACTIVE_WORK_POLL_MS = 250;
+
+/** Waits for the complete process-wide active-work inventory to become idle. */
+export async function waitForGatewayActiveWork(
+  timeoutMs?: number,
+  options: { onSnapshot?: (snapshot: GatewayActiveWorkSnapshot) => void } = {},
+): Promise<GatewayActiveWorkWaitResult> {
+  const timeout =
+    typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
+      ? Math.max(0, Math.floor(timeoutMs))
+      : undefined;
+  const deadlineAt = timeout === undefined ? undefined : Date.now() + timeout;
+
+  while (true) {
+    const snapshot = createGatewayActiveWorkSnapshot();
+    options.onSnapshot?.(snapshot);
+    if (snapshot.idle) {
+      return { drained: true, snapshot };
+    }
+    const remainingMs = deadlineAt === undefined ? undefined : deadlineAt - Date.now();
+    if (remainingMs !== undefined && remainingMs <= 0) {
+      return { drained: false, snapshot };
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, Math.min(GATEWAY_ACTIVE_WORK_POLL_MS, remainingMs ?? Infinity));
+    });
+  }
 }

--- a/src/process/command-queue.scoped-lanes.test.ts
+++ b/src/process/command-queue.scoped-lanes.test.ts
@@ -3,8 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import {
   enqueueCommandInLane,
-  getActiveTaskCount,
   getCommandLaneSnapshot,
+  getTotalQueueSize,
   resetCommandLane,
   setCommandLaneConcurrency,
 } from "./command-queue.js";
@@ -75,7 +75,7 @@ describe("scoped command lane lifecycle", () => {
       expect(results).toEqual(Array.from({ length: 10 }, (_, index) => index));
       expect(peakActiveRuns).toBe(10);
       expect(activeRuns).toBe(0);
-      expect(getActiveTaskCount()).toBe(0);
+      expect(getTotalQueueSize()).toBe(0);
       expect(lanes.size).toBe(baselineSize);
       for (const lane of laneNames) {
         expect(lanes.has(lane)).toBe(false);

--- a/src/process/command-queue.state.ts
+++ b/src/process/command-queue.state.ts
@@ -36,12 +36,6 @@ export type LaneState = {
   generation: number;
 };
 
-export type ActiveTaskWaiter = {
-  activeTaskIds: Set<number>;
-  resolve: (value: { drained: boolean }) => void;
-  timeout?: ReturnType<typeof setTimeout>;
-};
-
 /**
  * Keep queue runtime state on globalThis so every bundled entry/chunk shares
  * the same lanes, counters, and draining flag in production builds.
@@ -51,19 +45,9 @@ const COMMAND_QUEUE_STATE_KEY = Symbol.for("openclaw.commandQueueState");
 export function getQueueState() {
   const state = resolveGlobalSingleton(COMMAND_QUEUE_STATE_KEY, () => ({
     lanes: new Map<string, LaneState>(),
-    activeTaskWaiters: new Set<ActiveTaskWaiter>(),
     nextTaskId: 1,
     nextQueueSequence: 1,
   }));
-  // Schema migration: the singleton may have been created by an older code
-  // version (e.g. v2026.4.2) that did not include `activeTaskWaiters`.  After
-  // a SIGUSR1 in-process restart the new code inherits the stale object via
-  // `resolveGlobalSingleton` because the Symbol key already exists on
-  // globalThis.  Patch the missing field so all downstream consumers see a
-  // valid Set instead of `undefined`.
-  if (!state.activeTaskWaiters) {
-    state.activeTaskWaiters = new Set<ActiveTaskWaiter>();
-  }
   if (!state.nextQueueSequence) {
     state.nextQueueSequence = 1;
   }

--- a/src/process/command-queue.test-support.ts
+++ b/src/process/command-queue.test-support.ts
@@ -1,13 +1,7 @@
 import { resetGatewayWorkAdmission } from "./gateway-work-admission.js";
 
-type ActiveTaskWaiterShape = {
-  resolve: (value: { drained: boolean }) => void;
-  timeout?: ReturnType<typeof setTimeout>;
-};
-
 type CommandQueueStateShape = {
   lanes: Map<unknown, unknown>;
-  activeTaskWaiters?: Set<ActiveTaskWaiterShape>;
   nextTaskId: number;
   nextQueueSequence?: number;
 };
@@ -24,13 +18,6 @@ export function resetCommandQueueStateForTest(): void {
   }
 
   state.lanes.clear();
-  for (const waiter of Array.from(state.activeTaskWaiters ?? [])) {
-    state.activeTaskWaiters?.delete(waiter);
-    if (waiter.timeout) {
-      clearTimeout(waiter.timeout);
-    }
-    waiter.resolve({ drained: true });
-  }
   state.nextTaskId = 1;
   state.nextQueueSequence = 1;
 }

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -33,14 +33,13 @@ let clearCommandLane: CommandQueueModule["clearCommandLane"];
 let CommandLaneClearedError: CommandQueueModule["CommandLaneClearedError"];
 let enqueueCommandInLane: CommandQueueModule["enqueueCommandInLane"];
 let GatewayDrainingError: CommandQueueModule["GatewayDrainingError"];
-let getActiveTaskCount: CommandQueueModule["getActiveTaskCount"];
 let getCommandLaneSnapshot: CommandQueueModule["getCommandLaneSnapshot"];
 let getQueueSize: CommandQueueModule["getQueueSize"];
+let getTotalQueueSize: CommandQueueModule["getTotalQueueSize"];
 let markGatewayDraining: CommandQueueModule["markGatewayDraining"];
 let resetAllLanes: CommandQueueModule["resetAllLanes"];
 let resetCommandLane: CommandQueueModule["resetCommandLane"];
 let setCommandLaneConcurrency: CommandQueueModule["setCommandLaneConcurrency"];
-let waitForActiveTasks: CommandQueueModule["waitForActiveTasks"];
 
 function mockCallArg(
   mock: { mock: { calls: readonly unknown[][] } },
@@ -91,14 +90,13 @@ describe("command queue", () => {
       CommandLaneClearedError,
       enqueueCommandInLane,
       GatewayDrainingError,
-      getActiveTaskCount,
       getCommandLaneSnapshot,
       getQueueSize,
+      getTotalQueueSize,
       markGatewayDraining,
       resetAllLanes,
       resetCommandLane,
       setCommandLaneConcurrency,
-      waitForActiveTasks,
     } = await import("./command-queue.js"));
   });
 
@@ -120,9 +118,9 @@ describe("command queue", () => {
   });
 
   it("resetAllLanes is safe when no lanes have been created", () => {
-    expect(getActiveTaskCount()).toBe(0);
+    expect(getTotalQueueSize()).toBe(0);
     resetAllLanes();
-    expect(getActiveTaskCount()).toBe(0);
+    expect(getTotalQueueSize()).toBe(0);
   });
 
   it("runs tasks one at a time in order", async () => {
@@ -380,66 +378,14 @@ describe("command queue", () => {
     ).toBe(false);
   });
 
-  it("getActiveTaskCount returns count of currently executing tasks", async () => {
+  it("reports process queue totals while tasks execute", async () => {
     const { task, release } = enqueueBlockedMainTask();
 
-    expect(getActiveTaskCount()).toBe(1);
+    expect(getTotalQueueSize()).toBe(1);
 
     release();
     await task;
-    expect(getActiveTaskCount()).toBe(0);
-  });
-
-  it("waitForActiveTasks resolves immediately when no tasks are active", async () => {
-    const { drained } = await waitForActiveTasks(1000);
-    expect(drained).toBe(true);
-  });
-
-  it("waitForActiveTasks waits for active tasks to finish", async () => {
-    const { task, release } = enqueueBlockedMainTask();
-
-    vi.useFakeTimers();
-    try {
-      const drainPromise = waitForActiveTasks(5000);
-
-      await vi.advanceTimersByTimeAsync(50);
-      release();
-      await vi.advanceTimersByTimeAsync(50);
-
-      const { drained } = await drainPromise;
-      expect(drained).toBe(true);
-
-      await task;
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("waitForActiveTasks returns drained=false when timeout is zero and tasks are active", async () => {
-    const { task, release } = enqueueBlockedMainTask();
-
-    const { drained } = await waitForActiveTasks(0);
-    expect(drained).toBe(false);
-
-    release();
-    await task;
-  });
-
-  it("waitForActiveTasks returns drained=false on timeout", async () => {
-    const { task, release } = enqueueBlockedMainTask();
-
-    vi.useFakeTimers();
-    try {
-      const waitPromise = waitForActiveTasks(50);
-      await vi.advanceTimersByTimeAsync(100);
-      const { drained } = await waitPromise;
-      expect(drained).toBe(false);
-
-      release();
-      await task;
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(getTotalQueueSize()).toBe(0);
   });
 
   it("resetAllLanes drains queued work immediately after reset", async () => {
@@ -453,7 +399,7 @@ describe("command queue", () => {
       await blocker.promise;
     });
 
-    expect(getActiveTaskCount()).toBeGreaterThanOrEqual(1);
+    expect(getTotalQueueSize()).toBeGreaterThanOrEqual(1);
 
     // Enqueue another task — it should be stuck behind the blocker
     let task2Ran = false;
@@ -502,7 +448,9 @@ describe("command queue", () => {
     });
 
     expect(secondRan).toBe(false);
-    expect(getActiveTaskCount()).toBe(2);
+    expect(
+      getCommandLaneSnapshot(lane).activeCount + getCommandLaneSnapshot(otherLane).activeCount,
+    ).toBe(2);
     expect(resetCommandLane(lane)).toBe(1);
 
     await expect(second).resolves.toBe("second");
@@ -779,35 +727,6 @@ describe("command queue", () => {
     await expect(second).resolves.toBe("second");
   });
 
-  it("waitForActiveTasks ignores tasks that start after the call", async () => {
-    const lane = `drain-snapshot-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-    setCommandLaneConcurrency(lane, 2);
-
-    const blocker1 = createDeferred();
-    const blocker2 = createDeferred();
-    const firstStarted = createDeferred();
-
-    const first = enqueueCommandInLane(lane, async () => {
-      firstStarted.resolve();
-      await blocker1.promise;
-    });
-    await firstStarted.promise;
-    const drainPromise = waitForActiveTasks(2000);
-
-    // Starts after waitForActiveTasks snapshot and should not block drain completion.
-    const second = enqueueCommandInLane(lane, async () => {
-      await blocker2.promise;
-    });
-    expect(getActiveTaskCount()).toBeGreaterThanOrEqual(2);
-
-    blocker1.resolve();
-    const { drained } = await drainPromise;
-    expect(drained).toBe(true);
-
-    blocker2.resolve();
-    await Promise.all([first, second]);
-  });
-
   it("clearCommandLane rejects pending promises", async () => {
     // First task blocks the lane.
     const { task: first, release } = enqueueBlockedMainTask(async () => "first");
@@ -965,42 +884,6 @@ describe("command queue", () => {
     await expect(task).rejects.toBeInstanceOf(GatewayDrainingError);
   });
 
-  it("migrates legacy queue state missing activeTaskWaiters without crashing", async () => {
-    // Simulate a SIGUSR1 in-process restart where the globalThis singleton was
-    // created by an older code version (e.g. v2026.4.2) that did not include
-    // the `activeTaskWaiters` field.  The schema migration in getQueueState()
-    // must patch the missing field so resetAllLanes() and
-    // notifyActiveTaskWaiters() do not throw.
-    const key = Symbol.for("openclaw.commandQueueState");
-    const globalStore = globalThis as Record<PropertyKey, unknown>;
-    const original = globalStore[key];
-
-    try {
-      // Plant a legacy-shaped state object (no activeTaskWaiters).
-      globalStore[key] = {
-        gatewayDraining: false,
-        lanes: new Map(),
-        nextTaskId: 1,
-      };
-
-      // resetAllLanes calls notifyActiveTaskWaiters → Array.from(state.activeTaskWaiters).
-      // Without the migration this would throw:
-      //   TypeError: undefined is not iterable
-      resetAllLanes();
-
-      // waitForActiveTasks also accesses activeTaskWaiters.
-      await expect(waitForActiveTasks(0)).resolves.toEqual({ drained: true });
-    } finally {
-      // Restore original state so subsequent tests are not affected.
-      if (original !== undefined) {
-        globalStore[key] = original;
-      } else {
-        delete globalStore[key];
-      }
-      resetCommandQueueStateForTest();
-    }
-  });
-
   it("migrates legacy queued entries missing priority and wait diagnostics", async () => {
     const key = Symbol.for("openclaw.commandQueueState");
     const globalStore = globalThis as Record<PropertyKey, unknown>;
@@ -1081,7 +964,7 @@ describe("command queue", () => {
       });
 
       expect(commandQueueB.getQueueSize(lane)).toBe(1);
-      expect(commandQueueB.getActiveTaskCount()).toBe(1);
+      expect(commandQueueB.getTotalQueueSize()).toBe(1);
 
       blocker.resolve();
       await expect(task).resolves.toBe("done");

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -21,7 +21,6 @@ import {
   validateCommandLaneGroupSpec,
 } from "./command-queue.capacity-groups.js";
 import {
-  type ActiveTaskWaiter,
   type CommandLaneTaskMarker,
   getQueueState,
   type LaneState,
@@ -209,38 +208,6 @@ function retireIdleScopedCommandLane(state: LaneState): void {
   // idle scoped state after its pump has released the draining guard.
   if (lanes.get(state.lane) === state) {
     lanes.delete(state.lane);
-  }
-}
-
-function hasPendingActiveTasks(taskIds: Set<number>): boolean {
-  const queueState = getQueueState();
-  for (const state of queueState.lanes.values()) {
-    for (const taskId of state.activeTaskIds) {
-      if (taskIds.has(taskId)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-function resolveActiveTaskWaiter(waiter: ActiveTaskWaiter, result: { drained: boolean }): void {
-  const queueState = getQueueState();
-  if (!queueState.activeTaskWaiters.delete(waiter)) {
-    return;
-  }
-  if (waiter.timeout) {
-    clearTimeout(waiter.timeout);
-  }
-  waiter.resolve(result);
-}
-
-function notifyActiveTaskWaiters(): void {
-  const queueState = getQueueState();
-  for (const waiter of Array.from(queueState.activeTaskWaiters)) {
-    if (waiter.activeTaskIds.size === 0 || !hasPendingActiveTasks(waiter.activeTaskIds)) {
-      resolveActiveTaskWaiter(waiter, { drained: true });
-    }
   }
 }
 
@@ -460,7 +427,6 @@ function drainLane(
           });
           const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
           if (completedCurrentGeneration) {
-            notifyActiveTaskWaiters();
             diag.debug(
               `lane task done: lane=${lane} durationMs=${Date.now() - startTime} active=${state.activeTaskIds.size} queued=${state.queue.length}`,
             );
@@ -481,7 +447,6 @@ function drainLane(
             );
           }
           if (completedCurrentGeneration) {
-            notifyActiveTaskWaiters();
             drainReadyCommandLane(lane, state);
           }
           entry.reject(err);
@@ -752,7 +717,6 @@ export function resetCommandLane(lane: string = CommandLane.Main): number {
   // Clearing activeTaskIds may release multiple shared slots. Re-arbitrate the
   // whole group so the reset lane cannot reclaim them ahead of older siblings.
   drainReadyCommandLane(cleaned);
-  notifyActiveTaskWaiters();
   return released;
 }
 
@@ -786,58 +750,4 @@ export function resetAllLanes(): void {
   for (const lane of lanesToDrain) {
     drainReadyCommandLane(lane);
   }
-  notifyActiveTaskWaiters();
-}
-
-/**
- * Returns the total number of actively executing tasks across all lanes
- * (excludes queued-but-not-started entries).
- */
-export function getActiveTaskCount(): number {
-  const queueState = getQueueState();
-  let total = 0;
-  for (const s of queueState.lanes.values()) {
-    total += s.activeTaskIds.size;
-  }
-  return total;
-}
-
-/**
- * Wait for all currently active tasks across all lanes to finish.
- * Polls at a short interval; resolves when no tasks are active or
- * when `timeoutMs` elapses (whichever comes first). If no timeout is passed,
- * waits indefinitely for the active set captured at call time.
- *
- * New tasks enqueued after this call are ignored — only tasks that are
- * already executing are waited on.
- */
-export function waitForActiveTasks(timeoutMs?: number): Promise<{ drained: boolean }> {
-  const queueState = getQueueState();
-  const activeAtStart = new Set<number>();
-  for (const state of queueState.lanes.values()) {
-    for (const taskId of state.activeTaskIds) {
-      activeAtStart.add(taskId);
-    }
-  }
-
-  if (activeAtStart.size === 0) {
-    return Promise.resolve({ drained: true });
-  }
-  if (timeoutMs !== undefined && timeoutMs <= 0) {
-    return Promise.resolve({ drained: false });
-  }
-
-  return new Promise((resolve) => {
-    const waiter: ActiveTaskWaiter = {
-      activeTaskIds: activeAtStart,
-      resolve,
-    };
-    if (timeoutMs !== undefined) {
-      waiter.timeout = setTimeout(() => {
-        resolveActiveTaskWaiter(waiter, { drained: false });
-      }, timeoutMs);
-    }
-    queueState.activeTaskWaiters.add(waiter);
-    notifyActiveTaskWaiters();
-  });
 }

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -16,7 +16,6 @@ import {
   tryBeginGatewayPreparedRestartRootWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
   tryBeginGatewaySuspendAdmission,
-  waitForActiveGatewayRootWork,
 } from "./gateway-work-admission.js";
 import { runWithGatewayRootWorkAdmissionForTest } from "./gateway-work-admission.test-helpers.js";
 
@@ -38,17 +37,6 @@ it("counts one nested root chain once and excludes the preparing caller", async 
   });
   outer?.release();
   expect(getActiveGatewayRootWorkCount()).toBe(0);
-});
-
-it("waits for admitted roots and reports a bounded timeout", async () => {
-  const root = tryBeginGatewayRootWorkAdmission();
-  expect(root).not.toBeNull();
-  const pending = waitForActiveGatewayRootWork();
-  await expect(waitForActiveGatewayRootWork(0)).resolves.toEqual({ drained: false, active: 1 });
-
-  root?.release();
-
-  await expect(pending).resolves.toEqual({ drained: true, active: 0 });
 });
 
 it("rolls back or releases a generation-bound suspension without resetting roots", () => {

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -29,7 +29,6 @@ type GatewayWorkAdmissionState = {
   suspendGeneration: number;
   suspendInvalidated?: () => void;
   activeRootWork: Set<GatewayRootWorkAdmission>;
-  rootDrainWaiters?: Set<() => void>;
   currentRootWork: AsyncLocalStorage<GatewayRootWorkAdmission>;
   suspendOpenWaiters: Set<() => void>;
 };
@@ -45,7 +44,6 @@ const GATEWAY_WORK_ADMISSION_STATE = resolveGlobalSingleton(
     suspendPhase: "accepting",
     suspendGeneration: 0,
     activeRootWork: new Set(),
-    rootDrainWaiters: new Set(),
     currentRootWork: new AsyncLocalStorage(),
     suspendOpenWaiters: new Set(),
   }),
@@ -100,22 +98,7 @@ function createGatewayRootWorkRelease(admission: GatewayRootWorkAdmission): () =
     }
     admission.released = true;
     GATEWAY_WORK_ADMISSION_STATE.activeRootWork.delete(admission);
-    if (GATEWAY_WORK_ADMISSION_STATE.activeRootWork.size === 0) {
-      resolveRootDrainWaiters();
-    }
   };
-}
-
-function resolveRootDrainWaiters(): void {
-  const rootDrainWaiters = GATEWAY_WORK_ADMISSION_STATE.rootDrainWaiters;
-  if (!rootDrainWaiters) {
-    return;
-  }
-  const waiters = Array.from(rootDrainWaiters);
-  rootDrainWaiters.clear();
-  for (const resolve of waiters) {
-    resolve();
-  }
 }
 
 function invalidateSuspendAdmission(): void {
@@ -392,40 +375,6 @@ export function getActiveGatewayRootWorkCount(opts?: { excludeCurrent?: boolean 
   return Math.max(0, count);
 }
 
-/** Waits for admitted root transactions after restart has closed new admission. */
-export async function waitForActiveGatewayRootWork(
-  timeoutMs?: number,
-): Promise<{ drained: boolean; active: number }> {
-  if (GATEWAY_WORK_ADMISSION_STATE.activeRootWork.size === 0) {
-    return { drained: true, active: 0 };
-  }
-  const timeout =
-    typeof timeoutMs === "number" && Number.isFinite(timeoutMs)
-      ? Math.max(0, Math.floor(timeoutMs))
-      : undefined;
-  if (timeout === 0) {
-    return { drained: false, active: GATEWAY_WORK_ADMISSION_STATE.activeRootWork.size };
-  }
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let resolveDrain = () => {};
-  await new Promise<void>((resolve) => {
-    resolveDrain = () => resolve();
-    const waiters =
-      GATEWAY_WORK_ADMISSION_STATE.rootDrainWaiters ??
-      (GATEWAY_WORK_ADMISSION_STATE.rootDrainWaiters = new Set());
-    waiters.add(resolveDrain);
-    if (timeout !== undefined) {
-      timer = setTimeout(resolve, timeout);
-    }
-  });
-  if (timer) {
-    clearTimeout(timer);
-  }
-  GATEWAY_WORK_ADMISSION_STATE.rootDrainWaiters?.delete(resolveDrain);
-  const active = GATEWAY_WORK_ADMISSION_STATE.activeRootWork.size;
-  return { drained: active === 0, active };
-}
-
 /** Atomically closes new suspension admission before synchronous inspection. */
 export function tryBeginGatewaySuspendAdmission(
   onInvalidated: () => void,
@@ -478,7 +427,6 @@ export function resetGatewayWorkAdmission(): void {
     admission.released = true;
   }
   GATEWAY_WORK_ADMISSION_STATE.activeRootWork.clear();
-  resolveRootDrainWaiters();
   GATEWAY_WORK_ADMISSION_STATE.restartDraining = false;
   GATEWAY_WORK_ADMISSION_STATE.restartSignalPending = false;
   GATEWAY_WORK_ADMISSION_STATE.restartSignalGeneration += 1;

--- a/test/helpers/cron/service-regression-fixtures.ts
+++ b/test/helpers/cron/service-regression-fixtures.ts
@@ -9,12 +9,19 @@ import { createRunningCronServiceState } from "../../../src/cron/service.test-ha
 import type { CronServiceDeps } from "../../../src/cron/service/state.js";
 import type { CronJob, CronJobState } from "../../../src/cron/types.js";
 import { resetAgentEventsForTest } from "../../../src/infra/agent-events.js";
-import { waitForActiveTasks } from "../../../src/process/command-queue.js";
+import { getTotalQueueSize } from "../../../src/process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../../../src/process/command-queue.test-support.js";
 import { useFrozenTime, useRealTime } from "../../../src/test-utils/frozen-time.js";
 import { createDeferred } from "../promise.js";
 
 const TOP_OF_HOUR_STAGGER_MS = 5 * 60 * 1_000;
+
+async function waitForCommandQueueIdle(timeoutMs: number): Promise<void> {
+  const deadlineAt = Date.now() + timeoutMs;
+  while (getTotalQueueSize() > 0 && Date.now() < deadlineAt) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+}
 
 export const noopLogger = {
   info: () => {},
@@ -41,7 +48,7 @@ export function setupCronRegressionFixtures(options?: { prefix?: string; baseTim
     vi.clearAllTimers();
     vi.restoreAllMocks();
     useRealTime();
-    await waitForActiveTasks(250);
+    await waitForCommandQueueIdle(250);
     resetCommandQueueStateForTest();
     clearSessionStoreCacheForTest();
     resetAgentEventsForTest();
@@ -49,7 +56,7 @@ export function setupCronRegressionFixtures(options?: { prefix?: string; baseTim
 
   afterAll(async () => {
     useRealTime();
-    await waitForActiveTasks(250);
+    await waitForCommandQueueIdle(250);
     await fs.rm(fixtureRoot, { recursive: true, force: true });
   });
 

--- a/test/scripts/bench-agent-concurrency.test.ts
+++ b/test/scripts/bench-agent-concurrency.test.ts
@@ -115,12 +115,12 @@ describe("agent concurrency benchmark", () => {
     expect(summary).toMatchObject({ count: 20, p50: 10, p95: 19, p99: 20, max: 20 });
   });
 
-  it("drains detached gateway root work before the next spawn sample", async () => {
+  it("drains detached gateway active work before the next spawn sample", async () => {
     resetGatewayWorkAdmission();
     const deferred = createDeferred();
     const rootWork = runWithGatewayIndependentRootWorkAdmission(() => deferred.promise);
     try {
-      const drain = workerTesting.drainSpawnSampleRootWork();
+      const drain = workerTesting.drainSpawnSampleActiveWork();
       await expect(
         Promise.race([
           drain.then(() => "drained"),
@@ -139,13 +139,13 @@ describe("agent concurrency benchmark", () => {
     }
   });
 
-  it("rejects a spawn sample when detached gateway root work does not drain", async () => {
+  it("rejects a spawn sample when detached gateway active work does not drain", async () => {
     await expect(
-      workerTesting.drainSpawnSampleRootWork(async (timeoutMs) => {
+      workerTesting.drainSpawnSampleActiveWork(async (timeoutMs) => {
         expect(timeoutMs).toBe(30_000);
-        return { drained: false, active: 2 };
+        return { drained: false, snapshot: { counts: { totalActive: 2 } } };
       }),
-    ).rejects.toThrow("spawn sample left 2 active gateway root work items");
+    ).rejects.toThrow("spawn sample left 2 active gateway work items");
   });
 
   it("aggregates synthetic worker results into schema version 2", () => {

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -5,6 +5,7 @@ export const cliProcessTestFiles = [
   "src/cli/gateway-backed-exit.process.test.ts",
   "src/cli/help-exit.process.test.ts",
   "src/cli/hooks-cli.process.test.ts",
+  "src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts",
 ];
 
 const cliProcessTestFileSet = new Set(cliProcessTestFiles);

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -9,7 +9,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import type { GatewayServer } from "../../../src/gateway/server.js";
-import { waitForActiveGatewayRootWork } from "../../../src/process/gateway-work-admission.js";
+import { getActiveGatewayRootWorkCount } from "../../../src/process/gateway-work-admission.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -502,7 +502,7 @@ async function closeConnectedContext(context: BrowserContext): Promise<void> {
   await closeContext(context);
   // UI requests intentionally outlive socket teardown. Drain their admitted work
   // before another browser interaction so lazy handler imports cannot starve it.
-  await expect(waitForActiveGatewayRootWork()).resolves.toEqual({ active: 0, drained: true });
+  await expect.poll(() => getActiveGatewayRootWorkCount()).toBe(0);
 }
 
 async function captureChromiumScreenshot(page: Page, fileName: string): Promise<void> {

--- a/ui/src/lib/board/widget-sandbox-host.test.ts
+++ b/ui/src/lib/board/widget-sandbox-host.test.ts
@@ -949,15 +949,22 @@ describe("BoardWidgetSandboxHost", () => {
     let resolveFirstFetch: (response: Response) => void = () => {};
     const frame = document.createElement("iframe");
     document.body.append(frame);
-    const fetchMock = vi
-      .fn<() => Promise<Response>>()
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<Response>((resolve) => {
-            resolveFirstFetch = resolve;
-          }),
-      )
-      .mockResolvedValueOnce(new Response("<!doctype html><p>resumed</p>"));
+    const sourceUrl = "https://gateway.example/widget";
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    let sourceFetches = 0;
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url !== sourceUrl) {
+        return await originalFetch(input, init);
+      }
+      sourceFetches += 1;
+      if (sourceFetches === 1) {
+        return await new Promise<Response>((resolve) => {
+          resolveFirstFetch = resolve;
+        });
+      }
+      return new Response("<!doctype html><p>resumed</p>");
+    });
     vi.stubGlobal("fetch", fetchMock);
     const onLoaded = vi.fn();
     const host = new BoardWidgetSandboxHost({
@@ -985,7 +992,7 @@ describe("BoardWidgetSandboxHost", () => {
         },
       }),
     );
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(sourceFetches).toBe(1));
 
     host.setActive(false);
     resolveFirstFetch(new Response("<!doctype html><p>stale</p>"));
@@ -994,7 +1001,7 @@ describe("BoardWidgetSandboxHost", () => {
 
     host.setActive(true);
     await vi.waitFor(() => expect(onLoaded).toHaveBeenCalledOnce());
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(sourceFetches).toBe(2);
     host.dispose();
   });
 


### PR DESCRIPTION
Related: #125840 — this is the distinct active-work inventory gap that its hard-deadline repair does not fix.

AI-assisted: yes

## What Problem This Solves

Fixes an issue where intent-free SIGTERM and SIGINT drained only Gateway root work, so a channel-adopted embedded run with no remaining root could be truncated during server close.

## Why This Change Was Made

Adds one canonical active-work waiter covering queue, reply, embedded, background-exec, cron, task, root, and session owners, then uses it for both stop and restart under one deadline. Restart-only recovery and abort policy remain unchanged, and the old partial wait APIs are deleted.

The separate launchd/systemd timeout-budget mismatch is explicitly out of scope and tracked independently.

## User Impact

Direct Gateway stops now wait for active agent and channel work before teardown, bounded by the existing shutdown deadlines. Forced restart behavior is unchanged.

## Evidence

- Pre-fix real OS signal trace: `adopted:roots=0:embedded=1 -> gateway-close -> process-exit:0`, without embedded completion.
- The new process test proves embedded completion precedes Gateway close.
- 10 focused Vitest shards: 801 tests passed.
- Exact-head CI initially exposed an unrelated `isolate: false` global fetch mock collision; the repair now delegates unrelated requests and scopes counts to the widget URL.
- 20/20 focused repetitions passed.
- Exact CI group `core-runtime-media-ui-2` passed locally: 217 files passed, 2 skipped; 2742 tests passed, 3 skipped.
- Scoped `node scripts/check-changed.mjs` passed.
- `pnpm build`
- `git diff --check`
- Fresh autoreview clean.
- Production LOC: +100/-310 (net -210); tests/support: +501/-433 (net +68); tooling: +11/-8 (net +3).

No live production proof is claimed; the evidence above is local process, test, check, and build proof.
