### PR TITLE
refactor(agents): consolidate session auth selection behind prepared-facts facade

### DIFF
--- a/src/agents/auth-profiles/session-override.selection.test.ts
+++ b/src/agents/auth-profiles/session-override.selection.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  authStoreMocks,
+  createAuthStoreWithProfiles,
+  resolveSessionAuthSelection,
+  TEST_PRIMARY_PROFILE_ID,
+  TEST_SECONDARY_PROFILE_ID,
+  withAuthState,
+} from "./session-override.test-support.js";
+
+const OAUTH_PROFILE_ID = "openai:subscription";
+const SESSION_KEY = "agent:main:main";
+
+function configureProfiles(): void {
+  authStoreMocks.state.hasSource = true;
+  authStoreMocks.state.store = createAuthStoreWithProfiles({
+    profiles: {
+      [TEST_PRIMARY_PROFILE_ID]: {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-primary",
+      },
+      [TEST_SECONDARY_PROFILE_ID]: {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-secondary",
+      },
+      [OAUTH_PROFILE_ID]: {
+        type: "oauth",
+        provider: "openai",
+        access: "test-access",
+        refresh: "test-refresh",
+        expires: Date.now() + 60_000,
+      },
+    },
+    order: { openai: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID, OAUTH_PROFILE_ID] },
+  });
+}
+
+async function select(params: {
+  agentDir: string;
+  sessionEntry: SessionEntry;
+  configuredProfileId?: string;
+  modelId?: string;
+}) {
+  return await resolveSessionAuthSelection({
+    cfg: {} as OpenClawConfig,
+    provider: "openai",
+    modelId: params.modelId ?? "gpt-5.6-sol",
+    ...(params.configuredProfileId ? { configuredProfileId: params.configuredProfileId } : {}),
+    agentDir: params.agentDir,
+    sessionEntry: params.sessionEntry,
+    sessionStore: { [SESSION_KEY]: params.sessionEntry },
+    sessionKey: SESSION_KEY,
+    isNewSession: false,
+  });
+}
+
+describe("session auth selection prepared facts", () => {
+  it("returns prepared facts for a user pin", async () => {
+    await withAuthState(async (state) => {
+      configureProfiles();
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: 1,
+        authProfileOverride: TEST_PRIMARY_PROFILE_ID,
+        authProfileOverrideSource: "user",
+      };
+
+      await expect(select({ agentDir: state.agentDir(), sessionEntry })).resolves.toEqual({
+        profileId: TEST_PRIMARY_PROFILE_ID,
+        source: "user",
+        routeRequirement: "api-key",
+      });
+    });
+  });
+
+  it("returns prepared facts after automatic rotation", async () => {
+    await withAuthState(async (state) => {
+      configureProfiles();
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: 1,
+        model: "gpt-5.6-sol",
+        compactionCount: 1,
+        authProfileOverride: TEST_PRIMARY_PROFILE_ID,
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 0,
+      };
+
+      await expect(select({ agentDir: state.agentDir(), sessionEntry })).resolves.toEqual({
+        profileId: TEST_SECONDARY_PROFILE_ID,
+        source: "auto",
+        routeRequirement: "api-key",
+      });
+    });
+  });
+
+  it("uses only explicit configured-profile precedence", async () => {
+    await withAuthState(async (state) => {
+      configureProfiles();
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: 1,
+        compactionCount: 0,
+        authProfileOverride: TEST_PRIMARY_PROFILE_ID,
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 0,
+      };
+
+      await expect(
+        select({
+          agentDir: state.agentDir(),
+          sessionEntry,
+          modelId: `gpt-5.6-sol@${OAUTH_PROFILE_ID}`,
+        }),
+      ).resolves.toMatchObject({ profileId: TEST_PRIMARY_PROFILE_ID, source: "auto" });
+      await expect(
+        select({
+          agentDir: state.agentDir(),
+          sessionEntry,
+          configuredProfileId: OAUTH_PROFILE_ID,
+        }),
+      ).resolves.toEqual({
+        profileId: OAUTH_PROFILE_ID,
+        source: "user",
+        routeRequirement: "subscription",
+      });
+    });
+  });
+});

--- a/src/agents/auth-profiles/session-override.test-support.ts
+++ b/src/agents/auth-profiles/session-override.test-support.ts
@@ -70,7 +70,7 @@ vi.mock("../../plugins/provider-model-routes.js", () => ({
   resolveProviderModelRoutes: authStoreMocks.resolveProviderModelRoutes,
 }));
 
-export const { clearSessionAuthProfileOverride, resolveSessionAuthProfileOverride } =
+export const { clearSessionAuthProfileOverride, resolveSessionAuthSelection } =
   await import("./session-override.js");
 export { authStoreMocks };
 
