### PR TITLE
fix(ui): keep peer identity stable when actions appear

### DIFF
--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI E2E tests cover attributed chat identity placement.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { expect, type Page } from "playwright/test";
+import { expect, type Locator, type Page } from "playwright/test";
 import { it } from "vitest";
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -27,6 +27,42 @@ async function captureProof(page: Page, name: string) {
   });
 }
 
+async function readFooterGeometry(group: Locator) {
+  return group.locator(".chat-group-footer").evaluate((footer) => {
+    const actions = footer.querySelector<HTMLElement>(".chat-group-footer-actions");
+    const identity = footer.querySelector<HTMLElement>(".chat-group-footer__meta");
+    const name = footer.querySelector<HTMLElement>(".chat-sender-name");
+    if (!actions || !identity || !name) {
+      throw new Error("Expected message footer identity and actions");
+    }
+    const actionsRect = actions.getBoundingClientRect();
+    const footerRect = footer.getBoundingClientRect();
+    const identityRect = identity.getBoundingClientRect();
+    const nameRect = name.getBoundingClientRect();
+    return {
+      actions: {
+        left: actionsRect.left,
+        right: actionsRect.right,
+        top: actionsRect.top,
+      },
+      identity: {
+        bottom: identityRect.bottom,
+        left: identityRect.left,
+        right: identityRect.right,
+      },
+      name: { left: nameRect.left - footerRect.left, top: nameRect.top - footerRect.top },
+    };
+  });
+}
+
+function expectStableNamePosition(
+  actual: { left: number; top: number },
+  expected: { left: number; top: number },
+) {
+  expect(actual.left).toBe(expected.left);
+  expect(actual.top).toBeCloseTo(expected.top, 0);
+}
+
 suite.define(() => {
   it("uses one avatar placement and keeps shared-thread authors readable", async () => {
     const artifactDir = resolveArtifactDir();
@@ -46,6 +82,11 @@ suite.define(() => {
       presenceUsers: [
         { self: true, id: "profile-riley", name: "Riley", email: "riley@example.test" },
         { id: "profile-colin", name: "Colin", email: "colin@example.test" },
+        {
+          id: "profile-alexandria",
+          name: "Alexandria Montgomery-Winter",
+          email: "alexandria@example.test",
+        },
       ],
       historyMessages: [
         {
@@ -80,6 +121,22 @@ suite.define(() => {
             seq: 4,
           },
         },
+        {
+          role: "assistant",
+          content: "Long participant names keep the same stable layout.",
+          timestamp: now - 20_000,
+        },
+        {
+          role: "user",
+          content: "My longer identity should remain fixed too.",
+          timestamp: now - 10_000,
+          __openclaw: {
+            id: "alexandria-message",
+            senderId: "profile-alexandria",
+            senderName: "Alexandria Montgomery-Winter",
+            seq: 6,
+          },
+        },
       ],
     });
 
@@ -87,31 +144,95 @@ suite.define(() => {
     await page.getByText("This is much easier to scan in a team conversation.").waitFor();
 
     const userGroups = page.locator(".chat-group.user");
-    await expect(userGroups).toHaveCount(2);
-    await expect(page.locator(".chat-avatar.user")).toHaveCount(2);
-    await expect(page.locator(".chat-avatar.user")).toHaveText(["R", "C"]);
+    await expect(userGroups).toHaveCount(3);
+    await expect(page.locator(".chat-avatar.user")).toHaveCount(3);
+    await expect(page.locator(".chat-avatar.user")).toHaveText(["R", "C", "AM"]);
     await expect(page.locator(".sidebar-identity-card openclaw-viewer-avatar")).toContainText("R");
 
     await expect(
       page.locator(".chat-group-footer--persistent-identity .chat-sender-name"),
-    ).toHaveText(["Riley", "Colin"]);
+    ).toHaveText(["Riley", "Colin", "Alexandria Montgomery-Winter"]);
     await expect(page.locator(".chat-author-avatar")).toHaveCount(0);
-    const hoverDetails = userGroups.last().locator(".chat-group-timestamp");
+    const peerGroup = userGroups.nth(1);
+    const longNamePeerGroup = userGroups.last();
+    const hoverDetails = peerGroup.locator(".chat-group-timestamp");
     await expect(hoverDetails).toHaveCSS("opacity", "0");
     await captureProof(page, "after-default.png");
 
-    await userGroups.last().hover();
+    const restingPeerGeometry = await readFooterGeometry(peerGroup);
+    await peerGroup.hover();
     await expect(hoverDetails).toHaveCSS("opacity", "1");
     await expect(page.locator(".chat-author-avatar")).toHaveCount(0);
     await captureProof(page, "after-hover.png");
+    const hoveredPeerGeometry = await readFooterGeometry(peerGroup);
+    expectStableNamePosition(hoveredPeerGeometry.name, restingPeerGeometry.name);
+    expect(hoveredPeerGeometry.actions.left - hoveredPeerGeometry.identity.right).toBeCloseTo(8, 0);
 
+    await page.mouse.move(0, 0);
+    const restingLongNameGeometry = await readFooterGeometry(longNamePeerGroup);
+    await longNamePeerGroup.hover();
+    const hoveredLongNameGeometry = await readFooterGeometry(longNamePeerGroup);
+    expectStableNamePosition(hoveredLongNameGeometry.name, restingLongNameGeometry.name);
+    expect(
+      hoveredLongNameGeometry.actions.left - hoveredLongNameGeometry.identity.right,
+    ).toBeCloseTo(8, 0);
+
+    await page.mouse.move(0, 0);
+    const peerReply = peerGroup.getByRole("button", { name: "Reply to message" });
+    await peerReply.focus();
+    await expect(hoverDetails).toHaveCSS("opacity", "1");
+    const focusedPeerGeometry = await readFooterGeometry(peerGroup);
+    expectStableNamePosition(focusedPeerGeometry.name, restingPeerGeometry.name);
+    expect(focusedPeerGeometry.actions.left - focusedPeerGeometry.identity.right).toBeCloseTo(8, 0);
+    await expect(peerReply).toHaveCSS("opacity", "1");
+
+    await page.evaluate(() => {
+      document.documentElement.dir = "rtl";
+      document.body.tabIndex = -1;
+      document.body.focus();
+    });
+    await page.mouse.move(0, 0);
+    await expect(hoverDetails).toHaveCSS("opacity", "0");
+    const restingRtlGeometry = await readFooterGeometry(peerGroup);
+    await peerGroup.hover();
+    await expect(hoverDetails).toHaveCSS("opacity", "1");
+    const hoveredRtlGeometry = await readFooterGeometry(peerGroup);
+    expectStableNamePosition(hoveredRtlGeometry.name, restingRtlGeometry.name);
+    expect(hoveredRtlGeometry.identity.left - hoveredRtlGeometry.actions.right).toBeCloseTo(8, 0);
+
+    await page.evaluate(() => {
+      document.documentElement.dir = "ltr";
+    });
+    await page.setViewportSize({ height: 760, width: 390 });
+    await page.mouse.move(0, 0);
+    const restingTouchGeometry = await readFooterGeometry(longNamePeerGroup);
+    const restingTouchHeight = (await longNamePeerGroup.boundingBox())?.height;
+    await longNamePeerGroup
+      .locator(".chat-bubble")
+      .dispatchEvent("pointerup", { pointerType: "touch" });
+    await expect(longNamePeerGroup).toHaveClass(/\bchat-group--meta-revealed\b/u);
+    const revealedTouchGeometry = await readFooterGeometry(longNamePeerGroup);
+    const revealedTouchHeight = (await longNamePeerGroup.boundingBox())?.height;
+    expectStableNamePosition(revealedTouchGeometry.name, restingTouchGeometry.name);
+    expect(revealedTouchGeometry.actions.top).toBeGreaterThanOrEqual(
+      revealedTouchGeometry.identity.bottom,
+    );
+    await expect(longNamePeerGroup.getByRole("button", { name: "Reply to message" })).toHaveCSS(
+      "opacity",
+      "1",
+    );
+    expect(revealedTouchHeight).toBeGreaterThan(restingTouchHeight ?? 0);
+
+    await page.setViewportSize({ height: 760, width: 1180 });
     // Own-message footer: the always-visible name must stay put when hover
     // reveals the timestamp, which slots in to its left (right-aligned row).
     const ownGroup = userGroups.first();
     const ownName = ownGroup.locator(".chat-sender-name");
+    const ownBubble = ownGroup.locator(".chat-bubble");
     await page.mouse.move(0, 0);
     await expect(ownGroup.locator(".chat-group-timestamp")).toHaveCSS("opacity", "0");
     const restingNameBox = await ownName.boundingBox();
+    const ownBubbleBox = await ownBubble.boundingBox();
     await ownGroup.hover();
     const ownTimestamp = ownGroup.locator(".chat-group-timestamp");
     await expect(ownTimestamp).toHaveCSS("opacity", "1");
@@ -119,12 +240,15 @@ suite.define(() => {
     const hoveredNameBox = await ownName.boundingBox();
     const timestampBox = await ownTimestamp.boundingBox();
     expect(hoveredNameBox?.x).toBe(restingNameBox?.x);
+    expect((restingNameBox?.x ?? 0) + (restingNameBox?.width ?? 0)).toBeCloseTo(
+      (ownBubbleBox?.x ?? 0) + (ownBubbleBox?.width ?? 0),
+      0,
+    );
     expect((timestampBox?.x ?? 0) + (timestampBox?.width ?? 0)).toBeLessThan(
       hoveredNameBox?.x ?? 0,
     );
 
-    const footerOrder = await userGroups
-      .last()
+    const footerOrder = await peerGroup
       .locator(".chat-group-footer")
       .locator("button, .chat-sender-name, .chat-group-timestamp")
       .evaluateAll((elements) =>
@@ -138,7 +262,7 @@ suite.define(() => {
           return element.getAttribute("aria-label");
         }),
       );
-    expect(footerOrder).toEqual(["Reply to message", "Rewind", "name", "time"]);
+    expect(footerOrder).toEqual(["name", "time", "Reply to message", "Rewind"]);
 
     await context.close();
   });

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -50,6 +50,7 @@ async function readFooterGeometry(group: Locator) {
         left: identityRect.left,
         right: identityRect.right,
       },
+      footer: { right: footerRect.right },
       name: { left: nameRect.left - footerRect.left, top: nameRect.top - footerRect.top },
     };
   });
@@ -217,6 +218,7 @@ suite.define(() => {
     expect(revealedTouchGeometry.actions.top).toBeGreaterThanOrEqual(
       revealedTouchGeometry.identity.bottom,
     );
+    expect(revealedTouchGeometry.actions.right).toBeCloseTo(revealedTouchGeometry.footer.right, 0);
     await expect(longNamePeerGroup.getByRole("button", { name: "Reply to message" })).toHaveCSS(
       "opacity",
       "1",

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -432,6 +432,21 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
   const hasUserFooterActions =
     normalizedRole === "user" &&
     Boolean((footerActionDetails?.replyTarget && opts.onReply) || opts.onRewind);
+  const userFooterActions = hasUserFooterActions
+    ? html`
+        <div
+          class="chat-group-footer-actions"
+          data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
+        >
+          ${footerActionDetails?.replyTarget && opts.onReply
+            ? renderReplyButton(footerActionDetails.replyTarget, opts.onReply)
+            : nothing}
+          ${opts.onRewind
+            ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled))
+            : nothing}
+        </div>
+      `
+    : nothing;
 
   // Attributed (logged-in) senders tint their bubbles with the same stable
   // identity hue as their avatar initials; CSS owns per-theme lightness so
@@ -516,37 +531,25 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
               : ""}"
           >
             <div class="chat-group-footer__meta">
-              ${hasUserFooterActions
-                ? html`
-                    <div
-                      class="chat-group-footer-actions"
-                      data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
-                    >
-                      ${footerActionDetails?.replyTarget && opts.onReply
-                        ? renderReplyButton(footerActionDetails.replyTarget, opts.onReply)
-                        : nothing}
-                      ${opts.onRewind
-                        ? renderRewindButton(opts.onRewind, Boolean(opts.rewindDisabled))
-                        : nothing}
-                    </div>
-                  `
-                : nothing}
+              ${isPeerGroup ? nothing : userFooterActions}
               ${normalizedRole === "user" && !showAvatarGutter
                 ? renderChatAuthorAvatar(group.sender)
                 : nothing}
               <span class="chat-sender-name">${who}</span>
               ${renderMessageMeta(group.timestamp, meta)}
             </div>
-            ${normalizedRole !== "user" && footerActionDetails
-              ? html`
-                  <div
-                    class="chat-group-footer-actions"
-                    data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
-                  >
-                    ${renderMessageActionButtons(footerActionDetails, opts)}
-                  </div>
-                `
-              : nothing}
+            ${isPeerGroup
+              ? userFooterActions
+              : normalizedRole !== "user" && footerActionDetails
+                ? html`
+                    <div
+                      class="chat-group-footer-actions"
+                      data-message-actions-for=${group.messages[lastMessageIndex]?.key ?? nothing}
+                    >
+                      ${renderMessageActionButtons(footerActionDetails, opts)}
+                    </div>
+                  `
+                : nothing}
           </div>`}
     </div>
   `;

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -917,6 +917,38 @@ describe("grouped chat rendering", () => {
     expect(order).toEqual(["Reply to message", "Rewind", "name", "time"]);
   });
 
+  it("orders peer footer actions after the sender name and timestamp", () => {
+    const container = document.createElement("div");
+    const message = createUserMessage("Peer footer order.");
+    const group = createMessageGroup(message, "user", {
+      sender: { id: "peer-user", name: "Peer User" },
+      senderLabel: "Peer User",
+    });
+    render(
+      renderTestMessageGroup(group, {
+        onReply: vi.fn(),
+        onRewind: vi.fn(),
+        userId: "current-user",
+      }),
+      container,
+    );
+
+    const footer = expectElement(container, ".chat-group--peer .chat-group-footer", HTMLElement);
+    const order = [
+      ...footer.querySelectorAll<HTMLElement>("button, .chat-sender-name, .chat-group-timestamp"),
+    ].map((element) => {
+      if (element.classList.contains("chat-sender-name")) {
+        return "name";
+      }
+      if (element.classList.contains("chat-group-timestamp")) {
+        return "time";
+      }
+      return element.getAttribute("aria-label");
+    });
+
+    expect(order).toEqual(["name", "time", "Reply to message", "Rewind"]);
+  });
+
   it("keeps hidden assistant thinking out of inline reply context", () => {
     const container = document.createElement("div");
     const onReply = vi.fn();

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -770,6 +770,7 @@ img.chat-avatar.chat-avatar--logo {
 
   .chat-group.user.chat-group--peer .chat-group-footer-actions {
     flex-basis: 100%;
+    justify-content: flex-end;
   }
 
   .chat-group-footer-actions .chat-copy-btn,

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -23,6 +23,9 @@
 }
 
 .chat-group.user.chat-group--peer {
+  /* The left-aligned identity owns the leading edge while hidden details
+     reserve their desktop footprint after it. */
+  --chat-footer-detail-position: static;
   flex-direction: row;
 }
 
@@ -203,9 +206,13 @@
   min-width: 0;
 }
 
+.chat-group.user.chat-group--peer .chat-group-footer__meta {
+  min-height: 24px;
+}
+
 /* Own-message footers are right-aligned, so hover-revealed time/actions must
    slot in to the LEFT of the always-visible name; otherwise the name jumps
-   sideways on hover. Peer footers are left-aligned and already stable. */
+   sideways on hover. */
 .chat-group.user:not(.chat-group--peer) .chat-group-footer--persistent-identity .chat-sender-name {
   order: 1;
 }
@@ -228,6 +235,10 @@
 .chat-group.assistant .chat-message-actions-row {
   justify-content: flex-start;
   margin-left: 0;
+}
+
+.chat-group.user.chat-group--peer .chat-group-footer button:focus-visible {
+  opacity: 1;
 }
 
 .chat-message-actions-row {
@@ -750,6 +761,15 @@ img.chat-avatar.chat-avatar--logo {
     --chat-footer-disclosure-pointer-events: auto;
     --chat-footer-detail-position: static;
     --chat-persistent-footer-opacity: 1;
+  }
+
+  :where(.chat-thread)
+    .chat-group.user.chat-group--peer:not(.chat-group--meta-revealed, :focus-within) {
+    --chat-footer-detail-position: absolute;
+  }
+
+  .chat-group.user.chat-group--peer .chat-group-footer-actions {
+    flex-basis: 100%;
   }
 
   .chat-group-footer-actions .chat-copy-btn,


### PR DESCRIPTION
Closes #126239

## What Problem This Solves

Revealing reply and rewind actions on a peer message moved that peer's name and timestamp horizontally, making participant identity jump during hover, keyboard focus, and touch interaction.

## Why This Change Was Made

The shared user-footer renderer placed actions before identity for both the current user and peers. That order is correct for the existing right-aligned current-user footer, but on the left-aligned peer footer the newly visible in-flow actions displaced the identity by 60 px.

`renderMessageGroup` and the grouped-message footer styles now keep the existing current-user branch intact while giving peers an identity-first footer with a reserved action footprint. Mobile peer actions retain their own row and align to the logical trailing edge. Assistant rendering and existing message spacing are unchanged.

## User Impact

Peer identity remains stationary when actions appear across short and long names, light and dark themes, desktop and mobile layouts, LTR and RTL direction, hover, focus, and touch. Current-user actions keep their existing order and trailing alignment.

Production delta: `+48 / -24` (`+24` net). Tests: `+168 / -10` (`+158` net).

## Visual Evidence

Captured remotely from the real Control UI mock route. “Before” is base `755dad74d1fcaf4e22ee61e029a385207b7d251a`; “In this PR” is exact pushed head `a0cd5602ef6c2cb7245de2630c2dd071ef2b8ce9`. In both themes, the before frame shows reply/rewind preceding and shifting `Colin / just now`; the proposed frame keeps identity fixed and reveals actions after it.

### Full context

| Theme | Before | In this PR |
| --- | --- | --- |
| Light | ![Before, light theme, peer identity shifted by revealed actions](https://github.com/user-attachments/assets/5df781f6-a7a9-4486-9710-005bebd3fd9c) | ![In this PR, light theme, peer identity stable with actions trailing](https://github.com/user-attachments/assets/16747dfd-aa85-4b32-9082-caf0d7369b99) |
| Dark | ![Before, dark theme, peer identity shifted by revealed actions](https://github.com/user-attachments/assets/be37781c-a0c0-47c8-b856-3de8c925173e) | ![In this PR, dark theme, peer identity stable with actions trailing](https://github.com/user-attachments/assets/2c7ba4a0-2914-40b7-9fde-2dcbba31c423) |

### Peer footer detail

| Theme | Before | In this PR |
| --- | --- | --- |
| Light | ![Before peer footer detail in light theme](https://github.com/user-attachments/assets/9d7fc565-0fdc-4fc5-883a-ef50fd36d71c) | ![Stable peer footer detail in light theme](https://github.com/user-attachments/assets/dd94b0d1-179d-4f4c-b336-d3c2f497effc) |
| Dark | ![Before peer footer detail in dark theme](https://github.com/user-attachments/assets/f64d7fae-23b4-4b32-bbae-0468d2de3c2d) | ![Stable peer footer detail in dark theme](https://github.com/user-attachments/assets/a0fa5e39-f270-4f75-bbd7-a30a3c393a9b) |

## Evidence

- AWS Crabbox `run_cfe8d86133d5`: the regression scenario failed on the base as intended; the peer name moved from x=385 to x=445 when actions appeared.
- AWS Crabbox `run_9fc5e7099cc6`: final-head changed-file gate passed, and the focused attributed-identity E2E passed 2/2 across hover, focus, RTL, mobile row/trailing alignment, long names, and preserved current-user behavior.
- AWS Crabbox `run_ab06556b0fa7`: exact-head visual run confirmed `a0cd5602ef6c2cb7245de2630c2dd071ef2b8ce9`, reproduced the 60 px base shift, passed the candidate E2E 2/2, and produced the inspected light/dark before/after captures above.
- Focused owner unit coverage passed 199/199 remotely in `run_271b825aeee2`.
- Recursive OpenCode review found one mobile trailing-alignment issue, which was fixed in `a0cd5602ef6c2cb7245de2630c2dd071ef2b8ce9`; the fresh follow-up review completed with no actionable findings and `git diff --check` clean.
