### PR TITLE
fix(codex): refresh stale isolated Computer Use bundles

### DIFF
--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -115,7 +115,9 @@ nested client signatures, bundle identities, versions, builds, and code hashes.
 It installs a missing or incomplete copy, or stages and verifies a replacement
 before swapping out a complete copy whose signed identity no longer matches the
 selected desktop distribution. Failed swaps roll back without changing the
-rest of the isolated Codex home.
+rest of the isolated Codex home. This native-app synchronization runs only for
+OpenClaw-owned isolated agent homes. User-scoped homes and explicit
+`CODEX_HOME` overrides retain their existing native bundle ownership.
 On macOS, when no matching
 marketplace is registered and a standard desktop app bundle exists, OpenClaw
 also tries to register the bundled Codex marketplace from

--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -118,6 +118,9 @@ selected desktop distribution. Failed swaps roll back without changing the
 rest of the isolated Codex home. This native-app synchronization runs only for
 OpenClaw-owned isolated agent homes. User-scoped homes and explicit
 `CODEX_HOME` overrides retain their existing native bundle ownership.
+The agent directory is the trusted ownership boundary. Within it, native-service
+provisioning rejects symlinked Codex-home, `computer-use`, and service-app paths,
+and revalidates the owned parent around each staged swap.
 On macOS, when no matching
 marketplace is registered and a standard desktop app bundle exists, OpenClaw
 also tries to register the bundled Codex marketplace from

--- a/docs/plugins/codex-computer-use.md
+++ b/docs/plugins/codex-computer-use.md
@@ -108,9 +108,14 @@ With this config, OpenClaw checks Codex app-server before each Codex-mode
 turn. If Computer Use is missing but Codex app-server has already discovered
 an installable marketplace, OpenClaw asks Codex app-server to install or
 re-enable the plugin and reload MCP servers. Before starting an isolated
-Codex app-server on macOS, auto-install also copies the official signed
+Codex app-server on macOS, auto-install also provisions the official signed
 Computer Use service app from the selected desktop app bundle into that
-Codex home's `computer-use` directory when the native client is missing.
+Codex home's `computer-use` directory. OpenClaw verifies the outer service and
+nested client signatures, bundle identities, versions, builds, and code hashes.
+It installs a missing or incomplete copy, or stages and verifies a replacement
+before swapping out a complete copy whose signed identity no longer matches the
+selected desktop distribution. Failed swaps roll back without changing the
+rest of the isolated Codex home.
 On macOS, when no matching
 marketplace is registered and a standard desktop app bundle exists, OpenClaw
 also tries to register the bundled Codex marketplace from
@@ -145,7 +150,10 @@ OpenClaw serializes native Codex config reads and Computer Use installation
 inside one running Gateway. A separate Codex process or another Gateway is not
 part of that fence. After changing native Codex plugin config outside the
 Gateway, restart the Gateway and start a new chat before relying on the new
-selection.
+selection. Restart the Gateway after updating the selected ChatGPT or Codex
+desktop app as well; cold app-server startup then verifies and, when needed,
+refreshes each isolated home's signed Computer Use service before launching it.
+Warm clients are intentionally not polled for desktop bundle changes.
 
 ## Commands
 

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -365,6 +365,35 @@ describe("bridgeCodexAppServerStartOptions", () => {
     });
   });
 
+  it("does not replace the native service app for user-scoped homes", async () => {
+    await withTempDir("openclaw-codex-computer-use-user-home-", async (root) => {
+      const codexHome = path.join(root, "user-codex-home");
+      vi.stubEnv("CODEX_HOME", codexHome);
+
+      await bridgeCodexAppServerStartOptions({
+        startOptions: createStartOptions({ homeScope: "user" }),
+        agentDir: path.join(root, "agent"),
+        pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+      });
+
+      expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not replace the native service app for an explicit CODEX_HOME", async () => {
+    await withTempDir("openclaw-codex-computer-use-explicit-home-", async (root) => {
+      const codexHome = path.join(root, "explicit-codex-home");
+
+      await bridgeCodexAppServerStartOptions({
+        startOptions: createStartOptions({ env: { CODEX_HOME: codexHome } }),
+        agentDir: path.join(root, "agent"),
+        pluginConfig: { computerUse: { enabled: true, autoInstall: true } },
+      });
+
+      expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).not.toHaveBeenCalled();
+    });
+  });
+
   it("classifies native client provisioning failures as harness preflight", async () => {
     computerUseServiceMocks.ensureCodexComputerUseServiceApp.mockRejectedValueOnce(
       new Error("copy failed"),

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -32,7 +32,7 @@ const oauthMocks = vi.hoisted(() => ({
 
 const computerUseServiceMocks = vi.hoisted(() => ({
   ensureCodexComputerUseServiceApp: vi.fn(async () => ({
-    status: "already_installed" as const,
+    status: "already_current" as const,
     changed: false,
   })),
 }));

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -348,6 +348,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
 
       expect(computerUseServiceMocks.ensureCodexComputerUseServiceApp).toHaveBeenCalledWith({
         codexHome,
+        ownershipRoot: agentDir,
         appServerCommand: startOptions.command,
       });
     });

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -527,7 +527,9 @@ async function withCodexHomeEnvironment(
     codexHome,
     config: computerUseConfig,
   });
-  if (computerUseConfig.enabled && computerUseConfig.autoInstall) {
+  const ownsIsolatedCodexHome =
+    startOptions.homeScope !== "user" && !startOptions.env?.[CODEX_HOME_ENV_VAR]?.trim();
+  if (computerUseConfig.enabled && computerUseConfig.autoInstall && ownsIsolatedCodexHome) {
     try {
       await ensureCodexComputerUseServiceApp({
         codexHome,

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -533,6 +533,7 @@ async function withCodexHomeEnvironment(
     try {
       await ensureCodexComputerUseServiceApp({
         codexHome,
+        ownershipRoot: agentDir,
         appServerCommand: startOptions.command,
       });
     } catch (error) {

--- a/extensions/codex/src/app-server/computer-use-service-path.ts
+++ b/extensions/codex/src/app-server/computer-use-service-path.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { assertNoSymlinkParents } from "openclaw/plugin-sdk/security-runtime";
 
-export type OwnedServiceParent = {
+type OwnedServiceParent = {
   logicalPath: string;
   realPath: string;
   dev: number;

--- a/extensions/codex/src/app-server/computer-use-service-path.ts
+++ b/extensions/codex/src/app-server/computer-use-service-path.ts
@@ -1,0 +1,218 @@
+/** Filesystem ownership guards for isolated Computer Use service provisioning. */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { assertNoSymlinkParents } from "openclaw/plugin-sdk/security-runtime";
+
+export type OwnedServiceParent = {
+  logicalPath: string;
+  realPath: string;
+  dev: number;
+  ino: number;
+};
+
+export async function assertOwnedServicePath(params: {
+  ownershipRoot: string;
+  codexHome: string;
+  targetParent: string;
+  targetPath: string;
+}): Promise<void> {
+  await assertOwnedCodexHomePath({
+    ownershipRoot: params.ownershipRoot,
+    codexHome: params.codexHome,
+    allowMissing: true,
+  });
+  assertPathAtOrInside(params.ownershipRoot, params.targetParent, "Computer Use service parent");
+  await assertNoSymlinkParents({
+    rootDir: params.ownershipRoot,
+    targetPath: params.targetParent,
+    allowMissing: true,
+    requireDirectories: true,
+    messagePrefix: "Computer Use service path",
+  });
+  await assertNotSymlink(params.targetPath, "Computer Use service target");
+}
+
+export async function ensureOwnedCodexHome(
+  codexHomeInput: string,
+  ownershipRootInput = path.dirname(path.resolve(codexHomeInput)),
+): Promise<void> {
+  const codexHome = path.resolve(codexHomeInput);
+  const ownershipRoot = path.resolve(ownershipRootInput);
+  await fs.mkdir(ownershipRoot, { recursive: true, mode: 0o700 });
+  await assertOwnedCodexHomePath({ ownershipRoot, codexHome, allowMissing: true });
+  await ensureRealDirectoryTree(ownershipRoot, codexHome, "isolated Codex home");
+  await assertOwnedCodexHomePath({ ownershipRoot, codexHome, allowMissing: false });
+}
+
+export async function prepareOwnedServiceParent(params: {
+  ownershipRoot: string;
+  codexHome: string;
+  targetParent: string;
+}): Promise<OwnedServiceParent> {
+  await ensureOwnedCodexHome(params.codexHome, params.ownershipRoot);
+  await ensureRealDirectoryTree(
+    params.ownershipRoot,
+    params.targetParent,
+    "Computer Use service parent",
+  );
+  await assertNoSymlinkParents({
+    rootDir: params.ownershipRoot,
+    targetPath: params.targetParent,
+    allowMissing: false,
+    requireDirectories: true,
+    messagePrefix: "Computer Use service path",
+  });
+  const [rootIdentity, parentIdentity] = await Promise.all([
+    readRealDirectoryIdentity(params.ownershipRoot, "Computer Use ownership root"),
+    readRealDirectoryIdentity(params.targetParent, "Computer Use service parent"),
+  ]);
+  assertPathAtOrInside(
+    rootIdentity.realPath,
+    parentIdentity.realPath,
+    "canonical Computer Use service parent",
+  );
+  return parentIdentity;
+}
+
+async function assertOwnedCodexHomePath(params: {
+  ownershipRoot: string;
+  codexHome: string;
+  allowMissing: boolean;
+}): Promise<void> {
+  await readRealDirectoryIdentity(params.ownershipRoot, "Computer Use ownership root");
+  assertPathAtOrInside(params.ownershipRoot, params.codexHome, "isolated Codex home");
+  await assertNoSymlinkParents({
+    rootDir: params.ownershipRoot,
+    targetPath: params.codexHome,
+    allowMissing: params.allowMissing,
+    requireDirectories: true,
+    messagePrefix: "Computer Use service path",
+  });
+}
+
+export async function readRealDirectoryIdentity(
+  directoryPath: string,
+  label: string,
+): Promise<OwnedServiceParent> {
+  const logicalPath = path.resolve(directoryPath);
+  const before = await fs.lstat(logicalPath);
+  if (before.isSymbolicLink() || !before.isDirectory()) {
+    throw new Error(`${label} must be a real directory: ${logicalPath}`);
+  }
+  const realPath = await fs.realpath(logicalPath);
+  const [after, resolved] = await Promise.all([fs.lstat(logicalPath), fs.lstat(realPath)]);
+  if (
+    after.isSymbolicLink() ||
+    !after.isDirectory() ||
+    !resolved.isDirectory() ||
+    before.dev !== after.dev ||
+    before.ino !== after.ino ||
+    after.dev !== resolved.dev ||
+    after.ino !== resolved.ino
+  ) {
+    throw new Error(`${label} changed while its ownership boundary was being established.`);
+  }
+  return { logicalPath, realPath, dev: after.dev, ino: after.ino };
+}
+
+export async function assertOwnedServiceParentStable(parent: OwnedServiceParent): Promise<void> {
+  await assertDirectoryIdentityStable(parent, "Computer Use service parent");
+}
+
+export async function assertDirectoryIdentityStable(
+  expected: OwnedServiceParent,
+  label: string,
+): Promise<void> {
+  if (!(await directoryIdentityIsStable(expected))) {
+    throw new Error(`${label} changed during refresh; refusing to mutate the replacement path.`);
+  }
+}
+
+export async function ownedServiceParentIsStable(parent: OwnedServiceParent): Promise<boolean> {
+  return await directoryIdentityIsStable(parent);
+}
+
+export async function directoryIdentityIsStable(expected: OwnedServiceParent): Promise<boolean> {
+  try {
+    const current = await fs.lstat(expected.logicalPath);
+    if (
+      current.isSymbolicLink() ||
+      !current.isDirectory() ||
+      current.dev !== expected.dev ||
+      current.ino !== expected.ino
+    ) {
+      return false;
+    }
+    return (await fs.realpath(expected.logicalPath)) === expected.realPath;
+  } catch {
+    return false;
+  }
+}
+
+export async function assertNotSymlink(filePath: string, label: string): Promise<void> {
+  try {
+    if ((await fs.lstat(filePath)).isSymbolicLink()) {
+      throw new Error(`${label} must not be a symbolic link: ${filePath}`);
+    }
+  } catch (error) {
+    if (hasNodeErrorCode(error, "ENOENT")) {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function ensureRealDirectoryTree(
+  ownershipRoot: string,
+  directoryPath: string,
+  label: string,
+): Promise<void> {
+  const root = path.resolve(ownershipRoot);
+  const target = path.resolve(directoryPath);
+  assertPathAtOrInside(root, target, label);
+  const relative = path.relative(root, target);
+  let current = root;
+  for (const segment of relative.split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    const existing = await fs.lstat(current).catch((error: unknown) => {
+      if (hasNodeErrorCode(error, "ENOENT")) {
+        return undefined;
+      }
+      throw error;
+    });
+    if (!existing) {
+      try {
+        await fs.mkdir(current, { mode: 0o700 });
+      } catch (error) {
+        if (!hasNodeErrorCode(error, "EEXIST")) {
+          throw error;
+        }
+      }
+      const created = await fs.lstat(current);
+      if (created.isSymbolicLink() || !created.isDirectory()) {
+        throw new Error(`${label} changed while its directory tree was being created: ${current}`);
+      }
+    } else if (existing.isSymbolicLink() || !existing.isDirectory()) {
+      throw new Error(`${label} must traverse real directories: ${current}`);
+    }
+  }
+  await assertNoSymlinkParents({
+    rootDir: root,
+    targetPath: target,
+    allowMissing: false,
+    requireDirectories: true,
+    messagePrefix: "Computer Use service path",
+  });
+  await readRealDirectoryIdentity(target, label);
+}
+
+function assertPathAtOrInside(rootPath: string, candidatePath: string, label: string): void {
+  const relative = path.relative(path.resolve(rootPath), path.resolve(candidatePath));
+  if (relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error(`${label} must remain inside ${path.resolve(rootPath)}.`);
+  }
+}
+
+function hasNodeErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === code);
+}

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -129,6 +129,38 @@ describe("Codex Computer Use native service", () => {
     expect(copyServiceApp).toHaveBeenCalledTimes(copyCount);
   });
 
+  it("bounds completed synchronization state and re-inspects an evicted home", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-cache-");
+    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+    const inspectServiceApp = vi.fn(inspectServiceFixture);
+    const codexHomes = Array.from({ length: 65 }, (_, index) =>
+      path.join(root, `codex-home-${index}`),
+    );
+
+    for (const codexHome of codexHomes) {
+      const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+      await writeServiceFixture(targetPath, CURRENT_IDENTITY);
+      await ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [sourcePath],
+        inspectServiceApp,
+      });
+    }
+
+    const inspectionsBeforeRecall = inspectServiceApp.mock.calls.length;
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome: codexHomes[0],
+        platform: "darwin",
+        sourceAppCandidates: [sourcePath],
+        inspectServiceApp,
+      }),
+    ).resolves.toMatchObject({ status: "already_current", changed: false });
+    expect(inspectServiceApp.mock.calls.length).toBeGreaterThan(inspectionsBeforeRecall);
+  });
+
   it("invalidates a completed selection before a different selection fails", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-");
     const firstSourcePath = path.join(root, "first", "Codex Computer Use.app");

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -14,62 +14,205 @@ const CLIENT_RELATIVE_PATH = path.join(
   "MacOS",
   "SkyComputerUseClient",
 );
+const IDENTITY_FILE = ".test-signed-identity.json";
+
+type EnsureParams = Parameters<typeof ensureCodexComputerUseServiceApp>[0];
+type InspectServiceApp = NonNullable<EnsureParams["inspectServiceApp"]>;
+type ServiceIdentity = NonNullable<Awaited<ReturnType<InspectServiceApp>>>;
+
+const CURRENT_IDENTITY = serviceIdentity({
+  version: "26.817.1000761",
+  build: "1000761",
+  cdHash: "current-service",
+  clientCdHash: "current-client",
+});
+const STALE_IDENTITY = serviceIdentity({
+  version: "26.721.1000502",
+  build: "1000502",
+  cdHash: "stale-service",
+  clientCdHash: "stale-client",
+});
+const UNEXPECTED_IDENTITY = serviceIdentity({
+  version: "26.900.1000900",
+  build: "1000900",
+  cdHash: "unexpected-service",
+  clientCdHash: "unexpected-client",
+});
 
 describe("Codex Computer Use native service", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-  it("installs the official client beneath the isolated Codex home", async () => {
+  it("installs the selected signed client beneath the isolated Codex home", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-");
     const sourcePath = path.join(root, "source", "Codex Computer Use.app");
     const codexHome = path.join(root, "agent", "codex-home");
-    await writeExecutableClient(sourcePath);
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
 
     const result = await ensureCodexComputerUseServiceApp({
       codexHome,
       platform: "darwin",
       sourceAppCandidates: [sourcePath],
-      copyServiceApp: async (source, target) => await fs.cp(source, target, { recursive: true }),
+      copyServiceApp: copyServiceFixture,
+      inspectServiceApp: inspectServiceFixture,
     });
 
-    expect(result).toMatchObject({ status: "installed", changed: true, sourcePath });
-    await expect(
-      fs.access(
-        path.join(codexHome, "computer-use", "Codex Computer Use.app", CLIENT_RELATIVE_PATH),
-      ),
-    ).resolves.toBeUndefined();
+    expect(result).toMatchObject({
+      status: "installed",
+      changed: true,
+      sourcePath,
+      sourceBuild: "1000761",
+    });
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await expect(fs.access(path.join(targetPath, CLIENT_RELATIVE_PATH))).resolves.toBeUndefined();
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(CURRENT_IDENTITY);
   });
 
-  it("reuses a complete home-owned client without consulting desktop sources", async () => {
+  it("reuses a target only when its full signed identity matches the selected source", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
     const codexHome = path.join(root, "codex-home");
-    await writeExecutableClient(path.join(codexHome, "computer-use", "Codex Computer Use.app"));
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+    await writeServiceFixture(targetPath, CURRENT_IDENTITY);
     const copyServiceApp = vi.fn();
 
     const result = await ensureCodexComputerUseServiceApp({
       codexHome,
       platform: "darwin",
-      sourceAppCandidates: [],
+      sourceAppCandidates: [sourcePath],
       copyServiceApp,
+      inspectServiceApp: inspectServiceFixture,
     });
 
-    expect(result).toMatchObject({ status: "already_installed", changed: false });
+    expect(result).toMatchObject({
+      status: "already_current",
+      changed: false,
+      sourceBuild: "1000761",
+    });
     expect(copyServiceApp).not.toHaveBeenCalled();
   });
 
-  it("reports a missing source without creating a partial target", async () => {
+  it("reuses a completed process-lifetime sync without repeated signature inspection", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
     const codexHome = path.join(root, "codex-home");
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+    const copyServiceApp = vi.fn(copyServiceFixture);
+    const inspectServiceApp = vi.fn(inspectServiceFixture);
+
+    const first = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp,
+      inspectServiceApp,
+    });
+    expect(first.status).toBe("installed");
+    const inspectionCount = inspectServiceApp.mock.calls.length;
+    const copyCount = copyServiceApp.mock.calls.length;
+
+    const second = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp,
+      inspectServiceApp,
+    });
+
+    expect(second).toMatchObject({
+      status: "already_current",
+      changed: false,
+      sourceBuild: "1000761",
+    });
+    expect(inspectServiceApp).toHaveBeenCalledTimes(inspectionCount);
+    expect(copyServiceApp).toHaveBeenCalledTimes(copyCount);
+  });
+
+  it("invalidates a completed selection before a different selection fails", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const firstSourcePath = path.join(root, "first", "Codex Computer Use.app");
+    const failingSourcePath = path.join(root, "failing", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    await writeServiceFixture(firstSourcePath, CURRENT_IDENTITY);
+    await writeServiceFixture(failingSourcePath, UNEXPECTED_IDENTITY);
+    const inspectServiceApp = vi.fn(inspectServiceFixture);
+
+    await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [firstSourcePath],
+      copyServiceApp: copyServiceFixture,
+      inspectServiceApp,
+    });
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [failingSourcePath],
+        copyServiceApp: async (source, target) => {
+          await copyServiceFixture(source, target);
+          await writeFixtureIdentity(target, STALE_IDENTITY);
+        },
+        inspectServiceApp,
+      }),
+    ).rejects.toThrow("does not match its selected signed source");
+    const inspectionsAfterFailure = inspectServiceApp.mock.calls.length;
+
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [firstSourcePath],
+        copyServiceApp: copyServiceFixture,
+        inspectServiceApp,
+      }),
+    ).resolves.toMatchObject({ status: "already_current", changed: false });
+    expect(inspectServiceApp.mock.calls.length).toBeGreaterThan(inspectionsAfterFailure);
+  });
+
+  it("refreshes a complete but stale signed generation through the staged swap", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+    await writeServiceFixture(targetPath, STALE_IDENTITY);
 
     const result = await ensureCodexComputerUseServiceApp({
       codexHome,
       platform: "darwin",
-      sourceAppCandidates: [path.join(root, "missing.app")],
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp: copyServiceFixture,
+      inspectServiceApp: inspectServiceFixture,
+    });
+
+    expect(result).toMatchObject({
+      status: "refreshed",
+      changed: true,
+      previousBuild: "1000502",
+      sourceBuild: "1000761",
+    });
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(CURRENT_IDENTITY);
+  });
+
+  it("reports a missing or untrusted source without changing the target", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "untrusted", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeExecutableClient(sourcePath);
+    await writeServiceFixture(targetPath, STALE_IDENTITY);
+
+    const result = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [path.join(root, "missing.app"), sourcePath],
+      copyServiceApp: copyServiceFixture,
+      inspectServiceApp: inspectServiceFixture,
     });
 
     expect(result).toMatchObject({ status: "source_missing", changed: false });
