### PR TITLE
fix(agents): deliver subagent completions after parent turns end

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -1894,6 +1894,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       getRuntimeConfig: () => ({}) as never,
     });
 
+    const ownerContext = { owner: "gateway-a" } as never;
+    const resolveGatewayContext = () => ownerContext;
     const result = await deliverSubagentAnnouncement({
       requesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
       targetRequesterSessionKey: "agent:main:slack:channel:C123:thread:171.222",
@@ -1912,6 +1914,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expectsCompletionMessage: true,
       bestEffortDeliver: true,
       directIdempotencyKey: "announce-local-dispatch",
+      resolveGatewayContext,
     });
 
     expectDeliveryPath(result, "direct");
@@ -1936,10 +1939,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
         idempotencyKey: "announce-local-dispatch",
       },
       timeoutMs: 120_000,
+      resolveGatewayContext,
     });
-    // Instance-bound dispatch owns context resolution, so the caller's resolver
-    // is deliberately not forwarded; asserting it here would only prove the mock.
-    expect(dispatchOptions).not.toHaveProperty("resolveGatewayContext");
   });
 
   it("does not dispatch child-derived completion after source lifecycle ownership changes", async () => {

--- a/src/agents/subagents/announce/subagent-announce-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.ts
@@ -99,6 +99,7 @@ export async function deliverSubagentAnnouncement(params: {
   directIdempotencyKey: string;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   signal?: AbortSignal;
+  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<SubagentAnnounceDeliveryResult> {
   const sourceOwnerChanged = () => params.isSourceSessionEffectsAllowed?.() === false;
   if (sourceOwnerChanged()) {
@@ -258,6 +259,7 @@ export async function deliverSubagentAnnouncement(params: {
         onDeliveryResult: params.onDeliveryResult,
         signal: params.signal,
         bestEffortDeliver: params.bestEffortDeliver,
+        resolveGatewayContext: params.resolveGatewayContext,
       });
     },
   });

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -68,14 +68,12 @@ import {
 } from "./subagent-announce-origin.js";
 import { resolveRequesterStoreKey } from "./subagent-requester-store-key.js";
 
-// No resolveGatewayContext: this dispatch is bound to the Gateway instance,
-// which supplies its own context. The instance runtime forwards a fixed option
-// allowlist, so a caller-supplied resolver here would be silently ignored.
 async function runAnnounceAgentCall(params: {
   agentParams: Record<string, unknown>;
   delegatedToolPolicyHandoff?: SubagentCompletionToolHandoffRegistration;
   expectFinal?: boolean;
   timeoutMs?: number;
+  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<unknown> {
   return await dispatchSubagentAnnounceAgent(params.agentParams, {
     expectFinal: params.expectFinal,
@@ -84,6 +82,7 @@ async function runAnnounceAgentCall(params: {
     ),
     delegatedToolPolicyHandoff: params.delegatedToolPolicyHandoff,
     timeoutMs: params.timeoutMs,
+    resolveGatewayContext: params.resolveGatewayContext,
   });
 }
 
@@ -108,6 +107,7 @@ export async function sendSubagentAnnounceDirectly(params: {
   requesterIsSubagent: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   signal?: AbortSignal;
+  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<SubagentAnnounceDeliveryResult> {
   if (params.signal?.aborted) {
     return {
@@ -372,6 +372,7 @@ export async function sendSubagentAnnounceDirectly(params: {
                 : undefined,
             expectFinal: true,
             timeoutMs: announceTimeoutMs,
+            resolveGatewayContext: params.resolveGatewayContext,
           });
         },
       });

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -7,6 +7,7 @@
 import { SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { getRuntimeConfig } from "../../../config/config.js";
 import { logWarn } from "../../../logger.js";
+import { getSharedGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import { isCronSessionKey } from "../../../sessions/session-key-utils.js";
 import {
   type DeliveryContext,
@@ -451,6 +452,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
           attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
         ),
         signal: params.signal,
+        resolveGatewayContext: getSharedGatewayContextResolver(settledBatch),
       });
     } catch (error) {
       // A transport exception can arrive after gateway admission. Replay the

--- a/src/agents/subagents/announce/subagent-announce.ts
+++ b/src/agents/subagents/announce/subagent-announce.ts
@@ -193,6 +193,7 @@ export async function runSubagentAnnounceFlow(params: {
   bestEffortDeliver?: boolean;
   onDeliveryResult?: (delivery: SubagentAnnounceDeliveryResult) => void;
   onBeforeDeleteChildSession?: () => boolean;
+  resolveGatewayContext?: import("../../../gateway/server-methods/types.js").GatewayContextResolver;
 }): Promise<SubagentAnnounceFlowOutcome> {
   let announceOutcome: SubagentAnnounceFlowOutcome = "retryable";
   const expectsCompletionMessage = params.expectsCompletionMessage === true;
@@ -589,6 +590,7 @@ export async function runSubagentAnnounceFlow(params: {
       directIdempotencyKey,
       onDeliveryResult: reportDeliveryResult,
       signal: params.signal,
+      resolveGatewayContext: params.resolveGatewayContext,
     });
     reportDeliveryResult(delivery);
     announceOutcome = delivery.disposition ?? (delivery.delivered ? "delivered" : "retryable");

--- a/src/agents/subagents/registry/subagent-gateway-context-binding.test.ts
+++ b/src/agents/subagents/registry/subagent-gateway-context-binding.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   bindGatewayContextResolver,
   getGatewayContextResolver,
+  getSharedGatewayContextResolver,
 } from "../../../plugins/runtime/gateway-request-scope.js";
 import { createSubagentRunRecord } from "../../subagent-test-fixtures.test-helpers.js";
 
@@ -18,5 +19,18 @@ describe("subagent Gateway context binding", () => {
 
     expect(getGatewayContextResolver(successor)?.()).toBe(context);
     expect(getGatewayContextResolver(restored)).toBeUndefined();
+  });
+
+  it("refuses to select one Gateway for a mixed-owner settle batch", () => {
+    const first = createSubagentRunRecord({ runId: "run-first" });
+    const second = createSubagentRunRecord({ runId: "run-second" });
+    const firstContext = { owner: "gateway-a" } as never;
+    const secondContext = { owner: "gateway-b" } as never;
+    bindGatewayContextResolver(first, () => firstContext);
+    bindGatewayContextResolver(second, () => secondContext);
+
+    expect(getGatewayContextResolver(first)?.()).toBe(firstContext);
+    expect(getGatewayContextResolver(second)?.()).toBe(secondContext);
+    expect(getSharedGatewayContextResolver([first, second])).toBeUndefined();
   });
 });

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -1,3 +1,4 @@
+import { getGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import { defaultRuntime } from "../../../runtime.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
 import {
@@ -606,6 +607,7 @@ export const startSubagentAnnounceCleanupFlow = (
         params.persist(runId);
       }
     },
+    resolveGatewayContext: getGatewayContextResolver(entry),
   };
   runDetachedCleanupAttempt(context, {
     runId,

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -53,6 +53,15 @@ export const getGatewayContextResolver = (owner: object) => gatewayContextResolv
 
 export const clearGatewayContextResolver = (owner: object) => gatewayContextResolvers.delete(owner);
 
+export function getSharedGatewayContextResolver(
+  owners: readonly object[],
+): GatewayContextResolver | undefined {
+  const first = owners[0] ? gatewayContextResolvers.get(owners[0]) : undefined;
+  return first && owners.every((owner) => gatewayContextResolvers.get(owner) === first)
+    ? first
+    : undefined;
+}
+
 /**
  * Runs plugin gateway handlers with request-scoped context that runtime helpers can read.
  */


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.
-->

Related: #126030

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a native subagent could complete successfully after its parent turn ended, but its terminal reply would never reach the originating conversation. The detached completion retried until the task remained without a recorded delivery outcome, and the `subagent-completion-direct-fallback` QA scenario timed out after 60 seconds.

PR #126030 recorded the reproducible main-owned failure and exact private-QA invocation in its “Known main-owned failures” section.

## Why This Change Was Made

Detached completion delivery now retains the exact Gateway instance resolver captured when the subagent was registered and carries it through lifecycle cleanup, requester-settle wake, and direct announcement dispatch. A settle batch only reuses a resolver when every child belongs to that same instance; mixed-owner batches fail closed instead of guessing an active Gateway.

This restores the instance-binding design from #126062 that was accidentally disconnected by #126071 and subsequently removed as apparently unused by #126084. It does not add a global active-instance fallback, change the Gateway protocol, or change storage/config schemas.

Production LOC: +21/-3 (net +18). Tests: +18/-3 (net +15). The production growth is the ownership chain required to carry the existing exact-instance resolver from its lifecycle producer to the dispatcher.

AI-assisted: Codex. The implementation and evidence were inspected locally before publication.

## User Impact

Subagent completions that arrive after the parent turn has finished are delivered exactly once again. Visible, silent, fallback, restart-recovered, and intentionally empty completions all reach a recorded terminal outcome without leaking internal metadata or replaying old payloads after Gateway restart.

No screenshot is attached because this is channel-delivery lifecycle behavior. The repo-native QA scenario exercises the mock provider, ephemeral Gateway, real transport boundary, task ledger, restart, and QA bus end to end.

## Evidence

- Pre-fix Node 24 repro on current `origin/main`: the exact #126030 private-QA invocation failed after 60 seconds with `final bus-event kinds=[inbound-message,outbound-message]`. Gateway logs showed three rejected retries: `In-process gateway dispatch requires a gateway request scope or instance binding (method: agent)`.
- Post-fix Node 24 repro: the same profile, concurrency, and scenario passed all five verdicts (`visible`, `silent`, `fallback`, `restart`, `empty`). Each expected terminal send count was 1; all task delivery statuses were `delivered`; restart replay and unexpected-payload counts were 0; silence/internal metadata leak flags were false.
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build qaRuntime` — pass.
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH node scripts/run-vitest.mjs src/agents/subagents/announce/subagent-announce-delivery.test.ts src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts src/agents/subagents/registry/subagent-gateway-context-binding.test.ts` — pass after rebase, 3 files / 172 tests across 2 shards.
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm check:changed` — pass, including core/core-test typecheck, lint, formatting, dead-export, import-cycle, database-first, and architecture guards.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — clean; no accepted/actionable findings, patch judged correct at 0.98 confidence.
