### PR TITLE
fix(ui): workspace icons load after dashboard bootstrap

### DIFF
--- a/src/gateway/channel-avatar-http.test.ts
+++ b/src/gateway/channel-avatar-http.test.ts
@@ -7,22 +7,14 @@ import { HTTP_IMAGE_MAX_BYTES } from "./http-image-response.js";
 
 const mocks = vi.hoisted(() => ({
   authorize: vi.fn(),
-  resolveScopes: vi.fn(),
-  authorizeScopes: vi.fn(),
-  resolveIsOwner: vi.fn(),
   loadEntry: vi.fn(),
   resolveReference: vi.fn(),
   readMedia: vi.fn(),
 }));
 
 vi.mock("./http-utils.js", () => ({
-  authorizeGatewayHttpRequestOrReply: (...args: unknown[]) => mocks.authorize(...args),
-  resolveOpenAiCompatibleHttpOperatorScopes: (...args: unknown[]) => mocks.resolveScopes(...args),
-  resolveOpenAiCompatibleHttpSenderIsOwner: (...args: unknown[]) => mocks.resolveIsOwner(...args),
-}));
-
-vi.mock("./method-scopes.js", () => ({
-  authorizeOperatorScopesForMethod: (...args: unknown[]) => mocks.authorizeScopes(...args),
+  authorizeControlUiSessionOwnerReadRequestOrReply: (...args: unknown[]) =>
+    mocks.authorize(...args),
 }));
 
 vi.mock("./session-utils-store.js", () => ({
@@ -89,10 +81,10 @@ describe("handleChannelAvatarHttpRequest", () => {
 
   beforeEach(() => {
     clearChannelAvatarCacheForTest();
-    mocks.authorize.mockReset().mockResolvedValue({ ok: true });
-    mocks.resolveScopes.mockReset().mockReturnValue(["operator.read"]);
-    mocks.authorizeScopes.mockReset().mockReturnValue({ allowed: true });
-    mocks.resolveIsOwner.mockReset().mockReturnValue(true);
+    mocks.authorize.mockReset().mockResolvedValue({
+      authMethod: "token",
+      operatorScopes: ["operator.admin", "operator.read"],
+    });
     mocks.loadEntry.mockReset().mockReturnValue({ entry: avatarEntry() });
     mocks.resolveReference.mockReset().mockResolvedValue({
       id: "channel-avatar.png",
@@ -194,17 +186,14 @@ describe("handleChannelAvatarHttpRequest", () => {
     expect(mocks.resolveReference).not.toHaveBeenCalled();
   });
 
-  it("requires sessions.list scope before resolving the session", async () => {
-    mocks.authorizeScopes.mockReturnValue({ allowed: false, missingScope: "operator.read" });
-
-    const response = await fetch(avatarRoute("agent:main:hidden"));
-
-    expect(response.status).toBe(403);
-    expect(mocks.loadEntry).not.toHaveBeenCalled();
-  });
-
-  it("requires owner access before resolving the session", async () => {
-    mocks.resolveIsOwner.mockReturnValue(false);
+  it("does not resolve the session when the owner-read authorizer denies access", async () => {
+    mocks.authorize.mockImplementation(
+      async (params: { res: { statusCode: number; end: () => void } }) => {
+        params.res.statusCode = 403;
+        params.res.end();
+        return null;
+      },
+    );
 
     const response = await fetch(avatarRoute("agent:main:hidden"));
 

--- a/src/gateway/channel-avatar-http.ts
+++ b/src/gateway/channel-avatar-http.ts
@@ -10,19 +10,14 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import { CONTROL_UI_CHANNEL_AVATAR_PATH_PREFIX } from "./control-ui-contract.js";
 import { respondNotFound } from "./control-ui-http-utils.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
-import { sendJson, sendMethodNotAllowed, sendMissingScopeForbidden } from "./http-common.js";
+import { sendMethodNotAllowed } from "./http-common.js";
 import {
   HTTP_IMAGE_MAX_BYTES,
   resolveHttpImageRepresentation,
   sendHttpImageResponse,
   type HttpImageRepresentation,
 } from "./http-image-response.js";
-import {
-  authorizeGatewayHttpRequestOrReply,
-  resolveOpenAiCompatibleHttpOperatorScopes,
-  resolveOpenAiCompatibleHttpSenderIsOwner,
-} from "./http-utils.js";
-import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
+import { authorizeControlUiSessionOwnerReadRequestOrReply } from "./http-utils.js";
 
 const CHANNEL_AVATAR_CACHE_MAX_ENTRIES = 128;
 
@@ -133,7 +128,7 @@ export async function handleChannelAvatarHttpRequest(
     sendMethodNotAllowed(res, "GET, HEAD");
     return true;
   }
-  const requestAuth = await authorizeGatewayHttpRequestOrReply({
+  const requestAuth = await authorizeControlUiSessionOwnerReadRequestOrReply({
     req,
     res,
     auth: opts.auth,
@@ -142,21 +137,6 @@ export async function handleChannelAvatarHttpRequest(
     rateLimiter: opts.rateLimiter,
   });
   if (!requestAuth) {
-    return true;
-  }
-  const scopeAuth = authorizeOperatorScopesForMethod(
-    "sessions.list",
-    resolveOpenAiCompatibleHttpOperatorScopes(req, requestAuth),
-  );
-  if (!scopeAuth.allowed) {
-    sendMissingScopeForbidden(res, scopeAuth.missingScope);
-    return true;
-  }
-  if (!resolveOpenAiCompatibleHttpSenderIsOwner(req, requestAuth)) {
-    sendJson(res, 403, {
-      ok: false,
-      error: { message: "owner access required", type: "forbidden" },
-    });
     return true;
   }
   if (!parsed.sessionKey) {

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -18,12 +18,9 @@ import {
   readFileDescriptorBounded,
 } from "../infra/boundary-file-read.js";
 import { resolveDevInstallGitBranch } from "../infra/dev-install-branch.js";
-import { verifyDeviceToken } from "../infra/device-pairing-tokens.js";
-import { listDevicePairing } from "../infra/device-pairing.js";
 import { readFileWindowFully } from "../infra/file-read.js";
 import { openLocalFileSafely, FsSafeError } from "../infra/fs-safe.js";
 import { safeFileURLToPath } from "../infra/local-file-access.js";
-import { verifyPairingToken } from "../infra/pairing-token.js";
 import { isWithinDir } from "../infra/path-safety.js";
 import { assertLocalMediaAllowed, getDefaultLocalRootsCore } from "../media/local-media-access.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
@@ -45,12 +42,8 @@ import { resolveRuntimeServiceBuildId, resolveRuntimeServiceVersion } from "../v
 import { openGatewayAssistantAvatar, resolveGatewayAssistantAvatar } from "./assistant-avatar.js";
 import { DEFAULT_ASSISTANT_IDENTITY, resolveAssistantIdentity } from "./assistant-identity.js";
 import { buildAssistantMediaContentDisposition } from "./assistant-media-content-disposition.js";
-import {
-  AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
-  AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
-  type AuthRateLimiter,
-} from "./auth-rate-limit.js";
-import { authorizeHttpGatewayConnect, type ResolvedGatewayAuth } from "./auth.js";
+import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import type { ResolvedGatewayAuth } from "./auth.js";
 import {
   CONTROL_UI_BASE_PATH_ATTRIBUTE,
   CONTROL_UI_BOOTSTRAP_CONFIG_PATH,
@@ -87,20 +80,7 @@ import {
   resolveByteResponse,
   writeByteHeaders,
 } from "./http-byte-range.js";
-import { buildMissingScopeForbiddenBody, sendGatewayAuthFailure } from "./http-common.js";
-import {
-  getBearerToken,
-  resolveHttpBrowserOriginPolicy,
-  resolveTrustedHttpOperatorScopes,
-  setControlUiPluginAuthCookieForRequest as setPluginAuthCookie,
-} from "./http-utils.js";
-import {
-  prepareGatewayIngressAttribution,
-  PROXY_ATTRIBUTION_REQUIRED_REASON,
-} from "./ingress-attribution.js";
-import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
-import { withSerializedCredentialFallbackAttempt } from "./rate-limit-attempt-serialization.js";
-import { resolveSharedGatewaySessionGeneration } from "./server/ws-shared-generation.js";
+import { authorizeControlUiReadRequestOrReply } from "./http-utils.js";
 import { isTerminalConfigEnabled } from "./terminal/enabled.js";
 
 const ROOT_PREFIX = "/";
@@ -109,8 +89,6 @@ const CONTROL_UI_ASSISTANT_MEDIA_TICKET_SCOPE = "assistant-media";
 const CONTROL_UI_ASSISTANT_MEDIA_TICKET_TTL_MS = 5 * 60 * 1000;
 const CONTROL_UI_ASSETS_MISSING_MESSAGE =
   "Control UI assets not found. Build them with `pnpm ui:build` (auto-installs UI deps), or run `pnpm ui:dev` during development.";
-const CONTROL_UI_OPERATOR_READ_SCOPE = "operator.read";
-const CONTROL_UI_OPERATOR_ROLE = "operator";
 const controlUiAssistantMediaTicketSecret = randomBytes(32);
 
 type ControlUiRequestOptions = {
@@ -259,238 +237,6 @@ function resolveAssistantMediaRoutePath(basePath?: string): string {
   const normalizedBasePath =
     basePath && basePath !== "/" ? (basePath.endsWith("/") ? basePath.slice(0, -1) : basePath) : "";
   return `${normalizedBasePath}${CONTROL_UI_ASSISTANT_MEDIA_PREFIX}`;
-}
-
-function resolveAssistantMediaAuthToken(req: IncomingMessage): string | undefined {
-  const bearer = getBearerToken(req);
-  if (bearer) {
-    return bearer;
-  }
-  const urlRaw = req.url;
-  if (!urlRaw) {
-    return undefined;
-  }
-  try {
-    const url = new URL(urlRaw, "http://localhost");
-    const token = url.searchParams.get("token")?.trim();
-    return token || undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function resolveControlUiReadAuthToken(
-  req: IncomingMessage,
-  opts?: { allowQueryToken?: boolean },
-): string | undefined {
-  const bearer = getBearerToken(req);
-  if (bearer) {
-    return bearer;
-  }
-  if (!opts?.allowQueryToken) {
-    return undefined;
-  }
-  return resolveAssistantMediaAuthToken(req);
-}
-
-type ControlUiReadAuthOptions = {
-  auth?: ResolvedGatewayAuth;
-  trustedProxies?: string[];
-  allowRealIpFallback?: boolean;
-  rateLimiter?: AuthRateLimiter;
-  allowQueryToken?: boolean;
-  requiredOperatorMethod?: string;
-  onPluginFrameGrants?: (grants: readonly ControlUiPluginFrameGrantAck[]) => void;
-};
-
-async function authorizeControlUiReadRequest(
-  req: IncomingMessage,
-  res: ServerResponse,
-  opts?: ControlUiReadAuthOptions,
-): Promise<boolean> {
-  if (!opts?.auth) {
-    opts?.onPluginFrameGrants?.([]);
-    return true;
-  }
-  const authOpts = { ...opts, auth: opts.auth };
-
-  const queryTokenPolicy = opts.allowQueryToken;
-  const token = resolveControlUiReadAuthToken(req, { allowQueryToken: queryTokenPolicy });
-  const ingressAttribution = prepareGatewayIngressAttribution({
-    req,
-    trustedProxies: opts.trustedProxies,
-    allowRealIpFallback: opts.allowRealIpFallback,
-  });
-  if (ingressAttribution.kind === "unattributable-proxy") {
-    sendGatewayAuthFailure(res, { ok: false, reason: ingressAttribution.reason });
-    return false;
-  }
-  const clientIp = ingressAttribution.rateLimit.subject.key;
-  const canUseDeviceTokenFallback =
-    Boolean(token) && authOpts.auth.mode !== "trusted-proxy" && authOpts.auth.mode !== "none";
-  const run = async () =>
-    await authorizeControlUiReadRequestCore(req, res, authOpts, {
-      token,
-      clientIp,
-      canUseDeviceTokenFallback,
-    });
-  if (!canUseDeviceTokenFallback || !authOpts.rateLimiter) {
-    return await run();
-  }
-  // Shared and device credentials form one terminal auth attempt. Keep their
-  // async checks together so concurrent fallbacks cannot outrun either bucket.
-  return await withSerializedCredentialFallbackAttempt({
-    limiter: authOpts.rateLimiter,
-    ip: clientIp,
-    run,
-  });
-}
-
-async function authorizeControlUiReadRequestCore(
-  req: IncomingMessage,
-  res: ServerResponse,
-  opts: ControlUiReadAuthOptions & { auth: ResolvedGatewayAuth },
-  prepared: {
-    token: string | undefined;
-    clientIp: string | undefined;
-    canUseDeviceTokenFallback: boolean;
-  },
-): Promise<boolean> {
-  const { token, clientIp, canUseDeviceTokenFallback } = prepared;
-  const authResult = await authorizeHttpGatewayConnect({
-    auth: opts.auth,
-    connectAuth: token ? { token, password: token } : null,
-    req,
-    browserOriginPolicy: resolveHttpBrowserOriginPolicy(req),
-    trustedProxies: opts.trustedProxies,
-    allowRealIpFallback: opts.allowRealIpFallback,
-    rateLimiter: token ? opts.rateLimiter : undefined,
-    clientIp,
-    rateLimitScope: AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
-    deferRateLimitFailure: canUseDeviceTokenFallback,
-  });
-  const sharedAuthGeneration = resolveSharedGatewaySessionGeneration(
-    opts.auth,
-    opts.trustedProxies,
-  );
-  let resolvedAuthResult = authResult;
-  let verifiedDeviceScopes: string[] | undefined;
-  if (
-    !resolvedAuthResult.ok &&
-    resolvedAuthResult.reason !== PROXY_ATTRIBUTION_REQUIRED_REASON &&
-    canUseDeviceTokenFallback &&
-    token
-  ) {
-    const recordDeferredSharedSecretFailure = async () => {
-      if (authResult.reason === "token_mismatch" || authResult.reason === "password_mismatch") {
-        await opts.rateLimiter?.recordFailureAndDelay(
-          clientIp,
-          AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
-        );
-      }
-    };
-    const deviceRateCheck = opts.rateLimiter?.check(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
-    if (deviceRateCheck && !deviceRateCheck.allowed) {
-      await recordDeferredSharedSecretFailure();
-      resolvedAuthResult = {
-        ok: false,
-        reason: "rate_limited",
-        rateLimited: true,
-        retryAfterMs: deviceRateCheck.retryAfterMs,
-      };
-    } else {
-      const deviceTokenOk = await authorizeControlUiDeviceReadToken(token, sharedAuthGeneration);
-      const deviceScopes = deviceTokenOk
-        ? await resolveControlUiDeviceReadTokenScopes(token)
-        : null;
-      if (deviceScopes) {
-        verifiedDeviceScopes = deviceScopes;
-        opts.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
-        resolvedAuthResult = { ok: true, method: "device-token" };
-      } else {
-        await recordDeferredSharedSecretFailure();
-        await opts.rateLimiter?.recordFailureAndDelay(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
-      }
-    }
-  }
-  if (!resolvedAuthResult.ok) {
-    sendGatewayAuthFailure(res, resolvedAuthResult);
-    return false;
-  }
-
-  const authMethod = resolvedAuthResult.method;
-  const trustDeclaredOperatorScopes = authMethod === "trusted-proxy" || authMethod === "tailscale";
-  if (opts.onPluginFrameGrants) {
-    opts.onPluginFrameGrants(
-      setPluginAuthCookie(
-        req,
-        res,
-        authMethod,
-        trustDeclaredOperatorScopes,
-        sharedAuthGeneration,
-        verifiedDeviceScopes,
-      ),
-    );
-  }
-  if (!trustDeclaredOperatorScopes) {
-    return true;
-  }
-
-  const requestedScopes = resolveTrustedHttpOperatorScopes(req, {
-    trustDeclaredOperatorScopes,
-  });
-  const scopeAuth = authorizeOperatorScopesForMethod(
-    opts.requiredOperatorMethod ?? "assistant.media.get",
-    requestedScopes,
-  );
-  if (!scopeAuth.allowed) {
-    sendJson(res, 403, buildMissingScopeForbiddenBody(scopeAuth.missingScope));
-    return false;
-  }
-
-  return true;
-}
-
-async function authorizeControlUiDeviceReadToken(
-  token: string,
-  requiredSharedGatewaySessionGeneration: string | undefined,
-): Promise<boolean> {
-  const pairing = await listDevicePairing();
-  for (const device of pairing.paired) {
-    const operatorToken = device.tokens?.[CONTROL_UI_OPERATOR_ROLE];
-    if (!operatorToken || operatorToken.revokedAtMs) {
-      continue;
-    }
-    if (!verifyPairingToken(token, operatorToken.token)) {
-      continue;
-    }
-    const verified = await verifyDeviceToken({
-      deviceId: device.deviceId,
-      token,
-      role: CONTROL_UI_OPERATOR_ROLE,
-      scopes: [CONTROL_UI_OPERATOR_READ_SCOPE],
-      requiredSharedGatewaySessionGeneration,
-    });
-    if (verified.ok) {
-      return true;
-    }
-  }
-  return false;
-}
-
-async function resolveControlUiDeviceReadTokenScopes(token: string): Promise<string[] | null> {
-  const pairing = await listDevicePairing();
-  for (const device of pairing.paired) {
-    const operatorBearer = device.tokens?.[CONTROL_UI_OPERATOR_ROLE];
-    if (
-      operatorBearer &&
-      !operatorBearer.revokedAtMs &&
-      verifyPairingToken(token, operatorBearer.token)
-    ) {
-      return operatorBearer.scopes;
-    }
-  }
-  return null;
 }
 
 type AssistantMediaAvailability =
@@ -710,7 +456,9 @@ export async function handleControlUiAssistantMediaRequest(
     !isMetaRequest && verifyAssistantMediaTicket(url.searchParams.get("mediaTicket"), source);
   if (
     !hasValidMediaTicket &&
-    !(await authorizeControlUiReadRequest(req, res, {
+    !(await authorizeControlUiReadRequestOrReply({
+      req,
+      res,
       auth: opts?.auth,
       trustedProxies: opts?.trustedProxies,
       allowRealIpFallback: opts?.allowRealIpFallback,
@@ -845,7 +593,9 @@ export async function handleControlUiAvatarRequest(
   }
 
   if (
-    !(await authorizeControlUiReadRequest(req, res, {
+    !(await authorizeControlUiReadRequestOrReply({
+      req,
+      res,
       auth: opts.auth,
       trustedProxies: opts.trustedProxies,
       allowRealIpFallback: opts.allowRealIpFallback,
@@ -1094,7 +844,9 @@ export async function handleControlUiHttpRequest(
   if (matchesControlUiBootstrapConfigPath(pathname, basePath)) {
     let pluginFrameGrants: readonly ControlUiPluginFrameGrantAck[] = [];
     if (
-      !(await authorizeControlUiReadRequest(req, res, {
+      !(await authorizeControlUiReadRequestOrReply({
+        req,
+        res,
         auth: opts?.auth,
         trustedProxies: opts?.trustedProxies,
         allowRealIpFallback: opts?.allowRealIpFallback,

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -7,13 +7,21 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { getRuntimeConfig } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { verifyDeviceToken } from "../infra/device-pairing-tokens.js";
+import { listDevicePairing } from "../infra/device-pairing.js";
+import { verifyPairingToken } from "../infra/pairing-token.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
+import {
+  AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+  AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+} from "./auth-rate-limit.js";
 import {
   authorizeHttpGatewayConnect,
   authorizeUserProfileAvatarHttpGatewayConnect,
   type GatewayAuthResult,
   type ResolvedGatewayAuth,
 } from "./auth.js";
+import type { ControlUiPluginFrameGrantAck } from "./control-ui-contract.js";
 import {
   resolveControlUiPluginAuthCookieGrants,
   setControlUiPluginAuthCookie,
@@ -22,14 +30,22 @@ import {
   listControlUiPluginTabAuthGrants,
   type ControlUiPluginTabAuthGrant,
 } from "./control-ui-plugin-tabs.js";
-import { sendGatewayAuthFailure, sendMissingScopeForbidden } from "./http-common.js";
+import { sendGatewayAuthFailure, sendJson, sendMissingScopeForbidden } from "./http-common.js";
+import {
+  prepareGatewayIngressAttribution,
+  PROXY_ATTRIBUTION_REQUIRED_REASON,
+} from "./ingress-attribution.js";
 import {
   ADMIN_SCOPE,
   CLI_DEFAULT_OPERATOR_SCOPES,
   authorizeOperatorScopesForMethod,
 } from "./method-scopes.js";
 import { resolveBrowserOriginPolicy } from "./origin-check.js";
+import { withSerializedCredentialFallbackAttempt } from "./rate-limit-attempt-serialization.js";
 import { resolveSharedGatewaySessionGeneration } from "./server/ws-shared-generation.js";
+
+const CONTROL_UI_OPERATOR_READ_SCOPE = "operator.read";
+const CONTROL_UI_OPERATOR_ROLE = "operator";
 
 export function getHeader(req: IncomingMessage, name: string): string | undefined {
   const raw = req.headers[normalizeLowercaseStringOrEmpty(name)];
@@ -88,6 +104,18 @@ type GatewayHttpConnectAuthorizer = (
   params: Parameters<typeof authorizeHttpGatewayConnect>[0],
 ) => Promise<GatewayAuthResult>;
 
+export type AuthorizedControlUiReadRequest = {
+  authMethod: NonNullable<GatewayAuthResult["method"]>;
+  operatorScopes: string[];
+};
+
+type ControlUiReadAuthParams = Omit<GatewayHttpRequestAuthParams, "auth"> & {
+  auth?: ResolvedGatewayAuth;
+  allowQueryToken?: boolean;
+  requiredOperatorMethod?: string;
+  onPluginFrameGrants?: (grants: readonly ControlUiPluginFrameGrantAck[]) => void;
+};
+
 export function resolveHttpBrowserOriginPolicy(
   req: IncomingMessage,
   cfg = getRuntimeConfig(),
@@ -114,6 +142,204 @@ function shouldTrustDeclaredHttpOperatorScopes(
     return authOrRequest.trustDeclaredOperatorScopes;
   }
   return !isGatewayBearerHttpRequest(req, authOrRequest);
+}
+
+function resolveControlUiReadAuthToken(
+  req: IncomingMessage,
+  allowQueryToken: boolean | undefined,
+): string | undefined {
+  const bearer = getBearerToken(req);
+  if (bearer || !allowQueryToken || !req.url) {
+    return bearer;
+  }
+  try {
+    return normalizeOptionalString(new URL(req.url, "http://localhost").searchParams.get("token"));
+  } catch {
+    return undefined;
+  }
+}
+
+async function verifyControlUiDeviceReadToken(
+  token: string,
+  requiredSharedGatewaySessionGeneration: string | undefined,
+): Promise<string[] | null> {
+  const pairing = await listDevicePairing();
+  for (const device of pairing.paired) {
+    const operatorToken = device.tokens?.[CONTROL_UI_OPERATOR_ROLE];
+    if (
+      !operatorToken ||
+      operatorToken.revokedAtMs ||
+      !verifyPairingToken(token, operatorToken.token)
+    ) {
+      continue;
+    }
+    const verified = await verifyDeviceToken({
+      deviceId: device.deviceId,
+      token,
+      role: CONTROL_UI_OPERATOR_ROLE,
+      scopes: [CONTROL_UI_OPERATOR_READ_SCOPE],
+      requiredSharedGatewaySessionGeneration,
+    });
+    return verified.ok ? [...operatorToken.scopes] : null;
+  }
+  return null;
+}
+
+function resolveControlUiReadOperatorScopes(
+  req: IncomingMessage,
+  authMethod: NonNullable<GatewayAuthResult["method"]>,
+  deviceScopes: string[] | undefined,
+): string[] {
+  if (authMethod === "device-token") {
+    return deviceScopes ?? [];
+  }
+  if (authMethod === "trusted-proxy" || authMethod === "tailscale") {
+    return resolveTrustedHttpOperatorScopes(req, { trustDeclaredOperatorScopes: true });
+  }
+  return authMethod === "bootstrap-token" ? [] : [...CLI_DEFAULT_OPERATOR_SCOPES];
+}
+
+/** Authorize a read-only same-origin Control UI request, including paired devices. */
+export async function authorizeControlUiReadRequestOrReply(
+  params: ControlUiReadAuthParams,
+): Promise<AuthorizedControlUiReadRequest | null> {
+  const auth = params.auth;
+  if (!auth) {
+    params.onPluginFrameGrants?.([]);
+    return { authMethod: "none", operatorScopes: [...CLI_DEFAULT_OPERATOR_SCOPES] };
+  }
+
+  const token = resolveControlUiReadAuthToken(params.req, params.allowQueryToken);
+  const ingressAttribution = prepareGatewayIngressAttribution({
+    req: params.req,
+    trustedProxies: params.trustedProxies,
+    allowRealIpFallback: params.allowRealIpFallback,
+  });
+  if (ingressAttribution.kind === "unattributable-proxy") {
+    sendGatewayAuthFailure(params.res, { ok: false, reason: ingressAttribution.reason });
+    return null;
+  }
+  const clientIp = ingressAttribution.rateLimit.subject.key;
+  const canUseDeviceTokenFallback =
+    Boolean(token) && auth.mode !== "trusted-proxy" && auth.mode !== "none";
+  const run = async (): Promise<AuthorizedControlUiReadRequest | null> => {
+    const authResult = await authorizeHttpGatewayConnect({
+      auth,
+      connectAuth: token ? { token, password: token } : null,
+      req: params.req,
+      browserOriginPolicy: resolveHttpBrowserOriginPolicy(params.req),
+      trustedProxies: params.trustedProxies,
+      allowRealIpFallback: params.allowRealIpFallback,
+      rateLimiter: token ? params.rateLimiter : undefined,
+      clientIp,
+      rateLimitScope: AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+      deferRateLimitFailure: canUseDeviceTokenFallback,
+    });
+    const authGeneration = resolveSharedGatewaySessionGeneration(auth, params.trustedProxies);
+    let resolvedAuthResult = authResult;
+    let deviceScopes: string[] | undefined;
+    if (
+      !authResult.ok &&
+      authResult.reason !== PROXY_ATTRIBUTION_REQUIRED_REASON &&
+      canUseDeviceTokenFallback &&
+      token
+    ) {
+      const recordSharedSecretFailure = async () => {
+        if (authResult.reason === "token_mismatch" || authResult.reason === "password_mismatch") {
+          await params.rateLimiter?.recordFailureAndDelay(
+            clientIp,
+            AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET,
+          );
+        }
+      };
+      const deviceRateCheck = params.rateLimiter?.check(
+        clientIp,
+        AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+      );
+      if (deviceRateCheck && !deviceRateCheck.allowed) {
+        await recordSharedSecretFailure();
+        resolvedAuthResult = {
+          ok: false,
+          reason: "rate_limited",
+          rateLimited: true,
+          retryAfterMs: deviceRateCheck.retryAfterMs,
+        };
+      } else {
+        const verifiedScopes = await verifyControlUiDeviceReadToken(token, authGeneration);
+        if (verifiedScopes) {
+          deviceScopes = verifiedScopes;
+          params.rateLimiter?.reset(clientIp, AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN);
+          resolvedAuthResult = { ok: true, method: "device-token" };
+        } else {
+          await recordSharedSecretFailure();
+          await params.rateLimiter?.recordFailureAndDelay(
+            clientIp,
+            AUTH_RATE_LIMIT_SCOPE_DEVICE_TOKEN,
+          );
+        }
+      }
+    }
+    if (!resolvedAuthResult.ok) {
+      sendGatewayAuthFailure(params.res, resolvedAuthResult);
+      return null;
+    }
+
+    const authMethod = resolvedAuthResult.method ?? "none";
+    const trustDeclaredOperatorScopes =
+      authMethod === "trusted-proxy" || authMethod === "tailscale";
+    params.onPluginFrameGrants?.(
+      setControlUiPluginAuthCookieForRequest(
+        params.req,
+        params.res,
+        authMethod,
+        trustDeclaredOperatorScopes,
+        authGeneration,
+        deviceScopes,
+      ),
+    );
+    const operatorScopes = resolveControlUiReadOperatorScopes(params.req, authMethod, deviceScopes);
+    const scopeAuth = authorizeOperatorScopesForMethod(
+      params.requiredOperatorMethod ?? "assistant.media.get",
+      operatorScopes,
+    );
+    if (!scopeAuth.allowed) {
+      sendMissingScopeForbidden(params.res, scopeAuth.missingScope);
+      return null;
+    }
+    return { authMethod, operatorScopes };
+  };
+
+  if (!canUseDeviceTokenFallback || !params.rateLimiter) {
+    return await run();
+  }
+  // Shared and device credentials form one terminal auth attempt. Keep their
+  // async checks together so concurrent fallbacks cannot outrun either bucket.
+  return await withSerializedCredentialFallbackAttempt({
+    limiter: params.rateLimiter,
+    ip: clientIp,
+    run,
+  });
+}
+
+/**
+ * Session byte routes cannot apply the client-specific `sessions.list` filter.
+ * Require its read scope plus admin, whose owner view is not narrowed by that filter.
+ */
+export async function authorizeControlUiSessionOwnerReadRequestOrReply(
+  params: Omit<ControlUiReadAuthParams, "allowQueryToken" | "requiredOperatorMethod">,
+): Promise<AuthorizedControlUiReadRequest | null> {
+  const requestAuth = await authorizeControlUiReadRequestOrReply({
+    ...params,
+    requiredOperatorMethod: "sessions.list",
+  });
+  if (!requestAuth || requestAuth.operatorScopes.includes(ADMIN_SCOPE)) {
+    return requestAuth;
+  }
+  sendJson(params.res, 403, {
+    ok: false,
+    error: { message: "owner access required", type: "forbidden" },
+  });
+  return null;
 }
 
 export async function authorizeGatewayHttpRequestOrReply(params: {

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -10,12 +10,12 @@ import {
 } from "../infra/diagnostic-events.js";
 import type { GatewayAuthResult } from "./auth.js";
 import {
-  buildMissingScopeForbiddenBody,
   readJsonBodyOrError,
   sendGatewayAuthFailure,
   sendInvalidRequest,
   sendJson,
   sendMethodNotAllowed,
+  sendMissingScopeForbidden,
   sendRateLimited,
   sendUnauthorized,
   setDefaultSecurityHeaders,
@@ -123,15 +123,20 @@ describe("sendJson", () => {
   });
 });
 
-describe("buildMissingScopeForbiddenBody", () => {
+describe("sendMissingScopeForbidden", () => {
   it("preserves the legacy response when no concrete scope is available", () => {
-    expect(buildMissingScopeForbiddenBody(undefined)).toEqual({
-      ok: false,
-      error: {
-        type: "forbidden",
-        message: "missing scope: undefined",
-      },
-    });
+    const { res, end } = makeMockHttpResponse();
+    sendMissingScopeForbidden(res, undefined);
+    expect(res.statusCode).toBe(403);
+    expect(end).toHaveBeenCalledWith(
+      JSON.stringify({
+        ok: false,
+        error: {
+          type: "forbidden",
+          message: "missing scope: undefined",
+        },
+      }),
+    );
   });
 });
 

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -105,7 +105,7 @@ export function sendInvalidRequest(res: ServerResponse, message: string) {
   });
 }
 
-export function buildMissingScopeForbiddenBody(
+function buildMissingScopeForbiddenBody(
   missingScope: string | undefined,
   requiredScopes?: readonly string[],
 ) {

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -35,6 +35,8 @@ import { loadGatewayModelCatalog } from "./server-model-catalog.js";
 import { canonicalizeSessionKeyForAgent } from "./session-store-key.js";
 
 export {
+  authorizeControlUiReadRequestOrReply,
+  authorizeControlUiSessionOwnerReadRequestOrReply,
   authorizeOpenAiCompatibleHttpModelOverride,
   authorizeGatewayHttpRequestOrReply,
   authorizeScopedGatewayHttpRequestOrReply,
@@ -42,12 +44,10 @@ export {
   checkGatewayHttpRequestAuth,
   getBearerToken,
   getHeader,
-  resolveHttpBrowserOriginPolicy,
   resolveOpenAiCompatibleHttpOperatorScopes,
   resolveOpenAiCompatibleHttpSenderIsOwner,
   resolveSharedSecretHttpOperatorScopes,
   resolveTrustedHttpOperatorScopes,
-  setControlUiPluginAuthCookieForRequest,
   type AuthorizedGatewayHttpRequest,
 } from "./http-auth-utils.js";
 

--- a/src/gateway/plugin-icon-http.test.ts
+++ b/src/gateway/plugin-icon-http.test.ts
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./http-utils.js", () => ({
-  authorizeGatewayHttpRequestOrReply: (...args: unknown[]) => mocks.authorize(...args),
+  authorizeControlUiReadRequestOrReply: (...args: unknown[]) => mocks.authorize(...args),
 }));
 
 vi.mock("../media/fetch.js", () => ({
@@ -109,7 +109,7 @@ beforeEach(() => {
   mocks.authorize.mockReset();
   mocks.authorize.mockResolvedValue({
     authMethod: "token",
-    trustDeclaredOperatorScopes: false,
+    operatorScopes: ["operator.admin", "operator.read"],
   });
   mocks.resolveIconUrl.mockResolvedValue("https://cdn.example.test/plugin.svg");
   mocks.resolveCatalogIconUrl.mockImplementation(({ iconUrl }) => iconUrl);

--- a/src/gateway/plugin-icon-http.ts
+++ b/src/gateway/plugin-icon-http.ts
@@ -26,7 +26,7 @@ import {
 } from "./control-ui-contract.js";
 import { respondNotFound as sendNotFound } from "./control-ui-http-utils.js";
 import { sendMethodNotAllowed } from "./http-common.js";
-import { authorizeGatewayHttpRequestOrReply } from "./http-utils.js";
+import { authorizeControlUiReadRequestOrReply } from "./http-utils.js";
 
 const PLUGIN_ID_RE =
   /^(?:[a-z0-9][a-z0-9._-]{0,127}|@[a-z0-9][a-z0-9._-]{0,63}\/[a-z0-9][a-z0-9._-]{0,127})$/iu;
@@ -333,7 +333,7 @@ export async function handlePluginIconHttpRequest(
     sendMethodNotAllowed(res, "GET, HEAD");
     return true;
   }
-  const requestAuth = await authorizeGatewayHttpRequestOrReply({
+  const requestAuth = await authorizeControlUiReadRequestOrReply({
     req,
     res,
     auth: opts.auth,

--- a/src/gateway/server.auth.control-ui.owner-bootstrap.suite.ts
+++ b/src/gateway/server.auth.control-ui.owner-bootstrap.suite.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { expect, test } from "vitest";
 import {
   createOperatorIdentityFixture,
@@ -13,6 +15,7 @@ import {
   rpcReq,
   testState,
 } from "./server.auth.test-helpers.js";
+import { writeSessionStore } from "./test-helpers.js";
 
 export function registerControlUiOwnerBootstrapSuite(): void {
   test("silently approves host-authorized control ui owner bootstrap tokens", async () => {
@@ -23,6 +26,34 @@ export function registerControlUiOwnerBootstrapSuite(): void {
       await import("../shared/device-bootstrap-profile.js");
     const { resolveSharedGatewaySessionGeneration } =
       await import("./server/ws-shared-generation.js");
+    const { prepareSessionWorkspaceIcon } = await import("./workspace-icon-http.js");
+    const { mutateConfigFile } = await import("../config/config.js");
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("OPENCLAW_STATE_DIR must be set by the gateway test hooks");
+    }
+    const workspace = path.join(stateDir, "owner-icon-workspace");
+    await fs.mkdir(workspace, { recursive: true });
+    const icon = Buffer.from(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"><path d="M0 0h1v1H0z"/></svg>',
+    );
+    await fs.writeFile(path.join(workspace, "favicon.svg"), icon);
+    await mutateConfigFile({
+      mutate(config) {
+        config.agents = {
+          ...config.agents,
+          defaults: { ...config.agents?.defaults, workspace },
+        };
+      },
+      afterWrite: { mode: "auto" },
+    });
+    const sessionKey = "agent:main:owner-icon";
+    testState.sessionStorePath = path.join(stateDir, "sessions.sqlite");
+    await writeSessionStore({
+      entries: {
+        [sessionKey]: { sessionId: "owner-icon-session", updatedAt: Date.now() },
+      },
+    });
     testState.gatewayControlUi = { allowedOrigins: ["https://localhost"] };
     const { server, port, prevToken } = await startProxiedControlUiServer("secret");
 
@@ -69,6 +100,14 @@ export function registerControlUiOwnerBootstrapSuite(): void {
       expect(recoveryScope).toMatch(/^[A-Za-z0-9_-]+$/u);
       expect((await rpcReq(wsBootstrap, "set-heartbeats", { enabled: false })).ok).toBe(true);
       wsBootstrap.close();
+
+      await prepareSessionWorkspaceIcon({ sessionKey });
+      const iconResponse = await fetch(
+        `http://127.0.0.1:${port}/__openclaw__/workspace-icon/${encodeURIComponent(sessionKey)}`,
+        { headers: { Authorization: `Bearer ${deviceToken}` } },
+      );
+      expect(iconResponse.status).toBe(200);
+      expect(Buffer.from(await iconResponse.arrayBuffer())).toEqual(icon);
 
       const pending = (await listDevicePairing()).pending.filter(
         (entry) => entry.deviceId === identity.deviceId,

--- a/src/gateway/workspace-icon-http.test.ts
+++ b/src/gateway/workspace-icon-http.test.ts
@@ -9,20 +9,12 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 
 const mocks = vi.hoisted(() => ({
   authorize: vi.fn(),
-  resolveScopes: vi.fn(),
-  authorizeScopes: vi.fn(),
-  resolveIsOwner: vi.fn(),
   resolveLocalSessionWorkspaceRoot: vi.fn(),
 }));
 
 vi.mock("./http-utils.js", () => ({
-  authorizeGatewayHttpRequestOrReply: (...args: unknown[]) => mocks.authorize(...args),
-  resolveOpenAiCompatibleHttpOperatorScopes: (...args: unknown[]) => mocks.resolveScopes(...args),
-  resolveOpenAiCompatibleHttpSenderIsOwner: (...args: unknown[]) => mocks.resolveIsOwner(...args),
-}));
-
-vi.mock("./method-scopes.js", () => ({
-  authorizeOperatorScopesForMethod: (...args: unknown[]) => mocks.authorizeScopes(...args),
+  authorizeControlUiSessionOwnerReadRequestOrReply: (...args: unknown[]) =>
+    mocks.authorize(...args),
 }));
 
 vi.mock("./server-methods/sessions-files.js", () => ({
@@ -214,10 +206,10 @@ describe("handleWorkspaceIconHttpRequest", () => {
   });
 
   beforeEach(() => {
-    mocks.authorize.mockReset().mockResolvedValue({ ok: true });
-    mocks.resolveScopes.mockReset().mockReturnValue(["operator.read"]);
-    mocks.authorizeScopes.mockReset().mockReturnValue({ allowed: true });
-    mocks.resolveIsOwner.mockReset().mockReturnValue(true);
+    mocks.authorize.mockReset().mockResolvedValue({
+      authMethod: "token",
+      operatorScopes: ["operator.admin", "operator.read"],
+    });
     mocks.resolveLocalSessionWorkspaceRoot.mockReset().mockReturnValue(undefined);
   });
 
@@ -386,11 +378,17 @@ describe("handleWorkspaceIconHttpRequest", () => {
     expect(mocks.resolveLocalSessionWorkspaceRoot).not.toHaveBeenCalled();
   });
 
-  it("never reads a workspace for a caller without owner access", async () => {
+  it("never reads a workspace when the owner-read authorizer denies access", async () => {
     // `sessions.list` hides incognito and non-owner draft sessions per client.
     // Without that filter here, the read scope alone would let a caller who
     // knows such a key pull bytes derived from a session it cannot list.
-    mocks.resolveIsOwner.mockReturnValue(false);
+    mocks.authorize.mockImplementation(
+      async (params: { res: { statusCode: number; end: () => void } }) => {
+        params.res.statusCode = 403;
+        params.res.end();
+        return null;
+      },
+    );
     const response = await fetch(iconRoute("agent:main:hidden"));
     expect(response.status).toBe(403);
     expect(mocks.resolveLocalSessionWorkspaceRoot).not.toHaveBeenCalled();
@@ -404,13 +402,5 @@ describe("handleWorkspaceIconHttpRequest", () => {
     const response = await fetch(iconRoute("agent:main:remote"));
     expect(response.status).toBe(404);
     expect(response.headers.get("cache-control")).toBe("no-store");
-  });
-
-  it("never reads a workspace for a caller missing the session read scope", async () => {
-    mocks.authorizeScopes.mockReturnValue({ allowed: false, missingScope: "operator.read" });
-    const response = await fetch(iconRoute("agent:main:one"));
-    expect(response.status).toBe(403);
-    expect(mocks.authorizeScopes).toHaveBeenCalledWith("sessions.list", ["operator.read"]);
-    expect(mocks.resolveLocalSessionWorkspaceRoot).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/workspace-icon-http.ts
+++ b/src/gateway/workspace-icon-http.ts
@@ -15,7 +15,7 @@ import type { ResolvedGatewayAuth } from "./auth.js";
 import { CONTROL_UI_WORKSPACE_ICON_PATH_PREFIX } from "./control-ui-contract.js";
 import { respondNotFound } from "./control-ui-http-utils.js";
 import { normalizeControlUiBasePath } from "./control-ui-shared.js";
-import { sendJson, sendMethodNotAllowed, sendMissingScopeForbidden } from "./http-common.js";
+import { sendMethodNotAllowed } from "./http-common.js";
 import {
   HTTP_IMAGE_MAX_BYTES,
   HTTP_SVG_MAX_BYTES,
@@ -23,12 +23,7 @@ import {
   sendHttpImageResponse,
   type HttpImageRepresentation,
 } from "./http-image-response.js";
-import {
-  authorizeGatewayHttpRequestOrReply,
-  resolveOpenAiCompatibleHttpOperatorScopes,
-  resolveOpenAiCompatibleHttpSenderIsOwner,
-} from "./http-utils.js";
-import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
+import { authorizeControlUiSessionOwnerReadRequestOrReply } from "./http-utils.js";
 
 /**
  * Conventional project icon locations in deterministic product precedence.
@@ -229,7 +224,7 @@ export async function handleWorkspaceIconHttpRequest(
     sendMethodNotAllowed(res, "GET, HEAD");
     return true;
   }
-  const requestAuth = await authorizeGatewayHttpRequestOrReply({
+  const requestAuth = await authorizeControlUiSessionOwnerReadRequestOrReply({
     req,
     res,
     auth: opts.auth,
@@ -238,26 +233,6 @@ export async function handleWorkspaceIconHttpRequest(
     rateLimiter: opts.rateLimiter,
   });
   if (!requestAuth) {
-    return true;
-  }
-  const scopeAuth = authorizeOperatorScopesForMethod(
-    "sessions.list",
-    resolveOpenAiCompatibleHttpOperatorScopes(req, requestAuth),
-  );
-  if (!scopeAuth.allowed) {
-    sendMissingScopeForbidden(res, scopeAuth.missingScope);
-    return true;
-  }
-  // The read scope alone is not the session's visibility decision: `sessions.list`
-  // additionally hides incognito and non-owner draft sessions per client
-  // (createSessionListEntryFilter). This route has no Gateway client to run that
-  // filter against, so it takes the same owner gate the managed-media route uses
-  // for session-scoped bytes — the identity for which that filter is a no-op.
-  if (!resolveOpenAiCompatibleHttpSenderIsOwner(req, requestAuth)) {
-    sendJson(res, 403, {
-      ok: false,
-      error: { message: "owner access required", type: "forbidden" },
-    });
     return true;
   }
 

--- a/ui/src/app/control-ui-auth.test.ts
+++ b/ui/src/app/control-ui-auth.test.ts
@@ -1,19 +1,17 @@
-// Candidate ordering is a product contract: shared secrets first, because
-// several gateway byte routes (plugin/catalog/workspace icons) reject device
-// tokens, and each rejected attempt pays the shared-secret brute-force
-// penalty on the gateway (delay escalation, remote IP lockout).
+// Candidate ordering follows the live Control UI credential while retaining
+// saved-secret fallbacks for stale sessions.
 import { describe, expect, it } from "vitest";
 import { resolveControlUiAuthCandidates } from "./control-ui-auth.ts";
 
 describe("resolveControlUiAuthCandidates", () => {
-  it("orders shared secrets before the hello device token", () => {
+  it("orders the hello device token before saved shared secrets", () => {
     expect(
       resolveControlUiAuthCandidates({
         hello: { auth: { deviceToken: "device-token" } } as never,
         settings: { token: "shared-token" },
         password: "shared-password",
       }),
-    ).toEqual(["shared-token", "shared-password", "device-token"]);
+    ).toEqual(["device-token", "shared-token", "shared-password"]);
   });
 
   it("keeps the device token for pairing-only browsers", () => {

--- a/ui/src/app/control-ui-auth.ts
+++ b/ui/src/app/control-ui-auth.ts
@@ -36,21 +36,16 @@ export function resolveControlUiAuthHeader(source: ControlUiAuthSource): string 
   return token ? `Bearer ${token}` : null;
 }
 
-// Ordered list of non-empty, header-safe shared-secret candidates. Used by
+// Ordered list of non-empty, header-safe Control UI credentials. Used by
 // call sites that can retry a single request against an alternate credential
 // when the first returns 401 — for example, recovering from a stale
 // `settings.token` when the live session is authenticated via `password`.
-// Shared secrets go first: several byte routes (plugin/catalog/workspace
-// icons) only accept the gateway shared secret, so leading with the hello
-// device token made every icon fetch 401 first — and each of those 401s pays
-// the shared-secret brute-force penalty on the gateway. Pairing-only browsers
-// still reach the device token as the last candidate.
 export function resolveControlUiAuthCandidates(source: ControlUiAuthSource): string[] {
   return uniqueStrings(
     [
+      normalizeOptionalString(source.hello?.auth?.deviceToken),
       normalizeOptionalString(source.settings?.token),
       normalizeOptionalString(source.password),
-      normalizeOptionalString(source.hello?.auth?.deviceToken),
     ].flatMap((raw) => sanitizeHeaderToken(raw ?? null) ?? []),
   );
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a fresh browser opened through `openclaw dashboard` successfully paired and connected, but workspace and session icon requests returned 401 because the browser had only its durable device credential. The UI silently showed a folder glyph even though WebSocket authentication and assistant media worked. Browser presenter ownership is a separate regression and is not changed here.

## Why This Change Was Made

Same-origin icon routes entered generic shared-secret HTTP authentication, while assistant media privately owned the correct paired-device fallback. This deletion-first repair moves the device-aware Control UI read authorizer to the Gateway HTTP-auth owner, carries verified scopes once, and reuses it for workspace, channel, plugin, catalog, and favicon reads. Session-derived bytes retain `sessions.list` plus admin policy, query-token support remains limited to assistant media, and generic HTTP APIs remain shared-secret-only. The shared-secret-first UI workaround is removed.

## User Impact

Fresh dashboard handoffs and reloads render project, channel, and plugin icons without exposing or persisting the shared Gateway secret. Revoked or stale device tokens still fail closed, and invalid cache-busted bearers remain 401.

## Evidence

- Pre-fix composed regression: `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts -t "silently approves host-authorized control ui owner bootstrap tokens" -- --reporter=verbose`; old code expected 200 but got 401.
- Post-fix composed regression: 1 passed, 39 skipped.
- Focused Gateway/UI run over control-ui.http, workspace/channel/plugin icon, http-common, and UI auth tests: 5 Gateway files / 295 tests plus 1 UI file / 2 tests passed.
- `pnpm build` passed in 13m 6.1s; Control UI startup JavaScript stayed under budget.
- `node scripts/check-changed.mjs` passed the core, coreTests, and UI lanes.
- Fresh structured autoreview: Codex P1, clean, with no accepted or actionable findings.
- Live isolated token-authenticated Gateway with a deterministic mock model: browser bootstrap fragment stripped; device credential present; no shared connection token or password; forced pre-fix route outcome produced five 401s plus folder fallback; repaired route produced two 200s plus SVG, including reload.
- Production LOC +252/-324 (net -72); tests +87/-66 (net +21).

The before capture forces the pre-fix 401 route outcome; the source regression proves that old code naturally returned 401.

**Before — forced pre-fix 401 route outcome**

![Before: workspace icons fall back to folder glyphs after forced 401 responses](https://github.com/user-attachments/assets/6da11356-33e1-4a0a-8d9e-05cd59d1fbd9)

**After — paired-device reads render workspace icons**

![After: workspace icons render after paired-device authorization](https://github.com/user-attachments/assets/d590a559-e051-46ab-9d01-acd2300c8c8d)

**Live reload video**

https://github.com/user-attachments/assets/79c90b27-caf9-4878-9d30-312c0d699fee

AI-assisted and maintainer-reviewed.
