### PR TITLE
fix(workboard): preserve concurrent card edits when decomposition fails

### DIFF
--- a/extensions/workboard/src/dispatcher-compensation.test.ts
+++ b/extensions/workboard/src/dispatcher-compensation.test.ts
@@ -1,0 +1,87 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { dispatchAndStartWorkboardCards } from "./dispatcher.js";
+import { createWorkboardSqliteStores } from "./sqlite-store.js";
+import { WorkboardStore } from "./store.js";
+
+describe("Workboard dispatcher compensation", () => {
+  it.each([
+    {
+      edit: "unrelated notes",
+      hostWorkspace: undefined,
+      expectedWorkspace: { kind: "worktree", path: "/repo", branch: "main" } as const,
+    },
+    {
+      edit: "workspace",
+      hostWorkspace: {
+        kind: "worktree",
+        path: "/host-workspace",
+        branch: "host-branch",
+        sourcePath: "/host-source",
+        sourceBranch: "host-base",
+      } as const,
+      expectedWorkspace: {
+        kind: "worktree",
+        path: "/host-workspace",
+        branch: "host-branch",
+        sourcePath: "/host-source",
+        sourceBranch: "host-base",
+      } as const,
+    },
+  ])("compensates a materialized workspace after a concurrent $edit edit", async (testCase) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-dispatch-rollback-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    const dispatchStores = createWorkboardSqliteStores({ dbPath });
+    const hostStores = createWorkboardSqliteStores({ dbPath });
+    const store = new WorkboardStore(dispatchStores.cards);
+    const host = new WorkboardStore(hostStores.cards);
+    try {
+      const card = await store.create({
+        title: "Isolated worker",
+        status: "ready",
+        workspace: { kind: "worktree", path: "/repo", branch: "main" },
+        workspaceAccess: { unrestricted: true },
+      });
+      const worktrees = {
+        resolveCheckoutRoot: vi.fn().mockResolvedValue(undefined),
+        create: vi.fn().mockResolvedValue({
+          id: "managed-id",
+          path: "/state/worktrees/fingerprint/wb-card",
+          branch: `openclaw/wb-${card.id}`,
+        }),
+        release: vi.fn(),
+        removeIfLossless: vi.fn().mockResolvedValue(true),
+      };
+      const run = vi.fn(async () => {
+        await host.update(card.id, {
+          notes: "Concurrent host edit",
+          ...(testCase.hostWorkspace ? { workspace: testCase.hostWorkspace } : {}),
+        });
+        throw new Error("model unavailable");
+      });
+
+      const result = await dispatchAndStartWorkboardCards({
+        store,
+        subagent: { run },
+        worktrees,
+        options: { now: 10, maxStarts: 1, materializeWorktree: true },
+      });
+
+      expect(result.startFailures).toEqual([
+        expect.objectContaining({ cardId: card.id, error: "model unavailable" }),
+      ]);
+      const persisted = await host.get(card.id);
+      expect(persisted).toMatchObject({
+        status: "blocked",
+        notes: "Concurrent host edit",
+      });
+      expect(persisted?.metadata?.automation?.workspace).toEqual(testCase.expectedWorkspace);
+    } finally {
+      hostStores.close();
+      dispatchStores.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/workboard/src/dispatcher.ts
+++ b/extensions/workboard/src/dispatcher.ts
@@ -365,6 +365,7 @@ async function runWorkboardDispatch(
     let implicitWorkspaceCwd: string | undefined;
     let runStarted = false;
     let launchIntentPersisted = false;
+    let workspaceMutation: { before: WorkboardCard; after: WorkboardCard } | undefined;
     const requestedWorkspace = card.metadata?.automation?.workspace;
     let workspaceAccess: WorkboardWorkspaceAccess;
     let targetWorkspace: string | undefined;
@@ -490,7 +491,16 @@ async function runWorkboardDispatch(
       }
       materializedWorkspace = materialized.workspace;
       if (materializedWorkspace) {
-        await params.store.update(card.id, { workspace: materializedWorkspace, workspaceAccess });
+        const workspaceBase = await params.store.get(card.id);
+        if (!workspaceBase) {
+          throw new Error(`card not found: ${card.id}`);
+        }
+        const materializedCard = await params.store.update(
+          card.id,
+          { workspace: materializedWorkspace, workspaceAccess },
+          { expectedUpdatedAt: workspaceBase.updatedAt },
+        );
+        workspaceMutation = { before: workspaceBase, after: materializedCard };
       }
       const launchBase = await params.store.get(card.id);
       if (!launchBase) {
@@ -592,9 +602,10 @@ async function runWorkboardDispatch(
             ownerId: card.id,
           })
           .catch(() => undefined);
-        const sourceWorkspace = card.metadata?.automation?.workspace;
-        if (sourceWorkspace) {
-          await params.store.update(card.id, { workspace: sourceWorkspace }).catch(() => undefined);
+        if (workspaceMutation) {
+          await params.store
+            .compensateWorkspaceMutation(workspaceMutation.before, workspaceMutation.after)
+            .catch(() => undefined);
         }
       }
       const message = formatErrorMessage(error);

--- a/extensions/workboard/src/persistence-types.ts
+++ b/extensions/workboard/src/persistence-types.ts
@@ -51,6 +51,7 @@ export type WorkboardCardStore = WorkboardKeyedStore & {
     value: PersistedWorkboardCard,
     expectedUpdatedAt: number,
   ): Promise<boolean>;
+  deleteIfUpdatedAt(key: string, expectedUpdatedAt: number): Promise<boolean>;
   claimIfOwnerAvailable(
     key: string,
     value: PersistedWorkboardCard,
@@ -70,6 +71,8 @@ export function isWorkboardCardStore(store: WorkboardKeyedStore): store is Workb
     "registerIfUpdatedAt" in store &&
     typeof store.registerIfUpdatedAt === "function" &&
     "claimIfOwnerAvailable" in store &&
-    typeof store.claimIfOwnerAvailable === "function"
+    typeof store.claimIfOwnerAvailable === "function" &&
+    "deleteIfUpdatedAt" in store &&
+    typeof store.deleteIfUpdatedAt === "function"
   );
 }

--- a/extensions/workboard/src/sqlite-store.ts
+++ b/extensions/workboard/src/sqlite-store.ts
@@ -1263,6 +1263,19 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
     });
   }
 
+  async deleteIfUpdatedAt(key: string, expectedUpdatedAt: number): Promise<boolean> {
+    return runSqliteImmediateTransactionSync(this.db, () => {
+      const current = this.db
+        .prepare("SELECT updated_at FROM workboard_cards WHERE id = ?")
+        .get(key);
+      if (!isRecord(current) || numberValue(current, "updated_at") !== expectedUpdatedAt) {
+        return false;
+      }
+      this.deleteCard(key);
+      return true;
+    });
+  }
+
   async lookup(key: string): Promise<PersistedWorkboardCard | undefined> {
     const row = this.db.prepare("SELECT * FROM workboard_cards WHERE id = ?").get(key) as
       | Row
@@ -1271,20 +1284,22 @@ class WorkboardSqliteCardStore implements WorkboardCardStore {
   }
 
   async delete(key: string): Promise<boolean> {
-    const result = runSqliteImmediateTransactionSync(this.db, () => {
-      this.db
-        .prepare(
-          `
-            DELETE FROM workboard_attachment_blobs
-            WHERE attachment_id IN (
-              SELECT id FROM workboard_card_attachments WHERE card_id = ?
-            )
-          `,
-        )
-        .run(key);
-      return this.db.prepare("DELETE FROM workboard_cards WHERE id = ?").run(key);
-    });
+    const result = runSqliteImmediateTransactionSync(this.db, () => this.deleteCard(key));
     return result.changes > 0;
+  }
+
+  private deleteCard(key: string) {
+    this.db
+      .prepare(
+        `
+          DELETE FROM workboard_attachment_blobs
+          WHERE attachment_id IN (
+            SELECT id FROM workboard_card_attachments WHERE card_id = ?
+          )
+        `,
+      )
+      .run(key);
+    return this.db.prepare("DELETE FROM workboard_cards WHERE id = ?").run(key);
   }
 
   async entries(): Promise<Array<{ key: string; value: PersistedWorkboardCard }>> {

--- a/extensions/workboard/src/store-change-tracker.ts
+++ b/extensions/workboard/src/store-change-tracker.ts
@@ -48,6 +48,13 @@ export class WorkboardChangeTracker {
         }
         return updated;
       },
+      deleteIfUpdatedAt: async (key, expectedUpdatedAt) => {
+        const deleted = await store.deleteIfUpdatedAt(key, expectedUpdatedAt);
+        if (deleted) {
+          this.mutationRevision += 1;
+        }
+        return deleted;
+      },
       claimIfOwnerAvailable: async (key, value, expectedUpdatedAt, ownerId, now) => {
         const result = await store.claimIfOwnerAvailable(
           key,

--- a/extensions/workboard/src/store-compensation.ts
+++ b/extensions/workboard/src/store-compensation.ts
@@ -1,0 +1,191 @@
+import { isDeepStrictEqual } from "node:util";
+import type { WorkboardCard } from "@openclaw/workboard-contract";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const ABSENT = Symbol("workboard-compensation-absent");
+
+function recordValue(record: Record<string, unknown>, key: string): unknown {
+  return Object.hasOwn(record, key) && record[key] !== undefined ? record[key] : ABSENT;
+}
+
+function canonicalValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalValue);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, entry]) => entry !== undefined)
+      .map(([key, entry]) => [key, canonicalValue(entry)]),
+  );
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  return isDeepStrictEqual(canonicalValue(left), canonicalValue(right));
+}
+
+function stableId(value: unknown): string | undefined {
+  return isRecord(value) && typeof value.id === "string" ? value.id : undefined;
+}
+
+function hasOnlyStableIds(values: unknown[]): boolean {
+  return values.every((value) => stableId(value) !== undefined);
+}
+
+function insertRestoredValues(
+  current: unknown[],
+  restored: unknown[],
+  reference: unknown[],
+): unknown[] {
+  const result = [...current];
+  for (const value of restored.toReversed()) {
+    const referenceIndex = reference.findIndex((entry) => stableId(entry) === stableId(value));
+    const nextId = reference
+      .slice(referenceIndex + 1)
+      .map(stableId)
+      .find((id) => id !== undefined && result.some((entry) => stableId(entry) === id));
+    const nextIndex = nextId ? result.findIndex((entry) => stableId(entry) === nextId) : -1;
+    result.splice(nextIndex >= 0 ? nextIndex : result.length, 0, value);
+  }
+  return result;
+}
+
+function rollbackStableIdArray(before: unknown[], after: unknown[], current: unknown[]): unknown[] {
+  const beforeById = new Map(before.map((value) => [stableId(value)!, value]));
+  const afterById = new Map(after.map((value) => [stableId(value)!, value]));
+  const currentIds = new Set(current.map((value) => stableId(value)!));
+  const merged = current.flatMap((currentValue) => {
+    const id = stableId(currentValue)!;
+    const beforeValue = beforeById.get(id);
+    const afterValue = afterById.get(id);
+    if (beforeValue === undefined && afterValue !== undefined) {
+      return sameValue(currentValue, afterValue) ? [] : [currentValue];
+    }
+    if (beforeValue !== undefined && afterValue !== undefined) {
+      const value = rollbackValue(beforeValue, afterValue, currentValue);
+      return value === ABSENT ? [] : [value];
+    }
+    return [currentValue];
+  });
+  const restored = before.filter((value) => {
+    const id = stableId(value)!;
+    return !afterById.has(id) && !currentIds.has(id);
+  });
+  return insertRestoredValues(merged, restored, before);
+}
+
+function rollbackRecord(
+  before: unknown,
+  after: unknown,
+  current: Record<string, unknown>,
+): unknown {
+  const beforeRecord = isRecord(before) ? before : {};
+  const afterRecord = isRecord(after) ? after : {};
+  const keys = new Set([
+    ...Object.keys(beforeRecord),
+    ...Object.keys(afterRecord),
+    ...Object.keys(current),
+  ]);
+  const merged: Record<string, unknown> = {};
+  for (const key of keys) {
+    const value = rollbackValue(
+      recordValue(beforeRecord, key),
+      recordValue(afterRecord, key),
+      recordValue(current, key),
+    );
+    if (value !== ABSENT) {
+      merged[key] = value;
+    }
+  }
+  return before === ABSENT && Object.keys(merged).length === 0 ? ABSENT : merged;
+}
+
+function rollbackValue(before: unknown, after: unknown, current: unknown): unknown {
+  if (sameValue(before, after)) {
+    return current;
+  }
+  if (sameValue(current, after)) {
+    return before;
+  }
+  if (current === ABSENT) {
+    return ABSENT;
+  }
+  if (
+    Array.isArray(current) &&
+    (Array.isArray(before) || before === ABSENT) &&
+    (Array.isArray(after) || after === ABSENT)
+  ) {
+    const beforeArray = Array.isArray(before) ? before : [];
+    const afterArray = Array.isArray(after) ? after : [];
+    return hasOnlyStableIds([...beforeArray, ...afterArray, ...current])
+      ? rollbackStableIdArray(beforeArray, afterArray, current)
+      : current;
+  }
+  if (
+    isRecord(current) &&
+    (isRecord(before) || before === ABSENT) &&
+    (isRecord(after) || after === ABSENT)
+  ) {
+    return rollbackRecord(before, after, current);
+  }
+  return current;
+}
+
+export function invertWorkboardCardMutation(
+  before: WorkboardCard,
+  after: WorkboardCard,
+  current: WorkboardCard,
+): WorkboardCard {
+  const merged = rollbackValue(before, after, current);
+  if (!isRecord(merged)) {
+    throw new Error("workboard card compensation produced an invalid card");
+  }
+  // SAFETY: recursive rollback starts from three valid card states and preserves the card identity.
+  return { ...merged, id: current.id, updatedAt: current.updatedAt } as WorkboardCard;
+}
+
+export function sameWorkboardCardState(left: WorkboardCard, right: WorkboardCard): boolean {
+  const { updatedAt: _leftUpdatedAt, ...leftState } = left;
+  const { updatedAt: _rightUpdatedAt, ...rightState } = right;
+  return sameValue(leftState, rightState);
+}
+
+export function invertWorkboardWorkspaceMutation(
+  before: WorkboardCard,
+  after: WorkboardCard,
+  current: WorkboardCard,
+): WorkboardCard {
+  const merged = invertWorkboardCardMutation(before, after, current);
+  const afterAutomation = after.metadata?.automation;
+  const currentAutomation = current.metadata?.automation;
+  if (sameValue(currentAutomation?.workspace, afterAutomation?.workspace)) {
+    return merged;
+  }
+  // Workspace and its authority are one host-owned unit. A same-field host edit
+  // wins whole instead of inheriting a hybrid of source and materialized fields.
+  const automation = { ...merged.metadata?.automation };
+  if (currentAutomation?.workspace) {
+    automation.workspace = currentAutomation.workspace;
+  } else {
+    delete automation.workspace;
+  }
+  if (currentAutomation?.workspaceAccess) {
+    automation.workspaceAccess = currentAutomation.workspaceAccess;
+  } else {
+    delete automation.workspaceAccess;
+  }
+  const metadata = { ...merged.metadata };
+  if (Object.keys(automation).length > 0) {
+    metadata.automation = automation;
+  } else {
+    delete metadata.automation;
+  }
+  if (Object.keys(metadata).length > 0) {
+    return { ...merged, metadata };
+  }
+  const withoutMetadata = { ...merged };
+  delete withoutMetadata.metadata;
+  return withoutMetadata;
+}

