### PR TITLE
chore(macos): pin Peekaboo 4.2.2 source

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "009ce711da673deaa0e263005d3ceb3c94518c1f4829686709798e404117a187",
+  "originHash" : "9192d83763432d1dc27bc11b5af000b4c5f3d3515e3ddefb673899c4f97e0c31",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/Peekaboo.git",
       "state" : {
-        "revision" : "f22109e7e7810fb655000615e6c86856bdb77701"
+        "revision" : "05675b0b5e2c382146963e19493787d9dac0d45b"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
         .package(
             url: "https://github.com/openclaw/Peekaboo.git",
-            revision: "f22109e7e7810fb655000615e6c86856bdb77701"),
+            revision: "05675b0b5e2c382146963e19493787d9dac0d45b"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),


### PR DESCRIPTION
## What Problem This Solves

The macOS app still compiled against Peekaboo source `f22109e7…`, so future normal and elevation-host builds missed the released 4.2.2 background-automation, exact-target receipt, and certification hardening.

## Why This Change Was Made

Pins the macOS Swift package manifest to the exact source of [Peekaboo 4.2.2](https://github.com/openclaw/Peekaboo/releases/tag/v4.2.2), commit `05675b0b5e2c382146963e19493787d9dac0d45b`, and lets SwiftPM regenerate the matching lockfile `originHash`. All sixteen non-Peekaboo Swift pins remain byte-identical to current `main`.

## User Impact

Future OpenClaw macOS and elevation-host builds embed the released Peekaboo 4.2.2 Bridge runtime and its fail-closed background interaction fixes. This dependency-only PR does not itself package, install, notarize, or release a new OpenClaw app.

## Evidence

- `v4.2.2` resolves exactly to `05675b0b5e2c382146963e19493787d9dac0d45b`; the connected checkout resolved to the same commit.
- `swift package --package-path apps/macos resolve` is idempotent; only the Peekaboo revision and generated `originHash` differ from `main`.
- `pnpm test test/scripts/package-mac-app.test.ts test/scripts/codesign-mac-app.test.ts test/scripts/mac-elevation-host.test.ts`: 3 files, 178 tests passed.
- `pnpm check:changed`: all selected dependency, Swift lint, app, packaging, signing, elevation, and changed-file gates passed.
- `pnpm test:changed`: no additional precise Vitest targets.
- `swift build --package-path apps/macos --configuration release`: passed.
- `.agents/skills/autoreview/scripts/autoreview --mode local --engine codex --model gpt-5.6-sol --thinking high`: clean, no accepted or actionable findings.

AI-assisted: yes. I reviewed the exact two-file pin, upstream dependency contract, generated lockfile, and connected macOS build.
