### PR TITLE
fix(sandbox): block incompatible new shared runtimes

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -25,6 +25,13 @@ openclaw sandbox list --json
 
 Remove sandbox runtimes to force recreation with current config. Runtimes are recreated automatically the next time the agent is used.
 
+Before removing a grandfathered shared Docker or Podman runtime, `recreate` verifies that the
+current agent roster can recreate the same workspace mount layout. If shared agents resolve
+incompatible mounts, the command leaves the existing runtime intact and tells you to select
+`scope: "agent"` or `"session"`, use `workspaceAccess: "none"` with one shared `workspaceRoot`, or
+configure identical mounts. Save the compatible `agents.*` configuration, then rerun `recreate`;
+the default Gateway reload mode does not require a restart.
+
 ```bash
 openclaw sandbox recreate --all
 openclaw sandbox recreate --agent mybot        # includes agent:mybot:* sub-sessions

--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -44,6 +44,22 @@ Three independent settings control sandbox behavior:
 - `session`: one container per session.
 - `shared`: one container shared by all sandboxed sessions (per-agent `docker`/`ssh`/`browser` overrides are ignored under this scope).
 
+`shared` is one filesystem trust domain, not an agent-workspace isolation mode. Use it only when
+every participating agent is mutually trusted and intentionally uses the same effective workspace
+mounts. Use `agent` (recommended) or `session` when agents need separate workspaces.
+
+OpenClaw does not create a new shared Docker or Podman runtime when participating agents resolve
+incompatible workspace mounts. An existing legacy runtime remains available so upgrades do not
+interrupt it, but OpenClaw will not replace or recreate that runtime until you choose one of these
+configurations:
+
+- change `scope` to `agent` or `session`
+- use `workspaceAccess: "none"` with one shared `workspaceRoot`
+- configure identical effective workspace mounts for every participating agent
+
+`agents.*` changes hot-apply under the default Gateway reload mode, so saving a compatible
+configuration and retrying the original action does not require a Gateway restart.
+
 Non-shared runtime identity also includes the resolved agent workspace path. This prevents co-hosted workspaces that reuse the same agent or session keys from sharing Docker, browser, SSH, OpenShell, or plugin-provided sandbox state. `shared` scope intentionally remains workspace-independent.
 
 The first use after upgrading from an older release creates non-shared runtimes and sandbox workspaces under the workspace-qualified identity. Existing non-shared runtimes are not adopted; this is an intentional one-time reset. They can age out through configured prune settings or be removed with `openclaw sandbox recreate`; the next use provisions the current identity.

--- a/src/agents/sandbox.resolveSandboxContext.test.ts
+++ b/src/agents/sandbox.resolveSandboxContext.test.ts
@@ -613,6 +613,63 @@ describe("resolveSandboxContext", () => {
     }
   }, 15_000);
 
+  it("passes incompatible shared workspace mounts to the backend creation guard", async () => {
+    const backendFactory = vi.fn(async () => ({
+      id: "docker",
+      runtimeId: "docker-shared-runtime",
+      runtimeLabel: "Docker Shared Runtime",
+      workdir: "/workspace",
+      buildExecSpec: async () => ({
+        argv: ["docker", "exec"],
+        env: process.env,
+        stdinMode: "pipe-closed" as const,
+      }),
+      runShellCommand: async () => ({
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        code: 0,
+      }),
+    }));
+    const restore = registerSandboxBackend("docker", backendFactory);
+    const alphaWorkspace = await createSandboxFixtureDir("shared-alpha");
+    const betaWorkspace = await createSandboxFixtureDir("shared-beta");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            sandbox: {
+              mode: "all",
+              backend: "docker",
+              scope: "shared",
+              workspaceAccess: "rw",
+              prune: { idleHours: 0, maxAgeDays: 0 },
+            },
+          },
+          entries: {
+            alpha: { workspace: alphaWorkspace },
+            beta: { workspace: betaWorkspace },
+          },
+        },
+      };
+
+      await resolveSandboxContext({
+        config: cfg,
+        sessionKey: "agent:alpha:main",
+        workspaceDir: alphaWorkspace,
+      });
+
+      expect(backendFactory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          newRuntimeBlockReason: expect.stringContaining(
+            "Configured agents require incompatible mounts",
+          ),
+        }),
+      );
+    } finally {
+      restore();
+    }
+  }, 15_000);
+
   it("uses Podman directly when the Podman backend is configured", async () => {
     containerEngineMocks.resolvePodmanSandboxRuntimeInfo.mockResolvedValueOnce({
       rootless: true,

--- a/src/agents/sandbox/backend.types.ts
+++ b/src/agents/sandbox/backend.types.ts
@@ -39,6 +39,8 @@ export type CreateSandboxBackendParams = {
   agentWorkspaceDir: string;
   skillsWorkspaceDir?: string;
   cfg: SandboxConfig;
+  /** Actionable reason why this call may reuse, but must not create, a shared runtime. */
+  newRuntimeBlockReason?: string;
   requireCurrentConfig?: boolean;
 };
 

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -352,6 +352,50 @@ describe("ensureSandboxBrowser create args", () => {
     expect(createArgs).toContain(`openclaw.createArgsEpoch=${SANDBOX_DOCKER_CREATE_ARGS_EPOCH}`);
   });
 
+  it("blocks a new shared browser when agent workspace mounts conflict", async () => {
+    const cfg = buildConfig(false);
+    cfg.scope = "shared";
+
+    await expect(
+      ensureTestSandboxBrowser({
+        scopeKey: "shared",
+        workspaceDir: "/tmp/workspace",
+        agentWorkspaceDir: "/tmp/workspace",
+        cfg,
+        newRuntimeBlockReason: "alpha and beta require different workspace mounts",
+      }),
+    ).rejects.toThrow("Cannot create shared sandbox runtime");
+
+    expect(findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create")).toBeUndefined();
+  });
+
+  it("reuses a matching grandfathered shared browser", async () => {
+    const cfg = buildConfig(false);
+    cfg.scope = "shared";
+    const expectedHash = computeTestBrowserHash({
+      cfg,
+      createArgsEpoch: SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
+      dockerEnvPolicyEpoch: SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
+    });
+    dockerMocks.dockerContainerState.mockResolvedValue({ exists: true, running: true });
+    dockerMocks.readDockerContainerEnvVar.mockResolvedValue("existing-cdp-token");
+    dockerMocks.readDockerContainerLabel.mockResolvedValue(expectedHash);
+
+    await ensureTestSandboxBrowser({
+      scopeKey: "shared",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg,
+      newRuntimeBlockReason: "alpha and beta require different workspace mounts",
+    });
+
+    expect(findDockerArgsCall(dockerMocks.execDocker.mock.calls, "rm")).toBeUndefined();
+    expect(findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create")).toBeUndefined();
+    expect(runtimeMocks.log).toHaveBeenCalledWith(
+      expect.stringContaining("Reusing grandfathered shared sandbox runtime"),
+    );
+  });
+
   it("serializes concurrent provisioning for the same browser container", async () => {
     let created = false;
     let cdpAuthToken: string | undefined;

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -35,6 +35,10 @@ import {
   SANDBOX_DOCKER_CREATE_ARGS_EPOCH,
 } from "./constants.js";
 import {
+  assertSharedSandboxRuntimeCreationAllowed,
+  retainLegacySharedSandboxRuntime,
+} from "./current-config.js";
+import {
   buildSandboxCreateArgs,
   dockerContainerState,
   execDocker,
@@ -232,6 +236,7 @@ type EnsureSandboxBrowserParams = {
   agentWorkspaceDir: string;
   skillsWorkspaceDir?: string;
   cfg: SandboxConfig;
+  newRuntimeBlockReason?: string;
   evaluateEnabled?: boolean;
   bridgeAuth?: { token?: string; password?: string };
   ssrfPolicy?: SsrFPolicy;
@@ -326,6 +331,11 @@ async function ensureSandboxBrowserContainer(
     cdpAuthToken =
       (await readDockerContainerEnvVar(containerName, CDP_AUTH_TOKEN_ENV_KEY)) ?? undefined;
     if (!cdpAuthToken) {
+      if (params.newRuntimeBlockReason) {
+        throw new Error(
+          `Shared sandbox browser runtime ${containerName} must be replaced to restore its CDP authentication contract, but creating its replacement is blocked.\n${params.newRuntimeBlockReason}`,
+        );
+      }
       defaultRuntime.log(
         `Removing stale sandbox browser container ${containerName} because it lacks the current CDP relay auth contract; it will be recreated.`,
       );
@@ -346,33 +356,52 @@ async function ensureSandboxBrowserContainer(
       hashMismatch = !currentHash || currentHash !== expectedHash;
     }
     if (hashMismatch) {
-      const lastUsedAtMs = registryEntry?.lastUsedAtMs;
-      const isHot =
-        running && (typeof lastUsedAtMs !== "number" || now - lastUsedAtMs < HOT_BROWSER_WINDOW_MS);
-      if (isHot) {
-        const hint = (() => {
-          if (params.cfg.scope === "session") {
-            return `openclaw sandbox recreate --browser --session ${params.scopeKey}`;
-          }
-          if (params.cfg.scope === "agent") {
-            const agentId = resolveSandboxAgentId(params.scopeKey) ?? "main";
-            return `openclaw sandbox recreate --browser --agent ${agentId}`;
-          }
-          return "openclaw sandbox recreate --browser --all";
-        })();
-        defaultRuntime.log(
-          `Sandbox browser config changed for ${containerName} (recently used). Recreate to apply: ${hint}`,
-        );
+      if (params.newRuntimeBlockReason) {
+        retainLegacySharedSandboxRuntime({
+          containerName,
+          configMismatch: true,
+          newRuntimeBlockReason: params.newRuntimeBlockReason,
+        });
       } else {
-        await stopExistingForContainer();
-        await execDocker(["rm", "-f", containerName], { allowFailure: true });
-        hasContainer = false;
-        running = false;
+        const lastUsedAtMs = registryEntry?.lastUsedAtMs;
+        const isHot =
+          running &&
+          (typeof lastUsedAtMs !== "number" || now - lastUsedAtMs < HOT_BROWSER_WINDOW_MS);
+        if (isHot) {
+          const hint = (() => {
+            if (params.cfg.scope === "session") {
+              return `openclaw sandbox recreate --browser --session ${params.scopeKey}`;
+            }
+            if (params.cfg.scope === "agent") {
+              const agentId = resolveSandboxAgentId(params.scopeKey) ?? "main";
+              return `openclaw sandbox recreate --browser --agent ${agentId}`;
+            }
+            return "openclaw sandbox recreate --browser --all";
+          })();
+          defaultRuntime.log(
+            `Sandbox browser config changed for ${containerName} (recently used). Recreate to apply: ${hint}`,
+          );
+        } else {
+          await stopExistingForContainer();
+          await execDocker(["rm", "-f", containerName], { allowFailure: true });
+          hasContainer = false;
+          running = false;
+        }
       }
+    } else {
+      retainLegacySharedSandboxRuntime({
+        containerName,
+        configMismatch: false,
+        newRuntimeBlockReason: params.newRuntimeBlockReason,
+      });
     }
   }
 
   if (!hasContainer) {
+    assertSharedSandboxRuntimeCreationAllowed({
+      containerName,
+      newRuntimeBlockReason: params.newRuntimeBlockReason,
+    });
     if (noVncEnabled) {
       noVncPassword = generateNoVncPassword();
     }
@@ -566,7 +595,7 @@ async function ensureSandboxBrowserContainer(
     createdAtMs: now,
     lastUsedAtMs: now,
     image: browserImage,
-    configHash: hashMismatch && running ? (currentHash ?? undefined) : expectedHash,
+    configHash: hasContainer && hashMismatch ? (currentHash ?? undefined) : expectedHash,
     cdpPort: mappedCdp,
     noVncPort: mappedNoVnc ?? undefined,
   });

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -26,6 +26,7 @@ import { toSandboxProvisioningError } from "./provisioning-error.js";
 import { readRegisteredSandboxRuntimeIds, updateRegistry } from "./registry.js";
 import { resolveSandboxRuntimeStatus } from "./runtime-status.js";
 import { assertSshSandboxSecretOwnerAvailable } from "./secret-owner.js";
+import { resolveSharedSandboxWorkspaceConflictReason } from "./shared-workspace-policy.js";
 import { resolveSandboxWorkspaceLayoutPaths } from "./shared.js";
 import type { SandboxContext, SandboxWorkspaceInfo } from "./types.js";
 import { ensureSandboxWorkspace } from "./workspace.js";
@@ -250,6 +251,12 @@ async function resolveProvisionedSandboxContext(
   const resolvedCfg = docker === cfg.docker ? cfg : { ...cfg, docker };
 
   const backendFactory = requireSandboxBackendFactory(resolvedCfg.backend);
+  const newRuntimeBlockReason = resolveSharedSandboxWorkspaceConflictReason({
+    config: params.config,
+    backendId: resolvedCfg.backend,
+    activeAgentId: runtime.agentId,
+    activeWorkspaceDir: agentWorkspaceDir,
+  });
   const registeredRuntimeIds = await readRegisteredSandboxRuntimeIds({
     backendId: resolvedCfg.backend,
     scopeKey,
@@ -262,6 +269,7 @@ async function resolveProvisionedSandboxContext(
     agentWorkspaceDir,
     skillsWorkspaceDir,
     cfg: resolvedCfg,
+    ...(newRuntimeBlockReason ? { newRuntimeBlockReason } : {}),
     ...(params.requireCurrentConfig !== undefined
       ? { requireCurrentConfig: params.requireCurrentConfig }
       : {}),
@@ -311,6 +319,7 @@ async function resolveProvisionedSandboxContext(
           agentWorkspaceDir,
           skillsWorkspaceDir,
           cfg: resolvedCfg,
+          ...(newRuntimeBlockReason ? { newRuntimeBlockReason } : {}),
           evaluateEnabled,
           bridgeAuth,
           ssrfPolicy: resolvedBrowserConfig?.ssrfPolicy,

--- a/src/agents/sandbox/current-config.ts
+++ b/src/agents/sandbox/current-config.ts
@@ -4,6 +4,8 @@ import { defaultRuntime } from "../../runtime.js";
 import { resolveSandboxAgentId } from "./shared.js";
 import type { SandboxScope } from "./types.js";
 
+const warnedLegacySharedRuntimes = new Set<string>();
+
 function formatSandboxRecreateHint(params: { scope: SandboxScope; sessionKey: string }) {
   if (params.scope === "session") {
     return formatCliCommand(`openclaw sandbox recreate --session ${params.sessionKey}`);
@@ -29,5 +31,40 @@ export function handleHotSandboxConfigMismatch(params: {
   }
   defaultRuntime.log(
     `Sandbox config changed for ${params.containerName} (recently used). Recreate to apply: ${hint}`,
+  );
+}
+
+export function assertSharedSandboxRuntimeCreationAllowed(params: {
+  containerName: string;
+  newRuntimeBlockReason?: string;
+}): void {
+  if (!params.newRuntimeBlockReason) {
+    return;
+  }
+  throw new Error(
+    `Cannot create shared sandbox runtime ${params.containerName}.\n${params.newRuntimeBlockReason}`,
+  );
+}
+
+export function retainLegacySharedSandboxRuntime(params: {
+  containerName: string;
+  configMismatch: boolean;
+  newRuntimeBlockReason?: string;
+  requireCurrentConfig?: boolean;
+}): void {
+  if (!params.newRuntimeBlockReason) {
+    return;
+  }
+  if (params.configMismatch && params.requireCurrentConfig) {
+    throw new Error(
+      `Shared sandbox runtime ${params.containerName} does not match the requested workspace mounts, and creating its replacement is blocked.\n${params.newRuntimeBlockReason}`,
+    );
+  }
+  if (warnedLegacySharedRuntimes.has(params.containerName)) {
+    return;
+  }
+  warnedLegacySharedRuntimes.add(params.containerName);
+  defaultRuntime.log(
+    `Reusing grandfathered shared sandbox runtime ${params.containerName}; automatic replacement is blocked until its workspace configuration is compatible.\n${params.newRuntimeBlockReason}`,
   );
 }

--- a/src/agents/sandbox/docker-backend.test.ts
+++ b/src/agents/sandbox/docker-backend.test.ts
@@ -55,6 +55,25 @@ function createConfig(): OpenClawConfig {
   };
 }
 
+function createConflictingSharedConfig(): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        sandbox: {
+          mode: "all",
+          backend: "docker",
+          scope: "shared",
+          workspaceAccess: "rw",
+        },
+      },
+      entries: {
+        alpha: { workspace: "/tmp/openclaw-alpha" },
+        beta: { workspace: "/tmp/openclaw-beta" },
+      },
+    },
+  };
+}
+
 describe("docker sandbox backend manager", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -84,10 +103,11 @@ describe("docker sandbox backend manager", () => {
       workspaceDir: "/tmp/customer/workspace",
       agentWorkspaceDir: "/tmp/customer/workspace",
       cfg: resolveSandboxConfigForAgent(createConfig(), "poly"),
+      newRuntimeBlockReason: "incompatible shared mounts",
     });
 
     expect(dockerMocks.ensureSandboxContainer).toHaveBeenCalledWith(
-      expect.objectContaining({ scopeKey }),
+      expect.objectContaining({ scopeKey, newRuntimeBlockReason: "incompatible shared mounts" }),
     );
   });
 
@@ -268,6 +288,25 @@ describe("docker sandbox backend manager", () => {
         config: createConfig(),
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("refuses to remove a grandfathered shared runtime before config recovery", async () => {
+    await expect(
+      dockerSandboxBackendManager.removeRuntime({
+        entry: {
+          containerName: "oc-shared",
+          backendId: "docker",
+          runtimeLabel: "oc-shared",
+          sessionKey: "shared",
+          createdAtMs: 1,
+          lastUsedAtMs: 1,
+          image: "openclaw-sandbox:bookworm-slim",
+        },
+        config: createConflictingSharedConfig(),
+      }),
+    ).rejects.toThrow("Refusing to remove grandfathered shared sandbox runtime oc-shared");
+
+    expect(dockerMocks.execContainer).not.toHaveBeenCalled();
   });
 
   it("uses Podman for Podman registry entries", async () => {

--- a/src/agents/sandbox/docker-backend.ts
+++ b/src/agents/sandbox/docker-backend.ts
@@ -25,6 +25,7 @@ import {
   validateSandboxContainerEngineTarget,
 } from "./docker.js";
 import type { SandboxRegistryEntry } from "./registry.js";
+import { assertSharedSandboxRuntimeRemovalAllowed } from "./shared-workspace-policy.js";
 
 function resolveConfiguredDockerRuntimeImage(params: {
   config: CreateSandboxBackendParams["cfg"] | import("../../config/config.js").OpenClawConfig;
@@ -60,6 +61,9 @@ async function createContainerSandboxBackend(
     agentWorkspaceDir: params.agentWorkspaceDir,
     skillsWorkspaceDir: params.skillsWorkspaceDir,
     cfg: params.cfg,
+    ...(params.newRuntimeBlockReason
+      ? { newRuntimeBlockReason: params.newRuntimeBlockReason }
+      : {}),
     ...(params.requireCurrentConfig !== undefined
       ? { requireCurrentConfig: params.requireCurrentConfig }
       : {}),
@@ -250,7 +254,13 @@ function createContainerSandboxBackendManager(
         configLabelMatch,
       };
     },
-    async removeRuntime({ entry }) {
+    async removeRuntime({ entry, config }) {
+      assertSharedSandboxRuntimeRemovalAllowed({
+        config,
+        containerName: entry.containerName,
+        sessionKey: entry.sessionKey,
+        backendId: engine.id,
+      });
       const podmanTarget = resolvePodmanTarget(entry);
       await validateSandboxContainerEngineTarget(engine, podmanTarget);
       const runtimeEngine = podmanTarget ? bindPodmanSandboxEngine(podmanTarget) : engine;

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -299,6 +299,32 @@ describe("ensureSandboxContainer config-hash recreation", () => {
     expect(registryMocks.updateRegistry).toHaveBeenCalledTimes(2);
   });
 
+  it("does not replace a cold grandfathered runtime with stale mounts", async () => {
+    const workspaceDir = tempDirs.make("openclaw-docker-mounts-");
+    const cfg = createSandboxConfig([], [`${workspaceDir}:/workspace:rw`]);
+    spawnState.inspectRunning = false;
+    spawnState.labelHash = "legacy-workspace-hash";
+    registryMocks.readRegistryEntry.mockResolvedValue(null);
+
+    await ensureSandboxContainer({
+      scopeKey: "shared",
+      workspaceDir,
+      agentWorkspaceDir: workspaceDir,
+      cfg,
+      newRuntimeBlockReason: "alpha and beta require different workspace mounts",
+    });
+
+    expect(spawnState.calls.some((call) => call.args[0] === "rm")).toBe(false);
+    expect(spawnState.calls.some((call) => call.args[0] === "create")).toBe(false);
+    expect(spawnState.calls.some((call) => call.args[0] === "start")).toBe(true);
+    expect(runtimeMocks.log).toHaveBeenCalledWith(
+      expect.stringContaining("Reusing grandfathered shared sandbox runtime"),
+    );
+    expect(registryMocks.updateRegistry.mock.calls.at(-1)?.[0]?.configHash).toBe(
+      "legacy-workspace-hash",
+    );
+  });
+
   it("uses the canonical non-shared scope for Docker names, labels, and registry identity", async () => {
     const workspaceDir = tempDirs.make("openclaw-docker-mounts-");
     const cfg = createSandboxConfig([], [`${workspaceDir}:/workspace:rw`]);

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -17,7 +17,11 @@ import {
   type SandboxContainerEngine,
   type SandboxContainerEngineTarget,
 } from "./container-engine.js";
-import { handleHotSandboxConfigMismatch } from "./current-config.js";
+import {
+  assertSharedSandboxRuntimeCreationAllowed,
+  handleHotSandboxConfigMismatch,
+  retainLegacySharedSandboxRuntime,
+} from "./current-config.js";
 import {
   assertPodmanSandboxTarget,
   bindPodmanSandboxEngine,
@@ -549,6 +553,7 @@ type EnsureSandboxContainerParams = {
   agentWorkspaceDir: string;
   skillsWorkspaceDir?: string;
   cfg: SandboxConfig;
+  newRuntimeBlockReason?: string;
   requireCurrentConfig?: boolean;
 };
 
@@ -649,27 +654,46 @@ async function ensureSandboxContainerLifecycle(
     }
     hashMismatch = !currentHash || currentHash !== expectedHash;
     if (hashMismatch) {
-      const lastUsedAtMs = registryEntry?.lastUsedAtMs;
-      const isHot =
-        running &&
-        (typeof lastUsedAtMs !== "number" || now - lastUsedAtMs < HOT_CONTAINER_WINDOW_MS);
-      if (isHot) {
-        handleHotSandboxConfigMismatch({
+      if (params.newRuntimeBlockReason) {
+        retainLegacySharedSandboxRuntime({
           containerName,
-          scope: params.cfg.scope,
-          sessionKey: params.scopeKey,
-          ...(params.requireCurrentConfig !== undefined
-            ? { requireCurrentConfig: params.requireCurrentConfig }
-            : {}),
+          configMismatch: true,
+          newRuntimeBlockReason: params.newRuntimeBlockReason,
+          requireCurrentConfig: params.requireCurrentConfig,
         });
       } else {
-        await execContainer(engine, ["rm", "-f", containerName], { allowFailure: true });
-        hasContainer = false;
-        running = false;
+        const lastUsedAtMs = registryEntry?.lastUsedAtMs;
+        const isHot =
+          running &&
+          (typeof lastUsedAtMs !== "number" || now - lastUsedAtMs < HOT_CONTAINER_WINDOW_MS);
+        if (isHot) {
+          handleHotSandboxConfigMismatch({
+            containerName,
+            scope: params.cfg.scope,
+            sessionKey: params.scopeKey,
+            ...(params.requireCurrentConfig !== undefined
+              ? { requireCurrentConfig: params.requireCurrentConfig }
+              : {}),
+          });
+        } else {
+          await execContainer(engine, ["rm", "-f", containerName], { allowFailure: true });
+          hasContainer = false;
+          running = false;
+        }
       }
+    } else {
+      retainLegacySharedSandboxRuntime({
+        containerName,
+        configMismatch: false,
+        newRuntimeBlockReason: params.newRuntimeBlockReason,
+      });
     }
   }
   if (!hasContainer) {
+    assertSharedSandboxRuntimeCreationAllowed({
+      containerName,
+      newRuntimeBlockReason: params.newRuntimeBlockReason,
+    });
     await createSandboxContainer({
       engine,
       name: containerName,
@@ -697,7 +721,7 @@ async function ensureSandboxContainerLifecycle(
     lastUsedAtMs: now,
     image: params.cfg.docker.image,
     configLabelKind: "Image",
-    configHash: hashMismatch && running ? (currentHash ?? undefined) : expectedHash,
+    configHash: hasContainer && hashMismatch ? (currentHash ?? undefined) : expectedHash,
   });
   return containerName;
 }

--- a/src/agents/sandbox/manage.ts
+++ b/src/agents/sandbox/manage.ts
@@ -15,6 +15,7 @@ import {
   type SandboxBrowserRegistryEntry,
   type SandboxRegistryEntry,
 } from "./registry.js";
+import { assertSharedSandboxRuntimeRemovalAllowed } from "./shared-workspace-policy.js";
 import { resolveSandboxAgentId } from "./shared.js";
 
 export type SandboxContainerInfo = SandboxRegistryEntry & {
@@ -115,6 +116,14 @@ export async function removeSandboxBrowserContainer(containerName: string): Prom
   const config = getRuntimeConfig();
   const registry = await readBrowserRegistry();
   const entry = registry.entries.find((item) => item.containerName === containerName);
+  if (entry) {
+    assertSharedSandboxRuntimeRemovalAllowed({
+      config,
+      containerName: entry.containerName,
+      sessionKey: entry.sessionKey,
+      backendId: "docker",
+    });
+  }
   await stopCachedBrowserBridgesForContainer(containerName);
   if (entry) {
     await dockerSandboxBackendManager.removeRuntime({

--- a/src/agents/sandbox/prune.ts
+++ b/src/agents/sandbox/prune.ts
@@ -17,6 +17,7 @@ import {
   type SandboxBrowserRegistryEntry,
   type SandboxRegistryEntry,
 } from "./registry.js";
+import { assertSharedSandboxRuntimeRemovalAllowed } from "./shared-workspace-policy.js";
 import type { SandboxConfig } from "./types.js";
 
 let lastPruneAtMs = 0;
@@ -120,6 +121,12 @@ async function pruneSandboxBrowsers(cfg: SandboxConfig) {
       });
     },
     beforeRemove: async (entry) => {
+      assertSharedSandboxRuntimeRemovalAllowed({
+        config,
+        containerName: entry.containerName,
+        sessionKey: entry.sessionKey,
+        backendId: "docker",
+      });
       await stopCachedBrowserBridgesForContainer(entry.containerName);
     },
   });

--- a/src/agents/sandbox/shared-workspace-policy.test.ts
+++ b/src/agents/sandbox/shared-workspace-policy.test.ts
@@ -1,0 +1,94 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveSharedSandboxWorkspaceConflictReason } from "./shared-workspace-policy.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function createConfig(params?: {
+  access?: "none" | "ro" | "rw";
+  betaAccess?: "none" | "ro" | "rw";
+  sameWorkspace?: boolean;
+}): OpenClawConfig {
+  const root = tempDirs.make("openclaw-shared-policy-");
+  const alphaWorkspace = path.join(root, "alpha");
+  const betaWorkspace = params?.sameWorkspace ? alphaWorkspace : path.join(root, "beta");
+  return {
+    agents: {
+      defaults: {
+        sandbox: {
+          mode: "all",
+          backend: "docker",
+          scope: "shared",
+          workspaceAccess: params?.access ?? "rw",
+          workspaceRoot: path.join(root, "sandboxes"),
+        },
+      },
+      entries: {
+        alpha: { workspace: alphaWorkspace },
+        beta: {
+          workspace: betaWorkspace,
+          ...(params?.betaAccess ? { sandbox: { workspaceAccess: params.betaAccess } } : {}),
+        },
+      },
+    },
+  };
+}
+
+describe("resolveSharedSandboxWorkspaceConflictReason", () => {
+  it.each(["ro", "rw"] as const)(
+    "rejects distinct agent workspaces for shared %s mounts",
+    (access) => {
+      const reason = resolveSharedSandboxWorkspaceConflictReason({
+        config: createConfig({ access }),
+        backendId: "docker",
+      });
+
+      expect(reason).toContain("alpha");
+      expect(reason).toContain("beta");
+      expect(reason).toContain('Set sandbox.scope to "agent" or "session"');
+    },
+  );
+
+  it("allows agents that intentionally use the same shared mount layout", () => {
+    expect(
+      resolveSharedSandboxWorkspaceConflictReason({
+        config: createConfig({ access: "rw", sameWorkspace: true }),
+        backendId: "docker",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("allows distinct agent workspaces when none exposes an agent workspace", () => {
+    expect(
+      resolveSharedSandboxWorkspaceConflictReason({
+        config: createConfig({ access: "none" }),
+        backendId: "docker",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("rejects mixed workspace access because one runtime cannot honor both layouts", () => {
+    expect(
+      resolveSharedSandboxWorkspaceConflictReason({
+        config: createConfig({ access: "rw", betaAccess: "none" }),
+        backendId: "docker",
+      }),
+    ).not.toBeNull();
+  });
+
+  it("includes the active runtime workspace override in the mount identity", () => {
+    const config = createConfig({ access: "rw", sameWorkspace: true });
+    const overrideRoot = tempDirs.make("openclaw-shared-policy-override-");
+
+    expect(
+      resolveSharedSandboxWorkspaceConflictReason({
+        config,
+        backendId: "docker",
+        activeAgentId: "beta",
+        activeWorkspaceDir: path.join(overrideRoot, "beta"),
+      }),
+    ).not.toBeNull();
+  });
+});

--- a/src/agents/sandbox/shared-workspace-policy.ts
+++ b/src/agents/sandbox/shared-workspace-policy.ts
@@ -1,0 +1,75 @@
+/** Detects shared sandbox configurations that cannot share one workspace mount layout. */
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { listAgentIds, resolveAgentWorkspaceDir } from "../agent-scope.js";
+import { resolveSandboxConfigForAgent } from "./config.js";
+import { resolveSandboxHostPathViaExistingAncestor } from "./host-paths.js";
+import { resolveSandboxWorkspaceLayoutPaths } from "./shared.js";
+
+/** Returns an actionable reason when configured agents cannot share one runtime mount layout. */
+export function resolveSharedSandboxWorkspaceConflictReason(params: {
+  config?: OpenClawConfig;
+  backendId: string;
+  activeAgentId?: string;
+  activeWorkspaceDir?: string;
+}): string | undefined {
+  if (!params.config) {
+    return undefined;
+  }
+  const agentIds = new Set(listAgentIds(params.config));
+  if (params.activeAgentId) {
+    agentIds.add(params.activeAgentId);
+  }
+  const participants = [...agentIds].flatMap((agentId) => {
+    const cfg = resolveSandboxConfigForAgent(params.config!, agentId);
+    if (cfg.mode === "off" || cfg.scope !== "shared" || cfg.backend !== params.backendId) {
+      return [];
+    }
+    const layout = resolveSandboxWorkspaceLayoutPaths({
+      cfg,
+      rawSessionKey: `agent:${agentId}:main`,
+      agentId,
+      workspaceDir:
+        agentId === params.activeAgentId && params.activeWorkspaceDir
+          ? params.activeWorkspaceDir
+          : resolveAgentWorkspaceDir(params.config!, agentId),
+    });
+    const workspaceDir = resolveSandboxHostPathViaExistingAncestor(layout.workspaceDir);
+    const agentWorkspaceDir = resolveSandboxHostPathViaExistingAncestor(layout.agentWorkspaceDir);
+    const mounts =
+      cfg.workspaceAccess === "ro"
+        ? [`${workspaceDir} -> ${cfg.docker.workdir}`, `${agentWorkspaceDir} -> /agent`]
+        : [`${workspaceDir} -> ${cfg.docker.workdir}`];
+    return [
+      {
+        description: `${agentId} (${cfg.workspaceAccess}: ${mounts.join(", ")})`,
+        identity: JSON.stringify([cfg.workspaceAccess, mounts]),
+      },
+    ];
+  });
+  if (new Set(participants.map((entry) => entry.identity)).size <= 1) {
+    return undefined;
+  }
+  return [
+    `Configured agents require incompatible mounts for one shared ${params.backendId} sandbox:`,
+    ...participants.map((entry) => `- ${entry.description}`),
+    'Set sandbox.scope to "agent" or "session", use workspaceAccess "none" with one shared workspaceRoot, or configure identical workspace mounts for every participating agent.',
+    "After saving valid agents.* config, the Gateway hot-reloads it by default; retry the original action without restarting.",
+  ].join("\n");
+}
+
+export function assertSharedSandboxRuntimeRemovalAllowed(params: {
+  config: OpenClawConfig;
+  containerName: string;
+  sessionKey: string;
+  backendId: string;
+}): void {
+  const reason =
+    params.sessionKey === "shared"
+      ? resolveSharedSandboxWorkspaceConflictReason(params)
+      : undefined;
+  if (reason) {
+    throw new Error(
+      `Refusing to remove grandfathered shared sandbox runtime ${params.containerName} until its workspace configuration is compatible; otherwise the runtime could not be recreated.\n${reason}`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #113166

AI-assisted: Roboclaw investigated, implemented, tested, and independently autoreviewed this change with Sally's direction on compatibility behavior.

## What Problem This Solves

Fixes an issue where agents using a shared Docker or Podman sandbox could silently reuse a container bound to another agent's workspace when their effective workspace mounts differed. The first or most recently recreated container effectively won, so file tools could read or mutate the wrong workspace.

## Why This Change Was Made

OpenClaw now compares the effective mount layouts of agents participating in one shared container backend. Incompatible configurations cannot create a new shell or browser runtime. Existing legacy runtimes remain usable and emit one warning, while automatic replacement, pruning, and explicit recreation are refused until configuration is compatible.

This deliberately does not redefine `scope: "shared"` as per-agent isolation. Operators can recover by selecting `agent`/`session` scope, using `workspaceAccess: "none"` with one shared root, or configuring identical mounts. Existing `agents.*` hot reload applies the recovery without a Gateway restart.

Production delta is +202 net lines. The added surface owns the compatibility-sensitive safety invariant across creation, replacement, browser, prune, and explicit removal paths; keeping only a creation-site guard would allow later lifecycle operations to delete a grandfathered runtime that cannot be recreated.

## User Impact

Existing shared runtimes continue running, so upgrades do not immediately break current deployments. A new incompatible shared runtime fails before container creation with an error listing the conflicting agents, mounts, and recovery choices. Once configuration is corrected, the original action can be retried without restarting the Gateway under the default reload mode.

Operators should still treat `shared` as one filesystem trust domain. `agent` remains the recommended scope when agents need separate workspaces.

## Evidence

- 170 focused sandbox/context/manager tests passed before the final policy simplification; the affected simplified policy/context/manager lane then passed 68/68 tests.
- Final creation and grandfather-reuse regression selection passed 6/6 tests across Docker and browser paths.
- Full browser creation file: 188 tests passed; the only two failures were the same test selected in two projects and were environmental (`listen EPERM 127.0.0.1`) because this sandbox forbids loopback listeners.
- Repository check graph: every preflight/security ratchet passed and production plus test TypeScript checks passed. Full lint found one max-lines failure caused by the first regression-test placement; that test was reduced, and the affected file plus all subsequently changed files pass targeted oxlint.
- Docs: 6,541 internal links checked with 0 broken; 1,180 config examples validated.
- Final autoreview: clean, no accepted/actionable findings; confidence 0.97.
- Live Docker proof was infeasible on this host because the Docker CLI is not installed. The container lifecycle is covered through the repository's argv/state harnesses.
- Host note: validation ran under Node 26.7 because no repository-supported Node 22/24/25 runtime is installed here; CI remains the supported-runtime authority.
