### PR TITLE
fix(gateway): resolve ambient heartbeat owner without crashing startup

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -135,6 +135,7 @@ Outside heartbeats, stray `HEARTBEAT_OK` at the start/end of a message is stripp
 
 - `agents.defaults.heartbeat` sets global heartbeat behavior.
 - `agents.entries.*.heartbeat` merges on top; if any agent has a `heartbeat` block, **only those agents** run heartbeats.
+- Ambient ownership resolves through `agents.defaults.heartbeat.agentId`, the legacy default owner, `agents.defaults.systemAgent.agentId`, then the sole agent; when no per-agent or default heartbeat block applies and that chain leaves a multi-agent roster ownerless, heartbeats stay disabled and emit validation and Gateway warnings.
 - `channels.defaults.heartbeatVisibility` sets visibility defaults for all channels.
 - `channels.<channel>.heartbeatVisibility` overrides channel defaults.
 - `channels.<channel>.accounts.<id>.heartbeatVisibility` (multi-account channels) overrides per-channel settings.

--- a/src/config/validation-core.ts
+++ b/src/config/validation-core.ts
@@ -3,10 +3,13 @@ import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import {
+  listAgentEntries,
   listAgentEntriesWithSource,
+  listAgentIds,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
   tryResolveLegacyCompatibilityAgentId,
+  tryResolveSystemAgentTargetAgentId,
 } from "../agents/agent-scope.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import {
