### PR TITLE
fix(ui): keep prose fences fully visible

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -39,7 +39,7 @@ import { buildSkillWorkshopMocks } from "./control-ui-mock-skill-workshop.js";
 
 type CliOptions = {
   allowedHosts: string[];
-  fixture?: "approval" | "board" | "swarm" | "workboard";
+  fixture?: "approval" | "board" | "code-fences" | "swarm" | "workboard";
   host: string;
   operatorScopes?: string[];
   port: number;
@@ -169,7 +169,13 @@ function parseFixture(value: string | undefined): CliOptions["fixture"] {
   if (!value) {
     return undefined;
   }
-  if (value !== "approval" && value !== "board" && value !== "swarm" && value !== "workboard") {
+  if (
+    value !== "approval" &&
+    value !== "board" &&
+    value !== "code-fences" &&
+    value !== "swarm" &&
+    value !== "workboard"
+  ) {
     throw new Error(`Unknown Control UI mock fixture: ${value}`);
   }
   return value;
@@ -1147,6 +1153,25 @@ function buildScrollableChatHistory(baseTime: number): unknown[] {
   return messages;
 }
 
+function buildCodeFenceChatHistory(baseTime: number): unknown[] {
+  const proseFence = (language: string, label: string) => {
+    const lines = Array.from({ length: 16 }, (_, index) => `${label} line ${index + 1}`);
+    return `\`\`\`${language}\n${lines.join("\n")}\n\`\`\``;
+  };
+  const jsonLines = Array.from({ length: 18 }, (_, index) => `  "item-${index + 1}",`);
+  jsonLines[jsonLines.length - 1] = `  "item-${jsonLines.length}"`;
+  return [
+    chatHistoryMessage("assistant", proseFence("text", "Plain text"), baseTime),
+    chatHistoryMessage("assistant", proseFence("md", "Markdown alias"), baseTime + 1_000),
+    chatHistoryMessage("assistant", proseFence("markdown", "Markdown"), baseTime + 2_000),
+    chatHistoryMessage(
+      "assistant",
+      `\`\`\`json\n[\n${jsonLines.join("\n")}\n]\n\`\`\``,
+      baseTime + 3_000,
+    ),
+  ];
+}
+
 function searchPrefixes(term: string): string[] {
   return Array.from({ length: term.length }, (_value, index) => term.slice(0, index + 1));
 }
@@ -1613,7 +1638,10 @@ async function createChatPickerScenario(
     swarmEnabled: fixture === "swarm",
     workboardEnabled: fixture === "workboard",
   });
-  const historyMessages = buildScrollableChatHistory(baseTime);
+  const historyMessages =
+    fixture === "code-fences"
+      ? buildCodeFenceChatHistory(baseTime)
+      : buildScrollableChatHistory(baseTime);
   const planSessionInfo = {
     activeRunIds: [PLAN_DEMO_RUN_ID],
     hasActiveRun: true,

--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -316,10 +316,9 @@ export function renderMarkdownCodeBlock(
   if (!shouldRenderCodeBlockInteraction(env)) {
     return `<div class="code-block-wrapper">${renderCodeBlockHeader(lang, copyButton)}${codeBlock}</div>`;
   }
-  const hiddenLineCount = Math.max(
-    0,
-    markdownCodeBlockCopyText(text).split("\n").length - CODE_PREVIEW_LINE_COUNT,
-  );
+  const hiddenLineCount = ["text", "md", "markdown"].includes(lang.trim().toLowerCase())
+    ? 0
+    : Math.max(0, markdownCodeBlockCopyText(text).split("\n").length - CODE_PREVIEW_LINE_COUNT);
   const hiddenCount = { count: String(hiddenLineCount) };
   const expandLabel = t(
     hiddenLineCount === 1 ? "chat.codeBlock.showHiddenLine" : "chat.codeBlock.showHiddenLines",

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -445,13 +445,35 @@ PY
       expect(expand?.getAttribute("aria-label")).toBe("Show 1 hidden line");
     });
 
-    it("collapses on line count alone, not on JSON detection", () => {
+    it.each(["text", "md", "markdown", "TEXT", "Markdown title=notes"])(
+      "keeps long %s fences fully visible",
+      (info) => {
+        const fragment = htmlFragment(
+          toSanitizedMarkdownHtml(`\`\`\`${info}\n${"prose line\n".repeat(20)}\`\`\``, {
+            codeBlockInteraction: "interactive",
+          }),
+        );
+
+        expect(fragment.querySelector(".code-block-wrapper.is-collapsible")).toBeNull();
+        expect(fragment.querySelector(".code-block-expand")).toBeNull();
+        expect(fragment.querySelector("pre code")?.textContent).toContain("prose line");
+      },
+    );
+
+    it.each([
+      { info: "json", content: '"value",\n'.repeat(20) },
+      { info: "bash", content: "echo hi\n".repeat(20) },
+      { info: "", content: "unlabeled line\n".repeat(20) },
+    ])("keeps long $info fences collapsible", ({ info, content }) => {
       const fragment = htmlFragment(
-        toSanitizedMarkdownHtml(`\`\`\`bash\n${"echo hi\n".repeat(20)}\`\`\``, {
+        toSanitizedMarkdownHtml(`\`\`\`${info}\n${content}\`\`\``, {
           codeBlockInteraction: "interactive",
         }),
       );
 
+      expect(fragment.querySelector(".code-block-wrapper.is-collapsible")).toBeInstanceOf(
+        HTMLDivElement,
+      );
       expect(fragment.querySelector(".code-block-expand")?.textContent).toContain(
         "13 hidden lines",
       );

--- a/ui/src/e2e/chat-code-block-fences.e2e.test.ts
+++ b/ui/src/e2e/chat-code-block-fences.e2e.test.ts
@@ -24,6 +24,10 @@ function fencedJson(lineCount: number): string {
   return `\`\`\`json\n[\n${values.join("\n")}\n]\n\`\`\``;
 }
 
+function fencedProse(language: "text" | "md" | "markdown"): string {
+  return `\`\`\`${language}\n${`${language} prose line\n`.repeat(20)}\`\`\``;
+}
+
 const shortFence = `\`\`\`json
 {
   "status": "ok",
@@ -120,6 +124,12 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
             timestamp: Date.now() + 5,
             __openclaw: { id: "assistant-fence-wide", seq: 6 },
           },
+          ...(["text", "md", "markdown"] as const).map((language, index) => ({
+            role: "assistant",
+            content: [{ type: "text", text: fencedProse(language) }],
+            timestamp: Date.now() + 6 + index,
+            __openclaw: { id: `assistant-fence-${language}`, seq: 7 + index },
+          })),
         ],
       });
 
@@ -141,6 +151,15 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
         expect(await shortBubble.locator(".code-block-wrapper.is-collapsible").count()).toBe(0);
         expect(await shortBubble.locator(".code-block-expand").count()).toBe(0);
         expect(await shortBubble.locator("pre code").isVisible()).toBe(true);
+
+        for (const language of ["text", "md", "markdown"] as const) {
+          const proseBubble = page.locator(`[data-entry-id="assistant-fence-${language}"]`);
+          expect(await proseBubble.locator(".code-block-wrapper.is-collapsible").count()).toBe(0);
+          expect(await proseBubble.locator(".code-block-expand").count()).toBe(0);
+          expect(await proseBubble.locator("pre code").textContent()).toContain(
+            `${language} prose line`,
+          );
+        }
 
         const longWrapper = longBubble.locator(".code-block-wrapper");
         const expand = longWrapper.locator(".code-block-expand");


### PR DESCRIPTION
Closes #126328

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where Control UI users reading long `text`, `md`, or `markdown` fences would see document-like content hidden behind a line-count disclosure.

## Why This Change Was Made

The shared fenced-block renderer now reserves its existing seven-line disclosure for other fence formats while keeping the three explicit prose-oriented language tags fully visible. JSON, Bash, and untagged long fences retain their current collapse behavior. The existing route, component chrome, overflow handling, and CSS remain unchanged.

The mock dev server has a focused `code-fences` data fixture for visual review using the real Control UI route and components.

## User Impact

Long plain-text and Markdown documents are readable without an extra reveal action. Intentional structured/code disclosures continue to work as before.

## Evidence

Screenshots below were recaptured from the real `/chat` route and inspected against exact head `425b42c2eb824c1921f9a8cdc4b1ed9276d8d685` on Blacksmith Testbox run https://github.com/openclaw/openclaw/actions/runs/32300914247.

| Theme | Before (`HEAD^` renderer) | After (exact PR head) |
| --- | --- | --- |
| Dark | ![Before dark: prose fences show hidden-lines disclosure](https://github.com/user-attachments/assets/055a47d3-be58-43f6-b6f8-fabb9de68926) | ![After dark: prose fences are fully visible](https://github.com/user-attachments/assets/5c971de2-2c02-4254-98ca-b98819346495) |
| Light | ![Before light: prose fences show hidden-lines disclosure](https://github.com/user-attachments/assets/2d06d7cf-25e0-4dd8-9bbf-cc92ed26fe08) | ![After light: prose fences are fully visible](https://github.com/user-attachments/assets/6d3c7f51-b0ec-425a-9bdf-1349ad19a86c) |

- BEFORE failed both dark/light E2E cases because prose fences had `.is-collapsible`; AFTER passed both cases.
- Focused renderer coverage on the fixed tree: 110 tests passed.
- Control UI Playwright flow on the fixed tree covers `text`, `md`, `markdown`, long JSON reveal, short JSON, Bash wrapping, and transcript overflow.
- Production UI delta: `+3/-4`; test/fixture delta: `+74/-5`.
- Remaining draft gates: changed checks, build, and recursive review were interrupted by the explicit landing hard stop and are not claimed complete.

AI-assisted implementation; no transcripts, prompts, or session logs are included.
