### PR TITLE
fix(ui): bound expanded tool activity panel

### DIFF
--- a/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
+++ b/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
@@ -139,6 +139,84 @@ suite.define(() => {
     await context.close();
   });
 
+  it("renders expanded activity in a bounded panel above following content", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
+    const page = await context.newPage();
+    const workingText = "Working text must remain below expanded activity.";
+    const toolCalls = Array.from({ length: 24 }, (_, index) => ({
+      type: "toolCall",
+      id: `call-layout-${index}`,
+      name: "exec",
+      arguments: { command: `printf 'layout command ${index}'` },
+    }));
+    const toolResults = toolCalls.map((call, index) => ({
+      role: "toolResult",
+      toolCallId: call.id,
+      toolName: call.name,
+      content: [{ type: "text", text: `layout result ${index}` }],
+      timestamp: index + 2,
+    }));
+    await installMockGateway(page, {
+      historyMessages: [
+        { role: "assistant", content: toolCalls, timestamp: 1 },
+        ...toolResults,
+        { role: "assistant", content: [{ type: "text", text: workingText }], timestamp: 100 },
+      ],
+    });
+
+    await page.goto(`${suite.server.baseUrl}chat`);
+    const activitySummary = page.locator(".chat-group--activity .chat-activity-group__summary");
+    const followingText = page.getByText(workingText, { exact: true });
+    await activitySummary.waitFor();
+    await followingText.waitFor();
+    await waitForChatScrollIdle(page);
+    expect(await page.locator(".chat-activity-group__body:not([hidden])").count()).toBe(0);
+    const followingTopBefore = (await followingText.boundingBox())?.y;
+    expect(followingTopBefore).toBeTypeOf("number");
+
+    await activitySummary.click();
+    const activityBody = page.locator(".chat-activity-group__body:not([hidden])");
+    await activityBody.waitFor();
+    await waitForChatScrollIdle(page);
+
+    const layout = await page.evaluate((sentinel) => {
+      const body = document.querySelector<HTMLElement>(".chat-activity-group__body:not([hidden])");
+      const group = body?.closest<HTMLElement>(".chat-activity-group");
+      const following = [...document.querySelectorAll<HTMLElement>(".chat-text")].find((element) =>
+        element.textContent?.includes(sentinel),
+      );
+      if (!body || !group || !following) {
+        throw new Error("Expected expanded activity and following text");
+      }
+      const bodyStyle = getComputedStyle(body);
+      const groupRect = group.getBoundingClientRect();
+      const bodyRect = body.getBoundingClientRect();
+      const followingRect = following.getBoundingClientRect();
+      return {
+        borderRadiusPx: Number.parseFloat(bodyStyle.borderTopLeftRadius),
+        borderWidthPx: Number.parseFloat(bodyStyle.borderTopWidth),
+        bodyHeight: bodyRect.height,
+        followingTop: followingRect.top,
+        gapPx: followingRect.top - groupRect.bottom,
+        overlapPx: Math.max(
+          0,
+          Math.min(groupRect.bottom, followingRect.bottom) -
+            Math.max(groupRect.top, followingRect.top),
+        ),
+      };
+    }, workingText);
+
+    await captureToolActivityProof(page, "activity-disclosure-bounded-panel-light");
+    await page.evaluate(() => document.documentElement.setAttribute("data-theme-mode", "dark"));
+    await captureToolActivityProof(page, "activity-disclosure-bounded-panel-dark");
+    expect(layout.borderWidthPx).toBeGreaterThanOrEqual(1);
+    expect(layout.borderRadiusPx).toBeGreaterThan(0);
+    expect(layout.overlapPx).toBe(0);
+    expect(layout.gapPx).toBeGreaterThanOrEqual(0);
+    expect(layout.followingTop).toBeGreaterThan(followingTopBefore ?? layout.followingTop - 1);
+    await context.close();
+  });
+
   it("keeps an earlier autonomous failure visible after a later turn recovers", async () => {
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const page = await context.newPage();

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -1116,16 +1116,20 @@
   color: var(--warn);
 }
 
-/* Parent and child rows share one icon/text grid; order and whitespace carry
-   hierarchy without shrinking the available command width. */
+/* Keep expanded activity visibly bounded and in normal flow so the transcript
+   measures the panel as part of its row and places following work below it. */
 .chat-activity-group__body {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
   gap: 0;
   max-height: min(420px, 58vh);
-  margin: 0;
-  padding-left: 0;
-  border-left: 0;
+  margin: 4px 0 0;
+  padding: 4px 6px;
+  border: 1px solid color-mix(in srgb, var(--text) 22%, transparent);
+  border-radius: calc(14px * var(--openclaw-corner-radius-scale));
+  corner-shape: superellipse(1.5);
+  background: var(--card);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary

- render expanded multi-tool activity in a bordered, rounded panel
- retain bounded internal scrolling while normal-flow layout keeps following work below the panel
- add a browser regression for panel chrome, collapsed-state negative control, row displacement, and non-overlap in light and dark themes

## Testing

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts` (10/10 passed)
- `pnpm tsgo:ui`
- targeted Stylelint on `ui/src/styles/chat/tool-cards.css`
- targeted browser regression passed again on the exact rebased PR head

## Notes

The reported live overlap did not reproduce in clean exact-runtime geometry tests, so this avoids a speculative virtualizer change. It fixes the proven missing panel boundary and locks the already-correct in-flow/non-overlap behavior with regression coverage.
