### PR TITLE
fix(codex): preserve transcript mirror identity during redaction

### DIFF
--- a/extensions/codex/src/app-server/transcript-mirror.test.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.test.ts
@@ -935,6 +935,45 @@ describe("mirrorCodexAppServerTranscript", () => {
     ).toHaveLength(1);
   });
 
+  it("preserves mirror identity across redaction from prompt append through final snapshot", async () => {
+    const target = await createSqliteMirrorTarget("openclaw-codex-mirror-redacted-identity-");
+    const config = { logging: { redactPatterns: [String.raw`^codex-app-server:.*$`] } };
+    const userMessage = attachCodexMirrorIdentity(
+      makeAgentUserMessage({
+        content: [{ type: "text", text: "client prompt" }],
+        timestamp: Date.now(),
+      }),
+      "turn-1:prompt",
+    );
+    const assistantMessage = attachCodexMirrorIdentity(
+      makeAgentAssistantMessage({
+        content: [{ type: "text", text: "final answer" }],
+        timestamp: Date.now() + 1,
+      }),
+      "turn-1:assistant",
+    );
+    const mirrorParams = {
+      ...target,
+      idempotencyScope: "codex-app-server:thread-1",
+      config,
+    };
+
+    await mirrorCodexAppServerTranscript({ ...mirrorParams, messages: [userMessage] });
+    const finalMirror = await mirrorCodexAppServerTranscript({
+      ...mirrorParams,
+      messages: [userMessage, assistantMessage],
+    });
+
+    expect(finalMirror.assistantMirrorIdentitiesOwned).toEqual(["turn-1:assistant"]);
+    expect(await readMirrorMessages(target)).toEqual([
+      { role: "user", text: "client prompt" },
+      { role: "assistant", text: "final answer" },
+    ]);
+    const raw = await readMirrorRaw(target);
+    expect(raw).toContain('"idempotencyKey":"codex-app-server:thread-1:turn-1:prompt"');
+    expect(raw).toContain('"idempotencyKey":"codex-app-server:thread-1:turn-1:assistant"');
+  });
+
   it("emits message-bearing updates for newly appended mirrored messages only", async () => {
     const target = await createSqliteMirrorTarget("openclaw-codex-mirror-live-updates-");
     const userMessage = attachCodexMirrorIdentity(

--- a/src/agents/transcript-redact.ts
+++ b/src/agents/transcript-redact.ts
@@ -538,6 +538,11 @@ function redactTranscriptStructuredValue(
     next = { ...source };
   }
   for (const [key, item] of Object.entries(source)) {
+    // The append transaction owns this control-plane identity. Redacting it would
+    // make stored dedupe disagree with the admitted message identity.
+    if (location === "root" && key === "idempotencyKey") {
+      continue;
+    }
     if (location === "root" && source.role === "assistant" && key === "providerReplay") {
       const sanitizedReplay = sanitizeCompactionReplayState(
         item,


### PR DESCRIPTION
Closes #126244

## What Problem This Solves

Fixes an issue where successful Codex app-server turns could lose their final mirrored transcript snapshot when a configured redaction pattern matched the generated mirror idempotency key. The model reply still completed, but durable history omitted the mirrored messages and only a warning exposed the loss.

## Why This Change Was Made

Transcript redaction changed the top-level `idempotencyKey` after SQLite admission had captured the original value. The insert deduplicated against the redacted key, while replay lookup used the admitted key and missed. This change preserves that writer-owned control-plane identity byte-for-byte while continuing to redact message content.

Upstream Codex ordering and identity contracts were checked directly in `codex-rs`: turn IDs are stable submission UUIDs, item completion carries the authoritative turn/item identity, and notifications are translated serially. The defect is in OpenClaw's redaction/persistence boundary, not the Codex protocol.

AI-assisted implementation; the final diff and upstream contract were manually reviewed.

## User Impact

Codex-backed conversations now retain prompt and assistant transcript rows exactly once even when custom transcript redaction patterns match the generated mirror key. Completed replies no longer silently lose durable mirrored history in this case.

## Evidence

- Production observation: the same `SQLite transcript append did not insert message <uuid>` mirror failure occurred 10 times over roughly seven hours while the corresponding turns completed successfully.
- Pre-fix regression: the real SQLite prompt-then-final-snapshot sequence fails at `session-accessor.sqlite-transcript-message-append.ts:144` with the production error.
- Post-fix focused proof: 117 tests passed across:
  - `src/agents/transcript-redact.test.ts`
  - `src/config/sessions/transcript-append-redact.test.ts`
  - `extensions/codex/src/app-server/transcript-mirror.test.ts`
- `git diff --check` passed.
- Fresh Codex autoreview: clean, patch correctness 0.98, no actionable findings.
- LOC: production `+5/-0`; tests `+39/-0`. The production growth is the narrow identity-preservation branch and its ownership comment; no schema, protocol, config, dependency, release, or fallback surface changed.
