### PR TITLE
fix(skills): load hidden skills from channel slash commands

### DIFF
--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -1044,6 +1044,126 @@ describe("handleInlineActions", () => {
     expect(commandArgs.skillCommands).toEqual(skillCommands);
   });
 
+  it.each([
+    {
+      channelBody: "/skill wait-what explain the previous reply",
+      normalizedBody: "/skill wait-what explain the previous reply",
+      expectedRequest: "/skill wait-what explain the previous reply",
+    },
+    {
+      channelBody: "/wait_what explain the previous reply",
+      normalizedBody: "/wait_what explain the previous reply",
+      expectedRequest: "/wait_what explain the previous reply",
+    },
+    {
+      channelBody: "/skill@openclaw: wait-what explain the previous reply",
+      normalizedBody: "/skill wait-what explain the previous reply",
+      expectedRequest: "/skill wait-what explain the previous reply",
+      botUsername: "openclaw",
+    },
+    {
+      channelBody: "/wait_what@openclaw explain the previous reply",
+      normalizedBody: "/wait_what explain the previous reply",
+      expectedRequest: "/wait_what explain the previous reply",
+      botUsername: "openclaw",
+    },
+    {
+      channelBody: "/skill wait-what explain /help",
+      normalizedBody: "/skill wait-what explain /help",
+      expectedRequest: "/skill wait-what explain /help",
+    },
+    {
+      channelBody: "/skill wait-what explain /status",
+      normalizedBody: "/skill wait-what explain /status",
+      cleanedBody: "/skill wait-what explain",
+      expectedRequest: "/skill wait-what explain /status",
+      inlineStatusRequested: true,
+    },
+    {
+      channelBody: "/skill@OpenClaw: wait-what first line\nsecond line\n\n  indented third",
+      normalizedBody: "/skill wait-what first line\nsecond line\n\n  indented third",
+      expectedRequest: "/skill wait-what first line\nsecond line\n\n  indented third",
+      botUsername: "openclaw",
+    },
+    {
+      channelBody: "/wait_what@openclaw first line\nsecond line",
+      normalizedBody: "/wait_what first line\nsecond line",
+      expectedRequest: "/wait_what first line\nsecond line",
+      botUsername: "openclaw",
+    },
+    {
+      channelBody: "/skill@otherbot: wait-what explain",
+      normalizedBody: "/skill@otherbot wait-what explain",
+      botUsername: "openclaw",
+      foreignBot: true,
+    },
+    {
+      channelBody: "/wait_what@otherbot explain",
+      normalizedBody: "/wait_what@otherbot explain",
+      botUsername: "openclaw",
+      foreignBot: true,
+    },
+  ])("resolves channel skill request $channelBody", async (testCase) => {
+    const typing = createTypingController();
+    const ctx = buildTestCtx({
+      Body: testCase.channelBody,
+      CommandBody: testCase.normalizedBody,
+      BotUsername: testCase.botUsername,
+    });
+    const skillCommands: SkillCommandSpec[] = [
+      {
+        name: "wait_what",
+        skillName: "wait-what",
+        description: "Explain the previous reply clearly",
+        modelVisible: false,
+        skillFile: "/tmp/skills/wait-what/SKILL.md",
+      },
+    ];
+
+    const result = await runTestInlineActions({
+      ctx,
+      typing,
+      cleanedBody: testCase.cleanedBody ?? testCase.channelBody,
+      command: {
+        isAuthorizedSender: true,
+        rawBodyNormalized: testCase.normalizedBody,
+        commandBodyNormalized: testCase.normalizedBody,
+      },
+      overrides: {
+        allowTextCommands: true,
+        cfg: { commands: { text: true } },
+        skillCommands,
+        inlineStatusRequested: testCase.inlineStatusRequested === true,
+      },
+    });
+
+    expect(result.kind).toBe("continue");
+    if (result.kind !== "continue") {
+      throw new Error("expected hidden skill invocation to continue to the model");
+    }
+    if (testCase.foreignBot) {
+      expect(result.cleanedBody).toBe(testCase.channelBody);
+      expect(ctx.Body).toBe(testCase.channelBody);
+      expect(result.explicitSkillSelections).toBeUndefined();
+      return;
+    }
+    expect(result.cleanedBody).toBe(
+      [
+        "Use the following explicitly referenced skills for this request. Read each skill's SKILL.md before acting:",
+        "- wait-what (SKILL.md: /tmp/skills/wait-what/SKILL.md)",
+        "",
+        "User request:",
+        testCase.expectedRequest,
+      ].join("\n"),
+    );
+    expect(ctx.Body).toBe(result.cleanedBody);
+    expect(result.explicitSkillSelections).toEqual([
+      { name: "wait_what", path: "/tmp/skills/wait-what/SKILL.md" },
+    ]);
+    expect(handleCommandsMock).not.toHaveBeenCalled();
+    expect(buildStatusReplyMock).not.toHaveBeenCalled();
+  });
+
   it("preserves exact channel prompt bytes while expanding $ skill references", async () => {
     const typing = createTypingController();
     const original = "Review this plan with $office_hours and $release_notes.";
@@ -1231,10 +1351,22 @@ describe("handleInlineActions", () => {
     expect(typing.cleanup).toHaveBeenCalledOnce();
   });
 
-  it("returns a visible error for an allowlist-hidden leading skill slash command", async () => {
+  it.each([
+    {
+      channelBody: "/office_hours@openclaw review this",
+      normalizedBody: "/office_hours review this",
+    },
+    {
+      channelBody: "/skill@openclaw: office-hours review this",
+      normalizedBody: "/skill office-hours review this",
+    },
+  ])("returns a visible error for allowlist-hidden $channelBody", async (testCase) => {
     const typing = createTypingController();
-    const original = "/office_hours review this";
-    const ctx = buildTestCtx({ Body: original, CommandBody: original });
+    const ctx = buildTestCtx({
+      Body: testCase.channelBody,
+      CommandBody: testCase.normalizedBody,
+      BotUsername: "openclaw",
+    });
     listSkillCommandsForWorkspaceMock.mockImplementation(
       (params: { includeAllowlistHidden?: boolean }) =>
         params.includeAllowlistHidden
@@ -1252,11 +1384,11 @@ describe("handleInlineActions", () => {
     const result = await runTestInlineActions({
       ctx,
       typing,
-      cleanedBody: original,
+      cleanedBody: testCase.channelBody,
       command: {
         isAuthorizedSender: true,
-        rawBodyNormalized: original,
-        commandBodyNormalized: original,
+        rawBodyNormalized: testCase.normalizedBody,
+        commandBodyNormalized: testCase.normalizedBody,
       },
       overrides: {
         allowTextCommands: true,

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -468,34 +468,29 @@ export async function handleInlineActions(params: {
       }
     }
 
-    const rewrittenBody = skillInvocation.command.promptTemplate
-      ? expandBundleCommandPromptTemplate(
-          skillInvocation.command.promptTemplate,
-          skillInvocation.args,
-        )
-      : [
-          `Use the "${skillInvocation.command.skillName}" skill for this request.`,
-          skillInvocation.args ? `User input:\n${skillInvocation.args}` : null,
-        ]
-          .filter((entry): entry is string => Boolean(entry))
-          .join("\n\n");
-    ctx.Body = rewrittenBody;
-    ctx.agentText = rewrittenBody;
-    ctx.BodyForAgent = rewrittenBody;
-    sessionCtx.Body = rewrittenBody;
-    sessionCtx.agentText = rewrittenBody;
-    sessionCtx.BodyForAgent = rewrittenBody;
-    sessionCtx.BodyStripped = rewrittenBody;
-    cleanedBody = rewrittenBody;
+    if (skillInvocation.command.promptTemplate) {
+      const rewrittenBody = expandBundleCommandPromptTemplate(
+        skillInvocation.command.promptTemplate,
+        skillInvocation.args,
+      );
+      ctx.Body = rewrittenBody;
+      ctx.agentText = rewrittenBody;
+      ctx.BodyForAgent = rewrittenBody;
+      sessionCtx.Body = rewrittenBody;
+      sessionCtx.agentText = rewrittenBody;
+      sessionCtx.BodyForAgent = rewrittenBody;
+      sessionCtx.BodyStripped = rewrittenBody;
+      cleanedBody = rewrittenBody;
+    }
   }
 
   const referenced =
     allowTextCommands &&
     (hasSkillReferences || hasSkillSlashCandidate) &&
-    !skillInvocation &&
+    !skillInvocation?.command.promptTemplate &&
     (hasSkillSlashCandidate || resolveSlashCommandName(cleanedBody) === null)
       ? expandExplicitSkillReferences({
-          text: hasSkillReferences ? explicitSkillReferenceBody : cleanedBody,
+          text: explicitSkillReferenceBody,
           skillCommands,
           allSkillCommands,
         })


### PR DESCRIPTION
Related: #123367. Follow-up to #124784.

## What Problem This Solves

An authorized user invoking a model-hidden skill through `/skill <name>` or `/<skill-name>` could reach the model without the skill's `SKILL.md` path or structured selection. The channel dispatcher recognized the skill but rewrote the request to a generic instruction; a skill with `disable-model-invocation: true` was absent from the normal model catalog, leaving the model unable to reliably load it. Telegram's targeted `@bot` forms had the same gap.

## Why This Change Was Made

Ordinary model-routed skill slash commands now use the existing bounded explicit-skill renderer, which already handles `$skill` references and generic agent turns. Tool-dispatched skills still return through direct dispatch, and template-backed bundle commands still render their registered template. Allowlists, authorization, text-command enablement, unknown commands, and metadata limits retain their existing owners.

The maintainer revision rebases onto current `main` and simplifies the original proposal further: expansion consumes `command.commandBodyNormalized`, already produced by the ingress command-normalization owner. It does not normalize parser-mutated `cleanedBody` a second time. This preserves current main's #122425 behavior: `/help` and `/status` inside an explicit skill request remain literal request text and do not invoke unrelated handlers.

Production delta: **+16/-21, net -5 lines**. The duplicate generic prompt rewrite and redundant normalization are removed; no new runtime helper, public API, configuration, protocol, or persistence surface is introduced.

## User Impact

Users can explicitly invoke eligible model-hidden skills from Telegram and other channels and receive the same bounded instructions and selection metadata as an explicit dollar reference. Multiline arguments and literal command text are preserved. No new configuration is needed.

## Evidence

The contributor reproduced the bug on unpatched main: both `/skill wait-what ...` and `/wait_what ...` produced only a generic skill instruction, without a `SKILL.md` path or `explicitSkillSelections`.

The extended owner regression table covers generic/direct forms, hidden metadata and selections, matching Telegram bot identities, case-insensitive bot targeting, multiline arguments and indentation, foreign-bot non-selection, literal `/help` and `/status` preservation, and allowlist-hidden visible errors. Existing tests continue to cover `$skill` prompt bytes, template expansion, and direct tool dispatch.

Focused verification command:

```text
node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts src/skills/discovery/chat-commands.test.ts src/skills/discovery/command-specs.test.ts
```

Trusted formatting and fresh independent Codex review passed for the adapted patch. [Full CI passed](https://github.com/openclaw/openclaw/actions/runs/33007746239) on exact head `e3f4411f897b71024b683997bde06e6329b8b17a`. Contributor code is not executed on the credentialed maintainer host. The former red CI run failed only an unrelated audit timing assertion, already fixed on current main by #128228; this rebase includes that repair without weakening the test.

The latest ClawSweeper run reports all 87 focused tests passing; its subsequent output assertion hit the runner's 30-second command-collection limit, not a failing test assertion.

### Current-head real Gateway proof (2026-08-26)

**PASS**, exact head `e3f4411f897b71024b683997bde06e6329b8b17a`, Node 24.19.0, pnpm 11.22.0. A fresh secretless AWS Crabbox (`cbx_a3460d1aa56a`, successful run `run_2020e7b53fb5`) ran the actual Gateway and Telegram plugin against mock Telegram HTTP and mock OpenAI Responses endpoints. This is mock-gateway proof, not a new authenticated Telegram Desktop run. Native registration, actual incoming bot-command updates, the provider request, and outgoing Telegram delivery were observed. The mock model returned its success marker only after validating the real provider request contained the hidden SKILL.md path, read instruction, and original command.

```json
{
  "head": "e3f4411f897b71024b683997bde06e6329b8b17a",
  "status": "pass",
  "hiddenSkill": {"name": "slash-proof", "disable-model-invocation": true},
  "cases": [
    {"input": "/skill slash-proof alpha", "hiddenSkillPath": true, "readInstruction": true, "originalRequest": true, "telegramReply": "HIDDEN_SKILL_OK_ALPHA"},
    {"input": "/slash_proof beta", "hiddenSkillPath": true, "readInstruction": true, "originalRequest": true, "telegramReply": "HIDDEN_SKILL_OK_BETA"}
  ],
  "providerRequests": 2,
  "telegramReplies": 2,
  "serverErrors": []
}
```

The focused gateway scenario passed in 15.67s (23.65s total). The existing `telegram-command-menu-gateway.e2e.test.ts` sibling also passed on this exact build. Initial proof attempts exposed fixture/tooling mistakes, not PR defects: the bootstrap inherited umask 077, the temporary fixture used a retired streaming shape, and its request inspector selected appended runtime context instead of the active user input. These were corrected without changing the PR or weakening behavior assertions. The sandbox was released after proof. The artifact broker was unavailable; the redacted verdict and reproducible standalone fixture are preserved in this PR instead of claiming a successful upload.

Both latest ClawSweeper rank-up moves are addressed: current-head gateway proof above and green exact-head CI. Its missing sibling-Codex check is covered below. No code finding remains.

### Direct Codex contract check

The maintainer personally inspected the sibling Codex checkout at `d47e5cc0e2bbd35774dff15c83570519735d2ac4`: `codex-rs/protocol/src/user_input.rs:45-49` defines the skill name/path input; `codex-rs/skills/src/selection.rs:33-109` resolves explicit selections against enabled skill paths; `codex-rs/core/src/session/turn.rs:820-840` loads selected skill instructions. OpenClaw's existing `extensions/codex/src/app-server/explicit-skill-input.ts:17-47` adapts the restored selections to that contract. No protocol change is introduced. This covers the source-inspection gap in the ClawSweeper sandbox, where the sibling checkout was unavailable.

### Existing live Telegram evidence

The contributor exercised an isolated Telegram Gateway on 2026-08-19 with a hidden skill, separate state/workspace/bot, and read-only model tools. Both real provider requests returned HTTP 200 and Telegram delivered the expected replies:

```text
/skill slash-proof alpha → SLASH_PROOF_OK:alpha
/slash_proof beta        → SLASH_PROOF_OK:beta
```

ClawSweeper also independently ran the owner suite twice successfully on the earlier PR revision. Its [latest review](https://github.com/openclaw/openclaw/pull/126335#issuecomment-5346113237) correctly requires current-head Telegram or mock-gateway proof after the rebase. Historical proof is not presented as a new live run.

## Follow-up

Investigate whether `/model` and `/think` embedded in slash-skill arguments should bypass the earlier directive parser, as `$skill` payloads already do. This is a pre-existing adjacent behavior, not a verified regression introduced here; the current repair does not change those earlier directive effects.

Separately, make public-tool install permissions explicit in `scripts/crabbox-untrusted-bootstrap.sh` under a restrictive launcher umask. This proof used a task-local bootstrap with umask 022; identity, exact-SHA, package-manager-pin, no-role, and secretless checks remained intact.

AI-assisted: yes. Contributor credit is preserved; the maintainer revision was independently reviewed.
