### PR TITLE
fix(ui): preserve active run ownership across steering

### DIFF
--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -5,6 +5,7 @@ import {
   expectRequestCountStable,
   installMockGateway,
   requireRecord,
+  requireString,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
 
@@ -132,6 +133,177 @@ suite.define(() => {
       });
       expect(steerParams).not.toHaveProperty("expectedRunId");
       expect(steerParams).not.toHaveProperty("expectedLeafEntryId");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("keeps the active run across a live steer operation", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const runId = "run-a";
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "user",
+          content: "run the long command",
+          __openclaw: { id: "user-a", idempotencyKey: `${runId}:user`, seq: 1 },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "callExec", name: "exec", arguments: {} }],
+          __openclaw: { id: "exec-call", seq: 2 },
+        },
+        {
+          role: "toolResult",
+          toolCallId: "callExec",
+          toolName: "exec",
+          content: [{ type: "text", text: "process still running" }],
+          __openclaw: { id: "exec-result", seq: 3 },
+        },
+      ],
+      inFlightRun: { runId, text: "" },
+      sessionInfo: { activeRunIds: [runId], hasActiveRun: true, key: "main" },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}settings/appearance`);
+      const configPatchesBefore = (await gateway.getRequests("config.patch")).length;
+      await page.locator("[data-settings-follow-up-mode]").selectOption("queue");
+      await waitForRequests(gateway, "config.patch", configPatchesBefore + 1);
+      const shortcut = page.locator("[data-settings-send-shortcut]");
+      await shortcut.selectOption("enter");
+      expect(await shortcut.inputValue()).toBe("enter");
+      await page.goto(`${suite.server.baseUrl}chat`);
+
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await page.locator(".chat-tool-msg-summary", { hasText: "Exec" }).waitFor();
+      await page.getByRole("button", { name: "Stop generating" }).waitFor();
+      let toolSequence = 0;
+      const emitTool = (data: Record<string, unknown>) =>
+        gateway.emitGatewayEvent("agent", {
+          data,
+          runId,
+          seq: ++toolSequence,
+          sessionKey: "main",
+          stream: "tool",
+          ts: Date.now(),
+        });
+
+      const steerText = "steer while the process runs";
+      const sendsBeforeSteer = (await gateway.getRequests("chat.send")).length;
+      await gateway.deferNext("chat.send");
+      await composer.fill(steerText);
+      await composer.press("Control+Enter");
+      const steerSend = await gateway.waitForRequest("chat.send", { after: sendsBeforeSteer });
+      const steerParams = requireRecord(steerSend.params);
+      expect(steerParams).toMatchObject({
+        deliver: false,
+        message: steerText,
+        queueMode: "steer",
+        sessionKey: "main",
+      });
+      expect(steerParams).not.toHaveProperty("expectedRunId");
+      expect(steerParams).not.toHaveProperty("expectedLeafEntryId");
+      const steerRunId = requireString(
+        steerParams.idempotencyKey,
+        "steer chat send idempotency key",
+      );
+      await gateway.resolveDeferred("chat.send", { runId: steerRunId, status: "started" });
+      const steerUser = {
+        __openclaw: {
+          id: "ui4-steer-user",
+          idempotencyKey: `${steerRunId}:user`,
+          seq: 4,
+          steerTargetRunId: runId,
+        },
+        content: [{ text: steerText, type: "text" }],
+        role: "user",
+        timestamp: Date.now(),
+      };
+      await gateway.deferNext("chat.history");
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [runId],
+        clientRunId: steerRunId,
+        hasActiveRun: true,
+        message: steerUser,
+        messageId: "ui4-steer-user",
+        messageSeq: 4,
+        session: {
+          activeRunIds: [runId],
+          hasActiveRun: true,
+          key: "main",
+          kind: "direct",
+          status: "running",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+      await page.locator(".chat-group.user", { hasText: steerText }).waitFor();
+      await gateway.emitGatewayEvent("chat", {
+        runId: steerRunId,
+        sessionKey: "main",
+        state: "final",
+      });
+
+      await emitTool({
+        args: { action: "poll" },
+        name: "process",
+        phase: "start",
+        toolCallId: "callProcess",
+      });
+      await emitTool({
+        name: "process",
+        phase: "result",
+        result: "process complete",
+        toolCallId: "callProcess",
+      });
+      const finalText = "UI4_LONG_BASE UI4_STEER_OK";
+      await gateway.emitGatewayEvent("chat", {
+        deltaText: finalText,
+        message: {
+          content: [{ text: finalText, type: "text" }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+        runId,
+        sessionKey: "main",
+        state: "delta",
+      });
+      await gateway.emitGatewayEvent("session.message", {
+        activeRunIds: [runId],
+        clientRunId: runId,
+        hasActiveRun: true,
+        message: {
+          role: "assistant",
+          content: [{ text: finalText, type: "text" }],
+          __openclaw: { id: "ui4-final", seq: 5 },
+        },
+        messageId: "ui4-final",
+        messageSeq: 5,
+        session: {
+          activeRunIds: [runId],
+          hasActiveRun: true,
+          key: "main",
+          kind: "direct",
+          status: "running",
+          updatedAt: Date.now(),
+        },
+        sessionKey: "main",
+      });
+      await gateway.emitChatFinal({ runId, text: finalText });
+      await expect
+        .poll(() =>
+          page.locator(".chat-thread-inner").getByText(finalText, { exact: true }).count(),
+        )
+        .toBe(1);
+      await expect
+        .poll(() => page.locator(".chat-work-group", { hasText: "used process" }).count())
+        .toBe(0);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -381,15 +381,18 @@ async function sendQueuedChatMessage(
         });
         void loadChatHistory(host);
       } else if (isNonTerminalAgentRunStatus(ack.status)) {
-        const adopted = host.chatRunId === ack.runId;
-        const adoptedStream = adopted && typeof host.chatStream === "string";
-        host.chatRunId = ack.runId;
-        if (!adopted) {
-          host.chatRunStartup = null;
-        }
-        if (!adoptedStream) {
-          host.chatStream = "";
-          host.chatStreamStartedAt = startedAt;
+        // A steer ACK identifies its client operation, not the active model run.
+        if (prepared.queueMode !== "steer" || !host.chatRunId) {
+          const adopted = host.chatRunId === ack.runId;
+          const adoptedStream = adopted && typeof host.chatStream === "string";
+          host.chatRunId = ack.runId;
+          if (!adopted) {
+            host.chatRunStartup = null;
+          }
+          if (!adoptedStream) {
+            host.chatStream = "";
+            host.chatStreamStartedAt = startedAt;
+          }
         }
       }
     }

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -3783,7 +3783,8 @@ describe("handleSendChat", () => {
         }),
       ),
     );
-    expect(host.chatRunId).toBe("steer-run");
+    expect(host.chatRunId).toBe("run-1");
+    expect(host.chatStream).toBe("Working...");
     expect(host.chatQueue).toEqual([
       expect.objectContaining({
         queueMode: "steer",
@@ -3794,6 +3795,19 @@ describe("handleSendChat", () => {
     const payload = findRequestPayload(host.request, "chat.send", "default steer payload");
     expect(payload).not.toHaveProperty("expectedRunId");
     expect(payload).not.toHaveProperty("expectedLeafEntryId");
+  });
+
+  it("adopts a steer-mode ACK when no run is active", async () => {
+    const host = makeChatHost({
+      requestHandlers: {
+        "chat.send": { status: "started", runId: "started-run" },
+      },
+      chatMessage: "start through steer mode",
+    });
+
+    await handleSendChat(host, undefined, { followUpMode: "steer" });
+
+    expect(host.chatRunId).toBe("started-run");
   });
 
   it("sends a fresh mode-bearing row ahead of older outbox reconciliation", async () => {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -174,6 +174,7 @@ describe("canonical session message recovery", () => {
     ]);
     expect(state.chatRunId).toBe(activeRunId);
     expect(state.chatQueue).toEqual([]);
+    state.chatRunId = steerRunId;
 
     const steerEvent = {
       type: "event",
@@ -198,6 +199,7 @@ describe("canonical session message recovery", () => {
       },
     } satisfies Parameters<typeof handlePageGatewayEvent>[1];
     handlePageGatewayEvent(state, steerEvent);
+    expect(state.chatRunId).toBe(activeRunId);
     const segmentsAfterRequestBoundary = state.chatStreamSegments;
     expect(state.chatStreamSegments).toBe(segmentsAfterRequestBoundary);
     expect(
@@ -329,6 +331,43 @@ describe("canonical session message recovery", () => {
     expect(getChatSessionProjection(state, state.chatMessages).messages).toEqual(
       state.chatMessages,
     );
+  });
+
+  it("does not rebind an unrelated run from a persisted steer", () => {
+    const { state } = createSessionEventState({
+      connected: false,
+      chatMessages: [],
+      chatRunId: "run-c",
+      chatStream: "Run C",
+      chatStreamSegments: [],
+      chatToolMessages: [],
+    });
+
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: state.sessionKey,
+        clientRunId: "run-b",
+        hasActiveRun: true,
+        messageId: "steer-b",
+        messageSeq: 1,
+        message: {
+          role: "user",
+          content: "Steer A",
+          __openclaw: {
+            id: "steer-b",
+            idempotencyKey: "run-b:user",
+            seq: 1,
+            steerTargetRunId: "run-a",
+          },
+        },
+      },
+    });
+
+    expect(state.chatRunId).toBe("run-c");
+    expect(state.chatStream).toBe("Run C");
+    expect(state.chatStreamSegments).toEqual([]);
   });
 
   it("keeps pre-steer output above an earlier ordinary queued user", () => {

--- a/ui/src/pages/chat/session-message-apply.ts
+++ b/ui/src/pages/chat/session-message-apply.ts
@@ -72,16 +72,19 @@ export function applySessionMessagePayload(
     { type: "messagePersisted", message, envelope: event },
     { scope, runActive },
   );
+  const steerTargetRunId = persistedSteerTargetRunId(message);
+  const currentRunId = state.chatRunId;
   if (
     incoming.role === "user" &&
     runActive === true &&
-    state.chatRunId &&
     incoming.runId &&
-    persistedSteerTargetRunId(message) === state.chatRunId &&
+    steerTargetRunId &&
+    (!currentRunId || currentRunId === steerTargetRunId || currentRunId === incoming.runId) &&
     projection.messages.length > previousMessageCount
   ) {
+    state.chatRunId = steerTargetRunId;
     rolloverChatStream(state, {
-      runId: state.chatRunId,
+      runId: steerTargetRunId,
       boundaryRunId: incoming.runId,
     });
   }


### PR DESCRIPTION
Related: #125197, #125862

## What Problem This Solves

Fixes an issue where users steering an active Control UI turn with Control+Enter could see the same final assistant response rendered on both sides of the steering message.

## Why This Change Was Made

The Gateway correctly acknowledges `chat.send` with the steering client operation ID, but the selected-session pane incorrectly replaced its active model-run owner with that operation ID and cleared the active stream. When the persisted steering user later identified the authoritative target run, the pane rejected that boundary and projected the streamed and durable finals on opposite sides of the steering row.

The Control UI now keeps the existing active run and stream across an explicit steer acknowledgement. An idle `queueMode=steer` start-or-steer still adopts the acknowledged run. A persisted steer target can repair projection ownership from the target run, the client operation, or no local run, but never from an unrelated run, and then records the causal stream boundary.

Selected-session semantics are unchanged: the send targets the selected session with `queueMode=steer`, without `expectedRunId`, `expectedLeafEntryId`, `sessions.steer`, or an exact-run browser target.

Production LOC: +18/-12 (net +6). Tests: +226/-1.

## User Impact

The Control UI no longer renders the same final assistant response on both sides of a steering message. The active tool/stream presentation remains attached to the model run that owns it, and the final appears once in causal transcript order.

## Evidence

Live isolated Gateway proof exercised a real provider turn with a long-running tool, then steered it through the selected-session Control+Enter flow.

Before — the same final appeared above and below the steering message:

![Control UI before fix showing duplicate final assistant text](https://github.com/user-attachments/assets/fef933e1-fad3-47f6-8c3e-2a350861cef3)

After — the final appears once, below the steering message:

![Control UI after fix showing one causally ordered final assistant response](https://github.com/user-attachments/assets/a6a80b04-0146-4ee7-8544-75d64fb4a066)

Before recording:

https://github.com/user-attachments/assets/dea4f19e-9bda-4d11-af1f-c099419a75e5

After recording:

https://github.com/user-attachments/assets/b82c4ce7-fa71-4544-a295-36376301db75

The live proof recorded `finalCount=1` for every sample from 0 through 15 seconds, with `toolTop < steerTop < finalTop`. The request used `queueMode=steer` and carried neither expected ID.

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts ui/src/pages/chat/chat-state.test.ts ui/src/pages/chat/stream-reconciliation.test.ts ui/src/pages/chat/chat-history.test.ts ui/src/pages/chat/tool-stream.node.test.ts` — 5 files, 409 tests passed on the rebased head.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts` — 1 file, 6 tests passed.
- `node scripts/check-changed.mjs -- <five changed files>` — passed.
- `pnpm ui:build` — passed before the byte-equivalent rebase.
- Fresh branch autoreview — no actionable findings, 0.96 confidence.

AI-assisted maintainer repair; the patch and evidence were reviewed and verified before publication.
