### PR TITLE
fix(compaction): ignore decimal identifier fragments

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -146,14 +146,14 @@ function summaryIncludesIdentifier(summary: string, identifier: string): boolean
 
 /** Extracts likely exact identifiers that summaries should preserve literally. */
 export function extractOpaqueIdentifiers(text: string): string[] {
-  // Path and host/port candidates start at token boundaries so prose such as
-  // "typecheck/lint/format" is not mistaken for an absolute path.
-  const matches =
-    text.match(
-      /([A-Fa-f0-9]{8,}|https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}|\b\d{6,}\b)/g,
-    ) ?? [];
+  // Consume unambiguous decimal/scientific literals after structural identifiers.
   return uniqueStrings(
-    matches
+    Array.from(
+      text.matchAll(
+        /(https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5})|(?:(?:\d+\.\d+|\.\d+)(?:[eE][+-]?\d+)?|\d+\.?[eE][+-]\d+|(?![A-Fa-f0-9]{8,}(?![A-Fa-f0-9]))\d+\.?[eE]\d+)(?![A-Za-z0-9])|([A-Fa-f0-9]{8,}|\b\d{6,}\b)/g,
+      ),
+      (match) => match[1] ?? match[2] ?? "",
+    )
       .map((value) => normalizeOpaqueIdentifier(sanitizeExtractedIdentifier(value)))
       .filter((value) => value.length >= 4),
   ).slice(0, MAX_EXTRACTED_IDENTIFIERS);

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -146,11 +146,11 @@ function summaryIncludesIdentifier(summary: string, identifier: string): boolean
 
 /** Extracts likely exact identifiers that summaries should preserve literally. */
 export function extractOpaqueIdentifiers(text: string): string[] {
-  // Consume unambiguous decimal/scientific literals after structural identifiers.
+  // Consume unambiguous decimal/scientific literals and short non-hex unit suffixes.
   return uniqueStrings(
     Array.from(
       text.matchAll(
-        /(https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5})|(?:(?:\d+\.\d+|\.\d+)(?:[eE][+-]?\d+)?|\d+\.?[eE][+-]\d+|(?![A-Fa-f0-9]{8,}(?![A-Fa-f0-9]))\d+\.?[eE]\d+)(?![A-Za-z0-9])|([A-Fa-f0-9]{8,}|\b\d{6,}\b)/g,
+        /(https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5})|(?:(?:(?:\d+\.\d+|\.\d+)(?:[eE][+-]?\d+)?|\d+\.[eE][+-]?\d+|\d+\.?[eE][+-]\d+|(?![A-Fa-f0-9]{8,}(?![A-Fa-f0-9]))\d+\.?[eE]\d+)(?:(?=[A-Za-z]{1,3}(?![A-Za-z0-9]))(?=[A-Za-z]*[G-Zg-z])[A-Za-z]+)?)(?![A-Za-z0-9])|([A-Fa-f0-9]{8,}|\b\d{6,}\b)/g,
       ),
       (match) => match[1] ?? match[2] ?? "",
     )

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -146,11 +146,11 @@ function summaryIncludesIdentifier(summary: string, identifier: string): boolean
 
 /** Extracts likely exact identifiers that summaries should preserve literally. */
 export function extractOpaqueIdentifiers(text: string): string[] {
-  // Consume unambiguous decimal/scientific literals and short non-hex unit suffixes.
+  // Consume decimal/scientific literals and integral quantities with short non-hex unit suffixes.
   return uniqueStrings(
     Array.from(
       text.matchAll(
-        /(https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5})|(?:(?:(?:\d+\.\d+|\.\d+)(?:[eE][+-]?\d+)?|\d+\.[eE][+-]?\d+|\d+\.?[eE][+-]\d+|(?![A-Fa-f0-9]{8,}(?![A-Fa-f0-9]))\d+\.?[eE]\d+)(?:(?=[A-Za-z]{1,3}(?![A-Za-z0-9]))(?=[A-Za-z]*[G-Zg-z])[A-Za-z]+)?)(?![A-Za-z0-9])|([A-Fa-f0-9]{8,}|\b\d{6,}\b)/g,
+        /(https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5})|(?:(?:(?:\d+\.\d+|\.\d+)(?:[eE][+-]?\d+)?|\d+\.[eE][+-]?\d+|\d+\.?[eE][+-]\d+|(?![A-Fa-f0-9]{8,}(?![A-Fa-f0-9]))\d+\.?[eE]\d+)(?:(?=[A-Za-z]{1,3}(?![A-Za-z0-9]))(?=[A-Za-z]*[G-Zg-z])[A-Za-z]+)?|\d+(?:(?=[A-Za-z]{1,3}(?![A-Za-z0-9]))(?=[A-Za-z]*[G-Zg-z])[A-Za-z]+))(?![A-Za-z0-9])|([A-Fa-f0-9]{8,}|\b\d{6,}\b)/g,
       ),
       (match) => match[1] ?? match[2] ?? "",
     )

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -146,11 +146,12 @@ function summaryIncludesIdentifier(summary: string, identifier: string): boolean
 
 /** Extracts likely exact identifiers that summaries should preserve literally. */
 export function extractOpaqueIdentifiers(text: string): string[] {
-  // Consume decimal/scientific literals and integral quantities with short non-hex unit suffixes.
+  // Decimal/scientific syntax is unambiguous numeric data, including unit suffixes. Integer tokens
+  // with letters remain opaque because the suffix may be part of an exact identifier.
   return uniqueStrings(
     Array.from(
       text.matchAll(
-        /(https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5})|(?:(?:(?:\d+\.\d+|\.\d+)(?:[eE][+-]?\d+)?|\d+\.[eE][+-]?\d+|\d+\.?[eE][+-]\d+|(?![A-Fa-f0-9]{8,}(?![A-Fa-f0-9]))\d+\.?[eE]\d+)(?:(?=[A-Za-z]{1,3}(?![A-Za-z0-9]))(?=[A-Za-z]*[G-Zg-z])[A-Za-z]+)?|\d+(?:(?=[A-Za-z]{1,3}(?![A-Za-z0-9]))(?=[A-Za-z]*[G-Zg-z])[A-Za-z]+))(?![A-Za-z0-9])|([A-Fa-f0-9]{8,}|\b\d{6,}\b)/g,
+        /(https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5})|(?:(?:(?:\d+\.\d+|\.\d+)(?:[eE][+-]?\d+)?|\d+\.[eE][+-]?\d+|\d+\.?[eE][+-]\d+|(?![A-Fa-f0-9]{8,}(?![A-Fa-f0-9]))\d+\.?[eE]\d+)(?:(?=[A-Za-z]+(?![A-Za-z0-9]))(?=[A-Za-z]*[G-Zg-z])[A-Za-z]+)?(?![A-Za-z0-9])|(?<![A-Za-z0-9_-])(?=[A-Za-z0-9_-]*(?:[A-Fa-f0-9]{8,}|\d{6,}))([A-Za-z0-9_-]+))/g,
       ),
       (match) => match[1] ?? match[2] ?? "",
     )

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1211,6 +1211,14 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(identifiers).toStrictEqual(["12345678E10"]);
   });
 
