### PR TITLE
improve(ui): fix sidebar session row hierarchy and add a message-preview toggle

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -8,6 +8,7 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
+      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
       "extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",
       "extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts",

--- a/ui/src/components/app-sidebar-session-menu-renderers.ts
+++ b/ui/src/components/app-sidebar-session-menu-renderers.ts
@@ -273,6 +273,7 @@ export function renderSidebarSessionSortMenu(params: {
   peopleSortAvailable: boolean;
   statusFilter: SidebarSessionStatusFilter;
   showCron: boolean;
+  showPreview: boolean;
   showSystem: boolean;
   owners: readonly SessionOwnerOption[];
   ownerFilterId: string | null;
@@ -283,6 +284,7 @@ export function renderSidebarSessionSortMenu(params: {
   onStatusFilterChange: (statusFilter: SidebarSessionStatusFilter) => void;
   onOwnerFilterChange: (ownerId: string | null, involvingMe?: boolean) => void;
   onShowCronChange: (show: boolean) => void;
+  onShowPreviewChange: (show: boolean) => void;
   onShowSystemChange: (show: boolean) => void;
   onClose: (restoreFocus: boolean) => void;
 }) {
@@ -319,6 +321,8 @@ export function renderSidebarSessionSortMenu(params: {
               params.onOwnerFilterChange(value.slice("owner:".length) || null);
             } else if (value === "involving-me") {
               params.onOwnerFilterChange(null, true);
+            } else if (value === "show-preview") {
+              params.onShowPreviewChange(!params.showPreview);
             } else if (value === "show-cron") {
               params.onShowCronChange(!params.showCron);
             } else if (value === "show-system") {
@@ -371,6 +375,17 @@ export function renderSidebarSessionSortMenu(params: {
             params.selfOwnerId,
           )}
           <div class="session-menu__separator" role="separator"></div>
+          <wa-dropdown-item
+            class="sidebar-session-sort-menu__item"
+            type="checkbox"
+            value="show-preview"
+            .checked=${params.showPreview}
+          >
+            <span class="session-menu__text">${t("sessionsView.showSessionPreview")}</span>
+            <span slot="details" class="session-menu__check" aria-hidden="true"
+              >${params.showPreview ? icons.check : nothing}</span
+            >
+          </wa-dropdown-item>
           <wa-dropdown-item
             class="sidebar-session-sort-menu__item"
             type="checkbox"

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -587,22 +587,24 @@ export function collectKnownSidebarSessionGroups(
   return [...catalog, ...new Set(discovered)];
 }
 
-/** Depth-first flatten of a projected session tree. Callers that reason about the
- *  whole list (creator facets, selection fallback) need every descendant, not just
- *  the roots; two hand-rolled walks drifted apart before this existed. */
-export function flattenSidebarSessionTree(
+/** Depth-first search across a projected session tree, including descendants.
+ *  Both callers ask "does any row match", so this short-circuits rather than
+ *  flattening: the answer usually resolves in the first few rows. */
+export function someSidebarSessionInTree(
   roots: readonly SidebarRecentSession[],
-): SidebarRecentSession[] {
-  const flattened: SidebarRecentSession[] = [];
+  predicate: (row: SidebarRecentSession) => boolean,
+): boolean {
   const pending = [...roots];
   while (pending.length > 0) {
-    const row = pending.shift();
+    const row = pending.pop();
     if (row) {
-      flattened.push(row);
+      if (predicate(row)) {
+        return true;
+      }
       pending.push(...row.children);
     }
   }
-  return flattened;
+  return false;
 }
 
 export function findProjectedSidebarSession(input: {
@@ -665,7 +667,7 @@ export function applySidebarSessionOwnerFilter(input: {
     : facetOwners;
   const hasParticipants =
     ownerOptions.length < 2 &&
-    flattenSidebarSessionTree(input.projected).some((row) => (row.participantCount ?? 0) > 0);
+    someSidebarSessionInTree(input.projected, (row) => (row.participantCount ?? 0) > 0);
   const ownershipVisible = ownerOptions.length >= 2 || hasParticipants;
   const activeOwnerId = ownershipVisible
     ? ownerOptions.some((owner) => owner.id === input.selectedOwnerId)

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -587,6 +587,24 @@ export function collectKnownSidebarSessionGroups(
   return [...catalog, ...new Set(discovered)];
 }
 
+/** Depth-first flatten of a projected session tree. Callers that reason about the
+ *  whole list (creator facets, selection fallback) need every descendant, not just
+ *  the roots; two hand-rolled walks drifted apart before this existed. */
+export function flattenSidebarSessionTree(
+  roots: readonly SidebarRecentSession[],
+): SidebarRecentSession[] {
+  const flattened: SidebarRecentSession[] = [];
+  const pending = [...roots];
+  while (pending.length > 0) {
+    const row = pending.shift();
+    if (row) {
+      flattened.push(row);
+      pending.push(...row.children);
+    }
+  }
+  return flattened;
+}
+
 export function findProjectedSidebarSession(input: {
   sessionKey: string;
   navigationState: SidebarSessionNavigationState;
@@ -645,23 +663,9 @@ export function applySidebarSessionOwnerFilter(input: {
   const ownerOptions = selfOwner
     ? [selfOwner, ...facetOwners.filter((owner) => owner.id !== selfOwner.id)]
     : facetOwners;
-  let hasParticipants = false;
-  if (ownerOptions.length < 2) {
-    const pending = [...input.projected];
-    let index = 0;
-    while (index < pending.length) {
-      const row = pending[index];
-      index += 1;
-      if (!row) {
-        continue;
-      }
-      if ((row.participantCount ?? 0) > 0) {
-        hasParticipants = true;
-        break;
-      }
-      pending.push(...row.children);
-    }
-  }
+  const hasParticipants =
+    ownerOptions.length < 2 &&
+    flattenSidebarSessionTree(input.projected).some((row) => (row.participantCount ?? 0) > 0);
   const ownershipVisible = ownerOptions.length >= 2 || hasParticipants;
   const activeOwnerId = ownershipVisible
     ? ownerOptions.some((owner) => owner.id === input.selectedOwnerId)

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -36,6 +36,7 @@ import {
   extendSidebarSessionSelection,
   findSidebarMainSessionRow,
   findProjectedSidebarSession,
+  flattenSidebarSessionTree,
   mergeAdoptedSessionPullRequestRows,
   partitionSidebarVisibleSections,
   promoteSidebarSessionCreatedOrder,
@@ -57,6 +58,7 @@ import {
   loadStoredSidebarSessionStatusFilter,
   loadStoredSidebarSessionsGrouping,
   loadStoredSidebarSessionsShowCron,
+  loadStoredSidebarSessionsShowPreview,
   loadStoredSidebarSessionsShowSystem,
   resolveSidebarSessionSortMode,
   storeSidebarSessionSortMode,
@@ -136,6 +138,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
   @state() fullyShownChildSessionKeys: ReadonlySet<string> = new Set();
   @state() sessionsGrouping: SidebarSessionsGrouping = loadStoredSidebarSessionsGrouping();
   @state() sessionsShowCron = loadStoredSidebarSessionsShowCron();
+  @state() sessionsShowPreview = loadStoredSidebarSessionsShowPreview();
   @state() sessionsShowSystem = loadStoredSidebarSessionsShowSystem();
   @state() sessionsStatusFilter: SidebarSessionStatusFilter =
     loadStoredSidebarSessionStatusFilter();
@@ -676,22 +679,11 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       knownSessionAttention: this.attention.knownSessionAttention(),
       toSidebarSession: navigationState.toSidebarSession,
     });
-    if (selectedFallback) {
-      const projectedRows = [...projected];
-      let selectedAlreadyProjected = false;
-      while (projectedRows.length > 0) {
-        const row = projectedRows.pop();
-        if (row?.key === selectedFallback.key) {
-          selectedAlreadyProjected = true;
-          break;
-        }
-        if (row) {
-          projectedRows.push(...row.children);
-        }
-      }
-      if (!selectedAlreadyProjected) {
-        projected.unshift(navigationState.toSidebarSession(selectedFallback));
-      }
+    if (
+      selectedFallback &&
+      !flattenSidebarSessionTree(projected).some((row) => row.key === selectedFallback.key)
+    ) {
+      projected.unshift(navigationState.toSidebarSession(selectedFallback));
     }
     const ownerFacet =
       selected === loadedAgentId

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -36,7 +36,7 @@ import {
   extendSidebarSessionSelection,
   findSidebarMainSessionRow,
   findProjectedSidebarSession,
-  flattenSidebarSessionTree,
+  someSidebarSessionInTree,
   mergeAdoptedSessionPullRequestRows,
   partitionSidebarVisibleSections,
   promoteSidebarSessionCreatedOrder,
@@ -681,7 +681,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     });
     if (
       selectedFallback &&
-      !flattenSidebarSessionTree(projected).some((row) => row.key === selectedFallback.key)
+      !someSidebarSessionInTree(projected, (row) => row.key === selectedFallback.key)
     ) {
       projected.unshift(navigationState.toSidebarSession(selectedFallback));
     }

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -47,6 +47,7 @@ const SIDEBAR_VISIBLE_CHILD_SESSION_LIMIT = 4;
 export interface SessionListHost {
   readonly sessionDataContext: Pick<ApplicationContext, "gateway"> | undefined;
   readonly sidebarLiveActivity: boolean;
+  readonly sessionsShowPreview: boolean;
   readonly sidebarNarrationLines: ReadonlyMap<string, string>;
   readonly sidebarObserverDigests: ReadonlyMap<string, SessionObserverDigest>;
   readonly selectedSessionKeys: ReadonlySet<string>;
@@ -164,6 +165,7 @@ export function renderRecentSession(params: {
     hasDisplay: display !== undefined,
     displaySubtitle: display?.subtitle,
     sidebarLiveActivity: host.sidebarLiveActivity,
+    showPreview: host.sessionsShowPreview,
     narrationLine: host.sidebarNarrationLines.get(session.key),
     observerDigest: host.sidebarObserverDigests.get(session.key) ?? null,
   });
@@ -234,6 +236,7 @@ export function renderRecentSession(params: {
     "sidebar-recent-session",
     "session-row-host",
     session.isChild ? "sidebar-recent-session--child" : "",
+    !subtitle ? "sidebar-recent-session--single-line" : "",
     session.archived ? "sidebar-session--archived" : "",
     session.visuallyActive ? "sidebar-recent-session--active" : "",
     host.selectedSessionKeys.has(session.key) ? "sidebar-recent-session--selected" : "",

--- a/ui/src/components/app-sidebar-session-types.test.ts
+++ b/ui/src/components/app-sidebar-session-types.test.ts
@@ -6,9 +6,11 @@ import {
   loadStoredHiddenSessionCatalogIds,
   loadStoredSidebarSessionSortMode,
   loadStoredSidebarSessionStatusFilter,
+  loadStoredSidebarSessionsShowPreview,
   setStoredSessionCatalogHidden,
   storeSidebarSessionSortMode,
   storeSidebarSessionStatusFilter,
+  storeSidebarSessionsShowPreview,
 } from "./app-sidebar-session-types.ts";
 
 // getSafeLocalStorage only accepts an own value property under Vitest, so the
@@ -83,6 +85,18 @@ describe("sidebar session sort preference", () => {
 describe("collapsed sidebar sections preference", () => {
   it("defaults Coding to compact while Online remains expanded", () => {
     expect([...loadStoredCollapsedSessionSections()]).toEqual(["work"]);
+  });
+});
+
+describe("sidebar session preview preference", () => {
+  it("defaults to showing previews and round-trips the stored choice", () => {
+    expect(loadStoredSidebarSessionsShowPreview()).toBe(true);
+
+    storeSidebarSessionsShowPreview(false);
+    expect(loadStoredSidebarSessionsShowPreview()).toBe(false);
+
+    storeSidebarSessionsShowPreview(true);
+    expect(loadStoredSidebarSessionsShowPreview()).toBe(true);
   });
 });
 

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -228,6 +228,7 @@ export function sidebarSessionStateId(key: string): string {
 
 const SIDEBAR_SESSION_GROUPING_STORAGE_KEY = "openclaw:sidebar:sessions:grouping";
 const SIDEBAR_SESSION_CATALOG_GROUPING_STORAGE_KEY = "openclaw:sidebar:sessions:catalog-grouping";
+const SIDEBAR_SESSION_SHOW_PREVIEW_STORAGE_KEY = "openclaw:sidebar:sessions:show-preview";
 const SIDEBAR_SESSION_SHOW_CRON_STORAGE_KEY = "openclaw:sidebar:sessions:show-cron";
 const SIDEBAR_SESSION_SHOW_SYSTEM_STORAGE_KEY = "openclaw:sidebar:sessions:show-system";
 const SIDEBAR_SESSION_STATUS_FILTER_STORAGE_KEY = "openclaw:sidebar:sessions:status-filter";
@@ -269,6 +270,10 @@ export function loadStoredSidebarCatalogGrouping(): CatalogProjectGrouping {
 
 export function loadStoredSidebarSessionsShowCron(): boolean {
   return getSafeLocalStorage()?.getItem(SIDEBAR_SESSION_SHOW_CRON_STORAGE_KEY) === "true";
+}
+
+export function loadStoredSidebarSessionsShowPreview(): boolean {
+  return getSafeLocalStorage()?.getItem(SIDEBAR_SESSION_SHOW_PREVIEW_STORAGE_KEY) !== "false";
 }
 
 export function loadStoredSidebarSessionsShowSystem(): boolean {
@@ -331,6 +336,10 @@ export function storeSidebarCatalogGrouping(value: CatalogProjectGrouping) {
 
 export function storeSidebarSessionsShowCron(show: boolean) {
   getSafeLocalStorage()?.setItem(SIDEBAR_SESSION_SHOW_CRON_STORAGE_KEY, String(show));
+}
+
+export function storeSidebarSessionsShowPreview(show: boolean) {
+  getSafeLocalStorage()?.setItem(SIDEBAR_SESSION_SHOW_PREVIEW_STORAGE_KEY, String(show));
 }
 
 export function storeSidebarSessionsShowSystem(show: boolean) {

--- a/ui/src/components/session-organizer-controller-types.ts
+++ b/ui/src/components/session-organizer-controller-types.ts
@@ -23,6 +23,7 @@ export interface SessionOrganizerControllerHost extends ReactiveControllerHost {
   readonly onUpdateSidebarEntries?: (entries: string[]) => void;
   sessionsGrouping: SidebarSessionsGrouping;
   sessionsShowCron: boolean;
+  sessionsShowPreview: boolean;
   sessionsShowSystem: boolean;
   sessionsStatusFilter: SidebarSessionStatusFilter;
   clearSessionSelection(): void;

--- a/ui/src/components/session-organizer-controller.ts
+++ b/ui/src/components/session-organizer-controller.ts
@@ -24,6 +24,7 @@ import {
   storeCollapsedSessionSections,
   storeSidebarSessionsGrouping,
   storeSidebarSessionsShowCron,
+  storeSidebarSessionsShowPreview,
   storeSidebarSessionsShowSystem,
   type SidebarRecentSession,
   type SidebarSectionDropTarget,
@@ -736,6 +737,15 @@ export class SessionOrganizerController {
     this.host.sessionsShowCron = show;
     try {
       storeSidebarSessionsShowCron(show);
+    } catch {
+      // Keep the in-memory preference when storage is unavailable.
+    }
+  }
+
+  setSessionsShowPreview(show: boolean) {
+    this.host.sessionsShowPreview = show;
+    try {
+      storeSidebarSessionsShowPreview(show);
     } catch {
       // Keep the in-memory preference when storage is unavailable.
     }

--- a/ui/src/components/session-row-subtitle.test.ts
+++ b/ui/src/components/session-row-subtitle.test.ts
@@ -47,6 +47,21 @@ describe("resolveSidebarSessionSubtitle", () => {
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
+        showPreview: true,
+        narrationLine: undefined,
+      }),
+    ).toEqual({ subtitle: "Waiting for a concurrency slot", narration: undefined });
+  });
+
+  it("keeps the concurrency-slot explanation when previews are hidden", () => {
+    // Without it a queued run reads as an idle session: a visible non-outcome.
+    expect(
+      resolveSidebarSessionSubtitle({
+        session: { ...workSession(), hasActiveRun: true, status: "queued" },
+        hasDisplay: false,
+        displaySubtitle: undefined,
+        sidebarLiveActivity: true,
+        showPreview: false,
         narrationLine: undefined,
       }),
     ).toEqual({ subtitle: "Waiting for a concurrency slot", narration: undefined });

--- a/ui/src/components/session-row-subtitle.test.ts
+++ b/ui/src/components/session-row-subtitle.test.ts
@@ -21,6 +21,7 @@ describe("resolveSidebarSessionSubtitle", () => {
         hasDisplay: true,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
+        showPreview: true,
         narrationLine: undefined,
       }),
     ).toEqual({ subtitle: undefined, narration: undefined });
@@ -33,6 +34,7 @@ describe("resolveSidebarSessionSubtitle", () => {
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
+        showPreview: true,
         narrationLine: "Still running",
       }),
     ).toEqual({ subtitle: "~/Projects/openclaw", narration: undefined });
@@ -72,6 +74,7 @@ describe("resolveSidebarSessionSubtitle", () => {
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
+        showPreview: true,
         narrationLine: "Using test runner",
         observerDigest,
       });
@@ -92,6 +95,7 @@ describe("resolveSidebarSessionSubtitle", () => {
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
+        showPreview: true,
         narrationLine: "Using test runner",
         observerDigest: null,
       }),
@@ -111,6 +115,7 @@ describe("resolveSidebarSessionSubtitle", () => {
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
+        showPreview: true,
         narrationLine: "Using test runner",
         observerDigest: {
           runId,
@@ -150,6 +155,7 @@ describe("resolveSidebarSessionSubtitle", () => {
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
+        showPreview: true,
         narrationLine: undefined,
         observerDigest: null,
       }).subtitle,
@@ -173,6 +179,7 @@ describe("resolveSidebarSessionSubtitle", () => {
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
+        showPreview: true,
         narrationLine: undefined,
         observerDigest: null,
       }).subtitle,
@@ -197,6 +204,7 @@ describe("resolveSidebarSessionSubtitle", () => {
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
+        showPreview: true,
         narrationLine: undefined,
         observerDigest: null,
       }).subtitle;
@@ -221,6 +229,7 @@ describe("resolveSidebarSessionSubtitle", () => {
         hasDisplay: false,
         displaySubtitle: undefined,
         sidebarLiveActivity: true,
+        showPreview: true,
         narrationLine: "Running the focused tests",
         observerDigest: {
           runId: "run-1",
@@ -231,6 +240,44 @@ describe("resolveSidebarSessionSubtitle", () => {
         },
       }).subtitle,
     ).toBe("Implementing the repair");
+  });
+
+  it("keeps attention visible while hiding every preview candidate", () => {
+    const hidden = (session: SidebarRecentSession, narrationLine?: string) =>
+      resolveSidebarSessionSubtitle({
+        session,
+        hasDisplay: false,
+        displaySubtitle: undefined,
+        sidebarLiveActivity: true,
+        showPreview: false,
+        narrationLine,
+        observerDigest: session.observerDigest ?? null,
+      }).subtitle;
+
+    expect(
+      hidden({
+        ...workSession(),
+        attention: { kind: "error", reason: "Deployment failed" },
+        agentStatusNote: "Waiting for deployment",
+        lastMessagePreview: "The final reply is durable.",
+      }),
+    ).toBe("Run failed: Deployment failed");
+
+    expect([
+      hidden({ ...workSession(), agentStatusNote: "Waiting for deployment" }),
+      hidden({ ...workSession(), hasActiveRun: true }, "Using test runner"),
+      hidden({
+        ...workSession(),
+        observerDigest: {
+          headline: "Running checks",
+          health: "done",
+          updatedAt: 2_000,
+          revision: 1,
+        },
+      }),
+      hidden({ ...workSession(), lastMessagePreview: "The final reply is durable." }),
+      hidden(workSession()),
+    ]).toEqual([undefined, undefined, undefined, undefined, undefined]);
   });
 });
 

--- a/ui/src/components/session-row-subtitle.test.ts
+++ b/ui/src/components/session-row-subtitle.test.ts
@@ -53,6 +53,61 @@ describe("resolveSidebarSessionSubtitle", () => {
     ).toEqual({ subtitle: "Waiting for a concurrency slot", narration: undefined });
   });
 
+  it.each(["stuck", "waiting-on-user"] as const)(
+    "keeps a %s observer headline when previews are hidden",
+    (health) => {
+      // isCriticalObserverHealth owns these two states; the chat pane announces them
+      // too, so a display preference must not silence them in the sidebar.
+      expect(
+        resolveSidebarSessionSubtitle({
+          session: {
+            ...workSession(),
+            hasActiveRun: true,
+            activeRunIds: ["run-1"],
+            status: "running",
+          },
+          hasDisplay: false,
+          displaySubtitle: undefined,
+          sidebarLiveActivity: true,
+          showPreview: false,
+          narrationLine: "Using bash",
+          observerDigest: {
+            runId: "run-1",
+            headline: "Blocked on a missing credential",
+            health,
+            updatedAt: 2_000,
+            revision: 1,
+          },
+        }),
+      ).toEqual({ subtitle: "Blocked on a missing credential", narration: undefined });
+    },
+  );
+
+  it("still hides a non-critical observer headline when previews are hidden", () => {
+    expect(
+      resolveSidebarSessionSubtitle({
+        session: {
+          ...workSession(),
+          hasActiveRun: true,
+          activeRunIds: ["run-1"],
+          status: "running",
+        },
+        hasDisplay: false,
+        displaySubtitle: undefined,
+        sidebarLiveActivity: true,
+        showPreview: false,
+        narrationLine: undefined,
+        observerDigest: {
+          runId: "run-1",
+          headline: "Running checks",
+          health: "on-track",
+          updatedAt: 2_000,
+          revision: 1,
+        },
+      }),
+    ).toEqual({ subtitle: undefined, narration: undefined });
+  });
+
   it("keeps the concurrency-slot explanation when previews are hidden", () => {
     // Without it a queued run reads as an idle session: a visible non-outcome.
     expect(

--- a/ui/src/components/session-row-subtitle.ts
+++ b/ui/src/components/session-row-subtitle.ts
@@ -2,7 +2,7 @@ import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import type { SessionObserverDigest } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import { t } from "../i18n/index.ts";
-import { pickFreshestObserverDigest } from "../lib/observer-digest.ts";
+import { isCriticalObserverHealth, pickFreshestObserverDigest } from "../lib/observer-digest.ts";
 import type { SidebarRecentSession } from "./app-sidebar-session-types.ts";
 import { sessionAttentionSubtitle } from "./session-attention-presentation.ts";
 
@@ -29,16 +29,6 @@ export function resolveSidebarSessionSubtitle(params: {
   const running = session.hasActiveRun;
   const queued =
     running && session.status === "queued" ? t("sessionsView.waitingForConcurrency") : undefined;
-  // Preview off hides ambient text only. Attention and the queued explanation survive
-  // the toggle: an error, a pending approval, or the reason an admitted run is sitting
-  // still is state the operator must act on, and a display preference that can silence
-  // it turns a visible non-outcome into a silent one.
-  if (!params.showPreview) {
-    return { subtitle: attention ?? queued, narration: undefined };
-  }
-  // Agent-declared status (sessions tool) outranks live narration: it is an
-  // explicit message to the user, not ambient activity.
-  const agentStatus = session.agentStatusNote || undefined;
   const activeRunIds = session.activeRunIds ?? [];
   const digestMatchesActiveRun = (
     digest: typeof params.observerDigest,
@@ -59,6 +49,19 @@ export function resolveSidebarSessionSubtitle(params: {
     (session.lastReadAt ?? 0) < projectedDigest.updatedAt,
   );
   const observer = running || finalDigestUnread ? projectedDigest?.headline : undefined;
+  // Preview off hides ambient text only. Attention, the queued explanation, and a
+  // critical observer headline survive the toggle: an error, a pending approval, a run
+  // sitting on a slot, and the stuck / waiting-on-user health states are all things the
+  // operator must act on. isCriticalObserverHealth owns that classification and the chat
+  // pane announces the same two states, so a display preference must not silence them
+  // here — that would turn a visible non-outcome into a silent one.
+  if (!params.showPreview) {
+    const critical = isCriticalObserverHealth(projectedDigest?.health) ? observer : undefined;
+    return { subtitle: attention ?? queued ?? critical, narration: undefined };
+  }
+  // Agent-declared status (sessions tool) outranks live narration: it is an
+  // explicit message to the user, not ambient activity.
+  const agentStatus = session.agentStatusNote || undefined;
   const narration =
     attention || agentStatus || observer || !params.sidebarLiveActivity || !running
       ? undefined

--- a/ui/src/components/session-row-subtitle.ts
+++ b/ui/src/components/session-row-subtitle.ts
@@ -17,6 +17,7 @@ export function resolveSidebarSessionSubtitle(params: {
   hasDisplay: boolean;
   displaySubtitle: string | undefined;
   sidebarLiveActivity: boolean;
+  showPreview: boolean;
   narrationLine: string | undefined;
   observerDigest?: Pick<
     SessionObserverDigest,
@@ -25,6 +26,12 @@ export function resolveSidebarSessionSubtitle(params: {
 }): SidebarSessionSubtitle {
   const { session } = params;
   const attention = sessionAttentionSubtitle(session.attention);
+  // Preview off hides ambient text only. Attention survives the toggle because an
+  // error or pending approval is state the operator must act on, and a display
+  // preference that can silence it turns a visible failure into a silent one.
+  if (!params.showPreview) {
+    return { subtitle: attention, narration: undefined };
+  }
   // Agent-declared status (sessions tool) outranks live narration: it is an
   // explicit message to the user, not ambient activity.
   const agentStatus = session.agentStatusNote || undefined;

--- a/ui/src/components/session-row-subtitle.ts
+++ b/ui/src/components/session-row-subtitle.ts
@@ -26,17 +26,19 @@ export function resolveSidebarSessionSubtitle(params: {
 }): SidebarSessionSubtitle {
   const { session } = params;
   const attention = sessionAttentionSubtitle(session.attention);
-  // Preview off hides ambient text only. Attention survives the toggle because an
-  // error or pending approval is state the operator must act on, and a display
-  // preference that can silence it turns a visible failure into a silent one.
+  const running = session.hasActiveRun;
+  const queued =
+    running && session.status === "queued" ? t("sessionsView.waitingForConcurrency") : undefined;
+  // Preview off hides ambient text only. Attention and the queued explanation survive
+  // the toggle: an error, a pending approval, or the reason an admitted run is sitting
+  // still is state the operator must act on, and a display preference that can silence
+  // it turns a visible non-outcome into a silent one.
   if (!params.showPreview) {
-    return { subtitle: attention, narration: undefined };
+    return { subtitle: attention ?? queued, narration: undefined };
   }
   // Agent-declared status (sessions tool) outranks live narration: it is an
   // explicit message to the user, not ambient activity.
   const agentStatus = session.agentStatusNote || undefined;
-  const running = session.hasActiveRun;
-  const queued = session.status === "queued" ? t("sessionsView.waitingForConcurrency") : undefined;
   const activeRunIds = session.activeRunIds ?? [];
   const digestMatchesActiveRun = (
     digest: typeof params.observerDigest,

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -383,6 +383,7 @@ export function renderSidebarSessionSortMenuForController(controller: SidebarMen
     peopleSortAvailable: host.sessionPeopleSortAvailable(),
     statusFilter: host.sessionsStatusFilter,
     showCron: host.sessionsShowCron,
+    showPreview: host.sessionsShowPreview,
     showSystem: host.sessionsShowSystem,
     owners: host.sessionOwnershipVisible ? host.sessionOwnerOptions : [],
     ownerFilterId: host.sessionOwnerFilterActive ? host.sessionOwnerFilterId : null,
@@ -410,6 +411,10 @@ export function renderSidebarSessionSortMenuForController(controller: SidebarMen
     },
     onShowCronChange: (show) => {
       host.sessionOrganizer.setSessionsShowCron(show);
+      controller.closeSessionSortMenu({ restoreFocus: true });
+    },
+    onShowPreviewChange: (show) => {
+      host.sessionOrganizer.setSessionsShowPreview(show);
       controller.closeSessionSortMenu({ restoreFocus: true });
     },
     onShowSystemChange: (show) => {

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -316,7 +316,7 @@ suite.define(() => {
     }
   });
 
-  it("keeps session titles on the first line and status on a fixed second line", async () => {
+  it("keeps session titles on the first line and collapses rows that have no second line", async () => {
     if (captureUiProofEnabled) {
       await mkdir(sessionSecondRowProofDir, { recursive: true });
     }
@@ -412,9 +412,16 @@ suite.define(() => {
           subtitle: rect(".sidebar-recent-session__subtitle"),
         };
       });
-      const plainHeight = await plainRow.evaluate((row) => row.getBoundingClientRect().height);
+      const plain = await plainRow.evaluate((row) => ({
+        height: row.getBoundingClientRect().height,
+        singleLine: row.classList.contains("sidebar-recent-session--single-line"),
+      }));
 
-      expect(layout.busyHeight).toBeCloseTo(plainHeight, 1);
+      // A row with no secondary metadata no longer reserves the second line: it
+      // collapses so its endcap rides beside the title instead of hanging alone
+      // beneath it. Only rows that actually have a subtitle keep the two-line shape.
+      expect(plain.singleLine).toBe(true);
+      expect(plain.height).toBeLessThan(layout.busyHeight);
       expect(layout.badges.top).toBeGreaterThanOrEqual(layout.name.bottom - 1);
       expect(layout.name.right).toBeGreaterThan(layout.badges.left);
       expect((layout.badges.top + layout.badges.bottom) / 2).toBeCloseTo(

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -104,7 +104,10 @@ suite.define(() => {
       await secondRow.getByText("Using bash").waitFor();
       const heightAfter = await secondRow.evaluate((row) => row.getBoundingClientRect().height);
 
-      expect(heightAfter).toBe(heightBefore);
+      // Sub-pixel tolerance: getBoundingClientRect returns 1/65536 fractions that
+      // drift under CPU contention, so exact equality fails ~1 run in 3 in a loaded
+      // shard. The contract is "the row does not change size", not bit-identical floats.
+      expect(heightAfter).toBeCloseTo(heightBefore, 1);
       if (captureUiProofEnabled) {
         await page.waitForTimeout(800);
         await secondRow.screenshot({

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -493,18 +493,33 @@ suite.define(() => {
             nameFontSize: nameStyle?.fontSize ?? "",
             paddingBottom: linkStyle?.paddingBottom ?? "",
             paddingTop: linkStyle?.paddingTop ?? "",
+            singleLine: row.classList.contains("sidebar-recent-session--single-line"),
           };
         }),
       );
       expect(threadRowMetrics).toHaveLength(4);
-      expect(new Set(threadRowMetrics.map((metric) => metric.height)).size).toBe(1);
-      expect(threadRowMetrics[0]?.height).toBeGreaterThan(30);
+      // Gateway threads and native catalog children must stay density-identical, but a
+      // row with no preview text collapses to one line. Assert uniformity per shape, so
+      // the two sources drifting apart still fails while the collapse stays legal.
+      const singleLineHeights = new Set(
+        threadRowMetrics.filter((metric) => metric.singleLine).map((metric) => metric.height),
+      );
+      const twoLineHeights = new Set(
+        threadRowMetrics.filter((metric) => !metric.singleLine).map((metric) => metric.height),
+      );
+      expect(singleLineHeights.size).toBe(1);
+      expect(twoLineHeights.size).toBe(1);
+      const [collapsedHeight] = [...singleLineHeights];
+      const [expandedHeight] = [...twoLineHeights];
+      // Collapsed rows sit on the 30px min-height floor; renderer sub-pixels vary.
+      expect(collapsedHeight).toBeCloseTo(30, 1);
+      expect(expandedHeight).toBeGreaterThan(collapsedHeight!);
       for (const metric of threadRowMetrics) {
         expect(metric).toMatchObject({
           minHeight: "30px",
           nameFontSize: "13px",
-          paddingBottom: "3px",
-          paddingTop: "3px",
+          paddingBottom: "4px",
+          paddingTop: "4px",
         });
       }
       const projectLabelTone = await openclawProject

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -97,8 +97,11 @@ suite.define(() => {
       const actionOnlyLink = actionOnlyRow.locator(".sidebar-recent-session__link");
       const actionOnlyPin = actionOnlyRow.getByRole("button", { name: "Pin session" });
       await expect
+        .poll(() => actionOnlyRow.getAttribute("class"))
+        .toContain("sidebar-recent-session--single-line");
+      await expect
         .poll(() => actionOnlyLink.evaluate((element) => getComputedStyle(element).paddingRight))
-        .toBe("4px");
+        .toBe("2px");
       const restingTextBounds = await actionOnlyText.boundingBox();
 
       await actionOnlyRow.hover();
@@ -142,7 +145,10 @@ suite.define(() => {
       if (!nameBounds || !pinBounds || !menuBounds) {
         throw new Error("Expected visible hovered action geometry");
       }
-      expect(nameBounds.y + nameBounds.height / 2).toBeLessThan(pinBounds.y + pinBounds.height / 2);
+      expect(nameBounds.y + nameBounds.height / 2).toBeCloseTo(
+        pinBounds.y + pinBounds.height / 2,
+        1,
+      );
       expect(pinBounds.x + pinBounds.width).toBeLessThanOrEqual(menuBounds.x);
 
       await page.mouse.move(0, 0);
@@ -159,8 +165,9 @@ suite.define(() => {
       if (!focusedNameBounds || !focusedPinBounds || !focusedMenuBounds) {
         throw new Error("Expected visible focused action geometry");
       }
-      expect(focusedNameBounds.y + focusedNameBounds.height / 2).toBeLessThan(
+      expect(focusedNameBounds.y + focusedNameBounds.height / 2).toBeCloseTo(
         focusedPinBounds.y + focusedPinBounds.height / 2,
+        1,
       );
       expect(focusedPinBounds.x + focusedPinBounds.width).toBeLessThanOrEqual(focusedMenuBounds.x);
     } finally {
@@ -378,7 +385,7 @@ suite.define(() => {
       const menu = row.getByRole("button", { name: "Open session menu" });
       await expect
         .poll(() => link.evaluate((element) => getComputedStyle(element).paddingRight))
-        .toBe("4px");
+        .toBe("2px");
 
       const [restingTextBounds, restingStateBounds, restingPinBounds, restingMenuBounds] =
         await Promise.all([

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1151,6 +1151,7 @@ export const en: TranslationMap = {
     groupBy: "Group by",
     groupByNone: "None",
     groupByCategory: "Custom groups",
+    showSessionPreview: "Show message preview",
     showCronSessions: "Show automation sessions",
     showSystemSessions: "Show system sessions",
     groupByChannel: "Channel",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1496,6 +1496,9 @@ body.update-dialog-open .sidebar-update-card__status {
   display: flex;
   flex-direction: column;
   gap: var(--sidebar-group-gap);
+  /* Left-only on purpose (#124879): the right 8px of .sidebar-sessions padding is
+     clearance so a classic (non-overlay) scrollbar cannot clip the selection pill.
+     Reclaim space inside the row instead of widening it, or that fix regresses. */
   margin-inline: -8px 0;
   /* Sessions are stateful app chrome, not navigation links. */
   cursor: var(--cursor-action);
@@ -1534,7 +1537,7 @@ body.update-dialog-open .sidebar-update-card__status {
 .sidebar-recent-sessions__group {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
   min-height: 28px;
   border-radius: var(--radius-md);
   transition:
@@ -2053,7 +2056,7 @@ body.update-dialog-open .sidebar-update-card__status {
   align-items: center;
   min-width: 0;
   min-height: 30px;
-  padding-right: 4px;
+  padding-right: 2px;
   border-radius: var(--radius-md);
   color: var(--muted);
   cursor: var(--cursor-action);
@@ -2090,7 +2093,7 @@ body.update-dialog-open .sidebar-update-card__status {
   gap: var(--sidebar-row-gap);
   flex: 1 1 auto;
   min-width: 0;
-  padding: 3px 4px 3px var(--sidebar-inset);
+  padding: 4px 2px 4px var(--sidebar-inset);
   color: inherit;
   cursor: var(--cursor-action);
   text-decoration: none;
@@ -2297,8 +2300,8 @@ body.update-dialog-open .sidebar-update-card__status {
 }
 
 .sidebar-recent-session--child .sidebar-recent-session__link {
-  padding-top: 3px;
-  padding-bottom: 3px;
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 
 .sidebar-recent-sessions
@@ -3209,7 +3212,10 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   color: var(--accent);
 }
 
-/* Pinned sessions share the page-nav visual contract while retaining session actions. */
+/* Pinned sessions share the page-nav chrome (hover/active fill, muted glyphs and
+   meta) while retaining session actions. The title deliberately opts out and
+   keeps the list's --text: a session name is content in both zones, and pinning
+   a row must not make it read as dimmer than the same row further down. */
 .sidebar-zone-entry .sidebar-recent-session {
   position: relative;
   min-height: 32px;
@@ -3227,13 +3233,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 .sidebar-zone-entry .sidebar-recent-session__link {
   gap: 8px;
   min-height: 30px;
-  padding: 0;
-}
-
-.sidebar-zone-entry .sidebar-recent-session__name {
-  color: inherit;
-  font-size: calc(13px * var(--control-ui-text-scale));
-  font-weight: 500;
+  padding: 3px 0;
 }
 
 .sidebar-zone-entry .sidebar-recent-session:hover {
@@ -4235,6 +4235,24 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   min-width: 0;
 }
 
+/* No-preview rows collapse to one line so the endcap rides beside the title. */
+.sidebar-recent-session--single-line .sidebar-recent-session__text {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--sidebar-row-gap);
+}
+
+.sidebar-recent-session--single-line .sidebar-recent-session__name {
+  width: auto;
+  flex: 1 1 auto;
+}
+
+.sidebar-recent-session--single-line > .sidebar-recent-session__aside {
+  top: 0;
+  display: flex;
+  align-items: center;
+}
+
 .sidebar-recent-session__subtitle {
   flex: 1 1 0;
   min-width: 0;
@@ -4243,7 +4261,7 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   white-space: nowrap;
   font-size: var(--control-ui-text-xs);
   line-height: 18px;
-  color: color-mix(in srgb, var(--muted) 55%, var(--text) 45%);
+  color: var(--muted);
 }
 
 .sidebar-recent-session__details-endcap {

--- a/ui/src/test-helpers/app-sidebar-cases/attention.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/attention.ts
@@ -184,6 +184,37 @@ describe("AppSidebar session attention", () => {
     expect(sidebar.querySelector('[data-session-attention="agent"]')).toBeNull();
   });
 
+  it("collapses hidden previews to one line without hiding attention", async () => {
+    const sessionsHarness = createSessionsHarness("main", [sessionKey]);
+    setRows(sessionsHarness, [
+      {
+        key: sessionKey,
+        kind: "direct",
+        label: "Deploy",
+        updatedAt: 2,
+        agentStatus: { note: "Deploying to staging", expiresAt: Date.now() + 60_000 },
+      },
+    ]);
+    const { sidebar } = await mountSidebar(
+      createGateway({} as GatewayBrowserClient),
+      sessionsHarness.sessions,
+    );
+
+    sidebar.sessionOrganizer.setSessionsShowPreview(false);
+    await sidebar.updateComplete;
+
+    const previewRow = sidebar.querySelector(`[data-session-key="${sessionKey}"]`);
+    expect(previewRow?.textContent).not.toContain("Deploying to staging");
+    expect(previewRow?.classList.contains("sidebar-recent-session--single-line")).toBe(true);
+
+    setRows(sessionsHarness, [failedRow()]);
+    await sidebar.updateComplete;
+
+    const attentionRow = sidebar.querySelector(`[data-session-key="${sessionKey}"]`);
+    expect(attentionRow?.textContent).toContain("Run failed: Provider credits exhausted");
+    expect(attentionRow?.classList.contains("sidebar-recent-session--single-line")).toBe(false);
+  });
+
   it("does not render an expired agent declaration", async () => {
     const sessionsHarness = createSessionsHarness("main", [sessionKey]);
     setRows(sessionsHarness, [


### PR DESCRIPTION
## What Problem This Solves

Three related defects made the Control UI sidebar session list read badly.

**Pinned sessions looked dimmer than the same session unpinned.** Pinned rows sit in the nav zone, which paints its whole row `--muted` to share the page-nav chrome. `.sidebar-zone-entry .sidebar-recent-session__name { color: inherit }` pulled the session *title* down to `--muted` (#8b8b94) while the subtitle underneath kept `color-mix(--muted 55%, --text 45%)` (#a1a1a7) — so a pinned row's preview line was literally brighter than the session name it belonged to, and the same session read dimmer pinned than unpinned.

**Rows with no preview text looked broken.** Every row reserved a fixed 18px second line. A row with no subtitle either showed a dead band under the title, or worse, showed only its endcap — a lone spinner, unread dot, or badge hanging below-right of the title with nothing beside it.

**The right-hand gutter wasted space.** The session-row endcap sat 26px from the sidebar edge while nav-item content sat at 18px, so activity indicators floated well short of the edge.

## Why This Change Was Made

A session title is *content* in every zone; only glyphs, meta, and hover/active fill follow the zone's chrome contract. Deleting the zone title override (whose size and weight already duplicated the base rule) restores that, and the subtitle moves to plain `var(--muted)` — dimmer, and a token `theme-contrast.test.ts` already proves ≥4.5:1 against every surface in every theme, so it is better guarded than the ad-hoc mix it replaces.

Rows with no subtitle now collapse to one line via a `--single-line` row class plus a CSS variant that turns the text column into a row flex, so the endcap rides beside the title. No markup branch and no new element. This supersedes the previous "busy and plain rows are the same height" contract, so the e2e test that asserted it was rewritten to assert the new two-branch contract rather than deleted.

Preview text is now toggleable from the session sort menu ("Show message preview", default on, localStorage-backed, mirroring the existing `sessionsShowCron` plumbing). With it off, every non-attention row falls into the single-line variant. **Operator-actionable state is deliberately exempt from the toggle.** Silencing it behind a display preference is the silent-failure class this repo ranks worst, so three things always show and keep their two-line row: attention (error / approval / question), the queued "waiting for a concurrency slot" explanation, and a critical observer headline. That last one is `isCriticalObserverHealth` in `ui/src/lib/observer-digest.ts` — `stuck` and `waiting-on-user`, the same pair `critical-observer-notice.ts` announces in the chat pane. A toast is transient; the sidebar row is the durable signal. Everything else — narration, non-critical observer headlines, last-message preview, work subtitle, agent status note — is preview text and hides.

For the gutter: `.sidebar-recent-sessions { margin-inline: -8px 0 }` is asymmetric **on purpose** (#124879) — the right 8px of `.sidebar-sessions` padding is clearance so a classic non-overlay scrollbar cannot clip the selection pill. Making it symmetric reverts that fix, and `sidebar-selection-overflow.e2e.test.ts` catches it. Space is reclaimed *inside* the row instead (row + link `padding-right` 4px → 2px, endcap 26px → 22px from the edge), and a comment now records the asymmetry at the CSS site so the next person does not repeat the mistake. Rows also gained a little vertical air (link padding 3px → 4px, group gap 2px → 4px).

Two things surfaced while rebasing over 317 commits of `main`. `main` had added a "Waiting for a concurrency slot" subtitle for admitted-but-queued sessions; that is not preview text, it is the only thing separating a run waiting on a slot from an idle session, so it joins attention as exempt from the toggle. `main` had also rewritten the owner filter's descendant walk to short-circuit on the first participating row — both remaining call sites ask "does any row match", so the shared helper is `someSidebarSessionInTree`, a short-circuiting search, rather than a flatten that would have discarded that early exit.

Opportunistic cleanup: adding the preference pushed `app-sidebar-session-navigation.ts` to 701 lines against a hard 700-line limit where suppressions are banned. That file and its logic sibling each carried a hand-rolled walk over the same session tree — one flattening for creator facets, one searching for a key. Extracting one `someSidebarSessionInTree` helper dedupes both, shrinks the 123-line method the second was buried in, and puts the file back under the limit (−11 production lines there).

Non-goals: no gateway, protocol, config-file, or storage surface changes; the scrollbar gutter on `.sidebar-shell__body` is untouched. Reclaiming the remaining 8px properly means replacing that hand-rolled gutter with `scrollbar-gutter: stable`, which is a separate change with its own proof.

## User Impact

Session titles read at one consistent brightness whether a session is pinned or in the list, and preview text sits a clear step below the title instead of competing with it. Rows without a preview no longer show an orphaned indicator under a dead 18px band — they collapse to a compact single line with the indicator beside the title. Activity indicators sit closer to the sidebar edge, and rows have slightly more breathing room. Operators who prefer a dense list can now turn preview text off entirely from the session sort menu; errors and pending approvals stay visible regardless.

## Evidence

Captured from the mocked Control UI dev server (`pnpm dev:ui:mock`) at 2x, dark theme, on the rebased branch. Left is current `main`; middle is this change; right is the same with "Show message preview" turned off. Note the orphaned spinner and dots under "Sidebar narration demo", "Lisbon trip planning", and "Family" in BEFORE.

![sidebar before/after](https://github.com/user-attachments/assets/d8c60764-3294-4ef4-9c37-9653317c2502)

Measured geometry, 257px sidebar (before → after): pinned title `rgb(139,139,148)` → `rgb(188,188,192)` (matches list titles); subtitle `#a1a1a7` → `#8b8b94`; endcap right gap 26px → 22px; rows without a subtitle 44px → 30px.

Proof run:

- `node scripts/check-changed.mjs` — exit 0 (format, both typecheck lanes, oxlint core + UI styles, i18n catalog, max-lines ratchet, dead-export scan)
- `node scripts/run-vitest.mjs ui/src/components/session-row-subtitle.test.ts ui/src/components/app-sidebar-session-types.test.ts ui/src/components/app-sidebar.test.ts ui/src/styles/theme-contrast.test.ts` — 290 passed
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar-session-navigation-logic.test.ts ui/src/components/app-sidebar.test.ts ui/src/components/session-row-subtitle.test.ts ui/src/components/app-sidebar-session-types.test.ts` — 323 passed (rebased tree)
- `node scripts/run-vitest.mjs ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts ui/src/e2e/sidebar-selection-overflow.e2e.test.ts ui/src/e2e/session-management.trailing-state.e2e.test.ts ui/src/e2e/sidebar-interactions.e2e.test.ts ui/src/e2e/session-management.sidebar.e2e.test.ts` — 28 passed

New coverage: preference default-on plus persistence round-trip; an invariant assertion that every preview candidate is dropped when the toggle is off while attention text survives; and a boundary test through the mounted sidebar proving an attention row keeps its subtitle and stays two-line while a preview row collapses.

New coverage also asserts the queued explanation and both critical observer health values survive preview-off, with a non-critical (`on-track`) control so the exemption cannot pass by suppressing nothing.

LOC delta (branch vs merge base): production +124/−52 (net +72, the new preference surface), tests +207/−12 across 18 files.

**Also folded in while landing.** `main` was red at `7f60af7f8`: `extensions/codex/src/app-server/run-attempt-tools.test.ts` arrived in #126189 with no shard claim, because the support shard globs `app-server/**/*.test.ts` but excludes the whole `run-attempt*` pattern while the attempt shards enumerate by filename. It was owned by nobody and never executing. Registered in the `attempt-extra` shard next to its siblings; the ownership audit passes 18/18 and the previously-orphaned test runs green. Unrelated to the sidebar work, fixed here rather than landing onto a red gate. That shard layout will keep swallowing new `run-attempt-*` files — worth a follow-up so one shard claims the residue of that glob.

Two test contracts this change deliberately supersedes, rewritten rather than deleted: `chat-flow.sidebar-presentation` asserted busy and plain rows share a height, and `codex-sessions` asserted all four gateway/catalog rows share one height plus hardcoded 3px padding. Both now assert per-shape uniformity, so genuine drift between the two session sources still fails. One exact-equality height check also gained a tolerance after measuring 2 failures in 6 runs under a loaded shard (6/6 with the tolerance) — `getBoundingClientRect` returns 1/65536 fractions that move under CPU contention.

The added `openclaw:sidebar:sessions:show-preview` key reads `!== "false"`, so an existing browser with no key resolves to previews on — current behavior, no migration. It reads inverted relative to its `show-cron` / `show-system` siblings because those default off and this defaults on.
