### PR TITLE
fix(copilot): finalize settled BYOK tool turns reliably

### DIFF
--- a/extensions/copilot/src/attempt-config.ts
+++ b/extensions/copilot/src/attempt-config.ts
@@ -71,7 +71,7 @@ export function createResult(
     params.operation === "settled-tool-finalization"
       ? {
           hadPotentialSideEffects: false,
-          replaySafe: state.nativeReplayInvalid !== true && !transcriptPersistenceFailed,
+          replaySafe: !transcriptPersistenceFailed,
         }
       : computeReplayMetadata({
           priorReplayInvalid:

--- a/extensions/copilot/src/attempt-execution.ts
+++ b/extensions/copilot/src/attempt-execution.ts
@@ -363,6 +363,8 @@ export async function runCopilotExecution(context: {
         session = (await client.resumeSession(resumeSessionId, {
           ...sessionConfig,
           continuePendingWork: false,
+          // Settled finalization must not replay lifecycle from the completed turn.
+          ...(settledToolFinalization ? { suppressResumeEvent: true } : {}),
         })) as unknown as SessionLike;
         nativeSessionHistoryValidated = input.initialReplayState?.journalValidated === true;
       } catch (error: unknown) {

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -1451,6 +1451,7 @@ describe("runCopilotAttempt", () => {
     expect(
       (requireResumeSessionConfig(sdk) as { continuePendingWork?: boolean }).continuePendingWork,
     ).toBe(false);
+    expect(requireResumeSessionConfig(sdk)).not.toHaveProperty("suppressResumeEvent");
     expect(sdk.createSession).toHaveBeenCalledTimes(0);
     expect(result.replayMetadata.replaySafe).toBe(true);
     expect(
@@ -4540,7 +4541,15 @@ describe("runCopilotAttempt", () => {
       );
       const sdk = makeFakeSdk({
         onResumeSession: (session, _sessionId, config) => {
-          session.sendAndWait.mockImplementationOnce(async () => {
+          session.sendAndWait.mockImplementationOnce(async (options) => {
+            const systemMessage = (config.systemMessage as { content?: unknown } | undefined)
+              ?.content;
+            if (typeof systemMessage === "string") {
+              session.emit("system.message", {
+                __eventId: "finalization-system",
+                content: systemMessage,
+              });
+            }
             if (config.suppressResumeEvent !== true) {
               session.emit("assistant.message", {
                 __eventId: "prior-tool-assistant",
@@ -4558,6 +4567,12 @@ describe("runCopilotAttempt", () => {
                 toolCallId: "prior-tool-call",
               });
             }
+            const prompt = (options as { prompt?: unknown } | undefined)?.prompt;
+            session.emit("user.message", {
+              __eventId: "finalization-user",
+              content: typeof prompt === "string" ? prompt : "",
+              transformedContent: `sdk-wrapped:${typeof prompt === "string" ? prompt : ""}`,
+            });
             return makeAssistantMessageEvent("final answer");
           });
         },
@@ -4602,6 +4617,10 @@ describe("runCopilotAttempt", () => {
       expect(result.currentAttemptCompletedAssistant).toMatchObject({
         content: [{ type: "text", text: "final answer" }],
         stopReason: "stop",
+      });
+      expect(result.replayMetadata).toEqual({
+        hadPotentialSideEffects: false,
+        replaySafe: true,
       });
       expect({
         itemLifecycle: result.itemLifecycle,

--- a/extensions/copilot/src/attempt.test.ts
+++ b/extensions/copilot/src/attempt.test.ts
@@ -4539,8 +4539,27 @@ describe("runCopilotAttempt", () => {
         ]),
       );
       const sdk = makeFakeSdk({
-        onResumeSession: (session) => {
-          session.sendAndWait.mockResolvedValueOnce(makeAssistantMessageEvent("final answer"));
+        onResumeSession: (session, _sessionId, config) => {
+          session.sendAndWait.mockImplementationOnce(async () => {
+            if (config.suppressResumeEvent !== true) {
+              session.emit("assistant.message", {
+                __eventId: "prior-tool-assistant",
+                content: "",
+                messageId: "prior-tool-message",
+                toolRequests: [{ arguments: {}, name: "read", toolCallId: "prior-tool-call" }],
+              });
+              session.emit("tool.execution_start", {
+                toolCallId: "prior-tool-call",
+                toolName: "read",
+              });
+              session.emit("tool.execution_complete", {
+                result: { content: "prior tool result" },
+                success: true,
+                toolCallId: "prior-tool-call",
+              });
+            }
+            return makeAssistantMessageEvent("final answer");
+          });
         },
       });
       const permissivePolicy = vi.fn(async () => ({ kind: "approved" }) as never);
@@ -4584,7 +4603,17 @@ describe("runCopilotAttempt", () => {
         content: [{ type: "text", text: "final answer" }],
         stopReason: "stop",
       });
-      expect(result.toolMetas).toEqual([]);
+      expect({
+        itemLifecycle: result.itemLifecycle,
+        toolMetas: result.toolMetas,
+      }).toEqual({
+        itemLifecycle: {
+          activeCount: 0,
+          completedCount: 0,
+          startedCount: 0,
+        },
+        toolMetas: [],
+      });
       expect(sdk.createSession).not.toHaveBeenCalled();
       expect(sdk.resumeSession).toHaveBeenCalledTimes(1);
       expect(pool.acquire).toHaveBeenCalledWith(
@@ -4597,6 +4626,7 @@ describe("runCopilotAttempt", () => {
         coauthorEnabled: false,
         continuePendingWork: false,
         customAgents: [],
+        suppressResumeEvent: true,
         customAgentsLocalOnly: true,
         embeddingCacheStorage: "in-memory",
         enableConfigDiscovery: false,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Copilot runtime users using OpenAI BYOK could complete tool work successfully, then lose the final answer because settled-turn finalization rejected its own terminal result as capability activity.

The live failure was `replayMetadata.replaySafe: false`; all actual finalization capability fields were empty after resume lifecycle suppression. The Copilot SDK had expanded the known internal finalizer system prompt and transformed its user prompt, so ordinary transcript-reconstruction completeness was incorrectly vetoing a terminal-only finalization result.

## Why This Change Was Made

Settled finalization now resumes the exact compatible SDK session without emitting resume lifecycle, and its terminal replay metadata stays independent of ordinary native transcript reconstruction. Transcript persistence failures still fail closed, the core capability assertion is unchanged, and Copilot prompt-guidance policy is untouched.

This repairs the owner boundaries introduced with the settled finalizer in #110565 and later carried through the attempt-runtime split in #114035 rather than filtering capability evidence downstream.

Production LOC: +3/-1 (net +2) | Tests: +52/-3

## User Impact

Completed Copilot BYOK tool turns can now produce their visible final answer without repeating the tool or failing at finalization. Ordinary resumed Copilot sessions keep their existing resume behavior.

AI-assisted: yes. The final branch received a clean Codex autoreview after rebasing onto current `main`.

## Evidence

- Current-`main` focused regression failed before the fix with replayed tool lifecycle attributed to finalization: `toolMetas` contained one completed tool and `itemLifecycle` reported `startedCount: 1`, `completedCount: 1`, `activeCount: 0`.
- After suppressing resume lifecycle, the focused regression exposed the actual live blocker: `replayMetadata` was `{ hadPotentialSideEffects: false, replaySafe: false }` because expected SDK-transformed finalizer context marked ordinary transcript reconstruction incomplete.
- `node scripts/run-vitest.mjs extensions/copilot/src/attempt.test.ts -t "resumes with every ambient Copilot capability disabled"` — 1 passed, 151 skipped.
- `node scripts/run-vitest.mjs extensions/copilot/src/attempt.test.ts` — 152 passed.
- OpenAI BYOK focused live finalization with `gpt-5.6-sol` — passed with exact assistant text `COPILOT-SETTLED-FINALIZER-OK`, zero final capability events, zero permission requests, zero user-input requests, and the original `live_echo` call executed exactly once.
- Full `extensions/copilot/src/attempt.live.test.ts` through OpenAI BYOK — 2 passed.
- Repository formatter check on all three changed files — passed.
- `git diff --check` — passed.
- Final `autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
