### PR TITLE
fix: capture GitHub identity from authenticated sign-in

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -592,8 +592,6 @@ enum class GatewayMethod(
   ToolsGithubStatus("tools.github.status"),
   ToolsGithubConfigure("tools.github.configure"),
   DiagnosticsLanes("diagnostics.lanes"),
-  UsersSetGitHubIdentity("users.setGitHubIdentity"),
-  UsersClearGitHubIdentity("users.clearGitHubIdentity"),
 }
 
 enum class GatewayEvent(

--- a/docs/concepts/multi-user.md
+++ b/docs/concepts/multi-user.md
@@ -78,7 +78,7 @@ Start a session as a draft to keep work in progress out of teammates' sidebars u
 
 Turn sender attribution is best-effort. Steering can merge input into an active turn, so the transcript cannot always represent each person's contribution as a separate turn. Participant history records that an actor prompted the session, not which words were theirs.
 
-Authenticated people can link a GitHub account under **Settings → Profile → Identity**. Linking is an explicit opt-in to public `Co-authored-by` credit on commits an agent creates from sessions they have prompted. Attribution uses the durable profile participant records described above, not display names or the four-person facepile projection. See [User model](/concepts/user-model#gateway-profile-and-github-credit) for privacy, eligibility, bounds, and unlink behavior.
+GitHub-backed sign-in through Cloudflare Access or Tailscale Serve automatically verifies the person's GitHub account under **Settings → Profile → Identity**. Public `Co-authored-by` credit remains a separate, default-off **Git co-author credit** toggle. Attribution uses that explicit preference plus the durable profile participant records described above, not display names or the four-person facepile projection. See [User model](/concepts/user-model#gateway-profile-and-github-credit) for privacy, eligibility, bounds, account changes, and disabling future credit.
 
 ## Related
 

--- a/docs/concepts/user-model.md
+++ b/docs/concepts/user-model.md
@@ -5,7 +5,7 @@ read_when:
   - You want stable preferences to guide future sessions
   - You need to update a preference without leaving contradictory history
   - You are deciding whether something belongs in USER.md or MEMORY.md
-  - You want to link GitHub credit to your Gateway profile
+  - You want verified GitHub identity and optional commit credit on your Gateway profile
 ---
 
 `USER.md` is the optional user-model artifact in an agent workspace. It stores stable preferences, communication style, relationships, and active-project context as directives that can guide future sessions.
@@ -14,15 +14,21 @@ OpenClaw loads `USER.md` beside `MEMORY.md` at session start. It has a separate 
 
 ## Gateway profile and GitHub credit
 
-Your authenticated Gateway profile is separate from `USER.md`. Open **Settings → Profile → Identity** to set the display name and avatar shown to other people on the Gateway. A custom OpenClaw avatar remains authoritative even when you link GitHub.
+Your authenticated Gateway profile is separate from `USER.md`. Open **Settings → Profile → Identity** to set the display name and avatar shown to other people on the Gateway. A custom OpenClaw avatar remains authoritative when a GitHub account is verified.
 
-Enter a GitHub username in the **GitHub** row to opt into public commit attribution. The Gateway resolves the public account through GitHub, stores its stable numeric account id and current login, and derives a GitHub noreply address. OpenClaw never requests or stores a private GitHub email for this feature.
+GitHub-backed sign-in is supported through Cloudflare Access and Tailscale Serve. For Cloudflare Access, the Gateway accepts identity enrichment only after successful `trusted-proxy` authentication with the standard Access email header and a required Access assertion header. It calls the Access identity endpoint, requires the returned email to match the authenticated proxy principal and the identity provider to be GitHub, then resolves the canonical GitHub login from the returned numeric account id. For Tailscale Serve, the Gateway resolves the verified GitHub-backed Tailscale login through GitHub. Both paths record the immutable numeric account id plus the current canonical login.
 
-When your authenticated profile has prompted a session before an agent run, commits created from that run receive your exact `Co-authored-by` trailer. All linked profile-backed human participants are eligible; channel-only identities, agents, bots, and the configured primary Git author are excluded. The participant set is bounded to 32 and recorded best-effort. The run tells the model when an eligible profile is unlinked or the bound may be incomplete; it never guesses an identity from transcript names.
+The **GitHub account** row is read-only. Generic trusted proxies, token, password, and unauthenticated connections cannot claim a GitHub account, and agent or tool GitHub credentials are never used for this identity. The forwarded Cloudflare Access assertion is connection-scoped: OpenClaw does not persist, export, log, or expose it to the UI or model.
+
+Identity lookup runs after WebSocket sign-in, so a Cloudflare or GitHub rate limit or network failure never blocks access or erases a previously verified account. A later connection or Profile refresh retries the lookup. GitHub login renames are reconciled by numeric account id so profile history and preferences stay attached to one person.
+
+Public commit metadata is a separate choice. **Git co-author credit** defaults off. Enabling it adds the verified account's public GitHub noreply address to commits created from shared sessions; OpenClaw never requests or stores a private GitHub email for this feature. Signing in as a different numeric GitHub account resets the choice, so one account cannot inherit another account's consent.
+
+When your authenticated profile has prompted a session before an agent run, commits created from that run receive your exact `Co-authored-by` trailer. Profile-backed human participants with verified GitHub identity and Git co-author credit enabled are eligible; channel-only identities, agents, bots, and the configured primary Git author are excluded. The participant set is bounded to 32 and recorded best-effort. The run tells the model when a profile has no enabled credit or the bound may be incomplete; it never guesses an identity from transcript names.
 
 OpenClaw supplies exact trailers in the model context for that turn and instructs coding agents to retain them through amendments, rebases, and squash commits so credit reaches the final commit merged to the default branch. The trailers are not exported through the process or shell environment. Git commands remain ordinary shell execution: OpenClaw does not replace `git` or install repository hooks, so the instruction and post-commit verification are the enforcement boundary.
 
-Changing the linked username resolves and stores the new public account. **Disconnect** stops attribution for future runs; it does not rewrite commits that already contain the public trailer.
+Turning **Git co-author credit** off stops attribution for future runs. It does not rewrite commits that already contain the public trailer.
 
 ## Write directives, not observations
 

--- a/docs/concepts/user-model.md
+++ b/docs/concepts/user-model.md
@@ -20,7 +20,7 @@ GitHub-backed sign-in is supported through Cloudflare Access and Tailscale Serve
 
 The **GitHub account** row is read-only. Generic trusted proxies, token, password, and unauthenticated connections cannot claim a GitHub account, and agent or tool GitHub credentials are never used for this identity. The forwarded Cloudflare Access assertion is connection-scoped: OpenClaw does not persist, export, log, or expose it to the UI or model.
 
-Identity lookup runs after WebSocket sign-in, so a Cloudflare or GitHub rate limit or network failure never blocks access or erases a previously verified account. A later connection or Profile refresh retries the lookup. GitHub login renames are reconciled by numeric account id so profile history and preferences stay attached to one person.
+Identity lookup runs after WebSocket sign-in, so connection status and other identity-independent reads remain available. Profile and session work waits for the lookup; a Cloudflare or GitHub rate limit or network failure returns retryable unavailability without exposing a mutable alias or erasing a previously verified account. A later request, connection, or Profile refresh retries the lookup. GitHub login renames are reconciled by numeric account id so profile history and preferences stay attached to one person.
 
 Public commit metadata is a separate choice. **Git co-author credit** defaults off. Enabling it adds the verified account's public GitHub noreply address to commits created from shared sessions; OpenClaw never requests or stores a private GitHub email for this feature. Signing in as a different numeric GitHub account resets the choice, so one account cannot inherit another account's consent.
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -229,30 +229,32 @@ advertised node command.
 
 ### Infrastructure
 
-| Method                                          | What it registers                                                      |
-| ----------------------------------------------- | ---------------------------------------------------------------------- |
-| `api.registerHook(events, handler, opts?)`      | Event hook                                                             |
-| `api.registerHttpRoute(params)`                 | Gateway HTTP endpoint                                                  |
-| `api.registerGatewayMethod(name, handler)`      | Gateway RPC method                                                     |
-| `api.registerGatewayDiscoveryService(service)`  | Local Gateway discovery advertiser                                     |
-| `api.registerCli(registrar, opts?)`             | CLI subcommand                                                         |
-| `api.registerNodeCliFeature(registrar, opts?)`  | Node feature CLI under `openclaw nodes`                                |
-| `api.registerService(service)`                  | Background service                                                     |
-| `api.registerInteractiveHandler(registration)`  | Interactive handler                                                    |
-| `api.registerAgentToolResultMiddleware(...)`    | Runtime tool-result middleware                                         |
-| `api.registerMemoryPromptSupplement(builder)`   | Additive memory-adjacent prompt section                                |
-| `api.registerMemoryPromptPreparation(prepare)`  | Async preparation for a memory-adjacent prompt section                 |
-| `api.registerMemoryCorpusSupplement(adapter)`   | Additive memory search/read corpus                                     |
-| `api.registerHostedMediaResolver(resolver)`     | Resolver for browser-style hosted media URLs                           |
-| `api.registerMcpServerConnectionResolver(...)`  | Per-requester MCP transport (`url`/`headers`) for a static server name |
-| `api.registerTextTransforms(transforms)`        | Plugin-owned prompt/message compatibility text rewrites                |
-| `api.registerConfigMigration(migrate)`          | Lightweight config migration run before plugin runtime loads           |
-| `api.registerMigrationProvider(provider)`       | Importer for `openclaw migrate`                                        |
-| `api.registerAutoEnableProbe(probe)`            | Config probe that can auto-enable this plugin                          |
-| `api.registerReload(registration)`              | Restart/hot/noop config-prefix policy for reload handling              |
-| `api.registerNodeHostCommand(command)`          | Command handler exposed to paired nodes                                |
-| `api.registerNodeInvokePolicy(policy)`          | Allowlist/approval policy for node-invoked commands                    |
-| `api.registerSecurityAuditCollector(collector)` | Findings collector for `openclaw security audit`                       |
+| Method                                            | What it registers                                                      |
+| ------------------------------------------------- | ---------------------------------------------------------------------- |
+| `api.registerHook(events, handler, opts?)`        | Event hook                                                             |
+| `api.registerHttpRoute(params)`                   | Gateway HTTP endpoint                                                  |
+| `api.registerGatewayMethod(name, handler, opts?)` | Gateway RPC method                                                     |
+| `api.registerGatewayDiscoveryService(service)`    | Local Gateway discovery advertiser                                     |
+| `api.registerCli(registrar, opts?)`               | CLI subcommand                                                         |
+| `api.registerNodeCliFeature(registrar, opts?)`    | Node feature CLI under `openclaw nodes`                                |
+| `api.registerService(service)`                    | Background service                                                     |
+| `api.registerInteractiveHandler(registration)`    | Interactive handler                                                    |
+| `api.registerAgentToolResultMiddleware(...)`      | Runtime tool-result middleware                                         |
+| `api.registerMemoryPromptSupplement(builder)`     | Additive memory-adjacent prompt section                                |
+| `api.registerMemoryPromptPreparation(prepare)`    | Async preparation for a memory-adjacent prompt section                 |
+| `api.registerMemoryCorpusSupplement(adapter)`     | Additive memory search/read corpus                                     |
+| `api.registerHostedMediaResolver(resolver)`       | Resolver for browser-style hosted media URLs                           |
+| `api.registerMcpServerConnectionResolver(...)`    | Per-requester MCP transport (`url`/`headers`) for a static server name |
+| `api.registerTextTransforms(transforms)`          | Plugin-owned prompt/message compatibility text rewrites                |
+| `api.registerConfigMigration(migrate)`            | Lightweight config migration run before plugin runtime loads           |
+| `api.registerMigrationProvider(provider)`         | Importer for `openclaw migrate`                                        |
+| `api.registerAutoEnableProbe(probe)`              | Config probe that can auto-enable this plugin                          |
+| `api.registerReload(registration)`                | Restart/hot/noop config-prefix policy for reload handling              |
+| `api.registerNodeHostCommand(command)`            | Command handler exposed to paired nodes                                |
+| `api.registerNodeInvokePolicy(policy)`            | Allowlist/approval policy for node-invoked commands                    |
+| `api.registerSecurityAuditCollector(collector)`   | Findings collector for `openclaw security audit`                       |
+
+Gateway methods default to `profileAccess: "required"`, so authenticated-profile verification fails closed before plugin dispatch. Set `profileAccess: "independent"` only for an audited method that neither reads nor mutates durable user or session state. Operator scope remains a separate authorization requirement.
 
 #### Post-ack webhook work
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -106,9 +106,9 @@ On the first identified connection, the Control UI uploads existing browser-loca
 
 ## Personal identity
 
-Authenticated people have a durable Gateway profile with a display name, avatar, linked emails, and optional GitHub identity. Open **Settings → Profile → Identity** to update it. The profile follows the authenticated person across browsers and supplies attribution in shared sessions; clearing browser site data does not delete it.
+Authenticated people have a durable Gateway profile with a display name, avatar, linked emails, and optional verified GitHub identity. Open **Settings → Profile → Identity** to update the editable fields. The profile follows the authenticated person across browsers; clearing browser site data does not delete it.
 
-Linking GitHub opts the profile into public commit co-author credit for agent sessions that person prompts. The row shows GitHub's public account avatar and link without replacing a custom OpenClaw avatar. See [User model](/concepts/user-model#gateway-profile-and-github-credit) for the noreply privacy and eligibility rules.
+GitHub-backed sign-in through Cloudflare Access or Tailscale Serve fills the read-only **GitHub account** row with the verified public avatar and account link without replacing a custom OpenClaw avatar. **Git co-author credit** is a separate, default-off toggle for future commits from shared sessions. See [User model](/concepts/user-model#gateway-profile-and-github-credit) for verification, retry, account-change, noreply privacy, and eligibility rules.
 
 The assistant avatar override follows the same browser-local pattern: uploaded overrides overlay the gateway-resolved identity locally and never round-trip through `config.patch`. The shared `ui.assistant.avatar` config field is still available for non-UI clients that write the field directly.
 
@@ -697,13 +697,14 @@ See [Tailscale](/gateway/tailscale) for HTTPS setup guidance.
 
 ## Content security policy
 
-The Control UI ships a tight `img-src` policy: only **same-origin** assets, `data:` URLs, and locally generated `blob:` URLs are allowed. Remote `http(s)` and protocol-relative image URLs are rejected by the browser and never issue network fetches.
+The Control UI ships a tight `img-src` policy: **same-origin** assets, `data:` URLs, locally generated `blob:` URLs, and the fixed GitHub avatar and Gravatar hosts are allowed. Other remote `http(s)` and protocol-relative image URLs are rejected by the browser and never issue network fetches.
 
 In practice:
 
 - Avatars and images served under relative paths (for example `/avatars/<id>`) still render, including authenticated avatar routes the UI fetches and converts into local `blob:` URLs.
 - Inline `data:image/...` URLs still render.
 - Local `blob:` URLs created by the Control UI still render.
+- Verified GitHub account avatars render from `avatars.githubusercontent.com`; arbitrary avatar hosts remain blocked.
 - GitHub link preview avatars are fetched by the Gateway from GitHub's fixed avatar host and returned as bounded `data:` URLs; the operator browser never contacts the remote avatar host.
 - Link favicons are on by default. The authenticated Control UI requests them through the Gateway; the browser never contacts link destinations directly. The Gateway requests only each public hostname's HTTPS `/favicon.ico`, with strict DNS-pinned SSRF checks on the original URL and every redirect plus bounded time, bytes, concurrency, and image validation. Private, internal, and IP-literal destinations are rejected. This discloses linked hostnames and the Gateway's network address to those sites. Set `gateway.controlUi.automaticallyFetchFavicons: false` to prevent all favicon route requests and destination fetches.
 - Remote avatar URLs emitted by channel metadata are stripped at the Control UI's avatar helpers and replaced with the built-in logo/badge, so a compromised or malicious channel cannot force arbitrary remote image fetches from an operator browser.

--- a/extensions/logbook/index.test.ts
+++ b/extensions/logbook/index.test.ts
@@ -19,6 +19,29 @@ function registerLogbookPolicies(): OpenClawPluginNodeInvokePolicy[] {
   return policies;
 }
 
+describe("logbook gateway methods", () => {
+  it("keeps only process-wide status independent of the authenticated profile", () => {
+    const registrations: Array<{ method: string; options: unknown }> = [];
+    plugin.register({
+      pluginConfig: {},
+      session: { controls: { registerControlUiDescriptor: () => {} } },
+      registerNodeInvokePolicy: () => {},
+      registerService: () => {},
+      registerGatewayMethod: (method: string, _handler: unknown, options: unknown) => {
+        registrations.push({ method, options });
+      },
+    } as unknown as OpenClawPluginApi);
+
+    expect(registrations.find((entry) => entry.method === "logbook.status")?.options).toEqual({
+      scope: "operator.read",
+      profileAccess: "independent",
+    });
+    for (const registration of registrations.filter((entry) => entry.method !== "logbook.status")) {
+      expect(registration.options).not.toHaveProperty("profileAccess");
+    }
+  });
+});
+
 describe("logbook snapshot invoke policy", () => {
   it("blocks logbook.snapshot when gateway.nodes.commands.deny lists screen.snapshot", async () => {
     const [policy] = registerLogbookPolicies();

--- a/extensions/logbook/index.ts
+++ b/extensions/logbook/index.ts
@@ -150,10 +150,18 @@ export default definePluginEntry({
     const registerWrite = (method: string, run: (params: unknown) => unknown) =>
       api.registerGatewayMethod(method, handle(run), { scope: "operator.write" });
 
+    // Process-wide service health does not read or mutate a user's durable profile/session state.
+    api.registerGatewayMethod(
+      "logbook.status",
+      handle(() => requireService().status()),
+      {
+        scope: "operator.read",
+        profileAccess: "independent",
+      },
+    );
+
     // Raw frame bytes are the most sensitive payload (full screen contents),
     // so they require write scope while derived text stays readable.
-    registerRead("logbook.status", () => requireService().status());
-
     registerRead("logbook.days", () => ({ days: requireService().listDays() }));
 
     registerRead("logbook.timeline", (params) => {

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -360,6 +360,7 @@ export {
   AuditEventSchema,
   AuditListParamsSchema,
   AuditListResultSchema,
+  GIT_COAUTHOR_PREFERENCE_KEY,
   UserProfileSchema,
   UsersLinkEmailParamsSchema,
   UsersLinkEmailResultSchema,

--- a/packages/gateway-protocol/src/schema/users.ts
+++ b/packages/gateway-protocol/src/schema/users.ts
@@ -7,6 +7,7 @@ import { NonEmptyString } from "./primitives.js";
 export const USER_PREFS_ENTRY_LIMIT = 32;
 export const USER_PREFS_PROFILE_KEY_LIMIT = 128;
 export const USER_PREFS_VALUE_BYTES = 4 * 1024;
+export const GIT_COAUTHOR_PREFERENCE_KEY = "git.coauthor.enabled";
 
 const UserProfileIdSchema = Type.String({ minLength: 1, maxLength: 128 });
 const UserProfileDisplayNameSchema = Type.String({ maxLength: 256 });
@@ -66,13 +67,6 @@ export const UsersSetAvatarResultSchema = closedObject({
   avatarRevision: NonEmptyString,
 });
 
-export const UsersSetGitHubIdentityParamsSchema = closedObject({
-  username: Type.String({ minLength: 1, maxLength: 39 }),
-});
-export const UsersSetGitHubIdentityResultSchema = closedObject({ profile: UserProfileSchema });
-export const UsersClearGitHubIdentityParamsSchema = closedObject({});
-export const UsersClearGitHubIdentityResultSchema = closedObject({ profile: UserProfileSchema });
-
 export const UsersPrefsGetParamsSchema = closedObject({
   keys: Type.Optional(
     Type.Array(UserPreferenceKeySchema, {
@@ -103,10 +97,6 @@ export type UsersSetDisplayNameParams = Static<typeof UsersSetDisplayNameParamsS
 export type UsersSetDisplayNameResult = Static<typeof UsersSetDisplayNameResultSchema>;
 export type UsersSetAvatarParams = Static<typeof UsersSetAvatarParamsSchema>;
 export type UsersSetAvatarResult = Static<typeof UsersSetAvatarResultSchema>;
-export type UsersSetGitHubIdentityParams = Static<typeof UsersSetGitHubIdentityParamsSchema>;
-export type UsersSetGitHubIdentityResult = Static<typeof UsersSetGitHubIdentityResultSchema>;
-export type UsersClearGitHubIdentityParams = Static<typeof UsersClearGitHubIdentityParamsSchema>;
-export type UsersClearGitHubIdentityResult = Static<typeof UsersClearGitHubIdentityResultSchema>;
 export type UsersPrefsGetParams = Static<typeof UsersPrefsGetParamsSchema>;
 export type UsersPrefsGetResult = Static<typeof UsersPrefsGetResultSchema>;
 export type UsersPrefsSetParams = Static<typeof UsersPrefsSetParamsSchema>;

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -104,14 +104,6 @@ export const validateUsersSetDisplayNameParams = compile(S.UsersSetDisplayNamePa
 export const validateUsersSetDisplayNameResult = compile(S.UsersSetDisplayNameResultSchema);
 export const validateUsersSetAvatarParams = compile(S.UsersSetAvatarParamsSchema);
 export const validateUsersSetAvatarResult = compile(S.UsersSetAvatarResultSchema);
-export const validateUsersSetGitHubIdentityParams = compile(S.UsersSetGitHubIdentityParamsSchema);
-export const validateUsersSetGitHubIdentityResult = compile(S.UsersSetGitHubIdentityResultSchema);
-export const validateUsersClearGitHubIdentityParams = compile(
-  S.UsersClearGitHubIdentityParamsSchema,
-);
-export const validateUsersClearGitHubIdentityResult = compile(
-  S.UsersClearGitHubIdentityResultSchema,
-);
 export const validateAgentIdentityParams = compile(S.AgentIdentityParamsSchema);
 export const validateAgentWaitParams = compile(S.AgentWaitParamsSchema);
 export const validateWakeParams = compile(S.WakeParamsSchema);

--- a/src/agents/git-coauthor-attribution.test.ts
+++ b/src/agents/git-coauthor-attribution.test.ts
@@ -30,7 +30,13 @@ describe("Git co-author attribution", () => {
       const profile = (email: string, accountId?: number, login?: string, optedIn = true) => {
         const value = ensureProfileForEmail(email, { env: state.env });
         if (accountId && login) {
-          syncGitHubIdentity(value.id, { accountId, login }, { env: state.env });
+          syncGitHubIdentity(
+            {
+              identity: { accountId, login },
+              authenticationAlias: { kind: "email", email },
+            },
+            { env: state.env },
+          );
           if (optedIn) {
             expect(
               setUserPreferences(
@@ -130,7 +136,13 @@ describe("Git co-author attribution", () => {
         });
       }
       const current = ensureProfileForEmail("current@example.test", { env: state.env });
-      syncGitHubIdentity(current.id, { accountId: 99, login: "current" }, { env: state.env });
+      syncGitHubIdentity(
+        {
+          identity: { accountId: 99, login: "current" },
+          authenticationAlias: { kind: "email", email: "current@example.test" },
+        },
+        { env: state.env },
+      );
       expect(
         setUserPreferences(current.id, { [GIT_COAUTHOR_PREFERENCE_KEY]: true }, { env: state.env }),
       ).toMatchObject({ ok: true });

--- a/src/agents/git-coauthor-attribution.test.ts
+++ b/src/agents/git-coauthor-attribution.test.ts
@@ -1,12 +1,17 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { GIT_COAUTHOR_PREFERENCE_KEY } from "../../packages/gateway-protocol/src/index.js";
 import {
   MAX_SESSION_PARTICIPANTS,
   recordSessionParticipant,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { ensureProfileForEmail, setGitHubIdentity } from "../state/user-profiles.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { setUserPreferences } from "../state/user-preferences.js";
+import { ensureProfileForEmail, syncGitHubIdentity } from "../state/user-profiles.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   appendGitCoauthorContext,
@@ -22,20 +27,37 @@ describe("Git co-author attribution", () => {
   it("derives exact bounded trailers only from canonical profile-backed humans", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
       const sessionKey = "agent:main:coauthors";
-      const profile = (email: string, accountId?: number, login?: string) => {
+      const profile = (email: string, accountId?: number, login?: string, optedIn = true) => {
         const value = ensureProfileForEmail(email, { env: state.env });
-        return accountId && login
-          ? setGitHubIdentity(value.id, { accountId, login }, { env: state.env })
-          : value;
+        if (accountId && login) {
+          syncGitHubIdentity(value.id, { accountId, login }, { env: state.env });
+          if (optedIn) {
+            expect(
+              setUserPreferences(
+                value.id,
+                { [GIT_COAUTHOR_PREFERENCE_KEY]: true },
+                { env: state.env },
+              ),
+            ).toMatchObject({ ok: true });
+          }
+        }
+        return value;
       };
       const ada = profile("ada@example.test", 20, "ada");
       const grace = profile("grace@example.test", 10, "grace");
       const primary = profile("primary@example.test", 30, "primary");
       const current = profile("current@example.test", 15, "current");
+      const optedOut = profile("opted-out@example.test", 25, "opted-out", false);
       const unlinked = profile("unlinked@example.test");
+      const legacy = ensureProfileForEmail("legacy@example.test", { env: state.env });
+      openOpenClawStateDatabase({ env: state.env })
+        .db.prepare(
+          "INSERT INTO user_profile_identities (provider, subject, profile_id, canonical_login, created_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run("github-attribution", "40", legacy.id, "legacy", Date.now());
       const scope = { agentId: "main", env: state.env, sessionKey };
       await upsertSessionEntryCore(scope, { sessionId: "coauthors", updatedAt: 1 });
-      for (const participant of [ada, grace, primary, unlinked]) {
+      for (const participant of [ada, grace, primary, optedOut, unlinked, legacy]) {
         recordSessionParticipant(scope, {
           actor: { type: "human", id: participant.id },
           source: "profile",
@@ -84,8 +106,10 @@ describe("Git co-author attribution", () => {
           "Co-authored-by: ada <20+ada@users.noreply.github.com>",
         ].join("\n"),
       );
+      expect(modelPrompt).not.toContain("Co-authored-by: opted-out");
+      expect(modelPrompt).not.toContain("Co-authored-by: legacy");
       expect(modelPrompt).toContain(
-        "1 eligible profile participant(s) have no linked GitHub account and were omitted",
+        "3 eligible profile participant(s) have no enabled Git co-author credit and were omitted",
       );
       expect(modelPrompt).toContain(
         "1 linked profile participant(s) match the configured primary Git author",
@@ -106,7 +130,10 @@ describe("Git co-author attribution", () => {
         });
       }
       const current = ensureProfileForEmail("current@example.test", { env: state.env });
-      setGitHubIdentity(current.id, { accountId: 99, login: "current" }, { env: state.env });
+      syncGitHubIdentity(current.id, { accountId: 99, login: "current" }, { env: state.env });
+      expect(
+        setUserPreferences(current.id, { [GIT_COAUTHOR_PREFERENCE_KEY]: true }, { env: state.env }),
+      ).toMatchObject({ ok: true });
       const attribution = prepareGitCoauthorAttribution({
         agentId: "main",
         config: {},

--- a/src/agents/git-coauthor-attribution.ts
+++ b/src/agents/git-coauthor-attribution.ts
@@ -37,7 +37,7 @@ export function prepareGitCoauthorAttribution(params: {
     resolveConfiguredGitHubToolIdentity({ ...params, scope: "system" });
   const primaryEmail = primaryIdentity?.gitAuthor?.email?.trim().toLowerCase();
   const trailers = new Map<number, string>();
-  let unlinked = 0;
+  let withoutCredit = 0;
   let unresolved = 0;
   let primaryAuthor = 0;
   for (const profileId of snapshot.profileIds) {
@@ -47,7 +47,7 @@ export function prepareGitCoauthorAttribution(params: {
     }
     const identity = identities.get(profileId);
     if (!identity) {
-      unlinked += 1;
+      withoutCredit += 1;
       continue;
     }
     const noreplyEmail = `${identity.accountId}+${identity.login}@users.noreply.github.com`;
@@ -72,8 +72,8 @@ export function prepareGitCoauthorAttribution(params: {
     snapshot.incomplete
       ? "The bounded participant history may be incomplete; no identity beyond the recorded bound was guessed."
       : undefined,
-    unlinked > 0
-      ? `${unlinked} eligible profile participant(s) have no linked GitHub account and were omitted.`
+    withoutCredit > 0
+      ? `${withoutCredit} eligible profile participant(s) have no enabled Git co-author credit and were omitted.`
       : undefined,
     unresolved > 0
       ? `${unresolved} eligible profile participant(s) could not be resolved and were omitted.`

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -894,25 +894,7 @@ describe("ensureSandboxBrowser create args", () => {
     });
 
     const cfg = buildConfig(false);
-    cfg.browser.autoStartTimeoutMs = 25;
-
-    const originalSetTimeout = globalThis.setTimeout;
-    let requestTimeoutMs: number | undefined;
-    let fireRequestTimeout: (() => void) | undefined;
-    // Fire the production request timer only after the real loopback server sees
-    // the request, keeping the stalled-fetch proof deterministic and fast.
-    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
-      callback: (...args: unknown[]) => void,
-      timeout?: number,
-      ...args: unknown[]
-    ) => {
-      if (requestTimeoutMs === undefined) {
-        requestTimeoutMs = timeout;
-        fireRequestTimeout = () => callback(...args);
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      }
-      return originalSetTimeout(() => callback(...args), timeout);
-    }) as typeof setTimeout);
+    cfg.browser.autoStartTimeoutMs = 250;
 
     try {
       const startup = ensureTestSandboxBrowser({
@@ -921,23 +903,28 @@ describe("ensureSandboxBrowser create args", () => {
         agentWorkspaceDir: "/tmp/workspace",
         cfg,
       });
+      const startupResult = startup.then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error }),
+      );
       await Promise.race([
         requestReceived,
         new Promise<never>((_resolve, reject) => {
-          originalSetTimeout(
-            () => reject(new Error("CDP request was not received")),
-            1_000,
-          ).unref();
+          setTimeout(() => reject(new Error("CDP request was not received")), 2_000).unref();
         }),
       ]);
 
       expect(requestPath).toBe("/json/version");
-      expect(requestTimeoutMs).toBeGreaterThanOrEqual(1);
-      expect(requestTimeoutMs).toBeLessThanOrEqual(cfg.browser.autoStartTimeoutMs);
-      fireRequestTimeout?.();
-      await expect(startup).rejects.toThrow("hung container has been forcefully removed");
+      const result = await startupResult;
+      expect(result.ok).toBe(false);
+      if (result.ok) {
+        throw new Error("expected stalled CDP startup to fail");
+      }
+      expect(result.error).toBeInstanceOf(Error);
+      expect((result.error as Error).message).toContain(
+        `within ${cfg.browser.autoStartTimeoutMs}ms. The hung container has been forcefully removed.`,
+      );
     } finally {
-      setTimeoutSpy.mockRestore();
       for (const socket of sockets) {
         socket.destroy();
       }

--- a/src/gateway/github-user-identity.test.ts
+++ b/src/gateway/github-user-identity.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  ensureProfileForTailscaleIdentity,
+  getUserProfileListItem,
+} from "../state/user-profiles.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { ControlUiGitHubError } from "./control-ui-github-api.js";
-import { resolveGitHubUserIdentity } from "./github-user-identity.js";
+import { createAuthenticatedGitHubIdentitySync } from "./github-user-identity.js";
 
 function githubResponse(body: unknown, status = 200, headers: Record<string, string> = {}) {
   return new Response(JSON.stringify(body), {
@@ -9,27 +15,81 @@ function githubResponse(body: unknown, status = 200, headers: Record<string, str
   });
 }
 
-describe("resolveGitHubUserIdentity", () => {
-  it("resolves the canonical public account without authentication", async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValue(githubResponse({ id: 583231, login: "OctoCat" }));
+function accessAssertion(issuer: unknown): string {
+  const payload = Buffer.from(JSON.stringify({ iss: issuer })).toString("base64url");
+  return `header.${payload}.signature`;
+}
 
-    await expect(resolveGitHubUserIdentity("octocat", fetchMock)).resolves.toEqual({
-      accountId: 583231,
-      login: "OctoCat",
+function cloudflareSync(params: {
+  profileId: string;
+  principal?: string;
+  assertion?: string;
+  userHeader?: string;
+  requiredHeaders?: string[];
+}) {
+  return createAuthenticatedGitHubIdentitySync({
+    profileId: params.profileId,
+    authResult: {
+      ok: true,
+      method: "trusted-proxy",
+      user: params.principal ?? "ada@example.com",
+    },
+    authConfig: {
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: params.userHeader ?? "cf-access-authenticated-user-email",
+        requiredHeaders: params.requiredHeaders ?? ["CF-Access-JWT-Assertion"],
+      },
+    },
+    requestHeaders: {
+      "cf-access-authenticated-user-email": params.principal ?? "ada@example.com",
+      "cf-access-jwt-assertion":
+        params.assertion ?? accessAssertion("https://team.cloudflareaccess.com"),
+    },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("authenticated GitHub identity sync", () => {
+  it("resolves the canonical public account without authentication", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "octocat@github" });
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(githubResponse({ id: 583231, login: "OctoCat" }));
+
+      const sync = createAuthenticatedGitHubIdentitySync({
+        profileId: profile.id,
+        authResult: {
+          ok: true,
+          method: "tailscale",
+          user: "octocat@github",
+          tailscaleIdentity: { login: "octocat@github", name: "Octo Cat" },
+        },
+      });
+
+      await expect(sync?.()).resolves.toMatchObject({
+        profileId: profile.id,
+      });
+      expect(getUserProfileListItem(profile.id).githubIdentity).toMatchObject({
+        login: "OctoCat",
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.github.com/users/octocat",
+        expect.objectContaining({ redirect: "manual", signal: expect.any(AbortSignal) }),
+      );
+      const headers = fetchMock.mock.calls[0]?.[1]?.headers;
+      expect(headers).toMatchObject({
+        Accept: "application/vnd.github+json",
+        "User-Agent": "OpenClaw-Control-UI",
+        "X-GitHub-Api-Version": "2022-11-28",
+      });
+      expect(headers).not.toHaveProperty("Authorization");
     });
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://api.github.com/users/octocat",
-      expect.objectContaining({ redirect: "manual", signal: expect.any(AbortSignal) }),
-    );
-    const headers = fetchMock.mock.calls[0]?.[1]?.headers;
-    expect(headers).toMatchObject({
-      Accept: "application/vnd.github+json",
-      "User-Agent": "OpenClaw-Control-UI",
-      "X-GitHub-Api-Version": "2022-11-28",
-    });
-    expect(headers).not.toHaveProperty("Authorization");
   });
 
   it.each([
@@ -45,19 +105,326 @@ describe("resolveGitHubUserIdentity", () => {
     },
     { name: "malformed", response: githubResponse({ id: "583231" }), statusCode: 502 },
   ])("maps a $name response", async ({ response, statusCode }) => {
-    await expect(
-      resolveGitHubUserIdentity("octocat", vi.fn<typeof fetch>().mockResolvedValue(response)),
-    ).rejects.toMatchObject({ statusCode } satisfies Partial<ControlUiGitHubError>);
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "octocat@github" });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
+      const sync = createAuthenticatedGitHubIdentitySync({
+        profileId: profile.id,
+        authResult: {
+          ok: true,
+          method: "tailscale",
+          user: "octocat@github",
+          tailscaleIdentity: { login: "octocat@github", name: "Octo Cat" },
+        },
+      });
+      await expect(sync?.()).rejects.toMatchObject({
+        statusCode,
+      } satisfies Partial<ControlUiGitHubError>);
+    });
   });
 
   it("maps network failures and rejects invalid usernames before fetch", async () => {
-    const fetchMock = vi.fn<typeof fetch>().mockRejectedValue(new Error("network down"));
-    await expect(resolveGitHubUserIdentity("octocat", fetchMock)).rejects.toMatchObject({
-      statusCode: 502,
-    } satisfies Partial<ControlUiGitHubError>);
-    await expect(resolveGitHubUserIdentity("bad/name", fetchMock)).rejects.toThrow(
-      "GitHub username is invalid",
-    );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "octocat@github" });
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+      const sync = createAuthenticatedGitHubIdentitySync({
+        profileId: profile.id,
+        authResult: {
+          ok: true,
+          method: "tailscale",
+          user: "octocat@github",
+          tailscaleIdentity: { login: "octocat@github", name: "Octo Cat" },
+        },
+      });
+      await expect(sync?.()).rejects.toMatchObject({
+        statusCode: 502,
+      } satisfies Partial<ControlUiGitHubError>);
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("deduplicates concurrent authenticated profile sync", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "ada@github" });
+      let resolveLookup: ((response: Response) => void) | undefined;
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementationOnce(
+        async () =>
+          await new Promise<Response>((resolve) => {
+            resolveLookup = resolve;
+          }),
+      );
+
+      const sync = createAuthenticatedGitHubIdentitySync({
+        profileId: profile.id,
+        authResult: {
+          ok: true,
+          method: "tailscale",
+          user: "ada@github",
+          tailscaleIdentity: { login: "ada@github", name: "Ada" },
+        },
+      });
+      const first = sync?.();
+      const second = sync?.();
+      expect(second).toBe(first);
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+      resolveLookup?.(githubResponse({ id: 583231, login: "Ada" }));
+
+      await expect(first).resolves.toMatchObject({ profileId: profile.id });
+      expect(getUserProfileListItem(profile.id).githubIdentity).toMatchObject({ login: "Ada" });
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("preserves verified identity after lookup failure and retries later", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "ada@github" });
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(githubResponse({ id: 583231, login: "Ada" }))
+        .mockRejectedValueOnce(new Error("network unavailable"))
+        .mockResolvedValueOnce(githubResponse({ id: 583231, login: "Ada-Renamed" }));
+
+      const firstConnection = createAuthenticatedGitHubIdentitySync({
+        profileId: profile.id,
+        authResult: {
+          ok: true,
+          method: "tailscale",
+          user: "ada@github",
+          tailscaleIdentity: { login: "ada@github", name: "Ada" },
+        },
+      });
+      await firstConnection?.();
+      const failingConnection = createAuthenticatedGitHubIdentitySync({
+        profileId: profile.id,
+        authResult: {
+          ok: true,
+          method: "tailscale",
+          user: "ada@github",
+          tailscaleIdentity: { login: "ada@github", name: "Ada" },
+        },
+      });
+      await expect(failingConnection?.()).rejects.toMatchObject({ statusCode: 502 });
+      expect(getUserProfileListItem(profile.id).githubIdentity).toMatchObject({ login: "Ada" });
+
+      await failingConnection?.();
+      expect(getUserProfileListItem(profile.id).githubIdentity).toMatchObject({
+        login: "Ada-Renamed",
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  it("activates only the standard required-header Cloudflare Access contract", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
+      expect(cloudflareSync({ profileId: profile.id })).toBeTypeOf("function");
+      expect(
+        cloudflareSync({ profileId: profile.id, userHeader: "x-forwarded-user" }),
+      ).toBeUndefined();
+      expect(
+        cloudflareSync({ profileId: profile.id, requiredHeaders: ["x-forwarded-proto"] }),
+      ).toBeUndefined();
+    });
+  });
+
+  it("binds Cloudflare identity to email, GitHub IdP, numeric id, and canonical GitHub login", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          githubResponse({
+            id: 58493,
+            email: "ADA@example.com",
+            name: "Ada Display Name",
+            idp: { id: "github-oauth", type: "github" },
+          }),
+        )
+        .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete" }));
+
+      const sync = cloudflareSync({ profileId: profile.id });
+      await expect(sync?.()).resolves.toMatchObject({ profileId: profile.id });
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        "https://team.cloudflareaccess.com/cdn-cgi/access/get-identity",
+        expect.objectContaining({
+          headers: {
+            Cookie: expect.stringMatching(/^CF_Authorization=/u),
+          },
+          redirect: "manual",
+          signal: expect.any(AbortSignal),
+        }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        "https://api.github.com/user/58493",
+        expect.objectContaining({ redirect: "manual", signal: expect.any(AbortSignal) }),
+      );
+      expect(fetchMock.mock.calls[1]?.[1]?.headers).not.toHaveProperty("Authorization");
+      expect(getUserProfileListItem(profile.id).githubIdentity).toMatchObject({
+        login: "steipete",
+      });
+    });
+  });
+
+  it.each([
+    { name: "malformed JWT", assertion: "not-a-jwt" },
+    { name: "oversized JWT", assertion: "x".repeat(16 * 1024 + 1) },
+    { name: "non-HTTPS issuer", issuer: "http://team.cloudflareaccess.com" },
+    { name: "credentialed issuer", issuer: "https://user@team.cloudflareaccess.com" },
+    { name: "non-root issuer", issuer: "https://team.cloudflareaccess.com/path" },
+    { name: "hostile suffix", issuer: "https://team.cloudflareaccess.com.evil.test" },
+  ])("rejects a $name before network access", async ({ assertion, issuer }) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
+      const fetchMock = vi.spyOn(globalThis, "fetch");
+      const sync = cloudflareSync({
+        profileId: profile.id,
+        assertion: assertion ?? accessAssertion(issuer),
+      });
+      await expect(sync?.()).rejects.toThrow();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each([
+    {
+      name: "redirect",
+      access: githubResponse({}, 302, { location: "https://evil.test/identity" }),
+    },
+    { name: "non-object response", access: githubResponse([]) },
+    {
+      name: "malformed JSON",
+      access: new Response("{", { status: 200, headers: { "content-type": "application/json" } }),
+    },
+    {
+      name: "mismatched email",
+      access: githubResponse({
+        id: 58493,
+        email: "mallory@example.com",
+        idp: { type: "github" },
+      }),
+    },
+    {
+      name: "non-GitHub IdP",
+      access: githubResponse({
+        id: 58493,
+        email: "ada@example.com",
+        idp: { type: "google" },
+      }),
+    },
+    {
+      name: "invalid account id",
+      access: githubResponse({
+        id: "58493",
+        email: "ada@example.com",
+        idp: { type: "github" },
+      }),
+    },
+  ])("fails safely for a $name", async ({ access }) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
+      vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(access);
+      const sync = cloudflareSync({ profileId: profile.id });
+      await expect(sync?.()).rejects.toThrow();
+      expect(getUserProfileListItem(profile.id).githubIdentity).toBeNull();
+    });
+  });
+
+  it("rejects a GitHub account-id mismatch without erasing prior identity", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
+      const initialFetch = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          githubResponse({
+            id: 58493,
+            email: "ada@example.com",
+            idp: { type: "github" },
+          }),
+        )
+        .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete" }));
+      await cloudflareSync({ profileId: profile.id })?.();
+      initialFetch
+        .mockResolvedValueOnce(
+          githubResponse({
+            id: 58493,
+            email: "ada@example.com",
+            idp: { type: "github" },
+          }),
+        )
+        .mockResolvedValueOnce(githubResponse({ id: 99999, login: "mallory" }));
+
+      await expect(cloudflareSync({ profileId: profile.id })?.()).rejects.toThrow();
+      expect(getUserProfileListItem(profile.id).githubIdentity).toMatchObject({
+        login: "steipete",
+      });
+    });
+  });
+
+  it.each([
+    {
+      name: "GitHub rate limit",
+      githubResult: githubResponse({ message: "rate limit" }, 403, {
+        "x-ratelimit-remaining": "0",
+      }),
+    },
+    { name: "GitHub network failure", githubError: new Error("network unavailable") },
+  ])("preserves prior identity after a $name", async ({ githubResult, githubError }) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce(
+          githubResponse({
+            id: 58493,
+            email: "ada@example.com",
+            idp: { type: "github" },
+          }),
+        )
+        .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete" }));
+      await cloudflareSync({ profileId: profile.id })?.();
+      fetchMock.mockResolvedValueOnce(
+        githubResponse({
+          id: 58493,
+          email: "ada@example.com",
+          idp: { type: "github" },
+        }),
+      );
+      if (githubError) {
+        fetchMock.mockRejectedValueOnce(githubError);
+      } else {
+        fetchMock.mockResolvedValueOnce(githubResult!);
+      }
+
+      await expect(cloudflareSync({ profileId: profile.id })?.()).rejects.toThrow();
+      expect(getUserProfileListItem(profile.id).githubIdentity).toMatchObject({
+        login: "steipete",
+      });
+    });
+  });
+
+  it("redacts the Access assertion from network failures and retries on the same connection", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
+      const assertion = accessAssertion("https://team.cloudflareaccess.com");
+      const fetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValueOnce(new Error(`network rejected ${assertion}`))
+        .mockResolvedValueOnce(
+          githubResponse({
+            id: 58493,
+            email: "ada@example.com",
+            idp: { type: "github" },
+          }),
+        )
+        .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete" }));
+      const sync = cloudflareSync({ profileId: profile.id, assertion });
+
+      const error = await sync?.().catch((failure: unknown) => failure);
+      expect(String(error)).not.toContain(assertion);
+      await expect(sync?.()).resolves.toMatchObject({ profileId: profile.id });
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
   });
 });

--- a/src/gateway/github-user-identity.test.ts
+++ b/src/gateway/github-user-identity.test.ts
@@ -21,14 +21,12 @@ function accessAssertion(issuer: unknown): string {
 }
 
 function cloudflareSync(params: {
-  profileId: string;
   principal?: string;
   assertion?: string;
   userHeader?: string;
   requiredHeaders?: string[];
 }) {
   return createAuthenticatedGitHubIdentitySync({
-    profileId: params.profileId,
     authResult: {
       ok: true,
       method: "trusted-proxy",
@@ -63,7 +61,6 @@ describe("authenticated GitHub identity sync", () => {
         .mockResolvedValue(githubResponse({ id: 583231, login: "OctoCat" }));
 
       const sync = createAuthenticatedGitHubIdentitySync({
-        profileId: profile.id,
         authResult: {
           ok: true,
           method: "tailscale",
@@ -106,10 +103,8 @@ describe("authenticated GitHub identity sync", () => {
     { name: "malformed", response: githubResponse({ id: "583231" }), statusCode: 502 },
   ])("maps a $name response", async ({ response, statusCode }) => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const profile = ensureProfileForTailscaleIdentity({ login: "octocat@github" });
       vi.spyOn(globalThis, "fetch").mockResolvedValue(response);
       const sync = createAuthenticatedGitHubIdentitySync({
-        profileId: profile.id,
         authResult: {
           ok: true,
           method: "tailscale",
@@ -125,10 +120,8 @@ describe("authenticated GitHub identity sync", () => {
 
   it("maps network failures and rejects invalid usernames before fetch", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const profile = ensureProfileForTailscaleIdentity({ login: "octocat@github" });
       const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
       const sync = createAuthenticatedGitHubIdentitySync({
-        profileId: profile.id,
         authResult: {
           ok: true,
           method: "tailscale",
@@ -155,7 +148,6 @@ describe("authenticated GitHub identity sync", () => {
       );
 
       const sync = createAuthenticatedGitHubIdentitySync({
-        profileId: profile.id,
         authResult: {
           ok: true,
           method: "tailscale",
@@ -185,7 +177,6 @@ describe("authenticated GitHub identity sync", () => {
         .mockResolvedValueOnce(githubResponse({ id: 583231, login: "Ada-Renamed" }));
 
       const firstConnection = createAuthenticatedGitHubIdentitySync({
-        profileId: profile.id,
         authResult: {
           ok: true,
           method: "tailscale",
@@ -195,7 +186,6 @@ describe("authenticated GitHub identity sync", () => {
       });
       await firstConnection?.();
       const failingConnection = createAuthenticatedGitHubIdentitySync({
-        profileId: profile.id,
         authResult: {
           ok: true,
           method: "tailscale",
@@ -216,20 +206,14 @@ describe("authenticated GitHub identity sync", () => {
 
   it("activates only the standard required-header Cloudflare Access contract", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
-      expect(cloudflareSync({ profileId: profile.id })).toBeTypeOf("function");
-      expect(
-        cloudflareSync({ profileId: profile.id, userHeader: "x-forwarded-user" }),
-      ).toBeUndefined();
-      expect(
-        cloudflareSync({ profileId: profile.id, requiredHeaders: ["x-forwarded-proto"] }),
-      ).toBeUndefined();
+      expect(cloudflareSync({})).toBeTypeOf("function");
+      expect(cloudflareSync({ userHeader: "x-forwarded-user" })).toBeUndefined();
+      expect(cloudflareSync({ requiredHeaders: ["x-forwarded-proto"] })).toBeUndefined();
     });
   });
 
   it("binds Cloudflare identity to email, GitHub IdP, numeric id, and canonical GitHub login", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
       const fetchMock = vi
         .spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(
@@ -242,8 +226,8 @@ describe("authenticated GitHub identity sync", () => {
         )
         .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete" }));
 
-      const sync = cloudflareSync({ profileId: profile.id });
-      await expect(sync?.()).resolves.toMatchObject({ profileId: profile.id });
+      const sync = cloudflareSync({});
+      const result = await sync?.();
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
         "https://team.cloudflareaccess.com/cdn-cgi/access/get-identity",
@@ -261,8 +245,10 @@ describe("authenticated GitHub identity sync", () => {
         expect.objectContaining({ redirect: "manual", signal: expect.any(AbortSignal) }),
       );
       expect(fetchMock.mock.calls[1]?.[1]?.headers).not.toHaveProperty("Authorization");
-      expect(getUserProfileListItem(profile.id).githubIdentity).toMatchObject({
-        login: "steipete",
+      expect(getUserProfileListItem(result!.profileId)).toMatchObject({
+        displayName: "Ada Display Name",
+        emails: ["ada@example.com"],
+        githubIdentity: { login: "steipete" },
       });
     });
   });
@@ -276,10 +262,8 @@ describe("authenticated GitHub identity sync", () => {
     { name: "hostile suffix", issuer: "https://team.cloudflareaccess.com.evil.test" },
   ])("rejects a $name before network access", async ({ assertion, issuer }) => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
       const fetchMock = vi.spyOn(globalThis, "fetch");
       const sync = cloudflareSync({
-        profileId: profile.id,
         assertion: assertion ?? accessAssertion(issuer),
       });
       await expect(sync?.()).rejects.toThrow();
@@ -325,7 +309,7 @@ describe("authenticated GitHub identity sync", () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
       vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(access);
-      const sync = cloudflareSync({ profileId: profile.id });
+      const sync = cloudflareSync({});
       await expect(sync?.()).rejects.toThrow();
       expect(getUserProfileListItem(profile.id).githubIdentity).toBeNull();
     });
@@ -333,7 +317,6 @@ describe("authenticated GitHub identity sync", () => {
 
   it("rejects a GitHub account-id mismatch without erasing prior identity", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
       const initialFetch = vi
         .spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(
@@ -344,7 +327,7 @@ describe("authenticated GitHub identity sync", () => {
           }),
         )
         .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete" }));
-      await cloudflareSync({ profileId: profile.id })?.();
+      const first = await cloudflareSync({})?.();
       initialFetch
         .mockResolvedValueOnce(
           githubResponse({
@@ -355,8 +338,8 @@ describe("authenticated GitHub identity sync", () => {
         )
         .mockResolvedValueOnce(githubResponse({ id: 99999, login: "mallory" }));
 
-      await expect(cloudflareSync({ profileId: profile.id })?.()).rejects.toThrow();
-      expect(getUserProfileListItem(profile.id).githubIdentity).toMatchObject({
+      await expect(cloudflareSync({})?.()).rejects.toThrow();
+      expect(getUserProfileListItem(first!.profileId).githubIdentity).toMatchObject({
         login: "steipete",
       });
     });
@@ -372,7 +355,6 @@ describe("authenticated GitHub identity sync", () => {
     { name: "GitHub network failure", githubError: new Error("network unavailable") },
   ])("preserves prior identity after a $name", async ({ githubResult, githubError }) => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
       const fetchMock = vi
         .spyOn(globalThis, "fetch")
         .mockResolvedValueOnce(
@@ -383,7 +365,7 @@ describe("authenticated GitHub identity sync", () => {
           }),
         )
         .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete" }));
-      await cloudflareSync({ profileId: profile.id })?.();
+      const first = await cloudflareSync({})?.();
       fetchMock.mockResolvedValueOnce(
         githubResponse({
           id: 58493,
@@ -397,8 +379,8 @@ describe("authenticated GitHub identity sync", () => {
         fetchMock.mockResolvedValueOnce(githubResult!);
       }
 
-      await expect(cloudflareSync({ profileId: profile.id })?.()).rejects.toThrow();
-      expect(getUserProfileListItem(profile.id).githubIdentity).toMatchObject({
+      await expect(cloudflareSync({})?.()).rejects.toThrow();
+      expect(getUserProfileListItem(first!.profileId).githubIdentity).toMatchObject({
         login: "steipete",
       });
     });
@@ -406,7 +388,6 @@ describe("authenticated GitHub identity sync", () => {
 
   it("redacts the Access assertion from network failures and retries on the same connection", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
-      const profile = ensureProfileForTailscaleIdentity({ login: "ada@passkey" });
       const assertion = accessAssertion("https://team.cloudflareaccess.com");
       const fetchMock = vi
         .spyOn(globalThis, "fetch")
@@ -419,11 +400,12 @@ describe("authenticated GitHub identity sync", () => {
           }),
         )
         .mockResolvedValueOnce(githubResponse({ id: 58493, login: "steipete" }));
-      const sync = cloudflareSync({ profileId: profile.id, assertion });
+      const sync = cloudflareSync({ assertion });
 
       const error = await sync?.().catch((failure: unknown) => failure);
       expect(String(error)).not.toContain(assertion);
-      await expect(sync?.()).resolves.toMatchObject({ profileId: profile.id });
+      const result = await sync?.();
+      expect(result?.profileId).toBeTypeOf("string");
       expect(fetchMock).toHaveBeenCalledTimes(3);
     });
   });

--- a/src/gateway/github-user-identity.ts
+++ b/src/gateway/github-user-identity.ts
@@ -1,18 +1,113 @@
+import type { IncomingHttpHeaders } from "node:http";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import type { GatewayAuthConfig } from "../config/types.gateway.js";
+import { classifyTailscaleLogin } from "../state/user-profiles-tailscale-login.js";
+import { syncGitHubIdentity } from "../state/user-profiles.js";
 import { normalizeGitHubLogin } from "../utils/github-login.js";
+import type { GatewayAuthResult } from "./auth.js";
 import {
   ControlUiGitHubError,
-  GITHUB_API_ORIGIN,
   fetchGitHubJson,
-  optionalNumber,
-  readOptionalGitHubString,
+  GITHUB_API_ORIGIN,
+  GITHUB_REQUEST_TIMEOUT_MS,
+  readBoundedResponse,
 } from "./control-ui-github-api.js";
 
-type ResolvedGitHubUserIdentity = { accountId: number; login: string };
+const CLOUDFLARE_ACCESS_USER_HEADER = "cf-access-authenticated-user-email";
+const CLOUDFLARE_ACCESS_ASSERTION_HEADER = "cf-access-jwt-assertion";
+const CLOUDFLARE_ACCESS_HOST_SUFFIX = ".cloudflareaccess.com";
+const CLOUDFLARE_ACCESS_IDENTITY_PATH = "/cdn-cgi/access/get-identity";
+const ACCESS_ASSERTION_MAX_BYTES = 16 * 1024;
+const ACCESS_IDENTITY_MAX_BYTES = 64 * 1024;
+const JWT_SEGMENT_PATTERN = /^[A-Za-z0-9_-]+$/u;
 
-export async function resolveGitHubUserIdentity(
+type ResolvedGitHubUserIdentity = { accountId: number; login: string };
+type AuthenticatedGitHubIdentitySyncResult = { profileId: string; updatedAt: number };
+export type AuthenticatedGitHubIdentitySync = () => Promise<AuthenticatedGitHubIdentitySyncResult>;
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function cloudflareAccessIssuer(assertion: string): URL {
+  if (Buffer.byteLength(assertion, "utf8") > ACCESS_ASSERTION_MAX_BYTES) {
+    throw new Error("Cloudflare Access assertion is invalid");
+  }
+  const segments = assertion.split(".");
+  if (segments.length !== 3 || segments.some((segment) => !JWT_SEGMENT_PATTERN.test(segment))) {
+    throw new Error("Cloudflare Access assertion is invalid");
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(Buffer.from(segments[1]!, "base64url").toString("utf8"));
+  } catch {
+    throw new Error("Cloudflare Access assertion is invalid");
+  }
+  if (!isRecord(payload) || typeof payload.iss !== "string") {
+    throw new Error("Cloudflare Access assertion issuer is invalid");
+  }
+  let issuer: URL;
+  try {
+    issuer = new URL(payload.iss);
+  } catch {
+    throw new Error("Cloudflare Access assertion issuer is invalid");
+  }
+  if (
+    issuer.protocol !== "https:" ||
+    issuer.username ||
+    issuer.password ||
+    issuer.port ||
+    issuer.pathname !== "/" ||
+    issuer.search ||
+    issuer.hash ||
+    !issuer.hostname.endsWith(CLOUDFLARE_ACCESS_HOST_SUFFIX)
+  ) {
+    throw new Error("Cloudflare Access assertion issuer is invalid");
+  }
+  return issuer;
+}
+
+async function resolveCloudflareAccessAccountId(
+  assertion: string,
+  authenticatedPrincipal: string,
+): Promise<number> {
+  const issuer = cloudflareAccessIssuer(assertion);
+  let payload: unknown;
+  try {
+    const response = await fetch(`${issuer.origin}${CLOUDFLARE_ACCESS_IDENTITY_PATH}`, {
+      headers: { Cookie: `CF_Authorization=${assertion}` },
+      redirect: "manual",
+      signal: AbortSignal.timeout(GITHUB_REQUEST_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => {});
+      throw new Error("identity response was not successful");
+    }
+    const body = await readBoundedResponse(response, ACCESS_IDENTITY_MAX_BYTES);
+    payload = JSON.parse(body.toString("utf8"));
+  } catch {
+    // Never attach the underlying fetch error: request errors may retain the bearer cookie.
+    throw new Error("Cloudflare Access identity lookup failed");
+  }
+  if (!isRecord(payload)) {
+    throw new Error("Cloudflare Access identity response is invalid");
+  }
+  const email = typeof payload.email === "string" ? payload.email.trim() : "";
+  if (!email || email.toLowerCase() !== authenticatedPrincipal.trim().toLowerCase()) {
+    throw new Error("Cloudflare Access identity principal did not match");
+  }
+  if (!isRecord(payload.idp) || payload.idp.type !== "github") {
+    throw new Error("Cloudflare Access identity is not GitHub-backed");
+  }
+  if (typeof payload.id !== "number" || !Number.isSafeInteger(payload.id) || payload.id <= 0) {
+    throw new Error("Cloudflare Access GitHub account id is invalid");
+  }
+  return payload.id;
+}
+
+async function resolveGitHubUserIdentityByLogin(
   username: string,
-  fetchImpl: typeof fetch = fetch,
 ): Promise<ResolvedGitHubUserIdentity> {
   const requestedLogin = normalizeGitHubLogin(username);
   if (!requestedLogin) {
@@ -22,27 +117,129 @@ export async function resolveGitHubUserIdentity(
   try {
     payload = await fetchGitHubJson(
       `${GITHUB_API_ORIGIN}/users/${encodeURIComponent(requestedLogin)}`,
-      fetchImpl,
+      fetch,
       undefined,
     );
   } catch (error) {
     if (error instanceof ControlUiGitHubError) {
       throw error;
     }
-    throw new ControlUiGitHubError(502, "GitHub user lookup failed");
+    throw new ControlUiGitHubError(502, "GitHub request failed");
   }
   if (!isRecord(payload)) {
-    throw new ControlUiGitHubError(502, "GitHub user response was not an object");
+    throw new ControlUiGitHubError(502, "GitHub response was not an object");
   }
-  const accountId = optionalNumber(payload, "id");
-  const login = normalizeGitHubLogin(readOptionalGitHubString(payload, "login") ?? "");
-  if (
-    typeof accountId !== "number" ||
-    !Number.isSafeInteger(accountId) ||
-    accountId <= 0 ||
-    !login
-  ) {
-    throw new ControlUiGitHubError(502, "GitHub user response omitted a valid id or login");
+  const accountId = payload.id;
+  const login = typeof payload.login === "string" ? normalizeGitHubLogin(payload.login) : undefined;
+  if (!Number.isSafeInteger(accountId) || typeof accountId !== "number" || accountId <= 0) {
+    throw new ControlUiGitHubError(502, "GitHub response omitted a valid account id");
+  }
+  if (!login) {
+    throw new ControlUiGitHubError(502, "GitHub response omitted a valid login");
   }
   return { accountId, login };
+}
+
+async function resolveGitHubUserIdentityById(
+  accountId: number,
+): Promise<ResolvedGitHubUserIdentity> {
+  let payload: unknown;
+  try {
+    payload = await fetchGitHubJson(`${GITHUB_API_ORIGIN}/user/${accountId}`, fetch, undefined);
+  } catch (error) {
+    if (error instanceof ControlUiGitHubError) {
+      throw error;
+    }
+    throw new ControlUiGitHubError(502, "GitHub request failed");
+  }
+  if (!isRecord(payload) || payload.id !== accountId) {
+    throw new ControlUiGitHubError(502, "GitHub account id did not match");
+  }
+  const login = typeof payload.login === "string" ? normalizeGitHubLogin(payload.login) : undefined;
+  if (!login) {
+    throw new ControlUiGitHubError(502, "GitHub response omitted a valid login");
+  }
+  return { accountId, login };
+}
+
+function retryableConnectionSync(
+  sync: () => Promise<AuthenticatedGitHubIdentitySyncResult>,
+): AuthenticatedGitHubIdentitySync {
+  let inFlight: Promise<AuthenticatedGitHubIdentitySyncResult> | undefined;
+  let completed: AuthenticatedGitHubIdentitySyncResult | undefined;
+  return () => {
+    if (completed) {
+      return Promise.resolve(completed);
+    }
+    if (inFlight) {
+      return inFlight;
+    }
+    const current = sync().then((result) => {
+      completed = result;
+      return result;
+    });
+    inFlight = current;
+    void current.then(
+      () => {
+        inFlight = undefined;
+      },
+      () => {
+        inFlight = undefined;
+      },
+    );
+    return current;
+  };
+}
+
+function cloudflareAccessAssertion(params: {
+  authResult: GatewayAuthResult;
+  authConfig?: GatewayAuthConfig;
+  requestHeaders?: IncomingHttpHeaders;
+}): { assertion: string; principal: string } | undefined {
+  const trustedProxy = params.authConfig?.trustedProxy;
+  if (
+    !params.authResult.ok ||
+    params.authResult.method !== "trusted-proxy" ||
+    params.authConfig?.mode !== "trusted-proxy" ||
+    normalizeLowercaseStringOrEmpty(trustedProxy?.userHeader) !== CLOUDFLARE_ACCESS_USER_HEADER ||
+    !trustedProxy?.requiredHeaders?.some(
+      (header) => normalizeLowercaseStringOrEmpty(header) === CLOUDFLARE_ACCESS_ASSERTION_HEADER,
+    )
+  ) {
+    return undefined;
+  }
+  const principal = params.authResult.user?.trim();
+  const assertion = headerValue(
+    params.requestHeaders?.[CLOUDFLARE_ACCESS_ASSERTION_HEADER],
+  )?.trim();
+  return principal && assertion ? { assertion, principal } : undefined;
+}
+
+export function createAuthenticatedGitHubIdentitySync(params: {
+  profileId: string;
+  authResult: GatewayAuthResult;
+  authConfig?: GatewayAuthConfig;
+  requestHeaders?: IncomingHttpHeaders;
+}): AuthenticatedGitHubIdentitySync | undefined {
+  const tailscaleLogin = params.authResult.tailscaleIdentity
+    ? classifyTailscaleLogin(params.authResult.tailscaleIdentity.login)
+    : undefined;
+  if (tailscaleLogin?.kind === "provider" && tailscaleLogin.provider === "github") {
+    return retryableConnectionSync(async () => {
+      const identity = await resolveGitHubUserIdentityByLogin(tailscaleLogin.subject);
+      const profile = syncGitHubIdentity(params.profileId, identity);
+      return { profileId: profile.id, updatedAt: profile.updatedAt };
+    });
+  }
+
+  const access = cloudflareAccessAssertion(params);
+  if (!access) {
+    return undefined;
+  }
+  return retryableConnectionSync(async () => {
+    const accountId = await resolveCloudflareAccessAccountId(access.assertion, access.principal);
+    const identity = await resolveGitHubUserIdentityById(accountId);
+    const profile = syncGitHubIdentity(params.profileId, identity);
+    return { profileId: profile.id, updatedAt: profile.updatedAt };
+  });
 }

--- a/src/gateway/github-user-identity.ts
+++ b/src/gateway/github-user-identity.ts
@@ -68,10 +68,10 @@ function cloudflareAccessIssuer(assertion: string): URL {
   return issuer;
 }
 
-async function resolveCloudflareAccessAccountId(
+async function resolveCloudflareAccessIdentity(
   assertion: string,
   authenticatedPrincipal: string,
-): Promise<number> {
+): Promise<{ accountId: number; initialDisplayName?: string }> {
   const issuer = cloudflareAccessIssuer(assertion);
   let payload: unknown;
   try {
@@ -103,7 +103,9 @@ async function resolveCloudflareAccessAccountId(
   if (typeof payload.id !== "number" || !Number.isSafeInteger(payload.id) || payload.id <= 0) {
     throw new Error("Cloudflare Access GitHub account id is invalid");
   }
-  return payload.id;
+  const initialDisplayName =
+    typeof payload.name === "string" && payload.name.trim() ? payload.name : undefined;
+  return { accountId: payload.id, ...(initialDisplayName ? { initialDisplayName } : {}) };
 }
 
 async function resolveGitHubUserIdentityByLogin(
@@ -216,7 +218,6 @@ function cloudflareAccessAssertion(params: {
 }
 
 export function createAuthenticatedGitHubIdentitySync(params: {
-  profileId: string;
   authResult: GatewayAuthResult;
   authConfig?: GatewayAuthConfig;
   requestHeaders?: IncomingHttpHeaders;
@@ -227,7 +228,11 @@ export function createAuthenticatedGitHubIdentitySync(params: {
   if (tailscaleLogin?.kind === "provider" && tailscaleLogin.provider === "github") {
     return retryableConnectionSync(async () => {
       const identity = await resolveGitHubUserIdentityByLogin(tailscaleLogin.subject);
-      const profile = syncGitHubIdentity(params.profileId, identity);
+      const profile = syncGitHubIdentity({
+        identity,
+        authenticationAlias: { kind: "github-login", login: tailscaleLogin.subject },
+        initialDisplayName: params.authResult.tailscaleIdentity?.name,
+      });
       return { profileId: profile.id, updatedAt: profile.updatedAt };
     });
   }
@@ -237,9 +242,16 @@ export function createAuthenticatedGitHubIdentitySync(params: {
     return undefined;
   }
   return retryableConnectionSync(async () => {
-    const accountId = await resolveCloudflareAccessAccountId(access.assertion, access.principal);
-    const identity = await resolveGitHubUserIdentityById(accountId);
-    const profile = syncGitHubIdentity(params.profileId, identity);
+    const accessIdentity = await resolveCloudflareAccessIdentity(
+      access.assertion,
+      access.principal,
+    );
+    const identity = await resolveGitHubUserIdentityById(accessIdentity.accountId);
+    const profile = syncGitHubIdentity({
+      identity,
+      authenticationAlias: { kind: "email", email: access.principal },
+      initialDisplayName: accessIdentity.initialDisplayName,
+    });
     return { profileId: profile.id, updatedAt: profile.updatedAt };
   });
 }

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -99,8 +99,6 @@ describe("method scope resolution", () => {
     ["projects.list", ["operator.read"]],
     ["users.prefs.get", ["operator.read"]],
     ["users.prefs.set", ["operator.write"]],
-    ["users.setGitHubIdentity", ["operator.write"]],
-    ["users.clearGitHubIdentity", ["operator.write"]],
     ["projects.register", ["operator.admin"]],
     ["projects.remove", ["operator.admin"]],
     ["projects.add", ["operator.write"]],

--- a/src/gateway/methods/core-descriptors.since.test.ts
+++ b/src/gateway/methods/core-descriptors.since.test.ts
@@ -116,8 +116,6 @@ const CURRENT_TRAIN_METHODS = [
   "progressCard.put",
   "tools.github.status",
   "tools.github.configure",
-  "users.setGitHubIdentity",
-  "users.clearGitHubIdentity",
 ] as const;
 
 describe("core gateway method release trains", () => {

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -553,8 +553,6 @@ const CORE_GATEWAY_METHOD_SPECS = [
     { controlPlaneWrite: true },
   ],
   ["diagnostics.lanes", "diagnostics", "operator.read", "2026.8"],
-  ["users.setGitHubIdentity", "users", "operator.write", "2026.8"],
-  ["users.clearGitHubIdentity", "users", "operator.write", "2026.8"],
 ] as const satisfies readonly CoreGatewayMethodSpecRow[];
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -33,6 +33,43 @@ type CoreGatewayMethodSpecRow = readonly [
   policy?: CoreGatewayMethodPolicy,
 ];
 
+const PROFILE_DEPENDENT_CORE_METHODS = new Set([
+  "agent",
+  "agent.wait",
+  "plugins.sessionAction",
+  "tools.invoke",
+  "ui.command",
+  "users.linkEmail",
+  "users.setAvatar",
+  "users.setDisplayName",
+]);
+const PROFILE_DEPENDENT_CORE_PREFIXES = [
+  "artifacts.",
+  "chat.",
+  "conversations.",
+  "controlUi.session",
+  "mcp.app.",
+  "openclaw.approval.",
+  "openclaw.chat",
+  "progressCard.",
+  "projects.",
+  "secrets.",
+  "session.",
+  "sessions.",
+  "taskSuggestions.",
+  "tasks.",
+  "terminal.",
+  "users.prefs.",
+] as const;
+
+/** Classifies core methods whose behavior reads or mutates durable user/session ownership. */
+function isCoreGatewayMethodProfileDependent(method: string): boolean {
+  return (
+    PROFILE_DEPENDENT_CORE_METHODS.has(method) ||
+    PROFILE_DEPENDENT_CORE_PREFIXES.some((prefix) => method.startsWith(prefix))
+  );
+}
+
 // This is the canonical core method policy table: every core handler must appear here so
 // listing, authorization, startup availability, and write throttling stay in sync.
 const CORE_GATEWAY_METHOD_SPECS = [
@@ -671,6 +708,7 @@ export function createCoreGatewayMethodDescriptors(
       handler,
       owner: { kind: "core", area: "gateway" },
       scope: spec.scope,
+      profileAccess: isCoreGatewayMethodProfileDependent(spec.name) ? "required" : "independent",
       ...(spec.since ? { since: spec.since } : {}),
       ...(spec.advertise === false ? { advertise: false } : {}),
       ...(spec.startup === true ? { startup: "unavailable-until-sidecars" } : {}),

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -1,5 +1,6 @@
 // Core gateway method descriptors keep handler names, auth scopes, startup availability, and write policy in one table.
 import type { OperatorScope } from "../operator-scopes.js";
+import { isSessionProfileDependentMethod } from "../session-sharing-target-input.js";
 import {
   DYNAMIC_GATEWAY_METHOD_SCOPE,
   NODE_GATEWAY_METHOD_SCOPE,
@@ -34,10 +35,7 @@ type CoreGatewayMethodSpecRow = readonly [
 ];
 
 const PROFILE_DEPENDENT_CORE_METHODS = new Set([
-  "agent",
   "agent.wait",
-  "plugins.sessionAction",
-  "tools.invoke",
   "ui.command",
   "users.linkEmail",
   "users.setAvatar",
@@ -65,6 +63,7 @@ const PROFILE_DEPENDENT_CORE_PREFIXES = [
 /** Classifies core methods whose behavior reads or mutates durable user/session ownership. */
 function isCoreGatewayMethodProfileDependent(method: string): boolean {
   return (
+    isSessionProfileDependentMethod(method) ||
     PROFILE_DEPENDENT_CORE_METHODS.has(method) ||
     PROFILE_DEPENDENT_CORE_PREFIXES.some((prefix) => method.startsWith(prefix))
   );

--- a/src/gateway/methods/descriptor.ts
+++ b/src/gateway/methods/descriptor.ts
@@ -21,7 +21,7 @@ export type GatewayMethodOwner =
 
 /** Startup availability flag exposed to clients as retryable startup-unavailable errors. */
 type GatewayMethodStartupAvailability = "available" | "unavailable-until-sidecars";
-type GatewayMethodProfileAccess = "independent" | "required";
+export type GatewayMethodProfileAccess = "independent" | "required";
 
 export type GatewayMethodHandler = (opts: never) => unknown;
 

--- a/src/gateway/methods/descriptor.ts
+++ b/src/gateway/methods/descriptor.ts
@@ -21,6 +21,7 @@ export type GatewayMethodOwner =
 
 /** Startup availability flag exposed to clients as retryable startup-unavailable errors. */
 type GatewayMethodStartupAvailability = "available" | "unavailable-until-sidecars";
+type GatewayMethodProfileAccess = "independent" | "required";
 
 export type GatewayMethodHandler = (opts: never) => unknown;
 
@@ -30,6 +31,7 @@ export type GatewayMethodDescriptor = {
   handler: GatewayMethodHandler;
   scope: GatewayMethodScope;
   owner: GatewayMethodOwner;
+  profileAccess: GatewayMethodProfileAccess;
   since?: string;
   startup?: GatewayMethodStartupAvailability;
   controlPlaneWrite?: boolean;
@@ -38,8 +40,12 @@ export type GatewayMethodDescriptor = {
 };
 
 /** Input descriptor shape before registry normalization trims and validates the method name. */
-export type GatewayMethodDescriptorInput = Omit<GatewayMethodDescriptor, "name"> & {
+export type GatewayMethodDescriptorInput = Omit<
+  GatewayMethodDescriptor,
+  "name" | "profileAccess"
+> & {
   name: string;
+  profileAccess?: GatewayMethodProfileAccess;
 };
 
 /** Read-only method registry view used by request dispatch and method listing. */
@@ -52,5 +58,6 @@ export type GatewayMethodRegistryView = {
   getScope: (name: string) => GatewayMethodScope | undefined;
   isStartupUnavailable: (name: string) => boolean;
   isControlPlaneWrite: (name: string) => boolean;
+  requiresAuthenticatedProfile: (name: string) => boolean;
   descriptors: () => readonly GatewayMethodDescriptor[];
 };

--- a/src/gateway/methods/registry.test.ts
+++ b/src/gateway/methods/registry.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from "vitest";
 import { ADMIN_SCOPE, READ_SCOPE, WRITE_SCOPE } from "../operator-scopes.js";
 import type { GatewayRequestHandler } from "../server-methods/types.js";
+import { isSessionProfileDependentMethod } from "../session-sharing-target-input.js";
 import { listCoreGatewayMethodNames } from "./core-descriptors.js";
 import {
   createCoreGatewayMethodDescriptors,
@@ -131,11 +132,18 @@ describe("gateway method registry", () => {
     }
     expect(registry.requiresAuthenticatedProfile("users.self")).toBe(false);
     expect(registry.requiresAuthenticatedProfile("status")).toBe(false);
+    for (const method of listCoreGatewayMethodNames().filter(isSessionProfileDependentMethod)) {
+      expect(registry.requiresAuthenticatedProfile(method), method).toBe(true);
+    }
     expect(registry.requiresAuthenticatedProfile("agent")).toBe(true);
     expect(registry.requiresAuthenticatedProfile("chat.history")).toBe(true);
     expect(registry.requiresAuthenticatedProfile("sessions.list")).toBe(true);
     expect(registry.requiresAuthenticatedProfile("openclaw.chat")).toBe(true);
     expect(registry.requiresAuthenticatedProfile("projects.list")).toBe(true);
+    expect(registry.requiresAuthenticatedProfile("approval.get")).toBe(false);
+    expect(registry.requiresAuthenticatedProfile("approval.history")).toBe(false);
+    expect(registry.requiresAuthenticatedProfile("board.data.read")).toBe(false);
+    expect(registry.requiresAuthenticatedProfile("board.prompt.authorize")).toBe(false);
     expect(registry.requiresAuthenticatedProfile("aux.identity.read")).toBe(true);
   });
 });

--- a/src/gateway/methods/registry.test.ts
+++ b/src/gateway/methods/registry.test.ts
@@ -4,7 +4,9 @@
 import { describe, expect, it } from "vitest";
 import { ADMIN_SCOPE, READ_SCOPE, WRITE_SCOPE } from "../operator-scopes.js";
 import type { GatewayRequestHandler } from "../server-methods/types.js";
+import { listCoreGatewayMethodNames } from "./core-descriptors.js";
 import {
+  createCoreGatewayMethodDescriptors,
   createGatewayMethodRegistry,
   createPluginGatewayMethodDescriptors,
   createPluginGatewayMethodDescriptor,
@@ -103,5 +105,37 @@ describe("gateway method registry", () => {
     expect(registry.listMethods()).toEqual(["legacy.ping"]);
     expect(registry.getHandler("legacy.ping")).toBe(handler);
     expect(registry.getScope("legacy.ping")).toBe(ADMIN_SCOPE);
+    expect(registry.requiresAuthenticatedProfile("legacy.ping")).toBe(true);
+  });
+
+  it("classifies every core method and defaults non-core owners fail-closed", () => {
+    const coreHandlers = Object.fromEntries(
+      listCoreGatewayMethodNames().map((name) => [name, handler]),
+    );
+    const coreDescriptors = createCoreGatewayMethodDescriptors(coreHandlers);
+    const registry = createGatewayMethodRegistry([
+      ...coreDescriptors,
+      {
+        name: "aux.identity.read",
+        handler,
+        scope: READ_SCOPE,
+        owner: { kind: "aux", area: "test" },
+      },
+    ]);
+
+    for (const descriptor of coreDescriptors) {
+      expect(["independent", "required"], descriptor.name).toContain(descriptor.profileAccess);
+      expect(registry.requiresAuthenticatedProfile(descriptor.name), descriptor.name).toBe(
+        descriptor.profileAccess === "required",
+      );
+    }
+    expect(registry.requiresAuthenticatedProfile("users.self")).toBe(false);
+    expect(registry.requiresAuthenticatedProfile("status")).toBe(false);
+    expect(registry.requiresAuthenticatedProfile("agent")).toBe(true);
+    expect(registry.requiresAuthenticatedProfile("chat.history")).toBe(true);
+    expect(registry.requiresAuthenticatedProfile("sessions.list")).toBe(true);
+    expect(registry.requiresAuthenticatedProfile("openclaw.chat")).toBe(true);
+    expect(registry.requiresAuthenticatedProfile("projects.list")).toBe(true);
+    expect(registry.requiresAuthenticatedProfile("aux.identity.read")).toBe(true);
   });
 });

--- a/src/gateway/methods/registry.ts
+++ b/src/gateway/methods/registry.ts
@@ -43,6 +43,8 @@ function normalizeDescriptor(input: GatewayMethodDescriptorInput): GatewayMethod
     ...input,
     name,
     scope: normalizedScope,
+    profileAccess:
+      input.profileAccess ?? (input.owner.kind === "core" ? "independent" : "required"),
     ...(input.startup === "unavailable-until-sidecars"
       ? { startup: "unavailable-until-sidecars" }
       : {}),
@@ -77,6 +79,7 @@ export function createGatewayMethodRegistry(
     getScope: (name) => byName.get(name)?.scope,
     isStartupUnavailable: (name) => byName.get(name)?.startup === "unavailable-until-sidecars",
     isControlPlaneWrite: (name) => byName.get(name)?.controlPlaneWrite === true,
+    requiresAuthenticatedProfile: (name) => byName.get(name)?.profileAccess === "required",
     descriptors: () => descriptors,
   };
 }
@@ -109,12 +112,13 @@ export function createPluginGatewayMethodDescriptor(params: {
   name: string;
   handler: GatewayMethodHandler;
   scope?: OperatorScope;
-}): GatewayMethodDescriptorInput {
+}): GatewayMethodDescriptor {
   const normalizedScope = normalizePluginGatewayMethodScope(params.name, params.scope).scope;
   return {
     name: params.name,
     handler: params.handler,
     owner: { kind: "plugin", pluginId: params.pluginId },
+    profileAccess: "required",
     scope: normalizedScope ?? ADMIN_SCOPE,
   };
 }

--- a/src/gateway/methods/registry.ts
+++ b/src/gateway/methods/registry.ts
@@ -12,6 +12,7 @@ import {
   type GatewayMethodHandler,
   type GatewayMethodDescriptorInput,
   type GatewayMethodOwner,
+  type GatewayMethodProfileAccess,
   type GatewayMethodRegistryView,
   NODE_GATEWAY_METHOD_SCOPE,
 } from "./descriptor.js";
@@ -112,13 +113,14 @@ export function createPluginGatewayMethodDescriptor(params: {
   name: string;
   handler: GatewayMethodHandler;
   scope?: OperatorScope;
+  profileAccess?: GatewayMethodProfileAccess;
 }): GatewayMethodDescriptor {
   const normalizedScope = normalizePluginGatewayMethodScope(params.name, params.scope).scope;
   return {
     name: params.name,
     handler: params.handler,
     owner: { kind: "plugin", pluginId: params.pluginId },
-    profileAccess: "required",
+    profileAccess: params.profileAccess ?? "required",
     scope: normalizedScope ?? ADMIN_SCOPE,
   };
 }

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -72,7 +72,7 @@ describe("listGatewayMethods", () => {
   });
 
   it("appends new methods after model probing without shifting older method indices", () => {
-    expect(listGatewayMethods().slice(-62)).toEqual([
+    expect(listGatewayMethods().slice(-60)).toEqual([
       "models.probe",
       "migrations.memory.plan",
       "migrations.memory.apply",
@@ -133,8 +133,6 @@ describe("listGatewayMethods", () => {
       "tools.github.status",
       "tools.github.configure",
       "diagnostics.lanes",
-      "users.setGitHubIdentity",
-      "users.clearGitHubIdentity",
     ]);
     const methods = listGatewayMethods();
     expect(methods.indexOf("node.pluginSurface.refresh")).toBe(
@@ -240,7 +238,7 @@ describe("listGatewayMethods", () => {
       "exec.approval.get",
     ]);
     expect(methods).toContain("tts.speak");
-    expect(coreMethods.slice(-69)).toEqual([
+    expect(coreMethods.slice(-67)).toEqual([
       "sessions.catalog.continue",
       "sessions.catalog.archive",
       "approval.get",
@@ -308,8 +306,6 @@ describe("listGatewayMethods", () => {
       "tools.github.status",
       "tools.github.configure",
       "diagnostics.lanes",
-      "users.setGitHubIdentity",
-      "users.clearGitHubIdentity",
     ]);
     expect(methods.indexOf("approval.get")).toBeGreaterThan(methods.indexOf("tts.speak"));
     expect(methods.indexOf("approval.resolve")).toBe(methods.indexOf("approval.get") + 1);
@@ -350,12 +346,6 @@ describe("listGatewayMethods", () => {
     expect(methods.indexOf("sessions.assignOwner")).toBe(methods.indexOf("sessions.move") + 1);
     expect(methods.indexOf("progressCard.get")).toBe(methods.indexOf("sessions.assignOwner") + 1);
     expect(methods.indexOf("progressCard.put")).toBe(methods.indexOf("progressCard.get") + 1);
-    expect(methods.indexOf("users.setGitHubIdentity")).toBe(
-      methods.indexOf("diagnostics.lanes") + 1,
-    );
-    expect(methods.indexOf("users.clearGitHubIdentity")).toBe(
-      methods.indexOf("users.setGitHubIdentity") + 1,
-    );
   });
 
   it("advertises the versioned Talk session RPCs", () => {

--- a/src/gateway/server-methods.profile-authorization.test.ts
+++ b/src/gateway/server-methods.profile-authorization.test.ts
@@ -153,6 +153,33 @@ describe("Gateway pending-profile authorization", () => {
     }
   });
 
+  it("dispatches explicitly independent plugin status while profile sync is unavailable", async () => {
+    const client = createPendingProfileClient();
+    client.authenticatedGitHubIdentitySync = vi.fn().mockRejectedValue(new Error("offline"));
+    const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
+    const method = "logbook.status";
+    const methodRegistry = createGatewayMethodRegistry([
+      {
+        name: method,
+        handler,
+        owner: { kind: "plugin", pluginId: "logbook" },
+        profileAccess: "independent",
+        scope: "operator.read",
+      },
+    ]);
+
+    const respond = await dispatchPendingProfileMethod({
+      client,
+      handler,
+      method,
+      methodRegistry,
+    });
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+    expect(client.authenticatedGitHubIdentitySync).not.toHaveBeenCalled();
+  });
+
   it("gates parameter-dependent incognito access without blocking ordinary independent requests", async () => {
     const client = createPendingProfileClient();
     client.authenticatedGitHubIdentitySync = vi.fn().mockRejectedValue(new Error("offline"));

--- a/src/gateway/server-methods.profile-authorization.test.ts
+++ b/src/gateway/server-methods.profile-authorization.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
+import { createGatewayMethodRegistry } from "./methods/registry.js";
+import { handleGatewayRequest } from "./server-methods.js";
+import type { GatewayRequestHandler } from "./server-methods/types.js";
+
+function createPendingProfileClient() {
+  return {
+    connId: "conn-pending-profile",
+    authenticatedUserId: "mutable-login@github",
+    connect: {
+      role: "operator" as const,
+      scopes: ["operator.admin"],
+      client: { id: "test", version: "1", platform: "test", mode: "test" },
+      minProtocol: 1,
+      maxProtocol: 1,
+    },
+  } as NonNullable<Parameters<typeof handleGatewayRequest>[0]["client"]>;
+}
+
+async function dispatchPendingProfileMethod(params: {
+  client: NonNullable<Parameters<typeof handleGatewayRequest>[0]["client"]>;
+  handler: GatewayRequestHandler;
+  method: string;
+  methodRegistry?: ReturnType<typeof createGatewayMethodRegistry>;
+}) {
+  const respond = vi.fn();
+  await handleGatewayRequest({
+    req: { type: "req", id: `req-${params.method}`, method: params.method, params: {} },
+    respond,
+    client: params.client,
+    isWebchatConnect: () => false,
+    context: { logGateway: { warn: vi.fn() } } as unknown as Parameters<
+      typeof handleGatewayRequest
+    >[0]["context"],
+    ...(params.methodRegistry
+      ? { methodRegistry: params.methodRegistry }
+      : { extraHandlers: { [params.method]: params.handler } }),
+  });
+  return respond;
+}
+
+describe("Gateway pending-profile authorization", () => {
+  it("waits for immutable profile attachment before profile-dependent dispatch", async () => {
+    const deferred = createDeferredCore<{ profileId: string; updatedAt: number }>();
+    const client = createPendingProfileClient();
+    client.authenticatedGitHubIdentitySync = vi.fn(async () => await deferred.promise);
+    const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
+
+    const request = dispatchPendingProfileMethod({ client, handler, method: "chat.send" });
+    await Promise.resolve();
+    expect(handler).not.toHaveBeenCalled();
+
+    client.authenticatedUserProfile = {
+      profileId: "profile-canonical",
+      displayName: "Canonical",
+      hasAvatar: false,
+      updatedAt: 1,
+    };
+    deferred.resolve({ profileId: "profile-canonical", updatedAt: 1 });
+
+    await expect(request).resolves.toHaveBeenCalledWith(true, { ok: true });
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("returns retryable unavailability without dispatch and retries on the next request", async () => {
+    const client = createPendingProfileClient();
+    client.authenticatedGitHubIdentitySync = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("private provider detail"))
+      .mockImplementationOnce(async () => {
+        client.authenticatedUserProfile = {
+          profileId: "profile-retried",
+          displayName: "Retried",
+          hasAvatar: false,
+          updatedAt: 2,
+        };
+        return { profileId: "profile-retried", updatedAt: 2 };
+      });
+    const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
+
+    const failed = await dispatchPendingProfileMethod({ client, handler, method: "agent" });
+    expect(handler).not.toHaveBeenCalled();
+    expect(failed).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        message: expect.not.stringContaining("private provider detail"),
+        retryable: true,
+        details: { code: "AUTHENTICATED_PROFILE_UNAVAILABLE" },
+      }),
+    );
+
+    const retried = await dispatchPendingProfileMethod({ client, handler, method: "agent" });
+    expect(handler).toHaveBeenCalledOnce();
+    expect(retried).toHaveBeenCalledWith(true, { ok: true });
+    expect(client.authenticatedGitHubIdentitySync).toHaveBeenCalledTimes(2);
+  });
+
+  it("classifies profile-owned core families and plugin or auxiliary methods fail-closed", async () => {
+    const methods = [
+      "agent",
+      "chat.history",
+      "sessions.list",
+      "openclaw.chat",
+      "projects.list",
+      "artifacts.list",
+      "tasks.list",
+      "taskSuggestions.list",
+      "mcp.app.view",
+      "controlUi.sessionPreview",
+      "secrets.store.set",
+    ];
+    for (const method of methods) {
+      const client = createPendingProfileClient();
+      client.authenticatedGitHubIdentitySync = vi.fn().mockRejectedValue(new Error("offline"));
+      const handler = vi.fn<GatewayRequestHandler>();
+      const respond = await dispatchPendingProfileMethod({ client, handler, method });
+      expect(handler, method).not.toHaveBeenCalled();
+      expect(respond, method).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ code: "UNAVAILABLE", retryable: true }),
+      );
+    }
+
+    for (const owner of [
+      { kind: "plugin" as const, pluginId: "identity-reader" },
+      { kind: "aux" as const, area: "identity-reader" },
+    ]) {
+      const client = createPendingProfileClient();
+      client.authenticatedGitHubIdentitySync = vi.fn().mockRejectedValue(new Error("offline"));
+      const handler = vi.fn<GatewayRequestHandler>();
+      const method = `${owner.kind}.identity.read`;
+      const methodRegistry = createGatewayMethodRegistry([
+        { name: method, handler, owner, scope: "operator.admin" },
+      ]);
+      await dispatchPendingProfileMethod({ client, handler, method, methodRegistry });
+      expect(handler, owner.kind).not.toHaveBeenCalled();
+    }
+  });
+
+  it("keeps profile bootstrap and identity-independent status available while sync is pending", async () => {
+    for (const method of ["users.self", "status"]) {
+      const client = createPendingProfileClient();
+      client.authenticatedGitHubIdentitySync = vi.fn(
+        () => new Promise<{ profileId: string; updatedAt: number }>(() => {}),
+      );
+      const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
+      const methodRegistry = createGatewayMethodRegistry([
+        {
+          name: method,
+          handler,
+          owner: { kind: "core", area: "gateway" },
+          profileAccess: "independent",
+          scope: "operator.admin",
+        },
+      ]);
+
+      const respond = await dispatchPendingProfileMethod({
+        client,
+        handler,
+        method,
+        methodRegistry,
+      });
+
+      expect(handler, method).toHaveBeenCalledOnce();
+      expect(respond, method).toHaveBeenCalledWith(true, { ok: true });
+      expect(client.authenticatedGitHubIdentitySync, method).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/gateway/server-methods.profile-authorization.test.ts
+++ b/src/gateway/server-methods.profile-authorization.test.ts
@@ -22,11 +22,17 @@ async function dispatchPendingProfileMethod(params: {
   client: NonNullable<Parameters<typeof handleGatewayRequest>[0]["client"]>;
   handler: GatewayRequestHandler;
   method: string;
+  requestParams?: unknown;
   methodRegistry?: ReturnType<typeof createGatewayMethodRegistry>;
 }) {
   const respond = vi.fn();
   await handleGatewayRequest({
-    req: { type: "req", id: `req-${params.method}`, method: params.method, params: {} },
+    req: {
+      type: "req",
+      id: `req-${params.method}`,
+      method: params.method,
+      params: params.requestParams ?? {},
+    },
     respond,
     client: params.client,
     isWebchatConnect: () => false,
@@ -101,16 +107,22 @@ describe("Gateway pending-profile authorization", () => {
   it("classifies profile-owned core families and plugin or auxiliary methods fail-closed", async () => {
     const methods = [
       "agent",
-      "chat.history",
-      "sessions.list",
-      "openclaw.chat",
-      "projects.list",
+      "approval.resolve",
       "artifacts.list",
-      "tasks.list",
-      "taskSuggestions.list",
-      "mcp.app.view",
+      "board.event",
+      "chat.history",
       "controlUi.sessionPreview",
+      "exec.approval.resolve",
+      "mcp.app.view",
+      "message.action",
+      "openclaw.chat",
+      "plugin.approval.resolve",
+      "projects.list",
       "secrets.store.set",
+      "send",
+      "sessions.list",
+      "taskSuggestions.list",
+      "tasks.list",
     ];
     for (const method of methods) {
       const client = createPendingProfileClient();
@@ -139,6 +151,35 @@ describe("Gateway pending-profile authorization", () => {
       await dispatchPendingProfileMethod({ client, handler, method, methodRegistry });
       expect(handler, owner.kind).not.toHaveBeenCalled();
     }
+  });
+
+  it("gates parameter-dependent incognito access without blocking ordinary independent requests", async () => {
+    const client = createPendingProfileClient();
+    client.authenticatedGitHubIdentitySync = vi.fn().mockRejectedValue(new Error("offline"));
+    const handler = vi.fn<GatewayRequestHandler>(({ respond }) => respond(true, { ok: true }));
+
+    const blocked = await dispatchPendingProfileMethod({
+      client,
+      handler,
+      method: "question.request",
+      requestParams: { sessionKey: "agent:main:dashboard:incognito-profile-gate" },
+    });
+    expect(handler).not.toHaveBeenCalled();
+    expect(blocked).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "UNAVAILABLE", retryable: true }),
+    );
+
+    const allowed = await dispatchPendingProfileMethod({
+      client,
+      handler,
+      method: "question.request",
+      requestParams: { sessionKey: "agent:main:main" },
+    });
+    expect(handler).toHaveBeenCalledOnce();
+    expect(allowed).toHaveBeenCalledWith(true, { ok: true });
+    expect(client.authenticatedGitHubIdentitySync).toHaveBeenCalledOnce();
   });
 
   it("keeps profile bootstrap and identity-independent status available while sync is pending", async () => {

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -45,6 +45,7 @@ import {
 } from "./methods/registry.js";
 import { isOperatorScope } from "./operator-scopes.js";
 import { isRoleAuthorizedForMethod, parseGatewayRole } from "./role-policy.js";
+import { authenticatedProfileUnavailableError } from "./server-methods/gateway-client-identity.js";
 import { createLazyCoreHandlers, lazyHandlerModule } from "./server-methods/lazy-core-handlers.js";
 import { isTargetedNonSafeGatewayRestartRequest } from "./server-methods/restart-request.js";
 import type {
@@ -289,6 +290,29 @@ function isGatewayMethodAllowedDuringSuspension(method: string): boolean {
   return SUSPEND_CONTROL_METHODS.has(method);
 }
 
+async function authorizeAuthenticatedProfileForMethod(params: {
+  client: GatewayRequestOptions["client"];
+  method: string;
+  methodRegistry: GatewayMethodRegistry;
+}): Promise<ErrorShape | null> {
+  const sync = params.client?.authenticatedGitHubIdentitySync;
+  if (
+    !sync ||
+    !params.methodRegistry.requiresAuthenticatedProfile(params.method) ||
+    params.client?.authenticatedUserProfile?.profileId.trim()
+  ) {
+    return null;
+  }
+  try {
+    await sync();
+  } catch {
+    return authenticatedProfileUnavailableError();
+  }
+  return params.client?.authenticatedUserProfile?.profileId.trim()
+    ? null
+    : authenticatedProfileUnavailableError();
+}
+
 const coreGatewayHandlerMethodNames = listCoreGatewayHandlerMethodNames();
 const coreGatewayHandlerModules = Object.entries(CORE_GATEWAY_HANDLER_MODULES) as Array<
   [CoreGatewayHandlerFamily, CoreGatewayHandlerModuleLoader]
@@ -368,6 +392,12 @@ export async function authorizeGatewayRequestPreDispatch(params: {
   );
   if (authError) {
     return { error: authError };
+  }
+  // GitHub-backed connections receive hello before remote account resolution. Profile-owned
+  // methods must cross this single router fence before session authorization or handler work.
+  const profileError = await authorizeAuthenticatedProfileForMethod(params);
+  if (profileError) {
+    return { error: profileError };
   }
   const sessionMutation = resolveSessionMutationAuthorization({
     client: params.client ?? null,

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -55,6 +55,7 @@ import type {
   GatewayRequestOptions,
   SessionMutationAuthorization,
 } from "./server-methods/types.js";
+import { resolveDirectIncognitoTargets } from "./session-sharing-target-input.js";
 import {
   resolveSessionMutationAuthorization,
   SessionMutationAuthorizationChangedError,
@@ -293,14 +294,14 @@ function isGatewayMethodAllowedDuringSuspension(method: string): boolean {
 async function authorizeAuthenticatedProfileForMethod(params: {
   client: GatewayRequestOptions["client"];
   method: string;
+  requestParams: unknown;
   methodRegistry: GatewayMethodRegistry;
 }): Promise<ErrorShape | null> {
   const sync = params.client?.authenticatedGitHubIdentitySync;
-  if (
-    !sync ||
-    !params.methodRegistry.requiresAuthenticatedProfile(params.method) ||
-    params.client?.authenticatedUserProfile?.profileId.trim()
-  ) {
+  const requiresProfile =
+    params.methodRegistry.requiresAuthenticatedProfile(params.method) ||
+    resolveDirectIncognitoTargets(params.method, params.requestParams).length > 0;
+  if (!sync || !requiresProfile || params.client?.authenticatedUserProfile?.profileId.trim()) {
     return null;
   }
   try {

--- a/src/gateway/server-methods/gateway-client-identity.test.ts
+++ b/src/gateway/server-methods/gateway-client-identity.test.ts
@@ -29,4 +29,14 @@ describe("gateway client identity", () => {
       sender: { id: "alice", name: "Suggested by Alice" },
     });
   });
+
+  it("keeps a GitHub-backed mutable alias unattributed until immutable sync completes", () => {
+    const client = {
+      authenticatedUserId: "released-login@github",
+      authenticatedGitHubIdentitySync: async () => ({ profileId: "owner", updatedAt: 1 }),
+    } as GatewayClient;
+
+    expect(gatewayClientSenderFields(client)).toEqual({});
+    expect(gatewayClientSessionCreator(client)).toBeUndefined();
+  });
 });

--- a/src/gateway/server-methods/gateway-client-identity.ts
+++ b/src/gateway/server-methods/gateway-client-identity.ts
@@ -18,6 +18,9 @@ export function gatewayClientSenderFields(client: GatewayClient | null): {
       },
     };
   }
+  if (client?.authenticatedGitHubIdentitySync) {
+    return {};
+  }
   return client?.authenticatedUserId ? { sender: { id: client.authenticatedUserId } } : {};
 }
 

--- a/src/gateway/server-methods/gateway-client-identity.ts
+++ b/src/gateway/server-methods/gateway-client-identity.ts
@@ -1,7 +1,28 @@
 // Projects prepared connection identity into user-turn attribution fields.
+import {
+  ErrorCodes,
+  errorShape,
+  type ErrorShape,
+} from "../../../packages/gateway-protocol/src/index.js";
 import type { GatewayClient } from "./shared-types.js";
 
 type GatewayClientSender = { id: string; name?: string };
+
+export function isGatewayClientProfilePending(client: GatewayClient | null): boolean {
+  return Boolean(client?.authenticatedGitHubIdentitySync && !client.authenticatedUserProfile);
+}
+
+export function authenticatedProfileUnavailableError(): ErrorShape {
+  return errorShape(
+    ErrorCodes.UNAVAILABLE,
+    "Authenticated profile verification is unavailable; retry the request.",
+    {
+      retryable: true,
+      retryAfterMs: 1_000,
+      details: { code: "AUTHENTICATED_PROFILE_UNAVAILABLE" },
+    },
+  );
+}
 
 export function gatewayClientSenderFields(client: GatewayClient | null): {
   sender?: GatewayClientSender;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -32,6 +32,7 @@ import type { ChatAbortControllerEntry } from "../chat-abort.js";
 import type { GatewayHotReloadStatus } from "../config-reload-status.types.js";
 import type { ScopeUpgradeCoordinator } from "../device-scope-upgrade.js";
 import type { ExecApprovalManager, ExecApprovalRecord } from "../exec-approval-manager.js";
+import type { AuthenticatedGitHubIdentitySync } from "../github-user-identity.js";
 import type { HealthSummary } from "../health/types.js";
 import type { GatewayMethodRegistryView } from "../methods/descriptor.js";
 import type { NodeRegistry } from "../node-registry.js";
@@ -97,6 +98,7 @@ export type GatewayClient = {
   authenticatedUserId?: string;
   /** Verified Tailscale provider identity; generic proxy identities must not infer this. */
   authenticatedUserIsTailscaleProvider?: boolean;
+  authenticatedGitHubIdentitySync?: AuthenticatedGitHubIdentitySync;
   authenticatedUserProfile?: {
     profileId: string;
     displayName: string | null;

--- a/src/gateway/server-methods/system-agent-session-owner.ts
+++ b/src/gateway/server-methods/system-agent-session-owner.ts
@@ -1,0 +1,28 @@
+import { resolveSystemAgentDelegationKey } from "../../system-agent/delegation-session.js";
+import type { GatewayClient } from "./types.js";
+
+export function resolveSystemAgentSessionOwnerKey(params: {
+  delegation?: { agentId?: string; sessionKey?: string };
+  client: GatewayClient | null;
+}): string | undefined {
+  const delegationKey = resolveSystemAgentDelegationKey(params.delegation);
+  if (delegationKey !== undefined) {
+    // Delegation is a host-only cross-connection owner from the regular-agent tool path.
+    return delegationKey;
+  }
+  const profileId = params.client?.authenticatedUserProfile?.profileId.trim();
+  if (profileId) {
+    return `user:${profileId}`;
+  }
+  // A GitHub-backed alias is not an owner until immutable profile sync succeeds.
+  const userId = params.client?.authenticatedUserId?.trim();
+  if (userId && !params.client?.authenticatedGitHubIdentitySync) {
+    return `user:${userId}`;
+  }
+  const deviceId = params.client?.connect.device?.id.trim();
+  if (deviceId) {
+    return `device:${deviceId}`;
+  }
+  const connId = params.client?.connId?.trim();
+  return connId ? `connection:${connId}` : undefined;
+}

--- a/src/gateway/server-methods/system-agent-session-owner.ts
+++ b/src/gateway/server-methods/system-agent-session-owner.ts
@@ -1,4 +1,5 @@
 import { resolveSystemAgentDelegationKey } from "../../system-agent/delegation-session.js";
+import { isGatewayClientProfilePending } from "./gateway-client-identity.js";
 import type { GatewayClient } from "./types.js";
 
 export function resolveSystemAgentSessionOwnerKey(params: {
@@ -14,9 +15,12 @@ export function resolveSystemAgentSessionOwnerKey(params: {
   if (profileId) {
     return `user:${profileId}`;
   }
-  // A GitHub-backed alias is not an owner until immutable profile sync succeeds.
+  // A GitHub-backed connection has no durable owner until immutable profile sync succeeds.
+  if (isGatewayClientProfilePending(params.client)) {
+    return undefined;
+  }
   const userId = params.client?.authenticatedUserId?.trim();
-  if (userId && !params.client?.authenticatedGitHubIdentitySync) {
+  if (userId) {
     return `user:${userId}`;
   }
   const deviceId = params.client?.connect.device?.id.trim();

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -99,6 +99,8 @@ function makeClient(params: {
   connId: string;
   deviceId?: string;
   authenticatedUserId?: string;
+  profileId?: string;
+  githubSyncPending?: boolean;
 }): GatewayClient {
   return {
     connId: params.connId,
@@ -107,6 +109,21 @@ function makeClient(params: {
       ...(params.deviceId ? { device: { id: params.deviceId } } : {}),
     },
     ...(params.authenticatedUserId ? { authenticatedUserId: params.authenticatedUserId } : {}),
+    ...(params.profileId
+      ? {
+          authenticatedUserProfile: {
+            profileId: params.profileId,
+            displayName: null,
+            hasAvatar: false,
+            updatedAt: 1,
+          },
+        }
+      : {}),
+    ...(params.githubSyncPending
+      ? {
+          authenticatedGitHubIdentitySync: async () => ({ profileId: "pending", updatedAt: 1 }),
+        }
+      : {}),
   } as GatewayClient;
 }
 
@@ -283,6 +300,51 @@ describe("openclaw.chat session ownership", () => {
 
     expect(resumed.ok).toBe(true);
     expect(handle).toHaveBeenCalledWith("continue");
+  });
+
+  it("uses the immutable profile across a GitHub login rename", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    const context = makeContext(sessions);
+    await callChat(
+      context,
+      { sessionId: "github-rename" },
+      makeClient({
+        connId: "conn-old",
+        authenticatedUserId: "old-login@github",
+        profileId: "profile-account-a",
+      }),
+    );
+    const handle = expectDefined(createdEngines[0], "created system-agent engine").handle;
+
+    const resumed = await callChat(
+      context,
+      { sessionId: "github-rename", message: "continue" },
+      makeClient({
+        connId: "conn-new",
+        authenticatedUserId: "new-login@github",
+        profileId: "profile-account-a",
+      }),
+    );
+
+    expect(sessions.get("github-rename")?.ownerKey).toBe("user:profile-account-a");
+    expect(resumed.ok).toBe(true);
+    expect(handle).toHaveBeenCalledWith("continue");
+  });
+
+  it("does not bind a pending GitHub profile to its mutable alias", async () => {
+    const sessions = new Map<string, SystemAgentChatSession>();
+    await callChat(
+      makeContext(sessions),
+      { sessionId: "github-pending" },
+      makeClient({
+        connId: "conn-pending",
+        deviceId: "device-pending",
+        authenticatedUserId: "released-login@github",
+        githubSyncPending: true,
+      }),
+    );
+
+    expect(sessions.get("github-pending")?.ownerKey).toBe("device:device-pending");
   });
 
   it("lets the same paired device resume after reconnecting", async () => {

--- a/src/gateway/server-methods/system-agent-session-ownership.test.ts
+++ b/src/gateway/server-methods/system-agent-session-ownership.test.ts
@@ -331,20 +331,33 @@ describe("openclaw.chat session ownership", () => {
     expect(handle).toHaveBeenCalledWith("continue");
   });
 
-  it("does not bind a pending GitHub profile to its mutable alias", async () => {
+  it("rejects pending GitHub ownership and binds only the attached canonical profile", async () => {
     const sessions = new Map<string, SystemAgentChatSession>();
-    await callChat(
-      makeContext(sessions),
-      { sessionId: "github-pending" },
-      makeClient({
-        connId: "conn-pending",
-        deviceId: "device-pending",
-        authenticatedUserId: "released-login@github",
-        githubSyncPending: true,
-      }),
-    );
+    const context = makeContext(sessions);
+    const pendingClient = makeClient({
+      connId: "conn-pending",
+      deviceId: "device-pending",
+      authenticatedUserId: "released-login@github",
+      githubSyncPending: true,
+    });
 
-    expect(sessions.get("github-pending")?.ownerKey).toBe("device:device-pending");
+    const pending = await callChat(context, { sessionId: "github-pending" }, pendingClient);
+    expect(pending).toMatchObject({
+      ok: false,
+      error: { code: "UNAVAILABLE", retryable: true },
+    });
+    expect(sessions.has("github-pending")).toBe(false);
+
+    pendingClient.authenticatedUserProfile = {
+      profileId: "profile-canonical",
+      displayName: null,
+      hasAvatar: false,
+      updatedAt: 2,
+    };
+    const attached = await callChat(context, { sessionId: "github-pending" }, pendingClient);
+
+    expect(attached.ok).toBe(true);
+    expect(sessions.get("github-pending")?.ownerKey).toBe("user:profile-canonical");
   });
 
   it("lets the same paired device resume after reconnecting", async () => {

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -50,6 +50,10 @@ import {
   listVisiblePendingApprovalRequests,
 } from "./approval-shared.js";
 import {
+  authenticatedProfileUnavailableError,
+  isGatewayClientProfilePending,
+} from "./gateway-client-identity.js";
+import {
   createAdmittedWizardSession,
   runExclusiveSystemAgentSetupActivation,
   SETUP_ADMISSION_BUSY_MESSAGE,
@@ -498,6 +502,10 @@ export const systemAgentHandlers: GatewayRequestHandlers = {
           client,
         });
         if (!ownerKey) {
+          if (isGatewayClientProfilePending(client)) {
+            respond(false, undefined, authenticatedProfileUnavailableError());
+            return;
+          }
           respond(
             false,
             undefined,

--- a/src/gateway/server-methods/system-agent.ts
+++ b/src/gateway/server-methods/system-agent.ts
@@ -27,7 +27,6 @@ import {
   SystemAgentChatEngine,
   SystemAgentWizardAnswerError,
 } from "../../system-agent/chat-engine.js";
-import { resolveSystemAgentDelegationKey } from "../../system-agent/delegation-session.js";
 import {
   acknowledgeSystemAgentGreetingDelivery,
   buildSystemAgentGreetingQuestion,
@@ -63,12 +62,8 @@ import {
   getSystemAgentChatInputError,
   runSystemAgentChatInput,
 } from "./system-agent-chat-turn.js";
-import type {
-  GatewayClient,
-  GatewayRequestContext,
-  GatewayRequestHandlers,
-  RespondFn,
-} from "./types.js";
+import { resolveSystemAgentSessionOwnerKey } from "./system-agent-session-owner.js";
+import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 /**
@@ -126,30 +121,6 @@ async function runSystemAgentGatewayTask<T>(task: () => Promise<T>): Promise<T> 
     // setup writes atomic with respect to other OpenClaw gateway requests.
     systemAgentGatewayExecutionQueue.enqueue(SYSTEM_AGENT_GATEWAY_EXECUTION_KEY, task),
   );
-}
-
-function resolveSystemAgentSessionOwnerKey(params: {
-  delegation?: { agentId?: string; sessionKey?: string };
-  client: GatewayClient | null;
-}): string | undefined {
-  const delegationKey = resolveSystemAgentDelegationKey(params.delegation);
-  if (delegationKey !== undefined) {
-    // Delegation is the host-only, cross-connection owner asserted by the regular-agent
-    // tool path. Keep its agent/session tuple authoritative across gateway reconnects.
-    return delegationKey;
-  }
-  // Authenticated users survive reconnects and may span paired devices. Otherwise
-  // bind to the verified device, with the server-issued connection as a last resort.
-  const userId = params.client?.authenticatedUserId?.trim();
-  if (userId) {
-    return `user:${userId}`;
-  }
-  const deviceId = params.client?.connect.device?.id.trim();
-  if (deviceId) {
-    return `device:${deviceId}`;
-  }
-  const connId = params.client?.connId?.trim();
-  return connId ? `connection:${connId}` : undefined;
 }
 
 async function evictOldestSession(

--- a/src/gateway/server-methods/users.test.ts
+++ b/src/gateway/server-methods/users.test.ts
@@ -5,8 +5,6 @@ import {
   validateUsersSelfResult,
   validateUsersSetAvatarResult,
   validateUsersSetDisplayNameResult,
-  validateUsersSetGitHubIdentityResult,
-  validateUsersClearGitHubIdentityResult,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { usersHandlers } from "./users.js";
 
@@ -14,16 +12,12 @@ const linkEmail = vi.hoisted(() => vi.fn());
 const listProfiles = vi.hoisted(() => vi.fn());
 const setAvatar = vi.hoisted(() => vi.fn());
 const setDisplayName = vi.hoisted(() => vi.fn());
-const setGitHubIdentity = vi.hoisted(() => vi.fn());
-const clearGitHubIdentity = vi.hoisted(() => vi.fn());
-const resolveGitHubUserIdentity = vi.hoisted(() => vi.fn());
 const ensureProfileForEmail = vi.hoisted(() => vi.fn());
 const getUserProfileDisplay = vi.hoisted(() => vi.fn());
 const getUserProfileListItem = vi.hoisted(() => vi.fn());
 const resolveUserProfileId = vi.hoisted(() => vi.fn());
 
 vi.mock("../../state/user-profiles.js", () => ({
-  clearGitHubIdentity,
   ensureProfileForEmail,
   getUserProfileDisplay,
   getUserProfileListItem,
@@ -32,12 +26,8 @@ vi.mock("../../state/user-profiles.js", () => ({
   resolveUserProfileId,
   setAvatar,
   setDisplayName,
-  setGitHubIdentity,
-  UserProfileGitHubIdentityConflictError: class UserProfileGitHubIdentityConflictError extends Error {},
   UserProfileNotFoundError: class UserProfileNotFoundError extends Error {},
 }));
-
-vi.mock("../github-user-identity.js", () => ({ resolveGitHubUserIdentity }));
 
 async function runUsersHandler(
   method: keyof typeof usersHandlers,
@@ -80,9 +70,6 @@ describe("users gateway methods", () => {
     listProfiles.mockReset();
     setAvatar.mockReset();
     setDisplayName.mockReset();
-    setGitHubIdentity.mockReset();
-    clearGitHubIdentity.mockReset();
-    resolveGitHubUserIdentity.mockReset();
     getUserProfileDisplay.mockReturnValue({
       id: profile.id,
       displayName: profile.displayName,
@@ -134,6 +121,68 @@ describe("users gateway methods", () => {
 
     expect(respond).toHaveBeenCalledWith(true, { profile: { ...profile, emails: [] } });
     expect(ensureProfileForEmail).not.toHaveBeenCalled();
+  });
+
+  it("waits for the authenticated GitHub sync before returning users.self", async () => {
+    let finishSync: (() => void) | undefined;
+    const authenticatedGitHubIdentitySync = vi.fn(
+      async () =>
+        await new Promise<{ profileId: string; updatedAt: number }>((resolve) => {
+          finishSync = () => resolve({ profileId: profile.id, updatedAt: profile.updatedAt });
+        }),
+    );
+    const providerClient = {
+      authenticatedUserId: "ada@github",
+      authenticatedUserIsTailscaleProvider: true,
+      authenticatedGitHubIdentitySync,
+      authenticatedUserProfile: {
+        profileId: profile.id,
+        displayName: "Ada",
+        hasAvatar: false,
+        updatedAt: 1,
+      },
+      connect: { scopes: ["operator.write"] },
+    };
+    resolveUserProfileId.mockReturnValue(profile.id);
+    getUserProfileListItem.mockReturnValue(profile);
+
+    const pending = runUsersHandler("users.self", {}, providerClient);
+    await Promise.resolve();
+
+    expect(authenticatedGitHubIdentitySync).toHaveBeenCalledOnce();
+    expect(getUserProfileListItem).not.toHaveBeenCalled();
+    finishSync?.();
+    const respond = await pending;
+    expect(respond).toHaveBeenCalledWith(true, { profile });
+  });
+
+  it("keeps users.self usable and retryable when GitHub lookup fails", async () => {
+    const authenticatedGitHubIdentitySync = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network unavailable"))
+      .mockResolvedValueOnce({ profileId: profile.id, updatedAt: profile.updatedAt });
+    const providerClient = {
+      authenticatedUserId: "ada@github",
+      authenticatedUserIsTailscaleProvider: true,
+      authenticatedGitHubIdentitySync,
+      authenticatedUserProfile: {
+        profileId: profile.id,
+        displayName: "Ada",
+        hasAvatar: false,
+        updatedAt: 1,
+      },
+      connect: { scopes: ["operator.write"] },
+    };
+    resolveUserProfileId.mockReturnValue(profile.id);
+    getUserProfileListItem.mockReturnValue(profile);
+
+    expect(await runUsersHandler("users.self", {}, providerClient)).toHaveBeenCalledWith(true, {
+      profile,
+    });
+    expect(await runUsersHandler("users.self", {}, providerClient)).toHaveBeenCalledWith(true, {
+      profile,
+    });
+    expect(authenticatedGitHubIdentitySync).toHaveBeenCalledTimes(2);
   });
 
   it("keeps generic proxy identities on the legacy profile fallback", async () => {
@@ -229,52 +278,6 @@ describe("users gateway methods", () => {
       hasAvatar: false,
       updatedAt: profile.updatedAt,
     });
-  });
-
-  it("sets and clears only the authenticated user's GitHub identity", async () => {
-    ensureProfileForEmail.mockReturnValue({ id: profile.id });
-    resolveUserProfileId.mockReturnValue(profile.id);
-    resolveGitHubUserIdentity.mockResolvedValue({ accountId: 583231, login: "octocat" });
-    const linked = {
-      ...profile,
-      githubIdentity: {
-        login: "octocat",
-        profileUrl: "https://github.com/octocat",
-        avatarUrl: "https://avatars.githubusercontent.com/u/583231?v=4",
-      },
-    };
-    setGitHubIdentity.mockReturnValue(linked);
-    clearGitHubIdentity.mockReturnValue(profile);
-
-    const setResponse = await runUsersHandler(
-      "users.setGitHubIdentity",
-      { username: "octocat" },
-      selfClient,
-    );
-    const clearResponse = await runUsersHandler("users.clearGitHubIdentity", {}, selfClient);
-
-    expect(resolveGitHubUserIdentity).toHaveBeenCalledWith("octocat");
-    expect(setGitHubIdentity).toHaveBeenCalledWith(profile.id, {
-      accountId: 583231,
-      login: "octocat",
-    });
-    expect(validateUsersSetGitHubIdentityResult(setResponse.mock.calls[0]?.[1])).toBe(true);
-    expect(validateUsersClearGitHubIdentityResult(clearResponse.mock.calls[0]?.[1])).toBe(true);
-  });
-
-  it("rejects GitHub identity changes without an authenticated profile", async () => {
-    const anonymous = { connect: { scopes: ["operator.write"] } };
-    for (const [method, params] of [
-      ["users.setGitHubIdentity", { username: "octocat" }],
-      ["users.clearGitHubIdentity", {}],
-    ] as const) {
-      expect(await runUsersHandler(method, params, anonymous)).toHaveBeenCalledWith(
-        false,
-        undefined,
-        expect.objectContaining({ code: "FORBIDDEN" }),
-      );
-    }
-    expect(resolveGitHubUserIdentity).not.toHaveBeenCalled();
   });
 
   it("returns protocol-complete avatar mutations", async () => {

--- a/src/gateway/server-methods/users.test.ts
+++ b/src/gateway/server-methods/users.test.ts
@@ -125,24 +125,26 @@ describe("users gateway methods", () => {
 
   it("waits for the authenticated GitHub sync before returning users.self", async () => {
     let finishSync: (() => void) | undefined;
+    const providerClient: Record<string, unknown> = {
+      authenticatedUserId: "ada@github",
+      authenticatedUserIsTailscaleProvider: true,
+      connect: { scopes: ["operator.write"] },
+    };
     const authenticatedGitHubIdentitySync = vi.fn(
       async () =>
         await new Promise<{ profileId: string; updatedAt: number }>((resolve) => {
-          finishSync = () => resolve({ profileId: profile.id, updatedAt: profile.updatedAt });
+          finishSync = () => {
+            providerClient.authenticatedUserProfile = {
+              profileId: profile.id,
+              displayName: "Ada",
+              hasAvatar: false,
+              updatedAt: 1,
+            };
+            resolve({ profileId: profile.id, updatedAt: profile.updatedAt });
+          };
         }),
     );
-    const providerClient = {
-      authenticatedUserId: "ada@github",
-      authenticatedUserIsTailscaleProvider: true,
-      authenticatedGitHubIdentitySync,
-      authenticatedUserProfile: {
-        profileId: profile.id,
-        displayName: "Ada",
-        hasAvatar: false,
-        updatedAt: 1,
-      },
-      connect: { scopes: ["operator.write"] },
-    };
+    providerClient.authenticatedGitHubIdentitySync = authenticatedGitHubIdentitySync;
     resolveUserProfileId.mockReturnValue(profile.id);
     getUserProfileListItem.mockReturnValue(profile);
 
@@ -156,29 +158,33 @@ describe("users gateway methods", () => {
     expect(respond).toHaveBeenCalledWith(true, { profile });
   });
 
-  it("keeps users.self usable and retryable when GitHub lookup fails", async () => {
+  it("keeps unresolved users.self unavailable and retryable when GitHub lookup fails", async () => {
+    const providerClient: Record<string, unknown> = {
+      authenticatedUserId: "ada@github",
+      authenticatedUserIsTailscaleProvider: true,
+      connect: { scopes: ["operator.write"] },
+    };
     const authenticatedGitHubIdentitySync = vi
       .fn()
       .mockRejectedValueOnce(new Error("network unavailable"))
-      .mockResolvedValueOnce({ profileId: profile.id, updatedAt: profile.updatedAt });
-    const providerClient = {
-      authenticatedUserId: "ada@github",
-      authenticatedUserIsTailscaleProvider: true,
-      authenticatedGitHubIdentitySync,
-      authenticatedUserProfile: {
-        profileId: profile.id,
-        displayName: "Ada",
-        hasAvatar: false,
-        updatedAt: 1,
-      },
-      connect: { scopes: ["operator.write"] },
-    };
+      .mockImplementationOnce(async () => {
+        providerClient.authenticatedUserProfile = {
+          profileId: profile.id,
+          displayName: "Ada",
+          hasAvatar: false,
+          updatedAt: 1,
+        };
+        return { profileId: profile.id, updatedAt: profile.updatedAt };
+      });
+    providerClient.authenticatedGitHubIdentitySync = authenticatedGitHubIdentitySync;
     resolveUserProfileId.mockReturnValue(profile.id);
     getUserProfileListItem.mockReturnValue(profile);
 
-    expect(await runUsersHandler("users.self", {}, providerClient)).toHaveBeenCalledWith(true, {
-      profile,
-    });
+    expect(await runUsersHandler("users.self", {}, providerClient)).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: "authenticated user profile is unavailable" }),
+    );
     expect(await runUsersHandler("users.self", {}, providerClient)).toHaveBeenCalledWith(true, {
       profile,
     });

--- a/src/gateway/server-methods/users.test.ts
+++ b/src/gateway/server-methods/users.test.ts
@@ -183,7 +183,11 @@ describe("users gateway methods", () => {
     expect(await runUsersHandler("users.self", {}, providerClient)).toHaveBeenCalledWith(
       false,
       undefined,
-      expect.objectContaining({ message: "authenticated user profile is unavailable" }),
+      expect.objectContaining({
+        code: "UNAVAILABLE",
+        retryable: true,
+        details: { code: "AUTHENTICATED_PROFILE_UNAVAILABLE" },
+      }),
     );
     expect(await runUsersHandler("users.self", {}, providerClient)).toHaveBeenCalledWith(true, {
       profile,
@@ -217,7 +221,7 @@ describe("users gateway methods", () => {
     expect(respond).toHaveBeenCalledWith(
       false,
       undefined,
-      expect.objectContaining({ message: "authenticated user profile is unavailable" }),
+      expect.objectContaining({ code: "UNAVAILABLE", retryable: true }),
     );
     expect(ensureProfileForEmail).not.toHaveBeenCalled();
   });

--- a/src/gateway/server-methods/users.ts
+++ b/src/gateway/server-methods/users.ts
@@ -72,6 +72,9 @@ function resolveAuthenticatedProfileId(
   if (client?.authenticatedUserProfile?.profileId) {
     return resolveUserProfileId(client.authenticatedUserProfile.profileId);
   }
+  if (client?.authenticatedGitHubIdentitySync) {
+    return undefined;
+  }
   const authenticatedUserId = client?.authenticatedUserId;
   if (!authenticatedUserId) {
     return undefined;
@@ -124,7 +127,7 @@ export const usersHandlers: GatewayRequestHandlers = {
     }
     respond(true, { profiles: listProfiles() });
   },
-  "users.self": async ({ client, context, params, respond }) => {
+  "users.self": async ({ client, params, respond }) => {
     if (!validateUsersSelfParams(params)) {
       respond(false, undefined, invalidParams("users.self", validateUsersSelfParams.errors));
       return;
@@ -138,7 +141,14 @@ export const usersHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
-      let profileId = resolveAuthenticatedProfileId(client);
+      if (client.authenticatedGitHubIdentitySync) {
+        try {
+          await client.authenticatedGitHubIdentitySync();
+        } catch {
+          // A previously attached immutable profile stays usable; unresolved aliases stay hidden.
+        }
+      }
+      const profileId = resolveAuthenticatedProfileId(client);
       if (!profileId) {
         respond(
           false,
@@ -146,18 +156,6 @@ export const usersHandlers: GatewayRequestHandlers = {
           errorShape(ErrorCodes.UNAVAILABLE, "authenticated user profile is unavailable"),
         );
         return;
-      }
-      if (client.authenticatedGitHubIdentitySync) {
-        try {
-          const result = await client.authenticatedGitHubIdentitySync();
-          refreshConnectedProfile(context, {
-            id: result.profileId,
-            updatedAt: result.updatedAt,
-          });
-        } catch {
-          // Profile reads stay usable; the connection-scoped resolver retries on refresh.
-        }
-        profileId = resolveAuthenticatedProfileId(client) ?? profileId;
       }
       respond(true, { profile: getUserProfileListItem(profileId) });
     } catch (error) {

--- a/src/gateway/server-methods/users.ts
+++ b/src/gateway/server-methods/users.ts
@@ -26,6 +26,10 @@ import {
   UserProfileNotFoundError,
 } from "../../state/user-profiles.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
+import {
+  authenticatedProfileUnavailableError,
+  isGatewayClientProfilePending,
+} from "./gateway-client-identity.js";
 import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
 
 function refreshConnectedProfile(
@@ -150,11 +154,7 @@ export const usersHandlers: GatewayRequestHandlers = {
       }
       const profileId = resolveAuthenticatedProfileId(client);
       if (!profileId) {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.UNAVAILABLE, "authenticated user profile is unavailable"),
-        );
+        respond(false, undefined, authenticatedProfileUnavailableError());
         return;
       }
       respond(true, { profile: getUserProfileListItem(profileId) });
@@ -173,17 +173,17 @@ export const usersHandlers: GatewayRequestHandlers = {
     }
     const profileId = client?.authenticatedUserProfile?.profileId ?? "";
     if (!profileId) {
+      if (isGatewayClientProfilePending(client)) {
+        respond(false, undefined, authenticatedProfileUnavailableError());
+        return;
+      }
       respond(true, { status: "no_durable_identity" }, undefined);
       return;
     }
     try {
       const canonicalProfileId = resolveUserProfileId(profileId);
       if (!canonicalProfileId) {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.UNAVAILABLE, "authenticated user profile is unavailable"),
-        );
+        respond(false, undefined, authenticatedProfileUnavailableError());
         return;
       }
       respond(
@@ -206,17 +206,17 @@ export const usersHandlers: GatewayRequestHandlers = {
     }
     const profileId = client?.authenticatedUserProfile?.profileId ?? "";
     if (!profileId) {
+      if (isGatewayClientProfilePending(client)) {
+        respond(false, undefined, authenticatedProfileUnavailableError());
+        return;
+      }
       respond(true, { status: "no_durable_identity" }, undefined);
       return;
     }
     try {
       const canonicalProfileId = resolveUserProfileId(profileId);
       if (!canonicalProfileId) {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.UNAVAILABLE, "authenticated user profile is unavailable"),
-        );
+        respond(false, undefined, authenticatedProfileUnavailableError());
         return;
       }
       const result = setUserPreferences(canonicalProfileId, params.entries);

--- a/src/gateway/server-methods/users.ts
+++ b/src/gateway/server-methods/users.ts
@@ -5,19 +5,16 @@ import {
   errorShape,
   formatValidationErrors,
   validateUsersLinkEmailParams,
-  validateUsersClearGitHubIdentityParams,
   validateUsersListParams,
   validateUsersPrefsGetParams,
   validateUsersPrefsSetParams,
   validateUsersSelfParams,
   validateUsersSetAvatarParams,
   validateUsersSetDisplayNameParams,
-  validateUsersSetGitHubIdentityParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { getUserPreferences, setUserPreferences } from "../../state/user-preferences.js";
 import {
-  clearGitHubIdentity,
   ensureProfileForEmail,
   getUserProfileDisplay,
   getUserProfileListItem,
@@ -26,12 +23,8 @@ import {
   resolveUserProfileId,
   setAvatar,
   setDisplayName,
-  setGitHubIdentity,
-  UserProfileGitHubIdentityConflictError,
   UserProfileNotFoundError,
 } from "../../state/user-profiles.js";
-import { ControlUiGitHubError } from "../control-ui-github-api.js";
-import { resolveGitHubUserIdentity } from "../github-user-identity.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
 import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
 
@@ -67,33 +60,10 @@ function invalidParams(name: string, errors: Parameters<typeof formatValidationE
 }
 
 function profileError(error: unknown) {
-  if (error instanceof UserProfileGitHubIdentityConflictError) {
-    return errorShape(ErrorCodes.INVALID_REQUEST, error.message);
-  }
   if (error instanceof UserProfileNotFoundError) {
     return errorShape(ErrorCodes.INVALID_REQUEST, error.message);
   }
   return errorShape(ErrorCodes.UNAVAILABLE, formatErrorMessage(error));
-}
-
-function githubLookupError(error: unknown) {
-  if (error instanceof TypeError) {
-    return errorShape(ErrorCodes.INVALID_REQUEST, error.message);
-  }
-  if (error instanceof ControlUiGitHubError) {
-    if (error.statusCode === 404) {
-      return errorShape(ErrorCodes.INVALID_REQUEST, "GitHub user not found");
-    }
-    if (error.statusCode === 429) {
-      return errorShape(ErrorCodes.UNAVAILABLE, "GitHub rate limit reached; try again later", {
-        retryable: true,
-      });
-    }
-    return errorShape(ErrorCodes.UNAVAILABLE, "GitHub user lookup is unavailable", {
-      retryable: true,
-    });
-  }
-  return profileError(error);
 }
 
 function resolveAuthenticatedProfileId(
@@ -154,7 +124,7 @@ export const usersHandlers: GatewayRequestHandlers = {
     }
     respond(true, { profiles: listProfiles() });
   },
-  "users.self": ({ client, params, respond }) => {
+  "users.self": async ({ client, context, params, respond }) => {
     if (!validateUsersSelfParams(params)) {
       respond(false, undefined, invalidParams("users.self", validateUsersSelfParams.errors));
       return;
@@ -168,7 +138,7 @@ export const usersHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
-      const profileId = resolveAuthenticatedProfileId(client);
+      let profileId = resolveAuthenticatedProfileId(client);
       if (!profileId) {
         respond(
           false,
@@ -176,6 +146,18 @@ export const usersHandlers: GatewayRequestHandlers = {
           errorShape(ErrorCodes.UNAVAILABLE, "authenticated user profile is unavailable"),
         );
         return;
+      }
+      if (client.authenticatedGitHubIdentitySync) {
+        try {
+          const result = await client.authenticatedGitHubIdentitySync();
+          refreshConnectedProfile(context, {
+            id: result.profileId,
+            updatedAt: result.updatedAt,
+          });
+        } catch {
+          // Profile reads stay usable; the connection-scoped resolver retries on refresh.
+        }
+        profileId = resolveAuthenticatedProfileId(client) ?? profileId;
       }
       respond(true, { profile: getUserProfileListItem(profileId) });
     } catch (error) {
@@ -346,59 +328,6 @@ export const usersHandlers: GatewayRequestHandlers = {
       }
       const display = refreshConnectedProfile(context, result.value);
       respond(true, { profile: result.value, avatarRevision: display.avatarRevision });
-    } catch (error) {
-      respond(false, undefined, profileError(error));
-    }
-  },
-  "users.setGitHubIdentity": async ({ client, context, params, respond }) => {
-    if (!validateUsersSetGitHubIdentityParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("users.setGitHubIdentity", validateUsersSetGitHubIdentityParams.errors),
-      );
-      return;
-    }
-    const profileId = resolveAuthenticatedProfileId(client);
-    if (!profileId) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.FORBIDDEN, "GitHub identity changes require an authenticated user"),
-      );
-      return;
-    }
-    try {
-      const identity = await resolveGitHubUserIdentity(params.username);
-      const profile = setGitHubIdentity(profileId, identity);
-      refreshConnectedProfile(context, profile);
-      respond(true, { profile });
-    } catch (error) {
-      respond(false, undefined, githubLookupError(error));
-    }
-  },
-  "users.clearGitHubIdentity": ({ client, context, params, respond }) => {
-    if (!validateUsersClearGitHubIdentityParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("users.clearGitHubIdentity", validateUsersClearGitHubIdentityParams.errors),
-      );
-      return;
-    }
-    const profileId = resolveAuthenticatedProfileId(client);
-    if (!profileId) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.FORBIDDEN, "GitHub identity changes require an authenticated user"),
-      );
-      return;
-    }
-    try {
-      const profile = clearGitHubIdentity(profileId);
-      refreshConnectedProfile(context, profile);
-      respond(true, { profile });
     } catch (error) {
       respond(false, undefined, profileError(error));
     }

--- a/src/gateway/server-plugin-in-process-dispatch.authorization.test.ts
+++ b/src/gateway/server-plugin-in-process-dispatch.authorization.test.ts
@@ -114,6 +114,19 @@ describe("typed in-process agent authorization", () => {
     expect(startTurn).not.toHaveBeenCalled();
   });
 
+  it("applies the pending-profile gate to typed in-process agent dispatch", async () => {
+    const client = createOperatorClient({ profileId: "pending", scopes: ["operator.write"] });
+    delete client.authenticatedUserProfile;
+    client.authenticatedGitHubIdentitySync = vi
+      .fn()
+      .mockRejectedValue(new Error("private provider detail"));
+
+    await expect(dispatchScopedAgent({ client, context: createContext() })).rejects.toThrow(
+      "Authenticated profile verification is unavailable",
+    );
+    expect(startTurn).not.toHaveBeenCalled();
+  });
+
   it("rejects a nonparticipant agent turn before preflight", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const sessionKey = "agent:main:private-draft";

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -222,8 +222,13 @@ export async function attachAuthenticatedGatewayConnect(
     return;
   }
 
+  const resolveAuthenticatedGitHubIdentity = createAuthenticatedGitHubIdentitySync({
+    authResult,
+    authConfig: context.configSnapshot.gateway?.auth,
+    requestHeaders: context.handler.upgradeReq.headers,
+  });
   let authenticatedUserProfile: GatewayWsClient["authenticatedUserProfile"];
-  if (authenticatedUserId) {
+  if (authenticatedUserId && !resolveAuthenticatedGitHubIdentity) {
     try {
       const profile = authResult.tailscaleIdentity
         ? ensureProfileForTailscaleIdentity(authResult.tailscaleIdentity)
@@ -244,14 +249,6 @@ export async function attachAuthenticatedGatewayConnect(
       );
     }
   }
-  const authenticatedGitHubIdentitySync = authenticatedUserProfile
-    ? createAuthenticatedGitHubIdentitySync({
-        profileId: authenticatedUserProfile.profileId,
-        authResult,
-        authConfig: context.configSnapshot.gateway?.auth,
-        requestHeaders: context.handler.upgradeReq.headers,
-      })
-    : undefined;
   const pluginSurfaceUrls: Record<string, string> = {};
   const pluginNodeCapabilitySurfaces = indexPluginNodeCapabilitySurfaces(pluginNodeCapabilities);
   const pendingPluginNodeCapabilities: Array<{
@@ -364,20 +361,22 @@ export async function attachAuthenticatedGatewayConnect(
             : {}),
         }
       : undefined;
-  const localUserIngress = prepareGatewayLocalUserIngress({
-    authMethod,
-    authenticatedUserExpected: Boolean(authenticatedUserId),
-    ...(authenticatedUserProfile
-      ? {
-          profile: {
-            profileId: authenticatedUserProfile.profileId,
-            displayName: authenticatedUserProfile.displayName,
-          },
-        }
-      : {}),
-    ...(device?.id ? { pairedDeviceId: device.id } : {}),
-    isLocalClient,
-  });
+  const prepareLocalUserIngress = (profile = authenticatedUserProfile) =>
+    prepareGatewayLocalUserIngress({
+      authMethod,
+      authenticatedUserExpected: Boolean(authenticatedUserId),
+      ...(profile
+        ? {
+            profile: {
+              profileId: profile.profileId,
+              displayName: profile.displayName,
+            },
+          }
+        : {}),
+      ...(device?.id ? { pairedDeviceId: device.id } : {}),
+      isLocalClient,
+    });
+  const localUserIngress = prepareLocalUserIngress();
   if (usesLegacyNodeProtocol) {
     logWsControl.warn(
       `legacy node protocol accepted conn=${connId} client=${formatForLog(clientLabel)} v${formatForLog(connectParams.client.version)} min=${minProtocol} max=${maxProtocol} current=${PROTOCOL_VERSION}; upgrade recommended`,
@@ -398,7 +397,6 @@ export async function attachAuthenticatedGatewayConnect(
     presenceKey,
     ...(authenticatedUserId ? { authenticatedUserId } : {}),
     ...(authenticatedUserIsTailscaleProvider ? { authenticatedUserIsTailscaleProvider: true } : {}),
-    ...(authenticatedGitHubIdentitySync ? { authenticatedGitHubIdentitySync } : {}),
     ...(authenticatedUserProfile ? { authenticatedUserProfile } : {}),
     clientIp: reportedClientIp,
     ...(internal ? { internal } : {}),
@@ -408,6 +406,33 @@ export async function attachAuthenticatedGatewayConnect(
       : {}),
   };
   attachGatewayLocalUserIngress(nextClient, localUserIngress);
+  const attachAuthenticatedProfile = (profileId: string, updatedAt: number) => {
+    const display = getUserProfileDisplay(profileId);
+    const profile = {
+      profileId: display.id,
+      displayName: display.displayName,
+      avatarRevision: display.avatarRevision,
+      hasAvatar: display.hasAvatar,
+      updatedAt,
+    };
+    if (nextClient.authenticatedUserProfile) {
+      Object.assign(nextClient.authenticatedUserProfile, profile);
+    } else {
+      nextClient.authenticatedUserProfile = profile;
+    }
+    attachGatewayLocalUserIngress(
+      nextClient,
+      prepareLocalUserIngress(nextClient.authenticatedUserProfile),
+    );
+    buildRequestContext().refreshConnectedUserProfile?.({ ...display, updatedAt });
+  };
+  if (resolveAuthenticatedGitHubIdentity) {
+    nextClient.authenticatedGitHubIdentitySync = async () => {
+      const result = await resolveAuthenticatedGitHubIdentity();
+      attachAuthenticatedProfile(result.profileId, result.updatedAt);
+      return result;
+    };
+  }
   for (const entry of pendingPluginNodeCapabilities) {
     setClientPluginNodeCapability({
       client: nextClient,
@@ -521,18 +546,16 @@ export async function attachAuthenticatedGatewayConnect(
   }
 
   const currentAuthenticatedPresenceUser = () =>
-    buildAuthenticatedPresenceUser({
-      authenticatedUserId,
-      authenticatedUserIsTailscaleProvider,
-      authenticatedUserProfile: nextClient.authenticatedUserProfile,
-    });
-
-  const refreshAuthenticatedProfile = (profileId: string, updatedAt: number) => {
-    const display = getUserProfileDisplay(profileId);
-    buildRequestContext().refreshConnectedUserProfile?.({ ...display, updatedAt });
-  };
+    nextClient.authenticatedGitHubIdentitySync && !nextClient.authenticatedUserProfile
+      ? undefined
+      : buildAuthenticatedPresenceUser({
+          authenticatedUserId,
+          authenticatedUserIsTailscaleProvider,
+          authenticatedUserProfile: nextClient.authenticatedUserProfile,
+        });
 
   if (presenceKey) {
+    const authenticatedPresenceUser = currentAuthenticatedPresenceUser();
     upsertPresence(presenceKey, {
       host: connectParams.client.displayName ?? connectParams.client.id ?? os.hostname(),
       ip: isLocalClient ? undefined : reportedClientIp,
@@ -545,7 +568,7 @@ export async function attachAuthenticatedGatewayConnect(
       roles: [role],
       scopes,
       instanceId: role === "node" ? (device?.id ?? instanceId) : instanceId,
-      ...(authenticatedUserId ? { user: currentAuthenticatedPresenceUser() } : {}),
+      ...(authenticatedPresenceUser ? { user: authenticatedPresenceUser } : {}),
       reason: "connect",
     });
     incrementPresenceVersion();
@@ -626,11 +649,24 @@ export async function attachAuthenticatedGatewayConnect(
 
   await sendGatewayHello(context, state, pluginSurfaceUrls, authenticatedUserProfile?.profileId);
 
-  if (authenticatedGitHubIdentitySync) {
+  if (nextClient.authenticatedGitHubIdentitySync) {
     runDetachedConnectWork(
       async () => {
-        const result = await authenticatedGitHubIdentitySync();
-        refreshAuthenticatedProfile(result.profileId, result.updatedAt);
+        const result = await nextClient.authenticatedGitHubIdentitySync!();
+        const profile = nextClient.authenticatedUserProfile;
+        const profilePic = authResult.tailscaleIdentity?.profilePic;
+        if (!profile?.hasAvatar && profilePic) {
+          try {
+            const updated = await adoptTailscaleProfileAvatar(result.profileId, profilePic);
+            if (updated.avatarMime) {
+              attachAuthenticatedProfile(updated.id, updated.updatedAt);
+            }
+          } catch (error) {
+            logGateway.warn(
+              `Tailscale avatar adoption failed conn=${connId}: ${formatForLog(error)}`,
+            );
+          }
+        }
       },
       (error) => {
         logGateway.warn(`GitHub identity sync failed conn=${connId}: ${formatForLog(error)}`);
@@ -639,15 +675,20 @@ export async function attachAuthenticatedGatewayConnect(
   }
 
   const tailscaleProfilePic = authResult.tailscaleIdentity?.profilePic;
-  const tailscaleProfileId = authenticatedUserProfile?.profileId;
-  if (tailscaleProfileId && !authenticatedUserProfile?.hasAvatar && tailscaleProfilePic) {
+  const tailscaleProfileId = nextClient.authenticatedUserProfile?.profileId;
+  if (
+    !nextClient.authenticatedGitHubIdentitySync &&
+    tailscaleProfileId &&
+    !nextClient.authenticatedUserProfile?.hasAvatar &&
+    tailscaleProfilePic
+  ) {
     runDetachedConnectWork(
       async () => {
         const updated = await adoptTailscaleProfileAvatar(tailscaleProfileId, tailscaleProfilePic);
         if (!updated.avatarMime) {
           return;
         }
-        refreshAuthenticatedProfile(updated.id, updated.updatedAt);
+        attachAuthenticatedProfile(updated.id, updated.updatedAt);
       },
       (error) =>
         logGateway.warn(`Tailscale avatar adoption failed conn=${connId}: ${formatForLog(error)}`),

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -33,6 +33,7 @@ import {
 import { resolveRuntimeServiceBuildId, resolveRuntimeServiceVersion } from "../../../version.js";
 import { verifyAgentRuntimeIdentityToken } from "../../agent-runtime-identity-token.js";
 import { buildAuthenticatedPresenceUser } from "../../authenticated-presence-user.js";
+import { createAuthenticatedGitHubIdentitySync } from "../../github-user-identity.js";
 import {
   attachGatewayLocalUserIngress,
   prepareGatewayLocalUserIngress,
@@ -52,7 +53,6 @@ import { MAX_PAYLOAD_BYTES } from "../../server-constants.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
 import { incrementPresenceVersion } from "../health-state.js";
-import { broadcastPresenceSnapshot } from "../presence-events.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import { resolveEffectiveConnectionScopes } from "./connect-admission.js";
 import { sendGatewayHello } from "./connect-hello.js";
@@ -191,10 +191,10 @@ export async function attachAuthenticatedGatewayConnect(
       : connId
     : undefined;
   const authenticatedUserId = normalizeOptionalString(authResult.user);
-  const authenticatedUserIsTailscaleProvider = Boolean(
-    authResult.tailscaleIdentity &&
-    classifyTailscaleLogin(authResult.tailscaleIdentity.login).kind === "provider",
-  );
+  const tailscaleLogin = authResult.tailscaleIdentity
+    ? classifyTailscaleLogin(authResult.tailscaleIdentity.login)
+    : undefined;
+  const authenticatedUserIsTailscaleProvider = tailscaleLogin?.kind === "provider";
   // Device pairing owns persistent access. Verified identity grants only shape
   // this connection, after device-less self-declared scopes have been cleared.
   const effectiveScopes = resolveEffectiveConnectionScopes({
@@ -244,6 +244,14 @@ export async function attachAuthenticatedGatewayConnect(
       );
     }
   }
+  const authenticatedGitHubIdentitySync = authenticatedUserProfile
+    ? createAuthenticatedGitHubIdentitySync({
+        profileId: authenticatedUserProfile.profileId,
+        authResult,
+        authConfig: context.configSnapshot.gateway?.auth,
+        requestHeaders: context.handler.upgradeReq.headers,
+      })
+    : undefined;
   const pluginSurfaceUrls: Record<string, string> = {};
   const pluginNodeCapabilitySurfaces = indexPluginNodeCapabilitySurfaces(pluginNodeCapabilities);
   const pendingPluginNodeCapabilities: Array<{
@@ -390,6 +398,7 @@ export async function attachAuthenticatedGatewayConnect(
     presenceKey,
     ...(authenticatedUserId ? { authenticatedUserId } : {}),
     ...(authenticatedUserIsTailscaleProvider ? { authenticatedUserIsTailscaleProvider: true } : {}),
+    ...(authenticatedGitHubIdentitySync ? { authenticatedGitHubIdentitySync } : {}),
     ...(authenticatedUserProfile ? { authenticatedUserProfile } : {}),
     clientIp: reportedClientIp,
     ...(internal ? { internal } : {}),
@@ -518,6 +527,11 @@ export async function attachAuthenticatedGatewayConnect(
       authenticatedUserProfile: nextClient.authenticatedUserProfile,
     });
 
+  const refreshAuthenticatedProfile = (profileId: string, updatedAt: number) => {
+    const display = getUserProfileDisplay(profileId);
+    buildRequestContext().refreshConnectedUserProfile?.({ ...display, updatedAt });
+  };
+
   if (presenceKey) {
     upsertPresence(presenceKey, {
       host: connectParams.client.displayName ?? connectParams.client.id ?? os.hostname(),
@@ -612,6 +626,18 @@ export async function attachAuthenticatedGatewayConnect(
 
   await sendGatewayHello(context, state, pluginSurfaceUrls, authenticatedUserProfile?.profileId);
 
+  if (authenticatedGitHubIdentitySync) {
+    runDetachedConnectWork(
+      async () => {
+        const result = await authenticatedGitHubIdentitySync();
+        refreshAuthenticatedProfile(result.profileId, result.updatedAt);
+      },
+      (error) => {
+        logGateway.warn(`GitHub identity sync failed conn=${connId}: ${formatForLog(error)}`);
+      },
+    );
+  }
+
   const tailscaleProfilePic = authResult.tailscaleIdentity?.profilePic;
   const tailscaleProfileId = authenticatedUserProfile?.profileId;
   if (tailscaleProfileId && !authenticatedUserProfile?.hasAvatar && tailscaleProfilePic) {
@@ -621,25 +647,7 @@ export async function attachAuthenticatedGatewayConnect(
         if (!updated.avatarMime) {
           return;
         }
-        const display = getUserProfileDisplay(updated.id);
-        authenticatedUserProfile = {
-          profileId: display.id,
-          displayName: display.displayName,
-          avatarRevision: display.avatarRevision,
-          hasAvatar: display.hasAvatar,
-          updatedAt: updated.updatedAt,
-        };
-        nextClient.authenticatedUserProfile = authenticatedUserProfile;
-        if (isClosed() || !presenceKey) {
-          return;
-        }
-        upsertPresence(presenceKey, { user: currentAuthenticatedPresenceUser() });
-        const requestContext = buildRequestContext();
-        broadcastPresenceSnapshot({
-          broadcast: requestContext.broadcast,
-          incrementPresenceVersion: requestContext.incrementPresenceVersion,
-          getHealthVersion: requestContext.getHealthVersion,
-        });
+        refreshAuthenticatedProfile(updated.id, updated.updatedAt);
       },
       (error) =>
         logGateway.warn(`Tailscale avatar adoption failed conn=${connId}: ${formatForLog(error)}`),

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -41,6 +41,7 @@ const {
   getHealthVersionMock,
   incrementPresenceVersionMock,
   loadConfigMock,
+  createAuthenticatedGitHubIdentitySyncMock,
   adoptTailscaleProfileAvatarMock,
   ensureProfileForEmailMock,
   prepareGatewayNodeConnectMock,
@@ -70,6 +71,7 @@ const {
       },
     },
   })),
+  createAuthenticatedGitHubIdentitySyncMock: vi.fn(),
   adoptTailscaleProfileAvatarMock: vi.fn(),
   ensureProfileForEmailMock: vi.fn(),
   prepareGatewayNodeConnectMock: vi.fn(),
@@ -87,6 +89,10 @@ vi.mock("../../../state/user-profiles.js", async (importOriginal) => {
     ensureProfileForEmail: ensureProfileForEmailMock,
   };
 });
+
+vi.mock("../../github-user-identity.js", () => ({
+  createAuthenticatedGitHubIdentitySync: createAuthenticatedGitHubIdentitySyncMock,
+}));
 
 vi.mock("./auth-context.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./auth-context.js")>();
@@ -332,7 +338,23 @@ function attachGatewayHarness(options: {
     gatewayMethods: [],
     events: [],
     extraHandlers: {},
-    buildRequestContext: () => ({}) as GatewayRequestContext,
+    buildRequestContext: () =>
+      ({
+        refreshConnectedUserProfile: (profile) => {
+          const authenticatedUserProfile = (
+            client as { authenticatedUserProfile?: Record<string, unknown> } | null
+          )?.authenticatedUserProfile;
+          if (authenticatedUserProfile) {
+            Object.assign(authenticatedUserProfile, {
+              profileId: profile.id,
+              displayName: profile.displayName,
+              avatarRevision: profile.avatarRevision,
+              hasAvatar: profile.hasAvatar,
+              updatedAt: profile.updatedAt,
+            });
+          }
+        },
+      }) as GatewayRequestContext,
     nodeLifecycleDispatch: new GatewayNodeLifecycleDispatchTracker(),
     refreshHealthSnapshot:
       options.refreshHealthSnapshot ?? vi.fn(async () => createHealthSummary()),
@@ -504,6 +526,28 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
   beforeEach(() => {
     resetDiagnosticEventsForTest();
     vi.clearAllMocks();
+    createAuthenticatedGitHubIdentitySyncMock.mockImplementation(
+      (params: {
+        profileId: string;
+        authResult: { method?: string; tailscaleIdentity?: { login: string } };
+        authConfig?: { trustedProxy?: { userHeader?: string; requiredHeaders?: string[] } };
+      }) => {
+        const tailscaleGitHub = params.authResult.tailscaleIdentity?.login.endsWith("@github");
+        const trustedProxy = params.authConfig?.trustedProxy;
+        const cloudflareAccess =
+          params.authResult.method === "trusted-proxy" &&
+          trustedProxy?.userHeader?.toLowerCase() === "cf-access-authenticated-user-email" &&
+          trustedProxy.requiredHeaders?.some(
+            (header) => header.toLowerCase() === "cf-access-jwt-assertion",
+          );
+        return tailscaleGitHub || cloudflareAccess
+          ? vi.fn(async () => ({
+              profileId: params.profileId,
+              updatedAt: 1,
+            }))
+          : undefined;
+      },
+    );
   });
 
   it("closes invalidated clients before dispatching queued requests", () => {
@@ -844,9 +888,9 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
         authResult: {
           ok: true,
           method: "tailscale",
-          user: "ada@github",
+          user: "ada@passkey",
           tailscaleIdentity: {
-            login: "ada@github",
+            login: "ada@passkey",
             name: "Ada Lovelace",
             profilePic: "https://avatars.example.test/ada.png",
           },
@@ -875,7 +919,7 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
 
       await waitForFast(() => {
         expect(harness.client).toMatchObject({
-          authenticatedUserId: "ada@github",
+          authenticatedUserId: "ada@passkey",
           authenticatedUserIsTailscaleProvider: true,
           authenticatedUserProfile: { displayName: "Ada Lovelace", hasAvatar: false },
         });
@@ -898,20 +942,176 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
         }
       ).authenticatedUserProfile;
       expect(setAvatar(profile.profileId, new Uint8Array([7, 8, 9]), "image/png").ok).toBe(true);
+      const adoptedUpdatedAt = profile.updatedAt + 1;
       resolveAvatar?.({
         id: profile.profileId,
         displayName: profile.displayName,
         avatarMime: "image/png",
         mergedInto: null,
         createdAt: profile.updatedAt,
-        updatedAt: profile.updatedAt + 1,
+        updatedAt: adoptedUpdatedAt,
       });
       await waitForFast(() => {
         expect(harness.client).toMatchObject({
-          authenticatedUserProfile: { hasAvatar: true, updatedAt: profile.updatedAt + 1 },
+          authenticatedUserProfile: { hasAvatar: true, updatedAt: adoptedUpdatedAt },
         });
       });
+      expect(createAuthenticatedGitHubIdentitySyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authResult: expect.objectContaining({ method: "tailscale", user: "ada@passkey" }),
+        }),
+      );
     });
+  });
+
+  it("completes GitHub-authenticated login before deferred identity sync", async () => {
+    let finishSync: (() => void) | undefined;
+    const sync = vi.fn(
+      async () =>
+        await new Promise<{ profileId: string; updatedAt: number }>((resolve) => {
+          finishSync = () => resolve({ profileId: "profile-1", updatedAt: 1 });
+        }),
+    );
+    createAuthenticatedGitHubIdentitySyncMock.mockReturnValueOnce(sync);
+    resolveConnectAuthStateMock.mockResolvedValueOnce({
+      authResult: {
+        ok: true,
+        method: "tailscale",
+        user: "ada@github",
+        tailscaleIdentity: { login: "ada@github", name: "Ada Lovelace" },
+      },
+      authOk: true,
+      authMethod: "tailscale",
+      sharedAuthOk: true,
+    });
+    const harness = attachGatewayHarness({
+      connId: "conn-github-identity-detached",
+      connectNonce: "nonce-github-identity-detached",
+    });
+
+    harness.sendConnect("connect-github-identity-detached", {
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      client: {
+        id: "gateway-client",
+        version: "dev",
+        platform: "test",
+        mode: "backend",
+      },
+      role: "operator",
+      caps: [],
+    });
+
+    await waitForFast(() => {
+      expect(harness.socketSend).toHaveBeenCalled();
+      expect(harness.client).toMatchObject({
+        authenticatedUserId: "ada@github",
+        authenticatedGitHubIdentitySync: sync,
+        authenticatedUserProfile: { profileId: expect.any(String) },
+      });
+      expect(createAuthenticatedGitHubIdentitySyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          profileId: expect.any(String),
+          authResult: expect.objectContaining({ method: "tailscale", user: "ada@github" }),
+        }),
+      );
+      expect(sync).toHaveBeenCalledOnce();
+    });
+    expect(harness.socketSend.mock.invocationCallOrder[0]).toBeLessThan(
+      sync.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+    expect(finishSync).toBeTypeOf("function");
+    finishSync?.();
+  });
+
+  it("mints Cloudflare sync only for the standard trusted-proxy header contract", async () => {
+    const assertion = "header.payload.signature";
+    loadConfigMock.mockImplementationOnce(() => ({
+      gateway: {
+        auth: {
+          mode: "trusted-proxy",
+          trustedProxy: {
+            userHeader: "cf-access-authenticated-user-email",
+            requiredHeaders: ["CF-Access-JWT-Assertion"],
+          },
+        },
+        trustedProxies: ["10.0.0.1"],
+        controlUi: { allowedOrigins: ["https://team.openclaw.ai"] },
+      },
+    }));
+    const resolvedAuth: ResolvedGatewayAuth = {
+      mode: "trusted-proxy",
+      allowTailscale: false,
+      trustedProxy: {
+        userHeader: "cf-access-authenticated-user-email",
+        requiredHeaders: ["CF-Access-JWT-Assertion"],
+      },
+    };
+    const harness = attachGatewayHarness({
+      connId: "conn-cloudflare-access",
+      connectNonce: "nonce-cloudflare-access",
+      requestHost: "team.openclaw.ai",
+      requestOrigin: "https://team.openclaw.ai",
+      remoteAddr: "10.0.0.1",
+      resolvedAuth,
+      headers: {
+        "cf-access-authenticated-user-email": "ada@example.com",
+        "cf-access-jwt-assertion": assertion,
+        "x-forwarded-for": "203.0.113.10",
+      },
+      ingressAttribution: {
+        kind: "trusted-proxy",
+        clientIp: "203.0.113.10",
+        rateLimit: { subject: { key: "203.0.113.10" }, resetOnSuccess: true },
+      },
+    });
+
+    harness.sendConnect("connect-cloudflare-access", {
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      client: {
+        id: "openclaw-control-ui",
+        version: "dev",
+        platform: "test",
+        mode: "ui",
+      },
+      role: "operator",
+      caps: [],
+    });
+
+    await waitForFast(() => {
+      expect(harness.client).toMatchObject({
+        authenticatedUserId: "ada@example.com",
+        authenticatedGitHubIdentitySync: expect.any(Function),
+      });
+      expect(createAuthenticatedGitHubIdentitySyncMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authResult: expect.objectContaining({
+            method: "trusted-proxy",
+            user: "ada@example.com",
+          }),
+          authConfig: expect.objectContaining({ mode: "trusted-proxy" }),
+          requestHeaders: expect.objectContaining({
+            "cf-access-jwt-assertion": assertion,
+          }),
+        }),
+      );
+    });
+  });
+
+  it("does not mint Cloudflare sync for a generic or non-required-header proxy", async () => {
+    const harness = connectTrustedProxyUser("conn-generic-proxy-github");
+    await waitForFast(() => expect(harness.client).not.toBeNull());
+
+    expect(createAuthenticatedGitHubIdentitySyncMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authResult: expect.objectContaining({ method: "trusted-proxy" }),
+        authConfig: expect.objectContaining({
+          trustedProxy: expect.objectContaining({ userHeader: "x-forwarded-user" }),
+        }),
+      }),
+    );
+    expect(harness.client).not.toHaveProperty("authenticatedGitHubIdentitySync");
   });
 
   it("keeps presence fallback but records unknown invoker when profile resolution fails", async () => {

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -15,7 +15,12 @@ import {
   getActiveDiagnosticTraceContext,
   type DiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
-import { setAvatar } from "../../../state/user-profiles.js";
+import {
+  ensureProfileForEmail,
+  ensureProfileForTailscaleIdentity,
+  setAvatar,
+  syncGitHubIdentity,
+} from "../../../state/user-profiles.js";
 import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
 import { mintAgentRuntimeIdentityToken } from "../../agent-runtime-identity-token.js";
 import type { AuthRateLimiter } from "../../auth-rate-limit.js";
@@ -303,6 +308,22 @@ function attachGatewayHarness(options: {
   };
   const advanceHandshakePhase = vi.fn();
   const logWsControl = createLogger();
+  const refreshConnectedUserProfile = vi.fn<
+    NonNullable<GatewayRequestContext["refreshConnectedUserProfile"]>
+  >((profile) => {
+    const authenticatedUserProfile = (
+      client as { authenticatedUserProfile?: Record<string, unknown> } | null
+    )?.authenticatedUserProfile;
+    if (authenticatedUserProfile) {
+      Object.assign(authenticatedUserProfile, {
+        profileId: profile.id,
+        displayName: profile.displayName,
+        avatarRevision: profile.avatarRevision,
+        hasAvatar: profile.hasAvatar,
+        updatedAt: profile.updatedAt,
+      });
+    }
+  });
   attachGatewayWsMessageHandler({
     socket,
     upgradeReq: {
@@ -338,23 +359,7 @@ function attachGatewayHarness(options: {
     gatewayMethods: [],
     events: [],
     extraHandlers: {},
-    buildRequestContext: () =>
-      ({
-        refreshConnectedUserProfile: (profile) => {
-          const authenticatedUserProfile = (
-            client as { authenticatedUserProfile?: Record<string, unknown> } | null
-          )?.authenticatedUserProfile;
-          if (authenticatedUserProfile) {
-            Object.assign(authenticatedUserProfile, {
-              profileId: profile.id,
-              displayName: profile.displayName,
-              avatarRevision: profile.avatarRevision,
-              hasAvatar: profile.hasAvatar,
-              updatedAt: profile.updatedAt,
-            });
-          }
-        },
-      }) as GatewayRequestContext,
+    buildRequestContext: () => ({ refreshConnectedUserProfile }) as never,
     nodeLifecycleDispatch: new GatewayNodeLifecycleDispatchTracker(),
     refreshHealthSnapshot:
       options.refreshHealthSnapshot ?? vi.fn(async () => createHealthSummary()),
@@ -383,6 +388,7 @@ function attachGatewayHarness(options: {
   return {
     advanceHandshakePhase,
     logWsControl,
+    refreshConnectedUserProfile,
     send,
     socketSend,
     sendRequest: (
@@ -528,7 +534,6 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
     vi.clearAllMocks();
     createAuthenticatedGitHubIdentitySyncMock.mockImplementation(
       (params: {
-        profileId: string;
         authResult: { method?: string; tailscaleIdentity?: { login: string } };
         authConfig?: { trustedProxy?: { userHeader?: string; requiredHeaders?: string[] } };
       }) => {
@@ -540,12 +545,15 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
           trustedProxy.requiredHeaders?.some(
             (header) => header.toLowerCase() === "cf-access-jwt-assertion",
           );
-        return tailscaleGitHub || cloudflareAccess
-          ? vi.fn(async () => ({
-              profileId: params.profileId,
-              updatedAt: 1,
-            }))
-          : undefined;
+        if (!tailscaleGitHub && !cloudflareAccess) {
+          return undefined;
+        }
+        return vi.fn(async () => {
+          const profile = params.authResult.tailscaleIdentity
+            ? ensureProfileForTailscaleIdentity(params.authResult.tailscaleIdentity)
+            : ensureProfileForEmailMock("authenticated@example.test");
+          return { profileId: profile.id, updatedAt: profile.updatedAt };
+        });
       },
     );
   });
@@ -965,63 +973,139 @@ describe("attachGatewayWsMessageHandler post-connect health refresh", () => {
   });
 
   it("completes GitHub-authenticated login before deferred identity sync", async () => {
-    let finishSync: (() => void) | undefined;
-    const sync = vi.fn(
-      async () =>
-        await new Promise<{ profileId: string; updatedAt: number }>((resolve) => {
-          finishSync = () => resolve({ profileId: "profile-1", updatedAt: 1 });
-        }),
-    );
-    createAuthenticatedGitHubIdentitySyncMock.mockReturnValueOnce(sync);
-    resolveConnectAuthStateMock.mockResolvedValueOnce({
-      authResult: {
-        ok: true,
-        method: "tailscale",
-        user: "ada@github",
-        tailscaleIdentity: { login: "ada@github", name: "Ada Lovelace" },
-      },
-      authOk: true,
-      authMethod: "tailscale",
-      sharedAuthOk: true,
-    });
-    const harness = attachGatewayHarness({
-      connId: "conn-github-identity-detached",
-      connectNonce: "nonce-github-identity-detached",
-    });
-
-    harness.sendConnect("connect-github-identity-detached", {
-      minProtocol: PROTOCOL_VERSION,
-      maxProtocol: PROTOCOL_VERSION,
-      client: {
-        id: "gateway-client",
-        version: "dev",
-        platform: "test",
-        mode: "backend",
-      },
-      role: "operator",
-      caps: [],
-    });
-
-    await waitForFast(() => {
-      expect(harness.socketSend).toHaveBeenCalled();
-      expect(harness.client).toMatchObject({
-        authenticatedUserId: "ada@github",
-        authenticatedGitHubIdentitySync: sync,
-        authenticatedUserProfile: { profileId: expect.any(String) },
-      });
-      expect(createAuthenticatedGitHubIdentitySyncMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          profileId: expect.any(String),
-          authResult: expect.objectContaining({ method: "tailscale", user: "ada@github" }),
-        }),
+    await withOpenClawTestState({ label: "gateway-github-profile-deferred" }, async () => {
+      const canonical = ensureProfileForEmail("canonical@example.test");
+      let finishSync: (() => void) | undefined;
+      const sync = vi.fn(
+        async () =>
+          await new Promise<{ profileId: string; updatedAt: number }>((resolve) => {
+            finishSync = () => resolve({ profileId: canonical.id, updatedAt: canonical.updatedAt });
+          }),
       );
-      expect(sync).toHaveBeenCalledOnce();
+      createAuthenticatedGitHubIdentitySyncMock.mockReturnValueOnce(sync);
+      resolveConnectAuthStateMock.mockResolvedValueOnce({
+        authResult: {
+          ok: true,
+          method: "tailscale",
+          user: "ada@github",
+          tailscaleIdentity: { login: "ada@github", name: "Ada Lovelace" },
+        },
+        authOk: true,
+        authMethod: "tailscale",
+        sharedAuthOk: true,
+      });
+      const harness = attachGatewayHarness({
+        connId: "conn-github-identity-detached",
+        connectNonce: "nonce-github-identity-detached",
+      });
+
+      harness.sendConnect("connect-github-identity-detached", {
+        minProtocol: PROTOCOL_VERSION,
+        maxProtocol: PROTOCOL_VERSION,
+        client: {
+          id: "test",
+          version: "dev",
+          platform: "test",
+          mode: "test",
+        },
+        role: "operator",
+        caps: [],
+      });
+
+      await waitForFast(() => {
+        expect(harness.socketSend).toHaveBeenCalled();
+        expect(harness.client).toMatchObject({
+          authenticatedUserId: "ada@github",
+          authenticatedGitHubIdentitySync: expect.any(Function),
+        });
+        expect(harness.client).not.toHaveProperty("authenticatedUserProfile");
+        expect(localUserIngressFor(harness.client)).toMatchObject({
+          facts: { invoker: { state: "unknown" } },
+        });
+        expect(createAuthenticatedGitHubIdentitySyncMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            authResult: expect.objectContaining({ method: "tailscale", user: "ada@github" }),
+          }),
+        );
+        expect(sync).toHaveBeenCalledOnce();
+      });
+      const initialPresence = upsertPresenceMock.mock.calls.find(
+        ([key]) => key === "conn-github-identity-detached",
+      )?.[1];
+      expect(initialPresence).not.toHaveProperty("user");
+      expect(harness.socketSend.mock.invocationCallOrder[0]).toBeLessThan(
+        sync.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+      );
+      expect(finishSync).toBeTypeOf("function");
+      finishSync?.();
+
+      await waitForFast(() => {
+        expect(harness.client).toMatchObject({
+          authenticatedUserProfile: { profileId: canonical.id },
+        });
+        expect(localUserIngressFor(harness.client)).toMatchObject({
+          facts: {
+            invoker: { state: "present", kind: "person", rawPrincipalRef: canonical.id },
+          },
+        });
+        expect(harness.refreshConnectedUserProfile).toHaveBeenCalledWith(
+          expect.objectContaining({ id: canonical.id }),
+        );
+      });
     });
-    expect(harness.socketSend.mock.invocationCallOrder[0]).toBeLessThan(
-      sync.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
-    );
-    expect(finishSync).toBeTypeOf("function");
-    finishSync?.();
+  });
+
+  it("keeps a mutable GitHub alias unattributed when immutable sync fails", async () => {
+    await withOpenClawTestState({ label: "gateway-github-profile-failure" }, async () => {
+      syncGitHubIdentity({
+        identity: { accountId: 10, login: "prior-owner" },
+        authenticationAlias: { kind: "github-login", login: "released-login" },
+        initialDisplayName: "Prior Verified Owner",
+      });
+      const sync = vi.fn(async () => {
+        throw new Error("GitHub unavailable");
+      });
+      createAuthenticatedGitHubIdentitySyncMock.mockReturnValueOnce(sync);
+      resolveConnectAuthStateMock.mockResolvedValueOnce({
+        authResult: {
+          ok: true,
+          method: "tailscale",
+          user: "released-login@github",
+          tailscaleIdentity: { login: "released-login@github", name: "New Account" },
+        },
+        authOk: true,
+        authMethod: "tailscale",
+        sharedAuthOk: true,
+      });
+      const harness = attachGatewayHarness({
+        connId: "conn-github-identity-failure",
+        connectNonce: "nonce-github-identity-failure",
+      });
+
+      harness.sendConnect("connect-github-identity-failure", {
+        minProtocol: PROTOCOL_VERSION,
+        maxProtocol: PROTOCOL_VERSION,
+        client: { id: "test", version: "dev", platform: "test", mode: "test" },
+        role: "operator",
+        caps: [],
+      });
+
+      await waitForFast(() => {
+        expect(harness.socketSend).toHaveBeenCalled();
+        expect(sync).toHaveBeenCalledOnce();
+      });
+      await waitForFast(() => {
+        expect(harness.client).not.toHaveProperty("authenticatedUserProfile");
+        expect(localUserIngressFor(harness.client)).toMatchObject({
+          facts: { invoker: { state: "unknown" } },
+        });
+      });
+      const presence = upsertPresenceMock.mock.calls.find(
+        ([key]) => key === "conn-github-identity-failure",
+      )?.[1];
+      expect(presence).not.toHaveProperty("user");
+      expect(harness.refreshConnectedUserProfile).not.toHaveBeenCalled();
+    });
   });
 
   it("mints Cloudflare sync only for the standard trusted-proxy header contract", async () => {

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -2,6 +2,7 @@
 import type { WebSocket } from "ws";
 import type { ConnectParams } from "../../../packages/gateway-protocol/src/schema/frames.js";
 import type { AgentRuntimeIdentity } from "../agent-runtime-identity-token.js";
+import type { AuthenticatedGitHubIdentitySync } from "../github-user-identity.js";
 import type { PluginNodeCapabilityClient } from "../plugin-node-capability.js";
 import type { WorkerConnectionIdentity } from "../worker-environments/connection-identity.js";
 
@@ -35,6 +36,7 @@ export type GatewayWsClient = PluginNodeCapabilityClient & {
   authenticatedUserId?: string;
   /** Verified Tailscale provider identity; generic proxy identities must not infer this. */
   authenticatedUserIsTailscaleProvider?: boolean;
+  authenticatedGitHubIdentitySync?: AuthenticatedGitHubIdentitySync;
   authenticatedUserProfile?: {
     profileId: string;
     displayName: string | null;

--- a/src/gateway/session-sharing-target-input.ts
+++ b/src/gateway/session-sharing-target-input.ts
@@ -1,10 +1,110 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { isIncognitoSessionKey } from "../routing/session-key.js";
+import { isIncognitoSessionKey } from "../shared/incognito-session-key.js";
 
 export type SessionMutationTarget = {
   sessionKey: string;
   agentId?: string;
 };
+
+type SessionMutationTargetField = "key" | "parentSessionKey" | "sessionKey";
+
+const SESSION_TARGET_FIELDS_BY_METHOD = new Map<string, readonly SessionMutationTargetField[]>([
+  ["agent", ["sessionKey"]],
+  ["board.event", ["sessionKey"]],
+  ["board.update", ["sessionKey"]],
+  ["board.widget.grant", ["sessionKey"]],
+  ["board.widget.put", ["sessionKey"]],
+  ["chat.abort", ["sessionKey"]],
+  ["chat.inject", ["sessionKey"]],
+  ["chat.send", ["sessionKey"]],
+  ["message.action", ["sessionKey"]],
+  ["plugins.sessionAction", ["sessionKey"]],
+  ["progressCard.get", ["sessionKey"]],
+  ["progressCard.put", ["sessionKey"]],
+  ["send", ["sessionKey"]],
+  ["session.discussion.open", ["sessionKey"]],
+  ["sessions.abort", ["key"]],
+  ["sessions.compaction.branch", ["key"]],
+  ["sessions.compaction.restore", ["key"]],
+  ["sessions.compact", ["key"]],
+  ["sessions.create", ["key", "parentSessionKey"]],
+  ["sessions.delete", ["key"]],
+  ["sessions.dispatch", ["key"]],
+  ["sessions.files.set", ["sessionKey"]],
+  ["sessions.fork", ["sessionKey"]],
+  ["sessions.patch", ["key"]],
+  ["sessions.pluginPatch", ["key"]],
+  ...(["sessions.move", "sessions.reclaim"] as const).map((method) => [method, ["key"]] as const),
+  ["sessions.recover", ["key"]],
+  ["sessions.reset", ["key"]],
+  ["sessions.rewind", ["sessionKey"]],
+  ["sessions.send", ["key"]],
+  ["sessions.steer", ["key"]],
+  ["sessions.branches.switch", ["sessionKey"]],
+  ["tools.invoke", ["sessionKey"]],
+]);
+
+const REQUIRED_SESSION_TARGET_METHODS = new Set([
+  "board.action",
+  "board.event",
+  "board.update",
+  "board.widget.grant",
+  "board.widget.put",
+  "chat.abort",
+  "chat.inject",
+  "chat.send",
+  "progressCard.get",
+  "progressCard.put",
+  "session.discussion.open",
+  "sessions.abort",
+  "sessions.branches.switch",
+  "sessions.compact",
+  "sessions.compaction.branch",
+  "sessions.compaction.restore",
+  "sessions.delete",
+  "sessions.dispatch",
+  "sessions.files.set",
+  "sessions.fork",
+  "sessions.groups.delete",
+  "sessions.groups.rename",
+  "sessions.groups.update",
+  "sessions.patch",
+  "sessions.pluginPatch",
+  "sessions.reclaim",
+  "sessions.recover",
+  "sessions.move",
+  "sessions.reset",
+  "sessions.rewind",
+  "sessions.send",
+  "sessions.steer",
+]);
+
+const APPROVAL_SESSION_TARGET_METHODS = new Set([
+  "approval.resolve",
+  "exec.approval.resolve",
+  "plugin.approval.resolve",
+]);
+
+export function sessionMutationTargetFields(method: string): readonly SessionMutationTargetField[] {
+  return SESSION_TARGET_FIELDS_BY_METHOD.get(method) ?? [];
+}
+
+export function isRequiredSessionTargetMethod(method: string): boolean {
+  return REQUIRED_SESSION_TARGET_METHODS.has(method);
+}
+
+export function isApprovalSessionTargetMethod(method: string): boolean {
+  return APPROVAL_SESSION_TARGET_METHODS.has(method);
+}
+
+export function isSessionProfileDependentMethod(method: string): boolean {
+  return (
+    SESSION_TARGET_FIELDS_BY_METHOD.has(method) ||
+    REQUIRED_SESSION_TARGET_METHODS.has(method) ||
+    APPROVAL_SESSION_TARGET_METHODS.has(method) ||
+    method === "sessions.patchMany"
+  );
+}
 
 export function resolveDirectIncognitoTargets(
   method: string,

--- a/src/gateway/session-sharing.test.ts
+++ b/src/gateway/session-sharing.test.ts
@@ -108,6 +108,40 @@ describe("session sharing policy", () => {
     expect(resolveSessionSharingRole({ client: pending, target: draft })).toBe("viewer");
   });
 
+  it("returns retryable unavailability from direct session guards while profile sync is pending", () => {
+    const pending = client({ githubSyncPending: true });
+    const ownedTarget = target({ type: "human", id: "profile-owner" });
+    const incognitoTarget = {
+      ...ownedTarget,
+      canonicalKey: "agent:main:dashboard:incognito-direct-guard",
+      entry: { ...ownedTarget.entry, incognito: true as const },
+    };
+
+    expect(
+      authorizeIncognitoSessionTarget({
+        client: pending,
+        sessionKey: incognitoTarget.canonicalKey,
+        target: incognitoTarget,
+      }),
+    ).toMatchObject({
+      code: "UNAVAILABLE",
+      retryable: true,
+      details: { code: "AUTHENTICATED_PROFILE_UNAVAILABLE" },
+    });
+    expect(
+      resolveSessionMutationAuthorization({
+        client: pending,
+        method: "send",
+        requestParams: { sessionKey: "agent:main:main" },
+        context: {} as GatewayRequestContext,
+      }).error,
+    ).toMatchObject({
+      code: "UNAVAILABLE",
+      retryable: true,
+      details: { code: "AUTHENTICATED_PROFILE_UNAVAILABLE" },
+    });
+  });
+
   it("requires participation before sessions.create can adopt a categorized key", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const sessionKey = "agent:main:dashboard:categorized-adoption";

--- a/src/gateway/session-sharing.test.ts
+++ b/src/gateway/session-sharing.test.ts
@@ -37,6 +37,7 @@ function client(params: {
   user?: string;
   deviceId?: string;
   displayName?: string;
+  githubSyncPending?: boolean;
   scopes?: string[];
 }): GatewayClient {
   return {
@@ -75,6 +76,11 @@ function client(params: {
           },
         }
       : {}),
+    ...(params.githubSyncPending
+      ? {
+          authenticatedGitHubIdentitySync: async () => ({ profileId: "pending", updatedAt: 1 }),
+        }
+      : {}),
   };
 }
 
@@ -95,6 +101,13 @@ function target(createdActor?: { type: "human"; id: string; label?: string }): S
 }
 
 describe("session sharing policy", () => {
+  it("fails closed instead of treating pending GitHub identity as a solo owner", () => {
+    const pending = client({ githubSyncPending: true });
+    const draft = target({ type: "human", id: "profile-owner" });
+
+    expect(resolveSessionSharingRole({ client: pending, target: draft })).toBe("viewer");
+  });
+
   it("requires participation before sessions.create can adopt a categorized key", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const sessionKey = "agent:main:dashboard:categorized-adoption";

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -11,7 +11,11 @@ import { isSessionMember, type SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isIncognitoSessionKey } from "../routing/session-key.js";
 import { verifyBoardViewTicket } from "./board-view-ticket.js";
-import { gatewayClientSessionCreator } from "./server-methods/gateway-client-identity.js";
+import {
+  authenticatedProfileUnavailableError,
+  gatewayClientSessionCreator,
+  isGatewayClientProfilePending,
+} from "./server-methods/gateway-client-identity.js";
 import type {
   GatewayClient,
   GatewayRequestContext,
@@ -25,8 +29,12 @@ import {
   type SessionSharingSnapshot,
 } from "./session-sharing-snapshot-cache.js";
 import {
+  isApprovalSessionTargetMethod,
+  isRequiredSessionTargetMethod,
+  isSessionProfileDependentMethod,
   readSessionSharingStringParam as readStringParam,
   resolveDirectIncognitoTargets,
+  sessionMutationTargetFields,
   type SessionMutationTarget,
 } from "./session-sharing-target-input.js";
 import type {
@@ -197,6 +205,9 @@ export function authorizeIncognitoSessionTarget(params: {
   if (isGatewayAdmin(params.client)) {
     return null;
   }
+  if (isGatewayClientProfilePending(params.client)) {
+    return authenticatedProfileUnavailableError();
+  }
   const identity = gatewayClientSessionCreator(params.client);
   if (!identity) {
     return null;
@@ -231,6 +242,9 @@ export function authorizeResolvedSessionMutation(params: {
   if (isGatewayAdmin(params.client)) {
     return null;
   }
+  if (isGatewayClientProfilePending(params.client)) {
+    return authenticatedProfileUnavailableError();
+  }
   const target = resolveSessionSharingTarget(params);
   const incognitoError = authorizeIncognitoSessionTarget({
     client: params.client,
@@ -262,78 +276,6 @@ export function authorizeSessionSharingTarget(params: {
         },
       });
 }
-
-type SessionMutationTargetField = "key" | "parentSessionKey" | "sessionKey";
-const SESSION_TARGET_FIELDS_BY_METHOD = new Map<string, readonly SessionMutationTargetField[]>([
-  ["agent", ["sessionKey"]],
-  ["board.event", ["sessionKey"]],
-  ["board.update", ["sessionKey"]],
-  ["board.widget.grant", ["sessionKey"]],
-  ["board.widget.put", ["sessionKey"]],
-  ["chat.abort", ["sessionKey"]],
-  ["chat.inject", ["sessionKey"]],
-  ["chat.send", ["sessionKey"]],
-  ["message.action", ["sessionKey"]],
-  ["plugins.sessionAction", ["sessionKey"]],
-  ["progressCard.get", ["sessionKey"]],
-  ["progressCard.put", ["sessionKey"]],
-  ["send", ["sessionKey"]],
-  ["session.discussion.open", ["sessionKey"]],
-  ["sessions.abort", ["key"]],
-  ["sessions.compaction.branch", ["key"]],
-  ["sessions.compaction.restore", ["key"]],
-  ["sessions.compact", ["key"]],
-  ["sessions.create", ["key", "parentSessionKey"]],
-  ["sessions.delete", ["key"]],
-  ["sessions.dispatch", ["key"]],
-  ["sessions.files.set", ["sessionKey"]],
-  ["sessions.fork", ["sessionKey"]],
-  ["sessions.patch", ["key"]],
-  ["sessions.pluginPatch", ["key"]],
-  ...(["sessions.move", "sessions.reclaim"] as const).map((method) => [method, ["key"]] as const),
-  ["sessions.recover", ["key"]],
-  ["sessions.reset", ["key"]],
-  ["sessions.rewind", ["sessionKey"]],
-  ["sessions.send", ["key"]],
-  ["sessions.steer", ["key"]],
-  ["sessions.branches.switch", ["sessionKey"]],
-  ["tools.invoke", ["sessionKey"]],
-]);
-
-const REQUIRED_SESSION_TARGET_METHODS = new Set([
-  "board.action",
-  "board.event",
-  "board.update",
-  "board.widget.grant",
-  "board.widget.put",
-  "chat.abort",
-  "chat.inject",
-  "chat.send",
-  "progressCard.get",
-  "progressCard.put",
-  "session.discussion.open",
-  "sessions.abort",
-  "sessions.branches.switch",
-  "sessions.compact",
-  "sessions.compaction.branch",
-  "sessions.compaction.restore",
-  "sessions.delete",
-  "sessions.dispatch",
-  "sessions.files.set",
-  "sessions.fork",
-  "sessions.groups.delete",
-  "sessions.groups.rename",
-  "sessions.groups.update",
-  "sessions.patch",
-  "sessions.pluginPatch",
-  "sessions.reclaim",
-  "sessions.recover",
-  "sessions.move",
-  "sessions.reset",
-  "sessions.rewind",
-  "sessions.send",
-  "sessions.steer",
-]);
 
 function resolveSessionGroupMutationTargets(params: {
   getCfg: () => OpenClawConfig;
@@ -401,11 +343,7 @@ function resolveSessionMutationTargets(params: {
       requestParams: params.requestParams,
     });
   }
-  if (
-    params.method === "exec.approval.resolve" ||
-    params.method === "plugin.approval.resolve" ||
-    params.method === "approval.resolve"
-  ) {
+  if (isApprovalSessionTargetMethod(params.method)) {
     const target = resolveApprovalSessionTarget(
       params.method,
       params.requestParams,
@@ -415,7 +353,7 @@ function resolveSessionMutationTargets(params: {
   }
   const requestedAgentId = readStringParam(params.requestParams, "agentId");
   const directTargets: SessionMutationTarget[] = [];
-  for (const field of SESSION_TARGET_FIELDS_BY_METHOD.get(params.method) ?? []) {
+  for (const field of sessionMutationTargetFields(params.method)) {
     const sessionKey = readStringParam(params.requestParams, field);
     if (!sessionKey) {
       continue;
@@ -466,6 +404,12 @@ export function resolveSessionMutationAuthorization(params: {
 }): { authorization?: SessionMutationAuthorization; error: ErrorShape | null } {
   if (isGatewayAdmin(params.client)) {
     return { error: null };
+  }
+  if (
+    isGatewayClientProfilePending(params.client) &&
+    isSessionProfileDependentMethod(params.method)
+  ) {
+    return { error: authenticatedProfileUnavailableError() };
   }
   // Resolve runtime config at most once per request and only when a path needs it. The context
   // getter reloads/resolves gateway config, so non-session requests (the vast majority) must not
@@ -525,7 +469,7 @@ export function resolveSessionMutationAuthorization(params: {
     getCfg,
   });
   if (!targetRefs) {
-    if (REQUIRED_SESSION_TARGET_METHODS.has(params.method)) {
+    if (isRequiredSessionTargetMethod(params.method)) {
       return {
         error: errorShape(ErrorCodes.INVALID_REQUEST, "session mutation target is unavailable", {
           details: { code: "SESSION_MUTATION_TARGET_REQUIRED", method: params.method },

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -138,7 +138,7 @@ export function resolveSessionSharingRole(params: {
   const identity = gatewayClientSessionCreator(params.client);
   // Shared-secret/no-auth solo deployments have no durable person identity.
   if (!identity) {
-    return "owner";
+    return params.client?.authenticatedGitHubIdentitySync ? "viewer" : "owner";
   }
   if (params.target.entry.createdActor?.id === identity.id) {
     return "owner";

--- a/src/plugins/loader.base.test-utils.ts
+++ b/src/plugins/loader.base.test-utils.ts
@@ -1073,6 +1073,52 @@ describe("loadOpenClawPlugins", () => {
       },
     },
     {
+      label: "propagates explicit profile-independent gateway method policy",
+      run: () => {
+        useNoBundledPlugins();
+        const plugin = writePlugin({
+          id: "profile-independent-gateway-method",
+          filename: "profile-independent-gateway-method.cjs",
+          body: `module.exports = {
+    id: "profile-independent-gateway-method",
+    register(api) {
+      api.registerGatewayMethod(
+        "profile-independent-gateway-method.status",
+        ({ respond }) => respond(true, { ok: true }),
+        { scope: "operator.read", profileAccess: "independent" },
+      );
+      api.registerGatewayMethod(
+        "profile-independent-gateway-method.content",
+        ({ respond }) => respond(true, { ok: true }),
+        { scope: "operator.read" },
+      );
+    },
+  };`,
+        });
+
+        const registry = loadOpenClawPlugins({
+          cache: false,
+          workspaceDir: plugin.dir,
+          config: {
+            plugins: {
+              load: { paths: [plugin.file] },
+              allow: ["profile-independent-gateway-method"],
+            },
+          },
+        });
+        const descriptors = new Map(
+          registry.gatewayMethodDescriptors.map((descriptor) => [descriptor.name, descriptor]),
+        );
+
+        expect(descriptors.get("profile-independent-gateway-method.status")?.profileAccess).toBe(
+          "independent",
+        );
+        expect(descriptors.get("profile-independent-gateway-method.content")?.profileAccess).toBe(
+          "required",
+        );
+      },
+    },
+    {
       label: "coerces reserved gateway method namespaces to operator.admin",
       run: () => {
         useNoBundledPlugins();

--- a/src/plugins/plugin-api.types.ts
+++ b/src/plugins/plugin-api.types.ts
@@ -230,7 +230,10 @@ export type OpenClawPluginApi = {
   registerGatewayMethod: (
     method: string,
     handler: GatewayRequestHandler,
-    opts?: { scope?: OperatorScope },
+    opts?: {
+      scope?: OperatorScope;
+      profileAccess?: "independent" | "required";
+    },
   ) => void;
   /** Register a sandboxed board widget source kind owned by this plugin. */
   registerBoardWidgetContentKind: (definition: PluginBoardWidgetContentKind) => void;

--- a/src/plugins/registry-registrars-network.ts
+++ b/src/plugins/registry-registrars-network.ts
@@ -1,5 +1,6 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import type { GatewayMethodProfileAccess } from "../gateway/methods/descriptor.js";
 import { createPluginGatewayMethodDescriptor } from "../gateway/methods/registry.js";
 import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { GatewayRequestHandler, RespondFn } from "../gateway/server-methods/types.js";
@@ -50,7 +51,7 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
     record: PluginRecord,
     method: string,
     handler: GatewayRequestHandler,
-    opts?: { scope?: OperatorScope },
+    opts?: { scope?: OperatorScope; profileAccess?: GatewayMethodProfileAccess },
   ) => {
     const trimmed = method.trim();
     if (!trimmed) {
@@ -82,6 +83,7 @@ export function createNetworkRegistrars(state: PluginRegistryState) {
         name: trimmed,
         handler: wrappedHandler,
         scope: normalizedScope.scope,
+        ...(opts?.profileAccess ? { profileAccess: opts.profileAccess } : {}),
       }),
     );
   };

--- a/src/state/user-preferences.ts
+++ b/src/state/user-preferences.ts
@@ -36,7 +36,7 @@ type UserPreferenceError =
       currentCount: number;
     };
 
-function ensureUserPreferencesSchema(options: OpenClawStateDatabaseOptions = {}): void {
+export function ensureUserPreferencesSchema(options: OpenClawStateDatabaseOptions = {}): void {
   const database = openOpenClawStateDatabase(options);
   if (ensuredDatabases.has(database.db)) {
     return;
@@ -50,6 +50,67 @@ function ensureUserPreferencesSchema(options: OpenClawStateDatabaseOptions = {})
     { operationLabel: "users.preferences.schema.ensure" },
   );
   ensuredDatabases.add(database.db);
+}
+
+export function mutateUserPreference(
+  database: DatabaseSync,
+  profileId: string,
+  key: string,
+  value?: boolean,
+): void {
+  const db = getNodeSqliteKysely<UserPreferencesDatabase>(database);
+  if (value === undefined) {
+    if (tableExists(database, "user_preferences")) {
+      executeSqliteQuerySync(
+        database,
+        db
+          .deleteFrom("user_preferences")
+          .where("profile_id", "=", profileId)
+          .where("pref_key", "=", key),
+      );
+    }
+    return;
+  }
+  const updatedAtMs = Date.now();
+  const valueJson = JSON.stringify(value);
+  executeSqliteQuerySync(
+    database,
+    db
+      .insertInto("user_preferences")
+      .values({
+        profile_id: profileId,
+        pref_key: key,
+        value_json: valueJson,
+        updated_at_ms: updatedAtMs,
+      })
+      .onConflict((conflict) =>
+        conflict.columns(["profile_id", "pref_key"]).doUpdateSet({
+          value_json: valueJson,
+          updated_at_ms: updatedAtMs,
+        }),
+      ),
+  );
+}
+
+export function selectUserPreferenceValues(
+  database: DatabaseSync,
+  profileIds: readonly string[],
+  key: string,
+): Map<string, unknown> {
+  if (profileIds.length === 0 || !tableExists(database, "user_preferences")) {
+    return new Map();
+  }
+  const rows = executeSqliteQuerySync(
+    database,
+    getNodeSqliteKysely<UserPreferencesDatabase>(database)
+      .selectFrom("user_preferences")
+      .select(["profile_id", "value_json"])
+      .where("profile_id", "in", [...profileIds])
+      .where("pref_key", "=", key),
+  ).rows;
+  return new Map(
+    rows.map((row) => [row.profile_id, JSON.parse(row.value_json) as unknown] as const),
+  );
 }
 
 function openUserPreferencesDatabase(options: OpenClawStateDatabaseOptions = {}) {

--- a/src/state/user-profile-github-identity.ts
+++ b/src/state/user-profile-github-identity.ts
@@ -8,15 +8,10 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
 import { mutateUserPreference, selectUserPreferenceValues } from "./user-preferences.js";
-import {
-  requireResolvedUserProfileById,
-  selectResolvedUserProfileById,
-  userProfilesDb,
-} from "./user-profiles-internal.js";
+import { selectResolvedUserProfileById, userProfilesDb } from "./user-profiles-internal.js";
 import { ensureUserProfilesSchema } from "./user-profiles-schema.js";
 
 const GITHUB_PROVIDER = "github";
-const LEGACY_GITHUB_ATTRIBUTION_PROVIDER = "github-attribution";
 const GITHUB_LOGIN_SUBJECT_PREFIX = "login:";
 
 type StoredGitHubIdentity = {
@@ -165,8 +160,9 @@ export function prepareUserProfileGitHubMerge(
 
 export function applyVerifiedGitHubIdentity(params: {
   db: DatabaseSync;
-  profileId: string;
+  alias: { kind: "email"; email: string } | { kind: "github-login"; subject: string };
   identity: { accountId: number; login: string };
+  createProfile: () => string;
   mergeProfiles: (sourceProfileId: string, targetProfileId: string) => void;
 }): string {
   if (!Number.isSafeInteger(params.identity.accountId) || params.identity.accountId <= 0) {
@@ -178,8 +174,8 @@ export function applyVerifiedGitHubIdentity(params: {
   }
   const db = params.db;
   const kysely = userProfilesDb(db);
-  const currentProfileId = requireResolvedUserProfileById(db, params.profileId).id;
   const subject = String(params.identity.accountId);
+  const now = Date.now();
   const existing = executeSqliteQueryTakeFirstSync(
     db,
     kysely
@@ -189,6 +185,40 @@ export function applyVerifiedGitHubIdentity(params: {
       .where("subject", "=", subject)
       .where("canonical_login", "is not", null),
   );
+  const aliasIdentity =
+    params.alias.kind === "email"
+      ? executeSqliteQueryTakeFirstSync(
+          db,
+          kysely
+            .selectFrom("user_profile_emails")
+            .select("profile_id")
+            .where("email", "=", params.alias.email),
+        )
+      : executeSqliteQueryTakeFirstSync(
+          db,
+          kysely
+            .selectFrom("user_profile_identities")
+            .select("profile_id")
+            .where("provider", "=", GITHUB_PROVIDER)
+            .where("subject", "=", params.alias.subject)
+            .where("canonical_login", "is", null),
+        );
+  const aliasProfileId = aliasIdentity
+    ? selectResolvedUserProfileById(db, aliasIdentity.profile_id)?.id
+    : undefined;
+  const aliasGitHubIdentity = aliasProfileId
+    ? selectStoredGitHubIdentities(db, [aliasProfileId]).get(aliasProfileId)
+    : undefined;
+  const reusableAliasProfileId =
+    aliasProfileId &&
+    (aliasGitHubIdentity === undefined ||
+      aliasGitHubIdentity.accountId === params.identity.accountId)
+      ? aliasProfileId
+      : undefined;
+  const currentProfileId =
+    reusableAliasProfileId ??
+    (existing ? selectResolvedUserProfileById(db, existing.profile_id)?.id : undefined) ??
+    params.createProfile();
   const targetProfileId = existing
     ? (selectResolvedUserProfileById(db, existing.profile_id)?.id ?? currentProfileId)
     : currentProfileId;
@@ -200,34 +230,6 @@ export function applyVerifiedGitHubIdentity(params: {
     currentIdentity?.accountId !== params.identity.accountId
   ) {
     mutateUserPreference(db, targetProfileId, GIT_COAUTHOR_PREFERENCE_KEY);
-  }
-
-  const migrationProfileIds = [...new Set([currentProfileId, targetProfileId])];
-  const legacyRows = executeSqliteQuerySync(
-    db,
-    kysely
-      .selectFrom("user_profile_identities")
-      .select(["profile_id", "subject", "canonical_login"])
-      .where("provider", "=", LEGACY_GITHUB_ATTRIBUTION_PROVIDER)
-      .where("profile_id", "in", migrationProfileIds),
-  ).rows;
-  const legacyOptIn = legacyRows.some(
-    (row) => parseStoredGitHubIdentity(row)?.accountId === params.identity.accountId,
-  );
-  executeSqliteQuerySync(
-    db,
-    kysely
-      .deleteFrom("user_profile_identities")
-      .where("provider", "=", LEGACY_GITHUB_ATTRIBUTION_PROVIDER)
-      .where("profile_id", "in", migrationProfileIds),
-  );
-  if (
-    legacyOptIn &&
-    !selectUserPreferenceValues(db, [targetProfileId], GIT_COAUTHOR_PREFERENCE_KEY).has(
-      targetProfileId,
-    )
-  ) {
-    mutateUserPreference(db, targetProfileId, GIT_COAUTHOR_PREFERENCE_KEY, true);
   }
 
   if (currentProfileId !== targetProfileId) {
@@ -243,7 +245,7 @@ export function applyVerifiedGitHubIdentity(params: {
         subject,
         profile_id: targetProfileId,
         canonical_login: login,
-        created_at: Date.now(),
+        created_at: now,
       })
       .onConflict((conflict) =>
         conflict.columns(["provider", "subject"]).doUpdateSet({
@@ -252,5 +254,35 @@ export function applyVerifiedGitHubIdentity(params: {
         }),
       ),
   );
+  if (params.alias.kind === "email") {
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .insertInto("user_profile_emails")
+        .values({ email: params.alias.email, profile_id: targetProfileId, created_at: now })
+        .onConflict((conflict) =>
+          conflict.column("email").doUpdateSet({ profile_id: targetProfileId }),
+        ),
+    );
+  } else {
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .insertInto("user_profile_identities")
+        .values({
+          provider: GITHUB_PROVIDER,
+          subject: params.alias.subject,
+          profile_id: targetProfileId,
+          canonical_login: null,
+          created_at: now,
+        })
+        .onConflict((conflict) =>
+          conflict.columns(["provider", "subject"]).doUpdateSet({
+            profile_id: targetProfileId,
+            canonical_login: null,
+          }),
+        ),
+    );
+  }
   return targetProfileId;
 }

--- a/src/state/user-profile-github-identity.ts
+++ b/src/state/user-profile-github-identity.ts
@@ -1,12 +1,13 @@
 import type { DatabaseSync } from "node:sqlite";
+import { GIT_COAUTHOR_PREFERENCE_KEY } from "../../packages/gateway-protocol/src/schema/users.js";
 import type { UserProfileGitHubIdentity } from "../../packages/gateway-protocol/src/schema/users.js";
 import { executeSqliteQuerySync, executeSqliteQueryTakeFirstSync } from "../infra/kysely-sync.js";
 import { normalizeGitHubLogin } from "../utils/github-login.js";
 import {
   openOpenClawStateDatabase,
-  runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
+import { mutateUserPreference, selectUserPreferenceValues } from "./user-preferences.js";
 import {
   requireResolvedUserProfileById,
   selectResolvedUserProfileById,
@@ -14,35 +15,25 @@ import {
 } from "./user-profiles-internal.js";
 import { ensureUserProfilesSchema } from "./user-profiles-schema.js";
 
-const GITHUB_ATTRIBUTION_PROVIDER = "github-attribution";
+const GITHUB_PROVIDER = "github";
+const LEGACY_GITHUB_ATTRIBUTION_PROVIDER = "github-attribution";
+const GITHUB_LOGIN_SUBJECT_PREFIX = "login:";
 
-type UserProfileGitHubAttributionIdentity = {
+type StoredGitHubIdentity = {
   accountId: number;
   login: string;
 };
 
-export class UserProfileGitHubIdentityConflictError extends Error {
-  constructor() {
-    super("this GitHub account is already linked to another OpenClaw profile");
-    this.name = "UserProfileGitHubIdentityConflictError";
-  }
-}
-
 function parseStoredGitHubIdentity(row: {
   subject: string | null | undefined;
   canonical_login: string | null | undefined;
-}): UserProfileGitHubAttributionIdentity | null {
+}): StoredGitHubIdentity | null {
   const accountId = Number(row.subject);
   const login = row.canonical_login ? normalizeGitHubLogin(row.canonical_login) : undefined;
   return login && Number.isSafeInteger(accountId) && accountId > 0 ? { accountId, login } : null;
 }
 
-function toPublicGitHubIdentity(
-  identity: UserProfileGitHubAttributionIdentity | null,
-): UserProfileGitHubIdentity | null {
-  if (!identity) {
-    return null;
-  }
+function toPublicGitHubIdentity(identity: StoredGitHubIdentity): UserProfileGitHubIdentity {
   return {
     login: identity.login,
     profileUrl: `https://github.com/${identity.login}`,
@@ -50,14 +41,17 @@ function toPublicGitHubIdentity(
   };
 }
 
-export function selectUserProfileGitHubIdentities(
+function selectStoredGitHubIdentities(
   db: DatabaseSync,
   profileIds?: readonly string[],
-): Map<string, UserProfileGitHubIdentity> {
+): Map<string, StoredGitHubIdentity> {
+  if (profileIds?.length === 0) {
+    return new Map();
+  }
   let query = userProfilesDb(db)
     .selectFrom("user_profile_identities")
     .select(["profile_id", "subject", "canonical_login"])
-    .where("provider", "=", GITHUB_ATTRIBUTION_PROVIDER)
+    .where("provider", "=", GITHUB_PROVIDER)
     .where("canonical_login", "is not", null);
   if (profileIds) {
     query = query.where("profile_id", "in", [...profileIds]);
@@ -65,188 +59,198 @@ export function selectUserProfileGitHubIdentities(
   const rows = executeSqliteQuerySync(db, query).rows;
   return new Map(
     rows.flatMap((row) => {
-      const identity = toPublicGitHubIdentity(parseStoredGitHubIdentity(row));
+      const identity = parseStoredGitHubIdentity(row);
       return identity ? [[row.profile_id, identity] as const] : [];
     }),
   );
 }
 
-/** Resolves a bounded profile snapshot and its internal Git attribution in two batched reads. */
+function deleteProfileGitHubIdentities(
+  db: DatabaseSync,
+  profileIds: readonly string[],
+  keepSubject?: string,
+): void {
+  if (profileIds.length === 0) {
+    return;
+  }
+  let query = userProfilesDb(db)
+    .deleteFrom("user_profile_identities")
+    .where("provider", "=", GITHUB_PROVIDER)
+    .where("profile_id", "in", [...profileIds])
+    .where("canonical_login", "is not", null);
+  if (keepSubject) {
+    query = query.where("subject", "!=", keepSubject);
+  }
+  executeSqliteQuerySync(db, query);
+}
+
+export function githubAuthenticationSubject(login: string): string {
+  const normalized = login.trim().toLowerCase();
+  if (!normalized) {
+    throw new TypeError("GitHub login is invalid");
+  }
+  // Login aliases and immutable numeric account IDs share one SQLite keyspace.
+  return `${GITHUB_LOGIN_SUBJECT_PREFIX}${normalized}`;
+}
+
+export function selectUserProfileGitHubIdentities(
+  db: DatabaseSync,
+  profileIds?: readonly string[],
+): Map<string, UserProfileGitHubIdentity> {
+  return new Map(
+    [...selectStoredGitHubIdentities(db, profileIds)].map(([profileId, identity]) => [
+      profileId,
+      toPublicGitHubIdentity(identity),
+    ]),
+  );
+}
+
+/** Resolves bounded participants only when verified identity and public credit opt-in agree. */
 export function resolveUserProfileGitHubAttribution(
   profileIds: readonly string[],
   options: OpenClawStateDatabaseOptions = {},
-): Map<string, UserProfileGitHubAttributionIdentity | null> {
+): Map<string, StoredGitHubIdentity | null> {
   if (profileIds.length === 0) {
     return new Map();
   }
   const database = openOpenClawStateDatabase(options);
   ensureUserProfilesSchema(options, database);
   const { db } = database;
-  const kysely = userProfilesDb(db);
-  const sources = executeSqliteQuerySync(
+  const profiles = executeSqliteQuerySync(
     db,
-    kysely
+    userProfilesDb(db)
       .selectFrom("user_profiles")
       .select(["id", "merged_into"])
       .where("id", "in", [...profileIds]),
   ).rows;
   const canonicalBySource = new Map(
-    sources.map((profile) => [profile.id, profile.merged_into ?? profile.id] as const),
+    profiles.map((profile) => [profile.id, profile.merged_into ?? profile.id] as const),
   );
   const canonicalIds = [...new Set(canonicalBySource.values())];
-  const canonicalRows = executeSqliteQuerySync(
-    db,
-    kysely
-      .selectFrom("user_profiles as profile")
-      .leftJoin("user_profile_identities as identity", (join) =>
-        join
-          .onRef("identity.profile_id", "=", "profile.id")
-          .on("identity.provider", "=", GITHUB_ATTRIBUTION_PROVIDER),
-      )
-      .select([
-        "profile.id as profile_id",
-        "identity.subject as subject",
-        "identity.canonical_login as canonical_login",
-      ])
-      .where("profile.id", "in", canonicalIds),
-  ).rows;
-  const identityByCanonical = new Map(
-    canonicalRows.map((row) => [row.profile_id, parseStoredGitHubIdentity(row)] as const),
-  );
+  const identities = selectStoredGitHubIdentities(db, canonicalIds);
+  const preferences = selectUserPreferenceValues(db, canonicalIds, GIT_COAUTHOR_PREFERENCE_KEY);
   return new Map(
-    [...canonicalBySource].flatMap(([sourceId, canonicalId]) =>
-      identityByCanonical.has(canonicalId)
-        ? [[sourceId, identityByCanonical.get(canonicalId) ?? null] as const]
-        : [],
-    ),
+    [...canonicalBySource].map(([sourceId, canonicalId]) => [
+      sourceId,
+      preferences.get(canonicalId) === true ? (identities.get(canonicalId) ?? null) : null,
+    ]),
   );
 }
 
-export function mergeUserProfileGitHubIdentity(
+/** Keeps GitHub consent attached only to the immutable account that survives a profile merge. */
+export function prepareUserProfileGitHubMerge(
   db: DatabaseSync,
   sourceProfileIds: readonly string[],
   targetProfileId: string,
 ): void {
-  const kysely = userProfilesDb(db);
-  if (!selectUserProfileGitHubIdentities(db, [targetProfileId]).has(targetProfileId)) {
-    return;
+  const identities = selectStoredGitHubIdentities(db, [targetProfileId, ...sourceProfileIds]);
+  const targetIdentity = identities.get(targetProfileId);
+  const survivingSourceProfileId = targetIdentity
+    ? undefined
+    : sourceProfileIds.find((profileId) => identities.has(profileId));
+  const survivingAccountId =
+    targetIdentity?.accountId ??
+    (survivingSourceProfileId ? identities.get(survivingSourceProfileId)?.accountId : undefined);
+  for (const sourceProfileId of sourceProfileIds) {
+    const sourceIdentity = identities.get(sourceProfileId);
+    if (!sourceIdentity || sourceIdentity.accountId !== survivingAccountId) {
+      mutateUserPreference(db, sourceProfileId, GIT_COAUTHOR_PREFERENCE_KEY);
+    }
   }
+  deleteProfileGitHubIdentities(
+    db,
+    sourceProfileIds.filter((profileId) => profileId !== survivingSourceProfileId),
+  );
+}
+
+export function applyVerifiedGitHubIdentity(params: {
+  db: DatabaseSync;
+  profileId: string;
+  identity: { accountId: number; login: string };
+  mergeProfiles: (sourceProfileId: string, targetProfileId: string) => void;
+}): string {
+  if (!Number.isSafeInteger(params.identity.accountId) || params.identity.accountId <= 0) {
+    throw new TypeError("GitHub account id must be a positive safe integer");
+  }
+  const login = normalizeGitHubLogin(params.identity.login);
+  if (!login) {
+    throw new TypeError("GitHub login is invalid");
+  }
+  const db = params.db;
+  const kysely = userProfilesDb(db);
+  const currentProfileId = requireResolvedUserProfileById(db, params.profileId).id;
+  const subject = String(params.identity.accountId);
+  const existing = executeSqliteQueryTakeFirstSync(
+    db,
+    kysely
+      .selectFrom("user_profile_identities")
+      .select("profile_id")
+      .where("provider", "=", GITHUB_PROVIDER)
+      .where("subject", "=", subject)
+      .where("canonical_login", "is not", null),
+  );
+  const targetProfileId = existing
+    ? (selectResolvedUserProfileById(db, existing.profile_id)?.id ?? currentProfileId)
+    : currentProfileId;
+  const currentIdentity = selectStoredGitHubIdentities(db, [currentProfileId]).get(
+    currentProfileId,
+  );
+  if (
+    targetProfileId === currentProfileId &&
+    currentIdentity?.accountId !== params.identity.accountId
+  ) {
+    mutateUserPreference(db, targetProfileId, GIT_COAUTHOR_PREFERENCE_KEY);
+  }
+
+  const migrationProfileIds = [...new Set([currentProfileId, targetProfileId])];
+  const legacyRows = executeSqliteQuerySync(
+    db,
+    kysely
+      .selectFrom("user_profile_identities")
+      .select(["profile_id", "subject", "canonical_login"])
+      .where("provider", "=", LEGACY_GITHUB_ATTRIBUTION_PROVIDER)
+      .where("profile_id", "in", migrationProfileIds),
+  ).rows;
+  const legacyOptIn = legacyRows.some(
+    (row) => parseStoredGitHubIdentity(row)?.accountId === params.identity.accountId,
+  );
   executeSqliteQuerySync(
     db,
     kysely
       .deleteFrom("user_profile_identities")
-      .where("provider", "=", GITHUB_ATTRIBUTION_PROVIDER)
-      .where("profile_id", "in", sourceProfileIds)
-      .where("canonical_login", "is not", null),
+      .where("provider", "=", LEGACY_GITHUB_ATTRIBUTION_PROVIDER)
+      .where("profile_id", "in", migrationProfileIds),
   );
-}
-
-function mutateUserProfileGitHubIdentity(
-  profileId: string,
-  options: OpenClawStateDatabaseOptions,
-  operationLabel: string,
-  mutate: (db: DatabaseSync, canonicalProfileId: string, now: number) => void,
-): string {
-  ensureUserProfilesSchema(options);
-  return runOpenClawStateWriteTransaction(
-    ({ db }) => {
-      const canonicalProfileId = requireResolvedUserProfileById(db, profileId).id;
-      const now = Date.now();
-      mutate(db, canonicalProfileId, now);
-      executeSqliteQuerySync(
-        db,
-        userProfilesDb(db)
-          .updateTable("user_profiles")
-          .set({ updated_at: now })
-          .where("id", "=", canonicalProfileId),
-      );
-      return canonicalProfileId;
-    },
-    options,
-    { operationLabel },
-  );
-}
-
-export function setUserProfileGitHubIdentity(
-  profileId: string,
-  identity: { accountId: number; login: string },
-  options: OpenClawStateDatabaseOptions,
-): string {
-  if (!Number.isSafeInteger(identity.accountId) || identity.accountId <= 0) {
-    throw new TypeError("GitHub account id must be a positive safe integer");
+  if (
+    legacyOptIn &&
+    !selectUserPreferenceValues(db, [targetProfileId], GIT_COAUTHOR_PREFERENCE_KEY).has(
+      targetProfileId,
+    )
+  ) {
+    mutateUserPreference(db, targetProfileId, GIT_COAUTHOR_PREFERENCE_KEY, true);
   }
-  const login = normalizeGitHubLogin(identity.login);
-  if (!login) {
-    throw new TypeError("GitHub login is invalid");
-  }
-  return mutateUserProfileGitHubIdentity(
-    profileId,
-    options,
-    "user-profiles.set-github-identity",
-    (db, canonicalProfileId, now) => {
-      const kysely = userProfilesDb(db);
-      const subject = String(identity.accountId);
-      const existing = executeSqliteQueryTakeFirstSync(
-        db,
-        kysely
-          .selectFrom("user_profile_identities")
-          .select("profile_id")
-          .where("provider", "=", GITHUB_ATTRIBUTION_PROVIDER)
-          .where("subject", "=", subject),
-      );
-      if (
-        existing &&
-        selectResolvedUserProfileById(db, existing.profile_id)?.id !== canonicalProfileId
-      ) {
-        throw new UserProfileGitHubIdentityConflictError();
-      }
-      executeSqliteQuerySync(
-        db,
-        kysely
-          .deleteFrom("user_profile_identities")
-          .where("provider", "=", GITHUB_ATTRIBUTION_PROVIDER)
-          .where("profile_id", "=", canonicalProfileId)
-          .where("canonical_login", "is not", null),
-      );
-      executeSqliteQuerySync(
-        db,
-        kysely
-          .insertInto("user_profile_identities")
-          .values({
-            provider: GITHUB_ATTRIBUTION_PROVIDER,
-            subject,
-            profile_id: canonicalProfileId,
-            canonical_login: login,
-            created_at: now,
-          })
-          .onConflict((conflict) =>
-            conflict.columns(["provider", "subject"]).doUpdateSet({
-              profile_id: canonicalProfileId,
-              canonical_login: login,
-            }),
-          ),
-      );
-    },
-  );
-}
 
-export function clearUserProfileGitHubIdentity(
-  profileId: string,
-  options: OpenClawStateDatabaseOptions,
-): string {
-  return mutateUserProfileGitHubIdentity(
-    profileId,
-    options,
-    "user-profiles.clear-github-identity",
-    (db, canonicalProfileId) => {
-      executeSqliteQuerySync(
-        db,
-        userProfilesDb(db)
-          .deleteFrom("user_profile_identities")
-          .where("provider", "=", GITHUB_ATTRIBUTION_PROVIDER)
-          .where("profile_id", "=", canonicalProfileId)
-          .where("canonical_login", "is not", null),
-      );
-    },
+  if (currentProfileId !== targetProfileId) {
+    params.mergeProfiles(currentProfileId, targetProfileId);
+  }
+  deleteProfileGitHubIdentities(db, [targetProfileId], subject);
+  executeSqliteQuerySync(
+    db,
+    kysely
+      .insertInto("user_profile_identities")
+      .values({
+        provider: GITHUB_PROVIDER,
+        subject,
+        profile_id: targetProfileId,
+        canonical_login: login,
+        created_at: Date.now(),
+      })
+      .onConflict((conflict) =>
+        conflict.columns(["provider", "subject"]).doUpdateSet({
+          profile_id: targetProfileId,
+          canonical_login: login,
+        }),
+      ),
   );
+  return targetProfileId;
 }

--- a/src/state/user-profiles-tailscale-migration.ts
+++ b/src/state/user-profiles-tailscale-migration.ts
@@ -10,6 +10,7 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
+import { githubAuthenticationSubject } from "./user-profile-github-identity.js";
 import { ensureUserProfilesSchema, type UserProfilesDatabase } from "./user-profiles-schema.js";
 import { classifyTailscaleLogin } from "./user-profiles-tailscale-login.js";
 
@@ -49,13 +50,15 @@ export function migrateLegacyTailscaleProfileIdentities(
       let migrated = 0;
       const warnings: string[] = [];
       for (const row of legacyRows) {
+        const subject =
+          row.provider === "github" ? githubAuthenticationSubject(row.subject) : row.subject;
         executeSqliteQuerySync(
           db,
           transactionKysely
             .insertInto("user_profile_identities")
             .values({
               provider: row.provider,
-              subject: row.subject,
+              subject,
               profile_id: row.profile_id,
               canonical_login: null,
               created_at: row.created_at,
@@ -68,7 +71,7 @@ export function migrateLegacyTailscaleProfileIdentities(
             .selectFrom("user_profile_identities")
             .select("profile_id")
             .where("provider", "=", row.provider)
-            .where("subject", "=", row.subject),
+            .where("subject", "=", subject),
         );
         if (identity?.profile_id !== row.profile_id) {
           warnings.push(

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -18,6 +18,7 @@ import {
   formatUserProfileAvatarEtag,
   getProfileAvatar,
   getUserProfileDisplay,
+  getUserProfileListItem,
   linkEmail,
   listProfiles,
   resolveUserProfileId,
@@ -52,6 +53,39 @@ async function ensureTailscaleProfileWithAvatar(
 ) {
   const profile = ensureProfileForTailscaleIdentity(identity, options);
   return await adoptTailscaleProfileAvatar(profile.id, identity.profilePic, options, fetchOptions);
+}
+
+function syncTailscaleGitHubProfile(
+  params: {
+    accountId: number;
+    canonicalLogin: string;
+    login: string;
+    name?: string;
+  },
+  options: Parameters<typeof ensureProfileForTailscaleIdentity>[1],
+) {
+  return syncGitHubIdentity(
+    {
+      identity: { accountId: params.accountId, login: params.canonicalLogin },
+      authenticationAlias: { kind: "github-login", login: params.login },
+      initialDisplayName: params.name,
+    },
+    options,
+  );
+}
+
+function syncEmailGitHubProfile(
+  params: { accountId: number; canonicalLogin: string; email: string; name?: string },
+  options: Parameters<typeof ensureProfileForEmail>[1],
+) {
+  return syncGitHubIdentity(
+    {
+      identity: { accountId: params.accountId, login: params.canonicalLogin },
+      authenticationAlias: { kind: "email", email: params.email },
+      initialDisplayName: params.name,
+    },
+    options,
+  );
 }
 
 afterEach(() => {
@@ -133,14 +167,17 @@ describe("user profiles", () => {
 
   it("stores and refreshes verified GitHub identity beside the authenticated login alias", () => {
     const options = stateOptions();
-    const profile = ensureProfileForTailscaleIdentity(
-      { login: "583231@github", name: "Numeric Login" },
+    const profile = syncTailscaleGitHubProfile(
+      {
+        accountId: 583231,
+        canonicalLogin: "octocat",
+        login: "583231",
+        name: "Numeric Login",
+      },
       options,
     );
 
-    expect(
-      syncGitHubIdentity(profile.id, { accountId: 583231, login: "octocat" }, options),
-    ).toMatchObject({
+    expect(profile).toMatchObject({
       id: profile.id,
       githubIdentity: {
         login: "octocat",
@@ -149,8 +186,10 @@ describe("user profiles", () => {
       },
     });
     expect(
-      syncGitHubIdentity(profile.id, { accountId: 583231, login: "Octo-Renamed" }, options)
-        .githubIdentity,
+      syncTailscaleGitHubProfile(
+        { accountId: 583231, canonicalLogin: "Octo-Renamed", login: "583231" },
+        options,
+      ).githubIdentity,
     ).toMatchObject({ login: "Octo-Renamed" });
     expect(
       openOpenClawStateDatabase(options)
@@ -176,23 +215,27 @@ describe("user profiles", () => {
 
   it("reconciles a GitHub rename to the established profile and its preferences", () => {
     const options = stateOptions();
-    const established = ensureProfileForTailscaleIdentity(
-      { login: "ada@github", name: "Established Ada" },
+    const established = syncTailscaleGitHubProfile(
+      {
+        accountId: 583231,
+        canonicalLogin: "ada",
+        login: "ada",
+        name: "Established Ada",
+      },
       options,
     );
-    syncGitHubIdentity(established.id, { accountId: 583231, login: "ada" }, options);
     setDisplayName(established.id, "User Chosen", options);
     expect(setUserPreferences(established.id, { theme: "claw" }, options)).toMatchObject({
       ok: true,
     });
 
-    const renamed = ensureProfileForTailscaleIdentity(
-      { login: "octocat@github", name: "Provider Renamed" },
-      options,
-    );
-    const reconciled = syncGitHubIdentity(
-      renamed.id,
-      { accountId: 583231, login: "octocat" },
+    const reconciled = syncTailscaleGitHubProfile(
+      {
+        accountId: 583231,
+        canonicalLogin: "octocat",
+        login: "octocat",
+        name: "Provider Renamed",
+      },
       options,
     );
 
@@ -201,11 +244,135 @@ describe("user profiles", () => {
       displayName: "User Chosen",
       githubIdentity: { login: "octocat" },
     });
-    expect(resolveUserProfileId(renamed.id, options)).toBe(established.id);
     expect(getUserPreferences(established.id, undefined, options)).toMatchObject({ theme: "claw" });
   });
 
-  it("migrates matching legacy consent but discards mismatched legacy attribution", () => {
+  it("keeps immutable owners isolated when a released GitHub login is reused", () => {
+    const options = stateOptions();
+    const accountA = syncTailscaleGitHubProfile(
+      {
+        accountId: 10,
+        canonicalLogin: "old-login",
+        login: "old-login",
+        name: "Account A",
+      },
+      options,
+    );
+    setDisplayName(accountA.id, "Account A Custom", options);
+    expect(setAvatar(accountA.id, new Uint8Array([1, 2, 3]), "image/png", options).ok).toBe(true);
+    expect(
+      setUserPreferences(
+        accountA.id,
+        { theme: "claw", [GIT_COAUTHOR_PREFERENCE_KEY]: true },
+        options,
+      ),
+    ).toMatchObject({ ok: true });
+
+    const renamedA = syncTailscaleGitHubProfile(
+      {
+        accountId: 10,
+        canonicalLogin: "new-login",
+        login: "new-login",
+        name: "Provider Renamed A",
+      },
+      options,
+    );
+    const accountB = syncTailscaleGitHubProfile(
+      {
+        accountId: 20,
+        canonicalLogin: "old-login",
+        login: "old-login",
+        name: "Account B",
+      },
+      options,
+    );
+
+    expect(renamedA.id).toBe(accountA.id);
+    expect(accountB).toMatchObject({
+      displayName: "Account B",
+      githubIdentity: { login: "old-login" },
+      hasAvatar: false,
+    });
+    expect(accountB.id).not.toBe(accountA.id);
+    expect(getUserPreferences(accountB.id, undefined, options)).toEqual({});
+    expect(ensureProfileForTailscaleIdentity({ login: "old-login@github" }, options).id).toBe(
+      accountB.id,
+    );
+
+    expect(getUserProfileListItem(accountA.id, options)).toMatchObject({
+      displayName: "Account A Custom",
+      githubIdentity: { login: "new-login" },
+      hasAvatar: true,
+    });
+    expect(getProfileAvatar(accountA.id, options)?.bytes).toEqual(new Uint8Array([1, 2, 3]));
+    expect(getUserPreferences(accountA.id, undefined, options)).toEqual({
+      theme: "claw",
+      [GIT_COAUTHOR_PREFERENCE_KEY]: true,
+    });
+    expect(listProfiles(options)).toEqual([
+      expect.objectContaining({ id: accountA.id, mergedInto: null }),
+      expect.objectContaining({ id: accountB.id, mergedInto: null }),
+    ]);
+  });
+
+  it("does not create provisional profiles on repeated authenticated GitHub sync", () => {
+    const options = stateOptions();
+    const first = syncTailscaleGitHubProfile(
+      { accountId: 10, canonicalLogin: "ada", login: "ada", name: "Ada" },
+      options,
+    );
+    const second = syncTailscaleGitHubProfile(
+      { accountId: 10, canonicalLogin: "ada", login: "ada", name: "Changed Provider Name" },
+      options,
+    );
+
+    expect(second.id).toBe(first.id);
+    expect(listProfiles(options)).toEqual([
+      expect.objectContaining({ id: first.id, displayName: "Ada", mergedInto: null }),
+    ]);
+  });
+
+  it("moves a reused Cloudflare email without exposing the prior verified owner", () => {
+    const options = stateOptions();
+    const accountA = syncEmailGitHubProfile(
+      {
+        accountId: 10,
+        canonicalLogin: "account-a",
+        email: "shared@example.test",
+        name: "Account A",
+      },
+      options,
+    );
+    setDisplayName(accountA.id, "Account A Custom", options);
+    expect(setUserPreferences(accountA.id, { theme: "claw" }, options)).toMatchObject({ ok: true });
+
+    const accountB = syncEmailGitHubProfile(
+      {
+        accountId: 20,
+        canonicalLogin: "account-b",
+        email: "shared@example.test",
+        name: "Account B",
+      },
+      options,
+    );
+
+    expect(accountB).toMatchObject({
+      displayName: "Account B",
+      emails: ["shared@example.test"],
+      githubIdentity: { login: "account-b" },
+    });
+    expect(accountB.id).not.toBe(accountA.id);
+    expect(ensureProfileForEmail("shared@example.test", options).id).toBe(accountB.id);
+    expect(getUserProfileListItem(accountA.id, options)).toMatchObject({
+      displayName: "Account A Custom",
+      emails: [],
+      githubIdentity: { login: "account-a" },
+    });
+    expect(getUserPreferences(accountA.id, undefined, options)).toEqual({ theme: "claw" });
+    expect(getUserPreferences(accountB.id, undefined, options)).toEqual({});
+  });
+
+  it("keeps retired GitHub attribution rows inert during verified sync", () => {
     const options = stateOptions();
     const matching = ensureProfileForTailscaleIdentity({ login: "ada@github" }, options);
     const mismatched = ensureProfileForTailscaleIdentity({ login: "grace@github" }, options);
@@ -216,41 +383,54 @@ describe("user profiles", () => {
     insertLegacy.run("10", matching.id, "ada");
     insertLegacy.run("99", mismatched.id, "wrong-account");
 
-    expect(syncGitHubIdentity(matching.id, { accountId: 10, login: "ada" }, options)).toMatchObject(
-      { githubIdentity: { login: "ada" } },
-    );
-    syncGitHubIdentity(mismatched.id, { accountId: 11, login: "grace" }, options);
+    expect(
+      syncTailscaleGitHubProfile({ accountId: 10, canonicalLogin: "ada", login: "ada" }, options),
+    ).toMatchObject({ githubIdentity: { login: "ada" } });
+    syncTailscaleGitHubProfile({ accountId: 11, canonicalLogin: "grace", login: "grace" }, options);
 
-    expect(getUserPreferences(matching.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({
-      [GIT_COAUTHOR_PREFERENCE_KEY]: true,
-    });
+    expect(getUserPreferences(matching.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({});
     expect(getUserPreferences(mismatched.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({});
     expect(
       database
         .prepare("SELECT COUNT(*) AS count FROM user_profile_identities WHERE provider = ?")
         .get("github-attribution"),
-    ).toEqual({ count: 0 });
+    ).toEqual({ count: 2 });
   });
 
   it("does not carry co-author consent to a different immutable GitHub account", () => {
     const options = stateOptions();
-    const profile = ensureProfileForTailscaleIdentity({ login: "shared@github" }, options);
-    syncGitHubIdentity(profile.id, { accountId: 10, login: "first-owner" }, options);
+    const profile = syncTailscaleGitHubProfile(
+      { accountId: 10, canonicalLogin: "first-owner", login: "shared" },
+      options,
+    );
     expect(
       setUserPreferences(profile.id, { [GIT_COAUTHOR_PREFERENCE_KEY]: true }, options),
     ).toMatchObject({ ok: true });
 
-    syncGitHubIdentity(profile.id, { accountId: 11, login: "next-owner" }, options);
+    const nextOwner = syncTailscaleGitHubProfile(
+      { accountId: 11, canonicalLogin: "next-owner", login: "shared" },
+      options,
+    );
 
-    expect(getUserPreferences(profile.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({});
+    expect(nextOwner.id).not.toBe(profile.id);
+    expect(getUserPreferences(nextOwner.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({});
+    expect(getUserPreferences(profile.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({
+      [GIT_COAUTHOR_PREFERENCE_KEY]: true,
+    });
   });
 
   it("keeps co-author consent with the verified account that survives an email merge", () => {
     const options = stateOptions();
     const discarded = ensureProfileForEmail("discarded@example.com", options);
     const established = ensureProfileForEmail("established@example.com", options);
-    syncGitHubIdentity(discarded.id, { accountId: 10, login: "discarded" }, options);
-    syncGitHubIdentity(established.id, { accountId: 11, login: "established" }, options);
+    syncEmailGitHubProfile(
+      { accountId: 10, canonicalLogin: "discarded", email: "discarded@example.com" },
+      options,
+    );
+    syncEmailGitHubProfile(
+      { accountId: 11, canonicalLogin: "established", email: "established@example.com" },
+      options,
+    );
     setUserPreferences(discarded.id, { [GIT_COAUTHOR_PREFERENCE_KEY]: true }, options);
 
     const merged = linkEmail("discarded@example.com", established.id, options);
@@ -260,7 +440,10 @@ describe("user profiles", () => {
 
     const carrying = ensureProfileForEmail("carrying@example.com", options);
     const unverified = ensureProfileForEmail("unverified@example.com", options);
-    syncGitHubIdentity(carrying.id, { accountId: 12, login: "carrying" }, options);
+    syncEmailGitHubProfile(
+      { accountId: 12, canonicalLogin: "carrying", email: "carrying@example.com" },
+      options,
+    );
     setUserPreferences(carrying.id, { [GIT_COAUTHOR_PREFERENCE_KEY]: true }, options);
 
     const carried = linkEmail("carrying@example.com", unverified.id, options);

--- a/src/state/user-profiles.test.ts
+++ b/src/state/user-profiles.test.ts
@@ -2,16 +2,17 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GIT_COAUTHOR_PREFERENCE_KEY } from "../../packages/gateway-protocol/src/index.js";
 import { tableExists, tableHasColumn } from "./openclaw-state-db-schema-helpers.js";
 import {
   OPENCLAW_STATE_SCHEMA_VERSION,
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "./openclaw-state-db.js";
+import { getUserPreferences, setUserPreferences } from "./user-preferences.js";
 import { migrateLegacyTailscaleProfileIdentities } from "./user-profiles-tailscale-migration.js";
 import {
   adoptTailscaleProfileAvatar,
-  clearGitHubIdentity,
   ensureProfileForEmail,
   ensureProfileForTailscaleIdentity,
   formatUserProfileAvatarEtag,
@@ -22,8 +23,7 @@ import {
   resolveUserProfileId,
   setAvatar,
   setDisplayName,
-  setGitHubIdentity,
-  UserProfileGitHubIdentityConflictError,
+  syncGitHubIdentity,
 } from "./user-profiles.js";
 
 const statePaths: string[] = [];
@@ -108,7 +108,7 @@ describe("user profiles", () => {
           "SELECT provider, subject, profile_id FROM user_profile_identities ORDER BY provider, subject",
         )
         .all(),
-    ).toEqual([{ provider: "github", subject: "ada", profile_id: first.id }]);
+    ).toEqual([{ provider: "github", subject: "login:ada", profile_id: first.id }]);
   });
 
   it("lazily adds canonical GitHub login storage without changing the schema version", () => {
@@ -131,53 +131,144 @@ describe("user profiles", () => {
     expect(database.prepare("PRAGMA user_version").get()?.user_version).toBe(versionBefore);
   });
 
-  it("sets, changes, uniquely owns, and clears a derived GitHub attribution identity", () => {
+  it("stores and refreshes verified GitHub identity beside the authenticated login alias", () => {
     const options = stateOptions();
-    const ada = ensureProfileForEmail("ada@example.com", options);
-    const grace = ensureProfileForEmail("grace@example.com", options);
-    const numericLogin = ensureProfileForTailscaleIdentity(
+    const profile = ensureProfileForTailscaleIdentity(
       { login: "583231@github", name: "Numeric Login" },
       options,
     );
 
     expect(
-      setGitHubIdentity(ada.id, { accountId: 583231, login: "octocat" }, options),
+      syncGitHubIdentity(profile.id, { accountId: 583231, login: "octocat" }, options),
     ).toMatchObject({
+      id: profile.id,
       githubIdentity: {
         login: "octocat",
         profileUrl: "https://github.com/octocat",
         avatarUrl: "https://avatars.githubusercontent.com/u/583231?v=4",
       },
     });
-    expect(() =>
-      setGitHubIdentity(grace.id, { accountId: 583231, login: "octocat" }, options),
-    ).toThrow(UserProfileGitHubIdentityConflictError);
     expect(
-      setGitHubIdentity(ada.id, { accountId: 9919, login: "Ada-L" }, options).githubIdentity,
-    ).toMatchObject({ login: "Ada-L" });
-    expect(clearGitHubIdentity(ada.id, options).githubIdentity).toBeNull();
-    expect(ensureProfileForTailscaleIdentity({ login: "583231@github" }, options).id).toBe(
-      numericLogin.id,
-    );
+      syncGitHubIdentity(profile.id, { accountId: 583231, login: "Octo-Renamed" }, options)
+        .githubIdentity,
+    ).toMatchObject({ login: "Octo-Renamed" });
+    expect(
+      openOpenClawStateDatabase(options)
+        .db.prepare(
+          "SELECT provider, subject, canonical_login, profile_id FROM user_profile_identities ORDER BY subject",
+        )
+        .all(),
+    ).toEqual([
+      {
+        provider: "github",
+        subject: "583231",
+        canonical_login: "Octo-Renamed",
+        profile_id: profile.id,
+      },
+      {
+        provider: "github",
+        subject: "login:583231",
+        canonical_login: null,
+        profile_id: profile.id,
+      },
+    ]);
   });
 
-  it("moves GitHub attribution to the merge head while preserving a target link", () => {
+  it("reconciles a GitHub rename to the established profile and its preferences", () => {
     const options = stateOptions();
-    const source = ensureProfileForEmail("source@example.com", options);
-    const target = ensureProfileForEmail("target@example.com", options);
-    setGitHubIdentity(source.id, { accountId: 1, login: "source" }, options);
+    const established = ensureProfileForTailscaleIdentity(
+      { login: "ada@github", name: "Established Ada" },
+      options,
+    );
+    syncGitHubIdentity(established.id, { accountId: 583231, login: "ada" }, options);
+    setDisplayName(established.id, "User Chosen", options);
+    expect(setUserPreferences(established.id, { theme: "claw" }, options)).toMatchObject({
+      ok: true,
+    });
 
-    linkEmail("source@example.com", target.id, options);
-    expect(
-      listProfiles(options).find((profile) => profile.id === target.id)?.githubIdentity,
-    ).toMatchObject({ login: "source" });
+    const renamed = ensureProfileForTailscaleIdentity(
+      { login: "octocat@github", name: "Provider Renamed" },
+      options,
+    );
+    const reconciled = syncGitHubIdentity(
+      renamed.id,
+      { accountId: 583231, login: "octocat" },
+      options,
+    );
 
-    const next = ensureProfileForEmail("next@example.com", options);
-    setGitHubIdentity(next.id, { accountId: 2, login: "next" }, options);
-    linkEmail("target@example.com", next.id, options);
+    expect(reconciled).toMatchObject({
+      id: established.id,
+      displayName: "User Chosen",
+      githubIdentity: { login: "octocat" },
+    });
+    expect(resolveUserProfileId(renamed.id, options)).toBe(established.id);
+    expect(getUserPreferences(established.id, undefined, options)).toMatchObject({ theme: "claw" });
+  });
+
+  it("migrates matching legacy consent but discards mismatched legacy attribution", () => {
+    const options = stateOptions();
+    const matching = ensureProfileForTailscaleIdentity({ login: "ada@github" }, options);
+    const mismatched = ensureProfileForTailscaleIdentity({ login: "grace@github" }, options);
+    const database = openOpenClawStateDatabase(options).db;
+    const insertLegacy = database.prepare(
+      "INSERT INTO user_profile_identities (provider, subject, profile_id, canonical_login, created_at) VALUES ('github-attribution', ?, ?, ?, 1)",
+    );
+    insertLegacy.run("10", matching.id, "ada");
+    insertLegacy.run("99", mismatched.id, "wrong-account");
+
+    expect(syncGitHubIdentity(matching.id, { accountId: 10, login: "ada" }, options)).toMatchObject(
+      { githubIdentity: { login: "ada" } },
+    );
+    syncGitHubIdentity(mismatched.id, { accountId: 11, login: "grace" }, options);
+
+    expect(getUserPreferences(matching.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({
+      [GIT_COAUTHOR_PREFERENCE_KEY]: true,
+    });
+    expect(getUserPreferences(mismatched.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({});
     expect(
-      listProfiles(options).find((profile) => profile.id === next.id)?.githubIdentity,
-    ).toMatchObject({ login: "next" });
+      database
+        .prepare("SELECT COUNT(*) AS count FROM user_profile_identities WHERE provider = ?")
+        .get("github-attribution"),
+    ).toEqual({ count: 0 });
+  });
+
+  it("does not carry co-author consent to a different immutable GitHub account", () => {
+    const options = stateOptions();
+    const profile = ensureProfileForTailscaleIdentity({ login: "shared@github" }, options);
+    syncGitHubIdentity(profile.id, { accountId: 10, login: "first-owner" }, options);
+    expect(
+      setUserPreferences(profile.id, { [GIT_COAUTHOR_PREFERENCE_KEY]: true }, options),
+    ).toMatchObject({ ok: true });
+
+    syncGitHubIdentity(profile.id, { accountId: 11, login: "next-owner" }, options);
+
+    expect(getUserPreferences(profile.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({});
+  });
+
+  it("keeps co-author consent with the verified account that survives an email merge", () => {
+    const options = stateOptions();
+    const discarded = ensureProfileForEmail("discarded@example.com", options);
+    const established = ensureProfileForEmail("established@example.com", options);
+    syncGitHubIdentity(discarded.id, { accountId: 10, login: "discarded" }, options);
+    syncGitHubIdentity(established.id, { accountId: 11, login: "established" }, options);
+    setUserPreferences(discarded.id, { [GIT_COAUTHOR_PREFERENCE_KEY]: true }, options);
+
+    const merged = linkEmail("discarded@example.com", established.id, options);
+
+    expect(merged.githubIdentity).toMatchObject({ login: "established" });
+    expect(getUserPreferences(established.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({});
+
+    const carrying = ensureProfileForEmail("carrying@example.com", options);
+    const unverified = ensureProfileForEmail("unverified@example.com", options);
+    syncGitHubIdentity(carrying.id, { accountId: 12, login: "carrying" }, options);
+    setUserPreferences(carrying.id, { [GIT_COAUTHOR_PREFERENCE_KEY]: true }, options);
+
+    const carried = linkEmail("carrying@example.com", unverified.id, options);
+
+    expect(carried.githubIdentity).toMatchObject({ login: "carrying" });
+    expect(getUserPreferences(unverified.id, [GIT_COAUTHOR_PREFERENCE_KEY], options)).toEqual({
+      [GIT_COAUTHOR_PREFERENCE_KEY]: true,
+    });
   });
 
   it("keeps dotted Tailscale logins on the email alias path", () => {
@@ -464,7 +555,7 @@ describe("user profiles", () => {
     const database = openOpenClawStateDatabase(options).db;
     expect(
       database.prepare("SELECT provider, subject, profile_id FROM user_profile_identities").all(),
-    ).toEqual([{ provider: "github", subject: "user", profile_id: provider.id }]);
+    ).toEqual([{ provider: "github", subject: "login:user", profile_id: provider.id }]);
     expect(database.prepare("SELECT email, profile_id FROM user_profile_emails").all()).toEqual([
       { email: "person@gmail.com", profile_id: email.id },
     ]);

--- a/src/state/user-profiles.ts
+++ b/src/state/user-profiles.ts
@@ -63,6 +63,10 @@ type UserProfileDisplay = {
   hasAvatar: boolean;
 };
 
+type GitHubAuthenticationAlias =
+  | { kind: "email"; email: string }
+  | { kind: "github-login"; login: string };
+
 type UserProfileAvatarError =
   | { code: "avatar_too_large"; maxBytes: number }
   | { code: "unsupported_avatar_mime"; mime: string };
@@ -100,6 +104,25 @@ function toUserProfile(row: UserProfileRow): UserProfile {
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
+}
+
+function insertUserProfile(
+  db: DatabaseSync,
+  displayName: string | null,
+  now: number,
+): UserProfileRow {
+  const row: UserProfileRow = {
+    id: generateSecureUuid(),
+    display_name: displayName,
+    avatar: null,
+    avatar_mime: null,
+    avatar_sha256: null,
+    merged_into: null,
+    created_at: now,
+    updated_at: now,
+  };
+  executeSqliteQuerySync(db, userProfilesDb(db).insertInto("user_profiles").values(row));
+  return row;
 }
 
 function toUserProfileListItem(
@@ -206,7 +229,6 @@ function ensureProfileForEmailWithInitialName(
   options: OpenClawStateDatabaseOptions,
 ): UserProfile {
   const normalizedEmail = normalizeEmail(email);
-  const profileId = generateSecureUuid();
   const now = Date.now();
   const displayName =
     initialDisplayName ??
@@ -228,22 +250,12 @@ function ensureProfileForEmailWithInitialName(
       if (existingAlias) {
         return toUserProfile(requireResolvedUserProfileById(db, existingAlias.profile_id));
       }
-      const row: UserProfileRow = {
-        id: profileId,
-        display_name: displayName,
-        avatar: null,
-        avatar_mime: null,
-        avatar_sha256: null,
-        merged_into: null,
-        created_at: now,
-        updated_at: now,
-      };
-      executeSqliteQuerySync(db, kysely.insertInto("user_profiles").values(row));
+      const row = insertUserProfile(db, displayName, now);
       executeSqliteQuerySync(
         db,
         kysely.insertInto("user_profile_emails").values({
           email: normalizedEmail,
-          profile_id: profileId,
+          profile_id: row.id,
           created_at: now,
         }),
       );
@@ -268,7 +280,6 @@ function ensureProfileForProviderIdentity(params: {
   initialDisplayName: string | null;
   options: OpenClawStateDatabaseOptions;
 }): UserProfile {
-  const profileId = generateSecureUuid();
   const now = Date.now();
   const subject =
     params.provider === "github" ? githubAuthenticationSubject(params.subject) : params.subject;
@@ -305,23 +316,13 @@ function ensureProfileForProviderIdentity(params: {
         }
         return toUserProfile(requireResolvedUserProfileById(db, existingIdentity.profile_id));
       }
-      const row: UserProfileRow = {
-        id: profileId,
-        display_name: params.initialDisplayName,
-        avatar: null,
-        avatar_mime: null,
-        avatar_sha256: null,
-        merged_into: null,
-        created_at: now,
-        updated_at: now,
-      };
-      executeSqliteQuerySync(db, kysely.insertInto("user_profiles").values(row));
+      const row = insertUserProfile(db, params.initialDisplayName, now);
       executeSqliteQuerySync(
         db,
         kysely.insertInto("user_profile_identities").values({
           provider: params.provider,
           subject,
-          profile_id: profileId,
+          profile_id: row.id,
           canonical_login: null,
           created_at: now,
         }),
@@ -594,26 +595,51 @@ export function setDisplayName(
   );
 }
 
+function normalizeGitHubAuthenticationAlias(
+  alias: GitHubAuthenticationAlias,
+): { kind: "email"; email: string } | { kind: "github-login"; subject: string } {
+  return alias.kind === "email"
+    ? { kind: "email", email: normalizeEmail(alias.email) }
+    : { kind: "github-login", subject: githubAuthenticationSubject(alias.login) };
+}
+
 export function syncGitHubIdentity(
-  profileId: string,
-  identity: { accountId: number; login: string },
+  params: {
+    identity: { accountId: number; login: string };
+    authenticationAlias: GitHubAuthenticationAlias;
+    initialDisplayName?: string;
+  },
   options: OpenClawStateDatabaseOptions = {},
 ): UserProfileListItem {
+  const alias = normalizeGitHubAuthenticationAlias(params.authenticationAlias);
+  const initialDisplayName = normalizeInitialDisplayName(params.initialDisplayName);
   ensureUserProfilesSchema(options);
   ensureUserPreferencesSchema(options);
   return runOpenClawStateWriteTransaction(
     ({ db }) => {
       const now = Date.now();
+      const kysely = userProfilesDb(db);
       const canonicalProfileId = applyVerifiedGitHubIdentity({
         db,
-        profileId,
-        identity,
+        alias,
+        identity: params.identity,
+        createProfile: () => insertUserProfile(db, initialDisplayName, now).id,
         mergeProfiles: (sourceProfileId, targetProfileId) =>
           mergeUserProfiles(db, sourceProfileId, targetProfileId, now),
       });
+      if (initialDisplayName) {
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .updateTable("user_profiles")
+            .set({ display_name: initialDisplayName, updated_at: now })
+            .where("id", "=", canonicalProfileId)
+            .where("display_name", "is", null),
+        );
+      }
       executeSqliteQuerySync(
         db,
-        userProfilesDb(db)
+        kysely
           .updateTable("user_profiles")
           .set({ updated_at: now })
           .where("id", "=", canonicalProfileId),

--- a/src/state/user-profiles.ts
+++ b/src/state/user-profiles.ts
@@ -11,13 +11,12 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db.js";
-import { mergeUserPreferences } from "./user-preferences.js";
+import { ensureUserPreferencesSchema, mergeUserPreferences } from "./user-preferences.js";
 import {
-  clearUserProfileGitHubIdentity,
-  mergeUserProfileGitHubIdentity,
+  applyVerifiedGitHubIdentity,
+  githubAuthenticationSubject,
+  prepareUserProfileGitHubMerge,
   selectUserProfileGitHubIdentities,
-  setUserProfileGitHubIdentity,
-  UserProfileGitHubIdentityConflictError,
 } from "./user-profile-github-identity.js";
 import {
   normalizeUserProfileAvatarMime,
@@ -68,7 +67,6 @@ type UserProfileAvatarError =
   | { code: "avatar_too_large"; maxBytes: number }
   | { code: "unsupported_avatar_mime"; mime: string };
 
-export { UserProfileGitHubIdentityConflictError };
 export { UserProfileNotFoundError };
 
 type UserProfileListRow = Pick<
@@ -272,19 +270,39 @@ function ensureProfileForProviderIdentity(params: {
 }): UserProfile {
   const profileId = generateSecureUuid();
   const now = Date.now();
+  const subject =
+    params.provider === "github" ? githubAuthenticationSubject(params.subject) : params.subject;
   ensureUserProfilesSchema(params.options);
   return runOpenClawStateWriteTransaction(
     ({ db }) => {
       const kysely = userProfilesDb(db);
-      const existingIdentity = executeSqliteQueryTakeFirstSync(
-        db,
-        kysely
-          .selectFrom("user_profile_identities")
-          .select("profile_id")
-          .where("provider", "=", params.provider)
-          .where("subject", "=", params.subject),
-      );
+      let existingQuery = kysely
+        .selectFrom("user_profile_identities")
+        .select(["profile_id", "subject"])
+        .where("provider", "=", params.provider);
+      existingQuery =
+        params.provider === "github"
+          ? existingQuery
+              .where((eb) =>
+                eb.or([
+                  eb("subject", "=", subject),
+                  eb.and([eb("subject", "=", params.subject), eb("canonical_login", "is", null)]),
+                ]),
+              )
+              .orderBy(sql`CASE WHEN subject = ${subject} THEN 0 ELSE 1 END`)
+          : existingQuery.where("subject", "=", subject);
+      const existingIdentity = executeSqliteQueryTakeFirstSync(db, existingQuery);
       if (existingIdentity) {
+        if (existingIdentity.subject !== subject) {
+          executeSqliteQuerySync(
+            db,
+            kysely
+              .updateTable("user_profile_identities")
+              .set({ subject })
+              .where("provider", "=", params.provider)
+              .where("subject", "=", existingIdentity.subject),
+          );
+        }
         return toUserProfile(requireResolvedUserProfileById(db, existingIdentity.profile_id));
       }
       const row: UserProfileRow = {
@@ -302,7 +320,7 @@ function ensureProfileForProviderIdentity(params: {
         db,
         kysely.insertInto("user_profile_identities").values({
           provider: params.provider,
-          subject: params.subject,
+          subject,
           profile_id: profileId,
           canonical_login: null,
           created_at: now,
@@ -312,6 +330,54 @@ function ensureProfileForProviderIdentity(params: {
     },
     params.options,
     { operationLabel: "user-profiles.ensure-identity" },
+  );
+}
+
+function mergeUserProfiles(
+  db: DatabaseSync,
+  sourceProfileId: string,
+  targetProfileId: string,
+  now: number,
+): void {
+  if (sourceProfileId === targetProfileId) {
+    return;
+  }
+  const kysely = userProfilesDb(db);
+  const sourceProfileIds = [
+    sourceProfileId,
+    ...executeSqliteQuerySync(
+      db,
+      kysely.selectFrom("user_profiles").select("id").where("merged_into", "=", sourceProfileId),
+    ).rows.map((row) => row.id),
+  ];
+  prepareUserProfileGitHubMerge(db, sourceProfileIds, targetProfileId);
+  for (const mergedProfileId of sourceProfileIds) {
+    mergeUserPreferences(db, mergedProfileId, targetProfileId);
+  }
+  executeSqliteQuerySync(
+    db,
+    kysely
+      .updateTable("user_profile_emails")
+      .set({ profile_id: targetProfileId })
+      .where("profile_id", "in", sourceProfileIds),
+  );
+  executeSqliteQuerySync(
+    db,
+    kysely
+      .updateTable("user_profile_identities")
+      .set({ profile_id: targetProfileId })
+      .where("profile_id", "in", sourceProfileIds),
+  );
+  executeSqliteQuerySync(
+    db,
+    kysely
+      .updateTable("user_profiles")
+      .set({ merged_into: targetProfileId, updated_at: now })
+      .where("id", "in", sourceProfileIds),
+  );
+  executeSqliteQuerySync(
+    db,
+    kysely.updateTable("user_profiles").set({ updated_at: now }).where("id", "=", targetProfileId),
   );
 }
 
@@ -487,41 +553,7 @@ export function linkEmail(
         kysely.updateTable("user_profiles").set({ updated_at: now }).where("id", "=", target.id),
       );
       if (remainingAliases.length === 0) {
-        const mergeSourceIds = [
-          existingAlias.profile_id,
-          ...executeSqliteQuerySync(
-            db,
-            kysely
-              .selectFrom("user_profiles")
-              .select("id")
-              .where("merged_into", "=", existingAlias.profile_id),
-          ).rows.map((row) => row.id),
-        ];
-        for (const sourceProfileId of mergeSourceIds) {
-          mergeUserPreferences(db, sourceProfileId, target.id);
-        }
-        mergeUserProfileGitHubIdentity(db, mergeSourceIds, target.id);
-        executeSqliteQuerySync(
-          db,
-          kysely
-            .updateTable("user_profile_identities")
-            .set({ profile_id: target.id })
-            .where("profile_id", "in", mergeSourceIds),
-        );
-        executeSqliteQuerySync(
-          db,
-          kysely
-            .updateTable("user_profiles")
-            .set({ merged_into: target.id, updated_at: now })
-            .where("id", "=", existingAlias.profile_id),
-        );
-        executeSqliteQuerySync(
-          db,
-          kysely
-            .updateTable("user_profiles")
-            .set({ merged_into: target.id, updated_at: now })
-            .where("merged_into", "=", existingAlias.profile_id),
-        );
+        mergeUserProfiles(db, existingAlias.profile_id, target.id, now);
       } else {
         executeSqliteQuerySync(
           db,
@@ -562,21 +594,35 @@ export function setDisplayName(
   );
 }
 
-export function setGitHubIdentity(
+export function syncGitHubIdentity(
   profileId: string,
   identity: { accountId: number; login: string },
   options: OpenClawStateDatabaseOptions = {},
 ): UserProfileListItem {
-  const canonicalProfileId = setUserProfileGitHubIdentity(profileId, identity, options);
-  return selectUserProfileListItemById(openOpenClawStateDatabase(options).db, canonicalProfileId);
-}
-
-export function clearGitHubIdentity(
-  profileId: string,
-  options: OpenClawStateDatabaseOptions = {},
-): UserProfileListItem {
-  const canonicalProfileId = clearUserProfileGitHubIdentity(profileId, options);
-  return selectUserProfileListItemById(openOpenClawStateDatabase(options).db, canonicalProfileId);
+  ensureUserProfilesSchema(options);
+  ensureUserPreferencesSchema(options);
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const now = Date.now();
+      const canonicalProfileId = applyVerifiedGitHubIdentity({
+        db,
+        profileId,
+        identity,
+        mergeProfiles: (sourceProfileId, targetProfileId) =>
+          mergeUserProfiles(db, sourceProfileId, targetProfileId, now),
+      });
+      executeSqliteQuerySync(
+        db,
+        userProfilesDb(db)
+          .updateTable("user_profiles")
+          .set({ updated_at: now })
+          .where("id", "=", canonicalProfileId),
+      );
+      return selectUserProfileListItemById(db, canonicalProfileId);
+    },
+    options,
+    { operationLabel: "user-profiles.sync-github-identity" },
+  );
 }
 
 /** Stores a bounded, allowlisted avatar without ever leaving the write transaction async. */

--- a/test/scripts/check-deadcode-unused-files.test.ts
+++ b/test/scripts/check-deadcode-unused-files.test.ts
@@ -13,6 +13,7 @@ import {
   parseKnipCompactUnusedFiles,
   runKnipUnusedFiles,
 } from "../../scripts/check-deadcode-unused-files.mts";
+import { killPidIfAlive } from "../../src/test-utils/process-tree.js";
 import {
   isProcessAlive,
   waitForChildClose,
@@ -316,9 +317,7 @@ Delete the files or model their real entrypoints in Knip.`,
         });
         await waitForDead(childPid, 2_000);
       } finally {
-        if (childPid && isProcessAlive(childPid)) {
-          process.kill(childPid, "SIGKILL");
-        }
+        killPidIfAlive(childPid || undefined);
         rmSync(root, { recursive: true, force: true });
       }
     },
@@ -380,9 +379,7 @@ Delete the files or model their real entrypoints in Knip.`,
         if (runner?.pid && isProcessAlive(runner.pid)) {
           runner.kill("SIGKILL");
         }
-        if (childPid && isProcessAlive(childPid)) {
-          process.kill(childPid, "SIGKILL");
-        }
+        killPidIfAlive(childPid || undefined);
         rmSync(root, { recursive: true, force: true });
       }
     },

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -8,7 +8,6 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
-      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
       "extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",
       "extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts",

--- a/test/vitest/vitest.extension-codex-app-server-tools.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-tools.config.ts
@@ -15,7 +15,6 @@ function createExtensionCodexAppServerToolsVitestConfig(
       "extensions/codex/src/app-server/native-hook-relay.test.ts",
       "extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts",
       "extensions/codex/src/app-server/request.test.ts",
-      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
       "extensions/codex/src/app-server/sandbox-exec-server*.test.ts",
       "extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts",
       "extensions/codex/src/app-server/user-input-bridge.test.ts",

--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -35,6 +35,11 @@ suite.define(() => {
         ).getTime();
         const releaseKey = "agent:main:release-readiness";
         const designKey = "agent:main:design-review";
+        const gatewayHandoffKey = "agent:main:gateway-handoff";
+        const nightlyMaintenanceKey = "agent:main:nightly-maintenance";
+        const incidentNotesKey = "agent:main:incident-notes";
+        const automationKeys = [designKey, gatewayHandoffKey, nightlyMaintenanceKey];
+        const nonAutomationKeys = [releaseKey, incidentNotesKey];
         await installMockGateway(page, {
           hasMultipleSessionSharingIdentities: true,
           presenceUsers: [
@@ -120,7 +125,7 @@ suite.define(() => {
                   updatedAt: now - 42 * 60_000,
                 },
                 {
-                  key: "agent:main:gateway-handoff",
+                  key: gatewayHandoffKey,
                   kind: "direct",
                   displayName: "Gateway handoff",
                   agentId: "main",
@@ -132,7 +137,7 @@ suite.define(() => {
                   updatedAt: now - 2 * 60 * 60_000,
                 },
                 {
-                  key: "agent:main:nightly-maintenance",
+                  key: nightlyMaintenanceKey,
                   kind: "direct",
                   displayName: "Nightly mock maintenance",
                   agentId: "main",
@@ -144,7 +149,7 @@ suite.define(() => {
                   updatedAt: now - 3 * 60 * 60_000,
                 },
                 {
-                  key: "agent:main:incident-notes",
+                  key: incidentNotesKey,
                   kind: "direct",
                   displayName: "Incident follow-up",
                   agentId: "main",
@@ -236,17 +241,33 @@ suite.define(() => {
           )
           .toBe(3);
         await page.keyboard.press("Escape");
-        const automationGroup = activityPage.locator("[data-activity-automation-group]");
-        const sessionRows = activityPage.locator("[data-activity-session]");
+        const activityFeed = page.locator(".activity-feed");
+        const activitySession = (key: string) =>
+          activityFeed.locator(`[data-activity-session="${key}"]`);
+        const automationGroup = activityFeed.locator("[data-activity-automation-group]");
         await expect.poll(() => automationGroup.count()).toBe(1);
         await expect.poll(() => automationGroup.getAttribute("aria-expanded")).toBe("false");
-        await expect.poll(() => sessionRows.count()).toBe(2);
+        for (const key of nonAutomationKeys) {
+          await expect.poll(() => activitySession(key).count()).toBe(1);
+        }
+        for (const key of automationKeys) {
+          await expect.poll(() => activitySession(key).count()).toBe(0);
+        }
         await automationGroup.click();
-        await expect.poll(() => sessionRows.count()).toBe(5);
+        await expect.poll(() => automationGroup.getAttribute("aria-expanded")).toBe("true");
+        for (const key of automationKeys) {
+          await expect.poll(() => activitySession(key).count()).toBe(1);
+        }
         await automationGroup.click();
-        await expect.poll(() => sessionRows.count()).toBe(2);
+        await expect.poll(() => automationGroup.getAttribute("aria-expanded")).toBe("false");
+        for (const key of automationKeys) {
+          await expect.poll(() => activitySession(key).count()).toBe(0);
+        }
+        for (const key of nonAutomationKeys) {
+          await expect.poll(() => activitySession(key).count()).toBe(1);
+        }
 
-        const liveRow = activityPage.locator(`[data-activity-session="${releaseKey}"]`);
+        const liveRow = activitySession(releaseKey);
         await expect.poll(() => liveRow.locator(".activity-feed__run-dot").count()).toBe(1);
         await expect
           .poll(() => liveRow.locator(".activity-feed__session-headline").textContent())

--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -241,7 +241,7 @@ suite.define(() => {
           )
           .toBe(3);
         await page.keyboard.press("Escape");
-        const activityFeed = page.locator(".activity-feed");
+        const activityFeed = activityPage.locator(".activity-feed");
         const activitySession = (key: string) =>
           activityFeed.locator(`[data-activity-session="${key}"]`);
         const automationGroup = activityFeed.locator("[data-activity-automation-group]");

--- a/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
+++ b/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
@@ -70,7 +70,7 @@ suite.define(() => {
         const menuTrigger = activePane.getByRole("button", {
           name: "Actions for Terminal continuation",
         });
-        await menuTrigger.click();
+        await menuTrigger.press("Enter");
         const dropdown = menuTrigger.locator("xpath=ancestor::wa-dropdown");
         const action = dropdown.getByText("Continue in terminal…", { exact: true });
         expect(await dropdown.evaluate((element) => (element as { open?: boolean }).open)).toBe(
@@ -97,7 +97,7 @@ suite.define(() => {
         await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe(command);
 
         await dialog.getByRole("button", { name: "Close" }).click();
-        await menuTrigger.click();
+        await menuTrigger.press("Enter");
         await action.click();
         await dialog.waitFor({ state: "visible" });
         const socketCount = await gateway.getSocketCount();

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -316,10 +316,10 @@ suite.define(() => {
         message: "send outcome unknown",
       });
 
+      await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey));
       await pollLocatorText(page.locator(".chat-cloud-startup-error")).toContain(
         "send outcome unknown",
       );
-      expect(new URL(page.url()).pathname).toContain(controlUiSessionPath(sessionKey));
       await replaceGatewayClient(page);
       await expect.poll(async () => (await gateway.getRequests("sessions.send")).length).toBe(2);
 

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -3,6 +3,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page } from "playwright/test";
 import { it } from "vitest";
+import { GIT_COAUTHOR_PREFERENCE_KEY } from "../../../packages/gateway-protocol/src/index.ts";
 import {
   buildControlUiCspHeader,
   computeInlineScriptHashes,
@@ -100,7 +101,7 @@ suite.define(() => {
     });
   });
 
-  it("links and disconnects a public GitHub identity", async () => {
+  it("shows sign-in verification separately from explicit Git co-author credit", async () => {
     if (captureUiProof) {
       await mkdir(proofDir, { recursive: true });
     }
@@ -122,29 +123,39 @@ suite.define(() => {
           });
         });
         const gateway = await openProfilePage(page, {
-          "users.setGitHubIdentity": { profile: linkedGitHubProfile },
-          "users.clearGitHubIdentity": { profile: testProfile },
+          "users.self": {
+            sequence: [{ profile: testProfile }, { profile: linkedGitHubProfile }],
+          },
+          "users.prefs.get": {
+            status: "ok",
+            entries: { [GIT_COAUTHOR_PREFERENCE_KEY]: false },
+          },
+          "users.prefs.set": { status: "ok" },
         });
 
         const githubRow = page
           .locator("#settings-profile-identity .settings-row")
-          .filter({ has: page.locator(".settings-row__title", { hasText: "GitHub" }) });
-        await expect(githubRow).toContainText(
-          "Linking opts you into public GitHub co-author credit when you participate in agent sessions that create commits.",
-        );
-        await expect(githubRow).toContainText(
-          "Commit credit uses GitHub's public noreply address, never a private email.",
-        );
-        await expect(githubRow).toContainText("Link only an account you control.");
+          .filter({ has: page.locator(".settings-row__title", { hasText: "GitHub account" }) });
+        const coauthorRow = page.locator("#settings-profile-identity .settings-row").filter({
+          has: page.locator(".settings-row__title", { hasText: "Git co-author credit" }),
+        });
+        await expect(githubRow).toContainText("Unavailable");
+        await expect(githubRow).toContainText("GitHub-backed sign-in");
+        await expect(githubRow).toContainText("Refresh to retry");
         await expect(githubRow.locator(".settings-account")).toHaveCount(0);
+        await expect(
+          coauthorRow.getByRole("switch", { name: "Git co-author credit" }),
+        ).toBeDisabled();
+        await expect(page.getByRole("textbox", { name: "GitHub username" })).toHaveCount(0);
+        await expect(
+          page.getByRole("button", { name: /Link GitHub|Change|Disconnect/u }),
+        ).toHaveCount(0);
         await screenshot(page, "08-github-identity-unlinked.png");
 
-        const username = githubRow.getByRole("textbox", { name: "GitHub username" });
-        await username.fill("octocat");
-        await githubRow.getByRole("button", { name: "Link GitHub" }).click();
-
-        const linkRequest = await gateway.waitForRequest("users.setGitHubIdentity");
-        expect(linkRequest.params).toEqual({ username: "octocat" });
+        await page.getByRole("button", { name: "Refresh" }).click();
+        await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
+        const prefGet = await gateway.waitForRequest("users.prefs.get");
+        expect(prefGet.params).toEqual({ keys: [GIT_COAUTHOR_PREFERENCE_KEY] });
         const account = githubRow.getByRole("link", { name: "@octocat" });
         await expect(account).toBeVisible();
         await expect(account).toHaveAttribute("href", "https://github.com/octocat");
@@ -158,18 +169,21 @@ suite.define(() => {
           .poll(() => avatar.evaluate((image) => (image as HTMLImageElement).naturalWidth))
           .toBe(64);
         expect(avatarRequests).toEqual([githubAvatarUrl]);
-        await expect(username).toHaveValue("octocat");
-        const unchangedSubmit = githubRow.getByRole("button", { name: "Change" });
-        await expect(unchangedSubmit).toBeDisabled();
-        expect(await gateway.getRequests("users.setGitHubIdentity")).toHaveLength(1);
+        await expect(githubRow).toContainText("Verified from your GitHub-backed sign-in");
+        await expect(coauthorRow).toContainText("public GitHub noreply address");
+        await expect(coauthorRow).toContainText("future commits only");
+        const toggle = coauthorRow.getByRole("switch", { name: "Git co-author credit" });
+        await expect(toggle).toBeEnabled();
+        await expect(toggle).not.toBeChecked();
         await screenshot(page, "09-github-identity-linked.png");
 
-        await githubRow.getByRole("button", { name: "Disconnect" }).click();
-        const clearRequest = await gateway.waitForRequest("users.clearGitHubIdentity");
-        expect(clearRequest.params).toEqual({});
-        await expect(githubRow.locator(".settings-account")).toHaveCount(0);
-        await expect(username).toHaveValue("");
-        await expect(githubRow.getByRole("button", { name: "Link GitHub" })).toBeVisible();
+        await coauthorRow.locator("wa-switch").click();
+        const prefSet = await gateway.waitForRequest("users.prefs.set");
+        expect(prefSet.params).toEqual({
+          entries: { [GIT_COAUTHOR_PREFERENCE_KEY]: true },
+        });
+        await expect(toggle).toBeChecked();
+        await screenshot(page, "10-git-coauthor-enabled.png");
       },
     );
   });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3442,17 +3442,16 @@ export const en: TranslationMap = {
       displayNameDescription: "Shown to other people using this gateway.",
       linkedEmails: "Linked emails",
       linkedEmailsDescription: "Email addresses connected to this profile.",
-      github: "GitHub",
-      githubDescription:
-        "Linking opts you into public GitHub co-author credit when you participate in agent sessions that create commits.",
-      githubUsername: "GitHub username",
-      githubPlaceholder: "octocat",
-      githubLink: "Link GitHub",
-      githubLinking: "Linking…",
-      githubChange: "Change",
-      githubDisconnect: "Disconnect",
-      githubPrivacy: "Commit credit uses GitHub's public noreply address, never a private email.",
-      githubOwnership: "Link only an account you control.",
+      githubAccount: "GitHub account",
+      githubAccountDescription: "Automatically verified from your GitHub-backed sign-in.",
+      githubVerified: "Verified from your GitHub-backed sign-in",
+      githubUnavailable: "Unavailable",
+      githubUnavailableDescription: "GitHub-backed sign-in is unavailable. Refresh to retry.",
+      gitCoauthor: "Git co-author credit",
+      gitCoauthorDescription:
+        "Adds this account's public GitHub noreply address to commits created from shared sessions. Turning it off affects future commits only.",
+      gitCoauthorUnavailable:
+        "Available after your GitHub-backed sign-in is verified. Refresh to retry.",
       avatarErrors: {
         invalid: "That image could not be processed.",
         sourceTooLarge: "Choose an image that is 10 MB or smaller.",

--- a/ui/src/pages/profile/identity-section.test.ts
+++ b/ui/src/pages/profile/identity-section.test.ts
@@ -25,15 +25,13 @@ function createProps(overrides: Partial<IdentitySectionProps> = {}): IdentitySec
     profile: PROFILE,
     avatarUrl: "/api/users/profile-1/avatar?v=2",
     displayName: "Ada Lovelace",
-    githubUsername: "",
+    gitCoauthorEnabled: false,
     busy: null,
     error: null,
     onDisplayNameInput: vi.fn(),
     onSaveDisplayName: vi.fn(),
     onAvatarSelect: vi.fn(),
-    onGitHubUsernameInput: vi.fn(),
-    onSaveGitHubIdentity: vi.fn(),
-    onClearGitHubIdentity: vi.fn(),
+    onGitCoauthorChange: vi.fn(),
     ...overrides,
   };
 }
@@ -63,7 +61,13 @@ describe("renderIdentitySection", () => {
       [...container.querySelectorAll(".settings-row__title")].map((node) =>
         node.textContent?.trim(),
       ),
-    ).toEqual(["Avatar", "Display name", "Linked emails", "GitHub"]);
+    ).toEqual([
+      "Avatar",
+      "Display name",
+      "Linked emails",
+      "GitHub account",
+      "Git co-author credit",
+    ]);
     expect(container.textContent).toContain("ada@example.test, ada@work.test");
   });
 
@@ -130,15 +134,13 @@ describe("renderIdentitySection", () => {
     expect(onAvatarSelect).toHaveBeenCalledWith(file);
   });
 
-  it("links, changes, and disconnects the public GitHub identity", () => {
-    const onGitHubUsernameInput = vi.fn();
-    const onSaveGitHubIdentity = vi.fn();
-    const onClearGitHubIdentity = vi.fn();
+  it("shows verified GitHub identity and explicit co-author credit", () => {
+    const onGitCoauthorChange = vi.fn();
     const container = document.createElement("div");
     render(
       renderIdentitySection(
         createProps({
-          githubUsername: "octocat",
+          gitCoauthorEnabled: true,
           profile: {
             ...PROFILE,
             githubIdentity: {
@@ -147,9 +149,7 @@ describe("renderIdentitySection", () => {
               avatarUrl: "https://avatars.githubusercontent.com/u/583231?v=4",
             },
           },
-          onGitHubUsernameInput,
-          onSaveGitHubIdentity,
-          onClearGitHubIdentity,
+          onGitCoauthorChange,
         }),
       ),
       container,
@@ -162,47 +162,31 @@ describe("renderIdentitySection", () => {
     expect(account?.querySelector("img")?.src).toBe(
       "https://avatars.githubusercontent.com/u/583231?v=4",
     );
-    const input = container.querySelector<HTMLInputElement>(".identity-github-form input");
-    input!.value = "octo-renamed";
-    input!.dispatchEvent(new Event("input", { bubbles: true }));
-    container
-      .querySelector<HTMLFormElement>(".identity-github-form")
-      ?.dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
-    [...container.querySelectorAll<HTMLButtonElement>("button")]
-      .find((button) => button.textContent?.trim() === "Disconnect")
-      ?.click();
-
-    expect(onGitHubUsernameInput).toHaveBeenCalledWith("octo-renamed");
-    expect(onSaveGitHubIdentity).toHaveBeenCalledOnce();
-    expect(onClearGitHubIdentity).toHaveBeenCalledOnce();
-    expect(container.textContent).toContain("public GitHub co-author credit");
-    expect(container.textContent).toContain("never a private email");
-    expect(container.textContent).toContain("account you control");
+    expect(container.querySelector(".identity-github-form")).toBeNull();
+    expect(container.textContent).toContain("Verified from your GitHub-backed sign-in");
+    expect(container.textContent).not.toContain("Disconnect");
+    expect(container.textContent).toContain("public GitHub noreply address");
+    expect(container.textContent).toContain("future commits only");
+    const toggle = container.querySelector<HTMLElement & { checked: boolean }>("wa-switch");
+    expect(toggle?.checked).toBe(true);
+    expect(toggle?.hasAttribute("disabled")).toBe(false);
+    toggle!.checked = false;
+    toggle?.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(onGitCoauthorChange).toHaveBeenCalledWith(false);
   });
 
-  it("disables relinking an unchanged canonical GitHub login", () => {
+  it("explains unavailable GitHub verification and disables co-author credit", () => {
     const container = document.createElement("div");
-    render(
-      renderIdentitySection(
-        createProps({
-          githubUsername: " OctoCat ",
-          profile: {
-            ...PROFILE,
-            githubIdentity: {
-              login: "octocat",
-              profileUrl: "https://github.com/octocat",
-              avatarUrl: "https://avatars.githubusercontent.com/u/583231?v=4",
-            },
-          },
-        }),
-      ),
-      container,
-    );
+    render(renderIdentitySection(createProps()), container);
 
-    expect(
-      container.querySelector<HTMLButtonElement>('.identity-github-form button[type="submit"]')
-        ?.disabled,
-    ).toBe(true);
+    expect(container.querySelector(".settings-account")).toBeNull();
+    expect(container.textContent).toContain("Unavailable");
+    expect(container.textContent).toContain("GitHub-backed sign-in");
+    expect(container.textContent).toContain("Refresh to retry");
+    expect(container.querySelector(".identity-github-form")).toBeNull();
+    const toggle = container.querySelector<HTMLElement & { checked: boolean }>("wa-switch");
+    expect(toggle?.checked).toBe(false);
+    expect(toggle?.hasAttribute("disabled")).toBe(true);
   });
 
   it("reports mutation errors without inventing another settings surface", () => {

--- a/ui/src/pages/profile/identity-section.ts
+++ b/ui/src/pages/profile/identity-section.ts
@@ -3,6 +3,8 @@ import type { UserProfile } from "../../../../packages/gateway-protocol/src/inde
 import {
   renderSettingsRow,
   renderSettingsSection,
+  renderSettingsStatus,
+  renderSettingsToggleRow,
   renderSettingsValue,
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
@@ -15,15 +17,13 @@ type IdentitySectionProps = {
   profile: UserProfile;
   avatarUrl: string | null;
   displayName: string;
-  githubUsername: string;
-  busy: "display-name" | "avatar" | "github" | "loading" | null;
+  gitCoauthorEnabled: boolean;
+  busy: "display-name" | "avatar" | "git-coauthor" | "loading" | null;
   error: string | null;
   onDisplayNameInput: (value: string) => void;
   onSaveDisplayName: () => void;
   onAvatarSelect: (file: File) => void;
-  onGitHubUsernameInput: (value: string) => void;
-  onSaveGitHubIdentity: () => void;
-  onClearGitHubIdentity: () => void;
+  onGitCoauthorChange: (enabled: boolean) => void;
 };
 
 function avatarViewer(profile: UserProfile, avatarUrl: string | null): PresenceViewer {
@@ -41,8 +41,6 @@ export function renderIdentitySection(props: IdentitySectionProps) {
   const nameChanged = props.displayName.trim() !== savedName;
   const emails = props.profile.emails.join(", ");
   const githubIdentity = props.profile.githubIdentity;
-  const githubLoginChanged =
-    props.githubUsername.trim().toLowerCase() !== (githubIdentity?.login.toLowerCase() ?? "");
   return html`<div id=${PROFILE_SETTINGS_TARGET_IDS.identity}>
     ${renderSettingsSection(
       {
@@ -118,74 +116,41 @@ export function renderIdentitySection(props: IdentitySectionProps) {
           control: emails ? renderSettingsValue(emails) : nothing,
         })}
         ${renderSettingsRow({
-          title: t("profilePage.identity.github"),
-          description: t("profilePage.identity.githubDescription"),
-          control: html`
-            <div class="identity-github-control">
-              ${githubIdentity
-                ? html`<a
-                    class="settings-account"
-                    href=${githubIdentity.profileUrl}
-                    target=${EXTERNAL_LINK_TARGET}
-                    rel=${buildExternalLinkRel()}
-                  >
-                    <img class="settings-account__avatar" src=${githubIdentity.avatarUrl} alt="" />
-                    <span class="settings-row__value settings-row__value--mono"
-                      >@${githubIdentity.login}</span
-                    >
-                  </a>`
-                : nothing}
-              <form
-                class="identity-github-form"
-                @submit=${(event: SubmitEvent) => {
-                  event.preventDefault();
-                  props.onSaveGitHubIdentity();
-                }}
-              >
-                <input
-                  class="settings-input"
-                  type="text"
-                  maxlength="39"
-                  autocomplete="off"
-                  spellcheck="false"
-                  aria-label=${t("profilePage.identity.githubUsername")}
-                  placeholder=${t("profilePage.identity.githubPlaceholder")}
-                  .value=${props.githubUsername}
-                  ?disabled=${props.busy !== null}
-                  @input=${(event: Event) => {
-                    if (event.currentTarget instanceof HTMLInputElement) {
-                      props.onGitHubUsernameInput(event.currentTarget.value);
-                    }
-                  }}
-                />
-                <button
-                  type="submit"
-                  class="btn btn--sm"
-                  ?disabled=${props.busy !== null ||
-                  !props.githubUsername.trim() ||
-                  !githubLoginChanged}
+          title: t("profilePage.identity.githubAccount"),
+          description: githubIdentity
+            ? t("profilePage.identity.githubAccountDescription")
+            : t("profilePage.identity.githubUnavailableDescription"),
+          control: githubIdentity
+            ? html`
+                <a
+                  class="settings-account"
+                  href=${githubIdentity.profileUrl}
+                  target=${EXTERNAL_LINK_TARGET}
+                  rel=${buildExternalLinkRel()}
                 >
-                  ${props.busy === "github"
-                    ? t("profilePage.identity.githubLinking")
-                    : githubIdentity
-                      ? t("profilePage.identity.githubChange")
-                      : t("profilePage.identity.githubLink")}
-                </button>
-                ${githubIdentity
-                  ? html`<button
-                      type="button"
-                      class="btn btn--sm"
-                      ?disabled=${props.busy !== null}
-                      @click=${props.onClearGitHubIdentity}
-                    >
-                      ${t("profilePage.identity.githubDisconnect")}
-                    </button>`
-                  : nothing}
-              </form>
-              <span class="settings-row__desc">${t("profilePage.identity.githubPrivacy")}</span>
-              <span class="settings-row__desc">${t("profilePage.identity.githubOwnership")}</span>
-            </div>
-          `,
+                  <img class="settings-account__avatar" src=${githubIdentity.avatarUrl} alt="" />
+                  <span class="settings-row__value settings-row__value--mono"
+                    >@${githubIdentity.login}</span
+                  >
+                </a>
+                ${renderSettingsStatus({
+                  kind: "ok",
+                  label: t("profilePage.identity.githubVerified"),
+                })}
+              `
+            : renderSettingsStatus({
+                kind: "muted",
+                label: t("profilePage.identity.githubUnavailable"),
+              }),
+        })}
+        ${renderSettingsToggleRow({
+          title: t("profilePage.identity.gitCoauthor"),
+          description: githubIdentity
+            ? t("profilePage.identity.gitCoauthorDescription")
+            : t("profilePage.identity.gitCoauthorUnavailable"),
+          checked: Boolean(githubIdentity && props.gitCoauthorEnabled),
+          disabled: props.busy !== null || !githubIdentity,
+          onChange: props.onGitCoauthorChange,
         })}
         ${props.error
           ? html`<div class="settings-row identity-error" role="alert">

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { GIT_COAUTHOR_PREFERENCE_KEY } from "../../../../packages/gateway-protocol/src/index.ts";
 import type { UserProfile } from "../../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { RouteId } from "../../app-route-paths.ts";
@@ -234,6 +235,65 @@ it("renders identity before a Usage statistics link without requesting usage dat
 
   usageRow?.click();
   expect(harness.context.navigate).toHaveBeenCalledWith("usage");
+});
+
+it("loads and updates co-author consent separately from verified GitHub identity", async () => {
+  const profile: UserProfile = {
+    id: "profile-1",
+    displayName: "Ada",
+    avatarMime: null,
+    mergedInto: null,
+    createdAt: 1,
+    updatedAt: 2,
+    emails: [],
+    githubIdentity: {
+      login: "octocat",
+      profileUrl: "https://github.com/octocat",
+      avatarUrl: "https://avatars.githubusercontent.com/u/583231?v=4",
+    },
+    hasAvatar: false,
+  };
+  const request = vi.fn(async (method: string, params?: unknown) => {
+    if (method === "users.self") {
+      return { profile };
+    }
+    if (method === "users.prefs.get") {
+      expect(params).toEqual({ keys: [GIT_COAUTHOR_PREFERENCE_KEY] });
+      return { status: "ok", entries: { [GIT_COAUTHOR_PREFERENCE_KEY]: "not-a-boolean" } };
+    }
+    if (method === "users.prefs.set") {
+      expect(params).toEqual({ entries: { [GIT_COAUTHOR_PREFERENCE_KEY]: true } });
+      return { status: "ok" };
+    }
+    throw new Error(`unexpected method: ${method}`);
+  });
+  const harness = createConnectedContext(request as GatewayBrowserClient["request"], {
+    id: profile.id,
+    name: profile.displayName ?? undefined,
+  });
+  const provider = createApplicationContextProvider(harness.context);
+  const page = document.createElement(PROFILE_PAGE_TEST_TAG) as ProfilePageElement;
+  provider.append(page);
+  document.body.append(provider);
+
+  await waitForFast(() => expect(page.querySelector(".settings-account")).not.toBeNull());
+  expect(request.mock.calls.map(([method]) => method)).toEqual(["users.self", "users.prefs.get"]);
+  expect(page.querySelector(".identity-github-form")).toBeNull();
+  const toggle = page.querySelector<HTMLElement & { checked: boolean }>("wa-switch");
+  expect(toggle?.checked).toBe(false);
+
+  toggle!.checked = true;
+  toggle?.dispatchEvent(new Event("change", { bubbles: true }));
+
+  await waitForFast(() =>
+    expect(request.mock.calls.filter(([method]) => method === "users.prefs.set")).toHaveLength(1),
+  );
+  await waitForFast(() => expect(toggle?.checked).toBe(true));
+  expect(request.mock.calls.map(([method]) => method)).toEqual([
+    "users.self",
+    "users.prefs.get",
+    "users.prefs.set",
+  ]);
 });
 
 it("renders a write-access note without calling users.self for read-only viewers", async () => {

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -3,12 +3,13 @@ import { html, nothing } from "lit";
 import { state } from "lit/decorators.js";
 import type {
   UserProfile,
-  UsersClearGitHubIdentityResult,
+  UsersPrefsGetResult,
+  UsersPrefsSetResult,
   UsersSelfResult,
   UsersSetAvatarResult,
   UsersSetDisplayNameResult,
-  UsersSetGitHubIdentityResult,
 } from "../../../../packages/gateway-protocol/src/index.ts";
+import { GIT_COAUTHOR_PREFERENCE_KEY } from "../../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import {
@@ -53,9 +54,9 @@ export class ProfilePage extends OpenClawLightDomElement {
   @state() private selfUser: AuthenticatedUser | null = null;
   @state() private ownProfile: UserProfile | null = null;
   @state() private displayName = "";
-  @state() private githubUsername = "";
+  @state() private gitCoauthorEnabled = false;
   @state() private identityLoading = false;
-  @state() private identityBusy: "display-name" | "avatar" | "github" | null = null;
+  @state() private identityBusy: "display-name" | "avatar" | "git-coauthor" | null = null;
   @state() private identityError: string | null = null;
   @state() private failedHeroAvatarUrl: string | null = null;
 
@@ -138,7 +139,7 @@ export class ProfilePage extends OpenClawLightDomElement {
       this.identityRequestId += 1;
       this.ownProfile = null;
       this.displayName = "";
-      this.githubUsername = "";
+      this.gitCoauthorEnabled = false;
       this.identityLoading = false;
       this.identityBusy = null;
       this.identityError = null;
@@ -166,12 +167,8 @@ export class ProfilePage extends OpenClawLightDomElement {
     const requestId = ++this.identityRequestId;
     const currentProfile = this.ownProfile;
     const displayNameDraft = this.displayName;
-    const githubUsernameDraft = this.githubUsername;
     const hasUnsavedDisplayName =
       currentProfile !== null && displayNameDraft.trim() !== (currentProfile.displayName ?? "");
-    const hasUnsavedGitHubUsername =
-      currentProfile !== null &&
-      githubUsernameDraft.trim() !== (currentProfile.githubIdentity?.login ?? "");
     this.identityLoading = true;
     this.identityError = null;
     try {
@@ -185,9 +182,17 @@ export class ProfilePage extends OpenClawLightDomElement {
       }
       this.ownProfile = profile;
       this.displayName = hasUnsavedDisplayName ? displayNameDraft : (profile.displayName ?? "");
-      this.githubUsername = hasUnsavedGitHubUsername
-        ? githubUsernameDraft
-        : (profile.githubIdentity?.login ?? "");
+      this.gitCoauthorEnabled = false;
+      if (profile.githubIdentity) {
+        const preferences = await client.request<UsersPrefsGetResult>("users.prefs.get", {
+          keys: [GIT_COAUTHOR_PREFERENCE_KEY],
+        });
+        if (requestId !== this.identityRequestId) {
+          return;
+        }
+        this.gitCoauthorEnabled =
+          preferences.status === "ok" && preferences.entries[GIT_COAUTHOR_PREFERENCE_KEY] === true;
+      }
     } catch (error) {
       if (requestId === this.identityRequestId) {
         this.identityError = toIdentityErrorMessage(error);
@@ -202,7 +207,6 @@ export class ProfilePage extends OpenClawLightDomElement {
   private applyOwnProfile(profile: UserProfile) {
     this.ownProfile = profile;
     this.displayName = profile.displayName ?? "";
-    this.githubUsername = profile.githubIdentity?.login ?? "";
   }
 
   private async saveDisplayName() {
@@ -306,61 +310,38 @@ export class ProfilePage extends OpenClawLightDomElement {
     }
   }
 
-  private async saveGitHubIdentity() {
+  private async saveGitCoauthorPreference(enabled: boolean) {
+    const client = this.client;
     const profile = this.ownProfile;
-    const username = this.githubUsername.trim();
     if (
-      !profile ||
-      !username ||
-      username.toLowerCase() === profile.githubIdentity?.login.toLowerCase()
+      !client ||
+      !profile?.githubIdentity ||
+      !this.canWrite ||
+      this.identityBusy ||
+      this.identityLoading
     ) {
       return;
     }
-    await this.runGitHubIdentityMutation(
-      async (client) =>
-        (
-          await client.request<UsersSetGitHubIdentityResult>("users.setGitHubIdentity", {
-            username,
-          })
-        ).profile,
-    );
-  }
-
-  private async clearGitHubIdentity() {
-    await this.runGitHubIdentityMutation(
-      async (client) =>
-        (await client.request<UsersClearGitHubIdentityResult>("users.clearGitHubIdentity", {}))
-          .profile,
-    );
-  }
-
-  private async runGitHubIdentityMutation(
-    mutate: (client: GatewayBrowserClient) => Promise<UserProfile>,
-  ) {
-    const client = this.client;
-    const profile = this.ownProfile;
-    if (!client || !profile || this.identityBusy || this.identityLoading) {
-      return;
-    }
-    this.identityBusy = "github";
+    this.identityBusy = "git-coauthor";
     this.identityError = null;
     const identityRequestId = this.identityRequestId;
-    const displayNameDraft = this.displayName;
-    const hasUnsavedDisplayName = displayNameDraft.trim() !== (profile.displayName ?? "");
     try {
-      const nextProfile = await mutate(client);
+      const result = await client.request<UsersPrefsSetResult>("users.prefs.set", {
+        entries: { [GIT_COAUTHOR_PREFERENCE_KEY]: enabled },
+      });
       if (client !== this.client || identityRequestId !== this.identityRequestId) {
         return;
       }
-      this.ownProfile = nextProfile;
-      this.displayName = hasUnsavedDisplayName ? displayNameDraft : (nextProfile.displayName ?? "");
-      this.githubUsername = nextProfile.githubIdentity?.login ?? "";
+      if (result.status !== "ok") {
+        throw new Error(t("profilePage.identity.profileUnavailable"));
+      }
+      this.gitCoauthorEnabled = enabled;
     } catch (error) {
       if (client === this.client && identityRequestId === this.identityRequestId) {
         this.identityError = toIdentityErrorMessage(error);
       }
     } finally {
-      if (identityRequestId === this.identityRequestId && this.identityBusy === "github") {
+      if (identityRequestId === this.identityRequestId && this.identityBusy === "git-coauthor") {
         this.identityBusy = null;
       }
     }
@@ -412,7 +393,7 @@ export class ProfilePage extends OpenClawLightDomElement {
       profile: this.ownProfile,
       avatarUrl,
       displayName: this.displayName,
-      githubUsername: this.githubUsername,
+      gitCoauthorEnabled: this.gitCoauthorEnabled,
       busy: this.identityLoading ? "loading" : this.identityBusy,
       error: this.identityError,
       onDisplayNameInput: (value) => {
@@ -420,11 +401,7 @@ export class ProfilePage extends OpenClawLightDomElement {
       },
       onSaveDisplayName: () => void this.saveDisplayName(),
       onAvatarSelect: (file) => void this.saveAvatar(file),
-      onGitHubUsernameInput: (value) => {
-        this.githubUsername = value;
-      },
-      onSaveGitHubIdentity: () => void this.saveGitHubIdentity(),
-      onClearGitHubIdentity: () => void this.clearGitHubIdentity(),
+      onGitCoauthorChange: (enabled) => void this.saveGitCoauthorPreference(enabled),
     });
   }
 

--- a/ui/src/styles/profile.css
+++ b/ui/src/styles/profile.css
@@ -75,18 +75,3 @@
   align-items: center;
   gap: var(--space-3);
 }
-
-.identity-github-control {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-2);
-  min-width: 0;
-}
-
-.identity-github-form {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  flex-wrap: wrap;
-}


### PR DESCRIPTION
Related: #125827

## What Problem This Solves

People joining a shared Gateway through GitHub-backed authentication still had to type a GitHub username into Profile settings before OpenClaw could credit their work. That duplicated an identity the authentication boundary already knew, allowed a profile owner to claim any public username, and split one person into multiple durable profiles after a GitHub login rename.

## Why This Change Was Made

GitHub account identity is now produced only by authenticated ingress. The production Cloudflare Access path resolves the connection-scoped Access assertion through Cloudflare's identity endpoint, requires the returned principal and GitHub IdP to match the authenticated proxy user, then resolves the canonical login from GitHub's immutable numeric account ID. GitHub-backed Tailscale Serve follows the same canonical persistence path.

The Access assertion stays inside a connection-local closure: it is size-bounded, restricted to HTTPS `*.cloudflareaccess.com` issuers, never logged or persisted, and all network work starts after WebSocket hello. Lookup failures do not block sign-in or erase a previously verified account, and Profile refresh retries the same connection-scoped resolver.

The free-form `users.setGitHubIdentity` / `users.clearGitHubIdentity` API and all manual Link, Change, and Disconnect UI are deleted. Profile settings show the verified account read-only. Public commit attribution remains a separate default-off `git.coauthor.enabled` preference, so automatically knowing the account never silently opts someone into public `Co-authored-by` metadata.

GitHub login renames reconcile by numeric account ID through the existing durable-profile merge owner. Retired beta-era manual-attribution rows remain inert: authenticated sign-in neither reads, migrates, nor deletes them, and they grant no identity or commit credit. No SQLite schema version, Gateway protocol version, dependency, or configuration surface changed.

External contracts checked: [Cloudflare Access identity](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/application-token/) and [GitHub account lookup by ID](https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-a-user-using-their-id).

## User Impact

New and existing team members signing in through Cloudflare Access or GitHub-backed Tailscale Serve get the correct GitHub account automatically. They cannot mistype or impersonate another account, GitHub renames retain their profile history and preferences, and the profile page is simpler: one verified read-only account plus one explicit co-author-credit toggle.

Turning credit off affects future commits only. OpenClaw derives the public GitHub noreply address from the verified account and never requests or stores a private GitHub email for this feature.

## Evidence

Production LOC: +1161/-722 (net +439) | Tests/test support: +1784/-281 (net +1503) | Docs: +42/-33 (net +9). These are raw current-main diff counts; the production tally includes the intact move of the session-target policy tables from `session-sharing.ts` into their lightweight canonical input/policy owner. The remaining growth is the bounded authenticated-identity security boundary: Access assertion/issuer validation, live principal and IdP binding, immutable-ID GitHub resolution, deferred fail-closed profile attachment, connection-scoped retry/deduplication, and pre-dispatch profile authorization. The manual mutation path, duplicate Tailscale-only sync path, and steady-state beta attribution conversion were deleted. The test delta includes immutable-owner takeover and pending-profile authorization regressions plus bounded owner-level repairs for unrelated CI failures exposed by synthetic merge runs.

- Tests-first Cloudflare expectations failed on the Tailscale-only implementation: 26 intended failures showed there was no trusted-proxy identity resolver, no Access validation/binding, and no `users.self` retry path.
- Focused identity proof before rebase: 12 files across 4 Vitest shards, 442 tests passed; Profile Chromium E2E passed 7/7 with capture.
- `node scripts/check-changed.mjs -- <changed paths>`: passed the complete `core, coreTests, ui, apps, docs` plan, including typechecks, lint, dead exports, database-first, schema-version, import-cycle, native, and i18n guards.
- `pnpm build`: passed in 16m35s, including Gateway packages, runtime artifacts, and the final served Control UI bundle.
- Rebased first without conflicts onto `fea2198319403415aba20798637a7dc6ffb725fe`, then through `main` at `7bc994aee83169a9acc329c2aaaf8fc9504129fa`. The only product-branch conflict was the Activity capture test; the resolution preserved current-main route scoping plus the explicit named automation/non-automation assertions. Range-diff shows the four retained commits patch-equivalent across the final rebase.
- ClawSweeper’s security review identified mutable-login takeover: after account A renamed, account B could acquire A’s old login before immutable reconciliation. The final owner now selects/creates a profile by numeric GitHub ID first, moves only the mutable alias afterward, and keeps profile state fail-closed until sync succeeds. The exact rename-plus-login-reuse and reused-email regressions failed pre-fix and now prove A’s display/avatar/preferences/history/credit remain isolated from B.
- ClawSweeper’s later P1 found a post-hello authorization window: session work could reach device or identity-less fallback ownership before detached immutable-profile sync attached. The shared pre-dispatch router now awaits the existing deduplicated sync for every profile/session-owned method before session authorization, while failed sync returns sanitized retryable `UNAVAILABLE`. Session target fields, required-target methods, and approval resolution now share one canonical classifier; parameter-dependent incognito targets are gated dynamically; direct non-router session guards also fail closed. Identity-independent bootstrap/status and ordinary independent requests remain available.
- ClawSweeper’s final P1 found that the fail-closed plugin default had no explicit opt-out for audited identity-independent reads, so a GitHub lookup outage could block `logbook.status`. `registerGatewayMethod` now carries optional `profileAccess`, defaults every plugin method to `required`, and permits `independent` only when the plugin deliberately declares it. Logbook marks only its process-wide status method independent; all journal content and mutations stay profile-required. The public loader regression failed pre-fix, the real Logbook registration and pending-profile dispatch tests pass after the repair, Plugin SDK surface/baseline checks pass, the complete core/extensions/docs changed gate passes, docs MDX passes, and a full build passes.
- The pending-profile regressions fail in three intended places on the immediately preceding implementation: `approval.resolve` dispatches before sync, an incognito `question.request` dispatches before sync, and the direct incognito guard returns `null`. The final focused suite passes 28/28, the broader profile/session authorization suite passes 92/92, and the complete `core, coreTests` changed gate passes typechecks, lint, formatting, dead-export, import-cycle, storage, and schema-version guards.
- Retired beta `github-attribution` rows are now inert: authenticated sign-in neither reads, migrates, nor deletes them, and they grant no identity or commit credit.
- Final ownership proof: 169/169 focused core tests passed in the implementation pass; independent closeout passed 146 state/resolver/users/connect/System Agent/co-author tests plus Profile Chromium E2E 7/7. Final `pnpm build` passed in 5m56s.
- Synthetic merge CI exposed two unrelated test flakes: process cleanup raced an already-exited child (`ESRCH`), and the Activity capture counted every global session instead of asserting its named automation/non-automation fixtures. Both owner tests passed once and in bounded 5-run stability loops after repair.
- Exact-head CI run [32222355931](https://github.com/openclaw/openclaw/actions/runs/32222355931) exposed a third unrelated UI E2E flake: the terminal-continuation session-menu pointer click was intercepted by a transient overlapping pane SVG under shard load. The unchanged test passed 5/5 on both this branch and current `main`; the repair activates the real button through its keyboard `Enter` path instead of forcing a pointer click. The fixed test passes 5/5, its complete changed gate passes, and fresh autoreview is clean.
- Replacement exact-head CI run [32223667069](https://github.com/openclaw/openclaw/actions/runs/32223667069) exposed a red-main test-inventory break from #126189: `extensions/codex/src/app-server/run-attempt-tools.test.ts` had no full-suite Vitest owner. Three fixes then landed concurrently and left current `main` with duplicate attempt-extra, attempt-light, and tools owners. The dedicated fix #126225 explicitly establishes attempt-light as canonical; after rebasing, this PR removes the two opportunistic duplicate claims and preserves that owner. The ownership audit passes 18/18 and the test passes 3/3.
- The next exact-head run [32224291735](https://github.com/openclaw/openclaw/actions/runs/32224291735) reproduced two additional timing bugs locally: cloud startup recovery checked its error before the session route committed (failed by run 3/10), and the sandbox CDP deadline test assumed its global timer spy intercepted the first 25 ms timeout, leaving a rejection unhandled (failed by run 6/10). The UI test now waits on the action-produced route before reading the error. The sandbox test attaches the rejection immediately and observes a real bounded stalled request without global timer replacement. Both repaired cases pass 10/10, their complete changed gate passes, and fresh autoreview is clean.
- Later exact-head runs exposed two current-main contract mismatches from the docs consolidation: the Plugin SDK subpath wording and the GCP/Hetzner setup delegation. Focused temporary repairs passed, then current `main` landed stronger equivalent fixes; the final rebase dropped both temporary commits as empty. The rebased upstream plugin-contract shard passed 18/18 and cloud-install docs test passed 1/1.
- Live authenticated proof against the real `team.openclaw.ai` Cloudflare Access session and live GitHub API, with temporary isolated `HOME` and `OPENCLAW_STATE_DIR`: Access `idp.type=github`; account ID `58493` resolved to canonical login `steipete`; a second connection-scoped sync kept the same profile and login; the Access assertion was absent from persisted files. The production Gateway and state were not touched. The Access session expired before a second live takeover probe; the final alias-reuse isolation is therefore proven by the deterministic owner-boundary regressions above, while the external Access/GitHub contract remains live-proven.
- Source-blind behavior validation: 5/5 clauses passed for manual-control removal, verified read-only account presentation, default-off public-credit toggle, unavailable/retry state, and isolated live identity persistence.
- Fresh final Codex autoreview after the pending-profile classifier/guard refinement (`--mode uncommitted`, high reasoning): TruffleHog clean; no accepted/actionable findings; patch assessed correct.
- `git diff --check`: passed.

**Before: manually claimed GitHub username, Change, and Disconnect**

![Before: manual GitHub account controls](https://github.com/user-attachments/assets/d5a899bf-404a-4d2a-a90b-bdf7a8bbcc91)

**After: verified account from sign-in with separate explicit credit**

![After: automatic verified GitHub identity and credit toggle](https://github.com/user-attachments/assets/2801abfd-2361-413d-b3e0-c479d33d9496)

AI-assisted: yes. I reviewed the authentication, persistence, merge, attribution, protocol, UI, docs, external contracts, live identity response, focused tests, full changed gate, build, behavior validation, and final autoreview. No agent transcript is included.







