### PR TITLE
fix(test): route Codex run-attempt tools test

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -12,6 +12,7 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
       "extensions/codex/src/app-server/run-attempt-state.test.ts",
+      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the full-suite Vitest ownership audit failed after the Codex run-attempt tools test was added without a project owner. Tooling-affecting pull requests could not pass CI because the audit reported `extensions/codex/src/app-server/run-attempt-tools.test.ts` as missing.

## Why This Change Was Made

The lightweight three-case test is assigned to the existing Codex app-server attempt-light shard alongside the other small run-attempt support tests. No test behavior or runtime code changes.

## User Impact

No user-visible impact. Full-suite test ownership is complete again, and affected pull requests can pass CI.

## Evidence

- Failing CI: openclaw/openclaw#126223, run 32224019316, `checks-node-compact-large-22` reported the test as the sole missing project-owned file.
- Before the fix: `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts` failed with that exact missing file.
- After the fix: `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts extensions/codex/src/app-server/run-attempt-tools.test.ts` — 2 files, 21 tests passed.
- `node scripts/check-changed.mjs -- test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts` — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings.