--- a/extensions/workboard/src/store-core.ts
+++ b/extensions/workboard/src/store-core.ts
@@ -36,6 +36,11 @@ import {
   appendEvent,
 } from "./store-card-helpers.js";
 import { WorkboardChangeTracker } from "./store-change-tracker.js";
+import {
+  invertWorkboardCardMutation,
+  invertWorkboardWorkspaceMutation,
+  sameWorkboardCardState,
+} from "./store-compensation.js";
 import { MAX_CARD_COMMENTS, MAX_CARD_WORKER_LOGS, POSITION_STEP } from "./store-constants.js";
 import type {
   WorkboardBoardInput,
@@ -82,6 +87,11 @@ type WorkboardUpdateCardOptions = {
   preserveProofId?: string;
 };
 
+type WorkboardMutationJournalEntry = {
+  before?: WorkboardCard;
+  after: WorkboardCard;
+};
+
 const WORKBOARD_CAS_ATTEMPTS = 3;
 
 export class WorkboardCoreStore {
@@ -89,6 +99,7 @@ export class WorkboardCoreStore {
   private lastNotificationSequence = 0;
   private readonly changes: WorkboardChangeTracker;
   private readonly cardStore?: WorkboardCardStore;
+  private compensationJournal?: WorkboardMutationJournalEntry[];
   protected readonly store: WorkboardKeyedStore;
   protected readonly boardStore: WorkboardKeyedStore<PersistedWorkboardBoard>;
   protected readonly subscriptionStore: WorkboardKeyedStore<PersistedWorkboardNotificationSubscription>;
@@ -140,6 +151,129 @@ export class WorkboardCoreStore {
       () => undefined,
     );
     return await result;
+  }
+
+  protected async withCardCompensation<T>(run: () => Promise<T>): Promise<T> {
+    if (this.compensationJournal) {
+      return await run();
+    }
+    const journal: WorkboardMutationJournalEntry[] = [];
+    this.compensationJournal = journal;
+    try {
+      return await run();
+    } catch (operationError) {
+      const compensationErrors = await this.rollbackCardMutations(journal);
+      if (compensationErrors.length > 0) {
+        throw this.compensationError(operationError, compensationErrors);
+      }
+      throw operationError;
+    } finally {
+      this.compensationJournal = undefined;
+    }
+  }
+
+  private compensationError(operationError: unknown, cleanupErrors: unknown[]): AggregateError {
+    const message =
+      operationError instanceof Error ? operationError.message : String(operationError);
+    return new AggregateError([operationError, ...cleanupErrors], message, {
+      cause: operationError,
+    });
+  }
+
+  private recordCardMutation(before: WorkboardCard | undefined, after: WorkboardCard): void {
+    // Reverse replay needs every step: later inverses strip their fields before
+    // an operation-created row can be safely classified as host-adopted.
+    this.compensationJournal?.push({ before, after });
+  }
+
+  private async rollbackCardMutations(
+    journal: WorkboardMutationJournalEntry[],
+  ): Promise<unknown[]> {
+    const errors: unknown[] = [];
+    for (const entry of journal.toReversed()) {
+      try {
+        if (!entry.before) {
+          await this.rollbackCreatedCard(entry.after);
+          continue;
+        }
+        await this.rollbackUpdatedCard(entry.before, entry.after);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    return errors;
+  }
+
+  async compensateWorkspaceMutation(before: WorkboardCard, after: WorkboardCard): Promise<void> {
+    await this.enqueueMutation(
+      async () => await this.rollbackUpdatedCard(before, after, invertWorkboardWorkspaceMutation),
+    );
+  }
+
+  private async rollbackUpdatedCard(
+    before: WorkboardCard,
+    after: WorkboardCard,
+    invert = invertWorkboardCardMutation,
+  ): Promise<void> {
+    for (let attempt = 0; attempt < WORKBOARD_CAS_ATTEMPTS; attempt += 1) {
+      const current = await this.get(after.id);
+      if (!current) {
+        return;
+      }
+      const merged = invert(before, after, current);
+      if (sameWorkboardCardState(current, merged)) {
+        return;
+      }
+      const compensation = {
+        ...merged,
+        updatedAt: Math.max(Date.now(), current.updatedAt + 1),
+      };
+      if (await this.registerCardIfUpdatedAt(compensation, current.updatedAt)) {
+        return;
+      }
+    }
+    throw new Error(`card changed repeatedly during compensation: ${after.id}`);
+  }
+
+  private async rollbackCreatedCard(created: WorkboardCard): Promise<void> {
+    for (let attempt = 0; attempt < WORKBOARD_CAS_ATTEMPTS; attempt += 1) {
+      const current = await this.get(created.id);
+      if (!current || !sameWorkboardCardState(current, created)) {
+        return;
+      }
+      if (await this.deleteCardIfUpdatedAt(created.id, current.updatedAt)) {
+        return;
+      }
+    }
+    throw new Error(`card changed repeatedly during compensation: ${created.id}`);
+  }
+
+  private async registerCardIfUpdatedAt(
+    card: WorkboardCard,
+    expectedUpdatedAt: number,
+  ): Promise<boolean> {
+    if (this.cardStore) {
+      return await this.cardStore.registerIfUpdatedAt(
+        card.id,
+        { version: 1, card },
+        expectedUpdatedAt,
+      );
+    }
+    if ((await this.get(card.id))?.updatedAt !== expectedUpdatedAt) {
+      return false;
+    }
+    await this.store.register(card.id, { version: 1, card });
+    return true;
+  }
+
+  private async deleteCardIfUpdatedAt(id: string, expectedUpdatedAt: number): Promise<boolean> {
+    if (this.cardStore) {
+      return await this.cardStore.deleteIfUpdatedAt(id, expectedUpdatedAt);
+    }
+    if ((await this.get(id))?.updatedAt !== expectedUpdatedAt) {
+      return false;
+    }
+    return await this.store.delete(id);
   }
 
   protected async updateLatestCard(
@@ -374,7 +508,10 @@ export class WorkboardCoreStore {
     input: WorkboardLinkedCreateInput,
     scope?: WorkboardMutationScope,
   ): Promise<WorkboardCard> {
-    return await this.enqueueMutation(async () => await this.createDirect(input, scope));
+    return await this.enqueueMutation(
+      async () =>
+        await this.withCardCompensation(async () => await this.createDirect(input, scope)),
+    );
   }
 
   protected async createDirect(
@@ -506,20 +643,16 @@ export class WorkboardCoreStore {
         }
         return winner;
       }
+      this.recordCardMutation(undefined, card);
     } else {
       await this.store.register(card.id, { version: 1, card });
+      this.recordCardMutation(undefined, card);
     }
-    try {
-      for (const parent of parentCards) {
-        card = await this.linkCardsDirect(parent.id, card.id, now, {
-          allowStatusOnlyActiveChild: true,
-          scope,
-        });
-      }
-    } catch (error) {
-      await this.store.delete(card.id);
-      await this.removeReferencesToCard(card.id);
-      throw error;
+    for (const parent of parentCards) {
+      card = await this.linkCardsDirect(parent.id, card.id, now, {
+        allowStatusOnlyActiveChild: true,
+        scope,
+      });
     }
     return card;
   }
@@ -770,6 +903,7 @@ export class WorkboardCoreStore {
           throw new Error(`Owner ${options.ownerSlot.ownerId} already has active Workboard work.`);
         }
         if (result === "updated") {
+          this.recordCardMutation(existing, next);
           await this.deleteDetachedAttachments(existing, next);
           return next;
         }
@@ -780,6 +914,7 @@ export class WorkboardCoreStore {
           expectedUpdatedAt,
         )
       ) {
+        this.recordCardMutation(existing, next);
         await this.deleteDetachedAttachments(existing, next);
         return next;
       }
@@ -790,6 +925,7 @@ export class WorkboardCoreStore {
       throw new WorkboardCardConflictError(current);
     }
     await this.store.register(next.id, { version: 1, card: next });
+    this.recordCardMutation(existing, next);
     await this.deleteDetachedAttachments(existing, next);
     return next;
   }
@@ -901,7 +1037,10 @@ export class WorkboardCoreStore {
     scope?: WorkboardMutationScope,
   ): Promise<WorkboardCard> {
     return await this.enqueueMutation(
-      async () => await this.linkCardsDirect(parentId, childId, Date.now(), { scope }),
+      async () =>
+        await this.withCardCompensation(
+          async () => await this.linkCardsDirect(parentId, childId, Date.now(), { scope }),
+        ),
     );
   }
 
@@ -961,12 +1100,18 @@ export class WorkboardCoreStore {
           targetCardId: parent.id,
           createdAt: now,
         });
-    await this.updateCard(parent.id, {
-      metadata: { ...parent.metadata, links: nextParentLinks },
-    });
-    const nextChild = await this.updateCard(child.id, {
-      metadata: { ...child.metadata, links: nextChildLinks },
-    });
+    await this.updateCard(
+      parent.id,
+      {
+        metadata: { ...parent.metadata, links: nextParentLinks },
+      },
+      { expectedUpdatedAt: parent.updatedAt },
+    );
+    const nextChild = await this.updateCard(
+      child.id,
+      { metadata: { ...child.metadata, links: nextChildLinks } },
+      { expectedUpdatedAt: child.updatedAt },
+    );
     return await this.promoteDependencyReady(nextChild.id);
   }
 

