### PR TITLE
fix(doctor): recover recreated legacy workspace state

### DIFF
--- a/src/infra/state-migrations.workspace-setup-recreated.test.ts
+++ b/src/infra/state-migrations.workspace-setup-recreated.test.ts
@@ -1,0 +1,161 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-store.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
+import { useWorkspaceMigrationTestFixture } from "./state-migrations.workspace-setup.test-support.js";
+
+describe("recreated legacy workspace state migration", () => {
+  const { migrate, setup } = useWorkspaceMigrationTestFixture();
+
+  it("cleans a covered setup marker recreated after completed migration", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
+    const seededAt = "2026-07-15T10:00:00.000Z";
+    const completedAt = "2026-07-15T10:01:00.000Z";
+    await fsp.writeFile(
+      setupPath,
+      JSON.stringify({ version: 1, bootstrapSeededAt: seededAt, setupCompletedAt: completedAt }),
+      "utf8",
+    );
+    expect((await migrate(context)).warnings).toEqual([]);
+
+    const recreated = JSON.stringify({ version: 1, setupCompletedAt: completedAt });
+    await fsp.writeFile(setupPath, recreated, "utf8");
+
+    const result = await migrate(context);
+
+    expect(result.warnings).toEqual([]);
+    expect(fs.existsSync(setupPath)).toBe(false);
+    const db = openOpenClawStateDatabase({ env: context.env }).db;
+    expect(
+      db
+        .prepare(
+          "SELECT bootstrap_seeded_at, setup_completed_at FROM workspace_setup_state WHERE workspace_key = ?",
+        )
+        .get(identity.workspaceKey),
+    ).toEqual({ bootstrap_seeded_at: seededAt, setup_completed_at: completedAt });
+    const receipt = db
+      .prepare(
+        "SELECT source_sha256, removed_source, report_json FROM migration_sources WHERE source_path = ?",
+      )
+      .get(setupPath) as {
+      source_sha256: string;
+      removed_source: number;
+      report_json: string;
+    };
+    expect(receipt).toMatchObject({
+      source_sha256: createHash("sha256").update(recreated).digest("hex"),
+      removed_source: 1,
+    });
+    expect(JSON.parse(receipt.report_json)).toMatchObject({
+      authoritative: true,
+      resolution: "verified",
+    });
+  });
+
+  it.each([
+    { claimed: false, state: "source" },
+    { claimed: true, state: "interrupted claim" },
+  ])("imports an attestation recreated as a sole $state", async ({ claimed }) => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const attestationPath = path.join(
+      context.stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(
+      attestationPath,
+      "openclaw-workspace-attestation:v1\n2026-07-15T11:00:00.000Z\n",
+      "utf8",
+    );
+    const originalMtime = new Date("2026-07-15T11:01:00.000Z");
+    await fsp.utimes(attestationPath, originalMtime, originalMtime);
+    expect((await migrate(context)).warnings).toEqual([]);
+
+    const recreated = "openclaw-workspace-attestation:v1\n2026-07-16T11:00:00.000Z\n";
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(attestationPath, recreated, "utf8");
+    const recreatedMtime = new Date("2026-07-16T11:01:00.000Z");
+    await fsp.utimes(attestationPath, recreatedMtime, recreatedMtime);
+    const claimPath = `${attestationPath}.doctor-importing`;
+    if (claimed) {
+      await fsp.rename(attestationPath, claimPath);
+    }
+
+    const result = await migrate(context);
+
+    expect(result.warnings).toEqual([]);
+    expect(fs.existsSync(attestationPath)).toBe(false);
+    expect(fs.existsSync(claimPath)).toBe(false);
+    const db = openOpenClawStateDatabase({ env: context.env }).db;
+    expect(
+      db
+        .prepare("SELECT attested_at_ms FROM workspace_attestations WHERE workspace_key = ?")
+        .get(identity.workspaceKey),
+    ).toEqual({ attested_at_ms: recreatedMtime.getTime() });
+    expect(
+      db
+        .prepare(
+          "SELECT source_sha256, removed_source FROM migration_sources WHERE source_path = ?",
+        )
+        .get(attestationPath),
+    ).toEqual({
+      source_sha256: createHash("sha256").update(recreated).digest("hex"),
+      removed_source: 1,
+    });
+  });
+
+  it("retains colliding source and claim from a recreated generation", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const attestationPath = path.join(
+      context.stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    const original = "openclaw-workspace-attestation:v1\n2026-07-15T11:00:00.000Z\n";
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(attestationPath, original, "utf8");
+    const originalMtime = new Date("2026-07-15T11:01:00.000Z");
+    await fsp.utimes(attestationPath, originalMtime, originalMtime);
+    expect((await migrate(context)).warnings).toEqual([]);
+
+    const recreated = "openclaw-workspace-attestation:v1\n2026-07-16T11:00:00.000Z\n";
+    const claimPath = `${attestationPath}.doctor-importing`;
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await Promise.all([
+      fsp.writeFile(attestationPath, recreated, "utf8"),
+      fsp.writeFile(claimPath, recreated, "utf8"),
+    ]);
+
+    const result = await migrate(context);
+
+    expect(result.warnings).toEqual([
+      "Workspace state is in SQLite, but source and interrupted claim both exist.",
+    ]);
+    expect(fs.existsSync(attestationPath)).toBe(true);
+    expect(fs.existsSync(claimPath)).toBe(true);
+    const db = openOpenClawStateDatabase({ env: context.env }).db;
+    expect(
+      db
+        .prepare("SELECT attested_at_ms FROM workspace_attestations WHERE workspace_key = ?")
+        .get(identity.workspaceKey),
+    ).toEqual({ attested_at_ms: originalMtime.getTime() });
+    expect(
+      db
+        .prepare(
+          "SELECT source_sha256, removed_source FROM migration_sources WHERE source_path = ?",
+        )
+        .get(attestationPath),
+    ).toEqual({
+      source_sha256: createHash("sha256").update(original).digest("hex"),
+      removed_source: 1,
+    });
+  });
+});

