### PR TITLE
fix(telegram): preserve business identity in lanes and pairing

### DIFF
--- a/extensions/telegram/src/dm-access.test.ts
+++ b/extensions/telegram/src/dm-access.test.ts
@@ -171,4 +171,34 @@ describe("enforceTelegramDmAccess", () => {
       "telegram pairing request",
     );
   });
+
+  it("sends pairing challenges through the Business connection for unauthorized Business DMs", async () => {
+    const sendMessage = vi.fn(async () => undefined);
+    createChannelPairingChallengeIssuerMock.mockReturnValueOnce(
+      ({
+        sendPairingReply,
+      }: Parameters<ReturnType<typeof createChannelPairingChallengeIssuer>>[0]) =>
+        (async () => {
+          await sendPairingReply("Pairing code: 123456");
+        })(),
+    );
+
+    const allowed = await enforceTelegramDmAccess({
+      isGroup: false,
+      dmPolicy: "pairing",
+      msg: createDmMessage({ business_connection_id: "biz-conn-123" }),
+      chatId: 42,
+      effectiveDmAllow: normalizeAllowFrom([]),
+      accountId: "main",
+      bot: { api: { sendMessage } } as never,
+      logger: { info: vi.fn() },
+      upsertPairingRequest: upsertChannelPairingRequestMock,
+    });
+
+    expect(allowed).toBe(false);
+    expect(sendMessage).toHaveBeenCalledWith(42, expect.stringContaining("Pairing code:"), {
+      business_connection_id: "biz-conn-123",
+      parse_mode: "HTML",
+    });
+  });
 });

