### PR TITLE
fix(msteams): preserve replies after durable ingress replay

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -869,7 +869,7 @@ extensions/msteams/src/monitor-handler.ts	5
 extensions/msteams/src/monitor-handler/inbound-content.ts	1
 extensions/msteams/src/monitor-handler/inbound-dispatch.ts	1
 extensions/msteams/src/monitor-handler/inbound-facts.ts	1
-extensions/msteams/src/monitor.ts	9
+extensions/msteams/src/monitor.ts	8
 extensions/msteams/src/msteams-ingress.ts	1
 extensions/msteams/src/outbound.ts	1
 extensions/msteams/src/polls.ts	1

--- a/extensions/msteams/src/channel.setup.ts
+++ b/extensions/msteams/src/channel.setup.ts
@@ -18,10 +18,11 @@ export const msteamsSetupPlugin: ChannelPlugin<ResolvedMSTeamsAccount> = {
     aliases: [...msteamsMeta.aliases],
   },
   capabilities: {
-    chatTypes: ["direct", "channel", "thread"],
+    chatTypes: ["direct", "channel", "group", "thread"],
     polls: true,
     threads: true,
     media: true,
+    reactions: true,
   },
   reload: { configPrefixes: ["channels.msteams"] },
   configSchema: MSTeamsChannelConfigSchema,

--- a/extensions/msteams/src/channel.test.ts
+++ b/extensions/msteams/src/channel.test.ts
@@ -63,6 +63,11 @@ describe("msteamsPlugin", () => {
     );
   });
 
