### PR TITLE
fix: local model inference no longer times out during plugin preparation

### DIFF
--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -4,11 +4,14 @@ import { withActivatedPluginIds } from "../../plugins/activation-context.js";
 import { resolveManifestActivationPlan } from "../../plugins/activation-planner.js";
 import {
   isTestDefaultMemorySlotDisabled,
-  normalizePluginsConfig,
   resolveEffectivePluginActivationState,
   resolveSelectedContextEnginePluginId,
 } from "../../plugins/config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "../../plugins/default-enablement.js";
+import {
+  addConfiguredSlotPluginIds,
+  normalizePluginsConfigForInstalledIndex,
+} from "../../plugins/gateway-startup-plugin-config.js";
 import { hashJson } from "../../plugins/installed-plugin-index-hash.js";
 import { createInstalledPluginIndexScopeLookup } from "../../plugins/installed-plugin-index-scope-lookup.js";
 import type { InstalledPluginIndex } from "../../plugins/installed-plugin-index.js";
@@ -114,10 +117,11 @@ function resolveAgentRuntimeMetadataPluginIds(params: {
   shorthandModelIds?: readonly string[];
   index: InstalledPluginIndex;
 }): string[] | undefined {
-  if (!normalizePluginsConfig(params.config?.plugins).enabled) {
+  const lookup = createInstalledPluginIndexScopeLookup(params.index);
+  const pluginsConfig = normalizePluginsConfigForInstalledIndex(params.config?.plugins, lookup);
+  if (!pluginsConfig.enabled) {
     return [];
   }
-  const lookup = createInstalledPluginIndexScopeLookup(params.index);
   const pluginIds = new Set<string>();
   lookup.addShorthandModelOwners(pluginIds, params.shorthandModelIds ?? []);
   const selections = resolveAgentRuntimePluginSelections(params.config, params.selections);
@@ -146,13 +150,11 @@ function resolveAgentRuntimeMetadataPluginIds(params: {
     return undefined;
   }
   lookup.addAgentHarnessOwners(pluginIds, runtimeIds);
-  // Metadata retains every memory candidate so the canonical runtime plan can
-  // select the active memory owner and any manifest-declared companion sidecar.
-  lookup.addMemoryPluginIds(pluginIds);
-  const contextEnginePluginId = resolveSelectedContextEnginePluginId(params.config);
-  if (contextEnginePluginId) {
-    pluginIds.add(contextEnginePluginId);
-  }
+  addConfiguredSlotPluginIds(pluginIds, {
+    activationSourceConfig: params.config ?? {},
+    activationSourcePlugins: pluginsConfig,
+    lookup,
+  });
   if (!lookup.hasInstalledPluginIds(pluginIds)) {
     return undefined;
   }

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -4,11 +4,18 @@ import { withActivatedPluginIds } from "../../plugins/activation-context.js";
 import { resolveManifestActivationPlan } from "../../plugins/activation-planner.js";
 import {
   isTestDefaultMemorySlotDisabled,
+  normalizePluginsConfig,
   resolveEffectivePluginActivationState,
   resolveSelectedContextEnginePluginId,
 } from "../../plugins/config-state.js";
 import { isPluginEnabledByDefaultForPlatform } from "../../plugins/default-enablement.js";
-import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { hashJson } from "../../plugins/installed-plugin-index-hash.js";
+import { createInstalledPluginIndexScopeLookup } from "../../plugins/installed-plugin-index-scope-lookup.js";
+import type { InstalledPluginIndex } from "../../plugins/installed-plugin-index.js";
+import type {
+  PluginMetadataSnapshot,
+  PluginMetadataSnapshotPluginIdScope,
+} from "../../plugins/plugin-metadata-snapshot.types.js";
 import {
   loadPluginRegistrySnapshot,
   normalizePluginsConfigWithRegistry,
@@ -23,6 +30,7 @@ import {
   OPENCLAW_AGENT_RUNTIME_ID,
   normalizeOptionalAgentRuntimeId,
 } from "../agent-runtime-id.js";
+import { collectConfiguredAgentHarnessRuntimes } from "../harness-runtimes.js";
 import { isCliRuntimeAliasForProvider } from "../model-runtime-aliases.js";
 import { resolveAgentHarnessPolicy } from "./policy.js";
 
@@ -84,6 +92,96 @@ function resolveSelectedMemoryPluginIds(params: {
   }).activated
     ? [plugin.pluginId]
     : [];
+}
+
+export function resolveAgentRuntimePluginSelections(
+  config: OpenClawConfig | undefined,
+  selections: readonly AgentHarnessPluginSelection[],
+): AgentHarnessPluginSelection[] {
+  return [
+    ...collectConfiguredAgentHarnessRuntimes(config ?? {}).map((runtime) => ({
+      runtime,
+      provider: "",
+      modelId: "",
+    })),
+    ...selections,
+  ];
+}
+
+function resolveAgentRuntimeMetadataPluginIds(params: {
+  config?: OpenClawConfig;
+  selections: readonly AgentHarnessPluginSelection[];
+  shorthandModelIds?: readonly string[];
+  index: InstalledPluginIndex;
+}): string[] | undefined {
+  if (!normalizePluginsConfig(params.config?.plugins).enabled) {
+    return [];
+  }
+  const lookup = createInstalledPluginIndexScopeLookup(params.index);
+  const pluginIds = new Set<string>();
+  lookup.addShorthandModelOwners(pluginIds, params.shorthandModelIds ?? []);
+  const selections = resolveAgentRuntimePluginSelections(params.config, params.selections);
+  const providerIds = dedupePluginIds(selections.map((selection) => selection.provider));
+  for (const providerId of providerIds) {
+    const providerPluginIds = new Set<string>();
+    lookup.addDirectProviderOwners(providerPluginIds, [providerId]);
+    if (providerPluginIds.size === 0) {
+      lookup.addProviderContributionOwners(providerPluginIds, [providerId]);
+    }
+    if (providerPluginIds.size !== 1) {
+      return undefined;
+    }
+    for (const pluginId of providerPluginIds) {
+      pluginIds.add(pluginId);
+    }
+  }
+  const runtimeIds = dedupePluginIds(
+    selections
+      .map((selection) => resolveSelectedAgentHarnessRuntime(selection, params.config))
+      .filter(
+        (runtime) => !isDefaultAgentRuntimeId(runtime) && runtime !== OPENCLAW_AGENT_RUNTIME_ID,
+      ),
+  );
+  if (!lookup.hasAgentHarnessOwners(runtimeIds)) {
+    return undefined;
+  }
+  lookup.addAgentHarnessOwners(pluginIds, runtimeIds);
+  // Metadata retains every memory candidate so the canonical runtime plan can
+  // select the active memory owner and any manifest-declared companion sidecar.
+  lookup.addMemoryPluginIds(pluginIds);
+  const contextEnginePluginId = resolveSelectedContextEnginePluginId(params.config);
+  if (contextEnginePluginId) {
+    pluginIds.add(contextEnginePluginId);
+  }
+  if (!lookup.hasInstalledPluginIds(pluginIds)) {
+    return undefined;
+  }
+  return [...pluginIds].toSorted((left, right) => left.localeCompare(right));
+}
+
+/** Narrows cold manifest preparation to candidates needed by one selected runtime generation. */
+export function createAgentRuntimeMetadataPluginIdScope(params: {
+  config?: OpenClawConfig;
+  workspaceDir: string;
+  selections: readonly AgentHarnessPluginSelection[];
+  shorthandModelIds?: readonly string[];
+}): PluginMetadataSnapshotPluginIdScope {
+  return {
+    key: hashJson({
+      kind: "agent-runtime",
+      config: params.config ?? null,
+      workspaceDir: params.workspaceDir,
+      selections: params.selections,
+      shorthandModelIds: params.shorthandModelIds ?? [],
+    }),
+    resolve: ({ index }) =>
+      resolveAgentRuntimeMetadataPluginIds({
+        config: params.config,
+        selections: params.selections,
+        shorthandModelIds: params.shorthandModelIds,
+        index,
+      }),
+  };
 }
 
 // Every selected model provider must join the immutable run generation before

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -2,7 +2,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
-import { resolveAgentRuntimePluginLoadPlan } from "./runtime-plugin-load-plan.js";
+import {
+  createAgentRuntimeMetadataPluginIdScope,
+  resolveAgentRuntimePluginLoadPlan,
+} from "./runtime-plugin-load-plan.js";
 import {
   ensureSelectedAgentHarnessPlugin,
   resolveAgentHarnessRuntimeAvailability,
@@ -14,6 +17,32 @@ const mocks = vi.hoisted(() => ({
   resolveManifestActivationPlan: vi.fn(),
   resolveOwningPluginIdsForProvider: vi.fn(),
 }));
+
+function installedProviderRecord(
+  pluginId: string,
+  options: {
+    providers?: string[];
+    contracts?: Record<string, string[]>;
+    modelSupportPrefixes?: string[];
+  } = {},
+) {
+  return {
+    pluginId,
+    startup: { sidecar: false, memory: false, agentHarnesses: [] },
+    contributions: {
+      providers: options.providers ?? [],
+      modelCatalogProviders: [],
+      modelSupportPrefixes: options.modelSupportPrefixes ?? [],
+      modelSupportPatterns: [],
+      autoEnableProviderIds: [],
+      channels: [],
+      channelConfigs: [],
+      commandAliases: [],
+      contracts: options.contracts ?? {},
+    },
+    compat: [],
+  };
+}
 
 vi.mock("../../plugins/providers.js", () => ({
   resolveActivatableProviderOwnerPluginIds: mocks.resolveActivatableProviderOwnerPluginIds,
@@ -98,6 +127,91 @@ describe("harness runtime plugins", () => {
 
     expect(plan.pluginIds).toEqual(["openai"]);
     expect(plan.config?.plugins?.entries?.openai).toEqual({ enabled: true });
+  });
+
+  it("scopes cold metadata to selected runtime candidates from the installed index", () => {
+    const scope = createAgentRuntimeMetadataPluginIdScope({
+      config: { plugins: { slots: { memory: "none" } } },
+      workspaceDir: "/tmp/workspace",
+      selections: [
+        { provider: "selected-provider", modelId: "selected-model", runtime: "openclaw" },
+      ],
+    });
+    expect(
+      scope.resolve({
+        index: {
+          plugins: [
+            installedProviderRecord("selected-plugin", { providers: ["selected-provider"] }),
+            installedProviderRecord("unrelated-plugin", {
+              providers: ["unrelated-provider"],
+            }),
+          ],
+        } as never,
+      }),
+    ).toEqual(["selected-plugin"]);
+  });
+
+  it("retains shorthand model owners while resolving the fallback provider", () => {
+    const scope = createAgentRuntimeMetadataPluginIdScope({
+      config: { plugins: { slots: { memory: "none" } } },
+      workspaceDir: "/tmp/workspace",
+      selections: [{ provider: "fallback-provider", modelId: "magic-model" }],
+      shorthandModelIds: ["magic-model"],
+    });
+    expect(
+      scope.resolve({
+        index: {
+          plugins: [
+            installedProviderRecord("fallback-provider", {
+              providers: ["fallback-provider"],
+            }),
+            installedProviderRecord("magic-model-owner", {
+              modelSupportPrefixes: ["magic-"],
+            }),
+          ],
+        } as never,
+      }),
+    ).toEqual(["fallback-provider", "magic-model-owner"]);
+  });
+
+  it("prefers the direct model provider owner over unrelated provider contributions", () => {
+    const scope = createAgentRuntimeMetadataPluginIdScope({
+      config: { plugins: { slots: { memory: "none" } } },
+      workspaceDir: "/tmp/workspace",
+      selections: [{ provider: "selected-provider", modelId: "selected-model" }],
+    });
+    expect(
+      scope.resolve({
+        index: {
+          plugins: [
+            installedProviderRecord("selected-provider", {
+              providers: ["selected-provider"],
+            }),
+            installedProviderRecord("embedding-helper", {
+              contracts: { embeddingProviders: ["selected-provider"] },
+            }),
+          ],
+        } as never,
+      }),
+    ).toEqual(["selected-provider"]);
+  });
+
+  it("keeps metadata unscoped for ambiguous indirect provider ownership", () => {
+    const scope = createAgentRuntimeMetadataPluginIdScope({
+      config: { plugins: { slots: { memory: "none" } } },
+      workspaceDir: "/tmp/workspace",
+      selections: [{ provider: "provider-alias", modelId: "selected-model" }],
+    });
+    expect(
+      scope.resolve({
+        index: {
+          plugins: [
+            installedProviderRecord("first-owner", { providers: ["provider-alias"] }),
+            installedProviderRecord("second-owner", { providers: ["provider-alias"] }),
+          ],
+        } as never,
+      }),
+    ).toBeUndefined();
   });
 
   it("includes the selected provider owner when policy selects an omitted harness", () => {

--- a/src/agents/prepared-model-catalog-worker.test.ts
+++ b/src/agents/prepared-model-catalog-worker.test.ts
@@ -42,7 +42,13 @@ describe("prepared model catalog worker input", () => {
     };
     const workerInput = createPreparedModelCatalogWorkerInput({
       agentFacts: {
-        input: { agentDir: "/tmp/agent", config: {}, workspaceDir: "/tmp/workspace" },
+        input: {
+          agentDir: "/tmp/agent",
+          config: {},
+          workspaceDir: "/tmp/workspace",
+          loadRuntimePlugins: true,
+          runtimePluginSelections: [{ provider: "selected", modelId: "model" }],
+        },
         env: {},
         authStore,
         credentials: { shared: { ...authStore.profiles["shared:named"] } },
@@ -74,5 +80,9 @@ describe("prepared model catalog worker input", () => {
     });
     expect(cloned.authStore.order).toEqual(authStore.order);
     expect(cloned.authStore.lastGood).toEqual(authStore.lastGood);
+    expect(cloned.input.runtimePluginSelections).toEqual([
+      { provider: "selected", modelId: "model" },
+    ]);
+    expect(cloned.input).not.toHaveProperty("loadRuntimePlugins");
   });
 });

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -1,4 +1,5 @@
 /** Agent-run lease admission for lifecycle-owned prepared model runtimes. */
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
@@ -36,6 +37,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
     retainIdleRunOwner?: boolean;
     catalogMode?: PreparedModelRuntimeCatalogMode;
     pluginGeneration?: PreparedModelRuntimeOwner["pluginGeneration"];
+    pluginMetadataSnapshot?: PluginMetadataSnapshot;
   } = {},
 ): Promise<PreparedModelRuntimeLease> {
   let normalizedInput = normalizePreparedModelRuntimeInput({
@@ -127,6 +129,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
           provenance,
           options.catalogMode,
           options.pluginGeneration,
+          options.pluginMetadataSnapshot,
         );
       }
     } catch (error) {

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -72,6 +72,7 @@ export function prepareWorkspacePluginRegistries(
   const runtimePluginRegistry =
     input.runtimePluginSelections || !inboundPluginRegistry
       ? loadAgentRuntimePluginRegistryHandle({
+          ...(input.loadRuntimePlugins ? { basePluginIds: [] } : {}),
           config: input.config,
           env: input.env ?? process.env,
           ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),

--- a/src/agents/prepared-model-runtime.plugin-context.test.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.test.ts
@@ -93,4 +93,40 @@ describe("prepared model runtime plugin metadata ownership", () => {
       resolveMetadata.mockRestore();
     }
   });
+
+  it("requests selected-runtime metadata for executable prepared probes", () => {
+    const config = { plugins: { slots: { memory: "none" as const } } };
+    const workspaceDir = "/tmp/selected-runtime-workspace";
+    const directSnapshot = createPluginMetadataSnapshot({
+      config,
+      manifestRegistry: makeRegistry([{ id: "selected", channels: [] }]),
+      workspaceDir,
+    });
+    const resolveMetadata = vi
+      .spyOn(pluginMetadata, "loadPluginMetadataSnapshot")
+      .mockReturnValue(directSnapshot);
+
+    try {
+      prepareOwnedPluginLoadContext(
+        {
+          agentDir: "/tmp/selected-runtime-agent",
+          config,
+          loadRuntimePlugins: true,
+          runtimePluginSelections: [{ provider: "selected", modelId: "model" }],
+          workspaceDir,
+        },
+        process.env,
+        undefined,
+      );
+
+      expect(resolveMetadata).toHaveBeenCalledWith({
+        config,
+        env: process.env,
+        workspaceDir,
+        pluginIdScope: expect.objectContaining({ key: expect.any(String) }),
+      });
+    } finally {
+      resolveMetadata.mockRestore();
+    }
+  });
 });

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -7,6 +7,7 @@ import {
   resolvePluginRuntimeLoadContext,
   type PluginRuntimeLoadContext,
 } from "../plugins/runtime/load-context.js";
+import { createAgentRuntimeMetadataPluginIdScope } from "./harness/runtime-plugin-load-plan.js";
 import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
 
 const preparedPluginRuntimeLoadContext = Symbol("preparedPluginRuntimeLoadContext");
@@ -74,6 +75,15 @@ function resolveColdMetadataSnapshot(
     config: input.config,
     env,
     ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+    ...(input.loadRuntimePlugins && input.runtimePluginSelections && input.workspaceDir
+      ? {
+          pluginIdScope: createAgentRuntimeMetadataPluginIdScope({
+            config: input.config,
+            workspaceDir: input.workspaceDir,
+            selections: input.runtimePluginSelections,
+          }),
+        }
+      : {}),
   });
   return resolvedMetadataSnapshot;
 }

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -11,6 +11,7 @@ import { getPreparedModelRuntimeAuthStore } from "./prepared-model-runtime-auth.
 import { startSerializedSnapshotBuild } from "./prepared-model-runtime.build.js";
 import { prepareWorkspacePluginRegistries } from "./prepared-model-runtime.inbound-registry.js";
 import {
+  acquireAgentRunPreparedModelRuntime,
   acquireReadOnlyPreparedModelRuntime,
   activateStandalonePreparedModelRuntime,
   getPreparedModelRuntimeSnapshot,
@@ -46,6 +47,26 @@ describe("prepared model runtime snapshots", () => {
       pluginGeneration: expect.any(Object),
     });
     await expect(build.completion).resolves.toBeUndefined();
+  });
+
+  it("publishes a run owner from the caller-selected metadata generation", async () => {
+    const lease = await acquireAgentRunPreparedModelRuntime(
+      {
+        config: {},
+        agentId: "main",
+        agentDir: "/tmp/selected-metadata-agent",
+        workspaceDir: "/tmp/selected-metadata-workspace",
+        loadRuntimePlugins: true,
+        runtimePluginSelections: [{ provider: "selected", modelId: "model" }],
+      },
+      {
+        catalogMode: "static",
+        pluginMetadataSnapshot: mocks.pluginMetadataSnapshot as never,
+      },
+    );
+
+    expect(lease.snapshot.metadataSnapshot).toBe(mocks.pluginMetadataSnapshot);
+    lease.release();
   });
 
   it("keeps an isolated setup probe exact after a gateway replacement", async () => {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -2,6 +2,7 @@
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles/runtime-snapshots.js";
 import { acquirePreparedModelRuntimeLeaseFromOwners } from "./prepared-model-runtime-lease.js";
 import { registerPreparedRuntimeAuthMaterializationPublisher } from "./prepared-model-runtime-materializations.js";
@@ -286,6 +287,7 @@ export async function acquireAgentRunPreparedModelRuntime(
     retainIdleRunOwner?: boolean;
     catalogMode?: PreparedModelRuntimeCatalogMode;
     pluginGeneration?: PreparedModelRuntimeOwner["pluginGeneration"];
+    pluginMetadataSnapshot?: PluginMetadataSnapshot;
   } = {},
 ): Promise<PreparedModelRuntimeLease> {
   return await acquirePreparedModelRuntimeLeaseFromOwners(

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -7,6 +7,9 @@ const hoisted = vi.hoisted(() => ({
   loadPluginRegistryHandle: vi.fn(),
   adoptRuntimeContextEngineRegistrations: vi.fn((target: unknown) => target),
   resolveAgentRuntimePluginLoadPlan: vi.fn(),
+  resolveAgentRuntimePluginSelections: vi.fn(
+    (_config: unknown, selections: readonly unknown[]) => selections,
+  ),
 }));
 
 vi.mock("../context-engine/registry.js", () => ({
@@ -27,6 +30,7 @@ vi.mock("../plugins/loader.js", () => ({
 
 vi.mock("./harness/runtime-plugin-load-plan.js", () => ({
   resolveAgentRuntimePluginLoadPlan: hoisted.resolveAgentRuntimePluginLoadPlan,
+  resolveAgentRuntimePluginSelections: hoisted.resolveAgentRuntimePluginSelections,
 }));
 
 import {
@@ -68,6 +72,9 @@ describe("agent runtime plugin registries", () => {
       config,
       pluginIds: ["codex", "memory-core"],
     }));
+    hoisted.resolveAgentRuntimePluginSelections
+      .mockReset()
+      .mockImplementation((_config, selections) => selections);
   });
 
   it("adopts runtime context engines from the active composition-root registry", () => {

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -13,9 +13,9 @@ import {
   withPluginRuntimeRegistryScope,
 } from "../plugins/runtime/gateway-request-scope.js";
 import { resolveUserPath } from "../utils.js";
-import { collectConfiguredAgentHarnessRuntimes } from "./harness-runtimes.js";
 import {
   resolveAgentRuntimePluginLoadPlan,
+  resolveAgentRuntimePluginSelections,
   type AgentHarnessPluginSelection,
 } from "./harness/runtime-plugin-load-plan.js";
 
@@ -77,14 +77,7 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
     config: params.config,
     workspaceDir: workspaceDir ?? process.cwd(),
     ...(startupPluginIds === undefined ? {} : { basePluginIds: startupPluginIds }),
-    selections: [
-      ...collectConfiguredAgentHarnessRuntimes(params.config ?? {}).map((runtime) => ({
-        runtime,
-        provider: "",
-        modelId: "",
-      })),
-      ...(params.selections ?? []),
-    ],
+    selections: resolveAgentRuntimePluginSelections(params.config, params.selections ?? []),
     metadataSnapshot,
   };
   const plan = resolveAgentRuntimePluginLoadPlan(planParams);

--- a/src/agents/simple-completion-runtime.generation.test.ts
+++ b/src/agents/simple-completion-runtime.generation.test.ts
@@ -7,7 +7,6 @@ const mocks = vi.hoisted(() => ({
   acquireRuntimeLease: vi.fn(),
   getApiKeyForModel: vi.fn(),
   prepareProviderRuntimeAuth: vi.fn(),
-  getCurrentPluginMetadataSnapshot: vi.fn(),
   resolvePluginMetadataSnapshot: vi.fn(),
   publishedGeneration: "A",
   readGeneration: (() => "unscoped") as () => string,
@@ -15,10 +14,6 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./prepared-model-runtime.js", () => ({
   acquireAgentRunPreparedModelRuntime: mocks.acquireRuntimeLease,
-}));
-
-vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
-  getCurrentPluginMetadataSnapshot: mocks.getCurrentPluginMetadataSnapshot,
 }));
 
 vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
@@ -82,7 +77,6 @@ beforeEach(() => {
   mocks.acquireRuntimeLease.mockReset();
   mocks.getApiKeyForModel.mockReset();
   mocks.prepareProviderRuntimeAuth.mockReset();
-  mocks.getCurrentPluginMetadataSnapshot.mockReset().mockReturnValue(undefined);
   mocks.resolvePluginMetadataSnapshot.mockReset().mockReturnValue({
     plugins: [],
     index: { plugins: [] },
@@ -246,16 +240,6 @@ it("acquires the canonical manifest-derived utility model selection", async () =
     ],
     index: { plugins: [] },
   };
-  let scopedMetadataReads = 0;
-  mocks.getCurrentPluginMetadataSnapshot.mockImplementation(
-    (params?: { pluginIdScope?: unknown }) => {
-      if (!params?.pluginIdScope) {
-        return undefined;
-      }
-      scopedMetadataReads += 1;
-      return scopedMetadataReads === 1 ? metadataSnapshot : undefined;
-    },
-  );
   mocks.resolvePluginMetadataSnapshot.mockReturnValue(metadataSnapshot);
 
   const result = await prepareSimpleCompletionModelForAgent({
@@ -272,7 +256,11 @@ it("acquires the canonical manifest-derived utility model selection", async () =
     })),
   });
 
-  expect(scopedMetadataReads).toBe(2);
+  expect(
+    mocks.resolvePluginMetadataSnapshot.mock.calls.filter(
+      ([params]) => (params as { pluginIdScope?: unknown } | undefined)?.pluginIdScope,
+    ),
+  ).toHaveLength(2);
   expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
     expect.objectContaining({
       runtimePluginSelections: [

--- a/src/agents/simple-completion-runtime.generation.test.ts
+++ b/src/agents/simple-completion-runtime.generation.test.ts
@@ -7,12 +7,23 @@ const mocks = vi.hoisted(() => ({
   acquireRuntimeLease: vi.fn(),
   getApiKeyForModel: vi.fn(),
   prepareProviderRuntimeAuth: vi.fn(),
+  getCurrentPluginMetadataSnapshot: vi.fn(),
+  resolvePluginMetadataSnapshot: vi.fn(),
   publishedGeneration: "A",
   readGeneration: (() => "unscoped") as () => string,
 }));
 
 vi.mock("./prepared-model-runtime.js", () => ({
   acquireAgentRunPreparedModelRuntime: mocks.acquireRuntimeLease,
+}));
+
+vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: mocks.getCurrentPluginMetadataSnapshot,
+}));
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>()),
+  resolvePluginMetadataSnapshot: mocks.resolvePluginMetadataSnapshot,
 }));
 
 vi.mock("../plugins/runtime/generation-scope.js", async () => {
@@ -42,13 +53,40 @@ vi.mock("./sessions/model-registry-runtime.js", () => ({
   getModelRegistryRuntime: () => ({ llmRuntime: { registry: {}, streamSimple: vi.fn() } }),
 }));
 
-import { prepareSimpleCompletionModel } from "./simple-completion-runtime.js";
+import {
+  prepareSimpleCompletionModel,
+  prepareSimpleCompletionModelForAgent,
+} from "./simple-completion-runtime.js";
+
+function createOllamaModelResolver(): typeof resolveModelAsync {
+  return vi.fn(async (provider, modelId, _agentDir, _cfg, options) => ({
+    model: {
+      provider,
+      id: modelId,
+      name: modelId,
+      api: "ollama",
+      baseUrl: "http://127.0.0.1:11434",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 8192,
+      maxTokens: 1024,
+    } satisfies Model,
+    authStorage: options?.authStorage ?? AuthStorage.inMemory({}),
+    modelRegistry: options?.modelRegistry ?? ModelRegistry.inMemory(AuthStorage.inMemory({})),
+  }));
+}
 
 beforeEach(() => {
   mocks.publishedGeneration = "A";
   mocks.acquireRuntimeLease.mockReset();
   mocks.getApiKeyForModel.mockReset();
   mocks.prepareProviderRuntimeAuth.mockReset();
+  mocks.getCurrentPluginMetadataSnapshot.mockReset().mockReturnValue(undefined);
+  mocks.resolvePluginMetadataSnapshot.mockReset().mockReturnValue({
+    plugins: [],
+    index: { plugins: [] },
+  });
   const authStorage = AuthStorage.inMemory({});
   const modelRegistry = ModelRegistry.inMemory(authStorage);
   mocks.acquireRuntimeLease.mockResolvedValue({
@@ -131,4 +169,125 @@ it("keeps route rematerialization and runtime auth on the acquired generation", 
   expect(result.model.params).toMatchObject({ generation: "A" });
   expect(observedModelGenerations).toEqual(["A", "A"]);
   expect(observedRuntimeAuthGenerations).toEqual(["A"]);
+});
+
+it("acquires direct completion runtime for the exact selected model", async () => {
+  const modelResolver = createOllamaModelResolver();
+  mocks.getApiKeyForModel.mockResolvedValue({
+    apiKey: "ollama-local",
+    source: "local marker",
+    mode: "api-key",
+  });
+
+  await prepareSimpleCompletionModel({
+    cfg: {},
+    agentId: "main",
+    provider: "ollama",
+    modelId: "qwen3:0.6b",
+    agentDir: "/tmp/openclaw-agent",
+    agentRuntimeId: "openclaw",
+    modelResolver,
+  });
+
+  expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
+    expect.objectContaining({
+      runtimePluginSelections: [
+        {
+          provider: "ollama",
+          modelId: "qwen3:0.6b",
+          runtime: "openclaw",
+          agentId: "main",
+        },
+      ],
+    }),
+    expect.objectContaining({ catalogMode: "static" }),
+  );
+  expect(modelResolver).toHaveBeenCalledOnce();
+});
+
+it("selects an explicit agent completion model before runtime acquisition", async () => {
+  const modelResolver = createOllamaModelResolver();
+  mocks.getApiKeyForModel.mockResolvedValue({
+    apiKey: "ollama-local",
+    source: "local marker",
+    mode: "api-key",
+  });
+
+  await prepareSimpleCompletionModelForAgent({
+    cfg: {},
+    agentId: "main",
+    modelRef: "ollama/qwen3:0.6b",
+    modelResolver,
+  });
+
+  expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
+    expect.objectContaining({
+      runtimePluginSelections: [{ provider: "ollama", modelId: "qwen3:0.6b", agentId: "main" }],
+    }),
+    expect.objectContaining({ catalogMode: "static" }),
+  );
+  expect(modelResolver).toHaveBeenCalledOnce();
+});
+
+it("acquires the canonical manifest-derived utility model selection", async () => {
+  const metadataSnapshot = {
+    plugins: [
+      {
+        id: "selected-provider",
+        modelCatalog: {
+          providers: {
+            "selected-provider": {
+              defaultUtilityModel: "utility-model",
+              models: [{ id: "primary-model" }, { id: "utility-model" }],
+            },
+          },
+        },
+      },
+    ],
+    index: { plugins: [] },
+  };
+  let scopedMetadataReads = 0;
+  mocks.getCurrentPluginMetadataSnapshot.mockImplementation(
+    (params?: { pluginIdScope?: unknown }) => {
+      if (!params?.pluginIdScope) {
+        return undefined;
+      }
+      scopedMetadataReads += 1;
+      return scopedMetadataReads === 1 ? metadataSnapshot : undefined;
+    },
+  );
+  mocks.resolvePluginMetadataSnapshot.mockReturnValue(metadataSnapshot);
+
+  const result = await prepareSimpleCompletionModelForAgent({
+    cfg: {
+      agents: { defaults: { model: "selected-provider/primary-model@work" } },
+    },
+    agentId: "main",
+    agentDir: "/tmp/canonical-agent",
+    useUtilityModel: true,
+    modelResolver: vi.fn(async (_provider, _modelId, _agentDir, _cfg, options) => ({
+      error: "stop after canonical selection",
+      authStorage: options?.authStorage ?? AuthStorage.inMemory({}),
+      modelRegistry: options?.modelRegistry ?? ModelRegistry.inMemory(AuthStorage.inMemory({})),
+    })),
+  });
+
+  expect(scopedMetadataReads).toBe(2);
+  expect(mocks.acquireRuntimeLease).toHaveBeenCalledWith(
+    expect.objectContaining({
+      runtimePluginSelections: [
+        { provider: "selected-provider", modelId: "utility-model", agentId: "main" },
+      ],
+      agentDir: "/tmp/canonical-agent",
+    }),
+    expect.objectContaining({ catalogMode: "static", pluginMetadataSnapshot: metadataSnapshot }),
+  );
+  expect(result).toMatchObject({
+    selection: {
+      provider: "selected-provider",
+      modelId: "utility-model",
+      profileId: "work",
+      agentDir: "/tmp/canonical-agent",
+    },
+  });
 });

--- a/src/agents/simple-completion-runtime.plugin-scope.test.ts
+++ b/src/agents/simple-completion-runtime.plugin-scope.test.ts
@@ -9,7 +9,7 @@ import {
   createColdPluginHermeticEnv,
   isColdPluginRuntimeLoaded,
 } from "../plugins/test-helpers/cold-plugin-fixtures.js";
-import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
+import { createSyncSuiteTempRootTracker } from "../plugins/test-helpers/fs-fixtures.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
@@ -20,17 +20,13 @@ import {
   prepareSimpleCompletionModelForAgent,
 } from "./simple-completion-runtime.js";
 
-const tempDirs: string[] = [];
-
-function makeTempDir() {
-  return makeTrackedTempDir("openclaw-simple-completion-plugin-scope", tempDirs);
-}
+const tempRoots = createSyncSuiteTempRootTracker("openclaw-simple-completion-plugin-scope");
 
 afterEach(() => {
   resetPreparedModelRuntimeSnapshotsForTest();
   clearPluginMetadataLifecycleCaches();
   resetPluginLoaderTestStateForTest();
-  cleanupTrackedTempDirs(tempDirs);
+  tempRoots.cleanup();
 });
 
 describe("simple completion prepared plugin scope", () => {
@@ -71,7 +67,7 @@ describe("simple completion prepared plugin scope", () => {
   ])(
     "loads only the selected plugin generation for $name",
     async ({ expectedModelId, prepare }) => {
-      const tempRoot = makeTempDir();
+      const tempRoot = tempRoots.makeTempDir();
       const selectedRoot = path.join(tempRoot, "selected");
       const unrelatedRoot = path.join(tempRoot, "unrelated");
       fs.mkdirSync(selectedRoot, { recursive: true });
@@ -116,6 +112,7 @@ module.exports = {
         },
         plugins: {
           load: { paths: [selected.rootDir, unrelated.rootDir] },
+          slots: { memory: "none" },
           entries: {
             [selected.pluginId]: { enabled: true },
             [unrelated.pluginId]: { enabled: true },
@@ -135,7 +132,7 @@ module.exports = {
         },
       );
       const env = {
-        ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: makeTempDir() }),
+        ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: tempRoots.makeTempDir() }),
         OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
         OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
       };
@@ -149,9 +146,8 @@ module.exports = {
         }),
       );
 
-      expect(result).toEqual({
+      expect(result).toMatchObject({
         error: `stop after selected resolver ${selected.providerId}/${expectedModelId}`,
-        ...("selection" in result ? { selection: result.selection } : {}),
       });
       expect(modelResolver).toHaveBeenCalledOnce();
       expect(isColdPluginRuntimeLoaded(selected)).toBe(true);

--- a/src/agents/simple-completion-runtime.plugin-scope.test.ts
+++ b/src/agents/simple-completion-runtime.plugin-scope.test.ts
@@ -1,0 +1,166 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import {
+  createColdPluginFixture,
+  createColdPluginHermeticEnv,
+  isColdPluginRuntimeLoaded,
+} from "../plugins/test-helpers/cold-plugin-fixtures.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
+import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
+import { AuthStorage, ModelRegistry } from "./sessions/index.js";
+import {
+  prepareSimpleCompletionModel,
+  prepareSimpleCompletionModelForAgent,
+} from "./simple-completion-runtime.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir() {
+  return makeTrackedTempDir("openclaw-simple-completion-plugin-scope", tempDirs);
+}
+
+afterEach(() => {
+  resetPreparedModelRuntimeSnapshotsForTest();
+  clearPluginMetadataLifecycleCaches();
+  resetPluginLoaderTestStateForTest();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+describe("simple completion prepared plugin scope", () => {
+  it.each([
+    {
+      name: "direct provider and model",
+      expectedModelId: "selected-model",
+      prepare: (params: {
+        config: OpenClawConfig;
+        modelResolver: typeof resolveModelAsync;
+        provider: string;
+        modelId: string;
+      }) =>
+        prepareSimpleCompletionModel({
+          cfg: params.config,
+          agentId: "main",
+          provider: params.provider,
+          modelId: params.modelId,
+          modelResolver: params.modelResolver,
+        }),
+    },
+    {
+      name: "agent-selected manifest utility model",
+      expectedModelId: "utility-model",
+      prepare: (params: {
+        config: OpenClawConfig;
+        modelResolver: typeof resolveModelAsync;
+        provider: string;
+        modelId: string;
+      }) =>
+        prepareSimpleCompletionModelForAgent({
+          cfg: params.config,
+          agentId: "main",
+          useUtilityModel: true,
+          modelResolver: params.modelResolver,
+        }),
+    },
+  ])(
+    "loads only the selected plugin generation for $name",
+    async ({ expectedModelId, prepare }) => {
+      const tempRoot = makeTempDir();
+      const selectedRoot = path.join(tempRoot, "selected");
+      const unrelatedRoot = path.join(tempRoot, "unrelated");
+      fs.mkdirSync(selectedRoot, { recursive: true });
+      fs.mkdirSync(unrelatedRoot, { recursive: true });
+      const selected = createColdPluginFixture({
+        rootDir: selectedRoot,
+        pluginId: "selected-provider-plugin",
+        providerId: "selected-provider",
+        manifest: {
+          modelCatalog: {
+            providers: {
+              "selected-provider": {
+                defaultUtilityModel: "utility-model",
+                models: [{ id: "primary-model" }, { id: "utility-model" }],
+              },
+            },
+          },
+        },
+      });
+      const unrelated = createColdPluginFixture({
+        rootDir: unrelatedRoot,
+        pluginId: "unrelated-provider-plugin",
+        providerId: "unrelated-provider",
+        runtimeMessage: "unrelated provider runtime must remain cold",
+      });
+      fs.writeFileSync(
+        selected.runtimeSource,
+        `const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(selected.runtimeMarker)}, "loaded", "utf8");
+module.exports = {
+  id: ${JSON.stringify(selected.pluginId)},
+  register(api) {
+    api.registerProvider({ id: ${JSON.stringify(selected.providerId)}, label: "Selected", auth: [] });
+  },
+};
+`,
+        "utf8",
+      );
+      const config = {
+        agents: {
+          defaults: { model: `${selected.providerId}/primary-model@work` },
+        },
+        plugins: {
+          load: { paths: [selected.rootDir, unrelated.rootDir] },
+          entries: {
+            [selected.pluginId]: { enabled: true },
+            [unrelated.pluginId]: { enabled: true },
+          },
+        },
+      } satisfies OpenClawConfig;
+      let preparedRuntime: PreparedModelRuntimeSnapshot | undefined;
+      const modelResolver: typeof resolveModelAsync = vi.fn(
+        async (provider, modelId, _agentDir, _cfg, options) => {
+          preparedRuntime = options?.preparedModelRuntime;
+          return {
+            error: `stop after selected resolver ${provider}/${modelId}`,
+            authStorage: options?.authStorage ?? AuthStorage.inMemory({}),
+            modelRegistry:
+              options?.modelRegistry ?? ModelRegistry.inMemory(AuthStorage.inMemory({})),
+          };
+        },
+      );
+      const env = {
+        ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: makeTempDir() }),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
+      };
+
+      const result = await withEnvAsync(env, () =>
+        prepare({
+          config,
+          modelResolver,
+          provider: selected.providerId,
+          modelId: expectedModelId,
+        }),
+      );
+
+      expect(result).toEqual({
+        error: `stop after selected resolver ${selected.providerId}/${expectedModelId}`,
+        ...("selection" in result ? { selection: result.selection } : {}),
+      });
+      expect(modelResolver).toHaveBeenCalledOnce();
+      expect(isColdPluginRuntimeLoaded(selected)).toBe(true);
+      expect(isColdPluginRuntimeLoaded(unrelated)).toBe(false);
+      expect(preparedRuntime?.metadataSnapshot.pluginIds).toContain(selected.pluginId);
+      expect(preparedRuntime?.metadataSnapshot.pluginIds).not.toContain(unrelated.pluginId);
+      expect(preparedRuntime?.metadataSnapshot.plugins.map((plugin) => plugin.id)).toEqual([
+        selected.pluginId,
+      ]);
+    },
+  );
+});

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -21,6 +21,9 @@ import type {
   ModelThinkingLevel,
   ThinkingLevel as SimpleCompletionThinkingLevel,
 } from "../llm/types.js";
+import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.runtime.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import {
@@ -38,6 +41,10 @@ import {
 } from "./execution-auth-binding.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import {
+  createAgentRuntimeMetadataPluginIdScope,
+  type AgentHarnessPluginSelection,
+} from "./harness/runtime-plugin-load-plan.js";
+import {
   applySecretRefHeaderSentinels,
   applyLocalNoAuthHeaderOverride,
   formatMissingAuthError,
@@ -50,7 +57,6 @@ import {
   buildModelAliasIndex,
   resolveDefaultModelForAgent,
   resolveModelRefFromString,
-  type ModelManifestNormalizationContext,
 } from "./model-selection.js";
 import { resolveOpenAIModelRoutes, selectOpenAIModelRouteAuth } from "./openai-model-routes.js";
 import { OPENAI_PROVIDER_ID, isOpenAIProvider } from "./openai-routing.js";
@@ -111,14 +117,23 @@ type PreparedSimpleCompletionModelForAgent =
       selection?: AgentSimpleCompletionSelection;
     });
 
-export function resolveSimpleCompletionSelectionForAgent(params: {
+type SimpleCompletionSelectionParams = {
   cfg: OpenClawConfig;
   agentId: string;
   agentDir?: string;
   modelRef?: string;
   useUtilityModel?: boolean;
-  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
-}): AgentSimpleCompletionSelection | null {
+  manifestPlugins?: PluginMetadataSnapshot["plugins"];
+};
+
+type SimpleCompletionSelectionRequest = {
+  selection: AgentSimpleCompletionSelection;
+  shorthandModelId?: string;
+};
+
+function resolveSimpleCompletionSelectionRequest(
+  params: SimpleCompletionSelectionParams,
+): SimpleCompletionSelectionRequest | null {
   const fallbackRef = resolveDefaultModelForAgent({
     cfg: params.cfg,
     agentId: params.agentId,
@@ -133,6 +148,9 @@ export function resolveSimpleCompletionSelectionForAgent(params: {
           cfg: params.cfg,
           agentId: params.agentId,
           primaryProvider: fallbackRef.provider,
+          ...(params.manifestPlugins
+            ? { metadataSnapshot: { plugins: params.manifestPlugins } }
+            : {}),
         })
       : undefined) ||
     resolveAgentEffectiveModelPrimary(params.cfg, params.agentId);
@@ -162,12 +180,21 @@ export function resolveSimpleCompletionSelectionForAgent(params: {
       ? OPENAI_PROVIDER_ID
       : undefined;
   return {
-    provider,
-    modelId,
-    ...(runtimeProvider ? { runtimeProvider } : {}),
-    profileId: split?.profile || undefined,
-    agentDir: params.agentDir?.trim() || resolveAgentDir(params.cfg, params.agentId),
+    selection: {
+      provider,
+      modelId,
+      ...(runtimeProvider ? { runtimeProvider } : {}),
+      profileId: split?.profile || undefined,
+      agentDir: params.agentDir?.trim() || resolveAgentDir(params.cfg, params.agentId),
+    },
+    ...(split && !split.model.includes("/") ? { shorthandModelId: split.model } : {}),
   };
+}
+
+export function resolveSimpleCompletionSelectionForAgent(
+  params: SimpleCompletionSelectionParams,
+): AgentSimpleCompletionSelection | null {
+  return resolveSimpleCompletionSelectionRequest(params)?.selection ?? null;
 }
 
 export async function prepareSimpleCompletionModel(params: {
@@ -190,6 +217,13 @@ export async function prepareSimpleCompletionModel(params: {
 }): Promise<PreparedSimpleCompletionModel> {
   return await withPreparedSimpleCompletionRuntime(
     params,
+    [
+      {
+        provider: params.provider,
+        modelId: params.modelId,
+        ...(params.agentRuntimeId ? { runtime: params.agentRuntimeId } : {}),
+      },
+    ],
     async (context) =>
       await prepareSimpleCompletionModelCore(
         { ...params, agentDir: context.preparedModelRuntime.agentDir },
@@ -431,7 +465,9 @@ async function withPreparedSimpleCompletionRuntime<T>(
     preparedModelRuntime?: PreparedModelRuntimeSnapshot;
     workspaceDir?: string;
     agentRuntimeId?: string;
+    pluginMetadataSnapshot?: PluginMetadataSnapshot;
   },
+  runtimePluginSelections: readonly AgentHarnessPluginSelection[],
   run: (context: PreparedSimpleCompletionResolverContext) => Promise<T>,
 ): Promise<T> {
   const config = params.cfg ?? {};
@@ -443,12 +479,25 @@ async function withPreparedSimpleCompletionRuntime<T>(
     resolveAgentWorkspaceDir(config, agentId);
   const lease = params.preparedModelRuntime
     ? undefined
-    : await acquireAgentRunPreparedModelRuntime({
-        config,
-        agentId,
-        agentDir,
-        workspaceDir: requestedWorkspaceDir,
-      });
+    : await acquireAgentRunPreparedModelRuntime(
+        {
+          config,
+          agentId,
+          agentDir,
+          workspaceDir: requestedWorkspaceDir,
+          loadRuntimePlugins: true,
+          runtimePluginSelections: runtimePluginSelections.map((selection) => ({
+            ...selection,
+            agentId,
+          })),
+        },
+        {
+          catalogMode: "static",
+          ...(params.pluginMetadataSnapshot
+            ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
+            : {}),
+        },
+      );
   const preparedModelRuntime = params.preparedModelRuntime ?? lease!.snapshot;
   const workspaceDir =
     params.workspaceDir ?? preparedModelRuntime.workspaceDir ?? requestedWorkspaceDir;
@@ -480,38 +529,121 @@ export async function prepareSimpleCompletionModelForAgent(params: {
   bindAuthOwner?: boolean;
   modelResolver?: typeof resolveModelAsync;
 }): Promise<PreparedSimpleCompletionModelForAgent> {
-  return await withPreparedSimpleCompletionRuntime(params, async (context) => {
-    const selection = resolveSimpleCompletionSelectionForAgent({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      agentDir: context.preparedModelRuntime.agentDir,
-      modelRef: params.modelRef,
-      useUtilityModel: params.useUtilityModel,
-      manifestPlugins: context.preparedModelRuntime.metadataSnapshot.plugins,
+  const selectionParams = {
+    cfg: params.cfg,
+    agentId: params.agentId,
+    agentDir: params.agentDir,
+    modelRef: params.modelRef,
+    useUtilityModel: params.useUtilityModel,
+  };
+  const tentativeRequest = resolveSimpleCompletionSelectionRequest(selectionParams);
+  if (!tentativeRequest) {
+    return { error: `No model configured for agent ${params.agentId}.` };
+  }
+  const tentativeSelection = tentativeRequest.selection;
+  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.agentId);
+  const pluginIdScope = createAgentRuntimeMetadataPluginIdScope({
+    config: params.cfg,
+    workspaceDir,
+    selections: [
+      {
+        provider: tentativeSelection.runtimeProvider ?? tentativeSelection.provider,
+        modelId: tentativeSelection.modelId,
+        agentId: params.agentId,
+      },
+    ],
+    ...(tentativeRequest.shorthandModelId
+      ? { shorthandModelIds: [tentativeRequest.shorthandModelId] }
+      : {}),
+  });
+  const currentMetadataSnapshot = getCurrentPluginMetadataSnapshot({
+    config: params.cfg,
+    workspaceDir,
+    pluginIdScope,
+    allowWorkspaceScopedSnapshot: true,
+  });
+  let metadataSnapshot =
+    currentMetadataSnapshot ??
+    resolvePluginMetadataSnapshot({
+      config: params.cfg,
+      env: process.env,
+      workspaceDir,
+      pluginIdScope,
     });
+  const resolveSelection = () =>
+    resolveSimpleCompletionSelectionForAgent({
+      ...selectionParams,
+      manifestPlugins: metadataSnapshot.plugins,
+    });
+  let selection = resolveSelection();
+  if (!selection) {
+    return { error: `No model configured for agent ${params.agentId}.` };
+  }
+  const canonicalPluginIdScope = createAgentRuntimeMetadataPluginIdScope({
+    config: params.cfg,
+    workspaceDir,
+    selections: [
+      {
+        provider: selection.runtimeProvider ?? selection.provider,
+        modelId: selection.modelId,
+        agentId: params.agentId,
+      },
+    ],
+    ...(tentativeRequest.shorthandModelId &&
+    selection.provider === tentativeSelection.provider &&
+    selection.modelId === tentativeSelection.modelId
+      ? { shorthandModelIds: [tentativeRequest.shorthandModelId] }
+      : {}),
+  });
+  if (canonicalPluginIdScope.key !== pluginIdScope.key) {
+    metadataSnapshot =
+      getCurrentPluginMetadataSnapshot({
+        config: params.cfg,
+        workspaceDir,
+        pluginIdScope: canonicalPluginIdScope,
+        allowWorkspaceScopedSnapshot: true,
+      }) ??
+      resolvePluginMetadataSnapshot({
+        config: params.cfg,
+        env: process.env,
+        workspaceDir,
+        pluginIdScope: canonicalPluginIdScope,
+      });
+    selection = resolveSelection();
     if (!selection) {
       return { error: `No model configured for agent ${params.agentId}.` };
     }
-    const prepared = await prepareSimpleCompletionModelCore(
-      {
-        cfg: params.cfg,
-        agentId: params.agentId,
-        provider: selection.runtimeProvider ?? selection.provider,
-        modelId: selection.modelId,
-        agentDir: selection.agentDir,
-        profileId: selection.profileId,
-        preferredProfile: params.preferredProfile,
-        allowMissingApiKeyModes: params.allowMissingApiKeyModes,
-        ...(params.allowBundledStaticCatalogFallback !== undefined
-          ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
-          : {}),
-        skipAgentDiscovery: params.skipAgentDiscovery,
-        bindAuthOwner: params.bindAuthOwner,
-      },
-      context,
-    );
-    return { ...prepared, selection };
-  });
+  }
+  const selectedProvider = selection.runtimeProvider ?? selection.provider;
+  return await withPreparedSimpleCompletionRuntime(
+    {
+      ...params,
+      agentDir: selection.agentDir,
+      pluginMetadataSnapshot: metadataSnapshot,
+    },
+    [{ provider: selectedProvider, modelId: selection.modelId }],
+    async (context) => {
+      const prepared = await prepareSimpleCompletionModelCore(
+        {
+          cfg: params.cfg,
+          agentId: params.agentId,
+          provider: selectedProvider,
+          modelId: selection.modelId,
+          agentDir: selection.agentDir,
+          profileId: selection.profileId,
+          preferredProfile: params.preferredProfile,
+          allowMissingApiKeyModes: params.allowMissingApiKeyModes,
+          ...(params.allowBundledStaticCatalogFallback !== undefined
+            ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
+            : {}),
+          skipAgentDiscovery: params.skipAgentDiscovery,
+          bindAuthOwner: params.bindAuthOwner,
+        },
+        context,
+      );
+      return { ...prepared, selection };
+    },
+  );
 }
 
 export async function completeWithPreparedSimpleCompletionModel(params: {

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -21,7 +21,6 @@ import type {
   ModelThinkingLevel,
   ThinkingLevel as SimpleCompletionThinkingLevel,
 } from "../llm/types.js";
-import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { prepareProviderRuntimeAuth } from "../plugins/provider-runtime.runtime.js";
@@ -556,20 +555,13 @@ export async function prepareSimpleCompletionModelForAgent(params: {
       ? { shorthandModelIds: [tentativeRequest.shorthandModelId] }
       : {}),
   });
-  const currentMetadataSnapshot = getCurrentPluginMetadataSnapshot({
+  let metadataSnapshot = resolvePluginMetadataSnapshot({
     config: params.cfg,
+    env: process.env,
     workspaceDir,
     pluginIdScope,
-    allowWorkspaceScopedSnapshot: true,
+    allowWorkspaceScopedCurrent: true,
   });
-  let metadataSnapshot =
-    currentMetadataSnapshot ??
-    resolvePluginMetadataSnapshot({
-      config: params.cfg,
-      env: process.env,
-      workspaceDir,
-      pluginIdScope,
-    });
   const resolveSelection = () =>
     resolveSimpleCompletionSelectionForAgent({
       ...selectionParams,
@@ -596,19 +588,13 @@ export async function prepareSimpleCompletionModelForAgent(params: {
       : {}),
   });
   if (canonicalPluginIdScope.key !== pluginIdScope.key) {
-    metadataSnapshot =
-      getCurrentPluginMetadataSnapshot({
-        config: params.cfg,
-        workspaceDir,
-        pluginIdScope: canonicalPluginIdScope,
-        allowWorkspaceScopedSnapshot: true,
-      }) ??
-      resolvePluginMetadataSnapshot({
-        config: params.cfg,
-        env: process.env,
-        workspaceDir,
-        pluginIdScope: canonicalPluginIdScope,
-      });
+    metadataSnapshot = resolvePluginMetadataSnapshot({
+      config: params.cfg,
+      env: process.env,
+      workspaceDir,
+      pluginIdScope: canonicalPluginIdScope,
+      allowWorkspaceScopedCurrent: true,
+    });
     selection = resolveSelection();
     if (!selection) {
       return { error: `No model configured for agent ${params.agentId}.` };

--- a/src/agents/utility-model.ts
+++ b/src/agents/utility-model.ts
@@ -38,7 +38,7 @@ export function readUtilityModelSetting(cfg: OpenClawConfig, agentId: string): U
 function resolveProviderDefaultUtilityModelRef(params: {
   cfg: OpenClawConfig;
   provider: string;
-  metadataSnapshot?: PluginMetadataSnapshot;
+  metadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
 }): string | undefined {
   const provider = params.provider.trim().toLowerCase();
   if (!provider) {
@@ -76,7 +76,7 @@ export function resolveUtilityModelRefForAgent(params: {
   primaryProvider?: string;
   /** Pass with primaryProvider to carry a session-specific auth profile. */
   primaryModelRef?: string;
-  metadataSnapshot?: PluginMetadataSnapshot;
+  metadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
 }): string | undefined {
   const setting = readUtilityModelSetting(params.cfg, params.agentId);
   if (setting.kind === "explicit") {

--- a/src/plugins/installed-plugin-index-scope-lookup.ts
+++ b/src/plugins/installed-plugin-index-scope-lookup.ts
@@ -35,7 +35,6 @@ export type InstalledPluginIndexScopeLookup = {
   addChannelContributionOwners: (target: Set<string>, ids: readonly string[]) => void;
   addDirectChannelOwners: (target: Set<string>, ids: readonly string[]) => void;
   addDirectProviderOwners: (target: Set<string>, ids: readonly string[]) => void;
-  addMemoryPluginIds: (target: Set<string>) => void;
   addProviderContributionOwners: (target: Set<string>, ids: readonly string[]) => void;
   addShorthandModelOwners: (target: Set<string>, modelIds: readonly string[]) => void;
   canResolveDirectProviderIds: (
@@ -221,13 +220,6 @@ export function createInstalledPluginIndexScopeLookup(
       addOwners(target, maps.channelContributionOwners, ids),
     addDirectChannelOwners: (target, ids) => addOwners(target, maps.directChannelOwners, ids),
     addDirectProviderOwners: (target, ids) => addOwners(target, maps.directProviderOwners, ids),
-    addMemoryPluginIds: (target) => {
-      for (const plugin of index.plugins) {
-        if (plugin.startup.memory) {
-          target.add(plugin.pluginId);
-        }
-      }
-    },
     addProviderContributionOwners: (target, ids) =>
       addOwners(target, maps.providerContributionOwners, ids),
     addShorthandModelOwners: (target, modelIds) => {

--- a/src/plugins/installed-plugin-index-scope-lookup.ts
+++ b/src/plugins/installed-plugin-index-scope-lookup.ts
@@ -31,9 +31,11 @@ type ModelSupportOwner = {
 };
 
 export type InstalledPluginIndexScopeLookup = {
+  addAgentHarnessOwners: (target: Set<string>, ids: readonly string[]) => void;
   addChannelContributionOwners: (target: Set<string>, ids: readonly string[]) => void;
   addDirectChannelOwners: (target: Set<string>, ids: readonly string[]) => void;
   addDirectProviderOwners: (target: Set<string>, ids: readonly string[]) => void;
+  addMemoryPluginIds: (target: Set<string>) => void;
   addProviderContributionOwners: (target: Set<string>, ids: readonly string[]) => void;
   addShorthandModelOwners: (target: Set<string>, modelIds: readonly string[]) => void;
   canResolveDirectProviderIds: (
@@ -41,6 +43,7 @@ export type InstalledPluginIndexScopeLookup = {
     scopePluginIds: ReadonlySet<string>,
   ) => boolean;
   hasChannelContributionOwners: (ids: readonly string[]) => boolean;
+  hasAgentHarnessOwners: (ids: readonly string[]) => boolean;
   hasCompleteConfigPathActivationMetadata: () => boolean;
   hasDirectChannelOwners: (ids: readonly string[]) => boolean;
   hasInstalledPluginIds: (ids: Iterable<string>) => boolean;
@@ -130,6 +133,7 @@ function modelSupportOwnerMatches(owner: ModelSupportOwner, modelId: string): bo
 }
 
 function buildLookupMaps(index: InstalledPluginIndex): {
+  agentHarnessOwners: OwnerMap;
   channelContributionOwners: OwnerMap;
   directChannelOwners: OwnerMap;
   directProviderOwners: OwnerMap;
@@ -138,6 +142,7 @@ function buildLookupMaps(index: InstalledPluginIndex): {
   pluginIdsByLowercase: ReadonlyMap<string, string>;
   providerContributionOwners: OwnerMap;
 } {
+  const agentHarnessOwners = new Map<string, string[]>();
   const channelContributionOwners = new Map<string, string[]>();
   const directChannelOwners = new Map<string, string[]>();
   const directProviderOwners = new Map<string, string[]>();
@@ -153,6 +158,9 @@ function buildLookupMaps(index: InstalledPluginIndex): {
       appendOwner(directProviderOwners, plugin.pluginId, plugin.pluginId);
       appendOwner(channelContributionOwners, plugin.pluginId, plugin.pluginId);
       appendOwner(providerContributionOwners, plugin.pluginId, plugin.pluginId);
+    }
+    for (const runtimeId of plugin.startup.agentHarnesses) {
+      appendOwner(agentHarnessOwners, runtimeId, plugin.pluginId);
     }
 
     appendOwner(directChannelOwners, plugin.packageChannel?.id, plugin.pluginId);
@@ -187,6 +195,7 @@ function buildLookupMaps(index: InstalledPluginIndex): {
   }
 
   return {
+    agentHarnessOwners: freezeOwnerMap(agentHarnessOwners),
     channelContributionOwners: freezeOwnerMap(channelContributionOwners),
     directChannelOwners: freezeOwnerMap(directChannelOwners),
     directProviderOwners: freezeOwnerMap(directProviderOwners),
@@ -207,10 +216,18 @@ export function createInstalledPluginIndexScopeLookup(
     return lowercase ? (maps.pluginIdsByLowercase.get(lowercase) ?? normalized) : normalized;
   };
   return {
+    addAgentHarnessOwners: (target, ids) => addOwners(target, maps.agentHarnessOwners, ids),
     addChannelContributionOwners: (target, ids) =>
       addOwners(target, maps.channelContributionOwners, ids),
     addDirectChannelOwners: (target, ids) => addOwners(target, maps.directChannelOwners, ids),
     addDirectProviderOwners: (target, ids) => addOwners(target, maps.directProviderOwners, ids),
+    addMemoryPluginIds: (target) => {
+      for (const plugin of index.plugins) {
+        if (plugin.startup.memory) {
+          target.add(plugin.pluginId);
+        }
+      }
+    },
     addProviderContributionOwners: (target, ids) =>
       addOwners(target, maps.providerContributionOwners, ids),
     addShorthandModelOwners: (target, modelIds) => {
@@ -237,6 +254,7 @@ export function createInstalledPluginIndexScopeLookup(
       });
     },
     hasChannelContributionOwners: (ids) => hasOwners(maps.channelContributionOwners, ids),
+    hasAgentHarnessOwners: (ids) => hasOwners(maps.agentHarnessOwners, ids),
     hasCompleteConfigPathActivationMetadata: () =>
       index.plugins.every(
         (plugin) =>


### PR DESCRIPTION
Closes #126195

Related discovery context: #125802, #125834

AI-assisted: yes. The implementation, lifecycle ownership, tests, and live behavior were reviewed by the maintainer.

## What Problem This Solves

Fixes an issue where users running `openclaw infer model run --local` could wait until prepared-runtime publication timed out before any request reached the selected provider. On the reproduced default plugin configuration, local Ollama inference consumed about 5.9 GB RSS and still returned no model result after three minutes.

## Why This Change Was Made

Simple completions already know the intended provider/model before acquiring their immutable prepared runtime, but the acquisition did not carry that selection and defaulted to broad live catalog preparation. This change resolves the tentative model intent first, narrows cold plugin metadata to the selected provider/harness/configured-slot owners, canonicalizes manifest aliases, utility models, shorthand refs, and auth profiles, then publishes a static prepared generation for that exact selection. Full model inventory remains lazy control-plane work.

The repair preserves the generation ownership introduced by #125761 rather than bypassing it. Increasing the timeout, requiring `plugins.allow`, or reverting prepared-generation pinning would mask the lifecycle-owner defect. The selected-runtime metadata scope is provider-agnostic and falls back to unscoped discovery when ownership is incomplete or ambiguous.

Production LOC: +290/-53 (net +237) | Tests: +500/-3. The production growth establishes the reusable selected-runtime metadata ownership boundary across direct providers, contributed providers, shorthand models, non-core harnesses, memory/context slots, and fresh prepared-owner publication; there is no Ollama-specific production branch.

## User Impact

Local and utility-model completions now prepare only the runtime generation they will execute. The reproduced Ollama command reaches the provider and returns `pong` instead of exhausting the publication timeout, while aliases, utility defaults, auth profiles, harness routing, and immutable generation execution remain intact.

## Evidence

- Pre-fix current-main reproduction at `57e5ab7a8799c7425eecdd90d655b3afb74fa89f`: no Ollama request or model result after three minutes; approximately 5.9 GB maximum RSS. A bounded run reported `prepared model runtime publication timed out`.
- Control comparison on the same pre-fix code with `plugins.allow: ["ollama"]`: returned `pong` in 16.6 seconds at approximately 740 MB RSS, isolating broad plugin/runtime preparation as the failure.
- Regression boundary: a real cold selected provider plugin loads, while an unrelated enabled provider runtime remains cold for both direct and manifest-derived utility-model preparation.
- Focused agent/runtime Vitest proof: 314 tests passed, including simple-completion plugin scope and generation, prepared-runtime owner publication, harness load planning, worker cloning, and CLI capability coverage.
- `node scripts/check-changed.mjs -- <changed paths>` passed, including formatting, typecheck, lint, import-cycle, and architecture guards selected for this diff.
- `pnpm build` passed after the final lazy-loading/runtime-boundary changes.
- Real Ollama 0.32.14 live suite with `qwen3:0.6b`: 2 passed, 2 intentionally skipped (`node --import tsx scripts/test-live.mts --no-quiet-live extensions/ollama/ollama.live.test.ts`).
- Final built CLI with isolated state/config: provider `ollama`, model `qwen3:0.6b`, output `pong`, approximately 36 seconds, under 1 GB RSS.
- Fresh branch autoreview through P1: no accepted/actionable findings.

Provenance: clearly introduced by #125761 / `3b3af116728ab5e8fe6a37ed426ff4f164a73cf7` (code author and merger: @steipete, 2026-08-18), which correctly pinned completion workers to one prepared generation but acquired it before carrying the selected runtime intent.
