### PR TITLE
fix(codex): reap app-server descendant processes

### DIFF
--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -16,41 +16,52 @@ type PosixProcess = {
 };
 
 const PROCESS_COLUMNS = "pid=,ppid=,pgid=,stat=,lstart=";
+const MAX_CONTAINED_PROCESSES = 512;
+const MAX_PROCESS_CONTAINMENT_MS = 2_000;
 const MAX_PROCESS_QUIESCE_PASSES = 16;
 
 export function terminateCodexAppServerDescendants(
   child: ContainableTransport,
 ): (() => void) | undefined {
   const rootPid = child.pid;
-  if (process.platform === "win32" || !rootPid || hasExited(child)) {
-    return;
+  if (process.platform === "win32" || !rootPid || !child.kill || hasExited(child)) {
+    return undefined;
   }
-  const snapshot = readProcessSnapshot();
-  if (!snapshot) {
-    return;
+  const deadline = Date.now() + MAX_PROCESS_CONTAINMENT_MS;
+  const snapshot = readProcessSnapshot(deadline);
+  if (!snapshot || Date.now() >= deadline) {
+    return undefined;
   }
   const root = snapshot.find((row) => row.pid === rootPid);
   if (!root || !isSameLiveRoot(root, root)) {
-    return;
+    return undefined;
   }
 
   const initialDescendants = collectDescendants(snapshot, [rootPid]);
+  if (initialDescendants.length > MAX_CONTAINED_PROCESSES) {
+    return undefined;
+  }
   const stoppedDescendants = new Map<string, PosixProcess>();
-  if (!signalSameRoot(root, "SIGSTOP")) {
-    return;
+  if (!signalSameRoot(root, "SIGSTOP", deadline)) {
+    return undefined;
   }
   let resumeRootOnUnwind = true;
   try {
-    const descendants = quiesceDescendants(root, initialDescendants, stoppedDescendants);
+    const descendants = quiesceDescendants(root, initialDescendants, stoppedDescendants, deadline);
     if (!descendants) {
-      return;
+      return undefined;
     }
 
     // Parents are last: every destructive signal revalidates the exact live PID
     // while the stopped ancestry still prevents new descendants.
     for (const descendant of descendants.toReversed()) {
+      if (Date.now() >= deadline) {
+        return undefined;
+      }
       if (!descendant.state.startsWith("Z")) {
-        signalSameProcess(descendant, "SIGKILL");
+        if (!signalSameProcess(descendant, "SIGKILL", deadline) || Date.now() >= deadline) {
+          return undefined;
+        }
       }
     }
     resumeRootOnUnwind = false;
@@ -70,10 +81,6 @@ export function terminateCodexAppServerDescendants(
         signalProcess(descendant.pid, "SIGCONT");
       }
       resumeTransportRoot(child, root, true);
-    } else {
-      for (const descendant of stoppedDescendants.values()) {
-        signalSameProcess(descendant, "SIGCONT");
-      }
     }
   }
 }
@@ -82,12 +89,16 @@ function quiesceDescendants(
   root: PosixProcess,
   initialDescendants: PosixProcess[],
   stopped: Map<string, PosixProcess>,
+  deadline: number,
 ): PosixProcess[] | undefined {
   const provenByPid = new Map(initialDescendants.map((descendant) => [descendant.pid, descendant]));
   const stopFailures = new Map<string, number>();
   for (let pass = 0; pass < MAX_PROCESS_QUIESCE_PASSES; pass += 1) {
-    const snapshot = readProcessSnapshot();
-    if (!snapshot) {
+    if (Date.now() >= deadline) {
+      return undefined;
+    }
+    const snapshot = readProcessSnapshot(deadline);
+    if (!snapshot || Date.now() >= deadline) {
       return undefined;
     }
     const currentRoot = snapshot.find((row) => row.pid === root.pid);
@@ -95,7 +106,7 @@ function quiesceDescendants(
       return undefined;
     }
     if (!isSameLiveRoot(currentRoot, root, true)) {
-      if (!signalSameRoot(root, "SIGSTOP")) {
+      if (!signalSameRoot(root, "SIGSTOP", deadline) || Date.now() >= deadline) {
         return undefined;
       }
       continue;
@@ -128,16 +139,25 @@ function quiesceDescendants(
       }
       provenByPid.set(descendant.pid, descendant);
     }
+    if (provenByPid.size > MAX_CONTAINED_PROCESSES) {
+      return undefined;
+    }
     const quiescenceTargets = new Map(liveProven.map((process) => [process.pid, process]));
     for (const descendant of descendants) {
       quiescenceTargets.set(descendant.pid, descendant);
     }
     let allStopped = true;
     for (const descendant of quiescenceTargets.values()) {
+      if (Date.now() >= deadline) {
+        return undefined;
+      }
       if (isStoppedState(descendant.state)) {
         continue;
       }
-      const stopQueued = signalSameProcess(descendant, "SIGSTOP");
+      const stopQueued = signalSameProcess(descendant, "SIGSTOP", deadline);
+      if (Date.now() >= deadline) {
+        return undefined;
+      }
       if (stopQueued) {
         stopFailures.delete(identityKey(descendant));
         stopped.set(identityKey(descendant), descendant);
@@ -160,17 +180,26 @@ function quiesceDescendants(
   return undefined;
 }
 
-function readProcessSnapshot(): PosixProcess[] | undefined {
-  return readProcesses(["-axo", PROCESS_COLUMNS]);
+function readProcessSnapshot(deadline: number): PosixProcess[] | undefined {
+  return readProcesses(["-axo", PROCESS_COLUMNS], deadline);
 }
 
-function readProcess(pid: number): PosixProcess | undefined {
-  return readProcesses(["-o", PROCESS_COLUMNS, "-p", String(pid)])?.find((row) => row.pid === pid);
+function readProcess(pid: number, deadline: number): PosixProcess | undefined {
+  return readProcesses(["-o", PROCESS_COLUMNS, "-p", String(pid)], deadline)?.find(
+    (row) => row.pid === pid,
+  );
 }
 
-function readProcesses(args: string[]): PosixProcess[] | undefined {
+function readProcesses(args: string[], deadline: number): PosixProcess[] | undefined {
+  const remainingMs = deadline - Date.now();
+  if (remainingMs <= 0) {
+    return undefined;
+  }
   try {
-    const result = spawnSync("ps", args, { encoding: "utf8", timeout: 500 });
+    const result = spawnSync("ps", args, {
+      encoding: "utf8",
+      timeout: Math.max(1, Math.min(500, remainingMs)),
+    });
     if (result.error || result.status !== 0) {
       return undefined;
     }
@@ -260,8 +289,8 @@ function isSameLiveRoot(
   );
 }
 
-function signalSameRoot(root: PosixProcess, signal: NodeJS.Signals): boolean {
-  const current = readProcess(root.pid);
+function signalSameRoot(root: PosixProcess, signal: NodeJS.Signals, deadline: number): boolean {
+  const current = readProcess(root.pid, deadline);
   return Boolean(current && isSameLiveRoot(current, root) && signalProcess(current.pid, signal));
 }
 
@@ -287,10 +316,14 @@ function resumeTransportRoot(
   }
 }
 
-function signalSameProcess(expected: PosixProcess, signal: NodeJS.Signals): boolean {
+function signalSameProcess(
+  expected: PosixProcess,
+  signal: NodeJS.Signals,
+  deadline: number,
+): boolean {
   // Portable Node POSIX signals are PID-based, so never retain numeric authority:
   // take this final identity snapshot synchronously immediately before every signal.
-  const current = readProcess(expected.pid);
+  const current = readProcess(expected.pid, deadline);
   return Boolean(
     current && isSameLiveProcess(current, expected) && signalProcess(current.pid, signal),
   );

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -94,10 +94,12 @@ function quiesceDescendants(
       }
     }
     if (allStopped) {
-      return descendants;
+      return [...provenByPid.values()];
     }
   }
-  return undefined;
+  // Bounded quiescence must not fail open. Kill every identity proven while it
+  // belonged to the stopped root, including processes that have since reparented.
+  return [...provenByPid.values()];
 }
 
 function readProcessSnapshot(): PosixProcess[] | undefined {
@@ -189,6 +191,8 @@ function signalSameRoot(root: PosixProcess, signal: NodeJS.Signals): boolean {
 }
 
 function signalSameProcess(expected: PosixProcess, signal: NodeJS.Signals): boolean {
+  // Portable Node POSIX signals are PID-based, so never retain numeric authority:
+  // take this final identity snapshot synchronously immediately before every signal.
   const current = readProcess(expected.pid);
   return Boolean(
     current && isSameLiveProcess(current, expected) && signalProcess(current.pid, signal),

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -16,7 +16,9 @@ type PosixProcess = {
 
 const PROCESS_COLUMNS = "pid=,ppid=,pgid=,stat=,lstart=";
 
-export function terminateCodexAppServerDescendants(child: ContainableTransport): void {
+export function terminateCodexAppServerDescendants(
+  child: ContainableTransport,
+): (() => void) | undefined {
   const rootPid = child.pid;
   if (process.platform === "win32" || !rootPid || hasExited(child)) {
     return;
@@ -35,6 +37,7 @@ export function terminateCodexAppServerDescendants(child: ContainableTransport):
   if (!signalSameRoot(root, "SIGSTOP")) {
     return;
   }
+  let resumeRootOnUnwind = true;
   try {
     const descendants = quiesceDescendants(root, initialDescendants, stoppedDescendants);
     if (!descendants) {
@@ -48,11 +51,22 @@ export function terminateCodexAppServerDescendants(child: ContainableTransport):
         signalSameProcess(descendant, "SIGKILL");
       }
     }
+    resumeRootOnUnwind = false;
+    let resumed = false;
+    return () => {
+      if (resumed) {
+        return;
+      }
+      resumed = true;
+      signalSameRoot(root, "SIGCONT");
+    };
   } finally {
     for (const descendant of stoppedDescendants.values()) {
       signalSameProcess(descendant, "SIGCONT");
     }
-    signalSameRoot(root, "SIGCONT");
+    if (resumeRootOnUnwind) {
+      signalSameRoot(root, "SIGCONT");
+    }
   }
 }
 

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -15,6 +15,7 @@ type PosixProcess = {
 };
 
 const PROCESS_COLUMNS = "pid=,ppid=,pgid=,stat=,lstart=";
+const MAX_PROCESS_QUIESCE_PASSES = 16;
 
 export function terminateCodexAppServerDescendants(
   child: ContainableTransport,
@@ -77,7 +78,7 @@ function quiesceDescendants(
 ): PosixProcess[] | undefined {
   const provenByPid = new Map(initialDescendants.map((descendant) => [descendant.pid, descendant]));
   const stopFailures = new Map<string, number>();
-  for (;;) {
+  for (let pass = 0; pass < MAX_PROCESS_QUIESCE_PASSES; pass += 1) {
     const snapshot = readProcessSnapshot();
     if (!snapshot) {
       return undefined;
@@ -137,7 +138,7 @@ function quiesceDescendants(
         }
         stopFailures.set(key, failures);
       }
-      if (!descendant.state.startsWith("D") || !stopQueued) {
+      if (!isUninterruptibleState(descendant.state) || !stopQueued) {
         allStopped = false;
       }
     }
@@ -145,6 +146,7 @@ function quiesceDescendants(
       return [...provenByPid.values()];
     }
   }
+  return undefined;
 }
 
 function readProcessSnapshot(): PosixProcess[] | undefined {
@@ -220,7 +222,11 @@ function isStoppedState(state: string): boolean {
 }
 
 function isQuiescedState(state: string): boolean {
-  return isStoppedState(state) || state.startsWith("D");
+  return isStoppedState(state) || isUninterruptibleState(state);
+}
+
+function isUninterruptibleState(state: string): boolean {
+  return state.startsWith("D") || state.startsWith("U");
 }
 
 function isSameLiveProcess(current: PosixProcess, expected: PosixProcess): boolean {

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -62,6 +62,7 @@ function quiesceDescendants(
   stopped: Map<string, PosixProcess>,
 ): PosixProcess[] | undefined {
   const provenByPid = new Map(initialDescendants.map((descendant) => [descendant.pid, descendant]));
+  const stopFailures = new Map<string, number>();
   for (;;) {
     const snapshot = readProcessSnapshot();
     if (!snapshot) {
@@ -87,6 +88,7 @@ function quiesceDescendants(
       if (!hasSameIdentity(proven, current)) {
         return undefined;
       }
+      provenByPid.set(current.pid, current);
       liveProven.push(current);
     }
     const descendants = collectDescendants(snapshot, [
@@ -111,7 +113,15 @@ function quiesceDescendants(
       }
       const stopQueued = signalSameProcess(descendant, "SIGSTOP");
       if (stopQueued) {
+        stopFailures.delete(identityKey(descendant));
         stopped.set(identityKey(descendant), descendant);
+      } else {
+        const key = identityKey(descendant);
+        const failures = (stopFailures.get(key) ?? 0) + 1;
+        if (failures >= 2) {
+          return undefined;
+        }
+        stopFailures.set(key, failures);
       }
       if (!descendant.state.startsWith("D") || !stopQueued) {
         allStopped = false;

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -4,6 +4,7 @@ type ContainableTransport = {
   pid?: number;
   exitCode?: number | null;
   signalCode?: string | null;
+  kill?: (signal?: NodeJS.Signals) => unknown;
 };
 
 type PosixProcess = {
@@ -59,14 +60,20 @@ export function terminateCodexAppServerDescendants(
         return;
       }
       resumed = true;
-      signalSameRoot(root, "SIGCONT");
+      resumeTransportRoot(child, root, false);
     };
   } finally {
-    for (const descendant of stoppedDescendants.values()) {
-      signalSameProcess(descendant, "SIGCONT");
-    }
     if (resumeRootOnUnwind) {
-      signalSameRoot(root, "SIGCONT");
+      // Inspection failure cannot also own release. These PIDs were signaled
+      // synchronously in this call and have not crossed an asynchronous boundary.
+      for (const descendant of stoppedDescendants.values()) {
+        signalProcess(descendant.pid, "SIGCONT");
+      }
+      resumeTransportRoot(child, root, true);
+    } else {
+      for (const descendant of stoppedDescendants.values()) {
+        signalSameProcess(descendant, "SIGCONT");
+      }
     }
   }
 }
@@ -104,6 +111,10 @@ function quiesceDescendants(
         return undefined;
       }
       provenByPid.set(current.pid, current);
+      const key = identityKey(current);
+      if (stopped.has(key)) {
+        stopped.set(key, current);
+      }
       liveProven.push(current);
     }
     const descendants = collectDescendants(snapshot, [
@@ -252,6 +263,28 @@ function isSameLiveRoot(
 function signalSameRoot(root: PosixProcess, signal: NodeJS.Signals): boolean {
   const current = readProcess(root.pid);
   return Boolean(current && isSameLiveRoot(current, root) && signalProcess(current.pid, signal));
+}
+
+function resumeTransportRoot(
+  child: ContainableTransport,
+  root: PosixProcess,
+  allowSynchronousPidFallback: boolean,
+): void {
+  try {
+    if (child.kill) {
+      child.kill("SIGCONT");
+      return;
+    }
+  } catch {
+    if (!allowSynchronousPidFallback) {
+      return;
+    }
+  }
+  if (allowSynchronousPidFallback) {
+    // Failure unwind has not crossed an asynchronous boundary, so the saved
+    // PID is still bounded to this synchronous stopped-root custody window.
+    signalProcess(root.pid, "SIGCONT");
+  }
 }
 
 function signalSameProcess(expected: PosixProcess, signal: NodeJS.Signals): boolean {

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -14,7 +14,6 @@ type PosixProcess = {
   startedAt: string;
 };
 
-const MAX_PROCESS_QUIESCE_PASSES = 8;
 const PROCESS_COLUMNS = "pid=,ppid=,pgid=,stat=,lstart=";
 
 export function terminateCodexAppServerDescendants(child: ContainableTransport): void {
@@ -31,7 +30,7 @@ export function terminateCodexAppServerDescendants(child: ContainableTransport):
     return;
   }
 
-  const initialDescendants = collectDescendants(snapshot, rootPid);
+  const initialDescendants = collectDescendants(snapshot, [rootPid]);
   const stoppedDescendants = new Map<string, PosixProcess>();
   if (!signalSameRoot(root, "SIGSTOP")) {
     return;
@@ -63,7 +62,7 @@ function quiesceDescendants(
   stopped: Map<string, PosixProcess>,
 ): PosixProcess[] | undefined {
   const provenByPid = new Map(initialDescendants.map((descendant) => [descendant.pid, descendant]));
-  for (let pass = 0; pass < MAX_PROCESS_QUIESCE_PASSES; pass += 1) {
+  for (;;) {
     const snapshot = readProcessSnapshot();
     if (!snapshot) {
       return undefined;
@@ -73,9 +72,27 @@ function quiesceDescendants(
       return undefined;
     }
     if (!isSameLiveRoot(currentRoot, root, true)) {
+      if (!signalSameRoot(root, "SIGSTOP")) {
+        return undefined;
+      }
       continue;
     }
-    const descendants = collectDescendants(snapshot, root.pid);
+    const snapshotByPid = new Map(snapshot.map((process) => [process.pid, process]));
+    const liveProven: PosixProcess[] = [];
+    for (const proven of provenByPid.values()) {
+      const current = snapshotByPid.get(proven.pid);
+      if (!current) {
+        continue;
+      }
+      if (!hasSameIdentity(proven, current)) {
+        return undefined;
+      }
+      liveProven.push(current);
+    }
+    const descendants = collectDescendants(snapshot, [
+      root.pid,
+      ...liveProven.map(({ pid }) => pid),
+    ]);
     for (const descendant of descendants) {
       const proven = provenByPid.get(descendant.pid);
       if (proven && !hasSameIdentity(proven, descendant)) {
@@ -83,23 +100,27 @@ function quiesceDescendants(
       }
       provenByPid.set(descendant.pid, descendant);
     }
-    let allStopped = true;
+    const quiescenceTargets = new Map(liveProven.map((process) => [process.pid, process]));
     for (const descendant of descendants) {
-      if (descendant.state.startsWith("T") || descendant.state.startsWith("Z")) {
+      quiescenceTargets.set(descendant.pid, descendant);
+    }
+    let allStopped = true;
+    for (const descendant of quiescenceTargets.values()) {
+      if (isStoppedState(descendant.state)) {
         continue;
       }
-      allStopped = false;
-      if (signalSameProcess(descendant, "SIGSTOP")) {
+      const stopQueued = signalSameProcess(descendant, "SIGSTOP");
+      if (stopQueued) {
         stopped.set(identityKey(descendant), descendant);
+      }
+      if (!descendant.state.startsWith("D") || !stopQueued) {
+        allStopped = false;
       }
     }
     if (allStopped) {
       return [...provenByPid.values()];
     }
   }
-  // Bounded quiescence must not fail open. Kill every identity proven while it
-  // belonged to the stopped root, including processes that have since reparented.
-  return [...provenByPid.values()];
 }
 
 function readProcessSnapshot(): PosixProcess[] | undefined {
@@ -147,7 +168,7 @@ function parseProcesses(output: string): PosixProcess[] {
   return rows;
 }
 
-function collectDescendants(snapshot: PosixProcess[], rootPid: number): PosixProcess[] {
+function collectDescendants(snapshot: PosixProcess[], rootPids: number[]): PosixProcess[] {
   const childrenByParent = new Map<number, PosixProcess[]>();
   for (const row of snapshot) {
     const children = childrenByParent.get(row.ppid) ?? [];
@@ -155,14 +176,27 @@ function collectDescendants(snapshot: PosixProcess[], rootPid: number): PosixPro
     childrenByParent.set(row.ppid, children);
   }
   const descendants: PosixProcess[] = [];
-  const pending = [rootPid];
+  const pending = [...new Set(rootPids)];
+  const seen = new Set(pending);
   for (const parentPid of pending) {
     for (const child of childrenByParent.get(parentPid) ?? []) {
+      if (seen.has(child.pid)) {
+        continue;
+      }
+      seen.add(child.pid);
       descendants.push(child);
       pending.push(child.pid);
     }
   }
   return descendants;
+}
+
+function isStoppedState(state: string): boolean {
+  return state.startsWith("T") || state.startsWith("t") || state.startsWith("Z");
+}
+
+function isQuiescedState(state: string): boolean {
+  return isStoppedState(state) || state.startsWith("D");
 }
 
 function isSameLiveProcess(current: PosixProcess, expected: PosixProcess): boolean {
@@ -180,7 +214,7 @@ function isSameLiveRoot(
 ): boolean {
   return (
     current.ppid === process.pid &&
-    (!requireStopped || current.state.startsWith("T")) &&
+    (!requireStopped || isQuiescedState(current.state)) &&
     isSameLiveProcess(current, expected)
   );
 }

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
 
 type ContainableTransport = {
   pid?: number;
@@ -19,16 +19,17 @@ const PROCESS_COLUMNS = "pid=,ppid=,pgid=,stat=,lstart=";
 const MAX_CONTAINED_PROCESSES = 512;
 const MAX_PROCESS_CONTAINMENT_MS = 2_000;
 const MAX_PROCESS_QUIESCE_PASSES = 16;
+const PROCESS_INSPECTION_MAX_BYTES = 8 * 1024 * 1024;
 
-export function terminateCodexAppServerDescendants(
+export async function terminateCodexAppServerDescendants(
   child: ContainableTransport,
-): (() => void) | undefined {
+): Promise<(() => void) | undefined> {
   const rootPid = child.pid;
   if (process.platform === "win32" || !rootPid || !child.kill || hasExited(child)) {
     return undefined;
   }
   const deadline = Date.now() + MAX_PROCESS_CONTAINMENT_MS;
-  const snapshot = readProcessSnapshot(deadline);
+  const snapshot = await readProcessSnapshot(deadline);
   if (!snapshot || Date.now() >= deadline) {
     return undefined;
   }
@@ -42,12 +43,17 @@ export function terminateCodexAppServerDescendants(
     return undefined;
   }
   const stoppedDescendants = new Map<string, PosixProcess>();
-  if (!signalSameRoot(root, "SIGSTOP", deadline)) {
+  if (!(await signalSameRoot(root, "SIGSTOP", deadline))) {
     return undefined;
   }
   let resumeRootOnUnwind = true;
   try {
-    const descendants = quiesceDescendants(root, initialDescendants, stoppedDescendants, deadline);
+    const descendants = await quiesceDescendants(
+      root,
+      initialDescendants,
+      stoppedDescendants,
+      deadline,
+    );
     if (!descendants) {
       return undefined;
     }
@@ -59,7 +65,7 @@ export function terminateCodexAppServerDescendants(
         return undefined;
       }
       if (!descendant.state.startsWith("Z")) {
-        if (!signalSameProcess(descendant, "SIGKILL", deadline) || Date.now() >= deadline) {
+        if (!(await signalSameProcess(descendant, "SIGKILL", deadline)) || Date.now() >= deadline) {
           return undefined;
         }
       }
@@ -85,19 +91,19 @@ export function terminateCodexAppServerDescendants(
   }
 }
 
-function quiesceDescendants(
+async function quiesceDescendants(
   root: PosixProcess,
   initialDescendants: PosixProcess[],
   stopped: Map<string, PosixProcess>,
   deadline: number,
-): PosixProcess[] | undefined {
+): Promise<PosixProcess[] | undefined> {
   const provenByPid = new Map(initialDescendants.map((descendant) => [descendant.pid, descendant]));
   const stopFailures = new Map<string, number>();
   for (let pass = 0; pass < MAX_PROCESS_QUIESCE_PASSES; pass += 1) {
     if (Date.now() >= deadline) {
       return undefined;
     }
-    const snapshot = readProcessSnapshot(deadline);
+    const snapshot = await readProcessSnapshot(deadline);
     if (!snapshot || Date.now() >= deadline) {
       return undefined;
     }
@@ -106,7 +112,7 @@ function quiesceDescendants(
       return undefined;
     }
     if (!isSameLiveRoot(currentRoot, root, true)) {
-      if (!signalSameRoot(root, "SIGSTOP", deadline) || Date.now() >= deadline) {
+      if (!(await signalSameRoot(root, "SIGSTOP", deadline)) || Date.now() >= deadline) {
         return undefined;
       }
       continue;
@@ -116,6 +122,8 @@ function quiesceDescendants(
     for (const proven of provenByPid.values()) {
       const current = snapshotByPid.get(proven.pid);
       if (!current) {
+        provenByPid.delete(proven.pid);
+        stopped.delete(identityKey(proven));
         continue;
       }
       if (!hasSameIdentity(proven, current)) {
@@ -154,7 +162,7 @@ function quiesceDescendants(
       if (isStoppedState(descendant.state)) {
         continue;
       }
-      const stopQueued = signalSameProcess(descendant, "SIGSTOP", deadline);
+      const stopQueued = await signalSameProcess(descendant, "SIGSTOP", deadline);
       if (Date.now() >= deadline) {
         return undefined;
       }
@@ -180,33 +188,54 @@ function quiesceDescendants(
   return undefined;
 }
 
-function readProcessSnapshot(deadline: number): PosixProcess[] | undefined {
-  return readProcesses(["-axo", PROCESS_COLUMNS], deadline);
+async function readProcessSnapshot(deadline: number): Promise<PosixProcess[] | undefined> {
+  return await readProcesses(["-axo", PROCESS_COLUMNS], deadline);
 }
 
-function readProcess(pid: number, deadline: number): PosixProcess | undefined {
-  return readProcesses(["-o", PROCESS_COLUMNS, "-p", String(pid)], deadline)?.find(
+async function readProcess(pid: number, deadline: number): Promise<PosixProcess | undefined> {
+  return (await readProcesses(["-o", PROCESS_COLUMNS, "-p", String(pid)], deadline))?.find(
     (row) => row.pid === pid,
   );
 }
 
-function readProcesses(args: string[], deadline: number): PosixProcess[] | undefined {
+async function readProcesses(
+  args: string[],
+  deadline: number,
+): Promise<PosixProcess[] | undefined> {
   const remainingMs = deadline - Date.now();
   if (remainingMs <= 0) {
     return undefined;
   }
-  try {
-    const result = spawnSync("ps", args, {
-      encoding: "utf8",
-      timeout: Math.max(1, Math.min(500, remainingMs)),
-    });
-    if (result.error || result.status !== 0) {
-      return undefined;
-    }
-    return parseProcesses(result.stdout);
-  } catch {
-    return undefined;
-  }
+  return await new Promise<PosixProcess[] | undefined>((resolve) => {
+    let settled = false;
+    const settle = (processes: PosixProcess[] | undefined) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(processes);
+    };
+    const inspector = execFile(
+      "ps",
+      args,
+      { encoding: "utf8", maxBuffer: PROCESS_INSPECTION_MAX_BYTES },
+      (error, stdout) => {
+        settle(error ? undefined : parseProcesses(stdout));
+      },
+    );
+    const timer = setTimeout(
+      () => {
+        settle(undefined);
+        inspector.stdout?.destroy();
+        inspector.stderr?.destroy();
+        inspector.kill("SIGKILL");
+        inspector.unref();
+      },
+      Math.max(1, remainingMs),
+    );
+    timer.unref?.();
+  });
 }
 
 function parseProcesses(output: string): PosixProcess[] {
@@ -289,8 +318,12 @@ function isSameLiveRoot(
   );
 }
 
-function signalSameRoot(root: PosixProcess, signal: NodeJS.Signals, deadline: number): boolean {
-  const current = readProcess(root.pid, deadline);
+async function signalSameRoot(
+  root: PosixProcess,
+  signal: NodeJS.Signals,
+  deadline: number,
+): Promise<boolean> {
+  const current = await readProcess(root.pid, deadline);
   return Boolean(current && isSameLiveRoot(current, root) && signalProcess(current.pid, signal));
 }
 
@@ -316,14 +349,14 @@ function resumeTransportRoot(
   }
 }
 
-function signalSameProcess(
+async function signalSameProcess(
   expected: PosixProcess,
   signal: NodeJS.Signals,
   deadline: number,
-): boolean {
+): Promise<boolean> {
   // Portable Node POSIX signals are PID-based, so never retain numeric authority:
   // take this final identity snapshot synchronously immediately before every signal.
-  const current = readProcess(expected.pid, deadline);
+  const current = await readProcess(expected.pid, deadline);
   return Boolean(
     current && isSameLiveProcess(current, expected) && signalProcess(current.pid, signal),
   );

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -1,0 +1,217 @@
+import { spawnSync } from "node:child_process";
+
+type ContainableTransport = {
+  pid?: number;
+  exitCode?: number | null;
+  signalCode?: string | null;
+};
+
+type PosixProcess = {
+  pid: number;
+  ppid: number;
+  pgid: number;
+  state: string;
+  startedAt: string;
+};
+
+const MAX_PROCESS_QUIESCE_PASSES = 8;
+const PROCESS_COLUMNS = "pid=,ppid=,pgid=,stat=,lstart=";
+
+export function terminateCodexAppServerDescendants(child: ContainableTransport): void {
+  const rootPid = child.pid;
+  if (process.platform === "win32" || !rootPid || hasExited(child)) {
+    return;
+  }
+  const snapshot = readProcessSnapshot();
+  if (!snapshot) {
+    return;
+  }
+  const root = snapshot.find((row) => row.pid === rootPid);
+  if (!root || !isSameLiveRoot(root, root)) {
+    return;
+  }
+
+  const initialDescendants = collectDescendants(snapshot, rootPid);
+  const stoppedDescendants = new Map<string, PosixProcess>();
+  if (!signalSameRoot(root, "SIGSTOP")) {
+    return;
+  }
+  try {
+    const descendants = quiesceDescendants(root, initialDescendants, stoppedDescendants);
+    if (!descendants) {
+      return;
+    }
+
+    // Parents are last: every destructive signal revalidates the exact live PID
+    // while the stopped ancestry still prevents new descendants.
+    for (const descendant of descendants.toReversed()) {
+      if (!descendant.state.startsWith("Z")) {
+        signalSameProcess(descendant, "SIGKILL");
+      }
+    }
+  } finally {
+    for (const descendant of stoppedDescendants.values()) {
+      signalSameProcess(descendant, "SIGCONT");
+    }
+    signalSameRoot(root, "SIGCONT");
+  }
+}
+
+function quiesceDescendants(
+  root: PosixProcess,
+  initialDescendants: PosixProcess[],
+  stopped: Map<string, PosixProcess>,
+): PosixProcess[] | undefined {
+  const provenByPid = new Map(initialDescendants.map((descendant) => [descendant.pid, descendant]));
+  for (let pass = 0; pass < MAX_PROCESS_QUIESCE_PASSES; pass += 1) {
+    const snapshot = readProcessSnapshot();
+    if (!snapshot) {
+      return undefined;
+    }
+    const currentRoot = snapshot.find((row) => row.pid === root.pid);
+    if (!currentRoot || !isSameLiveRoot(currentRoot, root)) {
+      return undefined;
+    }
+    if (!isSameLiveRoot(currentRoot, root, true)) {
+      continue;
+    }
+    const descendants = collectDescendants(snapshot, root.pid);
+    for (const descendant of descendants) {
+      const proven = provenByPid.get(descendant.pid);
+      if (proven && !hasSameIdentity(proven, descendant)) {
+        return undefined;
+      }
+      provenByPid.set(descendant.pid, descendant);
+    }
+    let allStopped = true;
+    for (const descendant of descendants) {
+      if (descendant.state.startsWith("T") || descendant.state.startsWith("Z")) {
+        continue;
+      }
+      allStopped = false;
+      if (signalSameProcess(descendant, "SIGSTOP")) {
+        stopped.set(identityKey(descendant), descendant);
+      }
+    }
+    if (allStopped) {
+      return descendants;
+    }
+  }
+  return undefined;
+}
+
+function readProcessSnapshot(): PosixProcess[] | undefined {
+  return readProcesses(["-axo", PROCESS_COLUMNS]);
+}
+
+function readProcess(pid: number): PosixProcess | undefined {
+  return readProcesses(["-o", PROCESS_COLUMNS, "-p", String(pid)])?.find((row) => row.pid === pid);
+}
+
+function readProcesses(args: string[]): PosixProcess[] | undefined {
+  try {
+    const result = spawnSync("ps", args, { encoding: "utf8", timeout: 500 });
+    if (result.error || result.status !== 0) {
+      return undefined;
+    }
+    return parseProcesses(result.stdout);
+  } catch {
+    return undefined;
+  }
+}
+
+function parseProcesses(output: string): PosixProcess[] {
+  const rows: PosixProcess[] = [];
+  for (const line of output.split("\n")) {
+    const match = /^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(.+?)\s*$/.exec(line);
+    if (!match) {
+      continue;
+    }
+    const pid = Number(match[1] ?? "");
+    const ppid = Number(match[2] ?? "");
+    const pgid = Number(match[3] ?? "");
+    const startedAt = (match[5] ?? "").trim().replace(/\s+/g, " ");
+    if (
+      ![pid, ppid, pgid].every(Number.isSafeInteger) ||
+      pid <= 0 ||
+      ppid < 0 ||
+      pgid <= 0 ||
+      !startedAt
+    ) {
+      continue;
+    }
+    rows.push({ pid, ppid, pgid, state: match[4] ?? "", startedAt });
+  }
+  return rows;
+}
+
+function collectDescendants(snapshot: PosixProcess[], rootPid: number): PosixProcess[] {
+  const childrenByParent = new Map<number, PosixProcess[]>();
+  for (const row of snapshot) {
+    const children = childrenByParent.get(row.ppid) ?? [];
+    children.push(row);
+    childrenByParent.set(row.ppid, children);
+  }
+  const descendants: PosixProcess[] = [];
+  const pending = [rootPid];
+  for (const parentPid of pending) {
+    for (const child of childrenByParent.get(parentPid) ?? []) {
+      descendants.push(child);
+      pending.push(child.pid);
+    }
+  }
+  return descendants;
+}
+
+function isSameLiveProcess(current: PosixProcess, expected: PosixProcess): boolean {
+  return (
+    current.pgid === expected.pgid &&
+    !current.state.startsWith("Z") &&
+    hasSameIdentity(current, expected)
+  );
+}
+
+function isSameLiveRoot(
+  current: PosixProcess,
+  expected: PosixProcess,
+  requireStopped = false,
+): boolean {
+  return (
+    current.ppid === process.pid &&
+    (!requireStopped || current.state.startsWith("T")) &&
+    isSameLiveProcess(current, expected)
+  );
+}
+
+function signalSameRoot(root: PosixProcess, signal: NodeJS.Signals): boolean {
+  const current = readProcess(root.pid);
+  return Boolean(current && isSameLiveRoot(current, root) && signalProcess(current.pid, signal));
+}
+
+function signalSameProcess(expected: PosixProcess, signal: NodeJS.Signals): boolean {
+  const current = readProcess(expected.pid);
+  return Boolean(
+    current && isSameLiveProcess(current, expected) && signalProcess(current.pid, signal),
+  );
+}
+
+function hasSameIdentity(left: PosixProcess, right: PosixProcess): boolean {
+  return identityKey(left) === identityKey(right);
+}
+
+function identityKey(row: PosixProcess): string {
+  return `${row.pid}\0${row.startedAt}`;
+}
+
+function hasExited(child: ContainableTransport): boolean {
+  return child.exitCode != null || child.signalCode != null;
+}
+
+function signalProcess(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -1,0 +1,340 @@
+import { execFileSync, spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { closeCodexAppServerTransportAndWait } from "./transport.js";
+
+type FixtureEvent = {
+  role: "root" | "separate-leader" | "separate-descendant" | "shared-leader" | "shared-descendant";
+  pid: number;
+  pgid: number;
+};
+
+type ProcessRow = {
+  pid: number;
+  command: string;
+};
+
+const delay = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+function listProcesses(): ProcessRow[] {
+  return execFileSync("ps", ["-axo", "pid=,command="], {
+    encoding: "utf8",
+  })
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = /^(\d+)\s+(.*)$/.exec(line);
+      if (!match) {
+        throw new Error(`unexpected ps row: ${line}`);
+      }
+      return {
+        pid: Number(match[1]),
+        command: match[2] ?? "",
+      };
+    });
+}
+
+async function waitForFixtureEvents(logPath: string, count: number): Promise<FixtureEvent[]> {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const events = await readFixtureEvents(logPath);
+    if (events.length >= count) {
+      return events;
+    }
+    await delay(20);
+  }
+  throw new Error(`timed out waiting for ${count} process fixture events`);
+}
+
+async function readFixtureEvents(logPath: string): Promise<FixtureEvent[]> {
+  const contents = await fs.readFile(logPath, "utf8").catch(() => "");
+  return contents
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as FixtureEvent);
+}
+
+async function removeTaskOwnedFixtureProcesses(tempDir: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const allRows = listProcesses();
+    const ownedRows = allRows.filter((row) => row.command.includes(tempDir));
+    if (ownedRows.length === 0) {
+      return;
+    }
+    for (const row of ownedRows) {
+      try {
+        process.kill(row.pid, "SIGKILL");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+          throw error;
+        }
+      }
+    }
+    await delay(20);
+  }
+  const survivors = listProcesses().filter((row) => row.command.includes(tempDir));
+  if (survivors.length > 0) {
+    throw new Error(`task-owned process fixture survived cleanup: ${JSON.stringify(survivors)}`);
+  }
+}
+
+describe.skipIf(process.platform === "win32")("Codex app-server process containment", () => {
+  it("reaps descendants in independent and root process groups before close returns", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-transport-process-"));
+    const logPath = path.join(tempDir, "processes.jsonl");
+    const rootPath = path.join(tempDir, "root.mjs");
+    const leaderPath = path.join(tempDir, "leader.mjs");
+    const descendantPath = path.join(tempDir, "descendant.mjs");
+    await fs.writeFile(logPath, "");
+    await fs.writeFile(
+      descendantPath,
+      `
+import { appendFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+const [logPath, role] = process.argv.slice(2);
+const pgid = Number(execFileSync("ps", ["-o", "pgid=", "-p", String(process.pid)], { encoding: "utf8" }).trim());
+appendFileSync(logPath, JSON.stringify({ role, pid: process.pid, pgid }) + "\\n");
+for (const signal of ["SIGTERM", "SIGHUP", "SIGINT"]) process.on(signal, () => {});
+setInterval(() => {}, 1_000);
+`,
+    );
+    await fs.writeFile(
+      leaderPath,
+      `
+import { appendFileSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+const [logPath, role, descendantPath] = process.argv.slice(2);
+const pgid = Number(execFileSync("ps", ["-o", "pgid=", "-p", String(process.pid)], { encoding: "utf8" }).trim());
+appendFileSync(logPath, JSON.stringify({ role, pid: process.pid, pgid }) + "\\n");
+const descendant = spawn(process.execPath, [descendantPath, logPath, role.replace("leader", "descendant")], { stdio: "ignore" });
+descendant.unref();
+for (const signal of ["SIGTERM", "SIGHUP", "SIGINT"]) process.on(signal, () => {});
+setInterval(() => {}, 1_000);
+`,
+    );
+    await fs.writeFile(
+      rootPath,
+      `
+import { appendFileSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+const [logPath, leaderPath, descendantPath] = process.argv.slice(2);
+const pgid = Number(execFileSync("ps", ["-o", "pgid=", "-p", String(process.pid)], { encoding: "utf8" }).trim());
+appendFileSync(logPath, JSON.stringify({ role: "root", pid: process.pid, pgid }) + "\\n");
+for (const [role, detached] of [["separate-leader", true], ["shared-leader", false]]) {
+  const child = spawn(process.execPath, [leaderPath, logPath, role, descendantPath], { detached, stdio: "ignore" });
+  child.unref();
+}
+process.stdin.resume();
+process.stdin.on("end", () => process.exit(0));
+`,
+    );
+
+    const root = spawn(process.execPath, [rootPath, logPath, leaderPath, descendantPath], {
+      detached: true,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    try {
+      const events = await waitForFixtureEvents(logPath, 5);
+      const eventByRole = new Map(events.map((event) => [event.role, event]));
+      const rootEvent = eventByRole.get("root");
+      const separateLeader = eventByRole.get("separate-leader");
+      const separateDescendant = eventByRole.get("separate-descendant");
+      const sharedLeader = eventByRole.get("shared-leader");
+      const sharedDescendant = eventByRole.get("shared-descendant");
+      expect(rootEvent).toBeDefined();
+      expect(separateLeader?.pgid).toBe(separateLeader?.pid);
+      expect(separateDescendant?.pgid).toBe(separateLeader?.pgid);
+      expect(sharedLeader?.pgid).toBe(rootEvent?.pgid);
+      expect(sharedDescendant?.pgid).toBe(rootEvent?.pgid);
+      await expect(
+        closeCodexAppServerTransportAndWait(root, {
+          forceKillDelayMs: 500,
+          exitTimeoutMs: 2_000,
+        }),
+      ).resolves.toBe(true);
+      expect(root.exitCode).toBe(0);
+      expect(root.signalCode).toBeNull();
+
+      const survivors = listProcesses().filter((row) => row.command.includes(tempDir));
+      expect(survivors).toEqual([]);
+    } finally {
+      await removeTaskOwnedFixtureProcesses(tempDir);
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("revalidates reused identities and contains descendants discovered while quiescing", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-identity-reuse-"));
+    const rootPath = path.join(tempDir, "root.mjs");
+    const sentinelPath = path.join(tempDir, "sentinel.mjs");
+    const sentinelPidPath = path.join(tempDir, "sentinel.pid");
+    const driverPath = path.join(tempDir, "driver.mts");
+    const fakeBin = path.join(tempDir, "bin");
+    const fakePsPath = path.join(fakeBin, "ps");
+    const fakePsCounterPath = path.join(tempDir, "ps-count");
+    const scenarioPath = path.join(tempDir, "ps-scenario.json");
+    await fs.mkdir(fakeBin);
+    await fs.writeFile(
+      sentinelPath,
+      `
+for (const signal of ["SIGTERM", "SIGHUP", "SIGINT"]) process.on(signal, () => {});
+setInterval(() => {}, 1_000);
+`,
+    );
+    await fs.writeFile(
+      rootPath,
+      `
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+const [sentinelPath, sentinelPidPath] = process.argv.slice(2);
+const sentinel = spawn(process.execPath, [sentinelPath], { detached: true, stdio: "ignore" });
+sentinel.unref();
+writeFileSync(sentinelPidPath, String(sentinel.pid));
+process.stdin.resume();
+process.stdin.on("end", () => process.exit(0));
+`,
+    );
+    await fs.writeFile(
+      fakePsPath,
+      `#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+const scenarioPath = ${JSON.stringify(scenarioPath)};
+const counterPath = ${JSON.stringify(fakePsCounterPath)};
+const scenario = JSON.parse(readFileSync(scenarioPath, "utf8"));
+let count = 0;
+try { count = Number(readFileSync(counterPath, "utf8")); } catch {}
+writeFileSync(counterPath, String(count + 1));
+const rows = scenario.snapshots[Math.min(count, scenario.snapshots.length - 1)];
+for (const row of rows) {
+  process.stdout.write([row.pid, row.ppid, row.pgid, row.state, row.startedAt].join(" ") + "\\n");
+}
+`,
+      { mode: 0o755 },
+    );
+    await fs.writeFile(
+      driverPath,
+      `
+import { execFileSync, spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+const [mode, transportPath, rootPath, sentinelPath, sentinelPidPath, fakeBin, counterPath, scenarioPath, tempDir] = process.argv.slice(2);
+const { closeCodexAppServerTransportAndWait } = await import(pathToFileURL(transportPath).href);
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const readIdentity = (pid) => {
+  const line = execFileSync("/bin/ps", ["-o", "pid=,ppid=,pgid=,stat=,lstart=", "-p", String(pid)], { encoding: "utf8" }).trim();
+  const match = /^(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\S+)\\s+(.+)$/.exec(line);
+  if (!match) throw new Error("unexpected process identity row: " + line);
+  return { pid: Number(match[1]), ppid: Number(match[2]), pgid: Number(match[3]), state: match[4], startedAt: match[5] };
+};
+const waitForFile = async (filePath) => {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const contents = await fs.readFile(filePath, "utf8").catch(() => "");
+    if (contents) return contents;
+    await delay(20);
+  }
+  throw new Error("timed out waiting for sentinel PID");
+};
+const commandForPid = (pid) => {
+  try { return execFileSync("/bin/ps", ["-o", "command=", "-p", String(pid)], { encoding: "utf8" }).trim(); }
+  catch { return ""; }
+};
+const killOwned = (pid) => {
+  if (!commandForPid(pid).includes(tempDir)) return;
+  try { process.kill(pid, "SIGKILL"); } catch {}
+};
+const originalPath = process.env.PATH;
+let root;
+let sentinelPid;
+let result;
+try {
+  await fs.rm(sentinelPidPath, { force: true });
+  root = spawn(process.execPath, [rootPath, sentinelPath, sentinelPidPath], { detached: true, stdio: ["pipe", "pipe", "pipe"] });
+  sentinelPid = Number((await waitForFile(sentinelPidPath)).trim());
+  const rootIdentity = readIdentity(root.pid);
+  const sentinelIdentity = readIdentity(sentinelPid);
+  const stoppedRoot = { ...rootIdentity, state: "T" };
+  const oldSentinel = { ...sentinelIdentity, ppid: root.pid, state: "S", startedAt: "Mon Jan 1 00:00:00 2001" };
+  const stoppedOldSentinel = { ...oldSentinel, state: "T" };
+  const stoppedSentinel = { ...sentinelIdentity, state: "T" };
+  const snapshots = mode === "reuse"
+    ? [
+        [rootIdentity, oldSentinel],
+        [rootIdentity, oldSentinel],
+        [stoppedRoot, oldSentinel],
+        [stoppedRoot, oldSentinel],
+        [stoppedRoot, stoppedOldSentinel],
+        [stoppedRoot, stoppedSentinel],
+      ]
+    : [
+        [rootIdentity],
+        [rootIdentity],
+        [stoppedRoot, sentinelIdentity],
+        [stoppedRoot, sentinelIdentity],
+        [stoppedRoot, stoppedSentinel],
+      ];
+  await fs.writeFile(counterPath, "0");
+  await fs.writeFile(scenarioPath, JSON.stringify({ snapshots }));
+  process.env.PATH = fakeBin + path.delimiter + (originalPath ?? "");
+  const closed = await closeCodexAppServerTransportAndWait(root, { forceKillDelayMs: 500, exitTimeoutMs: 2_000 });
+  process.env.PATH = originalPath;
+  result = {
+    closed,
+    rootExitCode: root.exitCode,
+    sentinelSurvived: commandForPid(sentinelPid).includes(tempDir),
+  };
+} finally {
+  process.env.PATH = originalPath;
+  if (sentinelPid) killOwned(sentinelPid);
+  if (root?.pid) killOwned(root.pid);
+}
+process.stdout.write(JSON.stringify(result));
+`,
+    );
+
+    try {
+      const transportPath = path.resolve("extensions/codex/src/app-server/transport.ts");
+      for (const [mode, sentinelSurvived] of [
+        ["reuse", true],
+        ["late", false],
+      ] as const) {
+        const output = execFileSync(
+          process.execPath,
+          [
+            "--import",
+            "tsx",
+            driverPath,
+            mode,
+            transportPath,
+            rootPath,
+            sentinelPath,
+            sentinelPidPath,
+            fakeBin,
+            fakePsCounterPath,
+            scenarioPath,
+            tempDir,
+          ],
+          { cwd: path.resolve("."), encoding: "utf8", timeout: 10_000 },
+        );
+        const result = JSON.parse(output) as {
+          closed: boolean;
+          rootExitCode: number | null;
+          sentinelSurvived: boolean;
+        };
+        expect(result).toMatchObject({ closed: true, rootExitCode: 0, sentinelSurvived });
+      }
+    } finally {
+      await removeTaskOwnedFixtureProcesses(tempDir);
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -292,10 +292,35 @@ try {
               [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
               [stoppedRoot, { ...stoppedSentinel, ppid: 1 }],
             ]
+          : mode === "root-resumed"
+            ? [
+                [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+                [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+                [stoppedRoot, { ...stoppedSentinel, ppid: root.pid }],
+              ]
+            : mode === "traced"
+              ? [
+                  [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                  [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                  [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+                  [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+                  [
+                    stoppedRoot,
+                    { ...stoppedSentinel, ppid: root.pid, state: "t" },
+                  ],
+                ]
           : [
               [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
               [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
-              [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+              ...Array.from({ length: 8 }, () => [
+                [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+                [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+              ]).flat(),
+              [stoppedRoot, { ...stoppedSentinel, ppid: root.pid }],
             ];
   await fs.writeFile(counterPath, "0");
   await fs.writeFile(scenarioPath, JSON.stringify({ snapshots }));
@@ -322,7 +347,9 @@ process.stdout.write(JSON.stringify(result));
         ["reuse", true],
         ["late", false],
         ["reparented", false],
-        ["exhausted", false],
+        ["root-resumed", false],
+        ["traced", false],
+        ["extended", false],
       ] as const) {
         const output = execFileSync(
           process.execPath,

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -290,7 +290,10 @@ try {
               [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
               [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
               [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
-              [stoppedRoot, { ...stoppedSentinel, ppid: 1 }],
+              [
+                stoppedRoot,
+                { ...stoppedSentinel, ppid: 1, pgid: stoppedSentinel.pgid + 1 },
+              ],
             ]
           : mode === "root-resumed"
             ? [
@@ -367,7 +370,7 @@ process.stdout.write(JSON.stringify(result));
             scenarioPath,
             tempDir,
           ],
-          { cwd: path.resolve("."), encoding: "utf8", timeout: 10_000 },
+          { cwd: path.resolve("."), encoding: "utf8", timeout: 30_000 },
         );
         const result = JSON.parse(output) as {
           closed: boolean;

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -211,8 +211,10 @@ printf '%s' "$((count + 1))" > ${JSON.stringify(fakePsCounterPath)}
 last=$(command cat ${JSON.stringify(scenarioPath)})
 if [ "$count" -gt "$last" ]; then count=$last; fi
 rows=${JSON.stringify(scenarioPath)}.$count
-if [ "$(command cat "$rows")" = FAIL ]; then exit 1; fi
-command cat "$rows"
+payload=$(command cat "$rows")
+if [ "$payload" = FAIL ]; then exit 1; fi
+if [ "$payload" = HANG ]; then while :; do sleep 1; done; fi
+printf '%s\\n' "$payload"
 `,
       { mode: 0o755 },
     );
@@ -338,6 +340,12 @@ try {
                       [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
                       null,
                     ]
+                  : mode === "inspection-timeout"
+                    ? [
+                        [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                        [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                        "HANG",
+                      ]
               : [
               [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
               [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
@@ -352,7 +360,9 @@ try {
   await Promise.all(snapshots.map(async (rows, index) => {
     const contents = rows === null
       ? "FAIL\\n"
-      : rows.map((row) => [row.pid, row.ppid, row.pgid, row.state, row.startedAt].join(" ")).join("\\n") + "\\n";
+      : rows === "HANG"
+        ? "HANG\\n"
+        : rows.map((row) => [row.pid, row.ppid, row.pgid, row.state, row.startedAt].join(" ")).join("\\n") + "\\n";
     await fs.writeFile(scenarioPath + "." + index, contents);
   }));
   process.env.PATH = fakeBin + path.delimiter + (originalPath ?? "");
@@ -383,6 +393,7 @@ process.stdout.write(JSON.stringify(result));
         ["traced", false],
         ["uninterruptible", false],
         ["snapshot-failure", true, false],
+        ["inspection-timeout", true, false],
         ["extended", false],
       ] as const) {
         const output = execFileSync(

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -213,6 +213,7 @@ let count = 0;
 try { count = Number(readFileSync(counterPath, "utf8")); } catch {}
 writeFileSync(counterPath, String(count + 1));
 const rows = scenario.snapshots[Math.min(count, scenario.snapshots.length - 1)];
+if (rows === null) process.exit(1);
 for (const row of rows) {
   process.stdout.write([row.pid, row.ppid, row.pgid, row.state, row.startedAt].join(" ") + "\\n");
 }
@@ -247,6 +248,10 @@ const waitForFile = async (filePath) => {
 const commandForPid = (pid) => {
   try { return execFileSync("/bin/ps", ["-o", "command=", "-p", String(pid)], { encoding: "utf8" }).trim(); }
   catch { return ""; }
+};
+const stoppedForPid = (pid) => {
+  try { return /^[Tt]/.test(execFileSync("/bin/ps", ["-o", "stat=", "-p", String(pid)], { encoding: "utf8" }).trim()); }
+  catch { return false; }
 };
 const killOwned = (pid) => {
   if (!commandForPid(pid).includes(tempDir)) return;
@@ -329,6 +334,14 @@ try {
                       { ...sentinelIdentity, ppid: root.pid, state: "U" },
                     ],
                   ]
+                : mode === "snapshot-failure"
+                  ? [
+                      [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                      [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                      [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+                      [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+                      null,
+                    ]
               : [
               [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
               [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
@@ -347,6 +360,7 @@ try {
     closed,
     rootExitCode: root.exitCode,
     sentinelSurvived: commandForPid(sentinelPid).includes(tempDir),
+    sentinelStopped: stoppedForPid(sentinelPid),
   };
 } finally {
   process.env.PATH = originalPath;
@@ -359,13 +373,14 @@ process.stdout.write(JSON.stringify(result));
 
     try {
       const transportPath = path.resolve("extensions/codex/src/app-server/transport.ts");
-      for (const [mode, sentinelSurvived] of [
+      for (const [mode, sentinelSurvived, sentinelStopped] of [
         ["reuse", true],
         ["late", false],
         ["reparented", false],
         ["root-resumed", false],
         ["traced", false],
         ["uninterruptible", false],
+        ["snapshot-failure", true, false],
         ["extended", false],
       ] as const) {
         const output = execFileSync(
@@ -390,8 +405,12 @@ process.stdout.write(JSON.stringify(result));
           closed: boolean;
           rootExitCode: number | null;
           sentinelSurvived: boolean;
+          sentinelStopped: boolean;
         };
         expect(result).toMatchObject({ closed: true, rootExitCode: 0, sentinelSurvived });
+        if (sentinelStopped !== undefined) {
+          expect(result.sentinelStopped).toBe(sentinelStopped);
+        }
       }
     } finally {
       await removeTaskOwnedFixtureProcesses(tempDir);

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -204,19 +204,15 @@ process.stdin.on("end", () => process.exit(0));
     );
     await fs.writeFile(
       fakePsPath,
-      `#!/usr/bin/env node
-import { readFileSync, writeFileSync } from "node:fs";
-const scenarioPath = ${JSON.stringify(scenarioPath)};
-const counterPath = ${JSON.stringify(fakePsCounterPath)};
-const scenario = JSON.parse(readFileSync(scenarioPath, "utf8"));
-let count = 0;
-try { count = Number(readFileSync(counterPath, "utf8")); } catch {}
-writeFileSync(counterPath, String(count + 1));
-const rows = scenario.snapshots[Math.min(count, scenario.snapshots.length - 1)];
-if (rows === null) process.exit(1);
-for (const row of rows) {
-  process.stdout.write([row.pid, row.ppid, row.pgid, row.state, row.startedAt].join(" ") + "\\n");
-}
+      `#!/bin/sh
+count=0
+if [ -f ${JSON.stringify(fakePsCounterPath)} ]; then count=$(command cat ${JSON.stringify(fakePsCounterPath)}); fi
+printf '%s' "$((count + 1))" > ${JSON.stringify(fakePsCounterPath)}
+last=$(command cat ${JSON.stringify(scenarioPath)})
+if [ "$count" -gt "$last" ]; then count=$last; fi
+rows=${JSON.stringify(scenarioPath)}.$count
+if [ "$(command cat "$rows")" = FAIL ]; then exit 1; fi
+command cat "$rows"
 `,
       { mode: 0o755 },
     );
@@ -352,7 +348,13 @@ try {
               [stoppedRoot, { ...stoppedSentinel, ppid: root.pid }],
             ];
   await fs.writeFile(counterPath, "0");
-  await fs.writeFile(scenarioPath, JSON.stringify({ snapshots }));
+  await fs.writeFile(scenarioPath, String(snapshots.length - 1));
+  await Promise.all(snapshots.map(async (rows, index) => {
+    const contents = rows === null
+      ? "FAIL\\n"
+      : rows.map((row) => [row.pid, row.ppid, row.pgid, row.state, row.startedAt].join(" ")).join("\\n") + "\\n";
+    await fs.writeFile(scenarioPath + "." + index, contents);
+  }));
   process.env.PATH = fakeBin + path.delimiter + (originalPath ?? "");
   const closed = await closeCodexAppServerTransportAndWait(root, { forceKillDelayMs: 500, exitTimeoutMs: 2_000 });
   process.env.PATH = originalPath;

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -171,7 +171,7 @@ process.stdin.on("end", () => process.exit(0));
     }
   });
 
-  it("revalidates reused identities and contains descendants discovered while quiescing", async () => {
+  it("revalidates and retains every identity proven while quiescing", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-identity-reuse-"));
     const rootPath = path.join(tempDir, "root.mjs");
     const sentinelPath = path.join(tempDir, "sentinel.mjs");
@@ -266,8 +266,9 @@ try {
   const oldSentinel = { ...sentinelIdentity, ppid: root.pid, state: "S", startedAt: "Mon Jan 1 00:00:00 2001" };
   const stoppedOldSentinel = { ...oldSentinel, state: "T" };
   const stoppedSentinel = { ...sentinelIdentity, state: "T" };
-  const snapshots = mode === "reuse"
-    ? [
+  const snapshots =
+    mode === "reuse"
+      ? [
         [rootIdentity, oldSentinel],
         [rootIdentity, oldSentinel],
         [stoppedRoot, oldSentinel],
@@ -275,13 +276,27 @@ try {
         [stoppedRoot, stoppedOldSentinel],
         [stoppedRoot, stoppedSentinel],
       ]
-    : [
+      : mode === "late"
+        ? [
         [rootIdentity],
         [rootIdentity],
         [stoppedRoot, sentinelIdentity],
         [stoppedRoot, sentinelIdentity],
         [stoppedRoot, stoppedSentinel],
-      ];
+          ]
+        : mode === "reparented"
+          ? [
+              [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+              [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+              [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+              [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+              [stoppedRoot, { ...stoppedSentinel, ppid: 1 }],
+            ]
+          : [
+              [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+              [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+              [stoppedRoot, { ...sentinelIdentity, ppid: root.pid }],
+            ];
   await fs.writeFile(counterPath, "0");
   await fs.writeFile(scenarioPath, JSON.stringify({ snapshots }));
   process.env.PATH = fakeBin + path.delimiter + (originalPath ?? "");
@@ -306,6 +321,8 @@ process.stdout.write(JSON.stringify(result));
       for (const [mode, sentinelSurvived] of [
         ["reuse", true],
         ["late", false],
+        ["reparented", false],
+        ["exhausted", false],
       ] as const) {
         const output = execFileSync(
           process.execPath,

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -316,7 +316,20 @@ try {
                     { ...stoppedSentinel, ppid: root.pid, state: "t" },
                   ],
                 ]
-          : [
+              : mode === "uninterruptible"
+                ? [
+                    [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                    [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
+                    [
+                      stoppedRoot,
+                      { ...sentinelIdentity, ppid: root.pid, state: "U" },
+                    ],
+                    [
+                      stoppedRoot,
+                      { ...sentinelIdentity, ppid: root.pid, state: "U" },
+                    ],
+                  ]
+              : [
               [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
               [rootIdentity, { ...sentinelIdentity, ppid: root.pid }],
               ...Array.from({ length: 8 }, () => [
@@ -352,6 +365,7 @@ process.stdout.write(JSON.stringify(result));
         ["reparented", false],
         ["root-resumed", false],
         ["traced", false],
+        ["uninterruptible", false],
         ["extended", false],
       ] as const) {
         const output = execFileSync(

--- a/extensions/codex/src/app-server/transport.ts
+++ b/extensions/codex/src/app-server/transport.ts
@@ -2,6 +2,8 @@
  * Shared transport lifecycle helpers for stdio and WebSocket Codex app-server
  * connections.
  */
+import { terminateCodexAppServerDescendants } from "./transport-process-containment.js";
+
 /** Child-process-like transport shape consumed by the Codex app-server client. */
 export type CodexAppServerTransport = {
   stdin: {
@@ -34,6 +36,7 @@ export function closeCodexAppServerTransport(
   child: CodexAppServerTransport,
   options: { forceKillDelayMs?: number } = {},
 ): void {
+  terminateCodexAppServerDescendants(child);
   child.stdin.end?.();
   child.stdin.destroy?.();
   const forceKillDelayMs = options.forceKillDelayMs ?? 1_000;

--- a/extensions/codex/src/app-server/transport.ts
+++ b/extensions/codex/src/app-server/transport.ts
@@ -4,6 +4,8 @@
  */
 import { terminateCodexAppServerDescendants } from "./transport-process-containment.js";
 
+const CODEX_APP_SERVER_TRANSPORT_CLOSES = new WeakMap<object, Promise<void>>();
+
 /** Child-process-like transport shape consumed by the Codex app-server client. */
 export type CodexAppServerTransport = {
   stdin: {
@@ -36,13 +38,50 @@ export function closeCodexAppServerTransport(
   child: CodexAppServerTransport,
   options: { forceKillDelayMs?: number } = {},
 ): void {
-  const resumeRoot = terminateCodexAppServerDescendants(child);
-  try {
-    child.stdin.end?.();
-    child.stdin.destroy?.();
-  } finally {
-    resumeRoot?.();
+  void beginCodexAppServerTransportClose(child, options);
+}
+
+function beginCodexAppServerTransportClose(
+  child: CodexAppServerTransport,
+  options: { forceKillDelayMs?: number },
+): Promise<void> {
+  const current = CODEX_APP_SERVER_TRANSPORT_CLOSES.get(child);
+  if (current) {
+    return current;
   }
+  if (
+    process.platform === "win32" ||
+    !child.pid ||
+    !child.kill ||
+    hasCodexAppServerTransportExited(child)
+  ) {
+    finishCodexAppServerTransportClose(child, options);
+    const completed = Promise.resolve();
+    CODEX_APP_SERVER_TRANSPORT_CLOSES.set(child, completed);
+    return completed;
+  }
+  const closing = (async () => {
+    let resumeRoot: (() => void) | undefined;
+    try {
+      resumeRoot = await terminateCodexAppServerDescendants(child);
+    } catch {
+      resumeRoot = undefined;
+    }
+    try {
+      finishCodexAppServerTransportClose(child, options, resumeRoot);
+    } catch {
+      signalCodexAppServerTransport(child, "SIGKILL");
+    }
+  })();
+  CODEX_APP_SERVER_TRANSPORT_CLOSES.set(child, closing);
+  return closing;
+}
+
+function finishCodexAppServerTransportClose(
+  child: CodexAppServerTransport,
+  options: { forceKillDelayMs?: number },
+  resumeRoot?: () => void,
+): void {
   const forceKillDelayMs = options.forceKillDelayMs ?? 1_000;
   const forceKill = setTimeout(
     () => {
@@ -59,6 +98,12 @@ export function closeCodexAppServerTransport(
     child.stdout.destroy?.();
     child.stderr.destroy?.();
   });
+  try {
+    child.stdin.end?.();
+    child.stdin.destroy?.();
+  } finally {
+    resumeRoot?.();
+  }
   child.unref?.();
   child.stdout.unref?.();
   child.stderr.unref?.();
@@ -71,7 +116,7 @@ export async function closeCodexAppServerTransportAndWait(
   options: { exitTimeoutMs?: number; forceKillDelayMs?: number } = {},
 ): Promise<boolean> {
   if (!hasCodexAppServerTransportExited(child)) {
-    closeCodexAppServerTransport(child, options);
+    await beginCodexAppServerTransportClose(child, options);
   }
   return await waitForCodexAppServerTransportExit(child, options.exitTimeoutMs ?? 2_000);
 }

--- a/extensions/codex/src/app-server/transport.ts
+++ b/extensions/codex/src/app-server/transport.ts
@@ -36,9 +36,13 @@ export function closeCodexAppServerTransport(
   child: CodexAppServerTransport,
   options: { forceKillDelayMs?: number } = {},
 ): void {
-  terminateCodexAppServerDescendants(child);
-  child.stdin.end?.();
-  child.stdin.destroy?.();
+  const resumeRoot = terminateCodexAppServerDescendants(child);
+  try {
+    child.stdin.end?.();
+    child.stdin.destroy?.();
+  } finally {
+    resumeRoot?.();
+  }
   const forceKillDelayMs = options.forceKillDelayMs ?? 1_000;
   const forceKill = setTimeout(
     () => {


### PR DESCRIPTION
Closes #119760

## What Problem This Solves

Fixes an issue where retiring a Codex app-server client could leave Codex-owned stdio MCP descendants alive when those servers had moved into process groups independent of the detached app-server root. A replacement client could then overlap the surviving process fleet, accumulating processes and memory.

## Why This Change Was Made

OpenClaw is the physical transport owner of the app-server child, so its POSIX retirement boundary now snapshots the exact live ancestry, stops the root, and iteratively quiesces descendants across independent process groups. Proven identities remain ancestry roots after reparenting; each signal is preceded by PID, start-time, and PGID revalidation; descendants are killed leaf-first; and root custody is retained until stdin shutdown has begun.

Process inspection is asynchronous and bounded to 512 processes, 16 convergence passes, two seconds, and 8 MiB of output. Inspection, identity, signal, count, or deadline failure unwinds stopped processes and returns to the existing graceful EOF and force-kill path. Windows behavior is unchanged. This does not claim that the historical WhatsApp/channel event was the sole trigger for the reported incident.

## User Impact

No Codex-owned MCP process fleets should survive normal app-server/client retirement, so replacement clients no longer overlap a retired transport's independently grouped descendants.

## Evidence

- Pre-fix real-process regression: closing the detached app-server root left four task-owned processes alive across an independent MCP process group and the root-shared group.
- Exact-head owner proof: `pnpm test extensions/codex/src/app-server/transport.process.test.ts extensions/codex/src/app-server/transport-stdio.test.ts extensions/codex/src/app-server/client.test.ts` — 3 files / 44 tests passed. The regression also fails against the pre-fix containment behavior with a surviving sentinel.
- Exact-head proportional gate: `pnpm check:changed` passed, including extension production/test typechecks, lint, boundary guards, dead-export scan, contract tests, and import-cycle checks.
- Exact-head full build: `pnpm build` passed.
- Exact-head `pull_request` CI: https://github.com/openclaw/openclaw/actions/runs/32239967875 passed against current base `4bf8d549458d864ab0461b0a0c441c1d4d8c785c`.
- Final branch P1 autoreview: clean, with no accepted/actionable P0 or P1 findings.
- Direct Codex runtime contract inspection: [`stdio_server_launcher.rs:280-292`](https://github.com/openai/codex/blob/92cbfb4d2431bdc53dc03507aea2dc5b8e932e40/codex-rs/rmcp-client/src/stdio_server_launcher.rs#L280-L292) places each local stdio MCP server in its own process group; [`:403-435`](https://github.com/openai/codex/blob/92cbfb4d2431bdc53dc03507aea2dc5b8e932e40/codex-rs/rmcp-client/src/stdio_server_launcher.rs#L403-L435) and [`:475-505`](https://github.com/openai/codex/blob/92cbfb4d2431bdc53dc03507aea2dc5b8e932e40/codex-rs/rmcp-client/src/stdio_server_launcher.rs#L475-L505) confirm Codex's per-server termination owner.
- macOS bundled-Codex live probe on the root-fix branch: normal disposal left zero survivors; cancelling blocked `mcpServerStatus/list` forced retirement with zero survivors; replacement began about 500 ms later without any old PID/PGID; final survivor count was zero.
- Linux Blacksmith Testbox: `tbx_01m0ch8220wfxw0h7w3zg7bwz0`, https://github.com/openclaw/openclaw/actions/runs/32231460643 — real process regression passed 2/2, the bundled Codex probe had zero old/final survivors, and the lease stopped successfully.
- Production LOC: +439/-3 (net +436). Tests: +433/-0. The production growth is private process-identity, bounded-inspection, quiescence, failure-unwind, and PID-reuse containment at the physical transport owner; it adds no public SDK surface.
- Gaps: Windows is intentionally unchanged and was not exercised by this POSIX proof. The historical WhatsApp stop-timeout/channel-restart causality remains unproven; the current OpenClaw transport orphan/replacement bug is directly reproduced.

AI-assisted: yes. I reviewed and understand the code and validation. No agent transcript is included.
