### PR TITLE
fix(plugins): list MXC in the offline marketplace

### DIFF
--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -462,6 +462,23 @@
       }
     },
     {
+      "name": "@openclaw/mxc-sandbox",
+      "description": "OpenClaw MXC sandbox execution plugin for MXC-capable hosts",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "mxc",
+          "label": "MXC Sandbox Execution"
+        },
+        "install": {
+          "npmSpec": "@openclaw/mxc-sandbox",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.6.11"
+        }
+      }
+    },
+    {
       "name": "@openclaw/openshell-sandbox",
       "description": "OpenClaw OpenShell sandbox backend",
       "source": "official",
@@ -575,24 +592,6 @@
           "npmSpec": "@openclaw/perplexity-plugin",
           "defaultChoice": "npm",
           "minHostVersion": ">=2026.6.8"
-        }
-      }
-    },
-    {
-      "name": "@openclaw/pixverse-provider",
-      "description": "OpenClaw PixVerse video generation provider plugin",
-      "source": "official",
-      "kind": "plugin",
-      "openclaw": {
-        "plugin": {
-          "id": "pixverse",
-          "label": "PixVerse"
-        },
-        "install": {
-          "clawhubSpec": "clawhub:@openclaw/pixverse-provider",
-          "npmSpec": "@openclaw/pixverse-provider",
-          "defaultChoice": "npm",
-          "minHostVersion": ">=2026.5.26"
         }
       }
     },

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -1288,6 +1288,7 @@
           }
         ],
         "install": {
+          "clawhubSpec": "clawhub:@openclaw/pixverse-provider",
           "npmSpec": "@openclaw/pixverse-provider",
           "defaultChoice": "npm",
           "minHostVersion": ">=2026.5.26"

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -44,6 +44,7 @@ type ExtensionPackageMetadata = {
 
 type BundledCatalogIdentity = {
   id?: string;
+  name?: string;
   openclaw?: {
     channel?: { id?: string };
     plugin?: { id?: string };

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -1,9 +1,11 @@
 import crypto from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import officialExternalChannelCatalog from "../../scripts/lib/official-external-channel-catalog.json" with { type: "json" };
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
+import officialExternalProviderCatalog from "../../scripts/lib/official-external-provider-catalog.json" with { type: "json" };
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
 import {
@@ -15,6 +17,7 @@ import {
   getOfficialExternalPluginCatalogEntry,
   getOfficialExternalPluginCatalogEntryForPackage,
   getOfficialExternalPluginCatalogManifest,
+  isOfficialExternalPluginId,
   isOfficialExternalPluginCatalogFeed,
   listOfficialExternalChannelEnvVars,
   listOfficialExternalPluginCatalogEntries,
@@ -27,6 +30,73 @@ import {
   resolveOfficialExternalPluginInstall,
   resolveOfficialExternalPluginLegacyIds,
 } from "./official-external-plugin-catalog.js";
+
+type ExtensionPackageMetadata = {
+  name?: unknown;
+  openclaw?: {
+    build?: { bundledDist?: unknown };
+    release?: { publishToClawHub?: unknown; publishToNpm?: unknown };
+  };
+};
+
+type BundledCatalogIdentity = {
+  id?: string;
+  openclaw?: {
+    channel?: { id?: string };
+    plugin?: { id?: string };
+    providers?: readonly { id?: string }[];
+  };
+};
+
+function resolveBundledCatalogIdentity(entry: BundledCatalogIdentity): string | undefined {
+  return (
+    entry.openclaw?.plugin?.id ??
+    entry.openclaw?.channel?.id ??
+    entry.openclaw?.providers?.[0]?.id ??
+    entry.id
+  );
+}
+
+function listPublishedExternalPluginOwners(): Array<{ id: string; packageName: string }> {
+  const extensionsDir = new URL("../../extensions/", import.meta.url);
+  return readdirSync(extensionsDir, { withFileTypes: true }).flatMap((entry) => {
+    if (!entry.isDirectory()) {
+      return [];
+    }
+    const extensionDir = new URL(`${entry.name}/`, extensionsDir);
+    let packageJson: ExtensionPackageMetadata;
+    try {
+      packageJson = JSON.parse(
+        readFileSync(new URL("package.json", extensionDir), "utf8"),
+      ) as ExtensionPackageMetadata;
+    } catch {
+      return [];
+    }
+    const release = packageJson.openclaw?.release;
+    if (
+      packageJson.openclaw?.build?.bundledDist !== false ||
+      (release?.publishToClawHub !== true && release?.publishToNpm !== true)
+    ) {
+      return [];
+    }
+    const packageName = packageJson.name;
+    if (typeof packageName !== "string" || !packageName.trim()) {
+      throw new Error(`${entry.name} publishes without a package name`);
+    }
+    let manifest: { id?: unknown };
+    try {
+      manifest = JSON.parse(
+        readFileSync(new URL("openclaw.plugin.json", extensionDir), "utf8"),
+      ) as { id?: unknown };
+    } catch {
+      throw new Error(`${entry.name} publishes without a readable plugin manifest`);
+    }
+    if (typeof manifest.id !== "string" || !manifest.id.trim()) {
+      throw new Error(`${entry.name} publishes without a manifest id`);
+    }
+    return [{ id: manifest.id, packageName }];
+  });
+}
 
 function expectCatalogEntry(id: string): OfficialExternalPluginCatalogEntry {
   const entry = getOfficialExternalPluginCatalogEntry(id);
@@ -257,6 +327,30 @@ describe("official external plugin catalog", () => {
       sequence: 1,
     });
     expect(officialExternalPluginCatalog.entries.length).toBeGreaterThan(0);
+  });
+
+  it("catalogs every published external extension exactly once", async () => {
+    const catalogs: ReadonlyArray<readonly [string, readonly BundledCatalogIdentity[]]> = [
+      ["channel", officialExternalChannelCatalog.entries],
+      ["provider", officialExternalProviderCatalog.entries],
+      ["plugin", officialExternalPluginCatalog.entries],
+    ];
+    const fallback = await loadHostedCatalog({ offline: true, snapshotStore: null });
+    expectBundledFallback(fallback);
+    const fallbackIds = fallback.entries.map(resolveOfficialExternalPluginId);
+
+    const gaps = listPublishedExternalPluginOwners().flatMap(({ id, packageName }) => {
+      const catalogMatches = catalogs.flatMap(([catalog, entries]) =>
+        entries.filter((entry) => resolveBundledCatalogIdentity(entry) === id).map(() => catalog),
+      );
+      const official = isOfficialExternalPluginId(id);
+      const bundledFallbackMatches = fallbackIds.filter((candidate) => candidate === id).length;
+      return catalogMatches.length === 1 && official && bundledFallbackMatches === 1
+        ? []
+        : [{ id, packageName, catalogMatches, official, bundledFallbackMatches }];
+    });
+
+    expect(gaps).toEqual([]);
   });
 
   it("keeps Codex installable as a harness without declaring a model provider", () => {

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -2,11 +2,13 @@ import crypto from "node:crypto";
 import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import { describe, expect, it, vi } from "vitest";
 import officialExternalChannelCatalog from "../../scripts/lib/official-external-channel-catalog.json" with { type: "json" };
 import officialExternalPluginCatalog from "../../scripts/lib/official-external-plugin-catalog.json" with { type: "json" };
 import officialExternalProviderCatalog from "../../scripts/lib/official-external-provider-catalog.json" with { type: "json" };
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import type { PluginPackageInstall } from "./manifest.js";
 import { createSqliteHostedOfficialExternalPluginCatalogSnapshotStore } from "./official-external-plugin-catalog-snapshot-store.js";
 import {
   getOfficialExternalChannelSecretContract,
@@ -35,6 +37,7 @@ type ExtensionPackageMetadata = {
   name?: unknown;
   openclaw?: {
     build?: { bundledDist?: unknown };
+    install?: PluginPackageInstall;
     release?: { publishToClawHub?: unknown; publishToNpm?: unknown };
   };
 };
@@ -57,7 +60,11 @@ function resolveBundledCatalogIdentity(entry: BundledCatalogIdentity): string | 
   );
 }
 
-function listPublishedExternalPluginOwners(): Array<{ id: string; packageName: string }> {
+function listPublishedExternalPluginOwners(): Array<{
+  id: string;
+  packageName: string;
+  install: PluginPackageInstall;
+}> {
   const extensionsDir = new URL("../../extensions/", import.meta.url);
   return readdirSync(extensionsDir, { withFileTypes: true }).flatMap((entry) => {
     if (!entry.isDirectory()) {
@@ -83,6 +90,10 @@ function listPublishedExternalPluginOwners(): Array<{ id: string; packageName: s
     if (typeof packageName !== "string" || !packageName.trim()) {
       throw new Error(`${entry.name} publishes without a package name`);
     }
+    const install = packageJson.openclaw?.install;
+    if (!install) {
+      throw new Error(`${entry.name} publishes without install metadata`);
+    }
     let manifest: { id?: unknown };
     try {
       manifest = JSON.parse(
@@ -94,7 +105,7 @@ function listPublishedExternalPluginOwners(): Array<{ id: string; packageName: s
     if (typeof manifest.id !== "string" || !manifest.id.trim()) {
       throw new Error(`${entry.name} publishes without a manifest id`);
     }
-    return [{ id: manifest.id, packageName }];
+    return [{ id: manifest.id, packageName, install }];
   });
 }
 
@@ -339,15 +350,36 @@ describe("official external plugin catalog", () => {
     expectBundledFallback(fallback);
     const fallbackIds = fallback.entries.map(resolveOfficialExternalPluginId);
 
-    const gaps = listPublishedExternalPluginOwners().flatMap(({ id, packageName }) => {
+    const gaps = listPublishedExternalPluginOwners().flatMap(({ id, packageName, install }) => {
       const catalogMatches = catalogs.flatMap(([catalog, entries]) =>
-        entries.filter((entry) => resolveBundledCatalogIdentity(entry) === id).map(() => catalog),
+        entries
+          .filter((entry) => resolveBundledCatalogIdentity(entry) === id)
+          .map((entry) => ({ catalog, entry })),
       );
+      const catalogEntry = catalogMatches.length === 1 ? catalogMatches[0]?.entry : undefined;
+      const catalogInstall = catalogEntry
+        ? resolveOfficialExternalPluginInstall(catalogEntry)
+        : undefined;
       const official = isOfficialExternalPluginId(id);
       const bundledFallbackMatches = fallbackIds.filter((candidate) => candidate === id).length;
-      return catalogMatches.length === 1 && official && bundledFallbackMatches === 1
+      return catalogMatches.length === 1 &&
+        catalogEntry?.name === packageName &&
+        isDeepStrictEqual(catalogInstall, install) &&
+        official &&
+        bundledFallbackMatches === 1
         ? []
-        : [{ id, packageName, catalogMatches, official, bundledFallbackMatches }];
+        : [
+            {
+              id,
+              packageName,
+              install,
+              catalogMatches: catalogMatches.map(({ catalog }) => catalog),
+              catalogPackageName: catalogEntry?.name,
+              catalogInstall,
+              official,
+              bundledFallbackMatches,
+            },
+          ];
     });
 
     expect(gaps).toEqual([]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using the offline plugin marketplace could not discover or install the published `@openclaw/mxc-sandbox` plugin. The same ownership drift also left PixVerse duplicated across the plugin and provider catalogs, so its canonical provider entry lacked the ClawHub install metadata carried by the duplicate.

## Why This Change Was Made

This restores one canonical catalog owner per published external plugin: MXC is added to the plugin catalog, while PixVerse remains provider-owned and retains both ClawHub and npm install metadata there. A generic invariant now verifies every published `bundledDist: false` plugin is represented exactly once across the channel, provider, and plugin catalogs and that the sole row matches the package-owned name and install metadata, closing both observed drift modes with one owner-boundary check.

No package-name/provider heuristic or parallel ownership path is introduced.

## User Impact

Offline marketplace users can discover MXC and install `@openclaw/mxc-sandbox` from npm. PixVerse continues to appear once as a provider, now with both supported install routes.

## Evidence

- Source-blind rebuilt CLI: `pnpm openclaw plugins marketplace entries --offline --json` from a fresh state directory returned 95 entries; MXC appeared exactly once as `kind: plugin` with package-owned npm metadata, and PixVerse exactly once as `kind: provider` with ClawHub and npm metadata.
- Focused regression after the ClawSweeper metadata-ownership assertion: `node scripts/run-vitest.mjs src/plugins/official-external-plugin-catalog.test.ts` — 81/81 passed.
- Changed-file gates, full build, root/MXC package inventory inspection, and `git diff --check` passed during final validation.
- Fresh Codex autoreview on the final three-file diff and the review follow-up: clean, no accepted/actionable findings.
- LOC: catalog metadata +18/-18 (net zero); tests +128/-1; production TypeScript +0.
- The root release tarball independently exceeds its existing size budget on both sides of this patch (212,423,141 vs 211,812,352). This PR does not change package output or the budget; the unrelated follow-up is tracked separately.

AI-assisted. I understand and reviewed the change. No agent transcript is included.
