### PR TITLE
fix(channels): stop idle ingress retention writes

### DIFF
--- a/extensions/discord/src/monitor/ingress.test.ts
+++ b/extensions/discord/src/monitor/ingress.test.ts
@@ -102,9 +102,8 @@ describe("Discord durable ingress", () => {
       monitor.start();
       try {
         const accepted = monitor.accept(createRawMessage("1001"));
-        await Promise.resolve();
+        await vi.waitFor(() => expect(enqueue).toHaveBeenCalledTimes(1));
 
-        expect(enqueue).toHaveBeenCalledTimes(1);
         expect(dispatch).not.toHaveBeenCalled();
 
         appendGate.resolve();

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -63,6 +63,7 @@ function createMonitor(
               failedTtlMs: number;
               failedMaxEntries: number;
             }>;
+        now?: () => number;
         waitForDeliveryIdleBeforeRepump?: boolean;
         waitForDeliveryIdleOnStop?: boolean;
         retryPolicy?: IngressRetryPolicyConfig;
@@ -141,11 +142,16 @@ describe("channel ingress monitor", () => {
       [{ completedMaxEntries: 1_000 }, 1_000],
     ] as const) {
       await withQueue(async (queue) => {
+        let currentTime = CHANNEL_INGRESS_RETENTION_DEFAULTS.pruneIntervalMs;
         const prune = vi.spyOn(queue, "prune");
-        const monitor = createMonitor(queue, vi.fn(), { retention });
+        const monitor = createMonitor(queue, vi.fn(), {
+          retention,
+          now: () => currentTime,
+        });
         monitor.start();
         await monitor.waitForIdle();
 
+        expect(prune).toHaveBeenCalledOnce();
         expect(prune).toHaveBeenCalledWith({
           completedTtlMs: CHANNEL_INGRESS_RETENTION_DEFAULTS.completedTtlMs,
           completedMaxEntries,
@@ -153,9 +159,71 @@ describe("channel ingress monitor", () => {
           failedMaxEntries: CHANNEL_INGRESS_RETENTION_DEFAULTS.failedMaxEntries,
           now: expect.any(Number),
         });
+
+        currentTime += CHANNEL_INGRESS_RETENTION_DEFAULTS.pruneIntervalMs;
+        monitor.requestDrain();
+        await monitor.waitForPumpIdle();
+        expect(prune).toHaveBeenCalledTimes(2);
         await monitor.stop();
       });
     }
+  });
+
+  it("does not prune zero-interval retention from startup or idle polls", async () => {
+    await withQueue(async (queue) => {
+      const prune = vi.spyOn(queue, "prune");
+      const monitor = createMonitor(queue, vi.fn(), {
+        retention: { pruneIntervalMs: 0, completedMaxEntries: 10 },
+      });
+
+      monitor.start();
+      await sleep(65);
+      await monitor.stop();
+
+      expect(prune).not.toHaveBeenCalled();
+    });
+  });
+
+  it("prunes zero-interval retention once before one admission enqueue", async () => {
+    await withQueue(async (queue) => {
+      const prune = vi.spyOn(queue, "prune");
+      const enqueue = vi.spyOn(queue, "enqueue");
+      const monitor = createMonitor(queue, vi.fn(), {
+        retention: { pruneIntervalMs: 0, completedMaxEntries: 10 },
+      });
+
+      await monitor.admit({ id: "event-one", lane: "a", text: "hello" });
+
+      expect(prune).toHaveBeenCalledOnce();
+      expect(enqueue).toHaveBeenCalledOnce();
+      expect(Math.max(...prune.mock.invocationCallOrder)).toBeLessThan(
+        Math.min(...enqueue.mock.invocationCallOrder),
+      );
+      await monitor.stop();
+    });
+  });
+
+  it("prunes zero-interval retention once before a multi-event batch", async () => {
+    await withQueue(async (queue) => {
+      const prune = vi.spyOn(queue, "prune");
+      const enqueue = vi.spyOn(queue, "enqueue");
+      const monitor = createMonitor(queue, vi.fn(), {
+        retention: { pruneIntervalMs: 0, completedMaxEntries: 10 },
+      });
+
+      await monitor.admitBatch([
+        { id: "event-batch-1", lane: "a", text: "first" },
+        { id: "event-batch-2", lane: "b", text: "second" },
+        { id: "event-batch-3", lane: "c", text: "third" },
+      ]);
+
+      expect(prune).toHaveBeenCalledOnce();
+      expect(enqueue).toHaveBeenCalledTimes(3);
+      expect(Math.max(...prune.mock.invocationCallOrder)).toBeLessThan(
+        Math.min(...enqueue.mock.invocationCallOrder),
+      );
+      await monitor.stop();
+    });
   });
 
   it("adopts terminal no-dispatch events", async () => {

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -54,6 +54,7 @@ function createMonitor(
     | {
         admissionMode?: "durable-after-stop";
         deferredClaims?: "wait-on-stop" | "settle-on-abort" | "manual";
+        inspect?: (raw: RawEvent) => { eventId: string; laneKey: string } | null;
         retention?:
           | "standard"
           | Partial<{
@@ -77,10 +78,10 @@ function createMonitor(
     typeof activityOrMonitorOptions === "function" ? activityOrMonitorOptions : undefined;
   const monitorOptions =
     typeof activityOrMonitorOptions === "object" ? activityOrMonitorOptions : {};
-  const { retryPolicy, ...baseMonitorOptions } = monitorOptions;
+  const { inspect, retryPolicy, ...baseMonitorOptions } = monitorOptions;
   return createChannelIngressMonitor<RawEvent, string, StoredEvent>({
     queue,
-    inspect: (raw) => ({ eventId: raw.id, laneKey: `lane:${raw.lane}` }),
+    inspect: inspect ?? ((raw) => ({ eventId: raw.id, laneKey: `lane:${raw.lane}` })),
     payload: {
       storage: "raw-event",
       version: 1,
@@ -184,16 +185,23 @@ describe("channel ingress monitor", () => {
     });
   });
 
-  it("prunes zero-interval retention once before one admission enqueue", async () => {
+  it("skips ignored events and prunes once before one admission enqueue", async () => {
     await withQueue(async (queue) => {
       const prune = vi.spyOn(queue, "prune");
       const enqueue = vi.spyOn(queue, "enqueue");
       const monitor = createMonitor(queue, vi.fn(), {
+        inspect: (raw) =>
+          raw.id === "ignored" ? null : { eventId: raw.id, laneKey: `lane:${raw.lane}` },
         retention: { pruneIntervalMs: 0, completedMaxEntries: 10 },
       });
 
-      await monitor.admit({ id: "event-one", lane: "a", text: "hello" });
+      await expect(monitor.admit({ id: "ignored", lane: "a", text: "receipt" })).resolves.toEqual({
+        kind: "ignored",
+      });
+      expect(prune).not.toHaveBeenCalled();
+      expect(enqueue).not.toHaveBeenCalled();
 
+      await monitor.admit({ id: "event-one", lane: "a", text: "hello" });
       expect(prune).toHaveBeenCalledOnce();
       expect(enqueue).toHaveBeenCalledOnce();
       expect(Math.max(...prune.mock.invocationCallOrder)).toBeLessThan(
@@ -208,10 +216,13 @@ describe("channel ingress monitor", () => {
       const prune = vi.spyOn(queue, "prune");
       const enqueue = vi.spyOn(queue, "enqueue");
       const monitor = createMonitor(queue, vi.fn(), {
+        inspect: (raw) =>
+          raw.id === "ignored" ? null : { eventId: raw.id, laneKey: `lane:${raw.lane}` },
         retention: { pruneIntervalMs: 0, completedMaxEntries: 10 },
       });
 
       await monitor.admitBatch([
+        { id: "ignored", lane: "a", text: "receipt" },
         { id: "event-batch-1", lane: "a", text: "first" },
         { id: "event-batch-2", lane: "b", text: "second" },
         { id: "event-batch-3", lane: "c", text: "third" },

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -623,6 +623,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       receivedAt: number;
       facts?: ChannelIngressMonitorFacts;
       onDurablyAdmitted: () => void;
+      pruneTask?: Promise<void>;
     },
   ) => {
     try {
@@ -630,6 +631,8 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       if (!facts) {
         return { kind: "ignored" } as const;
       }
+      admitOptions.pruneTask ??= pruneIfDue("admission");
+      await admitOptions.pruneTask;
       const body = options.payload.serialize(raw, { facts, receivedAt: admitOptions.receivedAt });
       const payload =
         options.payload.storage === "raw-event"
@@ -651,11 +654,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
 
   const scheduleAdmission = <T>(work: () => Promise<T>): Promise<T> => {
     // Append retries stay serialized so backoff cannot invert one lane's arrival order.
-    const run = async () => {
-      await pruneIfDue("admission");
-      return await work();
-    };
-    const admission = admissionTail.then(() => withAdmissionClaimLock(run));
+    const admission = admissionTail.then(() => withAdmissionClaimLock(work));
     admissionTail = admission.then(
       () => undefined,
       () => undefined,
@@ -692,18 +691,17 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       assertAdmissionOpen();
       const receivedAt = admitOptions?.receivedAt ?? now();
       let durablyAdmitted = false;
+      const sharedOptions = {
+        receivedAt,
+        onDurablyAdmitted: () => {
+          durablyAdmitted = true;
+        },
+      };
       try {
         return await scheduleAdmission(async () => {
           const results = [];
           for (const raw of rawEvents) {
-            results.push(
-              await admitRaw(raw, {
-                receivedAt,
-                onDurablyAdmitted: () => {
-                  durablyAdmitted = true;
-                },
-              }),
-            );
+            results.push(await admitRaw(raw, sharedOptions));
           }
           return results;
         });

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -455,14 +455,12 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
   };
 
   const pruneIfDue = async (owner: "admission" | "pump"): Promise<void> => {
-    const admissionOwned = pruneIntervalMs <= 0;
-    // Zero preserves admission-owned channel compatibility: prune once per external
-    // admission operation, never from idle, timer, or requested drain pumps.
-    if ((owner === "admission") !== admissionOwned) {
+    // Zero preserves admission-owned compatibility: prune once per admission, never from a pump.
+    if ((owner === "admission") !== pruneIntervalMs <= 0) {
       return;
     }
     const currentTime = now();
-    if (!admissionOwned && currentTime - lastPrunedAt < pruneIntervalMs) {
+    if (owner === "pump" && currentTime - lastPrunedAt < pruneIntervalMs) {
       return;
     }
     await getQueue().prune({ ...pruneOptions, now: currentTime });

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -454,9 +454,15 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
     return drain;
   };
 
-  const pruneIfDue = async (): Promise<void> => {
+  const pruneIfDue = async (owner: "admission" | "pump"): Promise<void> => {
+    const admissionOwned = pruneIntervalMs <= 0;
+    // Zero preserves admission-owned channel compatibility: prune once per external
+    // admission operation, never from idle, timer, or requested drain pumps.
+    if ((owner === "admission") !== admissionOwned) {
+      return;
+    }
     const currentTime = now();
-    if (currentTime - lastPrunedAt < pruneIntervalMs) {
+    if (!admissionOwned && currentTime - lastPrunedAt < pruneIntervalMs) {
       return;
     }
     await getQueue().prune({ ...pruneOptions, now: currentTime });
@@ -498,7 +504,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
     try {
       for (;;) {
         requested = false;
-        await pruneIfDue();
+        await pruneIfDue("pump");
         // Stop may win the async prune race; keep lazy drain creation behind this fence.
         if (!running || isAborted()) {
           break;
@@ -647,7 +653,11 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
 
   const scheduleAdmission = <T>(work: () => Promise<T>): Promise<T> => {
     // Append retries stay serialized so backoff cannot invert one lane's arrival order.
-    const admission = admissionTail.then(() => withAdmissionClaimLock(work));
+    const run = async () => {
+      await pruneIfDue("admission");
+      return await work();
+    };
+    const admission = admissionTail.then(() => withAdmissionClaimLock(run));
     admissionTail = admission.then(
       () => undefined,
       () => undefined,


### PR DESCRIPTION
Closes #126033

## What Problem This Solves

Fixes an issue where idle Discord, Signal, Microsoft Teams, LINE, and SMS monitors repeatedly opened SQLite retention transactions on every 500ms or 1s drain poll, even when no messages had arrived. Those needless write-lock attempts amplified contention with audit and other shared-state writers and could surface as `database is locked` ingress failures.

## Why This Change Was Made

The shared monitor migration preserved channels' historical admission-time pruning with `pruneIntervalMs: 0`, but interpreted zero as “always due” inside the timer-driven pump. This change restores the original owner boundary centrally: zero/negative intervals prune once per external `admit` or `admitBatch`, while positive intervals retain startup and timed-pump pruning.

Retention caps, TTLs, queue transactions, and all five plugin call sites remain unchanged. This is an AI-assisted maintainer repair.

## User Impact

Idle durable channel accounts no longer perform 3,600–7,200 unnecessary shared-state retention transactions per hour. Ignored transport events do not prune. Accepted messages still prune before enqueueing, including exactly once for a mixed ignored/accepted multi-event batch, so replay-guard retention behavior remains intact.

Production diff: +17/-11 (net +6), justified by making the inspect/admission-versus-pump ownership state explicit in the shared monitor. Test diff: +83/-5 (net +78).

## Evidence

- Real SQLite reproduction before the fix: 7 prune calls in 65ms with zero admitted events.
- Same reproduction after the fix: `{"idlePrunes":0,"admissionOperations":2,"totalPrunes":2}`; ignored events remain at zero prunes.
- Exact rebased focused tests: 6 Vitest shards, 111 tests passed across shared monitor, Discord, Signal, Microsoft Teams, LINE, and SMS.
- `node scripts/check-changed.mjs -- <three changed files>`: passed all selected typecheck, lint, architecture, database-first, import-cycle, and guard lanes.
- `pnpm build`: passed in 13m39s before a clean conflict-free rebase; the post-rebase exact focused suite passed.
- Fresh branch autoreview and post-review correction review: clean, no accepted/actionable findings.
- Native landing review caught pruning before inspection; the corrected implementation prunes only after an event is accepted and shares one prune task across each batch.
- Initial exact-head CI found the shared monitor one line over the max-lines gate; the corrected head is within the limit and the focused regression suite remains green.
- A later merge-ref exposed unrelated red `main`; canonical repair #125946 landed with QA/CI proof, and this branch was cleanly rebased onto it. Current-main prod and test typechecks pass.
