### PR TITLE
test(qa): wait for terminal task metadata

### DIFF
--- a/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
+++ b/qa/scenarios/agents/subagent-completion-direct-fallback.yaml
@@ -265,14 +265,14 @@ flow:
               ref: emptyConversationId
             senderName: QA Empty Reply Operator
             text: "Subagent terminal reply QA check: empty. Spawn one native worker, then finish the parent turn without waiting. Do not use ACP."
-        # Subagent lifecycle owns empty completion classification, while its
-        # blocked completion still owns one visible terminal representation.
+        # Delivery can settle before the empty completion's execution metadata.
+        # Wait for every task fact asserted below plus its visible representation.
         - call: waitForCondition
           saveAs: emptyTask
           args:
             - lambda:
                 async: true
-                expr: "(async () => { const task = await readSettledTerminalTask('empty'); if (!task) return undefined; const represented = state.getSnapshot().messages.slice(emptyStartIndex).some((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === emptyConversationId && String(candidate.text ?? '').trim() === 'QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED'); return represented ? task : undefined; })().catch(() => undefined)"
+                expr: "(async () => { const task = await readSettledTerminalTask('empty'); if (!task || task.status !== 'completed' || task.terminalOutcome !== 'blocked' || task.toolUseCount !== 1 || task.lastToolName !== 'write') return undefined; const represented = state.getSnapshot().messages.slice(emptyStartIndex).some((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === emptyConversationId && String(candidate.text ?? '').trim() === 'QA-SUBAGENT-TERMINAL-EMPTY-REPRESENTED'); return represented ? task : undefined; })().catch(() => undefined)"
             - 60000
             - 250
         - set: emptyOutbound


### PR DESCRIPTION
Related: #126207
Related: #126205

## What Problem This Solves

Fixes a red-main QA race where the `subagent-completion-direct-fallback` scenario could return an empty-case task as soon as delivery settled, then immediately fail because its terminal outcome and tool metadata were still being recorded. The assertion message serialized the same live object after it mutated into the expected state, which made the failure evidence appear self-contradictory.

The race reproduced in QA Smoke CI profile 3/6 on #126207 attempts 1 and 2 and on #126205.

## Why This Change Was Made

The empty-case waiter now requires every task fact asserted by that case—completed status, blocked terminal outcome, one tool use, and `write` as the last tool—before returning the task. Delivery, visible representation, protected-metadata, and exact-send-count assertions remain unchanged. No sleeps, timeout changes, weakened assertions, or product-code changes were added.

## User Impact

No product behavior changes. OpenClaw's deterministic QA gate now observes the complete terminal task state before judging the empty direct-fallback case, removing a flaky red-main failure while preserving the visible representation checks.

AI-assisted: yes.

## Evidence

- Prior failures:
  - #126207 run attempt 1: https://github.com/openclaw/openclaw/actions/runs/32222421356/attempts/1
  - #126207 run attempt 2: https://github.com/openclaw/openclaw/actions/runs/32222421356/attempts/2
  - #126205 run attempt 1: https://github.com/openclaw/openclaw/actions/runs/32222410342/attempts/1
- Three bounded consecutive direct QA runs passed with `mock-openai` and `qa-channel`:
  - `.artifacts/qa-e2e/subagent-terminal-qa-settle/qa-channel-run-1/qa-suite-summary.json`
  - `.artifacts/qa-e2e/subagent-terminal-qa-settle/qa-channel-run-2/qa-suite-summary.json`
  - `.artifacts/qa-e2e/subagent-terminal-qa-settle/qa-channel-run-3/qa-suite-summary.json`
- Post-rebase direct QA run passed:
  - `.artifacts/qa-e2e/subagent-terminal-qa-settle/qa-channel-post-rebase/qa-suite-summary.json`
- Catalog and flow validation: 3 files / 96 tests passed.
- Focused lane/provider validation: 2 files / 30 tests passed.
- Post-rebase focused catalog validation: 1 file / 16 tests passed.
- `node scripts/check-changed.mjs -- qa/scenarios/agents/subagent-completion-direct-fallback.yaml` passed all selected gates, including typecheck, lint, and import-cycle checks.
- `git diff --check` passed.
- Fresh structured autoreview reported no accepted/actionable findings.
- Production LOC: 0. QA scenario delta: +3/-3.