--- a/src/infra/state-migrations.workspace-setup-store.ts
+++ b/src/infra/state-migrations.workspace-setup-store.ts
@@ -1,5 +1,6 @@
 // SQLite import and receipt semantics for retired workspace state.
 import { createHash } from "node:crypto";
+import { safeParseJsonRecord } from "@openclaw/normalization-core/json-coercion";
 import { LEGACY_WORKSPACE_ATTESTATION_HEADER } from "../agents/workspace-legacy-state.js";
 import {
   WORKSPACE_LEGACY_STATE_MIGRATION_KIND,
@@ -201,6 +202,14 @@ function attestationFingerprint(params: {
   });
 }
 
+function receiptPreservesAuthority(
+  receipt: { reportJson: string } | null,
+  expectedFingerprint: string,
+): boolean {
+  const report = receipt ? safeParseJsonRecord(receipt.reportJson) : undefined;
+  return report?.authoritative === true && report.canonicalFingerprint === expectedFingerprint;
+}
+
 function findMigrationAuthority(params: {
   db: ReturnType<typeof openOpenClawStateDatabase>["db"];
   kysely: ReturnType<typeof getNodeSqliteKysely<WorkspaceMigrationDatabase>>;
@@ -332,6 +341,7 @@ export function importAndRecordReceipt(params: {
   snapshot: SourceSnapshot;
   parsed: ParsedSource;
   env: NodeJS.ProcessEnv;
+  replaceRemovedReceipt?: boolean;
 }): { sourceKey: string; imported: boolean } {
   const key = resolveWorkspaceMigrationSourceKey(params.source);
   const runId = `${key}:${params.snapshot.sha256.slice(0, 16)}`;
@@ -341,7 +351,8 @@ export function importAndRecordReceipt(params: {
       const { db } = database;
       const kysely = getNodeSqliteKysely<WorkspaceMigrationDatabase>(db);
       const existingReceipt = readLegacyMigrationReceiptFromDatabase(db, key);
-      if (existingReceipt) {
+      // Only a receipt whose source was fully removed can be replaced by a later generation.
+      if (existingReceipt && (!params.replaceRemovedReceipt || !existingReceipt.removedSource)) {
         throw new Error("workspace migration receipt appeared concurrently; retry Doctor");
       }
 
@@ -654,7 +665,10 @@ export function importAndRecordReceipt(params: {
         // Only a whole-source insert or precedence replacement can establish
         // authority. Verification and complementary merges may cover cleanup,
         // but must not let a legacy source overwrite unrelated canonical data.
-        authoritative: resolution === "inserted" || resolution === "replaced",
+        authoritative:
+          resolution === "inserted" ||
+          resolution === "replaced" ||
+          receiptPreservesAuthority(existingReceipt, verifiedFingerprint),
         resolution,
         imported,
       });
@@ -669,6 +683,7 @@ export function importAndRecordReceipt(params: {
         runId,
         now,
         reportJson,
+        upsert: existingReceipt !== null,
       });
       return { sourceKey: key, imported };
     },

--- a/src/infra/state-migrations.workspace-setup.test-support.ts
+++ b/src/infra/state-migrations.workspace-setup.test-support.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import {
+  detectLegacyWorkspaceState,
+  migrateLegacyWorkspaceState,
+} from "./state-migrations.workspace-setup.js";
+
+export function useWorkspaceMigrationTestFixture() {
+  let envSnapshot: ReturnType<typeof captureEnv> | undefined;
+  const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+    afterEach(() => {
+      closeOpenClawStateDatabaseForTest();
+      envSnapshot?.restore();
+      envSnapshot = undefined;
+      cleanup();
+    });
+  });
+
+  function setup() {
+    const homeDir = tempDirs.make("openclaw-workspace-migration-home-");
+    const stateDir = path.join(homeDir, ".openclaw");
+    const workspaceDir = path.join(homeDir, "workspace");
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    envSnapshot ??= captureEnv(["HOME", "OPENCLAW_HOME", "OPENCLAW_STATE_DIR"]);
+    setTestEnvValue("HOME", homeDir);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    const cfg = {
+      agents: { defaults: { workspace: workspaceDir } },
+    } satisfies OpenClawConfig;
+    return {
+      cfg,
+      env: { ...process.env, HOME: homeDir, OPENCLAW_STATE_DIR: stateDir },
+      homeDir,
+      stateDir,
+      workspaceDir,
+    };
+  }
+
+  function detect(context: ReturnType<typeof setup>) {
+    return detectLegacyWorkspaceState({
+      cfg: context.cfg,
+      stateDir: context.stateDir,
+      env: context.env,
+      homedir: () => context.homeDir,
+      doctorOnlyStateMigrations: true,
+    });
+  }
+
+  async function migrate(context: ReturnType<typeof setup>) {
+    return await migrateLegacyWorkspaceState({
+      detected: detect(context),
+      env: context.env,
+      stateDir: context.stateDir,
+    });
+  }
+
+  return { detect, migrate, setup };
+}

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -886,6 +886,52 @@ describe("legacy workspace Doctor migration", () => {
     });
   });
 
+  it("resumes a recreated generation from its interrupted claim", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
+    await fsp.writeFile(
+      setupPath,
+      JSON.stringify({ version: 1, bootstrapSeededAt: "2026-07-15T10:00:00.000Z" }),
+      "utf8",
+    );
+    expect((await migrate(context)).warnings).toEqual([]);
+
+    const recreated = JSON.stringify({
+      version: 1,
+      setupCompletedAt: "2026-07-16T10:00:00.000Z",
+    });
+    await fsp.writeFile(setupPath, recreated, "utf8");
+    const claimPath = `${setupPath}.doctor-importing`;
+    await fsp.rename(setupPath, claimPath);
+
+    const result = await migrate(context);
+
+    expect(result.warnings).toEqual([]);
+    expect(fs.existsSync(claimPath)).toBe(false);
+    const db = openOpenClawStateDatabase({ env: context.env }).db;
+    expect(
+      db
+        .prepare(
+          "SELECT bootstrap_seeded_at, setup_completed_at FROM workspace_setup_state WHERE workspace_key = ?",
+        )
+        .get(identity.workspaceKey),
+    ).toEqual({
+      bootstrap_seeded_at: "2026-07-15T10:00:00.000Z",
+      setup_completed_at: "2026-07-16T10:00:00.000Z",
+    });
+    expect(
+      db
+        .prepare(
+          "SELECT source_sha256, removed_source FROM migration_sources WHERE source_path = ?",
+        )
+        .get(setupPath),
+    ).toEqual({
+      source_sha256: createHash("sha256").update(recreated).digest("hex"),
+      removed_source: 1,
+    });
+  });
+
   it("cleans receipt-covered superseded setup markers after an interrupted delete", async () => {
     const context = setup();
     const rootPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -2,8 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { describe, expect, it } from "vitest";
 import {
   deleteWorkspaceState,
   prepareWorkspaceStateDeletion,
@@ -11,66 +10,17 @@ import {
   resolveWorkspaceStateIdentity,
 } from "../agents/workspace-state-store.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  closeOpenClawStateDatabaseForTest,
-  openOpenClawStateDatabase,
-} from "../state/openclaw-state-db.js";
-import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
   detectLegacyWorkspaceState,
   migrateLegacyWorkspaceState,
 } from "./state-migrations.workspace-setup.js";
+import { useWorkspaceMigrationTestFixture } from "./state-migrations.workspace-setup.test-support.js";
 
 const HASH = "a".repeat(64);
 
 describe("legacy workspace Doctor migration", () => {
-  let envSnapshot: ReturnType<typeof captureEnv> | undefined;
-  const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
-    afterEach(() => {
-      closeOpenClawStateDatabaseForTest();
-      envSnapshot?.restore();
-      envSnapshot = undefined;
-      cleanup();
-    });
-  });
-
-  function setup() {
-    const homeDir = tempDirs.make("openclaw-workspace-migration-home-");
-    const stateDir = path.join(homeDir, ".openclaw");
-    const workspaceDir = path.join(homeDir, "workspace");
-    fs.mkdirSync(workspaceDir, { recursive: true });
-    envSnapshot ??= captureEnv(["HOME", "OPENCLAW_HOME", "OPENCLAW_STATE_DIR"]);
-    setTestEnvValue("HOME", homeDir);
-    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-    const cfg = {
-      agents: { defaults: { workspace: workspaceDir } },
-    } satisfies OpenClawConfig;
-    return {
-      cfg,
-      env: { ...process.env, HOME: homeDir, OPENCLAW_STATE_DIR: stateDir },
-      homeDir,
-      stateDir,
-      workspaceDir,
-    };
-  }
-
-  function detect(context: ReturnType<typeof setup>) {
-    return detectLegacyWorkspaceState({
-      cfg: context.cfg,
-      stateDir: context.stateDir,
-      env: context.env,
-      homedir: () => context.homeDir,
-      doctorOnlyStateMigrations: true,
-    });
-  }
-
-  async function migrate(context: ReturnType<typeof setup>) {
-    return await migrateLegacyWorkspaceState({
-      detected: detect(context),
-      env: context.env,
-      stateDir: context.stateDir,
-    });
-  }
+  const { detect, migrate, setup } = useWorkspaceMigrationTestFixture();
 
   it("detects configured and orphan sources only for explicit Doctor repair", async () => {
     const context = setup();
@@ -882,52 +832,6 @@ describe("legacy workspace Doctor migration", () => {
       source_sha256: createHash("sha256")
         .update(JSON.stringify({ version: 1, bootstrapSeededAt: seededAt }))
         .digest("hex"),
-      removed_source: 1,
-    });
-  });
-
-  it("resumes a recreated generation from its interrupted claim", async () => {
-    const context = setup();
-    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
-    const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
-    await fsp.writeFile(
-      setupPath,
-      JSON.stringify({ version: 1, bootstrapSeededAt: "2026-07-15T10:00:00.000Z" }),
-      "utf8",
-    );
-    expect((await migrate(context)).warnings).toEqual([]);
-
-    const recreated = JSON.stringify({
-      version: 1,
-      setupCompletedAt: "2026-07-16T10:00:00.000Z",
-    });
-    await fsp.writeFile(setupPath, recreated, "utf8");
-    const claimPath = `${setupPath}.doctor-importing`;
-    await fsp.rename(setupPath, claimPath);
-
-    const result = await migrate(context);
-
-    expect(result.warnings).toEqual([]);
-    expect(fs.existsSync(claimPath)).toBe(false);
-    const db = openOpenClawStateDatabase({ env: context.env }).db;
-    expect(
-      db
-        .prepare(
-          "SELECT bootstrap_seeded_at, setup_completed_at FROM workspace_setup_state WHERE workspace_key = ?",
-        )
-        .get(identity.workspaceKey),
-    ).toEqual({
-      bootstrap_seeded_at: "2026-07-15T10:00:00.000Z",
-      setup_completed_at: "2026-07-16T10:00:00.000Z",
-    });
-    expect(
-      db
-        .prepare(
-          "SELECT source_sha256, removed_source FROM migration_sources WHERE source_path = ?",
-        )
-        .get(setupPath),
-    ).toEqual({
-      source_sha256: createHash("sha256").update(recreated).digest("hex"),
       removed_source: 1,
     });
   });

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -378,12 +378,13 @@ async function cleanupReceiptSource(params: {
   source: LegacyWorkspaceStateSource;
   receipt: MigrationReceipt;
   env: NodeJS.ProcessEnv;
+  hasSource: boolean;
+  hasClaim: boolean;
 }): Promise<MigrationMessages> {
   try {
     assertConfiguredWorkspaceIdentity(params.source);
     const sourceClaim = params.sourceClaim;
-    const hasSource = await sourceClaim.exists();
-    const hasClaim = await sourceClaim.exists(true);
+    const { hasSource, hasClaim } = params;
     if (!hasSource && !hasClaim) {
       if (!params.receipt.removedSource) {
         markLegacyMigrationSourceRemoved(params.receipt.sourceKey, params.env);
@@ -470,14 +471,6 @@ async function migrateOneSource(params: {
     };
   }
   const receipt = readReceipt(params.source, params.env);
-  if (receipt) {
-    return cleanupReceiptSource({
-      sourceClaim,
-      source: params.source,
-      receipt,
-      env: params.env,
-    });
-  }
   let hasSource: boolean;
   let hasClaim: boolean;
   try {
@@ -488,6 +481,18 @@ async function migrateOneSource(params: {
       changes: [],
       warnings: [`Failed reading legacy workspace state: ${formatErrorMessage(error)}`],
     };
+  }
+  // One artifact after verified removal is a new generation, including a source
+  // already renamed before a crash. Collisions keep the stricter receipt check.
+  if (receipt && !(receipt.removedSource && hasSource !== hasClaim)) {
+    return cleanupReceiptSource({
+      sourceClaim,
+      source: params.source,
+      receipt,
+      env: params.env,
+      hasSource,
+      hasClaim,
+    });
   }
   if (hasSource && hasClaim) {
     return {
@@ -544,6 +549,7 @@ async function migrateOneSource(params: {
       snapshot,
       parsed,
       env: params.env,
+      replaceRemovedReceipt: receipt?.removedSource === true,
     });
   } catch (error) {
     const restoreError = claimedByThisRun ? await sourceClaim.restore() : null;


### PR DESCRIPTION
Closes #111498

## What Problem This Solves

Fixes an issue where users upgrading from legacy workspace state could have every agent turn, model probe, and channel dispatch blocked when a retired setup marker or attestation reappeared after Doctor had already migrated and removed it.

Doctor treated the completed migration receipt as cleanup-only provenance, so the recreated source could remain permanently at the retired path with `Workspace state is in SQLite, but the retired source now conflicts.` Runtime then continued to fail closed on every use.

## Why This Change Was Made

Doctor now recognizes a source that reappears after a receipt records verified removal as a new legacy generation. It reuses the existing claim, parse, canonical precedence, verification, and removal flow, then atomically replaces only the completed receipt.

Interrupted cleanup, malformed sources, source/claim collisions, and ambiguous canonical conflicts retain the existing fail-closed behavior. The change adds no runtime fallback, SQLite schema change, configuration, or protocol surface.

## User Impact

`openclaw doctor --fix` can recover affected installations without manual SQLite receipt deletion. Covered setup state remains canonical, newer valid attestations are imported through existing precedence rules, and the recreated retired source is removed so TUI turns, probes, and channel dispatch can resume.

## Evidence

- Pre-fix owner reproduction: the two recreated-source cases failed with the reported `retired source now conflicts` warning; 2 failed, 29 passed.
- Post-fix owner suite: 31/31 passed in `src/infra/state-migrations.workspace-setup.test.ts`.
- Runtime guard sibling suite: 9/9 passed in `src/agents/workspace-legacy-state.test.ts`.
- Doctor command boundary: 97/97 passed in `src/commands/doctor-state-migrations.test.ts`.
- `node scripts/check-changed.mjs -- src/infra/state-migrations.workspace-setup.ts src/infra/state-migrations.workspace-setup-store.ts src/infra/state-migrations.workspace-setup.test.ts` passed, including core/test typechecks, lint, SQLite ownership guards, and import cycles.
- Post-rebase owner suite: 31/31 passed.
- Fresh Codex autoreview: clean; no accepted/actionable findings.
- Production LOC: +41/-14 (net +27). Tests: +155. CI tooling: +3/-2 (net +1).
- Current-main comparison through `19c916be139` found no intervening changes in the workspace migration owner. Rebasing exposed a separate current-main type break from #126062: retained subagent completion resolvers were threaded to a lifecycle dispatch contract that neither accepted nor honored them. The lifecycle owner now selects the resolver's exact `recoveryRuntime` and rejects stale bindings instead of falling through to a replacement Gateway.
- Direct AWS Crabbox E2E: lease `cbx_d993fe6e93f5`, run [`run_7bf39496111a`](https://crabbox.openclaw.ai/portal/runs/run_7bf39496111a), clean PR checkout. The scenario observed the pre-Doctor runtime guard, ran `openclaw doctor --fix --non-interactive`, verified both recreated sources were removed and canonical SQLite receipts were complete, then completed a real `openclaw agent --local` turn through the repository mock OpenAI server.
- The packed Gateway CI shard failed identically on this PR and current `main` with three Vitest workers. Pinning the existing timing-sensitive group to two workers passed the exact compact job locally: 24 Gateway files / 399 tests plus 28 hook files / 254 tests.
- Exact-instance lifecycle dispatch tests: 2/2 passed; existing instance-runtime suite: 7/7 passed; the complete changed core gate passed production/test typechecks, lint, boundaries, database-first guards, and import cycles.

The issue thread contains independent live macOS reproductions of the failure. The added Crabbox proof reproduces the same recreated-source/runtime-guard sequence on Linux with an isolated state directory and a mock provider; it does not substitute for a follow-up rerun on the reporter's original macOS installation.

AI-assisted with Codex. I reviewed the migration ownership, receipt replacement guard, canonical precedence behavior, regression coverage, and validation output.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted openclaw session transcript</summary>

````text
source: [LOCAL_SESSION]
redaction: local paths, emails, phone-shaped strings, token-shaped strings, auth headers, auth query params
omitted: raw tool outputs, system/developer prompts, local paths, secrets, browser/session/auth details
stats: {"agent":"openclaw","entries":9,"user":4,"assistant":4,"toolCalls":36,"toolOutputsDropped":36,"web":0,"redactions":1,"omittedUnsafe":0,"rawEntries":24}

[user]
Take a look at https://github.com/openclaw/openclaw/issues/111498 and tell me if this is still an issue affecting current main

[assistant]
I’m using the OpenClaw PR-maintainer workflow because this is a live issue-status check. I’ll inspect the issue, current `main`, related history, and focused tests before giving a verdict.

The live thread now has two independent macOS reproductions, including one on an August 18 `main` checkout. I’m checking whether commits after that reproduction changed the legacy-state writer, runtime guard, or Doctor reconciliation path.

Current `main` still contains the same fail-closed guard and the same Doctor conflict-preservation behavior. No relevant file changed after the latest live reproduction; I’m doing one focused test pass and checking the exact owner/caller boundary before closing the analysis.

Yes—**#111498 still affects current `main`** at `41e3968ee4f`.

Evidence:

- Runtime still throws when retired workspace artifacts remain: `src/agents/workspace-legacy-state.ts:156`.
- Doctor still preserves conflicting artifacts without offering recovery: `src/infra/state-migrations.workspace-setup.ts:414`.
- Tests explicitly preserve this dead-end: `src/infra/state-migrations.workspace-setup.test.ts:775` and `:925`.
- Two independent macOS reproductions were posted, latest on August 18 against recent `main`.
- No relevant code changed between that reproduction and current `main`.

The Anthropic framing is incidental: this is a provider-independent workspace migration conflict that can block probes, TUI turns, and channel dispatch. The correct fix belongs in Doctor’s safe reconciliation path, not a runtime bypass.

Focused tests couldn’t run locally because this worktree lacks dependencies; source, existing regression coverage, history, and live reproduction all agree.

By: @eacperformance (acct [REDACTED_PHONE]) | OpenClaw: 1 issue, 0 PRs/commits. Assigned to @vincentkoc since July 31.

https://github.com/openclaw/openclaw/issues/111498

[user]
Alright, let's reassign this to @jalehman and get started on a fix. Walk me through the simplest, safest solution and any alternatives that come to mind.

[assistant]
I’ll reassign the issue to @jalehman, then implement the repair at Doctor’s migration boundary. The key constraint is preserving genuinely divergent workspace state while automatically recovering stale/recreated legacy artifacts.

The high-level `gh issue edit` route lacks GraphQL mutation scope in this environment. I’m retrying through GitHub’s REST assignee endpoint, adding @jalehman before removing @vincentkoc so ownership never drops.

The safest narrow design is now clear: only treat a legacy file as a new generation when its prior receipt says the source was successfully removed and the exact source path later reappears. Interrupted claims and unresolved divergences keep the existing fail-closed behavior.

The regression tests now encode the two reported recovery cases: a covered setup marker reappears with fewer fields, and a newer attestation reappears after a completed receipt. I’m running them against the unmodified production code first; both should fail with today’s conflict warning.

Blacksmith Testbox is unavailable on this host (`blacksmith` CLI missing), so I’m using the repository-approved direct AWS fallback for the focused pre-fix proof. No production edits are in place yet.

The AWS fallback is still waiting for capacity. This linked checkout has access to the canonical repository’s existing dependency install, so I’m cancelling the queued lease and will reuse that install locally after verifying the lockfile matches—faster and no cloud spend.

The owner regression and sibling boundaries are green: 31 migration tests, 9 runtime-guard tests, and 97 Doctor command tests. I’m now running the repository’s changed-surface type/lint/architecture gate, then the mandatory autoreview.

The fix keeps the existing safety gates intact: malformed sources, changed interrupted claims, source+claim collisions, and unverified canonical state still fail closed. Only a source that reappears after a completed removal receipt enters the reconciliation path. The full changed gate is currently in core test typechecking.

Core production typechecking is green; the longer core-test shard is still running. No new failures have appeared since the lint correction.

The complete changed gate is green, including core/test typechecks, lint, SQLite ownership guards, and import cycles. I’m applying the repo’s diff-cleanup skill now, then the mandatory autoreview.

Reassigned #111498 to **@jalehman** and implemented a local fix on `fix/workspace-migration-recovery`.

### Safest solution

When a completed receipt says a legacy source was removed, but that source later reappears:

1. Doctor treats it as a new legacy generation.
2. It claims and validates the file normally.
3. Existing canonical precedence decides whether to preserve, merge, or replace SQLite state.
4. Doctor updates the receipt and removes the retired file.
5. Interrupted claims, malformed data, and ambiguous conflicts remain fail-closed.

This repairs the owner boundary in `src/infra/state-migrations.workspace-setup.ts:473` and `src/infra/state-migrations.workspace-setup-store.ts:339`. No runtime bypass, schema change, config, or fallback path.

### Alternatives considered

- **Ignore/quarantine legacy files at runtime:** wrong layer; risks silently ignoring divergent state.
- **Delete the receipt and rerun Doctor:** effective manual workaround, but destroys migration provenance.
- **Always discard receipt-covered files:** simpler, but could lose a newer valid attestation.
- **Require an operator choice for every reappearance:** safest for ambiguity, but unnecessary friction when canonical reconciliation can decide deterministically.
- **Only stop old writers:** useful prevention, but current `main` already writes SQLite; it would not recover affected installations.

**Best-fix verdict:** the implemented Doctor reconciliation is the smallest safe architectural fix.

### Proof

- Pre-fix reproduction: **2 expected failures**, both returning the reported conflict warning.
- Post-fix migration suite: **31/31 passed**.
- Runtime guard: **9/9 passed**.
- Doctor command boundary: **97/97 passed**.
- Full changed gate: green, including typechecks, lint, SQLite guards, and import cycles.
- Autoreview: clean.
- Production LOC: **+33/-12, net +21**; tests: **+93**.

The patch is uncommitted; no PR has been opened yet.

https://github.com/openclaw/openclaw/issues/111498

[user]
Let's commit and open up a PR.

[assistant]
I’m using the PR-maintainer and agent-transcript workflows to commit the verified repair, push a takeover-ready branch, and open the PR with the required evidence and sanitized transcript decision.

A high-confidence sanitized transcript is available. It can help reviewers and improve prioritization; I can include it or generate a local HTML preview first. I’ll commit the code now, but I’ll wait for your transcript preference before publishing the PR body.

Committed as `5f98396912e`, rebased onto current `main`, and revalidated.

The Agent Transcript workflow requires approval before adding sanitized logs. Reply **include**, **preview**, or **omit**, and I’ll open the PR.

[user]
let's include it

[assistant]
I’ll include the sanitized transcript. The transcript skill will strip prompts, raw tool output, credentials, environment details, and unrelated turns before I attach it to the PR body.

[tool summary]
36 other; raw tool outputs dropped: 36
````

</details>
<!-- agent-transcript:end -->
