### PR TITLE
chore(macos): pin final Peekaboo source

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3d772c15878cee29346b54b6cb85f5a08bff6570cfbee044b340bc8d1b2e57fa",
+  "originHash" : "009ce711da673deaa0e263005d3ceb3c94518c1f4829686709798e404117a187",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/Peekaboo.git",
       "state" : {
-        "revision" : "d1217a9fdf02d882b7c170f294e1e75e20039320"
+        "revision" : "f22109e7e7810fb655000615e6c86856bdb77701"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
         .package(
             url: "https://github.com/openclaw/Peekaboo.git",
-            revision: "d1217a9fdf02d882b7c170f294e1e75e20039320"),
+            revision: "f22109e7e7810fb655000615e6c86856bdb77701"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),


### PR DESCRIPTION
## What Problem This Solves

The macOS app still compiled against Peekaboo `d1217a9f…` instead of the terminal reviewed source `f22109e7…`, so subsequent Peekaboo fixes were absent from future OpenClaw macOS builds.

## Why This Change Was Made

Pins the macOS Swift package manifest to exact Peekaboo commit `f22109e7e7810fb655000615e6c86856bdb77701` and lets SwiftPM regenerate the matching lockfile `originHash`. No other Swift dependency changed, and packaging, signing, notarization, installation, or release work is outside this PR.

## User Impact

Future OpenClaw macOS builds compile the final reviewed Peekaboo source. There is no standalone runtime or UI change until a later build is produced through the normal release process.

## Evidence

- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer swift package --package-path apps/macos resolve`
- Exact manifest and resolved-pin assertions both passed for `f22109e7e7810fb655000615e6c86856bdb77701`.
- Full lockfile comparison showed only the Peekaboo revision changed; SwiftPM regenerated `originHash` and all other 16 pins remained unchanged.
- Focused package/source-stamp/elevation proof: 3 files, 173 tests passed.
- `pnpm check:changed`: dependency pin guard, Swift lint, and 7 macOS CI shards passed (483 tests).
- `pnpm test:changed`: no additional test targets.
- Autoreview: clean, no accepted/actionable findings.

AI-assisted: yes. I reviewed the two-file change and understand the exact pin and lockfile update.
