### PR TITLE
fix(test): restore Codex attempt tools shard owner

### DIFF
--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -12,6 +12,7 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
       "extensions/codex/src/app-server/run-attempt-state.test.ts",
+      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
Related: #126225

## What Problem This Solves

Resolves a problem where `extensions/codex/src/app-server/run-attempt-tools.test.ts` had no Vitest shard owner after later merges removed the dedicated claim from `#126225`, causing the test ownership audit to fail.

## Why This Change Was Made

Restores the single canonical claim in the lightweight Codex app-server attempt shard. The extra attempt and tools shards remain unclaimed for this file, so the full suite runs it exactly once.

Production LOC: +0/-0 (net 0) | Test infrastructure: +1/-0

## User Impact

No runtime behavior changes. Maintainers regain deterministic coverage of the Codex attempt-tools test in the full test matrix.

## Evidence

- `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts` - 18 tests passed
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt-tools.test.ts` - 3 tests passed
- `node scripts/check-changed.mjs -- test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts` - passed
- `git diff --check` - passed
- Exact claim count: attempt-light 1, attempt-extra 0, tools 0
- Upstream Codex contract inspected: `codex-rs/app-server-protocol/src/protocol/common.rs` defines `item/tool/call`; `codex-rs/app-server/src/bespoke_event_handling.rs` maps dynamic tool requests through that app-server boundary.
