### PR TITLE
fix: nested session tools retain caller scope on multi-agent hosts

### DIFF
--- a/src/agents/openclaw-tools.session-context.test.ts
+++ b/src/agents/openclaw-tools.session-context.test.ts
@@ -1,0 +1,167 @@
+// Verifies that nested session tools keep execution identity without narrowing discovery policy.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setEmbeddedMode } from "../infra/embedded-mode.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+
+type GatewayRequest = { method: string; params?: Record<string, unknown> };
+type OpenClawToolsOptions = NonNullable<Parameters<typeof createOpenClawTools>[0]>;
+
+const embeddedGatewayCalls = vi.hoisted(() => vi.fn());
+const embeddedGatewayResponseMock = vi.hoisted(() => vi.fn());
+const createEmbeddedCallGatewayMock = vi.hoisted(() =>
+  vi.fn(() => async (request: GatewayRequest) => {
+    embeddedGatewayCalls(request);
+    const response = embeddedGatewayResponseMock(request);
+    if (response !== undefined) {
+      return response;
+    }
+    if (request.method === "sessions.list") {
+      return { sessions: [], hasMore: false };
+    }
+    if (request.method === "sessions.search") {
+      return { results: [], indexing: false, truncated: false };
+    }
+    if (request.method === "chat.history") {
+      return { messages: [] };
+    }
+    return { ok: false };
+  }),
+);
+
+vi.mock("./tools/embedded-gateway-stub.js", () => ({
+  createEmbeddedCallGateway: createEmbeddedCallGatewayMock,
+}));
+
+vi.mock("./openclaw-plugin-tools.js", () => ({
+  resolveOpenClawPluginToolsForOptions: () => [],
+}));
+
+function createTools(
+  config: OpenClawToolsOptions["config"],
+  options: { sandboxed?: boolean } = {},
+) {
+  return createOpenClawTools({
+    agentSessionKey: "global",
+    runSessionKey: "agent:research:main",
+    sandboxed: options.sandboxed,
+    config,
+    disablePluginTools: true,
+    wrapBeforeToolCallHook: false,
+  });
+}
+
+function requireTool(tools: ReturnType<typeof createOpenClawTools>, name: string) {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`Expected tool ${name} to be registered`);
+  }
+  return tool;
+}
+
+afterEach(() => {
+  setEmbeddedMode(false);
+  embeddedGatewayCalls.mockClear();
+  embeddedGatewayResponseMock.mockReset();
+  createEmbeddedCallGatewayMock.mockClear();
+});
+
+describe("openclaw session lookup context", () => {
+  it("binds nested session lookups to the durable caller", async () => {
+    const runSessionKey = "agent:research:main";
+    setEmbeddedMode(true);
+    const tools = createTools(
+      { agents: { list: [{ id: "main", default: true }, { id: "research" }] } },
+      { sandboxed: true },
+    );
+
+    await requireTool(tools, "sessions_list").execute("list", {});
+    await requireTool(tools, "sessions_search").execute("search", { query: "needle" });
+    await requireTool(tools, "sessions_history").execute("history", { sessionKey: "current" });
+
+    expect(createEmbeddedCallGatewayMock).toHaveBeenCalledWith();
+    expect(embeddedGatewayCalls).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.list",
+        params: expect.objectContaining({ spawnedBy: runSessionKey }),
+      }),
+    );
+    expect(embeddedGatewayCalls).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "sessions.search",
+        params: expect.objectContaining({ sessionKeys: [runSessionKey] }),
+      }),
+    );
+    expect(embeddedGatewayCalls).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "chat.history",
+        params: expect.objectContaining({ sessionKey: runSessionKey }),
+      }),
+    );
+  });
+
+  it("preserves implicit all-agent discovery for authorized callers", async () => {
+    embeddedGatewayResponseMock.mockImplementation((request: GatewayRequest) => {
+      if (request.method === "sessions.list") {
+        return {
+          sessions: [
+            { key: "agent:main:main", agentId: "main", kind: "main" },
+            { key: "agent:research:main", agentId: "research", kind: "main" },
+          ],
+          hasMore: false,
+        };
+      }
+      if (request.method === "sessions.search") {
+        const agentId = request.params?.agentId;
+        const sessionKeys = request.params?.sessionKeys;
+        const sessionKey = Array.isArray(sessionKeys) ? sessionKeys[0] : undefined;
+        return typeof agentId === "string" && typeof sessionKey === "string"
+          ? {
+              results: [
+                {
+                  sessionKey,
+                  timestamp: 1,
+                  role: "user",
+                  snippet: `${agentId} hit`,
+                  score: 1,
+                },
+              ],
+              indexing: false,
+              truncated: false,
+            }
+          : { results: [] };
+      }
+      return undefined;
+    });
+    setEmbeddedMode(true);
+    const tools = createTools({
+      agents: { list: [{ id: "main", default: true }, { id: "research" }] },
+      tools: {
+        sessions: { visibility: "all" },
+        agentToAgent: { enabled: true, allow: ["*"] },
+      },
+    });
+
+    const listed = await requireTool(tools, "sessions_list").execute("list", {});
+    const searched = await requireTool(tools, "sessions_search").execute("search", {
+      query: "hit",
+    });
+
+    expect((listed.details as { sessions: Array<{ agentId: string }> }).sessions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ agentId: "main" }),
+        expect.objectContaining({ agentId: "research" }),
+      ]),
+    );
+    expect((searched.details as { results: Array<{ snippet: string }> }).results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ snippet: "main hit" }),
+        expect.objectContaining({ snippet: "research hit" }),
+      ]),
+    );
+    const discoveryRequests = embeddedGatewayCalls.mock.calls
+      .map(([request]) => request as GatewayRequest)
+      .filter((request) => request.method === "sessions.list");
+    expect(discoveryRequests).not.toHaveLength(0);
+    expect(discoveryRequests.some((request) => request.params?.agentId === undefined)).toBe(true);
+  });
+});

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -235,7 +235,7 @@ export function createOpenClawTools(
     runtimeSourceConfig: runtimeSnapshot?.sourceConfig,
   });
   const { sessionAgentId } = resolveSessionAgentIds({
-    sessionKey: options?.agentSessionKey,
+    sessionKey: options?.runSessionKey ?? options?.agentSessionKey,
     config: resolvedConfig,
     agentId: options?.requesterAgentIdOverride,
   });
