### PR TITLE
fix(mcp): retire stale transports and process trees

### DIFF
--- a/src/agents/mcp-http-transport.test.ts
+++ b/src/agents/mcp-http-transport.test.ts
@@ -75,6 +75,52 @@ describe("OpenClaw MCP HTTP lifecycle adapters", () => {
     await vi.waitFor(() => expect(onclose).toHaveBeenCalledOnce());
   });
 
+  it("closes an established legacy SSE transport after a terminal reconnect response", async () => {
+    let streamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const encoder = new TextEncoder();
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (method !== "GET") {
+        return new Response(null, { status: 202 });
+      }
+      if (!streamController) {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              streamController = controller;
+              controller.enqueue(
+                encoder.encode("retry: 1\n\nevent: endpoint\ndata: /messages\n\n"),
+              );
+            },
+          }),
+          { headers: { "content-type": "text/event-stream" } },
+        );
+      }
+      return new Response(null, { status: 503, statusText: "Unavailable" });
+    });
+    const transport = new OpenClawSSEClientTransport(new URL("http://mcp.invalid/sse"), {
+      fetch: fetchMock,
+      eventSourceInit: { fetch: fetchMock },
+    });
+    const onclose = vi.fn();
+    // MCP transports expose callback properties rather than EventTarget listeners.
+    // oxlint-disable-next-line unicorn/prefer-add-event-listener
+    transport.onclose = onclose;
+
+    try {
+      await transport.start();
+      streamController?.close();
+
+      await vi.waitFor(() => expect(onclose).toHaveBeenCalledOnce());
+      await expect(transport.send({ jsonrpc: "2.0", id: 1, method: "tools/list" })).rejects.toThrow(
+        "closed",
+      );
+      expect(fetchMock.mock.calls.filter((call) => call[1]?.method === "POST")).toHaveLength(0);
+    } finally {
+      await transport.close();
+    }
+  });
+
   it("closes after Streamable notification retry exhaustion", async () => {
     let getCount = 0;
     const fetchMock = initializedFetch({
@@ -105,6 +151,30 @@ describe("OpenClaw MCP HTTP lifecycle adapters", () => {
     await client.connect(transport);
     await vi.waitFor(() => expect(onclose).toHaveBeenCalledOnce());
     expect(fetchMock.mock.calls.filter((call) => call[1]?.method === "GET")).toHaveLength(3);
+  });
+
+  it("closes a stateful Streamable session when its initial notification GET expired", async () => {
+    const fetchMock = initializedFetch({
+      onGet: () => new Response("Session not found", { status: 404, statusText: "Not Found" }),
+    });
+    const transport = new OpenClawStreamableHTTPClientTransport(new URL("http://mcp.invalid/mcp"), {
+      fetch: fetchMock,
+    });
+    const client = new Client({ name: "test", version: "1" });
+    const onclose = vi.fn();
+    // MCP clients expose callback properties rather than EventTarget listeners.
+    // oxlint-disable-next-line unicorn/prefer-add-event-listener
+    client.onclose = onclose;
+
+    try {
+      await client.connect(transport);
+
+      await vi.waitFor(() => expect(onclose).toHaveBeenCalledOnce());
+      expect(transport.sessionId).toBe("session-1");
+      expect(fetchMock.mock.calls.filter((call) => call[1]?.method === "GET")).toHaveLength(1);
+    } finally {
+      await disposeMcpClient({ client, transport, transportType: "streamable-http" });
+    }
   });
 
   it("sends stateful DELETE after failed initialization closed the SDK transport", async () => {

--- a/src/agents/mcp-http-transport.ts
+++ b/src/agents/mcp-http-transport.ts
@@ -58,7 +58,7 @@ export class OpenClawSSEClientTransport extends OpenClawMcpHttpTransport {
     // oxlint-disable-next-line unicorn/prefer-add-event-listener
     this.transport.onerror = (error) => {
       this.emitError(error);
-      if (error instanceof SseError && error.code === 204) {
+      if (error instanceof SseError && error.code !== undefined) {
         void this.close();
       }
     };
@@ -75,6 +75,9 @@ export class OpenClawSSEClientTransport extends OpenClawMcpHttpTransport {
   }
 
   async send(message: JSONRPCMessage): Promise<void> {
+    if (this.closed) {
+      throw new Error("MCP SSE transport is closed");
+    }
     await this.transport.send(message);
   }
 
@@ -94,6 +97,7 @@ export class OpenClawStreamableHTTPClientTransport extends OpenClawMcpHttpTransp
   private readonly url: URL;
   private readonly cleanupFetch: FetchLike;
   private readonly requestInit?: RequestInit;
+  private pendingExpiredNotificationGet = false;
   private terminatedSessionId?: string;
 
   constructor(url: URL, options: OpenClawStreamableHttpOptions = {}) {
@@ -105,7 +109,11 @@ export class OpenClawStreamableHTTPClientTransport extends OpenClawMcpHttpTransp
       if (this.closed) {
         throw new Error("MCP Streamable HTTP transport is closed");
       }
-      return await this.cleanupFetch(input, init);
+      const response = await this.cleanupFetch(input, init);
+      if (init?.method === "GET" && response.status === 404 && this.sessionId !== undefined) {
+        this.pendingExpiredNotificationGet = true;
+      }
+      return response;
     };
     this.transport = new StreamableHTTPClientTransport(url, {
       ...options,
@@ -136,7 +144,14 @@ export class OpenClawStreamableHTTPClientTransport extends OpenClawMcpHttpTransp
         return;
       }
       this.emitError(error);
-      if (STREAM_RETRY_EXHAUSTED_RE.test(error.message)) {
+      const sessionExpired =
+        this.pendingExpiredNotificationGet &&
+        error instanceof StreamableHTTPError &&
+        error.code === 404;
+      if (sessionExpired) {
+        this.pendingExpiredNotificationGet = false;
+      }
+      if (sessionExpired || STREAM_RETRY_EXHAUSTED_RE.test(error.message)) {
         void this.close();
       }
     };

--- a/src/agents/mcp-stdio-transport.process.test.ts
+++ b/src/agents/mcp-stdio-transport.process.test.ts
@@ -52,4 +52,41 @@ describe.skipIf(process.platform === "win32")("OpenClaw stdio process-group owne
       }
     },
   );
+
+  it(
+    "kills same-group descendants after a graceful leader shutdown",
+    { timeout: 10_000 },
+    async () => {
+      const root = tempDirs.make("mcp-stdio-graceful-descendant-");
+      const serverPath = path.join(root, "leader.mjs");
+      const descendantPidPath = path.join(root, "descendant.pid");
+      await fs.writeFile(
+        serverPath,
+        `import {spawn} from "node:child_process"; import fs from "node:fs"; const child=spawn(process.execPath,["-e","setInterval(()=>{},1000)"],{stdio:"ignore"}); fs.writeFileSync(${JSON.stringify(descendantPidPath)},String(child.pid)); process.stdin.resume(); process.stdin.on("end",()=>process.exit(0));`,
+        "utf8",
+      );
+      const transport = new OpenClawStdioClientTransport({
+        command: process.execPath,
+        args: [serverPath],
+        stderr: "ignore",
+      });
+      let descendantPid = 0;
+      try {
+        await transport.start();
+        await vi.waitFor(async () => {
+          descendantPid = Number(await fs.readFile(descendantPidPath, "utf8"));
+          expect(isPidAlive(descendantPid)).toBe(true);
+        });
+
+        await transport.close();
+
+        await vi.waitFor(() => expect(isPidAlive(descendantPid)).toBe(false));
+      } finally {
+        await transport.forceClose();
+        if (descendantPid && isPidAlive(descendantPid)) {
+          process.kill(descendantPid, "SIGKILL");
+        }
+      }
+    },
+  );
 });

--- a/src/agents/mcp-stdio-transport.test.ts
+++ b/src/agents/mcp-stdio-transport.test.ts
@@ -7,7 +7,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
-const killProcessTreeMock = vi.hoisted(() => vi.fn());
 const signalProcessTreeMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => ({
@@ -16,7 +15,6 @@ vi.mock("node:child_process", async () => ({
 }));
 
 vi.mock("../process/kill-tree.js", () => ({
-  killProcessTree: killProcessTreeMock,
   signalProcessTree: signalProcessTreeMock,
 }));
 
@@ -35,7 +33,6 @@ describe("OpenClawStdioClientTransport", () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     spawnMock.mockReset();
-    killProcessTreeMock.mockReset();
     signalProcessTreeMock.mockReset();
   });
 
@@ -113,14 +110,14 @@ describe("OpenClawStdioClientTransport", () => {
 
     const closing = transport.close();
     await vi.advanceTimersByTimeAsync(2000);
-    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { detached: true });
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGTERM", { detached: true });
 
     child.exitCode = 0;
     child.emit("close", 0);
     await closing;
   });
 
-  it("force-SIGKILLs synchronously when killProcessTree's grace expires (#86412)", async () => {
+  it("force-SIGKILLs synchronously when the owned process group outlives TERM", async () => {
     vi.useFakeTimers();
     const child = new MockChildProcess();
     spawnMock.mockReturnValue(child);
@@ -132,11 +129,9 @@ describe("OpenClawStdioClientTransport", () => {
 
     const closing = transport.close();
     await vi.advanceTimersByTimeAsync(2000);
-    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { detached: true });
-    expect(signalProcessTreeMock).not.toHaveBeenCalled();
+    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGTERM", { detached: true });
+    expect(signalProcessTreeMock).not.toHaveBeenCalledWith(4321, "SIGKILL", { detached: true });
 
-    // killProcessTree's SIGKILL is .unref()'d (#86412); close() force-SIGKILLs
-    // synchronously instead.
     await vi.advanceTimersByTimeAsync(2000);
     expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGKILL", { detached: true });
 
@@ -166,24 +161,6 @@ describe("OpenClawStdioClientTransport", () => {
     await expect(closing).resolves.toBeUndefined();
     await expect(repeatedClose).resolves.toBeUndefined();
     expect(transport.pid).toBeNull();
-  });
-
-  it("does not kill the process tree when graceful stdio close exits", async () => {
-    vi.useFakeTimers();
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
-
-    const transport = new OpenClawStdioClientTransport({ command: "npx" });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    const closing = transport.close();
-    child.exitCode = 0;
-    child.emit("close", 0);
-    await closing;
-
-    expect(killProcessTreeMock).not.toHaveBeenCalled();
   });
 
   it("immediately kills the retained process group after the stdio leader exits", async () => {

--- a/src/agents/mcp-stdio-transport.ts
+++ b/src/agents/mcp-stdio-transport.ts
@@ -11,7 +11,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { mergeProcessEnv } from "../infra/process-env.js";
-import { killProcessTree, signalProcessTree } from "../process/kill-tree.js";
+import { signalProcessTree } from "../process/kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
 
 type OpenClawStdioServerParameters = {
@@ -96,11 +96,10 @@ export class OpenClawStdioClientTransport implements Transport {
       });
       child.on("spawn", () => resolve());
       child.on("close", () => {
-        const exitedUnexpectedly = this.process === child && this.closingProcess !== child;
         if (this.process === child) {
           this.process = undefined;
         }
-        if (exitedUnexpectedly && child.pid && this.ownedProcessGroupId === child.pid) {
+        if (child.pid && this.ownedProcessGroupId === child.pid) {
           // The leader still owns this PGID at close notification time. Kill any
           // descendants now so a retained numeric PGID can never outlive ownership.
           signalProcessTree(child.pid, "SIGKILL", { detached: true });
@@ -154,9 +153,6 @@ export class OpenClawStdioClientTransport implements Transport {
     this.process = undefined;
     this.closingProcess = processToClose;
     if (processToClose) {
-      this.closingProcess = processToClose;
-    }
-    if (processToClose) {
       const closePromise = new Promise<void>((resolve) => {
         processToClose.once("close", () => resolve());
       });
@@ -167,10 +163,9 @@ export class OpenClawStdioClientTransport implements Transport {
       }
       await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS)]);
       if (processToClose.exitCode === null && processToClose.pid) {
-        killProcessTree(processToClose.pid, { detached: true });
+        signalProcessTree(processToClose.pid, "SIGTERM", { detached: true });
         await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS)]);
         if (processToClose.exitCode === null && processToClose.pid) {
-          // SIGKILL synchronously: killProcessTree's setTimeout is .unref()'d and races shutdown (#86412).
           signalProcessTree(processToClose.pid, "SIGKILL", { detached: true });
           await Promise.race([closePromise, delay(SIGKILL_REAP_TIMEOUT_MS)]);
         }

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.test.ts
@@ -8,6 +8,7 @@ import {
   parseNodeMcpTextRecord,
   processIsAlive,
   startHttpFixture,
+  stopChild,
 } from "./gateway-node-mcp.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -49,5 +50,35 @@ describe("gateway node MCP fixture ownership", () => {
       }
     }
     expect(processIsAlive(pid)).toBe(false);
+  });
+
+  it("kills task-owned fixture descendants when stopping the captured root", async () => {
+    const root = tempDirs.make("mcp-fixture-descendant-cleanup-");
+    const fixturePath = path.join(root, "fixture.mjs");
+    const descendantPidPath = path.join(root, "descendant.pid");
+    await fs.writeFile(
+      fixturePath,
+      `import {spawn} from "node:child_process"; import fs from "node:fs"; const child=spawn(process.execPath,["-e","setInterval(()=>{},1000)"],{stdio:"ignore"}); fs.writeFileSync(${JSON.stringify(descendantPidPath)},String(child.pid)); console.log(JSON.stringify({type:"openclaw-mcp-parity-ready",urls:{streamableHttp:"http://127.0.0.1/mcp",sse:"http://127.0.0.1/sse"}})); setInterval(()=>{},1000);`,
+      "utf8",
+    );
+
+    const fixture = await startHttpFixture({
+      fixturePath,
+      labelPrefix: "node",
+      env: createChildEnv({ home: root, tempDir: os.tmpdir() }),
+    });
+    const descendantPid = Number(await fs.readFile(descendantPidPath, "utf8"));
+    try {
+      expect(processIsAlive(descendantPid)).toBe(true);
+
+      await stopChild(fixture);
+
+      await vi.waitFor(() => expect(processIsAlive(descendantPid)).toBe(false), { timeout: 1_000 });
+    } finally {
+      await stopChild(fixture);
+      if (processIsAlive(descendantPid)) {
+        process.kill(descendantPid, "SIGKILL");
+      }
+    }
   });
 });

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.ts
@@ -9,6 +9,7 @@ import { expect, vi } from "vitest";
 import type { startQaGatewayChild } from "../../../../extensions/qa-lab/api.js";
 import type { NodePluginToolDescriptor } from "../../../../packages/gateway-protocol/src/schema/nodes.js";
 import type { McpServerConfig } from "../../../../src/config/types.mcp.js";
+import { signalProcessTree } from "../../../../src/process/kill-tree.js";
 
 export const TEST_TIMEOUT_MS = 180_000;
 const WAIT_TIMEOUT_MS = 30_000;
@@ -25,6 +26,7 @@ export type CapturedChild = {
   child: ChildProcess;
   exited: Promise<void>;
   logs: () => string;
+  signalTree: (signal: "SIGTERM" | "SIGKILL") => Promise<void>;
 };
 export type HttpFixture = CapturedChild & {
   pid: number;
@@ -66,10 +68,41 @@ function captureChild(child: ChildProcess): CapturedChild {
   child.stderr?.on("data", (chunk: Buffer) => {
     stderr = (stderr + chunk.toString()).slice(-200_000);
   });
+  const pid = child.pid;
+  let termPromise: Promise<void> | undefined;
+  let killPromise: Promise<void> | undefined;
+  const signalTree = (signal: "SIGTERM" | "SIGKILL") => {
+    const existing = signal === "SIGKILL" ? killPromise : termPromise;
+    if (existing) {
+      return existing;
+    }
+    const signaled = new Promise<void>((resolve) => {
+      if (pid === undefined) {
+        resolve();
+        return;
+      }
+      signalProcessTree(pid, signal, {
+        detached: process.platform !== "win32",
+        onComplete: resolve,
+      });
+    });
+    if (signal === "SIGKILL") {
+      killPromise = signaled;
+    } else {
+      termPromise = signaled;
+    }
+    return signaled;
+  };
+  const exited = once(child, "exit").then(async () => {
+    // The root PID still identifies this task-owned tree at exit delivery. Reap
+    // descendants before any retained numeric process-group authority can age.
+    await signalTree("SIGKILL");
+  });
   return {
     child,
-    exited: once(child, "exit").then(() => {}),
+    exited,
     logs: () => `stdout:\n${stdout}\nstderr:\n${stderr}`,
+    signalTree,
   };
 }
 
@@ -107,6 +140,7 @@ export async function startHttpFixture(params: {
   const captured = captureChild(
     spawn(process.execPath, [params.fixturePath, "http", "--label-prefix", params.labelPrefix], {
       cwd: process.cwd(),
+      detached: process.platform !== "win32",
       env: params.env,
       stdio: ["ignore", "pipe", "pipe"],
     }),
@@ -174,6 +208,7 @@ export function startNodeProcess(gatewayPort: number, nodeEnv: NodeJS.ProcessEnv
       ],
       {
         cwd: process.cwd(),
+        detached: process.platform !== "win32",
         env: nodeEnv,
         stdio: ["ignore", "pipe", "pipe"],
       },
@@ -186,15 +221,15 @@ export async function stopChild(captured: CapturedChild | undefined): Promise<vo
     await captured?.exited.catch(() => {});
     return;
   }
-  captured.child.kill("SIGTERM");
+  await captured.signalTree("SIGTERM");
   const graceful = await Promise.race([
     captured.exited.then(() => true),
     delay(10_000, false, { ref: false }),
   ]);
   if (!graceful) {
-    captured.child.kill("SIGKILL");
-    await captured.exited;
+    await captured.signalTree("SIGKILL");
   }
+  await captured.exited;
 }
 
 export function processIsAlive(pid: number): boolean {


### PR DESCRIPTION
Closes #126098
Closes #126099
Closes #126100

## What Problem This Solves

Fixes issues where MCP lifecycle owners could keep stale tools or processes after a terminal transport boundary:

- a graceful stdio server exit could leave same-group descendants running;
- an established legacy SSE stream could receive a terminal reconnect response without becoming visibly closed;
- a stateful Streamable HTTP notification GET could return session-expired 404 while the session/catalog remained attached.

The QA fixture helper had the same root-only teardown gap, allowing task-owned descendants to contaminate later real-process tests.

## Why This Change Was Made

The repair moves cleanup to the exact owners that still hold valid authority. Stdio groups are reaped synchronously when the leader exits, HTTP wrappers translate dependency-specific terminal errors into the existing close boundary, and QA children are spawned/signaled as whole task-owned trees. Stateful POST expiry remains with the request recovery owner and is never replayed.

The dependency contracts were checked directly in `@modelcontextprotocol/sdk` 1.30.0 and `eventsource`: status-bearing legacy SSE errors are terminal without an SDK close callback, while status-less network errors remain reconnectable; Streamable notification GET failures report through `onerror` without closing.

Production LOC: +21/-11 (net +10) | Tests/test support: +181/-31 (net +150)

## User Impact

Operators can expect terminal MCP outages and session expiry to retire stale tools immediately, and stdio MCP helpers to stop with their owning session/node instead of leaking across runs. Transient legacy SSE network disconnects still reconnect, and stateful mutating requests are not replayed.

## Evidence

Pre-fix regressions, added before production repair:

- `gateway-node-mcp.test-support.test.ts`: descendant remained alive after `stopChild()`.
- `mcp-stdio-transport.process.test.ts`: descendant remained alive after graceful `transport.close()`.
- `mcp-http-transport.test.ts`: both terminal SSE reconnect 503 and stateful notification GET 404 emitted zero close callbacks.

Post-fix proof:

- `node scripts/run-vitest.mjs src/agents/mcp-stdio-transport.test.ts src/agents/mcp-stdio-transport.process.test.ts src/agents/mcp-http-transport.test.ts test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.test.ts src/node-host/mcp.recovery.test.ts` — 37 tests passed.
- `node scripts/run-tsgo-core-test-shards.mjs` — passed.
- `node scripts/check-changed.mjs -- <seven touched paths>` — all proportional format, guard, typecheck, lint, dead-export, schema, and import-cycle checks passed.
- `corepack pnpm build` — passed.
- `OPENCLAW_BUILD_PRIVATE_QA=1 corepack pnpm build qaRuntime` — passed.
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-node-mcp.stress.e2e.test.ts` — passed the real built-dist Gateway/node MCP stress flow, including terminal SSE/Streamable recovery, stateful no-replay recovery, repeated stdio crash generations, descendant reaping, and fixture cleanup.
- Fresh Codex-backed autoreview at P1 — clean; no accepted/actionable findings.

Real process and built-dist proof ran on macOS/POSIX. Windows uses the existing repository `signalProcessTree()` / `taskkill /T` contract; exact-head CI supplies the cross-platform gate.

AI-assisted: implementation and review used coding agents; the resulting code, dependency contracts, regressions, and runtime proof were inspected directly.
