### PR TITLE
fix(test): doctor and auth fixtures fail Windows teardown with EBUSY

### DIFF
--- a/extensions/acpx/doctor-contract-api.test.ts
+++ b/extensions/acpx/doctor-contract-api.test.ts
@@ -105,6 +105,7 @@ describe("acpx doctor state migration", () => {
   });
 
   afterEach(async () => {
+    resetPluginStateStoreForTests();
     await fs.rm(stateDir, { recursive: true, force: true });
   });
 

--- a/extensions/active-memory/doctor-contract-api.test.ts
+++ b/extensions/active-memory/doctor-contract-api.test.ts
@@ -65,6 +65,7 @@ describe("active-memory doctor state migration", () => {
 
   afterEach(async () => {
     vi.useRealTimers();
+    resetPluginStateStoreForTests();
     await fs.rm(stateDir, { recursive: true, force: true });
   });
 

--- a/extensions/alibaba/video-generation-provider.test.ts
+++ b/extensions/alibaba/video-generation-provider.test.ts
@@ -17,6 +17,7 @@ import {
   mockSuccessfulDashscopeVideoTask,
 } from "openclaw/plugin-sdk/provider-test-contracts";
 // Alibaba tests cover video generation provider plugin behavior.
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import {
   DASHSCOPE_WAN_VIDEO_MODELS,
@@ -228,6 +229,10 @@ describe("alibaba video generation provider", () => {
       expect(alibabaVideoGenerationProvider.isConfigured?.({ cfg: {}, agentDir })).toBe(expected);
     } finally {
       clearRuntimeAuthProfileStoreSnapshots();
+      // Saving the profile store opens the per-agent database under the temporary agent
+      // dir, and clearing the snapshots does not release it, so Windows fails the removal
+      // with EBUSY unless the cached handles are closed first.
+      closeOpenClawAgentDatabasesForTest();
       await fs.rm(agentDir, { force: true, recursive: true });
     }
   });

--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -11,6 +11,7 @@ import type {
   PluginDoctorStateMigrationContext,
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { getSessionEntry, upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   legacyConfigRules,
@@ -57,6 +58,16 @@ function openBindingStore(env: NodeJS.ProcessEnv) {
     maxEntries: CODEX_APP_SERVER_BINDING_MAX_ENTRIES,
     overflowPolicy: "reject-new",
   });
+}
+
+async function removeCodexDoctorFixture(stateDir: string): Promise<void> {
+  // Doctor migrations open per-agent databases and leave the shared state database open under
+  // the temporary state dir; both must be released before removal or Windows keeps the files
+  // locked and the removal fails with EBUSY. Agent close first: it releases leases through
+  // shared state, so the reverse order can reopen it.
+  closeOpenClawAgentDatabasesForTest();
+  resetPluginStateStoreForTests();
+  await fs.rm(stateDir, { recursive: true, force: true });
 }
 
 async function createBindingMigrationFixture(options: {
@@ -272,7 +283,7 @@ describe("codex doctor contract", () => {
         }),
       ).toMatchObject({ agentHarnessId: "codex" });
     } finally {
-      await fs.rm(fixture.stateDir, { recursive: true, force: true });
+      await removeCodexDoctorFixture(fixture.stateDir);
     }
   });
 
