### PR TITLE
fix(ui): dismiss completed progress cards

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1257,21 +1257,25 @@ public struct ProgressCardPutParams: Codable, Sendable {
     public let sessionkey: String
     public let markdown: String?
     public let plan: [ProgressCardStep]?
+    public let expectedrevision: Int?
 
     public init(
         sessionkey: String,
         markdown: String? = nil,
-        plan: [ProgressCardStep]? = nil)
+        plan: [ProgressCardStep]? = nil,
+        expectedrevision: Int? = nil)
     {
         self.sessionkey = sessionkey
         self.markdown = markdown
         self.plan = plan
+        self.expectedrevision = expectedrevision
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case markdown
         case plan
+        case expectedrevision = "expectedRevision"
     }
 }
 

--- a/packages/gateway-protocol/src/schema/progress-card.ts
+++ b/packages/gateway-protocol/src/schema/progress-card.ts
@@ -43,6 +43,7 @@ export const ProgressCardPutParamsSchema = closedObject({
   sessionKey: NonEmptyString,
   markdown: Type.Optional(Type.String()),
   plan: Type.Optional(Type.Array(ProgressCardStepSchema, { maxItems: PROGRESS_CARD_MAX_STEPS })),
+  expectedRevision: Type.Optional(Type.Integer({ minimum: 1 })),
 });
 export type ProgressCardPutParams = Static<typeof ProgressCardPutParamsSchema>;
 

--- a/src/gateway/progress-card-store.ts
+++ b/src/gateway/progress-card-store.ts
@@ -1,5 +1,8 @@
 import type { ProgressCard, ProgressCardStep } from "../../packages/gateway-protocol/src/index.js";
-import { readSessionProgressCard, writeSessionProgressCard } from "../session-cards/progress-card-store.js";
+import {
+  readSessionProgressCard,
+  writeSessionProgressCard,
+} from "../session-cards/progress-card-store.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import {
   openOpenClawAgentDatabase,

--- a/src/gateway/progress-card-store.ts
+++ b/src/gateway/progress-card-store.ts
@@ -1,8 +1,5 @@
 import type { ProgressCard, ProgressCardStep } from "../../packages/gateway-protocol/src/index.js";
-import {
-  readSessionProgressCard,
-  writeSessionProgressCard,
-} from "../session-cards/progress-card-store.js";
+import { readSessionProgressCard, writeSessionProgressCard } from "../session-cards/progress-card-store.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import {
   openOpenClawAgentDatabase,
@@ -14,7 +11,7 @@ export type ProgressCardStore = {
   get(sessionKey: string): ProgressCard | null;
   put(
     sessionKey: string,
-    input: { markdown?: string; steps?: ProgressCardStep[] },
+    input: { markdown?: string; steps?: ProgressCardStep[]; expectedRevision?: number },
   ): { card: ProgressCard | null };
 };
 

--- a/src/gateway/server-methods/progress-card.test.ts
+++ b/src/gateway/server-methods/progress-card.test.ts
@@ -39,10 +39,7 @@ function createHarness() {
   };
   const handlers = createProgressCardHandlers(store);
   const broadcast = vi.fn();
