### PR TITLE
fix: show named CLI sessions in the sidebar

### DIFF
--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -372,6 +372,7 @@ export function createAgentTurnService({
           // string and numeric threadIds (e.g., Matrix uses integers).
           threadId: recipientThreadId,
         });
+        const explicitSessionKey = normalizeOptionalString(request.sessionKey);
         const buildSessionPatch = (freshEntry: SessionEntry | undefined) =>
           buildAgentSessionPatch({
             freshEntry,
@@ -383,6 +384,7 @@ export function createAgentTurnService({
             normalizedSpawned,
             requestDeliveryHint,
             requestLabel: request.label,
+            ...(explicitSessionKey ? { explicitSessionKey } : {}),
             pluginOwnerId:
               freshEntry === undefined
                 ? normalizeOptionalString(principal?.internal?.pluginRuntimeOwnerId)

--- a/src/gateway/server-methods/agent-session-patch.test.ts
+++ b/src/gateway/server-methods/agent-session-patch.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
+  mergeSessionEntry,
   resolveSessionResetPolicy,
   type InternalSessionEntry as SessionEntry,
 } from "../../config/sessions.js";
-import { buildAgentSessionPatch } from "./agent-session-patch.js";
+import { buildAgentSessionPatch, type AgentSessionPatchBuild } from "./agent-session-patch.js";
 
 function buildPatch(touchInteraction: boolean, opts?: { requestLabel?: string; label?: string }) {
   const now = 1_000;
@@ -37,6 +38,36 @@ function buildPatch(touchInteraction: boolean, opts?: { requestLabel?: string; l
   }).patch;
 }
 
+function buildCreationPatch(opts: {
+  canonicalSessionKey?: string;
+  explicitSessionKey?: string;
+  freshEntry?: SessionEntry;
+  isSystemGatewayRun?: boolean;
+  visibleRequest?: boolean;
+}): AgentSessionPatchBuild {
+  const now = 1_000;
+  return buildAgentSessionPatch({
+    freshEntry: opts.freshEntry,
+    initialEntry: opts.freshEntry,
+    cfg: {},
+    sessionAgentId: "main",
+    canonicalSessionKey: opts.canonicalSessionKey ?? "agent:main:incident-42",
+    storePath: "/tmp/openclaw-explicit-session-name-test.json",
+    normalizedSpawned: {},
+    requestDeliveryHint: undefined,
+    ...(opts.explicitSessionKey ? { explicitSessionKey: opts.explicitSessionKey } : {}),
+    ...(opts.freshEntry?.sessionId ? { expectedExistingSessionId: opts.freshEntry.sessionId } : {}),
+    hasRestoredCronContinuation: false,
+    resetPolicy: resolveSessionResetPolicy({ resetType: "direct" }),
+    now,
+    isSystemGatewayRun: opts.isSystemGatewayRun ?? false,
+    visibleRequest: opts.visibleRequest ?? true,
+    fallbackSessionId: "fallback",
+    touchInteraction: false,
+    failedSessionTranscriptMissing: () => false,
+  });
+}
+
 describe("agent session patch", () => {
   it("clears agent status at the next human interaction boundary", () => {
     const patch = buildPatch(true);
@@ -60,5 +91,80 @@ describe("agent session patch", () => {
 
   it("keeps the existing label when the request has none", () => {
     expect(buildPatch(false, { label: "Existing" }).label).toBe("Existing");
+  });
+
+  it("names a new session from an explicit agent session key", () => {
+    const result = buildCreationPatch({
+      canonicalSessionKey: "agent:main:incident-42 ",
+      explicitSessionKey: "agent:main:incident-42",
+    });
+
+    expect(result.patch.displayName).toBe("incident-42");
+  });
+
+  it("does not name an existing session", () => {
+    const entry: SessionEntry = { sessionId: "existing", updatedAt: 1_000 };
+    const result = buildCreationPatch({
+      explicitSessionKey: "agent:main:incident-42",
+      freshEntry: entry,
+    });
+
+    expect(result.patch).not.toHaveProperty("displayName");
+  });
+
+  it.each([
+    ["label", { label: "Existing label" }],
+    ["displayName", { displayName: "Existing display name" }],
+    ["subject", { subject: "Existing subject" }],
+  ] as const)("does not replace an existing %s", (_field, namedEntry) => {
+    const entry: SessionEntry = { sessionId: "existing", updatedAt: 1_000, ...namedEntry };
+    const result = buildCreationPatch({
+      explicitSessionKey: "agent:main:incident-42",
+      freshEntry: entry,
+    });
+
+    expect(mergeSessionEntry(entry, result.patch)).toMatchObject(namedEntry);
+  });
+
+  it("does not name a defaulted main session", () => {
+    expect(buildCreationPatch({ canonicalSessionKey: "agent:main:main" }).patch).not.toHaveProperty(
+      "displayName",
+    );
+  });
+
+  it("does not name a channel-derived session", () => {
+    expect(
+      buildCreationPatch({ canonicalSessionKey: "agent:main:telegram:direct:123" }).patch,
+    ).not.toHaveProperty("displayName");
+  });
+
+  it.each([
+    ["cron", "agent:main:cron:job-1", true, false],
+    ["heartbeat", "agent:main:heartbeat:main", true, false],
+    ["internal", "agent:main:internal:probe", false, false],
+  ] as const)(
+    "does not name a %s run",
+    (_kind, canonicalSessionKey, isSystemGatewayRun, visibleRequest) => {
+      const result = buildCreationPatch({
+        canonicalSessionKey,
+        explicitSessionKey: canonicalSessionKey,
+        isSystemGatewayRun,
+        visibleRequest,
+      });
+
+      expect(result.patch).not.toHaveProperty("displayName");
+    },
+  );
+
+  it.each([
+    ["subagent", "agent:main:subagent:worker-1"],
+    ["ACP", "agent:main:acp:thread-1"],
+  ] as const)("does not name a %s session", (_kind, canonicalSessionKey) => {
+    const result = buildCreationPatch({
+      canonicalSessionKey,
+      explicitSessionKey: canonicalSessionKey,
+    });
+
+    expect(result.patch).not.toHaveProperty("displayName");
   });
 });

--- a/src/gateway/server-methods/agent-session-patch.ts
+++ b/src/gateway/server-methods/agent-session-patch.ts
@@ -14,6 +14,12 @@ import { isRecoverableTerminalSessionStatus } from "../../config/sessions/termin
 import type { InternalSessionEntry as SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  isAcpSessionKey,
+  isCronSessionKey,
+  isSubagentSessionKey,
+  parseAgentSessionKey,
+} from "../../routing/session-key.js";
+import {
   deliveryContextFromSession,
   mergeDeliveryContext,
   normalizeSessionDeliveryState,
@@ -52,6 +58,7 @@ export function buildAgentSessionPatch(params: {
   normalizedSpawned: { groupId?: string; groupChannel?: string; groupSpace?: string };
   requestDeliveryHint: DeliveryContext | undefined;
   requestLabel?: string;
+  explicitSessionKey?: string;
   pluginOwnerId?: string;
   expectedExistingSessionId?: string;
   hasRestoredCronContinuation: boolean;
@@ -136,6 +143,16 @@ export function buildAgentSessionPatch(params: {
     origin: sessionDeliveryOrigin(params.freshEntry),
   });
   const labelValue = normalizeOptionalString(params.requestLabel) || params.freshEntry?.label;
+  const explicitSessionDisplayName =
+    params.freshEntry === undefined &&
+    params.visibleRequest &&
+    normalizeOptionalString(params.explicitSessionKey) &&
+    !labelValue &&
+    !isCronSessionKey(params.canonicalSessionKey) &&
+    !isSubagentSessionKey(params.canonicalSessionKey) &&
+    !isAcpSessionKey(params.canonicalSessionKey)
+      ? parseAgentSessionKey(params.canonicalSessionKey)?.rest.trim()
+      : undefined;
   const freshSessionRotatedSinceLoad = Boolean(
     params.initialEntry?.sessionId &&
     params.freshEntry?.sessionId &&
@@ -232,6 +249,9 @@ export function buildAgentSessionPatch(params: {
     ...automaticRecoveryClearPatch,
     delivery,
     ...(labelValue ? { label: labelValue } : {}),
+    // An operator-supplied key is an explicit name: keep it instead of generating
+    // a dashboard title later, matching the semantics of a Control UI rename.
+    ...(explicitSessionDisplayName ? { displayName: explicitSessionDisplayName } : {}),
     ...(freshSpawnedBy ? { spawnedBy: freshSpawnedBy } : {}),
     groupId: nextGroup.groupId,
     groupChannel: nextGroup.groupChannel,

--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
+import { resolveSessionResetPolicy } from "../../../../src/config/sessions.js";
+import { buildAgentSessionPatch } from "../../../../src/gateway/server-methods/agent-session-patch.js";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import {
   compareSessionRowsByUpdatedAt,
@@ -412,6 +414,39 @@ describe("visibleSessionMatches", () => {
 
 describe("isSystemCreatedSessionRow", () => {
   const base = { key: "agent:main:explicit:probe", kind: "direct", updatedAt: 1 } as const;
+  it("keeps a newly created operator-named CLI session visible", () => {
+    const key = "agent:main:incident-42";
+    const patch = buildAgentSessionPatch({
+      freshEntry: undefined,
+      initialEntry: undefined,
+      cfg: {},
+      sessionAgentId: "main",
+      canonicalSessionKey: key,
+      storePath: "/tmp/openclaw-explicit-session-visibility-test.json",
+      normalizedSpawned: {},
+      requestDeliveryHint: undefined,
+      explicitSessionKey: key,
+      hasRestoredCronContinuation: false,
+      resetPolicy: resolveSessionResetPolicy({ resetType: "direct" }),
+      now: 1,
+      isSystemGatewayRun: false,
+      visibleRequest: true,
+      fallbackSessionId: "session-id",
+      touchInteraction: true,
+      failedSessionTranscriptMissing: () => false,
+    }).patch;
+    const row: GatewaySessionRow = {
+      key,
+      kind: "direct",
+      updatedAt: 1,
+      createdVia: "run",
+      displayName: patch.displayName,
+    };
+
+    expect(row.displayName).toBe("incident-42");
+    expect(isSystemCreatedSessionRow(row)).toBe(false);
+  });
+
   it.each([
     ["run + no actor + unnamed is system", { createdVia: "run" }, true],
     ["internal + no actor + unnamed is system", { createdVia: "internal" }, true],

--- a/ui/src/lib/sessions/navigation.test.ts
+++ b/ui/src/lib/sessions/navigation.test.ts
@@ -1,7 +1,5 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { resolveSessionResetPolicy } from "../../../../src/config/sessions.js";
-import { buildAgentSessionPatch } from "../../../../src/gateway/server-methods/agent-session-patch.js";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import {
   compareSessionRowsByUpdatedAt,
@@ -415,35 +413,14 @@ describe("visibleSessionMatches", () => {
 describe("isSystemCreatedSessionRow", () => {
   const base = { key: "agent:main:explicit:probe", kind: "direct", updatedAt: 1 } as const;
   it("keeps a newly created operator-named CLI session visible", () => {
-    const key = "agent:main:incident-42";
-    const patch = buildAgentSessionPatch({
-      freshEntry: undefined,
-      initialEntry: undefined,
-      cfg: {},
-      sessionAgentId: "main",
-      canonicalSessionKey: key,
-      storePath: "/tmp/openclaw-explicit-session-visibility-test.json",
-      normalizedSpawned: {},
-      requestDeliveryHint: undefined,
-      explicitSessionKey: key,
-      hasRestoredCronContinuation: false,
-      resetPolicy: resolveSessionResetPolicy({ resetType: "direct" }),
-      now: 1,
-      isSystemGatewayRun: false,
-      visibleRequest: true,
-      fallbackSessionId: "session-id",
-      touchInteraction: true,
-      failedSessionTranscriptMissing: () => false,
-    }).patch;
     const row: GatewaySessionRow = {
-      key,
+      key: "agent:main:incident-42",
       kind: "direct",
       updatedAt: 1,
       createdVia: "run",
-      displayName: patch.displayName,
+      displayName: "incident-42",
     };
 
-    expect(row.displayName).toBe("incident-42");
     expect(isSystemCreatedSessionRow(row)).toBe(false);
   });
 
@@ -457,11 +434,6 @@ describe("isSystemCreatedSessionRow", () => {
       false,
     ],
     ["run + label stays visible", { createdVia: "run", label: "My batch job" }, false],
-    [
-      "run + displayName stays visible",
-      { createdVia: "run", displayName: "Nightly digest" },
-      false,
-    ],
     ["operator creation stays visible", { createdVia: "operator" }, false],
     ["legacy row without provenance stays visible", {}, false],
     [

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -239,9 +239,9 @@ type VisibleSessionRowOptions = {
  * message text, which rots and false-positives real chats. Rows without
  * recorded provenance (legacy stores) stay visible.
  *
- * Accepted tradeoff: a profile-less client's unnamed `run` session (e.g. an
- * explicit `--session-key` CLI conversation without an operator profile) is
- * indistinguishable from a probe and hides by default too. It stays fully
+ * Accepted tradeoff: a profile-less client's unnamed `run` session is
+ * indistinguishable from a probe and hides by default too. Operator-named CLI
+ * sessions are stamped at creation and remain visible. Unnamed rows stay fully
  * reachable: the selected session always renders in the sidebar, the Sessions
  * page never applies this filter, and the sort-menu toggle reveals all rows.
  */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators starting a deliberately named CLI session with `openclaw agent --session-key <key>` could not see that session in the Control UI sidebar. Profile-less CLI runs are recorded as `createdVia: "run"`; without a persisted name, the UI correctly classified the row as machine noise and hid it behind the default-off system-session toggle.

## Why This Change Was Made

The agent-turn session-entry producer now carries the explicit gateway `agent` request field into the authoritative creation patch and derives `displayName` from the canonical key's session portion using the existing parser. It stamps only an absent row from a visible request, never replaces `label`/`displayName`/`subject`, and excludes defaulted, channel-derived, cron/heartbeat/internal, subagent, and ACP sessions.

The name is written inside the authoritative session update because that boundary rereads the latest entry before creation; a concurrent or existing row is therefore left alone. `createdVia` remains `"run"`. Repurposing `"operator"` was rejected because `src/sessions/session-diff-baseline.ts` consumes it behaviorally. Changing the UI predicate/filter was rejected because it would weaken the machine-noise policy instead of recording the missing operator intent at its producer.

Intended title tradeoff: a stamped `displayName` makes `hasExplicitSessionName` true, so these sessions keep the operator's chosen name instead of receiving a generated title. That matches a Control UI rename and is the desired behavior.

Production LOC: +22/-0. Tests: +119/-6.

## User Impact

An operator-created session such as `agent:main:incident-42` now appears as `incident-42` in the normal sidebar without enabling “Show system sessions.” Calling `openclaw agent` without a session key still targets the main identity session and adds no extra sidebar row.

## Evidence

Pre-fix regression proof:

- Producer suite failed with `expected undefined to be "incident-42"`.
- The UI fixture independently verifies that the stamped row is not classified by the real `isSystemCreatedSessionRow` predicate.

Post-fix local proof:

- `node scripts/run-vitest.mjs src/gateway/server-methods/agent-session-patch.test.ts` — 16/16.
- `node scripts/run-vitest.mjs ui/src/lib/sessions/navigation.test.ts` — 26/26.
- `pnpm tsgo:core`, `pnpm tsgo:ui`, `pnpm check:assertion-safety`, targeted `pnpm format`, and production Knip dependency/export scans — clean.
- `pnpm ui:build` and `pnpm build` — clean.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — no accepted/actionable findings.

Live proof used an isolated real Gateway on port 19233, token auth, and `openai/gpt-5.6-luna`:

- Named turn returned `named-session-live-ok`; Gateway `sessions.list` persisted `displayName: "incident-42"` with `createdVia: "run"`.
- No-key control returned `default-main-live-ok`; Gateway state contained exactly `agent:main:main` and `agent:main:incident-42`, while the sidebar still showed only the named non-main row.
- Reload preserved the result. The system-session toggle was never enabled.

Named session visible:

![Control UI sidebar showing incident-42](https://github.com/user-attachments/assets/15f0b10b-bbfb-406c-b28a-a6bcad2e60f4)

No-key main-session control, with no extra sidebar row:

![Control UI sidebar after the default-main control turn](https://github.com/user-attachments/assets/0903636c-f87c-461d-81c6-a2ff84ffbc70)

Recorded live flow:

https://github.com/user-attachments/assets/2714089d-1d14-476d-9436-4710a874075b
