### PR TITLE
fix(ui): start new chat worktrees from fresh defaults

### DIFF
--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -19,7 +19,7 @@ Each worktree lives at:
 
 The repository fingerprint is the first 16 hexadecimal characters of a SHA-256 hash over the canonical git common directory and origin URL. A supplied name must match `[a-z0-9][a-z0-9-]{0,63}`. Without a name, OpenClaw generates a readable crustacean-themed name such as `brisk-lobster`. Inferred names already occupied by any registered worktree (including the caller's own removed checkout), local branch, or unmanaged path get a numeric suffix such as `brisk-lobster-2`; only a supplied name reuses or restores the caller's existing record.
 
-OpenClaw creates branch `openclaw/<name>` at the requested base ref. Without a base ref, it fetches `origin`, uses the remote default branch when available, and falls back to local `HEAD` when the repository is offline or has no usable remote.
+OpenClaw creates branch `openclaw/<name>` at the requested base ref. Without a base ref, a repository without `origin` uses local `HEAD`. When `origin` exists, OpenClaw fetches it, refreshes its default branch, and uses that branch. If `origin` is unreachable or has no usable default branch, creation fails with guidance to retry or choose an explicit local base.
 
 ## Provision ignored files
 

--- a/src/agents/worktrees/base-ref.test.ts
+++ b/src/agents/worktrees/base-ref.test.ts
@@ -1,0 +1,83 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resolveWorktreeBase } from "./base-ref.js";
+
+const execFileAsync = promisify(execFile);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  return stdout.trim();
+}
+
+describe("resolveWorktreeBase", () => {
+  let root: string;
+  let repo: string;
+
+  beforeEach(async () => {
+    root = tempDirs.make("openclaw-worktree-base-");
+    repo = path.join(root, "repo");
+    await fs.mkdir(repo);
+    await git(repo, "init", "-b", "main");
+    await git(repo, "config", "user.name", "OpenClaw Test");
+    await git(repo, "config", "user.email", "openclaw-test@example.invalid");
+    await fs.writeFile(path.join(repo, "README.md"), "base\n");
+    await git(repo, "add", "README.md");
+    await git(repo, "commit", "-m", "initial");
+  });
+
+  it("uses local HEAD when the repository has no origin", async () => {
+    await expect(resolveWorktreeBase(repo)).resolves.toEqual({
+      gitOperand: "HEAD",
+      recordRef: "HEAD",
+      remote: false,
+    });
+  });
+
+  it("fails visibly when origin cannot be refreshed", async () => {
+    await git(repo, "remote", "add", "origin", path.join(root, "missing.git"));
+    await expect(resolveWorktreeBase(repo)).rejects.toThrow(
+      /git fetch origin.*choose a base branch explicitly/s,
+    );
+  });
+
+  it("refreshes origin HEAD when the remote default branch changes", async () => {
+    const remote = path.join(root, "remote.git");
+    await execFileAsync("git", ["clone", "--bare", repo, remote]);
+    await git(repo, "remote", "add", "origin", remote);
+
+    await expect(resolveWorktreeBase(repo)).resolves.toEqual({
+      gitOperand: "origin/main",
+      recordRef: "origin/main",
+      remote: true,
+    });
+
+    await git(repo, "branch", "next");
+    await git(repo, "push", "origin", "next");
+    await git(remote, "symbolic-ref", "HEAD", "refs/heads/next");
+
+    await expect(resolveWorktreeBase(repo)).resolves.toEqual({
+      gitOperand: "origin/next",
+      recordRef: "origin/next",
+      remote: true,
+    });
+    await expect(git(repo, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")).resolves.toBe(
+      "origin/next",
+    );
+  });
+
+  it("fails visibly when origin has no default branch", async () => {
+    const remote = path.join(root, "remote.git");
+    await execFileAsync("git", ["clone", "--bare", repo, remote]);
+    await git(remote, "symbolic-ref", "HEAD", "refs/heads/missing");
+    await git(repo, "remote", "add", "origin", remote);
+
+    await expect(resolveWorktreeBase(repo)).rejects.toThrow(
+      "Set origin/HEAD or choose a base branch explicitly",
+    );
+  });
+});

--- a/src/agents/worktrees/base-ref.ts
+++ b/src/agents/worktrees/base-ref.ts
@@ -48,18 +48,43 @@ export async function resolveWorktreeBase(
     }
     return { gitOperand, recordRef: baseRef, remote: false };
   }
