### PR TITLE
improve(ui): slow the new-session submit spinner

### DIFF
--- a/ui/src/e2e/new-session-page.transition.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.transition.e2e.test.ts
@@ -133,6 +133,9 @@ suite.define(() => {
 
       await expect.poll(() => start.getAttribute("aria-busy")).toBe("true");
       const spinner = start.locator("svg");
+      expect(await spinner.evaluate((element) => getComputedStyle(element).animationDuration)).toBe(
+        "2.25s",
+      );
       const initialSpinnerTransform = await spinner.evaluate(
         (element) => getComputedStyle(element).transform,
       );

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -631,7 +631,7 @@ wa-popover.new-session-page__project-popover::part(body) {
 }
 
 .new-session-page__start-submit[aria-busy="true"] svg {
-  animation: new-session-start-spin 0.75s linear infinite;
+  animation: new-session-start-spin 2.25s linear infinite;
 }
 
 @keyframes new-session-start-spin {


### PR DESCRIPTION
AI-assisted: yes (Roboclaw/Codex).

## What Problem This Solves

The Control UI new-session submit spinner rotates once every 0.75 seconds, making the loading indicator move three times faster than intended.

## Why This Change Was Made

Set the spinner's owning CSS animation period to 2.25 seconds and extend the existing new-session transition E2E to assert the browser-computed duration. The loading state, rotation behavior, reduced-motion handling, and sibling spinners remain unchanged.

## User Impact

The new-session submit spinner now rotates at one-third of its previous speed while session creation and the handoff into chat continue to behave as before.

## Evidence

- Before the CSS change, the focused Chromium regression assertion failed with a computed duration of `0.75s` instead of `2.25s`.
- After rebasing onto current `main`, `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.transition.e2e.test.ts` passed both tests on AWS Crabbox `cbx_56cca2ed20ac` ([run](https://crabbox.openclaw.ai/portal/runs/run_9b885774c554)).
- `git diff --check origin/main...HEAD` passed.
- Autoreview completed with no findings.
- A still screenshot cannot demonstrate rotational speed; the browser E2E verifies both the exact computed period and that the spinner continues rotating through the session transition.
