### PR TITLE
refactor(google-meet): remove testing re-export

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -424,6 +424,7 @@ const config = {
     "src/system-agent/greeting.ts": ["exports", "types"],
     // Focused tests consume these diagnostic/test seams; production code uses
     // the surrounding runtime helpers rather than importing the exports.
+    "extensions/google-meet/src/plugin-registration.ts": ["exports"],
     "extensions/signal/src/setup-core.ts": ["exports"],
     // Focused CLI tests exercise plan construction through this explicit test seam.
     "extensions/onepassword/src/secret-ref-cli.ts": ["exports"],

--- a/extensions/google-meet/index.create.test.ts
+++ b/extensions/google-meet/index.create.test.ts
@@ -2,9 +2,10 @@ import { Command } from "commander";
 // Google Meet tests cover index.create plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import plugin, { testing as googleMeetPluginTesting } from "./index.js";
+import plugin from "./index.js";
 import { registerGoogleMeetCli } from "./src/cli.js";
 import { resolveGoogleMeetConfig } from "./src/config.js";
+import { testing as googleMeetPluginTesting } from "./src/plugin-registration.js";
 import type { GoogleMeetRuntime } from "./src/runtime.js";
 import {
   captureStdout,

--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -25,7 +25,7 @@ import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 // Google Meet tests cover index plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import plugin, { testing as googleMeetPluginTesting } from "./index.js";
+import plugin from "./index.js";
 import { findGoogleMeetCalendarEvent, listGoogleMeetCalendarEvents } from "./src/calendar.js";
 import { resolveGoogleMeetConfig, type GoogleMeetConfig } from "./src/config.js";
 import { normalizeMeetUrl } from "./src/meet-url.js";
@@ -38,6 +38,7 @@ import {
   fetchGoogleMeetSpace,
 } from "./src/meet.js";
 import { handleGoogleMeetNodeHostCommand } from "./src/node-host.js";
+import { testing as googleMeetPluginTesting } from "./src/plugin-registration.js";
 import {
   meetAudioBridge,
   meetBrowserState,

--- a/extensions/google-meet/index.ts
+++ b/extensions/google-meet/index.ts
@@ -20,12 +20,9 @@ import {
   resolveMeetingInput,
   sendGoogleMeetGatewayError,
   shouldJoinCreatedMeet,
-  testing,
 } from "./src/plugin-registration.js";
 import { googleMeetConfigSchema, GoogleMeetToolSchema } from "./src/plugin-schema.js";
 import { GOOGLE_MEET_NODE_COMMAND } from "./src/transports/google-meet-platform-constants.js";
-
-export { testing };
 
 export default definePluginEntry({
   id: "google-meet",


### PR DESCRIPTION
## What Problem This Solves

The Google Meet plugin entrypoint publicly re-exported a `testing` object solely because its behavior tests imported private owner hooks through the public barrel. That made a test-only seam look like plugin API surface.

## Why This Change Was Made

The public re-export is removed and the existing behavior tests now import the hooks directly from their owner, `src/plugin-registration.ts`. Runtime registration and all behavior coverage remain unchanged. Production Knip models that owner as a focused test seam, while the full-tree unused-export audit still verifies its consumers.

## User Impact

No user-visible or runtime behavior changes. Plugin developers no longer see an accidental test-only export on the Google Meet entrypoint.

## Evidence

- `node scripts/run-vitest.mjs extensions/google-meet/index.test.ts extensions/google-meet/index.create.test.ts` — 2 files, 178 tests passed.
- `node scripts/check-changed.mjs -- config/knip.config.ts extensions/google-meet/index.ts extensions/google-meet/index.test.ts extensions/google-meet/index.create.test.ts` — passed.
- `node --import tsx scripts/check-deadcode-exports.mts` — production, full-tree, and script scans passed with zero entries.
- `pnpm build` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings.
- `rg` confirms no `testing` export or public-index test import remains.
