### PR TITLE
fix(auto-reply): strip FluffyChat-style @[Name] bracket mentions

### DIFF
--- a/src/auto-reply/reply/mentions.test.ts
+++ b/src/auto-reply/reply/mentions.test.ts
@@ -561,9 +561,36 @@ describe("derived mention matching with decorated identity names", () => {
     } satisfies OpenClawConfig;
     const regexes = buildMentionRegexes(cfg, "decorated-agent");
 
-    expect(regexes).toHaveLength(1);
+    // One bare-name pattern plus one bracket-wrapped pattern (e.g. FluffyChat's
+    // "@[Clawd]" mention pills); the joiner-only emoji contributes no pattern
+    // of its own.
+    expect(regexes).toHaveLength(2);
     expect(matchesMentionPatterns("hello!", regexes)).toBe(false);
     expect(matchesMentionPatterns("clawd hello", regexes)).toBe(true);
+    expect(matchesMentionPatterns("@[Clawd] hello", regexes)).toBe(true);
+  });
+
+  it("strips a FluffyChat-style @[Name] mention pill so a following slash command matches", () => {
+    // FluffyChat renders a tapped mention pill as literal "@[Display Name]"
+    // text in the message body (Element renders a bare display name
+    // instead). Without a bracket-aware pattern the "@[...]" shell survives
+    // stripping and "/new" never reaches the start of the string, so the
+    // slash-command regex (which anchors at index 0) never matches and the
+    // command silently falls through to plain chat.
+    const cfg = {
+      agents: {
+        entries: { main: { identity: { name: "ping", emoji: "⚡️" } } },
+      },
+    } satisfies OpenClawConfig;
+    const ctx = {} as MsgContext;
+
+    expect(stripMentions("@[ping ⚡️] /new", ctx, cfg, "main")).toBe("/new");
+    expect(stripMentions("@[ping ⚡️]/new", ctx, cfg, "main")).toBe("/new");
+    expect(stripMentions("hey @[ping ⚡️] can you check this", ctx, cfg, "main")).toBe(
+      "hey can you check this",
+    );
+    // Element's bare-display-name convention must keep working unchanged.
+    expect(stripMentions("ping ⚡️ /new", ctx, cfg, "main")).toBe("/new");
   });
 
   it("never requires a bare variation selector as the identity token", () => {

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -58,6 +58,22 @@ function wrapDerivedMentionPattern(parts: DerivedNameParts): string {
   return `(?:@|(?<!${UNICODE_WORD_CHAR}${leading}))${leading}${parts.core}${trailing}`;
 }
 
+// Some Matrix clients (FluffyChat, at least) render a tapped mention pill as
+// literal "@[Display Name]" text instead of a bare display name (Element) or
+// a numeric/username token (Discord/Telegram). The brackets are ordinary
+// characters in the message body, so without a bracket-aware pattern the
+// whole "@[...]" construct survives stripping and a trailing "/command"
+// never matches the slash-command regex, which anchors at the string start.
+function wrapBracketedMentionPattern(core: string, emojiPattern: string): string {
+  // Match the "|)" empty-alternation shape used above instead of a group
+  // quantifier: a quantifier on a group that itself contains a quantified
+  // token (DECORATION_SPACING) reads as nested repetition and the config
+  // regex safety checker rejects it outright.
+  const emojiPrefix = emojiPattern ? `(?:${emojiPattern}${DECORATION_SPACING}|)` : "";
+  const emojiSuffix = emojiPattern ? `(?:${DECORATION_SPACING}${emojiPattern}|)` : "";
+  return String.raw`@\[${DECORATION_SPACING}${emojiPrefix}${core}${emojiSuffix}${DECORATION_SPACING}\]`;
+}
+
 function encodeOptionalJoiners(literal: string): string {
   return literal
     .split(/([\u200C\u200D]+)/u)
@@ -247,11 +263,15 @@ function deriveMentionPatterns(identity?: { name?: string; emoji?: string }) {
   const patterns: string[] = [];
   const name = normalizeOptionalString(identity?.name);
   const parts = name ? deriveNameParts(name) : undefined;
-  if (parts?.core) {
-    patterns.push(wrapDerivedMentionPattern(parts));
-  }
   const emoji = normalizeOptionalString(identity?.emoji);
   const emojiPattern = emoji ? escapeJoinerTolerantLiteral(emoji) : "";
+  if (parts?.core) {
+    // Bracket pattern first: it must claim the whole "@[Name]" construct
+    // before the bare-name pattern below eats "Name" out of the middle and
+    // leaves the brackets stranded with nothing left to match around them.
+    patterns.push(wrapBracketedMentionPattern(parts.core, emojiPattern));
+    patterns.push(wrapDerivedMentionPattern(parts));
+  }
   if (emojiPattern) {
     patterns.push(emojiPattern);
   }


### PR DESCRIPTION
## What Problem This Solves

Mention-stripping for text slash commands only recognized a bare display name (Element's convention: tab-completing a mention inserts the plain display name) or a leading `@name`. FluffyChat — a widely used Matrix client — renders a tapped mention pill as literal `@[Display Name]` text in the message body instead. Without a bracket-aware pattern, the whole `@[...]` construct survives stripping, and a following slash command (e.g. `@[Bot Name] /new`) never matches the command regex, which anchors at the start of the string. The command silently falls through to plain chat: no error, no reply, nothing in the logs pointing at the actual cause.

This affects any group-room command sent from FluffyChat (or any other client using the same `@[Name]` convention) whenever the operator has an `agents.entries.<id>.identity.name` configured — the exact identity fallback path that lets group-mention stripping work at all when a channel doesn't implement its own mention adapter.

## Why This Change Was Made

`deriveMentionPatterns` (in `src/auto-reply/reply/mentions.ts`) builds regex patterns from the configured agent identity (`name`/`emoji`) and is the shared fallback every channel without a dedicated `ChannelMentionAdapter` relies on for group-mention stripping (Matrix included — it doesn't implement one). It only emitted one pattern shape: a bare/`@`-prefixed name with decoration-aware boundaries. Added a second, bracket-aware pattern (`wrapBracketedMentionPattern`) that matches the whole `@[Name]` construct, ordered *before* the bare-name pattern so it claims the full bracketed span before the bare-name pattern can eat the name out of the middle and strand the brackets behind (confirmed via a live repro that this ordering bug — not just "no bracket pattern" — was the actual failure mode).

The optional emoji wrapper is built as `(?:X|)` rather than `(?:X)?`, mirroring the existing `wrapDerivedMentionPattern`'s technique immediately above it: a quantifier on a group that itself contains an already-quantified token (`DECORATION_SPACING`, which ends in `*`) reads as nested repetition to the config-regex safety checker (`src/security/safe-regex.ts`) and gets rejected outright as an unsafe pattern.

## User Impact

Operators on Matrix (or any channel relying on the generic identity-based mention fallback) whose users run FluffyChat can now use slash commands (`/new`, `/reset`, etc.) via a tapped mention in group rooms, the same way it already worked from Element. No config change required beyond the existing `agents.entries.<id>.identity` setup this fallback already depended on.

## Evidence

Reproduced against a real, live FluffyChat client message:

```json
{
  "body": "@[ping ⚡️] /new",
  "formatted_body": "<a href=\"https://matrix.to/#/@ping:...\">@[ping ⚡️]</a> /new",
  "m.mentions": { "user_ids": ["@ping:..."] }
}
```

Before the fix, `stripMentions("@[ping ⚡️] /new", ...)` returned `"@[ ] /new"` — the bare-name and emoji patterns each stripped their own piece out of the middle, leaving the bracket shell behind, which doesn't match `/^\/(new|reset)/`. After the fix it returns `"/new"`.

Verified the new/updated tests fail on the pre-fix code and pass after (temporarily reverted the production change, reran, confirmed both fail with the exact `"@[ ] /new"` symptom from the live report; restored the fix, reran, both pass).

Focused tests:

```
node scripts/run-vitest.mjs src/auto-reply/reply/mentions.test.ts
```
→ 1 file, 89 passed (was 88; added 1 new test, updated 1 stale pattern-count assertion in an existing test that hardcoded the old pattern count).

```
node scripts/run-vitest.mjs src/auto-reply/reply/commands-reset-hooks.test.ts src/auto-reply/reply/commands-reset-mode.test.ts src/channels/inbound-event/context.test.ts extensions/matrix/src/matrix/monitor/config.test.ts extensions/matrix/src/onboarding.test.ts
```
→ all passing (48 tests across 5 files), confirming no regressions in the downstream command-dispatch and Matrix onboarding paths that consume this shared mention pipeline.

`node scripts/run-oxlint.mjs src/auto-reply/reply/mentions.ts src/auto-reply/reply/mentions.test.ts` and `tsgo --noEmit`: both clean.

Autoreview (Codex, `gpt-5.6-sol`, high): clean, no accepted/actionable findings — "patch is correct (0.98)".

### Production LOC

`src/auto-reply/reply/mentions.ts`: +22/-2 (net +20) — one new pure helper function (`wrapBracketedMentionPattern`) plus its two call sites in `deriveMentionPatterns`. This is the minimal shape for a second, structurally distinct pattern (bracket-anchored vs. word-boundary-anchored); it can't be folded into the existing `wrapDerivedMentionPattern` without conflating two different boundary-detection strategies into one already-dense function.
