### PR TITLE
fix(signal): preserve partial final delivery after later send failures

### DIFF
--- a/extensions/signal/src/channel.ts
+++ b/extensions/signal/src/channel.ts
@@ -200,6 +200,7 @@ function attachSignalVisibleText<T extends object>(result: T, visibleText: strin
     ...result,
     meta: {
       ...meta,
+      visibleText,
       signalVisibleText: visibleText,
     },
   };
@@ -211,6 +212,9 @@ const signalMessageAdapter = defineChannelMessageAdapter({
     capabilities: {
       text: true,
       media: true,
+      payload: true,
+      replyTo: true,
+      messageSendingHooks: true,
     },
   },
   send: {
@@ -300,16 +304,17 @@ async function sendFormattedSignalText(ctx: {
   if (chunks.length === 0 && ctx.text) {
     chunks = [{ text: ctx.text, styles: [] }];
   }
+  const effectiveReplyToMode =
+    ctx.replyToMode ??
+    resolveSignalReplyToMode({
+      cfg: ctx.cfg,
+      accountId: ctx.accountId,
+      chatType: inferSignalTargetChatType(to),
+    });
   const nextReplyToId = createReplyToFanout({
     replyToId: ctx.replyToId,
     replyToIdSource: ctx.replyToIdSource,
-    replyToMode:
-      ctx.replyToMode ??
-      resolveSignalReplyToMode({
-        cfg: ctx.cfg,
-        accountId: ctx.accountId,
-        chatType: inferSignalTargetChatType(to),
-      }),
+    replyToMode: effectiveReplyToMode,
   });
   const results = [];
   for (const chunk of chunks) {

--- a/extensions/signal/src/core.test.ts
+++ b/extensions/signal/src/core.test.ts
@@ -1260,6 +1260,37 @@ describe("signal outbound", () => {
           });
           expect(result?.receipt.platformMessageIds).toEqual(["signal-media-1"]);
         },
+        payload: () => {
+          expect(signalPlugin.outbound?.renderPresentation).toBeTypeOf("function");
+          expect(signalPlugin.outbound?.sendFormattedText).toBeTypeOf("function");
+        },
+        replyTo: async () => {
+          await registerSignalReplyContext({
+            to: "signal:+15555550123",
+            replyToId: "1700000000001",
+            author: "+15555550123",
+            body: "original message",
+          });
+          await signalPlugin.message?.send?.text?.({
+            cfg: {} as OpenClawConfig,
+            to: "signal:+15555550123",
+            text: "reply",
+            replyToId: "1700000000001",
+            deps,
+          } as Parameters<NonNullable<typeof signalPlugin.message.send.text>>[0] & {
+            deps: typeof deps;
+          });
+          expect(send).toHaveBeenLastCalledWith(
+            "+15555550123",
+            "reply",
+            expect.objectContaining({ replyToId: "1700000000001" }),
+          );
+        },
+        messageSendingHooks: () => {
+          expect(signalPlugin.outbound?.shouldSuppressLocalPayloadPrompt).toBeTypeOf("function");
+          expect(signalPlugin.outbound?.renderPresentation).toBeTypeOf("function");
+          expect(signalPlugin.outbound?.afterDeliverPayload).toBeTypeOf("function");
+        },
       },
     });
 
@@ -1267,12 +1298,12 @@ describe("signal outbound", () => {
       { capability: "text", status: "verified" },
       { capability: "media", status: "verified" },
       { capability: "poll", status: "not_declared" },
-      { capability: "payload", status: "not_declared" },
+      { capability: "payload", status: "verified" },
       { capability: "silent", status: "not_declared" },
-      { capability: "replyTo", status: "not_declared" },
+      { capability: "replyTo", status: "verified" },
       { capability: "thread", status: "not_declared" },
       { capability: "nativeQuote", status: "not_declared" },
-      { capability: "messageSendingHooks", status: "not_declared" },
+      { capability: "messageSendingHooks", status: "verified" },
       { capability: "batch", status: "not_declared" },
       { capability: "reconcileUnknownSend", status: "not_declared" },
       { capability: "afterSendSuccess", status: "not_declared" },

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -22,7 +22,6 @@ import {
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import {
   chunkTextWithMode,
-  createReplyReferencePlanner,
   resolveChunkMode,
   resolveTextChunkLimit,
 } from "openclaw/plugin-sdk/reply-runtime";
@@ -58,6 +57,7 @@ import type {
   SignalReactionMessage,
   SignalReactionTarget,
 } from "./monitor/event-handler.types.js";
+import { createSignalNativeReplyIdResolver } from "./native-reply.js";
 import { materializeSignalPresentationFallback } from "./presentation-fallback.js";
 import { registerSignalReactionTargetsForDeliveredPayload } from "./reaction-targets.js";
 import { sendMessageSignal } from "./send.js";
@@ -424,43 +424,6 @@ export async function deliverReplies(params: {
   }
 }
 
-function resolveSignalNativeReplyOptions(params: {
-  payload: ReplyPayload;
-  replyContext?: SignalNativeReplyContext;
-}): Pick<Parameters<typeof sendMessageSignal>[2], "replyToId" | "replyToAuthor" | "replyToBody"> {
-  if (params.payload.replyToCurrent === false) {
-    return {};
-  }
-  const payloadReplyToId = normalizeOptionalString(params.payload.replyToId);
-  const isExplicitCurrentReply =
-    params.payload.replyToTag === true || params.payload.replyToCurrent === true;
-  if (
-    !payloadReplyToId &&
-    !isExplicitCurrentReply &&
-    params.replyContext?.allowImplicitCurrentMessage === false
-  ) {
-    return {};
-  }
-  const contextReplyToId = normalizeOptionalString(params.replyContext?.replyToId);
-  if (!contextReplyToId || (payloadReplyToId && payloadReplyToId !== contextReplyToId)) {
-    return {};
-  }
-  const replyToId = payloadReplyToId ?? contextReplyToId;
-  const replyToAuthor = normalizeOptionalString(params.replyContext?.author);
-  if (!replyToAuthor) {
-    return { replyToId };
-  }
-  return {
-    replyToId,
-    replyToAuthor,
-    replyToBody: params.replyContext?.body ?? "",
-  };
-}
-
-function isSignalStatusNoticePayload(payload: ReplyPayload): boolean {
-  return Boolean(payload.isCompactionNotice || payload.isFallbackNotice || payload.isStatusNotice);
-}
-
 function createSignalNativeReplyResolver(params: {
   payload: ReplyPayload;
   replyContext?: SignalNativeReplyContext;
@@ -469,33 +432,17 @@ function createSignalNativeReplyResolver(params: {
   Parameters<typeof sendMessageSignal>[2],
   "replyToId" | "replyToAuthor" | "replyToBody"
 > {
-  const nativeReply = resolveSignalNativeReplyOptions(params);
-  if (!nativeReply.replyToId) {
-    return () => ({});
-  }
-  const isExplicitReply =
-    params.payload.replyToTag === true || params.payload.replyToCurrent === true;
-  const isStatusNotice = isSignalStatusNoticePayload(params.payload);
-  if (isStatusNotice && params.replyToMode === "off") {
-    return () => ({});
-  }
-  if (isExplicitReply) {
-    return () => nativeReply;
-  }
-  if (isStatusNotice) {
-    return () => nativeReply;
-  }
-  const planner = createReplyReferencePlanner({
-    replyToMode: params.replyToMode,
-    existingId: nativeReply.replyToId,
-    hasReplied: params.replyContext?.state?.hasReplied,
-  });
+  const nextReplyToId = createSignalNativeReplyIdResolver(params);
   return () => {
-    const replyToId = planner.use();
-    if (params.replyContext?.state && !isStatusNotice) {
-      params.replyContext.state.hasReplied = planner.hasReplied();
+    const replyToId = nextReplyToId();
+    if (!replyToId) {
+      return {};
     }
-    return replyToId ? { ...nativeReply, replyToId } : {};
+    const replyToAuthor = normalizeOptionalString(params.replyContext?.author);
+    return {
+      replyToId,
+      ...(replyToAuthor ? { replyToAuthor, replyToBody: params.replyContext?.body ?? "" } : {}),
+    };
   };
 }
 

--- a/extensions/signal/src/monitor/event-handler.partial-delivery.test.ts
+++ b/extensions/signal/src/monitor/event-handler.partial-delivery.test.ts
@@ -1,0 +1,402 @@
+// Signal integration coverage for durable ingress after a partially visible final reply.
+import { buildExecApprovalPendingReplyPayload } from "openclaw/plugin-sdk/approval-reply-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { createChannelIngressQueueForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import {
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearSignalApprovalReactionTargetsForTest,
+  resolveSignalApprovalReactionTargetWithPersistence,
+} from "../approval-reactions.js";
+import { signalPlugin } from "../channel.js";
+import { maybeResolveSignalQuestionReaction } from "../question-reactions.js";
+import type { SignalIngressLifecycle } from "../signal-ingress.js";
+
+const { getReplyFromConfigMock, resolveQuestionReactionMock, sendMessageSignalMock } = vi.hoisted(
+  () => ({
+    getReplyFromConfigMock: vi.fn(),
+    resolveQuestionReactionMock: vi.fn(),
+    sendMessageSignalMock: vi.fn(),
+  }),
+);
+
+vi.mock("openclaw/plugin-sdk/question-gateway-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/question-gateway-runtime")>();
+  return {
+    ...actual,
+    questionGatewayRuntime: {
+      ...actual.questionGatewayRuntime,
+      resolveReaction: resolveQuestionReactionMock,
+    },
+  };
+});
+
+vi.mock("../../../../src/auto-reply/reply/get-reply-from-config.runtime.js", () => ({
+  getReplyFromConfig: getReplyFromConfigMock,
+  prewarmConfigDrivenReplyRuntime: vi.fn(async () => undefined),
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: sendMessageSignalMock,
+  sendTypingSignal: vi.fn(async () => true),
+  sendReadReceiptSignal: vi.fn(async () => true),
+}));
+
+vi.mock("../send-reactions.js", () => ({
+  sendReactionSignal: vi.fn(async () => ({ ok: true })),
+  removeReactionSignal: vi.fn(async () => ({ ok: true })),
+}));
+
+const [{ deliverReplies }, { startSignalIngressMonitor }, eventHandlerModule, harnessModule] =
+  await Promise.all([
+    import("../monitor.js"),
+    import("../signal-ingress.js"),
+    import("./event-handler.js"),
+    import("./event-handler.test-harness.js"),
+  ]);
+const { questionGatewayRuntime } = await import("openclaw/plugin-sdk/question-gateway-runtime");
+
+type SignalIngressQueue = ReturnType<typeof createChannelIngressQueueForTests<unknown>>;
+type SignalIngressPayload = Parameters<SignalIngressQueue["enqueue"]>[1];
+
+describe("Signal partial final delivery ingress boundary", () => {
+  let state: OpenClawTestState;
+  let queue: ReturnType<typeof createChannelIngressQueueForTests<SignalIngressPayload>>;
+
+  beforeEach(async () => {
+    state = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-signal-partial-delivery-",
+    });
+    queue = createChannelIngressQueueForTests({
+      channelId: "signal",
+      accountId: "default",
+      stateDir: state.stateDir,
+    });
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "signal", plugin: signalPlugin, source: "test" }]),
+    );
+    clearSignalApprovalReactionTargetsForTest();
+    getReplyFromConfigMock.mockReset();
+    resolveQuestionReactionMock.mockReset().mockResolvedValue({
+      status: "answered",
+      questionId: "ask-partial",
+      optionValue: "One",
+    });
+    sendMessageSignalMock.mockReset();
+  });
+
+  afterEach(async () => {
+    resetPluginRuntimeStateForTest();
+    clearSignalApprovalReactionTargetsForTest();
+    vi.restoreAllMocks();
+    await state.cleanup();
+  });
+
+  it("tombstones an accepted approval prefix and retains its reaction binding", async () => {
+    const afterDeliverPayload = vi.spyOn(signalPlugin.outbound!, "afterDeliverPayload");
+    const timestamp = 1_700_000_005_001;
+    const cfg = {
+      session: { store: state.statePath("sessions") },
+      channels: {
+        signal: {
+          account: "+15550009999",
+          dmPolicy: "allowlist",
+          allowFrom: ["+15550001111"],
+          textChunkLimit: 4_000,
+        },
+      },
+      approvals: {
+        exec: {
+          enabled: true,
+          mode: "targets",
+          targets: [{ channel: "signal", to: "+15550001111" }],
+        },
+      },
+    } as OpenClawConfig;
+    const payload = {
+      ...buildExecApprovalPendingReplyPayload({
+        approvalId: "exec-partial",
+        approvalSlug: "exec-partial",
+        allowedDecisions: ["allow-once", "deny"],
+        command: "printf test",
+        host: "gateway",
+        agentId: "main",
+        sessionKey: "agent:main:signal:direct:+15550001111",
+      }),
+      mediaUrls: ["https://example.test/one.png", "https://example.test/two.png"],
+    };
+    getReplyFromConfigMock.mockResolvedValue(payload);
+    sendMessageSignalMock
+      .mockResolvedValueOnce({ messageId: "1700000005999" })
+      .mockRejectedValueOnce(new Error("second Signal send failed"));
+
+    const handler = eventHandlerModule.createSignalEventHandler(
+      harnessModule.createBaseSignalEventHandlerDeps({
+        cfg,
+        baseUrl: "http://signal.test:8080",
+        account: "+15550009999",
+        accountId: "default",
+        mediaMaxBytes: 8 * 1024 * 1024,
+        deliverReplies: async (params) =>
+          await deliverReplies({ ...params, cfg, chunkMode: "length" }),
+      }),
+    );
+    const monitor = await startSignalIngressMonitor({
+      accountId: "default",
+      queue: queue as Parameters<typeof startSignalIngressMonitor>[0]["queue"],
+      dispatch: async (event, lifecycle: SignalIngressLifecycle) => await handler(event, lifecycle),
+      runtime: { error: vi.fn(), log: vi.fn() },
+    });
+    const event = harnessModule.createSignalReceiveEvent({
+      timestamp,
+      dataMessage: { timestamp, message: "please run it", attachments: [] },
+    });
+
+    try {
+      await monitor.receive(event);
+      await monitor.waitForIdle();
+
+      expect(getReplyFromConfigMock).toHaveBeenCalledTimes(1);
+      expect(sendMessageSignalMock).toHaveBeenCalledTimes(2);
+      expect(sendMessageSignalMock.mock.calls[0]?.[1]).toContain("React with:");
+      expect(afterDeliverPayload).toHaveBeenCalledOnce();
+      expect(afterDeliverPayload.mock.calls[0]?.[0]).toMatchObject({
+        payload: { text: expect.stringContaining("React with:") },
+        results: [{ messageId: "1700000005999" }],
+      });
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
+      await expect(
+        resolveSignalApprovalReactionTargetWithPersistence({
+          accountId: "default",
+          conversationKey: "+15550001111",
+          messageId: "1700000005999",
+          reactionKey: "👍",
+          targetAuthor: "+15550009999",
+        }),
+      ).resolves.toMatchObject({
+        approvalId: "exec-partial",
+        decision: "allow-once",
+      });
+
+      await monitor.receive(event);
+      await monitor.waitForIdle();
+      expect(getReplyFromConfigMock).toHaveBeenCalledTimes(1);
+      expect(sendMessageSignalMock).toHaveBeenCalledTimes(2);
+    } finally {
+      await monitor.stop();
+    }
+  });
+
+  it("drains an abort after an accepted question and resolves the retained binding", async () => {
+    const abort = new AbortController();
+    const timestamp = 1_700_000_005_002;
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const presentation = {
+      blocks: [
+        { type: "text" as const, text: "Pick one" },
+        {
+          type: "buttons" as const,
+          buttons: ["One", "Two"].map((label) => ({
+            label,
+            action: { type: "question" as const, questionId, optionValue: label },
+          })),
+        },
+      ],
+    };
+    const payload = questionGatewayRuntime.prepareReactionPayloadForDelivery({
+      payload: {
+        presentation,
+        channelData: { askUser: { questionId } },
+        mediaUrls: ["https://example.test/one.png", "https://example.test/two.png"],
+      },
+      presentation,
+    });
+    if (!payload) {
+      throw new Error("expected Signal question reaction payload");
+    }
+    getReplyFromConfigMock.mockResolvedValue(payload);
+    let firstSendAccepted!: () => void;
+    const firstSendAcceptedPromise = new Promise<void>((resolve) => {
+      firstSendAccepted = resolve;
+    });
+    sendMessageSignalMock.mockImplementationOnce(async () => {
+      firstSendAccepted();
+      abort.abort(new Error("Signal monitor stopping"));
+      return { messageId: "1700000006000" };
+    });
+    const cfg = {
+      session: { store: state.statePath("sessions") },
+      channels: {
+        signal: {
+          account: "+15550009999",
+          dmPolicy: "allowlist",
+          allowFrom: ["+15550001111"],
+        },
+      },
+    } as OpenClawConfig;
+    const handler = eventHandlerModule.createSignalEventHandler(
+      harnessModule.createBaseSignalEventHandlerDeps({
+        cfg,
+        abortSignal: abort.signal,
+        baseUrl: "http://signal.test:8080",
+        account: "+15550009999",
+        deliverReplies: async (params) =>
+          await deliverReplies({ ...params, cfg, chunkMode: "length" }),
+      }),
+    );
+    const monitor = await startSignalIngressMonitor({
+      accountId: "default",
+      queue: queue as Parameters<typeof startSignalIngressMonitor>[0]["queue"],
+      dispatch: async (event, lifecycle) => await handler(event, lifecycle),
+      runtime: { error: vi.fn(), log: vi.fn() },
+    });
+    const event = harnessModule.createSignalReceiveEvent({
+      timestamp,
+      dataMessage: { timestamp, message: "ask me", attachments: [] },
+    });
+
+    await monitor.receive(event);
+    await firstSendAcceptedPromise;
+    await monitor.stop();
+
+    expect(sendMessageSignalMock).toHaveBeenCalledOnce();
+    expect(await queue.listPending({ limit: "all" })).toEqual([]);
+    await expect(
+      maybeResolveSignalQuestionReaction({
+        cfg,
+        accountId: "default",
+        conversationKey: "+15550001111",
+        messageId: "1700000006000",
+        reactionKey: "1️⃣",
+        isRemove: false,
+        actorId: "+15550001111",
+        targetAuthor: "+15550009999",
+      }),
+    ).resolves.toBe(true);
+    expect(resolveQuestionReactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ questionId, optionValue: "One" }),
+    );
+
+    const restarted = await startSignalIngressMonitor({
+      accountId: "default",
+      queue: queue as Parameters<typeof startSignalIngressMonitor>[0]["queue"],
+      dispatch: async (incoming, lifecycle) => await handler(incoming, lifecycle),
+      runtime: { error: vi.fn(), log: vi.fn() },
+    });
+    try {
+      await restarted.receive(event);
+      expect(sendMessageSignalMock).toHaveBeenCalledOnce();
+    } finally {
+      await restarted.stop();
+    }
+  });
+
+  it("retries only a proven pre-dispatch failure after a fresh monitor restart", async () => {
+    const timestamp = 1_700_000_005_003;
+    const error = new PlatformMessageNotDispatchedError("Signal offline before dispatch", {
+      cause: new Error("offline"),
+    });
+    getReplyFromConfigMock.mockResolvedValue({ text: "retry me" });
+    sendMessageSignalMock.mockRejectedValueOnce(error);
+    const cfg = {
+      session: { store: state.statePath("sessions") },
+      channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const createMonitor = async () => {
+      const handler = eventHandlerModule.createSignalEventHandler(
+        harnessModule.createBaseSignalEventHandlerDeps({ cfg }),
+      );
+      return await startSignalIngressMonitor({
+        accountId: "default",
+        queue: queue as Parameters<typeof startSignalIngressMonitor>[0]["queue"],
+        dispatch: async (event, lifecycle) => await handler(event, lifecycle),
+        runtime: { error: vi.fn(), log: vi.fn() },
+      });
+    };
+    const event = harnessModule.createSignalReceiveEvent({
+      timestamp,
+      dataMessage: { timestamp, message: "please retry", attachments: [] },
+    });
+
+    const first = await createMonitor();
+    await first.receive(event);
+    await first.waitForIdle();
+    await first.stop();
+    expect(sendMessageSignalMock).toHaveBeenCalledOnce();
+    const [pending] = await queue.listPending({ limit: "all" });
+    expect(pending).toMatchObject({
+      attempts: 1,
+      lastError: expect.stringContaining("Signal offline before dispatch"),
+    });
+    if (!pending) {
+      throw new Error("expected retryable Signal ingress row");
+    }
+
+    // Advance the durable retry clock through its owner API, then rebuild the process-local
+    // runtime graph while retaining the same SQLite queue to model a real monitor restart.
+    await queue.release(pending.id, {
+      ...(pending.lastError ? { lastError: pending.lastError } : {}),
+      releasedAt: 1,
+    });
+    sendMessageSignalMock.mockResolvedValueOnce({ messageId: "1700000006001" });
+    vi.resetModules();
+    const [
+      freshChannel,
+      freshHandlerModule,
+      freshHarness,
+      freshIngress,
+      freshPluginRuntime,
+      freshReplyRuntime,
+    ] = await Promise.all([
+      import("../channel.js"),
+      import("./event-handler.js"),
+      import("./event-handler.test-harness.js"),
+      import("../signal-ingress.js"),
+      import("openclaw/plugin-sdk/plugin-test-runtime"),
+      import("openclaw/plugin-sdk/reply-runtime"),
+    ]);
+    freshReplyRuntime.resetInboundDedupe();
+    freshPluginRuntime.setActivePluginRegistry(
+      freshPluginRuntime.createTestRegistry([
+        { pluginId: "signal", plugin: freshChannel.signalPlugin, source: "test-restart" },
+      ]),
+    );
+    const retryHandler = freshHandlerModule.createSignalEventHandler(
+      freshHarness.createBaseSignalEventHandlerDeps({ cfg }),
+    );
+    const retryMonitor = await freshIngress.startSignalIngressMonitor({
+      accountId: "default",
+      queue: queue as Parameters<typeof freshIngress.startSignalIngressMonitor>[0]["queue"],
+      dispatch: async (retryEvent, lifecycle) => await retryHandler(retryEvent, lifecycle),
+      runtime: { error: vi.fn(), log: vi.fn() },
+    });
+
+    try {
+      await retryMonitor.receive(event);
+      await retryMonitor.waitForIdle();
+      expect(sendMessageSignalMock).toHaveBeenCalledTimes(2);
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
+      expect(
+        await queue.enqueue(pending.id, pending.payload, {
+          receivedAt: pending.receivedAt,
+          laneKey: pending.laneKey,
+        }),
+      ).toMatchObject({ kind: "completed", duplicate: true });
+
+      await retryMonitor.receive(event);
+      await retryMonitor.waitForIdle();
+      expect(sendMessageSignalMock).toHaveBeenCalledTimes(2);
+    } finally {
+      await retryMonitor.stop();
+      freshPluginRuntime.resetPluginRuntimeStateForTest();
+    }
+  });
+});

