### PR TITLE
fix(ci): preserve current Kova gate failures

### DIFF
--- a/scripts/lib/kova-report-gate.mts
+++ b/scripts/lib/kova-report-gate.mts
@@ -758,6 +758,7 @@ export function evaluateToleratedProfiledKovaReport(
   return evaluate(() => {
     const { gate, records, cards, groups } = validateEnvelope(report, options);
     check(gate.verdict === "DO_NOT_SHIP", "gate verdict was not DO_NOT_SHIP");
+    check(!options.requireInstrumentedPerformanceContract, "current producer retained failure");
     check(
       records.every((record) => record.status === "PASS" || record.status === "FAIL"),
       "invalid record status",

--- a/test/scripts/kova-report-gate.test.ts
+++ b/test/scripts/kova-report-gate.test.ts
@@ -703,6 +703,18 @@ describe("scripts/lib/kova-report-gate.mts", () => {
     });
   });
 
+  it("rejects deep-profile failures from the current producer contract", () => {
+    expect(
+      evaluateToleratedProfiledKovaReport(
+        profiledResourceReport(),
+        STRICT_INSTRUMENTED_PERFORMANCE_OPTIONS,
+      ),
+    ).toEqual({
+      ok: false,
+      reason: "current producer retained failure",
+    });
+  });
+
   it("accepts independently matching non-regressing baseline evidence", () => {
     const partial = partialReport();
     const profiled = profiledResourceReport();
@@ -1324,6 +1336,21 @@ describe("scripts/lib/kova-report-gate.mts", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("profiled-resource-only");
+  });
+
+  it("keeps current-producer deep-profile failures non-zero at the CLI boundary", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        SCRIPT_PATH,
+        writeReport(profiledResourceReport()),
+        "--require-instrumented-performance-contract",
+      ],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("current producer retained failure");
   });
 
   it("keeps required instrumented PARTIAL evidence non-zero at the CLI boundary", () => {


### PR DESCRIPTION
## What Problem This Solves

The current Kova producer can preserve a real, gate-blocking performance failure in a deep-profile report. OpenClaw was still normalizing that `DO_NOT_SHIP` report to success through its historical profiling compatibility path.

Observed in [performance run 32182788559](https://github.com/openclaw/openclaw/actions/runs/32182788559), where 12 selected records exceeded absolute gateway RSS budgets, and [deep-profile run 32187098393](https://github.com/openclaw/openclaw/actions/runs/32187098393), where the persistent gateway RSS violation remained gate-blocking but the OpenClaw adapter classified the report as `profiled-resource-only`.

## Root Cause

Kova `0f9e678e239b45db46d2bd930b7983203580df78` now removes profiler-affected threshold violations before deriving record status. Persistent managed-gateway commands intentionally do not receive profiler flags, so their RSS measurements are not skipped. A `FAIL` retained by that producer is therefore a real failure, not profiler overhead.

OpenClaw still allowed `evaluateToleratedProfiledKovaReport` to accept those failures even when the workflow selected the strict current-producer contract. That compatibility branch predates the producer-side threshold-assessment contract.

## Fix

- Reject every retained deep-profile failure when strict current-producer validation is enabled.
- Preserve the historical automatic compatibility path for marker-free older producers.
- Add evaluator and CLI-boundary regressions for the strict current-producer case.

No thresholds, Kova inputs, product runtime behavior, or memory implementation changed.

## Evidence

- Current non-profiled gate failure: [job 95859561907](https://github.com/openclaw/openclaw/actions/runs/32182788559/job/95859561907).
- Current deep diagnostic: [job 95873181184](https://github.com/openclaw/openclaw/actions/runs/32187098393/job/95873181184).
- Historical advisory comparison: [run 32000305724](https://github.com/openclaw/openclaw/actions/runs/32000305724) recorded the same absolute RSS violations but did not fail because `fail_on_regression=false`.
- Exact Kova producer: [`0f9e678e`](https://github.com/openclaw/Kova/commit/0f9e678e239b45db46d2bd930b7983203580df78).
- Exact head: `7f4cc2ef2637331ee6b1e5b9b428ff8e63e82741`.
- Exact-head CI: [run 32189061977](https://github.com/openclaw/openclaw/actions/runs/32189061977). The only test failure is the shared Gateway chat timeout/restart-drain pair in [job 95879411516](https://github.com/openclaw/openclaw/actions/runs/32189061977/job/95879411516), owned by [#125969](https://github.com/openclaw/openclaw/pull/125969); it does not execute the Kova report adapter changed here. All branch-owned checks completed successfully.
- Local tests, builds, lint, and format were intentionally not run under the release-validation constraint.

## Scope

Production/test-support delta: +1 line in the report adapter. Test delta: +27 lines. The one production line enforces the reviewed external producer contract at its existing owner boundary.

The underlying gateway retained-memory owner is not patched here: Kova intentionally did not attach profilers to the managed gateway, so the deep artifact profiles short-lived CLI processes and cannot source-prove a product memory repair.

## Pinned Producer Contract

ClawSweeper’s upstream-contract question is resolved directly against Kova `0f9e678e239b45db46d2bd930b7983203580df78`:

- [The evaluator builds an instrumented-threshold assessment](https://github.com/openclaw/Kova/blob/0f9e678e239b45db46d2bd930b7983203580df78/src/evaluator.mjs#L1267-L1396) and marks affected overages `affectsRecordStatus: false`.
- [The exact producer self-check](https://github.com/openclaw/Kova/blob/0f9e678e239b45db46d2bd930b7983203580df78/src/selfcheck.mjs#L2630-L2652) requires profiler-affected RSS/latency overages to leave the record `PASS` with no fatal violations.
- [The sibling managed-Gateway self-check](https://github.com/openclaw/Kova/blob/0f9e678e239b45db46d2bd930b7983203580df78/src/selfcheck.mjs#L2706-L2728) requires unprofiled Gateway RSS during a profiled run to remain `FAIL`, remain in `violations`, and not be mislabeled as instrumented.
- [The role-aware owner function](https://github.com/openclaw/Kova/blob/0f9e678e239b45db46d2bd930b7983203580df78/src/performance/instrumentation.mjs#L158-L187) is the source boundary that distinguishes those cases.
- [Exact Kova `0f9e678e` managed-Gateway artifact](https://github.com/openclaw/openclaw/actions/runs/32190970569/artifacts/9344412678) records `profileOnFailure: true`, `affectsResourceMeasurements: false`, and a retained `FAIL` for Gateway RSS.

Therefore strict-mode retained failures are not profiler-only findings. The one-line OpenClaw guard preserves that producer verdict; the legacy marker-free path remains unchanged.