### PR TITLE
refactor(google-meet): use explicit test API boundary

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -424,7 +424,6 @@ const config = {
     "src/system-agent/greeting.ts": ["exports", "types"],
     // Focused tests consume these diagnostic/test seams; production code uses
     // the surrounding runtime helpers rather than importing the exports.
-    "extensions/google-meet/src/plugin-registration.ts": ["exports"],
     "extensions/signal/src/setup-core.ts": ["exports"],
     // Focused CLI tests exercise plan construction through this explicit test seam.
     "extensions/onepassword/src/secret-ref-cli.ts": ["exports"],

--- a/extensions/google-meet/index.create.test.ts
+++ b/extensions/google-meet/index.create.test.ts
@@ -5,13 +5,13 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vites
 import plugin from "./index.js";
 import { registerGoogleMeetCli } from "./src/cli.js";
 import { resolveGoogleMeetConfig } from "./src/config.js";
-import { testing as googleMeetPluginTesting } from "./src/plugin-registration.js";
 import type { GoogleMeetRuntime } from "./src/runtime.js";
 import {
   captureStdout,
   invokeGoogleMeetGatewayMethodForTest,
   setupGoogleMeetPlugin,
 } from "./src/test-support/plugin-harness.js";
+import { testing as googleMeetPluginTesting } from "./test-api.js";
 
 const voiceCallMocks = vi.hoisted(() => ({
   createVoiceCallGateway: vi.fn(

--- a/extensions/google-meet/index.test.ts
+++ b/extensions/google-meet/index.test.ts
@@ -38,7 +38,6 @@ import {
   fetchGoogleMeetSpace,
 } from "./src/meet.js";
 import { handleGoogleMeetNodeHostCommand } from "./src/node-host.js";
-import { testing as googleMeetPluginTesting } from "./src/plugin-registration.js";
 import {
   meetAudioBridge,
   meetBrowserState,
@@ -62,6 +61,7 @@ import {
   normalizeDialInNumber,
   prefixDtmfWait,
 } from "./src/transports/twilio.js";
+import { testing as googleMeetPluginTesting } from "./test-api.js";
 
 type GoogleMeetManifestConfigSchema = JsonSchemaObject & {
   properties?: Record<string, JsonSchemaObject & { properties?: Record<string, unknown> }>;

--- a/extensions/google-meet/test-api.ts
+++ b/extensions/google-meet/test-api.ts
@@ -1,0 +1,2 @@
+// Google Meet test API exposes owner hooks without widening the runtime entrypoint.
+export { testing } from "./src/plugin-registration.js";


### PR DESCRIPTION
Related: #126223

## What Problem This Solves

The Google Meet follow-up to #126223 still modeled a test-only owner export as an allowed unused production export. That hid the test seam from Knip instead of routing it through the repository's explicit extension test API boundary.

## Why This Change Was Made

Adds a local `test-api.ts` barrel for the existing Google Meet testing hooks, routes both local behavior suites through it, and removes only the Google Meet `ignoreIssues` entry from the Knip configuration. The runtime plugin entrypoint remains unchanged and does not export `testing`; no package export is added because the consumers are local tests.

## User Impact

No user-visible or runtime behavior changes. The test-only seam is now explicit and remains outside the runtime plugin API.

## Evidence

- `node scripts/run-vitest.mjs extensions/google-meet/index.test.ts extensions/google-meet/index.create.test.ts` — 2 files, 178 tests passed.
- `node scripts/run-vitest.mjs src/plugins/contracts/extension-test-api-consumption.test.ts` — 1 file, 3 tests passed, including the repository-wide consumed-test-API contract.
- `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts` — 1 file, 18 tests passed after rebasing onto #126236, which repaired the unrelated Vitest inventory failure observed in the first exact-head CI run.
- `node scripts/check-changed.mjs -- config/knip.config.ts extensions/google-meet/test-api.ts extensions/google-meet/index.test.ts extensions/google-meet/index.create.test.ts` — passed; production and full-tree Knip scans both reported zero unused exports, extension production/test typechecks passed, lint passed, and runtime import cycles remained zero.
- `pnpm build` — passed; full dist, plugin, SDK export, runtime postbuild, and Control UI build completed.
- `git diff --cached --check` — passed before commit.
- `rg` confirms there is no Google Meet `plugin-registration.ts` Knip ignore, no test deep-import of that module, and no `testing` export from `extensions/google-meet/index.ts`.
- LOC classification: production runtime `+0/-0`; test support `+2/-0`; tests `+2/-2`; tooling `+0/-1`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output ...` — clean on the rebased branch, no accepted/actionable findings; patch correct with 0.99 confidence.
- CI recovery: initial exact-head run `32229161511` failed only because current `main` temporarily assigned `extensions/codex/src/app-server/run-attempt-tools.test.ts` to three Vitest configs. The canonical fix landed independently in #126236; this branch was rebased onto that commit without adding unrelated files.
