### PR TITLE
fix(onboard): keep agent names on guided setup

### DIFF
--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -959,6 +959,7 @@ describe("setupWizardCommand", () => {
   });
 
   it.each([
+    ["--agent-name", { agentName: "robby" }],
     ["--tui", { tui: true }],
     ["--skip-ui", { skipUi: true }],
   ])("keeps %s on guided onboarding", async (_label, opts) => {

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -423,7 +423,7 @@ const GUIDED_SAFE_ONBOARD_KEYS = new Set([
   "reset",
   "resetScope",
   "nonInteractive",
-  "classic",
+  "agentName",
   "tui",
   "skipUi",
 ]);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running interactive `openclaw onboard --agent-name <name>` were sent to the classic wizard even though guided onboarding supports and consumes the requested agent name.

## Why This Change Was Made

The guided-routing allowlist omitted `agentName`, so the option was treated as a classic-only setup flag. This adds `agentName` to the existing allowlist and removes the redundant `classic` entry, which is already handled by the explicit early check. Production code remains +1/-1 (net zero).

## User Impact

Interactive onboarding with `--agent-name` now stays on guided setup and carries the requested name into that flow. Other explicit classic-only flags continue to select the classic wizard.

## Evidence

- Pre-fix regression case failed on the guided-routing expectation; the same case passes after the repair.
- `node scripts/run-vitest.mjs src/commands/onboard.test.ts` — 64/64 passed.
- `node scripts/check-changed.mjs -- src/commands/onboard.ts src/commands/onboard.test.ts` — passed all selected core and core-test gates, including formatting, typechecks, lint, ratchets, dependency guards, dead-code scans, and architecture guards.
- `node_modules/.bin/oxfmt --check src/commands/onboard.ts src/commands/onboard.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh autoreview completed with no actionable findings (correctness confidence 0.94).
- Exact head: `00e4855d39ebb30aaaf5135a17e967e4004e478f`.
- LOC: production +1/-1 (net zero); tests +1/-0.

No live-flow proof was run: this is a deterministic dispatch decision covered directly at the owner boundary.

AI-assisted: yes. The change and regression proof were reviewed and understood by the author.
