### PR TITLE
test(openai): drop upstream realtime outcome assumption

### DIFF
--- a/extensions/openai/realtime-voice-provider.live.test.ts
+++ b/extensions/openai/realtime-voice-provider.live.test.ts
@@ -1,6 +1,5 @@
 // OpenAI tests cover the native realtime voice bridge against the live API.
 import { describe, expect, it } from "vitest";
-import WebSocket from "ws";
 import { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";
 
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY?.trim() ?? "";
@@ -8,72 +7,6 @@ const LIVE_ENABLED = OPENAI_API_KEY.length > 0 && process.env.OPENCLAW_LIVE_TEST
 const describeLive = LIVE_ENABLED ? describe : describe.skip;
 
 describeLive("OpenAI realtime voice lifecycle live", () => {
-  it("emits an incomplete response and then reuses the same session", async () => {
-    const socket = new WebSocket("wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1", {
-      headers: { Authorization: `Bearer ${OPENAI_API_KEY}` },
-    });
-    const outcomes: Array<{ status?: string; reason?: string }> = [];
-    const sendTurn = (text: string, maxOutputTokens: number) => {
-      socket.send(
-        JSON.stringify({
-          type: "conversation.item.create",
-          item: { type: "message", role: "user", content: [{ type: "input_text", text }] },
-        }),
-      );
-      socket.send(
-        JSON.stringify({
-          type: "response.create",
-          response: { output_modalities: ["text"], max_output_tokens: maxOutputTokens },
-        }),
-      );
-    };
-    try {
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(
-          () => reject(new Error("Realtime live probe timed out")),
-          45_000,
-        );
-        socket.on("message", (data) => {
-          const payload = Buffer.isBuffer(data)
-            ? data
-            : Array.isArray(data)
-              ? Buffer.concat(data)
-              : Buffer.from(data);
-          const event = JSON.parse(payload.toString("utf8")) as {
-            type?: string;
-            response?: { status?: string; status_details?: { reason?: string } | null };
-            error?: { message?: string };
-          };
-          if (event.type === "error") {
-            clearTimeout(timeout);
-            reject(new Error(event.error?.message ?? "Realtime API error"));
-          } else if (event.type === "session.created") {
-            sendTurn("Write a detailed paragraph about ocean tides.", 1);
-          } else if (event.type === "response.done") {
-            outcomes.push({
-              status: event.response?.status,
-              reason: event.response?.status_details?.reason,
-            });
-            if (outcomes.length === 1) {
-              sendTurn("Reply with exactly one word: ok", 100);
-            } else {
-              clearTimeout(timeout);
-              resolve();
-            }
-          }
-        });
-        socket.on("error", reject);
-      });
-    } finally {
-      socket.close();
-    }
-
-    expect(outcomes).toEqual([
-      { status: "incomplete", reason: "max_output_tokens" },
-      { status: "completed", reason: undefined },
-    ]);
-  }, 60_000);
-
   it("reuses a bridge after a terminal close", async () => {
     let closeCount = 0;
     let readyCount = 0;


### PR DESCRIPTION
## Summary

- remove the raw OpenAI Realtime WebSocket assertion that pins one model-generated turn to an exact upstream terminal status
- keep the live test that exercises OpenClaw's actual realtime voice bridge and reconnect lifecycle

## Root cause

The deleted case does not call OpenClaw production code. It opens a vendor WebSocket directly, asks `gpt-realtime-2.1` for a long answer with `max_output_tokens: 1`, and assumes the first `response.done` must be `incomplete/max_output_tokens`.

OpenAI's official [`response.done` server-event contract](https://platform.openai.com/docs/api-reference/realtime-server-events/response/output_audio_transcript/delta?lang=node) says the event is always emitted regardless of final state and directs clients to inspect `response.status`: success is `completed`, while the other permitted terminal outcomes are `cancelled`, `failed`, and `incomplete`. Its response schema separately says `status_details.error` is populated for `failed`, while `status_details.reason` can be `max_output_tokens` for `incomplete`; it does not promise that a one-token request must choose `incomplete` rather than `failed`. This is independent upstream contract proof, not an inference from OpenClaw code or the failing workflow. In two exact-source release attempts, the API returned `failed` for that synthetic one-token turn, then completed the follow-up on the same session. The assertion therefore converts permitted upstream model/service behavior into a deterministic release red without exercising the OpenClaw adapter.

The production-owned invariant remains covered by the [OpenClaw terminal-outcome/reuse suite](https://github.com/openclaw/openclaw/blob/0f753c2a355c9a0a6de92a4c9ed17e87a4f703dc/extensions/openai/realtime-voice-terminal-outcomes.test.ts#L162-L239): completed, cancelled, failed, incomplete, invalid, queued-follow-up, and connected-session behavior all pass through `buildOpenAIRealtimeVoiceProvider()`. Its callback-throw case also proves the same connected bridge drains a queued follow-up. The retained [provider live smoke](https://github.com/openclaw/openclaw/blob/0f753c2a355c9a0a6de92a4c9ed17e87a4f703dc/extensions/openai/realtime-voice-provider.live.test.ts#L9-L49) constructs the actual OpenClaw provider, connects, closes, reconnects, and verifies ready/close/error outcomes.

The only coverage removed is a raw vendor-socket assertion about which upstream status a model-generated one-token response chooses, plus raw upstream session reuse. Neither path traverses OpenClaw. The smaller useful provider-contract smoke is retained: the live OpenClaw bridge still proves provider construction and socket reuse, while deterministic provider-owned tests retain every terminal status and queued-follow-up reuse contract.

## Evidence

- full validation attempt 1, exact source `97a4d324f5c8f32b9c106d6a6e9ed33c180a5fcb`: https://github.com/openclaw/openclaw/actions/runs/32173561938/job/95832021747
- full validation attempt 2, same exact source: https://github.com/openclaw/openclaw/actions/runs/32184128652/job/95865512813
- official Realtime `response.done` contract and response status schema (independently checked): https://platform.openai.com/docs/api-reference/realtime-server-events/response/output_audio_transcript/delta?lang=node

No local tests, builds, formatting, or dependency setup were run, per release-validation policy. Exact-head GitHub CI and the native OpenAI live shard are the proof path.

Exact-head native OpenAI live proof for `0f753c2a355c9a0a6de92a4c9ed17e87a4f703dc`: https://github.com/openclaw/openclaw/actions/runs/32187879346. The modified surface passed on both attempts: the retained `reuses a bridge after a terminal close` live case completed in 1.037s and 0.724s, and the deleted raw vendor-status case is absent. The advisory shard's unrelated OpenAI provider tests timed out (`openai.live.test.ts` on both attempts and the `gpt-5.6` provider case on retry); other provider models passed. The first dispatch used a transcribed non-existent SHA and never reached tests.

## Scope

- production LOC: 0
- tests: -67
- no runtime, config, protocol, dependency, storage, or public API change

Agent transcript omitted.
