### PR TITLE
fix: prevent Skill Workshop context overflow on small models

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3819,7 +3819,6 @@ src/skills/runtime/remote-skills.ts	1
 src/skills/runtime/session-snapshot.ts	1
 src/skills/security/clawhub-verdicts.ts	2
 src/skills/workshop/experience-review.ts	2
-src/skills/workshop/history-scan-transcript.ts	1
 src/skills/workshop/history-scan.ts	2
 src/skills/workshop/policy.ts	1
 src/skills/workshop/store-record.ts	3

--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -262,7 +262,7 @@ and paths outside the standard support folders.
 ## Agent tool
 
 The model uses `skill_workshop` with one required `action`:
-`create | read | patch | update | revise | list | inspect | evaluate | apply | reject | quarantine`.
+`create | read | patch | update | revise | list | inspect | evaluate | apply | reject | quarantine | history | restore_collection`.
 Other parameters apply depending on the action:
 
 | Parameter                  | Used by                                                          | Notes                                                                |
@@ -275,10 +275,18 @@ Other parameters apply depending on the action:
 | `support_files`            | `create`, `update`, `revise`                                     | Array of `{ path, content }`                                         |
 | `goal`, `evidence`         | `create`, `update`, `revise`                                     | Free-text context                                                    |
 | `proposal_id`              | `inspect`, `revise`, `evaluate`, `apply`, `reject`, `quarantine` | Target proposal                                                      |
+| `artifact_path`            | `inspect`                                                        | `PROPOSAL.md` or one listed support-file path                        |
 | `expected_revision_hash`   | `evaluate`, `apply`, `reject`, `quarantine`                      | Rejects a stale orchestration step                                   |
 | `correlation_id`           | `evaluate`, `revise`, `apply`, `reject`, `quarantine`            | External run or experiment correlation                               |
 | `reason`                   | `apply`, `reject`, `quarantine`                                  | Optional                                                             |
 | `query`, `status`, `limit` | `list`                                                           | Filter/paginate; `limit` max 50, default 20                          |
+
+`inspect` returns proposal metadata, a bounded artifact manifest, and one
+complete artifact when it fits the selected model's context budget. It selects
+`PROPOSAL.md` by default. Set `artifact_path` to read one support file
+separately. When the selected artifact does not fit, the result omits its body,
+reports the original size, and points to smaller per-artifact reads or the
+unbounded operator CLI command shown above.
 
 Agents must use `skill_workshop` for generated skill work and must not create or
 change skill or proposal files directly. This rule is advisory and

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -822,6 +822,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
             hasCurrentInboundAudio: options?.hasCurrentInboundAudio,
             modelProvider: options?.modelProvider,
             modelId: options?.modelId,
+            modelContextWindowTokens: options?.modelContextWindowTokens,
             skillWorkshop: options?.skillWorkshop,
             replyToMode: options?.replyToMode,
             hasRepliedRef: options?.hasRepliedRef,

