### PR TITLE
fix(ui): keep New Session folder picker usable while menus close

### DIFF
--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -25,7 +25,14 @@ suite.define(() => {
         viewport: { height: 900, width: 1280 },
       },
       async ({ page }) => {
-        const now = Date.now();
+        const current = new Date();
+        // Keep the automation fixtures on one local calendar day in every timezone.
+        const now = new Date(
+          current.getFullYear(),
+          current.getMonth(),
+          current.getDate() - 1,
+          12,
+        ).getTime();
         const releaseKey = "agent:main:release-readiness";
         const designKey = "agent:main:design-review";
         await installMockGateway(page, {

--- a/ui/src/pages/new-session/draft-place-browser.test.ts
+++ b/ui/src/pages/new-session/draft-place-browser.test.ts
@@ -90,6 +90,23 @@ function createBrowser(request: (method: string) => Promise<unknown>, data?: New
 }
 
 describe("DraftPlaceBrowser", () => {
+  it("tracks overlapping popover hides independently", () => {
+    const { browser } = createBrowser(async () => ({}));
+
+    browser.onPopoverHide("project");
+    browser.onPopoverHide("where");
+
+    expect(browser.popoverHiding("project")).toBe(true);
+    expect(browser.popoverHiding("where")).toBe(true);
+
+    browser.onPopoverAfterHide("project");
+    expect(browser.popoverHiding("project")).toBe(false);
+    expect(browser.popoverHiding("where")).toBe(true);
+
+    browser.onPopoverAfterHide("where");
+    expect(browser.popoverHiding("where")).toBe(false);
+  });
+
   it.each([
     ["the Gateway omits recents", async () => ({ projects: [] })],
     [

--- a/ui/src/pages/new-session/draft-place-browser.ts
+++ b/ui/src/pages/new-session/draft-place-browser.ts
@@ -59,7 +59,8 @@ export class DraftPlaceBrowser {
   private browserProjectPathValue: string | null = null;
   private browserRegisteringValue = false;
   private openPopoverValue: DraftPickerKind | null = null;
-  private hidingPopoverValue: DraftPickerKind | null = null;
+  // Independent hide animations can overlap; keep every trigger fenced until its own completes.
+  private readonly hidingPopovers = new Set<DraftPickerKind>();
   // Live head input; absolute paths stay applicable even without fs.listDir.
   private browserPathDraftValue = "";
   private browserRequestToken = 0;
@@ -217,7 +218,7 @@ export class DraftPlaceBrowser {
   }
 
   popoverHiding(kind: DraftPickerKind): boolean {
-    return this.hidingPopoverValue === kind;
+    return this.hidingPopovers.has(kind);
   }
 
   popoverCallbacks(kind: DraftPickerKind) {
@@ -524,7 +525,7 @@ export class DraftPlaceBrowser {
     if (this.openPopoverValue === kind) {
       this.openPopoverValue = null;
     }
-    this.hidingPopoverValue = kind;
+    this.hidingPopovers.add(kind);
     if (kind === "project") {
       this.showRoot();
     } else {
@@ -533,15 +534,13 @@ export class DraftPlaceBrowser {
   }
 
   onPopoverAfterHide(kind: DraftPickerKind) {
-    if (this.hidingPopoverValue === kind) {
-      this.hidingPopoverValue = null;
-    }
+    this.hidingPopovers.delete(kind);
     this.restorePopoverTrigger(`new-session-${kind}-trigger`, `.new-session-page__${kind}-popover`);
     this.callbacks.requestUpdate();
   }
 
   guardPopoverTransition(event: Event, kind: DraftPickerKind) {
-    if (this.hidingPopoverValue !== kind) {
+    if (!this.hidingPopovers.has(kind)) {
       return;
     }
     event.preventDefault();
@@ -549,7 +548,7 @@ export class DraftPlaceBrowser {
   }
 
   clearPopoverHiding() {
-    this.hidingPopoverValue = null;
+    this.hidingPopovers.clear();
     this.callbacks.requestUpdate();
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where overlapping New Session popover hide animations shared one lifecycle slot. A stale hide could close or unfence a newly reopened picker, leaving the exec-only Working directory input present in the DOM but invisible and unusable.

This PR originally proposed the collapsible Online roster. That feature landed independently and more completely in #125963 / `1110cd09bd0`, so the duplicate Online implementation and its screenshots were dropped during rebase.

Its next exact-head run exposed red `main` after #126062 had propagated an exact Gateway resolver into detached completion delivery without a matching dispatcher contract. This branch initially carried that owner repair, but #125946 / `fe816d69ef5` then landed independently while final CI was running. #125946 routes detached announcements through the existing instance-aware in-process dispatcher, fixing both the red compile and the active completion path. The now-redundant Gateway commit was therefore dropped as well; this PR contains only the remaining proven picker repair.

## Why This Change Was Made

`DraftPlaceBrowser` now tracks every hiding picker independently until that picker's own `wa-after-hide` event completes. This represents overlapping lifecycles directly at their owner instead of adding timing guards to consumers.

## User Impact

New Session place pickers remain visible and usable when one menu opens while another is finishing its hide animation. The exec-only Working directory flow can accept its manual path reliably.

The Online roster remains default-expanded, browser-local, and collapsible through #125963. Detached subagent completion routing is owned by #125946 on current `main`.

## Evidence

### Regression proof

- [Original picker failure](https://github.com/openclaw/openclaw/actions/runs/32188515286/job/95877721476) timed out filling the exec-only Working directory input because the stale popover lifecycle left it invisible.
- The deterministic owner regression overlaps two hides, completes them independently, and verifies that each picker remains fenced until its own `wa-after-hide` event.
- [Exact-head run 32202014505](https://github.com/openclaw/openclaw/actions/runs/32202014505) exposed a separate current-main fixture bug twice: the activity capture's relative timestamps crossed midnight UTC and split automation rows across calendar days. `TZ=UTC` reproduced the same 3-versus-2 row failure locally; anchoring the fixture to a past local noon makes the grouping timezone-invariant without changing timeouts or assertions.
- `DraftPlaceBrowser` production code is net-negative: +7/-8.

### Focused validation

- `node scripts/run-vitest.mjs ui/src/pages/new-session/draft-place-browser.test.ts` — 4 passed
- `TZ=UTC node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/activity-session-feed.capture.e2e.test.ts` — failed before the fixture repair and passed after it
- Combined mocked-browser proof for `new-session-page.places.e2e.test.ts` plus `activity-session-feed.capture.e2e.test.ts` — 2 files, 6 tests passed
- `pnpm tsgo:prod` — passed on current `main`, confirming #125946 independently cleared the prior red-main type failure
- `node scripts/check-changed.mjs -- <all three changed UI paths>` — passed (`coreTests`, `ui`)
- Fresh structured branch review against `origin/main` — clean, no accepted/actionable findings
- Exact-head CI: [run 32203361948](https://github.com/openclaw/openclaw/actions/runs/32203361948) completed green on `d1bd57ce52d976a3b92e7c8b571a6587f5417d29`; the unrelated durable-write shard passed its focused rerun on the unchanged head

### Visual proof

The timing race has no honest deterministic “before” still: its visible symptom is an input that exists in the DOM but is hidden after overlapping asynchronous hides. The linked CI timeout and deterministic owner regression are the before evidence. This inspected mocked-browser frame shows the repaired exec-only picker in its usable state:

![Exec-only Working directory picker](https://github.com/user-attachments/assets/9e129a4e-61b1-4490-aa09-3e97d7124d06)

### Change size

- Production: +7/-8 (net -1)
- Tests: +25/-1
