### PR TITLE
test(gateway): bind image flow to static model

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -22,6 +22,7 @@ import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import * as sessionLifecycleState from "./session-lifecycle-state.js";
 import {
+  agentDiscoveryMock,
   connectOk,
   dispatchInboundMessageMock,
   installGatewayTestHooks,
@@ -591,8 +592,19 @@ describe("gateway server chat", () => {
   test("handles chat send and history flows", async () => {
     const tempDirs: string[] = [];
     let webchatWs: WebSocket | undefined;
+    const visionModel = { primary: "test-provider/vision-model" };
 
     try {
+      testState.agentConfig = { model: visionModel };
+      agentDiscoveryMock.enabled = true;
+      agentDiscoveryMock.models = [
+        {
+          provider: "test-provider",
+          id: "vision-model",
+          name: "Vision Model",
+          input: ["text", "image"],
+        },
+      ];
       webchatWs = new WebSocket(`ws://127.0.0.1:${port}`, {
         headers: { origin: `http://127.0.0.1:${port}` },
       });
@@ -620,7 +632,7 @@ describe("gateway server chat", () => {
       webchatWs.close();
       webchatWs = undefined;
 
-      testState.agentConfig = { timeoutSeconds: 123 };
+      testState.agentConfig = { timeoutSeconds: 123, model: visionModel };
       const timeoutRes = await rpcReq(ws, "chat.send", {
         sessionKey: "main",
         message: "hello",
@@ -629,7 +641,7 @@ describe("gateway server chat", () => {
       expect(timeoutRes.ok).toBe(true);
       expect(timeoutRes.payload?.runId).toBe("idem-timeout-1");
       await waitForAgentRunDrained("idem-timeout-1");
-      testState.agentConfig = undefined;
+      testState.agentConfig = { model: visionModel };
 
       const sessionRes = await rpcReq(ws, "chat.send", {
         sessionKey: "agent:main:subagent:abc",
@@ -785,6 +797,8 @@ describe("gateway server chat", () => {
       expect(extractFirstTextBlock(defaultMsgs[0])).toBe("m1");
     } finally {
       testState.agentConfig = undefined;
+      agentDiscoveryMock.enabled = false;
+      agentDiscoveryMock.models = [];
       testState.sessionStorePath = undefined;
       testState.sessionConfig = undefined;
       if (webchatWs) {


### PR DESCRIPTION
## What Problem This Solves

Main CI timed out in the WebSocket image-send regression, then its still-running request contaminated the following restart-drain test. The exact failure appeared in run 32178587569.

## Root Cause

Minimal Gateway tests disable bundled provider plugins, so their prepared static catalog contains no Anthropic models. The omnibus chat test sent an image using that absent default, correctly triggering slow full discovery before ACK.

## Fix

The image-flow test now installs its own image-capable discovery entry before the first chat send, retains that model through its timeout override, and clears the fixture in `finally`. No timeout or production behavior changed.

## Evidence

- Pre-fix: `handles chat send and history flows` timed out; the next restart-drain assertion observed a retired root.
- Blacksmith Testbox `tbx_01m0bdm8fvgcbv2d5s1zvqdb99`: 55/55 chat tests passed; the image flow completed in 6.5s.
- Run: https://github.com/openclaw/openclaw/actions/runs/32189741570
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: 0. Tests: +16/-2.

AI-assisted: yes. No agent transcript attached.
