### PR TITLE
fix(agents): record empty subagent completion delivery

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog-channels.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog-channels.test.ts
@@ -205,7 +205,8 @@ describe("qa scenario catalog channel contracts", () => {
     ]);
     expect(flow).toContain("env.gateway.call('tasks.list'");
     expect(flow).toContain("task.title === `qa-terminal-${caseName}`");
-    expect(flow).toContain("task.status === 'completed'");
+    expect(flow).toContain("terminalTask.status === 'completed'");
+    expect(flow).toContain("emptyTask.status === 'failed'");
     expect(flow).toContain("task.deliveryStatus === 'delivered'");
     expect(flow).toContain("readSettledTerminalTask('restart')");
     expect(flow).toContain("readSettledTerminalTask('empty')");

--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -23,7 +23,7 @@ scenario:
   successCriteria:
     - Visible completion output reaches the originating QA DM exactly once.
     - Exact worker NO_REPLY stays private while required parent completion represents missing child output visibly exactly once.
-    - Genuinely empty completion output is represented intentionally once.
+    - Empty output after a side effect remains a failed execution while its terminal representation is delivered exactly once.
     - Gateway restart does not replay prior terminal payloads or synthesize interruption notices for already-settled handoffs, and a post-restart completion is delivered exactly once.
     - Direct fallback strips protected internal metadata before one channel delivery.
   docsRefs:
@@ -82,7 +82,7 @@ flow:
               params:
                 - caseName
               async: true
-              expr: "(await env.gateway.call('tasks.list', { status: 'completed', agentId: 'qa', limit: 100 }, { timeoutMs: 10000 })).tasks?.find((task) => task.title === `qa-terminal-${caseName}` && task.status === 'completed' && task.deliveryStatus === 'delivered')"
+              expr: "(await env.gateway.call('tasks.list', { agentId: 'qa', limit: 100 }, { timeoutMs: 10000 })).tasks?.find((task) => task.title === `qa-terminal-${caseName}` && task.deliveryStatus === 'delivered')"
         - forEach:
             items:
               expr: config.cases
@@ -265,8 +265,8 @@ flow:
               ref: emptyConversationId
             senderName: QA Empty Reply Operator
             text: "Subagent terminal reply QA check: empty. Spawn one native worker, then finish the parent turn without waiting. Do not use ACP."
-        # Empty output after one side effect is terminal and must surface one
-        # explicit representation without leaking the protected raw result.
+        # Empty output after one side effect is an incomplete turn, but its
+        # failed execution still owns one visible terminal representation.
         - call: waitForCondition
           saveAs: emptyTask
           args:
@@ -297,12 +297,12 @@ flow:
             message:
               expr: "`empty completion did not exercise native spawn/direct-fallback: ${JSON.stringify(emptyRequests)}`"
         - assert:
-            expr: "emptyTask.title === 'qa-terminal-empty' && emptyTask.status === 'completed' && emptyTask.deliveryStatus === 'delivered'"
+            expr: "emptyTask.title === 'qa-terminal-empty' && emptyTask.status === 'failed' && emptyTask.deliveryStatus === 'delivered' && emptyTask.toolUseCount === 1 && emptyTask.lastToolName === 'write'"
             message:
-              expr: "`empty completion task lifecycle did not settle authoritatively; task=${JSON.stringify(emptyTask)}`"
+              expr: "`empty completion execution and delivery did not settle independently; task=${JSON.stringify(emptyTask)}`"
         - set: appendEmptyVerdict
           value:
