### PR TITLE
fix: restart-recovered turns no longer show fatal errors

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
@@ -464,11 +464,27 @@ describe("executeAgentTurn: terminal failures", () => {
   ])("hands an armed restart recovery owner the $label", async ({ label, result }) => {
     const runId = `armed-restart-${label.replaceAll(" ", "-")}`;
     const { replyOperation, failMock } = createMockReplyOperation();
+    let operationResult: typeof replyOperation.result = null;
+    const abortForRestart = vi.fn(() => {
+      operationResult = { kind: "aborted", code: "aborted_for_restart" };
+      return true;
+    });
+    const complete = vi.fn(() => {
+      operationResult ??= { kind: "completed" };
+    });
+    const restartReplyOperation = {
+      ...replyOperation,
+      get result() {
+        return operationResult;
+      },
+      abortForRestart,
+      complete,
+    } satisfies typeof replyOperation;
     state.runEmbeddedAgentMock.mockResolvedValueOnce(result);
     const { executeAgentTurn } = await import("./agent-runner-execution.js");
 
     const execution = await executeAgentTurn({
-      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      ...createMinimalRunAgentTurnParams({ replyOperation: restartReplyOperation }),
       opts: { runId } as GetReplyOptions,
       isRestartRecoveryArmed: () => true,
     });
@@ -476,6 +492,12 @@ describe("executeAgentTurn: terminal failures", () => {
     expect(execution).toEqual({
       runId,
       outcome: { kind: "aborted", reason: "restart" },
+    });
+    expect(abortForRestart).toHaveBeenCalledOnce();
+    expect(complete).not.toHaveBeenCalled();
+    expect(restartReplyOperation.result).toEqual({
+      kind: "aborted",
+      code: "aborted_for_restart",
     });
     expect(failMock).not.toHaveBeenCalled();
   });

--- a/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
@@ -441,6 +441,45 @@ describe("executeAgentTurn: terminal failures", () => {
     ).toBe(true);
   });
 
+  it.each([
+    {
+      label: "settled result",
+      result: {
+        payloads: [{ text: "completed before the restart marker was observed" }],
+        meta: {},
+      },
+    },
+    {
+      label: "client-close error result",
+      result: {
+        payloads: [
+          {
+            text: "Codex app-server stopped before confirming turn completion.",
+            isError: true,
+          },
+        ],
+        meta: { error: { message: "codex app-server client closed before turn completed" } },
+      },
+    },
+  ])("hands an armed restart recovery owner the $label", async ({ label, result }) => {
+    const runId = `armed-restart-${label.replaceAll(" ", "-")}`;
+    const { replyOperation, failMock } = createMockReplyOperation();
+    state.runEmbeddedAgentMock.mockResolvedValueOnce(result);
+    const { executeAgentTurn } = await import("./agent-runner-execution.js");
+
+    const execution = await executeAgentTurn({
+      ...createMinimalRunAgentTurnParams({ replyOperation }),
+      opts: { runId } as GetReplyOptions,
+      isRestartRecoveryArmed: () => true,
+    });
+
+    expect(execution).toEqual({
+      runId,
+      outcome: { kind: "aborted", reason: "restart" },
+    });
+    expect(failMock).not.toHaveBeenCalled();
+  });
+
   it("uses compact generic copy for raw external chat errors when verbose is off", async () => {
     const agentEvents = await import("../../infra/agent-events.js");
     const emitAgentEvent = vi.mocked(agentEvents.emitAgentEvent);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -375,6 +375,9 @@ async function executeAgentTurnInternalWithRetryState(
       terminalRunFailed = cycle.terminalRunFailed;
       break;
     } catch (err) {
+      if (isAgentRunRestartAbortReason(err)) {
+        throw err;
+      }
       if (err instanceof LiveSessionModelSwitchError) {
         liveModelSwitchRetries += 1;
       }

--- a/src/auto-reply/reply/agent-runner-fallback-settlement.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-settlement.ts
@@ -45,7 +45,7 @@ export async function settleAgentFallbackCycle(params: {
       ? cycle.state.pendingLifecycleTerminal.backstop
       : undefined;
   cycle.state.pendingLifecycleTerminal = undefined;
-  if (isReplyOperationRestartAbort(turn.replyOperation)) {
+  if (isReplyOperationRestartAbort(turn.replyOperation) || turn.isRestartRecoveryArmed?.()) {
     settledLifecycleTerminal?.emit("end", runResult);
     throw isAgentRunRestartAbortReason(cycle.runAbortSignal?.reason)
       ? cycle.runAbortSignal?.reason

--- a/src/auto-reply/reply/agent-runner-fallback-settlement.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-settlement.ts
@@ -45,7 +45,10 @@ export async function settleAgentFallbackCycle(params: {
       ? cycle.state.pendingLifecycleTerminal.backstop
       : undefined;
   cycle.state.pendingLifecycleTerminal = undefined;
-  if (isReplyOperationRestartAbort(turn.replyOperation) || turn.isRestartRecoveryArmed?.()) {
+  if (turn.isRestartRecoveryArmed?.()) {
+    turn.replyOperation?.abortForRestart();
+  }
+  if (isReplyOperationRestartAbort(turn.replyOperation)) {
     settledLifecycleTerminal?.emit("end", runResult);
     throw isAgentRunRestartAbortReason(cycle.runAbortSignal?.reason)
       ? cycle.runAbortSignal?.reason

--- a/src/auto-reply/reply/restart-recovery-claim.test.ts
+++ b/src/auto-reply/reply/restart-recovery-claim.test.ts
@@ -93,6 +93,46 @@ describe("createReplyRestartRecoveryClaimController", () => {
     },
   );
 
+  it("preserves lifecycle ownership when cleanup observes a restart abort", async () => {
+    const root = tempDirs.make("openclaw-reply-claim-restart-abort-");
+    const storePath = path.join(root, "sessions.json");
+    const sessionKey = "agent:main:main";
+    const sessionId = "session";
+    let restartAborted = false;
+    let entry: InternalSessionEntry = {
+      abortedLastRun: false,
+      lifecycleRunId: "recovery-run",
+      restartRecoveryDeliveryRunId: "recovery-run",
+      sessionId,
+      startedAt: 1,
+      status: "running",
+      updatedAt: 1,
+    };
+    await replaceSessionEntry({ storePath, sessionKey }, entry);
+    const controller = createReplyRestartRecoveryClaimController({
+      admissionRunId: "recovery-run",
+      getEntry: () => entry,
+      getSessionId: () => sessionId,
+      isRestartAbort: () => restartAborted,
+      resolveDeliveryContext: () => undefined,
+      sessionKey,
+      setEntry: (next) => {
+        entry = next;
+      },
+      storePath,
+    });
+
+    await expect(controller.admitUserTurn()).resolves.toBe("admitted");
+    restartAborted = true;
+    await controller.clear();
+
+    expect(loadSessionEntry({ storePath, sessionKey })).toMatchObject({
+      lifecycleRunId: "recovery-run",
+      restartRecoveryDeliveryRunId: "recovery-run",
+      status: "running",
+    });
+  });
+
   it("retargets durable user-turn admission to the prepared reply session", async () => {
     const root = tempDirs.make("openclaw-reply-admission-");
     const storePath = path.join(root, "sessions.json");

--- a/src/gateway/server-instance-runtime.types.ts
+++ b/src/gateway/server-instance-runtime.types.ts
@@ -3,6 +3,7 @@ import type { SubagentCompletionToolHandoffRegistration } from "../agents/subage
 import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
 import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import type { AgentRunRequest } from "./server-methods/agent-request-types.js";
+import type { GatewayContextResolver } from "./server-methods/types.js";
 
 export type GatewayInstanceAgentDispatchOptions = {
   allowModelOverride?: boolean;
@@ -22,6 +23,7 @@ export type GatewayInstanceAgentDispatchOptions = {
 };
 
 export type GatewayLifecycleAgentDispatchOptions = GatewayInstanceAgentDispatchOptions & {
+  resolveGatewayContext?: GatewayContextResolver;
   timeoutMs?: number;
 };
 

--- a/src/gateway/server-instance-runtime.types.ts
+++ b/src/gateway/server-instance-runtime.types.ts
@@ -3,7 +3,6 @@ import type { SubagentCompletionToolHandoffRegistration } from "../agents/subage
 import type { GatewayNativeApprovalRuntime } from "../infra/approval-gateway-runtime.types.js";
 import type { ChannelApprovalKind } from "../infra/approval-types.js";
 import type { AgentRunRequest } from "./server-methods/agent-request-types.js";
-import type { GatewayContextResolver } from "./server-methods/types.js";
 
 export type GatewayInstanceAgentDispatchOptions = {
   allowModelOverride?: boolean;
@@ -20,11 +19,6 @@ export type GatewayInstanceAgentDispatchOptions = {
   scopes?: string[];
   signal?: AbortSignal;
   syntheticScopes?: string[];
-};
-
-export type GatewayLifecycleAgentDispatchOptions = GatewayInstanceAgentDispatchOptions & {
-  resolveGatewayContext?: GatewayContextResolver;
-  timeoutMs?: number;
 };
 
 export type GatewayApprovalEventPublisher = {

--- a/src/gateway/server-recovery-runtime-context.ts
+++ b/src/gateway/server-recovery-runtime-context.ts
@@ -1,8 +1,14 @@
 import type {
-  GatewayLifecycleAgentDispatchOptions,
+  GatewayInstanceAgentDispatchOptions,
   GatewayRecoveryRuntime,
 } from "./server-instance-runtime.types.js";
 import type { AgentRunRequest } from "./server-methods/agent-request-types.js";
+import type { GatewayContextResolver } from "./server-methods/shared-types.js";
+
+type GatewayLifecycleAgentDispatchOptions = GatewayInstanceAgentDispatchOptions & {
+  resolveGatewayContext?: GatewayContextResolver;
+  timeoutMs?: number;
+};
 
 type ActiveGatewayRecoveryRuntime = {
   owner: symbol;

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
@@ -41,7 +41,7 @@ function createClient(): GatewayWsClient {
   };
 }
 
-describe("authenticated request connection liveness", () => {
+describe.sequential("authenticated request connection liveness", () => {
   beforeEach(() => {
     runtime.beforeHandler.mockReset();
   });


### PR DESCRIPTION
Closes #126086
Related: #57425
Related: #125955

## What Problem This Solves

Fixes an issue where users with an admitted dashboard or channel turn interrupted by a planned Gateway restart could see the generic fatal “use /new” error while the replacement Gateway was already recovering and continuing the same request.

## Why This Change Was Made

Durable restart recovery now wins at the terminal-settlement owner boundary, before the old process can commit or publish any terminal payload. The process-local reply operation and the persisted recovery claim are treated as equivalent restart ownership signals, and the canonical restart abort bypasses ordinary failure mapping.

This intentionally does not add a Control UI workaround, protocol field, provider special case, or broad update-drain window. Genuine failures remain visible whenever durable restart recovery has not claimed the turn.

After the branch was rebased, current `main` exposed an unrelated compile break in the same required CI run: lifecycle dispatch callers passed the live Gateway context resolver, but their options omitted that existing typed property. This PR keeps the resolver option beside the lifecycle dispatcher so the exact type remains available without closing a server-type import cycle. No in-flight fix existed and every exact-head type/package-boundary lane was otherwise red.

## User Impact

Planned Gateway restarts no longer tell users to abandon a session that is already recovering. The recovered continuation owns the next visible success or failure, which prevents confusing resends and duplicate `/new` sessions.

## Evidence

### Regression and focused tests

- Pre-fix focused regression failed for both observed races:
  - a normally settled result remained `status: ok` instead of yielding to recovery;
  - an app-server client-close became `status: failed` with the generic `/new` payload.
- Post-fix terminal settlement and claim-cleanup proof: **29/29 passed**. The regression now verifies the reply operation becomes `aborted_for_restart`, `complete()` is not called, and cleanup leaves the durable recovery run claim intact; genuine unarmed Codex client-close and generic external failures remain visible.
- Restart ownership sibling proof: **32 tests passed** across execution lifecycle/contract, restart-abort propagation, and main-session recovery ownership.
- `node scripts/check-changed.mjs -- <all changed paths>` passed formatting, typecheck, lint, dead-export, database/schema, and import-cycle guards.
- The exact previously failing package-boundary compile passed for all 122 plugins; core production typecheck and the full architecture gate passed with zero import cycles.
- The CI-only connection-liveness flake passed after its two shared-hoisted-mock table cases were made explicitly sequential; the failed CI split was exactly 0 calls in one case and 2 in the other.
- `git diff --check` passed.
- Codex autoreview: clean after the original fix, after rebase, and after the final acyclic type/concurrency repairs.

### Isolated real Gateway restart proof

`gateway-restart-inflight-run` passed against a source-built, isolated Gateway with the deterministic mock provider:

- three sequential Gateway replacements;
- three recovery dispatches with retained restart-safe policy;
- exactly one final delivery;
- zero resend notices;
- no generic `Something went wrong` or `/new` text in the Gateway logs;
- final marker: `RESTART-CODE-MODE-WAIT-OK`.

Artifacts: `.artifacts/qa-e2e/restart-recovery-fatal-banner/qa-suite-report.md` and `qa-evidence.json`.

After ClawSweeper identified the missing reply-operation handoff, its exact command was rerun against the repaired claim-preserving path. It passed all three restarts with one final delivery, zero resend notices, and `RESTART-CODE-MODE-WAIT-OK` in `.artifacts/qa-e2e/restart-recovery-claim-preserved/qa-suite-report.md`.

### Browser-visible before / after

The browser capture uses a sanitized deterministic Gateway event sequence. “Before” reproduces the production contradiction: restart recovery is active while the old run’s fatal banner remains. “After” shows the corrected producer behavior: the continuation remains active without the obsolete fatal instruction.

| Before | After |
| --- | --- |
| ![Before: recovered session still shows fatal use-new error](https://github.com/user-attachments/assets/5c934772-e4b1-43cc-92dd-bd873fa21902) | ![After: recovered continuation runs without obsolete fatal error](https://github.com/user-attachments/assets/3f880efe-8355-4983-9cf0-17435205969b) |

https://github.com/user-attachments/assets/6bac8229-80c4-416b-9ff5-ee39be0f8081

Production LOC: **+13/-5 (net +8)**, including the durable claim handoff and acyclic current-main CI repair. Tests: **+102/-1**.

AI-assisted: yes. The final implementation was independently reviewed and the captures were inspected before attachment.
