### PR TITLE
chore(skills): remove scanner cache reset seam

### DIFF
--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -3,14 +3,8 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
-import {
-  clearSkillScanCacheForTest,
-  isScannable,
-  scanDirectoryWithSummary,
-  scanSkillContent,
-  scanSource,
-} from "./scanner.js";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { isScannable, scanDirectoryWithSummary, scanSkillContent, scanSource } from "./scanner.js";
 import type { SkillScanOptions } from "./scanner.js";
 
 // ---------------------------------------------------------------------------
@@ -139,10 +133,6 @@ type SummaryCase = {
     expectedPresent?: boolean;
   };
 };
-
-afterEach(() => {
-  clearSkillScanCacheForTest();
-});
 
 // ---------------------------------------------------------------------------
 // scanSource
@@ -815,7 +805,6 @@ describe("scanDirectoryWithSummary", () => {
             testCase.expected.expectedPresent,
           );
         }
-        clearSkillScanCacheForTest();
       });
     }
   });

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -124,11 +124,6 @@ function setCachedDirEntries(dirPath: string, entry: DirEntryCacheEntry): void {
   DIR_ENTRY_CACHE.set(dirPath, entry);
 }
 
-export function clearSkillScanCacheForTest(): void {
-  FILE_SCAN_CACHE.clear();
-  DIR_ENTRY_CACHE.clear();
-}
-
 // ---------------------------------------------------------------------------
 // Rule definitions
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What Problem This Solves

Resolves a test-maintenance problem where the skill scanner exposed a production cache-reset API solely so tests could clear process-local caches, even though every directory fixture already uses a unique absolute temporary root.

## Why This Change Was Made

Remove the test-only reset export and its redundant test calls. The bounded file and directory caches, 5,000-entry limits, cache keys, and invalidation behavior are unchanged; the explicit same-root cache behavior tests remain.

## User Impact

No user-visible behavior changes. This removes an unnecessary test seam while preserving scanner cache behavior and coverage.

## Evidence

- `node scripts/check-changed.mjs -- src/skills/security/scanner.ts src/skills/security/scanner.test.ts` — passed.
- Fresh Codex autoreview — clean, no accepted/actionable findings.
- `rg -n "clearSkillScanCacheForTest" --glob '!node_modules/**' .` — no matches.
- The scanner owner suite passed twice (42/42 each run) as part of the requested paired command.
- The paired release scan currently exposes an unrelated `origin/main` baseline drift from #125908: `@openclaw/codex` now includes `src/app-server/sandbox-exec-server/sandbox-child.ts:44`, which the reviewed-finding table does not yet list. This PR does not alter that package, test, or baseline.
