### PR TITLE
fix(cron): prune terminal task history after seven days

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -844,7 +844,7 @@ Disable automations: `cron.enabled: false` or `OPENCLAW_SKIP_CRON=1`.
 
   </Accordion>
   <Accordion title="Maintenance">
-    `cron.sessionRetention` (default `24h`, `false` or `"0h"` disables) prunes isolated run-session entries. Run history keeps the newest 2000 terminal rows per job; lost rows retain their 24-hour cleanup window.
+    `cron.sessionRetention` (default `24h`, `false` or `"0h"` disables) prunes isolated run-session entries. Terminal run history is retained for 7 days (`lost` rows for 24 hours), with the newest 2000 rows per job and history class enforced as an additional ceiling.
   </Accordion>
   <Accordion title="Legacy store migration">
     On upgrade, run `openclaw doctor --fix` to import historical `~/.openclaw/cron/jobs.json`, `jobs-state.json`, `jobs-quarantine.json`, and `runs/*.jsonl` files into SQLite and archive the originals with a `.migrated` suffix. Malformed job rows remain recoverable in SQLite while valid jobs keep running.

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -233,7 +233,7 @@ The scheduler does not classify final-output prose or approval-looking refusal p
 Retention behavior:
 
 - `cron.sessionRetention` (default `24h`, or `false` to disable; a zero duration such as `"0h"` also disables) prunes completed isolated run sessions.
-- Run history keeps the newest 2000 terminal rows per job. Lost rows retain the standard 24-hour lost-task cleanup window.
+- Terminal run history is retained for 7 days (`lost` rows for 24 hours), with the newest 2000 rows per job and history class enforced as an additional ceiling.
 
 ## Migrating older jobs
 

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -215,8 +215,10 @@ openclaw sessions cleanup --json
 
 - Scope note: `openclaw sessions cleanup` maintains session stores,
   transcripts, trajectory rows, and legacy trajectory sidecars. It does not
