### PR TITLE
fix(cua-computer): resolve the ESM-only driver SDK during artifact verification

### DIFF
--- a/extensions/cua-computer/src/driver-artifacts.test.ts
+++ b/extensions/cua-computer/src/driver-artifacts.test.ts
@@ -141,3 +141,20 @@ describe("CUA Driver artifact verification", () => {
     expect(result.ok ? "" : result.diagnostic).toContain("glibc-based Linux");
   });
 });
+
+describe("verifyInstalledCuaDriverArtifacts (real resolution)", () => {
+  // Regression: the CUA Driver SDK is ESM-only, so require-condition resolution
+  // threw PATH_NOT_EXPORTED and every real install reported
+  // COMPUTER_DRIVER_PACKAGE_MISSING even with the packages present.
+  it("resolves the installed SDK package through import conditions", async () => {
+    const { verifyInstalledCuaDriverArtifacts } = await import("./driver-artifacts.js");
+    const result = verifyInstalledCuaDriverArtifacts();
+    if (process.platform === "linux" || process.platform === "win32") {
+      expect(result).toMatchObject({ ok: true, applicable: true });
+    } else if (!result.ok) {
+      // Other hosts are out of the fulfiller's scope but must never report a
+      // missing package for an installed SDK.
+      expect(result.code).not.toBe("COMPUTER_DRIVER_PACKAGE_MISSING");
+    }
+  });
+});

--- a/extensions/cua-computer/src/driver-artifacts.ts
+++ b/extensions/cua-computer/src/driver-artifacts.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import pluginManifest from "../package.json" with { type: "json" };
 import {
   inspectCuaDriverArtifacts,
@@ -9,14 +10,27 @@ import {
 
 const requireFromPlugin = createRequire(import.meta.url);
 
+function resolvePackageEntry(packageName: string): string | undefined {
+  try {
+    return requireFromPlugin.resolve(packageName);
+  } catch {}
+  // The CUA Driver SDK is ESM-only: its exports map carries only the "import"
+  // condition, so require-condition resolution throws PATH_NOT_EXPORTED even
+  // when the package is installed. Resolve with import conditions before
+  // concluding the package is missing.
+  try {
+    return fileURLToPath(import.meta.resolve(packageName));
+  } catch {
+    return undefined;
+  }
+}
+
 function resolvePackageJson(packageName: string): string | undefined {
   try {
     return requireFromPlugin.resolve(`${packageName}/package.json`);
   } catch {}
-  let entry: string;
-  try {
-    entry = requireFromPlugin.resolve(packageName);
-  } catch {
+  const entry = resolvePackageEntry(packageName);
+  if (!entry) {
     return undefined;
   }
   let current = path.dirname(entry);


### PR DESCRIPTION
## What Problem This Solves

Driver artifact verification on Windows/Linux node hosts (the gate added in #123986) fails on **every real install** with `COMPUTER_DRIVER_PACKAGE_MISSING: @trycua/cua-driver 0.19.3 is not installed` even when the SDK and its native platform package are correctly installed. The `cua-computer` fulfiller is therefore unusable on real node hosts: `plugins enable` warns and `computer.act` registration fails.

## Why This Change Was Made

`@trycua/cua-driver` is ESM-only — its `exports` map carries only the `import` condition (plus `types`), so both `require.resolve("@trycua/cua-driver/package.json")` and the bare `require.resolve("@trycua/cua-driver")` fallback in `resolvePackageJson` throw `ERR_PACKAGE_PATH_NOT_EXPORTED`. The existing unit tests inject `resolvePackageJson`, so the mock-backed suite never exercised the real resolution and the defect shipped. This adds an `import.meta.resolve` fallback (import conditions) before concluding the package is missing; native platform packages keep resolving through require.

## User Impact

Windows/Linux operators can actually enable the experimental `cua-computer` fulfiller: verification passes on a correct install, and `computer.act` registers.

## Evidence

- Reproduced live: fresh Ubuntu 26.04 node host (dev-channel checkout, pnpm-installed workspace with `@trycua/cua-driver` + `@trycua/cua-driver-linux-arm64-gnu` present) → `plugins enable cua-computer` emitted `COMPUTER_DRIVER_PACKAGE_MISSING`; `require.resolve('@trycua/cua-driver')` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` (SDK `exports`: `{".": {"types": ..., "import": ...}}`, no `require`/`default` condition).
- With this fix applied to that checkout and rebuilt, the same guest passed verification, registered `computer.act`, paired with a live gateway, and completed an end-to-end computer-use challenge (agent screenshot → keyboard → terminal command; file evidence verified out-of-band).
- New regression test runs the REAL `verifyInstalledCuaDriverArtifacts()` against installed workspace packages: on Linux/Windows it must report `ok: true, applicable: true` (fails pre-fix with `COMPUTER_DRIVER_PACKAGE_MISSING`); other hosts assert the package is never reported missing.
- `node scripts/run-vitest.mjs extensions/cua-computer/src/driver-artifacts.test.ts` → 6 passed; `node scripts/check-changed.mjs` → all gates green.
