### PR TITLE
fix(ci): restore protocol lint and Codex shard ownership

### DIFF
--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -692,10 +692,6 @@ export {
   FsListDirParamsSchema,
   FsListDirResultSchema,
 } from "./schema-modules.js";
-export {
-  MIN_CLIENT_PROTOCOL_VERSION,
-  MIN_NODE_PROTOCOL_VERSION,
-  MIN_PROBE_PROTOCOL_VERSION,
-  PROTOCOL_VERSION,
-} from "./version.js";
+export * from "./version.js";
 export type * from "./schema-types.js";
+export type { SessionsPatchResult } from "./sessions-patch-result.js";

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -699,4 +699,3 @@ export {
   PROTOCOL_VERSION,
 } from "./version.js";
 export type * from "./schema-types.js";
-export type { SessionsPatchResult } from "./sessions-patch-result.js";

--- a/packages/gateway-protocol/src/schema-types.ts
+++ b/packages/gateway-protocol/src/schema-types.ts
@@ -5,3 +5,4 @@
  * registry retains the full registry in downstream declaration bundles.
  */
 export type * from "./schema-modules.js";
+export type * from "./sessions-patch-result.js";

--- a/packages/gateway-protocol/src/schema-types.ts
+++ b/packages/gateway-protocol/src/schema-types.ts
@@ -5,4 +5,3 @@
  * registry retains the full registry in downstream declaration bundles.
  */
 export type * from "./schema-modules.js";
-export type * from "./sessions-patch-result.js";

--- a/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts
@@ -12,6 +12,7 @@ function createExtensionCodexAppServerAttemptLightVitestConfig(
       "extensions/codex/src/app-server/run-attempt-client-prewarm.test.ts",
       "extensions/codex/src/app-server/run-attempt-connection.test.ts",
       "extensions/codex/src/app-server/run-attempt-state.test.ts",
+      "extensions/codex/src/app-server/run-attempt-tools.test.ts",
     ],
     {
       dir: "extensions",


### PR DESCRIPTION
## What Problem This Solves

`main` has two independent CI regressions that prevent either isolated repair PR from reaching a green merge-tree gate:

- `check-lint-core-1`: `packages/gateway-protocol/src/index.ts` reached 701 lint-counted lines, one above the 700-line ceiling.
- `checks-node-compact-large-22`: `extensions/codex/src/app-server/run-attempt-tools.test.ts` has no full-suite Vitest owner.

The failures are visible together in run 32235592636. The second repair overlaps #126268; including both here is necessary because that PR inherits the protocol lint failure while this PR otherwise inherits the missing-owner failure.

## Why This Change Was Made

`version.ts` exports exactly the four protocol-version constants already named by the package root, so the root now re-exports that module directly instead of enumerating those same constants across six lines. This preserves the exact package API, keeps `schema-types.ts` registry-free, avoids a max-lines suppression, and reduces production LOC by five.

The Codex test returns to the purpose-built `attempt-light` shard selected by #126225 and used by the analogous run-attempt state tests. It executes exactly once; runtime code is unchanged.

## User Impact

No user-visible behavior change. Restores the full required CI gate without weakening assertions or lint budgets.

## Evidence

- `node --import tsx scripts/run-oxlint-shards.mts --only=core --split-core --core-stripe=1/5 --threads=1`
- `PROTOCOL_SINCE_BASE_SHA=e71fc902eece0f795d593e5d4e03ad6e7496d9a7 pnpm protocol:check`
- `node scripts/run-vitest.mjs packages/gateway-protocol/src/index.test.ts` (62 tests passed)
- `node scripts/run-vitest.mjs test/vitest-projects-config.test.ts` (18 tests passed)
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-codex-app-server-attempt-light.config.ts` (54 tests passed)
- `node scripts/check-changed.mjs`
- `git diff --check`
- Autoreview: clean, no actionable findings
- Delta: production +1/-6 (net -5); test infrastructure +1
