### PR TITLE
fix(gateway): keep history active through terminal persistence

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -148,7 +148,7 @@ describe("agent event handler", () => {
     lifecycleErrorRetryGraceMs?: number;
     isChatSendRunActive?: (runId: string) => boolean;
     clearTrackedActiveRun?: AgentEventHandlerOptions["clearTrackedActiveRun"];
-    markTrackedRunTerminalPersisted?: AgentEventHandlerOptions["markTrackedRunTerminalPersisted"];
+    settleTrackedTerminal?: AgentEventHandlerOptions["settleTrackedTerminal"];
     trackTrackedRunTerminalPersistence?: AgentEventHandlerOptions["trackTrackedRunTerminalPersistence"];
     resolveActiveLifecycleGenerationForRun?: (runId: string) => string | undefined;
     updateRunToolErrorSummary?: AgentEventHandlerOptions["updateRunToolErrorSummary"];
@@ -184,7 +184,7 @@ describe("agent event handler", () => {
       lifecycleErrorRetryGraceMs: params?.lifecycleErrorRetryGraceMs,
       isChatSendRunActive: params?.isChatSendRunActive,
       clearTrackedActiveRun: params?.clearTrackedActiveRun ?? clearTrackedActiveRun,
-      markTrackedRunTerminalPersisted: params?.markTrackedRunTerminalPersisted,
+      settleTrackedTerminal: params?.settleTrackedTerminal,
       trackTrackedRunTerminalPersistence: params?.trackTrackedRunTerminalPersistence,
       resolveActiveLifecycleGenerationForRun: params?.resolveActiveLifecycleGenerationForRun,
       updateRunToolErrorSummary: params?.updateRunToolErrorSummary,
@@ -2654,7 +2654,7 @@ describe("agent event handler", () => {
       },
       "session-recovery",
     );
-    const markTrackedRunTerminalPersisted = vi.fn();
+    const settleTrackedTerminal = vi.fn();
     const trackTrackedRunTerminalPersistence = vi.fn();
     const {
       broadcast,
@@ -2667,7 +2667,7 @@ describe("agent event handler", () => {
     } = createHarness({
       resolveSessionKeyForRun: () => "session-recovery",
       lifecycleErrorRetryGraceMs: 0,
-      markTrackedRunTerminalPersisted,
+      settleTrackedTerminal,
       trackTrackedRunTerminalPersistence,
     });
     sessionEventSubscribers.subscribe("conn-session");
@@ -2706,7 +2706,7 @@ describe("agent event handler", () => {
       persistence: expect.any(Promise),
     });
     await waitForFast(() => {
-      expect(markTrackedRunTerminalPersisted).toHaveBeenCalledWith({
+      expect(settleTrackedTerminal).toHaveBeenCalledWith({
         runId: "completed-during-marker-write",
         clientRunId: "completed-during-marker-write",
         sessionKey: "session-recovery",
@@ -2715,6 +2715,9 @@ describe("agent event handler", () => {
         broadcastToConnIds.mock.calls.filter(([event]) => event === "sessions.changed"),
       ).toHaveLength(1);
     });
+    expect(settleTrackedTerminal.mock.invocationCallOrder[0]).toBeLessThan(
+      broadcastToConnIds.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
     expect(chatRunState.registry.peek("completed-during-marker-write")).toBeUndefined();
     expect(clearAgentRunContext).toHaveBeenCalledWith("completed-during-marker-write");
     expect(clearTrackedActiveRun).toHaveBeenCalledWith({
@@ -2973,11 +2976,11 @@ describe("agent event handler", () => {
     persistGatewaySessionLifecycleEventMock.mockRejectedValueOnce(
       new Error("disk full sk-abcdefghijklmnopqrstuvwxyz123456"),
     );
-    const markTrackedRunTerminalPersisted = vi.fn();
+    const settleTrackedTerminal = vi.fn();
     const { broadcastToConnIds, handler, sessionEventSubscribers } = createHarness({
       resolveSessionKeyForRun: () => "session-failed-write",
       lifecycleErrorRetryGraceMs: 0,
-      markTrackedRunTerminalPersisted,
+      settleTrackedTerminal,
     });
     sessionEventSubscribers.subscribe("conn-session");
 
@@ -3006,7 +3009,15 @@ describe("agent event handler", () => {
     expect(logErrorMock).toHaveBeenCalledWith(
       "gateway: terminal session persistence failed session=session-failed-write run=run-failed-write error=Error: disk full sk-abc…3456",
     );
-    expect(markTrackedRunTerminalPersisted).not.toHaveBeenCalled();
+    expect(settleTrackedTerminal).toHaveBeenCalledWith({
+      runId: "run-failed-write",
+      clientRunId: "run-failed-write",
+      sessionKey: "session-failed-write",
+      persisted: false,
+    });
+    expect(settleTrackedTerminal.mock.invocationCallOrder[0]).toBeLessThan(
+      broadcastToConnIds.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   it("does not clear a same-id retry when an old restart terminal arrives", () => {
@@ -4552,9 +4563,11 @@ describe("agent event handler", () => {
   );
 
   it("does not project maintenance child events onto its selected parent session", () => {
+    const settleTrackedTerminal = vi.fn();
     const { broadcast, broadcastToConnIds, nodeSendToSession, sessionMessageSubscribers, handler } =
       createHarness({
         resolveSessionKeyForRun: () => "session-maintenance-parent",
+        settleTrackedTerminal,
       });
     sessionMessageSubscribers.subscribe("conn-selected", "session-maintenance-parent");
     registerAgentRunContext("run-maintenance-child", {
@@ -4599,6 +4612,12 @@ describe("agent event handler", () => {
     expect(broadcastToConnIds).not.toHaveBeenCalled();
     expect(nodeSendToSession).not.toHaveBeenCalled();
     expect(persistGatewaySessionLifecycleEventMock).not.toHaveBeenCalled();
+    expect(settleTrackedTerminal).toHaveBeenCalledWith({
+      runId: "run-maintenance-child",
+      clientRunId: "run-maintenance-child",
+      sessionKey: "session-maintenance-parent",
+      persisted: false,
+    });
   });
 
   it("sends non-control-UI-visible live chat only to exact session message subscribers", () => {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -347,10 +347,11 @@ export type AgentEventHandlerOptions = {
     clientRunId: string;
     sessionKey: string;
   }) => void;
-  markTrackedRunTerminalPersisted?: (params: {
+  settleTrackedTerminal?: (params: {
     runId: string;
     clientRunId: string;
     sessionKey: string;
+    persisted?: boolean;
   }) => void;
   trackTrackedRunTerminalPersistence?: (params: {
     runId: string;
@@ -449,7 +450,7 @@ export function createAgentEventHandler({
   lifecycleErrorRetryGraceMs = AGENT_LIFECYCLE_ERROR_RETRY_GRACE_MS,
   isChatSendRunActive = () => false,
   clearTrackedActiveRun,
-  markTrackedRunTerminalPersisted,
+  settleTrackedTerminal,
   trackTrackedRunTerminalPersistence,
   resolveActiveLifecycleGenerationForRun = () => undefined,
   updateRunToolErrorSummary,
@@ -832,18 +833,15 @@ export function createAgentEventHandler({
             { dropIfSlow: true },
           );
         };
-        const markPersisted = () => {
-          markTrackedRunTerminalPersisted?.({
-            runId: evt.runId,
-            clientRunId,
-            sessionKey,
-          });
-        };
         // Terminal writes serialize with restart markers. Reload only after the
         // write so subscribers see the canonical post-race session state.
         void persistence
           .then(() => {
-            markPersisted();
+            settleTrackedTerminal?.({
+              runId: evt.runId,
+              clientRunId,
+              sessionKey,
+            });
             broadcastSessionChange();
           })
           .catch((err: unknown) => {
@@ -852,8 +850,21 @@ export function createAgentEventHandler({
             );
             // Persistence recovery remains tracked by the controller entry, but
             // subscribers still need a terminal projection instead of hanging.
+            settleTrackedTerminal?.({
+              runId: evt.runId,
+              clientRunId,
+              sessionKey,
+              persisted: false,
+            });
             broadcastSessionChange(evt);
           });
+      } else {
+        settleTrackedTerminal?.({
+          runId: evt.runId,
+          clientRunId,
+          sessionKey,
+          persisted: false,
+        });
       }
     }
   };

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -323,6 +323,7 @@ async function settleTerminalSessionPersistenceForRestart(
     if (!tracked || tracked.entry.projectSessionTerminalPersistence !== tracked.persistence) {
       continue;
     }
+    tracked.entry.projectSessionTerminalPending = false;
     tracked.entry.projectSessionTerminalPersistence = undefined;
     if (result.status === "fulfilled") {
       tracked.entry.projectSessionTerminalPersisted = true;

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -442,6 +442,8 @@ async function handleChatHistoryRequest({
     sessionId,
     ...(activeRunAgentId ? { agentId: activeRunAgentId } : {}),
     defaultAgentId: compatibilityOwnerAgentId,
+    // History stays active until the terminal row is queryable or its write fails.
+    includeTerminalPersistence: true,
   });
   sessionInfo.hasActiveRun = activeRunState.active;
   if (activeRunState.runIds !== undefined) {

--- a/src/gateway/server-methods/session-active-runs.test.ts
+++ b/src/gateway/server-methods/session-active-runs.test.ts
@@ -54,6 +54,33 @@ it("projects admitted work as queued until execution starts", () => {
   registration.cleanup({ force: true });
 });
 
+it("keeps terminal persistence visible only to chat history", () => {
+  const terminal = {
+    sessionKey: "agent:main:main",
+    sessionId: "session-main",
+    projectSessionActive: false,
+    projectSessionTerminalPending: true,
+  };
+  const context = { chatAbortControllers: new Map([["run-terminal", terminal]]) } as never;
+  const params = {
+    context,
+    requestedKey: terminal.sessionKey,
+    canonicalKey: terminal.sessionKey,
+    sessionId: terminal.sessionId,
+    agentId: "main",
+  };
+
+  expect(resolveVisibleActiveSessionRunState(params)).toEqual({ active: false, runIds: [] });
+  expect(
+    resolveVisibleActiveSessionRunState({ ...params, includeTerminalPersistence: true }),
+  ).toEqual({ active: true });
+
+  terminal.projectSessionTerminalPending = false;
+  expect(
+    resolveVisibleActiveSessionRunState({ ...params, includeTerminalPersistence: true }),
+  ).toEqual({ active: false, runIds: [] });
+});
+
 it("keeps prebuilt active-run indexes in parity with per-row scans", () => {
   const context = {
     chatAbortControllers: new Map([

--- a/src/gateway/server-methods/session-active-runs.ts
+++ b/src/gateway/server-methods/session-active-runs.ts
@@ -14,6 +14,7 @@ type TrackedActiveSessionRun = {
   sessionId?: string;
   agentId?: string;
   executionStarted: boolean;
+  terminalPersistence?: boolean;
 };
 
 type VisibleActiveSessionRunState = {
@@ -25,13 +26,21 @@ type VisibleActiveSessionRunState = {
 
 export function collectTrackedActiveSessionRuns(
   context: Partial<Pick<GatewayRequestContext, "chatAbortControllers">>,
+  includeTerminalPersistence = false,
 ): TrackedActiveSessionRun[] {
   const runs: TrackedActiveSessionRun[] = [];
   if (!(context.chatAbortControllers instanceof Map)) {
     return runs;
   }
   for (const [runId, active] of context.chatAbortControllers) {
-    if (active.projectSessionActive !== false && active.controlUiVisible !== false) {
+    const terminalPersistence =
+      includeTerminalPersistence &&
+      active.projectSessionActive === false &&
+      active.projectSessionTerminalPending === true;
+    if (
+      (active.projectSessionActive !== false || terminalPersistence) &&
+      active.controlUiVisible !== false
+    ) {
       const sessionKey = active.sessionKey?.trim();
       const sessionId = active.sessionId?.trim();
       if (!sessionKey && !sessionId) {
@@ -44,6 +53,7 @@ export function collectTrackedActiveSessionRuns(
         agentId: typeof active.agentId === "string" ? normalizeAgentId(active.agentId) : undefined,
         // Entries created before this state existed are already executing.
         executionStarted: active.executionStarted !== false,
+        ...(terminalPersistence ? { terminalPersistence: true } : {}),
       });
     }
   }
@@ -156,37 +166,42 @@ export function resolveVisibleActiveSessionRunState(params: {
   defaultAgentId?: string;
   trackedActiveRuns?: readonly TrackedActiveSessionRun[];
   projectedAgentRunIndex?: ProjectedAgentRunIndex;
+  includeTerminalPersistence?: boolean;
 }): VisibleActiveSessionRunState {
   const sessionId = params.sessionId?.trim();
   const resolvedAgentId =
     params.agentId ??
     parseAgentSessionKey(params.canonicalKey)?.agentId ??
     parseAgentSessionKey(params.requestedKey)?.agentId;
+  const matchesRequestedSession = (active: TrackedActiveSessionRun) =>
+    isTrackedActiveSessionRunForKey(
+      active,
+      params.canonicalKey,
+      resolvedAgentId,
+      params.defaultAgentId,
+    ) ||
+    isTrackedActiveSessionRunForKey(
+      active,
+      params.requestedKey,
+      resolvedAgentId,
+      params.defaultAgentId,
+    ) ||
+    (sessionId !== undefined &&
+      isTrackedActiveSessionRunForSessionId(
+        active,
+        sessionId,
+        resolvedAgentId,
+        params.defaultAgentId,
+      ));
   const matchingTrackedRuns = (
-    params.trackedActiveRuns ?? collectTrackedActiveSessionRuns(params.context)
-  ).filter(
-    (active) =>
-      isTrackedActiveSessionRunForKey(
-        active,
-        params.canonicalKey,
-        resolvedAgentId,
-        params.defaultAgentId,
-      ) ||
-      isTrackedActiveSessionRunForKey(
-        active,
-        params.requestedKey,
-        resolvedAgentId,
-        params.defaultAgentId,
-      ) ||
-      (sessionId !== undefined &&
-        isTrackedActiveSessionRunForSessionId(
-          active,
-          sessionId,
-          resolvedAgentId,
-          params.defaultAgentId,
-        )),
-  );
-  const runIds = matchingTrackedRuns.map((active) => active.runId).toSorted();
+    params.trackedActiveRuns ??
+    collectTrackedActiveSessionRuns(params.context, params.includeTerminalPersistence)
+  ).filter(matchesRequestedSession);
+  const hasTerminalPersistence = matchingTrackedRuns.some((active) => active.terminalPersistence);
+  const runIds = matchingTrackedRuns
+    .filter((active) => !active.terminalPersistence)
+    .map((active) => active.runId)
+    .toSorted();
   const hasProjectedRun = hasProjectedAgentRunForSession({
     sessionKeys: [params.requestedKey, params.canonicalKey],
     ...(sessionId ? { sessionId } : {}),
@@ -203,7 +218,10 @@ export function resolveVisibleActiveSessionRunState(params: {
     hasProjectedRun ||
     embeddedRunState === "running";
   const active = running || matchingTrackedRuns.length > 0 || embeddedRunState === "queued";
-  const identitiesComplete = !hasProjectedRun && embeddedRunState === undefined;
+  // Terminal persistence is history visibility, not operational run identity.
+  // Omit the exact set until the persisted terminal projection releases it.
+  const identitiesComplete =
+    !hasProjectedRun && embeddedRunState === undefined && !hasTerminalPersistence;
   return {
     active,
     ...(identitiesComplete ? { runIds } : {}),

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -167,9 +167,7 @@ type SubscriptionParams = Parameters<typeof startGatewayEventSubscriptions>[0];
 type LifecycleOwnerCallbacks = Required<
   Pick<
     AgentEventHandlerOptions,
-    | "clearTrackedActiveRun"
-    | "markTrackedRunTerminalPersisted"
-    | "trackTrackedRunTerminalPersistence"
+    "clearTrackedActiveRun" | "settleTrackedTerminal" | "trackTrackedRunTerminalPersistence"
   >
 >;
 type LifecycleTransition = { state: string; lifecycle?: ReturnType<typeof readLifecycleState> };
@@ -209,14 +207,14 @@ function requireLifecycleOwnerCallbacks(): LifecycleOwnerCallbacks {
     | undefined;
   if (
     !options?.clearTrackedActiveRun ||
-    !options.markTrackedRunTerminalPersisted ||
+    !options.settleTrackedTerminal ||
     !options.trackTrackedRunTerminalPersistence
   ) {
     throw new Error("expected lifecycle owner callbacks");
   }
   return {
     clearTrackedActiveRun: options.clearTrackedActiveRun,
-    markTrackedRunTerminalPersisted: options.markTrackedRunTerminalPersisted,
+    settleTrackedTerminal: options.settleTrackedTerminal,
     trackTrackedRunTerminalPersistence: options.trackTrackedRunTerminalPersistence,
   };
 }
@@ -470,7 +468,7 @@ describe("startGatewayEventSubscriptions", () => {
 
     terminalPersistence.resolve();
     await terminalPersistence.promise;
-    callbacks.markTrackedRunTerminalPersisted({ runId, clientRunId: runId, sessionKey });
+    callbacks.settleTrackedTerminal({ runId, clientRunId: runId, sessionKey });
     transitions.push({ state: "Persisted", lifecycle: readLifecycleState(entry) });
 
     registration.cleanup();
@@ -482,11 +480,11 @@ describe("startGatewayEventSubscriptions", () => {
       { state: "Terminal-observed", lifecycle: lifecycleState(true, true, 3_000) },
       {
         state: "Projection-cleared",
-        lifecycle: lifecycleState(false, false, 3_000, undefined, false),
+        lifecycle: lifecycleState(false, true, 3_000, undefined, false),
       },
       {
         state: "Persisting",
-        lifecycle: lifecycleState(false, false, 3_000, terminalPersistence.promise, false),
+        lifecycle: lifecycleState(false, true, 3_000, terminalPersistence.promise, false),
       },
       { state: "Persisted", lifecycle: lifecycleState(false, false, 3_000, undefined, true) },
       { state: "Removed" },
@@ -586,14 +584,14 @@ describe("startGatewayEventSubscriptions", () => {
       persistence: terminalPersistence.promise,
     });
     void terminalPersistence.promise.then(() => {
-      callbacks.markTrackedRunTerminalPersisted({ runId, clientRunId: runId, sessionKey });
+      callbacks.settleTrackedTerminal({ runId, clientRunId: runId, sessionKey });
     });
 
     await Promise.resolve();
     expect(params.chatAbortControllers.get(runId)).toBe(entry);
     expect(readLifecycleState(entry)).toMatchObject({
       projectSessionActive: false,
-      projectSessionTerminalPending: false,
+      projectSessionTerminalPending: true,
       projectSessionTerminalPersistence: terminalPersistence.promise,
       projectSessionTerminalPersisted: false,
       registrationCleanupRequested: true,

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -171,7 +171,6 @@ export function startGatewayEventSubscriptions(params: {
                 // state holds the canonical key; the run ids are the scoped match.
                 if (entry) {
                   entry.projectSessionActive = false;
-                  entry.projectSessionTerminalPending = false;
                   entry.projectSessionTerminalPersisted = false;
                   markChatAbortTerminalPersistenceError(entry, undefined);
                   queueMicrotask(() => {
@@ -191,16 +190,25 @@ export function startGatewayEventSubscriptions(params: {
                 }
               }
             },
-            markTrackedRunTerminalPersisted: ({ runId, clientRunId }) => {
+            settleTrackedTerminal: ({ runId, clientRunId, persisted = true }) => {
               const candidateRunIds = runId === clientRunId ? [runId] : [runId, clientRunId];
               for (const candidateRunId of candidateRunIds) {
-                params.restartRecoveryCandidates.delete(candidateRunId);
                 const entry = params.chatAbortControllers.get(candidateRunId);
                 if (entry) {
+                  if (persisted) {
+                    params.restartRecoveryCandidates.delete(candidateRunId);
+                    markChatAbortTerminalPersistenceError(entry, undefined);
+                  }
                   entry.projectSessionTerminalPending = false;
-                  entry.projectSessionTerminalPersisted = true;
                   entry.projectSessionTerminalPersistence = undefined;
-                  markChatAbortTerminalPersistenceError(entry, undefined);
+                  entry.projectSessionTerminalPersisted = persisted;
+                  if (entry.registrationCleanupRequested === true) {
+                    removeChatAbortControllerEntry(
+                      params.chatAbortControllers,
+                      candidateRunId,
+                      entry,
+                    );
+                  }
                 }
               }
             },
@@ -215,24 +223,10 @@ export function startGatewayEventSubscriptions(params: {
               for (const candidateRunId of candidateRunIds) {
                 const entry = params.chatAbortControllers.get(candidateRunId);
                 if (entry) {
-                  entry.projectSessionTerminalPending = false;
                   entry.projectSessionTerminalPersistence = persistence;
                   void persistence.catch((error: unknown) => {
                     markChatAbortTerminalPersistenceError(entry, error);
                   });
-                  if (entry.registrationCleanupRequested === true) {
-                    void persistence
-                      .catch(() => undefined)
-                      .then(() => {
-                        if (params.chatAbortControllers.get(candidateRunId) === entry) {
-                          removeChatAbortControllerEntry(
-                            params.chatAbortControllers,
-                            candidateRunId,
-                            entry,
-                          );
-                        }
-                      });
-                  }
                   const lifecycleGeneration = entry.lifecycleGeneration?.trim();
                   const sessionKey = entry.sessionKey.trim();
                   const sessionId = terminalSessionId?.trim() || entry.sessionId.trim();


### PR DESCRIPTION
## What Problem This Solves

`chat.history` could report `hasActiveRun: false` after a run finished but before its terminal session row was persisted. A reconnecting Control UI could therefore treat an incomplete history snapshot as final.

## Why This Change Was Made

`projectSessionActive` had two jobs: runtime liveness for restart handling and temporary visibility for `chat.history`. Delaying that shared flag fixed history ordering but broke restart settlement.

The Gateway now keeps the synchronous runtime-liveness transition. Only `chat.history` also considers the existing `projectSessionTerminalPending` fact. The terminal persistence owner clears that fact on success, definitive failure, or the non-persisted path before broadcasting the settled session state.

This keeps one run registry and preserves current run identity, restart recovery, and exact active-run set semantics.

## User Impact

After reconnect, Control UI keeps the session active while its terminal session update is still pending. Once persistence succeeds or definitively fails, history becomes inactive normally. No protocol, configuration, timeout, retry, or fallback changes are required.

## Evidence

The same real source Gateway, mock OpenAI-compatible provider, source Control UI, and Chromium flow ran against exact current `main` and exact head. Terminal session persistence was deliberately held after runtime completion.

| Check | `main` `8e4075371039` | Head `02c19374682e` |
| --- | --- | --- |
| Runtime completion | `agent.wait: ok`; run context cleared | `agent.wait: ok`; run context cleared |
| Pending `chat.history` | `status: running`; no `endedAt`; `hasActiveRun: false` | `status: running`; no `endedAt`; `hasActiveRun: true` |
| Pending `sessions.list` | `hasActiveRun: false` | `hasActiveRun: false` |
| Persistence success | Settled to `status: done`, `hasActiveRun: false` | Settled to `status: done`, `hasActiveRun: false` |
| Persistence failure | Not applicable to red proof | Released history visibility to `hasActiveRun: false` |
| Gateway restart | Not applicable to red proof | Waited for the in-flight terminal write, then restarted with no old active run |

Focused regression support: 248 tests passed across Gateway terminal events, runtime subscriptions, restart shutdown, and session active-run projection.

### Control UI proof

The provider response is visible while the held terminal session update keeps the session in its working state. The test prompt is masked.

![Control UI keeps the session active while terminal persistence is pending](https://github.com/user-attachments/assets/88ae9093-f8fb-408b-9938-1bf95095bc70)

## AI Assistance

- AI-assisted: Yes
- Tools: Codex
- Confirmed understanding: Yes
