### PR TITLE
fix(ui): restore sidebar session hovercards

### DIFF
--- a/docs/tools/progress-card.md
+++ b/docs/tools/progress-card.md
@@ -88,7 +88,7 @@ The current chat shows exactly one live card:
 - When the session rail is visible, the card appears in the rail.
 - At narrow widths where the rail is hidden, the card appears in the collapsible surface beside the composer.
 
-The two placements are mutually exclusive. In chat content, hover a session-reference link to see that referenced session's latest card. Sidebar rows intentionally have no hover surface. All card placements read the same Gateway-backed state and refresh after `progressCard.changed` notifications.
+The two placements are mutually exclusive. Hover a session row in the sidebar or a session-reference link in chat to see the same card for that session. All card placements read the same Gateway-backed state and refresh after `progressCard.changed` notifications.
 
 ## Pin the card to the dashboard
 

--- a/test/vitest/vitest.extension-codex-app-server-tools.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-tools.config.ts
@@ -15,6 +15,7 @@ function createExtensionCodexAppServerToolsVitestConfig(
       "extensions/codex/src/app-server/native-hook-relay.test.ts",
       "extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts",
       "extensions/codex/src/app-server/request.test.ts",
+      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
       "extensions/codex/src/app-server/sandbox-exec-server*.test.ts",
       "extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts",
       "extensions/codex/src/app-server/user-input-bridge.test.ts",

--- a/ui/src/components/session-progress-hovercard-registration.ts
+++ b/ui/src/components/session-progress-hovercard-registration.ts
@@ -7,8 +7,8 @@ import {
   type HovercardBootstrapTrigger,
 } from "./lazy-hovercard-registration.ts";
 import {
-  SESSION_PROGRESS_HOVER_LINK_SELECTOR,
-  sessionProgressHoverAnchorFromEvent,
+  SESSION_PROGRESS_HOVER_TARGET_SELECTOR,
+  sessionProgressHoverTargetFromEvent,
 } from "./session-progress-hovercard-target.ts";
 
 const HOVERCARD_TAG = "openclaw-session-progress-hovercard-provider";
@@ -60,8 +60,8 @@ function handleBootstrapMutations(records: MutationRecord[]): void {
         continue;
       }
       if (
-        node.matches(SESSION_PROGRESS_HOVER_LINK_SELECTOR) ||
-        node.querySelector(SESSION_PROGRESS_HOVER_LINK_SELECTOR)
+        node.matches(SESSION_PROGRESS_HOVER_TARGET_SELECTOR) ||
+        node.querySelector(SESSION_PROGRESS_HOVER_TARGET_SELECTOR)
       ) {
         void bootstrap.define();
         return;
@@ -78,20 +78,20 @@ async function activateHovercard(event: Event, trigger: HovercardBootstrapTrigge
   ) {
     return;
   }
-  const anchor = sessionProgressHoverAnchorFromEvent(event);
-  if (!anchor || !bootstrap.providerFor(anchor)) {
+  const target = sessionProgressHoverTargetFromEvent(event);
+  if (!target || !bootstrap.providerFor(target)) {
     return;
   }
   await bootstrap.define();
-  const target = event.target;
+  const eventTarget = event.target;
   if (
-    !(target instanceof EventTarget) ||
-    !anchor.isConnected ||
-    !hovercardBootstrapIntentActive(anchor, trigger)
+    !(eventTarget instanceof EventTarget) ||
+    !target.isConnected ||
+    !hovercardBootstrapIntentActive(target, trigger, true)
   ) {
     return;
   }
-  target.dispatchEvent(
+  eventTarget.dispatchEvent(
     new Event(trigger === "pointer" ? "pointerover" : "focusin", {
       bubbles: true,
       composed: true,
@@ -103,7 +103,7 @@ bootstrap.install(activateHovercard);
 if (!customElements.get(HOVERCARD_TAG)) {
   bootstrapObserver = new MutationObserver(handleBootstrapMutations);
   bootstrapObserver.observe(document, { childList: true, subtree: true });
-  if (document.querySelector(SESSION_PROGRESS_HOVER_LINK_SELECTOR)) {
+  if (document.querySelector(SESSION_PROGRESS_HOVER_TARGET_SELECTOR)) {
     void bootstrap.define();
   }
 }

--- a/ui/src/components/session-progress-hovercard-target.test.ts
+++ b/ui/src/components/session-progress-hovercard-target.test.ts
@@ -1,45 +1,65 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { sessionProgressHoverAnchorFromEvent } from "./session-progress-hovercard-target.ts";
+import { sessionProgressHoverTargetFromEvent } from "./session-progress-hovercard-target.ts";
 
 afterEach(() => {
   document.body.replaceChildren();
   vi.restoreAllMocks();
 });
 
-describe("sessionProgressHoverAnchorFromEvent", () => {
-  it("matches only markdown session-reference anchors", () => {
+describe("sessionProgressHoverTargetFromEvent", () => {
+  it.each([
+    ["a chat link", "a", "markdown-session-link"],
+    ["a sidebar row", "div", "sidebar-recent-session"],
+  ])("matches %s", (_label, tagName, className) => {
     const host = document.body.appendChild(document.createElement("div"));
-    const anchor = host.appendChild(document.createElement("a"));
-    anchor.className = "markdown-session-link";
-    anchor.dataset.sessionKey = "agent:main:other-session";
-    const code = anchor.appendChild(document.createElement("code"));
-    let matched: HTMLAnchorElement | null = null;
+    const target = host.appendChild(document.createElement(tagName));
+    target.className = className;
+    target.dataset.sessionKey = "agent:main:other-session";
+    const child = target.appendChild(document.createElement("span"));
+    let matched: HTMLElement | null = null;
     host.addEventListener("pointerover", (event) => {
-      matched = sessionProgressHoverAnchorFromEvent(event);
+      matched = sessionProgressHoverTargetFromEvent(event);
     });
 
-    code.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+    child.dispatchEvent(new PointerEvent("pointerover", { bubbles: true, composed: true }));
 
-    expect(matched).toBe(anchor);
+    expect(matched).toBe(target);
   });
 
-  it.each([
-    ["a sidebar row", "div", "sidebar-recent-session"],
-    ["another data carrier", "button", "custom-session-control"],
-    ["an unmarked anchor", "a", "sidebar-recent-session__link"],
-  ])("ignores %s", (_label, tagName, className) => {
+  it("ignores unrelated data carriers", () => {
     const host = document.body.appendChild(document.createElement("div"));
-    const candidate = host.appendChild(document.createElement(tagName));
-    candidate.className = className;
+    const candidate = host.appendChild(document.createElement("button"));
+    candidate.className = "custom-session-control";
     candidate.dataset.sessionKey = "agent:main:other-session";
-    let matched: HTMLAnchorElement | null = null;
+    let matched: HTMLElement | null = null;
     host.addEventListener("pointerover", (event) => {
-      matched = sessionProgressHoverAnchorFromEvent(event);
+      matched = sessionProgressHoverTargetFromEvent(event);
     });
 
-    candidate.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
+    candidate.dispatchEvent(new PointerEvent("pointerover", { bubbles: true, composed: true }));
+
+    expect(matched).toBeNull();
+  });
+
+  it("ignores touch pointer events", () => {
+    const host = document.body.appendChild(document.createElement("div"));
+    const row = host.appendChild(document.createElement("div"));
+    row.className = "sidebar-recent-session";
+    row.dataset.sessionKey = "agent:main:other-session";
+    let matched: HTMLElement | null = null;
+    host.addEventListener("pointerover", (event) => {
+      matched = sessionProgressHoverTargetFromEvent(event);
+    });
+
+    row.dispatchEvent(
+      new PointerEvent("pointerover", {
+        bubbles: true,
+        composed: true,
+        pointerType: "touch",
+      }),
+    );
 
     expect(matched).toBeNull();
   });

--- a/ui/src/components/session-progress-hovercard-target.ts
+++ b/ui/src/components/session-progress-hovercard-target.ts
@@ -1,10 +1,15 @@
-export const SESSION_PROGRESS_HOVER_LINK_SELECTOR = "a.markdown-session-link[data-session-key]";
+const SESSION_PROGRESS_HOVER_LINK_SELECTOR = "a.markdown-session-link[data-session-key]";
+const SESSION_PROGRESS_HOVER_SIDEBAR_SELECTOR = ".sidebar-recent-session[data-session-key]";
+export const SESSION_PROGRESS_HOVER_TARGET_SELECTOR = `${SESSION_PROGRESS_HOVER_LINK_SELECTOR}, ${SESSION_PROGRESS_HOVER_SIDEBAR_SELECTOR}`;
 
-export function sessionProgressHoverAnchorFromEvent(event: Event): HTMLAnchorElement | null {
+export function sessionProgressHoverTargetFromEvent(event: Event): HTMLElement | null {
+  if (event instanceof PointerEvent && event.pointerType === "touch") {
+    return null;
+  }
   for (const candidate of event.composedPath()) {
     if (
-      candidate instanceof HTMLAnchorElement &&
-      candidate.matches(SESSION_PROGRESS_HOVER_LINK_SELECTOR)
+      candidate instanceof HTMLElement &&
+      candidate.matches(SESSION_PROGRESS_HOVER_TARGET_SELECTOR)
     ) {
       return candidate;
     }
@@ -13,4 +18,10 @@ export function sessionProgressHoverAnchorFromEvent(event: Event): HTMLAnchorEle
     }
   }
   return null;
+}
+
+export function sessionProgressHoverPlacementForTarget(
+  target: HTMLElement,
+): "horizontal" | "vertical" {
+  return target.matches(SESSION_PROGRESS_HOVER_SIDEBAR_SELECTOR) ? "horizontal" : "vertical";
 }

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -18,7 +18,10 @@ import type { AppSidebarSessionNavigationElement } from "./app-sidebar-session-n
 import { createPortaledHovercard, PortaledHovercardController } from "./portaled-hovercard.ts";
 import { renderSessionHovercard } from "./session-hovercard.ts";
 import { SessionLinkTitler } from "./session-link-titling.ts";
-import { sessionProgressHoverAnchorFromEvent } from "./session-progress-hovercard-target.ts";
+import {
+  sessionProgressHoverPlacementForTarget,
+  sessionProgressHoverTargetFromEvent,
+} from "./session-progress-hovercard-target.ts";
 
 const OPEN_DELAY_MS = 350;
 let nextHovercardId = 0;
@@ -31,7 +34,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private stopProgressCardUpdates: (() => void) | null = null;
   private pullRequests: SessionPullRequestSnapshotStore | null = null;
   private stopPullRequestUpdates: (() => void) | null = null;
-  private activeAnchor: HTMLAnchorElement | null = null;
+  private activeTarget: HTMLElement | null = null;
+  private activeTrigger: HTMLElement | null = null;
   private activeSessionKey: string | null = null;
   private activePullRequestKey: string | null = null;
   private open = false;
@@ -39,8 +43,8 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private readonly hovercard = new PortaledHovercardController(() => this.close());
   private readonly sessionLinkTitler = new SessionLinkTitler(this);
   private loadGeneration = 0;
-  private readonly activeAnchorObserver = new MutationObserver(() => {
-    if (this.activeAnchor && !this.contains(this.activeAnchor)) {
+  private readonly activeTargetObserver = new MutationObserver(() => {
+    if (this.activeTarget && !this.contains(this.activeTarget)) {
       this.close();
     }
   });
@@ -148,20 +152,20 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (event.pointerType === "touch" || !globalThis.matchMedia?.("(hover: hover)").matches) {
       return;
     }
-    const anchor = sessionProgressHoverAnchorFromEvent(event);
-    if (!anchor) {
+    const target = sessionProgressHoverTargetFromEvent(event);
+    if (!target) {
       return;
     }
-    this.activate(anchor, OPEN_DELAY_MS);
+    this.activate(target, target, OPEN_DELAY_MS);
     this.hovercard.pointerInside = true;
   };
 
   private readonly handlePointerOut = (event: PointerEvent) => {
-    const anchor = sessionProgressHoverAnchorFromEvent(event);
-    if (!anchor || anchor !== this.activeAnchor) {
+    const target = sessionProgressHoverTargetFromEvent(event);
+    if (!target || target !== this.activeTarget) {
       return;
     }
-    if (event.relatedTarget instanceof Node && anchor.contains(event.relatedTarget)) {
+    if (event.relatedTarget instanceof Node && target.contains(event.relatedTarget)) {
       return;
     }
     this.hovercard.pointerInside = false;
@@ -169,19 +173,20 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   };
 
   private readonly handleFocusIn = (event: FocusEvent) => {
-    const anchor = sessionProgressHoverAnchorFromEvent(event);
-    if (!anchor) {
+    const target = sessionProgressHoverTargetFromEvent(event);
+    const trigger = event.target instanceof HTMLElement ? event.target : target;
+    if (!target || !trigger) {
       return;
     }
-    this.activate(anchor, 0);
+    this.activate(target, trigger, 0);
     this.hovercard.focusInside = true;
   };
 
   private readonly handleFocusOut = (event: FocusEvent) => {
-    if (!this.activeAnchor) {
+    if (!this.activeTarget) {
       return;
     }
-    if (event.relatedTarget instanceof Node && this.activeAnchor.contains(event.relatedTarget)) {
+    if (event.relatedTarget instanceof Node && this.activeTarget.contains(event.relatedTarget)) {
       return;
     }
     this.hovercard.focusInside = false;
@@ -193,7 +198,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       this.close();
       return;
     }
-    if (event.key !== "Tab" || event.shiftKey || event.target !== this.activeAnchor) {
+    if (event.key !== "Tab" || event.shiftKey || event.target !== this.activeTrigger) {
       return;
     }
     const first = this.cardFocusables()[0];
@@ -203,27 +208,28 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     }
   };
 
-  private activate(anchor: HTMLAnchorElement, delay: number): void {
-    const sessionKey = anchor.dataset.sessionKey;
-    if (!sessionKey || (anchor === this.activeAnchor && sessionKey === this.activeSessionKey)) {
+  private activate(target: HTMLElement, trigger: HTMLElement, delay: number): void {
+    const sessionKey = target.dataset.sessionKey;
+    if (!sessionKey || (target === this.activeTarget && sessionKey === this.activeSessionKey)) {
       return;
     }
     this.close();
-    this.activeAnchor = anchor;
+    this.activeTarget = target;
+    this.activeTrigger = trigger;
     this.activeSessionKey = sessionKey;
     this.open = false;
     this.lastProgressCard = null;
     this.progressCards?.watch(this, [sessionKey]);
-    this.hovercard.markTrigger(anchor);
-    this.activeAnchorObserver.observe(this, { childList: true, subtree: true });
+    this.hovercard.markTrigger(trigger);
+    this.activeTargetObserver.observe(this, { childList: true, subtree: true });
     const generation = ++this.loadGeneration;
     this.hovercard.scheduleOpen(delay, () => void this.loadAndShow(sessionKey, generation));
   }
 
   private async loadAndShow(sessionKey: string, generation: number): Promise<void> {
-    const anchor = this.activeAnchor;
-    if (anchor?.dataset.sessionKey === sessionKey) {
-      void this.sessionLinkTitler.decorate(anchor, true);
+    const target = this.activeTarget;
+    if (target instanceof HTMLAnchorElement && target.dataset.sessionKey === sessionKey) {
+      void this.sessionLinkTitler.decorate(target, true);
     }
     if (
       generation !== this.loadGeneration ||
@@ -271,9 +277,9 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   }
 
   private showCurrent(): void {
-    const anchor = this.activeAnchor;
+    const target = this.activeTarget;
     const sessionKey = this.activeSessionKey;
-    if (!anchor || !sessionKey || !this.open) {
+    if (!target || !sessionKey || !this.open) {
       return;
     }
     const sidebarRow =
@@ -331,7 +337,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     card.addEventListener("focusin", this.handleCardFocusIn);
     card.addEventListener("focusout", this.handleCardFocusOut);
     card.addEventListener("keydown", this.handleCardKeyDown);
-    this.hovercard.mount(anchor, card, "vertical", false);
+    this.hovercard.mount(target, card, sessionProgressHoverPlacementForTarget(target), false);
   }
 
   private readonly handleCardPointerEnter = () => {
@@ -367,9 +373,9 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       return;
     }
     event.preventDefault();
-    const anchor = this.activeAnchor;
+    const trigger = this.activeTrigger;
     this.close();
-    anchor?.focus({ preventScroll: true });
+    trigger?.focus({ preventScroll: true });
   };
 
   private cardFocusables(): HTMLElement[] {
@@ -381,10 +387,11 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     this.loadGeneration += 1;
     this.open = false;
     this.lastProgressCard = null;
-    this.activeAnchorObserver.disconnect();
+    this.activeTargetObserver.disconnect();
     this.progressCards?.unwatch(this);
     this.releasePullRequestStore();
-    this.activeAnchor = null;
+    this.activeTarget = null;
+    this.activeTrigger = null;
     this.activeSessionKey = null;
   }
 }

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -47,6 +47,35 @@ async function waitForPullRequestSubscription(
     .toBe(true);
 }
 
+async function emitPullRequestSnapshot(
+  gateway: Awaited<ReturnType<typeof installMockGateway>>,
+  sessionKey: string,
+): Promise<void> {
+  await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, {
+    sessions: {
+      [sessionKey]: {
+        pullRequests: [
+          {
+            additions: 128,
+            branch: "steipete/session-hovercard-unify",
+            changedFiles: 7,
+            checks: { state: "passing", passed: 24, failed: 0, skipped: 2, running: 0 },
+            deletions: 34,
+            number: 417,
+            owner: "openclaw",
+            repo: "openclaw",
+            state: "open",
+            title: "Restore the session hovercard",
+            url: "https://github.com/openclaw/openclaw/pull/417",
+          },
+        ],
+        rateLimited: false,
+        status: "ready",
+      },
+    },
+  });
+}
+
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
@@ -144,48 +173,11 @@ suite.define(() => {
         await row.waitFor({ state: "visible" });
         await row.hover();
         const card = page.locator(".session-progress-hovercard");
-        expect(await card.count()).toBe(0);
-        expect(
-          (await gateway.getRequests("progressCard.get")).filter(
-            (request) => isRecord(request.params) && request.params.sessionKey === sessionKey,
-          ),
-        ).toHaveLength(0);
-
-        const link = page.locator(
-          `.chat-thread a.markdown-session-link[data-session-key="${sessionKey}"]`,
-        );
-        await link.waitFor({ state: "visible" });
-        await expect.poll(() => link.textContent()).toBe("Other session");
-        expect(await link.getAttribute("href")).toBe("/chat/main/other-session");
-        await link.hover();
-
         await waitForPullRequestSubscription(gateway, sessionKey);
-        await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, {
-          sessions: {
-            [sessionKey]: {
-              pullRequests: [
-                {
-                  additions: 128,
-                  branch: "steipete/session-hovercard-unify",
-                  changedFiles: 7,
-                  checks: { state: "passing", passed: 24, failed: 0, skipped: 2, running: 0 },
-                  deletions: 34,
-                  number: 417,
-                  owner: "openclaw",
-                  repo: "openclaw",
-                  state: "open",
-                  title: "Restore the session hovercard",
-                  url: "https://github.com/openclaw/openclaw/pull/417",
-                },
-              ],
-              rateLimited: false,
-              status: "ready",
-            },
-          },
-        });
+        await emitPullRequestSnapshot(gateway, sessionKey);
 
         await card.waitFor({ state: "visible" });
-        expect(["bottom", "top"]).toContain(await card.getAttribute("data-side"));
+        expect(["left", "right"]).toContain(await card.getAttribute("data-side"));
         await expect
           .poll(() => card.locator(".session-hovercard__title").textContent())
           .toBe("Other session");
@@ -230,6 +222,26 @@ suite.define(() => {
           .poll(() => card.locator(".session-progress-card__step--pending").textContent())
           .toContain("Publish");
         expect(await page.evaluate(() => "__progressCardPwned" in window)).toBe(false);
+        await captureProof(page, "sidebar-row-hovercard-progress.png");
+
+        const link = page.locator(
+          `.chat-thread a.markdown-session-link[data-session-key="${sessionKey}"]`,
+        );
+        await link.waitFor({ state: "visible" });
+        await expect.poll(() => link.textContent()).toBe("Other session");
+        expect(await link.getAttribute("href")).toBe("/chat/main/other-session");
+        await link.hover();
+        await card.waitFor({ state: "visible" });
+        await waitForPullRequestSubscription(gateway, sessionKey);
+        await emitPullRequestSnapshot(gateway, sessionKey);
+        expect(["bottom", "top"]).toContain(await card.getAttribute("data-side"));
+        await expect
+          .poll(() => card.locator(".session-hovercard__title").textContent())
+          .toBe("Other session");
+        await expect
+          .poll(() => card.locator(".session-hovercard__pr-number").textContent())
+          .toBe("#417");
+        await expect.poll(() => card.locator("strong").textContent()).toContain("Building");
         await captureProof(page, "chat-link-hovercard-progress.png");
 
         await gateway.deferNext("progressCard.get", { sessionKey });
@@ -430,19 +442,10 @@ suite.define(() => {
         expect(await row.getAttribute("title")).toBeNull();
         expect(await row.locator(".sidebar-recent-session__link").getAttribute("title")).toBeNull();
         await row.hover();
-        expect(await page.locator(".session-progress-hovercard").count()).toBe(0);
-
-        const link = page.locator(
-          `.chat-thread a.markdown-session-link[data-session-key="${sessionKey}"]`,
-        );
-        await link.waitFor({ state: "visible" });
-        await expect.poll(() => link.textContent()).toBe("No progress card");
-        expect(await link.getAttribute("href")).toBe("/chat/main/no-progress-card");
-        expect(await link.getAttribute("title")).toBe(sessionKey);
-        await link.hover();
         await expect.poll(() => gateway.getRequests("progressCard.get")).toHaveLength(1);
         const card = page.locator(".session-progress-hovercard");
         await card.waitFor({ state: "visible" });
+        expect(["left", "right"]).toContain(await card.getAttribute("data-side"));
         await expect
           .poll(() => card.locator(".session-hovercard__excerpt").textContent())
           .toBe(lastMessagePreview);
@@ -453,7 +456,7 @@ suite.define(() => {
             .locator(".session-hovercard__excerpt")
             .evaluate((element) => getComputedStyle(element).webkitLineClamp),
         ).toBe("2");
-        await captureProof(page, "chat-link-hovercard-last-turn.png");
+        await captureProof(page, "sidebar-row-hovercard-last-turn.png");
       },
     );
   });


### PR DESCRIPTION
## What Problem This Solves

PR #125733 intentionally restricted the session hovercard trigger to chat session links, leaving sidebar session rows hover-inert. That maintainer decision is now reversed: sidebar rows need the same glanceable session information, pull request state, progress, and bounded last-turn fallback already available from chat references.

## Why This Change Was Made

This keeps the single unified hovercard and renderer established by #125968. A precise selector union matches only chat session links and sidebar session rows; the same matcher drives lazy bootstrap and the live provider so those paths cannot drift. Sidebar rows use horizontal placement beside the row, while inline chat links retain their vertical text-flow placement. The deleted `session-link-hovercard*` preview remains deleted.

## User Impact

Hovering a sidebar session row now opens the unified session card with its info header, pull request chips/diff stats, and progress card. Sessions without progress show the same bounded plain-text last-turn excerpt. Chat session references keep the existing unified hovercard behavior.

## Evidence

Pre-fix regression proof:

- matcher test failed because a valid `.sidebar-recent-session[data-session-key]` returned no target
- mocked browser flow failed because sidebar hover never subscribed or loaded a card

Validation:

- `pnpm tsgo:ui`
- `pnpm lint:ui:styles`
- `pnpm deadcode:exports`
- `pnpm check:assertion-safety`
- `pnpm format:docs:check`
- `pnpm docs:check-mdx`
- `pnpm ui:build`
- `pnpm format`
- `node scripts/run-vitest.mjs ui/src/components/session-progress-hovercard-target.test.ts`
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-progress-hovercard.e2e.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`

Sidebar row hover — card is horizontally beside the row and includes the session header, PR/diff chip, and progress:

![Sidebar row unified hovercard](https://github.com/user-attachments/assets/d34bd911-450c-4eeb-a860-25a78153210a)

Chat-link hover — the same unified content uses vertical placement under the inline reference:

![Chat-link unified hovercard](https://github.com/user-attachments/assets/6961757d-6bd4-4d7f-9ebf-da347cc27674)

Sidebar session without progress — the bounded last-turn excerpt is plain text:

![Sidebar row last-turn fallback](https://github.com/user-attachments/assets/742c70f8-4d7a-4e88-8ab0-231acb5b28de)