--- a/extensions/telegram/src/dm-access.ts
+++ b/extensions/telegram/src/dm-access.ts
@@ -157,9 +157,14 @@ export async function enforceTelegramDmAccess(params: {
         },
         sendPairingReply: async (text) => {
           const html = renderTelegramHtmlText(text);
+          const businessConnectionId = msg.business_connection_id;
           await withTelegramApiErrorLogging({
             operation: "sendMessage",
-            fn: () => bot.api.sendMessage(chatId, html, { parse_mode: "HTML" }),
+            fn: () =>
+              bot.api.sendMessage(chatId, html, {
+                ...(businessConnectionId ? { business_connection_id: businessConnectionId } : {}),
+                parse_mode: "HTML",
+              }),
           });
         },
         onReplyError: (err) => {

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -97,6 +97,51 @@ describe("getTelegramSequentialKey", () => {
       "telegram:123:topic:1",
     ],
     [{ update: { message: mockMessage({ chat: mockChat({ id: 555 }) }) } }, "telegram:555"],
+    [
+      {
+        update: {
+          business_message: mockMessage({
+            business_connection_id: "biz-1",
+            chat: mockChat({ id: 555, type: "private" }),
+          }),
+        } as never,
+      },
+      "telegram:business:biz-1:555",
+    ],
+    [
+      {
+        update: {
+          edited_business_message: mockMessage({
+            business_connection_id: "biz-1",
+            chat: mockChat({ id: 555, type: "private" }),
+          }),
+        } as never,
+      },
+      "telegram:business:biz-1:555",
+    ],
+    [
+      {
+        update: {
+          deleted_business_messages: {
+            business_connection_id: "biz-1",
+            chat: mockChat({ id: 555, type: "private" }),
+            message_ids: [1],
+          },
+        } as never,
+      },
+      "telegram:business:biz-1:555",
+    ],
+    [
+      {
+        update: {
+          business_message: mockMessage({
+            business_connection_id: "biz-2",
+            chat: mockChat({ id: 555, type: "private" }),
+          }),
+        } as never,
+      },
+      "telegram:business:biz-2:555",
+    ],
     [{ update: { poll_answer: { poll_id: "poll-123" } } }, "telegram:poll:poll-123"],
     [
       {

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -1,5 +1,5 @@
 // Telegram plugin module implements sequential key behavior.
-import type { Message, UserFromGetMe } from "grammy/types";
+import type { BusinessMessagesDeleted, Message, UserFromGetMe } from "grammy/types";
 import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
 import {
   listChatCommands,
@@ -43,6 +43,9 @@ type TelegramSequentialKeyContext = {
   update?: {
     message?: Message;
     edited_message?: Message;
+    business_message?: Message;
+    edited_business_message?: Message;
+    deleted_business_messages?: BusinessMessagesDeleted;
     channel_post?: Message;
     edited_channel_post?: Message;
     callback_query?: { message?: Message; data?: string };
@@ -149,6 +152,17 @@ function isTelegramControlLaneText(params: { rawText?: string; botUsername?: str
   return isTelegramReadOnlyControlLaneText(params);
 }
 
+function resolveTelegramBusinessConnectionId(msg?: Message): string | undefined {
+  const businessConnectionId = msg?.business_connection_id;
+  return businessConnectionId && businessConnectionId.trim() ? businessConnectionId : undefined;
+}
+
+function formatTelegramChatLane(params: { businessConnectionId?: string; chatId: number }): string {
+  return params.businessConnectionId
+    ? `telegram:business:${params.businessConnectionId}:${params.chatId}`
+    : `telegram:${params.chatId}`;
+}
+
 export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): string {
   const reaction = ctx.update?.message_reaction;
   if (reaction?.chat?.id) {
@@ -173,32 +187,41 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
     ctx.editedChannelPost ??
     ctx.update?.message ??
     ctx.update?.edited_message ??
+    ctx.update?.business_message ??
+    ctx.update?.edited_business_message ??
     ctx.update?.channel_post ??
     ctx.update?.edited_channel_post ??
     ctx.update?.callback_query?.message;
-  const chatId = msg?.chat?.id ?? ctx.chat?.id;
+  const deletedBusinessMessages = ctx.update?.deleted_business_messages;
+  const businessConnectionId =
+    resolveTelegramBusinessConnectionId(msg) ?? deletedBusinessMessages?.business_connection_id;
+  const chatId = msg?.chat?.id ?? deletedBusinessMessages?.chat?.id ?? ctx.chat?.id;
   const rawText = msg?.text ?? msg?.caption;
   const botUsername = ctx.me?.username;
+  const chatLane =
+    typeof chatId === "number"
+      ? formatTelegramChatLane({ businessConnectionId, chatId })
+      : undefined;
   if (isTelegramControlLaneText({ rawText, botUsername })) {
-    if (typeof chatId === "number") {
-      return `telegram:${chatId}:control`;
+    if (chatLane) {
+      return `${chatLane}:control`;
     }
     return "telegram:control";
   }
   if (isBtwRequestText(rawText, botUsername ? { botUsername } : undefined)) {
     const messageId = msg?.message_id;
-    if (typeof chatId === "number" && typeof messageId === "number") {
-      return `telegram:${chatId}:btw:${messageId}`;
+    if (chatLane && typeof messageId === "number") {
+      return `${chatLane}:btw:${messageId}`;
     }
-    if (typeof chatId === "number") {
-      return `telegram:${chatId}:btw`;
+    if (chatLane) {
+      return `${chatLane}:btw`;
     }
     return "telegram:btw";
   }
   const callbackData = ctx.update?.callback_query?.data;
   if (hasTelegramQuestionCallbackPrefix(callbackData)) {
-    if (typeof chatId === "number") {
-      return `telegram:${chatId}:question`;
+    if (chatLane) {
+      return `${chatLane}:question`;
     }
     return "telegram:question";
   }
@@ -206,10 +229,13 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
     hasTelegramApprovalCallbackPrefix(callbackData) ||
     (callbackData && parseExecApprovalCommandText(callbackData) !== null)
   ) {
-    if (typeof chatId === "number") {
-      return `telegram:${chatId}:approval`;
+    if (chatLane) {
+      return `${chatLane}:approval`;
     }
     return "telegram:approval";
+  }
+  if (businessConnectionId && chatLane) {
+    return chatLane;
   }
   // Raw durable-ingress fixtures and malformed updates can carry a partial
   // message. Treat missing chat identity as an unknown lane instead of


### PR DESCRIPTION
## What Problem This Solves

Telegram Business updates need to stay business-scoped all the way through lane selection and pairing/access decisions. Without that boundary, Business traffic can collapse into plain chat-id lanes or lose its `business_connection_id` before downstream handling can make a safe distinction between ordinary bot DMs and secretary-mode messages.

## Summary

This is the focused business-identity slice from the Telegram Business Connect review work around #114087 / #20786.

It fixes two business-mode routing boundaries:

- business updates now use business-scoped sequential lanes instead of collapsing into plain chat-id lanes
- pairing/access decisions preserve `business_connection_id` when a Telegram Business message enters the DM access path

## Evidence

Tested locally after rebasing on current `openclaw/openclaw:main`:

- `pnpm test extensions/telegram/src/dm-access.test.ts extensions/telegram/src/sequential-key.test.ts` -> 2 files, 71 tests passed
- `pnpm tsgo:extensions` -> passed
- `git diff --check origin/main..HEAD` -> clean