### PR TITLE
fix(gateway): record display-cap truncation structurally on projected chat messages

### DIFF
--- a/src/gateway/chat-display-projection.canvas.ts
+++ b/src/gateway/chat-display-projection.canvas.ts
@@ -65,19 +65,24 @@ export function isToolResultHistoryBlockType(type: unknown): boolean {
 export function projectToolResultDetails(
   details: unknown,
   maxChars: number,
-): Record<string, unknown> | undefined {
+): { details: Record<string, unknown> | undefined; truncated: boolean } {
   const record = readRecord(details);
   if (!record) {
-    return undefined;
+    return { details: undefined, truncated: false };
   }
   const projected: Record<string, unknown> = {};
+  // The diff is the one display-capped field here; surface the fact so the
+  // message-level marker covers capped tool-result details too.
+  let truncated = false;
   for (const key of ["changed", "created"] as const) {
     if (typeof record[key] === "boolean") {
       projected[key] = record[key];
     }
   }
   if (typeof record.diff === "string" && record.diff.trim()) {
-    projected.diff = truncateChatHistoryText(record.diff, maxChars).text;
+    const diff = truncateChatHistoryText(record.diff, maxChars);
+    projected.diff = diff.text;
+    truncated = diff.truncated;
   }
   if (Array.isArray(record.approvalReviews)) {
     const reviews = record.approvalReviews
@@ -109,7 +114,7 @@ export function projectToolResultDetails(
       mcpApp: preview.mcpApp,
     };
   }
-  return Object.keys(projected).length > 0 ? projected : undefined;
+  return { details: Object.keys(projected).length > 0 ? projected : undefined, truncated };
 }
 
 export function messageHasToolResultShape(message: Record<string, unknown>): boolean {

--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -142,12 +142,15 @@ function projectChatHistoryMediaFacts(value: unknown): unknown[] | undefined {
 export function sanitizeChatHistoryContentBlock(
   block: unknown,
   opts?: { preserveExactToolPayload?: boolean; maxChars?: number },
-): { block: unknown; changed: boolean } {
+): { block: unknown; changed: boolean; truncated: boolean } {
   if (!block || typeof block !== "object") {
-    return { block, changed: false };
+    return { block, changed: false, truncated: false };
   }
   const entry = { ...(block as Record<string, unknown>) };
   let changed = false;
+  // Display-cap truncation is a fact consumers need (to fetch the full row), so
+  // it is tracked apart from `changed`, which also covers metadata stripping.
+  let truncated = false;
   const preserveExactToolPayload =
     opts?.preserveExactToolPayload === true || isToolHistoryBlockType(entry.type);
   const maxChars = opts?.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
@@ -165,6 +168,7 @@ export function sanitizeChatHistoryContentBlock(
       const res = truncateChatHistoryText(entry.text, maxChars);
       entry.text = res.text;
       changed ||= res.truncated;
+      truncated ||= res.truncated;
     }
   }
   if (typeof entry.content === "string") {
@@ -172,22 +176,26 @@ export function sanitizeChatHistoryContentBlock(
       const res = truncateChatHistoryText(entry.content, maxChars);
       entry.content = res.text;
       changed ||= res.truncated;
+      truncated ||= res.truncated;
     }
   }
   if (typeof entry.partialJson === "string" && !preserveExactToolPayload) {
     const res = truncateChatHistoryText(entry.partialJson, maxChars);
     entry.partialJson = res.text;
     changed ||= res.truncated;
+    truncated ||= res.truncated;
   }
   if (typeof entry.arguments === "string" && !preserveExactToolPayload) {
     const res = truncateChatHistoryText(entry.arguments, maxChars);
     entry.arguments = res.text;
     changed ||= res.truncated;
+    truncated ||= res.truncated;
   }
   if (typeof entry.thinking === "string") {
     const res = truncateChatHistoryText(entry.thinking, maxChars);
     entry.thinking = res.text;
     changed ||= res.truncated;
+    truncated ||= res.truncated;
   }
   if ("thinkingSignature" in entry) {
     delete entry.thinkingSignature;
@@ -199,7 +207,7 @@ export function sanitizeChatHistoryContentBlock(
   }
   const mediaChanged = projectChatHistoryMediaBlock(entry);
   changed ||= mediaChanged;
-  return { block: changed ? entry : block, changed };
+  return { block: changed ? entry : block, changed, truncated };
 }
 
 function sanitizeAssistantPhasedContentBlocks(content: unknown[]): {
@@ -372,6 +380,7 @@ export function sanitizeChatHistoryMessage(
   }
   const entry = { ...(message as Record<string, unknown>) };
   let changed = false;
+  let truncated = false;
   if ("providerReplay" in entry) {
     delete entry.providerReplay;
     changed = true;
@@ -464,6 +473,7 @@ export function sanitizeChatHistoryMessage(
       const res = truncateChatHistoryText(controlStripped, maxChars);
       entry.content = res.text;
       changed ||= res.truncated;
+      truncated ||= res.truncated;
     }
   } else if (Array.isArray(entry.content)) {
     const updated = entry.content.map((block) => {
@@ -486,12 +496,13 @@ export function sanitizeChatHistoryMessage(
       const text = stripSuppressedControlReplyToken(contentBlock.text);
       return text === contentBlock.text
         ? sanitized
-        : { block: { ...contentBlock, text }, changed: true };
+        : { block: { ...contentBlock, text }, changed: true, truncated: sanitized.truncated };
     });
     if (updated.some((item) => item.changed)) {
       entry.content = updated.map((item) => item.block);
       changed = true;
     }
+    truncated ||= updated.some((item) => item.truncated);
     if (entry.role === "assistant" && Array.isArray(entry.content)) {
       const mixedToolContent = projectAssistantMixedToolContent(entry.content, maxChars);
       if (mixedToolContent) {
@@ -521,7 +532,22 @@ export function sanitizeChatHistoryMessage(
       const res = truncateChatHistoryText(controlStripped, maxChars);
       entry.text = res.text;
       changed ||= res.truncated;
+      truncated ||= res.truncated;
     }
+  }
+
+  if (truncated) {
+    // Record the display cap where it is applied so any session.message or
+    // chat.history consumer can tell a bounded preview from the full row and
+    // fetch it via chat.message.get. An upstream "oversized" transcript
+    // marker already explains the truncation; never overwrite its reason.
+    const meta = readRecord(entry["__openclaw"]);
+    entry["__openclaw"] = {
+      ...meta,
+      truncated: true,
+      reason: typeof meta?.reason === "string" ? meta.reason : "display-cap",
+    };
+    changed = true;
   }
 
   return { message: changed ? entry : message, changed };

--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -156,12 +156,13 @@ export function sanitizeChatHistoryContentBlock(
   const maxChars = opts?.maxChars ?? DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS;
   if (isToolResultHistoryBlockType(entry.type) && "details" in entry) {
     const projectedDetails = projectToolResultDetails(entry.details, maxChars);
-    if (projectedDetails) {
-      entry.details = projectedDetails;
+    if (projectedDetails.details) {
+      entry.details = projectedDetails.details;
     } else {
       delete entry.details;
     }
     changed = true;
+    truncated ||= projectedDetails.truncated;
   }
   if (typeof entry.text === "string") {
     if (!preserveExactToolPayload) {
@@ -416,17 +417,19 @@ export function sanitizeChatHistoryMessage(
     typeof entry.tool_call_id === "string";
 
   if ("details" in entry) {
-    const projectedDetails =
-      projectWorkspaceConflictDetails(entry) ??
-      (messageHasToolResultShape(entry)
+    const conflictDetails = projectWorkspaceConflictDetails(entry);
+    const toolResultDetails =
+      !conflictDetails && messageHasToolResultShape(entry)
         ? projectToolResultDetails(entry.details, maxChars)
-        : undefined);
+        : undefined;
+    const projectedDetails = conflictDetails ?? toolResultDetails?.details;
     if (projectedDetails) {
       entry.details = projectedDetails;
     } else {
       delete entry.details;
     }
     changed = true;
+    truncated ||= toolResultDetails?.truncated === true;
   }
 
   if (entry.role !== "assistant") {

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -405,6 +405,34 @@ describe("transcript metadata projection", () => {
     expect(projected?.["__openclaw"]).toBeUndefined();
   });
 
+  it("marks display-cap truncation of a tool-result diff on both tool-result shapes", () => {
+    const longDiff = "+line\n".repeat(40);
+    const [blockShaped, messageShaped] = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [
+            { type: "toolResult", toolName: "edit", details: { changed: true, diff: longDiff } },
+          ],
+        },
+        { role: "toolResult", toolName: "edit", details: { changed: true, diff: longDiff } },
+      ],
+      32,
+    ) as Record<string, unknown>[];
+    for (const projected of [blockShaped, messageShaped]) {
+      expect(JSON.stringify(projected)).toContain("...(truncated)...");
+      expect(projected?.["__openclaw"]).toMatchObject({ truncated: true, reason: "display-cap" });
+    }
+  });
+
+  it("leaves a tool-result diff within the cap unmarked", () => {
+    const [projected] = sanitizeChatHistoryMessages(
+      [{ role: "toolResult", toolName: "edit", details: { changed: true, diff: "+ok" } }],
+      32,
+    ) as Record<string, unknown>[];
+    expect(projected?.["__openclaw"]).toBeUndefined();
+  });
+
   it("does not overwrite an upstream oversized reason with display-cap", () => {
     const [projected] = sanitizeChatHistoryMessages(
       [

--- a/src/gateway/chat-display-projection.test.ts
+++ b/src/gateway/chat-display-projection.test.ts
@@ -366,6 +366,58 @@ describe("transcript metadata projection", () => {
       );
     }
   });
+
+  it("records a display-cap marker on every history transport when text is truncated", () => {
+    const message = { role: "assistant", content: "x".repeat(9_000), timestamp: 1 };
+    for (const messages of projectHistoryTransports(message)) {
+      const projected = messages[0] as Record<string, unknown>;
+      expect(JSON.stringify(projected.content)).toContain("...(truncated)...");
+      // Structured fact, so consumers fetch the full row via chat.message.get
+      // instead of sniffing the in-band sentinel.
+      expect(projected["__openclaw"]).toEqual({ truncated: true, reason: "display-cap" });
+    }
+  });
+
+  it("marks display-cap truncation inside content blocks and keeps existing metadata", () => {
+    const [projected] = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "block text ".repeat(20) }],
+          __openclaw: { id: "message-9", senderId: "assistant-1" },
+        },
+      ],
+      16,
+    ) as Record<string, unknown>[];
+    expect(projected?.["__openclaw"]).toEqual({
+      id: "message-9",
+      senderId: "assistant-1",
+      truncated: true,
+      reason: "display-cap",
+    });
+  });
+
+  it("leaves untruncated messages without a truncation marker", () => {
+    const [projected] = sanitizeChatHistoryMessages(
+      [{ role: "assistant", content: "short", timestamp: 1 }],
+      16,
+    ) as Record<string, unknown>[];
+    expect(projected?.["__openclaw"]).toBeUndefined();
+  });
+
+  it("does not overwrite an upstream oversized reason with display-cap", () => {
+    const [projected] = sanitizeChatHistoryMessages(
+      [
+        {
+          role: "assistant",
+          content: "still long enough to cap ".repeat(4),
+          __openclaw: { truncated: true, reason: "oversized" },
+        },
+      ],
+      16,
+    ) as Record<string, unknown>[];
+    expect(projected?.["__openclaw"]).toEqual({ truncated: true, reason: "oversized" });
+  });
 });
 
 describe("managed inbound media fact projection", () => {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -888,7 +888,12 @@ describe("sanitizeChatHistoryMessages", () => {
     );
 
     expect(result).toEqual([
-      assistantHistoryMessage(`${prefix}\n...(truncated)...`, { timestamp: 1 }),
+      assistantHistoryMessage(`${prefix}\n...(truncated)...`, {
+        timestamp: 1,
+        // The display cap is recorded structurally so consumers need not sniff
+        // the in-band sentinel to know the row is a bounded preview.
+        __openclaw: { truncated: true, reason: "display-cap" },
+      }),
     ]);
   });
 
@@ -2074,6 +2079,7 @@ describe("projectRecentChatDisplayMessages", () => {
       assistantAudioAttachmentHistoryMessage(
         `${projectedVisibleText.slice(0, 24)}\n...(truncated)...`,
         1,
+        { __openclaw: { truncated: true, reason: "display-cap" } },
       ),
     ]);
   });

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -6246,12 +6246,19 @@ describe("gateway server chat", () => {
 
       const historyMessages = await fetchHistoryMessages(ws, { maxChars: 5 });
       expect(JSON.stringify(historyMessages)).toContain("abcde\\n...(truncated)...");
+      // The capped row is structurally marked so a client can detect the bounded
+      // preview without sniffing the sentinel, then fetch the durable content.
+      expect(
+        (historyMessages[0] as Record<string, unknown> | undefined)?.["__openclaw"],
+      ).toMatchObject({ truncated: true, reason: "display-cap" });
 
       const full = await fetchChatMessage(ws, makeMainMessageParams("msg-full-assistant"));
       expect(full.ok).toBe(true);
       expect(full.unavailableReason).toBeUndefined();
       expect(JSON.stringify(full.message)).toContain("abcdefghij");
       expect(JSON.stringify(full.message)).not.toContain("...(truncated)...");
+      const fullMeta = (full.message as Record<string, unknown> | undefined)?.["__openclaw"];
+      expect((fullMeta as { truncated?: unknown } | undefined)?.truncated).toBeUndefined();
     });
   });
 

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -1826,6 +1826,39 @@ describe("session.message websocket events", () => {
     });
   });
 