--- a/extensions/workboard/src/store-workflow.ts
+++ b/extensions/workboard/src/store-workflow.ts
@@ -541,109 +541,97 @@ export class WorkboardWorkflowStore extends WorkboardPromoteStore {
     input: WorkboardDecomposeInput = {},
     scope?: WorkboardMutationScope | null,
   ): Promise<{ parent: WorkboardCard; children: WorkboardCard[] }> {
-    return await this.enqueueMutation(async () => {
-      const parent = await this.get(id);
-      if (!parent) {
-        throw new Error(`card not found: ${id}`);
-      }
-      assertCanMutateClaimedCard(parent, scope === null ? undefined : scope);
-      const childrenInput = Array.isArray(input.children) ? input.children : [];
-      if (childrenInput.length === 0) {
-        throw new Error("children are required.");
-      }
-      if (childrenInput.length > 20) {
-        throw new Error("at most 20 children can be created at once.");
-      }
-      const parentAutomation = parent.metadata?.automation;
-      const existingCardIds = new Set((await this.list()).map((card) => card.id));
-      const children: WorkboardCard[] = [];
-      const reusedChildSnapshots = new Map<string, WorkboardCard>();
-      try {
-        for (const rawChild of childrenInput) {
-          if (!rawChild || typeof rawChild !== "object" || Array.isArray(rawChild)) {
-            throw new Error("children must be objects.");
+    return await this.enqueueMutation(
+      async () =>
+        await this.withCardCompensation(async () => {
+          const parent = await this.get(id);
+          if (!parent) {
+            throw new Error(`card not found: ${id}`);
           }
-          const child = rawChild as WorkboardDecomposeChildInput;
-          const created = await this.createDirect(
-            {
-              ...child,
-              parents: [parent.id],
-              boardId: child.boardId ?? parentAutomation?.boardId,
-              tenant: child.tenant ?? parentAutomation?.tenant,
-              createdByCardId: parent.id,
-              idempotencyKey:
-                child.idempotencyKey ??
-                deriveChildIdempotencyKey(parentAutomation?.idempotencyKey, children.length + 1),
-            },
-            scope === null ? undefined : scope,
-          );
-          const reusedUnlinkedChild =
-            existingCardIds.has(created.id) && !cardParentIds(created).includes(parent.id);
-          if (reusedUnlinkedChild) {
-            reusedChildSnapshots.set(created.id, created);
+          assertCanMutateClaimedCard(parent, scope === null ? undefined : scope);
+          const childrenInput = Array.isArray(input.children) ? input.children : [];
+          if (childrenInput.length === 0) {
+            throw new Error("children are required.");
           }
-          children.push(
-            cardParentIds(created).includes(parent.id)
-              ? created
-              : await this.linkCardsDirect(parent.id, created.id, Date.now(), {
-                  allowStatusOnlyActiveChild: true,
-                  scope: scope === null ? undefined : scope,
-                }),
+          if (childrenInput.length > 20) {
+            throw new Error("at most 20 children can be created at once.");
+          }
+          const parentAutomation = parent.metadata?.automation;
+          const children: WorkboardCard[] = [];
+          for (const rawChild of childrenInput) {
+            if (!rawChild || typeof rawChild !== "object" || Array.isArray(rawChild)) {
+              throw new Error("children must be objects.");
+            }
+            const child = rawChild as WorkboardDecomposeChildInput;
+            const created = await this.createDirect(
+              {
+                ...child,
+                parents: [parent.id],
+                boardId: child.boardId ?? parentAutomation?.boardId,
+                tenant: child.tenant ?? parentAutomation?.tenant,
+                createdByCardId: parent.id,
+                idempotencyKey:
+                  child.idempotencyKey ??
+                  deriveChildIdempotencyKey(parentAutomation?.idempotencyKey, children.length + 1),
+              },
+              scope === null ? undefined : scope,
+            );
+            children.push(
+              cardParentIds(created).includes(parent.id)
+                ? created
+                : await this.linkCardsDirect(parent.id, created.id, Date.now(), {
+                    allowStatusOnlyActiveChild: true,
+                    scope: scope === null ? undefined : scope,
+                  }),
+            );
+          }
+          const summary = normalizeBoundedString(
+            input.summary,
+            undefined,
+            2000,
+            "decompose summary",
           );
-        }
-        const summary = normalizeBoundedString(input.summary, undefined, 2000, "decompose summary");
-        const completeParent = input.completeParent !== false;
-        const updatedParent = completeParent
-          ? await this.completeDirect(
-              parent.id,
-              { summary, createdCardIds: children.map((child) => child.id) },
-              scope,
-            )
-          : await (async () => {
-              const latestParent = (await this.get(parent.id)) ?? parent;
-              return await this.updateCard(
+          const completeParent = input.completeParent !== false;
+          const updatedParent = completeParent
+            ? await this.completeDirect(
                 parent.id,
-                {
-                  status:
-                    latestParent.status === "triage" || latestParent.status === "backlog"
-                      ? "todo"
-                      : latestParent.status,
-                  metadata: {
-                    ...latestParent.metadata,
-                    automation: normalizeAutomation(
-                      {
-                        ...latestParent.metadata?.automation,
-                        summary,
-                        createdCardIds: children.map((child) => child.id),
-                      },
-                      latestParent.metadata?.automation,
-                    ),
+                { summary, createdCardIds: children.map((child) => child.id) },
+                scope,
+              )
+            : await (async () => {
+                const latestParent = (await this.get(parent.id)) ?? parent;
+                return await this.updateCard(
+                  parent.id,
+                  {
+                    status:
+                      latestParent.status === "triage" || latestParent.status === "backlog"
+                        ? "todo"
+                        : latestParent.status,
+                    metadata: {
+                      ...latestParent.metadata,
+                      automation: normalizeAutomation(
+                        {
+                          ...latestParent.metadata?.automation,
+                          summary,
+                          createdCardIds: children.map((child) => child.id),
+                        },
+                        latestParent.metadata?.automation,
+                      ),
+                    },
                   },
-                },
-                { enforceStatusHolds: true },
-              );
-            })();
-        const decomposedParent = await this.updateCard(
-          updatedParent.id,
-          {},
-          {
-            event: { kind: "decomposed" },
-            expectedUpdatedAt: updatedParent.updatedAt,
-          },
-        );
-        return { parent: decomposedParent, children };
-      } catch (error) {
-        for (const child of children.toReversed()) {
-          if (!existingCardIds.has(child.id)) {
-            await this.deleteDirect(child.id);
-          }
-        }
-        for (const child of reusedChildSnapshots.values()) {
-          await this.store.register(child.id, { version: 1, card: child });
-        }
-        await this.store.register(parent.id, { version: 1, card: parent });
-        throw error;
-      }
-    });
+                  { enforceStatusHolds: true },
+                );
+              })();
+          const decomposedParent = await this.updateCard(
+            updatedParent.id,
+            {},
+            {
+              event: { kind: "decomposed" },
+              expectedUpdatedAt: updatedParent.updatedAt,
+            },
+          );
+          return { parent: decomposedParent, children };
+        }),
+    );
   }
 }

--- a/extensions/workboard/src/store.test.ts
+++ b/extensions/workboard/src/store.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { WORKBOARD_STATUSES } from "@openclaw/workboard-contract";
+import { type WorkboardCard, WORKBOARD_STATUSES } from "@openclaw/workboard-contract";
 import { MAX_DATE_TIMESTAMP_MS } from "openclaw/plugin-sdk/number-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type {
@@ -47,9 +47,23 @@ function createSignal() {
   return { promise, resolve };
 }
 
+function expectSameCardState(actual: WorkboardCard | undefined, expected: WorkboardCard): void {
+  expect(actual).toBeDefined();
+  const { updatedAt: _actualUpdatedAt, ...actualState } = actual!;
+  const { updatedAt: _expectedUpdatedAt, ...expectedState } = expected;
+  expect(actualState).toEqual(expectedState);
+}
+
 function createPausedCardStore(delegate: WorkboardCardStore) {
   let pause:
     | {
+        reached: () => void;
+        waitForResume: Promise<void>;
+      }
+    | undefined;
+  let pauseAfter:
+    | {
+        matches: (key: string, value: PersistedWorkboardCard | undefined) => boolean;
         reached: () => void;
         waitForResume: Promise<void>;
       }
@@ -63,29 +77,69 @@ function createPausedCardStore(delegate: WorkboardCardStore) {
     current.reached();
     await current.waitForResume;
   };
+  const afterWrite = async (key: string, value?: PersistedWorkboardCard) => {
+    const current = pauseAfter;
+    if (!current || !current.matches(key, value)) {
+      return;
+    }
+    pauseAfter = undefined;
+    current.reached();
+    await current.waitForResume;
+  };
   return {
     store: {
       async register(key, value) {
         await beforeWrite();
         await delegate.register(key, value);
+        await afterWrite(key, value);
       },
       async registerIfAbsent(key, value) {
         await beforeWrite();
-        return await delegate.registerIfAbsent(key, value);
+        const inserted = await delegate.registerIfAbsent(key, value);
+        if (inserted) {
+          await afterWrite(key, value);
+        }
+        return inserted;
       },
       async registerIfUpdatedAt(key, value, expectedUpdatedAt) {
         await beforeWrite();
-        return await delegate.registerIfUpdatedAt(key, value, expectedUpdatedAt);
+        const updated = await delegate.registerIfUpdatedAt(key, value, expectedUpdatedAt);
+        if (updated) {
+          await afterWrite(key, value);
+        }
+        return updated;
       },
       async claimIfOwnerAvailable(key, value, expectedUpdatedAt, ownerId, now) {
         await beforeWrite();
-        return await delegate.claimIfOwnerAvailable(key, value, expectedUpdatedAt, ownerId, now);
+        const result = await delegate.claimIfOwnerAvailable(
+          key,
+          value,
+          expectedUpdatedAt,
+          ownerId,
+          now,
+        );
+        if (result === "updated") {
+          await afterWrite(key, value);
+        }
+        return result;
+      },
+      async deleteIfUpdatedAt(key, expectedUpdatedAt) {
+        await beforeWrite();
+        const deleted = await delegate.deleteIfUpdatedAt(key, expectedUpdatedAt);
+        if (deleted) {
+          await afterWrite(key);
+        }
+        return deleted;
       },
       async lookup(key) {
         return await delegate.lookup(key);
       },
       async delete(key) {
-        return await delegate.delete(key);
+        const deleted = await delegate.delete(key);
+        if (deleted) {
+          await afterWrite(key);
+        }
+        return deleted;
       },
       async entries() {
         return await delegate.entries();
@@ -99,6 +153,36 @@ function createPausedCardStore(delegate: WorkboardCardStore) {
       const resume = createSignal();
       pause = { reached: () => reached.resolve(), waitForResume: resume.promise };
       return { reached: reached.promise, resume: () => resume.resolve() };
+    },
+    pauseAfterMatchingWrite(
+      matches: (key: string, value: PersistedWorkboardCard | undefined) => boolean,
+    ) {
+      const reached = createSignal();
+      const resume = createSignal();
+      pauseAfter = {
+        matches,
+        reached: () => reached.resolve(),
+        waitForResume: resume.promise,
+      };
+      return { reached: reached.promise, resume: () => resume.resolve() };
+    },
+  };
+}
+
+function createConcurrentSqliteHarness(prefix: string) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const dbPath = path.join(dir, "workboard.sqlite");
+  const operationStores = createWorkboardSqliteStores({ dbPath });
+  const hostStores = createWorkboardSqliteStores({ dbPath });
+  const paused = createPausedCardStore(operationStores.cards);
+  return {
+    operation: new WorkboardStore(paused.store),
+    host: new WorkboardStore(hostStores.cards),
+    paused,
+    close() {
+      hostStores.close();
+      operationStores.close();
+      fs.rmSync(dir, { recursive: true, force: true });
     },
   };
 }
@@ -232,6 +316,34 @@ describe("WorkboardStore", () => {
         position: 2000,
         updatedAt: moved.updatedAt,
       });
+    } finally {
+      secondStores.close();
+      firstStores.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("deletes a sqlite card only at its exact updatedAt version", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-delete-cas-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    const firstStores = createWorkboardSqliteStores({ dbPath });
+    const secondStores = createWorkboardSqliteStores({ dbPath });
+    const first = new WorkboardStore(firstStores.cards);
+    const second = new WorkboardStore(secondStores.cards);
+    try {
+      const created = await first.create({ title: "Delete fence" });
+      const edited = await second.update(created.id, { notes: "Concurrent edit" });
+
+      await expect(
+        firstStores.cards.deleteIfUpdatedAt(created.id, created.updatedAt),
+      ).resolves.toBe(false);
+      await expect(first.get(created.id)).resolves.toMatchObject({
+        notes: "Concurrent edit",
+      });
+      await expect(firstStores.cards.deleteIfUpdatedAt(created.id, edited.updatedAt)).resolves.toBe(
+        true,
+      );
+      await expect(first.get(created.id)).resolves.toBeUndefined();
     } finally {
       secondStores.close();
       firstStores.close();
@@ -4141,6 +4253,242 @@ describe("WorkboardStore", () => {
         links: [expect.objectContaining({ type: "relates_to", targetCardId: parent.id })],
       },
     });
+  });
+
+  it("rolls back every task-owned decomposition write in sqlite when uncontended", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-workboard-decompose-control-"));
+    const dbPath = path.join(dir, "workboard.sqlite");
+    const stores = createWorkboardSqliteStores({ dbPath });
+    const store = new WorkboardStore(stores.cards);
+    try {
+      const parent = await store.create({ title: "Parent" });
+      const reusedChild = await store.create({
+        title: "Existing child",
+        idempotencyKey: "child-key",
+      });
+
+      await expect(
+        store.decompose(parent.id, {
+          children: [
+            { title: "New child" },
+            { title: "Existing child", idempotencyKey: "child-key" },
+            { notes: "Missing title" },
+          ],
+        }),
+      ).rejects.toThrow(/title is required/);
+
+      await expect(store.list()).resolves.toEqual([
+        expect.objectContaining({ id: parent.id }),
+        expect.objectContaining({ id: reusedChild.id }),
+      ]);
+      expectSameCardState(await store.get(parent.id), parent);
+      expectSameCardState(await store.get(reusedChild.id), reusedChild);
+    } finally {
+      stores.close();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("reverts completed parent state while preserving a concurrent parent edit", async () => {
+    const harness = createConcurrentSqliteHarness("openclaw-workboard-parent-rollback-");
+    const { operation, host, paused } = harness;
+    try {
+      const createdParent = await operation.create({ title: "Parent", status: "ready" });
+      const claimed = await operation.claim(createdParent.id, { ownerId: "worker" });
+      const parent = claimed.card;
+      const reusedChild = await operation.create({
+        title: "Existing child",
+        idempotencyKey: "child-key",
+      });
+      const pause = paused.pauseAfterMatchingWrite(
+        (key, value) => key === parent.id && value?.card.status === "done",
+      );
+      const decomposition = operation.decompose(
+        parent.id,
+        {
+          summary: "Task-owned decomposition",
+          children: [{ title: "Existing child", idempotencyKey: "child-key" }],
+        },
+        { ownerId: "worker", token: claimed.token },
+      );
+
+      await pause.reached;
+      await host.update(parent.id, { notes: "Concurrent parent edit" });
+      pause.resume();
+
+      await expect(decomposition).rejects.toThrow(/changed while you were editing/);
+      const rolledBackParent = await host.get(parent.id);
+      expect(rolledBackParent?.status).toBe(parent.status);
+      expect(rolledBackParent?.notes).toBe("Concurrent parent edit");
+      expect(rolledBackParent?.completedAt).toBeUndefined();
+      expect(rolledBackParent?.metadata).toEqual(parent.metadata);
+      expect(rolledBackParent?.events?.map((event) => event.kind)).toEqual([
+        ...(parent.events?.map((event) => event.kind) ?? []),
+        "edited",
+      ]);
+      expectSameCardState(await host.get(reusedChild.id), reusedChild);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it.each(["reused child", "new child"] as const)(
+    "reverts decomposition-owned links while preserving a concurrent %s edit",
+    async (target) => {
+      const harness = createConcurrentSqliteHarness("openclaw-workboard-child-rollback-");
+      const { operation, host, paused } = harness;
+      try {
+        const parent = await operation.create({ title: "Parent" });
+        const reusedChild =
+          target === "reused child"
+            ? await operation.create({ title: "Existing child", idempotencyKey: "child-key" })
+            : undefined;
+        const pause = paused.pauseAfterMatchingWrite((_key, value) => {
+          const card = value?.card;
+          if (!card || (target === "reused child" && card.id !== reusedChild?.id)) {
+            return false;
+          }
+          if (target === "new child" && card.title !== "New child") {
+            return false;
+          }
+          return Boolean(
+            card.metadata?.links?.some(
+              (link) => link.type === "parent" && link.targetCardId === parent.id,
+            ),
+          );
+        });
+        const decomposition = operation.decompose(parent.id, {
+          children: [
+            reusedChild
+              ? { title: "Existing child", idempotencyKey: "child-key" }
+              : { title: "New child" },
+            { notes: "Missing title" },
+          ],
+        });
+
+        await pause.reached;
+        const child = reusedChild ?? (await host.list()).find((card) => card.title === "New child");
+        expect(child).toBeDefined();
+        await host.update(child!.id, { notes: `Concurrent ${target} edit` });
+        pause.resume();
+
+        await expect(decomposition).rejects.toThrow(/title is required/);
+        expectSameCardState(await host.get(parent.id), parent);
+        const rolledBackChild = await host.get(child!.id);
+        expect(rolledBackChild?.notes).toBe(`Concurrent ${target} edit`);
+        expect(rolledBackChild?.metadata?.links).toBeUndefined();
+        expect(rolledBackChild?.metadata?.automation).toMatchObject(
+          target === "reused child"
+            ? { idempotencyKey: "child-key" }
+            : { createdByCardId: parent.id },
+        );
+        expect(rolledBackChild?.events?.map((event) => event.kind)).toEqual(["created", "edited"]);
+      } finally {
+        harness.close();
+      }
+    },
+  );
+
+  it("reverts a partial link while preserving a concurrent child edit", async () => {
+    const harness = createConcurrentSqliteHarness("openclaw-workboard-link-rollback-");
+    const { operation, host, paused } = harness;
+    try {
+      const parent = await operation.create({ title: "Parent" });
+      const child = await operation.create({ title: "Child" });
+      const pause = paused.pauseAfterMatchingWrite(
+        (key, value) =>
+          key === parent.id &&
+          Boolean(
+            value?.card.metadata?.links?.some(
+              (link) => link.type === "child" && link.targetCardId === child.id,
+            ),
+          ),
+      );
+      const linking = operation.linkCards(parent.id, child.id);
+
+      await pause.reached;
+      await host.update(child.id, { notes: "Concurrent child edit" });
+      pause.resume();
+
+      await expect(linking).rejects.toThrow(/changed while you were editing/);
+      expectSameCardState(await host.get(parent.id), parent);
+      await expect(host.get(child.id)).resolves.toMatchObject({
+        notes: "Concurrent child edit",
+      });
+      expect((await host.get(child.id))?.metadata?.links).toBeUndefined();
+      expect((await host.get(child.id))?.events?.map((event) => event.kind)).toEqual([
+        ...(child.events?.map((event) => event.kind) ?? []),
+        "edited",
+      ]);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("reverts task-owned links while preserving a concurrently adopted child", async () => {
+    const harness = createConcurrentSqliteHarness("openclaw-workboard-create-rollback-");
+    const { operation, host, paused } = harness;
+    try {
+      const firstParent = await operation.create({ title: "First parent" });
+      const secondParent = await operation.create({ title: "Second parent" });
+      const pause = paused.pauseAfterMatchingWrite(
+        (key, value) =>
+          key === secondParent.id &&
+          Boolean(
+            value?.card.metadata?.links?.some(
+              (link) => link.type === "child" && link.targetCardId !== undefined,
+            ),
+          ),
+      );
+      const creation = operation.create({
+        title: "New child",
+        parents: [firstParent.id, secondParent.id],
+      });
+
+      await pause.reached;
+      const child = (await host.list()).find((card) => card.title === "New child");
+      expect(child).toBeDefined();
+      await host.update(child!.id, { notes: "Concurrent child edit" });
+      pause.resume();
+
+      await expect(creation).rejects.toThrow(/changed while you were editing/);
+      await expect(host.get(child!.id)).resolves.toMatchObject({
+        notes: "Concurrent child edit",
+      });
+      expect((await host.get(child!.id))?.metadata?.links).toBeUndefined();
+      expect((await host.get(child!.id))?.events?.map((event) => event.kind)).toEqual([
+        "created",
+        "edited",
+      ]);
+      expectSameCardState(await host.get(firstParent.id), firstParent);
+      expectSameCardState(await host.get(secondParent.id), secondParent);
+    } finally {
+      harness.close();
+    }
+  });
+
+  it("preserves a linked-create failure when card compensation also fails", async () => {
+    const cards = createMemoryStore();
+    const store = new WorkboardStore(cards);
+    const parent = await store.create({ title: "Claimed parent", status: "ready" });
+    await store.claim(parent.id, { ownerId: "worker" });
+    cards.delete = async () => {
+      throw new Error("card compensation failed");
+    };
+
+    const error = await store
+      .create({ title: "New child", parents: [parent.id] }, { ownerId: "other" })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect(error).toMatchObject({
+      message: expect.stringMatching(/claimed by/),
+      cause: expect.objectContaining({ message: expect.stringMatching(/claimed by/) }),
+    });
+    expect((error as AggregateError).errors).toEqual([
+      expect.objectContaining({ message: expect.stringMatching(/claimed by/) }),
+      expect.objectContaining({ message: "card compensation failed" }),
+    ]);
   });
 
   it("preserves parent child links when decomposition leaves the parent open", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a failed Workboard decomposition, linked-card creation, or workspace materialization could restore stale whole-card snapshots and overwrite edits made concurrently by another Gateway host.

## Why This Change Was Made

Workboard now records each operation-owned card mutation and compensates it in reverse order with a three-way inverse against the latest card state. SQLite compensation writes and deletes use `updatedAt` compare-and-swap, so task-owned links, events, status, automation, and temporary workspace state are reverted without erasing unrelated concurrent edits; same-field host edits remain authoritative.

The repair also covers the sibling multi-step owners: explicit dependency linking, linked card creation, and dispatcher worktree materialization. `workboard_specify` remains a single CAS-owned mutation and does not need a rollback layer.

## User Impact

Operators can safely retry failed Workboard decomposition and dispatch flows without losing concurrent card edits or leaving partial task-owned dependency state behind.

Production growth is the canonical compensation capability and SQLite conditional-delete seam; it replaces operation-local stale-snapshot rollback rather than adding a second fallback path. No schema, protocol, configuration, or migration change is introduced.

AI-assisted: yes. The implementation and tests were reviewed and verified by the maintainer.

## Evidence

- Pre-fix reproduction: with only the old `store-workflow.ts` decomposition rollback restored, the two-connection reused-child and new-child regressions both failed because the concurrent `notes` edit was overwritten.
- Fixed-tree Testbox proof: `node scripts/run-vitest.mjs extensions/workboard/src/store.test.ts extensions/workboard/src/dispatcher-compensation.test.ts` — 2 files, 140 tests passed.
- Fixed-tree typed proof: `pnpm tsgo:extensions`, `pnpm tsgo:extensions:test`, and typed Oxlint over the nine changed Workboard files passed with 0 warnings/errors.
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/32194642068
- Local `oxfmt`, Oxlint, and `git diff --check` passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- Current-main CI repair absorbed during rebase: docs PR #126132 changed the SDK subpath wording to “selected private-local entries,” while the stale contract assertion still expected “private-local entries explicitly” and failed `checks-fast-contracts-plugins-a`. Current `main` now carries the stronger matching assertion, and `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-subpaths.test.ts` passes after rebase (1 file, 18 tests).
- The repository-wide assertion-safety ratchet remains red only for pre-existing growth in `extensions/copilot/src/tool-bridge.ts` and `src/agents/embedded-agent-runner/run/attempt-prompt-support.ts`; the changed Workboard files are compliant.
