### PR TITLE
improve(gateway): avoid repeated logging and delivery scans

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-server-requests.ts
+++ b/extensions/codex/src/app-server/run-attempt-server-requests.ts
@@ -35,6 +35,12 @@ import {
 } from "./tool-progress-normalization.js";
 import type { CodexAppServerServerRequest, CodexThreadRouteScope } from "./turn-router.js";
 
+const DYNAMIC_TOOL_TERMINAL_DIAGNOSTIC_TYPES = [
+  "tool.execution.completed",
+  "tool.execution.error",
+  "tool.execution.blocked",
+] as const;
+
 export function createCodexAttemptServerRequestController(
   resources: CodexAttemptResources,
   turnRuntime: CodexAttemptTurnState,
@@ -196,20 +202,23 @@ export function createCodexAttemptServerRequestController(
       const dynamicToolTimeoutMs = resolveDynamicToolCallTimeoutMs({ call, config: params.config });
       const toolStartedAt = Date.now();
       let terminalDiagnosticObserved = false;
-      const unsubscribeToolDiagnosticObserver = onInternalDiagnosticEvent((event) => {
-        if (
-          isDynamicToolTerminalDiagnosticEvent(event) &&
-          isMatchingDynamicToolTerminalDiagnostic({
-            event,
-            call,
-            runId: params.runId,
-            sessionId: params.sessionId,
-            sessionKey: params.sessionKey,
-          })
-        ) {
-          terminalDiagnosticObserved = true;
-        }
-      });
+      const unsubscribeToolDiagnosticObserver = onInternalDiagnosticEvent(
+        (event) => {
+          if (
+            isDynamicToolTerminalDiagnosticEvent(event) &&
+            isMatchingDynamicToolTerminalDiagnostic({
+              event,
+              call,
+              runId: params.runId,
+              sessionId: params.sessionId,
+              sessionKey: params.sessionKey,
+            })
+          ) {
+            terminalDiagnosticObserved = true;
+          }
+        },
+        { include: DYNAMIC_TOOL_TERMINAL_DIAGNOSTIC_TYPES },
+      );
       try {
         const { execution } = openClawDynamicToolExecutions.claim(call, () => {
           emitDynamicToolStartedDiagnostic({

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -6,6 +6,7 @@ import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coerc
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { setLoggerOverride } from "../../logging/logger.js";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 import { resolveProfileUnusableUntil } from "./usage-state.js";
 import {
@@ -1173,11 +1174,8 @@ describe("markAuthProfileFailure — locked update failure", () => {
   it("drops bookkeeping without an unlocked full-store save", async () => {
     const store = makeStore(undefined);
     const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const previousTestConsole = process.env.OPENCLAW_TEST_CONSOLE;
-    const previousLogLevel = process.env.OPENCLAW_LOG_LEVEL;
     storeMocks.updateAuthProfileStoreWithLock.mockResolvedValueOnce(null);
-    process.env.OPENCLAW_TEST_CONSOLE = "1";
-    process.env.OPENCLAW_LOG_LEVEL = "warn";
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
     try {
       await markAuthProfileFailure({
         store,
@@ -1194,16 +1192,7 @@ describe("markAuthProfileFailure — locked update failure", () => {
         ),
       ).toBe(true);
     } finally {
-      if (previousTestConsole === undefined) {
-        delete process.env.OPENCLAW_TEST_CONSOLE;
-      } else {
-        process.env.OPENCLAW_TEST_CONSOLE = previousTestConsole;
-      }
-      if (previousLogLevel === undefined) {
-        delete process.env.OPENCLAW_LOG_LEVEL;
-      } else {
-        process.env.OPENCLAW_LOG_LEVEL = previousLogLevel;
-      }
+      setLoggerOverride(null);
       consoleWarn.mockRestore();
     }
   });

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -8,6 +8,7 @@ import { CommanderError } from "commander";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
+import { setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { withSecureTestNodeExecPath } from "../secrets/test-node-command.test-support.js";
@@ -3245,18 +3246,20 @@ describe("runCli exit behavior", () => {
     const stdout: string[] = [];
     const stderr: string[] = [];
     const previousRawConsole = loggingState.rawConsole;
-    const previousOverrideSettings = loggingState.overrideSettings;
+    const previousOverrideSettings = loggingState.overrideSettings as Parameters<
+      typeof setLoggerOverride
+    >[0];
     const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(((
       value: string | Uint8Array,
     ) => {
       stdout.push(String(value));
       return true;
     }) as typeof process.stdout.write);
-    loggingState.overrideSettings = {
+    setLoggerOverride({
       level: "silent",
       consoleLevel: "info",
       consoleStyle: "compact",
-    };
+    });
     loggingState.rawConsole = {
       log: (value) => stdout.push(String(value)),
       info: (value) => stdout.push(String(value)),
@@ -3282,7 +3285,7 @@ describe("runCli exit behavior", () => {
     } finally {
       stdoutWrite.mockRestore();
       loggingState.rawConsole = previousRawConsole;
-      loggingState.overrideSettings = previousOverrideSettings;
+      setLoggerOverride(previousOverrideSettings);
       loggingState.forceConsoleToStderr = false;
       loggingState.earlyConsoleRoutingRestore = null;
     }

--- a/src/gateway/server-broadcast.serialization.test.ts
+++ b/src/gateway/server-broadcast.serialization.test.ts
@@ -1,7 +1,9 @@
 // Covers broadcast frame-serialization failure: an unserializable payload must
 // not consume per-client seqs (which would fire every client's gap detector and
 // cause a synchronized reconnect storm) and must leave a server-side record.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setVerbose } from "../global-state.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
@@ -50,6 +52,12 @@ function makeClient(connId: string): { client: GatewayWsClient; socket: Recordin
   };
 }
 
+afterEach(() => {
+  setVerbose(false);
+  setLoggerOverride(null);
+  resetLogger();
+});
+
 describe("broadcast serialization failures", () => {
   it("drops the event without consuming seqs when the payload cannot serialize", () => {
     warnSpy.mockClear();
@@ -73,5 +81,27 @@ describe("broadcast serialization failures", () => {
     broadcast("skills.changed", { reason: "recovered" });
     expect(first.socket.frames).toEqual([{ event: "skills.changed", seq: 1 }]);
     expect(second.socket.frames).toEqual([{ event: "skills.changed", seq: 1 }]);
+  });
+
+  it("does not inspect agent log summaries for an ineligible outbound broadcast", () => {
+    setVerbose(true);
+    setLoggerOverride({ level: "silent", consoleLevel: "info" });
+    const filtered = makeClient("filtered");
+    filtered.client.connect.scopes = [];
+    const { broadcast } = createGatewayBroadcaster({ clients: new Set([filtered.client]) });
+    let dataReads = 0;
+    const payload = {
+      runId: "run-1",
+      stream: "assistant",
+      get data() {
+        dataReads += 1;
+        return { text: "not delivered" };
+      },
+    };
+
+    broadcast("agent", payload);
+
+    expect(filtered.socket.send).not.toHaveBeenCalled();
+    expect(dataReads).toBe(0);
   });
 });

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -30,7 +30,7 @@ import type {
 import type { SessionMessageSubscriberRegistry } from "./server-chat-state.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
-import { logWs, shouldLogWs, summarizeAgentEventForWsLog } from "./ws-log.js";
+import { logWs, summarizeAgentEventForWsLog } from "./ws-log.js";
 
 // Pairing scope is for device-pairing handshakes only; chat transcript events
 // require operator-level session access. Pairing-scoped and node-role clients
@@ -235,21 +235,7 @@ export function createGatewayBroadcaster(params: {
       opts?.agentId,
     );
     const isTargeted = Boolean(targetConnIds);
-    if (shouldLogWs()) {
-      const logMeta: Record<string, unknown> = {
-        event,
-        seq: "per-client",
-        clients: params.clients.size,
-        targets: targetConnIds ? targetConnIds.size : undefined,
-        dropIfSlow: opts?.dropIfSlow,
-        presenceVersion: opts?.stateVersion?.presence,
-        healthVersion: opts?.stateVersion?.health,
-      };
-      if (event === "agent") {
-        Object.assign(logMeta, summarizeAgentEventForWsLog(payload));
-      }
-      logWs("out", "event", logMeta);
-    }
+    let outboundEventLogged = false;
     let frameBase:
       | {
           eventJSON: string;
@@ -308,6 +294,24 @@ export function createGatewayBroadcaster(params: {
         // Scoped clients opt out of cross-session fanout, including critical observer announces.
         // The registry is authoritative; for cap-gated events, unscoped Control UI clients keep full fanout.
         continue;
+      }
+      if (!outboundEventLogged) {
+        outboundEventLogged = true;
+        logWs("out", "event", () => {
+          const logMeta: Record<string, unknown> = {
+            event,
+            seq: "per-client",
+            clients: params.clients.size,
+            targets: targetConnIds ? targetConnIds.size : undefined,
+            dropIfSlow: opts?.dropIfSlow,
+            presenceVersion: opts?.stateVersion?.presence,
+            healthVersion: opts?.stateVersion?.health,
+          };
+          if (event === "agent") {
+            Object.assign(logMeta, summarizeAgentEventForWsLog(payload));
+          }
+          return logMeta;
+        });
       }
       const nextSeq = (clientSeq.get(c) ?? 0) + 1;
       const slow = c.socket.bufferedAmount > MAX_BUFFERED_BYTES;

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -251,6 +251,7 @@ const hoisted = vi.hoisted(() => ({
   markRestartAbortedMainSessions: vi.fn(async (_params: unknown) => ({ marked: 1, skipped: 0 })),
   runtimeConfig: { value: { session: { store: "/tmp/active-sessions.json" } } as OpenClawConfig },
   assertOpenClawDatabasesReadyForRestart: vi.fn(() => {}),
+  applyLoggingConfig: vi.fn(),
   resetSkillSnapshotConfigFingerprintCache: vi.fn(),
   reloadEvents: [] as string[],
   loadModelCatalog: vi.fn(async (_params: { config: OpenClawConfig }) => []),
@@ -342,6 +343,11 @@ vi.mock("../config/config.js", async () => {
 
 vi.mock("../state/openclaw-database-preflight.js", () => ({
   assertOpenClawDatabasesReadyForRestart: hoisted.assertOpenClawDatabasesReadyForRestart,
+}));
+
+vi.mock("../logging/logger.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../logging/logger.js")>()),
+  applyLoggingConfig: hoisted.applyLoggingConfig,
 }));
 
 vi.mock("../skills/runtime/snapshot-config-fingerprint.js", async (importOriginal) => ({
@@ -895,6 +901,7 @@ beforeEach(() => {
   delete process.env.OPENCLAW_SKIP_CHANNELS;
   delete process.env.OPENCLAW_SKIP_PROVIDERS;
   hoisted.resetSkillSnapshotConfigFingerprintCache.mockClear();
+  hoisted.applyLoggingConfig.mockClear();
 });
 
 afterEach(() => {
@@ -933,6 +940,7 @@ afterEach(() => {
 
 async function runManagedOwnershipScenario(params: {
   kind: "noop" | "hot" | "restart";
+  loggingChanged?: boolean;
   queueRevert: boolean;
 }) {
   const initialConfig = {
@@ -950,6 +958,7 @@ async function runManagedOwnershipScenario(params: {
       token: "test-token",
       path: params.kind === "noop" ? "/old" : "/a",
     },
+    ...(params.loggingChanged ? { logging: { level: "debug" as const } } : {}),
   } satisfies OpenClawConfig;
   const configB = structuredClone(initialConfig);
   const snapshot = (config: OpenClawConfig) => makePreparedSecretsSnapshot(config);
@@ -1014,8 +1023,15 @@ describe("managed reload transaction ownership", () => {
     expect(result.acceptTerminalConfig).toHaveBeenCalledOnce();
     expect(result.prepareTerminalConfig).toHaveBeenCalledOnce();
     expect(result.reconcileTerminalSessions).toHaveBeenCalledOnce();
+    expect(hoisted.applyLoggingConfig).not.toHaveBeenCalled();
     expect(hoisted.resetSkillSnapshotConfigFingerprintCache).toHaveBeenCalledOnce();
     expect(getActiveSecretsRuntimeSnapshot()?.sourceConfig).toEqual(result.configA);
+  });
+
+  it("publishes logging-only changes from an applied hot config", async () => {
+    await runManagedOwnershipScenario({ kind: "hot", loggingChanged: true, queueRevert: false });
+
+    expect(hoisted.applyLoggingConfig).toHaveBeenCalledExactlyOnceWith({ level: "debug" });
   });
 
   it.each(["noop", "hot", "restart"] as const)(
@@ -3907,6 +3923,7 @@ describe("gateway Gmail hot reload handlers", () => {
         },
       ]);
       expect(hoisted.resetSkillSnapshotConfigFingerprintCache).not.toHaveBeenCalled();
+      expect(hoisted.applyLoggingConfig).not.toHaveBeenCalled();
     } finally {
       await reloader.stop();
     }

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -1,5 +1,6 @@
 import { copyConfigResolutionFacts } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { applyLoggingConfig } from "../logging/logger.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { getActiveSecretsRuntimeSnapshotRevisionState } from "../secrets/runtime-state.js";
 import { resetSkillSnapshotConfigFingerprintCache } from "../skills/runtime/snapshot-config-fingerprint.js";
@@ -451,9 +452,12 @@ export function startManagedGatewayConfigReloader(
         throw error;
       }
     },
-    onConfigApplied: (_plan, nextConfig) => {
+    onConfigApplied: (plan, nextConfig) => {
       // Applied runtime identity owns config-derived process memos; accepted
       // source-only changes must not evict caches for the still-active config.
+      if (plan.changedPaths.some((path) => path === "logging" || path.startsWith("logging."))) {
+        applyLoggingConfig(nextConfig.logging);
+      }
       resetSkillSnapshotConfigFingerprintCache();
       params.commitTerminalConfig(nextConfig);
     },

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -40,6 +40,8 @@ type FailSessionDeliveryMock =
   typeof import("../infra/session-delivery-queue-storage.js").failSessionDelivery;
 type RecoverPendingSessionDeliveriesMock =
   typeof import("../infra/session-delivery-queue-recovery.js").recoverPendingSessionDeliveries;
+type DrainPendingSessionDeliveryMock =
+  typeof import("../infra/session-delivery-queue-recovery.js").drainPendingSessionDelivery;
 type AppendAssistantMessageToSessionTranscriptMock =
   typeof import("../config/sessions/transcript.js").appendAssistantMessageToSessionTranscript;
 
@@ -173,7 +175,7 @@ const mocks = vi.hoisted(() => {
     removeCronRunContinuationSessionIfIdle: vi.fn(async () => {}),
     settleCorrelatedSubagentDelivery: vi.fn(async () => {}),
     loadPendingSessionDelivery: vi.fn(),
-    drainPendingSessionDeliveries: vi.fn(),
+    drainPendingSessionDelivery: vi.fn<DrainPendingSessionDeliveryMock>(),
     recoverPendingSessionDeliveries: vi.fn<RecoverPendingSessionDeliveriesMock>(),
     resolveAgentConfig: vi.fn(() => undefined),
     resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-test-workspace"),
@@ -252,11 +254,11 @@ vi.mock("../infra/session-delivery-queue-storage.js", async (importOriginal) => 
 vi.mock("../infra/session-delivery-queue-recovery.js", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../infra/session-delivery-queue-recovery.js")>();
-  mocks.drainPendingSessionDeliveries.mockImplementation(actual.drainPendingSessionDeliveries);
+  mocks.drainPendingSessionDelivery.mockImplementation(actual.drainPendingSessionDelivery);
   mocks.recoverPendingSessionDeliveries.mockImplementation(actual.recoverPendingSessionDeliveries);
   return {
     ...actual,
-    drainPendingSessionDeliveries: mocks.drainPendingSessionDeliveries,
+    drainPendingSessionDelivery: mocks.drainPendingSessionDelivery,
     recoverPendingSessionDeliveries: mocks.recoverPendingSessionDeliveries,
   };
 });
@@ -676,7 +678,7 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.removeCronRunContinuationSessionIfIdle.mockClear();
     mocks.settleCorrelatedSubagentDelivery.mockClear();
     mocks.loadPendingSessionDelivery.mockClear();
-    mocks.drainPendingSessionDeliveries.mockClear();
+    mocks.drainPendingSessionDelivery.mockClear();
     mocks.recoverPendingSessionDeliveries.mockClear();
     mocks.finalizeUpdateRestartSentinelRunningVersion.mockReset();
     mocks.finalizeUpdateRestartSentinelRunningVersion.mockResolvedValue(null);
@@ -728,8 +730,10 @@ describe("scheduleRestartSentinelWake", () => {
   it("uses the same producer settlement callback for targeted recovery", async () => {
     await scheduleRestartSentinelWake({ deps: {} as never });
 
-    const targeted = mocks.drainPendingSessionDeliveries.mock.calls[0]?.[0];
+    const targeted = mocks.drainPendingSessionDelivery.mock.calls[0]?.[0];
     expect(targeted?.onSettled).toBe(settleQueuedSessionDelivery);
+    expect(targeted).toMatchObject({ bypassBackoff: true, id: expect.any(String) });
+    expect(targeted).not.toHaveProperty("drainKey");
   });
 
   it("enqueues the sentinel note and wakes the session even when outbound delivery succeeds", async () => {
@@ -2656,7 +2660,7 @@ describe("scheduleRestartSentinelWake", () => {
     await scheduleRestartSentinelWake({ deps: {} as never });
 
     expect(mocks.clearRestartSentinelIfRevision).not.toHaveBeenCalled();
-    expect(mocks.drainPendingSessionDeliveries).not.toHaveBeenCalled();
+    expect(mocks.drainPendingSessionDelivery).not.toHaveBeenCalled();
     expect(mocks.logWarn).toHaveBeenCalledWith("startup task failed", {
       source: "restart-sentinel",
       sessionKey: "agent:main:main",
@@ -2777,7 +2781,7 @@ describe("scheduleRestartSentinelWake", () => {
       expect(mocks.enqueueSessionDelivery).not.toHaveBeenCalled();
       expect(mocks.enqueueSystemEvent).not.toHaveBeenCalled();
       expect(mocks.requestHeartbeat).not.toHaveBeenCalled();
-      expect(mocks.drainPendingSessionDeliveries).not.toHaveBeenCalled();
+      expect(mocks.drainPendingSessionDelivery).not.toHaveBeenCalled();
     },
   );
 

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -28,14 +28,13 @@ import {
   summarizeRestartSentinel,
 } from "../infra/restart-sentinel.js";
 import {
-  drainPendingSessionDeliveries,
+  drainPendingSessionDelivery,
   recoverPendingSessionDeliveries,
   type SessionDeliveryRecoveryLogger,
   type SettleSessionDeliveryFn,
 } from "../infra/session-delivery-queue-recovery.js";
 import {
   enqueueSessionDelivery,
-  loadPendingSessionDelivery,
   markSessionDeliveryAttemptStarted,
   markSessionDeliverySettlement,
   SessionDeliveryDeadLetteredError,
@@ -406,10 +405,11 @@ async function drainRestartContinuationQueue(params: {
   log: SessionDeliveryRecoveryLogger;
 }) {
   for (let attempt = 1; attempt <= RESTART_CONTINUATION_BUSY_MAX_ATTEMPTS; attempt += 1) {
-    await drainPendingSessionDeliveries({
-      drainKey: `restart-continuation:${params.entryId}`,
+    const queued = await drainPendingSessionDelivery({
+      id: params.entryId,
       logLabel: "restart continuation",
       log: params.log,
+      bypassBackoff: true,
       deliver: (entry, context = {}) =>
         deliverQueuedSessionDelivery({
           deps: params.deps,
@@ -417,13 +417,8 @@ async function drainRestartContinuationQueue(params: {
           ...(context.stateDir !== undefined ? { stateDir: context.stateDir } : {}),
         }),
       onSettled: settleQueuedSessionDelivery,
-      selectEntry: (entry) => ({
-        match: entry.id === params.entryId,
-        bypassBackoff: true,
-      }),
     });
 
-    const queued = await loadPendingSessionDelivery(params.entryId);
     if (!isRestartContinuationBusyRetry(queued)) {
       return;
     }

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -35,6 +35,7 @@ import { readGatewayRestartHandoffSync } from "../infra/restart-handoff.js";
 import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../infra/restart.js";
 import { withSystemEventOwner } from "../infra/system-event-ownership.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
+import { applyLoggingConfig } from "../logging/logger.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { completePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
@@ -440,6 +441,7 @@ export async function prepareGatewayServerBootstrap(input: {
     startupLastGoodSnapshot = startupSnapshot;
   }
   setAppliedRuntimeConfigSnapshot(cfgAtStart, startupLastGoodSnapshot.sourceConfig);
+  applyLoggingConfig(cfgAtStart.logging);
   initializePublishedConfigRuntimeEnv(startupLastGoodSnapshot.sourceConfig, {
     ownedEnv: collectConfigRuntimeEnvOwnership(
       startupLastGoodSnapshot.sourceConfig,

--- a/src/gateway/server-startup-minimal-boot.test.ts
+++ b/src/gateway/server-startup-minimal-boot.test.ts
@@ -3,8 +3,10 @@
 // gateway boot tests do) hides startup work that materializes plugin runtime,
 // which is exactly how a startup stall shipped green while hanging every
 // ui-e2e suite that boots a minimal test gateway.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetConfigRuntimeState } from "../config/runtime-snapshot.js";
+import { readLoggingConfig } from "../logging/config.js";
+import { resetLogger } from "../logging/logger.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -16,6 +18,8 @@ import { getFreePort } from "../test-utils/ports.js";
 const BOOT_BUDGET_MS = 90_000;
 
 afterEach(() => {
+  resetLogger();
+  vi.unstubAllEnvs();
   resetConfigRuntimeState();
   clearPluginMetadataLifecycleCaches();
 });
@@ -38,7 +42,11 @@ describe("gateway minimal boot smoke", () => {
       },
     });
     const token = "gateway-bootstrap-test-token";
-    await state.writeConfig({ gateway: { auth: { mode: "token", token } }, plugins: {} });
+    await state.writeConfig({
+      gateway: { auth: { mode: "token", token } },
+      logging: { level: "debug" },
+      plugins: {},
+    });
     state.applyEnv();
 
     try {
@@ -60,6 +68,11 @@ describe("gateway minimal boot smoke", () => {
       });
 
       expect(bootstrap.ambientEnvTriggers).toBe("suppress");
+      vi.stubEnv(
+        "OPENCLAW_CONFIG_PATH",
+        `/tmp/openclaw-bootstrap-missing-${process.pid}-${Date.now()}.json`,
+      );
+      expect(readLoggingConfig()).toMatchObject({ level: "debug" });
     } finally {
       await state.cleanup();
     }

--- a/src/gateway/server.agent.gateway-server-agent-a.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-a.test.ts
@@ -17,6 +17,7 @@ import {
   type AgentRunDelegatedAuthority,
   validateAgentRunDelegatedAuthority,
 } from "../infra/agent-run-registry.js";
+import { redactSensitiveText } from "../logging/redact.js";
 import * as mediaStore from "../media/store.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -900,9 +901,12 @@ describe("gateway server agent", () => {
       },
       { mode: "full", reason: "durable agent media custody regression" },
     );
+    // Inbound ids are random; compare the durable fact against its public
+    // redaction contract because an id can resemble sensitive text.
+    const transcriptMediaUrl = media?.[0]?.url ? redactSensitiveText(media[0].url) : undefined;
     expect(
       (transcript[0] as { __openclaw?: { media?: Array<{ url?: string }> } })["__openclaw"]?.media,
-    ).toEqual(expect.arrayContaining([expect.objectContaining({ url: media?.[0]?.url })]));
+    ).toEqual(expect.arrayContaining([expect.objectContaining({ url: transcriptMediaUrl })]));
     const inboundAfter = await listInboundMedia();
     expect([...inboundAfter].filter((entry) => !inboundBefore.has(entry))).toHaveLength(1);
   });

--- a/src/gateway/ws-log.test.ts
+++ b/src/gateway/ws-log.test.ts
@@ -1,10 +1,50 @@
 /**
  * Gateway WebSocket log formatting tests.
  */
-import { describe, expect, test } from "vitest";
-import { formatForLog, summarizeAgentEventForWsLog } from "./ws-log.js";
+import { afterEach, describe, expect, test } from "vitest";
+import { setVerbose } from "../global-state.js";
+import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { formatForLog, logWs, summarizeAgentEventForWsLog } from "./ws-log.js";
+
+function shouldLogWs(direction: "in" | "out", kind: string): boolean {
+  let admitted = false;
+  logWs(direction, kind, () => {
+    admitted = true;
+    return { connId: "matrix", id: `matrix-${kind}`, ok: true };
+  });
+  return admitted;
+}
+
+afterEach(() => {
+  setVerbose(false);
+  setLoggerOverride(null);
+  resetLogger();
+});
 
 describe("gateway ws log helpers", () => {
+  test("admits only useful optimized-mode frames and honors console info enablement", () => {
+    setVerbose(false);
+    setLoggerOverride({ level: "silent", consoleLevel: "info" });
+
+    expect(shouldLogWs("out", "event")).toBe(false);
+    expect(shouldLogWs("in", "req")).toBe(true);
+    expect(shouldLogWs("out", "res")).toBe(true);
+    expect(shouldLogWs("out", "parse-error")).toBe(true);
+
+    setVerbose(true);
+    expect(shouldLogWs("out", "event")).toBe(true);
+
+    setVerbose(false);
+    setLoggerOverride({ level: "info", consoleLevel: "warn" });
+    expect(shouldLogWs("in", "req")).toBe(true);
+    expect(shouldLogWs("out", "res")).toBe(true);
+    expect(shouldLogWs("out", "parse-error")).toBe(true);
+    expect(shouldLogWs("out", "event")).toBe(false);
+
+    setVerbose(true);
+    expect(shouldLogWs("out", "event")).toBe(true);
+  });
+
   test.each([
     {
       name: "run ID prefix boundary",

--- a/src/gateway/ws-log.ts
+++ b/src/gateway/ws-log.ts
@@ -7,7 +7,6 @@ import chalk from "chalk";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { isVerbose } from "../globals.js";
 import { stringifyNonErrorCause } from "../infra/errors.js";
-import { shouldLogSubsystemToConsole } from "../logging/console.js";
 import { getDefaultRedactPatterns, redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
@@ -96,9 +95,17 @@ function logWsInfoLine(params: {
   wsLog.info(tokens.join(" "));
 }
 
-/** Returns true when gateway WebSocket logging is enabled for the current console. */
-export function shouldLogWs(): boolean {
-  return shouldLogSubsystemToConsole("gateway/ws");
+/** Returns true when a frame can produce console output or required timing state. */
+function shouldLogWs(direction: "in" | "out", kind: string): boolean {
+  if (isVerbose()) {
+    return wsLog.isEnabled("info");
+  }
+  if (kind === "parse-error") {
+    return wsLog.isEnabled("warn");
+  }
+  const recordsTiming = direction === "in" && kind === "req";
+  const readsTiming = direction === "out" && kind === "res";
+  return (recordsTiming || readsTiming) && wsLog.isEnabled("info");
 }
 
 /** Compacts long ids while keeping enough entropy for log correlation. */
@@ -292,10 +299,15 @@ export function summarizeAgentEventForWsLog(payload: unknown): Record<string, un
   return extra;
 }
 
-export function logWs(direction: "in" | "out", kind: string, meta?: Record<string, unknown>) {
-  if (!shouldLogSubsystemToConsole("gateway/ws")) {
+export function logWs(
+  direction: "in" | "out",
+  kind: string,
+  metaInput?: Record<string, unknown> | (() => Record<string, unknown>),
+) {
+  if (!shouldLogWs(direction, kind)) {
     return;
   }
+  const meta = typeof metaInput === "function" ? metaInput() : metaInput;
   const style = getGatewayWsLogStyle();
   if (!isVerbose()) {
     logWsOptimized(direction, kind, meta);

--- a/src/infra/diagnostic-event-listener-presence.ts
+++ b/src/infra/diagnostic-event-listener-presence.ts
@@ -1,10 +1,13 @@
 /** Process-wide listener counts used to avoid telemetry work without consumers. */
+import type { DiagnosticEventPayload } from "./diagnostic-events.js";
 
 const DIAGNOSTIC_EVENT_LISTENER_PRESENCE_KEY = Symbol.for(
   "openclaw.diagnosticEventListenerPresence.v1",
 );
 
 type DiagnosticEventListenerPresence = {
+  broadInterestCount: number;
+  eventInterestDeltas: Map<DiagnosticEventPayload["type"], number>;
   marker: symbol;
   internalCount: number;
   trustedCount: number;
@@ -19,9 +22,14 @@ function getDiagnosticEventListenerPresence(): DiagnosticEventListenerPresence {
     (existing as Partial<DiagnosticEventListenerPresence>).marker ===
       DIAGNOSTIC_EVENT_LISTENER_PRESENCE_KEY
   ) {
-    return existing as DiagnosticEventListenerPresence;
+    const state = existing as DiagnosticEventListenerPresence;
+    state.broadInterestCount ??= 0;
+    state.eventInterestDeltas ??= new Map();
+    return state;
   }
   const state: DiagnosticEventListenerPresence = {
+    broadInterestCount: 0,
+    eventInterestDeltas: new Map(),
     marker: DIAGNOSTIC_EVENT_LISTENER_PRESENCE_KEY,
     internalCount: 0,
     trustedCount: 0,
@@ -33,6 +41,56 @@ function getDiagnosticEventListenerPresence(): DiagnosticEventListenerPresence {
     writable: false,
   });
   return state;
+}
+
+export type InternalDiagnosticEventInterest = Readonly<{
+  include?: readonly DiagnosticEventPayload["type"][];
+  exclude?: readonly DiagnosticEventPayload["type"][];
+}>;
+
+function updateEventInterestDelta(
+  state: DiagnosticEventListenerPresence,
+  type: DiagnosticEventPayload["type"],
+  delta: number,
+): void {
+  const next = (state.eventInterestDeltas.get(type) ?? 0) + delta;
+  if (next === 0) {
+    state.eventInterestDeltas.delete(type);
+  } else {
+    state.eventInterestDeltas.set(type, next);
+  }
+}
+
+export function updateInternalDiagnosticEventInterest(
+  interest: InternalDiagnosticEventInterest | undefined,
+  delta: 1 | -1,
+): void {
+  const state = getDiagnosticEventListenerPresence();
+  if (interest?.include) {
+    for (const type of new Set(interest.include)) {
+      if (!interest.exclude?.includes(type)) {
+        updateEventInterestDelta(state, type, delta);
+      }
+    }
+    return;
+  }
+  state.broadInterestCount += delta;
+  for (const type of new Set(interest?.exclude ?? [])) {
+    updateEventInterestDelta(state, type, -delta);
+  }
+}
+
+export function hasInternalDiagnosticEventInterest(type: DiagnosticEventPayload["type"]): boolean {
+  const state = getDiagnosticEventListenerPresence();
+  return state.broadInterestCount + (state.eventInterestDeltas.get(type) ?? 0) > 0;
+}
+
+export function resetInternalDiagnosticEventListenerPresence(): void {
+  const state = getDiagnosticEventListenerPresence();
+  state.internalCount = 0;
+  state.trustedCount = 0;
+  state.broadInterestCount = 0;
+  state.eventInterestDeltas.clear();
 }
 
 export function setInternalDiagnosticEventListenerCounts(

--- a/src/infra/diagnostic-event-listener-presence.ts
+++ b/src/infra/diagnostic-event-listener-presence.ts
@@ -1,5 +1,4 @@
 /** Process-wide listener counts used to avoid telemetry work without consumers. */
-import type { DiagnosticEventPayload } from "./diagnostic-events.js";
 
 const DIAGNOSTIC_EVENT_LISTENER_PRESENCE_KEY = Symbol.for(
   "openclaw.diagnosticEventListenerPresence.v1",
@@ -7,7 +6,7 @@ const DIAGNOSTIC_EVENT_LISTENER_PRESENCE_KEY = Symbol.for(
 
 type DiagnosticEventListenerPresence = {
   broadInterestCount: number;
-  eventInterestDeltas: Map<DiagnosticEventPayload["type"], number>;
+  eventInterestDeltas: Map<string, number>;
   marker: symbol;
   internalCount: number;
   trustedCount: number;
@@ -43,14 +42,14 @@ function getDiagnosticEventListenerPresence(): DiagnosticEventListenerPresence {
   return state;
 }
 
-export type InternalDiagnosticEventInterest = Readonly<{
-  include?: readonly DiagnosticEventPayload["type"][];
-  exclude?: readonly DiagnosticEventPayload["type"][];
+export type InternalDiagnosticEventInterest<EventType extends string = string> = Readonly<{
+  include?: readonly EventType[];
+  exclude?: readonly EventType[];
 }>;
 
 function updateEventInterestDelta(
   state: DiagnosticEventListenerPresence,
-  type: DiagnosticEventPayload["type"],
+  type: string,
   delta: number,
 ): void {
   const next = (state.eventInterestDeltas.get(type) ?? 0) + delta;
@@ -80,7 +79,7 @@ export function updateInternalDiagnosticEventInterest(
   }
 }
 
-export function hasInternalDiagnosticEventInterest(type: DiagnosticEventPayload["type"]): boolean {
+export function hasInternalDiagnosticEventInterest(type: string): boolean {
   const state = getDiagnosticEventListenerPresence();
   return state.broadInterestCount + (state.eventInterestDeltas.get(type) ?? 0) > 0;
 }

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -1,6 +1,9 @@
 // Covers diagnostic event emission and metadata handling.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { hasInternalDiagnosticEventListeners } from "./diagnostic-event-listener-presence.js";
+import {
+  hasInternalDiagnosticEventInterest,
+  hasInternalDiagnosticEventListeners,
+} from "./diagnostic-event-listener-presence.js";
 import {
   areDiagnosticsEnabledForProcess,
   emitDiagnosticEvent,
@@ -144,6 +147,42 @@ describe("diagnostic-events", () => {
       error: "failed",
     });
     expect(seen).toEqual(["webhook.received"]);
+  });
+
+  it("applies internal listener interests before dispatch", async () => {
+    const included: string[] = [];
+    const excluded: string[] = [];
+    onInternalDiagnosticEvent((event) => included.push(event.type), {
+      include: ["message.queued"],
+    });
+    onTrustedInternalDiagnosticEvent((event) => excluded.push(event.type), {
+      exclude: ["log.record"],
+    });
+
+    emitDiagnosticEvent({ type: "message.queued", source: "plugin" });
+    emitDiagnosticEvent({ type: "log.record", level: "INFO", message: "ignored" });
+    await waitForDiagnosticEventsDrained();
+
+    expect(included).toEqual(["message.queued"]);
+    expect(excluded).toEqual(["message.queued"]);
+  });
+
+  it("tracks broad, included, and excluded event interest through unsubscribe and reset", () => {
+    const stopBroad = onInternalDiagnosticEvent(() => undefined);
+    expect(hasInternalDiagnosticEventInterest("log.record")).toBe(true);
+    stopBroad();
+    expect(hasInternalDiagnosticEventInterest("log.record")).toBe(false);
+
+    const stopIncluded = onInternalDiagnosticEvent(() => undefined, {
+      include: ["message.queued", "log.record"],
+      exclude: ["log.record"],
+    });
+    expect(hasInternalDiagnosticEventInterest("message.queued")).toBe(true);
+    expect(hasInternalDiagnosticEventInterest("log.record")).toBe(false);
+
+    resetDiagnosticEventsForTest();
+    expect(hasInternalDiagnosticEventInterest("message.queued")).toBe(false);
+    stopIncluded();
   });
 
   it("carries explicit trace context without creating retained trace state", () => {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -3,7 +3,12 @@ import { randomUUID } from "node:crypto";
 import type { EmbeddedAgentExecutionPhase } from "../agents/embedded-agent-runner/execution-phase.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { TalkBrain, TalkEventType, TalkMode, TalkTransport } from "../talk/talk-events.js";
-import { setInternalDiagnosticEventListenerCounts } from "./diagnostic-event-listener-presence.js";
+import {
+  resetInternalDiagnosticEventListenerPresence,
+  setInternalDiagnosticEventListenerCounts,
+  type InternalDiagnosticEventInterest,
+  updateInternalDiagnosticEventInterest,
+} from "./diagnostic-event-listener-presence.js";
 import {
   consumeCoreModelRequestLifecycleDiagnosticEvent,
   CORE_MODEL_REQUEST_LIFECYCLE_METADATA_KEY,
@@ -943,8 +948,11 @@ type DiagnosticEventsGlobalState = {
   marker: symbol;
   enabled: boolean;
   seq: number;
-  listeners: Set<DiagnosticEventListener>;
-  trustedListeners: Set<TrustedDiagnosticEventListener>;
+  listeners: Map<DiagnosticEventListener, InternalDiagnosticEventInterest | undefined>;
+  trustedListeners: Map<
+    TrustedDiagnosticEventListener,
+    InternalDiagnosticEventInterest | undefined
+  >;
   toolExecutionListeners: Set<TrustedToolExecutionEventListener>;
   toolExecutionSeq: number;
   dispatchDepth: number;
@@ -998,8 +1006,8 @@ function createDiagnosticEventsState(): DiagnosticEventsGlobalState {
     marker: DIAGNOSTIC_EVENTS_STATE_KEY,
     enabled: true,
     seq: 0,
-    listeners: new Set<DiagnosticEventListener>(),
-    trustedListeners: new Set<TrustedDiagnosticEventListener>(),
+    listeners: new Map(),
+    trustedListeners: new Map(),
     toolExecutionListeners: new Set<TrustedToolExecutionEventListener>(),
     toolExecutionSeq: 0,
     dispatchDepth: 0,
@@ -1021,8 +1029,8 @@ function isDiagnosticEventsState(value: unknown): value is DiagnosticEventsGloba
     candidate.marker === DIAGNOSTIC_EVENTS_STATE_KEY &&
     typeof candidate.enabled === "boolean" &&
     typeof candidate.seq === "number" &&
-    candidate.listeners instanceof Set &&
-    (candidate.trustedListeners === undefined || candidate.trustedListeners instanceof Set) &&
+    candidate.listeners instanceof Map &&
+    candidate.trustedListeners instanceof Map &&
     (candidate.toolExecutionListeners === undefined ||
       candidate.toolExecutionListeners instanceof Set) &&
     typeof candidate.dispatchDepth === "number" &&
@@ -1039,7 +1047,6 @@ function getDiagnosticEventsState(): DiagnosticEventsGlobalState {
     existing.asyncDroppedTrustedEvents ??= 0;
     existing.asyncDroppedUntrustedEvents ??= 0;
     existing.asyncDroppedPriorityEvents ??= 0;
-    existing.trustedListeners ??= new Set<TrustedDiagnosticEventListener>();
     existing.toolExecutionListeners ??= new Set<TrustedToolExecutionEventListener>();
     existing.toolExecutionSeq ??= 0;
     return existing;
@@ -1069,6 +1076,15 @@ export function areDiagnosticsEnabledForProcess(): boolean {
   return getDiagnosticEventsState().enabled;
 }
 
+function isDiagnosticEventListenerInterested(
+  interest: InternalDiagnosticEventInterest | undefined,
+  type: DiagnosticEventPayload["type"],
+): boolean {
+  return (
+    (!interest?.include || interest.include.includes(type)) && !interest?.exclude?.includes(type)
+  );
+}
+
 function dispatchDiagnosticEvent(
   state: DiagnosticEventsGlobalState,
   enriched: DiagnosticEventPayload,
@@ -1086,7 +1102,10 @@ function dispatchDiagnosticEvent(
   state.dispatchDepth += 1;
   try {
     if (!options.trustedListenersOnly) {
-      for (const listener of state.listeners) {
+      for (const [listener, interest] of state.listeners) {
+        if (!isDiagnosticEventListenerInterested(interest, enriched.type)) {
+          continue;
+        }
         try {
           listener(
             cloneDiagnosticEventForListener(enriched),
@@ -1106,7 +1125,10 @@ function dispatchDiagnosticEvent(
         }
       }
     }
-    for (const listener of state.trustedListeners) {
+    for (const [listener, interest] of state.trustedListeners) {
+      if (!isDiagnosticEventListenerInterested(interest, enriched.type)) {
+        continue;
+      }
       try {
         const eventForListener = cloneDiagnosticEventForListener(enriched);
         const metadataForListener = createDiagnosticMetadataForListener(metadata);
@@ -1516,26 +1538,44 @@ export function emitFailoverEvent(event: Omit<DiagnosticFailoverEvent, "seq" | "
   });
 }
 
-/** Subscribes to all diagnostic events with dispatcher metadata. */
-export function onInternalDiagnosticEvent(listener: DiagnosticEventListener): () => void {
+/** Subscribes to diagnostic events with dispatcher metadata. */
+export function onInternalDiagnosticEvent(
+  listener: DiagnosticEventListener,
+  filter?: InternalDiagnosticEventInterest,
+): () => void {
   const state = getDiagnosticEventsState();
-  state.listeners.add(listener);
+  if (state.listeners.has(listener)) {
+    updateInternalDiagnosticEventInterest(state.listeners.get(listener), -1);
+  }
+  state.listeners.set(listener, filter);
+  updateInternalDiagnosticEventInterest(filter, 1);
   setInternalDiagnosticEventListenerCounts(state.listeners.size, state.trustedListeners.size);
   return () => {
-    state.listeners.delete(listener);
+    const interest = state.listeners.get(listener);
+    if (state.listeners.delete(listener)) {
+      updateInternalDiagnosticEventInterest(interest, -1);
+    }
     setInternalDiagnosticEventListenerCounts(state.listeners.size, state.trustedListeners.size);
   };
 }
 
-/** Subscribes to all diagnostic events plus trusted private payload data. */
+/** Subscribes to diagnostic events plus trusted private payload data. */
 export function onTrustedInternalDiagnosticEvent(
   listener: TrustedDiagnosticEventListener,
+  filter?: InternalDiagnosticEventInterest,
 ): () => void {
   const state = getDiagnosticEventsState();
-  state.trustedListeners.add(listener);
+  if (state.trustedListeners.has(listener)) {
+    updateInternalDiagnosticEventInterest(state.trustedListeners.get(listener), -1);
+  }
+  state.trustedListeners.set(listener, filter);
+  updateInternalDiagnosticEventInterest(filter, 1);
   setInternalDiagnosticEventListenerCounts(state.listeners.size, state.trustedListeners.size);
   return () => {
-    state.trustedListeners.delete(listener);
+    const interest = state.trustedListeners.get(listener);
+    if (state.trustedListeners.delete(listener)) {
+      updateInternalDiagnosticEventInterest(interest, -1);
+    }
     setInternalDiagnosticEventListenerCounts(state.listeners.size, state.trustedListeners.size);
   };
 }
@@ -1572,12 +1612,15 @@ export function hasPendingInternalDiagnosticEvent(
 
 /** Subscribes to public untrusted diagnostic events only. */
 export function onDiagnosticEvent(listener: (evt: DiagnosticEventPayload) => void): () => void {
-  return onInternalDiagnosticEvent((event, metadata) => {
-    if (metadata.trusted || event.type === "log.record") {
-      return;
-    }
-    listener(event);
-  });
+  return onInternalDiagnosticEvent(
+    (event, metadata) => {
+      if (metadata.trusted) {
+        return;
+      }
+      listener(event);
+    },
+    { exclude: ["log.record"] },
+  );
 }
 
 /** Returns whether listener metadata marks dispatcher-internal provenance. */
@@ -1592,7 +1635,7 @@ export function resetDiagnosticEventsForTest(): void {
   state.seq = 0;
   state.listeners.clear();
   state.trustedListeners.clear();
-  setInternalDiagnosticEventListenerCounts(0, 0);
+  resetInternalDiagnosticEventListenerPresence();
   state.toolExecutionListeners.clear();
   state.toolExecutionSeq = 0;
   state.dispatchDepth = 0;

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -948,10 +948,13 @@ type DiagnosticEventsGlobalState = {
   marker: symbol;
   enabled: boolean;
   seq: number;
-  listeners: Map<DiagnosticEventListener, InternalDiagnosticEventInterest | undefined>;
+  listeners: Map<
+    DiagnosticEventListener,
+    InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]> | undefined
+  >;
   trustedListeners: Map<
     TrustedDiagnosticEventListener,
-    InternalDiagnosticEventInterest | undefined
+    InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]> | undefined
   >;
   toolExecutionListeners: Set<TrustedToolExecutionEventListener>;
   toolExecutionSeq: number;
@@ -1077,7 +1080,7 @@ export function areDiagnosticsEnabledForProcess(): boolean {
 }
 
 function isDiagnosticEventListenerInterested(
-  interest: InternalDiagnosticEventInterest | undefined,
+  interest: InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]> | undefined,
   type: DiagnosticEventPayload["type"],
 ): boolean {
   return (
@@ -1541,7 +1544,7 @@ export function emitFailoverEvent(event: Omit<DiagnosticFailoverEvent, "seq" | "
 /** Subscribes to diagnostic events with dispatcher metadata. */
 export function onInternalDiagnosticEvent(
   listener: DiagnosticEventListener,
-  filter?: InternalDiagnosticEventInterest,
+  filter?: InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]>,
 ): () => void {
   const state = getDiagnosticEventsState();
   if (state.listeners.has(listener)) {
@@ -1562,7 +1565,7 @@ export function onInternalDiagnosticEvent(
 /** Subscribes to diagnostic events plus trusted private payload data. */
 export function onTrustedInternalDiagnosticEvent(
   listener: TrustedDiagnosticEventListener,
-  filter?: InternalDiagnosticEventInterest,
+  filter?: InternalDiagnosticEventInterest<DiagnosticEventPayload["type"]>,
 ): () => void {
   const state = getDiagnosticEventsState();
   if (state.trustedListeners.has(listener)) {

--- a/src/infra/session-delivery-queue-recovery.ts
+++ b/src/infra/session-delivery-queue-recovery.ts
@@ -5,7 +5,6 @@ import {
   getErrnoCode,
   isDeliveryRecoveryRetryEligible,
   resolveDeliveryRecoveryDeadlineMs,
-  type DeliveryRecoveryDrainDecision,
   type DeliveryRecoverySummary,
 } from "./delivery-recovery.shared.js";
 import { formatErrorMessage } from "./errors.js";
@@ -119,148 +118,161 @@ function resolveSessionRetryEligibility(entry: QueuedSessionDelivery, now: numbe
   return isDeliveryRecoveryRetryEligible(entry, now);
 }
 
-async function drainQueuedEntry(opts: {
-  entry: QueuedSessionDelivery;
-  deliver: DeliverSessionDeliveryFn;
-  stateDir?: string;
-  onFailed?: (entry: QueuedSessionDelivery, errMsg: string) => void;
-}): Promise<"recovered" | "failed" | "deferred" | "moved-to-failed" | "already-gone"> {
-  const { entry } = opts;
-  try {
-    const pendingOutcome = resolvePendingSettlementOutcome(entry);
-    if (pendingOutcome) {
-      return pendingOutcome;
-    }
-    await opts.deliver(entry, { stateDir: opts.stateDir });
-    // Keep route/session metadata pending until owner cleanup succeeds. Recovery
-    // sees this marker and finalizes without replaying the external side effect.
-    await markSessionDeliverySettlement(entry, "recovered", opts.stateDir);
-    return "recovered";
-  } catch (err) {
-    if (err instanceof SessionDeliveryDeadLetteredError) {
-      try {
-        await markSessionDeliverySettlement(entry, "moved-to-failed", opts.stateDir);
-      } catch (markError) {
-        if (markError instanceof SessionDeliveryAcknowledgementFinalizeError) {
-          return "deferred";
-        }
-        throw markError;
-      }
-      return "moved-to-failed";
-    }
-    if (err instanceof SessionDeliveryDeferredError) {
-      return "deferred";
-    }
-    if (err instanceof SessionDeliveryAcknowledgementFinalizeError) {
-      return "deferred";
-    }
-    if (err instanceof SessionDeliveryAttemptStartError) {
-      return "deferred";
-    }
-    const errMsg = formatErrorMessage(err);
-    opts.onFailed?.(entry, errMsg);
-    if (err instanceof SessionDeliveryRetryChargedError) {
-      return "failed";
-    }
-    try {
-      await failSessionDelivery(entry.id, errMsg, opts.stateDir, {
-        releaseAttemptOwnership: err instanceof SessionDeliverySafeRetryError,
-      });
-      return "failed";
-    } catch (failErr) {
-      if (getErrnoCode(failErr) === "ENOENT") {
-        return "already-gone";
-      }
-      // A non-ENOENT persistence failure here means the retry metadata
-      // (retryCount/lastAttemptAt) never advanced, so swallowing it as "failed"
-      // re-drives the same entry forever without progressing toward the
-      // max-retries terminal move. Surface it like the sibling moveToFailed
-      // paths below, which also re-throw non-ENOENT.
-      throw failErr;
-    }
-  }
-}
-
-/** Drain matching queued session deliveries with retry/backoff protection. */
-export async function drainPendingSessionDeliveries(opts: {
-  drainKey: string;
+type SessionDeliveryDrainContext = {
   logLabel: string;
   log: SessionDeliveryRecoveryLogger;
   stateDir?: string;
   deliver: DeliverSessionDeliveryFn;
   onSettled?: SettleSessionDeliveryFn;
-  selectEntry: (entry: QueuedSessionDelivery, now: number) => DeliveryRecoveryDrainDecision;
-}): Promise<void> {
-  const drained = await recoveryCoordinator.withDrain(opts.drainKey, async () => {
-    const matchingEntries = (await loadPendingSessionDeliveries(opts.stateDir)).filter(
-      (entry) => opts.selectEntry(entry, Date.now()).match,
-    );
-    await recoveryCoordinator.scan({
-      entries: matchingEntries,
-      loadEntry: (id) => loadPendingSessionDelivery(id, opts.stateDir),
-      onClaimConflict: (entry) => {
-        opts.log.info(`${opts.logLabel}: entry ${entry.id} is already being recovered`);
-      },
-      onEntry: async (currentEntry) => {
-        const currentDecision = opts.selectEntry(currentEntry, Date.now());
-        if (!currentDecision.match) {
-          return;
-        }
-        const pendingSettlementOutcome = resolvePendingSettlementOutcome(currentEntry);
-        if (
-          !pendingSettlementOutcome &&
-          !canReconcileStartedAgentAttemptAtRetryLimit(currentEntry) &&
-          currentEntry.retryCount >= resolveSessionDeliveryMaxRetries(currentEntry)
-        ) {
-          await markSessionDeliverySettlement(currentEntry, "moved-to-failed", opts.stateDir);
-          const finalized = await finalizeSessionDeliverySettlement({
-            entry: currentEntry,
-            log: opts.log,
-            onSettled: opts.onSettled,
-            outcome: "moved-to-failed",
-            stateDir: opts.stateDir,
-          });
-          if (finalized) {
-            opts.log.warn(
-              `${opts.logLabel}: entry ${currentEntry.id} exceeded max retries and was moved to failed`,
-            );
-          }
-          return;
-        }
+};
 
-        if (!pendingSettlementOutcome && !currentDecision.bypassBackoff) {
-          const retryEligibility = resolveSessionRetryEligibility(currentEntry, Date.now());
-          if (!retryEligibility.eligible) {
-            opts.log.info(
-              `${opts.logLabel}: entry ${currentEntry.id} not ready for retry yet — backoff ${retryEligibility.remainingBackoffMs}ms remaining`,
-            );
-            return;
-          }
-        }
-
-        const result = await drainQueuedEntry({
-          entry: currentEntry,
-          deliver: opts.deliver,
-          stateDir: opts.stateDir,
-          onFailed: (failedEntry, errMsg) => {
-            opts.log.warn(`${opts.logLabel}: retry failed for entry ${failedEntry.id}: ${errMsg}`);
-          },
-        });
-        if (result === "recovered" || result === "moved-to-failed") {
-          await finalizeSessionDeliverySettlement({
-            entry: currentEntry,
-            log: opts.log,
-            onSettled: opts.onSettled,
-            outcome: result,
-            stateDir: opts.stateDir,
-          });
-        }
-      },
+async function processPendingSessionDelivery(opts: {
+  entry: QueuedSessionDelivery;
+  context: SessionDeliveryDrainContext;
+  bypassBackoff?: boolean;
+  beforeDelivery?: () => Promise<"continue" | "stop">;
+  onFailed?: (entry: QueuedSessionDelivery, errMsg: string) => void;
+}) {
+  const { entry, context } = opts;
+  const pendingSettlementOutcome = resolvePendingSettlementOutcome(entry);
+  if (pendingSettlementOutcome) {
+    const finalized = await finalizeSessionDeliverySettlement({
+      entry,
+      log: context.log,
+      onSettled: context.onSettled,
+      outcome: pendingSettlementOutcome,
+      stateDir: context.stateDir,
     });
-  });
-  if (!drained) {
-    opts.log.info(`${opts.logLabel}: already in progress for ${opts.drainKey}, skipping`);
+    return { status: pendingSettlementOutcome, finalized };
   }
+  if (
+    !canReconcileStartedAgentAttemptAtRetryLimit(entry) &&
+    entry.retryCount >= resolveSessionDeliveryMaxRetries(entry)
+  ) {
+    await markSessionDeliverySettlement(entry, "moved-to-failed", context.stateDir);
+    const finalized = await finalizeSessionDeliverySettlement({
+      entry,
+      log: context.log,
+      onSettled: context.onSettled,
+      outcome: "moved-to-failed",
+      stateDir: context.stateDir,
+    });
+    return { status: "max-retries", finalized };
+  }
+
+  if (!opts.bypassBackoff) {
+    const retryEligibility = resolveSessionRetryEligibility(entry, Date.now());
+    if (!retryEligibility.eligible) {
+      return {
+        status: "backoff",
+        remainingMs: retryEligibility.remainingBackoffMs,
+      };
+    }
+  }
+  if ((await opts.beforeDelivery?.()) === "stop") {
+    return { status: "stop" };
+  }
+
+  let result: SessionDeliverySettledOutcome;
+  try {
+    await context.deliver(entry, { stateDir: context.stateDir });
+    // Keep metadata pending until owner cleanup succeeds. Recovery sees this
+    // marker and finalizes without replaying the external side effect.
+    await markSessionDeliverySettlement(entry, "recovered", context.stateDir);
+    result = "recovered";
+  } catch (err) {
+    if (err instanceof SessionDeliveryDeadLetteredError) {
+      try {
+        await markSessionDeliverySettlement(entry, "moved-to-failed", context.stateDir);
+      } catch (markError) {
+        if (markError instanceof SessionDeliveryAcknowledgementFinalizeError) {
+          return { status: "deferred" };
+        }
+        throw markError;
+      }
+      result = "moved-to-failed";
+    } else if (
+      err instanceof SessionDeliveryDeferredError ||
+      err instanceof SessionDeliveryAcknowledgementFinalizeError ||
+      err instanceof SessionDeliveryAttemptStartError
+    ) {
+      return { status: "deferred" };
+    } else {
+      const errMsg = formatErrorMessage(err);
+      opts.onFailed?.(entry, errMsg);
+      if (err instanceof SessionDeliveryRetryChargedError) {
+        return { status: "failed" };
+      }
+      try {
+        await failSessionDelivery(entry.id, errMsg, context.stateDir, {
+          releaseAttemptOwnership: err instanceof SessionDeliverySafeRetryError,
+        });
+      } catch (failErr) {
+        if (getErrnoCode(failErr) === "ENOENT") {
+          return { status: "already-gone" };
+        }
+        // Retry metadata did not advance, so swallowing this would redrive the
+        // entry forever without progressing toward the terminal retry limit.
+        throw failErr;
+      }
+      return { status: "failed" };
+    }
+  }
+  const finalized = await finalizeSessionDeliverySettlement({
+    entry,
+    log: context.log,
+    onSettled: context.onSettled,
+    outcome: result,
+    stateDir: context.stateDir,
+  });
+  return { status: result, finalized };
+}
+
+async function processDrainedSessionDelivery(
+  entry: QueuedSessionDelivery,
+  context: SessionDeliveryDrainContext,
+  bypassBackoff?: boolean,
+) {
+  const result = await processPendingSessionDelivery({
+    entry,
+    context,
+    bypassBackoff,
+    onFailed: (failedEntry, errMsg) => {
+      context.log.warn(`${context.logLabel}: retry failed for entry ${failedEntry.id}: ${errMsg}`);
+    },
+  });
+  if (result.status === "max-retries" && result.finalized) {
+    context.log.warn(
+      `${context.logLabel}: entry ${entry.id} exceeded max retries and was moved to failed`,
+    );
+  } else if (result.status === "backoff") {
+    context.log.info(
+      `${context.logLabel}: entry ${entry.id} not ready for retry yet — backoff ${result.remainingMs}ms remaining`,
+    );
+  }
+  return result;
+}
+
+/** Drain one exact queued session delivery and return its final pending state. */
+export async function drainPendingSessionDelivery(
+  opts: SessionDeliveryDrainContext & { id: string; bypassBackoff?: boolean },
+): Promise<QueuedSessionDelivery | null> {
+  const claim = await recoveryCoordinator.withClaim(opts.id, async () => {
+    const entry = await loadPendingSessionDelivery(opts.id, opts.stateDir);
+    if (!entry) {
+      return null;
+    }
+    const result = await processDrainedSessionDelivery(entry, opts, opts.bypassBackoff);
+    if (result.status === "already-gone" || ("finalized" in result && result.finalized)) {
+      return null;
+    }
+    return result.status === "backoff" ? entry : loadPendingSessionDelivery(opts.id, opts.stateDir);
+  });
+  if (claim.status === "claimed-by-other-owner") {
+    opts.log.info(`${opts.logLabel}: entry ${opts.id} is already being recovered`);
+    return loadPendingSessionDelivery(opts.id, opts.stateDir);
+  }
+  return claim.value;
 }
 
 /** Replay pending session deliveries until the recovery budget is exhausted. */
@@ -284,6 +296,19 @@ export async function recoverPendingSessionDeliveries(opts: {
   const onDeadlineExceeded = () => {
     opts.log.warn("Session delivery recovery time budget exceeded — remaining entries deferred");
   };
+  const context: SessionDeliveryDrainContext = { ...opts, logLabel: "Session delivery" };
+  const beforeDelivery = async () => {
+    const paceResult = await recoveryCoordinator.waitForReplay(deadline);
+    if (paceResult === "deadline-exceeded") {
+      onDeadlineExceeded();
+      return "stop" as const;
+    }
+    return "continue" as const;
+  };
+  const onFailed = (_failedEntry: QueuedSessionDelivery, errMsg: string) => {
+    summary.failed += 1;
+    opts.log.warn(`Session delivery retry failed: ${errMsg}`);
+  };
   await recoveryCoordinator.scan({
     entries: pending,
     loadEntry: (id) => loadPendingSessionDelivery(id, opts.stateDir),
@@ -293,59 +318,26 @@ export async function recoverPendingSessionDeliveries(opts: {
       if (opts.maxEnqueuedAt != null && currentEntry.enqueuedAt > opts.maxEnqueuedAt) {
         return "continue";
       }
-      const pendingSettlementOutcome = resolvePendingSettlementOutcome(currentEntry);
-      if (
-        !pendingSettlementOutcome &&
-        !canReconcileStartedAgentAttemptAtRetryLimit(currentEntry) &&
-        currentEntry.retryCount >= resolveSessionDeliveryMaxRetries(currentEntry)
-      ) {
+      const result = await processPendingSessionDelivery({
+        entry: currentEntry,
+        context,
+        beforeDelivery,
+        onFailed,
+      });
+      if (result.status === "max-retries") {
         summary.skippedMaxRetries += 1;
-        await markSessionDeliverySettlement(currentEntry, "moved-to-failed", opts.stateDir);
-        await finalizeSessionDeliverySettlement({
-          entry: currentEntry,
-          log: opts.log,
-          onSettled: opts.onSettled,
-          outcome: "moved-to-failed",
-          stateDir: opts.stateDir,
-        });
         return "continue";
       }
-
-      if (!pendingSettlementOutcome) {
-        const retryEligibility = resolveSessionRetryEligibility(currentEntry, Date.now());
-        if (!retryEligibility.eligible) {
-          summary.deferredBackoff += 1;
-          return "continue";
-        }
-
-        const paceResult = await recoveryCoordinator.waitForReplay(deadline);
-        if (paceResult === "deadline-exceeded") {
-          onDeadlineExceeded();
-          return "stop";
-        }
+      if (result.status === "backoff") {
+        summary.deferredBackoff += 1;
+        return "continue";
       }
-
-      const result = await drainQueuedEntry({
-        entry: currentEntry,
-        deliver: opts.deliver,
-        stateDir: opts.stateDir,
-        onFailed: (_failedEntry, errMsg) => {
-          summary.failed += 1;
-          opts.log.warn(`Session delivery retry failed: ${errMsg}`);
-        },
-      });
-      if (result === "recovered" || result === "moved-to-failed") {
-        const finalized = await finalizeSessionDeliverySettlement({
-          entry: currentEntry,
-          log: opts.log,
-          onSettled: opts.onSettled,
-          outcome: result,
-          stateDir: opts.stateDir,
-        });
-        if (finalized && result === "recovered") {
-          summary.recovered += 1;
-          opts.log.info(`Recovered session delivery ${currentEntry.id}`);
-        }
+      if (result.status === "stop") {
+        return "stop";
+      }
+      if (result.status === "recovered" && result.finalized) {
+        summary.recovered += 1;
+        opts.log.info(`Recovered session delivery ${currentEntry.id}`);
       }
       return "continue";
     },

--- a/src/infra/session-delivery-queue-runtime.test.ts
+++ b/src/infra/session-delivery-queue-runtime.test.ts
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { drainPendingSessionDeliveries } from "./session-delivery-queue-recovery.js";
+import { drainPendingSessionDelivery } from "./session-delivery-queue-recovery.js";
 import {
   schedulePendingSessionDeliveries,
   scheduleSessionDelivery,
@@ -53,6 +53,41 @@ describe("session delivery queue runtime", () => {
         expect(onSettled).toHaveBeenCalledWith(expect.objectContaining({ id }), "recovered");
         expect(await loadPendingSessionDeliveries()).toStrictEqual([]);
         stop();
+      });
+    });
+  });
+
+  it("drains one scheduled id without parsing unrelated pending entries", async () => {
+    vi.useFakeTimers();
+    await withTestDir({ prefix: "openclaw-session-delivery-runtime-" }, async (tempDir) => {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: tempDir }, async () => {
+        const id = await enqueueSessionDelivery({
+          kind: "agentTurn",
+          sessionKey: "agent:main:main",
+          message: "target delivery",
+          messageId: "target:agent-loop",
+        });
+        for (let index = 0; index < 8; index += 1) {
+          await enqueueSessionDelivery({
+            kind: "agentTurn",
+            sessionKey: "agent:main:main",
+            message: `unrelated delivery ${index}`,
+            messageId: `unrelated:${index}:agent-loop`,
+          });
+        }
+        const deliver = vi.fn(async () => {});
+        startSessionDeliveryRuntime({ deliver, log: logger });
+        const parseSpy = vi.spyOn(JSON, "parse");
+
+        try {
+          await expect(scheduleSessionDelivery(id)).resolves.toBe(true);
+          await vi.advanceTimersByTimeAsync(0);
+
+          expect(deliver).toHaveBeenCalledTimes(1);
+          expect(parseSpy.mock.calls.length).toBeLessThanOrEqual(8);
+        } finally {
+          parseSpy.mockRestore();
+        }
       });
     });
   });
@@ -187,7 +222,7 @@ describe("session delivery queue runtime", () => {
     });
   });
 
-  it("rearms a pending entry after a transient reload failure", async () => {
+  it("rearms a pending entry after a transient final-state lookup failure", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-15T00:00:00.000Z"));
     await withTestDir({ prefix: "openclaw-session-delivery-runtime-" }, async (tempDir) => {
@@ -202,17 +237,19 @@ describe("session delivery queue runtime", () => {
           .fn<() => Promise<void>>()
           .mockRejectedValueOnce(new Error("session locked"))
           .mockResolvedValueOnce();
-        const reloadPending = vi
-          .fn<typeof loadPendingSessionDelivery>()
-          .mockImplementationOnce((entryId) => loadPendingSessionDelivery(entryId))
-          .mockRejectedValueOnce(new Error("database busy"))
-          .mockImplementation((entryId) => loadPendingSessionDelivery(entryId));
-        startSessionDeliveryRuntime({ deliver, log: logger, reloadPending });
+        const drain = vi
+          .fn<typeof drainPendingSessionDelivery>()
+          .mockImplementationOnce(async (params) => {
+            await drainPendingSessionDelivery(params);
+            throw new Error("database busy");
+          })
+          .mockImplementation((params) => drainPendingSessionDelivery(params));
+        startSessionDeliveryRuntime({ deliver, drain, log: logger });
 
         await scheduleSessionDelivery(id);
         await vi.advanceTimersByTimeAsync(0);
         expect(deliver).toHaveBeenCalledTimes(1);
-        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("failed to reload"));
+        expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("runtime drain failed"));
 
         await vi.advanceTimersByTimeAsync(4_999);
         expect(deliver).toHaveBeenCalledTimes(1);
@@ -235,9 +272,9 @@ describe("session delivery queue runtime", () => {
         });
         const deliver = vi.fn(async () => {});
         const drain = vi
-          .fn<typeof drainPendingSessionDeliveries>()
+          .fn<typeof drainPendingSessionDelivery>()
           .mockRejectedValueOnce(new Error("database scan failed"))
-          .mockImplementation((params) => drainPendingSessionDeliveries(params));
+          .mockImplementation((params) => drainPendingSessionDelivery(params));
         startSessionDeliveryRuntime({ deliver, drain, log: logger });
 
         await scheduleSessionDelivery(id);
@@ -266,9 +303,11 @@ describe("session delivery queue runtime", () => {
         });
         const deliver = vi.fn(async () => {});
         const drain = vi
-          .fn<typeof drainPendingSessionDeliveries>()
-          .mockResolvedValueOnce(undefined)
-          .mockImplementation((params) => drainPendingSessionDeliveries(params));
+          .fn<typeof drainPendingSessionDelivery>()
+          .mockImplementationOnce((params) =>
+            loadPendingSessionDelivery(params.id, params.stateDir),
+          )
+          .mockImplementation((params) => drainPendingSessionDelivery(params));
         startSessionDeliveryRuntime({ deliver, drain, log: logger });
 
         await scheduleSessionDelivery(id);

--- a/src/infra/session-delivery-queue-runtime.ts
+++ b/src/infra/session-delivery-queue-runtime.ts
@@ -1,7 +1,7 @@
 // Process-local retry scheduler for the durable session delivery queue.
 import { computeBackoffMs } from "./delivery-recovery.shared.js";
 import {
-  drainPendingSessionDeliveries,
+  drainPendingSessionDelivery,
   type DeliverSessionDeliveryFn,
   type SessionDeliveryRecoveryLogger,
   type SettleSessionDeliveryFn,
@@ -14,7 +14,7 @@ import {
 
 type SessionDeliveryRuntime = {
   deliver: DeliverSessionDeliveryFn;
-  drain?: typeof drainPendingSessionDeliveries;
+  drain?: typeof drainPendingSessionDelivery;
   log: SessionDeliveryRecoveryLogger;
   reloadPending?: typeof loadPendingSessionDelivery;
   listPending?: typeof loadPendingSessionDeliveries;
@@ -113,33 +113,27 @@ async function runScheduledSessionDelivery(id: string, generation: number): Prom
   runningEntries.set(id, generation);
   let pending: QueuedSessionDelivery | null = null;
   try {
-    await (activeRuntime.drain ?? drainPendingSessionDeliveries)({
-      drainKey: `runtime:${id}`,
+    pending = await (activeRuntime.drain ?? drainPendingSessionDelivery)({
+      id,
       logLabel: "session delivery",
       log: activeRuntime.log,
       deliver: activeRuntime.deliver,
       onSettled: activeRuntime.onSettled,
-      selectEntry: (entry) => ({ match: entry.id === id }),
     });
   } catch (error) {
     activeRuntime.log.error(`session delivery: runtime drain failed for ${id}: ${String(error)}`);
-  }
-  try {
-    if (!runtime || generation !== runtimeGeneration) {
-      return;
-    }
-    const reloadPending = activeRuntime.reloadPending ?? loadPendingSessionDelivery;
-    pending = await reloadPending(id).catch((error: unknown) => {
-      activeRuntime.log.error(`session delivery: failed to reload ${id}: ${String(error)}`);
-      // The durable row may still be pending. Retry the lookup so one transient
-      // database error cannot orphan it until the next gateway restart.
+    if (runtime && generation === runtimeGeneration) {
+      // The durable row may still be pending. Retry the exact drain so one
+      // transient database error cannot orphan it until the next restart.
       armSessionDeliveryId(id, RUNTIME_RELOAD_RETRY_MS, generation);
-      return null;
-    });
+    }
   } finally {
     if (runningEntries.get(id) === generation) {
       runningEntries.delete(id);
     }
+  }
+  if (!runtime || generation !== runtimeGeneration) {
+    return;
   }
   if (pending) {
     // Any still-pending row means the drain deferred, failed, or was owned

--- a/src/infra/session-delivery-queue.recovery.persistence.test.ts
+++ b/src/infra/session-delivery-queue.recovery.persistence.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import {
-  drainPendingSessionDeliveries,
+  drainPendingSessionDelivery,
   recoverPendingSessionDeliveries,
 } from "./session-delivery-queue-recovery.js";
 import {
@@ -37,13 +37,12 @@ describe("session-delivery recovery persistence", () => {
           const recovery =
             mode === "startup"
               ? recoverPendingSessionDeliveries({ deliver, stateDir: tempDir, log })
-              : drainPendingSessionDeliveries({
-                  drainKey: "test-read-only-retry-persistence",
+              : drainPendingSessionDelivery({
+                  id,
                   logLabel: "test read-only retry persistence",
                   deliver,
                   stateDir: tempDir,
                   log,
-                  selectEntry: (entry) => ({ match: entry.id === id }),
                 });
 
           await expect(recovery).rejects.toThrow(/readonly/iu);

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -10,7 +10,7 @@ const sleepMock = vi.hoisted(() => vi.fn<(ms: number) => Promise<void>>());
 vi.mock("../utils/sleep.js", () => ({ sleep: sleepMock }));
 
 import {
-  drainPendingSessionDeliveries,
+  drainPendingSessionDelivery,
   recoverPendingSessionDeliveries,
 } from "./session-delivery-queue-recovery.js";
 import {
@@ -256,14 +256,13 @@ describe("session-delivery queue recovery", () => {
       const deliver = vi.fn(async () => undefined);
       const onSettled = vi.fn(async () => undefined);
 
-      await drainPendingSessionDeliveries({
-        drainKey: "test-acknowledged-cleanup",
+      await drainPendingSessionDelivery({
+        id,
         logLabel: "test acknowledged cleanup",
         deliver,
         onSettled,
         stateDir: tempDir,
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-        selectEntry: (candidate) => ({ match: candidate.id === id }),
       });
 
       expect(deliver).not.toHaveBeenCalled();
@@ -608,9 +607,10 @@ describe("session-delivery queue recovery", () => {
       }
 
       const deliver = vi.fn(async () => undefined);
-      await drainPendingSessionDeliveries({
-        drainKey: "test-restart-continuation",
+      await drainPendingSessionDelivery({
+        id,
         logLabel: "test restart continuation",
+        bypassBackoff: true,
         deliver,
         stateDir: tempDir,
         log: {
@@ -618,10 +618,6 @@ describe("session-delivery queue recovery", () => {
           warn: vi.fn(),
           error: vi.fn(),
         },
-        selectEntry: (entry) => ({
-          match: entry.id === id,
-          bypassBackoff: true,
-        }),
       });
 
       expect(deliver).toHaveBeenCalledTimes(1);
@@ -645,14 +641,14 @@ describe("session-delivery queue recovery", () => {
 
       const deliver = vi.fn(async () => undefined);
       const onSettled = vi.fn(async () => undefined);
-      await drainPendingSessionDeliveries({
-        drainKey: "test-restart-continuation-exhausted",
+      await drainPendingSessionDelivery({
+        id,
         logLabel: "test restart continuation",
+        bypassBackoff: true,
         deliver,
         onSettled,
         stateDir: tempDir,
         log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-        selectEntry: (entry) => ({ match: entry.id === id, bypassBackoff: true }),
       });
 
       expect(deliver).not.toHaveBeenCalled();
@@ -721,13 +717,13 @@ describe("session-delivery queue recovery", () => {
             vi.setSystemTime(new Date(Date.now() + 60_000));
           }
           if (mode === "runtime") {
-            await drainPendingSessionDeliveries({
-              drainKey: `test-started-exhausted-${mode}`,
+            await drainPendingSessionDelivery({
+              id,
               logLabel: "test started reconciliation",
+              bypassBackoff: true,
               deliver,
               stateDir: tempDir,
               log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-              selectEntry: (candidate) => ({ match: candidate.id === id, bypassBackoff: true }),
             });
           } else {
             const summary = await recoverPendingSessionDeliveries({
@@ -775,13 +771,13 @@ describe("session-delivery queue recovery", () => {
         throw new Error("terminal evidence unavailable");
       });
       const drain = async () =>
-        await drainPendingSessionDeliveries({
-          drainKey: "test-started-reconciliation-failed",
+        await drainPendingSessionDelivery({
+          id,
           logLabel: "test started reconciliation",
+          bypassBackoff: true,
           deliver,
           stateDir: tempDir,
           log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-          selectEntry: (candidate) => ({ match: candidate.id === id, bypassBackoff: true }),
         });
 
       await drain();

--- a/src/logging/config.test.ts
+++ b/src/logging/config.test.ts
@@ -2,9 +2,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { withEnv } from "../test-utils/env.js";
 import { readLoggingConfig } from "./config.js";
+import { applyLoggingConfig, resetLogger } from "./logger.js";
 
 const originalArgv = process.argv;
 let tempDirs: string[] = [];
@@ -19,11 +20,20 @@ function writeConfig(source: string): string {
 
 describe("readLoggingConfig", () => {
   afterEach(() => {
+    resetLogger();
     process.argv = originalArgv;
     for (const dir of tempDirs) {
       fs.rmSync(dir, { force: true, recursive: true });
     }
     tempDirs = [];
+  });
+
+  it("returns the applied runtime snapshot without bootstrap filesystem work", () => {
+    const existsSync = vi.spyOn(fs, "existsSync");
+    applyLoggingConfig({ level: "debug", consoleStyle: "json" });
+
+    expect(readLoggingConfig()).toEqual({ level: "debug", consoleStyle: "json" });
+    expect(existsSync).not.toHaveBeenCalled();
   });
 
   it("reads logging style without a mutating config load for config schema", () => {
@@ -196,5 +206,30 @@ describe("readLoggingConfig", () => {
     withEnv({ OPENCLAW_CONFIG_PATH: configPath }, () => {
       expect(readLoggingConfig()).toBeUndefined();
     });
+  });
+
+  it("caches a missing config until the path selector changes", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-logging-config-missing-"));
+    tempDirs.push(dir);
+    const firstPath = path.join(dir, "missing-first.json");
+    const secondPath = path.join(dir, "missing-second.json");
+    const existsSync = vi.spyOn(fs, "existsSync");
+
+    try {
+      withEnv({ OPENCLAW_CONFIG_PATH: firstPath }, () => {
+        expect(readLoggingConfig()).toBeUndefined();
+        expect(readLoggingConfig()).toBeUndefined();
+      });
+      withEnv({ OPENCLAW_CONFIG_PATH: secondPath }, () => {
+        expect(readLoggingConfig()).toBeUndefined();
+      });
+
+      const checksFor = (configPath: string) =>
+        existsSync.mock.calls.filter(([candidate]) => candidate === configPath).length;
+      expect(checksFor(firstPath)).toBe(1);
+      expect(checksFor(secondPath)).toBe(1);
+    } finally {
+      existsSync.mockRestore();
+    }
   });
 });

--- a/src/logging/config.ts
+++ b/src/logging/config.ts
@@ -5,17 +5,43 @@ import { resolveConfigEnvVars } from "../config/env-substitution.js";
 import { resolveConfigIncludes, resolveConfigIncludesForTopLevelKey } from "../config/includes.js";
 import { resolveConfigPath, resolveIncludeRoots } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { tryProcessCwd } from "../infra/safe-cwd.js";
 import { parseJsonWithJson5Fallback } from "../utils/parse-json-compat.js";
+import { APPLIED_LOGGING_CONFIG_UNOWNED, loggingState } from "./state.js";
 
 // Lightweight logging-config reader used before the full config runtime is safe to load.
 type LoggingConfig = NonNullable<OpenClawConfig["logging"]>;
 
 let cachedLoggingConfig:
   | {
-      path: string;
+      selector: string;
       logging: LoggingConfig | undefined;
     }
   | undefined;
+
+export function invalidateLoggingConfigCache(): void {
+  cachedLoggingConfig = undefined;
+}
+
+function resolveLoggingConfigSelector(): string {
+  const env = process.env;
+  return [
+    env.OPENCLAW_CONFIG_PATH,
+    env.OPENCLAW_STATE_DIR,
+    env.OPENCLAW_HOME,
+    env.OPENCLAW_PROFILE,
+    env.HOME,
+    env.USERPROFILE,
+    env.HOMEDRIVE,
+    env.HOMEPATH,
+    env.PREFIX,
+    env.ANDROID_DATA,
+    env.OPENCLAW_TEST_FAST,
+    tryProcessCwd() ?? "",
+  ]
+    .map((value) => value ?? "")
+    .join("\0");
+}
 
 function resolvePartialDiagnosticLoggingConfig(logging: unknown): LoggingConfig | undefined {
   if (!isObjectRecord(logging)) {
@@ -57,11 +83,16 @@ function resolvePartialDiagnosticLoggingConfig(logging: unknown): LoggingConfig 
 /** Reads the logging block from config, caching by resolved config path. */
 export function readLoggingConfig(): LoggingConfig | undefined {
   try {
-    const configPath = resolveConfigPath();
-    if (cachedLoggingConfig?.path === configPath) {
+    if (loggingState.appliedConfig !== APPLIED_LOGGING_CONFIG_UNOWNED) {
+      return loggingState.appliedConfig;
+    }
+    const selector = resolveLoggingConfigSelector();
+    if (cachedLoggingConfig?.selector === selector) {
       return cachedLoggingConfig.logging;
     }
+    const configPath = resolveConfigPath();
     if (!fs.existsSync(configPath)) {
+      cachedLoggingConfig = { selector, logging: undefined };
       return undefined;
     }
     const parsed = parseJsonWithJson5Fallback(fs.readFileSync(configPath, "utf8"));
@@ -102,7 +133,7 @@ export function readLoggingConfig(): LoggingConfig | undefined {
     const logging = isObjectRecord(resolvedConfig) ? resolvedConfig.logging : undefined;
     const resolvedLogging = isObjectRecord(logging) ? (logging as LoggingConfig) : undefined;
     cachedLoggingConfig = {
-      path: configPath,
+      selector,
       logging: resolvedLogging,
     };
     return resolvedLogging;

--- a/src/logging/console-capture.test.ts
+++ b/src/logging/console-capture.test.ts
@@ -14,6 +14,7 @@ import {
 import { defaultRuntime } from "../runtime.js";
 import { withEnv } from "../test-utils/env.js";
 import { createSuiteLogPathTracker } from "./log-test-helpers.js";
+import { applyLoggingConfig } from "./logger.js";
 import { testApi } from "./logger.test-support.js";
 import { loggingState } from "./state.js";
 import {
@@ -386,6 +387,23 @@ describe("enableConsoleCapture", () => {
 
     const content = fs.readFileSync(logPath, "utf-8");
     expect(countMatchingLines(content, "conflicting schema definitions")).toBe(1);
+  });
+
+  it("uses the current applied logger generation for each forwarded console call", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FILE_LOG", "1");
+    const firstFile = tempLogPath();
+    const secondFile = tempLogPath();
+    applyLoggingConfig({ level: "info", file: firstFile });
+    enableConsoleCapture();
+
+    console.log("first applied generation");
+    applyLoggingConfig({ level: "info", file: secondFile });
+    console.log("second applied generation");
+    await testApi.flushFileLogQueueForTests();
+
+    expect(fs.readFileSync(firstFile, "utf8")).toContain("first applied generation");
+    expect(fs.readFileSync(firstFile, "utf8")).not.toContain("second applied generation");
+    expect(fs.readFileSync(secondFile, "utf8")).toContain("second applied generation");
   });
 
   it.each([

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -3,11 +3,10 @@ import util from "node:util";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { clearActiveProgressLine } from "../../packages/terminal-core/src/progress-line.js";
 import { isVerbose } from "../global-state.js";
-import { readLoggingConfig } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { formatJsonConsoleLine } from "./json-console-line.js";
 import { type LogLevel, normalizeLogLevel } from "./levels.js";
-import { getLogger } from "./logger.js";
+import { getLogger, readLoggerConfig } from "./logger.js";
 import { redactSensitiveText } from "./redact.js";
 import { loggingState } from "./state.js";
 import { formatTimestamp } from "./timestamps.js";
@@ -55,25 +54,19 @@ function resolveConsoleSettings(): ConsoleSettings {
     return { level: "silent", style: normalizeConsoleStyle(undefined) };
   }
 
-  const cfg = (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggingConfig();
+  const cfg = (loggingState.overrideSettings as LoggerSettings | null) ?? readLoggerConfig();
   const level = envLevel ?? normalizeConsoleLevel(cfg?.consoleLevel);
   const style = normalizeConsoleStyle(cfg?.consoleStyle);
   return { level, style };
 }
 
-function consoleSettingsChanged(a: ConsoleSettings | null, b: ConsoleSettings) {
-  if (!a) {
-    return true;
-  }
-  return a.level !== b.level || a.style !== b.style;
-}
-
 export function getConsoleSettings(): ConsoleLoggerSettings {
-  const settings = resolveConsoleSettings();
   const cached = loggingState.cachedConsoleSettings as ConsoleSettings | null;
-  if (!cached || consoleSettingsChanged(cached, settings)) {
-    loggingState.cachedConsoleSettings = settings;
+  if (cached) {
+    return cached;
   }
+  const settings = resolveConsoleSettings();
+  loggingState.cachedConsoleSettings = settings;
   return loggingState.cachedConsoleSettings as ConsoleSettings;
 }
 
@@ -286,14 +279,6 @@ export function enableConsoleCapture(): void {
     }
   }
 
-  let logger: ReturnType<typeof getLogger> | null = null;
-  const getLoggerLazy = () => {
-    if (!logger) {
-      logger = getLogger();
-    }
-    return logger;
-  };
-
   const original = {
     log: console.log,
     info: console.info,
@@ -316,7 +301,7 @@ export function enableConsoleCapture(): void {
         return;
       }
       try {
-        const resolvedLogger = getLoggerLazy();
+        const resolvedLogger = getLogger();
         // Map console levels to file logger
         if (level === "trace") {
           resolvedLogger.trace(formatted);

--- a/src/logging/diagnostic-log-events.test.ts
+++ b/src/logging/diagnostic-log-events.test.ts
@@ -1,7 +1,8 @@
 // Diagnostic log event tests cover structured events written to diagnostic logs.
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  onDiagnosticEvent,
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
   type DiagnosticEventMetadata,
@@ -33,9 +34,23 @@ afterEach(() => {
   resetDiagnosticEventsForTest();
   setLoggerOverride(null);
   resetLogger();
+  vi.restoreAllMocks();
 });
 
 describe("diagnostic log events", () => {
+  it("does not build or queue log records for a public-only listener", async () => {
+    const listener = vi.fn();
+    const unsubscribe = onDiagnosticEvent(listener);
+    const structuredCloneSpy = vi.spyOn(globalThis, "structuredClone");
+
+    getChildLogger({ subsystem: "diagnostic" }).info("public listener ignores this log");
+    await flushDiagnosticEvents();
+    unsubscribe();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(structuredCloneSpy).not.toHaveBeenCalled();
+  });
+
   it("emits structured log records through diagnostics", async () => {
     const received: Array<{
       event: Extract<DiagnosticEventPayload, { type: "log.record" }>;

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -402,10 +402,6 @@ function recordModelEnded(
   touchSessionActivity(activity, "model_call:ended");
 }
 
-function recordRunProgress(event: RunProgressEvent, coreSemantic: boolean): void {
-  applyRunProgress(event, coreSemantic);
-}
-
 export function markDiagnosticArgumentChurnObservation(
   params: DiagnosticArgumentChurnObservationParams,
 ): void {
@@ -683,13 +679,7 @@ function markDiagnosticRunProgressForTest(params: RunProgressEvent): void {
   applyRunProgress(params, params.progressKind === "semantic");
 }
 
-function markDiagnosticToolStartedForTest(params: {
-  sessionId?: string;
-  sessionKey?: string;
-  runId?: string;
-  toolName: string;
-  toolCallId?: string;
-}): void {
+function markDiagnosticToolStartedForTest(params: DiagnosticToolStartedActivityEvent): void {
   recordToolStarted(params);
 }
 
@@ -719,37 +709,49 @@ export function startDiagnosticRunActivityTracking(): void {
     return;
   }
   const startAfterEventSequence = getInternalDiagnosticEventSequence();
-  unregisterDiagnosticRunActivityListener = onInternalDiagnosticEvent((event, metadata) => {
-    // A prior lifecycle can leave already-sequenced events in the async queue.
-    // Ignore them so a restart cannot recreate activity that stop cleared.
-    if (event.seq <= startAfterEventSequence) {
-      return;
-    }
-    switch (event.type) {
-      case "tool.execution.started":
-        recordToolStarted(event);
+  unregisterDiagnosticRunActivityListener = onInternalDiagnosticEvent(
+    (event, metadata) => {
+      // A prior lifecycle can leave already-sequenced events in the async queue.
+      // Ignore them so a restart cannot recreate activity that stop cleared.
+      if (event.seq <= startAfterEventSequence) {
         return;
-      case "tool.execution.completed":
-      case "tool.execution.error":
-      case "tool.execution.blocked":
-        recordToolEnded(event);
-        return;
-      case "model.call.started":
-        recordModelStarted(event, resolveCoreModelRequestLifecycleDiagnosticMetadata(metadata));
-        return;
-      case "model.call.completed":
-      case "model.call.error":
-        recordModelEnded(event, resolveCoreModelRequestLifecycleDiagnosticMetadata(metadata));
-        return;
-      case "run.progress":
-        recordRunProgress(event, isCoreSemanticRunProgressDiagnosticMetadata(metadata));
-        return;
-      case "run.completed":
-        recordRunCompleted(event);
-
-      default:
-    }
-  });
+      }
+      switch (event.type) {
+        case "tool.execution.started":
+          return recordToolStarted(event);
+        case "tool.execution.completed":
+        case "tool.execution.error":
+        case "tool.execution.blocked":
+          return recordToolEnded(event);
+        case "model.call.started":
+          recordModelStarted(event, resolveCoreModelRequestLifecycleDiagnosticMetadata(metadata));
+          return;
+        case "model.call.completed":
+        case "model.call.error":
+          recordModelEnded(event, resolveCoreModelRequestLifecycleDiagnosticMetadata(metadata));
+          return;
+        case "run.progress":
+          return applyRunProgress(event, isCoreSemanticRunProgressDiagnosticMetadata(metadata));
+        case "run.completed":
+          return recordRunCompleted(event);
+        default:
+          break;
+      }
+    },
+    {
+      include: [
+        "tool.execution.started",
+        "tool.execution.completed",
+        "tool.execution.error",
+        "tool.execution.blocked",
+        "model.call.started",
+        "model.call.completed",
+        "model.call.error",
+        "run.progress",
+        "run.completed",
+      ],
+    },
+  );
 }
 
 export function stopDiagnosticRunActivityTracking(): void {

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -855,23 +855,22 @@ export function startDiagnosticStabilityRecorder(): void {
   if (state.unsubscribe) {
     return;
   }
-  state.unsubscribe = onInternalDiagnosticEvent((event, metadata) => {
-    if (event.type === "telemetry.exporter") {
-      return;
-    }
-    // Model-call instrumentation is trusted core telemetry required by recovery.
-    // Other trusted events retain their dedicated owners outside this ring.
-    if (
-      (metadata.trusted &&
+  state.unsubscribe = onInternalDiagnosticEvent(
+    (event, metadata) => {
+      // Model-call instrumentation is trusted core telemetry required by recovery.
+      // Other trusted events retain their dedicated owners outside this ring.
+      if (
+        metadata.trusted &&
         event.type !== "model.call.started" &&
         event.type !== "model.call.completed" &&
-        event.type !== "model.call.error") ||
-      event.type === "log.record"
-    ) {
-      return;
-    }
-    appendRecord(sanitizeDiagnosticEvent(event));
-  });
+        event.type !== "model.call.error"
+      ) {
+        return;
+      }
+      appendRecord(sanitizeDiagnosticEvent(event));
+    },
+    { exclude: ["log.record", "telemetry.exporter"] },
+  );
 }
 
 /** Stops the process-wide diagnostic event recorder. */

--- a/src/logging/level-filter.test.ts
+++ b/src/logging/level-filter.test.ts
@@ -2,10 +2,13 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { readLoggingConfigMock } = vi.hoisted(() => ({
-  readLoggingConfigMock: vi.fn(() => undefined),
+  readLoggingConfigMock: vi.fn<() => { level: "silent" } | { consoleLevel: "silent" } | undefined>(
+    () => undefined,
+  ),
 }));
 
 vi.mock("./config.js", () => ({
+  invalidateLoggingConfigCache: vi.fn(),
   readLoggingConfig: readLoggingConfigMock,
 }));
 
@@ -17,6 +20,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   delete process.env.OPENCLAW_TEST_FILE_LOG;
+  delete process.env.OPENCLAW_TEST_CONSOLE;
   delete process.env.OPENCLAW_LOG_LEVEL;
   readLoggingConfigMock.mockClear();
   logging.resetLogger();
@@ -25,10 +29,64 @@ beforeEach(() => {
 
 afterEach(() => {
   delete process.env.OPENCLAW_TEST_FILE_LOG;
+  delete process.env.OPENCLAW_TEST_CONSOLE;
   delete process.env.OPENCLAW_LOG_LEVEL;
   logging.resetLogger();
   logging.setLoggerOverride(null);
   vi.restoreAllMocks();
+});
+
+describe("resolved logging settings cache", () => {
+  it("loads file settings once per logger generation", () => {
+    process.env.OPENCLAW_TEST_FILE_LOG = "1";
+    readLoggingConfigMock.mockReturnValue({ level: "silent" });
+    logging.setLoggerConfigLoaderForTests(readLoggingConfigMock);
+
+    logging.getLogger();
+    logging.getLogger();
+    expect(readLoggingConfigMock).toHaveBeenCalledTimes(1);
+
+    logging.setLoggerOverride({ level: "silent" });
+    logging.getLogger();
+    expect(readLoggingConfigMock).toHaveBeenCalledTimes(1);
+
+    logging.setLoggerOverride(null);
+    logging.getLogger();
+    logging.getLogger();
+    expect(readLoggingConfigMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses settings resolved by the file-level admission check when building the logger", () => {
+    process.env.OPENCLAW_TEST_FILE_LOG = "1";
+    readLoggingConfigMock.mockReturnValue({ level: "silent" });
+    logging.setLoggerConfigLoaderForTests(readLoggingConfigMock);
+
+    expect(logging.isFileLogLevelEnabled("info")).toBe(false);
+    logging.getLogger();
+
+    expect(readLoggingConfigMock).toHaveBeenCalledOnce();
+  });
+
+  it("loads console settings once per logger generation", () => {
+    process.env.OPENCLAW_TEST_CONSOLE = "1";
+    readLoggingConfigMock.mockReturnValue({ consoleLevel: "silent" });
+    logging.setLoggerConfigLoaderForTests(readLoggingConfigMock);
+    logging.setLoggerOverride(null);
+    readLoggingConfigMock.mockClear();
+
+    logging.getConsoleSettings();
+    logging.getConsoleSettings();
+    expect(readLoggingConfigMock).toHaveBeenCalledTimes(1);
+
+    logging.setLoggerOverride({ consoleLevel: "silent" });
+    logging.getConsoleSettings();
+    expect(readLoggingConfigMock).toHaveBeenCalledTimes(1);
+
+    logging.setLoggerOverride(null);
+    logging.getConsoleSettings();
+    logging.getConsoleSettings();
+    expect(readLoggingConfigMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 function firstMockArg(mock: { mock: { calls: readonly unknown[][] } }): Record<string, unknown> {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -5,7 +5,9 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Logger as TsLogger } from "tslog";
 import type { OpenClawConfig } from "../config/types.js";
+import { hasInternalDiagnosticEventInterest } from "../infra/diagnostic-event-listener-presence.js";
 import {
+  areDiagnosticsEnabledForProcess,
   emitDiagnosticEvent,
   emitDiagnosticEventWithTrustedTraceContext,
 } from "../infra/diagnostic-events.js";
@@ -22,7 +24,7 @@ import {
   DEFAULT_POSIX_TMP_ROOT,
   resolvePreferredOpenClawTmpDir,
 } from "../infra/tmp-openclaw-dir.js";
-import { readLoggingConfig } from "./config.js";
+import { invalidateLoggingConfigCache, readLoggingConfig } from "./config.js";
 import { resolveEnvLogLevelOverride } from "./env-log-level.js";
 import { type LogLevel, levelToMinLevel, normalizeLogLevel } from "./levels.js";
 import {
@@ -35,7 +37,7 @@ import { fileLogTransport } from "./logger-file-transport.js";
 import { defaultLoggerHostnameResolver, loggerHostnameState } from "./logger-hostname-state.js";
 import { setLoggerFileTargetResolver } from "./logger-settings-internal.js";
 import { redactSecrets, redactSensitiveText } from "./redact.js";
-import { loggingState } from "./state.js";
+import { APPLIED_LOGGING_CONFIG_UNOWNED, loggingState } from "./state.js";
 import { formatTimestamp } from "./timestamps.js";
 import type { LoggerSettings } from "./types.js";
 export type { LoggerSettings } from "./types.js";
@@ -79,10 +81,27 @@ const MAX_DIAGNOSTIC_LOG_MESSAGE_CHARS = 4 * 1024;
 const loadLoggerConfigDefault: LoggerConfigLoader = () => readLoggingConfig();
 let loadLoggerConfig: LoggerConfigLoader = loadLoggerConfigDefault;
 
-export function setLoggerConfigLoaderForTests(loader?: LoggerConfigLoader): void {
-  loadLoggerConfig = loader ?? loadLoggerConfigDefault;
+function invalidateLoggerSettings(): void {
+  loggingState.generation += 1;
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
+  loggingState.cachedConsoleSettings = null;
+}
+
+/** Publishes authoritative config-derived logging state for the active runtime. */
+export function applyLoggingConfig(config: OpenClawConfig["logging"] | undefined): void {
+  loggingState.appliedConfig = config;
+  invalidateLoggingConfigCache();
+  invalidateLoggerSettings();
+}
+
+export function setLoggerConfigLoaderForTests(loader?: LoggerConfigLoader): void {
+  loadLoggerConfig = loader ?? loadLoggerConfigDefault;
+  invalidateLoggerSettings();
+}
+
+export function readLoggerConfig(): OpenClawConfig["logging"] | undefined {
+  return loadLoggerConfig();
 }
 const MAX_DIAGNOSTIC_LOG_ATTRIBUTE_COUNT = 32;
 const MAX_DIAGNOSTIC_LOG_ATTRIBUTE_VALUE_CHARS = 2 * 1024;
@@ -480,6 +499,9 @@ function redactLogRecordForTransport<T extends LogObj>(record: T): T {
 
 function attachDiagnosticEventTransport(logger: TsLogger<LogObj>): void {
   logger.attachTransport((logObj: LogObj) => {
+    if (!areDiagnosticsEnabledForProcess() || !hasInternalDiagnosticEventInterest("log.record")) {
+      return;
+    }
     try {
       const record = buildDiagnosticLogRecord(redactLogRecordForTransport(logObj) as TsLogRecord);
       const emit = record.trustedTraceContext
@@ -551,18 +573,6 @@ setLoggerFileTargetResolver(() => {
   const { file, rolling } = resolveSettings();
   return { file, rolling };
 });
-
-function settingsChanged(a: ResolvedRuntimeSettings | null, b: ResolvedRuntimeSettings) {
-  if (!a) {
-    return true;
-  }
-  return (
-    a.level !== b.level ||
-    a.file !== b.file ||
-    a.maxFileBytes !== b.maxFileBytes ||
-    a.rolling !== b.rolling
-  );
-}
 
 export function isFileLogLevelEnabled(level: LogLevel): boolean {
   const settings =
@@ -651,13 +661,15 @@ function resolveMaxLogFileBytes(raw: unknown): number {
 }
 
 export function getLogger(): TsLogger<LogObj> {
-  const settings = resolveSettings();
   const cachedLogger = loggingState.cachedLogger as TsLogger<LogObj> | null;
   const cachedSettings = loggingState.cachedSettings as ResolvedRuntimeSettings | null;
-  if (!cachedLogger || settingsChanged(cachedSettings, settings)) {
-    loggingState.cachedLogger = buildLogger(settings);
-    loggingState.cachedSettings = settings;
+  if (cachedLogger && cachedSettings) {
+    return cachedLogger;
   }
+  const settings = cachedSettings ?? resolveSettings();
+  const logger = buildLogger(settings);
+  loggingState.cachedLogger = logger;
+  loggingState.cachedSettings = settings;
   return loggingState.cachedLogger as TsLogger<LogObj>;
 }
 
@@ -744,19 +756,17 @@ export async function flushLogger(): Promise<void> {
 // Test helpers
 export function setLoggerOverride(settings: LoggerSettings | null) {
   loggingState.overrideSettings = settings;
-  loggingState.cachedLogger = null;
-  loggingState.cachedSettings = null;
-  loggingState.cachedConsoleSettings = null;
+  invalidateLoggerSettings();
 }
 
 export function resetLogger() {
-  loggingState.cachedLogger = null;
-  loggingState.cachedSettings = null;
-  loggingState.cachedConsoleSettings = null;
+  loggingState.appliedConfig = APPLIED_LOGGING_CONFIG_UNOWNED;
   loggingState.overrideSettings = null;
+  invalidateLoggingConfigCache();
   loadLoggerConfig = loadLoggerConfigDefault;
   loggerHostnameState.resolver = defaultLoggerHostnameResolver;
   loggerHostnameState.cached = null;
+  invalidateLoggerSettings();
 }
 
 function resolveActiveLogFileWithMode(file: string, rolling: boolean): string {

--- a/src/logging/state.ts
+++ b/src/logging/state.ts
@@ -1,8 +1,19 @@
 // Process-local logging state shared by logger, console capture, and test reset helpers.
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
 const LOGGING_STATE_KEY = Symbol.for("openclaw.loggingState");
+export const APPLIED_LOGGING_CONFIG_UNOWNED = "unowned" as const;
+
+function createUnownedAppliedLoggingConfig():
+  | OpenClawConfig["logging"]
+  | typeof APPLIED_LOGGING_CONFIG_UNOWNED {
+  return APPLIED_LOGGING_CONFIG_UNOWNED;
+}
 
 function createLoggingState() {
   return {
+    generation: 0,
+    appliedConfig: createUnownedAppliedLoggingConfig(),
     cachedLogger: null as unknown,
     cachedSettings: null as unknown,
     cachedConsoleSettings: null as unknown,
@@ -30,4 +41,7 @@ const globalStore = globalThis as Record<PropertyKey, unknown>;
 // state object so overrides and caches remain coherent across those copies.
 export const loggingState =
   (globalStore[LOGGING_STATE_KEY] as LoggingState | undefined) ?? createLoggingState();
+if (!Object.hasOwn(loggingState, "appliedConfig")) {
+  loggingState.appliedConfig = APPLIED_LOGGING_CONFIG_UNOWNED;
+}
 globalStore[LOGGING_STATE_KEY] = loggingState;

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -1,10 +1,11 @@
 // Subsystem logger tests cover per-subsystem log routing and filtering.
 import fs from "node:fs";
 import path from "node:path";
+import { Logger as TsLogger } from "tslog";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { setConsoleSubsystemFilter, shouldLogSubsystemToConsole } from "./console.js";
 import { createSuiteLogPathTracker } from "./log-test-helpers.js";
-import { resetLogger, setLoggerOverride } from "./logger.js";
+import { applyLoggingConfig, resetLogger, setLoggerOverride } from "./logger.js";
 import { testApi } from "./logger.test-support.js";
 import { loggingState } from "./state.js";
 import { createSubsystemLogger } from "./subsystem.js";
@@ -40,6 +41,7 @@ afterEach(() => {
   loggingState.rawConsole = null;
   resetLogger();
   vi.unstubAllEnvs();
+  vi.restoreAllMocks();
   vi.useRealTimers();
 });
 
@@ -354,5 +356,41 @@ describe("createSubsystemLogger().isEnabled", () => {
     expect(fs.readFileSync(firstDay, "utf8")).toContain("first day subsystem log");
     expect(fs.readFileSync(secondDay, "utf8")).toContain("second day subsystem log");
     expect(fs.readFileSync(firstDay, "utf8")).not.toContain("second day subsystem log");
+  });
+
+  it("reuses its file child until logger invalidation advances the generation", () => {
+    const firstFile = logPathTracker.nextPath();
+    const secondFile = logPathTracker.nextPath();
+    const getSubLogger = vi.spyOn(TsLogger.prototype, "getSubLogger");
+    setLoggerOverride({ level: "info", consoleLevel: "silent", file: firstFile });
+    const log = createSubsystemLogger("diagnostics");
+
+    log.info("first line");
+    log.info("second line");
+    expect(getSubLogger).toHaveBeenCalledTimes(1);
+
+    resetLogger();
+    setLoggerOverride({ level: "info", consoleLevel: "silent", file: secondFile });
+    log.info("after reset");
+    expect(getSubLogger).toHaveBeenCalledTimes(2);
+  });
+
+  it("publishes applied config and rebuilds its child for the new generation", () => {
+    const firstFile = logPathTracker.nextPath();
+    const secondFile = logPathTracker.nextPath();
+    vi.stubEnv("OPENCLAW_TEST_FILE_LOG", "1");
+    applyLoggingConfig({ level: "info", consoleLevel: "silent", file: firstFile });
+    const getSubLogger = vi.spyOn(TsLogger.prototype, "getSubLogger");
+    const log = createSubsystemLogger("diagnostics");
+
+    log.info("first line");
+    log.info("second line");
+    expect(getSubLogger).toHaveBeenCalledTimes(1);
+    expect(log.isEnabled("debug", "file")).toBe(false);
+
+    applyLoggingConfig({ level: "debug", consoleLevel: "silent", file: secondFile });
+    expect(log.isEnabled("debug", "file")).toBe(true);
+    log.debug("after applied config");
+    expect(getSubLogger).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -365,6 +365,17 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   const resolvedSubsystem = normalizeSubsystemLabel(subsystem);
+  let fileChild: { generation: number; logger: TsLogger<LogObj> } | undefined;
+
+  const getFileLogger = () => {
+    if (fileChild?.generation !== loggingState.generation) {
+      fileChild = {
+        generation: loggingState.generation,
+        logger: getChildLogger({ subsystem: resolvedSubsystem }),
+      };
+    }
+    return fileChild.logger;
+  };
 
   const emitLog = (level: LogLevel, message: string, meta?: Record<string, unknown>) => {
     const consoleSettings = getConsoleSettings();
@@ -387,7 +398,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
       fileMeta = Object.keys(rest).length > 0 ? rest : undefined;
     }
     if (fileEnabled) {
-      logToFile(getChildLogger({ subsystem: resolvedSubsystem }), level, message, fileMeta);
+      logToFile(getFileLogger(), level, message, fileMeta);
     }
     if (!consoleEnabled) {
       return;
@@ -451,7 +462,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     },
     raw(message) {
       if (isFileLogLevelEnabled("info")) {
-        logToFile(getChildLogger({ subsystem: resolvedSubsystem }), "info", message, { raw: true });
+        logToFile(getFileLogger(), "info", message, { raw: true });
       }
       const consoleSettings = getConsoleSettings();
       if (

--- a/src/talk/client-voice-session.ts
+++ b/src/talk/client-voice-session.ts
@@ -150,18 +150,21 @@ function recordClientVoiceToolEffect(event: TrustedToolExecutionEvent): void {
 
 function ensureToolEffectSubscription(): void {
   unsubscribeToolEffects ??= onTrustedToolExecutionEvent(recordClientVoiceToolEffect);
-  unsubscribeRunCompletion ??= onTrustedInternalDiagnosticEvent((event) => {
-    if (event.type !== "run.completed") {
-      return;
-    }
-    const binding = voiceSessionByRunId.get(event.runId);
-    if (!binding) {
-      return;
-    }
-    voiceSessionByRunId.delete(event.runId);
-    releaseClientVoiceConfirmationRun(binding.agentId, binding.voiceSessionId, event.runId);
-    mutationDigestDeliveryOwner.retry(binding);
-  });
+  unsubscribeRunCompletion ??= onTrustedInternalDiagnosticEvent(
+    (event) => {
+      if (event.type !== "run.completed") {
+        return;
+      }
+      const binding = voiceSessionByRunId.get(event.runId);
+      if (!binding) {
+        return;
+      }
+      voiceSessionByRunId.delete(event.runId);
+      releaseClientVoiceConfirmationRun(binding.agentId, binding.voiceSessionId, event.runId);
+      mutationDigestDeliveryOwner.retry(binding);
+    },
+    { include: ["run.completed"] },
+  );
 }
 
 /** Create a call record or resume the same open call across transport restarts. */


### PR DESCRIPTION
## What Problem This Solves

Resolves repeated hot-path work in the Gateway where one exact session-delivery retry scanned and parsed the entire durable queue, logging repeatedly rediscovered configuration and rebuilt subsystem children, uninterested diagnostics still projected log records, and outbound WebSocket summaries were built even when no recipient was admitted.

## Why This Change Was Made

The change moves each cost to its architectural owner: runtime timers and restart continuations use one canonical exact-ID delivery drain while startup retains the intentional full recovery scan; Gateway lifecycle startup and logging-only reload publish the active resolved logging snapshot; diagnostic subscriptions register O(1) event-type interest before projection; and outbound WebSocket summaries are created lazily after the first recipient passes admission. Codex dynamic-tool observation is narrowed to terminal tool diagnostics, consistent with the upstream app-server request lifecycle.

There are no schema, protocol, configuration-surface, or Plugin SDK changes. Named follow-ups outside this bounded change are transcript/session projection and narrowing the OTel traces-only broad diagnostic listener.

## User Impact

Gateway operators get lower CPU, allocation, and storage-read overhead on busy session delivery, logging, diagnostics, and WebSocket fanout paths without changing delivery semantics, log settings, diagnostic payloads, or client-visible events.

## Evidence

Before/after deterministic operation counts on the same owner-boundary scenarios:

- Exact retry JSON parsing: 68 calls -> at most 8, independent of unrelated queue size.
- Logging settings config reads: 2 -> 1 per lifecycle generation.
- Subsystem child construction: 2 -> 1 per lifecycle generation.
- Public-only log-record clones: 1 -> 0.
- Rejected outbound payload reads: 3 -> 0.

Validation on the final diff:

- Focused grouped Vitest: 714 tests passed across queue runtime/recovery/storage, restart continuation, Gateway reload/startup/WebSocket/broadcast, logging/diagnostics, Talk, and Codex dynamic tools.
- Post-CI focused proof: 43 diagnostic/log tests, 234 CLI tests, 102 auth-profile tests, and 32 Gateway agent/media tests passed.
- `node scripts/check-changed.mjs`: formatting, typechecks, lint, Knip, database-first, import-cycle, pairing, and architecture guards passed; targeted reruns passed after each CI repair.
- `pnpm check:architecture`: passed with zero runtime and Madge cycles.
- `git diff --check`: passed.
- Codex autoreview: full-branch review had no accepted/actionable findings; every CI repair received a fresh clean review, with the final review reporting the patch correct at 0.99.
- Exact-head required CI: green for `070040495663de05f872a945326cc4e91959bddf` in https://github.com/openclaw/openclaw/actions/runs/32217159498.
- Production LOC: +552/-382 (net +170). Tests: +410/-73. The production growth establishes one exact-ID owner, lifecycle-applied logging snapshots, O(1) diagnostic event-interest ownership, and post-admission WebSocket logging rather than adding parallel paths.

The proof is deterministic owner-boundary instrumentation rather than a live production Gateway benchmark.
