### PR TITLE
test(zai): enable GLM 5.3 reasoning in live probe

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -898,7 +898,7 @@ describe("OpenAI-compatible completions params", () => {
   });
 
   it("enables Z.AI thinking with the documented payload when requested", async () => {
-    const stream = streamOpenAICompletions(
+    const stream = streamSimpleOpenAICompletions(
       {
         ...createModel(32_000),
         provider: "zai",
@@ -908,15 +908,16 @@ describe("OpenAI-compatible completions params", () => {
       context,
       {
         apiKey: "sk-test",
-        reasoningEffort: "high",
+        reasoning: "max",
       },
     );
 
     await stream.result();
 
     expect(mockOpenAIOptionsRef.payloads[0]).toMatchObject({
-      thinking: { type: "enabled" },
+      thinking: { type: "enabled", clear_thinking: false },
     });
+    expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("reasoning_effort");
     expect(mockOpenAIOptionsRef.payloads[0]).not.toHaveProperty("enable_thinking");
   });
 

--- a/src/agents/zai.live.test.ts
+++ b/src/agents/zai.live.test.ts
@@ -42,7 +42,7 @@ async function expectModelReturnsAssistantText(
       {
         messages: createSingleUserPromptMessage(),
       },
-      { apiKey: ZAI_KEY, maxTokens },
+      { apiKey: ZAI_KEY, maxTokens, reasoning: modelId === "glm-5.3" ? "max" : undefined },
     );
 
   // A small probe cap can occasionally yield only hidden reasoning even though


### PR DESCRIPTION
## What Problem This Solves

Resolves a main-qualification failure where the Z.ai GLM-5.3 Coding Plan live probe is rejected because the direct completion probe disables thinking.

## Why This Change Was Made

The live probe constructs a model and calls `completeSimple` directly, bypassing the Z.ai plugin's GLM-5.3 default reasoning policy. Pass `max` reasoning only for GLM-5.3 so the probe matches the normal product path; older GLM probes are unchanged.

The transport regression test covers the complete simple-completion mapping and verifies the Z.ai wire payload enables thinking without emitting unsupported `reasoning_effort` or `enable_thinking` fields.

## User Impact

No production runtime behavior changes. This restores authenticated live coverage for the GLM-5.3 Coding Plan endpoint.

## Evidence

- `git diff --check`
- `./node_modules/.bin/oxfmt --check packages/ai/src/providers/openai-completions.test.ts src/agents/zai.live.test.ts`
- `node scripts/run-vitest.mjs src/agents/zai.live.test.ts extensions/zai/provider-policy-api.test.ts packages/ai/src/providers/openai-completions.test.ts`
  - 60 OpenAI-completions assertions passed
  - 16 Z.ai provider-policy assertions passed
  - live-only file loaded through the focused test classifier and remained credential-gated
- Production LOC: `0`
- Tests: `+5/-4`
- Exact-head hosted `live-e2e` proof: [run 32222770359](https://github.com/openclaw/openclaw/actions/runs/32222770359)
  - target SHA: `fcd8ec88d0ab370cec5d3dc404918144a05e740a`
  - suite: `native-live-src-agents-zai-coding`
  - result: passed
