### PR TITLE
fix(ui): keep retained dashboards warm

### DIFF
--- a/ui/src/e2e/dashboard-session-retention.e2e.test.ts
+++ b/ui/src/e2e/dashboard-session-retention.e2e.test.ts
@@ -1,0 +1,131 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { controlUiSessionPath, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI retained dashboard sessions",
+  startServerBeforeBrowser: true,
+});
+
+const alphaKey = "agent:main:dashboard-alpha";
+const betaKey = "agent:main:dashboard-beta";
+const proofDir = path.resolve(".artifacts/control-ui-e2e/dashboard-session-retention");
+
+function dashboardPath(key: string): string {
+  return controlUiSessionPath(key).replace(/^\/chat\//u, "/dashboard/");
+}
+
+function dashboardSnapshot(key: string, prefix: string) {
+  return {
+    sessionKey: key,
+    revision: 1,
+    tabs: [
+      { tabId: `${prefix}-main`, title: `${prefix} main`, position: 0, chatDock: "right" },
+      { tabId: `${prefix}-other`, title: `${prefix} other`, position: 1, chatDock: "right" },
+    ],
+    widgets: [],
+  };
+}
+
+suite.define(() => {
+  it("shows a warmed dashboard immediately while its refresh is pending", async () => {
+    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
+    if (recordProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({
+      viewport: { height: 900, width: 1280 },
+      ...(recordProof
+        ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      sessionKey: alphaKey,
+      featureMethods: ["board.get", "chat.metadata", "chat.startup"],
+      methodResponses: {
+        "board.get": {
+          cases: [
+            { match: { sessionKey: alphaKey }, response: dashboardSnapshot(alphaKey, "alpha") },
+            { match: { sessionKey: betaKey }, response: dashboardSnapshot(betaKey, "beta") },
+          ],
+        },
+        "sessions.list": {
+          count: 2,
+          defaults: { contextTokens: null, model: "gpt-5.6-luna", modelProvider: "openai" },
+          path: "",
+          sessions: [
+            {
+              boardFace: "dashboard",
+              key: alphaKey,
+              kind: "direct",
+              label: "Alpha dashboard",
+              updatedAt: 2,
+            },
+            {
+              boardFace: "dashboard",
+              key: betaKey,
+              kind: "direct",
+              label: "Beta dashboard",
+              updatedAt: 1,
+            },
+          ],
+          ts: Date.now(),
+        },
+      },
+    });
+
+    try {
+      await page.goto(new URL(dashboardPath(alphaKey), suite.server.baseUrl).href);
+      const alphaTab = page.locator('[data-board-tab-id="alpha-main"]');
+      await alphaTab.waitFor();
+      await alphaTab.evaluate((tab) => {
+        Reflect.set(globalThis, "__retainedDashboardTab", tab);
+      });
+      if (recordProof) {
+        await page.screenshot({ path: path.join(proofDir, "01-alpha-warmed.png") });
+      }
+
+      const sessionLink = (key: string) =>
+        page.locator(
+          `.sidebar-recent-session[data-session-key="${key}"] a.sidebar-recent-session__link`,
+        );
+      const dashboardActive = (key: string) =>
+        page.locator("openclaw-chat-pane").evaluateAll((panes, sessionKey) => {
+          const pane = panes.find(
+            (candidate) => Reflect.get(candidate, "sessionKey") === sessionKey,
+          );
+          const board = pane?.querySelector("openclaw-board-view");
+          return board ? Reflect.get(board, "active") : null;
+        }, key);
+      await sessionLink(betaKey).click();
+      await page.locator('[data-board-tab-id="beta-main"]').waitFor();
+      await expect.poll(() => new URL(page.url()).pathname).toBe(dashboardPath(betaKey));
+      await expect.poll(() => dashboardActive(alphaKey)).toBe(false);
+      await expect.poll(() => dashboardActive(betaKey)).toBe(true);
+      if (recordProof) {
+        await page.screenshot({ path: path.join(proofDir, "02-beta-selected.png") });
+      }
+
+      await gateway.deferNext("board.get", { sessionKey: alphaKey });
+      await sessionLink(alphaKey).click();
+      await alphaTab.waitFor({ state: "visible", timeout: 1_000 });
+      expect(
+        await alphaTab.evaluate((tab) => Reflect.get(globalThis, "__retainedDashboardTab") === tab),
+      ).toBe(true);
+      await expect.poll(() => dashboardActive(alphaKey)).toBe(true);
+      await expect.poll(() => dashboardActive(betaKey)).toBe(false);
+      if (recordProof) {
+        await page.screenshot({ path: path.join(proofDir, "03-alpha-retained.png") });
+      }
+    } finally {
+      const video = page.video();
+      await context.close();
+      if (recordProof && video) {
+        await video.saveAs(path.join(proofDir, "dashboard-session-retention.webm"));
+      }
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-page-pane-render.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.ts
@@ -94,6 +94,7 @@ export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
               .sessionSnapshotStore=${options.sessionSnapshotStore}
               .sessionKey=${sessionKey}
               .presented=${presented}
+              .visuallyPresented=${presented}
               .active=${active}
               .draft=${draft}
               .focusComposer=${options.draftFocus.shouldFocusPane(

--- a/ui/src/pages/chat/chat-page-retained-sessions.ts
+++ b/ui/src/pages/chat/chat-page-retained-sessions.ts
@@ -190,6 +190,7 @@ export class ChatPageRetainedSessions {
       }
       const presented = areUiSessionKeysEquivalent(pane.sessionKey ?? "", sessionKey);
       pane.classList.toggle("chat-pane-cache__pane--visible", presented);
+      pane.visuallyPresented = presented;
       if (preview) {
         pane.toggleAttribute("inert", true);
         continue;

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -109,6 +109,9 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   // bindings until the container supplies a real key (classic mode renders
   // before route data resolves).
   @property({ attribute: false }) sessionKey = "";
+  // Route ownership settles after retained-pane preview; dashboard activity follows
+  // the pane the user can already see so its warmed runtime paints immediately.
+  @property({ attribute: false }) visuallyPresented = true;
   private activeValue = false;
   private headerPresentationGeneration = 0;
   private presentedValue = true;

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -185,7 +185,7 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
       return null;
     }
     return {
-      active: board.face === "dashboard",
+      active: board.face === "dashboard" && this.visuallyPresented,
       basePath: state.basePath,
       client,
       sessionKey: this.resolveBoardSessionKey(board.snapshot.sessionKey),
@@ -341,7 +341,7 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
       board.hasBoard &&
       Boolean(sessionKey) &&
       (board.face === "dashboard" || this.retainedBoardSessionKey === sessionKey);
-    const boardActive = board.face === "dashboard";
+    const boardActive = board.face === "dashboard" && this.visuallyPresented;
     const renderSurface = (active: boolean) =>
       renderBoardSessionSurface({
         active,
@@ -393,6 +393,9 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
   }
 
   protected handleBoardCommand(event: BoardCommandEvent): void {
+    if (!this.presented) {
+      return;
+    }
     const board = this.resolveBoardView();
     const sessionKey = this.resolveBoardSessionKey(board.snapshot.sessionKey);
     if (!sessionKey || this.resolveBoardSessionKey(event.sessionKey) !== sessionKey) {

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -380,7 +380,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
   };
 
   override connectedCallback() {
-    this.boardProviderLifecycleConnected = this.presented;
+    this.boardProviderLifecycleConnected = true;
     this.resumeStagedAttachments();
     super.connectedCallback();
     if (!this.presented) {

--- a/ui/src/pages/chat/chat-pane-retained-presentation.ts
+++ b/ui/src/pages/chat/chat-pane-retained-presentation.ts
@@ -17,7 +17,7 @@ import { resetTaskDetail } from "./components/chat-task-detail-state.ts";
 import { resetTranscriptSession } from "./components/chat-thread-interactions.ts";
 import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "./composer-persistence.ts";
 
-/** Owns the resources and composer state that follow one retained presentation. */
+/** Owns foreground resources and composer state that follow one retained presentation. */
 export abstract class ChatPaneRetainedPresentation extends ChatPaneBoard {
   protected abstract clearComposerPrefillAttention(): void;
   protected abstract settleResetConfirmation(confirmed: boolean): void;
@@ -43,15 +43,12 @@ export abstract class ChatPaneRetainedPresentation extends ChatPaneBoard {
       return;
     }
     if (presented) {
-      this.boardProviderLifecycleConnected = true;
       this.minutePoll.start();
       this.consumeSessionHandoff(this.sessionKey);
       this.syncActiveBindings();
       void this.refreshSessionPullRequests();
       return;
     }
-    this.boardProviderLifecycleConnected = false;
-    this.releaseBoardProviderLease();
     this.minutePoll.stop();
     this.clearHistoryObserver();
     sessionPullRequestsForGateway(this.context.gateway).unwatch(this);

--- a/ui/src/pages/chat/route-draft-focus-handoff.ts
+++ b/ui/src/pages/chat/route-draft-focus-handoff.ts
@@ -19,6 +19,7 @@ export type ChatPaneElement = HTMLElement & {
   prepareForEviction?: () => void;
   presented?: boolean;
   sessionKey?: string;
+  visuallyPresented?: boolean;
 };
 
 let pendingHandoff: PendingHandoff | undefined;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

AI-assisted change. The implementation, lifecycle ownership, regression proof, and final diff were reviewed by the maintainer; no agent transcript or session links are included.

## What Problem This Solves

Fixes an issue where switching between retained team-server dashboard sessions painted chat first and then waited seconds for the dashboard to reload, even when that dashboard had already been warmed in the same pane.

## Why This Change Was Made

Retained chat panes released their dashboard provider and snapshot when they became hidden, even though the pane itself remained retained. The fix makes the board provider lease follow the bounded retained-pane lifetime, while a separate visual-presentation signal gates board activity so hidden widgets and commands remain suspended.

This is the owner-boundary fix: the retained pane owns the provider lifetime, while the visible presentation owns activity. It avoids a second board cache or prefetch path and keeps the existing inactive board/widget suspension contract.

Provenance: the release-on-hide behavior was carried forward by #121625, authored and merged by @steipete on August 10, 2026. No bot merge or automerge trigger was involved.

## User Impact

Revisiting a warmed dashboard is immediate instead of showing chat first and waiting for a dashboard reload. Hidden retained dashboards remain inactive, so this does not keep their widgets or commands running in the background.

## Evidence

### Before

Alpha is selected 500 ms after returning, but only chat is visible because the retained dashboard was torn down.

![Before: Alpha selected while its dashboard is missing](https://github.com/user-attachments/assets/5e72e600-a2fb-443e-9ac5-b5dde3e8b3fe)

### After

The warmed Alpha dashboard is visible immediately while its `board.get` refresh remains deliberately stalled.

![After: warmed Alpha dashboard retained during stalled refresh](https://github.com/user-attachments/assets/de532ac5-418c-4419-907c-183dcd3bb52a)

### Video

Alpha → Beta → retained Alpha:

https://github.com/user-attachments/assets/bd720f7e-07ef-4b7e-86cf-cd5d2c627f0d

### Focused verification

The deterministic Playwright/Vitest flow uses a real Chromium page and an isolated mocked Gateway. It warms Alpha, visits Beta, stalls the next Alpha `board.get`, then requires the original Alpha DOM node to become visible within one second while verifying that only the visible dashboard is active.

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/dashboard-session-retention.e2e.test.ts
PASS

node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-board.test.ts ui/src/pages/chat/chat-pane-retained-presentation.test.ts ui/src/pages/chat/chat-page-retained-sessions.test.ts
PASS

node scripts/check-changed.mjs -- ui/src/pages/chat/chat-page-pane-render.ts ui/src/pages/chat/chat-page-retained-sessions.ts ui/src/pages/chat/chat-pane-base.ts ui/src/pages/chat/chat-pane-board.ts ui/src/pages/chat/chat-pane-lifecycle.ts ui/src/pages/chat/chat-pane-retained-presentation.ts ui/src/pages/chat/route-draft-focus-handoff.ts ui/src/e2e/dashboard-session-retention.e2e.test.ts
PASS
```

Pre-fix A/B proof: reversing only the seven production changes makes the E2E fail because `alpha-main` does not become visible within one second while `board.get` is stalled. The fixed code passes and preserves the same runtime element identity.

Final code-aware autoreview completed with no accepted or actionable findings; patch correctness was rated 0.98.

Production LOC: +13/-7 (net +6), justified by separating retained provider lifetime from visual activity ownership. Test LOC: +131/-0.

Proof gap: the signed-in team-server Chrome relay was unavailable. This evidence is an isolated mocked-Gateway/real-Playwright-browser flow, not a live team-server test, and no operator Gateway or state was touched.
