### PR TITLE
fix: log cron notification failures for removed agents

### DIFF
--- a/src/gateway/server-cron-notifications.delivery-failure.test.ts
+++ b/src/gateway/server-cron-notifications.delivery-failure.test.ts
@@ -113,4 +113,26 @@ describe("cron primary delivery failure notifications", () => {
       expect(sendFailureNotificationAnnounce).toHaveBeenCalledTimes(expected);
     },
   );
+
+  it("keeps configured failure destinations from inheriting the primary delivery thread", () => {
+    const job = createThreadedJob(true);
+    job.sessionKey = "agent:main:telegram:group:-1001234567890:thread:42";
+
+    dispatchGatewayCronFinishedNotifications({
+      evt: { jobId: job.id, action: "finished", status: "error", error: "boom" },
+      job,
+      deps: {} as CliDeps,
+      logger: { warn: vi.fn() },
+      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
+    });
+
+    expect(sendFailureNotificationAnnounce).toHaveBeenCalledTimes(1);
+    expect(sendFailureNotificationAnnounce.mock.calls[0]?.[4]).toEqual({
+      channel: "telegram",
+      to: "-1001234567890",
+      accountId: undefined,
+      sessionKey: "agent:main:telegram:group:-1001234567890:thread:42",
+      inheritSessionThread: false,
+    });
+  });
 });

--- a/src/gateway/server-cron-notifications.test.ts
+++ b/src/gateway/server-cron-notifications.test.ts
@@ -622,6 +622,43 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
     await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
 