@@ -170,16 +170,19 @@ export async function resolveSession(params: {
   storePath?: string;
   isNewSession?: boolean;
 }): Promise<string | undefined> {
-  return await resolveSessionAuthProfileOverride({
-    cfg: params.cfg ?? ({} as OpenClawConfig),
-    provider: params.provider ?? "openai",
-    agentDir: params.agentDir,
-    sessionEntry: params.sessionEntry,
-    sessionStore: params.sessionStore,
-    sessionKey: params.sessionKey ?? "agent:main:main",
-    storePath: params.storePath,
-    isNewSession: params.isNewSession ?? false,
-  });
+  return (
+    await resolveSessionAuthSelection({
+      cfg: params.cfg ?? ({} as OpenClawConfig),
+      provider: params.provider ?? "openai",
+      modelId: params.sessionEntry.model ?? "model-x",
+      agentDir: params.agentDir,
+      sessionEntry: params.sessionEntry,
+      sessionStore: params.sessionStore,
+      sessionKey: params.sessionKey ?? "agent:main:main",
+      storePath: params.storePath,
+      isNewSession: params.isNewSession ?? false,
+    })
+  )?.profileId;
 }
 
 export function createAutomaticSessionEntry(overrides: Partial<SessionEntry> = {}): SessionEntry {

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -17,7 +17,6 @@ import {
   createAutomaticSessionEntry,
   prepareCooldownAuthState,
   resolveSession,
-  resolveSessionAuthProfileOverride,
   TEST_PRIMARY_PROFILE_ID,
   TEST_SECONDARY_PROFILE_ID,
   withAuthState,
@@ -36,7 +35,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       };
       const sessionStore = { "agent:main:main": sessionEntry };
 
-      const resolved = await resolveSessionAuthProfileOverride({
+      const resolved = await resolveSession({
         cfg: {} as OpenClawConfig,
         provider: "openrouter",
         agentDir,
@@ -74,7 +73,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       };
       const sessionStore = { "agent:main:main": sessionEntry };
 
-      const resolved = await resolveSessionAuthProfileOverride({
+      const resolved = await resolveSession({
         cfg: {} as OpenClawConfig,
         provider: "z.ai",
         agentDir,
@@ -105,7 +104,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       };
       const sessionStore = { "agent:main:main": sessionEntry };
 
-      const resolved = await resolveSessionAuthProfileOverride({
+      const resolved = await resolveSession({
         cfg: {
           models: {
             providers: {
@@ -163,7 +162,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       };
       const sessionStore = { "agent:main:main": sessionEntry };
 
-      const resolved = await resolveSessionAuthProfileOverride({
+      const resolved = await resolveSession({
         cfg: {
           models: {
             providers: {
@@ -230,7 +229,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       };
       const sessionStore = { "agent:main:main": sessionEntry };
 
-      const resolved = await resolveSessionAuthProfileOverride({
+      const resolved = await resolveSession({
         cfg: {} as OpenClawConfig,
         provider: "openai",
         agentDir,
@@ -273,7 +272,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       };
       const sessionStore = { "agent:main:main": sessionEntry };
 
-      const resolved = await resolveSessionAuthProfileOverride({
+      const resolved = await resolveSession({
         cfg: {} as OpenClawConfig,
         provider: "codex-cli",
         agentDir,
@@ -315,10 +314,9 @@ describe("resolveSessionAuthProfileOverride", () => {
       };
       const sessionStore = { "agent:main:main": sessionEntry };
 
-      const resolved = await resolveSessionAuthProfileOverride({
+      const resolved = await resolveSession({
         cfg: {} as OpenClawConfig,
         provider: "openai",
-        acceptedProviderIds: ["openai"],
         agentDir,
         sessionEntry,
         sessionStore,
@@ -363,10 +361,9 @@ describe("resolveSessionAuthProfileOverride", () => {
       };
       const sessionStore = { "agent:main:main": sessionEntry };
 
-      const resolved = await resolveSessionAuthProfileOverride({
+      const resolved = await resolveSession({
         cfg: {} as OpenClawConfig,
         provider: "openai",
-        acceptedProviderIds: ["openai"],
         agentDir,
         sessionEntry,
         sessionStore,
@@ -415,7 +412,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       };
       const sessionStore = { "agent:main:main": sessionEntry };
 
-      const resolved = await resolveSessionAuthProfileOverride({
+      const resolved = await resolveSession({
         cfg: {} as OpenClawConfig,
         provider: "openai",
         agentDir,

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -2,6 +2,7 @@
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ProviderModelRouteAuthRequirement } from "../../plugin-sdk/provider-model-types.js";
 import { resolveProviderModelRoutes } from "../../plugins/provider-model-routes.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import {
@@ -15,6 +16,8 @@ import {
   isModelScopedCooldownReason,
 } from "../auth-profiles/usage-state.js";
 import { isProfileInCooldown } from "../auth-profiles/usage.js";
+import { splitTrailingAuthProfile } from "../model-ref-profile.js";
+import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../openai-routing.js";
 import { resolveProviderModelRouteAuthRequirement } from "../provider-model-route-auth.js";
 
 const sessionAccessorLoader = createLazyImportLoader(
@@ -33,6 +36,21 @@ type SessionAuthProfileOverrideState = Pick<
 >;
 type SessionAuthProfileOverrideSnapshot = SessionAuthProfileOverrideState &
   Pick<SessionEntry, "sessionId">;
+type SessionAuthProfileOverrideResult = {
+  profileId: string | undefined;
+  store: ReturnType<typeof ensureAuthProfileStore> | undefined;
+};
+
+function profileAuthRequirement(params: {
+  cfg: OpenClawConfig;
+  store: ReturnType<typeof ensureAuthProfileStore> | undefined;
+  profileId: string;
+}): ProviderModelRouteAuthRequirement | undefined {
+  return resolveProviderModelRouteAuthRequirement(
+    params.store?.profiles[params.profileId]?.type ??
+      params.cfg.auth?.profiles?.[params.profileId]?.mode,
+  );
+}
 
 function applySessionAuthProfileOverrideState(
   entry: SessionEntry,
@@ -224,10 +242,10 @@ export async function clearSessionAuthProfileOverride(params: {
   });
 }
 
-/** Resolves and optionally rotates the session auth-profile override. */
-export async function resolveSessionAuthProfileOverride(params: {
+async function resolveSessionAuthProfileOverride(params: {
   cfg: OpenClawConfig;
   provider: string;
+  modelId: string;
   agentDir: string;
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
@@ -235,7 +253,7 @@ export async function resolveSessionAuthProfileOverride(params: {
   storePath?: string;
   isNewSession: boolean;
   acceptedProviderIds?: string[];
-}): Promise<string | undefined> {
+}): Promise<SessionAuthProfileOverrideResult> {
   const {
     cfg,
     provider,
@@ -247,7 +265,7 @@ export async function resolveSessionAuthProfileOverride(params: {
     isNewSession,
   } = params;
   if (!sessionEntry || !sessionStore || !sessionKey) {
-    return sessionEntry?.authProfileOverride;
+    return { profileId: sessionEntry?.authProfileOverride, store: undefined };
   }
 
   const hasConfiguredAuthProfiles =
@@ -258,7 +276,7 @@ export async function resolveSessionAuthProfileOverride(params: {
     !hasConfiguredAuthProfiles &&
     !hasAnyAuthProfileStoreSource(agentDir)
   ) {
-    return undefined;
+    return { profileId: undefined, store: undefined };
   }
 
   const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
@@ -296,7 +314,7 @@ export async function resolveSessionAuthProfileOverride(params: {
 
   // Explicit user pins are strict until the profile disappears or changes provider.
   if (source === "user" && current) {
-    return current;
+    return { profileId: current, store };
   }
 
   // Automatic pins must stay inside the currently configured rotation order.
@@ -306,7 +324,7 @@ export async function resolveSessionAuthProfileOverride(params: {
   }
 
   if (order.length === 0) {
-    return undefined;
+    return { profileId: undefined, store };
   }
 
   if (order.every((profileId) => isProfileGloballyInCooldown(store, profileId))) {
@@ -331,13 +349,17 @@ export async function resolveSessionAuthProfileOverride(params: {
       });
       const latestProfileId = latest?.authProfileOverride;
       const latestSource = resolveSessionAuthProfileOverrideSource(latest);
-      return latestProfileId &&
-        latestSource === "user" &&
-        isProfileForProvider({ cfg, providers, profileId: latestProfileId, store })
-        ? latestProfileId
-        : undefined;
+      return {
+        profileId:
+          latestProfileId &&
+          latestSource === "user" &&
+          isProfileForProvider({ cfg, providers, profileId: latestProfileId, store })
+            ? latestProfileId
+            : undefined,
+        store,
+      };
     }
-    return undefined;
+    return { profileId: undefined, store };
   }
 
   const isProfileUnavailableForSessionModel = (profileId: string) =>
@@ -352,19 +374,17 @@ export async function resolveSessionAuthProfileOverride(params: {
     Boolean(current) && !isNewSession && (currentUnavailable || compactionCount > storedCompaction);
 
   // Provider artifacts own persisted route stickiness; runtime planning owns cross-route failover.
-  const profileAuthRequirement = (profileId: string) =>
-    resolveProviderModelRouteAuthRequirement(
-      store.profiles[profileId]?.type ?? cfg.auth?.profiles?.[profileId]?.mode,
-    );
   const routeResolution = shouldRotateCurrent
-    ? resolveProviderModelRoutes({ provider, modelId: sessionEntry.model, config: cfg })
+    ? resolveProviderModelRoutes({ provider, modelId: params.modelId, config: cfg })
     : null;
   const currentAuthRequirement =
     current && routeResolution?.kind === "routes" && routeResolution.routes.length > 1
-      ? profileAuthRequirement(current)
+      ? profileAuthRequirement({ cfg, store, profileId: current })
       : undefined;
   const rotationOrder = currentAuthRequirement
-    ? order.filter((profileId) => profileAuthRequirement(profileId) === currentAuthRequirement)
+    ? order.filter(
+        (profileId) => profileAuthRequirement({ cfg, store, profileId }) === currentAuthRequirement,
+      )
     : order;
   const pickAvailable = (active?: string) => {
     const startIndex = active ? rotationOrder.indexOf(active) : -1;
@@ -385,7 +405,7 @@ export async function resolveSessionAuthProfileOverride(params: {
   }
 
   if (!next) {
-    return current;
+    return { profileId: current, store };
   }
   const shouldPersist =
     next !== sessionEntry.authProfileOverride ||
@@ -405,5 +425,52 @@ export async function resolveSessionAuthProfileOverride(params: {
     });
   }
 
-  return next;
+  return { profileId: next, store };
+}
+
+type SessionAuthSelection = {
+  profileId: string;
+  source: "auto" | "user";
+  routeRequirement: ProviderModelRouteAuthRequirement | undefined;
+};
+
+/** Resolves the session credential and its prepared route facts. */
+export async function resolveSessionAuthSelection(params: {
+  cfg: OpenClawConfig;
+  provider: string;
+  modelId: string;
+  configuredProfileId?: string;
+  harnessRuntime?: string;
+  agentDir: string;
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey?: string;
+  storePath?: string;
+  isNewSession: boolean;
+}): Promise<SessionAuthSelection | undefined> {
+  const { profileId: rotatedProfileId, store } = await resolveSessionAuthProfileOverride({
+    ...params,
+    modelId: splitTrailingAuthProfile(params.modelId).model,
+    acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
+      provider: params.provider,
+      harnessRuntime: params.harnessRuntime,
+      config: params.cfg,
+    }),
+  });
+  const rotatedSource = rotatedProfileId
+    ? params.sessionEntry?.authProfileOverride?.trim() === rotatedProfileId
+      ? (resolveSessionAuthProfileOverrideSource(params.sessionEntry) ?? "auto")
+      : "auto"
+    : undefined;
+  const rotatedUserProfileId = rotatedSource === "user" ? rotatedProfileId : undefined;
+  const configuredProfileId = params.configuredProfileId?.trim() || undefined;
+  const profileId = rotatedUserProfileId ?? configuredProfileId ?? rotatedProfileId;
+  if (!profileId) {
+    return undefined;
+  }
+  return {
+    profileId,
+    source: rotatedUserProfileId || configuredProfileId ? "user" : (rotatedSource ?? "auto"),
+    routeRequirement: profileAuthRequirement({ cfg: params.cfg, store, profileId }),
+  };
 }

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -40,7 +40,7 @@ const ensureAuthProfileStoreWithoutExternalProfilesMock = vi.fn();
 const resolveModelAsyncMock = vi.fn();
 const getApiKeyForModelMock = vi.fn();
 const requireApiKeyMock = vi.fn();
-const resolveSessionAuthProfileOverrideMock = vi.fn();
+const resolveSessionAuthSelectionMock = vi.fn();
 const getActiveEmbeddedRunSnapshotMock = vi.fn();
 const resolveSessionAgentIdMock = vi.fn();
 const resolveSessionAgentIdsMock = vi.fn();
@@ -338,8 +338,7 @@ vi.mock("./embedded-agent-runner/stream-resolution.js", () => ({
 }));
 
 vi.mock("./auth-profiles/session-override.js", () => ({
-  resolveSessionAuthProfileOverride: (...args: unknown[]) =>
-    resolveSessionAuthProfileOverrideMock(...args),
+  resolveSessionAuthSelection: (...args: unknown[]) => resolveSessionAuthSelectionMock(...args),
 }));
 
 vi.mock("../logging/diagnostic.js", () => ({
@@ -702,7 +701,7 @@ describe("runBtwSideQuestion", () => {
     ensureAuthProfileStoreWithoutExternalProfilesMock.mockReset();
     getApiKeyForModelMock.mockReset();
     requireApiKeyMock.mockReset();
-    resolveSessionAuthProfileOverrideMock.mockReset();
+    resolveSessionAuthSelectionMock.mockReset();
     getActiveEmbeddedRunSnapshotMock.mockReset();
     resolveSessionAgentIdMock.mockReset();
     resolveSessionAgentIdsMock.mockReset();
@@ -773,7 +772,11 @@ describe("runBtwSideQuestion", () => {
       ...(params.profileId ? { profileId: params.profileId } : {}),
     }));
     requireApiKeyMock.mockReturnValue("secret");
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue("profile-1");
+    resolveSessionAuthSelectionMock.mockResolvedValue({
+      profileId: "profile-1",
+      source: "auto",
+      routeRequirement: undefined,
+    });
     getActiveEmbeddedRunSnapshotMock.mockReturnValue(undefined);
     resolveSessionAgentIdMock.mockReturnValue("main");
     resolveSessionAgentIdsMock.mockReturnValue({ defaultAgentId: "main", sessionAgentId: "main" });
@@ -996,7 +999,11 @@ describe("runBtwSideQuestion", () => {
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
     });
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue("openai:work");
+    resolveSessionAuthSelectionMock.mockResolvedValue({
+      profileId: "openai:work",
+      source: "auto",
+      routeRequirement: "subscription",
+    });
     ensureAuthProfileStoreMock.mockReturnValue({
       version: 1,
       profiles: {
@@ -1134,7 +1141,7 @@ describe("runBtwSideQuestion", () => {
     };
     resolveModelWithRegistryMock.mockReturnValue(subscriptionModel);
     resolveModelAsyncMock.mockResolvedValue({ model: subscriptionModel });
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
+    resolveSessionAuthSelectionMock.mockResolvedValue(undefined);
     ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
     resolveProviderEntryApiKeyProfileReferenceMock.mockReturnValue({ kind: "literal" });
     getApiKeyForModelMock.mockResolvedValue({
@@ -1185,7 +1192,7 @@ describe("runBtwSideQuestion", () => {
     };
     resolveModelWithRegistryMock.mockReturnValue(platformModel);
     resolveModelAsyncMock.mockResolvedValue({ model: platformModel });
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
+    resolveSessionAuthSelectionMock.mockResolvedValue(undefined);
     ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
     resolveProviderEntryApiKeyProfileReferenceMock.mockReturnValue({ kind: "literal" });
     getApiKeyForModelMock.mockResolvedValue({
@@ -1247,7 +1254,7 @@ describe("runBtwSideQuestion", () => {
       baseUrl: "https://api.openai.com/v1",
     };
     resolveModelWithRegistryMock.mockReturnValue(platformModel);
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
+    resolveSessionAuthSelectionMock.mockResolvedValue(undefined);
     ensureAuthProfileStoreMock.mockReturnValue({ version: 1, profiles: {} });
     getApiKeyForModelMock.mockResolvedValue({
       apiKey: undefined,
@@ -1318,7 +1325,7 @@ describe("runBtwSideQuestion", () => {
       },
       order: { openai: ["openai:subscription", "openai:platform"] },
     });
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
+    resolveSessionAuthSelectionMock.mockResolvedValue(undefined);
     resolveModelWithRegistryMock.mockReturnValue(platformModel);
     resolveModelAsyncMock.mockImplementation(
       async (
@@ -1429,7 +1436,11 @@ describe("runBtwSideQuestion", () => {
       api: "openai-responses",
       baseUrl: "https://api.openai.com/v1",
     });
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue("openai-codex:user@example.test");
+    resolveSessionAuthSelectionMock.mockResolvedValue({
+      profileId: "openai-codex:user@example.test",
+      source: "auto",
+      routeRequirement: "subscription",
+    });
     ensureAuthProfileStoreMock.mockReturnValue({
       version: 1,
       profiles: {
@@ -1505,12 +1516,6 @@ describe("runBtwSideQuestion", () => {
     expect(
       Object.keys(sideQuestionParams.preparedRuntimeAuth?.authProfileStore?.profiles ?? {}),
     ).toEqual(["openai-codex:user@example.test"]);
-    const authArgs = mockArg(resolveSessionAuthProfileOverrideMock, 0, 0) as {
-      provider?: string;
-      acceptedProviderIds?: string[];
-    };
-    expect(authArgs.provider).toBe("openai");
-    expect(authArgs.acceptedProviderIds).toEqual(["openai"]);
     expect(streamSimpleMock).not.toHaveBeenCalled();
     expect(registerProviderStreamForModelMock).not.toHaveBeenCalled();
   });
@@ -1811,13 +1816,17 @@ describe("runBtwSideQuestion", () => {
       authProfileOverrideSource: "auto",
     });
     const sessionStore = { [DEFAULT_SESSION_KEY]: sessionEntry };
-    resolveSessionAuthProfileOverrideMock.mockImplementation(
+    resolveSessionAuthSelectionMock.mockImplementation(
       async (params: { sessionEntry?: SessionEntry }) => {
         if (params.sessionEntry) {
           params.sessionEntry.authProfileOverride = "anthropic:api";
           params.sessionEntry.authProfileOverrideSource = "auto";
         }
-        return "anthropic:api";
+        return {
+          profileId: "anthropic:api",
+          source: "auto",
+          routeRequirement: "api-key",
+        };
       },
     );
     mockDoneAnswer("Generic fallback answer.");
@@ -1846,7 +1855,7 @@ describe("runBtwSideQuestion", () => {
     expect(prepareParams.provider).toBe("claude-cli");
     expect(prepareParams.executionMode).toBe("side-question");
     expect(prepareParams.authProfileId).toBe("anthropic:auto-cli");
-    expect(resolveSessionAuthProfileOverrideMock).not.toHaveBeenCalled();
+    expect(resolveSessionAuthSelectionMock).not.toHaveBeenCalled();
     expect(cleanup).toHaveBeenCalledTimes(1);
     expect(getApiKeyForModelMock).not.toHaveBeenCalled();
     expect(streamSimpleMock).not.toHaveBeenCalled();
@@ -1879,7 +1888,7 @@ describe("runBtwSideQuestion", () => {
       profileId: "anthropic:claude-cli",
     });
     requireApiKeyMock.mockReturnValueOnce("claude-cli-access");
-    resolveSessionAuthProfileOverrideMock.mockResolvedValueOnce(undefined);
+    resolveSessionAuthSelectionMock.mockResolvedValueOnce(undefined);
     resolveModelAsyncMock.mockResolvedValueOnce({
       model: {
         provider: DEFAULT_PROVIDER,
@@ -1953,7 +1962,7 @@ describe("runBtwSideQuestion", () => {
       modelRegistry,
     });
     ensureAuthProfileStoreWithoutExternalProfilesMock.mockReturnValue(authStore);
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
+    resolveSessionAuthSelectionMock.mockResolvedValue(undefined);
     getApiKeyForModelMock.mockImplementation(async (authParams: { profileId?: string } = {}) => {
       if (authParams.profileId === "anthropic:primary") {
         throw new Error("primary credential resolution failed");
@@ -2072,7 +2081,7 @@ describe("runBtwSideQuestion", () => {
       }),
     );
     ensureAuthProfileStoreMock.mockReturnValue(authStore);
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
+    resolveSessionAuthSelectionMock.mockResolvedValue(undefined);
     getApiKeyForModelMock.mockImplementation(async (authParams: { profileId?: string } = {}) => {
       if (authParams.profileId === "openai:subscription") {
         throw new Error("subscription credential resolution failed");
@@ -2148,7 +2157,7 @@ describe("runBtwSideQuestion", () => {
     resolveModelWithRegistryMock.mockReturnValue(platformModel);
     resolveModelAsyncMock.mockResolvedValue({ model: platformModel });
     ensureAuthProfileStoreMock.mockReturnValue(authStore);
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
+    resolveSessionAuthSelectionMock.mockResolvedValue(undefined);
     resolveProviderEntryApiKeyProfileReferenceMock.mockReturnValue({ kind: "literal" });
     getApiKeyForModelMock.mockImplementation(
       async (authParams: { profileId?: string; allowAuthProfileFallback?: boolean }) => {
@@ -2233,7 +2242,11 @@ describe("runBtwSideQuestion", () => {
       profileId: "anthropic:api",
     });
     requireApiKeyMock.mockReturnValueOnce("static-key");
-    resolveSessionAuthProfileOverrideMock.mockResolvedValueOnce("anthropic:api");
+    resolveSessionAuthSelectionMock.mockResolvedValueOnce({
+      profileId: "anthropic:api",
+      source: "user",
+      routeRequirement: "api-key",
+    });
     mockDoneAnswer("Static answer.");
 
     await runSideQuestion({

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -25,7 +25,7 @@ import { isModelSelectionLocked } from "../sessions/model-overrides.js";
 import { prepareSystemAgentRunAdmission } from "./admitted-run-context.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
 import { resolveExternalCliAuthOverlayScopeFromSelection } from "./auth-profiles/external-cli-auth-selection.js";
-import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
+import { resolveSessionAuthSelection } from "./auth-profiles/session-override.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { readBtwTranscriptMessages, resolveBtwSessionTranscriptPath } from "./btw-transcript.js";
 import { executePreparedCliRun } from "./cli-runner/execute.runtime.js";
@@ -63,10 +63,7 @@ import {
   isCliRuntimeAliasForProvider,
   resolveCliRuntimeExecutionProvider,
 } from "./model-runtime-aliases.js";
-import {
-  isOpenAIProvider,
-  listOpenAIAuthProfileProvidersForAgentRuntime,
-} from "./openai-routing.js";
+import { isOpenAIProvider } from "./openai-routing.js";
 import {
   loadPreparedModelRuntimeSnapshot,
   preparedModelRuntimeConfigsMatch,
@@ -515,16 +512,11 @@ async function resolveRuntimeModel(params: {
   const runtimeProvider = model.provider;
   const runtimeModelId = model.id;
 
-  const acceptedProviderIds = listOpenAIAuthProfileProvidersForAgentRuntime({
-    provider: runtimeProvider,
-    harnessRuntime: params.harnessId,
-    agentHarnessId: params.harnessId,
-    config: cfg,
-  });
-  const authProfileId = await resolveSessionAuthProfileOverride({
+  const authSelection = await resolveSessionAuthSelection({
     cfg,
     provider: runtimeProvider,
-    acceptedProviderIds,
+    modelId: runtimeModelId,
+    harnessRuntime: params.harnessId,
     agentDir,
     sessionEntry: params.sessionEntry,
     sessionStore: params.sessionStore,
@@ -532,7 +524,8 @@ async function resolveRuntimeModel(params: {
     storePath: params.storePath,
     isNewSession: params.isNewSession,
   });
-  const authProfileIdSource = resolveReturnedAuthProfileSource(params.sessionEntry, authProfileId);
+  const authProfileId = authSelection?.profileId;
+  const authProfileIdSource = authSelection?.source;
   const authProfileStoreSelection = resolveBtwAuthProfileStore({
     cfg,
     provider: runtimeProvider,

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -1894,8 +1894,6 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       getRuntimeConfig: () => ({}) as never,
     });
 
-    const ownerContext = { owner: "gateway-a" } as never;
-    const resolveGatewayContext = () => ownerContext;
     const result = await deliverSubagentAnnouncement({
       requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
       targetRequesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
@@ -1914,7 +1912,6 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expectsCompletionMessage: true,
       bestEffortDeliver: true,
       directIdempotencyKey: "announce-local-dispatch",
-      resolveGatewayContext,
     });
 
     expectDeliveryPath(result, "direct");
@@ -1939,7 +1936,6 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         idempotencyKey: "announce-local-dispatch",
       },
       timeoutMs: 120_000,
-      resolveGatewayContext,
     });
   });
 

--- a/src/agents/subagents/announce/subagent-announce-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.ts
@@ -99,7 +99,6 @@ export async function deliverSubagentAnnouncement(params: {
   directIdempotencyKey: string;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   signal?: AbortSignal;
-  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<SubagentAnnounceDeliveryResult> {
   const sourceOwnerChanged = () => params.isSourceSessionEffectsAllowed?.() === false;
   if (sourceOwnerChanged()) {
@@ -259,7 +258,6 @@ export async function deliverSubagentAnnouncement(params: {
         onDeliveryResult: params.onDeliveryResult,
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,
-        resolveGatewayContext: params.resolveGatewayContext,
       });
     },
   });

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -73,7 +73,6 @@ async function runAnnounceAgentCall(params: {
   delegatedToolPolicyHandoff?: SubagentCompletionToolHandoffRegistration;
   expectFinal?: boolean;
   timeoutMs?: number;
-  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<unknown> {
   return await dispatchSubagentAnnounceAgent(params.agentParams, {
     expectFinal: params.expectFinal,
@@ -82,7 +81,6 @@ async function runAnnounceAgentCall(params: {
     ),
     delegatedToolPolicyHandoff: params.delegatedToolPolicyHandoff,
     timeoutMs: params.timeoutMs,
-    resolveGatewayContext: params.resolveGatewayContext,
   });
 }
 
@@ -107,7 +105,6 @@ export async function sendSubagentAnnounceDirectly(params: {
   requesterIsSubagent: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   signal?: AbortSignal;
-  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<SubagentAnnounceDeliveryResult> {
   if (params.signal?.aborted) {
     return {
@@ -372,7 +369,6 @@ export async function sendSubagentAnnounceDirectly(params: {
                 : undefined,
             expectFinal: true,
             timeoutMs: announceTimeoutMs,
-            resolveGatewayContext: params.resolveGatewayContext,
           });
         },
       });

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -7,7 +7,6 @@
 import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { getRuntimeConfig } from "../../../config/config.js";
 import { logWarn } from "../../../logger.js";
-import { getSharedGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import { isCronSessionKey } from "../../../sessions/session-key-utils.js";
 import {
   type DeliveryContext,
@@ -452,7 +451,6 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
           attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
         ),
         signal: params.signal,
-        resolveGatewayContext: getSharedGatewayContextResolver(settledBatch),
       });
     } catch (error) {
       // A transport exception can arrive after gateway admission. Replay the

--- a/src/agents/subagents/announce/subagent-announce.ts
+++ b/src/agents/subagents/announce/subagent-announce.ts
@@ -193,7 +193,6 @@ export async function runSubagentAnnounceFlow(params: {
   bestEffortDeliver?: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   onBeforeDeleteChildSession?: () => boolean;
-  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<SubagentAnnounceFlowOutcome> {
   let announceOutcome: SubagentAnnounceFlowOutcome = "retryable";
   const expectsCompletionMessage = params.expectsCompletionMessage === true;
@@ -590,7 +589,6 @@ export async function runSubagentAnnounceFlow(params: {
       directIdempotencyKey,
       onDeliveryResult: reportDeliveryResult,
       signal: params.signal,
-      resolveGatewayContext: params.resolveGatewayContext,
     });
     reportDeliveryResult(delivery);
     announceOutcome = delivery.disposition ?? (delivery.delivered ? "delivered" : "retryable");

--- a/src/agents/subagents/registry/subagent-gateway-context-binding.test.ts
+++ b/src/agents/subagents/registry/subagent-gateway-context-binding.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   bindGatewayContextResolver,
   getGatewayContextResolver,
-  getSharedGatewayContextResolver,
 } from "../../../plugins/runtime/gateway-request-scope.js";
 import { createSubagentRunRecord } from "../../subagent-test-fixtures.test-helpers.js";
 
@@ -19,18 +18,5 @@ describe("subagent Gateway context binding", () => {
 
     expect(getGatewayContextResolver(successor)?.()).toBe(context);
     expect(getGatewayContextResolver(restored)).toBeUndefined();
-  });
-
-  it("refuses to select one Gateway for a mixed-owner settle batch", () => {
-    const first = createSubagentRunRecord({ runId: "run-first" });
-    const second = createSubagentRunRecord({ runId: "run-second" });
-    const firstContext = { owner: "gateway-a" } as never;
-    const secondContext = { owner: "gateway-b" } as never;
-    bindGatewayContextResolver(first, () => firstContext);
-    bindGatewayContextResolver(second, () => secondContext);
-
-    expect(getGatewayContextResolver(first)?.()).toBe(firstContext);
-    expect(getGatewayContextResolver(second)?.()).toBe(secondContext);
-    expect(getSharedGatewayContextResolver([first, second])).toBeUndefined();
   });
 });

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -1,4 +1,3 @@
-import { getGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import { defaultRuntime } from "../../../runtime.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
 import {
@@ -607,7 +606,6 @@ export const startSubagentAnnounceCleanupFlow = (
         params.persist(runId);
       }
     },
-    resolveGatewayContext: getGatewayContextResolver(entry),
   };
   runDetachedCleanupAttempt(context, {
     runId,

--- a/src/auto-reply/reply.directive.directive-behavior.e2e-harness.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.e2e-harness.ts
@@ -14,7 +14,7 @@ import {
   compactEmbeddedAgentSessionMock,
   loadModelCatalogMock,
   resolveCommandSecretRefsViaGatewayMock,
-  resolveSessionAuthProfileOverrideMock,
+  resolveSessionAuthSelectionMock,
   runDirectiveBehaviorReplyAgent,
   runEmbeddedAgentMock,
   runDirectiveBehaviorPreparedReply,
@@ -123,8 +123,8 @@ export function installDirectiveBehaviorE2EHooks() {
     }));
     clearSessionAuthProfileOverrideMock.mockReset();
     clearSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
-    resolveSessionAuthProfileOverrideMock.mockReset();
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
+    resolveSessionAuthSelectionMock.mockReset();
+    resolveSessionAuthSelectionMock.mockResolvedValue(undefined);
     runReplyAgentMock.mockReset();
     runReplyAgentMock.mockImplementation(runDirectiveBehaviorReplyAgent);
     runPreparedReplyMock.mockReset();

--- a/src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts
+++ b/src/auto-reply/reply.directive.directive-behavior.e2e-mocks.ts
@@ -6,7 +6,7 @@ export const compactEmbeddedAgentSessionMock: Mock = vi.fn();
 export const loadModelCatalogMock: Mock = vi.fn();
 export const resolveCommandSecretRefsViaGatewayMock: Mock = vi.fn();
 export const clearSessionAuthProfileOverrideMock: Mock = vi.fn();
-export const resolveSessionAuthProfileOverrideMock: Mock = vi.fn();
+export const resolveSessionAuthSelectionMock: Mock = vi.fn();
 
 function objectRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" ? (value as Record<string, unknown>) : undefined;
@@ -127,8 +127,7 @@ vi.mock("../cli/command-secret-gateway.js", () => ({
 vi.mock("../agents/auth-profiles/session-override.js", () => ({
   clearSessionAuthProfileOverride: (...args: unknown[]) =>
     clearSessionAuthProfileOverrideMock(...args),
-  resolveSessionAuthProfileOverride: (...args: unknown[]) =>
-    resolveSessionAuthProfileOverrideMock(...args),
+  resolveSessionAuthSelection: (...args: unknown[]) => resolveSessionAuthSelectionMock(...args),
 }));
 
 vi.mock("../plugins/hook-runner-global.js", async (importOriginal) => {

--- a/src/auto-reply/reply.test-harness.ts
+++ b/src/auto-reply/reply.test-harness.ts
@@ -40,7 +40,7 @@ vi.mock("../agents/model-catalog.runtime.js", () => ({
 
 vi.mock("../agents/auth-profiles/session-override.js", () => ({
   clearSessionAuthProfileOverride: vi.fn(),
-  resolveSessionAuthProfileOverride: vi.fn().mockResolvedValue(undefined),
+  resolveSessionAuthSelection: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../commands-registry.runtime.js", () => ({

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -2,9 +2,8 @@ import crypto from "node:crypto";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { clearAutoFallbackPrimaryProbeSelection } from "../../agents/agent-scope.js";
-import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
+import { resolveSessionAuthSelection } from "../../agents/auth-profiles/session-override.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
-import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
 import { hasResolvedThinkingCatalogEntry } from "../../agents/thinking-runtime.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
@@ -407,14 +406,6 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
         agentId,
         sessionKey: context.runtimePolicySessionKey,
       });
-  const resolveAcceptedAuthProfileProviders = () =>
-    agentHarnessPolicy
-      ? listOpenAIAuthProfileProvidersForAgentRuntime({
-          provider,
-          harnessRuntime: agentHarnessPolicy.runtime,
-          config: cfg,
-        })
-      : [provider];
   const resolveRuntimeAuthProfile = async () => {
     if (useFastReplyRuntime) {
       return {
@@ -437,10 +428,11 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
       shouldUseEphemeralSession && authSessionEntry
         ? { [authSessionKey]: authSessionEntry }
         : sessionStore;
-    const resolvedAuthProfileId = await resolveSessionAuthProfileOverride({
+    const selection = await resolveSessionAuthSelection({
       cfg,
       provider,
-      acceptedProviderIds: resolveAcceptedAuthProfileProviders(),
+      modelId: model,
+      ...(agentHarnessPolicy ? { harnessRuntime: agentHarnessPolicy.runtime } : {}),
       agentDir,
       sessionEntry: authSessionEntry,
       sessionStore: authSessionStore,
@@ -449,11 +441,8 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
       isNewSession,
     });
     return {
-      authProfileId: resolvedAuthProfileId,
-      authProfileIdSource:
-        resolvedAuthProfileId && authSessionEntry?.authProfileOverride === resolvedAuthProfileId
-          ? resolveSessionAuthProfileOverrideSource(authSessionEntry)
-          : undefined,
+      authProfileId: selection?.profileId,
+      authProfileIdSource: selection?.source,
     };
   };
   let { authProfileId, authProfileIdSource } = await traceRunPhase(

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -43,7 +43,7 @@ import { withReplySystemEventSessionKey } from "./system-event-session-key.js";
 import { resolveTypingMode } from "./typing-mode.js";
 
 vi.mock("../../agents/auth-profiles/session-override.js", () => ({
-  resolveSessionAuthProfileOverride: vi.fn().mockResolvedValue(undefined),
+  resolveSessionAuthSelection: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../../agents/embedded-agent.runtime.js", () => ({
@@ -2072,11 +2072,11 @@ describe("runPreparedReply media-only handling", () => {
   });
 
   it("does not register a reply operation before auth setup succeeds", async () => {
-    const { resolveSessionAuthProfileOverride } =
+    const { resolveSessionAuthSelection } =
       await import("../../agents/auth-profiles/session-override.js");
     const sessionId = "reply-operation-auth-failure";
     const activeBefore = getActiveReplyRunCount();
-    vi.mocked(resolveSessionAuthProfileOverride).mockRejectedValueOnce(new Error("auth failed"));
+    vi.mocked(resolveSessionAuthSelection).mockRejectedValueOnce(new Error("auth failed"));
 
     await expect(
       runPrepared({
@@ -2525,7 +2525,7 @@ describe("runPreparedReply media-only handling", () => {
   });
 
   it("rechecks same-session ownership after async prep before registering a new reply operation", async () => {
-    const { resolveSessionAuthProfileOverride } =
+    const { resolveSessionAuthSelection } =
       await import("../../agents/auth-profiles/session-override.js");
     const queueSettings = await import("./queue/settings-runtime.js");
 
@@ -2534,7 +2534,7 @@ describe("runPreparedReply media-only handling", () => {
       resolveAuth = resolve;
     });
 
-    vi.mocked(resolveSessionAuthProfileOverride).mockImplementationOnce(
+    vi.mocked(resolveSessionAuthSelection).mockImplementationOnce(
       async () => await authPromise.then(() => undefined),
     );
     vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({ mode: "interrupt" });
@@ -2699,54 +2699,8 @@ describe("runPreparedReply media-only handling", () => {
     }
   });
 
-  it.each([
-    {
-      name: "legacy source-less user",
-      authProfileOverride: "profile-legacy-user",
-      authProfileOverrideCompactionCount: undefined,
-      expectedSource: "user",
-    },
-    {
-      name: "legacy marker-backed automatic",
-      authProfileOverride: "profile-legacy-auto",
-      authProfileOverrideCompactionCount: 0,
-      expectedSource: "auto",
-    },
-  ] as const)(
-    "forwards $name auth provenance to the runner",
-    async ({ authProfileOverride, authProfileOverrideCompactionCount, expectedSource }) => {
-      const { resolveSessionAuthProfileOverride } =
-        await import("../../agents/auth-profiles/session-override.js");
-      const sessionEntry: SessionEntry = {
-        sessionId: `session-${authProfileOverride}`,
-        updatedAt: 1,
-        authProfileOverride,
-        ...(authProfileOverrideCompactionCount === undefined
-          ? {}
-          : { authProfileOverrideCompactionCount }),
-      };
-      vi.mocked(resolveSessionAuthProfileOverride).mockImplementationOnce(
-        async ({ sessionEntry: resolvedEntry }) => resolvedEntry?.authProfileOverride,
-      );
-
-      await runPreparedReply(
-        baseParams({
-          isNewSession: false,
-          sessionId: sessionEntry.sessionId,
-          sessionEntry,
-          sessionStore: { "session-key": sessionEntry },
-        }),
-      );
-
-      expect(requireLastRunReplyAgentCall().followupRun.run).toMatchObject({
-        authProfileId: authProfileOverride,
-        authProfileIdSource: expectedSource,
-      });
-    },
-  );
-
   it("re-resolves auth profile after waiting for a prior run", async () => {
-    const { resolveSessionAuthProfileOverride } =
+    const { resolveSessionAuthSelection } =
       await import("../../agents/auth-profiles/session-override.js");
     const queueSettings = await import("./queue/settings-runtime.js");
     const sessionStore: Record<string, SessionEntry> = {
@@ -2758,8 +2712,14 @@ describe("runPreparedReply media-only handling", () => {
         updatedAt: 1,
       },
     };
-    vi.mocked(resolveSessionAuthProfileOverride).mockImplementation(async ({ sessionEntry }) => {
-      return sessionEntry?.authProfileOverride;
+    vi.mocked(resolveSessionAuthSelection).mockImplementation(async ({ sessionEntry }) => {
+      return sessionEntry?.authProfileOverride
+        ? {
+            profileId: sessionEntry.authProfileOverride,
+            source: sessionEntry.authProfileOverrideSource ?? "user",
+            routeRequirement: undefined,
+          }
+        : undefined;
     });
     vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({ mode: "interrupt" });
     const previousRun = createReplyOperation({
@@ -2788,11 +2748,11 @@ describe("runPreparedReply media-only handling", () => {
     await expect(runPromise).resolves.toEqual({ text: "ok" });
     const call = requireLastRunReplyAgentCall();
     expect(call?.followupRun.run.authProfileId).toBe("profile-after-wait");
-    expect(vi.mocked(resolveSessionAuthProfileOverride)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(resolveSessionAuthSelection)).toHaveBeenCalledTimes(1);
   });
 
   it("re-resolves same-session ownership after session-id rotation during async prep", async () => {
-    const { resolveSessionAuthProfileOverride } =
+    const { resolveSessionAuthSelection } =
       await import("../../agents/auth-profiles/session-override.js");
     const queueSettings = await import("./queue/settings-runtime.js");
 
@@ -2808,7 +2768,7 @@ describe("runPreparedReply media-only handling", () => {
       },
     };
 
-    vi.mocked(resolveSessionAuthProfileOverride).mockImplementationOnce(
+    vi.mocked(resolveSessionAuthSelection).mockImplementationOnce(
       async () => await authPromise.then(() => undefined),
     );
     vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({ mode: "interrupt" });

--- a/src/cron/isolated-agent.auth-profile-propagation.test.ts
+++ b/src/cron/isolated-agent.auth-profile-propagation.test.ts
@@ -10,7 +10,7 @@ import {
   loadRunCronIsolatedAgentTurn,
   mockRunCronFallbackPassthrough,
   resolveConfiguredModelRefMock,
-  resolveSessionAuthProfileOverrideMock,
+  resolveSessionAuthSelectionMock,
   runEmbeddedAgentMock,
 } from "./isolated-agent/run.test-harness.js";
 
@@ -57,7 +57,11 @@ describe("runCronIsolatedAgentTurn auth profile propagation (#20624, #90991)", (
       provider: "openrouter",
       model: "moonshotai/kimi-k2.5",
     });
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue("openrouter:default");
+    resolveSessionAuthSelectionMock.mockResolvedValue({
+      profileId: "openrouter:default",
+      source: "auto",
+      routeRequirement: "api-key",
+    });
     mockRunCronFallbackPassthrough();
 
     const result = await runCronIsolatedAgentTurn(

--- a/src/cron/isolated-agent.isolated-auth-session-flag.test.ts
+++ b/src/cron/isolated-agent.isolated-auth-session-flag.test.ts
@@ -6,7 +6,7 @@ import {
   makeCronSession,
   resolveConfiguredModelRefMock,
   resolveCronSessionMock,
-  resolveSessionAuthProfileOverrideMock,
+  resolveSessionAuthSelectionMock,
   resetRunCronIsolatedAgentTurnHarness,
   restoreFastTestEnv,
 } from "./isolated-agent/run.test-harness.js";
@@ -51,7 +51,7 @@ function makeParams(
   };
 }
 
-describe("isolated cron resolveSessionAuthProfileOverride isNewSession (#62783)", () => {
+describe("isolated cron auth selection isNewSession (#62783)", () => {
   let previousFastTestEnv: string | undefined;
 
   beforeEach(() => {
@@ -72,7 +72,11 @@ describe("isolated cron resolveSessionAuthProfileOverride isNewSession (#62783)"
         },
       }),
     );
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue("openrouter:default");
+    resolveSessionAuthSelectionMock.mockResolvedValue({
+      profileId: "openrouter:default",
+      source: "auto",
+      routeRequirement: "api-key",
+    });
   });
 
   afterEach(() => {
@@ -82,11 +86,11 @@ describe("isolated cron resolveSessionAuthProfileOverride isNewSession (#62783)"
   it("passes isNewSession=false when sessionTarget is isolated", async () => {
     await runCronIsolatedAgentTurn(makeParams());
 
-    const openRouterCall = resolveSessionAuthProfileOverrideMock.mock.calls.find(
+    const openRouterCall = resolveSessionAuthSelectionMock.mock.calls.find(
       (call) => call[0]?.provider === "openrouter",
     );
     if (!openRouterCall) {
-      throw new Error("resolveSessionAuthProfileOverride was not called with provider openrouter");
+      throw new Error("resolveSessionAuthSelection was not called with provider openrouter");
     }
     expect(openRouterCall[0]?.isNewSession).toBe(false);
   });

--- a/src/cron/isolated-agent/run-auth-profile.runtime.ts
+++ b/src/cron/isolated-agent/run-auth-profile.runtime.ts
@@ -1,2 +1,2 @@
 // Runtime auth-profile seam for isolated cron agent runs.
-export { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
+export { resolveSessionAuthSelection } from "../../agents/auth-profiles/session-override.js";

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -2,11 +2,9 @@
 import { isDeepStrictEqual } from "node:util";
 import { hasAnyAuthProfileStoreSource } from "../../agents/auth-profiles/source-check.js";
 import { findModelInCatalog } from "../../agents/model-catalog-lookup.js";
-import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
 import { loadAgentRuntimePluginRegistryHandle } from "../../agents/runtime-plugins.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { SessionEntry } from "../../config/sessions.js";
-import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import { resolveSessionWorkStartError } from "../../config/sessions/lifecycle.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -601,22 +599,19 @@ export async function prepareCronRunContext(params: {
     });
     const storedAuthProfileId = cronSession.sessionEntry.authProfileOverride?.trim();
     const hasSessionAuthProfileOverride = Boolean(storedAuthProfileId);
-    const authProfileId =
+    const authSelection =
       !hasSessionAuthProfileOverride &&
       !hasConfiguredAuthProfiles(cfgWithAgentDefaults) &&
       !hasAnyAuthProfileStoreSource(agentDir)
         ? undefined
         : await (
             await loadCronAuthProfileRuntime()
-          ).resolveSessionAuthProfileOverride({
+          ).resolveSessionAuthSelection({
             // Auth resolution may mutate session state; use the store/key persistence will write.
             cfg: cfgWithAgentDefaults,
             provider,
-            acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
-              provider,
-              harnessRuntime: effectiveAgentRuntime,
-              config: cfgWithAgentDefaults,
-            }),
+            modelId: model,
+            harnessRuntime: effectiveAgentRuntime,
             agentDir,
             sessionEntry: cronSession.sessionEntry,
             sessionStore: cronSession.store,
@@ -624,6 +619,7 @@ export async function prepareCronRunContext(params: {
             storePath: cronSession.storePath,
             isNewSession: cronSession.isNewSession && input.job.sessionTarget !== "isolated",
           });
+    const authProfileId = authSelection?.profileId;
     const liveSelection: CronLiveSelection = {
       provider,
       model,
@@ -633,11 +629,7 @@ export async function prepareCronRunContext(params: {
         cfg: cfgWithAgentDefaults,
       }),
       authProfileId,
-      authProfileIdSource: authProfileId
-        ? authProfileId === storedAuthProfileId
-          ? resolveSessionAuthProfileOverrideSource(cronSession.sessionEntry)
-          : "auto"
-        : undefined,
+      authProfileIdSource: authSelection?.source,
     };
     const runtimePluginCandidates =
       selectedPreflightCandidateIndex >= 0

--- a/src/cron/isolated-agent/run.auth-profile-cold-path.test.ts
+++ b/src/cron/isolated-agent/run.auth-profile-cold-path.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../agents/auth-profiles/source-check.js", () => ({
 import {
   clearFastTestEnv,
   loadRunCronIsolatedAgentTurn,
-  resolveSessionAuthProfileOverrideMock,
+  resolveSessionAuthSelectionMock,
   resetRunCronIsolatedAgentTurnHarness,
   restoreFastTestEnv,
 } from "./run.test-harness.js";
@@ -58,6 +58,6 @@ describe("runCronIsolatedAgentTurn auth-profile cold path", () => {
 
     expect(result.status).toBe("ok");
     expect(hasAnyAuthProfileStoreSourceMock).toHaveBeenCalledTimes(1);
-    expect(resolveSessionAuthProfileOverrideMock).not.toHaveBeenCalled();
+    expect(resolveSessionAuthSelectionMock).not.toHaveBeenCalled();
   });
 });

--- a/src/cron/isolated-agent/run.live-session-model-switch.test.ts
+++ b/src/cron/isolated-agent/run.live-session-model-switch.test.ts
@@ -10,7 +10,7 @@ import {
   resolveAllowedModelRefMock,
   resolveConfiguredModelRefMock,
   resolveCronSessionMock,
-  resolveSessionAuthProfileOverrideMock,
+  resolveSessionAuthSelectionMock,
   resetRunCronIsolatedAgentTurnHarness,
   runEmbeddedAgentMock,
   runWithModelFallbackMock,
@@ -193,7 +193,11 @@ describe("runCronIsolatedAgentTurn — LiveSessionModelSwitchError retry (#57206
   });
 
   it("propagates a legacy source-less user auth profile into the run", async () => {
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue("profile-a");
+    resolveSessionAuthSelectionMock.mockResolvedValue({
+      profileId: "profile-a",
+      source: "user",
+      routeRequirement: undefined,
+    });
     resolveCronSessionMock.mockReturnValue(
       makeCronSession({
         sessionEntry: makeCronSessionEntry({
@@ -222,7 +226,11 @@ describe("runCronIsolatedAgentTurn — LiveSessionModelSwitchError retry (#57206
   });
 
   it("keeps a resolved fallback profile automatic when it differs from the stored pin", async () => {
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue("profile-b");
+    resolveSessionAuthSelectionMock.mockResolvedValue({
+      profileId: "profile-b",
+      source: "auto",
+      routeRequirement: undefined,
+    });
     resolveCronSessionMock.mockReturnValue(
       makeCronSession({
         sessionEntry: makeCronSessionEntry({
@@ -251,7 +259,11 @@ describe("runCronIsolatedAgentTurn — LiveSessionModelSwitchError retry (#57206
   });
 
   it("retries with switched auth profile state from LiveSessionModelSwitchError", async () => {
-    resolveSessionAuthProfileOverrideMock.mockResolvedValue("profile-a");
+    resolveSessionAuthSelectionMock.mockResolvedValue({
+      profileId: "profile-a",
+      source: "auto",
+      routeRequirement: undefined,
+    });
     const cronSession = makeCronSession({
       sessionEntry: makeCronSessionEntry({
         model: undefined,

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -91,7 +91,7 @@ export const resolveDeliveryTargetMock = createMock();
 export const dispatchCronDeliveryMock = createMock();
 export const queueCronMessageToolDeliveryAwarenessMock = createMock();
 export const preflightCronModelProviderMock = createMock();
-export const resolveSessionAuthProfileOverrideMock = createMock();
+export const resolveSessionAuthSelectionMock = createMock();
 export const resolveFastModeStateMock = createMock();
 export const getChannelPluginMock = createMock();
 export const retireSessionMcpRuntimeMock = createMock();
@@ -335,7 +335,7 @@ vi.mock("../../agents/model-runtime-aliases.js", () => ({
 }));
 
 vi.mock("./run-auth-profile.runtime.js", () => ({
-  resolveSessionAuthProfileOverride: resolveSessionAuthProfileOverrideMock,
+  resolveSessionAuthSelection: resolveSessionAuthSelectionMock,
 }));
 
 vi.mock("./run-embedded.runtime.js", () => ({
@@ -759,8 +759,8 @@ function resetRunOutcomeMocks(): void {
   queueCronMessageToolDeliveryAwarenessMock.mockResolvedValue(undefined);
   preflightCronModelProviderMock.mockReset();
   preflightCronModelProviderMock.mockResolvedValue({ status: "available" });
-  resolveSessionAuthProfileOverrideMock.mockReset();
-  resolveSessionAuthProfileOverrideMock.mockResolvedValue(undefined);
+  resolveSessionAuthSelectionMock.mockReset();
+  resolveSessionAuthSelectionMock.mockResolvedValue(undefined);
 }
 
 function resetRunSessionMocks(): void {

--- a/src/gateway/worker-environments/inference-runtime.test.ts
+++ b/src/gateway/worker-environments/inference-runtime.test.ts
@@ -4,6 +4,7 @@ import {
   validateWorkerInferenceTerminalOutcome,
   type WorkerInferenceStartParams,
 } from "../../../packages/gateway-protocol/src/schema/worker-inference.js";
+import type { resolveSessionAuthSelection } from "../../agents/auth-profiles/session-override.js";
 import type { applyExtraParamsToAgent } from "../../agents/embedded-agent-runner/extra-params.js";
 import type { resolveModelAsync } from "../../agents/embedded-agent-runner/model.js";
 import type { resolveEmbeddedAgentStreamFn } from "../../agents/embedded-agent-runner/stream-resolution.js";
@@ -43,7 +44,7 @@ type Deps = {
   applyStreamPolicy: typeof applyExtraParamsToAgent;
   acquireRuntimeLease: typeof acquireAgentRunPreparedModelRuntime;
   prepareModel: typeof prepareSimpleCompletionModel;
-  resolveAuthProfileMode: () => string | undefined;
+  resolveSessionAuthSelection: typeof resolveSessionAuthSelection;
   resolveModel: typeof resolveModelAsync;
   resolveProviderStream: typeof registerProviderStreamForModel;
   resolveStream: typeof resolveEmbeddedAgentStreamFn;
@@ -247,7 +248,15 @@ function setup(
       },
     };
   });
-  const resolveAuthProfileMode = vi.fn<Deps["resolveAuthProfileMode"]>(() => undefined);
+  const resolveAuthSelection = vi.fn<Deps["resolveSessionAuthSelection"]>(async () =>
+    entry.authProfileOverride
+      ? {
+          profileId: entry.authProfileOverride,
+          source: entry.authProfileOverrideSource ?? "user",
+          routeRequirement: undefined,
+        }
+      : undefined,
+  );
   const observedRegistry = () => getPluginRuntimeGenerationRegistry() ?? getActivePluginRegistry();
   const stream = vi.fn<StreamFn>(() => {
     options.observeStage?.("execution", observedRegistry());
@@ -288,10 +297,9 @@ function setup(
     })),
     acquireRuntimeLease,
     resolveDefaultModel: vi.fn(() => ({ provider: PROVIDER, model: MODEL })),
-    resolveSessionAuthProfile: vi.fn(async () => entry.authProfileOverride),
+    resolveSessionAuthSelection: resolveAuthSelection,
     resolveModel,
     prepareModel,
-    resolveAuthProfileMode,
     resolveProviderStream,
     resolveStream,
     applyStreamPolicy,
@@ -307,7 +315,7 @@ function setup(
     acquireRuntimeLease,
     prepareModel,
     releaseRuntime,
-    resolveAuthProfileMode,
+    resolveAuthSelection,
     scope,
     stream,
   };
@@ -363,12 +371,20 @@ describe("worker inference provider runtime", () => {
 
   it("projects the gateway-owned auth profile onto the provider route", async () => {
     const oauthRuntime = setup();
-    oauthRuntime.resolveAuthProfileMode.mockReturnValue("oauth");
+    oauthRuntime.resolveAuthSelection.mockResolvedValue({
+      profileId: PROFILE,
+      source: "user",
+      routeRequirement: "subscription",
+    });
     await oauthRuntime.executor(params(request(), vi.fn()));
     const oauth = oauthRuntime.prepareModel.mock.calls[0]?.[0].cfg ?? {};
 
     const apiKeyRuntime = setup();
-    apiKeyRuntime.resolveAuthProfileMode.mockReturnValue("api_key");
+    apiKeyRuntime.resolveAuthSelection.mockResolvedValue({
+      profileId: PROFILE,
+      source: "user",
+      routeRequirement: "api-key",
+    });
     await apiKeyRuntime.executor(params(request(), vi.fn()));
     const apiKey = apiKeyRuntime.prepareModel.mock.calls[0]?.[0].cfg ?? {};
 
@@ -386,7 +402,11 @@ describe("worker inference provider runtime", () => {
 
   it("prepares the selected model against its gateway-owned OAuth route", async () => {
     const runtime = setup();
-    runtime.resolveAuthProfileMode.mockReturnValue("oauth");
+    runtime.resolveAuthSelection.mockResolvedValue({
+      profileId: PROFILE,
+      source: "user",
+      routeRequirement: "subscription",
+    });
 
     await expect(runtime.executor(params(request(), vi.fn()))).resolves.toMatchObject({
       type: "done",
@@ -405,7 +425,11 @@ describe("worker inference provider runtime", () => {
       authProfileOverrideSource: "auto",
       authProfileOverrideCompactionCount: 1,
     });
-    runtime.resolveAuthProfileMode.mockReturnValue("oauth");
+    runtime.resolveAuthSelection.mockResolvedValue({
+      profileId: PROFILE,
+      source: "auto",
+      routeRequirement: "subscription",
+    });
 
     await expect(runtime.executor(params(request(), vi.fn()))).resolves.toMatchObject({
       type: "done",

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -14,8 +14,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
-import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
-import { ensureAuthProfileStore } from "../../agents/auth-profiles/store.js";
+import { resolveSessionAuthSelection } from "../../agents/auth-profiles/session-override.js";
 import { applyExtraParamsToAgent } from "../../agents/embedded-agent-runner/extra-params.js";
 import { resolveModelAsync } from "../../agents/embedded-agent-runner/model.js";
 import { wrapStreamFnWithDiagnosticModelCallEvents } from "../../agents/embedded-agent-runner/run/attempt.model-diagnostic-events.js";
@@ -35,12 +34,10 @@ import {
   createModelVisibilityPolicy,
   RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
 } from "../../agents/model-visibility-policy.js";
-import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   type PreparedModelRuntimeSnapshot,
 } from "../../agents/prepared-model-runtime.js";
-import { resolveProviderModelRouteAuthRequirement } from "../../agents/provider-model-route-auth.js";
 import { projectProviderModelRouteConfig } from "../../agents/provider-model-route.js";
 import { registerProviderStreamForModel } from "../../agents/provider-stream.js";
 import {
@@ -49,7 +46,6 @@ import {
 } from "../../agents/simple-completion-runtime.js";
 import { normalizeUsage, hasNonzeroUsage } from "../../agents/usage.js";
 import { getRuntimeConfig } from "../../config/config.js";
-import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { resolveDiagnosticModelContentCapturePolicy } from "../../infra/diagnostic-llm-content.js";
@@ -106,8 +102,7 @@ type WorkerInferenceRuntimeDependencies = {
   ) => WorkerInferenceSessionTarget | undefined;
   acquireRuntimeLease: typeof acquireAgentRunPreparedModelRuntime;
   resolveDefaultModel: typeof resolveDefaultModelForAgent;
-  resolveSessionAuthProfile: typeof resolveSessionAuthProfileOverride;
-  resolveAuthProfileMode: typeof resolveWorkerInferenceAuthProfileMode;
+  resolveSessionAuthSelection: typeof resolveSessionAuthSelection;
   resolveModel: typeof resolveModelAsync;
   prepareModel: typeof prepareSimpleCompletionModel;
   resolveProviderStream: typeof registerProviderStreamForModel;
@@ -117,22 +112,6 @@ type WorkerInferenceRuntimeDependencies = {
   createTrace: typeof createDiagnosticTraceContextFromActiveScope;
   recordUsage: (params: WorkerInferenceUsageParams) => void;
 };
-
-function resolveWorkerInferenceAuthProfileMode(params: {
-  config: OpenClawConfig;
-  agentDir: string;
-  profileId: string;
-}): string | undefined {
-  const configuredMode = params.config.auth?.profiles?.[params.profileId]?.mode;
-  if (configuredMode) {
-    return configuredMode;
-  }
-  return ensureAuthProfileStore(params.agentDir, {
-    readOnly: true,
-    allowKeychainPrompt: false,
-    config: params.config,
-  }).profiles[params.profileId]?.type;
-}
 
 const ERROR_MESSAGES = {
   "model-not-approved": "Model is not approved for this agent.",
@@ -348,8 +327,7 @@ const DEFAULT_DEPENDENCIES: WorkerInferenceRuntimeDependencies = {
   },
   acquireRuntimeLease: acquireAgentRunPreparedModelRuntime,
   resolveDefaultModel: resolveDefaultModelForAgent,
-  resolveSessionAuthProfile: resolveSessionAuthProfileOverride,
-  resolveAuthProfileMode: resolveWorkerInferenceAuthProfileMode,
+  resolveSessionAuthSelection,
   resolveModel: resolveModelAsync,
   prepareModel: prepareSimpleCompletionModel,
   resolveProviderStream: registerProviderStreamForModel,
@@ -359,19 +337,6 @@ const DEFAULT_DEPENDENCIES: WorkerInferenceRuntimeDependencies = {
   createTrace: createDiagnosticTraceContextFromActiveScope,
   recordUsage: emitWorkerInferenceUsage,
 };
-
-function resolveReturnedProfileSource(
-  entry: WorkerInferenceSessionTarget["sessionEntry"],
-  profileId: string | undefined,
-): "auto" | "user" | undefined {
-  if (!profileId) {
-    return undefined;
-  }
-  if (entry.authProfileOverride?.trim() !== profileId) {
-    return "auto";
-  }
-  return resolveSessionAuthProfileOverrideSource(entry);
-}
 
 async function resolveApprovedModel(params: {
   config: OpenClawConfig;
@@ -492,14 +457,12 @@ async function resolveApprovedModel(params: {
         lifecycleConfig.plugins?.entries?.codex?.enabled === true
           ? harnessPolicy.runtime
           : undefined;
-      const sessionProfileId = await dependencies.resolveSessionAuthProfile({
+      const sessionSelection = await dependencies.resolveSessionAuthSelection({
         cfg: lifecycleConfig,
         provider: resolved.ref.provider,
-        acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
-          provider: resolved.ref.provider,
-          harnessRuntime: harnessPolicy.runtime,
-          config: lifecycleConfig,
-        }),
+        modelId: resolved.ref.model,
+        ...(configuredDefaultProfile ? { configuredProfileId: configuredDefaultProfile } : {}),
+        harnessRuntime: harnessPolicy.runtime,
         agentDir,
         sessionEntry: target.sessionEntry,
         sessionStore: target.sessionStore,
@@ -507,28 +470,10 @@ async function resolveApprovedModel(params: {
         storePath: target.storePath,
         isNewSession: false,
       });
-      const sessionProfileSource = resolveReturnedProfileSource(
-        target.sessionEntry,
-        sessionProfileId,
-      );
-      const selectedProfile =
-        sessionProfileId && sessionProfileSource === "user"
-          ? { id: sessionProfileId, source: sessionProfileSource }
-          : configuredDefaultProfile
-            ? { id: configuredDefaultProfile, source: "user" as const }
-            : sessionProfileId
-              ? { id: sessionProfileId, source: sessionProfileSource }
-              : undefined;
+      const selectedProfileId = sessionSelection?.profileId;
+      const routeRequirement = sessionSelection?.routeRequirement;
       let modelConfig = lifecycleConfig;
-      const authMode = selectedProfile
-        ? dependencies.resolveAuthProfileMode({
-            config: lifecycleConfig,
-            agentDir,
-            profileId: selectedProfile.id,
-          })
-        : undefined;
-      const authRequirement = resolveProviderModelRouteAuthRequirement(authMode);
-      const routeResolution = authRequirement
+      const routeResolution = routeRequirement
         ? resolveProviderModelRoutes({
             provider: resolved.ref.provider,
             modelId: resolved.ref.model,
@@ -538,7 +483,7 @@ async function resolveApprovedModel(params: {
       const route =
         routeResolution?.kind === "routes"
           ? routeResolution.routes.find(
-              (candidate) => candidate.authRequirement === authRequirement,
+              (candidate) => candidate.authRequirement === routeRequirement,
             )
           : undefined;
       if (route) {
@@ -559,9 +504,9 @@ async function resolveApprovedModel(params: {
         provider: resolved.ref.provider,
         modelId: resolved.ref.model,
         agentDir,
-        ...(selectedProfile ? { profileId: selectedProfile.id } : {}),
-        ...(selectedProfile ? { preferredProfile: selectedProfile.id } : {}),
-        ...(selectedProfile ? { bindAuthOwner: true } : {}),
+        ...(selectedProfileId ? { profileId: selectedProfileId } : {}),
+        ...(selectedProfileId ? { preferredProfile: selectedProfileId } : {}),
+        ...(selectedProfileId ? { bindAuthOwner: true } : {}),
         allowMissingApiKeyModes: ["aws-sdk"],
         modelResolver: dependencies.resolveModel,
         preparedModelRuntime: runtimeSnapshot,

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -53,15 +53,6 @@ export const getGatewayContextResolver = (owner: object) => gatewayContextResolv
 
 export const clearGatewayContextResolver = (owner: object) => gatewayContextResolvers.delete(owner);
 
-export function getSharedGatewayContextResolver(
-  owners: readonly object[],
-): GatewayContextResolver | undefined {
-  const first = owners[0] ? gatewayContextResolvers.get(owners[0]) : undefined;
-  return first && owners.every((owner) => gatewayContextResolvers.get(owner) === first)
-    ? first
-    : undefined;
-}
-
 /**
  * Runs plugin gateway handlers with request-scoped context that runtime helpers can read.
  */


### PR DESCRIPTION
## What Problem This Solves

Two things, stacked as independent commits:

1. **`fix(subagents)`: latent main breakage.** #126062 bound subagent completion dispatch to the Gateway instance (context now comes from the instance's own `getContext`), but left the old caller-supplied `resolveGatewayContext` plumbing threaded through the announce path. The forward into `GatewayLifecycleAgentDispatchOptions` fails `check-prod-types` (TS2353) in any CI lane that typechecks the gateway scope — #126062's own changed-scope lanes never did, so main is latently red for every future gateway-touching PR (this one was the first to trip it).
2. **`refactor(agents)`: auth-selection consolidation.** #123894 fixed route-blind session rotation inside `session-override.ts`, but every caller still hand-rolls the same selection prelude, and the inference runtime still re-derives the selected profile's credential mode and route requirement that the resolver just computed.

## Why This Change Was Made

The fix commit deletes the dead announce-path resolver plumbing (param decls, forwards, the now-unused `getSharedGatewayContextResolver`, and the stale forwarding assertions in the binding test). The spawn/tools resolver path is untouched — the in-process dispatch there still consumes it.

The refactor completes #123894's redesign at the call-site layer: a new `resolveSessionAuthSelection` façade returns prepared facts (`profileId`, `source`, `routeRequirement`) and owns provider expansion, provenance derivation, and explicit configured-default-profile precedence. All four callers (inference-runtime, get-reply-run-admission, btw, cron run-prepare) migrate to it and delete their preludes; inference-runtime drops its duplicate mode/route re-derivation and consumes the prepared route requirement directly. Rotation internals from #123894 are untouched.

## User Impact

None intended — behavior-neutral consolidation plus a type-level repair of main. Sessions keep the route-aware rotation shipped in #123894; gateway-scope CI lanes typecheck again.

## Evidence

- Production LOC net −35 vs base (fix −21, refactor −14); tests +149 including façade-facts coverage, explicit `configuredProfileId` precedence, and a negative test that `model@profile` suffixes cannot imply pin precedence.
- Suites: auth-profiles 27 files/385 tests PASS; subagents 39 files/1,095 tests PASS; announce delivery 169 tests PASS; inference-runtime 25, btw 57, reply media/admission 122, cron 13 PASS.
- `check:changed` PASS (fails on unpatched main with the TS2353 above — reproduced and attributed to 2cd87d3d27c); `check:import-cycles` 0; `pnpm build` PASS, no `[INEFFECTIVE_DYNAMIC_IMPORT]`; oxfmt clean; Codex autoreview clean on the final stack.
- Route contract previously ground-truthed against sibling Codex source (`codex-rs/model-provider-info/src/lib.rs`, `codex-rs/protocol/src/auth.rs`).
- Live gateway verification (OpenAI route-stay across compaction + Anthropic api→claude-cli fallback) to follow post-land; results will be posted here.

Follow-up candidate (out of scope): unify rotation onto the planner's `ProviderModelAuthSourcePlan` primitives so cooldown/order classification exists once.

AI-assisted: yes. Designed, reviewed, and verified by maintainer session.

Co-authored with @fuller-stack-dev (#123894 groundwork).
