### PR TITLE
fix: Full access sessions no longer request exec approval

### DIFF
--- a/docs/gateway/permission-modes.md
+++ b/docs/gateway/permission-modes.md
@@ -30,6 +30,6 @@ A new managed worktree session defaults to `workspace` when no mode is specified
 
 An explicit session mode takes precedence over the session's legacy `execSecurity` and `execAsk` overrides. When the mode is unset, those fields and the normal global or per-agent configuration continue to work as before.
 
-Host approval-file floors, sandbox restrictions, and tool allow/deny policy can only make the effective result stricter. A harness may also clamp an unsupported mode to a compatible safer policy tuple; it does not combine tuple fields into a less restrictive posture.
+An explicit `full` mode is the admin-authorized exception to host approval-file floors: its OpenClaw exec policy remains `full` with approvals off. Approval-file floors continue to tighten config-driven exec policy, legacy session overrides, unset modes, and every non-full session mode. Sandbox restrictions and tool allow/deny policy remain independent, and a harness may clamp an unsupported mode to a compatible safer policy tuple. Codex also continues to honor externally enforced `requirements.toml` constraints.
 
 For the independent sandbox, tool-policy, and elevated-exec controls, see [Sandbox vs tool policy vs elevated](/gateway/sandbox-vs-tool-policy-vs-elevated).

