### PR TITLE
fix(telegram): finalize streamed questions in place

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch-delivery.ts
+++ b/extensions/telegram/src/bot-message-dispatch-delivery.ts
@@ -52,7 +52,8 @@ import {
   type TelegramPromptContextProjectionSequence,
   type TelegramPromptContextSource,
 } from "./prompt-context-projection.js";
-import { editMessageTelegram } from "./send.js";
+import { registerTelegramQuestionDelivery } from "./question-finalization.js";
+import { editMessageReplyMarkupTelegram, editMessageTelegram } from "./send.js";
 import { resolveTelegramTargetChatType } from "./targets.js";
 
 type TelegramDeliveryConfig = TurnConfig & {
@@ -348,7 +349,7 @@ export async function emitPreviewFinalizedHook(
     chatId: String(turn.context.chatId),
     accountId: turn.context.route.accountId,
     content: result.delivery.content,
-    success: true,
+    success: result.kind === "preview-finalized",
     messageId: result.delivery.messageId,
     isGroup: turn.context.isGroup,
     groupId: turn.context.isGroup ? String(turn.context.chatId) : undefined,
@@ -359,6 +360,34 @@ export async function emitPreviewFinalizedHook(
       logVerbose(`telegram preview-finalized transcriptMirror failed: ${formatErrorMessage(err)}`);
     });
   }
