### PR TITLE
refactor: share capability-gated node selection

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -236,6 +236,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/lazy-runtime` | Lazy runtime import/binding helpers such as `createLazyRuntimeModule`, `createLazyRuntimeMethod`, and `createLazyRuntimeSurface` |
     | `plugin-sdk/process-runtime` | Private-local after July 2026; Process exec helpers |
     | `plugin-sdk/node-host` | Private-local after July 2026; Node-host executable resolution and PTY resume helpers |
+    | `plugin-sdk/node-selection-runtime` | Private-local bundled runtime facade for shared capability-gated node selection policy |
     | `plugin-sdk/cli-argv` | Dependency-light root-option parsing for CLI metadata, including `getRootOptionAwareCommandPath` and `consumeRootOptionToken` |
     | `plugin-sdk/cli-runtime` | Private-local after July 2026; Deprecated broad barrel for CLI formatting, wait, version, argument-invocation, and lazy command-group helpers; prefer focused CLI/runtime subpaths |
     | `plugin-sdk/qa-runner-runtime` | Private-local after July 2026; Supported facade exposing plugin QA scenarios through the CLI command surface |

--- a/extensions/canvas/src/node-eligibility.ts
+++ b/extensions/canvas/src/node-eligibility.ts
@@ -1,8 +1,8 @@
+import type { NodeListNode } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
-  type NodeListNode,
-  resolveNodeIdFromList,
-} from "openclaw/plugin-sdk/agent-harness-runtime";
-import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+  type EligibleNodeMessages,
+  resolveEligibleNodeFromList,
+} from "openclaw/plugin-sdk/node-selection-runtime";
 
 type CanvasNodeDescriptor = {
   commands?: string[];
@@ -22,60 +22,19 @@ export function isEligibleCanvasNode(node: CanvasNodeDescriptor): boolean {
   );
 }
 
-function formatEligibleNodeIds(nodes: NodeListNode[]): string {
-  return nodes.length > 0
-    ? nodes
-        .map((node) => node.nodeId)
-        .toSorted()
-        .join(", ")
-    : "none";
-}
-
-export function resolveCanvasNodeFromList(nodes: NodeListNode[], query?: string): NodeListNode {
-  const eligible = nodes.filter(isEligibleCanvasNode);
-  const eligibleIds = formatEligibleNodeIds(eligible);
-  const trimmed = query?.trim();
-  if (trimmed) {
-    const lowerTrimmed = trimmed.toLowerCase();
-    // Check explicit ids across the full list before eligible-name resolution so
-    // a retired node cannot fall through to a same-named Mac.
-    const exactNode =
-      nodes.find((node) => node.nodeId === trimmed) ??
-      nodes.find((node) => node.nodeId.toLowerCase() === lowerTrimmed);
-    if (exactNode) {
-      if (!isEligibleCanvasNode(exactNode)) {
-        throw new Error(
-          `node "${trimmed}" is not an eligible Canvas panel (requires a connected macOS node advertising ${CANVAS_PRESENT_COMMAND}; eligible node ids: ${eligibleIds})`,
-        );
-      }
-      return exactNode;
-    }
-    try {
-      const nodeId = resolveNodeIdFromList(eligible, trimmed, false);
-      const match = eligible.find((node) => node.nodeId === nodeId);
-      if (match) {
-        return match;
-      }
-    } catch (error) {
-      throw new Error(
-        `${formatErrorMessage(error)} (eligible Canvas panel node ids: ${eligibleIds})`,
-        { cause: error },
-      );
-    }
-    throw new Error(`node not found: ${trimmed}`);
-  }
-  const only = eligible.length === 1 ? eligible.at(0) : undefined;
-  if (only) {
-    return only;
-  }
-  if (eligible.length === 0) {
-    throw new Error(
-      `no eligible Canvas panel (requires a connected macOS node advertising ${CANVAS_PRESENT_COMMAND})`,
-    );
-  }
-  throw new Error(
+const CANVAS_NODE_MESSAGES: EligibleNodeMessages<NodeListNode> = {
+  ineligibleExact: (query, eligibleIds) =>
+    `node "${query}" is not an eligible Canvas panel (requires a connected macOS node advertising ${CANVAS_PRESENT_COMMAND}; eligible node ids: ${eligibleIds})`,
+  nameResolveFailed: (reason, eligibleIds) =>
+    `${reason} (eligible Canvas panel node ids: ${eligibleIds})`,
+  noneEligible: () =>
+    `no eligible Canvas panel (requires a connected macOS node advertising ${CANVAS_PRESENT_COMMAND})`,
+  multipleEligible: (eligible) =>
     `multiple eligible Canvas panels connected; pass node explicitly: ${eligible
       .map((node) => node.nodeId)
       .join(", ")}`,
-  );
+};
+
+export function resolveCanvasNodeFromList(nodes: NodeListNode[], query?: string): NodeListNode {
+  return resolveEligibleNodeFromList(nodes, query, isEligibleCanvasNode, CANVAS_NODE_MESSAGES);
 }

--- a/extensions/canvas/src/tool.test.ts
+++ b/extensions/canvas/src/tool.test.ts
@@ -143,7 +143,9 @@ describe("Canvas presenter tool", () => {
         action: "present",
         node: "legacy-android",
       }),
-    ).rejects.toThrow('node "legacy-android" is not an eligible Canvas panel');
+    ).rejects.toThrow(
+      'node "legacy-android" is not an eligible Canvas panel (requires a connected macOS node advertising canvas.present; eligible node ids: mac-1)',
+    );
     expect(mocks.callGatewayTool).not.toHaveBeenCalled();
   });
 

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -62,6 +62,9 @@
       "openclaw/plugin-sdk/file-access-runtime": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/file-access-runtime.d.ts"
       ],
+      "openclaw/plugin-sdk/node-selection-runtime": [
+        "../packages/plugin-sdk/dist/src/plugin-sdk/node-selection-runtime.d.ts"
+      ],
       "openclaw/plugin-sdk/heartbeat-runtime": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/heartbeat-runtime.d.ts"
       ],

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -62,6 +62,9 @@
       "openclaw/plugin-sdk/file-access-runtime": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/file-access-runtime.d.ts"
       ],
+      "openclaw/plugin-sdk/node-selection-runtime": [
+        "../../packages/plugin-sdk/dist/src/plugin-sdk/node-selection-runtime.d.ts"
+      ],
       "openclaw/plugin-sdk/heartbeat-runtime": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/heartbeat-runtime.d.ts"
       ],

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "!dist/plugin-sdk/music-generation.d.ts",
     "!dist/plugin-sdk/native-hook-relay-runtime.d.ts",
     "!dist/plugin-sdk/node-host.d.ts",
+    "!dist/plugin-sdk/node-selection-runtime.d.ts",
     "!dist/plugin-sdk/number-runtime.d.ts",
     "!dist/plugin-sdk/outbound-media.d.ts",
     "!dist/plugin-sdk/pair-loop-guard-runtime.d.ts",
@@ -619,6 +620,9 @@
     },
     "./plugin-sdk/file-access-runtime": {
       "default": "./dist/plugin-sdk/file-access-runtime.js"
+    },
+    "./plugin-sdk/node-selection-runtime": {
+      "default": "./dist/plugin-sdk/node-selection-runtime.js"
     },
     "./plugin-sdk/heartbeat-runtime": {
       "default": "./dist/plugin-sdk/heartbeat-runtime.js"

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -92,6 +92,10 @@
       "types": "./dist/src/plugin-sdk/model-session-runtime.d.ts",
       "default": "./src/model-session-runtime.ts"
     },
+    "./node-selection-runtime": {
+      "types": "./dist/src/plugin-sdk/node-selection-runtime.d.ts",
+      "default": "./src/node-selection-runtime.ts"
+    },
     "./number-runtime": {
       "types": "./dist/src/plugin-sdk/number-runtime.d.ts",
       "default": "./src/number-runtime.ts"

--- a/packages/plugin-sdk/src/node-selection-runtime.ts
+++ b/packages/plugin-sdk/src/node-selection-runtime.ts
@@ -1,0 +1,3 @@
+// Public package facade for shared node-selection policy.
+
+export * from "../../../src/plugin-sdk/node-selection-runtime.js";

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -64,6 +64,7 @@
   "dedupe-runtime",
   "delivery-queue-runtime",
   "file-access-runtime",
+  "node-selection-runtime",
   "heartbeat-runtime",
   "expect-runtime",
   "number-runtime",

--- a/scripts/lib/plugin-sdk-private-local-only-subpaths.json
+++ b/scripts/lib/plugin-sdk-private-local-only-subpaths.json
@@ -87,6 +87,7 @@
   "model-ref-parse",
   "music-generation",
   "node-host",
+  "node-selection-runtime",
   "number-runtime",
   "outbound-echo-runtime",
   "outbound-media",

--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -7,6 +7,7 @@ import { NODE_FS_LIST_DIR_COMMAND } from "../infra/node-commands.js";
 import { emitSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { parseNodeList } from "../shared/node-list-parse.js";
 import type { NodeListNode } from "../shared/node-list-types.js";
+import { resolveEligibleNodeFromList } from "../shared/node-resolve.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { boundCodeModeValue } from "./code-mode-json.js";
 import type { CodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
@@ -29,7 +30,6 @@ import {
   type CollectorCompletionResult,
 } from "./tools/agents-wait-tool.js";
 import { ToolInputError } from "./tools/common.js";
-import { resolveEligibleNodeFromList } from "./tools/nodes-utils.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
 export const CODE_MODE_NODES_TOOL_ID = "openclaw:core:nodes";

--- a/src/agents/tools/computer-tool-node.ts
+++ b/src/agents/tools/computer-tool-node.ts
@@ -14,6 +14,10 @@ import {
   COMPUTER_CONTRACT_MISMATCH,
   parseComputerActResult,
 } from "../../plugins/computer-use-contract.js";
+import {
+  type EligibleNodeMessages,
+  resolveEligibleNodeFromList,
+} from "../../shared/node-resolve.js";
 import { computerActionNeedsFrame, validateCapabilityBoundInput } from "./computer-tool-request.js";
 import type {
   ComputerContextEpoch,
@@ -30,12 +34,7 @@ import {
   SCREEN_SNAPSHOT_COMMAND,
 } from "./computer-tool-shared.js";
 import { callGatewayTool, type GatewayCallOptions } from "./gateway.js";
-import {
-  type EligibleNodeMessages,
-  listNodes,
-  type NodeListNode,
-  resolveEligibleNodeFromList,
-} from "./nodes-utils.js";
+import { listNodes, type NodeListNode } from "./nodes-utils.js";
 
 type ComputerState =
   | { kind: "unbound" }
@@ -65,7 +64,7 @@ function isEligibleComputerNode(node: NodeListNode): boolean {
   );
 }
 
-const COMPUTER_NODE_MESSAGES: EligibleNodeMessages = {
+const COMPUTER_NODE_MESSAGES: EligibleNodeMessages<NodeListNode> = {
   ineligibleExact: (query, eligibleIds) =>
     `node "${query}" is not computer-capable (needs a connected node advertising ${COMPUTER_ACT_COMMAND} and ${SCREEN_SNAPSHOT_COMMAND}; ${NOT_COMPUTER_CAPABLE_HINT}; ` +
     `eligible node ids: ${eligibleIds})`,

--- a/src/agents/tools/mobile-ui-tool.ts
+++ b/src/agents/tools/mobile-ui-tool.ts
@@ -10,16 +10,15 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { Type } from "typebox";
 import { formatErrorMessage } from "../../infra/errors.js";
+import {
+  type EligibleNodeMessages,
+  resolveEligibleNodeFromList,
+} from "../../shared/node-resolve.js";
 import { stringEnum } from "../schema/typebox.js";
 import { type AnyAgentTool, jsonResult, readToolStringParam, ToolInputError } from "./common.js";
 import { gatewayCallOptionSchemaProperties } from "./gateway-schema.js";
 import { callGatewayTool, type GatewayCallOptions, readGatewayCallOptions } from "./gateway.js";
-import {
-  type EligibleNodeMessages,
-  listNodes,
-  type NodeListNode,
-  resolveEligibleNodeFromList,
-} from "./nodes-utils.js";
+import { listNodes, type NodeListNode } from "./nodes-utils.js";
 
 const MOBILE_UI_OBSERVE_COMMAND = "mobile.ui.observe";
 const MOBILE_UI_ACT_COMMAND = "mobile.ui.act";
@@ -223,7 +222,7 @@ function isEligibleMobileUiNode(node: NodeListNode): boolean {
 
 const MOBILE_UI_NODE_HINT = "enable Android Accessibility Control and approve the pairing update";
 
-const MOBILE_UI_NODE_MESSAGES: EligibleNodeMessages = {
+const MOBILE_UI_NODE_MESSAGES: EligibleNodeMessages<NodeListNode> = {
   ineligibleExact: (query, eligibleIds) =>
     `node "${query}" is not a mobile-UI-capable device (${MOBILE_UI_NODE_HINT}; ` +
     `eligible device ids: ${eligibleIds})`,

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -4,7 +4,6 @@
  * Loads paired nodes from Gateway and resolves requested/default nodes with legacy pair-list fallback.
  */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import { formatErrorMessage } from "../../infra/errors.js";
 import { parseNodeList, parsePairingList } from "../../shared/node-list-parse.js";
 import type { NodeListNode } from "../../shared/node-list-types.js";
 import { resolveNodeFromNodeList, resolveNodeIdFromNodeList } from "../../shared/node-resolve.js";
@@ -171,79 +170,6 @@ export function resolveNodeIdFromList(
     allowCompactDisplayName: options.allowCompactDisplayName,
     pickDefaultNode,
   });
-}
-
-/** Tool-supplied error wording for {@link resolveEligibleNodeFromList}. */
-export type EligibleNodeMessages = {
-  /** Explicit exact-id match that is not eligible; `eligibleIds` is the sorted list (or "none"). */
-  ineligibleExact: (query: string, eligibleIds: string) => string;
-  /** Display-name/query resolution among eligible nodes failed (unknown/ambiguous). */
-  nameResolveFailed: (reason: string, eligibleIds: string) => string;
-  /** No eligible node exists. */
-  noneEligible: () => string;
-  /** Several eligible nodes and no query to disambiguate. */
-  multipleEligible: (eligible: NodeListNode[]) => string;
-};
-
-function formatNodeIdList(nodes: NodeListNode[]): string {
-  return nodes.length > 0
-    ? nodes
-        .map((node) => node.nodeId)
-        .toSorted()
-        .join(", ")
-    : "none";
-}
-
-/**
- * Resolves a capability-gated node from the FULL node list, keeping control off
- * the wrong device. An exact node-id match (case-sensitive, then -insensitive to
- * mirror display-name matching) is checked against every node first, so an
- * ineligible id can never fall through to an eligible node that merely shares its
- * display name. Display-name/query resolution runs only among eligible nodes and
- * rejects ambiguity. Any tool that filters nodes by capability must resolve
- * through here rather than handing a pre-filtered list to {@link resolveNodeIdFromList}.
- */
-export function resolveEligibleNodeFromList(
-  nodes: NodeListNode[],
-  query: string | undefined,
-  isEligible: (node: NodeListNode) => boolean,
-  messages: EligibleNodeMessages,
-): NodeListNode {
-  const eligible = nodes.filter(isEligible);
-  const trimmed = query?.trim();
-  if (trimmed) {
-    const eligibleIds = formatNodeIdList(eligible);
-    const lowerTrimmed = trimmed.toLowerCase();
-    const exactNode =
-      nodes.find((node) => node.nodeId === trimmed) ??
-      nodes.find((node) => node.nodeId.toLowerCase() === lowerTrimmed);
-    if (exactNode) {
-      if (!isEligible(exactNode)) {
-        throw new Error(messages.ineligibleExact(trimmed, eligibleIds));
-      }
-      return exactNode;
-    }
-    try {
-      const nodeId = resolveNodeIdFromList(eligible, trimmed, false);
-      const match = eligible.find((node) => node.nodeId === nodeId);
-      if (match) {
-        return match;
-      }
-    } catch (err) {
-      throw new Error(messages.nameResolveFailed(formatErrorMessage(err), eligibleIds), {
-        cause: err,
-      });
-    }
-    throw new Error(`node not found: ${trimmed}`);
-  }
-  const only = eligible.length === 1 ? eligible.at(0) : undefined;
-  if (only) {
-    return only;
-  }
-  if (eligible.length === 0) {
-    throw new Error(messages.noneEligible());
-  }
-  throw new Error(messages.multipleEligible(eligible));
 }
 
 /** Loads nodes from the Gateway and resolves the requested or default node id. */

--- a/src/plugin-sdk/node-selection-runtime.ts
+++ b/src/plugin-sdk/node-selection-runtime.ts
@@ -1,0 +1,4 @@
+// Shared node-selection policy for bundled plugin runtime code.
+
+export type { EligibleNodeMessages } from "../shared/node-resolve.js";
+export { resolveEligibleNodeFromList } from "../shared/node-resolve.js";

--- a/src/shared/node-resolve.ts
+++ b/src/shared/node-resolve.ts
@@ -1,5 +1,6 @@
 // Node resolution helpers resolve node references from names, ids, and URLs.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { formatErrorMessage } from "../infra/errors.js";
 import { type NodeMatchCandidate, resolveNodeIdFromCandidates } from "./node-match.js";
 
 type ResolveNodeFromListOptions<TNode extends NodeMatchCandidate> = {
@@ -36,4 +37,73 @@ export function resolveNodeFromNodeList<TNode extends NodeMatchCandidate>(
   const nodeId = resolveNodeIdFromNodeList(nodes, query, options);
   // Default pickers may return a node not present in the original list; keep that id usable.
   return nodes.find((node) => node.nodeId === nodeId) ?? ({ nodeId } as TNode);
+}
+
+/** Caller-supplied error wording for capability-gated node selection. */
+export type EligibleNodeMessages<TNode extends NodeMatchCandidate> = {
+  /** Exact-id match that is not eligible; `eligibleIds` is sorted or "none". */
+  ineligibleExact: (query: string, eligibleIds: string) => string;
+  /** Display-name/query resolution among eligible nodes failed. */
+  nameResolveFailed: (reason: string, eligibleIds: string) => string;
+  /** No eligible node exists. */
+  noneEligible: () => string;
+  /** Several eligible nodes exist and no query disambiguates them. */
+  multipleEligible: (eligible: TNode[]) => string;
+};
+
+function formatNodeIdList(nodes: NodeMatchCandidate[]): string {
+  return nodes.length > 0
+    ? nodes
+        .map((node) => node.nodeId)
+        .toSorted()
+        .join(", ")
+    : "none";
+}
+
+/**
+ * Resolves a capability-gated node from the full node list. Exact ids are
+ * checked before eligible-name resolution so an ineligible id cannot redirect
+ * to an eligible node that shares its display name.
+ */
+export function resolveEligibleNodeFromList<TNode extends NodeMatchCandidate>(
+  nodes: TNode[],
+  query: string | undefined,
+  isEligible: (node: TNode) => boolean,
+  messages: EligibleNodeMessages<TNode>,
+): TNode {
+  const eligible = nodes.filter(isEligible);
+  const trimmed = query?.trim();
+  if (trimmed) {
+    const eligibleIds = formatNodeIdList(eligible);
+    const lowerTrimmed = trimmed.toLowerCase();
+    const exactNode =
+      nodes.find((node) => node.nodeId === trimmed) ??
+      nodes.find((node) => node.nodeId.toLowerCase() === lowerTrimmed);
+    if (exactNode) {
+      if (!isEligible(exactNode)) {
+        throw new Error(messages.ineligibleExact(trimmed, eligibleIds));
+      }
+      return exactNode;
+    }
+    try {
+      const nodeId = resolveNodeIdFromNodeList(eligible, trimmed);
+      const match = eligible.find((node) => node.nodeId === nodeId);
+      if (match) {
+        return match;
+      }
+    } catch (error) {
+      throw new Error(messages.nameResolveFailed(formatErrorMessage(error), eligibleIds), {
+        cause: error,
+      });
+    }
+    throw new Error(`node not found: ${trimmed}`);
+  }
+  const only = eligible.length === 1 ? eligible.at(0) : undefined;
+  if (only) {
+    return only;
+  }
+  if (eligible.length === 0) {
+    throw new Error(messages.noneEligible());
+  }
+  throw new Error(messages.multipleEligible(eligible));
 }


### PR DESCRIPTION
## What Problem This Solves

Canvas copied the capability-gated node resolver that already protects Computer, Mobile UI, and Code Mode. The duplicate lived in plugin code and could drift from the shared exact-ID safety policy.

## Why This Change Was Made

This relocates the generic resolver into `src/shared/node-resolve.ts`, migrates core consumers to that owner, and exposes a private-local `node-selection-runtime` facade for Canvas. Canvas keeps only its product-specific eligibility predicate and byte-identical error messages.

## User Impact

No intended behavior change. Explicit node IDs are still checked against the full node list before eligible display-name matching, so an ineligible ID cannot redirect an action to another eligible machine with the same name.

## Evidence

- `node scripts/run-vitest.mjs extensions/canvas/src/tool.test.ts src/agents/tools/computer-tool.node-resolution.test.ts src/agents/tools/mobile-ui-tool.test.ts` — 48 tests passed after the final rebase.
- `node scripts/run-vitest.mjs src/plugins/contracts/plugin-sdk-subpaths.test.ts src/plugins/contracts/extension-package-project-boundaries.test.ts` — 26 tests passed.
- `pnpm plugin-sdk:check-exports` and `pnpm plugin-sdk:surface:check` passed.
- `pnpm check:changed` passed, including all-lane typecheck, lint, SDK/package guards, and import-cycle checks.
- `pnpm build` passed.
- `pnpm docs:check-mdx` passed.
- Independent pre-commit review reported no actionable findings.

Local `pnpm test:changed` passed its unit-fast shard, then the unrelated tooling shard hit the 15-minute no-output watchdog and reproduced the same package-lifecycle fixture stall on retry. Exact-head hosted CI remains the authoritative broad test proof.
