### PR TITLE
fix(line): deliver a location LINE cannot render instead of dropping it

### DIFF
--- a/extensions/line/src/auto-reply-delivery.test-helpers.ts
+++ b/extensions/line/src/auto-reply-delivery.test-helpers.ts
@@ -39,13 +39,10 @@ export const createImageMessage = (url: string) => ({
   previewImageUrl: url,
 });
 
-const createLocationMessage: LineAutoReplyDeps["createLocationMessage"] = (location) =>
-  location.title.trim() && location.address.trim()
-    ? {
-        type: "location" as const,
-        ...location,
-      }
-    : null;
+const createLocationMessage: LineAutoReplyDeps["createLocationMessage"] = (location) => ({
+  type: "location" as const,
+  ...location,
+});
 
 export function createDeps(overrides?: Partial<LineAutoReplyDeps>): LineAutoReplyTestDeps {
   const replyMessageLine = vi.fn<LineAutoReplyDeps["replyMessageLine"]>(async () => ({}));

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -13,8 +13,10 @@ import {
 } from "./auto-reply-delivery.test-helpers.js";
 import { processLineMessage as processOrderedLineMessage } from "./markdown-to-line.js";
 import { buildLineMediaMessage } from "./outbound-media.js";
-import { createLocationMessage as createRealLocationMessage } from "./send.js";
-import { createFlexMessage as createProviderFlexMessage } from "./send.js";
+import {
+  createFlexMessage as createProviderFlexMessage,
+  createLocationMessage as createRealLocationMessage,
+} from "./send.js";
 
 describe("deliverLineAutoReply", () => {
   it.each([

--- a/extensions/line/src/auto-reply-delivery.test.ts
+++ b/extensions/line/src/auto-reply-delivery.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./auto-reply-delivery.test-helpers.js";
 import { processLineMessage as processOrderedLineMessage } from "./markdown-to-line.js";
 import { buildLineMediaMessage } from "./outbound-media.js";
+import { createLocationMessage as createRealLocationMessage } from "./send.js";
 import { createFlexMessage as createProviderFlexMessage } from "./send.js";
 
 describe("deliverLineAutoReply", () => {
@@ -101,21 +102,19 @@ describe("deliverLineAutoReply", () => {
     expect(result.visibleReplySent).toBe(true);
   });
 
-  it.each([
-    { name: "title", title: " ", address: "1 Main Street" },
-    { name: "address", title: "Meet here", address: " " },
-  ])("skips a direct location with a blank $name while delivering text", async (location) => {
+  it("delivers whatever the location builder returns, including its text degradation", async () => {
+    // A blank required field makes LINE reject the pin, and the builder answers
+    // with the sender's values as text. The reply must carry that, not drop it.
     const lineData = {
-      location: { ...location, latitude: 35.6895, longitude: 139.6917 },
+      location: { title: "Meet here", address: " ", latitude: 35.6895, longitude: 139.6917 },
     };
-    const createLocationMessage = vi.fn<LineAutoReplyDeps["createLocationMessage"]>((value) =>
-      value.title.trim() && value.address.trim()
-        ? {
-            type: "location" as const,
-            ...value,
-          }
-        : null,
-    );
+    const degraded = {
+      type: "text" as const,
+      text: "Meet here" + String.fromCharCode(10) + "35.6895, 139.6917",
+    };
+    // The real builder decides the degradation; injecting a stand-in here would
+    // only prove the stand-in was pushed.
+    const createLocationMessage = vi.fn(createRealLocationMessage);
     const { deps, replyMessageLine } = createDeps({ createLocationMessage });
 
     const result = await deliverLineAutoReply({
@@ -127,7 +126,8 @@ describe("deliverLineAutoReply", () => {
 
     expect(replyMessageLine).toHaveBeenCalledExactlyOnceWith(
       "token",
-      [{ type: "text", text: "Meet me there." }],
+      // No quick replies here, so the text leads and rich parts follow it.
+      [{ type: "text", text: "Meet me there." }, degraded],
       { cfg: LINE_TEST_CFG, accountId: "acc" },
     );
     expect(createLocationMessage).toHaveBeenCalledOnce();

--- a/extensions/line/src/auto-reply-delivery.ts
+++ b/extensions/line/src/auto-reply-delivery.ts
@@ -41,7 +41,7 @@ type LineAutoReplyDeps = {
     address: string;
     latitude: number;
     longitude: number;
-  }) => messagingApi.LocationMessage | null;
+  }) => messagingApi.LocationMessage | messagingApi.TextMessage;
   replyMessageLine: (
     replyToken: string,
     messages: messagingApi.Message[],
@@ -241,10 +241,7 @@ export async function deliverLineAutoReply(params: {
   }
 
   if (lineData.location) {
-    const locationMessage = deps.createLocationMessage(lineData.location);
-    if (locationMessage) {
-      richMessages.push(locationMessage);
-    }
+    richMessages.push(deps.createLocationMessage(lineData.location));
   }
 
   // Inbound auto-replies bypass the channel outbound adapter, so enforce the

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -220,7 +220,7 @@ describe("line outbound sendPayload", () => {
   it.each([
     { name: "title", title: " ", address: "1 Main Street" },
     { name: "address", title: "Meet here", address: " " },
-  ])("skips a direct location with a blank $name while delivering text", async (location) => {
+  ])("delivers a blank-$name location instead of dropping it", async (location) => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);
 
@@ -239,7 +239,13 @@ describe("line outbound sendPayload", () => {
       cfg: { channels: { line: {} } } as OpenClawConfig,
     });
 
-    expect(mocks.pushLocationMessage).not.toHaveBeenCalled();
+    // The pin LINE will not render still reaches the chat as the text it was
+    // made of; the builder owns that degradation, so delivery must not skip it.
+    expect(mocks.pushLocationMessage).toHaveBeenCalledWith(
+      "line:user:U123",
+      { ...location, latitude: 35.6895, longitude: 139.6917 },
+      expect.any(Object),
+    );
     expect(mocks.pushMessageLine).toHaveBeenCalledWith(
       "line:user:U123",
       "Meet me there.",
@@ -247,7 +253,7 @@ describe("line outbound sendPayload", () => {
     );
   });
 
-  it("omits an invalid direct location from the quick-reply inline batch", async () => {
+  it("keeps a degraded location in the quick-reply inline batch", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);
 
@@ -272,9 +278,18 @@ describe("line outbound sendPayload", () => {
       cfg: { channels: { line: {} } } as OpenClawConfig,
     });
 
-    expect(mocks.pushLocationMessage).not.toHaveBeenCalled();
-    expect(mocks.pushMessagesLine).not.toHaveBeenCalled();
-    expect(mocks.pushTextMessageWithQuickReplies).toHaveBeenCalledWith(
+    expect(mocks.pushMessagesLine).toHaveBeenCalledWith(
+      "line:user:U123",
+      [
+        expect.objectContaining({
+          type: "text",
+          text: "Meet here" + String.fromCharCode(10) + "35.6895, 139.6917",
+          quickReply: expect.any(Object),
+        }),
+      ],
+      expect.any(Object),
+    );
+    expect(mocks.pushTextMessageWithQuickReplies).not.toHaveBeenCalledWith(
       "line:user:U123",
       expect.stringContaining("Continue"),
       ["Continue"],

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -51,7 +51,6 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
     const lineRuntime = runtime.channel.line;
     const location = lineData.location;
     const locationMessage = location ? outboundRuntime.createLocationMessage(location) : null;
-    const validLocation = locationMessage ? location : undefined;
     const sendText = lineRuntime?.pushMessageLine ?? outboundRuntime.pushMessageLine;
     const sendBatch = lineRuntime?.pushMessagesLine ?? outboundRuntime.pushMessagesLine;
     const sendFlex = lineRuntime?.pushFlexMessage ?? outboundRuntime.pushFlexMessage;
@@ -217,9 +216,9 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         }
       }
 
-      if (validLocation) {
+      if (location) {
         await recordResult(
-          sendLocation(to, validLocation, {
+          sendLocation(to, location, {
             verbose: false,
             cfg,
             accountId: accountId ?? undefined,

--- a/extensions/line/src/send.location.test.ts
+++ b/extensions/line/src/send.location.test.ts
@@ -1,0 +1,52 @@
+// Line tests cover how an unrenderable location reaches the chat.
+import { describe, expect, it } from "vitest";
+import { createLocationMessage } from "./send.js";
+
+describe("createLocationMessage", () => {
+  it("keeps a renderable location as a pin", () => {
+    const message = createLocationMessage({
+      title: "Blue Bottle",
+      address: "1 Main Street",
+      latitude: 35.6895,
+      longitude: 139.6917,
+    });
+
+    expect(message).toEqual({
+      type: "location",
+      title: "Blue Bottle",
+      address: "1 Main Street",
+      latitude: 35.6895,
+      longitude: 139.6917,
+    });
+  });
+
+  it.each([
+    { name: "title", title: " ", address: "1 Main Street", kept: "1 Main Street" },
+    { name: "address", title: "Blue Bottle", address: " ", kept: "Blue Bottle" },
+  ])(
+    "delivers a blank-$name location as the values the sender wrote",
+    ({ title, address, kept }) => {
+      // LINE rejects the pin, but the sender's label and coordinates are still
+      // deliverable, so they must reach the chat instead of being dropped.
+      const message = createLocationMessage({
+        title,
+        address,
+        latitude: 35.6895,
+        longitude: 139.6917,
+      });
+
+      expect(message).toEqual({ type: "text", text: `${kept}\n35.6895, 139.6917` });
+    },
+  );
+
+  it("still delivers the coordinates when the sender left both labels blank", () => {
+    const message = createLocationMessage({
+      title: "  ",
+      address: "",
+      latitude: 35.6895,
+      longitude: 139.6917,
+    });
+
+    expect(message).toEqual({ type: "text", text: "35.6895, 139.6917" });
+  });
+});

--- a/extensions/line/src/send.location.test.ts
+++ b/extensions/line/src/send.location.test.ts
@@ -39,6 +39,22 @@ describe("createLocationMessage", () => {
     },
   );
 
+  it("caps an oversized label so the fallback stays inside LINE's text limit", () => {
+    // Nothing bounds the label at the schema, so an unbounded fallback would be
+    // rejected for length and lose the location exactly as before.
+    const message = createLocationMessage({
+      title: "A".repeat(6000),
+      address: " ",
+      latitude: 35.6895,
+      longitude: 139.6917,
+    });
+
+    expect(message.type).toBe("text");
+    const text = (message as { text: string }).text;
+    expect(text).toBe("A".repeat(100) + String.fromCharCode(10) + "35.6895, 139.6917");
+    expect(text.length).toBeLessThanOrEqual(5000);
+  });
+
   it("still delivers the coordinates when the sender left both labels blank", () => {
     const message = createLocationMessage({
       title: "  ",

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -37,6 +37,7 @@ const userProfileCache = new Map<
 const PROFILE_CACHE_TTL_MS = 5 * 60 * 1000;
 const PROFILE_CACHE_MAX_ENTRIES = 1000;
 const LINE_FLEX_ALT_TEXT_LIMIT = 1500;
+const LINE_LOCATION_LABEL_LIMIT = 100;
 
 function cacheUserProfile(
   userId: string,
@@ -261,7 +262,11 @@ function isValidLineLocation(location: LineLocation): boolean {
 // coordinates are always present, so the location degrades to the text it was
 // made of instead of vanishing from the reply.
 function locationTextFallback(location: LineLocation): TextMessage {
-  const authored = [location.title.trim(), location.address.trim()].filter(Boolean);
+  // The pin caps each label, and so must the fallback: an unbounded label would
+  // breach LINE's text limit and lose the location the same silent way.
+  const authored = [location.title, location.address]
+    .map((label) => truncateUtf16Safe(label.trim(), LINE_LOCATION_LABEL_LIMIT))
+    .filter(Boolean);
   return {
     type: "text",
     text: [...authored, `${location.latitude}, ${location.longitude}`].join("\n"),
@@ -274,8 +279,8 @@ export function createLocationMessage(location: LineLocation): LocationMessage |
   }
   return {
     type: "location",
-    title: truncateUtf16Safe(location.title, 100),
-    address: truncateUtf16Safe(location.address, 100),
+    title: truncateUtf16Safe(location.title, LINE_LOCATION_LABEL_LIMIT),
+    address: truncateUtf16Safe(location.address, LINE_LOCATION_LABEL_LIMIT),
     latitude: location.latitude,
     longitude: location.longitude,
   };

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -257,9 +257,20 @@ function isValidLineLocation(location: LineLocation): boolean {
   return location.title.trim().length > 0 && location.address.trim().length > 0;
 }
 
-export function createLocationMessage(location: LineLocation): LocationMessage | null {
+// A pin LINE will not render still carries the values the sender wrote, and the
+// coordinates are always present, so the location degrades to the text it was
+// made of instead of vanishing from the reply.
+function locationTextFallback(location: LineLocation): TextMessage {
+  const authored = [location.title.trim(), location.address.trim()].filter(Boolean);
+  return {
+    type: "text",
+    text: [...authored, `${location.latitude}, ${location.longitude}`].join("\n"),
+  };
+}
+
+export function createLocationMessage(location: LineLocation): LocationMessage | TextMessage {
   if (!isValidLineLocation(location)) {
-    return null;
+    return locationTextFallback(location);
   }
   return {
     type: "location",
@@ -528,11 +539,7 @@ export async function pushLocationMessage(
   location: LineLocation,
   opts: LinePushOpts,
 ): Promise<LineSendResult> {
-  const message = createLocationMessage(location);
-  if (!message) {
-    throw new Error("LINE location title and address must be non-empty");
-  }
-  return pushLineMessages(to, [message], opts, {
+  return pushLineMessages(to, [createLocationMessage(location)], opts, {
     verboseMessage: (chatId) => `line: pushed location to ${chatId}`,
   });
 }


### PR DESCRIPTION
## What Problem This Solves

When an agent sends a LINE location whose title or address is blank, the chat receives the reply without the pin and nobody is told anything was removed. The coordinates the sender supplied are discarded, the operator sees no log line, and the tool call reports success — the user simply never gets the place they asked for.

This is the residue of #118029. That report was about the blank field making LINE reject the whole reply; the fix stopped the rejection by filtering the location out before sending, which turned a loud failure into a silent one.

## Why This Change Was Made

The behavior contract this restores: a part of a message the sender authored must never vanish without a trace — if LINE cannot render it, the chat still gets what it was made of.

The location builder now answers with a text message carrying the sender's own values — whichever label is non-blank, plus the coordinates — instead of returning null. Both delivery paths (the push path and the reply-token path) build their location through that single builder, so both inherit the degradation, and the three call sites that used to skip a null result no longer have a branch to take.

The fallback carries the same per-label cap the pin already applies, named once and shared, so an unbounded label cannot push the degraded message past LINE's text limit and lose it the same way.

Boundaries: nothing is invented. The degraded text contains only values the sender supplied, so this does not decide on the author's behalf what a missing address should say. Validating `channelData` at the message-tool boundary was considered and rejected: `prepareSendPayload` runs only for tool sends, so the reply-token path would have kept the old behavior and the two paths would have diverged. A sibling of this bug — a template payload that LINE cannot render being dropped the same way — is fixed in #113366; this change does not touch that path.

## User Impact

A LINE user who asks for a place now receives it, as a pin when LINE can render one and as the place text plus coordinates when it cannot. Nothing changes for a location that was already valid.

## Evidence

**The Messaging API rejects the authored message, and the rejection is atomic.** Validated against a live channel with `validate/push`, which applies the same validation as `push` without delivering:

```
$ curl -X POST https://api.line.me/v2/bot/message/validate/push \
  -d '{"messages":[{"type":"location","title":"Meet here","address":" ","latitude":35.6895,"longitude":139.6917}]}'
HTTP 400
{"message":"The request body has 1 error(s)","details":[{"message":"May not be empty","property":"messages[0].address"}]}
```

The same location in a batch that also carries valid text takes the whole batch down, which is why the pin cannot simply be passed through and left to the provider:

```
$ curl ... -d '{"messages":[{"type":"text","text":"Meet me there."},{"type":"location","title":"Meet here","address":" ","latitude":35.6895,"longitude":139.6917}]}'
HTTP 400
{"message":"The request body has 1 error(s)","details":[{"message":"May not be empty","property":"messages[1].address"}]}
```

**Both degraded forms are deliverable**, including the case where the sender left both labels blank and only coordinates remain:

```
$ curl ... -d '{"messages":[{"type":"text","text":"Meet here\n35.6895, 139.6917"}]}'
HTTP 200 {}

$ curl ... -d '{"messages":[{"type":"text","text":"35.6895, 139.6917"}]}'
HTTP 200 {}
```

**The fallback stays inside the text limit.** Nothing bounds the labels at the schema, so the degraded message needed the pin's cap:

```
$ curl ... -d '{"messages":[{"type":"text","text":"<6000 chars>
35.6895, 139.6917"}]}'
HTTP 400
{"message":"The request body has 1 error(s)","details":[{"message":"Length must be between 0 and 5000","property":"messages[0].text"}]}

$ curl ... -d '{"messages":[{"type":"text","text":"<100 chars>
<100 chars>
35.6895, 139.6917"}]}'   # 219 chars, the longest the fallback can now produce
HTTP 200
```

**Red/green.** Reverting the three source files to their previous form while keeping the tests fails seven tests across both delivery paths:

```
$ pnpm exec vitest run --config test/vitest/vitest.extension-line.config.ts     extensions/line/src/send.location.test.ts     extensions/line/src/channel.sendPayload.test.ts     extensions/line/src/auto-reply-delivery.test.ts
 Test Files  3 failed (3)
      Tests  7 failed | 59 passed (66)

 × delivers a blank-'title' location as the values the sender wrote
 × delivers a blank-'address' location as the values the sender wrote
 × still delivers the coordinates when the sender left both labels blank
 × delivers whatever the location builder returns, including its text degradation
 × delivers a blank-'title' location instead of dropping it
 × delivers a blank-'address' location instead of dropping it
 × keeps a degraded location in the quick-reply inline batch
```

With the change applied, the extension suite runs clean apart from a pre-existing failure described below:

```
$ pnpm exec vitest run --config test/vitest/vitest.extension-line.config.ts
 Test Files  1 failed | 34 passed (35)
      Tests  17 failed | 504 passed | 1 skipped (522)
```

The builder owns the contract, so its coverage lives in the new `send.location.test.ts`: a renderable location stays a pin, a blank title or address degrades to the remaining label plus coordinates, both labels blank still delivers the coordinates, and an oversized label is capped before the join. The delivery suites assert that the builder's answer reaches the chat; the reply-token test drives the real builder rather than a stand-in, which is what makes it fail on revert.

Both typecheck lanes (`tsconfig.extensions.json`, `test/tsconfig/tsconfig.extensions.test.json`) and `oxfmt --check` pass on the touched files, and `oxlint` reports no findings on them.

Proof limitations: `pnpm lint:extensions` could not be run end to end on this Windows checkout — with a cold plugin SDK boundary cache it fails before linting for a reason unrelated to this change (fixed separately in #126274), so the touched files were linted with `oxlint` directly. On this machine `extensions/line/src/bot-message-context.test.ts` fails with a Windows file-lock error; it fails identically on `main` and this branch touches neither that file nor anything in its import closure.
