### PR TITLE
fix(browser): isolate startup upload cleanup runtime

### DIFF
--- a/extensions/browser/plugin-registration.node-host-laziness.test.ts
+++ b/extensions/browser/plugin-registration.node-host-laziness.test.ts
@@ -8,7 +8,7 @@ vi.mock("./register.runtime.js", () => {
   throw new Error("node-host availability must not load the broad browser runtime");
 });
 
-vi.mock("./src/browser-proxy-upload.js", () => ({
+vi.mock("./src/browser-proxy-upload-cleanup.runtime.js", () => ({
   ensureBrowserProxyUploadCleanup: cleanupMocks.ensureBrowserProxyUploadCleanup,
 }));
 

--- a/extensions/browser/plugin-registration.node-host-laziness.test.ts
+++ b/extensions/browser/plugin-registration.node-host-laziness.test.ts
@@ -1,0 +1,27 @@
+import { expect, it, vi } from "vitest";
+
+const cleanupMocks = vi.hoisted(() => ({
+  ensureBrowserProxyUploadCleanup: vi.fn(async () => undefined),
+}));
+
+vi.mock("./register.runtime.js", () => {
+  throw new Error("node-host availability must not load the broad browser runtime");
+});
+
+vi.mock("./src/browser-proxy-upload.js", () => ({
+  ensureBrowserProxyUploadCleanup: cleanupMocks.ensureBrowserProxyUploadCleanup,
+}));
+
+const { browserPluginNodeHostCommands } = await import("./plugin-registration.js");
+
+it("starts node-host upload cleanup without loading the broad browser runtime", async () => {
+  const uploadCommand = browserPluginNodeHostCommands.find(
+    (command) => command.command === "browser.proxy.upload.v1",
+  );
+
+  uploadCommand?.watchAvailability?.({ config: {}, env: {} }, vi.fn());
+
+  await vi.waitFor(() => {
+    expect(cleanupMocks.ensureBrowserProxyUploadCleanup).toHaveBeenCalledOnce();
+  });
+});

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -201,7 +201,7 @@ function createBrowserProxyNodeHostCommand(command: string): OpenClawPluginNodeH
     ...(command === BROWSER_PROXY_UPLOAD_COMMAND
       ? {
           watchAvailability: () => {
-            void loadBrowserRegistrationRuntimeModule()
+            void import("./src/browser-proxy-upload.js")
               .then(({ ensureBrowserProxyUploadCleanup }) => ensureBrowserProxyUploadCleanup())
               .catch((error: unknown) => {
                 logger.warn(`browser proxy upload cleanup startup failed: ${String(error)}`);

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -45,6 +45,9 @@ const logger = createSubsystemLogger("browser");
 const loadBrowserRegistrationRuntimeModule = createLazyRuntimeModule(
   () => import("./register.runtime.js"),
 );
+const loadBrowserUploadCleanupRuntimeModule = createLazyRuntimeModule(
+  () => import("./src/browser-proxy-upload-cleanup.runtime.js"),
+);
 
 function deriveChatTypeFromSessionKey(
   sessionKey: string | undefined,
@@ -201,7 +204,7 @@ function createBrowserProxyNodeHostCommand(command: string): OpenClawPluginNodeH
     ...(command === BROWSER_PROXY_UPLOAD_COMMAND
       ? {
           watchAvailability: () => {
-            void import("./src/browser-proxy-upload.js")
+            void loadBrowserUploadCleanupRuntimeModule()
               .then(({ ensureBrowserProxyUploadCleanup }) => ensureBrowserProxyUploadCleanup())
               .catch((error: unknown) => {
                 logger.warn(`browser proxy upload cleanup startup failed: ${String(error)}`);

--- a/extensions/browser/register.runtime.ts
+++ b/extensions/browser/register.runtime.ts
@@ -3,7 +3,6 @@
  * registration lazy-load these exports when browser runtime behavior is needed.
  */
 export { createBrowserTool } from "./src/browser-tool.js";
-export { ensureBrowserProxyUploadCleanup } from "./src/browser-proxy-upload.js";
 export { handleBrowserGatewayRequest } from "./src/gateway/browser-request.js";
 export { runBrowserProxyCommand } from "./src/node-host/invoke-browser.js";
 export { createBrowserPluginService } from "./src/plugin-service.js";

--- a/extensions/browser/src/browser-proxy-upload-cleanup.runtime.ts
+++ b/extensions/browser/src/browser-proxy-upload-cleanup.runtime.ts
@@ -1,0 +1,1 @@
+export { ensureBrowserProxyUploadCleanup } from "./browser-proxy-upload.js";


### PR DESCRIPTION
## What Problem This Solves

The managed Gateway was loading the broad Browser runtime during node-host startup, before any Browser command ran. Heap evidence showed that this retained thousands of modules, including Browser tooling and Playwright.

The trigger was the upload cleanup availability watcher added in #115291. Node-host startup invokes registered availability watchers, and this watcher loaded `register.runtime.ts` solely to restore cleanup timers for staged uploads left by a previous process. That barrel also exports the Browser tool, Gateway handler, service, and node-host command runtime.

## What Changed

Upload cleanup now has a dedicated runtime entry. The startup watcher loads only that narrow owner, while actual Browser commands continue to load the broad Browser runtime on first use.

Cleanup intentionally still starts with node-host availability: it must recover and bound staged uploads left by a previous process. The change makes only the unrelated Browser/Playwright execution graph lazy again.

Production LOC: +5/-2 (net +3). Tests: +27/-0.

## User Impact

Gateways exposing node-host Browser commands no longer load the broad Browser/Playwright runtime solely to initialize stale-upload cleanup. Upload recovery and Browser command behavior are unchanged.

## Evidence

- Original strict performance failure: [run 32182788559, job 95859561907](https://github.com/openclaw/openclaw/actions/runs/32182788559/job/95859561907).
- Managed-Gateway diagnostic: [run 32194063062, job 95894374092](https://github.com/openclaw/openclaw/actions/runs/32194063062/job/95894374092), artifact `openclaw-performance-mock-deep-profile-32194063062-1`.
- PID `17820` was verified as `openclaw-gatewa`; `/proc` recorded 1,258,908 kB RSS with 1,189,512 kB anonymous/private memory.
- Its Node report recorded main-isolate V8 committed/used memory of 725/467 MB plus a worker at 157/28 MB. The 210 MB heap snapshot attributed 43.9 MB of module source to 2,684 OpenClaw dist modules and 13.3 MB to Playwright core bundles.
- The focused regression makes broad runtime loading throw, invokes the upload availability watcher, and verifies cleanup through the dedicated runtime entry. It fails on the pre-fix implementation.
- Exact-head build artifacts and CI are green. The emitted cleanup closure is separate from the broad Browser registration runtime.
- A controlled exact-head managed-Gateway RSS comparison has not been captured; the proof establishes the corrected load topology, not a measured memory delta.