-            expr: "verdicts.push({ case: 'empty', conversationId: emptyConversationId, taskId: emptyTask.taskId, taskDeliveryStatus: emptyTask.deliveryStatus, inputDisposition: 'empty-after-side-effect', representation: 'visible ambiguity warning for producer-empty result', restart: false, fallback: false, expectedTerminalSendCount: 1, actualTerminalSendCount: emptyRepresentation.length, capturedTerminalPayloads: emptyRepresentation.map((message) => String(message.text ?? '')), auxiliaryChannelEvents: emptyOutbound.filter((message) => !emptyRepresentation.includes(message)).map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
+            expr: "verdicts.push({ case: 'empty', conversationId: emptyConversationId, taskId: emptyTask.taskId, taskStatus: emptyTask.status, taskDeliveryStatus: emptyTask.deliveryStatus, inputDisposition: 'empty-after-side-effect', representation: 'visible ambiguity warning for producer-empty result', restart: false, fallback: false, expectedTerminalSendCount: 1, actualTerminalSendCount: emptyRepresentation.length, capturedTerminalPayloads: emptyRepresentation.map((message) => String(message.text ?? '')), auxiliaryChannelEvents: emptyOutbound.filter((message) => !emptyRepresentation.includes(message)).map((message) => String(message.text ?? '')), silenceTokenLeaked: false, internalMetadataLeak: false, pass: true })"
         - assert:
             expr: "verdicts.length === 5 && verdicts.every((verdict) => verdict.pass === true)"
             message:

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -3712,6 +3712,39 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("records a committed direct completion when the announce turn ends incomplete", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [],
+        deliveryStatus: {
+          status: "failed",
+          errorMessage: "Agent couldn't generate a response.",
+        },
+        didSendViaMessagingTool: true,
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "discord",
+            accountId: "acct-1",
+            to: "dm:U123",
+            text: "QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED",
+            sourceReplyFinal: true,
+          },
+        ],
+      },
+    });
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sourceTool: "subagent_announce",
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        result: "(no output)",
+      }),
+    });
+
+    expectDeliveryPath(result, "direct");
+  });
+
   it.each([
     {
       name: "accepts message delivery to the requester",

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -412,11 +412,17 @@ export async function sendSubagentAnnounceDirectly(params: {
     }
 
     const directAnnounceResult = getGatewayAgentResult(directAnnounceResponse);
+    const hasMessagingToolDelivery = Boolean(
+      directAnnounceResult &&
+      hasMessagingToolDeliveryToSource(directAnnounceResult, deliveryTarget),
+    );
     const directDeliveryFailure =
       (shouldDeliverAgentFinal || requiresMessageToolDelivery) && directAnnounceResult
         ? getAgentCommandDeliveryFailure(directAnnounceResult)
         : undefined;
-    if (directDeliveryFailure) {
+    // Automatic-delivery diagnostics and a committed source message are independent facts.
+    // Once the message tool delivered the owed final, the task must settle as delivered.
+    if (directDeliveryFailure && !hasMessagingToolDelivery) {
       return {
         delivered: false,
         path: "direct",
@@ -426,10 +432,6 @@ export async function sendSubagentAnnounceDirectly(params: {
           : {}),
       };
     }
-    const hasMessagingToolDelivery = Boolean(
-      directAnnounceResult &&
-      hasMessagingToolDeliveryToSource(directAnnounceResult, deliveryTarget),
-    );
     const completionPayloadVisibility = {
       includeErrorPayloads: false,
       includeReasoningPayloads: false,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.
-->

Related: #126122
Related: #126075

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes a stacked regression where an empty-after-side-effect subagent completion visibly sent its terminal representation but never recorded delivery after #126075 made the underlying tool-bearing turn fail closed. The `subagent-completion-direct-fallback` QA scenario therefore timed out after 60 seconds on current main even though the outbound marker had committed.

This is the single follow-up commit discovered while rebasing and proving #126122. That PR was independently merged before this second repair could be added.

## Why This Change Was Made

The incomplete-turn diagnostic from #126075 remains correct: a tool-bearing assistant turn without a later final reply is a failed execution. Delivery is a separate lifecycle fact, so a source-matched final message already committed through the message tool now settles the detached task as delivered even when automatic delivery diagnostics report failure.

The QA scenario now asserts both authoritative outcomes for the empty case: `taskStatus: failed` and `taskDeliveryStatus: delivered`. It continues to require exactly one terminal representation, no replay after restart, and no internal metadata leak.

Production LOC: +7/-5 (net +2). Tests/QA: +40/-7 (net +33). No protocol, config, storage, or schema changes.

AI-assisted: Codex. The implementation and evidence were inspected locally before publication.

## User Impact

Operators still receive the correct incomplete-turn diagnostic for an empty side-effect-bearing subagent, while the terminal representation is delivered exactly once and the task ledger no longer remains pending.

No screenshot is attached because this is lifecycle accounting behind channel delivery. The repo-native QA scenario exercises the mock provider, ephemeral Gateway, transport boundary, task ledger, restart, and QA bus end to end.

## Evidence

- Current-main red control: the exact `subagent-completion-direct-fallback` run timed out twice after 60 seconds. Gateway logs showed the empty-case marker was sent, while the task remained unobservable through the scenario's completed-only delivery query.
- Boundary red control: `records a committed direct completion when the announce turn ends incomplete` failed on current main with `delivery.delivered: expected false to deeply equal true`.
- Exact latest-main QA proof: all five cases (`visible`, `silent`, `fallback`, `restart`, `empty`) passed. Empty recorded `taskStatus: failed`, `taskDeliveryStatus: delivered`, and one `QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED` send; restart replay/unexpected counts were zero.
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build qaRuntime` — pass.
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH node scripts/run-vitest.mjs src/agents/subagents/announce/subagent-announce-delivery.test.ts src/agents/subagents/announce/subagent-announce-delivery.runtime.test.ts src/agents/subagents/registry/subagent-gateway-context-binding.test.ts` — pass, 3 files / 174 tests across 2 shards.
- `PATH=/opt/homebrew/opt/node@24/bin:$PATH pnpm check:changed` — pass through the fail-safe all-lanes plan, including all typecheck, lint, dead-export, import-cycle, storage, and architecture guards.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean; no accepted/actionable findings, patch judged correct at 0.98 confidence.
