### PR TITLE
fix(openai): let OAuth Talk consult the active agent

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1017,9 +1017,9 @@ value into `plugins.entries.openai.config.personality` when that key is unset.
     credentials on different sides of the trust boundary. Platform auth mints
     an ephemeral client secret and the browser exchanges SDP directly with
     OpenAI. OAuth auth stays in the Gateway: the existing single-use offer
-    broker sends raw `application/sdp` to
-    `/v1/realtime/calls?model=<model>` and returns only the answer SDP. The
-    OAuth token never reaches the browser. A configured Platform credential
+    broker sends multipart `sdp` plus the canonical browser `session` policy
+    to `/v1/realtime/calls` and returns only the answer SDP. The OAuth token
+    never reaches the browser. A configured Platform credential
     that cannot be resolved still fails closed; repair or remove that source
     before OAuth fallback can apply.
 

--- a/extensions/openai/realtime-quicksilver-ga-oauth.test.ts
+++ b/extensions/openai/realtime-quicksilver-ga-oauth.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { OPENAI_QUICKSILVER_OFFER_PATH } from "./realtime-quicksilver-session.js";
+import {
+  createBroker,
+  createRequest,
+  createResponseHarness,
+} from "./realtime-quicksilver.test-helpers.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+function requireStringBody(body: BodyInit | null | undefined): string {
+  if (typeof body !== "string") {
+    throw new Error("Expected string request body");
+  }
+  return body;
+}
+
+describe("GA OAuth offer broker", () => {
+  it.each([
+    {
+      name: "missing",
+      gaSession: undefined,
+      message: "require an initial session policy",
+    },
+    {
+      name: "mismatched",
+      gaSession: { type: "realtime", model: "gpt-realtime-2" },
+      message: "policy model must match the requested model",
+    },
+  ])("rejects a $name GA policy before reserving provider state", async (testCase) => {
+    const fetchImpl = vi.fn();
+    const { realtime, sockets } = createBroker({
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    try {
+      await expect(
+        realtime.broker.createBrowserSession(
+          {
+            providerConfig: {},
+            model: "gpt-realtime-2.1",
+            voice: "cedar",
+            ...(testCase.gaSession ? { gaSession: testCase.gaSession } : {}),
+          },
+          { type: "oauth", token: "oauth-token", accountId: "account-123" },
+        ),
+      ).rejects.toThrow(testCase.message);
+      expect(fetchImpl).not.toHaveBeenCalled();
+      expect(sockets).toEqual([]);
+      expect(realtime.getSessionCounts()).toEqual({
+        pending: 0,
+        inFlight: 0,
+        active: 0,
+        reservations: 0,
+      });
+    } finally {
+      await realtime.cleanup();
+    }
+  });
+
+  it("sends the browser policy as multipart without opening a sideband", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({
+        url: typeof url === "string" ? url : url instanceof URL ? url.href : url.url,
+        init,
+      });
+      return new Response("v=ga-answer\r\n", { status: 201 });
+    }) as unknown as typeof fetch;
+    const { realtime, sockets } = createBroker({ fetchImpl });
+    try {
+      const gaSession = {
+        type: "realtime",
+        model: "gpt-realtime-2.1",
+        instructions: "Use tools.",
+        audio: {
+          input: { transcription: { model: "gpt-4o-mini-transcribe" } },
+          output: { voice: "cedar" },
+        },
+        tools: [{ type: "function", name: "openclaw_agent_consult", parameters: {} }],
+        tool_choice: "auto",
+      };
+      const reservation = await realtime.broker.createBrowserSession(
+        { providerConfig: {}, model: "gpt-realtime-2.1", voice: "cedar", gaSession },
+        { type: "oauth", token: "oauth-token", accountId: "account-123" },
+      );
+      expect(reservation).toMatchObject({
+        offerUrl: OPENAI_QUICKSILVER_OFFER_PATH,
+        model: "gpt-realtime-2.1",
+        voice: "cedar",
+      });
+      if (reservation.transport !== "webrtc") {
+        throw new Error("Expected WebRTC reservation");
+      }
+
+      const response = createResponseHarness();
+      await realtime.handler(
+        createRequest({ token: reservation.clientSecret, body: "v=ga-offer\r\n" }),
+        response.res,
+      );
+
+      expect(response.res.statusCode).toBe(201);
+      expect(response.readBody()).toBe("v=ga-answer\r\n");
+      expect(sockets).toEqual([]);
+      expect(requests[0]).toMatchObject({
+        url: "https://api.openai.com/v1/realtime/calls",
+        init: {
+          method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer oauth-token",
+            "chatgpt-account-id": "account-123",
+            "Content-Type": expect.stringMatching(/^multipart\/form-data; boundary=/),
+          }),
+        },
+      });
+      expect(requests[0]?.init?.headers).not.toHaveProperty("OpenAI-Alpha");
+      const body = requireStringBody(requests[0]?.init?.body);
+      expect(body).toContain('name="sdp"\r\nContent-Type: application/sdp');
+      expect(body).toContain('name="session"\r\nContent-Type: application/json');
+      expect(body).toContain(JSON.stringify(gaSession));
+
+      const replay = createResponseHarness();
+      await realtime.handler(createRequest({ token: reservation.clientSecret }), replay.res);
+      expect(replay.res.statusCode).toBe(401);
+    } finally {
+      await realtime.cleanup();
+    }
+  });
+
+  it("redacts OAuth identity from a bounded browser-visible provider failure", async () => {
+    const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0In0.signature";
+    const accountId = "7a1f92f3-7f0d-4d18-b1a0-8e6bd215c12f";
+    const detail = `safe diagnostic token=${token} account=${accountId} ${"x".repeat(1_000)}`;
+    const fetchImpl = vi.fn(
+      async () => new Response(detail, { status: 429 }),
+    ) as unknown as typeof fetch;
+    const { realtime, sockets } = createBroker({ fetchImpl });
+    try {
+      const reservation = await realtime.broker.createBrowserSession(
+        {
+          providerConfig: {},
+          model: "gpt-realtime-2.1",
+          voice: "cedar",
+          gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
+        },
+        { type: "oauth", token, accountId },
+      );
+      if (reservation.transport !== "webrtc") {
+        throw new Error("Expected WebRTC reservation");
+      }
+
+      const response = createResponseHarness();
+      await realtime.handler(
+        createRequest({ token: reservation.clientSecret, body: "v=ga-offer\r\n" }),
+        response.res,
+      );
+
+      expect(response.res.statusCode).toBe(502);
+      expect(response.readBody()).toContain("safe diagnostic");
+      expect(response.readBody()).not.toContain(token);
+      expect(response.readBody()).not.toContain(accountId);
+      expect(response.readBody().length).toBeLessThan(700);
+      expect(sockets).toEqual([]);
+      expect(realtime.getSessionCounts()).toEqual({
+        pending: 0,
+        inFlight: 0,
+        active: 0,
+        reservations: 0,
+      });
+
+      const replay = createResponseHarness();
+      await realtime.handler(createRequest({ token: reservation.clientSecret }), replay.res);
+      expect(replay.res.statusCode).toBe(401);
+    } finally {
+      await realtime.cleanup();
+    }
+  });
+
+  it.each([
+    {
+      name: "token",
+      selectSecret: (token: string) => token,
+    },
+    {
+      name: "account id",
+      selectSecret: (_token: string, accountId: string) => accountId,
+    },
+  ])("redacts an OAuth $name that straddles the detail cutoff", async (testCase) => {
+    const token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJib3VuZGFyeSJ9.signature";
+    const accountId = "7a1f92f3-7f0d-4d18-b1a0-8e6bd215c12f";
+    const secret = testCase.selectSecret(token, accountId);
+    const secretPrefix = secret.slice(0, 12);
+    const detail = `${"x".repeat(490)}${secret}${"y".repeat(1_000)}`;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(detail, {
+          status: 429,
+        }),
+    ) as unknown as typeof fetch;
+    const { realtime } = createBroker({ fetchImpl });
+    try {
+      const reservation = await realtime.broker.createBrowserSession(
+        {
+          providerConfig: {},
+          model: "gpt-realtime-2.1",
+          gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
+        },
+        { type: "oauth", token, accountId },
+      );
+      if (reservation.transport !== "webrtc") {
+        throw new Error("Expected WebRTC reservation");
+      }
+
+      const response = createResponseHarness();
+      await realtime.handler(
+        createRequest({ token: reservation.clientSecret, body: "v=ga-offer\r\n" }),
+        response.res,
+      );
+
+      expect(response.res.statusCode).toBe(502);
+      expect(response.readBody()).not.toContain(secret);
+      expect(response.readBody()).not.toContain(secretPrefix);
+      expect(response.readBody()).toContain("[REDACTED]");
+      expect(response.readBody().length).toBeLessThan(700);
+    } finally {
+      await realtime.cleanup();
+    }
+  });
+
+  it.each([
+    {
+      name: "token",
+      tokenLength: 1_927,
+      selectSecret: (token: string) => token,
+    },
+    {
+      name: "account id",
+      tokenLength: 2_045,
+      selectSecret: (_token: string, accountId: string) => accountId,
+    },
+  ])("drops a provider error when an OAuth $name straddles the body cap", async (testCase) => {
+    const token = `eyJ${"a".repeat(testCase.tokenLength - 3)}`;
+    const accountId = "7a1f92f3-7f0d-4d18-b1a0-8e6bd215c12f";
+    const secret = testCase.selectSecret(token, accountId);
+    const splitAt = Math.floor(secret.length / 2);
+    const shrinkablePrefix = token.repeat(8);
+    const fillerLength = 16 * 1024 - shrinkablePrefix.length - splitAt;
+    expect(fillerLength).toBeGreaterThanOrEqual(0);
+    const detail = `${shrinkablePrefix}${" ".repeat(fillerLength)}${secret} trailing provider detail`;
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(detail, {
+          status: 429,
+        }),
+    ) as unknown as typeof fetch;
+    const { realtime } = createBroker({ fetchImpl });
+    try {
+      const reservation = await realtime.broker.createBrowserSession(
+        {
+          providerConfig: {},
+          model: "gpt-realtime-2.1",
+          gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
+        },
+        { type: "oauth", token, accountId },
+      );
+      if (reservation.transport !== "webrtc") {
+        throw new Error("Expected WebRTC reservation");
+      }
+
+      const response = createResponseHarness();
+      await realtime.handler(
+        createRequest({ token: reservation.clientSecret, body: "v=ga-offer\r\n" }),
+        response.res,
+      );
+
+      expect(response.res.statusCode).toBe(502);
+      expect(response.readBody()).not.toContain(secret.slice(0, splitAt));
+      expect(response.readBody()).not.toContain(secret.slice(splitAt));
+      expect(response.readBody()).not.toContain("trailing provider detail");
+      expect(response.readBody()).toBe("OpenAI Realtime call creation failed (429)");
+    } finally {
+      await realtime.cleanup();
+    }
+  });
+});

