### PR TITLE
fix: retry provably-not-sent outbound deliveries with evidence; auto-replay post-reasoning stalled Codex turns

### DIFF
--- a/extensions/codex/src/app-server/attempt-results.test.ts
+++ b/extensions/codex/src/app-server/attempt-results.test.ts
@@ -180,6 +180,43 @@ describe("Codex app-server attempt results", () => {
         }),
       ),
     ).toBe("active_item");
+    // Completed reasoning items are model-internal and never block replay.
+    expect(
+      resolveCodexAppServerReplayBlockedReason(
+        createResult({
+          itemLifecycle: {
+            startedCount: 1,
+            completedCount: 1,
+            activeCount: 0,
+            completedReasoningCount: 1,
+          },
+        }),
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveCodexAppServerReplayBlockedReason(
+        createResult({
+          itemLifecycle: {
+            startedCount: 2,
+            completedCount: 2,
+            activeCount: 0,
+            completedReasoningCount: 1,
+          },
+        }),
+      ),
+    ).toBe("active_item");
+    expect(
+      resolveCodexAppServerReplayBlockedReason(
+        createResult({
+          itemLifecycle: {
+            startedCount: 2,
+            completedCount: 1,
+            activeCount: 1,
+            completedReasoningCount: 1,
+          },
+        }),
+      ),
+    ).toBe("active_item");
   });
 
   it("recognizes invalid image payload errors without matching unsupported image input", () => {

--- a/extensions/codex/src/app-server/attempt-results.ts
+++ b/extensions/codex/src/app-server/attempt-results.ts
@@ -94,7 +94,12 @@ export function resolveCodexAppServerReplayBlockedReason(
   ) {
     return "tool_activity";
   }
-  if (result.itemLifecycle.startedCount > 0 || result.itemLifecycle.activeCount > 0) {
+  // Completed reasoning items are model-internal text (app-server protocol
+  // ThreadItem::Reasoning) with no recipient-visible side effect; a turn whose
+  // only items are completed reasoning is still safe to replay once.
+  const startedNonReasoningCount =
+    result.itemLifecycle.startedCount - (result.itemLifecycle.completedReasoningCount ?? 0);
+  if (startedNonReasoningCount > 0 || result.itemLifecycle.activeCount > 0) {
     return "active_item";
   }
   return undefined;

--- a/extensions/codex/src/app-server/event-projector-result.ts
+++ b/extensions/codex/src/app-server/event-projector-result.ts
@@ -49,6 +49,7 @@ type CodexAttemptResultInput = {
   completedCompactionCount: number;
   activeItemCount: number;
   completedItemCount: number;
+  completedReasoningItemCount: number;
   guardianReviewCount: number;
   toolTelemetry: CodexAppServerToolTelemetry;
   yieldDetected: boolean | undefined;
@@ -231,6 +232,7 @@ export function buildCodexAttemptResult(
       startedCount: input.activeItemCount + input.completedItemCount,
       completedCount: input.completedItemCount,
       activeCount: input.activeItemCount,
+      completedReasoningCount: input.completedReasoningItemCount,
     },
     yieldDetected: input.yieldDetected || false,
     didSendDeterministicApprovalPrompt: input.guardianReviewCount > 0 ? false : undefined,

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -66,6 +66,9 @@ export class CodexAppServerEventProjector {
   private readonly reasoningProjection: CodexReasoningProjection;
   private readonly activeItemIds = new Set<string>();
   private readonly completedItemIds = new Set<string>();
+  // Completed reasoning items are model-internal text with no side effect;
+  // replay gating must not treat them as replay-blocking turn activity.
+  private readonly completedReasoningItemIds = new Set<string>();
   private readonly activeCompactionItemIds = new Set<string>();
   private readonly terminalPresentationClearedItemIds = new Set<string>();
   private readonly nativeToolOutcomeOrdinals = new Map<string, number>();
@@ -356,6 +359,7 @@ export class CodexAppServerEventProjector {
       completedCompactionCount: this.completedCompactionCount,
       activeItemCount: this.activeItemIds.size,
       completedItemCount: this.completedItemIds.size,
+      completedReasoningItemCount: this.completedReasoningItemIds.size,
       guardianReviewCount: this.eventProjection.guardianReviewCount,
       toolTelemetry,
       yieldDetected: options?.yieldDetected,
@@ -469,6 +473,9 @@ export class CodexAppServerEventProjector {
     if (itemId) {
       this.activeItemIds.delete(itemId);
       this.completedItemIds.add(itemId);
+      if (item?.type === "reasoning") {
+        this.completedReasoningItemIds.add(itemId);
+      }
     }
     this.assistantProjection.recordItemCompleted(item, itemId, this.activeItemIds);
     this.reasoningProjection.recordItem(item);

--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -16,6 +16,7 @@ import * as approvalBridge from "./approval-bridge.js";
 import { buildCodexAppServerPromptTimeoutOutcome } from "./attempt-results.js";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
+import { CODEX_POST_REASONING_REPLY_IDLE_TIMEOUT_MS } from "./attempt-timeouts.js";
 import { createCodexAttemptTurnWatchController } from "./attempt-turn-watches.js";
 import * as authBridge from "./auth-bridge.js";
 import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
@@ -2252,6 +2253,47 @@ describe("runCodexAppServerAttempt turn watches", () => {
     const result = await run;
     expectSuccessfulAttempt(result);
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+  });
+
+  it("marks a completion idle timeout after completed reasoning as replay-safe", async () => {
+    // Regression for the post-reasoning stall: a completed reasoning item is
+    // model-internal and must not block the one automatic replay when the
+    // stream then goes permanently silent. The completed reasoning item arms
+    // the 5-minute post-reasoning reply window (CODEX_POST_REASONING_REPLY_
+    // IDLE_TIMEOUT_MS); driving that wall-clock window is infeasible here, so
+    // an inert raw bookkeeping completion re-arms the short base completion
+    // watch — the fired timeout kind and replay gating are identical.
+    expect(CODEX_POST_REASONING_REPLY_IDLE_TIMEOUT_MS).toBeGreaterThan(0);
+    const harness = createStartedThreadHarness();
+    const params = makeTestParams({ timeoutMs: 60_000 });
+    params.sourceReplyDeliveryMode = "message_tool_only";
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 100,
+      turnTerminalIdleTimeoutMs: 60_000,
+    });
+    await harness.waitForMethod("turn/start");
+    await harness.notify(
+      itemNotification("item/started", { id: "reasoning-1", type: "reasoning" }),
+    );
+    await harness.notify(
+      itemNotification("item/completed", { id: "reasoning-1", type: "reasoning" }),
+    );
+    await harness.notify(rawItemCompleted({ id: "raw-bookkeeping-1", type: "bookkeeping" }));
+
+    const result = await run;
+    expectTimedOutAttempt(result);
+    expect(result.codexAppServerFailure).toMatchObject({
+      kind: "turn_completion_idle_timeout",
+      turnWatchTimeoutKind: "completion",
+      replaySafe: true,
+    });
+    expect(result.codexAppServerFailure?.replayBlockedReason).toBeUndefined();
+    expect(result.itemLifecycle).toMatchObject({
+      startedCount: 1,
+      completedCount: 1,
+      activeCount: 0,
+      completedReasoningCount: 1,
+    });
   });
 
   it("keeps waiting after reasoning and its raw mirror complete before a visible message call", async () => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -104,6 +104,7 @@ import {
 import { buildTelegramThreadingToolContext } from "./threading-tool-context.js";
 import { resolveTelegramToken } from "./token.js";
 import { parseTelegramTopicConversation } from "./topic-conversation.js";
+import { reconcileTelegramUnknownSend } from "./unknown-send-reconciliation.js";
 
 type TelegramSendFn = typeof import("./send.js").sendMessageTelegram;
 
@@ -251,7 +252,7 @@ const telegramChannelOutbound = createTelegramOutboundAdapter({
   preferFinalAssistantVisibleText: true,
 });
 
-const telegramMessageAdapter = createChannelMessageAdapterFromOutbound<OpenClawConfig>({
+const telegramMessageAdapterBase = createChannelMessageAdapterFromOutbound<OpenClawConfig>({
   id: "telegram",
   live: {
     capabilities: {
@@ -274,6 +275,19 @@ const telegramMessageAdapter = createChannelMessageAdapterFromOutbound<OpenClawC
   },
   outbound: telegramChannelOutbound,
 });
+
+const telegramMessageAdapter = {
+  ...telegramMessageAdapterBase,
+  durableFinal: {
+    ...telegramMessageAdapterBase.durableFinal,
+    capabilities: {
+      ...telegramMessageAdapterBase.durableFinal?.capabilities,
+      reconcileUnknownSend: true,
+    },
+    reconcileUnknownSendKinds: { text: true, media: true },
+    reconcileUnknownSend: reconcileTelegramUnknownSend,
+  },
+} satisfies typeof telegramMessageAdapterBase;
 
 const telegramMessageActions: ChannelMessageActionAdapter = {
   providerOwnedReadGates: ["react", "edit", "delete"],

--- a/extensions/telegram/src/unknown-send-reconciliation.test.ts
+++ b/extensions/telegram/src/unknown-send-reconciliation.test.ts
@@ -1,0 +1,65 @@
+import type { ChannelMessageUnknownSendContext } from "openclaw/plugin-sdk/channel-outbound";
+import { describe, expect, it } from "vitest";
+import { reconcileTelegramUnknownSend } from "./unknown-send-reconciliation.js";
+
+function unknownSendContext(lastError?: string): ChannelMessageUnknownSendContext {
+  return {
+    cfg: {},
+    queueId: "queue-1",
+    channel: "telegram",
+    to: "123456",
+    enqueuedAt: 1,
+    retryCount: 1,
+    payloads: [{ text: "hello" }],
+    ...(lastError === undefined ? {} : { lastError }),
+  };
+}
+
+describe("reconcileTelegramUnknownSend", () => {
+  it.each([
+    ["channel no-send marker", "Telegram request not started"],
+    ["connect refusal", "connect ECONNREFUSED 149.154.167.220:443"],
+    ["dns not found", "getaddrinfo ENOTFOUND api.telegram.org"],
+    ["dns backoff", "getaddrinfo EAI_AGAIN api.telegram.org"],
+    ["connect timeout", "connect ETIMEDOUT 149.154.167.220:443"],
+    ["undici connect timeout", "UND_ERR_CONNECT_TIMEOUT: Connect Timeout Error"],
+    ["tls handshake", "ERR_TLS_CERT_ALTNAME_INVALID: Hostname/IP does not match"],
+    ["tls certificate", "certificate has expired"],
+    ["bot api semantic 400", "Call to 'sendMessage' failed! (400: Bad Request: chat not found)"],
+    ["bot api flood wait", "Call to 'sendMessage' failed! (429: Too Many Requests: retry after 5)"],
+    ["bot api server error", "Call to 'sendMessage' failed! (502: Bad Gateway)"],
+  ])("returns not_sent for %s evidence", (_label, lastError) => {
+    expect(reconcileTelegramUnknownSend(unknownSendContext(lastError))).toEqual({
+      status: "not_sent",
+    });
+  });
+
+  it.each([
+    ["socket reset after write", "read ECONNRESET"],
+    ["socket hang up", "socket hang up"],
+    ["non-connect timeout", "ETIMEDOUT"],
+    ["opaque failure", "something went wrong"],
+  ])("stays unresolved and non-retryable for %s", (_label, lastError) => {
+    expect(reconcileTelegramUnknownSend(unknownSendContext(lastError))).toMatchObject({
+      status: "unresolved",
+      retryable: false,
+    });
+  });
+
+  it("stays unresolved without recorded failure evidence", () => {
+    expect(reconcileTelegramUnknownSend(unknownSendContext())).toMatchObject({
+      status: "unresolved",
+      retryable: false,
+    });
+  });
+
+  it("is declared on the telegram message adapter", async () => {
+    const { telegramPlugin } = await import("./channel.js");
+    expect(telegramPlugin.message?.durableFinal?.capabilities?.reconcileUnknownSend).toBe(true);
+    expect(telegramPlugin.message?.durableFinal?.reconcileUnknownSend).toBeTypeOf("function");
+    expect(telegramPlugin.message?.durableFinal?.reconcileUnknownSendKinds).toEqual({
+      text: true,
+      media: true,
+    });
+  });
+});

--- a/extensions/telegram/src/unknown-send-reconciliation.ts
+++ b/extensions/telegram/src/unknown-send-reconciliation.ts
@@ -1,0 +1,47 @@
+// Telegram plugin module implements unknown-send reconciliation behavior.
+import type {
+  ChannelMessageUnknownSendContext,
+  ChannelMessageUnknownSendReconciliationResult,
+} from "openclaw/plugin-sdk/channel-outbound";
+
+// The Bot API has no arbitrary getMessage lookup, so Telegram cannot query the
+// platform to verify an ambiguous send. Reconciliation may consult only the
+// failure evidence recorded at the send boundary: when that evidence proves the
+// request never produced a recipient-visible message, replaying is safe;
+// anything else must stay unresolved — a blind replay risks a duplicate send.
+const NO_SEND_PROOF_RES: readonly RegExp[] = [
+  // Channel-owned no-send marker (PlatformMessageNotDispatchedError text).
+  /Telegram request not started/i,
+  // Connection-phase transport failures: the request never reached Telegram.
+  /\b(?:ECONNREFUSED|ENOTFOUND|EAI_AGAIN|ENETDOWN|ENETUNREACH|EHOSTUNREACH|UND_ERR_CONNECT_TIMEOUT|UND_ERR_DNS_RESOLVE_FAILED)\b/,
+  /\bconnect ETIMEDOUT\b/,
+  // TLS negotiation failures happen before any HTTP bytes are written.
+  /\b(?:ERR_TLS_\w+|ERR_SSL_\w+|CERT_HAS_EXPIRED|DEPTH_ZERO_SELF_SIGNED_CERT|SELF_SIGNED_CERT_IN_CHAIN|UNABLE_TO_VERIFY_LEAF_SIGNATURE|HOSTNAME_MISMATCH)\b/,
+  /certificate has expired|self[- ]signed certificate|unable to verify the first certificate|does not match certificate's altnames/i,
+  // Bot API error responses: Telegram decided the request, so nothing was
+  // delivered. Bounded to the status phrases the Bot API actually returns.
+  /\b4\d{2}:\s*(?:Bad Request|Unauthorized|Forbidden|Not Found|Conflict|Too Many Requests|Request Entity Too Large)/i,
+  /\b5\d{2}:\s*(?:Internal Server|Bad Gateway|Service Unavailable|Gateway Timeout)/i,
+];
+
+/** True when recorded failure text proves the send never became recipient-visible. */
+function telegramRecordedErrorProvesNotSent(lastError: string): boolean {
+  return NO_SEND_PROOF_RES.some((re) => re.test(lastError));
+}
+
+/** Evidence-only reconciliation for queued Telegram sends with unknown outcomes. */
+export function reconcileTelegramUnknownSend(
+  ctx: ChannelMessageUnknownSendContext,
+): ChannelMessageUnknownSendReconciliationResult {
+  const lastError = ctx.lastError?.trim();
+  if (lastError && telegramRecordedErrorProvesNotSent(lastError)) {
+    return { status: "not_sent" };
+  }
+  return {
+    status: "unresolved",
+    retryable: false,
+    error: lastError
+      ? `recorded failure is not proof of a dropped send: ${lastError}`
+      : "no recorded failure evidence; Telegram cannot verify an ambiguous send",
+  };
+}

--- a/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.codex-app-server-recovery.test-support.ts
@@ -80,6 +80,19 @@ function successAttempt(): EmbeddedRunAttemptResult {
   });
 }
 
+function codexReasoningStallIdleTimeoutAttempt(): EmbeddedRunAttemptResult {
+  // The production stall shape: the model completed a reasoning item, produced
+  // zero assistant text, and the stream then went silent past the idle window.
+  return codexTurnCompletionIdleTimeoutAttempt({
+    itemLifecycle: {
+      startedCount: 1,
+      completedCount: 1,
+      activeCount: 0,
+      completedReasoningCount: 1,
+    },
+  });
+}
+
 function ordinaryPromptFailureAttempt(): EmbeddedRunAttemptResult {
   return makeAttemptResult({
     assistantTexts: [],
@@ -261,6 +274,45 @@ describe("runEmbeddedAgent Codex app-server recovery", () => {
         }
       ).suppressNextUserMessagePersistence,
     ).toBe(true);
+  });
+
+  it("auto-replays exactly once after a reasoning-only completion idle timeout", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(codexReasoningStallIdleTimeoutAttempt())
+      .mockResolvedValueOnce(successAttempt());
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "codex",
+      model: "gpt-5.5",
+      runId: "run-codex-reasoning-stall-auto-replay",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    // The replay's success is the surfaced outcome: no error payload survives.
+    expect(result.meta.error).toBeUndefined();
+    expect(result.payloads?.some((payload) => payload.isError)).not.toBe(true);
+  });
+
+  it("surfaces the original idle timeout when the reasoning-stall replay also stalls", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(codexReasoningStallIdleTimeoutAttempt())
+      .mockResolvedValueOnce(codexReasoningStallIdleTimeoutAttempt());
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "codex",
+      model: "gpt-5.5",
+      runId: "run-codex-reasoning-stall-replay-exhausted",
+    });
+
+    // Exactly one replay: the second stall surfaces today's timeout payload.
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(result.payloads?.[0]).toMatchObject({
+      isError: true,
+      text: CODEX_MISSING_TERMINAL_MESSAGE,
+    });
+    expect(mockedMarkAuthProfileFailure).not.toHaveBeenCalled();
   });
 
   it("returns a timeout payload after a replay-safe turn/completed idle timeout retry is exhausted", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -304,8 +304,9 @@ export async function recoverEmbeddedRunAttempt(input: {
     if (recoveryRetry.retry) {
       runInput.laneController.throwIfAborted();
       sessionPromptState.suppressNextUserMessagePersistence = true;
+      // Stable operator-countable marker: one line per automatic replay.
       log.warn(
-        `codex app-server replay-safe failure; retrying once failureKind=${attempt.codexAppServerFailure?.kind} ` +
+        `codex app-server recovered_via_auto_replay: replaying turn once failureKind=${attempt.codexAppServerFailure?.kind} ` +
           `runId=${params.runId} sessionId=${params.sessionId}`,
       );
       return retry({ codexAppServerRecoveryRetries: input.codexAppServerRecoveryRetries + 1 });

--- a/src/agents/embedded-agent-runner/run/codex-app-server-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/codex-app-server-recovery.ts
@@ -56,10 +56,12 @@ export function resolveCodexAppServerRecoveryRetry(params: {
   ) {
     return { retry: false, reason: "tool_activity" };
   }
-  if (
-    params.attempt.itemLifecycle.startedCount > 0 ||
-    params.attempt.itemLifecycle.activeCount > 0
-  ) {
+  // Mirrors resolveCodexAppServerReplayBlockedReason: completed reasoning
+  // items are model-internal and must not veto the one replay-safe retry.
+  const startedNonReasoningCount =
+    params.attempt.itemLifecycle.startedCount -
+    (params.attempt.itemLifecycle.completedReasoningCount ?? 0);
+  if (startedNonReasoningCount > 0 || params.attempt.itemLifecycle.activeCount > 0) {
     return { retry: false, reason: "active_item" };
   }
   return { retry: true };

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -369,6 +369,8 @@ export type EmbeddedRunAttemptResult = {
     startedCount: number;
     completedCount: number;
     activeCount: number;
+    /** Completed model-internal reasoning items; excluded from replay gating. */
+    completedReasoningCount?: number;
   };
   setTerminalLifecycleMeta?: (meta: {
     replayInvalid?: boolean;

--- a/src/channels/message/types.ts
+++ b/src/channels/message/types.ts
@@ -292,6 +292,8 @@ export type ChannelMessageUnknownSendContext<TConfig = OpenClawConfig> = {
   enqueuedAt: number;
   retryCount: number;
   platformSendStartedAt?: number;
+  /** Failure evidence recorded at the send boundary for the latest attempt. */
+  lastError?: string;
   /** Canonical reply target persisted after hooks and before platform I/O. */
   effectiveReplyToId?: string | null;
   payloads: readonly ReplyPayload[];

--- a/src/infra/delivery-queue-sqlite-bound.ts
+++ b/src/infra/delivery-queue-sqlite-bound.ts
@@ -3,7 +3,10 @@ import type { DatabaseSync } from "node:sqlite";
 import type { Insertable } from "kysely";
 import type { OpenClawStateDatabase } from "../state/openclaw-state-db-contract.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
-import type { DeliveryQueueEntryState } from "./delivery-queue-sqlite.types.js";
+import type {
+  DeliveryQueueEntryState,
+  DeliveryQueueTerminalEvidence,
+} from "./delivery-queue-sqlite.types.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
@@ -111,7 +114,7 @@ export function terminalizeBoundDeliveryQueueEntry(
   queueName: string,
   id: string,
   expectedJson: string,
-  failedEntry: DeliveryQueueEntryState | undefined,
+  failedEntry: (DeliveryQueueEntryState & DeliveryQueueTerminalEvidence) | undefined,
   now: number,
 ): boolean {
   if (!failedEntry) {
@@ -125,17 +128,23 @@ export function terminalizeBoundDeliveryQueueEntry(
         .run(queueName, id, expectedJson).changes === 1
     );
   }
+  // Dead-letter rows keep channel/target/last_error evidence for operator
+  // diagnosis; stripping them made silent burial undebuggable in production.
   return (
     // sqlite-allow-raw: Exact JSON CAS keeps compaction atomic on the caller's transaction.
     db
       .prepare(
         `UPDATE delivery_queue_entries SET status = 'failed', entry_kind = NULL,
-        session_key = NULL, channel = NULL, target = NULL, account_id = NULL,
-        last_attempt_at = NULL, last_error = NULL, platform_send_started_at = NULL,
+        session_key = NULL, channel = ?, target = ?, account_id = NULL,
+        last_attempt_at = ?, last_error = ?, platform_send_started_at = NULL,
         recovery_state = ?, entry_json = ?, enqueued_at = ?, updated_at = ?, failed_at = ?
       WHERE queue_name = ? AND id = ? AND status = 'pending' AND entry_json = ?`,
       )
       .run(
+        failedEntry.channel ?? null,
+        failedEntry.to ?? null,
+        failedEntry.lastAttemptAt ?? null,
+        failedEntry.lastError ?? null,
         failedEntry.recoveryState ?? null,
         JSON.stringify(failedEntry),
         now,

--- a/src/infra/delivery-queue-sqlite.ts
+++ b/src/infra/delivery-queue-sqlite.ts
@@ -6,6 +6,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import {
   bindDeliveryQueueEntry,
+  deliveryQueueMetadata,
   deliveryQueueRowColumns,
   inflateDeliveryQueueRow,
   loadDeliveryQueueEntryInDatabase,
@@ -379,6 +380,7 @@ export function moveDeliveryQueueEntryToFailed(
   queueName: string,
   id: string,
   stateDir?: string,
+  terminalError?: string,
 ): void {
   const current = loadDeliveryQueueEntry(queueName, id, stateDir);
   if (!current) {
@@ -389,6 +391,7 @@ export function moveDeliveryQueueEntryToFailed(
     id,
     entry: current,
     stateDir,
+    ...(terminalError !== undefined ? { terminalError } : {}),
   });
   if (result.status !== "terminalized") {
     throw enoent(queueName, id);
@@ -401,6 +404,8 @@ export function terminalizePendingDeliveryQueueEntry(params: {
   id: string;
   entry: DeliveryQueueEntryState;
   stateDir?: string;
+  /** Terminal explanation recorded when the entry has no recorded send error. */
+  terminalError?: string;
 }): TerminalizePendingDeliveryQueueEntryResult {
   if (params.entry.id !== params.id) {
     throw new Error(`Delivery queue entry id mismatch: ${params.entry.id} != ${params.id}`);
@@ -421,7 +426,18 @@ export function terminalizePendingDeliveryQueueEntry(params: {
       ? { status: "terminalized", retained: false }
       : { status: "not_pending" };
   }
-  const failedEntry = projectDeliveryQueueTerminalEntry(params.entry, now, "failed", retention);
+  // The recorded send error is stronger evidence than a caller's terminal
+  // explanation; the explanation fills in only for never-recorded failures.
+  const metadata = deliveryQueueMetadata(params.queueName, params.entry);
+  const lastError = params.entry.lastError ?? params.terminalError;
+  const failedEntry = projectDeliveryQueueTerminalEntry(params.entry, now, "failed", retention, {
+    ...(metadata.channel ? { channel: metadata.channel } : {}),
+    ...(metadata.target ? { to: metadata.target } : {}),
+    ...(lastError ? { lastError } : {}),
+    ...(params.entry.lastAttemptAt !== undefined
+      ? { lastAttemptAt: params.entry.lastAttemptAt }
+      : {}),
+  });
   if (
     !terminalizeBoundDeliveryQueueEntry(
       database.db,

--- a/src/infra/delivery-queue-sqlite.types.ts
+++ b/src/infra/delivery-queue-sqlite.types.ts
@@ -105,13 +105,25 @@ export type DeliveryQueueEntryState = {
   recoveryState?: string;
 };
 
-/** Strip a terminal queue row to the producer policy needed for admission. */
+/** Longest failure evidence a terminal row retains; keeps tombstones bounded. */
+const DELIVERY_TERMINAL_ERROR_CAP = 300;
+
+/** Routing and failure facts a terminal row keeps for operator diagnosis. */
+export type DeliveryQueueTerminalEvidence = {
+  channel?: string;
+  to?: string;
+  lastError?: string;
+  lastAttemptAt?: number;
+};
+
+/** Strip a terminal queue row to producer admission policy plus failure evidence. */
 export function projectDeliveryQueueTerminalEntry(
   entry: Pick<DeliveryQueueEntryState, "id" | "retryCount">,
   terminalAt: number,
   terminal: "completed" | "failed",
   completionRetention?: DeliveryQueueCompletionRetention,
-): DeliveryQueueEntryState {
+  evidence?: DeliveryQueueTerminalEvidence,
+): DeliveryQueueEntryState & DeliveryQueueTerminalEvidence {
   const retryCount =
     Number.isSafeInteger(entry.retryCount) && entry.retryCount >= 0 ? entry.retryCount : 0;
   const recoveryState =
@@ -120,6 +132,7 @@ export function projectDeliveryQueueTerminalEntry(
       : completionRetention
         ? "completed_bounded"
         : undefined;
+  const lastError = evidence?.lastError?.slice(0, DELIVERY_TERMINAL_ERROR_CAP);
   return {
     id: entry.id,
     enqueuedAt: terminalAt,
@@ -127,5 +140,9 @@ export function projectDeliveryQueueTerminalEntry(
     ...(terminal === "completed" ? { acknowledgedAt: terminalAt } : { failedAt: terminalAt }),
     ...(completionRetention ? { completionRetention } : {}),
     ...(recoveryState ? { recoveryState } : {}),
+    ...(evidence?.channel ? { channel: evidence.channel } : {}),
+    ...(evidence?.to ? { to: evidence.to } : {}),
+    ...(lastError ? { lastError } : {}),
+    ...(evidence?.lastAttemptAt !== undefined ? { lastAttemptAt: evidence.lastAttemptAt } : {}),
   };
 }

--- a/src/infra/delivery-recovery.shared.test.ts
+++ b/src/infra/delivery-recovery.shared.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  classifyOutboundSendFailure,
   createDeliveryRecoveryCoordinator,
   isDeliveryRecoveryRetryEligible,
   resolveDeliveryRecoveryDeadlineMs,
 } from "./delivery-recovery.shared.js";
+import { PlatformMessageNotDispatchedError } from "./outbound/deliver-types.js";
 
 type RecoveryTestEntry = {
   id: string;
@@ -180,5 +182,97 @@ describe("shared durable delivery recovery coordinator", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+function errnoError(message: string, code: string, syscall?: string): Error {
+  return Object.assign(new Error(message), { code, ...(syscall ? { syscall } : {}) });
+}
+
+describe("classifyOutboundSendFailure", () => {
+  it.each([
+    ["connect refusal", errnoError("connect ECONNREFUSED 10.0.0.1:443", "ECONNREFUSED", "connect")],
+    ["dns not found", errnoError("getaddrinfo ENOTFOUND api.example", "ENOTFOUND", "getaddrinfo")],
+    ["dns backoff", errnoError("getaddrinfo EAI_AGAIN api.example", "EAI_AGAIN", "getaddrinfo")],
+    ["connect timeout", errnoError("connect ETIMEDOUT 10.0.0.1:443", "ETIMEDOUT", "connect")],
+    ["undici connect timeout", errnoError("Connect Timeout Error", "UND_ERR_CONNECT_TIMEOUT")],
+    [
+      "tls hostname mismatch",
+      errnoError("Hostname/IP does not match", "ERR_TLS_CERT_ALTNAME_INVALID"),
+    ],
+    ["tls expired certificate", errnoError("certificate has expired", "CERT_HAS_EXPIRED")],
+    [
+      "provider no-send marker",
+      new PlatformMessageNotDispatchedError("request not started", { cause: new Error("x") }),
+    ],
+    [
+      "nested connect refusal",
+      new Error("send failed", {
+        cause: errnoError("connect ECONNREFUSED 10.0.0.1:443", "ECONNREFUSED", "connect"),
+      }),
+    ],
+  ])("classifies %s as provably not sent and retryable", (_label, error) => {
+    expect(classifyOutboundSendFailure(error)).toEqual({
+      kind: "provably_not_sent",
+      retryable: true,
+    });
+  });
+
+  it("classifies platform 5xx and 429 responses as retryable, honoring retry_after", () => {
+    expect(
+      classifyOutboundSendFailure(
+        Object.assign(new Error("500: Internal Server Error"), {
+          error_code: 500,
+          description: "Internal Server Error",
+        }),
+      ),
+    ).toEqual({ kind: "provably_not_sent", retryable: true });
+    expect(
+      classifyOutboundSendFailure(
+        Object.assign(new Error("429: Too Many Requests: retry after 5"), {
+          error_code: 429,
+          description: "Too Many Requests: retry after 5",
+          parameters: { retry_after: 5 },
+        }),
+      ),
+    ).toEqual({ kind: "provably_not_sent", retryable: true, retryAfterMs: 5_000 });
+  });
+
+  it.each([
+    [
+      "platform semantic 400",
+      Object.assign(new Error("400: Bad Request: chat not found"), {
+        error_code: 400,
+        description: "Bad Request: chat not found",
+      }),
+    ],
+    [
+      "http client 404 response",
+      Object.assign(new Error("Not Found"), { status: 404, body: "{}" }),
+    ],
+    [
+      "provider permanent rejection marker",
+      new PlatformMessageNotDispatchedError("rejected payload", {
+        cause: new Error("x"),
+        retryable: false,
+      }),
+    ],
+  ])("classifies %s as provably not sent but terminal", (_label, error) => {
+    expect(classifyOutboundSendFailure(error)).toEqual({
+      kind: "provably_not_sent",
+      retryable: false,
+    });
+  });
+
+  it.each([
+    ["socket reset after write", errnoError("read ECONNRESET", "ECONNRESET", "read")],
+    ["non-connect timeout", errnoError("ETIMEDOUT", "ETIMEDOUT", "read")],
+    ["bare timeout code", errnoError("timed out", "ETIMEDOUT")],
+    ["plain error", new Error("boom")],
+    ["socket hang up", errnoError("socket hang up", "ECONNRESET")],
+    // A bare status number without response evidence is not a platform reply.
+    ["status without response evidence", Object.assign(new Error("failed"), { status: 500 })],
+  ])("keeps %s ambiguous", (_label, error) => {
+    expect(classifyOutboundSendFailure(error)).toEqual({ kind: "ambiguous" });
   });
 });

--- a/src/infra/delivery-recovery.shared.ts
+++ b/src/infra/delivery-recovery.shared.ts
@@ -3,6 +3,7 @@ import {
   resolveExpiresAtMsFromDurationMs,
   resolveNonNegativeIntegerOption,
 } from "../../packages/normalization-core/src/number-coercion.js";
+import { asNullableObjectRecord } from "../../packages/normalization-core/src/record-coerce.js";
 import { computeBackoffSchedule } from "../../packages/retry/src/index.js";
 import { sleep } from "../utils/sleep.js";
 import { collectErrorGraphCandidates, extractErrorCode } from "./errors.js";
@@ -23,6 +24,19 @@ const PRE_CONNECT_ERROR_CODES = new Set([
   "ENETDOWN",
   "ENETUNREACH",
   "EHOSTUNREACH",
+]);
+// TLS negotiation fails before any HTTP bytes are written, so the unambiguous
+// handshake/verification codes are no-send proof. A mid-stream TLS record
+// failure could reuse a code; that residual ambiguity is an accepted tradeoff.
+const TLS_HANDSHAKE_ERROR_CODE_RE = /^(?:ERR_TLS_|ERR_SSL_)/;
+const TLS_CERT_VERIFY_ERROR_CODES = new Set([
+  "CERT_HAS_EXPIRED",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "HOSTNAME_MISMATCH",
 ]);
 const TRANSPORT_ERROR_CODE_RE =
   /^(?:E(?:AI_|CONN|NET|HOST|ADDR|PIPE|TIMEDOUT|SOCKET)|UND_ERR_|ERR_(?:NETWORK|HTTP2|QUIC|TLS|SSL))/;
@@ -103,10 +117,21 @@ function isProvenPreConnectCandidate(candidate: unknown): boolean {
   if (code === "UND_ERR_CONNECT_TIMEOUT" || code === "UND_ERR_DNS_RESOLVE_FAILED") {
     return true;
   }
-  if (!code || !PRE_CONNECT_ERROR_CODES.has(code) || !candidate || typeof candidate !== "object") {
+  if (!code || !candidate || typeof candidate !== "object") {
     return false;
   }
+  if (TLS_HANDSHAKE_ERROR_CODE_RE.test(code) || TLS_CERT_VERIFY_ERROR_CODES.has(code)) {
+    return true;
+  }
   const syscall = (candidate as { syscall?: unknown }).syscall;
+  // Generic ETIMEDOUT can fire after the request was written; only the
+  // connect-stage variant proves the request never reached the platform.
+  if (code === "ETIMEDOUT") {
+    return syscall === "connect";
+  }
+  if (!PRE_CONNECT_ERROR_CODES.has(code)) {
+    return false;
+  }
   return syscall === "connect" || syscall === "getaddrinfo";
 }
 
@@ -171,6 +196,100 @@ export function findPlatformMessageRejectedError(
     }
   }
   return undefined;
+}
+
+type OutboundSendFailureClassification =
+  | { kind: "provably_not_sent"; retryable: true; retryAfterMs?: number }
+  | { kind: "provably_not_sent"; retryable: false }
+  | { kind: "ambiguous" };
+
+const isHttpStatusNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isInteger(value) && value >= 100 && value <= 599;
+
+function readHttpStatus(value: unknown): number | undefined {
+  if (isHttpStatusNumber(value)) {
+    return value;
+  }
+  if (typeof value === "string" && /^\d{3}$/.test(value.trim())) {
+    const parsed = Number(value.trim());
+    return isHttpStatusNumber(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function readRetryAfterMs(record: Record<string, unknown>): number | undefined {
+  const retryAfterSeconds = asNullableObjectRecord(record.parameters)?.retry_after;
+  return typeof retryAfterSeconds === "number" &&
+    Number.isFinite(retryAfterSeconds) &&
+    retryAfterSeconds >= 0
+    ? retryAfterSeconds * 1000
+    : undefined;
+}
+
+// `error_code` is a Bot-API-style response field and is response proof on its
+// own; bare `status`/`statusCode` numbers also appear on local errors, so they
+// count only next to response evidence. Keeps non-response failures ambiguous.
+const PLATFORM_RESPONSE_EVIDENCE_KEYS = [
+  "description",
+  "parameters",
+  "response",
+  "body",
+  "data",
+  "headers",
+] as const;
+
+function readPlatformErrorResponse(
+  candidate: unknown,
+): { status: number; retryAfterMs?: number } | undefined {
+  const record = asNullableObjectRecord(candidate);
+  if (!record) {
+    return undefined;
+  }
+  const status =
+    readHttpStatus(record.error_code) ??
+    (PLATFORM_RESPONSE_EVIDENCE_KEYS.some((key) => record[key] !== undefined)
+      ? (readHttpStatus(record.status) ?? readHttpStatus(record.statusCode))
+      : undefined);
+  if (status === undefined) {
+    return undefined;
+  }
+  const retryAfterMs = readRetryAfterMs(record);
+  return retryAfterMs === undefined ? { status } : { status, retryAfterMs };
+}
+
+/**
+ * Classifies one outbound send failure for retry policy. "Provably not sent"
+ * requires proof that no recipient-visible send occurred: a provider no-send
+ * marker, a connection-phase transport failure, or a platform API error
+ * response (the platform rejected the request, so nothing was delivered).
+ * Anything else — e.g. a socket that died after the request bytes were
+ * written with no response — stays ambiguous and must never blind-retry.
+ */
+export function classifyOutboundSendFailure(err: unknown): OutboundSendFailureClassification {
+  if (findPlatformMessageRejectedError(err)) {
+    return { kind: "provably_not_sent", retryable: false };
+  }
+  for (const candidate of collectErrorGraphCandidates(err, nestedErrorCandidates)) {
+    const response = readPlatformErrorResponse(candidate);
+    if (!response || response.status < 400) {
+      continue;
+    }
+    // 5xx and 429 are transient platform rejections; the platform still
+    // decided the request, so a bounded retry cannot duplicate a send.
+    // Other 4xx are semantic rejections a byte-identical retry cannot fix.
+    if (response.status >= 500 || response.status === 429) {
+      return {
+        kind: "provably_not_sent",
+        retryable: true,
+        ...(response.retryAfterMs !== undefined ? { retryAfterMs: response.retryAfterMs } : {}),
+      };
+    }
+    return { kind: "provably_not_sent", retryable: false };
+  }
+  if (isProvenDeliveryNotSentError(err)) {
+    return { kind: "provably_not_sent", retryable: true };
+  }
+  return { kind: "ambiguous" };
 }
 
 export function computeBackoffMs(retryCount: number): number {

--- a/src/infra/outbound/deliver-queue-execute.ts
+++ b/src/infra/outbound/deliver-queue-execute.ts
@@ -3,8 +3,8 @@ import { hasTrustedMessageAuditListeners } from "../../audit/message-audit-event
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import {
+  classifyOutboundSendFailure,
   findPlatformMessageRejectedError,
-  isProvenDeliveryNotSentError,
 } from "../delivery-recovery.shared.js";
 import { formatErrorMessage } from "../errors.js";
 import type { DeliverOutboundPayloadsParams, PlatformSendRoute } from "./deliver-contracts.js";
@@ -28,8 +28,8 @@ import { rejectDurableDelivery, settleDurableDelivery } from "./delivery-complet
 import {
   failDelivery,
   failDeliveryAfterPlatformSend,
-  failDeliveryBeforePlatformSend,
   markDeliveryPlatformSendDispatched,
+  resolveNotSentAwareFailureRecorder,
 } from "./delivery-queue-storage.js";
 import { createMessageSentEmitter, type MessageSentEvent } from "./message-sent-hook.js";
 import {
@@ -63,7 +63,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
   // payload failed so we can call failDelivery instead of ackDelivery.
   let hadPartialFailure = false;
   let lastPayloadError: unknown;
-  let partialFailuresAreProvenNotSent = true;
+  const partialFailureErrors: unknown[] = [];
   const ownsAuditTerminal = params.deliveryQueueId === undefined;
   const auditPayloadOutcomes =
     ownsAuditTerminal && hasTrustedMessageAuditListeners()
@@ -274,7 +274,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
       throwIfProducerLeaseLost();
       hadPartialFailure = true;
       lastPayloadError = err;
-      partialFailuresAreProvenNotSent &&= isProvenDeliveryNotSentError(err);
+      partialFailureErrors.push(err);
       params.onError?.(err, payload);
     },
     ...(auditPayloadOutcomes || stablePayloadOutcomes
@@ -357,10 +357,9 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
           (partialSendEvidence ? await persistOwnedPostSendState() : undefined);
         const error = "partial delivery failure (bestEffort)";
         if (postSendState === undefined || postSendState === "marked") {
-          const recordFailure =
-            !partialSendEvidence && partialFailuresAreProvenNotSent
-              ? failDeliveryBeforePlatformSend
-              : failDelivery;
+          const recordFailure = partialSendEvidence
+            ? failDelivery
+            : resolveNotSentAwareFailureRecorder(partialFailureErrors);
           await recordOwnedQueueFailure(recordFailure, error).catch((err: unknown) => {
             log.warn(
               `failed to mark queued delivery ${queueId} as failed after partial failure; continuing best-effort delivery: ${formatErrorMessage(err)}`,
@@ -546,8 +545,16 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
           }
         } else {
           const permanentRejection = findPlatformMessageRejectedError(err);
+          const classification = classifyOutboundSendFailure(err);
+          // A semantic platform rejection (explicit marker or a classified
+          // non-retryable platform error response) cannot succeed on replay.
+          const terminalRejectionMessage = permanentRejection
+            ? permanentRejection.message
+            : classification.kind === "provably_not_sent" && !classification.retryable
+              ? formatErrorMessage(err)
+              : undefined;
           let terminalRejectionHandled = false;
-          if (permanentRejection) {
+          if (terminalRejectionMessage !== undefined) {
             let ownerRejected = false;
             let queueAcked = false;
             try {
@@ -559,7 +566,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
               if (ambiguousStableRejection) {
                 await recordOwnedQueueFailure(
                   failDeliveryAfterPlatformSend,
-                  `delivery partially sent before permanent rejection: ${permanentRejection.message}`,
+                  `delivery partially sent before permanent rejection: ${terminalRejectionMessage}`,
                 );
                 queuedPostSendState = "failed";
                 terminalRejectionHandled = true;
@@ -567,7 +574,7 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
                 if (params.deliveryCompletion) {
                   await rejectDurableDelivery(
                     params.deliveryCompletion,
-                    permanentRejection.message,
+                    terminalRejectionMessage,
                     platformQueueStateDir,
                   );
                   ownerRejected = true;
@@ -597,16 +604,14 @@ export async function deliverOutboundPayloadsWithQueueCleanup(
             }
           }
           if (!terminalRejectionHandled) {
-            const recordFailure = isProvenDeliveryNotSentError(err)
-              ? failDeliveryBeforePlatformSend
-              : failDelivery;
-            await recordOwnedQueueFailure(recordFailure, formatErrorMessage(err)).catch(
-              (failErr: unknown) => {
-                log.warn(
-                  `failed to mark queued delivery ${queueId} as failed: ${formatErrorMessage(failErr)}`,
-                );
-              },
-            );
+            await recordOwnedQueueFailure(
+              resolveNotSentAwareFailureRecorder([err]),
+              formatErrorMessage(err),
+            ).catch((failErr: unknown) => {
+              log.warn(
+                `failed to mark queued delivery ${queueId} as failed: ${formatErrorMessage(failErr)}`,
+              );
+            });
           }
         }
       }

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -153,7 +153,7 @@ vi.mock("../../hooks/internal-hooks.js", () => ({
   createInternalHookEvent: internalHookMocks.createInternalHookEvent,
   triggerInternalHook: internalHookMocks.triggerInternalHook,
 }));
-vi.mock("./delivery-queue-storage.js", () => ({
+vi.mock("./delivery-queue-storage.js", async () => ({
   enqueueDelivery: async (params: Record<string, unknown>) =>
     queueMocks.enqueueDelivery(withoutInitialProducerClaim(params)),
   enqueueDeliveryOnce: async (params: Record<string, unknown>, id: string) =>
@@ -166,6 +166,17 @@ vi.mock("./delivery-queue-storage.js", () => ({
     queueMocks.failDeliveryAfterPlatformSend(id, error),
   failDeliveryBeforePlatformSend: async (id: string, error: string) =>
     queueMocks.failDeliveryBeforePlatformSend(id, error),
+  // Mirrors production selection through the real classifier so assertions on
+  // the mocked before/after recorders keep observing the same routing.
+  resolveNotSentAwareFailureRecorder: await import("../delivery-recovery.shared.js").then(
+    ({ classifyOutboundSendFailure }) =>
+      (errors: readonly unknown[]) =>
+        errors.length > 0 &&
+        errors.every((error) => classifyOutboundSendFailure(error).kind === "provably_not_sent")
+          ? async (id: string, error: string) =>
+              queueMocks.failDeliveryBeforePlatformSend(id, error)
+          : async (id: string, error: string) => queueMocks.failDelivery(id, error),
+  ),
   markDeliveryPlatformOutcomeUnknown: async (id: string) =>
     queueMocks.markDeliveryPlatformOutcomeUnknown(id),
   markDeliveryPlatformSendDispatched: async (

--- a/src/infra/outbound/delivery-queue-reconciliation.ts
+++ b/src/infra/outbound/delivery-queue-reconciliation.ts
@@ -17,6 +17,7 @@ type UnknownSendQueueEntry = {
   enqueuedAt: number;
   retryCount: number;
   platformSendStartedAt?: number;
+  lastError?: string;
   effectiveReplyToId?: string | null;
   renderedBatchPlan?: RenderedMessageBatchPlan;
   replyToId?: string | null;
@@ -43,6 +44,7 @@ export function buildUnknownSendContext(params: {
     ...(entry.platformSendStartedAt !== undefined
       ? { platformSendStartedAt: entry.platformSendStartedAt }
       : {}),
+    ...(entry.lastError !== undefined ? { lastError: entry.lastError } : {}),
     ...(entry.effectiveReplyToId !== undefined
       ? { effectiveReplyToId: entry.effectiveReplyToId }
       : {}),

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -7,12 +7,12 @@ import type {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import {
+  classifyOutboundSendFailure,
   createDeliveryRecoveryCoordinator,
   createEmptyDeliveryRecoverySummary,
   findPlatformMessageRejectedError,
   getErrnoCode,
   isDeliveryRecoveryRetryEligible,
-  isProvenDeliveryNotSentError,
   resolveDeliveryRecoveryDeadlineMs,
   type ActiveDeliveryRecoveryClaimResult,
   type DeliveryRecoveryDrainDecision,
@@ -58,12 +58,12 @@ import {
   claimDeliveryPlatformSendAttempt,
   failDelivery,
   failDeliveryAfterPlatformSend,
-  failDeliveryBeforePlatformSend,
   failPendingDelivery,
   loadPendingDelivery,
   loadPendingDeliveries,
   moveToFailed,
   reserveDeliveryAttempt,
+  resolveNotSentAwareFailureRecorder,
   type QueuedDelivery,
 } from "./delivery-queue-storage.js";
 import { createMessageSentEmitter, type MessageSentEvent } from "./message-sent-hook.js";
@@ -391,7 +391,12 @@ async function applyRecoveryDeliveryAdmission(params: {
   await markDurableDeliveryFailedBestEffort(params.entry, params.log, params.stateDir);
   const failed = await terminalizeWithMediaRetention(params, async (spoolPaths) => {
     const result = await failPendingDelivery(
-      { id: params.entry.id, entry: params.entry, retainSpoolArtifacts: true },
+      {
+        id: params.entry.id,
+        entry: params.entry,
+        retainSpoolArtifacts: true,
+        terminalError: admission.reason,
+      },
       params.stateDir,
     );
     return result.status === "failed" ? spoolPaths : false;
@@ -416,11 +421,13 @@ async function moveEntryToFailedAndCleanup(params: {
   log: RecoveryLogger;
   stateDir?: string;
   attemptId?: string | null;
+  /** Recorded on the terminal row when the entry has no persisted send error. */
+  terminalError?: string;
 }): Promise<void> {
   await terminalizeWithMediaRetention(params, async () =>
     params.attemptId !== undefined
-      ? moveToFailed(params.entry.id, params.stateDir, params.attemptId)
-      : moveToFailed(params.entry.id, params.stateDir),
+      ? moveToFailed(params.entry.id, params.stateDir, params.attemptId, params.terminalError)
+      : moveToFailed(params.entry.id, params.stateDir, undefined, params.terminalError),
   );
 }
 
@@ -540,11 +547,12 @@ async function moveEntryToFailedWithLogging(
   cfg: OpenClawConfig,
   log: RecoveryLogger,
   stateDir?: string,
+  terminalError = "delivery retry budget exhausted",
 ): Promise<boolean> {
   await markDurableDeliveryFailedBestEffort(entry, log, stateDir);
   try {
     const attemptId = recoveryPlatformAttemptId(entry);
-    await moveEntryToFailedAndCleanup({ entry, cfg, log, stateDir, attemptId });
+    await moveEntryToFailedAndCleanup({ entry, cfg, log, stateDir, attemptId, terminalError });
     emitRecoveredTerminalFailure(entry, "delivery retry budget exhausted");
     return true;
   } catch (err) {
@@ -701,7 +709,13 @@ async function resolveCompletedOwnerBeforeRecovery(opts: {
     return "failed";
   }
   if (operation.state === "unknown") {
-    const moved = await moveEntryToFailedWithLogging(opts.entry, opts.cfg, opts.log, opts.stateDir);
+    const moved = await moveEntryToFailedWithLogging(
+      opts.entry,
+      opts.cfg,
+      opts.log,
+      opts.stateDir,
+      "delivery owner state unknown after platform send",
+    );
     return moved ? "moved-to-failed" : "failed";
   }
   return "continue";
@@ -852,7 +866,11 @@ async function drainQueuedEntry(opts: {
           log: opts.log,
           stateDir: opts.stateDir,
           attemptId,
+          terminalError: errMsg,
         });
+        opts.log.error(
+          `Delivery entry ${entry.id} dead-lettered as ambiguous on ${entry.channel} -> ${entry.to}: ${errMsg}`,
+        );
         emitRecoveredTerminalFailure(entry, errMsg);
         emitQueuedAuditTerminals(entry, () => queuedUnknownAuditTerminals(entry));
         return "moved-to-failed";
@@ -930,6 +948,7 @@ async function drainQueuedEntry(opts: {
         log: opts.log,
         stateDir: opts.stateDir,
         attemptId: producerClaimId,
+        terminalError: errMsg,
       });
       emitRecoveredTerminalFailure(entry, errMsg);
     } catch (moveErr) {
@@ -1029,12 +1048,13 @@ async function drainQueuedEntry(opts: {
           );
         }
       } else {
-        const recordFailure = failedOutcomes.every((outcome) =>
-          isProvenDeliveryNotSentError(outcome.error),
-        )
-          ? failDeliveryBeforePlatformSend
-          : failDelivery;
-        await recordRecoveredFailure(recordFailure, entry, errMsg, opts.stateDir, producerClaimId);
+        await recordRecoveredFailure(
+          resolveNotSentAwareFailureRecorder(failedOutcomes.map((outcome) => outcome.error)),
+          entry,
+          errMsg,
+          opts.stateDir,
+          producerClaimId,
+        );
       }
       return "failed";
     }
@@ -1162,8 +1182,13 @@ async function drainQueuedEntry(opts: {
       );
       return "failed";
     }
+    const classification = classifyOutboundSendFailure(err);
     const permanentPlatformRejection = findPlatformMessageRejectedError(err);
-    if (permanentPlatformRejection || isPermanentDeliveryError(errMsg)) {
+    const permanentlyRejected =
+      permanentPlatformRejection !== undefined ||
+      isPermanentDeliveryError(errMsg) ||
+      (classification.kind === "provably_not_sent" && !classification.retryable);
+    if (permanentlyRejected) {
       try {
         if (permanentPlatformRejection && entry.deliveryCompletion) {
           await rejectDurableDelivery(
@@ -1180,6 +1205,7 @@ async function drainQueuedEntry(opts: {
           log: opts.log,
           stateDir: opts.stateDir,
           attemptId: producerClaimId,
+          terminalError: errMsg,
         });
         emitRecoveredTerminalFailure(entry, errMsg, messageSentEvents);
         emitQueuedAuditTerminals(entry, () =>
@@ -1198,10 +1224,13 @@ async function drainQueuedEntry(opts: {
       }
     } else {
       try {
-        const recordFailure = isProvenDeliveryNotSentError(err)
-          ? failDeliveryBeforePlatformSend
-          : failDelivery;
-        await recordRecoveredFailure(recordFailure, entry, errMsg, opts.stateDir, producerClaimId);
+        await recordRecoveredFailure(
+          resolveNotSentAwareFailureRecorder([err]),
+          entry,
+          errMsg,
+          opts.stateDir,
+          producerClaimId,
+        );
         return "failed";
       } catch (failErr) {
         if (getErrnoCode(failErr) === "ENOENT") {
@@ -1279,6 +1308,7 @@ export async function drainPendingDeliveriesCore(opts: {
               log: opts.log,
               stateDir: opts.stateDir,
               attemptId,
+              terminalError: "delivery retry budget exhausted",
             });
             emitRecoveredTerminalFailure(currentEntry, "delivery retry budget exhausted");
           } catch (err) {

--- a/src/infra/outbound/delivery-queue-storage.ts
+++ b/src/infra/outbound/delivery-queue-storage.ts
@@ -23,6 +23,7 @@ import {
   upsertDeliveryQueueEntry,
 } from "../delivery-queue-sqlite.js";
 import { inferDeliveryQueueFailureRetention } from "../delivery-queue-sqlite.types.js";
+import { classifyOutboundSendFailure } from "../delivery-recovery.shared.js";
 import { generateSecureUuid } from "../secure-random.js";
 import { collectEntrySpoolPaths, releaseSpoolArtifacts } from "./delivery-queue-media-spool.js";
 import {
@@ -350,6 +351,7 @@ export async function failDeliveryBeforePlatformSend(
   error: string,
   stateDir?: string,
   expectedPlatformSendAttemptId?: string | null,
+  retryDelayMs?: number,
 ): Promise<void> {
   updateQueuedDelivery(
     id,
@@ -359,8 +361,11 @@ export async function failDeliveryBeforePlatformSend(
       retryCount: entry.retryCount + 1,
       lastAttemptAt: Date.now(),
       lastError: error,
-      // Clear both fields together; retaining either would preserve false send evidence.
-      availableAt: undefined,
+      // Clear claim and platform evidence together; retaining either would
+      // preserve false send evidence. availableAt survives only as a platform
+      // retry-after floor (e.g. Telegram 429), never as an ownership lease.
+      availableAt:
+        retryDelayMs !== undefined && retryDelayMs > 0 ? Date.now() + retryDelayMs : undefined,
       producerClaimId: undefined,
       platformSendAttemptId: undefined,
       platformSendStartedAt: undefined,
@@ -392,6 +397,32 @@ export async function failDeliveryAfterPlatformSend(
     }),
     expectedPlatformSendAttemptId,
   );
+}
+
+/**
+ * Chooses the attempt-failure recorder from not-sent proof. Only when every
+ * failure provably never produced a recipient-visible send may the retry
+ * clear platform evidence; a platform retry-after hint floors the next try.
+ */
+export function resolveNotSentAwareFailureRecorder(
+  errors: readonly unknown[],
+): typeof failDelivery {
+  let retryDelayMs: number | undefined;
+  for (const error of errors) {
+    const classification = classifyOutboundSendFailure(error);
+    if (classification.kind !== "provably_not_sent") {
+      return failDelivery;
+    }
+    if (classification.retryable && classification.retryAfterMs !== undefined) {
+      retryDelayMs = Math.max(retryDelayMs ?? 0, classification.retryAfterMs);
+    }
+  }
+  if (errors.length === 0) {
+    return failDelivery;
+  }
+  const delay = retryDelayMs;
+  return (id, error, stateDir, expectedPlatformSendAttemptId) =>
+    failDeliveryBeforePlatformSend(id, error, stateDir, expectedPlatformSendAttemptId, delay);
 }
 
 export { claimDeliveryPlatformSendAttempt } from "./delivery-queue-platform-lease.js";
@@ -569,6 +600,7 @@ export async function moveToFailed(
   id: string,
   stateDir?: string,
   expectedPlatformSendAttemptId?: string | null,
+  terminalError?: string,
 ): Promise<string[]> {
   let spoolPaths: string[];
   if (expectedPlatformSendAttemptId !== undefined) {
@@ -585,7 +617,7 @@ export async function moveToFailed(
           queuedDeliveryPayloads(entry as QueuedDelivery),
           stateDir,
         );
-        moveDeliveryQueueEntryToFailed(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir);
+        moveDeliveryQueueEntryToFailed(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir, terminalError);
       },
     );
     if (!moved) {
@@ -597,7 +629,7 @@ export async function moveToFailed(
       throw new Error(`No pending outbound delivery queue entry ${id}`);
     }
     spoolPaths = collectEntrySpoolPaths(queuedDeliveryPayloads(entry), stateDir);
-    moveDeliveryQueueEntryToFailed(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir);
+    moveDeliveryQueueEntryToFailed(OUTBOUND_DELIVERY_QUEUE_NAME, id, stateDir, terminalError);
   }
   return spoolPaths;
 }
@@ -610,12 +642,21 @@ export async function failPendingDelivery(
     id: string;
     entry: QueuedDelivery;
     retainSpoolArtifacts?: boolean;
+    terminalError?: string;
   },
   stateDir?: string,
 ): Promise<FailPendingDeliveryResult> {
   let terminalized: ReturnType<typeof terminalizePendingDeliveryQueueEntry> = {
     status: "not_pending",
   };
+  const terminalize = () =>
+    terminalizePendingDeliveryQueueEntry({
+      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
+      id: params.id,
+      entry: params.entry,
+      stateDir,
+      ...(params.terminalError !== undefined ? { terminalError: params.terminalError } : {}),
+    });
   const retained =
     inferDeliveryQueueFailureRetention(params.entry, params.id, OUTBOUND_DELIVERY_QUEUE_NAME) !==
     undefined;
@@ -631,21 +672,11 @@ export async function failPendingDelivery(
         platformSendAttemptId: attemptId,
       },
       () => {
-        terminalized = terminalizePendingDeliveryQueueEntry({
-          queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-          id: params.id,
-          entry: params.entry,
-          stateDir,
-        });
+        terminalized = terminalize();
       },
     );
   } else {
-    terminalized = terminalizePendingDeliveryQueueEntry({
-      queueName: OUTBOUND_DELIVERY_QUEUE_NAME,
-      id: params.id,
-      entry: params.entry,
-      stateDir,
-    });
+    terminalized = terminalize();
   }
   if (terminalized.status === "terminalized") {
     if (params.retainSpoolArtifacts !== true) {

--- a/src/infra/outbound/delivery-queue.notsent-retry.test.ts
+++ b/src/infra/outbound/delivery-queue.notsent-retry.test.ts
@@ -1,0 +1,205 @@
+// Regression coverage: provably-not-sent send failures retry on the backoff
+// rails instead of dead-lettering, and terminal rows keep failure evidence.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
+import { recoverPendingDeliveries } from "./delivery-queue-recovery.js";
+import { enqueueDelivery, loadPendingDeliveries } from "./delivery-queue-storage.js";
+import {
+  asDeliverFn,
+  createRecoveryLog,
+  installDeliveryQueueTmpDirHooks,
+  readQueuedEntry,
+  setQueuedEntryState,
+} from "./delivery-queue.test-helpers.js";
+
+type TerminalRow = {
+  status: string;
+  channel: string | null;
+  target: string | null;
+  last_error: string | null;
+  entry_json: string;
+};
+
+function readTerminalRow(tmpDir: string, id: string): TerminalRow {
+  const { db } = openOpenClawStateDatabase({ env: { ...process.env, OPENCLAW_STATE_DIR: tmpDir } });
+  const row = db
+    .prepare(
+      `SELECT status, channel, target, last_error, entry_json
+         FROM delivery_queue_entries WHERE queue_name = ? AND id = ?`,
+    )
+    .get(OUTBOUND_DELIVERY_QUEUE_NAME, id) as TerminalRow | undefined;
+  if (!row) {
+    throw new Error(`Missing delivery queue row ${id}`);
+  }
+  return row;
+}
+
+function connectRefusedError(): Error {
+  return Object.assign(new Error("connect ECONNREFUSED 10.0.0.1:443"), {
+    code: "ECONNREFUSED",
+    syscall: "connect",
+  });
+}
+
+describe("outbound delivery provably-not-sent retry", () => {
+  const { tmpDir } = installDeliveryQueueTmpDirHooks();
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries a provably-not-sent failure with backoff and delivers later", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-07-25T00:00:00.000Z");
+    vi.setSystemTime(startedAt);
+    const stateDir = tmpDir();
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "retry me" }] },
+      stateDir,
+    );
+    const deliver = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("429: Too Many Requests: retry after 7"), {
+          error_code: 429,
+          description: "Too Many Requests: retry after 7",
+          parameters: { retry_after: 7 },
+        }),
+      )
+      .mockResolvedValue([]);
+    const recover = () =>
+      recoverPendingDeliveries({
+        deliver: asDeliverFn(deliver),
+        log: createRecoveryLog(),
+        cfg: {},
+        stateDir,
+        maxRecoveryMs: 60_000,
+      });
+
+    await expect(recover()).resolves.toMatchObject({ recovered: 0, failed: 1 });
+    const failedEntry = readQueuedEntry(stateDir, id);
+    expect(failedEntry.retryCount).toBe(1);
+    expect(failedEntry.lastError).toContain("Too Many Requests");
+    // Platform retry-after floors the next attempt via the availableAt rail.
+    expect(failedEntry.availableAt).toBe(startedAt.getTime() + 7_000);
+    expect(failedEntry.recoveryState).toBeUndefined();
+    expect(failedEntry.platformSendAttemptId).toBeUndefined();
+
+    // Before the retry-after floor the entry must stay deferred, not buried.
+    vi.setSystemTime(startedAt.getTime() + 6_000);
+    await expect(recover()).resolves.toMatchObject({ recovered: 0, deferredBackoff: 1 });
+
+    vi.setSystemTime(startedAt.getTime() + 7_000);
+    await expect(recover()).resolves.toMatchObject({ recovered: 1, deferredBackoff: 0 });
+    expect(deliver).toHaveBeenCalledTimes(2);
+    await expect(loadPendingDeliveries(stateDir)).resolves.toEqual([]);
+  });
+
+  it("keeps provably-not-sent connect failures pending instead of dead-lettering", async () => {
+    const stateDir = tmpDir();
+    const id = await enqueueDelivery(
+      { channel: "demo-channel-a", to: "+1", payloads: [{ text: "connect refused" }] },
+      stateDir,
+    );
+    const deliver = vi.fn().mockRejectedValue(connectRefusedError());
+
+    await recoverPendingDeliveries({
+      deliver: asDeliverFn(deliver),
+      log: createRecoveryLog(),
+      cfg: {},
+      stateDir,
+      maxRecoveryMs: 60_000,
+    });
+
+    const entry = readQueuedEntry(stateDir, id);
+    expect(entry.retryCount).toBe(1);
+    expect(entry.lastError).toContain("ECONNREFUSED");
+    const pending = await loadPendingDeliveries(stateDir);
+    expect(pending.map((pendingEntry) => pendingEntry.id)).toEqual([id]);
+  });
+
+  it("terminalizes with lastError, channel, and target after budget exhaustion", async () => {
+    const stateDir = tmpDir();
+    const id = await enqueueDelivery(
+      {
+        channel: "demo-channel-a",
+        to: "+1",
+        payloads: [{ text: "exhausted" }],
+        completionRetention: "permanent",
+      },
+      stateDir,
+    );
+    setQueuedEntryState(stateDir, id, {
+      retryCount: 5,
+      lastAttemptAt: Date.now() - 1_000,
+      lastError: "connect ECONNREFUSED 10.0.0.1:443",
+    });
+    const deliver = vi.fn();
+
+    await expect(
+      recoverPendingDeliveries({
+        deliver: asDeliverFn(deliver),
+        log: createRecoveryLog(),
+        cfg: {},
+        stateDir,
+        maxRecoveryMs: 60_000,
+      }),
+    ).resolves.toMatchObject({ skippedMaxRetries: 1 });
+
+    expect(deliver).not.toHaveBeenCalled();
+    const row = readTerminalRow(stateDir, id);
+    expect(row.status).toBe("failed");
+    expect(row.channel).toBe("demo-channel-a");
+    expect(row.target).toBe("+1");
+    expect(row.last_error).toBe("connect ECONNREFUSED 10.0.0.1:443");
+    expect(JSON.parse(row.entry_json)).toMatchObject({
+      channel: "demo-channel-a",
+      to: "+1",
+      lastError: "connect ECONNREFUSED 10.0.0.1:443",
+      retryCount: 5,
+    });
+  });
+
+  it("does not retry an ambiguous send and buries it with preserved evidence", async () => {
+    const stateDir = tmpDir();
+    const id = await enqueueDelivery(
+      {
+        channel: "demo-channel-a",
+        to: "+1",
+        payloads: [{ text: "ambiguous" }],
+        completionRetention: "permanent",
+      },
+      stateDir,
+    );
+    setQueuedEntryState(stateDir, id, {
+      retryCount: 1,
+      // Past the retry backoff window so recovery reaches reconciliation.
+      lastAttemptAt: Date.now() - 60_000,
+      lastError: "socket hang up",
+      platformSendStartedAt: Date.now() - 61_000,
+      recoveryState: "send_attempt_started",
+    });
+    const log = createRecoveryLog();
+    const deliver = vi.fn();
+
+    await recoverPendingDeliveries({
+      deliver: asDeliverFn(deliver),
+      log,
+      cfg: {},
+      stateDir,
+      maxRecoveryMs: 60_000,
+    });
+
+    // Ambiguity is never blind-replayed: no provider call, conservative burial.
+    expect(deliver).not.toHaveBeenCalled();
+    const row = readTerminalRow(stateDir, id);
+    expect(row.status).toBe("failed");
+    expect(row.channel).toBe("demo-channel-a");
+    expect(row.target).toBe("+1");
+    expect(row.last_error).toBe("socket hang up");
+    expect(
+      log.error.mock.calls.some(([message]) => message.includes("dead-lettered as ambiguous")),
+    ).toBe(true);
+  });
+});

--- a/src/infra/outbound/delivery-queue.storage.test.ts
+++ b/src/infra/outbound/delivery-queue.storage.test.ts
@@ -731,6 +731,9 @@ describe("delivery-queue storage", () => {
           retryCount: 0,
           completionRetention: "permanent",
           recoveryState: "completed_permanent",
+          // Terminal rows keep routing evidence for operator diagnosis.
+          channel: "directchat",
+          to: "+1555",
         });
         await expect(fs.stat(artifact)).rejects.toMatchObject({ code: "ENOENT" });
       } finally {
@@ -803,6 +806,9 @@ describe("delivery-queue storage", () => {
         retryCount: 0,
         completionRetention: "permanent",
         recoveryState: "completed_permanent",
+        // Terminal rows keep routing evidence for operator diagnosis.
+        channel: "workspace",
+        to: "#general",
       });
       await expect(
         enqueueDeliveryOnce(


### PR DESCRIPTION
## Summary

Two production-reliability fixes, found while investigating a deployment where **1,206 outbound messages were silently dead-lettered over 12 days** and long-context Codex app-server turns failed with `turn_completion_idle_timeout` despite being safely replayable.

### 1. Outbound delivery: retry provably-not-sent failures and keep dead-letter evidence (db2a0649)

Production signature: every dead-lettered row had `retry_count = 1` and NULL `channel`/`target`/`last_error`, so operators had zero evidence of what failed or why.

Root causes:
- Platform API rejections (Bot API 429/5xx) were classified ambiguous, and channels without an unknown-send reconciliation capability (e.g. Telegram) buried the message after a single attempt, even when the platform response proved nothing was ever delivered.
- `terminalizeBoundDeliveryQueueEntry` NULLed `channel`, `target`, `last_attempt_at`, and `last_error` on terminalization, destroying all failure evidence.

Changes:
- Shared `classifyOutboundSendFailure`: provably-not-sent (connection-phase errors incl. connect-stage `ETIMEDOUT`, TLS handshake/cert failures, DNS; platform error responses) vs ambiguous (post-write socket death). 5xx/429 retryable with `retry_after` honored; semantic 4xx terminal.
- Provably-not-sent retryable failures requeue with backoff on the existing rails instead of terminalizing at attempt 1.
- Terminal rows preserve `channel`/`target`/`last_error` (300-char cap)/`last_attempt_at`. No schema change; existing columns reused.
- Telegram gains an evidence-only `reconcileUnknownSend` (never blind-replays an ambiguous send).
- Ambiguous dead-letter decisions now log at error level.

### 2. Codex app-server: auto-replay a post-reasoning stalled turn once (61b3e5b6)

Production signature: model completes a reasoning item, stream goes permanently silent, completion idle timeout fires, and the user is told to retry manually — even though the failure computes as replay-safe and a once-per-run replay mechanism already exists.

Root cause: completed reasoning items counted into `itemLifecycle.startedCount`, so `resolveCodexAppServerReplayBlockedReason` returned `active_item` and the existing recovery path refused to replay. Verified against the Codex protocol (`Reasoning` thread items carry text only, no side-effect payload).

Changes:
- Track `completedReasoningItemCount` in the event projector and subtract it from replay-blocking activity in both gates (`resolveCodexAppServerReplayBlockedReason`, `resolveCodexAppServerRecoveryRetry`).
- Existing once-per-run budget unchanged; assistant output or tool activity still blocks replay; a failed replay surfaces the original timeout.
- Successful recovery logs a stable `recovered_via_auto_replay` marker.

## Tests

- New regression tests fail against pre-fix code at the exact production defects (evidence stripping, single-attempt burial, replay refusal) and pass after.
- Mission 1 sweep: 6 vitest shards, 2,241 tests green (all existing `src/infra/outbound` suites plus new classification matrix, retry-with-backoff, budget-exhaustion evidence, ambiguous-never-retries).
- Mission 2 sweep: 3 shards, 199 tests green (full `run-attempt.turn-watches`, `attempt-results`, shared-integration replay cases).
- `check-changed` gates green (typecheck, lint, ratchets).

Happy to split into two PRs if preferred.
