### PR TITLE
test(infra): remove channel activity reset seam

### DIFF
--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -302,7 +302,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       //     runtimes render the same guidance instead of diverging prompt copies.
       // +1: shared harness visible-source-reply guidance.
       // +1: typed guarded-fetch redirect error for direct-only plugin delivery.
-      4336,
+      // -1: remove the test-only channel activity reset export.
+      4335,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -388,7 +389,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: shared delegation policy (mode resolver + section builder) so harness
       //     runtimes render the same guidance instead of diverging prompt copies.
       // +1: shared harness visible-source-reply guidance.
-      2578,
+      // -1: remove the test-only channel activity reset export.
+      2577,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/infra/channel-activity.test.ts
+++ b/src/infra/channel-activity.test.ts
@@ -1,14 +1,9 @@
 // Covers channel activity recording and lookup.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  getChannelActivity,
-  recordChannelActivity,
-  resetChannelActivityForTest,
-} from "./channel-activity.js";
+import { getChannelActivity, recordChannelActivity } from "./channel-activity.js";
 
 describe("channel activity", () => {
   beforeEach(() => {
-    resetChannelActivityForTest();
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-08T00:00:00Z"));
   });
@@ -82,16 +77,6 @@ describe("channel activity", () => {
     expect(getChannelActivity({ channel: "telegram", accountId: " team-b " })).toEqual({
       inboundAt: null,
       outboundAt: 20,
-    });
-  });
-
-  it("reset clears previously recorded activity", () => {
-    recordChannelActivity({ channel: "line", direction: "outbound", at: 7 });
-    resetChannelActivityForTest();
-
-    expect(getChannelActivity({ channel: "line" })).toEqual({
-      inboundAt: null,
-      outboundAt: null,
     });
   });
 });

--- a/src/infra/channel-activity.ts
+++ b/src/infra/channel-activity.ts
@@ -58,8 +58,3 @@ export function getChannelActivity(params: {
     }
   );
 }
-
-/** Clears all tracked channel activity; test-only helper. */
-export function resetChannelActivityForTest() {
-  activity.clear();
-}

--- a/src/infra/infra-store.test.ts
+++ b/src/infra/infra-store.test.ts
@@ -1,13 +1,8 @@
 // Tests infra store file persistence and recovery.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-utils/temp-dir.js";
-import {
-  getChannelActivity,
-  recordChannelActivity,
-  resetChannelActivityForTest,
-} from "./channel-activity.js";
 import { createDedupeCache } from "./dedupe.js";
 import {
   emitDiagnosticEvent,
@@ -184,50 +179,6 @@ describe("infra store", () => {
       stop();
 
       expect(types).toEqual(["webhook.received", "message.queued", "session.state"]);
-    });
-  });
-
-  describe("channel activity", () => {
-    beforeEach(() => {
-      resetChannelActivityForTest();
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date("2026-01-08T00:00:00Z"));
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it("records inbound/outbound separately", () => {
-      recordChannelActivity({ channel: "telegram", direction: "inbound" });
-      vi.advanceTimersByTime(1000);
-      recordChannelActivity({ channel: "telegram", direction: "outbound" });
-      const res = getChannelActivity({ channel: "telegram" });
-      expect(res.inboundAt).toBe(1767830400000);
-      expect(res.outboundAt).toBe(1767830401000);
-    });
-
-    it("isolates accounts", () => {
-      recordChannelActivity({
-        channel: "whatsapp",
-        accountId: "a",
-        direction: "inbound",
-        at: 1,
-      });
-      recordChannelActivity({
-        channel: "whatsapp",
-        accountId: "b",
-        direction: "inbound",
-        at: 2,
-      });
-      expect(getChannelActivity({ channel: "whatsapp", accountId: "a" })).toEqual({
-        inboundAt: 1,
-        outboundAt: null,
-      });
-      expect(getChannelActivity({ channel: "whatsapp", accountId: "b" })).toEqual({
-        inboundAt: 2,
-        outboundAt: null,
-      });
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Channel activity tests still depended on a production-exported reset helper and duplicated behavior coverage in the aggregate infra-store suite. This kept a test-only production seam alive and repeated weaker assertions already owned by the dedicated channel activity suite.

## Why This Change Was Made

Remove `resetChannelActivityForTest` and the helper-only reset test, then delete the replayed aggregate channel activity block. The process-local activity map and `recordChannelActivity`/`getChannelActivity` behavior are unchanged; the three retained owner tests use non-overlapping channel/account keys and remain order-safe without reset state.

History confirms `7c58de294e26` moved this coverage to the dedicated owner suite, while unrelated voice-wake commit `afe1abc29745` later replayed the old aggregate block. Codex-assisted cleanup; implementation and proof were reviewed hands-on.

## User Impact

No user-visible or runtime behavior changes. Developers get a smaller, single-owner test surface with no test-only production export.

## Evidence

- Baseline: `node scripts/run-vitest.mjs src/infra/channel-activity.test.ts src/infra/infra-store.test.ts` — 22/22 passed.
- After cleanup: the same combined command — 19/19 passed, including after rebasing onto current `origin/main`.
- Order/process isolation: `node scripts/run-vitest.mjs src/infra/channel-activity.test.ts` run twice in fresh invocations — 3/3 passed both times.
- Exact changed gate: `node scripts/check-changed.mjs -- src/infra/channel-activity.ts src/infra/channel-activity.test.ts src/infra/infra-store.test.ts` — passed.
- CI surfaced the required shrink-only Plugin SDK ratchet update. `node scripts/run-vitest.mjs test/scripts/plugin-sdk-surface-report.test.ts` passes 10/10, and `pnpm plugin-sdk:surface:check` confirms 4,335 public exports / 2,577 callable exports.
- Expanded exact changed gate including `scripts/plugin-sdk-surface-report.mts` — passed.
- `git diff --check` — passed.
- `rg resetChannelActivityForTest` — no matches.
- Fresh Codex autoreview — clean, no accepted/actionable findings.
- Production LOC: +0/-5 (net -5). Tests: +2/-66 (net -64); additions are formatter-required import contractions.
- Tooling ratchet: +4/-2 (net +2) from two explanatory shrink comments and two decremented budget lines.
- No docs, changelog, config, dependency, lockfile, schema, protocol, release, or operator-state changes.
