### PR TITLE
refactor(llama-cpp): adopt canonical runtime owners

### DIFF
--- a/extensions/llama-cpp/src/external-server/auth.test.ts
+++ b/extensions/llama-cpp/src/external-server/auth.test.ts
@@ -7,6 +7,13 @@ import {
 } from "./auth.js";
 
 describe("llama-server auth", () => {
+  it.each([undefined, null, [], "Bearer proxy-token"])(
+    "rejects a non-record authorization header container: %j",
+    (headers) => {
+      expect(hasLlamaServerAuthorizationHeader(headers)).toBe(false);
+    },
+  );
+
   it("uses synthetic runtime auth for no-auth and header-only providers", () => {
     expect(
       shouldUseLlamaServerSyntheticAuth({ baseUrl: "http://localhost:8080/v1", models: [] }),
@@ -70,5 +77,18 @@ describe("llama-server auth", () => {
         headers: config.models.providers["llama-server"].headers,
       }),
     ).resolves.toEqual({ "X-Proxy-Key": "proxy-token" });
+  });
+
+  it("filters and trims plain provider headers without config", async () => {
+    await expect(
+      resolveLlamaServerProviderHeaders({
+        headers: {
+          "X-Proxy-Key": " proxy-token ",
+          "X-Empty": " ",
+          "X-Invalid": 42,
+        },
+      }),
+    ).resolves.toEqual({ "X-Proxy-Key": "proxy-token" });
+    await expect(resolveLlamaServerProviderHeaders({ headers: [] })).resolves.toBeUndefined();
   });
 });

