### PR TITLE
fix(config): reuse canonical git URL parser for cloud project identity

### DIFF
--- a/src/config/cloud-worker-project-profiles.test.ts
+++ b/src/config/cloud-worker-project-profiles.test.ts
@@ -9,6 +9,30 @@ describe("normalizeCloudRepo", () => {
     ["trailing .git", "https://github.com/acme/app.git", "github.com/acme/app"],
     ["missing owner and repo", "https://github.com", undefined],
     ["missing repo", "https://github.com/acme", undefined],
+    ["ssh scheme origin", "ssh://git@github.com/acme/app.git", "github.com/acme/app"],
+    [
+      "ssh scheme origin with default port",
+      "ssh://git@github.com:22/acme/app.git",
+      "github.com/acme/app",
+    ],
+    [
+      "ssh scheme origin with custom port",
+      "ssh://git@github.com:2222/acme/app.git",
+      "github.com/acme/app",
+    ],
+    [
+      "https origin with userinfo",
+      "https://user:token@github.com/acme/app.git",
+      "github.com/acme/app",
+    ],
+    [
+      "self-hosted nested path",
+      "https://gitlab.example.com/group/sub/app.git",
+      "gitlab.example.com/group/sub/app",
+    ],
+    ["path traversal", "https://github.com/acme/../app.git", undefined],
+    ["unsupported scheme", "file:///tmp/repo.git", undefined],
+    ["empty origin", "   ", undefined],
   ])("normalizes %s", (_label, originUrl, expected) => {
     expect(normalizeCloudRepo(originUrl)).toBe(expected);
   });

--- a/src/config/cloud-worker-project-profiles.ts
+++ b/src/config/cloud-worker-project-profiles.ts
@@ -1,40 +1,26 @@
 // Normalizes repository remotes for cloud-worker project profile selection.
 
+import { parseGitUrl } from "../agents/utils/git.js";
+
 /** Normalize a Git origin URL to a lowercase host/path repository identity. */
 export function normalizeCloudRepo(originUrl: string): string | undefined {
   const value = originUrl.trim();
   if (!value) {
     return undefined;
   }
-
-  let host: string;
-  let repoPath: string;
-  const scpLike = value.match(/^[^@\s]+@([^:\s]+):(.+)$/u);
-  if (scpLike) {
-    host = scpLike[1] ?? "";
-    repoPath = scpLike[2] ?? "";
-  } else {
-    let parsed: URL;
-    try {
-      parsed = new URL(value);
-    } catch {
-      return undefined;
-    }
-    if (!["git:", "http:", "https:", "ssh:"].includes(parsed.protocol)) {
-      return undefined;
-    }
-    host = parsed.hostname;
-    repoPath = parsed.pathname;
-  }
-
-  const normalizedPath = repoPath.replace(/^\/+|\/+$/gu, "").replace(/\.git$/iu, "");
-  const segments = normalizedPath.split("/");
-  if (
-    !host ||
-    segments.length < 2 ||
-    segments.some((segment) => !segment || segment === "." || segment === "..")
-  ) {
+  // The canonical parser owns remote-form handling: scp-vs-scheme detection, userinfo,
+  // ports, and `.git`/traversal rules. A local regex mis-parses `ssh://git@host:22/o/r`
+  // into the path and silently drops the operator's mapping.
+  const source = parseGitUrl(`git:${value}`);
+  if (!source) {
     return undefined;
   }
-  return `${host}/${segments.join("/")}`.toLowerCase();
+  const segments = source.path.split("/").filter(Boolean);
+  if (!source.host || segments.length < 2) {
+    return undefined;
+  }
+  // Unlike project memory scope, the whole key folds to lowercase: these are
+  // operator-typed config keys selecting a machine profile, so a casing variant must
+  // not silently miss its mapping. A case-only collision still selects one profile.
+  return `${source.host}/${segments.join("/")}`.toLowerCase();
 }


### PR DESCRIPTION
## What Problem This Solves

`cloudWorkers.projectProfiles` (#126238) keys per-project defaults by a normalized repository identity derived from the session worktree's `remote.origin.url`. The normalizer hand-rolled an scp-form regex (`user@host:path`) that also matches scheme URLs, so a standard ported ssh remote parsed wrong:

```
ssh://git@github.com:22/acme/app.git   ->  github.com/22/acme/app   (expected github.com/acme/app)
ssh://git@github.com:2222/acme/app.git ->  github.com/2222/acme/app
```

The port lands in the repository path, so the key never matches the operator's configured mapping. Dispatch then takes the "no mapping" branch: the configured default is silently ignored, with no error and no visible outcome — the failure class this repo ranks above crashes.

Found by fuzzing the normalizer against real-world remote forms while stress-testing #126238.

## Why This Change Was Made

The deeper cause is a duplicated parser. This repo already derives a `host/path` repository identity from `remote.origin.url` in `src/agents/project-memory-scope.ts`, using the canonical `parseGitUrl` helper (`src/agents/utils/git.ts`) with documented reasoning about userinfo folding and case. That parser handles every form the local regex got wrong.

This change deletes the local parser and delegates. Verified against `parseGitUrl` directly: scp form, https, ssh scheme with and without port (22 and 2222), userinfo, uppercase host, trailing slash, `.git` suffix, self-hosted nested paths, and traversal/`file:`/garbage rejection all resolve correctly. Only the config-specific decision stays local — folding the whole key to lowercase, because these are operator-typed config keys selecting a machine profile (a casing variant must not silently miss its mapping), which is deliberately different from memory scope's case-preserving key. Both invariants are now commented at the site.

Production LOC: net -6 (28 removed, 22 added); tests +16.

## User Impact

Operators whose origin is an ssh URL with an explicit port now get their `cloudWorkers.projectProfiles` mapping applied instead of silently ignored. No config or API change; keys that already resolved keep resolving to the same values.

## Evidence

- `node scripts/run-vitest.mjs src/config/cloud-worker-project-profiles.test.ts` — 14/14, including the two ported-ssh forms that produced the wrong key before this change, plus userinfo, self-hosted nested path, traversal, unsupported scheme, and empty input.
- Downstream unaffected: `sessions.dispatch`, `sessions.dispatch.authorization`, and `method-scopes` suites — 200 passed.
- Skills/config/scopes sweep (3 shards) green on the same tree.
- Live gateway on latest `main` (isolated state dir, own port): a multi-agent config carrying `cloudWorkers.projectProfiles` validates, boots clean with zero errors, round-trips the mapping through `config get`, and custodian skill gating still holds (custodian agent 4 model-visible custodian skills, default agent 0).
- Autoreview (Codex): clean, no accepted/actionable findings.
