### PR TITLE
fix(tui): restore remembered global sessions

### DIFF
--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -212,12 +212,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         ${TUI_PTY_SESSION_SUBSCRIPTION_FIXTURE_SCRIPT}
 
         async sendChat(opts: Parameters<TuiBackend["sendChat"]>[0]) {
-          record("sendChat", {
-            sessionKey: opts.sessionKey,
-            message: opts.message,
-            deliver: opts.deliver,
-            thinking: opts.thinking,
-          });
+          record("sendChat", opts);
           const runId = opts.runId ?? "run-pty-fixture";
           ${TUI_PTY_RECONNECT_FIXTURE.sendChat}
           if (opts.message.startsWith("live reply dedupe proof: ")) {
@@ -510,8 +505,8 @@ export async function writeTuiPtyFixtureScript(dir: string) {
         async listSessions(opts?: Parameters<TuiBackend["listSessions"]>[0]) {
           ${TUI_PTY_STARTUP_SESSION_FIXTURE.listSessionsSetup}
           record("listSessions", {
+            ...opts,
             purpose: opts?.includeDerivedTitles ? "picker" : "refresh",
-            search: opts?.search,
           });
           ${TUI_PTY_STARTUP_SESSION_FIXTURE.listSessionsDelay}
           const sessions = enablePickerFixture
@@ -524,11 +519,14 @@ export async function writeTuiPtyFixtureScript(dir: string) {
                 },
               ]
             : [];
+          const visibleSessions = sessions.filter(
+            (session) => session.key !== "global" || opts?.includeGlobal === true,
+          );
           return {
             ts: Date.now(),
             path: "",
-            count: sessions.length,
-            sessions,
+            count: visibleSessions.length,
+            sessions: visibleSessions,
             defaults: {
               model: currentModel,
               modelProvider: "fixture-provider",

--- a/src/tui/tui-session-identity-pty.e2e.test.ts
+++ b/src/tui/tui-session-identity-pty.e2e.test.ts
@@ -15,14 +15,17 @@ const STARTUP_TIMEOUT_MS = 60_000;
 const REMEMBERED_SESSION_KEY = "agent:main:picker-target";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-async function seedRememberedSession(stateDir: string) {
+async function seedRememberedSession(
+  stateDir: string,
+  sessionKey: string = REMEMBERED_SESSION_KEY,
+) {
   await writeTuiLastSessionKey({
     scopeKey: buildTuiLastSessionScopeKey({
       connectionUrl: "pty-fixture://local",
       agentId: "main",
       sessionScope: "per-sender",
     }),
-    sessionKey: REMEMBERED_SESSION_KEY,
+    sessionKey,
     stateDir,
   });
 }
@@ -101,6 +104,47 @@ it("hides a stale approval when startup restores the remembered session", async 
     );
 
     expect(rows.join("\n")).not.toContain("workspace skill approval");
+  } finally {
+    await fixture.cleanup();
+  }
+}, 65_000);
+
+it("restores a remembered global session before startup admits the first send", async () => {
+  const stateDir = tempDirs.make("openclaw-tui-global-session-");
+  const marker = "global startup session proof";
+  await seedRememberedSession(stateDir, "global");
+  const fixture = await startTuiFixture({
+    env: {
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
+      OPENCLAW_TUI_PTY_PICKER_SESSION_KEY: "global",
+    },
+  });
+
+  try {
+    const lookup = await fixture.waitForLogEntry(
+      (entry) => entry.method === "listSessions" && objectFieldEquals(entry, "search", "global"),
+      STARTUP_TIMEOUT_MS,
+    );
+    expect(lookup.payload).toMatchObject({
+      search: "global",
+      includeGlobal: true,
+      includeUnknown: false,
+      agentId: "main",
+    });
+
+    await fixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
+    await fixture.run.write(`${marker}\r`, { delay: false });
+    await fixture.waitForLogEntry(
+      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", marker),
+      STARTUP_TIMEOUT_MS,
+    );
+
+    const sends = (await readFixtureLog(fixture.logPath)).filter(
+      (entry) => entry.method === "sendChat",
+    );
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.payload).toMatchObject({ sessionKey: "global", agentId: "main" });
   } finally {
     await fixture.cleanup();
   }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1091,7 +1091,7 @@ async function runTuiUnlocked(opts: RunTuiOptions): Promise<TuiResult> {
       .listSessions({
         limit: TUI_SESSION_LOOKUP_LIMIT,
         search: rememberedKey,
-        includeGlobal: false,
+        includeGlobal: rememberedKey === "global",
         includeUnknown: false,
         agentId: state.currentAgentId,
       })


### PR DESCRIPTION
Related: #126046

## What Problem This Solves

Fixes an issue where users who had the special `global` TUI session remembered under per-sender scope would reopen the TUI without `--session` and silently end up in `main`. The exact restore lookup excluded the global row, so even after #126046 correctly held startup sends until restore and history settled, the first admitted send still targeted the wrong session.

## Why This Change Was Made

The remembered-session owner now includes the global row only when the exact remembered key is `global`. Ordinary Ctrl+P picker and recent-session list queries continue to exclude global sessions, so this changes only the broken exact restore path and composes with #126046's existing startup admission gate.

No protocol, config, storage, dependency, changelog, or release surface changes.

## User Impact

Reopening the TUI after using the remembered global session now restores that session before startup becomes ready, so the first send is delivered to `global` instead of silently falling back to `main`. Non-global remembered sessions and the ordinary session picker behave as before.

## Evidence

Before the fix, the focused real-`runTui` fake-backend PTY regression failed 1/1 because the restore request sent `includeGlobal: false`, so the backend filtered out the remembered `global` row.

After the fix:

- exact startup/first-send PTY regression: 1/1 passed, including the post-rebase rerun on this head
- session-identity PTY file: 8/8 passed
- focused TUI units: 318/318 passed
- full PTY lane: 69/72; three unrelated rendering timeouts failed in the broad run and then passed 3/3 on exact standalone reruns. The broad lane is not represented as green.
- `check:changed`, source-blind behavior validation, and `git diff --check`: passed
- fresh autoreview: clean, no accepted/actionable findings (0.98 confidence)

The PTY test drives the real `runTui()` loop and verifies the exact restore request plus first `sendChat` session key through the fake backend. It does not prove Gateway transport, embedded backend runtime, provider behavior, session persistence, or live streaming; no real Gateway transport proof was run. No screenshot is included because the defect is the hidden backend session target rather than a rendering change, and the PTY call assertion is the relevant boundary proof.

Production LOC: +1/-1 (net 0). Test support: +7/-9 (net -2). Tests: +46/-2 (net +44).

AI-assisted. I reviewed and understand the change. No prompts, transcripts, or session logs are included.
