### PR TITLE
fix(test): drain late mock registrations

### DIFF
--- a/test/non-isolated-runner.resolve-mocks.test.ts
+++ b/test/non-isolated-runner.resolve-mocks.test.ts
@@ -98,6 +98,28 @@ describe("serializeMockerResolveMocks", () => {
     expect(FakeMocker.pendingIds).toEqual([]);
   });
 
+  it("drains ids queued during the final pass without requiring another caller", async () => {
+    FakeMocker.pendingIds = ["mock-a"];
+    const firstPassStarted = deferred();
+    const releaseFirstPass = deferred();
+    const mocker = new FakeMocker();
+    mocker.beforeFirstPass = async () => {
+      firstPassStarted.resolve();
+      await releaseFirstPass.promise;
+    };
+    serializeMockerResolveMocks(mocker);
+
+    const first = mocker.resolveMocks();
+    await firstPassStarted.promise;
+    FakeMocker.pendingIds.push("mock-late");
+    releaseFirstPass.resolve();
+    await first;
+
+    expect(mocker.processed).toEqual(["mock-a", "mock-late"]);
+    expect(mocker.passes).toBe(2);
+    expect(FakeMocker.pendingIds).toEqual([]);
+  });
+
   it("does not double-wrap when installed repeatedly", async () => {
     FakeMocker.pendingIds = ["mock-a"];
     const mocker = new FakeMocker();

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -374,15 +374,20 @@ export function serializeMockerResolveMocks(mocker: SerializableMocker): void {
   const original = mocker.resolveMocks.bind(mocker);
   const statics = mocker.constructor as { pendingIds?: unknown[] };
   const runPass = async (): Promise<void> => {
-    const queue = statics.pendingIds;
-    const processedCount = queue?.length ?? 0;
-    await original();
-    // Upstream snapshots the queue contents at pass start and reassigns the
-    // pendingIds static to [] at the end, so ids queued during the pass's RPC
-    // window land in the abandoned array. Requeue them so the next chained
-    // pass registers them instead of silently dropping the registration.
-    if (queue && queue !== statics.pendingIds && queue.length > processedCount) {
-      statics.pendingIds?.push(...queue.slice(processedCount));
+    while (true) {
+      const queue = statics.pendingIds;
+      const processedCount = queue?.length ?? 0;
+      await original();
+      // Upstream snapshots the queue contents at pass start and reassigns the
+      // pendingIds static to [] at the end, so ids queued during the pass's RPC
+      // window land in the abandoned array. Requeue and drain them before this
+      // caller proceeds so a later module fetch cannot invalidate mocks mid-import.
+      if (queue && queue !== statics.pendingIds && queue.length > processedCount) {
+        statics.pendingIds?.push(...queue.slice(processedCount));
+      }
+      if ((statics.pendingIds?.length ?? 0) === 0) {
+        return;
+      }
     }
   };
   mocker.resolveMocks = () => {

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -349,15 +349,20 @@ export function serializeMockerResolveMocks(mocker: SerializableMocker): void {
   const original = mocker.resolveMocks.bind(mocker);
   const statics = mocker.constructor as { pendingIds?: unknown[] };
   const runPass = async (): Promise<void> => {
-    const queue = statics.pendingIds;
-    const processedCount = queue?.length ?? 0;
-    await original();
-    // Upstream snapshots the queue contents at pass start and reassigns the
-    // pendingIds static to [] at the end, so ids queued during the pass's RPC
-    // window land in the abandoned array. Requeue them so the next chained
-    // pass registers them instead of silently dropping the registration.
-    if (queue && queue !== statics.pendingIds && queue.length > processedCount) {
-      statics.pendingIds?.push(...queue.slice(processedCount));
+    while (true) {
+      const queue = statics.pendingIds;
+      const processedCount = queue?.length ?? 0;
+      await original();
+      // Upstream snapshots the queue contents at pass start and reassigns the
+      // pendingIds static to [] at the end, so ids queued during the pass's RPC
+      // window land in the abandoned array. Requeue and drain them before this
+      // caller proceeds so a later module fetch cannot invalidate mocks mid-import.
+      if (queue && queue !== statics.pendingIds && queue.length > processedCount) {
+        statics.pendingIds?.push(...queue.slice(processedCount));
+      }
+      if ((statics.pendingIds?.length ?? 0) === 0) {
+        return;
+      }
     }
   };
   mocker.resolveMocks = () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the non-isolated CLI test shard could split mocked imports across module instances, producing 35 false `src/cli/update-cli.test.ts` failures even though focused update CLI behavior remained green. Vitest 4.1.11's restored global lifecycle concurrency limit made the existing scheduling race recur in cleanup CI run https://github.com/openclaw/openclaw/actions/runs/32950521368.

## Why This Change Was Made

The serialized mock resolver now drains IDs queued during its final in-flight pass before allowing that caller to continue. This keeps later module fetches from invalidating mocks midway through an import graph and adds the no-second-caller case missing from the existing resolver coverage. It does not change production CLI behavior or downgrade Vitest.

## User Impact

There is no end-user CLI behavior change. Maintainers get reliable non-isolated CLI CI after the Vitest 4.1.11 upgrade, unblocking unrelated command cleanup work.

## Evidence

- Failed CI before repair: 35 failures in `src/cli/update-cli.test.ts`; 5,494 passed, 42 skipped: https://github.com/openclaw/openclaw/actions/runs/32950521368/job/98124290066
- Deterministic pre-fix owner regression on Vitest 4.1.11: `mock-late` remained unprocessed (`["mock-a"]` instead of `["mock-a", "mock-late"]`).
- After repair: resolver owner suite 7/7 passed; focused update CLI suite 247/247 passed.
- Post-repair full CLI shard with two workers: 231 files passed, 1 skipped; 5,506 tests passed, 79 skipped.
- Exact-head changed-file gate passed, including format, test-root types, dependency guards, and script lint.
- Exact-head structured autoreview: clean, no accepted/actionable findings. Separate exact-head Codex review: no concrete blockers.
- Vitest 4.1.11 source confirms `BareModuleMocker.resolveMocks()` resolves the current static queue before replacing it with `[]`; the 4.1.10→4.1.11 comparison does not modify that owner. The relevant 4.1.11 change restores lifecycle concurrency: https://github.com/vitest-dev/vitest/releases/tag/v4.1.11
- Production LOC: 0. Test support: +14/-9. Tests: +22.

AI-assisted: yes. No agent transcript attached.
