### PR TITLE
fix(sessions): suppress keyed channel-final mirrors that duplicate the primary reply

### DIFF
--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -841,6 +841,34 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
+  it("suppresses a keyed channel-final mirror that duplicates the preceding primary reply", async () => {
+    await writeTranscriptStore();
+
+    const primary = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      message: createExactAssistantMessage({ text: "Delivered once already" }),
+    });
+    expect(primary.ok).toBe(true);
+
+    const mirror = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Delivered once already",
+      storePath: fixture.storePath(),
+      idempotencyKey: "channel-final:telegram-message-1:0",
+      deliveryMirror: { kind: "channel-final", sourceMessageId: "telegram-message-1" },
+    });
+
+    expect(mirror.ok).toBe(true);
+    if (primary.ok && mirror.ok) {
+      expect(mirror.messageId).toBe(primary.messageId);
+      const messages = (await loadFixtureMessages()).flatMap((entry) =>
+        entry.message ? [entry.message] : [],
+      );
+      expect(messages).toHaveLength(1);
+    }
+  });
+
   it("idempotently appends identified message-tool source replies", async () => {
     await writeTranscriptStore();
     const deliveryMirror = {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -869,6 +869,36 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
+  it("keeps a distinct keyed mirror separate from a marker-only historical mirror with stripped provenance", async () => {
+    await writeTranscriptStore();
+    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
+      updateMode: "none",
+      messages: [
+        {
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "Delivered once already" }],
+            openclawDeliveryMirror: { kind: "channel-final", sourceMessageId: "stripped-message" },
+          },
+        },
+      ],
+    });
+
+    const mirror = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Delivered once already",
+      storePath: fixture.storePath(),
+      idempotencyKey: "channel-final:telegram-message-2:0",
+      deliveryMirror: { kind: "channel-final", sourceMessageId: "telegram-message-2" },
+    });
+
+    expect(mirror.ok).toBe(true);
+    const messages = (await loadFixtureMessages()).flatMap((entry) =>
+      entry.message ? [entry.message] : [],
+    );
+    expect(messages).toHaveLength(2);
+  });
+
   it("idempotently appends identified message-tool source replies", async () => {
     await writeTranscriptStore();
     const deliveryMirror = {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -18,6 +18,7 @@ import {
   OPENCLAW_DELIVERY_MIRROR_MODEL,
   OPENCLAW_TRANSCRIPT_ARTIFACT_API,
   OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER,
+  isTranscriptOnlyOpenClawAssistantMessage as isMarkerAwareTranscriptArtifactMessage,
   isTranscriptOnlyOpenClawAssistantModel,
 } from "../../shared/transcript-only-openclaw-assistant.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
@@ -786,8 +787,11 @@ async function findLatestEquivalentAssistantMessageId(
     }
     // An identified (keyed) mirror only suppresses against a genuine primary
     // reply, not against another mirror row, so distinct-source keyed mirrors
-    // with identical text stay separate rows.
-    if (requirePrimaryCandidate && isRedundantDeliveryMirror(latestMessage)) {
+    // with identical text stay separate rows. Use the marker-aware check
+    // (not the plain provider/model test) because session rebuild/side-branch
+    // merges can strip a historical mirror's provider/model while leaving its
+    // openclawDeliveryMirror marker intact (#99470).
+    if (requirePrimaryCandidate && isMarkerAwareTranscriptArtifactMessage(latestMessage)) {
       return undefined;
     }
     const candidateText = latest

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -559,8 +559,6 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
       storePath,
     };
     let latestEquivalentAssistantId: string | undefined;
-    // Identified delivery mirrors, including suppressed finals, dedupe only by
-    // key so same-text markers from different source ids remain separate rows.
     const turn = await persistSessionTranscriptTurn(
       {
         sessionId: currentEntry.sessionId,
@@ -603,14 +601,19 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
                 }
               : {}),
             shouldAppend: async (appendTarget) => {
-              latestEquivalentAssistantId =
-                isRedundantDeliveryMirror(params.message) && !identifiedDeliveryMirror
-                  ? await findLatestEquivalentAssistantMessageId(
-                      appendTarget,
-                      preparedUnkeyedMessage as SessionTranscriptAssistantMessage,
-                      params.config,
-                    )
-                  : undefined;
+              // An identified (keyed) mirror only suppresses against a genuine
+              // primary reply, never against another mirror row: key-scan
+              // dedup already handles repeated deliveries of the same source,
+              // and matching two distinct-source keyed mirrors on text alone
+              // would wrongly collapse them into one.
+              latestEquivalentAssistantId = isRedundantDeliveryMirror(params.message)
+                ? await findLatestEquivalentAssistantMessageId(
+                    appendTarget,
+                    preparedUnkeyedMessage as SessionTranscriptAssistantMessage,
+                    params.config,
+                    identifiedDeliveryMirror,
+                  )
+                : undefined;
               return !latestEquivalentAssistantId;
             },
           },
@@ -698,6 +701,17 @@ function isRedundantDeliveryMirror(message: SessionTranscriptAssistantMessage): 
   );
 }
 
