### PR TITLE
fix: fallback traces omit failed model candidates

### DIFF
--- a/.agents/skills/openclaw-release-validation/SKILL.md
+++ b/.agents/skills/openclaw-release-validation/SKILL.md
@@ -134,7 +134,7 @@ exists. When it does not exist, generate it:
    command and pass condition need separation. Use the literal `{{TEST_ENV}}`
    in generated OCM commands: for example, `ocm @{{TEST_ENV}} -- onboard`,
    `ocm @{{TEST_ENV}} -- tui`, and `ocm @{{TEST_ENV}} -- channels status
-   --probe`. The validator replaces this token with the actual disposable
+--probe`. The validator replaces this token with the actual disposable
    environment name only in each tester's local worksheet. Avoid broad prompts
    that bundle unrelated features or say only to "use," "exercise," or "verify"
    a surface.
@@ -302,7 +302,7 @@ Then give this compact orientation, using the actual worksheet contents:
   condition.
 - **How to leave feedback:** as they test, they should simply tell the agent
   their notes and name the surface (for example, `Models: switching persisted
-  after restart`). The agent adds those notes to that surface's **Testing
+after restart`). The agent adds those notes to that surface's **Testing
   notes** cell. They do not need to edit the file themselves.
 
 Finish with the exit instruction: **You can stop after any amount of testing;

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1837,7 +1837,7 @@ src/agents/embedded-agent-runner/prepared-compaction-runtime.ts	1
 src/agents/embedded-agent-runner/prompt-cache-observability.ts	2
 src/agents/embedded-agent-runner/replay-history.ts	60
 src/agents/embedded-agent-runner/result-fallback-classifier.ts	3
-src/agents/embedded-agent-runner/run-entry.ts	4
+src/agents/embedded-agent-runner/run-entry.ts	3
 src/agents/embedded-agent-runner/run-orchestrator.ts	1
 src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts	5
 src/agents/embedded-agent-runner/run/abortable.ts	2
@@ -2208,7 +2208,7 @@ src/auto-reply/reply/agent-runner-execution.ts	1
 src/auto-reply/reply/agent-runner-failure-reply.ts	1
 src/auto-reply/reply/agent-runner-fallback-candidate.ts	1
 src/auto-reply/reply/agent-runner-memory.ts	8
-src/auto-reply/reply/agent-runner-result-complete.ts	4
+src/auto-reply/reply/agent-runner-result-complete.ts	3
 src/auto-reply/reply/agent-runner-run.ts	1
 src/auto-reply/reply/agent-runner-session-reset.ts	1
 src/auto-reply/reply/agent-runner-trace.ts	1

