### PR TITLE
fix(mcp): preserve catalog and result integrity

### DIFF
--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -97,6 +97,16 @@ async function writeListToolsMcpServer(params: {
     execution?: { taskSupport?: "forbidden" | "optional" | "required" };
     _meta?: Record<string, unknown>;
   }>;
+  toolsByList?: Array<
+    Array<{
+      name: string;
+      description?: string;
+      inputSchema?: unknown;
+      outputSchema?: unknown;
+      execution?: { taskSupport?: "forbidden" | "optional" | "required" };
+      _meta?: Record<string, unknown>;
+    }>
+  >;
   capabilities?: Record<string, unknown>;
   databasePath?: string;
   pidPath?: string;
@@ -114,6 +124,8 @@ async function writeListToolsMcpServer(params: {
   callToolJsonRpcErrorCode?: number;
   callToolResult?: CallToolResult;
   callToolDelayMs?: number;
+  callToolReleasePath?: string;
+  notifyListChangedOnToolCall?: boolean;
   resourcePageDelayMs?: number;
   resourcePageCount?: number;
   resourcePageCursors?: Array<string | null>;
@@ -156,11 +168,14 @@ const tools = ${JSON.stringify(
         },
       ],
     )};
+const toolsByList = ${JSON.stringify(params.toolsByList)};
 const callToolIsError = ${params.callToolIsError === true};
 const callToolJsonRpcError = ${params.callToolJsonRpcError === true};
 const callToolJsonRpcErrorCode = ${params.callToolJsonRpcErrorCode ?? -32000};
 const callToolResult = ${JSON.stringify(params.callToolResult)};
 const callToolDelayMs = ${params.callToolDelayMs ?? 0};
+const callToolReleasePath = ${JSON.stringify(params.callToolReleasePath)};
+const notifyListChangedOnToolCall = ${params.notifyListChangedOnToolCall === true};
 const resourcePageDelayMs = ${params.resourcePageDelayMs ?? 0};
 const resourcePageCount = ${params.resourcePageCount ?? 1};
 const resourcePageCursors = ${JSON.stringify(params.resourcePageCursors)};
@@ -168,6 +183,16 @@ const resourceListJsonRpcError = ${params.resourceListJsonRpcError === true};
 const resourceReadJsonRpcError = ${params.resourceReadJsonRpcError === true};
 const promptPageDelayMs = ${params.promptPageDelayMs ?? 0};
 const promptPageCursors = ${JSON.stringify(params.promptPageCursors)};
+
+async function waitForPath(filePath) {
+  while (filePath) {
+    const exists = await fs.access(filePath).then(() => true).catch(() => false);
+    if (exists) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
 
 let buffer = "";
 let listCount = 0;
@@ -271,9 +296,11 @@ function handle(message) {
         jsonrpc: "2.0",
         id: message.id,
         result: {
-          tools: toolPageCursors
-            ? tools.map((tool) => ({ ...tool, name: tool.name + "-" + currentListCount }))
-            : tools,
+          tools: toolsByList
+            ? toolsByList[Math.min(currentListCount - 1, toolsByList.length - 1)]
+            : toolPageCursors
+              ? tools.map((tool) => ({ ...tool, name: tool.name + "-" + currentListCount }))
+              : tools,
           ...(toolPageCursor !== undefined && toolPageCursor !== null
             ? { nextCursor: toolPageCursor }
             : {}),
@@ -281,32 +308,14 @@ function handle(message) {
       });
       if (notifyListChangedAfterFirstList && currentListCount === 1) {
         void (async () => {
-          while (notifyListChangedReleasePath) {
-            const released = await fs
-              .access(notifyListChangedReleasePath)
-              .then(() => true)
-              .catch(() => false);
-            if (released) {
-              break;
-            }
-            await new Promise((resolve) => setTimeout(resolve, 10));
-          }
+          await waitForPath(notifyListChangedReleasePath);
           log("notify tools/list_changed");
           send({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
         })();
       }
     };
     void (async () => {
-      while (listToolsReleasePath) {
-        const released = await fs
-          .access(listToolsReleasePath)
-          .then(() => true)
-          .catch(() => false);
-        if (released) {
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      }
+      await waitForPath(listToolsReleasePath);
       pendingTimer = setTimeout(sendListResponse, delayMs);
     })();
   }
@@ -324,18 +333,25 @@ function handle(message) {
       });
       return;
     }
-    setTimeout(() => {
-      send({
-        jsonrpc: "2.0",
-        id: message.id,
-        result: {
-          isError: callToolIsError,
-          ...(callToolResult ?? {
-            content: [{ type: "text", text: callToolIsError ? "tool failed" : "tool ok" }],
-          }),
-        },
-      });
-    }, callToolDelayMs);
+    if (notifyListChangedOnToolCall) {
+      log("notify tools/list_changed during tools/call");
+      send({ jsonrpc: "2.0", method: "notifications/tools/list_changed" });
+    }
+    void (async () => {
+      await waitForPath(callToolReleasePath);
+      setTimeout(() => {
+        send({
+          jsonrpc: "2.0",
+          id: message.id,
+          result: {
+            isError: callToolIsError,
+            ...(callToolResult ?? {
+              content: [{ type: "text", text: callToolIsError ? "tool failed" : "tool ok" }],
+            }),
+          },
+        });
+      }, callToolDelayMs);
+    })();
   }
   if (message.method === "resources/list") {
     resourceListCount += 1;
@@ -948,6 +964,100 @@ describe("session MCP runtime", () => {
     });
     expect(validator({ a: {}, b: {} }).valid).toBe(true);
     expect(validator({ a: {}, b: 1 }).valid).toBe(false);
+  });
+
+  it("enforces output schemas under the canonical trimmed tool name", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-canonical-schema-");
+    const serverPath = path.join(tempDir, "server.mjs");
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath: path.join(tempDir, "server.log"),
+      tools: [
+        {
+          name: " spaced ",
+          inputSchema: { type: "object" },
+          outputSchema: {
+            type: "object",
+            properties: { count: { type: "number" } },
+            required: ["count"],
+          },
+        },
+      ],
+      callToolResult: { content: [], structuredContent: { count: "invalid" } },
+    });
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-canonical-schema",
+      workspaceDir: "/workspace",
+      cfg: { mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } } },
+    });
+
+    try {
+      expect((await runtime.getCatalog()).tools.map((entry) => entry.toolName)).toEqual(["spaced"]);
+      await expect(runtime.callTool("docs", "spaced", {})).rejects.toThrow(
+        "does not match the tool's output schema",
+      );
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it("validates an in-flight result against its dispatch-time output schema", async () => {
+    const tempDir = tempDirTracker.make("bundle-mcp-dispatch-schema-");
+    const serverPath = path.join(tempDir, "server.mjs");
+    const logPath = path.join(tempDir, "server.log");
+    const releasePath = path.join(tempDir, "release-call");
+    const schema = (revision: string) => ({
+      type: "object",
+      properties: { revision: { const: revision } },
+      required: ["revision"],
+    });
+    await writeListToolsMcpServer({
+      filePath: serverPath,
+      logPath,
+      toolsByList: [
+        [{ name: "versioned", inputSchema: { type: "object" }, outputSchema: schema("a") }],
+        [{ name: "versioned", inputSchema: { type: "object" }, outputSchema: schema("b") }],
+      ],
+      notifyListChangedOnToolCall: true,
+      capabilities: { tools: { listChanged: true } },
+      callToolReleasePath: releasePath,
+      callToolResult: { content: [], structuredContent: { revision: "a" } },
+    });
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-dispatch-schema",
+      workspaceDir: "/workspace",
+      cfg: { mcp: { servers: { docs: { command: process.execPath, args: [serverPath] } } } },
+    });
+
+    try {
+      expect((await runtime.getCatalog()).tools.map((entry) => entry.toolName)).toEqual([
+        "versioned",
+      ]);
+      const calling = runtime.callTool("docs", "versioned", {}).then(
+        (value) => ({ value, error: undefined }),
+        (error: unknown) => ({ value: undefined, error }),
+      );
+      await waitForFileText(
+        logPath,
+        "notify tools/list_changed during tools/call",
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+      );
+      await waitForPredicate(
+        () => runtime.peekCatalog() === null,
+        "dispatch-time catalog invalidation",
+        LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+      );
+      expect((await runtime.getCatalog()).tools.map((entry) => entry.toolName)).toEqual([
+        "versioned",
+      ]);
+      await fs.writeFile(releasePath, "release", "utf8");
+      const outcome = await calling;
+      expect(outcome.error).toBeUndefined();
+      expect(outcome.value).toMatchObject({ structuredContent: { revision: "a" } });
+    } finally {
+      await fs.writeFile(releasePath, "release", "utf8").catch(() => {});
+      await runtime.dispose();
+    }
   });
 
   it("keeps colliding sanitized tool definitions stable across catalog order changes", async () => {
@@ -5450,6 +5560,244 @@ process.stdin.on("end", () => {
         await new Promise<void>((resolve, reject) => {
           server.close((error) => (error ? reject(error) : resolve()));
         });
+      }
+    },
+  );
+
+  it(
+    "keeps catalog recovery single-flight while another server is recycled",
+    { timeout: 15_000 },
+    async () => {
+      const startServer = async (label: string) => {
+        let sessionGeneration = 0;
+        let listCount = 0;
+        let activeLists = 0;
+        let maxActiveLists = 0;
+        let hangCalls = true;
+        const pendingLists: Array<{
+          id: string | number;
+          response: http.ServerResponse;
+          sessionId: string;
+        }> = [];
+        const server = http.createServer((request, response) => {
+          if (request.method === "GET") {
+            response.writeHead(405).end();
+            return;
+          }
+          if (request.method === "DELETE") {
+            response.writeHead(204).end();
+            return;
+          }
+          if (request.method !== "POST") {
+            response.writeHead(405).end();
+            return;
+          }
+          let body = "";
+          request.setEncoding("utf8");
+          request.on("data", (chunk) => {
+            body += chunk;
+          });
+          request.on("end", () => {
+            const message = JSON.parse(body) as {
+              id: string | number;
+              method: string;
+              params?: { protocolVersion?: string };
+            };
+            if (message.method === "initialize") {
+              sessionGeneration += 1;
+              const sessionId = `${label}-${sessionGeneration}`;
+              response.setHeader("content-type", "application/json");
+              response.setHeader("mcp-session-id", sessionId);
+              response.writeHead(200).end(
+                JSON.stringify({
+                  jsonrpc: "2.0",
+                  id: message.id,
+                  result: {
+                    protocolVersion: message.params?.protocolVersion ?? "2025-03-26",
+                    capabilities: { tools: {} },
+                    serverInfo: { name: label, version: "1.0.0" },
+                  },
+                }),
+              );
+              return;
+            }
+            if (message.method === "notifications/initialized") {
+              response.writeHead(202).end();
+              return;
+            }
+            const rawSessionId = request.headers["mcp-session-id"];
+            const sessionId = typeof rawSessionId === "string" ? rawSessionId : "missing";
+            if (message.method === "tools/call") {
+              if (hangCalls) {
+                return;
+              }
+              response.setHeader("content-type", "application/json");
+              response.setHeader("mcp-session-id", sessionId);
+              response.writeHead(200).end(
+                JSON.stringify({
+                  jsonrpc: "2.0",
+                  id: message.id,
+                  result: {
+                    content: [],
+                    structuredContent: { revision: sessionId },
+                  },
+                }),
+              );
+              return;
+            }
+            if (message.method === "tools/list") {
+              listCount += 1;
+              if (listCount === 1) {
+                response.setHeader("content-type", "application/json");
+                response.setHeader("mcp-session-id", sessionId);
+                response.writeHead(200).end(
+                  JSON.stringify({
+                    jsonrpc: "2.0",
+                    id: message.id,
+                    result: {
+                      tools: [
+                        {
+                          name: "probe",
+                          inputSchema: { type: "object" },
+                          outputSchema: {
+                            type: "object",
+                            properties: { revision: { const: sessionId } },
+                            required: ["revision"],
+                          },
+                        },
+                      ],
+                    },
+                  }),
+                );
+                return;
+              }
+              activeLists += 1;
+              maxActiveLists = Math.max(maxActiveLists, activeLists);
+              pendingLists.push({ id: message.id, response, sessionId });
+            }
+          });
+        });
+        await new Promise<void>((resolve) => {
+          server.listen(0, "127.0.0.1", resolve);
+        });
+        const address = server.address() as { port: number };
+        return {
+          url: `http://127.0.0.1:${address.port}/mcp`,
+          activeLists: () => activeLists,
+          maxActiveLists: () => maxActiveLists,
+          allowCalls: () => {
+            hangCalls = false;
+          },
+          releaseLists: () => {
+            for (const pending of pendingLists.splice(0)) {
+              pending.response.setHeader("content-type", "application/json");
+              pending.response.setHeader("mcp-session-id", pending.sessionId);
+              pending.response.writeHead(200).end(
+                JSON.stringify({
+                  jsonrpc: "2.0",
+                  id: pending.id,
+                  result: {
+                    tools: [
+                      {
+                        name: "probe",
+                        inputSchema: { type: "object" },
+                        outputSchema: {
+                          type: "object",
+                          properties: { revision: { const: pending.sessionId } },
+                          required: ["revision"],
+                        },
+                      },
+                    ],
+                  },
+                }),
+              );
+              activeLists -= 1;
+            }
+          },
+          close: async () => {
+            server.closeAllConnections();
+            await new Promise<void>((resolve) => {
+              server.close(() => resolve());
+            });
+          },
+        };
+      };
+
+      const recovering = await startServer("recovering");
+      const trigger = await startServer("trigger");
+      testing.setBundleMcpCatalogListTimeoutMsForTest(4_000);
+      const runtime = createSessionMcpRuntime({
+        sessionId: "session-catalog-single-flight",
+        workspaceDir: "/workspace",
+        cfg: {
+          mcp: {
+            servers: {
+              recovering: {
+                url: recovering.url,
+                transport: "streamable-http",
+                requestTimeoutMs: 50,
+              },
+              trigger: {
+                url: trigger.url,
+                transport: "streamable-http",
+                requestTimeoutMs: 50,
+              },
+            },
+          },
+        },
+      });
+      const timeOutServer = async (serverName: string) => {
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          await expect(runtime.callTool(serverName, "probe", {})).rejects.toThrow();
+        }
+      };
+
+      try {
+        const initialCatalog = await runtime.getCatalog();
+        expect(initialCatalog.tools, JSON.stringify(initialCatalog)).toHaveLength(2);
+        await timeOutServer("recovering");
+        await runtime.getCatalog();
+        await waitForPredicate(
+          () => recovering.activeLists() === 1,
+          "recovering server catalog request",
+          LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+        );
+
+        await timeOutServer("trigger");
+        await runtime.getCatalog();
+        await Promise.race([
+          waitForPredicate(
+            () => recovering.maxActiveLists() > 1,
+            "overlapping catalog request",
+            500,
+          ).catch(() => undefined),
+          new Promise<void>((resolve) => {
+            setTimeout(resolve, 500);
+          }),
+        ]);
+        expect(recovering.maxActiveLists()).toBe(1);
+
+        recovering.allowCalls();
+        trigger.allowCalls();
+        recovering.releaseLists();
+        trigger.releaseLists();
+        await waitForPredicate(
+          () => recovering.activeLists() === 0 && trigger.activeLists() === 0,
+          "catalog requests to complete",
+          LIST_TOOLS_SERVER_LOG_TIMEOUT_MS,
+        );
+        const publishedCatalog = expectDefined(runtime.peekCatalog(), "published catalog");
+        expect(publishedCatalog.tools.map((tool) => `${tool.serverName}:${tool.toolName}`)).toEqual(
+          ["recovering:probe", "trigger:probe"],
+        );
+        await expect(runtime.callTool("recovering", "probe", {})).resolves.toMatchObject({
+          structuredContent: { revision: expect.stringMatching(/^recovering-/) },
+        });
+      } finally {
+        recovering.releaseLists();
+        trigger.releaseLists();
+        await runtime.dispose();
+        await Promise.all([recovering.close(), trigger.close()]);
       }
     },
   );

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -71,7 +71,7 @@ import { createMcpJsonSchemaValidator } from "./mcp-json-schema-validator.js";
 import { sanitizeMcpMetadataText } from "./mcp-metadata.js";
 import { collectMcpPaginatedItems } from "./mcp-pagination.js";
 import { isMcpToolAllowed, normalizeMcpToolFilter } from "./mcp-tool-filter.js";
