### PR TITLE
test(codex): include attempt tools in light shard

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -12,6 +12,7 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
       "extensions/codex/src/app-server/run-attempt-state.test.ts",
+      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
Related: #126226

## What Problem This Solves

Resolves a CI ownership gap where the Codex run-attempt tools test was not assigned to a full-suite Vitest project, leaving the compact Node shard unable to run the complete owned set.

## Why This Change Was Made

Adds the test to the existing light Codex app-server attempt shard beside the related run-attempt state tests. Runtime behavior, scanner behavior, scripts, and other shard configs are unchanged.

## User Impact

No user-visible behavior change. Maintainers get deterministic full-suite coverage for the Codex direct-tool selection tests, unblocking #126226.

## Evidence

- `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts extensions/codex/src/app-server/run-attempt-tools.test.ts` (21 tests passed)
- `node scripts/check-changed.mjs -- test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts`
- `git diff --check`
- Delta: production 0; test infrastructure +1
- AI-assisted development: yes
