### PR TITLE
fix(ui): identify the signed-in user in owner filters

### DIFF
--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -65,6 +65,7 @@ function renderSidebarOwnerFilter(
   owners: readonly SessionOwnerOption[],
   ownerFilterId: string | null,
   involvingMe: boolean,
+  selfOwnerId: string | null,
 ) {
   if (owners.length === 0) {
     return nothing;
@@ -86,7 +87,10 @@ function renderSidebarOwnerFilter(
       renderSidebarMenuRadioItem({
         value: `owner:${owner.id}`,
         checked: ownerFilterId === owner.id,
-        label: owner.label ?? owner.id,
+        label:
+          owner.id === selfOwnerId
+            ? t("sessionsView.ownerYou", { name: owner.label ?? owner.id })
+            : (owner.label ?? owner.id),
         owner,
       }),
     )}
@@ -193,6 +197,7 @@ export function renderSidebarCatalogViewMenu(params: {
   owners: readonly SessionOwnerOption[];
   ownerFilterId: string | null;
   involvingMe: boolean;
+  selfOwnerId: string | null;
   onGroupingChange: (grouping: CatalogProjectGrouping) => void;
   onOwnerFilterChange: (ownerId: string | null, involvingMe?: boolean) => void;
   onHide: () => void;
@@ -244,7 +249,12 @@ export function renderSidebarCatalogViewMenu(params: {
               label: option.label,
             }),
           )}
-          ${renderSidebarOwnerFilter(params.owners, params.ownerFilterId, params.involvingMe)}
+          ${renderSidebarOwnerFilter(
+            params.owners,
+            params.ownerFilterId,
+            params.involvingMe,
+            params.selfOwnerId,
+          )}
           <div class="session-menu__separator" role="separator"></div>
           <wa-dropdown-item class="sidebar-session-sort-menu__item" value="hide-catalog">
             <span class="session-menu__text">${t("chat.sidebar.hideFromSidebar")}</span>
@@ -267,6 +277,7 @@ export function renderSidebarSessionSortMenu(params: {
   owners: readonly SessionOwnerOption[];
   ownerFilterId: string | null;
   involvingMe: boolean;
+  selfOwnerId: string | null;
   onGroupingChange: (grouping: SidebarSessionsGrouping) => void;
   onSortModeChange: (mode: SidebarSessionSortMode) => void;
   onStatusFilterChange: (statusFilter: SidebarSessionStatusFilter) => void;
@@ -353,7 +364,12 @@ export function renderSidebarSessionSortMenu(params: {
                     : t("sessionsView.all"),
             }),
           )}
-          ${renderSidebarOwnerFilter(params.owners, params.ownerFilterId, params.involvingMe)}
+          ${renderSidebarOwnerFilter(
+            params.owners,
+            params.ownerFilterId,
+            params.involvingMe,
+            params.selfOwnerId,
+          )}
           <div class="session-menu__separator" role="separator"></div>
           <wa-dropdown-item
             class="sidebar-session-sort-menu__item"

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -51,7 +51,7 @@ import {
 import type { SidebarWorkboardBoard } from "./app-sidebar-workboard.ts";
 import { resolveCloudWorkerStopAction } from "./cloud-worker-stop.ts";
 import type { SessionAttentionController } from "./session-attention-controller.ts";
-import type { SessionOwnerOption } from "./session-owner-chip.ts";
+import { listAssignableSessionOwners, type SessionOwnerOption } from "./session-owner-chip.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
 
@@ -628,13 +628,23 @@ export function applySidebarSessionOwnerFilter(input: {
   projected: SidebarRecentSession[];
   ownerFacet: SessionsListResult["owners"];
   selectedOwnerId: string | null;
+  self?: { id: string; name?: string; avatarUrl?: string } | null;
 }): {
   rows: SidebarRecentSession[];
   ownerOptions: readonly SessionOwnerOption[];
   ownershipVisible: boolean;
   activeOwnerId: string | null;
 } {
-  const ownerOptions = input.ownerFacet ?? [];
+  const facetOwners = input.ownerFacet ?? [];
+  const selfId = input.self?.id;
+  const selfOwner = selfId
+    ? listAssignableSessionOwners({ facet: facetOwners, self: input.self }).find(
+        (owner) => owner.type === "human" && owner.id === selfId,
+      )
+    : undefined;
+  const ownerOptions = selfOwner
+    ? [selfOwner, ...facetOwners.filter((owner) => owner.id !== selfOwner.id)]
+    : facetOwners;
   let hasParticipants = false;
   if (ownerOptions.length < 2) {
     const pending = [...input.projected];

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -189,18 +189,13 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
   override updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);
     const selectedId = this.sessionOwnerFilterId;
-    const selectedResult = this.selectedAgentSessionResult();
-    const owners = selectedResult?.owners;
-    const hasParticipants = selectedResult?.sessions.some(
-      (session) => (session.participantCount ?? 0) > 0,
-    );
     if (this.sessionSortMode === "people" && this.sessionPeopleSortCapability() === false) {
       this.setSessionSortMode("created");
     }
     if (
       selectedId &&
-      owners &&
-      ((!hasParticipants && owners.length < 2) || !owners.some((owner) => owner.id === selectedId))
+      (!this.sessionOwnershipVisible ||
+        !this.sessionOwnerOptions.some((owner) => owner.id === selectedId))
     ) {
       this.sessionOwnerFilterId = null;
       void this.context?.sessions.setOwnerFilter(null);
@@ -252,6 +247,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       projected,
       ownerFacet,
       selectedOwnerId: this.sessionOwnerFilterId,
+      self: this.context?.gateway.snapshot.selfUser,
     });
     this.sessionOwnerOptions = result.ownerOptions;
     this.sessionOwnershipVisible = result.ownershipVisible;

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -379,6 +379,7 @@ export function renderSidebarSessionSortMenuForController(controller: SidebarMen
     owners: host.sessionOwnershipVisible ? host.sessionOwnerOptions : [],
     ownerFilterId: host.sessionOwnerFilterActive ? host.sessionOwnerFilterId : null,
     involvingMe: host.sessionInvolvingMeFilterActive,
+    selfOwnerId: host.sessionDataContext?.gateway.snapshot.selfUser?.id ?? null,
     onGroupingChange: (grouping) => {
       host.sessionOrganizer.setSessionsGrouping(grouping);
       controller.closeSessionSortMenu({ restoreFocus: true });
@@ -426,6 +427,7 @@ export function renderSidebarCatalogViewMenuForController(controller: SidebarMen
     owners: host.sessionOwnershipVisible ? host.sessionOwnerOptions : [],
     ownerFilterId: host.sessionOwnerFilterActive ? host.sessionOwnerFilterId : null,
     involvingMe: host.sessionInvolvingMeFilterActive,
+    selfOwnerId: host.sessionDataContext?.gateway.snapshot.selfUser?.id ?? null,
     onGroupingChange: (grouping) => {
       host.setCatalogProjectGrouping(grouping);
       controller.closeCatalogViewMenu({ restoreFocus: true });

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -116,6 +116,15 @@ suite.define(() => {
     const gateway = await installMockGateway(currentPage, {
       hasMultipleSessionSharingIdentities: true,
       sessionKey: "agent:main:ada",
+      presenceUsers: [
+        {
+          self: true,
+          id: "profile-patrick",
+          name: "Patrick",
+          avatarUrl:
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=",
+        },
+      ],
       historyMessages: [{ role: "assistant", content: [{ type: "text", text: "Ready." }] }],
       methodResponses: { "sessions.list": sessionsList(["profile-ada", "profile-bob"]) },
     });
@@ -129,6 +138,11 @@ suite.define(() => {
 
     const ownerMenu = await openSidebarSortMenu(currentPage);
     await ownerMenu.locator('[value="sort:people"]').waitFor();
+    const ownerRows = ownerMenu.locator('wa-dropdown-item[value^="owner:"]:not([value="owner:"])');
+    await expectBrowser(ownerRows).toHaveCount(3);
+    await expectBrowser(ownerRows.first()).toHaveAttribute("value", "owner:profile-patrick");
+    await expectBrowser(ownerRows.first()).toContainText("Patrick (You)");
+    await expectBrowser(ownerRows.first().locator("openclaw-session-owner-chip")).toHaveText("P");
     await captureUiProof(currentPage, "00-people-sort-available.png");
     await ownerMenu.evaluate((element) =>
       element.dispatchEvent(

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -947,6 +947,7 @@ export const en: TranslationMap = {
     owners: "Owners",
     allOwners: "All owners",
     involvingMe: "Involving me",
+    ownerYou: "{name} (You)",
     withParticipant: "with {name}",
     withMoreParticipants: "+{count} more",
     assignToMe: "Assign to me",

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
@@ -251,6 +251,42 @@ describe("AppSidebar session ownership", () => {
     expect(harness.setOwnerFilter).toHaveBeenLastCalledWith(null);
   });
 
+  it("shows the authenticated user first in the owner filter", async () => {
+    const gateway = createGatewayHarness({} as GatewayBrowserClient);
+    gateway.publish({
+      selfUser: {
+        id: "profile-patrick",
+        name: "Patrick",
+        avatarUrl: "/api/users/profile-patrick/avatar",
+      },
+    });
+    const harness = createSessionsHarness("main", ["agent:main:main"]);
+    const result = harness.sessions.state.result;
+    if (!result) {
+      throw new Error("expected session list");
+    }
+    result.owners = [
+      { type: "human", id: "profile-ayaan", label: "Ayaan" },
+      { type: "human", id: "profile-colin", label: "Colin" },
+    ];
+
+    const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
+    harness.publishList({ result, agentId: "main" });
+    await sidebar.updateComplete;
+
+    const menu = await openOwnerMenu(sidebar);
+    const ownerRows = [
+      ...menu.querySelectorAll<HTMLElement>('wa-dropdown-item[value^="owner:"]'),
+    ].filter((row) => row.getAttribute("value") !== "owner:");
+    expect(ownerRows.map((row) => row.getAttribute("value"))).toEqual([
+      "owner:profile-patrick",
+      "owner:profile-ayaan",
+      "owner:profile-colin",
+    ]);
+    expect(ownerRows[0]?.querySelector(".session-menu__text")?.textContent).toBe("Patrick (You)");
+    expect(ownerRows[0]?.querySelector("openclaw-session-owner-chip")).not.toBeNull();
+  });
+
   it("shows and requests Involving me for a participant session", async () => {
     // SAFETY: this sidebar fixture only needs the Gateway client surface supplied by its harness.
     const gateway = createGatewayHarness({} as GatewayBrowserClient);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where authenticated users opening the session owner filter could not identify their own row. The signed-in user stayed in the server-provided alphabetical order, or could be absent when they did not own a currently listed session.

## Why This Change Was Made

The sidebar now joins the authoritative authenticated profile into its owner options, pins that profile ahead of the other avatar rows, and renders the localized label as `Name (You)`. Identity data remains unchanged so avatar initials and profile pictures do not inherit the suffix. The shared projection covers both the global session filter and catalog filter without protocol, config, or storage changes.

AI-assisted. Production LOC: +37/-12 (net +25) for the authenticated-profile join and the two shared menu consumers. Tests: +50/-0.

## User Impact

People can immediately recognize themselves in the owner picker. Their own profile is the first avatar row and is explicitly labeled, while all existing owner and “Involving me” filters keep their current behavior.

## Evidence

### Before

![Owner filter before](https://github.com/user-attachments/assets/6a118028-7839-4c2a-b763-29226bbf970a)

### After

![Owner filter after](https://github.com/user-attachments/assets/fb718702-456b-40a4-8503-efff47dc7c88)

- Pre-fix regression reproduced: the focused sidebar test failed because `profile-patrick` was missing before the owner-facet repair.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/components/app-sidebar-session-navigation-logic.test.ts` — 299 passed.
- AWS Crabbox browser proof `run_bd24c37bc4a0` — focused Playwright owner-filter scenario passed; screenshot inspected; lease released.
- `node scripts/check-changed.mjs -- <changed UI files>` — formatting, i18n, core-test/UI typechecks, lint, dependency guards, and repository ratchets passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean, no accepted/actionable findings.