--- a/extensions/llama-cpp/src/external-server/auth.ts
+++ b/extensions/llama-cpp/src/external-server/auth.ts
@@ -8,13 +8,15 @@ import {
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { resolveConfiguredSecretInputString } from "openclaw/plugin-sdk/secret-input-runtime";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { LLAMA_SERVER_LOCAL_AUTH_MARKER, LLAMA_SERVER_PROVIDER_ID } from "./defaults.js";
 
 export function hasLlamaServerAuthorizationHeader(headers: unknown): boolean {
-  if (!headers || typeof headers !== "object" || Array.isArray(headers)) {
+  const record = asOptionalRecord(headers);
+  if (!record) {
     return false;
   }
-  return Object.entries(headers).some(
+  return Object.entries(record).some(
     ([name, value]) =>
       name.trim().toLowerCase() === "authorization" && hasConfiguredSecretInput(value),
   );
@@ -56,11 +58,12 @@ export async function resolveLlamaServerProviderHeaders(params: {
   env?: NodeJS.ProcessEnv;
   headers?: unknown;
 }): Promise<Record<string, string> | undefined> {
-  if (!params.headers || typeof params.headers !== "object" || Array.isArray(params.headers)) {
+  const headers = asOptionalRecord(params.headers);
+  if (!headers) {
     return undefined;
   }
   const resolved: Record<string, string> = {};
-  for (const [name, value] of Object.entries(params.headers)) {
+  for (const [name, value] of Object.entries(headers)) {
     if (!params.config) {
       if (typeof value === "string" && value.trim()) {
         resolved[name] = value.trim();

--- a/extensions/llama-cpp/src/external-server/discovery.test.ts
+++ b/extensions/llama-cpp/src/external-server/discovery.test.ts
@@ -1,5 +1,6 @@
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { discoverLlamaServer } from "./discovery.js";
 
 type LlamaServerFetchGuard = typeof fetchWithSsrFGuard;
@@ -40,6 +41,10 @@ function json(value: unknown, status = 200): Response {
 }
 
 describe("llama-server discovery", () => {
+  beforeEach(() => {
+    clearLiveCatalogCacheForTests();
+  });
+
   it("discovers a single model and reads runtime properties", async () => {
     const { guard, requests } = createFetchGuard({
       "http://localhost:8080/health": json({ status: "ok" }),
@@ -201,6 +206,60 @@ describe("llama-server discovery", () => {
     expect(requests.filter((url) => url.includes("/props?"))).toHaveLength(8);
   });
 
+  it("keeps router properties associated with their model when probes finish out of order", async () => {
+    const rows = [0, 1, 2].map((index) => ({
+      id: `model-${index}`,
+      object: "model",
+      status: { value: "loaded" },
+    }));
+    const routes: Record<string, RouteValue> = {
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ data: rows }),
+    };
+    for (const [index, row] of rows.entries()) {
+      routes[`http://localhost:8080/props?model=${row.id}&autoload=false`] = async () => {
+        await new Promise((resolve) => {
+          setTimeout(resolve, (2 - index) * 5);
+        });
+        return json({ default_generation_settings: { n_ctx: 8_000 + index } });
+      };
+    }
+    const { guard } = createFetchGuard(routes);
+
+    const result = await discoverTest({
+      baseUrl: "http://localhost:8080",
+      fetchGuard: guard,
+    });
+
+    expect(
+      result.kind === "success" ? result.models.map((model) => model.config.contextWindow) : [],
+    ).toEqual([8_000, 8_001, 8_002]);
+  });
+
+  it("caps router property probes at 200 models", async () => {
+    const rows = Array.from({ length: 205 }, (_, index) => ({
+      id: `model-${index}`,
+      object: "model",
+      status: { value: "loaded" },
+    }));
+    const routes: Record<string, RouteValue> = {
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ data: rows }),
+    };
+    for (const row of rows.slice(0, 200)) {
+      routes[`http://localhost:8080/props?model=${row.id}&autoload=false`] = json({});
+    }
+    const { guard, requests } = createFetchGuard(routes);
+
+    const result = await discoverTest({
+      baseUrl: "http://localhost:8080",
+      fetchGuard: guard,
+    });
+
+    expect(result.kind === "success" ? result.models : []).toHaveLength(205);
+    expect(requests.filter((url) => url.includes("/props?"))).toHaveLength(200);
+  });
+
   it("falls back to /v1/models for an older compatible server", async () => {
     const { guard } = createFetchGuard({
       "http://localhost:8080/health": json({ status: "ok" }),
@@ -311,6 +370,131 @@ describe("llama-server discovery", () => {
       cacheTtlMs: 30_000,
     });
     expect(guard).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent discovery for the same uncredentialed endpoint", async () => {
+    let releaseHealth: ((response: Response) => void) | undefined;
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": () =>
+        new Promise<Response>((resolve) => {
+          releaseHealth = resolve;
+        }),
+      "http://localhost:8080/models": () => json({ data: [] }),
+    });
+
+    const first = discoverTest({
+      baseUrl: "http://localhost:8080",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+      cacheTtlMs: 30_000,
+    });
+    const second = discoverTest({
+      baseUrl: "http://localhost:8080",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+      cacheTtlMs: 30_000,
+    });
+
+    expect(releaseHealth).toBeDefined();
+    expect(guard).toHaveBeenCalledTimes(1);
+    releaseHealth?.(json({ status: "ok" }));
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      expect.objectContaining({ kind: "success" }),
+      expect.objectContaining({ kind: "success" }),
+    ]);
+    expect(guard).toHaveBeenCalledTimes(2);
+  });
+
+  it("reloads cached discovery after its configured TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(1_000);
+      const { guard } = createFetchGuard({
+        "http://localhost:8080/health": () => json({ status: "ok" }),
+        "http://localhost:8080/models": () => json({ data: [] }),
+      });
+
+      await discoverTest({
+        baseUrl: "http://localhost:8080",
+        apiKey: "custom-local",
+        fetchGuard: guard,
+        cacheTtlMs: 100,
+      });
+      vi.setSystemTime(1_101);
+      await discoverTest({
+        baseUrl: "http://localhost:8080",
+        apiKey: "custom-local",
+        fetchGuard: guard,
+        cacheTtlMs: 100,
+      });
+
+      expect(guard).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not retain unsuccessful discovery results", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": () => json({ error: "unauthorized" }, 401),
+    });
+
+    for (let index = 0; index < 2; index += 1) {
+      await discoverTest({
+        baseUrl: "http://localhost:8080",
+        apiKey: "custom-local",
+        fetchGuard: guard,
+        cacheTtlMs: 30_000,
+      });
+    }
+
+    expect(guard).toHaveBeenCalledTimes(2);
+  });
+
+  it("bypasses an existing endpoint cache when a real API key is supplied", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": () => json({ status: "ok" }),
+      "http://localhost:8080/models": () => json({ data: [] }),
+    });
+
+    await discoverTest({
+      baseUrl: "http://localhost:8080",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+      cacheTtlMs: 30_000,
+    });
+    await discoverTest({
+      baseUrl: "http://localhost:8080",
+      apiKey: "real-secret",
+      fetchGuard: guard,
+      cacheTtlMs: 30_000,
+    });
+
+    expect(guard).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps uncredentialed discovery caches isolated by endpoint", async () => {
+    const { guard } = createFetchGuard({
+      "http://localhost:8080/health": json({ status: "ok" }),
+      "http://localhost:8080/models": json({ data: [] }),
+      "http://localhost:8081/health": json({ status: "ok" }),
+      "http://localhost:8081/models": json({ data: [] }),
+    });
+
+    await discoverTest({
+      baseUrl: "http://localhost:8080",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+      cacheTtlMs: 30_000,
+    });
+    await discoverTest({
+      baseUrl: "http://localhost:8081",
+      apiKey: "custom-local",
+      fetchGuard: guard,
+      cacheTtlMs: 30_000,
+    });
+
+    expect(guard).toHaveBeenCalledTimes(4);
   });
 
   it("bounds cached endpoint discovery", async () => {

--- a/extensions/llama-cpp/src/external-server/discovery.ts
+++ b/extensions/llama-cpp/src/external-server/discovery.ts
@@ -1,14 +1,17 @@
+import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import { isNonSecretApiKeyMarker } from "openclaw/plugin-sdk/provider-auth";
+import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
 } from "openclaw/plugin-sdk/ssrf-runtime";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { asOptionalRecord, isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { buildLlamaServerAuthHeaders } from "./auth.js";
 import {
   LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS,
   LLAMA_SERVER_DISCOVERY_TIMEOUT_MS,
+  LLAMA_SERVER_PROVIDER_ID,
 } from "./defaults.js";
 import { resolveLlamaServerEndpoint } from "./endpoint.js";
 import {
@@ -53,32 +56,8 @@ type FetchJsonResult =
   | { kind: "unreachable"; error: unknown }
   | { kind: "invalid-response"; error: unknown };
 
-type CachedDiscovery = {
-  expiresAt: number;
-  result: Extract<LlamaServerDiscoveryResult, { kind: "success" }>;
-};
-
-const discoveryCache = new Map<string, CachedDiscovery>();
-const LLAMA_SERVER_DISCOVERY_CACHE_MAX_ENTRIES = 100;
 const LLAMA_SERVER_ROUTER_PROPS_MAX_MODELS = 200;
 const LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY = 8;
-
-function cacheDiscovery(key: string, entry: CachedDiscovery, now: number): void {
-  for (const [cachedKey, cached] of discoveryCache) {
-    if (cached.expiresAt <= now) {
-      discoveryCache.delete(cachedKey);
-    }
-  }
-  discoveryCache.delete(key);
-  discoveryCache.set(key, entry);
-  while (discoveryCache.size > LLAMA_SERVER_DISCOVERY_CACHE_MAX_ENTRIES) {
-    const oldest = discoveryCache.keys().next();
-    if (oldest.done) {
-      break;
-    }
-    discoveryCache.delete(oldest.value);
-  }
-}
 
 async function fetchJson(params: {
   url: string;
@@ -131,17 +110,15 @@ async function fetchJson(params: {
 }
 
 function readModelRows(body: unknown): LlamaServerModelWire[] {
-  if (!isRecord(body)) {
+  const record = asOptionalRecord(body);
+  if (!record) {
     throw new Error("llama-server model list must be an object");
   }
-  const data = body.data;
+  const data = record.data;
   if (!Array.isArray(data)) {
     throw new Error("llama-server model list must contain data[]");
   }
-  return data.filter(
-    (entry): entry is LlamaServerModelWire =>
-      Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
-  );
+  return data.filter((entry): entry is LlamaServerModelWire => isRecord(entry));
 }
 
 function shouldReadProps(row: LlamaServerModelWire): boolean {
@@ -178,8 +155,7 @@ async function readModelProps(params: {
   return result.kind === "response" && result.ok && isRecord(result.body) ? result.body : undefined;
 }
 
-/** Discovers llama-server models without loading, waking, or unloading them. */
-export async function discoverLlamaServer(params: {
+type DiscoverLlamaServerParams = {
   baseUrl?: string;
   apiKey?: string;
   headers?: Record<string, string>;
@@ -187,23 +163,12 @@ export async function discoverLlamaServer(params: {
   cacheTtlMs?: number;
   signal?: AbortSignal;
   fetchGuard?: LlamaServerFetchGuard;
-}): Promise<LlamaServerDiscoveryResult> {
-  const endpoint = resolveLlamaServerEndpoint(params.baseUrl);
-  const normalizedApiKey = params.apiKey?.trim();
-  const hasCredentialScope =
-    Boolean(normalizedApiKey && !isNonSecretApiKeyMarker(normalizedApiKey)) ||
-    Boolean(params.headers && Object.keys(params.headers).length > 0);
-  const cacheTtlMs = hasCredentialScope
-    ? 0
-    : Math.max(0, params.cacheTtlMs ?? LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS);
-  const cached = discoveryCache.get(endpoint.origin);
-  if (cacheTtlMs > 0 && cached) {
-    if (cached.expiresAt > Date.now()) {
-      return cached.result;
-    }
-    discoveryCache.delete(endpoint.origin);
-  }
+};
 
+async function loadLlamaServerDiscovery(
+  params: DiscoverLlamaServerParams,
+  endpoint: ReturnType<typeof resolveLlamaServerEndpoint>,
+): Promise<LlamaServerDiscoveryResult> {
   const timeoutMs = params.timeoutMs ?? LLAMA_SERVER_DISCOVERY_TIMEOUT_MS;
   const fetchGuard = params.fetchGuard ?? fetchWithSsrFGuard;
   const healthResult = await fetchJson({
@@ -296,40 +261,35 @@ export async function discoverLlamaServer(params: {
     .map((row, index) => (shouldReadProps(row) ? index : -1))
     .filter((index) => index >= 0)
     .slice(0, LLAMA_SERVER_ROUTER_PROPS_MAX_MODELS);
-  for (
-    let offset = 0;
-    offset < propsRowIndexes.length;
-    offset += LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY
-  ) {
-    const remainingMs = propsDeadline - Date.now();
-    if (remainingMs <= 0) {
-      break;
-    }
-    const results = await Promise.all(
-      propsRowIndexes
-        .slice(offset, offset + LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY)
-        .map(async (index) => {
-          const row = rows[index];
-          if (!row) {
-            return undefined;
-          }
-          const props = await readModelProps({
-            row,
-            routerMode,
-            origin: endpoint.origin,
-            apiKey: params.apiKey,
-            headers: params.headers,
-            timeoutMs: Math.min(timeoutMs, remainingMs),
-            signal: params.signal,
-            fetchGuard,
-          });
-          return props ? ([index, props] as const) : undefined;
-        }),
-    );
-    for (const result of results) {
-      if (result) {
-        propsByRowIndex.set(...result);
+  const { results: propsResults } = await runTasksWithConcurrency({
+    limit: LLAMA_SERVER_ROUTER_PROPS_CONCURRENCY,
+    errorMode: "stop",
+    throwOnError: true,
+    tasks: propsRowIndexes.map((index) => async () => {
+      const remainingMs = propsDeadline - Date.now();
+      if (remainingMs <= 0) {
+        return undefined;
       }
+      const row = rows[index];
+      if (!row) {
+        return undefined;
+      }
+      const props = await readModelProps({
+        row,
+        routerMode,
+        origin: endpoint.origin,
+        apiKey: params.apiKey,
+        headers: params.headers,
+        timeoutMs: Math.min(timeoutMs, remainingMs),
+        signal: params.signal,
+        fetchGuard,
+      });
+      return props ? ([index, props] as const) : undefined;
+    }),
+  });
+  for (const result of propsResults) {
+    if (result) {
+      propsByRowIndex.set(...result);
     }
   }
   const models = rows.flatMap((row, index) => {
@@ -338,9 +298,29 @@ export async function discoverLlamaServer(params: {
   });
 
   const fetchedAt = Date.now();
-  const result = { kind: "success", endpoint, health, models, fetchedAt } as const;
-  if (cacheTtlMs > 0) {
-    cacheDiscovery(endpoint.origin, { result, expiresAt: fetchedAt + cacheTtlMs }, fetchedAt);
+  return { kind: "success", endpoint, health, models, fetchedAt };
+}
+
+/** Discovers llama-server models without loading, waking, or unloading them. */
+export async function discoverLlamaServer(
+  params: DiscoverLlamaServerParams,
+): Promise<LlamaServerDiscoveryResult> {
+  const endpoint = resolveLlamaServerEndpoint(params.baseUrl);
+  const normalizedApiKey = params.apiKey?.trim();
+  const hasCredentialScope =
+    Boolean(normalizedApiKey && !isNonSecretApiKeyMarker(normalizedApiKey)) ||
+    Boolean(params.headers && Object.keys(params.headers).length > 0);
+  const cacheTtlMs = hasCredentialScope
+    ? 0
+    : Math.max(0, params.cacheTtlMs ?? LLAMA_SERVER_DISCOVERY_CACHE_TTL_MS);
+  const load = async () => await loadLlamaServerDiscovery(params, endpoint);
+  if (cacheTtlMs === 0) {
+    return await load();
   }
-  return result;
+  return await getCachedLiveCatalogValue({
+    keyParts: [LLAMA_SERVER_PROVIDER_ID, endpoint.origin],
+    load,
+    shouldCache: (result) => result.kind === "success",
+    ttlMs: cacheTtlMs,
+  });
 }

--- a/extensions/llama-cpp/src/external-server/provider.test.ts
+++ b/extensions/llama-cpp/src/external-server/provider.test.ts
@@ -237,6 +237,87 @@ describe("llama-server provider catalog", () => {
     });
   });
 
+  it("moves a refreshed dynamic scope to the newest eviction position", async () => {
+    discoverMock.mockResolvedValue(success());
+    const contexts = Array.from(
+      { length: 101 },
+      (_, index) =>
+        ({
+          config: {},
+          provider: "llama-server",
+          modelId: "org/model:Q4",
+          modelRegistry: {},
+          agentRuntimeId: `refresh-runtime-${index}`,
+          providerConfig: {
+            baseUrl: "http://localhost:8080/v1",
+            api: "openai-completions",
+          },
+        }) as unknown as ProviderPrepareDynamicModelContext,
+    );
+
+    for (const ctx of contexts.slice(0, 100)) {
+      await prepareLlamaServerDynamicModels(ctx);
+    }
+    await prepareLlamaServerDynamicModels(contexts[0]!);
+    await prepareLlamaServerDynamicModels(contexts[100]!);
+
+    expect(resolveLlamaServerDynamicModel(contexts[0]!)).toMatchObject({ id: "org/model:Q4" });
+    expect(resolveLlamaServerDynamicModel(contexts[1]!)).toBeUndefined();
+  });
+
+  it("keeps dynamic snapshots separate when only the endpoint changes", async () => {
+    discoverMock.mockResolvedValueOnce(success()).mockResolvedValueOnce({
+      ...success(),
+      models: [{ ...model(), config: { ...model().config, name: "second endpoint" } }],
+    });
+    const base = {
+      config: {},
+      provider: "llama-server",
+      modelId: "org/model:Q4",
+      modelRegistry: {},
+      agentRuntimeId: "endpoint-runtime",
+      authProfileId: "endpoint-profile",
+    };
+    const first = {
+      ...base,
+      providerConfig: { baseUrl: "http://localhost:8080/v1", api: "openai-completions" },
+    } as unknown as ProviderPrepareDynamicModelContext;
+    const second = {
+      ...base,
+      providerConfig: { baseUrl: "http://localhost:8081/v1", api: "openai-completions" },
+    } as unknown as ProviderPrepareDynamicModelContext;
+
+    await prepareLlamaServerDynamicModels(first);
+    await prepareLlamaServerDynamicModels(second);
+
+    expect(resolveLlamaServerDynamicModel(first)?.name).toBe("org/model:Q4");
+    expect(resolveLlamaServerDynamicModel(second)?.name).toBe("second endpoint");
+  });
+
+  it("clears a scope snapshot when its refresh cannot discover the server", async () => {
+    discoverMock.mockResolvedValueOnce(success()).mockResolvedValueOnce({
+      kind: "unreachable",
+      endpoint: { origin: "http://localhost:8080", inferenceBaseUrl: "http://localhost:8080/v1" },
+      error: new Error("offline"),
+    });
+    const ctx = {
+      config: {},
+      provider: "llama-server",
+      modelId: "org/model:Q4",
+      modelRegistry: {},
+      agentRuntimeId: "failed-refresh-runtime",
+      providerConfig: {
+        baseUrl: "http://localhost:8080/v1",
+        api: "openai-completions",
+      },
+    } as unknown as ProviderPrepareDynamicModelContext;
+
+    await prepareLlamaServerDynamicModels(ctx);
+    expect(resolveLlamaServerDynamicModel(ctx)).toMatchObject({ id: "org/model:Q4" });
+    await prepareLlamaServerDynamicModels(ctx);
+    expect(resolveLlamaServerDynamicModel(ctx)).toBeUndefined();
+  });
+
   it("refreshes and resolves dynamic model ids containing slashes", async () => {
     discoverMock.mockResolvedValue(success());
     const ctx = {

--- a/extensions/llama-cpp/src/external-server/provider.ts
+++ b/extensions/llama-cpp/src/external-server/provider.ts
@@ -1,3 +1,4 @@
+import { pruneMapToMaxSize } from "openclaw/plugin-sdk/collection-runtime";
 import type {
   ProviderCatalogContext,
   ProviderPrepareDynamicModelContext,
@@ -23,13 +24,7 @@ const LLAMA_SERVER_DYNAMIC_MODEL_MAX_SCOPES = 100;
 function cacheDynamicModels(key: string, models: ProviderRuntimeModel[]): void {
   dynamicModels.delete(key);
   dynamicModels.set(key, models);
-  while (dynamicModels.size > LLAMA_SERVER_DYNAMIC_MODEL_MAX_SCOPES) {
-    const oldest = dynamicModels.keys().next();
-    if (oldest.done) {
-      break;
-    }
-    dynamicModels.delete(oldest.value);
-  }
+  pruneMapToMaxSize(dynamicModels, LLAMA_SERVER_DYNAMIC_MODEL_MAX_SCOPES);
 }
 
 function dynamicModelScopeKey(

--- a/extensions/llama-cpp/src/external-server/setup.test.ts
+++ b/extensions/llama-cpp/src/external-server/setup.test.ts
@@ -15,11 +15,11 @@ import {
 
 const discoverMock = vi.hoisted(() => vi.fn());
 const runtimeApiKeyMock = vi.hoisted(() => vi.fn());
-const updateAuthProfileStoreMock = vi.hoisted(() => vi.fn());
+const removeProviderAuthProfilesWithLockMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>()),
-  updateAuthProfileStoreWithLock: updateAuthProfileStoreMock,
+  removeProviderAuthProfilesWithLock: removeProviderAuthProfilesWithLockMock,
 }));
 
 vi.mock("./discovery.js", async (importOriginal) => ({
@@ -87,8 +87,8 @@ describe("llama-server setup", () => {
     discoverMock.mockReset();
     runtimeApiKeyMock.mockReset();
     runtimeApiKeyMock.mockResolvedValue(undefined);
-    updateAuthProfileStoreMock.mockReset();
-    updateAuthProfileStoreMock.mockResolvedValue({ version: 1, profiles: {} });
+    removeProviderAuthProfilesWithLockMock.mockReset();
+    removeProviderAuthProfilesWithLockMock.mockResolvedValue({ version: 1, profiles: {} });
   });
 
   it("detects a running local server without writing config", async () => {
@@ -224,9 +224,10 @@ describe("llama-server setup", () => {
     expect(provider?.apiKey).toBeUndefined();
     expect(provider?.headers).toEqual({ "X-Tenant": "one" });
     expect(result.defaultModel).toBe("llama-server/qwen/model:Q4_K_M");
-    expect(updateAuthProfileStoreMock).toHaveBeenCalledWith({
+    expect(removeProviderAuthProfilesWithLockMock).toHaveBeenCalledWith({
       agentDir: undefined,
-      updater: expect.any(Function),
+      provider: "llama-server",
+      profileIds: ["llama-server:default"],
     });
     expect(result.configPatch?.auth).toBeUndefined();
   });
@@ -444,9 +445,10 @@ describe("llama-server setup", () => {
     expect(configured?.agents?.defaults?.model).toEqual(
       expect.objectContaining({ primary: "llama-server/qwen/model:Q4_K_M" }),
     );
-    expect(updateAuthProfileStoreMock).toHaveBeenCalledWith({
+    expect(removeProviderAuthProfilesWithLockMock).toHaveBeenCalledWith({
       agentDir: undefined,
-      updater: expect.any(Function),
+      provider: "llama-server",
+      profileIds: ["llama-server:default"],
     });
     expect(configured?.auth).toEqual({ profiles: {}, order: undefined });
   });

--- a/extensions/llama-cpp/src/external-server/setup.ts
+++ b/extensions/llama-cpp/src/external-server/setup.ts
@@ -9,7 +9,7 @@ import {
   buildApiKeyCredential,
   ensureApiKeyFromEnvOrPrompt,
   normalizeOptionalSecretInput,
-  updateAuthProfileStoreWithLock,
+  removeProviderAuthProfilesWithLock,
   upsertAuthProfileWithLock,
   type OpenClawConfig,
   type SecretInput,
@@ -242,47 +242,10 @@ function buildSetupResult(params: {
 }
 
 async function removeDefaultAuthProfile(agentDir?: string): Promise<void> {
-  const updated = await updateAuthProfileStoreWithLock({
+  const updated = await removeProviderAuthProfilesWithLock({
     agentDir,
-    updater: (store) => {
-      let changed = false;
-      if (store.profiles[PROFILE_ID]) {
-        delete store.profiles[PROFILE_ID];
-        changed = true;
-      }
-      if (store.usageStats?.[PROFILE_ID]) {
-        delete store.usageStats[PROFILE_ID];
-        changed = true;
-      }
-      for (const [provider, order] of Object.entries(store.order ?? {})) {
-        const next = order.filter((profileId) => profileId !== PROFILE_ID);
-        if (next.length === order.length) {
-          continue;
-        }
-        changed = true;
-        if (next.length > 0) {
-          store.order![provider] = next;
-        } else {
-          delete store.order![provider];
-        }
-      }
-      for (const [provider, profileId] of Object.entries(store.lastGood ?? {})) {
-        if (profileId === PROFILE_ID) {
-          delete store.lastGood![provider];
-          changed = true;
-        }
-      }
-      if (store.order && Object.keys(store.order).length === 0) {
-        store.order = undefined;
-      }
-      if (store.lastGood && Object.keys(store.lastGood).length === 0) {
-        store.lastGood = undefined;
-      }
-      if (store.usageStats && Object.keys(store.usageStats).length === 0) {
-        store.usageStats = undefined;
-      }
-      return changed;
-    },
+    provider: LLAMA_SERVER_PROVIDER_ID,
+    profileIds: [PROFILE_ID],
   });
   if (!updated) {
     throw new Error(

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -22,7 +22,6 @@ import {
   markAuthProfileSuccess,
   promoteAuthProfileInOrder,
   removeAuthProfilesAcrossOwnerStores,
-  removeAuthProfilesWithLock,
   removeProviderAuthProfilesWithLock,
   setAuthProfileOrder,
   upsertAuthProfileWithLock,
@@ -1426,7 +1425,7 @@ describe("promoteAuthProfileInOrder", () => {
     );
   });
 
-  it("removes selected profiles while preserving unrelated provider credentials", async () => {
+  it("narrows provider removal to selected profiles", async () => {
     await withAuthProfileTestState("openclaw-auth-remove-selected-", async ({ agentDir }) => {
       fs.mkdirSync(agentDir, { recursive: true });
       saveAuthProfileStore(
@@ -1456,8 +1455,9 @@ describe("promoteAuthProfileInOrder", () => {
         agentDir,
       );
 
-      await removeAuthProfilesWithLock({
+      await removeProviderAuthProfilesWithLock({
         agentDir,
+        provider: "openrouter",
         profileIds: ["openrouter:oauth"],
       });
 

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -202,11 +202,18 @@ export function upsertAuthProfile(params: {
   });
 }
 
-/** Removes all auth profiles and related state for a provider. */
+/** Removes auth profiles and related state for a provider, optionally narrowed to exact IDs. */
 export async function removeProviderAuthProfilesWithLock(params: {
   provider: string;
   agentDir?: string;
+  profileIds?: readonly string[];
 }): Promise<AuthProfileStore | null> {
+  if (params.profileIds) {
+    return await removeAuthProfilesWithLock({
+      agentDir: params.agentDir,
+      profileIds: params.profileIds,
+    });
+  }
   const providerKey = resolveProviderIdForAuth(params.provider);
   return await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,


### PR DESCRIPTION
Related: #125781

## What Problem This Solves

The external llama-server feature landed with several plugin-local implementations of behavior that already has canonical OpenClaw owners: live catalog caching, bounded concurrency, insertion-order map pruning, auth-profile removal, and record coercion. Keeping those copies would let the plugin drift from the shared runtime policies over time.

This is a post-land canonicalization requested by the maintainer audit, not a criticism of the feature work. Thanks to @osolmaz for building and proving the external llama-server integration in #125781.

## Why This Change Was Made

The llama-server plugin now delegates each shared invariant to its existing owner while retaining the same endpoint, credential, cache, scheduling, and cleanup behavior.

| Family | Canonical owner adopted | Preserved behavior |
| --- | --- | --- |
| Discovery cache | `getCachedLiveCatalogValue` | 30,000 ms default TTL, success-only retention, credentialed bypass, 100-entry bound |
| Dynamic model scopes | `pruneMapToMaxSize` | delete-then-set refresh ordering and 100-scope insertion-order eviction |
| Auth-profile removal | `removeAuthProfilesWithLock` via the existing provider removal seam | exact `llama-server:default` deletion from profiles, usage, order, and last-good state; unrelated profiles remain |
| Router property probes | `runTasksWithConcurrency` | at most 8 concurrent probes, at most 200 models, one total deadline, ordered results, stop/throw on unexpected failures |
| Record boundaries | `asOptionalRecord` / `isRecord` | arrays and primitives remain rejected; valid header/model records retain their prior normalization |

The provider removal seam gained an optional exact-profile narrowing and delegates that path to the selected-profile owner. This avoids adding another public Plugin SDK callable or increasing the shrink-only SDK surface budget.

## User Impact

No user-visible behavior changes. Existing external llama-server discovery, setup, authentication, dynamic models, and router metadata should behave identically, with shared owners now enforcing the policies.

Production LOC: +87/-139 (net -52). Tests: +299/-12 (net +287).

## Evidence

- `node scripts/run-vitest.mjs extensions/llama-cpp/src/external-server src/agents/auth-profiles/profiles.test.ts src/plugin-sdk/provider-catalog-shared.test.ts src/utils/run-with-concurrency.test.ts` — 11 files, 126 tests passed.
- `node scripts/check-changed.mjs` — passed core + core tests + extension + extension tests, including formatting, typechecks, lint, coercion, boundaries, dead exports, and import cycles.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean; no accepted/actionable findings.
- Added 15 focused cases: 10 cache/concurrency/eviction cases and 5 record-boundary cases.
