### PR TITLE
feat(config): allow strict runtime reads to skip observation

### DIFF
--- a/src/config/io.runtime-observe.test.ts
+++ b/src/config/io.runtime-observe.test.ts
@@ -1,0 +1,60 @@
+// Verifies strict runtime config reads can opt out of config-health observation.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { getRuntimeConfig, loadConfig } from "./config.js";
+import { withTempHome, writeOpenClawConfig } from "./test-helpers.js";
+
+describe("runtime config observation", () => {
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("skips observation on request while preserving materialization and the default", async () => {
+    await withTempHome(async (home) => {
+      const stateDir = path.join(home, "state-root");
+      const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+      const configPath = await writeOpenClawConfig(home, { gateway: { mode: "local" } });
+
+      await withEnvAsync(
+        { OPENCLAW_CONFIG_PATH: configPath, OPENCLAW_STATE_DIR: stateDir },
+        async () => {
+          const loaded = loadConfig({ observe: false, pin: false });
+          const runtime = getRuntimeConfig({ observe: false, pin: false });
+
+          expect(loaded.agents?.defaults?.compaction?.mode).toBe("safeguard");
+          expect(runtime.agents?.defaults?.compaction?.mode).toBe("safeguard");
+          await expect(fs.stat(databasePath)).rejects.toMatchObject({ code: "ENOENT" });
+
+          expect(loadConfig({ pin: false }).gateway?.mode).toBe("local");
+          await expect(fs.stat(databasePath)).resolves.toBeDefined();
+        },
+      );
+    });
+  });
+
+  it("keeps strict validation enabled when observation is disabled", async () => {
+    await withTempHome(async (home) => {
+      const stateDir = path.join(home, "state-root");
+      const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+      const configPath = await writeOpenClawConfig(home, { gateway: { port: "invalid" } });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        await withEnvAsync(
+          { OPENCLAW_CONFIG_PATH: configPath, OPENCLAW_STATE_DIR: stateDir },
+          async () => {
+            expect(() => loadConfig({ observe: false, pin: false })).toThrow(
+              expect.objectContaining({ code: "INVALID_CONFIG" }),
+            );
+            await expect(fs.stat(databasePath)).rejects.toMatchObject({ code: "ENOENT" });
+          },
+        );
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+  });
+});

--- a/src/config/io.runtime.ts
+++ b/src/config/io.runtime.ts
@@ -87,11 +87,13 @@ export function loadConfig(options?: {
   skipPluginValidation?: boolean;
   pin?: boolean;
   skipShellEnvFallback?: boolean;
+  observe?: boolean;
 }): OpenClawConfig {
   const loadFresh = () =>
     createConfigIO({
       ...(options?.skipPluginValidation ? { pluginValidation: "skip" as const } : {}),
       ...(options?.skipShellEnvFallback ? { shellEnvFallback: "defer" as const } : {}),
+      ...(options?.observe === false ? { observe: false } : {}),
     }).loadConfig();
   return options?.pin === false ? loadFresh() : loadPinnedRuntimeConfig(loadFresh);
 }
@@ -100,6 +102,7 @@ export function getRuntimeConfig(options?: {
   skipPluginValidation?: boolean;
   pin?: boolean;
   skipShellEnvFallback?: boolean;
+  observe?: boolean;
 }): OpenClawConfig {
   return loadConfig(options);
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where callers that need a strictly validated, fully materialized runtime configuration cannot suppress config-health observation. The best-effort config APIs already expose an observation opt-out, but the strict `loadConfig` / `getRuntimeConfig` APIs always observe and can therefore open the shared state database even when a caller only needs an effective configuration snapshot.

## Why This Change Was Made

This adds the same optional `observe` control to the two strict public runtime-config wrappers and forwards an explicit `false` through the existing `createConfigIO` observation seam. The default remains unchanged: omitted or `true` still observes, including the existing suspicious-config recovery behavior.

Strict schema and plugin validation, runtime materialization, pinning, shell-environment fallback, and all existing caller defaults remain unchanged.

## User Impact

Callers can use `loadConfig({ observe: false })` or `getRuntimeConfig({ observe: false })` when they need strict effective configuration without config-health persistence or shared-state database work. Existing callers see no behavior change.

This PR is AI-assisted; the implementation and validation results were reviewed before submission.

## Evidence

Base: `openclaw/openclaw@627084304a9167544badaf6902db2720fd9f7859`

- Before the production change, `pnpm test src/config/io.runtime-observe.test.ts` failed both regression cases because valid and invalid strict reads opened the shared state database despite `observe: false`.
- After the change, `pnpm test src/config/io.runtime-observe.test.ts` passed: 1 file, 2 tests.
- `pnpm test src/config/io.runtime-observe.test.ts src/config/io.best-effort.test.ts src/config/io.observe-recovery.test.ts src/config/config.talk-validation.test.ts src/config/config.multi-agent-agentdir-validation.test.ts` passed: 5 files, 74 tests.
- `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.config-cli.json --builders 1` passed.
- The changed-file gate passed formatting, repository guards, dead-export scans, plugin-boundary checks, and the core production typecheck. Its all-shard core-test typecheck was stopped after 230 seconds; the directly relevant config/CLI typecheck shard above passed, and CI remains the broad test-type proof.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted ...` reported no accepted/actionable findings (`patch is correct`, confidence `0.99`).
