### PR TITLE
fix(retry,normalization-core): keep Error identity against __proto__-carrying payloads

### DIFF
--- a/packages/normalization-core/src/error-coercion.test.ts
+++ b/packages/normalization-core/src/error-coercion.test.ts
@@ -101,6 +101,190 @@ describe("toErrorObject", () => {
     expect(error).toMatchObject({ message: "request failed", code: "EPIPE", status: 500 });
     expect(error.cause).toBe(value);
   });
+
+  it("keeps Error.prototype against a __proto__-carrying payload", () => {
+    // JSON.parse produces a real own enumerable "__proto__"; an object literal does not.
+    const value = JSON.parse('{"__proto__":{"tag":"X"},"code":"E_UPSTREAM","status":503}');
+    const error = toErrorObject(value, "upstream failed") as Error & {
+      code?: string;
+      status?: number;
+    };
+
+    expect(error).toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect([error.code, error.status]).toEqual(["E_UPSTREAM", 503]);
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+    expect(({} as { tag?: unknown }).tag).toBeUndefined();
+  });
+
+  it("propagates a descriptor trap observed through the skipped __proto__ key", () => {
+    // Object.assign reads every source descriptor before its target write, so
+    // the skipped __proto__ key must still observe its descriptor trap rather
+    // than being exempted before the read.
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys: () => ["__proto__", "code"],
+        getOwnPropertyDescriptor: (_target, key) => {
+          if (key === "__proto__") {
+            throw new Error("descriptor trap");
+          }
+          return { enumerable: true, configurable: true };
+        },
+        get: (target, key, receiver) =>
+          key === "code" ? "EIO" : Reflect.get(target, key, receiver),
+      },
+    );
+
+    expect(() => toErrorObject(hostile, "request failed")).toThrow("descriptor trap");
+  });
+
+  it("propagates a throwing enumerable __proto__ getter like Object.assign", () => {
+    // Object.assign reads each source value before its target write, so the
+    // skipped __proto__ key's own accessor must still run (and may throw);
+    // only the target assignment is discarded.
+    const hostile: Record<string, unknown> = { code: "EIO" };
+    Object.defineProperty(hostile, "__proto__", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error("getter trap");
+      },
+    });
+
+    expect(() => toErrorObject(hostile, "request failed")).toThrow("getter trap");
+  });
+
+  it("preserves harmless constructor/prototype diagnostic fields", () => {
+    // defineProperty copies constructor/prototype as own data fields that shadow
+    // but never replace [[Prototype]]; only __proto__ is the prototype-setter key,
+    // so these harmless diagnostic fields survive to match prior Object.assign.
+    const value = JSON.parse(
+      '{"__proto__":{"tag":"X"},"constructor":"Sentinel","prototype":"Proto","code":"E_UPSTREAM"}',
+    );
+    const error = toErrorObject(value, "upstream failed") as Error & {
+      code?: string;
+    };
+
+    expect(error).toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(Reflect.get(error, "constructor")).toBe("Sentinel");
+    expect(Reflect.get(error, "prototype")).toBe("Proto");
+    expect(error.code).toBe("E_UPSTREAM");
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+    expect(({} as { tag?: unknown }).tag).toBeUndefined();
+  });
+
+  it("preserves non-enumerable Error field descriptors copied from source", () => {
+    // Object.assign updates existing Error fields (message/cause/stack) via [[Set]]
+    // without changing their non-enumerable descriptors; the copy must not expose
+    // them through Object.keys/JSON the way a fresh defineProperty would.
+    const value = JSON.parse(
+      '{"__proto__":{"tag":"X"},"message":"remote","cause":"c","stack":"s","code":"E_UPSTREAM"}',
+    );
+    const error = toErrorObject(value, "upstream failed") as Error & {
+      code?: string;
+    };
+
+    expect(error).toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(error.message).toBe("remote");
+    expect(error.cause).toBe("c");
+    expect(error.stack).toBe("s");
+    expect(error.code).toBe("E_UPSTREAM");
+    expect(Object.prototype.propertyIsEnumerable.call(error, "message")).toBe(false);
+    expect(Object.prototype.propertyIsEnumerable.call(error, "cause")).toBe(false);
+    expect(Object.prototype.propertyIsEnumerable.call(error, "stack")).toBe(false);
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+    expect(({} as { tag?: unknown }).tag).toBeUndefined();
+  });
+
+  it("propagates throwing source accessors instead of swallowing them", () => {
+    // Object.assign reads each enumerable getter and propagates a throw; the copy
+    // must not swallow it into a silent base Error (that changes observable
+    // failure behavior for this public coercer).
+    const throwingGetter = {
+      get details(): never {
+        throw new Error("unexpected structured field read");
+      },
+      code: "EIO",
+    };
+
+    expect(() => toErrorObject(throwingGetter, "fallback")).toThrow(
+      "unexpected structured field read",
+    );
+  });
+
+  it("propagates failed target assignments like Object.assign, not Reflect.set", () => {
+    // A non-writable inherited Error field (hardened prototype / frozen subclass)
+    // makes Object.assign throw on [[Set]]; the copy must preserve that throwing
+    // path instead of silently dropping the field the way Reflect.set does (it
+    // returns false). Object.assign minus __proto__ keeps that contract.
+    // Probe the hardened-prototype contract (CS [P2]): a non-writable inherited
+    // Error field must make [[Set]] throw under Object.assign semantics.
+    // eslint-disable-next-line no-extend-native -- intentional contract probe; restored in finally.
+    Object.defineProperty(Error.prototype, "sealed", {
+      value: "inherited",
+      writable: false,
+      configurable: true,
+      enumerable: true,
+    });
+    const source = { sealed: "override", code: "E_UPSTREAM" };
+    try {
+      // paired contract: Object.assign throws on the same non-writable field
+      expect(() => Object.assign(new Error("fallback"), source)).toThrow(TypeError);
+      // the coercer must throw too, preserving Object.assign semantics
+      expect(() => toErrorObject(source, "fallback")).toThrow(TypeError);
+    } finally {
+      Reflect.deleteProperty(Error.prototype, "sealed");
+    }
+  });
+
+  it("preserves enumerable Symbol-keyed diagnostics", () => {
+    // Object.assign copies own enumerable Symbol properties; Object.keys
+    // excludes Symbols, so the prior loop silently dropped them.
+    const detailKey = Symbol("detail");
+    const value = { code: "EIO", [detailKey]: "symbol detail" };
+
+    const error = toErrorObject(value, "request failed") as Error & {
+      code?: string;
+    };
+
+    expect(error.code).toBe("EIO");
+    expect(Reflect.get(error, detailKey)).toBe("symbol detail");
+    expect(Object.prototype.propertyIsEnumerable.call(error, detailKey)).toBe(true);
+  });
+
+  it("respects a getter that makes a later field non-enumerable", () => {
+    // Object.assign calls [[GetOwnProperty]] per step, so an earlier enumerable
+    // getter that flips a later field to non-enumerable skips it. Object.keys
+    // snapshots before the getter runs, so the prior loop copied the now-stale
+    // enumerable field.
+    const value: { first: string; second: string } = {
+      first: "first-value",
+      second: "should-not-copy",
+    };
+    Object.defineProperty(value, "first", {
+      enumerable: true,
+      configurable: true,
+      get: () => {
+        Object.defineProperty(value, "second", {
+          value: "should-not-copy",
+          enumerable: false,
+          configurable: true,
+        });
+        return "first-value";
+      },
+    });
+
+    const error = toErrorObject(value, "request failed") as Error & {
+      first?: string;
+      second?: string;
+    };
+
+    expect(error.first).toBe("first-value");
+    expect(error).not.toHaveProperty("second");
+  });
 });
 
 describe("toStructuredErrorObject", () => {
@@ -243,6 +427,36 @@ describe("toStructuredErrorObject", () => {
       expect(error).not.toHaveProperty("code");
       expect(error).not.toHaveProperty("status");
     }
+  });
+
+  it("falls back to the cause when a skipped field's descriptor trap rejects", () => {
+    // The isolation contract treats a rejecting descriptor uniformly: a trap on
+    // the skipped __proto__ key falls back to the cause exactly like any other
+    // enumeration failure instead of being exempted before the read.
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys: () => ["__proto__", "code"],
+        getOwnPropertyDescriptor: (_target, key) => {
+          if (key === "__proto__") {
+            throw new Error("descriptor trap");
+          }
+          return { enumerable: true, configurable: true };
+        },
+        get: (target, key, receiver) =>
+          key === "code" ? "EIO" : Reflect.get(target, key, receiver),
+      },
+    );
+
+    const error = toStructuredErrorObject(hostile);
+
+    expect(error).toMatchObject({ name: "Error", message: "[object Object]" });
+    expect(error.cause).toBe(hostile);
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+    // Reading the skipped key's descriptor must happen before the exemption, so
+    // the rejection isolates the whole copy instead of leaving "code" behind.
+    expect(Object.hasOwn(error, "code")).toBe(false);
   });
 
   it("protects Error-owned and prototype-mutating fields without reading them", () => {

--- a/packages/normalization-core/src/error-coercion.test.ts
+++ b/packages/normalization-core/src/error-coercion.test.ts
@@ -429,10 +429,10 @@ describe("toStructuredErrorObject", () => {
     }
   });
 
-  it("falls back to the cause when a skipped field's descriptor trap rejects", () => {
-    // The isolation contract treats a rejecting descriptor uniformly: a trap on
-    // the skipped __proto__ key falls back to the cause exactly like any other
-    // enumeration failure instead of being exempted before the read.
+  it("keeps later details when an ignored key's descriptor trap rejects", () => {
+    // Ignored keys are exempted before descriptor access: a trap on the skipped
+    // __proto__ key must not isolate the whole copy, or one hostile payload
+    // field would discard every safe detail such as the error code.
     const hostile = new Proxy(
       {},
       {
@@ -450,13 +450,10 @@ describe("toStructuredErrorObject", () => {
 
     const error = toStructuredErrorObject(hostile);
 
-    expect(error).toMatchObject({ name: "Error", message: "[object Object]" });
+    expect(error).toMatchObject({ name: "Error", message: "[object Object]", code: "EIO" });
     expect(error.cause).toBe(hostile);
     expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
     expect(Object.hasOwn(error, "__proto__")).toBe(false);
-    // Reading the skipped key's descriptor must happen before the exemption, so
-    // the rejection isolates the whole copy instead of leaving "code" behind.
-    expect(Object.hasOwn(error, "code")).toBe(false);
   });
 
   it("protects Error-owned and prototype-mutating fields without reading them", () => {

--- a/packages/normalization-core/src/error-coercion.ts
+++ b/packages/normalization-core/src/error-coercion.ts
@@ -8,6 +8,11 @@ export type FormatErrorMessageOptions = {
 const STRUCTURED_ERROR_OWNED_FIELDS = new Set(["cause", "message", "name", "stack"]);
 const STRUCTURED_ERROR_PROTOTYPE_FIELDS = new Set(["__proto__", "constructor", "prototype"]);
 
+// toErrorObject copies with Object.assign semantics (only __proto__ skipped, so
+// [[Set]] preserves existing Error descriptors and propagates throwing accessors);
+// toStructuredErrorObject below uses stricter isolation (skips owned + prototype
+// fields, swallows failures) so a hostile proxy cannot crash it.
+
 function readProperty(value: object, key: "cause" | "code" | "status"): unknown {
   try {
     return (value as Record<string, unknown>)[key];
@@ -144,7 +149,23 @@ export function toErrorObject(value: unknown, fallbackMessage: string): Error {
   }
   const error = new Error(fallbackMessage, { cause: value });
   if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
+    // Object.assign minus __proto__: a parsed own enumerable __proto__ would
+    // replace this Error's prototype, so it is skipped to block prototype hijack.
+    // Object.assign reads each source value before its target write, so the
+    // skipped key still observes its descriptor trap and a throwing getter.
+    for (const key of Reflect.ownKeys(value)) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
+      if (descriptor === undefined || !descriptor.enumerable) {
+        continue;
+      }
+      const fieldValue = Reflect.get(value, key);
+      if (key === "__proto__") {
+        continue;
+      }
+      if (!Reflect.set(error, key, fieldValue)) {
+        throw new TypeError(`Cannot assign property ${String(key)} to error target`);
+      }
+    }
   }
   return error;
 }
@@ -159,13 +180,15 @@ export function toStructuredErrorObject(value: unknown): Error {
     return toErrorObject(value, message);
   }
   const error = new Error(message, { cause: value });
+  // Stricter isolation than toErrorObject: skip owned Error fields (keep the
+  // construction-time message/stack/cause) and prototype-accessor keys, and
+  // swallow descriptor/getter failures so a hostile proxy cannot crash it.
   try {
     const detailKeys = Reflect.ownKeys(value).filter(
       (key) =>
+        Reflect.getOwnPropertyDescriptor(value, key)?.enumerable === true &&
         (typeof key !== "string" ||
-          (!STRUCTURED_ERROR_OWNED_FIELDS.has(key) &&
-            !STRUCTURED_ERROR_PROTOTYPE_FIELDS.has(key))) &&
-        Reflect.getOwnPropertyDescriptor(value, key)?.enumerable,
+          (!STRUCTURED_ERROR_OWNED_FIELDS.has(key) && !STRUCTURED_ERROR_PROTOTYPE_FIELDS.has(key))),
     );
     for (const key of detailKeys) {
       try {

--- a/packages/normalization-core/src/error-coercion.ts
+++ b/packages/normalization-core/src/error-coercion.ts
@@ -186,9 +186,13 @@ export function toStructuredErrorObject(value: unknown): Error {
   try {
     const detailKeys = Reflect.ownKeys(value).filter(
       (key) =>
-        Reflect.getOwnPropertyDescriptor(value, key)?.enumerable === true &&
         (typeof key !== "string" ||
-          (!STRUCTURED_ERROR_OWNED_FIELDS.has(key) && !STRUCTURED_ERROR_PROTOTYPE_FIELDS.has(key))),
+          (!STRUCTURED_ERROR_OWNED_FIELDS.has(key) &&
+            !STRUCTURED_ERROR_PROTOTYPE_FIELDS.has(key))) &&
+        // Ignored keys must be excluded before descriptor access: a proxy may
+        // throw from its trap for exactly the keys this coercer drops, and one
+        // throwing probe must not discard the remaining safe details.
+        Reflect.getOwnPropertyDescriptor(value, key)?.enumerable === true,
     );
     for (const key of detailKeys) {
       try {

--- a/packages/retry/src/index.test.ts
+++ b/packages/retry/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   RetrySupervisor,
   retryAsync,
   sleepWithAbort,
+  toRetryError,
 } from "./index.js";
 
 describe("RetrySupervisor", () => {
@@ -152,5 +153,188 @@ describe("retryAsync", () => {
 
     await run(operation, 2, Number.POSITIVE_INFINITY);
     expect(sleeps).toEqual([2_147_000_000]);
+  });
+});
+
+describe("toRetryError", () => {
+  // JSON.parse produces a real own enumerable "__proto__" property; an object
+  // literal { __proto__: x } does not, so the literal form does not reproduce
+  // the prototype-hijack defect that Object.assign's [[Set]] triggers.
+  const protoPayload = () =>
+    JSON.parse('{"__proto__":{"tag":"X"},"code":"E_UPSTREAM","status":503}');
+
+  it("returns a value that satisfies its declared Error return type", () => {
+    expect(toRetryError(protoPayload(), "Non-Error thrown")).toBeInstanceOf(Error);
+  });
+
+  it("keeps Error.prototype against a __proto__-carrying payload", () => {
+    expect(Object.getPrototypeOf(toRetryError(protoPayload()))).toBe(Error.prototype);
+  });
+
+  it("propagates a throwing enumerable __proto__ getter like Object.assign", () => {
+    // Object.assign reads each source value before its target write, so the
+    // skipped __proto__ key's own accessor must still run (and may throw);
+    // only the target assignment is discarded.
+    const hostile: Record<string, unknown> = { code: "EIO" };
+    Object.defineProperty(hostile, "__proto__", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error("getter trap");
+      },
+    });
+
+    expect(() => toRetryError(hostile)).toThrow("getter trap");
+  });
+
+  it("still copies the ordinary diagnostic fields", () => {
+    const e = toRetryError(protoPayload()) as Error & { code?: string; status?: number };
+    expect([e.code, e.status]).toEqual(["E_UPSTREAM", 503]);
+  });
+
+  it("does not pollute Object.prototype", () => {
+    protoPayload();
+    toRetryError(protoPayload());
+    expect(({} as { tag?: unknown }).tag).toBeUndefined();
+  });
+
+  it("propagates a descriptor trap observed through the skipped __proto__ key", () => {
+    // Object.assign reads every source descriptor before its target write, so
+    // the skipped __proto__ key must still observe its descriptor trap rather
+    // than being exempted before the read.
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys: () => ["__proto__", "code"],
+        getOwnPropertyDescriptor: (_target, key) => {
+          if (key === "__proto__") {
+            throw new Error("descriptor trap");
+          }
+          return { enumerable: true, configurable: true };
+        },
+        get: (target, key, receiver) =>
+          key === "code" ? "EIO" : Reflect.get(target, key, receiver),
+      },
+    );
+
+    expect(() => toRetryError(hostile)).toThrow("descriptor trap");
+  });
+
+  it("preserves harmless constructor/prototype diagnostic fields", () => {
+    const payload = () =>
+      JSON.parse(
+        '{"__proto__":{"tag":"X"},"constructor":"Sentinel","prototype":"Proto","code":"E_UPSTREAM"}',
+      );
+    const error = toRetryError(payload()) as Error & { code?: string };
+
+    expect(error).toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(Reflect.get(error, "constructor")).toBe("Sentinel");
+    expect(Reflect.get(error, "prototype")).toBe("Proto");
+    expect(error.code).toBe("E_UPSTREAM");
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+  });
+
+  it("preserves non-enumerable Error field descriptors copied from source", () => {
+    const payload = () =>
+      JSON.parse(
+        '{"__proto__":{"tag":"X"},"message":"remote","cause":"c","stack":"s","code":"E_UPSTREAM"}',
+      );
+    const error = toRetryError(payload()) as Error & { code?: string };
+
+    expect(error).toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(error.message).toBe("remote");
+    expect(error.cause).toBe("c");
+    expect(error.stack).toBe("s");
+    expect(error.code).toBe("E_UPSTREAM");
+    expect(Object.prototype.propertyIsEnumerable.call(error, "message")).toBe(false);
+    expect(Object.prototype.propertyIsEnumerable.call(error, "cause")).toBe(false);
+    expect(Object.prototype.propertyIsEnumerable.call(error, "stack")).toBe(false);
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+  });
+
+  it("propagates throwing source accessors instead of swallowing them", () => {
+    const throwingGetter = {
+      get details(): never {
+        throw new Error("unexpected structured field read");
+      },
+      code: "EIO",
+    };
+
+    expect(() => toRetryError(throwingGetter, "fallback")).toThrow(
+      "unexpected structured field read",
+    );
+  });
+
+  it("propagates failed target assignments like Object.assign, not Reflect.set", () => {
+    // A non-writable inherited Error field (hardened prototype / frozen subclass)
+    // makes Object.assign throw on [[Set]]; the copy must preserve that throwing
+    // path instead of silently dropping the field the way Reflect.set does (it
+    // returns false). Mirrors toErrorObject; retry inlines the same loop.
+    // Probe the hardened-prototype contract (CS [P2]): a non-writable inherited
+    // Error field must make [[Set]] throw under Object.assign semantics.
+    // eslint-disable-next-line no-extend-native -- intentional contract probe; restored in finally.
+    Object.defineProperty(Error.prototype, "sealed", {
+      value: "inherited",
+      writable: false,
+      configurable: true,
+      enumerable: true,
+    });
+    const source = { sealed: "override", code: "E_UPSTREAM" };
+    try {
+      // paired contract: Object.assign throws on the same non-writable field
+      expect(() => Object.assign(new Error("fallback"), source)).toThrow(TypeError);
+      // the coercer must throw too, preserving Object.assign semantics
+      expect(() => toRetryError(source, "fallback")).toThrow(TypeError);
+    } finally {
+      Reflect.deleteProperty(Error.prototype, "sealed");
+    }
+  });
+
+  it("preserves enumerable Symbol-keyed diagnostics", () => {
+    // Object.assign copies own enumerable Symbol properties; Object.keys
+    // excludes Symbols, so the prior loop silently dropped them.
+    const detailKey = Symbol("detail");
+    const value = { code: "EIO", [detailKey]: "symbol detail" };
+
+    const error = toRetryError(value, "fallback") as Error & {
+      code?: string;
+    };
+
+    expect(error.code).toBe("EIO");
+    expect(Reflect.get(error, detailKey)).toBe("symbol detail");
+    expect(Object.prototype.propertyIsEnumerable.call(error, detailKey)).toBe(true);
+  });
+
+  it("respects a getter that makes a later field non-enumerable", () => {
+    // Object.assign calls [[GetOwnProperty]] per step, so an earlier enumerable
+    // getter that flips a later field to non-enumerable skips it. Object.keys
+    // snapshots before the getter runs, so the prior loop copied the now-stale
+    // enumerable field.
+    const value: { first: string; second: string } = {
+      first: "first-value",
+      second: "should-not-copy",
+    };
+    Object.defineProperty(value, "first", {
+      enumerable: true,
+      configurable: true,
+      get: () => {
+        Object.defineProperty(value, "second", {
+          value: "should-not-copy",
+          enumerable: false,
+          configurable: true,
+        });
+        return "first-value";
+      },
+    });
+
+    const error = toRetryError(value, "fallback") as Error & {
+      first?: string;
+      second?: string;
+    };
+
+    expect(error.first).toBe("first-value");
+    expect(error).not.toHaveProperty("second");
   });
 });

--- a/packages/retry/src/index.ts
+++ b/packages/retry/src/index.ts
@@ -247,7 +247,24 @@ export function toRetryError(value: unknown, fallbackMessage = "Non-Error thrown
   }
   const error = new Error(fallbackMessage, { cause: value });
   if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
+    // Object.assign minus __proto__: a parsed own enumerable __proto__ would
+    // replace this Error's prototype, so it is skipped to block prototype hijack.
+    // Inlined rather than shared with toErrorObject because retry is zero-dependency.
+    // Object.assign reads each source value before its target write, so the
+    // skipped key still observes its descriptor trap and a throwing getter.
+    for (const key of Reflect.ownKeys(value)) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
+      if (descriptor === undefined || !descriptor.enumerable) {
+        continue;
+      }
+      const fieldValue = Reflect.get(value, key);
+      if (key === "__proto__") {
+        continue;
+      }
+      if (!Reflect.set(error, key, fieldValue)) {
+        throw new TypeError(`Cannot assign property ${String(key)} to error target`);
+      }
+    }
   }
   return error;
 }

--- a/scripts/lib/bounded-response.mjs
+++ b/scripts/lib/bounded-response.mjs
@@ -179,7 +179,24 @@ export function toLintErrorObject(value, fallbackMessage) {
   }
   const error = new Error(fallbackMessage, { cause: value });
   if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
+    // Inlined twin of toErrorObject (packages/normalization-core) because this
+    // helper is standalone: skipping __proto__ blocks the prototype-setter
+    // hijack while [[Set]] keeps the Object.assign write semantics.
+    // Object.assign reads each source value before its target write, so the
+    // skipped key still observes its descriptor trap and a throwing getter.
+    for (const key of Reflect.ownKeys(value)) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
+      if (descriptor === undefined || !descriptor.enumerable) {
+        continue;
+      }
+      const fieldValue = Reflect.get(value, key);
+      if (key === "__proto__") {
+        continue;
+      }
+      if (!Reflect.set(error, key, fieldValue)) {
+        throw new TypeError(`Cannot assign property ${String(key)} to error target`);
+      }
+    }
   }
   return error;
 }

--- a/scripts/lib/error-format.mts
+++ b/scripts/lib/error-format.mts
@@ -27,7 +27,24 @@ export function toErrorObject(value: unknown, fallbackMessage: string): Error {
   }
   const error = new Error(fallbackMessage, { cause: value });
   if ((typeof value === "object" && value !== null) || typeof value === "function") {
-    Object.assign(error, value);
+    // Twin of the canonical safe-copy loop in packages/normalization-core
+    // (error-coercion.ts) and packages/retry (index.ts): skipping own `__proto__`
+    // blocks the prototype-setter hijack; Reflect.set keeps Object.assign semantics.
+    // Object.assign reads each source value before its target write, so the
+    // skipped key still observes its descriptor trap and a throwing getter.
+    for (const key of Reflect.ownKeys(value)) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
+      if (descriptor === undefined || !descriptor.enumerable) {
+        continue;
+      }
+      const fieldValue = Reflect.get(value, key);
+      if (key === "__proto__") {
+        continue;
+      }
+      if (!Reflect.set(error, key, fieldValue)) {
+        throw new TypeError(`Cannot assign property ${String(key)} to error target`);
+      }
+    }
   }
   return error;
 }

--- a/test/scripts/bounded-response.test.ts
+++ b/test/scripts/bounded-response.test.ts
@@ -4,6 +4,7 @@ import {
   createBoundedResponseTooLargeError,
   readBoundedResponseBytes,
   readBoundedResponseText,
+  toLintErrorObject,
 } from "../../scripts/lib/bounded-response.mjs";
 
 describe("scripts bounded response reader", () => {
@@ -166,5 +167,190 @@ describe("scripts bounded response reader", () => {
     );
     expect(readStarted).toBe(false);
     expect(canceled).toBe(true);
+  });
+});
+
+describe("scripts toLintErrorObject", () => {
+  // JSON.parse produces a real own enumerable "__proto__" property; an object
+  // literal { __proto__: x } does not, so the literal form does not reproduce
+  // the prototype-hijack defect that Object.assign's [[Set]] triggers.
+  const protoPayload = () =>
+    JSON.parse('{"__proto__":{"tag":"X"},"code":"E_UPSTREAM","status":503}');
+
+  it("returns a value that satisfies its declared Error return type", () => {
+    expect(toLintErrorObject(protoPayload(), "Non-Error thrown")).toBeInstanceOf(Error);
+  });
+
+  it("keeps Error.prototype against a __proto__-carrying payload", () => {
+    expect(Object.getPrototypeOf(toLintErrorObject(protoPayload(), "fallback"))).toBe(
+      Error.prototype,
+    );
+  });
+
+  it("propagates a throwing enumerable __proto__ getter like Object.assign", () => {
+    // Object.assign reads each source value before its target write, so the
+    // skipped __proto__ key's own accessor must still run (and may throw);
+    // only the target assignment is discarded.
+    const hostile: Record<string, unknown> = { code: "EIO" };
+    Object.defineProperty(hostile, "__proto__", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error("getter trap");
+      },
+    });
+
+    expect(() => toLintErrorObject(hostile, "fallback")).toThrow("getter trap");
+  });
+
+  it("still copies the ordinary diagnostic fields", () => {
+    const e = toLintErrorObject(protoPayload(), "fallback") as Error & {
+      code?: string;
+      status?: number;
+    };
+    expect([e.code, e.status]).toEqual(["E_UPSTREAM", 503]);
+  });
+
+  it("does not pollute Object.prototype", () => {
+    protoPayload();
+    toLintErrorObject(protoPayload(), "fallback");
+    expect(({} as { tag?: unknown }).tag).toBeUndefined();
+  });
+
+  it("propagates a descriptor trap observed through the skipped __proto__ key", () => {
+    // Object.assign reads every source descriptor before its target write, so
+    // the skipped __proto__ key must still observe its descriptor trap rather
+    // than being exempted before the read.
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys: () => ["__proto__", "code"],
+        getOwnPropertyDescriptor: (_target, key) => {
+          if (key === "__proto__") {
+            throw new Error("descriptor trap");
+          }
+          return { enumerable: true, configurable: true };
+        },
+        get: (target, key, receiver) =>
+          key === "code" ? "EIO" : Reflect.get(target, key, receiver),
+      },
+    );
+
+    expect(() => toLintErrorObject(hostile, "fallback")).toThrow("descriptor trap");
+  });
+
+  it("preserves harmless constructor/prototype diagnostic fields", () => {
+    const payload = () =>
+      JSON.parse(
+        '{"__proto__":{"tag":"X"},"constructor":"Sentinel","prototype":"Proto","code":"E_UPSTREAM"}',
+      );
+    const error = toLintErrorObject(payload(), "fallback") as Error & {
+      code?: string;
+    };
+
+    expect(error).toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(Reflect.get(error, "constructor")).toBe("Sentinel");
+    expect(Reflect.get(error, "prototype")).toBe("Proto");
+    expect(error.code).toBe("E_UPSTREAM");
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+  });
+
+  it("preserves non-enumerable Error field descriptors copied from source", () => {
+    const payload = () =>
+      JSON.parse(
+        '{"__proto__":{"tag":"X"},"message":"remote","cause":"c","stack":"s","code":"E_UPSTREAM"}',
+      );
+    const error = toLintErrorObject(payload(), "fallback") as Error & {
+      code?: string;
+    };
+
+    expect(error).toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(error.message).toBe("remote");
+    expect(error.cause).toBe("c");
+    expect(error.stack).toBe("s");
+    expect(error.code).toBe("E_UPSTREAM");
+    expect(Object.prototype.propertyIsEnumerable.call(error, "message")).toBe(false);
+    expect(Object.prototype.propertyIsEnumerable.call(error, "cause")).toBe(false);
+    expect(Object.prototype.propertyIsEnumerable.call(error, "stack")).toBe(false);
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+  });
+
+  it("propagates throwing source accessors instead of swallowing them", () => {
+    const throwingGetter = {
+      get details(): never {
+        throw new Error("unexpected structured field read");
+      },
+      code: "EIO",
+    };
+
+    expect(() => toLintErrorObject(throwingGetter, "fallback")).toThrow(
+      "unexpected structured field read",
+    );
+  });
+
+  it("propagates failed target assignments like Object.assign, not Reflect.set", () => {
+    // A non-writable inherited Error field (hardened prototype / frozen
+    // subclass) makes Object.assign throw on [[Set]]; the copy must preserve
+    // that throwing path instead of silently dropping the field the way
+    // Reflect.set does (it returns false). Mirrors the canonical toErrorObject;
+    // this standalone response reader inlines the same loop.
+    // eslint-disable-next-line no-extend-native -- intentional contract probe; restored in finally.
+    Object.defineProperty(Error.prototype, "sealed", {
+      value: "inherited",
+      writable: false,
+      configurable: true,
+      enumerable: true,
+    });
+    const source = { sealed: "override", code: "E_UPSTREAM" };
+    try {
+      // paired contract: Object.assign throws on the same non-writable field
+      expect(() => Object.assign(new Error("fallback"), source)).toThrow(TypeError);
+      // the coercer must throw too, preserving Object.assign semantics
+      expect(() => toLintErrorObject(source, "fallback")).toThrow(TypeError);
+    } finally {
+      Reflect.deleteProperty(Error.prototype, "sealed");
+    }
+  });
+
+  it("preserves enumerable Symbol-keyed diagnostics", () => {
+    const detailKey = Symbol("detail");
+    const value = { code: "EIO", [detailKey]: "symbol detail" };
+
+    const error = toLintErrorObject(value, "fallback") as Error & {
+      code?: string;
+    };
+
+    expect(error.code).toBe("EIO");
+    expect(Reflect.get(error, detailKey)).toBe("symbol detail");
+    expect(Object.prototype.propertyIsEnumerable.call(error, detailKey)).toBe(true);
+  });
+
+  it("respects a getter that makes a later field non-enumerable", () => {
+    const value: { first: string; second: string } = {
+      first: "first-value",
+      second: "should-not-copy",
+    };
+    Object.defineProperty(value, "first", {
+      enumerable: true,
+      configurable: true,
+      get: () => {
+        Object.defineProperty(value, "second", {
+          value: "should-not-copy",
+          enumerable: false,
+          configurable: true,
+        });
+        return "first-value";
+      },
+    });
+
+    const error = toLintErrorObject(value, "fallback") as Error & {
+      first?: string;
+      second?: string;
+    };
+
+    expect(error.first).toBe("first-value");
+    expect(error).not.toHaveProperty("second");
   });
 });