-  prune cron run history, which automatically keeps the newest 2000 rows per job
-  ([Cron configuration](/automation/cron-jobs#configuration)).
+  prune cron run history. Task maintenance retains terminal cron history for 7
+  days (`lost` rows for 24 hours) and enforces the newest 2000 rows per job and
+  history class as an additional ceiling ([Task maintenance](/automation/tasks#automatic-maintenance),
+  [Cron configuration](/automation/cron-jobs#configuration)).
 - Cleanup also prunes unreferenced legacy/archive transcript artifacts,
   compaction checkpoints, and trajectory sidecars older than
   `session.maintenance.pruneAfter`; artifacts still referenced by SQLite

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1646,7 +1646,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 - `enabled`: execute stored automation jobs (default: `true`). Set `false` to pause all automation execution without deleting jobs.
 - `triggers.enabled`: run event-driven automation triggers (default: `true`). Set `false` to disable condition triggers, script payloads, and stream schedules.
 - `sessionRetention`: how long to keep completed isolated automation run sessions before pruning SQLite session rows. Also controls cleanup of archived deleted automation transcripts. Default: `24h`; set `false` or a zero duration such as `"0h"` to disable (negative durations are invalid).
-- Run history automatically keeps the newest 2000 terminal rows per job. Lost rows retain their 24-hour cleanup window.
+- Terminal run history is retained for 7 days (`lost` rows for 24 hours), with the newest 2000 rows per job and history class enforced as an additional ceiling.
 - `webhookToken`: bearer token used for automation webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.
 - `webhookSsrfPolicy`: shared outbound SSRF policy for primary, completion, failure-destination, and failure-alert webhooks. Private/internal targets are blocked when omitted. Prefer exact `allowedHostnames`; use `dangerouslyAllowPrivateNetwork: true` only for trusted private-network receivers. The narrow fake-IP proxy flags are `allowRfc2544BenchmarkRange` and `allowIpv6UniqueLocalRange`.
 

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -415,7 +415,7 @@ candidate contains a redacted secret placeholder such as `***` or `[redacted]`.
     ```
 
     - `sessionRetention`: prune completed isolated run sessions from SQLite session rows (default `24h`; set `false` or a zero duration such as `"0h"` to disable).
-    - Run history automatically keeps the newest 2000 terminal rows per job; lost rows retain their 24-hour cleanup window.
+    - Terminal run history is retained for 7 days (`lost` rows for 24 hours), with the newest 2000 rows per job and history class enforced as an additional ceiling.
     - See [Cron jobs](/automation/cron-jobs) for feature overview and CLI examples.
 
   </Accordion>

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -110,7 +110,7 @@ artifacts before importing.
 Isolated cron runs create their own session entries/transcripts with dedicated retention:
 
 - `cron.sessionRetention` (default `"24h"`) prunes old isolated cron run sessions from the store; `false` or a zero duration such as `"0h"` disables.
-- Run history keeps the newest 2000 terminal rows per cron job. Lost rows retain their 24-hour cleanup window.
+- Terminal run history is retained for 7 days (`lost` rows for 24 hours), with the newest 2000 rows per job and history class enforced as an additional ceiling.
 
 When cron force-creates a new isolated run session, it sanitizes the previous `cron:<jobId>` session entry before writing the new row: it carries safe preferences (thinking/fast/verbose/reasoning settings, labels, display name) and explicit user-selected model/auth overrides, but drops ambient conversation context (channel/group routing, send/queue policy, elevation, origin, ACP runtime binding) so a fresh isolated run cannot inherit stale delivery or runtime authority from an older run.
 

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -231,7 +231,7 @@ describe("cron service timer seam coverage", () => {
     expect(task.startedAt).toBe(now);
     expect(task.lastEventAt).toBe(now);
     expect(task.endedAt).toBe(now);
-    expect(task.cleanupAfter).toBeUndefined();
+    expect(task.cleanupAfter).toBe(now + 7 * 24 * 60 * 60_000);
 
     const delays = timeoutSpy.mock.calls
       .map(([, delay]) => delay)

--- a/src/tasks/cron-history-retention.ts
+++ b/src/tasks/cron-history-retention.ts
@@ -75,6 +75,5 @@ export function shouldPruneTerminalTask(
   if (cronHistoryOverflowTaskIds.has(task.taskId)) {
     return true;
   }
-  const cleanupAfter = resolveEffectiveTaskCleanupAfter(task);
-  return cleanupAfter !== undefined && now >= cleanupAfter;
+  return now >= resolveEffectiveTaskCleanupAfter(task);
 }

--- a/src/tasks/task-registry-mutation.ts
+++ b/src/tasks/task-registry-mutation.ts
@@ -168,8 +168,7 @@ export function updateTask(taskId: string, patch: Partial<TaskRecord>): TaskReco
   }
   if (isTerminalTaskStatus(next.status) && typeof next.cleanupAfter !== "number") {
     const createdAt = next.createdAt ?? Date.now();
-    const cleanupAfter = resolveTaskCleanupAfter({ ...next, createdAt });
-    Object.assign(next, cleanupAfter === undefined ? {} : { cleanupAfter });
+    next.cleanupAfter = resolveTaskCleanupAfter({ ...next, createdAt });
   }
   const sessionIndexChanged =
     normalizeOptionalString(current.ownerKey) !== normalizeOptionalString(next.ownerKey) ||

--- a/src/tasks/task-registry-record-api.ts
+++ b/src/tasks/task-registry-record-api.ts
@@ -263,8 +263,7 @@ export function createTaskRecord(params: {
     ...(params.detail !== undefined ? { detail: structuredClone(params.detail) } : {}),
   });
   if (isTerminalTaskStatus(record.status) && typeof record.cleanupAfter !== "number") {
-    const cleanupAfter = resolveTaskCleanupAfter(record);
-    Object.assign(record, cleanupAfter === undefined ? {} : { cleanupAfter });
+    record.cleanupAfter = resolveTaskCleanupAfter(record);
   }
   const requesterOrigin = normalizeDeliveryContext(params.requesterOrigin);
   const deliveryState = requesterOrigin

--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -200,7 +200,7 @@ describe("task-registry audit", () => {
     expect(findings.map((finding) => finding.code)).toEqual(["lost"]);
   });
 
-  it("does not flag count-retained cron history as missing cleanup", () => {
+  it("flags terminal cron history that is missing cleanup", () => {
     const findings = listTaskAuditFindings({
       tasks: [
         createTask({
@@ -213,6 +213,6 @@ describe("task-registry audit", () => {
       ],
     });
 
-    expect(findings).toEqual([]);
+    expect(findings.map((finding) => finding.code)).toEqual(["missing_cleanup"]);
   });
 });

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -8,7 +8,7 @@ import {
   type TaskAuditSummary,
 } from "./task-registry.audit.shared.js";
 import type { TaskRecord } from "./task-registry.types.js";
-import { resolveEffectiveTaskCleanupAfter, resolveTaskCleanupAfter } from "./task-retention.js";
+import { resolveEffectiveTaskCleanupAfter } from "./task-retention.js";
 
 type TaskAuditOptions = {
   now?: number;
@@ -134,9 +134,7 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
     if (task.status === "lost") {
       const effectiveCleanupAfter = resolveEffectiveTaskCleanupAfter(task);
       const retainedUntilCleanup =
-        typeof task.cleanupAfter === "number" &&
-        effectiveCleanupAfter !== undefined &&
-        effectiveCleanupAfter > now;
+        typeof task.cleanupAfter === "number" && effectiveCleanupAfter > now;
       findings.push(
         createFinding({
           severity: retainedUntilCleanup ? "warn" : "error",
@@ -167,8 +165,7 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
       task.status !== "lost" &&
       task.status !== "queued" &&
       task.status !== "running" &&
-      typeof task.cleanupAfter !== "number" &&
-      resolveTaskCleanupAfter(task) !== undefined
+      typeof task.cleanupAfter !== "number"
     ) {
       findings.push(
         createFinding({
@@ -196,7 +193,6 @@ function isRetainedLostTaskAuditFinding(finding: TaskAuditFinding, now = Date.no
     finding.code === "lost" &&
     finding.task.status === "lost" &&
     typeof finding.task.cleanupAfter === "number" &&
-    typeof cleanupAfter === "number" &&
     cleanupAfter > now
   );
 }
@@ -238,10 +234,7 @@ export function summarizeRetainedLostTaskAuditFindings(
     }
     count += 1;
     const cleanupAfter = resolveEffectiveTaskCleanupAfter(finding.task);
-    if (
-      typeof cleanupAfter === "number" &&
-      (nextCleanupAfter === undefined || cleanupAfter < nextCleanupAfter)
-    ) {
+    if (nextCleanupAfter === undefined || cleanupAfter < nextCleanupAfter) {
       nextCleanupAfter = cleanupAfter;
     }
   }

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -22,6 +22,7 @@ import {
 } from "./task-runtime.test-helpers.js";
 
 const GRACE_EXPIRED_MS = 10 * 60_000;
+const DEFAULT_TASK_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
 function makeStaleTask(overrides: Partial<TaskRecord>): TaskRecord {
   const now = Date.now();
@@ -899,7 +900,7 @@ describe("task-registry maintenance issue #60299", () => {
         status: "succeeded",
         endedAt: now + index + 1,
         lastEventAt: now + index + 1,
-        cleanupAfter: 0,
+        cleanupAfter: now + DEFAULT_TASK_RETENTION_MS,
         detail: { kind: "cron-run", status: "ok", storeKey: "store:history" },
       }),
     );
@@ -935,7 +936,7 @@ describe("task-registry maintenance issue #60299", () => {
       status: "succeeded",
       endedAt: now,
       lastEventAt: now,
-      cleanupAfter: 0,
+      cleanupAfter: now + DEFAULT_TASK_RETENTION_MS,
       detail: { kind: "cron-run", status: "ok", storeKey },
     });
     const quietRuns = Array.from({ length: CRON_HISTORY_KEEP_PER_JOB + 1 }, (_, index) =>
@@ -946,7 +947,7 @@ describe("task-registry maintenance issue #60299", () => {
         status: "succeeded",
         endedAt: now + index + 1,
         lastEventAt: now + index + 1,
-        cleanupAfter: 0,
+        cleanupAfter: now + DEFAULT_TASK_RETENTION_MS,
         detail: { storeKey },
       }),
     );
@@ -976,7 +977,7 @@ describe("task-registry maintenance issue #60299", () => {
         startedAt: now + index,
         endedAt: now + CRON_HISTORY_KEEP_PER_JOB + 1,
         lastEventAt: now + CRON_HISTORY_KEEP_PER_JOB + 1,
-        cleanupAfter: 0,
+        cleanupAfter: now + DEFAULT_TASK_RETENTION_MS,
         detail: { kind: "cron-run", status: "ok", storeKey: "store:same-ms" },
       }),
     );
@@ -1000,7 +1001,7 @@ describe("task-registry maintenance issue #60299", () => {
         status: "succeeded",
         endedAt: now + index + 2,
         lastEventAt: now + index + 2,
-        cleanupAfter: 0,
+        cleanupAfter: now + DEFAULT_TASK_RETENTION_MS,
         detail: { kind: "cron-run", status: "ok", storeKey: "store:a" },
       }),
     );
@@ -1011,7 +1012,7 @@ describe("task-registry maintenance issue #60299", () => {
       status: "succeeded",
       endedAt: now + 1,
       lastEventAt: now + 1,
-      cleanupAfter: 0,
+      cleanupAfter: now + DEFAULT_TASK_RETENTION_MS,
       detail: { kind: "cron-run", status: "ok", storeKey: "store:b" },
     });
     const { currentTasks } = createTaskRegistryMaintenanceHarness({
@@ -1025,10 +1026,9 @@ describe("task-registry maintenance issue #60299", () => {
     expect(currentTasks.has(storeBTask.taskId)).toBe(true);
   });
 
-  it("still stamps non-cron terminal rows with default retention", async () => {
+  it("stamps recent terminal cron rows with default retention", async () => {
     const endedAt = Date.now();
     const task = makeStaleTask({
-      runtime: "subagent",
       status: "succeeded",
       endedAt,
       lastEventAt: endedAt,
@@ -1036,12 +1036,30 @@ describe("task-registry maintenance issue #60299", () => {
     });
     const { currentTasks } = createTaskRegistryMaintenanceHarness({ tasks: [task] });
 
+    expect(previewTaskRegistryMaintenance().cleanupStamped).toBe(1);
     const result = await runTaskRegistryMaintenance();
 
     expect(result.cleanupStamped).toBe(1);
     expect(requireTaskRecord(currentTasks, task.taskId).cleanupAfter).toBe(
-      endedAt + 7 * 24 * 60 * 60_000,
+      endedAt + DEFAULT_TASK_RETENTION_MS,
     );
+  });
+
+  it("prunes terminal cron rows after default retention", async () => {
+    const endedAt = Date.now() - DEFAULT_TASK_RETENTION_MS - 1;
+    const task = makeStaleTask({
+      status: "succeeded",
+      endedAt,
+      lastEventAt: endedAt,
+      cleanupAfter: undefined,
+    });
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({ tasks: [task] });
+
+    expect(previewTaskRegistryMaintenance().pruned).toBe(1);
+    const result = await runTaskRegistryMaintenance();
+
+    expect(result.pruned).toBe(1);
+    expect(currentTasks.has(task.taskId)).toBe(false);
   });
 
   it("still prunes lost cron rows after 24 hours", async () => {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -490,15 +490,7 @@ function hasDetachedTaskRecoveryHook(): boolean {
 }
 
 function shouldStampCleanupAfter(task: TaskRecord): boolean {
-  return (
-    isTerminalTask(task) &&
-    typeof task.cleanupAfter !== "number" &&
-    resolveTaskCleanupAfter(task) !== undefined
-  );
-}
-
-function resolveCleanupAfter(task: TaskRecord): number | undefined {
-  return resolveTaskCleanupAfter(task);
+  return isTerminalTask(task) && typeof task.cleanupAfter !== "number";
 }
 
 function taskReferenceAt(task: TaskRecord): number {
@@ -698,7 +690,7 @@ function markTaskLost(
     ...task,
     status: "lost",
     endedAt: lostAt,
-  })!;
+  });
   const updated =
     taskRegistryMaintenanceRuntime.markTaskLostById({
       taskId: task.taskId,
@@ -747,7 +739,7 @@ function projectTaskRecovered(task: TaskRecord, recovery: CronTerminalRecovery):
     ...projected,
     ...(typeof projected.cleanupAfter === "number"
       ? {}
-      : { cleanupAfter: resolveCleanupAfter(projected) }),
+      : { cleanupAfter: resolveTaskCleanupAfter(projected) }),
   };
 }
 
@@ -767,7 +759,7 @@ function projectTaskLost(
     ...projected,
     ...(typeof projected.cleanupAfter === "number"
       ? {}
-      : { cleanupAfter: resolveCleanupAfter(projected) }),
+      : { cleanupAfter: resolveTaskCleanupAfter(projected) }),
   };
 }
 
@@ -1114,12 +1106,10 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
       continue;
     }
     if (shouldStampCleanupAfter(current)) {
-      const cleanupAfter = resolveCleanupAfter(current);
       if (
-        cleanupAfter !== undefined &&
         taskRegistryMaintenanceRuntime.setTaskCleanupAfterById({
           taskId: current.taskId,
-          cleanupAfter,
+          cleanupAfter: resolveTaskCleanupAfter(current),
         })
       ) {
         cleanupStamped += 1;

--- a/src/tasks/task-retention.test.ts
+++ b/src/tasks/task-retention.test.ts
@@ -9,14 +9,12 @@ describe("task retention", () => {
   it("keeps lost tasks on a shorter retention window", () => {
     expect(
       resolveTaskCleanupAfter({
-        runtime: "subagent",
         status: "lost",
         createdAt: 10,
       }),
     ).toBe(10 + LOST_TASK_RETENTION_MS);
     expect(
       resolveTaskCleanupAfter({
-        runtime: "subagent",
         status: "failed",
         createdAt: 10,
       }),
@@ -26,7 +24,6 @@ describe("task retention", () => {
   it("stamps cleanupAfter from terminal task timing", () => {
     expect(
       resolveTaskCleanupAfter({
-        runtime: "subagent",
         status: "lost",
         createdAt: 1,
         lastEventAt: 2,
@@ -38,7 +35,6 @@ describe("task retention", () => {
   it("clamps old lost cleanupAfter values to the shorter retention window", () => {
     expect(
       resolveEffectiveTaskCleanupAfter({
-        runtime: "subagent",
         status: "lost",
         createdAt: 1,
         endedAt: 10,
@@ -50,35 +46,11 @@ describe("task retention", () => {
   it("preserves explicit cleanupAfter for non-lost terminal tasks", () => {
     expect(
       resolveEffectiveTaskCleanupAfter({
-        runtime: "subagent",
         status: "failed",
         createdAt: 1,
         endedAt: 10,
         cleanupAfter: 99,
       }),
     ).toBe(99);
-  });
-
-  it("does not stamp or honor cleanupAfter for terminal cron history", () => {
-    const task = {
-      runtime: "cron" as const,
-      status: "failed" as const,
-      createdAt: 1,
-      endedAt: 10,
-      cleanupAfter: 99,
-    };
-    expect(resolveTaskCleanupAfter(task)).toBeUndefined();
-    expect(resolveEffectiveTaskCleanupAfter(task)).toBeUndefined();
-  });
-
-  it("keeps lost cron tasks on the 24-hour window", () => {
-    expect(
-      resolveTaskCleanupAfter({
-        runtime: "cron",
-        status: "lost",
-        createdAt: 1,
-        endedAt: 10,
-      }),
-    ).toBe(10 + LOST_TASK_RETENTION_MS);
   });
 });

--- a/src/tasks/task-retention.ts
+++ b/src/tasks/task-retention.ts
@@ -10,25 +10,16 @@ function resolveTaskRetentionMs(status: TaskStatus): number {
 }
 
 export function resolveTaskCleanupAfter(
-  task: Pick<TaskRecord, "runtime" | "status" | "endedAt" | "lastEventAt" | "createdAt">,
-): number | undefined {
-  if (task.runtime === "cron" && task.status !== "lost") {
-    return undefined;
-  }
+  task: Pick<TaskRecord, "status" | "endedAt" | "lastEventAt" | "createdAt">,
+): number {
   const terminalAt = task.endedAt ?? task.lastEventAt ?? task.createdAt;
   return terminalAt + resolveTaskRetentionMs(task.status);
 }
 
 export function resolveEffectiveTaskCleanupAfter(
-  task: Pick<
-    TaskRecord,
-    "runtime" | "status" | "endedAt" | "lastEventAt" | "createdAt" | "cleanupAfter"
-  >,
-): number | undefined {
+  task: Pick<TaskRecord, "status" | "endedAt" | "lastEventAt" | "createdAt" | "cleanupAfter">,
+): number {
   const statusCleanupAfter = resolveTaskCleanupAfter(task);
-  if (statusCleanupAfter === undefined) {
-    return undefined;
-  }
   if (typeof task.cleanupAfter !== "number") {
     return statusCleanupAfter;
   }


### PR DESCRIPTION
Closes #126063

## What Problem This Solves

Fixes an issue where successful and failed cron task records never aged out, even though terminal tasks are documented as retained for seven days. Because the existing 2,000-row ceiling is scoped per job and history class, cron history could still accumulate into many thousands of rows.

## Why This Change Was Made

Removes the cron-specific retention exemption so the shared terminal-task policy applies consistently: seven days for terminal tasks and 24 hours for lost tasks. The existing newest-2,000-rows-per-job-and-class ceiling remains as an additional bound; this adds no config, schema, or migration surface.

## User Impact

Operators can expect terminal cron task history to follow the documented retention window instead of accumulating indefinitely below each partition ceiling.

## Evidence

- Captured the pre-fix cron timer failure: cleanupAfter was undefined instead of endedAt plus seven days.
- Focused task-registry, timer, retention, audit, and maintenance validation passed (190 tests).
- Post-rebase focused validation passed: pnpm test src/cron/service/timer.test.ts src/tasks/task-retention.test.ts src/tasks/task-registry.maintenance.issue-60299.test.ts (55 tests across 3 shards).
- Type-aware Oxlint passed for every changed TypeScript file; three pinned Knip scans were clean.
- Local autoreview completed with no actionable findings.
- pnpm check:changed reaches an unrelated type error also reproducible on current main: src/agents/subagents/announce/subagent-announce-direct-delivery.ts:85.
- Testing level: fully tested at the focused unit/integration level. Live behavior proof was not run per maintainer direction; production prune evidence is recorded in #126063.

AI-assisted: Codex assisted with investigation, implementation, tests, documentation, and review; the maintainer directed the product behavior and reviewed the change scope.
