### PR TITLE
[ENG-6173] Expire inactive thread sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Session maintenance:** expire inactive thread-scoped session entries after a configurable 30-day default while preserving active, pinned, archived, model-locked, and unresolved work, preventing protected thread growth from crowding automation sessions out of bounded stores.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.

--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -221,6 +221,10 @@ openclaw sessions cleanup --json
   compaction checkpoints, and trajectory sidecars older than
   `session.maintenance.pruneAfter`; artifacts still referenced by SQLite
   session rows are preserved.
+- Thread-scoped session rows use the independent
+  `session.maintenance.threadRetention` inactivity window (default `30d`). Set
+  it to `false` to keep inactive threads indefinitely. Retained threads remain
+  protected from `maxEntries` eviction.
 - Cleanup reports short-lived Gateway model-run probe cleanup separately as
   `modelRunPruned`. This only matches strict explicit keys shaped like
   `agent:*:explicit:model-run-<uuid>`. Retention is a fixed `24h` and is
@@ -242,7 +246,7 @@ Flags:
 | `--enforce`          | Apply maintenance even when `session.maintenance.mode` is `warn`.                                                                                                                                                                                                                                          |
 | `--fix-missing`      | Remove legacy entries whose archived transcript artifacts are missing or header-only/empty, even if they would not normally age/count out yet.                                                                                                                                                             |
 | `--fix-dm-scope`     | When `session.dmScope` is `main`, retire stale peer-keyed direct-DM rows left behind by earlier `per-peer`, `per-channel-peer`, or `per-account-channel-peer` routing. Use `--dry-run` first; applying removes those rows from SQLite and preserves their legacy transcript artifacts as deleted archives. |
-| `--active-key <key>` | Protect a specific active key from automatic maintenance. It still counts toward `maxEntries`. Durable external conversation pointers, such as group sessions and thread-scoped chat sessions, are also kept by age/count/disk-budget maintenance.                                                         |
+| `--active-key <key>` | Protect a specific active key from automatic maintenance. It still counts toward `maxEntries`. Group/channel pointers and thread sessions still inside `threadRetention` are also protected from count eviction.                                                                                           |
 | `--agent <id>`       | Run cleanup for one configured agent store.                                                                                                                                                                                                                                                                |
 | `--all-agents`       | Run cleanup for all configured agent stores.                                                                                                                                                                                                                                                               |
 | `--store <path>`     | Run against a specific legacy store selector path.                                                                                                                                                                                                                                                         |

