### PR TITLE
fix(ui): side panel close button works after Board chat hides

### DIFF
--- a/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-sidebar-panel-contract.e2e.test.ts
@@ -3,6 +3,7 @@ import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import {
+  controlUiBundledSettingsStorageKey,
   installMockGateway,
   type ControlUiMockGatewayScenario,
 } from "../test-helpers/control-ui-e2e.ts";
@@ -12,6 +13,8 @@ const suite = createControlUiE2eSuite({
   name: "chat sidebar cold-open invariant",
   startServerBeforeBrowser: true,
 });
+
+const HIDDEN_BOARD_SESSION_KEY = "agent:main:hidden-board-slot";
 
 const ONE_PIXEL_PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nPcAAAAASUVORK5CYII=",
@@ -232,6 +235,38 @@ async function openColdSidebar(page: Page, scenario = coldOpenScenario()) {
   return choices;
 }
 
+async function seedHiddenBoardSlot(page: Page) {
+  const settingsKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+  await page.addInitScript(
+    ({ key, sessionKey }) => {
+      localStorage.setItem(
+        key,
+        JSON.stringify({
+          sessionKey,
+          sidebarSessionLayouts: {
+            [sessionKey]: {
+              columns: [
+                {
+                  id: "side-panel-column",
+                  side: "right",
+                  panels: [{ id: "chat", slot: "chat" }],
+                  activePanelId: "chat",
+                  height: 360,
+                  width: 480,
+                },
+              ],
+              dock: "right",
+              open: true,
+              expanded: false,
+            },
+          },
+        }),
+      );
+    },
+    { key: settingsKey, sessionKey: HIDDEN_BOARD_SESSION_KEY },
+  );
+}
+
 async function readColdOpenOutcome(page: Page): Promise<ColdOpenOutcome> {
   const activePanel = page.locator(".side-panel__panel:not([hidden])");
   await activePanel.waitFor();
@@ -280,6 +315,29 @@ async function readSlotColdOpenOutcome(
 }
 
 suite.define(() => {
+  it("closes a projected-empty side panel when a hidden board tab remains persisted", async () => {
+    const context = await suite.newBrowserContext({ serviceWorkers: "block" });
+    try {
+      const page = await context.newPage();
+      await seedHiddenBoardSlot(page);
+      await installMockGateway(page, {
+        ...coldOpenScenario(),
+        sessionKey: HIDDEN_BOARD_SESSION_KEY,
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await waitForControlUiGatewayReady(page);
+
+      const panel = page.locator(".sidebar-region__right-runtime .side-panel");
+      await panel.locator(".side-panel-empty--selector").waitFor();
+      expect(await panel.locator("wa-tab").count()).toBe(0);
+
+      await panel.getByRole("button", { name: "Close", exact: true }).click();
+      await expect.poll(() => panel.count()).toBe(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("preserves the production header-action shapes for Side chat and Discussion", async () => {
     const context = await suite.newBrowserContext({ serviceWorkers: "block" });
     const page = await context.newPage();

--- a/ui/src/pages/chat/sidebar-layout.ts
+++ b/ui/src/pages/chat/sidebar-layout.ts
@@ -121,7 +121,6 @@ export function closeSlot(layout: SidebarLayout, slot: SidebarSlotId): SidebarLa
     .find((entry) => entry.slot === slot);
   if (panel) {
     removePanel(next, panel.id);
-    next.open = true;
   }
   return next;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clicking the side panel X could leave the empty panel visible when Board chat remained in the stored layout but was hidden from the current Chat view.

## Why This Change Was Made

Slot removal now preserves the panel's existing open/closed state instead of reopening it. Visible final-tab closes still leave the type picker open because those interactions begin from an already-open panel; lifecycle and render-only removals no longer override an explicit close.

The regression formed when the tabbed-panel work in #123874 combined forced-open tab removal with the older Board-chat render projection. Production LOC is `+0/-1`; the browser regression is `+58/-0` test LOC.

AI-assisted: yes. The final diff passed the repository autoreview with no actionable findings.

## User Impact

The side panel X now reliably hides an empty panel and it stays closed across the following render. Existing tab-picker behavior remains unchanged.

Release note: Control UI side panels now close reliably after Board chat is hidden from the current view.

## Evidence

- Red: [AWS Crabbox run `run_6fa75fceef1a`](https://crabbox.openclaw.ai/portal/runs/run_6fa75fceef1a) reproduced the report in Chromium: after clicking X, panel count remained `1` instead of `0`.
- Green: [AWS Crabbox run `run_942ae84ce3e4`](https://crabbox.openclaw.ai/portal/runs/run_942ae84ce3e4) reran the identical focused E2E after the fix and passed.
- Full touched E2E: [run `run_d83cec879bdf`](https://crabbox.openclaw.ai/portal/runs/run_d83cec879bdf), 4/4 tests passed.
- Sibling layout/component tests: [run `run_775ad5a5a006`](https://crabbox.openclaw.ai/portal/runs/run_775ad5a5a006), 32/32 tests passed.
- Changed-scope typecheck/lint/guards: [run `run_ecdb25926737`](https://crabbox.openclaw.ai/portal/runs/run_ecdb25926737), exit 0.
- Targeted formatting: [run `run_86eff1f5e652`](https://crabbox.openclaw.ai/portal/runs/run_86eff1f5e652), clean.
- `git diff --check`: clean.
- Autoreview: clean, no accepted/actionable findings.

### Before: empty panel remains available to close

![Empty side panel before clicking close](https://github.com/user-attachments/assets/7cc40ca3-3780-4501-acd5-6e2e01529ea1)

### After: the same X action removes the panel

![Chat after the side panel closes](https://github.com/user-attachments/assets/1e98cf34-3ed2-4ec1-86f3-c24904242725)
