### PR TITLE
chore: remove moving-tip test redundancies

### DIFF
--- a/extensions/browser/src/browser/proxy-files.test.ts
+++ b/extensions/browser/src/browser/proxy-files.test.ts
@@ -250,23 +250,6 @@ describe("persistBrowserProxyResultFiles", () => {
     ).rejects.toHaveProperty("code", "ENOENT");
   });
 
-  it("maps repeated result references from one payload", async () => {
-    const sourcePath = "/node/repeated.png";
-    const result = {
-      path: sourcePath,
-      download: { path: sourcePath },
-      downloads: [{ path: sourcePath }],
-    };
-
-    await persistBrowserProxyResultFiles(result, [
-      { path: sourcePath, base64: Buffer.from("same file").toString("base64") },
-    ]);
-
-    expect(result.path).not.toBe(sourcePath);
-    expect(result.download.path).toBe(result.path);
-    expect(result.downloads[0]?.path).toBe(result.path);
-  });
-
   it("rewrites a complete file mapping without traversing nested page data", async () => {
     const result = {
       ok: true,

--- a/src/agents/worktrees/service.canonical-paths.test.ts
+++ b/src/agents/worktrees/service.canonical-paths.test.ts
@@ -77,66 +77,59 @@ describe("ManagedWorktreeService canonical paths", () => {
     expect(await fs.readFile(path.join(restored.path, "README.md"), "utf8")).toBe("base\n");
   });
 
-  it.each([
-    { label: "normal", allowSnapshotLoss: false },
-    { label: "forced", allowSnapshotLoss: true },
-  ])(
-    "repairs a $label removal to the live checkout repository before snapshotting",
-    async ({ label, allowSnapshotLoss }) => {
-      const canonicalLiveRepo = await cloneRepository(`live-${label}`);
-      const liveIdentity = await service.resolveRepositoryIdentity(canonicalLiveRepo);
-      const staleIdentity = await service.resolveRepositoryIdentity(repo);
-      const created = await service.create({
-        repoRoot: canonicalLiveRepo,
-        name: `repository-rebind-${label}`,
-        baseRef: "HEAD",
-        ownerKind: "session",
-        ownerId: `agent:main:${label}`,
-      });
-      await fs.writeFile(path.join(created.path, "README.md"), `${label} tracked change\n`);
-      await fs.writeFile(path.join(created.path, "untracked.txt"), `${label} untracked change\n`);
-      const staleHead = await git(repo, "rev-parse", "HEAD");
-      const snapshotRef = `refs/openclaw/snapshots/${created.id}`;
-      await git(repo, "branch", created.branch, staleHead);
-      await git(repo, "update-ref", snapshotRef, staleHead);
-      openOpenClawStateDatabase({ env })
-        .db.prepare("UPDATE worktrees SET repo_root = ?, repo_fingerprint = ? WHERE id = ?")
-        .run(staleIdentity.repoRoot, staleIdentity.fingerprint, created.id);
+  it("repairs removal to the live checkout repository before snapshotting", async () => {
+    const canonicalLiveRepo = await cloneRepository("live-normal");
+    const liveIdentity = await service.resolveRepositoryIdentity(canonicalLiveRepo);
+    const staleIdentity = await service.resolveRepositoryIdentity(repo);
+    const created = await service.create({
+      repoRoot: canonicalLiveRepo,
+      name: "repository-rebind-normal",
+      baseRef: "HEAD",
+      ownerKind: "session",
+      ownerId: "agent:main:normal",
+    });
+    await fs.writeFile(path.join(created.path, "README.md"), "normal tracked change\n");
+    await fs.writeFile(path.join(created.path, "untracked.txt"), "normal untracked change\n");
+    const staleHead = await git(repo, "rev-parse", "HEAD");
+    const snapshotRef = `refs/openclaw/snapshots/${created.id}`;
+    await git(repo, "branch", created.branch, staleHead);
+    await git(repo, "update-ref", snapshotRef, staleHead);
+    openOpenClawStateDatabase({ env })
+      .db.prepare("UPDATE worktrees SET repo_root = ?, repo_fingerprint = ? WHERE id = ?")
+      .run(staleIdentity.repoRoot, staleIdentity.fingerprint, created.id);
 
-      const removed = await service.remove({
-        id: created.id,
-        reason: "repository-rebind",
-        allowSnapshotLoss,
-      });
+    const removed = await service.remove({
+      id: created.id,
+      reason: "repository-rebind",
+    });
 
-      expect(removed).toEqual({ removed: true, snapshotRef });
-      expect(getRegistryWorktree(env, created.id)).toMatchObject({
-        repoRoot: liveIdentity.repoRoot,
-        repoFingerprint: liveIdentity.fingerprint,
-        path: created.path,
-        branch: created.branch,
-        baseRef: created.baseRef,
-        ownerKind: "session",
-        ownerId: `agent:main:${label}`,
-        snapshotRef,
-      });
-      expect(await git(canonicalLiveRepo, "show-ref", "--verify", snapshotRef)).not.toBe("");
-      expect(await git(canonicalLiveRepo, "branch", "--list", created.branch)).toBe("");
-      expect(await git(repo, "rev-parse", snapshotRef)).toBe(staleHead);
-      expect(await git(repo, "rev-parse", created.branch)).toBe(staleHead);
+    expect(removed).toEqual({ removed: true, snapshotRef });
+    expect(getRegistryWorktree(env, created.id)).toMatchObject({
+      repoRoot: liveIdentity.repoRoot,
+      repoFingerprint: liveIdentity.fingerprint,
+      path: created.path,
+      branch: created.branch,
+      baseRef: created.baseRef,
+      ownerKind: "session",
+      ownerId: "agent:main:normal",
+      snapshotRef,
+    });
+    expect(await git(canonicalLiveRepo, "show-ref", "--verify", snapshotRef)).not.toBe("");
+    expect(await git(canonicalLiveRepo, "branch", "--list", created.branch)).toBe("");
+    expect(await git(repo, "rev-parse", snapshotRef)).toBe(staleHead);
+    expect(await git(repo, "rev-parse", created.branch)).toBe(staleHead);
 
-      const restored = await service.restore({ id: created.id });
-      expect(restored.repoRoot).toBe(liveIdentity.repoRoot);
-      expect(restored.path).toBe(created.path);
-      expect(await git(restored.path, "branch", "--show-current")).toBe(created.branch);
-      expect(await fs.readFile(path.join(restored.path, "README.md"), "utf8")).toBe(
-        `${label} tracked change\n`,
-      );
-      expect(await fs.readFile(path.join(restored.path, "untracked.txt"), "utf8")).toBe(
-        `${label} untracked change\n`,
-      );
-    },
-  );
+    const restored = await service.restore({ id: created.id });
+    expect(restored.repoRoot).toBe(liveIdentity.repoRoot);
+    expect(restored.path).toBe(created.path);
+    expect(await git(restored.path, "branch", "--show-current")).toBe(created.branch);
+    expect(await fs.readFile(path.join(restored.path, "README.md"), "utf8")).toBe(
+      "normal tracked change\n",
+    );
+    expect(await fs.readFile(path.join(restored.path, "untracked.txt"), "utf8")).toBe(
+      "normal untracked change\n",
+    );
+  });
 
   it("rejects a live checkout from a different-origin repository before mutation", async () => {
     const differentOrigin = path.join(root, "different-origin.git");

--- a/ui/src/app/browser.test.ts
+++ b/ui/src/app/browser.test.ts
@@ -7,12 +7,6 @@ afterEach(() => {
 });
 
 describe("Control UI route and resource bases", () => {
-  it("keeps a root resource mount separate from an inferred route namespace", () => {
-    document.documentElement.setAttribute(CONTROL_UI_BASE_PATH_ATTRIBUTE, "");
-
-    expect(resolveControlUiPaths("/__openclaw__/new")).toEqual(["/__openclaw__", ""]);
-  });
-
   it("uses a configured Gateway mount for both routes and resources", () => {
     document.documentElement.setAttribute(CONTROL_UI_BASE_PATH_ATTRIBUTE, "/openclaw");
 


### PR DESCRIPTION
## What Problem This Solves

Three tests added after the previous audit repeated stronger coverage in the same owner boundaries. They increased suite maintenance and execution without protecting an independent regression.

## Why This Change Was Made

This removes the duplicate browser proxy and Control UI helper tests, then collapses the worktree repository-rebind matrix to its meaningful normal path. The retained tests still cover complete browser file mapping and repeated references, the real Control UI bootstrap/router flow, and snapshot-loss behavior when snapshotting actually fails.

Production LOC: +0/-0 (net 0) | Test support: +0/-0 (net 0) | Tests: +52/-82 (net -30; additions are the dedented one-row worktree test with fixed fixture names)

## User Impact

No user-visible behavior changes. The test suite is smaller while retaining the stronger boundary-level proofs.

AI-assisted; the implementation and retained coverage were inspected directly.

## Evidence

- `pnpm test extensions/browser/src/browser/proxy-files.test.ts extensions/browser/src/browser-node-proxy.test.ts extensions/browser/src/gateway/browser-request.profile-from-body.test.ts` — 3 files, 64 tests passed
- `pnpm test ui/src/app/browser.test.ts ui/src/app/bootstrap.test.ts ui/src/app/public-assets.test.ts` — 3 files, 51 tests passed
- `pnpm test src/agents/worktrees/service.canonical-paths.test.ts src/agents/worktrees/service.remove-lease.test.ts src/agents/worktrees/registry.test.ts` — 3 files, 14 tests passed
- `pnpm test:changed` — 3 shards, 26 tests passed
- `pnpm check:changed` — passed
- `git diff --check` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings
