### PR TITLE
chore: remove final low-value test artifacts

### DIFF
--- a/src/boards/sqlite-board-codec.test.ts
+++ b/src/boards/sqlite-board-codec.test.ts
@@ -1,46 +1,14 @@
 import { describe, expect, it } from "vitest";
-import {
-  parseManifest,
-  serializeManifest,
-  updateManifestHeightMode,
-} from "./sqlite-board-codec.js";
+import { parseManifest } from "./sqlite-board-codec.js";
 
 describe("board widget manifest codec", () => {
-  it("round-trips presentation and height mode", () => {
-    const serialized = serializeManifest(undefined, "none", undefined, {
-      presentation: "full-bleed",
-      heightMode: "auto",
-    });
-    expect(parseManifest(serialized)).toMatchObject({
-      presentation: "full-bleed",
-      heightMode: "auto",
-    });
-    expect(parseManifest(updateManifestHeightMode(serialized, "fixed"))).toMatchObject({
-      presentation: "full-bleed",
-      heightMode: "fixed",
-    });
-  });
-
   it("ignores invalid persisted frame preferences", () => {
     expect(
       parseManifest(JSON.stringify({ presentation: "floating", heightMode: "elastic" })),
     ).toEqual({});
   });
 
-  it("round-trips explicit and generated name identity metadata", () => {
-    const serialized = serializeManifest(undefined, "none", undefined, undefined, {
-      kind: "generated",
-      source: "show_widget",
-      key: "a".repeat(64),
-    });
-    expect(parseManifest(serialized)).toMatchObject({
-      nameIdentity: { kind: "generated", source: "show_widget", key: "a".repeat(64) },
-    });
-    expect(
-      parseManifest(
-        serializeManifest(undefined, "none", undefined, undefined, { kind: "explicit" }),
-      ),
-    ).toMatchObject({ nameIdentity: { kind: "explicit" } });
+  it("flags invalid persisted generated name identity metadata", () => {
     expect(
       parseManifest(
         JSON.stringify({

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -5,8 +5,6 @@ import {
   createStatusReactionController,
   DEFAULT_EMOJIS,
   DEFAULT_TIMING,
-  CODING_TOOL_TOKENS,
-  WEB_TOOL_TOKENS,
   type StatusReactionAdapter,
 } from "./status-reactions.js";
 
@@ -111,18 +109,6 @@ function countCallsForEmoji(calls: Array<{ method: string; emoji: string }>, emo
   }
   return count;
 }
-function expectArrayContainsAll(values: readonly string[], expected: readonly string[]) {
-  expected.forEach((value) => {
-    expect(values).toContain(value);
-  });
-}
-
-function expectObjectHasKeys(value: Record<string, unknown>, keys: readonly string[]) {
-  keys.forEach((key) => {
-    expect(value).toHaveProperty(key);
-  });
-}
-
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
@@ -680,43 +666,5 @@ describe("createStatusReactionController", () => {
     await vi.runAllTimersAsync();
 
     expect(onError).toHaveBeenCalled();
-  });
-});
-
-describe("constants", () => {
-  it("should export CODING_TOOL_TOKENS", () => {
-    expectArrayContainsAll(CODING_TOOL_TOKENS, ["exec", "read", "write"]);
-  });
-
-  it("should export WEB_TOOL_TOKENS", () => {
-    expectArrayContainsAll(WEB_TOOL_TOKENS, ["web_search", "browser"]);
-  });
-
-  it("should export DEFAULT_EMOJIS with all required keys", () => {
-    expectObjectHasKeys(DEFAULT_EMOJIS, [
-      "queued",
-      "thinking",
-      "compacting",
-      "tool",
-      "coding",
-      "web",
-      "deploy",
-      "build",
-      "concierge",
-      "done",
-      "error",
-      "stallSoft",
-      "stallHard",
-    ]);
-  });
-
-  it("should export DEFAULT_TIMING with all required keys", () => {
-    expectObjectHasKeys(DEFAULT_TIMING, [
-      "debounceMs",
-      "stallSoftMs",
-      "stallHardMs",
-      "doneHoldMs",
-      "errorHoldMs",
-    ]);
   });
 });

--- a/src/channels/status-reactions.test.ts
+++ b/src/channels/status-reactions.test.ts
@@ -162,6 +162,8 @@ describe("resolveToolEmoji", () => {
     };
 
     expect(resolveToolEmoji("exec", emojis, overrides)).toBe("🧪");
+    expect(resolveToolEmoji("read", emojis, overrides)).toBe("🧪");
+    expect(resolveToolEmoji("write", emojis, overrides)).toBe("🧪");
     expect(resolveToolEmoji("web_search", emojis, overrides)).toBe("🛰️");
     expect(resolveToolEmoji("message", emojis, overrides)).toBe("🔧");
   });

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -2137,17 +2137,6 @@ describe("update-startup", () => {
     });
   });
 
-  it("scheduleGatewayUpdateCheck returns a cleanup function", () => {
-    mockPackageUpdateStatus("latest", "2.0.0");
-
-    const stop = scheduleGatewayUpdateCheck({
-      cfg: { update: { channel: "stable" } },
-      log: { info: vi.fn() },
-      isNixMode: false,
-    });
-    stop();
-  });
-
   it("schedules an initial and recurring 24-hour extended-stable hint check with cleanup", async () => {
     mockPackageUpdateStatus("extended-stable", "2.0.0");
     const previousNodeEnv = process.env.NODE_ENV;

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -42,7 +42,6 @@ import {
   delegationFailedBeforeRunning,
 } from "../../scripts/check-changed.mts";
 import { resolveOxfmtInvocation } from "../../scripts/format-docs.mts";
-import { isDirectRunPath } from "../../scripts/lib/direct-run.mjs";
 import { cleanupTempDirs, makeTempDir as makeTempRepoRoot } from "../helpers/temp-dir.js";
 
 const tempDirs: string[] = [];
@@ -220,23 +219,6 @@ afterEach(() => {
 });
 
 describe("scripts/changed-lanes", () => {
-  it("detects direct script execution from Windows argv paths", () => {
-    expect(
-      isDirectRunPath(
-        "C:\\repo\\scripts\\check-changed.mjs",
-        "c:\\repo\\scripts\\check-changed.mjs",
-        "win32",
-      ),
-    ).toBe(true);
-    expect(
-      isDirectRunPath(
-        "C:\\repo\\scripts\\changed-lanes.mjs",
-        "C:\\repo\\scripts\\check-changed.mjs",
-        "win32",
-      ),
-    ).toBe(false);
-  });
-
   it.each([
     {
       name: "prints changed lane help without treating --help as a changed path",


### PR DESCRIPTION
## What Problem This Solves

Removes four independently proven low-value test artifacts that duplicated stronger owner-boundary coverage or asserted self-generated implementation shapes.

## Why This Change Was Made

This is a test-only cleanup with zero production and test-support changes. It removes:

- status-reaction constant mirrors while retaining tool-emoji behavior, overrides, controller timing/default lifecycle, Slack lifecycle, and Plugin SDK placement coverage;
- a vacuous updater cleanup-function smoke while retaining recurring-stop, active-refresh abort, and Gateway cleanup ownership coverage;
- self-generated board codec round trips while retaining invalid persisted metadata validation plus store parity, close/reopen, and direct-SQLite identity coverage;
- a duplicate Windows direct-run helper test while retaining the canonical helper, executable guard, all-script, and Windows routing proof.

The malformed generated board identity case remains because it independently validates persisted hostile/legacy input. No behavior, malformed-input, public-contract, schema, protocol, changelog, or operator-state coverage was removed.

ClawSweeper's rank-up move is applied: `read` and `write` now have direct behavior-level assertions for the coding override path instead of relying on the deleted token-array mirror.

## User Impact

No user-visible behavior changes. The test suite has less duplicated, implementation-coupled maintenance surface while retaining the contracts that catch credible regressions.

Production LOC: +0/-0 (net 0) | Test support: +0/-0 (net 0) | Tests: +4/-115 (net -111)

## Evidence

- `node scripts/run-vitest.mjs src/channels/status-reactions.test.ts src/channels/status-reactions.slack-lifecycle.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts` — 3 files, 67 tests passed
- `node scripts/run-vitest.mjs src/infra/update-startup.test.ts src/gateway/server-startup-post-attach.test.ts` — 2 files, 154 tests passed
- `node scripts/run-vitest.mjs src/boards/sqlite-board-codec.test.ts src/boards/board-store.parity.test.ts src/boards/board-generated-identity.test.ts` — 3 files, 34 tests passed
- `node scripts/run-vitest.mjs test/scripts/changed-lanes.test.ts test/scripts/direct-run-entrypoints.test.ts` — 2 files, 181 tests passed
- `pnpm test:changed` — 4 shards, 270 tests passed
- `pnpm check:changed` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean before commit and after the ClawSweeper correction; no accepted/actionable findings
- `git diff --check` — passed
