### PR TITLE
fix(gateway): hold the chat root through terminal persistence

### DIFF
--- a/src/gateway/server-methods/chat-send-admission.ts
+++ b/src/gateway/server-methods/chat-send-admission.ts
@@ -11,6 +11,7 @@ import { SESSION_ROUTING_CHANGED_ERROR_REASON } from "../../config/sessions/main
 import { readSessionTranscriptActivePathEntryRelation } from "../../config/sessions/session-accessor.js";
 import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { claimAgentRunContext, clearAgentRunContext } from "../../infra/agent-run-registry.js";
+import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { setGatewayDedupeEntry } from "../agent-turn/agent-job.js";
 import { registerChatAbortController, resolveChatRunExpiresAtMs } from "../chat-abort.js";
@@ -396,6 +397,11 @@ export async function admitChatSend(params: {
     });
     return { ok: false as const };
   }
+  // Reserved here, while the request's root is provably live, rather than after the ACK: the
+  // detached dispatch must keep that root until terminal persistence settles or restart drain
+  // completes early and loses the session's terminal state. Callers outside a Gateway request
+  // envelope (internal chat entries) hold no root, so there is nothing to extend for them.
+  const releaseGatewayRootContinuation = retainGatewayRootWorkAdmissionContinuation() ?? (() => {});
   if (params.onAdmissionOwned) {
     let proceed: boolean;
     try {
@@ -403,11 +409,13 @@ export async function admitChatSend(params: {
     } catch (error) {
       activeRunAbort.cleanup({ force: true });
       gatewayWorkAdmission.release();
+      releaseGatewayRootContinuation();
       throw error;
     }
     if (!proceed) {
       activeRunAbort.cleanup({ force: true });
       gatewayWorkAdmission.release();
+      releaseGatewayRootContinuation();
       return { ok: false as const };
     }
   }
@@ -445,7 +453,6 @@ export async function admitChatSend(params: {
       releaseGatewayWorkAdmission();
     };
   };
-  let releaseGatewayRootContinuation: (() => void) | undefined;
   // Prepared inbound media has no transcript reference until the user turn
   // persists; every abandonment exit funnels through cleanupAdmittedRun, so
   // the armed discard here is the single custody owner for that window. The
@@ -455,8 +462,7 @@ export async function admitChatSend(params: {
   const cleanupAdmittedRun: typeof activeRunAbort.cleanup = (options) => {
     activeRunAbort.cleanup(options);
     releaseInitialGatewayWorkAdmission();
-    releaseGatewayRootContinuation?.();
-    releaseGatewayRootContinuation = undefined;
+    releaseGatewayRootContinuation();
     discardAbandonedPreparedMedia?.();
     discardAbandonedPreparedMedia = undefined;
   };
@@ -501,9 +507,6 @@ export async function admitChatSend(params: {
       restartSafeAdmission,
       setDiscardAbandonedPreparedMedia: (discard: (() => void) | undefined) => {
         discardAbandonedPreparedMedia = discard;
-      },
-      setReleaseGatewayRootContinuation: (release: (() => void) | undefined) => {
-        releaseGatewayRootContinuation = release;
       },
     },
   };

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -9,7 +9,6 @@ import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js"
 import { dispatchInboundMessageWithProjectedDispatcher } from "../../auto-reply/dispatch.js";
 import type { ReplyMessageInjectionAttempt } from "../../auto-reply/reply/reply-run-registry.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
-import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
 import { isOperatorUiClient } from "../../utils/message-channel.js";
 import { setGatewayDedupeEntry } from "../agent-turn/agent-job.js";
 import { updateChatRunProvider } from "../chat-abort.js";
@@ -108,7 +107,6 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
     messageInjectionTarget,
     retainGatewayWorkAdmission,
     restartSafeAdmission,
-    setReleaseGatewayRootContinuation,
   } = admission;
   const {
     activeRunScopeKey,
@@ -210,9 +208,6 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
     }
     emitServerTiming("first-assistant-event", undefined, dispatchStartedAtMs);
   };
-  // Reserve the detached dispatch before this request releases its root. Otherwise
-  // its inherited ALS context becomes retired and rejects queued/session work.
-  setReleaseGatewayRootContinuation(retainGatewayRootWorkAdmissionContinuation() ?? undefined);
   const dispatch = replyDispatch
     .runAgentMediaTranscript(gatewayWorkAdmission, () =>
       measureDiagnosticsTimelineSpan(

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -10,6 +10,7 @@ import { loadSessionEntry } from "../config/sessions/session-accessor.js";
 import { replaceTranscriptEvents } from "../config/sessions/session-accessor.sqlite-transcript-write.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { registerAgentRunContext } from "../infra/agent-run-registry.js";
+import { createSafeGatewayRestartPreflight } from "../infra/restart-coordinator.js";
 import {
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
@@ -960,11 +961,23 @@ describe("gateway server chat", () => {
           rejectDispatch.resolve();
           await errorPromise;
           await persistenceEntered.promise;
-          expect(getActiveGatewayRootWorkCount()).toBe(1);
+          const restartInspectors = {
+            getQueueSize: () => 0,
+            getPendingReplies: () => 0,
+            getEmbeddedRuns: () => 0,
+            getCronRuns: () => 0,
+            getBackgroundExecSessions: () => 0,
+            getActiveTasks: () => 0,
+            getTaskBlockers: () => [],
+          };
+          expect(createSafeGatewayRestartPreflight(restartInspectors)).toMatchObject({
+            safe: false,
+            counts: { rootRequests: 1 },
+          });
           releasePersistence.resolve();
           const changed = await sessionChangedPromise;
           await waitForFast(() => {
-            expect(getActiveGatewayRootWorkCount()).toBe(0);
+            expect(createSafeGatewayRestartPreflight(restartInspectors).safe).toBe(true);
           });
           return changed;
         } finally {


### PR DESCRIPTION
## What Problem This Solves

A Gateway chat run could lose its root-work admission before its terminal state was written, so a
restart preflight reported it was **safe to restart while `persistGatewaySessionLifecycleEvent` was
still in flight**. The session's terminal state is then lost across the restart, with nothing logged.

The invariant is stated in `src/gateway/server-methods/chat-send-dispatch-errors.ts`:

```
// Stop exposing the rejected run before projecting its terminal state, but keep the
// admitted root until persistence settles so restart drain still observes this work.
```

`finalize()` upholds it by holding the root across the persistence `await`. But the root was only
held because of one line in `chat-send-agent-dispatch.ts`, executed **after** the ACK:

```ts
setReleaseGatewayRootContinuation(retainGatewayRootWorkAdmissionContinuation() ?? undefined);
```

`retainGatewayRootWorkAdmissionContinuation()` returns `null` when the ALS root store is absent or
already retired, and `?? undefined` swallowed it. No continuation was registered, the initial
admission was released, and the root count reached 0 before persistence ran — silently.

This surfaced as a CI failure on an unrelated PR (#125958), job `checks-node-compact-small-3`, shard
`agentic-control-plane-agent-chat-hosted-1`, on three separate attempts:

```
marks a running webchat session failed when restart drain overlaps dispatch rejection
AssertionError: expected +0 to be 1
```

## Why This Change Was Made

The reservation moves into `admitChatSend`, immediately after the session work admission is
registered — the earliest point where the request's root is provably live, and before
`onAdmissionOwned`, attachment preparation, the ACK, and `startChatDispatch`. The existing
`cleanupAdmittedRun` closure is the single release owner, and the early-abandonment paths release it
too. The late setter and the silent `?? undefined` are deleted.

Callers that enter `handleChatSend` outside a Gateway request envelope (internal chat entries such as
skills and suggestion flows) hold no root at all, so their continuation is a no-op — there is no
request root to extend and no drain guarantee to preserve. **This matters:** an earlier iteration
threw when the reservation was unavailable, which broke **183 tests** across those legitimate
callers. That is why the no-root case is a no-op rather than an error, and why the full
`server-methods` suite is part of the evidence below.

Rejected alternatives: keeping the late reservation (preserves the silent-null window); retaining
inside dispatch-error finalization (already too late if the inherited root was retired); relaxing the
assertion, retrying, or widening a timeout (masks silent terminal-state loss).

**Known gap, stated plainly:** the exact producer that retires the ALS root in the CI runs is not
proven. Source tracing found no normal chat caller that leaves the root scope, and
`startChatDispatch` is synchronous with no `await` before the old reservation. What *is* proven is the
consequence and its repair: forcing only the reservation to fail reproduces the CI signature exactly,
and reserving at admission removes the window regardless of which producer retires the root.

## User Impact

A chat run whose dispatch fails now keeps the Gateway root until its terminal state is persisted, so
a restart preflight reports "not safe" until that write completes instead of waving the restart
through. No API, config, or protocol change.

## Evidence

**Mechanism confirmed before writing any fix.** Replacing only the old retain with
`setReleaseGatewayRootContinuation(undefined)`, changing nothing else, reproduced the CI failure
verbatim: `AssertionError: expected +0 to be 1`.

Hypotheses tested and **disproved**, recorded so they are not re-tread: async release while
persistence is blocked (instrumented; count stayed 1 at t+0/25/225ms); a foreign
`persistGatewaySessionLifecycleEvent` resolving the test's deferred early (instrumented the spy;
exactly one call, `runId=idem-dispatch-error-1 phase=error rootCount=1`, for both the single test and
the full file); leaked `restartDraining` from a sibling file (fails differently, at
`expect(res.ok).toBe(true)`); sibling gateway files leaking admission state (all reset; running them
together passes).

**The regression now asserts the operator-visible surface, not an internal counter.** While
persistence is blocked it asserts `createSafeGatewayRestartPreflight(...)` reports
`{ safe: false, counts: { rootRequests: 1 } }`, then that it flips to `safe: true` once the write is
released. Proof it is load-bearing: with the reservation stubbed out the preflight reports
`safe: true` while the terminal state is still being written — i.e. the failure message now names the
actual bug — and restored, it passes.

**Suite results on current `main`:**
- `src/gateway/server-methods` — **3415 passed** (186 files).
- `src/gateway/server.chat.gateway-server-chat.test.ts` — 55 passed.
- `src/process/gateway-work-admission.test.ts` — 18 passed.
- `node scripts/run-tsgo-core-test-shards.mjs` — 0 type errors.

Branch-mode autoreview clean (`patch is correct`). Production LOC `+9/-11` (net **−2**); tests `+15/-2`.

Note: `waitForActiveGatewayRootWork` was removed from `main` by #126024 mid-work, so the test uses the
current `createSafeGatewayRestartPreflight` surface.
