### PR TITLE
refactor(cli): remove stale update sidecar fixture

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -8,7 +8,6 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { Command } from "commander";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writePackageDistInventory } from "../../scripts/lib/package-dist-inventory.ts";
-import { TEST_BUNDLED_RUNTIME_SIDECAR_PATHS } from "../../test/helpers/bundled-runtime-sidecars.js";
 import type { OpenClawConfig, ConfigFileSnapshot } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
@@ -1145,7 +1144,7 @@ describe("update-cli", () => {
   const writeOpenClawPackageFixture = async (
     root: string,
     version: string,
-    options: { entrySource?: string; sidecars?: boolean; inventory?: boolean } = {},
+    options: { entrySource?: string; inventory?: boolean } = {},
   ) => {
     const entryPath = path.join(root, "dist", "index.js");
     await fs.mkdir(options.entrySource === undefined ? root : path.dirname(entryPath), {
@@ -1158,13 +1157,6 @@ describe("update-cli", () => {
     );
     if (options.entrySource !== undefined) {
       await fs.writeFile(entryPath, options.entrySource, "utf-8");
-    }
-    if (options.sidecars) {
-      for (const relativePath of TEST_BUNDLED_RUNTIME_SIDECAR_PATHS) {
-        const absolutePath = path.join(root, relativePath);
-        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-        await fs.writeFile(absolutePath, "export {};\n", "utf-8");
-      }
     }
     if (options.inventory) {
       await writePackageDistInventory(root);
@@ -4456,7 +4448,6 @@ describe("update-cli", () => {
     const pkgRoot = path.join(nodeModules, "openclaw");
     mockPackageInstallStatus(tempDir);
     await writeOpenClawPackageFixture(pkgRoot, "2026.3.23", {
-      sidecars: true,
       inventory: true,
     });
     readPackageVersion.mockResolvedValue("2026.3.23");
@@ -5548,7 +5539,6 @@ describe("update-cli", () => {
       version: "2026.4.23",
     });
     await writeOpenClawPackageFixture(pkgRoot, "2026.4.23", {
-      sidecars: true,
       inventory: true,
     });
     mockFileBackedPathExists();
@@ -5579,7 +5569,6 @@ describe("update-cli", () => {
     mockPackageInstallStatus(pkgRoot);
     mockCurrentProcessFreshDoctor();
     await writeOpenClawPackageFixture(pkgRoot, "9999.0.0", {
-      sidecars: true,
       inventory: true,
     });
 

--- a/test/helpers/bundled-runtime-sidecars.ts
+++ b/test/helpers/bundled-runtime-sidecars.ts
@@ -1,8 +1,0 @@
-// Bundled runtime sidecar paths that package/build tests expect to exist.
-
-/** Runtime sidecar files shipped with bundled channel plugins. */
-export const TEST_BUNDLED_RUNTIME_SIDECAR_PATHS = [
-  "dist/extensions/discord/runtime-api.js",
-  "dist/extensions/telegram/runtime-api.js",
-  "dist/extensions/telegram/thread-bindings-runtime.js",
-] as const;


### PR DESCRIPTION
## What Problem This Solves

The update CLI test fixture carried a single-consumer list of three bundled runtime sidecars and an optional fixture branch that only wrote those files before generating a package inventory. The three callers exercise installed-version correction, same-version refresh, and npm optional-dependency retry behavior; none removes, inspects, or asserts a sidecar, so the files were unrelated inventory filler rather than meaningful coverage.

## Why This Change Was Made

Remove the stale helper, the unused fixture option and writer loop, and the three opt-in flags while retaining each inventory fixture and every behavioral assertion. The authoritative update-verifier regression remains in `src/infra/update-runner.test.ts` under `fails global npm update when bundled runtime sidecars are missing after install`; it writes the current canonical sidecar set, removes Telegram `runtime-api`, and asserts the global-install failure. Runtime-sidecar inventory and baseline ownership remains unchanged.

## User Impact

No user-visible or runtime behavior changes. This is test-only cleanup: no docs, changelog, schema, protocol, config, dependency, lockfile, packaged-sidecar, update behavior, or operator-state changes.

## Evidence

- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/infra/update-runner.test.ts` — 315 tests passed (243 CLI, 72 update runner).
- `node scripts/check-changed.mjs -- src/cli/update-cli.test.ts test/helpers/bundled-runtime-sidecars.ts` — passed selected guards, core/test-root typechecks, core lint, and tooling lint.
- `git diff --check` — passed.
- `rg` finds no `TEST_BUNDLED_RUNTIME_SIDECAR_PATHS`, helper-path consumer, fixture `sidecars` option, or `sidecars: true` flag.
- Codex-backed autoreview (`--mode uncommitted`) — clean; no accepted/actionable findings.
- LOC: production `+0/-0`; tests `+1/-12`; test support `+0/-8` (net `-19`).

AI-assisted: implemented and validated with Codex; the final diff and retained owner-boundary coverage were reviewed directly.
