### PR TITLE
fix(ci): retain pending QA workflow calls

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -29,6 +29,9 @@ paths:
       - 'constant expression "false" in condition'
       # actionlint's built-in runner label allowlist lags Blacksmith additions.
       - 'label "blacksmith-16vcpu-[^"]+" is unknown\.'
+  .github/workflows/qa-live-transports-convex.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'
   # GitHub Actions supports concurrency.queue, but actionlint does not yet model it.
   .github/workflows/docker-release.yml:
     ignore:

--- a/.github/workflows/qa-live-transports-convex.yml
+++ b/.github/workflows/qa-live-transports-convex.yml
@@ -120,6 +120,7 @@ permissions:
 concurrency:
   group: qa-lab-all-lanes-${{ github.event_name != 'schedule' && inputs.ref || github.sha }}
   cancel-in-progress: false
+  queue: max
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -1403,6 +1403,18 @@ ${actionRun}`;
 }
 
 describe("ci workflow guards", () => {
+  it("retains pending same-SHA QA calls in the shared concurrency group", () => {
+    const workflowPath = ".github/workflows/qa-live-transports-convex.yml";
+    const workflowSource = readFileSync(workflowPath, "utf8");
+    const workflow = parse(workflowSource);
+
+    expect(workflow.concurrency).toEqual({
+      group: "qa-lab-all-lanes-${{ github.event_name != 'schedule' && inputs.ref || github.sha }}",
+      "cancel-in-progress": false,
+      queue: "max",
+    });
+  });
+
   it("extracts module heredocs only at exact closing marker lines", () => {
     const run = runWorkflowShellScript(
       `node --input-type=module <<'NODE'


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where same-SHA QA Live transport calls could replace one another while pending in the shared concurrency group, leaving a requested qualification lane unrun.

## Why This Change Was Made

The workflow now uses GitHub's `concurrency.queue: max` policy so every pending same-SHA call is retained. A focused workflow guard locks the policy in place, and the path-scoped actionlint exception covers actionlint 1.7.12, which does not yet model the valid `queue` key.

The workflow owns this scheduling invariant. No runtime or product code changes.

## User Impact

Maintainers can dispatch multiple QA Live transport lanes for one SHA without a later pending call silently replacing an earlier one.

## Evidence

- Exact PR head: `859a73cec3f95ca092c2fa57b803cb30fe0f3092`
- Rebased base: `30337c896212578a1770c5057f6a317eeef62467`
- Paired same-SHA scheduler proof: https://github.com/openclaw/openclaw/actions/runs/32234978319
  - Temporary caller SHA: `0c5580b1213d9a21de9c494b8e463268b428e62c`
  - Both reusable calls used `ref` and `expected_sha` `859a73cec3f95ca092c2fa57b803cb30fe0f3092`.
  - Both calls explicitly set mock parity, Matrix, Buzz, Telegram, Discord, WhatsApp, and Slack false, with `fail_fast: false`.
  - Call two: authorize job `96012804507` succeeded at `08:55:17Z-08:55:27Z`; validate job `96012857916` succeeded at `08:55:29Z-08:58:24Z`.
  - Call one was retained pending, then authorize job `96012804746` succeeded at `08:58:26Z-08:58:37Z`; validate job `96013664609` succeeded at `08:58:38Z-09:01:15Z`.
  - Caller completed successfully at `09:01:16Z`; neither reusable call was cancelled. All product-lane jobs were skipped as configured.
  - The temporary proof ref and local proof worktrees were deleted after the run completed.
- `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts`: 18/18 passed on the exact head.
- `pnpm check:workflows`: passed on the exact head.
- `pnpm format:check -- .github/actionlint.yaml .github/workflows/qa-live-transports-convex.yml test/scripts/ci-workflow-guards.test.ts`: passed.
- `git diff --check`: passed.
- Tree-identical pre-rebase focused Blacksmith proof: `tbx_01m0cgbbcntaaactmgrmebtdef`, https://github.com/openclaw/openclaw/actions/runs/32230200809, 316/316 workflow guard and package acceptance tests passed with exact changed-file blob assertions.
- Two exact-head focused Testbox attempts stopped during delegated pre-test sync after stale full-clone expansion exceeded 10,000 files; neither reached the test command or reported a test failure. No further ad hoc retry was run.
- Delta: workflow/config/tests only, +16/-0; production TS/JS +0/-0.

AI-assisted: yes. The patch was independently audited, reviewed, and validated against the exact three-file fence.
