### PR TITLE
fix(codex): keep progress cards visible in normal runs

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import type { AnyAgentTool } from "openclaw/plugin-sdk/agent-harness";
 import {
+  type EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams,
   HEARTBEAT_RESPONSE_TOOL_NAME,
   embeddedAgentLog,
   getPluginToolMeta,
@@ -51,6 +52,7 @@ import {
   type JsonValue,
 } from "./protocol.js";
 import type { CodexRemoteWorkspaceFileReader } from "./remote-workspace-media.js";
+import { resolveCodexDynamicToolDirectNames } from "./run-attempt-tools.js";
 import { codexDynamicToolsFingerprint } from "./thread-fingerprints.js";
 
 const CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE = "openclaw";
@@ -761,6 +763,25 @@ describe("createCodexDynamicToolBridge", () => {
       },
     );
     expectNoNamespace(specs.find((tool) => tool.name === "message"));
+  });
+
+  it("keeps progress_card direct when searchable loading defers broad tools", () => {
+    const bridge = createCodexDynamicToolBridge({
+      tools: [createTool({ name: "progress_card" }), createTool({ name: "web_search" })],
+      signal: new AbortController().signal,
+      loading: "searchable",
+      directToolNames: resolveCodexDynamicToolDirectNames({} as EmbeddedRunAttemptParams),
+    });
+
+    const specs = flattenSpecsWithNamespace(bridge.specs);
+    const progressCard = specs.find((tool) => tool.name === "progress_card");
+    const webSearch = specs.find((tool) => tool.name === "web_search");
+    expectNoNamespace(progressCard);
+    expectDynamicSpec(webSearch, {
+      name: "web_search",
+      namespace: CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
+      deferLoading: true,
+    });
   });
 
   it("isolates direct-only tools in Codex's model-only namespace", () => {

--- a/extensions/codex/src/app-server/run-attempt-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-tools.test.ts
@@ -1,0 +1,31 @@
+import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { describe, expect, it } from "vitest";
+import { resolveCodexDynamicToolDirectNames } from "./run-attempt-tools.js";
+
+function createAttemptParams(
+  overrides: Partial<EmbeddedRunAttemptParams> = {},
+): EmbeddedRunAttemptParams {
+  return overrides as EmbeddedRunAttemptParams;
+}
+
+describe("resolveCodexDynamicToolDirectNames", () => {
+  it.each([
+    { label: "normal", restricted: false },
+    { label: "restricted", restricted: true },
+  ])("keeps progress_card direct for $label runs", ({ restricted }) => {
+    const params = createAttemptParams({ pluginHarnessToolPolicyRestricted: restricted });
+
+    expect(resolveCodexDynamicToolDirectNames(params)).toEqual(["progress_card"]);
+  });
+
+  it("preserves ring-zero and message tools alongside progress_card", () => {
+    const ringZeroParams = createAttemptParams({ toolsAllow: ["openclaw"] });
+    const messageParams = createAttemptParams({ sourceReplyDeliveryMode: "message_tool_only" });
+
+    expect(resolveCodexDynamicToolDirectNames(ringZeroParams, true)).toEqual([
+      "openclaw",
+      "progress_card",
+    ]);
+    expect(resolveCodexDynamicToolDirectNames(messageParams)).toEqual(["message", "progress_card"]);
+  });
+});

--- a/extensions/codex/src/app-server/run-attempt-tools.ts
+++ b/extensions/codex/src/app-server/run-attempt-tools.ts
@@ -88,11 +88,8 @@ export function resolveCodexDynamicToolDirectNames(
   if (params.sourceReplyDeliveryMode === "message_tool_only") {
     names.push("message");
   }
-  // Restricted plugin runs replace Codex's native tool surface with an exact
-  // OpenClaw policy-filtered catalog. Keep the replacement planner visible in
-  // the initial context so Codex can maintain the same user-facing plan stream.
-  if (params.pluginHarnessToolPolicyRestricted === true) {
-    names.push("progress_card");
-  }
+  // OpenClaw disables Codex's native update_plan on every thread. Keep its
+  // replacement in the initial context or the run has no visible progress tool.
+  names.push("progress_card");
   return names;
 }

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -74,6 +74,7 @@ import {
   type v2,
 } from "./protocol.js";
 import { itemNotification, rawItemCompleted, turnCompleted } from "./protocol.test-helpers.js";
+import { resolveCodexDynamicToolDirectNames } from "./run-attempt-tools.js";
 
 type CodexAppServerToolTelemetry = Parameters<CodexAppServerEventProjector["buildResult"]>[0];
 import {
@@ -153,26 +154,7 @@ const testing = {
   buildDeveloperInstructions,
   buildDynamicTools,
   filterCodexDynamicTools,
-  resolveCodexDynamicToolDirectNames(
-    params: EmbeddedRunAttemptParams,
-    hostSystemAgentActive = false,
-  ): string[] {
-    const names: string[] = [];
-    if (
-      hostSystemAgentActive &&
-      params.toolsAllow?.length === 1 &&
-      params.toolsAllow[0] === "openclaw"
-    ) {
-      names.push("openclaw");
-    }
-    if (params.sourceReplyDeliveryMode === "message_tool_only") {
-      names.push("message");
-    }
-    if (params.pluginHarnessToolPolicyRestricted === true) {
-      names.push("progress_card");
-    }
-    return names;
-  },
+  resolveCodexDynamicToolDirectNames,
   setOpenClawCodingToolsFactoryForTests(
     factory: NonNullable<typeof dynamicToolBuildState.openClawCodingToolsFactory>,
   ): void {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running normal Codex sessions could receive no progress card during multi-phase work. The default searchable dynamic-tool profile deferred `progress_card` behind tool search while OpenClaw had already disabled Codex's native `update_plan`, leaving the model with no initially visible progress tool.

## Why This Change Was Made

`progress_card` now remains in the direct dynamic-tool set for every Codex run, while unrelated broad tools still use searchable loading. This preserves the single durable progress owner introduced by #125125 instead of reviving Codex's separate native checklist.

### Root cause

- Before this patch, `extensions/codex/src/app-server/run-attempt-tools.ts:76-98` added `progress_card` to the direct-name set only when `pluginHarnessToolPolicyRestricted` was true.
- `extensions/codex/src/app-server/dynamic-tools.ts:1122-1126` defers every searchable tool not present in that direct-name set.
- `extensions/codex/src/app-server/dynamic-tool-profile.ts:82-89` makes `searchable` the default loading mode.
- `extensions/codex/src/app-server/thread-requests.ts:49-52`, introduced by #125125, disables native `update_plan` on every thread so the durable OpenClaw card remains the sole owner.

The sibling Codex contract matches that diagnosis at inspected revision `b5ea64a203ce1b04629010d3ef0a0d18c3c870a9`: [`codex-rs/core/src/tools/spec_plan.rs:1039-1041`](https://github.com/openai/codex/blob/b5ea64a203ce1b04629010d3ef0a0d18c3c870a9/codex-rs/core/src/tools/spec_plan.rs#L1039-L1041) omits native `update_plan` when its config gate is false, while [`codex-rs/core/src/tools/handlers/dynamic.rs:58-80`](https://github.com/openai/codex/blob/b5ea64a203ce1b04629010d3ef0a0d18c3c870a9/codex-rs/core/src/tools/handlers/dynamic.rs#L58-L80) maps `deferLoading` to deferred rather than direct exposure. Codex's own contract tests confirm both behaviors in [`spec_plan_tests.rs:623-635`](https://github.com/openai/codex/blob/b5ea64a203ce1b04629010d3ef0a0d18c3c870a9/codex-rs/core/src/tools/spec_plan_tests.rs#L623-L635) and [`spec_plan_tests.rs:1107-1177`](https://github.com/openai/codex/blob/b5ea64a203ce1b04629010d3ef0a0d18c3c870a9/codex-rs/core/src/tools/spec_plan_tests.rs#L1107-L1177).

Context cost is deliberately bounded: one always-visible `progress_card` tool spec replaces the native `update_plan` spec it supplanted; it does not add a second planner or make the broad catalog direct.

## User Impact

Codex can now create and incrementally maintain the durable progress card during ordinary multi-step work without being prompted to search for the tool. Other tools retain the lower-context searchable behavior.

## Evidence

### Maintainer-run live before/after

Maintainer-run rig: isolated state directory, port 19255, `gpt-5.6-luna`, Codex runtime, paired Control UI, and a build carrying this fix. The prompt never named `progress_card`; it requested four phases: scaffold a four-module CSV-to-JSON Node project, add four `node:test` files, run and repair tests until green, then write `REPORT.md`.

On `main` without this fix, the same class of run produced zero progress-card writes. With this fix, the agent created and maintained the card on its own, finishing at revision 3:

```text
markdown: **Completed:** tiny CSV-to-JSON Node project with 4 source modules, 4 `node:test` files, `REPORT.md`, and a clean passing test run (9/9).
steps:
  completed  Create Node project and CSV-to-JSON modules
  completed  Add four node:test module test files
  completed  Run tests and fix failures
  completed  Write REPORT.md and clean up bootstrap marker
```

Revision 3 proves incremental upkeep rather than a single write at completion.

### Automated proof

- Focused pre-fix regression set: 3 files, 300 tests passed.
- Codex startup race isolated rerun: 19/19 passed. Two extension-wide local sweeps otherwise passed but hit that unrelated load-sensitive timeout in the combined shard; exact-head CI is the clean-host authority.
- `pnpm tsgo:core`
- assertion-safety ratchet: 4,302 files, 13,618 grandfathered assertions, no growth
- dead-code dependency, unused-file, and unused-export scans: zero entries in an isolated clone containing exactly this patch
- `pnpm format`
- `pnpm build`
- Autoreview, `--mode branch --base origin/main`: clean, no accepted/actionable findings

Production LOC: +3/-6 (net -3) | Tests: +54/-20 (net +34)
