### PR TITLE
fix(slack): chunk legacy interactive text losslessly across sections

### DIFF
--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -29,6 +29,7 @@ import {
   hasSlackDataVisualizationBlock,
   SLACK_DATA_VISUALIZATION_BLOCKS_MAX,
 } from "./data-visualization.js";
+import { chunkSlackMrkdwnText } from "./format.js";
 import { renderSlackMessagePresentationChartFallbackText } from "./presentation-fallback.js";
 import {
   SLACK_ACTION_BLOCK_ELEMENTS_MAX,
@@ -259,13 +260,19 @@ export function buildSlackInteractiveBlocks(
       if (!trimmed) {
         return state;
       }
-      state.blocks.push({
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: truncateSlackText(trimmed, SLACK_SECTION_TEXT_MAX),
-        },
-      });
+      // Legacy interactive text arrives already-rendered as Slack mrkdwn, so chunk
+      // it losslessly across section blocks instead of truncating — a long prompt
+      // or explanation accompanying controls must not silently lose its tail. The
+      // 50-block message limit is enforced later by the reply renderer's segmentation.
+      for (const chunk of chunkSlackMrkdwnText(trimmed, SLACK_SECTION_TEXT_MAX)) {
+        state.blocks.push({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: chunk,
+          },
+        });
+      }
       return state;
     }
     if (block.type === "buttons") {

--- a/extensions/slack/src/reply-blocks.test.ts
+++ b/extensions/slack/src/reply-blocks.test.ts
@@ -521,6 +521,37 @@ describe("renderSlackMessagePresentationFallbackText", () => {
     });
   });
 