+  test("marks display-cap truncation structurally on live session.message events", async () => {
+    const storePath = await createSessionStoreFile();
+    await writeSessionStore({
+      entries: { main: { sessionId: "sess-main", updatedAt: Date.now() } },
+      storePath,
+    });
+    const transcriptMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "x".repeat(9_000) }],
+      timestamp: Date.now(),
+    };
+    await persistSessionTranscriptTurn(
+      { agentId: "main", sessionId: "sess-main", sessionKey: "agent:main:main", storePath },
+      { messages: [{ message: transcriptMessage }], updateMode: "none" },
+    );
+
+    await withOperatorSessionSubscriber(async (ws) => {
+      const { messageEvent } = await emitTranscriptUpdateAndCollectMessageEvent({
+        ws,
+        sessionKey: "agent:main:main",
+        sessionFile: "agent:main:main",
+        message: transcriptMessage,
+        messageId: "msg-capped",
+      });
+      const payload = requireRecord(messageEvent.payload, "capped message payload");
+      const message = requireRecord(payload.message, "capped message");
+      // The preview is bounded by the display cap and says so structurally, so a
+      // non-UI consumer can fetch the full row instead of sniffing the sentinel.
+      expect(JSON.stringify(message.content)).toContain("...(truncated)...");
+      expect(message["__openclaw"]).toMatchObject({ truncated: true, reason: "display-cap" });
+    });
+  });
+
   test("prefers carried transcript sequence for live session events", async () => {
     const storePath = await createSessionStoreFile();
     await writeSessionStore({

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -222,7 +222,14 @@ describeControlUiE2e("Control UI chat message actions", () => {
           role: "assistant",
           content: [{ type: "text", text: truncatedPreview }],
           timestamp: Date.now() + 4,
-          __openclaw: { id: "assistant-full-message", seq: 5 },
+          // The Gateway records a display-cap structurally; the sentinel alone is
+          // ordinary Markdown to the UI.
+          __openclaw: {
+            id: "assistant-full-message",
+            seq: 5,
+            truncated: true,
+            reason: "display-cap",
+          },
         },
       ],
       methodResponses: {

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -25,6 +25,22 @@ describe("resolveMessageActionDetails full-message fetch flag", () => {
     },
   );
 
+  it("does not fetch an assistant message that merely contains the sentinel text", () => {
+    // The in-band "...(truncated)..." is ordinary Markdown to the UI; without the
+    // Gateway's structural marker it is not evidence of a display cap.
+    const details = resolveMessageActionDetails({
+      message: {
+        role: "assistant",
+        content: "Quoting a log line:\n...(truncated)...\nand continuing normally.",
+        __openclaw: { id: "msg-3" },
+      },
+      messageId: "msg-3",
+      canFetchFullMessage: true,
+      senderLabel: "assistant",
+    });
+    expect(details?.shouldFetchFullMessage).toBe(false);
+  });
+
   it("does not fetch an untruncated assistant message", () => {
     const details = resolveMessageActionDetails({
       message: { role: "assistant", content: "Complete.", __openclaw: { id: "msg-2" } },

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -1,0 +1,37 @@
+/* @vitest-environment jsdom */
+// Contract for the full-message fetch flag: the Gateway marks every display-
+// capped projection (user rows included), but the expander that consumes this
+// flag renders loaded content for assistant rows alone.
+import { describe, expect, it } from "vitest";
+import { resolveMessageActionDetails } from "./chat-message-markdown.ts";
+
+const cappedMeta = { id: "msg-1", truncated: true, reason: "display-cap" };
+
+describe("resolveMessageActionDetails full-message fetch flag", () => {
+  it.each([
+    { role: "assistant", shouldFetch: true },
+    { role: "user", shouldFetch: false },
+  ])(
+    "role=$role capped by metadata -> shouldFetchFullMessage=$shouldFetch",
+    ({ role, shouldFetch }) => {
+      const details = resolveMessageActionDetails({
+        message: { role, content: "Preview\n...(truncated)...", __openclaw: cappedMeta },
+        messageId: "msg-1",
+        canFetchFullMessage: true,
+        onReply: () => {},
+        senderLabel: role,
+      });
+      expect(details?.shouldFetchFullMessage).toBe(shouldFetch);
+    },
+  );
+
+  it("does not fetch an untruncated assistant message", () => {
+    const details = resolveMessageActionDetails({
+      message: { role: "assistant", content: "Complete.", __openclaw: { id: "msg-2" } },
+      messageId: "msg-2",
+      canFetchFullMessage: true,
+      senderLabel: "assistant",
+    });
+    expect(details?.shouldFetchFullMessage).toBe(false);
+  });
+});

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -129,15 +129,16 @@ export function resolveMessageActionDetails(params: {
   const normalizedMessage = normalizeMessage(message);
   const role = normalizeRoleForGrouping(normalizedMessage.role);
   const previewMarkdown = resolveMessageReplyText(message);
-  // Loaded text must not erase the preview's truncation fact or collapse its disclosure.
-  // Assistant-only: the full-message expander renders loaded content for assistant
-  // rows alone, so a capped user row must not trigger a fetch it never displays.
+  // The Gateway records every display-cap truncation as __openclaw.truncated, so
+  // that marker is the whole contract: sniffing the in-band sentinel would fetch
+  // for any reply that merely contains the text. Assistant-only because the
+  // expander renders loaded content for assistant rows alone.
   const shouldFetchFullMessage = Boolean(
     role === "assistant" &&
     canFetchFullMessage &&
     messageId &&
     !record.openclawMessageToolMirror &&
-    (transcriptMeta?.truncated === true || previewMarkdown.includes("\n...(truncated)...")),
+    transcriptMeta?.truncated === true,
   );
   const expansion =
     role === "assistant" && shouldFetchFullMessage && messageId

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -130,12 +130,14 @@ export function resolveMessageActionDetails(params: {
   const role = normalizeRoleForGrouping(normalizedMessage.role);
   const previewMarkdown = resolveMessageReplyText(message);
   // Loaded text must not erase the preview's truncation fact or collapse its disclosure.
+  // Assistant-only: the full-message expander renders loaded content for assistant
+  // rows alone, so a capped user row must not trigger a fetch it never displays.
   const shouldFetchFullMessage = Boolean(
+    role === "assistant" &&
     canFetchFullMessage &&
     messageId &&
     !record.openclawMessageToolMirror &&
-    (transcriptMeta?.truncated === true ||
-      (role === "assistant" && previewMarkdown.includes("\n...(truncated)..."))),
+    (transcriptMeta?.truncated === true || previewMarkdown.includes("\n...(truncated)...")),
   );
   const expansion =
     role === "assistant" && shouldFetchFullMessage && messageId

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -5515,7 +5515,7 @@ describe("grouped chat rendering", () => {
       {
         role: "assistant",
         content: [{ type: "text", text: preview }],
-        __openclaw: { id: "assistant-disclosure-actions", seq: 1 },
+        __openclaw: { id: "assistant-disclosure-actions", seq: 1, truncated: true },
       },
       {
         sessionKey: "agent:main:main",
@@ -5648,7 +5648,7 @@ describe("grouped chat rendering", () => {
       message: {
         role: "assistant",
         content: [{ type: "text", text: "abcde\n...(truncated)..." }],
-        __openclaw: { id: "msg-truncated-marker", seq: 1 },
+        __openclaw: { id: "msg-truncated-marker", seq: 1, truncated: true },
       },
       messageId: "msg-truncated-marker",
     },
@@ -5693,7 +5693,7 @@ describe("grouped chat rendering", () => {
         {
           role: "assistant",
           content: [{ type: "text", text: "abcde\n...(truncated)..." }],
-          __openclaw: { id: "msg-retry-error", seq: 1 },
+          __openclaw: { id: "msg-retry-error", seq: 1, truncated: true },
         },
         {
           sessionKey: "global",
@@ -5719,7 +5719,7 @@ describe("grouped chat rendering", () => {
       {
         role: "assistant",
         content: [{ type: "text", text: "abcde\n...(truncated)..." }],
-        __openclaw: { id: "msg-retry-exhausted", seq: 1 },
+        __openclaw: { id: "msg-retry-exhausted", seq: 1, truncated: true },
       },
       {
         sessionKey: "global",
@@ -5763,7 +5763,7 @@ describe("grouped chat rendering", () => {
     renderAssistantMessage(container, {
       role: "assistant",
       content: [{ type: "text", text: "abcde\n...(truncated)..." }],
-      __openclaw: { id: "msg-no-loader", seq: 1 },
+      __openclaw: { id: "msg-no-loader", seq: 1, truncated: true },
     });
 
     expect(container.querySelector(".chat-message-disclosure__toggle")).toBeNull();

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -256,7 +256,7 @@ describe("chat transcript rendering", () => {
         {
           role: "assistant",
           content: "Preview\n...(truncated)...",
-          __openclaw: { id: "assistant-full-1" },
+          __openclaw: { id: "assistant-full-1", truncated: true },
           timestamp: 1_000,
         },
       ]),
@@ -296,7 +296,7 @@ describe("chat transcript rendering", () => {
         {
           role: "assistant",
           content: "Preview\n...(truncated)...",
-          __openclaw: { id: "assistant-retry-1" },
+          __openclaw: { id: "assistant-retry-1", truncated: true },
           timestamp: 1_000,
         },
       ]),


### PR DESCRIPTION
Closes #126229

## What Problem This Solves

When the chat display projection truncates a message at the display cap (`DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS`, 8,000 chars), the emitted `session.message` payload and `chat.history` row carried **no structured truncation marker** — the only signal was the in-band literal `\n...(truncated)...` appended to the Markdown. Programmatic consumers of `session.message` could not distinguish a bounded preview from the authoritative message, and the Control UI itself fell back to substring-matching that sentinel inside user-visible Markdown — a contract indistinguishable from the same characters appearing in legitimate content.

The fact *was* computed and then thrown away: `truncateChatHistoryText` returns `{ text, truncated }`, and every call site in `chat-display-projection.sanitize.ts` folded `res.truncated` into a local `changed` boolean that only decides whether a block gets replaced.

## Why This Change Was Made

Record the fact where it happens — at the shared projection owner that feeds both live events and history — rather than adding a client-side heuristic or touching the cap (#95318 settled that a bounded projection plus on-demand `chat.message.get` is the intended design; this PR only makes the bound detectable).

- **`src/gateway/chat-display-projection.sanitize.ts`**: `sanitizeChatHistoryContentBlock` returns `truncated` as its own fact alongside `changed` (they were overloaded — `changed` also covers metadata stripping like `thinkingSignature`, which is why the truncation signal got lost). `sanitizeChatHistoryMessage` aggregates it across string `content`, content-block arrays, and string `text`, and where the cap applied records `__openclaw: { truncated: true, reason: "display-cap" }` — the sibling of the existing `reason: "oversized"` transcript marker at `session-utils.fs.ts:425`. Existing `__openclaw` metadata (transcript `id`/`seq`, sender profile) is preserved; an upstream `oversized` reason is never overwritten.
- **`src/gateway/chat-display-projection.canvas.ts`** (review follow-up): `projectToolResultDetails` capped `details.diff` but kept only `.text`, dropping `.truncated` — the same discard one level down. It now returns `{ details, truncated }` and both sanitizer call sites (tool-result content block, tool-result-shaped message) aggregate the fact, so a capped tool-result diff carries the marker too. Workspace-conflict details keep precedence.
- **`ui/src/pages/chat/components/chat-message-markdown.ts`** (review follow-ups): `shouldFetchFullMessage` now keys **only** on `__openclaw.truncated === true`, and is assistant-only. (a) The sentinel fallback — treating literal Markdown ending in `...(truncated)...` as proof of a cap — is removed: it is obsolete now that the Gateway marks every cap structurally, and it was wrong, since an ordinary reply merely containing that text would spuriously fetch. No gateway-version compatibility is carried, per the Control UI coupling policy. (b) Assistant-only because the expander renders loaded content for assistant rows alone. The two consumers in `chat-message-group.ts` key purely off the flag and need no change. Existing fixtures that expressed truncation via the sentinel now carry the marker, as the Gateway emits.

The Control UI already treats `__openclaw.truncated === true` as authoritative and has a metadata-only detection test, so the producer change is a **missing producer fact**, not a new client capability. The addition is protocol-additive.

**Production LOC:** +37 across three files (~8 thread `truncated` through the per-field sites that previously discarded it; the marker write; the 1-line UI gate; repo-required invariant comments). Conceptually one new recorded fact at its owner plus one flag contract alignment. There was no stale structure to absorb it into — the discarding *was* the structure.

## User Impact

Any `session.message` or `chat.history` consumer — third-party clients, the `sessions_history` tool, the Control UI — can detect a display-capped message structurally and fetch the durable content via `chat.message.get`, instead of sniffing a sentinel. Visible text, the cap, and untruncated messages are unchanged.

## Evidence

### Real behavior proof — real gateway, real WebSocket subscriber (no mocks)

**Live `session.message` event.** A 9,000-char assistant message persisted to a transcript and broadcast through the real gateway to a real operator WebSocket subscriber. The payload the subscriber received (captured verbatim from the run at head `fdfa79c536`):

```json
{
    "event": "session.message",
    "sessionKey": "agent:main:main",
    "messageId": "msg-capped",
    "messageSeq": 1,
    "role": "assistant",
    "contentTextLength": 8018,
    "contentTail": "xxxxxx\n...(truncated)...",
    "__openclaw": {
        "id": "msg-capped",
        "seq": 1,
        "truncated": true,
        "reason": "display-cap"
    }
}
```

9,000 chars → 8,018 (8,000 + sentinel), the in-band sentinel is still present for legacy readers, and the structured `truncated: true, reason: "display-cap"` sits alongside the preserved transcript `id`/`seq`.

**`chat.history` → `chat.message.get` round-trip** over the real gateway harness, same head:

```json
{
    "chat.history(maxChars=5)": {
        "content": [
            {
                "type": "text",
                "text": "abcde\n...(truncated)..."
            }
        ],
        "__openclaw": {
            "id": "msg-full-assistant",
            "seq": 1,
            "truncated": true,
            "reason": "display-cap"
        }
    },
    "chat.message.get": {
        "ok": true,
        "content": [
            {
                "type": "text",
                "text": "abcdefghij"
            }
        ],
        "__openclaw": {
            "id": "msg-full-assistant",
            "seq": 1
        }
    }
}
```

The capped history row is marked; the full row for the same id returns the complete text with **no** truncation marker.

**Exact-head tool-result path (review follow-up, captured at the current head `f6ec2adec7`).** A tool-result message whose `details.diff` is 12,000 chars, persisted and broadcast through the real gateway to a real operator WebSocket subscriber — the diff is capped to 8,018 and the message carries the marker:

```json
{
    "event": "session.message",
    "sessionKey": "agent:main:main",
    "messageId": "msg-tool-capped",
    "role": "toolResult",
    "toolName": "edit",
    "originalDiffLength": 12000,
    "projectedDiffLength": 8018,
    "diffTail": "e\n+l\n...(truncated)...",
    "__openclaw": {
        "id": "msg-tool-capped",
        "seq": 1,
        "truncated": true,
        "reason": "display-cap"
    }
}
```

### Regression coverage

- `chat-display-projection.test.ts` (+6): marker on **both** history transports (WebSocket + SSE); marker for truncation **inside content blocks** preserving existing `__openclaw` keys; marker for a **capped tool-result diff on both tool-result shapes** (content block and tool-result message); **no marker** on untruncated rows or a within-cap diff; upstream **`oversized` reason not overwritten**.
- `session-message-events.test.ts` (+1): the live-event assertion behind the JSON above.
- `server.chat.gateway-server-chat-b.test.ts`: the existing round-trip test — which previously asserted via the sentinel substring, the reported anti-pattern — now asserts the marker on the capped row and its absence on the full row.
- `server-methods.test.ts`: two exact-shape assertions on deliberately truncated messages updated to the new contract.
- `chat-message-markdown.test.ts` (new, +4): the fetch flag contract — capped user row `false`, capped assistant row `true`, untruncated assistant `false`, and an assistant reply that merely **contains** the sentinel text without the marker `false` (fails with the fallback present).

**Fails pre-fix, passes post-fix:** with only the production file reverted, the three new marker tests fail (live event, every transport, content blocks); the `oversized`-preservation and no-marker cases pass on both (they guard invariants that already hold). With only the tool-result change reverted, the capped-diff case fails and the within-cap negative still passes. With only the UI gate reverted, the user-row flag case fails.

**On the review's P2 (capped user rows firing the assistant loader):** I tried to reproduce it through `renderChatThread` with a materialized capped user row, reply wired, and the gate removed — zero loader calls; the render path already blocks the fetch upstream of this flag. The gate is kept because it aligns the flag's contract with its assistant-only consumer (and is the shape the review asked for), but it is defense-in-depth, not the closing of an observed request. The discriminating test lives at the flag itself for that reason.

**CI note — `checks-ui-e2e (3/12)`:** three runs on this PR (`32284000525`, `32286141711`, `32288949072`, the last on a fully current base) failed only this shard, every time on the same assertion in `ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts` — `expected '' to be 'restore this text-only prompt after r…'`. That is a known intermittent race in that test, not this PR: #125548 (merged 2026-08-18) describes the identical failure blocking #125498 twice, and #125637 / #125702 / #125868 are further fixes to the same draft-restore path. The test exercises new-session draft persistence against a mock gateway and never touches chat projection or `__openclaw`; it passes 15/15 locally at this head with real Chromium. (`node-compact-large-16` failed once on `sessions-mutations.perf.test.ts`, a perf-timing test, likewise unrelated.)

**CI note — run `32292043317` on `a7f161ac50`:** `checks-ui-e2e (1/12)` failed in `chat-message-actions.e2e.test.ts:388` waiting for `chat.message.get` — **that one was this PR.** Removing the sentinel fallback was correct against the real Gateway, but this e2e's mock still seeded the truncated assistant message with the sentinel preview and no structural marker, so the UI (correctly) no longer fetched. Reproduced the timeout locally at that head and fixed by seeding `__openclaw.truncated`/`reason` as the Gateway now emits (`579a050ff9`); passes with real Chromium. A sweep confirms no production UI code still branches on the sentinel and no other e2e asserts the full-message load. (`node-compact-small-41` failed on `test/scripts/bench-gateway-startup.test.ts`, a startup-benchmark probe timing race, unrelated.)

### Gates on the head
- ClawSweeper acceptance: `chat-transcript-render.test.ts` + `chat-message.test.ts` — 198/198; `session-message-events.test.ts -t "marks display-cap..."` — pass; `check-changed` over the UI files — exit 0.
- Four gateway suites **375/375**; UI consumer suites green; `node scripts/check-changed.mjs` over all changed files — exit 0 (typecheck core + core tests, lint, format, all guards); `git diff --check` clean.
- Swept every other `.truncated` reader in `src/`, `ui/`, `packages/` — all unrelated (tool output, bash sessions, harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013n5eSiz5Uy57civqEnUMAS