### PR TITLE
fix(gateway): bind detached lifecycle dispatch

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WRITE_SCOPE } from "../../../gateway/method-scopes.js";
+import { createGatewayMethodRegistry } from "../../../gateway/methods/registry.js";
+import { createGatewayInstanceRuntime } from "../../../gateway/server-instance-runtime.js";
+import type {
+  GatewayRequestContext,
+  GatewayRequestHandlers,
+} from "../../../gateway/server-methods/types.js";
+import { dispatchSubagentAnnounceAgent } from "./subagent-announce-delivery.runtime.js";
+
+function createContext(): GatewayRequestContext {
+  return {
+    deps: {},
+    getRuntimeConfig: () => ({}),
+    logGateway: {
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    chatAbortControllers: new Map(),
+    chatQueuedTurns: new Map(),
+    dedupe: new Map(),
+  } as unknown as GatewayRequestContext;
+}
+
+function createRegistry(handlers: GatewayRequestHandlers) {
+  return createGatewayMethodRegistry(
+    Object.entries(handlers).map(([name, handler]) => ({
+      name,
+      handler,
+      owner: { kind: "core" as const, area: "test" },
+      scope: WRITE_SCOPE,
+    })),
+  );
+}
+
+describe("subagent announce Gateway instance dispatch", () => {
+  let closeRuntime: (() => void) | undefined;
+
+  afterEach(() => {
+    closeRuntime?.();
+    closeRuntime = undefined;
+  });
+
+  it("delivers a detached announce after the originating request scope has ended", async () => {
+    const context = createContext();
+    const idempotencyKey = "detached-subagent-announce";
+    context.dedupe.set(`agent:${idempotencyKey}`, {
+      ts: Date.now(),
+      ok: true,
+      payload: { runId: "announce-run", status: "ok", summary: "delivered" },
+    });
+    const runtime = createGatewayInstanceRuntime({
+      getContext: () => context,
+      getMethodRegistry: () =>
+        createRegistry({
+          agent: ({ respond }) => respond(true, { raw: true }),
+        }),
+      isDispatchAvailable: () => true,
+    });
+    closeRuntime = runtime.close;
+
+    await expect(
+      dispatchSubagentAnnounceAgent(
+        {
+          message: "Process one completed child result.",
+          idempotencyKey,
+        },
+        { expectFinal: true, forceSyntheticClient: true },
+      ),
+    ).resolves.toEqual({ runId: "announce-run", status: "ok", summary: "delivered" });
+  });
+});

--- a/src/agents/subagents/announce/subagent-announce-delivery.runtime.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.runtime.ts
@@ -12,7 +12,6 @@ import { loadSessionEntryReadOnly as loadSessionEntry } from "../../../config/se
 import { resolvePersistedSessionStoreOwnerForKey } from "../../../config/sessions/session-store-owner.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { callGateway } from "../../../gateway/call.js";
-import { dispatchGatewayMethodInProcess } from "../../../gateway/server-plugins.js";
 import { resolveExternalBestEffortDeliveryTarget } from "../../../infra/outbound/best-effort-delivery.js";
 import { createBoundDeliveryRouter } from "../../../infra/outbound/bound-delivery-router.js";
 import { resolveConversationIdFromTargets } from "../../../infra/outbound/conversation-id.js";
@@ -32,6 +31,7 @@ import {
   resolveActiveEmbeddedRunSessionId,
   type EmbeddedAgentQueueMessageOutcome,
 } from "../../embedded-agent-runner/runs.js";
+import { dispatchGatewayMethodInProcess } from "./subagent-announce.runtime.js";
 import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";
 
 export {

--- a/src/agents/subagents/announce/subagent-announce.runtime.ts
+++ b/src/agents/subagents/announce/subagent-announce.runtime.ts
@@ -5,6 +5,7 @@
  * IO without changing the announce logic itself.
  */
 import { loadSessionEntry } from "../../../config/sessions/session-accessor.js";
+export { dispatchGatewayLifecycleMethod as dispatchGatewayMethodInProcess } from "../../../gateway/server-recovery-runtime-context.js";
 export { getRuntimeConfig } from "../../../config/config.js";
 export {
   resolveAgentIdFromSessionKey,
@@ -16,7 +17,6 @@ export function readSubagentSessionEntry(storePath: string, sessionKey: string) 
 }
 export { callGateway } from "../../../gateway/call.js";
 export { readSessionMessagesAsync } from "../../../gateway/session-transcript-readers.js";
-export { dispatchGatewayMethodInProcess } from "../../../gateway/server-plugins.js";
 export {
   isEmbeddedAgentRunActive,
   waitForEmbeddedAgentRunEnd,

--- a/src/gateway/server-instance-runtime.ts
+++ b/src/gateway/server-instance-runtime.ts
@@ -18,6 +18,7 @@ import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import type { GatewayMethodRegistry } from "./methods/registry.js";
 import { dispatchGatewayRequestInProcess } from "./server-in-process-dispatch.js";
 import type {
+  GatewayInstanceAgentDispatchOptions,
   GatewayInstanceRuntime,
   GatewayRecoveryRuntime,
 } from "./server-instance-runtime.types.js";
@@ -25,6 +26,10 @@ import type { AgentRunRequest } from "./server-methods/agent-request-types.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
 import { registerGatewayRecoveryRuntime } from "./server-recovery-runtime-context.js";
+import {
+  cancelSubagentCompletionToolHandoff,
+  registerSubagentCompletionToolHandoff,
+} from "./subagent-completion-tool-handoff.js";
 
 const loadOutboundMessageRuntime = createLazyRuntimeModule(
   () => import("../infra/outbound/message.js"),
@@ -92,20 +97,49 @@ export function createGatewayInstanceRuntime(
     dispatchAgent: async <T>(
       payload: AgentRunRequest,
       timeoutMs?: number,
-      dispatchOptions?: { allowModelOverride?: boolean; scopes?: string[] },
+      dispatchOptions: GatewayInstanceAgentDispatchOptions = {},
     ) => {
       assertDispatchAvailable("agent");
-      const agentTurns = dispatchOptions
+      const delegatedToolPolicyHandoffId = dispatchOptions.delegatedToolPolicyHandoff
+        ? registerSubagentCompletionToolHandoff(dispatchOptions.delegatedToolPolicyHandoff)
+        : undefined;
+      const needsDedicatedPrincipal = Boolean(
+        dispatchOptions.allowModelOverride === true ||
+        dispatchOptions.allowSyntheticModelOverride === true ||
+        dispatchOptions.allowSyntheticCronRunContinuation === true ||
+        dispatchOptions.internalDeliveryMediaUrls ||
+        dispatchOptions.internalDeliverySuppressText === true ||
+        delegatedToolPolicyHandoffId ||
+        dispatchOptions.scopes ||
+        dispatchOptions.syntheticScopes,
+      );
+      const agentTurns = needsDedicatedPrincipal
         ? createInternalAgentTurnFacade({
             client: createSyntheticPluginRuntimeClient({
-              allowModelOverride: dispatchOptions.allowModelOverride,
-              scopes: dispatchOptions.scopes,
+              allowModelOverride:
+                dispatchOptions.allowModelOverride === true ||
+                dispatchOptions.allowSyntheticModelOverride === true,
+              cronRunContinuation: dispatchOptions.allowSyntheticCronRunContinuation === true,
+              internalDeliveryMediaUrls: dispatchOptions.internalDeliveryMediaUrls,
+              internalDeliverySuppressText: dispatchOptions.internalDeliverySuppressText,
+              delegatedToolPolicyHandoffId,
+              scopes: dispatchOptions.scopes ?? dispatchOptions.syntheticScopes,
             }),
             getContext: options.getContext,
             getMethodRegistry: options.getMethodRegistry,
           })
         : recoveryAgentTurns;
-      return await agentTurns.dispatch<T>(payload, timeoutMs);
+      try {
+        return await agentTurns.dispatch<T>(payload, {
+          expectFinal: dispatchOptions.expectFinal,
+          onAccepted: dispatchOptions.onAccepted,
+          onSignalAbort: dispatchOptions.onSignalAbort,
+          signal: dispatchOptions.signal,
+          timeoutMs,
+        });
+      } finally {
+        cancelSubagentCompletionToolHandoff(delegatedToolPolicyHandoffId);
+      }
     },
     waitForAgent: async <T>(payload: AgentWaitParams, timeoutMs?: number) => {
       assertDispatchAvailable("agent.wait");

--- a/src/gateway/server-instance-runtime.types.ts
+++ b/src/gateway/server-instance-runtime.types.ts
@@ -1,7 +1,29 @@
 import type { AgentWaitParams } from "../../packages/gateway-protocol/src/index.js";
+import type { SubagentCompletionToolHandoffRegistration } from "../agents/subagents/announce/subagent-announce-handoff.js";
 import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
 import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import type { AgentRunRequest } from "./server-methods/agent-request-types.js";
+
+export type GatewayInstanceAgentDispatchOptions = {
+  allowModelOverride?: boolean;
+  allowSyntheticModelOverride?: boolean;
+  allowSyntheticCronRunContinuation?: boolean;
+  delegatedToolPolicyHandoff?: SubagentCompletionToolHandoffRegistration;
+  expectFinal?: boolean;
+  /** Instance-owned dispatch always uses a synthetic client. */
+  forceSyntheticClient?: boolean;
+  internalDeliveryMediaUrls?: string[];
+  internalDeliverySuppressText?: boolean;
+  onAccepted?: (payload: unknown) => void;
+  onSignalAbort?: () => Promise<void> | void;
+  scopes?: string[];
+  signal?: AbortSignal;
+  syntheticScopes?: string[];
+};
+
+export type GatewayLifecycleAgentDispatchOptions = GatewayInstanceAgentDispatchOptions & {
+  timeoutMs?: number;
+};
 
 export type GatewayApprovalEventPublisher = {
   publishRequested: (kind: ChannelApprovalKind, request: unknown) => number;
@@ -12,7 +34,7 @@ export type GatewayRecoveryRuntime = {
   dispatchAgent: <T = unknown>(
     params: AgentRunRequest,
     timeoutMs?: number,
-    options?: { allowModelOverride?: boolean; scopes?: string[] },
+    options?: GatewayInstanceAgentDispatchOptions,
   ) => Promise<T>;
   waitForAgent: <T = unknown>(params: AgentWaitParams, timeoutMs?: number) => Promise<T>;
   sendRecoveryNotice: (params: {

--- a/src/gateway/server-recovery-runtime-context.ts
+++ b/src/gateway/server-recovery-runtime-context.ts
@@ -1,4 +1,8 @@
-import type { GatewayRecoveryRuntime } from "./server-instance-runtime.types.js";
+import type {
+  GatewayLifecycleAgentDispatchOptions,
+  GatewayRecoveryRuntime,
+} from "./server-instance-runtime.types.js";
+import type { AgentRunRequest } from "./server-methods/agent-request-types.js";
 
 type ActiveGatewayRecoveryRuntime = {
   owner: symbol;
@@ -27,4 +31,18 @@ export function registerGatewayRecoveryRuntime(runtime: GatewayRecoveryRuntime):
 
 export function getGatewayRecoveryRuntime(): GatewayRecoveryRuntime | undefined {
   return activeRuntime?.runtime;
+}
+
+/** Dispatches detached Gateway lifecycle work through the active instance principal. */
+export async function dispatchGatewayLifecycleMethod<T = unknown>(
+  method: "agent",
+  params: Record<string, unknown>,
+  options: GatewayLifecycleAgentDispatchOptions = {},
+): Promise<T> {
+  const agentParams = params as AgentRunRequest; // SAFETY: the bound facade validates the payload.
+  const runtime = getGatewayRecoveryRuntime();
+  if (!runtime) {
+    throw new Error(`Gateway instance lifecycle dispatch unavailable for ${method}`);
+  }
+  return await runtime.dispatchAgent<T>(agentParams, options.timeoutMs, options);
 }

--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -33,7 +33,7 @@ import {
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeMediaReferenceForComparison } from "../media/media-reference-comparison.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
-import { dispatchGatewayMethodInProcess } from "./server-plugins.js";
+import { dispatchGatewayLifecycleMethod as dispatchGatewayMethodInProcess } from "./server-recovery-runtime-context.js";
 import { loadSessionEntry } from "./session-utils.js";
 
 const log = createSubsystemLogger("gateway/restart-sentinel");

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -333,8 +333,11 @@ vi.mock("../channels/turn/lifecycle.js", () => ({
   },
 }));
 
-vi.mock("./server-plugins.js", () => ({
-  dispatchGatewayMethodInProcess: mocks.dispatchGatewayMethodInProcess,
+vi.mock("./server-recovery-runtime-context.js", async () => ({
+  ...(await vi.importActual<typeof import("./server-recovery-runtime-context.js")>(
+    "./server-recovery-runtime-context.js",
+  )),
+  dispatchGatewayLifecycleMethod: mocks.dispatchGatewayMethodInProcess,
 }));
 
 vi.mock("../infra/outbound/targets.js", () => ({


### PR DESCRIPTION
## What Problem This Solves

Detached subagent completion delivery failed after the originating Gateway request scope ended. Main CI profile 3/6 timed out in `subagent-completion-direct-fallback` because all direct-handoff retries lacked an instance binding.

## Root Cause

The ambient process-global Gateway fallback was correctly removed, but detached announce, descendant wake, and queued generated-media recovery still called the request-scoped in-process dispatcher. Their lifecycle owner had no closure-bound Gateway principal.

## Fix

The active Gateway instance now exposes a lifecycle-bound agent-turn dispatcher. It preserves final-result waiting, acceptance/abort hooks, delegated completion-tool handoff, model/scopes, cron continuation, and internal-delivery media facts. Detached announce, descendant wake, and restart recovery share this canonical owner; missing or closed instances fail closed.

## Evidence

- Pre-fix regression reaches the exact missing instance-binding error after request scope ends.
- Focused Vitest: 83/83 passed locally.
- Blacksmith Testbox `tbx_01m0bdm8fvgcbv2d5s1zvqdb99`: 137/137 Gateway tests plus the detached announce regression passed.
- Run: https://github.com/openclaw/openclaw/actions/runs/32189741570
- Path-scoped changed-file gate passed, including prod/test tsgo, lint, database-first, sidecar, and import-cycle checks.
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: +84/-10. Tests: +77/-2.

The exact Crabline Telegram scenario remains a proof gap: local source-runner artifact freshness scanning prevented the child launch. A qa-channel probe did confirm the former missing-binding error was gone before timing out on its Telegram-specific terminal marker.

AI-assisted: yes. No agent transcript attached.
