### PR TITLE
fix(status): show failed telemetry diagnostics as unavailable

### DIFF
--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -51,6 +51,10 @@ function createProgressReporter(): ProgressReporter {
   };
 }
 
+function availableDiagnostics(value: unknown) {
+  return { ok: true as const, value };
+}
+
 function createBaseParams(
   listeners: NonNullable<DiagnosisParams["portUsage"]>["listeners"],
 ): DiagnosisParams {
@@ -271,7 +275,7 @@ describe("status-all diagnosis port checks", () => {
   it("summarizes inbound delivery telemetry proof counters", async () => {
     const params = createBaseParams([]);
     params.gatewayReachable = true;
-    params.deliveryDiagnostics = {
+    params.deliveryDiagnostics = availableDiagnostics({
       summary: {
         byType: {
           "message.received": 2,
@@ -282,7 +286,7 @@ describe("status-all diagnosis port checks", () => {
         },
       },
       events: [{ type: "session.turn.created", ts: Date.now() - 60_000 }],
-    };
+    });
 
     await appendStatusAllDiagnosis(params);
 
@@ -295,7 +299,7 @@ describe("status-all diagnosis port checks", () => {
 
   it("renders the shared redacted telemetry exporter summary", async () => {
     const params = createBaseParams([]);
-    params.exporterDiagnostics = {
+    params.exporterDiagnostics = availableDiagnostics({
       events: [
         {
           seq: 1,
@@ -311,7 +315,7 @@ describe("status-all diagnosis port checks", () => {
           error: "raw failure",
         },
       ],
-    };
+    });
 
     await appendStatusAllDiagnosis(params);
 
@@ -325,10 +329,40 @@ describe("status-all diagnosis port checks", () => {
     expect(output).not.toContain("raw failure");
   });
 
+  it("renders failed diagnostics as unavailable instead of empty", async () => {
+    const params = createBaseParams([]);
+    params.gatewayReachable = true;
+    const failedProbe = {
+      ok: false as const,
+      error:
+        "Error: diagnostics probe timed out at wss://probe-user:probe-pass@gateway.example/socket?token=probe-secret",
+    };
+    params.deliveryDiagnostics = failedProbe;
+    params.exporterDiagnostics = failedProbe;
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("! Telemetry exporters: unavailable");
+    expect(output).toContain(
+      "Exporter diagnostics failed: Error: diagnostics probe timed out at wss://***:***@gateway.example/socket?token=***",
+    );
+    expect(output).toContain("Retry: openclaw gateway stability --type telemetry.exporter");
+    expect(output).toContain("! Inbound delivery telemetry: unavailable");
+    expect(output).toContain(
+      "Delivery diagnostics failed: Error: diagnostics probe timed out at wss://***:***@gateway.example/socket?token=***",
+    );
+    expect(output).toContain("Retry: openclaw gateway stability");
+    expect(output).not.toContain("received 0 · dispatch 0/0 · turns 0 · processed 0");
+    expect(output).not.toContain("probe-user");
+    expect(output).not.toContain("probe-pass");
+    expect(output).not.toContain("probe-secret");
+  });
+
   it("keeps handled terminal delivery paths healthy without dispatch starts", async () => {
     const params = createBaseParams([]);
     params.gatewayReachable = true;
-    params.deliveryDiagnostics = {
+    params.deliveryDiagnostics = availableDiagnostics({
       summary: {
         byType: {
           "message.received": 1,
@@ -339,7 +373,7 @@ describe("status-all diagnosis port checks", () => {
         },
       },
       events: [{ type: "message.processed", ts: Date.now() - 30_000 }],
-    };
+    });
 
     await appendStatusAllDiagnosis(params);
 
@@ -353,7 +387,7 @@ describe("status-all diagnosis port checks", () => {
   it("keeps handled terminal dispatches healthy without agent turns", async () => {
     const params = createBaseParams([]);
     params.gatewayReachable = true;
-    params.deliveryDiagnostics = {
+    params.deliveryDiagnostics = availableDiagnostics({
       summary: {
         byType: {
           "message.received": 1,
@@ -364,7 +398,7 @@ describe("status-all diagnosis port checks", () => {
         },
       },
       events: [{ type: "message.processed", ts: Date.now() - 30_000 }],
-    };
+    });
 
     await appendStatusAllDiagnosis(params);
 
@@ -378,7 +412,7 @@ describe("status-all diagnosis port checks", () => {
   it("warns when received messages never reach agent turn creation", async () => {
     const params = createBaseParams([]);
     params.gatewayReachable = true;
-    params.deliveryDiagnostics = {
+    params.deliveryDiagnostics = availableDiagnostics({
       summary: {
         byType: {
           "message.received": 3,
@@ -389,7 +423,7 @@ describe("status-all diagnosis port checks", () => {
         },
       },
       events: [{ type: "message.dispatch.started", ts: Date.now() - 120_000 }],
-    };
+    });
 
     await appendStatusAllDiagnosis(params);
 
@@ -421,6 +455,12 @@ describe("status-all diagnosis port checks", () => {
       ].join("\n"),
     };
     params.gatewayReachable = true;
+    const failedProbe = {
+      ok: false as const,
+      error: "Error: diagnostics probe unavailable in node-only mode",
+    };
+    params.deliveryDiagnostics = failedProbe;
+    params.exporterDiagnostics = failedProbe;
 
     await appendStatusAllDiagnosis(params);
 
@@ -432,6 +472,8 @@ describe("status-all diagnosis port checks", () => {
     expect(output).not.toContain("Channel issues skipped (gateway unreachable)");
     expect(output).not.toContain("Gateway health:");
     expect(output).not.toContain("Inbound delivery telemetry: unavailable");
+    expect(output).not.toContain("Telemetry exporters: unavailable");
+    expect(output).not.toContain("Retry: openclaw gateway stability");
   });
 
   it("does not read or display stale stderr tails on Darwin", async () => {

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -1,7 +1,9 @@
 // Appends the read-only diagnosis section for `openclaw status --all`.
 // Every line that can include logs, config, or connection details is redacted before display.
 
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import type { ProgressReporter } from "../../cli/progress.js";
 import { formatConfigIssueLine } from "../../config/issue-format.js";
 import {
@@ -24,6 +26,7 @@ import {
   formatPluginCompatibilityNotice,
   type PluginCompatibilityNotice,
 } from "../../plugins/status.js";
+import type { StatusGatewayDiagnosticsResult } from "../status-runtime-shared.ts";
 import {
   formatUpdateRestartActionLines,
   formatUpdateRestartStatusValue,
@@ -157,8 +160,8 @@ export async function appendStatusAllDiagnosis(params: {
   pluginCompatibility: PluginCompatibilityNotice[];
   channelsStatus: unknown;
   channelIssues: ChannelIssueLike[];
-  deliveryDiagnostics: unknown;
-  exporterDiagnostics: unknown;
+  deliveryDiagnostics: StatusGatewayDiagnosticsResult | null;
+  exporterDiagnostics: StatusGatewayDiagnosticsResult | null;
   agentStatus?: AgentStatusLike;
   gatewayReachable: boolean;
   health: unknown;
@@ -170,6 +173,17 @@ export async function appendStatusAllDiagnosis(params: {
     const icon = status === "ok" ? ok("✓") : status === "warn" ? warn("!") : fail("✗");
     const colored = status === "ok" ? ok(label) : status === "warn" ? warn(label) : fail(label);
     lines.push(`${icon} ${colored}`);
+  };
+  const emitUnavailableDiagnostics = (diagnostic: {
+    label: string;
+    detail: string;
+    retry: string;
+  }) => {
+    emitCheck(`${diagnostic.label}: unavailable`, "warn");
+    lines.push(
+      `  ${muted(sanitizeTerminalText(redactStatusSecrets(redactSensitiveUrlLikeString(diagnostic.detail))))}`,
+    );
+    lines.push(`  ${muted(`Retry: ${diagnostic.retry}`)}`);
   };
 
   lines.push("");
@@ -339,33 +353,41 @@ export async function appendStatusAllDiagnosis(params: {
     }
   }
 
-  const exporterSummary = formatTelemetryExporterSummary(params.exporterDiagnostics);
-  if (exporterSummary) {
-    emitCheck(exporterSummary.title, exporterSummary.status);
-    for (const line of exporterSummary.lines) {
-      lines.push(`  ${muted(line)}`);
+  if (!params.nodeOnlyGateway && params.exporterDiagnostics) {
+    if (params.exporterDiagnostics.ok) {
+      const exporterSummary = formatTelemetryExporterSummary(params.exporterDiagnostics.value);
+      if (exporterSummary) {
+        emitCheck(exporterSummary.title, exporterSummary.status);
+        for (const line of exporterSummary.lines) {
+          lines.push(`  ${muted(line)}`);
+        }
+      }
+    } else {
+      emitUnavailableDiagnostics({
+        label: "Telemetry exporters",
+        detail: `Exporter diagnostics failed: ${params.exporterDiagnostics.error}`,
+        retry: "openclaw gateway stability --type telemetry.exporter",
+      });
     }
   }
 
-  if (params.deliveryDiagnostics != null) {
-    if (isDeliveryDiagnosticsLike(params.deliveryDiagnostics)) {
-      const received = countDeliveryEvent(params.deliveryDiagnostics, "message.received");
-      const dispatchStarted = countDeliveryEvent(
-        params.deliveryDiagnostics,
-        "message.dispatch.started",
-      );
+  if (!params.nodeOnlyGateway && params.deliveryDiagnostics?.ok) {
+    if (isDeliveryDiagnosticsLike(params.deliveryDiagnostics.value)) {
+      const deliveryDiagnostics = params.deliveryDiagnostics.value;
+      const received = countDeliveryEvent(deliveryDiagnostics, "message.received");
+      const dispatchStarted = countDeliveryEvent(deliveryDiagnostics, "message.dispatch.started");
       const dispatchCompleted = countDeliveryEvent(
-        params.deliveryDiagnostics,
+        deliveryDiagnostics,
         "message.dispatch.completed",
       );
-      const turnsCreated = countDeliveryEvent(params.deliveryDiagnostics, "session.turn.created");
-      const processed = countDeliveryEvent(params.deliveryDiagnostics, "message.processed");
+      const turnsCreated = countDeliveryEvent(deliveryDiagnostics, "session.turn.created");
+      const processed = countDeliveryEvent(deliveryDiagnostics, "message.processed");
       const hasReceivedWithoutDispatch = received > 0 && dispatchStarted === 0 && processed === 0;
       const hasDispatchWithoutTurn =
         dispatchStarted > 0 && turnsCreated === 0 && processed < dispatchStarted;
       const dispatchGap = dispatchStarted - dispatchCompleted;
       const hasDispatchGap = dispatchGap >= 2;
-      const latestAgeMs = latestDeliveryEventAgeMs(params.deliveryDiagnostics);
+      const latestAgeMs = latestDeliveryEventAgeMs(deliveryDiagnostics);
       emitCheck(
         `Inbound delivery telemetry: received ${received} · dispatch ${dispatchStarted}/${dispatchCompleted} · turns ${turnsCreated} · processed ${processed}`,
         hasReceivedWithoutDispatch || hasDispatchWithoutTurn || hasDispatchGap ? "warn" : "ok",
@@ -389,10 +411,22 @@ export async function appendStatusAllDiagnosis(params: {
         );
       }
     } else {
-      emitCheck("Inbound delivery telemetry: unavailable", "warn");
+      emitUnavailableDiagnostics({
+        label: "Inbound delivery telemetry",
+        detail: "Delivery diagnostics returned an invalid response.",
+        retry: "openclaw gateway stability",
+      });
     }
-  } else if (params.gatewayReachable && !params.nodeOnlyGateway) {
-    emitCheck("Inbound delivery telemetry: unavailable", "warn");
+  } else if (
+    !params.nodeOnlyGateway &&
+    params.deliveryDiagnostics &&
+    !params.deliveryDiagnostics.ok
+  ) {
+    emitUnavailableDiagnostics({
+      label: "Inbound delivery telemetry",
+      detail: `Delivery diagnostics failed: ${params.deliveryDiagnostics.error}`,
+      retry: "openclaw gateway stability",
+    });
   }
 
   params.progress.setLabel("Reading logs…");

--- a/src/commands/status-all/report-data.test.ts
+++ b/src/commands/status-all/report-data.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(async () => ({ path: "/tmp/openclaw.json" })),
   inspectPortUsage: vi.fn(async () => null),
   resolveGatewayBindHost: vi.fn(async () => "127.0.0.1"),
-  resolveStatusGatewayDiagnosticsSafe: vi.fn(async () => null),
+  resolveStatusGatewayDiagnosticsSafe: vi.fn(async () => ({ ok: true, value: {} })),
   resolveStatusGatewayHealthSafe: vi.fn(async () => undefined),
   resolveNodeExecEligibility: vi.fn(() => ({ canExec: false })),
   loadExecApprovalsReadOnly: vi.fn(() => ({ version: 1, agents: {} })),
@@ -63,7 +63,7 @@ import { buildStatusAllReportData } from "./report-data.js";
 describe("buildStatusAllReportData", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.resolveStatusGatewayDiagnosticsSafe.mockResolvedValue(null);
+    mocks.resolveStatusGatewayDiagnosticsSafe.mockResolvedValue({ ok: true, value: {} });
     mocks.resolveStatusGatewayHealthSafe.mockResolvedValue(undefined);
   });
 

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -20,6 +20,7 @@ import {
 import {
   resolveStatusGatewayDiagnosticsSafe,
   resolveStatusGatewayHealthSafe,
+  type StatusGatewayDiagnosticsResult,
   type resolveStatusServiceSummaries,
 } from "../status-runtime-shared.ts";
 import { formatUpdateRestartStatusValue } from "../status-update-restart.ts";
@@ -81,8 +82,8 @@ async function resolveStatusAllLocalDiagnosis(params: {
     agentStatus: StatusScanOverviewResult["agentStatus"];
     gatewayReachable: boolean;
     health: StatusGatewayHealthSafe | undefined;
-    deliveryDiagnostics: unknown;
-    exporterDiagnostics: unknown;
+    deliveryDiagnostics: StatusGatewayDiagnosticsResult | null;
+    exporterDiagnostics: StatusGatewayDiagnosticsResult | null;
     nodeOnlyGateway: NodeOnlyGatewayInfo | null;
   };
 }> {

--- a/src/commands/status-runtime-shared.test.ts
+++ b/src/commands/status-runtime-shared.test.ts
@@ -448,18 +448,35 @@ describe("status-runtime-shared", () => {
   });
 
   it("requests the typed exporter stability projection", async () => {
-    await resolveStatusGatewayDiagnosticsSafe({
-      config: { gateway: {} },
-      timeoutMs: 4321,
-      gatewayReachable: true,
-      type: "telemetry.exporter",
-    });
+    await expect(
+      resolveStatusGatewayDiagnosticsSafe({
+        config: { gateway: {} },
+        timeoutMs: 4321,
+        gatewayReachable: true,
+        type: "telemetry.exporter",
+      }),
+    ).resolves.toEqual({ ok: true, value: { ok: true } });
 
     expect(mocks.callGateway).toHaveBeenCalledWith({
       method: "diagnostics.stability",
       params: { limit: 1000, type: "telemetry.exporter" },
       timeoutMs: 4321,
       config: { gateway: {} },
+    });
+  });
+
+  it("preserves failed gateway diagnostics as a typed result", async () => {
+    mocks.callGateway.mockRejectedValueOnce(new Error("diagnostics probe timed out"));
+
+    await expect(
+      resolveStatusGatewayDiagnosticsSafe({
+        config: { gateway: {} },
+        timeoutMs: 4321,
+        gatewayReachable: true,
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "Error: diagnostics probe timed out",
     });
   });
 

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -1,6 +1,7 @@
 // Shared runtime probes used by status text and JSON commands.
 // Heavy modules stay lazily loaded so fast status output avoids security/provider/gateway costs.
 
+import type { Result } from "@openclaw/normalization-core/result";
 import { listAgentIds, resolveSystemAgentTargetAgentId } from "../agents/agent-scope-config.js";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
@@ -205,7 +206,9 @@ export async function resolveStatusGatewayHealthSafe(params: {
   }).catch((err: unknown) => ({ error: String(err) }));
 }
 
-/** Reads gateway delivery diagnostics when reachable, returning null on failures. */
+export type StatusGatewayDiagnosticsResult = Result<unknown, string>;
+
+/** Reads gateway diagnostics while preserving whether data or an unavailable outcome was observed. */
 export async function resolveStatusGatewayDiagnosticsSafe(params: {
   config: OpenClawConfig;
   timeoutMs?: number;
@@ -216,9 +219,9 @@ export async function resolveStatusGatewayDiagnosticsSafe(params: {
     token?: string;
     password?: string;
   };
-}) {
+}): Promise<StatusGatewayDiagnosticsResult> {
   if (!params.gatewayReachable) {
-    return null;
+    return { ok: false, error: "gateway unreachable" };
   }
   const { callGateway } = await loadGatewayCallModule();
   return await callGateway<unknown>({
@@ -227,7 +230,10 @@ export async function resolveStatusGatewayDiagnosticsSafe(params: {
     timeoutMs: params.timeoutMs,
     config: params.config,
     ...params.callOverrides,
-  }).catch(() => null);
+  }).then<StatusGatewayDiagnosticsResult, StatusGatewayDiagnosticsResult>(
+    (value) => ({ ok: true, value }),
+    (error: unknown) => ({ ok: false, error: String(error) }),
+  );
 }
 
 /** Reads the most recent gateway heartbeat only when the gateway probe succeeded. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw status --all` could see inbound delivery diagnostics reported as generic unavailable while telemetry exporter diagnostics disappeared entirely when the shared Gateway diagnostics RPC failed. The RPC helper collapsed failures to `null`, so downstream consumers could not distinguish a failed probe from an empty successful result.

## Why This Change Was Made

The shared status diagnostics owner now carries a typed success-or-error result through collection into the status renderer. Failed delivery and exporter probes render explicit unavailable sections with terminal-safe, URL-credential-redacted, secret-redacted details and direct retry commands. Successful output is unchanged, and node-only status continues to suppress Gateway-only diagnostics.

The branch previously carried temporary red-main repair commit `1c03a6bae486437d094500a28a96a7e445f97d68`. Current `main` now has the canonical same-or-better Gateway context resolution from #125946 and later follow-ups: direct delivery is instance-bound, does not accept `resolveGatewayContext`, and has regression coverage asserting that dispatch options omit it. The temporary repair was therefore superseded and dropped completely during the rebase. No agent, Gateway, or plugin request-scope changes remain.

No JSON, Gateway protocol, config, storage, documentation, release, changelog, or dependency surface changes. AI-assisted; no agent transcript is included.

## User Impact

Operators get a visible, actionable result when either status diagnostics probe fails instead of a misleading empty counter set or a missing section. The report explains which probe failed and how to retry it without exposing terminal control text, URL credentials, sensitive query values, or known secret material.

## Evidence

- Rebased onto `origin/main` `6ccc57b331ae03de5c5df61cf00208769c6a8267`; rewritten head: `4e1593c27df380534b535ecdd83b8b917d0504db`.
- `node scripts/run-vitest.mjs src/commands/status-runtime-shared.test.ts src/commands/status-all/report-data.test.ts src/commands/status-all/diagnosis.test.ts` — 44/44 tests passed.
- Direct formatting: `./node_modules/.bin/oxfmt --write` on the six changed files; follow-up `--check` passed.
- Scoped lint: `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json` on the six changed files — passed.
- Production typecheck: `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/pr-126092-status-core.tsbuildinfo` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh P1 Codex autoreview against `origin/main` reported no accepted/actionable findings (overall correctness 0.91).
- Source-blind isolated CLI proof could not start because the stale-dist rebuild could not find the pinned pnpm binary link. Per task direction, no install was run. The focused renderer regression covers the observable unavailable output and URL redaction; exact-head pull-request CI must rerun for aggregate proof.
- Production LOC: +68/-27 (net +41). Tests: +77/-18 (net +59). The production growth is the typed failure result plus one shared safe unavailable-rendering path for both diagnostic probes.

The earlier successful CI run belongs to the superseded head and is not evidence for this rewrite. Exact-head pull-request CI must attach and rerun for `4e1593c27df380534b535ecdd83b8b917d0504db`.
