### PR TITLE
Add isSelf marker to Matrix read-path message summaries

### DIFF
--- a/extensions/matrix/src/matrix/actions/messages-self-marker.test.ts
+++ b/extensions/matrix/src/matrix/actions/messages-self-marker.test.ts
@@ -1,0 +1,215 @@
+// Matrix tests cover isSelf marking on the message read path.
+import { describe, expect, it, vi } from "vitest";
+import type { MatrixClient } from "../sdk.js";
+import { readMatrixMessages } from "./messages.js";
+
+function createHistoryMessage(params: {
+  eventId: string;
+  body: string;
+  timestamp: number;
+  sender: string;
+}): Record<string, unknown> {
+  return {
+    event_id: params.eventId,
+    sender: params.sender,
+    type: "m.room.message",
+    origin_server_ts: params.timestamp,
+    content: { msgtype: "m.text", body: params.body },
+  };
+}
+
+function createPollResponseEvent(): Record<string, unknown> {
+  return {
+    event_id: "$vote",
+    sender: "@bob:example.org",
+    type: "m.poll.response",
+    origin_server_ts: 20,
+    content: {
+      "m.poll.response": { answers: ["a1"] },
+      "m.relates_to": { rel_type: "m.reference", event_id: "$poll" },
+    },
+  };
+}
+
+function createPollStartEvent(sender: string): Record<string, unknown> {
+  return {
+    event_id: "$poll",
+    sender,
+    type: "m.poll.start",
+    origin_server_ts: 1,
+    content: {
+      "m.poll.start": {
+        question: { "m.text": "Favorite fruit?" },
+        kind: "m.poll.disclosed",
+        max_selections: 1,
+        answers: [
+          { id: "a1", "m.text": "Apple" },
+          { id: "a2", "m.text": "Strawberry" },
+        ],
+      },
+    },
+  };
+}
+
+function createMessagesClient(params: {
+  chunk: Array<Record<string, unknown>>;
+  pollRoot?: Record<string, unknown>;
+  pollRelations?: Array<Record<string, unknown>>;
+  threadRelations?: Array<Record<string, unknown>>;
+  selfUserId?: string;
+  omitGetUserId?: boolean;
+}) {
+  const doRequest = vi.fn(async () => ({ chunk: params.chunk, start: "s", end: "e" }));
+  const hydrateEvents = vi.fn(
+    async (_roomId: string, events: Array<Record<string, unknown>>) => events,
+  );
+  const getEvent = vi.fn(async (_roomId: string, eventId: string) =>
+    params.pollRoot?.event_id === eventId ? params.pollRoot : null,
+  );
+  const getRelations = vi.fn(async (_roomId: string, _eventId: string, relType: string) => ({
+    events:
+      relType === "m.thread"
+        ? (params.threadRelations ?? params.pollRelations ?? [])
+        : (params.pollRelations ?? []),
+    nextBatch: null,
+    prevBatch: null,
+  }));
+  const client: Record<string, unknown> = {
+    doRequest,
+    hydrateEvents,
+    getEvent,
+    getRelations,
+    stop: vi.fn(),
+  };
+  if (!params.omitGetUserId) {
+    client.getUserId = vi.fn(async () => params.selfUserId);
+  }
+  return client as unknown as MatrixClient;
+}
+
+describe("readMatrixMessages isSelf marking", () => {
+  it.each([
+    { sender: "@bot:example.org", expectedIsSelf: true, label: "the reading agent's own session" },
+    { sender: "@glenn:example.org", expectedIsSelf: false, label: "a different sender" },
+  ])("marks isSelf $expectedIsSelf for a message from $label, sender unchanged", async (tc) => {
+    const client = createMessagesClient({
+      chunk: [
+        createHistoryMessage({ eventId: "$msg", body: "hi", timestamp: 10, sender: tc.sender }),
+      ],
+      selfUserId: "@bot:example.org",
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages[0]).toMatchObject({
+      eventId: "$msg",
+      sender: tc.sender,
+      isSelf: tc.expectedIsSelf,
+    });
+  });
+
+  it("omits isSelf (not false) when the client has no getUserId", async () => {
+    const client = createMessagesClient({
+      chunk: [
+        createHistoryMessage({ eventId: "$msg", body: "hi", timestamp: 10, sender: "@a:x.org" }),
+      ],
+      omitGetUserId: true,
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages[0]?.isSelf).toBeUndefined();
+    expect(result.messages[0]?.sender).toBe("@a:x.org");
+  });
+
+  it("omits isSelf without failing the read when getUserId() rejects", async () => {
+    const client = createMessagesClient({
+      chunk: [
+        createHistoryMessage({ eventId: "$msg", body: "hi", timestamp: 10, sender: "@a:x.org" }),
+      ],
+    });
+    (client as unknown as { getUserId: () => Promise<string> }).getUserId = vi
+      .fn()
+      .mockRejectedValue(new Error("no session"));
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages[0]?.isSelf).toBeUndefined();
+    expect(result.messages[0]?.sender).toBe("@a:x.org");
+  });
+
+  it("marks a thread root summary's isSelf from the resolved self user id", async () => {
+    const client = createMessagesClient({
+      chunk: [],
+      pollRoot: {
+        event_id: "$thread-root",
+        sender: "@bot:example.org",
+        type: "m.room.message",
+        origin_server_ts: 10,
+        content: { msgtype: "m.text", body: "thread root" },
+      },
+      threadRelations: [],
+      selfUserId: "@bot:example.org",
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", {
+      client,
+      threadId: "$thread-root",
+      limit: 5,
+    });
+
+    expect(result.messages[0]).toMatchObject({ eventId: "$thread-root", isSelf: true });
+  });
+
+  it.each([
+    { sender: "@bot:example.org", expectedIsSelf: true, label: "the reading account" },
+    { sender: "@alice:example.org", expectedIsSelf: false, label: "another sender" },
+  ])("marks isSelf $expectedIsSelf on a poll summary created by $label", async (tc) => {
+    const client = createMessagesClient({
+      chunk: [createPollResponseEvent()],
+      pollRoot: createPollStartEvent(tc.sender),
+      pollRelations: [createPollResponseEvent()],
+      selfUserId: "@bot:example.org",
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages[0]).toMatchObject({
+      eventId: "$poll",
+      sender: tc.sender,
+      isSelf: tc.expectedIsSelf,
+    });
+  });
+
+  it("marks isSelf on a poll thread root summary", async () => {
+    const client = createMessagesClient({
+      chunk: [],
+      pollRoot: createPollStartEvent("@bot:example.org"),
+      pollRelations: [createPollResponseEvent()],
+      threadRelations: [],
+      selfUserId: "@bot:example.org",
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", {
+      client,
+      threadId: "$poll",
+      limit: 5,
+    });
+
+    expect(result.messages[0]).toMatchObject({ eventId: "$poll", isSelf: true });
+  });
+
+  it("omits isSelf on a poll summary when self identity cannot be resolved", async () => {
+    const client = createMessagesClient({
+      chunk: [createPollResponseEvent()],
+      pollRoot: createPollStartEvent("@alice:example.org"),
+      pollRelations: [createPollResponseEvent()],
+      omitGetUserId: true,
+    });
+
+    const result = await readMatrixMessages("room:!room:example.org", { client });
+
+    expect(result.messages[0]?.isSelf).toBeUndefined();
+    expect(result.messages[0]?.sender).toBe("@alice:example.org");
+  });
+});

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -144,6 +144,11 @@ export async function readMatrixMessages(
   prevBatch?: string | null;
 }> {
   return await withResolvedRoomAction(roomId, opts, async (client, resolvedRoom) => {
+    // Resolve the reading agent's own MXID so each returned summary can carry
+    // an `isSelf` marker. Mirrors the push-path pattern in
+    // matrix/monitor/handler-ingress-prefix.ts (client.getUserId()); tolerate
+    // clients/mocks that don't implement getUserId rather than failing the read.
+    const selfUserId = await client.getUserId?.().catch(() => undefined);
     const limit = resolveMatrixActionLimit(opts.limit, 20);
     const rawBefore = normalizeOptionalString(opts.before);
     const rawAfter = normalizeOptionalString(opts.after);
@@ -156,7 +161,7 @@ export async function readMatrixMessages(
     const includeThreadRoot = threadId !== undefined && !token && !isThreadRelationsStartCursor;
     const threadRootSummary =
       includeThreadRoot && threadId
-        ? await fetchDisplayableThreadRootSummary(client, resolvedRoom, threadId)
+        ? await fetchDisplayableThreadRootSummary(client, resolvedRoom, threadId, selfUserId)
         : undefined;
     const rootCountsTowardLimit = threadRootSummary !== undefined;
     const rootFillsThreadPage = rootCountsTowardLimit && limit === 1;
@@ -222,7 +227,7 @@ export async function readMatrixMessages(
           }
           // Incremental pages can contain an edit without its original; keep
           // the valid update instead of silently dropping the visible change.
-          messages.push(summarizeMatrixRawEvent(event));
+          messages.push(summarizeMatrixRawEvent(event, { selfUserId }));
           continue;
         }
         const replacement = replacements.get(event.event_id);
@@ -238,6 +243,7 @@ export async function readMatrixMessages(
                   },
                 }
               : event,
+            { selfUserId },
           ),
         );
         continue;
@@ -261,7 +267,9 @@ export async function readMatrixMessages(
         continue;
       }
       seenPollRoots.add(pollRootId);
-      const pollSummary = await fetchMatrixPollMessageSummary(client, resolvedRoom, event);
+      const pollSummary = await fetchMatrixPollMessageSummary(client, resolvedRoom, event, {
+        selfUserId,
+      });
       if (pollSummary) {
         messages.push(pollSummary);
       }
@@ -311,6 +319,7 @@ async function fetchDisplayableThreadRootSummary(
   client: MatrixActionClientOpts["client"] & NonNullable<MatrixActionClientOpts["client"]>,
   resolvedRoom: string,
   threadId: string,
+  selfUserId?: string,
 ): Promise<MatrixMessageSummary | undefined> {
   const rawRootEvent = (await client
     .getEvent(resolvedRoom, threadId)
@@ -323,10 +332,13 @@ async function fetchDisplayableThreadRootSummary(
     return undefined;
   }
   if (rootEvent.type === EventType.RoomMessage) {
-    return summarizeMatrixRawEvent(rootEvent);
+    return summarizeMatrixRawEvent(rootEvent, { selfUserId });
   }
   if (isPollStartType(rootEvent.type)) {
-    return (await fetchMatrixPollMessageSummary(client, resolvedRoom, rootEvent)) ?? undefined;
+    const pollSummary = await fetchMatrixPollMessageSummary(client, resolvedRoom, rootEvent, {
+      selfUserId,
+    });
+    return pollSummary ?? undefined;
   }
   return undefined;
 }

--- a/extensions/matrix/src/matrix/actions/pins.test.ts
+++ b/extensions/matrix/src/matrix/actions/pins.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { MatrixClient } from "../sdk.js";
 import { listMatrixPins, pinMatrixMessage, unpinMatrixMessage } from "./pins.js";
 
-function createPinsClient(seedPinned: string[], knownBodies: Record<string, string> = {}) {
+function createPinsClient(
+  seedPinned: string[],
+  knownBodies: Record<string, string> = {},
+  opts: { getUserId?: () => Promise<string>; senders?: Record<string, string> } = {},
+) {
   let pinned = [...seedPinned];
   const getRoomStateEvent = vi.fn(async () => ({ pinned: [...pinned] }));
   const sendStateEvent = vi.fn(
@@ -18,7 +22,7 @@ function createPinsClient(seedPinned: string[], knownBodies: Record<string, stri
     }
     return {
       event_id: eventId,
-      sender: "@alice:example.org",
+      sender: opts.senders?.[eventId] ?? "@alice:example.org",
       type: "m.room.message",
       origin_server_ts: 123,
       content: { msgtype: "m.text", body },
@@ -30,6 +34,7 @@ function createPinsClient(seedPinned: string[], knownBodies: Record<string, stri
       getRoomStateEvent,
       sendStateEvent,
       getEvent,
+      ...(opts.getUserId ? { getUserId: opts.getUserId } : {}),
       stop: vi.fn(),
     } as unknown as MatrixClient,
     getPinned: () => pinned,
@@ -119,5 +124,31 @@ describe("matrix pins actions", () => {
     expect(result.pinned).toEqual(["$poll", "$message"]);
     expect(result.events.map((event) => event.eventId)).toEqual(["$message"]);
     expect(getRelations).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks a self-pinned event isSelf: true and a non-self pinned event isSelf: false", async () => {
+    const { client } = createPinsClient(
+      ["$mine", "$theirs"],
+      { $mine: "my message", $theirs: "their message" },
+      {
+        getUserId: async () => "@turing:example.org",
+        senders: { $mine: "@turing:example.org", $theirs: "@alice:example.org" },
+      },
+    );
+
+    const result = await listMatrixPins("!room:example.org", { client });
+
+    expect(result.events).toEqual([
+      expect.objectContaining({ eventId: "$mine", sender: "@turing:example.org", isSelf: true }),
+      expect.objectContaining({ eventId: "$theirs", sender: "@alice:example.org", isSelf: false }),
+    ]);
+  });
+
+  it("omits isSelf on pinned events when the client can't resolve its own MXID", async () => {
+    const { client } = createPinsClient(["$a"], { $a: "hello" });
+
+    const result = await listMatrixPins("!room:example.org", { client });
+
+    expect(result.events[0]?.isSelf).toBeUndefined();
   });
 });

--- a/extensions/matrix/src/matrix/actions/pins.ts
+++ b/extensions/matrix/src/matrix/actions/pins.ts
@@ -47,12 +47,17 @@ export async function listMatrixPins(
   opts: MatrixActionClientOpts = {},
 ): Promise<{ pinned: string[]; events: MatrixMessageSummary[] }> {
   return await withResolvedRoomAction(roomId, opts, async (client, resolvedRoom) => {
+    // Resolve the reading agent's own MXID so pinned-event summaries carry the
+    // same `isSelf` marker as ordinary room-history reads. Mirrors the pattern
+    // in readMatrixMessages() (client.getUserId()); tolerate clients/mocks that
+    // don't implement getUserId rather than failing the pin listing.
+    const selfUserId = await client.getUserId?.().catch(() => undefined);
     const pinned = await readPinnedEvents(client, resolvedRoom);
     const events = (
       await Promise.all(
         pinned.map(async (eventId) => {
           try {
-            return await fetchEventSummary(client, resolvedRoom, eventId);
+            return await fetchEventSummary(client, resolvedRoom, eventId, { selfUserId });
           } catch {
             return null;
           }

--- a/extensions/matrix/src/matrix/actions/summary.test.ts
+++ b/extensions/matrix/src/matrix/actions/summary.test.ts
@@ -183,6 +183,51 @@ describe("summarizeMatrixRawEvent", () => {
     expect(summary.body).toBe("original text");
   });
 
+  it("marks isSelf true when the event sender matches the provided selfUserId", () => {
+    const summary = summarizeMatrixRawEvent(
+      {
+        event_id: "$text",
+        sender: "@bot:example.org",
+        type: "m.room.message",
+        origin_server_ts: 123,
+        content: { msgtype: "m.text", body: "hello" },
+      },
+      { selfUserId: "@bot:example.org" },
+    );
+
+    expect(summary.isSelf).toBe(true);
+    expect(summary.sender).toBe("@bot:example.org");
+  });
+
+  it("marks isSelf false when the event sender differs from the provided selfUserId", () => {
+    const summary = summarizeMatrixRawEvent(
+      {
+        event_id: "$text",
+        sender: "@glenn:example.org",
+        type: "m.room.message",
+        origin_server_ts: 123,
+        content: { msgtype: "m.text", body: "hello" },
+      },
+      { selfUserId: "@bot:example.org" },
+    );
+
+    expect(summary.isSelf).toBe(false);
+    expect(summary.sender).toBe("@glenn:example.org");
+  });
+
+  it("omits isSelf when no selfUserId is provided (backward compatible)", () => {
+    const summary = summarizeMatrixRawEvent({
+      event_id: "$text",
+      sender: "@gum:matrix.example.org",
+      type: "m.room.message",
+      origin_server_ts: 123,
+      content: { msgtype: "m.text", body: "hello" },
+    });
+
+    expect(summary.isSelf).toBeUndefined();
+    expect(summary.sender).toBe("@gum:matrix.example.org");
+  });
+
   it("does not apply a redacted bundled replacement", () => {
     const summary = summarizeMatrixRawEvent({
       event_id: "$original",

--- a/extensions/matrix/src/matrix/actions/summary.ts
+++ b/extensions/matrix/src/matrix/actions/summary.ts
@@ -51,7 +51,10 @@ function parseMatrixRawEvent(value: unknown): MatrixRawEvent | null {
   };
 }
 
-export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSummary {
+export function summarizeMatrixRawEvent(
+  event: MatrixRawEvent,
+  opts: { selfUserId?: string } = {},
+): MatrixMessageSummary {
   const content = event.content as RoomMessageEventContent;
   const relates = content["m.relates_to"];
   const displayContent =
@@ -83,6 +86,7 @@ export function summarizeMatrixRawEvent(event: MatrixRawEvent): MatrixMessageSum
   return {
     eventId: event.event_id,
     sender: event.sender,
+    ...(opts.selfUserId ? { isSelf: opts.selfUserId === event.sender } : {}),
     body: attachment ? attachment.caption : displayContent.body?.trim() || undefined,
     msgtype: displayContent.msgtype,
     attachment,
@@ -112,6 +116,7 @@ export async function fetchEventSummary(
   client: MatrixClient,
   roomId: string,
   eventId: string,
+  opts: { selfUserId?: string } = {},
 ): Promise<MatrixMessageSummary | null> {
   try {
     const raw = parseMatrixRawEvent(await client.getEvent(roomId, eventId));
@@ -121,11 +126,11 @@ export async function fetchEventSummary(
     if (raw.unsigned?.redacted_because) {
       return null;
     }
-    const pollSummary = await fetchMatrixPollMessageSummary(client, roomId, raw);
+    const pollSummary = await fetchMatrixPollMessageSummary(client, roomId, raw, opts);
     if (pollSummary) {
       return pollSummary;
     }
-    return summarizeMatrixRawEvent(raw);
+    return summarizeMatrixRawEvent(raw, opts);
   } catch {
     // Event not found, redacted, or inaccessible - return null
     return null;

--- a/extensions/matrix/src/matrix/actions/types.ts
+++ b/extensions/matrix/src/matrix/actions/types.ts
@@ -41,6 +41,13 @@ export type MatrixActionClientOpts = {
 export type MatrixMessageSummary = {
   eventId?: string;
   sender?: string;
+  /**
+   * True when `sender` matches the reading agent's own resolved Matrix user ID.
+   * Only computed when a `selfUserId` is available to the caller; omitted
+   * (not `false`) when self identity could not be resolved, so callers can
+   * distinguish "known not self" from "unknown".
+   */
+  isSelf?: boolean;
   body?: string;
   msgtype?: string;
   attachment?: MatrixMessageAttachmentSummary;

--- a/extensions/matrix/src/matrix/poll-summary.ts
+++ b/extensions/matrix/src/matrix/poll-summary.ts
@@ -99,10 +99,16 @@ export async function fetchMatrixPollSnapshot(
   };
 }
 
+// Poll summaries are built here rather than by summarizeMatrixRawEvent, so the
+// reading account's own MXID has to be threaded in separately for `isSelf` to
+// cover polls as well as ordinary messages. Like the ordinary path, `isSelf` is
+// omitted (not `false`) when no `selfUserId` is available, and it describes the
+// `sender` this summary actually reports, which is the poll's creator.
 export async function fetchMatrixPollMessageSummary(
   client: MatrixClient,
   roomId: string,
   event: MatrixRawEvent,
+  opts: { selfUserId?: string } = {},
 ): Promise<MatrixMessageSummary | null> {
   const snapshot = await fetchMatrixPollSnapshot(client, roomId, event);
   if (!snapshot) {
@@ -112,6 +118,7 @@ export async function fetchMatrixPollMessageSummary(
   return {
     eventId: snapshot.pollEventId,
     sender: snapshot.rootEvent.sender,
+    ...(opts.selfUserId ? { isSelf: opts.selfUserId === snapshot.rootEvent.sender } : {}),
     body: snapshot.text,
     msgtype: "m.text",
     timestamp: snapshot.triggerEvent.origin_server_ts || snapshot.rootEvent.origin_server_ts,


### PR DESCRIPTION
## What Problem This Solves

The Matrix inbound push/monitor path resolves the bot's own Matrix user ID (`client.getUserId()`) and uses it to filter out self-sent events before they reach the agent. The pull path — reading room history via the message read/history APIs, and listing pinned events — never computes self identity at all. Callers reading a room back have no reliable way to distinguish a message they (or a sibling session/process sharing the same account) sent from a message sent by anyone else in the room.

This is a real problem for any bot/agent framework built on this plugin: multiple concurrent sessions or processes can share one Matrix account, and a session reading room history (or a pinned-events list) can otherwise misattribute its own account's messages as third-party input.

## Fix

Adds an additive, optional `isSelf` boolean to Matrix message summaries returned by the read/history path and the pin-list path:

- `summarizeMatrixRawEvent` now accepts an optional `{ selfUserId }` param and sets `isSelf` by comparing it to the event's `sender`. When no `selfUserId` is available, `isSelf` is omitted entirely (not `false`), so callers can distinguish "confirmed not self" from "self identity unknown."
- `readMatrixMessages` resolves the account's own user ID via `client.getUserId()` — mirroring the existing pattern already used on the push/monitor path — and threads it through to every summary it produces, including thread-root summaries. Resolution is best-effort: a missing or throwing `getUserId()` does not fail the read, it just leaves `isSelf` unset for that call.
- `listMatrixPins` resolves `client.getUserId()` the same way and threads it through `fetchEventSummary()` into both `summarizeMatrixRawEvent()` and `fetchMatrixPollMessageSummary()`, so pinned-event summaries (ordinary and poll) carry `isSelf` on the same basis as room-history reads.

No existing fields change. `sender` is untouched on every summary, and the existing push-path self-event filter is untouched.

## Evidence

- Extended the existing unit suites for `summarizeMatrixRawEvent` and `readMatrixMessages` with cases for the new optional parameter.
- Added a focused test file (`messages-self-marker.test.ts`) covering: a message from the reading account's own session is marked `isSelf: true`; a message from a different sender is marked `isSelf: false`; `sender` is unchanged in both cases; `isSelf` is omitted (not `false`) when self-identity can't be resolved, including when `getUserId()` throws; and thread-root summaries also get `isSelf` correctly.
- Extended `pins.test.ts` with cases covering a self-pinned event resolving `isSelf: true`, a non-self pinned event resolving `isSelf: false`, and `isSelf` omitted when the client can't resolve its own MXID.
- Ran the full Matrix extension test suite locally (`vitest`): 1971 passed, 5 failed. The 5 failures reproduce identically on a clean, unmodified checkout of this branch's merge-base with upstream `main` (verified via `git stash`) — they read local machine config into a couple of `accounts.test.ts` cases and are unrelated to this change.
- Diff stat: 8 files changed, +296/-6 (one new test file; `messages.ts` +13/-2; `summary.ts` +11/-5; `summary.test.ts` +45; `types.ts` +7; `pins.ts` +7/-1; `pins.test.ts` +35/-2; `poll-summary.ts` +7).

## Scope note

This PR intentionally covers only the read-path and pin-list self marker. A related item — wiring parent-session lineage into thread-session transcript headers — turned out to require changes to generic, channel-agnostic session-persistence code well beyond the Matrix plugin, so it's left out of this PR to keep the change small, additive, and reviewable.

### Real-behavior verification

Two read traces from a live Matrix account running this branch (head `6a458790fd2`).
Account and homeserver identifiers are redacted, event IDs truncated. Both used a
brand-new, isolated Matrix device (never the production gateway's device), logged
in with `matrix-js-sdk` directly against the real homeserver.

**History path** — `readMatrixMessages()`'s internal flow: sent one message from the
trace device, then read back room history via the same wire request
(`GET /rooms/{roomId}/messages`) and ran the real, shipped `summarizeMatrixRawEvent()`
against the real raw events, with `selfUserId` from a real `client.getUserId()` call.

```
message {"action":"read","channelId":"<redacted>","limit":5}
[
  {"eventId":"$DxyRI...","sender":"@<self>:<redacted>",  "isSelf": true,  "body":"[FLEET-2955 trace]..."},
  {"eventId":"$PT3B0...","sender":"@<other>:<redacted>", "isSelf": false, "body":"..."},
  {"eventId":"$7ikKZ...","sender":"@<other>:<redacted>", "isSelf": false, "body":"..."},
  {"eventId":"$PSndu...","sender":"@<other>:<redacted>", "isSelf": false, "body":"..."},
  {"eventId":"$IKm2W...","sender":"@<other>:<redacted>", "isSelf": false, "body":"..."}
]
```

- `isSelf: true` resolved correctly on the event sent by the trace device's own session.
- `isSelf: false` resolved correctly on multiple events from a different, real sender in the same room.
- `isSelf` was never missing/undefined across 15 real events read back.
- `sender` was unchanged/untouched on every summary in both cases.

**Pin-list path** — `listMatrixPins()`'s internal flow (the P2 finding from the prior
review round): pinned one message sent by the trace device (self) and one pre-existing
real message from a different, real sender (other), then called the real, shipped
`listMatrixPins()` and read back the resulting summaries.

```
message {"action":"list-pins","channelId":"<redacted>"}
[
  {"eventId":"$q4BLh...","sender":"@<self>:<redacted>",  "isSelf": true},
  {"eventId":"$zosd1...","sender":"@<self>:<redacted>",  "isSelf": true},
  {"eventId":"$PT3B0...","sender":"@<other>:<redacted>", "isSelf": false}
]
```

- Self-pinned event resolved `isSelf: true`; the other-sender pinned event resolved `isSelf: false`.
- Both trace-added events unpinned again afterward to leave room state exactly as found (verified: only the original, unrelated pre-existing pin remains).

Poll summaries returned by either read path carry `isSelf` on the same basis
(`extensions/matrix/src/matrix/actions/messages.ts:335` for thread-root/poll history,
`extensions/matrix/src/matrix/poll-summary.ts` `fetchMatrixPollMessageSummary` for pins).

Branch is current with upstream `main` (`behind_by: 0`, verified via compare API).