+  it("rejects dotted and unit-suffixed numeric fragments", () => {
+    const identifiers = extractOpaqueIdentifiers(
+      "latency=0.123456789ms size=1.23456789e-987654321MB metric=12345678.e10 revision=1.23456789abcdef",
+    );
+
+    expect(identifiers).toStrictEqual(["23456789ABCDEF"]);
+  });
+
   it("does not consume decimal-looking prefixes of opaque identifiers", () => {
     const identifiers = extractOpaqueIdentifiers("revision=1.23456789abcdef");
 
@@ -2232,7 +2240,8 @@ describe("compaction-safeguard recent-turn preservation", () => {
             type: "text",
             text:
               `${"x".repeat(610)} metric=0.123456789 ` +
-              "negative=12345678e-987654321 positive=12345678e+987654321",
+              "negative=12345678e-987654321 positive=12345678e+987654321 " +
+              "latency=0.123456789ms size=1.23456789e-987654321MB metric=12345678.e10",
           },
         ],
         timestamp: 3,
@@ -2263,7 +2272,9 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const summary = expectCompactionResult(result).summary;
     expect(summary).toContain(latestAsk);
     expect(summary).not.toContain("123456789");
+    expect(summary).not.toContain("23456789e");
     expect(summary).not.toContain("987654321");
+    expect(summary).not.toContain("12345678");
     expect(mockSummarizeInStages).not.toHaveBeenCalled();
     expect(mockAuditSummaryQuality).toHaveBeenCalledTimes(1);
     const auditInput = requireRecord(mockCallArg(mockAuditSummaryQuality));

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1190,6 +1190,33 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(identifiers).toContain(uniqueTail[10]?.toUpperCase());
   });
 
