### PR TITLE
test: keep one shard claim for codex run-attempt-tools

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -8,7 +8,6 @@ function createExtensionCodexAppServerAttemptExtraVitestConfig(
     [
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
-      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
       "extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts",
       "extensions/codex/src/app-server/run-attempt.context-engine.test.ts",
       "extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts",

--- a/test/vitest/vitest.extension-codex-app-server-tools.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-tools.config.ts
@@ -15,7 +15,6 @@ function createExtensionCodexAppServerToolsVitestConfig(
       "extensions/codex/src/app-server/native-hook-relay.test.ts",
       "extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts",
       "extensions/codex/src/app-server/request.test.ts",
-      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
       "extensions/codex/src/app-server/sandbox-exec-server*.test.ts",
       "extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts",
       "extensions/codex/src/app-server/user-input-bridge.test.ts",


### PR DESCRIPTION
## What Problem This Solves

`main` is red at `554dfbe0a2c`. `checks-node-compact-large-22` fails the full-suite ownership audit in `test/vitest-projects-config.test.ts`: `extensions/codex/src/app-server/run-attempt-tools.test.ts` is claimed by three Vitest shard configs at once.

## Why This Change Was Made

That test arrived in #126189 with no shard claim at all, which turned the audit red in the other direction. Three PRs then fixed it independently within minutes of each other:

- #126225 `test(codex): route run attempt tools test` → `attempt-light`
- #126222 `fix(ui): restore sidebar session hovercards` → `tools`
- #126190 `improve(ui): fix sidebar session row hierarchy…` → `attempt-extra`

Each was individually correct; together they flipped the audit from `missing` to `duplicated`. I own one of the three (#126190), so I am fixing the collision rather than leaving it.

This keeps the claim from #126225 — the purpose-built fix, whose entire reason for existing was routing this test — and drops the two that were added incidentally while landing unrelated UI work.

The underlying trap is the shard layout, and it will keep firing: the support shard globs `app-server/**/*.test.ts` but excludes the whole `run-attempt*` pattern, while the attempt shards enumerate by filename. So every new `run-attempt-*.test.ts` is owned by nobody until a human adds it by hand, the audit only catches it on some later unrelated PR, and concurrent fixers then collide exactly as they did here. A follow-up making one shard claim the residue of that glob would remove the whole class; that is a test-infrastructure design decision rather than part of this repair.

## User Impact

None user-visible. Restores a green `main` and keeps `run-attempt-tools.test.ts` executing exactly once.

## Evidence

```
node scripts/run-vitest.mjs test/vitest-projects-config.test.ts
# 18 passed — audit reports neither missing nor duplicated

node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt-tools.test.ts
# 3 passed — still runs, in the attempt-light shard
```

Both halves matter: dropping a duplicate claim is only correct if the test still has exactly one owner and still executes.
