### PR TITLE
fix: doctor stops removing eager tool streaming config

### DIFF
--- a/src/commands/doctor-config-analysis.test.ts
+++ b/src/commands/doctor-config-analysis.test.ts
@@ -111,6 +111,36 @@ describe("doctor config analysis helpers", () => {
     expect((result.config as Record<string, unknown>).hooks).toStrictEqual({});
   });
 
+  it("preserves eager tool input streaming compatibility metadata", () => {
+    const result = stripUnknownConfigKeys({
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.com",
+            models: [
+              {
+                id: "test-model",
+                name: "Test Model",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                maxTokens: 4096,
+                compat: { supportsEagerToolInputStreaming: false },
+              },
+            ],
+          },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(result.removed).not.toContain(
+      "models.providers.custom.models[0].compat.supportsEagerToolInputStreaming",
+    );
+    expect(
+      result.config.models?.providers?.custom?.models?.[0]?.compat?.supportsEagerToolInputStreaming,
+    ).toBe(false);
+  });
+
   it("strips unknown root model metadata while preserving supported agent metadata", () => {
     const result = stripUnknownConfigKeys({
       defaultModel: "minimax/MiniMax-M2.7",

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -249,6 +249,7 @@ const ModelCompatSchema = z
     supportsReasoningEffort: z.boolean().optional(),
     supportsTemperature: z.boolean().optional(),
     supportsUsageInStreaming: z.boolean().optional(),
+    supportsEagerToolInputStreaming: z.boolean().optional(),
     supportsTools: z.boolean().optional(),
     codeMode: z.enum(["preferred", "capable"]).optional(),
     supportsStrictMode: z.boolean().optional(),


### PR DESCRIPTION
Closes #126308

## What Problem This Solves

Fixes an issue where users running OpenClaw Doctor config cleanup would silently lose `models.providers.*.models[].compat.supportsEagerToolInputStreaming`, even though the runtime supports that setting.

## Why This Change Was Made

The supported boolean is now included in the strict model compatibility schema. A focused regression test verifies that Doctor preserves a false-valued setting instead of treating it as unknown metadata.

## User Impact

Users can run Doctor without this model compatibility setting being removed from their configuration.

## Evidence

- Before the schema fix, the new regression test failed because Doctor reported `models.providers.custom.models[0].compat.supportsEagerToolInputStreaming` as removed (1 failed, 38 passed).
- After the fix: `node scripts/run-vitest.mjs src/commands/doctor-config-analysis.test.ts` (39 passed).
- `pnpm check:changed -- src/config/zod-schema.core.ts src/commands/doctor-config-analysis.test.ts` (passed).
- TruffleHog preflight scan: clean.
- `autoreview --mode local --engine pi --thinking high`: patch correct, no actionable findings (0.92 confidence).
- Real Doctor CLI proof on exact head `0476def28c6d869b5ff2d2aa9681143cb1606329` using an isolated disposable state/config directory:

```text
$ node -e '<read disposable config value>'
BEFORE supportsEagerToolInputStreaming=false

$ OPENCLAW_STATE_DIR=/tmp/openclaw-pr126336-proof-20260820 \
  OPENCLAW_CONFIG_PATH=/tmp/openclaw-pr126336-proof-20260820/openclaw.json \
  pnpm openclaw doctor --non-interactive
OpenClaw 2026.8.1 (0476def)
...
Doctor complete.
[exit 0]

$ node -e '<read disposable config value>'
AFTER supportsEagerToolInputStreaming=false
```

The disposable profile was intentionally minimal, so Doctor also reported unrelated setup recommendations. The target field remained present with its false value after the complete real CLI run.

AI-assisted: implemented with Codex and independently reviewed with the repository's autoreview workflow. I understand and verified the schema change and regression test.
