### PR TITLE
fix(qa-lab): include plural execution channels

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -574,6 +574,7 @@ const config = {
         "src/index.ts!",
         "src/agent-id.ts!",
         "src/boolean-coercion.ts!",
+        "src/browser-error-runtime.ts!",
         "src/error-coercion.ts!",
         "src/expect.ts!",
         "src/json-coercion.ts!",
@@ -805,7 +806,6 @@ const config = {
       "cli.ts!",
       "web/index.html!",
       "web/src/app.ts!",
-      "web/src/error-runtime.browser.ts!",
       "web/src/main.ts!",
       "web/vite.config.ts!",
       // Imported directly from the GitHub Actions smoke-plan script.

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -805,6 +805,7 @@ const config = {
       "cli.ts!",
       "web/index.html!",
       "web/src/app.ts!",
+      "web/src/error-runtime.browser.ts!",
       "web/src/main.ts!",
       "web/vite.config.ts!",
       // Imported directly from the GitHub Actions smoke-plan script.

--- a/extensions/qa-lab/src/ci-smoke-plan.ts
+++ b/extensions/qa-lab/src/ci-smoke-plan.ts
@@ -54,16 +54,10 @@ function estimateScenarioCost(scenario: QaSmokeCiScenario) {
   return scenario.execution.kind === "flow" && scenario.execution.isolationReason ? 4 : 1;
 }
 
-function listQaSmokeCiDeclaredChannels(scenario: QaSmokeCiScenario): readonly string[] {
-  if (scenario.execution.channel) {
-    return [scenario.execution.channel];
-  }
-  return scenario.execution.kind === "flow" ? (scenario.execution.channels ?? []) : [];
-}
-
 export function selectQaSmokeCiEligibilityChannel(scenario: QaSmokeCiScenario): string | undefined {
-  const declaredChannels = listQaSmokeCiDeclaredChannels(scenario);
-  return QA_SMOKE_CI_CHANNELS.find((channel) => declaredChannels.includes(channel));
+  return QA_SMOKE_CI_CHANNELS.find(
+    (channel) => scenario.execution.channels?.includes(channel) === true,
+  );
 }
 
 export function createQaSmokeCiPart(
@@ -101,7 +95,7 @@ export function createQaSmokeCiPart(
   const supportedChannels = new Set<string>(QA_SMOKE_CI_CHANNELS);
   const unsupportedChannels = new Set(
     scenarios.flatMap((scenario) => {
-      const declaredChannels = listQaSmokeCiDeclaredChannels(scenario);
+      const declaredChannels = scenario.execution.channels ?? [];
       return declaredChannels.length > 0 && !selectQaSmokeCiEligibilityChannel(scenario)
         ? declaredChannels.filter((channel) => !supportedChannels.has(channel))
         : [];

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -698,6 +698,58 @@ describe("qa-lab server", () => {
     });
   });
 
+  it("launches a plural-only catalog scenario on its selected live channel", async () => {
+    liveTransportMock.adapterFactories[0]!.matches.mockReturnValue(true);
+    const lab = await startQaLabServerForTest();
+    cleanups.push(async () => {
+      await lab.stop();
+    });
+    suiteLaunchMock.runQaSuite.mockResolvedValue({
+      executionKind: "flow",
+      expectedCells: [],
+      observedCells: [],
+      result: await createQaLabSuiteResultFixture(),
+    });
+
+    const response = await fetch(`${lab.baseUrl}/api/scenario/suite`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        profile: "all",
+        channel: "buzz",
+        channelDriver: "live",
+        providerMode: "mock-openai",
+        scenarioIds: ["channel-canary"],
+      }),
+    });
+
+    expect(response.status).toBe(202);
+    const payload = (await response.json()) as {
+      plan: {
+        selectedScenarios: Array<{
+          id: string;
+          declaredChannel: string | null;
+          effectiveChannel: string | null;
+        }>;
+      };
+    };
+    expect(payload.plan.selectedScenarios).toEqual([
+      expect.objectContaining({
+        id: "channel-canary",
+        declaredChannel: null,
+        effectiveChannel: "buzz",
+      }),
+    ]);
+    await vi.waitFor(() => expect(suiteLaunchMock.runQaSuite).toHaveBeenCalledTimes(1));
+    expect(suiteLaunchMock.runQaSuite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelDriver: "live",
+        channelId: "buzz",
+        scenarioIds: ["channel-canary"],
+      }),
+    );
+  });
+
   it("allows only one concurrent request to commit a resolved suite plan", async () => {
     const lab = await startQaLabServerForTest();
     cleanups.push(async () => {
@@ -1043,7 +1095,16 @@ describe("qa-lab server", () => {
       "release",
       "all",
     ]);
-    expect(bootstrap.runnerCatalog.channels).toContain("qa-channel");
+    expect(bootstrap.runnerCatalog.channels).toEqual([
+      "buzz",
+      "discord",
+      "matrix",
+      "msteams",
+      "qa-channel",
+      "slack",
+      "telegram",
+      "whatsapp",
+    ]);
 
     const startupStatus = (await (
       await fetchWithRetry(`${lab.baseUrl}/api/capture/startup-status`)

--- a/extensions/qa-lab/src/lab-server.ts
+++ b/extensions/qa-lab/src/lab-server.ts
@@ -310,11 +310,7 @@ export async function startQaLabServer(
   const scenarioCatalog = readQaBootstrapScenarioCatalog();
   const scorecardReport = readQaScorecardTaxonomyReport(scenarioCatalog.scenarios);
   const runnerChannels = [
-    ...new Set(
-      scenarioCatalog.scenarios
-        .map((scenario) => scenario.execution.channel)
-        .filter((channel): channel is string => Boolean(channel)),
-    ),
+    ...new Set(scenarioCatalog.scenarios.flatMap((scenario) => scenario.execution.channels ?? [])),
   ].toSorted();
   const bootstrapDefaults = createBootstrapDefaults(params?.autoKickoffTarget);
   let runnerModelOptions: QaRunnerModelOption[] = [];

--- a/extensions/qa-lab/src/profile-evidence-sharding.ts
+++ b/extensions/qa-lab/src/profile-evidence-sharding.ts
@@ -112,13 +112,7 @@ function selectQaProfileScenarioCategory(
 }
 
 function listQaProfileScenarioLiveChannels(scenario: QaSeedScenarioWithSource) {
-  const channel = scenario.execution.channel?.trim().toLowerCase();
-  if (channel) {
-    return [channel];
-  }
-  return scenario.execution.kind === "flow"
-    ? (scenario.execution.channels?.filter((candidate) => candidate !== "qa-channel") ?? [])
-    : [];
+  return (scenario.execution.channels ?? []).filter((candidate) => candidate !== "qa-channel");
 }
 
 function listExclusiveQaProfileChannels(

--- a/extensions/qa-lab/src/profile-planning.ts
+++ b/extensions/qa-lab/src/profile-planning.ts
@@ -133,7 +133,11 @@ export function resolveQaRunProfileExecutionSelection(params: {
       reasons.push(`execution.kind=${params.executionKind}`);
     }
     // qa-channel is the built-in harness channel, so another driver cannot implement it.
-    if (scenario.execution.channel === "qa-channel" && params.channelDriver !== "qa-channel") {
+    if (
+      scenario.execution.channels?.length === 1 &&
+      scenario.execution.channels[0] === "qa-channel" &&
+      params.channelDriver !== "qa-channel"
+    ) {
       reasons.push("channelDriver=qa-channel");
     }
     const effectiveChannel = resolveQaScenarioLaneChannel({
@@ -175,13 +179,7 @@ export function resolveQaRunProfileExecutionSelection(params: {
 
 export function scenarioDeclaresQaChannel(scenario: QaSeedScenarioWithSource, channel: string) {
   const normalizedChannel = channel.trim().toLowerCase();
-  if (scenario.execution.channel === normalizedChannel) {
-    return true;
-  }
-  return (
-    scenario.execution.kind === "flow" &&
-    scenario.execution.channels?.includes(normalizedChannel) === true
-  );
+  return scenario.execution.channels?.includes(normalizedChannel) === true;
 }
 
 export function resolveQaProfileScenarios(params: {
@@ -217,11 +215,7 @@ export function resolveQaProfileScenarios(params: {
       reasons.push(`does not declare channel ${channel}`);
     }
     if (eligibleChannels.size > 0) {
-      const declaredChannels = scenario.execution.channel
-        ? [scenario.execution.channel]
-        : scenario.execution.kind === "flow"
-          ? (scenario.execution.channels ?? [])
-          : [];
+      const declaredChannels = scenario.execution.channels ?? [];
       if (
         declaredChannels.length > 0 &&
         !declaredChannels.some((declaredChannel) => eligibleChannels.has(declaredChannel))

--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -41,6 +41,7 @@ describe("qa scenario catalog channel contracts", () => {
       | undefined;
 
     expect(scenario.execution.channel).toBe("telegram");
+    expect(scenario.execution.channels).toEqual(["telegram"]);
     expect(config?.requiredProviderMode).toBe("mock-openai");
     expect(config?.requiredChannelDriver).toBe("crabline");
     const flow = JSON.stringify(requireFlowScenario(scenario).execution.flow);

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -73,6 +73,15 @@ const qaScenarioTransportPolicySchema = z.object({
   topLevelReplies: z.literal(true).optional(),
 });
 
+function normalizeQaScenarioExecutionChannels<T extends { channel?: string; channels?: string[] }>(
+  execution: T,
+): T & { channels?: string[] } {
+  return {
+    ...execution,
+    channels: execution.channel ? [execution.channel] : (execution.channels ?? []),
+  };
+}
+
 const qaFlowScenarioExecutionSchema = z
   .object({
     kind: z.literal("flow").default("flow"),
@@ -116,10 +125,13 @@ const qaTestFileScenarioExecutionSchema = z.discriminatedUnion("kind", [
   }),
 ]);
 
-const qaScenarioExecutionSchema = z.union([
+const qaScenarioExecutionInputSchema = z.union([
   qaFlowScenarioExecutionSchema,
   qaTestFileScenarioExecutionSchema,
 ]);
+const qaScenarioExecutionSchema = qaScenarioExecutionInputSchema.transform(
+  normalizeQaScenarioExecutionChannels,
+);
 
 const qaCoverageIdListSchema = z.array(qaCoverageIdSchema).min(1);
 
@@ -305,7 +317,7 @@ const qaSeedScenarioBodySchema = z.object({
   regressionRefs: z.array(z.string().trim().min(1)).optional(),
   docsRefs: z.array(z.string().trim().min(1)).optional(),
   codeRefs: z.array(z.string().trim().min(1)).optional(),
-  execution: qaScenarioExecutionSchema.optional(),
+  execution: qaScenarioExecutionInputSchema.optional(),
 });
 
 const qaSeedScenarioSchema = qaSeedScenarioBodySchema.extend({

--- a/extensions/qa-lab/src/scenario-lane.ts
+++ b/extensions/qa-lab/src/scenario-lane.ts
@@ -29,21 +29,19 @@ function resolveQaScenarioLaneChannels(params: {
   if (selectedChannel) {
     return [selectedChannel];
   }
-  const scenarioChannel = params.scenario.execution.channel?.trim().toLowerCase();
-  if (scenarioChannel) {
-    return [scenarioChannel];
+  const declaredChannels = params.scenario.execution.channels ?? [];
+  if (declaredChannels.length === 1) {
+    return declaredChannels;
   }
   if (params.scenario.execution.kind === "flow") {
-    const driverChannels = params.scenario.execution.channels?.filter(
-      (channel) => channel !== "qa-channel",
-    );
-    const supportedChannels = driverChannels?.filter(
+    const driverChannels = declaredChannels.filter((channel) => channel !== "qa-channel");
+    const supportedChannels = driverChannels.filter(
       (channel) => !params.supportsChannel || params.supportsChannel(channel),
     );
-    if (supportedChannels?.length) {
+    if (supportedChannels.length) {
       return supportedChannels;
     }
-    if (driverChannels?.length) {
+    if (driverChannels.length) {
       return driverChannels;
     }
   }
@@ -102,14 +100,9 @@ export function describeQaProviderLaneMismatches(params: {
     effectiveChannelDriver === "qa-channel"
       ? "qa-channel"
       : params.channel?.trim().toLowerCase() || undefined;
-  const scenarioChannel = params.scenario.execution.channel?.trim().toLowerCase();
-  if (scenarioChannel && effectiveChannel !== scenarioChannel) {
-    mismatches.push(`channel=${scenarioChannel}`);
-  }
-  const allowedChannels =
-    params.scenario.execution.kind === "flow" ? params.scenario.execution.channels : undefined;
-  if (allowedChannels && !allowedChannels.includes(effectiveChannel ?? "")) {
-    mismatches.push(`channel=${allowedChannels.join("|")}`);
+  const declaredChannels = params.scenario.execution.channels ?? [];
+  if (declaredChannels.length > 0 && !declaredChannels.includes(effectiveChannel ?? "")) {
+    mismatches.push(`channel=${declaredChannels.join("|")}`);
   }
   if (
     params.scenario.execution.kind === "flow" &&

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -45,6 +45,7 @@ function makeMatrixFlowQaSuiteTestScenario(
     execution: {
       kind: "flow",
       channel: "matrix",
+      channels: ["matrix"],
       timeoutMs: 60_000,
       retryCount: 0,
       ...(providerMode ? { providerMode } : {}),

--- a/extensions/qa-lab/src/suite-test-helpers.ts
+++ b/extensions/qa-lab/src/suite-test-helpers.ts
@@ -37,6 +37,7 @@ export function makeQaSuiteTestScenario(
     execution: {
       kind: "flow",
       ...(params.channel ? { channel: params.channel } : {}),
+      channels: params.channel ? [params.channel] : [],
       ...(params.suiteIsolation ? { suiteIsolation: params.suiteIsolation } : {}),
       ...(params.transportPolicy ? { transportPolicy: params.transportPolicy } : {}),
       ...(params.config ? { config: params.config } : {}),

--- a/extensions/qa-lab/web/src/app.browser.test.ts
+++ b/extensions/qa-lab/web/src/app.browser.test.ts
@@ -84,7 +84,7 @@ function createBootstrap(selection: RunnerSelection): Bootstrap {
       status: "idle",
     },
     runnerCatalog: {
-      channels: ["matrix", "telegram"],
+      channels: ["buzz", "matrix", "telegram"],
       profiles: [
         { id: "smoke-ci", evidenceMode: "slim", channelDriver: "crabline", categoryIds: [] },
         { id: "all", evidenceMode: "full", channelDriver: "live", categoryIds: [] },
@@ -336,6 +336,12 @@ describe("QA Lab runner browser interactions", () => {
     });
 
     root.querySelector<HTMLButtonElement>("[data-sidebar-panel='config']")?.click();
+    expect(
+      Array.from(
+        root.querySelectorAll<HTMLSelectElement>("#execution-channel option"),
+        (option) => option.value,
+      ),
+    ).toEqual(["", "buzz", "matrix", "telegram"]);
     selectValue(root, "#channel-driver", "live");
     selectValue(root, "#execution-channel", "telegram");
     root.querySelector<HTMLButtonElement>("[data-action='run-suite']")?.click();

--- a/extensions/qa-lab/web/src/app.ts
+++ b/extensions/qa-lab/web/src/app.ts
@@ -1,10 +1,11 @@
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { formatErrorMessage as formatSharedErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { QaBusStateSnapshot } from "openclaw/plugin-sdk/qa-channel-protocol";
 // Qa Lab plugin module implements app behavior.
 import { defaultQaModelForMode, isQaFastModeEnabled } from "../../model-selection.js";
 import { normalizeCaptureSavedView, normalizeCaptureSavedViews } from "./capture-saved-view.js";
 import { getJson, getJsonNoStore, postJson, QaLabHttpError } from "./http.js";
 import { conversationSelectionKey, findConversationBySelectionKey } from "./ui-conversation-key.js";
+import { redactSensitiveText } from "./ui-render-capture-redaction.js";
 import {
   type Bootstrap,
   type EvidenceEnvelope,
@@ -22,6 +23,10 @@ import {
   type UiState,
   renderQaLabUi,
 } from "./ui-render.js";
+
+function formatErrorMessage(error: unknown): string {
+  return redactSensitiveText(formatSharedErrorMessage(error));
+}
 
 function countCaptureDimension(
   events: UiState["captureEvents"],

--- a/extensions/qa-lab/web/src/error-runtime.browser.ts
+++ b/extensions/qa-lab/web/src/error-runtime.browser.ts
@@ -1,0 +1,6 @@
+import { formatErrorMessage as formatSharedErrorMessage } from "@openclaw/normalization-core/error-coercion";
+import { redactCaptureInlineSecretPairs } from "./ui-render-capture-redaction.js";
+
+export function formatErrorMessage(error: unknown): string {
+  return formatSharedErrorMessage(error, { redact: redactCaptureInlineSecretPairs });
+}

--- a/extensions/qa-lab/web/src/error-runtime.browser.ts
+++ b/extensions/qa-lab/web/src/error-runtime.browser.ts
@@ -1,6 +1,0 @@
-import { formatErrorMessage as formatSharedErrorMessage } from "@openclaw/normalization-core/error-coercion";
-import { redactCaptureInlineSecretPairs } from "./ui-render-capture-redaction.js";
-
-export function formatErrorMessage(error: unknown): string {
-  return formatSharedErrorMessage(error, { redact: redactCaptureInlineSecretPairs });
-}

--- a/extensions/qa-lab/web/src/ui-render-capture-format.ts
+++ b/extensions/qa-lab/web/src/ui-render-capture-format.ts
@@ -1,9 +1,9 @@
 import {
   formatCaptureFieldValue,
   isSensitiveCaptureField,
-  redactCaptureInlineSecretPairs,
   redactCapturePayloadPreview,
   redactCaptureScalar,
+  redactSensitiveText,
   redactCaptureValue,
 } from "./ui-render-capture-redaction.js";
 import { esc, parseJsonObject } from "./ui-render-utils.js";
@@ -142,7 +142,7 @@ function renderCaptureSsePayload(
           const value = separatorIndex >= 0 ? line.slice(separatorIndex + 1).trim() : line;
           return {
             label,
-            value: redactCaptureScalar(redactCaptureInlineSecretPairs(value), label),
+            value: redactCaptureScalar(redactSensitiveText(value), label),
           };
         });
       const eventName = rows.find((row) => row.label === "event")?.value || "message";

--- a/extensions/qa-lab/web/src/ui-render-capture-redaction.ts
+++ b/extensions/qa-lab/web/src/ui-render-capture-redaction.ts
@@ -164,7 +164,7 @@ function redactCaptureJsonishSecretFields(value: string): string {
   return redacted;
 }
 
-export function redactCaptureInlineSecretPairs(value: string): string {
+export function redactSensitiveText(value: string): string {
   return redactCaptureJsonishSecretFields(value).replace(
     /\b([A-Za-z][A-Za-z0-9_-]{0,64})=([^&\s"',}\]]+)/gu,
     (match: string, key: string) => (isSensitiveCaptureField(key) ? `${key}=[redacted]` : match),
@@ -172,7 +172,7 @@ export function redactCaptureInlineSecretPairs(value: string): string {
 }
 
 export function redactCapturePayloadPreview(payload: string): string {
-  return redactCaptureScalar(redactCaptureInlineSecretPairs(payload));
+  return redactCaptureScalar(redactSensitiveText(payload));
 }
 
 export function formatCaptureFieldValue(value: unknown, label?: string): string {

--- a/extensions/qa-lab/web/vite.config.ts
+++ b/extensions/qa-lab/web/vite.config.ts
@@ -7,6 +7,14 @@ export default defineConfig({
   base: "./",
   resolve: {
     alias: {
+      "@openclaw/normalization-core/error-coercion": path.resolve(
+        import.meta.dirname,
+        "../../../packages/normalization-core/src/error-coercion.ts",
+      ),
+      "openclaw/plugin-sdk/error-runtime": path.resolve(
+        import.meta.dirname,
+        "./src/error-runtime.browser.ts",
+      ),
       "openclaw/plugin-sdk/text-utility-runtime": path.resolve(
         import.meta.dirname,
         "../../../packages/normalization-core/src/utf16-slice.ts",

--- a/extensions/qa-lab/web/vite.config.ts
+++ b/extensions/qa-lab/web/vite.config.ts
@@ -7,13 +7,9 @@ export default defineConfig({
   base: "./",
   resolve: {
     alias: {
-      "@openclaw/normalization-core/error-coercion": path.resolve(
-        import.meta.dirname,
-        "../../../packages/normalization-core/src/error-coercion.ts",
-      ),
       "openclaw/plugin-sdk/error-runtime": path.resolve(
         import.meta.dirname,
-        "./src/error-runtime.browser.ts",
+        "../../../packages/normalization-core/src/browser-error-runtime.ts",
       ),
       "openclaw/plugin-sdk/text-utility-runtime": path.resolve(
         import.meta.dirname,

--- a/packages/normalization-core/src/browser-error-runtime.test.ts
+++ b/packages/normalization-core/src/browser-error-runtime.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatErrorMessage } from "./browser-error-runtime.js";
+
+describe("browser error formatting", () => {
+  it.each([
+    ["request failed: Bearer browser-token-credential", "request failed: Bearer [redacted]"],
+    ["provider rejected sk-browser_token_123", "provider rejected [redacted]"],
+    ["upstream returned token=browser-token-credential", "upstream returned token=[redacted]"],
+    ['upstream returned token="browser-token-credential"', 'upstream returned token="[redacted]"'],
+    [
+      '{"access_token":"browser-token-credential","status":401}',
+      '{"access_token":"[redacted]","status":401}',
+    ],
+    [
+      "request failed: https://example.test/path?x=1&access_token=browser-token-credential",
+      "request failed: https://example.test/path?x=1&access_token=[redacted]",
+    ],
+  ])("redacts common credential forms in %s", (message, expected) => {
+    expect(formatErrorMessage(new Error(message))).toBe(expected);
+  });
+});

--- a/packages/normalization-core/src/browser-error-runtime.ts
+++ b/packages/normalization-core/src/browser-error-runtime.ts
@@ -1,6 +1,31 @@
 import { formatErrorMessage as formatSharedErrorMessage } from "./error-coercion.js";
 
-// Browser owners apply their redaction policy at the UI boundary.
+const BROWSER_ERROR_CREDENTIAL_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  [/\b(Bearer|Basic|Bot)\s+[-A-Za-z0-9._~+/=]{8,}/giu, "$1 [redacted]"],
+  [/\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/gu, "[redacted]"],
+  [
+    /\b(?:sk-[A-Za-z0-9_-]{8,}|ghp_[A-Za-z0-9]{10,}|xox[baprs]-[A-Za-z0-9-]{10,}|xai-[A-Za-z0-9]{30,})\b/gu,
+    "[redacted]",
+  ],
+  [
+    /(^|[\s,{?&])(["']?)(api[-_]?key|access[-_]?token|refresh[-_]?token|auth[-_]?token|client[-_]?secret|password|passwd|token|secret)\2(\s*[=:]\s*)(["'])([^"'\r\n]+)\5/giu,
+    "$1$2$3$2$4$5[redacted]$5",
+  ],
+  [
+    /(^|[\s,{?&])(["']?)(api[-_]?key|access[-_]?token|refresh[-_]?token|auth[-_]?token|client[-_]?secret|password|passwd|token|secret)\2(\s*[=:]\s*)([^\s&,'"}]+)/giu,
+    "$1$2$3$2$4[redacted]",
+  ],
+];
+
+function redactBrowserErrorText(text: string): string {
+  return BROWSER_ERROR_CREDENTIAL_PATTERNS.reduce(
+    (redacted, [pattern, replacement]) => redacted.replace(pattern, replacement),
+    text,
+  );
+}
+
+// Browser bundles cannot load the host secret registry, so retain a bounded
+// browser-safe baseline before an owning UI applies any additional policy.
 export function formatErrorMessage(error: unknown): string {
-  return formatSharedErrorMessage(error, { redact: (text) => text });
+  return formatSharedErrorMessage(error, { redact: redactBrowserErrorText });
 }

--- a/packages/normalization-core/src/browser-error-runtime.ts
+++ b/packages/normalization-core/src/browser-error-runtime.ts
@@ -1,0 +1,6 @@
+import { formatErrorMessage as formatSharedErrorMessage } from "./error-coercion.js";
+
+// Browser owners apply their redaction policy at the UI boundary.
+export function formatErrorMessage(error: unknown): string {
+  return formatSharedErrorMessage(error, { redact: (text) => text });
+}

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -10,7 +10,7 @@ import {
   resolveAgentIdFromSessionKey,
   toAgentStoreSessionKey,
 } from "../../routing/session-key.js";
-import { runQueuedStoreWrite, type StoreWriterQueue } from "../../shared/store-writer-queue.js";
+import { runQueuedStoreWrite } from "../../shared/store-writer-queue.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   resolveIncognitoOpenClawAgentSqlitePath,
@@ -25,6 +25,7 @@ import type {
 } from "./session-accessor.sqlite-contract.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
+import { SQLITE_SESSION_WRITER_QUEUES } from "./store-writer-state.js";
 import type { SessionEntry } from "./types.js";
 
 type SessionSqliteDatabase = Pick<
@@ -82,7 +83,6 @@ export type SessionSqliteTargetResolutionCache = Map<
 >;
 
 const SQLITE_SESSION_SLOW_WRITE_MS = 1_000;
-const SQLITE_SESSION_WRITER_QUEUES = new Map<string, StoreWriterQueue>();
 
 export function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
   return getNodeSqliteKysely<SessionSqliteDatabase>(database);

--- a/src/config/sessions/store-writer-state.ts
+++ b/src/config/sessions/store-writer-state.ts
@@ -9,13 +9,26 @@ import { clearSessionSkillPromptRefCache } from "./skill-prompt-blobs.js";
 type SessionStoreWriterQueue = StoreWriterQueue;
 
 export const WRITER_QUEUES = new Map<string, SessionStoreWriterQueue>();
+// State-dir teardown drains this owner before closing SQLite handles. Keeping
+// the queue here prevents late session writes from recreating removed fixtures.
+export const SQLITE_SESSION_WRITER_QUEUES = new Map<string, SessionStoreWriterQueue>();
 
-/** Clears legacy session writer queues and prompt-blob caches for tests. */
+/** Clears session writer queues and prompt-blob caches for tests. */
 export function clearSessionStoreCacheForTest(): void {
   clearSessionSkillPromptRefCache();
   clearStoreWriterQueuesForTest(WRITER_QUEUES, "session store queue cleared for test");
+  clearStoreWriterQueuesForTest(
+    SQLITE_SESSION_WRITER_QUEUES,
+    "SQLite session store queue cleared for test",
+  );
 }
 
 export async function drainSessionStoreWriterQueuesForTest(): Promise<void> {
-  await drainStoreWriterQueuesForTest(WRITER_QUEUES, "session store queue cleared for test");
+  await Promise.all([
+    drainStoreWriterQueuesForTest(WRITER_QUEUES, "session store queue cleared for test"),
+    drainStoreWriterQueuesForTest(
+      SQLITE_SESSION_WRITER_QUEUES,
+      "SQLite session store queue cleared for test",
+    ),
+  ]);
 }

--- a/src/plugin-sdk/test-helpers/temp-home.ts
+++ b/src/plugin-sdk/test-helpers/temp-home.ts
@@ -139,7 +139,9 @@ export async function withTempHomeCore<T>(
     return await fn(base);
   } finally {
     if (!opts.skipSessionCleanup) {
-      await cleanupSessionStateForTest().catch(() => undefined);
+      await cleanupSessionStateForTest({ stateDir: path.join(base, ".openclaw") }).catch(
+        () => undefined,
+      );
     }
     restoreExtraEnv(envSnapshot);
     restoreEnv(snapshot);

--- a/src/test-helpers/state-dir-env.ts
+++ b/src/test-helpers/state-dir-env.ts
@@ -33,7 +33,7 @@ export async function withStateDirEnv<T>(
   } finally {
     // Session state cleanup may race with assertions in failing tests; never let
     // that cleanup failure hide the original test error or skip env restoration.
-    await cleanupSessionStateForTest().catch(() => undefined);
+    await cleanupSessionStateForTest({ stateDir }).catch(() => undefined);
     restoreStateDirEnv(snapshot);
     await fs.rm(tempRoot, { recursive: true, force: true });
   }

--- a/src/test-utils/session-state-cleanup.test.ts
+++ b/src/test-utils/session-state-cleanup.test.ts
@@ -4,9 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { runExclusiveSqliteSessionWrite } from "../config/sessions/session-accessor.sqlite-scope.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
 import { runExclusiveSessionStoreWrite } from "../config/sessions/store-writer.js";
 import { resetFileLockStateForTest } from "../infra/file-lock.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   cleanupSessionStateForTest,
   resetSessionStateCleanupRuntimeForTests,
@@ -87,6 +93,54 @@ describe("cleanupSessionStateForTest", () => {
       finishDrain();
       await running?.catch(() => undefined);
       await cleanupSessionStateForTest();
+      await fs.rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("waits for SQLite session writers before closing their database handles", async () => {
+    const fixtureRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-session-cleanup-sqlite-"),
+    );
+    const databasePath = path.join(fixtureRoot, "openclaw-agent.sqlite");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: fixtureRoot };
+    const started = createDeferred();
+    const release = createDeferred();
+    let database: ReturnType<typeof openOpenClawAgentDatabase> | undefined;
+    let cleanupPromise: Promise<void> | undefined;
+    setSessionStateCleanupRuntimeForTests({ drainSessionStoreWriterQueuesForTest: null });
+
+    const running = runExclusiveSqliteSessionWrite(
+      { agentId: "main", env, path: databasePath },
+      async () => {
+        started.resolve();
+        await release.promise;
+        database = openOpenClawAgentDatabase({ agentId: "main", env, path: databasePath });
+      },
+    );
+    try {
+      await started.promise;
+      let cleanupSettled = false;
+      cleanupPromise = cleanupSessionStateForTest().then(() => {
+        cleanupSettled = true;
+      });
+
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(cleanupSettled).toBe(false);
+
+      release.resolve();
+      await running;
+      await cleanupPromise;
+      expect(database?.db.isOpen).toBe(false);
+    } finally {
+      release.resolve();
+      await running;
+      if (cleanupPromise) {
+        await cleanupPromise;
+      }
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
       await fs.rm(fixtureRoot, { recursive: true, force: true });
     }
   });

--- a/src/test-utils/session-state-cleanup.test.ts
+++ b/src/test-utils/session-state-cleanup.test.ts
@@ -120,7 +120,7 @@ describe("cleanupSessionStateForTest", () => {
     try {
       await started.promise;
       let cleanupSettled = false;
-      cleanupPromise = cleanupSessionStateForTest().then(() => {
+      cleanupPromise = cleanupSessionStateForTest({ stateDir: fixtureRoot }).then(() => {
         cleanupSettled = true;
       });
 

--- a/src/test-utils/session-state-cleanup.ts
+++ b/src/test-utils/session-state-cleanup.ts
@@ -4,8 +4,13 @@ import {
   drainSessionStoreWriterQueuesForTest,
 } from "../config/sessions/store-writer-state.js";
 import { drainFileLockStateForTest } from "../infra/file-lock.js";
-import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { isPathInside } from "../infra/path-guards.js";
+import {
+  closeOpenClawAgentDatabaseByPath,
+  listOpenClawAgentDatabasesForTest,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseByPath } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 
 let fileLockDrainerForTests: typeof drainFileLockStateForTest | null = null;
 let sessionStoreWriterQueueDrainerForTests: typeof drainSessionStoreWriterQueuesForTest | null =
@@ -29,12 +34,23 @@ export function resetSessionStateCleanupRuntimeForTests(): void {
   sessionStoreWriterQueueDrainerForTests = null;
 }
 
-export async function cleanupSessionStateForTest(): Promise<void> {
+export async function cleanupSessionStateForTest(
+  options: { stateDir?: string } = {},
+): Promise<void> {
   await (sessionStoreWriterQueueDrainerForTests ?? drainSessionStoreWriterQueuesForTest)();
   await (fileLockDrainerForTests ?? drainFileLockStateForTest)();
   clearSessionStoreCacheForTest();
-  // A queued writer can reopen both databases after an earlier close. Handles
-  // therefore close only after every session writer and file lock has drained.
-  closeOpenClawAgentDatabasesForTest();
-  closeOpenClawStateDatabaseForTest();
+  if (!options.stateDir) {
+    return;
+  }
+  // A queued writer can reopen both databases after an earlier close. Scope
+  // final handle cleanup to the fixture owner so unrelated tests stay live.
+  for (const database of listOpenClawAgentDatabasesForTest()) {
+    if (isPathInside(options.stateDir, database.path)) {
+      closeOpenClawAgentDatabaseByPath(database.path);
+    }
+  }
+  closeOpenClawStateDatabaseByPath(
+    resolveOpenClawStateSqlitePath({ ...process.env, OPENCLAW_STATE_DIR: options.stateDir }),
+  );
 }

--- a/src/test-utils/session-state-cleanup.ts
+++ b/src/test-utils/session-state-cleanup.ts
@@ -4,6 +4,8 @@ import {
   drainSessionStoreWriterQueuesForTest,
 } from "../config/sessions/store-writer-state.js";
 import { drainFileLockStateForTest } from "../infra/file-lock.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 
 let fileLockDrainerForTests: typeof drainFileLockStateForTest | null = null;
 let sessionStoreWriterQueueDrainerForTests: typeof drainSessionStoreWriterQueuesForTest | null =
@@ -29,6 +31,10 @@ export function resetSessionStateCleanupRuntimeForTests(): void {
 
 export async function cleanupSessionStateForTest(): Promise<void> {
   await (sessionStoreWriterQueueDrainerForTests ?? drainSessionStoreWriterQueuesForTest)();
-  clearSessionStoreCacheForTest();
   await (fileLockDrainerForTests ?? drainFileLockStateForTest)();
+  clearSessionStoreCacheForTest();
+  // A queued writer can reopen both databases after an earlier close. Handles
+  // therefore close only after every session writer and file lock has drained.
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
 }

--- a/src/test-utils/temp-home.ts
+++ b/src/test-utils/temp-home.ts
@@ -48,14 +48,15 @@ async function ensurePrefixRoot(prefix: string): Promise<string> {
 export async function createTempHomeEnv(prefix: string): Promise<TempHomeEnv> {
   const prefixRoot = await ensurePrefixRoot(prefix);
   const home = path.join(prefixRoot, `home-${String(nextHomeIndex)}`);
+  const stateDir = path.join(home, ".openclaw");
   nextHomeIndex += 1;
   await fs.rm(home, { recursive: true, force: true });
-  await fs.mkdir(path.join(home, ".openclaw"), { recursive: true });
+  await fs.mkdir(stateDir, { recursive: true });
 
   const snapshot = captureEnv([...HOME_ENV_KEYS]);
   setTestEnvValue("HOME", home);
   setTestEnvValue("USERPROFILE", home);
-  setTestEnvValue("OPENCLAW_STATE_DIR", path.join(home, ".openclaw"));
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
 
   if (process.platform === "win32") {
     const match = home.match(/^([A-Za-z]:)(.*)$/);
@@ -68,7 +69,7 @@ export async function createTempHomeEnv(prefix: string): Promise<TempHomeEnv> {
   return {
     home,
     restore: async () => {
-      await cleanupSessionStateForTest().catch(() => undefined);
+      await cleanupSessionStateForTest({ stateDir }).catch(() => undefined);
       snapshot.restore();
       await fs.rm(home, { recursive: true, force: true });
     },

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -8,6 +8,7 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
+      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
       "extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",
       "extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts",

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -12,7 +12,6 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
       "extensions/codex/src/app-server/run-attempt-state.test.ts",
-      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
     ],
     {
       dir: "extensions",

--- a/test/vitest/vitest.extension-codex-app-server-tools.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-tools.config.ts
@@ -15,7 +15,6 @@ function createExtensionCodexAppServerToolsVitestConfig(
       "extensions/codex/src/app-server/native-hook-relay.test.ts",
       "extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts",
       "extensions/codex/src/app-server/request.test.ts",
-      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
       "extensions/codex/src/app-server/sandbox-exec-server*.test.ts",
       "extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts",
       "extensions/codex/src/app-server/user-input-bridge.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA Lab users could not see or launch a channel that was declared only through plural `execution.channels`. Buzz was present in the scenario catalog but absent from the bootstrap/UI channel list, so selecting the plural-only `channel-canary` scenario could not reach its live Buzz lane.

This also restores the QA Lab browser build on current main. The UI imported the plugin SDK error formatter through an optional peer stub that did not export `formatErrorMessage`, preventing any honest pre-fix UI capture.

## Why This Change Was Made

Scenario loading now normalizes singular `execution.channel` and plural `execution.channels` into one canonical channels list exactly once. Singular declarations retain precedence and exact-pin behavior; plural declarations retain OR-list behavior, authored order, and existing deduplication validation. Bootstrap, validation, profile planning, CI selection, evidence sharding, and execution consume that normalized list consistently.

The browser build now source-aliases the existing Plugin SDK formatter import to a package-internal browser shim that preserves the canonical normalization formatter. QA Lab applies its existing inline-secret redaction at the UI boundary before rendering the result, and the Knip entry list records the build-only shim as a real root. This avoids the optional peer stub without changing dependencies, SDK contracts, product configuration, or runtime behavior outside the repaired build.

## User Impact

Buzz now appears in QA Lab's Execution channel selector and plural-only scenarios launch on Buzz. Existing singular channel declarations remain exact pins, while plural declarations continue to mean "any of these channels." The QA Lab UI builds again.

AI-assisted; the patch and evidence were reviewed and verified before publication.

## Evidence

### Before

- The bootstrap regression failed because the channel catalog omitted `buzz`.
- A true pre-fix UI screenshot is infeasible because current main cannot build QA Lab. The exact production build fails after transforming 40 modules with:

  ```text
  [MISSING_EXPORT] "formatErrorMessage" is not exported by "__vite-optional-peer-dep:openclaw/plugin-sdk/error-runtime:@openclaw/qa-lab".
  extensions/qa-lab/web/src/app.ts:1:10
  ```

  No baseline image was fabricated.

### After

![QA Lab Config showing Buzz as the selected execution channel](https://github.com/user-attachments/assets/6df5716a-5bd6-4936-943c-49b114757084)

- `node scripts/run-vitest.mjs ...` — 199/199 post-rebase owner tests passed across catalog, lane, profile/sharding, CI, server launch, and browser interaction. Earlier focused validation also passed 232 tests, with a separate key rerun at 134/134.
- `pnpm check:changed` — passed all selected core, extension, test, and tooling checks.
- `pnpm deadcode:full` — passed after registering the Vite alias target as an analyzed build entry.
- `node --import tsx scripts/run-additional-boundary-checks.mts` — passed the complete additional boundary suite, including plugin/Core import ownership and normalization facade rules.
- `pnpm qa:lab:build` — passed; Vite transformed 41 modules.
- Source-blind bootstrap validation passed twice with eight sorted, deduplicated channels: `buzz`, `discord`, `matrix`, `msteams`, `qa-channel`, `slack`, `telegram`, `whatsapp`.
- Source-blind browser validation reported zero page errors.
- Final branch-level P1 autoreview found no accepted/actionable findings (confidence 0.84).
- Production LOC: +57/-59 (net -2). Tests/support: +72/-2. Tooling: +1/-0.
- Exact-head CI is attached at [run 32212579880](https://github.com/openclaw/openclaw/actions/runs/32212579880). At publication time, its three failures are outside this patch: current-main SDK docs wording disagrees with its exact-string contract test; current-main GCP install docs omit blank secret placeholders required by their contract test; and QA Smoke profile 3 passes three scenarios before the existing `subagent-completion-direct-fallback` scenario times out, matching the prior head. The repaired dependency and additional-boundary checks pass locally with the exact CI commands.
