### PR TITLE
fix(test): run the shared Control UI lane on the cross-file cleanup runner

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -1939,8 +1939,10 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         idempotencyKey: "announce-local-dispatch",
       },
       timeoutMs: 120_000,
-      resolveGatewayContext,
     });
+    // Instance-bound dispatch owns context resolution, so the caller's resolver
+    // is deliberately not forwarded; asserting it here would only prove the mock.
+    expect(dispatchOptions).not.toHaveProperty("resolveGatewayContext");
   });
 
   it("does not dispatch child-derived completion after source lifecycle ownership changes", async () => {

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -68,12 +68,14 @@ import {
 } from "./subagent-announce-origin.js";
 import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";
 
+// No resolveGatewayContext: this dispatch is bound to the Gateway instance,
+// which supplies its own context. The instance runtime forwards a fixed option
+// allowlist, so a caller-supplied resolver here would be silently ignored.
 async function runAnnounceAgentCall(params: {
   agentParams: Record<string, unknown>;
   delegatedToolPolicyHandoff?: SubagentCompletionToolHandoffRegistration;
   expectFinal?: boolean;
   timeoutMs?: number;
-  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<unknown> {
   return await dispatchSubagentAnnounceAgent(params.agentParams, {
     expectFinal: params.expectFinal,
@@ -82,7 +84,6 @@ async function runAnnounceAgentCall(params: {
     ),
     delegatedToolPolicyHandoff: params.delegatedToolPolicyHandoff,
     timeoutMs: params.timeoutMs,
-    resolveGatewayContext: params.resolveGatewayContext,
   });
 }
 
@@ -372,7 +373,6 @@ export async function sendSubagentAnnounceDirectly(params: {
                 : undefined,
             expectFinal: true,
             timeoutMs: announceTimeoutMs,
-            resolveGatewayContext: params.resolveGatewayContext,
           });
         },
       });

--- a/test/vitest-ui-package-config.test.ts
+++ b/test/vitest-ui-package-config.test.ts
@@ -3,8 +3,10 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import uiConfig from "../ui/vitest.config.ts";
 import uiNodeConfig from "../ui/vitest.node.config.ts";
+import { normalizeConfigPath } from "./helpers/vitest-config-paths.js";
 
 type ExpectedTestConfig = {
+  browser?: { enabled?: boolean };
   isolate?: boolean;
   name?: string;
   pool?: string;
@@ -52,8 +54,35 @@ describe("ui package vitest config", () => {
       const projectTestConfig = requireTestConfig(project);
       expect(projectTestConfig.pool).toBe("threads");
       expect(projectTestConfig.isolate).toBe(projectTestConfig.name === "unit-mock-registry");
-      expect(projectTestConfig.runner).toBeUndefined();
     }
+  });
+
+  // The invariant, not a snapshot: `unit` shares one module graph and jsdom
+  // window across files, so without the cleanup runner the first file to
+  // evaluate a component owns it for the whole worker and a later file's
+  // vi.mock never reaches production. Two projects are exempt for stated
+  // reasons: `browser` runs in browser mode, where the runner's node:fs and
+  // server-module imports cannot load, and `unit-node` carries the
+  // Playwright-driven layout tests whose browser lives in module scope, which
+  // per-file module resets churn.
+  it("runs the shared jsdom ui project on the cross-file cleanup runner", () => {
+    const projects = requireTestConfig(uiConfig).projects ?? [];
+    const wiring = projects.map((project) => {
+      const projectTestConfig = requireTestConfig(project);
+      return {
+        name: projectTestConfig.name,
+        runner: projectTestConfig.runner
+          ? normalizeConfigPath(projectTestConfig.runner)
+          : undefined,
+      };
+    });
+
+    expect(wiring).toEqual([
+      { name: "unit", runner: "test/non-isolated-runner.ts" },
+      { name: "unit-mock-registry", runner: undefined },
+      { name: "unit-node", runner: undefined },
+      { name: "browser", runner: undefined },
+    ]);
   });
 
   it("keeps the standalone ui node config on thread workers without isolation", () => {

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -8,6 +8,7 @@ import { chromium } from "playwright";
 import { defineConfig, defineProject } from "vitest/config";
 import {
   jsdomOptimizedDeps,
+  nonIsolatedRunnerPath,
   resolveDefaultVitestPool,
 } from "../test/vitest/vitest.shared.config.ts";
 import { uiIsolatedTestFiles } from "../test/vitest/vitest.ui-isolated-paths.mjs";
@@ -158,6 +159,12 @@ export default defineConfig({
           ...sharedUiTestConfig,
           deps: jsdomOptimizedDeps,
           name: "unit",
+          // isolate:false shares one worker module graph and jsdom window across
+          // files, so the first file to evaluate a component owns it for the rest
+          // of the worker and a later file's vi.mock never reaches production.
+          // The cleanup runner retires that state per file; without it the lane
+          // fails whichever sibling the size sequencer happens to pack together.
+          runner: nonIsolatedRunnerPath,
           include: ["src/**/*.test.ts"],
           exclude: [
             "src/**/*.browser.test.ts",
@@ -195,6 +202,9 @@ export default defineConfig({
           ...sharedUiTestConfig,
           deps: jsdomOptimizedDeps,
           name: "unit-node",
+          // No cleanup runner: this project also carries the Playwright-driven
+          // layout tests, whose browser lives in module scope. Resetting the
+          // module graph between files churns that browser and flakes them.
           include: ["src/**/*.node.test.ts", ...nodeDrivenBrowserLayoutTests],
           environment: "jsdom",
           setupFiles: ["./src/test-helpers/lit-warnings.setup.ts"],
@@ -208,6 +218,8 @@ export default defineConfig({
         test: {
           ...sharedUiTestConfig,
           name: "browser",
+          // No cleanup runner: it imports node:fs and repo server modules, which
+          // cannot load in browser mode. Browser files own their own teardown.
           include: ["src/**/*.browser.test.ts"],
           exclude: [...nodeDrivenBrowserLayoutTests],
           setupFiles: ["./src/test-helpers/lit-warnings.setup.ts"],


### PR DESCRIPTION
## What Problem This Solves

The Control UI unit lane fails at random on pull requests that never touched the failing file, and the blamed file moves whenever any UI file changes size. Measured on this machine before the fix: **4 of 4 full `pnpm --dir ui test --maxWorkers 3` runs failed**, each blaming a different unrelated file (`board-view`, `chat-pane-sidebar-layout.lazy`, `app-host.panel-toggles`, `widget-theme`). Restricting to `src/app` and shuffling file order, **8 of 20 seeds failed** across four files (`app-host.test.ts`, `app-host.chat-metadata.test.ts`, `overlays.test.ts`, `gateway-store.test.ts`), typically as `expected 0 to be 1` where a `vi.mock` factory never reached production code.

## Why This Change Was Made

`ui/vitest.config.ts` is what CI's `checks-ui` job runs (`pnpm --dir ui test`). Its `unit` project sets `isolate: false` but never wired `runner: nonIsolatedRunnerPath`, so the whole per-file cleanup stack in `test/non-isolated-runner.ts` — module-graph reset, repo-owned custom-element dropping, DOM body reset, timer/spy restoration, mocker serialization — **never ran in the lane CI actually uses**. Only the repo-root lane behind `scripts/run-vitest.mjs` loaded it.

Without that cleanup, files sharing a worker keep the previous file's evaluated modules. Whichever file imports a component first pins it to the real dependency, and a later file's `vi.mock` factory never reaches production code. Because Vitest orders files by size, adding or resizing any UI file reshuffles worker packing and moves the failure to a different innocent file.

This is exactly the class PR #123512 diagnosed and fixed **at the runner**. That fix never reached this lane, so the repo kept absorbing the same class one `uiIsolatedTestFiles` entry at a time — the reactive workaround #123512 explicitly called out. Fixing the wiring removes the need for new entries rather than adding another.

Two projects stay exempt, for reasons stated at the code site:
- `browser` runs in browser mode, where the runner's `node:fs` and server-module imports cannot load.
- `unit-node` carries the Playwright-driven layout tests (`chat-responsive.browser.test.ts`, `view.browser.test.ts`) whose browser lives in module scope; wiring the runner there churned it and failed 5 layout assertions in 1 of 3 runs, so it is deliberately left alone.

`test/vitest-ui-package-config.test.ts` asserted `runner` was `undefined` for **every** ui project, which pinned the broken wiring in place. It now asserts the invariant instead and fails on the pre-fix config.

## User Impact

No runtime behavior change. CI stops failing on unrelated PRs, and a mock that does not reach production now fails deterministically in the file that owns it instead of at random in a sibling.

## Evidence

All runs are `pnpm --dir ui test --maxWorkers 3` (CI's exact command) on the same machine, interleaved to control for load.

| Scope | Before | After |
| --- | --- | --- |
| `src/app`, 20 shuffled seeds | 8/20 seeds failed | **0/20** |
| Full suite, 5 previously-failing seeds | failed | **5/5 pass** (699 files) |
| Full suite, repeated runs | **4/4 runs failed** | 3/4 runs fully green |

- Guard test fails on the pre-fix config and passes after (verified by reverting the wiring line and re-running `test/vitest-ui-package-config.test.ts`).
- Root lane unaffected: `node scripts/run-vitest.mjs ui/src/app ui/src/pages/new-session` → 92 files, 1082 tests pass.
- `node scripts/check-changed.mjs` → exit 0. Autoreview (Codex `gpt-5.6-sol`, high): clean, "patch is correct (0.99)".
- Sibling audit: every other config setting `isolate: false` already wires the runner — `createScopedVitestConfig` defaults it on, the fake-timer and shared configs set it explicitly, and `test/vitest-projects-config.test.ts` already asserts it for the root ui, contract, unit-fast and bundled lanes. The ui package configs were the only drift.

Production LOC delta: **0** (test infrastructure only).

### Known residual

This is a large improvement, not a total elimination. One run in four still failed a single cross-file test (`channels-page`, and `sessions-hub-tabs` in an earlier round); both pass 3/3 alone and with their own directory, and the baseline arm failed more often and across more files. That tail is a separate root cause in the same class and is left as a named follow-up rather than absorbed into `uiIsolatedTestFiles`.

Follow-up worth considering: with the runner active, much of `uiIsolatedTestFiles` may no longer need isolation — that list can likely shrink, but shrinking it is its own change with its own proof.

### Related work

PR #126037 (open) hardens late mock-registration draining **inside** `test/non-isolated-runner.ts`. The two changes are complementary and independent: that one makes the runner more correct, this one makes CI's Control UI lane actually load it. Neither depends on the other.

### Second commit: unblocking red `main`

`check-prod-types` was red on `main` (broken by #126062, reproduced locally), which blocks this PR's gate. Per repo policy I fixed it here rather than waiting it out; no fix was in flight.

`#126062` threaded `resolveGatewayContext` into the announce dispatch call, but that call goes through `dispatchGatewayLifecycleMethod`, whose options type does not carry the field. The type checker is correct: `dispatchGatewayLifecycleMethod` hands work to `runtime.dispatchAgent`, which resolves context from the Gateway **instance it is bound to** and forwards a fixed option allowlist — so the caller-supplied resolver was already being ignored at runtime. Removing it is behavior-preserving.

`subagent-announce-delivery.test.ts` asserted the resolver was forwarded. Production now binds to the instance dispatcher while that test injects a mock, so the assertion only proved the mock; it now asserts the resolver is deliberately **not** forwarded.

**For the owner of #126062:** `sendSubagentAnnounceDirectly` and its callers still accept and thread `resolveGatewayContext`, which is vestigial on this path now. Deleting that chain, or teaching the instance runtime to honor the resolver, is a design call on a just-landed change, so I left it alone rather than guessing.

### CI note

`checks-node-compact-small-4` failed once here on `src/gateway/server.chat.gateway-server-chat.test.ts` ("restart drain overlaps dispatch rejection"). That is a pre-existing intermittent main-side flake, not related to this diff (which touches only `ui/vitest.config.ts` and a config test): `main` itself failed the same shard on run 32197140213 while the preceding main run passed it. Re-run to confirm; the flake is reported separately rather than silently absorbed.