@@ -357,7 +368,7 @@ describe("codex doctor contract", () => {
       fs.readFile(fixture.storePath, "utf8").then(JSON.parse),
     ).resolves.not.toHaveProperty("agent:main:session-1.agentHarnessId");
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it.each([
@@ -396,7 +407,7 @@ describe("codex doctor contract", () => {
     await expect(fs.access(`${fixture.sidecarPath}.migrated`)).rejects.toThrow();
     await expect(openBindingStore(fixture.env).entries()).resolves.toEqual([]);
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("migrates a shared-root binding to the configured system agent", async () => {
@@ -448,7 +459,7 @@ describe("codex doctor contract", () => {
     ).toMatchObject({ agentHarnessId: "codex" });
     await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("keeps an agent-scoped shared-root binding with its explicit owner", async () => {
@@ -492,7 +503,7 @@ describe("codex doctor contract", () => {
     ).resolves.toMatchObject({ sessionId: "explicit-ops-owner" });
     await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("bounds oversized legacy fingerprints before plugin-state import", async () => {
@@ -560,7 +571,7 @@ describe("codex doctor contract", () => {
       warnings: [],
     });
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("normalizes a partial raw conversation import before copying the session row", async () => {
@@ -638,7 +649,7 @@ describe("codex doctor contract", () => {
       warnings: [],
     });
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("normalizes retained raw conversation and session rows before comparison", async () => {
@@ -710,7 +721,7 @@ describe("codex doctor contract", () => {
       warnings: [],
     });
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("rejects an explicit session file locator outside the session directory", async () => {
@@ -743,7 +754,7 @@ describe("codex doctor contract", () => {
     ).toBeUndefined();
     await expect(openBindingStore(fixture.env).entries()).resolves.toEqual([]);
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("deduplicates session-store aliases before classifying binding ownership", async () => {
@@ -795,7 +806,7 @@ describe("codex doctor contract", () => {
     expect(configuredIndex["agent:main:aliased-store"]).not.toHaveProperty("agentHarnessId");
     expect(targetIndex["agent:main:aliased-store"]).not.toHaveProperty("agentHarnessId");
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("resolves relative session files from a symlinked store path", async () => {
@@ -847,7 +858,7 @@ describe("codex doctor contract", () => {
       `${sessionKey}.agentHarnessId`,
     );
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it.each([
@@ -929,7 +940,7 @@ describe("codex doctor contract", () => {
         retired: true,
       });
 
-      await fs.rm(fixture.stateDir, { recursive: true, force: true });
+      await removeCodexDoctorFixture(fixture.stateDir);
     },
   );
 
@@ -986,7 +997,7 @@ describe("codex doctor contract", () => {
       retired: true,
     });
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("does not resurrect a retired session generation from its legacy sidecar", async () => {
@@ -1041,7 +1052,7 @@ describe("codex doctor contract", () => {
       fs.readFile(path.join(fixture.sessionsDir, "sessions.json"), "utf8").then(JSON.parse),
     ).resolves.not.toHaveProperty(`${sessionKey}.agentHarnessId`);
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it.each(["active", "cleared"] as const)(
@@ -1081,7 +1092,7 @@ describe("codex doctor contract", () => {
         warnings: [],
       });
 
-      await fs.rm(fixture.stateDir, { recursive: true, force: true });
+      await removeCodexDoctorFixture(fixture.stateDir);
     },
   );
 
@@ -1106,7 +1117,7 @@ describe("codex doctor contract", () => {
     await expect(fs.access(fixture.sidecarPath)).rejects.toThrow();
     await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("retains a zero-owner sidecar when canonical plugin state is malformed", async () => {
@@ -1135,7 +1146,7 @@ describe("codex doctor contract", () => {
     await expect(fs.access(fixture.sidecarPath)).resolves.toBeUndefined();
     await expect(store.lookup(bindingKey)).resolves.toEqual(malformed);
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("retains mixed Codex and foreign ambiguous binding owners", async () => {
@@ -1164,7 +1175,7 @@ describe("codex doctor contract", () => {
     await expect(fs.access(fixture.sidecarPath)).resolves.toBeUndefined();
     await expect(openBindingStore(fixture.env).entries()).resolves.toEqual([]);
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it("retains a sidecar owned by a foreign harness without importing plugin state", async () => {
@@ -1188,7 +1199,7 @@ describe("codex doctor contract", () => {
     await expect(fs.access(fixture.sidecarPath)).resolves.toBeUndefined();
     await expect(openBindingStore(fixture.env).entries()).resolves.toEqual([]);
 
-    await fs.rm(fixture.stateDir, { recursive: true, force: true });
+    await removeCodexDoctorFixture(fixture.stateDir);
   });
 
   it.each([
@@ -1230,10 +1241,8 @@ describe("codex doctor contract", () => {
     await expect(fs.access(`${fixture.sidecarPath}.migrated`)).rejects.toThrow();
     await expect(openBindingStore(fixture.env).entries()).resolves.toEqual([]);
 
-    await Promise.all([
-      fs.rm(fixture.stateDir, { recursive: true, force: true }),
-      fs.rm(externalDir, { recursive: true, force: true }),
-    ]);
+    await removeCodexDoctorFixture(fixture.stateDir);
+    await fs.rm(externalDir, { recursive: true, force: true });
   });
 
   it("does not scan above stateDir or follow escaped external store locators", async () => {
@@ -1284,10 +1293,8 @@ describe("codex doctor contract", () => {
 
     await expect(migration.detectLegacyState(params)).resolves.toBeNull();
 
-    await Promise.all([
-      fs.rm(outerDir, { recursive: true, force: true }),
-      fs.rm(outsideDir, { recursive: true, force: true }),
-    ]);
+    await removeCodexDoctorFixture(outerDir);
+    await fs.rm(outsideDir, { recursive: true, force: true });
   });
 
   it("renames old approval-routed destructive plugin policy values", () => {

--- a/extensions/device-pair/doctor-contract-api.test.ts
+++ b/extensions/device-pair/doctor-contract-api.test.ts
@@ -43,6 +43,7 @@ describe("device-pair doctor notify migration", () => {
   });
 
   afterEach(async () => {
+    resetPluginStateStoreForTests();
     await fs.rm(stateDir, { recursive: true, force: true });
   });
 

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -488,6 +488,7 @@ describe("memory-core doctor dreaming migration", () => {
 
   afterEach(async () => {
     resetMemoryCoreDreamingStateForTests();
+    resetPluginStateStoreForTests();
     await fs.rm(rootDir, { recursive: true, force: true });
   });
 

--- a/extensions/msteams/doctor-contract-api.test.ts
+++ b/extensions/msteams/doctor-contract-api.test.ts
@@ -83,6 +83,7 @@ describe("msteams doctor state migration", () => {
   });
 
   afterEach(async () => {
+    resetPluginStateStoreForTests();
     await fs.rm(stateDir, { recursive: true, force: true });
   });
 

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -13,6 +13,7 @@ import {
   installProviderHttpMockCleanup,
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
 import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
+import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const {
@@ -171,6 +172,10 @@ describe("openai video generation provider", () => {
       } else {
         process.env.OPENAI_API_KEY = previousOpenAIKey;
       }
+      // Saving the profile store opens the per-agent database under the temporary agent
+      // dir, and clearing the snapshots does not release it, so Windows fails the removal
+      // with EBUSY unless the cached handles are closed first.
+      closeOpenClawAgentDatabasesForTest();
       fs.rmSync(agentDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## What Problem This Solves

Contributors on Windows cannot run eight extension test suites: they fail in teardown with
`EBUSY`, so a green local run is impossible even when every assertion in the suite passes.
Each fixture removes a temporary state directory while a SQLite handle opened underneath it
is still cached. On Linux unlinking an open file succeeds, so CI never sees it.

```
Error: EBUSY: resource busy or locked, unlink
  'C:\...\Temp\openclaw-codex-doctor-HL4p5j\fixed-sessions\openclaw-agent.ops.sqlite'
Error: EBUSY: resource busy or locked, unlink
  'C:\...\Temp\openclaw-alibaba-wan-auth-2J4maB\openclaw-agent.sqlite'
```

Every failure is in teardown, never in an assertion.

## Why This Change Was Made

Two entry points open a database under the fixture directory and neither existing cleanup call
releases it:

- **Doctor state migrations** open per-agent databases plus the shared state database.
  `resetPluginStateStoreForTests()` releases plugin state and shared state only, so the
  per-agent handles stay cached.
- **`saveAuthProfileStore(..., agentDir, ...)`** opens the per-agent database under the temporary
  agent dir. `clearRuntimeAuthProfileStoreSnapshots()` drops the in-memory snapshots but does not
  close it.

The repair is the ordering the zalo and zalouser fixtures already use:
`closeOpenClawAgentDatabasesForTest()` before the removal, and before
`resetPluginStateStoreForTests()` where both apply — the agent close releases leases through
shared state, so the reverse order can reopen it.

Tests only; no production file is touched.

## User Impact

Contributors on Windows can run these eight suites to completion instead of reading a teardown
failure that has nothing to do with the code under test. Behavior on Linux and macOS is unchanged.

## Evidence

Windows 11, Node 22.23.2, one suite per run, both arms on the same tree — `origin/main`
`b24430fd042` and that tree with only these eight files patched.

| suite | `main` | with this branch |
|---|---|---|
| `extensions/acpx/doctor-contract-api.test.ts` | 3 failed / 3 passed (6) | **6 passed** |
| `extensions/active-memory/doctor-contract-api.test.ts` | 2 failed / 1 passed (3) | **3 passed** |
| `extensions/codex/doctor-contract-api.test.ts` | 17 failed / 15 passed (32) | **32 passed** |
| `extensions/device-pair/doctor-contract-api.test.ts` | 1 failed / 1 passed (2) | **2 passed** |
| `extensions/memory-core/doctor-contract-api.test.ts` | 48 failed / 10 passed / 2 skipped (60) | **58 passed / 2 skipped** |
| `extensions/msteams/doctor-contract-api.test.ts` | 5 failed / 6 passed (11) | **11 passed** |
| `extensions/alibaba/video-generation-provider.test.ts` | 2 failed / 16 passed (18) | **18 passed** |
| `extensions/openai/video-generation-provider.test.ts` | 1 failed / 30 passed (31) | **31 passed** |

79 failing cases on `main`, none after. Each row's `main` arm was measured by checking out
`origin/main`'s copy of that single file into the patched tree, so nothing else in the run differs
between arms.

- `./node_modules/.bin/tsgo -p test/tsconfig/tsconfig.extensions.test.json --noEmit` -> exit 0
- `./node_modules/.bin/oxlint <the eight files>` -> exit 0
- `./node_modules/.bin/oxfmt --check <the eight files>` -> exit 0

## Relationship to #119964

This does not overlap the open repair. #119964 owns exactly three files, all under
`extensions/zalouser/`:

```
extensions/zalouser/doctor-contract-api.test.ts
extensions/zalouser/src/zalo-js.credentials.test.ts
extensions/zalouser/src/zalo-quote-metadata.test.ts
```

The eight files here are disjoint from those three. I wrote on #119796 on 6 August that the issue
was "fully covered once #119964 lands"; that was measured against the `extension-zalo` shard and is
too narrow for the defect class — these eight fixtures reproduce the same teardown failure on
current `main` today, outside that shard. Both branches can land in either order.

Linked issue: #119796.
