### PR TITLE
fix(ui): keep Plugins hub navigation stable

### DIFF
--- a/.agents/skills/openclaw-release-validation/SKILL.md
+++ b/.agents/skills/openclaw-release-validation/SKILL.md
@@ -134,7 +134,7 @@ exists. When it does not exist, generate it:
    command and pass condition need separation. Use the literal `{{TEST_ENV}}`
    in generated OCM commands: for example, `ocm @{{TEST_ENV}} -- onboard`,
    `ocm @{{TEST_ENV}} -- tui`, and `ocm @{{TEST_ENV}} -- channels status
-   --probe`. The validator replaces this token with the actual disposable
+--probe`. The validator replaces this token with the actual disposable
    environment name only in each tester's local worksheet. Avoid broad prompts
    that bundle unrelated features or say only to "use," "exercise," or "verify"
    a surface.
@@ -302,7 +302,7 @@ Then give this compact orientation, using the actual worksheet contents:
   condition.
 - **How to leave feedback:** as they test, they should simply tell the agent
   their notes and name the surface (for example, `Models: switching persisted
-  after restart`). The agent adds those notes to that surface's **Testing
+after restart`). The agent adds those notes to that surface's **Testing
   notes** cell. They do not need to edit the file themselves.
 
 Finish with the exit instruction: **You can stop after any amount of testing;