-  const fetched = await runGit(repoRoot, ["fetch", "origin"]);
-  if (fetched.code === 0) {
-    const remoteHead = await runGit(repoRoot, [
-      "symbolic-ref",
-      "--quiet",
-      "--short",
-      "refs/remotes/origin/HEAD",
-    ]);
-    if (remoteHead.code === 0 && remoteHead.stdout.trim()) {
-      const remoteRef = remoteHead.stdout.trim();
-      return { gitOperand: remoteRef, recordRef: remoteRef, remote: true };
-    }
+
+  const origin = await runGit(repoRoot, ["config", "--get", "remote.origin.url"]);
+  if (origin.code === 1 || !origin.stdout.trim()) {
+    return { gitOperand: "HEAD", recordRef: "HEAD", remote: false };
   }
-  return { gitOperand: "HEAD", recordRef: "HEAD", remote: false };
+  if (origin.code !== 0) {
+    throw commandError("git config --get remote.origin.url", origin);
+  }
+
+  const fetched = await runGit(repoRoot, ["fetch", "origin"]);
+  if (fetched.code !== 0) {
+    const cause = commandError("git fetch origin", fetched);
+    throw new Error(
+      `${cause.message}\nRetry when origin is reachable or choose a base branch explicitly to use local state.`,
+      { cause },
+    );
+  }
+
+  const refreshedHead = await runGit(repoRoot, ["remote", "set-head", "origin", "--auto"]);
+  if (refreshedHead.code !== 0) {
+    const cause = commandError("git remote set-head origin --auto", refreshedHead);
+    throw new Error(`${cause.message}\nSet origin/HEAD or choose a base branch explicitly.`, {
+      cause,
+    });
+  }
+
+  const remoteHead = await runGit(repoRoot, [
+    "symbolic-ref",
+    "--quiet",
+    "--short",
+    "refs/remotes/origin/HEAD",
+  ]);
+  const remoteRef = remoteHead.stdout.trim();
+  if (remoteHead.code !== 0 || !remoteRef) {
+    throw new Error(
+      "origin has no default branch. Set origin/HEAD or choose a base branch explicitly.",
+    );
+  }
+  return { gitOperand: remoteRef, recordRef: remoteRef, remote: true };
 }

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -413,14 +413,7 @@ describe("ManagedWorktreeService", () => {
     expect(await git(created.path, "branch", "--show-current")).toBe("openclaw/concurrent");
   });
 
