### PR TITLE
fix(ui): show discovered models in new sessions

### DIFF
--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -75,7 +75,6 @@ suite.define(() => {
       const modelRequest = await gateway.waitForRequest("models.list");
       expect(modelRequest.params).toEqual({
         agentId: "main",
-        preparedOnly: true,
         view: "configured",
       });
 
@@ -139,7 +138,6 @@ suite.define(() => {
       for (const request of requests) {
         expect(request.params).toEqual({
           agentId: "main",
-          preparedOnly: true,
           view: "configured",
         });
       }

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -141,6 +141,33 @@ describe("new-session model runtime", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
   });
 
+  it("loads the configured catalog without prepared-only filtering", async () => {
+    const { context, request } = contextWith([
+      { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", provider: "google" },
+    ]);
+    const control = new NewSessionModelControl(() => undefined);
+
+    control.load(context, "main", true);
+
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        "models.list",
+        {
+          agentId: "main",
+          view: "configured",
+        },
+        { timeoutMs: 60_000 },
+      ),
+    );
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector(
+          '[data-chat-model-option="google/gemini-2.5-pro"]',
+        ),
+      ).not.toBeNull(),
+    );
+  });
+
   it("renders initial metadata loading without synthesizing the configured default", async () => {
     const pending = deferred<{ models: ModelCatalogEntry[] }>();
     const { context, request } = contextWith([]);

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -242,7 +242,7 @@ export class NewSessionModelControl {
       client,
       id: requestId,
     };
-    const cached = peekModels(client, { agentId, preparedOnly: true });
+    const cached = peekModels(client, { agentId });
     if (cached) {
       // Keep the complete picker stable while the automatic revalidation runs.
       // A failed refresh remains recorded but cannot displace usable options.
@@ -256,7 +256,6 @@ export class NewSessionModelControl {
 
     void revalidateModels(client, {
       agentId,
-      preparedOnly: true,
       startupRetryWindowMs: 60_000,
     }).then(
       (models) => {


### PR DESCRIPTION
Closes #124008

Depends on #125822. This PR is intentionally stacked on `fix/session-ui-state` so reviewers see only the focused follow-up. It should be retargeted and revalidated against `main` after #125822 lands.

## What Problem This Solves

Fixes an issue where users opening New Session could not select dynamically discovered provider models when those models were absent from the prepared startup catalog.

## Why This Change Was Made

New Session now uses the configured view already owned by #125822's shared model-catalog store. The change removes the consumer's prepared-only override while preserving the store's cache, timeout, startup retry, and stale-result fencing. The fast prepared-only `chat.metadata` path and provider policy are unchanged.

## User Impact

Dynamically discovered models from authenticated providers can appear in the New Session picker instead of being omitted until they are statically prepared.

## Evidence

- Failed-first on the earlier #125822 base: the New Session request included `preparedOnly: true`.
- `pnpm test ui/src/pages/new-session/model-control.test.ts` — 34/34 passed.
- `pnpm test ui/src/lib/chat/model-catalog-store.test.ts` — 9/9 passed.
- Exact-head regression confirms `models.list { agentId: "main", view: "configured" }` with the current 60-second timeout and renders a dynamically discovered provider model.
- `git diff --check upstream/pr-125822-current...HEAD` — passed.
- Scoped `openclaw-autoreview` on commit `325557c0e7cca7a7f8ced39a83194dc8883bf543` — zero findings; patch correct (0.99 confidence).
- Initial PR CI failed first in `new-session-page.model-catalog.e2e.test.ts` because two existing expectations still required `preparedOnly: true`; commit `640f9450a8a4870899a61999fe4c4760660e9021` removes only those stale expectations.
- Exact-head CI completed with 149 successful checks and 27 intentional skips. All Control UI and UI E2E jobs passed. The sole underlying failed job is unrelated `checks-node-compact-small-11`: 398/399 Gateway tests passed, while `agent retains image offload facts beside the claim-check line` expected a generated media URL containing a full UUID and received the existing sanitizer's masked `a4***` form. `openclaw/ci-gate` failed only as the aggregate result of that job.

Live Control UI + Gateway provider proof has not yet been run, so the current ceiling is focused test proof rather than runtime or end-to-end proof.

## Risk and Non-Goals

The patch changes one catalog-consumer option and adds one regression test. It does not change the Gateway metadata contract, provider discovery policy, shared-store ownership, dependencies, persistence, or fallback behavior. The integration risk is the explicit dependency on #125822 and its eventual rebase onto `main`.

## Agent Involvement

Codex prepared and tested the patch. A separate scoped OpenClaw autoreview inspected the exact production delta and its focused unit regression before publication; CI then exposed and drove the two-line E2E expectation correction.
