### PR TITLE
fix(tests): keep broad test helper routing complete

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -1631,6 +1631,7 @@ function findDirectImportersWithGitGrep(
 ) {
   const tooling = options.tooling === true;
   const cacheKey = `${cwd}\0${tooling ? "tooling" : "source"}\0${importedFile}`;
+  const isTestHelper = importedFile.startsWith("test/helpers/");
   if (cachedDirectImporters.has(cacheKey)) {
     return cachedDirectImporters.get(cacheKey) ?? null;
   }
@@ -1650,7 +1651,8 @@ function findDirectImportersWithGitGrep(
       cachedDirectImporters.set(cacheKey, null);
       return null;
     }
-    if (candidates.length > 800) {
+    // Central test helpers intentionally fan out broadly; incomplete scans silently drop owning tests.
+    if (candidates.length > 800 && !isTestHelper) {
       skippedBroadTerm = true;
       continue;
     }
@@ -1677,14 +1679,11 @@ function findDirectImportersWithGitGrep(
         }
       }
     }
-    if (importedFile.startsWith("test/helpers/") && importers.length > 0 && term.includes("/")) {
+    if (isTestHelper && importers.length > 0 && term.includes("/")) {
       break;
     }
   }
-  const result =
-    skippedBroadTerm && importers.length === 0 && !importedFile.startsWith("test/helpers/")
-      ? null
-      : importers;
+  const result = skippedBroadTerm && importers.length === 0 && !isTestHelper ? null : importers;
   cachedDirectImporters.set(cacheKey, result);
   return result;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where changed-test routing could silently omit owning tests once a central `test/helpers/**` helper crossed the generic importer-scan candidate cap. The runner recovery branch exposed this at 801 broad-term candidates, where 168 direct importing tests disappeared from the generated plan.

## Why This Change Was Made

Central test helpers are already a deliberate high-fanout namespace with narrower search terms and an early break after a slash-qualified term finds importers. This keeps the generic 800-candidate cap for ordinary source paths, but scans the complete candidate set for `test/helpers/**` so routing remains complete.

## User Impact

No runtime product behavior changes. Developers and CI can rely on changed-test plans for central test helpers to include every directly importing test instead of silently skipping owners as the repository grows.

## Evidence

- Exact runner head `98a7290b6800d7369defcb1422313fd4cc89f77e` before the fix: `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts --maxWorkers=1 --reporter=default` failed 1/84, reporting 168 missing direct importers (65.93s wall).
- The same runner tree with this commit applied: the command passed 84/84 (53.59s wall); the repaired regression took 1.43s.
- Dedicated branch: the focused suite passed five consecutive runs; regression-test duration 1.28–2.13s, full command wall 64.46–78.49s on the loaded local checkout.
- Related test-project and CI-plan owners passed 430/430 in 124.64s.
- `node scripts/check-changed.mjs --dry-run` selected only `scripts, tooling`; `node scripts/check-changed.mjs` passed in 50.00s.
- `node_modules/.bin/oxfmt --check scripts/test-projects.test-support.mts` and `git diff --check` passed.
- Structured Codex autoreview: no accepted/actionable findings.

Current `origin/main` is exactly at 800 broad-term candidates, so the same regression test passes there; the runner branch's additional matching test pushes the latent boundary bug to 801 and supplies the failing pre-fix proof.
