### PR TITLE
fix(state): restore upgrades from 2026.7.2-beta.4 agent state

### DIFF
--- a/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
@@ -42,6 +42,7 @@ function removeSchemaRange(sql: string, startMarker: string, endMarker: string):
 export function historicalV15AgentSchemaSql(): string {
   let sql = restoreHistoricalAgentLeaseSchema(OPENCLAW_AGENT_SCHEMA_SQL)
     .replace("  entry_valid INTEGER NOT NULL DEFAULT 0 CHECK (entry_valid IN (-1, 0, 1)),\n", "")
+    .replace("  project_id TEXT,\n", "")
     .replace(
       "  owner_actor_type TEXT,\n  owner_actor_id TEXT,\n  owner_assigned_by_type TEXT,\n  owner_assigned_by_id TEXT,\n  owner_assigned_at INTEGER,\n",
       "",

--- a/src/infra/state-migrations.media-persistence.historical-v14.test.ts
+++ b/src/infra/state-migrations.media-persistence.historical-v14.test.ts
@@ -26,8 +26,9 @@ describe("legacy media persistence Doctor migration from historical v14", () => 
   it("migrates a copy of the exact v2026.7.2-beta.4 schema without losing its session", () => {
     const historicalSchema = historicalV14AgentSchemaSql();
     expect(createHash("sha256").update(historicalSchema).digest("hex")).toBe(
-      "dfb2a98c9418eb1032e82e4310c7bde41700e4a0af05a2464673e9c4ece11fd1",
+      "955889668707fbccab70b80b5058af5a1587fd35ae32a80f8605179a68fb5117",
     );
+    expect(historicalSchema).not.toContain("  project_id TEXT,\n");
 
     const stateDir = makeTempDir(tempDirs, "media-persistence-historical-v14-");
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/infra/state-migrations.media-persistence.historical-v15.test.ts
+++ b/src/infra/state-migrations.media-persistence.historical-v15.test.ts
@@ -26,7 +26,7 @@ describe("legacy media persistence Doctor migration from historical v15", () => 
   it("converges the exact 509a5f0373764 schema before current-index repair", () => {
     const historicalSchema = historicalV15AgentSchemaSql();
     expect(createHash("sha256").update(historicalSchema).digest("hex")).toBe(
-      "2ad94b064159086923e24acf4e11cb77546fca71646e7f49c7a6d40d2a22890a",
+      "75953ef97a738251822fc5aaf283bbe55fbcabe8702ad771892cdafc85d8e6b9",
     );
 
     const stateDir = makeTempDir(tempDirs, "media-persistence-historical-v15-");

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -26,7 +26,10 @@ import { CONTEXT_ENGINE_TURN_OUTBOX_TABLE } from "./openclaw-agent-context-engin
 import { FIRST_USE_ADDITIVE_AGENT_COLUMN_DEFINITIONS } from "./openclaw-agent-db-additive-columns.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-agent-db-migration-required.js";
-import { ensureSessionEntryValidityProjection } from "./openclaw-agent-db-session-migrations.js";
+import {
+  ensureSessionEntryValidityProjection,
+  ensureSessionProjectColumn,
+} from "./openclaw-agent-db-session-migrations.js";
 import { MESSAGE_TOOL_RUN_OUTCOMES_TABLE } from "./openclaw-agent-message-tool-outcome-schema.js";
 import {
   ensureOpenClawAgentProgressCardSchemaInTransaction,
@@ -186,6 +189,7 @@ export function repairAndAssertOpenClawAgentV14SchemaForMigration(
     );
   }
 
+  ensureSessionProjectColumn(database);
   ensureSessionEntryValidityProjection(database);
   ensureSessionKeyContractSchemaInTransaction(database);
 


### PR DESCRIPTION
Related: #125626

## What Problem This Solves

Fixes an issue where users upgrading from `2026.7.2-beta.4` could have Doctor exit successfully while Gateway startup still refused the published schema-v14 agent database.

## Why This Change Was Made

The historical v14/v15 fixtures now match their tagged schema bytes, and the existing nullable session project column repair runs before strict v14 schema validation. Other schema drift remains rejected; this does not change Doctor's general exit semantics or broaden the migration policy.

## User Impact

Users with agent state created by `2026.7.2-beta.4` can run Doctor and start or restart the upgraded Gateway without manually editing or discarding their session database.

## Evidence

- Exact rebased head: `0aa6beb018ce4448a5c6e58ef86fa61a88b793c4`.
- Node 24.18.0: 10 focused migration/schema test files, 41/41 tests passed.
- `git diff --check`, TypeScript checks, lint, formatting, and the remaining repository policy guards passed. The current-main temp-path guard alone could not complete locally because `git ls-files src extensions` exceeded Node's default 1 MiB `spawnSync` output buffer (`ENOBUFS`); this is unrelated to the four changed files and is reported rather than counted green.
- Exact-head retained `2026.7.2-beta.4` checkpoint canary passed in a networkless, read-only-root container with no host mounts, Docker socket, SSH agent, or production secrets.

Redacted exact-head canary result:

```text
candidate.commit=0aa6beb018ce4448a5c6e58ef86fa61a88b793c4
candidate.version=2026.8.1
profile=2026.7.2-beta.4
source.shared.sha256=47310116a59ffe6b0b2df5463d8866f3b3a54e415aa4c4ca98e30ef5bf605840
source.agent.sha256=107f9d1da6bd89d18dd3d655838165f825ab567d41914296879ce9b85ef2bf42
container.network=none
container.status=0
doctor.status=0
convergence.restarts=0
shared.schema=5->9
shared.integrity=ok->ok
shared.device_bootstrap_tokens.setup_id=present
agent.schema=14->17
agent.integrity=ok->ok
agent.session_nodes.project_id=nullable
agent.session_nodes.entry_valid=present
gateway.first_health=true
gateway.restart_health=true
verdict=pass
```

### Owner acceptance

- **Assurance:** Critical because this changes session-state migration ordering. The patch is ready for domain-competent maintainer review; it must not merge without state-migration owner acceptance.
- **Scope:** 4 files, +9/-3. No public API change, generic Doctor behavior change, or unrelated refactor.
- **Falsifier:** Any tagged-schema fingerprint mismatch, failed migration, failed integrity check, or failed Gateway restart blocks this change.
- **Rollback:** Revert the single commit; the only production mutation added here is the existing nullable `project_id` repair during the v14 migration path.

AI-assisted: yes.