-  it("falls back to local HEAD when fetch fails", async () => {
-    await git(repo, "remote", "add", "origin", path.join(root, "missing.git"));
-    const created = await service.create({ repoRoot: repo, name: "offline" });
-    expect(created.baseRef).toBe("HEAD");
-    expect(await fs.readFile(path.join(created.path, "README.md"), "utf8")).toBe("base\n");
-  });
-
-  it("retries worktree add from local HEAD when the resolved remote base is stale", async () => {
+  it("does not replace a failed remote checkout with local HEAD", async () => {
     await addRemote(root, repo);
     const blob = await git(repo, "rev-parse", "HEAD:README.md");
     const tooLongForCheckout = "x".repeat(300);
@@ -431,9 +424,11 @@ describe("ManagedWorktreeService", () => {
     );
     const remoteCommit = await git(repo, "commit-tree", tree, "-p", "HEAD", "-m", "bad remote");
     await git(repo, "push", "--force", "origin", `${remoteCommit}:refs/heads/main`);
-    const created = await service.create({ repoRoot: repo, name: "stale-remote" });
-    expect(created.baseRef).toBe("HEAD");
-    expect(await git(created.path, "rev-parse", "HEAD")).toBe(await git(repo, "rev-parse", "HEAD"));
+    await expect(service.create({ repoRoot: repo, name: "stale-remote" })).rejects.toThrow(
+      "git worktree add",
+    );
+    expect(await git(repo, "branch", "--list", "openclaw/stale-remote")).toBe("");
+    expect(await git(repo, "worktree", "list", "--porcelain")).not.toContain("stale-remote");
   });
 
   it("preserves a pre-existing branch when a managed name collides", async () => {

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -255,7 +255,7 @@ async function cleanupFailedCreate(repoRoot: string, worktreePath: string, branc
   }
 }
 
-async function resetFailedWorktreeAdd(
+async function cleanupFailedWorktreeAdd(
   repoRoot: string,
   worktreePath: string,
   branch: string,
@@ -284,7 +284,7 @@ async function resetFailedWorktreeAdd(
   await requireGit(repoRoot, ["worktree", "prune"]);
 }
 
-async function canResetFailedWorktreeAdd(
+async function canCleanupFailedWorktreeAdd(
   repoRoot: string,
   worktreePath: string,
   branch: string,
@@ -683,10 +683,8 @@ export class ManagedWorktreeService {
     const base = await resolveWorktreeBase(repository.repoRoot, params.baseRef);
     params.commitGuard?.();
     await fs.mkdir(root, { recursive: true });
-    let gitBase = base.gitOperand;
-    let recordBase = base.recordRef;
     const runRepositorySetup = params.runSetupScript !== false;
-    const worktreeAddArgs = () => [
+    const worktreeAddArgs = [
       ...(runRepositorySetup ? [] : ["-c", `core.hooksPath=${os.devNull}`]),
       "worktree",
       "add",
@@ -694,17 +692,13 @@ export class ManagedWorktreeService {
       branch,
       "--",
       worktreePath,
-      gitBase,
+      base.gitOperand,
     ];
-    let added = await runGit(repository.repoRoot, worktreeAddArgs());
+    const added = await runGit(repository.repoRoot, worktreeAddArgs);
     if (added.code !== 0 && base.remote) {
-      if (!(await canResetFailedWorktreeAdd(repository.repoRoot, worktreePath, branch, added))) {
-        throw commandError("git worktree add", added);
+      if (await canCleanupFailedWorktreeAdd(repository.repoRoot, worktreePath, branch, added)) {
+        await cleanupFailedWorktreeAdd(repository.repoRoot, worktreePath, branch);
       }
-      await resetFailedWorktreeAdd(repository.repoRoot, worktreePath, branch);
-      gitBase = "HEAD";
-      recordBase = "HEAD";
-      added = await runGit(repository.repoRoot, worktreeAddArgs());
     }
     if (added.code !== 0) {
       throw commandError("git worktree add", added);
@@ -732,7 +726,7 @@ export class ManagedWorktreeService {
       repoRoot: repository.repoRoot,
       path: worktreePath,
       branch,
-      baseRef: recordBase,
+      baseRef: base.recordRef,
       ownerKind: params.ownerKind ?? "manual",
       ...(params.ownerId ? { ownerId: params.ownerId } : {}),
       createdAt,

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -2561,6 +2561,8 @@ test("sessions.create reset-in-place detaches the prior worktree permission boun
   await execFileAsync("git", ["init", "--bare", origin]);
   await execFileAsync("git", ["-C", workspace, "remote", "add", "origin", origin]);
   await execFileAsync("git", ["-C", workspace, "push", "-u", "origin", "main"]);
+  await execFileAsync("git", ["-C", origin, "symbolic-ref", "HEAD", "refs/heads/main"]);
+  await execFileAsync("git", ["-C", workspace, "remote", "set-head", "origin", "-a"]);
   closeOpenClawStateDatabaseForTest();
   testState.agentConfig = { workspace, model: { primary: "openai/current-model" } };
   testState.sessionConfig = { dmScope: "main" };

--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -155,8 +155,7 @@ suite.define(() => {
         { locator: page.getByLabel("Crabbox binary"), value: "/opt/bin/crabbox" },
       ]);
       const saveButton = page.getByRole("button", { name: "Save" });
-      const configGetCount = (await gateway.getRequests("config.get")).length;
-      await gateway.deferNext("config.get");
+      const configGetCount = await gateway.deferNext("config.get");
       await gateway.emitGatewayEvent("config.changed", {
         path: "/tmp/openclaw.json",
         hash: "cloud-workers-2",

--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -331,7 +331,7 @@ suite.define(() => {
           repoRoot: WORKSPACE,
           path: worktreePath,
           branch: "openclaw/terminal-task",
-          baseRef: "main",
+          baseRef: "origin/main",
           ownerKind: "manual",
           createdAt: 1,
           lastActiveAt: 1,
@@ -358,7 +358,9 @@ suite.define(() => {
       await worktreeButton.waitFor({ state: "visible" });
       const initialBranchRequestCount = (await gateway.getRequests("worktrees.branches")).length;
       await worktreeButton.click();
-      await expect.poll(() => placePopover.getByLabel("Base branch").inputValue()).toBe("main");
+      const baseBranch = placePopover.getByLabel("Base branch");
+      await expect.poll(() => baseBranch.inputValue()).toBe("");
+      expect(await baseBranch.getAttribute("placeholder")).toBe("main");
       await placePopover.getByLabel("Worktree name").fill("terminal-task");
       await page.locator("#new-session-detail-trigger").click();
       await page.locator(".new-session-page__message").fill("  inspect the checkout  ");
@@ -378,7 +380,6 @@ suite.define(() => {
       expect(worktreeRequest.params).toEqual({
         repoRoot: WORKSPACE,
         name: "terminal-task",
-        baseRef: "main",
       });
       const terminalRequest = await gateway.waitForRequest("sessions.catalog.startTerminal");
       expect(terminalRequest.params).toEqual({
@@ -897,7 +898,8 @@ suite.define(() => {
       const worktreeItem = placeSelect.getByRole("button", { name: "Worktree" });
       await worktreeItem.click();
       const baseInput = page.getByLabel("Base branch");
-      await expect.poll(() => baseInput.inputValue()).toBe("main");
+      await expect.poll(() => baseInput.inputValue()).toBe("");
+      expect(await baseInput.getAttribute("placeholder")).toBe("main");
       await page.keyboard.press("Escape");
 
       await gateway.deferNext("worktrees.branches");

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -202,10 +202,12 @@ suite.define(() => {
       expect(await page.locator("#new-session-detail-trigger").count()).toBe(0);
       await projectTrigger.click();
       await project.getByText("Advanced", { exact: true }).click();
-      await expect.poll(() => project.getByLabel("Base branch").inputValue()).toBe("main");
-      await project.getByLabel("Base branch").fill("release");
-      await expect.poll(() => project.getByLabel("Base branch").inputValue()).toBe("release");
-      await project.getByLabel("Base branch").fill("main");
+      const baseBranch = project.getByLabel("Base branch");
+      await expect.poll(() => baseBranch.inputValue()).toBe("");
+      expect(await baseBranch.getAttribute("placeholder")).toBe("main");
+      await baseBranch.fill("release");
+      await expect.poll(() => baseBranch.inputValue()).toBe("release");
+      await baseBranch.fill("main");
       await pollLocatorText(project.locator(".new-session-page__menu-note").last()).toContain(
         "Syncs target-repo to the cloud worker",
       );

--- a/ui/src/e2e/new-session-page.place-preferences.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.place-preferences.e2e.test.ts
@@ -21,14 +21,17 @@ const REGISTERED_PROJECT = {
 };
 
 suite.define(() => {
-  it("restores three-chip defaults from local storage without a durable identity", async () => {
+  it.each([
+    ["a legacy base ref without repository identity", "release/local"],
+    ["a base ref bound to another repository", { ref: "release/local", repoRoot: "/srv/other" }],
+  ])("does not restore %s", async (_label, storedBaseRef) => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
     const appUrl = new URL(suite.server.baseUrl);
     const gatewayUrl = `${appUrl.protocol === "https:" ? "wss:" : "ws:"}//${appUrl.host}`;
     const storageKey = `openclaw.new-session.preferences.v1:${gatewayOriginScope(gatewayUrl)}`;
     await page.addInitScript(
-      ({ key, workspace }) => {
+      ({ key, workspace, storedBaseRef: persistedBaseRef }) => {
         localStorage.setItem(
           key,
           JSON.stringify({
@@ -39,14 +42,14 @@ suite.define(() => {
                 where: { kind: "local" },
                 projectId: "registered",
                 worktree: true,
-                baseRef: "release/local",
+                baseRef: persistedBaseRef,
                 worktreeName: "browser-task",
               },
             },
           }),
         );
       },
-      { key: storageKey, workspace: WORKSPACE },
+      { key: storageKey, workspace: WORKSPACE, storedBaseRef },
     );
     const gateway = await installMockGateway(page, {
       workspace: WORKSPACE,
@@ -66,7 +69,8 @@ suite.define(() => {
       await pollLocatorText(project.locator(".new-session-page__trigger-label")).toBe("Registered");
       await expect.poll(() => detail.getAttribute("data-worktree")).toBe("true");
       await detail.click();
-      await expect.poll(() => page.getByLabel("Base branch").inputValue()).toBe("release/local");
+      await expect.poll(() => page.getByLabel("Base branch").inputValue()).toBe("");
+      expect(await page.getByLabel("Base branch").getAttribute("placeholder")).toBe("main");
       await expect.poll(() => page.getByLabel("Worktree name").inputValue()).toBe("browser-task");
       expect(await gateway.getRequests("users.prefs.get")).toHaveLength(0);
       expect(await gateway.getRequests("users.prefs.set")).toHaveLength(0);
@@ -110,7 +114,7 @@ suite.define(() => {
               where: { kind: "cloud", id: "aws" },
               projectId: "registered",
               worktree: true,
-              baseRef: "release/next",
+              baseRef: { ref: "release/next", repoRoot: REGISTERED_PROJECT.repoRoot },
               worktreeName: "identity-task",
             },
           },

--- a/ui/src/e2e/new-session-page.places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places.e2e.test.ts
@@ -312,6 +312,9 @@ suite.define(() => {
       expect(await worktreeItem.isEnabled()).toBe(true);
       await worktreeItem.click();
       await expect.poll(() => detailTrigger.getAttribute("data-worktree")).toBe("true");
+      const baseBranch = detailSelect.getByLabel("Base branch");
+      expect(await baseBranch.inputValue()).toBe("");
+      expect(await baseBranch.getAttribute("placeholder")).toBe("main");
       await page.keyboard.press("Escape");
       await expect.poll(() => detailTrigger.getAttribute("aria-expanded")).toBe("false");
       await expect
@@ -340,9 +343,9 @@ suite.define(() => {
         agentId: "main",
         message: "fix the flaky test",
         worktree: true,
-        worktreeBaseRef: "main",
         cwd: PICKED,
       });
+      expect(createRequest.params).not.toHaveProperty("worktreeBaseRef");
 
       await expect
         .poll(() => new URL(page.url()).pathname)
@@ -455,6 +458,9 @@ suite.define(() => {
         .locator("wa-popover.new-session-page__detail-popover")
         .getByRole("button", { name: "Worktree" })
         .click();
+      const baseBranch = page.getByLabel("Base branch");
+      expect(await baseBranch.inputValue()).toBe("");
+      expect(await baseBranch.getAttribute("placeholder")).toBe("main");
       await captureProjectUiProof(page, "project-selected.png");
       await page.keyboard.press("Escape");
       await page.locator(".new-session-page__message").fill("inspect the project");
@@ -466,8 +472,8 @@ suite.define(() => {
         message: "inspect the project",
         projectId: "recorded-openclaw",
         worktree: true,
-        worktreeBaseRef: "main",
       });
+      expect(create.params).not.toHaveProperty("worktreeBaseRef");
       expect(create.params).not.toHaveProperty("cwd");
       expect(create.params).not.toHaveProperty("execNode");
     } finally {

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -693,8 +693,13 @@ suite.define(() => {
         await expect
           .poll(async () => (await gateway.getRequests("users.prefs.set")).length)
           .toBe(2);
-        expect((await gateway.getRequests("users.prefs.set")).at(-1)?.params).toMatchObject({
-          entries: { "new-session.v1:main": { model: "" } },
+        expect((await gateway.getRequests("users.prefs.set")).at(-1)?.params).toEqual({
+          entries: {
+            "new-session.v1:main": {
+              folder: PICKED,
+              worktree: true,
+            },
+          },
         });
         expect((await readMainPreference(page))?.model).toBe("anthropic/claude-sonnet-4-6");
         await gateway.resolveDeferred("users.prefs.set", { status: "ok" });

--- a/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
@@ -450,7 +450,9 @@ suite.define(() => {
       const detailSelect = page.locator("wa-popover.new-session-page__detail-popover");
       await page.locator("#new-session-detail-trigger").click();
       await detailSelect.getByRole("button", { name: "Worktree" }).click();
-      await expect.poll(() => page.getByLabel("Base branch").inputValue()).toBe("beta");
+      const baseBranch = page.getByLabel("Base branch");
+      await expect.poll(() => baseBranch.inputValue()).toBe("");
+      expect(await baseBranch.getAttribute("placeholder")).toBe("beta");
       await page.keyboard.press("Escape");
 
       await gateway.resolveDeferred("fs.listDir", {

--- a/ui/src/pages/new-session/detail-chip.test.ts
+++ b/ui/src/pages/new-session/detail-chip.test.ts
@@ -42,9 +42,9 @@ describe("Detail chip state", () => {
         state: { label: "Worktree" },
         worktree: true,
         worktreeAvailable: true,
-        branches: { repoRoot: "/repo", branches: [] },
+        branches: { repoRoot: "/repo", branches: [], headBranch: "main" },
         branchesLoading: false,
-        baseRef: "main",
+        baseRef: "",
         worktreeName: "",
         submitting: false,
         pendingCloud: false,
@@ -62,7 +62,12 @@ describe("Detail chip state", () => {
     );
 
     const worktree = container.querySelector<HTMLButtonElement>('[data-value="worktree"]');
+    const baseBranch = container.querySelector<HTMLInputElement>(
+      'input[list="new-session-branches"]',
+    );
     expect(worktree?.disabled).toBe(false);
+    expect(baseBranch?.value).toBe("");
+    expect(baseBranch?.placeholder).toBe("main");
     expect(container.textContent).toContain("Worktree name");
   });
 });

--- a/ui/src/pages/new-session/detail-chip.ts
+++ b/ui/src/pages/new-session/detail-chip.ts
@@ -41,7 +41,9 @@ export function renderWorktreeFields(params: {
         ?disabled=${params.submitting || params.pendingCloud}
         placeholder=${params.branchesLoading
           ? t("common.loading")
-          : (params.branches?.defaultBranch ?? t("newSession.baseBranch"))}
+          : (params.branches?.defaultBranch ??
+            params.branches?.headBranch ??
+            t("newSession.baseBranch"))}
         .value=${params.baseRef}
         @input=${(event: Event) =>
           params.onBaseRefInput((event.target as HTMLInputElement).value.trim())}

--- a/ui/src/pages/new-session/draft-gateway-state.ts
+++ b/ui/src/pages/new-session/draft-gateway-state.ts
@@ -28,10 +28,12 @@ import {
   encodeIdentityPreferences,
   loadBrowserPreferences,
   loadNewSessionPreference,
+  mergeNewSessionPreference,
   patchNewSessionPreference,
   PREFS_MIGRATION_KEY,
   replaceBrowserPreference,
   type NewSessionPreference,
+  type NewSessionPreferencePatch,
 } from "./preferences.ts";
 
 const CATALOG_RETRY_DELAYS_MS = [0, 1_000, 3_000] as const;
@@ -378,7 +380,7 @@ export class DraftGatewayState {
       : loadNewSessionPreference(this.gatewayUrlValue, agentId);
   }
 
-  persistPreference(agentIdValue: string, workspace: string, patch: NewSessionPreference) {
+  persistPreference(agentIdValue: string, workspace: string, patch: NewSessionPreferencePatch) {
     const snapshot = this.read();
     if (
       catalog.isTarget(snapshot.data) ||
@@ -405,7 +407,10 @@ export class DraftGatewayState {
         patchNewSessionPreference(gatewayUrl, agentId, nextPatch);
         return;
       }
-      const next = { ...this.identityPreferences[agentId], ...nextPatch };
+      const next = mergeNewSessionPreference(this.identityPreferences[agentId], nextPatch);
+      if (!next) {
+        return;
+      }
       try {
         const result = await client.request<UsersPrefsSetResult>("users.prefs.set", {
           entries: encodeIdentityPreferences({ [agentId]: next }),

--- a/ui/src/pages/new-session/draft-repository-state.ts
+++ b/ui/src/pages/new-session/draft-repository-state.ts
@@ -4,7 +4,7 @@ import type {
 } from "../../../../packages/gateway-protocol/src/index.js";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { DraftRepositoryState } from "./discovery.ts";
-import type { NewSessionPreference } from "./preferences.ts";
+import type { NewSessionPreference, NewSessionPreferencePatch } from "./preferences.ts";
 
 type DraftRepositorySnapshot = Readonly<{
   execNode: string;
@@ -19,18 +19,22 @@ type DraftRepositorySnapshot = Readonly<{
 
 type DraftRepositoryCallbacks = {
   requestUpdate: () => void;
-  persistPreference: (patch: NewSessionPreference) => void;
+  persistPreference: (patch: NewSessionPreferencePatch) => void;
 };
+
+type DraftBaseRefSelection =
+  | { kind: "automatic" }
+  | { kind: "explicit"; ref: string; repoRoot: string };
 
 export class DraftRepositoryController {
   private worktreeValue = false;
   private worktreeNameValue = "";
-  private baseRefValue = "";
+  private baseRefSelection: DraftBaseRefSelection = { kind: "automatic" };
   private repositoryValue: DraftRepositoryState = { kind: "idle" };
   private requestToken = 0;
   private baseRefEditGeneration = 0;
   private preferredWorktreeRestore = false;
-  private preferredBaseRefRestore = "";
+  private preferredBaseRefRestore: DraftBaseRefSelection = { kind: "automatic" };
   private worktreeSelectedByUser = false;
   private detailsSelectedByUser = false;
 
@@ -48,7 +52,7 @@ export class DraftRepositoryController {
   }
 
   get baseRef(): string {
-    return this.baseRefValue;
+    return this.baseRefSelection.kind === "explicit" ? this.baseRefSelection.ref : "";
   }
 
   get repository(): DraftRepositoryState {
@@ -65,7 +69,10 @@ export class DraftRepositoryController {
 
   adoptPreference(preference: NewSessionPreference | null) {
     this.preferredWorktreeRestore = preference?.worktree === true;
-    this.preferredBaseRefRestore = preference?.baseRef ?? "";
+    this.preferredBaseRefRestore = preference?.baseRef
+      ? { kind: "explicit", ref: preference.baseRef.ref, repoRoot: preference.baseRef.repoRoot }
+      : { kind: "automatic" };
+    this.baseRefSelection = { kind: "automatic" };
     this.worktreeNameValue = preference?.worktreeName ?? "";
     this.worktreeSelectedByUser = false;
     this.detailsSelectedByUser = false;
@@ -76,10 +83,10 @@ export class DraftRepositoryController {
     this.baseRefEditGeneration += 1;
     this.worktreeValue = false;
     this.worktreeNameValue = "";
-    this.baseRefValue = "";
+    this.baseRefSelection = { kind: "automatic" };
     this.repositoryValue = { kind: "idle" };
     this.preferredWorktreeRestore = false;
-    this.preferredBaseRefRestore = "";
+    this.preferredBaseRefRestore = { kind: "automatic" };
     this.worktreeSelectedByUser = false;
     this.detailsSelectedByUser = false;
   }
@@ -87,7 +94,6 @@ export class DraftRepositoryController {
   invalidate() {
     this.requestToken += 1;
     this.repositoryValue = { kind: "idle" };
-    this.baseRefValue = "";
   }
 
   selectWorktree(value: boolean, clearName = true) {
@@ -130,10 +136,17 @@ export class DraftRepositoryController {
       return;
     }
     this.baseRefEditGeneration += 1;
-    this.baseRefValue = baseRef;
-    this.preferredBaseRefRestore = "";
+    this.baseRefSelection = baseRef
+      ? { kind: "explicit", ref: baseRef, repoRoot: this.selectedRepoRoot() }
+      : { kind: "automatic" };
+    this.preferredBaseRefRestore = { kind: "automatic" };
     this.detailsSelectedByUser = true;
-    this.callbacks.persistPreference({ baseRef });
+    this.callbacks.persistPreference({
+      baseRef:
+        this.baseRefSelection.kind === "explicit"
+          ? { ref: this.baseRefSelection.ref, repoRoot: this.baseRefSelection.repoRoot }
+          : null,
+    });
     this.callbacks.requestUpdate();
   }
 
@@ -169,10 +182,7 @@ export class DraftRepositoryController {
     if (this.read().execNode || this.repositoryValue.kind === "idle") {
       return false;
     }
-    const snapshot = this.read();
-    const repoRoot =
-      snapshot.selectedProject?.repoRoot ?? (snapshot.folder.trim() || snapshot.workspace);
-    return this.repositoryValue.repoRoot === repoRoot;
+    return this.repositoryValue.repoRoot === this.selectedRepoRoot();
   }
 
   load() {
@@ -182,23 +192,27 @@ export class DraftRepositoryController {
     const baseRefEditGeneration = this.baseRefEditGeneration;
     const snapshot = this.read();
     this.repositoryValue = { kind: "idle" };
-    this.baseRefValue = "";
     if (
       snapshot.remoteProjectSelected ||
       snapshot.execNode ||
       (snapshot.selectedProject && !snapshot.selectedProject.repoRoot)
     ) {
+      this.baseRefSelection = { kind: "automatic" };
       this.preferredWorktreeRestore = false;
       return;
     }
-    const repoRoot =
-      snapshot.selectedProject?.repoRoot ?? (snapshot.folder.trim() || snapshot.workspace);
+    const repoRoot = this.selectedRepoRoot();
+    if (this.baseRefSelection.kind === "explicit" && this.baseRefSelection.repoRoot !== repoRoot) {
+      this.baseRefSelection = { kind: "automatic" };
+    }
     const usesWorkspace = !snapshot.selectedProject && repoRoot === snapshot.workspace;
     if (!repoRoot) {
+      this.baseRefSelection = { kind: "automatic" };
       this.preferredWorktreeRestore = false;
       return;
     }
     if (usesWorkspace && !snapshot.workspaceGit) {
+      this.baseRefSelection = { kind: "automatic" };
       this.repositoryValue = { kind: "direct", repoRoot };
       const rejectedWorktree = !snapshot.cloudProfileId && (this.worktreeValue || restoreWorktree);
       if (!snapshot.cloudProfileId) {
@@ -257,11 +271,13 @@ export class DraftRepositoryController {
           this.worktreeValue = true;
         }
         this.preferredWorktreeRestore = false;
-        if (baseRefEditGeneration === this.baseRefEditGeneration) {
-          this.baseRefValue = restoreBaseRef || result.defaultBranch || result.headBranch || "";
-          if (restoreBaseRef) {
-            this.preferredBaseRefRestore = "";
-          }
+        if (
+          restoreBaseRef.kind === "explicit" &&
+          restoreBaseRef.repoRoot === repoRoot &&
+          baseRefEditGeneration === this.baseRefEditGeneration
+        ) {
+          this.baseRefSelection = restoreBaseRef;
+          this.preferredBaseRefRestore = { kind: "automatic" };
         }
         this.callbacks.requestUpdate();
       })
@@ -276,5 +292,10 @@ export class DraftRepositoryController {
         this.preferredWorktreeRestore = false;
         this.callbacks.requestUpdate();
       });
+  }
+
+  private selectedRepoRoot(): string {
+    const snapshot = this.read();
+    return snapshot.selectedProject?.repoRoot ?? (snapshot.folder.trim() || snapshot.workspace);
   }
 }

--- a/ui/src/pages/new-session/preferences.test.ts
+++ b/ui/src/pages/new-session/preferences.test.ts
@@ -21,7 +21,7 @@ describe("new-session browser preferences", () => {
       where: { kind: "cloud", id: "build-fleet" },
       projectId: "openclaw",
       worktree: true,
-      baseRef: "main",
+      baseRef: { ref: "main", repoRoot: "/workspace/project" },
       worktreeName: "picker-redesign",
       model: "openai/gpt-5.6-sol",
       thinkingLevel: "high",
@@ -33,7 +33,7 @@ describe("new-session browser preferences", () => {
       where: { kind: "cloud", id: "build-fleet" },
       projectId: "openclaw",
       worktree: true,
-      baseRef: "main",
+      baseRef: { ref: "main", repoRoot: "/workspace/project" },
       worktreeName: "picker-redesign",
       model: "openai/gpt-5.6-sol",
       thinkingLevel: "high",
@@ -68,6 +68,28 @@ describe("new-session browser preferences", () => {
       }),
     );
     expect(loadNewSessionPreference("ws://one.example", "main")).toBeNull();
+  });
+
+  it("drops legacy and incomplete base ref preferences", () => {
+    patchNewSessionPreference("ws://one.example", "main", { folder: "/workspace" });
+    const key = localStorage.key(0);
+    expect(key).not.toBeNull();
+    localStorage.setItem(
+      key ?? "",
+      JSON.stringify({
+        agents: {
+          main: { folder: "/workspace", baseRef: "legacy" },
+          research: { folder: "/research", baseRef: { ref: "release" } },
+        },
+      }),
+    );
+
+    expect(loadNewSessionPreference("ws://one.example", "main")).toEqual({
+      folder: "/workspace",
+    });
+    expect(loadNewSessionPreference("ws://one.example", "research")).toEqual({
+      folder: "/research",
+    });
   });
 
   it("round-trips normalized browser preferences through identity keys", () => {

--- a/ui/src/pages/new-session/preferences.ts
+++ b/ui/src/pages/new-session/preferences.ts
@@ -13,16 +13,25 @@ export type NewSessionWhere =
   | { kind: "node"; id: string }
   | { kind: "cloud"; id: string };
 
+type NewSessionBaseRefPreference = {
+  ref: string;
+  repoRoot: string;
+};
+
 export type NewSessionPreference = {
   workspace?: string;
   folder?: string;
   where?: NewSessionWhere;
   projectId?: string;
   worktree?: boolean;
-  baseRef?: string;
+  baseRef?: NewSessionBaseRefPreference;
   worktreeName?: string;
   model?: string;
   thinkingLevel?: string;
+};
+
+export type NewSessionPreferencePatch = Omit<NewSessionPreference, "baseRef"> & {
+  baseRef?: NewSessionBaseRefPreference | null;
 };
 
 type PersistedPreferences = {
@@ -41,7 +50,7 @@ function normalizePreference(value: unknown): NewSessionPreference | null {
   const workspace = normalizeOptionalString(record.workspace);
   const folder = normalizeOptionalString(record.folder);
   const projectId = normalizeOptionalString(record.projectId);
-  const baseRef = normalizeOptionalString(record.baseRef);
+  const baseRef = normalizeBaseRef(record.baseRef);
   const worktreeName = normalizeOptionalString(record.worktreeName);
   const model = normalizeOptionalString(record.model);
   const thinkingLevel = normalizeOptionalString(record.thinkingLevel);
@@ -71,6 +80,15 @@ function normalizePreference(value: unknown): NewSessionPreference | null {
     ...(model ? { model } : {}),
     ...(thinkingLevel ? { thinkingLevel } : {}),
   };
+}
+
+function normalizeBaseRef(value: unknown): NewSessionBaseRefPreference | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const ref = normalizeOptionalString(value.ref);
+  const repoRoot = normalizeOptionalString(value.repoRoot);
+  return ref && repoRoot ? { ref, repoRoot } : undefined;
 }
 
 function normalizeWhere(value: unknown): NewSessionWhere | undefined {
@@ -150,6 +168,13 @@ export function decodeIdentityPreferences(
   );
 }
 
+export function mergeNewSessionPreference(
+  current: NewSessionPreference | null | undefined,
+  patch: NewSessionPreferencePatch,
+): NewSessionPreference | null {
+  return normalizePreference({ ...current, ...patch });
+}
+
 export function replaceBrowserPreference(
   gatewayUrl: string,
   agentId: string,
@@ -178,7 +203,7 @@ export function replaceBrowserPreference(
 export function patchNewSessionPreference(
   gatewayUrl: string,
   agentId: string,
-  patch: NewSessionPreference,
+  patch: NewSessionPreferencePatch,
 ): void {
   const storage = getSafeLocalStorage();
   const normalizedAgentId = normalizeAgentId(agentId);
@@ -187,7 +212,7 @@ export function patchNewSessionPreference(
   }
   const store = readStore(storage, gatewayUrl);
   const current = normalizePreference(store.agents?.[normalizedAgentId]) ?? {};
-  const next = normalizePreference({ ...current, ...patch });
+  const next = mergeNewSessionPreference(current, patch);
   if (!next) {
     return;
   }

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -488,7 +488,7 @@ export function setSharedControlUiE2eServerBaseUrl(baseUrl: string | null): void
 export type MockGatewayControls = {
   closeLatest: (code?: number, reason?: string) => Promise<void>;
   deliverLatest: (frame: unknown) => Promise<void>;
-  deferNext: (method: string, match?: Record<string, unknown>) => Promise<void>;
+  deferNext: (method: string, match?: Record<string, unknown>) => Promise<number>;
   emitChatFinal: (params: { runId: string; sessionKey?: string; text: string }) => Promise<void>;
   emitGatewayEvent: (event: string, payload?: unknown) => Promise<void>;
   getRequests: (method?: string) => Promise<MockGatewayRequest[]>;
@@ -985,7 +985,7 @@ function installControlUiMockGateway(
   type ExposedGateway = {
     closeLatest: (code?: number, reason?: string) => void;
     deliverLatest: (frame: unknown) => void;
-    deferNext: (method: string, match?: Record<string, unknown>) => void;
+    deferNext: (method: string, match?: Record<string, unknown>) => number;
     emit: (event: string, payload?: unknown) => void;
     findRequests: (method?: string) => BrowserRequest[];
     rejectDeferred: (
@@ -2200,7 +2200,9 @@ function installControlUiMockGateway(
       MockWebSocket.latest?.deliver(frame);
     },
     deferNext(method, match) {
+      const priorCount = requests.filter((request) => request.method === method).length;
       deferredMethods.push({ method, match });
+      return priorCount;
     },
     emit(event, payload) {
       MockWebSocket.latest?.deliver({
@@ -2458,19 +2460,19 @@ function createMockGatewayControls(
     },
     deliverLatest,
     async deferNext(method, match) {
-      await page.evaluate(
+      return await page.evaluate(
         ({ targetMethod, requestMatch }) => {
           const gateway = (
             window as Window & {
               openclawControlUiE2eGateway?: {
-                deferNext: (method: string, match?: Record<string, unknown>) => void;
+                deferNext: (method: string, match?: Record<string, unknown>) => number;
               };
             }
           ).openclawControlUiE2eGateway;
           if (!gateway) {
             throw new Error("Mock Gateway is not installed");
           }
-          gateway.deferNext(targetMethod, requestMatch);
+          return gateway.deferNext(targetMethod, requestMatch);
         },
         { targetMethod: method, requestMatch: match },
       );


### PR DESCRIPTION
Related: #105326
Related: #105344

## What Problem This Solves

Fixes an issue where users starting a new chat in a worktree could silently branch from a stale local `main` because the New Session form submitted its discovered default as an explicit base. Remote refresh and checkout failures could also substitute local history without telling the operator.

## Why This Change Was Made

Automatic bases now remain display-only until managed worktree creation resolves the freshly fetched remote default. Explicit and restored bases remain exact, survive same-repository reconnects, and clear when the repository changes. Repositories without an origin still use local `HEAD`; repositories with an unreachable or invalid default fail with an actionable message instead of silently changing provenance.

After fetching a configured origin, the resolver uses Git's native `remote set-head --auto` flow to refresh `origin/HEAD` before selecting it. The failed-remote checkout cleanup path remains canonical, but its retry from local `HEAD` was removed.

Persisted explicit bases now use one closed `{ ref, repoRoot }` value and restore only when that repository is selected. Legacy unbound strings and incomplete or mismatched values remain automatic, so an old branch from one checkout cannot leak into another after reload.

## User Impact

New chats use the current remote default by default, including after the remote changes its default branch. Operators can still choose a local or remote ref explicitly, and that choice remains authoritative for the selected repository. Legacy unbound saved branches are intentionally not restored. If OpenClaw cannot refresh the configured origin, session creation reports how to retry or explicitly choose local state.

## Evidence

- Pre-fix Control UI E2E: `sessions.create` contained `worktreeBaseRef: "main"` for an untouched default; the regression failed at `new-session-page.places.e2e.test.ts`.
- Pre-fix Git service regression: unreachable origin resolved successfully to local `HEAD` instead of rejecting.
- ClawSweeper regression before the final resolver fix: after caching `origin/main` and switching a bare remote's default to `next`, the test received `origin/main` instead of expected `origin/next`.
- ClawSweeper persistence regression before the final UI fix: a legacy agent preference restored `release/local` into a different selected repository instead of leaving the base automatic.
- `node scripts/run-vitest.mjs src/agents/worktrees/base-ref.test.ts src/agents/worktrees/service.test.ts src/gateway/server.sessions.create.test.ts` — 158/158 passed after the final rebase.
- `node scripts/run-vitest.mjs src/agents/worktrees/base-ref.test.ts -t "refreshes origin HEAD when the remote default branch changes"` — passed after failing on the pre-fix implementation.
- `node scripts/run-vitest.mjs ui/src/pages/new-session/preferences.test.ts` — 4/4 passed; canonical round-trip plus legacy/incomplete discard.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.place-preferences.e2e.test.ts` — 3/3 passed; legacy, repository-mismatch, and repository-match branches.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts -t "restores valid preferences and repairs a worktree rejected by workspace metadata"` — 1/1 passed; real input, browser persistence, and reload.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts` — explicit base survives Gateway client replacement.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.places.e2e.test.ts` — 5/5 passed; screenshot and video inspected.
- `new-session-page.workspace-memory.e2e.test.ts -t 'separates model shortcuts|migrates identity preferences'` — 2/2 passed; the canonical identity write replaces the preference with the normalized folder/worktree value and no cleared model sentinel.
- `cloud-workers-settings.e2e.test.ts` — 3/3 passed after making mock deferral registration and its prior-request cursor atomic, removing the CI race without weakening the Save-disabled assertion.
- `pnpm docs:check-mdx` — passed across 778 files.
- `node scripts/check-changed.mjs` — full selected core, coreTests, UI, and docs plan passed on `c03a99edfc1` after rebasing onto current `origin/main`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean on `c03a99edfc1`; no accepted/actionable findings, 0.96 confidence.
- Production LOC: +129/−57 (net +72). The growth records automatic-versus-explicit repository-bound state, adds the closed persisted `{ ref, repoRoot }` owner boundary, and makes configured-origin failure visible; the obsolete fallback path was removed. Tests/test-support: +170/−41 (net +129), including real bare-remote default-switch, persisted-repository, canonical identity-write, and atomic mock-deferral regressions. Docs: +1/−1 (net 0).

![Automatic base shown without committing an explicit ref](https://github.com/user-attachments/assets/cec76d89-1c03-4438-98d7-14ddc7a8366a)

https://github.com/user-attachments/assets/4f060ad8-a45c-4ed8-b374-5d27e80bf5ef

AI-assisted implementation; I reviewed the source, Git behavior, regression failures, final browser captures, generated diff, and ClawSweeper findings.