@@ -45,6 +48,26 @@ import {
 import { isBuiltInModelProviderOverlayId } from "./zod-schema.core.js";
 import { OpenClawSchema } from "./zod-schema.js";
 import { McpServerNameSchema, NodeHostMcpServerNameSchema } from "./zod-schema.root-support.js";
+
+export function collectHeartbeatOwnerWarnings(config: OpenClawConfig): ConfigValidationIssue[] {
+  const agentEntries = listAgentEntries(config);
+  // Keep this equivalent to isHeartbeatOwnerUnresolved in heartbeat-runner-config.ts.
+  const unresolved =
+    listAgentIds(config).length > 1 &&
+    !agentEntries.some((entry) => Boolean(entry.heartbeat)) &&
+    !config.agents?.defaults?.heartbeat &&
+    tryResolveLegacyCompatibilityAgentId(config) === undefined &&
+    tryResolveSystemAgentTargetAgentId(config) === undefined;
+  return unresolved
+    ? [
+        {
+          path: "agents.defaults.heartbeat.agentId",
+          message:
+            "Multi-agent config has no ambient heartbeat owner; heartbeats stay disabled until agents.defaults.heartbeat.agentId or agents.defaults.systemAgent.agentId is set.",
+        },
+      ]
+    : [];
+}
 
 function materializeBundledModelProviderOverlays(config: OpenClawConfig): OpenClawConfig {
   const providers = config.models?.providers;

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -1,7 +1,11 @@
 // Covers config validation policy decisions and warning behavior.
 import { describe, expect, it, vi } from "vitest";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
-import { validateConfigObjectRaw, validateConfigObjectRawWithPlugins } from "./validation.js";
+import {
+  validateConfigObjectRaw,
+  validateConfigObjectRawWithPlugins,
+  validateConfigObjectWithPlugins,
+} from "./validation.js";
 
 vi.mock("../channels/plugins/legacy-config.js", () => ({
   collectChannelLegacyConfigRules: () => [],
@@ -355,5 +359,75 @@ describe("config validation gateway.port policy", () => {
     // port 1 — valid TCP min
     const min = validateConfigObjectRaw({ gateway: { port: 1 } });
     expect(min.ok).toBe(true);
+  });
+});
+
+describe("config validation ambient heartbeat ownership", () => {
+  const validate = (raw: unknown) =>
+    validateConfigObjectWithPlugins(raw, {
+      pluginMetadataSnapshot: { manifestRegistry: { diagnostics: [], plugins: [] } },
+    });
+  const heartbeatOwnerWarnings = (raw: unknown) => {
+    const result = validate(raw);
+    expect(result.ok).toBe(true);
+    return result.warnings.filter(
+      (warning) => warning.path === "agents.defaults.heartbeat.agentId",
+    );
+  };
+
+  it("warns that heartbeats stay disabled for an ownerless explicit multi-agent roster", () => {
+    expect(
+      heartbeatOwnerWarnings({
+        agents: { ownership: "explicit", entries: { main: {}, ops: {} } },
+      }),
+    ).toEqual([
+      {
+        path: "agents.defaults.heartbeat.agentId",
+        message:
+          "Multi-agent config has no ambient heartbeat owner; heartbeats stay disabled until agents.defaults.heartbeat.agentId or agents.defaults.systemAgent.agentId is set.",
+      },
+    ]);
+  });
+
+  it.each([
+    {
+      name: "system owner",
+      cfg: {
+        agents: {
+          ownership: "explicit",
+          entries: { main: {}, ops: {} },
+          defaults: { systemAgent: { agentId: "ops" } },
+        },
+      },
+    },
+    {
+      name: "single-agent roster",
+      cfg: { agents: { ownership: "explicit", entries: { main: {} } } },
+    },
+    {
+      name: "per-agent heartbeat",
+      cfg: {
+        agents: {
+          ownership: "explicit",
+          entries: { main: {}, ops: { heartbeat: { every: "30m" } } },
+        },
+      },
+    },
+    {
+      name: "broadcast heartbeat defaults",
+      cfg: {
+        agents: {
+          ownership: "explicit",
+          entries: { main: {}, ops: {} },
+          defaults: { heartbeat: { every: "30m" } },
+        },
+      },
+    },
+    {
+      name: "legacy default marker",
+      cfg: { agents: { entries: { main: { default: true }, ops: {} } } },
+    },
+  ])("does not warn for a $name", ({ cfg }) => {
+    expect(heartbeatOwnerWarnings(cfg)).toEqual([]);
   });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -38,7 +38,7 @@ import {
   hasChannelDmPolicyDependencyWarningCandidates,
   normalizeBundledChannelId,
 } from "./validation-channel-rules.js";
-import { validateConfigObjectRaw } from "./validation-core.js";
+import { collectHeartbeatOwnerWarnings, validateConfigObjectRaw } from "./validation-core.js";
 import { withConfigIssuePath } from "./validation-issues.js";
 import {
   collectExplicitPluginReferences,
@@ -230,6 +230,7 @@ function validateConfigObjectWithPluginsBase(
 
   const issues: ConfigValidationIssue[] = [];
   const warnings: ConfigValidationIssue[] = [];
+  warnings.push(...collectHeartbeatOwnerWarnings(config));
   const hasExplicitPluginsConfig = isRecord(raw) && Object.hasOwn(raw, "plugins");
   const explicitPluginReferences = collectExplicitPluginReferences(raw);
 

--- a/src/cron/heartbeat-monitor.test.ts
+++ b/src/cron/heartbeat-monitor.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveHeartbeatMonitorSpecs } from "./heartbeat-monitor.js";
+
+describe("resolveHeartbeatMonitorSpecs", () => {
+  it("creates no monitor jobs for an ownerless explicit multi-agent roster", () => {
+    const cfg = {
+      agents: { ownership: "explicit", entries: { main: {}, ops: {} } },
+    } as OpenClawConfig;
+
+    expect(resolveHeartbeatMonitorSpecs(cfg, [], { schedulerSeed: "test-seed" })).toEqual([]);
+  });
+});

--- a/src/infra/heartbeat-agent-resolution.test.ts
+++ b/src/infra/heartbeat-agent-resolution.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { tryResolveAmbientHeartbeatAgentId } from "./heartbeat-agent-resolution.js";
+import { isHeartbeatOwnerUnresolved, resolveHeartbeatAgents } from "./heartbeat-runner-config.js";
+import { isHeartbeatEnabledForAgent } from "./heartbeat-summary.js";
+
+describe("tryResolveAmbientHeartbeatAgentId", () => {
+  it.each([
+    {
+      name: "explicit heartbeat owner",
+      cfg: {
+        agents: {
+          ownership: "explicit",
+          entries: { main: {}, ops: {} },
+          defaults: {
+            heartbeat: { agentId: "ops" },
+            systemAgent: { agentId: "main" },
+          },
+        },
+      } as OpenClawConfig,
+      expected: "ops",
+    },
+    {
+      name: "legacy default marker before the system owner",
+      cfg: {
+        agents: {
+          entries: { legacy: { default: true }, ops: {} },
+          defaults: { systemAgent: { agentId: "ops" } },
+        },
+      } as OpenClawConfig,
+      expected: "legacy",
+    },
+    {
+      name: "system owner",
+      cfg: {
+        agents: {
+          ownership: "explicit",
+          entries: { main: {}, ops: {} },
+          defaults: { systemAgent: { agentId: "ops" } },
+        },
+      } as OpenClawConfig,
+      expected: "ops",
+    },
+    {
+      name: "sole agent",
+      cfg: {
+        agents: { ownership: "explicit", entries: { solo: {} } },
+      } as OpenClawConfig,
+      expected: "solo",
+    },
+    {
+      name: "ownerless explicit multi-agent roster",
+      cfg: {
+        agents: { ownership: "explicit", entries: { main: {}, ops: {} } },
+      } as OpenClawConfig,
+      expected: undefined,
+    },
+  ])("resolves the $name", ({ cfg, expected }) => {
+    expect(tryResolveAmbientHeartbeatAgentId(cfg)).toBe(expected);
+  });
+});
+
+describe("resolveHeartbeatAgents", () => {
+  const systemOwnedConfig = {
+    agents: {
+      ownership: "explicit",
+      entries: { ops: {}, main: {} },
+      defaults: { systemAgent: { agentId: "ops" } },
+    },
+  } as OpenClawConfig;
+  const ownerlessConfig = {
+    agents: { ownership: "explicit", entries: { ops: {}, main: {} } },
+  } as OpenClawConfig;
+
+  it("enrolls the system agent when ambient heartbeat config is absent", () => {
+    expect(resolveHeartbeatAgents(systemOwnedConfig)).toEqual([
+      { agentId: "ops", heartbeat: undefined },
+    ]);
+    expect(isHeartbeatEnabledForAgent(systemOwnedConfig, "ops")).toBe(true);
+    expect(isHeartbeatEnabledForAgent(systemOwnedConfig, "main")).toBe(false);
+    expect(isHeartbeatOwnerUnresolved(systemOwnedConfig)).toBe(false);
+  });
+
+  it("disables ambient heartbeats when an explicit multi-agent roster has no owner", () => {
+    expect(resolveHeartbeatAgents(ownerlessConfig)).toEqual([]);
+    expect(isHeartbeatEnabledForAgent(ownerlessConfig)).toBe(false);
+    expect(isHeartbeatEnabledForAgent(ownerlessConfig, "ops")).toBe(false);
+    expect(isHeartbeatOwnerUnresolved(ownerlessConfig)).toBe(true);
+  });
+
+  it.each([
+    { name: "system owner", cfg: systemOwnedConfig },
+    {
+      name: "explicit heartbeat owner",
+      cfg: {
+        agents: {
+          ownership: "explicit",
+          entries: { main: {}, ops: {} },
+          defaults: { heartbeat: { agentId: "ops" } },
+        },
+      } as OpenClawConfig,
+    },
+    {
+      name: "legacy default marker",
+      cfg: {
+        agents: { entries: { main: { default: true }, ops: {} } },
+      } as OpenClawConfig,
+    },
+    {
+      name: "sole agent",
+      cfg: { agents: { ownership: "explicit", entries: { solo: {} } } } as OpenClawConfig,
+    },
+    {
+      name: "per-agent heartbeat entries",
+      cfg: {
+        agents: {
+          ownership: "explicit",
+          entries: { main: {}, ops: { heartbeat: { every: "30m" } } },
+        },
+      } as OpenClawConfig,
+    },
+    {
+      name: "broadcast heartbeat defaults",
+      cfg: {
+        agents: {
+          ownership: "explicit",
+          entries: { main: {}, ops: {} },
+          defaults: { heartbeat: { every: "30m" } },
+        },
+      } as OpenClawConfig,
+    },
+  ])("keeps every enrolled agent runnable for the $name config", ({ cfg }) => {
+    const agents = resolveHeartbeatAgents(cfg);
+    expect(agents.length).toBeGreaterThan(0);
+    for (const agent of agents) {
+      expect(isHeartbeatEnabledForAgent(cfg, agent.agentId)).toBe(true);
+    }
+  });
+});

--- a/src/infra/heartbeat-agent-resolution.ts
+++ b/src/infra/heartbeat-agent-resolution.ts
@@ -1,16 +1,15 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { resolveDefaultAgentId } from "../agents/agent-scope.js";
-import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
+import {
+  tryResolveLegacyCompatibilityAgentId,
+  tryResolveSystemAgentTargetAgentId,
+} from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 
-export function resolveAmbientHeartbeatAgentId(cfg: OpenClawConfig): string {
-  return normalizeAgentId(
+export function tryResolveAmbientHeartbeatAgentId(cfg: OpenClawConfig): string | undefined {
+  const resolved =
     normalizeOptionalString(cfg.agents?.defaults?.heartbeat?.agentId) ??
-      tryResolveLegacyCompatibilityAgentId(cfg) ??
-      resolveDefaultAgentId(cfg, {
-        surface: "ambient heartbeat scheduling",
-        hint: "Set agents.defaults.heartbeat.agentId to the agent that owns ambient heartbeats.",
-      }),
-  );
+    tryResolveLegacyCompatibilityAgentId(cfg) ??
+    tryResolveSystemAgentTargetAgentId(cfg);
+  return resolved ? normalizeAgentId(resolved) : undefined;
 }

--- a/src/infra/heartbeat-runner-config.ts
+++ b/src/infra/heartbeat-runner-config.ts
@@ -20,7 +20,7 @@ import { normalizeAgentId } from "../routing/session-key.js";
 import { readStoredDeviceIdentityReadOnly } from "./device-identity-store.js";
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
 import { resolveActiveHoursTimezone } from "./heartbeat-active-hours.js";
-import { resolveAmbientHeartbeatAgentId } from "./heartbeat-agent-resolution.js";
+import { tryResolveAmbientHeartbeatAgentId } from "./heartbeat-agent-resolution.js";
 import { resolveHeartbeatIntervalMs } from "./heartbeat-summary.js";
 import type { HeartbeatWakeSource } from "./heartbeat-wake.js";
 
@@ -195,8 +195,20 @@ export function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
       heartbeat: resolveHeartbeatConfig(cfg, agentId),
     }));
   }
-  const fallbackId = resolveAmbientHeartbeatAgentId(cfg);
+  const fallbackId = tryResolveAmbientHeartbeatAgentId(cfg);
+  if (!fallbackId) {
+    return [];
+  }
   return [{ agentId: fallbackId, heartbeat: resolveHeartbeatConfig(cfg, fallbackId) }];
+}
+
+export function isHeartbeatOwnerUnresolved(cfg: OpenClawConfig): boolean {
+  return (
+    listAgentIds(cfg).length > 1 &&
+    !hasExplicitHeartbeatAgents(cfg) &&
+    !cfg.agents?.defaults?.heartbeat &&
+    tryResolveAmbientHeartbeatAgentId(cfg) === undefined
+  );
 }
 
 function resolveHeartbeatPromptRaw(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
@@ -310,4 +322,4 @@ export function resolveHeartbeatTypingIntervalSeconds(cfg: OpenClawConfig) {
   const configured = cfg.agents?.defaults?.typingIntervalSeconds;
   return typeof configured === "number" && configured > 0 ? configured : undefined;
 }
-export { resolveAmbientHeartbeatAgentId } from "./heartbeat-agent-resolution.js";
+export { tryResolveAmbientHeartbeatAgentId } from "./heartbeat-agent-resolution.js";

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -57,10 +57,10 @@ import { isWithinActiveHours } from "./heartbeat-active-hours.js";
 import { emitHeartbeatEvent } from "./heartbeat-events.js";
 import {
   heartbeatLog,
-  resolveAmbientHeartbeatAgentId,
   resolveHeartbeatForWake,
   resolveHeartbeatTimeoutOverrideSeconds,
   shouldUseHeartbeatResponseToolPrompt,
+  tryResolveAmbientHeartbeatAgentId,
   type HeartbeatConfig,
 } from "./heartbeat-runner-config.js";
 import {
@@ -151,9 +151,12 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
   const explicitAgentId = typeof opts.agentId === "string" ? opts.agentId.trim() : "";
   const forcedSessionAgentId =
     explicitAgentId.length > 0 ? undefined : parseAgentSessionKey(opts.sessionKey)?.agentId;
-  const agentId = normalizeAgentId(
-    explicitAgentId || forcedSessionAgentId || resolveAmbientHeartbeatAgentId(cfg),
-  );
+  const resolvedAgentId =
+    explicitAgentId || forcedSessionAgentId || tryResolveAmbientHeartbeatAgentId(cfg);
+  if (!resolvedAgentId) {
+    return { kind: "skipped", reason: "disabled" } as const;
+  }
+  const agentId = normalizeAgentId(resolvedAgentId);
   const wakeSource = opts.source ?? inferHeartbeatWakeSourceFromReason(opts.reason);
   const heartbeat = resolveHeartbeatForWake({
     cfg,

--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -9,11 +9,12 @@ import { recordRunStart, shouldDeferWake, type DeferDecision } from "./heartbeat
 import {
   activeHoursConfigMatch,
   heartbeatLog,
+  isHeartbeatOwnerUnresolved,
   resolveActiveHoursSchedule,
-  resolveAmbientHeartbeatAgentId,
   resolveHeartbeatAgents,
   resolveHeartbeatForWake,
   resolveHeartbeatSchedulerSeed,
+  tryResolveAmbientHeartbeatAgentId,
   type HeartbeatConfig,
 } from "./heartbeat-runner-config.js";
 import { runHeartbeatOnce } from "./heartbeat-runner-run.js";
@@ -268,20 +269,19 @@ export function startHeartbeatRunner(opts: {
     state.cfg = cfg;
     state.agents = nextAgents;
     const nextEnabled = nextAgents.size > 0;
-    if (!initialized) {
-      if (!nextEnabled) {
-        log.info("heartbeat: disabled", { enabled: false });
-      } else {
+    if (!initialized || prevEnabled !== nextEnabled) {
+      if (nextEnabled) {
         log.info("heartbeat: started", { intervalMs: Math.min(...intervals) });
-      }
-      initialized = true;
-    } else if (prevEnabled !== nextEnabled) {
-      if (!nextEnabled) {
-        log.info("heartbeat: disabled", { enabled: false });
       } else {
-        log.info("heartbeat: started", { intervalMs: Math.min(...intervals) });
+        log.info("heartbeat: disabled", { enabled: false });
+        if (isHeartbeatOwnerUnresolved(cfg)) {
+          log.warn(
+            "heartbeat: multi-agent config has no ambient heartbeat owner; set agents.defaults.heartbeat.agentId or agents.defaults.systemAgent.agentId",
+          );
+        }
       }
     }
+    initialized = true;
   };
 
   const run: HeartbeatWakeHandler = async (params) => {
@@ -428,7 +428,10 @@ export function startHeartbeatRunner(opts: {
     };
 
     if (requestedSessionKey || requestedAgentId) {
-      const targetAgentId = requestedTargetAgentId ?? resolveAmbientHeartbeatAgentId(wakeConfig);
+      const targetAgentId = requestedTargetAgentId ?? tryResolveAmbientHeartbeatAgentId(wakeConfig);
+      if (!targetAgentId) {
+        return { status: "skipped", reason: "disabled" };
+      }
       const targetAgent = state.agents.get(targetAgentId);
       // Task intent wins scheduled-task coalescing, so the cadence payload—not
       // the final intent—proves that the persisted monitor tick joined this turn.

--- a/src/infra/heartbeat-runner-session.ts
+++ b/src/infra/heartbeat-runner-session.ts
@@ -13,18 +13,18 @@ import {
   toAgentStoreSessionKey,
 } from "../routing/session-key.js";
 import { resolveMainScopedEventSessionKey } from "./event-session-routing.js";
-import { resolveAmbientHeartbeatAgentId, type HeartbeatConfig } from "./heartbeat-runner-config.js";
+import type { HeartbeatConfig } from "./heartbeat-runner-config.js";
 
 export function resolveHeartbeatSessionKey(
   cfg: OpenClawConfig,
-  agentId?: string,
+  agentId: string,
   heartbeat?: HeartbeatConfig,
   forcedSessionKey?: string,
   env: NodeJS.ProcessEnv = process.env,
 ) {
   const sessionCfg = cfg.session;
   const scope = sessionCfg?.scope ?? "per-sender";
-  const resolvedAgentId = normalizeAgentId(agentId ?? resolveAmbientHeartbeatAgentId(cfg));
+  const resolvedAgentId = normalizeAgentId(agentId);
   const mainSessionKey =
     scope === "global" ? "global" : resolveAgentMainSessionKey({ cfg, agentId: resolvedAgentId });
   const storePath = resolveSessionStorePathCore(sessionCfg?.store, {
@@ -119,7 +119,7 @@ export function resolveHeartbeatSessionKey(
 
 export function resolveHeartbeatSession(
   cfg: OpenClawConfig,
-  agentId?: string,
+  agentId: string,
   heartbeat?: HeartbeatConfig,
   forcedSessionKey?: string,
   env: NodeJS.ProcessEnv = process.env,

--- a/src/infra/heartbeat-runner.scheduler-owner-resolution.test.ts
+++ b/src/infra/heartbeat-runner.scheduler-owner-resolution.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { heartbeatLog } from "./heartbeat-runner-config.js";
+import { startHeartbeatRunner } from "./heartbeat-runner.js";
+import { requestHeartbeat } from "./heartbeat-wake.js";
+
+const TEST_SCHEDULER_SEED = "heartbeat-owner-resolution-test-seed";
+
+describe("startHeartbeatRunner ambient owner resolution", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts explicit multi-agent heartbeats under the configured system owner", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+    const runOnce = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        entries: { ops: {}, main: {} },
+        defaults: { systemAgent: { agentId: "ops" } },
+      },
+    } as OpenClawConfig;
+
+    const runner = startHeartbeatRunner({
+      cfg,
+      runOnce,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+    requestHeartbeat({ source: "manual", intent: "manual", reason: "manual", coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runOnce).toHaveBeenCalledOnce();
+    expect(runOnce.mock.calls[0]?.[0]).toMatchObject({ agentId: "ops" });
+    runner.stop();
+  });
+
+  it("starts disabled and warns once when an explicit multi-agent roster has no owner", () => {
+    const info = vi.spyOn(heartbeatLog, "info").mockImplementation(() => undefined);
+    const warn = vi.spyOn(heartbeatLog, "warn").mockImplementation(() => undefined);
+    const cfg = {
+      agents: { ownership: "explicit", entries: { ops: {}, main: {} } },
+    } as OpenClawConfig;
+
+    const runner = startHeartbeatRunner({
+      cfg,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+    runner.updateConfig(cfg);
+
+    expect(info).toHaveBeenCalledWith("heartbeat: disabled", { enabled: false });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("agents.defaults.heartbeat.agentId");
+    expect(warn.mock.calls[0]?.[0]).toContain("agents.defaults.systemAgent.agentId");
+    runner.stop();
+  });
+});

--- a/src/infra/heartbeat-runner.wake-owner-resolution.test.ts
+++ b/src/infra/heartbeat-runner.wake-owner-resolution.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+
+describe("heartbeat wake owner resolution", () => {
+  it("admits a scheduled tick for the configured system heartbeat owner", async () => {
+    await withOpenClawTestState({ label: "heartbeat-system-owner" }, async () => {
+      const cfg = {
+        agents: {
+          ownership: "explicit",
+          entries: { ops: {}, main: {} },
+          defaults: { systemAgent: { agentId: "ops" } },
+        },
+      } as OpenClawConfig;
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "ops",
+        source: "interval",
+        intent: "scheduled",
+        reason: "interval",
+        deps: { getQueueSize: () => 0, nowMs: () => 0 },
+      });
+
+      expect(result).not.toEqual({ status: "skipped", reason: "disabled" });
+    });
+  });
+});

--- a/src/infra/heartbeat-summary.ts
+++ b/src/infra/heartbeat-summary.ts
@@ -1,21 +1,16 @@
 // Summarizes heartbeat config for CLI and UI display.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  listAgentEntries,
-  resolveAgentConfig,
-  tryResolveDefaultAgentId,
-} from "../agents/agent-scope.js";
+import { listAgentEntries, resolveAgentConfig } from "../agents/agent-scope.js";
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   DEFAULT_HEARTBEAT_EVERY,
   resolveHeartbeatPromptCore as resolveHeartbeatPromptText,
 } from "../auto-reply/heartbeat.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
-import { tryResolveLegacyCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { resolveAmbientHeartbeatAgentId } from "./heartbeat-agent-resolution.js";
+import { tryResolveAmbientHeartbeatAgentId } from "./heartbeat-agent-resolution.js";
 
 // Heartbeat summaries merge default and per-agent heartbeat config for CLI/UI
 // display without scheduling any work.
@@ -42,10 +37,10 @@ function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
 
 /** Return whether heartbeat scheduling applies to an agent. */
 export function isHeartbeatEnabledForAgent(cfg: OpenClawConfig, agentId?: string): boolean {
-  const ambientAgentId =
-    agentId === undefined
-      ? resolveAmbientHeartbeatAgentId(cfg)
-      : (tryResolveLegacyCompatibilityAgentId(cfg) ?? tryResolveDefaultAgentId(cfg));
+  const ambientAgentId = tryResolveAmbientHeartbeatAgentId(cfg);
+  if (agentId === undefined && ambientAgentId === undefined) {
+    return false;
+  }
   const resolvedAgentId = normalizeAgentId(agentId ?? ambientAgentId);
   const list = listAgentEntries(cfg);
   const hasExplicit = hasExplicitHeartbeatAgents(cfg);


### PR DESCRIPTION
## What Problem This Solves

A config that passes `openclaw config validate` crashed the gateway at startup. With a multi-agent explicit-ownership roster (`agents.ownership: "explicit"`, `agents.entries: { ops: {}, main: {} }`), `agents.defaults.systemAgent.agentId: "ops"`, and no `agents.defaults.heartbeat.agentId`, gateway start threw `AgentSelectionRequiredError` ("Multiple agents are configured, but ambient heartbeat scheduling has no explicit owner") from `resolveDefaultAgentId` (the `@deprecated` legacy resolver) via `resolveAmbientHeartbeatAgentId` → `resolveHeartbeatAgents` → `startHeartbeatRunner` → `activateGatewayScheduledServices`.

Heartbeats are on by default, so the ambient owner resolution runs on every startup even with no heartbeat config block — and it never consulted the modern `systemAgent` owner chain.

## Why This Change Was Made

A valid config must never crash startup (severity order: silent failure > crash > missing feature; degrade-not-die startup policy). The cron surface already solved this exact crash class in `src/cron/agent-id.ts` (`tryResolveCronDefaultAgentId`); the heartbeat now mirrors that owner chain byte-for-byte:

`agents.defaults.heartbeat.agentId` → legacy compatibility owner (retained/`default: true`/sole) → `agents.defaults.systemAgent.agentId` → sole agent → unresolved.

- `tryResolveAmbientHeartbeatAgentId` replaces the throwing resolver (deleted, no compat alias).
- Ownerless multi-agent rosters disable the heartbeat with a Gateway warn naming both keys, plus a new `config validate` warning on the same condition (the named enablement path). All wake/scheduler/summary call sites degrade to a recorded `skipped: disabled` instead of throwing.
- `isHeartbeatEnabledForAgent` shares the same canonical resolver, guaranteeing the enrolled-implies-runnable invariant (first-pass fix left enrollment and the enabled-guard divergent, which would have enrolled the system agent and silently skipped every tick).
- Dead ambient fallback removed from `resolveHeartbeatSessionKey` (agentId now required; all callers already pass it).

Sibling sweep: the crash class was heartbeat-only. Cron already uses the try-based chain; the remaining `resolveDefaultAgentId` callers are CLI/request surfaces where `AgentSelectionRequiredError` is the designed "pass --agent" outcome delivered to the caller, not a startup crash.

## User Impact

- The repro config now boots the gateway and runs heartbeats under the configured system agent (`ops`).
- A truly ownerless multi-agent roster boots with heartbeats disabled, a Gateway warning, and a `config validate` warning naming `agents.defaults.heartbeat.agentId` / `agents.defaults.systemAgent.agentId`, instead of crashing.
- Docs: `docs/gateway/heartbeat.md` documents the ownership precedence.

## Evidence

- Regression tests fail pre-fix for the intended reason (verified by reverting the prod change): resolver tests fail with `AgentSelectionRequiredError`; wake test fails with `skipped: disabled`.
- New coverage: owner-chain precedence matrix, enrolled-implies-runnable invariant across six config shapes, real `runHeartbeatOnce` boundary proof, `startHeartbeatRunner` startup enrollment/disable/warn-once, cron heartbeat-monitor ownerless case, config-validation warning inclusion/exclusion matrix.
- Full heartbeat suite sweep green (3 shards incl. active-hours e2e), `server-runtime-services`/`server-cron` suites green, `check-changed` all lanes green, `check:import-cycles` clean.
- Live black-box proof on an isolated dev gateway: system-owner config → `Config valid` / `[gateway] ready` / `[heartbeat] started` and a real heartbeat turn on `agent:ops:main`; ownerless config → `[gateway] ready` / `[heartbeat] disabled` + warn naming both keys + validate warning.
- Production LOC +81/−45 (net +36: validation warning collector and degrade guards, offset by deleted throwing resolver and dead session fallback); tests +314.
