### PR TITLE
fix(clickclack): advertise media delivery capability

### DIFF
--- a/extensions/clickclack/src/channel.test.ts
+++ b/extensions/clickclack/src/channel.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { clickClackPlugin } from "../channel-plugin-api.js";
+
+describe("ClickClack channel capabilities", () => {
+  it("advertises media delivery through the public plugin descriptor", () => {
+    expect(clickClackPlugin.capabilities).toEqual({
+      chatTypes: ["direct", "group"],
+      threads: true,
+      media: true,
+      blockStreaming: true,
+    });
+  });
+});

--- a/extensions/clickclack/src/channel.ts
+++ b/extensions/clickclack/src/channel.ts
@@ -122,6 +122,7 @@ export const clickClackPlugin: ChannelPlugin<ResolvedClickClackAccount> = create
     capabilities: {
       chatTypes: ["direct", "group"],
       threads: true,
+      media: true,
       blockStreaming: true,
     },
     reload: { configPrefixes: ["channels.clickclack"] },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw channels capabilities` for ClickClack saw no media support even though ClickClack already implements durable media delivery.

## Why This Change Was Made

Adds the missing `media: true` fact to ClickClack's canonical public channel descriptor. The generic capabilities command already projects that descriptor, so no command-specific branch, generated metadata, mirror, external API, config, protocol, storage, dependency, or release behavior changes.

## User Impact

ClickClack now reports its existing attachment-delivery support accurately in channel capability output. Media sending behavior itself is unchanged.

## Evidence

- Focused descriptor and command projection: 10/10 assertions passed after rebasing onto current `main`.
- Full ClickClack plugin suite: 362 tests passed.
- Direct gates passed: extension production and test typechecks, extension lint, formatting, import boundaries, import cycles, build, and `git diff --check`.
- Fresh Codex autoreview: no accepted/actionable findings.
- Production LOC: +1/-0 (the canonical capability fact). Tests: +13/-0.
- History: ClickClack media delivery landed in #105775; this repair publishes that already-implemented capability through the descriptor consumed by the operator CLI.

AI-assisted. I reviewed the complete owner, manifest, capability projection, regression coverage, and relevant history. No agent transcript is included.
