### PR TITLE
fix(models): seed configured provider model entries from catalog metadata

### DIFF
--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -138,3 +138,134 @@ describe("config defaults", () => {
     expect(next.agents?.defaults?.subagents?.maxConcurrent).toBe(DEFAULT_SUBAGENT_MAX_CONCURRENT);
   });
 });
+
+describe("applyModelDefaults catalog seeding", () => {
+  const catalogRegistry = {
+    plugins: [
+      {
+        id: "openai",
+        modelCatalog: {
+          providers: {
+            openai: {
+              models: [
+                {
+                  id: "gpt-5.6-sol",
+                  name: "GPT-5.6 Sol",
+                  reasoning: true,
+                  input: ["text", "image"],
+                  contextWindow: 400_000,
+                  contextTokens: 272_000,
+                  maxTokens: 128_000,
+                  cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+                  thinkingLevelMap: { off: "none" },
+                },
+              ],
+            },
+          },
+        },
+      },
+    ],
+    // SAFETY: minimal manifest record carrying only the fields applyModelDefaults reads.
+  } as never;
+
+  // Regression: an override entry pinning only sizing fields materialized as a
+  // text-only, non-reasoning, zero-cost model, silently dropping vision-gated
+  // tools (like `computer`) for that model downstream.
+  it("fills omitted fields from the owning catalog row before generic defaults", async () => {
+    const { applyModelDefaults } = await import("./defaults.js");
+    const cfg = applyModelDefaults(
+      {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                // SAFETY: mirrors a real operator config entry that omits input/reasoning/cost.
+                {
+                  id: "gpt-5.6-sol",
+                  name: "GPT-5.6",
+                  contextWindow: 1_050_000,
+                  contextTokens: 922_000,
+                } as never,
+              ],
+            },
+          },
+        },
+      },
+      { manifestRegistry: catalogRegistry },
+    );
+    const model = expectDefined(
+      cfg.models?.providers?.openai?.models?.[0],
+      "materialized model entry",
+    );
+    expect(model.input).toEqual(["text", "image"]);
+    expect(model.reasoning).toBe(true);
+    expect(model.cost).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 });
+    expect(model.maxTokens).toBe(128_000);
+    expect(model.thinkingLevelMap).toEqual({ off: "none" });
+    // Authored fields stay authoritative.
+    expect(model.contextWindow).toBe(1_050_000);
+    expect(model.contextTokens).toBe(922_000);
+    expect(model.name).toBe("GPT-5.6");
+  });
+
+  it("keeps authored metadata authoritative over the catalog row", async () => {
+    const { applyModelDefaults } = await import("./defaults.js");
+    const cfg = applyModelDefaults(
+      {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                {
+                  id: "gpt-5.6-sol",
+                  name: "text-only override",
+                  reasoning: false,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 8_192,
+                  maxTokens: 4_096,
+                },
+              ],
+            },
+          },
+        },
+      },
+      { manifestRegistry: catalogRegistry },
+    );
+    const model = expectDefined(
+      cfg.models?.providers?.openai?.models?.[0],
+      "materialized model entry",
+    );
+    expect(model.input).toEqual(["text"]);
+    expect(model.reasoning).toBe(false);
+    expect(model.maxTokens).toBe(4_096);
+  });
+
+  it("falls back to generic defaults when no catalog row matches", async () => {
+    const { applyModelDefaults } = await import("./defaults.js");
+    const cfg = applyModelDefaults(
+      {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://custom.example.com/v1",
+              models: [
+                // SAFETY: mirrors a real operator config entry that omits input/reasoning/cost.
+                { id: "house-model", name: "House Model" } as never,
+              ],
+            },
+          },
+        },
+      },
+      { manifestRegistry: catalogRegistry },
+    );
+    const model = expectDefined(
+      cfg.models?.providers?.custom?.models?.[0],
+      "materialized model entry",
+    );
+    expect(model.input).toEqual(["text"]);
+    expect(model.reasoning).toBe(false);
+  });
+});

--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -243,6 +243,73 @@ describe("applyModelDefaults catalog seeding", () => {
     expect(model.maxTokens).toBe(4_096);
   });
 
