### PR TITLE
test(plugins): refresh Codex exec scan baseline

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -27,8 +27,8 @@ const execFileAsync = promisify(execFile);
 const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/acpx:dangerous-exec:src/codex-auth-bridge.ts", 1],
   ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs", 1],
-  ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/http.ts", 1],
-  ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/processes.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/sandbox-child.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/doctor.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts", 1],


### PR DESCRIPTION
## What Problem This Solves

Resolves a release qualification failure where the publishable plugin security scan still expected two Codex subprocess findings at their former caller files after subprocess creation moved to shared lifecycle owners, then missed a new reviewed process-inspection site.

## Why This Change Was Made

Replaces the stale `http.ts` and `processes.ts` entries with the canonical `sandbox-child.ts` subprocess owner and records the reviewed `transport-process-containment.ts` process-inspection site. Scanner semantics, Codex runtime behavior, config, scripts, workflows, and release behavior are unchanged.

## User Impact

No runtime user impact. Maintainers can run the publishable plugin release scan against the current Codex package layout without false baseline failures.

## Evidence

- Frozen main qualification at `b24430fd04232a3ce6fe0adc6add39647dcf0114` reported the unreviewed findings `sandbox-child.ts:44` and `transport-process-containment.ts:219`.
- On exact head `de2ab5d16f4c43d67abf88a35dc40966d4a5eb7f`, based on `main` `c5b7739ed56343761cc3db2c103df949a3e1b17e`: `node scripts/run-vitest.mjs src/plugins/npm-install-security-scan.release.test.ts` passed 94/94.
- Exact `checks-node-agentic-plugins` equivalent on Blacksmith Testbox `tbx_01m0dg25v8smm3vpamz3c9gnq6` passed 244 files / 3,727 tests with 1 skipped and exit 0: https://github.com/openclaw/openclaw/actions/runs/32280127398
- `pnpm format:check src/plugins/npm-install-security-scan.release.test.ts` and `git diff --check` passed.
- Diff: production LOC `0`; tests `+2/-2` (net `0`).
- `node scripts/check-changed.mjs -- src/plugins/npm-install-security-scan.release.test.ts` passed conflict, ratchet, dependency, format, plugin-boundary, wrapper, and patch lanes before the sparse checkout's dead-export scan rejected missing `ui/config` inputs. Re-running with `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1` completed the remaining targeted wrapper lanes; exact-head CI remains the authoritative full-check proof.
- Direct upstream Codex inspection at `openai/codex@414782450952a196bbb64b1605a458c2531c47b6`: `codex-rs/cli/src/main.rs:1002-1016` dispatches `exec`; `codex-rs/core/src/exec.rs:297-316` routes execution through the sandbox owner, `codex-rs/core/src/exec.rs:930-954` prepares the child request, and `codex-rs/core/src/spawn.rs:52-125` performs the process spawn.
- OpenClaw ownership inspection: `extensions/codex/src/app-server/sandbox-exec-server/sandbox-child.ts:30-48` owns sandbox child creation; `http.ts:110-137` and `processes.ts:92-134` delegate to it. `extensions/codex/src/app-server/transport.ts:44-76` delegates descendant cleanup to `transport-process-containment.ts:201-238`, whose `execFile("ps", ...)` is a separate reviewed execution site.

AI-assisted: yes.

Punchcard-Session: frost-orchard-lantern-ze
