### PR TITLE
fix: queued deliveries never recover at startup in multi-agent fleets

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -576,7 +576,7 @@ Periodic heartbeat runs.
 
 ### `agents.defaults.systemAgent`
 
-Selects the agent whose model and credentials own ambient OpenClaw system-agent and Custodian consults. It is also the fallback owner when `models.list`, `models.authStatus`, `skills.status`, or `doctor.memory.status` omits `agentId`:
+Selects the agent whose model and credentials own ambient OpenClaw system work: system-agent and Custodian consults, and the fallback owner whenever an ambient path omits `agentId`. That includes `models.list`, `models.authStatus`, `skills.status`, and `doctor.memory.status`, the default agent directory and workspace behind auth, model-catalog, and doctor resolution, outbound channel bootstrap and queued-delivery recovery, unscoped main-session routing, Talk relay ownership, and first-run onboarding:
 
 ```json5
 {
@@ -588,7 +588,7 @@ Selects the agent whose model and credentials own ambient OpenClaw system-agent 
 }
 ```
 
-An explicit request `agentId` always wins. Other agent-scoped methods do not use this setting as a general default. Delegated consults with a requesting agent keep that requester as their owner. When `systemAgent.agentId` is absent, a sole configured agent resolves implicitly; the four reads above and ambient consults in a multi-agent fleet fail with an actionable error. Upgrade-only ownership lives at `agents.defaults.authInheritance.agentId` for inherited credentials and `agents.defaults.sessionStore.agentId` for retired `main` session rows or unscoped rows in a fixed `session.store`.
+An explicit request `agentId` always wins. Delegated consults with a requesting agent keep that requester as their owner. Surfaces that enumerate or narrow across agents deliberately do not adopt this owner, because silently picking one agent would hide the others: session-store selection (`openclaw sessions`) and `openclaw hooks` status still require `--agent <id>` (or `--all-agents`). When `systemAgent.agentId` is absent, a sole configured agent resolves implicitly; ambient work in a multi-agent fleet then fails with an actionable error, except queued-delivery recovery, which records the failing delivery and keeps draining the rest of the queue. Upgrade-only ownership lives at `agents.defaults.authInheritance.agentId` for inherited credentials and `agents.defaults.sessionStore.agentId` for retired `main` session rows or unscoped rows in a fixed `session.store`.
 
 ### `agents.defaults.compaction`
 

--- a/src/agents/agent-scope-config.test.ts
+++ b/src/agents/agent-scope-config.test.ts
@@ -8,9 +8,12 @@ import {
   listAgentIds,
   resolveAgentConfig,
   resolveAgentWorkspaceDir,
+  resolveAmbientOwnerAgentId,
+  resolveDefaultAgentDir,
   resolveDefaultAgentId,
   resolveSoleAgentId,
   resolveSystemAgentTargetAgentId,
+  tryResolveAmbientOwnerAgentId,
   tryResolveDefaultAgentId,
   tryResolveSoleAgentId,
   tryResolveSystemAgentTargetAgentId,
@@ -89,6 +92,35 @@ describe("agent roster resolution", () => {
         agents: { entries: { main: { default: true }, ops: {} } },
       }),
     ).toThrow("Set agents.defaults.systemAgent.agentId");