--- a/ui/src/components/sessions-hub-header.browser.test.ts
+++ b/ui/src/components/sessions-hub-header.browser.test.ts
@@ -88,9 +88,11 @@ describe.skipIf(!hasBrowserLayout)("Sessions hub header browser layout", () => {
     const onSelect = vi.fn();
     const sessions = await mount("sessions", true, onSelect);
     const header = sessions.querySelector<HTMLElement>(".hub-page-header");
+    const title = sessions.querySelector<HTMLElement>(".page-title");
     const tabs = sessions.querySelector<HTMLElement>(".sessions-hub-tabs");
     const actions = sessions.querySelector<HTMLElement>(".hub-page-header__actions");
     expect(getComputedStyle(header!).display).toBe("grid");
+    expect(title?.getBoundingClientRect().width).toBeGreaterThan(0);
     expect(tabs?.getBoundingClientRect().width).toBeGreaterThan(0);
     expect(actions?.getBoundingClientRect().width).toBeGreaterThan(0);
 

--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -1,0 +1,307 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { BrowserContext, Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI Plugins hub navigation",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "plugins-hub-shell");
+
+const methodResponses = {
+  "agents.list": {
+    agents: [
+      { id: "main", identity: { name: "Main" }, name: "Main" },
+      { id: "reviewer", identity: { name: "Reviewer" }, name: "Reviewer" },
+    ],
+    defaultId: "main",
+    mainKey: "main",
+    scope: "agent",
+  },
+  "config.get": {
+    config: {},
+    sourceConfig: {},
+    hash: "plugins-hub-config",
+    issues: [],
+    raw: "{}",
+    valid: true,
+  },
+  "plugins.list": {
+    plugins: [
+      {
+        id: "workboard",
+        name: "Workboard",
+        description: "Dashboard workboard for agent-owned issues and sessions.",
+        kind: ["productivity"],
+        origin: "bundled",
+        installed: true,
+        enabled: true,
+        state: "enabled",
+        category: "tool",
+        removable: false,
+      },
+    ],
+    diagnostics: [],
+    mutationAllowed: true,
+  },
+  "skills.proposals.historyStatus": {
+    hasScanned: false,
+    hasMore: false,
+    ideasFound: 0,
+    reviewedSessions: 0,
+    lastScanReviewed: 0,
+  },
+  "skills.proposals.list": {
+    proposals: [],
+    schema: "openclaw.skill-workshop.proposals-manifest.v1",
+    updatedAt: "2026-08-17T12:00:00.000Z",
+  },
+  "skills.status": {
+    workspaceDir: "/tmp/openclaw-e2e/workspace",
+    managedSkillsDir: "/tmp/openclaw-e2e/skills",
+    skills: [],
+  },
+};
+
+type HubGeometry = {
+  height: number;
+  left: number;
+  title: string;
+  titleVisible: boolean;
+  top: number;
+  width: number;
+};
+
+type ControlGeometry = {
+  bottom: number;
+  height: number;
+  top: number;
+};
+
+async function createContext(viewport: { height: number; width: number }): Promise<BrowserContext> {
+  if (captureUiProof) {
+    await mkdir(proofDir, { recursive: true });
+  }
+  return suite.browser.newContext({
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport,
+    ...(captureUiProof ? { recordVideo: { dir: proofDir, size: viewport } } : {}),
+  });
+}
+
+async function hubGeometry(page: Page): Promise<HubGeometry> {
+  const tabs = page.locator(".plugins-hub-tabs");
+  await tabs.waitFor({ state: "visible" });
+  return tabs.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    const title = document.querySelector<HTMLElement>(".content-header .page-title");
+    return {
+      height: rect.height,
+      left: rect.left,
+      title: title?.textContent?.trim() ?? "",
+      titleVisible: (title?.getClientRects().length ?? 0) > 0,
+      top: rect.top,
+      width: rect.width,
+    };
+  });
+}
+
+function expectStableGeometry(actual: HubGeometry, expected: HubGeometry) {
+  expect(actual.title).toBe("Plugins");
+  expect(actual.titleVisible).toBe(true);
+  expect(Math.abs(actual.left - expected.left)).toBeLessThanOrEqual(1);
+  expect(Math.abs(actual.top - expected.top)).toBeLessThanOrEqual(1);
+  expect(Math.abs(actual.width - expected.width)).toBeLessThanOrEqual(1);
+  expect(Math.abs(actual.height - expected.height)).toBeLessThanOrEqual(1);
+}
+
+async function skillsToolbarGeometry(page: Page): Promise<ControlGeometry[]> {
+  const selectors = [
+    ".plugins-toolbar--fields > .settings-segmented",
+    ".skills-toolbar__agent .agent-select__trigger",
+    ".skills-toolbar__search .settings-input",
+    ".plugins-toolbar--fields > .plugins-toolbar__hint",
+    ".plugins-toolbar--fields > .btn",
+  ];
+  return page.locator(selectors.join(", ")).evaluateAll((elements) =>
+    elements.map((element) => {
+      const rect = element.getBoundingClientRect();
+      return { bottom: rect.bottom, height: rect.height, top: rect.top };
+    }),
+  );
+}
+
+function expectAlignedControlRow(controls: ControlGeometry[]) {
+  expect(controls).toHaveLength(5);
+  for (const metric of ["top", "bottom", "height"] as const) {
+    const values = controls.map((control) => control[metric]);
+    expect(
+      Math.max(...values) - Math.min(...values),
+      `${metric}: ${values.join(", ")}`,
+    ).toBeLessThanOrEqual(1);
+  }
+}
+
+async function expectStatusFilterContained(page: Page) {
+  const geometry = await page
+    .locator(".plugins-toolbar--fields > .settings-segmented")
+    .evaluate((element) => ({
+      containerTop: element.getBoundingClientRect().top,
+      containerBottom: element.getBoundingClientRect().bottom,
+      optionTop: Math.min(
+        ...Array.from(element.children, (child) => child.getBoundingClientRect().top),
+      ),
+      optionBottom: Math.max(
+        ...Array.from(element.children, (child) => child.getBoundingClientRect().bottom),
+      ),
+    }));
+  expect(geometry.optionTop).toBeGreaterThanOrEqual(geometry.containerTop - 1);
+  expect(geometry.optionBottom).toBeLessThanOrEqual(geometry.containerBottom + 1);
+}
+
+async function captureScreenshot(page: Page, name: string) {
+  if (!captureUiProof) {
+    return;
+  }
+  await page.screenshot({
+    animations: "disabled",
+    fullPage: true,
+    path: path.join(proofDir, name),
+  });
+}
+
+async function selectHubTab(
+  page: Page,
+  name: "Installed" | "Discover" | "Skills" | "Workshop",
+  target: { pathname: string; routeId: string },
+) {
+  await page.getByRole("tab", { name: new RegExp(`^${name}`, "u") }).click();
+  await waitForControlUiRoute(page, target);
+  await expect
+    .poll(() => page.getByRole("tab", { name: new RegExp(`^${name}`, "u") }).getAttribute("active"))
+    .not.toBeNull();
+}
+
+suite.define(() => {
+  it.each([
+    { label: "desktop", viewport: { height: 960, width: 1440 } },
+    { label: "narrow", viewport: { height: 852, width: 393 } },
+  ])(
+    "keeps the hub shell fixed through every $label tab transition",
+    async ({ label, viewport }) => {
+      const context = await createContext(viewport);
+      const page = await context.newPage();
+      await installMockGateway(page, {
+        featureMethods: [
+          "agents.list",
+          "config.get",
+          "plugins.list",
+          "skills.proposals.historyStatus",
+          "skills.proposals.list",
+          "skills.status",
+        ],
+        methodResponses,
+      });
+
+      try {
+        await page.goto(`${suite.server.baseUrl}settings/plugins`);
+        await page.addStyleTag({
+          content:
+            "*, *::before, *::after { animation-duration: 0s !important; transition-duration: 0s !important; }",
+        });
+        await waitForControlUiRoute(page, { pathname: "/settings/plugins", routeId: "plugins" });
+        const installed = await hubGeometry(page);
+        expect(installed.title).toBe("Plugins");
+        expect(installed.titleVisible).toBe(true);
+        await captureScreenshot(page, `${label}-01-installed.png`);
+
+        await selectHubTab(page, "Discover", {
+          pathname: "/settings/plugins/discover",
+          routeId: "plugins",
+        });
+        expectStableGeometry(await hubGeometry(page), installed);
+        await captureScreenshot(page, `${label}-02-discover.png`);
+
+        await selectHubTab(page, "Skills", { pathname: "/skills", routeId: "skills" });
+        expectStableGeometry(await hubGeometry(page), installed);
+        const needsSetupFilter = page.locator(
+          'wa-radio.settings-segmented__btn[value="needs-setup"]',
+        );
+        await needsSetupFilter.click();
+        await expect
+          .poll(() =>
+            needsSetupFilter.evaluate((element) =>
+              element.classList.contains("settings-segmented__btn--active"),
+            ),
+          )
+          .toBe(true);
+        if (label === "desktop") {
+          expectAlignedControlRow(await skillsToolbarGeometry(page));
+        }
+        await expectStatusFilterContained(page);
+        await captureScreenshot(page, `${label}-03-skills.png`);
+
+        await selectHubTab(page, "Workshop", {
+          pathname: "/skills/workshop",
+          routeId: "skill-workshop",
+        });
+        expectStableGeometry(await hubGeometry(page), installed);
+        const workshopShellBottom = await page
+          .locator(".plugins-hub-header")
+          .evaluate((element) => element.getBoundingClientRect().bottom);
+        const workshopControlsTop = await page
+          .locator(".sw-header-controls")
+          .evaluate((element) => element.getBoundingClientRect().top);
+        expect(workshopControlsTop).toBeGreaterThanOrEqual(workshopShellBottom);
+        await captureScreenshot(page, `${label}-04-workshop-today.png`);
+
+        await page.locator("#skill-workshop-mode-tab-board").click();
+        await expect
+          .poll(() => page.locator("#skill-workshop-mode-tab-board").getAttribute("active"))
+          .not.toBeNull();
+        expectStableGeometry(await hubGeometry(page), installed);
+        const boardLayout = await page.locator(".content--skill-workshop").evaluate((element) => {
+          const style = getComputedStyle(element);
+          return { display: style.display, overflow: style.overflow };
+        });
+        expect(boardLayout).toEqual({ display: "flex", overflow: "hidden" });
+        await captureScreenshot(page, `${label}-05-workshop-board.png`);
+
+        await page.locator("#skill-workshop-mode-tab-today").click();
+        await expect
+          .poll(() => page.locator("#skill-workshop-mode-tab-today").getAttribute("active"))
+          .not.toBeNull();
+        expectStableGeometry(await hubGeometry(page), installed);
+        const todayLayout = await page
+          .locator(".content--skill-workshop-today")
+          .evaluate((element) => {
+            const style = getComputedStyle(element);
+            return { display: style.display, overflowY: style.overflowY };
+          });
+        expect(todayLayout).toEqual({ display: "block", overflowY: "auto" });
+
+        await selectHubTab(page, "Skills", { pathname: "/skills", routeId: "skills" });
+        expectStableGeometry(await hubGeometry(page), installed);
+        await selectHubTab(page, "Discover", {
+          pathname: "/settings/plugins/discover",
+          routeId: "plugins",
+        });
+        expectStableGeometry(await hubGeometry(page), installed);
+        await selectHubTab(page, "Installed", {
+          pathname: "/settings/plugins",
+          routeId: "plugins",
+        });
+        expectStableGeometry(await hubGeometry(page), installed);
+      } finally {
+        await context.close();
+      }
+    },
+  );
+});

--- a/ui/src/pages/plugins/plugins-hub-header.ts
+++ b/ui/src/pages/plugins/plugins-hub-header.ts
@@ -1,0 +1,29 @@
+import { html, type TemplateResult } from "lit";
+import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
+import { renderDocsLink } from "../../components/settings-ui.ts";
+import { t } from "../../i18n/index.ts";
+import { renderPluginsHubTabs, type PluginsHubTab } from "./plugins-hub.ts";
+
+const PLUGINS_DOCS_URL = "https://docs.openclaw.ai/plugins/manage-plugins";
+
+type PluginsHubHeaderProps = {
+  active: PluginsHubTab;
+  onSelect: (tab: PluginsHubTab) => void;
+};
+
+export function renderPluginsHubHeader(props: PluginsHubHeaderProps): TemplateResult {
+  return html`
+    <section class="content-header content-header--page hub-page-header plugins-hub-header">
+      <div class="hub-page-header__title">
+        <h1 class="page-title">${titleForRoute("plugins")}</h1>
+        <div class="page-subtitle">
+          ${subtitleForRoute("plugins")} ${renderDocsLink(PLUGINS_DOCS_URL, t("common.learnMore"))}
+        </div>
+      </div>
+      <div class="hub-page-header__tabs">
+        ${renderPluginsHubTabs({ active: props.active, onSelect: props.onSelect })}
+      </div>
+      <div class="hub-page-header__actions"></div>
+    </section>
+  `;
+}

--- a/ui/src/pages/plugins/plugins-hub.ts
+++ b/ui/src/pages/plugins/plugins-hub.ts
@@ -1,17 +1,30 @@
-import type { HubTabOption } from "../../components/hub-tabs.ts";
+import { renderHubTabs, type HubTabOption } from "../../components/hub-tabs.ts";
 import { t } from "../../i18n/index.ts";
 
 export type PluginsHubTab = "installed" | "discover" | "skills" | "workshop";
 
 export const PLUGINS_HUB_PANEL_ID = "plugins-hub-panel";
 
-export function pluginsHubTabs(
-  installedCount: number | null = null,
-): ReadonlyArray<HubTabOption<PluginsHubTab>> {
+function pluginsHubTabs(): ReadonlyArray<HubTabOption<PluginsHubTab>> {
   return [
-    { value: "installed", label: t("pluginsPage.installedTab"), count: installedCount },
+    { value: "installed", label: t("pluginsPage.installedTab") },
     { value: "discover", label: t("pluginsPage.discoverTab") },
     { value: "skills", label: t("tabs.skills") },
     { value: "workshop", label: t("pluginsPage.workshopTab") },
   ];
+}
+
+export function renderPluginsHubTabs(props: {
+  active: PluginsHubTab;
+  onSelect: (tab: PluginsHubTab) => void;
+}) {
+  return renderHubTabs({
+    id: "plugins",
+    active: props.active,
+    tabs: pluginsHubTabs(),
+    ariaLabel: t("pluginsPage.hubTablistLabel"),
+    panelId: PLUGINS_HUB_PANEL_ID,
+    className: "plugins-tabs",
+    onSelect: props.onSelect,
+  });
 }

--- a/ui/src/pages/plugins/plugins-page.ts
+++ b/ui/src/pages/plugins/plugins-page.ts
@@ -4,7 +4,6 @@ import type { RouteLocation } from "@openclaw/uirouter";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { pathForPluginsHubTab, pathForRoute } from "../../app-route-paths.ts";
 import {
   applicationContext,
@@ -13,9 +12,7 @@ import {
 } from "../../app/context.ts";
 import { resolveControlUiAuthCandidates } from "../../app/control-ui-auth.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
-import { renderHubTabs } from "../../components/hub-tabs.ts";
 import type { McpServerForm } from "../../components/mcp-server-form.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveEditableSnapshotConfig } from "../../lib/config/config-state-model.ts";
@@ -52,7 +49,8 @@ import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import { fetchPluginIconBlobUrl } from "./icon-loader.ts";
 import { readPluginInstallPolicyWarning } from "./install-policy-warning.ts";
-import { PLUGINS_HUB_PANEL_ID, pluginsHubTabs, type PluginsHubTab } from "./plugins-hub.ts";
+import { renderPluginsHubHeader } from "./plugins-hub-header.ts";
+import type { PluginsHubTab } from "./plugins-hub.ts";
 import type { ConnectorSuggestion } from "./presentation.ts";
 import { pluginArtPath } from "./presentation.ts";
 import { canonicalPluginsRouteLocation, pluginsHubTabForRoute } from "./route-data.ts";
@@ -64,8 +62,6 @@ import {
   type PluginRowMessage,
   type PluginsTab,
 } from "./view.ts";
-
-const PLUGINS_DOCS_URL = "https://docs.openclaw.ai/plugins/manage-plugins";
 
 export type PluginsRouteData = {
   gateway: ApplicationContext["gateway"];
@@ -979,29 +975,11 @@ class PluginsPage extends OpenClawLightDomElement {
   override render() {
     const blockedReason = this.mutationBlockedReason();
     return html`
-      <section class="content-header content-header--page plugins-content-header">
-        <div>
-          <h1 class="page-title">${titleForRoute("plugins")}</h1>
-          <div class="page-subtitle">
-            ${subtitleForRoute("plugins")}
-            ${renderDocsLink(PLUGINS_DOCS_URL, t("common.learnMore"))}
-          </div>
-        </div>
-      </section>
+      ${renderPluginsHubHeader({
+        active: this.activeTab,
+        onSelect: (tab) => this.selectHubTab(tab),
+      })}
       ${renderSettingsWorkspace(html`
-        <div class="plugins-hub-tabs-row">
-          ${renderHubTabs({
-            id: "plugins",
-            active: this.activeTab,
-            tabs: pluginsHubTabs(
-              this.result?.plugins.filter((plugin) => plugin.installed).length ?? 0,
-            ),
-            ariaLabel: t("pluginsPage.hubTablistLabel"),
-            panelId: PLUGINS_HUB_PANEL_ID,
-            className: "plugins-tabs",
-            onSelect: (tab) => this.selectHubTab(tab),
-          })}
-        </div>
         ${renderPlugins({
           connected: this.gateway.connected,
           loading: this.loading,

--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -3,9 +3,7 @@ import { initialState, Task } from "@lit/task";
 import { html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import { applicationContext, type ApplicationGatewaySnapshot } from "../../app/context.ts";
-import { renderHubTabs } from "../../components/hub-tabs.ts";
 import "../../components/tooltip.ts";
-import { t } from "../../i18n/index.ts";
 import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import {
@@ -14,7 +12,8 @@ import {
 } from "../../lib/skill-workshop/index.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
-import { PLUGINS_HUB_PANEL_ID, pluginsHubTabs } from "../plugins/plugins-hub.ts";
+import { renderPluginsHubHeader } from "../plugins/plugins-hub-header.ts";
+import { PLUGINS_HUB_PANEL_ID } from "../plugins/plugins-hub.ts";
 import { canCallWorkshopAdminMethod, resolveWorkshopAccess } from "./access.ts";
 import { renderSkillWorkshopHeaderControls, setSkillWorkshopMode } from "./header-controls.ts";
 import {
@@ -67,25 +66,10 @@ function renderSkillWorkshopPage(
 
   return html`
     <section class=${pageClass}>
-      <section class="content-header content-header--page plugins-content-header">
-        <div>
-          <h1 class="page-title">${t("tabs.skillWorkshop")}</h1>
-        </div>
-        <div class="page-meta">
-          ${renderSkillWorkshopHeaderControls(state, renderContext, requestUpdate)}
-        </div>
-      </section>
-      <div class="plugins-hub-tabs-row">
-        ${renderHubTabs({
-          id: "plugins",
-          active: "workshop",
-          tabs: pluginsHubTabs(),
-          ariaLabel: t("pluginsPage.hubTablistLabel"),
-          panelId: PLUGINS_HUB_PANEL_ID,
-          className: "plugins-tabs",
-          onSelect: (tab) => selectPluginsHubTab(context, tab),
-        })}
-      </div>
+      ${renderPluginsHubHeader({
+        active: "workshop",
+        onSelect: (tab) => selectPluginsHubTab(context, tab),
+      })}
       <wa-tab-panel
         id=${PLUGINS_HUB_PANEL_ID}
         class="sw-hub-panel"
@@ -93,6 +77,9 @@ function renderSkillWorkshopPage(
         active
         aria-labelledby="plugins-tab-workshop"
       >
+        <div class="sw-workshop-toolbar">
+          ${renderSkillWorkshopHeaderControls(state, renderContext, requestUpdate)}
+        </div>
         ${(() => {
           const visibleProposals = filterSkillWorkshopProposals(
             state.skillWorkshopProposals,

--- a/ui/src/pages/skills/skills-page.ts
+++ b/ui/src/pages/skills/skills-page.ts
@@ -3,16 +3,13 @@ import { initialState, Task, TaskStatus } from "@lit/task";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import type { AgentsListResult, SkillStatusReport } from "../../api/types.ts";
-import { titleForRoute } from "../../app-navigation.ts";
 import { pathForPluginsHubTab } from "../../app-route-paths.ts";
 import {
   applicationContext,
   type ApplicationContext,
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
-import { renderHubTabs } from "../../components/hub-tabs.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
-import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
 import { searchClawHub, type ClawHubSearchResult } from "../../lib/skills/clawhub-search.ts";
@@ -37,11 +34,8 @@ import {
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
-import {
-  PLUGINS_HUB_PANEL_ID,
-  pluginsHubTabs,
-  type PluginsHubTab,
-} from "../plugins/plugins-hub.ts";
+import { renderPluginsHubHeader } from "../plugins/plugins-hub-header.ts";
+import { PLUGINS_HUB_PANEL_ID, type PluginsHubTab } from "../plugins/plugins-hub.ts";
 import { renderSkills, type SkillDetailTab, type SkillsStatusFilter } from "./view.ts";
 
 export type SkillsRouteData = {
@@ -362,23 +356,11 @@ class SkillsPage extends OpenClawLightDomElement {
     const agents = this.context.agents.state;
     const error = this.skillsError ?? agents.agentsError;
     return html`
-      <section class="content-header content-header--page plugins-content-header">
-        <div>
-          <h1 class="page-title">${titleForRoute("skills")}</h1>
-        </div>
-      </section>
+      ${renderPluginsHubHeader({
+        active: "skills",
+        onSelect: (tab) => this.selectHubTab(tab),
+      })}
       ${renderSettingsWorkspace(html`
-        <div class="plugins-hub-tabs-row">
-          ${renderHubTabs({
-            id: "plugins",
-            active: "skills",
-            tabs: pluginsHubTabs(),
-            ariaLabel: t("pluginsPage.hubTablistLabel"),
-            panelId: PLUGINS_HUB_PANEL_ID,
-            className: "plugins-tabs",
-            onSelect: (tab) => this.selectHubTab(tab),
-          })}
-        </div>
         <wa-tab-panel
           id=${PLUGINS_HUB_PANEL_ID}
           name="skills"

--- a/ui/src/styles/hub-tabs.css
+++ b/ui/src/styles/hub-tabs.css
@@ -137,10 +137,6 @@ wa-tab.hub-tab:focus-visible::part(base) {
     justify-self: stretch;
   }
 
-  .hub-page-header .page-title {
-    display: none;
-  }
-
   .hub-page-header .hub-page-header__tabs {
     grid-area: tabs;
   }

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -2,17 +2,8 @@
  * (styles/settings.css): art tiles, row messages, the detail overlay, and the
  * MCP inline form. Structural layout comes from .settings-page/.settings-row. */
 
-.plugins-content-header .page-title {
+.plugins-hub-header .page-title {
   margin: 0;
-}
-
-/* Hub tab strip aligned with the settings page column below it
-   (1120px matches .settings-page--wide). */
-.plugins-hub-tabs-row {
-  width: 100%;
-  max-width: 1120px;
-  margin: 0 auto;
-  padding: var(--space-3) var(--space-4) 0;
 }
 
 /* ---------- toolbar ---------- */
@@ -24,15 +15,26 @@
   flex-wrap: wrap;
 }
 
-/* Toolbars mixing labelled fields with buttons align on the control row. */
+/* Toolbars mixing labelled fields with buttons share one control-row baseline. */
 .plugins-toolbar--fields {
   align-items: flex-end;
 }
 
+.plugins-toolbar--fields > .plugins-toolbar__hint {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--settings-control-height);
+}
+
 .plugins-toolbar--fields > .settings-segmented,
 .plugins-toolbar--fields > .btn,
-.plugins-toolbar--fields > .plugins-toolbar__hint {
-  margin-bottom: 3px;
+.skills-toolbar__agent .agent-select__trigger {
+  box-sizing: border-box;
+  height: var(--settings-control-height);
+}
+
+.plugins-toolbar--fields > .settings-segmented {
+  --wa-form-control-height: calc(var(--settings-control-height) - 6px);
 }
 
 .plugins-toolbar__search {
@@ -909,6 +911,10 @@ h3.plugins-subheader {
 }
 
 @media (max-width: 560px) {
+  .plugins-toolbar--fields > .settings-segmented {
+    height: auto;
+  }
+
   .plugins-remove-confirm {
     flex-wrap: wrap;
     white-space: normal;

--- a/ui/src/styles/skill-workshop.css
+++ b/ui/src/styles/skill-workshop.css
@@ -26,15 +26,6 @@
   flex-shrink: 0;
 }
 
-/* Hub tab strip stays fixed; the board scrolls inside the panel below it.
-   The board is full-width, so the strip skips the settings-column centering. */
-.content--skill-workshop .plugins-hub-tabs-row {
-  flex-shrink: 0;
-  max-width: none;
-  margin: 0;
-  padding-inline: 0;
-}
-
 .sw-hub-panel {
   display: flex;
   flex-direction: column;
@@ -62,6 +53,16 @@
   flex: 1 1 auto;
   min-height: 0;
   width: 100%;
+}
+
+.sw-hub-panel::part(base) {
+  gap: var(--space-3);
+}
+
+.sw-workshop-toolbar {
+  display: flex;
+  flex-shrink: 0;
+  justify-content: flex-end;
 }
 
 .sw-hub-panel .skill-workshop {


### PR DESCRIPTION
## What Problem This Solves

Switching between Installed, Discover, Skills, and Workshop rebuilt the Plugins hub chrome with different titles, tab widths, alignment, actions, and scroll ownership. The tab strip moved between routes, Skills controls used inconsistent heights, selected status filters overflowed their track, and the shared mobile hub layout hid the page title.

## Why This Change Was Made

The four routes now render one shared Plugins header and stable tab model. Route-specific controls stay inside their tab panel, Workshop retains its Board/Today scroll containers below the shared shell, and the Skills toolbar uses one control-row height with contained segmented options. The shared mobile hub header keeps its page title visible.

## User Impact

Operators can move between Plugins hub tabs without the navigation or surrounding page identity shifting. Skills controls align consistently on desktop and wrap without clipping on narrow screens, and the Plugins title remains visible on mobile.

## Evidence

- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/plugins-hub-navigation.e2e.test.ts`: 2 passed across desktop and narrow viewports.
- `pnpm --dir ui test src/components/sessions-hub-header.browser.test.ts`: 3 passed.
- `node scripts/check-changed.mjs`: passed.
- `env -u CODEX_HOME .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output`: no findings.
- Production: +97/-105 lines (net -8). Tests: +309/-0 lines.

### Desktop

Before: Skills owned the page identity and positioned the tabs independently.

![Plugins hub before on desktop](https://github.com/user-attachments/assets/1a26cafc-0331-4b4f-80bf-0ad9bef85c69)

After: Plugins owns one stable page identity and centered tab frame.

![Plugins hub after on desktop](https://github.com/user-attachments/assets/77d0a68d-ffb6-4ef5-8b90-e04a6b89fafd)

### Mobile

Before: the active route supplied its own page title and tab geometry.

![Plugins hub before on mobile](https://github.com/user-attachments/assets/afe66ab0-3f90-4236-89ba-70afbf4567c2)

After: the shared Plugins title remains visible above the stable tabs.

![Plugins hub after on mobile](https://github.com/user-attachments/assets/16076a94-8ea9-48d2-a9e6-83597563f111)

AI-assisted: Codex implemented and verified this change under maintainer direction.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted OpenClaw session transcript</summary>

```text
[user]
Switching tabs in the Plugins hub reconfigures the tab bar and, on Workshop, much of the surrounding UI. Take a look and tell me what you notice.

[assistant]
The routes present one hub but independently own their page title, tab strip, actions, width policy, and scroll layout. The existing Sessions/Worktrees shared header is the direct precedent: one stable hub identity and tab frame, with route-specific controls inside the active panel.

[user]
Take a stab at that in a new worktree.

[assistant]
Created an isolated worktree from current main. Added a shared Plugins header and fixed tab model, moved Workshop controls below the shared shell, and preserved Board/Today scroll ownership. The pre-fix browser reproduction failed because titles and tab geometry shifted; the repaired desktop and 393px flows passed all forward/reverse transitions.

[user]
The controls within the Skills tab need an alignment pass.

[assistant]
Normalized the desktop toolbar to one 32px control row. The first narrow screenshot exposed clipped wrapped filters, so the mobile breakpoint restores intrinsic segmented-control height and verifies every option remains contained.

[user]
We need to fix the overflowing selected state.

[assistant]
The outer track was 32px while each radio retained a 32px minimum height, leaving no room for the border and inset. Constrained radios to the track's 26px inner height and added selected-state containment checks at desktop and narrow widths.

[user]
On mobile we lose the header. Is that a problem with our implementation?

[assistant]
Yes. The new shell inherited a shared mobile rule that hid every hub page title. Fixed the shared hub-header contract rather than adding a Plugins-only override; Plugins and the sibling Sessions browser test now retain visible mobile titles.

[user]
Looks good. Commit and open a PR with visual proof.

[assistant]
Committed the scoped UI changes, pushed the branch, created the PR as a draft to avoid the merge-ref race, and attached inspected before/after desktop and mobile screenshots. Focused browser proof, the changed-file gate, and Autoreview are green.
```

</details>
<!-- agent-transcript:end -->
