### PR TITLE
fix(agents): bind completion refresh to task ownership

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../tasks/detached-task-runtime.js";
 import { resolveRequiredCompletionDeliveryFailureTerminalResult } from "../../../tasks/task-completion-contract.js";
 import type { TaskDeliveryStatus } from "../../../tasks/task-registry.types.js";
+import type { AgentRunTerminalReplySnapshot } from "../../agent-run-terminal-reply.js";
 import {
   buildAnnounceIdFromChildRun,
   buildAnnounceIdempotencyKey,
@@ -38,7 +39,6 @@ import type {
   SubagentLifecycleOptions,
 } from "./subagent-registry-lifecycle-context.js";
 import type { PendingFinalDeliveryPayload, SubagentRunRecord } from "./subagent-registry.types.js";
-import { compareSubagentRunGeneration } from "./subagent-run-generation.js";
 import { hasSubagentRunEnded } from "./subagent-run-liveness.js";
 
 const DELIVERY_MIRROR_HISTORY_MAX_CHARS = 128 * 1024;
@@ -383,17 +383,17 @@ export const freezeRunResultAtCompletion = async (
   return true;
 };
 
-const listPendingCompletionRunsForSession = (
+const listPendingCompletionRunsForTask = (
   params: SubagentLifecycleOptions,
-  sessionKey: string,
+  taskRunId: string,
 ): SubagentRunRecord[] => {
-  const key = sessionKey.trim();
+  const key = taskRunId.trim();
   if (!key) {
     return [];
   }
   const out: SubagentRunRecord[] = [];
   for (const entry of params.runs.values()) {
-    if (entry.childSessionKey !== key) {
+    if (entry.taskRunId?.trim() !== key) {
       continue;
     }
     if (entry.expectsCompletionMessage !== true) {
@@ -417,47 +417,67 @@ const listPendingCompletionRunsForSession = (
   return out;
 };
 
-export const refreshFrozenResultFromSession = async (
+export const refreshFrozenResultForTask = async (
   context: SubagentLifecycleCommonContext,
-  sessionKey: string,
+  taskRunId: string,
+  terminalReply?: AgentRunTerminalReplySnapshot,
 ): Promise<boolean> => {
   const params = context.options;
-  const candidates = listPendingCompletionRunsForSession(params, sessionKey).filter(
+  const candidates = listPendingCompletionRunsForTask(params, taskRunId).filter(
     (entry) => entry.execution.outcome?.status !== "error",
   );
-  const entry = candidates.toSorted(compareSubagentRunGeneration).at(-1);
+  if (candidates.length !== 1) {
+    return false;
+  }
+  const entry = candidates[0];
   if (!entry || context.newerGenerationOwnsSession(entry)) {
     return false;
   }
   const generation = entry.generation;
 
-  let captured: string | undefined;
-  try {
-    captured = await params.captureSubagentCompletionReply(sessionKey);
-  } catch {
-    return false;
+  let nextTerminalReply: AgentRunTerminalReplySnapshot | undefined;
+  let nextResultText: string;
+  if (terminalReply) {
+    if (terminalReply.disposition !== "visible") {
+      return false;
+    }
+    nextTerminalReply = terminalReply;
+    nextResultText = capFrozenResultText(terminalReply.text);
+  } else {
+    let captured: string | undefined;
+    try {
+      captured = await params.captureSubagentCompletionReply(entry.childSessionKey);
+    } catch {
+      return false;
+    }
+    const trimmed = captured?.trim();
+    if (!trimmed || isSilentAgentReplyText(trimmed)) {
+      return false;
+    }
+    nextResultText = capFrozenResultText(trimmed);
   }
-  const trimmed = captured?.trim();
-  if (!trimmed || isSilentAgentReplyText(trimmed)) {
-    return false;
-  }
-  // Reply capture yields while registration can transfer session ownership.
-  // Only the exact row and generation that started capture may commit its text.
+  // Transcript capture yields while registration can transfer task ownership.
+  // Only the exact row, task, and generation that started capture may commit.
   if (
     params.runs.get(entry.runId) !== entry ||
+    entry.taskRunId?.trim() !== taskRunId.trim() ||
     entry.generation !== generation ||
     context.newerGenerationOwnsSession(entry)
   ) {
     return false;
   }
 
-  const nextFrozen = capFrozenResultText(trimmed);
   const completion = ensureCompletionState(entry);
-  if (completion.resultText === nextFrozen) {
+  if (
+    completion.resultText === nextResultText &&
+    JSON.stringify(completion.terminalReply) === JSON.stringify(nextTerminalReply)
+  ) {
     return false;
   }
-  completion.resultText = nextFrozen;
+  completion.resultText = nextResultText;
   completion.capturedAt = Date.now();
+  completion.terminalReply = nextTerminalReply;
+  refreshPendingFinalDeliveryPayload(entry);
   params.persist(entry.runId);
   return true;
 };

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-delivery.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../tasks/detached-task-runtime.js";
 import { resolveRequiredCompletionDeliveryFailureTerminalResult } from "../../../tasks/task-completion-contract.js";
 import type { TaskDeliveryStatus } from "../../../tasks/task-registry.types.js";
+import type { AgentRunTerminalReplySnapshot } from "../../agent-run-terminal-reply.js";
 import {
   buildAnnounceIdFromChildRun,
   buildAnnounceIdempotencyKey,
@@ -390,6 +391,7 @@ const listPendingCompletionRunsForSession = (
 export const refreshFrozenResultFromSession = async (
   context: SubagentLifecycleCommonContext,
   sessionKey: string,
+  terminalReply?: AgentRunTerminalReplySnapshot,
 ): Promise<boolean> => {
   const params = context.options;
   const candidates = listPendingCompletionRunsForSession(params, sessionKey).filter(
@@ -401,15 +403,22 @@ export const refreshFrozenResultFromSession = async (
   }
   const generation = entry.generation;
 
-  let captured: string | undefined;
-  try {
-    captured = await params.captureSubagentCompletionReply(sessionKey);
-  } catch {
+  if (terminalReply && terminalReply.disposition !== "visible") {
     return false;
   }
-  const trimmed = captured?.trim();
-  if (!trimmed || isSilentAgentReplyText(trimmed)) {
-    return false;
+  let frozenSource = terminalReply?.text;
+  if (!frozenSource) {
+    let captured: string | undefined;
+    try {
+      captured = await params.captureSubagentCompletionReply(sessionKey);
+    } catch {
+      return false;
+    }
+    const trimmed = captured?.trim();
+    if (!trimmed || isSilentAgentReplyText(trimmed)) {
+      return false;
+    }
+    frozenSource = trimmed;
   }
   // Reply capture yields while registration can transfer session ownership.
   // Only the exact row and generation that started capture may commit its text.
@@ -421,13 +430,20 @@ export const refreshFrozenResultFromSession = async (
     return false;
   }
 
-  const nextFrozen = capFrozenResultText(trimmed);
+  const nextFrozen = capFrozenResultText(frozenSource);
   const completion = ensureCompletionState(entry);
-  if (completion.resultText === nextFrozen) {
+  const replyChanged =
+    terminalReply?.disposition === "visible" &&
+    JSON.stringify(completion.terminalReply) !== JSON.stringify(terminalReply);
+  if (completion.resultText === nextFrozen && !replyChanged) {
     return false;
   }
   completion.resultText = nextFrozen;
   completion.capturedAt = Date.now();
+  if (terminalReply?.disposition === "visible") {
+    completion.terminalReply = terminalReply;
+    refreshPendingFinalDeliveryPayload(entry);
+  }
   params.persist(entry.runId);
   return true;
 };

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -198,8 +198,10 @@ type RunModeCleanupEntryOverrides = Omit<RunEntryOverrides, "execution"> & {
 
 function createRunEntry(overrides: RunEntryOverrides = {}): SubagentRunRecord {
   const { startedAt = 2_000, endedAt, outcome, execution, ...recordOverrides } = overrides;
+  const runId = recordOverrides.runId ?? "run-1";
   return {
-    runId: "run-1",
+    runId,
+    taskRunId: recordOverrides.taskRunId ?? runId,
     childSessionKey: "agent:main:subagent:child",
     requesterSessionKey: "agent:main:main",
     requesterDisplayKey: "main",
@@ -1616,7 +1618,7 @@ describe("subagent registry lifecycle hardening", () => {
     const captureSubagentCompletionReply = vi.fn(async () => "text from the next turn");
     const controller = createLifecycleController({ entry, captureSubagentCompletionReply });
 
-    expect(await controller.refreshFrozenResultFromSession(entry.childSessionKey)).toBe(false);
+    expect(await controller.refreshFrozenResultForTask(entry.taskRunId ?? "")).toBe(false);
 
     // The yield cleared this row's result on purpose. Whatever the session holds
     // now belongs to the turn that runs next, so refreezing it would announce a
@@ -1625,10 +1627,11 @@ describe("subagent registry lifecycle hardening", () => {
     expect(entry.completion?.resultText).toBeUndefined();
   });
 
-  it("refreshes only the newest pending completion generation for a shared session", async () => {
+  it("does not refresh when multiple pending rows claim the same task owner", async () => {
     const childSessionKey = "agent:main:subagent:shared-refresh";
     const older = createRunEntry({
       runId: "run-shared-refresh-old",
+      taskRunId: "task-shared-refresh",
       childSessionKey,
       generation: 1,
       createdAt: 1_000,
@@ -1643,6 +1646,7 @@ describe("subagent registry lifecycle hardening", () => {
     });
     const newer = createRunEntry({
       runId: "run-shared-refresh-new",
+      taskRunId: "task-shared-refresh",
       childSessionKey,
       generation: 2,
       createdAt: 2_000,
@@ -1667,15 +1671,11 @@ describe("subagent registry lifecycle hardening", () => {
       captureSubagentCompletionReply: vi.fn(async () => "latest session reply"),
     });
 
-    expect(await controller.refreshFrozenResultFromSession(childSessionKey)).toBe(true);
+    expect(await controller.refreshFrozenResultForTask("task-shared-refresh")).toBe(false);
 
     expect(older).toEqual(olderBefore);
-    expect(newer.completion).toMatchObject({
-      resultText: "latest session reply",
-      capturedAt: expect.any(Number),
-    });
-    expect(persist).toHaveBeenCalledOnce();
-    expect(persist).toHaveBeenCalledWith(newer.runId);
+    expect(newer.completion?.resultText).toBe("newer generation placeholder");
+    expect(persist).not.toHaveBeenCalled();
   });
 
   it("rejects a frozen-result refresh when a newer generation registers during capture", async () => {
@@ -1704,7 +1704,7 @@ describe("subagent registry lifecycle hardening", () => {
       captureSubagentCompletionReply,
     });
 
-    const refresh = controller.refreshFrozenResultFromSession(childSessionKey);
+    const refresh = controller.refreshFrozenResultForTask(entry.taskRunId ?? "");
     await waitForLifecycleState(() =>
       expect(captureSubagentCompletionReply).toHaveBeenCalledOnce(),
     );

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.ts
@@ -16,7 +16,7 @@ import type {
   ScheduledRequesterSettleWake,
   SubagentLifecycleOptions,
 } from "./subagent-registry-lifecycle-context.js";
-import { refreshFrozenResultFromSession } from "./subagent-registry-lifecycle-delivery.js";
+import { refreshFrozenResultForTask } from "./subagent-registry-lifecycle-delivery.js";
 import {
   completeCleanupBookkeeping,
   scheduleRequesterSettleWake,
@@ -215,8 +215,10 @@ export class SubagentLifecycleController {
   finalizeResumedAnnounceGiveUp = (params: Parameters<typeof finalizeResumedAnnounceGiveUp>[1]) =>
     finalizeResumedAnnounceGiveUp(this, params);
 
-  refreshFrozenResultFromSession = (sessionKey: string) =>
-    refreshFrozenResultFromSession(this, sessionKey);
+  refreshFrozenResultForTask = (
+    taskRunId: string,
+    terminalReply?: import("../../agent-run-terminal-reply.js").AgentRunTerminalReplySnapshot,
+  ) => refreshFrozenResultForTask(this, taskRunId, terminalReply);
 
   resumeRequesterSettleWake = (runId: string, entry: SubagentRunRecord) =>
     scheduleRequesterSettleWake(this, runId, entry);

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.ts
@@ -215,8 +215,10 @@ export class SubagentLifecycleController {
   finalizeResumedAnnounceGiveUp = (params: Parameters<typeof finalizeResumedAnnounceGiveUp>[1]) =>
     finalizeResumedAnnounceGiveUp(this, params);
 
-  refreshFrozenResultFromSession = (sessionKey: string) =>
-    refreshFrozenResultFromSession(this, sessionKey);
+  refreshFrozenResultFromSession = (
+    sessionKey: string,
+    terminalReply?: SubagentCompletionRequest["terminalReply"],
+  ) => refreshFrozenResultFromSession(this, sessionKey, terminalReply);
 
   resumeRequesterSettleWake = (runId: string, entry: SubagentRunRecord) =>
     scheduleRequesterSettleWake(this, runId, entry);

--- a/src/agents/subagents/registry/subagent-registry-listener.ts
+++ b/src/agents/subagents/registry/subagent-registry-listener.ts
@@ -17,7 +17,10 @@ export function createSubagentRegistryListener(config: {
   pendingLifecycle: ReturnType<typeof createPendingLifecycleScheduler>;
   onAgentEvent: (listener: (event: AgentEventPayload) => void) => () => void;
   persist: (...runIds: string[]) => void;
-  refreshFrozenResultFromSession: (sessionKey: string) => Promise<unknown>;
+  refreshFrozenResultForTask: (
+    taskRunId: string,
+    terminalReply?: SubagentCompletionRequest["terminalReply"],
+  ) => Promise<unknown>;
   completeSubagentRunWithRecovery: (
     params: SubagentCompletionRequest,
     source: string,
@@ -29,7 +32,7 @@ export function createSubagentRegistryListener(config: {
     pendingLifecycle,
     onAgentEvent,
     persist,
-    refreshFrozenResultFromSession,
+    refreshFrozenResultForTask,
     completeSubagentRunWithRecovery,
     warn,
   } = config;
@@ -49,12 +52,14 @@ export function createSubagentRegistryListener(config: {
         const phase = evt.data?.phase;
         const entry = runs.get(evt.runId);
         if (!entry) {
-          if (phase === "end" && typeof evt.sessionKey === "string") {
-            const sessionKey = evt.sessionKey;
+          if (phase === "end" && typeof evt.taskRunId === "string") {
+            const taskRunId = evt.taskRunId;
+            const terminalReply = normalizeAgentRunTerminalReplySnapshot(evt.data?.terminalReply);
             // A replacement generation can finish after its predecessor row is
-            // terminal. Keep capture + persistence inside the suspension fence.
+            // terminal. Exact task ownership prevents a later same-session task
+            // from rewriting the predecessor's pending completion.
             await runWithGatewayIndependentRootWorkAdmission(async () => {
-              await refreshFrozenResultFromSession(sessionKey);
+              await refreshFrozenResultForTask(taskRunId, terminalReply);
             });
           }
           return;

--- a/src/agents/subagents/registry/subagent-registry-listener.ts
+++ b/src/agents/subagents/registry/subagent-registry-listener.ts
@@ -22,7 +22,10 @@ export function createSubagentRegistryListener(config: {
   pendingLifecycle: ReturnType<typeof createPendingLifecycleScheduler>;
   onAgentEvent: (listener: (event: AgentEventPayload) => void) => () => void;
   persist: (...runIds: string[]) => void;
-  refreshFrozenResultFromSession: (sessionKey: string) => Promise<unknown>;
+  refreshFrozenResultFromSession: (
+    sessionKey: string,
+    terminalReply?: SubagentCompletionRequest["terminalReply"],
+  ) => Promise<unknown>;
   completeSubagentRunWithRecovery: (
     params: SubagentCompletionRequest,
     source: string,
@@ -52,6 +55,7 @@ export function createSubagentRegistryListener(config: {
           return;
         }
         const phase = evt.data?.phase;
+        const terminalReply = normalizeAgentRunTerminalReplySnapshot(evt.data?.terminalReply);
         const entry = runs.get(evt.runId);
         if (!entry) {
           if (phase === "end" && typeof evt.sessionKey === "string") {
@@ -59,7 +63,7 @@ export function createSubagentRegistryListener(config: {
             // A replacement generation can finish after its predecessor row is
             // terminal. Keep capture + persistence inside the suspension fence.
             await runWithGatewayIndependentRootWorkAdmission(async () => {
-              await refreshFrozenResultFromSession(sessionKey);
+              await refreshFrozenResultFromSession(sessionKey, terminalReply);
             });
           }
           return;
@@ -87,7 +91,6 @@ export function createSubagentRegistryListener(config: {
           typeof evt.data?.livenessState === "string" ? evt.data.livenessState : undefined;
         const stopReason =
           typeof evt.data?.stopReason === "string" ? evt.data.stopReason : undefined;
-        const terminalReply = normalizeAgentRunTerminalReplySnapshot(evt.data?.terminalReply);
         // sessions_yield ends the turn by aborting the run signal, so a yielded
         // terminal can also look aborted. An explicit yield is authoritative — pause,
         // don't kill — else the tracking task settles `cancelled` with a false notice (#92448).

--- a/src/agents/subagents/registry/subagent-registry-run-launch.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-launch.ts
@@ -4,6 +4,7 @@ import {
   getAgentEventLifecycleGeneration,
   isAgentEventLifecycleGenerationCurrent,
 } from "../../../infra/agent-events.js";
+import { bindAgentRunContextTaskRunId } from "../../../infra/agent-run-registry.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { bindGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import {
@@ -270,6 +271,7 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
         }
       }
     }
+    bindAgentRunContextTaskRunId(runId, entry.execution.lifecycleGeneration, entry.taskRunId);
     // Wait through Gateway RPC; the in-process lifecycle listener is the embedded fallback.
     activateRegistrationLifecycle();
   };
@@ -399,6 +401,7 @@ export class SubagentLaunchManager extends SubagentRecoveryManager {
       throw error;
     }
     bindGatewayContextResolver(entry, gatewayContextResolver);
+    bindAgentRunContextTaskRunId(nextRunId, entry.execution.lifecycleGeneration, entry.taskRunId);
     const cfg = this.options.getRuntimeConfig();
     void this.waitForSubagentCompletion(
       nextRunId,

--- a/src/agents/subagents/registry/subagent-registry-run-recovery.ts
+++ b/src/agents/subagents/registry/subagent-registry-run-recovery.ts
@@ -4,6 +4,7 @@ import {
   getAgentEventLifecycleGeneration,
   isAgentEventLifecycleGenerationCurrent,
 } from "../../../infra/agent-events.js";
+import { bindAgentRunContextTaskRunId } from "../../../infra/agent-run-registry.js";
 import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import {
   bindGatewayContextResolver,
@@ -322,6 +323,7 @@ export class SubagentRecoveryManager extends SubagentWaitManager {
       });
       this.options.persist(...changedRunIds);
     }
+    bindAgentRunContextTaskRunId(nextRunId, next.execution.lifecycleGeneration, next.taskRunId);
     if (previousRunId !== nextRunId) {
       this.options.clearPendingLifecycleError(previousRunId);
       this.options.resumedRuns.delete(previousRunId);

--- a/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -28,6 +28,7 @@ type LifecycleData = {
 type LifecycleEvent = {
   stream?: string;
   runId: string;
+  taskRunId?: string;
   sessionKey?: string;
   data?: LifecycleData;
 };
@@ -331,14 +332,21 @@ describe("subagent registry lifecycle error grace", () => {
   function emitLifecycleEvent(
     runId: string,
     data: LifecycleData,
-    options?: { sessionKey?: string },
+    options?: { sessionKey?: string; taskRunId?: string },
   ) {
-    lifecycleHandler?.({
+    const event: LifecycleEvent = {
       stream: "lifecycle",
       runId,
       sessionKey: options?.sessionKey,
       data,
-    });
+    };
+    if (options?.taskRunId) {
+      Object.defineProperty(event, "taskRunId", {
+        value: options.taskRunId,
+        enumerable: false,
+      });
+    }
+    lifecycleHandler?.(event);
   }
 
   function readFirstAnnounceOutcome() {
@@ -739,14 +747,21 @@ describe("subagent registry lifecycle error grace", () => {
       .find((candidate) => candidate.runId === "run-refresh");
     const firstCapturedAt = runBeforeRefresh?.completion?.capturedAt ?? 0;
 
-    setAssistantOutput(
-      "agent:main:subagent:refresh",
-      "All 3 subagents complete. Here's the final summary.",
-    );
+    setAssistantOutput("agent:main:subagent:refresh", "stale transcript placeholder");
     emitLifecycleEvent(
       "run-refresh-followup-turn",
-      { phase: "end", endedAt: endedAt + 200 },
-      { sessionKey: "agent:main:subagent:refresh" },
+      {
+        phase: "end",
+        endedAt: endedAt + 200,
+        terminalReply: {
+          disposition: "visible",
+          text: "All 3 subagents complete. Here's the final summary.",
+        },
+      },
+      {
+        sessionKey: "agent:main:subagent:refresh",
+        taskRunId: "run-refresh",
+      },
     );
     const runAfterRefresh = await waitForFrozenResultText(
       "run-refresh",
@@ -756,6 +771,10 @@ describe("subagent registry lifecycle error grace", () => {
       "All 3 subagents complete. Here's the final summary.",
     );
     expect((runAfterRefresh?.completion?.capturedAt ?? 0) >= firstCapturedAt).toBe(true);
+    expect(runAfterRefresh?.delivery?.payload?.terminalReply).toEqual({
+      disposition: "visible",
+      text: "All 3 subagents complete. Here's the final summary.",
+    });
 
     emitLifecycleEvent("run-refresh", {
       phase: "end",
@@ -772,6 +791,56 @@ describe("subagent registry lifecycle error grace", () => {
       "Both spawned. Waiting for completion events...",
       "All 3 subagents complete. Here's the final summary.",
     ]);
+  });
+
+  it("requires exact task ownership before transcript fallback can refresh a completion", async () => {
+    registerCompletionRun("run-owned-refresh", "owned-refresh", "owned refresh test");
+    setAssistantOutput("agent:main:subagent:owned-refresh", "initial result");
+    agentCallPlan = ["throw", "ok"];
+
+    const endedAt = Date.now();
+    emitLifecycleEvent("run-owned-refresh", {
+      phase: "end",
+      endedAt,
+      terminalReply: { disposition: "visible", text: "initial result" },
+    });
+    await waitForCleanupHandledFalse("run-owned-refresh");
+
+    setAssistantOutput("agent:main:subagent:owned-refresh", "new transcript result");
+    emitLifecycleEvent(
+      "run-owned-refresh-followup-missing-owner",
+      { phase: "end", endedAt: endedAt + 100 },
+      { sessionKey: "agent:main:subagent:owned-refresh" },
+    );
+    emitLifecycleEvent(
+      "run-other-task",
+      { phase: "end", endedAt: endedAt + 200 },
+      {
+        sessionKey: "agent:main:subagent:owned-refresh",
+        taskRunId: "run-other-task",
+      },
+    );
+    await flushAsync();
+
+    const beforeOwnedRefresh = mod
+      .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
+      .find((candidate) => candidate.runId === "run-owned-refresh");
+    expect(beforeOwnedRefresh?.completion?.resultText).toBe("initial result");
+
+    emitLifecycleEvent(
+      "run-owned-refresh-followup",
+      { phase: "end", endedAt: endedAt + 300 },
+      {
+        sessionKey: "agent:main:subagent:owned-refresh",
+        taskRunId: "run-owned-refresh",
+      },
+    );
+    const afterOwnedRefresh = await waitForFrozenResultText(
+      "run-owned-refresh",
+      "new transcript result",
+    );
+    expect(afterOwnedRefresh?.completion?.terminalReply).toBeUndefined();
+    expect(afterOwnedRefresh?.delivery?.payload?.terminalReply).toBeUndefined();
   });
 
   it("ignores silent follow-up turns when refreshing frozen completion output", async () => {
@@ -795,8 +864,15 @@ describe("subagent registry lifecycle error grace", () => {
     setAssistantOutput("agent:main:subagent:refresh-silent", "NO_REPLY");
     emitLifecycleEvent(
       "run-refresh-silent-followup-turn",
-      { phase: "end", endedAt: endedAt + 200 },
-      { sessionKey: "agent:main:subagent:refresh-silent" },
+      {
+        phase: "end",
+        endedAt: endedAt + 200,
+        terminalReply: { disposition: "silent" },
+      },
+      {
+        sessionKey: "agent:main:subagent:refresh-silent",
+        taskRunId: "run-refresh-silent",
+      },
     );
     await flushAsync();
 

--- a/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -687,7 +687,7 @@ describe("subagent registry lifecycle error grace", () => {
 
     setAssistantOutput(
       "agent:main:subagent:refresh",
-      "All 3 subagents complete. Here's the final summary.",
+      "Stale transcript text that must not replace producer evidence.",
     );
     emitLifecycleEvent(
       "run-refresh-followup-turn",
@@ -705,9 +705,13 @@ describe("subagent registry lifecycle error grace", () => {
       "run-refresh",
       "All 3 subagents complete. Here's the final summary.",
     );
-    expect(runAfterRefresh?.completion?.resultText).toBe(
-      "All 3 subagents complete. Here's the final summary.",
-    );
+    expect(runAfterRefresh?.completion).toMatchObject({
+      resultText: "All 3 subagents complete. Here's the final summary.",
+      terminalReply: {
+        disposition: "visible",
+        text: "All 3 subagents complete. Here's the final summary.",
+      },
+    });
     expect((runAfterRefresh?.completion?.capturedAt ?? 0) >= firstCapturedAt).toBe(true);
 
     emitLifecycleEvent("run-refresh", { phase: "end", endedAt: endedAt + 300 });

--- a/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -1,6 +1,7 @@
 // Lifecycle retry-grace e2e tests cover completion delivery retry behavior when
 // lifecycle events race gateway waits or transient announce failures.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentRunTerminalReplySnapshot } from "../../agent-run-terminal-reply.js";
 import { testing as subagentAnnounceDeliveryTesting } from "../announce/subagent-announce-delivery.test-support.js";
 import { testing as subagentAnnounceOutputTesting } from "../announce/subagent-announce-output.test-support.js";
 import { testing as subagentAnnounceTesting } from "../announce/subagent-announce.js";
@@ -17,6 +18,7 @@ type LifecycleData = {
   endedAt?: number;
   aborted?: boolean;
   error?: string;
+  terminalReply?: AgentRunTerminalReplySnapshot;
 };
 type LifecycleEvent = {
   stream?: string;
@@ -280,12 +282,15 @@ describe("subagent registry lifecycle error grace", () => {
     throw new Error(`expected ${expectedCount} agent call(s), got ${getAgentCalls().length}`);
   };
 
-  const waitForFrozenResultText = async (runId: string, expectedText: string) => {
+  const waitForFrozenResultText = async (runId: string, expectedText?: string) => {
     for (let attempt = 0; attempt < 80; attempt += 1) {
       const run = mod
         .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
         .find((candidate) => candidate.runId === runId);
-      if (run?.completion?.resultText === expectedText) {
+      if (
+        typeof run?.completion?.resultText === "string" &&
+        (expectedText === undefined || run.completion.resultText === expectedText)
+      ) {
         return run;
       }
       await vi.advanceTimersByTimeAsync(1);
@@ -299,6 +304,7 @@ describe("subagent registry lifecycle error grace", () => {
     childSuffix: string,
     task: string,
     requesterTurnRunId?: string,
+    expectsCompletionMessage = true,
   ) {
     mod.registerSubagentRun({
       runId,
@@ -308,7 +314,7 @@ describe("subagent registry lifecycle error grace", () => {
       requesterDisplayKey: MAIN_REQUESTER_DISPLAY_KEY,
       task,
       cleanup: "keep",
-      expectsCompletionMessage: true,
+      expectsCompletionMessage,
     });
   }
 
@@ -404,10 +410,18 @@ describe("subagent registry lifecycle error grace", () => {
       }),
     );
 
-    emitLifecycleEvent("run-yield-alpha", { phase: "end", endedAt: Date.now() });
+    emitLifecycleEvent("run-yield-alpha", {
+      phase: "end",
+      endedAt: Date.now(),
+      terminalReply: { disposition: "visible", text: "alpha complete" },
+    });
     await waitForAgentCallCount(1);
 
-    emitLifecycleEvent("run-yield-beta", { phase: "end", endedAt: Date.now() + 1 });
+    emitLifecycleEvent("run-yield-beta", {
+      phase: "end",
+      endedAt: Date.now() + 1,
+      terminalReply: { disposition: "visible", text: "beta complete" },
+    });
     await waitForAgentCallCount(2);
     const betaBeforeYield = mod
       .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
@@ -536,7 +550,11 @@ describe("subagent registry lifecycle error grace", () => {
     expect(getRequesterWakeCalls()).toHaveLength(0);
     expect(liveChild.execution.status).toBe("running");
 
-    emitLifecycleEvent("run-frozen-live-child", { phase: "end", endedAt: Date.now() + 1 });
+    emitLifecycleEvent("run-frozen-live-child", {
+      phase: "end",
+      endedAt: Date.now() + 1,
+      terminalReply: { disposition: "visible", text: "live child complete" },
+    });
     await waitForAgentCallCount(1);
     await waitForDeliveredCleanup("run-frozen-live-child");
 
@@ -569,7 +587,11 @@ describe("subagent registry lifecycle error grace", () => {
     await vi.advanceTimersByTimeAsync(20_000);
     expect(getAgentCalls()).toHaveLength(0);
 
-    emitLifecycleEvent("run-transient-error", { phase: "end", endedAt: 1_250 });
+    emitLifecycleEvent("run-transient-error", {
+      phase: "end",
+      endedAt: 1_250,
+      terminalReply: { disposition: "visible", text: "Final answer transient" },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(1);
@@ -603,7 +625,11 @@ describe("subagent registry lifecycle error grace", () => {
     agentCallPlan = ["throw", "ok"];
 
     const endedAt = Date.now();
-    emitLifecycleEvent("run-freeze", { phase: "end", endedAt });
+    emitLifecycleEvent("run-freeze", {
+      phase: "end",
+      endedAt,
+      terminalReply: { disposition: "visible", text: "Final answer X" },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(1);
@@ -633,7 +659,14 @@ describe("subagent registry lifecycle error grace", () => {
     agentCallPlan = ["throw", "ok"];
 
     const endedAt = Date.now();
-    emitLifecycleEvent("run-refresh", { phase: "end", endedAt });
+    emitLifecycleEvent("run-refresh", {
+      phase: "end",
+      endedAt,
+      terminalReply: {
+        disposition: "visible",
+        text: "Both spawned. Waiting for completion events...",
+      },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(1);
@@ -672,7 +705,7 @@ describe("subagent registry lifecycle error grace", () => {
     await waitForAgentCallCount(2);
     expect(getAgentResultsForChildSession("agent:main:subagent:refresh")).toEqual([
       "Both spawned. Waiting for completion events...",
-      "All 3 subagents complete. Here's the final summary.",
+      "Both spawned. Waiting for completion events...",
     ]);
   });
 
@@ -682,7 +715,11 @@ describe("subagent registry lifecycle error grace", () => {
     agentCallPlan = ["throw", "ok"];
 
     const endedAt = Date.now();
-    emitLifecycleEvent("run-refresh-silent", { phase: "end", endedAt });
+    emitLifecycleEvent("run-refresh-silent", {
+      phase: "end",
+      endedAt,
+      terminalReply: { disposition: "visible", text: "All work complete, final summary" },
+    });
     await flushAsync();
     await waitForCleanupHandledFalse("run-refresh-silent");
     await waitForFrozenResultText("run-refresh-silent", "All work complete, final summary");
@@ -703,36 +740,30 @@ describe("subagent registry lifecycle error grace", () => {
     emitLifecycleEvent("run-refresh-silent", { phase: "end", endedAt: endedAt + 300 });
     await flushAsync();
 
-    await waitForAgentCallCount(2);
-    expect(getAgentResultsForChildSession("agent:main:subagent:refresh-silent")).toEqual([
-      "All work complete, final summary",
-      "All work complete, final summary",
-    ]);
+    expect(runAfterSilent?.completion).toMatchObject({
+      resultText: "All work complete, final summary",
+      terminalReply: {
+        disposition: "visible",
+        text: "All work complete, final summary",
+      },
+    });
   });
 
   it("regression, captures frozen completion output with 100KB cap and retains it for keep-mode cleanup", async () => {
-    registerCompletionRun("run-capped", "capped", "capped result test");
+    registerCompletionRun("run-capped", "capped", "capped result test", undefined, false);
     setAssistantOutput("agent:main:subagent:capped", "x".repeat(120 * 1024));
 
     emitLifecycleEvent("run-capped", { phase: "end", endedAt: Date.now() });
     await flushAsync();
 
-    await waitForAgentCallCount(1);
-    const cappedResults = getAgentResultsForChildSession("agent:main:subagent:capped");
-    expect(cappedResults).toHaveLength(1);
-    expect(cappedResults[0]).toContain("[truncated: frozen completion output exceeded 100KB");
-    expect(Buffer.byteLength(cappedResults[0] ?? "", "utf8")).toBeLessThanOrEqual(100 * 1024);
-
-    const run = mod
-      .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
-      .find((candidate) => candidate.runId === "run-capped");
-    if (!run) {
-      throw new Error("expected capped run to exist");
-    }
+    const run = await waitForFrozenResultText("run-capped");
     expect(run.runId).toBe("run-capped");
     expect(typeof run.completion?.resultText).toBe("string");
     expect(run.completion?.resultText).toContain(
       "[truncated: frozen completion output exceeded 100KB",
+    );
+    expect(Buffer.byteLength(run.completion?.resultText ?? "", "utf8")).toBeLessThanOrEqual(
+      100 * 1024,
     );
     expect(run.completion?.capturedAt).toBeTypeOf("number");
   });
@@ -776,7 +807,11 @@ describe("subagent registry lifecycle error grace", () => {
     expect(getAgentCalls()).toHaveLength(0);
 
     // Before the grace window, the run successfully ends (non-aborted)
-    emitLifecycleEvent("run-timeout-cancel", { phase: "end", endedAt: 4_500 });
+    emitLifecycleEvent("run-timeout-cancel", {
+      phase: "end",
+      endedAt: 4_500,
+      terminalReply: { disposition: "visible", text: "Final answer after recovery" },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(1);
@@ -810,8 +845,16 @@ describe("subagent registry lifecycle error grace", () => {
     agentCallPlan = ["throw", "throw", "ok", "ok"];
 
     const parallelEndedAt = Date.now();
-    emitLifecycleEvent("run-parallel-a", { phase: "end", endedAt: parallelEndedAt });
-    emitLifecycleEvent("run-parallel-b", { phase: "end", endedAt: parallelEndedAt + 1 });
+    emitLifecycleEvent("run-parallel-a", {
+      phase: "end",
+      endedAt: parallelEndedAt,
+      terminalReply: { disposition: "visible", text: "Final answer A" },
+    });
+    emitLifecycleEvent("run-parallel-b", {
+      phase: "end",
+      endedAt: parallelEndedAt + 1,
+      terminalReply: { disposition: "visible", text: "Final answer B" },
+    });
     await flushAsync();
 
     await waitForAgentCallCount(2);

--- a/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.lifecycle-retry-grace.e2e.test.ts
@@ -230,13 +230,17 @@ describe("subagent registry lifecycle error grace", () => {
   };
 
   const waitForCleanupHandledFalse = async (runId: string) => {
-    // Cleanup can be released asynchronously after announce failure; poll fake
-    // time until the retry-grace state is observable.
+    // Cleanup is released before failed-delivery bookkeeping settles. Wait for
+    // the durable retry payload so the next lifecycle event cannot race it.
     for (let attempt = 0; attempt < 40; attempt += 1) {
       const run = mod
         .listSubagentRunsForRequester(MAIN_REQUESTER_SESSION_KEY)
         .find((candidate) => candidate.runId === runId);
-      if (run?.cleanupHandled === false) {
+      if (
+        run?.cleanupHandled === false &&
+        run.delivery?.status === "pending" &&
+        run.delivery.payload
+      ) {
         return;
       }
       await vi.advanceTimersByTimeAsync(1);
@@ -687,7 +691,14 @@ describe("subagent registry lifecycle error grace", () => {
     );
     emitLifecycleEvent(
       "run-refresh-followup-turn",
-      { phase: "end", endedAt: endedAt + 200 },
+      {
+        phase: "end",
+        endedAt: endedAt + 200,
+        terminalReply: {
+          disposition: "visible",
+          text: "All 3 subagents complete. Here's the final summary.",
+        },
+      },
       { sessionKey: "agent:main:subagent:refresh" },
     );
     const runAfterRefresh = await waitForFrozenResultText(
@@ -705,7 +716,7 @@ describe("subagent registry lifecycle error grace", () => {
     await waitForAgentCallCount(2);
     expect(getAgentResultsForChildSession("agent:main:subagent:refresh")).toEqual([
       "Both spawned. Waiting for completion events...",
-      "Both spawned. Waiting for completion events...",
+      "All 3 subagents complete. Here's the final summary.",
     ]);
   });
 
@@ -727,7 +738,11 @@ describe("subagent registry lifecycle error grace", () => {
     setAssistantOutput("agent:main:subagent:refresh-silent", "NO_REPLY");
     emitLifecycleEvent(
       "run-refresh-silent-followup-turn",
-      { phase: "end", endedAt: endedAt + 200 },
+      {
+        phase: "end",
+        endedAt: endedAt + 200,
+        terminalReply: { disposition: "silent" },
+      },
       { sessionKey: "agent:main:subagent:refresh-silent" },
     );
     await flushAsync();
@@ -740,6 +755,11 @@ describe("subagent registry lifecycle error grace", () => {
     emitLifecycleEvent("run-refresh-silent", { phase: "end", endedAt: endedAt + 300 });
     await flushAsync();
 
+    await waitForAgentCallCount(2);
+    expect(getAgentResultsForChildSession("agent:main:subagent:refresh-silent")).toEqual([
+      "All work complete, final summary",
+      "All work complete, final summary",
+    ]);
     expect(runAfterSilent?.completion).toMatchObject({
       resultText: "All work complete, final summary",
       terminalReply: {
@@ -749,7 +769,7 @@ describe("subagent registry lifecycle error grace", () => {
     });
   });
 
-  it("regression, captures frozen completion output with 100KB cap and retains it for keep-mode cleanup", async () => {
+  it("regression, caps frozen completion output at 100KB", async () => {
     registerCompletionRun("run-capped", "capped", "capped result test", undefined, false);
     setAssistantOutput("agent:main:subagent:capped", "x".repeat(120 * 1024));
 

--- a/src/agents/subagents/registry/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.steer-restart.test.ts
@@ -10,6 +10,9 @@ import { setDetachedTaskLifecycleRuntime } from "../../../tasks/task-runtime.tes
 import { findTaskByRunIdForStatus } from "../../../tasks/task-status-access.js";
 
 const noop = () => {};
+const agentRunRegistryMocks = vi.hoisted(() => ({
+  bindAgentRunContextTaskRunId: vi.fn(() => true),
+}));
 let lifecycleHandler:
   | ((evt: {
       stream?: string;
@@ -62,6 +65,11 @@ vi.mock("../../../infra/agent-events.js", () => ({
     lifecycleHandler = handler;
     return noop;
   }),
+}));
+
+vi.mock("../../../infra/agent-run-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../infra/agent-run-registry.js")>()),
+  bindAgentRunContextTaskRunId: agentRunRegistryMocks.bindAgentRunContextTaskRunId,
 }));
 
 vi.mock("../../../config/config.js", () => ({
@@ -201,6 +209,7 @@ describe("subagent registry steer restarts", () => {
     });
     announceSpy.mockReset();
     announceSpy.mockResolvedValue("delivered");
+    agentRunRegistryMocks.bindAgentRunContextTaskRunId.mockClear();
     runSubagentEndedHookMock.mockReset();
     runSubagentEndedHookMock.mockImplementation(async () => {});
     emitSessionLifecycleEventMock.mockReset();
@@ -624,6 +633,11 @@ describe("subagent registry steer restarts", () => {
     expect(run.task).toBe("new steer instruction from user");
     expect(run.taskRunId).toBe("run-steer-task-old");
     expect(run.generation).toBe(2);
+    expect(agentRunRegistryMocks.bindAgentRunContextTaskRunId).toHaveBeenCalledWith(
+      "run-steer-task-new",
+      "test-generation",
+      "run-steer-task-old",
+    );
   });
 
   it("advances the generation from a fallback outside the live registry", () => {
@@ -704,6 +718,11 @@ describe("subagent registry steer restarts", () => {
     );
     expect(second.taskRunId).toBeUndefined();
     expect(second.generation).toBe(3);
+    expect(agentRunRegistryMocks.bindAgentRunContextTaskRunId).toHaveBeenCalledWith(
+      "run-legacy-owner-next",
+      "test-generation",
+      undefined,
+    );
   });
 
   it("preserves cumulative session timing across steer replacement runs", () => {

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -160,7 +160,7 @@ const {
   completeCleanupBookkeeping,
   completeSubagentRun,
   finalizeResumedAnnounceGiveUp,
-  refreshFrozenResultFromSession,
+  refreshFrozenResultForTask,
   resumeRequesterSettleWake,
   settleRequesterTurnAfterSessionSpawns,
   startSubagentAnnounceCleanupFlow,
@@ -421,7 +421,7 @@ const subagentListener = createSubagentRegistryListener({
   pendingLifecycle,
   onAgentEvent: (listener) => subagentRegistryDeps.onAgentEvent(listener),
   persist: persistSubagentRuns,
-  refreshFrozenResultFromSession,
+  refreshFrozenResultForTask,
   completeSubagentRunWithRecovery: completionRuntime.completeSubagentRunWithRecovery,
   warn: (message, meta) => log.warn(message, meta),
 });

--- a/src/infra/agent-events.test.ts
+++ b/src/infra/agent-events.test.ts
@@ -78,6 +78,26 @@ describe("agent-events sequencing", () => {
     expect(getAgentRunContext("run-1")).toBeUndefined();
   });
 
+  test("stamps lifecycle task ownership without serializing it", () => {
+    registerAgentRunContext("run-task-owner", {
+      sessionKey: "agent:main:subagent:worker",
+      taskRunId: "detached-owner-secret",
+    });
+    const events: AgentEventPayload[] = [];
+    const unsubscribe = onAgentEvent((event) => events.push(event));
+
+    emitAgentEvent({
+      runId: "run-task-owner",
+      stream: "lifecycle",
+      data: { phase: "end", endedAt: 1_000 },
+    });
+    unsubscribe();
+
+    expect(events[0]?.taskRunId).toBe("detached-owner-secret");
+    expect(Object.keys(events[0] ?? {})).not.toContain("taskRunId");
+    expect(JSON.stringify(events[0])).not.toContain("detached-owner-secret");
+  });
+
   test("versions active-run projection ownership transitions", () => {
     let version = readAgentRunIndexVersion();
     registerAgentRunContext("projected-run", {

--- a/src/infra/agent-events.ts
+++ b/src/infra/agent-events.ts
@@ -62,6 +62,8 @@ export type AgentEventPayload = {
   data: Record<string, unknown>;
   /** Internal, non-enumerable gateway lifecycle generation that owns this run. */
   lifecycleGeneration?: string;
+  /** Internal, non-enumerable detached task owner for this operational run. */
+  taskRunId?: string;
   sessionKey?: string;
   /**
    * sessionId the run was bound to when it started. Lifecycle persistence uses
@@ -270,6 +272,7 @@ function enrichAgentEvent(
     event.stream === "lifecycle"
       ? (ownedLifecycleGeneration ?? currentLifecycleGeneration)
       : ownedLifecycleGeneration;
+  const taskRunId = event.stream === "lifecycle" ? context?.taskRunId : undefined;
   const agentId = event.agentId ?? context?.agentId;
   const enriched: AgentEventRuntimePayload = {
     ...event,
@@ -287,6 +290,14 @@ function enrichAgentEvent(
       value: lifecycleGeneration,
       enumerable: false,
     });
+  }
+  if (taskRunId) {
+    Object.defineProperty(enriched, "taskRunId", {
+      value: taskRunId,
+      enumerable: false,
+    });
+  } else {
+    delete enriched.taskRunId;
   }
   if (context?.isControlUiVisible !== undefined) {
     Object.defineProperty(enriched, "controlUiVisible", {

--- a/src/infra/agent-run-registry.task-ownership.test.ts
+++ b/src/infra/agent-run-registry.task-ownership.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import {
+  bindAgentRunContextTaskRunId,
   bindAgentRunTaskRunId,
   claimAgentRunContext,
   getAgentRunContext,
+  getAgentRunLifecycleGeneration,
   getAgentRunTaskRunId,
+  registerAgentRunContext,
   releaseAgentRunContext,
   resetAgentRunRegistryForTest,
 } from "./agent-run-registry.js";
@@ -43,5 +46,33 @@ describe("agent run task ownership", () => {
     releaseAgentRunContext("shared-task-run", firstClaim);
     expect(getAgentRunTaskRunId("shared-task-run")).toBeUndefined();
     expect(getAgentRunContext("shared-task-run")).toBeUndefined();
+  });
+
+  test("binds and clears event task ownership only on the current run context", () => {
+    const lifecycleGeneration = getAgentRunLifecycleGeneration();
+    registerAgentRunContext("subagent-replacement", {
+      lifecycleGeneration,
+      sessionKey: "agent:main:subagent:replacement",
+    });
+
+    expect(
+      bindAgentRunContextTaskRunId(
+        "subagent-replacement",
+        lifecycleGeneration,
+        "  original-task  ",
+      ),
+    ).toBe(true);
+    expect(getAgentRunContext("subagent-replacement")?.taskRunId).toBe("original-task");
+
+    expect(
+      bindAgentRunContextTaskRunId("subagent-replacement", "stale-generation", "other-task"),
+    ).toBe(false);
+    expect(getAgentRunContext("subagent-replacement")?.taskRunId).toBe("original-task");
+
+    expect(
+      bindAgentRunContextTaskRunId("subagent-replacement", lifecycleGeneration, undefined),
+    ).toBe(true);
+    expect(getAgentRunContext("subagent-replacement")?.taskRunId).toBeUndefined();
+    expect(bindAgentRunContextTaskRunId("missing-run", lifecycleGeneration, "task")).toBe(false);
   });
 });

--- a/src/infra/agent-run-registry.ts
+++ b/src/infra/agent-run-registry.ts
@@ -8,6 +8,8 @@ import { clearAgentRunUsage, resetAgentRunUsageForTest } from "./agent-run-usage
 /** Per-run metadata used to stamp events and gate Control UI visibility. */
 type AgentRunContext = {
   sessionKey?: string;
+  /** Detached task owner for lifecycle events emitted by this operational run. */
+  taskRunId?: string;
   /** Resolved agent owner, including for unscoped session keys. */
   agentId?: string;
   /** Owning run's sessionId; stamped onto lifecycle events. */
@@ -305,6 +307,24 @@ export function claimAgentRunContext(
 /** Returns the currently registered context for a run, if it has not been cleared or swept. */
 export function getAgentRunContext(runId: string): AgentRunContext | undefined {
   return getAgentRunRegistryState().contexts.get(runId);
+}
+
+export function bindAgentRunContextTaskRunId(
+  runId: string,
+  lifecycleGeneration: string | undefined,
+  taskRunId: string | undefined,
+): boolean {
+  const context = getAgentRunRegistryState().contexts.get(runId);
+  if (
+    !context ||
+    !lifecycleGeneration ||
+    context.lifecycleGeneration !== lifecycleGeneration ||
+    lifecycleGeneration !== getAgentRunLifecycleGeneration()
+  ) {
+    return false;
+  }
+  context.taskRunId = taskRunId?.trim() || undefined;
+  return true;
 }
 
 export function bindAgentRunTaskRunId(runId: string, claimId: string, taskRunId: string): boolean {


### PR DESCRIPTION
Related: #123125

## What Problem This Solves

A replacement or follow-up subagent run can finish after its active registry row
is gone. The no-entry lifecycle path previously matched pending completion state
by session key and selected the newest generation. Reusing that session for a
different task could therefore overwrite an unrelated task's frozen result and
retry payload.

This supersedes the behaviorally incomplete lifecycle portion of #123125.
Thanks to @RomneyDa for the baseline investigation.

## Why This Change Was Made

- Carry the detached `taskRunId` owner on lifecycle events as private,
  non-enumerable run metadata.
- Bind that owner only to the current run lifecycle generation.
- Preserve the same owner through steer/replacement runs for the same task.
- Require exactly one pending completion row with that task owner before any
  frozen-result mutation.
- Prefer producer-owned visible terminal reply evidence.
- Use transcript fallback only after exact task ownership is established.
- Preserve prior visible completion for missing, ambiguous, silent, or unrelated
  follow-up events.
- Refresh the stored completion and pending retry payload atomically.

No abort, timeout, schema, storage, configuration, preference, protocol, or
release surface changes.

## User Impact

Late follow-up turns can refresh the correct task's pending completion, while a
different task reusing the same session cannot corrupt that result.

## Evidence

- Exact base: `6cb08cb8ee9ee6235c7bd1f5f3fd7b85b8673ce7`
- Exact head: `4ea3d26b8ccb99a919f26134191b3b96968f986d`
- Focused tests: **239/239 passed**
  - agent event and run-context ownership: **49/49**
  - lifecycle ownership and race coverage: **149/149**
  - retry-grace E2E: **14/14**
  - steer/replacement ownership: **27/27**
- Scoped `oxlint`: **0 warnings, 0 errors**
- `git diff --check`: passed
- Core typecheck was not counted as proof: the shared remote install requested a
  modules purge, and the pre-refresh attempt reported unrelated current-main
  failures in `packages/terminal-core/src/ansi.ts` and
  `src/cli/session-ref.ts`.
- Production LOC: **+97/-34** (net **+63**) for the exact ownership boundary.
- Tests: **+168/-22** (net **+146**).
