### PR TITLE
fix(ui): sync Terminal with live theme changes

### DIFF
--- a/ui/src/app/app-host.gateway-lineage.test.ts
+++ b/ui/src/app/app-host.gateway-lineage.test.ts
@@ -59,6 +59,7 @@ function renderGatewaySurface(
         basePath: "",
         agentSelection: { state: { selectedId: null } },
         config: { current: { terminalEnabled: false } },
+        theme: { resolvedMode: "dark" },
       } as unknown as ApplicationContext,
     };
     app.synchronizeGateway(gateway);
@@ -133,6 +134,7 @@ describe("Control UI Gateway target lineage", () => {
         basePath: "",
         agentSelection: { state: { selectedId: null } },
         config: { current: { terminalEnabled: false } },
+        theme: { resolvedMode: "dark" },
       } as unknown as ApplicationContext,
     };
     app.synchronizeGateway(gateway);

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -31,10 +31,6 @@ import { resolveOnboardingMode } from "./onboarding-mode.ts";
 import { controlUiPublicAssetPath } from "./public-assets.ts";
 import { isTerminalOnlyView } from "./terminal-document-mode.ts";
 
-export function resolveTerminalThemeMode(): "dark" | "light" {
-  return document.documentElement.dataset.themeMode === "light" ? "light" : "dark";
-}
-
 function renderConnectingSplash(status?: string) {
   return html`
     <main
@@ -259,7 +255,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
           .client=${gatewayConnected ? gatewaySnapshot.client : null}
           .available=${terminalAvailable}
           .agentId=${terminalAgentId}
-          .themeMode=${resolveTerminalThemeMode()}
+          .themeMode=${context.theme.resolvedMode}
           fullscreen
         ></openclaw-terminal-panel>
         ${!gatewayConnected && gatewaySnapshot.lastError === null

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -115,6 +115,10 @@ export class OpenClawApp extends OpenClawLightDomElement {
         () => (this.terminalOnly ? this.context?.agentSelection : undefined),
         (selection, notify) => selection.subscribe(notify),
       )
+      .watch(
+        () => (this.terminalOnly ? this.context?.theme : undefined),
+        (theme, notify) => theme.subscribe(notify),
+      )
       .effect(() => this.ownerDocument, installNativeTitleGuard);
   }
 

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -22,7 +22,6 @@ import { findSettingsSearchBlocks } from "../pages/config/settings-search.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import { pluginTabKey, pluginTabRefFromSearch } from "../pages/plugin/route.ts";
 import type { ShellRouteState } from "./app-host-route-state.ts";
-import { resolveTerminalThemeMode } from "./app-root.ts";
 import { isBrowserPanelAvailable, isDesktopPanelAvailable } from "./app-shell-chrome.ts";
 import type { OutboxStoreRuntime, StoredOutboxScopeHost } from "./app-shell-gateway.ts";
 import type { ApplicationRuntime } from "./bootstrap.ts";
@@ -659,7 +658,7 @@ export function renderApplicationShell(host: ShellViewHost) {
         .agentId=${selectedAgentId}
         .sessionKey=${sessionRoute ? host.activeSessionKey : null}
         .suppressed=${settingsTakeover}
-        .themeMode=${resolveTerminalThemeMode()}
+        .themeMode=${context.theme.resolvedMode}
         .basePath=${context.basePath}
       ></openclaw-terminal-panel>
       ${sessionRoute

--- a/ui/src/app/bootstrap.ts
+++ b/ui/src/app/bootstrap.ts
@@ -135,6 +135,9 @@ function createApplicationTheme(
     get mode() {
       return settings.themeMode;
     },
+    get resolvedMode() {
+      return resolveTheme(settings.theme, settings.themeMode).endsWith("light") ? "light" : "dark";
+    },
     get serverSelection() {
       return serverSelection;
     },

--- a/ui/src/app/context.ts
+++ b/ui/src/app/context.ts
@@ -35,6 +35,7 @@ export type ApplicationThemeServerSelection = {
 
 export type ApplicationTheme = {
   readonly mode: ThemeMode;
+  readonly resolvedMode: "dark" | "light";
   readonly serverSelection: ApplicationThemeServerSelection | null;
   recordServerSelection: (theme: ThemeName | null, scope: string) => void;
   setMode: (mode: ThemeMode, element?: HTMLElement | null) => void;

--- a/ui/src/e2e/terminal-open.e2e.test.ts
+++ b/ui/src/e2e/terminal-open.e2e.test.ts
@@ -1,6 +1,4 @@
 import { createHash } from "node:crypto";
-import fs from "node:fs/promises";
-import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
@@ -14,9 +12,6 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) =>
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
 });
-
-const themeProofDir = process.env.OPENCLAW_TERMINAL_THEME_PROOF_DIR?.trim();
-const themeVideoDir = process.env.OPENCLAW_TERMINAL_THEME_VIDEO_DIR?.trim();
 
 async function openTerminalSidePanel(page: Page): Promise<Locator> {
   await page.goto(`${suite.server.baseUrl}chat`);
@@ -37,18 +32,6 @@ async function settleTerminalPaint(page: Page): Promise<void> {
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
       }),
   );
-}
-
-async function captureThemeProof(page: Page, name: string): Promise<void> {
-  if (!themeProofDir) {
-    return;
-  }
-  await fs.mkdir(themeProofDir, { recursive: true });
-  await page.screenshot({
-    animations: "disabled",
-    caret: "hide",
-    path: path.join(themeProofDir, `${name}.png`),
-  });
 }
 
 async function cycleThemeMode(page: Page, currentMode: "Dark" | "Light" | "System") {
@@ -96,9 +79,6 @@ suite.define(() => {
         colorScheme: "light",
         serviceWorkers: "block",
         viewport: { height: 800, width: 1280 },
-        ...(themeVideoDir
-          ? { recordVideo: { dir: themeVideoDir, size: { height: 800, width: 1280 } } }
-          : {}),
       },
       async ({ page }) => {
         const gateway = await installMockGateway(page, {
@@ -113,19 +93,15 @@ suite.define(() => {
         await canvas.evaluate((element) => {
           element.dataset.themeSyncIdentity = "original";
         });
-        await captureThemeProof(page, "light-initial");
-
         await cycleThemeMode(page, "System");
         await cycleThemeMode(page, "Light");
         await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("dark");
-        await captureThemeProof(page, "dark-after-toggle");
         await expect
           .poll(() => panel.evaluate((element) => Reflect.get(element, "themeMode")))
           .toBe("dark");
 
         await cycleThemeMode(page, "Dark");
         await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("light");
-        await captureThemeProof(page, "light-after-toggle");
         await expect
           .poll(() => panel.evaluate((element) => Reflect.get(element, "themeMode")))
           .toBe("light");
@@ -138,7 +114,6 @@ suite.define(() => {
         await expect
           .poll(() => panel.evaluate((element) => Reflect.get(element, "themeMode")))
           .toBe("light");
-        await captureThemeProof(page, "light-after-reopen");
         expect(await gateway.getRequests("terminal.open")).toHaveLength(1);
       },
     );

--- a/ui/src/e2e/terminal-open.e2e.test.ts
+++ b/ui/src/e2e/terminal-open.e2e.test.ts
@@ -1,4 +1,6 @@
 import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
@@ -12,6 +14,9 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) =>
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
 });
+
+const themeProofDir = process.env.OPENCLAW_TERMINAL_THEME_PROOF_DIR?.trim();
+const themeVideoDir = process.env.OPENCLAW_TERMINAL_THEME_VIDEO_DIR?.trim();
 
 async function openTerminalSidePanel(page: Page): Promise<Locator> {
   await page.goto(`${suite.server.baseUrl}chat`);
@@ -32,6 +37,27 @@ async function settleTerminalPaint(page: Page): Promise<void> {
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
       }),
   );
+}
+
+async function captureThemeProof(page: Page, name: string): Promise<void> {
+  if (!themeProofDir) {
+    return;
+  }
+  await fs.mkdir(themeProofDir, { recursive: true });
+  await page.screenshot({
+    animations: "disabled",
+    caret: "hide",
+    path: path.join(themeProofDir, `${name}.png`),
+  });
+}
+
+async function cycleThemeMode(page: Page, currentMode: "Dark" | "Light" | "System") {
+  const sidebar = page.locator("openclaw-app-sidebar");
+  const toggle = sidebar.getByRole("button", { name: `Color mode: ${currentMode}` });
+  if (!(await toggle.isVisible())) {
+    await sidebar.getByRole("button", { name: /^Identity and app menu for / }).click();
+  }
+  await toggle.click();
 }
 
 suite.define(() => {
@@ -62,6 +88,60 @@ suite.define(() => {
         .toContain(sentinel);
       await expect.poll(() => canvasDigest(canvas)).not.toBe(bannerDigest);
     });
+  });
+
+  it("keeps an open side-panel terminal synchronized with light and dark mode", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "light",
+        serviceWorkers: "block",
+        viewport: { height: 800, width: 1280 },
+        ...(themeVideoDir
+          ? { recordVideo: { dir: themeVideoDir, size: { height: 800, width: 1280 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.startup", "terminal.open"],
+          terminalEnabled: true,
+        });
+
+        const panel = await openTerminalSidePanel(page);
+        await gateway.waitForRequest("terminal.open");
+        const canvas = panel.locator(".tp-host canvas");
+        await canvas.waitFor({ state: "visible" });
+        await canvas.evaluate((element) => {
+          element.dataset.themeSyncIdentity = "original";
+        });
+        await captureThemeProof(page, "light-initial");
+
+        await cycleThemeMode(page, "System");
+        await cycleThemeMode(page, "Light");
+        await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("dark");
+        await captureThemeProof(page, "dark-after-toggle");
+        await expect
+          .poll(() => panel.evaluate((element) => Reflect.get(element, "themeMode")))
+          .toBe("dark");
+
+        await cycleThemeMode(page, "Dark");
+        await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("light");
+        await captureThemeProof(page, "light-after-toggle");
+        await expect
+          .poll(() => panel.evaluate((element) => Reflect.get(element, "themeMode")))
+          .toBe("light");
+        expect(await canvas.getAttribute("data-theme-sync-identity")).toBe("original");
+
+        await page.locator(".chat-side-panel-toggle").click();
+        await expect.poll(() => canvas.isVisible()).toBe(false);
+        await page.locator(".chat-side-panel-toggle").click();
+        await canvas.waitFor({ state: "visible" });
+        await expect
+          .poll(() => panel.evaluate((element) => Reflect.get(element, "themeMode")))
+          .toBe("light");
+        await captureThemeProof(page, "light-after-reopen");
+        expect(await gateway.getRequests("terminal.open")).toHaveLength(1);
+      },
+    );
   });
 
   it("names a missing field and retries the open successfully", async () => {

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -456,6 +456,10 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
           }),
       )
       .watch(
+        () => this.context?.theme,
+        (theme, notify) => theme.subscribe(notify),
+      )
+      .watch(
         () => this.resolveBoardProvider(),
         (provider, notify) => provider.snapshot$.subscribe(notify),
       )

--- a/ui/src/pages/chat/chat-pane-embedded-panels.ts
+++ b/ui/src/pages/chat/chat-pane-embedded-panels.ts
@@ -18,6 +18,7 @@ import type { SidebarSlotId } from "./sidebar-layout-types.ts";
 
 type SidebarPanelDefinitionParams = {
   state: ChatPageHost;
+  themeMode: "dark" | "light";
   agentId: string | null;
   browserPresented: boolean;
   desktopPresented: boolean;
@@ -93,7 +94,7 @@ export function sidebarPanelDefinitions(
           .available=${state.terminalAvailable}
           .agentId=${params?.agentId ?? null}
           .sessionKey=${state.sessionKey}
-          .themeMode=${document.documentElement.dataset.theme === "light" ? "light" : "dark"}
+          .themeMode=${params?.themeMode ?? "dark"}
           .basePath=${state.basePath}
         ></openclaw-terminal-panel>`
       : null;

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -102,6 +102,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
     const desktopRefreshOnPresentation = !this.pendingPanelToggleRequests.has("desktop");
     const panelDefinitions = sidebarPanelDefinitions({
       state,
+      themeMode: this.context.theme.resolvedMode,
       agentId: currentAgentId,
       browserPresented,
       desktopPresented,


### PR DESCRIPTION
Closes #126289

## What Problem This Solves

Fixes an issue where users with Terminal open in the chat side panel would keep the previous terminal palette after changing the Control UI color mode.

## Why This Change Was Made

The application theme owner now exposes its canonical resolved light/dark mode. Terminal hosts consume that projection, and chat panes subscribe to the existing theme publisher so mounted terminals receive live updates through their renderer-owned update path. Theme changes do not open a new PTY or replace the active canvas.

## User Impact

The side-panel Terminal now follows light-to-dark and dark-to-light changes immediately. Reopening the panel initializes it with the current mode and keeps the existing Gateway terminal session.

## Evidence

- Before: AWS Crabbox `run_38071e5b080c` reproduced a dark Control UI with the mounted Terminal still reporting `themeMode="light"`.
- After: AWS Crabbox `run_597e9a276c8f` passed the real `/chat` Playwright flow with the mocked Gateway used only as fixture data.
- Covered: light-to-dark, dark-to-light, same canvas across live changes, reopening in the current mode, and exactly one `terminal.open` request.
- Remote formatting check passed for all eight changed files.

Run: https://crabbox.openclaw.ai/portal/runs/run_597e9a276c8f
