### PR TITLE
fix(skills): restore oxfmt formatting in the release validation skill

### DIFF
--- a/.agents/skills/openclaw-release-validation/SKILL.md
+++ b/.agents/skills/openclaw-release-validation/SKILL.md
@@ -134,7 +134,7 @@ exists. When it does not exist, generate it:
    command and pass condition need separation. Use the literal `{{TEST_ENV}}`
    in generated OCM commands: for example, `ocm @{{TEST_ENV}} -- onboard`,
    `ocm @{{TEST_ENV}} -- tui`, and `ocm @{{TEST_ENV}} -- channels status
-   --probe`. The validator replaces this token with the actual disposable
+--probe`. The validator replaces this token with the actual disposable
    environment name only in each tester's local worksheet. Avoid broad prompts
    that bundle unrelated features or say only to "use," "exercise," or "verify"
    a surface.
@@ -302,7 +302,7 @@ Then give this compact orientation, using the actual worksheet contents:
   condition.
 - **How to leave feedback:** as they test, they should simply tell the agent
   their notes and name the surface (for example, `Models: switching persisted
-  after restart`). The agent adds those notes to that surface's **Testing
+after restart`). The agent adds those notes to that surface's **Testing
   notes** cell. They do not need to edit the file themselves.
 
 Finish with the exit instruction: **You can stop after any amount of testing;


### PR DESCRIPTION
## What Problem This Solves

`oxfmt --check` fails on `main`, so `check-docs` is red on every open PR.

On main tip `1d9cda833f9`:

```
$ ./node_modules/.bin/oxfmt --check
.agents/skills/openclaw-release-validation/SKILL.md (34ms)

Format issues found in above 1 files. Run without `--check` to fix.
Finished in 6242ms on 29409 files using 10 threads.
```

That is the only unformatted file in the repository, so it is the whole failure.

The check name makes it easy to misread as a docs-content problem, so to be precise about where it lands: `check-docs` runs `pnpm format:check`, and the job log ends with

```
$ oxfmt --check
.agents/skills/openclaw-release-validation/SKILL.md (37ms)
Format issues found in above 1 files. Run without `--check` to fix.
[ELIFECYCLE] Command failed with exit code 1.
```

The drift arrived with #126055 (`ed7317eeb95`, "fix(release): streamline validation setup"), which is two commits back from the current tip.

## Why This Change Was Made

Running the formatter over that one file is the smallest correct fix, and red `main` should not sit while it blocks a docs gate on everyone's PRs.

## User Impact

None at runtime, and no content change. The effect is on contributors: `check-docs` goes green again, so PRs stop carrying a red mark they did not cause. I have four of my own PRs currently red on exactly this.

## Evidence

The diff is two lines, both formatter output.

Worth flagging because it looks odd at a glance: both hunks remove the leading indentation from a wrapped line that sits inside an inline code span, for example

```
  their notes and name the surface (for example, `Models: switching persisted
- after restart`). The agent adds those notes ...
+after restart`). The agent adds those notes ...
```

That is deliberate on oxfmt's part rather than damage. Inside an inline code span the leading whitespace is content, so the indented continuation would render as extra spaces inside the code text. Removing it keeps the rendered span correct, and CommonMark lazy continuation means the line still belongs to the same list item, so the bullet structure is unchanged.

I chose to take the formatter's canonical output rather than rewrap the sentences to avoid the wrapped code spans. Rewrapping would render more conventionally in source, but it would be me making editorial changes inside a maintainer-owned skill document, and `oxfmt` is the canonical formatter for this repo. Happy to do it the other way if you would prefer the source not to have zero-indent continuation lines.

```
./node_modules/.bin/oxfmt --check        All matched files use the correct format.
                                         (29409 files, repo-wide)
```

Verified against a pristine checkout of `main` immediately before opening this: the failure still reproduces there, and no open PR is fixing it.

No test is added. A formatting-only change is covered by `oxfmt --check` itself, which is the gate that caught it.

AI-assisted: yes, with the failing job log read directly and every command above run by me.

- Exact-head GitHub CI passed: [run 32194218649](https://github.com/openclaw/openclaw/actions/runs/32194218649); [check-docs job 95895212092](https://github.com/openclaw/openclaw/actions/runs/32194218649/job/95895212092) completed the repository-wide `oxfmt --check` gate successfully.