### PR TITLE
fix(codex): prevent node process control from targeting gateway sessions

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -57,18 +57,19 @@ existing per-session OpenClaw process scope for background follow-up. Prefer
 Codex native shell for ordinary local work.
 
 With the default `tools.exec.host: "auto"` and no active OpenClaw sandbox,
-Codex also receives `node_exec` and `node_process` tools for commands on paired
-nodes. Native shell remains on the Codex app-server host and workspace
+Codex also receives `node_exec` for commands on paired nodes. Native shell
+remains on the Codex app-server host and workspace
 (Gateway-local for the default stdio deployment); `node_exec` selects a node by
-name or id and keeps OpenClaw's node approval policy in force. If a finite
-runtime allowlist disables native Code Mode and leaves the turn without an
-execution environment, OpenClaw keeps its policy-filtered `exec` and `process`
-tools available instead for direct, unsandboxed execution.
+name or id, keeps OpenClaw's node approval policy in force, and waits for the
+remote command to finish. Remote-node background follow-up is not available. If
+a finite runtime allowlist disables native Code Mode and leaves the turn without
+an execution environment, OpenClaw keeps its policy-filtered `exec` and
+`process` tools available instead for direct, unsandboxed execution.
 
 When `tools.exec.host: "node"` or `/exec host=node` makes the node the session
-default, OpenClaw hides the Codex-native shell and exposes `node_exec` and
-`node_process` as the shell path. This keeps the configured execution host from
-silently falling back to the app-server or Gateway machine.
+default, OpenClaw hides the Codex-native shell and exposes `node_exec` as the
+shell path. This keeps the configured execution host from silently falling
+back to the app-server or Gateway machine.
 
 `gateway_exec` is not exposed when an active OpenClaw sandbox, a node-default
 execution policy, memory-flush restrictions, tool allow/deny policy, or

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -1350,8 +1350,12 @@ describe("Codex app-server dynamic tool build", () => {
           security: { type: "string" },
           ask: { type: "string" },
           node: { type: "string" },
+          background: { type: "boolean" },
+          yieldMs: { type: "number" },
+          pty: { type: "boolean" },
+          elevated: { type: "boolean" },
         },
-        required: ["command", "host", "node"],
+        required: ["command", "host", "node", "background", "yieldMs", "pty", "elevated"],
         additionalProperties: false,
       },
     };
@@ -1364,12 +1368,7 @@ describe("Codex app-server dynamic tool build", () => {
       ],
       details: { status: "running" },
     });
-    const processTool = createRuntimeDynamicTool("process");
-    setOpenClawCodingToolsFactoryForTests(() => [
-      execTool,
-      processTool,
-      createRuntimeDynamicTool("message"),
-    ]);
+    setOpenClawCodingToolsFactoryForTests(() => [execTool, createRuntimeDynamicTool("message")]);
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
@@ -1388,11 +1387,10 @@ describe("Codex app-server dynamic tool build", () => {
     });
 
     expect(nativeToolSurfaceEnabled).toBe(false);
-    expect(tools.map((tool) => tool.name)).toEqual(["message", "node_exec", "node_process"]);
+    expect(tools.map((tool) => tool.name)).toEqual(["message", "node_exec"]);
     const nodeExec = tools.find((tool) => tool.name === "node_exec");
-    const nodeProcess = tools.find((tool) => tool.name === "node_process");
     expect(nodeExec?.description).toContain("host=node internally");
