### PR TITLE
fix(discord): retain attachment-only reply context

### DIFF
--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -480,7 +480,9 @@ export async function buildDiscordMessageProcessContext(params: {
                 );
                 return isContextAborted(abortSignal)
                   ? []
-                  : await toInboundMediaFactsWithMetadata(referencedReplyMediaList);
+                  : await toInboundMediaFactsWithMetadata(referencedReplyMediaList, {
+                      messageId: replyContext.id,
+                    });
               },
             }
           : undefined,

--- a/extensions/discord/src/monitor/message-handler.process.session-routing.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.session-routing.test.ts
@@ -174,6 +174,64 @@ describe("processDiscordMessage session routing", () => {
     expect(dispatchCtx.MediaPaths).toBeUndefined();
   });
 
+  it("keeps attachment-only referenced messages as typed reply context", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(Buffer.from("image"), { headers: { "content-type": "image/png" } }),
+    );
+    const ctx = await createBaseContext({
+      cfg: {
+        channels: { discord: { contextVisibility: "all" } },
+        messages: { ackReaction: "👀" },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+      },
+      discordRestFetch: fetchImpl,
+      message: {
+        id: "m-attachment-reply",
+        channelId: "c1",
+        content: "<@bot> what is this?",
+        timestamp: new Date().toISOString(),
+        attachments: [],
+        messageReference: { type: 0, message_id: "m-attachment-only", channel_id: "c1" },
+        referencedMessage: {
+          id: "m-attachment-only",
+          channelId: "c1",
+          content: "",
+          timestamp: new Date().toISOString(),
+          attachments: [
+            {
+              id: "att-only",
+              url: "https://cdn.discordapp.com/attachments/1/attachment-only.png",
+              content_type: "image/png",
+              filename: "attachment-only.png",
+            },
+          ],
+          author: {
+            id: "U2",
+            username: "bob",
+            discriminator: "0",
+            globalName: "Bob",
+          },
+        },
+      },
+      baseText: "<@bot> what is this?",
+      messageText: "<@bot> what is this?",
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    const dispatchCtx = requireRecord(getLastDispatchCtx(), "dispatch context");
+    expect(dispatchCtx.ReplyToId).toBe("m-attachment-only");
+    expect(dispatchCtx.ReplyToSender).toBe("bob");
+    expect(dispatchCtx.ReplyToBody).toBeUndefined();
+    expect(dispatchCtx.media).toEqual([
+      expect.objectContaining({
+        contentType: "image/png",
+        messageId: "m-attachment-only",
+      }),
+    ]);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
   it("does not inject the bot's previous message body when users reply to it", async () => {
     const fetchImpl = vi.fn(async () => {
       throw new Error("self-reply media should not be fetched");

--- a/extensions/discord/src/monitor/reply-context.ts
+++ b/extensions/discord/src/monitor/reply-context.ts
@@ -1,6 +1,7 @@
 // Discord plugin module implements reply context behavior.
 import type { Guild, Message, User } from "../internal/discord.js";
 import { resolveTimestampMs } from "./format.js";
+import { resolveDiscordMessageStickers } from "./message-forwarded.js";
 import { resolveDiscordSenderIdentity } from "./sender-identity.js";
 
 type DiscordReplyContext = {
@@ -11,7 +12,7 @@ type DiscordReplyContext = {
   senderName?: string;
   senderTag?: string;
   memberRoleIds?: string[];
-  body: string;
+  body?: string;
   timestamp?: number;
 };
 
@@ -26,7 +27,10 @@ export function resolveReplyContext(
   const referencedText = resolveDiscordMessageText(referenced, {
     includeForwarded: true,
   });
-  if (!referencedText) {
+  const hasVisibleMedia =
+    referenced.attachments.length > 0 ||
+    (!referencedText && resolveDiscordMessageStickers(referenced).length > 0);
+  if (!referencedText && !hasVisibleMedia) {
     return null;
   }
   const sender = resolveDiscordSenderIdentity({
@@ -44,7 +48,7 @@ export function resolveReplyContext(
       const roles = (referenced as { member?: { roles?: string[] } }).member?.roles;
       return Array.isArray(roles) ? roles.map((roleId) => roleId) : undefined;
     })(),
-    body: referencedText,
+    ...(referencedText ? { body: referencedText } : {}),
     timestamp: resolveTimestampMs(referenced.timestamp),
   };
 }

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -733,13 +733,30 @@ describe("buildInboundUserContextPrefix", () => {
 
   it("labels reply context as the current message target", () => {
     const text = buildInboundUserContextPrefix({
+      ReplyToId: "message-41",
       ReplyToSender: "Quoter",
       ReplyToBody: "quoted body",
     } as TemplateContext);
 
     const reply = parseReplyPayload(text);
+    expect(reply["message_id"]).toBe("message-41");
     expect(reply["sender_label"]).toBe("Quoter");
     expect(reply["body"]).toBe("quoted body");
+  });
+
+  it("renders reply metadata without a body but not without any reply fields", () => {
+    const text = buildInboundUserContextPrefix({
+      ReplyToId: "message-42",
+      ReplyToSender: "Attachment Sender",
+    } as TemplateContext);
+
+    expect(parseReplyPayload(text)).toEqual({
+      message_id: "message-42",
+      sender_label: "Attachment Sender",
+    });
+    expect(buildInboundUserContextPrefix({} as TemplateContext)).not.toContain(
+      "Reply target of current user message",
+    );
   });
 
   it("renders hydrated reply chain instead of duplicate one-hop reply target", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -706,6 +706,8 @@ export function buildInboundUserContextPrefix(
 
   const rawReplyToBody = sanitizePromptBody(ctx.ReplyToBody);
   const replyToBody = rawReplyToBody ? truncateBodyHeadTail(rawReplyToBody) : rawReplyToBody;
+  const replyToSender = normalizePromptMetadataString(ctx.ReplyToSender);
+  const hasReplyTargetMetadata = Boolean(replyToId || replyToSender || replyToBody);
   if (replyChainPayload.length > 0 && !chatWindowCoversReplyContext && !currentMessageContext) {
     blocks.push(
       formatContextJsonBlock(
@@ -713,12 +715,13 @@ export function buildInboundUserContextPrefix(
         replyChainPayload,
       ),
     );
-  } else if (replyToBody && !chatWindowCoversReplyContext && !currentMessageContext) {
+  } else if (hasReplyTargetMetadata && !chatWindowCoversReplyContext && !currentMessageContext) {
     blocks.push(
       formatContextJsonBlock(markInboundContextLabel("Reply target of current user message:"), {
-        sender_label: normalizePromptMetadataString(ctx.ReplyToSender),
+        message_id: replyToId,
+        sender_label: replyToSender,
         is_quote: ctx.ReplyToIsQuote === true ? true : undefined,
-        body: replyToBody,
+        body: replyToBody || undefined,
       }),
     );
   }


### PR DESCRIPTION
## What Problem This Solves
Fixes an issue where replying to an attachment-only Discord message omitted the referenced message context, so the model received the media without a useful quoted-message identity.
## Why This Change Was Made
Keep hydrated attachment/sticker-only references as typed reply context and project message ID/sender metadata even when the referenced text body is empty. Visibility and self-quote gates remain unchanged.
## User Impact
Discord replies to images or other attachment-only messages now preserve the referenced sender/message context and media association.
## Evidence
- 102 focused Discord/inbound metadata tests passed.
- `node scripts/check-changed.mjs` passed.
- Autoreview clean.
- Production LOC +16/-7 (net +9); tests +75.
- AI-assisted; maintainer reviewed the implementation and proof.