+  it("rejects decimal and scientific fragments while keeping standalone numeric IDs", () => {
+    const identifiers = extractOpaqueIdentifiers(
+      "metric=0.123456789 scientific=1.23456789e10 exponent=1e-987654321 order_id=246813579 hash=deadbeef1234 ambiguous=12345678e10",
+    );
+
+    expect(identifiers).not.toContain("123456789");
+    expect(identifiers).not.toContain("23456789E10");
+    expect(identifiers).not.toContain("987654321");
+    expect(identifiers).toContain("246813579");
+    expect(identifiers).toContain("DEADBEEF1234"); // pragma: allowlist secret
+    expect(identifiers).toContain("12345678E10");
+  });
+
+  it("rejects signed scientific values with long hex-shaped mantissas", () => {
+    const identifiers = extractOpaqueIdentifiers(
+      "negative=12345678e-987654321 positive=12345678e+987654321 ambiguous=12345678e10",
+    );
+
+    expect(identifiers).toStrictEqual(["12345678E10"]);
+  });
+
+  it("does not consume decimal-looking prefixes of opaque identifiers", () => {
+    const identifiers = extractOpaqueIdentifiers("revision=1.23456789abcdef");
+
+    expect(identifiers).toContain("23456789ABCDEF");
+  });
+
   it("filters ordinary short numbers and trims wrapped punctuation", () => {
     const identifiers = extractOpaqueIdentifiers(
       "Year 2026 count 42 port 18789 ticket 123456 URL https://example.com/a, path /tmp/x.log, and tiny /a with prose on/off plus typecheck/lint/format.",
@@ -2177,6 +2204,70 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(summary).toContain(latestAsk);
     expect(summary).toContain(identifier);
     expect(mockSummarizeInStages).not.toHaveBeenCalled();
+  });
+
+  it("ignores truncated numeric tool-result noise in strict all-preserved audits", async () => {
+    mockSummarizeInStages.mockReset();
+    const latestAsk = "report metric status";
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model: createAnthropicModelFixture(),
+      recentTurnsPreserve: 12,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+    const messagesToSummarize: AgentMessage[] = [
+      { role: "user", content: latestAsk, timestamp: 1 },
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_metric", name: "read", arguments: {} }],
+        timestamp: 2,
+      }),
+      castAgentMessage({
+        role: "toolResult",
+        toolCallId: "call_metric",
+        toolName: "read",
+        content: [
+          {
+            type: "text",
+            text:
+              `${"x".repeat(610)} metric=0.123456789 ` +
+              "negative=12345678e-987654321 positive=12345678e+987654321",
+          },
+        ],
+        timestamp: 3,
+      }),
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "metric checked" }],
+        timestamp: 4,
+      }),
+    ];
+    const event = {
+      preparation: {
+        messagesToSummarize,
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
+
+    const summary = expectCompactionResult(result).summary;
+    expect(summary).toContain(latestAsk);
+    expect(summary).not.toContain("123456789");
+    expect(summary).not.toContain("987654321");
+    expect(mockSummarizeInStages).not.toHaveBeenCalled();
+    expect(mockAuditSummaryQuality).toHaveBeenCalledTimes(1);
+    const auditInput = requireRecord(mockCallArg(mockAuditSummaryQuality));
+    expect(auditInput.identifiers).toEqual([]);
   });
 
   it("rejects all-preserved fallback output that truncates source facts", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1213,7 +1213,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("rejects dotted and unit-suffixed numeric fragments", () => {
     const identifiers = extractOpaqueIdentifiers(
-      "latency=0.123456789ms size=1.23456789e-987654321MB metric=12345678.e10 revision=1.23456789abcdef",
+      "latency=0.123456789ms size=1.23456789e-987654321MB duration=123456789ms metric=12345678.e10 revision=1.23456789abcdef",
     );
 
     expect(identifiers).toStrictEqual(["23456789ABCDEF"]);
@@ -2241,7 +2241,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
             text:
               `${"x".repeat(610)} metric=0.123456789 ` +
               "negative=12345678e-987654321 positive=12345678e+987654321 " +
-              "latency=0.123456789ms size=1.23456789e-987654321MB metric=12345678.e10",
+              "latency=0.123456789ms size=1.23456789e-987654321MB duration=123456789ms metric=12345678.e10",
           },
         ],
         timestamp: 3,

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1190,39 +1190,30 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(identifiers).toContain(uniqueTail[10]?.toUpperCase());
   });
 
