### PR TITLE
docs(gateway): document the Cloudflare Tunnel and Access deployment

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1740,7 +1740,8 @@
                   "gateway/remote",
                   "gateway/remote-gateway-readme",
                   "gateway/stable-https-url",
-                  "gateway/tailscale"
+                  "gateway/tailscale",
+                  "gateway/cloudflare-access"
                 ]
               },
               {

--- a/docs/gateway/cloudflare-access.md
+++ b/docs/gateway/cloudflare-access.md
@@ -1,0 +1,157 @@
+---
+summary: "Publish a loopback Gateway through a Cloudflare Tunnel and authenticate every client with Cloudflare Access"
+read_when:
+  - You want a public HTTPS Gateway URL without opening a port
+  - You want Cloudflare Access (SSO) to authenticate the Control UI
+  - Your CLI, TUI, or nodes get HTTP 302 from a Cloudflare-fronted Gateway
+title: "Cloudflare Tunnel and Access"
+---
+
+Run the Gateway on loopback, publish it through a Cloudflare Tunnel, and let Cloudflare
+Access authenticate every request before it reaches OpenClaw. The Gateway keeps
+`gateway.bind: "loopback"`, so no port is exposed and no inbound firewall rule is
+needed; `cloudflared` dials out from the host.
+
+This is one supported remote-access topology alongside [Tailscale](/gateway/tailscale)
+and an [SSH tunnel](/gateway/remote#ssh-tunnel-cli--tools). Choose it when you want a
+stable public HTTPS URL and identity-provider SSO in front of the Control UI.
+
+## Before you begin
+
+- A Cloudflare account with the zone for your hostname, and Cloudflare Zero Trust enabled.
+- `cloudflared` installed on the Gateway host, and on any machine that will use the CLI.
+- A running Gateway on `127.0.0.1:18789` with `gateway.bind: "loopback"`.
+- Familiarity with [trusted-proxy auth](/gateway/trusted-proxy-auth), which this topology uses.
+
+## How the pieces fit
+
+```text
+browser / CLI / node  ->  Cloudflare Access (identity)  ->  Tunnel  ->  127.0.0.1:18789
+```
+
+Access authenticates the request and injects identity headers. The Gateway does not
+re-authenticate the person; it trusts those headers because the only thing that can
+reach its loopback port is the local `cloudflared` process. That trust is why the
+`trustedProxies` and `allowLoopback` settings below are mandatory rather than optional.
+
+## Step 1: Route the tunnel to loopback
+
+Add an ingress rule mapping your hostname to the Gateway port, then run `cloudflared`
+as a service on the Gateway host:
+
+```yaml
+tunnel: <tunnel-id>
+credentials-file: /root/.cloudflared/<tunnel-id>.json
+ingress:
+  - hostname: gateway.example
+    service: http://localhost:18789
+  - service: http_status:404
+```
+
+See Cloudflare's own documentation for creating the tunnel and DNS record.
+
+## Step 2: Protect the hostname with Access
+
+Create an Access application for `gateway.example` with a policy that allows your
+users. Note the two headers Access adds to authenticated requests, because the Gateway
+consumes them in the next step:
+
+- `cf-access-authenticated-user-email` — the authenticated identity.
+- `cf-access-jwt-assertion` — the signed assertion proving Access performed the check.
+
+## Step 3: Trust those headers in the Gateway
+
+Set `gateway.auth.mode` to `trusted-proxy` and name the Access headers. `allowLoopback`
+is required here: `cloudflared` connects from `127.0.0.1`, and trusted-proxy auth
+otherwise expects a non-loopback proxy.
+
+```json5
+{
+  gateway: {
+    bind: "loopback",
+    trustedProxies: ["127.0.0.1", "::1"],
+    auth: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "cf-access-authenticated-user-email",
+        requiredHeaders: ["cf-access-jwt-assertion"],
+        allowLoopback: true,
+      },
+    },
+  },
+}
+```
+
+Requiring `cf-access-jwt-assertion` matters. Without a required header that only Access
+can produce, any process able to reach the loopback port could assert an identity by
+setting the email header itself.
+
+## Step 4: Decide how nodes and workers get in
+
+Access protects every route on the hostname, including the ones nodes use. Pick one:
+
+- **Exempt the self-authenticating routes.** Allow `/j/*` and `/__openclaw__/worker`
+  without Access identity, and keep WebSocket upgrade enabled on the worker route. Both
+  enforce their own short-lived credentials, so they do not depend on Access. See
+  [Nodes](/nodes#edge-routing).
+- **Use an Access service token.** Add a Service Auth policy and give the node
+  `gateway.cloudflareAccess.clientId` / `clientSecret`. See [Node CLI](/cli/node).
+
+If you do neither, `openclaw connect` fails against the tunnel even though the browser
+works, because the join request is redirected to the Access login page.
+
+## Step 5: Connect each client
+
+**Control UI.** Open `https://gateway.example` and sign in through Access. With
+trusted-proxy auth the Gateway maps your Access identity to an operator session.
+
+**CLI and TUI.** These do not carry browser cookies, so they present an Access token on
+the WebSocket upgrade. Configure `gateway.remote.edgeAuth` as described in
+[Remote access](/gateway/remote#gateway-behind-an-identity-aware-proxy), then run
+`cloudflared access login https://gateway.example` once to cache a token.
+
+**Nodes.** Follow the choice made in step 4.
+
+## Verify
+
+```bash
+openclaw tui
+```
+
+Expect the TUI to reach `wss://gateway.example` and show `connected`. A first
+connection may report `device pairing required`; approve it in the Control UI under
+Settings → Devices, or run `openclaw devices approve --latest` on the Gateway host.
+
+Reaching the Gateway's own pairing prompt is itself the proof that Access was
+satisfied — an unauthenticated request never gets that far.
+
+## Production readiness
+
+- Keep `gateway.bind: "loopback"`. Binding wider re-exposes the Gateway beside the
+  tunnel and bypasses Access entirely.
+- Keep `trustedProxies` limited to loopback. It is the list of addresses whose identity
+  headers the Gateway will believe.
+- `trustedProxy.deviceAutoApprove` can pair devices automatically for
+  Access-authenticated identities. It removes a manual approval step; enable it only
+  when you accept that anyone who passes Access gets a paired device with the scopes you
+  list.
+- Access tokens expire on the application's session duration. Expect CLI users to re-run
+  `cloudflared access login` when their token lapses.
+
+## Troubleshooting
+
+| Symptom                                                             | Cause and fix                                                                                                                                     |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gateway rejected websocket upgrade (HTTP 302)` from the CLI or TUI | Access intercepted the upgrade. Configure `gateway.remote.edgeAuth`; see [Remote access](/gateway/remote#gateway-behind-an-identity-aware-proxy). |
+| Browser works, `openclaw connect` fails                             | Node routes are still behind Access. Apply one of the options in step 4.                                                                          |
+| `Exec provider ... exited with code 1`                              | The exec secret provider runs with a scrubbed environment; `cloudflared` needs `passEnv: ["HOME"]` to read its cached token.                      |
+| `secrets.providers.*.command must not be a symlink`                 | Point `command` at the resolved binary, not a package-manager symlink.                                                                            |
+| Gateway starts but every request is anonymous                       | `allowLoopback` is unset, so headers from the local `cloudflared` are ignored.                                                                    |
+
+## Related
+
+- [Remote access](/gateway/remote)
+- [Trusted-proxy auth](/gateway/trusted-proxy-auth)
+- [Nodes](/nodes)
+- [Tailscale](/gateway/tailscale)
+- [Authentication](/gateway/authentication)

--- a/docs/gateway/cloudflare-access.md
+++ b/docs/gateway/cloudflare-access.md
@@ -30,9 +30,10 @@ browser / CLI / node  ->  Cloudflare Access (identity)  ->  Tunnel  ->  127.0.0.
 ```
 
 Access authenticates the request and injects identity headers. The Gateway does not
-re-authenticate the person; it trusts those headers because the only thing that can
-reach its loopback port is the local `cloudflared` process. That trust is why the
-`trustedProxies` and `allowLoopback` settings below are mandatory rather than optional.
+re-authenticate the person or verify the Access JWT signature; it checks the trusted
+proxy source and configured header presence, then trusts the user header. Because
+`allowLoopback` also lets other local processes present those headers, keep the Gateway
+port private to the host and run only trusted workloads there.
 
 ## Step 1: Route the tunnel to loopback
 
@@ -57,7 +58,8 @@ users. Note the two headers Access adds to authenticated requests, because the G
 consumes them in the next step:
 
 - `cf-access-authenticated-user-email` — the authenticated identity.
-- `cf-access-jwt-assertion` — the signed assertion proving Access performed the check.
+- `cf-access-jwt-assertion` — Access's signed assertion. OpenClaw checks only that this
+  header is present and non-blank; it does not verify the JWT signature.
 
 ## Step 3: Trust those headers in the Gateway
 
@@ -82,9 +84,11 @@ otherwise expects a non-loopback proxy.
 }
 ```
 
-Requiring `cf-access-jwt-assertion` matters. Without a required header that only Access
-can produce, any process able to reach the loopback port could assert an identity by
-setting the email header itself.
+Requiring `cf-access-jwt-assertion` adds a second presence check, not cryptographic
+verification. A local process that can connect to the Gateway can submit both headers,
+so do not treat this setting as a defense against untrusted local code. The security
+boundary is the locked-down loopback port plus Cloudflare Access and the tunnel being
+the only path for external traffic.
 
 ## Step 4: Decide how nodes and workers get in
 

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -93,6 +93,11 @@ For a Gateway already reachable on a trusted LAN or Tailnet, use direct mode:
 
 ## Gateway behind an identity-aware proxy
 
+To deploy this way from scratch — tunnel, Access application, Gateway trusted-proxy
+auth, and node routes — see [Cloudflare Tunnel and Access](/gateway/cloudflare-access).
+This section covers only the client side: how a CLI, TUI, or app authenticates to that
+edge.
+
 Use `gateway.remote.edgeAuth` when an identity-aware proxy must authenticate the
 WebSocket upgrade before traffic reaches the Gateway. Header values are
 `SecretInput` fields, so they can come from `env`, `file`, `exec`, or `store`

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -298,6 +298,9 @@ Use one TLS termination point and apply HSTS there.
 
 ## Proxy setup examples
 
+Cloudflare Access is covered end to end, including the tunnel and node routes, in
+[Cloudflare Tunnel and Access](/gateway/cloudflare-access).
+
 <AccordionGroup>
   <Accordion title="Pomerium">
     Pomerium passes identity in `x-pomerium-claim-email` (or other claim headers) and a JWT in `x-pomerium-jwt-assertion`.


### PR DESCRIPTION
Follow-up to #125700 and #125982.

## What Problem This Solves

Hosting a Gateway behind Cloudflare and authenticating with Cloudflare Access is a real,
working deployment topology — it is what `team.openclaw.ai` runs today — but it was not
documented as one. The pieces existed in three places and no page told an operator how to
deploy this way:

- `docs/install/cloudflare.md` is the Workers/Containers template and uses `--gateway-auth token`.
  Its title makes "Cloudflare" look covered when this topology is not.
- `docs/gateway/trusted-proxy-auth.md` is the canonical identity-aware-proxy page and documents
  Pomerium, Caddy, and nginx + OAuth. It had **zero** mentions of Cloudflare, even though
  Cloudflare Access is the same pattern and is the deployment in production.
- `docs/gateway/remote.md` listed Tailscale, SSH tunnel, and LAN as the topologies. Its only
  Cloudflare content was the client-side `edgeAuth` section added in #125700.
- The node-side Access instructions and the `/j/*` + `/__openclaw__/worker` exemption guidance
  lived only in `docs/nodes/index.md`.

The cost is concrete: `team.openclaw.ai` returns 302 on `/j/*` and `/__openclaw__/worker`, so
`openclaw connect` cannot join it. The exemption guidance exists, but nothing surfaces it at
deploy time.

## Why This Change Was Made

Adds `docs/gateway/cloudflare-access.md`, a guide for the whole topology, and cross-links it from
the two pages an operator actually searches (`gateway/remote`, `gateway/trusted-proxy-auth`).

Content is grounded in the running reference deployment rather than invented: the Gateway stays on
`gateway.bind: "loopback"`, `cloudflared` maps the hostname to `http://localhost:18789`, and the
Gateway uses `auth.mode: "trusted-proxy"` with `userHeader: "cf-access-authenticated-user-email"`,
`requiredHeaders: ["cf-access-jwt-assertion"]`, `trustedProxies: ["127.0.0.1", "::1"]`, and
`allowLoopback: true`. Every config key was checked against `src/config/types.gateway.ts`.

The guide explains why each guard exists rather than only listing it: `allowLoopback` is required
because `cloudflared` dials from `127.0.0.1`; the JWT assertion is accurately described as a
presence check rather than signature verification, and the guide calls out that same-host
processes share the loopback trust boundary; `deviceAutoApprove` is presented with its tradeoff
instead of as a convenience. Cloudflare dashboard steps are deliberately delegated to
Cloudflare's own docs rather than paraphrased.

## User Impact

Operators get one page for a topology that previously had to be reverse-engineered from three, and
the node-route decision (exempt the self-authenticating routes, or use a service token) is now
stated where it is made instead of only on the nodes page. Troubleshooting maps the exact symptoms
this path produces — the 302 on WebSocket upgrade, `openclaw connect` failing while the browser
works, the exec provider exiting 1 without `passEnv: ["HOME"]`, and the symlink rejection.

## Evidence

Docs-only. `node scripts/check-changed.mjs` exit 0, including `docs:check-config-examples`
(1180 fences validated), link checks, and formatting. `docs.json` re-parsed as valid JSON after the
navigation entry was added under Remote access.

Config values were read from the live reference deployment and cross-checked against the schema in
`src/config/types.gateway.ts` (`userHeader`, `requiredHeaders`, `allowLoopback`, `deviceAutoApprove`).
The connect/verify flow in the guide is the one exercised end to end in #125982: a TUI reaching
`wss://`, pairing, and returning a model reply through Access.
