### PR TITLE
fix(gateway): avoid readiness flaps during Reef reconnects

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -8,10 +8,9 @@ title: "Plugin SDK subpaths"
 ---
 
 The plugin SDK contains narrow public subpaths and repository-only bundled
-helpers under `openclaw/plugin-sdk/`. This page catalogs every typed public
-subpath and selected private-local entries that clarify the package boundary;
-it is not an inventory of every internal runtime helper. Three files define
-the boundary:
+helpers under `openclaw/plugin-sdk/`.
+This page catalogs every typed public subpath and labels selected private-local entries explicitly; it is not an inventory of every internal runtime helper.
+Three files define the boundary:
 
 - `scripts/lib/plugin-sdk-entrypoints.json`: the maintained entrypoint inventory
   the build compiles.

--- a/extensions/reef/src/channel.ts
+++ b/extensions/reef/src/channel.ts
@@ -463,19 +463,10 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
           initialCursor: inboxCursor.load(),
           persistCursor: (cursor) => inboxCursor.advance(cursor),
           onState: (state) => {
-            if (ctx.abortSignal.aborted) {
+            if (ctx.abortSignal.aborted || state !== "connected") {
               return;
             }
-            ctx.setStatus(
-              state === "connected"
-                ? channelReadyPatch({ accountId: "default" })
-                : {
-                    accountId: "default",
-                    running: true,
-                    connected: false,
-                    lifecycle: "recovering",
-                  },
-            );
+            ctx.setStatus(channelReadyPatch({ accountId: "default", lastDisconnect: null }));
           },
           onError: (error) => {
             if (ctx.abortSignal.aborted) {
@@ -488,6 +479,7 @@ export const reefPlugin: ChannelPlugin<ReefAccount> = {
               connected: false,
               lifecycle: "recovering",
               lastError: error.message,
+              lastDisconnect: { at: Date.now(), error: error.message },
             });
           },
         },

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -521,6 +521,17 @@ describe("channel-health-monitor", () => {
     await expectNoRestart(manager);
   });
 
