### PR TITLE
fix(tui): prevent startup sends to the wrong session

### DIFF
--- a/src/tui/tui-gateway-delay-proxy-test-support.ts
+++ b/src/tui/tui-gateway-delay-proxy-test-support.ts
@@ -1,0 +1,116 @@
+import { type RawData, WebSocket, WebSocketServer } from "ws";
+import { createDeferred } from "../../test/helpers/promise.js";
+
+type DelayedGatewayRpcRequest = {
+  type: "req";
+  id: string;
+  method: string;
+  params?: Record<string, unknown>;
+};
+
+function decodeGatewayFrame(data: RawData): string {
+  if (Array.isArray(data)) {
+    return Buffer.concat(data).toString("utf8");
+  }
+  if (Buffer.isBuffer(data)) {
+    return data.toString("utf8");
+  }
+  return Buffer.from(new Uint8Array(data)).toString("utf8");
+}
+
+export async function startGatewayRpcDelayProxy(
+  targetUrl: string,
+  delayedMethods: readonly string[],
+) {
+  const gates = new Map(
+    delayedMethods.map((method) => [method, { seen: createDeferred(), release: createDeferred() }]),
+  );
+  const requests: DelayedGatewayRpcRequest[] = [];
+  const sockets = new Set<WebSocket>();
+  const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+
+  server.on("connection", (downstream) => {
+    const upstream = new WebSocket(targetUrl);
+    sockets.add(downstream);
+    sockets.add(upstream);
+    const queued: Array<{ data: RawData; isBinary: boolean }> = [];
+    upstream.on("open", () => {
+      for (const message of queued.splice(0)) {
+        upstream.send(message.data, { binary: message.isBinary });
+      }
+    });
+    downstream.on("message", (data, isBinary) => {
+      try {
+        const frame = JSON.parse(decodeGatewayFrame(data)) as Partial<DelayedGatewayRpcRequest>;
+        if (
+          frame.type === "req" &&
+          typeof frame.id === "string" &&
+          typeof frame.method === "string"
+        ) {
+          const request = frame as DelayedGatewayRpcRequest;
+          requests.push(request);
+          gates.get(request.method)?.seen.resolve();
+        }
+      } catch {
+        // Forward malformed frames so the real Gateway remains the protocol authority.
+      }
+      if (upstream.readyState === WebSocket.OPEN) {
+        upstream.send(data, { binary: isBinary });
+      } else {
+        queued.push({ data, isBinary });
+      }
+    });
+    upstream.on("message", (data, isBinary) => {
+      void (async () => {
+        try {
+          const frame = JSON.parse(decodeGatewayFrame(data)) as { type?: unknown; id?: unknown };
+          if (frame.type === "res" && typeof frame.id === "string") {
+            const method = requests.find((request) => request.id === frame.id)?.method;
+            const gate = method ? gates.get(method) : undefined;
+            if (gate) {
+              await gate.release.promise;
+            }
+          }
+        } catch {
+          // Forward malformed frames so the real TUI remains the protocol authority.
+        }
+        if (downstream.readyState === WebSocket.OPEN) {
+          downstream.send(data, { binary: isBinary });
+        }
+      })();
+    });
+    downstream.on("close", () => upstream.close());
+    upstream.on("close", () => downstream.close());
+    downstream.on("error", () => upstream.close());
+    upstream.on("error", () => downstream.close());
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Gateway RPC delay proxy did not bind");
+  }
+  return {
+    url: `ws://127.0.0.1:${address.port}`,
+    requests,
+    waitForRequest: async (method: string) => {
+      const gate = gates.get(method);
+      if (!gate) {
+        throw new Error(`Gateway RPC method is not delayed: ${method}`);
+      }
+      await gate.seen.promise;
+    },
+    release: (method: string) => gates.get(method)?.release.resolve(),
+    stop: async () => {
+      for (const socket of sockets) {
+        socket.close();
+      }
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -12,6 +12,7 @@ import {
 import { TUI_PTY_RECONNECT_FIXTURE } from "./tui-pty-reconnect-fixture-test-support.js";
 import { TUI_PTY_RENDERING_FIXTURE_SCRIPT } from "./tui-pty-rendering-test-support.js";
 import { TUI_PTY_RESET_FIXTURE } from "./tui-pty-reset-fixture-test-support.js";
+import { TUI_PTY_STARTUP_SESSION_FIXTURE } from "./tui-pty-startup-session-fixture-test-support.js";
 import { TUI_PTY_SESSION_SUBSCRIPTION_FIXTURE_SCRIPT } from "./tui-pty-subscription-fixture-test-support.js";
 import { startPty, type PtyRun } from "./tui-pty-test-support.js";
 
@@ -83,6 +84,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
       const actionLogPath = process.env.OPENCLAW_TUI_PTY_LOG_PATH;
       const gatewayStatus = process.env.OPENCLAW_TUI_PTY_GATEWAY_STATUS ?? "fixture gateway ok";
       const startupDelayMs = Number(process.env.OPENCLAW_TUI_PTY_STARTUP_DELAY_MS ?? 0);
+      ${TUI_PTY_STARTUP_SESSION_FIXTURE.variables}
       const footerModel = process.env.OPENCLAW_TUI_PTY_MODEL;
       const footerThinkingLevel = process.env.OPENCLAW_TUI_PTY_THINKING_LEVEL;
       let verboseLevel = process.env.OPENCLAW_TUI_PTY_VERBOSE_LEVEL;
@@ -458,6 +460,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
           const gapHistory = loadGapHistory(sessionKey);
           if (gapHistory) { return gapHistory; }
           ${TUI_PTY_RECONNECT_FIXTURE.loadHistory}
+          ${TUI_PTY_STARTUP_SESSION_FIXTURE.loadHistory}
           if (liveReplyHistory.length > 0) {
             return { messages: [...liveReplyHistory] };
           }
@@ -505,9 +508,12 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         }
 
         async listSessions(opts?: Parameters<TuiBackend["listSessions"]>[0]) {
+          ${TUI_PTY_STARTUP_SESSION_FIXTURE.listSessionsSetup}
           record("listSessions", {
             purpose: opts?.includeDerivedTitles ? "picker" : "refresh",
+            search: opts?.search,
           });
+          ${TUI_PTY_STARTUP_SESSION_FIXTURE.listSessionsDelay}
           const sessions = enablePickerFixture
             ? [
                 sessionEntry("main"),
@@ -674,6 +680,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
             session: { scope: "per-sender", mainKey: "main" },
           },
           deliver: process.env.OPENCLAW_TUI_PTY_DELIVER === "1",
+          session: process.env.OPENCLAW_TUI_PTY_SESSION,
           thinking: launchThinkingLevel,
           message: initialMessage,
           historyLimit: 5,

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -4,6 +4,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { pathToFileURL } from "node:url";
 import { afterAll, beforeAll, describe, expect, it, type TestFunction } from "vitest";
 import {
@@ -20,6 +21,8 @@ import { runExec } from "../process/exec.js";
 import { sleep } from "../utils/sleep.js";
 import { GatewayChatClient } from "./gateway-chat.js";
 import { extractTextFromMessage } from "./tui-formatters.js";
+import { startGatewayRpcDelayProxy } from "./tui-gateway-delay-proxy-test-support.js";
+import { buildTuiLastSessionScopeKey, writeTuiLastSessionKey } from "./tui-last-session.js";
 import {
   synchronizedFrameRows,
   waitForSynchronizedFrameRows,
@@ -936,8 +939,15 @@ async function startIsolatedGatewayPty(params: {
   sessionKey?: string;
   token?: string;
   clientStateDir?: string;
+  url?: string;
 }) {
-  const { gateway, registerCleanup, sessionKey, token = gateway.gatewayToken } = params;
+  const {
+    gateway,
+    registerCleanup,
+    sessionKey,
+    token = gateway.gatewayToken,
+    url = gateway.url,
+  } = params;
   const ownsClientStateDir = !params.clientStateDir;
   const tempDir =
     params.clientStateDir ??
@@ -945,7 +955,7 @@ async function startIsolatedGatewayPty(params: {
   let run: PtyRun;
   try {
     await writeFile(path.join(tempDir, "openclaw.json"), "{}\n", "utf8");
-    const cliArgs = ["tui", "--url", gateway.url, "--token", token];
+    const cliArgs = ["tui", "--url", url, "--token", token];
     if (sessionKey) {
       cliArgs.push("--session", sessionKey);
     }
@@ -984,6 +994,7 @@ async function startIsolatedGatewayPty(params: {
   registerCleanup(cleanup);
   return { run, cleanup };
 }
+
 type GatewayHistory = { messages: unknown[]; sessionInfo?: Record<string, unknown> };
 function findOrderedTurn(messages: unknown[], userText: string, assistantText: string, after = -1) {
   const exact = (message: unknown, role: "assistant" | "user", text: string) =>
@@ -1797,7 +1808,7 @@ export default {
     LOCAL_TEST_TIMEOUT_MS,
   );
   registerGatewayTest(
-    "restores the remembered Gateway session and history after a real TUI relaunch",
+    "gates input while a real Gateway restores the remembered session and history",
     async ({ onTestFinished }) => {
       const shared = await requireSharedGatewayFixture();
       const scenario = GATEWAY_SCENARIOS.resume;
@@ -1889,28 +1900,97 @@ export default {
       } finally {
         await first.cleanup();
       }
-      const resumed = await startIsolatedGatewayPty(ptyParams);
+      const proxy = await startGatewayRpcDelayProxy(shared.gateway.url, [
+        "sessions.list",
+        "chat.history",
+      ]);
+      const cleanupProxy = registerIdempotentCleanup(onTestFinished, proxy.stop);
+      await writeTuiLastSessionKey({
+        scopeKey: buildTuiLastSessionScopeKey({
+          connectionUrl: proxy.url,
+          agentId,
+          sessionScope: "per-sender",
+        }),
+        sessionKey,
+        stateDir: clientStateDir,
+      });
+      const resumed = await startIsolatedGatewayPty({ ...ptyParams, url: proxy.url });
       try {
+        await proxy.waitForRequest("sessions.list");
+        const outputOffset = resumed.run.visibleOutput().length;
+        await resumed.run.write(`${next[0]}\r`, { delay: false });
+        const decision = await waitFor({
+          timeoutMs: LOCAL_OUTPUT_TIMEOUT_MS,
+          read: () => {
+            const sends = proxy.requests.filter(
+              (request) => request.method === "chat.send" && request.params?.message === next[0],
+            );
+            const output = resumed.run.visibleOutput().slice(outputOffset);
+            return sends.length > 0 ||
+              output.includes("not connected to gateway — message not sent")
+              ? { sends, output }
+              : null;
+          },
+          onTimeout: () => new Error("startup followup was neither blocked nor sent"),
+        });
+        expect(decision.sends.map((request) => request.params)).toEqual([]);
+        expect(decision.output).toContain("not connected to gateway — message not sent");
+
+        proxy.release("sessions.list");
+        await proxy.waitForRequest("chat.history");
+        proxy.release("chat.history");
         await resumed.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
-        await waitForSynchronizedFrameRows(
+        const restoredFrame = await waitForSynchronizedFrameRows(
           resumed.run,
-          (rows) => restoredMarkers.every((marker) => rows.some((row) => row.includes(marker))),
+          (rows) =>
+            [...restoredMarkers, next[0]].every((marker) =>
+              rows.some((row) => row.includes(marker)),
+            ),
           LOCAL_OUTPUT_TIMEOUT_MS,
         );
-        await resumed.run.write(`${next[0]}\r`);
+        expect(restoredFrame.join("\n")).toContain(next[0]);
+        await resumed.run.write("\r", { delay: false });
         await resumed.run.waitForOutput(scenario.followupReplyText, LOCAL_OUTPUT_TIMEOUT_MS);
         await waitForCheckpoint(terminalUpdatedAt, [initial, next]);
+        const sends = proxy.requests.filter(
+          (request) => request.method === "chat.send" && request.params?.message === next[0],
+        );
+        expect(sends.map((request) => request.params?.sessionKey)).toEqual([sessionKey]);
+        const db = new DatabaseSync(
+          path.join(shared.gateway.stateDir, "agents", agentId, "agent", "openclaw-agent.sqlite"),
+          { readOnly: true },
+        );
+        const sqliteRows = db
+          .prepare(
+            `SELECT node.session_key AS sessionKey, COUNT(*) AS eventCount
+             FROM session_nodes AS node
+             JOIN transcript_events AS event ON event.session_id = node.current_session_id
+             WHERE event.event_json LIKE ?
+             GROUP BY node.session_key
+             ORDER BY node.session_key`,
+          )
+          .all(`%${next[0]}%`);
+        db.close();
+        expect(sqliteRows).toEqual([{ sessionKey, eventCount: 1 }]);
         const requests = shared.mockModel.requests(scenario.modelId).slice(requestOffset);
         expect(requests).toHaveLength(2);
         const secondRequestBody = JSON.stringify(requests[1]?.body);
         expect(secondRequestBody).toContain(initial[0]);
         expect(secondRequestBody).toContain(scenario.replyText);
         expect(secondRequestBody).toContain(next[0]);
+        console.log(
+          `[behavior-evidence] tui-startup-session-gate ${JSON.stringify({
+            sentKey: sessionKey,
+            headerSession: sessionKey,
+            sqliteRows,
+          })}`,
+        );
         await resumed.run.write("/exit\r", { delay: false });
         expect((await resumed.run.waitForExit()).exitCode).toBe(0);
       } finally {
         await cleanup();
         await resumed.cleanup();
+        await cleanupProxy();
       }
     },
     LOCAL_TEST_TIMEOUT_MS,

--- a/src/tui/tui-pty-startup-session-fixture-test-support.ts
+++ b/src/tui/tui-pty-startup-session-fixture-test-support.ts
@@ -1,0 +1,36 @@
+// Injects delayed session restore and history controls into the real-runTui PTY fixture.
+export const TUI_PTY_STARTUP_SESSION_FIXTURE = {
+  variables: `
+      const restoreDelayMs = Number(process.env.OPENCLAW_TUI_PTY_RESTORE_DELAY_MS ?? 0);
+      const restoreFailures = Number(process.env.OPENCLAW_TUI_PTY_RESTORE_FAILURES ?? 0);
+      const reconnectHistoryDelayMs = Number(
+        process.env.OPENCLAW_TUI_PTY_RECONNECT_HISTORY_DELAY_MS ?? 0,
+      );
+      let restoreAttempts = 0;
+      let reconnectDuringRestore = process.env.OPENCLAW_TUI_PTY_RECONNECT_DURING_RESTORE === "1";
+  `,
+  loadHistory: `
+          if (reconnectHistoryReady && reconnectHistoryDelayMs > 0) {
+            reconnectHistoryReady = false;
+            record("reconnectHistoryPending", { sessionKey });
+            await new Promise((resolve) => setTimeout(resolve, reconnectHistoryDelayMs));
+          }
+  `,
+  listSessionsSetup: `
+          const isRestore = Boolean(opts?.search);
+  `,
+  listSessionsDelay: `
+          if (isRestore && reconnectDuringRestore) {
+            reconnectDuringRestore = false;
+            record("restoreReconnect");
+            this.onDisconnected?.("fixture reconnect during restore");
+            queueMicrotask(() => this.onConnected?.());
+          }
+          if (isRestore && restoreDelayMs > 0) {
+            await new Promise((resolve) => setTimeout(resolve, restoreDelayMs));
+          }
+          if (isRestore && restoreAttempts++ < restoreFailures) {
+            throw new Error("fixture remembered-session lookup failed");
+          }
+  `,
+} as const;

--- a/src/tui/tui-session-identity-pty.e2e.test.ts
+++ b/src/tui/tui-session-identity-pty.e2e.test.ts
@@ -1,23 +1,21 @@
 import { afterEach, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { sleep } from "../utils/sleep.js";
 import { buildTuiLastSessionScopeKey, writeTuiLastSessionKey } from "./tui-last-session.js";
 import {
   disposeActiveTuiFixtures,
   objectFieldEquals,
+  readFixtureLog,
   startTuiFixture,
   waitForSynchronizedFrameRows,
+  type FixtureLogEntry,
 } from "./tui-pty-harness-fixture-test-support.js";
 
 const STARTUP_TIMEOUT_MS = 60_000;
 const REMEMBERED_SESSION_KEY = "agent:main:picker-target";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-afterEach(async () => {
-  await disposeActiveTuiFixtures();
-});
-
-it("hides a stale approval when startup restores the remembered session", async () => {
-  const stateDir = tempDirs.make("openclaw-tui-identity-");
+async function seedRememberedSession(stateDir: string) {
   await writeTuiLastSessionKey({
     scopeKey: buildTuiLastSessionScopeKey({
       connectionUrl: "pty-fixture://local",
@@ -27,6 +25,55 @@ it("hides a stale approval when startup restores the remembered session", async 
     sessionKey: REMEMBERED_SESSION_KEY,
     stateDir,
   });
+}
+
+async function waitForLogCount(params: {
+  logPath: string;
+  predicate: (entry: FixtureLogEntry) => boolean;
+  count: number;
+}) {
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  for (; Date.now() < deadline; await sleep(25)) {
+    const entries = await readFixtureLog(params.logPath);
+    if (entries.filter(params.predicate).length >= params.count) {
+      return entries;
+    }
+  }
+  throw new Error(`fixture log did not reach ${params.count} matching entries`);
+}
+
+function markerSends(entries: FixtureLogEntry[], marker: string) {
+  return entries.filter(
+    (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", marker),
+  );
+}
+
+async function waitForSubmitDecision(params: {
+  fixture: Awaited<ReturnType<typeof startTuiFixture>>;
+  marker: string;
+  outputOffset: number;
+}) {
+  const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+  for (; Date.now() < deadline; await sleep(25)) {
+    const entries = await readFixtureLog(params.fixture.logPath);
+    const output = params.fixture.run.visibleOutput().slice(params.outputOffset);
+    if (
+      markerSends(entries, params.marker).length > 0 ||
+      output.includes("local runtime not ready — message not sent")
+    ) {
+      return { entries, output };
+    }
+  }
+  throw new Error("TUI neither blocked nor sent the submitted marker");
+}
+
+afterEach(async () => {
+  await disposeActiveTuiFixtures();
+});
+
+it("hides a stale approval when startup restores the remembered session", async () => {
+  const stateDir = tempDirs.make("openclaw-tui-identity-");
+  await seedRememberedSession(stateDir);
   const fixture = await startTuiFixture({
     env: {
       OPENCLAW_STATE_DIR: stateDir,
@@ -54,6 +101,256 @@ it("hides a stale approval when startup restores the remembered session", async 
     );
 
     expect(rows.join("\n")).not.toContain("workspace skill approval");
+  } finally {
+    await fixture.cleanup();
+  }
+}, 65_000);
+
+it("keeps startup input editable until the remembered session and history are stable", async () => {
+  const stateDir = tempDirs.make("openclaw-tui-startup-session-");
+  const marker = "startup remembered session proof";
+  await seedRememberedSession(stateDir);
+  const fixture = await startTuiFixture({
+    env: {
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
+      OPENCLAW_TUI_PTY_RESTORE_DELAY_MS: "400",
+    },
+  });
+
+  try {
+    await fixture.waitForLogEntry(
+      (entry) =>
+        entry.method === "listSessions" &&
+        objectFieldEquals(entry, "search", REMEMBERED_SESSION_KEY),
+      STARTUP_TIMEOUT_MS,
+    );
+    const outputOffset = fixture.run.visibleOutput().length;
+    await fixture.run.write(`${marker}\r`, { delay: false });
+    const decision = await waitForSubmitDecision({ fixture, marker, outputOffset });
+    expect(markerSends(decision.entries, marker).map((entry) => entry.payload)).toEqual([]);
+    expect(decision.output).toContain("local runtime not ready — message not sent");
+    const rows = await waitForSynchronizedFrameRows(
+      fixture.run,
+      (frame) =>
+        frame.some((row) => row.includes("session picker-target")) &&
+        frame.some((row) => row.includes("local ready")) &&
+        frame.some((row) => row.includes(marker)),
+      STARTUP_TIMEOUT_MS,
+    );
+    expect(rows.join("\n")).toContain(marker);
+    expect(markerSends(await readFixtureLog(fixture.logPath), marker)).toHaveLength(0);
+
+    await fixture.run.write("\r", { delay: false });
+    const sent = await fixture.waitForLogEntry(
+      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", marker),
+      STARTUP_TIMEOUT_MS,
+    );
+    expect(sent.payload).toMatchObject({ sessionKey: REMEMBERED_SESSION_KEY });
+    expect(markerSends(await readFixtureLog(fixture.logPath), marker)).toHaveLength(1);
+  } finally {
+    await fixture.cleanup();
+  }
+}, 65_000);
+
+it("keeps input editable while remembered startup history is loading", async () => {
+  const stateDir = tempDirs.make("openclaw-tui-startup-history-");
+  const marker = "startup remembered history proof";
+  await seedRememberedSession(stateDir);
+  const fixture = await startTuiFixture({
+    env: {
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
+      OPENCLAW_TUI_PTY_STARTUP_DELAY_MS: "400",
+    },
+  });
+
+  try {
+    await fixture.waitForLogEntry(
+      (entry) =>
+        entry.method === "loadHistory" &&
+        objectFieldEquals(entry, "sessionKey", REMEMBERED_SESSION_KEY),
+      STARTUP_TIMEOUT_MS,
+    );
+    const outputOffset = fixture.run.visibleOutput().length;
+    await fixture.run.write(`${marker}\r`, { delay: false });
+    const decision = await waitForSubmitDecision({ fixture, marker, outputOffset });
+    expect(markerSends(decision.entries, marker).map((entry) => entry.payload)).toEqual([]);
+    expect(decision.output).toContain("local runtime not ready — message not sent");
+    await waitForSynchronizedFrameRows(
+      fixture.run,
+      (frame) =>
+        frame.some((row) => row.includes("session picker-target")) &&
+        frame.some((row) => row.includes("local ready")) &&
+        frame.some((row) => row.includes(marker)),
+      STARTUP_TIMEOUT_MS,
+    );
+
+    await fixture.run.write("\r", { delay: false });
+    const sent = await fixture.waitForLogEntry(
+      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", marker),
+      STARTUP_TIMEOUT_MS,
+    );
+    expect(sent.payload).toMatchObject({ sessionKey: REMEMBERED_SESSION_KEY });
+    expect(markerSends(await readFixtureLog(fixture.logPath), marker)).toHaveLength(1);
+  } finally {
+    await fixture.cleanup();
+  }
+}, 65_000);
+
+it("keeps reconnect input editable until restored history is stable", async () => {
+  const stateDir = tempDirs.make("openclaw-tui-reconnect-session-");
+  const marker = "reconnect remembered session proof";
+  await seedRememberedSession(stateDir);
+  const fixture = await startTuiFixture({
+    env: {
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
+      OPENCLAW_TUI_PTY_DISCONNECT_REASON: "fixture transport loss",
+      OPENCLAW_TUI_PTY_RECONNECT_HISTORY_DELAY_MS: "400",
+    },
+  });
+
+  try {
+    await fixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+    await fixture.run.write("/gateway-status\r", { delay: false });
+    await fixture.waitForLogEntry(
+      (entry) => entry.method === "reconnectHistoryPending",
+      STARTUP_TIMEOUT_MS,
+    );
+    const outputOffset = fixture.run.visibleOutput().length;
+    await fixture.run.write(`${marker}\r`, { delay: false });
+    const decision = await waitForSubmitDecision({ fixture, marker, outputOffset });
+    expect(markerSends(decision.entries, marker).map((entry) => entry.payload)).toEqual([]);
+    expect(decision.output).toContain("local runtime not ready — message not sent");
+    const rows = await waitForSynchronizedFrameRows(
+      fixture.run,
+      (frame) =>
+        frame.some((row) => row.includes("gateway reconnected after transport loss")) &&
+        frame.some((row) => row.includes(marker)),
+      STARTUP_TIMEOUT_MS,
+    );
+    expect(rows.join("\n")).toContain(marker);
+    expect(markerSends(await readFixtureLog(fixture.logPath), marker)).toHaveLength(0);
+
+    await fixture.run.write("\r", { delay: false });
+    const sent = await fixture.waitForLogEntry(
+      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", marker),
+      STARTUP_TIMEOUT_MS,
+    );
+    expect(sent.payload).toMatchObject({ sessionKey: REMEMBERED_SESSION_KEY });
+    expect(markerSends(await readFixtureLog(fixture.logPath), marker)).toHaveLength(1);
+  } finally {
+    await fixture.cleanup();
+  }
+}, 65_000);
+
+it("keeps an explicit launch session authoritative over remembered state", async () => {
+  const stateDir = tempDirs.make("openclaw-tui-explicit-session-");
+  const explicitSession = "agent:main:explicit-target";
+  const marker = "explicit startup session proof";
+  await seedRememberedSession(stateDir);
+  const fixture = await startTuiFixture({
+    env: {
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
+      OPENCLAW_TUI_PTY_SESSION: explicitSession,
+    },
+  });
+
+  try {
+    await fixture.run.waitForOutput("session explicit-target", STARTUP_TIMEOUT_MS);
+    await fixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+    await fixture.run.write(`${marker}\r`, { delay: false });
+    const sent = await fixture.waitForLogEntry(
+      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", marker),
+      STARTUP_TIMEOUT_MS,
+    );
+    expect(sent.payload).toMatchObject({ sessionKey: explicitSession });
+    const entries = await readFixtureLog(fixture.logPath);
+    expect(
+      entries.some((entry) => objectFieldEquals(entry, "search", REMEMBERED_SESSION_KEY)),
+    ).toBe(false);
+    expect(markerSends(entries, marker)).toHaveLength(1);
+  } finally {
+    await fixture.cleanup();
+  }
+}, 65_000);
+
+it("falls back to the default session when remembered lookup fails", async () => {
+  const stateDir = tempDirs.make("openclaw-tui-restore-failure-");
+  const marker = "restore failure fallback proof";
+  await seedRememberedSession(stateDir);
+  const fixture = await startTuiFixture({
+    env: {
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
+      OPENCLAW_TUI_PTY_RESTORE_FAILURES: "1",
+    },
+  });
+
+  try {
+    await fixture.run.waitForOutput("session main", STARTUP_TIMEOUT_MS);
+    await fixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+    await fixture.run.write(`${marker}\r`, { delay: false });
+    const sent = await fixture.waitForLogEntry(
+      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", marker),
+      STARTUP_TIMEOUT_MS,
+    );
+    expect(sent.payload).toMatchObject({ sessionKey: "main" });
+    expect(markerSends(await readFixtureLog(fixture.logPath), marker)).toHaveLength(1);
+  } finally {
+    await fixture.cleanup();
+  }
+}, 65_000);
+
+it("abandons a stale restore generation without sending or duplicating input", async () => {
+  const stateDir = tempDirs.make("openclaw-tui-restore-generation-");
+  const marker = "restore generation proof";
+  await seedRememberedSession(stateDir);
+  const fixture = await startTuiFixture({
+    env: {
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
+      OPENCLAW_TUI_PTY_RECONNECT_DURING_RESTORE: "1",
+      OPENCLAW_TUI_PTY_RESTORE_DELAY_MS: "400",
+    },
+  });
+
+  try {
+    await fixture.waitForLogEntry(
+      (entry) => entry.method === "restoreReconnect",
+      STARTUP_TIMEOUT_MS,
+    );
+    await waitForLogCount({
+      logPath: fixture.logPath,
+      predicate: (entry) =>
+        entry.method === "listSessions" &&
+        objectFieldEquals(entry, "search", REMEMBERED_SESSION_KEY),
+      count: 2,
+    });
+    const outputOffset = fixture.run.visibleOutput().length;
+    await fixture.run.write(`${marker}\r`, { delay: false });
+    const decision = await waitForSubmitDecision({ fixture, marker, outputOffset });
+    expect(markerSends(decision.entries, marker).map((entry) => entry.payload)).toEqual([]);
+    expect(decision.output).toContain("local runtime not ready — message not sent");
+    await waitForSynchronizedFrameRows(
+      fixture.run,
+      (frame) =>
+        frame.some((row) => row.includes("session picker-target")) &&
+        frame.some((row) => row.includes("local ready")) &&
+        frame.some((row) => row.includes(marker)),
+      STARTUP_TIMEOUT_MS,
+    );
+    expect(markerSends(await readFixtureLog(fixture.logPath), marker)).toHaveLength(0);
+
+    await fixture.run.write("\r", { delay: false });
+    const sent = await fixture.waitForLogEntry(
+      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", marker),
+      STARTUP_TIMEOUT_MS,
+    );
+    expect(sent.payload).toMatchObject({ sessionKey: REMEMBERED_SESSION_KEY });
+    expect(markerSends(await readFixtureLog(fixture.logPath), marker)).toHaveLength(1);
   } finally {
     await fixture.cleanup();
   }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1073,11 +1073,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
     const remembered = await readTuiLastSessionKey({
       scopeKey: buildLastSessionScopeKeyFor(),
     });
-    if (
-      expectedConnectionGeneration !== connectionGeneration ||
-      !state.isConnected ||
-      exitRequested
-    ) {
+    if (expectedConnectionGeneration !== connectionGeneration || exitRequested) {
       return;
     }
     const rememberedSelection = remembered ? resolveSessionSelection(remembered) : null;
@@ -1100,12 +1096,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
         agentId: state.currentAgentId,
       })
       .catch(() => null);
-    if (
-      !sessions ||
-      expectedConnectionGeneration !== connectionGeneration ||
-      !state.isConnected ||
-      exitRequested
-    ) {
+    if (!sessions || expectedConnectionGeneration !== connectionGeneration || exitRequested) {
       return;
     }
     // An abandoned connection must leave restoration eligible for the next handshake.
@@ -1784,7 +1775,6 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       if (!ownsConnection()) {
         return;
       }
-      state.isConnected = true;
       const reconnected = connectionLineage.connect();
       if (reconnected) {
         reconnectStreamingWatchdog();
@@ -1825,6 +1815,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       if (!ownsConnection()) {
         return;
       }
+      state.isConnected = true;
       if (state.activityStatus === "starting up") {
         setActivityStatus("idle");
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users launching the TUI without `--session` could immediately press Enter and silently send to the default `main` session before the remembered session finished restoring. The viewport would then switch to the remembered session, hiding that the message and resulting transcript were stored elsewhere.

## Why This Change Was Made

Connection readiness now remains owned by the existing connection generation until remembered-session selection and history loading settle. Input during that window is visibly rejected and remains editable; no second readiness flag or message queue is introduced.

## User Impact

No-session TUI launches and reconnects cannot send against an unstable session identity. Explicit `--session`, `/session`, `/new`, and `/reset` behavior is unchanged; failed remembered lookup still falls back to `main`.

## Evidence

Pre-fix real PTY/Gateway oracle: delayed `sessions.list` accepted the marker as `agent:tui-pty-validation:main`, then rendered the remembered session header; isolated SQLite contained the marker under `main` only.

Post-fix real PTY/Gateway oracle:

```text
[behavior-evidence] tui-startup-session-gate {"sentKey":"agent:tui-pty-validation:tui-pty-resume-1","headerSession":"agent:tui-pty-validation:tui-pty-resume-1","sqliteRows":[{"sessionKey":"agent:tui-pty-validation:tui-pty-resume-1","eventCount":1}]}
```

Validated:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-session-identity-pty.e2e.test.ts` (7/7)
- targeted isolated live Gateway + real PTY + SQLite test
- full fake-backend PTY shard; one unrelated xAI rendering timeout passed its exact standalone rerun
- `node scripts/check-changed.mjs`
- `pnpm build`
- source-blind behavior validation: all clauses passed
- autoreview: clean, no accepted/actionable findings

Production LOC: +3/-12 (net -9). Tests and test support: +549/-13.
