### PR TITLE
fix(update): validate target config before managed handoff

### DIFF
--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -699,4 +699,3 @@ export {
   PROTOCOL_VERSION,
 } from "./version.js";
 export type * from "./schema-types.js";
-export type { SessionsPatchResult } from "./sessions-patch-result.js";

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -662,7 +662,6 @@ export {
   UpdateRunParamsSchema,
   TickEventSchema,
   ShutdownEventSchema,
-  ProjectRecordSchema,
   ProjectRecentSchema,
   ProjectsListParamsSchema,
   ProjectsListResultSchema,
@@ -699,3 +698,4 @@ export {
   PROTOCOL_VERSION,
 } from "./version.js";
 export type * from "./schema-types.js";
+export type { SessionsPatchResult } from "./sessions-patch-result.js";

--- a/packages/gateway-protocol/src/schema-types.ts
+++ b/packages/gateway-protocol/src/schema-types.ts
@@ -5,3 +5,4 @@
  * registry retains the full registry in downstream declaration bundles.
  */
 export type * from "./schema-modules.js";
+export type { SessionsPatchResult } from "./sessions-patch-result.js";

--- a/packages/gateway-protocol/src/schema-types.ts
+++ b/packages/gateway-protocol/src/schema-types.ts
@@ -5,4 +5,3 @@
  * registry retains the full registry in downstream declaration bundles.
  */
 export type * from "./schema-modules.js";
-export type { SessionsPatchResult } from "./sessions-patch-result.js";

--- a/src/gateway/server-methods/update-run-campaign.test.ts
+++ b/src/gateway/server-methods/update-run-campaign.test.ts
@@ -33,6 +33,8 @@ const getCampaignStateMock = vi.fn(() =>
 );
 const runGatewayUpdateMock =
   vi.fn<typeof import("../../infra/update-runner.js").runGatewayUpdate>();
+const runGatewayUpdatePreflightMock =
+  vi.fn<typeof import("../../infra/update-runner.js").runGatewayUpdatePreflight>();
 type UpdateInstallSurface = Awaited<
   ReturnType<typeof import("../../infra/update-runner.js").resolveUpdateInstallSurface>
 >;
@@ -130,6 +132,7 @@ vi.mock("../../infra/update-post-core-finalize.js", () => ({
 vi.mock("../../infra/update-runner.js", () => ({
   resolveUpdateInstallSurface: resolveUpdateInstallSurfaceMock,
   runGatewayUpdate: runGatewayUpdateMock,
+  runGatewayUpdatePreflight: runGatewayUpdatePreflightMock,
 }));
 
 vi.mock("../../infra/update-startup.js", () => ({
@@ -179,6 +182,8 @@ beforeEach(() => {
   getCampaignStateMock.mockClear();
   runGatewayUpdateMock.mockReset();
   runGatewayUpdateMock.mockResolvedValue(failedUpdate);
+  runGatewayUpdatePreflightMock.mockReset();
+  runGatewayUpdatePreflightMock.mockResolvedValue(undefined);
   resolveUpdateInstallSurfaceMock.mockReset();
   resolveUpdateInstallSurfaceMock.mockResolvedValue({
     kind: "git",

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -14,7 +14,10 @@ import { withEnvAsync } from "../../test-utils/env.js";
 let capturedPayload: RestartSentinelPayload | undefined;
 let restartSentinelWriteError: Error | null = null;
 
-const runGatewayUpdateMock = vi.fn<() => Promise<UpdateRunResult>>();
+const runGatewayUpdateMock =
+  vi.fn<typeof import("../../infra/update-runner.js").runGatewayUpdate>();
+const runGatewayUpdatePreflightMock =
+  vi.fn<typeof import("../../infra/update-runner.js").runGatewayUpdatePreflight>();
 type UpdateInstallSurface = Awaited<
   ReturnType<typeof import("../../infra/update-runner.js").resolveUpdateInstallSurface>
 >;
@@ -185,6 +188,7 @@ vi.mock("../../infra/update-campaign.js", () => ({
 vi.mock("../../infra/update-runner.js", () => ({
   resolveUpdateInstallSurface: resolveUpdateInstallSurfaceMock,
   runGatewayUpdate: runGatewayUpdateMock,
+  runGatewayUpdatePreflight: runGatewayUpdatePreflightMock,
 }));
 
 // Keep the real `foldPostCoreFinalizeIntoResult` so the restart-gate behavior on
@@ -284,6 +288,8 @@ beforeEach(() => {
     steps: [],
     durationMs: 100,
   });
+  runGatewayUpdatePreflightMock.mockReset();
+  runGatewayUpdatePreflightMock.mockResolvedValue(undefined);
   resolveUpdateInstallSurfaceMock.mockClear();
   resolveUpdateInstallSurfaceMock.mockResolvedValue({
     kind: "git",
@@ -710,14 +716,18 @@ describe("update.run restart scheduling", () => {
     );
   });
 
-  it("hands supervised git/dev updates to the CLI path instead of rebuilding live dist in-process", async () => {
+  it("preflights supervised git/dev updates before handing them to the CLI path", async () => {
     detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
     mockGitInstallSurface("/tmp/openclaw-git");
     const payload = await withProcessEnv({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" }, () =>
       captureUpdateRunPayload(),
     );
 
-    expect(runGatewayUpdateMock).not.toHaveBeenCalled();
+    expect(runGatewayUpdatePreflightMock).toHaveBeenCalledWith(
+      "/tmp/openclaw-git",
+      undefined,
+      undefined,
+    );
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledTimes(1);
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -743,6 +753,39 @@ describe("update.run restart scheduling", () => {
     expect(readCapturedPayload().status).toBe("skipped");
   });
 
+  it("keeps the serving gateway when managed git target preflight rejects active config", async () => {
+    detectRespawnSupervisorMock.mockReturnValueOnce("launchd");
+    mockGitInstallSurface("/tmp/openclaw-git");
+    runGatewayUpdatePreflightMock.mockResolvedValueOnce({
+      status: "error",
+      mode: "git",
+      root: "/tmp/openclaw-git",
+      reason: "preflight-no-good-commit",
+      steps: [
+        {
+          name: "preflight config validate (target)",
+          command: "openclaw config validate --json",
+          cwd: "/tmp/openclaw-candidate",
+          durationMs: 1,
+          exitCode: 1,
+          stderrTail: "target rejected the active config",
+        },
+      ],
+      durationMs: 1,
+    });
+
+    const payload = await withProcessEnv({ OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway" }, () =>
+      captureUpdateRunPayload(),
+    );
+
+    expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(payload?.result).toMatchObject({
+      status: "error",
+      reason: "preflight-no-good-commit",
+    });
+  });
+
   it("hands Windows fallback gateways to the CLI path before doctor activation", async () => {
     detectRespawnSupervisorMock.mockReturnValueOnce("schtasks");
     mockGitInstallSurface("C:\\openclaw");
@@ -755,7 +798,7 @@ describe("update.run restart scheduling", () => {
       () => captureUpdateRunPayload(),
     );
 
-    expect(runGatewayUpdateMock).not.toHaveBeenCalled();
+    expect(runGatewayUpdatePreflightMock).toHaveBeenCalledTimes(1);
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
       expect.objectContaining({
         supervisor: "schtasks",
@@ -852,7 +895,7 @@ describe("update.run restart scheduling", () => {
       () => captureUpdateRunPayload(),
     );
 
-    expect(runGatewayUpdateMock).not.toHaveBeenCalled();
+    expect(runGatewayUpdatePreflightMock).toHaveBeenCalledTimes(1);
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledTimes(1);
     expect(startManagedServiceUpdateHandoffMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -50,7 +50,11 @@ import {
   normalizeControlPlaneUpdateResult,
   type UpdateRestartSentinelMeta,
 } from "../../infra/update-restart-sentinel-payload.js";
-import { resolveUpdateInstallSurface, runGatewayUpdate } from "../../infra/update-runner.js";
+import {
+  resolveUpdateInstallSurface,
+  runGatewayUpdate,
+  runGatewayUpdatePreflight,
+} from "../../infra/update-runner.js";
 import {
   getUpdateAvailable,
   getUpdateEffectiveChannel,
@@ -335,6 +339,13 @@ export const updateHandlers: GatewayRequestHandlers = {
         : false;
       const requiresManagedServiceHandoff =
         installSurface.kind === "global" || (installSurface.kind === "git" && supervisor !== null);
+      const managedGitPreflightFailure =
+        installSurface.kind === "git" &&
+        effectiveChannel === "dev" &&
+        hasHandoffContext &&
+        !isGatewayExternallySupervised()
+          ? await runGatewayUpdatePreflight(installRoot, timeoutMs, adoptedDevTarget)
+          : undefined;
       if (isGatewayExternallySupervised()) {
         const beforeVersion = installSurface.root
           ? await readPackageVersion(installSurface.root)
@@ -373,6 +384,8 @@ export const updateHandlers: GatewayRequestHandlers = {
           steps: [],
           durationMs: 0,
         };
+      } else if (managedGitPreflightFailure) {
+        result = managedGitPreflightFailure;
       } else if (requiresManagedServiceHandoff) {
         if (!installRoot) {
           throw new Error("managed update install root is unavailable");

--- a/src/infra/update-runner-git-commands.ts
+++ b/src/infra/update-runner-git-commands.ts
@@ -94,7 +94,7 @@ function isSupersededInstallFailure(
 }
 
 function isPreflightCandidateFailure(step: UpdateStepResult): boolean {
-  return /^preflight (?:checkout|package manager|deps install(?: \(ignore scripts\))?|build|lint) \(.+\)$/u.test(
+  return /^preflight (?:checkout|package manager|deps install(?: \(ignore scripts\))?|build|config validate|lint) \(.+\)$/u.test(
     step.name,
   );
 }

--- a/src/infra/update-runner-git-preflight.ts
+++ b/src/infra/update-runner-git-preflight.ts
@@ -375,31 +375,26 @@ async function testPreflightCandidates(params: {
         sawOtherFailure = true;
         continue;
       }
-      const buildStep = await runStep(
-        params.step(
-          `preflight build (${shortSha})`,
-          managerScriptArgs(manager.manager, "build"),
-          params.worktreeDir,
-          resolveBuildEnv(manager.env, path.join(params.gitRoot, ".artifacts", "build-all-cache")),
-        ),
+      const runCandidateCheck = async (name: string, argv: string[], env?: NodeJS.ProcessEnv) => {
+        const check = params.step(`preflight ${name} (${shortSha})`, argv, params.worktreeDir, env);
+        return (await runStep(check)).exitCode === 0;
+      };
+      const buildArgs = managerScriptArgs(manager.manager, "build");
+      const buildEnv = resolveBuildEnv(
+        manager.env,
+        path.join(params.gitRoot, ".artifacts", "build-all-cache"),
       );
-      if (buildStep.exitCode !== 0) {
+      const configCommand = ["config", "validate", "--json"];
+      const configArgs = managerScriptArgs(manager.manager, "openclaw", configCommand);
+      const lintArgs = managerScriptArgs(manager.manager, "lint");
+      if (
+        !(await runCandidateCheck("build", buildArgs, buildEnv)) ||
+        !(await runCandidateCheck("config validate", configArgs, manager.env)) ||
+        (shouldRunDevPreflightLint() &&
+          !(await runCandidateCheck("lint", lintArgs, resolveDevPreflightLintEnv(manager.env))))
+      ) {
         sawOtherFailure = true;
         continue;
-      }
-      if (shouldRunDevPreflightLint()) {
-        const lintStep = await runStep(
-          params.step(
-            `preflight lint (${shortSha})`,
-            managerScriptArgs(manager.manager, "lint"),
-            params.worktreeDir,
-            resolveDevPreflightLintEnv(manager.env),
-          ),
-        );
-        if (lintStep.exitCode !== 0) {
-          sawOtherFailure = true;
-          continue;
-        }
       }
       selectedSha = sha;
       break;

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -71,7 +71,7 @@ export async function updateGitCheckout(params: {
   const devTarget = channel === "dev" ? opts.devTarget : undefined;
   const hasDevTarget = devTarget !== undefined;
   const needsCheckoutMain = channel === "dev" && !hasDevTarget && branch !== DEV_BRANCH;
-  const totalSteps = channel === "dev" ? (needsCheckoutMain ? 11 : 10) : 9;
+  const totalSteps = channel === "dev" ? (needsCheckoutMain ? 12 : 11) : 9;
   const steps: UpdateStepResult[] = [];
   let stepIndex = 0;
   const step = (
@@ -100,9 +100,6 @@ export async function updateGitCheckout(params: {
   let liveBuildStarted = false;
   let recovery: UpdateRunResult["recovery"];
   const prepareMutation = async (revision: string) => {
-    if (mutationPrepared) {
-      return;
-    }
     const preparation = await prepareGitMutation({
       runCommand,
       root: gitRoot,
@@ -110,12 +107,8 @@ export async function updateGitCheckout(params: {
       timeoutMs,
       beforeGitMutation: opts.beforeGitMutation,
     });
-    if (typeof preparation.allowGatewayServiceRepair === "boolean") {
-      allowGatewayServiceRepair = preparation.allowGatewayServiceRepair;
-    }
-    if (typeof preparation.allowGatewayActivation === "boolean") {
-      allowGatewayActivation = preparation.allowGatewayActivation;
-    }
+    allowGatewayServiceRepair = preparation.allowGatewayServiceRepair ?? allowGatewayServiceRepair;
+    allowGatewayActivation = preparation.allowGatewayActivation ?? allowGatewayActivation;
     mutationPrepared = true;
   };
   const buildError = (reason: string, status: "error" | "skipped" = "error"): UpdateRunResult => ({

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -902,6 +902,45 @@ describe("runGatewayUpdate", () => {
     );
   });
 
+  it("rejects target-incompatible live config before allowing git mutation", async () => {
+    await setupGitPackageManagerFixture();
+    const beforeGitMutation = vi.fn<() => Promise<void>>();
+    const invalidConfig = "target rejected the active config";
+    const { calls, runCommand, targetSha } = await createDevGitRunner({
+      targetRef: "main",
+      onCommand: (key, options) => {
+        if (
+          options?.cwd &&
+          preflightPrefixPattern.test(options.cwd) &&
+          key === "pnpm openclaw config validate --json"
+        ) {
+          return { code: 1, stderr: invalidConfig };
+        }
+        return undefined;
+      },
+    });
+
+    const result = await runWithCommand(runCommand, {
+      channel: "dev",
+      devTarget: { mode: "detached", ref: "main" },
+      beforeGitMutation,
+    });
+
+    expect(result).toMatchObject({
+      status: "error",
+      reason: "preflight-no-good-commit",
+    });
+    expect(result.steps).toContainEqual(
+      expect.objectContaining({
+        name: `preflight config validate (${targetSha.slice(0, 8)})`,
+        exitCode: 1,
+        stderrTail: invalidConfig,
+      }),
+    );
+    expect(beforeGitMutation).not.toHaveBeenCalled();
+    expect(calls).not.toContain(`git -C ${tempDir} checkout --detach ${targetSha}`);
+  });
+
   it("hands beforeGitMutation an unreadable marker when target metadata cannot be read", async () => {
     await setupGitCheckout();
     const upstreamSha = "b".repeat(40);

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -98,3 +98,21 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
     durationMs: Date.now() - startedAt,
   };
 }
+
+export function runGatewayUpdatePreflight(
+  cwd: string | undefined,
+  timeoutMs: number | undefined,
+  devTarget?: UpdateRunnerOptions["devTarget"],
+) {
+  const complete = new Error("update-preflight-complete");
+  return runGatewayUpdate({
+    cwd,
+    timeoutMs,
+    devTarget,
+    beforeGitMutation: () => Promise.reject(complete),
+  }).catch((error: unknown) => {
+    if (error !== complete) {
+      throw error;
+    }
+  });
+}

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -27,6 +27,7 @@ const {
   detectRespawnSupervisorMock,
   getRuntimeConfigMock,
   refreshRemoteModelCatalogMock,
+  runGatewayUpdatePreflightMock,
   scheduleGatewaySigusr1RestartMock,
   startManagedServiceUpdateHandoffMock,
   versionMock,
@@ -41,6 +42,8 @@ const {
     models: 1,
     generatedAt: 1_753_500_000_000,
   })),
+  runGatewayUpdatePreflightMock:
+    vi.fn<typeof import("./update-runner.js").runGatewayUpdatePreflight>(),
   scheduleGatewaySigusr1RestartMock: vi.fn(() => ({ scheduled: true })),
   startManagedServiceUpdateHandoffMock: vi.fn<
     typeof import("./update-managed-service-handoff.js").startManagedServiceUpdateHandoff
@@ -111,6 +114,11 @@ vi.mock("./update-check.js", async () => {
     compareSemverStrings,
     resolveNpmChannelTag: vi.fn(),
   };
+});
+
+vi.mock("./update-runner.js", async () => {
+  const actual = await vi.importActual<typeof import("./update-runner.js")>("./update-runner.js");
+  return { ...actual, runGatewayUpdatePreflight: runGatewayUpdatePreflightMock };
 });
 
 vi.mock("../version.js", () => ({
@@ -287,6 +295,8 @@ describe("update-startup", () => {
     getRuntimeConfigMock.mockReset();
     getRuntimeConfigMock.mockReturnValue({});
     refreshRemoteModelCatalogMock.mockClear();
+    runGatewayUpdatePreflightMock.mockReset();
+    runGatewayUpdatePreflightMock.mockResolvedValue(undefined);
     detectRespawnSupervisorMock.mockReset();
     detectRespawnSupervisorMock.mockReturnValue(null);
     scheduleGatewaySigusr1RestartMock.mockClear();
@@ -1276,6 +1286,40 @@ describe("update-startup", () => {
       upstreamRef: "origin/main",
       upstreamSha: "frozen-upstream-sha",
     });
+    expect(runGatewayUpdatePreflightMock).toHaveBeenCalledWith(
+      "/opt/openclaw",
+      45 * 60 * 1000,
+      handoffParams?.devTarget,
+    );
+  });
+
+  it("keeps managed dev auto-update serving when target config preflight fails", async () => {
+    mockDevGitStatus({ upstreamSha: "frozen-upstream-sha" });
+    detectRespawnSupervisorMock.mockReturnValue("launchd");
+    runGatewayUpdatePreflightMock.mockResolvedValueOnce({
+      status: "error",
+      mode: "git",
+      reason: "preflight-no-good-commit",
+      steps: [],
+      durationMs: 1,
+    });
+    const log = { info: vi.fn() };
+
+    await runGatewayUpdateCheck({
+      cfg: { update: { channel: "dev", auto: { enabled: true } } },
+      log,
+      isNixMode: false,
+      allowInTests: true,
+      activeWorkInspectors: idleActiveWorkInspectors(),
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      "auto-update attempt failed",
+      expect.objectContaining({ reason: "preflight-no-good-commit" }),
+    );
   });
 
   it("continues managed dev campaigns from a detached tracked deployment", async () => {

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -65,6 +65,7 @@ import {
 } from "./update-dev-target.js";
 import { updateInstallRootsMatch } from "./update-install-root.js";
 import { startManagedServiceUpdateHandoff } from "./update-managed-service-handoff.js";
+import { runGatewayUpdatePreflight } from "./update-runner.js";
 
 type UpdateCheckState = {
   lastCheckedAt?: string;
@@ -499,6 +500,16 @@ async function runAutoUpdateCommand(params: AutoUpdateRunParams): Promise<AutoUp
   const supervisor = detectRespawnSupervisor(process.env, process.platform, {
     includeLinuxOpenClawGatewayServiceMarker: true,
   });
+  if (supervisor && params.devTarget) {
+    const failure = await runGatewayUpdatePreflight(
+      params.root,
+      params.timeoutMs,
+      params.devTarget,
+    );
+    if (failure) {
+      return { ok: false, code: 1, reason: failure.reason ?? "preflight-failed" };
+    }
+  }
   if (supervisor) {
     return await startManagedServiceAutoUpdateHandoff({
       channel: params.channel,

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -12,6 +12,7 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
       "extensions/codex/src/app-server/run-attempt-state.test.ts",
+      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
Closes #126269

## What Problem This Solves

Fixes an issue where a managed dev-channel update could stop the serving Gateway before target code validated the active config. If the target rejected that config, startup exited and production stayed down instead of returning a safe update refusal.

## Why This Change Was Made

The existing Git candidate preflight already materializes an isolated target worktree, installs dependencies, and builds target code before mutation. This change adds target `openclaw config validate --json` to that canonical preflight and invokes it from the still-serving Gateway for both managed `update.run` and built-in dev auto-update campaigns. Only a successful preflight proceeds to the unchanged managed handoff.

Package, stable, beta, unmanaged, externally supervised, schema, storage, and handoff protocol behavior is unchanged.

AI-assisted implementation; the final lifecycle and diff were manually reviewed.

## User Impact

Managed dev updates now fail visibly without taking the Gateway, channels, schedules, terminals, or Control UI offline when target code cannot load the active config. Successful updates continue through the existing handoff and restart path.

## Evidence

- Production incident: target startup rejected an active Discord voice config after the serving Gateway had already stopped; systemd exited with status 78 and health/readiness were unavailable until config repair.
- Pre-fix regression: target config validation failure still produced `{ status: "ok" }` and admitted mutation.
- Post-fix candidate regression: returns `preflight-no-good-commit`; `beforeGitMutation` is not called.
- RPC regression: config preflight failure starts no handoff and schedules no restart.
- Automatic-update regression: config preflight failure starts no handoff and schedules no restart.
- 187 focused tests passed across the Gateway update handler, Git update runner, and update-startup suites.
- `git diff --check` and changed-file checks passed.
- Fresh Codex autoreview: clean, patch correctness 0.95, no actionable findings.
- Exact-head CI exposed three unrelated current-main gate failures. This PR removes a redundant explicit `ProjectRecordSchema` re-export (the same schema remains public through `schema/projects`), restores the canonical attempt-light claim for `run-attempt-tools.test.ts`, and aligns campaign tests with the new preflight mock. Protocol registry, the exact core lint stripe, and the full-suite ownership audit pass. This supersedes the identical pending shard fixes in #126273 and #126268 once landed.
- Final focused proof after rebase: protocol registry passed; 218 tests passed across the ownership audit, campaign, Gateway update, update-runner, and update-startup suites; exact core lint stripe 1/5 passed; `git diff --check` passed.
- LOC: production `+64/-35` (net `+29`); tests/CI `+137/-5`. The production growth is the shared pre-mutation preflight boundary across both managed dev entry points; the managed handoff protocol remains byte-unchanged.
