### PR TITLE
fix(ui): prevent duplicate assistant bubbles after history refresh

### DIFF
--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -8,6 +8,7 @@ import type { ApplicationContext } from "../../app/context.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import "./chat-pane.ts";
 import { loadChatHistory } from "./chat-history.ts";
+import { nativeHistoryMessageIdentity } from "./chat-pane-shared.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 
 type TestChatPane = HTMLElement & {
@@ -516,8 +517,14 @@ describe("chat pane native history pagination", () => {
     const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
     const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
     const projected = [
-      nativeHistoryMessage(1, "tool call"),
-      nativeHistoryMessage(1, "visible tool reply"),
+      {
+        ...nativeHistoryMessage(1, "Same routed send"),
+        openclawMessageToolMirror: { toolName: "message", toolCallId: "call-a" },
+      },
+      {
+        ...nativeHistoryMessage(1, "Same routed send"),
+        openclawMessageToolMirror: { toolName: "message", toolCallId: "call-b" },
+      },
     ];
 
     expect(pane.prependUniqueNativeMessages(projected, [nativeHistoryMessage(2)])).toEqual([
@@ -528,6 +535,37 @@ describe("chat pane native history pagination", () => {
     expect(
       pane.prependUniqueNativeMessages(projected, [projected[1], nativeHistoryMessage(2)]),
     ).toEqual([projected[0], projected[1], nativeHistoryMessage(2)]);
+  });
+
+  it("deduplicates byte-different live-event and history projections of one transcript row", () => {
+    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+    const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
+    const liveEventProjection = {
+      role: "assistant",
+      content: [{ type: "text", text: "One stored reply" }],
+      __openclaw: {
+        id: "assistant-message-42",
+        idempotencyKey: "run-42",
+        seq: 42,
+      },
+    };
+    const historyProjection = {
+      role: "assistant",
+      content: [{ type: "text", text: "One stored reply" }],
+      __openclaw: {
+        id: "assistant-message-42",
+        idempotencyKey: "run-42",
+        recordTimestampMs: 1_786_000_000_000,
+        seq: 42,
+      },
+    };
+
+    expect(nativeHistoryMessageIdentity(liveEventProjection)).toBe(
+      nativeHistoryMessageIdentity(historyProjection),
+    );
+    expect(pane.prependUniqueNativeMessages([historyProjection], [liveEventProjection])).toEqual([
+      liveEventProjection,
+    ]);
   });
 
   it("deduplicates projected catalog transcript records by catalog message id", () => {

--- a/ui/src/pages/chat/chat-pane-shared.ts
+++ b/ui/src/pages/chat/chat-pane-shared.ts
@@ -1,4 +1,3 @@
-import { stableStringify } from "@openclaw/normalization-core";
 import { asNullableRecord as catalogRawRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SessionCatalogPullRequestSummary } from "../../../../packages/gateway-protocol/src/index.js";
 import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
@@ -13,7 +12,6 @@ import { clampText } from "../../lib/format.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { releaseChatAttachmentPayloads } from "./attachment-payload-store.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
-import { safeNormalizeMessage } from "./chat-turn-boundary.ts";
 
 export type ChatPageContext = ApplicationContext;
 export type PaneSessionChangeOptions = { replace?: boolean };
@@ -207,36 +205,23 @@ export function nativeHistoryMessageIdentity(message: unknown): string | null {
   const seq = metadata?.seq;
   const id = metadata?.id ?? record?.messageId;
   const sourceIdentity =
-    typeof id === "string" && id.trim()
-      ? `id:${id}`
-      : typeof seq === "number" && Number.isSafeInteger(seq) && seq > 0
-        ? `seq:${seq}`
+    typeof seq === "number" && Number.isSafeInteger(seq) && seq > 0
+      ? `seq:${seq}`
+      : typeof id === "string" && id.trim()
+        ? `id:${id}`
         : null;
   if (!sourceIdentity) {
     return null;
   }
-  const normalized = safeNormalizeMessage(message);
-  const normalizedProjection = normalized
-    ? (() => {
-        const { id: _id, sender, timestamp: _timestamp, ...visible } = normalized;
-        const { profileAvatarUrl: _profileAvatarUrl, ...stableSender } = sender ?? {};
-        return {
-          ...visible,
-          ...(Object.keys(stableSender).length > 0 ? { sender: stableSender } : {}),
-        };
-      })()
-    : { role: record?.role, content: record?.content ?? record?.text };
-  // One transcript record can project to multiple visible siblings. Pair its
-  // source with stable display facts, excluding delivery-only timing/run metadata.
-  return `${sourceIdentity}:${stableStringify({
-    message: normalizedProjection,
-    kind: metadata?.kind ?? record?.customType ?? record?.type,
-    toolCallId: record?.toolCallId ?? record?.tool_call_id ?? record?.callId ?? record?.call_id,
-    toolName: record?.toolName ?? record?.tool_name ?? record?.name ?? record?.tool,
-    mirror: record?.openclawMessageToolMirror,
-    details: record?.details,
-    provenance: record?.provenance,
-  })}`;
+  const { recordTimestampMs: _recordTimestampMs, ...projectionMetadata } = metadata ?? {};
+  const projection = metadata ? { ...record, __openclaw: projectionMetadata } : record;
+  try {
+    // History alone adds recordTimestampMs; delivery metadata is not projection identity.
+    // Keep every other projection byte so siblings from one transcript row stay distinct.
+    return `${sourceIdentity}:${JSON.stringify(projection)}`;
+  } catch {
+    return sourceIdentity;
+  }
 }
 
 export type ChatPaneConnectionScope = {

--- a/ui/src/pages/chat/chat-pane-shared.ts
+++ b/ui/src/pages/chat/chat-pane-shared.ts
@@ -1,3 +1,4 @@
+import { stableStringify } from "@openclaw/normalization-core";
 import { asNullableRecord as catalogRawRecord } from "@openclaw/normalization-core/record-coerce";
 import type { SessionCatalogPullRequestSummary } from "../../../../packages/gateway-protocol/src/index.js";
 import type { ControlUiSessionPullRequest } from "../../../../src/gateway/control-ui-contract.js";
@@ -12,6 +13,7 @@ import { clampText } from "../../lib/format.ts";
 import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { releaseChatAttachmentPayloads } from "./attachment-payload-store.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { safeNormalizeMessage } from "./chat-turn-boundary.ts";
 
 export type ChatPageContext = ApplicationContext;
 export type PaneSessionChangeOptions = { replace?: boolean };
@@ -205,21 +207,36 @@ export function nativeHistoryMessageIdentity(message: unknown): string | null {
   const seq = metadata?.seq;
   const id = metadata?.id ?? record?.messageId;
   const sourceIdentity =
-    typeof seq === "number" && Number.isSafeInteger(seq) && seq > 0
-      ? `seq:${seq}`
-      : typeof id === "string" && id.trim()
-        ? `id:${id}`
+    typeof id === "string" && id.trim()
+      ? `id:${id}`
+      : typeof seq === "number" && Number.isSafeInteger(seq) && seq > 0
+        ? `seq:${seq}`
         : null;
   if (!sourceIdentity) {
     return null;
   }
-  try {
-    // One transcript record can project to multiple visible siblings. Include
-    // the projection bytes so partial page overlap removes the matching sibling.
-    return `${sourceIdentity}:${JSON.stringify(message)}`;
-  } catch {
-    return sourceIdentity;
-  }
+  const normalized = safeNormalizeMessage(message);
+  const normalizedProjection = normalized
+    ? (() => {
+        const { id: _id, sender, timestamp: _timestamp, ...visible } = normalized;
+        const { profileAvatarUrl: _profileAvatarUrl, ...stableSender } = sender ?? {};
+        return {
+          ...visible,
+          ...(Object.keys(stableSender).length > 0 ? { sender: stableSender } : {}),
+        };
+      })()
+    : { role: record?.role, content: record?.content ?? record?.text };
+  // One transcript record can project to multiple visible siblings. Pair its
+  // source with stable display facts, excluding delivery-only timing/run metadata.
+  return `${sourceIdentity}:${stableStringify({
+    message: normalizedProjection,
+    kind: metadata?.kind ?? record?.customType ?? record?.type,
+    toolCallId: record?.toolCallId ?? record?.tool_call_id ?? record?.callId ?? record?.call_id,
+    toolName: record?.toolName ?? record?.tool_name ?? record?.name ?? record?.tool,
+    mirror: record?.openclawMessageToolMirror,
+    details: record?.details,
+    provenance: record?.provenance,
+  })}`;
 }
 
 export type ChatPaneConnectionScope = {

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -2221,18 +2221,21 @@ describe("buildCachedChatItems", () => {
     expect(groupAt(groups, 0).messages).toHaveLength(1);
   });
 
-  it("collapses consecutive duplicate text messages into one rendered item with a count", () => {
+  it("collapses two distinct persisted rows with identical text into one rendered item", () => {
     const groups = messageGroups({
       messages: [
-        assistantMessage([{ type: "text", text: "Same update" }], 1),
-        assistantMessage([{ type: "text", text: "Same update" }], 2),
-        assistantMessage([{ type: "text", text: "Same update" }], 3),
+        assistantMessage([{ type: "text", text: "Same update" }], 1, {
+          __openclaw: { seq: 7 },
+        }),
+        assistantMessage([{ type: "text", text: "Same update" }], 2, {
+          __openclaw: { seq: 8 },
+        }),
       ],
     });
 
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).messages).toHaveLength(1);
-    expect(messageAt(groupAt(groups, 0), 0).duplicateCount).toBe(3);
+    expect(messageAt(groupAt(groups, 0), 0).duplicateCount).toBe(2);
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI could render one stored assistant message as two consecutive identical bubbles with the ×2 collapse badge, making users believe a reply was delivered twice even though the transcript contained only one stored row.

## Why This Change Was Made

The older-history overlap check keyed each projection on the entire serialized message, but stored history alone adds `__openclaw.recordTimestampMs`. The identity now removes only that proven delivery-only timestamp before applying the existing whole-projection `JSON.stringify` identity. Source precedence and every other projection byte remain unchanged, so distinct visible siblings from one transcript row stay distinct.

## User Impact

Users no longer see phantom duplicate replies after live events and history refreshes overlap. Legitimately repeated messages still collapse behind the existing count badge.

## Evidence

- Live evidence on `main` at `ae55a4090c4`: intermittent duplicate assistant bubble reproduced after `/steer`, `/redirect`, and a plain send during subagent activity, while `session_transcript_fts` contained exactly one stored assistant row for the marker.
- Pre-fix regression: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-history.test.ts` failed 1/26. The received live key omitted `__openclaw.recordTimestampMs`; the expected history key contained `recordTimestampMs: 1786000000000`, proving whole-message byte identity split one logical row.
- Post-fix: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-history.test.ts` — 26/26 passed.
- Sibling and legitimate-repeat coverage: `node scripts/run-vitest.mjs ui/src/pages/chat/chat-thread.test.ts` — 172/172 passed.
- Badge preservation: `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-message.test.ts -t "renders a compact count for collapsed duplicate messages"` — 1 passed.
- Source-blind behavior validation: all four contract clauses passed (cross-path dedupe, sibling preservation, real-row `n=2`, and rendered count badge).
- `node scripts/check-changed.mjs` — passed.
- `pnpm ui:build` — passed, including Control UI performance budgets.
- `node --import tsx scripts/check-control-ui-performance.mts` — passed directly after the build.
- Startup JS gzip: 345093 B before narrowing; 344776 B after narrowing (317 B smaller; 709 B below the 345485 B authoritative local limit).
- `.claude/skills/autoreview/scripts/autoreview --mode local` — clean; no accepted/actionable findings, correctness 0.98.
