### PR TITLE
test(docs): repair consolidated docs contracts

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -9,9 +9,9 @@ title: "Plugin SDK subpaths"
 
 The plugin SDK contains narrow public subpaths and repository-only bundled
 helpers under `openclaw/plugin-sdk/`. This page catalogs every typed public
-subpath and selected private-local entries that clarify the package boundary;
-it is not an inventory of every internal runtime helper. Three files define
-the boundary:
+subpath and labels private-local entries explicitly to clarify the package
+boundary; it is not an inventory of every internal runtime helper. Three files
+define the boundary:
 
 - `scripts/lib/plugin-sdk-entrypoints.json`: the maintained entrypoint inventory
   the build compiles.

--- a/src/docs/install-cloud-secrets.test.ts
+++ b/src/docs/install-cloud-secrets.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 const INSTALL_DOCS_DIR = path.join(process.cwd(), "docs", "install");
-const CLOUD_DOCKER_VM_INSTALL_DOCS = new Set(["gcp.md", "hetzner.md"]);
+const DOCKER_VM_RUNTIME_DOC = path.join(INSTALL_DOCS_DIR, "docker-vm-runtime.md");
 const KNOWN_WEAK_GATEWAY_TOKEN_PLACEHOLDERS = [
   "change-me-to-a-long-random-token",
   "change-me-now",
@@ -34,11 +34,13 @@ describe("cloud install docs", () => {
         expect(markdown, docName).not.toContain(`OPENCLAW_GATEWAY_PASSWORD=${password}`);
       }
       expect(markdown, docName).not.toMatch(/^ {4}GOG_KEYRING_PASSWORD=change-me-now$/m);
-      if (CLOUD_DOCKER_VM_INSTALL_DOCS.has(docName)) {
-        expect(markdown, docName).toMatch(/^ {4}OPENCLAW_GATEWAY_TOKEN=[ \t]*\r?$/m);
-        expect(markdown, docName).toMatch(/^ {4}GOG_KEYRING_PASSWORD=[ \t]*\r?$/m);
-        expect(markdown, docName).toContain("openssl rand -hex 32");
-      }
     }
+
+    // The shared Docker VM runtime owns token setup for GCP and Hetzner. Its
+    // maintained setup script must generate the token rather than document a
+    // copy-paste value in either provider guide.
+    const dockerVmRuntime = await fs.readFile(DOCKER_VM_RUNTIME_DOC, "utf8");
+    expect(dockerVmRuntime).toContain("generates a Gateway token");
+    expect(dockerVmRuntime).toContain("synchronizes `.env`");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

`main` is red in two core-lane documentation contracts inherited by every merge-ref after #126132 (`docs: consolidate setup and plugin references`). The docs-only PR did not run these core-lane assertions.

## Why This Change Was Made

The consolidation moved GCP and Hetzner Docker setup ownership to `docs/install/docker-vm-runtime.md`. The cloud-secret contract now verifies that canonical page states the maintained setup generates the Gateway token and synchronizes `.env`, while retaining the scan that rejects copy-paste token and password placeholders throughout install docs. The Plugin SDK catalog again explicitly states that it labels private-local entries, preserving the public-surface documentation boundary.

## User Impact

No product behavior changes. This restores main-green documentation contracts and preserves safe token setup guidance for cloud VM installs.

## Evidence

- Provenance and urgency: #126132 introduced the cross-lane failures now making `main` red.
- Before this patch on `origin/main` (`57e5ab7a879`): `node scripts/run-vitest.mjs src/docs/install-cloud-secrets.test.ts` failed because `gcp.md` no longer contained the copied environment block; `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-subpaths.test.ts` failed because the SDK catalog no longer contained `private-local entries explicitly`.
- After this patch: both focused `node scripts/run-vitest.mjs` commands passed (1/1 and 18/18 tests).
- `pnpm check:changed` passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` passed clean with no accepted/actionable findings.
- Follow-up, out of scope: these documentation-content assertions still run in core lanes. Consider assigning them to a docs-affecting lane so a docs-only PR cannot skip this coverage.