--- a/src/agents/embedded-agent-runner/run/agent-end-context.ts
+++ b/src/agents/embedded-agent-runner/run/agent-end-context.ts
@@ -24,6 +24,7 @@ export function buildEmbeddedAgentEndContext(params: {
     workspaceDir: run.workspaceDir,
     modelProviderId: run.provider,
     modelId: run.modelId,
+    modelContextWindowTokens: run.contextTokenBudget ?? run.model.contextWindow,
     authProfileId: run.authProfileId,
     skillWorkshopAvailable: params.skillWorkshopAvailable,
     compacted: params.compacted,

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -190,7 +190,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
     modelProvider: attempt.provider,
     modelId: attempt.modelId,
     modelApi: attempt.model.api,
-    modelContextWindowTokens: attempt.model.contextWindow,
+    modelContextWindowTokens: attempt.contextTokenBudget ?? attempt.model.contextWindow,
     modelHasVision: attempt.model.input?.includes("image") ?? false,
     workspaceDir: params.effectiveWorkspace,
     cwd: params.effectiveCwd,
@@ -307,7 +307,7 @@ export function prepareEmbeddedAttemptToolBase(params: {
           },
           modelCompat: extractModelCompat(attempt.model),
           modelApi: attempt.model.api,
-          modelContextWindowTokens: attempt.model.contextWindow,
+          modelContextWindowTokens: attempt.contextTokenBudget ?? attempt.model.contextWindow,
           delegationCapability: attempt.delegationCapability,
           modelAuthMode: resolveModelAuthMode(attempt.model.provider, attempt.config, undefined, {
             workspaceDir: params.effectiveWorkspace,

--- a/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -199,6 +199,23 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(toolSearchControlsCase.toolSearchCatalogRef).toEqual({});
   });
 
+  it("carries the resolved context budget into OpenClaw tool construction", async () => {
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      sessionKey,
+      tempPaths,
+      attemptOverrides: {
+        contextTokenBudget: 1_000_000,
+        disableTools: false,
+      },
+    });
+
+    expect(
+      mockParams(hoisted.createOpenClawCodingToolsMock, 0, "tool construction params")
+        .modelContextWindowTokens,
+    ).toBe(1_000_000);
+  });
+
   it("keeps client tool names out of context engine capability guidance", async () => {
     const contextEngine = createContextEngineBootstrapAndAssemble();
 

--- a/src/agents/harness/agent-end-side-effects.ts
+++ b/src/agents/harness/agent-end-side-effects.ts
@@ -19,6 +19,7 @@ type AgentEndSideEffectsParams = Omit<BaseAgentEndSideEffectsParams, "ctx"> & {
   ctx: BaseAgentEndSideEffectsParams["ctx"] & {
     authProfileId?: string;
     modelIterations?: number;
+    modelContextWindowTokens?: number;
     skillWorkshopAvailable?: boolean;
     compacted?: boolean;
     messageChannel?: string | null;

--- a/src/agents/openclaw-tools.model-context.ts
+++ b/src/agents/openclaw-tools.model-context.ts
@@ -12,6 +12,8 @@ export type ModelAwareToolContext = {
   /** Active provider/model pair used for tool gating. */
   modelProvider?: string;
   modelId?: string;
+  /** Effective context ceiling for selected-model model-visible projections. */
+  modelContextWindowTokens?: number;
   /** Explicit agent ID override for cron and hook sessions. */
   requesterAgentIdOverride?: string;
 };

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -16,7 +16,6 @@ import { resolveWidgetPresenters } from "../plugins/widget-presenters.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
 import { getActiveRuntimeWebToolsMetadataFromState } from "../secrets/runtime-web-tools-state.js";
 import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
-import type { SkillWorkshopRunOptions } from "../skills/workshop/types.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
 import {
@@ -167,8 +166,7 @@ export function createOpenClawTools(
     computerContextEpoch?: { value: number };
     /** Registers run-owned cleanup for tools that hold node resources. */
     registerRunCleanup?: (cleanup: (reason: string) => Promise<void>) => void;
-    /** Internal review-run restrictions and proposal provenance. */
-    skillWorkshop?: SkillWorkshopRunOptions;
+    skillWorkshop?: import("../skills/workshop/types.js").SkillWorkshopRunOptions;
     /** If true, nodes action="invoke" can call media-returning commands directly. */
     allowMediaInvokeCommands?: boolean;
     /** Trusted sender identity bit for channel action auth. */
@@ -593,6 +591,7 @@ export function createOpenClawTools(
             runId: options?.runId,
             messageId: options?.currentMessageId,
             run: options?.skillWorkshop,
+            modelContextWindowTokens: options?.modelContextWindowTokens,
           }),
         ]),
     ...collectPresentOpenClawTools([progressCardTool]),

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -19,6 +19,7 @@ import {
   SESSIONS_SEND_TOOL_DISPLAY_SUMMARY,
   SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY,
   SESSION_STATUS_TOOL_DISPLAY_SUMMARY,
+  SKILL_WORKSHOP_TOOL_DISPLAY_SUMMARY,
   SUGGEST_TASK_TOOL_DISPLAY_SUMMARY,
   DISMISS_TASK_TOOL_DISPLAY_SUMMARY,
 } from "./tool-description-presets.js";
@@ -439,8 +440,7 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
   {
     id: "skill_workshop",
     label: "skill_workshop",
-    description:
-      "Create, update, revise, list, inspect, apply, reject, or quarantine Skill Workshop proposals",
+    description: SKILL_WORKSHOP_TOOL_DISPLAY_SUMMARY,
     sectionId: "agents",
     profiles: ["coding"],
     includeInOpenClawGroup: true,

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -15,6 +15,8 @@ export const SESSION_STATUS_TOOL_DISPLAY_SUMMARY = "Show session status/model/us
 export const ASK_USER_TOOL_DISPLAY_SUMMARY = "Ask the user and wait for an answer.";
 export const SUGGEST_TASK_TOOL_DISPLAY_SUMMARY = "Suggest follow-up work for operator approval.";
 export const DISMISS_TASK_TOOL_DISPLAY_SUMMARY = "Withdraw a pending task suggestion.";
+export const SKILL_WORKSHOP_TOOL_DISPLAY_SUMMARY =
+  "Manage reusable-skill proposals; inspect can select one stored artifact and returns complete content only when it fits the model budget.";
 
 export function describeAgentsListTool(sessionsSpawnAvailable: boolean): string {
   return sessionsSpawnAvailable

--- a/src/agents/tools/skill-workshop-tool-collection.ts
+++ b/src/agents/tools/skill-workshop-tool-collection.ts
@@ -22,7 +22,6 @@ import { readToolStringParam, ToolInputError } from "./common.js";
 
 const SKILL_COLLECTION_HISTORY_REASON_MAX_CHARS = 300;
 const SKILL_COLLECTION_HISTORY_NAME_LIMIT = 10;
-const SKILL_COLLECTION_HISTORY_TEXT_MAX_CHARS = 8_000;
 const SKILL_COLLECTION_HISTORY_TRUNCATION_MARKER = "\n(history truncated)";
 
 function summarizeSkillNames(names: string[]) {
@@ -149,10 +148,13 @@ export async function executeSkillCollectionRestore(params: {
   };
 }
 
-export function executeSkillCollectionHistory(params: {
-  workspaceDir: string;
-  env?: NodeJS.ProcessEnv;
-}) {
+export function executeSkillCollectionHistory(
+  params: {
+    workspaceDir: string;
+    env?: NodeJS.ProcessEnv;
+  },
+  maxChars: number,
+) {
   const outcomes = listSkillCollectionReviewOutcomes(
     params.workspaceDir,
     params.env ? { env: params.env } : {},
@@ -160,8 +162,7 @@ export function executeSkillCollectionHistory(params: {
   const reviews = [];
   let text = "Recent collection reviews, newest first:";
   let truncated = false;
-  const textLimit =
-    SKILL_COLLECTION_HISTORY_TEXT_MAX_CHARS - SKILL_COLLECTION_HISTORY_TRUNCATION_MARKER.length;
+  const textLimit = maxChars - SKILL_COLLECTION_HISTORY_TRUNCATION_MARKER.length;
   for (const outcome of outcomes) {
     const review = {
       createTime: new Date(outcome.createTime).toISOString(),

--- a/src/agents/tools/skill-workshop-tool-description.ts
+++ b/src/agents/tools/skill-workshop-tool-description.ts
@@ -1,4 +1,5 @@
 import { SKILL_AUTHORING_STANDARDS_PROMPT } from "../../skills/workshop/skill-authoring-standards.js";
+import { SKILL_WORKSHOP_TOOL_DISPLAY_SUMMARY } from "../tool-description-presets.js";
 
 export function buildSkillWorkshopToolDescription(params: {
   proposalOnly: boolean;
@@ -8,7 +9,7 @@ export function buildSkillWorkshopToolDescription(params: {
   collectionOnly: boolean;
 }): string {
   if (params.collectionOnly) {
-    return `Read every current writable skill, then replace the collection with one reconcile call. Every current skill needs exactly one keep, write, or drop decision.\n\n${SKILL_AUTHORING_STANDARDS_PROMPT}`;
+    return `${SKILL_WORKSHOP_TOOL_DISPLAY_SUMMARY} Read every current writable skill, then replace the collection with one reconcile call. Every current skill needs exactly one keep, write, or drop decision.\n\n${SKILL_AUTHORING_STANDARDS_PROMPT}`;
   }
   if (!params.proposalOnly) {
     const repairPolicy =
@@ -17,9 +18,9 @@ export function buildSkillWorkshopToolDescription(params: {
         : params.autonomousMode === "propose"
           ? "A foreground patch to a skill used in this run stays pending for review."
           : "A foreground patch to a skill used in this run is scanned and applied immediately.";
-    return `Read, patch, create, update, revise, inspect, evaluate, and apply reusable-procedure skill proposals. Restore the backup retained by the last collection cleanup when the user asks to undo it. ${repairPolicy}\n\n${SKILL_AUTHORING_STANDARDS_PROMPT}`;
+    return `${SKILL_WORKSHOP_TOOL_DISPLAY_SUMMARY} Read, patch, create, update, revise, inspect, evaluate, and apply reusable-procedure skill proposals. Restore the backup retained by the last collection cleanup when the user asks to undo it. ${repairPolicy}\n\n${SKILL_AUTHORING_STANDARDS_PROMPT}`;
   }
   const completion = params.supportsCompletion ? " complete = durably finish this review." : "";
   const draftKinds = params.updateProposals ? "create, update, or revise" : "create or revise";
-  return `Inspect reusable-procedure skill proposals and draft pending ${draftKinds} proposals.${completion} Nothing writes a live skill directly; lifecycle actions are unavailable.\n\n${SKILL_AUTHORING_STANDARDS_PROMPT}`;
+  return `${SKILL_WORKSHOP_TOOL_DISPLAY_SUMMARY} Inspect reusable-procedure skill proposals and draft pending ${draftKinds} proposals.${completion} Nothing writes a live skill directly; lifecycle actions are unavailable.\n\n${SKILL_AUTHORING_STANDARDS_PROMPT}`;
 }

--- a/src/agents/tools/skill-workshop-tool-factory.ts
+++ b/src/agents/tools/skill-workshop-tool-factory.ts
@@ -12,6 +12,7 @@ export function createConfiguredSkillWorkshopTool(params: {
   runId?: string;
   messageId?: string | number;
   run?: SkillWorkshopRunOptions;
+  modelContextWindowTokens?: number;
 }) {
   const sessionKey = normalizeOptionalString(params.sessionKey);
   const runId = normalizeOptionalString(params.runId);
@@ -39,5 +40,6 @@ export function createConfiguredSkillWorkshopTool(params: {
       (params.run?.proposalOnly ? { remaining: 1 } : undefined),
     proposalReviewCompletion: params.run?.proposalReviewCompletion,
     collectionReconcile: params.run?.collectionReconcile,
+    modelContextWindowTokens: params.modelContextWindowTokens,
   });
 }

--- a/src/agents/tools/skill-workshop-tool-helpers.ts
+++ b/src/agents/tools/skill-workshop-tool-helpers.ts
@@ -97,7 +97,15 @@ export function actionResult(
 
 export function proposalResult(
   proposal: SkillProposalReadResult,
-  options: { contentText?: string; includeContent?: boolean } = {},
+  options: {
+    contentText?: string;
+    inspect?: {
+      artifactPath: string;
+      artifactSizeBytes: number;
+      availableArtifacts: Array<{ path: string; sizeBytes: number }>;
+      contentIncluded: boolean;
+    };
+  } = {},
 ) {
   return {
     content: options.contentText ? [{ type: "text" as const, text: options.contentText }] : [],
@@ -115,10 +123,7 @@ export function proposalResult(
       draftHash: proposal.record.draftHash,
       revisionHash: proposal.revisionHash,
       ...(proposal.record.evaluation ? { evaluation: proposal.record.evaluation } : {}),
-      ...(options.includeContent ? { proposalContent: proposal.content } : {}),
-      ...(options.includeContent && proposal.supportFiles
-        ? { supportFiles: proposal.supportFiles }
-        : {}),
+      ...(options.inspect ? { inspect: options.inspect } : {}),
     },
   };
 }

--- a/src/agents/tools/skill-workshop-tool-presentation.ts
+++ b/src/agents/tools/skill-workshop-tool-presentation.ts
@@ -93,18 +93,70 @@ export function formatProposalEvaluation(
     : text;
 }
 
-export function formatProposalInspect(proposal: SkillProposalReadResult): string {
-  const supportFiles =
-    proposal.supportFiles && proposal.supportFiles.length > 0
-      ? [
-          "",
-          "Support files:",
-          ...proposal.supportFiles.flatMap((file) => ["", `--- ${file.path} ---`, file.content]),
-        ]
-      : [];
+type SkillProposalInspectArtifact = {
+  path: string;
+  content: string;
+  sizeBytes: number;
+};
+
+type SkillProposalInspectArtifactMetadata = Omit<SkillProposalInspectArtifact, "content">;
+
+function formatArtifactManifest(
+  artifacts: readonly SkillProposalInspectArtifactMetadata[],
+  maxChars: number,
+): string[] {
+  const lines = [`Artifacts (${artifacts.length}):`];
+  for (const [index, file] of artifacts.entries()) {
+    const line = `- ${file.path} (${file.sizeBytes} bytes)`;
+    if ([...lines, line].join("\n").length > maxChars) {
+      const remaining = artifacts.length - index;
+      const omitted = `- … ${remaining} more artifact${remaining === 1 ? "" : "s"} in result metadata`;
+      if ([...lines, omitted].join("\n").length <= maxChars) {
+        lines.push(omitted);
+      }
+      break;
+    }
+    lines.push(line);
+  }
+  return lines;
+}
+
+export function resolveProposalInspectArtifact(
+  proposal: SkillProposalReadResult,
+  artifactPath?: string,
+): SkillProposalInspectArtifact | undefined {
+  if (!artifactPath || artifactPath === proposal.record.draftFile) {
+    return {
+      path: proposal.record.draftFile,
+      content: proposal.content,
+      sizeBytes: Buffer.byteLength(proposal.content),
+    };
+  }
+  const file = proposal.supportFiles?.find((candidate) => candidate.path === artifactPath);
+  return file
+    ? { path: file.path, content: file.content, sizeBytes: Buffer.byteLength(file.content) }
+    : undefined;
+}
+
+export function formatProposalInspect(
+  proposal: SkillProposalReadResult,
+  artifact: SkillProposalInspectArtifact,
+  maxChars: number,
+): {
+  text: string;
+  contentIncluded: boolean;
+  availableArtifacts: SkillProposalInspectArtifactMetadata[];
+} {
   const evaluation = proposal.record.evaluation;
   const evaluationLines = evaluation ? [formatProposalEvaluation(evaluation)] : [];
-  return [
+  const artifacts = [
+    { path: proposal.record.draftFile, sizeBytes: Buffer.byteLength(proposal.content) },
+    ...(proposal.record.supportFiles ?? []).map((file) => ({
+      path: file.path,
+      sizeBytes: file.sizeBytes,
+    })),
+  ];
+  const prefix = [
     `Proposal: ${proposal.record.id}`,
     `Status: ${proposal.record.status}`,
     `Kind: ${proposal.record.kind}`,
@@ -113,7 +165,28 @@ export function formatProposalInspect(proposal: SkillProposalReadResult): string
     `Scan: ${proposal.record.scan.state}`,
     ...evaluationLines,
     "",
-    proposal.content,
-    ...supportFiles,
-  ].join("\n");
+  ];
+  const suffix = ["", `--- ${artifact.path} ---`, artifact.content];
+  const manifestBudget = maxChars - [...prefix, ...suffix].join("\n").length - 2;
+  const text = [...prefix, ...formatArtifactManifest(artifacts, manifestBudget), ...suffix].join(
+    "\n",
+  );
+  if (text.length <= maxChars) {
+    return { text, contentIncluded: true, availableArtifacts: artifacts };
+  }
+  const safeId = truncateUtf16Safe(proposal.record.id, 80);
+  const safePath = truncateUtf16Safe(artifact.path, 120);
+  const summary = [
+    `Proposal: ${safeId}`,
+    `Selected artifact: ${safePath} (${artifact.sizeBytes} bytes)`,
+    "Content omitted: the complete artifact projection exceeds the selected-model inspect budget.",
+    `Next: inspect a smaller listed artifact with artifact_path, or run openclaw skills workshop inspect ${safeId} for complete operator output.`,
+    "",
+  ];
+  const manifest = formatArtifactManifest(artifacts, maxChars - summary.join("\n").length);
+  return {
+    text: truncateUtf16Safe([...summary, ...manifest].join("\n"), maxChars),
+    contentIncluded: false,
+    availableArtifacts: artifacts,
+  };
 }

--- a/src/agents/tools/skill-workshop-tool-schema.ts
+++ b/src/agents/tools/skill-workshop-tool-schema.ts
@@ -60,7 +60,7 @@ export function buildSkillWorkshopToolSchema(
             : [...SKILL_WORKSHOP_ACTIONS],
         {
           description: proposalOnly
-            ? `create = new skill;${updateProposals ? " patch = targeted find-and-replace on an existing live skill (quote the exact current text in old_string, replacement in new_string; empty old_string appends new_string at the end); read = bounded excerpt of an existing live skill (required before patch or update); update = full-body rewrite of an existing live skill after reading it;" : ""} revise = existing pending proposal; list/inspect discover pending proposals (not filesystem search).${supportsCompletion ? " complete = durably finish this review after all proposal work." : ""} Nothing writes a live skill directly; lifecycle actions are unavailable.`
+            ? `create = new skill;${updateProposals ? " patch = targeted find-and-replace on an existing live skill (quote the exact current text in old_string, replacement in new_string; empty old_string appends new_string at the end); read = complete existing live skill when it fits the selected-model budget, otherwise metadata without a partial body (required before patch or update); update = full-body rewrite of an existing live skill after reading it;" : ""} revise = existing pending proposal; list/inspect discover pending proposals (not filesystem search).${supportsCompletion ? " complete = durably finish this review after all proposal work." : ""} Nothing writes a live skill directly; lifecycle actions are unavailable.`
             : collectionOnly
               ? SKILL_COLLECTION_ACTION_DESCRIPTION
               : "create = new skill; read = existing live skill; patch = targeted find-and-replace after reading; update = full-body rewrite; history = show up to 20 recent collection review outcomes and drop reasons; restore_collection = restore the collection backup retained by the last cleanup; revise = existing pending proposal; list/inspect discover pending proposals (not filesystem search); evaluate runs plugin evaluators for the exact draft; apply/reject/quarantine are explicit lifecycle actions.",
@@ -70,6 +70,12 @@ export function buildSkillWorkshopToolSchema(
         Type.String({
           description:
             "Existing proposal id for action=inspect, action=revise, action=evaluate, action=apply, action=reject, or action=quarantine.",
+        }),
+      ),
+      artifact_path: Type.Optional(
+        Type.String({
+          description:
+            "For action=inspect, select PROPOSAL.md or one listed support-file path. Omit to inspect PROPOSAL.md. Complete content is returned only when the selected artifact projection fits the model budget.",
         }),
       ),
       name: Type.Optional(

--- a/src/agents/tools/skill-workshop-tool.history.test.ts
+++ b/src/agents/tools/skill-workshop-tool.history.test.ts
@@ -84,10 +84,11 @@ describe("skill_workshop collection history", () => {
       );
     }
 
-    const result = await createSkillWorkshopTool({ workspaceDir, env: testState.env }).execute(
-      "history",
-      { action: "history" },
-    );
+    const result = await createSkillWorkshopTool({
+      workspaceDir,
+      env: testState.env,
+      modelContextWindowTokens: 200_000,
+    }).execute("history", { action: "history" });
     const text = result.content[0]?.type === "text" ? result.content[0].text : "";
     const firstTenKept = names("kept", 19).slice(0, 10);
 
@@ -109,6 +110,16 @@ describe("skill_workshop collection history", () => {
     const boundedReviews = (result.details as { reviews: unknown[] }).reviews;
     expect(boundedReviews.length).toBeGreaterThan(0);
     expect(boundedReviews.length).toBeLessThan(20);
+
+    const smallContextResult = await createSkillWorkshopTool({
+      workspaceDir,
+      env: testState.env,
+      modelContextWindowTokens: 8_192,
+    }).execute("history-small", { action: "history" });
+    const smallContextText =
+      smallContextResult.content[0]?.type === "text" ? smallContextResult.content[0].text : "";
+    expect(smallContextText.length).toBeLessThanOrEqual(2_867);
+    expect(smallContextText).toMatch(/\(history truncated\)$/u);
   });
 
   it("keeps isolated collection reviews limited to read and reconcile", () => {

--- a/src/agents/tools/skill-workshop-tool.projection.test.ts
+++ b/src/agents/tools/skill-workshop-tool.projection.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { writeWorkspaceSkills } from "../../skills/test-support/e2e-test-helpers.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+import { createConfiguredSkillWorkshopTool } from "./skill-workshop-tool-factory.js";
+
+const tempDirs = createTrackedTempDirs();
+let testState: OpenClawTestState;
+
+beforeEach(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-skill-workshop-projection-state-",
+  });
+});
+
+afterEach(async () => {
+  await testState.cleanup();
+  await tempDirs.cleanup();
+});
+
+describe("skill_workshop model projection", () => {
+  it.each([
+    {
+      provider: "anthropic",
+      model: "small-context",
+      modelContextWindowTokens: 8_192,
+      maxChars: 2_867,
+      contentIncluded: false,
+    },
+    {
+      provider: "openai",
+      model: "large-context",
+      modelContextWindowTokens: 200_000,
+      maxChars: 20_000,
+      contentIncluded: true,
+    },
+  ])(
+    "projects complete per-artifact inspection for $provider/$model",
+    async ({ modelContextWindowTokens, maxChars, contentIncluded }) => {
+      const workspaceDir = await tempDirs.make("openclaw-skill-workshop-inspect-budget-");
+      const tool = createConfiguredSkillWorkshopTool({
+        workspaceDir,
+        config: {},
+        agentId: "main",
+        modelContextWindowTokens,
+        run: { env: testState.env },
+      });
+      const created = await tool.execute("create-large", {
+        action: "create",
+        name: "large-proposal",
+        description: "Large proposal",
+        proposal_content: `# Large proposal\n\nMODEL_VISIBLE_PROPOSAL_BODY\n${"p".repeat(10_000)}`,
+        support_files: [
+          {
+            path: "references/large.txt",
+            content: `MODEL_VISIBLE_SUPPORT_BODY\n${"s".repeat(10_000)}`,
+          },
+        ],
+      });
+
+      const inspected = await tool.execute("inspect-large", {
+        action: "inspect",
+        proposal_id: (created.details as { id: string }).id,
+      });
+      const text = inspected.content[0]?.type === "text" ? inspected.content[0].text : "";
+
+      expect(text.length).toBeLessThanOrEqual(maxChars);
+      expect(text).toContain("large-proposal");
+      expect(text).toContain("references/large.txt");
+      expect(text.includes("MODEL_VISIBLE_PROPOSAL_BODY")).toBe(contentIncluded);
+      expect(text.includes("Content omitted")).toBe(!contentIncluded);
+      expect(inspected.details).not.toHaveProperty("proposalContent");
+      expect(inspected.details).not.toHaveProperty("supportFiles");
+      expect(inspected.details).toMatchObject({ inspect: { contentIncluded } });
+
+      const support = await tool.execute("inspect-support", {
+        action: "inspect",
+        proposal_id: (created.details as { id: string }).id,
+        artifact_path: "references/large.txt",
+      });
+      const supportText = support.content[0]?.type === "text" ? support.content[0].text : "";
+      expect(supportText.length).toBeLessThanOrEqual(maxChars);
+      expect(supportText.includes("MODEL_VISIBLE_SUPPORT_BODY")).toBe(contentIncluded);
+      expect(supportText).not.toContain("MODEL_VISIBLE_PROPOSAL_BODY");
+      expect(support.details).toMatchObject({
+        inspect: { artifactPath: "references/large.txt", contentIncluded },
+      });
+    },
+  );
+
+  it.each([
+    { modelContextWindowTokens: 8_192, contentIncluded: false },
+    { modelContextWindowTokens: 200_000, contentIncluded: true },
+  ])(
+    "binds collection read receipts to a complete $modelContextWindowTokens-token projection",
+    async ({ modelContextWindowTokens, contentIncluded }) => {
+      const workspaceDir = await tempDirs.make("openclaw-skill-collection-context-read-");
+      await writeWorkspaceSkills(workspaceDir, [
+        {
+          name: "large",
+          description: "Large procedure",
+          body: `MODEL_VISIBLE_SKILL_BODY\n${"x".repeat(10_000)}`,
+        },
+      ]);
+      const tool = createConfiguredSkillWorkshopTool({
+        workspaceDir,
+        config: {},
+        agentId: "main",
+        modelContextWindowTokens,
+        run: {
+          env: testState.env,
+          collectionReconcile: { approvedSkillNames: new Set(["large"]) },
+        },
+      });
+
+      const read = await tool.execute("read", { action: "read", skill_name: "large" });
+      const text = read.content[0]?.type === "text" ? read.content[0].text : "";
+      expect(read.details).toMatchObject({ skillKey: "large", contentIncluded });
+      expect(text.includes("MODEL_VISIBLE_SKILL_BODY")).toBe(contentIncluded);
+      const reconciliation = tool.execute("reconcile", {
+        action: "reconcile",
+        collection: [{ action: "keep", name: "large" }],
+      });
+      if (contentIncluded) {
+        await expect(reconciliation).resolves.toMatchObject({ details: { kept: ["large"] } });
+      } else {
+        await expect(reconciliation).rejects.toThrow("Read every current skill");
+      }
+    },
+  );
+
+  it("keeps a selected small artifact complete when its manifest is oversized", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-skill-workshop-manifest-budget-");
+    const supportFiles = Array.from({ length: 16 }, (_, index) => ({
+      path: `references/${String(index).padStart(2, "0")}-${"x".repeat(140)}.txt`,
+      content: index === 15 ? "SELECTED_SUPPORT_BODY" : `UNSELECTED_SUPPORT_${index}`,
+    }));
+    const tool = createConfiguredSkillWorkshopTool({
+      workspaceDir,
+      config: {},
+      agentId: "main",
+      modelContextWindowTokens: 8_192,
+      run: { env: testState.env },
+    });
+    const created = await tool.execute("create-many", {
+      action: "create",
+      name: "many-artifacts",
+      description: "Many support artifacts",
+      proposal_content: "# Many artifacts\n",
+      support_files: supportFiles,
+    });
+    const selected = supportFiles.at(-1);
+    if (!selected) {
+      throw new Error("expected selected support artifact");
+    }
+
+    const inspected = await tool.execute("inspect-selected", {
+      action: "inspect",
+      proposal_id: (created.details as { id: string }).id,
+      artifact_path: selected.path,
+    });
+    const text = inspected.content[0]?.type === "text" ? inspected.content[0].text : "";
+
+    expect(text.length).toBeLessThanOrEqual(2_867);
+    expect(text).toContain("SELECTED_SUPPORT_BODY");
+    expect(text).not.toContain("UNSELECTED_SUPPORT_0");
+    expect(text).toContain("more artifacts in result metadata");
+    expect(inspected.details).toMatchObject({ inspect: { contentIncluded: true } });
+  });
+});

--- a/src/agents/tools/skill-workshop-tool.review.test.ts
+++ b/src/agents/tools/skill-workshop-tool.review.test.ts
@@ -316,15 +316,17 @@ describe("skill_workshop review mode", () => {
       proposalOnly: true,
       updateProposals: true,
       proposalMutationBudget: { remaining: 1 },
+      modelContextWindowTokens: 200_000,
     });
     const read = await reviewTool.execute("review-read", {
       action: "read",
       skill_name: "big-skill",
     });
     const text = (read.content[0] as { text: string }).text;
-    expect(read.details).toMatchObject({ skillKey: "big-skill", truncated: true });
-    expect(text.length).toBeLessThanOrEqual(20_000 + 100);
-    expect(text).toContain("[truncated: skill exceeds the Workshop read budget]");
+    expect(read.details).toMatchObject({ skillKey: "big-skill", contentIncluded: false });
+    expect(text.length).toBeLessThanOrEqual(20_000);
+    expect(text).toContain("Content omitted");
+    expect(text).not.toContain("A detailed operational line.");
 
     await expect(
       reviewTool.execute("oversized-patch", {

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../../test-utils/openclaw-test-state.js";
 import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
 import { createOpenClawTools } from "../openclaw-tools.js";
+import { listCoreToolSections } from "../tool-catalog.js";
 import { createSkillWorkshopTool } from "./skill-workshop-tool.js";
 
 const tempDirs = createTrackedTempDirs();
@@ -41,7 +42,7 @@ afterEach(async () => {
 
 describe("skill_workshop tool", () => {
   it("gives an isolated collection review only read and reconcile", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-skill-collection-tool-");
+    const workspaceDir = await fs.realpath(await tempDirs.make("openclaw-skill-collection-tool-"));
     // Drop targets must be Workshop-owned: seed via an applied create proposal, not a raw write.
     const seeded = await proposeCreateSkill({
       workspaceDir,
@@ -150,27 +151,6 @@ describe("skill_workshop tool", () => {
     );
   });
 
-  it("reads a full skill above the ordinary 40KB Workshop limit", async () => {
-    const workspaceDir = await tempDirs.make("openclaw-skill-collection-full-read-");
-    await writeWorkspaceSkills(workspaceDir, [
-      { name: "large", description: "Large procedure", body: "x".repeat(40_001) },
-    ]);
-    const tool = createSkillWorkshopTool({
-      workspaceDir,
-      env: testState.env,
-      collectionReconcile: { approvedSkillNames: new Set(["large"]) },
-    });
-
-    const read = await tool.execute("read", { action: "read", skill_name: "large" });
-    expect(read.details).toMatchObject({ skillKey: "large", truncated: false });
-    await expect(
-      tool.execute("reconcile", {
-        action: "reconcile",
-        collection: [{ action: "keep", name: "large" }],
-      }),
-    ).resolves.toMatchObject({ details: { kept: ["large"] } });
-  });
-
   it("keeps reconcile unavailable to ordinary off and propose sessions", async () => {
     const workspaceDir = await tempDirs.make("openclaw-skill-collection-policy-");
     for (const mode of ["off", "propose"] as const) {
@@ -187,6 +167,12 @@ describe("skill_workshop tool", () => {
   it("describes action selection and pending-proposal discovery in its schema", () => {
     const tool = createSkillWorkshopTool({ workspaceDir: "/tmp/openclaw" });
     const schema = JSON.stringify(tool.parameters);
+    const lazyDescription = listCoreToolSections()
+      .flatMap((section) => section.tools)
+      .find((entry) => entry.id === "skill_workshop")?.description;
+    if (!lazyDescription) {
+      throw new Error("expected lazy skill_workshop description");
+    }
 
     expect(schema).toContain("create = new skill");
     expect(schema).toContain("patch = targeted");
@@ -199,6 +185,8 @@ describe("skill_workshop tool", () => {
     expect(schema).toContain("returns candidates");
     expect(schema).toContain("max 160 bytes");
     expect(schema).toContain("shortens the proposal listing entry");
+    expect(schema).toContain("artifact_path");
+    expect(tool.description).toContain(lazyDescription);
     expect(tool.description).toContain(SKILL_AUTHORING_STANDARDS_PROMPT);
   });
 
@@ -674,24 +662,34 @@ describe("skill_workshop tool", () => {
     expect((inspected.content[0] as { text: string }).text).toContain(
       "Proposal: " + (result.details as { id: string }).id,
     );
-    expect((inspected.details as { proposalContent: string }).proposalContent).toContain(
+    expect((inspected.content[0] as { text: string }).text).toContain(
       "Check weather, alerts, and timing.",
     );
-    expect((inspected.content[0] as { text: string }).text).toContain(
-      "--- references/weather.md ---",
+    expect((inspected.content[0] as { text: string }).text).toContain("- references/weather.md");
+    expect((inspected.content[0] as { text: string }).text).not.toContain(
+      "Use weather API details and current alerts.",
     );
-    expect(
-      (
-        inspected.details as {
-          supportFiles: Array<{ path: string; content: string }>;
-        }
-      ).supportFiles,
-    ).toEqual([
-      {
-        path: "references/weather.md",
-        content: "Use weather API details and current alerts.\n",
+    expect(inspected.details).not.toHaveProperty("proposalContent");
+    expect(inspected.details).not.toHaveProperty("supportFiles");
+    expect(inspected.details).toMatchObject({
+      inspect: {
+        artifactPath: "PROPOSAL.md",
+        availableArtifacts: [
+          expect.objectContaining({ path: "PROPOSAL.md" }),
+          expect.objectContaining({ path: "references/weather.md" }),
+        ],
+        contentIncluded: true,
       },
-    ]);
+    });
+
+    const inspectedSupport = await tool.execute("call-4-support", {
+      action: "inspect",
+      proposal_id: (result.details as { id: string }).id,
+      artifact_path: "references/weather.md",
+    });
+    expect((inspectedSupport.content[0] as { text: string }).text).toContain(
+      "--- references/weather.md ---\nUse weather API details and current alerts.",
+    );
 
     const revisedByName = await reviewerTool.execute("call-5", {
       action: "revise",

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -7,12 +7,10 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import { hasRunWorkspaceSkillUsage } from "../../skills/runtime/run-usage.js";
-import {
-  MAX_RECONCILED_SKILL_BYTES,
-  type SkillCollectionReconcileContext,
-} from "../../skills/workshop/collection-contracts.js";
+import type { SkillCollectionReconcileContext } from "../../skills/workshop/collection-contracts.js";
 import { resolveSkillWorkshopConfig } from "../../skills/workshop/config.js";
 import { stripProposalFrontmatterForSkill } from "../../skills/workshop/frontmatter.js";
+import { resolveSkillWorkshopProjectionBudgets } from "../../skills/workshop/model-context-budget.js";
 import {
   applySkillProposal,
   composeSkillBodyPatch,
@@ -65,6 +63,7 @@ import {
   formatProposalInspect,
   formatProposalList,
   listProposalEntries,
+  resolveProposalInspectArtifact,
 } from "./skill-workshop-tool-presentation.js";
 import {
   buildSkillWorkshopToolSchema,
@@ -74,10 +73,6 @@ import {
 } from "./skill-workshop-tool-schema.js";
 
 const SKILL_WORKSHOP_MUTATION_ACTIONS = new Set(["create", "patch", "update", "revise"]);
-// Reads give the model the text it must quote to patch. Composition still uses
-// the authoritative live body, while the cap bounds provider payloads.
-const SKILL_WORKSHOP_READ_MAX_CHARS = 20_000;
-
 function requireProposalContent(content: string | undefined): string {
   if (content === undefined) {
     throw new ToolInputError("proposal_content required");
@@ -115,11 +110,14 @@ type SkillWorkshopToolOptions = {
   proposalReviewCompletion?: SkillWorkshopProposalReviewCompletion;
   /** Isolated collection review latch; when present only read/reconcile are exposed. */
   collectionReconcile?: SkillCollectionReconcileContext;
+  /** Effective selected-model context used for every model-visible Workshop projection. */
+  modelContextWindowTokens?: number;
 };
 
 /** Create the Skill Workshop tool for proposal discovery and lifecycle actions. */
 export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyAgentTool {
   const workshopConfig = resolveSkillWorkshopConfig(options.config);
+  const projectionBudgets = resolveSkillWorkshopProjectionBudgets(options.modelContextWindowTokens);
   const readSkillHashes =
     options.collectionReconcile?.readSkillHashes ??
     options.proposalMutationBudget?.readSkillHashes ??
@@ -186,7 +184,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
       }
 
       if (action === "history") {
-        return executeSkillCollectionHistory(options);
+        return executeSkillCollectionHistory(options, projectionBudgets.collectionHistoryChars);
       }
 
       if (action === "read") {
@@ -208,9 +206,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
         ) {
           throw new ToolInputError(`skill is outside this collection review: ${skill.skillKey}`);
         }
-        const readMaxChars = options.collectionReconcile
-          ? MAX_RECONCILED_SKILL_BYTES
-          : SKILL_WORKSHOP_READ_MAX_CHARS;
+        const readMaxChars = projectionBudgets.artifactChars;
         const truncated = skill.content.length > readMaxChars;
         // A truncated read is context, not sight of the whole skill: it earns no
         // receipt, so oversized skills cannot be patched by a reviewer that never
@@ -227,12 +223,22 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
         } else {
           readSkillHashes.set(skill.skillKey, sha256Hex(skill.content));
         }
+        const sizeBytes = Buffer.byteLength(skill.content);
         const text = truncated
-          ? `${truncateUtf16Safe(skill.content, readMaxChars)}\n[truncated: skill exceeds the Workshop read budget]`
+          ? truncateUtf16Safe(
+              [
+                `Skill: ${skill.skillKey} (${sizeBytes} bytes)`,
+                "Content omitted: the complete skill exceeds the selected-model read budget.",
+                options.collectionReconcile
+                  ? "Next: select a larger-context model or use operator/CLI access; this collection cannot be reconciled without a complete read."
+                  : "Next: use operator/CLI access for the complete skill; autonomous patch/update requires a complete model read.",
+              ].join("\n"),
+              readMaxChars,
+            )
           : skill.content;
         return {
           content: [{ type: "text", text }],
-          details: { skillKey: skill.skillKey, truncated },
+          details: { skillKey: skill.skillKey, sizeBytes, contentIncluded: !truncated },
         };
       }
 
@@ -282,9 +288,35 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
           options.env,
           options.agentId,
         );
+        const artifactPath = readToolStringParam(params, "artifact_path", {
+          label: "artifact_path",
+        });
+        const artifact = resolveProposalInspectArtifact(proposal, artifactPath);
+        if (!artifact) {
+          const available = [
+            proposal.record.draftFile,
+            ...(proposal.record.supportFiles ?? []).map((file) => file.path),
+          ];
+          throw new ToolInputError(
+            truncateUtf16Safe(
+              `proposal artifact not found: ${artifactPath}. Inspect without artifact_path for the bounded manifest. Available artifacts: ${available.join(", ")}`,
+              projectionBudgets.artifactChars,
+            ),
+          );
+        }
+        const projection = formatProposalInspect(
+          proposal,
+          artifact,
+          projectionBudgets.artifactChars,
+        );
         return proposalResult(proposal, {
-          contentText: formatProposalInspect(proposal),
-          includeContent: true,
+          contentText: projection.text,
+          inspect: {
+            artifactPath: artifact.path,
+            artifactSizeBytes: artifact.sizeBytes,
+            availableArtifacts: projection.availableArtifacts,
+            contentIncluded: projection.contentIncluded,
+          },
         });
       }
 
@@ -396,7 +428,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
         const readHash = readSkillHashes.get(target.skillKey);
         if (!readHash) {
           throw new ToolInputError(
-            target.content.length > SKILL_WORKSHOP_READ_MAX_CHARS
+            target.content.length > projectionBudgets.artifactChars
               ? `skill "${target.skillKey}" exceeds the reviewer read budget and cannot be updated autonomously`
               : `read the live skill first: call action=read with skill_name "${target.skillKey}", then ${action === "patch" ? "quote its current text in the patch" : "rewrite it from the returned content"}`,
           );

--- a/src/skills/workshop/experience-review-prompt.ts
+++ b/src/skills/workshop/experience-review-prompt.ts
@@ -1,12 +1,12 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { RunSkillUsage } from "../runtime/run-usage.js";
+import { resolveSkillWorkshopProjectionBudgets } from "./model-context-budget.js";
 import {
   SKILL_AUTHORING_STANDARDS_PROMPT,
   SKILL_AUTONOMOUS_CAPTURE_EXCLUSIONS_PROMPT,
 } from "./skill-authoring-standards.js";
 
-const EXPERIENCE_REVIEW_MAX_TRANSCRIPT_CHARS = 60_000;
 const EXPERIENCE_REVIEW_MAX_SKILL_ENTRIES = 50;
 const EXPERIENCE_REVIEW_MAX_SKILL_LINE_CHARS = 200;
 const EXPERIENCE_REVIEW_MAX_USED_SKILLS_CHARS = 2_000;
@@ -84,15 +84,23 @@ function renderMessage(message: unknown): string {
   return `[${role}${toolName}${error}]\n${renderContent(message.content)}`;
 }
 
-export function formatSkillExperienceReviewTranscript(messages: readonly unknown[]): string {
+export function formatSkillExperienceReviewTranscript(
+  messages: readonly unknown[],
+  maxChars = resolveSkillWorkshopProjectionBudgets(Number.MAX_SAFE_INTEGER).reviewTranscriptChars,
+): string {
   const rendered = messages.map(renderMessage);
   const full = rendered.join("\n\n");
-  if (full.length <= EXPERIENCE_REVIEW_MAX_TRANSCRIPT_CHARS) {
+  if (full.length <= maxChars) {
     return full;
   }
-  const first = truncateUtf16Safe(rendered[0] ?? "", 6_000);
-  const tailBudget = EXPERIENCE_REVIEW_MAX_TRANSCRIPT_CHARS - first.length - 80;
-  return `${first}\n\n[older trajectory omitted]\n\n${sliceUtf16Safe(full, -tailBudget)}`;
+  const marker = "\n\n[older trajectory omitted]\n\n";
+  const contentBudget = Math.max(0, maxChars - marker.length);
+  const first = truncateUtf16Safe(
+    rendered[0] ?? "",
+    Math.min(6_000, Math.floor(contentBudget / 3)),
+  );
+  const tailBudget = Math.max(0, contentBudget - first.length);
+  return `${first}${marker}${sliceUtf16Safe(full, -tailBudget)}`;
 }
 
 function renderExistingSkillsSection(

--- a/src/skills/workshop/experience-review.test.ts
+++ b/src/skills/workshop/experience-review.test.ts
@@ -26,6 +26,7 @@ function completedRun(
     senderName?: string;
     chatType?: "direct" | "group";
     modelProviderId?: string;
+    modelContextWindowTokens?: number;
     authProfileId?: string;
     usedSkills?: SkillExperienceReviewParams["usedSkills"];
   } = {},
@@ -60,6 +61,7 @@ function completedRun(
         : {
             modelProviderId: options.modelProviderId ?? "openai",
             modelId: "gpt-test",
+            modelContextWindowTokens: options.modelContextWindowTokens,
             authProfileId: options.authProfileId ?? "openai:work",
           }),
       skillWorkshopAvailable: options.skillWorkshopAvailable ?? true,
@@ -95,6 +97,35 @@ afterEach(() => {
 });
 
 describe("skill experience review scheduler", () => {
+  it.each([
+    { provider: "anthropic", contextTokens: 8_192, maxChars: 2_867 },
+    { provider: "openai", contextTokens: 200_000, maxChars: 60_000 },
+  ])(
+    "bounds the $provider review projection to its selected model",
+    async ({ provider, contextTokens, maxChars }) => {
+      vi.useFakeTimers();
+      const runReview = vi.fn().mockResolvedValue(undefined);
+      const scheduler = createSkillExperienceReviewScheduler({
+        isSystemActive: () => false,
+        runReview,
+      });
+
+      scheduler.schedule(
+        completedRun({
+          modelProviderId: provider,
+          modelContextWindowTokens: contextTokens,
+          userText: "trajectory ".repeat(20_000),
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      const candidate = runReview.mock.calls[0]?.[0] as { transcript: string } | undefined;
+      expect(candidate?.transcript.length).toBeLessThanOrEqual(maxChars);
+      expect(candidate?.transcript).toContain("older trajectory omitted");
+      scheduler.clear();
+    },
+  );
+
   it("waits for a completed substantial turn and an idle window", async () => {
     vi.useFakeTimers();
     const runReview = vi.fn().mockResolvedValue(undefined);

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -17,6 +17,7 @@ import {
   formatSkillExperienceReviewTranscript,
   selectCurrentSkillTurnMessages,
 } from "./experience-review-prompt.js";
+import { resolveSkillWorkshopProjectionBudgets } from "./model-context-budget.js";
 import type { SkillWorkshopProposalMutationBudget } from "./types.js";
 
 const EXPERIENCE_REVIEW_MIN_MODEL_ITERATIONS = 10;
@@ -51,6 +52,7 @@ type ExperienceReviewAgentContext = {
   workspaceDir?: string;
   modelProviderId?: string;
   modelId?: string;
+  modelContextWindowTokens?: number;
   authProfileId?: string;
   modelIterations?: number;
   skillWorkshopAvailable?: boolean;
@@ -404,6 +406,7 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
           ...senderIdentity,
           params.ctx.modelProviderId ?? "",
           params.ctx.modelId ?? "",
+          params.ctx.modelContextWindowTokens ?? "",
           params.ctx.authProfileId ?? "",
         ]);
         let accumulator = shallowBySession.get(sessionKey);
@@ -473,6 +476,7 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
             workspaceDir,
             modelProviderId: params.ctx.modelProviderId,
             modelId: params.ctx.modelId,
+            modelContextWindowTokens: params.ctx.modelContextWindowTokens,
             authProfileId: params.ctx.authProfileId,
             skillWorkshopAvailable: params.ctx.skillWorkshopAvailable,
             compacted: params.ctx.compacted,
@@ -493,7 +497,11 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
             senderIsOwner: params.ctx.senderIsOwner,
           },
           ...(params.config ? { config: params.config } : {}),
-          transcript: formatSkillExperienceReviewTranscript(reviewMessages),
+          transcript: formatSkillExperienceReviewTranscript(
+            reviewMessages,
+            resolveSkillWorkshopProjectionBudgets(params.ctx.modelContextWindowTokens)
+              .reviewTranscriptChars,
+          ),
           modelIterations: reviewIterations,
           usedSkills: reviewUsedSkills,
           turnAborted: reviewAborted,

--- a/src/skills/workshop/history-scan-review.test.ts
+++ b/src/skills/workshop/history-scan-review.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { runSkillHistoryScanReview } from "./history-scan-review.js";
+
+const runEmbeddedAgent = vi.hoisted(() => vi.fn(async () => ({ meta: { durationMs: 1 } })));
+
+vi.mock("../../agents/embedded-agent.js", () => ({ runEmbeddedAgent }));
+
+describe("Skill Workshop history scan review", () => {
+  it("locks the model that sized the history projection", async () => {
+    await runSkillHistoryScanReview({
+      agentId: "main",
+      config: {},
+      modelRef: { provider: "openai", model: "gpt-test" },
+      sessions: [
+        {
+          instanceId: "session-1",
+          sessionKey: "agent:main:main",
+          updatedAt: "2026-08-18T00:00:00.000Z",
+          modelIterations: 6,
+          transcript: "[user]\nRepair it.\n\n[assistant]\nDone.",
+        },
+      ],
+      workspaceDir: "/tmp/openclaw-history-scan-review",
+    });
+
+    expect(runEmbeddedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-test",
+        modelSelectionLocked: true,
+        modelFallbacksOverride: [],
+      }),
+    );
+  });
+});

--- a/src/skills/workshop/history-scan-review.ts
+++ b/src/skills/workshop/history-scan-review.ts
@@ -89,6 +89,7 @@ export async function runSkillHistoryScanReview(params: {
       provider: modelRef.provider,
       model: modelRef.model,
       // A smaller configured fallback must not receive a prompt sized for the primary model.
+      modelSelectionLocked: true,
       modelFallbacksOverride: [],
       timeoutMs: HISTORY_SCAN_TIMEOUT_MS,
       runId,

--- a/src/skills/workshop/history-scan-transcript.ts
+++ b/src/skills/workshop/history-scan-transcript.ts
@@ -14,22 +14,9 @@ export type SkillHistoryScanBatchSession = SkillHistoryScanPromptSession & {
 
 const HISTORY_SCAN_MAX_CANDIDATES = 60;
 const HISTORY_SCAN_MAX_SESSIONS = 20;
-const HISTORY_SCAN_MAX_TRANSCRIPT_CHARS = 80_000;
 export const HISTORY_SCAN_MAX_SESSION_CHARS = 16_000;
 export const HISTORY_SCAN_SESSION_OVERHEAD_CHARS = 256;
-const HISTORY_SCAN_DEFAULT_CONTEXT_TOKENS = 8_192;
 const HISTORY_SCAN_MIN_MODEL_ITERATIONS = 6;
-
-export function resolveSkillHistoryScanTranscriptBudget(contextTokens?: number): number {
-  const effectiveContextTokens =
-    Number.isFinite(contextTokens) && (contextTokens ?? 0) > 0
-      ? Math.floor(contextTokens as number)
-      : HISTORY_SCAN_DEFAULT_CONTEXT_TOKENS;
-  return Math.min(
-    HISTORY_SCAN_MAX_TRANSCRIPT_CHARS,
-    Math.max(256, Math.floor(effectiveContextTokens * 0.35)),
-  );
-}
 
 export async function readHistoryScanSession(params: {
   agentId: string;
@@ -79,7 +66,7 @@ export async function readHistoryScanSession(params: {
 export async function collectSkillHistoryScanBatch(params: {
   candidates: readonly SkillHistoryScanCandidate[];
   isSessionActive?: (candidate: SkillHistoryScanCandidate) => boolean;
-  maxTranscriptChars?: number;
+  maxTranscriptChars: number;
   readSession: (
     candidate: SkillHistoryScanCandidate,
   ) => Promise<SkillHistoryScanPromptSession | undefined>;
@@ -90,7 +77,7 @@ export async function collectSkillHistoryScanBatch(params: {
 }> {
   const considered: SkillHistoryScanCandidate[] = [];
   const sessions: SkillHistoryScanBatchSession[] = [];
-  const maxTranscriptChars = params.maxTranscriptChars ?? HISTORY_SCAN_MAX_TRANSCRIPT_CHARS;
+  const maxTranscriptChars = params.maxTranscriptChars;
   let blockedByActive = false;
   let transcriptChars = 0;
   for (const candidate of params.candidates.slice(0, HISTORY_SCAN_MAX_CANDIDATES)) {

--- a/src/skills/workshop/history-scan.test.ts
+++ b/src/skills/workshop/history-scan.test.ts
@@ -26,11 +26,9 @@ import {
   isSkillHistoryScanLocalTranscriptSizeEligible,
   prepareSkillHistoryScanReviewMessages,
 } from "./history-scan-transcript-content.js";
-import {
-  collectSkillHistoryScanBatch,
-  resolveSkillHistoryScanTranscriptBudget,
-} from "./history-scan-transcript.js";
+import { collectSkillHistoryScanBatch } from "./history-scan-transcript.js";
 import { runSkillHistoryScan } from "./history-scan.js";
+import { resolveSkillWorkshopProjectionBudgets } from "./model-context-budget.js";
 
 function summary(sessionKey: string, overrides: Partial<SessionEntrySummary["entry"]> = {}) {
   return {
@@ -226,9 +224,9 @@ describe("Skill Workshop history scan", () => {
   });
 
   it("bounds transcript input against the selected model context", () => {
-    expect(resolveSkillHistoryScanTranscriptBudget(undefined)).toBe(2_867);
-    expect(resolveSkillHistoryScanTranscriptBudget(32_768)).toBe(11_468);
-    expect(resolveSkillHistoryScanTranscriptBudget(1_000_000)).toBe(80_000);
+    expect(resolveSkillWorkshopProjectionBudgets(undefined).historyTranscriptChars).toBe(2_867);
+    expect(resolveSkillWorkshopProjectionBudgets(32_768).historyTranscriptChars).toBe(11_468);
+    expect(resolveSkillWorkshopProjectionBudgets(1_000_000).historyTranscriptChars).toBe(80_000);
   });
 
   it("redacts complete multiline secrets before transcript truncation", () => {
@@ -450,6 +448,7 @@ describe("Skill Workshop history scan", () => {
     await expect(
       collectSkillHistoryScanBatch({
         candidates: [candidate],
+        maxTranscriptChars: resolveSkillWorkshopProjectionBudgets().historyTranscriptChars,
         readSession: async () => {
           throw new Error("transient read failure");
         },
@@ -467,6 +466,7 @@ describe("Skill Workshop history scan", () => {
     let activeCheck = 0;
     const batch = await collectSkillHistoryScanBatch({
       candidates: [candidate],
+      maxTranscriptChars: resolveSkillWorkshopProjectionBudgets().historyTranscriptChars,
       isSessionActive: () => ++activeCheck === 2,
       readSession: async () => ({
         instanceId: candidate.instanceId,
@@ -497,6 +497,7 @@ describe("Skill Workshop history scan", () => {
     ];
     const batch = await collectSkillHistoryScanBatch({
       candidates,
+      maxTranscriptChars: resolveSkillWorkshopProjectionBudgets().historyTranscriptChars,
       isSessionActive: (candidate) => candidate.instanceId === "running",
       readSession: async (candidate) => ({
         instanceId: candidate.instanceId,

--- a/src/skills/workshop/history-scan.ts
+++ b/src/skills/workshop/history-scan.ts
@@ -36,9 +36,12 @@ import {
   HISTORY_SCAN_MAX_SESSION_CHARS,
   HISTORY_SCAN_SESSION_OVERHEAD_CHARS,
   readHistoryScanSession,
-  resolveSkillHistoryScanTranscriptBudget,
   type SkillHistoryScanBatchSession,
 } from "./history-scan-transcript.js";
+import {
+  resolveSkillWorkshopModelContextTokens,
+  resolveSkillWorkshopProjectionBudgets,
+} from "./model-context-budget.js";
 import { getSkillProposalRunProgress } from "./service.js";
 
 type ActiveSkillHistoryScan = {
@@ -222,17 +225,9 @@ async function runSkillHistoryScanCore(
           )
         ).model
       : undefined;
-  const contextTokens = (() => {
-    if (!resolvedModel) {
-      return undefined;
-    }
-    const contextWindow = resolvedModel.contextWindow;
-    if (contextWindow === undefined) {
-      return resolvedModel.contextTokens;
-    }
-    return Math.min(resolvedModel.contextTokens ?? contextWindow, contextWindow);
-  })();
-  const maxTranscriptChars = resolveSkillHistoryScanTranscriptBudget(contextTokens);
+  const contextTokens = resolveSkillWorkshopModelContextTokens(resolvedModel);
+  const maxTranscriptChars =
+    resolveSkillWorkshopProjectionBudgets(contextTokens).historyTranscriptChars;
   const maxSessionTranscriptChars = Math.min(
     HISTORY_SCAN_MAX_SESSION_CHARS,
     Math.max(1, maxTranscriptChars - HISTORY_SCAN_SESSION_OVERHEAD_CHARS),

--- a/src/skills/workshop/model-context-budget.ts
+++ b/src/skills/workshop/model-context-budget.ts
@@ -1,0 +1,46 @@
+type SkillWorkshopModelContext = {
+  contextTokens?: number;
+  contextWindow?: number;
+};
+
+const DEFAULT_MODEL_CONTEXT_TOKENS = 8_192;
+const MODEL_CONTEXT_PROJECTION_SHARE = 0.35;
+const MIN_PROJECTION_CHARS = 256;
+
+const PROJECTION_CAPS = {
+  artifactChars: 20_000,
+  collectionHistoryChars: 8_000,
+  historyTranscriptChars: 80_000,
+  reviewTranscriptChars: 60_000,
+} as const;
+
+function positiveInteger(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+export function resolveSkillWorkshopModelContextTokens(
+  model: SkillWorkshopModelContext | undefined,
+): number | undefined {
+  const contextTokens = positiveInteger(model?.contextTokens);
+  const contextWindow = positiveInteger(model?.contextWindow);
+  if (contextTokens === undefined) {
+    return contextWindow;
+  }
+  return contextWindow === undefined ? contextTokens : Math.min(contextTokens, contextWindow);
+}
+
+export function resolveSkillWorkshopProjectionBudgets(contextTokens?: number) {
+  const effectiveContextTokens = positiveInteger(contextTokens) ?? DEFAULT_MODEL_CONTEXT_TOKENS;
+  const contextChars = Math.max(
+    MIN_PROJECTION_CHARS,
+    Math.floor(effectiveContextTokens * MODEL_CONTEXT_PROJECTION_SHARE),
+  );
+  return {
+    artifactChars: Math.min(contextChars, PROJECTION_CAPS.artifactChars),
+    collectionHistoryChars: Math.min(contextChars, PROJECTION_CAPS.collectionHistoryChars),
+    historyTranscriptChars: Math.min(contextChars, PROJECTION_CAPS.historyTranscriptChars),
+    reviewTranscriptChars: Math.min(contextChars, PROJECTION_CAPS.reviewTranscriptChars),
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Skill Workshop could inject storage-sized proposal bundles and fixed-size review trajectories into models with much smaller context windows. Oversized inspect/read results could also present partial documents as though they were complete, leaving the model without a reliable continuation path.

## Why This Change Was Made

Centralizes Skill Workshop model-visible projection budgets around the selected model's prepared context window. Inspect now returns a bounded manifest plus one complete selected artifact when it fits, otherwise an explicit omission with size and continuation guidance. Experience and history reviews use the same budget owner and lock the model that sized their prompts. Operator CLI artifact access remains complete and unbounded.

This change is AI-assisted and was reviewed with the repository autoreview workflow.

## User Impact

Small-context models no longer receive oversized or misleadingly partial Skill Workshop documents. Models can inspect proposal support files individually with `artifact_path`, while large-context models still receive complete fitting artifacts. Collection reconciliation only accepts read receipts for complete skill bodies.

## Evidence

- `node scripts/run-vitest.mjs src/docs/install-cloud-secrets.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts src/agents/tools/skill-workshop-tool.projection.test.ts src/skills/workshop/experience-review.test.ts src/skills/workshop/history-scan.test.ts src/skills/workshop/history-scan-review.test.ts` — 91 tests passed across three shards after refreshing onto current `main`.
- `pnpm openclaw skills workshop --help` — local build and CLI help passed.
- `git diff --check` — passed.
- Fresh autoreview — clean, no accepted/actionable findings, confidence 0.97.
- Blacksmith Testbox `check:changed` and full build for the patch — passed: https://github.com/openclaw/openclaw/actions/runs/32198677921

Production LOC is +258/-87. The growth provides per-artifact inspection, centralized selected-model budget ownership, and prepared-context wiring; obsolete fixed limits and duplicate budget resolution were removed.
