### PR TITLE
perf(test): consolidate TUI PTY session coverage

### DIFF
--- a/src/tui/tui-pty-harness-assertion-test-support.ts
+++ b/src/tui/tui-pty-harness-assertion-test-support.ts
@@ -428,7 +428,7 @@ function hasStatusFrame(
   );
 }
 
-async function exerciseSelectorOutputSafety(
+export async function exerciseSelectorOutputSafety(
   startFixture: StartTuiPtyFixture,
   startupTimeoutMs: number,
 ) {
@@ -555,7 +555,7 @@ export async function exerciseNarrowTerminalRendering(
   }
 }
 
-async function exerciseGatewayOutputSafety(
+export async function exerciseGatewayOutputSafety(
   startFixture: StartTuiPtyFixture,
   startupTimeoutMs: number,
 ) {
@@ -591,6 +591,13 @@ async function exerciseGatewayOutputSafety(
     expect(hasStatusFrame(fixture.run.output(), idlePayload.markers, /\| idle/u, fixture.run)).toBe(
       true,
     );
+    await waitForSynchronizedFrameRows(
+      fixture.run,
+      (rows) =>
+        rows.some((row) => row.includes("gateway reconnected after transport loss")) &&
+        rows.some((row) => row.includes("local ready | idle")),
+      startupTimeoutMs,
+    );
 
     const helpOffset = fixture.run.visibleOutput().length;
     await fixture.run.write("/help\r", { delay: false });
@@ -604,7 +611,7 @@ async function exerciseGatewayOutputSafety(
   }
 }
 
-async function exerciseMarkdownAndAutocompleteOutputSafety(
+export async function exerciseMarkdownAndAutocompleteOutputSafety(
   startFixture: StartTuiPtyFixture,
   startupTimeoutMs: number,
 ) {
@@ -660,7 +667,7 @@ async function exerciseMarkdownAndAutocompleteOutputSafety(
   }
 }
 
-async function exerciseInteractiveOutputSafety(
+export async function exerciseInteractiveOutputSafety(
   startFixture: StartTuiPtyFixture,
   startupTimeoutMs: number,
 ) {
@@ -696,18 +703,6 @@ async function exerciseInteractiveOutputSafety(
   } finally {
     await fixture.cleanup();
   }
-}
-
-export async function exerciseTerminalOutputSafety(
-  startFixture: StartTuiPtyFixture,
-  startupTimeoutMs: number,
-) {
-  await Promise.all([
-    exerciseGatewayOutputSafety(startFixture, startupTimeoutMs),
-    exerciseInteractiveOutputSafety(startFixture, startupTimeoutMs),
-    exerciseMarkdownAndAutocompleteOutputSafety(startFixture, startupTimeoutMs),
-    exerciseSelectorOutputSafety(startFixture, startupTimeoutMs),
-  ]);
 }
 
 /** Proves fixture-local fragmentation preserves a Unicode prompt through the real TUI loop. */

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -8,7 +8,6 @@ import {
   disposeActiveTuiFixtures,
   exerciseFragmentedUnicodePrompt,
   exerciseNarrowTerminalRendering,
-  exerciseTerminalOutputSafety,
   objectFieldEquals,
   readFixtureLog,
   startTuiFixture,
@@ -22,6 +21,7 @@ import {
   streamingPrefixFrame,
   toolFrame,
 } from "./tui-pty-rendering-test-support.js";
+import { exerciseTerminalOutputSafety } from "./tui-pty-terminal-output-safety-test-support.js";
 const STARTUP_TIMEOUT_MS = 20_000;
 const TEST_TIMEOUT_MS = 5_000;
 const STARTUP_TEST_TIMEOUT_MS = 25_000;

--- a/src/tui/tui-pty-terminal-output-safety-test-support.ts
+++ b/src/tui/tui-pty-terminal-output-safety-test-support.ts
@@ -1,0 +1,20 @@
+// Groups the terminal-output safety exercises behind one PTY harness entry point.
+import {
+  exerciseGatewayOutputSafety,
+  exerciseInteractiveOutputSafety,
+  exerciseMarkdownAndAutocompleteOutputSafety,
+  exerciseSelectorOutputSafety,
+  type StartTuiPtyFixture,
+} from "./tui-pty-harness-assertion-test-support.js";
+
+export async function exerciseTerminalOutputSafety(
+  startFixture: StartTuiPtyFixture,
+  startupTimeoutMs: number,
+) {
+  await Promise.all([
+    exerciseGatewayOutputSafety(startFixture, startupTimeoutMs),
+    exerciseInteractiveOutputSafety(startFixture, startupTimeoutMs),
+    exerciseMarkdownAndAutocompleteOutputSafety(startFixture, startupTimeoutMs),
+    exerciseSelectorOutputSafety(startFixture, startupTimeoutMs),
+  ]);
+}

--- a/src/tui/tui-session-identity-pty.e2e.test.ts
+++ b/src/tui/tui-session-identity-pty.e2e.test.ts
@@ -109,15 +109,16 @@ it("hides a stale approval when startup restores the remembered session", async 
   }
 }, 65_000);
 
-it("restores a remembered global session before startup admits the first send", async () => {
-  const stateDir = tempDirs.make("openclaw-tui-global-session-");
-  const marker = "global startup session proof";
+it("restores a remembered global session while keeping pre-ready input editable", async () => {
+  const stateDir = tempDirs.make("openclaw-tui-startup-session-");
+  const marker = "startup remembered session proof";
   await seedRememberedSession(stateDir, "global");
   const fixture = await startTuiFixture({
     env: {
       OPENCLAW_STATE_DIR: stateDir,
       OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
       OPENCLAW_TUI_PTY_PICKER_SESSION_KEY: "global",
+      OPENCLAW_TUI_PTY_RESTORE_DELAY_MS: "400",
     },
   });
 
@@ -132,43 +133,6 @@ it("restores a remembered global session before startup admits the first send", 
       includeUnknown: false,
       agentId: "main",
     });
-
-    await fixture.run.waitForOutput("local ready", STARTUP_TIMEOUT_MS);
-    await fixture.run.write(`${marker}\r`, { delay: false });
-    await fixture.waitForLogEntry(
-      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", marker),
-      STARTUP_TIMEOUT_MS,
-    );
-
-    const sends = (await readFixtureLog(fixture.logPath)).filter(
-      (entry) => entry.method === "sendChat",
-    );
-    expect(sends).toHaveLength(1);
-    expect(sends[0]?.payload).toMatchObject({ sessionKey: "global", agentId: "main" });
-  } finally {
-    await fixture.cleanup();
-  }
-}, 65_000);
-
-it("keeps startup input editable until the remembered session and history are stable", async () => {
-  const stateDir = tempDirs.make("openclaw-tui-startup-session-");
-  const marker = "startup remembered session proof";
-  await seedRememberedSession(stateDir);
-  const fixture = await startTuiFixture({
-    env: {
-      OPENCLAW_STATE_DIR: stateDir,
-      OPENCLAW_TUI_PTY_PICKER_FIXTURE: "1",
-      OPENCLAW_TUI_PTY_RESTORE_DELAY_MS: "400",
-    },
-  });
-
-  try {
-    await fixture.waitForLogEntry(
-      (entry) =>
-        entry.method === "listSessions" &&
-        objectFieldEquals(entry, "search", REMEMBERED_SESSION_KEY),
-      STARTUP_TIMEOUT_MS,
-    );
     const outputOffset = fixture.run.visibleOutput().length;
     await fixture.run.write(`${marker}\r`, { delay: false });
     const decision = await waitForSubmitDecision({ fixture, marker, outputOffset });
@@ -177,7 +141,7 @@ it("keeps startup input editable until the remembered session and history are st
     const rows = await waitForSynchronizedFrameRows(
       fixture.run,
       (frame) =>
-        frame.some((row) => row.includes("session picker-target")) &&
+        frame.some((row) => row.includes("session global")) &&
         frame.some((row) => row.includes("local ready")) &&
         frame.some((row) => row.includes(marker)),
       STARTUP_TIMEOUT_MS,
@@ -190,7 +154,7 @@ it("keeps startup input editable until the remembered session and history are st
       (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", marker),
       STARTUP_TIMEOUT_MS,
     );
-    expect(sent.payload).toMatchObject({ sessionKey: REMEMBERED_SESSION_KEY });
+    expect(sent.payload).toMatchObject({ sessionKey: "global", agentId: "main" });
     expect(markerSends(await readFixtureLog(fixture.logPath), marker)).toHaveLength(1);
   } finally {
     await fixture.cleanup();


### PR DESCRIPTION
## What Problem This Solves

The fake-backend TUI PTY lane paid for a standalone child process to verify the remembered global-session startup path even though the neighboring delayed-startup case exercised the same lifecycle. The lane also inherited an existing ANSI terminal-safety race on current `main`: `/help` could be submitted after the disconnect marker appeared but before post-reconnect command admission reopened.

## Why This Change Was Made

This combines global remembered-session coverage with the delayed pre-ready startup lifecycle, reducing the lane from eight PTY tests/children to seven without dropping behavior. The retained case still verifies the global `listSessions` request (`includeGlobal: true`, `includeUnknown: false`, `agentId: "main"`), blocked-but-editable pre-ready input, the ready frame, and exactly one final send to `{ sessionKey: "global", agentId: "main" }`; ordinary remembered sessions remain covered by sibling cases.

The adjacent red-`main` terminal-safety case now waits for one synchronized frame containing both the reconnect marker and `local ready | idle` before submitting `/help`. This fixes the command-admission race without sleeps, longer timeouts, or weaker assertions. The unchanged terminal-output safety orchestration moved into a concept-named support module so the assertion helper remains under its max-lines budget.

## User Impact

There is no user-visible product behavior change. Maintainers get a faster, less variable TUI PTY test lane while preserving the same session-startup and terminal-safety guarantees.

## Evidence

- Controlled same-Testbox A/B, excluding warmup and retaining two measured runs with distinct caches and import diagnostics: wall `28.07s -> 24.94s` (`-3.13s`, `-11.15%`); Vitest `-11.53%`; test bodies `-12.55%`; CPU user `-13.21%`; CPU system `-16.45%`; spread `1.76s -> 1.08s`; max RSS `+0.68%`.
- Testbox `tbx_01m0c1pe9jry8djxsx3b2thmgq`; completed/stopped run: https://github.com/openclaw/openclaw/actions/runs/32212985499
- Consolidated focused target: `7/7` passed.
- Full fake-backend PTY lane: `71/71` passed across three files.
- Exact ANSI terminal-safety case: passed twice after the synchronization fix (`7.83s`, `7.86s`) and again after the support-module split.
- Complete changed gate exited `0`: max-lines, format, types, lint, dead exports, cycles, and guards green. `oxfmt`, `oxlint`, and `git diff --check` are green.
- A temporary fault injection changed the expected global request to `includeGlobal: false`; it failed against the received `true`, and the expectation was restored byte-for-byte.
- Fresh post-rebase autoreview: clean, `0.99`, no accepted/actionable findings.
- Stable patch-id before and after rebase: `d2f0132494865f229bfcf43a6b555d3f019daffe`.
- Production LOC: `+0/-0`. Tests and test support: `+38/-59` (net `-21`).
- Screenshots: N/A (no visual or user-facing change). Changelog/docs: N/A. Agent transcript: intentionally omitted.

AI-assisted maintainer change; the implementation and proof were reviewed before publication.
