### PR TITLE
fix(ui): expanded mobile side panel leaves blank upper half

### DIFF
--- a/ui/src/e2e/chat-rail-columns.e2e.test.ts
+++ b/ui/src/e2e/chat-rail-columns.e2e.test.ts
@@ -244,6 +244,25 @@ async function narrowestRailTabLabel(page: Page): Promise<number> {
     );
 }
 
+async function expectExpandedSidePanelFillsRegion(page: Page): Promise<void> {
+  const geometry = await sidePanel(page).evaluate((element) => {
+    const panel = element.getBoundingClientRect();
+    const region = element.closest(".sidebar-region")?.getBoundingClientRect();
+    if (!region) {
+      throw new Error("Expanded side panel has no sidebar region");
+    }
+    return {
+      bottom: Math.abs(panel.bottom - region.bottom),
+      left: Math.abs(panel.left - region.left),
+      right: Math.abs(panel.right - region.right),
+      top: Math.abs(panel.top - region.top),
+    };
+  });
+  for (const delta of Object.values(geometry)) {
+    expect(delta).toBeLessThanOrEqual(1);
+  }
+}
+
 async function captureRichPanel(page: Page, name: string) {
   if (!proofDir) {
     return;
@@ -736,6 +755,8 @@ suite.define(() => {
                 .evaluate((element) => getComputedStyle(element).display),
             )
             .toBe("none");
+          await expectExpandedSidePanelFillsRegion(page);
+          await captureRichPanel(page, `rails-tabs-expanded-${themeMode}`);
           await sidePanel(page).getByRole("button", { name: "Restore side panel" }).click();
 
           await sidePanel(page).getByRole("button", { name: "Close", exact: true }).click();
@@ -947,6 +968,7 @@ suite.define(() => {
               .evaluate((element) => getComputedStyle(element).display),
           )
           .toBe("none");
+        await expectExpandedSidePanelFillsRegion(page);
         await captureRichPanel(page, "rails-tabs-mobile-light");
       },
     );

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -254,7 +254,7 @@ openclaw-chat-sidebar-region,
   z-index: 2;
 }
 
-.sidebar-region--narrow {
+.sidebar-region--narrow:not(.sidebar-region--expanded) {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: minmax(200px, 1fr) minmax(160px, 1fr);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where mobile users expanding the chat side panel would hide the conversation but leave the panel in the lower half of the workspace, producing a large blank area above it.

## Why This Change Was Made

The narrow layout now uses its two-row chat-and-panel grid only while the panel is not expanded. Expanded narrow panels fall back to the existing single-child flex layout, so the panel fills the workspace without introducing an overlay or a second expansion path. The existing browser contract now verifies the same full-region geometry on mobile and desktop.

## User Impact

Expanding a side panel on mobile now uses the full chat workspace. Desktop expansion, docking, persistence, themes, and panel navigation remain unchanged.

## Evidence

### Mobile — 390×844 viewport

| Before | After |
| --- | --- |
| ![Mobile expanded side panel before: blank upper row](https://github.com/user-attachments/assets/a956d1c3-6fb8-4b40-8f65-68307d60482d) | ![Mobile expanded side panel after: fills workspace](https://github.com/user-attachments/assets/b5f04989-8d8c-4dec-bc0f-47fc9b462286) |

The pre-fix geometry assertion reproduced a 414 px top-edge gap. The same assertion passes after the fix.

### Desktop — 1600×900 viewport

| Before | After |
| --- | --- |
| ![Desktop expanded side panel before](https://github.com/user-attachments/assets/c1948276-541b-4b27-98f7-a8961e7f5133) | ![Desktop expanded side panel after](https://github.com/user-attachments/assets/8e3be6b5-db09-40a5-94ff-86873d50981f) |

The desktop before/after PNGs are byte-identical, and both satisfy the full-region geometry assertion.

- Pre-fix regression: focused mobile E2E failed with a 414 px gap ([Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_33f4310ebcc3)).
- Desktop parent/current comparison: both passed; screenshots are byte-identical ([Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_26a3d2dd7eb5)).
- Full side-panel E2E: 5/5 passed, including mobile, desktop light/dark, docking, persistence, and topbar sibling paths ([Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_45edb4c9d90a)).
- Scoped changed gate: formatting, typecheck, lint, stylelint, guards, dead-code checks, and UI i18n passed ([Crabbox run](https://crabbox.openclaw.ai/portal/runs/run_c7a76850785f)).
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`: clean; no accepted/actionable findings.
- Production LOC: +1/-1 (net 0). Tests: +22/-0.

AI-assisted: yes. The implementation and evidence were produced with Codex and independently checked by the repository autoreview workflow.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted OpenClaw session transcript</summary>

````text
source: local OpenClaw session
omitted: system/developer prompts, raw tool output, reasoning, local paths, credentials, cookies, and unrelated turns

[user]
What is the expand button supposed to do? On mobile UI it seems to be bugged or is that intentional?

[assistant]
Traced the expand control through its persisted state and responsive layout. Confirmed that expansion intentionally hides the conversation and should make the side panel fill the workspace. The mobile defect was the narrow two-row grid retaining an empty first row after chat was hidden; existing coverage asserted only that chat disappeared.

[user]
Propose options for resolving this.

[assistant]
Recommended repairing the narrow expanded layout at its CSS owner boundary. Rejected a fullscreen overlay because it adds stacking, focus, safe-area, and scroll complexity; rejected hiding the control because it removes useful mobile capability.

[user]
Do option 1, then include before and after screenshots once all review commits are in.

[assistant]
Captured the broken mobile state, added a geometry assertion that failed pre-fix with a 414 px top gap, and changed the narrow grid to apply only when not expanded. The same focused E2E then passed. Scoped format/type/lint/style gates and autoreview were clean, and review-clean before/after screenshots were captured.

[user]
Open a PR and include screenshots. Also make sure desktop is not broken and include those screenshots.

[assistant]
Extended the shared full-region assertion to desktop, captured 1600×900 parent/current screenshots, and confirmed they are byte-identical. The complete five-case side-panel E2E passed across mobile, desktop light/dark, docking, persistence, and topbar sibling paths; the final scoped gate and autoreview were clean.
````

</details>
<!-- agent-transcript:end -->

Co-authored-by: Tak Hoffman <781889+Takhoffman@users.noreply.github.com>