-    await expect(fs.access(path.join(codexHome, "computer-use"))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(STALE_IDENTITY);
   });
 
   it("replaces an incomplete home-owned service app", async () => {
@@ -77,7 +220,7 @@ describe("Codex Computer Use native service", () => {
     const sourcePath = path.join(root, "source", "Codex Computer Use.app");
     const codexHome = path.join(root, "codex-home");
     const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
-    await writeExecutableClient(sourcePath);
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
     await fs.mkdir(targetPath, { recursive: true });
     await fs.writeFile(path.join(targetPath, "partial"), "incomplete");
 
@@ -85,23 +228,181 @@ describe("Codex Computer Use native service", () => {
       codexHome,
       platform: "darwin",
       sourceAppCandidates: [sourcePath],
-      copyServiceApp: async (source, target) => await fs.cp(source, target, { recursive: true }),
+      copyServiceApp: copyServiceFixture,
+      inspectServiceApp: inspectServiceFixture,
     });
 
-    expect(result).toMatchObject({ status: "installed", changed: true });
-    await expect(fs.access(path.join(targetPath, CLIENT_RELATIVE_PATH))).resolves.toBeUndefined();
+    expect(result).toMatchObject({ status: "refreshed", changed: true });
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(CURRENT_IDENTITY);
     await expect(fs.access(path.join(targetPath, "partial"))).rejects.toMatchObject({
       code: "ENOENT",
     });
   });
 
+  it("preserves the previous target when the staged copy does not match its source", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+    await writeServiceFixture(targetPath, STALE_IDENTITY);
+
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [sourcePath],
+        copyServiceApp: async (source, target) => {
+          await copyServiceFixture(source, target);
+          await writeFixtureIdentity(target, UNEXPECTED_IDENTITY);
+        },
+        inspectServiceApp: inspectServiceFixture,
+      }),
+    ).rejects.toThrow("does not match its selected signed source");
+
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(STALE_IDENTITY);
+    await expect(findInstallDebris(path.dirname(targetPath))).resolves.toEqual([]);
+  });
+
+  it("keeps a concurrent installer that wins with the same selected identity", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+    await writeServiceFixture(targetPath, STALE_IDENTITY);
+
+    const result = await ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [sourcePath],
+      copyServiceApp: async (source, target) => {
+        await copyServiceFixture(source, target);
+        await writeFixtureIdentity(targetPath, CURRENT_IDENTITY);
+      },
+      inspectServiceApp: inspectServiceFixture,
+    });
+
+    expect(result).toMatchObject({ status: "already_current", changed: false });
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(CURRENT_IDENTITY);
+    await expect(findInstallDebris(path.dirname(targetPath))).resolves.toEqual([]);
+  });
+
+  it("restores an unexpected concurrent generation instead of overwriting it", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+    await writeServiceFixture(targetPath, STALE_IDENTITY);
+
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [sourcePath],
+        copyServiceApp: async (source, target) => {
+          await copyServiceFixture(source, target);
+          await writeFixtureIdentity(targetPath, UNEXPECTED_IDENTITY);
+        },
+        inspectServiceApp: inspectServiceFixture,
+      }),
+    ).rejects.toThrow("changed to an unexpected generation");
+
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(UNEXPECTED_IDENTITY);
+    await expect(findInstallDebris(path.dirname(targetPath))).resolves.toEqual([]);
+  });
+
+  it("serializes different selected sources and invalidates the prior completed selection", async () => {
+    const root = tempDirs.make("openclaw-computer-use-service-");
+    const firstSourcePath = path.join(root, "first", "Codex Computer Use.app");
+    const secondSourcePath = path.join(root, "second", "Codex Computer Use.app");
+    const codexHome = path.join(root, "codex-home");
+    const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
+    await writeServiceFixture(firstSourcePath, CURRENT_IDENTITY);
+    await writeServiceFixture(secondSourcePath, UNEXPECTED_IDENTITY);
+    let signalFirstCopyStarted: () => void;
+    let releaseFirstCopy: () => void;
+    const firstCopyStarted = new Promise<void>((resolve) => {
+      signalFirstCopyStarted = resolve;
+    });
+    const firstCopyGate = new Promise<void>((resolve) => {
+      releaseFirstCopy = resolve;
+    });
+    let activeCopies = 0;
+    let maxActiveCopies = 0;
+    const copyServiceApp = vi.fn(async (source: string, target: string) => {
+      activeCopies += 1;
+      maxActiveCopies = Math.max(maxActiveCopies, activeCopies);
+      try {
+        if (source === firstSourcePath) {
+          signalFirstCopyStarted();
+          await firstCopyGate;
+        }
+        await copyServiceFixture(source, target);
+      } finally {
+        activeCopies -= 1;
+      }
+    });
+
+    const first = ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [firstSourcePath],
+      copyServiceApp,
+      inspectServiceApp: inspectServiceFixture,
+    });
+    await firstCopyStarted;
+    const second = ensureCodexComputerUseServiceApp({
+      codexHome,
+      platform: "darwin",
+      sourceAppCandidates: [secondSourcePath],
+      copyServiceApp,
+      inspectServiceApp: inspectServiceFixture,
+    });
+    releaseFirstCopy();
+
+    await expect(first).resolves.toMatchObject({
+      status: "installed",
+      sourceBuild: "1000761",
+    });
+    await expect(second).resolves.toMatchObject({
+      status: "refreshed",
+      previousBuild: "1000761",
+      sourceBuild: "1000900",
+    });
+    await expect(
+      ensureCodexComputerUseServiceApp({
+        codexHome,
+        platform: "darwin",
+        sourceAppCandidates: [firstSourcePath],
+        copyServiceApp,
+        inspectServiceApp: inspectServiceFixture,
+      }),
+    ).resolves.toMatchObject({
+      status: "refreshed",
+      previousBuild: "1000900",
+      sourceBuild: "1000761",
+    });
+    expect(maxActiveCopies).toBe(1);
+    expect(copyServiceApp.mock.calls.map(([source]) => source)).toEqual([
+      firstSourcePath,
+      secondSourcePath,
+      firstSourcePath,
+    ]);
+    await expect(inspectServiceFixture(targetPath)).resolves.toEqual(CURRENT_IDENTITY);
+  });
+
   it("does not provision the macOS service on other platforms", async () => {
+    const inspectServiceApp = vi.fn();
     const result = await ensureCodexComputerUseServiceApp({
       codexHome: "/tmp/codex-home",
       platform: "linux",
+      inspectServiceApp,
     });
 
     expect(result).toEqual({ status: "unsupported", changed: false });
+    expect(inspectServiceApp).not.toHaveBeenCalled();
   });
 
   it("prefers service assets owned by the selected desktop app-server", () => {
@@ -116,9 +417,52 @@ describe("Codex Computer Use native service", () => {
   });
 });
 