+  it("does not restart a long-running channel during fresh reconnect grace", async () => {
+    const now = Date.now();
+    const manager = createSlackSnapshotManager(
+      disconnectedAccount(now - 300_000, {
+        lifecycle: "recovering",
+        lastDisconnect: { at: now - 5_000, error: "socket closed" },
+      }),
+    );
+    await expectNoRestart(manager);
+  });
+
   it("respects custom per-channel startup grace", async () => {
     const now = Date.now();
     const manager = createSnapshotManager({

--- a/src/gateway/channel-health-policy.test.ts
+++ b/src/gateway/channel-health-policy.test.ts
@@ -122,6 +122,50 @@ describe("evaluateChannelHealth", () => {
     ).toEqual({ healthy: false, reason: "disconnected" });
   });
 
+  it.each([
+    {
+      name: "uses reconnect grace for a fresh typed disconnect",
+      lastStartAt: 0,
+      lastDisconnect: { at: 95_000, error: "socket closed" },
+      expected: { healthy: true, reason: "reconnect-grace" },
+    },
+    {
+      name: "expires reconnect grace after 120 seconds",
+      lastStartAt: 0,
+      lastDisconnect: { at: -20_001, error: "socket closed" },
+      expected: { healthy: false, reason: "disconnected" },
+    },
+    {
+      name: "ignores a legacy string disconnect",
+      lastStartAt: 0,
+      lastDisconnect: "socket closed",
+      expected: { healthy: false, reason: "disconnected" },
+    },
+    {
+      name: "ignores a malformed typed disconnect",
+      lastStartAt: 0,
+      lastDisconnect: { at: Number.NaN, error: "socket closed" },
+      expected: { healthy: false, reason: "disconnected" },
+    },
+    {
+      name: "ignores a disconnect from the previous lifecycle",
+      lastStartAt: 80_000,
+      lastDisconnect: { at: 79_000, error: "socket closed" },
+      expected: { healthy: false, reason: "disconnected" },
+    },
+  ] as const)("$name", ({ lastStartAt, lastDisconnect, expected }) => {
+    expect(
+      evaluateHealth(
+        runningAccount({
+          connected: false,
+          lifecycle: "recovering",
+          lastStartAt,
+          lastDisconnect,
+        }),
+      ),
+    ).toEqual(expected);
+  });
+
   it("treats recorded blocked lifecycle as unhealthy", () => {
     expect(evaluateHealth(connectedAccount({ lifecycle: "blocked" }))).toEqual({
       healthy: false,

--- a/src/gateway/channel-health-policy.ts
+++ b/src/gateway/channel-health-policy.ts
@@ -1,6 +1,6 @@
 // Gateway channel health policy.
 // Evaluates channel lifecycle snapshots for restart/readiness decisions.
-import type { ChannelId } from "../channels/plugins/types.public.js";
+import type { ChannelAccountSnapshot, ChannelId } from "../channels/plugins/types.public.js";
 
 type ChannelHealthSnapshot = {
   running?: boolean;
@@ -15,6 +15,7 @@ type ChannelHealthSnapshot = {
   activeRunStartedAt?: number | null;
   lastEventAt?: number | null;
   lastConnectedAt?: number | null;
+  lastDisconnect?: ChannelAccountSnapshot["lastDisconnect"];
   lastTransportActivityAt?: number | null;
   lastStartAt?: number | null;
   reconnectAttempts?: number;
@@ -34,6 +35,7 @@ type ChannelHealthEvaluationReason =
   | "busy"
   | "stuck"
   | "startup-connect-grace"
+  | "reconnect-grace"
   | "disconnected"
   | "stale-socket"
   | "ingress-unavailable";
@@ -74,6 +76,7 @@ function isManagedAccount(snapshot: ChannelHealthSnapshot): boolean {
 }
 
 const BUSY_ACTIVITY_STALE_THRESHOLD_MS = 25 * 60_000;
+const CHANNEL_RECONNECT_GRACE_MS = 120_000;
 // Keep these shared between the background health monitor and on-demand readiness
 // probes so both surfaces evaluate channel lifecycle windows consistently.
 export const DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS = 30 * 60_000;
@@ -170,6 +173,22 @@ export function evaluateChannelHealth(
     }
   }
   if (snapshot.connected === false) {
+    const lastDisconnectAt =
+      snapshot.lastDisconnect &&
+      typeof snapshot.lastDisconnect !== "string" &&
+      Number.isFinite(snapshot.lastDisconnect.at)
+        ? snapshot.lastDisconnect.at
+        : null;
+    // A disconnect is current only when its producer recorded it inside this
+    // account lifecycle; patch-merged timestamps from prior runs grant no grace.
+    const disconnectBelongsToLifecycle =
+      lastDisconnectAt != null && (lastStartAt == null || lastDisconnectAt >= lastStartAt);
+    if (
+      disconnectBelongsToLifecycle &&
+      Math.max(0, policy.now - lastDisconnectAt) < CHANNEL_RECONNECT_GRACE_MS
+    ) {
+      return { healthy: true, reason: "reconnect-grace" };
+    }
     return { healthy: false, reason: "disconnected" };
   }
   // App-level events are not socket liveness: quiet Slack/Discord workspaces can

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -261,6 +261,20 @@ describe("createReadinessChecker", () => {
     });
   });
 
+  it("keeps a long-running Reef account ready during fresh reconnect grace", () => {
+    withReadinessClock(() => {
+      const { readiness } = createLongRunningReadinessHarness({
+        reef: managedAccount({
+          connected: false,
+          lifecycle: "recovering",
+          lastStartAt: Date.now() - THIRTY_ONE_MIN_MS,
+          lastDisconnect: { at: Date.now() - 5_000, error: "socket closed" },
+        }),
+      });
+      expect(readiness()).toEqual(readySnapshot(THIRTY_ONE_MIN_MS));
+    });
+  });
+
   it("uses fresh recorded lifecycle within connect grace", () => {
     withReadinessClock(() => {
       const { readiness } = createLongRunningReadinessHarness({


### PR DESCRIPTION
Related: #126132

## What Problem This Solves

Fixes an issue where operators monitoring `/readyz` could see brief HTTP 503 responses during an ordinary self-healing Reef WebSocket reconnect. A long-running Reef account was classified as immediately unhealthy as soon as its transport entered recovery, even when it reconnected within seconds.

## Why This Change Was Made

Reef now records the authoritative disconnect timestamp and clears it after reconnection. The shared channel-health owner gives a running account a fixed 120-second reconnect grace only when that disconnect belongs to the current lifecycle; sustained disconnects, blocked or terminal states, and unavailable ingress remain readiness failures.

This keeps `/readyz` as deep channel monitoring rather than weakening it or adding probe retries. `/startupz` traffic-admission behavior is unchanged.

Exact-head CI also exposed a current-main Plugin SDK docs/test drift introduced by #126132. This PR restores the required private-local catalog wording without changing SDK behavior.

AI-assisted; implementation and evidence were reviewed by the maintainer.

## User Impact

Short, recoverable Reef socket interruptions no longer flap Gateway readiness or trigger the channel health monitor. A Reef connection that fails to recover within the bounded grace period still becomes unready and remains eligible for recovery handling.

Production LOC: +23/-12 (net +11) | Tests: +69/-0 | Docs: one contract-wording repair

## Evidence

- Redacted production evidence from the August 18 Gateway soak showed intermittent Reef socket close code 1006 events. Forty-nine Reef socket closures were observed, with no Reef live-buffer overflow events; only one occurred within 30 seconds of a Gateway liveness warning.
- Pre-fix focused reproduction returned `{"ready":false,"failing":["reef"]}` for a fresh typed disconnect on a long-running Reef account.
- Post-fix focused reproduction returned `{"ready":true,"failing":[]}` for the same state.
- Focused Vitest proof: 178 tests passed across Gateway health/readiness and Reef channel/transport suites.
- `node scripts/check-changed.mjs -- extensions/reef/src/channel.ts src/gateway/channel-health-policy.ts src/gateway/channel-health-policy.test.ts src/gateway/server/readiness.test.ts src/gateway/channel-health-monitor.test.ts`
- `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-subpaths.test.ts`
- `git diff --check`
- Fresh Codex autoreview: clean, no accepted/actionable findings.
