### PR TITLE
fix(macos): localize gateway setup alerts

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -23418,6 +23418,10 @@
           "path": "apps/macos/Sources/OpenClaw/CronSettings+Layout.swift"
         },
         {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/DashboardWindowController+Gateways.swift"
+        },
+        {
           "kind": "ui-call",
           "path": "apps/macos/Sources/OpenClaw/GatewaySettings.swift"
         },
@@ -23618,12 +23622,23 @@
       ]
     },
     {
+      "id": "native.apple.11dfa551e1c0cab8",
+      "source": "Change Gateway",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/DashboardWindowController+Gateways.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.c767224da1135c79",
       "source": "Change the primary Gateway?",
       "surface": "apple",
       "sites": [
         {
-          "kind": "ui-call",
+          "kind": "ui-localized-call",
           "path": "apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift"
         }
       ]
@@ -25132,6 +25147,17 @@
       ]
     },
     {
+      "id": "native.apple.41304f8f292602af",
+      "source": "Connect the Mac app directly to %@ using %@?",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.95850409a087b937",
       "source": "Connect this iPhone to a Gateway before opening the OpenClaw settings assistant.",
       "surface": "apple",
@@ -26275,7 +26301,7 @@
       "surface": "apple",
       "sites": [
         {
-          "kind": "ui-call",
+          "kind": "ui-localized-call",
           "path": "apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift"
         }
       ]
@@ -30214,7 +30240,7 @@
       "surface": "apple",
       "sites": [
         {
-          "kind": "ui-call",
+          "kind": "ui-localized-call",
           "path": "apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift"
         }
       ]
@@ -38419,6 +38445,17 @@
       ]
     },
     {
+      "id": "native.apple.c94b907489b7de9d",
+      "source": "Password authentication is not supported by the Mac app's primary Gateway connection. Use a token instead.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.d1ed2f81c595fc4f",
       "source": "Paste a setup code to continue.",
       "surface": "apple",
@@ -43640,6 +43677,17 @@
       ]
     },
     {
+      "id": "native.apple.edf83ff7ab9e70de",
+      "source": "Set %@ as primary?",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/DashboardWindowController+Gateways.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.49c597caf33902b9",
       "source": "Set API Key",
       "surface": "apple",
@@ -43680,6 +43728,17 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/macos/Sources/OpenClaw/MenuGatewaysInjector.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.009f96b5c7539815",
+      "source": "Set as Primary",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/DashboardWindowController+Gateways.swift"
         }
       ]
     },
@@ -45732,6 +45791,10 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/ios/Sources/Design/SettingsProTabActions.swift"
+        },
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift"
         }
       ]
     },
@@ -46985,6 +47048,17 @@
       ]
     },
     {
+      "id": "native.apple.d45e330cb331698a",
+      "source": "This Gateway cannot be set as primary.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift"
+        }
+      ]
+    },
+    {
       "id": "native.apple.7eaec64446531ddf",
       "source": "This allowlist entry is inherited. Edit its owning scope and retry.",
       "surface": "apple",
@@ -47103,6 +47177,17 @@
         {
           "kind": "ui-localized-call",
           "path": "apps/ios/Sources/Design/SettingsProTabActions.swift"
+        }
+      ]
+    },
+    {
+      "id": "native.apple.d07cdec724b1ccea",
+      "source": "This changes the Mac app's primary Gateway and resets Talk Mode, canvas, and chat connections.",
+      "surface": "apple",
+      "sites": [
+        {
+          "kind": "ui-localized-call",
+          "path": "apps/macos/Sources/OpenClaw/DashboardWindowController+Gateways.swift"
         }
       ]
     },
@@ -50900,7 +50985,7 @@
       "surface": "apple",
       "sites": [
         {
-          "kind": "conditional-branch",
+          "kind": "ui-localized-call",
           "path": "apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift"
         }
       ]