+function serviceIdentity(
+  overrides: Pick<ServiceIdentity, "version" | "build" | "cdHash" | "clientCdHash">,
+): ServiceIdentity {
+  return {
+    bundleId: "com.openai.sky.CUAService",
+    teamId: "2DC432GLL2",
+    clientBundleId: "com.openai.sky.CUAService.cli",
+    clientTeamId: "2DC432GLL2",
+    ...overrides,
+  };
+}
+
+async function writeServiceFixture(appPath: string, identity: ServiceIdentity): Promise<void> {
+  await writeExecutableClient(appPath);
+  await fs.writeFile(path.join(appPath, "Contents", "Info.plist"), "fixture");
+  await writeFixtureIdentity(appPath, identity);
+}
+
+async function writeFixtureIdentity(appPath: string, identity: ServiceIdentity): Promise<void> {
+  await fs.writeFile(path.join(appPath, IDENTITY_FILE), JSON.stringify(identity));
+}
+
+async function inspectServiceFixture(appPath: string): Promise<ServiceIdentity | undefined> {
+  try {
+    return JSON.parse(
+      await fs.readFile(path.join(appPath, IDENTITY_FILE), "utf8"),
+    ) as ServiceIdentity;
+  } catch {
+    return undefined;
+  }
+}
+
+async function copyServiceFixture(sourcePath: string, targetPath: string): Promise<void> {
+  await fs.cp(sourcePath, targetPath, { recursive: true });
+}
+
 async function writeExecutableClient(appPath: string): Promise<void> {
   const clientPath = path.join(appPath, CLIENT_RELATIVE_PATH);
   await fs.mkdir(path.dirname(clientPath), { recursive: true });
   await fs.writeFile(clientPath, "client");
   await fs.chmod(clientPath, 0o755);
+}
+
+async function findInstallDebris(targetParent: string): Promise<string[]> {
+  return (await fs.readdir(targetParent)).filter(
+    (entry) =>
+      entry.startsWith(".service-app.staging-") || entry.startsWith(".service-app.backup-"),
+  );
 }

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -1,6 +1,7 @@
 // Codex tests cover native Computer Use service provisioning.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ensureCodexComputerUseServiceApp } from "./computer-use-service.js";
 import { resolveMacOSDesktopCodexComputerUseServiceAppCandidates } from "./desktop-app-paths.js";
