### PR TITLE
fix(gateway): keep large CLI histories responsive

### DIFF
--- a/src/gateway/cli-session-history.merge.ts
+++ b/src/gateway/cli-session-history.merge.ts
@@ -10,22 +10,38 @@ import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 
 const DEDUPE_TIMESTAMP_WINDOW_MS = 5 * 60 * 1000;
 
-function extractComparableText(message: unknown): string | undefined {
+type ComparableHistoryMessage = {
+  message: unknown;
+  order: number;
+  externalIdentityKey?: string;
+  role?: string;
+  text?: string;
+  timestamp?: number;
+};
+
+type TimestampSummary = {
+  hasMissingTimestamp: boolean;
+  buckets: Map<number, { min: number; max: number }>;
+};
+
+type RoleTextIndex = Map<string, Map<string, TimestampSummary>>;
+
+function extractComparableText(message: unknown, role: string | undefined): string | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
   }
   const record = message as { role?: unknown; text?: unknown; content?: unknown };
-  const role = readStringValue(record.role);
   const parts: string[] = [];
   const text = readStringValue(record.text);
   if (text !== undefined) {
     parts.push(text);
   }
-  const content = readStringValue(record.content);
+  const rawContent = record.content;
+  const content = readStringValue(rawContent);
   if (content !== undefined) {
     parts.push(content);
-  } else if (Array.isArray(record.content)) {
-    for (const block of record.content) {
+  } else if (Array.isArray(rawContent)) {
+    for (const block of rawContent) {
       if (block && typeof block === "object" && "text" in block) {
         const blockText = readStringValue(block.text);
         if (blockText !== undefined) {
@@ -48,97 +64,96 @@ function extractComparableText(message: unknown): string | undefined {
   return normalized || undefined;
 }
 
-function resolveComparableTimestamp(message: unknown): number | undefined {
+function prepareComparableMessage(message: unknown, order: number): ComparableHistoryMessage {
   if (!message || typeof message !== "object") {
-    return undefined;
+    return { message, order };
   }
-  return asFiniteNumber((message as { timestamp?: unknown }).timestamp);
-}
-
-function resolveComparableRole(message: unknown): string | undefined {
-  if (!message || typeof message !== "object") {
-    return undefined;
-  }
-  return readStringValue((message as { role?: unknown }).role);
+  const record = message as { role?: unknown; timestamp?: unknown };
+  const role = readStringValue(record.role);
+  return {
+    message,
+    order,
+    externalIdentityKey: resolveImportedExternalIdentityKey(message),
+    role,
+    text: extractComparableText(message, role),
+    timestamp: asFiniteNumber(record.timestamp),
+  };
 }
 
 // External identity survives text edits, so it is the strongest match signal
 // for imported messages from Claude CLI or similar external histories.
-type ImportedExternalIdentity = {
-  externalId: string;
-  importedFrom?: string;
-  cliSessionId?: string;
-};
-
-function resolveImportedExternalIdentity(message: unknown): ImportedExternalIdentity | undefined {
+function resolveImportedExternalIdentityKey(message: unknown): string | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
   }
-  const meta =
-    "__openclaw" in message &&
-    (message as { __openclaw?: unknown })["__openclaw"] &&
-    typeof (message as { __openclaw?: unknown })["__openclaw"] === "object"
-      ? ((message as { __openclaw?: Record<string, unknown> })["__openclaw"] ?? {})
-      : undefined;
-  const externalId = normalizeOptionalString(meta?.externalId);
+  const rawMeta = (message as { __openclaw?: unknown })["__openclaw"];
+  if (!rawMeta || typeof rawMeta !== "object") {
+    return undefined;
+  }
+  const externalId = normalizeOptionalString((rawMeta as { externalId?: unknown }).externalId);
   return externalId
-    ? {
+    ? JSON.stringify([
         externalId,
-        importedFrom: normalizeOptionalString(meta?.importedFrom),
-        cliSessionId: normalizeOptionalString(meta?.cliSessionId),
-      }
+        normalizeOptionalString((rawMeta as { importedFrom?: unknown }).importedFrom),
+        normalizeOptionalString((rawMeta as { cliSessionId?: unknown }).cliSessionId),
+      ])
     : undefined;
 }
 
-function hasSameExternalIdentity(existing: unknown, imported: unknown): boolean | undefined {
-  const importedIdentity = resolveImportedExternalIdentity(imported);
-  const existingIdentity = resolveImportedExternalIdentity(existing);
-  if (!importedIdentity || !existingIdentity) {
-    return undefined;
+function addRoleTextCandidate(index: RoleTextIndex, entry: ComparableHistoryMessage): void {
+  if (!entry.role || !entry.text) {
+    return;
   }
-  return (
-    importedIdentity.externalId === existingIdentity.externalId &&
-    importedIdentity.importedFrom === existingIdentity.importedFrom &&
-    importedIdentity.cliSessionId === existingIdentity.cliSessionId
-  );
+  let byText = index.get(entry.role);
+  if (!byText) {
+    byText = new Map();
+    index.set(entry.role, byText);
+  }
+  let summary = byText.get(entry.text);
+  if (!summary) {
+    summary = { hasMissingTimestamp: false, buckets: new Map() };
+    byText.set(entry.text, summary);
+  }
+  if (entry.timestamp === undefined) {
+    summary.hasMissingTimestamp = true;
+    return;
+  }
+  const bucketKey = Math.floor(entry.timestamp / DEDUPE_TIMESTAMP_WINDOW_MS);
+  const bucket = summary.buckets.get(bucketKey);
+  if (bucket) {
+    bucket.min = Math.min(bucket.min, entry.timestamp);
+    bucket.max = Math.max(bucket.max, entry.timestamp);
+  } else {
+    summary.buckets.set(bucketKey, { min: entry.timestamp, max: entry.timestamp });
+  }
 }
 
-function isEquivalentImportedMessage(existing: unknown, imported: unknown): boolean {
-  // Text is a fallback only when either message lacks authoritative source identity.
-  const sameExternalIdentity = hasSameExternalIdentity(existing, imported);
-  if (sameExternalIdentity !== undefined) {
-    return sameExternalIdentity;
-  }
-
-  const existingRole = resolveComparableRole(existing);
-  const importedRole = resolveComparableRole(imported);
-  if (!existingRole || existingRole !== importedRole) {
+function hasRoleTextCandidate(index: RoleTextIndex, entry: ComparableHistoryMessage): boolean {
+  if (!entry.role || !entry.text) {
     return false;
   }
-
-  const existingText = extractComparableText(existing);
-  const importedText = extractComparableText(imported);
-  if (!existingText || !importedText || existingText !== importedText) {
+  const summary = index.get(entry.role)?.get(entry.text);
+  if (!summary) {
     return false;
   }
-
-  const existingTimestamp = resolveComparableTimestamp(existing);
-  const importedTimestamp = resolveComparableTimestamp(imported);
-  if (existingTimestamp === undefined || importedTimestamp === undefined) {
+  if (entry.timestamp === undefined || summary.hasMissingTimestamp) {
     return true;
   }
-
-  return Math.abs(existingTimestamp - importedTimestamp) <= DEDUPE_TIMESTAMP_WINDOW_MS;
+  const bucketKey = Math.floor(entry.timestamp / DEDUPE_TIMESTAMP_WINDOW_MS);
+  if (summary.buckets.has(bucketKey)) {
+    return true;
+  }
+  const previous = summary.buckets.get(bucketKey - 1);
+  if (previous && previous.max >= entry.timestamp - DEDUPE_TIMESTAMP_WINDOW_MS) {
+    return true;
+  }
+  const next = summary.buckets.get(bucketKey + 1);
+  return next !== undefined && next.min <= entry.timestamp + DEDUPE_TIMESTAMP_WINDOW_MS;
 }
 
-function compareHistoryMessages(
-  a: { message: unknown; order: number },
-  b: { message: unknown; order: number },
-): number {
-  const aTimestamp = resolveComparableTimestamp(a.message);
-  const bTimestamp = resolveComparableTimestamp(b.message);
-  if (aTimestamp !== undefined && bTimestamp !== undefined && aTimestamp !== bTimestamp) {
-    return aTimestamp - bTimestamp;
+function compareHistoryMessages(a: ComparableHistoryMessage, b: ComparableHistoryMessage): number {
+  if (a.timestamp !== undefined && b.timestamp !== undefined && a.timestamp !== b.timestamp) {
+    return a.timestamp - b.timestamp;
   }
   return a.order - b.order;
 }
@@ -151,13 +166,33 @@ export function mergeImportedChatHistoryMessages(params: {
   if (params.importedMessages.length === 0) {
     return params.localMessages;
   }
-  const merged = params.localMessages.map((message, index) => ({ message, order: index }));
+  const merged = params.localMessages.map(prepareComparableMessage);
+  const exactExternalIdentityIndex = new Set<string>();
+  const allMessageRoleTextIndex: RoleTextIndex = new Map();
+  const identitylessRoleTextIndex: RoleTextIndex = new Map();
+  const indexEntry = (entry: ComparableHistoryMessage) => {
+    if (entry.externalIdentityKey) {
+      exactExternalIdentityIndex.add(entry.externalIdentityKey);
+    } else {
+      addRoleTextCandidate(identitylessRoleTextIndex, entry);
+    }
+    addRoleTextCandidate(allMessageRoleTextIndex, entry);
+  };
+  for (const entry of merged) {
+    indexEntry(entry);
+  }
   let nextOrder = merged.length;
-  for (const imported of params.importedMessages) {
-    if (merged.some((existing) => isEquivalentImportedMessage(existing.message, imported))) {
+  for (const message of params.importedMessages) {
+    const imported = prepareComparableMessage(message, nextOrder);
+    const duplicate = imported.externalIdentityKey
+      ? exactExternalIdentityIndex.has(imported.externalIdentityKey) ||
+        hasRoleTextCandidate(identitylessRoleTextIndex, imported)
+      : hasRoleTextCandidate(allMessageRoleTextIndex, imported);
+    if (duplicate) {
       continue;
     }
-    merged.push({ message: imported, order: nextOrder });
+    merged.push(imported);
+    indexEntry(imported);
     nextOrder += 1;
   }
   merged.sort(compareHistoryMessages);

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -974,6 +974,46 @@ describe("cli session history", () => {
     });
   });
 
+  it("reads comparable fields once while merging large identity-less histories", () => {
+    const rowCount = 200;
+    const reads = { role: 0, content: 0, timestamp: 0 };
+    const createMessage = (source: "imported" | "local", index: number) => {
+      const timestamp = Date.parse("2026-03-26T16:29:54.800Z") + index;
+      return {
+        get role() {
+          reads.role += 1;
+          return "user";
+        },
+        get content() {
+          reads.content += 1;
+          return `${source}-${index}`;
+        },
+        get timestamp() {
+          reads.timestamp += 1;
+          return timestamp;
+        },
+      };
+    };
+    const localMessages = Array.from({ length: rowCount }, (_, index) =>
+      createMessage("local", index),
+    );
+    const importedMessages = Array.from({ length: rowCount }, (_, index) =>
+      createMessage("imported", rowCount + index),
+    );
+
+    // The former growing scan made 59,900 failed comparisons for these unique rows.
+    const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
+
+    expect(reads).toEqual({
+      role: rowCount * 2,
+      content: rowCount * 2,
+      timestamp: rowCount * 2,
+    });
+    expect(merged).toHaveLength(rowCount * 2);
+    expect(merged[0]).toBe(localMessages[0]);
+    expect(merged.at(-1)).toBe(importedMessages.at(-1));
+  });
+
   it.each([
     ["deduplicates a local redacted copy against an imported full copy", false],
     ["deduplicates when both local and imported copies are already redacted", true],
@@ -1145,6 +1185,35 @@ describe("cli session history", () => {
     const merged = mergeImportedChatHistoryMessages({ localMessages, importedMessages });
     expect(merged).toHaveLength(2);
   });
+
+  it.each([
+    ["at the five-minute boundary", 0, 5 * 60 * 1000, 1],
+    ["outside the five-minute boundary", 0, 5 * 60 * 1000 + 1, 2],
+    ["when the local timestamp is missing", undefined, 1, 1],
+    ["when the imported timestamp is missing", 1, undefined, 1],
+  ])(
+    "deduplicates matching identity-less text %s",
+    (_label, localTimestamp, importedTimestamp, expectedLength) => {
+      const localMessages = [
+        {
+          role: "user",
+          content: "same text",
+          ...(localTimestamp === undefined ? {} : { timestamp: localTimestamp }),
+        },
+      ];
+      const importedMessages = [
+        {
+          role: "user",
+          content: "same text",
+          ...(importedTimestamp === undefined ? {} : { timestamp: importedTimestamp }),
+        },
+      ];
+
+      expect(mergeImportedChatHistoryMessages({ localMessages, importedMessages })).toHaveLength(
+        expectedLength,
+      );
+    },
+  );
 
   it("keeps untimestamped local messages in place when importing timestamped history", () => {
     const localMessages = [{ role: "user", content: "local without timestamp" }];


### PR DESCRIPTION
Fixes #126137

## What Problem This Solves

Fixes an issue where opening chat history for a session bound to a large Claude CLI transcript could pin the gateway event loop for minutes, interrupting every channel and RPC served by that process.

Reported with detailed profiling and reproduction evidence by David Lambl (@davidlambl).

## Why This Change Was Made

The merge now prepares each message's external identity, role, normalized text, timestamp, and stable order once. Exact external identities and the two asymmetric role/text fallback paths use dedicated indexes, preserving existing identity, session, five-minute timestamp, missing-timestamp, ordering, and deduplication behavior without scanning the growing merged history for every imported row.

No config, SDK, persistence, dependency, response-shape, or changelog surface changes.

## User Impact

Large bound CLI transcripts no longer make chat history deduplication grow quadratically. Operators can open affected conversations without the merge monopolizing the gateway process.

## Evidence

- Deterministic red proof on `dcdfd737e5973ef1113b21e94d4ba79b7bc69ec9`: 200 local plus 200 unique imported identity-less rows forced 59,900 failed candidates and read `role` 239,600 times, `content` 119,800 times, and `timestamp` 798 times.
- Green proof: the same 400 rows read each comparable field exactly 400 times.
- `node scripts/run-vitest.mjs src/gateway/cli-session-history.test.ts` — 52 passed.
- `node scripts/run-vitest.mjs src/gateway/server-methods/chat-history-pages.test.ts` — 2 passed.
- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts -t "chat startup and history share a non-blocking large Claude snapshot"` — 1 passed.
- Targeted format and Oxlint checks passed; `git diff --check` passed.
- `node scripts/check-changed.mjs -- src/gateway/cli-session-history.merge.ts src/gateway/cli-session-history.test.ts` passed every guard through core typecheck. Core-test typecheck is red on an unrelated pre-existing `ui/src/pages/chat/route-loader.ts:712` error; the same error reproduces in a clean GWT at live main `a6b77ffc074ce61f5e31c229ded1986f84562b75`.
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: +110/-75 (net +35). Tests: +69/-0.

AI-assisted implementation and review; the maintainer verified the owner path, behavioral contract, focused tests, and current-main baseline independently.

Punchcard-Session: clear-river-meadow-gr