--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -243,7 +243,7 @@ describe("runEmbeddedAgentEntry", () => {
       const result = await runEmbeddedAgentEntry({
         selection: { cfg, provider: "primary-provider", model: "primary-model" },
         identity: {
-          runId: `run-${behavior}`,
+          runId: "run-shared-fallback",
           agentId: "main",
           sessionId: "session-1",
         },
@@ -278,6 +278,39 @@ describe("runEmbeddedAgentEntry", () => {
             provider,
             model,
             classification: options.isFallbackRetry ? undefined : "empty",
+            meta: options.isFallbackRetry
+              ? {
+                  executionTrace: {
+                    winnerProvider: provider,
+                    winnerModel: model,
+                    attempts: [
+                      {
+                        provider,
+                        model,
+                        result: "same_model_rate_limit",
+                        reason: "rate_limit",
+                      },
+                      { provider, model, result: "success" },
+                    ],
+                    fallbackUsed: false,
+                    runner: "embedded",
+                  },
+                  agentMeta: {
+                    sessionId: "session-1",
+                    provider,
+                    model,
+                    terminalReceipt: {
+                      runId: "run-shared-fallback",
+                      sessionId: "session-1",
+                      turnId: "turn-1",
+                      requested: { provider, model },
+                      effective: { provider, model, responseModel: model },
+                      successfulToolNames: [],
+                      rerouted: false,
+                    },
+                  },
+                }
+              : undefined,
           });
         },
       });
@@ -295,6 +328,38 @@ describe("runEmbeddedAgentEntry", () => {
     expect(channel.result.model).toBe("fallback-model");
     expect(channel.result.attempts).toEqual(command.result.attempts);
     expect(channel.result.terminal).toEqual(command.result.terminal);
+    expect(channel.result.result.meta.executionTrace).toEqual({
+      winnerProvider: "fallback-provider",
+      winnerModel: "fallback-model",
+      attempts: [
+        {
+          provider: "primary-provider",
+          model: "primary-model",
+          result: "candidate_failed",
+          reason: "format",
+        },
+        {
+          provider: "fallback-provider",
+          model: "fallback-model",
+          result: "same_model_rate_limit",
+          reason: "rate_limit",
+        },
+        { provider: "fallback-provider", model: "fallback-model", result: "success" },
+      ],
+      fallbackUsed: true,
+      runner: "embedded",
+    });
+    expect(channel.result.result.meta.agentMeta?.terminalReceipt).toMatchObject({
+      requested: { provider: "primary-provider", model: "primary-model" },
+      effective: { provider: "fallback-provider", model: "fallback-model" },
+      rerouted: true,
+    });
+    expect(channel.result.terminal.metadata.terminalReceipt).toMatchObject({
+      requested: { provider: "primary-provider", model: "primary-model" },
+      effective: { provider: "fallback-provider", model: "fallback-model" },
+      rerouted: true,
+      terminalDisposition: "not-visible",
+    });
     expect(channel.candidateLeases[0]).toBe(channel.candidateLeases[1]);
     expect(state.selectAgentHarness).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -28,7 +28,7 @@ import {
   classifyEmbeddedAgentRunResultForModelFallback,
   mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
 } from "./result-fallback-classifier.js";
-import type { EmbeddedAgentRunResult } from "./types.js";
+import type { EmbeddedAgentRunResult, TraceAttempt } from "./types.js";
 
 type RunEntryCandidateOptions = {
   allowTransientCooldownProbe?: boolean;
@@ -186,6 +186,80 @@ function canAdvanceContextEngineTurn(params: {
   );
 }
 
+function mergeRunEntryExecutionTrace<T extends EmbeddedAgentRunResult>(params: {
+  result: T;
+  outcome: "completed" | "exhausted";
+  provider: string;
+  model: string;
+  requestedProvider: string;
+  requestedModel: string;
+  fallbackAttempts: FallbackAttempt[];
+}): T {
+  const currentTrace = params.result.meta.executionTrace;
+  const winnerProvider =
+    params.outcome === "completed" ? (currentTrace?.winnerProvider ?? params.provider) : undefined;
+  const winnerModel =
+    params.outcome === "completed" ? (currentTrace?.winnerModel ?? params.model) : undefined;
+  const outerAttempts: TraceAttempt[] = params.fallbackAttempts.map((attempt) => ({
+    provider: attempt.provider,
+    model: attempt.model,
+    result: attempt.reason === "timeout" ? "timeout" : "candidate_failed",
+    ...(attempt.reason ? { reason: attempt.reason } : {}),
+    ...(typeof attempt.status === "number" ? { status: attempt.status } : {}),
+  }));
+  const innerAttempts = (currentTrace?.attempts ?? []).filter(
+    (attempt) => attempt.result !== "success",
+  );
+  const winnerAttempt = currentTrace?.attempts?.findLast(
+    (attempt) =>
+      attempt.result === "success" &&
+      attempt.provider === winnerProvider &&
+      attempt.model === winnerModel,
+  );
+  const attempts = [
+    ...outerAttempts,
+    ...innerAttempts,
+    ...(winnerProvider && winnerModel
+      ? [
+          winnerAttempt ?? {
+            provider: winnerProvider,
+            model: winnerModel,
+            result: "success" as const,
+          },
+        ]
+      : []),
+  ];
+  const terminalReceipt = params.result.meta.agentMeta?.terminalReceipt;
+  const requested = { provider: params.requestedProvider, model: params.requestedModel };
+  const agentMeta = terminalReceipt
+    ? {
+        ...params.result.meta.agentMeta,
+        terminalReceipt: {
+          ...terminalReceipt,
+          requested,
+          rerouted:
+            terminalReceipt.rerouted ||
+            terminalReceipt.effective.provider !== requested.provider ||
+            terminalReceipt.effective.model !== requested.model,
+        },
+      }
+    : params.result.meta.agentMeta;
+  return {
+    ...params.result,
+    meta: {
+      ...params.result.meta,
+      agentMeta,
+      executionTrace: {
+        ...currentTrace,
+        winnerProvider,
+        winnerModel,
+        attempts: attempts.length > 0 ? attempts : undefined,
+        fallbackUsed: currentTrace?.fallbackUsed === true || outerAttempts.length > 0,
+      },
+    },
+  };
+}
+
 function buildTerminal(params: {
   result: EmbeddedAgentRunResult;
   fallbackExhausted: boolean;
@@ -209,9 +283,7 @@ function buildTerminal(params: {
       terminalReplyKind: meta.terminalReplyKind,
     });
   const metadata: Record<string, unknown> = { terminalReply };
-  const terminalReceipt = normalizeAgentRunTerminalReceipt(
-    (meta.agentMeta as { terminalReceipt?: unknown } | undefined)?.terminalReceipt,
-  );
+  const terminalReceipt = normalizeAgentRunTerminalReceipt(meta.agentMeta?.terminalReceipt);
   if (terminalReceipt?.runId === params.runId) {
     metadata.terminalReceipt = {
       ...terminalReceipt,
@@ -437,7 +509,7 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
       params.behavior.kind === "command-rpc"
         ? resolveAgentRunAbortLifecycleFields(params.abortSignal)
         : {};
-    const result =
+    const candidateResult =
       abortFields.aborted === true
         ? ({
             ...fallbackResult.result.result,
@@ -447,10 +519,20 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
             },
           } as T)
         : fallbackResult.result.result;
+    const outcome =
+      fallbackResult.outcome === "exhausted" ? ("exhausted" as const) : ("completed" as const);
+    const result = mergeRunEntryExecutionTrace({
+      result: candidateResult,
+      outcome,
+      provider: fallbackResult.provider,
+      model: fallbackResult.model,
+      requestedProvider: params.selection.provider,
+      requestedModel: params.selection.model,
+      fallbackAttempts: fallbackResult.attempts,
+    });
     const settledResult = {
       ...fallbackResult,
-      outcome:
-        fallbackResult.outcome === "exhausted" ? ("exhausted" as const) : ("completed" as const),
+      outcome,
       result,
     };
     const terminal = buildTerminal({

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -318,6 +318,7 @@ describe("prepareEmbeddedRunTerminal run stats", () => {
     assistantTurns?: number;
     bridgeCalls?: { search: number; describe: number; call: number };
     config?: unknown;
+    assistantProvider?: string;
     provider?: string;
     model?: string;
     outerContextTokenMeta?: { contextTokens?: number };
@@ -336,7 +337,7 @@ describe("prepareEmbeddedRunTerminal run stats", () => {
     const model = statsInput.model ?? "cost-model";
     const assistant = {
       ...assistantMessage("stop"),
-      provider,
+      provider: statsInput.assistantProvider ?? provider,
       model,
       ...(statsInput.responseModel ? { responseModel: statsInput.responseModel } : {}),
     };
@@ -494,9 +495,7 @@ describe("prepareEmbeddedRunTerminal run stats", () => {
       },
     });
 
-    expect(
-      (prepared.agentMeta as { terminalReceipt?: Record<string, unknown> }).terminalReceipt,
-    ).toMatchObject({
+    expect(prepared.agentMeta.terminalReceipt).toMatchObject({
       runId: "run-1",
       sessionId: "session-1",
       turnId: "turn-7",
@@ -509,10 +508,22 @@ describe("prepareEmbeddedRunTerminal run stats", () => {
       successfulToolNames: ["exec", "read", "Zeta", "alpha", "zeta"],
       rerouted: true,
     });
-    expect(
-      (prepared.agentMeta as { terminalReceipt?: Record<string, unknown> }).terminalReceipt,
-    ).not.toHaveProperty("terminalDisposition");
+    expect(prepared.agentMeta.terminalReceipt).not.toHaveProperty("terminalDisposition");
     expect(prepared.agentMeta.model).toBe("cost-model");
     expect(prepared.reportedModelRef.model).toBe("cost-model");
+  });
+
+  it("marks a provider-only response route as rerouted", async () => {
+    const prepared = await prepareStats({ assistantProvider: "routed-provider" });
+
+    expect(prepared.agentMeta.terminalReceipt).toMatchObject({
+      requested: { provider: "cost-test-provider", model: "cost-model" },
+      effective: {
+        provider: "routed-provider",
+        model: "cost-model",
+        responseModel: "cost-model",
+      },
+      rerouted: true,
+    });
   });
 });

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.ts
@@ -171,7 +171,10 @@ export function prepareEmbeddedRunTerminal(input: {
         responseModel,
       },
       successfulToolNames,
-      rerouted: responseModel !== input.model,
+      rerouted:
+        reportedModelRef.provider !== input.provider ||
+        reportedModelRef.model !== input.model ||
+        responseModel !== input.model,
     } satisfies Omit<AgentRunTerminalReceipt, "terminalDisposition">,
   });
   // A yielded attempt ends before message_end. Its aborted tool-call assistant,

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../config/sessions/types.js";
 import type { DiagnosticTraceContext } from "../../infra/diagnostic-trace-context.js";
 import type { AcceptedSessionSpawn } from "../accepted-session-spawn.js";
+import type { AgentRunTerminalReceipt } from "../agent-run-terminal-receipt.js";
 import type { AgentRunTerminalReplySnapshot } from "../agent-run-terminal-reply.js";
 import type {
   MessagingToolSend,
@@ -95,6 +96,7 @@ export type EmbeddedAgentMeta = {
   };
   /** Estimated USD cost of the run's accumulated usage. Omitted when the model has no cost data. */
   costUsd?: number;
+  terminalReceipt?: Omit<AgentRunTerminalReceipt, "terminalDisposition">;
 };
 
 export type TraceAttempt = {

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -44,6 +44,13 @@ vi.mock("./models-config.js", async () => {
 const installRunEmbeddedMocks = () => {
   // Install the runner mocks before importing runEmbeddedAgent so the e2e path
   // exercises fallback orchestration without live model/provider calls.
+  vi.doMock("../plugins/runtime.js", () => ({
+    getActivePluginRegistry: () => null,
+    requireActivePluginRegistry: () => ({}),
+  }));
+  vi.doMock("./harness/runtime-plugin.js", () => ({
+    ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+  }));
   installEmbeddedRunnerBaseE2eMocks();
   installEmbeddedRunnerFastRunE2eMocks({
     runEmbeddedAttempt: (params) => runEmbeddedAttemptMock(params),
@@ -69,6 +76,7 @@ type TestRunEmbeddedAgent = (
 ) => ReturnType<ProductionRunEmbeddedAgent>;
 let runEmbeddedAgent: TestRunEmbeddedAgent;
 let runWithModelFallback: typeof import("./model-fallback-runner.js").runWithModelFallback;
+let runEmbeddedAgentEntry: typeof import("./embedded-agent-runner/run-entry.js").runEmbeddedAgentEntry;
 
 beforeAll(async () => {
   vi.resetModules();
@@ -77,6 +85,7 @@ beforeAll(async () => {
     (await import("./embedded-agent-runner/run.js")).runEmbeddedAgent,
   );
   ({ runWithModelFallback } = await import("./model-fallback-runner.js"));
+  ({ runEmbeddedAgentEntry } = await import("./embedded-agent-runner/run-entry.js"));
 });
 
 beforeEach(() => {
@@ -281,6 +290,62 @@ async function runEmbeddedFallback(params: {
   });
 }
 
+async function runEmbeddedEntryFallback(params: {
+  agentDir: string;
+  workspaceDir: string;
+  sessionKey: string;
+  runId: string;
+}) {
+  const cfg = makeConfig();
+  const sessionId = `session:${params.runId}`;
+  return await runEmbeddedAgentEntry({
+    selection: {
+      cfg,
+      provider: "openai",
+      model: "mock-1",
+      agentDir: params.agentDir,
+      manifestPlugins: [],
+    },
+    identity: {
+      runId: params.runId,
+      agentId: "test",
+      sessionId,
+      sessionKey: params.sessionKey,
+    },
+    harness: {
+      workspaceDir: params.workspaceDir,
+      sessionKey: params.sessionKey,
+      preparation: { kind: "direct" },
+      resolveRuntimeOverride: () => undefined,
+      resolveContextEngineHost: (provider, model) => ({
+        id: `embedded-e2e:${provider}/${model}`,
+        label: "embedded runner e2e",
+        capabilities: [],
+      }),
+    },
+    behavior: { kind: "maintenance" },
+    sessionOverride: { kind: "preserve" },
+    runCandidate: (provider, model, options) =>
+      runEmbeddedAgent({
+        sessionId,
+        sessionKey: params.sessionKey,
+        workspaceDir: params.workspaceDir,
+        agentDir: params.agentDir,
+        config: cfg,
+        prompt: "hello",
+        provider,
+        model,
+        authProfileIdSource: "auto",
+        isFinalFallbackAttempt: options.isFinalFallbackAttempt,
+        timeoutMs: 5_000,
+        runId: params.runId,
+        enqueue: async (task) => await task(),
+        contextEngineLogicalTurnLease: options.contextEngineLogicalTurnLease,
+        onContextEngineTurnCandidate: options.onContextEngineTurnCandidate,
+      }),
+  });
+}
+
 function mockPrimaryOverloadedThenFallbackSuccess() {
   mockPrimaryErrorThenFallbackSuccess(OVERLOADED_ERROR_PAYLOAD);
 }
@@ -422,6 +487,50 @@ function expectProviderAttemptCounts(expected: { openai: number; groq: number })
 }
 
 describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
+  it("carries failed outer candidates into the winning execution trace", async () => {
+    await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
+      await writeAuthStore(agentDir);
+      mockPrimaryOverloadedThenFallbackSuccess();
+
+      const result = await runEmbeddedEntryFallback({
+        agentDir,
+        workspaceDir,
+        sessionKey: "agent:test:execution-trace-fallback",
+        runId: "run:execution-trace-fallback",
+      });
+
+      expect(result.result.meta.executionTrace).toMatchObject({
+        winnerProvider: "groq",
+        winnerModel: "mock-2",
+        fallbackUsed: true,
+        runner: "embedded",
+      });
+      expect(result.result.meta.executionTrace?.attempts).toEqual([
+        expect.objectContaining({
+          provider: "openai",
+          model: "mock-1",
+          result: "candidate_failed",
+          reason: "overloaded",
+        }),
+        expect.objectContaining({
+          provider: "groq",
+          model: "mock-2",
+          result: "success",
+        }),
+      ]);
+      expect(result.result.meta.agentMeta?.terminalReceipt).toMatchObject({
+        requested: { provider: "openai", model: "mock-1" },
+        effective: { provider: "groq", model: "mock-2" },
+        rerouted: true,
+      });
+      expect(result.terminal.metadata.terminalReceipt).toMatchObject({
+        requested: { provider: "openai", model: "mock-1" },
+        effective: { provider: "groq", model: "mock-2" },
+        rerouted: true,
+      });
+    });
+  });
+
   it("keeps tool summary on incomplete side-effect terminal results", async () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeAuthStore(agentDir);

--- a/src/auto-reply/reply/agent-runner-result-complete.ts
+++ b/src/auto-reply/reply/agent-runner-result-complete.ts
@@ -2,7 +2,6 @@ import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hasConfiguredModelFallbacks } from "../../agents/agent-scope.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
-import { isCliProvider } from "../../agents/model-selection.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
@@ -26,10 +25,8 @@ import {
   derivePromptSegments,
   type TraceCompletionView,
   type TraceContextManagementView,
-  type TraceExecutionView,
   type TracePromptSegmentView,
   type TraceToolSummaryView,
-  mergeExecutionTrace,
 } from "./agent-runner-trace.js";
 import { appendUsageLine } from "./agent-runner-usage-line.js";
 import {
@@ -83,8 +80,6 @@ export async function completeReplyAgentRun(input: {
   const {
     autoCompactionCount,
     contextTokensUsed,
-    fallbackAttempts,
-    fallbackExhausted,
     modelUsed,
     promptTokens,
     providerUsed,
@@ -158,14 +153,7 @@ export async function completeReplyAgentRun(input: {
     ? undefined
     : (runResult.meta?.finalAssistantRawText ?? runResult.meta?.finalAssistantVisibleText);
   const traceAuthorized = followupRun.run.traceAuthorized === true;
-  const executionTrace = mergeExecutionTrace({
-    fallbackAttempts,
-    executionTrace: runResult.meta?.executionTrace as TraceExecutionView | undefined,
-    provider: providerUsed,
-    model: modelUsed,
-    runner: isCliProvider(providerUsed, cfg) ? "cli" : "embedded",
-    exhausted: fallbackExhausted,
-  });
+  const executionTrace = runResult.meta?.executionTrace;
   const requestShaping = {
     authMode:
       runResult.meta?.requestShaping?.authMode ??

--- a/src/auto-reply/reply/agent-runner-trace.ts
+++ b/src/auto-reply/reply/agent-runner-trace.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { FailoverReason } from "../../agents/failover/signal.js";
 import { deriveContextPromptTokens } from "../../agents/usage.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { readLatestSessionUsageFromTranscriptAsync } from "../../gateway/session-transcript-readers.js";
@@ -132,88 +131,6 @@ function formatKeyValueTraceBlock(
     return undefined;
   }
   return `🔎 ${title}:\n~~~text\n${lines.join("\n")}\n~~~`;
-}
-
-function inferFallbackAttemptResult(attempt: { reason?: FailoverReason; status?: number }): string {
-  if (attempt.reason === "timeout") {
-    return "timeout";
-  }
-  return "candidate_failed";
-}
-
-export function mergeExecutionTrace(params: {
-  fallbackAttempts?: Array<{
-    provider: string;
-    model: string;
-    reason?: FailoverReason;
-    status?: number;
-  }>;
-  executionTrace?: {
-    winnerProvider?: string;
-    winnerModel?: string;
-    attempts?: TraceAttemptView[];
-    fallbackUsed?: boolean;
-    runner?: "embedded" | "cli";
-  };
-  provider?: string;
-  model?: string;
-  runner: "embedded" | "cli";
-  exhausted?: boolean;
-}): TraceExecutionView | undefined {
-  const executionAttempts = params.exhausted
-    ? (params.executionTrace?.attempts ?? []).filter((attempt) => attempt.result !== "success")
-    : (params.executionTrace?.attempts ?? []);
-  const attempts: TraceAttemptView[] = [
-    ...(params.fallbackAttempts ?? []).map((attempt) =>
-      Object.assign(
-        {
-          provider: attempt.provider,
-          model: attempt.model,
-          result: inferFallbackAttemptResult(attempt),
-        },
-        attempt.reason ? { reason: attempt.reason } : {},
-        typeof attempt.status === `number` ? { status: attempt.status } : {},
-      ),
-    ),
-    ...executionAttempts,
-  ];
-  const winnerProvider = params.exhausted
-    ? undefined
-    : (params.executionTrace?.winnerProvider ?? normalizeOptionalString(params.provider));
-  const winnerModel = params.exhausted
-    ? undefined
-    : (params.executionTrace?.winnerModel ?? normalizeOptionalString(params.model));
-  if (
-    winnerProvider &&
-    winnerModel &&
-    !attempts.some(
-      (attempt) =>
-        attempt.provider === winnerProvider &&
-        attempt.model === winnerModel &&
-        attempt.result === "success",
-    )
-  ) {
-    attempts.push({
-      provider: winnerProvider,
-      model: winnerModel,
-      result: "success",
-    });
-  }
-  if (!winnerProvider && !winnerModel && attempts.length === 0) {
-    return undefined;
-  }
-  const fallbackAttemptCount = params.fallbackAttempts?.length ?? 0;
-  const traceFallbackUsed = params.executionTrace?.fallbackUsed;
-  return {
-    winnerProvider,
-    winnerModel,
-    attempts: attempts.length > 0 ? attempts : undefined,
-    fallbackUsed:
-      traceFallbackUsed === true ||
-      fallbackAttemptCount > 0 ||
-      (traceFallbackUsed === undefined && attempts.length > 1),
-    runner: params.executionTrace?.runner ?? params.runner,
-  };
 }
 
 function formatExecutionResultTraceBlock(

--- a/src/auto-reply/reply/agent-runner-trace.ts
+++ b/src/auto-reply/reply/agent-runner-trace.ts
@@ -75,7 +75,7 @@ type TraceAttemptView = {
   status?: number;
 };
 
-export type TraceExecutionView = {
+type TraceExecutionView = {
   winnerProvider?: string;
   winnerModel?: string;
   attempts?: TraceAttemptView[];

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -454,6 +454,7 @@ describe("runReplyAgent media path normalization", () => {
         result: await run(provider, model),
         provider,
         model,
+        attempts: [],
       }),
     );
   });

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -342,6 +342,7 @@ function setupAgentRunnerMocks(): void {
       result: await run(provider, model),
       provider,
       model,
+      attempts: [],
     }),
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an embedded agent that failed on its primary model and succeeded on a configured fallback returned a candidate-local execution trace: the failed primary candidate was omitted and `fallbackUsed` could remain false. Terminal receipts could also report `rerouted: false` when the provider changed but the model ID stayed the same.

## Why This Change Was Made

The outer run-entry boundary now composes the ordered outer candidate failures with the winning candidate's inner retry trace before terminal construction, preserving one success record and one canonical source of trace truth. The downstream auto-reply reconstruction path is removed. Terminal rerouting now compares both provider and model identity, and the outer entry rewrites the receipt's requested route to the original selection while retaining the effective winner.

This is the owning boundary because it uniquely has the original request, complete candidate chain, accepted winner, candidate-local trace, and terminal receipt. Inner retry accounting remains candidate-local. No auth or configuration behavior changes.

## User Impact

Operators and diagnostics now see the complete model fallback chain. Successful fallbacks report `fallbackUsed: true`, include the failed primary candidate, identify the fallback winner once, and expose truthful requested/effective terminal routing even for provider-only reroutes.

Production LOC: +97/-105 (net -8). Tests: +195/-8.

## Evidence

- Pre-fix owner regression failed for the intended reason: the primary candidate was absent and `fallbackUsed` was false.
- Focused owner tests: 89 passed.
- Embedded runner two-candidate regression: 1 passed (`src/agents/model-fallback.run-embedded.e2e.test.ts`).
- Provider-only reroute regression passed (`src/agents/embedded-agent-runner/run/terminal-preparation.test.ts`).
- Isolated real-process Gateway proof passed on Blacksmith Testbox `tbx_01m0be1a8wqvqpgkp28f3eg0pa`: https://github.com/openclaw/openclaw/actions/runs/32190345637
  - private temporary `OPENCLAW_STATE_DIR` and free loopback Gateway port
  - primary `mock-openai/gpt-5.6-luna` produced a rejected blank result
  - fallback `mock-openai/gpt-5.6-luna-alt` produced the visible reply
  - final `executionTrace`: primary `candidate_failed`, fallback `success`, `fallbackUsed: true`, runner `embedded`
  - result and `agent.wait` receipts: requested primary, effective fallback, `rerouted: true`, terminal disposition `visible`
- Type-aware Oxlint passed for changed production and test files.
- Formatting, assertion/max-lines ratchets, and `git diff --check` passed.
- Post-CI Testbox repair proof passed on `tbx_01m0bfqbv02ceahd5qjrq7qgfw`: https://github.com/openclaw/openclaw/actions/runs/32192717321
  - 90 focused auto-reply tests passed
  - production/full-tree unused-export scans passed
  - dependency scan passed
- Initial and post-CI Codex autoreviews: clean, no accepted/actionable findings.
- Exact-head CI passed for `477c731100a6e826296a6be2a08f6fe29afeecf8`: https://github.com/openclaw/openclaw/actions/runs/32195972561

The full local changed/typecheck lane was not usable after an interrupted dependency install left this linked worktree's `node_modules` partially linked; exact-head hosted CI and the repository landing Testbox gate are required before merge.

## Provenance

The outer run-entry unwrapping that discarded outer candidate facts was introduced in #119325 (landed as `5621979a469a`, authored by Vito Cappello, merged by Vincent Koc on 2026-08-07). Candidate-local receipt rerouting was introduced in #119662 (landed as `5a795f4ddacc`, authored by Peter Steinberger, merged by Vincent Koc on 2026-08-07). The defect became visible after execution traces and run-owned terminal receipts were consumed together.

## Alternatives Considered

- Keep repairing the trace in auto-reply consumers: rejected because Gateway lifecycle and other consumers would retain contradictory candidate-local truth.
- Push outer candidate state into the inner embedded loop: rejected because same-candidate retries and outer model selection have different owners and semantics.
- Infer fallback from attempt count: rejected because same-model rate-limit and timeout retries are not model fallbacks.

AI-assisted change; implementation and proof were reviewed against the complete owner/caller/sibling path.
