### PR TITLE
fix: show generated media previews after durable recovery

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3069,7 +3069,7 @@ src/gateway/server-plugins.ts	2
 src/gateway/server-reload-restart.ts	2
 src/gateway/server-reload-utils.ts	1
 src/gateway/server-resident-registry.ts	1
-src/gateway/server-restart-sentinel-agent-delivery.ts	3
+src/gateway/server-restart-sentinel-agent-delivery.ts	2
 src/gateway/server-runtime-handles.ts	11
 src/gateway/server-runtime-state-prepare.ts	2
 src/gateway/server-session-events.ts	1

--- a/src/agents/embedded-agent-subscribe.run-state.ts
+++ b/src/agents/embedded-agent-subscribe.run-state.ts
@@ -1,70 +1,16 @@
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { createInlineCodeState } from "../../packages/markdown-core/src/code-spans.js";
 import { createEmbeddedRunReplayState } from "./embedded-agent-runner/replay-state.js";
 import type { EmbeddedAgentSubscribeState } from "./embedded-agent-subscribe.handlers.types.js";
 import type { SubscribeEmbeddedAgentSessionParams } from "./embedded-agent-subscribe.types.js";
 import { createThinkingTagStreamState } from "./embedded-agent-utils.js";
-import { mediaUrlsFromGeneratedAttachments } from "./generated-attachments.js";
-import { hasGeneratedMediaCompletionEvent } from "./internal-event-contract.js";
-import type { AgentInternalEvent } from "./internal-events.js";
-
-function collectPendingMediaFromInternalEvents(
-  events: SubscribeEmbeddedAgentSessionParams["internalEvents"],
-): {
-  mediaUrls: string[];
-  attachments: NonNullable<AgentInternalEvent["attachments"]>;
-  trustByUrl: Map<string, boolean>;
-} {
-  if (!events?.length) {
-    return { mediaUrls: [], attachments: [], trustByUrl: new Map() };
-  }
-  const pending: string[] = [];
-  const attachments: NonNullable<AgentInternalEvent["attachments"]> = [];
-  const indexByUrl = new Map<string, number>();
-  const trustedByUrl = new Map<string, boolean>();
-  for (const event of events) {
-    const generatedMediaEvent = hasGeneratedMediaCompletionEvent([event]);
-    const attachmentByUrl = new Map(
-      (event.attachments ?? []).flatMap((attachment) => {
-        const reference = normalizeOptionalString(
-          attachment.path ?? attachment.url ?? attachment.mediaUrl ?? attachment.filePath,
-        );
-        return reference ? [[reference, attachment] as const] : [];
-      }),
-    );
-    const mediaUrls = [
-      ...(Array.isArray(event.mediaUrls) ? event.mediaUrls : []),
-      ...mediaUrlsFromGeneratedAttachments(event.attachments),
-    ];
-    for (const mediaUrl of mediaUrls) {
-      const normalized = normalizeOptionalString(mediaUrl) ?? "";
-      if (!normalized) {
-        continue;
-      }
-      const metadata = attachmentByUrl.get(normalized);
-      const existingIndex = indexByUrl.get(normalized);
-      if (existingIndex !== undefined) {
-        trustedByUrl.set(normalized, trustedByUrl.get(normalized) === true || generatedMediaEvent);
-        if (metadata && Object.keys(attachments[existingIndex] ?? {}).length === 0) {
-          attachments[existingIndex] = metadata;
-        }
-        continue;
-      }
-      indexByUrl.set(normalized, pending.length);
-      trustedByUrl.set(normalized, generatedMediaEvent);
-      pending.push(normalized);
-      attachments.push(metadata ?? {});
-    }
-  }
-  return { mediaUrls: pending, attachments, trustByUrl: trustedByUrl };
-}
+import { collectAgentInternalEventMedia } from "./internal-events.js";
 
 export function createEmbeddedAgentSubscribeState(
   params: SubscribeEmbeddedAgentSessionParams,
 ): EmbeddedAgentSubscribeState {
   const reasoningMode = params.reasoningMode ?? "off";
   const canShowReasoning = params.thinkingLevel !== "off";
-  const initialPendingToolMedia = collectPendingMediaFromInternalEvents(params.internalEvents);
+  const initialPendingToolMedia = collectAgentInternalEventMedia(params.internalEvents);
   return {
     assistantTexts: [],
     toolMetas: [],

--- a/src/agents/internal-events.ts
+++ b/src/agents/internal-events.ts
@@ -3,6 +3,7 @@
  * Sanitizes background task completion events into protected runtime-context
  * blocks or plain prompt text.
  */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   formatGeneratedAttachmentLines,
   mediaUrlsFromGeneratedAttachments,
@@ -10,6 +11,7 @@ import {
 } from "./generated-attachments.js";
 import {
   AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION,
+  hasGeneratedMediaCompletionEvent,
   type AgentInternalEventSource,
   type AgentInternalEventStatus,
 } from "./internal-event-contract.js";
@@ -43,6 +45,55 @@ const TASK_COMPLETION_RESULT_TRUNCATION_NOTICE = "\n[child result truncated]";
 
 /** Internal event variants that can be rendered into agent prompt context. */
 export type AgentInternalEvent = AgentTaskCompletionInternalEvent;
+
+/** Collect ordered media descriptors and per-reference trust from internal events. */
+export function collectAgentInternalEventMedia(events: AgentInternalEvent[] | undefined): {
+  mediaUrls: string[];
+  attachments: NonNullable<AgentInternalEvent["attachments"]>;
+  trustByUrl: Map<string, boolean>;
+} {
+  if (!events?.length) {
+    return { mediaUrls: [], attachments: [], trustByUrl: new Map() };
+  }
+  const mediaUrls: string[] = [];
+  const attachments: NonNullable<AgentInternalEvent["attachments"]> = [];
+  const indexByUrl = new Map<string, number>();
+  const trustByUrl = new Map<string, boolean>();
+  for (const event of events) {
+    const generatedMediaEvent = hasGeneratedMediaCompletionEvent([event]);
+    const attachmentByUrl = new Map(
+      (event.attachments ?? []).flatMap((attachment) => {
+        const reference = normalizeOptionalString(
+          attachment.path ?? attachment.url ?? attachment.mediaUrl ?? attachment.filePath,
+        );
+        return reference ? [[reference, attachment] as const] : [];
+      }),
+    );
+    for (const mediaUrl of [
+      ...(Array.isArray(event.mediaUrls) ? event.mediaUrls : []),
+      ...mediaUrlsFromGeneratedAttachments(event.attachments),
+    ]) {
+      const normalized = normalizeOptionalString(mediaUrl);
+      if (!normalized) {
+        continue;
+      }
+      const metadata = attachmentByUrl.get(normalized);
+      const existingIndex = indexByUrl.get(normalized);
+      if (existingIndex !== undefined) {
+        trustByUrl.set(normalized, trustByUrl.get(normalized) === true || generatedMediaEvent);
+        if (metadata && Object.keys(attachments[existingIndex] ?? {}).length === 0) {
+          attachments[existingIndex] = metadata;
+        }
+        continue;
+      }
+      indexByUrl.set(normalized, mediaUrls.length);
+      trustByUrl.set(normalized, generatedMediaEvent);
+      mediaUrls.push(normalized);
+      attachments.push(metadata ?? {});
+    }
+  }
+  return { mediaUrls, attachments, trustByUrl };
+}
 
 function sanitizeSingleLineField(value: string, fallback: string): string {
   const sanitized = escapeInternalRuntimeContextDelimiters(value)

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -2672,37 +2672,69 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     {
       name: "image",
       sourceTool: "image_generate",
-      internalEvents: imageCompletionEvents(),
-      expectedMediaUrls: ["/tmp/generated-daily.png"],
+      attachment: {
+        type: "image" as const,
+        path: "/tmp/generated-daily.png",
+        name: "generated-daily.png",
+        mimeType: "image/png",
+        sizeBytes: 1234,
+        width: 1024,
+        height: 768,
+      },
+      buildEvents: (attachment: NonNullable<AgentInternalEvent["attachments"]>[number]) =>
+        imageCompletionEvents({ attachments: [attachment] }),
     },
     {
       name: "music",
       sourceTool: "music_generate",
-      internalEvents: musicCompletionEvents(),
-      expectedMediaUrls: ["/tmp/generated-night-drive.mp3"],
+      attachment: {
+        type: "audio" as const,
+        path: "/tmp/generated-night-drive.mp3",
+        name: "generated-night-drive.mp3",
+        mimeType: "audio/mpeg",
+        sizeBytes: 5678,
+        durationMs: 42_000,
+      },
+      buildEvents: (attachment: NonNullable<AgentInternalEvent["attachments"]>[number]) =>
+        musicCompletionEvents({ attachments: [attachment] }),
     },
     {
       name: "video",
       sourceTool: "video_generate",
-      internalEvents: taskCompletionEvents({
-        source: "video_generation",
-        childSessionKey: "video_generate:task-123",
-        childSessionId: "task-123",
-        announceType: "video generation task",
-        mediaUrls: ["/tmp/generated-corgi.mp4"],
-      }),
-      expectedMediaUrls: ["/tmp/generated-corgi.mp4"],
+      attachment: {
+        type: "video" as const,
+        path: "/tmp/generated-corgi.mp4",
+        name: "generated-corgi.mp4",
+        mimeType: "video/mp4",
+        sizeBytes: 9012,
+        durationMs: 8_000,
+        width: 1280,
+        height: 720,
+      },
+      buildEvents: (attachment: NonNullable<AgentInternalEvent["attachments"]>[number]) =>
+        taskCompletionEvents({
+          source: "video_generation",
+          childSessionKey: "video_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "video generation task",
+          mediaUrls: [attachment.path ?? ""],
+          attachments: [attachment],
+        }),
     },
   ])(
     "queues generated $name completions without opt-in or direct delivery",
-    async ({ sourceTool, internalEvents, expectedMediaUrls }) => {
+    async ({ sourceTool, attachment, buildEvents }) => {
+      const mediaUrl = attachment.path;
+      if (!mediaUrl) {
+        throw new Error("generated media fixture requires a path");
+      }
       const callGateway = createPayloadGatewayMock();
       const sendMessage = createSendMessageMock();
       const result = await deliverDiscordDirectMessageCompletion({
         callGateway,
         sendMessage,
         sourceTool,
-        internalEvents,
+        internalEvents: buildEvents(attachment),
       });
 
       expectDeliveryPath(result, "queued");
@@ -2714,7 +2746,8 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
           sessionKey: "agent:main:discord:dm:U123",
           inputProvenance: expect.objectContaining({ kind: "inter_session", sourceTool }),
           sourceReplyDeliveryMode: "automatic",
-          expectedMediaUrls,
+          expectedMediaUrls: [mediaUrl],
+          expectedMediaAttachments: { [mediaUrl]: attachment },
           idempotencyKey: "announce-dm-fallback-empty:agent-loop",
         }),
         expect.any(Number),
@@ -2744,10 +2777,10 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
 
     expectDeliveryPath(result, "queued");
-    expect(sessionDeliveryQueueMocks.enqueueClaimedSessionDelivery).toHaveBeenCalledWith(
-      expect.objectContaining({ expectedMediaUrls: [] }),
-      expect.any(Number),
-    );
+    const queuedPayload =
+      sessionDeliveryQueueMocks.enqueueClaimedSessionDelivery.mock.calls.at(-1)?.[0];
+    expect(queuedPayload).toMatchObject({ expectedMediaUrls: [] });
+    expect(queuedPayload).not.toHaveProperty("expectedMediaAttachments");
     expect(callGateway).not.toHaveBeenCalled();
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/src/agents/subagents/announce/subagent-announce-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.ts
@@ -3,7 +3,6 @@
  *
  * Routes completion payloads through gateway/channel/session paths and records delivery evidence.
  */
-import { normalizeUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import { completionRequiresMessageToolDelivery } from "../../../auto-reply/reply/completion-delivery-policy.js";
 import { scheduleSessionDelivery } from "../../../infra/session-delivery-queue-runtime.js";
 import {
@@ -14,9 +13,9 @@ import { defaultRuntime } from "../../../runtime.js";
 import { isAgentMediatedCompletionSourceTool } from "../../../sessions/input-provenance.js";
 import { isCronSessionKey } from "../../../sessions/session-key-utils.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../../utils/message-channel.js";
-import { mediaUrlsFromGeneratedAttachments } from "../../generated-attachments.js";
 import { hasGeneratedMediaCompletionEvent } from "../../internal-event-contract.js";
 import {
+  collectAgentInternalEventMedia,
   formatAgentInternalEventsForPrompt,
   type AgentInternalEvent,
 } from "../../internal-events.js";
@@ -61,15 +60,18 @@ export function isInternalAnnounceRequesterSession(sessionKey: string | undefine
   return getSubagentDepthFromSessionStore(sessionKey) >= 1 || isCronSessionKey(sessionKey);
 }
 
-function collectExpectedMediaFromInternalEvents(
-  events: AgentInternalEvent[] | undefined,
-): string[] {
-  return normalizeUniqueTrimmedStringList(
-    events?.flatMap((event) => [
-      ...(Array.isArray(event.mediaUrls) ? event.mediaUrls : []),
-      ...mediaUrlsFromGeneratedAttachments(event.attachments),
-    ]),
+function collectExpectedMediaFromInternalEvents(events: AgentInternalEvent[] | undefined): {
+  expectedMediaUrls: string[];
+  expectedMediaAttachments?: Record<string, NonNullable<AgentInternalEvent["attachments"]>[number]>;
+} {
+  const { mediaUrls: expectedMediaUrls, attachments } = collectAgentInternalEventMedia(events);
+  const expectedMediaAttachments = Object.fromEntries(
+    expectedMediaUrls.map((mediaUrl, index) => [mediaUrl, attachments[index] ?? {}]),
   );
+  return {
+    expectedMediaUrls,
+    ...(expectedMediaUrls.length > 0 ? { expectedMediaAttachments } : {}),
+  };
 }
 
 export async function deliverSubagentAnnouncement(params: {
@@ -150,6 +152,7 @@ export async function deliverSubagentAnnouncement(params: {
               })
             ? "message_tool_only"
             : "automatic";
+      const expectedMedia = collectExpectedMediaFromInternalEvents(params.internalEvents);
       const queuePayload = {
         kind: "agentTurn",
         sessionKey: canonicalSessionKey,
@@ -164,7 +167,7 @@ export async function deliverSubagentAnnouncement(params: {
           sourceTool: params.sourceTool ?? "subagent_announce",
         },
         sourceReplyDeliveryMode,
-        expectedMediaUrls: collectExpectedMediaFromInternalEvents(params.internalEvents),
+        ...expectedMedia,
         idempotencyKey: `${params.directIdempotencyKey}:agent-loop`,
       } as const;
       const queued = params.sourceRunId

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -682,9 +682,7 @@ type LoadedReferenceImage = Awaited<ReturnType<typeof loadReferenceImages>>[numb
 type ExecutedImageGeneration = {
   provider: string;
   model: string;
-  savedPaths: string[];
   count: number;
-  paths: string[];
   attachments: AgentGeneratedAttachment[];
   contentText: string;
   details: Record<string, unknown>;
@@ -819,9 +817,7 @@ async function executeImageGenerationJob(params: {
   return {
     provider: result.provider,
     model: result.model,
-    savedPaths: savedImages.map((image) => image.path),
     count: savedImages.length,
-    paths: savedImages.map((image) => image.path),
     attachments,
     contentText: lines.join("\n"),
     wakeResult: lines.join("\n"),
@@ -1196,7 +1192,6 @@ export function createImageGenerateTool(options?: {
           provider: executed.provider,
           model: executed.model,
           count: executed.count,
-          paths: executed.paths,
         });
         return {
           content: [{ type: "text", text: executed.contentText }],

--- a/src/agents/tools/media-generate-background-shared.test.ts
+++ b/src/agents/tools/media-generate-background-shared.test.ts
@@ -154,7 +154,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
       provider: "openai",
       model: "gpt-image-1",
       count: 1,
-      paths: ["/tmp/qa-lighthouse.png"],
       wakeResult: "generated",
     }));
 
@@ -201,19 +200,12 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
     try {
       const scheduled: Array<() => Promise<void>> = [];
       let resolveRun:
-        | ((value: {
-            provider: string;
-            model: string;
-            count: number;
-            paths: string[];
-            wakeResult: string;
-          }) => void)
+        | ((value: { provider: string; model: string; count: number; wakeResult: string }) => void)
         | undefined;
       const runPromise = new Promise<{
         provider: string;
         model: string;
         count: number;
-        paths: string[];
         wakeResult: string;
       }>((resolve) => {
         resolveRun = resolve;
@@ -261,7 +253,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         provider: "openai",
         model: "gpt-image-1",
         count: 1,
-        paths: ["/tmp/proof.png"],
         wakeResult: "generated",
       });
       await task;
@@ -318,7 +309,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
           provider: "openai",
           model: "gpt-image-1",
           count: 1,
-          paths: ["/tmp/proof.png"],
           wakeResult: "generated",
         };
       },
@@ -336,7 +326,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
     expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
       expect.objectContaining({
         count: 1,
-        paths: ["/tmp/proof.png"],
         terminalResult: undefined,
       }),
     );
@@ -365,14 +354,17 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         provider: "openai",
         model: "gpt-image-1",
         count: 1,
-        paths: ["/tmp/proof.png"],
         wakeResult: "generated",
       }),
     });
 
     await scheduled[0]?.();
 
-    expect(detachedTaskRuntimeMocks.completeTaskRunByRunId).toHaveBeenCalledOnce();
+    expect(detachedTaskRuntimeMocks.completeTaskRunByRunId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalSummary: "Generated 1 image with openai/gpt-image-1.",
+      }),
+    );
     expect(
       cronContinuationCleanupMocks.removeCronRunContinuationSessionIfIdle,
     ).toHaveBeenCalledWith(sessionKey);
@@ -407,7 +399,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         provider: "openai",
         model: "gpt-image-1",
         count: 1,
-        paths: ["/tmp/proof.png"],
         wakeResult: "generated",
         mediaUrls: ["/tmp/proof.png"],
       }),
@@ -458,7 +449,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
           provider: "openai",
           model: "gpt-image-1",
           count: 1,
-          paths: ["/tmp/proof.png"],
           wakeResult: "generated",
         }),
       });
