### PR TITLE
fix(agents): stale sub-agent failure warning shown after successful spawn retry

### DIFF
--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -50,6 +50,24 @@ describe("tool mutation helpers", () => {
     expect(readFingerprint).toBeUndefined();
   });
 
+  it("keeps sessions_spawn recovery identity at tool level across adjusted retries", () => {
+    // Spawn retries adjust args (drop a rejected cwd, reword the task); a
+    // per-args identity would never let the successful retry clear the failure.
+    const failed = buildToolMutationState(
+      "sessions_spawn",
+      { task: "Investigate", label: "Investigate", cwd: "/outside" },
+      "label Investigate, task Investigate",
+    );
+    const retried = buildToolMutationState(
+      "sessions_spawn",
+      { task: "Investigate in repo scope" },
+      "Investigate in repo scope",
+    );
+    expect(failed.mutatingAction).toBe(true);
+    expect(failed.actionFingerprint).toBe("tool=sessions_spawn");
+    expect(retried.actionFingerprint).toBe(failed.actionFingerprint);
+  });
+
   it("binds reordered exact arguments to one owner but separates changed facts and owners", () => {
     const ownerKey = '["memory-lancedb","memory_store"]';
     const metric = buildToolMutationState(

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -439,6 +439,13 @@ function buildToolActionFingerprint(
     return undefined;
   }
   const normalizedTool = normalizeLowercaseStringOrEmpty(toolName);
+  // sessions_spawn has no stable target: retries adjust args (drop a rejected
+  // cwd, reword the task), so arg/meta identity never matches and a recovered
+  // failure keeps warning "Sub-agent failed". A later successful spawn in the
+  // same run is the recovery proof; keep the identity at tool level.
+  if (normalizedTool === "sessions_spawn") {
+    return `tool=${normalizedTool}`;
+  }
   const record = asRecord(args);
   const action = normalizeActionName(record?.action);
   const parts = [`tool=${normalizedTool}`];

--- a/src/agents/tool-terminal-outcome.test.ts
+++ b/src/agents/tool-terminal-outcome.test.ts
@@ -8,6 +8,7 @@ import {
   resetAdjustedParamsByToolCallIdForTests,
 } from "./agent-tools.before-tool-call.state.js";
 import { buildPayloads } from "./embedded-agent-runner/run/payloads.test-helpers.js";
+import { inferToolMetaFromArgsCore } from "./tool-display.js";
 import { createToolTerminalObserver } from "./tool-terminal-outcome.js";
 
 describe("tool terminal outcome observer", () => {
@@ -165,6 +166,65 @@ describe("tool terminal outcome observer", () => {
       sideEffectEvidence: false,
       lastToolError: { mutatingAction: false },
     });
+  });
+
+  it("clears a failed sessions_spawn once a retry with adjusted arguments succeeds", () => {
+    const observe = createToolTerminalObserver("run-spawn-retry");
+    const failedArgs = {
+      task: "Investigate the flaky gateway test",
+      label: "Investigate",
+      cwd: "/outside/workspace",
+    };
+    // The retry the model actually issues: drops the rejected cwd and rewords the task.
+    const retryArgs = { task: "Investigate the flaky gateway test in repo scope" };
+
+    observe({
+      toolName: "sessions_spawn",
+      arguments: failedArgs,
+      meta: inferToolMetaFromArgsCore("sessions_spawn", failedArgs),
+      outcome: "failure",
+      failure: { error: "cwd is outside the workspace" },
+    });
+    const afterRetry = observe({
+      toolName: "sessions_spawn",
+      arguments: retryArgs,
+      meta: inferToolMetaFromArgsCore("sessions_spawn", retryArgs),
+      outcome: "success",
+    });
+
+    expect(afterRetry.lastToolError).toBeUndefined();
+    expect(afterRetry.lastToolRecovery).toEqual({ toolName: "sessions_spawn" });
+
+    const payloads = buildPayloads({
+      assistantTexts: ["Started Investigate in a new session."],
+      lastToolError: afterRetry.lastToolError,
+      lastToolRecovery: afterRetry.lastToolRecovery,
+    });
+    expect(payloads.map((payload) => payload.text)).toEqual([
+      "Started Investigate in a new session.",
+      "✅ 🧑‍🔧 Sub-agent succeeded after retry.",
+    ]);
+  });
+
+  it("keeps the sessions_spawn failure warning when no later spawn succeeds", () => {
+    const observe = createToolTerminalObserver("run-spawn-failed");
+    const failedArgs = { task: "Investigate the flaky gateway test", label: "Investigate" };
+
+    const terminal = observe({
+      toolName: "sessions_spawn",
+      arguments: failedArgs,
+      meta: inferToolMetaFromArgsCore("sessions_spawn", failedArgs),
+      outcome: "failure",
+      failure: { error: "cwd is outside the workspace" },
+    });
+
+    const payloads = buildPayloads({
+      assistantTexts: ["Started Investigate in a new session."],
+      lastToolError: terminal.lastToolError,
+      lastToolRecovery: terminal.lastToolRecovery,
+    });
+    expect(payloads.at(-1)?.isError).toBe(true);
+    expect(payloads.at(-1)?.text).toContain("Sub-agent failed");
   });
 
   it("preserves durable memory recall side-effect evidence", () => {

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -12,6 +12,7 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
       "extensions/codex/src/app-server/run-attempt-state.test.ts",
+      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users would see a stale "⚠️ 🧑‍🔧 Sub-agent failed" warning appended to a channel reply even though the sub-agent actually started. When a `sessions_spawn` call failed (e.g. a visible-session `cwd` outside the workspace returned `forbidden`) and the model immediately retried with adjusted arguments and succeeded, the durable tool-failure warning still fired — making the assistant look broken while the reply ("Started Investigate…") was correct.

Observed live on 2026-08-19 on team.openclaw.ai: Roboclaw's first nested spawn was forbidden, the retry without `cwd` succeeded, and Discord still showed "Sub-agent failed".

## Why This Change Was Made

The recovery seam already exists: `createToolErrorState` clears an unresolved mutating failure when a matching success arrives, and the payload builder even renders "✅ … succeeded after retry." The break was in the matching identity. `sessions_spawn` has no stable-target arg key (`path`/`to`/`id`…), so `buildToolActionFingerprint` fell back to display meta built from `label`, `task`, `model`, etc. Spawn retries adjust exactly those args (drop the rejected `cwd`, reword the task), so the failed call and the successful retry never matched as the same action, `recordSuccess` could not clear `lastToolError`, and the mutating warning tier fired.

The fix collapses the `sessions_spawn` recovery fingerprint to tool-level identity (`tool=sessions_spawn`): a later successful spawn in the same run is recovery proof for an earlier failed one. That matches the product meaning — a spawn retry is never "the same action against the same target" the way a file write is; the recovered fact is "the model got its sub-agent started."

Edge cases verified against the real observer: a success followed by a later spawn failure still warns, and a spawn failure after a recovery invalidates the recovery receipt (existing `recordFailure` path).

## User Impact

Channel replies no longer carry a false "Sub-agent failed" warning when a spawn retry succeeded in the same run. The recovered case now also emits "✅ 🧑‍🔧 Sub-agent succeeded after retry," matching the recovery reporting other tools got in #125078. A genuinely failed spawn (no successful sibling call) still warns exactly as before.

## Evidence

- Root cause traced through `src/agents/tool-mutation.ts` (`buildToolActionFingerprint` meta fallback), `src/agents/tool-error-state.ts` (`recordSuccess` matching), `src/agents/tool-terminal-outcome.ts` (observer), and `src/agents/embedded-agent-runner/run/tool-error-warning.ts` (mutating warning tier).
- Regression test (fails pre-fix with the stale `lastToolError`): `src/agents/tool-terminal-outcome.test.ts` — incident shape (forbidden spawn with `cwd`, retry with adjusted args, assistant reply "Started Investigate…") driven through the real observer + payload builder asserts no failure payload and the recovery payload.
- Sibling test pins that a lone failed spawn still produces the "Sub-agent failed" warning.
- Fingerprint contract pinned in `src/agents/tool-mutation.test.ts`.
- Local proof: `node scripts/run-vitest.mjs src/agents/tool-mutation.test.ts src/agents/tool-terminal-outcome.test.ts src/agents/tool-error-state.test.ts src/agents/embedded-agent-runner/run/payloads.test.ts` → 141 passed; sibling suites `embedded-agent-subscribe.handlers.tools.test.ts` + `run.incomplete-turn.delivery-resolution.test.ts` green; `node scripts/check-changed.mjs` clean.
- Codex autoreview (`gpt-5.6-sol`, high) on the diff: clean, no accepted findings.
- Production LOC: +7 (5 of which are the invariant comment) | Tests: +78.
