### PR TITLE
fix(agents): keep guided auth atomic through creation

### DIFF
--- a/extensions/cloudflare-ai-gateway/index.ts
+++ b/extensions/cloudflare-ai-gateway/index.ts
@@ -99,6 +99,7 @@ export default definePluginEntry({
                   ? (ctx.secretInputMode ?? "plaintext")
                   : ctx.secretInputMode,
               config: ctx.config,
+              workspaceDir: ctx.workspaceDir,
               expectedProviders: [PROVIDER_ID],
               provider: PROVIDER_ID,
               envLabel: PROVIDER_ENV_VAR,

--- a/extensions/lmstudio/index.ts
+++ b/extensions/lmstudio/index.ts
@@ -190,6 +190,7 @@ export default definePluginEntry({
             return await providerSetup.promptAndConfigureLmstudioInteractive({
               config: ctx.config,
               agentDir: ctx.agentDir,
+              workspaceDir: ctx.workspaceDir,
               prompter: ctx.prompter,
               secretInputMode: ctx.secretInputMode,
               allowSecretRefPrompt: ctx.allowSecretRefPrompt,

--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -508,6 +508,7 @@ export async function prepareAppGuidedLmstudioSetup(
 export async function promptAndConfigureLmstudioInteractive(params: {
   config: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   prompter?: WizardPrompter;
   secretInputMode?: SecretInputMode;
   allowSecretRefPrompt?: boolean;
@@ -541,6 +542,7 @@ export async function promptAndConfigureLmstudioInteractive(params: {
       : params.prompter
         ? await ensureApiKeyFromEnvOrPrompt({
             config: params.config,
+            workspaceDir: params.workspaceDir,
             provider: PROVIDER_ID,
             envLabel: LMSTUDIO_DEFAULT_API_KEY_ENV_VAR,
             promptMessage: `${LMSTUDIO_PROVIDER_LABEL} API key`,

--- a/extensions/microsoft-foundry/auth.ts
+++ b/extensions/microsoft-foundry/auth.ts
@@ -235,6 +235,7 @@ export const apiKeyAuthMethod: ProviderAuthMethod = {
           ? (ctx.secretInputMode ?? "plaintext")
           : ctx.secretInputMode,
       config: ctx.config,
+      workspaceDir: ctx.workspaceDir,
       expectedProviders: [PROVIDER_ID],
       provider: PROVIDER_ID,
       envLabel: "AZURE_OPENAI_API_KEY",

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -1050,6 +1050,7 @@ export default definePluginEntry({
             const result = await promptAndConfigureOllama({
               cfg: ctx.config,
               env: ctx.env,
+              workspaceDir: ctx.workspaceDir,
               opts: ctx.opts as Record<string, unknown> | undefined,
               prompter: ctx.prompter,
               ...(ctx.signal ? { signal: ctx.signal } : {}),

--- a/extensions/ollama/src/setup.runtime.ts
+++ b/extensions/ollama/src/setup.runtime.ts
@@ -147,6 +147,7 @@ export async function checkOllamaCloudAuth(
 async function promptForOllamaCloudCredential(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  workspaceDir?: string;
   opts?: Record<string, unknown>;
   prompter: WizardPrompter;
   secretInputMode?: SecretInputMode;
@@ -169,6 +170,7 @@ async function promptForOllamaCloudCredential(params: {
         : params.secretInputMode,
     config: params.cfg,
     env: params.env,
+    workspaceDir: params.workspaceDir,
     expectedProviders: ["ollama"],
     provider: "ollama",
     envLabel: "OLLAMA_API_KEY",
@@ -383,6 +385,7 @@ async function promptAndConfigureHostBackedOllama(params: {
 export async function promptAndConfigureOllama(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  workspaceDir?: string;
   opts?: Record<string, unknown>;
   prompter: WizardPrompter;
   secretInputMode?: SecretInputMode;
@@ -405,6 +408,7 @@ export async function promptAndConfigureOllama(params: {
     const { credential, credentialMode, discoveryApiKey } = await promptForOllamaCloudCredential({
       cfg: params.cfg,
       env: params.env,
+      workspaceDir: params.workspaceDir,
       opts: params.opts,
       prompter: params.prompter,
       secretInputMode: params.secretInputMode,

--- a/extensions/pixverse/index.test.ts
+++ b/extensions/pixverse/index.test.ts
@@ -24,6 +24,7 @@ function registerPixVerseProvider() {
 function createRuntimeContext(
   region: "international" | "cn",
   config: Record<string, unknown> = {
+    agents: { entries: { main: {}, work: { workspace: "/tmp/pixverse-workspace" } } },
     models: {
       providers: {
         pixverse: {
@@ -42,6 +43,7 @@ function createRuntimeContext(
   const ctx = {
     config,
     env: {},
+    workspaceDir: "/tmp/pixverse-workspace",
     prompter: {
       intro: vi.fn(),
       outro: vi.fn(),

--- a/extensions/pixverse/onboard.ts
+++ b/extensions/pixverse/onboard.ts
@@ -144,6 +144,7 @@ async function runPixVerseApiKeyAuth(ctx: ProviderAuthContext): Promise<PixVerse
         : ctx.secretInputMode,
     config: ctx.config,
     env: ctx.env,
+    workspaceDir: ctx.workspaceDir,
     expectedProviders: [PIXVERSE_PROVIDER_ID],
     provider: PIXVERSE_PROVIDER_ID,
     envLabel: "PIXVERSE_API_KEY",

--- a/extensions/xiaomi/index.ts
+++ b/extensions/xiaomi/index.ts
@@ -191,6 +191,7 @@ async function runXiaomiApiKeyAuth(
         : ctx.secretInputMode,
     config: ctx.config,
     env: ctx.env,
+    workspaceDir: ctx.workspaceDir,
     expectedProviders: [params.providerId],
     provider: params.providerId,
     envLabel: params.envVar,

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -187,6 +187,7 @@ async function runZaiApiKeyAuth(
         ? (ctx.secretInputMode ?? "plaintext")
         : ctx.secretInputMode,
     config: ctx.config,
+    workspaceDir: ctx.workspaceDir,
     expectedProviders: [PROVIDER_ID, "z-ai"],
     provider: PROVIDER_ID,
     envLabel: "ZAI_API_KEY",

--- a/src/agents/agent-create.test.ts
+++ b/src/agents/agent-create.test.ts
@@ -607,6 +607,60 @@ describe("createAgent", () => {
     expect(mocks.ensureAgentWorkspace).toHaveBeenCalledOnce();
   });
 
+  it("prepares staged config effects after setup and immediately before publication", async () => {
+    mocks.ensureAgentWorkspace.mockResolvedValue({
+      dir: "/tmp/default-researcher",
+      bootstrapPending: false,
+    });
+    const prepareConfigCommit = vi.fn(async () => {
+      expect(mocks.ensureAgentWorkspace).toHaveBeenCalledOnce();
+      expect(mocks.mkdir).toHaveBeenCalledOnce();
+      expect(mocks.rootWrite).toHaveBeenCalledOnce();
+      expect(mocks.persisted).not.toHaveProperty("agents");
+    });
+
+    await createAgent({ name: "researcher", prepareConfigCommit });
+
+    expect(prepareConfigCommit).toHaveBeenCalledOnce();
+    expect(mocks.persisted).toHaveProperty("agents.entries.researcher");
+  });
+
+  it("rolls staged config effects back once when config publication fails", async () => {
+    const rollback = vi.fn();
+    const prepareConfigCommit = vi.fn(async () => rollback);
+    mocks.transformConfigFileWithRetry.mockImplementationOnce(async ({ transform }) => {
+      await transform(structuredClone(mocks.config), {
+        snapshot: { exists: false },
+        previousHash: null,
+      });
+      throw new Error("injected config commit failure");
+    });
+
+    await expect(createAgent({ name: "researcher", prepareConfigCommit })).rejects.toThrow(
+      "injected config commit failure",
+    );
+
+    expect(prepareConfigCommit).toHaveBeenCalledOnce();
+    expect(rollback).toHaveBeenCalledOnce();
+  });
+
+  it("does not roll staged config effects back after config publication", async () => {
+    const rollback = vi.fn();
+    mocks.recordAgentProvenance.mockImplementationOnce(() => {
+      throw new Error("injected provenance failure");
+    });
+
+    await expect(
+      createAgent({
+        name: "researcher",
+        prepareConfigCommit: async () => rollback,
+      }),
+    ).rejects.toThrow("injected provenance failure");
+
+    expect(mocks.persisted).toHaveProperty("agents.entries.researcher");
+    expect(rollback).not.toHaveBeenCalled();
+  });
+
   it("keeps the template identity while bootstrap is pending", async () => {
     await createAgent({ name: "researcher" });
 

--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -66,6 +66,7 @@ type CreateError = {
 type CreateAgentResult = (CreateAgentSuccess & { config: OpenClawConfig }) | CreateError;
 type AgentEntryConfig = NonNullable<NonNullable<OpenClawConfig["agents"]>["entries"]>[string];
 type CreateAgentEntry = AgentEntryConfig & { id: string };
+type ConfigCommitRollback = () => void | Promise<void>;
 
 type CreateAgentParams = {
   name?: string;
@@ -87,6 +88,8 @@ type CreateAgentParams = {
   skipOptionalBootstrapFiles?: OptionalBootstrapFileName[];
   bindingSpecs?: string[];
   transformConfig?: typeof transformConfigFileWithRetry;
+  /** Prepare guided staged state at the last reversible edge before config publication. */
+  prepareConfigCommit?: () => Promise<ConfigCommitRollback | void>;
   provenance?: { createdVia: AgentCreatedVia; creatorAgentId?: string };
 };
 
@@ -255,6 +258,7 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
     ? resolveUserPath(requestedAgentDir.trim())
     : undefined;
   const transformConfig = params.transformConfig ?? transformConfigFileWithRetry;
+  let configCommitRollback: ConfigCommitRollback | undefined;
 
   try {
     return await withConfigMutationExclusive(async (lockedConfig) => {
@@ -436,6 +440,10 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
           if (!workspace.bootstrapPending) {
             await writeIdentityFile({ workspaceDir: workspace.dir, identity });
           }
+          // The receipt owns compensation until the config transform publishes this result.
+          const preparedRollback = await params.prepareConfigCommit?.();
+          configCommitRollback =
+            typeof preparedRollback === "function" ? preparedRollback : undefined;
 
           return {
             nextConfig,
@@ -452,6 +460,8 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
           };
         },
       });
+      // Publication is now irreversible; later tombstone or provenance failures retain staged state.
+      configCommitRollback = undefined;
       if (
         deletion?.cleanupCompleted &&
         !tombstoneClaimed &&
@@ -473,6 +483,16 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
       };
     });
   } catch (error) {
+    if (configCommitRollback) {
+      try {
+        await configCommitRollback();
+      } catch (rollbackError) {
+        throw new Error(
+          `${String(error)}\nstaged config rollback failed: ${String(rollbackError)}`,
+          { cause: rollbackError },
+        );
+      }
+    }
     if (error instanceof DuplicateAgentError) {
       return createError("already-exists", `agent "${agentId}" already exists`, agentId);
     }

--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -45,6 +45,7 @@ export {
   upsertAuthProfileWithLock,
   upsertAuthProfileWithLockOrThrow,
 } from "./auth-profiles/profiles.js";
+export { persistAuthProfileBatch } from "./auth-profiles/upsert-with-lock.js";
 export {
   repairOAuthProfileIdMismatch,
   suggestOAuthProfileIdForLegacyDefault,

--- a/src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts
+++ b/src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts
@@ -1,0 +1,195 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { loadPersistedAuthProfileStore } from "./persisted.js";
+import {
+  inspectPersistedAuthProfileStateRaw,
+  inspectPersistedAuthProfileStoreRaw,
+  resolveAuthProfileDatabasePath,
+} from "./sqlite.js";
+import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
+import type { ApiKeyCredential } from "./types.js";
+import { persistAuthProfileBatch } from "./upsert-with-lock.js";
+
+function apiKey(key: string): ApiKeyCredential {
+  return { type: "api_key", provider: "openai", key };
+}
+
+function profile(profileId: string, key: string) {
+  return { profileId, credential: apiKey(key) };
+}
+
+async function withAgentDir(run: (agentDir: string) => Promise<void>): Promise<void> {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-batch-"));
+  const agentDir = path.join(root, "agents", "work", "agent");
+  fs.mkdirSync(agentDir, { recursive: true });
+  try {
+    await withEnvAsync(
+      { OPENCLAW_STATE_DIR: root, OPENCLAW_AGENT_DIR: agentDir },
+      async () => await run(agentDir),
+    );
+  } finally {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("auth profile batch persistence", () => {
+  it("conditionally rolls a portable profile batch and its order back to absence", async () => {
+    await withAgentDir(async (agentDir) => {
+      const noOp = await persistAuthProfileBatch({ agentDir, profiles: [] });
+      noOp.rollback();
+      expect(fs.existsSync(resolveAuthProfileDatabasePath(agentDir))).toBe(false);
+
+      const receipt = await persistAuthProfileBatch({
+        agentDir,
+        profiles: [
+          profile("openai:primary", " sk-primary "),
+          {
+            profileId: "openai:backup",
+            credential: { type: "token", provider: "openai", token: " backup-token " },
+          },
+        ],
+        order: { openai: ["openai:primary", "openai:backup"] },
+      });
+
+      expect(loadPersistedAuthProfileStore(agentDir)).toMatchObject({
+        profiles: {
+          "openai:primary": { key: "sk-primary" },
+          "openai:backup": { token: "backup-token" },
+        },
+        order: { openai: ["openai:primary", "openai:backup"] },
+      });
+
+      receipt.rollback();
+      receipt.rollback();
+
+      expect(loadPersistedAuthProfileStore(agentDir)).toBeNull();
+      expect(inspectPersistedAuthProfileStoreRaw(agentDir).status).toBe("missing");
+      expect(inspectPersistedAuthProfileStateRaw(agentDir).status).toBe("missing");
+    });
+  });
+
+  it("removes only owned profiles and introduced order ids", async () => {
+    await withAgentDir(async (agentDir) => {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "openai:existing": apiKey("sk-existing"),
+          },
+          order: { openai: ["openai:existing"] },
+        },
+        agentDir,
+      );
+      const receipt = await persistAuthProfileBatch({
+        agentDir,
+        profiles: [profile("openai:primary", "sk-attempt"), profile("openai:backup", "sk-backup")],
+        order: { openai: ["openai:primary", "openai:backup"] },
+      });
+      await updateAuthProfileStoreWithLock({
+        agentDir,
+        saveOptions: { filterExternalAuthProfiles: false, syncExternalCli: false },
+        updater: (store) => {
+          store.profiles["openai:primary"] = apiKey("sk-newer");
+          store.profiles["openai:concurrent"] = apiKey("sk-unrelated");
+          store.order = {
+            openai: ["openai:primary", "openai:backup", "openai:concurrent", "openai:existing"],
+          };
+          return true;
+        },
+      });
+
+      receipt.rollback();
+
+      expect(loadPersistedAuthProfileStore(agentDir)).toMatchObject({
+        profiles: {
+          "openai:primary": { key: "sk-newer" },
+          "openai:existing": { key: "sk-existing" },
+          "openai:concurrent": { key: "sk-unrelated" },
+        },
+        order: {
+          openai: ["openai:primary", "openai:concurrent", "openai:existing"],
+        },
+      });
+      expect(loadPersistedAuthProfileStore(agentDir)?.profiles["openai:backup"]).toBeUndefined();
+    });
+  });
+
+  it("does not claim skipped non-replacing profiles or their order entries", async () => {
+    await withAgentDir(async (agentDir) => {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "openai:existing": apiKey("sk-existing"),
+            "openai:conflict": apiKey("sk-concurrent"),
+          },
+          order: { openai: ["openai:existing"] },
+        },
+        agentDir,
+      );
+      const receipt = await persistAuthProfileBatch({
+        agentDir,
+        profiles: [
+          { ...profile("openai:conflict", "sk-portable"), replaceExisting: false },
+          { ...profile("openai:portable", "sk-portable"), replaceExisting: false },
+        ],
+        order: { openai: ["openai:conflict", "openai:portable"] },
+      });
+
+      expect(loadPersistedAuthProfileStore(agentDir)).toMatchObject({
+        profiles: {
+          "openai:conflict": { key: "sk-concurrent" },
+          "openai:portable": { key: "sk-portable" },
+        },
+        order: { openai: ["openai:existing", "openai:portable"] },
+      });
+
+      receipt.rollback();
+
+      expect(loadPersistedAuthProfileStore(agentDir)).toMatchObject({
+        profiles: {
+          "openai:existing": { key: "sk-existing" },
+          "openai:conflict": { key: "sk-concurrent" },
+        },
+        order: { openai: ["openai:existing"] },
+      });
+      expect(loadPersistedAuthProfileStore(agentDir)?.profiles["openai:portable"]).toBeUndefined();
+    });
+  });
+
+  it("leaves no partial profile batch when the SQLite state write fails", async () => {
+    await withAgentDir(async (agentDir) => {
+      const database = openOpenClawAgentDatabase({
+        agentId: "work",
+        path: resolveAuthProfileDatabasePath(agentDir),
+      });
+      database.db.exec(`
+        CREATE TRIGGER reject_auth_profile_batch_state
+        BEFORE INSERT ON auth_profile_state
+        BEGIN
+          SELECT RAISE(ABORT, 'injected auth batch state failure');
+        END;
+      `);
+
+      await expect(
+        persistAuthProfileBatch({
+          agentDir,
+          profiles: [profile("openai:first", "sk-first"), profile("openai:second", "sk-second")],
+          order: { openai: ["openai:first", "openai:second"] },
+        }),
+      ).rejects.toThrow("injected auth batch state failure");
+
+      expect(loadPersistedAuthProfileStore(agentDir)).toBeNull();
+    });
+  });
+});

--- a/src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts
+++ b/src/agents/auth-profiles/upsert-with-lock.sqlite.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -18,6 +18,8 @@ import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js
 import type { ApiKeyCredential } from "./types.js";
 import { persistAuthProfileBatch } from "./upsert-with-lock.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 function apiKey(key: string): ApiKeyCredential {
   return { type: "api_key", provider: "openai", key };
 }
@@ -27,7 +29,7 @@ function profile(profileId: string, key: string) {
 }
 
 async function withAgentDir(run: (agentDir: string) => Promise<void>): Promise<void> {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-batch-"));
+  const root = tempDirs.make("openclaw-auth-batch-");
   const agentDir = path.join(root, "agents", "work", "agent");
   fs.mkdirSync(agentDir, { recursive: true });
   try {
@@ -38,7 +40,6 @@ async function withAgentDir(run: (agentDir: string) => Promise<void>): Promise<v
   } finally {
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
-    fs.rmSync(root, { recursive: true, force: true });
   }
 }
 

--- a/src/agents/auth-profiles/upsert-with-lock.ts
+++ b/src/agents/auth-profiles/upsert-with-lock.ts
@@ -1,11 +1,161 @@
-/**
- * Locked auth profile upsert helper.
- * Normalizes literal secrets before persistence and routes all writes through
- * the shared SQLite lock to avoid racing concurrent auth updates.
- */
+/** Locked auth profile writes and attempt-scoped compensation. */
+import { isDeepStrictEqual } from "node:util";
+import { AUTH_STORE_VERSION } from "./constants.js";
 import { normalizeAuthProfileCredential } from "./credential-normalize.js";
-import { updateAuthProfileStoreWithLock } from "./store.js";
+import { loadPersistedAuthProfileStore } from "./persisted.js";
+import {
+  deletePersistedAuthProfileStoreRaw,
+  inspectPersistedAuthProfileStateRaw,
+  inspectPersistedAuthProfileStoreRaw,
+  runAuthProfileWriteTransaction,
+  writePersistedAuthProfileStateRaw,
+} from "./sqlite.js";
+import { buildPersistedAuthProfileState } from "./state.js";
+import { saveAuthProfileStore, updateAuthProfileStoreWithLock } from "./store.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
+
+type PersistAuthProfileBatchParams = {
+  profiles: readonly {
+    profileId: string;
+    credential: AuthProfileCredential;
+    replaceExisting?: boolean;
+  }[];
+  order?: Readonly<Record<string, readonly string[]>>;
+  agentDir?: string;
+  stateDir?: string;
+};
+
+/** Atomically persists a batch and returns conditional attempt-scoped compensation. */
+export async function persistAuthProfileBatch(
+  params: PersistAuthProfileBatchParams,
+): Promise<{ rollback: () => void }> {
+  const profiles = new Map(
+    params.profiles.map(({ profileId, credential, replaceExisting }) => [
+      profileId,
+      {
+        credential: normalizeAuthProfileCredential(credential),
+        replaceExisting: replaceExisting !== false,
+      },
+    ]),
+  );
+  if (profiles.size === 0) {
+    return { rollback() {} };
+  }
+
+  const previousProfiles = new Map<string, AuthProfileCredential | undefined>();
+  const previousOrder = new Map<string, readonly string[] | undefined>();
+  const appliedProfiles = new Map<string, AuthProfileCredential>();
+  let storeWasAbsent = false;
+  let stateWasAbsent = false;
+  runAuthProfileWriteTransaction(
+    params.agentDir,
+    (database) => {
+      storeWasAbsent =
+        inspectPersistedAuthProfileStoreRaw(params.agentDir, database).status === "missing";
+      stateWasAbsent =
+        inspectPersistedAuthProfileStateRaw(params.agentDir, database).status === "missing";
+      const next =
+        loadPersistedAuthProfileStore(params.agentDir, { database }) ??
+        ({ version: AUTH_STORE_VERSION, profiles: {} } satisfies AuthProfileStore);
+      for (const [profileId, entry] of profiles) {
+        if (!entry.replaceExisting && Object.hasOwn(next.profiles, profileId)) {
+          continue;
+        }
+        previousProfiles.set(profileId, next.profiles[profileId]);
+        next.profiles[profileId] = entry.credential;
+        appliedProfiles.set(profileId, entry.credential);
+      }
+      for (const [provider, profileIds] of Object.entries(params.order ?? {})) {
+        previousOrder.set(provider, next.order?.[provider]);
+        const existing = next.order?.[provider] ?? [];
+        const additions = [...new Set(profileIds)].filter(
+          (profileId) => appliedProfiles.has(profileId) && !existing.includes(profileId),
+        );
+        if (additions.length > 0) {
+          next.order = { ...next.order, [provider]: [...existing, ...additions] };
+        }
+      }
+      if (appliedProfiles.size > 0) {
+        saveAuthProfileStore(
+          next,
+          params.agentDir,
+          { filterExternalAuthProfiles: false, syncExternalCli: false },
+          database,
+        );
+      }
+    },
+    { stateDir: params.stateDir },
+  );
+
+  let rolledBack = false;
+  return {
+    rollback: () => {
+      if (rolledBack) {
+        return;
+      }
+      runAuthProfileWriteTransaction(
+        params.agentDir,
+        (database) => {
+          const current = loadPersistedAuthProfileStore(params.agentDir, { database });
+          if (!current) {
+            return;
+          }
+          const ownedProfiles = new Set<string>();
+          for (const [profileId, credential] of appliedProfiles) {
+            if (!isDeepStrictEqual(current.profiles[profileId], credential)) {
+              continue;
+            }
+            ownedProfiles.add(profileId);
+            const previous = previousProfiles.get(profileId);
+            if (previous) {
+              current.profiles[profileId] = previous;
+            } else {
+              delete current.profiles[profileId];
+            }
+          }
+          for (const [provider, profileIds] of Object.entries(params.order ?? {})) {
+            const existing = current.order?.[provider];
+            if (!existing) {
+              continue;
+            }
+            const preexisting = new Set(previousOrder.get(provider) ?? []);
+            const introduced = new Set(
+              profileIds.filter((profileId) => !preexisting.has(profileId)),
+            );
+            const remaining = existing.filter(
+              (profileId) => !introduced.has(profileId) || !ownedProfiles.has(profileId),
+            );
+            if (remaining.length === existing.length) {
+              continue;
+            }
+            if (remaining.length > 0) {
+              current.order = { ...current.order, [provider]: remaining };
+            } else if (current.order) {
+              delete current.order[provider];
+              if (Object.keys(current.order).length === 0) {
+                delete current.order;
+              }
+            }
+          }
+          saveAuthProfileStore(
+            current,
+            params.agentDir,
+            { filterExternalAuthProfiles: false, syncExternalCli: false },
+            database,
+          );
+          if (storeWasAbsent && Object.keys(current.profiles).length === 0) {
+            deletePersistedAuthProfileStoreRaw(params.agentDir, database);
+          }
+          if (stateWasAbsent && buildPersistedAuthProfileState(current) === null) {
+            writePersistedAuthProfileStateRaw(null, params.agentDir, database);
+          }
+        },
+        { stateDir: params.stateDir },
+      );
+      rolledBack = true;
+    },
+  };
+}
 
 /** Upserts an auth profile under the store lock, returning null on store write failure. */
 export async function upsertAuthProfileWithLock(params: {

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -1894,8 +1894,6 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       getRuntimeConfig: () => ({}) as never,
     });
 
-    const ownerContext = { owner: "gateway-a" } as never;
-    const resolveGatewayContext = () => ownerContext;
     const result = await deliverSubagentAnnouncement({
       requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
       targetRequesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
@@ -1914,7 +1912,6 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expectsCompletionMessage: true,
       bestEffortDeliver: true,
       directIdempotencyKey: "announce-local-dispatch",
-      resolveGatewayContext,
     });
 
     expectDeliveryPath(result, "direct");

--- a/src/agents/subagents/announce/subagent-announce-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.ts
@@ -99,7 +99,6 @@ export async function deliverSubagentAnnouncement(params: {
   directIdempotencyKey: string;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   signal?: AbortSignal;
-  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<SubagentAnnounceDeliveryResult> {
   const sourceOwnerChanged = () => params.isSourceSessionEffectsAllowed?.() === false;
   if (sourceOwnerChanged()) {
@@ -259,7 +258,6 @@ export async function deliverSubagentAnnouncement(params: {
         onDeliveryResult: params.onDeliveryResult,
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,
-        resolveGatewayContext: params.resolveGatewayContext,
       });
     },
   });

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -108,7 +108,6 @@ export async function sendSubagentAnnounceDirectly(params: {
   requesterIsSubagent: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   signal?: AbortSignal;
-  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<SubagentAnnounceDeliveryResult> {
   if (params.signal?.aborted) {
     return {

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -7,7 +7,6 @@
 import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { getRuntimeConfig } from "../../../config/config.js";
 import { logWarn } from "../../../logger.js";
-import { getSharedGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import { isCronSessionKey } from "../../../sessions/session-key-utils.js";
 import {
   type DeliveryContext,
@@ -452,7 +451,6 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
           attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
         ),
         signal: params.signal,
-        resolveGatewayContext: getSharedGatewayContextResolver(settledBatch),
       });
     } catch (error) {
       // A transport exception can arrive after gateway admission. Replay the

--- a/src/agents/subagents/announce/subagent-announce.ts
+++ b/src/agents/subagents/announce/subagent-announce.ts
@@ -193,7 +193,6 @@ export async function runSubagentAnnounceFlow(params: {
   bestEffortDeliver?: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   onBeforeDeleteChildSession?: () => boolean;
-  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<SubagentAnnounceFlowOutcome> {
   let announceOutcome: SubagentAnnounceFlowOutcome = "retryable";
   const expectsCompletionMessage = params.expectsCompletionMessage === true;
@@ -590,7 +589,6 @@ export async function runSubagentAnnounceFlow(params: {
       directIdempotencyKey,
       onDeliveryResult: reportDeliveryResult,
       signal: params.signal,
-      resolveGatewayContext: params.resolveGatewayContext,
     });
     reportDeliveryResult(delivery);
     announceOutcome = delivery.disposition ?? (delivery.delivered ? "delivered" : "retryable");

--- a/src/agents/subagents/registry/subagent-gateway-context-binding.test.ts
+++ b/src/agents/subagents/registry/subagent-gateway-context-binding.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   bindGatewayContextResolver,
   getGatewayContextResolver,
-  getSharedGatewayContextResolver,
 } from "../../../plugins/runtime/gateway-request-scope.js";
 import { createSubagentRunRecord } from "../../subagent-test-fixtures.test-helpers.js";
 
@@ -19,18 +18,5 @@ describe("subagent Gateway context binding", () => {
 
     expect(getGatewayContextResolver(successor)?.()).toBe(context);
     expect(getGatewayContextResolver(restored)).toBeUndefined();
-  });
-
-  it("refuses to select one Gateway for a mixed-owner settle batch", () => {
-    const first = createSubagentRunRecord({ runId: "run-first" });
-    const second = createSubagentRunRecord({ runId: "run-second" });
-    const firstContext = { owner: "gateway-a" } as never;
-    const secondContext = { owner: "gateway-b" } as never;
-    bindGatewayContextResolver(first, () => firstContext);
-    bindGatewayContextResolver(second, () => secondContext);
-
-    expect(getGatewayContextResolver(first)?.()).toBe(firstContext);
-    expect(getGatewayContextResolver(second)?.()).toBe(secondContext);
-    expect(getSharedGatewayContextResolver([first, second])).toBeUndefined();
   });
 });

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -1,4 +1,3 @@
-import { getGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import { defaultRuntime } from "../../../runtime.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
 import {
@@ -607,7 +606,6 @@ export const startSubagentAnnounceCleanupFlow = (
         params.persist(runId);
       }
     },
-    resolveGatewayContext: getGatewayContextResolver(entry),
   };
   runDetachedCleanupAttempt(context, {
     runId,

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -7,7 +7,7 @@ import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
 import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
 import { resolveAuthProfileDatabasePath } from "../agents/auth-profiles/sqlite.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
-import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import type { AuthProfileCredential, AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { ChannelOnboardingPostWriteHook } from "../channels/plugins/setup-wizard-types.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { writeConfigMachineState } from "../state/config-machine-state.js";
@@ -20,7 +20,7 @@ import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-hel
 
 type SetupChannels = typeof import("./onboard-channels.js").setupChannels;
 type EnsureWorkspaceAndSessions = typeof import("./onboard-helpers.js").ensureWorkspaceAndSessions;
-type ApplyAuthChoice = typeof import("./auth-choice.js").applyAuthChoice;
+type PrepareAuthChoice = typeof import("./auth-choice.js").prepareAuthChoice;
 
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
 const writeConfigFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
@@ -79,12 +79,32 @@ const transformConfigWithPendingPluginInstallsMock = vi.hoisted(() =>
 const wizardMocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(),
 }));
+const pluginLifecycleMocks = vi.hoisted(() => {
+  const state = { active: false };
+  return {
+    state,
+    withPluginLifecycleLease: vi.fn(async (_options, run: () => Promise<unknown>) => {
+      state.active = true;
+      try {
+        return await run();
+      } finally {
+        state.active = false;
+      }
+    }),
+  };
+});
 const terminalMocks = vi.hoisted(() => ({
   isTerminalInteractive: vi.fn(() => true),
 }));
 const authChoiceMocks = vi.hoisted(() => ({
-  applyAuthChoice: vi.fn<ApplyAuthChoice>(),
+  prepareAuthChoice: vi.fn<PrepareAuthChoice>(),
   warnIfModelConfigLooksOff: vi.fn(async () => {}),
+}));
+const authProfileMocks = vi.hoisted(() => ({
+  persistBatch: vi.fn(),
+}));
+const authPromptMocks = vi.hoisted(() => ({
+  promptAuthChoiceGrouped: vi.fn(async () => "fixture-auth"),
 }));
 const onboardChannelsMocks = vi.hoisted(() => ({
   setupChannels: vi.fn<SetupChannels>(async (config) => config),
@@ -122,14 +142,26 @@ vi.mock("../wizard/clack-prompter.js", () => ({
   createClackPrompter: wizardMocks.createClackPrompter,
 }));
 
+vi.mock("../plugins/plugin-lifecycle-lease.js", () => ({
+  withPluginLifecycleLease: pluginLifecycleMocks.withPluginLifecycleLease,
+}));
+
 vi.mock("../cli/terminal-interactivity.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../cli/terminal-interactivity.js")>()),
   isTerminalInteractive: terminalMocks.isTerminalInteractive,
 }));
 
 vi.mock("./auth-choice.js", () => ({
-  applyAuthChoice: authChoiceMocks.applyAuthChoice,
+  prepareAuthChoice: authChoiceMocks.prepareAuthChoice,
   warnIfModelConfigLooksOff: authChoiceMocks.warnIfModelConfigLooksOff,
+}));
+
+vi.mock("./auth-choice-prompt.js", () => ({
+  promptAuthChoiceGrouped: authPromptMocks.promptAuthChoiceGrouped,
+}));
+
+vi.mock("../agents/auth-profiles/upsert-with-lock.js", () => ({
+  persistAuthProfileBatch: authProfileMocks.persistBatch,
 }));
 
 vi.mock("./onboard-channels.js", () => ({
@@ -142,6 +174,10 @@ vi.mock("./onboard-helpers.js", () => ({
 
 import { WizardCancelledError } from "../wizard/prompts.js";
 import { agentsAddCommand } from "./agents.commands.add.js";
+
+const { persistAuthProfileBatch } = await vi.importActual<
+  typeof import("../agents/auth-profiles/upsert-with-lock.js")
+>("../agents/auth-profiles/upsert-with-lock.js");
 
 const runtime = createTestRuntime();
 const RESERVED_SYSTEM_AGENT_IDS_FOR_TEST = ["openclaw", "crestodian"] as const; // reserved ids
@@ -174,6 +210,7 @@ describe("agents add command", () => {
         entry?: { id: string; name?: string; workspace?: string; agentDir?: string };
         bindingSpecs?: string[];
         stagedConfig?: Record<string, unknown>;
+        prepareConfigCommit?: () => Promise<(() => void | Promise<void>) | void>;
       }) => {
         const name = params.name ?? params.entry?.name ?? params.entry?.id ?? "";
         const agentId = (params.entry?.id ?? name).toLowerCase();
@@ -187,6 +224,7 @@ describe("agents add command", () => {
               match: { channel: params.bindingSpecs[0].split(":")[0] },
             }
           : undefined;
+        await params.prepareConfigCommit?.();
         return {
           status: "created" as const,
           agentId,
@@ -210,9 +248,13 @@ describe("agents add command", () => {
       },
     );
     wizardMocks.createClackPrompter.mockClear();
+    pluginLifecycleMocks.withPluginLifecycleLease.mockClear();
+    pluginLifecycleMocks.state.active = false;
     terminalMocks.isTerminalInteractive.mockReset().mockReturnValue(true);
-    authChoiceMocks.applyAuthChoice.mockClear();
+    authChoiceMocks.prepareAuthChoice.mockReset();
     authChoiceMocks.warnIfModelConfigLooksOff.mockClear();
+    authPromptMocks.promptAuthChoiceGrouped.mockClear();
+    authProfileMocks.persistBatch.mockReset().mockImplementation(persistAuthProfileBatch);
     onboardChannelsMocks.setupChannels.mockClear();
     onboardHelpersMocks.ensureWorkspaceAndSessions.mockClear();
     runtime.log.mockClear();
@@ -263,6 +305,24 @@ describe("agents add command", () => {
     });
     wizardMocks.createClackPrompter.mockReturnValue(wizard.prompter);
     return wizard;
+  }
+
+  function stageGuidedAuth(
+    profiles: Array<{ profileId: string; credential: AuthProfileCredential }> = [
+      {
+        profileId: "openai:primary",
+        credential: { type: "api_key", provider: "openai", key: "sk-primary" },
+      },
+    ],
+  ): void {
+    authChoiceMocks.prepareAuthChoice.mockImplementationOnce(async ({ config }) => ({
+      config: {
+        ...config,
+        auth: { profiles: { "openai:primary": { provider: "openai", mode: "api_key" } } },
+      },
+      authProfiles: profiles,
+      persistAuthProfiles: async () => {},
+    }));
   }
 
   function stageChannelPostWriteHook(run: ChannelOnboardingPostWriteHook["run"]): void {
@@ -523,7 +583,7 @@ describe("agents add command", () => {
     expect(checkAgentCreationGateMock).toHaveBeenCalledWith("main");
     expect(prompter.outro).toHaveBeenCalledWith("Run openclaw doctor --fix, then retry.");
     expect(prompter.text).not.toHaveBeenCalled();
-    expect(authChoiceMocks.applyAuthChoice).not.toHaveBeenCalled();
+    expect(authChoiceMocks.prepareAuthChoice).not.toHaveBeenCalled();
     expect(createAgentMock).not.toHaveBeenCalled();
   });
 
@@ -628,7 +688,25 @@ describe("agents add command", () => {
     });
   });
 
-  it("keeps guided auth written after portable copy acceptance when finalizing the copy", async () => {
+  it("does not persist prepared provider auth when a later prompt is cancelled", async () => {
+    await withAgentsAddStateRoot("openclaw-agents-add-auth-cancel-provider-", async (root) => {
+      const agentDir = path.join(root, "agents", "work", "agent");
+      const workspaceDir = path.join(root, "workspace-work");
+      setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
+      useFreshAgentWizard({ workspaceDir, confirmValues: [true] });
+      stageGuidedAuth();
+      authChoiceMocks.warnIfModelConfigLooksOff.mockRejectedValueOnce(new WizardCancelledError());
+
+      await agentsAddCommand({}, runtime);
+
+      expect(loadPersistedAuthProfileStore(agentDir)).toBeNull();
+      expect(authProfileMocks.persistBatch).not.toHaveBeenCalled();
+      expect(createAgentMock).not.toHaveBeenCalled();
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  it("keeps guided auth while applying portable profiles without overwriting", async () => {
     await withAgentsAddStateRoot("openclaw-agents-add-auth-guided-", async (root) => {
       const destAgentDir = path.join(root, "agents", "work", "agent");
       const workspaceDir = path.join(root, "workspace-work");
@@ -655,28 +733,16 @@ describe("agents add command", () => {
         selectValues: ["openai", "openai-api-key"],
       });
       wizardMocks.createClackPrompter.mockReturnValue(wizard.prompter);
-      authChoiceMocks.applyAuthChoice.mockImplementationOnce(async ({ config, agentDir }) => {
-        saveAuthProfileStore(
-          {
-            version: AUTH_STORE_VERSION,
-            profiles: {
-              "openai:api-key": {
-                type: "api_key",
-                provider: "openai",
-                key: "guided-wins",
-              },
-              "openai:guided": {
-                type: "api_key",
-                provider: "openai",
-                key: "guided-retained",
-              },
-            },
-            order: { openai: ["openai:guided", "openai:api-key"] },
-          },
-          agentDir,
-        );
-        return { config, retrySelection: false };
-      });
+      stageGuidedAuth([
+        {
+          profileId: "openai:api-key",
+          credential: { type: "api_key", provider: "openai", key: "guided-wins" },
+        },
+        {
+          profileId: "openai:guided",
+          credential: { type: "api_key", provider: "openai", key: "guided-retained" },
+        },
+      ]);
 
       await agentsAddCommand({}, runtime);
 
@@ -686,11 +752,136 @@ describe("agents add command", () => {
         "openai:portable": { key: "portable-retained" },
         "openai:guided": { key: "guided-retained" },
       });
-      expect(persisted?.order?.openai).toEqual(["openai:guided", "openai:api-key"]);
+      expect(persisted?.order?.openai).toEqual(["openai:api-key", "openai:portable"]);
       expect(wizard.note).toHaveBeenCalledWith(
         'Copied 2 portable auth profiles from "main".',
         "Auth profiles",
       );
+    });
+  });
+
+  it("persists staged provider auth only at the agent config commit edge", async () => {
+    await withAgentsAddStateRoot("openclaw-agents-add-auth-create-", async (root) => {
+      const agentDir = path.join(root, "agents", "work", "agent");
+      const workspaceDir = path.join(root, "workspace-work");
+      setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
+      useFreshAgentWizard({ workspaceDir, confirmValues: [true] });
+      stageGuidedAuth();
+      createAgentMock.mockImplementationOnce(
+        async (params: {
+          stagedConfig?: Record<string, unknown>;
+          prepareConfigCommit?: () => Promise<(() => void | Promise<void>) | void>;
+        }) => {
+          expect(pluginLifecycleMocks.state.active).toBe(true);
+          expect(authProfileMocks.persistBatch).not.toHaveBeenCalled();
+          await params.prepareConfigCommit?.();
+          return {
+            status: "created" as const,
+            agentId: "work",
+            name: "work",
+            workspace: workspaceDir,
+            agentDir,
+            bootstrapPending: true,
+            config: params.stagedConfig ?? {},
+          };
+        },
+      );
+
+      await agentsAddCommand({}, runtime);
+
+      expect(loadPersistedAuthProfileStore(agentDir)?.profiles["openai:primary"]).toMatchObject({
+        key: "sk-primary",
+      });
+      expect(authProfileMocks.persistBatch).toHaveBeenCalledOnce();
+      expect(createAgentMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stagedConfig: expect.objectContaining({ auth: expect.any(Object) }),
+          prepareConfigCommit: expect.any(Function),
+        }),
+      );
+    });
+  });
+
+  it("publishes no agent when staged provider auth cannot persist atomically", async () => {
+    await withAgentsAddStateRoot("openclaw-agents-add-auth-persist-failure-", async (root) => {
+      const agentDir = path.join(root, "agents", "work", "agent");
+      const workspaceDir = path.join(root, "workspace-work");
+      const profiles = ["first", "second"].map((name) => ({
+        profileId: `openai:${name}`,
+        credential: { type: "api_key" as const, provider: "openai", key: `sk-${name}` },
+      }));
+      setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
+      useFreshAgentWizard({ workspaceDir, confirmValues: [true] });
+      stageGuidedAuth(profiles);
+      authProfileMocks.persistBatch.mockRejectedValueOnce(
+        new Error("injected auth batch persistence failure"),
+      );
+
+      await expect(agentsAddCommand({}, runtime)).rejects.toThrow(
+        "injected auth batch persistence failure",
+      );
+
+      expect(loadPersistedAuthProfileStore(agentDir)).toBeNull();
+      expect(createAgentMock).toHaveBeenCalledOnce();
+      expect(commitConfigWithPendingPluginInstallsMock).not.toHaveBeenCalled();
+      expect(writeConfigFileMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("retains existing-agent auth after config publication when later output fails", async () => {
+    await withAgentsAddStateRoot("openclaw-agents-add-auth-existing-", async (root) => {
+      const agentDir = path.join(root, "agents", "work", "agent");
+      const workspaceDir = path.join(root, "workspace-work");
+      setConfigSnapshot({
+        agents: { entries: { work: { id: "work", workspace: workspaceDir, agentDir } } },
+      });
+      const wizard = createQueuedWizardPrompter({
+        textValues: [workspaceDir],
+        confirmValues: [true, true],
+      });
+      wizardMocks.createClackPrompter.mockReturnValue(wizard.prompter);
+      stageGuidedAuth();
+      wizard.outro.mockRejectedValueOnce(new Error("injected late failure"));
+
+      await expect(agentsAddCommand({ name: "work" }, runtime)).rejects.toThrow(
+        "injected late failure",
+      );
+
+      expect(loadPersistedAuthProfileStore(agentDir)?.profiles["openai:primary"]).toMatchObject({
+        key: "sk-primary",
+      });
+      expect(commitConfigWithPendingPluginInstallsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nextConfig: expect.objectContaining({ auth: expect.any(Object) }),
+        }),
+      );
+      expect(createAgentMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rolls existing-agent auth back when config publication fails", async () => {
+    await withAgentsAddStateRoot("openclaw-agents-add-auth-existing-rollback-", async (root) => {
+      const agentDir = path.join(root, "agents", "work", "agent");
+      const workspaceDir = path.join(root, "workspace-work");
+      setConfigSnapshot({
+        agents: { entries: { work: { id: "work", workspace: workspaceDir, agentDir } } },
+      });
+      const wizard = createQueuedWizardPrompter({
+        textValues: [workspaceDir],
+        confirmValues: [true, true],
+      });
+      wizardMocks.createClackPrompter.mockReturnValue(wizard.prompter);
+      stageGuidedAuth();
+      commitConfigWithPendingPluginInstallsMock.mockRejectedValueOnce(
+        new Error("injected config publication failure"),
+      );
+
+      await expect(agentsAddCommand({ name: "work" }, runtime)).rejects.toThrow(
+        "injected config publication failure",
+      );
+
+      expect(loadPersistedAuthProfileStore(agentDir)).toBeNull();
+      expect(createAgentMock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -793,6 +793,13 @@ describe("agents add command", () => {
         key: "sk-primary",
       });
       expect(authProfileMocks.persistBatch).toHaveBeenCalledOnce();
+      expect(authChoiceMocks.warnIfModelConfigLooksOff).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        expect.objectContaining({
+          pendingAuthProfiles: [expect.objectContaining({ profileId: "openai:primary" })],
+        }),
+      );
       expect(createAgentMock).toHaveBeenCalledWith(
         expect.objectContaining({
           stagedConfig: expect.objectContaining({ auth: expect.any(Object) }),

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -1,5 +1,4 @@
 // Implements `openclaw agents add`, including config mutation, workspace setup, auth copy, and route binding setup.
-import fs from "node:fs/promises";
 import path from "node:path";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -18,22 +17,17 @@ import {
 import {
   buildPortableAuthProfileStoreForAgentCopy,
   ensureAuthProfileStore,
+  persistAuthProfileBatch,
   type AuthProfileStore,
 } from "../agents/auth-profiles.js";
 import { AuthProfileStoreUnreadableError } from "../agents/auth-profiles/legacy-source-diagnostic.js";
-import {
-  loadPersistedAuthProfileStore,
-  mergeAuthProfileStores,
-} from "../agents/auth-profiles/persisted.js";
+import { loadPersistedAuthProfileStore } from "../agents/auth-profiles/persisted.js";
 import { resolveSharedMainAuthAgentDir } from "../agents/auth-profiles/shared-main-dir.js";
 import {
   inspectPersistedAuthProfileStoreRaw,
   resolveAuthProfileDatabasePath,
 } from "../agents/auth-profiles/sqlite.js";
-import {
-  loadAuthProfileStoreWithoutExternalProfiles,
-  saveAuthProfileStore,
-} from "../agents/auth-profiles/store.js";
+import { loadAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-profiles/store.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { isTerminalInteractive } from "../cli/terminal-interactivity.js";
 import { logConfigUpdated } from "../config/logging.js";
@@ -51,7 +45,7 @@ import { WizardCancelledError } from "../wizard/prompts.js";
 import { applyAgentBindings, buildChannelBindings, describeBinding } from "./agents.bindings.js";
 import { applyAgentConfig, listAgentEntries } from "./agents.config.js";
 import { promptAuthChoiceGrouped } from "./auth-choice-prompt.js";
-import { applyAuthChoice, warnIfModelConfigLooksOff } from "./auth-choice.js";
+import { prepareAuthChoice, warnIfModelConfigLooksOff } from "./auth-choice.js";
 import { requireValidConfigFileSnapshot } from "./config-validation.js";
 import {
   ensureOnboardingAgentWorkspace,
@@ -296,7 +290,11 @@ export async function agentsAddCommand(
       workspace: workspaceDir,
       agentDir,
     });
-    let finalizePortableAuthCopy: (() => Promise<void>) | undefined;
+    const stagedAuthProfiles: Array<
+      Parameters<typeof persistAuthProfileBatch>[0]["profiles"][number]
+    > = [];
+    let stagedAuthOrder: AuthProfileStore["order"];
+    let reportPortableAuthCopy: (() => Promise<void>) | undefined;
 
     const defaultAgentId = resolveDefaultAgentId(cfg);
     if (defaultAgentId !== agentId) {
@@ -333,7 +331,6 @@ export async function agentsAddCommand(
             initialValue: false,
           });
           if (shouldCopy) {
-            const portableStore = portable.store;
             const copiedProfileIds = portable.copiedProfileIds;
             const copiedOAuthProfileIds = copiedProfileIds.filter(
               (profileId) => sourceStore.profiles[profileId]?.type === "oauth",
@@ -341,16 +338,11 @@ export async function agentsAddCommand(
             const sourceAgentId = defaultAgentId;
             const sourceInheritedMain = sourceIsInheritedMain;
             const destinationAgentDir = agentDir;
-            finalizePortableAuthCopy = async () => {
-              await fs.mkdir(destinationAgentDir, { recursive: true });
-              const destinationStore = loadPersistedAuthProfileStore(destinationAgentDir);
-              const storeToPersist = destinationStore
-                ? mergeAuthProfileStores(portableStore, destinationStore)
-                : portableStore;
-              saveAuthProfileStore(storeToPersist, destinationAgentDir, {
-                filterExternalAuthProfiles: false,
-                syncExternalCli: false,
-              });
+            for (const [profileId, credential] of Object.entries(portable.store.profiles)) {
+              stagedAuthProfiles.push({ profileId, credential, replaceExisting: false });
+            }
+            stagedAuthOrder = portable.store.order;
+            reportPortableAuthCopy = async () => {
               const persisted = loadPersistedAuthProfileStore(destinationAgentDir);
               const persistedIds = new Set(Object.keys(persisted?.profiles ?? {}));
               const copiedCount = copiedProfileIds.filter((profileId) =>
@@ -371,7 +363,7 @@ export async function agentsAddCommand(
         } else if (skippedOAuthProfiles) {
           const sourceAgentId = defaultAgentId;
           const sourceInheritedMain = sourceIsInheritedMain;
-          finalizePortableAuthCopy = async () => {
+          reportPortableAuthCopy = async () => {
             await prompter.note(
               formatSkippedOAuthProfilesMessage(sourceAgentId, sourceInheritedMain),
               "Auth profiles",
@@ -388,6 +380,8 @@ export async function agentsAddCommand(
     if (wantsAuth) {
       const authStore = ensureAuthProfileStore(agentDir, {
         allowKeychainPrompt: false,
+        readOnly: true,
+        syncExternalCli: false,
       });
       while (true) {
         const authChoice = await promptAuthChoiceGrouped({
@@ -397,7 +391,7 @@ export async function agentsAddCommand(
           config: nextConfig,
         });
 
-        const authResult = await applyAuthChoice({
+        const authResult = await prepareAuthChoice({
           authChoice,
           config: nextConfig,
           prompter,
@@ -410,6 +404,7 @@ export async function agentsAddCommand(
         if (authResult.retrySelection) {
           continue;
         }
+        stagedAuthProfiles.push(...authResult.authProfiles);
         if (authResult.agentModelOverride) {
           nextConfig = applyAgentConfig(nextConfig, {
             agentId,
@@ -479,6 +474,20 @@ export async function agentsAddCommand(
       }
     }
 
+    const stagedEntry = existingAgent
+      ? undefined
+      : listAgentEntries(nextConfig).find(
+          (candidate) => normalizeAgentId(candidate.id) === agentId,
+        );
+    const stagedAuthBatch =
+      stagedAuthProfiles.length > 0
+        ? {
+            profiles: stagedAuthProfiles,
+            ...(stagedAuthOrder ? { order: stagedAuthOrder } : {}),
+            agentDir,
+          }
+        : undefined;
+
     let payload: { agentId: string; name: string; workspace: string; agentDir: string };
     if (existingAgent) {
       const target = resolveOnboardingAgentTarget(nextConfig, agentId);
@@ -486,13 +495,21 @@ export async function agentsAddCommand(
         skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
         skipOptionalBootstrapFiles: nextConfig.agents?.defaults?.skipOptionalBootstrapFiles,
       });
-      nextConfig = await channelSetup.commit(nextConfig, async (configToCommit) => {
-        const committed = await commitConfigWithPendingPluginInstalls({
-          nextConfig: configToCommit,
-          ...(baseHash !== undefined ? { baseHash } : {}),
+      const authPersistence = stagedAuthBatch
+        ? await persistAuthProfileBatch(stagedAuthBatch)
+        : undefined;
+      try {
+        nextConfig = await channelSetup.commit(nextConfig, async (configToCommit) => {
+          const committed = await commitConfigWithPendingPluginInstalls({
+            nextConfig: configToCommit,
+            ...(baseHash !== undefined ? { baseHash } : {}),
+          });
+          return committed.config;
         });
-        return committed.config;
-      });
+      } catch (error) {
+        authPersistence?.rollback();
+        throw error;
+      }
       payload = {
         agentId: target.agentId,
         name: agentName,
@@ -500,17 +517,22 @@ export async function agentsAddCommand(
         agentDir: target.agentDir,
       };
     } else {
-      const entry = listAgentEntries(nextConfig).find(
-        (candidate) => normalizeAgentId(candidate.id) === agentId,
-      );
-      if (!entry) {
+      if (!stagedEntry) {
         throw new Error(`staged agent "${agentId}" is missing from config`);
       }
-      const created = await createAgent({
-        entry: { ...entry, id: agentId },
-        expectedConfigHash: baseHash ?? null,
-        stagedConfig: nextConfig,
-        transformConfig: transformConfigWithPendingPluginInstalls,
+      const created = await withPluginLifecycleLease({}, async () => {
+        return await createAgent({
+          entry: { ...stagedEntry, id: agentId },
+          expectedConfigHash: baseHash ?? null,
+          stagedConfig: nextConfig,
+          transformConfig: transformConfigWithPendingPluginInstalls,
+          ...(stagedAuthBatch
+            ? {
+                prepareConfigCommit: async () =>
+                  (await persistAuthProfileBatch(stagedAuthBatch)).rollback,
+              }
+            : {}),
+        });
       });
       if (created.status === "error") {
         await prompter.outro(created.message);
@@ -525,7 +547,7 @@ export async function agentsAddCommand(
       };
       await channelSetup.runPostWriteHooks(nextConfig);
     }
-    await finalizePortableAuthCopy?.();
+    await reportPortableAuthCopy?.();
     if (!opts.json) {
       logConfigUpdated(runtime);
     }

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -418,6 +418,10 @@ export async function agentsAddCommand(
     await warnIfModelConfigLooksOff(nextConfig, prompter, {
       agentId,
       agentDir,
+      pendingAuthProfiles: stagedAuthProfiles.map(({ profileId, credential }) => ({
+        profileId,
+        credential,
+      })),
       validateCatalog: false,
     });
 

--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -1,6 +1,7 @@
 // Auth-choice plugin provider tests cover loaded provider setup, plugin install, and credential routing.
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileCredential } from "../agents/auth-profiles/types.js";
 import {
   applyAuthChoiceLoadedPluginProvider,
   prepareAuthChoiceLoadedPluginProvider,
@@ -42,11 +43,9 @@ vi.mock("../plugins/provider-auth-choices.js", () => ({
   resolveManifestProviderAuthChoice,
 }));
 
-const upsertAuthProfile = vi.hoisted(() => vi.fn(() => ({ version: 1, profiles: {} })));
+const persistAuthProfileBatch = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock("../agents/auth-profiles.js", () => ({
-  upsertAuthProfile,
-  upsertAuthProfileWithLock: upsertAuthProfile,
-  upsertAuthProfileWithLockOrThrow: upsertAuthProfile,
+  persistAuthProfileBatch,
 }));
 
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "default"));
@@ -109,6 +108,15 @@ const LOCAL_PROFILE_ID = `${LOCAL_PROVIDER_ID}:default`;
 const LOCAL_API_KEY = "local-provider-key";
 const LOCAL_DEFAULT_MODEL = `${LOCAL_PROVIDER_ID}/demo-model`;
 const EXISTING_DEFAULT_MODEL = "amazon-bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+function expectPersistedProfile(profileId: string, credential: AuthProfileCredential): void {
+  expect(persistAuthProfileBatch).toHaveBeenCalledWith(
+    expect.objectContaining({
+      profiles: [{ profileId, credential }],
+      agentDir: "/tmp/agent",
+    }),
+  );
+}
 
 function buildProvider(): ProviderPlugin {
   return {
@@ -254,7 +262,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
         },
       },
     ]);
-    expect(upsertAuthProfile).not.toHaveBeenCalled();
+    expect(persistAuthProfileBatch).not.toHaveBeenCalled();
 
     await prepared?.persistAuthProfiles([
       {
@@ -268,15 +276,11 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     ]);
     await prepared?.persistAuthProfiles();
 
-    expect(upsertAuthProfile).toHaveBeenCalledOnce();
-    expect(upsertAuthProfile).toHaveBeenCalledWith({
-      profileId: LOCAL_PROFILE_ID,
-      credential: {
-        type: "api_key",
-        provider: LOCAL_PROVIDER_ID,
-        key: "test-key",
-      },
-      agentDir: "/tmp/agent",
+    expect(persistAuthProfileBatch).toHaveBeenCalledOnce();
+    expectPersistedProfile(LOCAL_PROFILE_ID, {
+      type: "api_key",
+      provider: LOCAL_PROVIDER_ID,
+      key: "test-key",
     });
   });
 
@@ -376,14 +380,10 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     expect(result?.config.models?.providers?.["remote-alpha"]?.models?.[0]?.input).toContain(
       "image",
     );
-    expect(upsertAuthProfile).toHaveBeenCalledWith({
-      profileId: "remote-alpha:default",
-      credential: {
-        type: "api_key",
-        provider: "remote-alpha",
-        key: "sk-remote-alpha-test",
-      },
-      agentDir: "/tmp/agent",
+    expectPersistedProfile("remote-alpha:default", {
+      type: "api_key",
+      provider: "remote-alpha",
+      key: "sk-remote-alpha-test",
     });
     expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
   });
@@ -401,14 +401,10 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     expect(result?.config.agents?.defaults?.model).toEqual({
       primary: LOCAL_DEFAULT_MODEL,
     });
-    expect(upsertAuthProfile).toHaveBeenCalledWith({
-      profileId: LOCAL_PROFILE_ID,
-      credential: {
-        type: "api_key",
-        provider: LOCAL_PROVIDER_ID,
-        key: LOCAL_API_KEY,
-      },
-      agentDir: "/tmp/agent",
+    expectPersistedProfile(LOCAL_PROFILE_ID, {
+      type: "api_key",
+      provider: LOCAL_PROVIDER_ID,
+      key: LOCAL_API_KEY,
     });
     expect(runProviderModelSelectedHook).toHaveBeenCalledOnce();
     const [hookParams] = runProviderModelSelectedHook.mock
@@ -621,6 +617,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
           },
         },
       },
+      env: { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" },
       runtime: {} as ApplyAuthChoiceParams["runtime"],
       prompter: {
         note,
@@ -644,6 +641,9 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     expect(note).toHaveBeenCalledWith(
       "Detected local provider runtime.\nPulled model metadata.",
       "Provider notes",
+    );
+    expect(persistAuthProfileBatch).toHaveBeenCalledWith(
+      expect.objectContaining({ stateDir: "/tmp/openclaw-state" }),
     );
     expect(events).toEqual(["note", "lock"]);
   });

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -185,6 +185,23 @@ function seedTestAuthProfile(params: {
 }
 
 vi.mock("../agents/auth-profiles.js", () => ({
+  persistAuthProfileBatch: async (params: {
+    profiles: readonly {
+      profileId: string;
+      credential: StoredAuthProfile;
+      replaceExisting?: boolean;
+    }[];
+    agentDir?: string;
+  }) => {
+    for (const profile of params.profiles) {
+      const existing = readTestAuthProfileStore(params.agentDir).profiles[profile.profileId];
+      if (profile.replaceExisting === false && existing) {
+        continue;
+      }
+      seedTestAuthProfile({ ...profile, agentDir: params.agentDir });
+    }
+    return { rollback() {} };
+  },
   upsertAuthProfile: (params: {
     profileId: string;
     credential: StoredAuthProfile;

--- a/src/plugins/provider-api-key-auth.ts
+++ b/src/plugins/provider-api-key-auth.ts
@@ -165,6 +165,7 @@ export function createProviderApiKeyAuthMethod(
             : ctx.secretInputMode,
         config: ctx.config,
         env: ctx.env,
+        workspaceDir: ctx.workspaceDir,
         expectedProviders: params.expectedProviders ?? [params.providerId],
         provider: params.providerId,
         envLabel: params.envVar,

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -5,7 +5,7 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
-import { upsertAuthProfileWithLockOrThrow } from "../agents/auth-profiles.js";
+import { persistAuthProfileBatch } from "../agents/auth-profiles.js";
 import { formatLiteralProviderPrefixedModelRef } from "../agents/model-ref-shared.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import { normalizeAgentModelRefForConfig } from "../config/model-input.js";
@@ -330,52 +330,12 @@ export async function runProviderPluginAuthMethod(params: {
   allowSecretRefPrompt?: boolean;
   opts?: Partial<ProviderAuthOptionBag>;
 }): Promise<{ config: OpenClawConfig; defaultModel?: string }> {
-  const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
-  const agentDir = params.agentDir ?? resolveAgentDir(params.config, agentId);
-  const workspaceDir =
-    params.workspaceDir ??
-    resolveAgentWorkspaceDir(params.config, agentId) ??
-    resolveDefaultAgentWorkspaceDir();
-  const result = await runProviderPluginAuthMethodUnpersisted({
-    config: params.config,
-    env: params.env,
-    runtime: params.runtime,
-    prompter: params.prompter,
-    method: params.method,
-    agentDir,
-    workspaceDir,
-    ...(params.signal ? { signal: params.signal } : {}),
-    ...(params.isRemote !== undefined ? { isRemote: params.isRemote } : {}),
-    secretInputMode: params.secretInputMode,
-    allowSecretRefPrompt: params.allowSecretRefPrompt,
-    opts: params.opts,
-  });
-
-  if (params.emitNotes !== false && result.notes && result.notes.length > 0) {
-    await params.prompter.note(result.notes.join("\n"), "Provider notes");
-  }
-
-  await params.beforePersistentEffect?.();
-  for (const profile of result.profiles) {
-    await upsertAuthProfileWithLockOrThrow({
-      profileId: profile.profileId,
-      credential: profile.credential,
-      agentDir,
-    });
-  }
-
-  const nextConfig = applyProviderPluginAuthMethodResultConfig({
-    config: params.config,
-    result,
-  });
-
-  const defaultModel = result.defaultModel
-    ? normalizeAgentModelRefForConfig(result.defaultModel)
-    : undefined;
+  const prepared = await prepareProviderPluginAuthMethod(params);
+  await prepared.persistAuthProfiles();
 
   return {
-    config: nextConfig,
-    ...(defaultModel ? { defaultModel } : {}),
+    config: prepared.config,
+    ...(prepared.defaultModel ? { defaultModel: prepared.defaultModel } : {}),
   };
 }
 
@@ -426,15 +386,11 @@ async function prepareProviderPluginAuthMethod(
       return;
     }
     await params.beforePersistentEffect?.();
-    for (const profile of profiles) {
-      const { profileId, credential } = profile;
-      await upsertAuthProfileWithLockOrThrow({
-        profileId,
-        credential,
-        agentDir,
-        stateDir: params.env?.OPENCLAW_STATE_DIR,
-      });
-    }
+    await persistAuthProfileBatch({
+      profiles,
+      agentDir,
+      stateDir: params.env?.OPENCLAW_STATE_DIR,
+    });
     profilesPersisted = true;
   };
 

--- a/src/plugins/provider-auth-input.test.ts
+++ b/src/plugins/provider-auth-input.test.ts
@@ -100,6 +100,7 @@ function currentMinimaxTestEnv(): NodeJS.ProcessEnv {
 async function ensureMinimaxApiKey(params: {
   config?: Parameters<typeof ensureApiKeyFromEnvOrPrompt>[0]["config"];
   env?: Parameters<typeof ensureApiKeyFromEnvOrPrompt>[0]["env"];
+  workspaceDir?: string;
   confirm: WizardPrompter["confirm"];
   note?: WizardPrompter["note"];
   select?: WizardPrompter["select"];
@@ -110,6 +111,7 @@ async function ensureMinimaxApiKey(params: {
   return await ensureMinimaxApiKeyInternal({
     config: params.config,
     env: params.env ?? currentMinimaxTestEnv(),
+    workspaceDir: params.workspaceDir,
     prompter: createPrompter({
       confirm: params.confirm,
       note: params.note,
@@ -124,6 +126,7 @@ async function ensureMinimaxApiKey(params: {
 async function ensureMinimaxApiKeyInternal(params: {
   config?: Parameters<typeof ensureApiKeyFromEnvOrPrompt>[0]["config"];
   env?: Parameters<typeof ensureApiKeyFromEnvOrPrompt>[0]["env"];
+  workspaceDir?: string;
   prompter: WizardPrompter;
   secretInputMode?: Parameters<typeof ensureApiKeyFromEnvOrPrompt>[0]["secretInputMode"];
   setCredential: Parameters<typeof ensureApiKeyFromEnvOrPrompt>[0]["setCredential"];
@@ -131,6 +134,7 @@ async function ensureMinimaxApiKeyInternal(params: {
   return await ensureApiKeyFromEnvOrPrompt({
     config: params.config ?? {},
     env: params.env,
+    workspaceDir: params.workspaceDir,
     provider: "minimax",
     envLabel: "MINIMAX_API_KEY",
     promptMessage: "Enter key",
@@ -250,10 +254,10 @@ describe("validateApiKeyInput", () => {
 });
 
 describe("ensureApiKeyFromEnvOrPrompt", () => {
-  it("resolves environment auth using the same config and workspace as provider runtime", async () => {
+  it("uses the prepared workspace when staged config has no default agent", async () => {
     const workspaceDir = "/tmp/openclaw-provider-workspace";
     const config: OpenClawConfig = {
-      agents: { defaults: { workspace: workspaceDir } },
+      agents: { entries: { main: {}, work: { workspace: workspaceDir } } },
       plugins: { entries: { minimax: { enabled: true } } },
     };
     const env = { MINIMAX_API_KEY: "workspace-env-key" } as NodeJS.ProcessEnv;
@@ -262,6 +266,7 @@ describe("ensureApiKeyFromEnvOrPrompt", () => {
     const result = await ensureMinimaxApiKey({
       config,
       env,
+      workspaceDir,
       confirm,
       text,
       setCredential,

--- a/src/plugins/provider-auth-input.ts
+++ b/src/plugins/provider-auth-input.ts
@@ -137,6 +137,7 @@ export async function ensureApiKeyFromOptionEnvOrPrompt(params: {
   secretInputMode?: SecretInputMode;
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  workspaceDir?: string;
   expectedProviders: string[];
   provider: string;
   envLabel: string;
@@ -168,6 +169,7 @@ export async function ensureApiKeyFromOptionEnvOrPrompt(params: {
   return await ensureApiKeyFromEnvOrPrompt({
     config: params.config,
     env: params.env,
+    workspaceDir: params.workspaceDir,
     provider: params.provider,
     envLabel: params.envLabel,
     promptMessage: params.promptMessage,
@@ -183,6 +185,7 @@ export async function ensureApiKeyFromOptionEnvOrPrompt(params: {
 export async function ensureApiKeyFromEnvOrPrompt(params: {
   config: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  workspaceDir?: string;
   provider: string;
   envLabel: string;
   promptMessage: string;
@@ -201,11 +204,9 @@ export async function ensureApiKeyFromEnvOrPrompt(params: {
   // runtime; dropping the staged config silently changes credential ownership.
   const envKey = resolveEnvApiKey(params.provider, env, {
     config: params.config,
-    workspaceDir: resolveAgentWorkspaceDir(
-      params.config,
-      resolveDefaultAgentId(params.config),
-      env,
-    ),
+    workspaceDir:
+      params.workspaceDir ??
+      resolveAgentWorkspaceDir(params.config, resolveDefaultAgentId(params.config), env),
   });
 
   if (selectedMode === "ref") {

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -53,15 +53,6 @@ export const getGatewayContextResolver = (owner: object) => gatewayContextResolv
 
 export const clearGatewayContextResolver = (owner: object) => gatewayContextResolvers.delete(owner);
 
-export function getSharedGatewayContextResolver(
-  owners: readonly object[],
-): GatewayContextResolver | undefined {
-  const first = owners[0] ? gatewayContextResolvers.get(owners[0]) : undefined;
-  return first && owners.every((owner) => gatewayContextResolvers.get(owner) === first)
-    ? first
-    : undefined;
-}
-
 /**
  * Runs plugin gateway handlers with request-scoped context that runtime helpers can read.
  */


### PR DESCRIPTION
Related: #125768

## What Problem This Solves

Fixes an issue where guided `openclaw agents add` could persist provider credentials before the new agent and its model/auth configuration were durably created. Cancelling a later prompt or hitting a creation/config failure could leave credentials for an agent that did not exist; reversing the order could instead publish unusable config without credentials.

The real CLI also lost the explicitly selected staged-agent workspace during API-key discovery, causing guided auth to fail with “multiple agents configured” before the key prompt.

## Why This Change Was Made

The guided flow now stages portable and provider credentials until the canonical config publication edge. Credential batches commit atomically in SQLite immediately before config publication and return an ownership-scoped rollback receipt; handled config/create failures restore only values still owned by that attempt, preserving unrelated writes and newer concurrent credentials. Portable copies remain non-overwriting.

Canonical `createAgent` owns the exact new-agent publication edge, while existing-agent updates use the equivalent credential-then-config transaction with conditional compensation. Provider auth input also carries the already prepared workspace instead of rediscovering a global default from staged multi-agent config.

This preserves the channel post-write and guided JSON behavior from #125768. No SQLite schema/version change or compatibility path is introduced. A process crash in the narrow interval between the SQLite commit and config-file publication remains outside this non-journaled repair.

AI-assisted: yes. The resulting code, ownership boundary, tests, and live behavior were reviewed directly.

## User Impact

Operators can configure model auth while adding a new agent without creating orphan credential databases or durable config that lacks its required credentials. Cancelling after entering credentials leaves no agent and no stored credential; completing the wizard creates both together. Concurrent credential updates are not erased by rollback.

## Evidence

- Pre-fix regression: the portable-auth cancellation case left `openai:api-key` in the destination auth store while no agent was created.
- Current `main` inspection: guided provider auth still called eager `applyAuthChoice` before model validation, channel prompts, workspace setup, and canonical creation.
- Focused Vitest: 113 tests passed across `agents.add`, provider auth input, canonical agent creation, SQLite batch persistence, and plugin-provider auth choice.
- `check:changed`: passed all selected core/coreTests formatting, typecheck, lint, dead-export, import-cycle, database-first, schema-version, and boundary guards. The tool ran in an isolated pnpm home because the shared host dlx cache was corrupt.
- Build: `pnpm build` passed; a subsequent uncached core/runtime rebuild passed after the final auth-input changes.
- Live isolated PTY proof with the built CLI and a synthetic OpenAI key:
  - Cancel after credential entry at the later channel prompt: exit 1, agent absent from `agents list --json`, zero persisted auth profiles.
  - Complete the wizard: exit 0, agent present, `openai:api-key` persisted, ready message shown.
  - Both flows reached the post-auth prompt without the prior multi-agent owner error or a false missing-auth warning.
- ClawSweeper’s old-head P1 was addressed systematically: the prepared workspace now reaches direct/custom API-key setup for Microsoft Foundry, PixVerse, Xiaomi, Z.AI, Cloudflare AI Gateway, Ollama, and LM Studio. A PixVerse staged multi-agent setup exercises the custom-provider path; 246 focused extension tests and core + extension tsgo passed.
- Exact-head CI initially exposed an unrelated current-`main` regression from #126040: detached lifecycle dispatch still forwarded the retired `resolveGatewayContext` option. The obsolete resolver thread was removed, `pnpm tsgo:core` passed, and 204 focused subagent delivery tests passed.
- A later exact-head run found the corresponding obsolete shared-resolver export plus an explicit auth-profile module mock that had not modeled atomic batch persistence. The dead production/test-only path was deleted, the mock now implements the public batch effect, and both previously failing CI lanes pass locally (`auth-choice.test.ts`, gateway context binding, `deadcode:dependencies`, and `deadcode:exports`).
- Final Codex autoreview: clean, no accepted/actionable findings.

Production LOC: +273/-123 (net +150) | Tests: +534/-79 (net +455). The production growth is the atomic multi-profile write plus profile-scoped conditional rollback boundary; the existing whole-store receipt cannot remove attempt-owned profiles after an unrelated concurrent auth write without clobbering or leaking state. The provider additions systematically carry an existing prepared fact, and the red-main repair is net-negative production cleanup completing #126040's active-runtime migration.
