### PR TITLE
fix(tests): deflake qa-lab process-group pid-file waits

### DIFF
--- a/extensions/qa-lab/src/model-catalog.runtime.test.ts
+++ b/extensions/qa-lab/src/model-catalog.runtime.test.ts
@@ -3,48 +3,17 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { loadQaRunnerModelOptions } from "./model-catalog.runtime.js";
+import {
+  isProcessAlive,
+  waitForDead,
+  waitForFile,
+  waitForPidFile,
+} from "./process-wait.test-helper.js";
 import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 const { cleanup, makeTempDir } = createTempDirHarness();
 
 afterEach(cleanup);
-
-async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
-  const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
-    try {
-      await fs.access(filePath);
-      return;
-    } catch {
-      await new Promise((resolvePoll) => {
-        setTimeout(resolvePoll, 5);
-      });
-    }
-  }
-  throw new Error(`timed out waiting for ${filePath}`);
-}
-
-function isProcessAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
-  const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
-    if (!isProcessAlive(pid)) {
-      return;
-    }
-    await new Promise((resolvePoll) => {
-      setTimeout(resolvePoll, 5);
-    });
-  }
-  throw new Error(`timed out waiting for pid ${pid} to exit`);
-}
 
 describe("qa runner model catalog", () => {
   it("filters catalog output and prefers gpt-5.6-luna first", async () => {
@@ -128,14 +97,12 @@ describe("qa runner model catalog", () => {
           signal: controller.signal,
         });
 
-        await waitForFile(pidPath, 2_000);
-        descendantPid = Number.parseInt(await fs.readFile(pidPath, "utf8"), 10);
-        expect(Number.isInteger(descendantPid)).toBe(true);
+        descendantPid = await waitForPidFile(pidPath);
         expect(isProcessAlive(descendantPid)).toBe(true);
         controller.abort();
 
         await expect(runPromise).rejects.toThrow("qa model catalog aborted");
-        await waitForDead(descendantPid, 2_000);
+        await waitForDead(descendantPid);
       } finally {
         if (descendantPid !== undefined && isProcessAlive(descendantPid)) {
           process.kill(descendantPid, "SIGKILL");
@@ -181,16 +148,19 @@ describe("qa runner model catalog", () => {
           signal: controller.signal,
         });
 
-        await waitForFile(readyPath, 2_000);
-        descendantPid = Number.parseInt(await fs.readFile(pidPath, "utf8"), 10);
-        expect(Number.isInteger(descendantPid)).toBe(true);
+        // The ready marker lands after the SIGTERM handler is installed, and the
+        // pid file is fully written before it, so this read is parse-safe.
+        await waitForFile(readyPath);
+        descendantPid = await waitForPidFile(pidPath);
         const abortStartedAt = Date.now();
         controller.abort();
 
         await expect(runPromise).rejects.toThrow("qa model catalog aborted");
         expect(await fs.readFile(cleanupPath, "utf8")).toBe("clean");
-        expect(Date.now() - abortStartedAt).toBeLessThan(1_700);
-        await waitForDead(descendantPid, 2_000);
+        // Abort must settle with the exiting descendants (grace window is 300ms),
+        // never a long fixed kill ceiling; generous bound for loaded runners.
+        expect(Date.now() - abortStartedAt).toBeLessThan(5_000);
+        await waitForDead(descendantPid);
       } finally {
         if (descendantPid !== undefined && isProcessAlive(descendantPid)) {
           process.kill(descendantPid, "SIGKILL");

--- a/extensions/qa-lab/src/process-wait.test-helper.ts
+++ b/extensions/qa-lab/src/process-wait.test-helper.ts
@@ -1,0 +1,69 @@
+// Qa Lab plugin module implements process wait helper behavior.
+import fs from "node:fs/promises";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const POLL_INTERVAL_MS = 10;
+// Generous ceiling for loaded CI runners: callers synchronize on the asserted
+// state, so a large bound only delays failure reporting, never success.
+const DEFAULT_WAIT_TIMEOUT_MS = 10_000;
+
+export function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function waitForFile(
+  filePath: string,
+  timeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
+): Promise<void> {
+  const deadlineAt = Date.now() + timeoutMs;
+  while (Date.now() < deadlineAt) {
+    try {
+      await fs.access(filePath);
+      return;
+    } catch {
+      await sleep(POLL_INTERVAL_MS);
+    }
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for ${filePath}`);
+}
+
+// writeFileSync exposes an open-truncate window to observers, so wait for a
+// parseable pid, never bare existence; an existence wait reads "" into NaN.
+export async function waitForPidFile(
+  filePath: string,
+  timeoutMs = DEFAULT_WAIT_TIMEOUT_MS,
+): Promise<number> {
+  const deadlineAt = Date.now() + timeoutMs;
+  let lastContent: string | undefined;
+  while (Date.now() < deadlineAt) {
+    lastContent = await fs.readFile(filePath, "utf8").catch(() => undefined);
+    if (lastContent !== undefined) {
+      const pid = Number.parseInt(lastContent, 10);
+      if (Number.isInteger(pid) && pid > 0) {
+        return pid;
+      }
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  const lastState =
+    lastContent === undefined
+      ? "file missing"
+      : `unparsable content ${JSON.stringify(lastContent)}`;
+  throw new Error(`timed out after ${timeoutMs}ms waiting for pid file ${filePath} (${lastState})`);
+}
+
+export async function waitForDead(pid: number, timeoutMs = DEFAULT_WAIT_TIMEOUT_MS): Promise<void> {
+  const deadlineAt = Date.now() + timeoutMs;
+  while (Date.now() < deadlineAt) {
+    if (!isProcessAlive(pid)) {
+      return;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+  throw new Error(`timed out after ${timeoutMs}ms waiting for pid ${pid} to exit`);
+}

--- a/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
@@ -29,6 +29,7 @@ vi.mock("node:child_process", async (importOriginal) => {
   };
 });
 
+import { isProcessAlive, waitForDead, waitForPidFile } from "./process-wait.test-helper.js";
 import {
   resetQaScenarioCommandCleanupTimings,
   runQaScenarioCommandLifecycle,
@@ -60,38 +61,6 @@ function runCommand(timeoutMs?: number) {
     env: { OPENCLAW_QA_REF: "test" },
     ...(timeoutMs === undefined ? {} : { timeoutMs }),
   });
-}
-
-function isProcessRunning(pid: number) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function waitForPidFile(filePath: string, timeoutMs = 2_000) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const value = await readFile(filePath, "utf8").catch(() => "");
-    if (/^[1-9]\d*$/u.test(value.trim())) {
-      return Number(value.trim());
-    }
-    await sleep(10);
-  }
-  throw new Error(`timed out waiting for pid file ${filePath}`);
-}
-
-async function waitForProcessExit(pid: number, timeoutMs = 2_000) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!isProcessRunning(pid)) {
-      return;
-    }
-    await sleep(10);
-  }
-  throw new Error(`timed out waiting for process ${pid} to exit`);
 }
 
 describe.skipIf(process.platform === "win32")("qa scenario command real POSIX lifecycle", () => {
@@ -153,9 +122,9 @@ describe.skipIf(process.platform === "win32")("qa scenario command real POSIX li
       if (descendantPid === undefined) {
         throw new Error("scenario command descendant did not expose its pid");
       }
-      await waitForProcessExit(descendantPid);
+      await waitForDead(descendantPid);
     } finally {
-      if (descendantPid && isProcessRunning(descendantPid)) {
+      if (descendantPid && isProcessAlive(descendantPid)) {
         process.kill(descendantPid, "SIGKILL");
       }
       await rm(root, { force: true, recursive: true });
@@ -197,12 +166,12 @@ describe.skipIf(process.platform === "win32")("qa scenario command real POSIX li
       expect(result.exitCode).toBe(1);
       expect(result.failureMessage).toBe("stdio-drain-timeout");
       expect(result.stdout).toContain("escaped descendant output");
-      expect(isProcessRunning(descendantPid)).toBe(true);
+      expect(isProcessAlive(descendantPid)).toBe(true);
     } finally {
       // A true setsid descendant is outside the original PGID by design.
-      if (descendantPid && isProcessRunning(descendantPid)) {
+      if (descendantPid && isProcessAlive(descendantPid)) {
         process.kill(descendantPid, "SIGKILL");
-        await waitForProcessExit(descendantPid).catch(() => undefined);
+        await waitForDead(descendantPid).catch(() => undefined);
       }
       await rm(root, { force: true, recursive: true });
     }
@@ -257,7 +226,7 @@ describe.skipIf(process.platform === "win32")("qa scenario command real POSIX li
       { cwd: process.cwd(), env: process.env, stdio: "ignore" },
     );
     try {
-      descendantPid = await waitForPidFile(descendantPidPath, 10_000);
+      descendantPid = await waitForPidFile(descendantPidPath);
       controller.kill("SIGTERM");
       const [exitCode, signal] = await new Promise<[number | null, NodeJS.Signals | null]>(
         (resolve) => {
@@ -267,12 +236,12 @@ describe.skipIf(process.platform === "win32")("qa scenario command real POSIX li
 
       expect(exitCode).toBeNull();
       expect(signal).toBe("SIGTERM");
-      await waitForProcessExit(descendantPid);
+      await waitForDead(descendantPid);
     } finally {
       if (controller.exitCode === null && controller.signalCode === null) {
         controller.kill("SIGKILL");
       }
-      if (descendantPid && isProcessRunning(descendantPid)) {
+      if (descendantPid && isProcessAlive(descendantPid)) {
         process.kill(descendantPid, "SIGKILL");
       }
       await rm(root, { force: true, recursive: true });


### PR DESCRIPTION
## What Problem This Solves

Fixes a flaky CI failure where the qa-lab test "kills aborted catalog process groups when the catalog child exits first" intermittently failed on loaded runners (run 32231699569, job `checks-node-changed-extensions-config-37`, 2026-08-19) with a `Number.isInteger(descendantPid)` assertion on a `NaN` pid.

## Why This Change Was Made

The failure signature (NaN assertion rather than a wait timeout) shows the pid file existed but read back empty: the catalog child's `writeFileSync` exposes an open-truncate window, so an existence-based `waitForFile` can win between the child's open and write and parse `""` into `NaN`. The 2s wait ceilings were additionally flaky-by-construction for spawning a real node CLI plus a grandchild under CI load. The same hazards were hand-rolled twice in qa-lab (`model-catalog.runtime.test.ts` and `test-file-scenario-command-lifecycle.test.ts`); core's `test/helpers/process-wait.ts` already documents and solves this bug class but is not importable across the extension boundary.

This change adds a qa-lab-local `process-wait.test-helper.ts` (waits on the asserted state — a parseable pid — with generous 10s deadlines and self-diagnosing timeout errors) and consolidates both test files onto it. It also retires the stale `< 1_700ms` abort-settle ceiling, which was calibrated against a 1.5s in-plugin kill grace deleted when the runtime moved to `runCommandWithTimeout` (300ms tree grace); the new 5s bound still proves abort settles with the exiting descendants rather than a long fixed kill ceiling.

## User Impact

None at runtime — test-only change. CI stops flaking on this suite; future timeouts self-diagnose ("file missing" vs. the unparsable content last seen) instead of failing on an opaque NaN assertion.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/model-catalog.runtime.test.ts extensions/qa-lab/src/test-file-scenario-command-lifecycle.test.ts` — 2 files, 12/12 tests passed.
- `pnpm tsgo:extensions:test`, `scripts/run-oxlint.mjs` on touched files, `git diff --check` — all clean.
- Autoreview (Codex, gpt-5.6-sol, high): clean, no actionable findings.
- Production LOC delta: 0 (all changes are tests/test support; net test-support ≈ +8 after deleting the two duplicated helper trios).