+  it("delivers long legacy interactive text losslessly across delivered section blocks", () => {
+    // Channel-boundary proof: a portable interactive text block longer than one
+    // Slack section must reach the send adapter as multiple ordered section
+    // blocks, not one truncated section. resolveSlackReplyBlockResolution is the
+    // compile step that turns portable interactive blocks into the native Block
+    // Kit payload Slack posts via chat.postMessage.
+    const text = "y".repeat(3100);
+    const { segments } = resolveSlackReplyBlockResolution({
+      interactive: {
+        blocks: [{ type: "text" as const, text }],
+      },
+    });
+    const sections = segments
+      .flatMap((segment) => (segment.kind === "blocks" ? segment.blocks : []))
+      .filter(
+        (block): block is { type: "section"; text: { type: string; text: string } } =>
+          typeof block === "object" &&
+          block !== null &&
+          (block as { type?: string }).type === "section",
+      );
+
+    // The full authored text is preserved in order across the delivered blocks.
+    expect(sections.map((section) => section.text.text).join("")).toBe(text);
+    // No delivered section exceeds the Slack Block Kit limit.
+    for (const section of sections) {
+      expect(section.text.text.length).toBeLessThanOrEqual(3000);
+    }
+    // Overflow was chunked into continuation sections, not collapsed into one.
+    expect(sections.length).toBeGreaterThan(1);
+  });
+
   it("subtracts exact legacy mirrors for every typed action family", () => {
     const presentation = {
       blocks: [

--- a/extensions/slack/src/send.blocks.test.ts
+++ b/extensions/slack/src/send.blocks.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createSlackSendTestClient } from "./blocks.test-helpers.js";
 import { SLACK_MESSAGE_TEXT_RECOMMENDED_LIMIT } from "./limits.js";
 import { SLACK_QUESTION_FINALIZATION_BLOCKS } from "./reply-action-ids.js";
+import { resolveSlackReplyBlockResolution } from "./reply-blocks.js";
 import {
   clearSlackThreadParticipationCache,
   hasSlackThreadParticipation,
@@ -1514,6 +1515,50 @@ describe("sendMessageSlack blocks", () => {
       }),
     ).rejects.toThrow(error);
     expect(client.chat.postMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("sendMessageSlack legacy interactive chunking at the delivery boundary", () => {
+  // Outbound delivery proof: the chunkSlackMrkdwnText repair must be visible at
+  // the Slack delivery boundary (chat.postMessage), not only at the compile
+  // step. A >3000-char legacy interactive text block is compiled to ordered
+  // section blocks, routed through sendMessageSlack's blocks path, and must
+  // arrive at chat.postMessage as multiple sections with the full text
+  // preserved — the tail is not silently dropped. Fails on pre-fix main, where
+  // truncateSlackText produced one 3000-char section and lost the rest.
+  it("delivers compiled long interactive text as multiple section blocks via chat.postMessage", async () => {
+    const text = "z".repeat(3100);
+    const { segments } = resolveSlackReplyBlockResolution({
+      interactive: { blocks: [{ type: "text" as const, text }] },
+    });
+    const blocks = segments.flatMap((segment) => (segment.kind === "blocks" ? segment.blocks : []));
+
+    const client = createSlackSendTestClient();
+    await sendMessageSlack("channel:C123", "", {
+      token: "xoxb-test",
+      cfg: SLACK_TEST_CFG,
+      client,
+      blocks: blocks as never,
+    });
+
+    const posted = postedMessage(client);
+    const sections = ((posted.blocks as unknown[]) ?? []).filter(
+      (block): block is { type: "section"; text: { type: string; text: string } } =>
+        typeof block === "object" &&
+        block !== null &&
+        (block as { type?: string }).type === "section",
+    );
+    const postedText = sections.map((section) => section.text.text).join("");
+
+    expect(client.chat.postMessage).toHaveBeenCalledTimes(1);
+    // Overflow was chunked into continuation sections, not one truncated section.
+    expect(sections.length).toBeGreaterThan(1);
+    // The full authored text is preserved in order at the delivery boundary.
+    expect(postedText).toBe(text);
+    // No delivered section exceeds the Slack Block Kit limit.
+    for (const section of sections) {
+      expect(section.text.text.length).toBeLessThanOrEqual(3000);
+    }
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/slack/src/shared-interactive.test.ts
+++ b/extensions/slack/src/shared-interactive.test.ts
@@ -76,26 +76,67 @@ describe("buildSlackInteractiveBlocks", () => {
     ]);
   });
 
+  it("chunks long interactive text across sections instead of truncating", () => {
+    const text = "y".repeat(3100);
+    const blocks = buildSlackInteractiveBlocks({
+      blocks: [{ type: "text", text }],
+    });
+    const sections = blocks.filter(
+      (block): block is { type: "section"; text: { type: "mrkdwn"; text: string } } =>
+        typeof block === "object" &&
+        block !== null &&
+        (block as { type?: string }).type === "section",
+    );
+
+    // The full authored text is preserved in order across lossless section blocks.
+    expect(sections.map((section) => section.text.text).join("")).toBe(text);
+    // No single section exceeds the Slack Block Kit limit.
+    for (const section of sections) {
+      expect(section.text.text.length).toBeLessThanOrEqual(3000);
+    }
+  });
+
   it("truncates Slack render strings to Block Kit limits", () => {
     const long = "x".repeat(120);
     const blocks = buildSlackInteractiveBlocks({
       blocks: [
-        { type: "text", text: "y".repeat(3100) },
         { type: "select", placeholder: long, options: [{ label: long, value: "valid" }] },
         { type: "buttons", buttons: [{ label: long, value: long }] },
       ],
     });
-    const section = blocks[0] as { text?: { text?: string } };
-    const selectBlock = blocks[1] as {
+    const selectBlock = blocks[0] as {
       elements?: Array<{ placeholder?: { text?: string } }>;
     };
-    const buttonBlock = blocks[2] as {
+    const buttonBlock = blocks[1] as {
       elements?: Array<{ value?: string }>;
     };
 
-    expect((section.text?.text ?? "").length).toBeLessThanOrEqual(3000);
     expect((selectBlock.elements?.[0]?.placeholder?.text ?? "").length).toBeLessThanOrEqual(75);
     expect(buttonBlock.elements?.[0]?.value).toBe(long);
+  });
+
+  it("preserves surrogate pairs when chunking long interactive text with emoji", () => {
+    // Astral characters (emoji) are encoded as a UTF-16 surrogate pair; chunking
+    // must not split a pair across two sections, which would emit a lone
+    // surrogate half that serializes to an invalid Slack payload.
+    const emoji = "\u{1F680}"; // 🚀 — one astral code point, two UTF-16 units
+    const text = emoji.repeat(1600); // 3200 UTF-16 units -> must span >1 section
+    const blocks = buildSlackInteractiveBlocks({
+      blocks: [{ type: "text", text }],
+    });
+    const sections = blocks.filter(
+      (block): block is { type: "section"; text: { type: "mrkdwn"; text: string } } =>
+        typeof block === "object" &&
+        block !== null &&
+        (block as { type?: string }).type === "section",
+    );
+
+    expect(sections.map((section) => section.text.text).join("")).toBe(text);
+    // No chunk carries a lone surrogate half.
+    for (const section of sections) {
+      expect(section.text.text).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
+      expect(section.text.text).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+    }
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Slack legacy interactive text longer than one 3,000-character Block Kit section was silently truncated instead of being emitted losslessly across additional section blocks. `buildSlackInteractiveBlocks` called `truncateSlackText(trimmed, SLACK_SECTION_TEXT_MAX)`, emitting a single section and permanently dropping every character after the first 3,000 — so a long prompt or explanation accompanying interactive controls could lose its tail with no visible signal.

Closes #126018.

## Why This Change Was Made

The violated invariant is "authored Slack section text is delivered in full." It was violated only on the legacy `interactive` text branch (`extensions/slack/src/blocks-render.ts:266`), which reduced overflow text to one truncated section. OpenClaw already ships a renderer-owned chunker, `chunkSlackMrkdwnText` (`extensions/slack/src/format.ts:463`), that splits Slack mrkdwn losslessly while protecting mrkdwn entities and code markers and never splitting UTF-16 surrogate pairs (it delegates to the shared surrogate-safe `chunkTextByBreakResolver`). Reusing it at the producer boundary lets the existing reply-renderer 50-block segmentation (`extensions/slack/src/reply-blocks.ts`) handle multi-message continuation — no new splitter, no parallel delivery path, net-neutral production change (one `push` becomes a `for…of` over the existing chunker).

`truncateSlackText` remains in use for the other render sites that have genuine hard Block Kit limits (button labels, select options/placeholders, headers), where truncation is correct rather than a data-loss bug.

### Sibling surface: the modern `presentation` renderer is NOT affected

The same `truncateSlackText(text, SLACK_SECTION_TEXT_MAX)` call appears in the modern presentation renderer (`renderSlackMessagePresentation`, `extensions/slack/src/blocks-render.ts:409` and `:417`), so I verified whether it is the same reachable defect. It is not — that truncation is defensive code behind a capability gate, never reached with overflow text:

- `canRenderSlackPresentation` (`blocks-render.ts:568`) returns `false` for any `text`/`context` presentation block whose trimmed text exceeds `SLACK_SECTION_TEXT_MAX`.
- Both callers gate on it: `renderNativePresentation` (`reply-blocks.ts:316`) returns `undefined`, and `message-action-dispatch.ts:61` branches on it. So `buildSlackPresentationBlocks` is never called with >3,000-char text.
- Overflow presentation text is routed to a lossless fallback: `appendPresentationPart` (`reply-blocks.ts:339`) → `renderMessagePresentationFallbackText` (preserves full `block.text`) → `appendTextSegment`, then compiled via `buildSlackAuthoredTextBlocks` (`reply-blocks.ts:224`) → `markdownToSlackMrkdwnChunks(text, SLACK_SECTION_TEXT_MAX)`, which chunks losslessly across section blocks (same surrogate-safe family as `chunkSlackMrkdwnText`).

The legacy `interactive` renderer has no such capability gate — it is called directly with arbitrary-length text — which is why its truncation was a real silent-data-loss path and is the one this PR repairs. Changing the presentation gate's all-or-nothing behavior (one long text block currently downgrades a whole presentation to text fallback) is a capability/API-semantics decision for the modern contract, not this legacy compat repair.

## User Impact

Slack users receiving replies through the legacy `interactive` contract no longer silently lose content when a single interactive text block exceeds 3,000 characters. The full authored text is preserved in order across valid section blocks; surrogate pairs (emoji) are never split, so the serialized Slack payload stays valid. No behavior change for blocks under the limit, and no change to the modern `presentation` API.

## Evidence

**Pre-fix reproduction (failing on current `main`):** with the production change stashed, the new regression tests fail for the intended reason — the joined section text is truncated, not the full input:

```
FAIL > chunks long interactive text across sections instead of truncating
  expected 'yyyy…' to be 'yyyy…'   // joined sections != full 3,100-char input
FAIL > preserves surrogate pairs when chunking long interactive text with emoji
  expected '🚀🚀…' to be '🚀🚀…'    // 3,200-unit emoji run truncated
Tests  2 failed | 29 passed (31)
```

**Post-fix (green):**

```
node scripts/run-vitest.mjs extensions/slack/src/shared-interactive.test.ts
Test Files  1 passed (1)
     Tests  31 passed (31)

# CS-named sibling suites (unchanged chunker + segmenter):
node scripts/run-vitest.mjs extensions/slack/src/reply-blocks.test.ts extensions/slack/src/format.test.ts
Test Files  2 passed (2)
     Tests  34 passed (34)
```

The two new regression tests assert the invariant directly:
- `chunks long interactive text across sections instead of truncating` — 3,100-char input: joined sections equal the full input, and every section ≤ 3,000.
- `preserves surrogate pairs when chunking long interactive text with emoji` — 3,200-unit emoji run (1 astral code point × 1,600): joined sections equal the full input, and no section carries a lone surrogate half.

**Boundary proof (channel-visible continuation order):** the unit tests prove continuation blocks are emitted in order and concatenate to the original text; the reply renderer's existing 50-block segmentation (`reply-blocks.test.ts`, green) owns multi-message delivery, so continuation across messages is covered by the unchanged segmenter.

**Channel-boundary proof (mock-gateway verdict):** `resolveSlackReplyBlockResolution` is the compile step that turns portable interactive blocks into the native Block Kit payload Slack posts via `chat.postMessage`. A new end-to-end test in `reply-blocks.test.ts` feeds a 3,100-char portable interactive `text` block through that compile step and asserts the delivered native section blocks:

```
node scripts/run-vitest.mjs extensions/slack/src/reply-blocks.test.ts
Test Files  1 passed (1)
     Tests  20 passed (20)   # includes "delivers long legacy interactive text
                             # losslessly across delivered section blocks"
```

The proof asserts the channel-boundary invariant directly: the joined delivered section text equals the full 3,100-char input, every delivered section ≤ 3,000 chars, and overflow produced more than one section (chunking, not truncation). This test fails on pre-fix `main` (the single delivered section is truncated to 3,000 + `…`, dropping the tail) and passes after the `chunkSlackMrkdwnText` repair — verified by restoring `origin/main`'s `blocks-render.ts` and re-running.

**Outbound delivery proof (Slack `chat.postMessage` verdict):** the compile-step proof above stops at the resolver's segment output; this adds the after-fix outbound trace the repair must survive. A new test in `send.blocks.test.ts` compiles the same 3,100-char portable interactive `text` block, routes the resulting section blocks through `sendMessageSlack`'s `blocks` path with a mock `chat.postMessage`, and asserts the *posted* payload:

```
node scripts/run-vitest.mjs extensions/slack/src/send.blocks.test.ts \
  -t "legacy interactive chunking at the delivery boundary"
Test Files  1 passed (1)
     Tests  1 passed | 50 skipped (51)
```

The posted `chat.postMessage` payload carries multiple ordered section blocks whose joined text equals the full 3,100-char input, each ≤ 3,000 chars, and more than one section (chunking, not truncation). This test fails on pre-fix `main` — `truncateSlackText` yields one 3,000-char section, so `sections.length` is `1` (not `> 1`) — verified by restoring `origin/main`'s `blocks-render.ts` and re-running; it passes after the `chunkSlackMrkdwnText` repair.

**Type/format:** `oxfmt` clean; tsgo extensions + extensions-test report no Slack errors (the only tsgo failures are pre-existing, unrelated `extensions/cua-computer` `@trycua/cua-driver` type mismatches on `main`, present in the base commit and untouched by this change).
