### PR TITLE
fix(config): clone catalog metadata before defaults

### DIFF
--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -310,6 +310,56 @@ describe("applyModelDefaults catalog seeding", () => {
     expect(model.input).toEqual(["text", "image"]);
   });
 
+  it("copies frozen catalog metadata before downstream normalization", async () => {
+    const supportedReasoningEfforts = Object.freeze(["low", "high"]);
+    const compat = Object.freeze({ supportedReasoningEfforts });
+    const frozenRegistry = {
+      plugins: [
+        {
+          id: "openai",
+          modelCatalog: {
+            providers: {
+              openai: {
+                models: [
+                  Object.freeze({
+                    id: "gpt-5.6-sol",
+                    name: "GPT-5.6 Sol",
+                    reasoning: true,
+                    compat,
+                  }),
+                ],
+              },
+            },
+          },
+        },
+      ],
+      // SAFETY: minimal frozen manifest record reproducing production registry ownership.
+    } as never;
+    const { applyModelDefaults } = await import("./defaults.js");
+    const cfg = applyModelDefaults(
+      {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [{ id: "gpt-5.6-sol", name: "GPT-5.6" } as never],
+            },
+          },
+        },
+      },
+      { manifestRegistry: frozenRegistry },
+    );
+    const model = expectDefined(
+      cfg.models?.providers?.openai?.models?.[0],
+      "materialized model entry",
+    );
+
+    expect(() => {
+      model.compat!.supportedReasoningEfforts = ["low"];
+    }).not.toThrow();
+    expect(compat.supportedReasoningEfforts).toEqual(["low", "high"]);
+  });
+
   it("falls back to generic defaults when no catalog row matches", async () => {
     const { applyModelDefaults } = await import("./defaults.js");
     const cfg = applyModelDefaults(

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -206,8 +206,7 @@ function buildManifestCatalogModelLookup(
         }
       }
     }
-    const model = index.get(keyFor(providerId, modelId));
-    return model ? structuredClone(model) : undefined;
+    return structuredClone(index.get(keyFor(providerId, modelId)));
   };
 }
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -206,7 +206,8 @@ function buildManifestCatalogModelLookup(
         }
       }
     }
-    return index.get(keyFor(providerId, modelId));
+    const model = index.get(keyFor(providerId, modelId));
+    return model ? structuredClone(model) : undefined;
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Commit #126068 made configured model overrides inherit omitted metadata from plugin manifest catalogs, but the catalog lookup returned the registry's object references. Manifest registry rows are frozen, so downstream provider normalization crashed Gateway startup when it assigned `compat.supportedReasoningEfforts`. All QA Smoke profiles on current `main` failed with Gateway exit 78 and `TypeError: Cannot assign to read only property 'supportedReasoningEfforts' of object '#<Object>'`.

## Why This Change Was Made

The catalog lookup now returns a structured clone of the matched model metadata. This keeps manifest registry ownership immutable while giving config materialization its own mutable metadata tree for subsequent normalization. A regression test freezes the catalog model and nested compatibility metadata, then proves the materialized config can be normalized without mutating the catalog.

## User Impact

Gateway startup works again for configured provider model overrides that inherit metadata from frozen plugin manifest catalogs. The change preserves authored config precedence and existing catalog-seeding behavior.

## Evidence

- Pre-fix focused regression reproduced the frozen-property `TypeError`.
- `node scripts/run-vitest.mjs src/config/defaults.test.ts` — 11/11 passed.
- `node scripts/check-changed.mjs -- src/config/defaults.ts src/config/defaults.test.ts` — passed the `core, coreTests` lanes.
- `git diff --check` — passed.
- Fresh autoreview — clean, no accepted/actionable findings; correctness 0.98.
- Observed red-main failure: https://github.com/openclaw/openclaw/actions/runs/32204878040 (QA Smoke profile 1 reports Gateway exit 78 and the frozen-property error).

AI-assisted: Yes. Agent transcript: not included.

No CHANGELOG edit: this is a focused broken-main repair, and changelog updates are release-only.
