### PR TITLE
fix(ui): vertically center session row actions

### DIFF
--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -3,6 +3,7 @@ import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gat
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import {
   actionOpacity,
+  captureUiProof,
   createSessionManagementE2eSuite,
   installMockGateway,
   requireRecord,
@@ -13,6 +14,56 @@ import {
 const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
+  it("vertically centers session actions in a two-line row", async () => {
+    const context = await suite.browser.newContext({
+      hasTouch: true,
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", Date.now()),
+          Object.assign(
+            sessionRow("agent:main:two-line", "Two-line session", Date.now() - 1, {
+              pinned: true,
+            }),
+            { lastMessagePreview: "Finishing repository setup review" },
+          ),
+        ]),
+      },
+      sessionKey: "agent:main:two-line",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const row = page.locator('[data-session-key="agent:main:two-line"]');
+      await row.waitFor({ state: "visible", timeout: 10_000 });
+      const pin = row.getByRole("button", { name: "Unpin session" });
+      const menu = row.getByRole("button", { name: "Open session menu" });
+      await expect.poll(() => actionOpacity(pin)).toBe("1");
+      await captureUiProof(page, "sidebar-session-actions-centered.png");
+
+      const [rowBounds, subtitleBounds, pinBounds, menuBounds] = await Promise.all([
+        row.boundingBox(),
+        row.locator(".sidebar-recent-session__subtitle").boundingBox(),
+        pin.boundingBox(),
+        menu.boundingBox(),
+      ]);
+      if (!rowBounds || !subtitleBounds || !pinBounds || !menuBounds) {
+        throw new Error("Expected visible two-line session action geometry");
+      }
+      const rowCenter = rowBounds.y + rowBounds.height / 2;
+      expect(subtitleBounds.y).toBeGreaterThan(rowCenter);
+      expect(Math.abs(pinBounds.y + pinBounds.height / 2 - rowCenter)).toBeLessThanOrEqual(1);
+      expect(Math.abs(menuBounds.y + menuBounds.height / 2 - rowCenter)).toBeLessThanOrEqual(1);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps action-only text widest at rest and swaps active state for actions", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
@@ -44,7 +95,6 @@ suite.define(() => {
       await actionOnlyRow.waitFor({ state: "visible", timeout: 10_000 });
       const actionOnlyText = actionOnlyRow.locator(".sidebar-recent-session__text");
       const actionOnlyLink = actionOnlyRow.locator(".sidebar-recent-session__link");
-      const actionOnlyDetails = actionOnlyRow.locator(".sidebar-recent-session__details");
       const actionOnlyPin = actionOnlyRow.getByRole("button", { name: "Pin session" });
       await expect
         .poll(() => actionOnlyLink.evaluate((element) => getComputedStyle(element).paddingRight))
@@ -54,7 +104,7 @@ suite.define(() => {
       await actionOnlyRow.hover();
       await expect.poll(() => actionOpacity(actionOnlyPin)).toBe("1");
       await expect
-        .poll(() => actionOnlyDetails.evaluate((element) => getComputedStyle(element).paddingRight))
+        .poll(() => actionOnlyText.evaluate((element) => getComputedStyle(element).paddingRight))
         .toBe("52px");
       const hoveredTextBounds = await actionOnlyText.boundingBox();
 
@@ -62,7 +112,7 @@ suite.define(() => {
       await actionOnlyPin.focus();
       await expect.poll(() => actionOpacity(actionOnlyPin)).toBe("1");
       await expect
-        .poll(() => actionOnlyDetails.evaluate((element) => getComputedStyle(element).paddingRight))
+        .poll(() => actionOnlyText.evaluate((element) => getComputedStyle(element).paddingRight))
         .toBe("52px");
       const focusedTextBounds = await actionOnlyText.boundingBox();
       if (!restingTextBounds || !hoveredTextBounds || !focusedTextBounds) {
@@ -168,6 +218,7 @@ suite.define(() => {
         Math.abs(forkBounds.y + forkBounds.height / 2 - (nameBounds.y + nameBounds.height / 2)),
       ).toBeLessThanOrEqual(2);
       expect(nameBounds.y + nameBounds.height / 2).toBeLessThan(pinBounds.y + pinBounds.height / 2);
+      expect(nameBounds.x + nameBounds.width).toBeLessThanOrEqual(pinBounds.x + 1);
       expect(pinBounds.x + pinBounds.width).toBeLessThanOrEqual(menuBounds.x);
     } finally {
       await context.close();
@@ -322,7 +373,7 @@ suite.define(() => {
         );
       }
       const link = row.locator(".sidebar-recent-session__link");
-      const details = row.locator(".sidebar-recent-session__details");
+      const rowText = row.locator(".sidebar-recent-session__text");
       const pin = row.getByRole("button", { name: "Pin session" });
       const menu = row.getByRole("button", { name: "Open session menu" });
       await expect
@@ -355,7 +406,7 @@ suite.define(() => {
       await expect.poll(() => actionOpacity(pin)).toBe("1");
       await expect.poll(() => actionOpacity(menu)).toBe("1");
       await expect
-        .poll(() => details.evaluate((element) => getComputedStyle(element).paddingRight))
+        .poll(() => rowText.evaluate((element) => getComputedStyle(element).paddingRight))
         .toBe("52px");
 
       const [textBounds, nameBounds, pinBounds, menuBounds] = await Promise.all([
@@ -369,6 +420,7 @@ suite.define(() => {
       }
       expect(textBounds.width).toBeCloseTo(restingTextBounds.width, 1);
       expect(nameBounds.y + nameBounds.height / 2).toBeLessThan(pinBounds.y + pinBounds.height / 2);
+      expect(nameBounds.x + nameBounds.width).toBeLessThanOrEqual(pinBounds.x + 1);
       expect(pinBounds.x + pinBounds.width).toBeLessThanOrEqual(menuBounds.x);
       await page.mouse.move(0, 0);
       await pin.focus();
@@ -376,7 +428,7 @@ suite.define(() => {
       await expect.poll(() => actionOpacity(pin)).toBe("1");
       await expect.poll(() => actionOpacity(menu)).toBe("1");
       await expect
-        .poll(() => details.evaluate((element) => getComputedStyle(element).paddingRight))
+        .poll(() => rowText.evaluate((element) => getComputedStyle(element).paddingRight))
         .toBe("52px");
 
       const [focusedTextBounds, focusedNameBounds, focusedPinBounds, focusedMenuBounds] =
@@ -392,6 +444,9 @@ suite.define(() => {
       expect(focusedTextBounds.width).toBeCloseTo(restingTextBounds.width, 1);
       expect(focusedNameBounds.y + focusedNameBounds.height / 2).toBeLessThan(
         focusedPinBounds.y + focusedPinBounds.height / 2,
+      );
+      expect(focusedNameBounds.x + focusedNameBounds.width).toBeLessThanOrEqual(
+        focusedPinBounds.x + 1,
       );
       expect(focusedPinBounds.x + focusedPinBounds.width).toBeLessThanOrEqual(focusedMenuBounds.x);
     } finally {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2353,12 +2353,12 @@ body.update-dialog-open .sidebar-update-card__status {
   padding-right: 2px;
 }
 
-/* Actions overlay only the second line, preserving the title's full width.
-   The buttons re-enable their own pointer-events on hover/focus. */
+/* Actions overlay the row center. The buttons re-enable their own
+   pointer-events on hover/focus. */
 .sidebar-recent-session:not(.sidebar-recent-session--child) > .sidebar-recent-session__aside {
   position: absolute;
-  bottom: 0;
-  right: 2px;
+  inset: 50% 2px auto auto;
+  transform: translateY(-50%);
   pointer-events: none;
 }
 
@@ -2379,9 +2379,9 @@ body.update-dialog-open .sidebar-update-card__status {
   right: calc(var(--sidebar-child-session-toggle-width) + 4px);
 }
 
-/* Hover actions replace the second-row endcap without shortening the title. */
+/* Centered actions overlap both lines, so the full text column yields their width. */
 .sidebar-recent-session:not(.sidebar-recent-session--child):is(:hover, :focus-within)
-  .sidebar-recent-session__details {
+  .sidebar-recent-session__text {
   padding-right: 52px;
 }
 
@@ -2393,7 +2393,7 @@ body.update-dialog-open .sidebar-update-card__status {
 
 /* Touch keeps the actions permanently visible beside the persistent endcap. */
 @media (hover: none), (pointer: coarse) {
-  .sidebar-recent-session:not(.sidebar-recent-session--child) .sidebar-recent-session__details {
+  .sidebar-recent-session:not(.sidebar-recent-session--child) .sidebar-recent-session__text {
     padding-right: 52px;
   }
 }
@@ -4233,6 +4233,7 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   flex: 1 1 auto;
   flex-direction: column;
   min-width: 0;
+  transition: padding-right var(--duration-fast) ease;
 }
 
 .sidebar-recent-session__details {
@@ -4241,7 +4242,6 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   gap: 6px;
   height: 18px;
   min-width: 0;
-  transition: padding-right var(--duration-fast) ease;
 }
 
 .sidebar-recent-session__subtitle {


### PR DESCRIPTION
Related: #125820

## What Problem This Solves

Fixes an issue where sidebar sessions with a title and subtitle placed the pin and overflow-menu controls on the subtitle baseline instead of vertically centering them in the full row.

## Why This Change Was Made

The shared session-row action overlay now anchors to the row midpoint. While the actions are visible, the full two-line text column reserves their width so neither a long title nor its subtitle can run underneath the controls. This preserves the existing two-line row structure rather than moving the actions onto the title line.

## User Impact

Pin and overflow-menu icons now sit visually centered in two-line sidebar session rows on both pointer and touch layouts. Long session text remains clipped clear of the controls.

## Evidence

Before the fix, the browser regression measured the pin and menu centers **7.07 px** below the row center. The same test now requires both controls to land within **1 px** of the row center.

| Before | After |
| --- | --- |
| ![Session actions aligned to the subtitle](https://github.com/user-attachments/assets/84e85193-84e7-427e-9aac-c266ca8d6c7e) | ![Session actions vertically centered](https://github.com/user-attachments/assets/e87379ec-d524-4b43-a468-cfdaf7d750d7) |

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.trailing-state.e2e.test.ts` — 5 tests passed
- `node scripts/check-changed.mjs -- ui/src/styles/layout.css ui/src/e2e/session-management.trailing-state.e2e.test.ts` — formatting, typechecks, oxlint, stylelint, i18n, dead-code, and repository guards passed
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean, no accepted/actionable findings
- `git diff --check` — passed

Production LOC: +8/-8 (net 0) | Tests: +61/-6

AI-assisted: yes, using Codex. The implementation and rendered before/after proof were reviewed before submission.
