### PR TITLE
test: remove strict-subset assertions

### DIFF
--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -1885,7 +1885,6 @@ describe("Anthropic provider", () => {
     expect(result.stopReason).toBe("error");
     // Keep salient transport fields while replacing the cycle, so the terminal
     // diagnostic remains actionable without stranding the stream.
-    expect(result.errorMessage).toBeTruthy();
     expect(result.errorMessage).toBe('{"code":"ECONNRESET","self":"[Circular]"}');
   });
 

--- a/packages/ai/src/utils/provider-error.test.ts
+++ b/packages/ai/src/utils/provider-error.test.ts
@@ -408,7 +408,6 @@ describe("projectProviderError", () => {
 
     expect(projected.stopReason).toBe("error");
     expect(projected.errorMessage).toBe("[Unserializable]");
-    expect(projected.errorMessage.length).toBeLessThanOrEqual(4096);
   });
 
   it("caps descriptor reads from hostile objects", () => {

--- a/src/agents/compaction.failure-proof.test.ts
+++ b/src/agents/compaction.failure-proof.test.ts
@@ -59,7 +59,6 @@ describe("compaction failure real-behavior proof", () => {
 
     // The caller must see the failure and keep the transcript intact.
     // No compaction placeholder is returned, so messages are not rotated away.
-    expect(messages).toHaveLength(3);
     expect(messages.map((message) => message.content)).toEqual([
       "first user request",
       "second user request",

--- a/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/llm-idle-timeout.test.ts
@@ -894,7 +894,6 @@ describe("streamWithIdleTimeout", () => {
       results.push(chunk);
     }
 
-    expect(results).toHaveLength(3);
     expect(results).toEqual(chunks);
   });
 

--- a/src/agents/exec-auto-reviewer.test.ts
+++ b/src/agents/exec-auto-reviewer.test.ts
@@ -784,7 +784,6 @@ describe("createModelExecAutoReviewer", () => {
       Array.from({ length: 24 }, () => Promise.resolve(reviewer(input))),
     );
 
-    expect(decisions).toHaveLength(24);
     expect(decisions).toEqual(
       Array.from({ length: 24 }, () =>
         expect.objectContaining({ decision: "allow-once", risk: "low" }),

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -378,7 +378,6 @@ describe("provider attribution", () => {
       OPENCLAW_VERSION: "2026.3.22",
     });
 
-    expect(policy).toBeDefined();
     expect(policy).toEqual({
       provider: "nvidia",
       enabledByDefault: true,

--- a/src/auto-reply/reply/agent-runner-session-reset.test.ts
+++ b/src/auto-reply/reply/agent-runner-session-reset.test.ts
@@ -500,7 +500,6 @@ describe("resetReplyRunSession", () => {
     });
 
     // The boundary reset keeps both the logical id and transcript in place.
-    expect(rotatedSessionId).toBeDefined();
     expect(rotatedSessionId).toBe("old-session");
     await fs.access(oldTranscriptPath);
   });

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -860,7 +860,6 @@ describe("followup queue collect routing", () => {
 
     await drainRecordedQueue(key, runFollowup, done);
 
-    expect(calls).toHaveLength(3);
     expect(calls.map((call) => call.originatingTo)).toEqual([
       "channel:B",
       "channel:C",

--- a/src/auto-reply/reply/queue.media-carrier.test.ts
+++ b/src/auto-reply/reply/queue.media-carrier.test.ts
@@ -169,7 +169,6 @@ describe("followup prompt metadata carrier", () => {
       "---\nQueued #1\n[media attached: /tmp/a.png (image/png)]\nfirst",
       "---\nQueued #2\n[media attached: /tmp/b.pdf (application/pdf)]\nsecond",
     ].join("\n\n");
-    expect(calls).toHaveLength(2);
     expect(calls.map((run) => run.prompt)).toEqual([expectedPrompt, expectedPrompt]);
     expect(calls.map((run) => run.media)).toEqual([
       [

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -685,7 +685,6 @@ describe("channel ingress queue", () => {
         await queue.enqueue("good-2", { text: "world" });
 
         const pending = await queue.listPending();
-        expect(pending).toHaveLength(2);
         expect(pending.map((r) => r.id).toSorted()).toEqual(["good-1", "good-2"]);
       });
     });

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -1504,7 +1504,6 @@ describe("maybeRepairLegacyCronStore", () => {
     });
 
     const jobs = await readPersistedJobs(storePath);
-    expect(jobs).toHaveLength(2);
     expect(jobs.map((job) => job.id)).toEqual(["legacy-job", "legacy-only"]);
     expect(requirePersistedJob(jobs, 0).name).toBe("SQLite wins");
     expect(requirePersistedJob(jobs, 1).name).toBe("Legacy only");

--- a/src/commands/onboard-config.test.ts
+++ b/src/commands/onboard-config.test.ts
@@ -74,7 +74,6 @@ describe("applyLocalSetupWorkspaceConfig", () => {
 
     const result = applyLocalSetupWorkspaceConfig(baseConfig, "/tmp/workspace");
 
-    expect(result.agents?.list).toHaveLength(2);
     expect(result.agents?.list?.map((a) => a.id)).toEqual(["alpha", "beta"]);
     expect(result.bindings).toEqual(baseConfig.bindings);
   });

--- a/src/config/sessions/conversation-registry.test.ts
+++ b/src/config/sessions/conversation-registry.test.ts
@@ -67,7 +67,6 @@ describe("conversation registry", () => {
     });
 
     const conversations = listConversations({ agentId: "main", storePath }, { channel: "reef" });
-    expect(conversations).toHaveLength(2);
     expect(conversations.map((entry) => entry.target).toSorted()).toEqual([
       "reef:peer-a",
       "reef:peer-b",

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -987,7 +987,6 @@ describe("SQLite active transcript event projection", () => {
     });
 
     expect(page.totalMessages).toBe(100_000);
-    expect(page.events).toHaveLength(25);
     expect(page.events.map((entry) => entry.seq)).toEqual(
       Array.from({ length: 25 }, (_, index) => 99_976 + index),
     );

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -1378,7 +1378,6 @@ describe("gateway startup config secret preflight", () => {
       await activateRuntimeSecrets(config, { reason: "startup", activate: false });
 
       const events = readTimelineEvents(timelineEnv.timelinePath);
-      expect(events).toHaveLength(2);
       expect(events.map((event) => event.type)).toEqual(["span.start", "span.end"]);
       for (const event of events) {
         expect(event.name).toBe("secrets.prepare");

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -1147,7 +1147,6 @@ test("sessions.reset waits for terminal compaction before replacing the session"
   const reset = await resetResult;
   expect(reset.ok).toBe(true);
   const resetSessionId = reset.payload?.entry.sessionId;
-  expect(resetSessionId).toBeTruthy();
   expect(resetSessionId).toBe("sess-compact-reset");
   const resetEntry = loadSessionEntry({ sessionKey: "agent:main:main", storePath });
   expect(resetEntry?.sessionId).toBe(resetSessionId);

--- a/src/image-generation/openai-compatible-image-provider.test.ts
+++ b/src/image-generation/openai-compatible-image-provider.test.ts
@@ -285,7 +285,6 @@ describe("OpenAI-compatible image provider helper", () => {
       cfg: {} as never,
     });
 
-    expect(result.images).toHaveLength(4);
     expect(result.images.map((image) => image.buffer.byteLength)).toEqual([
       imageBytes.byteLength,
       imageBytes.byteLength,

--- a/src/infra/command-explainer/extract.test.ts
+++ b/src/infra/command-explainer/extract.test.ts
@@ -51,7 +51,6 @@ describe("command explainer tree-sitter runtime", () => {
     const source = "echo café😀 && echo 雪";
     const explanation = await explainShellCommand(source);
 
-    expect(explanation.topLevelCommands).toHaveLength(2);
     expect(explanation.topLevelCommands.map((command) => command.argv)).toEqual([
       ["echo", "café😀"],
       ["echo", "雪"],

--- a/src/infra/delivery-queue-sqlite.test.ts
+++ b/src/infra/delivery-queue-sqlite.test.ts
@@ -91,7 +91,6 @@ describe("delivery-queue-sqlite corrupt JSON resilience", () => {
       enqueueValid("valid-b");
 
       const entries = loadDeliveryQueueEntries(QUEUE, stateDir);
-      expect(entries).toHaveLength(2);
       expect(entries.map((e) => e.id).toSorted()).toEqual(["valid-a", "valid-b"]);
     });
 

--- a/src/infra/outbound/outbound-audit.test.ts
+++ b/src/infra/outbound/outbound-audit.test.ts
@@ -111,7 +111,6 @@ describe("outbound audit projection", () => {
       unsubscribe();
     }
 
-    expect(events).toHaveLength(2);
     expect(events.map((event) => event.sourceId)).toEqual([
       "message:outbound:queue:queue-1:payload:0",
       "message:outbound:queue:queue-1:payload:1",

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -623,7 +623,6 @@ describeUnix("inspectPortUsage", () => {
 
     const result = await inspectPortConnections(18789);
 
-    expect(result.connections).toHaveLength(2);
     expect(result.connections).toEqual([
       expect.objectContaining({
         pid: 111,

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -2220,7 +2220,6 @@ describe("runGatewayUpdate", () => {
     const result = await runWithCommand(runCommand, { channel: "dev" });
 
     expect(result.status).toBe("ok");
-    expect(buildNodeOptions).toHaveLength(2);
     expect(buildNodeOptions).toEqual(["--max-old-space-size=8192", "--max-old-space-size=8192"]);
     expect(buildCacheRoots).toEqual([
       path.join(tempDir, ".artifacts", "build-all-cache"),

--- a/src/plugin-sdk/memory-host-markdown.test.ts
+++ b/src/plugin-sdk/memory-host-markdown.test.ts
@@ -93,7 +93,6 @@ describe("replaceManagedMarkdownBlock", () => {
     });
 
     expect(updated).toBe("# Title\n\n## Generated\n<!-- start -->\n- latest\n<!-- end -->\n");
-    expect(updated.match(/<!-- start -->/g)?.length).toBe(1);
     expect(updated).not.toContain("run-");
   });
 

--- a/src/plugin-state/plugin-state-store.e2e.test.ts
+++ b/src/plugin-state/plugin-state-store.e2e.test.ts
@@ -176,30 +176,6 @@ describe("limits", () => {
       });
     });
   });
-
-  it("evicts oldest entries when namespace maxEntries is exceeded", async () => {
-    await withOpenClawTestState({ label: "e2e-limit-eviction" }, async () => {
-      vi.useFakeTimers();
-      const store = createPluginStateKeyedStore<number>("fixture-plugin", {
-        namespace: "capped",
-        maxEntries: 3,
-      });
-
-      vi.setSystemTime(1000);
-      await store.register("a", 1);
-      vi.setSystemTime(2000);
-      await store.register("b", 2);
-      vi.setSystemTime(3000);
-      await store.register("c", 3);
-      vi.setSystemTime(4000);
-      await store.register("d", 4); // should evict "a"
-
-      const entries = await store.entries();
-      expect(entries).toHaveLength(3);
-      expect(entries.map((e) => e.key)).toEqual(["b", "c", "d"]);
-      await expect(store.lookup("a")).resolves.toBeUndefined();
-    });
-  });
 });
 
 // ---------------------------------------------------------------------------

--- a/test/e2e/qa-lab/runtime/gateway-client-transport-defaults.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-client-transport-defaults.e2e.test.ts
@@ -270,7 +270,6 @@ describe("GatewayClient transport defaults", () => {
       );
     }
 
-    expect(closeEvents).toHaveLength(expectedDelays.length);
     expect(closeEvents).toEqual(expectedDelays.map(() => ({ code: 1012, reason: "retry" })));
   });
 


### PR DESCRIPTION
## What Problem This Solves

The test suite carried 24 assertions that were strict subsets of adjacent exact equalities, plus one plugin-state E2E case duplicated by tighter real-SQLite facade coverage. These checks added maintenance surface without detecting an independent regression.

## Why This Change Was Made

This removes only assertions whose cardinality or definedness is fully implied by the stronger exact proof beside them, and removes the duplicated plugin-state max-entry eviction E2E case. The owner test remains and more tightly covers eviction ordering, timestamp ties, preservation of the new write, and lookup absence. The alias-sensitive length assertion in `embedded-agent-helpers.validate-turns.test.ts` is intentionally retained because exact equality can alias the same mutable input after an in-place splice.

This is AI-assisted maintainer work. I reviewed every candidate against current `main`, the adjacent stronger assertion, and the relevant sibling coverage.

## User Impact

No user-visible or runtime behavior changes. There are no production, test-support, docs, changelog, schema, protocol, config, dependency, or operator-state changes; the suite keeps the same independent behavioral guarantees with less duplicated assertion surface.

## Evidence

- Production LOC: +0/-0; test-support LOC: +0/-0; tests: +0/-48. The anchor estimate was -47; current `oxfmt` also removes the now-empty separator before the closing `limits` block.
- `pnpm test:changed` — 12 Vitest shards passed.
- `node scripts/run-vitest.mjs src/agents/exec-auto-reviewer.test.ts src/agents/exec-auto-review.stress.test.ts` — 238 tests passed.
- Compaction sibling group — 136 tests passed.
- Plugin-state owner and E2E group — 51 tests passed.
- Onboarding/provider sibling group — 108 tests passed.
- `pnpm check:changed` — passed.
- `git diff --check` — passed.
- Codex-backed autoreview — clean; no accepted/actionable findings.
