### PR TITLE
docs(config): clarify missing unset behavior

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -461,7 +461,7 @@ After every successful `config set` / `config patch` / `config unset`, the CLI p
 | `Change will apply without restarting the gateway.` | Hot reload picks it up automatically.  |
 | `No gateway restart needed.`                        | Nothing runtime-relevant changed.      |
 
-Effective changes to `plugins.entries` (or any subpath) require a restart, since the CLI cannot prove every plugin's reload metadata is loaded. An authored `config set` or `config unset` no-op prints `No change` and leaves the JSON5 file byte-for-byte untouched. Setting an absent key to a value equal to its runtime default is still an authored change and persists the explicit value.
+Effective changes to `plugins.entries` (or any subpath) require a restart, since the CLI cannot prove every plugin's reload metadata is loaded. Successful `config set` or `config unset` operations that produce no effective config diff print `No change` and leave the JSON5 file byte-for-byte untouched. A `config unset` target that is absent from the authored config exits with status 1 and also leaves the file untouched. Setting an absent key to a value equal to its runtime default is still an authored change and persists the explicit value.
 
 ## Write safety
 


### PR DESCRIPTION
## What Problem This Solves

Merged PR #125958 changed a missing authored `config unset` target to exit with status 1, but the CLI reference still promised `No change` for authored unset no-ops.

## Why This Change Was Made

This accurately distinguishes successful mutations with no effective config diff from missing authored targets. It follows #125958 and the landed fix in [f97a133](https://github.com/openclaw/openclaw/commit/f97a133254fdbe3f46c7681ac9fa83ddd1968318).

## User Impact

The docs now match the scripting exit and output behavior. There is no runtime code change.

## Evidence

- Docs MDX validation: 777 files passed.
- Docs formatting: clean.
- `git diff --check`: clean.
- Docs-only autoreview: clean.
- Original behavior proof lives in #125958.

Production LOC: 0  
Tests: 0  
Docs: +1/-1