-import { createMcpToolCatalogMetadata, type McpToolCatalogMetadata } from "./mcp-tool-metadata.js";
+import { normalizeMcpToolCatalog, type McpToolCatalogMetadata } from "./mcp-tool-metadata.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
 
 type BundleMcpSession = {
@@ -128,9 +128,8 @@ async function listAllTools(
   client: Client,
   timeoutMs: number,
   signal: AbortSignal,
-  schemaValidator = createMcpJsonSchemaValidator(),
-) {
-  const tools = await collectMcpPaginatedItems({
+): Promise<Tool[]> {
+  return await collectMcpPaginatedItems({
     label: "MCP tool listing",
     itemLabel: "tools",
     timeoutMs,
@@ -161,11 +160,6 @@ async function listAllTools(
       }
     },
   });
-  const metadata = createMcpToolCatalogMetadata(tools, schemaValidator);
-  return {
-    tools: tools.filter((tool) => !metadata.isRequiredTaskTool(tool.name)),
-    metadata,
-  };
 }
 
 function isMcpMethodNotFoundError(error: unknown): boolean {
@@ -345,7 +339,6 @@ export function createSessionMcpRuntime(params: {
       ].toSorted((left, right) => left.serverName.localeCompare(right.serverName)),
     };
     catalogRetryAfterMs = Date.now();
-    catalogInFlight = undefined;
   };
   const catalogRetryIsDue = (): boolean =>
     catalogRetryAfterMs !== undefined && Date.now() >= catalogRetryAfterMs;
@@ -752,14 +745,11 @@ export function createSessionMcpRuntime(params: {
                 );
                 let listedTools: ListedTool[];
                 try {
-                  const listed = await listAllTools(
+                  listedTools = await listAllTools(
                     session.client,
                     getCatalogListTimeoutMs(rawServer, resolved.requestTimeoutMs),
                     lifecycleAbortController.signal,
-                    schemaValidator,
                   );
-                  listedTools = listed.tools;
-                  session.toolMetadata = listed.metadata;
                 } catch (error) {
                   if (
                     !capabilities.tools &&
@@ -779,13 +769,18 @@ export function createSessionMcpRuntime(params: {
                 const deniedToolNames = new Set(
                   denialMap && Object.hasOwn(denialMap, serverName) ? denialMap[serverName] : [],
                 );
-                const policyEligibleTools = listedTools.filter((tool) =>
-                  isMcpToolAllowed(toolFilter, tool.name.trim()),
+                const normalizedTools = normalizeMcpToolCatalog(
+                  listedTools,
+                  schemaValidator,
+                  (toolName) => {
+                    if (!isMcpToolAllowed(toolFilter, toolName)) {
+                      return "exclude";
+                    }
+                    return deniedToolNames.has(toolName) ? "denied" : "include";
+                  },
                 );
-                const exposedTools = policyEligibleTools.filter((tool) => {
-                  const toolName = tool.name.trim();
-                  return !deniedToolNames.has(toolName);
-                });
+                session.toolMetadata = normalizedTools.metadata;
+                const exposedTools = normalizedTools.tools;
                 const serverEntry: McpServerCatalog = {
                   serverName,
                   safeServerName,
@@ -812,11 +807,11 @@ export function createSessionMcpRuntime(params: {
                   codexApprovalMode: resolveMcpCodexToolApprovalMode(serverName, rawServer),
                 };
                 const toolEntries: McpCatalogTool[] = [];
-                for (const tool of policyEligibleTools) {
-                  const toolName = tool.name.trim();
-                  if (!toolName) {
-                    continue;
-                  }
+                for (const [tool, deniedBySession] of [
+                  ...normalizedTools.tools.map((entry) => [entry, false] as const),
+                  ...normalizedTools.deniedTools.map((entry) => [entry, true] as const),
+                ]) {
+                  const toolName = tool.name;
                   const { _meta: metadata } = tool;
                   const uiMeta =
                     metadata?.ui && typeof metadata.ui === "object" && !Array.isArray(metadata.ui)
@@ -838,7 +833,7 @@ export function createSessionMcpRuntime(params: {
                     fallbackDescription: `Provided by bundle MCP server "${serverName}" (${launchDescription}).`,
                     ...(uiResourceUri ? { uiResourceUri } : {}),
                     ...(uiVisibility ? { uiVisibility } : {}),
-                    ...(deniedToolNames.has(toolName) ? { deniedBySession: true } : {}),
+                    ...(deniedBySession ? { deniedBySession: true } : {}),
                     codexAnnotations: normalizeMcpCodexToolAnnotations(tool.annotations),
                   });
                 }
@@ -1020,6 +1015,7 @@ export function createSessionMcpRuntime(params: {
     },
     async callTool(serverName, toolName, input) {
       const session = await getActiveSession(serverName);
+      const validateResult = session.toolMetadata?.validatorForCall(toolName);
       const result = (await runGuardedMcpRequest(serverName, session, (signal) =>
         session.client.callTool(
           { name: toolName, arguments: isRecord(input) ? input : {} },
@@ -1027,7 +1023,7 @@ export function createSessionMcpRuntime(params: {
           { timeout: session.requestTimeoutMs, signal },
         ),
       )) as CallToolResult;
-      session.toolMetadata?.validateResult(toolName, result);
+      validateResult?.(result);
       return result;
     },
     async listTools(serverName, requestParams) {

--- a/src/agents/mcp-tool-metadata.test.ts
+++ b/src/agents/mcp-tool-metadata.test.ts
@@ -1,0 +1,56 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+import { createMcpJsonSchemaValidator } from "./mcp-json-schema-validator.js";
+import { normalizeMcpToolCatalog } from "./mcp-tool-metadata.js";
+
+function tool(name: string, overrides: Partial<Tool> = {}): Tool {
+  return { name, inputSchema: { type: "object" }, ...overrides };
+}
+
+describe("normalizeMcpToolCatalog", () => {
+  it.each([
+    {
+      label: "trim-equivalent names",
+      colliding: [tool("duplicate"), tool(" duplicate ")],
+    },
+    {
+      label: "a required-task alias",
+      colliding: [
+        tool(" task ", { execution: { taskSupport: "optional" } }),
+        tool("task", { execution: { taskSupport: "required" } }),
+      ],
+    },
+  ])("rejects canonical collisions from $label", ({ colliding }) => {
+    const normalized = normalizeMcpToolCatalog(
+      [...colliding, tool("healthy")],
+      createMcpJsonSchemaValidator(),
+    );
+
+    expect(normalized.tools.map((entry) => entry.name)).toEqual(["healthy"]);
+    expect(normalized.deniedTools).toEqual([]);
+    expect(normalized.metadata.validatorForCall(colliding[0]?.name.trim() ?? "")).toBeUndefined();
+  });
+
+  it("filters excluded tools before compiling their output schemas", () => {
+    const normalized = normalizeMcpToolCatalog(
+      [
+        tool("healthy", {
+          outputSchema: {
+            type: "object",
+            properties: { count: { type: "number" } },
+            required: ["count"],
+          },
+        }),
+        tool("excluded", {
+          outputSchema: { type: "object", $ref: "#/$defs/Missing" },
+        }),
+      ],
+      createMcpJsonSchemaValidator(),
+      (toolName) => (toolName === "excluded" ? "exclude" : "include"),
+    );
+
+    expect(normalized.tools.map((entry) => entry.name)).toEqual(["healthy"]);
+    expect(normalized.metadata.validatorForCall("healthy")).toBeTypeOf("function");
+    expect(normalized.metadata.validatorForCall("excluded")).toBeUndefined();
+  });
+});

--- a/src/agents/mcp-tool-metadata.ts
+++ b/src/agents/mcp-tool-metadata.ts
@@ -9,51 +9,88 @@ import type {
   jsonSchemaValidator,
 } from "@modelcontextprotocol/sdk/validation/types.js";
 
-type ToolOutputValidator = JsonSchemaValidator<unknown>;
+type McpToolResultValidator = (result: CallToolResult) => void;
+
+type McpToolCatalogDisposition = "include" | "denied" | "exclude";
 
 export type McpToolCatalogMetadata = {
-  isRequiredTaskTool(toolName: string): boolean;
-  validateResult(toolName: string, result: CallToolResult): void;
+  validatorForCall(toolName: string): McpToolResultValidator | undefined;
 };
 
-/** Owns complete tool metadata after all list pages have been merged. */
-export function createMcpToolCatalogMetadata(
+/** Canonicalizes one server catalog before policy, publication, and call metadata diverge. */
+export function normalizeMcpToolCatalog(
   tools: readonly Tool[],
   schemaValidator: jsonSchemaValidator,
-): McpToolCatalogMetadata {
-  const outputValidators = new Map<string, ToolOutputValidator>();
-  const requiredTaskTools = new Set<string>();
-  for (const tool of tools) {
-    if (tool.outputSchema) {
-      outputValidators.set(tool.name, schemaValidator.getValidator(tool.outputSchema));
-    }
-    if (tool.execution?.taskSupport === "required") {
-      requiredTaskTools.add(tool.name);
+  classify: (toolName: string) => McpToolCatalogDisposition = () => "include",
+): {
+  tools: Tool[];
+  deniedTools: Tool[];
+  metadata: McpToolCatalogMetadata;
+} {
+  const canonicalNames = tools.map((tool) => tool.name.trim());
+  const nameCounts = new Map<string, number>();
+  for (const toolName of canonicalNames) {
+    if (toolName) {
+      nameCounts.set(toolName, (nameCounts.get(toolName) ?? 0) + 1);
     }
   }
+
+  const included: Tool[] = [];
+  const deniedTools: Tool[] = [];
+  const resultValidators = new Map<string, McpToolResultValidator>();
+  for (const [index, sourceTool] of tools.entries()) {
+    const toolName = canonicalNames[index] ?? "";
+    // One wire name is one operation. Ambiguous aliases are safer omitted than
+    // published under multiple model names with conflicting metadata.
+    if (
+      !toolName ||
+      nameCounts.get(toolName) !== 1 ||
+      sourceTool.execution?.taskSupport === "required"
+    ) {
+      continue;
+    }
+    const disposition = classify(toolName);
+    if (disposition === "exclude") {
+      continue;
+    }
+    const tool = { ...sourceTool, name: toolName };
+    if (disposition === "include") {
+      included.push(tool);
+      if (tool.outputSchema) {
+        const validator: JsonSchemaValidator<unknown> = schemaValidator.getValidator(
+          tool.outputSchema,
+        );
+        resultValidators.set(toolName, (result) => {
+          if (result.structuredContent === undefined && result.isError !== true) {
+            throw new McpError(
+              ErrorCode.InvalidRequest,
+              `Tool ${toolName} has an output schema but did not return structured content`,
+            );
+          }
+          if (result.structuredContent === undefined) {
+            return;
+          }
+          const validation = validator(result.structuredContent);
+          if (!validation.valid) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              `Structured content does not match the tool's output schema: ${validation.errorMessage}`,
+            );
+          }
+        });
+      }
+    } else {
+      deniedTools.push(tool);
+    }
+  }
+
   return {
-    isRequiredTaskTool: (toolName) => requiredTaskTools.has(toolName),
-    validateResult(toolName, result) {
-      const validator = outputValidators.get(toolName);
-      if (!validator) {
-        return;
-      }
-      if (result.structuredContent === undefined && result.isError !== true) {
-        throw new McpError(
-          ErrorCode.InvalidRequest,
-          `Tool ${toolName} has an output schema but did not return structured content`,
-        );
-      }
-      if (result.structuredContent === undefined) {
-        return;
-      }
-      const validation = validator(result.structuredContent);
-      if (!validation.valid) {
-        throw new McpError(
-          ErrorCode.InvalidParams,
-          `Structured content does not match the tool's output schema: ${validation.errorMessage}`,
-        );
-      }
+    tools: included,
+    metadata: {
+      validatorForCall(toolName) {
+        return resultValidators.get(toolName);
+      },
     },
+    deniedTools,
   };
 }

--- a/src/agents/node-plugin-tools.test.ts
+++ b/src/agents/node-plugin-tools.test.ts
@@ -447,7 +447,23 @@ describe("createNodePluginTools", () => {
       });
     }
     vi.mocked(callGatewayTool).mockResolvedValueOnce({
-      payload: { content: [{ type: "text", text: "node-b" }] },
+      payload: {
+        content: [
+          {
+            type: "image",
+            data: 42,
+            mimeType: "image/png",
+            annotations: { audience: ["assistant"], canary: "malformed-annotations" },
+            _meta: { canary: "malformed-meta" },
+          },
+          {
+            type: "text",
+            text: "node-b",
+            annotations: { canary: "text-annotations" },
+            _meta: { canary: "text-meta" },
+          },
+        ],
+      },
     });
 
     const { codeModeTools, compacted } = createCodeModeHarness([

--- a/src/agents/node-plugin-tools.test.ts
+++ b/src/agents/node-plugin-tools.test.ts
@@ -257,11 +257,18 @@ describe("createNodePluginTools", () => {
     vi.mocked(callGatewayTool).mockResolvedValueOnce({
       payload: {
         content: [
-          { type: "image", data: "aW1hZ2UtMQ==", mimeType: "image/png" },
+          {
+            type: "image",
+            data: "aW1hZ2UtMQ==",
+            mimeType: "image/png",
+            annotations: { audience: ["assistant"] },
+            _meta: { detailCanary: "must-not-leak" },
+          },
           { type: "text", text: "first" },
           { type: "text", text: "second" },
           { type: "image", data: "aW1hZ2UtMg==", mimeType: "image/png" },
           { type: "image", data: 42, mimeType: "image/png" },
+          { type: "audio", data: "audio-canary", mimeType: "audio/wav" },
         ],
         structuredContent: { hits: 2 },
         isError: true,
@@ -295,19 +302,15 @@ describe("createNodePluginTools", () => {
       { type: "text", text: "second" },
       { type: "image", data: "aW1hZ2UtMg==", mimeType: "image/png" },
       { type: "text", text: '{"type":"image","data":42,"mimeType":"image/png"}' },
+      { type: "text", text: "[audio audio/wav]" },
     ]);
     expect(result.details).toEqual({
-      content: [
-        { type: "image", data: "aW1hZ2UtMQ==", mimeType: "image/png" },
-        { type: "text", text: "first" },
-        { type: "text", text: "second" },
-        { type: "image", data: "aW1hZ2UtMg==", mimeType: "image/png" },
-        { type: "image", data: 42, mimeType: "image/png" },
-      ],
+      mcpServer: "docs",
+      mcpTool: "search",
       structuredContent: { hits: 2 },
-      isError: true,
       status: "error",
     });
+    expect(JSON.stringify(result.details)).not.toContain("canary");
     expect(isToolResultError(result)).toBe(true);
   });
 
@@ -372,7 +375,8 @@ describe("createNodePluginTools", () => {
     expect(details.value).toEqual({
       api: expect.stringContaining("query: string;"),
       called: {
-        content: [{ type: "text", text: "found" }],
+        mcpServer: "docs",
+        mcpTool: "search",
         structuredContent: { hits: 1 },
       },
       allHasNodeMcp: false,
@@ -472,7 +476,11 @@ describe("createNodePluginTools", () => {
         "mcp/nodeCDocs.d.ts",
         "mcp/tickets.d.ts",
       ],
-      called: { content: [{ type: "text", text: "node-b" }] },
+      called: {
+        mcpServer: "docs",
+        mcpTool: "search_c",
+        content: [{ type: "text", text: "node-b" }],
+      },
     });
     expect(callGatewayTool).toHaveBeenCalledWith(
       "node.invoke",

--- a/src/agents/node-plugin-tools.ts
+++ b/src/agents/node-plugin-tools.ts
@@ -47,11 +47,21 @@ function mapMcpPayloadToAgentToolResult(
   if (payload.structuredContent !== undefined || !isRecord(projected.details)) {
     return projected;
   }
+  const textContent = Array.isArray(payload.content)
+    ? payload.content.flatMap((block) =>
+        isRecord(block) && block.type === "text" && typeof block.text === "string"
+          ? [{ type: "text" as const, text: block.text }]
+          : [],
+      )
+    : [];
+  if (textContent.length === 0) {
+    return projected;
+  }
   return {
     ...projected,
     details: {
       ...projected.details,
-      content: projected.content.filter((block) => block.type === "text"),
+      content: textContent,
     },
   };
 }

--- a/src/agents/node-plugin-tools.ts
+++ b/src/agents/node-plugin-tools.ts
@@ -33,11 +33,27 @@ function readNodeInvokePayload(value: unknown): unknown {
   return isRecord(value) && "payload" in value ? value.payload : value;
 }
 
-function mapMcpPayloadToAgentToolResult(payload: unknown): AgentToolResult<unknown> {
+function mapMcpPayloadToAgentToolResult(
+  payload: unknown,
+  mcp: { server: string; tool: string },
+): AgentToolResult<unknown> {
   if (!isRecord(payload)) {
     return jsonResult(payload);
   }
-  return projectMcpCallToolResult(payload, payload);
+  const projected = projectMcpCallToolResult(payload, {
+    mcpServer: mcp.server,
+    mcpTool: mcp.tool,
+  });
+  if (payload.structuredContent !== undefined || !isRecord(projected.details)) {
+    return projected;
+  }
+  return {
+    ...projected,
+    details: {
+      ...projected.details,
+      content: projected.content.filter((block) => block.type === "text"),
+    },
+  };
 }
 
 function normalizePolicyNames(values: readonly string[] | undefined): Set<string> {
@@ -226,7 +242,7 @@ export function createNodePluginTools(params: {
         );
         const payload = readNodeInvokePayload(raw);
         if (mcpTool) {
-          return mapMcpPayloadToAgentToolResult(payload);
+          return mapMcpPayloadToAgentToolResult(payload, mcpTool);
         }
         return isAgentToolResult(payload) ? payload : jsonResult(payload);
       },

--- a/src/node-host/invoke-mcp-result.test.ts
+++ b/src/node-host/invoke-mcp-result.test.ts
@@ -5,27 +5,25 @@ import { describe, expect, it } from "vitest";
 const execFileAsync = promisify(execFile);
 
 describe("boundMcpToolResultPayload", () => {
-  it("bounds a resident 64 MiB audio result under a constrained process heap", async () => {
+  it("bounds a resident 64 MiB audio result without full serialization", async () => {
     const source = String.raw`
       import { boundMcpToolResultPayload } from ${JSON.stringify(new URL("./invoke-mcp-result.ts", import.meta.url).href)};
       const payload = boundMcpToolResultPayload({
         content: [{ type: "audio", data: "A".repeat(64 * 1024 * 1024), mimeType: "audio/wav" }],
       });
-      process.stdout.write(JSON.stringify({ payload, rss: process.memoryUsage().rss }));
+      process.stdout.write(JSON.stringify(payload));
     `;
     const { stdout } = await execFileAsync(
       process.execPath,
-      ["--max-old-space-size=128", "--import", "tsx", "--input-type=module", "-e", source],
+      ["--max-old-space-size=192", "--import", "tsx", "--input-type=module", "-e", source],
       { cwd: process.cwd(), encoding: "utf8", maxBuffer: 1024 * 1024 },
     );
 
-    const result = JSON.parse(stdout) as {
-      payload: { content: Array<{ type: string; text?: string }> };
-      rss: number;
+    const payload = JSON.parse(stdout) as {
+      content: Array<{ type: string; text?: string }>;
     };
-    expect(result.payload.content).toEqual([
+    expect(payload.content).toEqual([
       { type: "text", text: "[truncated: MCP result exceeded 20 MB]" },
     ]);
-    expect(result.rss).toBeLessThan(300 * 1024 * 1024);
   });
 });

--- a/src/node-host/invoke-mcp-result.test.ts
+++ b/src/node-host/invoke-mcp-result.test.ts
@@ -1,0 +1,31 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+describe("boundMcpToolResultPayload", () => {
+  it("bounds a resident 64 MiB audio result under a constrained process heap", async () => {
+    const source = String.raw`
+      import { boundMcpToolResultPayload } from ${JSON.stringify(new URL("./invoke-mcp-result.ts", import.meta.url).href)};
+      const payload = boundMcpToolResultPayload({
+        content: [{ type: "audio", data: "A".repeat(64 * 1024 * 1024), mimeType: "audio/wav" }],
+      });
+      process.stdout.write(JSON.stringify({ payload, rss: process.memoryUsage().rss }));
+    `;
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      ["--max-old-space-size=128", "--import", "tsx", "--input-type=module", "-e", source],
+      { cwd: process.cwd(), encoding: "utf8", maxBuffer: 1024 * 1024 },
+    );
+
+    const result = JSON.parse(stdout) as {
+      payload: { content: Array<{ type: string; text?: string }> };
+      rss: number;
+    };
+    expect(result.payload.content).toEqual([
+      { type: "text", text: "[truncated: MCP result exceeded 20 MB]" },
+    ]);
+    expect(result.rss).toBeLessThan(300 * 1024 * 1024);
+  });
+});

--- a/src/node-host/invoke-mcp-result.ts
+++ b/src/node-host/invoke-mcp-result.ts
@@ -1,0 +1,116 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { boundedJsonUtf8Bytes, jsonUtf8BytesOrInfinity } from "../infra/json-utf8-bytes.js";
+import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
+
+export const MCP_TEXT_CONTENT_MAX_BYTES = 1024 * 1024;
+const MCP_TEXT_TRUNCATION_MARKER = "\n[truncated: MCP text content exceeded 1 MB]";
+
+export const MCP_INVOKE_PAYLOAD_MAX_BYTES = 20 * 1024 * 1024;
+const MCP_PAYLOAD_TRUNCATION_MARKER = "[truncated: MCP result exceeded 20 MB]";
+
+type McpInvokeContentBlock = Record<string, unknown>;
+
+/** Bounds MCP result content before it crosses node.invoke. */
+export function boundMcpToolResultPayload(result: {
+  content: readonly unknown[];
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}): {
+  content: McpInvokeContentBlock[];
+  structuredContent?: Record<string, unknown>;
+  isError?: true;
+} {
+  const payloadMarker = { type: "text" as const, text: MCP_PAYLOAD_TRUNCATION_MARKER };
+  const reservedMarkerBytes = jsonUtf8BytesOrInfinity(payloadMarker) + 1;
+  const isError = result.isError === true;
+  let usedBytes = jsonUtf8BytesOrInfinity({ content: [], ...(isError ? { isError } : {}) });
+  let payloadTruncated = false;
+  let structuredContent: Record<string, unknown> | undefined;
+  if (result.structuredContent) {
+    const prefixBytes = Buffer.byteLength(',"structuredContent":');
+    const availableBytes = Math.max(
+      0,
+      MCP_INVOKE_PAYLOAD_MAX_BYTES - usedBytes - prefixBytes - reservedMarkerBytes,
+    );
+    const measured = boundedJsonUtf8Bytes(result.structuredContent, availableBytes);
+    if (measured.complete && measured.bytes <= availableBytes) {
+      structuredContent = result.structuredContent;
+      usedBytes += prefixBytes + measured.bytes;
+    } else {
+      payloadTruncated = true;
+    }
+  }
+  const mirroredStructuredContent = structuredContent
+    ? JSON.stringify(structuredContent, null, 2)
+    : undefined;
+  const normalizedBlocks = result.content.filter(
+    (block): block is McpInvokeContentBlock =>
+      isRecord(block) &&
+      (mirroredStructuredContent === undefined ||
+        block.type !== "text" ||
+        block.text !== mirroredStructuredContent),
+  );
+  const totalTextBytes = normalizedBlocks.reduce<number>(
+    (total, block) =>
+      total +
+      (block.type === "text" && typeof block.text === "string" ? Buffer.byteLength(block.text) : 0),
+    0,
+  );
+  let remainingTextBytes =
+    totalTextBytes > MCP_TEXT_CONTENT_MAX_BYTES
+      ? MCP_TEXT_CONTENT_MAX_BYTES - Buffer.byteLength(MCP_TEXT_TRUNCATION_MARKER)
+      : MCP_TEXT_CONTENT_MAX_BYTES;
+  let markedTruncated = false;
+  const textBoundedContent: McpInvokeContentBlock[] = [];
+  for (const block of normalizedBlocks) {
+    if (block.type !== "text" || typeof block.text !== "string") {
+      textBoundedContent.push(block);
+      continue;
+    }
+    if (totalTextBytes <= MCP_TEXT_CONTENT_MAX_BYTES) {
+      textBoundedContent.push(block);
+      continue;
+    }
+    if (markedTruncated) {
+      continue;
+    }
+    const text = truncateUtf8Prefix(block.text, remainingTextBytes);
+    remainingTextBytes -= Buffer.byteLength(text);
+    const blockWasTruncated = text.length < block.text.length;
+    if (text || blockWasTruncated) {
+      textBoundedContent.push({
+        ...block,
+        text: blockWasTruncated ? `${text}${MCP_TEXT_TRUNCATION_MARKER}` : text,
+      });
+    }
+    if (blockWasTruncated || remainingTextBytes === 0) {
+      if (!blockWasTruncated) {
+        textBoundedContent.push({ type: "text", text: MCP_TEXT_TRUNCATION_MARKER.trimStart() });
+      }
+      markedTruncated = true;
+    }
+  }
+  const content: McpInvokeContentBlock[] = [];
+  for (const block of textBoundedContent) {
+    const separatorBytes = content.length > 0 ? 1 : 0;
+    const availableBytes = Math.max(
+      0,
+      MCP_INVOKE_PAYLOAD_MAX_BYTES - usedBytes - separatorBytes - reservedMarkerBytes,
+    );
+    const measured = boundedJsonUtf8Bytes(block, availableBytes);
+    if (!measured.complete || measured.bytes > availableBytes) {
+      payloadTruncated = true;
+      continue;
+    }
+    content.push(block);
+    usedBytes += measured.bytes + separatorBytes;
+  }
+  if (payloadTruncated) {
+    content.push(payloadMarker);
+  }
+  return {
+    content,
+    ...(structuredContent ? { structuredContent } : {}),
+    ...(isError ? { isError } : {}),
+  };
+}

--- a/src/node-host/invoke-mcp-result.ts
+++ b/src/node-host/invoke-mcp-result.ts
@@ -2,10 +2,10 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { boundedJsonUtf8Bytes, jsonUtf8BytesOrInfinity } from "../infra/json-utf8-bytes.js";
 import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
 
-export const MCP_TEXT_CONTENT_MAX_BYTES = 1024 * 1024;
+const MCP_TEXT_CONTENT_MAX_BYTES = 1024 * 1024;
 const MCP_TEXT_TRUNCATION_MARKER = "\n[truncated: MCP text content exceeded 1 MB]";
 
-export const MCP_INVOKE_PAYLOAD_MAX_BYTES = 20 * 1024 * 1024;
+const MCP_INVOKE_PAYLOAD_MAX_BYTES = 20 * 1024 * 1024;
 const MCP_PAYLOAD_TRUNCATION_MARKER = "[truncated: MCP result exceeded 20 MB]";
 
 type McpInvokeContentBlock = Record<string, unknown>;

--- a/src/node-host/invoke.mcp.test.ts
+++ b/src/node-host/invoke.mcp.test.ts
@@ -2,7 +2,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
 import { handleInvoke } from "./invoke.js";
-import { testing } from "./invoke.test-support.js";
 import { NodeHostMcpError, type NodeHostMcpManager } from "./mcp.js";
 
 const MEBIBYTE = 1024 * 1024;

--- a/src/node-host/invoke.mcp.test.ts
+++ b/src/node-host/invoke.mcp.test.ts
@@ -1,6 +1,7 @@
 /** Tests the built-in node-host MCP invocation command. */
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
+import { MCP_INVOKE_PAYLOAD_MAX_BYTES, MCP_TEXT_CONTENT_MAX_BYTES } from "./invoke-mcp-result.js";
 import { handleInvoke } from "./invoke.js";
 import { testing } from "./invoke.test-support.js";
 import { NodeHostMcpError, type NodeHostMcpManager } from "./mcp.js";
@@ -159,7 +160,7 @@ describe("mcp.tools.call.v1", () => {
     const result = await invokeMcp(
       managerWith(async () => ({
         content: [
-          { type: "text", text: "a".repeat(testing.MCP_TEXT_CONTENT_MAX_BYTES) },
+          { type: "text", text: "a".repeat(MCP_TEXT_CONTENT_MAX_BYTES) },
           { type: "text", text: "overflow" },
         ],
       })),
@@ -169,12 +170,12 @@ describe("mcp.tools.call.v1", () => {
       content: Array<{ type: string; text: string }>;
     };
     const text = payload.content.map((block) => block.text).join("");
-    expect(Buffer.byteLength(text)).toBeLessThanOrEqual(testing.MCP_TEXT_CONTENT_MAX_BYTES);
+    expect(Buffer.byteLength(text)).toBeLessThanOrEqual(MCP_TEXT_CONTENT_MAX_BYTES);
     expect(text).toContain("truncated: MCP text content exceeded 1 MB");
   });
 
   it("drops oversized images and structured content before node.invoke serialization", async () => {
-    const oversized = "A".repeat(testing.MCP_INVOKE_PAYLOAD_MAX_BYTES);
+    const oversized = "A".repeat(MCP_INVOKE_PAYLOAD_MAX_BYTES);
     const result = await invokeMcp(
       managerWith(async () => ({
         content: [{ type: "image", data: oversized, mimeType: "image/png" }],
@@ -187,7 +188,7 @@ describe("mcp.tools.call.v1", () => {
       structuredContent?: Record<string, unknown>;
     };
     expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThanOrEqual(
-      testing.MCP_INVOKE_PAYLOAD_MAX_BYTES,
+      MCP_INVOKE_PAYLOAD_MAX_BYTES,
     );
     expect(payload.content).toEqual([
       { type: "text", text: "[truncated: MCP result exceeded 20 MB]" },
@@ -197,7 +198,7 @@ describe("mcp.tools.call.v1", () => {
 
   it("preserves structured content and recovery guidance when an exact JSON mirror is oversized", async () => {
     const structuredContent = {
-      oversized: "S".repeat(Math.floor(testing.MCP_INVOKE_PAYLOAD_MAX_BYTES / 2)),
+      oversized: "S".repeat(Math.floor(MCP_INVOKE_PAYLOAD_MAX_BYTES / 2)),
     };
     const recovery = "authentication expired; run login";
     const result = await invokeMcp(
@@ -206,7 +207,7 @@ describe("mcp.tools.call.v1", () => {
           { type: "text", text: JSON.stringify(structuredContent, null, 2) },
           {
             type: "image",
-            data: "I".repeat(Math.floor(testing.MCP_INVOKE_PAYLOAD_MAX_BYTES / 2)),
+            data: "I".repeat(Math.floor(MCP_INVOKE_PAYLOAD_MAX_BYTES / 2)),
             mimeType: "image/png",
           },
           { type: "text", text: recovery },
@@ -229,7 +230,7 @@ describe("mcp.tools.call.v1", () => {
       { type: "text", text: "[truncated: MCP result exceeded 20 MB]" },
     ]);
     expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThanOrEqual(
-      testing.MCP_INVOKE_PAYLOAD_MAX_BYTES,
+      MCP_INVOKE_PAYLOAD_MAX_BYTES,
     );
   });
 
@@ -244,7 +245,7 @@ describe("mcp.tools.call.v1", () => {
       (result.payload as { structuredContent: { escaped: string } }).structuredContent.escaped,
     ).toBe(escaped);
     expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThanOrEqual(
-      testing.MCP_INVOKE_PAYLOAD_MAX_BYTES,
+      MCP_INVOKE_PAYLOAD_MAX_BYTES,
     );
   });
 });

--- a/src/node-host/invoke.mcp.test.ts
+++ b/src/node-host/invoke.mcp.test.ts
@@ -1,10 +1,11 @@
 /** Tests the built-in node-host MCP invocation command. */
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "../gateway/client.js";
-import { MCP_INVOKE_PAYLOAD_MAX_BYTES, MCP_TEXT_CONTENT_MAX_BYTES } from "./invoke-mcp-result.js";
 import { handleInvoke } from "./invoke.js";
 import { testing } from "./invoke.test-support.js";
 import { NodeHostMcpError, type NodeHostMcpManager } from "./mcp.js";
+
+const MEBIBYTE = 1024 * 1024;
 
 async function invokeMcp(manager: NodeHostMcpManager, params: unknown) {
   const request = vi.fn<GatewayClient["request"]>().mockResolvedValue(null);
@@ -160,7 +161,7 @@ describe("mcp.tools.call.v1", () => {
     const result = await invokeMcp(
       managerWith(async () => ({
         content: [
-          { type: "text", text: "a".repeat(MCP_TEXT_CONTENT_MAX_BYTES) },
+          { type: "text", text: "a".repeat(MEBIBYTE) },
           { type: "text", text: "overflow" },
         ],
       })),
@@ -170,12 +171,12 @@ describe("mcp.tools.call.v1", () => {
       content: Array<{ type: string; text: string }>;
     };
     const text = payload.content.map((block) => block.text).join("");
-    expect(Buffer.byteLength(text)).toBeLessThanOrEqual(MCP_TEXT_CONTENT_MAX_BYTES);
+    expect(Buffer.byteLength(text)).toBeLessThanOrEqual(MEBIBYTE);
     expect(text).toContain("truncated: MCP text content exceeded 1 MB");
   });
 
   it("drops oversized images and structured content before node.invoke serialization", async () => {
-    const oversized = "A".repeat(MCP_INVOKE_PAYLOAD_MAX_BYTES);
+    const oversized = "A".repeat(20 * MEBIBYTE);
     const result = await invokeMcp(
       managerWith(async () => ({
         content: [{ type: "image", data: oversized, mimeType: "image/png" }],
@@ -187,9 +188,7 @@ describe("mcp.tools.call.v1", () => {
       content: Array<{ type: string; text?: string }>;
       structuredContent?: Record<string, unknown>;
     };
-    expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThanOrEqual(
-      MCP_INVOKE_PAYLOAD_MAX_BYTES,
-    );
+    expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThanOrEqual(20 * MEBIBYTE);
     expect(payload.content).toEqual([
       { type: "text", text: "[truncated: MCP result exceeded 20 MB]" },
     ]);
@@ -198,7 +197,7 @@ describe("mcp.tools.call.v1", () => {
 
   it("preserves structured content and recovery guidance when an exact JSON mirror is oversized", async () => {
     const structuredContent = {
-      oversized: "S".repeat(Math.floor(MCP_INVOKE_PAYLOAD_MAX_BYTES / 2)),
+      oversized: "S".repeat(10 * MEBIBYTE),
     };
     const recovery = "authentication expired; run login";
     const result = await invokeMcp(
@@ -207,7 +206,7 @@ describe("mcp.tools.call.v1", () => {
           { type: "text", text: JSON.stringify(structuredContent, null, 2) },
           {
             type: "image",
-            data: "I".repeat(Math.floor(MCP_INVOKE_PAYLOAD_MAX_BYTES / 2)),
+            data: "I".repeat(10 * MEBIBYTE),
             mimeType: "image/png",
           },
           { type: "text", text: recovery },
@@ -229,9 +228,7 @@ describe("mcp.tools.call.v1", () => {
       { type: "text", text: recovery },
       { type: "text", text: "[truncated: MCP result exceeded 20 MB]" },
     ]);
-    expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThanOrEqual(
-      MCP_INVOKE_PAYLOAD_MAX_BYTES,
-    );
+    expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThanOrEqual(20 * MEBIBYTE);
   });
 
   it("sends MCP payloads as structured invoke data without double JSON escaping", async () => {
@@ -244,8 +241,6 @@ describe("mcp.tools.call.v1", () => {
     expect(
       (result.payload as { structuredContent: { escaped: string } }).structuredContent.escaped,
     ).toBe(escaped);
-    expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThanOrEqual(
-      MCP_INVOKE_PAYLOAD_MAX_BYTES,
-    );
+    expect(Buffer.byteLength(JSON.stringify(result))).toBeLessThanOrEqual(20 * MEBIBYTE);
   });
 });

--- a/src/node-host/invoke.test-support.ts
+++ b/src/node-host/invoke.test-support.ts
@@ -2,8 +2,6 @@ import type { RunResult } from "./invoke-types.js";
 import "./invoke.js";
 
 type NodeHostInvokeTestApi = {
-  readonly MCP_TEXT_CONTENT_MAX_BYTES: number;
-  readonly MCP_INVOKE_PAYLOAD_MAX_BYTES: number;
   clarifyNodeExecCwdSpawnError(error: NodeJS.ErrnoException, cwd: string | undefined): string;
   runCommand(
     argv: string[],
@@ -21,12 +19,6 @@ function getTestApi(): NodeHostInvokeTestApi {
 }
 
 export const testing: NodeHostInvokeTestApi = {
-  get MCP_TEXT_CONTENT_MAX_BYTES() {
-    return getTestApi().MCP_TEXT_CONTENT_MAX_BYTES;
-  },
-  get MCP_INVOKE_PAYLOAD_MAX_BYTES() {
-    return getTestApi().MCP_INVOKE_PAYLOAD_MAX_BYTES;
-  },
   clarifyNodeExecCwdSpawnError(error, cwd) {
     return getTestApi().clarifyNodeExecCwdSpawnError(error, cwd);
   },

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -35,7 +35,6 @@ import {
   sanitizeHostExecEnv,
   sanitizeSystemRunEnvOverrides,
 } from "../infra/host-env-security.js";
-import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import {
   NODE_AGENT_CLI_CLAUDE_RUN_COMMAND,
   NODE_DEVICE_APPS_COMMAND,
@@ -44,7 +43,6 @@ import {
 import { logWarn } from "../logger.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { NODE_DESKTOP_STREAM_COMMAND } from "../shared/node-desktop-stream.js";
-import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
 import type { NodeHostClient } from "./client.js";
 import { invokeNodeDesktopStream } from "./desktop-stream-command.js";
 import {
@@ -53,6 +51,7 @@ import {
 } from "./invoke-agent-cli-claude-handler.js";
 import { invokeDeviceApps } from "./invoke-device-apps.js";
 import { invokeNodeFileCommand } from "./invoke-file-commands.js";
+import { boundMcpToolResultPayload } from "./invoke-mcp-result.js";
 import {
   buildSystemRunApprovalPlan,
   handleSystemRunInvoke,
@@ -76,12 +75,6 @@ import { invokeRegisteredNodeHostCommand as invokePlugin } from "./plugin-node-h
 import { resolveNodeHostedSkillDirectory } from "./skills.js";
 
 const OUTPUT_CAP = 200_000;
-
-const MCP_TEXT_CONTENT_MAX_BYTES = 1024 * 1024;
-const MCP_TEXT_TRUNCATION_MARKER = "\n[truncated: MCP text content exceeded 1 MB]";
-
-const MCP_INVOKE_PAYLOAD_MAX_BYTES = 20 * 1024 * 1024;
-const MCP_PAYLOAD_TRUNCATION_MARKER = "[truncated: MCP result exceeded 20 MB]";
 
 const MCP_ERROR_MESSAGE_MAX_CHARS = 1_024;
 
@@ -974,104 +967,6 @@ function decodeMcpToolsCallParams(raw?: string | null): McpToolsCallParams {
   };
 }
 
-type McpInvokeContentBlock = Record<string, unknown>;
-
-/** Keeps MCP text/image content while bounding text sent through node.invoke. */
-function boundMcpToolResultPayload(result: {
-  content: readonly unknown[];
-  structuredContent?: Record<string, unknown>;
-  isError?: boolean;
-}): {
-  content: McpInvokeContentBlock[];
-  structuredContent?: Record<string, unknown>;
-  isError?: true;
-} {
-  const mirroredStructuredContent = result.structuredContent
-    ? JSON.stringify(result.structuredContent, null, 2)
-    : undefined;
-  const normalizedBlocks = result.content.filter(
-    (block): block is McpInvokeContentBlock =>
-      isRecord(block) &&
-      (mirroredStructuredContent === undefined ||
-        block.type !== "text" ||
-        block.text !== mirroredStructuredContent),
-  );
-  const totalTextBytes = normalizedBlocks.reduce<number>(
-    (total, block) =>
-      total +
-      (block.type === "text" && typeof block.text === "string" ? Buffer.byteLength(block.text) : 0),
-    0,
-  );
-  let remainingTextBytes =
-    totalTextBytes > MCP_TEXT_CONTENT_MAX_BYTES
-      ? MCP_TEXT_CONTENT_MAX_BYTES - Buffer.byteLength(MCP_TEXT_TRUNCATION_MARKER)
-      : MCP_TEXT_CONTENT_MAX_BYTES;
-  let markedTruncated = false;
-  const textBoundedContent: McpInvokeContentBlock[] = [];
-  for (const block of normalizedBlocks) {
-    if (block.type !== "text" || typeof block.text !== "string") {
-      textBoundedContent.push(block);
-      continue;
-    }
-    if (totalTextBytes <= MCP_TEXT_CONTENT_MAX_BYTES) {
-      textBoundedContent.push(block);
-      continue;
-    }
-    if (markedTruncated) {
-      continue;
-    }
-    const text = truncateUtf8Prefix(block.text, remainingTextBytes);
-    remainingTextBytes -= Buffer.byteLength(text);
-    const blockWasTruncated = text.length < block.text.length;
-    if (text || blockWasTruncated) {
-      textBoundedContent.push({
-        ...block,
-        text: blockWasTruncated ? `${text}${MCP_TEXT_TRUNCATION_MARKER}` : text,
-      });
-    }
-    if (blockWasTruncated || remainingTextBytes === 0) {
-      if (!blockWasTruncated) {
-        textBoundedContent.push({ type: "text", text: MCP_TEXT_TRUNCATION_MARKER.trimStart() });
-      }
-      markedTruncated = true;
-    }
-  }
-  const payloadMarker = { type: "text" as const, text: MCP_PAYLOAD_TRUNCATION_MARKER };
-  const reservedMarkerBytes = jsonUtf8Bytes(payloadMarker) + 1;
-  const isError = result.isError === true;
-  let usedBytes = jsonUtf8Bytes({ content: [], ...(isError ? { isError } : {}) });
-  let payloadTruncated = false;
-  let structuredContent: Record<string, unknown> | undefined;
-  if (result.structuredContent) {
-    const structuredBytes =
-      Buffer.byteLength(',"structuredContent":') + jsonUtf8Bytes(result.structuredContent);
-    if (usedBytes + structuredBytes + reservedMarkerBytes <= MCP_INVOKE_PAYLOAD_MAX_BYTES) {
-      structuredContent = result.structuredContent;
-      usedBytes += structuredBytes;
-    } else {
-      payloadTruncated = true;
-    }
-  }
-  const content: McpInvokeContentBlock[] = [];
-  for (const block of textBoundedContent) {
-    const blockBytes = jsonUtf8Bytes(block) + (content.length > 0 ? 1 : 0);
-    if (usedBytes + blockBytes + reservedMarkerBytes > MCP_INVOKE_PAYLOAD_MAX_BYTES) {
-      payloadTruncated = true;
-      continue;
-    }
-    content.push(block);
-    usedBytes += blockBytes;
-  }
-  if (payloadTruncated) {
-    content.push(payloadMarker);
-  }
-  return {
-    content,
-    ...(structuredContent ? { structuredContent } : {}),
-    ...(isError ? { isError } : {}),
-  };
-}
-
 async function handleMcpToolsCall(
   frame: NodeInvokeRequestPayload,
   client: NodeHostClient,
@@ -1188,8 +1083,6 @@ async function sendNodeEvent(client: NodeHostClient, event: string, payload: unk
 }
 
 const testing = {
-  MCP_TEXT_CONTENT_MAX_BYTES,
-  MCP_INVOKE_PAYLOAD_MAX_BYTES,
   clarifyNodeExecCwdSpawnError,
   runCommand,
 } as const;

--- a/src/node-host/mcp.recovery.test.ts
+++ b/src/node-host/mcp.recovery.test.ts
@@ -3,6 +3,7 @@
 import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { OpenClawStreamableHTTPClientTransport } from "../agents/mcp-http-transport.js";
 import { startNodeHostMcpManager } from "./mcp.js";
 
@@ -14,7 +15,7 @@ function createClient(params: {
   tools?: () => Tool[];
   connect?: () => Promise<void>;
   list?: (input?: { cursor?: string }) => Promise<{ tools: Tool[]; nextCursor?: string }>;
-  call?: () => Promise<CallToolResult>;
+  call?: (input: { name: string; arguments?: Record<string, unknown> }) => Promise<CallToolResult>;
 }) {
   const call =
     params.call ??
@@ -147,6 +148,64 @@ describe("node host MCP live lifecycle", () => {
     await manager.close();
   });
 
+  it("validates a call against the schema dispatched before a catalog refresh", async () => {
+    const schemaA = {
+      type: "object" as const,
+      properties: { revision: { const: "a" } },
+      required: ["revision"],
+    };
+    const schemaB = {
+      type: "object" as const,
+      properties: { revision: { const: "b" } },
+      required: ["revision"],
+    };
+    let listed = [{ ...tool("versioned"), outputSchema: schemaA }];
+    let notifyToolsChanged: (() => void) | undefined;
+    let resolveCall: ((result: CallToolResult) => void) | undefined;
+    const client = createClient({
+      tools: () => listed,
+      call: async () =>
+        await new Promise<CallToolResult>((resolve) => {
+          resolveCall = resolve;
+        }),
+    });
+    const manager = await startNodeHostMcpManager(
+      { docs: { command: "docs" } },
+      {
+        createClient: (_serverName, options) => {
+          notifyToolsChanged = options.onToolsChanged;
+          return client;
+        },
+        resolveTransport: () => stdioTransport,
+        warn: vi.fn(),
+      },
+    );
+
+    const calling = manager.callMcpTool({ server: "docs", tool: "versioned" });
+    await vi.waitFor(() => expect(client.callTool).toHaveBeenCalledOnce());
+    listed = [{ ...tool("versioned"), outputSchema: schemaB }];
+    notifyToolsChanged?.();
+    await vi.waitFor(() => expect(client.request).toHaveBeenCalledTimes(2));
+    resolveCall?.({ content: [], structuredContent: { revision: "a" } });
+
+    await expect(calling).resolves.toMatchObject({ structuredContent: { revision: "a" } });
+    await manager.close();
+  });
+
+  it("does not publish duplicate canonical wire names", async () => {
+    const client = createClient({ tools: () => [tool("search"), tool(" search ")] });
+    const manager = await startNodeHostMcpManager(
+      { docs: { command: "docs" } },
+      { createClient: () => client, resolveTransport: () => stdioTransport, warn: vi.fn() },
+    );
+
+    expect(manager.descriptors).toEqual([]);
+    await expect(manager.callMcpTool({ server: "docs", tool: "search" })).rejects.toMatchObject({
+      code: "MCP_TOOL_UNAVAILABLE",
+    });
+    await manager.close();
+  });
+
   it("redacts Streamable HTTP response bodies from node diagnostics", async () => {
     const client = createClient({
       tools: () => [tool("fail")],
@@ -260,6 +319,58 @@ describe("node host MCP live lifecycle", () => {
     await manager.close();
   });
 
+  it("closes only after an accepted catalog refresh and session disposal settle", async () => {
+    let notifyToolsChanged: (() => void) | undefined;
+    let listCount = 0;
+    const refreshStarted = createDeferred();
+    const refreshRelease = createDeferred<{ tools: Tool[] }>();
+    const disposalStarted = createDeferred();
+    const disposalRelease = createDeferred();
+    const client = createClient({
+      list: async () => {
+        listCount += 1;
+        if (listCount === 1) {
+          return { tools: [tool("initial")] };
+        }
+        refreshStarted.resolve();
+        return await refreshRelease.promise;
+      },
+    });
+    client.close.mockImplementation(async () => {
+      client.onclose?.();
+      disposalStarted.resolve();
+      await disposalRelease.promise;
+      refreshRelease.reject(new Error("session disposed"));
+    });
+    const manager = await startNodeHostMcpManager(
+      { docs: { command: "docs" } },
+      {
+        createClient: (_serverName, options) => {
+          notifyToolsChanged = options.onToolsChanged;
+          return client;
+        },
+        resolveTransport: () => stdioTransport,
+        warn: vi.fn(),
+      },
+    );
+
+    notifyToolsChanged?.();
+    await refreshStarted.promise;
+    let closeSettled = false;
+    const closing = manager.close().then(() => {
+      closeSettled = true;
+    });
+    await disposalStarted.promise;
+    await Promise.resolve();
+    expect(closeSettled).toBe(false);
+    expect(client.close).toHaveBeenCalledOnce();
+
+    disposalRelease.resolve();
+    await closing;
+    expect(closeSettled).toBe(true);
+    expect(client.request).toHaveBeenCalledTimes(2);
+  });
+
   it("fences a stale refresh and reconnects after transport close", async () => {
     let notifyToolsChanged: (() => void) | undefined;
     let resolveStale: ((value: { tools: Tool[] }) => void) | undefined;
@@ -356,10 +467,7 @@ describe("node host MCP live lifecycle", () => {
   });
 
   it("recovers only an exact stateful Streamable HTTP 404 and never replays the call", async () => {
-    let releaseReplacement: (() => void) | undefined;
-    const replacementReady = new Promise<void>((resolve) => {
-      releaseReplacement = resolve;
-    });
+    const replacementReady = createDeferred();
     const expiredStateful = createClient({
       tools: () => [tool("run")],
       call: async () => {
@@ -371,7 +479,7 @@ describe("node host MCP live lifecycle", () => {
         expiredStateful,
         createClient({
           tools: () => [tool("run")],
-          connect: async () => await replacementReady,
+          connect: async () => await replacementReady.promise,
         }),
       ],
       stateless: [
@@ -421,7 +529,7 @@ describe("node host MCP live lifecycle", () => {
       "stateful",
     );
 
-    releaseReplacement?.();
+    replacementReady.resolve();
     await vi.waitFor(() =>
       expect(manager.descriptors.map((descriptor) => descriptor.mcp?.server)).toContain("stateful"),
     );

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -24,7 +24,7 @@ import { sanitizeMcpMetadataText } from "../agents/mcp-metadata.js";
 import { collectMcpPaginatedItems } from "../agents/mcp-pagination.js";
 import { isMcpToolAllowed } from "../agents/mcp-tool-filter.js";
 import {
-  createMcpToolCatalogMetadata,
+  normalizeMcpToolCatalog,
   type McpToolCatalogMetadata,
 } from "../agents/mcp-tool-metadata.js";
 import { resolveMcpRequestTimeoutMs } from "../agents/mcp-transport-config.js";
@@ -252,19 +252,11 @@ async function listAllTools(
       );
       return { items: page.tools, nextCursor: page.nextCursor, serializedValue: page };
     },
-    mapItem: (tool) => {
-      const toolName = tool.name.trim();
-      if (!toolName || !shouldInclude(toolName)) {
-        return undefined;
-      }
-      return { ...tool, name: toolName };
-    },
   });
-  const metadata = createMcpToolCatalogMetadata(tools, createMcpJsonSchemaValidator());
-  return {
-    tools: tools.filter((tool) => !metadata.isRequiredTaskTool(tool.name)),
-    metadata,
-  };
+  const normalized = normalizeMcpToolCatalog(tools, createMcpJsonSchemaValidator(), (toolName) =>
+    shouldInclude(toolName) ? "include" : "exclude",
+  );
+  return { tools: normalized.tools, metadata: normalized.metadata };
 }
 
 function disposeNodeHostMcpSession(session: NodeHostMcpSession): Promise<void> {
@@ -526,10 +518,10 @@ export async function startNodeHostMcpManager(
       return;
     }
     state.refreshQueued = true;
-    enqueueWork(state, async () => {
+    void enqueueCatalogWork(state, async () => {
       state.refreshQueued = false;
-      await enqueueCatalogWork(state, () => refresh(state, session));
-    });
+      await refresh(state, session);
+    }).catch(() => {});
   }
 
   const tasks = Array.from(states.values(), (state) => async () => {
@@ -581,6 +573,7 @@ export async function startNodeHostMcpManager(
       }
       const requestedTimeoutMs =
         clampPositiveTimerTimeoutMs(params.timeoutMs) ?? NODE_MCP_TOOL_CALL_TIMEOUT_MS;
+      const validateResult = session.toolMetadata?.validatorForCall(params.tool);
       try {
         const result = await session.client.callTool(
           { name: params.tool, arguments: params.arguments ?? {} },
@@ -590,7 +583,7 @@ export async function startNodeHostMcpManager(
             ...(params.signal ? { signal: params.signal } : {}),
           },
         );
-        session.toolMetadata?.validateResult(params.tool, result);
+        validateResult?.(result);
         return result;
       } catch (error) {
         const sessionExpired = isStatefulMcpHttpSessionExpired(session, error);
@@ -629,13 +622,16 @@ export async function startNodeHostMcpManager(
           clearTimeout(state.retryTimer);
           state.retryTimer = undefined;
         }
-        await state.work;
         const session = state.current;
         state.current = undefined;
         state.listedTools = [];
         if (session) {
           await disposeNodeHostMcpSession(session);
         }
+        // Lifecycle work accepted before close may append catalog work. Drain it
+        // first, then await the latest catalog tail before releasing ownership.
+        await state.work;
+        await state.catalogWork;
       });
       await Promise.allSettled(closing);
     },


### PR DESCRIPTION
Closes #126077.
Closes #126078.
Closes #126079.

## What Problem This Solves

Fixes issues where MCP catalogs could publish ambiguous or uncallable tool identities, apply a refreshed schema to an already-running call, let excluded invalid schemas disable healthy tools, overlap recovery catalog generations, or return from node shutdown before catalog work settled. It also prevents node-hosted MCP payload limits from fully serializing oversized binary blocks before dropping them and keeps safe text results available without leaking raw content metadata.

The final P1 was in the text-only Node MCP fallback. `projectMcpCallToolResult` intentionally serializes malformed MCP blocks as model-facing text, but `node-plugin-tools` copied every projected text block into script-visible details. A malformed image/resource block without `structuredContent` could therefore expose its annotations or `_meta` as JSON text in `called.details`.

## Why This Change Was Made

Moves canonical tool identity and immutable result validation into one shared merged-catalog owner before filtering, publication, and calls. Both Gateway/session and node placements capture the exact dispatch-time validator, reject ambiguous canonical names, hide required-task tools, and compile schemas only for retained tools. Node catalog refresh remains single-flight and shutdown drains both lifecycle and catalog queues.

Node result bounding uses bounded JSON traversal before serialization. Script-visible fallback details are now derived only from original, well-formed text blocks and rebuilt as exactly `{ type: "text", text }`; malformed non-text blocks and all annotations, `_meta`, and extra fields are discarded. When no valid source text exists, `details.content` is omitted. Model-facing `projectMcpCallToolResult` behavior is unchanged. The changed gate also removed two test-only production exports and a stale test import without changing runtime limits.

## User Impact

Dynamic and paginated MCP servers remain consistent during catalog refresh. Agents no longer see duplicate aliases for one wire tool, valid in-flight calls are not rejected against a later schema, excluded bad tools do not remove healthy tools, and node shutdown waits for its owned work. Large binary results are truncated without a large pre-allocation spike, raw annotations or binary payloads no longer leak through details, and normal text-only results remain script-readable.

## Evidence

- Pre-fix P1 reproduction: `node scripts/run-vitest.mjs src/agents/node-plugin-tools.test.ts` failed because `called.details.content` contained JSON text with `malformed-annotations` and `malformed-meta`. The same test passes after deriving details from original valid text blocks.
- Fresh focused exact-head proof, one file per invocation: `agent-bundle-mcp-runtime` 97/97, `mcp-tool-metadata` 3/3, `node-plugin-tools` 15/15, `invoke-mcp-result` 1/1, `invoke.mcp` 7/7, and `mcp.recovery` 15/15.
- `node scripts/run-tsgo-core-test-shards.mjs`: passed with exit 0.
- `node scripts/check-changed.mjs --dry-run -- <all 13 PR paths>` selected `core, coreTests`; the proportional actual changed gate passed all formatting, typecheck, lint, dead-export, dependency, boundary, database-first, sidecar, import-cycle, webhook, and pairing checks.
- All 13 changed paths were formatted with `oxfmt`; `git diff --check` passed.
- Fresh branch autoreview against `origin/main` with P1 findings enabled: clean, no accepted/actionable findings.
- Earlier focused Blacksmith Testbox proof: 136 tests passed on [run 32190080573](https://github.com/openclaw/openclaw/actions/runs/32190080573).
- Earlier simplified owner proof: 156 tests passed on Testbox lease `tbx_01m0bj8s65w5vaezwv0r73tq4t` before an unrelated broad-base ratchet check.
- Earlier private-QA build and both built-distribution Gateway/node MCP E2Es passed on [run 32196064022](https://github.com/openclaw/openclaw/actions/runs/32196064022).
- Direct dependency proof: inspected installed `@modelcontextprotocol/sdk` 1.30.0 content/result schemas and call validation. Direct sibling Codex source inspection covered MCP binding identity, raw Code Mode results, private top-level metadata removal, and process/recovery ownership.

## Patch Surface

- Production: +255/-191 (net +64).
- Tests and test support: +629/-77 (net +552).
- Total: +884/-268 across 13 files (net +616).

The positive production delta is the canonical merged-catalog owner, bounded pre-serialization traversal, and the narrow source-text details whitelist. Node invocation code and duplicate metadata paths shrink; the gate-driven cleanup made result limits module-private and added no production LOC.

## Exact-Head State

- Head: `101a717f2f9204a811c5bdfbfd9c6cb4390d9a93`.
- Validated rebase anchor: `61eb7b932b91702b24e6207a6d8726e5fa891e3e`; the original catalog/result and P1 patches were byte-equivalent across the rebase.
- GitHub currently reports `MERGEABLE` and `BEHIND` because `main` advanced again after the validated rebase.
- Exact-head CI is attached as [run 32206182933](https://github.com/openclaw/openclaw/actions/runs/32206182933) and was queued/in progress when this body was refreshed.
- This update does not merge or run `scripts/pr`.
