### PR TITLE
fix(ui): dedupe streamed final assistant messages

### DIFF
--- a/ui/src/pages/chat/chat-gateway.test.ts
+++ b/ui/src/pages/chat/chat-gateway.test.ts
@@ -855,6 +855,34 @@ describe("handleChatGatewayEvent", () => {
     expect(state.chatStreamSegments).toEqual([]);
   });
 
+  it("replaces an exact keyed final-answer stream with the persisted terminal", () => {
+    const user = { role: "user", content: [{ type: "text", text: "Ask" }], timestamp: 1 };
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatMessages: [user],
+      chatStream: null,
+      chatStreamStartedAt: null,
+    }) as ChatState & {
+      chatStreamSegments: Array<{ text: string; ts: number; itemId: string }>;
+    };
+    state.chatStreamSegments = [{ text: "Final answer.", ts: 2, itemId: "final-answer-1" }];
+
+    expect(
+      handleChatGatewayEvent(state, {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "final",
+        message: createTextChatMessage("assistant", "Final answer.", undefined, 5),
+      }),
+    ).toBe("final");
+
+    expect(state.chatMessages).toHaveLength(2);
+    expectTextChatMessage(state.chatMessages[0], "user", "Ask");
+    expectTextChatMessage(state.chatMessages[1], "assistant", "Final answer.");
+    expect(state.chatStreamSegments).toEqual([]);
+  });
+
   it("preserves an already-recorded stream boundary for a persisted steer", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/pages/chat/stream-reconciliation.ts
+++ b/ui/src/pages/chat/stream-reconciliation.ts
@@ -136,8 +136,13 @@ function buildAssistantStreamMessage(
   };
 }
 
-function unkeyedStreamFallbackMetadata(message: unknown): Record<string, unknown> | null {
+function streamFallbackMetadata(message: unknown): Record<string, unknown> | null {
   const metadata = asNullableRecord(asNullableRecord(message)?.openclawStreamFallback);
+  return metadata;
+}
+
+function unkeyedStreamFallbackMetadata(message: unknown): Record<string, unknown> | null {
+  const metadata = streamFallbackMetadata(message);
   return metadata && !normalizeOptionalString(metadata.itemId) ? metadata : null;
 }
 
@@ -168,14 +173,24 @@ export function appendTerminalAssistantMessage(messages: unknown[], message: unk
   let terminalCursor = 0;
   for (let index = interval.start; index < interval.end; index += 1) {
     const existing = messages[index];
-    const fallback = unkeyedStreamFallbackMetadata(existing);
+    const fallback = streamFallbackMetadata(existing);
     if (!fallback) {
+      continue;
+    }
+    const visibleText = extractText(existing)?.trim();
+    if (normalizeOptionalString(fallback.itemId)) {
+      // Keyed stream segments normally represent commentary and must remain
+      // beside the final answer. When a keyed segment is the exact final
+      // answer, though, retaining both renders the streamed and persisted
+      // copies as duplicate assistant messages.
+      if (visibleText && visibleText === terminalText) {
+        removedIndexes.add(index);
+      }
       continue;
     }
     if (fallback.source === "current") {
       currentFallbackIndexes.push(index);
     }
-    const visibleText = extractText(existing)?.trim();
     if (!visibleText) {
       continue;
     }


### PR DESCRIPTION
## Summary
- replace a keyed streamed assistant segment when it exactly matches the persisted terminal answer
- preserve distinct keyed commentary/preambles beside the final answer
- add a regression test for the duplicate live + persisted final-message rendering

## Root cause
The final-event path materialized keyed stream segments before appending the persisted terminal message. Keyed segments were always treated as commentary, so an exact final-answer segment survived and rendered immediately above the same persisted response.

## Validation
- `pnpm exec vitest run src/pages/chat/chat-gateway.test.ts src/pages/chat/stream-reconciliation.test.ts --config vitest.config.ts` (194 tests passed)
- `pnpm check:changed`
