### PR TITLE
fix(scripts): detect existing dist-runtime byte growth

### DIFF
--- a/scripts/check-gateway-watch-regression.mts
+++ b/scripts/check-gateway-watch-regression.mts
@@ -908,6 +908,9 @@ export function writeBuildAndRuntimePostBuildStamps(params: { cwd?: string } = {
   writeRuntimePostBuildStamp({ cwd });
 }
 
+export function calculateDistRuntimeByteGrowth(beforeBytes: number, afterBytes: number): number {
+  return afterBytes - beforeBytes;
+}
 /**
  * Collects pass/fail findings for the bounded gateway watch regression run.
  */
@@ -1076,10 +1079,10 @@ async function main() {
     entry.startsWith("dist-runtime/"),
   ).length;
   const distRuntimeFileGrowth = distRuntimeAddedPaths;
-  const distRuntimeByteGrowth =
-    distRuntimeAddedPaths === 0
-      ? 0
-      : post.distRuntime.apparentBytes - pre.distRuntime.apparentBytes;
+  const distRuntimeByteGrowth = calculateDistRuntimeByteGrowth(
+    pre.distRuntime.apparentBytes,
+    post.distRuntime.apparentBytes,
+  );
   const totalCpuMs = Math.round(
     (watchResult.timing.userSeconds + watchResult.timing.sysSeconds) * 1000,
   );

--- a/test/scripts/check-gateway-watch-regression.test.ts
+++ b/test/scripts/check-gateway-watch-regression.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   appendBoundedWatchLog,
   buildTimedWatchCommand,
+  calculateDistRuntimeByteGrowth,
   collectGatewayWatchFindings,
   hasGatewayReadyLog,
   parseArgs,
@@ -84,6 +85,35 @@ describe("check-gateway-watch-regression", () => {
       true,
     );
     expect(hasGatewayReadyLog("[gateway] starting HTTP server...")).toBe(false);
+  });
+
+  it("detects byte growth in existing dist-runtime paths", () => {
+    const distRuntimeByteGrowth = calculateDistRuntimeByteGrowth(100, 2_097_253);
+    const findings = collectGatewayWatchFindings({
+      cpuMs: 0,
+      distRuntimeByteGrowth,
+      distRuntimeFileGrowth: 0,
+      options: {
+        cpuFailMs: 8000,
+        cpuWarnMs: 1000,
+        distRuntimeByteGrowthMax: 2 * 1024 * 1024,
+        distRuntimeFileGrowthMax: 200,
+        windowMs: 10_000,
+      },
+      watchBuildReason: null,
+      watchResult: {
+        idleCpuMs: 0,
+        readyBeforeWindow: true,
+        spawnError: null,
+        timingFileMissing: false,
+      },
+      watchTriggeredBuild: false,
+    });
+
+    expect(distRuntimeByteGrowth).toBe(2_097_153);
+    expect(findings.failures).toContain(
+      "dist-runtime apparent byte growth 2097153 exceeded max 2097152",
+    );
   });
 
   it("bounds in-memory watch output capture while keeping the newest logs", () => {


### PR DESCRIPTION
## Summary

- detect apparent-byte growth in existing `dist-runtime` files even when no paths were added
- keep the path-count signal independent from byte-growth accounting
- add focused regression coverage for the exact threshold crossing

Related: https://github.com/openclaw/openclaw/pull/120468

This independently re-cleared replacement preserves and credits the useful source work from #120468 by @qingminglong. The source PR is closed and its head is not maintainer-editable; its object-coupled helper was also type-red, so this branch implements the same invariant with the typed numeric helper required by the current script boundary.

## Problem

The gateway watch regression checker forced `distRuntimeByteGrowth` to zero whenever `distRuntimeAddedPaths === 0`. Growth inside an already-existing runtime file could therefore exceed the 2 MiB limit while the check exited successfully and emitted no threshold finding.

## Fix

`calculateDistRuntimeByteGrowth(beforeBytes, afterBytes)` now performs unconditional before/after apparent-byte subtraction. Added-path counting remains unchanged and independent.

Production delta: `+7/-4` (net `+3`). Test delta: `+30/-0`.

## Evidence

```json
{
  "redBaseSha": "5564671c4fe0458252f786747c2d7b60c948c4eb",
  "rebasedMainSha": "076790233069ed3c09a314db0e996656ac582a9c",
  "headSha": "bc1549711cff2cc2836e5428781d308310aff3fa",
  "scenario": "append to an existing dist-runtime file after pre-snapshot and gateway readiness",
  "appendedBytes": 2097153,
  "before": {
    "exit": 0,
    "addedPaths": 0,
    "distRuntimeByteGrowth": 0,
    "thresholdFinding": false,
    "readyBeforeWindow": true
  },
  "after": {
    "exit": 1,
    "addedPaths": 0,
    "distRuntimeByteGrowth": 2097153,
    "thresholdFinding": "FAIL: dist-runtime apparent byte growth 2097153 exceeded max 2097152",
    "readyBeforeWindow": true
  }
}
```

- focused Vitest: 19/19 passed
- `pnpm check:test-types`: passed
- `pnpm tsgo:scripts`: passed
- changed classifier/Testbox: passed, lease `tbx_01m0c6n7xcp3kjyb9a1bm1tgzn`
- targeted `oxfmt`, `oxlint`, and `git diff --check`: passed
- fresh autoreview: clean, no actionable findings; correctness `0.99`
- Testbox run: https://github.com/openclaw/openclaw/actions/runs/32218235170

Punchcard-Session: golden-lantern-cedar-9j
