### PR TITLE
chore: trim residual exact-subset assertions

### DIFF
--- a/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.cache.test.ts
@@ -726,8 +726,6 @@ describe("ChatGPT Responses cached transport", () => {
       cleanupSessionResources();
       expect((await runSession("sticky-sse-fallback")).stopReason).toBe("stop");
       expect((await runSession("unrelated-sse-fallback")).stopReason).toBe("stop");
-      expect(websocketUpgrades).toHaveLength(5);
-      expect(sseRequests).toHaveLength(8);
 
       expect(websocketUpgrades.map((request) => request.sessionId)).toEqual([
         "sticky-sse-fallback",

--- a/packages/ai/src/providers/transform-messages.test.ts
+++ b/packages/ai/src/providers/transform-messages.test.ts
@@ -49,7 +49,6 @@ describe("transformMessages", () => {
 
     const transformed = transformProviderMessages(messages, model);
 
-    expect(transformed).toHaveLength(3);
     expect(transformed.map((message) => message.content)).toEqual([[], [], []]);
   });
 

--- a/packages/gateway-client/src/client.handshake.test.ts
+++ b/packages/gateway-client/src/client.handshake.test.ts
@@ -138,7 +138,6 @@ describe("GatewayClient websocket opening handshakeTimeout", () => {
     });
     await retried;
     expect(requestCount).toBe(2);
-    expect(errors).toHaveLength(2);
     expect(errors.map((error) => error.message)).toEqual([
       "gateway rejected websocket upgrade (HTTP 503): Gateway websocket admission closed",
       "gateway rejected websocket upgrade (HTTP 503): Gateway websocket admission closed",

--- a/packages/gateway-client/src/session-projection-conformance.test.ts
+++ b/packages/gateway-client/src/session-projection-conformance.test.ts
@@ -208,7 +208,6 @@ describe("cross-client session projection conformance", () => {
       { message: firstImport, type: "messagePersisted" },
     ]);
 
-    expect(state.entries).toHaveLength(4);
     expect(state.entries.map((entry) => entry.identity?.externalSource)).toEqual([
       null,
       JSON.stringify(["provider-a", "cli-a", externalId]),

--- a/packages/memory-host-sdk/src/host/remote-error-redaction.test.ts
+++ b/packages/memory-host-sdk/src/host/remote-error-redaction.test.ts
@@ -228,7 +228,6 @@ describe.sequential("memory remote error redaction", () => {
         }),
       ).resolves.toBe("file_control");
       const batchRecords = records.filter((record) => record.path.endsWith("/files"));
-      expect(batchRecords).toHaveLength(3);
       expect(batchRecords[0]?.contentType).toMatch(/^multipart\/form-data; boundary=/u);
       expect(batchRecords[0]?.body).toContain('name="purpose"');
       expect(batchRecords[0]?.body).toContain("batch");

--- a/src/agents/agent-command-execution-identity.test.ts
+++ b/src/agents/agent-command-execution-identity.test.ts
@@ -140,7 +140,6 @@ describe("Gateway agent command execution identity", () => {
       throw new Error("expected captured present invoker");
     }
     expect(work.envelope.invoker.displayLabel).toBe("Operator OPENAI_API_KEY=***");
-    expect(work.envelope.invoker.displayLabel?.length).toBeLessThanOrEqual(128);
   });
 
   it("does not offer the prepared profile label to storage without execution audit opt-in", async () => {

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -836,7 +836,6 @@ describe("loadCliSessionReseedMessages", () => {
           sessionKey: "agent:main:main",
           agentId: "main",
         });
-        expect(reseed).toHaveLength(2);
         expectCompactionSummary(reseed[0], "safe compacted summary");
         expectMessageFields(reseed[1], { role: "user", content: "post-compaction ask" });
         expect(reseed.map((message) => requireRecord(message, "reseed message").timestamp)).toEqual(

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -86,7 +86,6 @@ describe("compaction token accounting sanitization", () => {
 
     const sanitized = sanitizeCompactionMessages(messages);
 
-    expect(sanitized).toHaveLength(2);
     expect(sanitized[0]).not.toHaveProperty("details");
     expect(sanitized.map((message) => message.role)).toEqual(["toolResult", "user"]);
   });

--- a/src/agents/embedded-agent-runner/run/preparation-timing.test.ts
+++ b/src/agents/embedded-agent-runner/run/preparation-timing.test.ts
@@ -37,7 +37,6 @@ describe("embedded agent preparation timing", () => {
     );
 
     const events = await readTimeline(path);
-    expect(events).toHaveLength(4);
     expect(events.map((event) => event.name)).toEqual([
       "agent.prepare",
       "agent.prepare",

--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -458,7 +458,6 @@ describe("openai-responses reasoning replay", () => {
     });
 
     const messages = extractInputMessages(input);
-    expect(messages).toHaveLength(2);
     const ids = messages.map((item) => item.id);
     expect(ids.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
     expect(new Set(ids).size).toBe(2);

--- a/src/agents/openai-transport-stream.replay-and-tools.test.ts
+++ b/src/agents/openai-transport-stream.replay-and-tools.test.ts
@@ -1098,8 +1098,6 @@ describe("openai transport stream", () => {
     const functionCalls = params.input?.filter((item) => item.type === "function_call") ?? [];
     const functionOutputs =
       params.input?.filter((item) => item.type === "function_call_output") ?? [];
-    expect(functionCalls).toHaveLength(2);
-    expect(functionOutputs).toHaveLength(2);
     expect(functionCalls.map((item) => item.id)).toEqual([undefined, undefined]);
     expect(functionOutputs.map((item) => item.call_id)).toEqual(["call_first", "call_second"]);
   });

--- a/src/agents/sandbox/registry.test.ts
+++ b/src/agents/sandbox/registry.test.ts
@@ -188,7 +188,6 @@ describe("registry race safety", () => {
     ]);
 
     const registry = await readRegistry();
-    expect(registry.entries).toHaveLength(2);
     expect(
       registry.entries
         .map((entry) => entry.containerName)
@@ -241,7 +240,6 @@ describe("registry race safety", () => {
     ]);
 
     const registry = await readBrowserRegistry();
-    expect(registry.entries).toHaveLength(2);
     expect(
       registry.entries
         .map((entry) => entry.containerName)

--- a/src/agents/tool-schema-hints.test.ts
+++ b/src/agents/tool-schema-hints.test.ts
@@ -87,7 +87,6 @@ describe("tool schema hints", () => {
     const outputHint = compactToolOutputHint(schema);
 
     expect(inputHint).toBe("unknown");
-    expect(inputHint.length).toBeLessThanOrEqual(300);
     expect(outputHint).toBeDefined();
     expect(outputHint!.length).toBeGreaterThan(300);
     expect(outputHint!.length).toBeLessThanOrEqual(600);

--- a/src/auto-reply/reply/queue.collect.test.ts
+++ b/src/auto-reply/reply/queue.collect.test.ts
@@ -757,7 +757,6 @@ describe("followup queue collect routing", () => {
 
     const queue = getExistingFollowupQueue(key);
     expect(accepted).toEqual([true, true, true, true, true, true, true]);
-    expect(queue?.summaryElisions).toHaveLength(2);
     expect(queue?.summaryElisions.map((entry) => entry.sources.at(-1)?.originatingTo)).toEqual([
       "channel:B",
       "channel:A",

--- a/src/commands/doctor-heartbeat-task-migration.test.ts
+++ b/src/commands/doctor-heartbeat-task-migration.test.ts
@@ -218,7 +218,6 @@ describe("heartbeat scratch task cron migration", () => {
     const jobs = (await loadCronJobsStore(fixture.storePath)).jobs
       .filter(isHeartbeatTaskCronJob)
       .toSorted((a, b) => a.name.localeCompare(b.name));
-    expect(jobs).toHaveLength(2);
     expect(
       jobs.map((job) => ({ name: job.name, schedule: job.schedule, payload: job.payload })),
     ).toEqual([
@@ -432,7 +431,6 @@ tasks:
     const jobs = (await loadCronJobsStore(fixture.storePath)).jobs
       .filter(isHeartbeatTaskCronJob)
       .toSorted((left, right) => left.payload.text.localeCompare(right.payload.text));
-    expect(jobs).toHaveLength(2);
     expect(jobs.map((job) => job.declarationKey)).toEqual([
       heartbeatTaskDeclarationKey("main", "inbox", 0),
       heartbeatTaskDeclarationKey("main", "inbox", 1),
@@ -491,7 +489,6 @@ tasks:
 
     expect(result.warnings).toEqual([]);
     const jobs = (await loadCronJobsStore(fixture.storePath)).jobs.filter(isHeartbeatTaskCronJob);
-    expect(jobs).toHaveLength(3);
     expect(new Set(jobs.map((job) => job.declarationKey)).size).toBe(3);
     expect(
       jobs.map((job) => job.payload.text).toSorted((left, right) => left.localeCompare(right)),

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1218,7 +1218,6 @@ describe("runDoctorSessionSqlite", () => {
       storePath: expectedStorePath,
       validationBeforeArchive: "passed",
     });
-    expect(target.plannedMoves).toHaveLength(4);
     expect(target.completedMoves).toHaveLength(4);
     expect(target.plannedMoves.map((move) => path.basename(move.sourcePath)).toSorted()).toEqual([
       "orphan.jsonl",

--- a/src/cron/store/failure-alert-codec.test.ts
+++ b/src/cron/store/failure-alert-codec.test.ts
@@ -48,7 +48,5 @@ describe("failureAlertFromRow", () => {
     expect(row.failure_alert_after).toBeNull();
     const decoded = failureAlertFromRow(row);
     expect(decoded).toEqual({});
-    expect(decoded).not.toBeUndefined();
-    expect(decoded).toBeTruthy();
   });
 });

--- a/src/docker-setup.e2e.test.ts
+++ b/src/docker-setup.e2e.test.ts
@@ -978,7 +978,6 @@ describe("scripts/docker/setup.sh", () => {
     const argLine = dockerfile
       .split("\n")
       .find((line) => line.startsWith("ARG OPENCLAW_IMAGE_APT_PACKAGES"));
-    expect(argLine).toBeDefined();
     // Must be bare `ARG OPENCLAW_IMAGE_APT_PACKAGES` with no default assignment
     expect(argLine).toBe("ARG OPENCLAW_IMAGE_APT_PACKAGES");
   });

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1479,7 +1479,6 @@ describe("agent event handler", () => {
     emitLifecycleEnd(handler, "run-no-dup-flush");
 
     const chatCalls = chatBroadcastCalls(broadcast);
-    expect(chatCalls).toHaveLength(3);
     expect(chatCalls.map(([, payload]) => (payload as { state?: string }).state)).toEqual([
       "delta",
       "delta",

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -3353,7 +3353,6 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       });
 
       const messages = await readActiveAssistantTranscriptMessages();
-      expect(messages).toHaveLength(2);
       expect(messages.map((message) => message.idempotencyKey)).toEqual([
         "older-distinct-assistant",
         "runtime-owned-assistant",

--- a/src/gateway/server-node-subscriptions.test.ts
+++ b/src/gateway/server-node-subscriptions.test.ts
@@ -18,7 +18,6 @@ describe("node subscription manager", () => {
       sent.push(event);
     });
 
-    expect(sent).toHaveLength(2);
     expect(sent.map((event) => event.nodeId).toSorted()).toEqual(["node-a", "node-b"]);
     expect(sent.map((event) => event.pairingGeneration).toSorted()).toEqual([
       "generation-a",

--- a/src/gateway/worker-environments/workspace-hash-memo.test.ts
+++ b/src/gateway/worker-environments/workspace-hash-memo.test.ts
@@ -270,7 +270,6 @@ describe("workspace hash memo", () => {
     };
 
     const first = await capture([]);
-    expect(first.memo).toHaveLength(2);
     expect(
       first.memo
         .map(([identity]) => Number(identity.split(":")[3]))

--- a/src/gateway/worker-environments/workspace-sync-tunnel.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-tunnel.test.ts
@@ -193,7 +193,6 @@ describe("worker tunnel manager", () => {
       expect(ports).toEqual(expect.arrayContaining([2222, 22]));
       expect(new Set(ports)).toEqual(new Set([2222, 22]));
       const transfers = freshConnections.filter((entry) => entry.argv[0] === "rsync");
-      expect(transfers).toHaveLength(2);
       expect(transfers.map((entry) => rsyncReceiverNonce(entry.argv))).toEqual([
         expect.stringMatching(/^[a-f0-9]{32}$/u),
         expect.stringMatching(/^[a-f0-9]{32}$/u),

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -981,7 +981,6 @@ describe("createBackupArchive", () => {
             maxEntries: CONFIG_AUDIT_MAX_ENTRIES,
             env: { ...process.env, OPENCLAW_STATE_DIR: restoredStateDir },
           }).entries();
-          expect(restoredEntries).toHaveLength(2);
           expect(new Set(restoredEntries.map((entry) => entry.key)).size).toBe(2);
           expect(restoredEntries.map((entry) => entry.value)).toEqual([record, record]);
         } finally {

--- a/src/infra/state-migrations.cron-run-logs.test.ts
+++ b/src/infra/state-migrations.cron-run-logs.test.ts
@@ -201,7 +201,6 @@ describe("cron run-log task import", () => {
             "SELECT task_id, cleanup_after FROM task_runs WHERE task_id LIKE 'cron-runlog-import:%' ORDER BY task_id",
           )
           .all() as Array<{ task_id: string; cleanup_after: number | null }>;
-        expect(imported).toHaveLength(4);
         expect(imported.map((row) => row.task_id)).toEqual([
           "cron-runlog-import:legacy-history-job:1100:1",
           "cron-runlog-import:legacy-history-job:2100:1",

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -713,11 +713,9 @@ describe("stuck session diagnostics threshold", () => {
     }
 
     // Warning stays throttled: still only the single 60s warning.
-    expect(stuckEvents).toHaveLength(1);
     expect(stuckEvents.map((event) => event.ageMs)).toEqual([60_000]);
     // Recovery was not suppressed by the warning backoff on the 90s tick.
     expect(recoverStuckSession).toHaveBeenCalledTimes(2);
-    expect(recoveryRequests).toHaveLength(2);
     expect(recoveryRequests.map((event) => event.ageMs)).toEqual([60_000, 90_000]);
   });
 

--- a/src/plugins/bundle-mcp.test.ts
+++ b/src/plugins/bundle-mcp.test.ts
@@ -598,7 +598,6 @@ describe("loadEnabledBundleMcpConfig", () => {
           loaded.config.mcpServers.dotPrefixedChild?.cwd,
           path.join(pluginRoot, "..cache"),
         );
-        expect(loaded.diagnostics).toHaveLength(2);
         expect(loaded.diagnostics.map((entry) => entry.message)).toEqual([
           expect.stringContaining('invalid MCP server "relativeEscape"'),
           expect.stringContaining('invalid MCP server "placeholderEscape"'),

--- a/src/plugins/http-registry.test.ts
+++ b/src/plugins/http-registry.test.ts
@@ -322,7 +322,6 @@ describe("registerPluginHttpRoute", () => {
       throwOnFailure: true,
     });
 
-    expect(registry.httpRoutes).toHaveLength(2);
     expect(registry.httpRoutes.map((route) => route.source)).toEqual(["prefix", "sms-exact"]);
   });
 

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -1122,7 +1122,6 @@ describe("installPluginFromArchive", () => {
 
     expect(result.ok).toBe(true);
     const requests = readCapturedInstallPolicyRequests(logPath);
-    expect(requests).toHaveLength(2);
     expect(requests.map((request) => request.request.kind)).toEqual([
       "plugin-archive",
       "plugin-archive",
@@ -1946,7 +1945,6 @@ describe("installPluginFromArchive", () => {
 
     expect(result.ok).toBe(true);
     const requests = readCapturedInstallPolicyRequests(logPath);
-    expect(requests).toHaveLength(2);
     expect(requests.map((request) => request.request.kind)).toEqual(["plugin-dir", "plugin-dir"]);
     expect(requests.map((request) => request.plugin?.contentType)).toEqual([
       "package",

--- a/src/skills/loading/workspace-skill-prompt.test.ts
+++ b/src/skills/loading/workspace-skill-prompt.test.ts
@@ -194,7 +194,6 @@ describe("applySkillsPromptLimits (via buildWorkspaceSkillsPrompt)", () => {
     // Budget so small that even one compact skill can't fit
     const prompt = buildPrompt(skills, { maxChars: 10 });
     expect(prompt).toBe("");
-    expect(prompt.length).toBeLessThanOrEqual(10);
   });
 
   it.each([0, 1, 10, 64])("never exceeds a tiny configured prompt budget of %i", (maxChars) => {

--- a/src/worker/worker.fault-injection.test.ts
+++ b/src/worker/worker.fault-injection.test.ts
@@ -361,7 +361,6 @@ describe("cloud worker milestone 2 fault injection", () => {
     const messages = SessionManager.open(harness.sessionTarget)
       .getEntries()
       .flatMap((entry) => (entry.type === "message" ? [entry.message] : []));
-    expect(messages).toHaveLength(2);
     expect(messages.map((message) => message.role)).toEqual(["user", "user"]);
     expect(harness.providerCalls).toBe(2);
     expect(


### PR DESCRIPTION
Internal task: 228

## What Problem This Solves

Removes residual one-line test assertions that duplicate stronger adjacent proof and therefore add maintenance noise without detecting an independent regression.

## Why This Change Was Made

Deletes exactly 39 assertions across 31 test files. Each removed assertion is logically implied by an adjacent exact same-value assertion or a length-preserving full projection. Enclosing tests, intermediate and synchronization assertions, repeated-execution checks, uniqueness checks, completed-move counts, and every stronger exact assertion remain unchanged.

Deletion criterion was revalidated against current `main` by test name and adjacency before editing. Skips: none; all 39 requested candidates were still present. No substitute candidates were added.

## User Impact

No user-visible behavior changes. Test coverage retains the exact assertions that prove the values and ordering while dropping redundant subset checks.

## Evidence

- `pnpm check:changed` — passed.
- `node scripts/run-vitest.mjs <30 explicit non-backup changed files>` — passed 13 Vitest shards; all 30 files were selected explicitly.
- `node scripts/run-vitest.mjs src/infra/backup-create.test.ts -- --reporter=verbose -t 'preserves audit ordinals for identical later appends across backup restore'` — passed.
- `pnpm test:changed -- --reporter=verbose` — selected all 31 files. Every changed assertion path passed; the full backup suite had two unrelated 120-second host-load timeouts. Both timed-out neighboring tests passed on their required isolated rerun in about 29 seconds each.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings.
- `git diff --check` — passed.
- Diff audit: 31 test files, 0 additions, 39 assertion deletions, 0 production/test-support changes, 0 non-assertion deletions.
