### PR TITLE
feat(skills): custodian-only skill library (first wave)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -285,6 +285,16 @@
       - any-glob-to-any-file:
           - "docs/**"
 
+"r: skill":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "custodian-skills/**"
+          - "skills/**"
+          - "src/skills/**"
+          - "docs/tools/custodian-skills.md"
+          - "docs/tools/skills-config.md"
+          - "docs/tools/skills.md"
+
 "cli":
   - changed-files:
       - any-glob-to-any-file:

--- a/custodian-skills/add-model-provider/SKILL.md
+++ b/custodian-skills/add-model-provider/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: add-model-provider
+description: Add and live-prove a model provider without exposing credentials or breaking the active route.
+---
+
+# Add a model provider
+
+Never print or persist secret values; credentials belong in SecretRefs or agent-scoped credential stores. Never hand-edit config files on disk. Every run ends with the observable Prove result or an exact explanation of why it could not be proven.
+
+Use [Model providers](https://docs.openclaw.ai/providers/models), the provider page, and [OpenAI](https://docs.openclaw.ai/providers/openai) for the worked example.
+
+## Gather
+
+Read the current agent, default model, catalog, and redacted auth-profile status with `gateway` `config.get` plus the `openclaw` tool's model/status inspection. Decide which auth contract applies:
+
+- API-key auth uses an agent-scoped `openai` API-key profile populated by the credential flow.
+- ChatGPT/Codex subscription auth uses OpenAI OAuth and remains distinct from Platform API billing.
+
+Never substitute one path for the other.
+
+## Mutate
+
+Provider credentials and catalogs cannot be changed with raw `config_set`. Use `openclaw onboard` and select the documented provider/auth choice; for OpenAI API-key setup use the masked credential-store flow, while subscription setup uses the documented OAuth login. Resume only after onboarding reports a passing candidate. If the user asks to change the default, have Custodian call the `openclaw` action `set_default_model` with the exact `provider/model` and optional `agentId`; it live-tests before saving. Do not mutate `auth.*`, `models.*`, or credential files directly.
+
+## Repair
+
+Run `openclaw doctor`. Apply `openclaw doctor --fix` only outside the active Custodian inference session and only after approval, then re-check auth profiles and the model catalog.
+
+## Prove
+
+Run one live inference through the Gateway using the newly configured provider and exact target agent. Record the resolved public model id and elapsed latency, not prompt content or credentials. A catalog listing or auth check alone is not proof. If the probe fails, keep the previous default and report the exact redacted failure.
+
+## Report
+
+State the provider, API-key or subscription/OAuth path, agent scope, whether the default changed, the live-proven model id and latency, and any next action.

--- a/custodian-skills/add-model-provider/SKILL.md
+++ b/custodian-skills/add-model-provider/SKILL.md
@@ -1,35 +1,61 @@
 ---
 name: add-model-provider
-description: Add and live-prove a model provider without exposing credentials or breaking the active route.
+description: Add and live-prove a model provider with non-interactive config one-liners, without exposing credentials.
 ---
 
 # Add a model provider
 
-Never print or persist secret values; credentials belong in SecretRefs or agent-scoped credential stores. Never hand-edit config files on disk. Every run ends with the observable Prove result or an exact explanation of why it could not be proven.
+Never print or persist secret values; credentials enter config only as SecretRefs (env or file source). Never hand-edit config files on disk — every mutation goes through `openclaw config` so it is validated and audited. Every run ends with the observable Prove result or an exact explanation of why it could not be proven.
 
-Use [Model providers](https://docs.openclaw.ai/providers/models), the provider page, and [OpenAI](https://docs.openclaw.ai/providers/openai) for the worked example.
+In-session `config_set`/`config_set_ref` tool actions are policy-blocked for `models.*` and `secrets.*`; use the trusted shell (`exec`) for the commands below. `set_default_model` is the one in-session action allowed to change the default route — it live-tests before saving.
 
 ## Gather
 
-Read the current agent, default model, catalog, and redacted auth-profile status with `gateway` `config.get` plus the `openclaw` tool's model/status inspection. Decide which auth contract applies:
+```
+openclaw config get models --json
+openclaw models list
+openclaw models auth list
+openclaw config schema --json | jq '.properties.models'   # confirm exact provider paths before writing
+```
 
-- API-key auth uses an agent-scoped `openai` API-key profile populated by the credential flow.
-- ChatGPT/Codex subscription auth uses OpenAI OAuth and remains distinct from Platform API billing.
-
-Never substitute one path for the other.
+Decide the auth contract: API-key providers take a SecretRef on `models.providers.<id>.apiKey`; subscription/OAuth providers (ChatGPT/Codex, Claude subscriptions) use `openclaw models auth login --provider <id>` instead and must not be given an API key path.
 
 ## Mutate
 
-Provider credentials and catalogs cannot be changed with raw `config_set`. Use `openclaw onboard` and select the documented provider/auth choice; for OpenAI API-key setup use the masked credential-store flow, while subscription setup uses the documented OAuth login. Resume only after onboarding reports a passing candidate. If the user asks to change the default, have Custodian call the `openclaw` action `set_default_model` with the exact `provider/model` and optional `agentId`; it live-tests before saving. Do not mutate `auth.*`, `models.*`, or credential files directly.
+API-key example (OpenAI), key staged by the operator in a `0600` file — validate first with `--dry-run`, then write:
+
+```
+openclaw config set secrets.providers.openai_key_file --provider-source file --provider-path /path/to/openai.key --provider-mode singleValue --dry-run
+openclaw config set secrets.providers.openai_key_file --provider-source file --provider-path /path/to/openai.key --provider-mode singleValue
+openclaw config set models.providers.openai.apiKey --ref-provider openai_key_file --ref-source file --ref-id value
+```
+
+Env-var alternative when the gateway process env carries the key:
+
+```
+openclaw config set models.providers.openai.apiKey --ref-provider default --ref-source env --ref-id OPENAI_API_KEY
+```
+
+To change a default model, use the in-session `set_default_model` action (with `agentId` for a non-default agent); it live-tests the route before saving. Do not change defaults with raw config writes.
 
 ## Repair
 
-Run `openclaw doctor`. Apply `openclaw doctor --fix` only outside the active Custodian inference session and only after approval, then re-check auth profiles and the model catalog.
+```
+openclaw doctor --non-interactive
+```
+
+If it reports a config repair, get approval, run `openclaw doctor --fix --non-interactive`, then re-run the Gather reads.
 
 ## Prove
 
-Run one live inference through the Gateway using the newly configured provider and exact target agent. Record the resolved public model id and elapsed latency, not prompt content or credentials. A catalog listing or auth check alone is not proof. If the probe fails, keep the previous default and report the exact redacted failure.
+```
+openclaw infer model run --gateway --model openai/gpt-5.4 --prompt "Reply with exactly: PROVIDER-PROOF-OK"
+```
+
+Expect the exact probe string; record model id and wall time. Known dependency: OpenAI routes need the codex harness plugin at runtime — if the probe reports the runtime unavailable, run `openclaw plugins install @openclaw/codex` and restart the gateway, then re-probe.
 
 ## Report
 
-State the provider, API-key or subscription/OAuth path, agent scope, whether the default changed, the live-proven model id and latency, and any next action.
+State the provider added, the SecretRef path written (never the value), the probe result with model id and latency, and whether the default model changed. If the probe failed, report the exact error and the next command to try.
+
+Further reference: https://docs.openclaw.ai/providers/models and https://docs.openclaw.ai/providers/openai

--- a/custodian-skills/add-model-provider/SKILL.md
+++ b/custodian-skills/add-model-provider/SKILL.md
@@ -12,9 +12,9 @@ In-session `config_set`/`config_set_ref` tool actions are policy-blocked for `mo
 ## Gather
 
 ```
-openclaw config get models --json
-openclaw models list
-openclaw models auth list
+openclaw config get models --json          # "Config path not found" is normal before first setup
+openclaw models list --agent <agentId>     # --agent is required in multi-agent rosters
+openclaw models auth list --agent <agentId>
 openclaw config schema --json | jq '.properties.models'   # confirm exact provider paths before writing
 ```
 
@@ -47,6 +47,14 @@ openclaw doctor --non-interactive
 If it reports a config repair, get approval, run `openclaw doctor --fix --non-interactive`, then re-run the Gather reads.
 
 ## Prove
+
+Roster-safe probe (works in every setup; use your own agent id or any configured agent):
+
+```
+openclaw agent --agent <agentId> --model openai/gpt-5.4 -m "Reply with exactly: PROVIDER-PROOF-OK"
+```
+
+Single-agent installs can use the lighter completion probe instead — it has no `--agent` flag and fails with "no explicit owner" on multi-agent rosters, so do not retry it there:
 
 ```
 openclaw infer model run --gateway --model openai/gpt-5.4 --prompt "Reply with exactly: PROVIDER-PROOF-OK"

--- a/custodian-skills/add-model-provider/SKILL.md
+++ b/custodian-skills/add-model-provider/SKILL.md
@@ -16,7 +16,10 @@ openclaw config get models --json          # "Config path not found" is normal b
 openclaw models list --agent <agentId>     # --agent is required in multi-agent rosters
 openclaw models auth list --agent <agentId>
 openclaw config schema --json | jq '.properties.models'   # confirm exact provider paths before writing
+openclaw plugins list   # OpenAI routes need the codex harness plugin; enable/install NOW, not mid-proof
 ```
+
+If the harness plugin for the target provider is missing or disabled, remediate here (`openclaw plugins enable codex` or `openclaw plugins install @openclaw/codex`) so the Prove step does not stall on it later; plugin enable is picked up by gateway hot-reload.
 
 Decide the auth contract: API-key providers take a SecretRef on `models.providers.<id>.apiKey`; subscription/OAuth providers (ChatGPT/Codex, Claude subscriptions) use `openclaw models auth login --provider <id>` instead and must not be given an API key path.
 

--- a/custodian-skills/cloud-image-bake/SKILL.md
+++ b/custodian-skills/cloud-image-bake/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: cloud-image-bake
+description: Bake, select, dispatch-prove, and safely retire a Cloud Worker image.
+---
+
+# Bake a Cloud Worker image
+
+Never print or persist secret values; use SecretRefs and provider credential stores. Never hand-edit config files on disk. Every run ends with the observable Prove result or an exact explanation of why it could not be proven. Snapshots are cheap; unmanaged snapshot sprawl is not.
+
+Follow [Cloud Workers](https://docs.openclaw.ai/gateway/cloud-workers) and the active provider's image documentation.
+
+## Gather
+
+Read `cloudWorkers.profiles.<profile>` with `gateway` `config.get`, then use `crabbox config show --json`, `crabbox doctor --provider <backend> --json`, and the read-only lease/image inventory. Record the current provider, class, image selection, setup, and superseded image id. Confirm the requested tooling and a secret-free bake source.
+
+## Mutate
+
+Lease from the current profile with `crabbox warmup --provider <backend> --class <class> --keep --timing-json`, then install and smoke-test the requested tooling with `crabbox run --id <lease> -- ...`.
+
+- AWS: create a native image checkpoint with `crabbox checkpoint create --provider aws --id <lease> --mode native --strategy image --wait`, inspect it, then run `crabbox image promote <ami-id>` with the matching scope.
+- Hetzner: create the project snapshot with `hcloud image create --type snapshot --server <server-id> --description <name>`. There is no Crabbox Hetzner create/promote lifecycle for shared defaults; record this lifecycle gap and the explicit image selection outside OpenClaw.
+- Firecracker: rebuild and publish the rootfs template through the provider's documented template pipeline; do not snapshot a running microVM as a substitute.
+
+Ask Custodian to run `config_schema` for the exact profile setting, then use approved `config_set` only for a supported image selector. The current Crabbox OpenClaw profile has no `image` key: AWS selection is owned by `crabbox image promote`; never invent a config field. Preserve the old image until proof passes.
+
+## Repair
+
+Run `openclaw doctor`. If repair is required, obtain approval and run `openclaw doctor --fix` outside the active Custodian inference session, then re-read the profile and provider inventory.
+
+## Prove
+
+Create a disposable managed-worktree session and time one real `sessions.dispatch` to the profile, using a generous Gateway timeout. Confirm the placement reaches `active`, the requested tooling runs on the worker, and record dispatch duration. If any step fails, roll back the image selection and report the exact blocker.
+
+## Report
+
+Report the profile, backend, new and previous image ids, tooling smoke, dispatch duration, and rollback state. Only after successful proof, show the exact provider deletion target and get hard human confirmation. Then delete only that superseded snapshot (`crabbox image delete` or `hcloud image delete`) and verify it is absent; without confirmation, leave it intact and report cleanup pending.

--- a/custodian-skills/cloud-image-bake/SKILL.md
+++ b/custodian-skills/cloud-image-bake/SKILL.md
@@ -1,36 +1,71 @@
 ---
 name: cloud-image-bake
-description: Bake, select, dispatch-prove, and safely retire a Cloud Worker image.
+description: Bake, select, prove, and safely retire a Cloud Worker image with crabbox and config one-liners.
 ---
 
 # Bake a Cloud Worker image
 
-Never print or persist secret values; use SecretRefs and provider credential stores. Never hand-edit config files on disk. Every run ends with the observable Prove result or an exact explanation of why it could not be proven. Snapshots are cheap; unmanaged snapshot sprawl is not.
-
-Follow [Cloud Workers](https://docs.openclaw.ai/gateway/cloud-workers) and the active provider's image documentation.
+Never print or persist secret values; provider credentials stay in their stores. Never hand-edit config files on disk — profile changes go through `openclaw config`. Every run ends with the observable Prove result or an exact explanation of why it could not be proven. Snapshots are cheap; unmanaged snapshot sprawl is not. Never delete a provider image without hard operator confirmation.
 
 ## Gather
 
-Read `cloudWorkers.profiles.<profile>` with `gateway` `config.get`, then use `crabbox config show --json`, `crabbox doctor --provider <backend> --json`, and the read-only lease/image inventory. Record the current provider, class, image selection, setup, and superseded image id. Confirm the requested tooling and a secret-free bake source.
+```
+openclaw config get cloudWorkers --json
+crabbox config show --json
+crabbox doctor --provider <backend> --json
+crabbox checkpoint list --json
+```
+
+Record the current provider, class, image selection, setup command, and the id of the image being superseded. Confirm the requested tooling and a secret-free bake source.
 
 ## Mutate
 
-Lease from the current profile with `crabbox warmup --provider <backend> --class <class> --keep --timing-json`, then install and smoke-test the requested tooling with `crabbox run --id <lease> -- ...`.
+Lease from the current profile, install and smoke-test the tooling:
 
-- AWS: create a native image checkpoint with `crabbox checkpoint create --provider aws --id <lease> --mode native --strategy image --wait`, inspect it, then run `crabbox image promote <ami-id>` with the matching scope.
-- Hetzner: create the project snapshot with `hcloud image create --type snapshot --server <server-id> --description <name>`. There is no Crabbox Hetzner create/promote lifecycle for shared defaults; record this lifecycle gap and the explicit image selection outside OpenClaw.
-- Firecracker: rebuild and publish the rootfs template through the provider's documented template pipeline; do not snapshot a running microVM as a substitute.
+```
+crabbox warmup --provider <backend> --class <class> --keep --timing-json
+crabbox run --provider <backend> --id <lease> --no-sync -- bash -lc '<install commands> && <tool> --version'
+```
 
-Ask Custodian to run `config_schema` for the exact profile setting, then use approved `config_set` only for a supported image selector. The current Crabbox OpenClaw profile has no `image` key: AWS selection is owned by `crabbox image promote`; never invent a config field. Preserve the old image until proof passes.
+Snapshot per backend:
+
+- AWS: `crabbox checkpoint create --provider aws --id <lease> --mode native --strategy image --wait`, inspect it, then `crabbox image promote <ami-id>` with the matching scope. AWS image selection is owned by the promote catalog.
+- Hetzner: `hcloud image create --type snapshot --server <server-id> --description <name>`; there is no crabbox create/promote lifecycle for Hetzner yet, so record the snapshot id explicitly.
+- Firecracker: rebuild and republish the rootfs template through the host's template pipeline; do not snapshot a running microVM as a substitute.
+
+Point the profile at the new selection only through validated config writes — confirm the exact key first, dry-run, then write (example for a backend whose settings carry an image field):
+
+```
+openclaw config schema --json | jq '.properties.cloudWorkers'
+openclaw config set cloudWorkers.profiles.<profile>.settings.<imageKey> "<image-id>" --dry-run
+openclaw config set cloudWorkers.profiles.<profile>.settings.<imageKey> "<image-id>"
+```
+
+The bundled crabbox profile currently has no `image` settings key — AWS selection lives in `crabbox image promote`; never invent a config field. Preserve the old image until proof passes.
 
 ## Repair
 
-Run `openclaw doctor`. If repair is required, obtain approval and run `openclaw doctor --fix` outside the active Custodian inference session, then re-read the profile and provider inventory.
+```
+openclaw doctor --non-interactive
+crabbox doctor --provider <backend> --json
+```
+
+Apply `openclaw doctor --fix --non-interactive` only after approval, then re-read the profile and provider inventory.
 
 ## Prove
 
-Create a disposable managed-worktree session and time one real `sessions.dispatch` to the profile, using a generous Gateway timeout. Confirm the placement reaches `active`, the requested tooling runs on the worker, and record dispatch duration. If any step fails, roll back the image selection and report the exact blocker.
+Lease once from the new image and verify the baked tooling is present and fast:
+
+```
+crabbox warmup --provider <backend> --class <class> --timing-json
+crabbox run --provider <backend> --id <lease> --no-sync -- bash -lc '<tool> --version'
+crabbox stop --provider <backend> --id <lease>
+```
+
+Record warmup total and compare against the pre-bake timing. Then confirm the OpenClaw path end to end: dispatch one session to the profile from a client (Cloud destination) and verify the placement reaches active. If any step fails, roll back the image selection and report the exact blocker.
 
 ## Report
 
-Report the profile, backend, new and previous image ids, tooling smoke, dispatch duration, and rollback state. Only after successful proof, show the exact provider deletion target and get hard human confirmation. Then delete only that superseded snapshot (`crabbox image delete` or `hcloud image delete`) and verify it is absent; without confirmation, leave it intact and report cleanup pending.
+Report the profile, backend, new and previous image ids, tooling smoke result, timed warmup before/after, and rollback state. Only after successful proof, show the exact deletion target and get hard operator confirmation, then delete only that superseded snapshot (`crabbox image delete <id>` or `hcloud image delete <id>`) and verify it is gone. Without confirmation, leave it intact and report cleanup pending.
+
+Further reference: https://docs.openclaw.ai/gateway/cloud-workers

--- a/custodian-skills/configure-channel/SKILL.md
+++ b/custodian-skills/configure-channel/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: configure-channel
+description: Configure and prove a Telegram, Discord, Slack, WhatsApp, or other OpenClaw channel.
+---
+
+# Configure a channel
+
+Never print or persist secret values; put credentials in SecretRefs or the channel credential store. Never hand-edit config files on disk. Every run ends with the observable Prove result or an exact explanation of why it could not be proven.
+
+Use the channel's guide as the source of truth: [Telegram](https://docs.openclaw.ai/channels/telegram), [Discord](https://docs.openclaw.ai/channels/discord), [Slack](https://docs.openclaw.ai/channels/slack), or [WhatsApp](https://docs.openclaw.ai/channels/whatsapp).
+
+## Gather
+
+Identify the channel family, account, test destination, and intended agent. Read current state with the `gateway` tool's `config.get` action and ask the `openclaw` tool to inspect the channel. Probe live status before changing anything. Do not request a token in chat or logs.
+
+## Mutate
+
+Route setup through the `openclaw` tool. Its Custodian flow uses `connect_channel` and, when masked credential entry is needed, `open_setup` with `target=channels`; these are the canonical channel config flows. If an approved leaf change is necessary inside Custodian, it must use `config_schema` first, then `config_set` or `config_set_ref`, never a filesystem edit. Preserve unrelated accounts and bindings.
+
+## Repair
+
+Run `openclaw doctor`. If it reports a safe repair, explain it and get approval before running `openclaw doctor --fix` outside the active Custodian inference session. Re-read channel state afterward.
+
+## Prove
+
+Send one real, clearly labeled test message through the configured account to the agreed destination. Confirm receipt from the channel response, delivery result, or recipient observation. If sending or confirmation is impossible, report the exact account, permission, destination, or network blocker without exposing credentials.
+
+## Report
+
+State the channel and account changed, the canonical flow used, the redacted config paths affected, the test destination, and the observed receipt. List any remaining operator action.

--- a/custodian-skills/configure-channel/SKILL.md
+++ b/custodian-skills/configure-channel/SKILL.md
@@ -12,8 +12,7 @@ Never print or persist secret values; channel tokens enter config only as Secret
 ```
 openclaw channels list --all
 openclaw channels status
-openclaw channels capabilities --channel telegram
-openclaw config get channels --json
+openclaw config get channels --json        # "Config path not found" is normal before first setup
 ```
 
 Confirm the exact config path before writing — key names differ per channel (`channels.telegram.botToken`, `channels.discord.token`, ...):
@@ -55,8 +54,8 @@ Apply `openclaw doctor --fix --non-interactive` only after approval, then re-che
 Send one real, clearly labeled test message and confirm delivery from the command result (use `--dry-run` first to inspect the payload):
 
 ```
-openclaw message send --channel telegram --target @yourtestchat --message "OpenClaw channel test — please ignore" --dry-run
-openclaw message send --channel telegram --target @yourtestchat --message "OpenClaw channel test — please ignore"
+openclaw message send --channel telegram --target <chatId> --message "OpenClaw channel test — please ignore" --dry-run
+openclaw message send --channel telegram --target <chatId> --message "OpenClaw channel test — please ignore"
 ```
 
 If sending fails, report the exact account, permission, destination, or network blocker without exposing credentials.

--- a/custodian-skills/configure-channel/SKILL.md
+++ b/custodian-skills/configure-channel/SKILL.md
@@ -1,30 +1,68 @@
 ---
 name: configure-channel
-description: Configure and prove a Telegram, Discord, Slack, WhatsApp, or other OpenClaw channel.
+description: Configure and prove a chat channel with non-interactive one-liners; secrets only as SecretRefs.
 ---
 
 # Configure a channel
 
-Never print or persist secret values; put credentials in SecretRefs or the channel credential store. Never hand-edit config files on disk. Every run ends with the observable Prove result or an exact explanation of why it could not be proven.
-
-Use the channel's guide as the source of truth: [Telegram](https://docs.openclaw.ai/channels/telegram), [Discord](https://docs.openclaw.ai/channels/discord), [Slack](https://docs.openclaw.ai/channels/slack), or [WhatsApp](https://docs.openclaw.ai/channels/whatsapp).
+Never print or persist secret values; channel tokens enter config only as SecretRefs, or through the in-session `connect_channel` flow where the operator types the secret into a masked prompt. Never hand-edit config files on disk. Every run ends with the observable Prove result or an exact explanation of why it could not be proven.
 
 ## Gather
 
-Identify the channel family, account, test destination, and intended agent. Read current state with the `gateway` tool's `config.get` action and ask the `openclaw` tool to inspect the channel. Probe live status before changing anything. Do not request a token in chat or logs.
+```
+openclaw channels list --all
+openclaw channels status
+openclaw channels capabilities --channel telegram
+openclaw config get channels --json
+```
+
+Confirm the exact config path before writing — key names differ per channel (`channels.telegram.botToken`, `channels.discord.token`, ...):
+
+```
+openclaw config schema --json | jq '.properties.channels.properties.telegram'
+```
 
 ## Mutate
 
-Route setup through the `openclaw` tool. Its Custodian flow uses `connect_channel` and, when masked credential entry is needed, `open_setup` with `target=channels`; these are the canonical channel config flows. If an approved leaf change is necessary inside Custodian, it must use `config_schema` first, then `config_set` or `config_set_ref`, never a filesystem edit. Preserve unrelated accounts and bindings.
+Preferred shell path — token staged as an env var on the gateway process or in a `0600` file, wired as a SecretRef (Telegram example):
+
+```
+openclaw config set channels.telegram.botToken --ref-provider default --ref-source env --ref-id TELEGRAM_BOT_TOKEN
+openclaw config set channels.telegram.allowFrom '["+15555550123"]' --strict-json
+```
+
+Multi-field changes in one validated write:
+
+```
+openclaw config patch --stdin <<'JSON'
+{ channels: { telegram: { enabled: true, groupPolicy: "allowlist" } } }
+JSON
+```
+
+In-session alternative: call the `connect_channel` tool action with the channel id — the operator enters the token in a masked prompt, never in chat. Avoid `openclaw channels add --token <value>`: it puts the secret in argv and process listings.
 
 ## Repair
 
-Run `openclaw doctor`. If it reports a safe repair, explain it and get approval before running `openclaw doctor --fix` outside the active Custodian inference session. Re-read channel state afterward.
+```
+openclaw doctor --non-interactive
+openclaw channels status --deep
+```
+
+Apply `openclaw doctor --fix --non-interactive` only after approval, then re-check status.
 
 ## Prove
 
-Send one real, clearly labeled test message through the configured account to the agreed destination. Confirm receipt from the channel response, delivery result, or recipient observation. If sending or confirmation is impossible, report the exact account, permission, destination, or network blocker without exposing credentials.
+Send one real, clearly labeled test message and confirm delivery from the command result (use `--dry-run` first to inspect the payload):
+
+```
+openclaw message send --channel telegram --target @yourtestchat --message "OpenClaw channel test — please ignore" --dry-run
+openclaw message send --channel telegram --target @yourtestchat --message "OpenClaw channel test — please ignore"
+```
+
+If sending fails, report the exact account, permission, destination, or network blocker without exposing credentials.
 
 ## Report
 
-State the channel and account changed, the canonical flow used, the redacted config paths affected, the test destination, and the observed receipt. List any remaining operator action.
+State the channel and account changed, the exact config paths written (never values), the test destination, and the observed delivery result. List any remaining operator action.
+
+Further reference: https://docs.openclaw.ai/channels/telegram (and the matching page for other channels)

--- a/custodian-skills/diagnose-gateway/SKILL.md
+++ b/custodian-skills/diagnose-gateway/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: diagnose-gateway
+description: Diagnose Gateway, config, secrets, channels, and port failures without changing system state.
+---
+
+# Diagnose the Gateway
+
+This playbook is read-only. Never print or persist secret values; report only redacted SecretRef owner state. Never hand-edit config files on disk. Every run ends with the observable Prove result or an exact explanation of why it could not be proven.
+
+Use [Gateway troubleshooting](https://docs.openclaw.ai/gateway/troubleshooting) and [SecretRefs](https://docs.openclaw.ai/gateway/secrets).
+
+## Gather
+
+Run the `openclaw` tool's read actions `status`, `validate_config`, `gateway_status`, and `doctor`. From a trusted shell, collect `openclaw gateway status --deep`; on managed installs use `./scripts/clawlog.sh` for bounded recent logs. Check these signatures without guessing:
+
+- invalid config or schema errors;
+- degraded SecretRef owners, never secret ids or values;
+- expired or rejected channel authentication;
+- `EADDRINUSE`, another Gateway listener, or service/config port mismatch.
+
+Correlate timestamps and identify the first owner-boundary failure.
+
+## Mutate
+
+Do not mutate config, services, credentials, ports, or files. Do not run `doctor --fix`, restart the Gateway, or kill a listener.
+
+## Repair
+
+Run read-only `openclaw doctor` and translate each finding into a recommended next action. Name the best next skill when applicable: `configure-channel`, `add-model-provider`, or `cloud-image-bake`. Recommend `openclaw doctor --fix` only as a separately approved action outside the active Custodian inference session.
+
+## Prove
+
+Repeat the smallest read-only probe that exposes the condition, such as `openclaw gateway status --deep --require-rpc` or a channel status probe. Record the observable result. If access, logs, or the Gateway are unavailable, report that exact blocker rather than declaring a cause.
+
+## Report
+
+Return findings in causal order, evidence for each, the current Gateway/config/SecretRef/channel/port state, and one recommended next skill or operator action. State explicitly that nothing was changed.

--- a/custodian-skills/diagnose-gateway/SKILL.md
+++ b/custodian-skills/diagnose-gateway/SKILL.md
@@ -1,37 +1,56 @@
 ---
 name: diagnose-gateway
-description: Diagnose Gateway, config, secrets, channels, and port failures without changing system state.
+description: Diagnose Gateway, config, secrets, channels, and port failures with read-only one-liners.
 ---
 
 # Diagnose the Gateway
 
-This playbook is read-only. Never print or persist secret values; report only redacted SecretRef owner state. Never hand-edit config files on disk. Every run ends with the observable Prove result or an exact explanation of why it could not be proven.
-
-Use [Gateway troubleshooting](https://docs.openclaw.ai/gateway/troubleshooting) and [SecretRefs](https://docs.openclaw.ai/gateway/secrets).
+This playbook is read-only: no config writes, no service restarts, no `doctor --fix`, no killing listeners. Never print secret values; report only redacted SecretRef owner state. Every run ends with the observable Prove result or an exact explanation of why it could not be proven.
 
 ## Gather
 
-Run the `openclaw` tool's read actions `status`, `validate_config`, `gateway_status`, and `doctor`. From a trusted shell, collect `openclaw gateway status --deep`; on managed installs use `./scripts/clawlog.sh` for bounded recent logs. Check these signatures without guessing:
+```
+openclaw doctor --non-interactive
+openclaw gateway status --deep
+openclaw config validate
+openclaw channels status
+openclaw models status
+openclaw channels logs --channel <id>
+```
 
-- invalid config or schema errors;
-- degraded SecretRef owners, never secret ids or values;
-- expired or rejected channel authentication;
-- `EADDRINUSE`, another Gateway listener, or service/config port mismatch.
+On managed installs, bounded recent logs: `./scripts/clawlog.sh` (repo checkout) or the log path printed at gateway startup (`/tmp/openclaw/openclaw-<date>.log` by default).
+
+Check these signatures without guessing:
+
+- invalid config or schema errors (`config validate` names the exact key and line);
+- degraded SecretRef owners — report the owner, never ids or values;
+- expired or rejected channel authentication (`channels status` per account);
+- `EADDRINUSE`, a second gateway listener, or service/config port mismatch (`lsof -nP -iTCP:<port> -sTCP:LISTEN`);
+- gateway crash loops: read the last startup stack in the gateway log; a schema-valid config that still crashes startup is a bug — capture the stack and report it.
 
 Correlate timestamps and identify the first owner-boundary failure.
 
 ## Mutate
 
-Do not mutate config, services, credentials, ports, or files. Do not run `doctor --fix`, restart the Gateway, or kill a listener.
+Nothing. This skill changes no state.
 
 ## Repair
 
-Run read-only `openclaw doctor` and translate each finding into a recommended next action. Name the best next skill when applicable: `configure-channel`, `add-model-provider`, or `cloud-image-bake`. Recommend `openclaw doctor --fix` only as a separately approved action outside the active Custodian inference session.
+Translate each finding into the next action, naming the responsible skill when one exists: `configure-channel`, `add-model-provider`, or `cloud-image-bake`. Recommend `openclaw doctor --fix --non-interactive` only as a separately approved step.
 
 ## Prove
 
-Repeat the smallest read-only probe that exposes the condition, such as `openclaw gateway status --deep --require-rpc` or a channel status probe. Record the observable result. If access, logs, or the Gateway are unavailable, report that exact blocker rather than declaring a cause.
+Repeat the smallest read-only probe that exposes the condition and record its output, for example:
+
+```
+openclaw gateway status --deep
+openclaw channels status --deep
+```
+
+If access, logs, or the gateway are unavailable, report that exact blocker rather than declaring a cause.
 
 ## Report
 
-Return findings in causal order, evidence for each, the current Gateway/config/SecretRef/channel/port state, and one recommended next skill or operator action. State explicitly that nothing was changed.
+Findings in causal order with evidence for each; current gateway/config/SecretRef/channel/port state; one recommended next skill or operator action. State explicitly that nothing was changed.
+
+Further reference: https://docs.openclaw.ai/gateway/troubleshooting

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1358,6 +1358,7 @@
                 "group": "Skills",
                 "pages": [
                   "tools/skills",
+                  "tools/custodian-skills",
                   "tools/skill-workshop",
                   "tools/self-learning",
                   "tools/creating-skills",

--- a/docs/tools/custodian-skills.md
+++ b/docs/tools/custodian-skills.md
@@ -1,0 +1,73 @@
+---
+title: "Custodian skills"
+sidebarTitle: "Custodian skills"
+summary: "Release-versioned operational skills that only the configured Custodian agent can discover and use."
+read_when:
+  - Configuring or extending the Custodian agent
+  - Reviewing agent-only skill loading
+  - Planning operational skill coverage
+---
+
+Custodian skills are release-versioned operational playbooks shipped with OpenClaw. They live under `custodian-skills/` in the package and load at the bundled-skill precedence tier, but only for the agent resolved by `agents.defaults.systemAgent.agentId`.
+
+When that setting is absent, OpenClaw uses the existing system-agent fallback: the sole configured agent, or legacy `main` when no explicit agent roster exists. If several agents are configured and no system agent is selected, no agent receives the library. For every other agent, Custodian skills are absent from discovery, snapshots, slash-command catalogs, sandbox sync, and the model-facing skills prompt.
+
+Normal skill controls still apply. `skills.entries.<name>.enabled: false` disables an individual Custodian skill, and agent skill allowlists can narrow the final set. See [Skills config](/tools/skills-config).
+
+## Workflow contract
+
+Every shipped Custodian skill uses the same five sections in this order:
+
+1. **Gather** reads redacted current config and probes live state.
+2. **Mutate** uses the canonical Custodian or onboarding config flow, never a direct file edit.
+3. **Repair** runs `openclaw doctor` and separates diagnosis from any approved repair.
+4. **Prove** exercises one live end-to-end outcome.
+5. **Report** records what changed, what was observed, and what remains.
+
+All five-section playbooks keep secret values out of prompts, logs, and files. Credentials use SecretRefs or credential stores. A workflow never claims success without its Prove outcome; it reports the exact blocker when live proof is unavailable.
+
+## First wave
+
+| Skill                | Outcome                                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `configure-channel`  | Configure and send a confirmed test message through a channel family such as Discord, Slack, Telegram, or WhatsApp. |
+| `add-model-provider` | Configure API-key or subscription/OAuth provider access and run one live Gateway inference.                         |
+| `diagnose-gateway`   | Perform read-only Gateway, config, SecretRef, channel-auth, log, and port triage.                                   |
+| `cloud-image-bake`   | Bake a Cloud Worker image, prove it with a timed dispatch, and safely retire the superseded snapshot.               |
+
+## Roadmap catalog
+
+The following catalog documents intended later tiers. These names are roadmap entries, not bundled skills or promises of current behavior.
+
+### Tier 2: common operations
+
+- `configure-search`: configure and live-prove a search provider.
+- `create-agent`: create an agent, verify its workspace, and prove one turn.
+- `manage-plugin`: install, configure, verify, or remove an approved plugin.
+- `rotate-credential`: rotate one supported credential through its owning store and prove the consumer.
+- `upgrade-openclaw`: stage an upgrade, run health checks, and verify rollback readiness.
+
+### Tier 3: advanced operations
+
+- `fleet-rollout`: roll out one verified config or release across managed Gateways.
+- `incident-response`: collect redacted evidence, contain an incident, and verify recovery.
+- `migrate-gateway`: move a Gateway while preserving explicit state and identity contracts.
+- `release-validation`: run release-track package, install, and live behavior proof.
+- `restore-backup`: restore into an isolated target, validate state, and cut over deliberately.
+
+## Add an operator skill
+
+Put local additions in the configured Custodian agent's workspace, not in the release-owned package directory:
+
+```text
+<custodian-workspace>/skills/<skill-name>/SKILL.md
+```
+
+Workspace skills already have higher precedence than the bundled tier and are scoped to that agent's workspace. Follow the same Gather → Mutate → Repair → Prove → Report contract, keep the description short, and start a new session after changing the skill. See [Creating skills](/tools/creating-skills) for the full format.
+
+## Related
+
+- [Skills](/tools/skills)
+- [Skills config](/tools/skills-config)
+- [Cloud Workers](/gateway/cloud-workers)
+- [Gateway troubleshooting](/gateway/troubleshooting)

--- a/docs/tools/custodian-skills.md
+++ b/docs/tools/custodian-skills.md
@@ -19,7 +19,7 @@ Normal skill controls still apply. `skills.entries.<name>.enabled: false` disabl
 Every shipped Custodian skill uses the same five sections in this order:
 
 1. **Gather** reads redacted current config and probes live state.
-2. **Mutate** uses the canonical Custodian or onboarding config flow, never a direct file edit.
+2. **Mutate** uses validated non-interactive writes — `openclaw config set` / `openclaw config patch` from a trusted shell, or the in-session Custodian tool actions where policy allows — never a direct file edit.
 3. **Repair** runs `openclaw doctor` and separates diagnosis from any approved repair.
 4. **Prove** exercises one live end-to-end outcome.
 5. **Report** records what changed, what was observed, and what remains.

--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -482,9 +482,13 @@ workspace/skills      (highest)
 workspace/.agents/skills
 ~/.agents/skills
 ~/.openclaw/skills
-bundled skills
+bundled + Custodian skills
 skills.load.extraDirs (lowest)
 ```
+
+Custodian skills share bundled precedence but load only for the agent selected
+by `agents.defaults.systemAgent.agentId` (or the existing sole-agent fallback).
+See [Custodian skills](/tools/custodian-skills).
 
 Changes to skills and config take effect on the next new session when the
 watcher is enabled, or on the next agent turn when the watcher detects a

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -34,14 +34,15 @@ binary presence.
 OpenClaw loads from these sources, **highest precedence first**. When the same
 skill name appears in multiple places, the highest source wins.
 
-| Priority    | Source                 | Path                                    |
-| ----------- | ---------------------- | --------------------------------------- |
-| 1 — highest | Workspace skills       | `<workspace>/skills`                    |
-| 2           | Project agent skills   | `<workspace>/.agents/skills`            |
-| 3           | Personal agent skills  | `~/.agents/skills` (default state only) |
-| 4           | Managed / local skills | `<state-dir>/skills`                    |
-| 5           | Bundled skills         | shipped with the install                |
-| 6 — lowest  | Extra directories      | `skills.load.extraDirs` + plugin skills |
+| Priority    | Source                 | Path                                     |
+| ----------- | ---------------------- | ---------------------------------------- |
+| 1 — highest | Workspace skills       | `<workspace>/skills`                     |
+| 2           | Project agent skills   | `<workspace>/.agents/skills`             |
+| 3           | Personal agent skills  | `~/.agents/skills` (default state only)  |
+| 4           | Managed / local skills | `<state-dir>/skills`                     |
+| 5           | Bundled skills         | shipped with the install                 |
+| 5           | Custodian skills       | shipped; configured Custodian agent only |
+| 6 — lowest  | Extra directories      | `skills.load.extraDirs` + plugin skills  |
 
 Skill roots support grouped layouts. OpenClaw discovers a skill whenever
 `SKILL.md` appears anywhere under a configured root (up to 6 levels deep):
@@ -54,6 +55,10 @@ Skill roots support grouped layouts. OpenClaw discovers a skill whenever
 The folder path is for organization only. The skill's name and slash command
 come from the `name` frontmatter field (or the directory name when `name` is
 missing). Agent allowlists (below) also match on this `name`.
+
+The release-versioned [Custodian skill library](/tools/custodian-skills) shares
+the bundled precedence tier but is absent for every agent except the configured
+system/Custodian agent.
 
 <Note>
   Codex CLI's native `$CODEX_HOME/skills` directory is **not** an OpenClaw

--- a/package.json
+++ b/package.json
@@ -371,6 +371,7 @@
     "scripts/lib/tsx-cli-shim.mjs",
     "patches/",
     "skills/",
+    "custodian-skills/",
     "scripts/prepare-git-hooks.mjs",
     "scripts/preinstall-package-manager-warning.mjs",
     "scripts/lib/official-external-channel-catalog.json",

--- a/src/skills/discovery/skill-index.ts
+++ b/src/skills/discovery/skill-index.ts
@@ -92,6 +92,7 @@ function createSkillIndexEntry(
     source,
     bundled:
       source === "openclaw-bundled" ||
+      source === "openclaw-custodian" ||
       (source === "unknown" && opts?.bundledNames?.has(name) === true),
     agentAllowed: agentSkillSet === undefined || agentSkillSet.has(name),
     runtimeVisible: isSkillRuntimeVisible(entry),

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -363,6 +363,7 @@ export function buildWorkspaceSkillStatus(
     opts?.entries ??
       loadWorkspaceSkills(workspaceDir, {
         config: opts?.config,
+        agentId: opts?.agentId,
         managedSkillsDir,
         bundledSkillsDir: bundledContext.dir,
         includeArchived: true,

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -363,7 +363,10 @@ export function buildWorkspaceSkillStatus(
     opts?.entries ??
       loadWorkspaceSkills(workspaceDir, {
         config: opts?.config,
+        // agentId scopes custodian-source discovery only; the "ignore" mode
+        // keeps the entry list unfiltered per the invariant above.
         agentId: opts?.agentId,
+        agentSkillFilter: "ignore",
         managedSkillsDir,
         bundledSkillsDir: bundledContext.dir,
         includeArchived: true,

--- a/src/skills/loading/config.ts
+++ b/src/skills/loading/config.ts
@@ -100,7 +100,7 @@ function normalizeAllowlist(input: unknown): ReadonlySet<string> | undefined {
   return normalized.length > 0 ? new Set(normalized) : undefined;
 }
 
-const BUNDLED_SOURCES = new Set(["openclaw-bundled"]);
+const BUNDLED_SOURCES = new Set(["openclaw-bundled", "openclaw-custodian"]);
 
 function isBundledSkill(entry: SkillEntry): boolean {
   return BUNDLED_SOURCES.has(resolveSkillSource(entry.skill));

--- a/src/skills/loading/source.ts
+++ b/src/skills/loading/source.ts
@@ -22,7 +22,7 @@ export function resolveSkillSource(skill: Skill): string {
 
 export function resolveSkillTelemetrySourceValue(value: unknown): SkillTelemetrySource {
   const source = normalizeOptionalString(value) ?? "";
-  if (source === "bundled" || source === "openclaw-bundled") {
+  if (source === "bundled" || source === "openclaw-bundled" || source === "openclaw-custodian") {
     return "bundled";
   }
   if (

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -3,12 +3,14 @@ import fs from "node:fs";
 import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
+import { tryResolveSystemAgentTargetAgentId } from "../../agents/agent-scope-config.js";
 import { canonicalizePath } from "../../agents/utils/paths.js";
 import { isDefaultStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { normalizeAgentId } from "../../routing/session-key.js";
 import { CONFIG_DIR, resolveUserPath } from "../../utils.js";
 import {
   isSessionSkillEnabled,
@@ -49,6 +51,7 @@ import {
 import { resolveAllowedSkillSymlinkTargetRealPaths, tryRealpath } from "./symlink-targets.js";
 
 const skillsLogger = createSubsystemLogger("skills");
+const CUSTODIAN_SKILLS_DIR_NAME = "custodian-skills";
 const SKILL_SOURCE_ORIGIN_RELATIVE_PATH = path.join(".openclaw", "source-origin.json");
 const MAX_SKILL_SOURCE_ORIGIN_BYTES = 16 * 1024;
 
@@ -368,6 +371,19 @@ function loadSkillEntries(
   const bundledSkills = bundledSkillsDir
     ? loadSkills({ dir: bundledSkillsDir, source: "openclaw-bundled" })
     : [];
+  const custodianAgentId = opts?.config
+    ? tryResolveSystemAgentTargetAgentId(opts.config)
+    : undefined;
+  const custodianSkillsDir =
+    bundledSkillsDir &&
+    opts?.agentId &&
+    custodianAgentId &&
+    normalizeAgentId(opts.agentId) === custodianAgentId
+      ? path.join(path.dirname(bundledSkillsDir), CUSTODIAN_SKILLS_DIR_NAME)
+      : undefined;
+  const custodianSkills = custodianSkillsDir
+    ? loadSkills({ dir: custodianSkillsDir, source: "openclaw-custodian" })
+    : [];
   const extraSkills = [
     ...mergedExtraDirs.flatMap((dir) =>
       loadSkills({ dir: resolveUserPath(dir), source: "openclaw-extra" }),
@@ -411,7 +427,14 @@ function loadSkillEntries(
   for (const record of extraSkills) {
     mergeRecord(record);
   }
-  for (const record of bundledSkills) {
+  // Custodian skills share bundled precedence. Sort the tier so source traversal
+  // remains deterministic even if a package accidentally ships a duplicate name.
+  const bundledTierSkills = [...bundledSkills, ...custodianSkills].toSorted(
+    (left, right) =>
+      left.skill.name.localeCompare(right.skill.name, "en") ||
+      left.skill.source.localeCompare(right.skill.source, "en"),
+  );
+  for (const record of bundledTierSkills) {
     mergeRecord(record);
   }
   for (const record of managedSkills) {

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -75,6 +75,12 @@ type WorkspaceSkillLoadOptions = {
   skillFilter?: string[];
   skillOverrides?: Record<string, boolean>;
   agentId?: string;
+  /**
+   * "ignore" keeps agentId scoping source discovery (custodian skills) without
+   * activating the agent allowlist filter — status/inventory views need the
+   * full entry list so excluded skills stay present-but-marked.
+   */
+  agentSkillFilter?: "apply" | "ignore";
   eligibility?: SkillEligibilityContext;
   workspaceOnly?: boolean;
   includeArchived?: boolean;
@@ -492,12 +498,13 @@ function filterArchivedSkillEntries(entries: SkillEntry[]): SkillEntry[] {
 function resolveEffectiveWorkspaceSkillFilter(opts?: {
   config?: OpenClawConfig;
   agentId?: string;
+  agentSkillFilter?: "apply" | "ignore";
   skillFilter?: string[];
 }): string[] | undefined {
   if (opts?.skillFilter !== undefined) {
     return normalizeSkillFilter(opts.skillFilter);
   }
-  if (!opts?.config || !opts.agentId) {
+  if (opts?.agentSkillFilter === "ignore" || !opts?.config || !opts.agentId) {
     return undefined;
   }
   return resolveEffectiveAgentSkillFilter(opts.config, opts.agentId);

--- a/src/skills/loading/workspace-skill-snapshot.test.ts
+++ b/src/skills/loading/workspace-skill-snapshot.test.ts
@@ -2,9 +2,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withEnv, withPathResolutionEnv } from "../../test-utils/env.js";
 import { createFixtureSuite } from "../../test-utils/fixture-suite.js";
 import { createTempHomeEnv, type TempHomeEnv } from "../../test-utils/temp-home.js";
+import { buildWorkspaceSkillStatus } from "../discovery/status.js";
 import { resolveEmbeddedRunSkillEntries } from "../runtime/embedded-run-entries.js";
 import { resolveReusableWorkspaceSkillSnapshot } from "../runtime/session-snapshot.js";
 import { writeSkill, writeWorkspaceSkills } from "../test-support/e2e-test-helpers.js";
@@ -67,6 +69,34 @@ function buildSnapshot(workspaceDir: string, options?: Parameters<typeof buildSk
   );
 }
 
+const CUSTODIAN_SKILL_NAMES = [
+  "add-model-provider",
+  "cloud-image-bake",
+  "configure-channel",
+  "diagnose-gateway",
+] as const;
+
+async function writeCustodianSkillFixture(workspaceDir: string): Promise<void> {
+  for (const name of CUSTODIAN_SKILL_NAMES) {
+    await writeSkill({
+      dir: path.join(workspaceDir, "custodian-skills", name),
+      name,
+      description: `Custodian ${name}`,
+    });
+  }
+}
+
+function buildAgentSnapshot(params: {
+  workspaceDir: string;
+  config: OpenClawConfig;
+  agentId: string;
+}) {
+  return buildSnapshot(params.workspaceDir, {
+    config: params.config,
+    agentId: params.agentId,
+  });
+}
+
 async function cloneTemplateDir(templateDir: string, prefix: string): Promise<string> {
   const cloned = await fixtureSuite.createCaseDir(prefix);
   await fs.cp(templateDir, cloned, { recursive: true });
@@ -121,6 +151,101 @@ function expectSnapshotNamesAndPrompt(
 }
 
 describe("buildSkillSnapshot", () => {
+  it("keeps custodian skills absent from every non-custodian discovery surface", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("custodian-gate");
+    await writeCustodianSkillFixture(workspaceDir);
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: { systemAgent: { agentId: "ops" } },
+        entries: { ops: {}, writer: {} },
+      },
+    };
+
+    const firstCustodianSnapshot = buildAgentSnapshot({ workspaceDir, config, agentId: "ops" });
+    const secondCustodianSnapshot = buildAgentSnapshot({ workspaceDir, config, agentId: "ops" });
+    const writerSnapshot = buildAgentSnapshot({ workspaceDir, config, agentId: "writer" });
+    const custodianStatus = buildWorkspaceSkillStatus(workspaceDir, {
+      config,
+      agentId: "ops",
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+    });
+    const writerStatus = buildWorkspaceSkillStatus(workspaceDir, {
+      config,
+      agentId: "writer",
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+    });
+
+    expect(firstCustodianSnapshot.skills.map((skill) => skill.name)).toEqual(CUSTODIAN_SKILL_NAMES);
+    expect(firstCustodianSnapshot.resolvedSkills?.map((skill) => skill.source)).toEqual(
+      CUSTODIAN_SKILL_NAMES.map(() => "openclaw-custodian"),
+    );
+    expect(secondCustodianSnapshot.skills).toEqual(firstCustodianSnapshot.skills);
+    expect(secondCustodianSnapshot.prompt).toBe(firstCustodianSnapshot.prompt);
+    expect(writerSnapshot.skills).toEqual([]);
+    expect(writerSnapshot.prompt).toBe("");
+    expect(
+      custodianStatus.skills
+        .filter((skill) => skill.source === "openclaw-custodian")
+        .map((skill) => skill.name),
+    ).toEqual(CUSTODIAN_SKILL_NAMES);
+    expect(writerStatus.skills.filter((skill) => skill.source === "openclaw-custodian")).toEqual(
+      [],
+    );
+  });
+
+  it("mirrors the system-agent resolver fallback when no owner is configured", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("custodian-owner-fallback");
+    await writeCustodianSkillFixture(workspaceDir);
+
+    const soleAgentConfig: OpenClawConfig = {
+      agents: { entries: { caretaker: {} } },
+    };
+    const ambiguousConfig: OpenClawConfig = {
+      agents: { entries: { ops: {}, writer: {} } },
+    };
+    const soleSnapshot = buildAgentSnapshot({
+      workspaceDir,
+      config: soleAgentConfig,
+      agentId: "caretaker",
+    });
+    const mainSnapshot = buildAgentSnapshot({ workspaceDir, config: {}, agentId: "main" });
+    const ambiguousSnapshot = buildAgentSnapshot({
+      workspaceDir,
+      config: ambiguousConfig,
+      agentId: "ops",
+    });
+
+    expect(soleSnapshot.skills.map((skill) => skill.name)).toEqual(CUSTODIAN_SKILL_NAMES);
+    expect(mainSnapshot.skills.map((skill) => skill.name)).toEqual(CUSTODIAN_SKILL_NAMES);
+    expect(ambiguousSnapshot.skills).toEqual([]);
+    expect(ambiguousSnapshot.prompt).toBe("");
+  });
+
+  it("applies per-skill disabled overrides to custodian skills", async () => {
+    const workspaceDir = await fixtureSuite.createCaseDir("custodian-disabled");
+    await writeCustodianSkillFixture(workspaceDir);
+    const config: OpenClawConfig = {
+      agents: {
+        defaults: { systemAgent: { agentId: "ops" } },
+        entries: { ops: {} },
+      },
+      skills: {
+        entries: {
+          "cloud-image-bake": { enabled: false },
+        },
+      },
+    };
+
+    const snapshot = buildAgentSnapshot({ workspaceDir, config, agentId: "ops" });
+
+    expect(snapshot.skills.map((skill) => skill.name)).toEqual([
+      "add-model-provider",
+      "configure-channel",
+      "diagnose-gateway",
+    ]);
+    expect(snapshot.prompt).not.toContain("cloud-image-bake");
+  });
+
   it("orders agent skills before execution skills with lexical order inside each root", async () => {
     const { snapshot } = await createMultiRootFixture();
 


### PR DESCRIPTION
## What Problem This Solves

Operators configure OpenClaw through docs and trial-and-error; the system custodian agent has no executable knowledge of the common configuration workflows. There was also no way to ship skills that only the custodian can see: anything bundled today is visible to every agent, which pollutes regular agents' skill prompts with privileged config workflows they cannot (and should not) run.

## Why This Change Was Made

Adds a custodian-only skill source and the first wave of an operational skill library:

- **New skill source `openclaw-custodian`** (`custodian-skills/` in the package, bundled precedence): loaded only for the agent resolved by `agents.defaults.systemAgent.agentId`, reusing the existing system-agent resolver (`tryResolveSystemAgentTargetAgentId`, fallback `tryResolveSoleAgentId`). For every other agent the source is absent — not listed, not disabled — across discovery, snapshots, slash-command catalogs, and the model-facing skills prompt. Fails closed when agent identity is unavailable. Deterministic ordering inside the bundled tier (prompt-cache safe).
- **Four skills**, each following a fixed Gather -> Mutate -> Repair -> Prove -> Report skeleton with hard guardrails (secrets only via SecretRefs/credential stores, mutations only through the canonical custodian config flows, every run ends in an observable outcome or an explicit blocker report): `configure-channel`, `add-model-provider`, `diagnose-gateway`, `cloud-image-bake`.
- **Docs**: `docs/tools/custodian-skills.md` (semantics, workflow contract, first wave, tier-2/3 roadmap, operator extension path) plus cross-links from the skills pages; labeler coverage for the new paths.

Sole-agent semantics are intentional and documented: in a single-agent install the resolver treats that agent as the system agent, so it receives the library; in multi-agent rosters without an explicit `systemAgent.agentId`, no agent receives it.

Non-goals (follow-ups): `cloudWorkers.projectProfiles` mapping, thin-pack workspace sync, tier-2/3 skill implementations.

## User Impact

Operators with a configured custodian agent can ask it to configure channels/providers, triage the gateway, or bake cloud-worker images, and it follows release-versioned, prove-before-report playbooks. Regular agents see zero change (verified: no trace in their snapshots or prompts). No new config keys.

## Evidence

- Focused tests: `node scripts/run-vitest.mjs src/skills/loading/workspace-skill-snapshot.test.ts` — 14/14 pass (gating, resolver-fallback mirror, deterministic ordering, per-skill disabled override, prompt absence for non-custodian agents).
- Packaging: `pnpm build` clean, no `[INEFFECTIVE_DYNAMIC_IMPORT]`; npm dry-run pack ships exactly the 4 custodian skills alongside 51 bundled skills.
- **Live end-to-end test** (isolated dev gateway, own state dir, port 19750; two agents `ops` custodian + `main` default; real keys):
  - Skill gating live: `openclaw skills --agent ops` lists exactly the 4 custodian skills (`source=openclaw-custodian`); `--agent main` lists 0.
  - A real custodian agent turn (`openclaw agent --agent ops`, claude-sonnet-4-6) invoked `add-model-provider` and executed Gather -> Mutate via the canonical flows: it created a file-backed SecretRef provider (`secrets.providers.openai_key_file`) and wired `models.providers.openai.apiKey` to it — with a real OpenAI API key staged on disk, never pasted in chat.
  - Secret hygiene verified: zero occurrences of the key material in the session transcript, gateway log, or turn output.
  - Live inference through the custodian-written config: `openclaw infer model run --gateway --model openai/gpt-5.4` returned the expected probe string (`CUSTODIAN-PROOF-OK`) in ~16s including CLI startup.
  - Caveats found while testing (filed, not blockers): the custodian hit the 10-minute CLI turn cap mid-Prove (proof completed operator-side); OpenAI inference requires the external `@openclaw/codex` plugin at runtime; a schema-valid multi-agent config without `heartbeat.agentId` crashes gateway startup via the deprecated default-agent resolver (bug card filed separately).
- Autoreview (Codex): clean, no actionable findings.

### A/B live test: same task with vs without the skill (2026-08-18)

Identical rigs (fresh isolated gateways, two-agent roster, `agents.defaults.timeoutSeconds: 1500`, codex plugin installed), identical task prompt ("add OpenAI via API-key auth from a staged key file, prove with live inference"), custodian on claude-sonnet-4-6. Rig B disabled all four custodian skills via `skills.entries.*.enabled: false` (verified `modelVisible: false`).

| | With skill | Without skill |
| --- | --- | --- |
| Outcome | Full success | Config correct, **proof invalid** |
| Wall time | 12.6 min across 2 turns (incl. one approval gate) | 9.8 min, 1 turn |
| Assistant turns | 43 | 54 |
| Config writes | canonical SecretRef one-liners from the skill | same shape (model already knew the CLI from exploration) |
| Proof | through the gateway: `openai/gpt-5.4` via codex harness, `PROVIDER-PROOF-OK`, 3,226 ms | **bypassed OpenClaw**: raw `curl` to `api.openai.com` with the key resolved from the SecretRef file, on `gpt-4o-mini` (never configured) |
| Secret handling | key never left SecretRef machinery | key shelled into a curl Authorization header (transcript shows only redacted prefixes, but the raw value transited argv/env) |
| Remediation | self-served: enabled the codex plugin per the skill's dependency note, requested approval for restart (hot-reload sufficed) | n/a — never exercised the harness path |

The skill's value is correctness of the *proof level* and secret discipline, not raw speed: the skill-less agent finished slightly faster by silently substituting a direct OpenAI API call for a product-level verification — exactly the failure mode the Prove contract exists to prevent.

The A/B run also hardened the skills (commit `134d5ccbfde`): `--agent` on models list/auth in multi-agent rosters, roster-safe prove via an agent turn (`infer model run` has no `--agent` flag and dead-ends multi-agent setups — CLI gap filed), dropped a hanging `channels capabilities` probe, telegram `--target <chatId>`, expected not-found notes. Every command in the skills has now been executed against a live gateway.
