### PR TITLE
perf(test): fake audit contention retry clock

### DIFF
--- a/src/audit/audit-event-writer.test.ts
+++ b/src/audit/audit-event-writer.test.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from "node:sqlite";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { DecisionReceiptV1 } from "../../packages/gateway-protocol/src/index.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { readSqliteBusyTimeout } from "../infra/sqlite-busy-timeout.js";
@@ -459,8 +459,13 @@ describe("audit event writer", () => {
     const { path } = openOpenClawStateDatabase(database);
     const contender = new DatabaseSync(path);
     contender.exec("PRAGMA busy_timeout = 0; BEGIN IMMEDIATE");
+    let fakeTimersActive = false;
 
     try {
+      vi.useFakeTimers({
+        toFake: ["setImmediate", "clearImmediate", "setTimeout", "clearTimeout"],
+      });
+      fakeTimersActive = true;
       expect(
         writer.record({
           ...input(),
@@ -468,14 +473,28 @@ describe("audit event writer", () => {
           runId: "sustained-contention",
         }),
       ).toBe(true);
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 1_750);
-      });
+      await vi.advanceTimersByTimeAsync(1_750);
       expect(contentions).toEqual(["audit event persistence delayed by SQLite lock contention"]);
     } finally {
-      contender.exec("ROLLBACK");
-      contender.close();
-      await writer.stop();
+      try {
+        try {
+          contender.exec("ROLLBACK");
+        } finally {
+          contender.close();
+        }
+      } finally {
+        try {
+          const stopPromise = writer.stop();
+          if (fakeTimersActive) {
+            await vi.advanceTimersToNextTimerAsync();
+          }
+          await stopPromise;
+        } finally {
+          if (fakeTimersActive) {
+            vi.useRealTimers();
+          }
+        }
+      }
     }
 
     expect(errors).toEqual([]);


### PR DESCRIPTION
## What Problem This Solves

The audit-writer SQLite contention regression test unconditionally spent 1,750 ms sleeping on the wall clock even though the behavior under test is retry/backoff scheduling. That made a bounded, deterministic test materially slower without adding runtime coverage.

## Why This Change Was Made

This uses Vitest fake timers only for `setImmediate`, `clearImmediate`, `setTimeout`, and `clearTimeout` during the contention case. Writer startup and the maintenance interval, `Date`, `performance`, SQLite, the separate `DatabaseSync` `BEGIN IMMEDIATE` lock, retry/backoff logic, contention reporting, and eventual persistence remain real.

Cleanup still releases the real SQLite lock, starts writer shutdown, advances the next required fake timer, awaits shutdown and persistence, and restores real timers even when an earlier assertion fails.

## User Impact

No production behavior changes. Maintainers and CI retain the same audit-contention coverage while the focused test finishes substantially faster.

Production LOC: +0/-0. Tests: +26/-7.

## Evidence

- Testbox: `tbx_01m0c5kgcm1r2th43r8d4bmg8z`
- Completed proof run: https://github.com/openclaw/openclaw/actions/runs/32217113417
- Controlled A/B excluded warmup and retained two measured runs, using one worker, distinct caches, import diagnostics, and `/usr/bin/time -v`.
- Wall time: 12.16s -> 10.61s (-1.55s, -12.7%).
- Vitest duration: 6.375s -> 4.10s. Test body: 4.175s -> 1.625s. Contention case: 2653.5ms -> 68.5ms. RSS was essentially flat.
- Focused target: 11/11 passing. SQLite busy-timeout sibling: 6/6 passing.
- Negative-control fault: advancing only 774ms left the contention list empty and failed the one-message assertion; restoring the exact timing made the proof pass.
- Complete changed gate passed: all guards, production/test types, lint, format, dead-code checks, target tests, and sibling tests.
- `git diff --check` clean. Fresh branch autoreview: 0.99, no accepted/actionable findings.

Docs: N/A (test-only). Changelog: N/A (no user-visible behavior). Screenshots: N/A (no UI change). Agent transcript: omitted per maintainer instruction.
