### PR TITLE
fix(ci): restore agentic plugin prerelease fixture loading

### DIFF
--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -113,6 +113,7 @@ function useMemoryProviderOwner(params: {
       plugins: [
         {
           pluginId: params.pluginId,
+          startup: { sidecar: false, memory: false, agentHarnesses: [] },
           contributions: {
             contracts: { [params.contract]: [params.adapterId] },
           },
@@ -135,7 +136,15 @@ describe("ensurePluginRegistryLoaded", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.resolvePluginMetadataSnapshot.mockReset().mockReturnValue({
-      index: { installRecords: {}, plugins: [{ pluginId: "openai" }] },
+      index: {
+        installRecords: {},
+        plugins: [
+          {
+            pluginId: "openai",
+            startup: { sidecar: false, memory: false, agentHarnesses: [] },
+          },
+        ],
+      },
       manifestRegistry: { plugins: [], diagnostics: [] },
     } as never);
     mocks.isPluginMetadataSnapshotCompatible.mockReturnValue(true);


### PR DESCRIPTION
Related: #126215

## What Problem This Solves

Resolves a problem where the agentic plugin prerelease shard failed before exercising the scanner because two synthetic runtime-registry records omitted required startup metadata.

## Why This Change Was Made

The two test fixtures now satisfy the same installed-plugin startup contract as production records. This is test-only: runtime behavior and fallback policy are unchanged.

## User Impact

No user-visible runtime change. Maintainers regain reliable agentic plugin prerelease coverage.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/runtime/runtime-registry-loader.test.ts src/agents/harness/runtime-plugin.test.ts`
  - runtime registry loader: 9/9 passed
  - harness runtime plugin: 27/27 passed
- `pnpm format src/plugins/runtime/runtime-registry-loader.test.ts`
- `git diff --check`
- `node scripts/check-changed.mjs -- src/plugins/runtime/runtime-registry-loader.test.ts`
  - all relevant guards, formatting, plugin boundaries, and dead-export scans passed
  - stopped in the core-test typecheck on the unrelated existing `packages/terminal-core/src/ansi.ts:194` argument-count error