--- a/docs/concepts/session.md
+++ b/docs/concepts/session.md
@@ -217,6 +217,7 @@ shown:
     maintenance: {
       mode: "enforce", // "enforce" applies cleanup; "warn" only reports
       pruneAfter: "30d",
+      threadRetention: "30d", // false keeps inactive threads indefinitely
       archiveDashboardAfter: "7d", // false or 0 disables
       maxEntries: 500,
       preserveRecent: "7d", // optional; false or omitted disables
@@ -232,8 +233,8 @@ startup and isolated cron sessions do not pay for a full store cleanup.
 `openclaw sessions cleanup --enforce` applies the cap immediately.
 
 `maxEntries` counts every live session row. Archived or pinned sessions, active
-or admitted work, model-locked sessions, and durable external conversation
-pointers are protected from automatic eviction, but still consume the cap.
+or admitted work, model-locked sessions, group/channel pointers, and retained
+thread pointers are protected from count eviction, but still consume the cap.
 Cleanup removes the oldest unprotected rows until it reaches `maxEntries` or
 runs out of eligible victims. The total can therefore remain above the cap when
 protected rows alone exceed it or active work temporarily blocks eviction.
@@ -247,9 +248,13 @@ maintenance/cap pressure is reached, and runs before the broader stale-entry
 age cutoff and entry cap. Normal direct, group, thread, cron, hook, heartbeat,
 ACP, and sub-agent sessions do not inherit this 24h retention.
 
-Maintenance preserves durable external conversation pointers, including group
-sessions and thread-scoped chat sessions, while still allowing synthetic cron,
-hook, heartbeat, ACP, and sub-agent entries to age out.
+Maintenance preserves group/channel conversation pointers. Thread-scoped chat
+sessions remain count-protected while retained, then age out after 30 days of
+inactivity by default through the independent `threadRetention` setting. Set it
+to `false` to retain inactive threads indefinitely. Pinned, archived,
+model-locked, admitted, and unresolved-work threads remain protected. Synthetic
+cron, hook, heartbeat, ACP, and sub-agent entries continue to follow their
+normal cleanup policies.
 
 Shared or high-volume installations can set `preserveRecent` to protect
 recently active interactive sessions and every SQLite history generation owned

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1221,6 +1221,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
     maintenance: {
       mode: "enforce", // enforce (default) | warn
       pruneAfter: "30d",
+      threadRetention: "30d", // false keeps inactive threads indefinitely
       archiveDashboardAfter: "7d", // false or 0 disables
       maxEntries: 500,
       preserveRecent: "7d", // optional duration or false
@@ -1269,8 +1270,9 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
 - **`maintenance`**: session-store cleanup + retention controls.
   - `mode`: `enforce` applies cleanup and is the default; `warn` emits warnings only.
   - `pruneAfter`: age cutoff for stale entries (default `30d`).
+  - `threadRetention`: inactivity cutoff for thread-scoped sessions (default `30d`), independent of `pruneAfter`; `false` disables thread aging. Recent threads remain protected from count eviction, and pinned, archived, model-locked, admitted, or unresolved-work threads are retained.
   - `archiveDashboardAfter`: inactivity cutoff for archiving visible dashboard sessions (default `7d`); `false` or `0` disables automatic archiving.
-  - `maxEntries`: maximum total number of live SQLite session entries (default `500`). Every row counts toward the cap, but archived or pinned sessions, active or admitted work, model-locked sessions, and durable external conversation pointers are never automatic eviction targets. Cleanup removes the oldest unprotected rows; if protection prevents reaching the cap, the store remains above it. Runtime writes batch cleanup with a small high-water buffer for production-sized caps; `openclaw sessions cleanup --enforce` applies the cap immediately but does not unprotect rows. Unarchive, unpin, wait for active work to finish, or explicitly delete protected sessions to reduce the total.
+  - `maxEntries`: maximum total number of live SQLite session entries (default `500`). Every row counts toward the cap, but archived or pinned sessions, active or admitted work, model-locked sessions, group/channel pointers, and retained thread pointers are not count-eviction targets. Inactive thread pointers age out through `threadRetention`. Cleanup removes the oldest unprotected rows; if protection prevents reaching the cap, the store remains above it. Runtime writes batch cleanup with a small high-water buffer for production-sized caps; `openclaw sessions cleanup --enforce` applies the cap immediately but does not unprotect rows. Unarchive, unpin, wait for active work to finish, or explicitly delete protected sessions to reduce the total.
   - `preserveRecent`: optional inactivity window that protects recently active interactive sessions and all of their SQLite history generations from automatic age, count, and disk-budget history eviction (for example `"7d"`). Unset or `false` disables this protection. Synthetic model-run, cron, hook, heartbeat, ACP, and sub-agent sessions remain eligible for bounded cleanup. Protection can temporarily keep the store above configured entry or disk targets and does not archive sessions.
   - Short-lived gateway model-run probe sessions use fixed `24h` retention, but cleanup is pressure-gated: it only removes stale strict model-run probe rows when session-entry maintenance/cap pressure is reached. Only strict explicit probe keys matching `agent:*:explicit:model-run-<uuid>` are eligible; normal direct, group, thread, cron, hook, heartbeat, ACP, and sub-agent sessions do not inherit this 24h retention. When model-run cleanup runs, it runs before the broader `pruneAfter` stale-entry cleanup and `maxEntries` cap.
   - Legacy `rotateBytes` is rejected by the current schema; `openclaw doctor --fix` removes it from older configs.

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -143,6 +143,7 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
     maintenance: {
       mode: "warn",
       pruneAfter: "30d",
+      threadRetention: "30d", // false keeps inactive threads indefinitely
       maxEntries: 500,
       resetArchiveRetention: "30d", // duration or false
       maxDiskBytes: "500mb", // optional

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -48,6 +48,7 @@ Per agent, on the Gateway host (resolved via `src/config/sessions.ts`):
 | ----------------------- | --------------------- | ------------------------------------------------------------------------------------------- |
 | `mode`                  | `"enforce"`           | or `"warn"` (report only, no mutation)                                                      |
 | `pruneAfter`            | `"30d"`               | stale-entry age cutoff                                                                      |
+| `threadRetention`       | `"30d"`               | thread inactivity cutoff, independent of `pruneAfter`; `false` disables                     |
 | `archiveDashboardAfter` | `"7d"`                | inactivity cutoff for dashboard sessions; `false` or `0` disables                           |
 | `maxEntries`            | `500`                 | cap on total live session rows when protection permits                                      |
 | `resetArchiveRetention` | keep (no age cutoff)  | age cutoff for `*.reset.*`/`*.deleted.*` transcript archives; a duration opts into deletion |
@@ -71,7 +72,7 @@ openclaw sessions cleanup --dry-run
 openclaw sessions cleanup --enforce
 ```
 
-`maxEntries` counts every live session row. Archived or pinned sessions, active or admitted work, model-locked sessions, and durable external conversation pointers such as group sessions and thread-scoped chat sessions are never automatic eviction targets, but they still consume the cap. Cleanup removes the oldest unprotected rows until the total reaches `maxEntries` or no eligible victims remain. The store can therefore remain above the cap when protected rows alone exceed it or active work temporarily blocks eviction. Synthetic runtime entries (cron, hooks, heartbeat, ACP, sub-agents) can still be removed once they exceed the configured age, count, or disk budget. Isolated cron runs use a separate `cron.sessionRetention` control, independent of model-run probe retention.
+`maxEntries` counts every live session row. Archived or pinned sessions, active or admitted work, model-locked sessions, group/channel pointers, and retained thread pointers are not count-eviction targets, but they still consume the cap. Inactive thread pointers age out through `threadRetention` (default `30d`; `false` disables) independently of `pruneAfter`. Cleanup removes the oldest unprotected rows until the total reaches `maxEntries` or no eligible victims remain. The store can therefore remain above the cap when protected rows alone exceed it or active work temporarily blocks eviction. Synthetic runtime entries (cron, hooks, heartbeat, ACP, sub-agents) can still be removed once they exceed the configured age, count, or disk budget. Isolated cron runs use a separate `cron.sessionRetention` control, independent of model-run probe retention.
 
 `--dry-run` previews the total-row cap and identifies the unprotected rows that would satisfy it; `--enforce` applies that cleanup immediately but does not remove protection. To reduce protected history, unarchive, unpin, wait for active work to finish, or explicitly delete sessions you no longer want to retain.
 

--- a/src/config/schema.help.automation.ts
+++ b/src/config/schema.help.automation.ts
@@ -78,6 +78,8 @@ export const AUTOMATION_FIELD_HELP: Record<string, string> = {
     'Determines whether maintenance policies are only reported ("warn") or actively applied ("enforce"). Keep "warn" during rollout and switch to "enforce" after validating safe thresholds.',
   "session.maintenance.pruneAfter":
     "Removes entries older than this duration (for example `30d` or `12h`) during maintenance passes. Use this as the primary age-retention control and align it with data retention policy.",
+  "session.maintenance.threadRetention":
+    "Removes thread-scoped sessions after this period without activity (for example `30d`), independently of general session pruning. Active work, pinned sessions, and archived sessions remain protected. Defaults to `30d`; set `false` to keep inactive threads indefinitely.",
   "session.maintenance.archiveDashboardAfter":
     "Archives inactive dashboard sessions after this duration (for example `7d`) so they remain available without crowding the active session list. Set `false` or `0` to disable automatic dashboard archiving.",
   "session.maintenance.maxEntries":

--- a/src/config/schema.help.quality.test-fixtures.ts
+++ b/src/config/schema.help.quality.test-fixtures.ts
@@ -112,6 +112,7 @@ export const TARGET_KEYS = [
   "session.maintenance",
   "session.maintenance.mode",
   "session.maintenance.pruneAfter",
+  "session.maintenance.threadRetention",
   "session.maintenance.archiveDashboardAfter",
   "session.maintenance.maxEntries",
   "session.maintenance.preserveRecent",

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -244,6 +244,7 @@ describe("config help copy quality", () => {
       name: "documents session maintenance duration/size examples and deprecations",
       fields: [
         ["session.maintenance.pruneAfter", ["30d", "12h"]],
+        ["session.maintenance.threadRetention", ["30d", /false/i, /inactiv/i, /independent/i]],
         ["session.maintenance.archiveDashboardAfter", ["7d", /false/i, "0"]],
         ["session.maintenance.preserveRecent", ["7d", /false/i]],
         ["session.maintenance.resetArchiveRetention", [".reset.", /false/i]],

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -761,6 +761,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "session.maintenance": "Session Maintenance",
   "session.maintenance.mode": "Session Maintenance Mode",
   "session.maintenance.pruneAfter": "Session Prune After",
+  "session.maintenance.threadRetention": "Inactive Thread Retention",
   "session.maintenance.archiveDashboardAfter": "Archive Inactive Dashboard Sessions After",
   "session.maintenance.maxEntries": "Session Max Entries",
   "session.maintenance.preserveRecent": "Preserve Recent Sessions",

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -32,6 +32,7 @@ import {
   archiveStaleDashboardEntries,
   capEntryCount,
   pruneStaleModelRunEntries,
+  pruneStaleThreadEntries,
   pruneStaleEntries,
   shouldPreserveMaintenanceEntry,
   shouldRunModelRunPrune,
@@ -434,7 +435,7 @@ async function previewStoreCleanup(params: {
       preserveKeys: preserveSessionKeys,
     },
   );
-  const pruned = pruneStaleEntries(previewStore, params.maintenance.pruneAfterMs, {
+  const threadPruned = pruneStaleThreadEntries(previewStore, params.maintenance.threadRetentionMs, {
     log: false,
     preserveKeys: preserveSessionKeys,
     preserveRecentMs: params.maintenance.preserveRecentMs,
@@ -442,6 +443,15 @@ async function previewStoreCleanup(params: {
       staleKeys.add(key);
     },
   });
+  const stalePruned = pruneStaleEntries(previewStore, params.maintenance.pruneAfterMs, {
+    log: false,
+    preserveKeys: preserveSessionKeys,
+    preserveRecentMs: params.maintenance.preserveRecentMs,
+    onPruned: ({ key }) => {
+      staleKeys.add(key);
+    },
+  });
+  const pruned = threadPruned + stalePruned;
   const capped = capEntryCount(previewStore, params.maintenance.maxEntries, {
     log: false,
     preserveKeys: preserveSessionKeys,

--- a/src/config/sessions/incognito-session-transcript.test.ts
+++ b/src/config/sessions/incognito-session-transcript.test.ts
@@ -151,6 +151,7 @@ describe("incognito transcript access", () => {
           modelRunPruneAfterMs: 24 * 60 * 60 * 1000,
           pruneAfterMs: 365 * 24 * 60 * 60 * 1000,
           resetArchiveRetentionMs: null,
+          threadRetentionMs: null,
         },
       });
 

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -1656,6 +1656,84 @@ describe("sqlite session normalization", () => {
     ).toEqual(["agent:main:newer", "agent:main:newest"]);
   });
 
+  it("prunes inactive SQLite thread sessions below the entry cap on a write", async () => {
+    vi.mocked(getRuntimeConfig).mockReturnValue({
+      session: {
+        maintenance: {
+          mode: "enforce",
+          pruneAfter: "365d",
+          threadRetention: "30d",
+          maxEntries: 500,
+          maxDiskBytes: false,
+        },
+      },
+    });
+    const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
+    const scopeFor = (sessionKey: string) => ({
+      agentId: "main",
+      env,
+      sessionKey,
+      storePath: paths.sqlitePath,
+    });
+    const staleKey = "agent:main:slack:channel:C1:thread:stale";
+    const freshKey = "agent:main:slack:channel:C1:thread:fresh";
+    const staleSessionId = "stale-thread-session";
+    const staleUpdatedAt = Date.now() - 31 * 24 * 60 * 60 * 1000;
+    const staleTranscriptEvent = {
+      id: "stale-thread-event",
+      timestamp: new Date(staleUpdatedAt).toISOString(),
+      type: "metadata",
+    };
+
+    await patchSessionEntryCore(
+      scopeFor(staleKey),
+      () => ({ sessionId: staleSessionId, updatedAt: staleUpdatedAt }),
+      {
+        fallbackEntry: { sessionId: staleSessionId, updatedAt: staleUpdatedAt },
+        replaceEntry: true,
+        skipMaintenance: true,
+      },
+    );
+    await appendTranscriptEvent(
+      { ...scopeFor(staleKey), sessionId: staleSessionId },
+      staleTranscriptEvent,
+    );
+    await patchSessionEntryCore(
+      scopeFor(freshKey),
+      () => ({ sessionId: "fresh-thread-session", updatedAt: Date.now() }),
+      {
+        fallbackEntry: { sessionId: "fresh-thread-session", updatedAt: Date.now() },
+        replaceEntry: true,
+        skipMaintenance: true,
+      },
+    );
+
+    await patchSessionEntryCore(
+      scopeFor("agent:main:explicit:maintenance-trigger"),
+      () => ({ sessionId: "maintenance-trigger", updatedAt: Date.now() }),
+      {
+        fallbackEntry: { sessionId: "maintenance-trigger", updatedAt: Date.now() },
+        replaceEntry: true,
+      },
+    );
+
+    expect(loadSessionEntry(scopeFor(staleKey))).toBeUndefined();
+    expect(loadSessionEntry(scopeFor(freshKey))).toBeDefined();
+    await expect(
+      loadTranscriptEvents({
+        agentId: "main",
+        env,
+        sessionId: staleSessionId,
+        storePath: paths.sqlitePath,
+      }),
+    ).resolves.toEqual([]);
+    expect(
+      fs
+        .readdirSync(paths.tempDir)
+        .some((file) => file.startsWith(`${staleSessionId}.jsonl.deleted.`)),
+    ).toBe(true);
+  });
+
   it("persists automatic dashboard archiving before stale-entry pruning", async () => {
     vi.mocked(getRuntimeConfig).mockReturnValue({
       session: {

--- a/src/config/sessions/session-accessor.sqlite-maintenance.ts
+++ b/src/config/sessions/session-accessor.sqlite-maintenance.ts
@@ -44,6 +44,7 @@ import {
   archiveStaleDashboardEntries,
   capEntryCount,
   pruneStaleModelRunEntries,
+  pruneStaleThreadEntries,
   pruneStaleEntries,
   normalizeResolvedMaintenanceConfigInput,
   shouldPreserveMaintenanceEntry,
@@ -163,6 +164,18 @@ export function applySessionEntryMaintenance(
         preserveRecentMs: maintenance.preserveRecentMs ?? null,
       }),
   );
+  const hasStaleThreadCandidate =
+    maintenance.threadRetentionMs != null &&
+    hasStaleSqliteSessionEntryCandidate(
+      database,
+      maintenance.threadRetentionMs,
+      (key, entry) =>
+        pruneStaleThreadEntries({ [key]: entry }, maintenance.threadRetentionMs, {
+          log: false,
+          preserveKeys: preserveCandidateKeys,
+          preserveRecentMs: maintenance.preserveRecentMs,
+        }) > 0,
+    );
   const hasStaleDashboardCandidate =
     maintenance.archiveDashboardAfterMs != null &&
     hasStaleSqliteSessionEntryCandidate(
@@ -178,6 +191,7 @@ export function applySessionEntryMaintenance(
     params.forceMaintenance === true ||
     entryCount > maintenance.maxEntries ||
     hasStaleDashboardCandidate ||
+    hasStaleThreadCandidate ||
     hasStaleCandidate ||
     shouldRunModelRunPrune({
       maintenance,
@@ -242,18 +256,29 @@ export function applySessionEntryMaintenance(
     preserveKeys,
   });
   let pruned = 0;
-  if (
-    params.forceMaintenance === true ||
-    hasStaleCandidate ||
-    remainingEntryCount > maintenance.maxEntries
-  ) {
-    pruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
+  if (hasStaleThreadCandidate || params.forceMaintenance === true) {
+    const threadPruned = pruneStaleThreadEntries(store, maintenance.threadRetentionMs, {
       log: false,
       onPruned: rememberRemovedEntry,
       preserveKeys,
       preserveRecentMs: maintenance.preserveRecentMs,
     });
-    remainingEntryCount -= pruned;
+    pruned += threadPruned;
+    remainingEntryCount -= threadPruned;
+  }
+  if (
+    params.forceMaintenance === true ||
+    hasStaleCandidate ||
+    remainingEntryCount > maintenance.maxEntries
+  ) {
+    const stalePruned = pruneStaleEntries(store, maintenance.pruneAfterMs, {
+      log: false,
+      onPruned: rememberRemovedEntry,
+      preserveKeys,
+      preserveRecentMs: maintenance.preserveRecentMs,
+    });
+    pruned += stalePruned;
+    remainingEntryCount -= stalePruned;
   }
   let capped = 0;
   if (

--- a/src/config/sessions/store-maintenance-operations.ts
+++ b/src/config/sessions/store-maintenance-operations.ts
@@ -8,6 +8,7 @@ import {
   capEntryCount,
   getActiveSessionMaintenanceWarning,
   pruneStaleModelRunEntries,
+  pruneStaleThreadEntries,
   pruneStaleEntries,
   shouldRunModelRunPrune,
   shouldRunSessionEntryMaintenance,
@@ -231,13 +232,25 @@ async function applyEnforcedMaintenance(params: {
     params.maintenance.archiveDashboardAfterMs,
     { preserveKeys: params.preserveSessionKeys },
   );
-  const pruned = pruneStaleEntries(params.operation.store, params.maintenance.pruneAfterMs, {
+  const threadPruned = pruneStaleThreadEntries(
+    params.operation.store,
+    params.maintenance.threadRetentionMs,
+    {
+      onPruned: ({ entry }) => {
+        rememberRemovedSessionFile(removedSessionFiles, entry);
+      },
+      preserveKeys: params.preserveSessionKeys,
+      preserveRecentMs: params.maintenance.preserveRecentMs,
+    },
+  );
+  const stalePruned = pruneStaleEntries(params.operation.store, params.maintenance.pruneAfterMs, {
     onPruned: ({ entry }) => {
       rememberRemovedSessionFile(removedSessionFiles, entry);
     },
     preserveKeys: params.preserveSessionKeys,
     preserveRecentMs: params.maintenance.preserveRecentMs,
   });
+  const pruned = threadPruned + stalePruned;
   const countAfterPrune = Object.keys(params.operation.store).length;
   const shouldRunCapMaintenance =
     params.forceMaintenance ||

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -20,6 +20,7 @@ import type { SessionEntry } from "./types.js";
 const log = createSubsystemLogger("sessions/store");
 
 const DEFAULT_SESSION_PRUNE_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+const DEFAULT_THREAD_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const DEFAULT_DASHBOARD_ARCHIVE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_MODEL_RUN_PRUNE_AFTER_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_SESSION_MAX_ENTRIES = 500;
@@ -45,6 +46,7 @@ export type SessionMaintenanceWarning = {
 export type ResolvedSessionMaintenanceConfig = {
   mode: SessionMaintenanceMode;
   pruneAfterMs: number;
+  threadRetentionMs: number | null;
   archiveDashboardAfterMs: number | null;
   maxEntries: number;
   modelRunPruneAfterMs: number;
@@ -56,10 +58,13 @@ export type ResolvedSessionMaintenanceConfig = {
 
 export type ResolvedSessionMaintenanceConfigInput = Omit<
   ResolvedSessionMaintenanceConfig,
-  "archiveDashboardAfterMs" | "modelRunPruneAfterMs"
+  "archiveDashboardAfterMs" | "modelRunPruneAfterMs" | "threadRetentionMs"
 > &
   Partial<
-    Pick<ResolvedSessionMaintenanceConfig, "archiveDashboardAfterMs" | "modelRunPruneAfterMs">
+    Pick<
+      ResolvedSessionMaintenanceConfig,
+      "archiveDashboardAfterMs" | "modelRunPruneAfterMs" | "threadRetentionMs"
+    >
   >;
 
 function resolvePruneAfterMs(maintenance?: SessionMaintenanceConfig): number {
@@ -89,6 +94,22 @@ function resolveArchiveDashboardAfterMs(maintenance?: SessionMaintenanceConfig):
     return parsed > 0 ? parsed : null;
   } catch {
     return DEFAULT_DASHBOARD_ARCHIVE_AFTER_MS;
+  }
+}
+
+function resolveThreadRetentionMs(maintenance?: SessionMaintenanceConfig): number | null {
+  const raw = maintenance?.threadRetention;
+  if (raw === false) {
+    return null;
+  }
+  const normalized = normalizeStringifiedOptionalString(raw);
+  if (!normalized) {
+    return DEFAULT_THREAD_RETENTION_MS;
+  }
+  try {
+    return parseDurationMs(normalized, { defaultUnit: "d" });
+  } catch {
+    return DEFAULT_THREAD_RETENTION_MS;
   }
 }
 
@@ -188,6 +209,7 @@ export function resolveMaintenanceConfigFromInput(
   return {
     mode: maintenance?.mode ?? DEFAULT_SESSION_MAINTENANCE_MODE,
     pruneAfterMs,
+    threadRetentionMs: resolveThreadRetentionMs(maintenance),
     archiveDashboardAfterMs: resolveArchiveDashboardAfterMs(maintenance),
     maxEntries: maintenance?.maxEntries ?? DEFAULT_SESSION_MAX_ENTRIES,
     modelRunPruneAfterMs: DEFAULT_MODEL_RUN_PRUNE_AFTER_MS,
@@ -207,6 +229,10 @@ export function normalizeResolvedMaintenanceConfigInput(
       maintenance.archiveDashboardAfterMs === undefined
         ? DEFAULT_DASHBOARD_ARCHIVE_AFTER_MS
         : maintenance.archiveDashboardAfterMs,
+    threadRetentionMs:
+      maintenance.threadRetentionMs === undefined
+        ? DEFAULT_THREAD_RETENTION_MS
+        : maintenance.threadRetentionMs,
     modelRunPruneAfterMs: maintenance.modelRunPruneAfterMs ?? DEFAULT_MODEL_RUN_PRUNE_AFTER_MS,
     preserveRecentMs: maintenance.preserveRecentMs ?? null,
   };
@@ -425,6 +451,86 @@ function getSessionMaintenanceActivityAt(entry: SessionEntry | undefined): numbe
   );
 }
 
+function isThreadSessionMaintenanceEntry(
+  sessionKey: string,
+  entry: SessionEntry | undefined,
+): boolean {
+  if (parseSessionThreadInfoFast(sessionKey).threadId || isTelegramTopicSessionKey(sessionKey)) {
+    return true;
+  }
+  if (sessionDeliveryOrigin(entry)?.threadId != null) {
+    return true;
+  }
+  const chatType = normalizeLowercaseStringOrEmpty(
+    entry?.chatType ?? sessionDeliveryOrigin(entry)?.chatType,
+  );
+  return chatType === "thread";
+}
+
+function hasUnresolvedSessionMaintenanceWork(entry: SessionEntry | undefined): boolean {
+  return (
+    entry?.initializationPending === true ||
+    entry?.pendingFinalDelivery !== undefined ||
+    entry?.pendingDeliveryNotice !== undefined ||
+    (entry?.pendingTranscriptRepair?.length ?? 0) > 0 ||
+    (entry?.restartRecoveryRuns?.length ?? 0) > 0 ||
+    entry?.restartRecoveryBeforeAgentReplyState === "admitted" ||
+    entry?.restartRecoveryBeforeAgentReplyState === "pending" ||
+    entry?.restartRecoveryBeforeAgentReplyState === "continue" ||
+    entry?.restartRecoveryDeliveryReceiptState === "terminal-pending"
+  );
+}
+
+/** Remove inactive thread-scoped sessions while preserving explicit user/runtime ownership. */
+export function pruneStaleThreadEntries(
+  store: Record<string, SessionEntry>,
+  retentionMs: number | null,
+  opts: {
+    log?: boolean;
+    nowMs?: number;
+    onPruned?: (params: { key: string; entry: SessionEntry }) => void;
+    preserveKeys?: ReadonlySet<string>;
+    preserveRecentMs?: number | null;
+  } = {},
+): number {
+  if (retentionMs == null) {
+    return 0;
+  }
+  const now = opts.nowMs ?? Date.now();
+  const cutoffMs = now - retentionMs;
+  let pruned = 0;
+  for (const [key, entry] of Object.entries(store)) {
+    if (
+      isSyntheticSessionMaintenanceKey(key) ||
+      !isThreadSessionMaintenanceEntry(key, entry) ||
+      entry.archivedAt !== undefined ||
+      entry.pinnedAt !== undefined ||
+      entry.modelSelectionLocked === true ||
+      hasUnresolvedSessionMaintenanceWork(entry) ||
+      opts.preserveKeys?.has(key) === true ||
+      isRecentSessionMaintenanceEntry({
+        key,
+        entry,
+        preserveRecentMs: opts.preserveRecentMs,
+        nowMs: now,
+      })
+    ) {
+      continue;
+    }
+    const activityAt = getSessionMaintenanceActivityAt(entry);
+    if (activityAt <= 0 || activityAt >= cutoffMs) {
+      continue;
+    }
+    opts.onPruned?.({ key, entry });
+    delete store[key];
+    pruned += 1;
+  }
+  if (pruned > 0 && opts.log !== false) {
+    log.info("pruned inactive thread session entries", { pruned, retentionMs });
+  }
+  return pruned;
+}
+
 /** Archive inactive dashboard sessions while retaining runtime-owned or explicitly active keys. */
 export function archiveStaleDashboardEntries(
   store: Record<string, SessionEntry>,
@@ -530,10 +636,7 @@ function isProtectedSessionMaintenanceEntry(
   if (isPrimarySessionMaintenanceKey(sessionKey)) {
     return true;
   }
-  if (parseSessionThreadInfoFast(sessionKey).threadId) {
-    return true;
-  }
-  if (isTelegramTopicSessionKey(sessionKey)) {
+  if (isThreadSessionMaintenanceEntry(sessionKey, entry)) {
     return true;
   }
   if (isExternalGroupOrChannelSessionKey(sessionKey)) {
@@ -561,6 +664,7 @@ export function shouldPreserveMaintenanceEntry(params: {
   // configured retention limits while the lock remains.
   return (
     params.entry?.modelSelectionLocked === true ||
+    hasUnresolvedSessionMaintenanceWork(params.entry) ||
     params.preserveKeys?.has(params.key) === true ||
     isRecentSessionMaintenanceEntry(params) ||
     isProtectedSessionMaintenanceEntry(params.key, params.entry)

--- a/src/config/sessions/store.thread-retention.test.ts
+++ b/src/config/sessions/store.thread-retention.test.ts
@@ -1,0 +1,147 @@
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
+import { applyFileBackedSessionStoreMaintenance } from "./store-maintenance-operations.js";
+import { pruneStaleThreadEntries, resolveMaintenanceConfigFromInput } from "./store-maintenance.js";
+import type { SessionEntry } from "./types.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeEntry(updatedAt: number): SessionEntry {
+  return { sessionId: crypto.randomUUID(), updatedAt };
+}
+
+function makeStore(entries: Array<[string, SessionEntry]>): Record<string, SessionEntry> {
+  return Object.fromEntries(entries);
+}
+
+describe("thread session retention", () => {
+  it("prunes inactive threads across canonical, topic, and metadata shapes", () => {
+    const now = Date.now();
+    const staleAt = now - 31 * DAY_MS;
+    const recentAt = now - DAY_MS;
+    const store = makeStore([
+      ["agent:main:slack:channel:C1:thread:1", makeEntry(staleAt)],
+      ["agent:main:telegram:group:-100123:topic:77", makeEntry(staleAt)],
+      [
+        "agent:main:opaque-thread",
+        {
+          ...makeEntry(staleAt),
+          delivery: normalizeSessionDeliveryState({
+            context: { channel: "slack", to: "C1", threadId: "reply-1" },
+            origin: { provider: "slack", threadId: "reply-1" },
+          }),
+        },
+      ],
+      ["agent:main:slack:channel:C2:thread:2", makeEntry(recentAt)],
+      [
+        "agent:main:slack:channel:C3:thread:3",
+        { ...makeEntry(staleAt), lastInteractionAt: recentAt },
+      ],
+      ["agent:main:slack:channel:C4", makeEntry(staleAt)],
+    ]);
+
+    expect(pruneStaleThreadEntries(store, 30 * DAY_MS, { nowMs: now })).toBe(3);
+    expect(store).not.toHaveProperty("agent:main:slack:channel:C1:thread:1");
+    expect(store).not.toHaveProperty("agent:main:telegram:group:-100123:topic:77");
+    expect(store).not.toHaveProperty("agent:main:opaque-thread");
+    expect(store).toHaveProperty("agent:main:slack:channel:C2:thread:2");
+    expect(store).toHaveProperty("agent:main:slack:channel:C3:thread:3");
+    expect(store).toHaveProperty("agent:main:slack:channel:C4");
+  });
+
+  it("supports disabling thread retention", () => {
+    const now = Date.now();
+    const key = "agent:main:slack:channel:C1:thread:1";
+    const store = makeStore([[key, makeEntry(now - 365 * DAY_MS)]]);
+
+    expect(pruneStaleThreadEntries(store, null, { nowMs: now })).toBe(0);
+    expect(store).toHaveProperty(key);
+  });
+
+  it("preserves active, user-retained, and unresolved thread work", () => {
+    const now = Date.now();
+    const staleAt = now - 31 * DAY_MS;
+    const activeKey = "agent:main:slack:channel:C1:thread:active";
+    const pinnedKey = "agent:main:slack:channel:C1:thread:pinned";
+    const archivedKey = "agent:main:slack:channel:C1:thread:archived";
+    const lockedKey = "agent:main:slack:channel:C1:thread:locked";
+    const pendingKey = "agent:main:slack:channel:C1:thread:pending";
+    const recentKey = "agent:main:slack:channel:C1:thread:recent-policy";
+    const store = makeStore([
+      [activeKey, makeEntry(staleAt)],
+      [pinnedKey, { ...makeEntry(staleAt), pinnedAt: staleAt }],
+      [archivedKey, { ...makeEntry(staleAt), archivedAt: staleAt }],
+      [lockedKey, { ...makeEntry(staleAt), modelSelectionLocked: true }],
+      [pendingKey, { ...makeEntry(staleAt), initializationPending: true }],
+      [recentKey, makeEntry(now - 20 * DAY_MS)],
+    ]);
+
+    expect(
+      pruneStaleThreadEntries(store, 10 * DAY_MS, {
+        nowMs: now,
+        preserveKeys: new Set([activeKey]),
+        preserveRecentMs: 30 * DAY_MS,
+      }),
+    ).toBe(0);
+    expect(Object.keys(store)).toHaveLength(6);
+  });
+
+  it("bounds inactive thread growth before capping while preserving active automation", async () => {
+    const now = Date.now();
+    const cronKey = "agent:main:cron:job:run:current";
+    const heartbeatKey = "agent:main:heartbeat";
+    const recentThreadKey = "agent:main:slack:channel:C1:thread:recent";
+    const store = makeStore([
+      [cronKey, makeEntry(now)],
+      [heartbeatKey, makeEntry(now - 1)],
+      [recentThreadKey, makeEntry(now - DAY_MS)],
+      ...Array.from({ length: 40 }, (_, index): [string, SessionEntry] => [
+        `agent:main:slack:channel:C1:thread:stale-${index}`,
+        makeEntry(now - (31 + index) * DAY_MS),
+      ]),
+    ]);
+    let report: { pruned: number; capped: number } | undefined;
+
+    await applyFileBackedSessionStoreMaintenance({
+      storePath: "/tmp/openclaw-sessions/thread-retention.json",
+      store,
+      activeSessionKey: cronKey,
+      maintenanceConfig: {
+        mode: "enforce",
+        pruneAfterMs: 365 * DAY_MS,
+        threadRetentionMs: 30 * DAY_MS,
+        maxEntries: 4,
+        modelRunPruneAfterMs: DAY_MS,
+        resetArchiveRetentionMs: null,
+        maxDiskBytes: null,
+        highWaterBytes: null,
+      },
+      onMaintenanceApplied: (applied) => {
+        report = { pruned: applied.pruned, capped: applied.capped };
+      },
+      log: { warn: () => {}, info: () => {} },
+      artifacts: {
+        archiveRemovedSessionTranscripts: async () => new Set<string>(),
+        removeRemovedSessionTrajectoryArtifacts: async () => {},
+        cleanupArchivedSessionTranscripts: async () => {},
+      },
+    });
+
+    expect(report).toEqual({ pruned: 40, capped: 0 });
+    expect(Object.keys(store)).toHaveLength(3);
+    expect(store).toHaveProperty(cronKey);
+    expect(store).toHaveProperty(heartbeatKey);
+    expect(store).toHaveProperty(recentThreadKey);
+  });
+
+  it("defaults to 30d and allows custom or disabled retention", () => {
+    expect(resolveMaintenanceConfigFromInput().threadRetentionMs).toBe(30 * DAY_MS);
+    expect(resolveMaintenanceConfigFromInput({ threadRetention: "7d" }).threadRetentionMs).toBe(
+      7 * DAY_MS,
+    );
+    expect(
+      resolveMaintenanceConfigFromInput({ threadRetention: false }).threadRetentionMs,
+    ).toBeNull();
+  });
+});

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -252,6 +252,8 @@ export type SessionMaintenanceConfig = {
   mode?: SessionMaintenanceMode;
   /** Remove session entries older than this duration (e.g. "30d", "12h"). Default: "30d". */
   pruneAfter?: string | number;
+  /** Remove inactive thread-scoped sessions after this duration. Default: "30d"; false disables. */
+  threadRetention?: string | number | false;
   /** Archive inactive dashboard sessions after this duration. Default: "7d"; false or 0 disables. */
   archiveDashboardAfter?: string | number | false;
   /** Maximum total session entries to keep when protection permits. Default: 500. */

--- a/src/config/zod-schema.session-maintenance-extensions.test.ts
+++ b/src/config/zod-schema.session-maintenance-extensions.test.ts
@@ -19,6 +19,22 @@ describe("SessionSchema maintenance extensions", () => {
     expect(SessionSchema.safeParse({ maintenance: { preserveRecent: false } }).success).toBe(true);
   });
 
+  it.each(["30d", 86_400_000, false] as const)(
+    "accepts thread retention value %s",
+    (threadRetention) => {
+      expect(SessionSchema.safeParse({ maintenance: { threadRetention } }).success).toBe(true);
+    },
+  );
+
+  it.each([0, "0d", -1, "forever"] as const)(
+    "rejects invalid thread retention value %s",
+    (threadRetention) => {
+      const result = SessionSchema.safeParse({ maintenance: { threadRetention } });
+      expect(result.success).toBe(false);
+      expect(result.error?.issues[0]?.path).toContain("threadRetention");
+    },
+  );
+
   it.each([false, 0] as const)("accepts disabling dashboard archiving with %s", (value) => {
     expect(SessionSchema.safeParse({ maintenance: { archiveDashboardAfter: value } }).success).toBe(
       true,

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -86,6 +86,7 @@ export const SessionSchema = z
       .object({
         mode: z.enum(["enforce", "warn"]).optional(),
         pruneAfter: PositiveDurationSchema.optional(),
+        threadRetention: z.union([PositiveDurationSchema, z.literal(false)]).optional(),
         archiveDashboardAfter: z
           .union([PositiveDurationSchema, z.literal(false), z.literal(0)])
           .optional(),

--- a/src/infra/state-migrations.legacy-session-store.ts
+++ b/src/infra/state-migrations.legacy-session-store.ts
@@ -20,6 +20,7 @@ import {
   capEntryCount,
   pruneStaleEntries,
   pruneStaleModelRunEntries,
+  pruneStaleThreadEntries,
   shouldRunModelRunPrune,
   shouldRunSessionEntryMaintenance,
   type ResolvedSessionMaintenanceConfig,
@@ -286,6 +287,11 @@ export function loadLegacySessionStore(
           preserveRecentMs: maintenance.preserveRecentMs,
         });
       }
+      pruneStaleThreadEntries(sessionStore, maintenance.threadRetentionMs, {
+        log: false,
+        preserveKeys: preserveSessionKeys,
+        preserveRecentMs: maintenance.preserveRecentMs,
+      });
       if (Object.keys(sessionStore).length > maintenance.maxEntries) {
         pruneStaleEntries(sessionStore, maintenance.pruneAfterMs, {
           log: false,


### PR DESCRIPTION
## What Problem This Solves

Thread-scoped sessions are intentionally protected from the generic entry cap. That protection is necessary for active work but made inactive Slack thread entries immortal, so the protected set grew without bound and could eventually crowd out cron/heartbeat automation.

## Summary

- add configurable `session.maintenance.threadRetention` with a 30-day default and `false` opt-out
- prune stale thread-scoped sessions before general retention/capping while preserving active, pinned, archived, model-locked, recent, and unresolved work
- apply the policy consistently to file-backed and SQLite session stores, cleanup previews, and legacy loading
- document the setting and cleanup behavior

## Evidence

- focused Vitest suite: 7 files, 195 tests passed, including file-backed and SQLite retention paths
- `pnpm tsgo:core` passed
- `pnpm check`: preflight, typechecks, lint, formatting, and all policy guards except the unrelated temp-path guard passed; that guard aborts with Node `spawnSync git ENOBUFS` while reading repository-wide `git ls-files src extensions` output
- `git diff --check` passed
- release backport package built with the repository packaging script and its package-integrity checker passed

Linear: https://linear.app/vecflow/issue/ENG-6173/expire-inactive-slack-thread-session-entries-unbounded-protected