### PR TITLE
fix(ui): make assign-to-me update session owner

### DIFF
--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -131,7 +131,7 @@ function iconChoices(menu: ParentNode): HTMLButtonElement[] {
 }
 
 describe("session menu", () => {
-  it("renders owner radio state and closes before dispatching assignment", async () => {
+  it("dispatches the same canonical owner from the self shortcut and submenu", async () => {
     const onAction = vi.fn<(action: SessionMenuAction) => void>();
     const onClose = vi.fn();
     const selfOwner = { type: "human", id: "profile-ada", label: "Ada" } as const;
@@ -148,15 +148,21 @@ describe("session menu", () => {
     expect(selected.disabled).toBe(true);
     expect(selected.querySelector("[slot='details']")).not.toBeNull();
 
-    menu.querySelector("wa-dropdown")?.dispatchEvent(
-      new CustomEvent("wa-select", {
-        bubbles: true,
-        composed: true,
-        detail: { item: { value: "assign-owner:self" } },
-      }),
-    );
-    expect(onAction).toHaveBeenCalledWith({ kind: "assign-owner", owner: selfOwner });
-    expect(onClose).toHaveBeenCalledOnce();
+    for (const label of ["Assign to me", "Ada"]) {
+      const value = menuItem(menu, label).getAttribute("value");
+      menu.querySelector("wa-dropdown")?.dispatchEvent(
+        new CustomEvent("wa-select", {
+          bubbles: true,
+          composed: true,
+          detail: { item: { value } },
+        }),
+      );
+    }
+    expect(onAction.mock.calls).toEqual([
+      [{ kind: "assign-owner", owner: { type: "human", id: "profile-ada" } }],
+      [{ kind: "assign-owner", owner: { type: "human", id: "profile-ada" } }],
+    ]);
+    expect(onClose).toHaveBeenCalledTimes(2);
     const closeOrder = onClose.mock.invocationCallOrder[0];
     const actionOrder = onAction.mock.invocationCallOrder[0];
     if (closeOrder === undefined || actionOrder === undefined) {

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -179,7 +179,7 @@ class SessionMenu extends OpenClawLightDomElement {
       });
       return;
     }
-    const owner = sessionOwnerAssignmentFromMenuValue(value, this.selfOwner);
+    const owner = sessionOwnerAssignmentFromMenuValue(value);
     if (owner) {
       this.runAction({ kind: "assign-owner", owner });
     }

--- a/ui/src/components/session-owner-menu.ts
+++ b/ui/src/components/session-owner-menu.ts
@@ -7,13 +7,7 @@ import { syncDropdownItemRadio } from "./web-awesome.ts";
 
 type SessionOwnerAssignment = Pick<SessionOwnerOption, "type" | "id">;
 
-export function sessionOwnerAssignmentFromMenuValue(
-  value: string,
-  selfOwner: SessionOwnerOption | null,
-): SessionOwnerAssignment | null {
-  if (value === "assign-owner:self") {
-    return selfOwner;
-  }
+export function sessionOwnerAssignmentFromMenuValue(value: string): SessionOwnerAssignment | null {
   if (!value.startsWith("assign-owner:")) {
     return null;
   }
@@ -34,7 +28,7 @@ export function renderSessionOwnerAssignmentMenu(params: {
     ${params.selfOwner
       ? html`<wa-dropdown-item
           class="session-menu__item"
-          value="assign-owner:self"
+          value=${`assign-owner:${params.selfOwner.type}:${encodeURIComponent(params.selfOwner.id)}`}
           ?disabled=${params.disabled || params.currentOwnerId === params.selfOwner.id}
           title=${title}
         >

--- a/ui/src/pages/chat/components/chat-header-session-menu.test.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.test.ts
@@ -265,10 +265,10 @@ describe("chat header session menu", () => {
     expect(selected.disabled).toBe(true);
     expect(selected.querySelector("[slot='details']")).not.toBeNull();
 
-    select(menu, "assign-owner:self");
+    select(menu, item(menu, "Assign to me").getAttribute("value") ?? "");
     select(menu, "assign-owner:agent:research%3Aone");
     expect(onAction.mock.calls).toEqual([
-      [{ kind: "assign-owner", owner: { type: "human", id: "profile-ada", label: "Ada" } }],
+      [{ kind: "assign-owner", owner: { type: "human", id: "profile-ada" } }],
       [{ kind: "assign-owner", owner: { type: "agent", id: "research:one" } }],
     ]);
   });

--- a/ui/src/pages/chat/components/chat-header-session-menu.ts
+++ b/ui/src/pages/chat/components/chat-header-session-menu.ts
@@ -103,7 +103,7 @@ class ChatHeaderSessionMenu extends OpenClawLightDomElement {
       }
       return;
     }
-    const owner = sessionOwnerAssignmentFromMenuValue(value, this.selfOwner);
+    const owner = sessionOwnerAssignmentFromMenuValue(value);
     if (owner) {
       this.onAction({ kind: "assign-owner", owner });
       return;

--- a/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-mutations.ts
@@ -151,15 +151,17 @@ describe("AppSidebar session mutation feedback", () => {
   });
 
   it("assigns owners from the row menu and updates the owner chip", async () => {
-    const request = vi.fn(async (method: string) => {
+    const request = vi.fn(async (method: string, params: unknown) => {
       if (method !== "sessions.assignOwner") {
         throw new Error(`unexpected method: ${method}`);
       }
+      const owner = (params as { owner: { type: "human"; id: string } }).owner;
+      const label = owner.id === "profile-ada" ? "Ada" : "Bob";
       return {
         ok: true,
         key: "agent:main:a",
         owner: {
-          actor: { type: "human", id: "profile-bob", label: "Bob" },
+          actor: { ...owner, label },
           assignedBy: { type: "human", id: "profile-ada", label: "Ada" },
           assignedAt: 10,
         },
@@ -208,6 +210,31 @@ describe("AppSidebar session mutation feedback", () => {
           .querySelector(`[data-session-key="${row.key}"] .session-owner-chip`)
           ?.getAttribute("title"),
       ).toBe("Owned by Bob");
+    });
+
+    const selfMenu = await openSessionMenu(sidebar, row.key);
+    const selfItem = selfMenu.querySelector<HTMLElement>(
+      ':scope > wa-dropdown > wa-dropdown-item[value="assign-owner:human:profile-ada"]',
+    );
+    selfMenu.querySelector("wa-dropdown")?.dispatchEvent(
+      new CustomEvent("wa-select", {
+        bubbles: true,
+        detail: { item: { value: selfItem?.getAttribute("value") } },
+      }),
+    );
+
+    await waitForFast(() => expect(request).toHaveBeenCalledTimes(2));
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.assignOwner", {
+      key: row.key,
+      agentId: "main",
+      owner: { type: "human", id: "profile-ada" },
+    });
+    await waitForFast(() => {
+      expect(
+        sidebar
+          .querySelector(`[data-session-key="${row.key}"] .session-owner-chip`)
+          ?.getAttribute("title"),
+      ).toBe("Owned by Ada");
     });
   });
 


### PR DESCRIPTION
Closes #126026

AI-assisted: yes. The implementation and tests were inspected and verified by the maintainer before landing.

## What Problem This Solves

Fixes an issue where Control UI users selecting **Assign to me** in a session menu would see the menu close without ownership changing, while selecting the same profile through **Assign to…** succeeded.

## Why This Change Was Made

Both session-menu routes now encode and parse one canonical `{ type, id }` owner payload accepted by the closed Gateway schema. The sidebar and chat-header menus share that path; there is no API or configuration change.

## User Impact

**Assign to me** now reliably changes session ownership from both the sidebar and chat-header menus. The existing **Assign to…** behavior remains unchanged.

## Evidence

The pre-fix focused regression failed because the self shortcut emitted an unexpected `label: "Ada"` field; the Gateway's closed `sessions.assignOwner` schema accepts only `type` and `id`.

- `node scripts/run-vitest.mjs ui/src/components/session-menu.test.ts ui/src/pages/chat/components/chat-header-session-menu.test.ts ui/src/components/app-sidebar.test.ts`
  - 3 files passed, 319 tests passed.
- Deterministic mocked-Gateway Chromium proof exercised both visible menu routes, asserted identical `sessions.assignOwner` owner payloads, and observed both owner chips update to Ada.
  - This is mocked-Gateway browser proof, not a live dev Gateway run.
- `.claude/skills/autoreview/scripts/autoreview --mode uncommitted`
  - Clean: no accepted/actionable findings; patch correctness 0.99.
- Production LOC: +4/-10 (net -6). Tests and test support: +47/-14 (net +33).
- Changed checks excluding the globally contended Knip scan passed: guards, formatting, UI i18n, core-test/UI typechecks, lint, and style checks. A prior full changed check timed out only while shared Knip scans were heavily contended; a separate clean changed-check run passed.

Before: both synthetic fixture sessions are owned by Bob and the shortcut is visible.

![Control UI session menu before owner assignment](https://github.com/user-attachments/assets/eb7d4921-efd3-4b8f-a51f-8aa6acef707d)

After: both routes have assigned the synthetic fixture sessions to Ada.

![Control UI after both owner assignment routes](https://github.com/user-attachments/assets/aa900dd8-ba73-4351-9539-709ee1f77b2a)

## ClawSweeper Review Handling

The exact-head review found no actionable code defect. Its only rank-up move was optional isolated live dev-Gateway proof of both routes. Maintainer decision: skip that optional upgrade for this bounded payload-shape repair because the failing/passing owner-boundary regression and deterministic mocked-Gateway Chromium flow exercise both visible routes and the exact request contract. The remaining uncertainty is explicit: this PR does not include a live dev-Gateway run.

The review's stored-data heuristic is not applicable: this changes UI menu serialization and tests only, with no persisted state, database schema, migration, API, or configuration change.