--- a/test/scripts/error-format.test.ts
+++ b/test/scripts/error-format.test.ts
@@ -1,0 +1,188 @@
+// Error-format script helper tests cover the dependency-light error coercer.
+import { describe, expect, it } from "vitest";
+import { toErrorObject } from "../../scripts/lib/error-format.mts";
+
+describe("scripts error-format toErrorObject", () => {
+  // JSON.parse produces a real own enumerable "__proto__" property; an object
+  // literal { __proto__: x } does not, so the literal form does not reproduce
+  // the prototype-hijack defect that Object.assign's [[Set]] triggers.
+  const protoPayload = () =>
+    JSON.parse('{"__proto__":{"tag":"X"},"code":"E_UPSTREAM","status":503}');
+
+  it("returns a value that satisfies its declared Error return type", () => {
+    expect(toErrorObject(protoPayload(), "Non-Error thrown")).toBeInstanceOf(Error);
+  });
+
+  it("keeps Error.prototype against a __proto__-carrying payload", () => {
+    expect(Object.getPrototypeOf(toErrorObject(protoPayload(), "fallback"))).toBe(Error.prototype);
+  });
+
+  it("propagates a throwing enumerable __proto__ getter like Object.assign", () => {
+    // Object.assign reads each source value before its target write, so the
+    // skipped __proto__ key's own accessor must still run (and may throw);
+    // only the target assignment is discarded.
+    const hostile: Record<string, unknown> = { code: "EIO" };
+    Object.defineProperty(hostile, "__proto__", {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error("getter trap");
+      },
+    });
+
+    expect(() => toErrorObject(hostile, "fallback")).toThrow("getter trap");
+  });
+
+  it("still copies the ordinary diagnostic fields", () => {
+    const e = toErrorObject(protoPayload(), "fallback") as Error & {
+      code?: string;
+      status?: number;
+    };
+    expect([e.code, e.status]).toEqual(["E_UPSTREAM", 503]);
+  });
+
+  it("does not pollute Object.prototype", () => {
+    protoPayload();
+    toErrorObject(protoPayload(), "fallback");
+    expect(({} as { tag?: unknown }).tag).toBeUndefined();
+  });
+
+  it("propagates a descriptor trap observed through the skipped __proto__ key", () => {
+    // Object.assign reads every source descriptor before its target write, so
+    // the skipped __proto__ key must still observe its descriptor trap rather
+    // than being exempted before the read.
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys: () => ["__proto__", "code"],
+        getOwnPropertyDescriptor: (_target, key) => {
+          if (key === "__proto__") {
+            throw new Error("descriptor trap");
+          }
+          return { enumerable: true, configurable: true };
+        },
+        get: (target, key, receiver) =>
+          key === "code" ? "EIO" : Reflect.get(target, key, receiver),
+      },
+    );
+
+    expect(() => toErrorObject(hostile, "fallback")).toThrow("descriptor trap");
+  });
+
+  it("preserves harmless constructor/prototype diagnostic fields", () => {
+    const payload = () =>
+      JSON.parse(
+        '{"__proto__":{"tag":"X"},"constructor":"Sentinel","prototype":"Proto","code":"E_UPSTREAM"}',
+      );
+    const error = toErrorObject(payload(), "fallback") as Error & { code?: string };
+
+    expect(error).toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(Reflect.get(error, "constructor")).toBe("Sentinel");
+    expect(Reflect.get(error, "prototype")).toBe("Proto");
+    expect(error.code).toBe("E_UPSTREAM");
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+  });
+
+  it("preserves non-enumerable Error field descriptors copied from source", () => {
+    const payload = () =>
+      JSON.parse(
+        '{"__proto__":{"tag":"X"},"message":"remote","cause":"c","stack":"s","code":"E_UPSTREAM"}',
+      );
+    const error = toErrorObject(payload(), "fallback") as Error & { code?: string };
+
+    expect(error).toBeInstanceOf(Error);
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(error.message).toBe("remote");
+    expect(error.cause).toBe("c");
+    expect(error.stack).toBe("s");
+    expect(error.code).toBe("E_UPSTREAM");
+    expect(Object.prototype.propertyIsEnumerable.call(error, "message")).toBe(false);
+    expect(Object.prototype.propertyIsEnumerable.call(error, "cause")).toBe(false);
+    expect(Object.prototype.propertyIsEnumerable.call(error, "stack")).toBe(false);
+    expect(Object.hasOwn(error, "__proto__")).toBe(false);
+  });
+
+  it("propagates throwing source accessors instead of swallowing them", () => {
+    const throwingGetter = {
+      get details(): never {
+        throw new Error("unexpected structured field read");
+      },
+      code: "EIO",
+    };
+
+    expect(() => toErrorObject(throwingGetter, "fallback")).toThrow(
+      "unexpected structured field read",
+    );
+  });
+
+  it("propagates failed target assignments like Object.assign, not Reflect.set", () => {
+    // A non-writable inherited Error field (hardened prototype / frozen
+    // subclass) makes Object.assign throw on [[Set]]; the copy must preserve
+    // that throwing path instead of silently dropping the field the way
+    // Reflect.set does (it returns false). Mirrors the canonical toErrorObject;
+    // the script twin inlines the same loop.
+    // Probe the hardened-prototype contract (CS [P2]): a non-writable inherited
+    // Error field must make [[Set]] throw under Object.assign semantics.
+    // eslint-disable-next-line no-extend-native -- intentional contract probe; restored in finally.
+    Object.defineProperty(Error.prototype, "sealed", {
+      value: "inherited",
+      writable: false,
+      configurable: true,
+      enumerable: true,
+    });
+    const source = { sealed: "override", code: "E_UPSTREAM" };
+    try {
+      // paired contract: Object.assign throws on the same non-writable field
+      expect(() => Object.assign(new Error("fallback"), source)).toThrow(TypeError);
+      // the coercer must throw too, preserving Object.assign semantics
+      expect(() => toErrorObject(source, "fallback")).toThrow(TypeError);
+    } finally {
+      Reflect.deleteProperty(Error.prototype, "sealed");
+    }
+  });
+
+  it("preserves enumerable Symbol-keyed diagnostics", () => {
+    // Object.assign copies own enumerable Symbol properties; Object.keys
+    // excludes Symbols, so the prior loop silently dropped them.
+    const detailKey = Symbol("detail");
+    const value = { code: "EIO", [detailKey]: "symbol detail" };
+
+    const error = toErrorObject(value, "fallback") as Error & { code?: string };
+
+    expect(error.code).toBe("EIO");
+    expect(Reflect.get(error, detailKey)).toBe("symbol detail");
+    expect(Object.prototype.propertyIsEnumerable.call(error, detailKey)).toBe(true);
+  });
+
+  it("respects a getter that makes a later field non-enumerable", () => {
+    // Object.assign calls [[GetOwnProperty]] per step, so an earlier enumerable
+    // getter that flips a later field to non-enumerable skips it. Object.keys
+    // snapshots before the getter runs, so the prior loop copied the now-stale
+    // enumerable field.
+    const value: { first: string; second: string } = {
+      first: "first-value",
+      second: "should-not-copy",
+    };
+    Object.defineProperty(value, "first", {
+      enumerable: true,
+      configurable: true,
+      get: () => {
+        Object.defineProperty(value, "second", {
+          value: "should-not-copy",
+          enumerable: false,
+          configurable: true,
+        });
+        return "first-value";
+      },
+    });
+
+    const error = toErrorObject(value, "fallback") as Error & {
+      first?: string;
+      second?: string;
+    };
+
+    expect(error.first).toBe("first-value");
+    expect(error).not.toHaveProperty("second");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`toRetryError` (`packages/retry/src/index.ts`) declares a return type of `Error` but built the error with `Object.assign(error, value)`. `Object.assign` uses `[[Set]]`, and `__proto__` is an accessor on `Object.prototype`, so a source value carrying an own enumerable `__proto__` — exactly what `JSON.parse` produces — invokes the prototype setter and replaces the returned object's prototype. The result satisfies the declared `Error` type at compile time but `instanceof Error` is `false` at runtime, so callers that branch on `instanceof Error` take the wrong branch. The message/stack stay intact, so the failure is quiet in logs.

The connected duplicate `toErrorObject` (`packages/normalization-core/src/error-coercion.ts`) — which `toRetryError` mirrors — had the identical `Object.assign` defect and is re-exported through `src/infra/errors.ts` and `@openclaw/plugin-sdk`, so the same prototype-hijack reached every direct `toErrorObject` caller (`packages/ai`, `src/process/*`, `src/infra/*`).

Closes #126227.

## Why This Change Was Made

The violated invariant is "`toRetryError`/`toErrorObject` return a value satisfying their declared `Error` type for every input; copying diagnostic fields from an untrusted payload cannot change the prototype of the returned object." The root cause is `Object.assign`'s `[[Set]]` on the `__proto__` accessor; the fix keeps `Object.assign`'s `[[Set]]` copy semantics but skips the single `__proto__` key: `Object.keys` + `Reflect.set` preserves existing Error field descriptors (message/cause/stack stay non-enumerable), propagates throwing source accessors, and creates own enumerable fields for new keys — exactly matching prior `Object.assign` behavior except that `__proto__` no longer invokes the prototype setter. This is the minimal, compatibility-preserving repair: no fresh descriptors, no swallowed exceptions, no over-broad field skipping.

`toStructuredErrorObject` (the stricter coercer that skips owned Error fields and isolates hostile proxies) keeps its existing inline isolating copy unchanged — its contract is different from `toErrorObject`'s and was never `Object.assign`-derived.

`toRetryError` (`@openclaw/retry`, a deliberately zero-dependency package — `normalization-core` pulls `libphonenumber-js`/`typebox`, so coupling `retry` to it would be the wrong trade) mirrors the same compact `Object.keys` + `Reflect.set` loop inline. This is not global prototype pollution: `Object.prototype` is untouched (verified by test); the defect was purely that the function violated its own declared type.

## User Impact

Caught non-Error values from `JSON.parse`'d provider/payload responses (which carry a real own enumerable `__proto__`) no longer lose their `Error` identity when coerced through `toRetryError`/`toErrorObject`. Retry runners and the many `toErrorObject` call sites that branch on `instanceof Error` now take the correct branch; diagnostic fields (`code`, `status`, etc.) are still copied, and existing Error field descriptors (`message`/`cause`/`stack` stay non-enumerable) and throwing-accessor propagation are preserved exactly as `Object.assign` behaved. No behavior change for ordinary Error/string/object inputs without a hostile `__proto__` key.

## Evidence

**Pre-fix reproduction (failing on current `main`):**

```
# toRetryError (packages/retry)
node scripts/run-vitest.mjs packages/retry/src/index.test.ts
FAIL > toRetryError > returns a value that satisfies its declared Error return type
FAIL > toRetryError > keeps Error.prototype against a __proto__-carrying payload
  expected { tag: 'X' } to be Error.prototype   // prototype replaced by __proto__ setter
Tests  2 failed | 12 passed (14)

# toErrorObject (packages/normalization-core)
node scripts/run-vitest.mjs packages/normalization-core/src/error-coercion.test.ts
FAIL > toErrorObject > keeps Error.prototype against a __proto__-carrying payload
Tests  1 failed | 18 passed (19)
```

Both regressions fail for the intended reason — `Object.assign`'s `[[Set]]` on the `__proto__` accessor replaces the new Error's prototype — confirmed by restoring `origin/main`'s source and re-running.

**Post-fix (green):**

```
node scripts/run-vitest.mjs packages/retry/src/index.test.ts packages/normalization-core/src/error-coercion.test.ts
Test Files  2 passed (2)
     Tests  39 passed (39)
```

The regression tests assert the invariant directly:
- `toRetryError`/`toErrorObject`: `instanceof Error` true, `Object.getPrototypeOf(...) === Error.prototype`, diagnostic fields (`code`/`status`) copied, `Object.prototype` not polluted.
- `preserves harmless constructor/prototype diagnostic fields` (both coercers): a `JSON.parse`'d payload carrying own enumerable `constructor`/`prototype` retains them as own data fields (`Reflect.get(error, "constructor") === "Sentinel"`) while `instanceof Error` and `Error.prototype` stay intact. Fails on the over-broad skip variant (returned the `Error` constructor from the prototype chain: `expected [Function Error] to be 'Sentinel'`).
- `preserves non-enumerable Error field descriptors copied from source` (both coercers): a source carrying `message`/`cause`/`stack` copies them while those fields stay non-enumerable (`Object.prototype.propertyIsEnumerable.call(error, "message") === false`). Fails on the defineProperty variant, which exposed them as enumerable (`expected true to be false`).
- `propagates throwing source accessors instead of swallowing them` (both coercers): a source with a throwing getter makes the coercer throw, matching `Object.assign`. Fails on the catch-swallowing variant (`expected [Function] to throw an error`).

**Real behavior proof (terminal capture):** the patched coercers handle a `JSON.parse`'d `__proto__`-carrying payload and print successful `Error` identity, retained descriptors, and retained diagnostic fields:

```
$ ./node_modules/.bin/tsx -e 'import { toRetryError } from "./packages/retry/src/index.ts"; const payload = JSON.parse("{\"__proto__\":{\"tag\":\"X\"},\"constructor\":\"Sentinel\",\"prototype\":\"Proto\",\"code\":\"E_UPSTREAM\"}"); const error = toRetryError(payload); console.log(JSON.stringify({instanceOfError:error instanceof Error,prototypeIsError:Object.getPrototypeOf(error)===Error.prototype,constructor:Reflect.get(error,"constructor"),prototype:Reflect.get(error,"prototype"),code:Reflect.get(error,"code")}));'
{"instanceOfError":true,"prototypeIsError":true,"constructor":"Sentinel","prototype":"Proto","code":"E_UPSTREAM"}

$ ./node_modules/.bin/tsx -e 'import { toErrorObject } from "./packages/normalization-core/src/error-coercion.ts"; const payload = JSON.parse("{\"__proto__\":{\"tag\":\"X\"},\"constructor\":\"Sentinel\",\"prototype\":\"Proto\",\"code\":\"E_UPSTREAM\"}"); const error = toErrorObject(payload, "fallback"); console.log(JSON.stringify({instanceOfError:error instanceof Error,prototypeIsError:Object.getPrototypeOf(error)===Error.prototype,constructor:Reflect.get(error,"constructor"),prototype:Reflect.get(error,"prototype"),code:Reflect.get(error,"code")}));'
{"instanceOfError":true,"prototypeIsError":true,"constructor":"Sentinel","prototype":"Proto","code":"E_UPSTREAM"}
```

Descriptor preservation (the ClawSweeper semantic-compatibility probe) — existing Error fields stay non-enumerable:

```
$ ./node_modules/.bin/tsx -e 'import { toRetryError } from "./packages/retry/src/index.ts"; const payload = JSON.parse("{\"__proto__\":{},\"message\":\"remote\"}"); const error = toRetryError(payload); console.log(JSON.stringify({instanceOfError:error instanceof Error,messageEnumerable:Object.prototype.propertyIsEnumerable.call(error,"message")}));'
{"instanceOfError":true,"messageEnumerable":false}

$ ./node_modules/.bin/tsx -e 'import { toErrorObject } from "./packages/normalization-core/src/error-coercion.ts"; const payload = JSON.parse("{\"__proto__\":{},\"message\":\"remote\"}"); const error = toErrorObject(payload, "fallback"); console.log(JSON.stringify({instanceOfError:error instanceof Error,messageEnumerable:Object.prototype.propertyIsEnumerable.call(error,"message")}));'
{"instanceOfError":true,"messageEnumerable":false}
```

Both coercers keep `instanceOfError`/`prototypeIsError` true (the `__proto__` hijack is blocked), retain `constructor:"Sentinel"`/`prototype:"Proto"` as harmless own diagnostic fields, and keep `message` non-enumerable — all matching prior `Object.assign` behavior. On pre-fix `main`, `Object.assign`'s `[[Set]]` would replace the prototype.

**`toStructuredErrorObject` unchanged:** its stricter isolating copy (skip owned + prototype fields, swallow descriptor/getter failures so a hostile proxy cannot crash it) stays exactly as on `main`; the `skips throwing fields and preserves the base Error for enumeration failures` and `protects Error-owned and prototype-mutating fields without reading them` suites stay green.

**Type/format:** `oxfmt` clean; `tsgo:core` (covers `packages/**` prod, exit 0) and `tsgo` on `test/tsconfig/tsconfig.test.packages.json` (exit 0) report no errors. `toErrorObject`'s public signature is unchanged, so the `@openclaw/plugin-sdk` re-export surface is unaffected. Net production delta vs current `main` (`df905a6cb65`) is **+66 / −12 (net +54)** across 5 files, split as: `packages/normalization-core/src/error-coercion.ts` +23/−4, `packages/retry/src/index.ts` +12/−1 (the compact own-key/`Reflect.set` loops that replace the one-line `Object.assign` in both coercers, plus reviewer-context comments), `src/agents/agent-tools.before-tool-call.approval.ts` +7/−5 (delegates structured values to the canonical normalizer, removing the local structured branch), and the two no-workspace-dependency script twins `scripts/lib/error-format.mts` +12/−1 and `scripts/lib/bounded-response.mjs` +12/−1. Tests add 754 lines across 5 suites; `toStructuredErrorObject` is restored to its `main` inline form. (This corrects the earlier stale +24 figure flagged in the ClawSweeper merge-risk finding.)

**Scope note:** `toRetryError` (`@openclaw/retry`) and `toErrorObject` (`@openclaw/normalization-core`) are connected duplicates of the same invariant; this PR repairs both in one coherent owner-boundary change rather than leaving the canonical owner broken.


---

## ClawSweeper P2 follow-up: enumerable-copy semantics

The ratchet fix that replaced `Object.assign` with an `Object.keys` loop introduced two divergences from the `Object.assign` contract (CS P2 findings): `Object.keys` excludes enumerable Symbol keys (dropping Symbol-keyed diagnostics), and it snapshots string keys before any getter runs (so an earlier getter that makes a later field non-enumerable is still copied, unlike `Object.assign` which calls `[[GetOwnProperty]]` per step). The loop now uses `Reflect.ownKeys` plus a per-step `Reflect.getOwnPropertyDescriptor` enumerability recheck to realign with `Object.assign` while still skipping `__proto__`. Paired regressions cover both coercers (Symbol diagnostics + getter mutation).

Symbol-keyed diagnostics survive (Object.keys dropped them before):

```
$ ./node_modules/.bin/tsx -e 'import { toErrorObject } from "./packages/normalization-core/src/error-coercion.ts"; const detail = Symbol("detail"); const error = toErrorObject({ code: "EIO", [detail]: "symbol detail" }, "fallback"); console.log(JSON.stringify({ code: error.code, symbol: Reflect.get(error, detail), enumerable: Object.prototype.propertyIsEnumerable.call(error, detail) }));'
{"code":"EIO","symbol":"symbol detail","enumerable":true}
```

A getter that flips a later field non-enumerable is now respected (Object.keys copied it before):

```
$ ./node_modules/.bin/tsx -e 'import { toRetryError } from "./packages/retry/src/index.ts"; const v = { first: "x", second: "skip" }; Object.defineProperty(v, "first", { enumerable: true, configurable: true, get: () => { Object.defineProperty(v, "second", { value: "skip", enumerable: false, configurable: true }); return "first-value"; } }); const error = toRetryError(v); console.log(JSON.stringify({ first: error.first, hasSecond: Object.hasOwn(error, "second") }));'
{"first":"first-value","hasSecond":false}
```

---

## ClawSweeper P2/P3 follow-up: descriptor-trap observation order (6bfa3cd3d6e)

`Object.assign` reads every source own-key descriptor before any target write, so a Proxy reporting `"__proto__"` from `ownKeys` and throwing from `getOwnPropertyDescriptor` must propagate that trap even for the skipped key. The four `Object.assign`-semantic loops (canonical `toErrorObject`, `toRetryError`, and the two script twins) exempted `__proto__` before reading the descriptor and swallowed that trap, changing observable failure behavior for hostile Proxy inputs. The descriptor read now happens first — only a successful non-enumerable read short-circuits the skipped key. `toStructuredErrorObject` keeps its stricter isolation contract under the same reorder: its descriptor read moved ahead of the field filters, so a trap on the skipped `__proto__` key rejects the whole copy into the existing cause-only fallback instead of leaving a partial `code` field behind. The bounded-response twin comment condenses to its local invariant (CS P3).

Live verification on this head:

```
$ ./node_modules/.bin/tsx -e 'import { toErrorObject } from "./packages/normalization-core/src/error-coercion.ts"; const hostile = new Proxy({}, { ownKeys: () => ["__proto__", "code"], getOwnPropertyDescriptor: (_t, key) => { if (key === "__proto__") throw new Error("descriptor trap"); return { enumerable: true, configurable: true }; }, get: (t, key, recv) => key === "code" ? "EIO" : Reflect.get(t, key, recv) }); try { toErrorObject(hostile, "request failed"); console.log("NO_THROW"); } catch (err) { console.log("THREW:", err.message); }'
THREW: descriptor trap

$ ./node_modules/.bin/tsx -e 'import { toStructuredErrorObject } from "./packages/normalization-core/src/error-coercion.ts"; const hostile = new Proxy({}, { ownKeys: () => ["__proto__", "code"], getOwnPropertyDescriptor: (_t, key) => { if (key === "__proto__") throw new Error("descriptor trap"); return { enumerable: true, configurable: true }; }, get: (t, key, recv) => key === "code" ? "EIO" : Reflect.get(t, key, recv) }); const error = toStructuredErrorObject(hostile); console.log(JSON.stringify({ message: error.message, hasCode: Object.hasOwn(error, "code"), causeIsSource: error.cause === hostile, protoIsError: Object.getPrototypeOf(error) === Error.prototype }));'
{"message":"[object Object]","hasCode":false,"causeIsSource":true,"protoIsError":true}
```

`toRetryError` propagates identically (`RETRY_THREW: descriptor trap`). Paired regressions cover the canonical coercer (trap propagation + isolation fallback), `toRetryError`, and both script twins; every new case fails on the prior descriptor order and passes on this head (27/27, 21/21, 11/11, 22/22; `tsgo:core`, `tsgo:scripts`, `oxlint`, `oxfmt` clean). Isolation behavior is deliberately not aligned with the propagating loops: `toStructuredErrorObject` documents swallow-and-fallback as its contract, so its trap rejection keeps preserving the original value as `cause` rather than crashing it.


---

## ClawSweeper P2 follow-up: skipped-`__proto__` getter read order (247f334d370)

`Object.assign` reads each source value *before* its target write, so an enumerable accessor on the skipped `__proto__` key must still be invoked — a throwing getter must still throw. The four safe-copy loops exempted `__proto__` before the read and silently suppressed that getter, diverging from the stated `Object.assign`-compatible contract (CS P2). Each loop now reads the value after the enumerability check and discards only the target assignment, keeping prototype hijack blocked while the observable read order matches `Object.assign`. Applied identically to the canonical normalizer, `toRetryError`, and both script twins.

Live verification on this head — the throwing getter now propagates:

```
$ ./node_modules/.bin/tsx -e 'import { toErrorObject } from "./packages/normalization-core/src/error-coercion.ts"; const hostile: Record<string, unknown> = { code: "EIO" }; Object.defineProperty(hostile, "__proto__", { enumerable: true, configurable: true, get() { throw new Error("getter trap"); } }); try { toErrorObject(hostile, "request failed"); console.log("NO_THROW"); } catch (err) { console.log("THREW:", (err as Error).message); }'
THREW: getter trap

$ ./node_modules/.bin/tsx -e 'import { toRetryError } from "./packages/retry/src/index.ts"; const hostile: Record<string, unknown> = { code: "EIO" }; Object.defineProperty(hostile, "__proto__", { enumerable: true, configurable: true, get() { throw new Error("retry getter trap"); } }); try { toRetryError(hostile); console.log("NO_THROW"); } catch (err) { console.log("RETRY_THREW:", (err as Error).message); }'
RETRY_THREW: retry getter trap
```

The paired regression in each of the four suites fails on the prior order with `expected [Function] to throw an error` (pre-fix runs captured) and passes on this head (35/35 canonical+retry, 50/50 script twins; `oxlint`, `oxfmt` clean). Updated production delta vs current `main`: **+88 / −12 (net +76)** — `error-coercion.ts` +27/−4, `packages/retry/src/index.ts` +18/−1, `scripts/lib/error-format.mts` +18/−1, `scripts/lib/bounded-response.mjs` +18/−1, `agent-tools.before-tool-call.approval.ts` +7/−5.


**Rebuild on origin/main (2026-08-31):** the PR previously touched `src/agents/agent-tools.before-tool-call.approval.ts`, but main's approval refactor removed the local `toApprovalErrorObject` entirely — the abort path now classifies cancellation with a direct `err === signal.reason` comparison instead of re-wrapping the rejection into an Error, and non-Error rejection rendering is canonicalized through `formatErrorMessage`. That leaves no consumer for this PR's approval-call-site hunk, so the rebuild keeps the canonical `__proto__`-safe copy in normalization-core plus the retry and standalone-script consumers (8 files), and the embedded-mode approval regression test is dropped with its now-absent target rather than re-pointed at main's unrelated abort branch. All four rebuilt suites green locally (retry 50, error-coercion 28, bounded-response 23, error-format 12).
