### PR TITLE
fix(test): keep Control UI changed tests in UI lane

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -3262,7 +3262,7 @@ function classifyTarget(arg: string, cwd: string) {
   if (isUiIsolatedTestFile(relative)) {
     return "uiIsolated";
   }
-  if (isPathAtOrUnder(relative, "ui/src")) {
+  if (isPathAtOrUnder(relative, "ui")) {
     return "ui";
   }
   if (relative.startsWith("src/tui/tui-pty-")) {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2387,6 +2387,19 @@ describe("scripts/test-projects changed-target routing", () => {
     ]);
   });
 
+  it("keeps mixed Control UI root and source changes in the UI lane", () => {
+    const plans = buildVitestRunPlans(["--changed", "origin/main"], process.cwd(), () => [
+      "ui/index.html",
+      "ui/src/components/markdown.test.ts",
+      "ui/src/pages/agents/memory/dreaming.test.ts",
+    ]);
+
+    expect(plans.map((plan) => plan.config)).toEqual([
+      "test/vitest/vitest.ui.config.ts",
+      "test/vitest/vitest.ui-isolated.config.ts",
+    ]);
+  });
+
   it.each([
     ["ui/config/control-ui-chunking.ts", "ui/src/app/control-ui-chunking.test.ts"],
     ["ui/config/control-ui-locales.ts", "ui/src/app/vite-config.node.test.ts"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `pnpm test:changed` on a Control UI-only diff could execute Control UI tests under the unit Vitest configuration when the diff also changed a root UI file such as `ui/index.html`. That produced widespread false failures and zero-test collections, hiding the useful changed-test signal.

## Why This Change Was Made

The changed-test planner already admits every `ui/**` path, so the project classifier now assigns that same complete tree to the Control UI owner while preserving the earlier E2E and isolated-test classifications. A mixed root/source regression protects the full command boundary.

## User Impact

There is no product runtime change. Contributors can rely on Control UI-only diffs staying in the Control UI Vitest lanes instead of spuriously starting the unit lane.

## Evidence

- Before: a diff containing `ui/index.html`, `ui/src/components/markdown.test.ts`, and `ui/src/pages/agents/memory/dreaming.test.ts` started the unit and UI configs; 39 suites failed, including 97/97 markdown tests and 1/45 dreaming tests.
- After: the same mixed diff starts tooling, UI, and UI-isolated only; all selected tests pass and no unit shard starts.
- `node scripts/run-vitest.mjs ui/src/components/markdown.test.ts ui/src/pages/agents/memory/dreaming.test.ts` — 142/142 passed.
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts test/scripts/run-vitest.test.ts` — 375/375 passed.
- `node scripts/check-changed.mjs -- scripts/test-projects.test-support.mts test/scripts/test-projects.test.ts` — passed.
- Fresh autoreview — no actionable findings.

AI-assisted; implementation, root cause, and proof reviewed by the maintainer.
