### PR TITLE
fix(ui): move attachment menu to composer footer

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -267,9 +267,7 @@ suite.define(() => {
         .poll(() => page.getByRole("button", { name: "Start video talk" }).count())
         .toBe(0);
       await expect
-        .poll(() =>
-          attach.evaluate((node) => node.closest(".agent-chat__composer-input-row") != null),
-        )
+        .poll(() => attach.evaluate((node) => node.closest(".agent-chat__composer-footer") != null))
         .toBe(true);
       await expect
         .poll(() =>
@@ -662,23 +660,14 @@ suite.define(() => {
       }
       expect(mobileSettingsBox.x).toBeGreaterThanOrEqual(0);
       expect(mobileSettingsBox.x + mobileSettingsBox.width).toBeLessThanOrEqual(393);
-      expect(mobileAttachBox.x + mobileAttachBox.width).toBeLessThanOrEqual(mobileVoiceBox.x + 1);
-      await expect
-        .poll(async () => {
-          const [polledAttachBox, polledVoiceBox] = await Promise.all([
-            attach.boundingBox(),
-            voice.boundingBox(),
-          ]);
-          if (!polledAttachBox || !polledVoiceBox) {
-            return Number.POSITIVE_INFINITY;
-          }
-          return Math.abs(
-            polledAttachBox.y +
-              polledAttachBox.height / 2 -
-              (polledVoiceBox.y + polledVoiceBox.height / 2),
-          );
-        })
-        .toBeLessThanOrEqual(2);
+      expect(mobileAttachBox.x + mobileAttachBox.width).toBeLessThanOrEqual(mobileModelBox.x + 1);
+      expect(
+        Math.abs(
+          mobileAttachBox.y +
+            mobileAttachBox.height / 2 -
+            (mobileModelBox.y + mobileModelBox.height / 2),
+        ),
+      ).toBeLessThanOrEqual(2);
       await attach.click();
       await expect.poll(() => takePhoto.isVisible()).toBe(true);
       await expect
@@ -687,6 +676,18 @@ suite.define(() => {
       await expect
         .poll(() => composerShell.getByRole("menuitem", { name: "File", exact: true }).isVisible())
         .toBe(true);
+      const attachmentMenuBox = await composer
+        .locator("wa-dropdown.agent-chat__attach-menu")
+        .evaluate((node) => {
+          const menu = node.shadowRoot?.querySelector<HTMLElement>("[part=menu]");
+          const rect = menu?.getBoundingClientRect();
+          return rect ? { x: rect.x, y: rect.y, right: rect.right, bottom: rect.bottom } : null;
+        });
+      expect(attachmentMenuBox).not.toBeNull();
+      expect(attachmentMenuBox?.x ?? -1).toBeGreaterThanOrEqual(0);
+      expect(attachmentMenuBox?.y ?? -1).toBeGreaterThanOrEqual(0);
+      expect(attachmentMenuBox?.right ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(393);
+      expect(attachmentMenuBox?.bottom ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(852);
       await page.keyboard.press("Escape");
       await textarea.fill("Keep camera access in the attachment menu");
       await expect.poll(() => camera.count()).toBe(0);

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -295,6 +295,14 @@ function chatControlsHtml(opts: { agent?: boolean } = {}) {
 function composerControlsHtml(crowded = false) {
   return `
     <div class="agent-chat__composer-controls">
+      <details class="agent-chat__attach-menu">
+        <summary class="agent-chat__input-btn agent-chat__input-btn--attach" aria-label="Add attachment">${iconSvg()}</summary>
+        <div class="agent-chat__attach-menu-popover" role="menu">
+          <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>Camera</span></button>
+          <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>Photo</span></button>
+          <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>File</span></button>
+        </div>
+      </details>
       ${
         crowded
           ? `<div class="agent-chat__composer-run-status">
@@ -497,14 +505,6 @@ function chatHtml(opts: ChatFixtureOptions = {}, mobileNavLayout = false) {
                   }
                   <div class="agent-chat__composer-status-stack"> </div>
                   <div class="agent-chat__composer-input-row">
-                    <details class="agent-chat__attach-menu">
-                      <summary class="agent-chat__input-btn agent-chat__input-btn--attach" aria-label="Add attachment">${iconSvg()}</summary>
-                      <div class="agent-chat__attach-menu-popover" role="menu">
-                        <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>Camera</span></button>
-                        <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>Photo</span></button>
-                        <button class="agent-chat__attach-menu-option" role="menuitem">${iconSvg()}<span>File</span></button>
-                      </div>
-                    </details>
                     <div class="agent-chat__composer-combobox">
                       <textarea rows="1">Queued follow-up for the active operator session</textarea>
                     </div>
@@ -2391,7 +2391,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(input.y - (thread.y + thread.height)).toBeGreaterThanOrEqual(5.5);
       expect(shell.x).toBeLessThanOrEqual(8);
       expect(layout.viewportWidth - (shell.x + shell.width)).toBeLessThanOrEqual(8);
-      expect(attach.x - input.x).toBeLessThanOrEqual(10);
+      expect(attach.x + attach.width).toBeLessThanOrEqual(model.x + 1);
       expect(context.x).toBeGreaterThanOrEqual(model.x + model.width - 1);
       expect(input.x + input.width - (send.x + send.width)).toBeLessThanOrEqual(8);
       for (const control of [model, context]) {
@@ -2658,9 +2658,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expect(model.y).toBeGreaterThanOrEqual(textarea.y);
         expect(context.y).toBeGreaterThanOrEqual(textarea.y);
         expect(
-          Math.abs(attach.y + attach.height / 2 - (send.y + send.height / 2)),
+          Math.abs(attach.y + attach.height / 2 - (model.y + model.height / 2)),
         ).toBeLessThanOrEqual(2);
-        expect(attach.x + attach.width).toBeLessThanOrEqual(textarea.x + 1);
+        expect(attach.x + attach.width).toBeLessThanOrEqual(model.x + 1);
         expect(send.x).toBeGreaterThanOrEqual(textarea.x + textarea.width - 1);
         expect(send.x + send.width).toBeLessThanOrEqual(input.x + input.width + 1);
         expect(rectsOverlap(model, send)).toBe(false);

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -4949,9 +4949,13 @@ describe("chat attachment picker", () => {
 
   it("keeps attachment-only composers free of capability rows", () => {
     const container = renderChatView();
+    const attachMenu = requireElement(container, ".agent-chat__attach-menu", "attachment menu");
 
     expect(container.querySelectorAll(".agent-chat__attach-menu-option")).toHaveLength(3);
     expect(container.querySelector(".agent-chat__capability-menu-item")).toBeNull();
+    expect(attachMenu.closest(".agent-chat__composer-footer")).not.toBeNull();
+    expect(attachMenu.closest(".agent-chat__composer-controls")).not.toBeNull();
+    expect(attachMenu.closest(".agent-chat__composer-input-row")).toBeNull();
   });
 
   it("opens the camera input from the attachment menu and attaches the captured photo", async () => {

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -148,6 +148,48 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
       `
     : nothing;
   const showComposerInput = showComposer && props.disabledBanner?.kind !== "composer-replacement";
+  const plusMenu = showComposerInput
+    ? renderChatComposerPlusMenu({
+        attachments: props,
+        showCapabilities: props.capabilityMenu !== undefined,
+        basePath: props.capabilityMenu?.basePath ?? "",
+        disabled: !canCompose || props.suggestionComposer === true,
+        open: state.capabilityMenuOpen,
+        view: state.capabilityMenuView,
+        toolOverrides: props.toolOverrides,
+        skills: props.capabilityMenu?.skills ?? null,
+        skillsLoading: props.capabilityMenu?.skillsLoading ?? false,
+        skillsError: props.capabilityMenu?.skillsError ?? false,
+        mcpServers: props.capabilityMenu?.mcpServers ?? [],
+        toolsEffectiveResult: props.capabilityMenu?.toolsEffectiveResult ?? null,
+        toolsEffectiveLoading: props.capabilityMenu?.toolsEffectiveLoading ?? false,
+        toolsEffectiveError: props.capabilityMenu?.toolsEffectiveError ?? false,
+        toolAccessMutationBlockedReason:
+          props.capabilityMenu?.toolAccessMutationBlockedReason ?? null,
+        webSearchBaseEnabled: props.capabilityMenu?.webSearchBaseEnabled ?? true,
+        mutationBlockedReason: props.capabilityMenu?.mutationBlockedReason ?? null,
+        canAdmin: props.capabilityMenu?.canAdmin ?? false,
+        adminBlockedReason: props.capabilityMenu?.adminBlockedReason ?? null,
+        addServerDialog: props.capabilityMenu?.addServerDialog,
+        onOpenChange: (open) => {
+          state.capabilityMenuOpen = open;
+          if (!open) {
+            state.capabilityMenuView = "root";
+          }
+          requestUpdate();
+        },
+        onViewChange: (view) => {
+          state.capabilityMenuView = view;
+          requestUpdate();
+        },
+        onLoadSkills: props.capabilityMenu?.onLoadSkills ?? (() => {}),
+        onPatchToolOverrides: props.capabilityMenu?.onPatchToolOverrides ?? (() => {}),
+        onNavigate: props.capabilityMenu?.onNavigate ?? (() => {}),
+        onAddServer: props.capabilityMenu?.onAddServer,
+        onEnsureToolAccess: props.capabilityMenu?.onEnsureToolAccess,
+        onOpenToolAccess: props.capabilityMenu?.onOpenToolAccess,
+      })
+    : nothing;
   if (!props.capabilityMenu) {
     state.capabilityMenuView = "root";
   }
@@ -336,46 +378,6 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
               : nothing}
 
             <div class="agent-chat__composer-input-row">
-              ${renderChatComposerPlusMenu({
-                attachments: props,
-                showCapabilities: props.capabilityMenu !== undefined,
-                basePath: props.capabilityMenu?.basePath ?? "",
-                disabled: !canCompose || props.suggestionComposer === true,
-                open: state.capabilityMenuOpen,
-                view: state.capabilityMenuView,
-                toolOverrides: props.toolOverrides,
-                skills: props.capabilityMenu?.skills ?? null,
-                skillsLoading: props.capabilityMenu?.skillsLoading ?? false,
-                skillsError: props.capabilityMenu?.skillsError ?? false,
-                mcpServers: props.capabilityMenu?.mcpServers ?? [],
-                toolsEffectiveResult: props.capabilityMenu?.toolsEffectiveResult ?? null,
-                toolsEffectiveLoading: props.capabilityMenu?.toolsEffectiveLoading ?? false,
-                toolsEffectiveError: props.capabilityMenu?.toolsEffectiveError ?? false,
-                toolAccessMutationBlockedReason:
-                  props.capabilityMenu?.toolAccessMutationBlockedReason ?? null,
-                webSearchBaseEnabled: props.capabilityMenu?.webSearchBaseEnabled ?? true,
-                mutationBlockedReason: props.capabilityMenu?.mutationBlockedReason ?? null,
-                canAdmin: props.capabilityMenu?.canAdmin ?? false,
-                adminBlockedReason: props.capabilityMenu?.adminBlockedReason ?? null,
-                addServerDialog: props.capabilityMenu?.addServerDialog,
-                onOpenChange: (open) => {
-                  state.capabilityMenuOpen = open;
-                  if (!open) {
-                    state.capabilityMenuView = "root";
-                  }
-                  requestUpdate();
-                },
-                onViewChange: (view) => {
-                  state.capabilityMenuView = view;
-                  requestUpdate();
-                },
-                onLoadSkills: props.capabilityMenu?.onLoadSkills ?? (() => {}),
-                onPatchToolOverrides: props.capabilityMenu?.onPatchToolOverrides ?? (() => {}),
-                onNavigate: props.capabilityMenu?.onNavigate ?? (() => {}),
-                onAddServer: props.capabilityMenu?.onAddServer,
-                onEnsureToolAccess: props.capabilityMenu?.onEnsureToolAccess,
-                onOpenToolAccess: props.capabilityMenu?.onOpenToolAccess,
-              })}
               <div class="agent-chat__composer-combobox">
                 <textarea
                   ${ref(state.textareaRef ?? undefined)}
@@ -445,9 +447,10 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                     ${renderChatPermissionPicker(props.permissionPicker)}
                   </div>`
                 : nothing}
-              ${composerControls !== nothing
-                ? html`
-                    <div class="agent-chat__composer-controls">
+              <div class="agent-chat__composer-controls">
+                ${plusMenu}
+                ${composerControls !== nothing
+                  ? html`
                       ${composerRunStatus?.phase === "interrupted"
                         ? html`
                             <div class="agent-chat__composer-run-status">
@@ -495,9 +498,9 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                           `
                         : nothing}
                       ${composerControls}
-                    </div>
-                  `
-                : nothing}
+                    `
+                  : nothing}
+              </div>
               <div class="agent-chat__composer-context">${contextNotice}</div>
             </div>
           </div>`

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4032,12 +4032,6 @@ button.chat-pr__diff {
     gap: 0;
   }
 
-  .agent-chat__composer-input-row .agent-chat__input-btn--attach {
-    width: 36px;
-    min-width: 36px;
-    height: var(--chat-composer-control-height);
-  }
-
   .agent-chat__composer-combobox {
     align-self: stretch;
   }
@@ -4116,7 +4110,14 @@ button.chat-pr__diff {
     width: fit-content;
     min-width: 0;
     max-width: min(70vw, 100%);
+  }
+
+  .agent-chat__composer-controls .chat-controls__model {
     margin-left: 0;
+  }
+
+  .chat-composer-model-control {
+    margin-left: auto;
   }
 
   /* Reserve the readable model trigger, 44px effort target, and their gap;


### PR DESCRIPTION
## Summary

- move the attachment/capability `+` menu out of the text-input row and into the composer footer controls
- keep attachment access available when optional model controls are absent
- preserve mobile alignment by keeping the model controls right-aligned
- add structural, responsive, and real-menu viewport coverage

## Visual proof

**Attachment button in the footer**

![Attachment button in the composer footer](https://raw.githubusercontent.com/Patrick-Erichsen/openclaw/proof/chat-composer-attachment-footer/composer-footer-mobile.png)

**Attachment menu open without clipping**

![Attachment menu open above the footer](https://raw.githubusercontent.com/Patrick-Erichsen/openclaw/proof/chat-composer-attachment-footer/composer-footer-menu-open.png)

## Validation

- `pnpm --dir ui exec vitest run --config vitest.config.ts src/pages/chat/chat-view.test.ts src/pages/chat/chat-responsive.browser.test.ts` — 340 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-redesign.e2e.test.ts` — 3 passed
- `pnpm exec stylelint --config config/stylelint.config.mjs ...` — passed
- `pnpm exec oxfmt --check ...` — passed
- `pnpm ui:build` — passed
