### PR TITLE
perf(test): gate Skill Workshop proof capture

### DIFF
--- a/ui/src/e2e/skill-workshop-applied-diff.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-applied-diff.e2e.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser } from "playwright";
+import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
   canRunPlaywrightChromium,
@@ -15,6 +15,7 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/applied-revision-diff");
 
 let browser: Browser;
@@ -59,13 +60,26 @@ function inspectedProposalId(request: MockGatewayRequest): unknown {
   return params.proposalId;
 }
 
+async function screenshot(page: Page, fileName: string): Promise<void> {
+  if (!captureUiProofEnabled) {
+    return;
+  }
+  await page.screenshot({
+    animations: "disabled",
+    fullPage: true,
+    path: path.join(artifactDir, fileName),
+  });
+}
+
 describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
-    await rm(artifactDir, { force: true, recursive: true });
-    await mkdir(artifactDir, { recursive: true });
+    if (captureUiProofEnabled) {
+      await rm(artifactDir, { force: true, recursive: true });
+      await mkdir(artifactDir, { recursive: true });
+    }
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
@@ -82,9 +96,11 @@ describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", 
     const latestBody = "# Deploy review\n\n## Steps\n1. Verify package.\n2. Publish package.";
     const context = await browser.newContext({
       locale: "en-US",
-      recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
+      ...(captureUiProofEnabled
+        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
     });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -127,11 +143,7 @@ describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", 
       expect(new Set(inspectRequests.map(inspectedProposalId))).toEqual(
         new Set([latest.id, previous.id]),
       );
-      await page.screenshot({
-        animations: "disabled",
-        fullPage: true,
-        path: path.join(artifactDir, "01-changes.png"),
-      });
+      await screenshot(page, "01-changes.png");
 
       await page.getByRole("button", { name: "Full body", exact: true }).click();
       await page.getByText("Publish package.", { exact: true }).waitFor();
@@ -139,11 +151,7 @@ describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", 
       expect(await gateway.getRequests("skills.proposals.inspect")).toHaveLength(
         inspectRequests.length,
       );
-      await page.screenshot({
-        animations: "disabled",
-        fullPage: true,
-        path: path.join(artifactDir, "02-full-body.png"),
-      });
+      await screenshot(page, "02-full-body.png");
     } finally {
       await context.close();
     }
@@ -161,9 +169,11 @@ describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", 
     latestLines[scenario.changedIndex] = changedText;
     const context = await browser.newContext({
       locale: "en-US",
-      recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
+      ...(captureUiProofEnabled
+        ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+        : {}),
     });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
@@ -203,11 +213,7 @@ describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", 
       expect((await page.locator(".sw-diff__row--add").count()) > 0).toBe(
         scenario.hasVisibleChange,
       );
-      await page.screenshot({
-        animations: "disabled",
-        fullPage: true,
-        path: path.join(artifactDir, `03-${scenario.label}-change.png`),
-      });
+      await screenshot(page, `03-${scenario.label}-change.png`);
 
       await page.getByRole("button", { name: "Full body", exact: true }).click();
       await expect.poll(() => page.locator(".sw-body-card").textContent()).toContain(changedText);


### PR DESCRIPTION
## What Problem This Solves

The Skill Workshop applied-revision browser test always encoded screenshots and finalized three videos during ordinary CI, even though those artifacts are proof-only and the behavioral assertions already cover the browser, mocked Gateway, DOM, diff, truncation, and request contracts. That made the default test path slower and more CPU-intensive without increasing its assertion coverage.

## Why This Change Was Made

Gate artifact-directory setup, Playwright `recordVideo`, and screenshots behind the existing `OPENCLAW_CAPTURE_UI_PROOF=1` opt-in. Default runs now execute the same three Chromium scenarios and assertions without writing proof artifacts; opt-in runs retain the prior four screenshots and three videos. This is an AI-assisted maintainer test-performance change with no runtime or UI semantic changes.

## User Impact

There is no user-visible or runtime behavior change. Developers and CI get a faster default Skill Workshop E2E run, while maintainers can still request the complete visual proof bundle with `OPENCLAW_CAPTURE_UI_PROOF=1`.

## Evidence

Production LOC: +0/-0. Tests: +26/-20 (net +6).

Controlled same-Testbox A/B on `tbx_01m0bb2ra75dv06h0nybyx8681`, excluding one warmup and retaining two samples per side, with one worker, distinct filesystem module caches, import diagnostics, and `/usr/bin/time -v`: https://github.com/openclaw/openclaw/actions/runs/32185863969. Delegated Testbox commands completed successfully; the linked Actions host run later shows canceled during external lease cleanup after the Testbox was stopped.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Wall | 9.10s | 8.34s | -0.76s / -8.35% |
| Vitest | 8.745s | 7.95s | -9.09% |
| Test body | 3.89s | 3.30s | -15.17% |
| Imports | 174ms | 166ms | -4.60% |
| User CPU | baseline | measured | -19.36% |
| System CPU | baseline | measured | -13.51% |
| Maximum RSS | baseline | measured | +0.71% |
| Wall spread | 1.40s | 0.40s | tightened by 1.00s |

- Default run: 3/3 passing; proof artifact directory absent.
- Proof-enabled run: 3/3 passing; four non-empty PNGs and three non-empty videos. All four screenshots were visually inspected and correct; none were uploaded because runtime/UI behavior is unchanged.
- Fault injection: making the compact latest body equal the previous body failed on the missing `.sw-diff__row--add` assertion. The exact file was restored; both truncation cases passed.
- Same-Testbox changed gate: `coreTests`; conflict, max-lines, assertion, changelog, doctor, wildcard, duplicate, coercion, dependency, package, dead-code, temp-file, i18n, typecheck, lint, and format gates passed. Focused UI E2E: 3/3 passed. `git diff --check` passed.
- Fresh post-rebase autoreview: clean, 0.99, no accepted/actionable findings.
- Screenshots: N/A for the PR because runtime/UI behavior is unchanged; proof artifacts remain opt-in and were not uploaded.
- Changelog: N/A; test-only performance change.
