### PR TITLE
fix(ui): balance completed-work spacing

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -251,12 +251,39 @@ function activityAlignmentHtml() {
 function completedWorkSpacingHtml() {
   return `
     <div class="chat-thread" role="log">
-      <div class="chat-thread-inner">
-        <div class="chat-group user"><div class="chat-group-messages">Prompt</div></div>
-        <div class="chat-group tool chat-group--work">
-          <div class="chat-group-messages">Worked for 10s</div>
+      <div class="chat-thread-inner chat-thread-inner--virtual">
+        <div class="chat-virtual-sizer" style="height: 400px;">
+          <div class="chat-virtual-row" data-spacing-row="prompt">
+            <div class="chat-group user chat-group--with-footer">
+              <div class="chat-group-messages">
+                <div class="chat-bubble"><div class="chat-text">Prompt</div></div>
+              </div>
+              <div class="chat-group-footer"><span class="chat-sender-name">You</span></div>
+            </div>
+          </div>
+          <div class="chat-virtual-row" data-spacing-row="work">
+            <div class="chat-group tool chat-group--work">
+              <div class="chat-group-messages">
+                <div class="chat-activity-group chat-work-group">
+                  <button class="chat-inline-disclosure chat-activity-group__summary" type="button">
+                    <span class="chat-tool-disclosure__content">
+                      <span class="chat-activity-group__label">Worked for 10s</span>
+                    </span>
+                  </button>
+                  <div class="chat-work-group__separator"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="chat-virtual-row" data-spacing-row="reply">
+            <div class="chat-group assistant chat-group--with-footer">
+              <div class="chat-group-messages">
+                <div class="chat-bubble"><div class="chat-text">Final reply</div></div>
+              </div>
+              <div class="chat-group-footer"><span class="chat-sender-name">Assistant</span></div>
+            </div>
+          </div>
         </div>
-        <div class="chat-group assistant"><div class="chat-group-messages">Final reply</div></div>
       </div>
     </div>
   `;
@@ -610,14 +637,14 @@ async function openFixture(width: number, height: number, opts: ChatFixtureOptio
 async function openBrowserPage(
   width: number,
   height: number,
-  options: { isolated?: boolean } = {},
+  options: { hasTouch?: boolean; isolated?: boolean } = {},
 ): Promise<Page> {
   sharedBrowser ??= await chromium.launch({
     executablePath: chromiumExecutablePath,
     headless: true,
   });
   if (options.isolated) {
-    return await sharedBrowser.newPage({ viewport: { width, height } });
+    return await sharedBrowser.newPage({ hasTouch: options.hasTouch, viewport: { width, height } });
   }
   // Static setContent fixtures do not mutate context-owned storage or routes,
   // so they can share one context while their pages remain concurrent.
@@ -1240,26 +1267,40 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   });
 
   it.each([
-    { width: 430, expected: { marginTop: "4px", marginBottom: "10px" } },
-    { width: 1366, expected: { marginTop: "0px", marginBottom: "0px" } },
-  ])("balances completed-work spacing at $width px", async ({ width, expected }) => {
-    const page = await openBrowserPage(width, 720);
+    { label: "desktop", width: 1366, hasTouch: false, expectedGap: 4 },
+    { label: "narrow touch", width: 430, hasTouch: true, expectedGap: 18 },
+    { label: "wide touch", width: 1366, hasTouch: true, expectedGap: 18 },
+  ])("balances completed-work spacing on $label", async ({ width, hasTouch, expectedGap }) => {
+    const page = await openBrowserPage(width, 720, { hasTouch, isolated: true });
     try {
       await page.setContent(
         `<!doctype html><html><head><style>${readUiCss()}</style></head><body>${completedWorkSpacingHtml()}</body></html>`,
       );
+      await waitForLayoutSettled(page, "[data-spacing-row], .chat-group--work");
 
-      expect(
-        await page.locator(".chat-group--work").evaluate((element) => {
-          const style = getComputedStyle(element);
-          return {
-            marginTop: style.marginTop,
-            marginBottom: style.marginBottom,
-            paddingTop: style.paddingTop,
-            paddingBottom: style.paddingBottom,
-          };
-        }),
-      ).toEqual({ ...expected, paddingTop: "4px", paddingBottom: "4px" });
+      const gaps = await page.evaluate(() => {
+        const rows = [...document.querySelectorAll<HTMLElement>("[data-spacing-row]")];
+        let offset = 0;
+        for (const row of rows) {
+          row.style.transform = `translateY(${offset}px)`;
+          offset += row.getBoundingClientRect().height;
+        }
+        const prompt = document.querySelector<HTMLElement>(
+          '[data-spacing-row="prompt"] .chat-group',
+        )!;
+        const summary = document.querySelector<HTMLElement>(".chat-work-group > button")!;
+        const separator = document.querySelector<HTMLElement>(".chat-work-group__separator")!;
+        const reply = document.querySelector<HTMLElement>(
+          '[data-spacing-row="reply"] .chat-group',
+        )!;
+        return {
+          after: reply.getBoundingClientRect().top - separator.getBoundingClientRect().bottom,
+          before: summary.getBoundingClientRect().top - prompt.getBoundingClientRect().bottom,
+        };
+      });
+
+      expect(gaps.before).toBeCloseTo(expectedGap, 0);
+      expect(gaps.after).toBeCloseTo(expectedGap, 0);
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -248,6 +248,20 @@ function activityAlignmentHtml() {
   `;
 }
 
+function completedWorkSpacingHtml() {
+  return `
+    <div class="chat-thread" role="log">
+      <div class="chat-thread-inner">
+        <div class="chat-group user"><div class="chat-group-messages">Prompt</div></div>
+        <div class="chat-group tool chat-group--work">
+          <div class="chat-group-messages">Worked for 10s</div>
+        </div>
+        <div class="chat-group assistant"><div class="chat-group-messages">Final reply</div></div>
+      </div>
+    </div>
+  `;
+}
+
 function chatFooterActionsHtml() {
   return `
     <div class="chat-group-footer-actions">
@@ -1220,6 +1234,32 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         chevronGap: 5,
         tool: "text",
       });
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
+  it.each([
+    { width: 430, expected: { marginTop: "4px", marginBottom: "10px" } },
+    { width: 1366, expected: { marginTop: "0px", marginBottom: "0px" } },
+  ])("balances completed-work spacing at $width px", async ({ width, expected }) => {
+    const page = await openBrowserPage(width, 720);
+    try {
+      await page.setContent(
+        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>${completedWorkSpacingHtml()}</body></html>`,
+      );
+
+      expect(
+        await page.locator(".chat-group--work").evaluate((element) => {
+          const style = getComputedStyle(element);
+          return {
+            marginTop: style.marginTop,
+            marginBottom: style.marginBottom,
+            paddingTop: style.paddingTop,
+            paddingBottom: style.paddingBottom,
+          };
+        }),
+      ).toEqual({ ...expected, paddingTop: "4px", paddingBottom: "4px" });
     } finally {
       await closeBrowserPage(page);
     }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1267,9 +1267,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   });
 
   it.each([
-    { label: "desktop", width: 1366, hasTouch: false, expectedGap: 4 },
-    { label: "narrow touch", width: 430, hasTouch: true, expectedGap: 18 },
-    { label: "wide touch", width: 1366, hasTouch: true, expectedGap: 18 },
+    { label: "desktop", width: 1366, hasTouch: false, expectedGap: 9 },
+    { label: "narrow touch", width: 430, hasTouch: true, expectedGap: 23 },
+    { label: "wide touch", width: 1366, hasTouch: true, expectedGap: 23 },
   ])("balances completed-work spacing on $label", async ({ width, hasTouch, expectedGap }) => {
     const page = await openBrowserPage(width, 720, { hasTouch, isolated: true });
     try {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -734,6 +734,12 @@ img.chat-avatar.chat-avatar--logo {
     margin-bottom: 14px;
   }
 
+  .chat-group.chat-group--work {
+    margin-top: 4px;
+    margin-bottom: 10px;
+    padding-block: 0;
+  }
+
   .chat-group-footer {
     margin-top: 4px;
   }

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -737,7 +737,6 @@ img.chat-avatar.chat-avatar--logo {
   .chat-group.chat-group--work {
     margin-top: 4px;
     margin-bottom: 10px;
-    padding-block: 0;
   }
 
   .chat-group-footer {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -734,11 +734,6 @@ img.chat-avatar.chat-avatar--logo {
     margin-bottom: 14px;
   }
 
-  .chat-group.chat-group--work {
-    margin-top: 4px;
-    margin-bottom: 10px;
-  }
-
   .chat-group-footer {
     margin-top: 4px;
   }

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1130,10 +1130,10 @@
 }
 
 /* Completed-turn work rollup: slim "Worked for X" disclosure standing in for
-   the turn's intermediate tool/commentary groups. Sits snug above the final
-   reply, aligned with the message column via a gutter matching the avatar. */
+   the turn's intermediate tool/commentary groups. Redistribute its existing
+   gap so it separates from the prompt while staying grouped with the reply. */
 .chat-group--work {
-  padding-bottom: 8px;
+  padding-block: 4px;
 }
 
 .chat-work-group .chat-activity-group__label {

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1130,10 +1130,10 @@
 }
 
 /* Completed-turn work rollup: slim "Worked for X" disclosure standing in for
-   the turn's intermediate tool/commentary groups. Redistribute its existing
-   gap so it separates from the prompt while staying grouped with the reply. */
+   the turn's intermediate tool/commentary groups. Keep it equally separated
+   from the prompt and final reply. */
 .chat-group--work {
-  padding-block: 4px;
+  padding-block: 9px;
 }
 
 .chat-work-group .chat-activity-group__label {


### PR DESCRIPTION
Closes #126302

## What Problem This Solves

Fixes an issue where the Control UI's completed-turn "Worked for ..." disclosure sat too close to the preceding user bubble while leaving disproportionately more space before the assistant's final reply.

This spacing defect is independent of the disclosure flicker/scroll-anchor work in #126093 and #126272.

## Why This Change Was Made

The completed-work row now owns equal block-axis spacing around the disclosure. Desktop changes from `0px above / 8px below` to `9px / 9px`. Touch layouts combine the shared 14px row margin with the work-row padding to change from `14px / 22px` to `23px / 23px`.

The final values intentionally add 5px beyond the initially balanced design on each side. A redundant touch-specific margin override was removed, leaving one canonical spacing path. Tool-only turns remain unaffected because they do not render the completed-work rollup.

## User Impact

Completed turns scan more clearly: the work disclosure no longer crowds either neighboring message. Each completed-work rollup is intentionally 10px taller than the original layout.

Production delta: `+3/-3` (net 0). Test delta: `+83/-2` (net +81).

## Evidence

- Exact-head proof comment: https://github.com/openclaw/openclaw/pull/126303#issuecomment-5350600440
- AWS Crabbox final regression, format, and lint: https://crabbox.openclaw.ai/portal/runs/run_052ceff8f594 (`87/87`)
- AWS Crabbox exact-head screenshot run: https://crabbox.openclaw.ai/portal/runs/run_1cf90c7dfb0a (`87/87`)
- Pre-fix geometry proof: https://crabbox.openclaw.ai/portal/runs/run_4e15dde6a972
- Exact-head desktop and touch captures were opened and inspected.
- Direct final review: no blocking findings after stale wording was corrected.
