### PR TITLE
fix(agents): keep gateway prepared runtimes on built plugin artifacts

### DIFF
--- a/scripts/test-built-plugin-singleton.mts
+++ b/scripts/test-built-plugin-singleton.mts
@@ -15,11 +15,13 @@ const smokeEntryPath = path.join(repoRoot, "dist", "plugins", "build-smoke-entry
 assert.ok(fs.existsSync(smokeEntryPath), `missing build output: ${smokeEntryPath}`);
 
 const {
+  buildPluginRuntimeLoadOptions,
   clearPluginCommands,
   getPluginCommandSpecs,
   getPluginModuleLoaderStats,
   loadOpenClawPlugins,
   matchPluginCommand,
+  resolvePluginRuntimeLoadContext,
 } = await import(pathToFileURL(smokeEntryPath).href);
 
 assert.equal(typeof loadOpenClawPlugins, "function", "built loader export missing");
@@ -126,24 +128,28 @@ assert.equal(
 clearPluginCommands();
 
 const smsStatsBefore = getPluginModuleLoaderStats();
-const smsRegistry = loadOpenClawPlugins({
-  cache: false,
-  preferBuiltPluginArtifacts: true,
-  workspaceDir: tempRoot,
-  env: {
-    ...process.env,
-    OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(repoRoot, "dist-runtime", "extensions"),
-  },
-  config: {
-    plugins: {
-      enabled: true,
-      allow: ["sms"],
-      entries: {
-        sms: { enabled: true },
+// Prepared runtimes carry this context into late, plugin-scoped loads. Prove that the load-options
+// projection retains the built-artifact choice instead of reopening source transformation.
+const smsRegistry = loadOpenClawPlugins(
+  buildPluginRuntimeLoadOptions(
+    resolvePluginRuntimeLoadContext({
+      config: {
+        plugins: {
+          enabled: true,
+          allow: ["sms"],
+          entries: { sms: { enabled: true } },
+        },
       },
-    },
-  },
-});
+      env: {
+        ...process.env,
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(repoRoot, "extensions"),
+      },
+      preferBuiltPluginArtifacts: true,
+      workspaceDir: tempRoot,
+    }),
+    { cache: false, onlyPluginIds: ["sms"] },
+  ),
+);
 const smsRecord = smsRegistry.plugins.find((entry: { id: string }) => entry.id === "sms");
 assert.ok(smsRecord, "SMS plugin missing from registry");
 assert.equal(smsRecord.status, "loaded", smsRecord.error ?? "SMS plugin failed to load");

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -16,6 +16,7 @@ import {
   registerPreparedModelRuntimePublicationListener,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
+import { getPreparedPluginRuntimeLoadContext } from "./prepared-model-runtime.plugin-context.js";
 
 const mocks = getPreparedModelRuntimeMocks();
 
@@ -73,6 +74,12 @@ describe("prepared reply dispatch runtime", () => {
     );
     expect(firstSnapshot?.metadataSnapshot).toBe(mocks.pluginMetadataSnapshot);
     expect(Object.isFrozen(firstRuntime)).toBe(true);
+    expect(
+      mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.every(
+        ([params]) =>
+          (params as { preferBuiltPluginArtifacts?: boolean }).preferBuiltPluginArtifacts,
+      ),
+    ).toBe(true);
 
     const replacementCatalog = createDeferred<{ entries: [] }>();
     mocks.prepareStaticCatalog.mockImplementationOnce(async () => await replacementCatalog.promise);
@@ -107,6 +114,12 @@ describe("prepared reply dispatch runtime", () => {
     });
     expect(replacementRuntime).not.toBe(firstRuntime);
     expect(replacementRuntime?.modelCatalog).not.toBe(firstRuntime?.modelCatalog);
+    expect(
+      mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.every(
+        ([params]) =>
+          (params as { preferBuiltPluginArtifacts?: boolean }).preferBuiltPluginArtifacts,
+      ),
+    ).toBe(true);
   });
 
   it("resolves the configured inbound registry across a launch-workspace override", async () => {
@@ -200,6 +213,9 @@ describe("prepared reply dispatch runtime", () => {
     expect(dynamicPreparationRegistries.every(Boolean)).toBe(true);
     expect(catalogGenerationRegistries.every(Boolean)).toBe(true);
     expect(dynamicSelectedBefore).toBe(configuredSelectedBefore);
+    expect(getPreparedPluginRuntimeLoadContext(dynamicSelectedBefore)).toMatchObject({
+      preferBuiltPluginArtifacts: true,
+    });
     const registryCallsBeforeAuth = mocks.loadAgentRuntimePluginRegistryHandle.mock.calls.length;
     const authStorageCallsBeforeAuth = mocks.discoverAuthStorage.mock.calls.length;
     const modelCallsBeforeAuth = mocks.discoverModels.mock.calls.length;

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -15,6 +15,7 @@ function inboundRegistryIdentity(input: PreparedModelRuntimeInput): string {
     env: hashRuntimeConfigValue(input.env ?? process.env),
     workspaceDir: input.workspaceDir,
     allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
+    preferBuiltPluginArtifacts: input.preferBuiltPluginArtifacts === true,
   });
 }
 
@@ -27,6 +28,7 @@ export function preparedModelRuntimeWorkspaceFactsKey(input: PreparedModelRuntim
     loadRuntimePlugins: input.loadRuntimePlugins === true,
     workspaceDir: input.workspaceDir,
     allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
+    preferBuiltPluginArtifacts: input.preferBuiltPluginArtifacts === true,
     runtimePluginSelections: input.runtimePluginSelections,
   });
 }
@@ -45,6 +47,7 @@ export function createPreparedInboundRegistryLoader(): PreparedInboundRegistryLo
       env: input.env ?? process.env,
       ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
       ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+      ...(input.preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
       metadataSnapshot,
     });
     registries.set(key, registry);
@@ -77,6 +80,7 @@ export function prepareWorkspacePluginRegistries(
           env: input.env ?? process.env,
           ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
           ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+          ...(input.preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
           metadataSnapshot,
           selections: input.runtimePluginSelections,
         })

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -185,6 +185,8 @@ export function rebindInputToCommittedConfiguredOwner(
     preserveWorkspaceDirOnRefresh: preserveWorkspaceDir,
     allowGatewaySubagentBinding:
       input.allowGatewaySubagentBinding ?? owner.input.allowGatewaySubagentBinding,
+    preferBuiltPluginArtifacts:
+      input.preferBuiltPluginArtifacts ?? owner.input.preferBuiltPluginArtifacts,
     runtimePluginSelections: input.runtimePluginSelections ?? owner.input.runtimePluginSelections,
   });
 }
