### PR TITLE
fix(security): prevent blocked SearXNG refs from using ambient URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **SearXNG SecretRef policy:** prevent explicitly blocked base-URL references from falling through to the ambient `SEARXNG_BASE_URL` while preserving ambient fallback for missing configuration.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **SearXNG SecretRef policy:** prevent explicitly blocked base-URL references from falling through to the ambient `SEARXNG_BASE_URL` while preserving ambient fallback for missing configuration.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1145,7 +1145,7 @@ extensions/reef/src/setup.ts	5
 extensions/reef/src/state.ts	3
 extensions/reef/src/transport.ts	3
 extensions/runway/video-generation-provider.ts	1
-extensions/searxng/src/config.ts	2
+extensions/searxng/src/config.ts	1
 extensions/searxng/src/searxng-client.ts	3
 extensions/signal/src/accounts.ts	3
 extensions/signal/src/approval-handler.runtime.ts	2

--- a/docs/tools/searxng-search.md
+++ b/docs/tools/searxng-search.md
@@ -93,10 +93,12 @@ Set `SEARXNG_BASE_URL` as an alternative to config:
 export SEARXNG_BASE_URL="http://localhost:8888"
 ```
 
-Resolution order: configured `baseUrl` string, then an inline env SecretRef on
-`baseUrl`, then `SEARXNG_BASE_URL`. When none of the config paths are set and
-`SEARXNG_BASE_URL` is present with no explicit provider chosen, auto-detection
-picks SearXNG.
+Resolution order: configured `baseUrl` (a string or an allowed env SecretRef),
+then `SEARXNG_BASE_URL` only when `baseUrl` is missing. An explicit SecretRef
+that read-only config inspection blocks does not fall through to the ambient
+environment; fix its provider, default-provider, or env allowlist policy
+instead. When none of the config paths are set and `SEARXNG_BASE_URL` is
+present with no explicit provider chosen, auto-detection picks SearXNG.
 
 ## Plugin config reference
 

--- a/extensions/browser/chrome-extension/modules/native-bootstrap.js
+++ b/extensions/browser/chrome-extension/modules/native-bootstrap.js
@@ -1,3 +1,4 @@
+import { randomRelayBase64Url } from "./relay-auth-v2-crypto.js";
 import { ACCESS_MODE_ALL, parsePairingString } from "./relay-core.js";
 
 const NATIVE_HOST_NAME = "ai.openclaw.browser_bootstrap";
@@ -52,15 +53,6 @@ function nativeResponse(value, nonce) {
     return { kind: "failure", code: value.code };
   }
   return { kind: "malformed" };
-}
-
-function randomNonce() {
-  const hex = crypto.randomUUID().replaceAll("-", "");
-  let binary = "";
-  for (let offset = 0; offset < hex.length; offset += 2) {
-    binary += String.fromCharCode(Number.parseInt(hex.slice(offset, offset + 2), 16));
-  }
-  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
 }
 
 function isHostMissing(error) {
@@ -148,7 +140,7 @@ export function createNativeBootstrapController({ chromeApi = chrome, getPairing
       if (state.state === "manual_required") {
         return { status: "manual_required", code: state.failureCode };
       }
-      const nonce = randomNonce();
+      const nonce = randomRelayBase64Url(crypto, 16);
       let response;
       try {
         response = await sendNativeBootstrap(chromeApi, {

--- a/extensions/browser/chrome-extension/modules/native-bootstrap.test.ts
+++ b/extensions/browser/chrome-extension/modules/native-bootstrap.test.ts
@@ -314,7 +314,10 @@ describe("native bootstrap timeout", () => {
   it("bounds a stuck native call and leaves status retryable", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("crypto", {
-      randomUUID: vi.fn(() => "00112233-4455-6677-8899-aabbccddeeff"),
+      getRandomValues: vi.fn((bytes: Uint8Array) => {
+        bytes.set(Uint8Array.from({ length: 16 }, (_, index) => index * 17));
+        return bytes;
+      }),
     });
     const stored: Record<string, unknown> = {};
     let onDisconnect = () => {};

--- a/extensions/browser/src/browser/extension-relay/relay-server.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.ts
@@ -3,7 +3,11 @@ import crypto from "node:crypto";
 import http, { type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
-import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
+import {
+  rawDataToString,
+  readRequestBodyWithLimit,
+  WEBHOOK_BODY_READ_DEFAULTS,
+} from "openclaw/plugin-sdk/webhook-ingress";
 import { WebSocketServer, type RawData, type WebSocket } from "ws";
 import { isLoopbackHost } from "../../gateway/net.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -157,14 +161,15 @@ function rejectHttp(res: ServerResponse, status: number, message: string): void 
 }
 
 async function readAuthBody(req: IncomingMessage): Promise<string | null> {
-  let body = "";
-  for await (const chunk of req) {
-    body += Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
-    if (Buffer.byteLength(body) > MAX_AUTH_BODY_BYTES) {
-      return null;
-    }
+  try {
+    return await readRequestBodyWithLimit(req, {
+      ...WEBHOOK_BODY_READ_DEFAULTS.preAuth,
+      maxBytes: MAX_AUTH_BODY_BYTES,
+      destroyOnLimit: false,
+    });
+  } catch {
+    return null;
   }
-  return body;
 }
 
 function bindSocket(

--- a/extensions/onepassword/onepassword-secret-ref-resolver.js
+++ b/extensions/onepassword/onepassword-secret-ref-resolver.js
@@ -4,8 +4,8 @@ import fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DEFAULT_SECRET_FILE_MAX_BYTES, tryReadSecretFileSync } from "@openclaw/fs-safe/secret";
-import { execa } from "execa";
 import { coerceErrorMessage as errorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { runCommandBuffered } from "openclaw/plugin-sdk/process-runtime";
 import { resolveTrustedOnePasswordCli } from "./onepassword-op-path.js";
 import { resolveOnePasswordSecretReference } from "./onepassword-secret-id.js";
 
@@ -180,54 +180,32 @@ function opEnvironment(token) {
 }
 
 async function runOpRead(opCommand, token, secretReference) {
-  // Keep execa's default utf8 encoding: secrets are decoded as utf8 anyway, and
-  // Bun's spawn rejects execa's "buffer" encoding option (oven-sh/bun#36049),
-  // surfacing as a masked "Attempted to assign to readonly property." TypeError.
-  const subprocess = execa(opCommand, ["read", "--cache=false", "--no-newline", secretReference], {
-    cleanup: true,
-    env: opEnvironment(token),
-    extendEnv: false,
-    killDescendants: true,
-    killSignal: "SIGKILL",
-    reject: false,
-    stripFinalNewline: false,
-  });
-  let outputBytes = 0;
-  let terminationReason;
-  const terminate = (reason) => {
-    if (terminationReason) {
-      return;
-    }
-    terminationReason = reason;
-    subprocess.kill("SIGKILL");
-  };
-  subprocess.stdout?.on("data", (chunk) => {
-    outputBytes += chunk.byteLength;
-    if (outputBytes > MAX_SECRET_VALUE_BYTES) {
-      terminate("output-limit");
-    }
-  });
-  const timeout = setTimeout(() => terminate("timeout"), OP_READ_TIMEOUT_MS);
-  timeout.unref?.();
-  const result = await subprocess.finally(() => clearTimeout(timeout));
-  if (result.code === "ENOENT") {
+  const result = await runCommandBuffered(
+    [opCommand, "read", "--cache=false", "--no-newline", secretReference],
+    {
+      baseEnv: {},
+      discardOutput: { stderr: true },
+      env: opEnvironment(token),
+      maxOutputBytes: { stdout: MAX_SECRET_VALUE_BYTES },
+      timeoutMs: OP_READ_TIMEOUT_MS,
+    },
+  );
+  if (result.termination === "error" && result.error?.code === "ENOENT") {
     throw new Error(opMissingMessage(opCommand));
   }
-  if (terminationReason === "timeout") {
+  if (result.termination === "timeout") {
     throw new Error(`op read timed out after ${OP_READ_TIMEOUT_MS}ms.`);
   }
-  if (terminationReason === "output-limit") {
+  if (result.termination === "output-limit") {
     throw new Error("op read output exceeded the secret value limit.");
   }
-  if (result.exitCode !== 0) {
-    throw new Error(`op read failed with exit code ${String(result.exitCode)}.`);
-  }
-  // A missing stdout string means the subprocess never produced output streams
-  // (spawn-level failure with reject:false), not an empty secret.
-  if (typeof result.stdout !== "string") {
+  if (result.termination === "error") {
     throw new Error("op read could not be started.");
   }
-  return result.stdout;
+  if (result.code !== 0) {
+    throw new Error(`op read failed with exit code ${String(result.code)}.`);
+  }
+  return result.stdout.toString("utf8");
 }
 
 async function runWithConcurrency(values, limit, task) {

--- a/extensions/onepassword/package.json
+++ b/extensions/onepassword/package.json
@@ -5,8 +5,7 @@
   "description": "1Password SecretRef resolver and audited agent secrets broker for OpenClaw",
   "type": "module",
   "dependencies": {
-    "@openclaw/fs-safe": "0.5.5",
-    "execa": "10.0.0"
+    "@openclaw/fs-safe": "0.5.5"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/extensions/onepassword/src/secret-ref-resolver.test.ts
+++ b/extensions/onepassword/src/secret-ref-resolver.test.ts
@@ -814,7 +814,8 @@ while true; do sleep 1; done
       // Windows verifies the executable owner and ACL chain through OS tooling before op starts.
       // Keep the synchronization bound above that preflight without weakening the kill deadline.
       await Promise.race([
-        waitForPath(descendantReady, process.platform === "win32" ? 15_000 : 5_000),
+        // Source-mode loading now includes the shared process runtime before op starts.
+        waitForPath(descendantReady, process.platform === "win32" ? 15_000 : 10_000),
         resultPromise.then((result) => {
           throw new Error(
             `Resolver exited before the descendant was ready: ${JSON.stringify(result)}`,

--- a/extensions/raft/src/gateway.ts
+++ b/extensions/raft/src/gateway.ts
@@ -10,6 +10,10 @@ import { channelReadyPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { createChannelReplayGuard } from "openclaw/plugin-sdk/persistent-dedupe";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
+import {
+  readJsonBodyWithLimit,
+  WEBHOOK_BODY_READ_DEFAULTS,
+} from "openclaw/plugin-sdk/webhook-request-guards";
 import { RAFT_CHANNEL_ID, type ResolvedRaftAccount } from "./accounts.js";
 import { dispatchRaftWake } from "./inbound.js";
 
@@ -76,6 +80,7 @@ class WakeRequestError extends Error {
   constructor(
     readonly statusCode: number,
     message: string,
+    readonly closeAfterResponse = false,
   ) {
     super(message);
   }
@@ -124,31 +129,23 @@ function hasMatchingToken(request: IncomingMessage, expected: string): boolean {
 }
 
 async function readWakePayload(request: IncomingMessage): Promise<Record<string, unknown>> {
-  const chunks: Buffer[] = [];
-  let bytes = 0;
-  let tooLarge = false;
-  for await (const chunk of request) {
-    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    bytes += buffer.length;
-    if (bytes > MAX_WAKE_BODY_BYTES) {
-      tooLarge = true;
-      continue;
+  const body = await readJsonBodyWithLimit(request, {
+    ...WEBHOOK_BODY_READ_DEFAULTS.postAuthResponseFirst,
+    maxBytes: MAX_WAKE_BODY_BYTES,
+  });
+  if (!body.ok) {
+    if (body.code === "PAYLOAD_TOO_LARGE") {
+      throw new WakeRequestError(413, "Wake payload exceeds the 16 KiB limit.", true);
     }
-    chunks.push(buffer);
+    if (body.code === "REQUEST_BODY_TIMEOUT") {
+      throw new WakeRequestError(408, body.error, true);
+    }
+    throw new WakeRequestError(
+      400,
+      body.code === "INVALID_JSON" ? "Wake payload must be valid JSON." : body.error,
+    );
   }
-  if (tooLarge) {
-    throw new WakeRequestError(413, "Wake payload exceeds the 16 KiB limit.");
-  }
-  const text = Buffer.concat(chunks).toString("utf8").trim();
-  if (!text) {
-    return {};
-  }
-  let payload: unknown;
-  try {
-    payload = JSON.parse(text);
-  } catch {
-    throw new WakeRequestError(400, "Wake payload must be valid JSON.");
-  }
+  const payload = body.value;
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     throw new WakeRequestError(400, "Wake payload must be an object.");
   }
@@ -339,6 +336,14 @@ export async function startRaftGatewayAccount(
       const message = error instanceof WakeRequestError ? error.message : "Internal server error.";
       ctx.log?.warn?.(`Raft wake request rejected: ${message}`);
       if (!response.headersSent) {
+        if (error instanceof WakeRequestError && error.closeAfterResponse) {
+          response.setHeader("Connection", "close");
+          response.once("close", () => {
+            if (!request.destroyed) {
+              request.destroy();
+            }
+          });
+        }
         sendJson(response, statusCode, { error: message });
       } else {
         response.destroy();

--- a/extensions/searxng/src/config.ts
+++ b/extensions/searxng/src/config.ts
@@ -1,10 +1,11 @@
 // Searxng helper module supports config behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import {
-  normalizeResolvedSecretInputString,
-  normalizeSecretInput,
-} from "openclaw/plugin-sdk/secret-input";
+import { normalizeSecretInput } from "openclaw/plugin-sdk/secret-input";
+import { resolveReadOnlyEnvSecretRef } from "openclaw/plugin-sdk/secret-ref-readonly";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+const SEARXNG_BASE_URL_ENV_VAR = "SEARXNG_BASE_URL";
+const SEARXNG_BASE_URL_PATH = "plugins.entries.searxng.config.webSearch.baseUrl";
 
 type SearxngPluginConfig = {
   webSearch?: {
@@ -14,32 +15,8 @@ type SearxngPluginConfig = {
   };
 };
 
-function normalizeConfiguredString(value: unknown, path: string): string | undefined {
-  try {
-    return normalizeSecretInput(
-      normalizeResolvedSecretInputString({
-        value,
-        path,
-      }),
-    );
-  } catch {
-    return undefined;
-  }
-}
-
-function readInlineEnvSecretRefValue(value: unknown, env: NodeJS.ProcessEnv): string | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-  const record = value as { source?: unknown; id?: unknown };
-  if (record.source !== "env" || typeof record.id !== "string") {
-    return undefined;
-  }
-  return normalizeSecretInput(env[record.id]);
-}
-
-function normalizeBaseUrl(value: string | undefined): string | undefined {
-  return value?.replace(/\/+$/u, "") || undefined;
+function normalizeBaseUrl(value: unknown): string | undefined {
+  return normalizeSecretInput(value)?.replace(/\/+$/u, "") || undefined;
 }
 
 function resolveSearxngWebSearchConfig(
@@ -53,21 +30,22 @@ function resolveSearxngWebSearchConfig(
   return undefined;
 }
 
-export function resolveSearxngBaseUrl(
-  config?: OpenClawConfig,
-  env: NodeJS.ProcessEnv = process.env,
-): string | undefined {
+export function resolveSearxngBaseUrl(config?: OpenClawConfig): string | undefined {
   const webSearch = resolveSearxngWebSearchConfig(config);
-  return (
-    normalizeBaseUrl(
-      normalizeConfiguredString(
-        webSearch?.baseUrl,
-        "plugins.entries.searxng.config.webSearch.baseUrl",
-      ),
-    ) ??
-    normalizeBaseUrl(readInlineEnvSecretRefValue(webSearch?.baseUrl, env)) ??
-    normalizeBaseUrl(normalizeSecretInput(env.SEARXNG_BASE_URL))
-  );
+  const resolved = resolveReadOnlyEnvSecretRef({
+    value: webSearch?.baseUrl,
+    path: SEARXNG_BASE_URL_PATH,
+    cfg: config,
+    expectedEnvId: SEARXNG_BASE_URL_ENV_VAR,
+    normalizeValue: normalizeBaseUrl,
+  });
+  if (resolved.status === "available") {
+    return resolved.value;
+  }
+  if (resolved.status === "blocked") {
+    return undefined;
+  }
+  return normalizeBaseUrl(process.env[SEARXNG_BASE_URL_ENV_VAR]);
 }
 
 export function resolveSearxngCategories(config?: OpenClawConfig): string | undefined {

--- a/extensions/searxng/src/searxng-search-provider.test.ts
+++ b/extensions/searxng/src/searxng-search-provider.test.ts
@@ -25,6 +25,7 @@ describe("searxng web search provider", () => {
   });
 
   beforeEach(() => {
+    vi.unstubAllEnvs();
     runSearxngSearch.mockReset();
     runSearxngSearch.mockImplementation(async (params: Record<string, unknown>) => params);
   });
@@ -135,36 +136,63 @@ describe("searxng web search provider", () => {
   });
 
   it("reads base URL from plugin config SecretRef, then env var, stripping trailing slashes", () => {
+    vi.stubEnv("SEARXNG_BASE_URL", "http://localhost:8888/");
     expect(
-      resolveSearxngBaseUrl(
-        {
-          plugins: {
-            entries: {
-              searxng: {
-                config: {
-                  webSearch: {
-                    baseUrl: {
-                      source: "env",
-                      provider: "default",
-                      id: "SEARXNG_BASE_URL",
-                    },
+      resolveSearxngBaseUrl({
+        plugins: {
+          entries: {
+            searxng: {
+              config: {
+                webSearch: {
+                  baseUrl: {
+                    source: "env",
+                    provider: "default",
+                    id: "SEARXNG_BASE_URL",
                   },
                 },
               },
             },
           },
-        } as never,
-        { SEARXNG_BASE_URL: "http://localhost:8888/" },
-      ),
+        },
+      } as never),
     ).toBe("http://localhost:8888");
 
-    expect(
-      resolveSearxngBaseUrl({} as never, {
-        SEARXNG_BASE_URL: "https://search.local/searxng///",
-      }),
-    ).toBe("https://search.local/searxng");
+    vi.stubEnv("SEARXNG_BASE_URL", "https://search.local/searxng///");
+    expect(resolveSearxngBaseUrl({} as never)).toBe("https://search.local/searxng");
 
-    expect(resolveSearxngBaseUrl({} as never, {})).toBeUndefined();
+    vi.stubEnv("SEARXNG_BASE_URL", "");
+    expect(resolveSearxngBaseUrl({} as never)).toBeUndefined();
+  });
+
+  it("does not fall back to ambient env when an explicit SecretRef is blocked", () => {
+    vi.stubEnv("SEARXNG_BASE_URL", "https://ambient.example/");
+    const config = {
+      secrets: {
+        providers: {
+          restricted: {
+            source: "env",
+            allowlist: [],
+          },
+        },
+      },
+      plugins: {
+        entries: {
+          searxng: {
+            config: {
+              webSearch: {
+                baseUrl: {
+                  source: "env",
+                  provider: "restricted",
+                  id: "SEARXNG_BASE_URL",
+                },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(resolveSearxngBaseUrl(config)).toBeUndefined();
   });
 
   it("reads categories and language from plugin config", () => {
@@ -204,6 +232,6 @@ describe("searxng web search provider", () => {
 
     setConfiguredCredentialValue(config, "http://search.local:9000");
 
-    expect(resolveSearxngBaseUrl(config, {})).toBe("http://search.local:9000");
+    expect(resolveSearxngBaseUrl(config)).toBe("http://search.local:9000");
   });
 });

--- a/extensions/telegram/src/miniapp/routes.ts
+++ b/extensions/telegram/src/miniapp/routes.ts
@@ -8,6 +8,10 @@ import {
 } from "openclaw/plugin-sdk/device-bootstrap";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  createFixedWindowRateLimiter,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+} from "openclaw/plugin-sdk/webhook-ingress";
 import { readJsonWebhookBodyOrReject } from "openclaw/plugin-sdk/webhook-request-guards";
 import { resolveTelegramAccount } from "../accounts.js";
 import { validateTelegramMiniAppInitData } from "./init-data.js";
@@ -26,7 +30,11 @@ const REPLAY_CACHE_LIMIT = 1000;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX = 10;
 const replayCache = new Map<string, number>();
-const rateLimit = new Map<string, { count: number; resetAtMs: number }>();
+const rateLimit = createFixedWindowRateLimiter({
+  windowMs: RATE_LIMIT_WINDOW_MS,
+  maxRequests: RATE_LIMIT_MAX,
+  maxTrackedKeys: WEBHOOK_RATE_LIMIT_DEFAULTS.maxTrackedKeys,
+});
 
 export function registerTelegramMiniAppRoutes(
   api: OpenClawPluginApi,
@@ -180,14 +188,7 @@ function parseAuthBody(
 }
 
 function consumeRateLimit(ip: string): boolean {
-  const now = Date.now();
-  const current = rateLimit.get(ip);
-  if (!current || current.resetAtMs <= now) {
-    rateLimit.set(ip, { count: 1, resetAtMs: now + RATE_LIMIT_WINDOW_MS });
-    return true;
-  }
-  current.count += 1;
-  return current.count <= RATE_LIMIT_MAX;
+  return !rateLimit.isRateLimited(ip);
 }
 
 function rememberReplay(hash: string, expiresAtMs: number): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1487,9 +1487,6 @@ importers:
       '@openclaw/fs-safe':
         specifier: 0.5.5
         version: 0.5.5
-      execa:
-        specifier: 10.0.0
-        version: 10.0.0
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -12,6 +12,7 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
       "extensions/codex/src/app-server/run-attempt-state.test.ts",
+      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
## What Problem This Solves

Fixes a security issue where an explicitly configured but policy-blocked SearXNG base-URL SecretRef could silently fall through to the ambient `SEARXNG_BASE_URL`, bypassing the configured provider allowlist. It also replaces five small duplicate implementations with their existing bounded/canonical owners.

## Why This Change Was Made

SearXNG now uses the Plugin SDK read-only SecretRef tri-state and treats `blocked` as authoritative; ambient fallback remains available only when configuration is genuinely missing. The same change adopts the canonical bounded request readers for Raft and Browser Relay, the bounded fixed-window limiter for the Telegram Mini App, the managed buffered process runner for 1Password, and the browser-safe relay codec for native bootstrap nonces.

Raft keeps its JSON error envelope and response-first close behavior. Browser Relay keeps its challenge-specific 400/401 responses and duplicate-key parser. No config, protocol, or public API surface changes.

## User Impact

Operators can rely on a blocked SearXNG SecretRef not borrowing ambient configuration. Raft and Browser Relay request reads now have declared-length and timeout bounds, Telegram Mini App rate-limit state has bounded key cardinality, 1Password no longer carries a plugin-local `execa` dependency, and browser bootstrap uses one canonical base64url codec.

## Evidence

- Pre-fix regression: `extensions/searxng/src/searxng-search-provider.test.ts` failed with received `https://ambient.example` for an allowlist-blocked explicit ref.
- Post-fix SearXNG suite: 27 passed.
- Raft gateway: 7 passed.
- Browser native bootstrap: 17 passed.
- Browser relay auth v2: 18 passed; the strict duplicate-key path remains covered.
- Telegram Mini App routes: 14 passed.
- 1Password resolver: 18 existing cases passed in the first run; two host-load timing cases were rerun in isolation and passed after separating source-mode startup synchronization from the unchanged process kill deadline.
- Canonical helper coverage included `webhook-memory-guards`, `process/exec`, and extension runtime dependency contracts.
- `pnpm check:changed`: passed, including extension types, format/lint, package locks, dependency boundaries, dead exports, database-first guard, and import cycles. The SearXNG assertion-safety ratchet shrank from 2 to 1.
- Final structured autoreview: no accepted/actionable findings.
- Production: +95/-137 (net -42). Package/lock ownership metadata: +1/-6. Tests: +56/-24 (net +32). Tooling baseline: +1/-1.

No live external SearXNG request was sent: the security behavior is the pre-network configuration boundary, and the blocked-path proof specifically verifies that no usable URL is produced.


- The first exact-head CI run exposed a current-main QA assertion drift in `subagent-completion-direct-fallback`; #125954 landed the equivalent test-only repair while this branch was being validated. After rebasing, the focused scenario passed all five terminal cases and the redundant local repair was dropped.

- A later exact-head run exposed one more current-main test-routing gap from #126189: `run-attempt-tools.test.ts` was not owned by a leaf Vitest project. The one-line route into the lightweight attempt shard is covered by the ownership audit (18 passed) and the helper test (3 passed).
