### PR TITLE
fix(cli): return JSON when docs search fails

### DIFF
--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -125,11 +125,11 @@ describe("docsSearchCommand", () => {
     fetchMock.mockResolvedValueOnce(response);
     const runtime = makeRuntime();
 
-    await docsSearchCommand(["browser", "existing-session"], runtime);
+    await expect(docsSearchCommand(["browser", "existing-session"], runtime)).rejects.toThrow(
+      "Docs search failed: HTTP 503",
+    );
 
     expect(cancelled).toBe(true);
-    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("HTTP 503"));
-    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
   it("reports malformed docs search JSON with CLI context", async () => {
@@ -140,13 +140,9 @@ describe("docsSearchCommand", () => {
     );
     const runtime = makeRuntime();
 
-    await docsSearchCommand(["bad-json"], runtime);
-
-    expect(runtime.error).toHaveBeenCalledWith(
+    await expect(docsSearchCommand(["bad-json"], runtime)).rejects.toThrow(
       "Docs search failed: Docs search response is malformed JSON",
     );
-    expect(runtime.error).toHaveBeenCalledTimes(1);
-    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
   it("reports docs search responses with invalid UTF-8 bytes as malformed", async () => {
@@ -160,12 +156,9 @@ describe("docsSearchCommand", () => {
     );
     const runtime = makeRuntime();
 
-    await docsSearchCommand(["plugin"], runtime);
-
-    expect(runtime.error).toHaveBeenCalledWith(
+    await expect(docsSearchCommand(["plugin"], runtime)).rejects.toThrow(
       "Docs search failed: Docs search response is malformed JSON",
     );
-    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
   it("renders successful results from the Cloudflare docs search API", async () => {
@@ -212,12 +205,9 @@ describe("docsSearchCommand", () => {
     );
     const runtime = makeRuntime();
 
-    await docsSearchCommand(["oversized"], runtime);
-
-    expect(runtime.error).toHaveBeenCalledWith(
-      expect.stringContaining("Docs search response exceeds"),
+    await expect(docsSearchCommand(["oversized"], runtime)).rejects.toThrow(
+      "Docs search failed: Docs search response exceeds 8388608 bytes",
     );
-    expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(cancel).toHaveBeenCalledOnce();
   });
 });

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -150,9 +150,7 @@ export async function docsSearchCommand(
     results = await fetchDocsSearch(query);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    runtime.error(`Docs search failed: ${message}`);
-    runtime.exit(1);
-    return;
+    throw new Error(`Docs search failed: ${message}`, { cause: error });
   }
 
   if (options.json) {

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -295,6 +295,30 @@ describe("cli json stdout contract", () => {
     );
   });
 
+  it("returns one canonical document when docs search fails", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const preload = `data:text/javascript,${encodeURIComponent(
+          'globalThis.fetch = async () => { throw new Error("offline fixture"); };',
+        )}`;
+        const result = runBuiltCli(tempHome, ["docs", "offline", "--json"], {
+          NODE_OPTIONS: `--import=${preload}`,
+        });
+
+        expect(result.status).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message: "Docs search failed: offline fixture",
+          },
+        });
+        expect(result.stderr).toContain("Docs search failed: offline fixture");
+      },
+      { prefix: "openclaw-docs-json-failure-e2e-" },
+    );
+  });
+
   it("keeps Commander parse failures machine-readable in JSON mode", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scripts running `openclaw docs <query> --json` received exit code 1 with empty stdout when the hosted docs search failed. That violated the documented CLI contract that JSON-mode failures emit one parseable `cli_error` object.

## Why This Change Was Made

Docs search failures now preserve their existing `Docs search failed: ...` context and escape to the shared CLI failure owner. The existing process-level renderer selects terse human output or the canonical JSON envelope, avoiding command-specific rendering, fallback behavior, or a second error path.

The response timeout, body cancellation, malformed-response handling, size limit, successful search output, and no-query output are unchanged.

## User Impact

`openclaw docs <query> --json` now reliably writes one canonical JSON error object to stdout and exits 1 when search is unavailable. Human mode keeps the same error text and exit code.

Release-note context: docs CLI JSON failures are now machine-readable instead of returning empty stdout.

## Evidence

Before the fix, a built CLI with a fetch-throw preload returned exit 1, `Docs search failed: offline fixture` on stderr, and empty stdout. The added built-process regression failed with `Unexpected end of JSON input` on that baseline.

After the fix, the same built CLI returns:

```json
{
  "ok": false,
  "error": {
    "type": "cli_error",
    "message": "Docs search failed: offline fixture"
  }
}
```

Validation:

- `pnpm docs:list`; reviewed `docs/cli/docs.md` and `docs/cli/index.md` (already describe the desired contract)
- `pnpm test src/commands/docs.test.ts` — 8 passed
- `pnpm test test/cli-json-stdout.e2e.test.ts -t "returns one canonical document when docs search fails"` — 1 passed
- Source-blind built CLI contract probes — JSON failure, human failure, no-query JSON, and successful JSON all passed
- `pnpm check:changed` — passed
- `pnpm build` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode local --max-priority P1 --stream-engine-output` — clean, no findings

The full shared `test/cli-json-stdout.e2e.test.ts` run passed the new docs case and 28 other cases, but its unrelated final Doctor fixture failed because the local private-QA build could not resolve `memory-core/doctor-health-api.js`. The focused docs process proof and all changed gates are green. Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/32265819907 is also green; an unrelated process-group readiness timeout passed on failed-job retry without a code change.

ClawSweeper rank-up moves:

- Resolve merge risk (P1): resolved; required exact-head CI is green on `966ac5d7bba855e7fa9fe21e934b3f69109bbeee`.
- Complete next step (P2): no repair lane is needed; proceed through the normal native maintainer review, Testbox preparation, and merge gates.

Production LOC: +1/-3 (net -2). Tests: +31/-17.

AI-assisted: implemented and independently reviewed with Codex.