+  });
+
+  it("resolves ambient owners through the system-agent chain", () => {
+    const systemOwnedFleet = {
+      agents: {
+        ownership: "explicit" as const,
+        defaults: { systemAgent: { agentId: "ops" } },
+        entries: { ops: { agentDir: "/tmp/openclaw-ops-agent" }, research: {} },
+      },
+    } satisfies OpenClawConfig;
+
+    expect(tryResolveAmbientOwnerAgentId(systemOwnedFleet)).toBe("ops");
+    expect(resolveAmbientOwnerAgentId(systemOwnedFleet)).toBe("ops");
+    // Ambient dir resolution is the shared producer behind auth, model, and
+    // doctor surfaces; before the system-agent leg it threw for these rosters.
+    expect(resolveDefaultAgentDir(systemOwnedFleet)).toBe("/tmp/openclaw-ops-agent");
+
+    const ownerlessFleet = {
+      agents: { ownership: "explicit" as const, entries: { ops: {}, research: {} } },
+    } satisfies OpenClawConfig;
+
+    expect(tryResolveAmbientOwnerAgentId(ownerlessFleet)).toBeUndefined();
+    expect(() => resolveAmbientOwnerAgentId(ownerlessFleet)).toThrow(AgentSelectionRequiredError);
+    expect(() =>
+      resolveAmbientOwnerAgentId(ownerlessFleet, {
+        surface: "Talk relay ownership",
+        hint: "Set talk.agentId.",
+      }),
+    ).toThrow("Talk relay ownership");
   });
 
   it("resolves defaults only for the rosterless implicit main agent", () => {

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -255,7 +255,19 @@ export function tryResolveAmbientOwnerAgentId(cfg: OpenClawConfig): string | und
   return tryResolveLegacyCompatibilityAgentId(cfg) ?? tryResolveSystemAgentTargetAgentId(cfg);
 }
 
-/** @deprecated Use resolveSoleAgentId; accepts raw shipped markers only for input compatibility. */
+/** Ambient owner for surfaces that must fail loudly rather than act on the wrong agent. */
+export function resolveAmbientOwnerAgentId(
+  cfg: OpenClawConfig,
+  context?: AgentSelectionContext,
+): string {
+  return tryResolveAmbientOwnerAgentId(cfg) ?? resolveSoleAgentId(cfg, context);
+}
+
+/**
+ * @deprecated Ambient system work uses resolveAmbientOwnerAgentId so the configured
+ * system agent is honored; explicit-selection surfaces use resolveSoleAgentId. This
+ * accepts raw shipped markers only for input compatibility.
+ */
 export function resolveDefaultAgentId(
   cfg: OpenClawConfig,
   context?: AgentSelectionContext,
@@ -426,9 +438,5 @@ export function resolveDefaultAgentDir(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): string {
-  return resolveAgentDir(
-    cfg,
-    tryResolveLegacyCompatibilityAgentId(cfg) ?? resolveDefaultAgentId(cfg),
-    env,
-  );
+  return resolveAgentDir(cfg, resolveAmbientOwnerAgentId(cfg), env);
 }

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -250,6 +250,11 @@ export function resolveSystemAgentTargetAgentId(
   );
 }
 
+/** Resolves the ambient system owner: shipped legacy default first, then the system-agent target. */
+export function tryResolveAmbientOwnerAgentId(cfg: OpenClawConfig): string | undefined {
+  return tryResolveLegacyCompatibilityAgentId(cfg) ?? tryResolveSystemAgentTargetAgentId(cfg);
+}
+
 /** @deprecated Use resolveSoleAgentId; accepts raw shipped markers only for input compatibility. */
 export function resolveDefaultAgentId(
   cfg: OpenClawConfig,

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -49,6 +49,7 @@ export {
   tryResolveConfiguredAgentWorkspaceDir,
   resolveDefaultAgentId,
   resolveSoleAgentId,
+  tryResolveAmbientOwnerAgentId,
   tryResolveLegacyCompatibilityAgentId,
   tryResolveSystemAgentTargetAgentId,
   tryResolveSoleAgentId,

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -48,6 +48,7 @@ export {
   resolveAgentWorkspaceDir,
   tryResolveConfiguredAgentWorkspaceDir,
   resolveDefaultAgentId,
+  resolveAmbientOwnerAgentId,
   resolveSoleAgentId,
   tryResolveAmbientOwnerAgentId,
   tryResolveLegacyCompatibilityAgentId,

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -26,8 +26,8 @@ import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.j
 import type { PreparedProviderStaticCatalog } from "../plugins/provider-discovery.js";
 import {
   resolveAgentWorkspaceDir,
+  resolveAmbientOwnerAgentId,
   resolveDefaultAgentDir,
-  resolveDefaultAgentId,
 } from "./agent-scope.js";
 import { resolveAuthProfileDatabasePath } from "./auth-profiles/sqlite.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
@@ -297,7 +297,9 @@ function prepareModelsConfigContext(
     options.workspaceDir ??
     (agentDirOverride?.trim()
       ? undefined
-      : resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg)));
+      : // Same ambient owner resolveDefaultAgentDir just used for agentDir; resolving it
+        // on the deprecated chain here rejected explicit fleets owned by a system agent.
+        resolveAgentWorkspaceDir(cfg, resolveAmbientOwnerAgentId(cfg)));
   const fingerprintEnv = createConfigRuntimeEnv(cfg, options.env ?? {});
   const env = options.env ? fingerprintEnv : createConfigRuntimeEnv(cfg);
   const providerScopedDiscovery = Boolean(options.providerDiscoveryProviderIds?.length);

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -26,6 +26,7 @@ vi.mock("./agent-scope.js", () => ({
   resolveAgentDir: (_config: object, agentId: string) =>
     mocks.agentDirs.get(agentId) ?? "/tmp/prepared-model-catalog-agent",
   resolveAgentWorkspaceDir: () => "/tmp/prepared-model-catalog-workspace",
+  resolveAmbientOwnerAgentId: () => "main",
   resolveDefaultAgentDir: () => "/tmp/prepared-model-catalog-agent",
   resolveDefaultAgentId: () => "main",
   tryResolveLegacyCompatibilityAgentId: () => "main",

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -5,8 +5,7 @@ import {
   listAgentIds,
   resolveAgentDir,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-  tryResolveLegacyCompatibilityAgentId,
+  resolveAmbientOwnerAgentId,
 } from "./agent-scope.js";
 import { resolveLegacyInheritedAuthDir } from "./legacy-inherited-auth-dir.js";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "./model-catalog.types.js";
@@ -119,9 +118,7 @@ function resolveInputs(params: LoadPreparedModelCatalogParams = {}): {
   const config = params.config ?? getRuntimeConfig();
   const explicitOrDefaultAgentId =
     params.agentId ??
-    (params.agentDir === undefined
-      ? (tryResolveLegacyCompatibilityAgentId(config) ?? resolveDefaultAgentId(config))
-      : undefined);
+    (params.agentDir === undefined ? resolveAmbientOwnerAgentId(config) : undefined);
   const agentDir =
     params.agentDir ?? resolveAgentDir(config, explicitOrDefaultAgentId as string, params.env);
   const matchingAgentIds =

--- a/src/agents/prepared-model-registry.test.ts
+++ b/src/agents/prepared-model-registry.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => {
 vi.mock("./agent-scope.js", () => ({
   resolveAgentDir: (_config: unknown, agentId: string) => `/agents/${agentId}`,
   resolveAgentWorkspaceDir: (_config: unknown, agentId: string) => `/workspaces/${agentId}`,
+  resolveAmbientOwnerAgentId: () => "main",
   resolveDefaultAgentDir: () => "/agents/main",
   resolveDefaultAgentId: () => "main",
   tryResolveLegacyCompatibilityAgentId: () => undefined,

--- a/src/agents/prepared-model-registry.ts
+++ b/src/agents/prepared-model-registry.ts
@@ -6,8 +6,7 @@ import { normalizeDiscoveredAgentModel } from "./agent-model-discovery.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-  tryResolveLegacyCompatibilityAgentId,
+  resolveAmbientOwnerAgentId,
 } from "./agent-scope.js";
 import { resolveLegacyInheritedAuthDir } from "./legacy-inherited-auth-dir.js";
 import {
@@ -121,10 +120,7 @@ function resolveInput(
   config: OpenClawConfig,
   options: LoadPreparedAgentModelRegistryOptions = {},
 ): PreparedModelRuntimeInput {
-  const agentId =
-    options.agentId ??
-    tryResolveLegacyCompatibilityAgentId(config) ??
-    resolveDefaultAgentId(config);
+  const agentId = options.agentId ?? resolveAmbientOwnerAgentId(config);
   const agentDir = options.agentDir ?? resolveAgentDir(config, agentId);
   const workspaceDir = options.workspaceDir ?? resolveAgentWorkspaceDir(config, agentId);
   return {

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -186,6 +186,7 @@ vi.mock("./agent-scope.js", () => ({
     (agentId === "default" ? "/tmp/unused-workspace" : `/tmp/workspace-${agentId}`),
   tryResolveConfiguredAgentWorkspaceDir: () => "/tmp/unused-workspace",
   tryResolveSystemAgentWorkspaceDir: () => "/tmp/unused-workspace",
+  resolveAmbientOwnerAgentId: () => "default",
   resolveDefaultAgentDir: () => "/tmp/unused-agent",
   resolveDefaultAgentId: () => "default",
   resolveAgentConfig: (config: { agents?: { list?: Array<{ id?: string }> } }, agentId: string) =>

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -13,8 +13,7 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-  tryResolveLegacyCompatibilityAgentId,
+  resolveAmbientOwnerAgentId,
 } from "../agents/agent-scope.js";
 import { getRuntimeConfig, readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -86,8 +85,7 @@ function resolveHooksReportTarget(config: OpenClawConfig, rawAgentId?: string): 
   }
   const agentId =
     requestedAgentId ??
-    tryResolveLegacyCompatibilityAgentId(config) ??
-    resolveDefaultAgentId(config, {
+    resolveAmbientOwnerAgentId(config, {
       surface: "hooks status reporting",
       hint: "Pass --agent <id> to select a configured agent.",
     });

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -13,7 +13,8 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
-  resolveAmbientOwnerAgentId,
+  resolveSoleAgentId,
+  tryResolveLegacyCompatibilityAgentId,
 } from "../agents/agent-scope.js";
 import { getRuntimeConfig, readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -85,7 +86,10 @@ function resolveHooksReportTarget(config: OpenClawConfig, rawAgentId?: string): 
   }
   const agentId =
     requestedAgentId ??
-    resolveAmbientOwnerAgentId(config, {
+    // Status reporting narrows to one workspace, so it keeps demanding an explicit
+    // choice rather than adopting the system agent and hiding the other agents' hooks.
+    tryResolveLegacyCompatibilityAgentId(config) ??
+    resolveSoleAgentId(config, {
       surface: "hooks status reporting",
       hint: "Pass --agent <id> to select a configured agent.",
     });

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -13,7 +13,7 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
-  resolveSoleAgentId,
+  resolveDefaultAgentId,
   tryResolveLegacyCompatibilityAgentId,
 } from "../agents/agent-scope.js";
 import { getRuntimeConfig, readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
@@ -89,7 +89,7 @@ function resolveHooksReportTarget(config: OpenClawConfig, rawAgentId?: string): 
     // Status reporting narrows to one workspace, so it keeps demanding an explicit
     // choice rather than adopting the system agent and hiding the other agents' hooks.
     tryResolveLegacyCompatibilityAgentId(config) ??
-    resolveSoleAgentId(config, {
+    resolveDefaultAgentId(config, {
       surface: "hooks status reporting",
       hint: "Pass --agent <id> to select a configured agent.",
     });

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -2,11 +2,13 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { note } from "../../../../packages/terminal-core/src/note.js";
 import { resolveStaticSessionMcpServerNames } from "../../../agents/agent-bundle-mcp-runtime-config.js";
-import { resolveAgentWorkspaceDir } from "../../../agents/agent-scope.js";
+import {
+  resolveAgentWorkspaceDir,
+  tryResolveAmbientOwnerAgentId,
+} from "../../../agents/agent-scope.js";
 import { resolveCodexMcpToolOverridesForAgent } from "../../../agents/cli-runner/bundle-mcp-codex.js";
 import { formatCliCommand } from "../../../cli/command-format.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { tryResolveCronDefaultAgentId } from "../../../cron/agent-id.js";
 import { loadCronQuarantinedJobs, resolveCronJobsStorePath } from "../../../cron/store.js";
 import type { HealthFinding } from "../../../flows/health-checks.js";
 import { formatErrorMessage as errorMessage } from "../../../infra/errors.js";
@@ -507,7 +509,7 @@ export async function maybeRepairLegacyCronStore(params: {
         const agentId =
           typeof job.agentId === "string" && job.agentId.trim()
             ? job.agentId.trim()
-            : tryResolveCronDefaultAgentId(params.cfg);
+            : tryResolveAmbientOwnerAgentId(params.cfg);
         if (!agentId) {
           return false;
         }

--- a/src/commands/onboard-agent.ts
+++ b/src/commands/onboard-agent.ts
@@ -2,9 +2,8 @@
 import { createAgent, validateAgentIdInput } from "../agents/agent-create.js";
 import {
   listAgentEntries,
-  resolveDefaultAgentId,
+  resolveAmbientOwnerAgentId,
   toAgentEntriesRecord,
-  tryResolveLegacyCompatibilityAgentId,
 } from "../agents/agent-scope-config.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
 import { readConfigFileSnapshot, resolveConfigSnapshotHash } from "../config/config.js";
@@ -96,8 +95,7 @@ export async function ensureOnboardingAgent(params: {
   ) {
     return {
       config: params.config,
-      agentId:
-        tryResolveLegacyCompatibilityAgentId(params.config) ?? resolveDefaultAgentId(params.config),
+      agentId: resolveAmbientOwnerAgentId(params.config),
       bootstrapPending: false,
       createdAgent: false,
     };
@@ -115,7 +113,7 @@ export async function ensureOnboardingAgent(params: {
         candidate: params.config,
         currentRuntime: effective,
       }),
-      agentId: tryResolveLegacyCompatibilityAgentId(effective) ?? resolveDefaultAgentId(effective),
+      agentId: resolveAmbientOwnerAgentId(effective),
       bootstrapPending: false,
       createdAgent: false,
     };

--- a/src/config/sessions/main-session.ts
+++ b/src/config/sessions/main-session.ts
@@ -1,7 +1,8 @@
 import {
   listAgentIds,
-  resolveDefaultAgentId,
+  resolveAmbientOwnerAgentId,
   resolveSystemAgentTargetAgentId,
+  tryResolveAmbientOwnerAgentId,
 } from "../../agents/agent-scope-config.js";
 // Main-session keys normalize configured agents and legacy aliases into store keys.
 import {
@@ -9,7 +10,6 @@ import {
   normalizeMainKey,
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
-import { tryResolveLegacyCompatibilityAgentId } from "../legacy.default-agent-owner.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveCanonicalMainSessionKey } from "./main-session-key.js";
 import { resolvePersistedSessionStoreOwnerForKey } from "./session-store-owner.js";
@@ -26,12 +26,10 @@ function buildMainSessionKey(agentId: string, mainKey?: string): string {
 /** Resolves the configured main session key, honoring global session scope. */
 export function resolveMainSessionKey(cfg: OpenClawConfig): string {
   return resolveCanonicalMainSessionKey({
-    agentId:
-      tryResolveLegacyCompatibilityAgentId(cfg) ??
-      resolveDefaultAgentId(cfg, {
-        surface: "main-session routing",
-        hint: "Pass an explicit agent/session key instead of the unscoped main alias.",
-      }),
+    agentId: resolveAmbientOwnerAgentId(cfg, {
+      surface: "main-session routing",
+      hint: "Pass an explicit agent/session key instead of the unscoped main alias.",
+    }),
     mainKey: cfg.session?.mainKey,
     sessionScope: cfg.session?.scope,
   });
@@ -72,7 +70,7 @@ export function resolveSessionRoutingContract(cfg: OpenClawConfig): string {
       ? persistedOwner.agentId
       : persistedOwner.kind === "retired"
         ? `retired:${persistedOwner.agentId}`
-        : (tryResolveLegacyCompatibilityAgentId(cfg) ??
+        : (tryResolveAmbientOwnerAgentId(cfg) ??
           (cfg.agents?.ownership === "explicit" ? "unowned" : (listAgentIds(cfg)[0] ?? "main")));
   return [scope, normalizeMainKey(cfg?.session?.mainKey), routingOwner].join("|");
 }

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -1,7 +1,11 @@
 // Session store target discovery maps configured and on-disk agent stores to canonical targets.
 import fsSync from "node:fs";
 import path from "node:path";
-import { listAgentEntries, listAgentIds, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import {
+  listAgentEntries,
+  listAgentIds,
+  resolveAmbientOwnerAgentId,
+} from "../../agents/agent-scope.js";
 import { resolveAgentSessionDirsFromAgentsDirSync } from "../../agents/session-dirs.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
@@ -9,10 +13,7 @@ import {
   createOpenClawAgentDatabasePathMatcher,
   listOpenClawRegisteredAgentDatabases,
 } from "../../state/openclaw-agent-db-registry.js";
-import {
-  resolveSessionStoreCompatibilityAgentId,
-  tryResolveLegacyCompatibilityAgentId,
-} from "../legacy.default-agent-owner.js";
+import { resolveSessionStoreCompatibilityAgentId } from "../legacy.default-agent-owner.js";
 import { resolveStateDir } from "../paths.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveAgentsDirFromSessionStorePath, resolveSessionStorePathCore } from "./paths.js";
@@ -650,8 +651,7 @@ export function resolveSessionStoreTargets(
     const defaultAgentId =
       requestedAgentId ??
       (persistedStoreOwner.kind === "configured" ? persistedStoreOwner.agentId : undefined) ??
-      tryResolveLegacyCompatibilityAgentId(cfg) ??
-      resolveDefaultAgentId(cfg);
+      resolveAmbientOwnerAgentId(cfg);
     const knownAgentIds = new Set(listAgentIds(cfg).map(normalizeAgentId));
     if (hasAgent && !knownAgentIds.has(defaultAgentId)) {
       throw new Error(
@@ -707,8 +707,7 @@ export function resolveSessionStoreTargets(
   }
   const defaultAgentId =
     (persistedStoreOwner.kind === "configured" ? persistedStoreOwner.agentId : undefined) ??
-    tryResolveLegacyCompatibilityAgentId(cfg) ??
-    resolveDefaultAgentId(cfg);
+    resolveAmbientOwnerAgentId(cfg);
   return [
     {
       agentId: defaultAgentId,

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -1,7 +1,7 @@
 // Session store target discovery maps configured and on-disk agent stores to canonical targets.
 import fsSync from "node:fs";
 import path from "node:path";
-import { listAgentEntries, listAgentIds, resolveSoleAgentId } from "../../agents/agent-scope.js";
+import { listAgentEntries, listAgentIds, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { resolveAgentSessionDirsFromAgentsDirSync } from "../../agents/session-dirs.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
@@ -654,7 +654,7 @@ export function resolveSessionStoreTargets(
       // agent would hide the other agents' sessions, so this stays explicit and
       // offers --agent/--all-agents instead of the ambient owner chain.
       tryResolveLegacyCompatibilityAgentId(cfg) ??
-      resolveSoleAgentId(cfg);
+      resolveDefaultAgentId(cfg);
     const knownAgentIds = new Set(listAgentIds(cfg).map(normalizeAgentId));
     if (hasAgent && !knownAgentIds.has(defaultAgentId)) {
       throw new Error(
@@ -712,7 +712,7 @@ export function resolveSessionStoreTargets(
     (persistedStoreOwner.kind === "configured" ? persistedStoreOwner.agentId : undefined) ??
     // Explicit selection, not ambient ownership: see listConfiguredSessionStoreAgentIds.
     tryResolveLegacyCompatibilityAgentId(cfg) ??
-    resolveSoleAgentId(cfg);
+    resolveDefaultAgentId(cfg);
   return [
     {
       agentId: defaultAgentId,

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -1,11 +1,7 @@
 // Session store target discovery maps configured and on-disk agent stores to canonical targets.
 import fsSync from "node:fs";
 import path from "node:path";
-import {
-  listAgentEntries,
-  listAgentIds,
-  resolveAmbientOwnerAgentId,
-} from "../../agents/agent-scope.js";
+import { listAgentEntries, listAgentIds, resolveSoleAgentId } from "../../agents/agent-scope.js";
 import { resolveAgentSessionDirsFromAgentsDirSync } from "../../agents/session-dirs.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
@@ -13,7 +9,10 @@ import {
   createOpenClawAgentDatabasePathMatcher,
   listOpenClawRegisteredAgentDatabases,
 } from "../../state/openclaw-agent-db-registry.js";
-import { resolveSessionStoreCompatibilityAgentId } from "../legacy.default-agent-owner.js";
+import {
+  resolveSessionStoreCompatibilityAgentId,
+  tryResolveLegacyCompatibilityAgentId,
+} from "../legacy.default-agent-owner.js";
 import { resolveStateDir } from "../paths.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveAgentsDirFromSessionStorePath, resolveSessionStorePathCore } from "./paths.js";
@@ -651,7 +650,11 @@ export function resolveSessionStoreTargets(
     const defaultAgentId =
       requestedAgentId ??
       (persistedStoreOwner.kind === "configured" ? persistedStoreOwner.agentId : undefined) ??
-      resolveAmbientOwnerAgentId(cfg);
+      // Session-store selection enumerates agents: silently adopting the system
+      // agent would hide the other agents' sessions, so this stays explicit and
+      // offers --agent/--all-agents instead of the ambient owner chain.
+      tryResolveLegacyCompatibilityAgentId(cfg) ??
+      resolveSoleAgentId(cfg);
     const knownAgentIds = new Set(listAgentIds(cfg).map(normalizeAgentId));
     if (hasAgent && !knownAgentIds.has(defaultAgentId)) {
       throw new Error(
@@ -707,7 +710,9 @@ export function resolveSessionStoreTargets(
   }
   const defaultAgentId =
     (persistedStoreOwner.kind === "configured" ? persistedStoreOwner.agentId : undefined) ??
-    resolveAmbientOwnerAgentId(cfg);
+    // Explicit selection, not ambient ownership: see listConfiguredSessionStoreAgentIds.
+    tryResolveLegacyCompatibilityAgentId(cfg) ??
+    resolveSoleAgentId(cfg);
   return [
     {
       agentId: defaultAgentId,

--- a/src/config/validation-core.ts
+++ b/src/config/validation-core.ts
@@ -7,7 +7,7 @@ import {
   listAgentEntriesWithSource,
   listAgentIds,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
+  resolveAmbientOwnerAgentId,
   tryResolveLegacyCompatibilityAgentId,
   tryResolveSystemAgentTargetAgentId,
 } from "../agents/agent-scope.js";
@@ -203,7 +203,7 @@ function validateIdentityAvatar(
     }
     const workspaceDir = resolveAgentWorkspaceDir(
       config,
-      entry.id ?? tryResolveLegacyCompatibilityAgentId(config) ?? resolveDefaultAgentId(config),
+      entry.id ?? resolveAmbientOwnerAgentId(config),
       env,
     );
     if (!isWorkspaceAvatarPath(avatar, workspaceDir)) {

--- a/src/cron/agent-id.ts
+++ b/src/cron/agent-id.ts
@@ -1,8 +1,3 @@
-import {
-  tryResolveLegacyCompatibilityAgentId,
-  tryResolveSystemAgentTargetAgentId,
-} from "../agents/agent-scope-config.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 
 type CronAgentScope = {
@@ -12,11 +7,6 @@ type CronAgentScope = {
 
 export const CRON_AGENT_SELECTION_REQUIRED_MESSAGE =
   "Agent-less cron job has no resolvable owner. Pass --agent <id> when creating or editing the job, or set agents.defaults.systemAgent.agentId.";
-
-/** Keeps shipped legacy defaults while routing modern ambient jobs through the system owner. */
-export function tryResolveCronDefaultAgentId(cfg: OpenClawConfig): string | undefined {
-  return tryResolveLegacyCompatibilityAgentId(cfg) ?? tryResolveSystemAgentTargetAgentId(cfg);
-}
 
 /** Resolves cron ownership: explicit non-blank id, scoped session key, then configured default. */
 export function resolveCronJobEffectiveAgentId(

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -1,5 +1,6 @@
 /** Session identity and context preparation for isolated cron runs. */
 import { isDeepStrictEqual } from "node:util";
+import { tryResolveAmbientOwnerAgentId } from "../../agents/agent-scope.js";
 import { hasAnyAuthProfileStoreSource } from "../../agents/auth-profiles/source-check.js";
 import { findModelInCatalog } from "../../agents/model-catalog-lookup.js";
 import { loadAgentRuntimePluginRegistryHandle } from "../../agents/runtime-plugins.js";
@@ -22,7 +23,7 @@ import {
 } from "../../sessions/session-lifecycle-admission.js";
 import { resolveCronSkillsSnapshot } from "../../skills/runtime/cron-snapshot.js";
 import type { SkillSnapshot } from "../../skills/types.js";
-import { resolveCronJobEffectiveAgentId, tryResolveCronDefaultAgentId } from "../agent-id.js";
+import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
 import type { CronDeliveryPlan } from "../delivery-plan.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
 import { resolveCronScheduledToolPolicy } from "../scheduled-tool-policy.js";
@@ -148,7 +149,7 @@ export async function prepareCronRunContext(params: {
     normalizedRequested ?? parseAgentSessionKey(input.job.sessionKey ?? input.sessionKey)?.agentId;
   const initialAgentId = resolveCronJobEffectiveAgentId(
     { agentId: requiredAgentId },
-    tryResolveCronDefaultAgentId(requestedRuntimeCfg),
+    tryResolveAmbientOwnerAgentId(requestedRuntimeCfg),
   );
   const modelOwner = await resolveCronModelSelectionOwner({
     cfg: requestedRuntimeCfg,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -2,7 +2,11 @@
 // plugin hooks, notifications, and cron lifecycle cleanup.
 import { retireSessionMcpRuntime } from "../agents/agent-bundle-mcp-tools.js";
 import { isAgentDeletionBlocked } from "../agents/agent-lifecycle-registry.js";
-import { listAgentEntries, listAgentIds } from "../agents/agent-scope.js";
+import {
+  listAgentEntries,
+  listAgentIds,
+  tryResolveAmbientOwnerAgentId,
+} from "../agents/agent-scope.js";
 import { abortAndDrainEmbeddedAgentRun } from "../agents/embedded-agent.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { CliDeps } from "../cli/deps.types.js";
@@ -24,7 +28,7 @@ import {
 } from "../config/sessions/targets.js";
 import type { AgentDefaultsConfig } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveCronJobEffectiveAgentId, tryResolveCronDefaultAgentId } from "../cron/agent-id.js";
+import { resolveCronJobEffectiveAgentId } from "../cron/agent-id.js";
 import {
   buildCronCommandSummary,
   redactCronCommandSummaryForExternalDelivery,
@@ -383,7 +387,7 @@ export function buildGatewayCronService(params: {
     const runtimeConfig = getRuntimeConfig();
     const normalized =
       typeof requested === "string" && requested.trim() ? normalizeAgentId(requested) : undefined;
-    const defaultAgentId = tryResolveCronDefaultAgentId(runtimeConfig);
+    const defaultAgentId = tryResolveAmbientOwnerAgentId(runtimeConfig);
     if (
       normalized !== undefined &&
       normalized !== defaultAgentId &&
@@ -504,7 +508,7 @@ export function buildGatewayCronService(params: {
     return sanitizeCronHeartbeatOverride(heartbeatOverride);
   };
 
-  const defaultAgentId = tryResolveCronDefaultAgentId(params.cfg);
+  const defaultAgentId = tryResolveAmbientOwnerAgentId(params.cfg);
   const legacyDefaultAgentId = tryGetLegacyDefaultAgentId(params.cfg);
   const resolveSessionStorePath = (agentId?: string) =>
     resolveSessionStorePathCore(params.cfg.session?.store, {
@@ -721,7 +725,7 @@ export function buildGatewayCronService(params: {
       : {}),
     ...(defaultAgentId ? { defaultAgentId } : {}),
     ...(legacyDefaultAgentId ? { legacyDefaultAgentId } : {}),
-    resolveDefaultAgentId: () => tryResolveCronDefaultAgentId(getRuntimeConfig()),
+    resolveDefaultAgentId: () => tryResolveAmbientOwnerAgentId(getRuntimeConfig()),
     resolveSessionStoreAgentIds: () => {
       const cfg = getRuntimeConfig();
       try {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -15,8 +15,7 @@ import {
 import {
   listAgentIds,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
-  tryResolveLegacyCompatibilityAgentId,
+  resolveAmbientOwnerAgentId,
 } from "../agents/agent-scope.js";
 import {
   clearBootstrapSnapshot,
@@ -122,9 +121,7 @@ import {
 } from "./worker-environments/session-placement-lifecycle.js";
 
 function resolveLifecycleAgentId(cfg: OpenClawConfig, agentId?: string): string {
-  return normalizeAgentId(
-    agentId ?? tryResolveLegacyCompatibilityAgentId(cfg) ?? resolveDefaultAgentId(cfg),
-  );
+  return normalizeAgentId(agentId ?? resolveAmbientOwnerAgentId(cfg));
 }
 
 type McpRunEndWatcherState = {

--- a/src/infra/heartbeat-agent-resolution.ts
+++ b/src/infra/heartbeat-agent-resolution.ts
@@ -1,15 +1,11 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  tryResolveLegacyCompatibilityAgentId,
-  tryResolveSystemAgentTargetAgentId,
-} from "../agents/agent-scope-config.js";
+import { tryResolveAmbientOwnerAgentId } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 
 export function tryResolveAmbientHeartbeatAgentId(cfg: OpenClawConfig): string | undefined {
   const resolved =
     normalizeOptionalString(cfg.agents?.defaults?.heartbeat?.agentId) ??
-    tryResolveLegacyCompatibilityAgentId(cfg) ??
-    tryResolveSystemAgentTargetAgentId(cfg);
+    tryResolveAmbientOwnerAgentId(cfg);
   return resolved ? normalizeAgentId(resolved) : undefined;
 }

--- a/src/infra/outbound/channel-bootstrap.runtime.test.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.test.ts
@@ -56,6 +56,20 @@ const explicitFleetDiscordConfig = {
   },
 } satisfies OpenClawConfig;
 
+const systemOwnedFleetDiscordConfig = {
+  agents: {
+    ownership: "explicit",
+    defaults: { systemAgent: { agentId: "ops" } },
+    entries: {
+      ops: { workspace: "/tmp/openclaw-ops" },
+      research: { workspace: "/tmp/openclaw-research" },
+    },
+  },
+  channels: {
+    discord: {},
+  },
+} satisfies OpenClawConfig;
+
 function installDiscordSetupShell(): void {
   const registry = createEmptyPluginRegistry();
   registry.channels = [
@@ -161,15 +175,36 @@ describe("bootstrapOutboundChannelPlugin", () => {
     );
   });
 
-  it("still rejects ownerless bootstrap in an explicit multi-agent fleet", () => {
+  it("routes agent-less bootstrap through the configured system-agent owner", () => {
     installDiscordSetupShell();
+    loaderMocks.loadPluginRegistryHandle.mockReturnValue(createEmptyPluginRegistry());
+
+    bootstrapOutboundChannelPlugin({
+      channel: "discord",
+      cfg: systemOwnedFleetDiscordConfig,
+    });
+
+    expect(loaderMocks.loadPluginRegistryHandle).toHaveBeenCalledTimes(1);
+    expect(loaderMocks.resolveDiscoverableScopedChannelPluginIds).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/openclaw-ops" }),
+    );
+  });
+
+  it("bootstraps ownerless fleets with global discovery instead of throwing", () => {
+    installDiscordSetupShell();
+    loaderMocks.loadPluginRegistryHandle.mockReturnValue(createEmptyPluginRegistry());
 
     expect(() =>
       bootstrapOutboundChannelPlugin({
         channel: "discord",
         cfg: explicitFleetDiscordConfig,
       }),
-    ).toThrow(AgentSelectionRequiredError);
+    ).not.toThrow(AgentSelectionRequiredError);
+
+    expect(loaderMocks.loadPluginRegistryHandle).toHaveBeenCalledTimes(1);
+    expect(loaderMocks.resolveDiscoverableScopedChannelPluginIds).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: undefined }),
+    );
   });
 
   it("caches bootstrap outcomes per admitted agent", () => {

--- a/src/infra/outbound/channel-bootstrap.runtime.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.ts
@@ -1,7 +1,9 @@
 // Outbound channel bootstrap lazily loads runtime plugins for selected channels
 // when only setup-shell metadata is active.
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { tryResolveLegacyCompatibilityAgentId } from "../../config/legacy.default-agent-owner.js";
+import {
+  resolveAgentWorkspaceDir,
+  tryResolveAmbientOwnerAgentId,
+} from "../../agents/agent-scope.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -100,10 +102,15 @@ export function bootstrapOutboundChannelPlugin(params: {
 
   // Outbound callers already know the admitted run owner. Preserve it here so
   // explicit fleets do not fall back to forbidden ambient-agent selection.
+  // Agent-less sends route through the configured ambient owner (legacy
+  // default, then systemAgent); ownerless fleets never throw — startup
+  // delivery recovery runs this path — and bootstrap with global-scope
+  // plugin discovery only. normalizeAgentId never returns "", so "" is a
+  // collision-free ownerless cache slot.
   const agentId = params.agentId?.trim()
     ? normalizeAgentId(params.agentId)
-    : (tryResolveLegacyCompatibilityAgentId(cfg) ?? resolveDefaultAgentId(cfg));
-  const outcomeKey = `${agentId}\0${params.channel}`;
+    : tryResolveAmbientOwnerAgentId(cfg);
+  const outcomeKey = `${agentId ?? ""}\0${params.channel}`;
   const registries = resolveBootstrapRegistries(cfg);
   const cachedRegistry = registries.get(outcomeKey);
   if (cachedRegistry !== undefined) {
@@ -112,7 +119,7 @@ export function bootstrapOutboundChannelPlugin(params: {
   }
 
   const autoEnabled = applyPluginAutoEnable({ config: cfg });
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
+  const workspaceDir = agentId === undefined ? undefined : resolveAgentWorkspaceDir(cfg, agentId);
   const pluginIds = resolveDiscoverableScopedChannelPluginIds({
     config: autoEnabled.config,
     activationSourceConfig: cfg,

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -2,7 +2,7 @@
 // bootstrap fallback, and runtime facade projection.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const resolveDefaultAgentIdMock = vi.hoisted(() => vi.fn());
+const tryResolveAmbientOwnerAgentIdMock = vi.hoisted(() => vi.fn());
 const resolveAgentWorkspaceDirMock = vi.hoisted(() => vi.fn());
 const getLoadedChannelPluginMock = vi.hoisted(() => vi.fn());
 const getChannelPluginMock = vi.hoisted(() => vi.fn());
@@ -15,7 +15,7 @@ const normalizeMessageChannelMock = vi.hoisted(() => vi.fn());
 const isDeliverableMessageChannelMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../agents/agent-scope.js", () => ({
-  resolveDefaultAgentId: (...args: unknown[]) => resolveDefaultAgentIdMock(...args),
+  tryResolveAmbientOwnerAgentId: (...args: unknown[]) => tryResolveAmbientOwnerAgentIdMock(...args),
   resolveAgentWorkspaceDir: (...args: unknown[]) => resolveAgentWorkspaceDirMock(...args),
 }));
 
@@ -73,7 +73,7 @@ function firstMockArg(mock: { mock: { calls: readonly unknown[][] } }): Record<s
 describe("outbound channel resolution", () => {
   beforeEach(async () => {
     vi.resetModules();
-    resolveDefaultAgentIdMock.mockReset();
+    tryResolveAmbientOwnerAgentIdMock.mockReset();
     resolveAgentWorkspaceDirMock.mockReset();
     getLoadedChannelPluginMock.mockReset();
     getChannelPluginMock.mockReset();
@@ -99,7 +99,7 @@ describe("outbound channel resolution", () => {
     });
     resolveDiscoverableScopedChannelPluginIdsMock.mockReturnValue(["alpha-plugin"]);
     resolveRuntimePluginRegistryMock.mockReturnValue({ channels: [] });
-    resolveDefaultAgentIdMock.mockReturnValue("main");
+    tryResolveAmbientOwnerAgentIdMock.mockReturnValue("main");
     resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
   });
 

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -165,8 +165,8 @@ async function resolveAgentId(params: {
     }
     return requestedAgentId;
   }
-  const { resolveDefaultAgentId } = await import("../../agents/agent-scope.js");
-  return resolveDefaultAgentId(params.cfg);
+  const { resolveAmbientOwnerAgentId } = await import("../../agents/agent-scope.js");
+  return resolveAmbientOwnerAgentId(params.cfg);
 }
 
 function buildSystemPrompt(params: LlmCompleteParams): string | undefined {

--- a/src/talk/agent-target.ts
+++ b/src/talk/agent-target.ts
@@ -1,8 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  resolveDefaultAgentId,
-  tryResolveLegacyCompatibilityAgentId,
-} from "../agents/agent-scope-config.js";
+import { resolveAmbientOwnerAgentId } from "../agents/agent-scope-config.js";
 import { resolveSessionAgentId } from "../agents/agent-scope.js";
 import { resolvePersistedSessionStoreOwnerForKey } from "../config/sessions/session-store-owner.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -12,8 +9,7 @@ import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.j
 export function resolveTalkTargetAgentId(config: OpenClawConfig): string {
   return normalizeAgentId(
     normalizeOptionalString(config.talk?.agentId) ??
-      tryResolveLegacyCompatibilityAgentId(config) ??
-      resolveDefaultAgentId(config, {
+      resolveAmbientOwnerAgentId(config, {
         surface: "Talk relay ownership",
         hint: "Set talk.agentId to the agent that owns unscoped Talk sessions.",
       }),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running a multi-agent fleet with explicit ownership
would see queued messages never get delivered after a Gateway restart, with only a
generic `Delivery recovery failed: ...` line in the log and no per-message outcome.

The trigger is a config that owns ambient system work through
`agents.defaults.systemAgent.agentId` instead of a legacy default agent — the shape
operators are told to use for explicit fleets. On startup, delivery recovery aborted
its entire drain the moment it reached a queued entry that carried no agent of its
own, so messages that *did* have an explicit owner were starved too.

The same configuration also broke unrelated ambient surfaces: resolving the default
agent directory (auth profiles, model catalogs, doctor, wizard, Plugin SDK helpers),
Talk relay ownership, main-session routing, hooks status, session store discovery,
plugin LLM completions, and first-run onboarding all raised
`AgentSelectionRequiredError` in configs where a system agent was configured.

## Why This Change Was Made

Ambient ownership was resolved by an idiom copy-pasted across the codebase:

```ts
tryResolveLegacyCompatibilityAgentId(cfg) ?? resolveDefaultAgentId(cfg)
```

That chain reads like a fallback but provably is not one. When the first call returns
`undefined`, `resolveDefaultAgentId` reduces to `resolveSoleAgentId`, which throws — so
the second leg only ever throws, and neither leg ever consults
`agents.defaults.systemAgent.agentId`. Every ambient surface using it was one
system-agent-only config away from an exception.

PR #126232 fixed exactly this class for heartbeats by mirroring the cron owner chain.
This change promotes that chain to a single canonical owner in `agent-scope-config`
and routes every ambient surface through it:

- `tryResolveAmbientOwnerAgentId(cfg)` — legacy default, then system agent, then sole
  agent; `undefined` when a fleet genuinely has no ambient owner.
- `resolveAmbientOwnerAgentId(cfg, context?)` — same chain, throwing with the caller's
  existing selection context when there is no owner. This is a drop-in for every site
  that used the old idiom: identical failure message, but the system-agent leg now
  works.

The duplicated chain in `src/cron/agent-id.ts` is deleted and heartbeat resolution
reuses the canonical helper, so the three startup-adjacent owners (cron, heartbeat,
outbound delivery) now share one spelling of the invariant.

Not every user of the old idiom is ambient system work, and CI caught the difference.
Surfaces that **narrow output across agents** must keep failing loudly instead of
adopting the system agent, because picking one agent silently hides the others:

- `openclaw sessions` (session-store selection) — pinned by
  `sessions.default-agent-store.test.ts`, which configures a system agent and still
  expects the `--agent` / `--all-agents` error.
- `openclaw hooks` status reporting — same hazard, one workspace at a time.

Both keep their previous behavior; the only change there is a comment recording why
they resist the ambient chain. The distinction this PR settles on: a surface that
**acts on behalf of the system** takes the ambient owner, a surface that
**enumerates or narrows across agents** requires an explicit choice.

Outbound delivery is the one caller that must not throw: it runs inside the Gateway's
startup recovery drain, which has no per-entry error boundary. Agent-less bootstrap
there now uses the non-throwing variant, and a fleet with no ambient owner bootstraps
with global-scope plugin discovery only — it never selects another agent's workspace,
preserving the explicit-fleet ownership boundary from #123283 while letting each queued
delivery record its own outcome.

Non-goal: `resolveDefaultAgentId` still backs explicit-selection surfaces (CLI commands,
wizards) where "pass `--agent <id>`" is the correct answer. Its deprecation note now
points ambient callers at the new helper so the idiom cannot quietly return.

## User Impact

Operators running an explicit multi-agent fleet with `agents.defaults.systemAgent.agentId`
set get working ambient system work instead of startup exceptions: queued messages drain
after a restart, and agent-directory, Talk, main-session, hooks, session-store, plugin
LLM, and onboarding paths resolve the configured system agent.

Delivery recovery no longer fails as a whole batch. A queued entry that cannot be
resolved fails on its own and is recorded, instead of aborting the drain for every other
message.

No config migration is needed and no configuration changes meaning. Fleets that already
resolved an owner behave exactly as before, and fleets with genuinely no ambient owner
still get the same actionable `AgentSelectionRequiredError` everywhere except the
delivery-recovery path, which is intentionally non-fatal.

## Evidence

**Root cause traced to the failing line.** `bootstrapOutboundChannelPlugin` resolved its
agent-less owner with the idiom above; the throw escapes
`createDeliveryRecoveryCoordinator().scan()` (`src/infra/delivery-recovery.shared.ts`),
which has no per-entry `catch`, and surfaces as the single
`Delivery recovery failed: ...` line at `src/gateway/server-runtime-services.ts:230`.

**Regression tests fail on pre-fix code, for the right reason.** Reverting only the
production hunks and re-running:

- `src/agents/agent-scope-config.test.ts` → `AgentSelectionRequiredError: Multiple agents
  are configured, but this operation has no explicit owner` thrown from
  `resolveSoleAgentId` via `resolveDefaultAgentDir` — the reported class, at the shared
  producer.
- `src/infra/outbound/channel-bootstrap.runtime.test.ts` → both new cases fail; the
  system-agent case throws `AgentSelectionRequiredError`.

Post-fix all pass.

**Two CI rounds shaped the final scope**, both recorded here rather than squashed away:

1. `sessions.default-agent-store` failed, proving session-store selection is
   deliberately explicit. That site and `hooks` status were restored to their previous
   behavior (comment-only diffs against `main`).
2. `prepared-model-catalog`, `prepared-model-registry`, and `channel-resolution` failed
   with `No "resolveAmbientOwnerAgentId" export is defined on the ... mock` — explicit
   `vi.mock` factories must declare every binding production touches. The four
   factories now declare it.

**Validation run locally:**

- `pnpm test` — full local suite green.
- `pnpm test:changed` — 6513 passed, 1 pre-existing failure in
  `src/plugins/setup-registry.migrations.test.ts` traced to a stale local `dist/`
  (`dist/extensions/canvas/setup-api.js` held a pre-#126030 build of the canvas
  migration string). After `pnpm build` that file passes 2/2. Not a `main` breakage and
  not related to this change.
- `pnpm build` — clean.
- `node scripts/check-changed.mjs` — all lanes green (format, `tsgo` core/test types,
  lint, import cycles, coercion guard, dead-export scan, plugin boundaries).
- Autoreview (Codex `gpt-5.6-sol`, high reasoning) — no accepted/actionable findings.

**Production LOC:** net negative. The canonical helper pair plus one invariant comment
replaces nine copies of the idiom and deletes `tryResolveCronDefaultAgentId`.