--- a/extensions/signal/src/monitor/event-handler.partial-delivery.test.ts
+++ b/extensions/signal/src/monitor/event-handler.partial-delivery.test.ts
@@ -38,10 +38,29 @@ vi.mock("openclaw/plugin-sdk/question-gateway-runtime", async (importOriginal) =
   };
 });
 
-vi.mock("../../../../src/auto-reply/reply/get-reply-from-config.runtime.js", () => ({
-  getReplyFromConfig: getReplyFromConfigMock,
-  prewarmConfigDrivenReplyRuntime: vi.fn(async () => undefined),
-}));
+vi.mock("openclaw/plugin-sdk/channel-inbound", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/channel-inbound")>(
+    "openclaw/plugin-sdk/channel-inbound",
+  );
+  return {
+    ...actual,
+    runChannelInboundEvent: async (params: Parameters<typeof actual.runChannelInboundEvent>[0]) => {
+      const resolveTurn = params.adapter.resolveTurn;
+      return await actual.runChannelInboundEvent({
+        ...params,
+        adapter: {
+          ...params.adapter,
+          resolveTurn: async (...args: Parameters<typeof resolveTurn>) => {
+            const resolved = await resolveTurn(...args);
+            return "runDispatch" in resolved
+              ? resolved
+              : ({ ...resolved, replyResolver: getReplyFromConfigMock } as typeof resolved);
+          },
+        },
+      });
+    },
+  };
+});
 
 vi.mock("../send.js", () => ({
   sendMessageSignal: sendMessageSignalMock,

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -79,6 +79,7 @@ import {
   type SignalSender,
 } from "../identity.js";
 import { formatSignalMediaText } from "../media-text.js";
+import { createSignalNativeReplyIdPlan } from "../native-reply.js";
 import { normalizeSignalMessagingTarget } from "../normalize.js";
 import { maybeResolveSignalQuestionReaction } from "../question-reactions.js";
 import { resolveSignalReactionLevel } from "../reaction-level.js";
@@ -447,6 +448,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     };
     const dispatcherOptions: NonNullable<ChannelInboundTurnPlan["dispatcherOptions"]> = {
       ...replyPipeline,
+      propagateRetryableNoSendFailure: true,
       humanDelay: resolveHumanDelayConfig(deps.cfg, route.agentId),
       typingCallbacks,
     };
@@ -466,6 +468,34 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           replyContext: nativeReplyContext,
           chatType: entry.isGroup ? "group" : "direct",
         });
