### PR TITLE
fix(canvas): avoid stale panel when widget presentation fails

### DIFF
--- a/extensions/canvas/src/widget-presenter.test.ts
+++ b/extensions/canvas/src/widget-presenter.test.ts
@@ -2,7 +2,7 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { createCanvasWidgetPresenter } from "./widget-presenter.js";
 
-const commands = ["canvas.present", "canvas.navigate"];
+const commands = ["canvas.present"];
 
 function createNodesRuntime(
   nodes: Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"],
@@ -14,7 +14,7 @@ function createNodesRuntime(
 }
 
 describe("Canvas widget presenter", () => {
-  it("prefers the existing local Mac default and invokes present before navigate", async () => {
+  it("prefers the existing local Mac default and presents the hosted URL atomically", async () => {
     const runtime = createNodesRuntime([
       {
         nodeId: "android-recent",
@@ -52,21 +52,12 @@ describe("Canvas widget presenter", () => {
       expect.objectContaining({
         nodeId: "mac-local",
         command: "canvas.present",
-        params: {},
-        sessionKey: "agent:main:status",
-        idempotencyKey: expect.any(String),
-      }),
-    );
-    expect(runtime.invoke).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        nodeId: "mac-local",
-        command: "canvas.navigate",
         params: { url: "/__openclaw__/canvas/documents/cv_1/index.html" },
         sessionKey: "agent:main:status",
         idempotencyKey: expect.any(String),
       }),
     );
+    expect(runtime.invoke).toHaveBeenCalledTimes(1);
   });
 
   it("maps missing eligible nodes and node invocation failures", async () => {
@@ -106,6 +97,48 @@ describe("Canvas widget presenter", () => {
     ).resolves.toEqual({
       ok: false,
       error: { code: "node_error", message: "panel disabled", nodeId: "mac-panel" },
+    });
+  });
+
+  it("leaves no stale visible content when atomic presentation fails", async () => {
+    const documentUrlPath = "/__openclaw__/canvas/documents/cv_partial/index.html";
+    const panel = { visible: false, url: undefined as string | undefined };
+    const transcript: Array<{ command: string; params: unknown }> = [];
+    const runtime = createNodesRuntime([
+      {
+        nodeId: "mac-panel",
+        platform: "macos",
+        connected: true,
+        caps: ["canvas"],
+        invocableCommands: commands,
+      },
+    ]);
+    vi.mocked(runtime.invoke).mockImplementation(async ({ command, params }) => {
+      transcript.push({ command, params });
+      if (command === "canvas.present") {
+        if ((params as { url?: unknown } | undefined)?.url === documentUrlPath) {
+          throw new Error("presentation rejected");
+        }
+        panel.visible = true;
+        panel.url = "default";
+        return { ok: true };
+      }
+      throw new Error("navigation rejected after presentation");
+    });
+
+    const result = await createCanvasWidgetPresenter(runtime).present({
+      documentUrlPath,
+      title: "Status",
+      sessionContext: {},
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: "node_error", message: "presentation rejected", nodeId: "mac-panel" },
+    });
+    expect({ panel, transcript }).toEqual({
+      panel: { visible: false, url: undefined },
+      transcript: [{ command: "canvas.present", params: { url: documentUrlPath } }],
     });
   });
 

--- a/extensions/canvas/src/widget-presenter.ts
+++ b/extensions/canvas/src/widget-presenter.ts
@@ -4,7 +4,6 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 
-const REQUIRED_WIDGET_COMMANDS = ["canvas.present", "canvas.navigate"] as const;
 const DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS = 30_000;
 
 type CanvasRuntimeNode = Awaited<ReturnType<PluginRuntime["nodes"]["list"]>>["nodes"][number];
@@ -12,16 +11,10 @@ type WidgetPresenter = Parameters<OpenClawPluginApi["registerWidgetPresenter"]>[
 
 function isEligibleCanvasNode(node: CanvasRuntimeNode): boolean {
   const commands = node.invocableCommands ?? node.commands ?? [];
-  const hasCanvasCapability =
-    node.caps?.includes("canvas") === true ||
-    commands.some((command) => command.startsWith("canvas."));
   return (
     // macOS is the only panel whose resolver handles hosted document paths;
     // other platforms' Canvas surfaces are being retired.
-    node.platform === "macos" &&
-    node.connected === true &&
-    hasCanvasCapability &&
-    REQUIRED_WIDGET_COMMANDS.every((command) => commands.includes(command))
+    node.platform === "macos" && node.connected === true && commands.includes("canvas.present")
   );
 }
 
@@ -80,17 +73,14 @@ export function createCanvasWidgetPresenter(nodesRuntime: PluginRuntime["nodes"]
         };
       }
       try {
-        const invoke = (command: string, params?: Record<string, unknown>) =>
-          nodesRuntime.invoke({
-            nodeId: node.nodeId,
-            command,
-            params,
-            timeoutMs: DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS,
-            idempotencyKey: randomUUID(),
-            ...(sessionContext.sessionKey ? { sessionKey: sessionContext.sessionKey } : {}),
-          });
-        await invoke("canvas.present", {});
-        await invoke("canvas.navigate", { url: documentUrlPath });
+        await nodesRuntime.invoke({
+          nodeId: node.nodeId,
+          command: "canvas.present",
+          params: { url: documentUrlPath },
+          timeoutMs: DEFAULT_CANVAS_NODE_INVOKE_TIMEOUT_MS,
+          idempotencyKey: randomUUID(),
+          ...(sessionContext.sessionKey ? { sessionKey: sessionContext.sessionKey } : {}),
+        });
         return {
           ok: true,
           value: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where presenting a widget on the macOS Canvas node panel could open stale or default content when panel presentation succeeded but the following navigation failed. The tool then reported failure and fell back inline even though the panel had already mutated.

## Why This Change Was Made

The Canvas widget presenter now uses the native macOS atomic contract: one `canvas.present` invocation carries the hosted document URL. Node selection, hosted capability resolution, pairing/policy validation, timeout handling, and inline fallback remain on their existing owners; Android and iOS are intentionally unaffected.

## User Impact

Failed node-panel widget presentation can no longer leave a stale/default Canvas panel visible before the widget falls back inline.

## Evidence

- Frozen baseline `39b39ca6eec684f0675cd93500646b578f6e7021`: the regression fixture failed with transcript `canvas.present {}` then `canvas.navigate {url}`, leaving `{ visible: true, url: "default" }` while presentation returned failure.
- Fixed fixture: transcript is exactly one `canvas.present {url}`; rejected presentation leaves `{ visible: false, url: undefined }`; 4/4 focused presenter tests pass.
- Existing core inline-fallback suite: 23/23 tests pass.
- macOS contract: `CanvasCommandParams.swift` accepts the optional present URL; `MacNodeRuntime.swift` resolves the hosted target before `CanvasManager.showDetailed` mutates UI state. The ordinary Canvas tool already uses this one-call shape.
- `node scripts/check-changed.mjs -- extensions/canvas/src/widget-presenter.ts extensions/canvas/src/widget-presenter.test.ts` passes.
- `pnpm build` passes.
- Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +9/-19 (net -10). Tests: +45/-12.

Live macOS screenshot/video proof is blocked: no campaign-owned signed Canvas app/node was available, and the only available signed instance was operator-owned. No node RPC was sent and no operator state was touched. The fixture structural proof and native source contract are provided instead.
