### PR TITLE
fix(ui): keep mobile sidebar session menus reachable

### DIFF
--- a/ui/src/components/session-icon-picker.ts
+++ b/ui/src/components/session-icon-picker.ts
@@ -30,6 +30,7 @@ function sessionEmojiPickerShortcut(): string | null {
 }
 
 type SessionIconPickerProps = {
+  inline?: boolean;
   mode: "grid" | "custom";
   currentIcon: string | null;
   customIconValue: string;
@@ -48,7 +49,10 @@ function renderCustomSessionIconEntry(props: SessionIconPickerProps) {
   const normalized = normalizeSessionIconValue(props.customIconValue);
   const shortcut = sessionEmojiPickerShortcut();
   return html`
-    <div slot="submenu" class="session-menu__icon-picker session-menu__icon-custom-entry">
+    <div
+      slot=${props.inline ? nothing : "submenu"}
+      class="session-menu__icon-picker session-menu__icon-custom-entry"
+    >
       <div class="session-menu__icon-custom-header">
         <button
           type="button"
@@ -96,7 +100,7 @@ export function renderSessionIconPicker(props: SessionIconPickerProps) {
     (icon) => icon === props.currentIcon,
   );
   return html`
-    <div slot="submenu" class="session-menu__icon-picker">
+    <div slot=${props.inline ? nothing : "submenu"} class="session-menu__icon-picker">
       <div
         class="session-menu__icon-options"
         role="group"

--- a/ui/src/components/session-menu-compact.ts
+++ b/ui/src/components/session-menu-compact.ts
@@ -1,0 +1,91 @@
+import { html, nothing, type TemplateResult } from "lit";
+import { t } from "../i18n/index.ts";
+import { icons } from "./icons.ts";
+import type { SessionOwnerOption } from "./session-owner-chip.ts";
+import { renderSessionOwnerAssignmentOptions } from "./session-owner-menu.ts";
+
+export type CompactSessionMenuView = "root" | "open-in" | "assign-owner" | "icon" | "group";
+
+const COMPACT_SESSION_MENU_VIEW_BY_VALUE: Record<string, CompactSessionMenuView> = {
+  "compact:back": "root",
+  "compact:open-assign-owner": "assign-owner",
+  "compact:open-group": "group",
+  "compact:open-icon": "icon",
+  "compact:open-open-in": "open-in",
+};
+
+export function compactSessionMenuViewForValue(value: string): CompactSessionMenuView | null {
+  return COMPACT_SESSION_MENU_VIEW_BY_VALUE[value] ?? null;
+}
+
+export function compactSessionOwnerOptions(
+  ownerOptions: readonly SessionOwnerOption[],
+  selfOwner: SessionOwnerOption | null,
+): readonly SessionOwnerOption[] {
+  if (!selfOwner || ownerOptions.some((owner) => owner.id === selfOwner.id)) {
+    return ownerOptions;
+  }
+  return [selfOwner, ...ownerOptions];
+}
+
+export function renderCompactSessionMenuNavigationItem(params: {
+  view: Exclude<CompactSessionMenuView, "root">;
+  label: string;
+  icon: TemplateResult;
+  disabled?: boolean;
+  title?: string;
+}) {
+  return html`
+    <wa-dropdown-item
+      class="session-menu__item"
+      value=${`compact:open-${params.view}`}
+      ?disabled=${params.disabled ?? false}
+      title=${params.title ?? nothing}
+    >
+      <span slot="icon" class="session-menu__icon" aria-hidden="true">${params.icon}</span>
+      <span class="session-menu__text">${params.label}</span>
+      <span slot="details" class="session-menu__icon session-menu__chevron" aria-hidden="true"
+        >${icons.chevronRight}</span
+      >
+    </wa-dropdown-item>
+  `;
+}
+
+export function renderCompactSessionMenuView(params: {
+  view: CompactSessionMenuView;
+  ownerOptions: readonly SessionOwnerOption[];
+  currentOwnerId: string | null;
+  assignOwnerDisabled: boolean;
+  assignOwnerDisabledReason?: string;
+  renderOpenIn: () => TemplateResult;
+  renderIcon: () => TemplateResult;
+  renderGroup: () => TemplateResult;
+}) {
+  if (params.view === "root") {
+    return nothing;
+  }
+  const body =
+    params.view === "open-in"
+      ? params.renderOpenIn()
+      : params.view === "assign-owner"
+        ? renderSessionOwnerAssignmentOptions(
+            {
+              ownerOptions: params.ownerOptions,
+              currentOwnerId: params.currentOwnerId,
+              disabled: params.assignOwnerDisabled,
+              disabledReason: params.assignOwnerDisabledReason,
+            },
+            true,
+          )
+        : params.view === "icon"
+          ? params.renderIcon()
+          : params.renderGroup();
+  return html`
+    <wa-dropdown-item class="session-menu__item session-menu__back" value="compact:back">
+      <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.arrowLeft}</span>
+      <span class="session-menu__text">${t("common.back")}</span>
+    </wa-dropdown-item>
+    <div class="session-menu__separator" role="separator"></div>
+    ${body}
+  `;
+}

--- a/ui/src/components/session-menu-options.ts
+++ b/ui/src/components/session-menu-options.ts
@@ -1,0 +1,80 @@
+import { html, nothing } from "lit";
+import { ref } from "lit/directives/ref.js";
+import { t } from "../i18n/index.ts";
+import { EDITOR_IDS, EDITOR_LABELS } from "../lib/editor-links.ts";
+import { icons } from "./icons.ts";
+import { menuShortcutHint } from "./menu-shortcuts.ts";
+import { syncDropdownItemRadio } from "./web-awesome.ts";
+
+export function renderSessionEditorOptions(params: { inline: boolean; disabled: boolean }) {
+  return html`
+    ${EDITOR_IDS.map(
+      (editor) => html`
+        <wa-dropdown-item
+          slot=${params.inline ? nothing : "submenu"}
+          class="session-menu__item"
+          value=${`open-in:${editor}`}
+          ?disabled=${params.disabled}
+        >
+          <span class="session-menu__text">${EDITOR_LABELS[editor]}</span>
+        </wa-dropdown-item>
+      `,
+    )}
+  `;
+}
+
+export function renderSessionGroupOptions(params: {
+  inline: boolean;
+  category: string | null;
+  categoryClearReturnsToGroups: boolean;
+  groups: readonly string[];
+  actionDisabled: (kind: "move-to-group" | "new-group") => boolean;
+  actionTitle: (kind: "move-to-group" | "new-group") => string | typeof nothing;
+}) {
+  let nextDigit = 1;
+  const takeDigit = () => (nextDigit <= 9 ? String(nextDigit++) : null);
+  const entry = (label: string, checked: boolean, value: string, radio = true) => {
+    const digit = takeDigit();
+    const actionKind = value === "new-group" ? "new-group" : "move-to-group";
+    return html`
+      <wa-dropdown-item
+        slot=${params.inline ? nothing : "submenu"}
+        class="session-menu__item"
+        value=${value}
+        role=${radio ? "menuitemradio" : "menuitem"}
+        aria-checked=${radio ? String(checked) : nothing}
+        ${radio ? ref((element) => syncDropdownItemRadio(element, checked)) : nothing}
+        data-shortcut=${digit ?? nothing}
+        aria-keyshortcuts=${digit ?? nothing}
+        ?disabled=${params.actionDisabled(actionKind)}
+        title=${params.actionTitle(actionKind)}
+      >
+        <span class="session-menu__text">${label}</span>
+        ${radio && checked
+          ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
+              >${icons.check}</span
+            >`
+          : nothing}
+        ${digit ? menuShortcutHint(digit) : nothing}
+      </wa-dropdown-item>
+    `;
+  };
+  return html`
+    ${params.groups.map((group) =>
+      entry(group, params.category === group, `move-to-group:${encodeURIComponent(group)}`),
+    )}
+    ${params.category
+      ? entry(
+          t(
+            params.categoryClearReturnsToGroups
+              ? "sessionsView.moveBackToGroups"
+              : "sessionsView.removeFromGroup",
+          ),
+          false,
+          "move-to-group:",
+          false,
+        )
+      : nothing}
+    ${entry(t("sessionsView.newGroup"), false, "new-group", false)}
+  `;
+}

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -724,6 +724,7 @@ describe("session menu", () => {
 
     const openPr = menuItem(menu, "Open PR");
     expect(openPr.disabled).toBe(false);
+    expect(openPr.hasAttribute("data-new-tab-action")).toBe(true);
     expect(openPr.querySelector(".session-menu__shortcut")?.textContent).toBe("G");
     expect(menuItem(menu, "Open in").disabled).toBe(true);
 

--- a/ui/src/components/session-menu.test.ts
+++ b/ui/src/components/session-menu.test.ts
@@ -19,6 +19,7 @@ type SessionMenuData = {
 };
 type SessionMenuElement = HTMLElement & {
   anchor: { x: number; y: number };
+  compact: boolean;
   lastActive: string;
   session: SessionMenuData;
   ownerOptions: readonly SessionOwnerOption[];
@@ -37,6 +38,7 @@ afterEach(() => {
 async function mountMenu(
   options: {
     session?: Partial<SessionMenuData>;
+    compact?: boolean;
     work?: SessionMenuWork | null;
     workboard?: { captured: boolean; busy: boolean } | null;
     archiveAllowed?: boolean;
@@ -73,6 +75,7 @@ async function mountMenu(
   render(
     html`<openclaw-session-menu
       .session=${session}
+      .compact=${options.compact ?? false}
       .selectionCount=${options.selectionCount ?? 1}
       .lastActive=${options.lastActive ?? "57d"}
       .anchor=${{ x: 100, y: 100 }}
@@ -130,6 +133,16 @@ function menuItem(menu: ParentNode, label: string): SessionMenuItem {
 
 function iconChoices(menu: ParentNode): HTMLButtonElement[] {
   return Array.from(menu.querySelectorAll<HTMLButtonElement>(".session-menu__icon-choice"));
+}
+
+function selectMenuValue(menu: SessionMenuElement, value: string) {
+  menu.querySelector("wa-dropdown")?.dispatchEvent(
+    new CustomEvent("wa-select", {
+      bubbles: true,
+      composed: true,
+      detail: { item: { value } },
+    }),
+  );
 }
 
 describe("session menu", () => {
@@ -226,6 +239,53 @@ describe("session menu", () => {
       "Archive session",
       "Delete…",
     ]);
+  });
+
+  it("drills into compact menu groups without rendering side flyouts", async () => {
+    const ada = { type: "human", id: "profile-ada", label: "Ada" } as const;
+    const research = { type: "agent", id: "research:one", label: "Research owner" } as const;
+    const menu = await mountMenu({
+      compact: true,
+      groups: ["Research", "Operations"],
+      ownerOptions: [ada, research],
+      selfOwner: ada,
+      currentOwnerId: research.id,
+      work: {
+        loading: false,
+        pullRequestUrl: "https://example.test/pr",
+        worktreePath: "/work/openclaw",
+      },
+    });
+
+    expect(menu.querySelector("[slot='submenu']")).toBeNull();
+    expect(menuItemLabels(menu)).toContain("Open in");
+    expect(menuItemLabels(menu)).toContain("Assign to…");
+    expect(menuItemLabels(menu)).toContain("Set icon");
+    expect(menuItemLabels(menu)).toContain("Move to group");
+
+    selectMenuValue(menu, "compact:open-open-in");
+    await menu.updateComplete;
+    expect(menuItemLabels(menu)).toEqual(["Back", "Cursor", "VS Code", "Windsurf", "Zed"]);
+
+    selectMenuValue(menu, "compact:back");
+    await menu.updateComplete;
+    selectMenuValue(menu, "compact:open-assign-owner");
+    await menu.updateComplete;
+    expect(menuItemLabels(menu)).toEqual(["Back", "Ada", "Research owner"]);
+
+    selectMenuValue(menu, "compact:back");
+    await menu.updateComplete;
+    selectMenuValue(menu, "compact:open-icon");
+    await menu.updateComplete;
+    expect(menuItemLabels(menu)).toEqual(["Back"]);
+    expect(menu.querySelector(".session-menu__icon-picker")?.getAttribute("slot")).toBeNull();
+
+    selectMenuValue(menu, "compact:back");
+    await menu.updateComplete;
+    selectMenuValue(menu, "compact:open-group");
+    await menu.updateComplete;
+    expect(menuItemLabels(menu)).toEqual(["Back", "Research", "Operations", "New group…"]);
+    expect(menu.querySelector("[slot='submenu']")).toBeNull();
   });
 
   it("omits root placement actions for child sessions", async () => {

--- a/ui/src/components/session-menu.ts
+++ b/ui/src/components/session-menu.ts
@@ -1,22 +1,28 @@
 import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { keyed } from "lit/directives/keyed.js";
-import { ref } from "lit/directives/ref.js";
 import { normalizeSessionIconValue } from "../../../packages/gateway-protocol/src/session-agent-status.js";
 import { t } from "../i18n/index.ts";
-import { EDITOR_IDS, EDITOR_LABELS, type EditorId } from "../lib/editor-links.ts";
+import { EDITOR_IDS, type EditorId } from "../lib/editor-links.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { DropdownMenuController } from "./dropdown-menu-controller.ts";
 import { icons } from "./icons.ts";
 import { activateMenuShortcut, menuShortcutHint } from "./menu-shortcuts.ts";
 import { promoteToPopoverTopLayer } from "./menu-surface.ts";
 import { renderSessionIconPicker } from "./session-icon-picker.ts";
+import {
+  compactSessionMenuViewForValue,
+  compactSessionOwnerOptions,
+  renderCompactSessionMenuNavigationItem,
+  renderCompactSessionMenuView,
+  type CompactSessionMenuView,
+} from "./session-menu-compact.ts";
+import { renderSessionEditorOptions, renderSessionGroupOptions } from "./session-menu-options.ts";
 import type { SessionOwnerOption } from "./session-owner-chip.ts";
 import {
   renderSessionOwnerAssignmentMenu,
   sessionOwnerAssignmentFromMenuValue,
 } from "./session-owner-menu.ts";
-import { syncDropdownItemRadio } from "./web-awesome.ts";
 
 type SessionMenuData = {
   label: string;
@@ -76,6 +82,7 @@ const SESSION_ICON_GRID_COLUMNS = 6;
 
 class SessionMenu extends OpenClawLightDomElement {
   @property({ attribute: false }) session: SessionMenuData = EMPTY_SESSION;
+  @property({ attribute: false }) compact = false;
   // >1 renders the batch menu: only actions that apply to every selected
   // session (unread/group/archive/delete); `session` then carries aggregated
   // flags (unread = all unread, category = shared category or null).
@@ -100,6 +107,7 @@ class SessionMenu extends OpenClawLightDomElement {
   @property({ attribute: false }) workboard: { captured: boolean; busy: boolean } | null = null;
   @property({ attribute: false }) onAction: (action: SessionMenuAction) => void = () => {};
   @property({ attribute: false }) onClose: () => void = () => {};
+  @state() private compactView: CompactSessionMenuView = "root";
   @state() private iconPickerMode: "grid" | "custom" = "grid";
   @state() private customIconValue = "";
   readonly menuLifecycle = new DropdownMenuController(this, {
@@ -137,6 +145,18 @@ class SessionMenu extends OpenClawLightDomElement {
     event.preventDefault();
     const value = event.detail.item.value;
     if (!value) {
+      return;
+    }
+    const compactView = compactSessionMenuViewForValue(value);
+    if (compactView) {
+      this.compactView = compactView;
+      if (compactView === "icon") {
+        this.iconPickerMode = "grid";
+        this.customIconValue = "";
+      }
+      void this.updateComplete.then(() => {
+        this.querySelector<HTMLElement>("wa-dropdown-item:not([disabled])")?.focus();
+      });
       return;
     }
     const simpleActions: Partial<Record<string, SessionMenuAction>> = {
@@ -218,87 +238,45 @@ class SessionMenu extends OpenClawLightDomElement {
         <span class="session-menu__text">${t("sessionsView.openPullRequest")}</span>
         ${menuShortcutHint("g")}
       </wa-dropdown-item>
-      <wa-dropdown-item class="session-menu__item" ?disabled=${this.disabled || !worktreePath}>
-        <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.externalLink}</span>
-        <span class="session-menu__text">${t("sessionsView.openInEditorMenu")}</span>
-        ${worktreePath ? this.renderEditorSubmenu() : nothing}
-      </wa-dropdown-item>
+      ${this.compact
+        ? renderCompactSessionMenuNavigationItem({
+            view: "open-in",
+            label: t("sessionsView.openInEditorMenu"),
+            icon: icons.externalLink,
+            disabled: this.disabled || !worktreePath,
+          })
+        : html`<wa-dropdown-item
+            class="session-menu__item"
+            ?disabled=${this.disabled || !worktreePath}
+          >
+            <span slot="icon" class="session-menu__icon" aria-hidden="true"
+              >${icons.externalLink}</span
+            >
+            <span class="session-menu__text">${t("sessionsView.openInEditorMenu")}</span>
+            ${worktreePath ? this.renderEditorSubmenu() : nothing}
+          </wa-dropdown-item>`}
       <div class="session-menu__separator" role="separator"></div>
     `;
   }
 
-  private renderEditorSubmenu() {
-    return html`
-      ${EDITOR_IDS.map(
-        (editor) => html`
-          <wa-dropdown-item
-            slot="submenu"
-            class="session-menu__item"
-            value=${`open-in:${editor}`}
-            ?disabled=${this.disabled}
-          >
-            <span class="session-menu__text">${EDITOR_LABELS[editor]}</span>
-          </wa-dropdown-item>
-        `,
-      )}
-    `;
+  private renderEditorSubmenu(inline = false) {
+    return renderSessionEditorOptions({ inline, disabled: this.disabled });
   }
 
-  private renderGroupSubmenu() {
-    const session = this.session;
-    // Entries are numbered like the digits users see: existing groups first,
-    // then the ungroup entry, then New group…; entries past 9 stay unnumbered
-    // rather than reusing digits.
-    let nextDigit = 1;
-    const takeDigit = () => (nextDigit <= 9 ? String(nextDigit++) : null);
-    const entry = (label: string, checked: boolean, value: string, radio = true) => {
-      const digit = takeDigit();
-      const actionKind = value === "new-group" ? "new-group" : "move-to-group";
-      return html`
-        <wa-dropdown-item
-          slot="submenu"
-          class="session-menu__item"
-          value=${value}
-          role=${radio ? "menuitemradio" : "menuitem"}
-          aria-checked=${radio ? String(checked) : nothing}
-          ${radio ? ref((element) => syncDropdownItemRadio(element, checked)) : nothing}
-          data-shortcut=${digit ?? nothing}
-          aria-keyshortcuts=${digit ?? nothing}
-          ?disabled=${this.actionDisabled(actionKind)}
-          title=${this.actionTitle(actionKind)}
-        >
-          <span class="session-menu__text">${label}</span>
-          ${radio && checked
-            ? html`<span slot="details" class="session-menu__check" aria-hidden="true"
-                >${icons.check}</span
-              >`
-            : nothing}
-          ${digit ? menuShortcutHint(digit) : nothing}
-        </wa-dropdown-item>
-      `;
-    };
-    return html`
-      ${this.groups.map((group) =>
-        entry(group, session.category === group, `move-to-group:${encodeURIComponent(group)}`),
-      )}
-      ${session.category
-        ? entry(
-            t(
-              session.categoryClearReturnsToGroups
-                ? "sessionsView.moveBackToGroups"
-                : "sessionsView.removeFromGroup",
-            ),
-            false,
-            "move-to-group:",
-            false,
-          )
-        : nothing}
-      ${entry(t("sessionsView.newGroup"), false, "new-group", false)}
-    `;
+  private renderGroupSubmenu(inline = false) {
+    return renderSessionGroupOptions({
+      inline,
+      category: this.session.category,
+      categoryClearReturnsToGroups: this.session.categoryClearReturnsToGroups,
+      groups: this.groups,
+      actionDisabled: (kind) => this.actionDisabled(kind),
+      actionTitle: (kind) => this.actionTitle(kind),
+    });
   }
 
-  private renderIconSubmenu() {
+  private renderIconSubmenu(inline = false) {
     return renderSessionIconPicker({
+      inline,
       mode: this.iconPickerMode,
       currentIcon: this.session.icon,
       customIconValue: this.customIconValue,
@@ -452,7 +430,7 @@ class SessionMenu extends OpenClawLightDomElement {
     return keyed(
       this.anchor,
       html`<wa-dropdown
-        class="session-menu"
+        class=${`session-menu${this.compact ? " session-menu--compact" : ""}`}
         .open=${true}
         placement="bottom-start"
         .distance=${0}
@@ -468,213 +446,268 @@ class SessionMenu extends OpenClawLightDomElement {
           aria-label=${menuLabel}
           style="position: fixed; left: ${clampedX}px; top: ${clampedY}px; width: 1px; height: 1px; opacity: 0; pointer-events: none;"
         ></button>
-        ${!batch && this.lastActive
-          ? html`<div class="session-menu__info">
-              ${t("sessionsView.lastActive", { time: this.lastActive })}
-            </div>`
-          : nothing}
-        ${batch ? nothing : this.renderWorkItems()}
-        ${batch || !rootPlacementActions
-          ? nothing
+        ${this.compact && this.compactView !== "root"
+          ? renderCompactSessionMenuView({
+              view: this.compactView,
+              ownerOptions: compactSessionOwnerOptions(this.ownerOptions, this.selfOwner),
+              currentOwnerId: this.currentOwnerId,
+              assignOwnerDisabled: this.actionDisabled("assign-owner"),
+              assignOwnerDisabledReason: this.actionDisabledReasons["assign-owner"],
+              renderOpenIn: () => this.renderEditorSubmenu(true),
+              renderIcon: () => this.renderIconSubmenu(true),
+              renderGroup: () => this.renderGroupSubmenu(true),
+            })
           : html`
+              ${!batch && this.lastActive
+                ? html`<div class="session-menu__info">
+                    ${t("sessionsView.lastActive", { time: this.lastActive })}
+                  </div>`
+                : nothing}
+              ${batch ? nothing : this.renderWorkItems()}
+              ${batch || !rootPlacementActions
+                ? nothing
+                : html`
+                    <wa-dropdown-item
+                      class="session-menu__item"
+                      value="toggle-pin"
+                      data-shortcut="p"
+                      aria-keyshortcuts="P"
+                      ?disabled=${this.actionDisabled("toggle-pin", session.archived)}
+                      title=${this.actionTitle("toggle-pin")}
+                    >
+                      <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                        >${session.pinned ? icons.pinOff : icons.pin}</span
+                      >
+                      <span class="session-menu__text"
+                        >${session.pinned
+                          ? t("sessionsView.unpinSession")
+                          : t("sessionsView.pinSession")}</span
+                      >
+                      ${menuShortcutHint("p")}
+                    </wa-dropdown-item>
+                  `}
               <wa-dropdown-item
                 class="session-menu__item"
-                value="toggle-pin"
-                data-shortcut="p"
-                aria-keyshortcuts="P"
-                ?disabled=${this.actionDisabled("toggle-pin", session.archived)}
-                title=${this.actionTitle("toggle-pin")}
+                value="toggle-unread"
+                data-shortcut="u"
+                aria-keyshortcuts="U"
+                ?disabled=${this.actionDisabled("toggle-unread")}
+                title=${this.actionTitle("toggle-unread")}
               >
                 <span slot="icon" class="session-menu__icon" aria-hidden="true"
-                  >${session.pinned ? icons.pinOff : icons.pin}</span
+                  >${session.unread ? icons.eye : icons.circle}</span
                 >
                 <span class="session-menu__text"
-                  >${session.pinned
-                    ? t("sessionsView.unpinSession")
-                    : t("sessionsView.pinSession")}</span
+                  >${batch
+                    ? session.unread
+                      ? t("sessionsView.markReadCount", { count })
+                      : t("sessionsView.markUnreadCount", { count })
+                    : session.unread
+                      ? t("sessionsView.markRead")
+                      : t("sessionsView.markUnread")}</span
                 >
-                ${menuShortcutHint("p")}
+                ${menuShortcutHint("u")}
               </wa-dropdown-item>
-            `}
-        <wa-dropdown-item
-          class="session-menu__item"
-          value="toggle-unread"
-          data-shortcut="u"
-          aria-keyshortcuts="U"
-          ?disabled=${this.actionDisabled("toggle-unread")}
-          title=${this.actionTitle("toggle-unread")}
-        >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true"
-            >${session.unread ? icons.eye : icons.circle}</span
-          >
-          <span class="session-menu__text"
-            >${batch
-              ? session.unread
-                ? t("sessionsView.markReadCount", { count })
-                : t("sessionsView.markUnreadCount", { count })
-              : session.unread
-                ? t("sessionsView.markRead")
-                : t("sessionsView.markUnread")}</span
-          >
-          ${menuShortcutHint("u")}
-        </wa-dropdown-item>
-        ${batch
-          ? nothing
-          : html`
+              ${batch
+                ? nothing
+                : html`
+                    <wa-dropdown-item
+                      class="session-menu__item"
+                      value="rename"
+                      data-shortcut="r"
+                      aria-keyshortcuts="R"
+                      ?disabled=${this.actionDisabled("rename")}
+                      title=${this.actionTitle("rename")}
+                    >
+                      <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                        >${icons.edit}</span
+                      >
+                      <span class="session-menu__text">${t("sessionsView.renameSessionMenu")}</span>
+                      ${menuShortcutHint("r")}
+                    </wa-dropdown-item>
+                    ${this.compact
+                      ? compactSessionOwnerOptions(this.ownerOptions, this.selfOwner).length > 0
+                        ? renderCompactSessionMenuNavigationItem({
+                            view: "assign-owner",
+                            label: t("sessionsView.assignTo"),
+                            icon: icons.users,
+                            disabled: this.actionDisabled("assign-owner"),
+                            title: this.actionDisabledReasons["assign-owner"],
+                          })
+                        : nothing
+                      : renderSessionOwnerAssignmentMenu({
+                          ownerOptions: this.ownerOptions,
+                          selfOwner: this.selfOwner,
+                          currentOwnerId: this.currentOwnerId,
+                          disabled: this.actionDisabled("assign-owner"),
+                          disabledReason: this.actionDisabledReasons["assign-owner"],
+                        })}
+                    ${this.compact
+                      ? renderCompactSessionMenuNavigationItem({
+                          view: "icon",
+                          label: t("sessionsView.setIconMenu"),
+                          icon: icons.star,
+                          disabled: this.actionDisabled("set-icon"),
+                          title: this.actionDisabledReasons["set-icon"],
+                        })
+                      : html`<wa-dropdown-item
+                          class="session-menu__item"
+                          data-shortcut="i"
+                          aria-keyshortcuts="I"
+                          ?disabled=${this.actionDisabled("set-icon")}
+                          title=${this.actionTitle("set-icon")}
+                          @submenu-opening=${this.focusIconGridOnOpen}
+                        >
+                          <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                            >${icons.star}</span
+                          >
+                          <span class="session-menu__text">${t("sessionsView.setIconMenu")}</span>
+                          ${menuShortcutHint("i")} ${this.renderIconSubmenu()}
+                        </wa-dropdown-item>`}
+                    <wa-dropdown-item
+                      class="session-menu__item"
+                      value="fork"
+                      data-shortcut="f"
+                      aria-keyshortcuts="F"
+                      ?disabled=${this.actionDisabled("fork", this.forkDisabled)}
+                      title=${this.actionTitle("fork")}
+                    >
+                      <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                        >${icons.copy}</span
+                      >
+                      <span class="session-menu__text"
+                        >${t(
+                          this.forkFromLastCompleted
+                            ? "sessionsView.forkFromLastCompleted"
+                            : "sessionsView.forkSession",
+                        )}</span
+                      >
+                      ${menuShortcutHint("f")}
+                    </wa-dropdown-item>
+                    <wa-dropdown-item
+                      class="session-menu__item"
+                      value="copy-session-id"
+                      data-shortcut="c"
+                      aria-keyshortcuts="C"
+                      ?disabled=${!session.sessionId}
+                    >
+                      <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                        >${icons.copy}</span
+                      >
+                      <span class="session-menu__text">${t("sessionsView.copySessionId")}</span>
+                      ${menuShortcutHint("c")}
+                    </wa-dropdown-item>
+                  `}
+              ${!batch && this.workboard
+                ? html`
+                    <wa-dropdown-item
+                      class="session-menu__item"
+                      value="workboard"
+                      data-shortcut="w"
+                      aria-keyshortcuts="W"
+                      ?disabled=${this.disabled || this.workboard.busy}
+                    >
+                      <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                        >${this.workboard.captured ? icons.check : icons.plus}</span
+                      >
+                      <span class="session-menu__text"
+                        >${this.workboard.captured
+                          ? t("sessionsView.openWorkboardCard")
+                          : t("sessionsView.addToWorkboard")}</span
+                      >
+                      ${menuShortcutHint("w")}
+                    </wa-dropdown-item>
+                  `
+                : nothing}
+              ${rootPlacementActions
+                ? this.compact
+                  ? renderCompactSessionMenuNavigationItem({
+                      view: "group",
+                      label: batch
+                        ? t("sessionsView.moveToGroupMenuCount", { count })
+                        : t("sessionsView.moveToGroupMenu"),
+                      icon: icons.folder,
+                      disabled: this.actionDisabled("move-to-group"),
+                      title: this.actionDisabledReasons["move-to-group"],
+                    })
+                  : html`<wa-dropdown-item
+                      class="session-menu__item"
+                      ?disabled=${this.actionDisabled("move-to-group")}
+                      title=${this.actionTitle("move-to-group")}
+                    >
+                      <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                        >${icons.folder}</span
+                      >
+                      <span class="session-menu__text"
+                        >${batch
+                          ? t("sessionsView.moveToGroupMenuCount", { count })
+                          : t("sessionsView.moveToGroupMenu")}</span
+                      >
+                      ${this.renderGroupSubmenu()}
+                    </wa-dropdown-item>`
+                : nothing}
+              <div class="session-menu__separator" role="separator"></div>
+              ${!batch && this.cloudWorkerStopAllowed
+                ? html`
+                    <wa-dropdown-item
+                      class="session-menu__item session-menu__item--destructive"
+                      value="stop-cloud-worker"
+                      variant="danger"
+                      ?disabled=${this.actionDisabled("stop-cloud-worker")}
+                      title=${this.actionTitle("stop-cloud-worker")}
+                    >
+                      <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                        >${icons.stop}</span
+                      >
+                      <span class="session-menu__text">${t("sessionsView.stopCloudWorker")}</span>
+                    </wa-dropdown-item>
+                  `
+                : nothing}
               <wa-dropdown-item
                 class="session-menu__item"
-                value="rename"
-                data-shortcut="r"
-                aria-keyshortcuts="R"
-                ?disabled=${this.actionDisabled("rename")}
-                title=${this.actionTitle("rename")}
-              >
-                <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.edit}</span>
-                <span class="session-menu__text">${t("sessionsView.renameSessionMenu")}</span>
-                ${menuShortcutHint("r")}
-              </wa-dropdown-item>
-              ${renderSessionOwnerAssignmentMenu({
-                ownerOptions: this.ownerOptions,
-                selfOwner: this.selfOwner,
-                currentOwnerId: this.currentOwnerId,
-                disabled: this.actionDisabled("assign-owner"),
-                disabledReason: this.actionDisabledReasons["assign-owner"],
-              })}
-              <wa-dropdown-item
-                class="session-menu__item"
-                data-shortcut="i"
-                aria-keyshortcuts="I"
-                ?disabled=${this.actionDisabled("set-icon")}
-                title=${this.actionTitle("set-icon")}
-                @submenu-opening=${this.focusIconGridOnOpen}
-              >
-                <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.star}</span>
-                <span class="session-menu__text">${t("sessionsView.setIconMenu")}</span>
-                ${menuShortcutHint("i")} ${this.renderIconSubmenu()}
-              </wa-dropdown-item>
-              <wa-dropdown-item
-                class="session-menu__item"
-                value="fork"
-                data-shortcut="f"
-                aria-keyshortcuts="F"
-                ?disabled=${this.actionDisabled("fork", this.forkDisabled)}
-                title=${this.actionTitle("fork")}
-              >
-                <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.copy}</span>
-                <span class="session-menu__text"
-                  >${t(
-                    this.forkFromLastCompleted
-                      ? "sessionsView.forkFromLastCompleted"
-                      : "sessionsView.forkSession",
-                  )}</span
-                >
-                ${menuShortcutHint("f")}
-              </wa-dropdown-item>
-              <wa-dropdown-item
-                class="session-menu__item"
-                value="copy-session-id"
-                data-shortcut="c"
-                aria-keyshortcuts="C"
-                ?disabled=${!session.sessionId}
-              >
-                <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.copy}</span>
-                <span class="session-menu__text">${t("sessionsView.copySessionId")}</span>
-                ${menuShortcutHint("c")}
-              </wa-dropdown-item>
-            `}
-        ${!batch && this.workboard
-          ? html`
-              <wa-dropdown-item
-                class="session-menu__item"
-                value="workboard"
-                data-shortcut="w"
-                aria-keyshortcuts="W"
-                ?disabled=${this.disabled || this.workboard.busy}
+                value="toggle-archived"
+                data-shortcut="a"
+                aria-keyshortcuts="A"
+                ?disabled=${this.actionDisabled(
+                  "toggle-archived",
+                  !batch && !session.archived && !this.archiveAllowed,
+                )}
+                title=${this.actionTitle("toggle-archived")}
               >
                 <span slot="icon" class="session-menu__icon" aria-hidden="true"
-                  >${this.workboard.captured ? icons.check : icons.plus}</span
+                  >${session.archived ? icons.archiveRestore : icons.archive}</span
                 >
                 <span class="session-menu__text"
-                  >${this.workboard.captured
-                    ? t("sessionsView.openWorkboardCard")
-                    : t("sessionsView.addToWorkboard")}</span
+                  >${batch
+                    ? session.archived
+                      ? t("sessionsView.restoreSessionCount", { count })
+                      : t("sessionsView.archiveSessionCount", { count })
+                    : session.archived
+                      ? t("sessionsView.restoreSession")
+                      : t("sessionsView.archiveSession")}</span
                 >
-                ${menuShortcutHint("w")}
+                ${menuShortcutHint("a")}
               </wa-dropdown-item>
-            `
-          : nothing}
-        ${rootPlacementActions
-          ? html`<wa-dropdown-item
-              class="session-menu__item"
-              ?disabled=${this.actionDisabled("move-to-group")}
-              title=${this.actionTitle("move-to-group")}
-            >
-              <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.folder}</span>
-              <span class="session-menu__text"
-                >${batch
-                  ? t("sessionsView.moveToGroupMenuCount", { count })
-                  : t("sessionsView.moveToGroupMenu")}</span
-              >
-              ${this.renderGroupSubmenu()}
-            </wa-dropdown-item>`
-          : nothing}
-        <div class="session-menu__separator" role="separator"></div>
-        ${!batch && this.cloudWorkerStopAllowed
-          ? html`
               <wa-dropdown-item
                 class="session-menu__item session-menu__item--destructive"
-                value="stop-cloud-worker"
+                value="delete"
                 variant="danger"
-                ?disabled=${this.actionDisabled("stop-cloud-worker")}
-                title=${this.actionTitle("stop-cloud-worker")}
+                data-shortcut="d"
+                aria-keyshortcuts="D"
+                ?disabled=${this.actionDisabled("delete", !this.deleteAllowed)}
+                title=${this.actionTitle("delete")}
               >
-                <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.stop}</span>
-                <span class="session-menu__text">${t("sessionsView.stopCloudWorker")}</span>
+                <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                  >${icons.trash}</span
+                >
+                <span class="session-menu__text"
+                  >${batch
+                    ? t("sessionsView.deleteSessionCount", { count })
+                    : t("sessionsView.deleteSessionMenu")}</span
+                >
+                ${menuShortcutHint("d")}
               </wa-dropdown-item>
-            `
-          : nothing}
-        <wa-dropdown-item
-          class="session-menu__item"
-          value="toggle-archived"
-          data-shortcut="a"
-          aria-keyshortcuts="A"
-          ?disabled=${this.actionDisabled(
-            "toggle-archived",
-            !batch && !session.archived && !this.archiveAllowed,
-          )}
-          title=${this.actionTitle("toggle-archived")}
-        >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true"
-            >${session.archived ? icons.archiveRestore : icons.archive}</span
-          >
-          <span class="session-menu__text"
-            >${batch
-              ? session.archived
-                ? t("sessionsView.restoreSessionCount", { count })
-                : t("sessionsView.archiveSessionCount", { count })
-              : session.archived
-                ? t("sessionsView.restoreSession")
-                : t("sessionsView.archiveSession")}</span
-          >
-          ${menuShortcutHint("a")}
-        </wa-dropdown-item>
-        <wa-dropdown-item
-          class="session-menu__item session-menu__item--destructive"
-          value="delete"
-          variant="danger"
-          data-shortcut="d"
-          aria-keyshortcuts="D"
-          ?disabled=${this.actionDisabled("delete", !this.deleteAllowed)}
-          title=${this.actionTitle("delete")}
-        >
-          <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.trash}</span>
-          <span class="session-menu__text"
-            >${batch
-              ? t("sessionsView.deleteSessionCount", { count })
-              : t("sessionsView.deleteSessionMenu")}</span
-          >
-          ${menuShortcutHint("d")}
-        </wa-dropdown-item>
+            `}
       </wa-dropdown>`,
     );
   }

--- a/ui/src/components/sidebar-menus-render.ts
+++ b/ui/src/components/sidebar-menus-render.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
 import { DEFAULT_SIDEBAR_ENTRIES, serializeSidebarEntry } from "../app-navigation.ts";
+import { isMobileNavLayout } from "../app/mobile-nav-layout.ts";
 import { readPresenceEntries, resolveCurrentSelfUser } from "../app/user-profile.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
@@ -216,6 +217,7 @@ export function renderSidebarSessionMenuForController(controller: SidebarMenusCo
             rows.every((row) => categoryClearReturnsToGroups(row, host.sessionsGrouping)),
         }}
         .selectionCount=${rows.length}
+        .compact=${isMobileNavLayout()}
         .lastActive=${batchRows ? "" : formatSidebarTimestamp(session.updatedAt)}
         .anchor=${menu}
         .trigger=${controller.sessionMenuTrigger}

--- a/ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts
@@ -29,7 +29,12 @@ suite.define(() => {
           }),
         ]),
       },
-      sessionGroups: ["Research", "Operations", "Planning"],
+      sessionGroups: [
+        "Research",
+        "Operations",
+        "Planning",
+        ...Array.from({ length: 24 }, (_, index) => `Team ${index + 1}`),
+      ],
       sessionKey,
     });
 
@@ -51,7 +56,8 @@ suite.define(() => {
 
       expect(await page.locator("openclaw-session-menu [slot='submenu']").count()).toBe(0);
       await page.getByRole("menuitem", { name: "Move to group" }).click();
-      await page.getByRole("menuitem", { name: "Back" }).waitFor({ state: "visible" });
+      const back = page.getByRole("menuitem", { name: "Back" });
+      await back.waitFor({ state: "visible" });
       await page.getByRole("menuitemradio", { name: "Operations" }).waitFor({ state: "visible" });
       expect(await page.locator("openclaw-session-menu [slot='submenu']").count()).toBe(0);
       const menuBox = await menu.boundingBox();
@@ -60,6 +66,24 @@ suite.define(() => {
       }
       expect(menuBox.x).toBeGreaterThanOrEqual(8);
       expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(382);
+      expect(menuBox.y).toBeGreaterThanOrEqual(8);
+      expect(menuBox.y + menuBox.height).toBeLessThanOrEqual(642);
+      const scroll = await menu.evaluate((element) => {
+        element.scrollTop = element.scrollHeight;
+        return {
+          clientHeight: element.clientHeight,
+          scrollHeight: element.scrollHeight,
+          scrollTop: element.scrollTop,
+        };
+      });
+      expect(scroll.scrollHeight).toBeGreaterThan(scroll.clientHeight);
+      expect(scroll.scrollTop).toBeGreaterThan(0);
+      const backBox = await back.boundingBox();
+      if (!backBox) {
+        throw new Error("expected sticky Back action bounds");
+      }
+      expect(backBox.y).toBeGreaterThanOrEqual(menuBox.y);
+      expect(backBox.y + backBox.height).toBeLessThanOrEqual(menuBox.y + menuBox.height);
       await captureUiProof(page, "mobile-sidebar-session-menu-after-group-drilldown.png");
     } finally {
       await context.close();

--- a/ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts
@@ -1,0 +1,68 @@
+import { expect, it } from "vitest";
+import {
+  captureUiProof,
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  sessionRow,
+  sessionsListResponse,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite(true);
+
+suite.define(() => {
+  it("keeps mobile sidebar session menu groups inside the viewport", async () => {
+    const sessionKey = "agent:main:mobile-sidebar-menu";
+    const context = await suite.browser.newContext({
+      colorScheme: "dark",
+      hasTouch: true,
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 650, width: 390 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow(sessionKey, "Mobile sidebar menu", Date.parse("2026-08-19T03:00:00.000Z"), {
+            category: "Research",
+          }),
+        ]),
+      },
+      sessionGroups: ["Research", "Operations", "Planning"],
+      sessionKey,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+      const drawerToggle = page
+        .locator(".topbar-nav-toggle:visible, .chat-pane__nav-toggle:visible")
+        .first();
+      await drawerToggle.waitFor({ state: "visible", timeout: 10_000 });
+      await drawerToggle.click();
+
+      const row = page.locator(`[data-session-key="${sessionKey}"]`);
+      await row.waitFor({ state: "visible" });
+      await row.getByRole("button", { name: "Open session menu" }).click();
+
+      const menu = page.getByRole("menu", { name: "Actions for Mobile sidebar menu" });
+      await menu.waitFor({ state: "visible" });
+      await captureUiProof(page, "mobile-sidebar-session-menu-after-root.png");
+
+      expect(await page.locator("openclaw-session-menu [slot='submenu']").count()).toBe(0);
+      await page.getByRole("menuitem", { name: "Move to group" }).click();
+      await page.getByRole("menuitem", { name: "Back" }).waitFor({ state: "visible" });
+      await page.getByRole("menuitemradio", { name: "Operations" }).waitFor({ state: "visible" });
+      expect(await page.locator("openclaw-session-menu [slot='submenu']").count()).toBe(0);
+      const menuBox = await menu.boundingBox();
+      if (!menuBox) {
+        throw new Error("expected visible compact sidebar session menu");
+      }
+      expect(menuBox.x).toBeGreaterThanOrEqual(8);
+      expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(382);
+      await captureUiProof(page, "mobile-sidebar-session-menu-after-group-drilldown.png");
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2734,6 +2734,11 @@ wa-dropdown.session-menu::part(menu) {
   display: inline-flex;
 }
 
+wa-dropdown.session-menu--compact::part(menu) {
+  max-height: calc(100dvh - 16px);
+  overflow-y: auto;
+}
+
 /* Popover hosts live in the top layer so menus escape in-page stacking
    contexts (e.g. the sidebar resizer above the nav); the host itself must
    stay a zero-size shell around its fixed-position menu. */

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2723,6 +2723,17 @@ wa-dropdown.session-menu::part(menu) {
   box-shadow: var(--overlay-shadow);
 }
 
+.session-menu--compact .session-menu__back {
+  z-index: 1;
+  position: sticky;
+  top: 0;
+  background: var(--wa-color-surface-raised);
+}
+
+.session-menu--compact .session-menu__chevron {
+  display: inline-flex;
+}
+
 /* Popover hosts live in the top layer so menus escape in-page stacking
    contexts (e.g. the sidebar resizer above the nav); the host itself must
    stay a zero-size shell around its fixed-position menu. */


### PR DESCRIPTION
Related: #126124

## What Problem This Solves

Fixes an issue where users opening session actions from the mobile sidebar could not reliably reach nested choices because Open in, Assign to, Set icon, and Move to group opened as desktop side flyouts outside the usable viewport.

## Why This Change Was Made

The sidebar session menu now follows the compact interaction established by #126124: mobile nested actions drill into the same menu with a sticky Back action, while desktop retains Web Awesome flyout submenus. Shared option renderers keep action semantics identical across compact and desktop layouts.

This is AI-assisted work. I reviewed the implementation, browser behavior, tests, final diff, and captured proof.

## User Impact

Mobile users can reach editor, owner, icon, and group choices without horizontal clipping. Group choices stay inside the viewport, and desktop menu behavior is unchanged.

## Evidence

Mocked Control UI at 390×650, inspected after capture:

| Before: group flyout clipped beyond the viewport | After: same-panel group drill-down |
| --- | --- |
| ![Before mobile sidebar session menu](https://github.com/user-attachments/assets/c521831a-3875-4995-9e18-2933b382e488) | ![After mobile sidebar session menu](https://github.com/user-attachments/assets/f5c93b36-4f1d-4a85-bdd5-0c059973384b) |

Browser assertions:

- Compact mode renders zero `[slot="submenu"]` nodes.
- Move to group opens Back plus inline radio choices.
- A long discovered-group catalog scrolls vertically within the 390×650 viewport.
- The sticky Back action remains visible after scrolling to the bottom.

Validation on attributed head `c56ffc0ba3e`:

- `node scripts/run-vitest.mjs ui/src/components/session-menu.test.ts` — 43 passed.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts` — 1 passed.
- `node scripts/check-changed.mjs -- <eight changed paths>` — passed, including formatting, typechecks, lint, i18n, dead-export, and policy guards.
- `pnpm ui:build` — passed; Control UI performance budgets passed.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.
- Fresh autoreview after restoring the Open PR cursor marker — clean; no actionable findings.
- `git diff --check origin/main...HEAD` — passed.

Production LOC: +490/-263 (net +227) | Tests: +153/-0 (net +153). The production growth adds one compact navigation owner and moves existing editor/group option rendering into focused modules rather than introducing parallel mobile action semantics.

Proof gap: browser proof uses mocked Chromium rather than Mobile Safari.