+      },
+      durable: (payload, info) => {
+        if (info.kind !== "final") {
+          return false;
+        }
+        const replyPlan = createSignalNativeReplyIdPlan({
+          payload,
+          replyContext: nativeReplyContext,
+          replyToMode,
+        });
+        const send: typeof sendMessageSignal = async (to, text, options) => {
+          entry.turnAdoptionLifecycle?.abortSignal.throwIfAborted();
+          deps.abortSignal?.throwIfAborted();
+          const result = await sendMessageSignal(to, text, {
+            ...options,
+            baseUrl: deps.baseUrl,
+            account: deps.account,
+            maxBytes: deps.mediaMaxBytes,
+            accountId: deps.accountId,
+          });
+          replyPlan.markSent();
+          return result;
+        };
+        return {
+          deps: { signal: send },
+          replyToId: replyPlan.peek() ?? null,
+          replyToMode,
+        };
       },
       onError: (err, info) => {
         deps.runtime.error?.(danger(`signal ${info.kind} reply failed: ${String(err)}`));

--- a/extensions/signal/src/native-reply.ts
+++ b/extensions/signal/src/native-reply.ts
@@ -1,0 +1,92 @@
+import type { ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
+import { createReplyReferencePlanner } from "openclaw/plugin-sdk/reply-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { SignalNativeReplyContext } from "./monitor/event-handler.types.js";
+
+type SignalNativeReplyIdPlan = {
+  peek: () => string | undefined;
+  use: () => string | undefined;
+  markSent: () => void;
+};
+
+function resolveSignalNativeReplyId(params: {
+  payload: ReplyPayload;
+  replyContext?: SignalNativeReplyContext;
+}): string | undefined {
+  if (params.payload.replyToCurrent === false) {
+    return undefined;
+  }
+  const payloadReplyToId = normalizeOptionalString(params.payload.replyToId);
+  const isExplicitCurrentReply =
+    params.payload.replyToTag === true || params.payload.replyToCurrent === true;
+  if (
+    !payloadReplyToId &&
+    !isExplicitCurrentReply &&
+    params.replyContext?.allowImplicitCurrentMessage === false
+  ) {
+    return undefined;
+  }
+  const contextReplyToId = normalizeOptionalString(params.replyContext?.replyToId);
+  if (!contextReplyToId || (payloadReplyToId && payloadReplyToId !== contextReplyToId)) {
+    return undefined;
+  }
+  return payloadReplyToId ?? contextReplyToId;
+}
+
+function isSignalStatusNoticePayload(payload: ReplyPayload): boolean {
+  return Boolean(payload.isCompactionNotice || payload.isFallbackNotice || payload.isStatusNotice);
+}
+
+export function createSignalNativeReplyIdPlan(params: {
+  payload: ReplyPayload;
+  replyContext?: SignalNativeReplyContext;
+  replyToMode: ReplyToMode;
+}): SignalNativeReplyIdPlan {
+  const replyToId = resolveSignalNativeReplyId(params);
+  if (!replyToId) {
+    return { peek: () => undefined, use: () => undefined, markSent: () => undefined };
+  }
+  const isExplicitReply =
+    params.payload.replyToTag === true || params.payload.replyToCurrent === true;
+  const isStatusNotice = isSignalStatusNoticePayload(params.payload);
+  if (isStatusNotice) {
+    const resolve = params.replyToMode === "off" ? () => undefined : () => replyToId;
+    return { peek: resolve, use: resolve, markSent: () => undefined };
+  }
+  if (isExplicitReply) {
+    const resolve = () => replyToId;
+    return { peek: resolve, use: resolve, markSent: () => undefined };
+  }
+  const planner = createReplyReferencePlanner({
+    replyToMode: params.replyToMode,
+    existingId: replyToId,
+    hasReplied: params.replyContext?.state?.hasReplied,
+  });
+  const syncState = () => {
+    if (params.replyContext?.state) {
+      params.replyContext.state.hasReplied = planner.hasReplied();
+    }
+  };
+  return {
+    peek: () => planner.peek(),
+    use: () => {
+      const nextReplyToId = planner.use();
+      syncState();
+      return nextReplyToId;
+    },
+    markSent: () => {
+      planner.markSent();
+      syncState();
+    },
+  };
+}
+
+export function createSignalNativeReplyIdResolver(params: {
+  payload: ReplyPayload;
+  replyContext?: SignalNativeReplyContext;
+  replyToMode: ReplyToMode;
+}): () => string | undefined {
+  const plan = createSignalNativeReplyIdPlan(params);
+  return plan.use;
+}

--- a/src/auto-reply/reply/dispatch-from-config.final-outcome-counts.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.final-outcome-counts.test.ts
@@ -1,8 +1,26 @@
 // Tests settled dispatcher outcome accounting for dispatch-from-config runs.
 import { describe, expect, it } from "vitest";
+import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
 import { createReplyDispatcher } from "./reply-dispatcher.js";
 
 describe("settled dispatcher final outcomes", () => {
+  it("rethrows an opted-in proven no-send failure when nothing was visible", async () => {
+    const error = new PlatformMessageNotDispatchedError("offline before dispatch", {
+      cause: new Error("offline"),
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async () => {
+        throw error;
+      },
+      propagateRetryableNoSendFailure: true,
+    });
+
+    dispatcher.sendFinalReply({ text: "retry me" });
+    dispatcher.markComplete();
+
+    await expect(dispatcher.waitForIdle()).rejects.toBe(error);
+  });
+
   it("keeps non-visible, pre-send, and post-send outcomes distinct", async () => {
     const dispatcher = createReplyDispatcher({
       deliver: async (_payload, info) => {

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -7,7 +7,7 @@ import {
   findPlatformMessageRejectedError,
   isProvenDeliveryNotSentError,
 } from "../../infra/delivery-recovery.shared.js";
-import { collectErrorGraphCandidates } from "../../infra/errors.js";
+import { collectErrorGraphCandidates, toErrorObject } from "../../infra/errors.js";
 import { settlePendingFinalDelivery } from "../../infra/outbound/delivery-completion.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
@@ -166,6 +166,8 @@ export type ReplyDispatcherOptions = {
   onHeartbeatStrip?: () => void;
   onIdle?: () => Promise<void> | void;
   onError?: ReplyDispatchErrorHandler;
+  /** Let a durable ingress owner retry when every attempted send proves no recipient visibility. */
+  propagateRetryableNoSendFailure?: boolean;
   // AIDEV-NOTE: onSkip lets channels detect silent/empty drops (e.g. Telegram empty-response fallback).
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
@@ -273,6 +275,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     block: createReplyDispatchSettledCounts(),
     final: createReplyDispatchSettledCounts(),
   };
+  let retryableNoSendError: Error | undefined;
   let sendChain: Promise<void> = Promise.resolve();
   let settlementChain: Promise<void> = Promise.resolve();
   let pendingFinalizations = 0;
@@ -441,10 +444,12 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         })(),
       };
     } catch (error) {
+      const retryableNoSend = isRetryableNoSendFailure(error);
+      if (retryableNoSend) {
+        retryableNoSendError ??= toErrorObject(error, "reply delivery failed before dispatch");
+      }
       const outcome: ReplyDispatchDeliveryOutcome =
-        deliveryStarted && !isRetryableNoSendFailure(error)
-          ? "failed-deliver"
-          : "failed-before-deliver";
+        deliveryStarted && !retryableNoSend ? "failed-deliver" : "failed-before-deliver";
       if (custody && deliveryStarted) {
         // Proven no-send keeps the marker replayable for restart recovery —
         // including after direct custody escalated queued→unknown pre-I/O,
@@ -610,7 +615,15 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     supportsSettledReceipt: true,
     waitForIdle: async () => {
       await waitForIdle();
-      return buildReceipt();
+      const receipt = buildReceipt();
+      if (
+        options.propagateRetryableNoSendFailure === true &&
+        !receipt.anyVisibleDelivered &&
+        retryableNoSendError !== undefined
+      ) {
+        throw retryableNoSendError;
+      }
+      return receipt;
     },
     getQueuedCounts: () => ({ ...queuedCounts }),
     getCancelledCounts: () => mapReplyDispatchCounts(settledCounts, (counts) => counts.cancelled),

--- a/src/channels/turn/durable-delivery.test.ts
+++ b/src/channels/turn/durable-delivery.test.ts
@@ -24,7 +24,11 @@ vi.mock("../message/send.js", async (importOriginal) => {
 
 import { createExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import type { FinalizedMsgContext } from "../../auto-reply/templating.js";
-import { deliverInboundReplyWithMessageSendContextCore } from "./durable-delivery.js";
+import { PlatformMessageNotDispatchedError } from "../../infra/outbound/deliver-types.js";
+import {
+  deliverInboundReplyWithMessageSendContextCore,
+  throwIfDurableInboundReplyDeliveryFailed,
+} from "./durable-delivery.js";
 
 type SendDurableMessageBatchRequest = {
   cfg?: unknown;
@@ -170,7 +174,13 @@ describe("durable inbound reply delivery", () => {
     const error = new Error("second chunk failed");
     mocks.sendDurableMessageBatch.mockResolvedValueOnce({
       status: "partial_failed",
-      results: [{ channel: "telegram", messageId: "m1" }],
+      results: [
+        {
+          channel: "telegram",
+          messageId: "m1",
+          meta: { visibleText: "formatted accepted prefix" },
+        },
+      ],
       receipt: {
         primaryPlatformMessageId: "m1",
         platformMessageIds: ["m1"],
@@ -179,6 +189,12 @@ describe("durable inbound reply delivery", () => {
       },
       error,
       sentBeforeError: true,
+      deliveryIntent: {
+        id: "queue-1",
+        channel: "telegram",
+        to: "chat-1",
+        queuePolicy: "best_effort",
+      },
     });
 
     const result = await deliverInboundReplyWithMessageSendContextCore({
@@ -187,12 +203,62 @@ describe("durable inbound reply delivery", () => {
       agentId: "main",
       info: { kind: "final" },
       payload: { text: "final" },
+      replyToId: "source-1",
+      threadId: "thread-1",
       ctxPayload: ctxPayload({
         OriginatingTo: "chat-1",
       }),
     });
 
-    expect(result).toEqual({ status: "failed", error, sentBeforeError: true });
-    expect(error).toMatchObject({ sentBeforeError: true, visibleReplySent: true });
+    expect(result).toMatchObject({
+      status: "failed",
+      sentBeforeError: true,
+      error: {
+        code: "CHANNEL_PARTIAL_DELIVERY",
+        cause: error,
+        deliveryResult: {
+          messageIds: ["m1"],
+          receipt: expect.objectContaining({ primaryPlatformMessageId: "m1" }),
+          visibleReplySent: true,
+          content: "formatted accepted prefix",
+          replyToId: "source-1",
+          threadId: "thread-1",
+          deliveryIntent: {
+            id: "queue-1",
+            kind: "outbound_queue",
+            queuePolicy: "best_effort",
+          },
+        },
+      },
+    });
+    expect(() => throwIfDurableInboundReplyDeliveryFailed(result)).toThrow(
+      expect.objectContaining({ code: "CHANNEL_PARTIAL_DELIVERY" }),
+    );
+    expect(error).not.toHaveProperty("sentBeforeError");
+  });
+
+  it.each([
+    {
+      label: "proven no-dispatch",
+      error: new PlatformMessageNotDispatchedError("offline before dispatch", {
+        cause: new Error("offline"),
+      }),
+    },
+    { label: "ambiguous first-send", error: new Error("socket closed") },
+  ])("keeps a $label failure non-visible and preserves its retry contract", async ({ error }) => {
+    mocks.sendDurableMessageBatch.mockResolvedValueOnce({ status: "failed", error });
+
+    const result = await deliverInboundReplyWithMessageSendContextCore({
+      cfg: {},
+      channel: "telegram",
+      agentId: "main",
+      info: { kind: "final" },
+      payload: { text: "final" },
+      ctxPayload: ctxPayload({ OriginatingTo: "chat-1" }),
+    });
+
+    expect(result).toEqual({ status: "failed", error });
+    expect(error).not.toHaveProperty("visibleReplySent");
+    expect(error).not.toHaveProperty("sentBeforeError");
   });
 });

--- a/src/channels/turn/durable-delivery.ts
+++ b/src/channels/turn/durable-delivery.ts
@@ -18,7 +18,10 @@ import {
   durableMessageBatchMayHaveReachedRecipient,
   sendDurableMessageBatchCore,
 } from "../message/send.js";
-import { createChannelDeliveryResultFromReceipt } from "./delivery-result.js";
+import {
+  createChannelDeliveryResultFromReceipt,
+  createChannelPartialDeliveryError,
+} from "./delivery-result.js";
 import type { ChannelDeliveryInfo, ChannelDeliveryResult } from "./types.js";
 
 /** Options controlling durable final delivery for inbound channel replies. */
@@ -131,22 +134,18 @@ export function throwIfDurableInboundReplyDeliveryFailed(
   result: DurableInboundReplyDeliveryResult,
 ): void {
   if (result.status === "failed") {
-    throw result.sentBeforeError === true
-      ? markDurableInboundReplyDeliveryErrorVisible(result.error)
-      : result.error;
+    throw result.error;
   }
 }
 
-function markDurableInboundReplyDeliveryErrorVisible(error: unknown): unknown {
-  // Partial durable sends must suppress duplicate fallback delivery while still surfacing failure.
-  if (typeof error === "object" && error !== null && Object.isExtensible(error)) {
-    Object.assign(error, { sentBeforeError: true, visibleReplySent: true });
-    return error;
-  }
-
-  const visibleError = new Error("visible durable reply delivery failed", { cause: error });
-  Object.assign(visibleError, { sentBeforeError: true, visibleReplySent: true });
-  return visibleError;
+function resolveAcceptedVisibleContent(
+  results: readonly { meta?: Record<string, unknown> }[],
+): string | undefined {
+  const content = results
+    .map((result) => result.meta?.visibleText)
+    .filter((value): value is string => typeof value === "string")
+    .join("");
+  return content || undefined;
 }
 
 /** Delivers final inbound replies through the durable message-send context when supported. */
@@ -241,9 +240,21 @@ export async function deliverInboundReplyWithMessageSendContextCore(
     return { status: "failed" as const, error: send.error };
   }
   if (send.status === "partial_failed") {
+    const content = resolveAcceptedVisibleContent(send.results);
+    const delivery = createChannelDeliveryResultFromReceipt({
+      receipt: send.receipt,
+      threadId: stringifyThreadId(threadId),
+      ...(replyToId ? { replyToId } : {}),
+      visibleReplySent: true,
+      ...(content ? { content } : {}),
+      ...(send.deliveryIntent ? { deliveryIntent: toDeliveryIntent(send.deliveryIntent) } : {}),
+    });
     return {
       status: "failed" as const,
-      error: markDurableInboundReplyDeliveryErrorVisible(send.error),
+      error: createChannelPartialDeliveryError(send.error, {
+        ...delivery,
+        visibleReplySent: true,
+      }),
       sentBeforeError: true,
     };
   }

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -225,6 +225,7 @@ export async function deliverOutboundPayloadsCore(
     activeSourceIndex = payloadIndex;
     const payload = preparedEntry.payload;
     const payloadResultStartIndex = results.length;
+    let effectivePayload: typeof payload | null | undefined;
     let payloadSummary = buildPayloadSummary(payload);
     const originalMediaCount = preparedEntry.preparedMediaCount;
     let deliveryKind: DiagnosticMessageDeliveryKind = "other";
@@ -301,7 +302,7 @@ export async function deliverOutboundPayloadsCore(
         renderedHandler.normalizePayload
           ? renderedHandler.normalizePayload(renderedPayload)
           : renderedPayload;
-      const effectivePayload = normalizedEffectivePayload
+      effectivePayload = normalizedEffectivePayload
         ? normalizeEmptyPayloadForDelivery(
             stripInternalRuntimeScaffoldingFromPayload(normalizedEffectivePayload),
           )
@@ -586,6 +587,15 @@ export async function deliverOutboundPayloadsCore(
       // results. Keep the results, but never match them to a later payload.
       resetReportedResults();
       const failedPayloadResults = results.slice(payloadResultStartIndex);
+      adoptSuccessfulResultsSince(payloadResultStartIndex);
+      if (effectivePayload && failedPayloadResults.length > 0) {
+        await maybeNotifyAfterDeliveredPayload({
+          handler: await getDeliveryHandler(buildPayloadSummary(effectivePayload).mediaUrls),
+          payload: effectivePayload,
+          target: baseHandler.buildTargetRef({ threadId: preparedTarget.threadId }),
+          results: failedPayloadResults,
+        });
+      }
       recordPayloadOutcome({
         index: payloadIndex,
         status: "failed",

--- a/src/infra/outbound/deliver.target-adoption.test.ts
+++ b/src/infra/outbound/deliver.target-adoption.test.ts
@@ -108,7 +108,7 @@ describe("outbound durable-batch target adoption", () => {
     expect(adoptTargetFromDelivery).toHaveBeenCalledTimes(1);
   });
 
-  it("waits for an identified successful send after no-identity and failed attempts", async () => {
+  it("adopts an identified accepted send before a later payload failure", async () => {
     const sendText = vi.fn(
       async ({
         text,
@@ -157,12 +157,13 @@ describe("outbound durable-batch target adoption", () => {
     expect(sendText.mock.calls.map(([ctx]) => ctx.threadId)).toEqual([
       undefined,
       undefined,
-      undefined,
-      "thread-created",
+      "thread-failed",
+      "thread-failed",
     ]);
     expect(afterDeliverPayload.mock.calls.map(([ctx]) => ctx.target.threadId)).toEqual([
-      "thread-created",
-      "thread-created",
+      "thread-failed",
+      "thread-failed",
+      "thread-failed",
     ]);
     expect(adoptTargetFromDelivery).toHaveBeenCalledTimes(1);
   });

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -3700,6 +3700,66 @@ describe("deliverOutboundPayloads", () => {
     expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
   });
 
+  it("runs partial after-delivery bookkeeping once with rendered payload and accepted target", async () => {
+    const platformError = new Error("second formatted chunk failed");
+    const firstResult = {
+      channel: "line" as const,
+      messageId: "fmt-1",
+      meta: { visibleText: "native formatted prefix" },
+    };
+    const afterDeliverPayload = vi.fn(async () => {
+      throw new Error("observer failed");
+    });
+    const onError = vi.fn();
+    setTestOutbound(
+      {
+        renderPresentation: ({ payload }) => ({ ...payload, text: "native formatted prefix" }),
+        sendFormattedText: async (ctx) => {
+          await ctx.onDeliveryResult?.(firstResult);
+          throw platformError;
+        },
+        sendText: async () => firstResult,
+        adoptTargetFromDelivery: ({ result }) =>
+          result.messageId === "fmt-1" ? { threadId: "thread-from-platform" } : null,
+        afterDeliverPayload,
+      },
+      "line",
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [
+        {
+          text: "fallback",
+          presentation: { blocks: [{ type: "context", text: "native" }] },
+        },
+      ],
+      bestEffort: true,
+      skipQueue: true,
+      onError,
+    });
+
+    expect(results).toEqual([firstResult]);
+    expect(afterDeliverPayload).toHaveBeenCalledOnce();
+    expect(afterDeliverPayload).toHaveBeenCalledWith({
+      cfg: {},
+      target: {
+        channel: "line",
+        to: "U123",
+        accountId: undefined,
+        threadId: "thread-from-platform",
+      },
+      payload: { text: "native formatted prefix" },
+      results: [firstResult],
+    });
+    expect(onError).toHaveBeenCalledWith(
+      platformError,
+      expect.objectContaining({ text: "native formatted prefix" }),
+    );
+  });
+
   it("preserves repeated platform identities across separate adapter invocations", async () => {
     const sendFormattedText = vi.fn(
       async (ctx: {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Signal interactive and final replies could visibly send an early chunk and then fail later. Ingress was already durably adopted, so it did not replay, but accepted formatted content and approval/question reaction bindings were lost, leaving users with a visible dead prompt.

## Why This Change Was Made

Signal finals now use shared durable-final delivery, while non-final replies retain direct delivery. Accepted prefixes run the shared after-delivery bookkeeping, and partial outcomes project the canonical delivery receipt and accepted content. Only proven no-dispatch failures propagate back to durable ingress; ambiguous sends remain fail-closed. Native quote behavior and fallback state are preserved.

## User Impact

Partial sends no longer trigger duplicate replay, and reaction controls attached to accepted approval or question content remain usable. Failures proven to occur before the first send can retry, while ambiguous sends remain fail-closed.

Release-note context: Signal partial interactive replies retain durable delivery receipts and reaction controls when a later chunk fails.

## Evidence

- Pre-fix regression: the approval binding resolved to `null` after an early accepted chunk followed by a later send failure.
- Final boundary test: 3/3 passed.
- Full Signal suite: 821/821 passed.
- Channel contracts: 1928/1928 passed.
- Shared durable/outbound tests: 236 passed.
- Complete `check-changed` passed.
- `pnpm build` passed.
- Fresh autoreview completed with no actionable findings.
- Production LOC: +199/-91 (net +108). Tests: +584/-7, including the two new files. The production growth establishes shared durable ownership, canonical error projection, and an extracted native reply planner.
- A later re-run after dependency drift could not collect because the primary checkout's shared `node_modules` lacked `openai/index.mjs`. This is an environment gap, not an assertion failure; exact-head hosted CI/Testbox is required before merge.
- No live Signal account was available. Verification used the real event-handler and SQLite boundary; no existing Signal mock-gateway QA lane was found.

AI-assisted: Yes.