+  it("owns missing-agent failures during detached failure destination delivery", async () => {
+    const warning = createVoidDeferred();
+    const logger = { warn: vi.fn(() => warning.resolve()) };
+    const job = createWebhookJob({
+      mode: "announce",
+      channel: "last",
+      failureDestination: {
+        mode: "announce",
+        channel: "telegram",
+        to: "-1001234567890",
+      },
+    });
+
+    expect(() =>
+      dispatchGatewayCronFinishedNotifications({
+        evt: { jobId: job.id, action: "finished", status: "error", error: "boom" },
+        job,
+        deps: {} as CliDeps,
+        logger,
+        resolveCronAgent: () => {
+          throw new Error("cron job agent is unavailable: removed-agent");
+        },
+      }),
+    ).not.toThrow();
+
+    await warning.promise;
+    expect(mocks.sendFailureNotificationAnnounce).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      {
+        jobId: job.id,
+        err: "cron job agent is unavailable: removed-agent",
+      },
+      "cron: detached notification delivery failed",
+    );
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+  });
+
   it("uses the persisted run failure reason for chat without changing webhook text", async () => {
     const runAtMs = Date.parse("2026-01-15T15:30:00.000Z");
     const announceJob = createWebhookJob({
@@ -788,58 +825,6 @@ describe("dispatchGatewayCronFinishedNotifications", () => {
       "cron: skipped completion webhook delivery, delivery.completionDestination.to must be a valid http(s) URL",
     );
     expect(mocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
-  });
-
-  it("keeps configured failure destinations from inheriting the primary delivery thread", () => {
-    const logger = {
-      warn: vi.fn(),
-    };
-    const job = {
-      id: "cron-threaded-failure-dest",
-      name: "threaded failure dest",
-      enabled: true,
-      createdAtMs: 1,
-      updatedAtMs: 1,
-      schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget: "isolated",
-      sessionKey: "agent:main:telegram:group:-1001234567890:thread:42",
-      wakeMode: "next-heartbeat",
-      payload: { kind: "agentTurn", message: "hello" },
-      delivery: {
-        mode: "announce",
-        channel: "telegram",
-        to: "-1001234567890",
-        threadId: 42,
-        failureDestination: {
-          mode: "announce",
-          channel: "telegram",
-          to: "-1001234567890",
-        },
-      },
-      state: {},
-    } satisfies CronJob;
-
-    dispatchGatewayCronFinishedNotifications({
-      evt: {
-        jobId: job.id,
-        action: "finished",
-        status: "error",
-        error: "boom",
-      },
-      job,
-      deps: {} as CliDeps,
-      logger,
-      resolveCronAgent: () => ({ agentId: "main", cfg: {} }),
-    });
-
-    expect(mocks.sendFailureNotificationAnnounce).toHaveBeenCalledTimes(1);
-    expect(mocks.sendFailureNotificationAnnounce.mock.calls[0]?.[4]).toEqual({
-      channel: "telegram",
-      to: "-1001234567890",
-      accountId: undefined,
-      sessionKey: "agent:main:telegram:group:-1001234567890:thread:42",
-      inheritSessionThread: false,
-    });
   });
 
   it("preserves the primary topic when a failed run falls back to its delivery route", () => {

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -14,7 +14,7 @@ import {
   resolveCronDeliveryPlan,
   resolveFailureDestination,
   sendCronAnnouncePayloadStrict,
-  sendFailureNotificationAnnounce,
+  sendFailureNotificationAnnounce as sendFailureAnnounce,
 } from "../cron/delivery.js";
 import { cronFailureDetailLines } from "../cron/failure-notification-text.js";
 import { retryTransientDirectCronDelivery } from "../cron/isolated-agent/delivery-dispatch-policy.js";
@@ -597,7 +597,6 @@ function dispatchCronFailureDestinationNotifications(params: {
     return;
   }
 
-  const { agentId, cfg: runtimeConfig } = params.resolveCronAgent(job.agentId);
   const failureAlertText = [
     `Automation "${job.name}" ${params.evt.status === "error" ? "failed" : "delivery failed"}`,
     ...cronFailureDetailLines(job.state.lastErrorReason),
@@ -605,9 +604,11 @@ function dispatchCronFailureDestinationNotifications(params: {
   dispatchDetachedCronNotification({
     jobId: job.id,
     logger: params.logger,
-    deliver: () =>
-      sendFailureNotificationAnnounce(params.deps, runtimeConfig, agentId, job.id, announceTarget, {
+    deliver: () => {
+      const { agentId, cfg: runtimeConfig } = params.resolveCronAgent(job.agentId);
+      return sendFailureAnnounce(params.deps, runtimeConfig, agentId, job.id, announceTarget, {
         text: appendCronRunStarted(`⚠️ ${failureAlertText}`, params.evt.runAtMs, runtimeConfig),
-      }),
+      });
+    },
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a failed automation job's announce-style failure notification could disappear silently when the job referenced an agent that had since been removed from the runtime roster.

The finished-event subscriber resolved the job agent before entering detached notification ownership. That resolution throw escaped the dispatcher, and the cron emitter's best-effort subscriber boundary suppressed it without recording a warning.

## Why This Change Was Made

Agent resolution now runs inside the existing detached notification closure. Its established rejection handler records `cron: detached notification delivery failed`, and its Gateway-root admission is released normally. Retry, fallback, routing, destination, persistence, configuration, protocol, SDK, and product policy are unchanged.

This is the canonical owner-boundary fix: catching at the cron emitter would preserve the silent failure, while inventing a fallback agent would change delivery policy. Production code is net +1 line. One existing failure-destination thread-routing case moved into its focused sibling test file to keep the oversized notification suite under the enforced line limit.

AI-assisted: yes. The implementation and proof were reviewed before publication.

## User Impact

Operators now receive a clear Gateway warning when a finished cron failure notification cannot even prepare because its stored agent no longer exists. The channel sender is not called with invalid ownership state, and detached Gateway work does not remain active.

## Evidence

- Exact reviewed head: `cf3eeaef380b09486250b249ac5ac380b0895f95`.
- Pre-fix regression: `node scripts/run-vitest.mjs src/gateway/server-cron-notifications.test.ts` failed 1/29 because the dispatcher synchronously threw `cron job agent is unavailable: removed-agent`.
- Focused notification proof: `node scripts/run-vitest.mjs src/gateway/server-cron-notifications.test.ts src/gateway/server-cron-notifications.delivery-failure.test.ts src/gateway/server-cron-notifications.presentation.test.ts` passed 33 tests.
- Gateway cron subscriber proof: `node scripts/run-vitest.mjs src/gateway/server.cron.test.ts src/cron/service.failure-alert.test.ts src/cron/delivery.failure-notify.test.ts` passed 65 tests across the Gateway and cron shards.
- Changed gates: `node scripts/check-changed.mjs -- src/gateway/server-cron-notifications.ts src/gateway/server-cron-notifications.test.ts src/gateway/server-cron-notifications.delivery-failure.test.ts` passed.
- Fresh P1 autoreview: no accepted/actionable findings; patch correct with 0.98 confidence.
- Exact-head CI: [run 32278064451](https://github.com/openclaw/openclaw/actions/runs/32278064451) passed; the watcher resolved superseded draft-run cancellations and finished `GREEN` with zero pending checks.
- LOC: production +6/-5 (net +1); tests +59/-52 (net +7).

Live channel delivery is intentionally not claimed: the reproduced state has no resolvable agent, so no valid channel send can begin. The boundary regression proves the required operator-visible warning, no sender call, and Gateway-root release.