+  it("declares its implemented group and reaction capabilities", () => {
+    expect(msteamsSetupPlugin.capabilities.chatTypes).toContain("group");
+    expect(msteamsSetupPlugin.capabilities.reactions).toBe(true);
+  });
+
   it("preserves the default account and allowlist across runtime and setup", () => {
     const cfg: OpenClawConfig = {
       channels: {

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -17,7 +17,7 @@ import type { MSTeamsConversationStore } from "./conversation-store.js";
 import { formatUnknownError } from "./errors.js";
 import { runMSTeamsFeedbackInvokeHandler } from "./feedback-invoke.js";
 import { runMSTeamsFileConsentInvokeHandler } from "./file-consent-invoke.js";
-import { extractMSTeamsConversationMessageId, normalizeMSTeamsConversationId } from "./inbound.js";
+import { normalizeMSTeamsConversationId } from "./inbound.js";
 import {
   isCardActionInvokeAuthorized,
   isSigninInvokeAuthorized,
@@ -39,6 +39,7 @@ import {
   type MSTeamsPollStore,
 } from "./polls.js";
 import { resolveMSTeamsPrivateQaRuntime } from "./qa/private-runtime.js";
+import { createMSTeamsReplayContext } from "./replay-context.js";
 import {
   looksLikeMSTeamsConversationId,
   projectStableMSTeamsGroupAllowlist,
@@ -48,11 +49,6 @@ import {
   resolveMSTeamsUserAllowlist,
 } from "./resolve-allowlist.js";
 import { getMSTeamsRuntime } from "./runtime.js";
-import {
-  deleteMSTeamsActivityWithReference,
-  sendMSTeamsActivityWithReference,
-  updateMSTeamsActivityWithReference,
-} from "./sdk-proactive.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 import {
   createMSTeamsExpressAdapter,
@@ -698,65 +694,6 @@ function buildActivityHandler(): MSTeamsActivityHandler {
   };
 
   return handler;
-}
-
-function createMSTeamsReplayContext(
-  activity: MSTeamsTurnContext["activity"],
-  app: MSTeamsApp,
-  serviceUrlBoundary: ReturnType<typeof resolveMSTeamsSdkCloudOptions>,
-): MSTeamsTurnContext {
-  const rawConversationId = activity.conversation?.id ?? "";
-  const conversationId = normalizeMSTeamsConversationId(rawConversationId);
-  const conversationType = activity.conversation?.conversationType ?? "personal";
-  const threadActivityId =
-    conversationType.toLowerCase() === "channel"
-      ? (extractMSTeamsConversationMessageId(rawConversationId) ?? activity.replyToId)
-      : undefined;
-  const tenantId = activity.channelData?.tenant?.id ?? activity.conversation?.tenantId;
-  const reference = {
-    activityId: activity.id,
-    user: activity.from,
-    agent: activity.recipient,
-    conversation: {
-      id: conversationId,
-      conversationType,
-      ...(tenantId ? { tenantId } : {}),
-    },
-    channelId: activity.channelId,
-    serviceUrl: activity.serviceUrl,
-    locale: activity.locale,
-    ...(tenantId ? { tenantId } : {}),
-    ...(activity.from?.aadObjectId ? { aadObjectId: activity.from.aadObjectId } : {}),
-  };
-  const proactiveOptions = {
-    ...(threadActivityId ? { threadActivityId } : {}),
-    serviceUrlBoundary,
-  };
-  const sendActivity: MSTeamsTurnContext["sendActivity"] = (outbound) =>
-    sendMSTeamsActivityWithReference(app, reference, outbound, proactiveOptions);
-  return {
-    activity,
-    sendActivity,
-    sendActivities: async (activities) => {
-      const results: unknown[] = [];
-      for (const outbound of activities) {
-        results.push(await sendActivity(outbound));
-      }
-      return results;
-    },
-    updateActivity: async (outbound) =>
-      (await updateMSTeamsActivityWithReference(
-        app,
-        reference,
-        typeof outbound.id === "string" ? outbound.id : "",
-        outbound,
-        proactiveOptions,
-      )) as { id?: string } | void,
-    deleteActivity: async (activityId) => {
-      await deleteMSTeamsActivityWithReference(app, reference, activityId, proactiveOptions);
-    },
-    getTeamDetails: (teamId) => app.api.teams.getById(teamId),
-  };
 }
 
 /**

--- a/extensions/msteams/src/msteams-ingress.test.ts
+++ b/extensions/msteams/src/msteams-ingress.test.ts
@@ -9,8 +9,10 @@ import {
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createMSTeamsIngress } from "./msteams-ingress.js";
+import { createMSTeamsReplayContext } from "./replay-context.js";
 import { MSTEAMS_REQUEST_TIMEOUT_MS } from "./request-timeout.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
+import type { MSTeamsApp } from "./sdk.js";
 
 type IngressQueue = NonNullable<Parameters<typeof createMSTeamsIngress>[0]["queue"]>;
 type IngressPayload = Parameters<IngressQueue["enqueue"]>[1];
@@ -21,6 +23,8 @@ function activity(params?: {
   type?: string;
   name?: string;
   conversationId?: string;
+  conversationType?: string;
+  replyToId?: string;
   text?: string;
 }): MSTeamsTurnContext["activity"] {
   return {
@@ -32,11 +36,33 @@ function activity(params?: {
     recipient: { id: "bot-1", name: "Bot" },
     conversation: {
       id: params?.conversationId ?? "conversation-1",
-      conversationType: "personal",
+      conversationType: params?.conversationType ?? "personal",
     },
+    ...(params?.replyToId ? { replyToId: params.replyToId } : {}),
     channelId: "msteams",
     serviceUrl: "https://smba.trafficmanager.net/emea/",
   };
+}
+
+function createOutboundCapture() {
+  const outbound: Array<{ activity: Record<string, unknown>; conversationId: string }> = [];
+  const app = {
+    api: {
+      serviceUrl: "https://smba.trafficmanager.net/emea/",
+      teams: { getById: vi.fn(async () => ({})) },
+      conversations: {
+        activities: (conversationId: string) => ({
+          create: async (sentActivity: Record<string, unknown>) => {
+            outbound.push({ activity: sentActivity, conversationId });
+            return { id: `outbound-${outbound.length}` };
+          },
+          update: vi.fn(async () => ({})),
+          delete: vi.fn(async () => ({})),
+        }),
+      },
+    },
+  } as unknown as MSTeamsApp;
+  return { app, outbound };
 }
 
 function runtime() {
@@ -142,27 +168,108 @@ describe("Microsoft Teams durable ingress", () => {
     });
   });
 
-  it("recovers an uncompleted append with a fresh drain and dispatches exactly once", async () => {
-    await withQueue(async (queue) => {
-      const incoming = activity({ id: "activity-restart" });
-      const interrupted = makeIngress(queue, vi.fn());
-      await interrupted.accept(incoming);
-      await interrupted.stop();
+  it.each([
+    {
+      conversationId: "19:group-restart@thread.v2",
+      conversationType: "groupChat",
+      expectedConversationId: "19:group-restart@thread.v2",
+      recovery: "restart",
+    },
+    {
+      conversationId: "19:channel-restart@thread.tacv2;messageid=thread-root",
+      conversationType: "channel",
+      expectedConversationId: "19:channel-restart@thread.tacv2;messageid=thread-root",
+      recovery: "restart",
+    },
+    {
+      conversationId: "19:group-retry@thread.v2",
+      conversationType: "groupChat",
+      expectedConversationId: "19:group-retry@thread.v2",
+      recovery: "retry",
+    },
+    {
+      conversationId: "19:channel-retry@thread.tacv2;messageid=thread-root",
+      conversationType: "channel",
+      expectedConversationId: "19:channel-retry@thread.tacv2;messageid=thread-root",
+      recovery: "retry",
+    },
+  ])(
+    "preserves the inbound quote across $recovery for $conversationType replies",
+    async (testCase) => {
+      await withQueue(async (queue) => {
+        const activityId = `activity-${testCase.recovery}-${testCase.conversationType}`;
+        const incoming = activity({
+          id: activityId,
+          conversationId: testCase.conversationId,
+          conversationType: testCase.conversationType,
+          replyToId: testCase.conversationType === "channel" ? "thread-root" : undefined,
+        });
+        const { app, outbound } = createOutboundCapture();
+        let attempts = 0;
+        let deliveryError: unknown;
+        const dispatch: IngressDispatch = async (delivered, lifecycle, liveContext) => {
+          attempts += 1;
+          if (testCase.recovery === "retry" && attempts === 1) {
+            expect(liveContext).toBeDefined();
+            throw new Error("temporary dispatch outage");
+          }
+          expect(liveContext).toBeUndefined();
+          const replayContext = createMSTeamsReplayContext(delivered, app, {
+            cloud: "Public",
+          });
+          try {
+            await replayContext.sendActivity({ type: "message", text: "Recovered reply" });
+          } catch (error) {
+            deliveryError = error;
+            throw error;
+          }
+          await lifecycle.onAdopted();
+        };
+        let recovered: ReturnType<typeof makeIngress>;
+        if (testCase.recovery === "restart") {
+          const interrupted = makeIngress(queue, vi.fn());
+          await interrupted.accept(incoming, { activity: incoming } as MSTeamsTurnContext);
+          await interrupted.stop();
+          recovered = makeIngress(queue, dispatch);
+          recovered.start();
+        } else {
+          recovered = makeIngress(queue, dispatch);
+          recovered.start();
+          await recovered.accept(incoming, { activity: incoming } as MSTeamsTurnContext);
+        }
 
-      const recoveredDispatch = vi.fn(async (_activity, lifecycle) => {
-        await lifecycle.onAdopted();
+        try {
+          await vi.waitFor(
+            async () => {
+              if (deliveryError) {
+                throw deliveryError;
+              }
+              const verdict = await queue.enqueue(activityId, {} as IngressPayload);
+              expect(verdict.kind).toBe("completed");
+            },
+            { timeout: 5_000 },
+          );
+          expect(attempts).toBe(testCase.recovery === "retry" ? 2 : 1);
+          expect(outbound).toEqual([
+            {
+              conversationId: testCase.expectedConversationId,
+              activity: expect.objectContaining({
+                text: `<quoted messageId="${activityId}"/> Recovered reply`,
+                entities: [
+                  {
+                    type: "quotedReply",
+                    quotedReply: { messageId: activityId },
+                  },
+                ],
+              }),
+            },
+          ]);
+        } finally {
+          await recovered.stop();
+        }
       });
-      const recovered = makeIngress(queue, recoveredDispatch);
-      recovered.start();
-      try {
-        await waitForVerdict(queue, "activity-restart", "completed");
-        expect(recoveredDispatch).toHaveBeenCalledTimes(1);
-        expect(recoveredDispatch).toHaveBeenCalledWith(incoming, expect.any(Object), undefined);
-      } finally {
-        await recovered.stop();
-      }
-    });
-  });
+    },
+  );
 
   it("keeps a completion tombstone and rejects a post-completion duplicate", async () => {
     await withQueue(async (queue) => {

--- a/extensions/msteams/src/msteams-ingress.test.ts
+++ b/extensions/msteams/src/msteams-ingress.test.ts
@@ -206,7 +206,7 @@ describe("Microsoft Teams durable ingress", () => {
         });
         const { app, outbound } = createOutboundCapture();
         let attempts = 0;
-        let deliveryError: unknown;
+        let deliveryError: Error | undefined;
         const dispatch: IngressDispatch = async (delivered, lifecycle, liveContext) => {
           attempts += 1;
           if (testCase.recovery === "retry" && attempts === 1) {
@@ -220,8 +220,8 @@ describe("Microsoft Teams durable ingress", () => {
           try {
             await replayContext.sendActivity({ type: "message", text: "Recovered reply" });
           } catch (error) {
-            deliveryError = error;
-            throw error;
+            deliveryError = error instanceof Error ? error : new Error(String(error));
+            throw deliveryError;
           }
           await lifecycle.onAdopted();
         };

--- a/extensions/msteams/src/replay-context.ts
+++ b/extensions/msteams/src/replay-context.ts
@@ -1,0 +1,75 @@
+// Microsoft Teams plugin reconstructs transport context for durable ingress replay.
+import type { MSTeamsSdkCloudOptions } from "./cloud.js";
+import { extractMSTeamsConversationMessageId, normalizeMSTeamsConversationId } from "./inbound.js";
+import {
+  deleteMSTeamsActivityWithReference,
+  sendMSTeamsActivityWithReference,
+  updateMSTeamsActivityWithReference,
+} from "./sdk-proactive.js";
+import type { MSTeamsTurnContext } from "./sdk-types.js";
+import type { MSTeamsApp } from "./sdk.js";
+
+export function createMSTeamsReplayContext(
+  activity: MSTeamsTurnContext["activity"],
+  app: MSTeamsApp,
+  serviceUrlBoundary: MSTeamsSdkCloudOptions,
+): MSTeamsTurnContext {
+  const rawConversationId = activity.conversation?.id ?? "";
+  const conversationId = normalizeMSTeamsConversationId(rawConversationId);
+  const conversationType = activity.conversation?.conversationType ?? "personal";
+  const normalizedConversationType = conversationType.toLowerCase();
+  const threadActivityId =
+    normalizedConversationType === "channel"
+      ? (extractMSTeamsConversationMessageId(rawConversationId) ?? activity.replyToId)
+      : undefined;
+  const quoteActivityId =
+    normalizedConversationType === "channel" || normalizedConversationType === "groupchat"
+      ? activity.id
+      : undefined;
+  const tenantId = activity.channelData?.tenant?.id ?? activity.conversation?.tenantId;
+  const reference = {
+    activityId: activity.id,
+    user: activity.from,
+    agent: activity.recipient,
+    conversation: {
+      id: conversationId,
+      conversationType,
+      ...(tenantId ? { tenantId } : {}),
+    },
+    channelId: activity.channelId,
+    serviceUrl: activity.serviceUrl,
+    locale: activity.locale,
+    ...(tenantId ? { tenantId } : {}),
+    ...(activity.from?.aadObjectId ? { aadObjectId: activity.from.aadObjectId } : {}),
+  };
+  const proactiveOptions = {
+    ...(quoteActivityId ? { quoteActivityId } : {}),
+    ...(threadActivityId ? { threadActivityId } : {}),
+    serviceUrlBoundary,
+  };
+  const sendActivity: MSTeamsTurnContext["sendActivity"] = (outbound) =>
+    sendMSTeamsActivityWithReference(app, reference, outbound, proactiveOptions);
+  return {
+    activity,
+    sendActivity,
+    sendActivities: async (activities) => {
+      const results: unknown[] = [];
+      for (const outbound of activities) {
+        results.push(await sendActivity(outbound));
+      }
+      return results;
+    },
+    updateActivity: async (outbound) =>
+      (await updateMSTeamsActivityWithReference(
+        app,
+        reference,
+        typeof outbound.id === "string" ? outbound.id : "",
+        outbound,
+        proactiveOptions,
+      )) as { id?: string } | void,
+    deleteActivity: async (activityId) => {
+      await deleteMSTeamsActivityWithReference(app, reference, activityId, proactiveOptions);
+    },
+    getTeamDetails: (teamId) => app.api.teams.getById(teamId),
+  };
+}

--- a/extensions/msteams/src/replay-context.ts
+++ b/extensions/msteams/src/replay-context.ts
@@ -59,14 +59,17 @@ export function createMSTeamsReplayContext(
       }
       return results;
     },
-    updateActivity: async (outbound) =>
-      (await updateMSTeamsActivityWithReference(
+    updateActivity: async (outbound) => {
+      const result = await updateMSTeamsActivityWithReference(
         app,
         reference,
         typeof outbound.id === "string" ? outbound.id : "",
         outbound,
         proactiveOptions,
-      )) as { id?: string } | void,
+      );
+      // SAFETY: the SDK update result exposes only the optional activity id used by this adapter.
+      return result as { id?: string } | void;
+    },
     deleteActivity: async (activityId) => {
       await deleteMSTeamsActivityWithReference(app, reference, activityId, proactiveOptions);
     },

--- a/extensions/msteams/src/sdk-proactive.test.ts
+++ b/extensions/msteams/src/sdk-proactive.test.ts
@@ -10,7 +10,8 @@ const clientState = vi.hoisted(() => ({
   })),
 }));
 
-vi.mock("@microsoft/teams.api", () => ({
+vi.mock("@microsoft/teams.api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@microsoft/teams.api")>()),
   Client: vi.fn(function MockClient(this: unknown, serviceUrl: string, http: unknown) {
     clientState.created.push({ serviceUrl, http });
     return {

--- a/extensions/msteams/src/sdk-proactive.ts
+++ b/extensions/msteams/src/sdk-proactive.ts
@@ -1,3 +1,4 @@
+import type { IMessageActivityInput } from "@microsoft/teams.api/dist/activities/message/message.js";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Msteams plugin module implements sdk proactive behavior.
 import { normalizeBotFrameworkServiceUrl } from "./bot-framework-service-url.js";
@@ -5,6 +6,7 @@ import {
   validateMSTeamsProactiveServiceUrlBoundary,
   type MSTeamsSdkCloudOptions,
 } from "./cloud.js";
+import type { MSTeamsActivityLike } from "./sdk-types.js";
 import type { MSTeamsApp } from "./sdk.js";
 
 type MSTeamsAccountRef = {
@@ -57,11 +59,35 @@ type MSTeamsApiClient = {
 };
 
 type MSTeamsProactiveOptions = {
+  quoteActivityId?: string;
   threadActivityId?: string;
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
 };
 
-const loadMSTeamsApiModule = createLazyRuntimeModule(() => import("@microsoft/teams.api"));
+const loadMSTeamsApiClient = createLazyRuntimeModule(() =>
+  import("@microsoft/teams.api").then((api) => ({ Client: api.Client })),
+);
+
+const loadMSTeamsQuoteModule = createLazyRuntimeModule(() =>
+  import("@microsoft/teams.api/dist/activities/message/message.js").then((message) => ({
+    MessageActivityInput: message.MessageActivityInput,
+  })),
+);
+
+async function quoteMSTeamsActivity(
+  activity: MSTeamsActivityLike,
+  messageId: string,
+): Promise<unknown> {
+  const { MessageActivityInput } = await loadMSTeamsQuoteModule();
+  if (typeof activity === "string") {
+    return new MessageActivityInput(activity).prependQuote(messageId);
+  }
+  if (activity.type !== "message") {
+    return activity;
+  }
+  // SAFETY: the message discriminator narrows this structural outbound input to the SDK shape.
+  return MessageActivityInput.from(activity as IMessageActivityInput).prependQuote(messageId);
+}
 
 function resolveThreadedConversationId(conversationId: string, threadActivityId?: string): string {
   if (!threadActivityId) {
@@ -177,7 +203,7 @@ async function getApiClientForReference(
     return api;
   }
 
-  const { Client } = await loadMSTeamsApiModule();
+  const { Client } = await loadMSTeamsApiClient();
   return new Client(ref.serviceUrl, httpClient) as unknown as MSTeamsApiClient;
 }
 
@@ -224,13 +250,16 @@ function mergeReferenceIntoActivity(
 export async function sendMSTeamsActivityWithReference(
   app: MSTeamsApp,
   source: MSTeamsSdkReferenceSource,
-  activity: unknown,
+  activity: MSTeamsActivityLike,
   options?: MSTeamsProactiveOptions,
 ): Promise<{ id?: string }> {
   const ref = buildSdkConversationReference(source, options);
   const api = await getApiClientForReference(app, ref);
   const activities = api.conversations.activities(ref.conversation.id);
-  const activityWithRef = mergeReferenceIntoActivity(activity, ref);
+  const quotedActivity = options?.quoteActivityId
+    ? await quoteMSTeamsActivity(activity, options.quoteActivityId)
+    : activity;
+  const activityWithRef = mergeReferenceIntoActivity(quotedActivity, ref);
   const isTargeted =
     (activityWithRef.recipient as { isTargeted?: unknown } | undefined)?.isTargeted === true;
   if (isTargeted && ref.conversation.conversationType === "personal") {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

No linked issue.

## What Problem This Solves

Fixes an issue where recovered Microsoft Teams group-chat replies became unquoted top-level messages after a durable ingress retry or restart. Channel recovery also needs the same reply/quote contract to preserve the inbound message context.

## Why This Change Was Made

Durable replay reconstructed proactive conversation and channel-thread routing but omitted the live SDK context's reply semantics. The inbound `activity.id` is already the durable identity, so replay now carries it as the quote activity ID for channels and group chats and uses the pinned Teams SDK's canonical `prependQuote()` behavior. The complete replay-context construction now lives with the replay owner.

## User Impact

Recovered Microsoft Teams channel and group-chat responses preserve their quote/reply context across retries and restarts instead of appearing as unrelated top-level messages. Microsoft Teams discovery metadata also advertises its existing group-chat and reaction support.

## Evidence

Before the fix, all four restart/retry × groupChat/channel regression cases reached the SDK client without `quotedReply` metadata. The repaired boundary tests inspect the actual outbound activity handed to the SDK client and assert both the quoted-reply entity and quote placeholder.

Focused verification on the exact head:

```text
./node_modules/.bin/vitest run --config test/vitest/vitest.extension-msteams.config.ts --maxWorkers=1 --no-file-parallelism extensions/msteams/src/msteams-ingress.test.ts extensions/msteams/src/sdk-proactive.test.ts extensions/msteams/src/channel.test.ts
# 3 files, 53 tests passed

./node_modules/.bin/tsgo -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
./node_modules/.bin/tsgo -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/msteams/src/channel.setup.ts extensions/msteams/src/channel.test.ts extensions/msteams/src/monitor.ts extensions/msteams/src/msteams-ingress.test.ts extensions/msteams/src/replay-context.ts extensions/msteams/src/sdk-proactive.test.ts extensions/msteams/src/sdk-proactive.ts
node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main
pnpm build
git diff --check
# all passed; build emitted only existing dependency-evaluation warnings
```

Fresh structured autoreview after the final code edits reported no accepted or actionable findings.

No live authenticated Microsoft Teams tenant send was run. The deterministic proof covers the real durable restart/retry path through the outbound SDK activity boundary, but it is not live tenant proof.

Production raw LOC is +115/-70, tests are +134/-21, and assertion-ratchet tooling is +1/-1. The production count includes moving the 59-line replay-context constructor out of `monitor.ts` into its owning module. The remaining positive production growth is justified by the missing SDK quote capability, the metadata correction, and the required assertion invariant; replay now has one canonical owner instead of adding a second downstream compensation path.
