### PR TITLE
fix(ui): buttons use the default cursor instead of the link hand

### DIFF
--- a/config/stylelint.config.mjs
+++ b/config/stylelint.config.mjs
@@ -6,14 +6,6 @@ export default {
     // Cascade-order advice, not an error class; 400+ intentional hits in the
     // existing token/override cascade make it pure noise here.
     "no-descending-specificity": null,
-    // stylelint 17.14.1 knows display-mode as fullscreen | standalone |
-    // minimal-ui | browser | picture-in-picture (lib/reference/mediaFeatures.mjs),
-    // predating window-controls-overlay. Allow that one value only, so typos in
-    // the rest still fail.
-    "media-feature-name-value-no-unknown": [
-      true,
-      { ignoreMediaFeatureNameValues: { "display-mode": ["window-controls-overlay"] } },
-    ],
     // `clip` survives only inside the standard sr-only fallback pattern.
     "property-no-deprecated": [true, { ignoreProperties: ["clip"] }],
     // `word-break: break-word` is deprecated but swapping it for overflow-wrap

--- a/ui/AGENTS.md
+++ b/ui/AGENTS.md
@@ -28,6 +28,7 @@ This directory owns Control UI-specific guidance that should not live in the rep
 
 ## Stylesheet Policy
 
+- Cursors: links and controls that open a new tab use the pointer; state-changing controls keep the default arrow.
 - Colors: stylesheet colors flow through custom-property tokens defined in `ui/src/styles/base.css`; `color-no-hex` enforces this. Exempt surfaces (token definitions, `lobster-pet.css` sprite artwork, `--theme-chip-*` preview swatches) each carry a stated contract. Lit `css\`\`` templates are not yet gated — prefer tokens there too.
 - Breakpoints: `max-width` media conditions use the canonical ladder 400/560/640/768/900/1100/1320px (plus the 932×500 landscape-phone compound); stylelint's allowed-list enforces it. New thresholds round up to the next rung. Don't add rungs without updating the config comment and this note.
 - Duplicate selectors are lint errors; deliberate topic-section reopens use `stylelint-disable-next-line no-duplicate-selectors -- <reason>`.

--- a/ui/index.html
+++ b/ui/index.html
@@ -202,10 +202,7 @@
         margin-top: 24px;
       }
 