@@ -443,7 +443,7 @@ export function createOpenClawTools(
       denylist: explicitFactoryDenylist,
     });
   const sessionLookupToolOptions = {
-    agentSessionKey: options?.agentSessionKey,
+    agentSessionKey: options?.runSessionKey ?? options?.agentSessionKey,
     sandboxed: options?.sandboxed,
     config: resolvedConfig,
     callGateway: embedded ? createEmbeddedCallGateway() : callAgentToolGatewayRequest,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Code Mode calls to `sessions_list` and `sessions_search` could fail on multi-agent hosts when the model omitted an explicit scope:

> Multiple agents are configured, but the request has no explicit owner.

Related session lookups could also use the sandbox policy key instead of the durable originating session.

## Why This Change Was Made

The tool factory resolved the caller agent from the sandbox/policy key before it built the session tools. A policy key such as `global` is ownerless on an explicit multi-agent roster, even though the same attempt already carries an agent-scoped `runSessionKey`. The factory now uses that durable run key for both owner resolution and list/search/history requester context. Gateway discovery remains unscoped where visibility policy requires it, so existing visibility and agent-to-agent checks still govern authorized foreign/global results.

Maintainer decision: @obviyus explicitly requested and approved preserving the originating caller identity while retaining authorization for explicit cross-agent/global queries. Configured `visibility: "all"` discovery remains unchanged.

No overlapping open PR fixes this invariant. #126177 touches the embedded search stub for result modes only; #111101 and #114194 address different session visibility/history behavior.

Production LOC: +2/-2 (net 0) | Tests: +167

## User Impact

Nested session discovery and history now authorize from the originating run on multi-agent hosts instead of failing during owner resolution. Authorized all-agent discovery and explicit cross-agent/global queries continue to work.

## Evidence

- Pre-fix owner-boundary regression: `AgentSelectionRequiredError: Multiple agents are configured, but session agent resolution has no explicit owner.`
- Post-fix grouped focused run: 21 test files, 440 tests passed, including list/search/history and embedded gateway siblings.
- Two-agent `visibility: "all"` plus agent-to-agent coverage proves implicit foreign discovery remains authorized.
- `git diff --check`
- Targeted Oxfmt and Oxlint passed for both changed files.
- `pnpm tsgo:core`
- `pnpm check:test-types`

<details>
<summary>Redacted two-agent owner-boundary red/green trace</summary>

Before the production substitution, the first regression test failed through the real session lookup owner boundary:

```text
FAIL openclaw session lookup context > binds nested session lookups to the durable caller
AgentSelectionRequiredError: Multiple agents are configured, but session agent resolution has no explicit owner.
The agent-scoped session key belongs to "research", not "main".
  at resolveSessionAgentId (src/agents/agent-scope.ts:329)
  via sessions_list
```

Exact-head rerun:

```text
$ pnpm test src/agents/openclaw-tools.session-context.test.ts -- --reporter=verbose
PASS binds nested session lookups to the durable caller
PASS preserves implicit all-agent discovery for authorized callers
Test Files  1 passed (1)
Tests       2 passed (2)
```

</details>

Exact-head CI run `32229894840` passed all 172 jobs at
`049691803e488d2f579cf61ac952ca7abc194ac5`.

Provenance: the split between sandbox policy identity and `runSessionKey` was introduced in #76995 by @amknight and intentionally applied to `session_status`; the session lookup trio retained the policy key. The PR was squash-merged by `clawsweeper[bot]` after `/clawsweeper automerge` from @amknight on 2026-05-04. This patch completes that owner-boundary split for list, search, and history.