+function isIdentifiedDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {
+  const marker = (message as { openclawDeliveryMirror?: InternalSessionTranscriptDeliveryMirror })
+    .openclawDeliveryMirror;
+  return (
+    isRedundantDeliveryMirror(message) &&
+    (marker?.kind === "channel-final" ||
+      marker?.kind === "channel-final-suppressed" ||
+      marker?.kind === "message-tool-source-reply")
+  );
+}
+
 async function readLatestVisibleTranscriptMessage(scope: {
   agentId?: string;
   sessionId: string;
@@ -729,17 +743,6 @@ async function readLatestVisibleTranscriptMessage(scope: {
   return undefined;
 }
 
-function isIdentifiedDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {
-  const marker = (message as { openclawDeliveryMirror?: InternalSessionTranscriptDeliveryMirror })
-    .openclawDeliveryMirror;
-  return (
-    isRedundantDeliveryMirror(message) &&
-    (marker?.kind === "channel-final" ||
-      marker?.kind === "channel-final-suppressed" ||
-      marker?.kind === "message-tool-source-reply")
-  );
-}
-
 function extractAssistantMessageText(message: AgentMessage): string | null {
   if (message.role !== "assistant" || !Array.isArray(message.content)) {
     return null;
@@ -762,7 +765,8 @@ function extractAssistantMessageText(message: AgentMessage): string | null {
 async function findLatestEquivalentAssistantMessageId(
   target: SessionTranscriptTurnWriteContext,
   message: SessionTranscriptAssistantMessage,
-  config?: OpenClawConfig,
+  config: OpenClawConfig | undefined,
+  requirePrimaryCandidate: boolean,
 ): Promise<string | undefined> {
   const expectedText = extractAssistantMessageText(redactTranscriptMessage(message, config));
   if (!expectedText) {
@@ -776,8 +780,14 @@ async function findLatestEquivalentAssistantMessageId(
       ...(target.sessionKey ? { sessionKey: target.sessionKey } : {}),
       storePath: target.storePath,
     });
-    const latestMessage = latest?.message as { role?: unknown } | undefined;
+    const latestMessage = latest?.message as SessionTranscriptAssistantMessage | undefined;
     if (latestMessage?.role !== "assistant") {
+      return undefined;
+    }
+    // An identified (keyed) mirror only suppresses against a genuine primary
+    // reply, not against another mirror row, so distinct-source keyed mirrors
+    // with identical text stay separate rows.
+    if (requirePrimaryCandidate && isRedundantDeliveryMirror(latestMessage)) {
       return undefined;
     }
     const candidateText = latest

--- a/src/plugin-sdk/session-transcript-runtime.test.ts
+++ b/src/plugin-sdk/session-transcript-runtime.test.ts
@@ -480,6 +480,41 @@ describe("session transcript runtime SDK", () => {
     ).resolves.toMatchObject({ ok: false, code: "session-rebound" });
   });
 
+  it("suppresses a keyed channel-final mirror that duplicates the preceding primary reply", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "primary-then-keyed-mirror-session",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+    const primary = await appendSessionTranscriptMessageByIdentity({
+      ...scope,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Delivered once already" }],
+      },
+    });
+    if (!primary) {
+      throw new Error("expected primary reply to append");
+    }
+
+    const mirror = await appendAssistantMirrorMessageByIdentity({
+      ...scope,
+      deliveryMirror: { kind: "channel-final", sourceMessageId: "telegram-message-1" },
+      idempotencyKey: "channel-final:telegram-message-1:0",
+      text: "Delivered once already",
+    });
+
+    expect(mirror).toEqual({ ok: true, messageId: primary.messageId });
+    const assistantMessages = (await readSessionTranscriptEvents(scope)).filter((event) => {
+      const message = (event as { message?: { role?: unknown } }).message;
+      return message?.role === "assistant";
+    });
+    expect(assistantMessages).toHaveLength(1);
+  });
+
   it("dedupes unkeyed assistant mirrors against only the visible SQLite branch", async () => {
     const scope = {
       agentId: "main",

--- a/src/plugin-sdk/session-transcript-runtime.test.ts
+++ b/src/plugin-sdk/session-transcript-runtime.test.ts
@@ -515,6 +515,42 @@ describe("session transcript runtime SDK", () => {
     expect(assistantMessages).toHaveLength(1);
   });
 
+  it("keeps a distinct keyed mirror separate from a marker-only historical mirror with stripped provenance", async () => {
+    const scope = {
+      agentId: "main",
+      sessionId: "stripped-mirror-then-keyed-mirror-session",
+      sessionKey: "agent:main:main",
+      storePath,
+    };
+
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+    const historicalMirror = await appendSessionTranscriptMessageByIdentity({
+      ...scope,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Delivered once already" }],
+        openclawDeliveryMirror: { kind: "channel-final", sourceMessageId: "stripped-message" },
+      },
+    });
+    if (!historicalMirror) {
+      throw new Error("expected historical mirror to append");
+    }
+
+    const mirror = await appendAssistantMirrorMessageByIdentity({
+      ...scope,
+      deliveryMirror: { kind: "channel-final", sourceMessageId: "telegram-message-2" },
+      idempotencyKey: "channel-final:telegram-message-2:0",
+      text: "Delivered once already",
+    });
+
+    expect(mirror.ok).toBe(true);
+    const assistantMessages = (await readSessionTranscriptEvents(scope)).filter((event) => {
+      const message = (event as { message?: { role?: unknown } }).message;
+      return message?.role === "assistant";
+    });
+    expect(assistantMessages).toHaveLength(2);
+  });
+
   it("dedupes unkeyed assistant mirrors against only the visible SQLite branch", async () => {
     const scope = {
       agentId: "main",

--- a/src/plugin-sdk/session-transcript-runtime.ts
+++ b/src/plugin-sdk/session-transcript-runtime.ts
@@ -36,6 +36,7 @@ import type {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { extractAssistantPhaseText } from "../shared/chat-message-content.js";
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../shared/transcript-only-openclaw-assistant.js";
 import type { AgentMessage } from "./agent-core.js";
 import { withProjectedSessionTranscriptWriteLock } from "./session-transcript-lock-runtime.js";
 import {
@@ -510,8 +511,11 @@ function findLatestEquivalentAssistantMessageId(
     }
     // A keyed mirror only suppresses against a genuine primary reply, not
     // against another mirror row, so distinct-source keyed mirrors with
-    // identical text stay separate rows.
-    if (requirePrimaryCandidate && isDeliveryMirrorAssistantMessage(candidate)) {
+    // identical text stay separate rows. Use the marker-aware check (not the
+    // plain provider/model test) because session rebuild/side-branch merges
+    // can strip a historical mirror's provider/model while leaving its
+    // openclawDeliveryMirror marker intact (#99470).
+    if (requirePrimaryCandidate && isTranscriptOnlyOpenClawAssistantMessage(candidate)) {
       return undefined;
     }
     return extractAssistantMirrorComparableText(candidate, config) === expectedText &&

--- a/src/plugin-sdk/session-transcript-runtime.ts
+++ b/src/plugin-sdk/session-transcript-runtime.ts
@@ -315,14 +315,19 @@ export async function appendAssistantMirrorMessageByIdentity(
       sessionId: currentEntry.sessionId,
     };
     const target = await resolveSessionTranscriptRuntimeTarget(scope);
-    const latestEquivalentAssistantId =
-      !params.idempotencyKey && isDeliveryMirrorAssistantMessage(message)
-        ? findLatestEquivalentAssistantMessageId(
-            selectVisibleTranscriptEvents(await locked.readEvents()),
-            message,
-            params.config,
-          )
-        : undefined;
+    // A keyed mirror only suppresses against a genuine primary reply, never
+    // against another mirror row: key-scan dedup already handles repeated
+    // deliveries of the same source, and matching two distinct-source keyed
+    // mirrors on text alone would wrongly collapse them into one. An unkeyed
+    // mirror keeps deduping against any equivalent-text tail, mirror or not.
+    const latestEquivalentAssistantId = isDeliveryMirrorAssistantMessage(message)
+      ? findLatestEquivalentAssistantMessageId(
+          selectVisibleTranscriptEvents(await locked.readEvents()),
+          message,
+          params.config,
+          Boolean(params.idempotencyKey),
+        )
+      : undefined;
     if (latestEquivalentAssistantId) {
       return {
         ok: true,
@@ -484,6 +489,7 @@ function findLatestEquivalentAssistantMessageId(
   events: readonly SessionTranscriptEvent[],
   message: SessionTranscriptAssistantMessage,
   config: OpenClawConfig | undefined,
+  requirePrimaryCandidate: boolean,
 ): string | undefined {
   const expectedText = extractAssistantMirrorComparableText(message, config);
   if (!expectedText) {
@@ -500,6 +506,12 @@ function findLatestEquivalentAssistantMessageId(
       continue;
     }
     if (candidate.role !== "assistant") {
+      return undefined;
+    }
+    // A keyed mirror only suppresses against a genuine primary reply, not
+    // against another mirror row, so distinct-source keyed mirrors with
+    // identical text stay separate rows.
+    if (requirePrimaryCandidate && isDeliveryMirrorAssistantMessage(candidate)) {
       return undefined;
     }
     return extractAssistantMirrorComparableText(candidate, config) === expectedText &&


### PR DESCRIPTION
Closes #126090

## What Problem This Solves

Every Telegram-originated assistant turn (and any other channel routed
through `routeReplyToOriginating`) wrote a duplicate `delivery-mirror`
assistant message into the session transcript, parented to the primary
assistant reply. This corrupts the session tree (later user turns parent to
the mirror instead of the real reply), inflates transcript size, and
pollutes LLM context with duplicate assistant turns.

## Why This Change Was Made

`appendExactAssistantMessageToSessionTranscript` (`src/config/sessions/transcript.ts`)
and its plugin-sdk sibling `appendAssistantMirrorMessageByIdentity`
(`src/plugin-sdk/session-transcript-runtime.ts`) both run a text-based
dedup check before appending a delivery-mirror row, so a channel can avoid
writing a mirror that just repeats the primary reply already in the
transcript. That check was unconditionally skipped whenever the mirror
carried an identified/keyed marker (`channel-final`,
`channel-final-suppressed`, `message-tool-source-reply`, or any keyed
mirror in the plugin-sdk path) — which is exactly the shape Telegram's
`routeReplyToOriginating` flow always uses. So the one case dedup most
needed to run for (a keyed mirror immediately following its own primary
reply) was the one case where it never ran.

The fix keeps text-based dedup for identified/keyed mirrors, but scopes it
correctly: it only suppresses a mirror against a genuine primary reply,
never against another mirror row. That preserves the existing, intentional
behavior (covered by tests already on `main`) where two distinct-source
keyed mirrors with identical text must both be appended as separate rows —
removing the guard unconditionally, as the issue's own suggested patch
did, would have broken that contract, which is why the ClawSweeper review
on the issue flagged the naive fix as too broad.

Both the core writer and its plugin-sdk sibling get the identical,
narrowly-scoped fix since Telegram's `mirrorTelegramAssistantReplyToTranscript`
calls the plugin-sdk path directly, while the core `routeReplyToOriginating`
flow calls the `transcript.ts` path — both are live call paths for the same
class of bug.

## User Impact

A Telegram reply (or any reply delivered through the shared
`routeReplyToOriginating`/plugin-sdk mirror paths) no longer creates a
duplicate assistant row in the session transcript when the mirror's text
matches the primary reply that immediately precedes it. Distinct-source
mirrors with identical text (e.g. two separate deliveries that happen to
say the same thing) are unaffected and still both persist.

## Evidence

Repro before fix — new regression test fails on pre-fix code
(`git checkout HEAD~1 -- src/config/sessions/transcript.ts` then rerun):

```
FAIL  src/config/sessions/transcript.test.ts > appendAssistantMessageToSessionTranscript > suppresses a keyed channel-final mirror that duplicates the preceding primary reply
AssertionError: expected '22b1df30-d632-4cae-8e18-a365a6766bda' to be '5f98d1ce-192f-4cba-bbe0-1276510485c2'
```

Same reproduction on the plugin-sdk sibling
(`git checkout HEAD~1 -- src/plugin-sdk/session-transcript-runtime.ts`):

```
FAIL  src/plugin-sdk/session-transcript-runtime.test.ts > session transcript runtime SDK > suppresses a keyed channel-final mirror that duplicates the preceding primary reply
AssertionError: expected { ok: true, …(1) } to deeply equal { ok: true, …(1) }
- "messageId": "706b42f9-af27-4d79-97b4-8b690a672067",
+ "messageId": "c415af5e-b926-41e6-89e0-1dbbf6fb3f25",
```

After the fix, both pass, along with the existing suite (which locks the
distinct-source-mirrors-stay-separate contract):

```
$ node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts
 Test Files  1 passed (1)
      Tests  64 passed (64)

$ node scripts/run-vitest.mjs src/plugin-sdk/session-transcript-runtime.test.ts
 Test Files  1 passed (1)
      Tests  23 passed (23)

$ node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.delivery-transcript.test.ts
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Sibling-surface regression coverage (all pass unchanged):

```
$ node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts \
    src/config/sessions/transcript-append-redact.test.ts \
    src/channels/turn/pending-delivery-notice.test.ts \
    src/channels/turn/pending-delivery-notice.integration.test.ts
 Test Files  4 passed (4)
      Tests  151 passed (151)

$ node scripts/run-vitest.mjs src/infra/outbound/outbound-send-service.test.ts \
    src/infra/outbound/deliver.test.ts src/gateway/server-methods/send.test.ts
 Test Files  3 passed (3)
      Tests  319 passed (319)

$ node scripts/run-vitest.mjs src/gateway/session-message-events.test.ts
 Test Files  1 passed (1)
      Tests  28 passed (28)
```

Format/lint:

```
$ ./node_modules/.bin/oxfmt --check src/config/sessions/transcript.ts \
    src/config/sessions/transcript.test.ts src/plugin-sdk/session-transcript-runtime.ts \
    src/plugin-sdk/session-transcript-runtime.test.ts
All matched files use the correct format.

$ node scripts/run-oxlint.mjs src/config/sessions/transcript.ts \
    src/config/sessions/transcript.test.ts src/plugin-sdk/session-transcript-runtime.ts \
    src/plugin-sdk/session-transcript-runtime.test.ts
(clean, exit 0)
```

Typecheck:

```
$ node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental ...
(clean)
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental ...
(clean)
```

Production LOC: `+53/-31` across the two owner files (net +22); the
remainder of the diff (+63) is test coverage in the two matching test files.

Not run: `src/gateway/sessions-history-http.test.ts` (lives in the e2e
Vitest project, which triggered a first-time full repo build in this
environment that exceeded the available time budget; unrelated to this
change's write path, and `session-message-events.test.ts` in the same
gateway config already covers transcript-read behavior).

AI-assisted: yes — Claude Code (Sonnet 5) investigated, implemented, and
verified this change, including reproducing the regression tests against
pre-fix code before restoring the fix.


## Boundary-level proof (added in response to review)

The review asked for proof that goes through the real channel boundary
instead of the writer-level unit tests above (the existing Telegram
dispatch test, `bot-message-dispatch.delivery-transcript.test.ts`, mocks
`appendAssistantMirrorMessageByIdentity` itself, so it never exercises the
real writer). To close that gap without adding production/test code to the
PR, I wrote a throwaway spec that calls Telegram's real, unmocked
`mirrorTelegramAssistantReplyToTranscript` (`extensions/telegram/src/bot-message-dispatch-session.ts`)
against a real temp SQLite-backed session store, with only the trivial
`resolveStorePath` dependency stubbed — the session lookup, the transcript
writer, and the dedup logic under review all run for real. It:

1. Creates a real session entry and writes a real "primary" assistant reply
   into the transcript.
2. Calls the real `mirrorTelegramAssistantReplyToTranscript` with matching
   text and a `channel-final` idempotency key, exactly as Telegram's
   production dispatch path does after a final delivery.
3. Reads the transcript back and asserts exactly one assistant row exists.

Post-fix (current HEAD, `088ada4ae51`):
```
$ node scripts/run-vitest.mjs extensions/telegram/src/__scratch-boundary-proof.test.ts
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Same spec against pre-fix code (`git checkout 05817086cc89930f2ec59b81671c4fe20b3df836 -- src/plugin-sdk/session-transcript-runtime.ts extensions/telegram/src/bot-message-dispatch-session.ts`):
```
$ node scripts/run-vitest.mjs extensions/telegram/src/__scratch-boundary-proof.test.ts
SCRATCH_ASSISTANT_ROW_COUNT 2
 ❯ ... real unmocked Telegram mirror call collapses into the primary reply via the real writer
AssertionError: expected [ { type: 'message', …(4) }, …(1) ] to have a length of 1 but got 2
 Test Files  1 failed (1)
```

This confirms the real Telegram-side entrypoint, not just the writer unit
tests, produces two transcript rows pre-fix and one post-fix. The spec file
was scratch-only (`extensions/telegram/src/__scratch-boundary-proof.test.ts`)
and has been deleted; it is not part of this PR's diff.

Gap still open: this is not a literal mock-gateway (no ephemeral gateway
process, no mocked Bot API) or a live-Telegram run — those need Crabbox with
leased Telegram credentials, which is out of scope for what I can produce in
this pass. Flagging that gap rather than claiming it's covered.