--- a/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
@@ -134,9 +134,14 @@ enum DashboardPrimaryGatewayError: LocalizedError, Equatable {
     var errorDescription: String? {
         switch self {
         case .notPromotable:
-            "This Gateway cannot be set as primary."
+            String(localized: "This Gateway cannot be set as primary.")
         case .passwordUnsupported:
-            "Password authentication is not supported by the Mac app's primary Gateway connection. Use a token instead."
+            // Localization extraction requires one literal.
+            // swiftlint:disable line_length
+            // swiftformat:disable wrap,wrapArguments
+            String(localized: "Password authentication is not supported by the Mac app's primary Gateway connection. Use a token instead.")
+            // swiftformat:enable wrap,wrapArguments
+            // swiftlint:enable line_length
         }
     }
 }
@@ -218,21 +223,28 @@ struct DashboardGatewaySetupCoordinator {
     func handle(_ link: GatewayConnectDeepLink) {
         if link.password?.trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty != nil {
             self.presentError(
-                "Gateway Setup Not Supported",
+                String(localized: "Gateway Setup Not Supported"),
                 DashboardPrimaryGatewayError.passwordUnsupported.localizedDescription)
             return
         }
         let endpoint = "\(link.host):\(link.port)"
-        let transport = link.tls ? "TLS" : "an unencrypted private-network connection"
+        let transport = link.tls
+            ? String(localized: "TLS")
+            : String(localized: "an unencrypted private-network connection")
         guard self.confirm(
-            "Change the primary Gateway?",
-            "Connect the Mac app directly to \(endpoint) using \(transport)?")
+            String(localized: "Change the primary Gateway?"),
+            String(
+                format: String(localized: "Connect the Mac app directly to %@ using %@?"),
+                endpoint,
+                transport))
         else { return }
         do {
             try self.adapter.apply(link: link)
             self.openConnectionSettings()
         } catch {
-            self.presentError("Could Not Change Primary Gateway", error.localizedDescription)
+            self.presentError(
+                String(localized: "Could Not Change Primary Gateway"),
+                error.localizedDescription)
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+Gateways.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+Gateways.swift
@@ -141,11 +141,17 @@ extension DashboardWindowController {
 
     static func makeSetPrimaryAlert(gatewayName: String) -> NSAlert {
         let alert = NSAlert()
-        alert.messageText = "Set \(gatewayName) as primary?"
-        alert.informativeText =
-            "This changes the Mac app's primary Gateway and resets Talk Mode, canvas, and chat connections."
-        alert.addButton(withTitle: "Set as Primary")
-        alert.addButton(withTitle: "Cancel")
+        alert.messageText = String(
+            format: String(localized: "Set %@ as primary?"),
+            gatewayName)
+        // Localization extraction requires one literal.
+        // swiftlint:disable line_length
+        // swiftformat:disable wrap,wrapArguments
+        alert.informativeText = String(localized: "This changes the Mac app's primary Gateway and resets Talk Mode, canvas, and chat connections.")
+        // swiftformat:enable wrap,wrapArguments
+        // swiftlint:enable line_length
+        alert.addButton(withTitle: String(localized: "Set as Primary"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
         return alert
     }
 
@@ -153,8 +159,8 @@ extension DashboardWindowController {
         let alert = NSAlert()
         alert.messageText = title
         alert.informativeText = message
-        alert.addButton(withTitle: "Change Gateway")
-        alert.addButton(withTitle: "Cancel")
+        alert.addButton(withTitle: String(localized: "Change Gateway"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
         alert.alertStyle = .warning
         return alert
     }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardGatewaysTests.swift
@@ -176,6 +176,21 @@ struct DashboardGatewaysBridgeTests {
             port: 80,
             dashboardURL: url))
     }
+
+    @Test func `gateway alerts preserve exact English copy`() {
+        let setPrimary = DashboardWindowController.makeSetPrimaryAlert(gatewayName: "Studio")
+        #expect(setPrimary.messageText == "Set Studio as primary?")
+        #expect(setPrimary.informativeText ==
+            "This changes the Mac app's primary Gateway and resets Talk Mode, canvas, and chat connections.")
+        #expect(setPrimary.buttons.map(\.title) == ["Set as Primary", "Cancel"])
+
+        let setup = DashboardWindowController.makeGatewaySetupAlert(
+            title: "Gateway Setup Not Supported",
+            message: "Use a token instead.")
+        #expect(setup.messageText == "Gateway Setup Not Supported")
+        #expect(setup.informativeText == "Use a token instead.")
+        #expect(setup.buttons.map(\.title) == ["Change Gateway", "Cancel"])
+    }
 }
 
 @Suite(.serialized)
@@ -487,6 +502,14 @@ private final class DashboardGatewayTestUpdater: UpdaterProviding {
 
 @MainActor
 struct DashboardPrimaryGatewayAdapterTests {
+    @Test func `gateway errors preserve exact English copy`() {
+        let passwordError = "Password authentication is not supported by the Mac app's " +
+            "primary Gateway connection. Use a token instead."
+        #expect(DashboardPrimaryGatewayError.notPromotable.errorDescription ==
+            "This Gateway cannot be set as primary.")
+        #expect(DashboardPrimaryGatewayError.passwordUnsupported.errorDescription == passwordError)
+    }
+
     @Test func `token profile promotion carries its TLS pin`() async throws {
         let state = AppState(preview: true)
         let url = try #require(URL(string: "wss://studio.example:443/"))
@@ -678,9 +701,11 @@ struct DashboardGatewaySetupCoordinatorTests {
         coordinator.handle(link)
 
         #expect(prompts.count == 1)
+        #expect(prompts[0].0 == "Change the primary Gateway?")
+        #expect(prompts[0].1 ==
+            "Connect the Mac app directly to 192.168.1.20:18789 using an unencrypted private-network connection?")
         #expect(!prompts[0].0.contains(token))
         #expect(!prompts[0].1.contains(token))
-        #expect(prompts[0].1.contains("unencrypted private-network connection"))
         #expect(!prompts[0].1.localizedCaseInsensitiveContains("loopback"))
         #expect(state.remoteTransport == .ssh)
         #expect(state.remoteUrl == "wss://previous.example:443")
@@ -694,6 +719,7 @@ struct DashboardGatewaySetupCoordinatorTests {
         let state = AppState(preview: true)
         var persistedFingerprints: [String?] = []
         var openedSettings = 0
+        var prompts: [(String, String)] = []
         let adapter = DashboardPrimaryGatewayAdapter(
             state: state,
             persist: { _, fingerprint in
@@ -702,7 +728,10 @@ struct DashboardGatewaySetupCoordinatorTests {
             })
         let coordinator = DashboardGatewaySetupCoordinator(
             adapter: adapter,
-            confirm: { _, _ in true },
+            confirm: {
+                prompts.append(($0, $1))
+                return true
+            },
             presentError: { _, _ in Issue.record("unexpected error") },
             openConnectionSettings: { openedSettings += 1 })
         let link = GatewayConnectDeepLink(
@@ -715,6 +744,9 @@ struct DashboardGatewaySetupCoordinatorTests {
 
         coordinator.handle(link)
 
+        #expect(prompts.count == 1)
+        #expect(prompts[0].0 == "Change the primary Gateway?")
+        #expect(prompts[0].1 == "Connect the Mac app directly to gateway.example:443 using TLS?")
         #expect(state.remoteUrl == "wss://gateway.example:443")
         #expect(state.remoteToken == "fixture-token")
         #expect(persistedFingerprints == [nil])
@@ -747,6 +779,10 @@ struct DashboardGatewaySetupCoordinatorTests {
 
         #expect(promptCount == 0)
         #expect(errors.count == 1)
+        #expect(errors[0].0 == "Gateway Setup Not Supported")
+        #expect(errors[0].1 ==
+            "Password authentication is not supported by the Mac app's " +
+            "primary Gateway connection. Use a token instead.")
         #expect(!errors[0].0.contains(password))
         #expect(!errors[0].1.contains(password))
         #expect(state.remoteUrl == "wss://previous.example:443")

--- a/scripts/apple-app-i18n.ts
+++ b/scripts/apple-app-i18n.ts
@@ -157,6 +157,22 @@ const APPLE_LOCALE_DIRECTORIES: Record<string, string> = {
   "zh-TW": "zh-Hant",
 };
 const LOCALIZED_WRAPPER_CONTRACTS: Record<string, readonly string[]> = {
+  "apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift": [
+    'String(localized: "This Gateway cannot be set as primary.")',
+    'String(localized: "Password authentication is not supported by the Mac app\'s primary Gateway connection. Use a token instead.")',
+    'String(localized: "Gateway Setup Not Supported")',
+    'String(localized: "an unencrypted private-network connection")',
+    'String(localized: "Change the primary Gateway?")',
+    'format: String(localized: "Connect the Mac app directly to %@ using %@?")',
+    'String(localized: "Could Not Change Primary Gateway")',
+  ],
+  "apps/macos/Sources/OpenClaw/DashboardWindowController+Gateways.swift": [
+    'format: String(localized: "Set %@ as primary?")',
+    'String(localized: "This changes the Mac app\'s primary Gateway and resets Talk Mode, canvas, and chat connections.")',
+    'alert.addButton(withTitle: String(localized: "Set as Primary"))',
+    'alert.addButton(withTitle: String(localized: "Change Gateway"))',
+    'alert.addButton(withTitle: String(localized: "Cancel"))',
+  ],
   "apps/macos/Sources/OpenClaw/SettingsComponents.swift": [
     "enum SettingsTextValue: ExpressibleByStringLiteral",
     "case localized(LocalizedStringKey)",

--- a/test/scripts/apple-app-i18n.test.ts
+++ b/test/scripts/apple-app-i18n.test.ts
@@ -110,15 +110,26 @@ describe("Apple app i18n catalogs", () => {
     expect(keys).toEqual(
       expect.arrayContaining([
         "Browse ClawHub",
+        "Change Gateway",
+        "Change the primary Gateway?",
+        "Connect the Mac app directly to %@ using %@?",
+        "Could Not Change Primary Gateway",
         "Done in %@",
         "Enable debug tools",
         "Everyday OpenClaw app behavior.",
+        "Gateway Setup Not Supported",
         "General",
+        "Password authentication is not supported by the Mac app's primary Gateway connection. Use a token instead.",
         "Searching…",
+        "Set %@ as primary?",
+        "Set as Primary",
         "Shelling",
         "Stopped",
+        "This Gateway cannot be set as primary.",
+        "This changes the Mac app's primary Gateway and resets Talk Mode, canvas, and chat connections.",
         "Voice Wake requires macOS 26 or newer",
         "Waiting",
+        "an unencrypted private-network connection",
       ]),
     );
     expect(keys).not.toContain("OpenClaw");


### PR DESCRIPTION
Related: #125967

## What Problem This Solves

Fixes an issue where macOS users running OpenClaw in a non-English locale would still see English-only Gateway setup, primary-Gateway confirmation, error, and alert button copy.

## Why This Change Was Made

The Gateway alerts used raw Swift strings, so the native localization extractor could inventory some copy without the runtime actually resolving translations. This changes the owning macOS alert paths to `String(localized:)`, uses a `%@` template with `String(format:)` for dynamic endpoint and transport text, and adds targeted extraction contracts plus exact English-formatting tests.

Only the canonical native source baseline is regenerated here. Locale catalogs remain owned by the Native App Locale Refresh workflow; #125967 should update after this source PR lands.

## User Impact

Gateway setup and primary-Gateway alerts can now render their titles, explanatory text, errors, and buttons using the active macOS locale while preserving the existing English wording and interpolation.

## Evidence

- `pnpm native:i18n:baseline` -> 4,261 entries, no drift after rebase
- `pnpm native:i18n:verify` -> 1,286 macOS source keys
- `node scripts/run-vitest.mjs test/scripts/apple-app-i18n.test.ts` -> 16 passed
- `swift test --package-path apps/macos --filter DashboardGateway` -> 33 passed across 6 suites
- scoped SwiftLint -> 0 violations
- scoped Oxfmt check and `git diff --check` -> passed
- `node scripts/check-changed.mjs --dry-run -- <six reviewed files>` -> macOS CI lane identified; heavy `test:macos:ci` fan-out intentionally deferred to the shared QA FIFO
- local ClawSweeper reviewed `c2b61a40..74219a2b`; it reported one low-severity adjacent raw-title path in `DashboardManager.swift`, outside this independently reviewed six-file fence and not introduced by this change