-  const invoke = async (
-    method: "progressCard.get" | "progressCard.put",
-    params: unknown,
-  ) => {
+  const invoke = async (method: "progressCard.get" | "progressCard.put", params: unknown) => {
     const respond = vi.fn<RespondFn>();
     await handlers[method]!({
       params,

--- a/src/gateway/server-methods/progress-card.test.ts
+++ b/src/gateway/server-methods/progress-card.test.ts
@@ -18,7 +18,11 @@ function createHarness() {
   const store: ProgressCardStore = {
     get: (sessionKey) => cards.get(sessionKey) ?? null,
     put: (sessionKey, input) => {
+      const current = cards.get(sessionKey);
       if (!input.markdown && !input.steps?.length) {
+        if (input.expectedRevision !== undefined && current?.revision !== input.expectedRevision) {
+          return { card: current ?? null };
+        }
         cards.delete(sessionKey);
         return { card: null };
       }
@@ -35,7 +39,10 @@ function createHarness() {
   };
   const handlers = createProgressCardHandlers(store);
   const broadcast = vi.fn();
-  const invoke = async (method: "progressCard.get" | "progressCard.put", params: unknown) => {
+  const invoke = async (
+    method: "progressCard.get" | "progressCard.put",
+    params: unknown,
+  ) => {
     const respond = vi.fn<RespondFn>();
     await handlers[method]!({
       params,
@@ -152,6 +159,36 @@ describe("progress card gateway methods", () => {
     const clear = await invoke("progressCard.put", { sessionKey: "agent:main:main" });
 
     expect(clear).toHaveBeenCalledWith(true, { card: null }, undefined);
+    expect(broadcast).toHaveBeenCalledWith("progressCard.changed", {
+      sessionKey: "agent:main:main",
+      revision: null,
+    });
+  });
+
+  it("dismisses only the matching completed revision", async () => {
+    const { broadcast, invoke } = createHarness();
+    await invoke("progressCard.put", {
+      sessionKey: "agent:main:main",
+      plan: [{ step: "Done", status: "completed" }],
+    });
+    broadcast.mockClear();
+
+    const stale = await invoke("progressCard.put", {
+      sessionKey: "agent:main:main",
+      expectedRevision: 2,
+    });
+    const dismissed = await invoke("progressCard.put", {
+      sessionKey: "agent:main:main",
+      expectedRevision: 1,
+    });
+
+    expect(stale).toHaveBeenCalledWith(
+      true,
+      { card: expect.objectContaining({ revision: 1 }) },
+      undefined,
+    );
+    expect(dismissed).toHaveBeenCalledWith(true, { card: null }, undefined);
+    expect(broadcast).toHaveBeenCalledOnce();
     expect(broadcast).toHaveBeenCalledWith("progressCard.changed", {
       sessionKey: "agent:main:main",
       revision: null,

--- a/src/gateway/server-methods/progress-card.ts
+++ b/src/gateway/server-methods/progress-card.ts
@@ -71,16 +71,26 @@ export function createProgressCardHandlers(
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, error.message));
         return;
       }
+      if (params.expectedRevision !== undefined && (input.markdown || input.steps?.length)) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "expectedRevision is only valid when clearing a card"),
+        );
+        return;
+      }
       const sessionKey = resolveProgressCardSessionKey(params.sessionKey, context, respond);
       if (!sessionKey) {
         return;
       }
       try {
-        const result = store.put(sessionKey, input);
-        context.broadcast("progressCard.changed", {
-          sessionKey,
-          revision: result.card?.revision ?? null,
-        });
+        const result = store.put(sessionKey, { ...input, expectedRevision: params.expectedRevision });
+        if (params.expectedRevision === undefined || result.card === null) {
+          context.broadcast("progressCard.changed", {
+            sessionKey,
+            revision: result.card?.revision ?? null,
+          });
+        }
         respond(true, result, undefined);
       } catch (error) {
         respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, String(error)));

--- a/src/gateway/server-methods/progress-card.ts
+++ b/src/gateway/server-methods/progress-card.ts
@@ -75,7 +75,10 @@ export function createProgressCardHandlers(
         respond(
           false,
           undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, "expectedRevision is only valid when clearing a card"),
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "expectedRevision is only valid when clearing a card",
+          ),
         );
         return;
       }
@@ -84,7 +87,10 @@ export function createProgressCardHandlers(
         return;
       }
       try {
-        const result = store.put(sessionKey, { ...input, expectedRevision: params.expectedRevision });
+        const result = store.put(sessionKey, {
+          ...input,
+          expectedRevision: params.expectedRevision,
+        });
         if (params.expectedRevision === undefined || result.card === null) {
           context.broadcast("progressCard.changed", {
             sessionKey,

--- a/src/session-cards/progress-card-store.test.ts
+++ b/src/session-cards/progress-card-store.test.ts
@@ -88,4 +88,42 @@ describe("session progress card store", () => {
 
     expect(readSessionProgressCard(db, SESSION_KEY)).toBeNull();
   });
+
+  it("dismisses only a completed card at the expected revision", () => {
+    writeSessionProgressCard(db, SESSION_KEY, {
+      steps: [{ step: "Done", status: "completed" }],
+    });
+
+    expect(writeSessionProgressCard(db, SESSION_KEY, { expectedRevision: 2 })).toEqual({
+      card: expect.objectContaining({ revision: 1 }),
+    });
+    expect(readSessionProgressCard(db, SESSION_KEY)).not.toBeNull();
+    expect(writeSessionProgressCard(db, SESSION_KEY, { expectedRevision: 1 })).toEqual({
+      cleared: true,
+    });
+    expect(readSessionProgressCard(db, SESSION_KEY)).toBeNull();
+
+    expect(
+      writeSessionProgressCard(db, SESSION_KEY, {
+        steps: [{ step: "New work", status: "in_progress" }],
+      }),
+    ).toEqual({
+      card: expect.objectContaining({ revision: 3 }),
+    });
+    expect(writeSessionProgressCard(db, SESSION_KEY, { expectedRevision: 1 })).toEqual({
+      card: expect.objectContaining({ revision: 3 }),
+    });
+  });
+
+  it("does not dismiss an active or note-only card", () => {
+    writeSessionProgressCard(db, SESSION_KEY, { steps: STEPS });
+    expect(writeSessionProgressCard(db, SESSION_KEY, { expectedRevision: 1 })).toEqual({
+      card: expect.objectContaining({ revision: 1 }),
+    });
+
+    writeSessionProgressCard(db, SESSION_KEY, { markdown: "Still relevant" });
+    expect(writeSessionProgressCard(db, SESSION_KEY, { expectedRevision: 2 })).toEqual({
+      card: expect.objectContaining({ revision: 2 }),
+    });
+  });
 });

--- a/src/session-cards/progress-card-store.ts
+++ b/src/session-cards/progress-card-store.ts
@@ -61,8 +61,11 @@ function selectProgressCard(db: DatabaseSync, sessionKey: string): StoredProgres
   );
 }
 
-function rowToProgressCard(row: StoredProgressCardRow): ProgressCard {
+function rowToProgressCard(row: StoredProgressCardRow): ProgressCard | null {
   const steps = row.steps_json ? readStoredSteps(row.steps_json) : undefined;
+  if (!row.markdown && !steps?.length) {
+    return null;
+  }
   return {
     sessionKey: row.session_key,
     revision: row.revision,
@@ -112,19 +115,41 @@ export function readSessionProgressCard(
 export function writeSessionProgressCard(
   dbPathOrDb: ProgressCardDatabaseInput,
   sessionKey: string,
-  input: { markdown?: string; steps?: ProgressCardStep[] },
-): { card: ProgressCard } | { cleared: true } {
+  input: { markdown?: string; steps?: ProgressCardStep[]; expectedRevision?: number },
+): { card: ProgressCard | null } | { cleared: true } {
   return withProgressCardDatabase(dbPathOrDb, false, (db, label) => {
-    const write = (): { card: ProgressCard } | { cleared: true } => {
+    const write = (): { card: ProgressCard | null } | { cleared: true } => {
       ensureOpenClawAgentProgressCardSchemaInTransaction(db);
       const kysely = getNodeSqliteKysely<ProgressCardDatabase>(db);
       const markdown = input.markdown?.trim() ? input.markdown : undefined;
       const steps = input.steps && input.steps.length > 0 ? input.steps : undefined;
       if (!markdown && !steps) {
-        executeSqliteQuerySync(
-          db,
-          kysely.deleteFrom("session_progress_cards").where("session_key", "=", sessionKey),
-        );
+        const previous = selectProgressCard(db, sessionKey);
+        if (input.expectedRevision !== undefined) {
+          const current = previous ? rowToProgressCard(previous) : null;
+          if (
+            !previous ||
+            previous.revision !== input.expectedRevision ||
+            !current?.steps?.length ||
+            current.steps.some((step) => step.status !== "completed")
+          ) {
+            return { card: current };
+          }
+        }
+        if (previous) {
+          executeSqliteQuerySync(
+            db,
+            kysely
+              .updateTable("session_progress_cards")
+              .set({
+                markdown: null,
+                steps_json: null,
+                revision: previous.revision + 1,
+                updated_at: Date.now(),
+              })
+              .where("session_key", "=", sessionKey),
+          );
+        }
         return { cleared: true };
       }
       const previous = selectProgressCard(db, sessionKey);

--- a/ui/src/components/session-progress-card-controller.ts
+++ b/ui/src/components/session-progress-card-controller.ts
@@ -28,6 +28,8 @@ export class SessionProgressCardController implements ReactiveController {
     return this.store?.get(this.sessionKey) ?? null;
   }
 
+  dismiss = (card: ProgressCard): Promise<boolean> => this.store?.dismiss(card) ?? Promise.resolve(false);
+
   hostUpdate(): void {
     this.synchronize();
   }

--- a/ui/src/components/session-progress-card-controller.ts
+++ b/ui/src/components/session-progress-card-controller.ts
@@ -28,7 +28,8 @@ export class SessionProgressCardController implements ReactiveController {
     return this.store?.get(this.sessionKey) ?? null;
   }
 
-  dismiss = (card: ProgressCard): Promise<boolean> => this.store?.dismiss(card) ?? Promise.resolve(false);
+  dismiss = (card: ProgressCard): Promise<boolean> =>
+    this.store?.dismiss(card) ?? Promise.resolve(false);
 
   hostUpdate(): void {
     this.synchronize();

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -2,7 +2,7 @@
 
 import type { ProgressCard } from "@openclaw/gateway-protocol";
 import { render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { renderSessionProgressCard } from "./session-progress-card.ts";
 
 const progressCard: ProgressCard = {
@@ -50,19 +50,4 @@ describe("renderSessionProgressCard", () => {
     ]);
   });
 
-  it("offers dismissal only for a completed checklist", () => {
-    const container = document.createElement("div");
-    const completed = {
-      ...progressCard,
-      steps: progressCard.steps?.map((step) => ({ ...step, status: "completed" as const })),
-    };
-    const onDismiss = vi.fn();
-
-    render(renderSessionProgressCard(completed, "composer", onDismiss), container);
-    container.querySelector<HTMLButtonElement>(".session-progress-card__dismiss")?.click();
-    expect(onDismiss).toHaveBeenCalledWith(completed);
-
-    render(renderSessionProgressCard(progressCard, "composer", onDismiss), container);
-    expect(container.querySelector(".session-progress-card__dismiss")).toBeNull();
-  });
 });

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -2,7 +2,7 @@
 
 import type { ProgressCard } from "@openclaw/gateway-protocol";
 import { render } from "lit";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { renderSessionProgressCard } from "./session-progress-card.ts";
 
 const progressCard: ProgressCard = {
@@ -48,5 +48,21 @@ describe("renderSessionProgressCard", () => {
         status: "session-progress-card__step--pending",
       },
     ]);
+  });
+
+  it("offers dismissal only for a completed checklist", () => {
+    const container = document.createElement("div");
+    const completed = {
+      ...progressCard,
+      steps: progressCard.steps?.map((step) => ({ ...step, status: "completed" as const })),
+    };
+    const onDismiss = vi.fn();
+
+    render(renderSessionProgressCard(completed, "composer", onDismiss), container);
+    container.querySelector<HTMLButtonElement>(".session-progress-card__dismiss")?.click();
+    expect(onDismiss).toHaveBeenCalledWith(completed);
+
+    render(renderSessionProgressCard(progressCard, "composer", onDismiss), container);
+    expect(container.querySelector(".session-progress-card__dismiss")).toBeNull();
   });
 });

--- a/ui/src/components/session-progress-card.test.ts
+++ b/ui/src/components/session-progress-card.test.ts
@@ -49,5 +49,4 @@ describe("renderSessionProgressCard", () => {
       },
     ]);
   });
-
 });

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -87,7 +87,7 @@ export function renderSessionProgressCard(
   );
   const dismiss = dismissible
     ? html`<button
-        class="session-progress-card__dismiss"
+        class="rail-header__action session-progress-card__dismiss"
         type="button"
         aria-label=${t("sessionProgressCard.dismiss")}
         title=${t("sessionProgressCard.dismiss")}

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -2,6 +2,7 @@ import type { ProgressCard, ProgressCardStep } from "@openclaw/gateway-protocol"
 import { html, nothing } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../i18n/index.ts";
+import { icons } from "./icons.ts";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
 type SessionProgressCardPlacement = "board" | "composer" | "hovercard" | "rail";
@@ -69,6 +70,7 @@ function renderBody(card: ProgressCard) {
 export function renderSessionProgressCard(
   card: ProgressCard | null | undefined,
   placement: SessionProgressCardPlacement,
+  onDismiss?: (card: ProgressCard) => void,
 ) {
   if (!card) {
     return nothing;
@@ -80,6 +82,24 @@ export function renderSessionProgressCard(
         total: String(counts.total),
       })
     : t("sessionProgressCard.noteLabel");
+  const dismissible = Boolean(
+    onDismiss && card.steps?.length && card.steps.every((step) => step.status === "completed"),
+  );
+  const dismiss = dismissible
+    ? html`<button
+        class="session-progress-card__dismiss"
+        type="button"
+        aria-label=${t("sessionProgressCard.dismiss")}
+        title=${t("sessionProgressCard.dismiss")}
+        @click=${(event: MouseEvent) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onDismiss?.(card);
+        }}
+      >
+        ${icons.x}
+      </button>`
+    : nothing;
   if (placement === "composer") {
     const current = currentProgressStep(card.steps ?? []);
     return html`<details
@@ -96,6 +116,7 @@ export function renderSessionProgressCard(
               >${counts.completed}/${counts.total}</span
             >`
           : nothing}
+        ${dismiss}
       </summary>
       ${renderBody(card)}
     </details>`;
@@ -108,7 +129,10 @@ export function renderSessionProgressCard(
     ${counts
       ? html`<div class="session-progress-card__heading">
           <span>${t("sessionProgressCard.title")}</span>
-          <span>${counts.completed}/${counts.total}</span>
+          <span class="session-progress-card__heading-actions">
+            <span>${counts.completed}/${counts.total}</span>
+            ${dismiss}
+          </span>
         </div>`
       : nothing}
     ${renderBody(card)}

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -199,11 +199,7 @@ suite.define(() => {
           await page.locator("textarea").fill("rerender");
           await expect.poll(() => card.count()).toBe(0);
           await gateway.setMethodResponse("progressCard.get", { card: null });
-          const requestsBeforeReload = (await gateway.getRequests("progressCard.get")).length;
           await page.reload();
-          await expect
-            .poll(async () => (await gateway.getRequests("progressCard.get")).length)
-            .toBeGreaterThan(requestsBeforeReload);
           await expect.poll(() => card.count()).toBe(0);
           expect(await gateway.getRequests("chat.send")).toHaveLength(0);
           await captureProof(page, `completed-${colorScheme}-after.png`);

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -200,6 +200,7 @@ suite.define(() => {
           await expect.poll(() => card.count()).toBe(0);
           await gateway.setMethodResponse("progressCard.get", { card: null });
           await page.reload();
+          await page.locator("textarea").waitFor({ state: "visible" });
           await expect.poll(() => card.count()).toBe(0);
           expect(await gateway.getRequests("chat.send")).toHaveLength(0);
           await captureProof(page, `completed-${colorScheme}-after.png`);

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -247,7 +247,9 @@ suite.define(() => {
         await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
         const card = page.locator('[data-progress-card-placement="composer"]');
         await expect.poll(() => card.isVisible()).toBe(true);
-        await expect(card.getByRole("button", { name: "Dismiss progress card" })).toHaveCount(0);
+        await expect
+          .poll(() => card.getByRole("button", { name: "Dismiss progress card" }).count())
+          .toBe(0);
         expect(await gateway.getRequests("progressCard.put")).toHaveLength(0);
       },
     );

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -208,4 +208,48 @@ suite.define(() => {
       );
     }
   });
+
+  it("keeps dismissal unavailable to a restricted session viewer", async () => {
+    const sessionKey = "agent:main:progress-viewer";
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 560 },
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "progressCard.get", "progressCard.put"],
+          hasMultipleSessionSharingIdentities: true,
+          methodResponses: {
+            "progressCard.get": {
+              card: {
+                revision: 1,
+                sessionKey,
+                steps: [{ step: "Completed work", status: "completed" }],
+                updatedAt: 1,
+              },
+            },
+            "sessions.list": chatSessionListResponse([
+              {
+                key: sessionKey,
+                kind: "direct",
+                label: "Restricted progress",
+                sharingRole: "viewer",
+                updatedAt: 1,
+                visibility: "suggest",
+              },
+            ]),
+          },
+          sessionKey,
+        });
+
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+        const card = page.locator('[data-progress-card-placement="composer"]');
+        await expect.poll(() => card.isVisible()).toBe(true);
+        await expect(card.getByRole("button", { name: "Dismiss progress card" })).toHaveCount(0);
+        expect(await gateway.getRequests("progressCard.put")).toHaveLength(0);
+      },
+    );
+  });
 });

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -156,7 +156,12 @@ suite.define(() => {
         },
         async ({ page }) => {
           const gateway = await installMockGateway(page, {
-            featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
+            featureMethods: [
+              "chat.metadata",
+              "chat.startup",
+              "progressCard.get",
+              "progressCard.put",
+            ],
             methodResponses: {
               "progressCard.get": {
                 card: {
@@ -166,6 +171,7 @@ suite.define(() => {
                   updatedAt: 3,
                 },
               },
+              "progressCard.put": { card: null },
               "sessions.list": chatSessionListResponse([
                 {
                   key: sessionKey,
@@ -185,16 +191,22 @@ suite.define(() => {
           await card.locator("summary").click();
           await captureProof(page, `completed-${colorScheme}-before.png`);
 
-          if (colorScheme === "light") {
-            return;
-          }
           await card.getByRole("button", { name: "Dismiss progress card" }).click();
+          const dismissRequest = await gateway.waitForRequest("progressCard.put");
+          expect(dismissRequest.params).toEqual({ sessionKey, expectedRevision: 3 });
           await expect.poll(() => card.count()).toBe(0);
 
           await page.locator("textarea").fill("rerender");
           await expect.poll(() => card.count()).toBe(0);
+          await gateway.setMethodResponse("progressCard.get", { card: null });
+          const requestsBeforeReload = (await gateway.getRequests("progressCard.get")).length;
           await page.reload();
+          await expect
+            .poll(async () => (await gateway.getRequests("progressCard.get")).length)
+            .toBeGreaterThan(requestsBeforeReload);
           await expect.poll(() => card.count()).toBe(0);
+          expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+          await captureProof(page, `completed-${colorScheme}-after.png`);
         },
       );
     }

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -146,7 +146,7 @@ suite.define(() => {
       { step: "Filed issue", status: "completed" },
     ];
 
-    for (const colorScheme of ["dark", "light"] as const) {
+    for (const colorScheme of ["light", "dark"] as const) {
       await suite.withPage(
         {
           colorScheme,

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -137,4 +137,66 @@ suite.define(() => {
       },
     );
   });
+
+  it("dismisses a completed card across rerender and reload", async () => {
+    const sessionKey = "agent:main:progress-complete";
+    const plan = [
+      { step: "Inspected owner", status: "completed" },
+      { step: "Implemented fix", status: "completed" },
+      { step: "Filed issue", status: "completed" },
+    ];
+
+    for (const colorScheme of ["dark", "light"] as const) {
+      await suite.withPage(
+        {
+          colorScheme,
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 560 },
+        },
+        async ({ page }) => {
+          const gateway = await installMockGateway(page, {
+            featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
+            methodResponses: {
+              "progressCard.get": {
+                card: {
+                  revision: 3,
+                  sessionKey,
+                  steps: plan,
+                  updatedAt: 3,
+                },
+              },
+              "sessions.list": chatSessionListResponse([
+                {
+                  key: sessionKey,
+                  kind: "direct",
+                  label: "Completed progress",
+                  updatedAt: 3,
+                },
+              ]),
+            },
+            sessionKey,
+          });
+
+          await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+          await expect.poll(() => gateway.getRequests("progressCard.get")).toHaveLength(1);
+          const card = page.locator('[data-progress-card-placement="composer"]');
+          await expect.poll(() => card.isVisible()).toBe(true);
+          await card.locator("summary").click();
+          await captureProof(page, `completed-${colorScheme}-before.png`);
+
+          if (colorScheme === "light") {
+            return;
+          }
+          await card.getByRole("button", { name: "Dismiss progress card" }).click();
+          await expect.poll(() => card.count()).toBe(0);
+
+          await page.locator("textarea").fill("rerender");
+          await expect.poll(() => card.count()).toBe(0);
+          await page.reload();
+          await expect.poll(() => card.count()).toBe(0);
+        },
+      );
+    }
+  });
 });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -189,6 +189,8 @@ export const en: TranslationMap = {
     ariaLabel: "Session progress",
     title: "Progress",
     noteLabel: "Progress note",
+    dismiss: "Dismiss progress card",
+    dismissFailed: "Could not dismiss the progress card. Try again.",
     widgetLabel: "Session progress",
     widgetLoading: "Loading session progress…",
     widgetEmpty: "No progress card yet",

--- a/ui/src/lib/session-progress-cards.ts
+++ b/ui/src/lib/session-progress-cards.ts
@@ -1,6 +1,7 @@
 import type {
   ProgressCard,
   ProgressCardGetResult,
+  ProgressCardPutResult,
   ProgressCardStep,
 } from "@openclaw/gateway-protocol";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -9,6 +10,7 @@ import type { ApplicationGateway } from "../app/gateway.ts";
 import { isGatewayMethodAdvertised } from "./gateway-methods.ts";
 
 const PROGRESS_CARD_GET_METHOD = "progressCard.get";
+const PROGRESS_CARD_PUT_METHOD = "progressCard.put";
 const PROGRESS_CARD_CHANGED_EVENT = "progressCard.changed";
 const CACHE_LIMIT = 100;
 
@@ -23,6 +25,7 @@ export type SessionProgressCardStore = {
   watch: (owner: object, sessionKeys: readonly string[]) => void;
   unwatch: (owner: object) => void;
   load: (sessionKey: string) => Promise<ProgressCard | null>;
+  dismiss: (card: ProgressCard) => Promise<boolean>;
   get: (sessionKey: string) => ProgressCard | null | undefined;
   getError: (sessionKey: string) => SessionProgressCardLoadError | undefined;
   subscribe: (listener: () => void) => () => void;
@@ -289,6 +292,25 @@ function createStore(gateway: ApplicationGateway): SessionProgressCardStore {
     watch,
     unwatch: (owner) => watch(owner, []),
     load,
+    dismiss: async (card) => {
+      const client = gateway.snapshot.client;
+      if (!client) {
+        return false;
+      }
+      const result = await client.request<ProgressCardPutResult>(PROGRESS_CARD_PUT_METHOD, {
+        sessionKey: card.sessionKey,
+        expectedRevision: card.revision,
+      });
+      const dismissed = result.card === null;
+      if (dismissed && cache.get(card.sessionKey)?.revision === card.revision) {
+        remember(card.sessionKey, { card: null, revision: null });
+        notify();
+      } else if (result.card) {
+        remember(card.sessionKey, { card: result.card, revision: result.card.revision });
+        notify();
+      }
+      return dismissed;
+    },
     get: (sessionKey) => cache.get(sessionKey)?.card,
     getError: (sessionKey) => errors.get(sessionKey),
     subscribe: (listener) => {

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -32,6 +32,7 @@ type SidebarPanelDefinitionParams = {
   lastReadAt: number | undefined;
   pullRequests: ControlUiSessionPullRequest[];
   progressCard: ProgressCard | null;
+  onDismissProgressCard?: (card: ProgressCard) => void;
   companion: ChatSessionCompanionThread;
   onCompanionSubmit: (question: string) => void;
   onCompanionDraftChange: (draft: string) => void;
@@ -114,6 +115,7 @@ export function sidebarPanelDefinitions(
         .startedAt=${params.startedAt}
         .lastReadAt=${params.lastReadAt}
         .progressCard=${params.progressCard}
+        .onDismissProgressCard=${params.onDismissProgressCard}
         .pullRequests=${params.pullRequests}
         .companion=${params.companion}
         .connected=${state?.connected === true}

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -1,5 +1,8 @@
 import { html, nothing } from "lit";
-import type { SessionObserverDigest } from "../../../../packages/gateway-protocol/src/schema/sessions.js";
+import type {
+  ProgressCard,
+  SessionObserverDigest,
+} from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { isDesktopPanelAvailable } from "../../app/app-shell-chrome.ts";
 import { ChatPaneBrowserAnnotationRender } from "./chat-pane-browser-annotation-render.ts";
@@ -35,6 +38,7 @@ type ChatPaneLayoutRenderParams = {
   board: ResolvedBoardView;
   sidebarLayout: SidebarLayout;
   progressCardInRail: boolean;
+  onDismissProgressCard?: (card: ProgressCard) => void;
   sessionWorkspace: SessionWorkspaceProps;
   backgroundTasks: BackgroundTasksProps;
   chatProps: ChatProps;
@@ -57,6 +61,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       board,
       sidebarLayout,
       progressCardInRail,
+      onDismissProgressCard,
       sessionWorkspace,
       backgroundTasks,
       chatProps,
@@ -114,6 +119,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       lastReadAt: selectedSession?.lastReadAt,
       pullRequests: this.sessionPullRequests,
       progressCard: progressCardInRail ? this.progressCard.card : null,
+      onDismissProgressCard,
       companion: companionThread,
       onCompanionSubmit: (question) => void this.submitSessionCompanionQuestion(question),
       onCompanionDraftChange: (draft) =>

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -160,6 +160,7 @@ export class ChatPane extends ChatPaneLayoutRender {
     const gatewaySnapshot = this.context.gateway.snapshot;
     const canDismissProgressCard =
       state.connected &&
+      !sessionParticipationBlocked &&
       hasOperatorWriteAccess(gatewaySnapshot.hello?.auth ?? null) &&
       isGatewayMethodAdvertised(gatewaySnapshot, "progressCard.put") === true;
     const onDismissProgressCard = canDismissProgressCard

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -5,6 +5,7 @@ import { cancelQuestionPrompt, submitQuestionPrompt } from "../../app/question-p
 import { readPresenceEntries, resolveCurrentSelfUser } from "../../app/user-profile.ts";
 import { navigateMarkdownSession } from "../../components/markdown-session-links.ts";
 import { t } from "../../i18n/index.ts";
+import { showToast } from "../../lib/toast.ts";
 import {
   resolveControlUiFollowUpMode,
   resolveControlUiServerQueueMode,
@@ -157,6 +158,17 @@ export class ChatPane extends ChatPaneLayoutRender {
       session: selectedSession,
     });
     const gatewaySnapshot = this.context.gateway.snapshot;
+    const canDismissProgressCard =
+      state.connected &&
+      hasOperatorWriteAccess(gatewaySnapshot.hello?.auth ?? null) &&
+      isGatewayMethodAdvertised(gatewaySnapshot, "progressCard.put") === true;
+    const onDismissProgressCard = canDismissProgressCard
+      ? (card: NonNullable<ChatProps["progressCard"]>) => {
+          void this.progressCard
+            .dismiss(card)
+            .catch(() => showToast({ message: t("sessionProgressCard.dismissFailed") }));
+        }
+      : undefined;
     const restartRecoveryTombstoned = selectedSession?.restartRecoveryStatus === "tombstoned";
     const multiIdentity = this.hasMultipleIdentities();
     const suggestionViewer =
@@ -284,6 +296,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       compactionStatus: state.compactionStatus,
       fallbackStatus: state.fallbackStatus,
       progressCard: progressCardInRail ? null : this.progressCard.card,
+      onDismissProgressCard,
       gatewayQuestionPrompts: catalogKey || sessionParticipationBlocked ? [] : this.questionPrompts,
       onGatewayQuestionChange: () => {
         this.questionPrompts = [...this.questionPrompts];
@@ -546,6 +559,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       board,
       sidebarLayout,
       progressCardInRail,
+      onDismissProgressCard,
       sessionWorkspace,
       backgroundTasks,
       chatProps: props,

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -5,7 +5,6 @@ import { cancelQuestionPrompt, submitQuestionPrompt } from "../../app/question-p
 import { readPresenceEntries, resolveCurrentSelfUser } from "../../app/user-profile.ts";
 import { navigateMarkdownSession } from "../../components/markdown-session-links.ts";
 import { t } from "../../i18n/index.ts";
-import { showToast } from "../../lib/toast.ts";
 import {
   resolveControlUiFollowUpMode,
   resolveControlUiServerQueueMode,
@@ -19,6 +18,7 @@ import {
 } from "../../lib/observer-digest.ts";
 import { hasSessionPresenceViewers } from "../../lib/presence-users.ts";
 import { buildAgentMainSessionKey } from "../../lib/sessions/session-key.ts";
+import { showToast } from "../../lib/toast.ts";
 import { clearChatHistory } from "./chat-history.ts";
 import { resolveChatMessageAccess } from "./chat-message-access.ts";
 import { requiresChatModelSetup } from "./chat-model-setup.ts";

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -98,6 +98,7 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     compactionStatus?: CompactionStatus | null;
     fallbackStatus?: FallbackStatus | null;
     progressCard?: ProgressCard | null;
+    onDismissProgressCard?: (card: ProgressCard) => void;
     gatewayQuestionPrompts?: readonly QuestionPrompt[];
     onGatewayQuestionChange?: () => void;
     onGatewayQuestionSubmit?: (
@@ -389,6 +390,7 @@ export function renderChat(props: ChatProps) {
     compactionStatus: props.compactionStatus,
     fallbackStatus: props.fallbackStatus,
     progressCard: props.progressCard,
+    onDismissProgressCard: props.onDismissProgressCard,
     gatewayQuestionPrompts: props.gatewayQuestionPrompts,
     messages: props.messages,
     stream: props.stream,

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -86,6 +86,7 @@ export type ChatComposerProps = ChatAttachmentControlsProps & {
   compactionStatus?: CompactionStatus | null;
   fallbackStatus?: FallbackStatus | null;
   progressCard?: ProgressCard | null;
+  onDismissProgressCard?: (card: ProgressCard) => void;
   gatewayQuestionPrompts?: readonly QuestionPrompt[];
   messages: unknown[];
   stream: string | null;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -266,7 +266,11 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                     </div>
                   `
                 : nothing}
-              ${renderSessionProgressCard(props.progressCard, "composer")}
+              ${renderSessionProgressCard(
+                props.progressCard,
+                "composer",
+                props.onDismissProgressCard,
+              )}
               ${renderFallbackIndicator(props.fallbackStatus)}
               ${renderCompactionIndicator(props.compactionStatus)}
               ${renderChatGoal(state, activeSession?.goal, {

--- a/ui/src/pages/chat/components/chat-session-rail.ts
+++ b/ui/src/pages/chat/components/chat-session-rail.ts
@@ -220,6 +220,7 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
   @property({ attribute: false }) startedAt?: number;
   @property({ attribute: false }) lastReadAt?: number;
   @property({ attribute: false }) progressCard: ProgressCard | null = null;
+  @property({ attribute: false }) onDismissProgressCard?: (card: ProgressCard) => void;
   @property({ attribute: false }) pullRequests: ControlUiSessionPullRequest[] = [];
   @property({ attribute: false }) companion: ChatSessionCompanionThread = {
     exchanges: [],
@@ -626,7 +627,8 @@ export class ChatSessionRailElement extends OpenClawLightDomElement {
         ${digest
           ? html`<div class="chat-session-rail__digest">${this.renderDigestDetails(digest)}</div>`
           : nothing}
-        ${renderSessionProgressCard(this.progressCard, "rail")} ${this.renderThread()}
+        ${renderSessionProgressCard(this.progressCard, "rail", this.onDismissProgressCard)}
+        ${this.renderThread()}
         ${this.companion.exchanges.length === 0 && !this.companion.pendingQuestion
           ? this.renderStarters()
           : nothing}

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -179,9 +179,15 @@
   text-transform: uppercase;
 }
 
+.session-progress-card__heading-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .session-progress-card__summary {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 7px;
   min-width: 0;
@@ -234,6 +240,35 @@
   font-family: var(--mono);
   font-size: var(--control-ui-text-xs);
   font-variant-numeric: tabular-nums;
+}
+
+.session-progress-card__dismiss {
+  display: inline-flex;
+  width: 22px;
+  height: 22px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: var(--cursor-action);
+}
+
+.session-progress-card__dismiss:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.session-progress-card__dismiss:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 65%, transparent);
+  outline-offset: 1px;
+}
+
+.session-progress-card__dismiss svg {
+  width: 14px;
+  height: 14px;
 }
 
 .session-progress-card--composer .session-progress-card__body {

--- a/ui/src/styles/chat/progress-card.css
+++ b/ui/src/styles/chat/progress-card.css
@@ -243,32 +243,10 @@
 }
 
 .session-progress-card__dismiss {
-  display: inline-flex;
   width: 22px;
+  min-width: 22px;
   height: 22px;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: 0;
-  border-radius: var(--radius-sm);
-  background: transparent;
-  color: var(--muted);
-  cursor: var(--cursor-action);
-}
-
-.session-progress-card__dismiss:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-
-.session-progress-card__dismiss:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 65%, transparent);
-  outline-offset: 1px;
-}
-
-.session-progress-card__dismiss svg {
-  width: 14px;
-  height: 14px;
+  min-height: 22px;
 }
 
 .session-progress-card--composer .session-progress-card__body {


### PR DESCRIPTION
Closes #126081

## What Problem This Solves

Fixes an issue where users with a completed session progress card would have the card remain pinned above the Control UI composer with no way to dismiss it.

## Why This Change Was Made

Completed checklist cards now expose one discreet, accessible dismiss action in their canonical composer/rail renderer. Dismissal reuses the progress-card owner's replace/clear path with an expected revision: the store clears only the matching terminal card, keeps revisions monotonic across clears, and preserves a newer concurrent update.

The action does not alter transcript entries, cancel a run, or mutate background tasks. Active and note-only cards remain visible, read-only viewers do not receive the action, and failures keep the card visible with a retryable toast.

Root cause: durable progress cards were intentionally retained per session, but their renderer exposed only expand/collapse and the owner had no user-initiated conditional clear. A browser-only hide would reappear after reload and could not safely arbitrate concurrent updates.

Provenance: the durable progress-card owner and composer placement were introduced by Peter Steinberger (@steipete) in #125125, commit `7170a6231a4a`, merged on 2026-08-17 by `web-flow`. The missing dismiss affordance was carried forward from that initial feature.

Production LOC: +161/-19 (net +142). Tests: +189/-0. The production growth adds the explicit accessible action, owner-level revision fencing/tombstone lifecycle, shared composer/rail wiring, authorization and session-participation gating, failure feedback, protocol input, and the regenerated Swift binding needed for the new capability. A separate dismiss RPC and duplicate renderer test were removed during implementation; the existing `progressCard.put` owner remains canonical.

## User Impact

Users can dismiss a completed progress card from the composer or session rail. The card stays gone across rerender and reload, while the composer draft, transcript, completed work, runs, and tasks remain unchanged. A stale dismiss cannot erase a newer card revision.

## Evidence

### Before

Dark:

![Completed progress card without a dismiss action in dark theme](https://github.com/user-attachments/assets/5023eb6f-3157-4366-996f-2acfaa2b335c)

Light:

![Completed progress card without a dismiss action in light theme](https://github.com/user-attachments/assets/d3f16b40-a9a0-405f-b570-ec1fa00d8942)

Pre-fix reproduction: Blacksmith Testbox `tbx_01m0bkc5wmm4q3nxxvw9p4mhrt`, run https://github.com/openclaw/openclaw/actions/runs/32197448083. The browser flow timed out waiting for `Dismiss progress card`.

### After

Dark, dismiss action visible:

![Completed progress card with dismiss action in dark theme](https://github.com/user-attachments/assets/843a47cd-d1c2-4db2-935e-3741ce5162df)

Dark, after dismiss + rerender + reload:

![Dark composer loaded after dismissal with draft preserved and card absent](https://github.com/user-attachments/assets/30ca1295-4252-4f9f-aa73-e0335892e969)

Light, dismiss action visible:

![Completed progress card with dismiss action in light theme](https://github.com/user-attachments/assets/bfc32d49-e419-4e18-8d32-343275aeb3de)

Light, after dismiss + rerender + reload:

![Light composer loaded after dismissal with draft preserved and card absent](https://github.com/user-attachments/assets/caae4b6a-534e-4a2b-9dc8-7e80bfb9e2e1)

All captures were downloaded and inspected at full frame. Final rebased browser/owner proof: Blacksmith Testbox `tbx_01m0btc6gjh2x7hth0j3vgwk8g`, run https://github.com/openclaw/openclaw/actions/runs/32205308933.

Commands executed exclusively on remote Testboxes:

```shell
pnpm test src/session-cards/progress-card-store.test.ts src/gateway/server-methods/progress-card.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-progress-live-placement.e2e.test.ts
pnpm build
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs -- <20 changed paths>
pnpm ui:i18n:baseline
pnpm ui:i18n:verify
pnpm protocol:check
.agents/skills/autoreview/scripts/autoreview --mode branch --base 48c05d435e3ef2b3562f98f71e631bd212d74ed8 --engine claude --model claude-fable-5 --thinking max
```

Results:

- Owner/Gateway tests: 16 passed.
- Mocked Control UI E2E: 2 passed, including dismiss → rerender → reload in dark and light themes.
- Full build: passed; Control UI startup and sidecar performance checks passed.
- `check:changed`: passed for `core`, `coreTests`, and `ui`, including format, i18n, tsgo, lint/stylelint, deadcode, schema/version, and import-cycle guards.
- Protocol generation/check: passed after rebase on Testbox `tbx_01m0btc6gjh2x7hth0j3vgwk8g`, run https://github.com/openclaw/openclaw/actions/runs/32205308933; Swift generated output is current and Kotlin remained unchanged.
- Moving `main` independently fixed the two unrelated UI E2E failures observed before the conflict rebase in #126032; rebased activity/New Session proof passed 6/6 and no duplicate repair remains in this PR.
- ClawSweeper's restricted-viewer finding was accepted: dismissal now also requires session participation. The extended browser test proves permitted dismissal and restricted-viewer suppression with no `progressCard.put`; 3/3 passed on Testbox `tbx_01m0bw2t6fj0b4vmph96xg69a8`, run https://github.com/openclaw/openclaw/actions/runs/32207101011.
- Claude autoreview: clean, no accepted/actionable findings; final rebased bundle 32,639 bytes.

No validation, browser, mock server, build, lint, typecheck, or test was run on the workstation.
