### PR TITLE
fix(compaction): stop reading decimal fractions as opaque identifiers

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -148,9 +148,12 @@ function summaryIncludesIdentifier(summary: string, identifier: string): boolean
 export function extractOpaqueIdentifiers(text: string): string[] {
   // Path and host/port candidates start at token boundaries so prose such as
   // "typecheck/lint/format" is not mistaken for an absolute path.
+  // The digit runs also reject a leading "." so a decimal such as 0.123456789
+  // does not donate its fractional digits as an identifier the guard then
+  // demands verbatim, which cancels compaction for data that is not an ID.
   const matches =
     text.match(
-      /([A-Fa-f0-9]{8,}|https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}|\b\d{6,}\b)/g,
+      /((?<![A-Fa-f0-9.])[A-Fa-f0-9]{8,}|https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}|(?<!\.)\b\d{6,}\b)/g,
     ) ?? [];
   return uniqueStrings(
     matches

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1150,6 +1150,24 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(quality.ok).toBe(true);
   });
 
+  it("does not treat decimal fractions in tool output as opaque identifiers", () => {
+    // A fractional digit run is numeric data, not an ID. Extracting it made the
+    // quality guard demand it verbatim in the summary, which it cannot contain,
+    // so compaction failed with missing_identifiers and never shrank the session.
+    expect(extractOpaqueIdentifiers("metric=0.123456789")).toStrictEqual([]);
+    expect(extractOpaqueIdentifiers("value 0.123456")).toStrictEqual([]);
+    expect(extractOpaqueIdentifiers("ratio=12.3456789")).toStrictEqual([]);
+    expect(extractOpaqueIdentifiers("p99=0.999999")).toStrictEqual([]);
+    // Scientific notation must not donate its exponent digits either.
+    expect(extractOpaqueIdentifiers("rate 1.5e123456")).toStrictEqual([]);
+  });
+
+  it("still extracts standalone numeric identifiers", () => {
+    // Guards the fix above against over-reaching: a bare digit run is still an ID.
+    expect(extractOpaqueIdentifiers("id 987654321")).toStrictEqual(["987654321"]);
+    expect(extractOpaqueIdentifiers("order 4567890123 shipped")).toStrictEqual(["4567890123"]);
+  });
+
   it("dedupes pure-hex identifiers across case variants", () => {
     const identifiers = extractOpaqueIdentifiers(
       "Track id a1b2c3d4e5f6 plus A1B2C3D4E5F6 and again a1b2c3d4e5f6",


### PR DESCRIPTION
## What Problem This Solves

Fixes #126016.

`extractOpaqueIdentifiers` collects values a compaction summary must reproduce verbatim. It runs over the text of the recent turns, `toolResult` payloads included, and its numeric branches match any digit run:

`src/agents/agent-hooks/compaction-safeguard-quality.ts:153`

```ts
/([A-Fa-f0-9]{8,}|https?:\/\/\S+|...|\b\d{6,}\b)/g
```

So ordinary numeric data donates its fractional digits as if they were IDs. On current `main`:

```
"metric=0.123456789"  -> ["123456789"]
"value 0.123456"      -> ["123456"]
"ratio=12.3456789"    -> ["3456789"]
"p99=0.999999"        -> ["999999"]
"rate 1.5e123456"     -> ["5e123456"]
```

The quality guard then requires each extracted value literally in the finalized artifact. Nothing produces `123456789`, because it is not an identifier, so the guard reports `missing_identifiers` and compaction is cancelled with `guard_blocked`. History is preserved correctly, but the session never shrinks and every later attempt pays the same cost again.

## Why This Change Was Made

Both numeric branches now reject a leading `.`. A standalone digit run is still treated as an identifier; only a run sitting inside a decimal is skipped.

One correction to the issue as filed, since it changes the fix: it attributes this to `\b\d{6,}\b` alone. That branch is not sufficient. `[A-Fa-f0-9]{8,}` comes first in the alternation and accepts digits, so for `0.123456789` it matches `123456789` before the digit branch is ever tried, and for `1.5e123456` it matches `5e123456` by absorbing the exponent `e`. Guarding only the digit branch would have left the 8-or-more-digit case, which is the exact one in the report, still broken. Both branches needed it.

I checked the guard cascades correctly too: once the hex branch refuses to start after `.`, it also refuses to restart one character later, because the preceding character is then itself a hex digit. That is why the decimal cases return nothing at all rather than a shorter fragment.

## User Impact

Sessions with tool output containing decimals or scientific notation can compact again instead of failing with `missing_identifiers`. Before this, such a session would keep its history but never shrink, and would retry the full summarization repeatedly.

No identifier that was preserved before stops being preserved. The change only removes candidates that were never identifiers.

## Evidence

The decimal test fails on unfixed code, for the right reason. Reverting only the source file:

```
× does not treat decimal fractions in tool output as opaque identifiers
  Tests  1 failed | 130 passed (131)
```

With the fix:

```
node scripts/run-vitest.mjs src/agents/agent-hooks/compaction-safeguard.test.ts   131 passed (131)
node scripts/run-vitest.mjs src/agents/agent-hooks                                131 passed (131)
node scripts/run-oxlint.mjs <both touched files>                                  clean
node scripts/run-tsgo.mjs -p tsconfig.core.json                                   clean
./node_modules/.bin/oxfmt <both touched files>                                    clean
```

Before and after on the same inputs, to show the change is narrow:

```
                          before            after
"metric=0.123456789"      ["123456789"]     []
"value 0.123456"          ["123456"]        []
"ratio=12.3456789"        ["3456789"]       []
"p99=0.999999"            ["999999"]        []
"rate 1.5e123456"         ["5e123456"]      []
"id 987654321"            ["987654321"]     ["987654321"]
"order 4567890123"        ["4567890123"]    ["4567890123"]
```

The existing expectations are unchanged. I ran the two established cases through both patterns and the output is identical, including `127.0.0.1:8080` and the other host/port values, which are matched by their own branch and never reached the numeric ones.

The second test I added (`still extracts standalone numeric identifiers`) passes before and after by design. It is not a regression test; it is there so a future tightening of these branches cannot quietly start dropping real numeric IDs.

Production delta is +4/-1, three of the added lines being the comment recording why the branches refuse a leading dot.

Not reproduced against a live compaction run. The report includes the production event (`reasonCodes=missing_identifiers`, `outcome=failed reason=guard_blocked`), and the extractor is deterministic and pure, so the proof here is at that level rather than a full session replay. Saying so rather than implying more.

For transparency: #75336 also touches compaction identifiers, but it adds survival validation after the fact rather than changing extraction, so I do not believe they conflict. Happy to rebase if it lands first.

AI-assisted: yes, with the regex behavior measured directly and every command above run by me.