+  it("preserves catalog tiered pricing when flat cost fields are authored", async () => {
+    const { applyModelDefaults } = await import("./defaults.js");
+    const tieredRegistry = {
+      plugins: [
+        {
+          id: "openai",
+          modelCatalog: {
+            providers: {
+              openai: {
+                models: [
+                  {
+                    id: "gpt-5.6-sol",
+                    name: "GPT-5.6 Sol",
+                    input: ["text", "image"],
+                    cost: {
+                      input: 5,
+                      output: 30,
+                      cacheRead: 0.5,
+                      cacheWrite: 6.25,
+                      tieredPricing: [
+                        {
+                          input: 2.5,
+                          output: 15,
+                          cacheRead: 0.25,
+                          cacheWrite: 3,
+                          maxInputTokens: 200_000,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+      // SAFETY: minimal manifest record carrying only the fields applyModelDefaults reads.
+    } as never;
+    const cfg = applyModelDefaults(
+      {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                // SAFETY: mirrors an operator override with explicit flat cost only.
+                {
+                  id: "gpt-5.6-sol",
+                  name: "GPT-5.6",
+                  cost: { input: 4, output: 24, cacheRead: 0.4, cacheWrite: 5 },
+                } as never,
+              ],
+            },
+          },
+        },
+      },
+      { manifestRegistry: tieredRegistry },
+    );
+    const model = expectDefined(
+      cfg.models?.providers?.openai?.models?.[0],
+      "materialized model entry",
+    );
+    expect(model.cost?.input).toBe(4);
+    expect(model.cost?.tieredPricing).toHaveLength(1);
+    expect(model.input).toEqual(["text", "image"]);
+  });
+
   it("falls back to generic defaults when no catalog row matches", async () => {
     const { applyModelDefaults } = await import("./defaults.js");
     const cfg = applyModelDefaults(

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -157,6 +157,59 @@ export function applyTalkConfigNormalization(config: OpenClawConfig): OpenClawCo
   return normalizeTalkConfig(config);
 }
 
+/** Catalog metadata eligible to fill fields the operator did not author. */
+type CatalogSeedModel = Pick<
+  ModelDefinitionConfig,
+  | "input"
+  | "reasoning"
+  | "cost"
+  | "contextWindow"
+  | "contextTokens"
+  | "maxTokens"
+  | "thinkingLevelMap"
+  | "compat"
+>;
+
+/**
+ * Indexes plugin manifest catalog rows so configured model entries can inherit
+ * metadata the operator omitted. Without this, materialization would turn an
+ * override entry that pins only sizing fields into a text-only, non-reasoning,
+ * zero-cost model — silently dropping vision-gated tools downstream.
+ */
+function buildManifestCatalogModelLookup(
+  manifestRegistry: Pick<PluginManifestRegistry, "plugins"> | undefined,
+  policies: ReturnType<typeof collectManifestModelIdNormalizationPolicies> | undefined,
+): (providerId: string, modelId: string) => Partial<CatalogSeedModel> | undefined {
+  const plugins = manifestRegistry?.plugins;
+  if (!plugins || plugins.length === 0) {
+    return () => undefined;
+  }
+  let index: Map<string, Partial<CatalogSeedModel>> | undefined;
+  const keyFor = (providerId: string, modelId: string) =>
+    normalizeProviderId(providerId) +
+    " " +
+    normalizeConfiguredProviderCatalogModelId(providerId, modelId, policies).toLowerCase();
+  return (providerId, modelId) => {
+    if (!index) {
+      index = new Map();
+      for (const plugin of plugins) {
+        for (const [catalogProviderId, provider] of Object.entries(
+          plugin.modelCatalog?.providers ?? {},
+        )) {
+          for (const model of provider.models) {
+            const key = keyFor(catalogProviderId, model.id);
+            if (!index.has(key)) {
+              // SAFETY: ModelCatalogModel's seed fields are a structural subset of ModelDefinitionConfig; only the picked metadata fields are read from this entry.
+              index.set(key, model as Partial<CatalogSeedModel>);
+            }
+          }
+        }
+      }
+    }
+    return index.get(keyFor(providerId, modelId));
+  };
+}
+
 export function applyModelDefaults(
   cfg: OpenClawConfig,
   options: ProviderPolicyDefaultsOptions = {},
@@ -170,6 +223,10 @@ export function applyModelDefaults(
     const modelIdNormalizationPolicies = manifestRegistry
       ? collectManifestModelIdNormalizationPolicies(manifestRegistry.plugins)
       : undefined;
+    const resolveCatalogModel = buildManifestCatalogModelLookup(
+      manifestRegistry,
+      modelIdNormalizationPolicies,
+    );
     const nextProviders = { ...providerConfig };
     for (const [providerId, provider] of Object.entries(providerConfig)) {
       const normalizedProvider = normalizeProviderConfigForConfigDefaults({
@@ -206,17 +263,26 @@ export function applyModelDefaults(
           modelMutated = true;
         }
 
-        const reasoning = typeof raw.reasoning === "boolean" ? raw.reasoning : false;
+        // Config entries are overrides, not full definitions: authored fields
+        // win, the owning catalog row fills omitted fields, and only then do
+        // generic defaults apply. Defaulting straight past the catalog would
+        // erase field absence (for example turning an entry that pins only
+        // contextWindow into a text-only model, dropping vision-gated tools).
+        const catalogModel = resolveCatalogModel(providerId, id);
+        const reasoning =
+          typeof raw.reasoning === "boolean" ? raw.reasoning : (catalogModel?.reasoning ?? false);
         if (raw.reasoning !== reasoning) {
           modelMutated = true;
         }
 
-        const input = raw.input ?? [...DEFAULT_MODEL_INPUT];
+        const input = raw.input ?? catalogModel?.input ?? [...DEFAULT_MODEL_INPUT];
         if (raw.input === undefined) {
           modelMutated = true;
         }
 
-        const cost = resolveModelCost(raw.cost);
+        const cost = resolveModelCost(
+          raw.cost || catalogModel?.cost ? { ...catalogModel?.cost, ...raw.cost } : undefined,
+        );
         const costMutated =
           !raw.cost ||
           raw.cost.input !== cost.input ||
@@ -227,12 +293,20 @@ export function applyModelDefaults(
           modelMutated = true;
         }
 
-        const contextWindow = isPositiveNumber(raw.contextWindow) ? raw.contextWindow : undefined;
+        const contextWindow = isPositiveNumber(raw.contextWindow)
+          ? raw.contextWindow
+          : isPositiveNumber(catalogModel?.contextWindow)
+            ? catalogModel.contextWindow
+            : undefined;
         if (raw.contextWindow !== contextWindow) {
           modelMutated = true;
         }
 
-        const contextTokens = isPositiveNumber(raw.contextTokens) ? raw.contextTokens : undefined;
+        const contextTokens = isPositiveNumber(raw.contextTokens)
+          ? raw.contextTokens
+          : isPositiveNumber(catalogModel?.contextTokens)
+            ? catalogModel.contextTokens
+            : undefined;
         if (raw.contextTokens !== contextTokens) {
           modelMutated = true;
         }
@@ -242,7 +316,11 @@ export function applyModelDefaults(
           providerMaxTokens ?? DEFAULT_MODEL_MAX_TOKENS,
           maxTokenContextWindow,
         );
-        const rawMaxTokens = isPositiveNumber(raw.maxTokens) ? raw.maxTokens : defaultMaxTokens;
+        const rawMaxTokens = isPositiveNumber(raw.maxTokens)
+          ? raw.maxTokens
+          : isPositiveNumber(catalogModel?.maxTokens)
+            ? catalogModel.maxTokens
+            : defaultMaxTokens;
         const maxTokens = resolveNormalizedProviderModelMaxTokens({
           providerId,
           modelId: id,
@@ -257,20 +335,38 @@ export function applyModelDefaults(
           modelMutated = true;
         }
 
+        const thinkingLevelMap =
+          raw.thinkingLevelMap === undefined && catalogModel?.thinkingLevelMap !== undefined
+            ? catalogModel.thinkingLevelMap
+            : undefined;
+        const compat =
+          raw.compat === undefined && catalogModel?.compat !== undefined
+            ? catalogModel.compat
+            : undefined;
+        if (thinkingLevelMap !== undefined || compat !== undefined) {
+          modelMutated = true;
+        }
+
         if (!modelMutated) {
           return model;
         }
         providerMutated = true;
-        return Object.assign({}, raw, {
-          id,
-          reasoning,
-          input,
-          cost,
-          contextWindow,
-          contextTokens,
-          maxTokens,
-          api,
-        }) as ModelDefinitionConfig;
+        return Object.assign(
+          {},
+          raw,
+          {
+            id,
+            reasoning,
+            input,
+            cost,
+            contextWindow,
+            contextTokens,
+            maxTokens,
+            api,
+          },
+          thinkingLevelMap !== undefined ? { thinkingLevelMap } : {},
+          compat !== undefined ? { compat } : {},
+        ) as ModelDefinitionConfig;
       });
 
       if (!providerMutated) {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -283,12 +283,20 @@ export function applyModelDefaults(
         const cost = resolveModelCost(
           raw.cost || catalogModel?.cost ? { ...catalogModel?.cost, ...raw.cost } : undefined,
         );
+        // resolveModelCost keeps only the flat per-token fields; carry tiered
+        // pricing through explicitly so an authored or catalog tier table is
+        // not silently discarded when other cost fields are defaulted.
+        const tieredPricing = raw.cost?.tieredPricing ?? catalogModel?.cost?.tieredPricing;
+        if (tieredPricing) {
+          cost.tieredPricing = tieredPricing;
+        }
         const costMutated =
           !raw.cost ||
           raw.cost.input !== cost.input ||
           raw.cost.output !== cost.output ||
           raw.cost.cacheRead !== cost.cacheRead ||
-          raw.cost.cacheWrite !== cost.cacheWrite;
+          raw.cost.cacheWrite !== cost.cacheWrite ||
+          raw.cost.tieredPricing !== cost.tieredPricing;
         if (costMutated) {
           modelMutated = true;
         }


### PR DESCRIPTION
## What Problem This Solves

A `models.providers.<provider>.models[]` config entry that pins only sizing fields (for example `contextWindow`/`contextTokens`, as written by setup flows) was materialized into a **text-only, non-reasoning, zero-cost** model at config load: `applyModelDefaults` replaced omitted `input`/`reasoning`/`cost`/`maxTokens` with generic defaults, erasing the fact that the operator never authored them. Downstream, `modelHasVision` resolved `false` for such models, silently dropping vision-gated tools — most visibly the `computer` tool disappearing for the default model (`openai/gpt-5.6` runtime-migrates to `gpt-5.6-sol`, which hit exactly this config shape on a live gateway). Screenshots still reached the model via the nodes-tool `FILE:` attachment path, masking the defect; the only symptom was a misleading `tools.allow allowlist contains unknown entries (computer)` warning.

## Why This Change Was Made

Config entries are overrides, not full model definitions. Per ClawSweeper's owner-boundary finding on the first revision (which seeded too late, after materialization had already erased field absence), the fix now lives at the erasure point: `applyModelDefaults` consults the plugin manifest catalog row for the same provider+model id (using the same id-normalization policies it already applies) and fills omitted fields from the catalog before falling back to generic defaults. Authored fields always win; entries with no catalog row behave exactly as before.

## User Impact

Operators with setup-written or partial provider model entries keep vision input, reasoning flags, pricing, token limits, thinking-level maps, and compat metadata from the owning catalog instead of silently losing them — restoring the `computer` tool (and correct media/effort routing) for default models like `openai/gpt-5.6-sol`.

## Evidence

- Regression test (`src/config/defaults.test.ts`): an override entry pinning only sizing fields inherits catalog `input`/`reasoning`/`cost`/`maxTokens`/`thinkingLevelMap` while authored fields stay authoritative; fails pre-fix (`input` collapses to `["text"]`, `reasoning` to `false`). Verified by stash-run: 1 failed pre-fix, 9 passed post-fix.
- `node scripts/run-vitest.mjs src/config/defaults.test.ts src/config/model-alias-defaults.test.ts src/config/model-provider-config.test.ts` → 39 passed.
- `node scripts/check-changed.mjs` → all gates green.
- Live A/B on clawstudio (gateway on main): default gpt-5.6 probe `no-computer` with the input-less config sol entry → explicitly adding `input: ["text","image"]` to that entry flips it to `yes-computer`; removal flips it back. This PR makes the inheritance automatic at the true owner.
