### PR TITLE
test(gateway): drop the chat image-capability mask

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -721,7 +721,20 @@ describe("gateway server chat", () => {
 
       const pngB64 =
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+      // The discovered model advertises image input, so the real capability
+      // resolver must keep these attachments inline; offloading here would mean
+      // the catalog lookup silently failed and returned false. Capability
+      // resolution happens before dispatch, so capturing dispatch args observes
+      // the real resolver's decision.
+      const inlineDispatches: { runId?: string; images?: unknown[] }[] = [];
+      const captureInlineDispatch = async (args: unknown) => {
+        const replyOptions = (args as { replyOptions?: { runId?: string; images?: unknown[] } })
+          .replyOptions;
+        inlineDispatches.push({ runId: replyOptions?.runId, images: replyOptions?.images });
+        return { queuedFinal: false, counts: { block: 0, final: 0, tool: 0 } };
+      };
 
+      dispatchInboundMessageMock.mockImplementationOnce(captureInlineDispatch);
       const imgRes = await rpcReq(ws, "chat.send", {
         sessionKey: "main",
         message: "see image",
@@ -740,6 +753,8 @@ describe("gateway server chat", () => {
       expect(imgRes.ok).toBe(true);
       expectStringRunId(imgRes.payload);
       await waitForAgentRunDrained("idem-img");
+      expect(inlineDispatches).toEqual([{ runId: "idem-img", images: [expect.anything()] }]);
+      dispatchInboundMessageMock.mockImplementationOnce(captureInlineDispatch);
       const imgOnlyRes = await rpcReq(ws, "chat.send", {
         sessionKey: "main",
         message: "",
@@ -756,6 +771,10 @@ describe("gateway server chat", () => {
       expect(imgOnlyRes.ok).toBe(true);
       expectStringRunId(imgOnlyRes.payload);
       await waitForAgentRunDrained("idem-img-only");
+      expect(inlineDispatches).toEqual([
+        { runId: "idem-img", images: [expect.anything()] },
+        { runId: "idem-img-only", images: [expect.anything()] },
+      ]);
 
       const historyDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-"));
       tempDirs.push(historyDir);

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -38,11 +38,6 @@ import {
 import { agentCommandMock } from "./test-helpers.runtime-state.js";
 import { installConnectedControlUiServerSuite } from "./test-with-server.js";
 
-vi.mock("./session-utils.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./session-utils.js")>();
-  return { ...actual, resolveGatewayModelSupportsImages: vi.fn(async () => true) };
-});
-
 function createGatewayHistoryText(role: "user" | "assistant", text: unknown, timestamp: number) {
   return { role, content: [{ type: "text", text }], timestamp };
 }


### PR DESCRIPTION
## What Problem This Solves

PR #126030 recorded two "Known main-owned failures" in the gateway 24-file vitest shard on `origin/main` at `8ccfd075fe8`: `handles chat send and history flows` timing out and `marks a running webchat session failed when restart drain overlaps dispatch rejection` observing zero active gateway roots instead of one (both in `src/gateway/server.chat.gateway-server-chat.test.ts`).

This PR closes out the root-cause investigation of those failures. The investigation found that the underlying producer bugs are already fixed on `main`, and that one piece of masking debt remained: a `vi.mock` of `resolveGatewayModelSupportsImages` inside the victim test file, added by #123847 as an isolation workaround while the real producer was still unknown. The mock hid the real capability-resolution path (model catalog lookup incl. the `readOnly:false` discovery pass) from the largest gateway chat suite. It is removed here, restoring real-path coverage.

## Why This Change Was Made

Attribution evidence, all measured with the exact shard invocation from #126030 on one machine (Node v24.19.0, `OPENCLAW_VITEST_MAX_WORKERS=3`):

| main SHA | context | chat-pair failures / runs |
|---|---|---|
| `8ccfd075fe8` (= `2cd87d3d27c~1`) | original repro SHA | 2/2 (plus the original report) |
| `2cd87d3d27c` (#126062) | subagent completion binding | 2/2 |
| `19c916be139` (#123894) | auth rotation | 1/2 |
| `10610d9f639` (#123847) | adds the `vi.mock` | 0/1 |
| `fe816d69ef5`, `3666fa68251`, `feda957fc5f`, `57e5ab7a879` | later main | 0/10 |
| `95ac5b27fa1` **with the mock removed** | producer probe | 0/5 |

So the failure was probabilistic (6/8 failing runs) before #123847 and vanished after it — but #123847's operative hunk was consumer-side masking in the victim file, not a producer fix. The true producer of the root-count failure was found and fixed at the owner by #126183: `startChatDispatch` reserved the detached dispatch's root-work continuation after the ACK and swallowed a failed reservation, releasing the request root before terminal persistence completed, so a concurrent restart drain could observe zero active roots. #126183 also replaced the fragile absolute-counter assertion with a drain-based regression. The recorded QA `subagent-completion-direct-fallback` failure from #126030 was separately root-caused and fixed by the gateway-instance binding series #126062 / #125946 / #126113 (regression window opened by #125821).

With the producers fixed, the mock is pure masking debt: five consecutive shard runs on `95ac5b27fa1` with the mock removed were green before this change was made, proving the suite no longer needs it.

## User Impact

None at runtime; test-only. The gateway chat suite again exercises the real `resolveGatewayModelSupportsImages` path (catalog snapshot + discovery fallback), so future regressions in that path fail visibly in the shard instead of being hidden by a stub.

## Evidence

On this PR's head (branch on `2e6457b8e6e`):

- Exact #126030 shard invocation: green 2/2 runs with the mock removed (258.4s, 246.9s).
- `node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat.test.ts`: green solo (61.9s).
- Producer probe on `95ac5b27fa1`: green 5/5 shard runs with the mock removed (212–271s).
- `node scripts/check-changed.mjs`: pass.
- Fresh Codex autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.

LOC delta: production 0/0; tests +0/−5.

Residual observation for the record: across 22 post-#123847 shard runs, one run (at `feda957fc5f`, under elevated machine load) timed out in `server.chat.gateway-server-chat-b.test.ts` `smoke: supports abort and idempotent completion`. It did not recur in any later run, including 7 runs on newer main; if it reappears, it should be investigated against the #126183 fix rather than re-masked.