-      /* The fallback renders when the bundle fails to load, so it cannot read
-         base.css tokens; it repeats the cursor policy locally for that reason. */
       .mount-fallback__button {
-        cursor: pointer;
         min-height: 42px;
         border: 1px solid rgba(148, 163, 184, 0.36);
         border-radius: 6px;
@@ -214,19 +211,6 @@
         background: transparent;
         font: inherit;
         font-weight: 700;
-      }
-
-      @media (display-mode: standalone),
-        (display-mode: minimal-ui),
-        (display-mode: window-controls-overlay) {
-        .mount-fallback__button {
-          cursor: default;
-        }
-      }
-
-      html:is(.openclaw-native-macos, .openclaw-native-nav, .openclaw-native-web-chrome)
-        .mount-fallback__button {
-        cursor: default;
       }
 
       .mount-fallback__button--primary {

--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -220,6 +220,7 @@ function renderIdentityMenuHelpSubmenu() {
           slot="submenu"
           class="sidebar-customize-menu__item"
           value=${`${LINK_VALUE_PREFIX}${encodeURIComponent(link.href)}`}
+          data-new-tab-action
           @click=${(event: MouseEvent) => {
             if (event.target instanceof Element && event.target.closest("a")) {
               (event.currentTarget as HTMLElement).dataset.nativeNavigation = "true";

--- a/ui/src/components/browser/browser-panel-render.ts
+++ b/ui/src/components/browser/browser-panel-render.ts
@@ -59,6 +59,7 @@ function renderHeaderActions(
       <button
         class="rail-header__action bp-icon"
         type="button"
+        data-new-tab-action
         title=${t("browser.openExternal")}
         aria-label=${t("browser.openExternal")}
         ?disabled=${!activeUrl}
@@ -91,6 +92,7 @@ function renderToolbar(controller: BrowserPanelController, embedded: boolean) {
         ? html`<button
             class="bp-icon"
             type="button"
+            data-new-tab-action
             title=${t("browser.newTab")}
             aria-label=${t("browser.newTab")}
             @click=${() => controller.beginNewTab()}

--- a/ui/src/components/browser/browser-panel-tabs.ts
+++ b/ui/src/components/browser/browser-panel-tabs.ts
@@ -41,6 +41,7 @@ export function renderBrowserPanelTabs(params: {
     onClose: params.onClose,
     onNew: params.onNew,
     newLabel: t("browser.newTab"),
+    newTabAction: true,
     ...(params.hideNewControl ? { newControl: nothing } : {}),
   });
 }

--- a/ui/src/components/dock-layout-controller.ts
+++ b/ui/src/components/dock-layout-controller.ts
@@ -397,6 +397,9 @@ export const dockPanelStyles = css`
   .rail-header__action[aria-disabled="true"] {
     opacity: var(--rail-header-action-disabled-opacity, 0.4);
   }
+  [data-new-tab-action]:not(:disabled):not([disabled]):not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
   .rail-header__action svg {
     width: var(--rail-header-action-glyph-size, 16px);
     height: var(--rail-header-action-glyph-size, 16px);

--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -326,7 +326,7 @@ describeBrowserLayout("touch-primary form controls", () => {
 });
 
 describeBrowserLayout("mount fallback cursor", () => {
-  it("advertises its controls with the hand in a browser tab, alongside its real link", async () => {
+  it("uses the arrow for recovery controls and the hand for its real link", async () => {
     const page = await desktopContext.newPage();
     try {
       await page.setContent(readStyleSheet("ui/index.html"));
@@ -345,11 +345,9 @@ describeBrowserLayout("mount fallback cursor", () => {
         };
       });
 
-      // A browser tab is display-mode: browser, so the fallback follows the same
-      // cursor policy as the app it is standing in for.
       expect(cursors).toEqual({
-        retry: "pointer",
-        wait: "pointer",
+        retry: "default",
+        wait: "default",
         docs: "pointer",
       });
     } finally {

--- a/ui/src/components/native-link-menu.ts
+++ b/ui/src/components/native-link-menu.ts
@@ -74,6 +74,7 @@ export class NativeLinkMenu extends OpenClawLightDomElement {
         <wa-dropdown-item
           class="session-menu__item"
           value="external"
+          data-new-tab-action
           data-shortcut="b"
           aria-keyshortcuts="B"
         >

--- a/ui/src/components/panel-tab-strip.ts
+++ b/ui/src/components/panel-tab-strip.ts
@@ -193,6 +193,7 @@ export function renderPanelTabStrip(params: {
   onNew: () => void;
   newLabel: string;
   newDisabled?: boolean;
+  newTabAction?: boolean;
   newControl?: TemplateResult | typeof nothing;
   separateTabs?: boolean;
   onReorder?: (sourceId: string, targetId: string, placement: "before" | "after") => void;
@@ -209,6 +210,7 @@ export function renderPanelTabStrip(params: {
               slot=${slotted ? "nav" : nothing}
               class="rail-header__action tabstrip-new"
               type="button"
+              ?data-new-tab-action=${params.newTabAction}
               ?disabled=${params.newDisabled}
               title=${params.newLabel}
               aria-label=${params.newLabel}

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -207,6 +207,7 @@ class SessionMenu extends OpenClawLightDomElement {
       <wa-dropdown-item
         class="session-menu__item"
         value="open-pr"
+        data-new-tab-action
         data-shortcut="g"
         aria-keyshortcuts="G"
         ?disabled=${this.disabled || !pullRequestUrl}

--- a/ui/src/components/terminal/terminal-panel-upload.ts
+++ b/ui/src/components/terminal/terminal-panel-upload.ts
@@ -381,6 +381,7 @@ export function renderTerminalPanelActions(params: {
               <button
                 class="rail-header__action tp-icon tp-open-fullscreen"
                 type="button"
+                data-new-tab-action
                 title=${t("terminal.openFullscreen")}
                 aria-label=${t("terminal.openFullscreen")}
                 @click=${params.onOpenFullscreen}

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -376,7 +376,7 @@ suite.define(() => {
         const optionRestingStyle = await twitchOption.evaluate(readInteractionStyle);
         await twitchOption.hover();
         const optionHoverStyle = await twitchOption.evaluate(readInteractionStyle);
-        expect(optionRestingStyle.cursor).toBe("pointer");
+        expect(optionRestingStyle.cursor).toBe("default");
         expect(optionHoverStyle.borderColor).not.toBe(optionRestingStyle.borderColor);
 
         const disabledContinueStyle = await continueButton.evaluate(readInteractionStyle);
@@ -384,7 +384,7 @@ suite.define(() => {
         expect(await continueButton.evaluate(readInteractionStyle)).toEqual(disabledContinueStyle);
         expect(disabledContinueStyle.cursor).toBe("not-allowed");
         expect(await cancelButton.evaluate((element) => getComputedStyle(element).cursor)).toBe(
-          "pointer",
+          "default",
         );
         expect(
           await Promise.all(
@@ -453,7 +453,7 @@ suite.define(() => {
         });
         await page.getByLabel("Twitch").check();
         expect(await continueButton.evaluate((element) => getComputedStyle(element).cursor)).toBe(
-          "pointer",
+          "default",
         );
         await page.getByRole("button", { name: "Continue" }).click();
         await page.getByLabel("Announcements").waitFor();

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -268,6 +268,7 @@
   --duration-fast: 100ms;
   --duration-normal: 180ms;
   --duration-slow: 300ms;
+  --cursor-action: default;
   --safe-area-top: env(safe-area-inset-top, 0px);
   --safe-area-right: env(safe-area-inset-right, 0px);
   --safe-area-bottom: env(safe-area-inset-bottom, 0px);
@@ -996,37 +997,9 @@ openclaw-app {
   }
 }
 
-/* Cursor policy. A browser tab gets the pointer hand, the only hover affordance
-   a page owns; installed/app-like windows are desktop chrome and keep the arrow.
-   Controls consume --cursor-action rather than hardcoding a cursor, and real
-   hyperlinks keep the UA pointer in every mode. */
-/* stylelint-disable-next-line no-duplicate-selectors -- cursor policy block, see comment above */
-:root {
-  --cursor-action: pointer;
-}
-
-/* Separate from the standalone block above, which owns viewport and safe-area
-   insets; widening its condition would change those too. `fullscreen` is absent
-   on purpose: it is a transient presentation state any window can enter, and
-   the manifest installs this UI as `standalone`. */
-@media (display-mode: standalone),
-  (display-mode: minimal-ui),
-  (display-mode: window-controls-overlay) {
-  :root {
-    --cursor-action: default;
-  }
-}
-
-/* Native app hosts are installed desktop windows too, but they embed a plain
-   web view that reports `display-mode: browser`; they announce themselves with
-   these `<html>` markers instead (all three, as layout.css already matches). */
-html:is(.openclaw-native-macos, .openclaw-native-nav, .openclaw-native-web-chrome) {
-  --cursor-action: default;
-}
-
-/* Generic actionable controls, at element/attribute specificity only so the
-   component rules that own semantic cursors (not-allowed, disabled, grab,
-   resize, deliberate `default` on non-actionable elements) still win. */
+/* State-changing controls use the desktop arrow. This stays at
+   element/attribute specificity so component rules that own semantic cursors
+   (not-allowed, disabled, grab, resize, deliberate `default`) still win. */
 button,
 summary,
 select,
@@ -1056,6 +1029,17 @@ a {
   color: var(--accent);
   text-decoration: underline;
   text-underline-offset: 2px;
+}
+
+/* Real links keep the hand even when styled as controls. */
+a[href] {
+  cursor: pointer;
+}
+
+/* Non-anchor controls opt in only when their primary action opens a browser
+   tab/window. Disabled controls keep their component-owned cursor. */
+[data-new-tab-action]:not(:disabled):not([disabled]):not([aria-disabled="true"]) {
+  cursor: pointer;
 }
 
 a:hover {

--- a/ui/src/styles/cursor-policy.browser.test.ts
+++ b/ui/src/styles/cursor-policy.browser.test.ts
@@ -1,10 +1,11 @@
-// Control UI tests cover the display-mode cursor policy.
+// Control UI tests cover the semantic cursor policy.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { readStyleSheet } from "../../../test/helpers/ui-style-fixtures.js";
+import { dockPanelStyles } from "../components/dock-layout-controller.ts";
 import {
   canRunPlaywrightChromium,
   resolvePlaywrightChromiumExecutablePath,
@@ -19,40 +20,38 @@ const describeCursorPolicy = canRunPlaywrightChromium(chromiumExecutablePath)
 const NATIVE_HOST_MARKERS = ["openclaw-native-macos", "openclaw-native-web-chrome"] as const;
 
 type CursorCase = {
-  /**
-   * Expected cursor in an installed/app window: a `display-mode: standalone`
-   * window, or a native app host that stamps `NATIVE_HOST_MARKERS` instead.
-   */
-  readonly appWindow: string;
-  /** Expected cursor in an ordinary tab (`display-mode: browser`). */
-  readonly browserTab: string;
+  readonly expected: string;
   readonly selector: string;
+  readonly shadow?: boolean;
 };
 
 const CURSOR_CASES: readonly CursorCase[] = [
-  // Actionable controls follow the window they run in.
-  { appWindow: "default", browserTab: "pointer", selector: ".btn" },
-  { appWindow: "default", browserTab: "pointer", selector: "#plain-summary" },
-  { appWindow: "default", browserTab: "pointer", selector: "#plain-select" },
-  { appWindow: "default", browserTab: "pointer", selector: "#plain-checkbox" },
-  { appWindow: "default", browserTab: "pointer", selector: "#role-button" },
-  { appWindow: "default", browserTab: "pointer", selector: ".nav-item" },
-  { appWindow: "default", browserTab: "pointer", selector: ".settings-secret__toggle" },
-  // Real links keep the hand in both windows: a[href] through the UA, the
-  // href-less content link through its own documented rule.
-  { appWindow: "pointer", browserTab: "pointer", selector: "#real-link" },
-  { appWindow: "pointer", browserTab: "pointer", selector: ".markdown-file-link" },
-  // Semantic cursors belong to their component and never follow the policy.
-  { appWindow: "text", browserTab: "text", selector: "#plain-text-input" },
-  { appWindow: "text", browserTab: "text", selector: ".chat-pane__session-title-button" },
-  { appWindow: "grab", browserTab: "grab", selector: ".sidebar-session-group-drag-handle" },
-  { appWindow: "col-resize", browserTab: "col-resize", selector: ".sw-queue-resizer" },
-  { appWindow: "zoom-in", browserTab: "zoom-in", selector: ".chat-message-image-button" },
-  { appWindow: "not-allowed", browserTab: "not-allowed", selector: ".btn--ghost:disabled" },
-  { appWindow: "wait", browserTab: "wait", selector: ".sidebar-update-card__hold:disabled" },
-  // Deliberate `default` on non-actionable elements survives in both windows.
-  { appWindow: "default", browserTab: "default", selector: ".session-tokens" },
-  { appWindow: "default", browserTab: "default", selector: ".agent-tools-runtime-chip--more" },
+  // State-changing controls use the desktop arrow in every host.
+  { expected: "default", selector: ".btn" },
+  { expected: "default", selector: "#plain-summary" },
+  { expected: "default", selector: "#plain-select" },
+  { expected: "default", selector: "#plain-checkbox" },
+  { expected: "default", selector: "#role-button" },
+  { expected: "default", selector: ".settings-secret__toggle" },
+  // Links and explicit new-tab controls keep the hand.
+  { expected: "pointer", selector: "#real-link" },
+  { expected: "pointer", selector: ".nav-item" },
+  { expected: "pointer", selector: "#new-tab-link" },
+  { expected: "pointer", selector: "#new-tab-button" },
+  { expected: "pointer", selector: "#shadow-new-tab-button", shadow: true },
+  { expected: "pointer", selector: ".markdown-file-link" },
+  // Semantic cursors remain owned by their components.
+  { expected: "text", selector: "#plain-text-input" },
+  { expected: "text", selector: ".chat-pane__session-title-button" },
+  { expected: "grab", selector: ".sidebar-session-group-drag-handle" },
+  { expected: "col-resize", selector: ".sw-queue-resizer" },
+  { expected: "zoom-in", selector: ".chat-message-image-button" },
+  { expected: "not-allowed", selector: ".btn--ghost:disabled" },
+  { expected: "not-allowed", selector: "#disabled-new-tab-button" },
+  { expected: "default", selector: "#shadow-disabled-new-tab-button", shadow: true },
+  { expected: "wait", selector: ".sidebar-update-card__hold:disabled" },
+  { expected: "default", selector: ".session-tokens" },
+  { expected: "default", selector: ".agent-tools-runtime-chip--more" },
 ];
 
 function readUiCss(): string {
@@ -84,6 +83,9 @@ function fixtureDocument(): string {
       <div id="role-button" role="button" tabindex="0">Role button</div>
       <a id="real-link" href="https://example.com">Real link</a>
       <a class="nav-item" href="#/chat">Nav rail</a>
+      <a id="new-tab-link" class="btn" href="https://example.com/docs" target="_blank">Docs</a>
+      <button id="new-tab-button" class="btn" type="button" data-new-tab-action>New tab</button>
+      <button id="disabled-new-tab-button" class="btn btn--ghost" type="button" data-new-tab-action disabled>Unavailable new tab</button>
       <button class="settings-secret__toggle" type="button">Reveal</button>
       <button class="sidebar-update-card__hold" type="button" disabled>Hold</button>
       <button class="chat-pane__session-title-button" type="button">Session title</button>
@@ -93,6 +95,11 @@ function fixtureDocument(): string {
       <div class="session-tokens"><span class="session-tokens__value">12k</span></div>
       <span class="agent-tools-runtime-chip--more">+3</span>
       <div class="chat-text"><a class="markdown-file-link">src/index.ts</a></div>
+      <div id="shadow-policy-host"><template shadowrootmode="open">
+        <style>${dockPanelStyles.cssText}</style>
+        <button id="shadow-new-tab-button" class="rail-header__action" type="button" data-new-tab-action>New tab</button>
+        <button id="shadow-disabled-new-tab-button" class="rail-header__action" type="button" data-new-tab-action disabled>Unavailable new tab</button>
+      </template></div>
     </main>
   </body></html>`;
 }
@@ -103,35 +110,29 @@ type WindowProbe = {
 };
 
 async function probeWindow(page: Page): Promise<WindowProbe> {
-  return await page.evaluate(
-    (selectors: readonly string[]) => {
-      const modes = [
-        "browser",
-        "standalone",
-        "minimal-ui",
-        "window-controls-overlay",
-        "fullscreen",
-      ];
-      const cursors = selectors.map((selector) => {
-        const element = document.querySelector(selector);
-        if (!element) {
-          throw new Error(`Missing cursor fixture element for ${selector}`);
-        }
-        return [selector, getComputedStyle(element).cursor] as const;
-      });
-      return {
-        cursors: Object.fromEntries(cursors),
-        displayMode:
-          modes.find((mode) => matchMedia(`(display-mode: ${mode})`).matches) ?? "unknown",
-      };
-    },
-    CURSOR_CASES.map((cursorCase) => cursorCase.selector),
-  );
+  return await page.evaluate((cursorCases: readonly CursorCase[]) => {
+    const modes = ["browser", "standalone", "minimal-ui", "window-controls-overlay", "fullscreen"];
+    const cursors = cursorCases.map(({ selector, shadow }) => {
+      const element = shadow
+        ? document
+            .querySelector<HTMLElement>("#shadow-policy-host")
+            ?.shadowRoot?.querySelector(selector)
+        : document.querySelector(selector);
+      if (!element) {
+        throw new Error(`Missing cursor fixture element for ${selector}`);
+      }
+      return [selector, getComputedStyle(element).cursor] as const;
+    });
+    return {
+      cursors: Object.fromEntries(cursors),
+      displayMode: modes.find((mode) => matchMedia(`(display-mode: ${mode})`).matches) ?? "unknown",
+    };
+  }, CURSOR_CASES);
 }
 
-function expectedCursors(key: "appWindow" | "browserTab"): Record<string, string> {
+function expectedCursors(): Record<string, string> {
   return Object.fromEntries(
-    CURSOR_CASES.map((cursorCase) => [cursorCase.selector, cursorCase[key]]),
+    CURSOR_CASES.map((cursorCase) => [cursorCase.selector, cursorCase.expected]),
   );
 }
 
@@ -172,20 +173,20 @@ afterAll(async () => {
 });
 
 describeCursorPolicy("Control UI cursor policy", () => {
-  it("advertises actionable controls with the hand in a browser tab", async () => {
+  it("uses semantic cursors in a browser tab", async () => {
     const page = await tabBrowser.newPage();
     try {
       await page.goto(`file://${fixtureFile}`);
       const probe = await probeWindow(page);
 
       expect(probe.displayMode).toBe("browser");
-      expect(probe.cursors).toEqual(expectedCursors("browserTab"));
+      expect(probe.cursors).toEqual(expectedCursors());
     } finally {
       await page.close().catch(() => {});
     }
   });
 
-  it("keeps the desktop arrow on app chrome in a native app host", async () => {
+  it("uses the same semantic cursors in a native app host", async () => {
     const page = await tabBrowser.newPage();
     try {
       await page.goto(`file://${fixtureFile}`);
@@ -197,19 +198,19 @@ describeCursorPolicy("Control UI cursor policy", () => {
       const probe = await probeWindow(page);
 
       expect(probe.displayMode).toBe("browser");
-      expect(probe.cursors).toEqual(expectedCursors("appWindow"));
+      expect(probe.cursors).toEqual(expectedCursors());
     } finally {
       await page.close().catch(() => {});
     }
   });
 
-  it("keeps the desktop arrow on app chrome in an installed window", async () => {
+  it("uses the same semantic cursors in an installed window", async () => {
     const [page] = appContext.pages();
     expect(page, "Chromium --app window did not expose a page").toBeDefined();
     await page!.waitForLoadState("load");
     const probe = await probeWindow(page!);
 
     expect(probe.displayMode).toBe("standalone");
-    expect(probe.cursors).toEqual(expectedCursors("appWindow"));
+    expect(probe.cursors).toEqual(expectedCursors());
   });
 });

--- a/ui/src/styles/cursor-policy.node.test.ts
+++ b/ui/src/styles/cursor-policy.node.test.ts
@@ -6,14 +6,6 @@ import { describe, expect, it } from "vitest";
 
 const stylesDir = path.dirname(fileURLToPath(import.meta.url));
 
-const APP_LIKE_MODES = ["standalone", "minimal-ui", "window-controls-overlay"] as const;
-/** `<html>` markers the native app hosts stamp; they report display-mode browser. */
-const NATIVE_HOST_MARKERS = [
-  "openclaw-native-macos",
-  "openclaw-native-nav",
-  "openclaw-native-web-chrome",
-] as const;
-
 function collectStyleSources(directory: string): string[] {
   return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const entryPath = path.join(directory, entry.name);
@@ -46,77 +38,48 @@ function selectorFor(lines: readonly string[], declarationIndex: number): string
   return parts.join(" ");
 }
 
+function selectorBranches(selector: string): string[] {
+  const branches: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let index = 0; index < selector.length; index += 1) {
+    const character = selector[index];
+    if (character === "(" || character === "[") {
+      depth += 1;
+    } else if (character === ")" || character === "]") {
+      depth -= 1;
+    } else if (character === "," && depth === 0) {
+      branches.push(selector.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  branches.push(selector.slice(start).trim());
+  return branches;
+}
+
 const ANCHOR_SELECTOR = /(^|[\s,(>~+])a([.#:[]|\b)/u;
+const NEW_TAB_ACTION_SELECTOR = /\[data-new-tab-action\]/u;
 
 describe("Control UI cursor policy", () => {
-  it("selects the cursor token by display mode and leaves fullscreen alone", () => {
-    const baseCss = fs.readFileSync(path.join(stylesDir, "base.css"), "utf8");
-
-    expect(baseCss).toMatch(/:root\s*\{[^}]*--cursor-action:\s*pointer;/u);
-
-    const appLikeQuery = baseCss.match(
-      /@media\s*\(display-mode:[^{]*\{\s*:root\s*\{\s*--cursor-action:\s*default;/u,
-    )?.[0];
-    expect(appLikeQuery, "base.css must map app-like display modes to the arrow").toBeDefined();
-    for (const mode of APP_LIKE_MODES) {
-      expect(appLikeQuery).toContain(`display-mode: ${mode}`);
-    }
-    // `fullscreen` is a transient presentation state any window can enter; the
-    // manifest installs this UI as `standalone`, so it never appears here.
-    expect(appLikeQuery).not.toContain("fullscreen");
-  });
-
-  it("gives the native app hosts the same arrow as an app-like display mode", () => {
-    const baseCss = fs.readFileSync(path.join(stylesDir, "base.css"), "utf8");
-
-    const nativeHostRule = baseCss.match(
-      /html:is\([^)]*\)\s*\{\s*--cursor-action:\s*default;/u,
-    )?.[0];
-    expect(nativeHostRule, "base.css must map the native host markers to the arrow").toBeDefined();
-    for (const marker of NATIVE_HOST_MARKERS) {
-      expect(nativeHostRule).toContain(`.${marker}`);
-    }
-  });
-
-  it("repeats the same app-like mode list in the pre-boot mount fallback", () => {
-    // The fallback ships its own inline stylesheet because it has to render when
-    // the bundle fails to load, so the policy is duplicated there on purpose.
-    const indexHtml = fs.readFileSync(path.join(stylesDir, "..", "..", "index.html"), "utf8");
-
-    const fallbackQuery = indexHtml.match(
-      /@media\s*\(display-mode:[^{]*\{\s*\.mount-fallback__button\s*\{\s*cursor:\s*default;/u,
-    )?.[0];
-    expect(fallbackQuery, "ui/index.html must keep the fallback on the policy").toBeDefined();
-    for (const mode of APP_LIKE_MODES) {
-      expect(fallbackQuery).toContain(`display-mode: ${mode}`);
-    }
-
-    const fallbackNativeRule = indexHtml.match(
-      /html:is\([^)]*\)\s*\.mount-fallback__button\s*\{\s*cursor:\s*default;/u,
-    )?.[0];
-    expect(
-      fallbackNativeRule,
-      "ui/index.html must keep the fallback on the native host policy",
-    ).toBeDefined();
-    for (const marker of NATIVE_HOST_MARKERS) {
-      expect(fallbackNativeRule).toContain(`.${marker}`);
-    }
-  });
-
-  it("keeps the unconditional pointer hand on link rules only", () => {
+  it("keeps the unconditional pointer on links and explicit new-tab controls only", () => {
     const offenders = collectStyleSources(path.join(stylesDir, ".."))
       .flatMap((filePath) => {
         const lines = fs.readFileSync(filePath, "utf8").split("\n");
         return lines.flatMap((line, index) =>
           /^\s*cursor:\s*pointer;\s*$/u.test(line)
-            ? [{ file: path.relative(stylesDir, filePath), selector: selectorFor(lines, index) }]
+            ? selectorBranches(selectorFor(lines, index)).map((selector) => ({
+                file: path.relative(stylesDir, filePath),
+                selector,
+              }))
             : [],
         );
       })
-      .filter((hit) => !ANCHOR_SELECTOR.test(hit.selector));
+      .filter(
+        (hit) => !ANCHOR_SELECTOR.test(hit.selector) && !NEW_TAB_ACTION_SELECTOR.test(hit.selector),
+      );
 
-    // Controls consume var(--cursor-action); a hardcoded hand is how the policy
-    // drifted apart before (92 declarations by the time it was caught).
+    // State controls consume var(--cursor-action); only links and the explicit
+    // browser-tab/window hook may own an unconditional hand.
     expect(offenders).toEqual([]);
   });
 });

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -504,8 +504,7 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
   color: var(--muted);
 }
 
-/* Settings rail entries are anchors but read as app chrome: default arrow,
-   not the UA link pointer. */
+/* Settings rail entries are navigation anchors and keep the link pointer. */
 .settings-sidebar__item {
   position: relative;
   display: flex;
@@ -517,7 +516,6 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
   border-radius: var(--radius-md);
   background: transparent;
   color: var(--muted);
-  cursor: var(--cursor-action);
   text-decoration: none;
   transition:
     border-color var(--duration-fast) ease,
@@ -589,7 +587,6 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
   padding: 0 9px;
   border-radius: var(--radius-sm);
   color: var(--text);
-  cursor: var(--cursor-action);
   text-decoration: none;
 }
 
@@ -1500,8 +1497,7 @@ body.update-dialog-open .sidebar-update-card__status {
   flex-direction: column;
   gap: var(--sidebar-group-gap);
   margin-inline: -8px 0;
-  /* Sessions are app chrome, not hyperlinks: the whole region follows the
-     base.css cursor policy so it tracks the window it is running in. */
+  /* Sessions are stateful app chrome, not navigation links. */
   cursor: var(--cursor-action);
 }
 
@@ -2636,8 +2632,6 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
   font: inherit;
   font-size: calc(13px * var(--control-ui-text-scale));
   text-align: left;
-  /* More-menu route rows are anchors acting as chrome (see base.css cursor policy). */
-  cursor: var(--cursor-action);
   text-decoration: none;
 }
 
@@ -3103,8 +3097,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   outline-offset: -2px;
 }
 
-/* Nav rail entries are anchors (for middle-click/new-tab) but read as app
-   chrome: override the UA link pointer back to the default arrow. */
+/* Nav rail entries are anchors so middle-click/new-tab keeps link behavior. */
 .nav-item {
   position: relative;
   display: flex;
@@ -3117,7 +3110,6 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   border: 1px solid transparent;
   background: transparent;
   color: var(--muted);
-  cursor: var(--cursor-action);
   text-decoration: none;
   transition:
     border-color var(--duration-fast) ease,


### PR DESCRIPTION
Related: #121258

## What Problem This Solves

Fixes an issue where users hovering state-changing controls in the Control UI would see the hyperlink hand cursor in ordinary browser tabs. Buttons, menus, tabs, selects, checkboxes, and similar app controls therefore looked like navigation links instead of desktop-style controls.

## Why This Change Was Made

The Control UI now uses one semantic cursor policy in every host: real links and enabled actions whose primary behavior opens a browser tab or window use the pointer hand, while state-changing controls use the default arrow. The base stylesheet owns the rule, explicit new-tab actions opt in through one narrow attribute, and the obsolete display-mode split is removed. Existing text, drag, resize, zoom, busy, and disabled cursors remain component-owned.

**Owner decision:** adopt the uniform semantic cursor policy in browser tabs, installed windows, and native hosts. The hand indicates a link or browser-tab/window action; state-changing controls use the arrow.

Provenance: clear. PR #121258 (commit `32ced3053df`, authored by @vyctorbrzezowski and merged 2026-08-10) changed browser-tab controls to the pointer hand. This restores and clarifies the app-wide convention from PR #103411 while retaining a pointer for non-anchor actions that genuinely open a browser tab/window.

Production LOC: +30/-58 (net -28) | Tests: +100/-138 (net -38) | Docs/tooling: +1/-8

## User Impact

Links and new-tab actions continue to show the hand pointer. Buttons and controls that change application state now show the normal arrow, making navigation and actions easier to distinguish without changing keyboard behavior, focus treatment, hit targets, or touch behavior.

## Evidence

### Before

![Before: browser-tab controls all resolve to the pointer cursor](https://github.com/user-attachments/assets/91a52f2a-5c7d-4795-9140-465cffffb58d)

### After

![After: state-changing controls use the default cursor while links and new-tab actions retain pointer](https://github.com/user-attachments/assets/1f8bc16b-05a8-42a3-b389-8f7ce808758f)

Both captures use the same running mocked Control UI in Chromium. The overlay reports computed styles from the live page. Only the state-changing button changes (`pointer` → `default`); the navigation link and explicit new-tab action remain `pointer`, while disabled, text-entry, and drag cursors remain `not-allowed`, `text`, and `grab`.

Focused validation:

- `node scripts/run-vitest.mjs ui/src/styles/cursor-policy.node.test.ts ui/src/styles/cursor-policy.browser.test.ts ui/src/components/form-controls.browser.test.ts` — 13 passed
- `node scripts/run-vitest.mjs ui/src/components/session-menu.test.ts ui/src/components/session-menu-work.test.ts ui/src/components/native-link-menu.test.ts ui/src/components/panel-tab-strip.test.ts ui/src/components/panel-tab-strip.browser.test.ts ui/src/components/terminal/terminal-panel-upload.test.ts ui/src/components/browser/browser-panel.test.ts ui/src/components/browser/browser-panel-surface.test.ts` — 79 passed, 3 skipped
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/custodian-event-nudge.e2e.test.ts` — 7 passed
- `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-subpaths.test.ts` — 18 passed
- `node scripts/run-vitest.mjs src/docs/install-cloud-secrets.test.ts` — 1 passed
- `node scripts/check-changed.mjs` — passed formatting, core/UI/extension type checks, stylelint, lint, architecture/guard checks, dead-code checks, and UI i18n verification
- Mock Control UI preview — no browser console or server errors; computed styles verified for buttons, links, text entry, drag handles, and disabled controls
- Fresh full-branch Codex autoreview — clean, no accepted/actionable findings

The first exact-head CI run exposed the stale cursor expectation in the real custodian wizard E2E plus two docs-contract failures from a newer `main` merge tree. The branch now updates the wizard option, cancel, and enabled continue controls to the new arrow contract. Rebasing onto current `main` preserved its stronger fixes for the Plugin SDK and cloud-install docs contracts; those repairs are no longer part of this PR's diff.

`pnpm test:changed` locally routes some UI tests through the unit config and fails before exercising this patch correctly; the same reported files pass through the repository's UI test router. That separate harness issue is tracked outside this PR.

AI-assisted; I reviewed the implementation, tests, computed-style evidence, CI repairs, and final diff.