-    expect(nodeProcess?.description).toContain("background shell sessions");
+    expect(nodeExec?.description).toContain("background follow-up is unavailable");
     expect(nodeExec?.parameters).toEqual({
       type: "object",
       properties: {
@@ -1410,6 +1408,10 @@ describe("Codex app-server dynamic tool build", () => {
         node: "model-selected-node",
         security: "full",
         ask: "off",
+        background: true,
+        yieldMs: 10,
+        pty: true,
+        elevated: true,
       },
       undefined,
     );
@@ -1426,7 +1428,7 @@ describe("Codex app-server dynamic tool build", () => {
     expect(result?.content).toEqual([
       {
         type: "text",
-        text: "Command still running (session exec-1, pid 123). Use remote-node background-session control (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up when available.",
+        text: "Command still running (session exec-1, pid 123). Remote-node background follow-up is unavailable. Wait for the command to complete.",
       },
     ]);
 
@@ -1456,14 +1458,10 @@ describe("Codex app-server dynamic tool build", () => {
     });
 
     expect(runtimePolicyNativeToolSurfaceEnabled).toBe(false);
-    expect(runtimePolicyTools.map((tool) => tool.name)).toEqual([
-      "message",
-      "node_exec",
-      "node_process",
-    ]);
+    expect(runtimePolicyTools.map((tool) => tool.name)).toEqual(["message", "node_exec"]);
   });
 
-  it("exposes selectable node shell tools beside native shell for auto host runs", async () => {
+  it("does not expose Gateway process sessions as remote-node control in auto host runs", async () => {
     const execTool = {
       ...createRuntimeDynamicTool("exec"),
       parameters: {
@@ -1504,8 +1502,39 @@ describe("Codex app-server dynamic tool build", () => {
       "gateway_exec",
       "gateway_process",
       "node_exec",
-      "node_process",
     ]);
+    const bridge = createCodexDynamicToolBridge({
+      tools,
+      signal: new AbortController().signal,
+      loading: "direct",
+    });
+    const gatewayList = await bridge.handleToolCall({
+      threadId: "auto-thread",
+      turnId: "auto-turn",
+      tool: "gateway_process",
+      callId: "gateway-process-list",
+      arguments: { action: "list" },
+    });
+    expect(gatewayList.success).toBe(true);
+    expect(processTool.execute).toHaveBeenCalledWith(
+      "gateway-process-list",
+      { action: "list" },
+      expect.any(AbortSignal),
+      undefined,
+    );
+    vi.mocked(processTool.execute).mockClear();
+    const nodeList = await bridge.handleToolCall({
+      threadId: "auto-thread",
+      turnId: "auto-turn",
+      tool: "node_process",
+      callId: "node-process-list",
+      arguments: { action: "list" },
+    });
+    expect(nodeList.success).toBe(false);
+    expect(nodeList.contentItems).toEqual([
+      { type: "inputText", text: "Unknown OpenClaw tool: node_process" },
+    ]);
+    expect(processTool.execute).not.toHaveBeenCalled();
     const nodeExec = tools.find((tool) => tool.name === "node_exec");
     expect(nodeExec?.description).toContain("Select the node by name or id");
     expect(nodeExec?.parameters).toEqual({
@@ -1621,13 +1650,7 @@ describe("Codex app-server dynamic tool build", () => {
     });
 
     expect(nativeToolSurfaceEnabled).toBe(false);
-    expect(tools.map((tool) => tool.name)).toEqual([
-      "exec",
-      "process",
-      "message",
-      "node_exec",
-      "node_process",
-    ]);
+    expect(tools.map((tool) => tool.name)).toEqual(["exec", "process", "message", "node_exec"]);
 
     const bridge = createCodexDynamicToolBridge({
       tools,
@@ -1711,7 +1734,6 @@ describe("Codex app-server dynamic tool build", () => {
       "process",
       "message",
       "node_exec",
-      "node_process",
     ]);
   });
 

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -46,9 +46,8 @@ import {
   CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME,
   CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
   CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
-  CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME,
   createExecAliasDynamicTool,
-  createProcessAliasDynamicTool,
+  createGatewayProcessAliasDynamicTool,
   isCodexDynamicToolExcluded,
 } from "./shell-dynamic-tools.js";
 import { filterCodexVisionTools } from "./vision-tools.js";
@@ -581,7 +580,7 @@ function addGatewayShellDynamicToolsIfAvailable(
     }),
   ];
   if (processAliasAvailable && processTool) {
-    toolsToAppend.push(createProcessAliasDynamicTool(processTool, "gateway"));
+    toolsToAppend.push(createGatewayProcessAliasDynamicTool(processTool));
   }
   return [...filteredTools, ...toolsToAppend];
 }
@@ -870,35 +869,21 @@ function addNodeShellDynamicToolsIfNeeded(
     return filteredTools;
   }
   const execTool = allTools.find((tool) => normalizeCodexDynamicToolName(tool.name) === "exec");
-  const processTool = allTools.find(
-    (tool) => normalizeCodexDynamicToolName(tool.name) === "process",
-  );
-  if (!execTool || !processTool) {
+  if (!execTool) {
     return filteredTools;
   }
-  const toolsToAppend: OpenClawDynamicTool[] = [];
   if (
     !isCodexDynamicToolExcluded(input.pluginConfig, ["exec", CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME]) &&
     !filteredTools.some(
       (tool) => normalizeCodexDynamicToolName(tool.name) === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
     )
   ) {
-    toolsToAppend.push(
+    return [
+      ...filteredTools,
       createExecAliasDynamicTool(execTool, { host: "node", node: nodePolicy.node }),
-    );
+    ];
   }
-  if (
-    !isCodexDynamicToolExcluded(input.pluginConfig, [
-      "process",
-      CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME,
-    ]) &&
-    !filteredTools.some(
-      (tool) => normalizeCodexDynamicToolName(tool.name) === CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME,
-    )
-  ) {
-    toolsToAppend.push(createProcessAliasDynamicTool(processTool, "node"));
-  }
-  return toolsToAppend.length > 0 ? [...filteredTools, ...toolsToAppend] : filteredTools;
+  return filteredTools;
 }
 function shouldKeepOpenClawShellDynamicTools(
   input: DynamicToolBuildParams,
@@ -952,9 +937,7 @@ function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(
       (normalized === CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME && allowSet.has("exec")) ||
       (normalized === CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME &&
         (allowSet.has("exec") || allowSet.has("process"))) ||
-      (normalized === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME && allowSet.has("exec")) ||
-      (normalized === CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME &&
-        (allowSet.has("exec") || allowSet.has("process")))
+      (normalized === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME && allowSet.has("exec"))
     );
   });
 }

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -9,10 +9,16 @@ type ExecAliasParams =
   | { host: "node"; node?: string };
 
 export const CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME = "node_exec";
-export const CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME = "node_process";
 export const CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME = "gateway_exec";
 export const CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME = "gateway_process";
 const CODEX_EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
+const CODEX_NODE_EXEC_PARAMETER_NAMES = new Set([
+  "command",
+  "workdir",
+  "env",
+  "timeoutSeconds",
+  "node",
+]);
 const PROCESS_FOLLOWUP_TEXT =
   "Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.";
 
@@ -37,11 +43,11 @@ export function createExecAliasDynamicTool(
   const name = nodeAlias ? CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME : CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME;
   const description = nodeAlias
     ? pinnedNode
-      ? "Run a shell command on the OpenClaw configured remote node for this session. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Use remote-node background-session control for follow-up when available. Use Codex's native shell for local app-server work."
-      : "Run a shell command on an OpenClaw remote node. Select the node by name or id when multiple nodes are available. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Use remote-node background-session control for follow-up when available. Use Codex's native shell for local app-server work."
+      ? "Run a shell command to completion on the OpenClaw configured remote node for this session. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work."
+      : "Run a shell command to completion on an OpenClaw remote node. Select the node by name or id when multiple nodes are available. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work."
     : "Run a shell command through OpenClaw on the Gateway host for OpenClaw-managed Gateway environment access, including Secret Store agent-readable environment values and protected egress sentinels. Native Codex shell remains preferred for ordinary local work. This tool always uses OpenClaw host=gateway internally and follows Gateway exec approval and allowlist policy.";
   const followupText = nodeAlias
-    ? "Use remote-node background-session control (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up when available."
+    ? "Remote-node background follow-up is unavailable. Wait for the command to complete."
     : gatewayProcessAliasAvailable
       ? "Use gateway_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up."
       : "Background session follow-up is unavailable because gateway_process is not exposed. Rerun without background=true and set yieldMs high enough to wait for completion.";
@@ -52,6 +58,7 @@ export function createExecAliasDynamicTool(
     parameters: hideExecDynamicToolParameters(
       execTool.parameters,
       !nodeAlias || Boolean(pinnedNode),
+      nodeAlias,
     ),
     execute: async (toolCallId, args, signal, onUpdate) => {
       const result = await execTool.execute(
@@ -74,18 +81,15 @@ export function createExecAliasDynamicTool(
   };
 }
 
-export function createProcessAliasDynamicTool(
+export function createGatewayProcessAliasDynamicTool(
   processTool: OpenClawDynamicTool,
-  host: "gateway" | "node",
 ): OpenClawDynamicTool {
-  const nodeAlias = host === "node";
-  const name = nodeAlias
-    ? CODEX_NODE_PROCESS_DYNAMIC_TOOL_NAME
-    : CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME;
-  const description = nodeAlias
-    ? "Manage background shell sessions on OpenClaw remote nodes: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use only for remote-node follow-up; use Codex's native shell session handling for local app-server work."
-    : "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.";
-  return { ...processTool, name, description };
+  return {
+    ...processTool,
+    name: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
+    description:
+      "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.",
+  };
 }
 
 function pinExecDynamicToolArgs(
@@ -98,9 +102,12 @@ function pinExecDynamicToolArgs(
   if (host === "gateway") {
     return { ...rest, host };
   }
+  const nodeArgs = Object.fromEntries(
+    Object.entries(rest).filter(([name]) => CODEX_NODE_EXEC_PARAMETER_NAMES.has(name)),
+  );
   const node = configuredNode ?? (typeof requestedNode === "string" ? requestedNode.trim() : "");
   return {
-    ...rest,
+    ...nodeArgs,
     host,
     ...(node ? { node } : {}),
   };
@@ -115,6 +122,7 @@ function normalizeExecDynamicToolArgs(args: unknown): Record<string, unknown> {
 function hideExecDynamicToolParameters(
   parameters: OpenClawDynamicTool["parameters"],
   hideNode: boolean,
+  nodeOnly: boolean,
 ) {
   if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
     return parameters;
@@ -124,21 +132,17 @@ function hideExecDynamicToolParameters(
   if (!rawProperties || typeof rawProperties !== "object" || Array.isArray(rawProperties)) {
     return parameters;
   }
+  const includeParameter = (name: string) =>
+    nodeOnly
+      ? CODEX_NODE_EXEC_PARAMETER_NAMES.has(name) && !(hideNode && name === "node")
+      : !CODEX_EXEC_POLICY_PARAMETER_NAMES.has(normalizeCodexDynamicToolName(name)) &&
+        !(hideNode && normalizeCodexDynamicToolName(name) === "node");
   const nextProperties = Object.fromEntries(
-    Object.entries(rawProperties).filter(
-      ([name]) =>
-        !CODEX_EXEC_POLICY_PARAMETER_NAMES.has(normalizeCodexDynamicToolName(name)) &&
-        !(hideNode && normalizeCodexDynamicToolName(name) === "node"),
-    ),
+    Object.entries(rawProperties).filter(([name]) => includeParameter(name)),
   );
   const rawRequired = schema.required;
   const nextRequired = Array.isArray(rawRequired)
-    ? rawRequired.filter(
-        (name) =>
-          typeof name !== "string" ||
-          (!CODEX_EXEC_POLICY_PARAMETER_NAMES.has(normalizeCodexDynamicToolName(name)) &&
-            !(hideNode && normalizeCodexDynamicToolName(name) === "node")),
-      )
+    ? rawRequired.filter((name) => typeof name !== "string" || includeParameter(name))
     : rawRequired;
   return {
     ...schema,

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -475,7 +475,8 @@ export function createExecTool(
             approvalRunningNoticeMs,
             warnings,
             foregroundWarnings: foregroundFallbackWarning ? [foregroundFallbackWarning] : [],
-            processContinuationAvailable: allowBackground,
+            // Remote system.run has no process-session owner.
+            processContinuationAvailable: false,
             notifySessionKey,
             notifyOnExit,
             trustedSafeBinDirs,

--- a/src/agents/bash-tools.exec.approval-id.test.ts
+++ b/src/agents/bash-tools.exec.approval-id.test.ts
@@ -244,11 +244,16 @@ function expectPendingApprovalText(
   expect(pendingText).toContain(options.command);
   if (options.interactive) {
     expect(pendingText).toContain("Mode: foreground (interactive approvals available).");
+  }
+  if (options.interactive && options.host !== "node") {
     expect(pendingText).toContain(
       (options.allowedDecisions ?? "").includes("allow-always")
         ? "Background mode requires pre-approved policy"
         : "Background mode requires an effective policy that allows pre-approval",
     );
+  }
+  if (options.host === "node") {
+    expect(pendingText).not.toContain("Background mode");
   }
   return details;
 }


### PR DESCRIPTION
Related: #126088

Follow-up to ClawSweeper's final review on #126088: https://github.com/openclaw/openclaw/pull/126088#issuecomment-5335797403

AI-assisted: yes. I reviewed the execution-owner boundary, upstream Codex callback contract, regression proof, and final diff.

## What Problem This Solves

Fixes an issue where Codex turns using automatic or node-host execution were offered a `node_process` tool that claimed to control remote-node background commands, but actually addressed the Gateway-local process registry. Remote follow-up could not work, and the mislabeled tool could enumerate or mutate unrelated Gateway-local sessions in the same scope.

## Why This Change Was Made

Remote node execution is a synchronous `node.invoke` / `system.run` request-response boundary; there is no durable remote process-session API for list, poll, log, input, or kill. This removes the unsupported `node_process` surface instead of adding a Gateway-local fallback or a second registry. `node_exec` remains node-pinned, exposes only the canonical node-supported arguments, waits for completion, and reports that remote background follow-up is unavailable. `gateway_process` remains the sole owner of Gateway-local process sessions.

The original renamed node alias predates #126088, but #126088 made the owner mismatch reachable in the default auto-host surface by advertising `gateway_process` and `node_process` together. The affected surface was only on `main`, so no shipped compatibility alias or migration is retained.

## User Impact

Codex no longer presents a remote-node control tool that cannot control its own work or can accidentally target Gateway sessions. Node commands run through `node_exec` to completion. Gateway background commands continue to use `gateway_process` unchanged.

## Evidence

### Regression

Before the production fix, this owner-boundary regression failed with the extra `node_process` tool still present:

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts -t "does not expose Gateway process sessions as remote-node control in auto host runs"` — 1 failed / 80 skipped as expected.

After the fix, the same test passes. It verifies that `gateway_process` still dispatches, while a `node_process` call is rejected without invoking the shared Gateway process tool.

### Focused proof

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/dynamic-tool-build.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts` — 234 passed.
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec.approval-id.test.ts src/agents/bash-tools.exec-host-node.test.ts src/agents/bash-tools.test.ts` — 152 passed.
- `node scripts/run-vitest.mjs src/agents/bash-tools.process.e2e.test.ts` — 9 passed against real background children; this run also rebuilt the current tree successfully.
- Final changed-gate proof was split only because the first invocation reached the 10-minute harness limit after its dead-export scan had passed. The follow-up `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 node scripts/check-changed.mjs -- <changed paths>` completed the full selected core, core-test, extension, extension-test, docs, typecheck, lint, boundary, architecture, database/storage, and import-cycle gates.
- `pnpm check:docs` — passed formatting, Markdown lint, MDX, glossary, 6,510 internal links, and config-example validation.
- `git diff --check` — passed.
- Fresh structured autoreview — clean; no accepted/actionable findings; secret scan clean.

### Contract inspection

Directly inspected sibling Codex source at `86b1123ff6b5d089a146be4e603a324cf454223a`:

- `codex-rs/protocol/src/dynamic_tools.rs` — dynamic tools carry name, description, schema, arguments, content items, and success; no remote process handle exists.
- `codex-rs/core/src/tools/handlers/dynamic.rs` — Codex registers the active-turn callback and waits for the host response.
- `codex-rs/app-server/src/bespoke_event_handling.rs` and `codex-rs/app-server/src/dynamic_tools.rs` — app-server dispatches the host callback and submits its response to the active turn.

OpenClaw's node host advertises one-shot `system.run` / `system.run.prepare` / `system.which`; execution waits for the command result. In-flight node invoke cancellation/input is tied to the exact active invocation and is not a durable process-session API.

Authenticated paired-node continuation proof is not applicable because the production boundary has no remote continuation capability to exercise. The repair removes that claim; it does not substitute a mock or fallback for live remote control.

### Size

Production LOC: +40/-52 (net -12) | Tests: +53/-26 | Docs: +10/-9

No protocol version, schema version, config surface, dependency, fallback, or compatibility shim changed.
