### PR TITLE
fix(status): keep reports available when enrichment fails

### DIFF
--- a/src/commands/status.scan-overview.test.ts
+++ b/src/commands/status.scan-overview.test.ts
@@ -220,4 +220,57 @@ describe("collectStatusScanOverview", () => {
     expect(result.channelsStatus).toBeNull();
     expect(result.channelIssues).toStrictEqual([]);
   });
+
+  it("returns the base overview when a reachable gateway lacks read scope", async () => {
+    mocks.createStatusScanCoreBootstrap.mockResolvedValueOnce({
+      tailscaleMode: "off",
+      tailscaleDnsPromise: Promise.resolve(null),
+      updatePromise: Promise.resolve({ installKind: "git" }),
+      agentStatusPromise: Promise.resolve({
+        defaultId: "main",
+        agents: [],
+        totalSessions: 0,
+        bootstrapPendingCount: 0,
+      }),
+      gatewayProbePromise: Promise.resolve({
+        gatewayConnection: {
+          url: "ws://127.0.0.1:18789",
+          urlSource: "default",
+        },
+        remoteUrlMissing: false,
+        gatewayMode: "local",
+        gatewayProbeAuth: {},
+        gatewayProbeAuthWarning: undefined,
+        gatewayProbe: {
+          ok: false,
+          connectLatencyMs: 12,
+          error: "missing scope: operator.read",
+          auth: {
+            role: "operator",
+            scopes: [],
+            capability: "connected_no_operator_scope",
+          },
+        },
+        gatewayReachable: true,
+        gatewaySelf: null,
+      }),
+      resolveTailscaleHttpsUrl: vi.fn(async () => null),
+      skipColdStartNetworkChecks: false,
+    });
+    mocks.callGateway.mockRejectedValueOnce(new Error("missing scope: operator.read"));
+
+    const result = await collectStatusScanOverview({
+      commandName: "status",
+      opts: {},
+      showSecrets: false,
+      includeChannelsData: false,
+    });
+
+    expect(result.gatewaySnapshot.gatewayReachable).toBe(true);
+    expect(result.gatewaySnapshot.gatewayProbe).toMatchObject({
+      ok: false,
+      error: "missing scope: operator.read",
+    });
+    expect(result.runtimeDegradation).toBeNull();
+  });
 });

--- a/src/commands/status.scan-overview.ts
+++ b/src/commands/status.scan-overview.ts
@@ -247,9 +247,9 @@ export async function collectStatusScanOverview(params: {
         params: { includeChannelSummary: false },
         timeoutMs: Math.min(5000, params.opts.timeoutMs ?? 10_000),
         ...gatewaySnapshot.gatewayCallOverrides,
-      }),
+      }).catch(() => null),
     );
-    runtimeDegradation = {
+    runtimeDegradation = status && {
       degradedSecretOwners: status.degradedSecretOwners ?? [],
       degradedPlugins: status.degradedPlugins ?? [],
     };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw status` could lose the entire report when a reachable Gateway's optional runtime-degradation query failed after the base probe had already collected useful diagnostics.

## Why This Change Was Made

Optional runtime-degradation enrichment is now best-effort at the shared status scan owner. The original probe/auth diagnostic remains authoritative, while unavailable enrichment remains `null` rather than being mistaken for an authoritative empty degradation list.

## User Impact

Status text, JSON, `--all`, and `--deep` modes continue to return the available base state and probe diagnostic when the supplemental Gateway query is rejected or becomes unavailable, instead of exiting early.

## Evidence

- Pre-fix regression: `node scripts/run-vitest.mjs src/commands/status.scan-overview.test.ts` failed 1/4 because a rejected supplemental `status` RPC escaped `collectStatusScanOverview`.
- Post-fix owner and sibling proof: `node scripts/run-vitest.mjs src/commands/status.scan-overview.test.ts src/commands/status.scan.shared.test.ts src/commands/status.scan.test.ts src/commands/status.scan.fast-json.test.ts` passed 54/54 assertions.
- Direct checks passed: `pnpm tsgo:core`, `pnpm tsgo:test:src`, `pnpm lint:core`, targeted `pnpm format:check`, `pnpm check:import-cycles`, `pnpm check:database-first-legacy-stores`, and `git diff --check`.
- Fresh Codex autoreview was clean with no accepted/actionable P0/P1 findings (score 0.96).
- Production LOC: +2/-2 (net 0). Tests: +53/-0.
- The aggregate changed gate passed through the package-patch guard, then Knip could not run because a concurrently removed shared pnpm-store link made dependency resolution unavailable. This aggregate is not represented as green; exact-head hosted CI owns dead-export and later-stage proof.
- Live-proof result: an isolated real Gateway showed that supported CLI shared-token and persisted device-token paths acquire or imply `operator.read` before the supplemental call; device tokens cannot retain `operator.write` without implied read. Therefore the exact stable "connected credential without read scope" state used by the deterministic regression cannot be created through supported credential flows. The fix remains valid for any optional enrichment rejection after a reachable probe, but no synthetic live success is claimed.

AI-assisted: yes. The change and evidence were reviewed by the maintainer.
