### PR TITLE
chore: remove channel avatar cache reset seam

### DIFF
--- a/src/gateway/channel-avatar-http.test.ts
+++ b/src/gateway/channel-avatar-http.test.ts
@@ -29,8 +29,7 @@ vi.mock("../media/store.js", () => ({
   readMediaBuffer: (...args: unknown[]) => mocks.readMedia(...args),
 }));
 
-const { clearChannelAvatarCacheForTest, handleChannelAvatarHttpRequest } =
-  await import("./channel-avatar-http.js");
+const { handleChannelAvatarHttpRequest } = await import("./channel-avatar-http.js");
 
 const PNG_BYTES = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Zb0YAAAAASUVORK5CYII=",
@@ -80,7 +79,6 @@ describe("handleChannelAvatarHttpRequest", () => {
   });
 
   beforeEach(() => {
-    clearChannelAvatarCacheForTest();
     mocks.authorize.mockReset().mockResolvedValue({
       authMethod: "token",
       operatorScopes: ["operator.admin", "operator.read"],

--- a/src/gateway/channel-avatar-http.ts
+++ b/src/gateway/channel-avatar-http.ts
@@ -26,13 +26,8 @@ type ChannelAvatarCacheIndex = {
   imageKey: string;
 };
 
-let channelAvatarIndex = new Map<string, ChannelAvatarCacheIndex>();
-let channelAvatarBytes = new Map<string, HttpImageRepresentation>();
-
-export function clearChannelAvatarCacheForTest(): void {
-  channelAvatarIndex = new Map();
-  channelAvatarBytes = new Map();
-}
+const channelAvatarIndex = new Map<string, ChannelAvatarCacheIndex>();
+const channelAvatarBytes = new Map<string, HttpImageRepresentation>();
 
 const getSessionStoreModule = createLazyRuntimeModule(() => import("./session-utils-store.js"));
 


### PR DESCRIPTION
## What Problem This Solves

The channel-avatar HTTP tests reset a module-level cache through a production export that had no runtime or lifecycle caller. That test-only seam forced otherwise stable cache bindings to remain reassignable and coupled the suite to cache representation rather than observable HTTP behavior.

## Why This Change Was Made

Remove the test-only reset export and keep both bounded LRU maps as immutable bindings while preserving their existing in-place mutation, eviction, and image-representation logic. The cache-populating success cases already use distinct session keys (`user-1`, `cached`, and `head`); deliberate same-key reuse remains confined to the cache/ETag test, while repeated authorization, missing, malformed, and method cases never populate the cache.

Production LOC: +2/-7 (net -5) | Tests: +1/-3 (net -2)

AI-assisted by Codex. The change was inspected and validated by the maintainer workflow.

## User Impact

No user-visible behavior changes. Channel-avatar authorization, media loading, bounded cache reuse, conditional requests, and response headers remain unchanged; the production module simply exposes less test-only surface.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/channel-avatar-http.test.ts` — 11/11 passed in two fresh processes after rebasing onto current `main`'s unified avatar authorization path.
- `node scripts/check-changed.mjs --dry-run -- src/gateway/channel-avatar-http.ts src/gateway/channel-avatar-http.test.ts` — selected the core and core-test lanes.
- `node scripts/check-changed.mjs -- src/gateway/channel-avatar-http.ts src/gateway/channel-avatar-http.test.ts` — passed formatting, ratchets, dead-export scan, core production/test typechecks, lint, architecture, and boundary guards.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean on the final rebased diff; no accepted/actionable findings.
- `git diff --check` — clean.
- `rg clearChannelAvatarCacheForTest` — no matches after the change.

History: the seam arrived with `2bed8caf9ef8`; repository search found no public, runtime, or lifecycle caller.
