### PR TITLE
fix(channels): reject malformed ingress queue claims instead of minting sentinel identity

### DIFF
--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -1019,14 +1019,23 @@ describe("channel ingress queue", () => {
       });
     });
 
-    it("tombstones a claimed row with missing claim columns and keeps it resubmittable", async () => {
+    it("tombstones malformed claims regardless of timestamp and keeps them resubmittable", async () => {
       await withTempState(async (stateDir) => {
         const queue = createTestIngressQueue<{ text: string }>(stateDir);
-        // Valid payload, but no claim token/owner/timestamp: no owner can ever
-        // release this row, and a NULL claimed_at dodges cutoff-based scans.
+        const payload = JSON.stringify({ text: "still valid" });
+        // Valid payloads, but incomplete claim columns: no owner can ever
+        // release these rows. A NULL claimed_at dodges cutoff-based scans, and
+        // a corrupt future claimed_at dodges every cutoff comparison; the
+        // missing columns alone must pull both rows into the recovery scan.
         insertCorruptRow(stateDir, '["test","account"]', "claimless", {
-          payload_json: JSON.stringify({ text: "still valid" }),
+          payload_json: payload,
           status: "claimed",
+        });
+        insertCorruptRow(stateDir, '["test","account"]', "future-ownerless", {
+          payload_json: payload,
+          status: "claimed",
+          claim_token: "test-token-placeholder",
+          claimed_at: 1_000_000,
         });
 
         await expect(queue.listClaims()).resolves.toEqual([]);
@@ -1034,26 +1043,35 @@ describe("channel ingress queue", () => {
         const shouldRecoverCorrupt = vi.fn(() => false);
         await expect(
           queue.recoverStaleClaims({ staleMs: 10, now: 20, shouldRecoverCorrupt }),
-        ).resolves.toBe(1);
+        ).resolves.toBe(2);
         // No reachable owner exists, so ownership policy is not consulted.
         expect(shouldRecoverCorrupt).not.toHaveBeenCalled();
 
         const { db } = openIngressStateDatabase(stateDir);
-        const row = executeSqliteQueryTakeFirstSync(
+        const rows = executeSqliteQuerySync(
           db,
           getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
             .selectFrom("channel_ingress_events")
-            .select(["status", "failed_reason", "payload_json", "claim_token", "claimed_at"])
+            .select(["event_id", "status", "failed_reason", "payload_json", "claim_token"])
             .where("queue_name", "=", '["test","account"]')
-            .where("event_id", "=", "claimless"),
-        );
-        expect(row).toEqual({
-          status: "failed",
-          failed_reason: "corrupt_claim",
-          payload_json: JSON.stringify({ text: "still valid" }),
-          claim_token: null,
-          claimed_at: null,
-        });
+            .orderBy("event_id", "asc"),
+        ).rows;
+        expect(rows).toEqual([
+          {
+            event_id: "claimless",
+            status: "failed",
+            failed_reason: "corrupt_claim",
+            payload_json: payload,
+            claim_token: null,
+          },
+          {
+            event_id: "future-ownerless",
+            status: "failed",
+            failed_reason: "corrupt_claim",
+            payload_json: payload,
+            claim_token: null,
+          },
+        ]);
 
         const resubmitted = await queue.resubmit?.("claimless");
         expect(resubmitted?.kind).toBe("resubmitted");

--- a/src/channels/message/ingress-queue.test.ts
+++ b/src/channels/message/ingress-queue.test.ts
@@ -960,7 +960,7 @@ describe("channel ingress queue", () => {
         });
 
         await expect(queue.enqueue("dup-claimed-bad", { text: "late" })).rejects.toThrow(
-          "Corrupt payload_json in claimed channel ingress event",
+          "Corrupt claimed channel ingress event",
         );
 
         const { db } = openIngressStateDatabase(stateDir);
@@ -1016,6 +1016,47 @@ describe("channel ingress queue", () => {
         expect(row?.claim_token).toBeNull();
         expect(row?.claimed_at).toBeNull();
         await expect(queue.recoverStaleClaims({ staleMs: Date.now() - oldTime })).resolves.toBe(0);
+      });
+    });
+
+    it("tombstones a claimed row with missing claim columns and keeps it resubmittable", async () => {
+      await withTempState(async (stateDir) => {
+        const queue = createTestIngressQueue<{ text: string }>(stateDir);
+        // Valid payload, but no claim token/owner/timestamp: no owner can ever
+        // release this row, and a NULL claimed_at dodges cutoff-based scans.
+        insertCorruptRow(stateDir, '["test","account"]', "claimless", {
+          payload_json: JSON.stringify({ text: "still valid" }),
+          status: "claimed",
+        });
+
+        await expect(queue.listClaims()).resolves.toEqual([]);
+
+        const shouldRecoverCorrupt = vi.fn(() => false);
+        await expect(
+          queue.recoverStaleClaims({ staleMs: 10, now: 20, shouldRecoverCorrupt }),
+        ).resolves.toBe(1);
+        // No reachable owner exists, so ownership policy is not consulted.
+        expect(shouldRecoverCorrupt).not.toHaveBeenCalled();
+
+        const { db } = openIngressStateDatabase(stateDir);
+        const row = executeSqliteQueryTakeFirstSync(
+          db,
+          getNodeSqliteKysely<ChannelIngressTestDatabase>(db)
+            .selectFrom("channel_ingress_events")
+            .select(["status", "failed_reason", "payload_json", "claim_token", "claimed_at"])
+            .where("queue_name", "=", '["test","account"]')
+            .where("event_id", "=", "claimless"),
+        );
+        expect(row).toEqual({
+          status: "failed",
+          failed_reason: "corrupt_claim",
+          payload_json: JSON.stringify({ text: "still valid" }),
+          claim_token: null,
+          claimed_at: null,
+        });
+
+        const resubmitted = await queue.resubmit?.("claimless");
+        expect(resubmitted?.kind).toBe("resubmitted");
       });
     });
 

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -327,25 +327,34 @@ function baseRecord<TPayload, TMetadata>(
   };
 }
 
+type ChannelIngressClaimColumns = { token: string; ownerId: string; claimedAt: number };
+
+// A claimant writes token/owner/claimed_at in one UPDATE, and complete/release/
+// refresh all match on claim_token. A claimed row missing any of the three has
+// no reachable owner and could never be released; reject it instead of minting
+// sentinel claim identity that release/liveness checks silently fail against.
+function decodeClaimColumns(row: ChannelIngressRow): ChannelIngressClaimColumns | null {
+  if (!row.claim_token || !row.claim_owner || row.claimed_at === null) {
+    return null;
+  }
+  return { token: row.claim_token, ownerId: row.claim_owner, claimedAt: row.claimed_at };
+}
+
 function claimedRecord<TPayload, TMetadata>(
   row: ChannelIngressRow,
 ): ChannelIngressQueueClaim<TPayload, TMetadata> | null {
-  const base = baseRecord<TPayload, TMetadata>(row);
-  if (base === null) {
+  const claim = decodeClaimColumns(row);
+  const base = claim === null ? null : baseRecord<TPayload, TMetadata>(row);
+  if (claim === null || base === null) {
     return null;
   }
-  return {
-    ...base,
-    claim: {
-      token: row.claim_token ?? "",
-      ownerId: row.claim_owner ?? "",
-      claimedAt: row.claimed_at ?? 0,
-    },
-  };
+  return { ...base, claim };
 }
 
-function corruptClaimRecord(row: ChannelIngressRow): ChannelIngressQueueCorruptClaim {
-  const claimValue = row.claim_token ?? "";
+function corruptClaimRecord(
+  row: ChannelIngressRow,
+  claim: ChannelIngressClaimColumns,
+): ChannelIngressQueueCorruptClaim {
   return {
     id: row.event_id,
     channelId: row.channel_id,
@@ -353,11 +362,7 @@ function corruptClaimRecord(row: ChannelIngressRow): ChannelIngressQueueCorruptC
     queueName: row.queue_name,
     ...(row.lane_key === null ? {} : { laneKey: row.lane_key }),
     reason: "corrupt_payload",
-    claim: {
-      token: claimValue,
-      ownerId: row.claim_owner ?? "",
-      claimedAt: row.claimed_at ?? 0,
-    },
+    claim,
   };
 }
 
@@ -415,28 +420,39 @@ function selectRow(db: DatabaseSync, queueName: string, id: string) {
   );
 }
 
-function tombstoneCorruptPayloadRow(params: {
+function tombstoneCorruptRow(params: {
   db: DatabaseSync;
   row: ChannelIngressRow;
   expectedStatus: "pending" | "claimed";
   failedAt: number;
   staleCutoff?: number;
+  reason: "corrupt_payload" | "corrupt_claim";
 }): boolean {
   const kysely = getChannelIngressKysely(params.db);
   const baseUpdate = kysely
     .updateTable("channel_ingress_events")
-    .set({
+    .set((eb) => ({
       status: "failed",
       failed_at: params.failedAt,
-      failed_reason: "corrupt_payload",
+      failed_reason: params.reason,
       last_error: null,
-      payload_json: "null",
-      metadata_json: null,
+      // A corrupt payload is unreadable — scrub it. A corrupt claim can wrap a
+      // valid payload; keep it resubmittable (JSON null maps to the fail() sentinel).
+      ...(params.reason === "corrupt_payload"
+        ? { payload_json: "null", metadata_json: null }
+        : {
+            payload_json: eb
+              .case()
+              .when("payload_json", "=", "null")
+              .then(FAILED_NULL_PAYLOAD_SENTINEL)
+              .else(eb.ref("payload_json"))
+              .end(),
+          }),
       claim_token: null,
       claim_owner: null,
       claimed_at: null,
       updated_at: params.failedAt,
-    })
+    }))
     .where("queue_name", "=", params.row.queue_name)
     .where("event_id", "=", params.row.event_id)
     .where("status", "=", params.expectedStatus);
@@ -447,10 +463,14 @@ function tombstoneCorruptPayloadRow(params: {
     params.row.claim_token === null
       ? baseUpdate.where("claim_token", "is", null)
       : baseUpdate.where("claim_token", "=", params.row.claim_token);
+  // Guard on the claimed_at value as read: a NULL timestamp cannot satisfy a
+  // numeric cutoff comparison, and no live owner can exist for such a row.
   const staleGuardedUpdate =
     params.staleCutoff === undefined
       ? claimGuardedUpdate
-      : claimGuardedUpdate.where("claimed_at", "<=", params.staleCutoff);
+      : params.row.claimed_at === null
+        ? claimGuardedUpdate.where("claimed_at", "is", null)
+        : claimGuardedUpdate.where("claimed_at", "<=", params.staleCutoff);
   return affectedRows(executeSqliteQuerySync(params.db, staleGuardedUpdate)) > 0;
 }
 
@@ -594,16 +614,15 @@ export function createChannelIngressQueue<
           // Duplicate enqueue cannot prove ownership is stale, so leave claimed
           // corruption for the ownership-aware recovery path.
           if (row.status === "claimed") {
-            throw new Error(
-              `Corrupt payload_json in claimed channel ingress event ${queueName}/${eventId}`,
-            );
+            throw new Error(`Corrupt claimed channel ingress event ${queueName}/${eventId}`);
           }
           if (
-            !tombstoneCorruptPayloadRow({
+            !tombstoneCorruptRow({
               db: tx.db,
               row,
               expectedStatus: "pending",
               failedAt: updatedAt,
+              reason: "corrupt_payload",
             })
           ) {
             throw new Error(`Failed to tombstone corrupt ingress event ${queueName}/${eventId}`);
@@ -816,11 +835,12 @@ export function createChannelIngressQueue<
               if (corruptReconciliations >= MAX_CORRUPT_RECONCILIATIONS_PER_CLAIM) {
                 continue;
               }
-              const didTombstone = tombstoneCorruptPayloadRow({
+              const didTombstone = tombstoneCorruptRow({
                 db: tx.db,
                 row,
                 expectedStatus: "pending",
                 failedAt: transitionAt,
+                reason: "corrupt_payload",
               });
               tombstonedCorruptRow = didTombstone || tombstonedCorruptRow;
               if (didTombstone) {
@@ -892,11 +912,12 @@ export function createChannelIngressQueue<
           return null;
         }
         if (baseRecord<TPayload, TMetadata>(pendingRow) === null) {
-          tombstoneCorruptPayloadRow({
+          tombstoneCorruptRow({
             db: tx.db,
             row: pendingRow,
             expectedStatus: "pending",
             failedAt: transitionAt,
+            reason: "corrupt_payload",
           });
           return null;
         }
@@ -1005,31 +1026,39 @@ export function createChannelIngressQueue<
         .selectAll()
         .where("queue_name", "=", queueName)
         .where("status", "=", "claimed")
-        .where("claimed_at", "<=", cutoff),
+        // A claimed row with no claimed_at has no live owner (see
+        // decodeClaimColumns) and would otherwise dodge every cutoff scan.
+        .where((eb) => eb.or([eb("claimed_at", "<=", cutoff), eb("claimed_at", "is", null)])),
     ).rows;
     let recovered = 0;
     for (const row of claimedRows) {
-      const claimRec = claimedRecord<TPayload, TMetadata>(row);
+      const claim = decodeClaimColumns(row);
+      const claimRec = claim === null ? null : claimedRecord<TPayload, TMetadata>(row);
       if (claimRec === null) {
-        const shouldRecoverCorrupt = recoverOptions?.shouldRecoverCorrupt;
-        if (shouldRecoverCorrupt) {
-          if (!(await shouldRecoverCorrupt(corruptClaimRecord(row)))) {
+        if (claim !== null) {
+          const shouldRecoverCorrupt = recoverOptions?.shouldRecoverCorrupt;
+          if (shouldRecoverCorrupt) {
+            if (!(await shouldRecoverCorrupt(corruptClaimRecord(row, claim)))) {
+              continue;
+            }
+          } else if (recoverOptions?.shouldRecover) {
+            // Existing payload-aware policies cannot safely decide on corrupt
+            // data. Preserve ownership unless the caller opts into the raw claim
+            // identity contract above.
             continue;
           }
-        } else if (recoverOptions?.shouldRecover) {
-          // Existing payload-aware policies cannot safely decide on corrupt
-          // data. Preserve ownership unless the caller opts into the raw claim
-          // identity contract above.
-          continue;
         }
+        // claim === null: no reachable owner can exist, so no policy consult —
+        // tombstone the row unconditionally to keep the queue recoverable.
         const tombstoned = runOpenClawStateWriteTransaction(
           (tx) =>
-            tombstoneCorruptPayloadRow({
+            tombstoneCorruptRow({
               db: tx.db,
               row,
               expectedStatus: "claimed",
               failedAt: current,
               staleCutoff: cutoff,
+              reason: claim === null ? "corrupt_claim" : "corrupt_payload",
             }),
           { path: database.path },
         );

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -459,18 +459,18 @@ function tombstoneCorruptRow(params: {
   if (params.expectedStatus === "pending") {
     return affectedRows(executeSqliteQuerySync(params.db, baseUpdate)) > 0;
   }
+  // The exact-token guard fences concurrent re-claims: claiming always writes a
+  // fresh random token, so a matching (or still-NULL) token proves the row is
+  // unchanged since it was read. Malformed-claim tombstones rely on this guard
+  // alone and pass no staleCutoff — their claimed_at can be NULL or corrupt.
   const claimGuardedUpdate =
     params.row.claim_token === null
       ? baseUpdate.where("claim_token", "is", null)
       : baseUpdate.where("claim_token", "=", params.row.claim_token);
-  // Guard on the claimed_at value as read: a NULL timestamp cannot satisfy a
-  // numeric cutoff comparison, and no live owner can exist for such a row.
   const staleGuardedUpdate =
     params.staleCutoff === undefined
       ? claimGuardedUpdate
-      : params.row.claimed_at === null
-        ? claimGuardedUpdate.where("claimed_at", "is", null)
-        : claimGuardedUpdate.where("claimed_at", "<=", params.staleCutoff);
+      : claimGuardedUpdate.where("claimed_at", "<=", params.staleCutoff);
   return affectedRows(executeSqliteQuerySync(params.db, staleGuardedUpdate)) > 0;
 }
 
@@ -1026,9 +1026,19 @@ export function createChannelIngressQueue<
         .selectAll()
         .where("queue_name", "=", queueName)
         .where("status", "=", "claimed")
-        // A claimed row with no claimed_at has no live owner (see
-        // decodeClaimColumns) and would otherwise dodge every cutoff scan.
-        .where((eb) => eb.or([eb("claimed_at", "<=", cutoff), eb("claimed_at", "is", null)])),
+        // A claimed row missing any claim column has no live owner (see
+        // decodeClaimColumns); scan it regardless of claimed_at, since a NULL
+        // or corrupt future timestamp would dodge every cutoff comparison.
+        .where((eb) =>
+          eb.or([
+            eb("claimed_at", "<=", cutoff),
+            eb("claimed_at", "is", null),
+            eb("claim_token", "is", null),
+            eb("claim_owner", "is", null),
+            eb("claim_token", "=", ""),
+            eb("claim_owner", "=", ""),
+          ]),
+        ),
     ).rows;
     let recovered = 0;
     for (const row of claimedRows) {
@@ -1057,7 +1067,9 @@ export function createChannelIngressQueue<
               row,
               expectedStatus: "claimed",
               failedAt: current,
-              staleCutoff: cutoff,
+              // Malformed claims skip the stale guard: their claimed_at may be
+              // NULL or a corrupt future value; the exact-token guard fences.
+              ...(claimColumns === null ? {} : { staleCutoff: cutoff }),
               reason: claimColumns === null ? "corrupt_claim" : "corrupt_payload",
             }),
           { path: database.path },

--- a/src/channels/message/ingress-queue.ts
+++ b/src/channels/message/ingress-queue.ts
@@ -1032,13 +1032,13 @@ export function createChannelIngressQueue<
     ).rows;
     let recovered = 0;
     for (const row of claimedRows) {
-      const claim = decodeClaimColumns(row);
-      const claimRec = claim === null ? null : claimedRecord<TPayload, TMetadata>(row);
+      const claimColumns = decodeClaimColumns(row);
+      const claimRec = claimColumns === null ? null : claimedRecord<TPayload, TMetadata>(row);
       if (claimRec === null) {
-        if (claim !== null) {
+        if (claimColumns !== null) {
           const shouldRecoverCorrupt = recoverOptions?.shouldRecoverCorrupt;
           if (shouldRecoverCorrupt) {
-            if (!(await shouldRecoverCorrupt(corruptClaimRecord(row, claim)))) {
+            if (!(await shouldRecoverCorrupt(corruptClaimRecord(row, claimColumns)))) {
               continue;
             }
           } else if (recoverOptions?.shouldRecover) {
@@ -1048,8 +1048,8 @@ export function createChannelIngressQueue<
             continue;
           }
         }
-        // claim === null: no reachable owner can exist, so no policy consult —
-        // tombstone the row unconditionally to keep the queue recoverable.
+        // claimColumns === null: no reachable owner can exist, so no policy
+        // consult — tombstone unconditionally to keep the queue recoverable.
         const tombstoned = runOpenClawStateWriteTransaction(
           (tx) =>
             tombstoneCorruptRow({
@@ -1058,7 +1058,7 @@ export function createChannelIngressQueue<
               expectedStatus: "claimed",
               failedAt: current,
               staleCutoff: cutoff,
-              reason: claim === null ? "corrupt_claim" : "corrupt_payload",
+              reason: claimColumns === null ? "corrupt_claim" : "corrupt_payload",
             }),
           { path: database.path },
         );


### PR DESCRIPTION
## What Problem This Solves

A `status="claimed"` channel ingress row missing its claim data (`claim_token`, `claim_owner`, or `claimed_at` NULL) was decoded into a valid-looking claim with sentinel identity (`token: ""`, `ownerId: ""`, `claimedAt: 0`) instead of being rejected. Two structural bugs hid behind those sentinels and made such rows permanently unrecoverable:

- `releaseClaimIfStillStale` guarded on `claim_token = ""`, which never matches a NULL column, so the row could never be released back to pending.
- `recoverStaleClaims` selected `claimed_at <= cutoff`, which never matches a NULL timestamp, so the row was never even scanned by recovery.

The row stayed `claimed` forever, blocked its dedupe slot, and leaked fake claim identity into `listClaims` and the corrupt-claim ownership-liveness policy. Flagged by the architecture audit (deferred from the LOC campaign as correctness/recovery hardening).

## Why This Change Was Made

Invariant: `claimed` requires a nonempty token, owner, and timestamp — a claimant writes all three in one UPDATE, and every complete/release/refresh matches on `claim_token`, so a row missing any of them provably has no reachable owner. Rows are now decoded through a strict claim-column decoder (`decodeClaimColumns`); malformed claims are rejected at decode and tombstoned as `failed`/`corrupt_claim` by stale recovery, without consulting the ownership-liveness policy (no owner can exist), fail-closed at the queue owner rather than compensated downstream.

Because only the claim bookkeeping is broken — the payload may be perfectly valid — the tombstone preserves a decodable payload (mapping JSON `null` to the existing `fail()` sentinel) instead of scrubbing it, so the event remains recoverable via operator `resubmit`. Corrupt-payload tombstoning behavior is unchanged.

## User Impact

Operators with a corrupted state DB (partial write, manual edit) no longer get ingress events silently wedged in `claimed` forever. Such rows now surface as `failed`/`corrupt_claim` dead letters visible to `listFailed`/dead-letter tooling, and events with intact payloads can be resubmitted instead of being lost.

## Evidence

- Regression test fails on pre-fix code for the intended reason: `listClaims` leaked the sentinel-claim row and `recoverStaleClaims` returned 0 (row never scanned). Post-fix: hidden from `listClaims`, tombstoned without a `shouldRecoverCorrupt` consult, payload intact, `resubmit` returns `resubmitted`.
- `src/channels/message/ingress-queue.test.ts`: 35/35 pass.
- `tsgo:core:test` clean; `oxfmt --check` clean; `check:changed` guard lanes green. `tsgo:core` has 7 pre-existing undici/`RequestInit` errors in `src/infra/net/*` + MCP fetch files — reproduced byte-identical on pristine HEAD (local type skew, unrelated to this change).
- Codex autoreview (`gpt-5.6-sol`, high reasoning) over the diff: clean, no accepted findings — "patch is correct (0.98)".
- Production LOC +70/−41 (decoder, payload-preserving tombstone branch, and invariant comments; sentinel paths deleted) | Tests +42/−1.