@@ -519,7 +509,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
           provider: "openai",
           model: "gpt-image-1",
           count: 1,
-          paths: ["/tmp/proof.png"],
           wakeResult: "generated",
         }),
       });
@@ -572,7 +561,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
           provider: "openai",
           model: "gpt-image-1",
           count: 1,
-          paths: ["/tmp/proof.png"],
           wakeResult: "generated",
         }),
       });
@@ -625,7 +613,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         provider: "openai",
         model: "gpt-image-1",
         count: 1,
-        paths: ["/tmp/proof.png"],
         wakeResult: "generated",
       }),
     });
@@ -642,7 +629,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
     expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
       expect.objectContaining({
         count: 1,
-        paths: ["/tmp/proof.png"],
         terminalResult: {
           terminalOutcome: "blocked",
           terminalSummary:
@@ -684,7 +670,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         provider: "openai",
         model: "gpt-image-1",
         count: 1,
-        paths: ["/tmp/proof.png"],
         wakeResult: "generated",
       }),
     });
@@ -702,7 +687,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
     expect(lifecycle.completeTaskRun).toHaveBeenCalledWith(
       expect.objectContaining({
         count: 1,
-        paths: ["/tmp/proof.png"],
         terminalResult: {
           terminalOutcome: "blocked",
           terminalSummary:
@@ -747,7 +731,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         provider: "openai",
         model: "gpt-image-1",
         count: 1,
-        paths: ["/tmp/proof.png"],
         wakeResult: "generated",
         mediaUrls: ["/tmp/proof.png"],
       }),
@@ -796,7 +779,6 @@ describe("scheduleMediaGenerationTaskCompletion", () => {
         provider: "openai",
         model: "gpt-image-1",
         count: 1,
-        paths: ["/tmp/proof.png"],
         wakeResult: "generated",
       }),
     });

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -102,7 +102,6 @@ type MediaGenerationExecutionResult = {
   provider: string;
   model: string;
   count: number;
-  paths: string[];
   wakeResult: string;
   attachments?: AgentGeneratedAttachment[];
   mediaUrls?: string[];
@@ -127,7 +126,6 @@ type CompleteMediaGenerationTaskRunParams = {
   provider: string;
   model: string;
   count: number;
-  paths: string[];
   terminalResult?: RequiredCompletionTerminalResult;
 };
 
@@ -335,7 +333,6 @@ function completeMediaGenerationTaskRun(params: {
   provider: string;
   model: string;
   count: number;
-  paths: string[];
   generatedLabel: string;
   terminalResult?: RequiredCompletionTerminalResult;
 }) {
@@ -344,7 +341,6 @@ function completeMediaGenerationTaskRun(params: {
   }
   try {
     const endedAt = Date.now();
-    const target = params.count === 1 ? params.paths[0] : `${params.count} files`;
     completeTaskRunByRunId({
       runId: params.handle.runId,
       runtime: "cli",
@@ -354,7 +350,7 @@ function completeMediaGenerationTaskRun(params: {
       progressSummary: `Generated ${params.count} ${params.generatedLabel}${params.count === 1 ? "" : "s"}`,
       terminalSummary:
         params.terminalResult?.terminalSummary ??
-        `Generated ${params.count} ${params.generatedLabel}${params.count === 1 ? "" : "s"} with ${params.provider}/${params.model}${target ? ` -> ${target}` : ""}.`,
+        `Generated ${params.count} ${params.generatedLabel}${params.count === 1 ? "" : "s"} with ${params.provider}/${params.model}.`,
       terminalOutcome: params.terminalResult?.terminalOutcome,
     });
   } finally {
@@ -591,7 +587,6 @@ export function scheduleMediaGenerationTaskCompletion<
         provider: executed.provider,
         model: executed.model,
         count: executed.count,
-        paths: executed.paths,
         terminalResult,
       });
     } catch (error) {

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -401,9 +401,7 @@ type LoadedReferenceImage = Awaited<ReturnType<typeof loadReferenceImages>>[numb
 type ExecutedMusicGeneration = {
   provider: string;
   model: string;
-  savedPaths: string[];
   count: number;
-  paths: string[];
   attachments: AgentGeneratedAttachment[];
   contentText: string;
   details: Record<string, unknown>;
@@ -553,9 +551,7 @@ async function executeMusicGenerationJob(params: {
   return {
     provider: result.provider,
     model: result.model,
-    savedPaths: savedTracks.map((track) => track.path),
     count: savedTracks.length,
-    paths: savedTracks.map((track) => track.path),
     attachments,
     contentText: lines.join("\n"),
     wakeResult: lines.join("\n"),
@@ -891,8 +887,7 @@ export function createMusicGenerateTool(options?: {
           handle: taskHandle,
           provider: executed.provider,
           model: executed.model,
-          count: executed.savedPaths.length,
-          paths: executed.savedPaths,
+          count: executed.count,
         });
         return {
           content: [{ type: "text", text: executed.contentText }],

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -583,12 +583,10 @@ type LoadedReferenceAsset = Awaited<ReturnType<typeof loadReferenceAssets>>[numb
 type ExecutedVideoGeneration = {
   provider: string;
   model: string;
-  savedPaths: string[];
   /** URLs of url-only assets that were not saved locally. */
   urlOnlyUrls: string[];
   /** Total generated video count, including url-only assets. */
   count: number;
-  paths: string[];
   mediaUrls: string[];
   attachments: AgentGeneratedAttachment[];
   contentText: string;
@@ -784,17 +782,21 @@ async function executeVideoGenerationJob(params: {
     },
   );
   const attachments: AgentGeneratedAttachment[] = [
-    ...savedVideos.map((video, index) => ({
-      type: "video" as const,
-      path: video.path,
-      mimeType: video.contentType,
-      name: video.id,
-      sizeBytes: video.size,
-      ...(typeof normalizedDurationSeconds === "number"
-        ? { durationMs: normalizedDurationSeconds * 1000 }
-        : {}),
-      ...savedVideoMetadata[index],
-    })),
+    ...savedVideos.map((video, index) =>
+      Object.assign(
+        {
+          type: "video" as const,
+          path: video.path,
+          mimeType: video.contentType,
+          name: video.id,
+          sizeBytes: video.size,
+          ...(typeof normalizedDurationSeconds === "number"
+            ? { durationMs: normalizedDurationSeconds * 1000 }
+            : {}),
+        },
+        savedVideoMetadata[index] ?? {},
+      ),
+    ),
     ...urlOnlyVideos.map((video) => ({
       type: "video" as const,
       url: video.url,
@@ -819,10 +821,8 @@ async function executeVideoGenerationJob(params: {
   return {
     provider: result.provider,
     model: result.model,
-    savedPaths: savedVideos.map((video) => video.path),
     urlOnlyUrls: urlOnlyVideos.map((video) => video.url),
     count: totalCount,
-    paths: savedVideos.map((video) => video.path),
     mediaUrls: allMediaUrls,
     attachments,
     contentText: lines.join("\n"),
@@ -1270,7 +1270,6 @@ export function createVideoGenerateTool(options?: {
           provider: executed.provider,
           model: executed.model,
           count: executed.count,
-          paths: executed.savedPaths,
         });
 
         return {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -389,6 +389,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
   sessionLifecyclePatch?: SessionTranscriptTurnLifecyclePatch;
   text?: string;
   mediaUrls?: string[];
+  content?: SessionTranscriptAssistantMessage["content"];
   idempotencyKey?: string;
   deliveryMirror?: InternalSessionTranscriptDeliveryMirror;
   /** Optional override for store path (mostly for tests). */
@@ -402,11 +403,15 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     return { ok: false, reason: "missing sessionKey" };
   }
 
-  const mirrorText = resolveMirroredTranscriptText({
-    text: params.text,
-    mediaUrls: params.mediaUrls,
-  });
-  if (!mirrorText) {
+  const mirrorText = params.content
+    ? null
+    : resolveMirroredTranscriptText({
+        text: params.text,
+        mediaUrls: params.mediaUrls,
+      });
+  const content =
+    params.content ?? (mirrorText ? [{ type: "text" as const, text: mirrorText }] : []);
+  if (content.length === 0) {
     return { ok: false, reason: "empty text" };
   }
 
@@ -429,7 +434,7 @@ export async function appendAssistantMessageToSessionTranscript(params: {
     ...(params.beforeMessageWrite ? { beforeMessageWrite: params.beforeMessageWrite } : {}),
     message: {
       role: "assistant" as const,
-      content: [{ type: "text", text: mirrorText }],
+      content,
       api: OPENCLAW_TRANSCRIPT_ARTIFACT_API,
       provider: OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER,
       model: OPENCLAW_DELIVERY_MIRROR_MODEL,

--- a/src/gateway/managed-image-attachments.test.ts
+++ b/src/gateway/managed-image-attachments.test.ts
@@ -16,6 +16,10 @@ import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/sess
 import { resolveExistingAgentSessionStoreTargetsReadOnlyResult } from "../config/sessions/targets-read-availability.js";
 import { createPinnedLookup } from "../infra/net/ssrf.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import {
+  completeSessionDelivery,
+  enqueueSessionDelivery,
+} from "../infra/session-delivery-queue-storage.js";
 import { readImageProbeFromHeader } from "../media/image-ops.js";
 import { setMediaStoreNetworkDepsForTest } from "../media/store.test-support.js";
 import {
@@ -1986,7 +1990,7 @@ describe("attachManagedOutgoingImagesToMessage", () => {
       stateDir,
     });
 
-    await attachManagedOutgoingImagesToMessage({
+    attachManagedOutgoingImagesToMessage({
       messageId: "msg-committed",
       blocks: blocks as Record<string, unknown>[],
       stateDir,
@@ -2061,6 +2065,42 @@ describe("cleanupManagedOutgoingImageRecords", () => {
     const attached = readManagedImageRecord(fixture.attachmentId, stateDir);
     expect(attached?.messageId).toBe("msg-late");
     expect(attached?.retentionClass).toBe("history");
+  });
+
+  it("retains transient records referenced by pending prepared session delivery", async () => {
+    const blocks = await createManagedOutgoingImageBlocks({
+      sessionKey: "agent:main:main",
+      mediaUrls: [`data:image/png;base64,${TINY_PNG_BASE64}`],
+      stateDir,
+    });
+    const attachmentId = requireAttachmentIdFromUrl(blocks[0]?.url);
+    const record = readManagedImageRecord(attachmentId, stateDir);
+    if (!record) {
+      throw new Error("expected pending managed media record");
+    }
+    const queueId = await enqueueSessionDelivery(
+      {
+        kind: "agentTurn",
+        sessionKey: "agent:main:main",
+        message: "deliver generated image",
+        messageId: "generated-image-agent-turn",
+        expectedMediaUrls: ["/tmp/generated.png"],
+        preparedMediaBlocks: {
+          "/tmp/generated.png": blocks as Array<Record<string, unknown>>,
+        },
+      },
+      stateDir,
+    );
+    const afterTtl = Date.parse(record.createdAt) + 16 * 60 * 1000;
+
+    await expect(
+      cleanupManagedOutgoingImageRecords({ stateDir, nowMs: afterTtl }),
+    ).resolves.toEqual({ deletedRecordCount: 0, deletedFileCount: 0, retainedCount: 1 });
+
+    await completeSessionDelivery(queueId, stateDir);
+    await expect(
+      cleanupManagedOutgoingImageRecords({ stateDir, nowMs: afterTtl }),
+    ).resolves.toEqual({ deletedRecordCount: 1, deletedFileCount: 1, retainedCount: 0 });
   });
 
   it("reaps an aged transient record once its session has no active run", async () => {

--- a/src/gateway/managed-image-attachments.ts
+++ b/src/gateway/managed-image-attachments.ts
@@ -24,6 +24,7 @@ import {
 } from "../config/sessions/targets-read-availability.js";
 import { openLocalFileSafely, readLocalFileSafely } from "../infra/fs-safe.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
+import { loadPendingSessionDeliveries } from "../infra/session-delivery-queue-storage.js";
 import { assertLocalMediaAllowed, resolveLocalMediaRoots } from "../media/local-media-access.js";
 import { resolveLocalMediaPath } from "../media/local-media-path.js";
 import { probePlaybackMediaFileDescriptor } from "../media/media-probe.js";
@@ -695,6 +696,7 @@ export async function cleanupManagedOutgoingMediaRecords(params?: {
       : undefined;
   const forceDeleteSessionRecords = params?.forceDeleteSessionRecords === true;
   const entries = listManagedImageRecordEntries({ stateDir });
+  let pendingPreparedAttachmentIds: Set<string> | null | undefined;
 
   let deletedRecordCount = 0;
   let deletedFileCount = 0;
@@ -744,11 +746,19 @@ export async function cleanupManagedOutgoingMediaRecords(params?: {
       shouldDelete = transcriptMatch === "missing";
     } else if (!entry.cleanupPending) {
       const createdAtMs = Date.parse(record.createdAt);
-      shouldDelete =
+      const otherwiseDeletable =
         Number.isFinite(createdAtMs) &&
         nowMs - createdAtMs >= transientMaxAgeMs &&
         params?.hasActiveSessionRun?.(record.sessionKey, record.agentId?.trim() || undefined) !==
           true;
+      if (otherwiseDeletable) {
+        if (pendingPreparedAttachmentIds === undefined) {
+          pendingPreparedAttachmentIds = await loadPendingPreparedAttachmentIds(stateDir);
+        }
+        shouldDelete =
+          pendingPreparedAttachmentIds !== null &&
+          !pendingPreparedAttachmentIds.has(record.attachmentId);
+      }
     }
 
     if (shouldDelete) {
@@ -899,6 +909,26 @@ function collectManagedOutgoingAttachmentRefs(
     }
   }
   return [...refs.values()];
+}
+
+async function loadPendingPreparedAttachmentIds(stateDir: string): Promise<Set<string> | null> {
+  try {
+    const attachmentIds = new Set<string>();
+    for (const entry of await loadPendingSessionDeliveries(stateDir)) {
+      if (entry.kind !== "agentTurn") {
+        continue;
+      }
+      for (const blocks of Object.values(entry.preparedMediaBlocks ?? {})) {
+        for (const ref of collectManagedOutgoingAttachmentRefs(blocks, entry.sessionKey)) {
+          attachmentIds.add(ref.attachmentId);
+        }
+      }
+    }
+    return attachmentIds;
+  } catch {
+    // Queue ownership must be readable before transient artifacts can be reaped safely.
+    return null;
+  }
 }
 
 function getCachedSessionManagedOutgoingAttachmentIndex(
@@ -1259,30 +1289,30 @@ export async function resolveManagedOutgoingMediaUrlDownload(params: {
   return await resolveManagedOutgoingMediaArtifactDownloadForRecord(record, params.stateDir);
 }
 
-export async function attachManagedOutgoingMediaToMessage(params: {
+export function attachManagedOutgoingMediaToMessage(params: {
   messageId: string;
   blocks?: readonly Record<string, unknown>[];
   stateDir?: string;
 }) {
   const messageId = params.messageId.trim();
   if (!messageId) {
-    return;
+    return false;
   }
   const refs = collectManagedOutgoingAttachmentRefs(params.blocks);
   if (refs.length === 0) {
-    return;
+    return false;
   }
-  await Promise.all(
-    refs.map(async ({ attachmentId, sessionKey }) => {
+  return refs
+    .map(({ attachmentId, sessionKey }) =>
       attachManagedImageRecordToMessage({
         attachmentId,
         sessionKey,
         messageId,
         updatedAt: new Date().toISOString(),
         stateDir: params.stateDir,
-      });
-    }),
-  );
+      }),
+    )
+    .every(Boolean);
 }
 
 export async function createManagedOutgoingMediaBlocks(params: {

--- a/src/gateway/server-methods/chat-send-nonagent-finalization.ts
+++ b/src/gateway/server-methods/chat-send-nonagent-finalization.ts
@@ -322,7 +322,7 @@ export async function finalizeChatSendNonAgentReplies(params: {
     });
     if (appended.ok) {
       if (appended.messageId && assistantContent?.length) {
-        await attachManagedOutgoingMediaToMessage({
+        attachManagedOutgoingMediaToMessage({
           messageId: appended.messageId,
           blocks: assistantContent,
         });

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -242,7 +242,7 @@ export function createChatSendReplyDispatch(params: {
           rewritten: [rewritten],
         });
         if (assistantContent?.length) {
-          await attachManagedOutgoingMediaToMessage({
+          attachManagedOutgoingMediaToMessage({
             messageId: rewritten.messageId,
             blocks: assistantContent,
           });
@@ -292,7 +292,7 @@ export function createChatSendReplyDispatch(params: {
           rewritten: [rewritten],
         });
         if (assistantContent?.length) {
-          await attachManagedOutgoingMediaToMessage({
+          attachManagedOutgoingMediaToMessage({
             messageId: rewritten.messageId,
             blocks: assistantContent,
           });
@@ -319,7 +319,7 @@ export function createChatSendReplyDispatch(params: {
     });
     if (appended.ok) {
       if (appended.messageId && assistantContent?.length) {
-        await attachManagedOutgoingMediaToMessage({
+        attachManagedOutgoingMediaToMessage({
           messageId: appended.messageId,
           blocks: assistantContent,
         });

--- a/src/gateway/server-methods/chat-send-source-finalization.ts
+++ b/src/gateway/server-methods/chat-send-source-finalization.ts
@@ -233,7 +233,7 @@ export async function finalizeChatSendSourceReplies(params: {
     if (!attachParams.messageId) {
       return;
     }
-    await attachManagedOutgoingMediaToMessage({
+    attachManagedOutgoingMediaToMessage({
       messageId: attachParams.messageId,
       blocks: attachParams.request.state.persistedContent,
     });

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 
 type AppendMessageArg = Parameters<SessionManager["appendMessage"]>[0];
+type AssistantMessageContent = Extract<AppendMessageArg, { role: "assistant" }>["content"];
 
 /** Metadata persisted on gateway-injected assistant messages that mark a stopped run. */
 type GatewayInjectedAbortMeta = {
@@ -52,6 +53,13 @@ function resolveInjectedAssistantContent(params: {
     return [{ type: "text", text: labelPrefix.trim() }, ...params.content];
   }
   return [{ type: "text", text: `${labelPrefix}${params.message}` }];
+}
+
+/** Clone Gateway display blocks into the transcript's assistant-content boundary. */
+export function prepareGatewayInjectedAssistantContent(
+  content: readonly Record<string, unknown>[],
+): AssistantMessageContent {
+  return content.map((block) => Object.assign({}, block)) as unknown as AssistantMessageContent;
 }
 
 /** Append a gateway-authored assistant message while preserving transcript parent links. */
@@ -103,10 +111,7 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
   const messageBody: AppendMessageArg & Record<string, unknown> = applyAssistantDeliveryDirectives({
     role: "assistant",
     // Gateway-injected assistant messages can include non-model content blocks (e.g. embedded TTS audio).
-    content: resolvedContent.map((block) => Object.assign({}, block)) as unknown as Extract<
-      AppendMessageArg,
-      { role: "assistant" }
-    >["content"],
+    content: prepareGatewayInjectedAssistantContent(resolvedContent),
     timestamp: now,
     // stopReason is a strict runner enum; this is not model output, but we still store it as a
     // normal assistant message so it participates in the session parentId chain.

--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   collectAmbiguousAutomaticMediaUrls,
   collectAutomaticDeliveredMediaUrls,
@@ -11,11 +12,15 @@ import {
 } from "../agents/embedded-agent-runner/delivery-evidence.js";
 import { formatGeneratedMediaDeliveryRetryForPrompt } from "../agents/internal-events.js";
 import { resolveDurableCompletionDeliveryMode } from "../auto-reply/reply/completion-delivery-policy.js";
+import { resolveStateDir } from "../config/paths.js";
 import {
   getRestartRecoveryTerminalDeliveryEvidence,
   hasRestartRecoveryTerminalRun,
 } from "../config/sessions/restart-recovery-state.js";
-import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
+import {
+  appendAssistantMessageToSessionTranscript,
+  type SessionTranscriptAssistantMessage,
+} from "../config/sessions/transcript.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import {
   advanceSessionDeliveryAgentRun,
@@ -23,6 +28,7 @@ import {
   failSessionDelivery,
   markSessionDeliveryAttemptStarted,
   markSessionDeliverySettlement,
+  mergeSessionDeliveryPreparedMediaBlocks,
   SessionDeliveryDeadLetteredError,
   SessionDeliveryDeferredError,
   SessionDeliveryRetryChargedError,
@@ -32,7 +38,12 @@ import {
 } from "../infra/session-delivery-queue-storage.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeMediaReferenceForComparison } from "../media/media-reference-comparison.js";
+import { getMediaDir } from "../media/store.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
+import {
+  attachManagedOutgoingMediaToMessage,
+  createManagedOutgoingMediaBlocks,
+} from "./managed-image-attachments.js";
 import type { GatewayContextResolver } from "./server-methods/types.js";
 import { dispatchGatewayLifecycleMethod as dispatchGatewayMethodInProcess } from "./server-recovery-runtime-context.js";
 import { loadSessionEntry } from "./session-utils.js";
@@ -41,6 +52,7 @@ const log = createSubsystemLogger("gateway/restart-sentinel");
 const AGENT_DELIVERY_OWNERSHIP_RETRY_MS = 1_000;
 
 type QueuedAgentTurnSessionDelivery = Extract<QueuedSessionDelivery, { kind: "agentTurn" }>;
+type GeneratedMediaTranscriptContent = SessionTranscriptAssistantMessage["content"];
 
 function sessionDeliveryStateDirArgs(stateDir?: string): [] | [string] {
   return stateDir === undefined ? [] : [stateDir];
@@ -63,8 +75,8 @@ async function deadLetterSessionDelivery(
 }
 
 function hasQueuedVisiblePayload(payload: unknown): boolean {
-  if (payload && typeof payload === "object" && !Array.isArray(payload)) {
-    const visible = (payload as { visible?: unknown }).visible;
+  if (isRecord(payload)) {
+    const visible = payload.visible;
     if (typeof visible === "boolean") {
       return visible;
     }
@@ -345,6 +357,42 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
           if (!sessionId) {
             throw new Error("queued internal generated-media delivery has no owning session");
           }
+          const stateDir = params.stateDir ?? resolveStateDir();
+          const preparedMediaBlocks = { ...entry.preparedMediaBlocks };
+          const content: Array<Record<string, unknown>> = [];
+          for (const mediaUrl of mediaUrls) {
+            let blocks = preparedMediaBlocks[mediaUrl];
+            if (!blocks) {
+              blocks = await createManagedOutgoingMediaBlocks({
+                sessionKey: params.canonicalKey,
+                agentId: params.agentId,
+                mediaUrls: [mediaUrl],
+                attachments: [entry.expectedMediaAttachments?.[mediaUrl] ?? {}],
+                stateDir,
+                localRoots: [getMediaDir()],
+                allowLocalNonImage: true,
+              });
+              if (
+                !blocks.some(
+                  (block) =>
+                    block.type === "image" || block.type === "audio" || block.type === "video",
+                )
+              ) {
+                throw new Error("queued internal generated media could not be prepared");
+              }
+              blocks = await mergeSessionDeliveryPreparedMediaBlocks(
+                entry.id,
+                mediaUrl,
+                blocks,
+                stateDir,
+              );
+              preparedMediaBlocks[mediaUrl] = blocks;
+            }
+            content.push(...blocks);
+          }
+          const transcriptContent =
+            // SAFETY: managed preparation returns transcript display blocks.
+            content as unknown as GeneratedMediaTranscriptContent;
           const appended = await appendAssistantMessageToSessionTranscript({
             agentId: params.agentId,
             sessionKey: params.canonicalKey,
@@ -356,7 +404,7 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
                     params.sessionEntry.cronRunContinuation.lifecycleRevision,
                 }
               : {}),
-            mediaUrls,
+            content: transcriptContent,
             idempotencyKey: `${queuedRunId}:generated-media-transcript`,
             updateMode: "inline",
           });
@@ -371,6 +419,14 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
             throw new Error(
               `queued internal generated-media transcript persistence failed: ${appended.reason}`,
             );
+          }
+          const attached = attachManagedOutgoingMediaToMessage({
+            messageId: appended.messageId,
+            blocks: content,
+            stateDir,
+          });
+          if (!attached) {
+            throw new Error("queued internal generated-media artifact attachment failed");
           }
         }
       : undefined;

--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -17,10 +17,7 @@ import {
   getRestartRecoveryTerminalDeliveryEvidence,
   hasRestartRecoveryTerminalRun,
 } from "../config/sessions/restart-recovery-state.js";
-import {
-  appendAssistantMessageToSessionTranscript,
-  type SessionTranscriptAssistantMessage,
-} from "../config/sessions/transcript.js";
+import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import {
   advanceSessionDeliveryAgentRun,
@@ -44,6 +41,7 @@ import {
   attachManagedOutgoingMediaToMessage,
   createManagedOutgoingMediaBlocks,
 } from "./managed-image-attachments.js";
+import { prepareGatewayInjectedAssistantContent } from "./server-methods/chat-transcript-inject.js";
 import type { GatewayContextResolver } from "./server-methods/types.js";
 import { dispatchGatewayLifecycleMethod as dispatchGatewayMethodInProcess } from "./server-recovery-runtime-context.js";
 import { loadSessionEntry } from "./session-utils.js";
@@ -52,7 +50,6 @@ const log = createSubsystemLogger("gateway/restart-sentinel");
 const AGENT_DELIVERY_OWNERSHIP_RETRY_MS = 1_000;
 
 type QueuedAgentTurnSessionDelivery = Extract<QueuedSessionDelivery, { kind: "agentTurn" }>;
-type GeneratedMediaTranscriptContent = SessionTranscriptAssistantMessage["content"];
 
 function sessionDeliveryStateDirArgs(stateDir?: string): [] | [string] {
   return stateDir === undefined ? [] : [stateDir];
@@ -390,9 +387,6 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
             }
             content.push(...blocks);
           }
-          const transcriptContent =
-            // SAFETY: managed preparation returns transcript display blocks.
-            content as unknown as GeneratedMediaTranscriptContent;
           const appended = await appendAssistantMessageToSessionTranscript({
             agentId: params.agentId,
             sessionKey: params.canonicalKey,
@@ -404,7 +398,7 @@ export async function deliverQueuedGeneratedMediaAgentTurn(params: {
                     params.sessionEntry.cronRunContinuation.lifecycleRevision,
                 }
               : {}),
-            content: transcriptContent,
+            content: prepareGatewayInjectedAssistantContent(content),
             idempotencyKey: `${queuedRunId}:generated-media-transcript`,
             updateMode: "inline",
           });

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -1,6 +1,9 @@
 // Restart sentinel tests protect queued post-restart delivery recovery and the
 // session/channel context used when the gateway resumes an interrupted run.
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import {
   loadTranscriptEvents,
@@ -38,12 +41,18 @@ type DeferSessionDeliveryMock =
   typeof import("../infra/session-delivery-queue-storage.js").deferSessionDelivery;
 type FailSessionDeliveryMock =
   typeof import("../infra/session-delivery-queue-storage.js").failSessionDelivery;
+type MergeSessionDeliveryPreparedMediaBlocksMock =
+  typeof import("../infra/session-delivery-queue-storage.js").mergeSessionDeliveryPreparedMediaBlocks;
 type RecoverPendingSessionDeliveriesMock =
   typeof import("../infra/session-delivery-queue-recovery.js").recoverPendingSessionDeliveries;
 type DrainPendingSessionDeliveryMock =
   typeof import("../infra/session-delivery-queue-recovery.js").drainPendingSessionDelivery;
 type AppendAssistantMessageToSessionTranscriptMock =
   typeof import("../config/sessions/transcript.js").appendAssistantMessageToSessionTranscript;
+type CreateManagedOutgoingMediaBlocksMock =
+  typeof import("./managed-image-attachments.js").createManagedOutgoingMediaBlocks;
+type AttachManagedOutgoingMediaToMessageMock =
+  typeof import("./managed-image-attachments.js").attachManagedOutgoingMediaToMessage;
 
 const mocks = vi.hoisted(() => {
   const state = {
@@ -158,6 +167,9 @@ const mocks = vi.hoisted(() => {
     advanceSessionDeliveryAgentRun: vi.fn<AdvanceSessionDeliveryAgentRunMock>(async () => {}),
     deferSessionDelivery: vi.fn<DeferSessionDeliveryMock>(async () => {}),
     failSessionDelivery: vi.fn<FailSessionDeliveryMock>(async () => {}),
+    mergeSessionDeliveryPreparedMediaBlocks: vi.fn<MergeSessionDeliveryPreparedMediaBlocksMock>(
+      async (_id, _mediaUrl, blocks) => blocks,
+    ),
     markSessionDeliveryAttemptStarted: vi.fn(async () => {}),
     markSessionDeliverySettlement: vi.fn(async () => {}),
     appendAssistantMessageToSessionTranscript: vi.fn<AppendAssistantMessageToSessionTranscriptMock>(
@@ -172,6 +184,15 @@ const mocks = vi.hoisted(() => {
         messageId: "generated-media-transcript",
       }),
     ),
+    createManagedOutgoingMediaBlocks: vi.fn<CreateManagedOutgoingMediaBlocksMock>(async (params) =>
+      (params.mediaUrls ?? []).map((mediaUrl) => ({
+        type: params.attachments?.[0]?.type ?? "image",
+        artifactId: `artifact:${mediaUrl}`,
+        url: `/api/chat/media/outgoing/${encodeURIComponent(params.sessionKey)}/${encodeURIComponent(mediaUrl)}/full`,
+        openUrl: `/api/chat/media/outgoing/${encodeURIComponent(params.sessionKey)}/${encodeURIComponent(mediaUrl)}/full`,
+      })),
+    ),
+    attachManagedOutgoingMediaToMessage: vi.fn<AttachManagedOutgoingMediaToMessageMock>(() => true),
     removeCronRunContinuationSessionIfIdle: vi.fn(async () => {}),
     settleCorrelatedSubagentDelivery: vi.fn(async () => {}),
     loadPendingSessionDelivery: vi.fn(),
@@ -238,12 +259,21 @@ vi.mock("../infra/session-delivery-queue-storage.js", async (importOriginal) => 
       await actual.failSessionDelivery(id, error, stateDir, options);
     }
   });
+  mocks.mergeSessionDeliveryPreparedMediaBlocks.mockImplementation(
+    async (id, mediaUrl, blocks, stateDir) => {
+      if (await actual.loadPendingSessionDelivery(id, stateDir)) {
+        return await actual.mergeSessionDeliveryPreparedMediaBlocks(id, mediaUrl, blocks, stateDir);
+      }
+      return blocks;
+    },
+  );
   mocks.loadPendingSessionDelivery.mockImplementation(actual.loadPendingSessionDelivery);
   return {
     ...actual,
     advanceSessionDeliveryAgentRun: mocks.advanceSessionDeliveryAgentRun,
     deferSessionDelivery: mocks.deferSessionDelivery,
     failSessionDelivery: mocks.failSessionDelivery,
+    mergeSessionDeliveryPreparedMediaBlocks: mocks.mergeSessionDeliveryPreparedMediaBlocks,
     enqueueSessionDelivery: mocks.enqueueSessionDelivery,
     loadPendingSessionDelivery: mocks.loadPendingSessionDelivery,
     markSessionDeliveryAttemptStarted: mocks.markSessionDeliveryAttemptStarted,
@@ -271,6 +301,12 @@ vi.mock("../config/sessions/transcript.js", () => ({
   appendAssistantMessageToSessionTranscript: mocks.appendAssistantMessageToSessionTranscript,
 }));
 
+vi.mock("./managed-image-attachments.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./managed-image-attachments.js")>()),
+  createManagedOutgoingMediaBlocks: mocks.createManagedOutgoingMediaBlocks,
+  attachManagedOutgoingMediaToMessage: mocks.attachManagedOutgoingMediaToMessage,
+}));
+
 vi.mock("../config/sessions.js", () => ({
   resolveSystemMainSessionTarget: mocks.resolveSystemMainSessionTarget,
   resolveSessionStorePathCore: vi.fn(() => "/tmp/sessions.json"),
@@ -283,7 +319,8 @@ vi.mock("../config/sessions/thread-info.js", () => ({
   parseSessionThreadInfo: mocks.parseSessionThreadInfo,
 }));
 
-vi.mock("./session-utils.js", () => ({
+vi.mock("./session-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./session-utils.js")>()),
   loadSessionEntry: mocks.loadSessionEntry,
 }));
 
@@ -677,9 +714,12 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.advanceSessionDeliveryAgentRun.mockClear();
     mocks.deferSessionDelivery.mockClear();
     mocks.failSessionDelivery.mockClear();
+    mocks.mergeSessionDeliveryPreparedMediaBlocks.mockClear();
     mocks.markSessionDeliveryAttemptStarted.mockClear();
     mocks.markSessionDeliverySettlement.mockClear();
     mocks.appendAssistantMessageToSessionTranscript.mockClear();
+    mocks.createManagedOutgoingMediaBlocks.mockClear();
+    mocks.attachManagedOutgoingMediaToMessage.mockClear();
     mocks.removeCronRunContinuationSessionIfIdle.mockClear();
     mocks.settleCorrelatedSubagentDelivery.mockClear();
     mocks.loadPendingSessionDelivery.mockClear();
@@ -1497,45 +1537,64 @@ describe("scheduleRestartSentinelWake", () => {
     expect(mocks.deferSessionDelivery).not.toHaveBeenCalled();
   });
 
-  it("accepts a generated-media reply committed only to the owning transcript", async () => {
+  it("persists internal generated audio as managed transcript content", async () => {
+    const attachment = {
+      type: "audio" as const,
+      mediaUrl: "/tmp/proof.mp3",
+      mimeType: "audio/mpeg",
+    };
     mocks.dispatchGatewayMethodInProcess.mockResolvedValueOnce({
       status: "ok",
-      result: {
-        payloads: [{ text: "ready", mediaUrls: ["/tmp/proof.png"] }],
-      },
+      result: { payloads: [{ text: "ready", mediaUrls: [attachment.mediaUrl] }] },
     });
 
     await deliverGeneratedMedia({
-      id: "session-delivery-media-internal",
-      messageId: "image:task-internal:agent-loop",
+      id: `session-delivery-media-internal-${attachment.type}`,
+      messageId: `${attachment.type}:task-internal:agent-loop`,
       route: { channel: "webchat", to: "agent:main:main", chatType: "direct" },
-      expectedMediaUrls: ["/tmp/proof.png"],
+      expectedMediaUrls: [attachment.mediaUrl],
+      expectedMediaAttachments: {
+        [attachment.mediaUrl]: {
+          type: attachment.type,
+          path: attachment.mediaUrl,
+          mimeType: attachment.mimeType,
+        },
+      },
     });
 
     expect(mocks.dispatchGatewayMethodInProcess).toHaveBeenCalledWith(
       "agent",
       expect.objectContaining({ deliver: false, sourceReplyDeliveryMode: "automatic" }),
-      {
-        expectFinal: true,
-        forceSyntheticClient: true,
-        internalDeliveryMediaUrls: ["/tmp/proof.png"],
-        onAccepted: expect.any(Function),
-      },
+      expect.objectContaining({ internalDeliveryMediaUrls: [attachment.mediaUrl] }),
     );
-    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
-      agentId: "main",
+    expect(mocks.createManagedOutgoingMediaBlocks).toHaveBeenCalledWith({
       sessionKey: "agent:main:main",
-      storePath: "/tmp/sessions.json",
-      expectedSessionId: "agent:main:main",
-      mediaUrls: ["/tmp/proof.png"],
-      idempotencyKey: "image:task-internal:agent-loop:generated-media-transcript",
-      updateMode: "inline",
+      agentId: "main",
+      mediaUrls: [attachment.mediaUrl],
+      attachments: [
+        { type: attachment.type, path: attachment.mediaUrl, mimeType: attachment.mimeType },
+      ],
+      stateDir: testState.stateDir,
+      localRoots: [testState.statePath("media")],
+      allowLocalNonImage: true,
     });
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: [expect.objectContaining({ type: attachment.type })],
+        idempotencyKey: `${attachment.type}:task-internal:agent-loop:generated-media-transcript`,
+      }),
+    );
+    expect(mocks.attachManagedOutgoingMediaToMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: "generated-media-transcript" }),
+    );
     expect(mocks.advanceSessionDeliveryAgentRun).not.toHaveBeenCalled();
   });
 
   it("persists targetless global generated media in its resolved owner transcript", async () => {
     const sessionId = "ops-global-session";
+    const mediaPath = testState.statePath("media", "tool-image-generation", "proof.png");
+    await fs.mkdir(path.dirname(mediaPath), { recursive: true });
+    await fs.writeFile(mediaPath, createSolidPngBuffer(1, 1, { r: 24, g: 64, b: 128 }));
     const opsStorePath = testState.statePath("agents", "ops", "sessions", "sessions.json");
     const researchStorePath = testState.statePath(
       "agents",
@@ -1551,12 +1610,27 @@ describe("scheduleRestartSentinelWake", () => {
       { agentId: "research", sessionKey: "global", storePath: researchStorePath },
       { sessionId: "research-global-session", updatedAt: 1 },
     );
-    const { appendAssistantMessageToSessionTranscript } = await vi.importActual<
+    const transcriptActual = await vi.importActual<
       typeof import("../config/sessions/transcript.js")
     >("../config/sessions/transcript.js");
-    mocks.appendAssistantMessageToSessionTranscript.mockImplementationOnce(
-      appendAssistantMessageToSessionTranscript,
+    const managedMediaActual = await vi.importActual<
+      typeof import("./managed-image-attachments.js")
+    >("./managed-image-attachments.js");
+    const queueStorageActual = await vi.importActual<
+      typeof import("../infra/session-delivery-queue-storage.js")
+    >("../infra/session-delivery-queue-storage.js");
+    const { readManagedImageRecord } = await import("./managed-image-record-store.js");
+    mocks.appendAssistantMessageToSessionTranscript
+      .mockImplementationOnce(transcriptActual.appendAssistantMessageToSessionTranscript)
+      .mockImplementationOnce(transcriptActual.appendAssistantMessageToSessionTranscript);
+    mocks.createManagedOutgoingMediaBlocks.mockImplementationOnce(
+      managedMediaActual.createManagedOutgoingMediaBlocks,
     );
+    mocks.attachManagedOutgoingMediaToMessage
+      .mockImplementationOnce(() => {
+        throw new Error("synthetic crash after transcript append");
+      })
+      .mockImplementationOnce(managedMediaActual.attachManagedOutgoingMediaToMessage);
     mocks.loadSessionEntry.mockReturnValue({
       cfg: {},
       agentId: "ops",
@@ -1568,13 +1642,71 @@ describe("scheduleRestartSentinelWake", () => {
       legacyKey: undefined,
     });
 
-    await deliverGeneratedMedia({
-      id: "session-delivery-media-global",
-      sessionKey: "global",
-      messageId: "image:task-global:agent-loop",
-      route: { channel: "webchat", to: "global", chatType: "direct" },
-      expectedMediaUrls: ["/tmp/proof.png"],
+    const queueId = await queueStorageActual.enqueueSessionDelivery(
+      {
+        kind: "agentTurn",
+        sessionKey: "global",
+        message: "generated image ready",
+        messageId: "image:task-global:agent-loop",
+        route: { channel: "webchat", to: "global", chatType: "direct" },
+        inputProvenance: {
+          kind: "inter_session",
+          sourceChannel: "webchat",
+          sourceTool: "image_generate",
+        },
+        sourceReplyDeliveryMode: "automatic",
+        expectedMediaUrls: [mediaPath],
+        expectedMediaAttachments: {
+          [mediaPath]: {
+            type: "image",
+            path: mediaPath,
+            name: "proof.png",
+            mimeType: "image/png",
+            sizeBytes: (await fs.stat(mediaPath)).size,
+            width: 1,
+            height: 1,
+          },
+        },
+        idempotencyKey: "image:task-global:agent-loop",
+      },
+      testState.stateDir,
+    );
+    const firstAttempt = await queueStorageActual.loadPendingSessionDelivery(
+      queueId,
+      testState.stateDir,
+    );
+    if (!firstAttempt || firstAttempt.kind !== "agentTurn") {
+      throw new Error("expected queued generated media attempt");
+    }
+    mocks.dispatchGatewayMethodInProcess.mockResolvedValue({
+      status: "ok",
+      result: { payloads: [{ text: "ready", mediaUrls: [mediaPath] }] },
     });
+
+    await expect(deliverGeneratedMedia(firstAttempt, testState.stateDir)).rejects.toThrow(
+      "synthetic crash after transcript append",
+    );
+    const replayAttempt = await queueStorageActual.loadPendingSessionDelivery(
+      queueId,
+      testState.stateDir,
+    );
+    if (!replayAttempt || replayAttempt.kind !== "agentTurn") {
+      throw new Error("expected prepared generated media replay");
+    }
+    const firstPreparedBlocks = replayAttempt.preparedMediaBlocks?.[mediaPath];
+    expect(firstPreparedBlocks).toEqual([
+      expect.objectContaining({ type: "image", artifactId: expect.any(String) }),
+    ]);
+
+    await deliverGeneratedMedia(replayAttempt, testState.stateDir);
+    const afterReplay = await queueStorageActual.loadPendingSessionDelivery(
+      queueId,
+      testState.stateDir,
+    );
+    expect(
+      afterReplay?.kind === "agentTurn" ? afterReplay.preparedMediaBlocks?.[mediaPath] : null,
+    ).toEqual(firstPreparedBlocks);
+    expect(mocks.createManagedOutgoingMediaBlocks).toHaveBeenCalledTimes(1);
 
     const opsEvents = await loadTranscriptEvents({
       agentId: "ops",
@@ -1582,16 +1714,34 @@ describe("scheduleRestartSentinelWake", () => {
       sessionKey: "global",
       storePath: opsStorePath,
     });
-    expect(opsEvents).toMatchObject([
-      { type: "session", id: sessionId },
-      {
-        type: "message",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "proof.png" }],
-        },
-      },
+    expect(opsEvents).toHaveLength(2);
+    expect(opsEvents[0]).toMatchObject({ type: "session", id: sessionId });
+    const messageEvent = opsEvents[1] as {
+      id?: string;
+      message?: { role?: string; content?: Array<Record<string, unknown>> };
+    };
+    expect(messageEvent.message).toMatchObject({
+      role: "assistant",
+      content: [expect.objectContaining({ type: "image", artifactId: expect.any(String) })],
+    });
+    expect(messageEvent.message?.content).not.toEqual([
+      { type: "text", text: path.basename(mediaPath) },
     ]);
+    const imageBlock = messageEvent.message?.content?.[0];
+    const artifactId = imageBlock?.artifactId;
+    expect(artifactId).toBeTypeOf("string");
+    const parsedArtifact = managedMediaActual.parseManagedOutgoingArtifactId(String(artifactId));
+    expect(parsedArtifact).not.toBeNull();
+    const record = readManagedImageRecord(parsedArtifact?.attachmentId ?? "", testState.stateDir);
+    expect(record).toMatchObject({ messageId: messageEvent.id, sessionKey: "global" });
+    await expect(
+      managedMediaActual.resolveManagedOutgoingMediaArtifactDownload({
+        sessionKey: "global",
+        agentId: "ops",
+        artifactId: String(artifactId),
+        stateDir: testState.stateDir,
+      }),
+    ).resolves.toMatchObject({ artifactId, type: "image" });
     await expect(
       loadTranscriptEvents({
         agentId: "research",
@@ -1619,16 +1769,32 @@ describe("scheduleRestartSentinelWake", () => {
         messageId: "image:task-internal-partial:agent-loop",
         route: { channel: "webchat", to: "agent:main:main", chatType: "direct" },
         expectedMediaUrls: ["/tmp/one.png", "/tmp/two.png"],
+        expectedMediaAttachments: {
+          "/tmp/one.png": { type: "image", path: "/tmp/one.png", name: "one.png" },
+          "/tmp/two.png": { type: "image", path: "/tmp/two.png", name: "two.png" },
+        },
       }),
     ).rejects.toThrow("partially missed expected media: /tmp/two.png");
 
     expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "main",
-        mediaUrls: ["/tmp/one.png"],
+        content: [expect.objectContaining({ type: "image" })],
         storePath: "/tmp/sessions.json",
         idempotencyKey: "image:task-internal-partial:agent-loop:generated-media-transcript",
       }),
+    );
+    expect(mocks.createManagedOutgoingMediaBlocks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mediaUrls: ["/tmp/one.png"],
+        attachments: [{ type: "image", path: "/tmp/one.png", name: "one.png" }],
+      }),
+    );
+    expect(mocks.mergeSessionDeliveryPreparedMediaBlocks).toHaveBeenCalledWith(
+      "session-delivery-media-internal-partial",
+      "/tmp/one.png",
+      [expect.objectContaining({ type: "image" })],
+      testState.stateDir,
     );
     expect(mocks.advanceSessionDeliveryAgentRun).toHaveBeenCalledWith(
       "session-delivery-media-internal-partial",

--- a/src/infra/session-delivery-queue-storage.ts
+++ b/src/infra/session-delivery-queue-storage.ts
@@ -1,5 +1,6 @@
 import { computeBackoff } from "../../packages/retry/src/index.js";
 // Persists queued session deliveries for retry and recovery.
+import type { ReplyMediaAttachment } from "../auto-reply/reply-payload.js";
 import type { SourceReplyDeliveryMode } from "../auto-reply/source-reply-delivery-mode.types.js";
 import type { ChatType } from "../channels/chat-type.js";
 import type { InputProvenance } from "../sessions/input-provenance.js";
@@ -74,6 +75,8 @@ export type QueuedSessionDeliveryPayload =
       inputProvenance?: InputProvenance;
       sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
       expectedMediaUrls?: string[];
+      expectedMediaAttachments?: Record<string, ReplyMediaAttachment>;
+      preparedMediaBlocks?: Record<string, Array<Record<string, unknown>>>;
       suppressTextDelivery?: true;
       idempotencyKey?: string;
       owner?: SessionDeliveryOwnerReference;
@@ -236,6 +239,30 @@ export async function advanceSessionDeliveryAgentRun(
       ...(updates?.suppressTextDelivery === true ? { suppressTextDelivery: true as const } : {}),
     };
   });
+}
+
+/** Preserve one prepared artifact before transcript persistence or retry transitions. */
+export async function mergeSessionDeliveryPreparedMediaBlocks(
+  id: string,
+  mediaUrl: string,
+  blocks: Array<Record<string, unknown>>,
+  stateDir?: string,
+): Promise<Array<Record<string, unknown>>> {
+  let retained = blocks;
+  updateDeliveryQueueEntry(SESSION_DELIVERY_QUEUE_NAME, id, stateDir, (entry) => {
+    // SAFETY: this queue namespace stores only QueuedSessionDelivery payloads.
+    const queued = entry as QueuedSessionDelivery;
+    if (queued.kind !== "agentTurn") {
+      return queued;
+    }
+    retained = queued.preparedMediaBlocks?.[mediaUrl] ?? blocks;
+    return {
+      ...queued,
+      // The first durable artifact identity wins if the same attempt is replayed.
+      preparedMediaBlocks: { ...queued.preparedMediaBlocks, [mediaUrl]: retained },
+    };
+  });
+  return retained;
 }
 
 /** Mark an agent turn before it can commit transcript or channel side effects. */

--- a/src/infra/session-delivery-queue.storage.test.ts
+++ b/src/infra/session-delivery-queue.storage.test.ts
@@ -13,6 +13,7 @@ import {
   loadPendingSessionDeliveries,
   markSessionDeliveryAttemptStarted,
   markSessionDeliverySettlement,
+  mergeSessionDeliveryPreparedMediaBlocks,
   moveSessionDeliveryToFailed,
   releaseSessionDeliveryClaim,
 } from "./session-delivery-queue-storage.js";
@@ -299,6 +300,10 @@ describe("session-delivery queue storage", () => {
           message: "all generated media",
           messageId: "image:task-retry:agent-loop",
           expectedMediaUrls: ["/tmp/one.png", "/tmp/two.png"],
+          expectedMediaAttachments: {
+            "/tmp/one.png": { type: "image", path: "/tmp/one.png", mimeType: "image/png" },
+            "/tmp/two.png": { type: "image", path: "/tmp/two.png", mimeType: "image/png" },
+          },
         },
         tempDir,
       );
@@ -309,6 +314,27 @@ describe("session-delivery queue storage", () => {
       expect(entry).toMatchObject({ retryCount: 1 });
       expect(entry?.agentRunAttempt).toBeUndefined();
       expect(entry?.availableAt).toBeGreaterThan(Date.now());
+
+      await mergeSessionDeliveryPreparedMediaBlocks(
+        id,
+        "/tmp/one.png",
+        [{ type: "image", artifactId: "artifact-one" }],
+        tempDir,
+      );
+      await expect(
+        mergeSessionDeliveryPreparedMediaBlocks(
+          id,
+          "/tmp/one.png",
+          [{ type: "image", artifactId: "replacement-must-not-win" }],
+          tempDir,
+        ),
+      ).resolves.toEqual([{ type: "image", artifactId: "artifact-one" }]);
+      await mergeSessionDeliveryPreparedMediaBlocks(
+        id,
+        "/tmp/two.png",
+        [{ type: "image", artifactId: "artifact-two" }],
+        tempDir,
+      );
 
       await advanceSessionDeliveryAgentRun(
         id,
@@ -325,6 +351,14 @@ describe("session-delivery queue storage", () => {
         retryCount: 1,
         message: "only missing media",
         expectedMediaUrls: ["/tmp/two.png"],
+        expectedMediaAttachments: {
+          "/tmp/one.png": { type: "image", path: "/tmp/one.png", mimeType: "image/png" },
+          "/tmp/two.png": { type: "image", path: "/tmp/two.png", mimeType: "image/png" },
+        },
+        preparedMediaBlocks: {
+          "/tmp/one.png": [{ type: "image", artifactId: "artifact-one" }],
+          "/tmp/two.png": [{ type: "image", artifactId: "artifact-two" }],
+        },
         suppressTextDelivery: true,
       });
     });


### PR DESCRIPTION
Closes #126006

## What Problem This Solves

Fixes an issue where users opening Board chat or another transcript surface would see an opaque generated-media filename instead of the image, audio player, or video preview when a background generation completed through durable session recovery.

## Why This Change Was Made

Durable recovery previously retained only media URLs, then sent them through the generic transcript mirror that intentionally reduces media references to filename text. This change carries the generated attachment descriptors through the durable queue, materializes them with the existing Gateway managed-media owner, persists exact typed assistant content, and attaches the resulting artifact records to the authoritative transcript message.

Prepared media blocks are checkpointed before transcript persistence, so a crash or replay reuses the same artifact IDs. Partial delivery persists proven media and retries only the missing subset. Pending queue references also protect transient managed-media records from garbage collection. No SQLite schema version or Gateway protocol change is required because the queue payload remains opaque JSON.

The adjacent generated-task completion summary no longer includes local output paths, removing the separate source of random-looking filenames in session/task UI.

Media-repair production delta: +228/-127 (net +101). Test delta: +340/-85 (net +255). Tooling baseline delta: +1/-1 (net 0, shrink-only assertion ratchet maintenance). The production growth is the durable descriptor/checkpoint contract, managed-media finalization, and queue-aware retention needed to preserve artifact identity across crashes.

During landing, exact-head merge CI exposed two current-`main` integration failures unrelated to this media patch: protocol max-lines and missing Codex test-lane ownership. The canonical fix landed separately as [#126275](https://github.com/openclaw/openclaw/pull/126275). This branch was rebased onto that merge and its temporary CI commits were dropped; both remaining media commits are patch-identical by `git range-diff`, so this PR is focused on the generated-media repair again.

## User Impact

Recovered generated images now render as images in Board chat and transcript consumers instead of random filename text. Generated audio and video retain their typed players as well. A crash between media preparation, transcript append, and artifact attachment can be replayed without duplicating the transcript message or minting a new artifact.

## Evidence

### Before and after

| Before: filename-only transcript | After: managed image preview |
| --- | --- |
| ![Board chat showing an opaque generated image filename](https://github.com/user-attachments/assets/094fea74-1fe6-4b65-8d17-5ef2f7fdfacb) | ![Board chat showing the generated image preview](https://github.com/user-attachments/assets/6c4c3a21-28a2-4406-b16d-57150b5a414a) |

The inspected real-Chromium recording shows the same transition:

https://github.com/user-attachments/assets/df46913c-8ac1-4255-8135-bdad38f13895

The browser proof loaded the typed content through the existing Control UI mocked-Gateway harness. It asserted that the filename text disappeared, one managed image frame rendered, the decoded image width was 1280px, and the UI requested the stable artifact ID through artifacts.download.

### Automated proof

- `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts src/agents/subagents/announce/subagent-announce-delivery.test.ts src/agents/tools/media-generate-background-shared.test.ts src/config/sessions/transcript.test.ts src/infra/session-delivery-queue.storage.test.ts src/gateway/managed-image-attachments.test.ts src/gateway/server-restart-sentinel.test.ts` — 508 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/gateway/managed-image-actions.e2e.test.ts` — real ephemeral Gateway ticket/full/thumbnail byte flow passed; the required dist build also completed.
- `node scripts/check-changed.mjs` — passed, including formatting, production/test typechecks, full core lint, schema-v9 guard, database-first guard, and zero runtime import cycles.
- `node --import tsx scripts/run-oxlint-shards.mts --only=core --split-core --core-stripe=2/5 --threads=1` and `pnpm run lint:no-chained-type-assertions` — the exact initially failing media-head CI lint surfaces pass locally.
- `node scripts/run-vitest.mjs src/gateway/server-methods/chat-send-reply-dispatch.test.ts src/gateway/server-restart-sentinel.test.ts src/config/sessions/transcript.test.ts` — 144 tests passed after the media-head CI repair.
- Canonical base fix [#126275](https://github.com/openclaw/openclaw/pull/126275) resolves the unrelated protocol max-lines and Codex test-lane failures. After rebasing onto it, both media commits remained patch-identical and the PR carries no protocol-registry or Vitest-lane diff.
- `node scripts/run-vitest.mjs src/agents/compaction.abort-http.test.ts` — the unrelated full-shard timing failure passed on an unloaded focused rerun.
- `git diff --check` — passed.
- Codex-backed autoreview — the full repair and post-media-CI follow-up were clean with no accepted/actionable findings; correctness 0.98 and 0.96. Both commits remained patch-identical through the final rebase.

The crash/replay regression uses a real tiny PNG and verifies one typed transcript message, stable prepared blocks/artifact ID across replay, record attachment to the deduplicated message ID, successful artifact download resolution, and no write to another agent's global transcript.

AI-assisted implementation and review; the final diff, tests, visual captures, and runtime behavior were inspected directly.
