### PR TITLE
refactor(release): remove test-only helper re-exports

### DIFF
--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -64,9 +64,6 @@ type ReleaseCheckExecOptions = ExecFileSyncOptions & {
   windowsVerbatimArguments?: boolean;
 };
 
-export { collectBundledExtensionManifestErrors } from "./lib/bundled-extension-manifest.ts";
-export { packageNameFromSpecifier } from "./lib/plugin-package-dependencies.mts";
-
 export const RELEASE_CHECK_LOCAL_PACKAGE_TARBALL_DIR_ENV =
   "OPENCLAW_RELEASE_CHECK_LOCAL_PACKAGE_TARBALL_DIR";
 
@@ -1158,8 +1155,6 @@ export function collectForbiddenPackContentPaths(
     })
     .toSorted((left, right) => left.localeCompare(right));
 }
-
-export { collectPackUnpackedSizeErrors } from "./lib/npm-pack-budget.mts";
 
 function extractTag(item: string, tag: string): string | null {
   const escapedTag = escapeRegExp(tag);

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -4,8 +4,10 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve as resolvePath, win32 } from "node:path";
 import { bundledDistPluginFile, bundledPluginFile } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
+import { collectBundledExtensionManifestErrors } from "../scripts/lib/bundled-extension-manifest.ts";
 import { listBundledPluginPackArtifacts } from "../scripts/lib/bundled-plugin-build-entries.mjs";
 import { resolveNpmJsonEntries } from "../scripts/lib/npm-json-output.mts";
+import { collectPackUnpackedSizeErrors } from "../scripts/lib/npm-pack-budget.mts";
 import {
   LOCAL_BUILD_METADATA_DIST_PATHS,
   PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
@@ -25,13 +27,11 @@ import {
 } from "../scripts/openclaw-npm-postpublish-verify.ts";
 import {
   collectAppcastSparkleVersionErrors,
-  collectBundledExtensionManifestErrors,
   collectCriticalPluginSdkEntrypointSizeErrors,
   collectForbiddenPackContentPaths,
   collectForbiddenPackPaths,
   collectMissingPackPaths,
   collectSkillShellScriptExecutableErrors,
-  collectPackUnpackedSizeErrors,
   collectPackedInstalledPackageVerificationErrors,
   createPackedPluginSdkTypescriptSmokeProject,
   createPackedCompletionSmokeEnv,
@@ -41,7 +41,6 @@ import {
   PACKED_BUNDLED_RUNTIME_DEPS_REPAIR_ARGS,
   PACKED_CLI_SMOKE_COMMANDS,
   PACKED_COMPLETION_SMOKE_ARGS,
-  packageNameFromSpecifier,
   resolvePackedTarballPath,
   resolveReleaseNpmCommand,
   resolveMissingPackBuildHint,
@@ -392,15 +391,6 @@ describe("collectBundledExtensionManifestErrors", () => {
 });
 
 describe("bundled plugin package dependency checks", () => {
-  it("maps package names from import specifiers", () => {
-    expect(packageNameFromSpecifier("@larksuiteoapi/node-sdk/subpath")).toBe(
-      "@larksuiteoapi/node-sdk",
-    );
-    expect(packageNameFromSpecifier("grammy/web")).toBe("grammy");
-    expect(packageNameFromSpecifier("node:fs")).toBeNull();
-    expect(packageNameFromSpecifier("./local")).toBeNull();
-  });
-
   it("does not require root deps for root chunks sourced from the owning installed plugin", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "openclaw-root-owned-installed-"));
 


### PR DESCRIPTION
## What Problem This Solves

The release-check test suite imported three canonical helpers through the large executable `scripts/release-check.ts` aggregator. That test-only routing kept otherwise unnecessary re-exports public and duplicated the package-specifier helper coverage already owned by its focused suite.

## Why This Change Was Made

Manifest validation tests now import `scripts/lib/bundled-extension-manifest.ts` directly, and npm pack-budget tests import `scripts/lib/npm-pack-budget.mts` directly. The weaker duplicate `packageNameFromSpecifier` test was removed because `test/scripts/plugin-package-dependencies.test.ts` already covers scoped, plain, invalid-scope, Node built-in, relative, absolute, and internal specifiers.

Release execution is unchanged: `scripts/release-check.ts` retains its own manifest helper import/use and its aliased npm pack-budget import/use. This removes only three test-only re-exports. There are no docs, changelog, schema, protocol, config, dependency, or operator-state changes.

## User Impact

No user-visible or release behavior changes. Tests depend on canonical owner modules instead of forcing the release executable aggregator to expose helper aliases.

## Evidence

- `node scripts/run-vitest.mjs test/release-check.test.ts test/scripts/plugin-package-dependencies.test.ts` — 2 files and 63 tests passed.
- `node scripts/check-changed.mjs -- scripts/release-check.ts test/release-check.test.ts` — all selected formatting, guard, typecheck, and lint gates passed.
- `git diff --check` — passed.
- Codex-backed autoreview — clean; no accepted/actionable findings.
- `rg` confirms no test consumer remains for the removed `scripts/release-check.ts` exports.
- LOC: tooling `+0/-5`; tests `+2/-12`; total `+2/-17` (net `-15`).

AI-assisted implementation and review; all changes and evidence were verified by the maintainer workflow.
