### PR TITLE
fix(qa): prevent reserved gateway port startup deadlock

### DIFF
--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -3,7 +3,6 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { createWriteStream, existsSync, type WriteStream } from "node:fs";
 import fs from "node:fs/promises";
-import net from "node:net";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -501,7 +500,7 @@ export async function startQaGatewayChild(params: {
     };
     for (let attempt = 1; attempt <= QA_GATEWAY_CHILD_STARTUP_MAX_ATTEMPTS; attempt += 1) {
       if (!reuseStartupLaunchState) {
-        gatewayPortReservation = await reserveQaGatewayPort(() => net.createServer());
+        gatewayPortReservation = await reserveQaGatewayPort();
         gatewayPort = gatewayPortReservation.port;
         baseUrl = `http://127.0.0.1:${gatewayPort}`;
         wsUrl = `ws://127.0.0.1:${gatewayPort}`;

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -3,6 +3,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { createWriteStream, existsSync, type WriteStream } from "node:fs";
 import fs from "node:fs/promises";
+import net from "node:net";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -500,7 +501,7 @@ export async function startQaGatewayChild(params: {
     };
     for (let attempt = 1; attempt <= QA_GATEWAY_CHILD_STARTUP_MAX_ATTEMPTS; attempt += 1) {
       if (!reuseStartupLaunchState) {
-        gatewayPortReservation = await reserveQaGatewayPort();
+        gatewayPortReservation = await reserveQaGatewayPort(net.createServer());
         gatewayPort = gatewayPortReservation.port;
         baseUrl = `http://127.0.0.1:${gatewayPort}`;
         wsUrl = `ws://127.0.0.1:${gatewayPort}`;

--- a/extensions/qa-lab/src/gateway-port-reservation.test.ts
+++ b/extensions/qa-lab/src/gateway-port-reservation.test.ts
@@ -1,5 +1,7 @@
 // Qa Lab tests cover Gateway port reservation behavior.
+import { once } from "node:events";
 import net from "node:net";
+import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import { reserveQaGatewayPort } from "./gateway-port-reservation.js";
 
@@ -29,12 +31,35 @@ async function bindReservedPort(port: number) {
 
 describe("reserveQaGatewayPort", () => {
   it("keeps the selected port unavailable until release", async () => {
-    const reservation = await reserveQaGatewayPort(() => net.createServer());
+    const reservation = await reserveQaGatewayPort();
 
     await expect(bindReservedPort(reservation.port)).rejects.toMatchObject({ code: "EADDRINUSE" });
     await reservation.release();
 
     await expect(bindReservedPort(reservation.port)).resolves.toBeInstanceOf(net.Server);
     await expect(reservation.release()).resolves.toBeUndefined();
+  });
+
+  it("closes probes before releasing the reserved port", async () => {
+    const reservation = await reserveQaGatewayPort();
+    const probe = net.createConnection({ host: "127.0.0.1", port: reservation.port });
+    const probeClosed = new Promise<void>((resolve) => {
+      probe.once("close", () => resolve());
+    });
+    probe.on("error", () => {});
+
+    try {
+      await once(probe, "connect");
+      const released = reservation.release();
+      const outcome = await Promise.race([
+        Promise.all([probeClosed, released]).then(() => "released"),
+        delay(250, "probe remained open and release stayed pending"),
+      ]);
+
+      expect(outcome).toBe("released");
+    } finally {
+      probe.destroy();
+      await reservation.release();
+    }
   });
 });

--- a/extensions/qa-lab/src/gateway-port-reservation.test.ts
+++ b/extensions/qa-lab/src/gateway-port-reservation.test.ts
@@ -31,7 +31,7 @@ async function bindReservedPort(port: number) {
 
 describe("reserveQaGatewayPort", () => {
   it("keeps the selected port unavailable until release", async () => {
-    const reservation = await reserveQaGatewayPort();
+    const reservation = await reserveQaGatewayPort(net.createServer());
 
     await expect(bindReservedPort(reservation.port)).rejects.toMatchObject({ code: "EADDRINUSE" });
     await reservation.release();
@@ -41,7 +41,7 @@ describe("reserveQaGatewayPort", () => {
   });
 
   it("closes probes before releasing the reserved port", async () => {
-    const reservation = await reserveQaGatewayPort();
+    const reservation = await reserveQaGatewayPort(net.createServer());
     const probe = net.createConnection({ host: "127.0.0.1", port: reservation.port });
     const probeClosed = new Promise<void>((resolve) => {
       probe.once("close", () => resolve());

--- a/extensions/qa-lab/src/gateway-port-reservation.ts
+++ b/extensions/qa-lab/src/gateway-port-reservation.ts
@@ -1,14 +1,10 @@
 // Qa Lab plugin module reserves Gateway ports across pre-spawn setup.
-type QaGatewayPortServer = {
-  once(event: "error", listener: (error: Error) => void): void;
-  off(event: "error", listener: (error: Error) => void): void;
-  listen(port: number, host: string, listener: () => void): void;
-  address(): { port: number } | string | null;
-  close(callback?: (error?: Error) => void): void;
-};
+import net from "node:net";
 
-export async function reserveQaGatewayPort(createServer: () => QaGatewayPortServer) {
-  const server = createServer();
+export async function reserveQaGatewayPort() {
+  // This reserves a bind address; it must not impersonate a usable Gateway or
+  // retain probes that would prevent release immediately before the real bind.
+  const server = net.createServer((socket) => socket.destroy());
   const port = await new Promise<number>((resolve, reject) => {
     const handleError = (error: Error) => {
       server.close(() => {});

--- a/extensions/qa-lab/src/gateway-port-reservation.ts
+++ b/extensions/qa-lab/src/gateway-port-reservation.ts
@@ -1,10 +1,16 @@
 // Qa Lab plugin module reserves Gateway ports across pre-spawn setup.
-import net from "node:net";
+type QaGatewayPortServer = {
+  once(event: "error", listener: (error: Error) => void): void;
+  off(event: "error", listener: (error: Error) => void): void;
+  on(event: "connection", listener: (socket: { destroy(): void }) => void): void;
+  listen(port: number, host: string, listener: () => void): void;
+  address(): { port: number } | string | null;
+  close(callback?: (error?: Error) => void): void;
+};
 
-export async function reserveQaGatewayPort() {
-  // This reserves a bind address; it must not impersonate a usable Gateway or
-  // retain probes that would prevent release immediately before the real bind.
-  const server = net.createServer((socket) => socket.destroy());
+export async function reserveQaGatewayPort(server: QaGatewayPortServer) {
+  // Reject probes so release cannot wait on accepted sockets.
+  server.on("connection", (socket) => socket.destroy());
   const port = await new Promise<number>((resolve, reject) => {
     const handleError = (error: Error) => {
       server.close(() => {});


### PR DESCRIPTION
AI-assisted: Yes. The implementation and validation used AI coding tools, with a clean final autoreview.

## What Problem This Solves

Fixes an issue where QA flows that stage packaged authentication before launching an isolated Gateway could hang until their outer test timeout. The reserved Gateway port accepted an internal probe connection, and release then waited indefinitely before the real Gateway process was spawned. This surfaced in the real Gateway/node MCP stress suite as a 180-second timeout and an orphaned fixture process.

## Why This Change Was Made

The port-reservation owner now immediately closes any probe connection while continuing to hold the bind address through staging. Socket creation remains at the existing Gateway-child network boundary, while release stays idempotent and occurs immediately before the real Gateway bind.

## User Impact

There is no production runtime or user-visible behavior change. QA Gateway launches no longer deadlock when staged CLI work probes the reserved port, so real-process integration tests fail or proceed at their actual product boundary instead of timing out before Gateway startup.

## Evidence

- Pre-fix real-process reproduction: `gateway-node-mcp.stress.e2e.test.ts` exhausted its 180-second test budget; the preserved QA root had completed both auth writes but had empty Gateway logs, proving no Gateway child was spawned.
- The focused regression failed before the fix with `Expected: "released"` / `Received: "probe remained open and release stayed pending"`.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-port-reservation.test.ts` — 2/2 passed on final head.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/gateway-child.test.ts` — 87/87 passed on final head.
- `node scripts/check-changed.mjs -- extensions/qa-lab/src/gateway-port-reservation.ts extensions/qa-lab/src/gateway-port-reservation.test.ts extensions/qa-lab/src/gateway-child.ts` — passed on final head.
- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-node-mcp.stress.e2e.test.ts` — passed on final head in 26.80 seconds; transport recovery, stateful expiry, and descendant cleanup assertions all completed.
- Final Codex autoreview — clean, no accepted/actionable findings.
- The first PR head moved the existing `node:net` import into the helper and correctly triggered the network-runtime boundary scanner. The final head keeps socket construction in the already-classified Gateway owner while the helper owns connection rejection; focused proof and autoreview were rerun after that refinement.

Production LOC: +5/-3 (net +2), justified by the lifecycle invariant that accepted probes cannot block reservation release. Tests: +26/-1.