+}
+
+export function registerTelegramQuestionDeliveryForMessage(
+  turn: Turn,
+  payload: ReplyPayload,
+  delivery: { messageId: number; text: string },
+): void {
+  const { chatId } = turn.context;
+  const accountId = turn.context.route.accountId;
+  const api = turn.bot.api;
+  const cfg = turn.cfg;
+  const linkPreview = turn.telegramCfg.linkPreview;
+  const editText = turn.telegramDeps.editMessageTelegram ?? editMessageTelegram;
+  const { messageId, text } = delivery;
+  registerTelegramQuestionDelivery({
+    accountId,
+    chatId: String(chatId),
+    messageId,
+    payload,
+    text,
+    textLimit: turn.textLimit,
+    clearButtons: async () => {
+      await editMessageReplyMarkupTelegram(chatId, messageId, [], { api, cfg, accountId });
+    },
+    annotate: async (finalText) => {
+      await editText(chatId, messageId, finalText, { api, cfg, accountId, linkPreview });
+    },
+  });
 }
 
 async function materializeAnswerLaneBeforeRotation(turn: Turn): Promise<void> {
@@ -487,6 +516,12 @@ export async function deliverFinalAnswerText(
   }
   if (result.kind === "preview-finalized" || result.kind === "preview-finalized-partial") {
     await emitPreviewFinalizedHook(turn, result);
+  }
+  if (result.kind === "preview-finalized") {
+    registerTelegramQuestionDeliveryForMessage(turn, answerPayload, {
+      messageId: result.delivery.messageId,
+      text: result.delivery.content,
+    });
   }
   if (result.kind === "preview-finalized-partial") {
     throw mergeTelegramPartialDeliveryError(result.error, {

--- a/extensions/telegram/src/bot-message-dispatch-delivery.ts
+++ b/extensions/telegram/src/bot-message-dispatch-delivery.ts
@@ -332,10 +332,7 @@ export async function sendPayload(
   }
 }
 
-export async function emitPreviewFinalizedHook(
-  turn: Turn,
-  result: LaneDeliveryResult,
-): Promise<void> {
+async function emitPreviewFinalizedHook(turn: Turn, result: LaneDeliveryResult): Promise<void> {
   if (
     turn.isSuperseded() ||
     (result.kind !== "preview-finalized" && result.kind !== "preview-finalized-partial")
@@ -358,6 +355,27 @@ export async function emitPreviewFinalizedHook(
   if (transcriptMirror && result.delivery.content) {
     void transcriptMirror({ text: result.delivery.content }).catch((err: unknown) => {
       logVerbose(`telegram preview-finalized transcriptMirror failed: ${formatErrorMessage(err)}`);
+    });
+  }
+}
+
+export async function handlePreviewFinalizedResult(
+  turn: Turn,
+  result: LaneDeliveryResult,
+): Promise<void> {
+  if (result.kind !== "preview-finalized" && result.kind !== "preview-finalized-partial") {
+    return;
+  }
+  await emitPreviewFinalizedHook(turn, result);
+  if (result.kind === "preview-finalized-partial") {
+    // The preview is already visible, so this failure is terminal: preserve its
+    // receipt and prevent outer fallback delivery from duplicating the message.
+    markFinalDelivered(turn);
+    throw mergeTelegramPartialDeliveryError(result.error, {
+      receipt: result.delivery.receipt,
+      content: result.delivery.content,
+      messageIds: result.delivery.receipt.platformMessageIds,
+      visibleReplySent: true,
     });
   }
 }
@@ -416,7 +434,7 @@ async function materializeAnswerLaneBeforeRotation(turn: Turn): Promise<void> {
     durable: false,
   });
   turn.activeAnswerBlockDelivery = undefined;
-  await emitPreviewFinalizedHook(turn, result);
+  await handlePreviewFinalizedResult(turn, result);
 }
 
 async function deliverTelegramProgressModeFinalAnswer(
@@ -514,21 +532,11 @@ export async function deliverFinalAnswerText(
       markFinalDelivered(turn);
     }
   }
-  if (result.kind === "preview-finalized" || result.kind === "preview-finalized-partial") {
-    await emitPreviewFinalizedHook(turn, result);
-  }
+  await handlePreviewFinalizedResult(turn, result);
   if (result.kind === "preview-finalized") {
     registerTelegramQuestionDeliveryForMessage(turn, answerPayload, {
       messageId: result.delivery.messageId,
       text: result.delivery.content,
-    });
-  }
-  if (result.kind === "preview-finalized-partial") {
-    throw mergeTelegramPartialDeliveryError(result.error, {
-      receipt: result.delivery.receipt,
-      content: result.delivery.content,
-      messageIds: result.delivery.receipt.platformMessageIds,
-      visibleReplySent: true,
     });
   }
   return result;

--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -16,6 +16,7 @@ import {
   deliverFinalAnswerText,
   emitPreviewFinalizedHook,
   normalizeDeliveryPayload,
+  registerTelegramQuestionDeliveryForMessage,
   sendPayload,
 } from "./bot-message-dispatch-delivery.js";
 import {
@@ -47,6 +48,7 @@ import {
   type TelegramDroppedControl,
   type TelegramInlineButtons,
 } from "./button-types.js";
+import { mergeTelegramPartialDeliveryError } from "./chunk-delivery.js";
 import {
   buildTelegramErrorScopeKey,
   isSilentErrorPolicy,
@@ -427,8 +429,28 @@ export async function deliverReply(
             onPlatformSendDispatch: info.onPlatformSendDispatch,
             bindPendingFinalDelivery: info.bindPendingFinalDelivery,
           });
-    if (segment.lane === "answer" && info.kind !== "final" && result.kind === "preview-finalized") {
+    const finalizedPreview =
+      segment.lane === "answer" &&
+      info.kind !== "final" &&
+      (result.kind === "preview-finalized" || result.kind === "preview-finalized-partial");
+    if (finalizedPreview) {
       await emitPreviewFinalizedHook(turn, result);
+      if (result.kind === "preview-finalized-partial") {
+        markFinalDelivered(turn);
+        throw mergeTelegramPartialDeliveryError(result.error, {
+          receipt: result.delivery.receipt,
+          content: result.delivery.content,
+          messageIds: result.delivery.receipt.platformMessageIds,
+          visibleReplySent: true,
+        });
+      }
+    }
+    if (segment.lane === "answer" && info.kind === "tool" && result.kind === "preview-updated") {
+      const messageId = turn.answerLane.stream?.messageId();
+      const text = turn.answerLane.stream?.lastDeliveredText?.();
+      if (typeof messageId === "number" && text) {
+        registerTelegramQuestionDeliveryForMessage(turn, effectivePayload, { messageId, text });
+      }
     }
     if (segment.lane === "answer" && info.kind === "block" && result.kind === "preview-updated") {
       turn.activeAnswerBlockDelivery = {

--- a/extensions/telegram/src/bot-message-dispatch-reply.ts
+++ b/extensions/telegram/src/bot-message-dispatch-reply.ts
@@ -14,7 +14,7 @@ import type { TelegramBotDeps } from "./bot-deps.js";
 import {
   applyTextToPayload,
   deliverFinalAnswerText,
-  emitPreviewFinalizedHook,
+  handlePreviewFinalizedResult,
   normalizeDeliveryPayload,
   registerTelegramQuestionDeliveryForMessage,
   sendPayload,
@@ -48,7 +48,6 @@ import {
   type TelegramDroppedControl,
   type TelegramInlineButtons,
 } from "./button-types.js";
-import { mergeTelegramPartialDeliveryError } from "./chunk-delivery.js";
 import {
   buildTelegramErrorScopeKey,
   isSilentErrorPolicy,
@@ -434,16 +433,7 @@ export async function deliverReply(
       info.kind !== "final" &&
       (result.kind === "preview-finalized" || result.kind === "preview-finalized-partial");
     if (finalizedPreview) {
-      await emitPreviewFinalizedHook(turn, result);
-      if (result.kind === "preview-finalized-partial") {
-        markFinalDelivered(turn);
-        throw mergeTelegramPartialDeliveryError(result.error, {
-          receipt: result.delivery.receipt,
-          content: result.delivery.content,
-          messageIds: result.delivery.receipt.platformMessageIds,
-          visibleReplySent: true,
-        });
-      }
+      await handlePreviewFinalizedResult(turn, result);
     }
     if (segment.lane === "answer" && info.kind === "tool" && result.kind === "preview-updated") {
       const messageId = turn.answerLane.stream?.messageId();

--- a/extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts
@@ -1,4 +1,5 @@
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
 import { beforeEach, expect, it, vi } from "vitest";
 
@@ -410,7 +411,8 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
     if (!isChannelPartialDeliveryError(observedError)) {
       throw new Error("Expected queued block rotation to surface a partial delivery error");
     }
-    expect(observedError.cause).toBe(buttonError);
+    expect(observedError.code).toBe("CHANNEL_PARTIAL_DELIVERY");
+    expect(formatErrorMessage(observedError)).toBe(formatErrorMessage(buttonError));
     expect(observedError.deliveryResult).toEqual(
       expect.objectContaining({
         content: "Pick one",

--- a/extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.draft-rotation.test.ts
@@ -1,12 +1,27 @@
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it, vi } from "vitest";
+
+const registerChannelDelivery = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/question-gateway-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/question-gateway-runtime")>();
+  return {
+    ...actual,
+    questionGatewayRuntime: { ...actual.questionGatewayRuntime, registerChannelDelivery },
+  };
+});
+
+beforeEach(() => registerChannelDelivery.mockReset());
 import {
   describeTelegramDispatch,
   createContext,
+  createStatusReactionController,
   deliverReplies,
   dispatchReplyWithBufferedBlockDispatcher,
   dispatchWithContext,
   editMessageTelegram,
+  emitTelegramMessageSentHooks,
   expectDraftStreamParams,
   mockCallArg,
   requireInvocationOrder,
@@ -350,6 +365,74 @@ describeTelegramDispatch("dispatchTelegramMessage draft-rotation", () => {
     );
     expect(rotationOrder).toBeLessThan(secondBlockUpdateOrder);
     expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("surfaces control failure while materializing a queued block before rotation", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    const statusReactionController = createStatusReactionController();
+    const context = createContext({ statusReactionController: statusReactionController as never });
+    const questionId = "ask_0123456789abcdef0123456789abcdef";
+    const firstPayload = {
+      text: "Pick one",
+      channelData: {
+        askUser: { questionId },
+        telegram: { buttons: [[{ text: "One", callback_data: `tgq1:${questionId}:0` }]] },
+      },
+    };
+    const secondPayload = { text: "Next answer" };
+    const buttonError = new Error("400: button rejected during rotation");
+    editMessageTelegram.mockResolvedValueOnce({ ok: true }).mockRejectedValueOnce(buttonError);
+    let observedError: unknown;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onBlockReplyQueued?.(firstPayload, { assistantMessageIndex: 0 });
+        await dispatcherOptions.deliver(firstPayload, {
+          kind: "block",
+          assistantMessageIndex: 0,
+        });
+        await replyOptions?.onBlockReplyQueued?.(secondPayload, { assistantMessageIndex: 1 });
+        try {
+          await dispatcherOptions.deliver(secondPayload, {
+            kind: "block",
+            assistantMessageIndex: 1,
+          });
+        } catch (error) {
+          observedError = error;
+          throw error;
+        }
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context });
+
+    expect(isChannelPartialDeliveryError(observedError)).toBe(true);
+    if (!isChannelPartialDeliveryError(observedError)) {
+      throw new Error("Expected queued block rotation to surface a partial delivery error");
+    }
+    expect(observedError.cause).toBe(buttonError);
+    expect(observedError.deliveryResult).toEqual(
+      expect.objectContaining({
+        content: "Pick one",
+        messageIds: ["2001"],
+        receipt: expect.objectContaining({
+          primaryPlatformMessageId: "2001",
+          platformMessageIds: ["2001"],
+        }),
+        visibleReplySent: true,
+      }),
+    );
+    expect(emitTelegramMessageSentHooks).toHaveBeenCalledOnce();
+    expect(emitTelegramMessageSentHooks).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "Pick one", success: false, messageId: 2001 }),
+    );
+    expect(registerChannelDelivery).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(answerDraftStream.update).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.stop).toHaveBeenCalled();
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(statusReactionController.setError).toHaveBeenCalledOnce());
   });
 
   it("falls back to normal delivery before rotating a stale queued block preview", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-rendering.test.ts
@@ -1,5 +1,17 @@
 import { setReplyPayloadMetadata } from "openclaw/plugin-sdk/reply-payload-testing";
-import { expect, it, vi } from "vitest";
+import { beforeEach, expect, it, vi } from "vitest";
+
+const registerChannelDelivery = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/question-gateway-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/question-gateway-runtime")>();
+  return {
+    ...actual,
+    questionGatewayRuntime: { ...actual.questionGatewayRuntime, registerChannelDelivery },
+  };
+});
+
+beforeEach(() => registerChannelDelivery.mockReset());
 import {
   describeTelegramDispatch,
   appendAssistantMirrorMessageByIdentity,
@@ -14,6 +26,7 @@ import {
   deliverReplies,
   dispatchReplyWithBufferedBlockDispatcher,
   dispatchWithContext,
+  editMessageReplyMarkupTelegram,
   editMessageTelegram,
   emitTelegramMessageSentHooks,
   expectDeliveredReply,
@@ -426,28 +439,46 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
     expectDeliveredReply(0, { text: "Post-processing failed", isError: true });
   });
 
-  it("streams button-bearing text into the same message", async () => {
+  it("registers a streamed ask_user on its concrete message exactly once", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    const buttons = [[{ text: "OK", callback_data: "ok" }]];
+    const buttons = [[{ text: "One", callback_data: "ask:one" }]];
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver(
-        { text: "Choose", channelData: { telegram: { buttons } } },
-        { kind: "final" },
+        {
+          text: "Pick one",
+          channelData: {
+            askUser: { questionId: "ask_0123456789abcdef0123456789abcdef" },
+            telegram: { buttons },
+          },
+        },
+        { kind: "tool" },
       );
       return { queuedFinal: true };
     });
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), textLimit: 80 });
 
-    expect(answerDraftStream.update).toHaveBeenCalledWith(
-      "Choose",
-      expect.objectContaining({ onPlatformSendDispatch: expect.any(Function) }),
-    );
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Pick one");
     expect(mockCallArg(editMessageTelegram)).toBe(123);
     expect(mockCallArg(editMessageTelegram, 0, 1)).toBe(2001);
-    expect(mockCallArg(editMessageTelegram, 0, 2)).toBe("Choose");
+    expect(mockCallArg(editMessageTelegram, 0, 2)).toBe("Pick one");
     expectRecordFields(mockCallArg(editMessageTelegram, 0, 3), { buttons });
     expect(deliverReplies).not.toHaveBeenCalled();
+    expect(registerChannelDelivery).toHaveBeenCalledOnce();
+    const registration = mockCallArg(registerChannelDelivery) as {
+      deliveryId: string;
+      finalize: (statusLine: string) => Promise<void>;
+    };
+    expect(registration.deliveryId).toBe("telegram:default:123:2001");
+    await registration.finalize(`Answered: ${"x".repeat(100)}`);
+    expect(editMessageReplyMarkupTelegram).toHaveBeenCalledWith(
+      123,
+      2001,
+      [],
+      expect.objectContaining({ accountId: "default" }),
+    );
+    const finalText = editMessageTelegram.mock.calls.at(-1)?.[2] as string;
+    expect(finalText.length).toBeLessThanOrEqual(80);
   });
 
   it("streams interactive buttons into the same message", async () => {
@@ -475,6 +506,36 @@ describeTelegramDispatch("dispatchTelegramMessage progress-rendering", () => {
       buttons: [[{ text: "OK", callback_data: "ok" }]],
     });
     expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("makes streamed ask_user control failure terminal without fallback", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    const statusReactionController = createStatusReactionController();
+    const context = createContext();
+    context.statusReactionController = statusReactionController as never;
+    editMessageTelegram.mockRejectedValueOnce(new Error("400: button rejected"));
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        {
+          text: "Pick one",
+          channelData: {
+            askUser: { questionId: "ask_0123456789abcdef0123456789abcdef" },
+            telegram: { buttons: [[{ text: "One", callback_data: "ask:one" }]] },
+          },
+        },
+        { kind: "tool" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context });
+
+    expect(registerChannelDelivery).not.toHaveBeenCalled();
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(statusReactionController.setError).toHaveBeenCalledOnce();
+    expect(emitTelegramMessageSentHooks).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, messageId: 2001 }),
+    );
   });
 
   it("streams reasoning and answer text on separate lanes", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.progress-updates.test.ts
@@ -293,7 +293,7 @@ describeTelegramDispatch("dispatchTelegramMessage progress-updates", () => {
       expectRecordFields(mockCallArg(emitTelegramMessageSentHooks), {
         content: "Photo",
         messageId: 2001,
-        success: true,
+        success: false,
       });
       expect(appendAssistantMirrorMessageByIdentity).toHaveBeenCalledTimes(1);
       expectRecordFields(mockCallArg(appendAssistantMirrorMessageByIdentity), {

--- a/extensions/telegram/src/bot-message-dispatch.test-harness.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test-harness.ts
@@ -45,6 +45,7 @@ const createForumTopicTelegramHoisted = vi.hoisted(() => vi.fn());
 const deleteMessageTelegramHoisted = vi.hoisted(() => vi.fn());
 const editForumTopicTelegramHoisted = vi.hoisted(() => vi.fn());
 const editMessageTelegramHoisted = vi.hoisted(() => vi.fn());
+const editMessageReplyMarkupTelegramHoisted = vi.hoisted(() => vi.fn());
 const reactMessageTelegramHoisted = vi.hoisted(() => vi.fn());
 const sendMessageTelegramHoisted = vi.hoisted(() => vi.fn());
 const sendPollTelegramHoisted = vi.hoisted(() => vi.fn());
@@ -128,6 +129,7 @@ const createForumTopicTelegram = createForumTopicTelegramHoisted;
 const deleteMessageTelegram = deleteMessageTelegramHoisted;
 const editForumTopicTelegram = editForumTopicTelegramHoisted;
 export const editMessageTelegram = editMessageTelegramHoisted;
+export const editMessageReplyMarkupTelegram = editMessageReplyMarkupTelegramHoisted;
 const reactMessageTelegram = reactMessageTelegramHoisted;
 export const sendMessageTelegram = sendMessageTelegramHoisted;
 const sendPollTelegram = sendPollTelegramHoisted;
@@ -273,6 +275,7 @@ vi.mock("./send.js", () => ({
   createForumTopicTelegram: createForumTopicTelegramHoisted,
   deleteMessageTelegram: deleteMessageTelegramHoisted,
   editForumTopicTelegram: editForumTopicTelegramHoisted,
+  editMessageReplyMarkupTelegram: editMessageReplyMarkupTelegramHoisted,
   editMessageTelegram: editMessageTelegramHoisted,
   reactMessageTelegram: reactMessageTelegramHoisted,
   sendMessageTelegram: sendMessageTelegramHoisted,
@@ -378,6 +381,7 @@ function resetTelegramDispatchTestState() {
   deleteMessageTelegram.mockReset();
   editForumTopicTelegram.mockReset();
   editMessageTelegram.mockReset();
+  editMessageReplyMarkupTelegram.mockReset();
   reactMessageTelegram.mockReset();
   sendMessageTelegram.mockReset();
   sendPollTelegram.mockReset();
@@ -422,6 +426,7 @@ function resetTelegramDispatchTestState() {
   deleteMessageTelegram.mockResolvedValue(true);
   editForumTopicTelegram.mockResolvedValue(true);
   editMessageTelegram.mockResolvedValue({ ok: true });
+  editMessageReplyMarkupTelegram.mockResolvedValue({ ok: true });
   reactMessageTelegram.mockResolvedValue(true);
   sendMessageTelegram.mockResolvedValue({ message_id: 1001 });
   sendPollTelegram.mockResolvedValue({ message_id: 1001 });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -507,7 +507,8 @@ export const dispatchTelegramMessage = async (
       {
         outcome:
           turn.agentRunFailed ||
-          (!turn.finalAnswerDelivered && (turn.dispatchError != null || sentFallback))
+          turn.dispatchError != null ||
+          (!turn.finalAnswerDelivered && sentFallback)
             ? "error"
             : "done",
       },

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -324,6 +324,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams): 
       }
     } else {
       await params.flushDraftLane(lane);
+      if (buttons) {
+        await stream.waitForInFlight();
+      }
     }
     const messageId = stream.messageId();
     if (typeof messageId !== "number") {
@@ -355,6 +358,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams): 
     const activeSnapshot =
       finalizePreview || buttons ? stream.currentMessageSnapshot?.() : undefined;
     let buttonsAttached = false;
+    let buttonAttachmentError: unknown;
     if (buttons && activeSnapshot) {
       try {
         await onPlatformSendDispatch?.();
@@ -367,14 +371,17 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams): 
         });
         buttonsAttached = true;
       } catch (err) {
+        buttonAttachmentError = err;
         params.log(`telegram: ${laneName} stream button edit failed: ${String(err)}`);
       }
     }
-    if (!finalizePreview) {
+    if (!finalizePreview && buttonAttachmentError === undefined) {
       return result("preview-updated");
     }
     if (!activeSnapshot) {
-      promptContextSequence.invalidate();
+      if (finalizePreview) {
+        promptContextSequence.invalidate();
+      }
       return undefined;
     }
     lane.finalized = true;
@@ -383,11 +390,15 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams): 
     if (!followedByDurablePayload) {
       await promptContextSequence.finish();
     }
-    return result("preview-finalized", {
+    const delivery = {
       content: previewText,
       messageId,
       buttonsAttached,
-    });
+      receipt: createPreviewMessageReceipt({ id: messageId }),
+    };
+    return buttonAttachmentError
+      ? { kind: "preview-finalized-partial", delivery, error: buttonAttachmentError }
+      : result("preview-finalized", delivery);
   };
 
   return async ({
@@ -473,6 +484,9 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams): 
         onPlatformSendDispatch,
       );
       if (finalizedPreview) {
+        if (finalizedPreview.kind === "preview-finalized-partial") {
+          return finalizedPreview;
+        }
         const stripButtons =
           finalizedPreview.kind === "preview-finalized" &&
           finalizedPreview.delivery.buttonsAttached === true;

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -860,7 +860,7 @@ describe("createLaneTextDeliverer", () => {
     );
   });
 
-  it("keeps inline buttons on late media when the stream button edit fails", async () => {
+  it("does not retry late media when the stream button edit fails", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     harness.lanes.answer.hasStreamedMessage = true;
     harness.editStreamMessage.mockRejectedValueOnce(new Error("400: button rejected"));
@@ -878,49 +878,15 @@ describe("createLaneTextDeliverer", () => {
       buttons,
     });
 
-    expectPreviewFinalized(result);
+    expect(result).toMatchObject({
+      kind: "preview-finalized-partial",
+      delivery: { messageId: 999, receipt: { primaryPlatformMessageId: "999" } },
+      error: expect.objectContaining({ message: "400: button rejected" }),
+    });
     expect(harness.log).toHaveBeenCalledWith(
       "telegram: answer stream button edit failed: Error: 400: button rejected",
     );
-    expectSentPayload(
-      harness,
-      {
-        mediaUrl: "https://example.com/a.png",
-        channelData: { telegram: { buttons, effect: "spark" }, other: true },
-      },
-      true,
-    );
-  });
-
-  it("preserves derived inline buttons on late media when the stream button edit fails", async () => {
-    const harness = createHarness({ answerMessageId: 999 });
-    harness.lanes.answer.hasStreamedMessage = true;
-    harness.editStreamMessage.mockRejectedValueOnce(new Error("400: button rejected"));
-    const buttons = [[{ text: "OK", callback_data: "ok" }]];
-
-    const result = await harness.deliverLaneText({
-      laneName: "answer",
-      text: "photo",
-      payload: {
-        text: "photo",
-        mediaUrl: "https://example.com/a.png",
-        interactive: {
-          blocks: [{ type: "buttons", buttons: [{ label: "OK", value: "ok" }] }],
-        },
-      },
-      infoKind: "final",
-      buttons,
-    });
-
-    expectPreviewFinalized(result);
-    expectSentPayload(
-      harness,
-      {
-        mediaUrl: "https://example.com/a.png",
-        channelData: { telegram: { buttons } },
-      },
-      true,
-    );
+    expect(harness.sendPayload).not.toHaveBeenCalled();
   });
 
   it("records the exact rendered draft pages in Telegram message order", async () => {
@@ -1233,7 +1199,29 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.sendPayload).not.toHaveBeenCalled();
   });
 
-  it("keeps the stream delivery when button attachment fails", async () => {
+  it("waits for a concrete streamed tool message before attaching buttons", async () => {
+    const answer = createTestDraftStream();
+    answer.waitForInFlight.mockImplementation(async () => answer.setMessageId(999));
+    const harness = createHarness({ answerStream: answer });
+    const buttons = [[{ text: "OK", callback_data: "ok" }]];
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: HELLO_FINAL,
+      payload: { text: HELLO_FINAL, channelData: { telegram: { buttons } } },
+      infoKind: "tool",
+      buttons,
+    });
+
+    expect(answer.waitForInFlight).toHaveBeenCalledOnce();
+    expect(result.kind).toBe("preview-updated");
+    expect(harness.editStreamMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 999, buttons }),
+    );
+    expect(harness.sendPayload).not.toHaveBeenCalled();
+  });
+
+  it("reports a finalized preview as partial when button attachment fails", async () => {
     const harness = createHarness({ answerMessageId: 999 });
     const buttons = [[{ text: "OK", callback_data: "ok" }]];
     harness.editStreamMessage.mockRejectedValue(new Error("400: button rejected"));
@@ -1246,9 +1234,15 @@ describe("createLaneTextDeliverer", () => {
       buttons,
     });
 
-    const delivery = expectPreviewFinalized(result);
-    expect(delivery.content).toBe(HELLO_FINAL);
-    expect(delivery.messageId).toBe(999);
+    expect(result).toMatchObject({
+      kind: "preview-finalized-partial",
+      delivery: {
+        content: HELLO_FINAL,
+        messageId: 999,
+        receipt: { primaryPlatformMessageId: "999" },
+      },
+      error: expect.objectContaining({ message: "400: button rejected" }),
+    });
     expect(harness.sendPayload).not.toHaveBeenCalled();
     expect(harness.log).toHaveBeenCalledWith(
       "telegram: answer stream button edit failed: Error: 400: button rejected",

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -10,7 +10,6 @@ import {
   createAttachedChannelResultAdapter,
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
-import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import {
   resolveSendableOutboundReplyParts,
@@ -32,6 +31,7 @@ import {
   createTelegramPromptContextProjectionCursor,
   resolveTelegramPromptContextSource,
 } from "./prompt-context-projection.js";
+import { registerTelegramQuestionDelivery } from "./question-finalization.js";
 import { loadTelegramSendModule, type TelegramSendModule } from "./send-runtime.js";
 import { normalizeTelegramOutboundTarget, parseTelegramTarget } from "./targets.js";
 
@@ -505,7 +505,6 @@ export function createTelegramOutboundAdapter(
         },
       ),
     afterDeliverPayload: ({ cfg, target, payload, results }) => {
-      const questionId = questionGatewayRuntime.readAskUserQuestionId(payload);
       const telegramResults = results.filter(
         (candidate) => candidate.channel === "telegram" && candidate.messageId,
       );
@@ -517,22 +516,35 @@ export function createTelegramOutboundAdapter(
           ? result.meta.telegramDeliveredText
           : payload.text
       )?.trim();
-      if (!questionId || !result || !text) {
+      if (!result || !text) {
         return;
       }
       const chatId =
         result.target?.kind === "chat"
           ? result.target.id
           : normalizeTelegramOutboundTarget(target.to);
-      questionGatewayRuntime.registerChannelDelivery({
-        questionId,
-        deliveryId: `telegram:${target.accountId ?? "default"}:${chatId}:${result.messageId}`,
-        finalize: async (statusLine) => {
-          const { editMessageTelegram } = await loadSendModule();
-          await editMessageTelegram(chatId, result.messageId, `${text}\n\n${statusLine}`, {
+      const messageId = result.messageId;
+      const accountId = target.accountId ?? undefined;
+      registerTelegramQuestionDelivery({
+        accountId,
+        chatId,
+        messageId,
+        payload,
+        text,
+        textLimit: TELEGRAM_TEXT_CHUNK_LIMIT,
+        clearButtons: async () => {
+          const { editMessageReplyMarkupTelegram } = await loadSendModule();
+          await editMessageReplyMarkupTelegram(chatId, messageId, [], {
             cfg,
-            accountId: target.accountId ?? undefined,
-            buttons: [],
+            accountId,
+            verbose: false,
+          });
+        },
+        annotate: async (finalText) => {
+          const { editMessageTelegram } = await loadSendModule();
+          await editMessageTelegram(chatId, messageId, finalText, {
+            cfg,
+            accountId,
             verbose: false,
           });
         },

--- a/extensions/telegram/src/question-finalization.test.ts
+++ b/extensions/telegram/src/question-finalization.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   edit: vi.fn(),
+  editMarkup: vi.fn(),
   registration: undefined as
     | { finalize: (statusLine: string) => void | Promise<void>; deliveryId: string }
     | undefined,
@@ -20,12 +21,17 @@ vi.mock("openclaw/plugin-sdk/question-gateway-runtime", async (importOriginal) =
     },
   };
 });
-vi.mock("./send.js", () => ({ editMessageTelegram: hoisted.edit }));
+vi.mock("./send.js", () => ({
+  editMessageReplyMarkupTelegram: hoisted.editMarkup,
+  editMessageTelegram: hoisted.edit,
+}));
 
 import { createTelegramOutboundAdapter } from "./outbound-adapter.js";
 
 describe("Telegram question finalization", () => {
   it("removes buttons and appends terminal status", async () => {
+    const deliveredText = "x".repeat(5000);
+    const statusLine = `Answered: ${"y".repeat(600)}`;
     const outbound = createTelegramOutboundAdapter();
     await outbound.afterDeliverPayload?.({
       cfg: {},
@@ -47,17 +53,22 @@ describe("Telegram question finalization", () => {
           channel: "telegram",
           messageId: "55",
           target: { kind: "chat", id: "123" },
-          meta: { telegramDeliveredText: "Pick one", telegramHasInlineKeyboard: true },
+          meta: { telegramDeliveredText: deliveredText, telegramHasInlineKeyboard: true },
         },
       ],
     });
 
-    await hoisted.registration?.finalize("Answered: One");
-    expect(hoisted.edit).toHaveBeenCalledWith("123", "55", "Pick one\n\nAnswered: One", {
+    await hoisted.registration?.finalize(statusLine);
+    expect(hoisted.editMarkup).toHaveBeenCalledWith("123", "55", [], {
       cfg: {},
       accountId: "default",
-      buttons: [],
       verbose: false,
     });
+    const annotatedText = hoisted.edit.mock.calls[0]?.[2] as string;
+    expect(annotatedText.length).toBeLessThanOrEqual(4000);
+    expect(annotatedText).toContain("\n\nAnswered: ");
+    expect(hoisted.editMarkup.mock.invocationCallOrder[0]).toBeLessThan(
+      hoisted.edit.mock.invocationCallOrder[0] ?? Infinity,
+    );
   });
 });

--- a/extensions/telegram/src/question-finalization.ts
+++ b/extensions/telegram/src/question-finalization.ts
@@ -1,0 +1,34 @@
+import { questionGatewayRuntime } from "openclaw/plugin-sdk/question-gateway-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+
+export function registerTelegramQuestionDelivery(params: {
+  accountId?: string;
+  chatId: string;
+  messageId: string | number;
+  payload: ReplyPayload;
+  text: string;
+  textLimit: number;
+  clearButtons: () => Promise<void>;
+  annotate: (text: string) => Promise<void>;
+}): void {
+  const questionId = questionGatewayRuntime.readAskUserQuestionId(params.payload);
+  const text = params.text.trim();
+  if (!questionId || !text) {
+    return;
+  }
+  const { accountId, chatId, messageId, textLimit, clearButtons, annotate } = params;
+  const deliveryId = `telegram:${accountId ?? "default"}:${chatId}:${messageId}`;
+  questionGatewayRuntime.registerChannelDelivery({
+    questionId,
+    deliveryId,
+    finalize: async (statusLine) => {
+      await clearButtons();
+      const limit = Math.max(0, Math.floor(textLimit));
+      const suffix = truncateUtf16Safe(statusLine.trim(), Math.min(512, limit));
+      const separator = suffix && limit - suffix.length >= 2 ? "\n\n" : "";
+      const prefix = truncateUtf16Safe(text, limit - separator.length - suffix.length);
+      await annotate(`${prefix}${separator}${suffix}`);
+    },
+  });
+}

--- a/src/agents/tools/ask-user-tool.test.ts
+++ b/src/agents/tools/ask-user-tool.test.ts
@@ -1,5 +1,6 @@
 import { Value } from "typebox/value";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReplyDispatchDeliveryError } from "../../auto-reply/reply/reply-dispatch-outcome.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
 import { steerActiveSessionWithOptionalDeliveryWait } from "../embedded-agent-runner/run/attempt-queue-message.js";
 import {
@@ -568,7 +569,7 @@ describe("ask_user execution", () => {
     );
   });
 
-  it("cancels instead of waiting when originating prompt delivery fails", async () => {
+  it("terminates after a visible prompt fails to attach its controls", async () => {
     const sessionKey = "agent:main:delivery-failure";
     const reservation = reserveAskUserPromptDelivery({
       toolCallId: "call-delivery-failure",
@@ -600,9 +601,16 @@ describe("ask_user execution", () => {
     );
     await vi.waitFor(() => expect(finishWait).toBeTypeOf("function"));
 
-    settleAskUserPromptDelivery(reservation.questionId, new Error("channel unavailable"));
+    settleAskUserPromptDelivery(
+      reservation.questionId,
+      new ReplyDispatchDeliveryError("failed-deliver"),
+    );
 
-    await expect(pending).rejects.toThrow("ask_user prompt delivery failed");
+    await expect(pending).resolves.toMatchObject({
+      terminate: true,
+      details: { status: "delivery_failed" },
+      content: [expect.objectContaining({ text: expect.stringMatching(/no retry\/fallback/i) })],
+    });
     expect(gateway.mock).toHaveBeenCalledWith(
       "question.resolve",
       { timeoutMs: 10_000 },
@@ -648,7 +656,10 @@ describe("ask_user execution", () => {
     );
     await vi.waitFor(() => expect(waitCalls).toBe(1));
 
-    settleAskUserPromptDelivery(reservation.questionId, new Error("channel unavailable"));
+    settleAskUserPromptDelivery(
+      reservation.questionId,
+      new ReplyDispatchDeliveryError("failed-deliver"),
+    );
 
     await expect(pending).resolves.toMatchObject({ details: { status: "answered", answers } });
     expect(waitCalls).toBe(2);

--- a/src/agents/tools/ask-user-tool.ts
+++ b/src/agents/tools/ask-user-tool.ts
@@ -6,6 +6,7 @@ import type {
   QuestionRequestQuestion,
   QuestionWaitAnswerResult,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { isReplyDispatchDeliveryError } from "../../auto-reply/reply/reply-dispatch-outcome.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { registerPendingAgentQuestion } from "../harness/gateway-question.js";
 import { ASK_USER_TOOL_DISPLAY_SUMMARY, describeAskUserTool } from "../tool-description-presets.js";
@@ -654,6 +655,19 @@ export function createAskUserTool(params: {
             const answered = await cancelPendingQuestion("prompt-delivery-failed");
             if (answered) {
               return answeredResult(normalized.questions, answered.answers);
+            }
+            if (
+              isReplyDispatchDeliveryError(deliveryResult.error) &&
+              deliveryResult.error.outcome === "failed-deliver"
+            ) {
+              const details = { status: "delivery_failed" as const };
+              return {
+                ...textResult(
+                  `The prompt became visible, but its controls failed to deliver. The question was cancelled; no retry/fallback should be sent.\n\n${JSON.stringify(details, null, 2)}`,
+                  details,
+                ),
+                terminate: true,
+              };
             }
             throw new Error("ask_user prompt delivery failed", { cause: deliveryResult.error });
           }

--- a/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.routing.test-utils.ts
@@ -26,6 +26,7 @@ import {
   globalBeforeAll0,
   describe0BeforeEach0,
 } from "./dispatch-from-config.test-harness.js";
+import { isReplyDispatchDeliveryError } from "./reply-dispatch-outcome.js";
 import { createReplyDispatcher } from "./reply-dispatcher.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 import { buildTestCtx } from "./test-ctx.js";
@@ -429,13 +430,13 @@ describe("dispatchReplyFromConfig", () => {
   });
 
   it.each([
-    ["cancelled", "cancelled", true],
-    ["failed before transport", "failed-before-deliver", true],
-    ["delivered", "delivered", false],
-    ["failed during transport", "failed-deliver", false],
+    ["cancelled", "cancelled", true, undefined],
+    ["failed before transport", "failed-before-deliver", true, undefined],
+    ["delivered", "delivered", false, undefined],
+    ["failed during transport", "failed-deliver", true, "failed-deliver"],
   ] as const)(
     "settles ask_user delivery when the prompt is %s",
-    async (_name, outcome, rejects) => {
+    async (_name, outcome, rejects, expectedOutcome) => {
       hookMocks.runner.hasHooks.mockReturnValue(false);
       const deliver = vi.fn(async (_payload: ReplyPayload, info: { kind: string }) => {
         if (outcome === "failed-deliver" && info.kind === "tool") {
@@ -472,7 +473,13 @@ describe("dispatchReplyFromConfig", () => {
         },
       });
 
-      if (rejects) {
+      if (expectedOutcome) {
+        const error = await dispatch.catch((caught: unknown) => caught);
+        expect(isReplyDispatchDeliveryError(error)).toBe(true);
+        if (isReplyDispatchDeliveryError(error)) {
+          expect(error.outcome).toBe(expectedOutcome);
+        }
+      } else if (rejects) {
         await expect(dispatch).rejects.toThrow();
       } else {
         await expect(dispatch).resolves.toMatchObject({ queuedFinal: true });

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { createReplyTurnLedger } from "./dispatch-from-config.turn-ledger.js";
-import { createReplyDispatcher } from "./reply-dispatcher.js";
+import {
+  createReplyTurnLedger,
+  requireQueuedReplyDelivery,
+} from "./dispatch-from-config.turn-ledger.js";
+import { isReplyDispatchDeliveryError } from "./reply-dispatch-outcome.js";
+import { createReplyDispatcher, type ReplyDispatchDeliveryOutcome } from "./reply-dispatcher.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.types.js";
 
 function createUntrackedDispatcher(overrides: Partial<ReplyDispatcher> = {}): ReplyDispatcher {
@@ -15,6 +19,35 @@ function createUntrackedDispatcher(overrides: Partial<ReplyDispatcher> = {}): Re
     ...overrides,
   };
 }
+
+describe("requireQueuedReplyDelivery", () => {
+  it.each([
+    ["delivered", true],
+    ["delivered-not-visible", false],
+    ["cancelled", false],
+    ["failed-before-deliver", false],
+    ["failed-deliver", false],
+  ] satisfies Array<[ReplyDispatchDeliveryOutcome, boolean]>)(
+    "requires canonical %s delivery",
+    async (outcome, accepted) => {
+      const delivery = requireQueuedReplyDelivery({
+        delivery: { queued: true, outcome: Promise.resolve(outcome) },
+        dispatcher: { waitForIdle: async () => undefined },
+        abortSignal: undefined,
+      });
+
+      if (accepted) {
+        await expect(delivery).resolves.toBeUndefined();
+        return;
+      }
+      const error = await delivery.catch((caught: unknown) => caught);
+      expect(isReplyDispatchDeliveryError(error)).toBe(true);
+      if (isReplyDispatchDeliveryError(error)) {
+        expect(error.outcome).toBe(outcome);
+      }
+    },
+  );
+});
 
 describe("createReplyTurnLedger", () => {
   it("counts a delivered contentful payload as visible after settlement", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
@@ -6,9 +6,9 @@
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "../reply-payload.js";
 import { runWithDispatchAbortSignal } from "./dispatch-from-config.abort.js";
+import { ReplyDispatchDeliveryError } from "./reply-dispatch-outcome.js";
 import {
   captureReplyDispatchDeliveryOutcome,
-  isReplyDispatchProvenInvisible,
   type ReplyDispatchDeliveryOutcome,
   waitForReplyDispatcherIdle,
 } from "./reply-dispatcher.js";
@@ -58,8 +58,8 @@ export async function requireQueuedReplyDelivery(params: {
     return;
   }
   const settledOutcome = await runWithDispatchAbortSignal(params.abortSignal, () => outcome);
-  if (isReplyDispatchProvenInvisible(settledOutcome)) {
-    throw new Error("queued reply delivery failed");
+  if (settledOutcome !== "delivered") {
+    throw new ReplyDispatchDeliveryError(settledOutcome);
   }
 }
 

--- a/src/auto-reply/reply/reply-dispatch-outcome.ts
+++ b/src/auto-reply/reply/reply-dispatch-outcome.ts
@@ -8,6 +8,17 @@ export type ReplyDispatchDeliveryOutcome =
   | "failed-before-deliver"
   | "failed-deliver";
 
+export class ReplyDispatchDeliveryError extends Error {
+  constructor(readonly outcome: ReplyDispatchDeliveryOutcome) {
+    super("queued reply delivery failed");
+    this.name = "ReplyDispatchDeliveryError";
+  }
+}
+
+export function isReplyDispatchDeliveryError(error: unknown): error is ReplyDispatchDeliveryError {
+  return error instanceof ReplyDispatchDeliveryError;
+}
+
 export function isReplyDispatchProvenInvisible(outcome: ReplyDispatchDeliveryOutcome): boolean {
   return outcome !== "delivered" && outcome !== "failed-deliver";
 }

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -67,7 +67,7 @@ type ReplyDispatchCancelHandler = (
   info: ReplyDispatchRuntimeInfo,
 ) => Promise<void> | void;
 
-export { isReplyDispatchProvenInvisible, type ReplyDispatchDeliveryOutcome };
+export type { ReplyDispatchDeliveryOutcome };
 
 function isRetryableNoSendFailure(error: unknown): boolean {
   return (


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where streamed Telegram ask_user prompts could bypass question registration, report button attachment failure as success, or generate a duplicate fallback after a visible partial delivery.

## Why This Change Was Made

Register the concrete preview message, share control-first bounded finalization with durable delivery, and treat visible-but-unusable prompts as terminal delivery failures while preserving answer races.

## User Impact

Telegram questions finalize on the same message, clear buttons when answered, and cancel cleanly without duplicate output when controls fail.

## Evidence

- 112 Telegram tests and 45 core delivery/tool tests passed.
- Core/plugin production and test typechecks, `node scripts/check-changed.mjs`, `pnpm build`, and autoreview passed.
- Production LOC +165/-22 (net +143); tests/support +182/-67.
- AI-assisted; maintainer reviewed the implementation and proof.