--- a/extensions/codex/src/app-server/config-exec-policy.ts
+++ b/extensions/codex/src/app-server/config-exec-policy.ts
@@ -1,4 +1,5 @@
 import { AgentHarnessPreflightError } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { EmbeddedRunAttemptParamsV2 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
@@ -99,6 +100,7 @@ function resolveOpenClawExecPolicyFromConfig(params: {
 }
 
 export function resolveOpenClawExecPolicyForCodexAppServer(params: {
+  permissionMode?: EmbeddedRunAttemptParamsV2["permissionMode"];
   execOverrides?: {
     mode?: unknown;
     security?: unknown;
@@ -108,6 +110,9 @@ export function resolveOpenClawExecPolicyForCodexAppServer(params: {
   config?: OpenClawConfig;
   agentId?: string;
 }): OpenClawExecPolicyForCodexAppServer {
+  if (params.permissionMode === "full") {
+    return { ...resolveOpenClawExecPolicyForMode("full"), touched: true };
+  }
   const basePolicy = resolveOpenClawExecPolicyFromConfig({
     config: params.config,
     agentId: params.agentId,

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -2795,6 +2795,28 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     );
   });
 
+  it("does not apply host exec approval floors to an explicit full session", () => {
+    const execPolicy = resolveOpenClawExecPolicyForCodexAppServer({
+      permissionMode: "full",
+      config: {
+        tools: {
+          exec: {
+            mode: "ask",
+          },
+        },
+      },
+      approvals: {
+        version: 1,
+        defaults: {
+          ask: "always",
+        },
+        agents: {},
+      },
+    });
+
+    expect(execPolicy).toMatchObject({ mode: "full", security: "full", ask: "off" });
+  });
+
   it("preserves explicit read-only sandbox for host exec approval ask floors", () => {
     const execPolicy = resolveOpenClawExecPolicyForCodexAppServer({
       config: {

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -2141,7 +2141,10 @@ describe("Codex app-server dynamic tool build", () => {
       await buildDynamicToolsForTest(params, workspaceDir, { sandbox: null as never });
 
       expect(factoryOptions).toHaveLength(1);
-      expect(factoryOptions[0]).toMatchObject({ exec: { mode: execMode } });
+      expect(factoryOptions[0]).toMatchObject({
+        exec: { mode: execMode },
+        sessionPermissionPolicy: { mode: permissionMode, root: workspaceDir },
+      });
     },
   );
 

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -264,6 +264,10 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
         config: params.config,
         elevated: params.bashElevated,
       },
+      sessionPermissionPolicy:
+        params.permissionMode && params.sessionRoot
+          ? { mode: params.permissionMode, root: params.sessionRoot }
+          : undefined,
       sandbox: input.sandbox,
       messageProvider: resolveCodexMessageToolProvider(params),
       toolPolicyMessageProvider: params.messageProvider ?? params.messageChannel,

--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -101,10 +101,10 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
         });
   preDynamicStartupStages.mark("sandbox");
   const execPolicy = resolveOpenClawExecPolicyForCodexAppServer({
-    // The explicit session mode replaces legacy per-session execSecurity/execAsk.
-    // Global/agent policy and approvals-file floors remain authoritative.
+    // Explicit modes replace legacy fields; full also replaces approval-file floors.
+    permissionMode: params.permissionMode,
     execOverrides: params.execOverrides,
-    approvals: loadExecApprovals(),
+    approvals: params.permissionMode === "full" ? undefined : loadExecApprovals(),
     config: params.config,
     agentId: sessionAgentId,
   });

--- a/extensions/codex/src/app-server/session-permission-policy.test.ts
+++ b/extensions/codex/src/app-server/session-permission-policy.test.ts
@@ -98,29 +98,18 @@ describe("Codex session permission policy", () => {
     });
   });
 
-  it.each([
-    {
-      mode: "full" as const,
-      execMode: "ask" as const,
-      sandbox: "danger-full-access",
-    },
-    {
-      mode: "guarded" as const,
-      execMode: "deny" as const,
-      sandbox: "read-only",
-    },
-  ])("lets effective $execMode exec floors tighten a $mode tuple", (expected) => {
+  it("lets a deny exec floor tighten a guarded tuple", () => {
     const resolved = applyCodexSessionPermissionPolicy({
       appServer: appServer(),
-      permissionMode: expected.mode,
+      permissionMode: "guarded",
       sessionRoot: "/workspace/project",
       pluginConfig,
       canUseAutoReview: true,
-      execMode: expected.execMode,
+      execMode: "deny",
     });
 
     expect(resolved).toMatchObject({
-      sandbox: expected.sandbox,
+      sandbox: "read-only",
       approvalPolicy: "on-request",
       approvalsReviewer: "user",
     });

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -592,6 +592,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     applyPatchWorkspaceOnly,
     execDefaults: {
       ...execDefaults,
+      bypassHostApprovalFloors: sessionCoreToolPolicy?.bypassHostApprovalFloors,
       host: options?.exec?.host ?? execConfig.host,
       mode: effectiveExecPolicy.mode,
       security: effectiveExecPolicy.security,

--- a/src/agents/bash-tools.exec-host-node.test.ts
+++ b/src/agents/bash-tools.exec-host-node.test.ts
@@ -3858,6 +3858,14 @@ describe("executeNodeHostCommand", () => {
     expect(Object.hasOwn(runParams, "systemRunPlan")).toBe(false);
   });
 
+  it("bypasses host approval floors for an explicit full session", async () => {
+    await executeNodeHostCommand(createNodeHostRequest({ bypassHostApprovalFloors: true }));
+
+    expect(resolveExecHostApprovalContextMock).not.toHaveBeenCalled();
+    expect(callGatewayToolMock).toHaveBeenCalledTimes(1);
+    expect(Object.hasOwn(requireRunParams(requireGatewayCall(0)), "systemRunPlan")).toBe(false);
+  });
+
   it("does not dispatch a direct full/off command after gateway policy revocation", async () => {
     resolveExecHostApprovalContextMock
       .mockReturnValueOnce({

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -111,6 +111,11 @@ async function assertCurrentNodeGatewayPolicyAllowsDispatch(params: {
 export async function executeNodeHostCommand(
   params: ExecuteNodeHostCommandParams,
 ): Promise<AgentToolResult<ExecToolDetails>> {
+  const target = await resolveNodeExecutionTarget(params);
+  params.signal?.throwIfAborted();
+  if (params.bypassHostApprovalFloors) {
+    return await invokeNodeSystemRunDirect({ request: params, target });
+  }
   const { hostSecurity, hostAsk, askFallback } =
     await execHostShared.resolveExecHostApprovalContext({
       agentId: params.agentId,
@@ -118,8 +123,6 @@ export async function executeNodeHostCommand(
       ask: params.ask,
       host: "node",
     });
-  const target = await resolveNodeExecutionTarget(params);
-  params.signal?.throwIfAborted();
   if (
     shouldSkipNodeApprovalPrepare({
       hostSecurity,

--- a/src/agents/bash-tools.exec-host-node.types.ts
+++ b/src/agents/bash-tools.exec-host-node.types.ts
@@ -32,6 +32,7 @@ export type ExecuteNodeHostCommandParams = {
   agentId?: string;
   security: ExecSecurity;
   ask: ExecAsk;
+  bypassHostApprovalFloors?: boolean;
   autoReview?: boolean;
   autoReviewer?: ExecAutoReviewer;
   signal?: AbortSignal;

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -296,7 +296,7 @@ export function createExecTool(
         ask: defaults?.ask ?? "off",
       });
       const approvalPolicy =
-        host === "sandbox"
+        host === "sandbox" || defaults?.bypassHostApprovalFloors === true
           ? undefined
           : resolveExecApprovalsFromFile({
               file: loadExecApprovals(),
@@ -306,7 +306,7 @@ export function createExecTool(
                 ask: "off",
               },
             }).agent;
-      let security = minSecurity(
+      const security = minSecurity(
         modePolicy.security,
         approvalPolicy?.security ?? modePolicy.security,
       );
@@ -319,24 +319,17 @@ export function createExecTool(
       const hostPolicyAllowsFullBypass =
         (approvalPolicy?.security ?? "full") === "full" && (approvalPolicy?.ask ?? "off") === "off";
       const modePolicyAllowsFullBypass = modePolicy.security === "full" && modePolicy.ask === "off";
-      if (
-        elevatedRequested &&
-        elevatedMode === "full" &&
-        modePolicyAllowsFullBypass &&
-        hostPolicyAllowsFullBypass
-      ) {
-        security = "full";
-      }
-      // Keep local exec defaults in sync with host approval state when tools.exec.* is unset.
+      // Explicit full-session authority is the sole exception to host approval floors.
       const requestedAsk = normalizeExecAsk(params.ask);
       const hostAsk = maxAsk(modePolicy.ask, approvalPolicy?.ask ?? modePolicy.ask);
       const trustedAsk = defaults?.messageProvider && hostAsk === "off" ? undefined : requestedAsk;
       let ask = maxAsk(hostAsk, trustedAsk ?? hostAsk);
       const bypassApprovals =
-        elevatedRequested &&
-        elevatedMode === "full" &&
-        modePolicyAllowsFullBypass &&
-        hostPolicyAllowsFullBypass;
+        defaults?.bypassHostApprovalFloors === true ||
+        (elevatedRequested &&
+          elevatedMode === "full" &&
+          modePolicyAllowsFullBypass &&
+          hostPolicyAllowsFullBypass);
       if (bypassApprovals) {
         ask = "off";
       }
@@ -464,6 +457,7 @@ export function createExecTool(
             agentId,
             security,
             ask,
+            bypassHostApprovalFloors: defaults?.bypassHostApprovalFloors,
             autoReview,
             autoReviewer,
             signal,

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -28,6 +28,7 @@ export type ExecToolDefaults = {
   hasCronTool?: boolean;
   host?: ExecTarget;
   mode?: ExecMode;
+  bypassHostApprovalFloors?: boolean;
   security?: ExecSecurity;
   ask?: ExecAsk;
   trigger?: string;

--- a/src/agents/bash-tools.exec.security-floor.test.ts
+++ b/src/agents/bash-tools.exec.security-floor.test.ts
@@ -1,7 +1,7 @@
 /**
  * Exec security floor tests.
- * Verifies tool config and exec-approvals policy combine by tightening
- * security/ask rather than silently broadening execution.
+ * Verifies host approval floors tighten normal exec policy while explicit
+ * full-session authority remains full/off.
  */
 import fs from "node:fs";
 import os from "node:os";
@@ -373,6 +373,24 @@ describe("exec security floor", () => {
 
     expect(result.details.status).toBe("approval-pending");
     expect(calls).toContain("exec.approval.request");
+  });
+
+  it("does not prompt explicit full sessions despite host ask floors", async () => {
+    writeFullAskExecApprovalsFixture(tempRoot ?? os.tmpdir());
+    const tool = createExecTool({
+      host: "gateway",
+      mode: "full",
+      bypassHostApprovalFloors: true,
+      approvalRunningNoticeMs: 0,
+    });
+
+    const result = await tool.execute("call-session-full-host-ask-floor", {
+      command: "echo session-full-ok",
+    });
+
+    expect(result.details.status).toBe("completed");
+    expect((result.content[0] as { text?: string }).text).toContain("session-full-ok");
+    expect(callGatewayTool).not.toHaveBeenCalled();
   });
 
   it("honors normalized auto mode before elevated full bypass", async () => {

--- a/src/agents/cli-runner/claude-live-session-policy.test.ts
+++ b/src/agents/cli-runner/claude-live-session-policy.test.ts
@@ -67,4 +67,19 @@ describe("acceptsClaudeLive", () => {
       permissionMode: "default",
     });
   });
+
+  it("uses bypass permissions for an explicit full session despite restrictive config", () => {
+    const context = {
+      params: {
+        config: { tools: { exec: { mode: "ask" } } },
+        sessionEntry: { permissionMode: "full" },
+      },
+    } as unknown as PreparedCliRunContext;
+
+    expect(resolveClaudeLiveExecPermission(context)).toEqual({
+      security: "full",
+      ask: "off",
+      permissionMode: "bypassPermissions",
+    });
+  });
 });

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1171,6 +1171,20 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     });
   });
 
+  it("preserves the recorded session permission policy when building compaction tools", async () => {
+    await compactEmbeddedAgentSessionDirect(
+      wrappedCompactionArgs({
+        workspaceDir: "/tmp/workspace",
+        permissionMode: "full",
+        sessionRoot: "/tmp/workspace",
+      }),
+    );
+
+    expectRecordFields(mockCallArg(createOpenClawCodingToolsMock), {
+      sessionPermissionPolicy: { mode: "full", root: "/tmp/workspace" },
+    });
+  });
+
   it("keeps manifest-profiled plugin tools executable during compaction", async () => {
     const toolName = "profiled_plugin_tool";
     const metadataSnapshot = {

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -1175,8 +1175,11 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
     await compactEmbeddedAgentSessionDirect(
       wrappedCompactionArgs({
         workspaceDir: "/tmp/workspace",
-        permissionMode: "full",
-        sessionRoot: "/tmp/workspace",
+        sessionEntry: {
+          sessionId: "session-1",
+          permissionMode: "full",
+          sessionRoot: "/tmp/workspace",
+        },
       }),
     );
 

--- a/src/agents/embedded-agent-runner/compact.types.ts
+++ b/src/agents/embedded-agent-runner/compact.types.ts
@@ -77,6 +77,8 @@ export type CompactEmbeddedAgentSessionParams = {
   bootstrapWorkspaceDir?: string;
   /** Optional task working directory; workspaceDir remains the agent bootstrap workspace. */
   cwd?: string;
+  permissionMode?: SessionEntry["permissionMode"];
+  sessionRoot?: string;
   agentDir?: string;
   config?: OpenClawConfig;
   toolOverrides?: SessionToolOverrides;

--- a/src/agents/embedded-agent-runner/compact.types.ts
+++ b/src/agents/embedded-agent-runner/compact.types.ts
@@ -77,8 +77,6 @@ export type CompactEmbeddedAgentSessionParams = {
   bootstrapWorkspaceDir?: string;
   /** Optional task working directory; workspaceDir remains the agent bootstrap workspace. */
   cwd?: string;
-  permissionMode?: SessionEntry["permissionMode"];
-  sessionRoot?: string;
   agentDir?: string;
   config?: OpenClawConfig;
   toolOverrides?: SessionToolOverrides;

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -101,6 +101,10 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     effectiveCwd,
     effectiveSkillAgentId,
   } = prepared;
+  const sessionPermissionPolicy =
+    params.sessionEntry?.permissionMode && params.sessionEntry.sessionRoot
+      ? { mode: params.sessionEntry.permissionMode, root: params.sessionEntry.sessionRoot }
+      : undefined;
   let restoreSkillEnv: (() => void) | undefined;
   let bundleMcpRuntime: Awaited<ReturnType<typeof createBundleMcpToolRuntime>> | undefined;
   let bundleLspRuntime: Awaited<ReturnType<typeof createBundleLspToolRuntime>> | undefined;
@@ -315,10 +319,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
             elevated: params.bashElevated,
           },
           sandbox,
-          sessionPermissionPolicy:
-            params.permissionMode && params.sessionRoot
-              ? { mode: params.permissionMode, root: params.sessionRoot }
-              : undefined,
+          sessionPermissionPolicy,
           messageProvider: resolvedMessageProvider,
           clientCaps: params.clientCaps,
           chatType: params.chatType,
@@ -510,7 +511,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       config: params.config,
       agentId: sessionAgentId,
       sessionKey: params.sessionKey,
-      permissionMode: params.permissionMode,
+      permissionMode: sessionPermissionPolicy?.mode,
       sandboxAvailable: sandbox?.enabled === true,
       execOverrides: params.execOverrides,
     });

--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -315,6 +315,10 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
             elevated: params.bashElevated,
           },
           sandbox,
+          sessionPermissionPolicy:
+            params.permissionMode && params.sessionRoot
+              ? { mode: params.permissionMode, root: params.sessionRoot }
+              : undefined,
           messageProvider: resolvedMessageProvider,
           clientCaps: params.clientCaps,
           chatType: params.chatType,
@@ -506,6 +510,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       config: params.config,
       agentId: sessionAgentId,
       sessionKey: params.sessionKey,
+      permissionMode: params.permissionMode,
       sandboxAvailable: sandbox?.enabled === true,
       execOverrides: params.execOverrides,
     });

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt-prepare.ts
@@ -109,6 +109,7 @@ export async function prepareEmbeddedAttemptSystemPrompt(params: {
     config: attempt.config,
     agentId: params.sessionAgentId,
     sessionKey: attempt.sessionKey,
+    permissionMode: attempt.permissionMode,
     sandboxAvailable: params.sandbox?.enabled === true,
     execOverrides: attempt.execOverrides,
   });

--- a/src/agents/embedded-agent-runner/sandbox-info.ts
+++ b/src/agents/embedded-agent-runner/sandbox-info.ts
@@ -1,3 +1,4 @@
+import type { SessionEntry } from "../../config/sessions.js";
 /**
  * Builds sandbox/full-access status metadata for embedded-agent run results.
  */
@@ -73,6 +74,7 @@ export function resolveEmbeddedSandboxInfoExecPolicy(params: {
   config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  permissionMode?: SessionEntry["permissionMode"];
   sandboxAvailable?: boolean;
   execOverrides?: EmbeddedSandboxInfoExecOverrides;
 }): EmbeddedFullAccessExecPolicy {
@@ -80,6 +82,7 @@ export function resolveEmbeddedSandboxInfoExecPolicy(params: {
     cfg: params.config,
     agentId: params.agentId,
     sessionKey: params.sessionKey,
+    sessionEntry: params.permissionMode ? { permissionMode: params.permissionMode } : undefined,
     sandboxAvailable: params.sandboxAvailable,
     elevatedRequested: true,
     execOverrides: params.execOverrides,

--- a/src/agents/exec-defaults.test.ts
+++ b/src/agents/exec-defaults.test.ts
@@ -236,6 +236,29 @@ describe("resolveExecDefaults", () => {
     });
   });
 
+  it("keeps an explicit full session at full/off despite host approval floors", () => {
+    vi.mocked(execApprovals.loadExecApprovals).mockReturnValue({
+      version: 1,
+      defaults: {
+        security: "full",
+        ask: "always",
+      },
+      agents: {},
+    });
+
+    expect(
+      resolveExecDefaults({
+        cfg: withDefaultAgent({}),
+        sessionEntry: { permissionMode: "full" } as SessionEntry,
+        sandboxAvailable: false,
+      }),
+    ).toMatchObject({
+      mode: "full",
+      security: "full",
+      ask: "off",
+    });
+  });
+
   it("keeps agent mode overrides ahead of the global mode", () => {
     expect(
       resolveExecDefaults({

--- a/src/agents/exec-defaults.ts
+++ b/src/agents/exec-defaults.ts
@@ -24,11 +24,12 @@ import { applyExecPolicyLayer } from "../infra/exec-policy.js";
 import { resolveAgentConfig, resolveSessionAgentId } from "./agent-scope.js";
 import { isRequestedExecTargetAllowed, resolveExecTarget } from "./bash-tools.exec-runtime.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import { resolveSessionPermissionCoreToolPolicy } from "./session-permission-exec-mode.js";
 
 /** Session-scoped exec fields that may be carried across an isolated runtime boundary. */
 export type ExecSessionDefaults = Pick<
   SessionEntry,
-  "execHost" | "execSecurity" | "execAsk" | "execNode" | "execCwd"
+  "execHost" | "execSecurity" | "execAsk" | "execNode" | "execCwd" | "permissionMode"
 >;
 
 // Resolved exec config layers come from global config, agent config, legacy
@@ -43,8 +44,8 @@ type ResolvedExecConfig = {
 
 export type ExecPolicyOverrides = Omit<ResolvedExecConfig, "mode">;
 
-// Layering keeps the most specific mode/security/ask while preserving policy
-// bounds from approvals and sandbox availability later in resolution.
+// Legacy/config resolution keeps the most specific mode/security/ask while
+// preserving policy bounds from approvals and sandbox availability later.
 type LayeredExecPolicy = {
   mode?: ExecMode;
   security: ExecSecurity;
@@ -172,8 +173,11 @@ export function resolveExecDefaults(params: {
     sandboxAvailable,
   });
   const defaultSecurity = resolved.effectiveHost === "sandbox" ? "deny" : "full";
+  const sessionPermissionPolicy = params.sessionEntry?.permissionMode
+    ? resolveSessionPermissionCoreToolPolicy({ mode: params.sessionEntry.permissionMode })
+    : undefined;
   const approvalDefaults =
-    resolved.effectiveHost === "sandbox"
+    resolved.effectiveHost === "sandbox" || sessionPermissionPolicy?.bypassHostApprovalFloors
       ? undefined
       : resolveExecApprovalsFromFile({
           file: params.execApprovals ?? loadExecApprovals(),
@@ -187,16 +191,17 @@ export function resolveExecDefaults(params: {
     security: approvalDefaults?.security ?? defaultSecurity,
     ask: approvalDefaults?.ask ?? "off",
   };
-  const layeredPolicy = applyExecPolicyLayer(
-    applySessionLegacyExecPolicyLayer(
-      applyExecPolicyLayer(applyExecPolicyLayer(basePolicy, globalExec), agentExec),
-      params.sessionEntry,
-    ),
-    params.execOverrides,
-  );
+  const layeredPolicy: LayeredExecPolicy = sessionPermissionPolicy
+    ? { mode: sessionPermissionPolicy.execMode, security: defaultSecurity, ask: "off" }
+    : applyExecPolicyLayer(
+        applySessionLegacyExecPolicyLayer(
+          applyExecPolicyLayer(applyExecPolicyLayer(basePolicy, globalExec), agentExec),
+          params.sessionEntry,
+        ),
+        params.execOverrides,
+      );
   const modePolicy = resolveExecModePolicy(layeredPolicy);
-  // Approval files are safety bounds: they can only reduce security/ask from
-  // config-derived policy, never grant a less restrictive effective mode.
+  // Approval files bound every policy source except explicit admin-only full sessions.
   const security =
     approvalDefaults?.security !== undefined
       ? minSecurity(modePolicy.security, approvalDefaults.security)

--- a/src/agents/session-permission-exec-mode.ts
+++ b/src/agents/session-permission-exec-mode.ts
@@ -17,6 +17,7 @@ export function resolveSessionPermissionCoreToolPolicy(
     readOnly: policy.mode === "read-only",
     applyPatchWorkspaceOnly: workspaceOnly,
     execMode: EXEC_MODE_BY_PERMISSION_MODE[policy.mode],
+    bypassHostApprovalFloors: policy.mode === "full",
   };
 }
 

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -262,6 +262,7 @@ type CompactEmbeddedAgentSessionParams = {
   modelSelectionLocked?: boolean;
   preflightRequired?: boolean;
   preflightCompactionTrigger?: string;
+  sessionEntry?: SessionEntry;
   sessionFile?: string;
   sessionId?: string;
   trigger?: string;
@@ -1889,7 +1890,7 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(incrementCompactionCountMock).not.toHaveBeenCalled();
   });
 
-  it("passes runtime policy session key to preflight compaction sandbox resolution", async () => {
+  it("passes persisted session policy and runtime policy key to preflight compaction", async () => {
     const sessionFile = path.join(rootDir, "session.jsonl");
     await fs.writeFile(
       sessionFile,
@@ -1910,6 +1911,8 @@ describe("runMemoryFlushIfNeeded", () => {
       totalTokens: 120,
       totalTokensFresh: true,
       totalTokensVersion: 1,
+      permissionMode: "full",
+      sessionRoot: "/tmp/workspace",
     };
 
     await runPreflightCompactionIfNeeded({
@@ -1937,6 +1940,7 @@ describe("runMemoryFlushIfNeeded", () => {
     expect(compactCall.sessionKey).toBe("agent:main:main");
     expect(compactCall.cwd).toBe("/tmp/task-repo");
     expect(compactCall.sandboxSessionKey).toBe("agent:main:telegram:default:direct:12345");
+    expect(compactCall.sessionEntry).toBe(sessionEntry);
   });
 
   it.each([

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -969,6 +969,7 @@ export async function runPreflightCompactionIfNeeded(params: {
       model: params.followupRun.run.model,
       authProfileId: params.followupRun.run.authProfileId,
       authProfileIdSource: params.followupRun.run.authProfileIdSource,
+      sessionEntry: entry,
       agentHarnessId:
         entry.sessionId === params.followupRun.run.sessionId
           ? entry.modelSelectionLocked === true


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who explicitly selected **Full access** for a session could still receive an exec approval prompt when the host approval policy used `ask: "always"`. The session footer promised unrestricted commands, but the effective runtime policy silently restored human review and disabled **Allow Always**.

## Why This Change Was Made

An explicit, admin-authorized `full` session mode now remains `full` with approvals off across core exec, remote nodes, Claude CLI sessions, and the Codex app-server's native and dynamic tools. Default, config-driven, legacy, and non-full session modes continue to honor host approval floors. Sandbox restrictions, tool allow/deny policy, and externally enforced Codex `requirements.toml` constraints remain independent.

The regression was introduced when session permission modes shipped in #124909: `full` was documented as having no reviewer, while the shared exec resolver and Codex policy path still reapplied host approval floors.

## User Impact

Selecting **Full access** now means what the UI says: commands run without an OpenClaw approval dialog. Operators who want approval review can continue to use Guarded, Workspace, Default, or host-level policy without selecting Full access.

## Evidence

- Added owner-boundary regressions for shared exec policy resolution, gateway exec, remote node execution, Claude CLI permission mapping, Codex policy resolution, and Codex dynamic tools.
- Focused local proof: 371 tests passed across the core and Codex policy shards, plus 145/145 direct-compaction and 76/76 preflight-memory tests after sourcing compaction policy from the persisted session entry.
- Core and extension production/test typechecks passed.
- Changed core and Codex files passed oxlint, formatting, import-cycle, database-first, runtime-sidecar, media-helper, pairing-auth, webhook-body, docs inventory, and dead-export checks.
- `git diff --check` passed.
- Fresh Codex autoreview: no accepted/actionable findings.
- Direct upstream Codex inspection at [`86b1123`](https://github.com/openai/codex/commit/86b1123ff6b5d089a146be4e603a324cf454223a) confirmed that turn policy accepts approval/sandbox overrides, `never` suppresses approval, and `requirements.toml` constrains the allowed approval and sandbox values before runtime use.
- Source-blind live proof on an isolated Gateway with private state, a non-default port, and the public deterministic QA provider:
  - Host policy was re-read as `security=full`, `ask=always`.
  - A Full access session executed randomized stdout, recorded `exec` success in the audit log, and left the approval queue empty.
  - A Guarded comparison session attempted the same command shape and failed with `Headless runs cannot wait for interactive exec approval.`

**Full access — randomized exec completed without an approval:**

![Full access session completing exec without approval](https://github.com/user-attachments/assets/fbfa447f-a818-447c-a9dc-70e73efefc1c)

![Completed exec tool result](https://github.com/user-attachments/assets/e9882140-f8d8-4066-b7f1-cb185cdfebc5)

**Guarded comparison — the same command shape remains approval-gated:**

![Guarded session blocking approval-required exec](https://github.com/user-attachments/assets/da9609df-becf-4dd5-a3a0-4b56bd07d456)

AI-assisted: implementation and review used coding agents; the final diff, contracts, tests, and upstream Codex behavior were inspected by the maintainer.
