### PR TITLE
fix: retry messages after handler timeouts

### DIFF
--- a/extensions/qa-lab/index.ts
+++ b/extensions/qa-lab/index.ts
@@ -13,11 +13,37 @@ const EMPTY_TOOL_PARAMETERS = {
   additionalProperties: false,
 } as const;
 
+const QA_PRE_DISPATCH_STALL_ONCE_MS_ENV = "OPENCLAW_QA_PRE_DISPATCH_STALL_ONCE_MS";
+const QA_PRE_DISPATCH_STALL_MARKER_ENV = "OPENCLAW_QA_PRE_DISPATCH_STALL_MARKER";
+const stalledQaPreDispatches = new Set<string>();
+
+async function stallQaBeforeDispatchOnce(
+  event: { channel?: string; content?: string },
+  context: { accountId?: string; conversationId?: string },
+) {
+  const marker = process.env[QA_PRE_DISPATCH_STALL_MARKER_ENV]?.trim();
+  const delayMs = Number(process.env[QA_PRE_DISPATCH_STALL_ONCE_MS_ENV]);
+  if (!marker || !event.content?.includes(marker) || !Number.isFinite(delayMs) || delayMs <= 0) {
+    return;
+  }
+  const key = [event.channel, context.accountId, context.conversationId, event.content].join(
+    "\u0000",
+  );
+  if (stalledQaPreDispatches.has(key)) {
+    return;
+  }
+  stalledQaPreDispatches.add(key);
+  // Deliberately ignore the ingress abort: the QA scenario verifies that a late
+  // first attempt cannot adopt after the watchdog releases its durable claim.
+  await sleep(Math.floor(delayMs));
+}
+
 export default definePluginEntry({
   id: "qa-lab",
   name: "QA Lab",
   description: "Private QA automation harness and debugger UI",
   register(api) {
+    api.on("before_dispatch", stallQaBeforeDispatchOnce);
     api.registerTool(
       {
         name: "qa_restart_wait",

--- a/extensions/telegram/AGENTS.md
+++ b/extensions/telegram/AGENTS.md
@@ -17,7 +17,7 @@ Proof: `src/channels/message/ingress-drain.test.ts`,
 
 - Completed rows tombstone via `complete()`, never `delete`.
 - Complete at turn adoption, not settle. Deferred holds the claim; watchdog
-  stays armed through deferral; dead-letter reason `handler-timeout`.
+  stays armed through deferral and routes timeouts through the shared retry policy.
 - One retry policy: attempt floor **and** age gate (defaults 8 / 24h).
 - Claim refresh heartbeat while dispatching/deferred (`claimLeaseMs / 3`).
 - Never silently complete on transient failure — release/fail via disposition.

--- a/extensions/telegram/src/bot-handlers.inbound-processing.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-processing.ts
@@ -247,6 +247,13 @@ export function createTelegramInboundProcessing({
         maxBytes: mediaMaxBytes,
         ...mediaRuntime,
       });
+      if (mediaRuntime.abortSignal?.aborted) {
+        const abortError =
+          mediaRuntime.abortSignal.reason ?? new Error("telegram media hydration owner aborted");
+        recordTelegramMessageProcessingResult({ kind: "failed-retryable", error: abortError });
+        releaseDispatchDedupeClaims(dispatchDedupeClaims, abortError);
+        return { kind: "ignored" };
+      }
       if (media) {
         await recordMessageResolvedMedia({ msg, media, botUserId: ctx.me?.id });
       }

--- a/extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.pipeline-init.test.ts
@@ -11,6 +11,25 @@ import type { TelegramMessageContext } from "./bot-message-dispatch.test-harness
 import { telegramInboundEventDelivery } from "./inbound-event-delivery.js";
 
 describeTelegramDispatch("dispatchTelegramMessage pipeline-init", () => {
+  it("does not enter the reply pipeline after the durable owner aborts", async () => {
+    const abortController = new AbortController();
+    abortController.abort(new Error("handler-timeout"));
+
+    await expect(
+      dispatchWithContext({
+        context: createContext(),
+        turnAdoptionLifecycle: {
+          abortSignal: abortController.signal,
+          onAdopted: vi.fn(),
+          onDeferred: vi.fn(),
+          onAbandoned: vi.fn(),
+        },
+      }),
+    ).resolves.toEqual({ kind: "completed" });
+
+    expect(createChannelMessageReplyPipeline).not.toHaveBeenCalled();
+  });
+
   it("keeps Telegram typing below its client expiry without a per-message cutoff", async () => {
     await dispatchWithContext({ context: createContext() });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -385,6 +385,12 @@ export const dispatchTelegramMessage = async (
       }
     }
     loadFreshSessionEntry.clear();
+    // Media hydration and other pre-dispatch work can outlive the durable
+    // ingress watchdog. Never enter the reply pipeline after that owner has
+    // already fenced this attempt; the canonical spool row will retry it.
+    if (isDispatchSuperseded()) {
+      return { kind: "completed" };
+    }
     if (status.controller && !isRoomEvent) {
       void status.controller.setThinking();
     }

--- a/extensions/telegram/src/bot-message.test.ts
+++ b/extensions/telegram/src/bot-message.test.ts
@@ -444,6 +444,38 @@ describe("telegram bot message processor", () => {
     expect(finalizeSpooledReplayResult).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a pre-adoption owner timeout retryable when dispatch returns completed", async () => {
+    buildTelegramMessageContext.mockResolvedValue(createMessageContext());
+    const timeoutError = new Error("handler-timeout");
+    const ownerAbort = new AbortController();
+    const finalizeSpooledReplayResult = vi.fn(
+      async (result: TelegramMessageProcessingResult): Promise<TelegramMessageProcessingResult> =>
+        result,
+    );
+    dispatchTelegramMessage.mockImplementationOnce(async () => {
+      ownerAbort.abort(timeoutError);
+      return { kind: "completed" };
+    });
+    const processMessage = createTelegramMessageProcessor(baseDeps);
+    const update = { update_id: 1234581 };
+
+    const replay = await runWithTelegramSpooledReplayUpdate(update, async () =>
+      processSampleMessage(
+        processMessage,
+        {
+          finalizeSpooledReplayResult,
+          spooledReplayAbortSignal: ownerAbort.signal,
+        },
+        { update },
+      ),
+    );
+
+    const expected = { kind: "failed-retryable", error: timeoutError };
+    expect(replay.value).toEqual(expected);
+    await expect(replay.deferredWork?.task).resolves.toEqual(expected);
+    expect(finalizeSpooledReplayResult).toHaveBeenCalledWith(expected, "terminal");
+  });
+
   it("keeps a spooled replay completed when dispatch fails after adoption", async () => {
     buildTelegramMessageContext.mockResolvedValue(createMessageContext());
     const lateError = new Error("late dispatch failure");

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -447,6 +447,18 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         if (settledResult) {
           return settledResult;
         }
+        if (turnAbortSignal.aborted) {
+          const abortResult: TelegramMessageProcessingResult =
+            turnAbortSignal.reason === "skipped"
+              ? { kind: "skipped" }
+              : {
+                  kind: "failed-retryable",
+                  error:
+                    turnAbortSignal.reason ??
+                    new Error("telegram spooled replay owner cancelled before adoption"),
+                };
+          return await settle(abortResult, "terminal");
+        }
         if (adoptionAttempted && !deferred && result.kind === "completed") {
           runtime.error?.(
             danger(

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -2711,7 +2711,7 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("fails buffered spooled claims instead of requeueing when deferred processing times out", async () => {
+  it("requeues buffered spooled claims when deferred processing times out", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();
       const log = vi.fn();
@@ -2731,15 +2731,15 @@ describe("TelegramPollingSession", () => {
 
       await waitForTelegramTestState(() => expect(participants).toHaveLength(1));
       await waitForTelegramTestState(async () =>
-        expect(await failedUpdateIds(tempDir)).toEqual([42]),
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([42]),
       );
-      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await failedUpdateIds(tempDir)).toEqual([]);
       expect(await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).toEqual([]);
       // Core drain watchdog log (display-id stripped of zero padding).
       expectLogIncludes(log, "claim→adoption stalled for event");
       expectLogIncludes(log, "handler-timeout");
-      expectLogExcludes(log, "spooled update 42 failed; keeping for retry");
-      expect(await failedUpdateReasons(tempDir)).toEqual([{ id: 42, reason: "handler-timeout" }]);
+      expectLogIncludes(log, "spooled update 42 failed; keeping for retry");
+      expect(await failedUpdateReasons(tempDir)).toEqual([]);
       abort.abort();
       stopWorker();
       await runPromise;
@@ -3512,9 +3512,9 @@ describe("TelegramPollingSession", () => {
     });
   });
 
-  it("recovers a lone active spooled handler owned by a replaced session (#84158)", async () => {
-    // Core drain: a lone hanging claim is dead-lettered by the adoption-stall
-    // watchdog so a replacement session is not blocked forever on that lane.
+  it("retries a lone active spooled handler in a replacement session (#84158)", async () => {
+    // Core drain: a lone hanging claim is released by the adoption-stall
+    // watchdog so a replacement session can retry it on the same lane.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const firstAbort = new AbortController();
     const secondAbort = new AbortController();
@@ -3524,7 +3524,9 @@ describe("TelegramPollingSession", () => {
       releaseTurn = resolve;
     });
     const handleUpdate = vi.fn(async () => {
-      await turnDone;
+      if (handleUpdate.mock.calls.length === 1) {
+        await turnDone;
+      }
     });
     createTelegramBotMock.mockImplementation(() => makeIsolatedBot({ handleUpdate }));
     await writeSpooledTestUpdates(tempDir, [topicUpdate(42, 10, "lone active topic turn")]);
@@ -3558,10 +3560,10 @@ describe("TelegramPollingSession", () => {
       });
       const firstRunPromise = firstSession.runUntilAbort();
       await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
-      // Watchdog dead-letters the hanging claim before the session is replaced.
+      // Watchdog releases the hanging claim before the session is replaced.
       await vi.advanceTimersByTimeAsync(1_000);
       await waitForTelegramTestState(async () =>
-        expect(await failedUpdateIds(tempDir)).toEqual([42]),
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([42]),
       );
       firstAbort.abort();
       await vi.advanceTimersByTimeAsync(16_000);
@@ -3578,10 +3580,12 @@ describe("TelegramPollingSession", () => {
         },
       });
       const secondRunPromise = secondSession.runUntilAbort();
-      await vi.advanceTimersByTimeAsync(1_000);
-      // Tombstoned/failed claim is not re-dispatched; replacement is unblocked.
-      expect(handleUpdate).toHaveBeenCalledTimes(1);
-      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      await waitForTelegramTestState(() => expect(handleUpdate).toHaveBeenCalledTimes(2));
+      await waitForTelegramTestState(async () =>
+        expect(await pendingUpdateIds(tempDir, "all")).toEqual([]),
+      );
+      expect(await failedUpdateIds(tempDir)).toEqual([]);
 
       secondAbort.abort();
       await vi.advanceTimersByTimeAsync(20_000);
@@ -4434,10 +4438,9 @@ describe("TelegramPollingSession", () => {
     }
   });
 
-  it("fails a timed-out spooled handler and drains later same-lane updates without restart", async () => {
-    // Core drain: adoption-stall dead-letters 42 and frees the lane for 43 on
-    // the same bot. Session restart on handler timeout is removed private-drain
-    // behavior; the user-visible outcome is 42 failed and 43 processed.
+  it("retries a timed-out spooled handler before later same-lane updates without restart", async () => {
+    // Core drain: adoption-stall releases 42 for retry before 43 on the same
+    // bot. Session restart on handler timeout remains unnecessary.
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const abort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
@@ -4451,11 +4454,13 @@ describe("TelegramPollingSession", () => {
       init: vi.fn(async () => undefined),
       handleUpdate: vi.fn(async (update: { update_id?: number }) => {
         events.push(`bot:${update.update_id}`);
-        if (update.update_id === 42) {
+        if (update.update_id === 42 && events.filter((event) => event === "bot:42").length === 1) {
           // Hang until the core watchdog aborts the drain lifecycle.
           await new Promise<void>(() => {});
         }
-        abort.abort();
+        if (update.update_id === 43) {
+          abort.abort();
+        }
       }),
       stop: vi.fn(async () => undefined),
     };
@@ -4482,11 +4487,8 @@ describe("TelegramPollingSession", () => {
       const runPromise = session.runUntilAbort();
       await waitForTelegramTestState(() => expect(events).toEqual(["bot:42"]));
 
-      await vi.advanceTimersByTimeAsync(1_000);
-      await waitForTelegramTestState(async () =>
-        expect(await failedUpdateIds(tempDir)).toEqual([42]),
-      );
-      await waitForTelegramTestState(() => expect(events).toEqual(["bot:42", "bot:43"]));
+      await vi.advanceTimersByTimeAsync(2_000);
+      await waitForTelegramTestState(() => expect(events).toEqual(["bot:42", "bot:42", "bot:43"]));
       await vi.advanceTimersByTimeAsync(15_000);
       await runPromise;
 
@@ -4494,6 +4496,7 @@ describe("TelegramPollingSession", () => {
       expect(worker.createWorker).toHaveBeenCalledTimes(1);
       expect(createTelegramBotMock).toHaveBeenCalledTimes(1);
       expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await failedUpdateIds(tempDir)).toEqual([]);
       expectLogIncludes(log, "handler-timeout");
     } finally {
       abort.abort();

--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -354,19 +354,31 @@ describe("Telegram durable ingress coalescing", () => {
       expectBufferedFailure: true,
     },
   ])(
-    "cancels $label hydration at the claim watchdog and releases the same-chat lane",
+    "retries $label hydration after the claim watchdog before delivering the same-chat successor",
     async ({ update, expectBufferedFailure }) => {
-      const getFile = vi.fn(
-        () =>
-          new Response(
-            JSON.stringify({
-              ok: false,
-              error_code: 429,
-              description: "Too Many Requests: retry after 60",
-              parameters: { retry_after: 60 },
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
+      const getFile = vi.fn((call: number) =>
+        call === 1
+          ? new Response(
+              JSON.stringify({
+                ok: false,
+                error_code: 429,
+                description: "Too Many Requests: retry after 60",
+                parameters: { retry_after: 60 },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            )
+          : new Response(
+              JSON.stringify({
+                ok: true,
+                result: {
+                  file_id: "photo-retry",
+                  file_unique_id: "unique-retry",
+                  file_size: 4,
+                  file_path: "photos/photo-retry.jpg",
+                },
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
       );
       const runtimeError = vi.fn();
       const telegramTransport = createBotApiTransport({ onGetFile: getFile });
@@ -388,25 +400,33 @@ describe("Telegram durable ingress coalescing", () => {
         timeout: 1_000,
         interval: 5,
       });
-      const nextAdmittedAt = Date.now();
       await monitor.admit(next);
-      const turn = await awaitSingleDownstreamTurn();
-
-      expect(Date.now() - nextAdmittedAt).toBeLessThan(1_000);
-      expect(turn.Body).toContain("next message after stalled media");
-      expect(turn.Body).not.toContain("<media:image>");
+      await vi.waitFor(() => expect(downstreamTurns).toHaveBeenCalledTimes(2), {
+        timeout: 5_000,
+        interval: 5,
+      });
+      const turns = downstreamTurns.mock.calls.map(
+        ([context]) => context as MsgContext & Record<string, unknown>,
+      );
+      const successorTurn = turns.find((turn) =>
+        String(turn.Body).includes("next message after stalled media"),
+      );
+      const retriedMediaTurn = turns.find((turn) => turn !== successorTurn);
+      expect(successorTurn?.Body).not.toContain("<media:image>");
+      expect(retriedMediaTurn?.media).toMatchObject([
+        { path: "/tmp/photo-retry.jpg", kind: "image" },
+      ]);
       const queue = openTelegramIngressQueue(spoolDir);
       await vi.waitFor(async () => {
-        expect(await queue.listFailed?.({ limit: "all" })).toEqual([
-          expect.objectContaining({
-            id: telegramQueueEventId(update.update_id),
-            reason: "handler-timeout",
-          }),
-        ]);
+        expect(await queue.listClaims()).toEqual([]);
+        expect(await queue.listPending({ limit: "all" })).toEqual([]);
       });
-      await expect(
-        queue.enqueue(telegramQueueEventId(nextUpdateId), {} as never),
-      ).resolves.toMatchObject({ kind: "completed" });
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      for (const updateId of [update.update_id, nextUpdateId]) {
+        await expect(
+          queue.enqueue(telegramQueueEventId(updateId), {} as never),
+        ).resolves.toMatchObject({ kind: "completed" });
+      }
       if (expectBufferedFailure) {
         await vi.waitFor(() => expect(runtimeError).toHaveBeenCalledOnce());
       } else {
@@ -415,8 +435,8 @@ describe("Telegram durable ingress coalescing", () => {
       await new Promise<void>((resolve) => {
         setTimeout(resolve, 50);
       });
-      expect(getFile).toHaveBeenCalledOnce();
-      expect(downstreamTurns).toHaveBeenCalledOnce();
+      expect(getFile).toHaveBeenCalledTimes(2);
+      expect(downstreamTurns).toHaveBeenCalledTimes(2);
     },
   );
 

--- a/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
+++ b/extensions/telegram/src/telegram-ingress-coalescing.e2e.test.ts
@@ -27,6 +27,7 @@ const downstreamTurns = vi.hoisted(() =>
     counts: { block: 0, final: 0, tool: 0 },
   })),
 );
+const downstreamHarness = vi.hoisted(() => ({ adoptAfterDispatch: false }));
 
 vi.mock("./fetch.js", () => ({
   resolveTelegramApiBase: (apiRoot?: string) => apiRoot ?? "https://api.telegram.org",
@@ -44,7 +45,14 @@ vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
     ...actual,
     runChannelInboundEvent: async (params: Parameters<typeof actual.runChannelInboundEvent>[0]) =>
       await runTelegramChannelInboundEventWithHarness(actual, params, async (dispatchParams) => {
-        return await downstreamTurns(dispatchParams.ctx);
+        const result = await downstreamTurns(dispatchParams.ctx);
+        if (downstreamHarness.adoptAfterDispatch) {
+          // The real reply runner owns adoption. This lightweight harness returns
+          // immediately, so settle its successful mock before the short watchdog
+          // can mistake the retry itself for another stall.
+          await dispatchParams.replyOptions?.turnAdoptionLifecycle?.onAdopted?.();
+        }
+        return result;
       }),
   };
 });
@@ -257,6 +265,7 @@ describe("Telegram durable ingress coalescing", () => {
     downstreamTurns
       .mockReset()
       .mockResolvedValue({ queuedFinal: false, counts: { block: 0, final: 0, tool: 0 } });
+    downstreamHarness.adoptAfterDispatch = false;
     resetInboundDedupe();
     resetPluginStateStoreForTests({ closeDatabase: false });
     resetTelegramAccountThrottlersForTest();
@@ -356,35 +365,52 @@ describe("Telegram durable ingress coalescing", () => {
   ])(
     "retries $label hydration after the claim watchdog before delivering the same-chat successor",
     async ({ update, expectBufferedFailure }) => {
-      const getFile = vi.fn((call: number) =>
-        call === 1
-          ? new Response(
-              JSON.stringify({
-                ok: false,
-                error_code: 429,
-                description: "Too Many Requests: retry after 60",
-                parameters: { retry_after: 60 },
-              }),
-              { status: 200, headers: { "content-type": "application/json" } },
-            )
-          : new Response(
-              JSON.stringify({
-                ok: true,
-                result: {
-                  file_id: "photo-retry",
-                  file_unique_id: "unique-retry",
-                  file_size: 4,
-                  file_path: "photos/photo-retry.jpg",
-                },
-              }),
-              { status: 200, headers: { "content-type": "application/json" } },
-            ),
-      );
+      downstreamHarness.adoptAfterDispatch = true;
+      const getFile = vi.fn((call: number) => {
+        if (call === 1) {
+          // Keep hydration beyond the 750 ms watchdog deterministically. Without
+          // this hold, a busy runner can let the mocked downstream turn start
+          // before the watchdog and turn this race test into a scheduler lottery.
+          const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+              setTimeout(() => {
+                controller.enqueue(
+                  new TextEncoder().encode(
+                    JSON.stringify({
+                      ok: false,
+                      error_code: 429,
+                      description: "Too Many Requests: retry after 60",
+                      parameters: { retry_after: 60 },
+                    }),
+                  ),
+                );
+                controller.close();
+              }, 1_200);
+            },
+          });
+          return new Response(body, {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            result: {
+              file_id: "photo-retry",
+              file_unique_id: "unique-retry",
+              file_size: 4,
+              file_path: "photos/photo-retry.jpg",
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      });
       const runtimeError = vi.fn();
       const telegramTransport = createBotApiTransport({ onGetFile: getFile });
       const { monitor } = await createMonitor({
         telegramTransport,
-        adoptionStallTimeoutMs: 120,
+        adoptionStallTimeoutMs: 750,
         onRuntimeError: runtimeError,
       });
       const nextUpdateId = update.update_id + 10;
@@ -401,10 +427,19 @@ describe("Telegram durable ingress coalescing", () => {
         interval: 5,
       });
       await monitor.admit(next);
-      await vi.waitFor(() => expect(downstreamTurns).toHaveBeenCalledTimes(2), {
-        timeout: 5_000,
-        interval: 5,
-      });
+      await vi.waitFor(
+        () =>
+          expect(
+            downstreamTurns.mock.calls.length,
+            JSON.stringify(
+              downstreamTurns.mock.calls.map(([turn]) => ({
+                body: turn.Body,
+                media: turn.media,
+              })),
+            ),
+          ).toBeGreaterThanOrEqual(2),
+        { timeout: 5_000, interval: 5 },
+      );
       const turns = downstreamTurns.mock.calls.map(
         ([context]) => context as MsgContext & Record<string, unknown>,
       );
@@ -435,8 +470,8 @@ describe("Telegram durable ingress coalescing", () => {
       await new Promise<void>((resolve) => {
         setTimeout(resolve, 50);
       });
-      expect(getFile).toHaveBeenCalledTimes(2);
       expect(downstreamTurns).toHaveBeenCalledTimes(2);
+      expect(getFile.mock.calls.length).toBeGreaterThanOrEqual(2);
     },
   );
 

--- a/extensions/telegram/src/webhook.test.ts
+++ b/extensions/telegram/src/webhook.test.ts
@@ -1350,10 +1350,11 @@ describe("startTelegramWebhook", () => {
     }
   });
 
-  it("keeps a timed-out webhook lane guarded until replay settles", async () => {
+  it("retries a timed-out webhook update before later same-lane updates", async () => {
     vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
     try {
       let finishFirstUpdate: (() => void) | undefined;
+      let finishRetry: (() => void) | undefined;
       const seenUpdateIds: number[] = [];
       const firstUpdate = telegramMessageUpdate(40, "slow");
       const secondUpdate = telegramMessageUpdate(41, "blocked");
@@ -1370,7 +1371,11 @@ describe("startTelegramWebhook", () => {
         seenUpdateIds.push(updateId);
         if (updateId === 40) {
           await new Promise<void>((resolve) => {
-            finishFirstUpdate = resolve;
+            if (seenUpdateIds.filter((id) => id === 40).length === 1) {
+              finishFirstUpdate = resolve;
+            } else {
+              finishRetry = resolve;
+            }
           });
         }
       });
@@ -1390,7 +1395,9 @@ describe("startTelegramWebhook", () => {
         expect(seenUpdateIds).toEqual([40]);
 
         finishFirstUpdate?.();
-        await waitForWebhookState(() => expect(seenUpdateIds).toEqual([40, 41]));
+        await waitForWebhookState(() => expect(seenUpdateIds).toEqual([40, 40]));
+        finishRetry?.();
+        await waitForWebhookState(() => expect(seenUpdateIds).toEqual([40, 40, 41]));
       } finally {
         await started.stop();
       }

--- a/extensions/zalouser/src/ingress.test.ts
+++ b/extensions/zalouser/src/ingress.test.ts
@@ -231,7 +231,7 @@ describe("Zalouser durable ingress", () => {
     });
   });
 
-  it("settles deferred bookkeeping when the adoption watchdog aborts a claim", async () => {
+  it("releases deferred bookkeeping for retry when the adoption watchdog aborts a claim", async () => {
     await withZalouserIngressTestQueue(async (queue) => {
       let deferredLifecycle: ZalouserIngressLifecycle | undefined;
       const dispatch = vi.fn(async (_message, lifecycle: ZalouserIngressLifecycle) => {
@@ -244,10 +244,21 @@ describe("Zalouser durable ingress", () => {
         runtime: runtime(),
         queue,
         dispatch,
+        pollIntervalMs: 60_000,
         adoptionStallTimeoutMs: 10,
       });
       await ingress.receive(createRawZalouserMessage({ msgId: "deferred-timeout" }));
-      await waitForZalouserIngressVerdict(queue, "deferred-timeout", "failed");
+      await vi.waitFor(async () => {
+        expect(await queue.listClaims()).toEqual([]);
+        expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+        expect(await queue.listPending({ limit: "all" })).toMatchObject([
+          {
+            id: "deferred-timeout",
+            attempts: 1,
+            lastError: expect.stringContaining("handler-timeout"),
+          },
+        ]);
+      });
       expect(deferredLifecycle?.abortSignal.aborted).toBe(true);
 
       await ingress.stop();

--- a/qa/scenarios/channels/telegram-handler-timeout-retry.yaml
+++ b/qa/scenarios/channels/telegram-handler-timeout-retry.yaml
@@ -1,0 +1,160 @@
+title: Telegram handler-timeout retry ordering
+
+scenario:
+  id: telegram-handler-timeout-retry
+  surface: channels
+  coverage:
+    primary:
+      - channels.recovered-final-reply
+    secondary:
+      - agent-runtime.failure-recovery-retry-policy
+      - agent-runtime.session-turn-ordering
+  objective: Verify a Telegram update released by the claim-to-adoption watchdog is retried before a later same-chat update, with one visible reply per update.
+  gatewayConfigPatch:
+    messages:
+      inbound:
+        debounceMs: 0
+  successCriteria:
+    - A real Telegram plugin connected to Crabline records the handler-timeout retry disposition.
+    - The same ephemeral Gateway replays the first update before its same-chat successor.
+    - The transport observes exactly one ordered final reply for each update.
+  docsRefs:
+    - docs/channels/qa-channel.md
+    - docs/channels/telegram.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - extensions/qa-lab/index.ts
+    - extensions/qa-lab/src/crabline-transport.ts
+    - extensions/telegram/src/telegram-ingress-drain.ts
+    - src/channels/message/ingress-drain.ts
+  execution:
+    kind: flow
+    channel: telegram
+    suiteIsolation: isolated
+    isolationReason: Uses a QA-only one-shot pre-dispatch stall and a shortened watchdog timeout.
+    summary: Force one Telegram claim-to-adoption timeout, then prove same-Gateway retry-before-successor ordering and single delivery.
+    config:
+      requiredProviderMode: mock-openai
+      requiredChannelDriver: crabline
+      forcedTimeoutMs: "2000"
+      stallMs: "2200"
+      conversationId: handler-timeout-retry
+      senderId: qa-timeout-operator
+      firstMarker: TELEGRAM-HANDLER-TIMEOUT-FIRST-OK
+      secondMarker: TELEGRAM-HANDLER-TIMEOUT-SECOND-OK
+      firstPrompt: "Reply exactly: TELEGRAM-HANDLER-TIMEOUT-FIRST-OK"
+      secondPrompt: "Reply exactly: TELEGRAM-HANDLER-TIMEOUT-SECOND-OK"
+
+flow:
+  steps:
+    - name: retries the timed-out update before its same-chat successor
+      actions:
+        - assert:
+            expr: env.providerMode === config.requiredProviderMode
+            message: this deterministic proof requires mock-openai
+        - assert:
+            expr: env.gateway.runtimeEnv.OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS === config.forcedTimeoutMs
+            message: start the proof with OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS=2000
+        - assert:
+            expr: env.gateway.runtimeEnv.OPENCLAW_QA_PRE_DISPATCH_STALL_ONCE_MS === config.stallMs
+            message: start the proof with OPENCLAW_QA_PRE_DISPATCH_STALL_ONCE_MS=2200
+        - assert:
+            expr: env.gateway.runtimeEnv.OPENCLAW_QA_PRE_DISPATCH_STALL_MARKER === config.firstMarker
+            message: the QA one-shot pre-dispatch stall marker must match the first update
+        - call: waitForGatewayHealthy
+          args:
+            - ref: env
+            - 60000
+        - call: waitForTransportReady
+          args:
+            - ref: env
+            - 60000
+        - resetTransport: true
+        - set: timeoutLogMark
+          value:
+            expr: markGatewayLogCursor()
+        - sendInbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Timeout Operator
+            text:
+              ref: config.firstPrompt
+        - sendInbound:
+            conversation:
+              id:
+                ref: config.conversationId
+              kind: direct
+            senderId:
+              ref: config.senderId
+            senderName: QA Timeout Operator
+            text:
+              ref: config.secondPrompt
+        - call: waitForCondition
+          saveAs: timeoutLogs
+          args:
+            - lambda:
+                expr: "(() => { const logs = readGatewayLogs().slice(timeoutLogMark); return logs.includes('handler-timeout') && logs.includes('keeping for retry') ? logs : undefined; })()"
+            - 30000
+            - 25
+        - call: waitForCondition
+          saveAs: orderedOutbounds
+          args:
+            - lambda:
+                expr: "(() => { const outbounds = state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId); const markers = outbounds.map((message) => message.text).filter((text) => text.includes(config.firstMarker) || text.includes(config.secondMarker)); return markers.length >= 2 ? markers : undefined; })()"
+            - 90000
+            - 50
+        - call: sleep
+          args:
+            - 1000
+        - set: matchingOutbounds
+          value:
+            expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId && (message.text.includes(config.firstMarker) || message.text.includes(config.secondMarker)))"
+        - assert:
+            expr: "matchingOutbounds.length === 2 && matchingOutbounds[0]?.text.includes(config.firstMarker) && matchingOutbounds[1]?.text.includes(config.secondMarker)"
+            message:
+              expr: "`expected exactly one ordered reply per update; transcript=${formatTransportTranscript(state, { conversationId: config.conversationId })}`"
+        - set: timeoutLogLine
+          value:
+            expr: "timeoutLogs.split('\\n').find((line) => line.includes('handler-timeout'))?.replace(/event \\d+/u, 'event <redacted>').replace(/lane [^ ]+/u, 'lane <redacted>') ?? 'handler-timeout observed'"
+        - set: timeoutCount
+          value:
+            expr: "timeoutLogs.split('\\n').filter((line) => line.includes('] Channel ingress claim→adoption stalled')).length"
+        - set: retryDispositionCount
+          value:
+            expr: "timeoutLogs.split('\\n').filter((line) => line.includes('keeping for retry')).length"
+        - assert:
+            expr: timeoutCount === 1 && retryDispositionCount === 1
+            message:
+              expr: "`expected one timeout and one retry disposition; timeoutCount=${timeoutCount} retryDispositionCount=${retryDispositionCount}`"
+        - set: verdict
+          value:
+            expr: |-
+              ({
+                schemaVersion: 1,
+                headSha: env.gateway.runtimeEnv.OPENCLAW_QA_HEAD_SHA ?? null,
+                transport: 'crabline:telegram',
+                provider: env.providerMode,
+                gateway: 'ephemeral',
+                eventOrder: ['first:handler-timeout', 'first:retry:outbound', 'second:outbound'],
+                outboundOrder: matchingOutbounds.map((message) => message.text),
+                outboundCount: matchingOutbounds.length,
+                timeoutCount,
+                retryDispositionCount,
+                timeoutLog: timeoutLogLine,
+                queueOutcome: 'retry completed before same-lane successor',
+                pass: true,
+              })
+        - set: verdictPath
+          value:
+            expr: path.join(env.outputDir, 'handler-timeout-verdict.json')
+        - set: wroteVerdict
+          value:
+            expr: "await fs.writeFile(verdictPath, `${JSON.stringify(verdict, null, 2)}\\n`, 'utf8').then(() => true)"
+        - assert:
+            expr: wroteVerdict === true
+            message: failed to write handler-timeout verdict
+      detailsExpr: "`timeout=${timeoutLogLine}; outbound=${matchingOutbounds.map((message) => message.text).join(' -> ')}; verdict=${path.basename(verdictPath)}`"

--- a/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
@@ -345,6 +345,123 @@ describe("dispatchReplyFromConfig", () => {
     activeOperation.complete();
   });
 
+  it("releases inbound dedupe when durable ingress aborts before adoption", async () => {
+    setNoAbort();
+    hookMocks.runner.hasHooks.mockImplementation(
+      ((hookName?: string) => hookName === "before_dispatch") as () => boolean,
+    );
+    let markHookStarted!: () => void;
+    const hookStarted = new Promise<void>((resolve) => {
+      markHookStarted = resolve;
+    });
+    let releaseHook!: () => void;
+    const hookRelease = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+    hookMocks.runner.runBeforeDispatch
+      .mockImplementationOnce(async () => {
+        markHookStarted();
+        await hookRelease;
+        return undefined;
+      })
+      .mockResolvedValue(undefined);
+
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "user:1",
+      SessionKey: "agent:main:telegram:direct:1",
+      MessageSid: "42",
+      BodyForAgent: "retry me",
+    });
+    const firstAbort = new AbortController();
+    const replyResolver = vi.fn(async () => ({ text: "retried" }) satisfies ReplyPayload);
+    const lifecycle = {
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onSettled: vi.fn(),
+    };
+
+    const firstDispatch = dispatchReplyFromConfig({
+      ctx,
+      cfg: automaticDirectReplyConfig,
+      dispatcher: createDispatcher(),
+      replyOptions: { abortSignal: firstAbort.signal, turnAdoptionLifecycle: lifecycle },
+      replyResolver,
+    });
+    await hookStarted;
+    firstAbort.abort(new Error("handler-timeout"));
+    releaseHook();
+    await expect(firstDispatch).resolves.toMatchObject({ queuedFinal: false });
+    expect(replyResolver).not.toHaveBeenCalled();
+
+    await expect(
+      dispatchReplyFromConfig({
+        ctx,
+        cfg: automaticDirectReplyConfig,
+        dispatcher: createDispatcher(),
+        replyOptions: { turnAdoptionLifecycle: lifecycle },
+        replyResolver,
+      }),
+    ).resolves.toMatchObject({ queuedFinal: true });
+    expect(replyResolver).toHaveBeenCalledOnce();
+  });
+
+  it("retains inbound dedupe when a reply operation aborts after durable adoption", async () => {
+    setNoAbort();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "user:1",
+      SessionKey: "agent:main:telegram:direct:1",
+      MessageSid: "43",
+      BodyForAgent: "run once",
+    });
+    const lifecycle = {
+      onAdopted: vi.fn(async () => {}),
+      onDeferred: vi.fn(),
+      onSettled: vi.fn(),
+    };
+    const firstReplyResolver = vi.fn(
+      async (_ctx: MsgContext, opts?: GetReplyOptions): Promise<ReplyPayload | undefined> => {
+        await opts?.turnAdoptionLifecycle?.onAdopted();
+        const operation = (
+          opts as { replyOperation?: ReturnType<typeof createReplyOperation> } | undefined
+        )?.replyOperation;
+        expect(operation?.abortForRestart()).toBe(true);
+        await new Promise<never>(() => {});
+        return undefined;
+      },
+    );
+
+    await expect(
+      dispatchReplyFromConfig({
+        ctx,
+        cfg: automaticDirectReplyConfig,
+        dispatcher: createDispatcher(),
+        replyOptions: { turnAdoptionLifecycle: lifecycle },
+        replyResolver: firstReplyResolver,
+      }),
+    ).resolves.toMatchObject({ queuedFinal: false });
+    expect(lifecycle.onAdopted).toHaveBeenCalledOnce();
+
+    const duplicateReplyResolver = vi.fn(
+      async () => ({ text: "duplicate" }) satisfies ReplyPayload,
+    );
+    await expect(
+      dispatchReplyFromConfig({
+        ctx,
+        cfg: automaticDirectReplyConfig,
+        dispatcher: createDispatcher(),
+        replyOptions: { turnAdoptionLifecycle: lifecycle },
+        replyResolver: duplicateReplyResolver,
+      }),
+    ).resolves.toMatchObject({ queuedFinal: false });
+    expect(duplicateReplyResolver).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["confirmed", false, "succeeded", "completed", "active_run_injected"],
     ["unconfirmed", true, "blocked", "skipped", "reply_operation_aborted"],

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -484,7 +484,14 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
           isError: true,
         })
       : false;
-    commitInboundDedupeIfClaimed();
+    // A durable transport owns retry after a pre-adoption abort. Releasing its
+    // process-local claim lets the canonical spool row re-enter dispatch; the
+    // transport lifecycle still decides whether that row is retried or closed.
+    if (params.turnAdoptionState && !params.turnAdoptionState.adopted) {
+      releaseInboundDedupeIfClaimed();
+    } else {
+      commitInboundDedupeIfClaimed();
+    }
     recordProcessed("completed", { reason: "reply_operation_aborted" });
     markIdle("message_completed");
     state.completeDispatchReplyOperation();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -24,16 +24,34 @@ export type { DispatchFromConfigResult } from "./dispatch-from-config.types.js";
 export async function dispatchReplyFromConfig(
   params: DispatchFromConfigParams,
 ): Promise<DispatchFromConfigResult> {
+  const turnAdoptionLifecycle = params.replyOptions?.turnAdoptionLifecycle;
+  const turnAdoptionState = { adopted: false };
+  const trackedParams = turnAdoptionLifecycle
+    ? {
+        ...params,
+        turnAdoptionState,
+        replyOptions: {
+          ...params.replyOptions,
+          turnAdoptionLifecycle: {
+            ...turnAdoptionLifecycle,
+            onAdopted: async () => {
+              await turnAdoptionLifecycle.onAdopted();
+              turnAdoptionState.adopted = true;
+            },
+          },
+        },
+      }
+    : params;
   const ticket = reserveReplyAdmissionTicket([
-    params.ctx.SessionKey,
-    params.ctx.CommandTargetSessionKey,
+    trackedParams.ctx.SessionKey,
+    trackedParams.ctx.CommandTargetSessionKey,
   ]);
   const ticketedParams = ticket
     ? {
-        ...params,
-        replyOptions: { ...params.replyOptions, [REPLY_ADMISSION_TICKET]: ticket },
+        ...trackedParams,
+        replyOptions: { ...trackedParams.replyOptions, [REPLY_ADMISSION_TICKET]: ticket },
       }
-    : params;
+    : trackedParams;
   const messageAuditTerminal = createInboundMessageAuditTerminal(params);
   try {
     const result = await dispatchReplyFromConfigInner(ticketedParams, messageAuditTerminal);

--- a/src/auto-reply/reply/dispatch-from-config.types.ts
+++ b/src/auto-reply/reply/dispatch-from-config.types.ts
@@ -47,6 +47,8 @@ export type DispatchFromConfigParams = {
    * config snapshot is unavailable during startup or durable ingress replay.
    */
   usePublishedModelRuntime?: boolean;
+  /** Internal per-dispatch fact used to distinguish pre-adoption from later aborts. */
+  turnAdoptionState?: { adopted: boolean };
 };
 
 export type DispatchReplyFromConfig = (

--- a/src/channels/message/ingress-drain.debounce-failure.test.ts
+++ b/src/channels/message/ingress-drain.debounce-failure.test.ts
@@ -85,7 +85,7 @@ describe("channel ingress drain debounce failures", () => {
     });
   });
 
-  it("keeps watchdog recovery after retry settlement fails", async () => {
+  it("keeps watchdog ownership when retry settlement keeps failing", async () => {
     vi.useFakeTimers();
     await withTempState(async (stateDir) => {
       let clock = 10_000;
@@ -98,6 +98,7 @@ describe("channel ingress drain debounce failures", () => {
       queue.release = async () => {
         throw new Error("persistent release failure");
       };
+      const log = vi.fn();
 
       const sessionError = new Error("Session changed while starting work. Retry.");
       const debouncer = createInboundDebouncer<{ lifecycle: ChannelIngressDispatchLifecycle }>({
@@ -116,6 +117,7 @@ describe("channel ingress drain debounce failures", () => {
         queue,
         now: () => clock,
         adoptionStallTimeoutMs: 200_000,
+        onLog: log,
         dispatchClaimedEvent: async (_event, lifecycle) => {
           await debouncer.enqueue({ lifecycle });
           return { kind: "deferred" };
@@ -134,11 +136,14 @@ describe("channel ingress drain debounce failures", () => {
 
       clock += 73_000;
       await vi.advanceTimersByTimeAsync(73_000);
-      expect(await queue.listClaims()).toEqual([]);
-      expect(await queue.listFailed?.({ limit: "all" })).toMatchObject([
-        { id: "debounced-settlement-failure", reason: "handler-timeout" },
+      expect((await queue.listClaims()).map((claim) => claim.id)).toEqual([
+        "debounced-settlement-failure",
       ]);
-      expect(drain.activeLaneKeys().has("shared")).toBe(false);
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      expect(drain.activeLaneKeys().has("shared")).toBe(true);
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining("applying retry policy (handler-timeout)"),
+      );
       drain.dispose();
     });
   });

--- a/src/channels/message/ingress-drain.test.ts
+++ b/src/channels/message/ingress-drain.test.ts
@@ -300,9 +300,15 @@ describe("channel ingress drain", () => {
 
       clock += 1_000;
       await vi.advanceTimersByTimeAsync(1_000);
-      await vi.waitFor(async () => expect(await queue.listFailed?.()).toHaveLength(1));
-      const failed = await queue.listFailed?.();
-      expect(failed?.[0]).toMatchObject({ id: "released-stall", reason: "handler-timeout" });
+      await vi.waitFor(async () => expect(await queue.listClaims()).toEqual([]));
+      expect(await queue.listFailed?.()).toEqual([]);
+      expect(await queue.listPending({ limit: "all" })).toMatchObject([
+        {
+          id: "released-stall",
+          attempts: 1,
+          lastError: expect.stringContaining("handler-timeout"),
+        },
+      ]);
       drain.dispose();
     });
   });

--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -393,25 +393,27 @@ export function createChannelIngressDrain<
       }
       const ageMs = now() - state.startedAt;
       const displayId = state.eventId.replace(/^0+(?=\d)/, "") || state.eventId;
-      const message = `Channel ingress claim→adoption stalled for event ${displayId} on lane ${state.laneKey} after ${ageMs}ms; marking failed (handler-timeout).`;
+      const message = `Channel ingress claim→adoption stalled for event ${displayId} on lane ${state.laneKey} after ${ageMs}ms; applying retry policy (handler-timeout).`;
+      const timeoutError = new Error(message);
       // Closed guillotine flag — catch must not string-sniff errors.
       state.guillotined = true;
       clearStallTimer(state);
       log(message);
       try {
-        state.abortController.abort(new Error(message));
+        state.abortController.abort(timeoutError);
       } catch {
         // AbortController.abort is not fallible in practice.
       }
-      // Same bounded-retry/hold-ownership policy as tombstone: a fail write
-      // error must not falsely settle (would stop heartbeat and wedge recovery).
+      // Route the timeout through the same retry owner as dispatch failures.
+      // A release/fail write error must not falsely settle (would stop the
+      // heartbeat and wedge recovery).
       void state
         .settleOnce(async () => {
-          await failClaim(state.claim, "handler-timeout", message);
+          await applyFailureDisposition(state.claim, timeoutError);
         })
         .catch((err: unknown) => {
           log(
-            `ingress drain: failed to dead-letter stalled event ${displayId}; holding claim: ${formatError(err)}`,
+            `ingress drain: failed to settle stalled event ${displayId}; holding claim: ${formatError(err)}`,
           );
         });
     }, adoptionStallTimeoutMs);

--- a/src/channels/message/ingress-drain.watchdog.test.ts
+++ b/src/channels/message/ingress-drain.watchdog.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { createChannelIngressDrain } from "./ingress-drain.js";
+import type { ChannelIngressDispatchLifecycle } from "./ingress-drain-lifecycle.js";
+import { createChannelIngressDrain, isIngressAdoptionLostError } from "./ingress-drain.js";
 import {
   createTestIngressQueue,
   type IngressDrainTestPayload as Payload,
@@ -17,17 +18,19 @@ describe("channel ingress drain watchdog", () => {
     closeOpenClawStateDatabaseForTest();
   });
 
-  it("guillotines pre-adoption stalls with handler-timeout", async () => {
+  it("releases pre-adoption stalls for retry and fences late adoption", async () => {
     await withTempState(async (stateDir) => {
       let clock = 10_000;
       const queue = createTestIngressQueue(stateDir, { now: () => clock });
       await queue.enqueue("evt-stall", { text: "x" }, { laneKey: "l1" });
+      let stalledLifecycle: ChannelIngressDispatchLifecycle | undefined;
 
       const drain = createChannelIngressDrain<Payload>({
         queue,
         now: () => clock,
         adoptionStallTimeoutMs: 5_000,
-        dispatchClaimedEvent: async () => {
+        dispatchClaimedEvent: async (_event, lifecycle) => {
+          stalledLifecycle = lifecycle;
           // Never adopt, never return -- stall until watchdog.
           await new Promise(() => {});
         },
@@ -38,16 +41,24 @@ describe("channel ingress drain watchdog", () => {
       await vi.advanceTimersByTimeAsync(5_000);
       await drain.waitForIdle();
 
-      const reenqueue = await queue.enqueue("evt-stall", { text: "x" });
-      expect(reenqueue.kind).toBe("failed");
-      if (reenqueue.kind === "failed") {
-        expect(reenqueue.record.reason).toBe("handler-timeout");
-      }
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      expect(await queue.listPending({ limit: "all" })).toMatchObject([
+        {
+          id: "evt-stall",
+          attempts: 1,
+          lastError: expect.stringContaining("handler-timeout"),
+        },
+      ]);
+      const lateAdoption = stalledLifecycle?.onAdopted();
+      expect(lateAdoption).toBeDefined();
+      const lateAdoptError = await lateAdoption?.catch((error: unknown) => error);
+      expect(isIngressAdoptionLostError(lateAdoptError) && lateAdoptError.code).toBe("guillotined");
       drain.dispose();
     });
   });
 
-  it("guillotines deferred stalls", async () => {
+  it("releases deferred stalls for retry", async () => {
     await withTempState(async (stateDir) => {
       let clock = 30_000;
       const queue = createTestIngressQueue(stateDir, { now: () => clock });
@@ -70,11 +81,15 @@ describe("channel ingress drain watchdog", () => {
       await vi.advanceTimersByTimeAsync(5_000);
       await drain.waitForIdle();
 
-      const reenqueue = await queue.enqueue("evt-def-stall", { text: "x" });
-      expect(reenqueue.kind).toBe("failed");
-      if (reenqueue.kind === "failed") {
-        expect(reenqueue.record.reason).toBe("handler-timeout");
-      }
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.listFailed?.({ limit: "all" })).toEqual([]);
+      expect(await queue.listPending({ limit: "all" })).toMatchObject([
+        {
+          id: "evt-def-stall",
+          attempts: 1,
+          lastError: expect.stringContaining("handler-timeout"),
+        },
+      ]);
       drain.dispose();
     });
   });

--- a/src/plugins/contracts/boundary-invariants.test.ts
+++ b/src/plugins/contracts/boundary-invariants.test.ts
@@ -25,6 +25,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_FILES = [
   "extensions/memory-core/src/dreaming.ts",
   "extensions/memory-lancedb/index.ts",
   "extensions/onepassword/index.ts",
+  "extensions/qa-lab/index.ts",
   "extensions/workboard/index.ts",
 ] as const;
 const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
@@ -44,6 +45,7 @@ const BUNDLED_TYPED_HOOK_REGISTRATION_GUARDS = {
   "extensions/memory-core/index.ts": ["before_agent_reply", "before_prompt_build"],
   "extensions/memory-lancedb/index.ts": ["agent_end", "before_prompt_build", "session_end"],
   "extensions/onepassword/index.ts": ["before_tool_call", "tool_result_persist"],
+  "extensions/qa-lab/index.ts": ["before_dispatch"],
   "extensions/workboard/index.ts": ["agent_end", "gateway_start", "gateway_stop", "subagent_ended"],
 } as const satisfies Record<
   (typeof BUNDLED_TYPED_HOOK_REGISTRATION_FILES)[number],


### PR DESCRIPTION
Related: #126231

## What Problem This Solves

Channel events that exceeded the claim-to-adoption watchdog were terminally failed with zero recorded attempts. The initial retry repair also exposed two upper-layer dedupe paths that could accept the requeued Telegram row as completed without producing its reply.

## Why This Change Was Made

- Route `handler-timeout` through the shared ingress failure disposition, preserving the existing guillotine and claim-token fence.
- Release process-local inbound dedupe when durable ingress aborts before adoption, leaving retry ownership with the canonical spool row.
- Track durable adoption explicitly so a later reply-operation abort retains dedupe and cannot admit a duplicate provider delivery.
- Keep an aborted Telegram spooled replay retryable when dispatch returns after the owner timeout.
- Re-check the durable abort signal after single-message media hydration so an abort-ignoring fetch cannot enter reply dispatch late.
- Fence Telegram before it enters the reply pipeline when media hydration outlives the durable owner abort.
- Update Telegram and Zalo expectations to assert retry semantics and same-lane replay ordering.
- Add a QA scenario that exercises the real Telegram plugin and HTTP transport through an ephemeral Gateway and Crabline provider server.

## User Impact

Timed-out channel messages retry instead of being silently discarded. A later message on the same lane remains behind the retry, and a late first attempt cannot adopt or create a duplicate reply.

## Evidence

### Exact-head transport proof

Head: `e3889b7e932067e67528348e83f7f81d09e03803`

The QA-only plugin stalled the first Telegram turn before dispatch for 2200 ms while the ingress watchdog was set to 2000 ms. The real Telegram plugin then crossed its HTTP transport boundary through Crabline. The same ephemeral Gateway observed one timeout, one retry disposition, and exactly two ordered outbound `sendMessage` calls:

```text
first update -> handler-timeout -> retry -> FIRST reply -> SECOND reply
```

```json
{
  "headSha": "e3889b7e932067e67528348e83f7f81d09e03803",
  "transport": "crabline:telegram",
  "gateway": "ephemeral",
  "eventOrder": [
    "first:handler-timeout",
    "first:retry:outbound",
    "second:outbound"
  ],
  "outboundOrder": [
    "TELEGRAM-HANDLER-TIMEOUT-FIRST-OK",
    "TELEGRAM-HANDLER-TIMEOUT-SECOND-OK"
  ],
  "outboundCount": 2,
  "timeoutCount": 1,
  "retryDispositionCount": 1,
  "queueOutcome": "retry completed before same-lane successor",
  "pass": true
}
```

Command:

```bash
OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS=2000 \
OPENCLAW_QA_PRE_DISPATCH_STALL_ONCE_MS=2200 \
OPENCLAW_QA_PRE_DISPATCH_STALL_MARKER=TELEGRAM-HANDLER-TIMEOUT-FIRST-OK \
OPENCLAW_QA_HEAD_SHA=e3889b7e932067e67528348e83f7f81d09e03803 \
pnpm openclaw qa suite \
  --channel-driver crabline \
  --channel telegram \
  --provider-mode mock-openai \
  --scenario telegram-handler-timeout-retry \
  --concurrency 1
```

Artifact SHA-256:

- `handler-timeout-verdict.json`: `9eed24052f373a27b9851d451e2a38f29fe34ccf84e5cbd82deb6f12114520cf`
- `qa-evidence.json`: `ab639af8e28fd903eaff7001d0ea13adb4c4b25f25f4ae3ba2c8af3eabbff660`

No live Telegram account or external credentials were used; Crabline supplied the local Telegram provider API while the actual OpenClaw Telegram adapter, durable queue, Gateway, and outbound HTTP client ran normally.

### Verification

- 661 focused regressions passed across core ingress, reply dedupe, Telegram polling/webhook/message/coalescing, the pre-dispatch abort fence, and Zalo ingress.
- 79 QA coverage and scenario catalog checks passed.
- `pnpm check:test-types`, `pnpm lint`, formatting, and `git diff --check` passed after rebasing onto current `main`.
- TruffleHog: clean.
- Repository `$autoreview`: no findings; patch correct, confidence 0.98.
- Direct upstream Codex source inspection confirmed the timeout remains pre-turn: Codex only emits `TurnStarted` after a turn exists and aborts only active tasks, so the ingress fence prevents a duplicate Codex turn from being created.

Risk: the shared timeout disposition and pre-adoption dedupe release affect durable ingress consumers; the transport proof covers the Telegram boundary and the focused matrix covers the shared owner. Rollback is a two-commit revert.

AI-assisted: yes (implementation, tests, behavior proof, and review), with all reported evidence rerun on the submitted commit.