--- a/extensions/openai/realtime-quicksilver-session.test.ts
+++ b/extensions/openai/realtime-quicksilver-session.test.ts
@@ -157,8 +157,8 @@ describe("GPT-Live offer broker", () => {
         {
           providerConfig: {},
           model: "gpt-realtime-2.1",
+          gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
           gaSideband: {
-            session: { type: "realtime", model: "gpt-realtime-2.1" },
             createBridge,
           },
         },
@@ -243,8 +243,8 @@ describe("GPT-Live offer broker", () => {
         {
           providerConfig: {},
           model: "gpt-realtime-2.1",
+          gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
           gaSideband: {
-            session: { type: "realtime", model: "gpt-realtime-2.1" },
             createBridge: () => bridge,
           },
         },
@@ -295,8 +295,8 @@ describe("GPT-Live offer broker", () => {
         {
           providerConfig: {},
           model: "gpt-realtime-2.1",
+          gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
           gaSideband: {
-            session: { type: "realtime", model: "gpt-realtime-2.1" },
             createBridge: () => bridge,
           },
         },
@@ -342,8 +342,8 @@ describe("GPT-Live offer broker", () => {
           {
             providerConfig: {},
             model: "gpt-realtime-2.1",
+            gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
             gaSideband: {
-              session: { type: "realtime", model: "gpt-realtime-2.1" },
               createBridge: vi.fn(),
             },
           },
@@ -365,61 +365,6 @@ describe("GPT-Live offer broker", () => {
       }
     },
   );
-
-  it("brokers GA OAuth with raw SDP and no sideband while preserving single-use tokens", async () => {
-    const requests: Array<{ url: string; init?: RequestInit }> = [];
-    const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      requests.push({
-        url: typeof url === "string" ? url : url instanceof URL ? url.href : url.url,
-        init,
-      });
-      return new Response("v=ga-answer\r\n", { status: 201 });
-    }) as unknown as typeof fetch;
-    const { realtime, sockets } = createBroker({ fetchImpl });
-    try {
-      const reservation = await realtime.broker.createBrowserSession(
-        { providerConfig: {}, model: "gpt-realtime-2.1", voice: "cedar" },
-        { type: "oauth", token: "oauth-token", accountId: "account-123" },
-      );
-      expect(reservation).toMatchObject({
-        offerUrl: OPENAI_QUICKSILVER_OFFER_PATH,
-        model: "gpt-realtime-2.1",
-        voice: "cedar",
-      });
-      if (reservation.transport !== "webrtc") {
-        throw new Error("Expected WebRTC reservation");
-      }
-
-      const response = createResponseHarness();
-      await realtime.handler(
-        createRequest({ token: reservation.clientSecret, body: "v=ga-offer\r\n" }),
-        response.res,
-      );
-
-      expect(response.res.statusCode).toBe(201);
-      expect(response.readBody()).toBe("v=ga-answer\r\n");
-      expect(sockets).toEqual([]);
-      expect(requests[0]).toMatchObject({
-        url: "https://api.openai.com/v1/realtime/calls?model=gpt-realtime-2.1",
-        init: {
-          method: "POST",
-          body: "v=ga-offer\r\n",
-          headers: expect.objectContaining({
-            Authorization: "Bearer oauth-token",
-            "chatgpt-account-id": "account-123",
-            "Content-Type": "application/sdp",
-          }),
-        },
-      });
-      expect(requests[0]?.init?.headers).not.toHaveProperty("OpenAI-Alpha");
-
-      const replay = createResponseHarness();
-      await realtime.handler(createRequest({ token: reservation.clientSecret }), replay.res);
-      expect(replay.res.statusCode).toBe(401);
-    } finally {
-      await realtime.cleanup();
-    }
-  });
 
   it.each([
     {
@@ -870,8 +815,8 @@ describe("GPT-Live offer broker", () => {
           providerConfig: {},
           model: "gpt-realtime-2.1",
           gatewayControl: { bindBridge: vi.fn(), onClose },
+          gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
           gaSideband: {
-            session: { type: "realtime", model: "gpt-realtime-2.1" },
             createBridge: vi.fn(),
           },
         },
@@ -922,8 +867,8 @@ describe("GPT-Live offer broker", () => {
       providerConfig: {},
       model: "gpt-realtime-2.1",
       ownerConnId,
+      gaSession: { type: "realtime" as const, model: "gpt-realtime-2.1" },
       gaSideband: {
-        session: { type: "realtime" as const, model: "gpt-realtime-2.1" },
         createBridge: vi.fn(),
       },
     });
@@ -953,14 +898,19 @@ describe("GPT-Live offer broker", () => {
     }
   });
 
-  it("does not apply the GA sideband owner quota to legacy broker sessions", async () => {
+  it("does not apply the GA sideband owner quota to browser-owned GA sessions", async () => {
     const { realtime } = createBroker();
     try {
       await expect(
         Promise.all(
           Array.from({ length: 3 }, () =>
             realtime.broker.createBrowserSession(
-              { providerConfig: {}, model: "gpt-realtime-2.1", ownerConnId: "conn-legacy" },
+              {
+                providerConfig: {},
+                model: "gpt-realtime-2.1",
+                ownerConnId: "conn-browser",
+                gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
+              },
               { type: "api-key", token: "platform-key" },
             ),
           ),

--- a/extensions/openai/realtime-quicksilver-session.ts
+++ b/extensions/openai/realtime-quicksilver-session.ts
@@ -55,8 +55,8 @@ const WEBSOCKET_OPEN = 1;
 type OpenAIQuicksilverSessionRequest = RealtimeVoiceBrowserSessionCreateRequest & {
   initialItems?: OpenAIQuicksilverInitialItem[];
   ownerConnId?: string;
+  gaSession?: Record<string, unknown> & { model: string };
   gaSideband?: {
-    session: Record<string, unknown> & { model: string };
     createBridge: (params: {
       apiKey: string;
       callId: string;
@@ -295,8 +295,17 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
       if (!model) {
         throw new Error("OpenAI realtime browser sessions require a model");
       }
-      if (isOpenAIGptLiveModel(model) && !request.runAgentConsult) {
+      const isGptLive = isOpenAIGptLiveModel(model);
+      if (isGptLive && !request.runAgentConsult) {
         throw new Error("OpenAI GPT-Live requires the Gateway agent-consult runtime");
+      }
+      if (!isGptLive) {
+        if (!request.gaSession) {
+          throw new Error("OpenAI GA realtime browser sessions require an initial session policy");
+        }
+        if (request.gaSession.model !== model) {
+          throw new Error("OpenAI GA realtime session policy model must match the requested model");
+        }
       }
       prunePendingOffers();
       if (
@@ -447,6 +456,17 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         lifecycleSignal,
         AbortSignal.timeout(OPENAI_QUICKSILVER_UPSTREAM_TIMEOUT_MS),
       ]);
+      const sessionConfig = isOpenAIGptLiveModel(offer.request.model)
+        ? buildOpenAIQuicksilverSession({
+            model: offer.request.model,
+            instructions: offer.request.instructions,
+            voice: offer.request.voice,
+            initialItems: offer.request.initialItems,
+          })
+        : offer.request.gaSession;
+      if (!sessionConfig) {
+        throw new Error("OpenAI GA realtime browser sessions require an initial session policy");
+      }
       const gaSideband = offer.request.gaSideband;
       if (gaSideband) {
         try {
@@ -463,7 +483,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
           auth: offer.auth,
           requestIds: offer.requestIds,
           sdp,
-          session: gaSideband.session,
+          session: sessionConfig,
           gaSideband: true,
           signal: upstreamSignal,
           fetchImpl: params.fetchImpl,
@@ -540,12 +560,7 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         auth: offer.auth,
         requestIds: offer.requestIds,
         sdp,
-        session: buildOpenAIQuicksilverSession({
-          model: offer.request.model,
-          instructions: offer.request.instructions,
-          voice: offer.request.voice,
-          initialItems: offer.request.initialItems,
-        }),
+        session: sessionConfig,
         signal: upstreamSignal,
         fetchImpl: params.fetchImpl,
       });

--- a/extensions/openai/realtime-quicksilver-wire.test.ts
+++ b/extensions/openai/realtime-quicksilver-wire.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("GPT-Live call creation", () => {
+describe("Realtime call creation", () => {
   it("uses one multipart /v1/live wire shape for OAuth and API-key auth", async () => {
     vi.stubEnv("OPENCLAW_VERSION", "2026.7.2-test");
     const requests: Array<{ url: string; init?: RequestInit }> = [];
@@ -101,21 +101,30 @@ describe("GPT-Live call creation", () => {
   });
 
   it.each(["gpt-realtime-2.1", "gpt-realtime-2.1-mini", "gpt-realtime-2"])(
-    "uses raw SDP with the model query and no quicksilver alpha header for %s OAuth",
+    "uses multipart session initialization without a sideband for %s OAuth",
     async (model) => {
       vi.stubEnv("OPENCLAW_VERSION", "2026.7.2-test");
-      let capturedHeaders: HeadersInit | undefined;
-      const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
-        capturedHeaders = init?.headers;
+      let capturedUrl: string | undefined;
+      let capturedInit: RequestInit | undefined;
+      const fetchImpl = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        capturedUrl = typeof url === "string" ? url : url instanceof URL ? url.href : url.url;
+        capturedInit = init;
         return new Response("v=ga-answer\r\n", { status: 201 });
       });
+      const session = {
+        type: "realtime",
+        model,
+        instructions: "Use tools.",
+        tools: [{ type: "function", name: "openclaw_agent_consult", parameters: {} }],
+        tool_choice: "auto",
+      };
 
       await expect(
         createOpenAIQuicksilverCall({
           auth: { type: "oauth", token: "oauth-token", accountId: "acct-1" },
           requestIds: createRequestIds("ga-oauth"),
           sdp: "v=ga-offer\r\n",
-          session: buildOpenAIQuicksilverSession({ model }),
+          session,
           fetchImpl: fetchImpl as unknown as typeof fetch,
         }),
       ).resolves.toEqual({
@@ -123,25 +132,27 @@ describe("GPT-Live call creation", () => {
         status: 201,
         answerSdp: "v=ga-answer\r\n",
       });
-      expect(fetchImpl).toHaveBeenCalledWith(
-        `https://api.openai.com/v1/realtime/calls?model=${model}`,
-        expect.objectContaining({
-          method: "POST",
-          body: "v=ga-offer\r\n",
-          headers: {
-            Authorization: "Bearer oauth-token",
-            "User-Agent": "openclaw/2026.7.2-test",
-            "chatgpt-account-id": "acct-1",
-            originator: "openclaw",
-            "session-id": "ga-oauth-session",
-            "thread-id": "ga-oauth-thread",
-            version: "2026.7.2-test",
-            "x-session-id": "ga-oauth-realtime",
-            "Content-Type": "application/sdp",
-          },
-        }),
-      );
-      expect(capturedHeaders).not.toHaveProperty("OpenAI-Alpha");
+      expect(capturedUrl).toBe("https://api.openai.com/v1/realtime/calls");
+      expect(capturedInit?.method).toBe("POST");
+      const headers = capturedInit?.headers as Record<string, string> | undefined;
+      expect(headers).toMatchObject({
+        Authorization: "Bearer oauth-token",
+        "User-Agent": "openclaw/2026.7.2-test",
+        "chatgpt-account-id": "acct-1",
+        originator: "openclaw",
+        "session-id": "ga-oauth-session",
+        "thread-id": "ga-oauth-thread",
+        version: "2026.7.2-test",
+        "x-session-id": "ga-oauth-realtime",
+        "Content-Type": expect.stringMatching(/^multipart\/form-data; boundary=/),
+      });
+      expect(headers).not.toHaveProperty("OpenAI-Alpha");
+      const boundary = headers?.["Content-Type"]?.split("boundary=")[1];
+      expect(boundary).toBeTruthy();
+      expect(typeof capturedInit?.body).toBe("string");
+      expect(capturedInit?.body).toContain('name="sdp"\r\nContent-Type: application/sdp');
+      expect(capturedInit?.body).toContain('name="session"\r\nContent-Type: application/json');
+      expect(capturedInit?.body).toContain(JSON.stringify(session));
     },
   );
 
@@ -187,12 +198,12 @@ describe("GPT-Live call creation", () => {
     {
       name: "GPT-Live",
       model: "gpt-live-1-codex",
-      expectedMessage: "GPT-Live call creation failed (429): provider diagnostic:",
+      expectedMessage: "GPT-Live call creation failed (429)",
     },
     {
       name: "GA realtime",
       model: "gpt-realtime-2.1",
-      expectedMessage: "OpenAI Realtime call creation failed (429): provider diagnostic:",
+      expectedMessage: "OpenAI Realtime call creation failed (429)",
     },
   ])("bounds and cancels an oversized streaming $name error response", async (testCase) => {
     const detailPrefix = "provider diagnostic: ";
@@ -234,7 +245,7 @@ describe("GPT-Live call creation", () => {
       await expect(promise).rejects.toMatchObject({
         name: "OpenAIQuicksilverCallError",
         status: 429,
-        message: expect.stringContaining(testCase.expectedMessage),
+        message: testCase.expectedMessage,
       });
       await responseClosed;
       expect(controller.signal.aborted).toBe(false);

--- a/extensions/openai/realtime-quicksilver-wire.ts
+++ b/extensions/openai/realtime-quicksilver-wire.ts
@@ -2,9 +2,9 @@
 import { randomBytes } from "node:crypto";
 import {
   readProviderTextResponse,
-  readResponseTextLimited,
   resolveProviderRequestHeaders,
 } from "openclaw/plugin-sdk/provider-http";
+import { readResponseTextPrefix } from "openclaw/plugin-sdk/response-limit-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { z } from "zod";
@@ -23,6 +23,17 @@ const OPENAI_REALTIME_SDP_ANSWER_MAX_BYTES = 256 * 1024;
 const OPENAI_REALTIME_LOCATION_MAX_BYTES = 512;
 const OPENAI_REALTIME_CALL_ID_RE = /^[A-Za-z0-9_-]{1,128}$/u;
 const OPENAI_GPT_LIVE_WAITLIST_URL = "https://openai.com/form/gpt-live-1-in-the-api/";
+
+function redactOpenAIRealtimeErrorDetail(text: string, auth: OpenAIQuicksilverAuth): string {
+  let redacted = text;
+  const exactSecrets = [auth.token, auth.type === "oauth" ? auth.accountId : undefined];
+  for (const secret of exactSecrets) {
+    if (secret) {
+      redacted = redacted.split(secret).join("[REDACTED]");
+    }
+  }
+  return redactSensitiveText(redacted, { mode: "tools" });
+}
 
 const OPENAI_QUICKSILVER_VOICES = [
   "alloy",
@@ -444,41 +455,36 @@ export async function createOpenAIQuicksilverCall(params: {
         baseUrl: OPENAI_REALTIME_CALL_URL,
         includeQuicksilverAlpha: false,
       });
-  const multipart =
-    isGptLive || params.gaSideband
-      ? buildOpenAIQuicksilverMultipartBody({
-          sdp: params.sdp,
-          session: params.session,
-        })
-      : undefined;
-  const callUrl = isGptLive
-    ? OPENAI_QUICKSILVER_CALL_URL
-    : params.gaSideband
-      ? OPENAI_REALTIME_CALL_URL
-      : `${OPENAI_REALTIME_CALL_URL}?model=${encodeURIComponent(params.session.model)}`;
+  const multipart = buildOpenAIQuicksilverMultipartBody({
+    sdp: params.sdp,
+    session: params.session,
+  });
+  const callUrl = isGptLive ? OPENAI_QUICKSILVER_CALL_URL : OPENAI_REALTIME_CALL_URL;
 
   const response = await (params.fetchImpl ?? fetch)(callUrl, {
     method: "POST",
     headers: {
       ...authHeaders,
-      "Content-Type": multipart?.contentType ?? "application/sdp",
+      "Content-Type": multipart.contentType,
     },
-    body: multipart?.body ?? params.sdp,
+    body: multipart.body,
     signal: params.signal,
   });
   if (!response.ok) {
     // Provider failures are untrusted streams. Bound and cancel unread overflow
     // before retaining the short diagnostic included in the user-facing error.
-    const detail = redactSensitiveText(
-      (
-        await readResponseTextLimited(response, OPENAI_REALTIME_ERROR_BODY_MAX_BYTES).catch(
-          () => "",
-        )
-      )
-        .trim()
-        .slice(0, OPENAI_REALTIME_ERROR_DETAIL_MAX_CHARS),
-      { mode: "tools" },
-    );
+    // A truncated prefix can end inside an OAuth identifier. Exact redaction
+    // cannot prove that a partial suffix is safe, so omit provider detail.
+    const providerDetail = await readResponseTextPrefix(
+      response,
+      OPENAI_REALTIME_ERROR_BODY_MAX_BYTES,
+    ).catch(() => undefined);
+    const detail = providerDetail?.truncated
+      ? ""
+      : truncateUtf16Safe(
+          redactOpenAIRealtimeErrorDetail(providerDetail?.text.trim() ?? "", params.auth),
+          OPENAI_REALTIME_ERROR_DETAIL_MAX_CHARS,
+        );
     throw new OpenAIQuicksilverCallError(
       isGptLive
         ? describeOpenAIQuicksilverCallError(response.status, detail)

--- a/extensions/openai/realtime-quicksilver.live.test.ts
+++ b/extensions/openai/realtime-quicksilver.live.test.ts
@@ -19,6 +19,7 @@ import {
   type OpenAIQuicksilverAuth,
 } from "./realtime-quicksilver-wire.js";
 import { buildOpenAIRealtimeVoiceProvider } from "./realtime-voice-provider.js";
+import { OPENAI_REALTIME_INPUT_TRANSCRIPTION_MODEL } from "./realtime-voice-session-policy.js";
 
 const LIVE_ENABLED =
   process.env.OPENCLAW_LIVE_TEST === "1" && process.env.OPENCLAW_LIVE_GPT_LIVE === "1";
@@ -524,7 +525,30 @@ describeLive("OpenAI OAuth WebRTC", () => {
         for (const model of ["gpt-realtime-2.1", "gpt-realtime-2.1-mini", "gpt-realtime-2"]) {
           try {
             const reservation = await realtime.broker.createBrowserSession(
-              { providerConfig: {}, model, voice: "marin" },
+              {
+                providerConfig: {},
+                model,
+                voice: "marin",
+                gaSession: {
+                  type: "realtime",
+                  model,
+                  instructions: "Keep this transport verification session silent.",
+                  audio: {
+                    input: {
+                      noise_reduction: { type: "near_field" },
+                      turn_detection: {
+                        type: "server_vad",
+                        create_response: true,
+                        interrupt_response: true,
+                      },
+                      transcription: { model: OPENAI_REALTIME_INPUT_TRANSCRIPTION_MODEL },
+                    },
+                    output: { voice: "marin" },
+                  },
+                  tools: [REALTIME_VOICE_AGENT_CONSULT_TOOL],
+                  tool_choice: "auto",
+                },
+              },
               auth,
             );
             if (reservation.transport !== "webrtc") {

--- a/extensions/openai/realtime-voice-bridge-connection.test.ts
+++ b/extensions/openai/realtime-voice-bridge-connection.test.ts
@@ -132,7 +132,8 @@ describe("OpenAI realtime voice bridge connection", () => {
       token: "test-api-key-platform",
     });
     const gaSideband = requireRecord(brokerRequest.gaSideband, "GA sideband request");
-    expect(gaSideband.session).toMatchObject({
+    const gaSession = requireRecord(brokerRequest.gaSession, "GA session policy");
+    expect(gaSession).toMatchObject({
       type: "realtime",
       instructions: "Stay concise.",
       model: "gpt-realtime-2.1",
@@ -176,7 +177,7 @@ describe("OpenAI realtime voice bridge connection", () => {
     await Promise.resolve();
     const sessionUpdates = parseSent(socket).filter((event) => event.type === "session.update");
     expect(sessionUpdates).toHaveLength(1);
-    expect(sessionUpdates[0]?.session).toEqual(gaSideband.session);
+    expect(sessionUpdates[0]?.session).toEqual(gaSession);
     emitServerEvent(socket, {
       type: "session.created",
       session: { type: "realtime", tools: [{ type: "function" }], tool_choice: "auto" },

--- a/extensions/openai/realtime-voice-provider-routing.test.ts
+++ b/extensions/openai/realtime-voice-provider-routing.test.ts
@@ -512,7 +512,7 @@ describe("OpenAI realtime voice provider routing", () => {
     ).not.toHaveProperty("supportsGatewayControl");
   });
 
-  it("uses ChatGPT OAuth as the browser-only fallback for GA realtime", async () => {
+  it("gives GA OAuth the same browser session policy as Platform auth", async () => {
     const oauthToken = createTestJwt({
       "https://api.openai.com/auth": { chatgpt_account_id: "account-123" },
     });
@@ -536,6 +536,12 @@ describe("OpenAI realtime voice provider routing", () => {
       providerConfig: {},
       model: "gpt-realtime-2.1",
       voice: "cedar",
+      instructions: "Use the configured tools when needed.",
+      vadThreshold: 0.42,
+      prefixPaddingMs: 240,
+      silenceDurationMs: 620,
+      reasoningEffort: "low",
+      tools: [createRealtimeTool("openclaw_agent_consult")],
       agentId: "main",
       workspaceDir: "/tmp/openclaw-agent-workspace",
       initialItems: [],
@@ -554,10 +560,53 @@ describe("OpenAI realtime voice provider routing", () => {
       offerUrl: "/plugins/openai/realtime/calls",
     });
     expect(createBrowserSession).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "gpt-realtime-2.1", voice: "cedar" }),
+      expect.objectContaining({
+        model: "gpt-realtime-2.1",
+        voice: "cedar",
+        gaSession: {
+          type: "realtime",
+          model: "gpt-realtime-2.1",
+          instructions: "Use the configured tools when needed.",
+          audio: {
+            input: {
+              noise_reduction: { type: "near_field" },
+              turn_detection: {
+                type: "server_vad",
+                create_response: true,
+                interrupt_response: true,
+                threshold: 0.42,
+                prefix_padding_ms: 240,
+                silence_duration_ms: 620,
+              },
+              transcription: { model: "gpt-4o-mini-transcribe" },
+            },
+            output: { voice: "cedar" },
+          },
+          tools: [createRealtimeTool("openclaw_agent_consult")],
+          tool_choice: "auto",
+          reasoning: { effort: "low" },
+        },
+      }),
       { type: "oauth", token: oauthToken, accountId: "account-123" },
     );
+    const brokerRequest = requireRecord(
+      createBrowserSession.mock.calls[0]?.[0],
+      "OAuth broker request",
+    );
+    const gaSession = requireRecord(brokerRequest.gaSession, "OAuth GA session");
+    expect(gaSession).not.toHaveProperty("output_modalities");
+    expect(gaSession).not.toHaveProperty("initial_items");
+    expect(requireRecord(gaSession.audio, "OAuth GA audio").input).not.toHaveProperty("format");
+    expect(requireRecord(gaSession.audio, "OAuth GA audio").output).not.toHaveProperty("format");
     expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
+
+    mockRealtimeClientSecretResponse();
+    await provider.createBrowserSession?.({
+      ...request,
+      providerConfig: { apiKey: "test-api-key-platform" },
+    });
+    expect(gaSession).toEqual(requireFetchJsonBody().session);
+    expect(createBrowserSession).toHaveBeenCalledTimes(1);
   });
 
   it("passes configured gpt-live model and voice to the native broker", async () => {

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -211,8 +211,8 @@ async function createOpenAIRealtimeBrowserSession(
         ...req,
         model,
         voice,
+        gaSession: sessionConfig,
         gaSideband: {
-          session: sessionConfig,
           createBridge: ({ apiKey, callId, onTerminal }) => {
             const bridge = new OpenAIRealtimeBridge({
               cfg: req.cfg,
@@ -271,6 +271,7 @@ async function createOpenAIRealtimeBrowserSession(
     });
     return await quicksilverBroker.createBrowserSession(quicksilverRequest, auth);
   }
+  const { session, voice } = buildOpenAIRealtimeBrowserSessionConfig(req, config, model);
   const auth = await resolveOpenAIRealtimePlatformAuth({
     configuredApiKey: config.apiKey,
     cfg: req.cfg,
@@ -300,13 +301,12 @@ async function createOpenAIRealtimeBrowserSession(
       {
         ...req,
         model,
-        voice: normalizeOpenAIRealtimeVoice(req.voice) ?? config.voice ?? "alloy",
+        voice,
+        gaSession: session,
       },
       subscriptionAuth,
     );
   }
-
-  const { session, voice } = buildOpenAIRealtimeBrowserSessionConfig(req, config, model);
 
   const clientSecret = await createOpenAIRealtimeClientSecret({
     authToken: auth.value,


### PR DESCRIPTION
Closes #125604

## What Problem This Solves

Fixes an issue where browser Talk configured with `brain: agent-consult` could not consult the active OpenClaw agent when `gpt-realtime-2.1` used ChatGPT subscription OAuth. Voice audio still worked, but the OAuth WebRTC call silently omitted the consult tool and answered from only its bounded realtime context.

## Why This Change Was Made

OAuth and Platform browser sessions now share one canonical initial session policy. The OAuth broker sends that policy atomically with the SDP offer using the Realtime multipart `sdp + session` contract, so tools, instructions, transcription, VAD, reasoning, and voice configuration exist before the call becomes conversational.

The existing browser-owned data-channel tool loop remains unchanged. This does not open a Gateway sideband, force every voice turn through the agent, or change GPT-Live relay ownership.

The broker also rejects missing or model-mismatched GA policies before creating a reservation. Complete bounded OAuth provider errors redact token/account identifiers before applying the browser-visible cap; truncated provider bodies omit detail entirely so a partial identifier cannot straddle the read boundary.

## User Impact

ChatGPT subscription users can use contextual browser voice conversations with `brain: agent-consult`: the realtime model can ask the active agent for written conversation context, memory, workspace state, and tools when needed. Ordinary provider-direct voice replies remain direct.

## Evidence

### Regression proof

On baseline `a7f9a7fdd4fedf32149a6d295cbdc1c3d251a19d`, the test-only patch failed at the intended boundaries:

- OAuth provider routing omitted the canonical GA browser session policy.
- OAuth call creation used raw `application/sdp` with `?model=`.
- The broker could not serialize the supplied policy as multipart.

The production patch was absent from the baseline red worktree. The same test-only patch and command were then run unchanged against the candidate:

```bash
pnpm test \
  extensions/openai/realtime-voice-provider-routing.test.ts \
  extensions/openai/realtime-quicksilver-wire.test.ts \
  extensions/openai/realtime-quicksilver-ga-oauth.test.ts
```

- Baseline: 10 intended failures, 44 passes.
- Candidate: 54 passes.

The six owner-boundary source/test blobs used by the red run are byte-identical between baseline `a7f9a7f` and the candidate's parent. Later security-hardening tests additionally cover both the 500-character browser-detail cap and the 16 KiB provider-body cap.

### Real browser/OAuth/OpenShift validation

An immutable candidate image was deployed to an isolated, channel-dark OpenShift fixture using real ChatGPT subscription OAuth and `gpt-realtime-2.1`. A Playwright Chromium client used WebRTC with a deterministic fake microphone.

The fixture first stored `project codename is Copper Kestrel` in an isolated fixture session, then voice asked what codename was chosen. Sanitized browser data-channel evidence showed:

```json
{
  "userTranscript": "Did we choose?",
  "assistantTranscript": "Let me check that for you.Yes, we did. The chosen project codename is Copper Kestrel.",
  "consultCallObserved": true,
  "toolOutputObserved": true,
  "errors": []
}
```

After rebasing onto current upstream `main`, PipelineRun `openclaw-pr125604-5534c3075b-fgcc2` built the exact-head image for `5534c3075b6f42dbe1936bed91530e526169ae91` with rollout disabled. The deployed fixture's CRI image ID matched digest `sha256:d54e1ca6b67dcdb6566347e755080bbf80aad2fc33864364e6ac430edbbf083f`, reported runtime `OpenClaw 2026.8.1 (5534c30)`, and had zero restarts.

That exact image produced a closed durable voice-session record with `hasUserTranscript: true`, one non-empty consult run ID, and zero unresolved transcript failures. The correlated 17-second Gateway log window contained `talk.client.create` and zero sideband lifecycle lines; the function call and `function_call_output` were observed on the browser data channel.

A sanitized 1366×900 screenshot was captured and visually inspected. It shows the written seed fact, finalized voice transcript, consult tool block, memory lookup, and contextual answer in one Control UI session. No credential or account identifier is visible.

An exact-head provider-direct behavior control on the same candidate completed normally with a finalized user transcript, no consult call, no tool output, and no errors.

No production deployment or configuration was changed. One successful finalized user transcript supports this consult-flow proof but does not claim that #125601 is fixed generally.

### Automated validation

- Pre-rebase full OpenAI plugin suite: 861 passed, 1 skipped
- Post-rebase owner-boundary suite: 122 passed
- Gateway Talk sibling tests: 74 passed
- `pnpm check:changed`: passed against current upstream `main`
- Production build: passed
- Formatting, extension production/test types, extension lint, docs, plugin boundaries, dead-code scan, dependency guards, and `git diff --check`: passed
- UI Talk shard could not collect locally because the repository runner resolved an invalid `node:` builtin; no UI assertion ran or failed. Browser E2E exercised the shipped Control UI instead.

AI-assisted implementation. I reviewed the OAuth credential boundary, multipart wire contract, browser/Gateway tool ownership, error redaction, reservation lifecycle, regression tests, and live proof.
