### PR TITLE
fix(agents): prevent aborted steers from being queued

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-queue-message.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-queue-message.ts
@@ -318,9 +318,11 @@ async function steerAndWaitForTranscriptCommit(
     );
     function onAbort() {
       abortRequested = true;
-      if (accepted) {
-        rejectAfterCancellation("queued steering message was cancelled before delivery");
+      if (!accepted) {
+        rejectBeforeAcceptance("queued steering message was cancelled before acceptance");
+        return;
       }
+      rejectAfterCancellation("queued steering message was cancelled before delivery");
     }
     abortSignal?.addEventListener("abort", onAbort, { once: true });
   });

--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -348,6 +348,49 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     }
   });
 
+  it("fences an aborted steer before delayed preparation can enqueue it", async () => {
+    let releasePreparation!: () => void;
+    const preparation = new Promise<void>((resolve) => {
+      releasePreparation = resolve;
+    });
+    let preparationStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      preparationStarted = resolve;
+    });
+    let enqueued = false;
+    const onQueueAccepted = vi.fn();
+    const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
+      steer: async (_text, _images, _recorder, _media, _imageOrder, _identity, canInject) => {
+        preparationStarted();
+        await preparation;
+        if (canInject && !canInject()) {
+          throw new Error("active session is finalizing");
+        }
+        enqueued = true;
+      },
+      subscribe: () => () => {},
+    };
+    const controller = new AbortController();
+    const wait = steerActiveSessionWithOptionalDeliveryWait(activeSession, "delayed steer", {
+      abortSignal: controller.signal,
+      deliveryTimeoutMs: 10_000,
+      onQueueAccepted,
+      waitForTranscriptCommit: true,
+    });
+    const rejection = expect(wait).rejects.toThrow(
+      "queued steering message was cancelled before acceptance",
+    );
+
+    await started;
+    controller.abort();
+    releasePreparation();
+
+    await rejection;
+    expect(enqueued).toBe(false);
+    expect(onQueueAccepted).toHaveBeenCalledOnce();
+    expect(onQueueAccepted).toHaveBeenCalledWith(false);
+  });
+
   it("matches identical steering text by stable queue identity", async () => {
     let emit!: (event: unknown) => void;
     const first = {


### PR DESCRIPTION
Related: #126291

## What Problem This Solves

Fixes an issue where a shared steering follow-up aborted during delayed transcript preparation could still be accepted, enqueued, and persisted after cancellation. #126291 fixed direct `sessions.steer` admission, but the embedded follow-up adoption path left its acceptance gate open until preparation completed.

## Why This Change Was Made

Pre-acceptance abort now uses the existing `rejectBeforeAcceptance` owner path, which closes the acceptance gate before delayed preparation can inject the message and reports `onQueueAccepted(false)`. Cancellation after acceptance keeps the existing exact queued-message retirement path.

This is an AI-assisted Auto QA repair. It changes no protocol, config, storage/schema, plugin SDK, authentication, or replay contract.

## User Impact

Cancelled steering follow-ups can no longer appear later in the transcript when cancellation races with asynchronous preparation. Already accepted steers retain their existing cancellation behavior.

## Evidence

- Current-main reproduction before the fix observed `acceptance=true`, `enqueued=1`, and `committed=1` after aborting during delayed preparation.
- The new regression delays preparation, aborts, releases preparation, and verifies no enqueue plus `onQueueAccepted(false)`.
- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts` — 16/16 passed.
- Focused sibling validation and seven targeted Gateway tests passed; `check:changed`, formatting, types, lint, and architecture checks were green.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --max-priority P1` — clean, no accepted/actionable findings.
- Production: +4/-2 (net +2). Tests: +43/-0.

No live-channel proof was obtained. This is a deterministic embedded-runner acceptance race covered at its owner boundary; exact-head CI remains the merge gate.