@@ -213,6 +215,7 @@ export function normalizePreparedModelRuntimeInput(
 ): PreparedModelRuntimeInput {
   const {
     inheritedAuthDir: _inheritedAuthDir,
+    preferBuiltPluginArtifacts: _preferBuiltPluginArtifacts,
     readOnly,
     runtimePluginSelections: _runtimePluginSelections,
     skipCredentials,
@@ -244,6 +247,7 @@ export function normalizePreparedModelRuntimeInput(
     ...(workspaceDir ? { workspaceDir } : {}),
     ...(env ? { env } : {}),
     ...(input.allowGatewaySubagentBinding === true ? { allowGatewaySubagentBinding: true } : {}),
+    ...(input.preferBuiltPluginArtifacts === true ? { preferBuiltPluginArtifacts: true } : {}),
     ...(runtimePluginSelections?.length ? { runtimePluginSelections } : {}),
   };
 }
@@ -267,6 +271,7 @@ export function ownerKey(input: PreparedModelRuntimeInput): string {
     workspaceDir: input.workspaceDir,
     env: environmentFingerprint(input.env),
     allowGatewaySubagentBinding: input.allowGatewaySubagentBinding === true,
+    preferBuiltPluginArtifacts: input.preferBuiltPluginArtifacts === true,
     runtimePluginSelections: input.runtimePluginSelections,
     config: input.readOnly ? hashRuntimeConfigValue(input.config) : undefined,
   });
@@ -281,7 +286,7 @@ export function resolvePublishedOwner(
   if (exact) {
     return exact;
   }
-  if (!options.allowConfiguredWorkspaceFallback) {
+  if (!options.allowConfiguredWorkspaceFallback && "preferBuiltPluginArtifacts" in input) {
     return undefined;
   }
   // Gateway launch may supply an authoritative workspace outside config. Request readers still
@@ -302,6 +307,8 @@ export function resolvePublishedOwner(
       // rebuild a live ephemeral catalog per request.
       (input.allowGatewaySubagentBinding === undefined ||
         owner.input.allowGatewaySubagentBinding === input.allowGatewaySubagentBinding) &&
+      (input.preferBuiltPluginArtifacts === undefined ||
+        owner.input.preferBuiltPluginArtifacts === input.preferBuiltPluginArtifacts) &&
       (input.runtimePluginSelections === undefined ||
         JSON.stringify(owner.input.runtimePluginSelections) ===
           JSON.stringify(input.runtimePluginSelections)) &&
@@ -327,6 +334,7 @@ export function hasSameLifecycleInput(
     environmentFingerprint(left.env) === environmentFingerprint(right.env) &&
     left.preserveWorkspaceDirOnRefresh === right.preserveWorkspaceDirOnRefresh &&
     left.allowGatewaySubagentBinding === right.allowGatewaySubagentBinding &&
+    left.preferBuiltPluginArtifacts === right.preferBuiltPluginArtifacts &&
     JSON.stringify(left.runtimePluginSelections) === JSON.stringify(right.runtimePluginSelections)
   );
 }

--- a/src/agents/prepared-model-runtime.plugin-context.test.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.test.ts
@@ -29,6 +29,7 @@ describe("prepared model runtime plugin metadata ownership", () => {
     const inputs = ["first", "second"].map((name) => ({
       agentDir: `/tmp/${name}-agent`,
       config,
+      preferBuiltPluginArtifacts: true as const,
       workspaceDir: `/tmp/${name}-workspace`,
     }));
     const pluginGeneration = {
@@ -45,9 +46,10 @@ describe("prepared model runtime plugin metadata ownership", () => {
         expect(prepareOwnedPluginLoadContext(input, process.env, registry, gatewaySnapshot)).toBe(
           gatewaySnapshot,
         );
-        expect(getPreparedPluginRuntimeLoadContext(registry)?.metadataSnapshot).toBe(
-          gatewaySnapshot,
-        );
+        expect(getPreparedPluginRuntimeLoadContext(registry)).toMatchObject({
+          metadataSnapshot: gatewaySnapshot,
+          preferBuiltPluginArtifacts: true,
+        });
         expect(
           withPreparedPluginGenerationScope({ input, pluginGeneration }, (snapshot) => snapshot),
         ).toBe(gatewaySnapshot);
@@ -73,6 +75,7 @@ describe("prepared model runtime plugin metadata ownership", () => {
       .mockReturnValue(directSnapshot);
 
     try {
+      const registry = createEmptyPluginRegistry();
       expect(
         prepareOwnedPluginLoadContext(
           {
@@ -81,9 +84,12 @@ describe("prepared model runtime plugin metadata ownership", () => {
             workspaceDir,
           },
           process.env,
-          undefined,
+          registry,
         ),
       ).toBe(directSnapshot);
+      expect(getPreparedPluginRuntimeLoadContext(registry)).not.toHaveProperty(
+        "preferBuiltPluginArtifacts",
+      );
       expect(resolveMetadata).toHaveBeenCalledWith({
         config,
         env: process.env,

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -37,6 +37,7 @@ function preparePluginLoadContext(
   const preparedMetadataSnapshot = metadataSnapshot.discovery
     ? metadataSnapshot
     : { ...metadataSnapshot, discovery: emptyPluginDiscovery };
+  const preparedContext = getPreparedPluginRuntimeLoadContext(registry);
   const context = {
     ...resolvePluginRuntimeLoadContext({
       config,
@@ -44,6 +45,8 @@ function preparePluginLoadContext(
       workspaceDir,
       metadataSnapshot: preparedMetadataSnapshot,
       manifestRegistry: metadataSnapshot.manifestRegistry,
+      preferBuiltPluginArtifacts:
+        input.preferBuiltPluginArtifacts || preparedContext?.preferBuiltPluginArtifacts,
     }),
     metadataSnapshot,
     installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index),

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -431,7 +431,10 @@ async function refreshPreparedModelRuntimeSnapshotsNow(
   const entries: Array<{ owner?: PreparedModelRuntimeOwner; input: PreparedModelRuntimeInput }> =
     [];
   const knownKeys = new Set<string>();
-  for (const rawInput of listConfiguredOwnerInputs(config, workspace, bindings)) {
+  for (const configuredInput of listConfiguredOwnerInputs(config, workspace, bindings)) {
+    const rawInput = gatewayLifecycleActive
+      ? { ...configuredInput, preferBuiltPluginArtifacts: true as const }
+      : configuredInput;
     let input = normalizePreparedModelRuntimeInput(rawInput);
     const preservedOwner = [...owners.values()].find(
       (owner) =>

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -92,6 +92,8 @@ export type PreparedModelRuntimeInput = {
   skipCredentials?: boolean;
   env?: NodeJS.ProcessEnv;
   allowGatewaySubagentBinding?: boolean;
+  /** Gateway lifecycle owners load bundled plugins from packaged build artifacts. */
+  preferBuiltPluginArtifacts?: true;
   runtimePluginSelections?: readonly AgentHarnessPluginSelection[];
   config: OpenClawConfig;
 };

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -148,7 +148,7 @@ describe("agent runtime plugin registries", () => {
     });
   });
 
-  it("preserves the gateway startup scope and ordering", () => {
+  it("preserves the gateway startup scope, artifact selection, and ordering", () => {
     const config = {} as never;
     const metadataSnapshot = createMetadataSnapshot();
 
@@ -156,6 +156,7 @@ describe("agent runtime plugin registries", () => {
       config,
       workspaceDir: "/tmp/workspace",
       metadataSnapshot: metadataSnapshot as never,
+      preferBuiltPluginArtifacts: true,
     });
 
     expect(hoisted.resolveAgentRuntimePluginLoadPlan).toHaveBeenCalledWith({
@@ -168,6 +169,7 @@ describe("agent runtime plugin registries", () => {
     expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith(
       expect.objectContaining({
         channelPluginLoadIntent: "full",
+        preferBuiltPluginArtifacts: true,
       }),
     );
   });
@@ -250,6 +252,9 @@ describe("agent runtime plugin registries", () => {
       runtimeOptions: undefined,
       workspaceDir: snapshot.workspaceDir,
     });
+    expect(hoisted.loadPluginRegistryHandle.mock.calls[0]?.[0]).not.toHaveProperty(
+      "preferBuiltPluginArtifacts",
+    );
   });
 
   it("owns a scoped registry for direct hosts", async () => {

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -29,6 +29,7 @@ type AgentRuntimePluginRegistryParams = {
   selections?: readonly AgentHarnessPluginSelection[];
   /** Lifecycle-selected metadata. Omission selects one standalone cold generation. */
   metadataSnapshot?: PluginMetadataSnapshot;
+  preferBuiltPluginArtifacts?: true;
 };
 
 function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistryParams) {
@@ -44,6 +45,7 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
         ...(params.env ? { env: params.env } : {}),
         workspaceDir: requestedWorkspaceDir,
         onlyPluginIds: [],
+        ...(params.preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
         runtimeOptions: params.allowGatewaySubagentBinding
           ? { allowGatewaySubagentBinding: true }
           : undefined,
@@ -62,6 +64,7 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
     ...(metadataSnapshot.discovery ? { discovery: metadataSnapshot.discovery } : {}),
     installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index),
     manifestRegistry: metadataSnapshot.manifestRegistry,
+    ...(params.preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
     ...(workspaceDir ? { workspaceDir } : {}),
   };
   const requestPluginRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;

--- a/src/plugins/build-smoke-entry.ts
+++ b/src/plugins/build-smoke-entry.ts
@@ -3,3 +3,7 @@ export { clearPluginCommands, executePluginCommand, matchPluginCommand } from ".
 export { getPluginCommandSpecs } from "./command-specs.js";
 export { loadOpenClawPlugins, loadPluginRegistryHandle } from "./loader.js";
 export { getPluginModuleLoaderStats } from "./plugin-module-loader-cache.js";
+export {
+  buildPluginRuntimeLoadOptions,
+  resolvePluginRuntimeLoadContext,
+} from "./runtime/load-context.js";

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -314,6 +314,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
     const context = resolvePluginRuntimeLoadContext({
       config: { plugins: {} },
       env: { HOME: "/tmp/openclaw-home" } as NodeJS.ProcessEnv,
+      preferBuiltPluginArtifacts: true,
       workspaceDir: "/explicit-workspace",
     });
 
@@ -332,6 +333,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
       logger: context.logger,
       manifestRegistry,
       installRecords: {},
+      preferBuiltPluginArtifacts: true,
       cache: false,
       activate: false,
       onlyPluginIds: ["demo"],

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -137,6 +137,7 @@ export type PluginRuntimeLoadContext = {
   manifestRegistry?: PluginManifestRegistry;
   metadataSnapshot?: PluginMetadataSnapshot;
   installRecords?: Record<string, PluginInstallRecord>;
+  preferBuiltPluginArtifacts?: true;
 };
 
 /** Runtime load option values that can be passed directly to plugin loading. */
@@ -150,6 +151,7 @@ type PluginRuntimeResolvedLoadValues = Pick<
   | "logger"
   | "manifestRegistry"
   | "installRecords"
+  | "preferBuiltPluginArtifacts"
 >;
 
 /** Options accepted while resolving plugin runtime load context. */
@@ -162,6 +164,7 @@ type PluginRuntimeLoadContextOptions = {
   logger?: PluginLogger;
   manifestRegistry?: PluginManifestRegistry;
   metadataSnapshot?: PluginMetadataSnapshot;
+  preferBuiltPluginArtifacts?: true;
 };
 
 /** Creates the default plugin runtime loader logger. */
@@ -262,6 +265,7 @@ export function resolvePluginRuntimeLoadContext(
     ...(finalManifestRegistry ? { manifestRegistry: finalManifestRegistry } : {}),
     ...(metadataSnapshot ? { metadataSnapshot } : {}),
     installRecords,
+    ...(options?.preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
   };
 }
 
@@ -287,6 +291,7 @@ export function buildPluginRuntimeLoadOptionsFromValues(
     logger: values.logger,
     manifestRegistry: values.manifestRegistry,
     installRecords: values.installRecords,
+    ...(values.preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
     ...overrides,
   };
 }


### PR DESCRIPTION
Related: #125595

Successor to #125957, whose contributor branch is not maintainer-editable. This keeps Dallin Romney's original diagnosis and implementation credit; the commit includes Dallin as co-author.

## What Problem This Solves

Fixes an issue where Gateway-prepared agent turns could synchronously compile bundled plugin source even after Gateway startup selected built plugin artifacts. On current `main`, the affected prepared-runtime path performs 82 forced source transforms and spends roughly 23-27 seconds preparing runtime plugins.

## Why This Change Was Made

The built-artifact choice is now an explicit literal Gateway lifecycle fact carried through prepared owner input, generation identity, initial registry loading, reused generations, and deferred load context. It is never inferred from metadata, provenance, catalogs, bindings, or global state, so standalone and direct prepared runtimes remain source-default.

This is the narrow owner-boundary repair requested by the ClawSweeper review on #125957. An exact-head local review also found that a reused Gateway plugin generation could overwrite its attached built-artifact context with a flagless run projection; the final head preserves the immutable generation-owned `true` fact and adds a red/green reuse regression.

## User Impact

Gateway agent turns can reuse the built plugin artifacts selected at startup instead of blocking on source transforms during initial or deferred plugin loading. Source-development and standalone runtime behavior is unchanged.

No config, environment, protocol, persistent schema, storage, Plugin SDK, public API, timeout, retry, or eager-preload behavior changes.

Production LOC: +30/-2 (net +28) for the explicit lifecycle ownership boundary.
Tests and build-smoke support: +61/-22 (net +39).

## Evidence

- Current-main artifact-only performance reproduction, repeat 3: https://github.com/openclaw/openclaw/actions/runs/32222388432
  - 165 sidecar loader calls
  - 83 native artifact hits
  - 82 forced source transforms
  - roughly 23-27 seconds in prepared runtime-plugin loading
  - source startup probe failed readiness while the artifact-only guard passed
- Exact-head focused proof on `e4ad9334b4c06924a5860f49e7cdb674815cad14`:
  - `prepared-model-runtime.owner-selection.test.ts`: 22 tests passed, including the branch-local CI regression
  - directly affected runtime lifecycle, registry, and context coverage: 88 tests passed across 4 files
- Packaged Gateway composition on predecessor `6f30d3f1fe3afeccd9eab8af3ccaa3de3d7977a8`:
  - Gateway prepared runtime -> reused dynamic owner -> deferred `diffs` tool
  - 8 native artifact hits
  - 0 native misses
  - 0 forced source transforms
  - 0 source-transform fallbacks
  - the successor head changes only the configured-owner lookup guard; it does not change artifact loading or deferred-tool composition
- `pnpm test:build:singleton` passed from the emitted `6f30d3f1fe3afeccd9eab8af3ccaa3de3d7977a8` artifacts.
- Local `pnpm build` emitted those artifacts, then its control-plane postbuild check hit a stale linked `@openclaw/ai` install missing current exports. The packaged proof used the built workspace package in an ignored local resolution overlay; shared dependencies and source were not modified.
- Earlier Blacksmith Testbox build/singleton baseline: https://github.com/openclaw/openclaw/actions/runs/32224547889
  - provider `blacksmith-testbox`
  - lease `tbx_01m0cc3gnjcfcc3ajk68ar6qqm`
  - `pnpm build` and `pnpm test:build:singleton` passed after the `f92e9367e8c79e55041728d9f8c21f18fcaf7d3e` managed-cache repair
- `node scripts/check-changed.mjs` passed all guards, formatting, boundaries, dead-code checks, and core production typecheck, then captured the unrelated existing Control UI test-type error at `ui/src/pages/chat/route-loader.ts:712` (`literalSessionKey`). This PR does not modify that surface.
- `git diff --check` passed.

The branch-local CI failure on `6f30d3f1fe3afeccd9eab8af3ccaa3de3d7977a8` was caused by a fully specified configured-owner reader omitting the Gateway-owned artifact preference bit. The resolver required exact identity before reaching its existing configured-owner wildcard match, while acquisition correctly rebound the same input. The final head lets only an absent artifact preference reach that configured-owner match; explicit artifact identities and standalone owners remain exact.

Base proof was completed on `f92e9367e8c79e55041728d9f8c21f18fcaf7d3e`. Later `main` drift through `cb5c061cb36a` does not overlap the reviewed prepared-model-runtime or artifact-selection owner files, so the exact-head proof was preserved without a drift-only rebase.

Punchcard-Session: frost-orchard-lantern-ze
