### PR TITLE
test: stabilize extension lifecycle isolation

### DIFF
--- a/extensions/imessage/src/approval-handler.runtime.test.ts
+++ b/extensions/imessage/src/approval-handler.runtime.test.ts
@@ -151,9 +151,15 @@ vi.mock("./actions.runtime.js", () => ({
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
   resolveApprovalOverGateway: approvalGatewayMock.resolveApprovalOverGateway,
 }));
-vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
-  isApprovalNotFoundError: approvalGatewayMock.isApprovalNotFoundError,
-}));
+vi.mock("openclaw/plugin-sdk/error-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/error-runtime")>(
+    "openclaw/plugin-sdk/error-runtime",
+  );
+  return {
+    ...actual,
+    isApprovalNotFoundError: approvalGatewayMock.isApprovalNotFoundError,
+  };
+});
 
 describe("imessageApprovalNativeRuntime", () => {
   it("renders shared reactions in pending exec approvals", async () => {

--- a/extensions/imessage/src/approval-polls.test.ts
+++ b/extensions/imessage/src/approval-polls.test.ts
@@ -17,9 +17,15 @@ const resolverMocks = vi.hoisted(() => ({
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
   resolveApprovalOverGateway: resolverMocks.resolveApprovalOverGateway,
 }));
-vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
-  isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
-}));
+vi.mock("openclaw/plugin-sdk/error-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/error-runtime")>(
+    "openclaw/plugin-sdk/error-runtime",
+  );
+  return {
+    ...actual,
+    isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+  };
+});
 
 const APPROVER = "+15551230000";
 const POLL_GUID = "poll-guid-1";

--- a/extensions/imessage/src/approval-reaction-poller.test.ts
+++ b/extensions/imessage/src/approval-reaction-poller.test.ts
@@ -20,9 +20,15 @@ const registerIMessageApprovalReactionTarget = (
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
   resolveApprovalOverGateway: resolverMocks.resolveApprovalOverGateway,
 }));
-vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
-  isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
-}));
+vi.mock("openclaw/plugin-sdk/error-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/error-runtime")>(
+    "openclaw/plugin-sdk/error-runtime",
+  );
+  return {
+    ...actual,
+    isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+  };
+});
 
 function createClient(request: ReturnType<typeof vi.fn>): IMessageRpcClient {
   return { request } as unknown as IMessageRpcClient;

--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -39,9 +39,15 @@ function registerIMessageApprovalReactionTarget(
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
   resolveApprovalOverGateway: resolverMocks.resolveApprovalOverGateway,
 }));
-vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
-  isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
-}));
+vi.mock("openclaw/plugin-sdk/error-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/error-runtime")>(
+    "openclaw/plugin-sdk/error-runtime",
+  );
+  return {
+    ...actual,
+    isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+  };
+});
 
 function requireExecApprovalMetadata(payload: ReplyPayload): Record<string, unknown> {
   const value = payload.channelData?.execApproval;

--- a/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
+++ b/extensions/matrix/src/matrix/monitor/reaction-events.test.ts
@@ -46,10 +46,16 @@ type MatrixReactionEvent = MatrixReactionParams["event"];
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
   resolveApprovalOverGateway: (...args: unknown[]) => resolveMatrixApproval(...args),
 }));
-vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
-  isApprovalNotFoundError: (err: unknown) =>
-    err instanceof Error && /unknown or expired approval id/i.test(err.message),
-}));
+vi.mock("openclaw/plugin-sdk/error-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/error-runtime")>(
+    "openclaw/plugin-sdk/error-runtime",
+  );
+  return {
+    ...actual,
+    isApprovalNotFoundError: (err: unknown) =>
+      err instanceof Error && /unknown or expired approval id/i.test(err.message),
+  };
+});
 
 vi.mock("../send.js", () => ({
   editMessageMatrix: (...args: unknown[]) => editMessageMatrix(...args),

--- a/extensions/msteams/src/reply-stream-controller.sdk.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.sdk.test.ts
@@ -10,6 +10,14 @@ type TeamsLoopbackRequest = {
   status: number;
 };
 
+function createOneShot() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 const acknowledgedPrefix = "a".repeat(4_000);
 const completeReply = `${acknowledgedPrefix}${"b".repeat(200)}`;
 const replacementReply = "provider-final replacement";
@@ -116,12 +124,18 @@ function createLoopbackController(scenario: string) {
     }
     return result.body;
   };
+  const firstAcknowledgement = createOneShot();
+  const firstFlushFailure = createOneShot();
   const logger = {
     child: vi.fn(),
     debug: vi.fn(),
-    error: vi.fn(),
+    error: vi.fn(() => firstFlushFailure.resolve()),
     info: vi.fn(),
-    warn: vi.fn(),
+    warn: vi.fn(() => {
+      if (scenario.startsWith("cancel")) {
+        firstFlushFailure.resolve();
+      }
+    }),
   };
   logger.child.mockReturnValue(logger);
   const stream = new HttpStream(
@@ -146,6 +160,7 @@ function createLoopbackController(scenario: string) {
   const acknowledgements: Array<{ id: string; text: string }> = [];
   stream.events.on("chunk", (activity) => {
     acknowledgements.push({ id: activity.id, text: activity.text ?? "" });
+    firstAcknowledgement.resolve();
   });
   const controller = createTeamsReplyStreamController({
     allowProviderPreview: true,
@@ -153,30 +168,34 @@ function createLoopbackController(scenario: string) {
     context: { activity: { type: "message" }, stream } as never,
     feedbackLoopEnabled: false,
   });
-  return { acknowledgements, controller, logger, stream };
+  return {
+    acknowledgements,
+    controller,
+    firstAcknowledgement: firstAcknowledgement.promise,
+    firstFlushFailure: firstFlushFailure.promise,
+    logger,
+    stream,
+  };
 }
 
 describe("Microsoft Teams SDK acknowledged stream fallback", () => {
   it("redelivers only text not acknowledged by the real Teams SDK and HTTP provider", async () => {
-    const { acknowledgements, controller, logger } = createLoopbackController("size-limit");
+    const { acknowledgements, controller, firstAcknowledgement, firstFlushFailure, logger } =
+      createLoopbackController("size-limit");
 
     controller.onPartialReply({ text: acknowledgedPrefix });
-    await vi.waitFor(() => {
-      expect(logger.error).not.toHaveBeenCalled();
-      expect(acknowledgements).toEqual([{ id: "stream-size-limit", text: acknowledgedPrefix }]);
-    });
+    await firstAcknowledgement;
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(acknowledgements).toEqual([{ id: "stream-size-limit", text: acknowledgedPrefix }]);
 
     controller.onPartialReply({ text: completeReply });
-    await vi.waitFor(() => {
-      expect(
-        requests.filter(
-          (request) =>
-            request.scenario === "size-limit" &&
-            request.type === "typing" &&
-            request.status === 403,
-        ),
-      ).toHaveLength(1);
-    });
+    await firstFlushFailure;
+    expect(
+      requests.filter(
+        (request) =>
+          request.scenario === "size-limit" && request.type === "typing" && request.status === 403,
+      ),
+    ).toHaveLength(1);
     expect(acknowledgements).toEqual([{ id: "stream-size-limit", text: acknowledgedPrefix }]);
     expect(controller.preparePayload({ text: completeReply })).toBeUndefined();
 
@@ -197,30 +216,33 @@ describe("Microsoft Teams SDK acknowledged stream fallback", () => {
   });
 
   it("never acknowledges a Teams HTTP request rejected before delivery", async () => {
-    const { acknowledgements, controller, logger } = createLoopbackController("no-ack");
+    const { acknowledgements, controller, firstFlushFailure } = createLoopbackController("no-ack");
 
     controller.onPartialReply({ text: acknowledgedPrefix });
-    await vi.waitFor(() => {
-      expect(logger.error).toHaveBeenCalled();
-      expect(requests.filter((request) => request.scenario === "no-ack")).toHaveLength(1);
-    });
+    await firstFlushFailure;
 
     expect(acknowledgements).toEqual([]);
     expect(requests.find((request) => request.scenario === "no-ack")?.status).toBe(403);
   });
 
   it("honors a real Teams HTTP cancellation without redelivering the remaining text", async () => {
-    const { acknowledgements, controller, logger, stream } = createLoopbackController("cancel");
+    const {
+      acknowledgements,
+      controller,
+      firstAcknowledgement,
+      firstFlushFailure,
+      logger,
+      stream,
+    } = createLoopbackController("cancel");
 
     controller.onPartialReply({ text: acknowledgedPrefix });
-    await vi.waitFor(() => {
-      expect(logger.error).not.toHaveBeenCalled();
-      expect(acknowledgements).toEqual([{ id: "stream-cancel", text: acknowledgedPrefix }]);
-    });
+    await firstAcknowledgement;
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(acknowledgements).toEqual([{ id: "stream-cancel", text: acknowledgedPrefix }]);
     controller.onPartialReply({ text: completeReply });
-    await vi.waitFor(() => {
-      expect(stream.canceled).toBe(true);
-    });
+    await firstFlushFailure;
+    await stream.close();
+    expect(stream.canceled).toBe(true);
 
     expect(controller.preparePayload({ text: completeReply })).toBeUndefined();
     await expect(controller.finalize()).resolves.toEqual({
@@ -232,13 +254,13 @@ describe("Microsoft Teams SDK acknowledged stream fallback", () => {
   });
 
   it("replaces a divergent preview through the same real Teams stream", async () => {
-    const { acknowledgements, controller, logger } = createLoopbackController("replacement");
+    const { acknowledgements, controller, firstAcknowledgement, logger } =
+      createLoopbackController("replacement");
 
     controller.onPartialReply({ text: acknowledgedPrefix });
-    await vi.waitFor(() => {
-      expect(logger.error).not.toHaveBeenCalled();
-      expect(acknowledgements).toEqual([{ id: "stream-replacement", text: acknowledgedPrefix }]);
-    });
+    await firstAcknowledgement;
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(acknowledgements).toEqual([{ id: "stream-replacement", text: acknowledgedPrefix }]);
 
     controller.onPartialReply({ text: replacementReply });
     expect(
@@ -267,16 +289,15 @@ describe("Microsoft Teams SDK acknowledged stream fallback", () => {
   });
 
   it("detects Stop while replacing a divergent preview and suppresses the final", async () => {
-    const { acknowledgements, controller, logger, stream } =
+    const { acknowledgements, controller, firstAcknowledgement, logger, stream } =
       createLoopbackController("cancel-replacement");
 
     controller.onPartialReply({ text: acknowledgedPrefix });
-    await vi.waitFor(() => {
-      expect(logger.error).not.toHaveBeenCalled();
-      expect(acknowledgements).toEqual([
-        { id: "stream-cancel-replacement", text: acknowledgedPrefix },
-      ]);
-    });
+    await firstAcknowledgement;
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(acknowledgements).toEqual([
+      { id: "stream-cancel-replacement", text: acknowledgedPrefix },
+    ]);
 
     controller.onPartialReply({ text: replacementReply });
     expect(

--- a/extensions/signal/src/approval-reactions.test.ts
+++ b/extensions/signal/src/approval-reactions.test.ts
@@ -23,9 +23,15 @@ const resolverMocks = vi.hoisted(() => ({
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
   resolveApprovalOverGateway: resolverMocks.resolveSignalApproval,
 }));
-vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
-  isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
-}));
+vi.mock("openclaw/plugin-sdk/error-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/error-runtime")>(
+    "openclaw/plugin-sdk/error-runtime",
+  );
+  return {
+    ...actual,
+    isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+  };
+});
 
 const approvalRoute = {
   deliveryMode: "session" as const,

--- a/extensions/whatsapp/src/approval-reactions.test.ts
+++ b/extensions/whatsapp/src/approval-reactions.test.ts
@@ -21,9 +21,15 @@ const resolverMocks = vi.hoisted(() => ({
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
   resolveApprovalOverGateway: resolverMocks.resolveWhatsAppApproval,
 }));
-vi.mock("openclaw/plugin-sdk/error-runtime", () => ({
-  isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
-}));
+vi.mock("openclaw/plugin-sdk/error-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/error-runtime")>(
+    "openclaw/plugin-sdk/error-runtime",
+  );
+  return {
+    ...actual,
+    isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+  };
+});
 
 function approvalConfig(allowFrom: string[]) {
   return {


### PR DESCRIPTION
AI-assisted: Yes (Codex).

## What Problem This Solves

Fixes two test-lifecycle failures that made otherwise healthy extension CI nondeterministic under the repository's shared `isolate: false` Vitest workers.

The Microsoft Teams real-SDK stream tests polled for asynchronous provider delivery with Vitest's default one-second `vi.waitFor` timeout. On the two-CPU runner used by `checks-node-changed-extensions-config-35`, all five cases reached that timeout before the real loopback provider and Teams SDK emitted their authoritative result.

Separately, seven approval tests in WhatsApp, Signal, Matrix, and iMessage replaced the entire `openclaw/plugin-sdk/error-runtime` module while overriding only `isApprovalNotFoundError`. In a shared worker, that removed `PlatformMessageNotDispatchedError` from later consumers and could crash an unrelated Teams `instanceof` check. This second failure was reproduced locally from the exact CI shard composition after the timing failure was removed; it was not present in the public Actions log because the five Teams polling assertions failed first.

## Why This Change Was Made

The Teams tests now wait on narrow one-shot promises resolved by the first real Teams SDK `chunk` acknowledgement and the first SDK flush failure or cancellation warning. The real loopback HTTP provider and real Teams SDK remain in the test; no sleep, retry, widened timeout, or production path was added.

The approval tests now import and spread the real error-runtime module, overriding only the predicate each test owns. Every other runtime export keeps its canonical identity under non-isolated execution.

## User Impact

There is no production behavior change. Maintainers get deterministic extension CI without hiding failures or weakening the real SDK and cross-extension coverage.

## Evidence

- Original opening-head failure: CI run https://github.com/openclaw/openclaw/actions/runs/32234170510, job https://github.com/openclaw/openclaw/actions/runs/32234170510/job/96010527509. `reply-stream-controller.sdk.test.ts` failed 5/5 cases at 1002–1007 ms.
- Repeated exact-head failure: CI run https://github.com/openclaw/openclaw/actions/runs/32242587238, job https://github.com/openclaw/openclaw/actions/runs/32242587238/job/96036342873. The job reported two CPUs and failed the same 5/5 cases at 1003–1011 ms.
- Dependency contract: the installed Vitest implementation defaults `vi.waitFor` to a 1000 ms timeout and 50 ms interval; the installed Teams SDK emits `chunk` only after its provider request succeeds and records terminal flush/cancellation through the logger path used by these one-shots.
- Focused final-head proof: the eight changed tests passed 8 files / 157 tests.
- Teams stress proof before publication: 10 consecutive focused runs passed, 50/50 tests.
- Exact clean-runner-equivalent shard on final head: two workers, `changed-extensions-config-35`, 91 files / 1,433 tests passed.
- `OPENCLAW_TEST_PROJECTS_TIMINGS=0 pnpm test:changed`: 8 files / 157 tests passed.
- `pnpm check:changed`: passed all selected extension-test checks.
- `git diff --check origin/main...HEAD`: passed.
- Fresh final-head P1 Codex autoreview: no accepted/actionable findings.
- Production LOC: +0/-0. Tests: +128/-65.
- No release, publish, deploy, version, changelog, schema, protocol, product config, or Plugin SDK change.
