### PR TITLE
fix(agents): preserve prompt cache boundary keys

### DIFF
--- a/src/agents/embedded-agent-runner/run/session-boundary-prompt-cache-key.test.ts
+++ b/src/agents/embedded-agent-runner/run/session-boundary-prompt-cache-key.test.ts
@@ -10,9 +10,12 @@ describe("resolveSessionBoundaryPromptCacheKey", () => {
         sessionId: "session-1",
       });
 
-    expect(resolve(0)).toBe(resolve(0));
-    expect(resolve(1)).not.toBe(resolve(0));
-    expect(resolve(2)).not.toBe(resolve(1));
+    expect([resolve(0), resolve(0), resolve(1), resolve(2)]).toEqual([
+      "session-1:0",
+      "session-1:0",
+      "session-1:1",
+      "session-1:2",
+    ]);
   });
 
   it("preserves an explicit caller cache key", () => {
@@ -26,15 +29,21 @@ describe("resolveSessionBoundaryPromptCacheKey", () => {
     ).toBe("caller-key");
   });
 
-  it("clamps derived keys from long internal session ids to OpenAI's 64-char limit", () => {
-    const longSessionId = `internal-session-effects-session-companion-${"a".repeat(50)}`;
-    const key = resolveSessionBoundaryPromptCacheKey({
-      api: "openai-responses",
-      boundaryCount: 0,
-      sessionId: longSessionId,
-    });
-    expect(key).toBeDefined();
-    expect(Array.from(key ?? "").length).toBeLessThanOrEqual(64);
-    expect(key?.startsWith("internal-session-effects-session-companion-")).toBe(true);
+  it("keeps long Unicode derived keys distinct across boundaries within the 64-char limit", () => {
+    const longSessionId = `internal-session-effects-${"🦞".repeat(64)}`;
+    const keys = [0, 1, 2].map((boundaryCount) =>
+      resolveSessionBoundaryPromptCacheKey({
+        api: "openai-responses",
+        boundaryCount,
+        sessionId: longSessionId,
+      }),
+    );
+
+    expect(new Set(keys).size).toBe(keys.length);
+    for (const [boundaryCount, key] of keys.entries()) {
+      expect(key).toBeDefined();
+      expect(Array.from(key ?? "").length).toBeLessThanOrEqual(64);
+      expect(key?.endsWith(`:${boundaryCount}`)).toBe(true);
+    }
   });
 });

--- a/src/agents/embedded-agent-runner/run/session-boundary-prompt-cache-key.ts
+++ b/src/agents/embedded-agent-runner/run/session-boundary-prompt-cache-key.ts
@@ -1,4 +1,4 @@
-import { clampOpenAIPromptCacheKey } from "@openclaw/ai/providers";
+import { OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH } from "@openclaw/ai/providers";
 
 export function resolveSessionBoundaryPromptCacheKey(params: {
   api: string;
@@ -17,8 +17,8 @@ export function resolveSessionBoundaryPromptCacheKey(params: {
   if (!usesOpenAIPromptCacheKey) {
     return undefined;
   }
-  // Clamp at derivation, not only in provider param builders: proxy runtimes
-  // serialize this key verbatim, and long internal-effects session ids
-  // (companion/btw) otherwise exceed OpenAI's 64-char prompt_cache_key limit.
-  return clampOpenAIPromptCacheKey(`${params.sessionId}:${params.boundaryCount}`);
+  // Reserve the lifecycle suffix inside OpenAI's 64-code-point limit for proxy runtimes.
+  const suffix = `:${params.boundaryCount}`;
+  const maxSessionIdLength = OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH - suffix.length;
+  return `${Array.from(params.sessionId).slice(0, maxSessionIdLength).join("")}${suffix}`;
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenAI-backed sessions with long internally derived session IDs could reuse the same prompt-cache key after a reset or compaction. The lifecycle boundary suffix was appended after the session ID and then truncated away at the 64-code-point provider limit, so distinct boundaries collided.

## Why This Change Was Made

Derived keys now reserve space for `:<boundaryCount>` inside the canonical OpenAI prompt-cache-key limit and truncate only the session ID using Unicode code-point semantics. Explicit caller-provided keys, short derived keys, and non-OpenAI APIs keep their existing behavior.

This is the canonical derivation-owner repair: no fallback or downstream guard was added. Production LOC is +5/-5 (net zero); tests are +22/-13.

## User Impact

Reset and compaction boundaries retain distinct prompt-cache affinity even for long internal session IDs, preventing stale boundary collisions while keeping normal short-session behavior unchanged.

Release-note context: OpenAI prompt-cache keys now preserve reset and compaction boundaries for long session IDs.

## Evidence

- Exact head: `31a1dca82acee7304a76b6dab73191d460555949`
- Rebased base: `e474d23e653c91fb3364976f6ecd8fb61b4cf0f5`
- Before: the previous append-then-clamp derivation produced one distinct key for boundary counts 0, 1, and 2; each key was 64 Unicode code points and had lost its suffix.
- After: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/session-boundary-prompt-cache-key.test.ts` — 1 file, 3/3 tests passed.
- Changed gates: `node scripts/check-changed.mjs` — `core` and `coreTests` passed.
- Formatting: `node_modules/.bin/oxfmt --check src/agents/embedded-agent-runner/run/session-boundary-prompt-cache-key.ts src/agents/embedded-agent-runner/run/session-boundary-prompt-cache-key.test.ts` — passed.
- Diff integrity: `git diff --check origin/main...HEAD` — passed.
- Fresh mandatory autoreview: clean, with no accepted or actionable findings; correctness assessment 0.99.
- Live-provider gap: no provider call was made because this is deterministic local key derivation with no external API behavior change; the focused owner regression and exact-head CI cover the changed contract.
- AI-assisted: yes. The maintainer reviewed the patch, affected owner/caller/provider paths, tests, and evidence.
