### PR TITLE
fix(telegram): hide spaced internal reasoning prefixes

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
@@ -188,21 +188,34 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
-  it("suppresses internal reflection when reasoning streams", async () => {
-    const { reasoningDraftStream } = setupDraftStreams({
+  it("suppresses whitespace-form internal prefixes until one visible final", async () => {
+    const { answerDraftStream, reasoningDraftStream } = setupDraftStreams({
       answerMessageId: 2001,
       reasoningMessageId: 3001,
     });
     mockTurn(async ({ dispatcherOptions }) => {
-      await dispatcherOptions.deliver(
-        { text: "<internal>private reflection</internal>", isReasoning: true },
-        { kind: "final" },
-      );
+      for (const text of [
+        "< internal",
+        "<  internal",
+        "</ internal",
+        "< / internal",
+        "<\u00a0internal",
+      ]) {
+        await dispatcherOptions.deliver({ text, isReasoning: true }, { kind: "block" });
+      }
+      expect(reasoningDraftStream.update).not.toHaveBeenCalled();
+      expect(deliverReplies).not.toHaveBeenCalled();
+      await dispatcherOptions.deliver({ text: "VISIBLE" }, { kind: "final" });
     });
 
     await dispatchWithContext({ context: createReasoningStreamContext() });
 
     expect(reasoningDraftStream.update).not.toHaveBeenCalled();
+    expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.update).toHaveBeenCalledWith(
+      "VISIBLE",
+      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
+    );
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.reasoning-room-events.test.ts
@@ -198,6 +198,7 @@ describeTelegramDispatch("dispatchTelegramMessage reasoning-room-events", () => 
         "< internal",
         "<  internal",
         "</ internal",
+        "< /internal",
         "< / internal",
         "<\u00a0internal",
       ]) {

--- a/extensions/telegram/src/reasoning-lane-coordinator.test.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.test.ts
@@ -41,9 +41,22 @@ describe("splitTelegramReasoningText", () => {
     });
   });
 
-  it("does not emit partial reasoning tag prefixes", () => {
-    expect(splitTelegramReasoningText("  <thi", true)).toStrictEqual({});
-    expect(splitTelegramReasoningText("  <int", true)).toStrictEqual({});
+  it.each([
+    "  <thi",
+    "  <int",
+    "< internal",
+    "<  internal",
+    "</ internal",
+    "< / internal",
+    "<\u00a0internal",
+  ])("does not emit partial reasoning tag prefix %j", (text) => {
+    expect(splitTelegramReasoningText(text, true)).toStrictEqual({});
+  });
+
+  it("keeps unrelated partial tags visible", () => {
+    expect(splitTelegramReasoningText("< interface", true)).toStrictEqual({
+      reasoningText: "🧠 _< interface_",
+    });
   });
 
   it("keeps visible Thinking-prefixed answers in the answer lane", () => {

--- a/extensions/telegram/src/reasoning-lane-coordinator.test.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.test.ts
@@ -47,6 +47,7 @@ describe("splitTelegramReasoningText", () => {
     "< internal",
     "<  internal",
     "</ internal",
+    "< /internal",
     "< / internal",
     "<\u00a0internal",
   ])("does not emit partial reasoning tag prefix %j", (text) => {

--- a/extensions/telegram/src/reasoning-lane-coordinator.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.ts
@@ -1,7 +1,6 @@
 // Telegram plugin module implements reasoning lane coordinator behavior.
 import { formatReasoningMessage } from "openclaw/plugin-sdk/agent-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   findCodeRegions,
   isInsideCode,
@@ -71,14 +70,14 @@ function extractThinkingFromTaggedStreamOutsideCode(text: string): string {
 }
 
 function isPartialReasoningTagPrefix(text: string): boolean {
-  const trimmed = normalizeLowercaseStringOrEmpty(text.trimStart());
+  const trimmed = text.trim().replace(/^<\s*(\/?)\s+/u, "<$1");
   if (!trimmed.startsWith("<")) {
     return false;
   }
   if (trimmed.includes(">")) {
     return false;
   }
-  return REASONING_TAG_PREFIXES.some((prefix) => prefix.startsWith(trimmed));
+  return REASONING_TAG_PREFIXES.some((prefix) => prefix.startsWith(trimmed.toLowerCase()));
 }
 
 type TelegramReasoningSplit = {

--- a/extensions/telegram/src/reasoning-lane-coordinator.ts
+++ b/extensions/telegram/src/reasoning-lane-coordinator.ts
@@ -1,6 +1,5 @@
 import { formatReasoningMessage } from "openclaw/plugin-sdk/agent-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   findCodeRegions,
   isInsideCode,
@@ -69,14 +68,14 @@ function extractThinkingFromTaggedStreamOutsideCode(text: string): string {
 }
 
 function isPartialReasoningTagPrefix(text: string): boolean {
-  const trimmed = normalizeLowercaseStringOrEmpty(text.trimStart());
+  const trimmed = text.trim().replace(/^<\s*(\/?)\s+/u, "<$1");
   if (!trimmed.startsWith("<")) {
     return false;
   }
   if (trimmed.includes(">")) {
     return false;
   }
-  return REASONING_TAG_PREFIXES.some((prefix) => prefix.startsWith(trimmed));
+  return REASONING_TAG_PREFIXES.some((prefix) => prefix.startsWith(trimmed.toLowerCase()));
 }
 
 type TelegramReasoningSplit = {


### PR DESCRIPTION
Related: #122623

Related source contribution: #122650

Related canonical repair: #123196

Credit: @wangyan2026 identified the incomplete reasoning-prefix leak and contributed the original approach and test direction.

## What Problem This Solves

Telegram users could briefly see internal reasoning markup when a streamed opening or closing reasoning tag contained whitespace after `<`, after `</`, or between `<` and `/`.

## Why This Change Was Made

Telegram's reasoning-lane coordinator owns the incomplete-prefix decision. It normalizes whitespace around the initial tag delimiter before applying the existing markdown-core-compatible prefix grammar. Unrelated partial tags such as `< interface` remain visible; shared parsers, protocol, SDK, config, dependencies, and other channels are unchanged.

Root cause: the coordinator recognized compact incomplete prefixes such as `<int` and `</int`, but not equivalent streamed prefixes containing markdown whitespace.

Production LOC: `+2/-3` (net `-1`). Test LOC: `+37/-9`.

## User Impact

Telegram no longer emits draft or durable messages for whitespace-split internal reasoning prefixes. The first visible assistant answer is still delivered normally and exactly once.

## Current Review Resolution

The September 3 review reported that `< /internal` bypassed normalization. That premise is false: with `/^<\s*(\/?)\s+/u`, regex backtracking consumes the whitespace while leaving the slash in the remainder, so `< /internal` becomes `</internal` and matches the private-prefix list.

Current head `cc5a870fdeed9e33e4dfe16bae2a9fa6d50f2ad2` adds explicit coordinator and dispatcher-boundary coverage for that exact form. No production change was needed for the review finding.

## Evidence

- Direct runtime probe: `< /internal` normalizes to `</internal`; `< / internal` and `</ internal` do too, while `< interface` remains unrelated and visible.
- The coordinator table asserts every whitespace form returns an empty split.
- The dispatcher-boundary table asserts no Telegram reasoning draft or durable reply is emitted for those forms, followed by exactly one visible final answer.
- Fresh independent autoreview is scoped-clean with no P0/P1 findings and independently confirms the regex-backtracking behavior and the distinct value of both test boundaries.
- `git diff --check` and formatting pass on the rebased head.
- Exact-head hosted CI is attached and running. Local Vitest could not start because the shared checkout lacks `mdast-util-gfm-table`; dependencies were not reconciled inside the worktree.
- Earlier production-boundary proof at `be0cb021380d4f2f2a16aa67603008fd670c9dc3` used a mock Telegram Bot API, mock OpenAI Responses provider, and ephemeral Gateway:

```json
{
  "harness": "mock Telegram Bot API + mock OpenAI Responses provider + ephemeral Gateway",
  "reasoningDeltas": ["<", " ", "/", "\u00a0", "internal"],
  "cumulativeFinalReasoningSnapshot": "< /\u00a0internal",
  "reasoningDraftOrDurableSends": 0,
  "visibleFinal": "VISIBLE",
  "visibleFinalDeliveries": 1,
  "totalTelegramDeliveryCalls": 1,
  "providerRequests": 1,
  "status": "pass"
}
```

## Live Telegram Proof

Maintainer decision: the successful authenticated Mantis run
https://github.com/openclaw/openclaw/actions/runs/32692646134 satisfies the
real Telegram proof requirement for current head
`cc5a870fdeed9e33e4dfe16bae2a9fa6d50f2ad2`.

The run compared baseline `ca6fea301ba94144796fed67035dd97364679da4`
with candidate `a1da8788b05e8915647a793c1ac7a9a8cc2424ef`. It recorded
one visible final message and zero reasoning sends, edits, or deletes for the
candidate.

The behavior-determining classifier is text-identical on the current head.
Subsequent changes are test-only or unrelated to the production suppression
path. The historical artifact and original proof comment have expired, but the
successful workflow and its durable logs preserve the authenticated result.
Historical proof continuity is accepted for landing.

Punchcard-Session: amber-summit-river-a3