-  it("rejects decimal and scientific fragments while keeping standalone numeric IDs", () => {
-    const identifiers = extractOpaqueIdentifiers(
-      "metric=0.123456789 scientific=1.23456789e10 exponent=1e-987654321 order_id=246813579 hash=deadbeef1234 ambiguous=12345678e10",
-    );
-
-    expect(identifiers).not.toContain("123456789");
-    expect(identifiers).not.toContain("23456789E10");
-    expect(identifiers).not.toContain("987654321");
-    expect(identifiers).toContain("246813579");
-    expect(identifiers).toContain("DEADBEEF1234"); // pragma: allowlist secret
-    expect(identifiers).toContain("12345678E10");
-  });
-
-  it("rejects signed scientific values with long hex-shaped mantissas", () => {
-    const identifiers = extractOpaqueIdentifiers(
-      "negative=12345678e-987654321 positive=12345678e+987654321 ambiguous=12345678e10",
-    );
-
-    expect(identifiers).toStrictEqual(["12345678E10"]);
-  });
-
-  it("rejects dotted and unit-suffixed numeric fragments", () => {
-    const identifiers = extractOpaqueIdentifiers(
-      "latency=0.123456789ms size=1.23456789e-987654321MB duration=123456789ms metric=12345678.e10 revision=1.23456789abcdef",
-    );
-
-    expect(identifiers).toStrictEqual(["23456789ABCDEF"]);
-  });
-
-  it("does not consume decimal-looking prefixes of opaque identifiers", () => {
-    const identifiers = extractOpaqueIdentifiers("revision=1.23456789abcdef");
-
-    expect(identifiers).toContain("23456789ABCDEF");
+  it.each([
+    {
+      name: "decimal and scientific values",
+      input:
+        "metric=0.123456789 scientific=1.23456789e10 exponent=1e-987654321 order_id=246813579 hash=deadbeef1234 ambiguous=12345678e10",
+      expected: ["246813579", "DEADBEEF1234", "12345678E10"], // pragma: allowlist secret
+    },
+    {
+      name: "signed scientific values with long hex-shaped mantissas",
+      input: "negative=12345678e-987654321 positive=12345678e+987654321 ambiguous=12345678e10",
+      expected: ["12345678E10"],
+    },
+    {
+      name: "dotted values with long unit suffixes",
+      input: "latency=0.123456789seconds size=1.23456789e-987654321megabytes metric=12345678.e10",
+      expected: [],
+    },
+    {
+      name: "ambiguous integer tokens and decimal-looking opaque identifiers",
+      input: "order_id=246813579xy duration=123456789ms revision=1.23456789abcdef",
+      expected: ["246813579xy", "123456789ms", "23456789ABCDEF"],
+    },
+  ])("classifies $name", ({ input, expected }) => {
+    expect(extractOpaqueIdentifiers(input)).toStrictEqual(expected);
   });
 
   it("filters ordinary short numbers and trims wrapped punctuation", () => {
@@ -2241,7 +2232,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
             text:
               `${"x".repeat(610)} metric=0.123456789 ` +
               "negative=12345678e-987654321 positive=12345678e+987654321 " +
-              "latency=0.123456789ms size=1.23456789e-987654321MB duration=123456789ms metric=12345678.e10",
+              "latency=0.123456789seconds size=1.23456789e-987654321megabytes metric=12345678.e10",
           },
         ],
         timestamp: 3,


### PR DESCRIPTION
## What Problem This Solves

Strict safeguard compaction could classify long digit runs inside decimal and scientific numeric values as exact identifiers. For example, `metric=0.123456789` could add `123456789` to the strict audit set even though it is not an identifier. If that source text is later bounded out of the preserved recent-turn suffix, the quality guard can become unsatisfiable and cancel compaction with `missing_identifiers`.

Fixes #126016.

## Why This Change Was Made

The repair stays at the identifier producer boundary instead of weakening the downstream strict audit.

Structural identifiers retain precedence. Unambiguous decimal and scientific literals are consumed without becoming scalar identifiers, while standalone long numeric IDs, genuine hex identifiers, and ambiguous integer-plus-letter tokens remain eligible for exact preservation. An explicit exponent sign disambiguates long-mantissa scientific values such as `12345678e-987654321` and `12345678e+987654321` before generic hex matching. The unsigned pure-hex-shaped token `12345678e10` intentionally retains the existing identifier contract. Dotted scientific spellings such as `12345678.e10` and fractional/scientific values with unambiguous unit suffixes are consumed as numeric quantities; ambiguous integer-plus-letter tokens such as `123456789ms` remain identifiers.

Regression coverage includes the extractor and the real strict all-preserved tool-result path. The separate genuine-identifier retention/truncation problem in #125641 remains out of scope.

## User Impact

Tool-heavy sessions containing metrics or scientific numeric output should no longer have safeguard compaction blocked solely by false numeric identifier candidates. Strict mode still fails closed for genuinely missing identifiers, including ambiguous unsigned pure-hex-shaped tokens.

## Evidence

### RED / GREEN

- RED head `ba7f65dfa28fb5ff80a4ec88586bfde22a24318d`: [CI run](https://github.com/openclaw/openclaw/actions/runs/32285393562) failed only the two signed-scientific regressions in [the owned compaction shard](https://github.com/openclaw/openclaw/actions/runs/32285393562/job/96173880249).
- GREEN signed-scientific head `98af52beb6b44603e7a3f3157bb6ddf9741e71fc`: [the owned compaction shard](https://github.com/openclaw/openclaw/actions/runs/32301720168/job/96225693331) and [aggregate gate](https://github.com/openclaw/openclaw/actions/runs/32301720168/job/96228845445) passed.
- Numeric-boundary RED head `1b7e2ecd75af4ff4fe1a7f25dbabe8bbe8e49d71`: [the owned compaction shard](https://github.com/openclaw/openclaw/actions/runs/32770510164/job/97569851209) failed only the two dotted/fractional-unit regressions; 98/99 files and 2,493/2,495 tests otherwise passed.
- Pre-integral follow-up head `e656c1bd0186caaca2d5127b612c3a84b875d5c7`: [the owned compaction shard](https://github.com/openclaw/openclaw/actions/runs/32772401758/job/97575852205) passed the safeguard file 134/134, all 99/99 shard files, and 2,495/2,495 tests.
- Integral-unit RED head `916ecb199bf0ccd3cd822f639cf38f05122eefdf`: [the owned compaction shard](https://github.com/openclaw/openclaw/actions/runs/32777259581/job/97591345467) failed only the two new regressions. The extractor returned `123456789` in addition to the retained opaque hex suffix, and the strict all-preserved path cancelled; 98/99 files and 2,493/2,495 tests otherwise passed.
- Intermediate head `c9fec9d3824a68a4ea61b805dcd6ab29b6195297`: [the owned compaction shard](https://github.com/openclaw/openclaw/actions/runs/32778194883/job/97594520380) passed the safeguard file 134/134, all 99/99 shard files, and 2,495/2,495 tests.
- Final head `0cc40beb3d16bc3b5bf048e4a72446e9ad02c108`: [full exact-head CI](https://github.com/openclaw/openclaw/actions/runs/32903125198) completed successfully, including `openclaw/ci-gate` and the owned compaction shard.
- `git diff --check upstream/main...HEAD` passed against reviewed base `a99317ef97`.
- Production LOC: +8/-7 (net +1). Tests: +93/-0.

### Real Gateway behavior

A sanitized AWS Crabbox run exercised the real OpenClaw Gateway child and overflow-compaction path on exact PR head `0cc40beb3d16bc3b5bf048e4a72446e9ad02c108` with the repository's local OpenAI-compatible provider and a scenario-only overlay. Production files remained byte-identical to the PR head.

The scenario seeded prunable history with unambiguous decimal/scientific measurement noise and verified that the complete noise string was present in the overflowing request and absent from the compacted retry. It also verified that the retry fell below the overflow threshold, the mutation occurred exactly once, and the checkpoint persisted. Focused exact-head tests separately cover intentional retention of ambiguous integer-plus-letter identifiers such as `123456789ms`.

- [Exact-head AWS Crabbox proof](https://github.com/openclaw/openclaw/pull/126089#issuecomment-5417992160)
- [Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_7afa81b776ac)
- Result: 1/1 scenario passed; request size 1,469,894 -> 192,526 bytes; logical writes=1; wire successes=1; compactions=1; checkpoints=1.

## Scope checks

- Final pushed head: `0cc40beb3d16bc3b5bf048e4a72446e9ad02c108`.
- Production delta is +1 line at the identifier producer boundary.
- No Codex protocol, runtime, config, storage, or changelog changes.
- The unrelated in-flight compaction retention issue #125641 remains out of scope.

AI-assisted. The producer boundary, controlled pre-fix failure, focused post-fix suite, real Gateway path, source LOC, and current-main overlap were verified directly.

Punchcard-Session: quiet-willow-willow-6c
