### PR TITLE
fix(skills): require re-review when proposals change

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -41909,6 +41909,17 @@
       ]
     },
     {
+      "id": "native.apple.08109b7e335603e1",
+      "source": "Review the proposal draft before applying or rejecting it.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.d23668f12e319332",
       "source": "Review this endpoint. Credentials are applied only after you tap Connect.",
       "surface": "apple",

--- a/apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift
+++ b/apps/ios/Sources/Design/IPadSkillWorkshopScreen.swift
@@ -1,4 +1,5 @@
 import OpenClawKit
+import OpenClawProtocol
 import SwiftUI
 
 struct IPadSkillWorkshopScreen: View {
@@ -857,9 +858,9 @@ struct IPadSkillWorkshopScreen: View {
         do {
             let data = try await request(
                 method: "skills.proposals.inspect",
-                params: IPadSkillProposalInspectParams(
-                    agentId: selectedAgentParam,
-                    proposalId: proposalID),
+                params: SkillsProposalInspectParams(
+                    agentid: selectedAgentParam,
+                    proposalid: proposalID),
                 timeoutSeconds: 20)
             let response = try JSONDecoder().decode(IPadSkillProposalInspectResponse.self, from: data)
             self.merge(IPadSkillProposal(inspect: response, previous: self.proposals.first { $0.id == proposalID }))
@@ -870,25 +871,29 @@ struct IPadSkillWorkshopScreen: View {
 
     private func run(_ action: IPadSkillProposalAction.Kind, proposal: IPadSkillProposal) async {
         guard self.canApplyProposalMutations, self.busyAction == nil else { return }
-        self.busyAction = IPadSkillProposalAction(kind: action, proposalID: proposal.id)
+        guard let preparedAction = IPadSkillProposalAction(kind: action, proposal: proposal) else {
+            self.noticeText = nil
+            self.errorText = String(localized: "Review the proposal draft before applying or rejecting it.")
+            return
+        }
+        self.busyAction = preparedAction
         self.errorText = nil
         self.noticeText = nil
         defer { self.busyAction = nil }
 
         do {
-            let method = action == .apply ? "skills.proposals.apply" : "skills.proposals.reject"
             _ = try await self.request(
-                method: method,
-                params: IPadSkillProposalInspectParams(
-                    agentId: self.selectedAgentParam,
-                    proposalId: proposal.id),
+                method: preparedAction.method,
+                params: preparedAction.params(agentID: self.selectedAgentParam),
                 timeoutSeconds: 30)
-            self.noticeText = action == .apply
+            self.noticeText = preparedAction.kind == .apply
                 ? String(localized: "Proposal applied.")
                 : String(localized: "Proposal rejected.")
             await self.loadProposals(force: true)
         } catch {
-            self.errorText = Self.message(for: error)
+            let actionError = Self.message(for: error)
+            await self.loadProposals(force: true)
+            self.errorText = actionError
         }
     }
 
@@ -1128,6 +1133,25 @@ struct IPadSkillProposalAction: Equatable {
 
     let kind: Kind
     let proposalID: String
+    let revisionHash: String
+
+    init?(kind: Kind, proposal: IPadSkillProposal) {
+        guard let revisionHash = proposal.revisionHash else { return nil }
+        self.kind = kind
+        self.proposalID = proposal.id
+        self.revisionHash = revisionHash
+    }
+
+    var method: String {
+        self.kind == .apply ? "skills.proposals.apply" : "skills.proposals.reject"
+    }
+
+    func params(agentID: String?) -> SkillsProposalDecisionParams {
+        SkillsProposalDecisionParams(
+            agentid: agentID,
+            proposalid: self.proposalID,
+            expectedrevisionhash: self.revisionHash)
+    }
 }
 
 private struct IPadSkillProposalManifest: Decodable {
@@ -1154,13 +1178,9 @@ private struct IPadSkillProposalListParams: Encodable {
     let agentId: String?
 }
 
-private struct IPadSkillProposalInspectParams: Encodable {
-    let agentId: String?
-    let proposalId: String
-}
-
 struct IPadSkillProposalInspectResponse: Decodable {
     let record: IPadSkillProposalRecord
+    let revisionHash: String?
     let content: String
     let supportFiles: [IPadSkillProposalSupportFile]?
 }
@@ -1192,6 +1212,7 @@ struct IPadSkillProposal: Identifiable {
     let skillName: String
     let skillKey: String
     let updatedAtMs: Double
+    let revisionHash: String?
     var content: String?
     var supportFiles: [IPadSkillProposalSupportFile]
 
@@ -1203,8 +1224,10 @@ struct IPadSkillProposal: Identifiable {
         self.skillName = entry.skillName
         self.skillKey = entry.skillKey
         self.updatedAtMs = Self.parseDate(entry.updatedAt)
-        self.content = previous?.updatedAtMs == self.updatedAtMs ? previous?.content : nil
-        self.supportFiles = previous?.updatedAtMs == self.updatedAtMs ? previous?.supportFiles ?? [] : []
+        let isSameRevision = previous?.updatedAtMs == self.updatedAtMs
+        self.revisionHash = isSameRevision ? previous?.revisionHash : nil
+        self.content = isSameRevision ? previous?.content : nil
+        self.supportFiles = isSameRevision ? previous?.supportFiles ?? [] : []
     }
 
     init(inspect: IPadSkillProposalInspectResponse, previous: IPadSkillProposal?) {
@@ -1216,6 +1239,7 @@ struct IPadSkillProposal: Identifiable {
         self.skillName = record.target.skillName
         self.skillKey = record.target.skillKey
         self.updatedAtMs = Self.parseDate(record.updatedAt)
+        self.revisionHash = inspect.revisionHash
         self.content = Self.stripFrontmatter(inspect.content)
         self.supportFiles = inspect.supportFiles ?? previous?.supportFiles ?? []
     }

--- a/apps/ios/Tests/RootTabsPresentationTests.swift
+++ b/apps/ios/Tests/RootTabsPresentationTests.swift
@@ -252,6 +252,33 @@ struct RootTabsPresentationTests {
         #expect(!IPadSkillWorkshopScreen.shouldEnableProposalMutation(canWrite: false, hasOperatorAdminScope: true))
     }
 
+    @Test func `skill workshop actions carry the reviewed revision hash`() throws {
+        let revisionHash = String(repeating: "a", count: 64)
+        let proposal = Self.skillWorkshopProposal(revisionHash: revisionHash)
+        let apply = try #require(IPadSkillProposalAction(kind: .apply, proposal: proposal))
+        let reject = try #require(IPadSkillProposalAction(kind: .reject, proposal: proposal))
+
+        for (action, method) in [
+            (apply, "skills.proposals.apply"),
+            (reject, "skills.proposals.reject"),
+        ] {
+            let encoded = try #require(
+                JSONSerialization.jsonObject(
+                    with: JSONEncoder().encode(action.params(agentID: "main"))) as? [String: Any])
+
+            #expect(action.method == method)
+            #expect(encoded["agentId"] as? String == "main")
+            #expect(encoded["proposalId"] as? String == proposal.id)
+            #expect(encoded["expectedRevisionHash"] as? String == revisionHash)
+        }
+    }
+
+    @Test func `skill workshop actions require an inspected revision hash`() {
+        #expect(IPadSkillProposalAction(
+            kind: .apply,
+            proposal: Self.skillWorkshopProposal(revisionHash: nil)) == nil)
+    }
+
     @Test func `skill workshop held filter includes quarantined and stale`() {
         #expect(IPadSkillWorkshopScreen.proposalStatusFilters.contains("held"))
         #expect(IPadSkillWorkshopScreen.proposalStatusMatchesFilter(status: "quarantined", filter: "held"))
@@ -1058,5 +1085,23 @@ struct RootTabsPresentationTests {
             payload: AnyCodable(["kind": AnyCodable("agentTurn")]),
             state: [:],
             lastrunstatus: AnyCodable(status))
+    }
+
+    private static func skillWorkshopProposal(revisionHash: String?) -> IPadSkillProposal {
+        IPadSkillProposal(
+            inspect: IPadSkillProposalInspectResponse(
+                record: IPadSkillProposalRecord(
+                    id: "proposal-1",
+                    status: "pending",
+                    title: "Reviewed proposal",
+                    description: "A reviewed Skill Workshop proposal.",
+                    updatedAt: "2026-08-18T12:00:00Z",
+                    target: IPadSkillProposalTarget(
+                        skillName: "reviewed-skill",
+                        skillKey: "reviewed-skill")),
+                revisionHash: revisionHash,
+                content: "# Reviewed skill",
+                supportFiles: nil),
+            previous: nil)
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1785,6 +1785,28 @@ public struct McpAppViewExpiredErrorDetails: Codable, Sendable {
     }
 }
 
+public struct SkillProposalRevisionChangedErrorDetails: Codable, Sendable {
+    public let code: String
+    public let expectedrevisionhash: String
+    public let currentrevisionhash: String
+
+    public init(
+        code: String,
+        expectedrevisionhash: String,
+        currentrevisionhash: String)
+    {
+        self.code = code
+        self.expectedrevisionhash = expectedrevisionhash
+        self.currentrevisionhash = currentrevisionhash
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case code
+        case expectedrevisionhash = "expectedRevisionHash"
+        case currentrevisionhash = "currentRevisionHash"
+    }
+}
+
 public struct UnknownAgentIdErrorDetails: Codable, Sendable {
     public let code: String
     public let agentid: String
@@ -15786,7 +15808,7 @@ public struct SkillsProposalRequestRevisionParams: Codable, Sendable {
     public let agentid: String?
     public let targetagentid: String?
     public let proposalid: String
-    public let expectedrevisionhash: String?
+    public let expectedrevisionhash: String
     public let instructions: String
     public let sessionkey: String
     public let sessionid: String?
@@ -15796,7 +15818,7 @@ public struct SkillsProposalRequestRevisionParams: Codable, Sendable {
         agentid: String? = nil,
         targetagentid: String? = nil,
         proposalid: String,
-        expectedrevisionhash: String? = nil,
+        expectedrevisionhash: String,
         instructions: String,
         sessionkey: String,
         sessionid: String? = nil,
@@ -15839,6 +15861,36 @@ public struct SkillsProposalRequestRevisionResult: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case runid = "runId"
         case status
+    }
+}
+
+public struct SkillsProposalDecisionParams: Codable, Sendable {
+    public let agentid: String?
+    public let proposalid: String
+    public let expectedrevisionhash: String
+    public let correlationid: String?
+    public let reason: String?
+
+    public init(
+        agentid: String? = nil,
+        proposalid: String,
+        expectedrevisionhash: String,
+        correlationid: String? = nil,
+        reason: String? = nil)
+    {
+        self.agentid = agentid
+        self.proposalid = proposalid
+        self.expectedrevisionhash = expectedrevisionhash
+        self.correlationid = correlationid
+        self.reason = reason
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+        case proposalid = "proposalId"
+        case expectedrevisionhash = "expectedRevisionHash"
+        case correlationid = "correlationId"
+        case reason
     }
 }
 
@@ -20822,6 +20874,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
     case missingScope(MissingScopeErrorDetails)
     case mcpAppViewExpired(McpAppViewExpiredErrorDetails)
     case userPrefsLimitExceeded(UserPrefsLimitExceededErrorDetails)
+    case skillProposalRevisionChanged(SkillProposalRevisionChangedErrorDetails)
     case projectCloneFailed(ProjectCloneErrorDetails)
     case unknownAgentId(UnknownAgentIdErrorDetails)
     case wizardNotFound(WizardNotFoundErrorDetails)
@@ -20842,6 +20895,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
         case .missingScope(let value): value.code
         case .mcpAppViewExpired(let value): value.code
         case .userPrefsLimitExceeded(let value): value.code
+        case .skillProposalRevisionChanged(let value): value.code
         case .projectCloneFailed(let value): value.code
         case .unknownAgentId(let value): value.code
         case .wizardNotFound(let value): value.code
@@ -20870,6 +20924,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
         case "MISSING_SCOPE": self = try .missingScope(MissingScopeErrorDetails(from: decoder))
         case "MCP_APP_VIEW_EXPIRED": self = try .mcpAppViewExpired(McpAppViewExpiredErrorDetails(from: decoder))
         case "USER_PREFS_LIMIT_EXCEEDED": self = try .userPrefsLimitExceeded(UserPrefsLimitExceededErrorDetails(from: decoder))
+        case "SKILL_PROPOSAL_REVISION_CHANGED": self = try .skillProposalRevisionChanged(SkillProposalRevisionChangedErrorDetails(from: decoder))
         case "PROJECT_CLONE_FAILED": self = try .projectCloneFailed(ProjectCloneErrorDetails(from: decoder))
         case "UNKNOWN_AGENT_ID": self = try .unknownAgentId(UnknownAgentIdErrorDetails(from: decoder))
         case "WIZARD_NOT_FOUND": self = try .wizardNotFound(WizardNotFoundErrorDetails(from: decoder))
@@ -20888,6 +20943,7 @@ public enum GatewayErrorDetails: Codable, Sendable {
         case .missingScope(let value): try value.encode(to: encoder)
         case .mcpAppViewExpired(let value): try value.encode(to: encoder)
         case .userPrefsLimitExceeded(let value): try value.encode(to: encoder)
+        case .skillProposalRevisionChanged(let value): try value.encode(to: encoder)
         case .projectCloneFailed(let value): try value.encode(to: encoder)
         case .unknownAgentId(let value): try value.encode(to: encoder)
         case .wizardNotFound(let value): try value.encode(to: encoder)

--- a/packages/gateway-protocol/src/error-details.ts
+++ b/packages/gateway-protocol/src/error-details.ts
@@ -4,16 +4,19 @@ export * from "./system-agent-error-details.js";
 export {
   ErrorCodes,
   GatewayErrorDetailCodes,
+  buildSkillProposalRevisionChangedErrorDetails,
   isMcpAppViewExpiredError,
   readCronJobNotFoundError,
   readMissingScopeError,
   readMissingScopeErrorDetails,
+  readSkillProposalRevisionChangedError,
 } from "./gateway-error-details.js";
 export type {
   CronJobNotFoundErrorDetails,
   GatewayErrorDetails,
   McpAppViewExpiredErrorDetails,
   MissingScopeErrorDetails,
+  SkillProposalRevisionChangedErrorDetails,
   UserPrefsLimitExceededErrorDetails,
   ProjectCloneErrorDetails,
   ProjectCloneFailureCause,
@@ -25,6 +28,7 @@ export {
   MissingScopeErrorDetailsSchema,
   UserPrefsLimitExceededErrorDetailsSchema,
   ProjectCloneErrorDetailsSchema,
+  SkillProposalRevisionChangedErrorDetailsSchema,
   WizardNotFoundErrorDetailsSchema,
   buildMissingScopeErrorDetails,
   errorShape,

--- a/packages/gateway-protocol/src/gateway-error-details.ts
+++ b/packages/gateway-protocol/src/gateway-error-details.ts
@@ -28,6 +28,7 @@ export const GatewayErrorDetailCodes = {
   MCP_APP_VIEW_EXPIRED: "MCP_APP_VIEW_EXPIRED",
   USER_PREFS_LIMIT_EXCEEDED: "USER_PREFS_LIMIT_EXCEEDED",
   SESSION_COMPANION_BUSY: "SESSION_COMPANION_BUSY",
+  SKILL_PROPOSAL_REVISION_CHANGED: "SKILL_PROPOSAL_REVISION_CHANGED",
   PROJECT_CLONE_FAILED: "PROJECT_CLONE_FAILED",
   UNKNOWN_AGENT_ID: "UNKNOWN_AGENT_ID",
   WIZARD_NOT_FOUND: "WIZARD_NOT_FOUND",
@@ -81,12 +82,20 @@ export type ProjectCloneErrorDetails = {
   cause: ProjectCloneFailureCause;
 };
 
+/** Optimistic-concurrency mismatch for an operator-reviewed Skill Workshop draft. */
+export type SkillProposalRevisionChangedErrorDetails = {
+  code: typeof GatewayErrorDetailCodes.SKILL_PROPOSAL_REVISION_CHANGED;
+  expectedRevisionHash: string;
+  currentRevisionHash: string;
+};
+
 /** Structured details emitted by method-level failures. */
 export type GatewayErrorDetails =
   | CronJobNotFoundErrorDetails
   | MissingScopeErrorDetails
   | McpAppViewExpiredErrorDetails
   | UserPrefsLimitExceededErrorDetails
+  | SkillProposalRevisionChangedErrorDetails
   | ProjectCloneErrorDetails
   | UnknownAgentIdErrorDetails
   | WizardNotFoundErrorDetails;
@@ -99,6 +108,7 @@ type GatewayErrorLike = {
 };
 
 const LEGACY_MISSING_SCOPE_PATTERN = /\bmissing scope:\s*([a-z0-9._-]+)/i;
+const SHA256_PATTERN = /^[a-fA-F0-9]{64}$/;
 
 /** Reads a typed cron lookup miss without parsing operator-facing prose. */
 export function readCronJobNotFoundError(error: unknown): CronJobNotFoundErrorDetails | null {
@@ -109,6 +119,40 @@ export function readCronJobNotFoundError(error: unknown): CronJobNotFoundErrorDe
   }
   const jobId = typeof details.jobId === "string" ? details.jobId.trim() : "";
   return jobId ? { code: GatewayErrorDetailCodes.CRON_JOB_NOT_FOUND, jobId } : null;
+}
+
+/** Builds the canonical stale-draft details shared by Skill Workshop RPCs. */
+export function buildSkillProposalRevisionChangedErrorDetails(params: {
+  expectedRevisionHash: string;
+  currentRevisionHash: string;
+}): SkillProposalRevisionChangedErrorDetails {
+  return {
+    code: GatewayErrorDetailCodes.SKILL_PROPOSAL_REVISION_CHANGED,
+    expectedRevisionHash: params.expectedRevisionHash,
+    currentRevisionHash: params.currentRevisionHash,
+  };
+}
+
+/** Reads a stale Skill Workshop decision without parsing operator-facing prose. */
+export function readSkillProposalRevisionChangedError(
+  error: unknown,
+): SkillProposalRevisionChangedErrorDetails | null {
+  const record = asProtocolRecord(error);
+  const details = asProtocolRecord(record?.details);
+  if (details?.code !== GatewayErrorDetailCodes.SKILL_PROPOSAL_REVISION_CHANGED) {
+    return null;
+  }
+  const expectedRevisionHash =
+    typeof details.expectedRevisionHash === "string" ? details.expectedRevisionHash : "";
+  const currentRevisionHash =
+    typeof details.currentRevisionHash === "string" ? details.currentRevisionHash : "";
+  if (!SHA256_PATTERN.test(expectedRevisionHash) || !SHA256_PATTERN.test(currentRevisionHash)) {
+    return null;
+  }
+  return buildSkillProposalRevisionChangedErrorDetails({
+    expectedRevisionHash,
+    currentRevisionHash,
+  });
 }
 
 /** Reads validated missing-scope details from an untrusted protocol payload. */

--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -570,6 +570,7 @@ describe("lazy protocol validators", () => {
         idempotencyKey: "revision-run-1",
       }),
       proposalRequest({
+        expectedRevisionHash: "a".repeat(64),
         instructions: "Make the support files 5",
         sessionKey: "agent:main:session:skill-workshop",
         idempotencyKey: "revision-run-1",

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -555,6 +555,7 @@ export {
   SkillsProposalReviseParamsSchema,
   SkillsProposalRequestRevisionParamsSchema,
   SkillsProposalRequestRevisionResultSchema,
+  SkillsProposalDecisionParamsSchema,
   SkillsProposalActionParamsSchema,
   SkillProposalEvaluationSchema,
   SkillsProposalEvaluateParamsSchema,

--- a/packages/gateway-protocol/src/schema/agents-models-skills.revision.test.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.revision.test.ts
@@ -1,0 +1,35 @@
+import { Value } from "typebox/value";
+import { describe, expect, it } from "vitest";
+import {
+  SkillsProposalActionParamsSchema,
+  SkillsProposalDecisionParamsSchema,
+  SkillsProposalRequestRevisionParamsSchema,
+} from "./agents-models-skills.js";
+
+describe("Skill Workshop revision-bound request schemas", () => {
+  it("requires exact revision hashes for operator decisions and natural revisions", () => {
+    const decision = { proposalId: "proposal-1", expectedRevisionHash: "a".repeat(64) };
+
+    expect(Value.Check(SkillsProposalDecisionParamsSchema, decision)).toBe(true);
+    expect(Value.Check(SkillsProposalDecisionParamsSchema, { proposalId: "proposal-1" })).toBe(
+      false,
+    );
+    expect(Value.Check(SkillsProposalActionParamsSchema, { proposalId: "proposal-1" })).toBe(true);
+    expect(
+      Value.Check(SkillsProposalRequestRevisionParamsSchema, {
+        ...decision,
+        instructions: "Revise the draft",
+        sessionKey: "agent:main:revision",
+        idempotencyKey: "revision-1",
+      }),
+    ).toBe(true);
+    expect(
+      Value.Check(SkillsProposalRequestRevisionParamsSchema, {
+        proposalId: "proposal-1",
+        instructions: "Revise the draft",
+        sessionKey: "agent:main:revision",
+        idempotencyKey: "revision-1",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -838,7 +838,7 @@ export const SkillsProposalRequestRevisionParamsSchema = closedObject({
   agentId: Type.Optional(NonEmptyString),
   targetAgentId: Type.Optional(NonEmptyString),
   proposalId: NonEmptyString,
-  expectedRevisionHash: Type.Optional(Sha256String),
+  expectedRevisionHash: Sha256String,
   instructions: Type.String({ minLength: 1, maxLength: 32_768 }),
   sessionKey: NonEmptyString,
   sessionId: Type.Optional(NonEmptyString),
@@ -860,7 +860,16 @@ export const SkillsProposalRequestRevisionResultSchema = Type.Object(
   { additionalProperties: true },
 );
 
-/** Shared approve/reject/quarantine action payload for one proposal. */
+/** Apply/reject payload bound to the exact proposal revision reviewed by the operator. */
+export const SkillsProposalDecisionParamsSchema = closedObject({
+  agentId: Type.Optional(NonEmptyString),
+  proposalId: NonEmptyString,
+  expectedRevisionHash: Sha256String,
+  correlationId: Type.Optional(Type.String({ minLength: 1, maxLength: 256 })),
+  reason: Type.Optional(Type.String()),
+});
+
+/** Quarantine payload with optional optimistic-concurrency evidence. */
 export const SkillsProposalActionParamsSchema = closedObject({
   agentId: Type.Optional(NonEmptyString),
   proposalId: NonEmptyString,
@@ -1292,6 +1301,7 @@ export type SkillsProposalRequestRevisionParams = Static<
 export type SkillsProposalRequestRevisionResult = Static<
   typeof SkillsProposalRequestRevisionResultSchema
 >;
+export type SkillsProposalDecisionParams = Static<typeof SkillsProposalDecisionParamsSchema>;
 export type SkillsProposalActionParams = Static<typeof SkillsProposalActionParamsSchema>;
 export type SkillProposalEvaluation = Static<typeof SkillProposalEvaluationSchema>;
 export type SkillsProposalEvaluateParams = Static<typeof SkillsProposalEvaluateParamsSchema>;

--- a/packages/gateway-protocol/src/schema/error-codes.test.ts
+++ b/packages/gateway-protocol/src/schema/error-codes.test.ts
@@ -9,7 +9,9 @@ import {
   McpAppViewExpiredErrorDetailsSchema,
   MissingScopeErrorDetailsSchema,
   ProjectCloneErrorDetailsSchema,
+  SkillProposalRevisionChangedErrorDetailsSchema,
   missingScopeErrorShape,
+  readSkillProposalRevisionChangedError,
   readMissingScopeError,
   readMissingScopeErrorDetails,
   readCronJobNotFoundError,
@@ -78,6 +80,23 @@ describe("gateway error details", () => {
     expect(Value.Check(ProjectCloneErrorDetailsSchema, { ...details, cause: "unknown" })).toBe(
       false,
     );
+  });
+
+  it("validates and reads changed skill proposal revisions", () => {
+    const details = {
+      code: GatewayErrorDetailCodes.SKILL_PROPOSAL_REVISION_CHANGED,
+      expectedRevisionHash: "A".repeat(64),
+      currentRevisionHash: "b".repeat(64),
+    };
+
+    expect(Value.Check(SkillProposalRevisionChangedErrorDetailsSchema, details)).toBe(true);
+    expect(Value.Check(GatewayErrorDetailsSchema, details)).toBe(true);
+    expect(readSkillProposalRevisionChangedError({ details })).toEqual(details);
+    expect(
+      readSkillProposalRevisionChangedError({
+        details: { ...details, currentRevisionHash: "not-a-sha256" },
+      }),
+    ).toBeNull();
   });
 
   it("builds a distinct forbidden missing-scope response", () => {

--- a/packages/gateway-protocol/src/schema/error-codes.ts
+++ b/packages/gateway-protocol/src/schema/error-codes.ts
@@ -18,6 +18,7 @@ export {
   type GatewayErrorDetails,
   type McpAppViewExpiredErrorDetails,
   type MissingScopeErrorDetails,
+  type SkillProposalRevisionChangedErrorDetails,
   type UserPrefsLimitExceededErrorDetails,
   type ProjectCloneErrorDetails,
   type ProjectCloneFailureCause,
@@ -27,6 +28,8 @@ export {
   isMcpAppViewExpiredError,
   readMissingScopeError,
   readMissingScopeErrorDetails,
+  buildSkillProposalRevisionChangedErrorDetails,
+  readSkillProposalRevisionChangedError,
 } from "../gateway-error-details.js";
 
 export const CronJobNotFoundErrorDetailsSchema = closedObject({
@@ -67,12 +70,21 @@ export const ProjectCloneErrorDetailsSchema = closedObject({
   }),
 });
 
+const RevisionHashSchema = Type.String({ pattern: "^[a-fA-F0-9]{64}$" });
+
+export const SkillProposalRevisionChangedErrorDetailsSchema = closedObject({
+  code: Type.Literal(GatewayErrorDetailCodes.SKILL_PROPOSAL_REVISION_CHANGED),
+  expectedRevisionHash: RevisionHashSchema,
+  currentRevisionHash: RevisionHashSchema,
+});
+
 /** Structured details emitted by method-level failures. */
 export const GatewayErrorDetailsSchema = Type.Union([
   CronJobNotFoundErrorDetailsSchema,
   MissingScopeErrorDetailsSchema,
   McpAppViewExpiredErrorDetailsSchema,
   UserPrefsLimitExceededErrorDetailsSchema,
+  SkillProposalRevisionChangedErrorDetailsSchema,
   ProjectCloneErrorDetailsSchema,
   UnknownAgentIdErrorDetailsSchema,
   WizardNotFoundErrorDetailsSchema,

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-agents-skills.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-agents-skills.ts
@@ -83,6 +83,7 @@ export const AgentSkillProtocolSchemas = {
   SkillsProposalReviseParams: agentsModelsSkills.SkillsProposalReviseParamsSchema,
   SkillsProposalRequestRevisionParams: agentsModelsSkills.SkillsProposalRequestRevisionParamsSchema,
   SkillsProposalRequestRevisionResult: agentsModelsSkills.SkillsProposalRequestRevisionResultSchema,
+  SkillsProposalDecisionParams: agentsModelsSkills.SkillsProposalDecisionParamsSchema,
   SkillsProposalActionParams: agentsModelsSkills.SkillsProposalActionParamsSchema,
   SkillsProposalApplyResult: agentsModelsSkills.SkillsProposalApplyResultSchema,
   SkillsProposalRecordResult: agentsModelsSkills.SkillsProposalRecordResultSchema,

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-transport.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-transport.ts
@@ -19,6 +19,8 @@ export const TransportProtocolSchemas = {
   CronJobNotFoundErrorDetails: errorCodes.CronJobNotFoundErrorDetailsSchema,
   MissingScopeErrorDetails: errorCodes.MissingScopeErrorDetailsSchema,
   McpAppViewExpiredErrorDetails: errorCodes.McpAppViewExpiredErrorDetailsSchema,
+  SkillProposalRevisionChangedErrorDetails:
+    errorCodes.SkillProposalRevisionChangedErrorDetailsSchema,
   UnknownAgentIdErrorDetails: errorCodes.UnknownAgentIdErrorDetailsSchema,
   WizardNotFoundErrorDetails: errorCodes.WizardNotFoundErrorDetailsSchema,
   GatewayErrorDetails: errorCodes.GatewayErrorDetailsSchema,

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -378,6 +378,7 @@ export const validateSkillsProposalReviseParams = compile(S.SkillsProposalRevise
 export const validateSkillsProposalRequestRevisionParams = compile(
   S.SkillsProposalRequestRevisionParamsSchema,
 );
+export const validateSkillsProposalDecisionParams = compile(S.SkillsProposalDecisionParamsSchema);
 export const validateSkillsProposalActionParams = compile(S.SkillsProposalActionParamsSchema);
 export const validateSkillsProposalEvaluateParams = compile(S.SkillsProposalEvaluateParamsSchema);
 export const validateSkillsProposalEventsListParams = compile(

--- a/src/agents/cli-runner/mcp-grant-context.test.ts
+++ b/src/agents/cli-runner/mcp-grant-context.test.ts
@@ -41,6 +41,19 @@ describe("buildCliMcpGrantContext source-reply authority", () => {
     expect(buildGrant({ replyToMode: "all" }).replyToMode).toBe("all");
   });
 
+  it("carries the exact Skill Workshop revision into the loopback grant", () => {
+    const proposalRevision = {
+      agentId: "proposal-owner",
+      workspaceDir: "/proposal-workspace",
+      proposalId: "proposal-h1",
+      expectedRevisionHash: "1".repeat(64),
+    };
+
+    expect(buildGrant({ skillWorkshopProposalRevision: proposalRevision }).skillWorkshop).toEqual({
+      proposalRevision,
+    });
+  });
+
   it.each([
     { label: "the provider", overrides: { messageProvider: undefined } },
     { label: "the destination", overrides: { currentChannelId: undefined } },

--- a/src/agents/cli-runner/mcp-grant-context.ts
+++ b/src/agents/cli-runner/mcp-grant-context.ts
@@ -143,6 +143,9 @@ export function buildCliMcpGrantContext(params: {
     // Restricted runs get their allowlist stamped into the grant; the
     // loopback server enforces it on tools/list and tools/call.
     ...(params.toolsAllow ? { toolsAllow: params.toolsAllow } : {}),
+    ...(params.run.skillWorkshopProposalRevision
+      ? { skillWorkshop: { proposalRevision: params.run.skillWorkshopProposalRevision } }
+      : {}),
     ...(params.run.scheduledToolPolicy
       ? { scheduledToolPolicy: { ...params.run.scheduledToolPolicy } }
       : {}),

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -33,6 +33,7 @@ import type { SpawnSecretInput } from "../../process/supervisor/types.js";
 import type { InputProvenance } from "../../sessions/input-provenance.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import type { SkillSnapshot } from "../../skills/types.js";
+import type { SkillWorkshopProposalRevisionConstraint } from "../../skills/workshop/types.js";
 import type { AdmittedRunContext, PreparedAgentRunAdmission } from "../admitted-run-context.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import type { ExecElevatedDefaults } from "../bash-tools.exec-types.js";
@@ -233,6 +234,8 @@ export type RunCliAgentParams = {
   approvalReviewerDeviceId?: string;
   /** Runtime tool allow-list. CLI harnesses need a backend-owned exact translation. */
   toolsAllow?: string[];
+  /** Exact Skill Workshop proposal revision bound by the Gateway for this turn. */
+  skillWorkshopProposalRevision?: SkillWorkshopProposalRevisionConstraint;
   /** Trusted server-stamped authority for an explicitly capped scheduled run. */
   scheduledToolPolicy?: ScheduledToolPolicyContext;
   /** Server-authored origin for fresh automation mutations from this CLI run. */

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -304,6 +304,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
             proposalMutationBudget: attempt.skillWorkshopProposalMutationBudget,
             proposalReviewCompletion: attempt.skillWorkshopProposalReviewCompletion,
             collectionReconcile: attempt.skillWorkshopCollectionReconcile,
+            proposalRevision: attempt.skillWorkshopProposalRevision,
           },
           modelCompat: extractModelCompat(attempt.model),
           modelApi: attempt.model.api,

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -194,6 +194,8 @@ export type RunEmbeddedAgentParams = {
   skillWorkshopProposalReviewCompletion?: SkillWorkshopRunOptions["proposalReviewCompletion"];
   /** Restrict Skill Workshop to one atomic collection reconciliation. */
   skillWorkshopCollectionReconcile?: SkillWorkshopRunOptions["collectionReconcile"];
+  /** Bind an operator-requested revision turn to the exact proposal revision they reviewed. */
+  skillWorkshopProposalRevision?: SkillWorkshopRunOptions["proposalRevision"];
   /** Explicit system prompt mode override for trusted callers. */
   promptMode?: PromptMode;
   /** Keep the message tool available even when a narrow profile would omit it. */

--- a/src/agents/embedded-agent-runner/run/skill-workshop-attempt-params.ts
+++ b/src/agents/embedded-agent-runner/run/skill-workshop-attempt-params.ts
@@ -11,6 +11,7 @@ export function resolveSkillWorkshopAttemptParams(
     | "skillWorkshopProposalOnly"
     | "skillWorkshopProposalReviewCompletion"
     | "skillWorkshopCollectionReconcile"
+    | "skillWorkshopProposalRevision"
   >,
 ) {
   return {
@@ -22,5 +23,6 @@ export function resolveSkillWorkshopAttemptParams(
     skillWorkshopProposalMutationBudget: params.skillWorkshopProposalMutationBudget,
     skillWorkshopProposalReviewCompletion: params.skillWorkshopProposalReviewCompletion,
     skillWorkshopCollectionReconcile: params.skillWorkshopCollectionReconcile,
+    skillWorkshopProposalRevision: params.skillWorkshopProposalRevision,
   };
 }

--- a/src/agents/tools/skill-workshop-tool-description.ts
+++ b/src/agents/tools/skill-workshop-tool-description.ts
@@ -7,7 +7,11 @@ export function buildSkillWorkshopToolDescription(params: {
   updateProposals: boolean;
   autonomousMode: "off" | "propose" | "auto";
   collectionOnly: boolean;
+  proposalRevision: boolean;
 }): string {
+  if (params.proposalRevision) {
+    return `Inspect and revise only the proposal revision selected by the operator. The proposal id and expected revision hash are bound by the run and cannot be replaced by tool arguments. Never apply, reject, quarantine, or create another proposal.\n\n${SKILL_AUTHORING_STANDARDS_PROMPT}`;
+  }
   if (params.collectionOnly) {
     return `${SKILL_WORKSHOP_TOOL_DISPLAY_SUMMARY} Read every current writable skill, then replace the collection with one reconcile call. Every current skill needs exactly one keep, write, or drop decision.\n\n${SKILL_AUTHORING_STANDARDS_PROMPT}`;
   }

--- a/src/agents/tools/skill-workshop-tool-factory.ts
+++ b/src/agents/tools/skill-workshop-tool-factory.ts
@@ -19,15 +19,17 @@ export function createConfiguredSkillWorkshopTool(params: {
   const messageId = normalizeOptionalString(
     params.messageId === undefined ? undefined : String(params.messageId),
   );
+  const revision = params.run?.proposalRevision;
+  const agentId = revision?.agentId ?? params.agentId;
   return createSkillWorkshopTool({
-    workspaceDir: getCanonicalSkillWorkspace() ?? params.workspaceDir,
+    workspaceDir: revision?.workspaceDir ?? getCanonicalSkillWorkspace() ?? params.workspaceDir,
     config: params.config,
     env: params.run?.env,
-    agentId: params.agentId,
+    agentId,
     origin:
       params.run?.origin ??
       ({
-        agentId: params.agentId,
+        agentId,
         ...(sessionKey ? { sessionKey } : {}),
         ...(runId ? { runId } : {}),
         ...(messageId ? { messageId } : {}),
@@ -41,5 +43,6 @@ export function createConfiguredSkillWorkshopTool(params: {
     proposalReviewCompletion: params.run?.proposalReviewCompletion,
     collectionReconcile: params.run?.collectionReconcile,
     modelContextWindowTokens: params.modelContextWindowTokens,
+    proposalRevision: params.run?.proposalRevision,
   });
 }

--- a/src/agents/tools/skill-workshop-tool-schema.ts
+++ b/src/agents/tools/skill-workshop-tool-schema.ts
@@ -48,22 +48,27 @@ export function buildSkillWorkshopToolSchema(
   supportsCompletion: boolean,
   updateProposals: boolean,
   collectionOnly: boolean,
+  proposalRevision = false,
 ) {
   const proposalActions = resolveProposalOnlyActions(updateProposals, supportsCompletion);
   return Type.Object(
     {
       action: stringEnum(
-        collectionOnly
-          ? ["read", "reconcile"]
-          : proposalOnly
-            ? proposalActions
-            : [...SKILL_WORKSHOP_ACTIONS],
+        proposalRevision
+          ? ["inspect", "revise"]
+          : collectionOnly
+            ? ["read", "reconcile"]
+            : proposalOnly
+              ? proposalActions
+              : [...SKILL_WORKSHOP_ACTIONS],
         {
-          description: proposalOnly
-            ? `create = new skill;${updateProposals ? " patch = targeted find-and-replace on an existing live skill (quote the exact current text in old_string, replacement in new_string; empty old_string appends new_string at the end); read = complete existing live skill when it fits the selected-model budget, otherwise metadata without a partial body (required before patch or update); update = full-body rewrite of an existing live skill after reading it;" : ""} revise = existing pending proposal; list/inspect discover pending proposals (not filesystem search).${supportsCompletion ? " complete = durably finish this review after all proposal work." : ""} Nothing writes a live skill directly; lifecycle actions are unavailable.`
-            : collectionOnly
-              ? SKILL_COLLECTION_ACTION_DESCRIPTION
-              : "create = new skill; read = existing live skill; patch = targeted find-and-replace after reading; update = full-body rewrite; history = show up to 20 recent collection review outcomes and drop reasons; restore_collection = restore the collection backup retained by the last cleanup; revise = existing pending proposal; list/inspect discover pending proposals (not filesystem search); evaluate runs plugin evaluators for the exact draft; apply/reject/quarantine are explicit lifecycle actions.",
+          description: proposalRevision
+            ? "inspect = read the exact operator-reviewed proposal; revise = update only that proposal with the run-bound expected revision hash."
+            : proposalOnly
+              ? `create = new skill;${updateProposals ? " patch = targeted find-and-replace on an existing live skill (quote the exact current text in old_string, replacement in new_string; empty old_string appends new_string at the end); read = complete existing live skill when it fits the selected-model budget, otherwise metadata without a partial body (required before patch or update); update = full-body rewrite of an existing live skill after reading it;" : ""} revise = existing pending proposal; list/inspect discover pending proposals (not filesystem search).${supportsCompletion ? " complete = durably finish this review after all proposal work." : ""} Nothing writes a live skill directly; lifecycle actions are unavailable.`
+              : collectionOnly
+                ? SKILL_COLLECTION_ACTION_DESCRIPTION
+                : "create = new skill; read = existing live skill; patch = targeted find-and-replace after reading; update = full-body rewrite; history = show up to 20 recent collection review outcomes and drop reasons; restore_collection = restore the collection backup retained by the last cleanup; revise = existing pending proposal; list/inspect discover pending proposals (not filesystem search); evaluate runs plugin evaluators for the exact draft; apply/reject/quarantine are explicit lifecycle actions.",
         },
       ),
       proposal_id: Type.Optional(
@@ -153,7 +158,7 @@ export function buildSkillWorkshopToolSchema(
       expected_revision_hash: Type.Optional(
         Type.String({
           description:
-            "Optional exact proposal revision hash for evaluate/apply/reject/quarantine. The action fails if content or support files changed.",
+            "Optional exact proposal revision hash for revise/evaluate/apply/reject/quarantine. The action fails if content or support files changed.",
         }),
       ),
       correlation_id: Type.Optional(

--- a/src/agents/tools/skill-workshop-tool.revision-constraint.test.ts
+++ b/src/agents/tools/skill-workshop-tool.revision-constraint.test.ts
@@ -99,11 +99,12 @@ describe("skill_workshop operator revision constraint", () => {
     await expect(
       foregroundTool.execute("inspect-current", { action: "inspect", proposal_id: reviewed.id }),
     ).resolves.toMatchObject({
+      content: [{ type: "text", text: expect.stringContaining("Third draft") }],
       details: {
         id: reviewed.id,
         status: "pending",
         revisionHash: current.revisionHash,
-        proposalContent: expect.stringContaining("Third draft"),
+        inspect: { contentIncluded: true },
       },
     });
   });

--- a/src/agents/tools/skill-workshop-tool.revision-constraint.test.ts
+++ b/src/agents/tools/skill-workshop-tool.revision-constraint.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { createConfiguredSkillWorkshopTool } from "./skill-workshop-tool-factory.js";
+import { createSkillWorkshopTool } from "./skill-workshop-tool.js";
+
+const tempDirs = createTrackedTempDirs();
+let testState: OpenClawTestState;
+
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-skill-workshop-revision-constraint-",
+  });
+});
+
+afterEach(async () => {
+  await testState.cleanup();
+  await tempDirs.cleanup();
+});
+
+describe("skill_workshop operator revision constraint", () => {
+  it("hard-binds the turn to the reviewed proposal revision", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-bound-revision-");
+    const foregroundTool = createSkillWorkshopTool({
+      workspaceDir,
+      env: testState.env,
+      agentId: "main",
+    });
+    const created = await foregroundTool.execute("create", {
+      action: "create",
+      name: "Bound Revision",
+      description: "Exercise operator revision binding",
+      proposal_content: "# Bound Revision\n\nFirst draft.\n",
+    });
+    const reviewed = created.details as { id: string; revisionHash: string };
+    const revisionTool = createConfiguredSkillWorkshopTool({
+      workspaceDir: await tempDirs.make("openclaw-skill-workshop-chat-agent-"),
+      agentId: "writer",
+      run: {
+        env: testState.env,
+        proposalRevision: {
+          agentId: "main",
+          workspaceDir,
+          proposalId: reviewed.id,
+          expectedRevisionHash: reviewed.revisionHash,
+        },
+      },
+    });
+
+    expect(
+      (revisionTool.parameters as { properties: { action: { enum: string[] } } }).properties.action
+        .enum,
+    ).toEqual(["inspect", "revise"]);
+    await expect(revisionTool.execute("inspect", { action: "inspect" })).resolves.toMatchObject({
+      details: { id: reviewed.id, revisionHash: reviewed.revisionHash },
+    });
+    await expect(
+      revisionTool.execute("wrong-action", { action: "reject", proposal_id: reviewed.id }),
+    ).rejects.toThrow("can only inspect or revise");
+    await expect(
+      revisionTool.execute("wrong-proposal", {
+        action: "revise",
+        proposal_id: "another-proposal",
+        proposal_content: "# Wrong\n",
+      }),
+    ).rejects.toThrow("proposal_id conflicts");
+    await expect(
+      revisionTool.execute("wrong-hash", {
+        action: "revise",
+        expected_revision_hash: "another-hash",
+        proposal_content: "# Wrong\n",
+      }),
+    ).rejects.toThrow("expected_revision_hash conflicts");
+
+    const h2 = await foregroundTool.execute("concurrent-h2", {
+      action: "revise",
+      proposal_id: reviewed.id,
+      expected_revision_hash: reviewed.revisionHash,
+      proposal_content: "# Bound Revision\n\nSecond draft.\n",
+    });
+    const h2Details = h2.details as { revisionHash: string };
+    const h3 = await foregroundTool.execute("concurrent-h3", {
+      action: "revise",
+      proposal_id: reviewed.id,
+      expected_revision_hash: h2Details.revisionHash,
+      proposal_content: "# Bound Revision\n\nThird draft.\n",
+    });
+    const current = h3.details as { revisionHash: string };
+    await expect(
+      revisionTool.execute("stale-revision", {
+        action: "revise",
+        proposal_content: "# Bound Revision\n\nStale operator draft.\n",
+      }),
+    ).rejects.toThrow("proposal revision changed");
+    await expect(
+      foregroundTool.execute("inspect-current", { action: "inspect", proposal_id: reviewed.id }),
+    ).resolves.toMatchObject({
+      details: {
+        id: reviewed.id,
+        status: "pending",
+        revisionHash: current.revisionHash,
+        proposalContent: expect.stringContaining("Third draft"),
+      },
+    });
+  });
+
+  it("refuses an empty bound revision hash", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-empty-bound-revision-");
+    const tool = createSkillWorkshopTool({
+      workspaceDir,
+      env: testState.env,
+      proposalRevision: {
+        agentId: "main",
+        workspaceDir,
+        proposalId: "proposal-1",
+        expectedRevisionHash: "",
+      },
+    });
+
+    await expect(
+      tool.execute("missing-bound-hash", {
+        action: "revise",
+        proposal_content: "# Missing hash\n",
+      }),
+    ).rejects.toThrow("operator-reviewed expected_revision_hash required");
+  });
+});

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -29,6 +29,7 @@ import type {
   SkillProposalReadResult,
   SkillWorkshopProposalMutationBudget,
   SkillWorkshopProposalReviewCompletion,
+  SkillWorkshopProposalRevisionConstraint,
 } from "../../skills/workshop/types.js";
 import { readWritableWorkspaceSkill } from "../../skills/workshop/workspace-skill-read.js";
 import {
@@ -92,6 +93,45 @@ function readSkillPatchText(params: Record<string, unknown>) {
   };
 }
 
+function bindProposalRevisionConstraint(
+  params: Record<string, unknown>,
+  action: string,
+  constraint: SkillWorkshopProposalRevisionConstraint | undefined,
+): Record<string, unknown> {
+  if (!constraint) {
+    return params;
+  }
+  if (!constraint.proposalId.trim()) {
+    throw new ToolInputError("operator-reviewed proposal_id required");
+  }
+  if (!constraint.expectedRevisionHash.trim()) {
+    throw new ToolInputError("operator-reviewed expected_revision_hash required");
+  }
+  if (action !== "inspect" && action !== "revise") {
+    throw new ToolInputError(
+      "this operator-requested Skill Workshop turn can only inspect or revise its reviewed proposal",
+    );
+  }
+  const proposalId = readToolStringParam(params, "proposal_id", { label: "proposal_id" });
+  if (proposalId && proposalId !== constraint.proposalId) {
+    throw new ToolInputError("proposal_id conflicts with the operator-reviewed proposal");
+  }
+  if (readToolStringParam(params, "name")) {
+    throw new ToolInputError("name cannot replace the operator-reviewed proposal_id");
+  }
+  const expectedRevisionHash = readToolStringParam(params, "expected_revision_hash");
+  if (expectedRevisionHash && expectedRevisionHash !== constraint.expectedRevisionHash) {
+    throw new ToolInputError(
+      "expected_revision_hash conflicts with the operator-reviewed proposal revision",
+    );
+  }
+  return {
+    ...params,
+    proposal_id: constraint.proposalId,
+    expected_revision_hash: constraint.expectedRevisionHash,
+  };
+}
+
 type SkillWorkshopToolOptions = {
   workspaceDir: string;
   config?: OpenClawConfig;
@@ -112,6 +152,8 @@ type SkillWorkshopToolOptions = {
   collectionReconcile?: SkillCollectionReconcileContext;
   /** Effective selected-model context used for every model-visible Workshop projection. */
   modelContextWindowTokens?: number;
+  /** Exact proposal revision reviewed before this operator-requested revision turn. */
+  proposalRevision?: SkillWorkshopProposalRevisionConstraint;
 };
 
 /** Create the Skill Workshop tool for proposal discovery and lifecycle actions. */
@@ -139,16 +181,19 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
       updateProposals: options.updateProposals === true,
       autonomousMode: workshopConfig.autonomous.mode,
       collectionOnly: options.collectionReconcile !== undefined,
+      proposalRevision: options.proposalRevision !== undefined,
     }),
     parameters: buildSkillWorkshopToolSchema(
       options.proposalOnly === true,
       options.proposalReviewCompletion !== undefined,
       options.updateProposals === true,
       options.collectionReconcile !== undefined,
+      options.proposalRevision !== undefined,
     ),
     execute: async (_toolCallId, args) => {
-      const params = asToolParamsRecord(args);
-      const action = readToolStringParam(params, "action", { required: true });
+      const rawParams = asToolParamsRecord(args);
+      const action = readToolStringParam(rawParams, "action", { required: true });
+      const params = bindProposalRevisionConstraint(rawParams, action, options.proposalRevision);
       const proposalActions = resolveProposalOnlyActions(
         options.updateProposals === true,
         options.proposalReviewCompletion !== undefined,
@@ -551,24 +596,30 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
               : proposalMutationText("Created skill patch proposal", proposal.record)
             : proposalMutationText("Created skill patch proposal", proposal.record);
         } else if (action === "revise") {
-          const pendingProposal = await resolvePendingSkillProposal({
-            proposalId: readToolStringParam(params, "proposal_id", {
-              label: "proposal_id",
-            }),
-            name: readToolStringParam(params, "name"),
-            workspaceDir: options.workspaceDir,
-            agentId: options.agentId,
-            env: options.env,
-          });
+          let proposalId = options.proposalRevision?.proposalId;
+          let expectedRevisionHash = options.proposalRevision?.expectedRevisionHash;
+          if (!proposalId) {
+            const pendingProposal = await resolvePendingSkillProposal({
+              proposalId: readToolStringParam(params, "proposal_id", {
+                label: "proposal_id",
+              }),
+              name: readToolStringParam(params, "name"),
+              workspaceDir: options.workspaceDir,
+              agentId: options.agentId,
+              env: options.env,
+            });
+            proposalId = pendingProposal.record.id;
+            expectedRevisionHash =
+              readToolStringParam(params, "expected_revision_hash") ?? pendingProposal.revisionHash;
+          }
           proposal = await reviseSkillProposal({
             workspaceDir: options.workspaceDir,
             agentId: options.agentId,
             eventActor: skillWorkshopAgentEventActor(options.agentId),
             config: options.config,
             env: options.env,
-            proposalId: pendingProposal.record.id,
-            expectedRevisionHash:
-              readToolStringParam(params, "expected_revision_hash") ?? pendingProposal.revisionHash,
+            proposalId,
+            expectedRevisionHash,
             correlationId: readToolStringParam(params, "correlation_id"),
             content: proposalContent,
             supportFiles,

--- a/src/auto-reply/reply/agent-runner-cli-candidate.ts
+++ b/src/auto-reply/reply/agent-runner-cli-candidate.ts
@@ -454,6 +454,7 @@ export async function runCliFallbackCandidate(params: {
             senderIsOwner: turn.followupRun.run.senderIsOwner,
             approvalReviewerDeviceId: turn.followupRun.run.approvalReviewerDeviceId,
             toolsAllow: turn.opts?.toolsAllow,
+            skillWorkshopProposalRevision: params.candidateRun.skillWorkshopProposalRevision,
             disableTools: turn.opts?.disableTools,
             toolAuthorityFingerprint: resolveFollowupRunToolAuthorityFingerprint(
               turn.followupRun,

--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -126,6 +126,45 @@ describe("executeAgentTurn: run lifecycle and ownership", () => {
     expect(embeddedCall.abortSignal).toBe(replyOperation.abortSignal);
   });
 
+  it("passes the operator-reviewed proposal revision to every embedded candidate", async () => {
+    const followupRun = createFollowupRun();
+    followupRun.run.skillWorkshopProposalRevision = {
+      agentId: "main",
+      workspaceDir: "/tmp/workspace",
+      proposalId: "proposal-h1",
+      expectedRevisionHash: "revision-h1",
+    };
+    state.runEmbeddedAgentMock.mockResolvedValue({ payloads: [{ text: "ok" }], meta: {} });
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => {
+      await params.run("anthropic", "primary");
+      const result = await params.run("openai", "fallback");
+      return { result, provider: "openai", model: "fallback", attempts: [] };
+    });
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    await executeAgentTurn(createMinimalRunAgentTurnParams({ followupRun }));
+
+    expect(
+      state.runEmbeddedAgentMock.mock.calls.map(
+        (call, index) =>
+          requireRecord(call[0], `embedded candidate ${index}`).skillWorkshopProposalRevision,
+      ),
+    ).toEqual([
+      {
+        agentId: "main",
+        workspaceDir: "/tmp/workspace",
+        proposalId: "proposal-h1",
+        expectedRevisionHash: "revision-h1",
+      },
+      {
+        agentId: "main",
+        workspaceDir: "/tmp/workspace",
+        proposalId: "proposal-h1",
+        expectedRevisionHash: "revision-h1",
+      },
+    ]);
+  });
+
   it("records diagnostic progress from global-lane wait notifications", async () => {
     const replyOperation = createReplyOperation({
       sessionKey: "agent:main:global-lane-progress",

--- a/src/auto-reply/reply/agent-runner-run-params.ts
+++ b/src/auto-reply/reply/agent-runner-run-params.ts
@@ -116,6 +116,7 @@ export function buildEmbeddedRunBaseParams(params: {
     clientCaps: params.run.clientCaps,
     toolBindings: params.run.toolBindings,
     taskSuggestionDeliveryMode: params.run.taskSuggestionDeliveryMode,
+    skillWorkshopProposalRevision: params.run.skillWorkshopProposalRevision,
     provider: params.provider,
     model: params.model,
     modelSelectionLocked: params.run.modelSelectionLocked,

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -498,6 +498,11 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
       skipProviderRuntimeHints: useFastReplyRuntime,
       allowEmptyAssistantReplyAsSilent,
       suppressTranscriptOnlyAssistantPersistence: isRoomEvent,
+      ...(opts?.skillWorkshopProposalRevision
+        ? {
+            skillWorkshopProposalRevision: { ...opts.skillWorkshopProposalRevision },
+          }
+        : {}),
       ...(!useFastReplyRuntime &&
       isReasoningTagProvider(provider, { config: cfg, workspaceDir, modelId: model })
         ? { enforceFinalTag: true }

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -4343,6 +4343,22 @@ describe("runPreparedReply media-only handling", () => {
     expect(call.followupRun.run.fastMode).toBe("auto");
   });
 
+  it("keeps an operator-reviewed proposal revision isolated on the queued run", async () => {
+    const proposalRevision = {
+      agentId: "main",
+      workspaceDir: "/tmp/workspace",
+      proposalId: "proposal-h1",
+      expectedRevisionHash: "revision-h1",
+    };
+    await runPrepared({
+      opts: { skillWorkshopProposalRevision: proposalRevision } as never,
+    });
+
+    const call = requireRunReplyAgentCall();
+    expect(call.followupRun.run.skillWorkshopProposalRevision).toEqual(proposalRevision);
+    expect(call.followupRun.run.skillWorkshopProposalRevision).not.toBe(proposalRevision);
+  });
+
   it("carries system events into followupRun.prompt for deferred turns", async () => {
     // drainFormattedSystemEvents returns the events block; the caller prepends it to
     // effectiveBaseBody for the queue path so deferred turns see events.

--- a/src/auto-reply/reply/get-reply.types.ts
+++ b/src/auto-reply/reply/get-reply.types.ts
@@ -4,6 +4,7 @@ import type { SessionToolOverrides } from "../../config/sessions/types.js";
 // Shared get-reply type contracts for command, directive, and runtime layers.
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginCommandReplyOptions } from "../../plugins/plugin-command-dispatch-contract.js";
+import type { SkillWorkshopProposalRevisionConstraint } from "../../skills/workshop/types.js";
 import type { GetReplyOptions } from "../get-reply-options.types.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { MsgContext } from "../templating.js";
@@ -37,6 +38,8 @@ type InternalReplySessionOptions = {
   /** Dispatch-owned operation used to defer hooks until durable run admission. */
   replyOperation?: ReplyOperation;
   skillOverrides?: SessionToolOverrides["skills"];
+  /** Gateway-private optimistic-concurrency constraint for an operator-requested proposal revision. */
+  skillWorkshopProposalRevision?: SkillWorkshopProposalRevisionConstraint;
 };
 
 export type InternalGetReplyOptions = GetReplyOptions &

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -1813,6 +1813,27 @@ describe("followup queue collect routing", () => {
     }
   });
 
+  it("drains a bound Skill Workshop revision individually", async () => {
+    const { key, calls, done, runFollowup, settings } = createQueueCase(
+      `test-collect-skill-workshop-revision-${Date.now()}`,
+      {},
+      2,
+    );
+    const revisionRun = createRun({ prompt: "revise proposal" });
+    revisionRun.run.skillWorkshopProposalRevision = {
+      agentId: "main",
+      workspaceDir: "/tmp/workspace",
+      proposalId: "proposal-h1",
+      expectedRevisionHash: "1".repeat(64),
+    };
+
+    enqueueFollowupRun(key, createRun({ prompt: "normal" }), settings);
+    enqueueFollowupRun(key, revisionRun, settings);
+    await drainRecordedQueue(key, runFollowup, done);
+
+    expect(calls.map((call) => call.prompt)).toEqual(["normal", "revise proposal"]);
+  });
+
   it("can prepend priority followups before already queued items", () => {
     const key = `test-priority-followup-front-${Date.now()}`;
     const settings = createQueueSettings({ mode: "followup" });

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -522,7 +522,11 @@ function resolveAggregateOwner(items: readonly FollowupRun[]): FollowupRun | und
 }
 
 function requiresIndividualCollectDrain(item: FollowupRun): boolean {
-  return item.disableCollectBatching === true || hasRuntimeOnlyFollowupMetadata(item);
+  return (
+    item.disableCollectBatching === true ||
+    item.run.skillWorkshopProposalRevision !== undefined ||
+    hasRuntimeOnlyFollowupMetadata(item)
+  );
 }
 
 type AggregateCancellation = {

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -23,6 +23,7 @@ import type { RuntimePluginToolGrant } from "../../../plugins/runtime/tool-grant
 import type { InputProvenance } from "../../../sessions/input-provenance.js";
 import type { UserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.types.js";
 import type { ExplicitSkillSelection, SkillSnapshot } from "../../../skills/types.js";
+import type { SkillWorkshopProposalRevisionConstraint } from "../../../skills/workshop/types.js";
 import type {
   QueuedReplyDeliveryCorrelation,
   SourceReplyDeliveryMode,
@@ -231,6 +232,8 @@ export type FollowupRun = {
     allowEmptyAssistantReplyAsSilent?: boolean;
     suppressNextUserMessagePersistence?: boolean;
     suppressTranscriptOnlyAssistantPersistence?: boolean;
+    /** Gateway-private optimistic-concurrency constraint for an operator-requested proposal revision. */
+    skillWorkshopProposalRevision?: SkillWorkshopProposalRevisionConstraint;
   };
 };
 

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -812,7 +812,7 @@ describe("gateway-backed CLI process exit", () => {
       label: "skills workshop apply",
       args: ["skills", "workshop", "apply", "proposal-missing-credentials"],
       gatewayOwnsLock: true,
-      method: "health",
+      method: "skills.proposals.inspect",
     },
   ])(
     "renders missing $label credentials as expected guidance, not a crash",

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -447,13 +447,14 @@ async function runSkillProposalApply(
 ): Promise<SkillProposalApplyResult> {
   const { callGateway, isGatewayCredentialsRequiredError, isGatewayTransportError } =
     await import("../gateway/call.js");
+  let proposal: SkillProposalReadResult;
   try {
     // Decide offline fallback before dispatching the non-idempotent mutation.
     // Once a Gateway answers, apply failures must never be replayed locally.
-    await callGateway({
+    proposal = await callGateway<SkillProposalReadResult>({
       config: resolved.config,
-      method: "health",
-      params: {},
+      method: "skills.proposals.inspect",
+      params: { agentId: resolved.agentId, proposalId },
       timeoutMs: GATEWAY_SKILLS_STATUS_TIMEOUT_MS,
       clientName: GATEWAY_CLIENT_NAMES.CLI,
       mode: GATEWAY_CLIENT_MODES.CLI,
@@ -486,12 +487,20 @@ async function runSkillProposalApply(
       throw err;
     }
     try {
+      const reviewedProposal = await inspectSkillProposal(proposalId, {
+        agentId: resolved.agentId,
+        workspaceDir: resolved.workspaceDir,
+      });
+      if (!reviewedProposal) {
+        throw new Error(`Skill proposal not found: ${proposalId}`, { cause: err });
+      }
       return await applySkillProposal({
         agentId: resolved.agentId,
         eventActor: { type: "system", id: "cli" },
         workspaceDir: resolved.workspaceDir,
         config: resolved.config,
         proposalId,
+        expectedRevisionHash: reviewedProposal.revisionHash,
       });
     } finally {
       await lock.release();
@@ -501,7 +510,11 @@ async function runSkillProposalApply(
   return await callGateway<SkillProposalApplyResult>({
     config: resolved.config,
     method: "skills.proposals.apply",
-    params: { agentId: resolved.agentId, proposalId },
+    params: {
+      agentId: resolved.agentId,
+      proposalId,
+      expectedRevisionHash: proposal.revisionHash,
+    },
     timeoutMs: GATEWAY_SKILLS_APPLY_TIMEOUT_MS,
     clientName: GATEWAY_CLIENT_NAMES.CLI,
     mode: GATEWAY_CLIENT_MODES.CLI,
@@ -1227,14 +1240,23 @@ export function registerSkillsCli(program: Command) {
           runWorkshopAction(
             opts,
             command,
-            ({ agentId, workspaceDir }) =>
-              action({
+            async ({ agentId, workspaceDir }) => {
+              const reviewed =
+                name === "reject"
+                  ? await inspectSkillProposal(proposalId, { agentId, workspaceDir })
+                  : undefined;
+              if (name === "reject" && !reviewed) {
+                throw new Error(`Skill proposal not found: ${proposalId}`);
+              }
+              return action({
                 agentId,
                 eventActor: { type: "system", id: "cli" },
                 workspaceDir,
                 proposalId,
+                ...(reviewed ? { expectedRevisionHash: reviewed.revisionHash } : {}),
                 reason: opts.reason,
-              }),
+              });
+            },
             (record) => `${verb} ${record.id}\n`,
           ),
       );

--- a/src/cli/skills-cli.workshop-cache.test.ts
+++ b/src/cli/skills-cli.workshop-cache.test.ts
@@ -17,7 +17,10 @@ const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
   config: {} as { gateway?: { mode: "local" | "remote" } },
   gatewayApply: undefined as
-    | ((request: { method: string; params?: { proposalId?: string } }) => Promise<unknown>)
+    | ((request: {
+        method: string;
+        params?: { proposalId?: string; expectedRevisionHash?: string };
+      }) => Promise<unknown>)
     | undefined,
   acquireGatewayLock: vi.fn(),
   releaseGatewayLock: vi.fn(),
@@ -82,9 +85,6 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
     mocks.defaultRuntime.error.mockClear();
     mocks.defaultRuntime.exit.mockClear();
     mocks.callGateway.mockReset().mockImplementation(async (request) => {
-      if (request.method === "health") {
-        return {};
-      }
       if (!mocks.gatewayApply) {
         throw new Error("gateway unavailable");
       }
@@ -117,11 +117,15 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
     const { resolvedSkills: _runtimeOnly, ...persistedSnapshot } = beforeApply;
     const beforeVersion = gatewayRefreshState.getSkillsSnapshotVersion(mocks.workspaceDir);
     mocks.gatewayApply = async (request) => {
+      if (request.method === "skills.proposals.inspect") {
+        return await gatewayWorkshop.inspectSkillProposal(proposal.record.id);
+      }
       expect(request.method).toBe("skills.proposals.apply");
       return await gatewayWorkshop.applySkillProposal({
         workspaceDir: mocks.workspaceDir,
         config: mocks.config,
         proposalId: request.params?.proposalId ?? "",
+        expectedRevisionHash: request.params?.expectedRevisionHash,
       });
     };
 
@@ -137,7 +141,11 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
     expect(mocks.callGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         method: "skills.proposals.apply",
-        params: { agentId: "main", proposalId: proposal.record.id },
+        params: {
+          agentId: "main",
+          proposalId: proposal.record.id,
+          expectedRevisionHash: proposal.revisionHash,
+        },
         timeoutMs: 1_850_000,
       }),
     );
@@ -160,7 +168,10 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       description: "Apply only in the process that owns snapshot state",
       content: "# Single Dispatch\n\nDo not replay this mutation.\n",
     });
-    mocks.gatewayApply = async () => {
+    mocks.gatewayApply = async (request) => {
+      if (request.method === "skills.proposals.inspect") {
+        return await gatewayWorkshop.inspectSkillProposal(proposal.record.id);
+      }
       throw new Error("gateway apply failed");
     };
 
@@ -172,7 +183,7 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
     ).rejects.toThrow("__exit__:1");
 
     expect(mocks.callGateway.mock.calls.map(([request]) => request.method)).toEqual([
-      "health",
+      "skills.proposals.inspect",
       "skills.proposals.apply",
     ]);
     await expect(gatewayWorkshop.inspectSkillProposal(proposal.record.id)).resolves.toMatchObject({
@@ -187,9 +198,9 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       description: "Keep shipped configless Workshop apply behavior",
       content: "# Offline Upgrade\n\nApply without a running gateway.\n",
     });
-    const authError = Object.assign(new Error("gateway health requires credentials"), {
+    const authError = Object.assign(new Error("gateway proposal inspection requires credentials"), {
       name: "GatewayCredentialsRequiredError",
-      method: "health",
+      method: "skills.proposals.inspect",
       configPath: "/tmp/openclaw.json",
     });
     mocks.callGateway.mockRejectedValueOnce(authError);
@@ -221,9 +232,9 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       description: "Keep snapshot invalidation in the running gateway",
       content: "# Gateway Owned Upgrade\n\nDo not apply in the CLI process.\n",
     });
-    const authError = Object.assign(new Error("gateway health requires credentials"), {
+    const authError = Object.assign(new Error("gateway proposal inspection requires credentials"), {
       name: "GatewayCredentialsRequiredError",
-      method: "health",
+      method: "skills.proposals.inspect",
       configPath: "/tmp/openclaw.json",
     });
     mocks.callGateway.mockRejectedValueOnce(authError);
@@ -236,8 +247,8 @@ describe("skills workshop CLI gateway snapshot invalidation", () => {
       program.parseAsync(["skills", "workshop", "apply", proposal.record.id], { from: "user" }),
     ).rejects.toMatchObject({
       name: "GatewayCredentialsRequiredError",
-      message: "gateway health requires credentials",
-      method: "health",
+      message: "gateway proposal inspection requires credentials",
+      method: "skills.proposals.inspect",
       configPath: "/tmp/openclaw.json",
     });
 

--- a/src/gateway/mcp-grant-store.ts
+++ b/src/gateway/mcp-grant-store.ts
@@ -15,6 +15,7 @@ import type { InboundEventKind } from "../channels/inbound-event/kind.js";
 import type { CronScheduledToolCallerOrigin } from "../cron/scheduled-tool-policy.js";
 import type { PluginHookChannelContext } from "../plugins/hook-types.js";
 import { resolveGlobalMap } from "../shared/global-singleton.js";
+import type { SkillWorkshopRunOptions } from "../skills/workshop/types.js";
 
 export type McpLoopbackRequestContext = {
   sessionKey: string;
@@ -52,6 +53,7 @@ export type McpLoopbackRequestContext = {
    * hard enforcement. Unset keeps the full session-scoped surface.
    */
   toolsAllow?: string[];
+  skillWorkshop?: SkillWorkshopRunOptions;
   scheduledToolPolicy?: ScheduledToolPolicyContext;
   /** Host-owned creator origin; child MCP request fields cannot widen it. */
   cronCreatorCallerOrigin?: CronScheduledToolCallerOrigin;

--- a/src/gateway/mcp-http.runtime.test.ts
+++ b/src/gateway/mcp-http.runtime.test.ts
@@ -85,6 +85,26 @@ describe("resolveMcpLoopbackScopedTools", () => {
     expect(scoped.tools).toEqual([]);
   });
 
+  it("forwards the exact Skill Workshop revision into loopback tool construction", () => {
+    const proposalRevision = {
+      agentId: "proposal-owner",
+      workspaceDir: "/proposal-workspace",
+      proposalId: "proposal-h1",
+      expectedRevisionHash: "1".repeat(64),
+    };
+
+    resolveMcpLoopbackScopedTools(
+      scopeParams({
+        toolsAllow: ["skill_workshop"],
+        skillWorkshop: { proposalRevision },
+      }),
+    );
+
+    expect(resolveGatewayScopedTools).toHaveBeenCalledWith(
+      expect.objectContaining({ skillWorkshop: { proposalRevision } }),
+    );
+  });
+
   it("exposes explicitly granted coding tools through the mediated loopback surface", () => {
     resolveGatewayScopedTools.mockReturnValue(scopedToolFixture(["read", "exec", "browser"]));
 

--- a/src/gateway/mcp-http.runtime.ts
+++ b/src/gateway/mcp-http.runtime.ts
@@ -207,6 +207,7 @@ export class McpLoopbackToolCache {
       // Unset (full scope) must never share a cache row with an empty
       // allowlist (deny-all), so the marker distinguishes presence.
       params.toolsAllow ? `allow:${[...new Set(params.toolsAllow)].toSorted().join(",")}` : "",
+      JSON.stringify(params.skillWorkshop?.proposalRevision ?? null),
       JSON.stringify(params.scheduledToolPolicy ?? null),
       params.nodeExecAllowed === true ? "node-exec" : "",
       params.execSession?.execHost ?? "",

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -9,6 +9,7 @@ import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js"
 import { dispatchInboundMessageWithProjectedDispatcher } from "../../auto-reply/dispatch.js";
 import type { ReplyMessageInjectionAttempt } from "../../auto-reply/reply/reply-run-registry.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
+import type { SkillWorkshopProposalRevisionConstraint } from "../../skills/workshop/types.js";
 import { isOperatorUiClient } from "../../utils/message-channel.js";
 import { setGatewayDedupeEntry } from "../agent-turn/agent-job.js";
 import { updateChatRunProvider } from "../chat-abort.js";
@@ -58,6 +59,7 @@ type StartChatDispatchParams = {
   client: GatewayRequestHandlerOptions["client"];
   context: GatewayRequestHandlerOptions["context"];
   toolsAllow?: string[];
+  skillWorkshopProposalRevision?: SkillWorkshopProposalRevisionConstraint;
   cronCreatorAuthority: ReturnType<ChatSendExternalAuthorityAdmission["resolve"]>;
   externalAuthorityAdmission: ChatSendExternalAuthorityAdmission | undefined;
   injection: {
@@ -88,6 +90,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
     client,
     context,
     toolsAllow,
+    skillWorkshopProposalRevision,
     cronCreatorAuthority,
     externalAuthorityAdmission,
     injection,
@@ -247,6 +250,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
                 changes.forEach((change) => emitSessionsChanged(context, change)),
               replyOptions: {
                 runId: clientRunId,
+                skillWorkshopProposalRevision,
                 ...(cronCreatorAuthority
                   ? { cronCreatorAuthorityCapability: cronCreatorAuthority }
                   : {}),

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -3,6 +3,7 @@ import { performance } from "node:perf_hooks";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { emitDiagnosticsTimelineEvent } from "../../infra/diagnostics-timeline.js";
+import type { SkillWorkshopProposalRevisionConstraint } from "../../skills/workshop/types.js";
 import { discardPreparedInboundMedia } from "../chat-attachments.js";
 import type { ChatRunTiming } from "../server-chat-state.js";
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
@@ -25,11 +26,17 @@ import {
 import { createGatewayChatUserTurnController } from "./chat-user-turn-recorder.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 
+type ChatSendInternalOptions = {
+  trustedSystemInput?: boolean;
+  toolsAllow?: string[];
+  skillWorkshopProposalRevision?: SkillWorkshopProposalRevisionConstraint;
+};
+
 async function handleChatSendWithOptions(
   { params, respond, context, client }: GatewayRequestHandlerOptions,
   onAdmissionOwned?: () => Promise<boolean>,
   externalAuthorityAdmission?: ChatSendExternalAuthorityAdmission,
-  options?: { trustedSystemInput?: boolean; toolsAllow?: string[] },
+  options?: ChatSendInternalOptions,
 ): Promise<void> {
   const setup = await prepareAndAdmitChatSend(
     { params, respond, context, client },
@@ -271,6 +278,7 @@ async function handleChatSendWithOptions(
       client,
       context,
       toolsAllow: options?.toolsAllow,
+      skillWorkshopProposalRevision: options?.skillWorkshopProposalRevision,
       cronCreatorAuthority,
       externalAuthorityAdmission,
       injection: {
@@ -315,6 +323,17 @@ export async function handleChatSendWithRuntimeTools(
   toolsAllow: string[],
 ): Promise<void> {
   await handleChatSendWithOptions(options, undefined, undefined, { toolsAllow });
+}
+
+/** Dispatches an operator-requested proposal revision with its reviewed revision bound to the run. */
+export async function handleChatSendWithSkillWorkshopProposalRevision(
+  options: GatewayRequestHandlerOptions,
+  proposalRevision: SkillWorkshopProposalRevisionConstraint,
+): Promise<void> {
+  await handleChatSendWithOptions(options, undefined, undefined, {
+    toolsAllow: ["skill_workshop"],
+    skillWorkshopProposalRevision: { ...proposalRevision },
+  });
 }
 
 /** Dispatches Gateway-authored system input without widening the public chat-send contract. */

--- a/src/gateway/server-methods/skills-workspace-handler.ts
+++ b/src/gateway/server-methods/skills-workspace-handler.ts
@@ -1,5 +1,9 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  buildSkillProposalRevisionChangedErrorDetails,
+  ErrorCodes,
+  errorShape,
+} from "../../../packages/gateway-protocol/src/index.js";
 import { AgentSelectionRequiredError } from "../../agents/agent-scope-config.js";
 import {
   listAgentIds,
@@ -8,6 +12,7 @@ import {
 } from "../../agents/agent-scope.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { SkillProposalRevisionChangedError } from "../../skills/workshop/service-evaluation.js";
 import type { GatewayRequestContext, RespondFn } from "./types.js";
 import { assertValidParams, type Validator } from "./validation.js";
 
@@ -80,10 +85,21 @@ export async function runSkillsProposalWorkspaceHandler<TParams, TResult>(params
       params.respond(true, result, undefined);
     }
   } catch (error) {
+    const details =
+      error instanceof SkillProposalRevisionChangedError
+        ? buildSkillProposalRevisionChangedErrorDetails({
+            expectedRevisionHash: error.expectedRevisionHash,
+            currentRevisionHash: error.currentRevisionHash,
+          })
+        : undefined;
     params.respond(
       false,
       undefined,
-      errorShape(ErrorCodes.INVALID_REQUEST, formatErrorMessage(error)),
+      errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        formatErrorMessage(error),
+        details ? { details } : undefined,
+      ),
     );
   }
 }

--- a/src/gateway/server-methods/skills.proposals.test.ts
+++ b/src/gateway/server-methods/skills.proposals.test.ts
@@ -89,6 +89,7 @@ vi.mock("./chat.js", () => ({
 
 vi.mock("./chat-send-handler.js", () => ({
   handleChatSend: mocks.chatSend,
+  handleChatSendWithSkillWorkshopProposalRevision: mocks.chatSend,
 }));
 
 const { skillsHandlers } = await import("./skills.js");
@@ -171,6 +172,7 @@ describe("skills proposal gateway handlers", () => {
       proposalId: created.record.id,
     });
     expect(inspect.ok).toBe(true);
+    const reviewedRevisionHash = (inspect.response as { revisionHash: string }).revisionHash;
     expect((inspect.response as { content: string }).content).toContain("status: proposal");
     expect(
       (
@@ -187,10 +189,12 @@ describe("skills proposal gateway handlers", () => {
 
     const revise = await callHandler("skills.proposals.revise", {
       proposalId: created.record.id,
+      expectedRevisionHash: reviewedRevisionHash,
       description: "Plan with current weather",
       content: "# Weather Planner\n\nUse current weather and alerts.\n",
     });
     expect(revise.ok).toBe(true);
+    const revisedRevisionHash = (revise.response as { revisionHash: string }).revisionHash;
     expect(
       (revise.response as { record: { id: string; proposedVersion: string } }).record,
     ).toMatchObject({
@@ -200,6 +204,7 @@ describe("skills proposal gateway handlers", () => {
 
     const apply = await callHandler("skills.proposals.apply", {
       proposalId: created.record.id,
+      expectedRevisionHash: revisedRevisionHash,
     });
     expect(apply.ok).toBe(true);
     await expect(
@@ -395,6 +400,48 @@ describe("skills proposal gateway handlers", () => {
     }
   });
 
+  it.each([
+    ["skills.proposals.apply", {}, mocks.applySkillProposal],
+    ["skills.proposals.reject", {}, mocks.rejectSkillProposal],
+    [
+      "skills.proposals.requestRevision",
+      {
+        instructions: "Tighten the examples.",
+        sessionKey: "agent:main:revision",
+        idempotencyKey: "revision-missing-hash",
+      },
+      mocks.chatSend,
+    ],
+  ] as const)("%s refuses missing reviewed revision evidence", async (method, extra, owner) => {
+    const result = await callHandler(method, { proposalId: "proposal-1", ...extra });
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: {
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("expectedRevisionHash"),
+      },
+    });
+    expect(owner).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["skills.proposals.revise", { description: "Tighter" }, mocks.reviseSkillProposal],
+    ["skills.proposals.quarantine", {}, mocks.quarantineSkillProposal],
+  ] as const)("%s preserves optional revision evidence", async (method, extra, owner) => {
+    owner.mockResolvedValueOnce(
+      method.endsWith("revise")
+        ? { record: { id: "proposal-1" }, revisionHash: "b".repeat(64), content: "# Revised" }
+        : { id: "proposal-1" },
+    );
+
+    await callHandler(method, { proposalId: "proposal-1", ...extra });
+
+    expect(owner).toHaveBeenCalledWith(
+      expect.objectContaining({ proposalId: "proposal-1", expectedRevisionHash: undefined }),
+    );
+  });
+
   it("reports empty historical scan coverage and validates scan direction", async () => {
     const status = await callHandler("skills.proposals.historyStatus", {});
     expect(status).toMatchObject({
@@ -451,6 +498,7 @@ describe("skills proposal gateway handlers", () => {
       deliver: false,
       idempotencyKey: "revision-run-1",
       message: "Make the support files 5",
+      queueMode: "followup",
       sessionKey: "agent:main:session:skill-workshop",
       suppressCommandInterpretation: true,
     });
@@ -461,11 +509,18 @@ describe("skills proposal gateway handlers", () => {
       "Use `skill_workshop` with `action=inspect` first, then `action=revise`",
     );
     expect(String(forwarded.params?.systemProvenanceReceipt)).toContain(
-      `expected_revision_hash=${expectedRevisionHash}`,
+      "The proposal ID and expected revision hash are bound by this run",
     );
+    expect(String(forwarded.params?.systemProvenanceReceipt)).not.toContain(expectedRevisionHash);
     expect(String(forwarded.params?.systemProvenanceReceipt)).not.toContain(
       "Make the support files 5",
     );
+    expect(mocks.chatSend.mock.calls[0]?.[1]).toEqual({
+      agentId: "main",
+      workspaceDir: mocks.workspaceDir,
+      proposalId: created.record.id,
+      expectedRevisionHash,
+    });
   });
 
   it("does not start revision chat turns from a stale revision hash", async () => {
@@ -476,10 +531,20 @@ describe("skills proposal gateway handlers", () => {
     });
     expect(create.ok).toBe(true);
     const created = create.response as { record: { id: string } };
+    const inspected = await callHandler("skills.proposals.inspect", {
+      proposalId: created.record.id,
+    });
+    const expectedRevisionHash = (inspected.response as { revisionHash: string }).revisionHash;
+    const revised = await callHandler("skills.proposals.revise", {
+      proposalId: created.record.id,
+      expectedRevisionHash,
+      description: "Updated while the operator was reviewing",
+    });
+    const currentRevisionHash = (revised.response as { revisionHash: string }).revisionHash;
 
     const result = await callHandler("skills.proposals.requestRevision", {
       proposalId: created.record.id,
-      expectedRevisionHash: "f".repeat(64),
+      expectedRevisionHash,
       instructions: "Revise this draft",
       sessionKey: "agent:main:session:skill-workshop",
       idempotencyKey: "revision-run-stale",
@@ -489,8 +554,63 @@ describe("skills proposal gateway handlers", () => {
     expect((result.error as { message?: string }).message).toContain(
       "Skill proposal revision changed",
     );
+    expect((result.error as { details?: unknown }).details).toEqual({
+      code: "SKILL_PROPOSAL_REVISION_CHANGED",
+      expectedRevisionHash,
+      currentRevisionHash,
+    });
     expect(mocks.chatSend).not.toHaveBeenCalled();
+    await expect(
+      callHandler("skills.proposals.inspect", { proposalId: created.record.id }),
+    ).resolves.toMatchObject({
+      ok: true,
+      response: {
+        revisionHash: currentRevisionHash,
+        record: { status: "pending" },
+      },
+    });
   });
+
+  it.each(["apply", "reject"])(
+    "returns structured stale details without mutating H2 for %s",
+    async (action) => {
+      const create = await callHandler("skills.proposals.create", {
+        name: `Stale ${action} sampler`,
+        description: `Rejects a stale ${action} decision`,
+        content: `# Stale ${action} sampler\n`,
+      });
+      const proposalId = (create.response as { record: { id: string } }).record.id;
+      const inspected = await callHandler("skills.proposals.inspect", { proposalId });
+      const expectedRevisionHash = (inspected.response as { revisionHash: string }).revisionHash;
+      const revised = await callHandler("skills.proposals.revise", {
+        proposalId,
+        expectedRevisionHash,
+        description: "Changed after operator review",
+      });
+      const currentRevisionHash = (revised.response as { revisionHash: string }).revisionHash;
+
+      const result = await callHandler(`skills.proposals.${action}`, {
+        proposalId,
+        expectedRevisionHash,
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: "INVALID_REQUEST",
+          details: {
+            code: "SKILL_PROPOSAL_REVISION_CHANGED",
+            expectedRevisionHash,
+            currentRevisionHash,
+          },
+        },
+      });
+      await expect(callHandler("skills.proposals.inspect", { proposalId })).resolves.toMatchObject({
+        ok: true,
+        response: { revisionHash: currentRevisionHash, record: { status: "pending" } },
+      });
+    },
+  );
 
   it("does not start revision chat turns for non-pending proposals", async () => {
     const create = await callHandler("skills.proposals.create", {
@@ -500,14 +620,20 @@ describe("skills proposal gateway handlers", () => {
     });
     expect(create.ok).toBe(true);
     const created = create.response as { record: { id: string } };
+    const inspect = await callHandler("skills.proposals.inspect", {
+      proposalId: created.record.id,
+    });
+    const expectedRevisionHash = (inspect.response as { revisionHash: string }).revisionHash;
     const apply = await callHandler("skills.proposals.apply", {
       proposalId: created.record.id,
+      expectedRevisionHash,
     });
     expect(apply.ok).toBe(true);
     mocks.chatSend.mockClear();
 
     const result = await callHandler("skills.proposals.requestRevision", {
       proposalId: created.record.id,
+      expectedRevisionHash,
       instructions: "Make the support files 5",
       sessionKey: "agent:main:session:skill-workshop",
       idempotencyKey: "revision-run-applied",

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -11,6 +11,7 @@ import {
   validateSkillsInstallParams,
   validateSkillsProposalActionParams,
   validateSkillsProposalCreateParams,
+  validateSkillsProposalDecisionParams,
   validateSkillsProposalEvaluateParams,
   validateSkillsProposalEventsListParams,
   validateSkillsProposalInspectParams,
@@ -56,6 +57,7 @@ import {
   restoreCuratedSkill,
   unpinCuratedSkill,
 } from "../../skills/workshop/curator.js";
+import { assertExpectedRevisionHash } from "../../skills/workshop/service-evaluation.js";
 import {
   applySkillProposal,
   evaluateSkillProposal,
@@ -126,10 +128,7 @@ function collectClawHubTrustWarnings(results: Array<{ warning?: string }>): stri
     .filter((warning): warning is string => Boolean(warning));
 }
 
-function buildRevisionAgentInstruction(
-  proposal: Awaited<ReturnType<typeof inspectSkillProposal>>,
-  expectedRevisionHash: string,
-) {
+function buildRevisionAgentInstruction(proposal: Awaited<ReturnType<typeof inspectSkillProposal>>) {
   if (!proposal) {
     return "";
   }
@@ -137,7 +136,7 @@ function buildRevisionAgentInstruction(
     `Revise Skill Workshop proposal \`${proposal.record.id}\` (${proposal.record.target.skillKey}).`,
     "",
     "Use `skill_workshop` with `action=inspect` first, then `action=revise` for that pending proposal.",
-    `Pass \`expected_revision_hash=${expectedRevisionHash}\` to reject stale proposal revisions.`,
+    "The proposal ID and expected revision hash are bound by this run; do not substitute them.",
     "Do not apply, approve, reject, quarantine, or install the proposal.",
     "",
     "Requested changes:",
@@ -152,30 +151,38 @@ async function forwardSkillWorkshopRevisionToChatSend(
     instructions: string;
     proposal: NonNullable<Awaited<ReturnType<typeof inspectSkillProposal>>>;
     expectedRevisionHash: string;
+    workspaceDir: string;
     sessionId?: string;
     sessionKey: string;
     targetAgentId?: string;
   },
 ): Promise<void> {
-  const { handleChatSend } = await import("./chat-send-handler.js");
+  const { handleChatSendWithSkillWorkshopProposalRevision } =
+    await import("./chat-send-handler.js");
   const chatParams = {
     sessionKey: params.sessionKey,
     agentId: params.targetAgentId ?? params.agentId,
     ...(params.sessionId ? { sessionId: params.sessionId } : {}),
     message: params.instructions,
     deliver: false,
-    systemProvenanceReceipt: buildRevisionAgentInstruction(
-      params.proposal,
-      params.expectedRevisionHash,
-    ),
+    queueMode: "followup" as const,
+    systemProvenanceReceipt: buildRevisionAgentInstruction(params.proposal),
     suppressCommandInterpretation: true,
     idempotencyKey: params.idempotencyKey,
   };
-  await handleChatSend({
-    ...opts,
-    req: { ...opts.req, method: "chat.send", params: chatParams },
-    params: chatParams,
-  });
+  await handleChatSendWithSkillWorkshopProposalRevision(
+    {
+      ...opts,
+      req: { ...opts.req, method: "chat.send", params: chatParams },
+      params: chatParams,
+    },
+    {
+      agentId: params.agentId,
+      workspaceDir: params.workspaceDir,
+      proposalId: params.proposal.record.id,
+      expectedRevisionHash: params.expectedRevisionHash,
+    },
+  );
 }
 
 /** Gateway request handlers for skill status, catalogs, installs, updates, and workshop proposals. */
@@ -535,6 +542,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
       context,
       validate: validateSkillsProposalRequestRevisionParams,
       run: async (parsedParams, resolved) => {
+        const expectedRevisionHash = parsedParams.expectedRevisionHash;
         const proposal = await inspectSkillProposal(parsedParams.proposalId, {
           agentId: resolved.agentId,
           workspaceDir: resolved.workspaceDir,
@@ -561,26 +569,14 @@ export const skillsHandlers: GatewayRequestHandlers = {
           );
           return SKILL_PROPOSAL_RESPONSE_HANDLED;
         }
-        if (
-          parsedParams.expectedRevisionHash &&
-          parsedParams.expectedRevisionHash !== proposal.revisionHash
-        ) {
-          respond(
-            false,
-            undefined,
-            errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              `Skill proposal revision changed: ${parsedParams.proposalId}`,
-            ),
-          );
-          return SKILL_PROPOSAL_RESPONSE_HANDLED;
-        }
+        assertExpectedRevisionHash(proposal.revisionHash, expectedRevisionHash);
         await forwardSkillWorkshopRevisionToChatSend(opts, {
           agentId: resolved.agentId,
-          expectedRevisionHash: parsedParams.expectedRevisionHash ?? proposal.revisionHash,
+          expectedRevisionHash,
           idempotencyKey: parsedParams.idempotencyKey,
           instructions: parsedParams.instructions,
           proposal,
+          workspaceDir: resolved.workspaceDir,
           sessionId: parsedParams.sessionId,
           sessionKey: parsedParams.sessionKey,
           targetAgentId: parsedParams.targetAgentId
@@ -597,7 +593,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
       rawParams: params,
       respond,
       context,
-      validate: validateSkillsProposalActionParams,
+      validate: validateSkillsProposalDecisionParams,
       run: (parsedParams, resolved) =>
         applySkillProposal({
           workspaceDir: resolved.workspaceDir,
@@ -617,7 +613,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
       rawParams: params,
       respond,
       context,
-      validate: validateSkillsProposalActionParams,
+      validate: validateSkillsProposalDecisionParams,
       run: (parsedParams, resolved) =>
         rejectSkillProposal({
           workspaceDir: resolved.workspaceDir,

--- a/src/gateway/tool-resolution.ts
+++ b/src/gateway/tool-resolution.ts
@@ -54,6 +54,7 @@ import {
   DEFAULT_GATEWAY_HTTP_TOOL_DENY,
   GATEWAY_OWNER_ONLY_CORE_TOOLS,
 } from "../security/dangerous-tools.js";
+import type { SkillWorkshopRunOptions } from "../skills/workshop/types.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel-constants.js";
 import { normalizeMessageChannel } from "../utils/message-channel-core.js";
 
@@ -116,6 +117,7 @@ export function resolveGatewayScopedTools(params: {
   groupChannel?: string;
   groupSpace?: string;
   spawnedBy?: string;
+  skillWorkshop?: SkillWorkshopRunOptions;
   scheduledToolPolicy?: ScheduledToolPolicyContext;
 }) {
   const runtimePolicySessionKey = params.runtimePolicySessionKey?.trim() || params.sessionKey;
@@ -307,6 +309,7 @@ export function resolveGatewayScopedTools(params: {
     senderIsOwner: params.senderIsOwner,
     conversationReadOrigin: params.conversationReadOrigin,
     allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
+    skillWorkshop: params.skillWorkshop,
     allowMediaInvokeCommands: params.allowMediaInvokeCommands,
     disablePluginTools: params.disablePluginTools,
     wrapBeforeToolCallHook: false,

--- a/src/skills/workshop/service-evaluation.test.ts
+++ b/src/skills/workshop/service-evaluation.test.ts
@@ -22,6 +22,7 @@ vi.mock("../../plugins/hook-runner-global.js", () => ({
 }));
 
 import { buildSkillProposalEvaluationBundles } from "./proposal-bundle.js";
+import { SkillProposalRevisionChangedError } from "./service-evaluation.js";
 import {
   applySkillProposal,
   evaluateSkillProposal,
@@ -629,7 +630,11 @@ describe("Skill Workshop proposal evaluation", () => {
         proposalId: proposal.record.id,
         expectedRevisionHash: proposal.revisionHash,
       }),
-    ).rejects.toThrow("proposal revision changed");
+    ).rejects.toMatchObject({
+      constructor: SkillProposalRevisionChangedError,
+      expectedRevisionHash: proposal.revisionHash,
+      currentRevisionHash: revised.revisionHash,
+    });
     expect(hookMocks.evaluate).not.toHaveBeenCalled();
   });
 

--- a/src/skills/workshop/service-evaluation.ts
+++ b/src/skills/workshop/service-evaluation.ts
@@ -39,6 +39,18 @@ const MAX_EVALUATION_METRICS = 64;
 
 export class SkillProposalCreateTargetConflictError extends Error {}
 
+export class SkillProposalRevisionChangedError extends Error {
+  constructor(
+    readonly expectedRevisionHash: string,
+    readonly currentRevisionHash: string,
+  ) {
+    super(
+      `Skill proposal revision changed (expected ${expectedRevisionHash}, current ${currentRevisionHash}); reload and retry.`,
+    );
+    this.name = "SkillProposalRevisionChangedError";
+  }
+}
+
 export async function evaluateSkillProposal(
   input: SkillProposalEvaluateInput,
 ): Promise<SkillProposalEvaluateResult> {
@@ -215,9 +227,7 @@ export function listSkillProposalEvents(
 export function assertExpectedRevisionHash(actual: string, expected?: string): void {
   const normalized = normalizeOptionalString(expected);
   if (normalized && normalized !== actual) {
-    throw new Error(
-      `Skill proposal revision changed (expected ${normalized}, current ${actual}); reload and retry.`,
-    );
+    throw new SkillProposalRevisionChangedError(normalized, actual);
   }
 }
 

--- a/src/skills/workshop/types.ts
+++ b/src/skills/workshop/types.ts
@@ -93,6 +93,14 @@ export type SkillWorkshopProposalReviewCompletion = {
   recordProgress?: (progress: SkillWorkshopProposalReviewProgress) => Promise<void>;
 };
 
+/** Exact proposal revision an operator reviewed before requesting an agent-authored revision. */
+export type SkillWorkshopProposalRevisionConstraint = {
+  readonly agentId: string;
+  readonly workspaceDir: string;
+  readonly proposalId: string;
+  readonly expectedRevisionHash: string;
+};
+
 export type SkillWorkshopRunOptions = {
   env?: NodeJS.ProcessEnv;
   proposalOnly?: boolean;
@@ -102,6 +110,7 @@ export type SkillWorkshopRunOptions = {
   proposalMutationBudget?: SkillWorkshopProposalMutationBudget;
   proposalReviewCompletion?: SkillWorkshopProposalReviewCompletion;
   collectionReconcile?: SkillCollectionReconcileContext;
+  proposalRevision?: SkillWorkshopProposalRevisionConstraint;
 };
 
 export type SkillProposalScan = {

--- a/test/skills-proposal-manual-target.e2e.test.ts
+++ b/test/skills-proposal-manual-target.e2e.test.ts
@@ -120,7 +120,7 @@ describe("Skill proposal manual-target product proof", () => {
         const inspected = (await started.client.request("skills.proposals.inspect", {
           agentId: "main",
           proposalId: created.record.id,
-        })) as { record: ProposalRecord };
+        })) as { record: ProposalRecord; revisionHash: string };
         expect(inspected.record).toMatchObject({
           id: created.record.id,
           status: "stale",
@@ -150,6 +150,7 @@ describe("Skill proposal manual-target product proof", () => {
           await started.client.request("skills.proposals.apply", {
             agentId: "main",
             proposalId: created.record.id,
+            expectedRevisionHash: inspected.revisionHash,
           });
         } catch (error) {
           applyError = error;

--- a/ui/src/app/skill-workshop-revision-admissions.test.ts
+++ b/ui/src/app/skill-workshop-revision-admissions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { GatewayRequestError, type GatewayBrowserClient } from "../api/gateway.ts";
 import { requestSkillWorkshopRevisionAdmission } from "../pages/skill-workshop/revision-admission.ts";
 import { gatewayHelloForMethods } from "../test-helpers/gateway-methods.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "./context.ts";
@@ -75,6 +75,29 @@ describe("Skill Workshop revision admission owner", () => {
     attempts[1]!.resolve({ sessionKey: "agent:main:retry" });
     await expect(retry?.completion).resolves.toMatchObject({ status: "admitted" });
     expect(owner.get(run.entry.id)).toBeNull();
+  });
+
+  it("retires a changed proposal revision instead of making the stale decision retryable", async () => {
+    const owner = createSkillWorkshopRevisionAdmissions();
+    const run = owner.start(input("retry exactly"), async () => {
+      throw new GatewayRequestError({
+        code: "INVALID_REQUEST",
+        message: "Skill proposal revision changed",
+        details: {
+          code: "SKILL_PROPOSAL_REVISION_CHANGED",
+          currentRevisionHash: "b".repeat(64),
+          expectedRevisionHash: "a".repeat(64),
+        },
+      });
+    });
+
+    await expect(run.completion).resolves.toEqual({
+      id: run.entry.id,
+      status: "revision-changed",
+    });
+    expect(owner.get(run.entry.id)).toBeNull();
+    expect(owner.retry(run.entry.id)).toBeNull();
+    expect(owner.firstFailed("main")).toBeNull();
   });
 
   it("keeps overlapping failures independent and reveals them in insertion order", async () => {

--- a/ui/src/app/skill-workshop-revision-admissions.test.ts
+++ b/ui/src/app/skill-workshop-revision-admissions.test.ts
@@ -17,6 +17,8 @@ const input = (instructions: string): SkillWorkshopRevisionAdmissionInput => ({
   useCurrentChatForRevisions: false,
 });
 
+type AdmittedExecutorResult = { sessionKey: string; status: "admitted" };
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (error: unknown) => void;
@@ -27,15 +29,50 @@ function deferred<T>() {
   return { promise, reject, resolve };
 }
 
+function revisionContext(params: {
+  agentId: string;
+  client: GatewayBrowserClient;
+  sessionId: string;
+  sessionKey: string;
+}): ApplicationContext {
+  const snapshot = {
+    client: params.client,
+    phase: "connected",
+    hello: gatewayHelloForMethods([]),
+    assistantAgentId: params.agentId,
+  } as unknown as ApplicationGatewaySnapshot;
+  return {
+    gateway: { snapshot },
+    sessions: {
+      state: {
+        agentId: params.agentId,
+        result: {
+          sessions: [
+            {
+              key: params.sessionKey,
+              sessionId: params.sessionId,
+              agentId: params.agentId,
+              archived: false,
+              hasActiveRun: false,
+            },
+          ],
+        },
+        loading: false,
+        error: null,
+      },
+    },
+  } as unknown as ApplicationContext;
+}
+
 describe("Skill Workshop revision admission owner", () => {
   it("removes only the exact ACK-admitted entry", async () => {
     const owner = createSkillWorkshopRevisionAdmissions();
-    const first = deferred<{ sessionKey: string }>();
-    const second = deferred<{ sessionKey: string }>();
+    const first = deferred<AdmittedExecutorResult>();
+    const second = deferred<AdmittedExecutorResult>();
     const runA = owner.start(input("first"), () => first.promise);
     const runB = owner.start(input("second"), () => second.promise);
 
-    second.resolve({ sessionKey: "agent:main:second" });
+    second.resolve({ sessionKey: "agent:main:second", status: "admitted" });
     await expect(runB.completion).resolves.toEqual({
       id: runB.entry.id,
       sessionKey: "agent:main:second",
@@ -48,11 +85,11 @@ describe("Skill Workshop revision admission owner", () => {
 
   it("retains failure and retries the same record and idempotency key", async () => {
     const owner = createSkillWorkshopRevisionAdmissions();
-    const attempts: Array<ReturnType<typeof deferred<{ sessionKey: string }>>> = [];
+    const attempts: Array<ReturnType<typeof deferred<AdmittedExecutorResult>>> = [];
     const idempotencyKeys: string[] = [];
     const run = owner.start(input("retry exactly"), (entry) => {
       idempotencyKeys.push(entry.idempotencyKey);
-      const attempt = deferred<{ sessionKey: string }>();
+      const attempt = deferred<AdmittedExecutorResult>();
       attempts.push(attempt);
       return attempt.promise;
     });
@@ -72,24 +109,16 @@ describe("Skill Workshop revision admission owner", () => {
       phase: "pending",
     });
     expect(idempotencyKeys).toEqual([run.entry.idempotencyKey, run.entry.idempotencyKey]);
-    attempts[1]!.resolve({ sessionKey: "agent:main:retry" });
+    attempts[1]!.resolve({ sessionKey: "agent:main:retry", status: "admitted" });
     await expect(retry?.completion).resolves.toMatchObject({ status: "admitted" });
     expect(owner.get(run.entry.id)).toBeNull();
   });
 
   it("retires a changed proposal revision instead of making the stale decision retryable", async () => {
     const owner = createSkillWorkshopRevisionAdmissions();
-    const run = owner.start(input("retry exactly"), async () => {
-      throw new GatewayRequestError({
-        code: "INVALID_REQUEST",
-        message: "Skill proposal revision changed",
-        details: {
-          code: "SKILL_PROPOSAL_REVISION_CHANGED",
-          currentRevisionHash: "b".repeat(64),
-          expectedRevisionHash: "a".repeat(64),
-        },
-      });
-    });
+    const run = owner.start(input("retry exactly"), async () => ({
+      status: "revision-changed",
+    }));
 
     await expect(run.completion).resolves.toEqual({
       id: run.entry.id,
@@ -100,10 +129,51 @@ describe("Skill Workshop revision admission owner", () => {
     expect(owner.firstFailed("main")).toBeNull();
   });
 
+  it("classifies a typed stale Gateway reply at the lazy request boundary without replaying", async () => {
+    const request = vi.fn(async () => {
+      throw new GatewayRequestError({
+        code: "INVALID_REQUEST",
+        message: "Skill proposal revision changed",
+        details: {
+          code: "SKILL_PROPOSAL_REVISION_CHANGED",
+          currentRevisionHash: "b".repeat(64),
+          expectedRevisionHash: "a".repeat(64),
+        },
+      });
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const context = revisionContext({
+      agentId: "main",
+      client,
+      sessionId: "session-main-workshop",
+      sessionKey: "agent:main:workshop",
+    });
+    const entry = {
+      ...input("preserve reviewed content"),
+      id: "revision-admission",
+      idempotencyKey: "revision-idempotency",
+      phase: "pending" as const,
+      proposalOriginSessionKey: "agent:main:workshop",
+    };
+
+    await expect(
+      requestSkillWorkshopRevisionAdmission({ context, entry, materialize: vi.fn() }),
+    ).resolves.toEqual({ status: "revision-changed" });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      "skills.proposals.requestRevision",
+      expect.objectContaining({
+        expectedRevisionHash: "a".repeat(64),
+        idempotencyKey: "revision-idempotency",
+        sessionKey: "agent:main:workshop",
+      }),
+    );
+  });
+
   it("keeps overlapping failures independent and reveals them in insertion order", async () => {
     const owner = createSkillWorkshopRevisionAdmissions();
-    const first = deferred<{ sessionKey: string }>();
-    const second = deferred<{ sessionKey: string }>();
+    const first = deferred<AdmittedExecutorResult>();
+    const second = deferred<AdmittedExecutorResult>();
     const runA = owner.start(input("first failed"), () => first.promise);
     const runB = owner.start(input("second failed"), () => second.promise);
 
@@ -155,33 +225,12 @@ describe("Skill Workshop revision admission owner", () => {
       return { status: "started" };
     });
     const client = { request } as unknown as GatewayBrowserClient;
-    const snapshot = {
+    const context = revisionContext({
+      agentId: "research",
       client,
-      phase: "connected",
-      hello: gatewayHelloForMethods([]),
-      assistantAgentId: "research",
-    } as unknown as ApplicationGatewaySnapshot;
-    const context = {
-      gateway: { snapshot },
-      sessions: {
-        state: {
-          agentId: "research",
-          result: {
-            sessions: [
-              {
-                key: "agent:research:second",
-                sessionId: "session-second",
-                agentId: "research",
-                archived: false,
-                hasActiveRun: false,
-              },
-            ],
-          },
-          loading: false,
-          error: null,
-        },
-      },
-    } as unknown as ApplicationContext;
+      sessionId: "session-second",
+      sessionKey: "agent:research:second",
+    });
     const owner = createSkillWorkshopRevisionAdmissions();
     const run = owner.start(
       {

--- a/ui/src/app/skill-workshop-revision-admissions.ts
+++ b/ui/src/app/skill-workshop-revision-admissions.ts
@@ -1,3 +1,4 @@
+import { readSkillProposalRevisionChangedError } from "@openclaw/gateway-protocol";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { generateUUID } from "../lib/uuid.ts";
 
@@ -27,6 +28,7 @@ export type SkillWorkshopRevisionAdmissionEntry = SkillWorkshopRevisionAdmission
 
 export type SkillWorkshopRevisionAdmissionOutcome =
   | { id: string; sessionKey: string; status: "admitted" }
+  | { id: string; status: "revision-changed" }
   | { error: string; id: string; status: "retryable-failed" };
 
 type AdmissionExecutor = (
@@ -98,6 +100,13 @@ export function createSkillWorkshopRevisionAdmissions(): ApplicationSkillWorksho
         return { id: entry.value.id, sessionKey, status: "admitted" };
       })
       .catch((error: unknown): SkillWorkshopRevisionAdmissionOutcome => {
+        if (readSkillProposalRevisionChangedError(error)) {
+          if (entries.get(entry.value.id) === entry && entry.generation === generation) {
+            entries.delete(entry.value.id);
+            publish();
+          }
+          return { id: entry.value.id, status: "revision-changed" };
+        }
         const message = error instanceof Error ? error.message : String(error);
         if (entries.get(entry.value.id) === entry && entry.generation === generation) {
           entry.value = { ...entry.value, error: message, phase: "retryable-failed" };

--- a/ui/src/app/skill-workshop-revision-admissions.ts
+++ b/ui/src/app/skill-workshop-revision-admissions.ts
@@ -1,4 +1,3 @@
-import { readSkillProposalRevisionChangedError } from "@openclaw/gateway-protocol";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { generateUUID } from "../lib/uuid.ts";
 
@@ -31,12 +30,16 @@ export type SkillWorkshopRevisionAdmissionOutcome =
   | { id: string; status: "revision-changed" }
   | { error: string; id: string; status: "retryable-failed" };
 
+type AdmissionExecutorResult =
+  | { sessionKey: string; status: "admitted" }
+  | { status: "revision-changed" };
+
 type AdmissionExecutor = (
   entry: SkillWorkshopRevisionAdmissionEntry,
   materialize: (
     binding: SkillWorkshopRevisionAdmissionBinding,
   ) => SkillWorkshopRevisionAdmissionEntry | null,
-) => Promise<{ sessionKey: string }>;
+) => Promise<AdmissionExecutorResult>;
 
 type SkillWorkshopRevisionAdmissionRun = {
   completion: Promise<SkillWorkshopRevisionAdmissionOutcome>;
@@ -92,21 +95,16 @@ export function createSkillWorkshopRevisionAdmissions(): ApplicationSkillWorksho
     };
     const completion = entry
       .execute(copyEntry(entry), materialize)
-      .then(({ sessionKey }): SkillWorkshopRevisionAdmissionOutcome => {
-        if (entries.get(entry.value.id) === entry) {
+      .then((result): SkillWorkshopRevisionAdmissionOutcome => {
+        if (entries.get(entry.value.id) === entry && entry.generation === generation) {
           entries.delete(entry.value.id);
           publish();
         }
-        return { id: entry.value.id, sessionKey, status: "admitted" };
+        return result.status === "admitted"
+          ? { id: entry.value.id, sessionKey: result.sessionKey, status: "admitted" }
+          : { id: entry.value.id, status: "revision-changed" };
       })
       .catch((error: unknown): SkillWorkshopRevisionAdmissionOutcome => {
-        if (readSkillProposalRevisionChangedError(error)) {
-          if (entries.get(entry.value.id) === entry && entry.generation === generation) {
-            entries.delete(entry.value.id);
-            publish();
-          }
-          return { id: entry.value.id, status: "revision-changed" };
-        }
         const message = error instanceof Error ? error.message : String(error);
         if (entries.get(entry.value.id) === entry && entry.generation === generation) {
           entry.value = { ...entry.value, error: message, phase: "retryable-failed" };

--- a/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
@@ -309,11 +309,10 @@ suite.define(() => {
         sessionKey: "main",
       });
       expect(await gateway.getRequests("chat.send")).toHaveLength(0);
-      await page.waitForURL(/\/chat(?:[/?#].*)?$/u);
+      await page.waitForURL(/\/skills\/workshop(?:[?#].*)?$/u);
 
       await setProposalRevision(gateway, H2);
       await gateway.rejectDeferred("skills.proposals.requestRevision", staleError);
-      await page.waitForURL(/\/skills\/workshop(?:[?#].*)?$/u);
       await waitForProposalRefresh(page, gateway, listCount, inspectCount);
       expect(await gateway.getRequests("skills.proposals.requestRevision")).toHaveLength(
         revisionCount + 1,
@@ -369,8 +368,7 @@ suite.define(() => {
         runId,
         status: "started",
       });
-      await gateway.emitChatFinal({ runId, sessionKey: "main", text: "H2 revision started." });
-      await page.locator("p").getByText("H2 revision started.", { exact: true }).waitFor();
+      await page.waitForURL(/\/chat(?:[/?#].*)?$/u);
       expect(await gateway.getRequests("skills.proposals.requestRevision")).toHaveLength(
         secondRevisionCount + 1,
       );

--- a/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
@@ -1,0 +1,381 @@
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import type { BrowserContext, Page } from "playwright";
+import { beforeAll, expect, it } from "vitest";
+import {
+  defaultControlUiFeatureMethods,
+  installMockGateway,
+  type MockGatewayControls,
+  type MockGatewayRequest,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Skill Workshop proposal revision integrity mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
+const artifactDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "skill-workshop-revision-integrity",
+);
+const viewport = { height: 900, width: 1280 };
+const PROPOSAL_ID = "revision-integrity-proposal";
+const SKILL_KEY = "revision-integrity";
+const H1_HASH = "1".repeat(64);
+const H2_HASH = "2".repeat(64);
+const H1 = {
+  body: "Reviewed H1 draft.",
+  hash: H1_HASH,
+  updatedAt: "2026-08-18T10:00:00.000Z",
+  version: "v1",
+};
+const H2 = {
+  body: "Updated H2 draft requires a new review.",
+  hash: H2_HASH,
+  updatedAt: "2026-08-18T10:01:00.000Z",
+  version: "v2",
+};
+const staleMessage = /Proposal changed\. Review the updated draft/i;
+const staleError = {
+  code: "INVALID_REQUEST",
+  message: "Skill proposal revision changed.",
+  details: {
+    code: "SKILL_PROPOSAL_REVISION_CHANGED",
+    expectedRevisionHash: H1_HASH,
+    currentRevisionHash: H2_HASH,
+  },
+};
+
+type ProposalRevision = typeof H1;
+type ProposalStatus = "pending" | "applied" | "rejected";
+
+const workshopFeatureMethods = [
+  ...defaultControlUiFeatureMethods,
+  "sessions.list",
+  "skills.proposals.apply",
+  "skills.proposals.inspect",
+  "skills.proposals.list",
+  "skills.proposals.reject",
+  "skills.proposals.requestRevision",
+];
+
+function proposalManifest(revision: ProposalRevision, status: ProposalStatus = "pending") {
+  return {
+    schema: "openclaw.skill-workshop.proposals-manifest.v1",
+    updatedAt: revision.updatedAt,
+    proposals: [
+      {
+        id: PROPOSAL_ID,
+        kind: "create",
+        status,
+        title: "Revision integrity proposal",
+        description: "Protect proposal decision integrity.",
+        skillName: "Revision Integrity",
+        skillKey: SKILL_KEY,
+        createdAt: H1.updatedAt,
+        updatedAt: revision.updatedAt,
+        scanState: "clean",
+      },
+    ],
+  };
+}
+
+function proposalInspect(revision: ProposalRevision, status: ProposalStatus = "pending") {
+  return {
+    record: {
+      id: PROPOSAL_ID,
+      kind: "create",
+      status,
+      title: "Revision integrity proposal",
+      description: "Protect proposal decision integrity.",
+      createdAt: H1.updatedAt,
+      updatedAt: revision.updatedAt,
+      proposedVersion: revision.version,
+      draftHash: "d".repeat(64),
+      origin: { agentId: "main", sessionKey: "main" },
+      target: { skillName: "Revision Integrity", skillKey: SKILL_KEY },
+    },
+    revisionHash: revision.hash,
+    content: `# Revision Integrity\n\n${revision.body}`,
+    supportFiles: [],
+  };
+}
+
+function requestParams(request: MockGatewayRequest): Record<string, unknown> {
+  if (!request.params || typeof request.params !== "object" || Array.isArray(request.params)) {
+    throw new Error(`Expected object params for ${request.method}`);
+  }
+  return request.params as Record<string, unknown>;
+}
+
+async function setProposalRevision(
+  gateway: MockGatewayControls,
+  revision: ProposalRevision,
+  status: ProposalStatus = "pending",
+): Promise<void> {
+  await gateway.setMethodResponse("skills.proposals.list", proposalManifest(revision, status));
+  await gateway.setMethodResponse("skills.proposals.inspect", proposalInspect(revision, status));
+}
+
+async function openReviewedProposal(page: Page): Promise<MockGatewayControls> {
+  const gateway = await installMockGateway(page, {
+    featureMethods: workshopFeatureMethods,
+    methodResponses: {
+      "skills.proposals.list": proposalManifest(H1),
+      "skills.proposals.inspect": proposalInspect(H1),
+    },
+  });
+  const response = await page.goto(`${suite.server.baseUrl}skills/workshop`);
+  expect(response?.status()).toBe(200);
+  await gateway.waitForRequest("skills.proposals.list");
+  await page.locator("#skill-workshop-mode-tab-board").click();
+  await page.getByText(H1.body, { exact: true }).waitFor();
+  return gateway;
+}
+
+async function waitForProposalRefresh(
+  page: Page,
+  gateway: MockGatewayControls,
+  previousListCount: number,
+  previousInspectCount: number,
+): Promise<void> {
+  await gateway.waitForRequest("skills.proposals.list", { after: previousListCount });
+  await gateway.waitForRequest("skills.proposals.inspect", { after: previousInspectCount });
+  await page.locator("#skill-workshop-mode-tab-board").click();
+  await page.getByText(H2.body, { exact: true }).waitFor();
+  await page.getByText(staleMessage).waitFor();
+}
+
+async function provePersistentStaleOutcome(page: Page): Promise<void> {
+  await page.locator("#skill-workshop-mode-tab-today").click();
+  await page.locator("#skill-workshop-mode-tab-board").click();
+  await page.getByText(staleMessage).waitFor();
+}
+
+async function proveNoReplayAcrossReconnect(
+  page: Page,
+  gateway: MockGatewayControls,
+  method: string,
+  expectedCount: number,
+): Promise<void> {
+  const connectCount = (await gateway.getRequests("connect")).length;
+  await gateway.closeLatest(1006, "revision-integrity-reconnect");
+  await gateway.waitForRequest("connect", { after: connectCount });
+  await page.getByText(H2.body, { exact: true }).waitFor();
+  expect(await gateway.getRequests(method)).toHaveLength(expectedCount);
+}
+
+async function closeProofContext(params: { context: BrowserContext }): Promise<void> {
+  await suite.closeBrowserContext(params.context);
+}
+
+suite.define(() => {
+  beforeAll(async () => {
+    await rm(artifactDir, { force: true, recursive: true });
+    await mkdir(artifactDir, { recursive: true });
+  });
+
+  it.each([
+    {
+      action: "Apply",
+      method: "skills.proposals.apply",
+      status: "applied",
+    },
+    {
+      action: "Reject",
+      method: "skills.proposals.reject",
+      status: "rejected",
+    },
+  ] as const)(
+    "refreshes H2 and requires a second explicit $action after stale H1",
+    async ({ action, method, status }) => {
+      const label = action.toLowerCase();
+      const caseDir = path.join(artifactDir, label);
+      await mkdir(caseDir, { recursive: true });
+      const context = await suite.newBrowserContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport,
+      });
+      const page = await context.newPage();
+      try {
+        const gateway = await openReviewedProposal(page);
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(caseDir, "01-reviewed-h1.png"),
+        });
+
+        const actionCount = (await gateway.getRequests(method)).length;
+        const listCount = (await gateway.getRequests("skills.proposals.list")).length;
+        const inspectCount = (await gateway.getRequests("skills.proposals.inspect")).length;
+        await gateway.deferNext(method, { expectedRevisionHash: H1_HASH });
+        await page.locator(".sw-action-bar").getByRole("button", { name: action }).click();
+
+        const staleRequest = await gateway.waitForRequest(method, { after: actionCount });
+        expect(requestParams(staleRequest)).toEqual({
+          agentId: "main",
+          expectedRevisionHash: H1_HASH,
+          proposalId: PROPOSAL_ID,
+        });
+
+        await setProposalRevision(gateway, H2);
+        await gateway.rejectDeferred(method, staleError);
+        await waitForProposalRefresh(page, gateway, listCount, inspectCount);
+        expect(await gateway.getRequests(method)).toHaveLength(actionCount + 1);
+        await provePersistentStaleOutcome(page);
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(caseDir, "02-stale-h2-review-required.png"),
+        });
+
+        await proveNoReplayAcrossReconnect(page, gateway, method, actionCount + 1);
+
+        const secondActionCount = (await gateway.getRequests(method)).length;
+        const secondListCount = (await gateway.getRequests("skills.proposals.list")).length;
+        const secondInspectCount = (await gateway.getRequests("skills.proposals.inspect")).length;
+        await gateway.deferNext(method, { expectedRevisionHash: H2_HASH });
+        await page.locator(".sw-action-bar").getByRole("button", { name: action }).click();
+        const currentRequest = await gateway.waitForRequest(method, { after: secondActionCount });
+        expect(requestParams(currentRequest)).toEqual({
+          agentId: "main",
+          expectedRevisionHash: H2_HASH,
+          proposalId: PROPOSAL_ID,
+        });
+
+        await setProposalRevision(gateway, H2, status);
+        await gateway.resolveDeferred(method, {});
+        await gateway.waitForRequest("skills.proposals.list", { after: secondListCount });
+        await gateway.waitForRequest("skills.proposals.inspect", { after: secondInspectCount });
+        await page
+          .locator(".sw-lifecycle-tab")
+          .filter({ hasText: status === "applied" ? "Applied" : "Rejected" })
+          .click();
+        await page.getByText(H2.body, { exact: true }).waitFor();
+        expect(await gateway.getRequests(method)).toHaveLength(secondActionCount + 1);
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(caseDir, "03-second-explicit-h2.png"),
+        });
+      } finally {
+        await closeProofContext({ context });
+      }
+    },
+  );
+
+  it("returns a stale natural Revision to H2 without retrying H1", async () => {
+    const caseDir = path.join(artifactDir, "revision");
+    await mkdir(caseDir, { recursive: true });
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport,
+    });
+    const page = await context.newPage();
+    try {
+      const gateway = await openReviewedProposal(page);
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(caseDir, "01-reviewed-h1.png"),
+      });
+
+      await page.locator(".sw-action-bar").getByRole("button", { name: "Revise" }).click();
+      const revisionInput = page.locator(".sw-revision-dialog__input");
+      const instructions = "Preserve the reviewed H1 workflow and tighten its checks.";
+      await revisionInput.fill(instructions);
+      const revisionCount = (await gateway.getRequests("skills.proposals.requestRevision")).length;
+      const listCount = (await gateway.getRequests("skills.proposals.list")).length;
+      const inspectCount = (await gateway.getRequests("skills.proposals.inspect")).length;
+      await gateway.deferNext("skills.proposals.requestRevision", {
+        expectedRevisionHash: H1_HASH,
+      });
+      await page.getByRole("button", { name: "Send revision", exact: true }).click();
+
+      const staleRequest = await gateway.waitForRequest("skills.proposals.requestRevision", {
+        after: revisionCount,
+      });
+      expect(requestParams(staleRequest)).toMatchObject({
+        agentId: "main",
+        expectedRevisionHash: H1_HASH,
+        instructions,
+        proposalId: PROPOSAL_ID,
+        sessionKey: "main",
+      });
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      await page.waitForURL(/\/chat(?:[/?#].*)?$/u);
+
+      await setProposalRevision(gateway, H2);
+      await gateway.rejectDeferred("skills.proposals.requestRevision", staleError);
+      await page.waitForURL(/\/skills\/workshop(?:[?#].*)?$/u);
+      await waitForProposalRefresh(page, gateway, listCount, inspectCount);
+      expect(await gateway.getRequests("skills.proposals.requestRevision")).toHaveLength(
+        revisionCount + 1,
+      );
+      expect(await page.locator(".chat-queue__retry").count()).toBe(0);
+      await provePersistentStaleOutcome(page);
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(caseDir, "02-stale-h2-review-required.png"),
+      });
+
+      await proveNoReplayAcrossReconnect(
+        page,
+        gateway,
+        "skills.proposals.requestRevision",
+        revisionCount + 1,
+      );
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+
+      await page.locator(".sw-action-bar").getByRole("button", { name: "Revise" }).click();
+      const reviewedInstructions = "Revise the newly reviewed H2 draft.";
+      await page.locator(".sw-revision-dialog__input").fill(reviewedInstructions);
+      const secondRevisionCount = (await gateway.getRequests("skills.proposals.requestRevision"))
+        .length;
+      await gateway.deferNext("skills.proposals.requestRevision", {
+        expectedRevisionHash: H2_HASH,
+      });
+      await page.getByRole("button", { name: "Send revision", exact: true }).click();
+      const currentRequest = await gateway.waitForRequest("skills.proposals.requestRevision", {
+        after: secondRevisionCount,
+      });
+      const currentParams = requestParams(currentRequest);
+      expect(currentParams).toMatchObject({
+        agentId: "main",
+        expectedRevisionHash: H2_HASH,
+        instructions: reviewedInstructions,
+        proposalId: PROPOSAL_ID,
+        sessionKey: "main",
+      });
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      await page.screenshot({
+        animations: "disabled",
+        fullPage: true,
+        path: path.join(caseDir, "03-second-explicit-h2.png"),
+      });
+
+      const runId = currentParams.idempotencyKey;
+      if (typeof runId !== "string" || !runId) {
+        throw new Error("Expected the revision request to carry an idempotency key");
+      }
+      await gateway.resolveDeferred("skills.proposals.requestRevision", {
+        runId,
+        status: "started",
+      });
+      await gateway.emitChatFinal({ runId, sessionKey: "main", text: "H2 revision started." });
+      await page.locator("p").getByText("H2 revision started.", { exact: true }).waitFor();
+      expect(await gateway.getRequests("skills.proposals.requestRevision")).toHaveLength(
+        secondRevisionCount + 1,
+      );
+    } finally {
+      await closeProofContext({ context });
+    }
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3570,6 +3570,7 @@ export const en: TranslationMap = {
     },
     notices: {
       applied: "Applied",
+      proposalChanged: "Proposal changed. Review the updated draft before choosing another action.",
       rejected: "Rejected",
       revisionRequested: "Revision requested",
     },

--- a/ui/src/lib/skill-workshop/index.ts
+++ b/ui/src/lib/skill-workshop/index.ts
@@ -97,6 +97,11 @@ export type SkillWorkshopActionNotice = {
   slug: string;
 };
 
+export type SkillWorkshopProposalDecision = {
+  proposalId: string;
+  expectedRevisionHash: string | null;
+};
+
 type SkillWorkshopAppliedRevision = {
   proposal: SkillWorkshopProposal;
   version: number;

--- a/ui/src/pages/skill-workshop/evaluation.browser.test.ts
+++ b/ui/src/pages/skill-workshop/evaluation.browser.test.ts
@@ -144,6 +144,38 @@ function propsFor(mode: SkillWorkshopMode): SkillWorkshopProps {
 }
 
 describe("Skill Workshop evaluation results (browser)", () => {
+  it.each([
+    ["board", "apply", ".sw-action-bar .sw-btn--primary", "onApply"],
+    ["board", "reject", ".sw-action-bar .sw-btn--danger", "onReject"],
+    ["today", "apply", ".sw-today__big--primary", "onApply"],
+    ["today", "reject", ".sw-today__big--skip", "onReject"],
+  ] as const)(
+    "captures the rendered revision when %s %s is chosen",
+    async (mode, _action, selector, callbackName) => {
+      const container = document.createElement("div");
+      const props = propsFor(mode);
+      document.body.append(container);
+
+      try {
+        render(renderSkillWorkshop(props), container);
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        });
+
+        const actionButton = container.querySelector<HTMLButtonElement>(selector);
+        expect(actionButton).toBeInstanceOf(HTMLButtonElement);
+        actionButton?.click();
+        expect(props[callbackName]).toHaveBeenCalledWith({
+          proposalId: "proposal-1",
+          expectedRevisionHash: DRAFT_HASH,
+        });
+      } finally {
+        render(nothing, container);
+        container.remove();
+      }
+    },
+  );
+
   it.each(["board", "today"] as const)(
     "renders attributed completed, error, and block results with an Evaluate command in %s",
     async (mode) => {

--- a/ui/src/pages/skill-workshop/proposals.test.ts
+++ b/ui/src/pages/skill-workshop/proposals.test.ts
@@ -2,6 +2,7 @@
 // Control UI tests cover skill workshop controller behavior.
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type { SkillWorkshopProposal } from "../../lib/skill-workshop/index.ts";
 import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
@@ -21,6 +22,7 @@ type TestRequest = (method: string, payload?: unknown) => Promise<unknown>;
 const ISO_NOW = "2026-06-16T12:00:00.000Z";
 const DRAFT_HASH = "a".repeat(64);
 const REVISION_HASH = "b".repeat(64);
+const UPDATED_REVISION_HASH = "c".repeat(64);
 
 function createFixture(
   overrides: Partial<SkillWorkshopState> = {},
@@ -135,6 +137,10 @@ function proposal(overrides: Partial<SkillWorkshopProposal> = {}): SkillWorkshop
   };
 }
 
+function proposalDecision(expectedRevisionHash: string | null = REVISION_HASH) {
+  return { proposalId: "proposal-1", expectedRevisionHash };
+}
+
 function clearNoticeTimer(state: SkillWorkshopState): void {
   if (state.skillWorkshopActionNoticeTimer) {
     globalThis.clearTimeout(state.skillWorkshopActionNoticeTimer);
@@ -158,7 +164,7 @@ describe("Skill Workshop proposal RPCs", () => {
       },
     );
 
-    await runSkillWorkshopLifecycleAction(state, context, "apply", "proposal-1");
+    await runSkillWorkshopLifecycleAction(state, context, "apply", proposalDecision());
     await expect(runSkillWorkshopEvaluation(state, context, "proposal-1")).resolves.toBe(false);
     await expect(requestSkillWorkshopRevision(state, context, "proposal-1", vi.fn())).resolves.toBe(
       null,
@@ -292,13 +298,14 @@ describe("Skill Workshop proposal RPCs", () => {
       });
 
       try {
-        await runSkillWorkshopLifecycleAction(state, context, action, "proposal-1");
+        await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision());
       } finally {
         clearNoticeTimer(state);
       }
 
       expect(request).toHaveBeenNthCalledWith(1, method, {
         agentId: "reviewer",
+        expectedRevisionHash: REVISION_HASH,
         proposalId: "proposal-1",
       });
       expect(request).toHaveBeenNthCalledWith(2, "skills.proposals.list", {
@@ -308,6 +315,132 @@ describe("Skill Workshop proposal RPCs", () => {
         agentId: "reviewer",
         proposalId: "proposal-1",
       });
+    },
+  );
+
+  it.each(["apply", "reject"] as const)(
+    "%s refuses to act without the reviewed revision hash",
+    async (action) => {
+      const method = `skills.proposals.${action}`;
+      const { state, context, request } = createFixture(
+        { skillWorkshopProposals: [proposal({ revisionHash: null })] },
+        {},
+        [method],
+      );
+
+      await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision(null));
+
+      expect(request).not.toHaveBeenCalled();
+      expect(state.skillWorkshopError).toBe(
+        "The current proposal revision could not be identified.",
+      );
+    },
+  );
+
+  it.each([
+    ["apply", "skills.proposals.apply"],
+    ["reject", "skills.proposals.reject"],
+  ] as const)(
+    "%s refreshes a changed proposal without replaying the stale decision",
+    async (action, method) => {
+      const updatedAt = "2026-06-16T12:01:00.000Z";
+      const updatedManifest = manifest();
+      updatedManifest.updatedAt = updatedAt;
+      updatedManifest.proposals[0] = {
+        ...updatedManifest.proposals[0]!,
+        description: "Clean inbox triage with an explicit archive review",
+        updatedAt,
+      };
+      const updatedInspect = inspectResult();
+      updatedInspect.record = {
+        ...updatedInspect.record,
+        description: "Clean inbox triage with an explicit archive review",
+        proposedVersion: "v2",
+        updatedAt,
+      };
+      updatedInspect.revisionHash = UPDATED_REVISION_HASH;
+      updatedInspect.content = "Review unread mail, confirm archive candidates, then archive.";
+      const { state, context, request } = createFixture(
+        {
+          skillWorkshopAgentId: "reviewer",
+          skillWorkshopProposals: [proposal()],
+          skillWorkshopSelectedKey: "proposal-1",
+        },
+        { assistantAgentId: "reviewer" },
+        [method, "skills.proposals.list", "skills.proposals.inspect"],
+      );
+      let stale = true;
+      request.mockImplementation(async (calledMethod: string) => {
+        if (calledMethod === method) {
+          if (stale) {
+            stale = false;
+            throw new GatewayRequestError({
+              code: "INVALID_REQUEST",
+              message: "Skill proposal revision changed",
+              details: {
+                code: "SKILL_PROPOSAL_REVISION_CHANGED",
+                currentRevisionHash: UPDATED_REVISION_HASH,
+                expectedRevisionHash: REVISION_HASH,
+              },
+            });
+          }
+          return {};
+        }
+        if (calledMethod === "skills.proposals.list") {
+          return updatedManifest;
+        }
+        if (calledMethod === "skills.proposals.inspect") {
+          return updatedInspect;
+        }
+        return {};
+      });
+
+      await runSkillWorkshopLifecycleAction(state, context, action, proposalDecision());
+
+      const actionCalls = () =>
+        request.mock.calls.filter(([calledMethod]) => calledMethod === method);
+      expect(actionCalls()).toEqual([
+        [
+          method,
+          {
+            agentId: "reviewer",
+            expectedRevisionHash: REVISION_HASH,
+            proposalId: "proposal-1",
+          },
+        ],
+      ]);
+      expect(state.skillWorkshopProposals[0]).toMatchObject({
+        body: "Review unread mail, confirm archive candidates, then archive.",
+        revisionHash: UPDATED_REVISION_HASH,
+        version: 2,
+      });
+      expect(state.skillWorkshopActionNotice).toMatchObject({
+        key: "proposal-1",
+        label: "Proposal changed. Review the updated draft before choosing another action.",
+      });
+      expect(state.skillWorkshopActionNoticeTimer).toBeNull();
+      expect(state.skillWorkshopError).toBeNull();
+
+      try {
+        await runSkillWorkshopLifecycleAction(
+          state,
+          context,
+          action,
+          proposalDecision(UPDATED_REVISION_HASH),
+        );
+      } finally {
+        clearNoticeTimer(state);
+      }
+
+      expect(actionCalls()).toHaveLength(2);
+      expect(actionCalls()[1]).toEqual([
+        method,
+        {
+          agentId: "reviewer",
+          expectedRevisionHash: UPDATED_REVISION_HASH,
+          proposalId: "proposal-1",
+        },
+      ]);
     },
   );
 

--- a/ui/src/pages/skill-workshop/proposals.ts
+++ b/ui/src/pages/skill-workshop/proposals.ts
@@ -1,4 +1,5 @@
 // Control UI controller manages skill workshop gateway state.
+import { readSkillProposalRevisionChangedError } from "@openclaw/gateway-protocol";
 import type { AgentSelectionCapability } from "../../app/agent-selection.ts";
 import type { ApplicationGateway } from "../../app/context.ts";
 import type { SkillWorkshopRevisionAdmissionOutcome } from "../../app/skill-workshop-revision-admissions.ts";
@@ -14,6 +15,7 @@ import {
   findSkillWorkshopAppliedPredecessor,
   type SkillWorkshopAction,
   type SkillWorkshopProposal,
+  type SkillWorkshopProposalDecision,
   type SkillWorkshopProposalStatus,
 } from "../../lib/skill-workshop/index.ts";
 import {
@@ -107,6 +109,7 @@ function showActionNotice(
   state: SkillWorkshopState,
   proposal: SkillWorkshopProposal | undefined,
   label: string,
+  options?: { persistent?: boolean },
 ): void {
   if (!proposal) {
     return;
@@ -117,6 +120,9 @@ function showActionNotice(
     label,
     slug: proposal.slug || proposal.name,
   };
+  if (options?.persistent) {
+    return;
+  }
   state.skillWorkshopActionNoticeTimer = globalThis.setTimeout(() => {
     if (state.skillWorkshopActionNotice?.key === proposal.key) {
       state.skillWorkshopActionNotice = null;
@@ -360,12 +366,26 @@ async function refreshAfterMutation(
   await loadSkillWorkshopProposalDetail(state, context, proposalId, { force: true });
 }
 
+export function markSkillWorkshopRevisionChanged(
+  state: SkillWorkshopState,
+  proposalId: string,
+  fallback?: SkillWorkshopProposal,
+): void {
+  showActionNotice(
+    state,
+    state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId) ?? fallback,
+    t("skillWorkshop.notices.proposalChanged"),
+    { persistent: true },
+  );
+}
+
 export async function runSkillWorkshopLifecycleAction(
   state: SkillWorkshopState,
   context: SkillWorkshopContext,
   action: Extract<SkillWorkshopAction, "apply" | "reject">,
-  proposalId: string,
+  decision: SkillWorkshopProposalDecision,
 ): Promise<void> {
+  const { proposalId, expectedRevisionHash } = decision;
   const method = action === "apply" ? "skills.proposals.apply" : "skills.proposals.reject";
   if (!canCallGatewayMethod(context.gateway.snapshot, method, "operator.admin")) {
     return;
@@ -376,11 +396,21 @@ export async function runSkillWorkshopLifecycleAction(
     return;
   }
   const previous = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
+  if (!expectedRevisionHash) {
+    clearActionNoticeTimer(state);
+    state.skillWorkshopActionNotice = null;
+    state.skillWorkshopError = t("skillWorkshop.evaluation.errors.revisionHashUnavailable");
+    return;
+  }
   state.skillWorkshopActionBusy = { key: proposalId, action };
   state.skillWorkshopActionNotice = null;
   state.skillWorkshopError = null;
   try {
-    const requestParams = { ...loadedSkillWorkshopAgentParams(state, context), proposalId };
+    const requestParams = {
+      ...loadedSkillWorkshopAgentParams(state, context),
+      proposalId,
+      expectedRevisionHash,
+    };
     await client.request(method, requestParams);
     await refreshAfterMutation(state, context, proposalId);
     const updated = state.skillWorkshopProposals.find((proposal) => proposal.key === proposalId);
@@ -390,7 +420,12 @@ export async function runSkillWorkshopLifecycleAction(
       t(action === "apply" ? "skillWorkshop.notices.applied" : "skillWorkshop.notices.rejected"),
     );
   } catch (err) {
-    state.skillWorkshopError = formatUiError(err);
+    if (readSkillProposalRevisionChangedError(err)) {
+      await refreshAfterMutation(state, context, proposalId);
+      markSkillWorkshopRevisionChanged(state, proposalId, previous);
+    } else {
+      state.skillWorkshopError = formatUiError(err);
+    }
   } finally {
     if (
       state.skillWorkshopActionBusy?.key === proposalId &&
@@ -534,6 +569,15 @@ export async function requestSkillWorkshopRevision(
       proposalAgentId,
       currentProposal.revisionHash ?? undefined,
     );
+    if (outcome.status === "revision-changed") {
+      if (isCurrent() && state.skillWorkshopAgentId === proposalAgentId) {
+        await refreshAfterMutation(state, context, proposalId);
+        state.skillWorkshopRevisionKey = null;
+        state.skillWorkshopRevisionDraft = "";
+        markSkillWorkshopRevisionChanged(state, proposalId, proposal);
+      }
+      return outcome;
+    }
     if (outcome.status === "retryable-failed") {
       if (isCurrent() && state.skillWorkshopAgentId === proposalAgentId) {
         state.skillWorkshopError = t("skillWorkshop.revision.notAdmitted", {

--- a/ui/src/pages/skill-workshop/proposals.ts
+++ b/ui/src/pages/skill-workshop/proposals.ts
@@ -366,7 +366,7 @@ async function refreshAfterMutation(
   await loadSkillWorkshopProposalDetail(state, context, proposalId, { force: true });
 }
 
-export function markSkillWorkshopRevisionChanged(
+function markSkillWorkshopRevisionChanged(
   state: SkillWorkshopState,
   proposalId: string,
   fallback?: SkillWorkshopProposal,

--- a/ui/src/pages/skill-workshop/revision-admission.ts
+++ b/ui/src/pages/skill-workshop/revision-admission.ts
@@ -1,3 +1,4 @@
+import { readSkillProposalRevisionChangedError } from "@openclaw/gateway-protocol";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import type {
   SkillWorkshopRevisionAdmissionBinding,
@@ -13,7 +14,7 @@ export async function requestSkillWorkshopRevisionAdmission(params: {
   materialize: (
     binding: SkillWorkshopRevisionAdmissionBinding,
   ) => SkillWorkshopRevisionAdmissionEntry | null;
-}): Promise<{ sessionKey: string }> {
+}) {
   const source = params.context.gateway.snapshot;
   const client = source.client;
   if (!client) {
@@ -56,20 +57,31 @@ export async function requestSkillWorkshopRevisionAdmission(params: {
   if (!target) {
     throw new Error("Revision request was interrupted before admission.");
   }
-  const result = await client.request<{
-    status: "started" | "in_flight" | "ok" | "timeout" | "error";
-  }>("skills.proposals.requestRevision", {
-    agentId: normalizeAgentId(entry.proposalOriginAgentId ?? entry.proposalAgentId),
-    targetAgentId: target.targetAgentId,
-    proposalId: entry.proposalId,
-    expectedRevisionHash: entry.expectedRevisionHash,
-    instructions: entry.instructions,
-    sessionKey: target.sessionKey,
-    ...(target.sessionId ? { sessionId: target.sessionId } : {}),
-    idempotencyKey: entry.idempotencyKey,
-  });
+  const result = await client
+    .request<{ status: "started" | "in_flight" | "ok" | "timeout" | "error" }>(
+      "skills.proposals.requestRevision",
+      {
+        agentId: normalizeAgentId(entry.proposalOriginAgentId ?? entry.proposalAgentId),
+        targetAgentId: target.targetAgentId,
+        proposalId: entry.proposalId,
+        expectedRevisionHash: entry.expectedRevisionHash,
+        instructions: entry.instructions,
+        sessionKey: target.sessionKey,
+        ...(target.sessionId ? { sessionId: target.sessionId } : {}),
+        idempotencyKey: entry.idempotencyKey,
+      },
+    )
+    .catch((error: unknown) => {
+      if (readSkillProposalRevisionChangedError(error)) {
+        return { status: "revision-changed" as const };
+      }
+      throw error;
+    });
+  if (result.status === "revision-changed") {
+    return result;
+  }
   if (result.status !== "started" && result.status !== "in_flight" && result.status !== "ok") {
     throw new Error(`Gateway returned ${result.status} before admitting the revision request.`);
   }
-  return { sessionKey: target.sessionKey };
+  return { sessionKey: target.sessionKey, status: "admitted" as const };
 }

--- a/ui/src/pages/skill-workshop/skill-workshop-page.ts
+++ b/ui/src/pages/skill-workshop/skill-workshop-page.ts
@@ -193,13 +193,13 @@ function renderSkillWorkshopPage(
               },
               onPrev: () => selectRelativeProposal(-1),
               onNext: () => selectRelativeProposal(1),
-              onApply: (key) => {
+              onApply: (decision) => {
                 if (
                   !canCallWorkshopAdminMethod(context.gateway.snapshot, "skills.proposals.apply")
                 ) {
                   return;
                 }
-                void runSkillWorkshopLifecycleAction(state, context, "apply", key).finally(
+                void runSkillWorkshopLifecycleAction(state, context, "apply", decision).finally(
                   requestUpdate,
                 );
                 requestUpdate();
@@ -226,13 +226,13 @@ function renderSkillWorkshopPage(
                 state.skillWorkshopRevisionDraft = "";
                 requestUpdate();
               },
-              onReject: (key) => {
+              onReject: (decision) => {
                 if (
                   !canCallWorkshopAdminMethod(context.gateway.snapshot, "skills.proposals.reject")
                 ) {
                   return;
                 }
-                void runSkillWorkshopLifecycleAction(state, context, "reject", key).finally(
+                void runSkillWorkshopLifecycleAction(state, context, "reject", decision).finally(
                   requestUpdate,
                 );
                 requestUpdate();

--- a/ui/src/pages/skill-workshop/view-types.ts
+++ b/ui/src/pages/skill-workshop/view-types.ts
@@ -4,6 +4,7 @@ import type {
   SkillWorkshopAppliedDiffMode,
   SkillWorkshopMode,
   SkillWorkshopProposal,
+  SkillWorkshopProposalDecision,
   SkillWorkshopStatusFilter,
 } from "../../lib/skill-workshop/index.ts";
 import type { SkillWorkshopAccess } from "./access.ts";
@@ -44,10 +45,10 @@ export type SkillWorkshopProps = {
   onAppliedDiffModeChange: (mode: SkillWorkshopAppliedDiffMode) => void;
   onPrev: () => void;
   onNext: () => void;
-  onApply: (key: string) => void;
+  onApply: (decision: SkillWorkshopProposalDecision) => void;
   onEvaluate: (key: string) => void;
   onRevise: (key: string) => void;
-  onReject: (key: string) => void;
+  onReject: (decision: SkillWorkshopProposalDecision) => void;
   onRevisionDraftChange: (draft: string) => void;
   onRevisionCancel: () => void;
   onRevisionSubmit: (key: string) => void;

--- a/ui/src/pages/skill-workshop/view.ts
+++ b/ui/src/pages/skill-workshop/view.ts
@@ -20,6 +20,7 @@ import {
   type SkillWorkshopEvaluationFinding,
   type SkillWorkshopEvaluationOutcome,
   type SkillWorkshopProposal,
+  type SkillWorkshopProposalDecision,
   type SkillWorkshopStatusFilter,
 } from "../../lib/skill-workshop/index.ts";
 import {
@@ -475,6 +476,13 @@ function renderActionNotice(notice: SkillWorkshopActionNotice) {
   `;
 }
 
+function proposalDecision(proposal: SkillWorkshopProposal): SkillWorkshopProposalDecision {
+  return {
+    proposalId: proposal.key,
+    expectedRevisionHash: proposal.revisionHash,
+  };
+}
+
 function renderPendingActions(props: SkillWorkshopProps, proposal: SkillWorkshopProposal) {
   const busy = props.actionBusy?.key === proposal.key ? props.actionBusy.action : null;
   const disabled = Boolean(props.actionBusy);
@@ -492,7 +500,7 @@ function renderPendingActions(props: SkillWorkshopProps, proposal: SkillWorkshop
       <button
         class="sw-btn sw-btn--primary ${busy === "apply" ? "is-busy" : ""}"
         ?disabled=${disabled || !props.access.canApply}
-        @click=${() => props.onApply(proposal.key)}
+        @click=${() => props.onApply(proposalDecision(proposal))}
       >
         ${busy === "apply" ? t("skillWorkshop.actions.applying") : t("skillWorkshop.actions.apply")}
       </button>
@@ -508,7 +516,7 @@ function renderPendingActions(props: SkillWorkshopProps, proposal: SkillWorkshop
       <button
         class="sw-btn sw-btn--ghost sw-btn--danger ${busy === "reject" ? "is-busy" : ""}"
         ?disabled=${disabled || !props.access.canReject}
-        @click=${() => props.onReject(proposal.key)}
+        @click=${() => props.onReject(proposalDecision(proposal))}
       >
         ${busy === "reject"
           ? t("skillWorkshop.actions.rejecting")
@@ -646,7 +654,7 @@ function renderToday(
                 <button
                   class="sw-today__big sw-today__big--primary ${busy === "apply" ? "is-busy" : ""}"
                   ?disabled=${disabled || !props.access.canApply}
-                  @click=${() => props.onApply(hero.key)}
+                  @click=${() => props.onApply(proposalDecision(hero))}
                 >
                   ${busy === "apply"
                     ? t("skillWorkshop.actions.applying")
@@ -666,7 +674,7 @@ function renderToday(
                 <button
                   class="sw-today__big sw-today__big--skip ${busy === "reject" ? "is-busy" : ""}"
                   ?disabled=${disabled || !props.access.canReject}
-                  @click=${() => props.onReject(hero.key)}
+                  @click=${() => props.onReject(proposalDecision(hero))}
                 >
                   ${busy === "reject"
                     ? t("skillWorkshop.today.skipping")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators could review Skill Workshop proposal revision H1, but Apply, Reject, or natural-language Revision would act on a concurrently loaded H2 because the reviewed `revisionHash` was dropped by client and handoff paths.

This is an operator-decision integrity failure: the mutation could be validly authorized but target content the operator never reviewed.

## Why This Change Was Made

Every operator decision now carries the exact reviewed revision hash through the Control UI, revision queue, Gateway RPC, CLI, iOS, embedded runtime, and CLI-backed MCP runtime. Apply, Reject, and natural-language Revision require the hash at the protocol boundary.

A stale decision returns structured `SKILL_PROPOSAL_REVISION_CHANGED` details, refreshes H2, removes the stale queued action without replay, and requires a new explicit review/action. Cross-agent revision runs retain the proposal owner's workspace and run with only the bound `skill_workshop` tool. Authorization scopes and protocol version remain unchanged.

AI-assisted implementation; the final diff was independently autoreviewed.

### Review disposition

- **Protocol transition:** no protocol-version bump. The `expectedRevisionHash` proposal contract was introduced in `14940edf15f` and is reachable only from beta/release-publish tags (`v2026.7.2-beta.6`, `v2026.7.2-beta.7`, `v2026.8.1-beta.1`, `v2026.8.1-beta.2`), not a stable release tag. Repository compatibility policy explicitly permits removing/tightening beta-only contracts. Existing clients are updated and generated together here; an omitted review hash fails closed rather than permitting an unreviewed decision.
- **Direct `skills.proposals.revise`:** intentionally remains optional. It is the direct controller/tool mutation RPC, not the operator natural-language Revision decision. Natural-language Revision is hard-bound through `skills.proposals.requestRevision` and the private run/tool constraint.
- **CLI credential expectation:** already updated in `src/cli/skills-cli.workshop-cache.test.ts` to expect `skills.proposals.inspect`; the reviewed finding refers to the superseded `health` expectation.

## User Impact

Operators can trust that Apply, Reject, and Revision affect exactly the proposal revision they inspected. If another revision arrives concurrently, OpenClaw shows the updated draft and asks for re-review instead of silently acting on it.

### Visual evidence

**Apply: reviewed H1**

![Reviewed H1 before Apply](https://github.com/user-attachments/assets/ee1af1f6-7a40-478c-a732-d0bc4319ac29)

**Apply: stale H1 rejected, refreshed H2 requires review**

![Updated H2 after stale Apply](https://github.com/user-attachments/assets/898cc14f-5c45-4722-b8c2-cd5555c3c736)

**Natural-language Revision: reviewed H1**

![Reviewed H1 before Revision](https://github.com/user-attachments/assets/9719b3c5-cf79-4bb6-afe2-d6e8cef32b24)

**Natural-language Revision: stale H1 rejected, refreshed H2 requires review**

![Updated H2 after stale Revision](https://github.com/user-attachments/assets/0e4e873f-e9fb-42f5-a602-2b3b303f37b2)

## Evidence

Focused behavior and contract proof:

- Protocol request and structured-error schema tests passed.
- Gateway proposal tests: 17 passed, including stale Apply/Reject/Revision and no agent start.
- Service concurrency tests: 21 passed.
- Embedded and CLI-backed revision constraint tests passed, including owner-workspace binding and stale H3 rejection.
- CLI Apply tests: 5 passed.
- Control UI controller/chat/page tests: 359 passed across focused files.
- Mocked real-Chromium concurrent revision E2E: 3 passed; Apply, Reject, and Revision each prove H1 request, H2 refresh, no replay across reconnect, and a second explicit H2 action.
- iOS `RootTabsPresentationTests`: 67 passed.
- Generated Swift/Kotlin protocol checks passed.
- `pnpm build` passed with Control UI performance budgets green.
- Final `autoreview --mode uncommitted`: clean, no accepted/actionable findings.

The broad changed gate passed formatting, guards, dead-export checks, all TypeScript typecheck lanes, core/UI/scripts/Swift lint, and task-owned tests. The local macOS aggregate gate was blocked only by the unrelated `test/scripts/mac-elevation-host.test.ts` no-output hang; all six sibling packaging/tooling tests passed individually and the hang is under separate investigation.

Exact-head CI exposed a temporary red-main Plugin SDK docs-contract drift introduced by #126132. Current `main` now contains the equivalent wording repair, so the credited docs-only commit was dropped during rebase; #126152 retains its separate cloud-doc contract work.

Production LOC: +570/-153 (net +417) | Tests: +1180/-24 | Generated protocol: +58/-2 | Native i18n inventory: +11


