### PR TITLE
docs(gateway): document cloud-workers settings page and machine picker

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -80,6 +80,8 @@ Keep the token out of repository config and shell arguments.
 
 ## Configuration
 
+Manage profiles in the Control UI under **Settings → Connections → Cloud workers**, or edit `cloudWorkers.profiles` directly in `openclaw.json` — both write the same config keys. The settings page lists each profile's backend, class, lifetime, and idle-stop in plain language, and shows whether it is advertised to `environments.list` or waiting on a Gateway restart. With no profiles configured it explains the feature, links back to this page, and starts the add flow.
+
 Add a profile under `cloudWorkers.profiles` in `openclaw.json`:
 
 ```json
@@ -179,7 +181,7 @@ openclaw gateway call sessions.dispatch \
 
 ### Choose a machine class per session
 
-A worker profile's `settings.class` remains its default. To choose a different size for one new placement, pass `machineClass` with `profileId`:
+A worker profile's `settings.class` remains its default. In the Control UI, selecting a **Cloud · profile** destination in the Place picker reveals a machine section listing the profile's advertised classes, each with a one-line description and the default marked; picking one updates the place chip (for example `hetzner · Fast`) and carries the choice into dispatch. To choose a different size for one new placement over RPC instead, pass `machineClass` with `profileId`:
 
 ```bash
 openclaw gateway call sessions.dispatch \


### PR DESCRIPTION
## What Problem This Solves
`docs/gateway/cloud-workers.md` documented only the JSON/RPC configuration and dispatch paths. The Control UI settings page (Settings → Connections → Cloud workers, #124864) and the New Session place picker's machine-class section — the way most operators will actually use this feature — had no coverage.

## Why This Change Was Made
Per the Model's Experience doctrine: capability that docs don't mention doesn't exist for the user. Verified against current `main` (post the node-transport rewrite in #125288/#125384/#125465/#125787) that both UI surfaces are still present and functionally unchanged before documenting them.

## User Impact
Docs-only. No behavior change.

## Evidence
- Verified `ui/src/pages/cloud-workers/*` and `where-chip.ts` machine-class handling exist on current `main`.
- Verified the settings page's docs link (`CLOUD_WORKERS_DOCS_URL`) targets this exact page.
- Verified the settings nav path: Settings → Connections → Cloud workers, route `/settings/cloud-workers`.
- `git diff --check` clean; `pnpm docs:list` sanity pass.
