### PR TITLE
fix(qa): wait for config restart wake

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.config-restart.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.config-restart.test.ts
@@ -1,0 +1,17 @@
+// Qa Lab tests cover config-restart scenario ordering.
+import { describe, expect, it } from "vitest";
+import { readQaScenarioById } from "./scenario-catalog.js";
+
+describe("QA config-restart scenario catalog", () => {
+  it("waits for the restart wake before using restored capabilities", () => {
+    const flow = JSON.stringify(readQaScenarioById("config-restart-capability-flip"));
+    const restartPatchIndex = flow.indexOf('"note":{"ref":"wakeMarker"}');
+    const wakeWaitIndex = flow.indexOf("candidate.text.includes(wakeMarker)");
+    const capabilityPollIndex = flow.indexOf('"saveAs":"afterTools"');
+
+    expect(restartPatchIndex).toBeGreaterThanOrEqual(0);
+    expect(wakeWaitIndex).toBeGreaterThan(restartPatchIndex);
+    expect(capabilityPollIndex).toBeGreaterThan(wakeWaitIndex);
+    expect(flow.indexOf('"call":"runAgentPrompt"')).toBeGreaterThan(capabilityPollIndex);
+  });
+});

--- a/qa/scenarios/config/config-restart-capability-flip.yaml
+++ b/qa/scenarios/config/config-restart-capability-flip.yaml
@@ -111,6 +111,9 @@ flow:
                                 ref: originalImageGenerationModelPrimary
                     sessionKey:
                       ref: sessionKey
+                    deliveryContext:
+                      channel: qa-channel
+                      to: dm:qa-operator
                     note:
                       ref: wakeMarker
                     replacePaths:
@@ -123,6 +126,13 @@ flow:
                 args:
                   - ref: env
                   - 60000
+              - call: waitForOutboundMessage
+                args:
+                  - ref: state
+                  - lambda:
+                      params: [candidate]
+                      expr: "candidate.conversation.id === 'qa-operator' && candidate.text.includes(wakeMarker)"
+                  - expr: liveTurnTimeoutMs(env, config.imageTurnTimeoutMs)
               - call: waitForCondition
                 saveAs: afterTools
                 args:


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the QA config-restart scenario could poll restored capabilities and start its follow-up turn before the restarted gateway had delivered the session wake message.

## Why This Change Was Made

Restores the scenario's explicit `qa-channel` delivery context and waits for the unique wake marker before capability polling. A catalog regression assertion preserves the required restart patch, wake wait, then prompt ordering.

## User Impact

No product behavior changes. Release qualification no longer races the config restart wake path.

## Evidence

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.config-restart.test.ts` - 1 passed
- `node scripts/run-oxlint.mjs extensions/qa-lab/src/scenario-catalog.config-restart.test.ts` - passed
- targeted `oxfmt --check` - passed
- `git diff --check` - passed
- changed-file gate static guards and full typecheck - passed
- Production LOC: +0/-0 | QA fixture/tests: +27/-0
