### PR TITLE
fix(browser): resolve chrome-extension bundled dir from built package layout

### DIFF
--- a/extensions/browser/src/doctor-browser.test.ts
+++ b/extensions/browser/src/doctor-browser.test.ts
@@ -1,9 +1,14 @@
 // Browser tests cover doctor browser plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../test-support.js";
 import {
   maybeArchiveLegacyClawdBrowserProfileResidue,
   noteChromeMcpBrowserReadiness,
 } from "./doctor-browser.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function requireFirstNoteText(noteFn: ReturnType<typeof vi.fn>): string {
   const [call] = noteFn.mock.calls;
@@ -298,6 +303,55 @@ describe("browser doctor readiness", () => {
     expect(noteFn).toHaveBeenCalled();
     const note = requireNoteTextContaining(noteFn, "explicit Chromium user data directory");
     expect(note).toContain("brave://inspect/#remote-debugging");
+  });
+});
+
+describe("browser plugin package layout", () => {
+  async function expectRepairLayout(layout: "source" | "built") {
+    const packageRoot = fs.realpathSync(tempDirs.make("openclaw-browser-doctor-"));
+    const moduleDir = layout === "source" ? path.join(packageRoot, "src") : packageRoot;
+    const modulePath = path.join(
+      moduleDir,
+      layout === "source" ? "doctor-browser.ts" : "browser-doctor.js",
+    );
+    fs.mkdirSync(moduleDir, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), "{}");
+
+    const repairOwnedChromeExtensionNativeHosts = vi.fn(async () => ({
+      changes: [],
+      warnings: [],
+    }));
+    vi.resetModules();
+    vi.doMock("node:url", async () => ({
+      ...(await vi.importActual<typeof import("node:url")>("node:url")),
+      fileURLToPath: () => modulePath,
+    }));
+    vi.doMock("./browser/extension-install.js", () => ({
+      browserExtensionStatus: vi.fn(),
+      FOUNDATION_CHROME_WEB_STORE_URL: "https://example.invalid",
+      repairOwnedChromeExtensionNativeHosts,
+    }));
+
+    try {
+      const { maybeRepairOwnedChromeExtensionNativeHosts } = await import("./doctor-browser.js");
+      await maybeRepairOwnedChromeExtensionNativeHosts();
+      expect(repairOwnedChromeExtensionNativeHosts).toHaveBeenCalledWith({
+        bundledDir: path.join(packageRoot, "chrome-extension"),
+        pluginRoot: packageRoot,
+      });
+    } finally {
+      vi.doUnmock("node:url");
+      vi.doUnmock("./browser/extension-install.js");
+      vi.resetModules();
+    }
+  }
+
+  it("resolves assets from the source package root", async () => {
+    await expectRepairLayout("source");
+  });
+
+  it("resolves assets from the built package root", async () => {
+    await expectRepairLayout("built");
   });
 });
 

--- a/extensions/browser/src/doctor-browser.ts
+++ b/extensions/browser/src/doctor-browser.ts
@@ -35,7 +35,10 @@ const REMOTE_DEBUGGING_PAGES = [
   "brave://inspect/#remote-debugging",
   "edge://inspect/#remote-debugging",
 ].join(", ");
-const BROWSER_PLUGIN_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const BROWSER_MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const BROWSER_PLUGIN_ROOT = fs.existsSync(path.join(BROWSER_MODULE_DIR, "package.json"))
+  ? BROWSER_MODULE_DIR
+  : path.dirname(BROWSER_MODULE_DIR);
 const BUNDLED_CHROME_EXTENSION_DIR = path.join(BROWSER_PLUGIN_ROOT, "chrome-extension");
 
 type ExistingSessionProfile = {


### PR DESCRIPTION
<!--
Closes: doctor reports a false-positive Chrome extension bootstrap failure when OpenClaw is run from a built package.
-->

## What Problem This Solves

Fix Browser Doctor's bundled Chrome-extension lookup in compiled package layouts.

The source entry is nested under `extensions/browser/src`, while the compiled entry and copied assets are siblings under `dist/extensions/browser`. The resolver now handles exactly those two supported layouts:

- built package: when the module directory contains `package.json`, use that directory as the package root;
- source package: otherwise, use the module directory's parent.

This preserves the existing path-ownership checks. It does not add an ancestor search, fallback stack, public helper, config surface, or Knip exception.

## Root Cause

Browser Doctor always used the executing module directory's parent as the browser package root. That is correct for `extensions/browser/src/doctor-browser.ts`, but the compiled entry is already at the package root:

```text
dist/extensions/browser/browser-doctor.js
dist/extensions/browser/package.json
dist/extensions/browser/chrome-extension/
```

The old calculation therefore looked for `<checkout>/dist/extensions/chrome-extension`, which does not exist.

## User Impact

Built `openclaw doctor` and `openclaw doctor --fix` runs now inspect and repair the packaged Chrome-extension assets instead of reporting a misleading `ENOENT` for `dist/extensions/chrome-extension`.

## Evidence

- `node scripts/run-vitest.mjs extensions/browser/src/doctor-browser.test.ts`: 14/14 passed.
- Tests exercise both source and built package layouts through `maybeRepairOwnedChromeExtensionNativeHosts`.
- `pnpm build`: passed on Blacksmith Testbox against base `980b07f4a2908b007254ac3b5b9902efa412850a`.
- Built artifacts verified:
  - `dist/extensions/browser/browser-doctor.js`
  - `dist/extensions/browser/package.json`
  - `dist/extensions/browser/chrome-extension/`
  - no `dist/extensions/chrome-extension`
- Isolated built CLI proof:

```text
browser doctor proof: artifacts=pass installed_manifest=pass doctor_rc=0 doctor_fix_rc=0 legacy_lookup_matches=0 lookup_failure_matches=0 setup_install_rc=1
```

The setup-only install exit is the expected clean-Testbox result when no Chrome-family user-data directory exists; it still creates the owned stable extension copy needed to exercise Doctor repair.

- `node scripts/check-changed.mjs -- extensions/browser/src/doctor-browser.ts extensions/browser/src/doctor-browser.test.ts`: passed.
- `oxfmt --check` and `git diff --check`: passed.
- Autoreview: clean, no actionable findings.
- Offline local Claw review: `nothing_found`, high confidence, best-fix verdict.

Testbox run: https://github.com/openclaw/openclaw/actions/runs/32347674521

## Scope

- Production: `+4/-1` (net `+3`).
- Tests: `+55/-1` (net `+54`).
- Config/default surfaces: `0`.
- Changed files: Browser Doctor implementation and its focused test only.