@@ -321,14 +322,8 @@ describe("Codex Computer Use native service", () => {
     const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
     await writeServiceFixture(firstSourcePath, CURRENT_IDENTITY);
     await writeServiceFixture(secondSourcePath, UNEXPECTED_IDENTITY);
-    let signalFirstCopyStarted: () => void;
-    let releaseFirstCopy: () => void;
-    const firstCopyStarted = new Promise<void>((resolve) => {
-      signalFirstCopyStarted = resolve;
-    });
-    const firstCopyGate = new Promise<void>((resolve) => {
-      releaseFirstCopy = resolve;
-    });
+    const firstCopyStarted = createDeferred<void>();
+    const firstCopyGate = createDeferred<void>();
     let activeCopies = 0;
     let maxActiveCopies = 0;
     const copyServiceApp = vi.fn(async (source: string, target: string) => {
@@ -336,8 +331,8 @@ describe("Codex Computer Use native service", () => {
       maxActiveCopies = Math.max(maxActiveCopies, activeCopies);
       try {
         if (source === firstSourcePath) {
-          signalFirstCopyStarted();
-          await firstCopyGate;
+          firstCopyStarted.resolve();
+          await firstCopyGate.promise;
         }
         await copyServiceFixture(source, target);
       } finally {
@@ -352,7 +347,7 @@ describe("Codex Computer Use native service", () => {
       copyServiceApp,
       inspectServiceApp: inspectServiceFixture,
     });
-    await firstCopyStarted;
+    await firstCopyStarted.promise;
     const second = ensureCodexComputerUseServiceApp({
       codexHome,
       platform: "darwin",
@@ -360,7 +355,7 @@ describe("Codex Computer Use native service", () => {
       copyServiceApp,
       inspectServiceApp: inspectServiceFixture,
     });
-    releaseFirstCopy();
+    firstCopyGate.resolve();
 
     await expect(first).resolves.toMatchObject({
       status: "installed",

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -137,6 +137,10 @@ describe("Codex Computer Use native service", () => {
     const codexHomes = Array.from({ length: 65 }, (_, index) =>
       path.join(root, `codex-home-${index}`),
     );
+    const oldestCodexHome = codexHomes[0];
+    if (!oldestCodexHome) {
+      throw new Error("expected at least one Codex home fixture");
+    }
 
     for (const codexHome of codexHomes) {
       const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
@@ -152,7 +156,7 @@ describe("Codex Computer Use native service", () => {
     const inspectionsBeforeRecall = inspectServiceApp.mock.calls.length;
     await expect(
       ensureCodexComputerUseServiceApp({
-        codexHome: codexHomes[0],
+        codexHome: oldestCodexHome,
         platform: "darwin",
         sourceAppCandidates: [sourcePath],
         inspectServiceApp,

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -43,7 +43,7 @@ const UNEXPECTED_IDENTITY = serviceIdentity({
 describe("Codex Computer Use native service", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-  it("installs the selected signed client beneath the isolated Codex home", async () => {
+  it("creates a fresh agent tree and installs beneath the isolated Codex home", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-");
     const sourcePath = path.join(root, "source", "Codex Computer Use.app");
     const codexHome = path.join(root, "agent", "codex-home");
@@ -67,6 +67,211 @@ describe("Codex Computer Use native service", () => {
     await expect(fs.access(path.join(targetPath, CLIENT_RELATIVE_PATH))).resolves.toBeUndefined();
     await expect(inspectServiceFixture(targetPath)).resolves.toEqual(CURRENT_IDENTITY);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked isolated Codex home without touching its external target",
+    async () => {
+      const root = tempDirs.make("openclaw-computer-use-service-symlink-");
+      const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+      const agentDir = path.join(root, "agent");
+      const codexHome = path.join(agentDir, "codex-home");
+      const externalHome = path.join(root, "external-home");
+      const externalParent = path.join(externalHome, "computer-use");
+      const externalTarget = path.join(externalParent, "Codex Computer Use.app");
+      const sentinelPath = path.join(externalParent, "sentinel.txt");
+      await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+      await writeServiceFixture(externalTarget, STALE_IDENTITY);
+      await fs.writeFile(sentinelPath, "outside");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.symlink(externalHome, codexHome);
+      const externalInode = (await fs.lstat(externalTarget)).ino;
+      const copyServiceApp = vi.fn(copyServiceFixture);
+
+      await expect(
+        ensureCodexComputerUseServiceApp({
+          codexHome,
+          platform: "darwin",
+          sourceAppCandidates: [sourcePath],
+          copyServiceApp,
+          inspectServiceApp: inspectServiceFixture,
+        }),
+      ).rejects.toThrow(/symlinked directory|real directory|symbolic link/iu);
+
+      expect(copyServiceApp).not.toHaveBeenCalled();
+      expect((await fs.lstat(codexHome)).isSymbolicLink()).toBe(true);
+      expect((await fs.lstat(externalTarget)).ino).toBe(externalInode);
+      await expect(inspectServiceFixture(externalTarget)).resolves.toEqual(STALE_IDENTITY);
+      await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("outside");
+      await expect(findInstallDebris(externalParent)).resolves.toEqual([]);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked ownership root without touching its external target",
+    async () => {
+      const root = tempDirs.make("openclaw-computer-use-service-symlink-");
+      const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+      const ownershipRoot = path.join(root, "agent");
+      const codexHome = path.join(ownershipRoot, "codex-home");
+      const externalAgentRoot = path.join(root, "external-agent");
+      const externalParent = path.join(externalAgentRoot, "codex-home", "computer-use");
+      const externalTarget = path.join(externalParent, "Codex Computer Use.app");
+      const sentinelPath = path.join(externalParent, "sentinel.txt");
+      await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+      await writeServiceFixture(externalTarget, STALE_IDENTITY);
+      await fs.writeFile(sentinelPath, "outside");
+      await fs.symlink(externalAgentRoot, ownershipRoot);
+      const externalInode = (await fs.lstat(externalTarget)).ino;
+      const copyServiceApp = vi.fn(copyServiceFixture);
+
+      await expect(
+        ensureCodexComputerUseServiceApp({
+          codexHome,
+          ownershipRoot,
+          platform: "darwin",
+          sourceAppCandidates: [sourcePath],
+          copyServiceApp,
+          inspectServiceApp: inspectServiceFixture,
+        }),
+      ).rejects.toThrow(/symlinked directory|real director|symbolic link/iu);
+
+      expect(copyServiceApp).not.toHaveBeenCalled();
+      expect((await fs.lstat(ownershipRoot)).isSymbolicLink()).toBe(true);
+      expect((await fs.lstat(externalTarget)).ino).toBe(externalInode);
+      await expect(inspectServiceFixture(externalTarget)).resolves.toEqual(STALE_IDENTITY);
+      await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("outside");
+      await expect(findInstallDebris(externalParent)).resolves.toEqual([]);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked Computer Use parent without touching its external target",
+    async () => {
+      const root = tempDirs.make("openclaw-computer-use-service-symlink-");
+      const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+      const codexHome = path.join(root, "codex-home");
+      const targetParent = path.join(codexHome, "computer-use");
+      const externalParent = path.join(root, "external-computer-use");
+      const externalTarget = path.join(externalParent, "Codex Computer Use.app");
+      const sentinelPath = path.join(externalParent, "sentinel.txt");
+      await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+      await writeServiceFixture(externalTarget, STALE_IDENTITY);
+      await fs.writeFile(sentinelPath, "outside");
+      await fs.mkdir(codexHome, { recursive: true });
+      await fs.symlink(externalParent, targetParent);
+      const externalInode = (await fs.lstat(externalTarget)).ino;
+      const copyServiceApp = vi.fn(copyServiceFixture);
+
+      await expect(
+        ensureCodexComputerUseServiceApp({
+          codexHome,
+          platform: "darwin",
+          sourceAppCandidates: [sourcePath],
+          copyServiceApp,
+          inspectServiceApp: inspectServiceFixture,
+        }),
+      ).rejects.toThrow(/symlinked directory|real directory|symbolic link/iu);
+
+      expect(copyServiceApp).not.toHaveBeenCalled();
+      expect((await fs.lstat(targetParent)).isSymbolicLink()).toBe(true);
+      expect((await fs.lstat(externalTarget)).ino).toBe(externalInode);
+      await expect(inspectServiceFixture(externalTarget)).resolves.toEqual(STALE_IDENTITY);
+      await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("outside");
+      await expect(findInstallDebris(externalParent)).resolves.toEqual([]);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a symlinked service target without following its external app",
+    async () => {
+      const root = tempDirs.make("openclaw-computer-use-service-symlink-");
+      const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+      const codexHome = path.join(root, "codex-home");
+      const targetParent = path.join(codexHome, "computer-use");
+      const targetPath = path.join(targetParent, "Codex Computer Use.app");
+      const externalTarget = path.join(root, "external", "Codex Computer Use.app");
+      await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+      await writeServiceFixture(externalTarget, STALE_IDENTITY);
+      await fs.mkdir(targetParent, { recursive: true });
+      await fs.symlink(externalTarget, targetPath);
+      const externalInode = (await fs.lstat(externalTarget)).ino;
+      const copyServiceApp = vi.fn(copyServiceFixture);
+
+      await expect(
+        ensureCodexComputerUseServiceApp({
+          codexHome,
+          platform: "darwin",
+          sourceAppCandidates: [sourcePath],
+          copyServiceApp,
+          inspectServiceApp: inspectServiceFixture,
+        }),
+      ).rejects.toThrow(/must not be a symbolic link/iu);
+
+      expect(copyServiceApp).not.toHaveBeenCalled();
+      expect((await fs.lstat(targetPath)).isSymbolicLink()).toBe(true);
+      await expect(fs.readlink(targetPath)).resolves.toBe(externalTarget);
+      expect((await fs.lstat(externalTarget)).ino).toBe(externalInode);
+      await expect(inspectServiceFixture(externalTarget)).resolves.toEqual(STALE_IDENTITY);
+      await expect(findInstallDebris(targetParent)).resolves.toEqual([]);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "refuses to publish or clean up through a parent rebound during staging",
+    async () => {
+      const root = tempDirs.make("openclaw-computer-use-service-rebind-");
+      const sourcePath = path.join(root, "source", "Codex Computer Use.app");
+      const codexHome = path.join(root, "codex-home");
+      const targetParent = path.join(codexHome, "computer-use");
+      const targetPath = path.join(targetParent, "Codex Computer Use.app");
+      const parkedParent = path.join(codexHome, "computer-use-owned");
+      const externalParent = path.join(root, "external-computer-use");
+      const externalTarget = path.join(externalParent, "Codex Computer Use.app");
+      const externalSentinel = path.join(externalParent, "sentinel.txt");
+      await writeServiceFixture(sourcePath, CURRENT_IDENTITY);
+      await writeServiceFixture(targetPath, STALE_IDENTITY);
+      await writeServiceFixture(externalTarget, UNEXPECTED_IDENTITY);
+      await fs.writeFile(externalSentinel, "outside");
+      const externalInode = (await fs.lstat(externalTarget)).ino;
+      let externalStagingSentinel = "";
+
+      await expect(
+        ensureCodexComputerUseServiceApp({
+          codexHome,
+          platform: "darwin",
+          sourceAppCandidates: [sourcePath],
+          copyServiceApp: async (source, stagedTarget) => {
+            await copyServiceFixture(source, stagedTarget);
+            const stagingName = path.basename(path.dirname(stagedTarget));
+            externalStagingSentinel = path.join(
+              externalParent,
+              stagingName,
+              "external-sentinel.txt",
+            );
+            await fs.mkdir(path.dirname(externalStagingSentinel), { recursive: true });
+            await fs.writeFile(externalStagingSentinel, "do-not-delete");
+            await fs.rename(targetParent, parkedParent);
+            await fs.symlink(externalParent, targetParent);
+          },
+          inspectServiceApp: inspectServiceFixture,
+        }),
+      ).rejects.toThrow(/service parent changed during refresh/iu);
+
+      expect(externalStagingSentinel).not.toBe("");
+      await expect(fs.readFile(externalStagingSentinel, "utf8")).resolves.toBe("do-not-delete");
+      await expect(fs.readFile(externalSentinel, "utf8")).resolves.toBe("outside");
+      expect((await fs.lstat(externalTarget)).ino).toBe(externalInode);
+      await expect(inspectServiceFixture(externalTarget)).resolves.toEqual(UNEXPECTED_IDENTITY);
+      await expect(
+        inspectServiceFixture(path.join(parkedParent, "Codex Computer Use.app")),
+      ).resolves.toEqual(STALE_IDENTITY);
+      await expect(
+        findInstallDebris(externalParent).then((entries) =>
+          entries.filter((entry) => entry.startsWith(".service-app.backup-")),
+        ),
+      ).resolves.toEqual([]);
+    },
+  );
 
   it("reuses a target only when its full signed identity matches the selected source", async () => {
     const root = tempDirs.make("openclaw-computer-use-service-");

--- a/extensions/codex/src/app-server/computer-use-service.ts
+++ b/extensions/codex/src/app-server/computer-use-service.ts
@@ -6,52 +6,126 @@ import { runExec } from "openclaw/plugin-sdk/process-runtime";
 import { resolveMacOSDesktopCodexComputerUseServiceAppCandidates } from "./desktop-app-paths.js";
 
 const SERVICE_APP_NAME = "Codex Computer Use.app";
+const SERVICE_BUNDLE_ID = "com.openai.sky.CUAService";
+const CLIENT_BUNDLE_ID = "com.openai.sky.CUAService.cli";
+const OPENAI_TEAM_ID = "2DC432GLL2";
+const CLIENT_APP_RELATIVE_PATH = path.join("Contents", "SharedSupport", "SkyComputerUseClient.app");
 const CLIENT_RELATIVE_PATH = path.join(
-  "Contents",
-  "SharedSupport",
-  "SkyComputerUseClient.app",
+  CLIENT_APP_RELATIVE_PATH,
   "Contents",
   "MacOS",
   "SkyComputerUseClient",
 );
 const COPY_TIMEOUT_MS = 120_000;
-const activeInstalls = new Map<string, Promise<CodexComputerUseServiceStatus>>();
+const INSPECT_TIMEOUT_MS = 30_000;
+const activeInstalls = new Map<
+  string,
+  { syncKey: string; promise: Promise<CodexComputerUseServiceStatus> }
+>();
+const completedSyncs = new Map<
+  string,
+  Pick<CodexComputerUseServiceStatus, "targetPath" | "sourcePath" | "sourceBuild"> & {
+    syncKey: string;
+  }
+>();
 
 type CodexComputerUseServiceStatus = {
-  status: "installed" | "already_installed" | "source_missing" | "unsupported";
+  status: "installed" | "refreshed" | "already_current" | "source_missing" | "unsupported";
   changed: boolean;
   targetPath?: string;
   sourcePath?: string;
+  sourceBuild?: string;
+  previousBuild?: string;
 };
 
 type CopyServiceApp = (sourcePath: string, targetPath: string) => Promise<void>;
+type InspectServiceApp = (appPath: string) => Promise<CodexComputerUseServiceIdentity | undefined>;
 
-/** Ensures the official native client exists beneath the CODEX_HOME used by its launcher. */
+type CodexComputerUseServiceIdentity = {
+  bundleId: string;
+  version: string;
+  build: string;
+  cdHash: string;
+  teamId: string;
+  clientBundleId: string;
+  clientCdHash: string;
+  clientTeamId: string;
+};
+
+type ServiceAppSnapshot = {
+  exists: boolean;
+  identity?: CodexComputerUseServiceIdentity;
+  filesystemKey?: string;
+};
+
+/** Synchronizes the CODEX_HOME native client with the selected signed desktop distribution. */
 export async function ensureCodexComputerUseServiceApp(params: {
   codexHome: string;
   platform?: NodeJS.Platform;
   appServerCommand?: string;
   sourceAppCandidates?: readonly string[];
   copyServiceApp?: CopyServiceApp;
+  inspectServiceApp?: InspectServiceApp;
 }): Promise<CodexComputerUseServiceStatus> {
   const platform = params.platform ?? process.platform;
   if (platform !== "darwin") {
     return { status: "unsupported", changed: false };
   }
   const targetPath = path.join(path.resolve(params.codexHome), "computer-use", SERVICE_APP_NAME);
+  const candidates =
+    params.sourceAppCandidates ??
+    resolveMacOSDesktopCodexComputerUseServiceAppCandidates(platform, params.appServerCommand);
+  const syncKey = [targetPath, ...candidates].join("\0");
+  const completed = completedSyncs.get(targetPath);
+  if (completed?.syncKey === syncKey) {
+    return {
+      status: "already_current",
+      changed: false,
+      targetPath: completed.targetPath,
+      sourcePath: completed.sourcePath,
+      sourceBuild: completed.sourceBuild,
+    };
+  }
   const active = activeInstalls.get(targetPath);
   if (active) {
-    return await active;
+    if (active.syncKey === syncKey) {
+      return await active.promise;
+    }
+    await active.promise.catch(() => undefined);
+    return await ensureCodexComputerUseServiceApp(params);
   }
-  const install = ensureCodexComputerUseServiceAppOnce({ ...params, targetPath, platform });
-  activeInstalls.set(targetPath, install);
-  try {
-    return await install;
-  } finally {
-    if (activeInstalls.get(targetPath) === install) {
+  if (completed) {
+    completedSyncs.delete(targetPath);
+  }
+  const install = ensureCodexComputerUseServiceAppOnce({
+    ...params,
+    targetPath,
+    platform,
+    sourceAppCandidates: candidates,
+  }).then((result) => {
+    if (isCompletedSyncStatus(result.status)) {
+      completedSyncs.set(targetPath, {
+        syncKey,
+        targetPath: result.targetPath,
+        sourcePath: result.sourcePath,
+        sourceBuild: result.sourceBuild,
+      });
+    }
+    return result;
+  });
+  const activeEntry = { syncKey, promise: install };
+  activeInstalls.set(targetPath, activeEntry);
+  const clearActive = () => {
+    if (activeInstalls.get(targetPath) === activeEntry) {
       activeInstalls.delete(targetPath);
     }
-  }
+  };
+  void install.then(clearActive, clearActive);
+  return await install;
+}
+
+function isCompletedSyncStatus(status: CodexComputerUseServiceStatus["status"]): boolean {
+  return status === "installed" || status === "refreshed" || status === "already_current";
 }
 
 async function ensureCodexComputerUseServiceAppOnce(params: {
@@ -61,19 +135,24 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
   appServerCommand?: string;
   sourceAppCandidates?: readonly string[];
   copyServiceApp?: CopyServiceApp;
+  inspectServiceApp?: InspectServiceApp;
 }): Promise<CodexComputerUseServiceStatus> {
-  if (await hasExecutableClient(params.targetPath)) {
-    return { status: "already_installed", changed: false, targetPath: params.targetPath };
-  }
-  const candidates =
-    params.sourceAppCandidates ??
-    resolveMacOSDesktopCodexComputerUseServiceAppCandidates(
-      params.platform,
-      params.appServerCommand,
-    );
-  const sourcePath = await findUsableServiceApp(candidates);
-  if (!sourcePath) {
+  const inspectServiceApp = params.inspectServiceApp ?? inspectTrustedServiceApp;
+  const candidates = params.sourceAppCandidates ?? [];
+  const source = await findUsableServiceApp(candidates, inspectServiceApp);
+  if (!source) {
     return { status: "source_missing", changed: false, targetPath: params.targetPath };
+  }
+  const { path: sourcePath, identity: sourceIdentity } = source;
+  const initialTarget = await readServiceAppSnapshot(params.targetPath, inspectServiceApp);
+  if (initialTarget.identity && identitiesMatch(initialTarget.identity, sourceIdentity)) {
+    return {
+      status: "already_current",
+      changed: false,
+      targetPath: params.targetPath,
+      sourcePath,
+      sourceBuild: sourceIdentity.build,
+    };
   }
 
   const targetParent = path.dirname(params.targetPath);
@@ -84,53 +163,102 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
   let backupCreated = false;
   try {
     await (params.copyServiceApp ?? copyServiceAppWithDitto)(sourcePath, stagedPath);
-    if (!(await hasExecutableClient(stagedPath))) {
-      throw new Error(`Copied Computer Use service app is incomplete at ${stagedPath}.`);
+    const stagedIdentity = await inspectServiceApp(stagedPath);
+    if (!stagedIdentity || !identitiesMatch(stagedIdentity, sourceIdentity)) {
+      throw new Error(
+        `Copied Computer Use service app at ${stagedPath} does not match its selected signed source.`,
+      );
+    }
+    const stagedSnapshot = await readServiceAppSnapshot(stagedPath, inspectServiceApp);
+    const currentSourceIdentity = await inspectServiceApp(sourcePath);
+    if (!currentSourceIdentity || !identitiesMatch(currentSourceIdentity, sourceIdentity)) {
+      throw new Error("Selected Computer Use service source changed during refresh.");
     }
     if (await pathExists(params.targetPath)) {
       await fs.rename(params.targetPath, backupPath);
       backupCreated = true;
-      if (await hasExecutableClient(backupPath)) {
-        // A separate runtime can win after the initial target check. Restore
-        // its complete signed app rather than replacing it from our staging copy.
+      const movedTarget = await readServiceAppSnapshot(backupPath, inspectServiceApp);
+      if (movedTarget.identity && identitiesMatch(movedTarget.identity, sourceIdentity)) {
+        // Another runtime installed the selected signed generation while this
+        // process was staging. Keep that winner rather than replacing it.
         await fs.rename(backupPath, params.targetPath);
         backupCreated = false;
         return {
-          status: "already_installed",
+          status: "already_current",
           changed: false,
           targetPath: params.targetPath,
           sourcePath,
+          sourceBuild: sourceIdentity.build,
         };
+      }
+      if (!snapshotsMatch(initialTarget, movedTarget)) {
+        await fs.rename(backupPath, params.targetPath);
+        backupCreated = false;
+        throw new Error(
+          "Computer Use service target changed to an unexpected generation during refresh.",
+        );
       }
     }
     try {
       await fs.rename(stagedPath, params.targetPath);
     } catch (error) {
-      // Another runtime can finish the same isolated-home install first.
-      // Preserve that complete winner instead of replacing a live signed app.
-      if (!(await hasExecutableClient(params.targetPath))) {
+      const winnerIdentity = await inspectServiceApp(params.targetPath);
+      if (!winnerIdentity || !identitiesMatch(winnerIdentity, sourceIdentity)) {
         if (backupCreated) {
-          await fs.rename(backupPath, params.targetPath);
-          backupCreated = false;
+          if (!(await pathExists(params.targetPath))) {
+            await fs.rename(backupPath, params.targetPath);
+            backupCreated = false;
+          }
         }
         throw error;
       }
+      // A concurrent installer won with the same selected signed generation.
       if (backupCreated) {
         await fs.rm(backupPath, { recursive: true, force: true });
         backupCreated = false;
       }
       return {
-        status: "already_installed",
+        status: "already_current",
         changed: false,
         targetPath: params.targetPath,
         sourcePath,
+        sourceBuild: sourceIdentity.build,
       };
+    }
+    const installedSnapshot = await readServiceAppSnapshot(params.targetPath, inspectServiceApp);
+    if (
+      !installedSnapshot.identity ||
+      !identitiesMatch(installedSnapshot.identity, sourceIdentity)
+    ) {
+      if (filesystemSnapshotsMatch(installedSnapshot, stagedSnapshot)) {
+        await fs.rm(params.targetPath, { recursive: true, force: true });
+        if (backupCreated) {
+          await fs.rename(backupPath, params.targetPath);
+          backupCreated = false;
+        }
+      }
+      throw new Error(
+        "Installed Computer Use service app failed post-install identity verification.",
+      );
     }
     if (backupCreated) {
       await fs.rm(backupPath, { recursive: true, force: true });
       backupCreated = false;
     }
-    return { status: "installed", changed: true, targetPath: params.targetPath, sourcePath };
+    return {
+      status: initialTarget.exists ? "refreshed" : "installed",
+      changed: true,
+      targetPath: params.targetPath,
+      sourcePath,
+      sourceBuild: sourceIdentity.build,
+      ...(initialTarget.identity ? { previousBuild: initialTarget.identity.build } : {}),
+    };
+  } catch (error) {
+    if (backupCreated && !(await pathExists(params.targetPath))) {
+      await fs.rename(backupPath, params.targetPath);
+      backupCreated = false;
+    }
+    throw error;
   } finally {
     await fs.rm(stagingRoot, { recursive: true, force: true });
   }
@@ -143,13 +271,93 @@ async function pathExists(filePath: string): Promise<boolean> {
   );
 }
 
-async function findUsableServiceApp(candidates: readonly string[]): Promise<string | undefined> {
+async function findUsableServiceApp(
+  candidates: readonly string[],
+  inspectServiceApp: InspectServiceApp,
+): Promise<{ path: string; identity: CodexComputerUseServiceIdentity } | undefined> {
   for (const candidate of candidates) {
-    if (await hasExecutableClient(candidate)) {
-      return candidate;
+    const identity = await inspectServiceApp(candidate);
+    if (identity) {
+      return { path: candidate, identity };
     }
   }
   return undefined;
+}
+
+async function readServiceAppSnapshot(
+  appPath: string,
+  inspectServiceApp: InspectServiceApp,
+): Promise<ServiceAppSnapshot> {
+  if (!(await pathExists(appPath))) {
+    return { exists: false };
+  }
+  return {
+    exists: true,
+    identity: await inspectServiceApp(appPath),
+    filesystemKey: await readServiceAppFilesystemKey(appPath),
+  };
+}
+
+async function readServiceAppFilesystemKey(appPath: string): Promise<string | undefined> {
+  const paths = [
+    appPath,
+    path.join(appPath, "Contents", "Info.plist"),
+    path.join(appPath, CLIENT_RELATIVE_PATH),
+  ];
+  const entries = await Promise.all(
+    paths.map(
+      async (entryPath) =>
+        await fs.stat(entryPath).then(
+          (stat) => `${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`,
+          () => "missing",
+        ),
+    ),
+  );
+  return entries.join("|");
+}
+
+function snapshotsMatch(left: ServiceAppSnapshot, right: ServiceAppSnapshot): boolean {
+  if (left.exists !== right.exists) {
+    return false;
+  }
+  if (!left.exists) {
+    return true;
+  }
+  if (left.filesystemKey && right.filesystemKey && left.filesystemKey !== right.filesystemKey) {
+    return false;
+  }
+  if (left.identity || right.identity) {
+    return Boolean(
+      left.identity && right.identity && identitiesMatch(left.identity, right.identity),
+    );
+  }
+  return left.filesystemKey !== undefined && left.filesystemKey === right.filesystemKey;
+}
+
+function filesystemSnapshotsMatch(left: ServiceAppSnapshot, right: ServiceAppSnapshot): boolean {
+  return Boolean(
+    left.exists &&
+    right.exists &&
+    left.filesystemKey &&
+    right.filesystemKey &&
+    left.filesystemKey === right.filesystemKey,
+  );
+}
+
+function identitiesMatch(
+  left: CodexComputerUseServiceIdentity,
+  right: CodexComputerUseServiceIdentity,
+): boolean {
+  return (
+    left.bundleId === right.bundleId &&
+    left.version === right.version &&
+    left.build === right.build &&
+    left.cdHash === right.cdHash &&
+    left.teamId === right.teamId &&
+    left.clientBundleId === right.clientBundleId &&
+    left.clientCdHash === right.clientCdHash &&
+    left.clientTeamId === right.clientTeamId
+  );
 }
 
 async function hasExecutableClient(appPath: string): Promise<boolean> {
@@ -159,6 +367,102 @@ async function hasExecutableClient(appPath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function inspectTrustedServiceApp(
+  appPath: string,
+): Promise<CodexComputerUseServiceIdentity | undefined> {
+  if (!(await hasExecutableClient(appPath))) {
+    return undefined;
+  }
+  const clientAppPath = path.join(appPath, CLIENT_APP_RELATIVE_PATH);
+  try {
+    await verifyTrustedBundle(appPath, SERVICE_BUNDLE_ID, true);
+    await verifyTrustedBundle(clientAppPath, CLIENT_BUNDLE_ID, false);
+    const [info, serviceSignature, clientSignature] = await Promise.all([
+      readBundleInfo(appPath),
+      readCodeSignature(appPath),
+      readCodeSignature(clientAppPath),
+    ]);
+    if (
+      !info ||
+      serviceSignature.identifier !== SERVICE_BUNDLE_ID ||
+      serviceSignature.teamId !== OPENAI_TEAM_ID ||
+      clientSignature.identifier !== CLIENT_BUNDLE_ID ||
+      clientSignature.teamId !== OPENAI_TEAM_ID
+    ) {
+      return undefined;
+    }
+    return {
+      bundleId: serviceSignature.identifier,
+      version: info.version,
+      build: info.build,
+      cdHash: serviceSignature.cdHash,
+      teamId: serviceSignature.teamId,
+      clientBundleId: clientSignature.identifier,
+      clientCdHash: clientSignature.cdHash,
+      clientTeamId: clientSignature.teamId,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+async function verifyTrustedBundle(
+  appPath: string,
+  bundleId: string,
+  deep: boolean,
+): Promise<void> {
+  const requirement =
+    `anchor apple generic and certificate leaf[subject.OU] = "${OPENAI_TEAM_ID}" ` +
+    `and identifier "${bundleId}"`;
+  await runExec(
+    "/usr/bin/codesign",
+    ["--verify", "--strict", ...(deep ? ["--deep"] : []), `-R=${requirement}`, appPath],
+    { logOutput: false, timeoutMs: INSPECT_TIMEOUT_MS },
+  );
+}
+
+async function readBundleInfo(
+  appPath: string,
+): Promise<{ version: string; build: string } | undefined> {
+  const result = await runExec(
+    "/usr/bin/plutil",
+    ["-convert", "json", "-o", "-", "--", path.join(appPath, "Contents", "Info.plist")],
+    { logOutput: false, timeoutMs: INSPECT_TIMEOUT_MS },
+  );
+  const parsed = JSON.parse(result.stdout) as {
+    CFBundleShortVersionString?: unknown;
+    CFBundleVersion?: unknown;
+  };
+  const version = parsed.CFBundleShortVersionString;
+  const build = parsed.CFBundleVersion;
+  return typeof version === "string" && version && typeof build === "string" && build
+    ? { version, build }
+    : undefined;
+}
+
+async function readCodeSignature(
+  appPath: string,
+): Promise<{ identifier: string; teamId: string; cdHash: string }> {
+  const result = await runExec("/usr/bin/codesign", ["-d", "--verbose=4", appPath], {
+    logOutput: false,
+    timeoutMs: INSPECT_TIMEOUT_MS,
+  });
+  const output = `${result.stdout}\n${result.stderr}`;
+  const identifier = readCodeSignField(output, "Identifier");
+  const teamId = readCodeSignField(output, "TeamIdentifier");
+  const cdHash = readCodeSignField(output, "CDHash").toLowerCase();
+  if (!identifier || !teamId || !/^[a-f0-9]+$/.test(cdHash)) {
+    throw new Error(`Could not inspect the signed identity at ${appPath}.`);
+  }
+  return { identifier, teamId, cdHash };
+}
+
+function readCodeSignField(output: string, field: string): string {
+  const prefix = `${field}=`;
+  const line = output.split(/\r?\n/u).find((candidate) => candidate.startsWith(prefix));
+  return line?.slice(prefix.length).trim() ?? "";
 }
 
 async function copyServiceAppWithDitto(sourcePath: string, targetPath: string): Promise<void> {

--- a/extensions/codex/src/app-server/computer-use-service.ts
+++ b/extensions/codex/src/app-server/computer-use-service.ts
@@ -5,6 +5,17 @@ import path from "node:path";
 import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { runExec } from "openclaw/plugin-sdk/process-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  assertDirectoryIdentityStable,
+  assertNotSymlink,
+  assertOwnedServiceParentStable,
+  assertOwnedServicePath,
+  directoryIdentityIsStable,
+  ensureOwnedCodexHome,
+  ownedServiceParentIsStable,
+  prepareOwnedServiceParent,
+  readRealDirectoryIdentity,
+} from "./computer-use-service-path.js";
 import { resolveMacOSDesktopCodexComputerUseServiceAppCandidates } from "./desktop-app-paths.js";
 
 const SERVICE_APP_NAME = "Codex Computer Use.app";
@@ -64,6 +75,7 @@ type ServiceAppSnapshot = {
 /** Synchronizes the CODEX_HOME native client with the selected signed desktop distribution. */
 export async function ensureCodexComputerUseServiceApp(params: {
   codexHome: string;
+  ownershipRoot?: string;
   platform?: NodeJS.Platform;
   appServerCommand?: string;
   sourceAppCandidates?: readonly string[];
@@ -74,7 +86,12 @@ export async function ensureCodexComputerUseServiceApp(params: {
   if (platform !== "darwin") {
     return { status: "unsupported", changed: false };
   }
-  const targetPath = path.join(path.resolve(params.codexHome), "computer-use", SERVICE_APP_NAME);
+  const codexHome = path.resolve(params.codexHome);
+  const ownershipRoot = path.resolve(params.ownershipRoot ?? path.dirname(codexHome));
+  const targetParent = path.join(codexHome, "computer-use");
+  const targetPath = path.join(targetParent, SERVICE_APP_NAME);
+  await ensureOwnedCodexHome(codexHome, ownershipRoot);
+  await assertOwnedServicePath({ ownershipRoot, codexHome, targetParent, targetPath });
   const candidates =
     params.sourceAppCandidates ??
     resolveMacOSDesktopCodexComputerUseServiceAppCandidates(platform, params.appServerCommand);
@@ -105,6 +122,9 @@ export async function ensureCodexComputerUseServiceApp(params: {
   }
   const install = ensureCodexComputerUseServiceAppOnce({
     ...params,
+    codexHome,
+    ownershipRoot,
+    targetParent,
     targetPath,
     platform,
     sourceAppCandidates: candidates,
@@ -138,6 +158,8 @@ function isCompletedSyncStatus(status: CodexComputerUseServiceStatus["status"]):
 
 async function ensureCodexComputerUseServiceAppOnce(params: {
   codexHome: string;
+  ownershipRoot: string;
+  targetParent: string;
   targetPath: string;
   platform: NodeJS.Platform;
   appServerCommand?: string;
@@ -152,7 +174,14 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
     return { status: "source_missing", changed: false, targetPath: params.targetPath };
   }
   const { path: sourcePath, identity: sourceIdentity } = source;
-  const initialTarget = await readServiceAppSnapshot(params.targetPath, inspectServiceApp);
+  const ownedParent = await prepareOwnedServiceParent({
+    ownershipRoot: params.ownershipRoot,
+    codexHome: params.codexHome,
+    targetParent: params.targetParent,
+  });
+  const operationTargetPath = path.join(ownedParent.realPath, SERVICE_APP_NAME);
+  await assertNotSymlink(operationTargetPath, "Computer Use service target");
+  const initialTarget = await readServiceAppSnapshot(operationTargetPath, inspectServiceApp);
   if (initialTarget.identity && identitiesMatch(initialTarget.identity, sourceIdentity)) {
     return {
       status: "already_current",
@@ -163,14 +192,26 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
     };
   }
 
-  const targetParent = path.dirname(params.targetPath);
-  await fs.mkdir(targetParent, { recursive: true });
-  const stagingRoot = await fs.mkdtemp(path.join(targetParent, ".service-app.staging-"));
+  await assertOwnedServiceParentStable(ownedParent);
+  const stagingRoot = await fs.mkdtemp(path.join(ownedParent.realPath, ".service-app.staging-"));
+  const stagingRootIdentity = await readRealDirectoryIdentity(
+    stagingRoot,
+    "Computer Use service staging directory",
+  );
   const stagedPath = path.join(stagingRoot, SERVICE_APP_NAME);
-  const backupPath = path.join(targetParent, `.service-app.backup-${process.pid}-${Date.now()}`);
+  const backupPath = path.join(
+    ownedParent.realPath,
+    `.service-app.backup-${process.pid}-${Date.now()}`,
+  );
   let backupCreated = false;
   try {
     await (params.copyServiceApp ?? copyServiceAppWithDitto)(sourcePath, stagedPath);
+    await assertOwnedServiceParentStable(ownedParent);
+    await assertDirectoryIdentityStable(
+      stagingRootIdentity,
+      "Computer Use service staging directory",
+    );
+    await assertNotSymlink(stagedPath, "Copied Computer Use service app");
     const stagedIdentity = await inspectServiceApp(stagedPath);
     if (!stagedIdentity || !identitiesMatch(stagedIdentity, sourceIdentity)) {
       throw new Error(
@@ -179,17 +220,23 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
     }
     const stagedSnapshot = await readServiceAppSnapshot(stagedPath, inspectServiceApp);
     const currentSourceIdentity = await inspectServiceApp(sourcePath);
+    await assertOwnedServiceParentStable(ownedParent);
     if (!currentSourceIdentity || !identitiesMatch(currentSourceIdentity, sourceIdentity)) {
       throw new Error("Selected Computer Use service source changed during refresh.");
     }
-    if (await pathExists(params.targetPath)) {
-      await fs.rename(params.targetPath, backupPath);
+    await assertNotSymlink(operationTargetPath, "Computer Use service target");
+    if (await pathExists(operationTargetPath)) {
+      await assertOwnedServiceParentStable(ownedParent);
+      await fs.rename(operationTargetPath, backupPath);
+      await assertOwnedServiceParentStable(ownedParent);
       backupCreated = true;
       const movedTarget = await readServiceAppSnapshot(backupPath, inspectServiceApp);
       if (movedTarget.identity && identitiesMatch(movedTarget.identity, sourceIdentity)) {
         // Another runtime installed the selected signed generation while this
         // process was staging. Keep that winner rather than replacing it.
-        await fs.rename(backupPath, params.targetPath);
+        await assertOwnedServiceParentStable(ownedParent);
+        await fs.rename(backupPath, operationTargetPath);
+        await assertOwnedServiceParentStable(ownedParent);
         backupCreated = false;
         return {
           status: "already_current",
@@ -200,7 +247,9 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
         };
       }
       if (!snapshotsMatch(initialTarget, movedTarget)) {
-        await fs.rename(backupPath, params.targetPath);
+        await assertOwnedServiceParentStable(ownedParent);
+        await fs.rename(backupPath, operationTargetPath);
+        await assertOwnedServiceParentStable(ownedParent);
         backupCreated = false;
         throw new Error(
           "Computer Use service target changed to an unexpected generation during refresh.",
@@ -208,13 +257,19 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
       }
     }
     try {
-      await fs.rename(stagedPath, params.targetPath);
+      await assertOwnedServiceParentStable(ownedParent);
+      await fs.rename(stagedPath, operationTargetPath);
+      await assertOwnedServiceParentStable(ownedParent);
     } catch (error) {
-      const winnerIdentity = await inspectServiceApp(params.targetPath);
+      await assertOwnedServiceParentStable(ownedParent);
+      await assertNotSymlink(operationTargetPath, "Computer Use service target");
+      const winnerIdentity = await inspectServiceApp(operationTargetPath);
       if (!winnerIdentity || !identitiesMatch(winnerIdentity, sourceIdentity)) {
         if (backupCreated) {
-          if (!(await pathExists(params.targetPath))) {
-            await fs.rename(backupPath, params.targetPath);
+          if (!(await pathExists(operationTargetPath))) {
+            await assertOwnedServiceParentStable(ownedParent);
+            await fs.rename(backupPath, operationTargetPath);
+            await assertOwnedServiceParentStable(ownedParent);
             backupCreated = false;
           }
         }
@@ -222,7 +277,10 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
       }
       // A concurrent installer won with the same selected signed generation.
       if (backupCreated) {
+        await assertOwnedServiceParentStable(ownedParent);
+        await assertNotSymlink(backupPath, "Computer Use service backup");
         await fs.rm(backupPath, { recursive: true, force: true });
+        await assertOwnedServiceParentStable(ownedParent);
         backupCreated = false;
       }
       return {
@@ -233,15 +291,19 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
         sourceBuild: sourceIdentity.build,
       };
     }
-    const installedSnapshot = await readServiceAppSnapshot(params.targetPath, inspectServiceApp);
+    await assertNotSymlink(operationTargetPath, "Installed Computer Use service app");
+    const installedSnapshot = await readServiceAppSnapshot(operationTargetPath, inspectServiceApp);
     if (
       !installedSnapshot.identity ||
       !identitiesMatch(installedSnapshot.identity, sourceIdentity)
     ) {
       if (filesystemSnapshotsMatch(installedSnapshot, stagedSnapshot)) {
-        await fs.rm(params.targetPath, { recursive: true, force: true });
+        await assertOwnedServiceParentStable(ownedParent);
+        await fs.rm(operationTargetPath, { recursive: true, force: true });
+        await assertOwnedServiceParentStable(ownedParent);
         if (backupCreated) {
-          await fs.rename(backupPath, params.targetPath);
+          await fs.rename(backupPath, operationTargetPath);
+          await assertOwnedServiceParentStable(ownedParent);
           backupCreated = false;
         }
       }
@@ -250,7 +312,10 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
       );
     }
     if (backupCreated) {
+      await assertOwnedServiceParentStable(ownedParent);
+      await assertNotSymlink(backupPath, "Computer Use service backup");
       await fs.rm(backupPath, { recursive: true, force: true });
+      await assertOwnedServiceParentStable(ownedParent);
       backupCreated = false;
     }
     return {
@@ -262,13 +327,23 @@ async function ensureCodexComputerUseServiceAppOnce(params: {
       ...(initialTarget.identity ? { previousBuild: initialTarget.identity.build } : {}),
     };
   } catch (error) {
-    if (backupCreated && !(await pathExists(params.targetPath))) {
-      await fs.rename(backupPath, params.targetPath);
+    if (
+      backupCreated &&
+      (await ownedServiceParentIsStable(ownedParent)) &&
+      !(await pathExists(operationTargetPath))
+    ) {
+      await assertOwnedServiceParentStable(ownedParent);
+      await fs.rename(backupPath, operationTargetPath);
       backupCreated = false;
     }
     throw error;
   } finally {
-    await fs.rm(stagingRoot, { recursive: true, force: true });
+    if (
+      (await ownedServiceParentIsStable(ownedParent)) &&
+      (await directoryIdentityIsStable(stagingRootIdentity))
+    ) {
+      await fs.rm(stagingRoot, { recursive: true, force: true });
+    }
   }
 }
 

--- a/extensions/codex/src/app-server/computer-use-service.ts
+++ b/extensions/codex/src/app-server/computer-use-service.ts
@@ -2,6 +2,7 @@
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import { runExec } from "openclaw/plugin-sdk/process-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveMacOSDesktopCodexComputerUseServiceAppCandidates } from "./desktop-app-paths.js";
@@ -19,6 +20,7 @@ const CLIENT_RELATIVE_PATH = path.join(
 );
 const COPY_TIMEOUT_MS = 120_000;
 const INSPECT_TIMEOUT_MS = 30_000;
+const COMPLETED_SYNC_CACHE_MAX_ENTRIES = 64;
 const activeInstalls = new Map<
   string,
   { syncKey: string; promise: Promise<CodexComputerUseServiceStatus> }
@@ -79,6 +81,9 @@ export async function ensureCodexComputerUseServiceApp(params: {
   const syncKey = [targetPath, ...candidates].join("\0");
   const completed = completedSyncs.get(targetPath);
   if (completed?.syncKey === syncKey) {
+    // Keep frequently reused homes while bounding dynamic-agent history.
+    completedSyncs.delete(targetPath);
+    completedSyncs.set(targetPath, completed);
     return {
       status: "already_current",
       changed: false,
@@ -105,12 +110,14 @@ export async function ensureCodexComputerUseServiceApp(params: {
     sourceAppCandidates: candidates,
   }).then((result) => {
     if (isCompletedSyncStatus(result.status)) {
+      completedSyncs.delete(targetPath);
       completedSyncs.set(targetPath, {
         syncKey,
         targetPath: result.targetPath,
         sourcePath: result.sourcePath,
         sourceBuild: result.sourceBuild,
       });
+      pruneMapToMaxSize(completedSyncs, COMPLETED_SYNC_CACHE_MAX_ENTRIES);
     }
     return result;
   });

--- a/extensions/codex/src/app-server/computer-use-service.ts
+++ b/extensions/codex/src/app-server/computer-use-service.ts
@@ -3,6 +3,7 @@ import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { runExec } from "openclaw/plugin-sdk/process-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveMacOSDesktopCodexComputerUseServiceAppCandidates } from "./desktop-app-paths.js";
 
 const SERVICE_APP_NAME = "Codex Computer Use.app";
@@ -431,10 +432,10 @@ async function readBundleInfo(
     ["-convert", "json", "-o", "-", "--", path.join(appPath, "Contents", "Info.plist")],
     { logOutput: false, timeoutMs: INSPECT_TIMEOUT_MS },
   );
-  const parsed = JSON.parse(result.stdout) as {
-    CFBundleShortVersionString?: unknown;
-    CFBundleVersion?: unknown;
-  };
+  const parsed: unknown = JSON.parse(result.stdout);
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
   const version = parsed.CFBundleShortVersionString;
   const build = parsed.CFBundleVersion;
   return typeof version === "string" && version && typeof build === "string" && build


### PR DESCRIPTION
> [!IMPORTANT]
> Rebased onto current `main` after #125883 and #126450 landed. This PR now
> contains only the signed native Computer Use bundle synchronization,
> containment, tests, and documentation. External app-server admission is not
> part of this diff. The earlier composite production run remains historical
> behavior proof for the refresh path described below.

## What Problem This Solves

Users running Codex with isolated per-agent homes can lose working Computer Use
after the selected ChatGPT or Codex desktop distribution is updated.

OpenClaw previously treated any executable agent-local Computer Use client as
permanently reusable. An isolated agent could therefore have all of these at
the same time:

- a current Codex app-server;
- a current `computer-use` plugin cache;
- a current global Computer Use service;
- an older, complete, validly OpenAI-signed native client under its private
  `CODEX_HOME`.

The plugin could initialize and expose genuine Computer Use tools, but native
invocation could still fail at the client/service boundary. In the real
installation below, a genuine `get_app_state` invocation returned:

```text
Computer Use server error -10000: Sender process is not authenticated
```

The affected bundle was neither corrupt nor unsigned. It was a validly signed
older generation, so the former executable-only predicate considered it
healthy and never refreshed it.

## Fix

This change makes the existing Computer Use provisioning owner synchronize the
native distribution under an isolated `CODEX_HOME` with the selected trusted
desktop distribution before a cold app-server startup.

### Platform scope

This changes only OpenClaw's existing **macOS** native Computer Use provisioning
path. The synchronized artifact is a macOS `.app`, and the implementation
returns `unsupported` before source discovery or inspection whenever
`platform !== "darwin"`. Linux and Windows therefore do not invoke `codesign`,
`plutil`, Apple trust requirements, or `.app` copying, and their existing Codex
startup behavior is unchanged. A focused non-macOS regression test covers that
early-exit contract.

### Selected source and signed-identity contract

OpenClaw now:

1. resolves the existing ordered desktop candidates before deciding that the
   isolated target is reusable;
2. prefers assets associated with the selected `appServer.command` when those
   assets are available and trusted, while preserving the resolver's existing
   ordered fallback candidates;
3. requires the outer service and nested client to satisfy explicit Apple code
   requirements:
   - Apple generic anchor;
   - OpenAI Team Identifier `2DC432GLL2`;
   - outer bundle identifier `com.openai.sky.CUAService`;
   - nested client identifier `com.openai.sky.CUAService.cli`;
4. runs strict signature verification for both bundles and deep verification
   for the outer service;
5. compares the complete identity consumed by this integration:
   - outer bundle identifier;
   - outer `CFBundleShortVersionString`;
   - outer `CFBundleVersion`;
   - outer CDHash;
   - outer Team Identifier;
   - nested client bundle identifier;
   - nested client CDHash;
   - nested client Team Identifier;
6. reuses the isolated copy only when that identity exactly matches the
   selected signed source.

This is intentionally synchronization, not a numeric "newer version wins"
policy. The compatibility/provenance unit is the selected Desktop distribution.

The user-scoped `~/.codex/computer-use` copy is used below only as corroborating
evidence. It is not promoted to the provisioning source. The provisioning
owner now excludes both `homeScope: "user"` and every explicit `CODEX_HOME`
override from native bundle replacement, so synchronization is limited to the
standard OpenClaw-owned isolated home.

### Staging, rollback, and races

For a missing, incomplete, or mismatched target, OpenClaw:

1. copies the selected source to a staging directory on the target filesystem;
2. verifies that staging has the exact signed identity inspected from source;
3. re-inspects source before the swap, detecting a Desktop update during copy;
4. snapshots the original target's filesystem ownership and signed identity;
5. moves the original target to a rollback path;
6. moves the verified staged tree into the target path;
7. verifies the installed target before removing the rollback copy.

Each rename is atomic, but the complete replacement is deliberately described
as a staged swap rather than a single atomic exchange: there is a brief interval
between moving the old target aside and installing the staged target.

Failures are conservative:

- a staged/source mismatch is rejected before the target is touched;
- an unchanged stale or incomplete target can be replaced;
- a concurrent installer that already installed the selected identity is kept;
- an unexpected concurrent generation is preserved instead of overwritten;
- a failed installed target is removed only when it is still the staged
  filesystem tree owned by this invocation;
- the previous target is restored when this invocation still owns the empty
  target path;
- user-scoped and explicitly configured Codex homes never enter this native
  bundle replacement path;
- the rest of the isolated `CODEX_HOME` is never replaced or shared.

### Owned-path containment

The caller supplies the effective agent directory as the trusted ownership
boundary for native-service provisioning. Before source or target inspection,
OpenClaw rejects a symlinked ownership root, isolated Codex home,
`computer-use` parent, or final service-app target. Missing owned descendants
are created one component at a time and then revalidated as real directories.

The transaction captures the canonical service parent and its device/inode/real
path identity, derives staging and backup paths from that canonical parent, and
revalidates the parent and staging identities around copy, rename, rollback, and
cleanup operations. If the owned path is rebound, publication stops and path-based
rollback or cleanup is skipped rather than following the replacement path.
Aliases above the caller-designated agent-directory boundary retain their existing
compatibility; user-scoped homes and explicit `CODEX_HOME` overrides remain outside
native bundle replacement.

Outcomes now distinguish `installed`, `refreshed`, `already_current`,
`source_missing`, and `unsupported`.

### Lifecycle and performance boundary

Synchronization remains a cold app-server startup preflight.

Within one Gateway process:

- concurrent calls for the same target and selection share one operation;
- calls for the same target but different selections serialize and re-evaluate;
- a successful synchronization is cached for that exact target/selection,
  avoiding repeated `codesign` and `plutil` work on ordinary turns;
- completed synchronization state is held in a bounded 64-entry LRU; eviction
  only causes a later trusted reinspection and never mutates the target;
- changing selection invalidates the previous completed selection, including
  when the new selection subsequently fails;
- missing-source results and failures are not cached.

This PR intentionally does not poll Desktop files while a Gateway/app-server
client remains warm, invalidate an active thread, or restart the Gateway.
After ChatGPT or Codex Desktop updates, the documented invalidation boundary is
a Gateway restart followed by cold app-server startup.

## User impact

Operators can retain per-agent `CODEX_HOME` isolation without manually deleting
native bundles or sharing the entire user-scoped Codex home. After a Desktop
update and Gateway restart, a subsequently cold-started isolated agent keeps a
matching bundle, installs a missing one, or refreshes a complete-but-mismatched
signed generation while preserving auth, config, plugin state, and threads.
User-scoped homes and explicit `CODEX_HOME` overrides retain ownership of their
existing native service app.

There is no new configuration option, dependency, public plugin API, persistent
sidecar state, `homeScope` change, or automatic Gateway restart.

## Evidence

### Real macOS production proof of the refresh path

Complete line-oriented redacted artifact:
[comment 5336833505](https://github.com/openclaw/openclaw/pull/126080#issuecomment-5336833505)
(SHA-256 `dbd189736518040a34a1bbe169acdfeda6fa9846e33f26c5793324d60d7df1fb`).

Production exercised refresh implementation head
`fb0bf42c94e66fab35e71fa2357ca4694a872bb2`, which is an ancestor of
current PR head
`18dd3db77a093244aa073fe58041e04cd8217e0f`. The current-head delta adds owned-path containment and
focused regression coverage; it does not change the signed source-selection,
identity-comparison, or native MCP behavior exercised below. At the tested
refresh head, `auth-bridge.ts` and `computer-use-service.ts` were object-identical
to the running production build:

```text
auth-bridge.ts:
  tested head  f2a47a3ed1b0a1168f2fdf3212064566c4a950ee
  tested build f2a47a3ed1b0a1168f2fdf3212064566c4a950ee

computer-use-service.ts:
  tested head  7fca14fcb64e5fda60f53117cab903c42f61bf71
  tested build 7fca14fcb64e5fda60f53117cab903c42f61bf71
```

An ordinary cold acquisition of an isolated `CODEX_HOME` produced this signed
generation transition without a manual copy, repair command, or intervening
Gateway restart:

```text
selected trusted source:
  build:                            1000761
  outer CDHash:                     f4fcdc11ff65b810195ae7119d56021c4e92a07d
  nested CDHash:                    099beab9164eaa8dc1dd6288210cac38a7a4d9e7
  OpenAI Team/bundle requirements:  PASS

isolated target before:
  complete, executable, strictly signed
  build:                            1000502
  outer CDHash:                     2ce8ac267121a9035983fbdfba42963a1f87d482
  nested CDHash:                    3c3b8f4061cc8037124bfafda3c99aab6aefb837

isolated target after cold acquisition:
  build:                            1000761
  outer and nested inodes:          changed
  outer/nested hashes:              MATCH selected source
  signature and Team/bundle checks: PASS
  staging artifacts:                0
  backup artifacts:                 0
```

The refreshed client then ran from the same isolated `CODEX_HOME`. The selected
Desktop app-server (`codex-cli 0.148.0-alpha.15`) initialized OpenClaw's V2
thread and real `computer-use` MCP path, after which the same production turn
recorded:

```text
computer-use/get_app_state(TextEdit)  Ok; CUA App Version 1000761
computer-use/type_text(TextEdit)      Ok; entered all four requested lines
computer-use/get_app_state(TextEdit)  Ok; accessibility state and screenshot
                                          contained all four lines

native Computer Use results:          3 Ok / 0 Error
Computer Use failures or timeouts:    0
AppleScript/shell/browser/node-tool substitutions: 0
Gateway PID after operation:          unchanged
surrounding isolated home:            preserved
```

This demonstrates the changed behavior end to end: the complete but stale,
validly OpenAI-signed isolated bundle was synchronized to the selected trusted
generation before client launch, isolation was preserved, and the refreshed
native client successfully performed and visibly verified real Computer Use
operations. The linked artifact retains the exact timestamps, signed identities,
inode/hash transition, process tree, initialization records, native tool records,
visible TextEdit result, cleanup checks, preservation checks, and post-operation
service health.

### Pre-fix code contract

At the composite base,
`extensions/codex/src/app-server/computer-use-service.ts` returned
`already_installed` as soon as the nested executable passed `X_OK`. That return
happened before desktop candidates were resolved and before source/target
identity inspection.

The old test encoded the same behavior as:

```text
reuses a complete home-owned client without consulting desktop sources
```

The selected-source resolver already existed in
`extensions/codex/src/app-server/desktop-app-paths.ts`; this PR keeps that
selection policy and fixes the provisioning decision that consumes it.

Provisioning remains in `auth-bridge.ts` before a new isolated app-server is
launched. Warm acquisition can return before that preflight, which is why this
change claims a cold-start repair rather than hot filesystem polling.

### BEFORE: real production installation

```text
OpenClaw runtime base:
  d5f8d87ec72b383b6318d5183c6c33f38bce5316

Composition:
  #125883 exact head: e8a5035ca6bf2604665aad6c54d2c346221bc3a6
  #125362 exact head: 77f4df4e36dc5aa8d50d9c26c94aa1e2e7b3c3bc

Home scope:
  isolated per-agent CODEX_HOME

Isolated homes inspected:
  6
```

The six production agent homes are labeled `agent1` through `agent6` below.
Only agent names and private path prefixes were replaced. Version/build values,
bundle IDs, Team IDs, CDHashes, signature results, timestamp, native method,
elapsed time, and native error are exact observations.

| Component | Version | Build | Outer CDHash | Nested client CDHash |
|---|---:|---:|---|---|
| Selected Desktop source | `26.817.1000761` | `1000761` | `f4fcdc11ff65b810195ae7119d56021c4e92a07d` | `099beab9164eaa8dc1dd6288210cac38a7a4d9e7` |
| User-home reference | `26.817.1000761` | `1000761` | `f4fcdc11ff65b810195ae7119d56021c4e92a07d` | `099beab9164eaa8dc1dd6288210cac38a7a4d9e7` |
| `agent1` isolated home | `26.721.1000502` | `1000502` | `2ce8ac267121a9035983fbdfba42963a1f87d482` | `3c3b8f4061cc8037124bfafda3c99aab6aefb837` |
| `agent2` isolated home | `26.721.1000502` | `1000502` | `2ce8ac267121a9035983fbdfba42963a1f87d482` | `3c3b8f4061cc8037124bfafda3c99aab6aefb837` |
| `agent3` isolated home | `26.721.1000502` | `1000502` | `2ce8ac267121a9035983fbdfba42963a1f87d482` | `3c3b8f4061cc8037124bfafda3c99aab6aefb837` |
| `agent4` isolated home | `26.721.1000502` | `1000502` | `2ce8ac267121a9035983fbdfba42963a1f87d482` | `3c3b8f4061cc8037124bfafda3c99aab6aefb837` |
| `agent5` isolated home | `26.721.1000502` | `1000502` | `2ce8ac267121a9035983fbdfba42963a1f87d482` | `3c3b8f4061cc8037124bfafda3c99aab6aefb837` |
| `agent6` isolated home | `26.721.1000502` | `1000502` | `2ce8ac267121a9035983fbdfba42963a1f87d482` | `3c3b8f4061cc8037124bfafda3c99aab6aefb837` |

All eight rows passed both applicable strict OpenAI code requirements. Every
row reported:

```text
outer bundle identifier:  com.openai.sky.CUAService
nested bundle identifier: com.openai.sky.CUAService.cli
Team Identifier:          2DC432GLL2
outer requirement:        PASS
nested requirement:       PASS
```

The failure therefore involved an older valid OpenAI-signed generation being
reused solely because its executable existed.

The invoking isolated home's plugin cache had already advanced while its native
application remained at build `1000502`. A genuine invocation then produced:

```text
timestamp: 2026-08-18T22:09:42.047Z
plugin:    computer-use@openai-bundled
method:    get_app_state
elapsed:   approximately 49 ms
result:    Computer Use server error -10000:
           Sender process is not authenticated
```

The request payload and user prompt are intentionally omitted. This is strong
mixed-generation evidence and makes that mismatch the leading mechanism. The
private native authentication handshake is not public, so this PR does not
claim mathematically proven causality before the post-install test below.

### Focused verification

```text
node scripts/run-vitest.mjs extensions/codex/src/app-server/computer-use-service.test.ts

Test Files  1 passed
Tests       19 passed
Duration    8.96s
```

The suite covers:

1. missing-target installation;
2. exact signed-identity reuse;
3. process-lifetime successful-sync reuse without reinspection/copy;
4. bounded completed-sync eviction and safe reinspection;
5. old-selection cache invalidation after a different selection fails;
6. complete but stale validly signed generation refresh;
7. missing or untrusted source preservation;
8. incomplete target replacement;
9. staged identity mismatch rollback and cleanup;
10. same-generation concurrent winner preservation;
11. unexpected concurrent-generation preservation;
12. different-selection serialization and `A -> B -> A` refresh;
13. non-macOS behavior;
14. selected app-server source preference;
15. symlinked ownership-root rejection without external mutation;
16. symlinked isolated-home rejection without external mutation;
17. symlinked `computer-use` parent rejection without external mutation;
18. symlinked final service-target rejection without following it;
19. parent-rebind detection with safe publication and cleanup refusal.

The stale-generation regression fails against the pre-fix contract: old code
returns `already_installed`, never consults the source, and leaves build
`1000502` in place.

Combined focused bridge verification:

```text
Test Files  2 passed
Tests       110 passed
```

The bridge suite includes explicit regressions proving that auto-install does
not invoke native service replacement for either `homeScope: "user"` or an
explicit `CODEX_HOME`, while retaining the positive isolated-home case.

Additional checks:

```text
focused Vitest (2 files / 110 tests)              PASS
full repository `check:test-types`                 PASS
oxfmt --check (6 changed files)                    PASS
oxlint (5 changed TypeScript files)                PASS
max-lines and assertion-safety ratchets            PASS
git diff --check                                   PASS
```

The live macOS `codesign` route and explicit Team/bundle requirements were
also exercised directly against current and stale signed real distributions,
producing the results above.

### AFTER: production restart, on-demand refresh, and real native operation

#### Runtime and refresh-head provenance

The operator restarted the production Gateway after installing refresh implementation
head `fb0bf42c94e66fab35e71fa2357ca4694a872bb2` as a parent of integration commit
`d43c92193777860da8b249d7ee0dd8af90c464c4`. Current PR head
`18dd3db77a093244aa073fe58041e04cd8217e0f` retains that functional path and adds the
owned-path containment
described and regression-tested above.

The running bundle identifies its immediately preceding production integration as:

```text
version:  2026.8.1
commit:   fd501f91776fb0a4513b18a2fb60ced39fb3ff46
build ID: 2026.8.1-fd501f91776f-2026-08-19T00-16-36.234Z
```

The only source difference between tested refresh head `fb0bf42` and that emitted runtime
is the final test-only bounded-cache guard in `computer-use-service.test.ts`. The
production TypeScript and emitted refresh behavior under test are byte-identical to that
tested head. The production composite also contains exact
parent head `e8a5035ca6bf2604665aad6c54d2c346221bc3a6` and the separately tested Matrix
head `77f4df4e36dc5aa8d50d9c26c94aa1e2e7b3c3bc`.

The new Gateway process started at `2026-08-19 04:32:09.833 +03:00`, became ready at
`04:39:28.499`, and remained the same PID through the proof. No additional restart,
manual bundle replacement, or direct filesystem repair was performed.

#### Post-restart, pre-request baseline

At `2026-08-19 05:01:46 +03:00`:

```text
plugins.entries.codex.config.appServer.command: absent
plugins.entries.codex.config.appServer.homeScope: absent
effective ordinary harness home scope: agent
computerUse.enabled: true
computerUse.autoInstall: true
computerUse.autoRepair: true
managed selection order: desktop-first
temporary staging/backup artifacts: 0
```

The selected app-server was the ChatGPT Desktop executable:

```text
/Applications/ChatGPT.app/Contents/Resources/codex
codex-cli 0.148.0-alpha.15
```

The selected signed Computer Use source was:

```text
<ChatGPT.app>/Contents/Resources/cua_node/lib/node_modules/@oai/sky/Codex Computer Use.app
version/build:          26.817.1000761 / 1000761
outer identifier:       com.openai.sky.CUAService
nested identifier:      com.openai.sky.CUAService.cli
Team Identifier:        2DC432GLL2
outer CDHash:            f4fcdc11ff65b810195ae7119d56021c4e92a07d
nested client CDHash:    099beab9164eaa8dc1dd6288210cac38a7a4d9e7
nested client SHA-256:   9d55690c0aee43e006f6b1304da80bf8e3f89f6209ca1d823e43a8b836a24057
strict signature checks: PASS
```

One isolated production home, sanitized here as `agent1`, provided the clean refresh
control. It had no running app-server/client and still contained the older complete,
validly signed generation:

```text
version/build:          26.721.1000502 / 1000502
outer inode:            83063031
nested client inode:    83063268
outer CDHash:            2ce8ac267121a9035983fbdfba42963a1f87d482
nested client CDHash:    3c3b8f4061cc8037124bfafda3c99aab6aefb837
nested client SHA-256:   4222fbefbde6e2ce3713fb0b28a9ab0dd6463fcf20db6ef74817d69df84bf5a9
Team Identifier:        2DC432GLL2
```

That is the exact state that current main incorrectly treats as reusable solely because
the nested executable exists.

#### On-demand signed-generation transition

At `05:05:37.057`, an ordinary production VoiceClaw request selected `agent1` and caused
its cold isolated app-server acquisition. No internal repair command or status probe was
issued. The request was a benign visible-GUI task: create a new TextEdit document, enter
a four-sentence poem, and verify it.

The PR refreshed only that isolated home before its native client started:

| Field | Before | After | Selected source |
|---|---|---|---|
| Build | `1000502` | `1000761` | `1000761` |
| Outer inode | `83063031` | `112654392` | separate Desktop source inode |
| Nested client inode | `83063268` | `112654506` | separate Desktop source inode |
| Outer CDHash | `2ce8ac267121a9035983fbdfba42963a1f87d482` | `f4fcdc11ff65b810195ae7119d56021c4e92a07d` | `f4fcdc11ff65b810195ae7119d56021c4e92a07d` |
| Nested CDHash | `3c3b8f4061cc8037124bfafda3c99aab6aefb837` | `099beab9164eaa8dc1dd6288210cac38a7a4d9e7` | `099beab9164eaa8dc1dd6288210cac38a7a4d9e7` |
| Nested SHA-256 | `4222fbef...bf5a9` | `9d55690c...a24057` | `9d55690c...a24057` |

Both the installed outer app and nested client passed strict `codesign` verification and
the explicit OpenAI bundle-ID/Team-ID requirements. After completion:

```text
.service-app.staging-* count: 0
.service-app.backup-* count: 0
```

No staging, backup, `.bak`, or synchronization debris remained under any of the six
isolated Computer Use directories.

The resulting process tree proved that isolation was retained:

```text
Gateway
  -> /Applications/ChatGPT.app/Contents/Resources/codex app-server --listen stdio://
       CODEX_HOME=<agent1-isolated-home>
       -> <agent1-isolated-home>/computer-use/Codex Computer Use.app/
          Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/
          SkyComputerUseClient mcp
       -> second scoped SkyComputerUseClient mcp
```

Both clients executed from the refreshed isolated build `1000761`; their working
directory was the matching isolated plugin cache
`computer-use/1.0.1000761`. The already-running signed user-scope native service remained
owned by ChatGPT. No new user-scope service was installed or replaced.

#### Real Computer Use behavior

The same production turn then used the real `computer-use@openai-bundled` MCP surface:

| Local time (+03:00) | Native operation | Result |
|---|---|---|
| `05:05:55`–`05:05:57.493` | `computer-use/get_app_state` on TextEdit | `Ok`; reported `CUA App Version: 1000761`, new `Untitled` window, focused empty text area |
| `05:06:02`–`05:06:04.329` | `computer-use/type_text` | `Ok`; entered four sentences |
| `05:06:02`–`05:06:04.436` | second `computer-use/get_app_state` | `Ok`; accessibility state and screenshot contained all four sentences |

The production task completed successfully at `05:06:14.154` after `37.097s`; the Codex
turn itself reported `29.659s`. Its final answer accurately stated that the new TextEdit
document had been created, populated, and visibly verified.

Negative assertions from the complete rollout:

```text
OpenClaw node computer tool: not called
computer.act / screen.snapshot: not called
AppleScript / osascript: not called
shell UI automation: not used
managed browser: not used
Computer Use MCP failures/timeouts: 0
fallback after Computer Use failure: none
old -10000 sender-authentication error: absent
old -10013 client/server mismatch error: absent
```

The only shell command in the turn read the installed Computer Use skill instructions;
the GUI work itself was performed by the three native Computer Use MCP calls above.

This also directly exercises the stacked runtime-admission behavior against the exact
Desktop runtime present on this Mac: `codex-cli 0.148.0-alpha.15` initialized, exposed
the expected Computer Use tools, and completed real `get_app_state`, `type_text`, and
verification calls. This is evidence for that exact newer Desktop runtime; it does not
claim an unbounded protocol guarantee for every possible future version.

#### Isolated-home preservation

The synchronization did not replace the broader isolated home. Pre-existing persistent
files retained their inodes and creation dates, including the agent's `config.toml`,
state, logs, goals, memories, and queue databases. Expected per-turn WAL/log/session
changes occurred, while the targeted durable changes were limited to the isolated
Computer Use app and matching `computer-use/1.0.1000761` plugin cache.

#### Postcondition and deployment scope

After the request:

```text
Gateway PID: unchanged since the operator restart
Gateway HTTP: 200
Gateway event loop: not degraded
Matrix accounts: 6/6 running, connected, healthy, ready
Matrix restartPending: false for all accounts
Matrix reconnectAttempts: 0 for all accounts
Matrix lastError: null for all accounts
Gateway-to-Synapse established sockets: 6
post-request Matrix errors/exits: 0
```

Across the six isolated homes, four had naturally passed through qualifying cold
app-server preflight and matched build `1000761`; two that had not yet done so remained
at build `1000502`. This confirms the documented on-demand per-home boundary rather than
an eager all-home mutation during installation or Gateway startup.

The private unredacted transcript and identity capture were retained locally in a small
restricted evidence file. The public proof above changes only the agent label and private
home prefix; timestamps, versions, build numbers, inodes, hashes, tool names, durations,
results, and health assertions are exact.

## Diff accounting

```text
Production TypeScript: +356 / -42
Test TypeScript:       +423 / -23
Documentation:          +13 /  -3
Total:                 +792 / -68
```

The production delta implements the trust and lifecycle boundary absent from
the executable-only predicate: signature requirements, outer/nested identity
inspection, staged verification, rollback ownership, race handling,
selection-aware serialization, and process-lifetime inspection caching.

- [x] AI-assisted
- [x] Failure and rollback behavior manually reviewed
- [x] Focused regression and bridge suites passed
- [x] Real signed BEFORE evidence captured and sanitized
- [x] Clean-checkout GitHub CI
- [x] Post-install, pre-restart identity snapshot
- [x] Operator-directed post-restart real-world Computer Use proof



### Directly inspectable redacted trace

The complete line-oriented final-head macOS artifact is published in
[PR comment 5336833505](https://github.com/openclaw/openclaw/pull/126080#issuecomment-5336833505)
with redacted artifact SHA-256
`dbd189736518040a34a1bbe169acdfeda6fa9846e33f26c5793324d60d7df1fb`.

It contains the fresh [current-main executable-only source boundary at
`2a469c1cb2e1`](https://github.com/openclaw/openclaw/blob/2a469c1cb2e1da9a43dd425170aa23027cc5d5e2/extensions/codex/src/app-server/computer-use-service.ts#L65-L74),
final-PR-head containment and production-blob identity output, strict signed
source/target identities before and after refresh, the inode/build/hash transition,
the isolated `CODEX_HOME` process tree, real `0.148.0-alpha.15` V2 `thread/start` and Computer Use MCP initialization records, three timestamped native
`computer-use@openai-bundled` MCP completion records, the exact TextEdit verification
excerpt, zero fallback/tool-substitution assertions, cleanup results, non-CU home
preservation, and post-operation Gateway/Matrix health.