### PR TITLE
fix(ui): render one assistant reply when history and the terminal event race

### DIFF
--- a/packages/gateway-client/src/session-projection-run-terminal.test.ts
+++ b/packages/gateway-client/src/session-projection-run-terminal.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSessionProjection,
+  hasSessionProjectionAcceptedFinal,
+  reduceSessionProjection,
+  type SessionProjectionScope,
+} from "./session-projection.js";
+
+const primaryScope: SessionProjectionScope = {
+  sessionKey: "agent:main:shared",
+  sessionId: "session-1",
+  agentId: "main",
+  lifecycleRevision: 1,
+  activeLeafEntryId: "leaf-1",
+};
+
+function createMessage(
+  role: "user" | "assistant",
+  text: string,
+  metadata?: Record<string, unknown>,
+) {
+  return {
+    role,
+    content: [{ type: "text", text }],
+    ...(metadata ? { __openclaw: metadata } : {}),
+  };
+}
+
+/** Run-scoped terminal state: final acceptance, late diagnostics, and retention. */
+describe("session run terminal bookkeeping", () => {
+  it("does not reopen a completed run when a stale stream delta arrives", () => {
+    const completed = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+    });
+
+    expect(
+      reduceSessionProjection(completed, {
+        type: "runDelta",
+        runId: "run-1",
+        message: createMessage("assistant", "late stream"),
+      }),
+    ).toBe(completed);
+  });
+
+  it("upgrades an empty completed final exactly once without reopening the run", () => {
+    const emptyMessage = createMessage("assistant", "");
+    const deliveredMessage = createMessage("assistant", "eventual final");
+    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: emptyMessage,
+    });
+    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], emptyMessage)).toBe(false);
+    state = reduceSessionProjection(state, {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: deliveredMessage,
+    });
+
+    expect(state.runs["run-1"]).toMatchObject({
+      status: "completed",
+      message: deliveredMessage,
+    });
+    const laterFinal = createMessage("assistant", "later distinct final");
+    const laterEvent = {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: laterFinal,
+    } as const;
+    const acceptedLaterFinal = reduceSessionProjection(state, laterEvent);
+    expect(acceptedLaterFinal.runs["run-1"]?.message).toBe(deliveredMessage);
+    expect(hasSessionProjectionAcceptedFinal(acceptedLaterFinal.runs["run-1"], laterFinal)).toBe(
+      true,
+    );
+    expect(reduceSessionProjection(acceptedLaterFinal, laterEvent)).toBe(acceptedLaterFinal);
+  });
+
+  it("accepts distinct same-run persisted finals and ignores the later final's replay", () => {
+    const first = createMessage("assistant", "first final", { id: "assistant-a", seq: 4 });
+    const second = createMessage("assistant", "second final", { id: "assistant-b", seq: 5 });
+    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: first,
+    });
+    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], second)).toBe(false);
+
+    const secondEvent = {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: second,
+    } as const;
+    state = reduceSessionProjection(state, secondEvent);
+
+    expect(state.runs["run-1"]?.message).toBe(first);
+    expect(state.runs["run-1"]?.acceptedFinalMessageIdentities).toHaveLength(2);
+    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], first)).toBe(true);
+    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], second)).toBe(true);
+    expect(reduceSessionProjection(state, secondEvent)).toBe(state);
+  });
+
+  it.each(["error", "aborted"] as const)(
+    "accepts a displayable final after a message-less %s without replaying it",
+    (initialStatus) => {
+      const delivered = createMessage("assistant", "recovered final", {
+        id: "recovered-assistant",
+        seq: 7,
+      });
+      let state = reduceSessionProjection(createSessionProjection(primaryScope), {
+        type: "runTerminal",
+        runId: "run-1",
+        status: initialStatus,
+        ...(initialStatus === "error"
+          ? { errorKind: "provider_error", errorMessage: "provider diagnostic" }
+          : { stopReason: "aborted" }),
+      });
+      const finalEvent = {
+        type: "runTerminal",
+        runId: "run-1",
+        status: "completed",
+        message: delivered,
+      } as const;
+      state = reduceSessionProjection(state, finalEvent);
+
+      expect(state.runs["run-1"]).toMatchObject({
+        status: initialStatus,
+        message: delivered,
+      });
+      expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], delivered)).toBe(true);
+      expect(reduceSessionProjection(state, finalEvent)).toBe(state);
+      if (initialStatus === "error") {
+        expect(state.runs["run-1"]?.errorMessage).toBe("provider diagnostic");
+      }
+    },
+  );
+
+  it("remembers distinct recovered finals after an initial message-less error", () => {
+    const first = createMessage("assistant", "first recovered final", {
+      id: "recovered-a",
+      seq: 7,
+    });
+    const second = createMessage("assistant", "second recovered final", {
+      id: "recovered-b",
+      seq: 8,
+    });
+    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "error",
+      errorKind: "provider_error",
+      errorMessage: "original diagnostic",
+    });
+    state = reduceSessionProjection(state, {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: first,
+    });
+    const secondEvent = {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: second,
+    } as const;
+    state = reduceSessionProjection(state, secondEvent);
+
+    expect(state.runs["run-1"]).toMatchObject({
+      status: "error",
+      message: first,
+      errorMessage: "original diagnostic",
+    });
+    expect(state.runs["run-1"]?.acceptedFinalMessageIdentities).toHaveLength(2);
+    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], second)).toBe(true);
+    expect(reduceSessionProjection(state, secondEvent)).toBe(state);
+  });
+
+  it("does not replace a displayable error with a conflicting later final", () => {
+    const errorMessage = createMessage("assistant", "displayable failure");
+    const state = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "error",
+      errorKind: "provider_error",
+      message: errorMessage,
+    });
+
+    expect(
+      reduceSessionProjection(state, {
+        type: "runTerminal",
+        runId: "run-1",
+        status: "completed",
+        message: createMessage("assistant", "conflicting final"),
+      }),
+    ).toBe(state);
+    expect(state.runs["run-1"]?.message).toBe(errorMessage);
+  });
+
+  it("distinguishes and deduplicates metadata-free finals by canonical visible content", () => {
+    const first = createMessage("assistant", "first metadata-free final");
+    const second = createMessage("assistant", "second metadata-free final");
+    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: first,
+    });
+    const secondEvent = {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: second,
+    } as const;
+    state = reduceSessionProjection(state, secondEvent);
+
+    expect(state.runs["run-1"]?.message).toBe(first);
+    expect(state.runs["run-1"]?.acceptedFinalMessageIdentities).toHaveLength(2);
+    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], second)).toBe(true);
+    expect(reduceSessionProjection(state, secondEvent)).toBe(state);
+  });
+
+  it("bounds accepted same-run final identities without losing the first delivered reply", () => {
+    const first = createMessage("assistant", "final 0", { id: "assistant-0", seq: 1 });
+    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: first,
+    });
+    for (let index = 1; index < 48; index += 1) {
+      state = reduceSessionProjection(state, {
+        type: "runTerminal",
+        runId: "run-1",
+        status: "completed",
+        message: createMessage("assistant", `final ${index}`, {
+          id: `assistant-${index}`,
+          seq: index + 1,
+        }),
+      });
+    }
+
+    expect(state.runs["run-1"]?.message).toBe(first);
+    expect(state.runs["run-1"]?.acceptedFinalMessageIdentities).toHaveLength(32);
+    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], first)).toBe(true);
+    expect(
+      hasSessionProjectionAcceptedFinal(
+        state.runs["run-1"],
+        createMessage("assistant", "final 47", { id: "assistant-47", seq: 48 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores whitespace diagnostics and accepts one meaningful late provider error", () => {
+    const emptyError = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runTerminal",
+      runId: "empty-error",
+      status: "error",
+      errorMessage: " \n\t ",
+    });
+    expect(emptyError.runs["empty-error"]?.errorMessage).toBeUndefined();
+    const delivered = createMessage("assistant", "delivered final", {
+      id: "delivered-assistant",
+      seq: 7,
+    });
+    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "completed",
+      message: delivered,
+    });
+    const completed = state;
+    state = reduceSessionProjection(state, {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "error",
+      errorKind: "provider_error",
+      errorMessage: "  \n\t ",
+    });
+    expect(state).toBe(completed);
+
+    const actionableError = {
+      type: "runTerminal",
+      runId: "run-1",
+      status: "error",
+      errorKind: "provider_error",
+      errorMessage: "  provider rejected request  ",
+    } as const;
+    state = reduceSessionProjection(state, actionableError);
+
+    expect(state.runs["run-1"]).toMatchObject({
+      status: "completed",
+      message: delivered,
+      errorKind: "provider_error",
+      errorMessage: "provider rejected request",
+    });
+    expect(reduceSessionProjection(state, actionableError)).toBe(state);
+  });
+
+  it("bounds long-session terminal history without evicting any active stream", () => {
+    let state = createSessionProjection(primaryScope);
+    for (const runId of ["active-first", "active-second"]) {
+      state = reduceSessionProjection(state, {
+        type: "runDelta",
+        runId,
+        message: createMessage("assistant", `stream ${runId}`),
+      });
+    }
+    for (let index = 0; index < 1_000; index += 1) {
+      state = reduceSessionProjection(state, {
+        type: "runTerminal",
+        runId: `completed-${index}`,
+        status: "completed",
+        stopReason: "stop",
+      });
+    }
+
+    expect(Object.keys(state.runs).length).toBeLessThanOrEqual(200);
+    expect(state.runs["active-first"]?.status).toBe("streaming");
+    expect(state.runs["active-second"]?.status).toBe("streaming");
+    expect(state.runs["completed-0"]).toBeUndefined();
+    expect(state.runs["completed-999"]).toMatchObject({
+      status: "completed",
+      stopReason: "stop",
+    });
+  });
+
+  it("retains a newly completed live stream ahead of older terminal diagnostics", () => {
+    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
+      type: "runDelta",
+      runId: "active-first",
+      message: createMessage("assistant", "stream"),
+    });
+    for (let index = 0; index < 199; index += 1) {
+      state = reduceSessionProjection(state, {
+        type: "runTerminal",
+        runId: `older-${index}`,
+        status: "completed",
+      });
+    }
+    state = reduceSessionProjection(state, {
+      type: "runTerminal",
+      runId: "active-first",
+      status: "completed",
+    });
+    state = reduceSessionProjection(state, {
+      type: "runTerminal",
+      runId: "newest",
+      status: "completed",
+    });
+
+    expect(Object.keys(state.runs)).toHaveLength(150);
+    expect(state.runs["older-0"]).toBeUndefined();
+    expect(state.runs["active-first"]?.status).toBe("completed");
+    expect(state.runs.newest?.status).toBe("completed");
+  });
+
+  it("protects every concurrent active stream when terminal retention reaches its soft cap", () => {
+    let state = createSessionProjection(primaryScope);
+    for (let index = 0; index < 205; index += 1) {
+      state = reduceSessionProjection(state, {
+        type: "runDelta",
+        runId: `active-${index}`,
+      });
+    }
+
+    expect(Object.keys(state.runs)).toHaveLength(205);
+    expect(state.runs["active-0"]?.status).toBe("streaming");
+    expect(state.runs["active-204"]?.status).toBe("streaming");
+  });
+});

--- a/packages/gateway-client/src/session-projection.test.ts
+++ b/packages/gateway-client/src/session-projection.test.ts
@@ -3,7 +3,6 @@ import { readSessionMessageIdentity as readBrowserSessionMessageIdentity } from 
 import { readSessionMessageIdentity as readNodeSessionMessageIdentity } from "./index.js";
 import {
   createSessionProjection,
-  hasSessionProjectionAcceptedFinal,
   isLocallyOptimisticSessionMessage,
   normalizeSessionProjectionRunId,
   projectLiveSessionMessage,
@@ -201,6 +200,24 @@ describe("session transcript projection", () => {
     state = projectLiveSessionMessage(state, persisted, { runId: "final-run" });
 
     expect(state.messages).toEqual([persisted]);
+  });
+
+  it("keeps the durable assistant identity when its run's terminal projection replays", () => {
+    const persisted = createMessage("assistant", "persisted final", {
+      id: "assistant-final",
+      seq: 2,
+    });
+    const synthetic = createMessage("assistant", "persisted final");
+    let state = projectLiveSessionMessage(createSessionProjection(primaryScope), persisted, {
+      runId: "final-run",
+    });
+
+    state = projectLiveSessionMessage(state, synthetic, { runId: "final-run" });
+
+    expect(state.messages).toEqual([persisted]);
+    expect(reconcileSessionProjectionSnapshot(state, [persisted], primaryScope).messages).toEqual([
+      persisted,
+    ]);
   });
 
   it("does not adopt an ambiguous synthetic final across distinct same-run assistants", () => {
@@ -556,352 +573,6 @@ describe("session transcript projection", () => {
     expect(state).toBe(resetState);
     expect(state.scope.lifecycleRevision).toBe(2);
     expect(state.messages).toEqual([]);
-  });
-
-  it("does not reopen a completed run when a stale stream delta arrives", () => {
-    const completed = reduceSessionProjection(createSessionProjection(primaryScope), {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-    });
-
-    expect(
-      reduceSessionProjection(completed, {
-        type: "runDelta",
-        runId: "run-1",
-        message: createMessage("assistant", "late stream"),
-      }),
-    ).toBe(completed);
-  });
-
-  it("upgrades an empty completed final exactly once without reopening the run", () => {
-    const emptyMessage = createMessage("assistant", "");
-    const deliveredMessage = createMessage("assistant", "eventual final");
-    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: emptyMessage,
-    });
-    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], emptyMessage)).toBe(false);
-    state = reduceSessionProjection(state, {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: deliveredMessage,
-    });
-
-    expect(state.runs["run-1"]).toMatchObject({
-      status: "completed",
-      message: deliveredMessage,
-    });
-    const laterFinal = createMessage("assistant", "later distinct final");
-    const laterEvent = {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: laterFinal,
-    } as const;
-    const acceptedLaterFinal = reduceSessionProjection(state, laterEvent);
-    expect(acceptedLaterFinal.runs["run-1"]?.message).toBe(deliveredMessage);
-    expect(hasSessionProjectionAcceptedFinal(acceptedLaterFinal.runs["run-1"], laterFinal)).toBe(
-      true,
-    );
-    expect(reduceSessionProjection(acceptedLaterFinal, laterEvent)).toBe(acceptedLaterFinal);
-  });
-
-  it("accepts distinct same-run persisted finals and ignores the later final's replay", () => {
-    const first = createMessage("assistant", "first final", { id: "assistant-a", seq: 4 });
-    const second = createMessage("assistant", "second final", { id: "assistant-b", seq: 5 });
-    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: first,
-    });
-    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], second)).toBe(false);
-
-    const secondEvent = {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: second,
-    } as const;
-    state = reduceSessionProjection(state, secondEvent);
-
-    expect(state.runs["run-1"]?.message).toBe(first);
-    expect(state.runs["run-1"]?.acceptedFinalMessageIdentities).toHaveLength(2);
-    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], first)).toBe(true);
-    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], second)).toBe(true);
-    expect(reduceSessionProjection(state, secondEvent)).toBe(state);
-  });
-
-  it.each(["error", "aborted"] as const)(
-    "accepts a displayable final after a message-less %s without replaying it",
-    (initialStatus) => {
-      const delivered = createMessage("assistant", "recovered final", {
-        id: "recovered-assistant",
-        seq: 7,
-      });
-      let state = reduceSessionProjection(createSessionProjection(primaryScope), {
-        type: "runTerminal",
-        runId: "run-1",
-        status: initialStatus,
-        ...(initialStatus === "error"
-          ? { errorKind: "provider_error", errorMessage: "provider diagnostic" }
-          : { stopReason: "aborted" }),
-      });
-      const finalEvent = {
-        type: "runTerminal",
-        runId: "run-1",
-        status: "completed",
-        message: delivered,
-      } as const;
-      state = reduceSessionProjection(state, finalEvent);
-
-      expect(state.runs["run-1"]).toMatchObject({
-        status: initialStatus,
-        message: delivered,
-      });
-      expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], delivered)).toBe(true);
-      expect(reduceSessionProjection(state, finalEvent)).toBe(state);
-      if (initialStatus === "error") {
-        expect(state.runs["run-1"]?.errorMessage).toBe("provider diagnostic");
-      }
-    },
-  );
-
-  it("remembers distinct recovered finals after an initial message-less error", () => {
-    const first = createMessage("assistant", "first recovered final", {
-      id: "recovered-a",
-      seq: 7,
-    });
-    const second = createMessage("assistant", "second recovered final", {
-      id: "recovered-b",
-      seq: 8,
-    });
-    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "error",
-      errorKind: "provider_error",
-      errorMessage: "original diagnostic",
-    });
-    state = reduceSessionProjection(state, {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: first,
-    });
-    const secondEvent = {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: second,
-    } as const;
-    state = reduceSessionProjection(state, secondEvent);
-
-    expect(state.runs["run-1"]).toMatchObject({
-      status: "error",
-      message: first,
-      errorMessage: "original diagnostic",
-    });
-    expect(state.runs["run-1"]?.acceptedFinalMessageIdentities).toHaveLength(2);
-    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], second)).toBe(true);
-    expect(reduceSessionProjection(state, secondEvent)).toBe(state);
-  });
-
-  it("does not replace a displayable error with a conflicting later final", () => {
-    const errorMessage = createMessage("assistant", "displayable failure");
-    const state = reduceSessionProjection(createSessionProjection(primaryScope), {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "error",
-      errorKind: "provider_error",
-      message: errorMessage,
-    });
-
-    expect(
-      reduceSessionProjection(state, {
-        type: "runTerminal",
-        runId: "run-1",
-        status: "completed",
-        message: createMessage("assistant", "conflicting final"),
-      }),
-    ).toBe(state);
-    expect(state.runs["run-1"]?.message).toBe(errorMessage);
-  });
-
-  it("distinguishes and deduplicates metadata-free finals by canonical visible content", () => {
-    const first = createMessage("assistant", "first metadata-free final");
-    const second = createMessage("assistant", "second metadata-free final");
-    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: first,
-    });
-    const secondEvent = {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: second,
-    } as const;
-    state = reduceSessionProjection(state, secondEvent);
-
-    expect(state.runs["run-1"]?.message).toBe(first);
-    expect(state.runs["run-1"]?.acceptedFinalMessageIdentities).toHaveLength(2);
-    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], second)).toBe(true);
-    expect(reduceSessionProjection(state, secondEvent)).toBe(state);
-  });
-
-  it("bounds accepted same-run final identities without losing the first delivered reply", () => {
-    const first = createMessage("assistant", "final 0", { id: "assistant-0", seq: 1 });
-    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: first,
-    });
-    for (let index = 1; index < 48; index += 1) {
-      state = reduceSessionProjection(state, {
-        type: "runTerminal",
-        runId: "run-1",
-        status: "completed",
-        message: createMessage("assistant", `final ${index}`, {
-          id: `assistant-${index}`,
-          seq: index + 1,
-        }),
-      });
-    }
-
-    expect(state.runs["run-1"]?.message).toBe(first);
-    expect(state.runs["run-1"]?.acceptedFinalMessageIdentities).toHaveLength(32);
-    expect(hasSessionProjectionAcceptedFinal(state.runs["run-1"], first)).toBe(true);
-    expect(
-      hasSessionProjectionAcceptedFinal(
-        state.runs["run-1"],
-        createMessage("assistant", "final 47", { id: "assistant-47", seq: 48 }),
-      ),
-    ).toBe(true);
-  });
-
-  it("ignores whitespace diagnostics and accepts one meaningful late provider error", () => {
-    const emptyError = reduceSessionProjection(createSessionProjection(primaryScope), {
-      type: "runTerminal",
-      runId: "empty-error",
-      status: "error",
-      errorMessage: " \n\t ",
-    });
-    expect(emptyError.runs["empty-error"]?.errorMessage).toBeUndefined();
-    const delivered = createMessage("assistant", "delivered final", {
-      id: "delivered-assistant",
-      seq: 7,
-    });
-    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "completed",
-      message: delivered,
-    });
-    const completed = state;
-    state = reduceSessionProjection(state, {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "error",
-      errorKind: "provider_error",
-      errorMessage: "  \n\t ",
-    });
-    expect(state).toBe(completed);
-
-    const actionableError = {
-      type: "runTerminal",
-      runId: "run-1",
-      status: "error",
-      errorKind: "provider_error",
-      errorMessage: "  provider rejected request  ",
-    } as const;
-    state = reduceSessionProjection(state, actionableError);
-
-    expect(state.runs["run-1"]).toMatchObject({
-      status: "completed",
-      message: delivered,
-      errorKind: "provider_error",
-      errorMessage: "provider rejected request",
-    });
-    expect(reduceSessionProjection(state, actionableError)).toBe(state);
-  });
-
-  it("bounds long-session terminal history without evicting any active stream", () => {
-    let state = createSessionProjection(primaryScope);
-    for (const runId of ["active-first", "active-second"]) {
-      state = reduceSessionProjection(state, {
-        type: "runDelta",
-        runId,
-        message: createMessage("assistant", `stream ${runId}`),
-      });
-    }
-    for (let index = 0; index < 1_000; index += 1) {
-      state = reduceSessionProjection(state, {
-        type: "runTerminal",
-        runId: `completed-${index}`,
-        status: "completed",
-        stopReason: "stop",
-      });
-    }
-
-    expect(Object.keys(state.runs).length).toBeLessThanOrEqual(200);
-    expect(state.runs["active-first"]?.status).toBe("streaming");
-    expect(state.runs["active-second"]?.status).toBe("streaming");
-    expect(state.runs["completed-0"]).toBeUndefined();
-    expect(state.runs["completed-999"]).toMatchObject({
-      status: "completed",
-      stopReason: "stop",
-    });
-  });
-
-  it("retains a newly completed live stream ahead of older terminal diagnostics", () => {
-    let state = reduceSessionProjection(createSessionProjection(primaryScope), {
-      type: "runDelta",
-      runId: "active-first",
-      message: createMessage("assistant", "stream"),
-    });
-    for (let index = 0; index < 199; index += 1) {
-      state = reduceSessionProjection(state, {
-        type: "runTerminal",
-        runId: `older-${index}`,
-        status: "completed",
-      });
-    }
-    state = reduceSessionProjection(state, {
-      type: "runTerminal",
-      runId: "active-first",
-      status: "completed",
-    });
-    state = reduceSessionProjection(state, {
-      type: "runTerminal",
-      runId: "newest",
-      status: "completed",
-    });
-
-    expect(Object.keys(state.runs)).toHaveLength(150);
-    expect(state.runs["older-0"]).toBeUndefined();
-    expect(state.runs["active-first"]?.status).toBe("completed");
-    expect(state.runs.newest?.status).toBe("completed");
-  });
-
-  it("protects every concurrent active stream when terminal retention reaches its soft cap", () => {
-    let state = createSessionProjection(primaryScope);
-    for (let index = 0; index < 205; index += 1) {
-      state = reduceSessionProjection(state, {
-        type: "runDelta",
-        runId: `active-${index}`,
-      });
-    }
-
-    expect(Object.keys(state.runs)).toHaveLength(205);
-    expect(state.runs["active-0"]?.status).toBe("streaming");
-    expect(state.runs["active-204"]?.status).toBe("streaming");
   });
 
   it("clears a transport gap only after an authoritative snapshot", () => {

--- a/packages/gateway-client/src/session-projection.ts
+++ b/packages/gateway-client/src/session-projection.ts
@@ -411,6 +411,11 @@ export function projectLiveSessionMessage(
   if (existing && existing.message === message && existing.live && !existing.pending) {
     return state;
   }
+  if (existing && !existing.pending && existing.identity?.id && !incoming.identity.id) {
+    // A terminal projection carries no transcript identity; adopting it over the
+    // durable row would lose the ID every later snapshot reconciles against.
+    return state;
+  }
   if (existing?.pending && incoming.identity.sequence !== null) {
     const sequence = incoming.identity.sequence;
     const violatesOrder = state.entries.some(

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -10,6 +10,7 @@ import {
   SLASH_COMMANDS,
 } from "../../lib/chat/commands.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
+import { loadChatHistory } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 import { ChatStateController } from "./chat-state-controller.ts";
 import { handlePageGatewayEvent } from "./chat-state-events.ts";
@@ -248,6 +249,86 @@ describe("canonical session message recovery", () => {
       { role: "assistant", text: "Before steer." },
       { role: "user", text: "Steer prompt" },
       { role: "assistant", text: "After steer. Final unseen suffix." },
+    ]);
+  });
+
+  it.each([
+    { name: "the persisted reply lands after the terminal event", persistedFirst: false },
+    { name: "the persisted reply lands before the terminal event", persistedFirst: true },
+  ])("renders one assistant reply when $name", async ({ persistedFirst }) => {
+    const activeRunId = "active-run";
+    const replyText = "Here is the answer.";
+    const prompt = {
+      role: "user",
+      content: [{ type: "text", text: "Original prompt" }],
+      __openclaw: { id: "original-user", idempotencyKey: `${activeRunId}:user`, seq: 1 },
+    };
+    const persistedReply = {
+      role: "assistant",
+      content: [{ type: "text", text: replyText }],
+      __openclaw: { id: "persisted-reply", seq: 2 },
+    };
+    const { state } = createSessionEventState({
+      chatMessages: [prompt],
+      chatRunId: activeRunId,
+      chatStream: null,
+      chatStreamSegments: [],
+      chatToolMessages: [],
+      client: {
+        request: vi.fn().mockResolvedValue({
+          messages: [prompt, persistedReply],
+          sessionId: "selected-session",
+          sessionInfo: {
+            key: "agent:main:main",
+            kind: "direct",
+            updatedAt: 1,
+            hasActiveRun: false,
+            activeRunIds: [],
+            status: "done",
+          },
+        }),
+      } as unknown as GatewayBrowserClient,
+    });
+    // The Gateway persists the reply and ends the run on independent lanes, so
+    // the pane must reconcile the durable row with its own terminal projection
+    // in either arrival order.
+    const persistedEvent = {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: state.sessionKey,
+        hasActiveRun: false,
+        messageId: "persisted-reply",
+        messageSeq: 2,
+        message: persistedReply,
+      },
+    } satisfies Parameters<typeof handlePageGatewayEvent>[1];
+    const terminalEvent = {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: activeRunId,
+        state: "final",
+        message: { role: "assistant", content: [{ type: "text", text: replyText }] },
+      },
+    } satisfies Parameters<typeof handlePageGatewayEvent>[1];
+
+    for (const event of persistedFirst
+      ? [persistedEvent, terminalEvent]
+      : [terminalEvent, persistedEvent]) {
+      handlePageGatewayEvent(state, event);
+    }
+    await loadChatHistory(state as unknown as Parameters<typeof loadChatHistory>[0]);
+
+    // Rendering collapses consecutive identical messages behind a count badge,
+    // so the transcript itself has to hold exactly one copy of the reply.
+    expect(state.chatMessages.filter((message) => extractText(message) === replyText)).toEqual([
+      persistedReply,
+    ]);
+    expect(renderedTranscript(state)).toEqual([
+      { role: "user", text: "Original prompt" },
+      { role: "assistant", text: replyText },
     ]);
   });
 

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -332,6 +332,53 @@ describe("canonical session message recovery", () => {
     ]);
   });
 
+  it("never lets a delayed older assistant row displace a newer run's reply", () => {
+    const olderReply = {
+      role: "assistant",
+      content: [{ type: "text", text: "Answer from the older run." }],
+      __openclaw: { id: "older-reply", seq: 2 },
+    };
+    const { state } = createSessionEventState({
+      chatMessages: [],
+      chatRunId: "newer-run",
+      chatStream: null,
+      chatStreamSegments: [],
+      chatToolMessages: [],
+    });
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "chat",
+      payload: {
+        sessionKey: state.sessionKey,
+        runId: "newer-run",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Answer from the newer run." }],
+        },
+      },
+    });
+    expect(state.chatRunId).toBeNull();
+
+    // The terminal tombstone outlives its run, so a late row carrying some
+    // other reply must not borrow that run's ownership and replace it.
+    handlePageGatewayEvent(state, {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: state.sessionKey,
+        hasActiveRun: false,
+        messageId: "older-reply",
+        messageSeq: 2,
+        message: olderReply,
+      },
+    });
+
+    expect(state.chatMessages.map((message) => extractText(message))).toEqual([
+      "Answer from the newer run.",
+    ]);
+  });
+
   it("keeps an ordinary queued user after the active run assistant", () => {
     const activeRunId = "active-run";
     const originalPrompt = {

--- a/ui/src/pages/chat/session-message-apply.ts
+++ b/ui/src/pages/chat/session-message-apply.ts
@@ -2,10 +2,16 @@ import {
   readSessionMessageIdentity,
   readSessionMessageSequence,
 } from "@openclaw/gateway-client/browser";
+import type { SessionProjectionScope } from "@openclaw/gateway-client/browser";
 import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
+import { extractText } from "../../lib/chat/message-extract.ts";
 import { resolveChatAgentId } from "./chat-agent-id.ts";
 import type { ChatState } from "./chat-state-contract.ts";
-import { readChatSessionProjectionScope, reduceChatSessionProjection } from "./history-merge.ts";
+import {
+  getChatSessionProjection,
+  readChatSessionProjectionScope,
+  reduceChatSessionProjection,
+} from "./history-merge.ts";
 import { persistedSteerTargetRunId, rolloverChatStream } from "./stream-causal-boundary.ts";
 
 type SessionMessageApplySource =
@@ -15,9 +21,17 @@ type SessionMessageApplySource =
 /**
  * The run this pane is finishing. A terminal chat event clears the local run
  * before its persisted reply row arrives, so the armed terminal tombstone is
- * the same pane's proof of ownership for that trailing row.
+ * the same pane's proof of ownership for that trailing row. The tombstone
+ * outlives its run by design, so it may only claim the row that carries the
+ * reply already projected for that run; a delayed older row keeps its own
+ * missing ownership instead of displacing a newer run's answer.
  */
-function finishingChatRunId(state: ChatState, source: SessionMessageApplySource): string | null {
+function finishingChatRunId(
+  state: ChatState,
+  source: SessionMessageApplySource,
+  message: unknown,
+  scope: SessionProjectionScope,
+): string | null {
   if (source.kind !== "live") {
     return null;
   }
@@ -25,7 +39,13 @@ function finishingChatRunId(state: ChatState, source: SessionMessageApplySource)
     return source.activeRunId;
   }
   const recent = state.lastLocalTerminalReconcile;
-  return recent?.sessionKey === state.sessionKey ? (recent.runId ?? null) : null;
+  const runId = recent?.sessionKey === state.sessionKey ? recent.runId : null;
+  if (!runId) {
+    return null;
+  }
+  const projected = getChatSessionProjection(state, state.chatMessages, scope).runs[runId]?.message;
+  const projectedText = extractText(projected)?.trim();
+  return projectedText && projectedText === extractText(message)?.trim() ? runId : null;
 }
 
 /** Apply one durable session.message payload through the pane-owned transcript reducer. */
@@ -44,6 +64,7 @@ export function applySessionMessagePayload(
   if (!incoming) {
     return;
   }
+  const scope = readChatSessionProjectionScope(state, { agentId: resolveChatAgentId(state) });
   const isPreviousRunAssistant = Boolean(
     incoming.role === "assistant" &&
     incoming.sequence !== null &&
@@ -62,7 +83,7 @@ export function applySessionMessagePayload(
     !incoming.isImported &&
     !incoming.runId &&
     runActive !== true
-      ? finishingChatRunId(state, source)
+      ? finishingChatRunId(state, source, sourceMessage, scope)
       : null;
   if (
     source.kind === "live" &&
@@ -98,7 +119,6 @@ export function applySessionMessagePayload(
       ...(incoming.sequence !== null ? { seq: incoming.sequence } : {}),
     },
   };
-  const scope = readChatSessionProjectionScope(state, { agentId: resolveChatAgentId(state) });
   const previousMessageCount = state.chatMessages.length;
   const projection = reduceChatSessionProjection(
     state,

--- a/ui/src/pages/chat/session-message-apply.ts
+++ b/ui/src/pages/chat/session-message-apply.ts
@@ -12,6 +12,22 @@ type SessionMessageApplySource =
   | { kind: "history-delta" }
   | { kind: "live"; activeRunId: string | null };
 
+/**
+ * The run this pane is finishing. A terminal chat event clears the local run
+ * before its persisted reply row arrives, so the armed terminal tombstone is
+ * the same pane's proof of ownership for that trailing row.
+ */
+function finishingChatRunId(state: ChatState, source: SessionMessageApplySource): string | null {
+  if (source.kind !== "live") {
+    return null;
+  }
+  if (source.activeRunId) {
+    return source.activeRunId;
+  }
+  const recent = state.lastLocalTerminalReconcile;
+  return recent?.sessionKey === state.sessionKey ? (recent.runId ?? null) : null;
+}
+
 /** Apply one durable session.message payload through the pane-owned transcript reducer. */
 export function applySessionMessagePayload(
   state: ChatState,
@@ -36,7 +52,24 @@ export function applySessionMessagePayload(
     source.activeRunId &&
     incoming.runId !== source.activeRunId,
   );
-  if (source.kind === "live" && incoming.role !== "user" && !isPreviousRunAssistant) {
+  // The transcript never records which run wrote an assistant row, so the run
+  // this pane is finishing is the only proof of ownership for the reply that
+  // ends it. Admitting it here lets the reducer recognize the same run's
+  // terminal projection instead of rendering the reply twice.
+  const assistantOwnerRunId =
+    incoming.role === "assistant" &&
+    incoming.id &&
+    !incoming.isImported &&
+    !incoming.runId &&
+    runActive !== true
+      ? finishingChatRunId(state, source)
+      : null;
+  if (
+    source.kind === "live" &&
+    incoming.role !== "user" &&
+    !isPreviousRunAssistant &&
+    !assistantOwnerRunId
+  ) {
     return;
   }
   // Partial import provenance cannot turn an envelope position into durable
@@ -69,7 +102,11 @@ export function applySessionMessagePayload(
   const previousMessageCount = state.chatMessages.length;
   const projection = reduceChatSessionProjection(
     state,
-    { type: "messagePersisted", message, envelope: event },
+    {
+      type: "messagePersisted",
+      message,
+      envelope: assistantOwnerRunId ? { ...event, runId: assistantOwnerRunId } : event,
+    },
     { scope, runActive },
   );
   const steerTargetRunId = persistedSteerTargetRunId(message);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users of the Control UI chat would see a single assistant reply rendered twice — shown collapsed with the `×2` "consecutive identical messages collapsed" badge — after a turn finished. It was reproducible after `/steer` and `/redirect` turns and after a plain send to a parent session whose subagent was running, but it appeared intermittently: the same command duplicated in one run and not the next.

The stored transcript was always correct. Querying the gateway's session database for an affected turn returned exactly one user row and one assistant row, so the second copy existed only in the browser's message list.

## Why This Change Was Made

The two copies of the reply shared no identity, so the session projection reducer could not tell they were the same message.

The `chat` terminal event carries `runId` but no `messageId`/`messageSeq`, so the pane's own terminal projection has no transcript identity. The durable assistant row has `__openclaw.id`/`.seq` but no run identity — `projectTranscriptEntryMessage` stamps `id`, `seq`, and `idempotencyKey`, and embedded-agent assistant rows have no `idempotencyKey`. The reducer's snapshot promotion needs `persisted.runId === observed.runId`, which a durable assistant row can never satisfy, so the live copy matched nothing in the authoritative snapshot and was re-inserted beside it.

Only a WeakMap side channel (`rememberAuthoritativeTerminal`) covered the gap, and only for one arrival order: it discards the terminal event when history has already been applied. Whether that race was won is what made the badge intermittent.

The pane now records the missing fact where the reducer reads it. `applySessionMessagePayload` admits the durable assistant row of the run the pane is finishing — same guards the side channel already used, with the owning run taken from the active run or the armed terminal tombstone — attributed to that run through the reducer envelope, so the existing same-run clause in `entryMatches` lets the durable row adopt the terminal projection in place. `projectLiveSessionMessage` gains the missing symmetry: an entry that already carries a transcript id is never replaced by an id-less projection of the same run, which the late-terminal order needs.

Deliberately not done: two broader reducer relaxations (matching regardless of liveness, and carrying run attribution across snapshots) both looked right and were wrong — a run can publish several durable assistant rows, so run identity is ownership, not a row, and the relaxed rule made a steer's boundary-split tail collide with the run's earlier persisted message. The duplicate-collapse badge itself is untouched; it remains correct for genuinely repeated messages.

Production delta is +44/−2, in the two owner boundaries only.

## User Impact

A finished reply renders once, in either order the gateway's persistence and run-terminal lanes happen to deliver. The `×2` badge now only appears when the transcript really does hold repeated identical messages.

## Evidence

Regression tests, both failing on pre-fix code for the intended reason:

- `ui/src/pages/chat/chat-state.test.ts` — an `it.each` over both arrival orders (durable row before vs. after the terminal event), followed by a history load, asserting the transcript holds exactly one copy. It asserts on `chatMessages` rather than the rendered items on purpose: collapsing is precisely what hides the duplicate, so a rendered-transcript assertion passes pre-fix.
- `packages/gateway-client/src/session-projection.test.ts` — reducer-level mirror of the existing "adopts a durable assistant identity from the same live run" case.

Adding those lines pushed `session-projection.test.ts` past the 1000-line `max-lines` ratchet, so the run-terminal bookkeeping block (final acceptance, late diagnostics, retention bounds) moved into `session-projection-run-terminal.test.ts` rather than adding a suppression. Test count went 255 → 256, so nothing was lost in the move.

Local proof:

- `node scripts/run-vitest.mjs packages/gateway-client ui/src/pages/chat` — 164 files, 3194 passed, 11 skipped.
- Earlier full pass including `src/tui` — 208 files, 4386 passed.
- `node scripts/check-changed.mjs` — green (the one lint hit was the max-lines ratchet above, resolved by the split).
- Codex autoreview on the diff — clean, no accepted findings.

Known proof gap: not live-verified on a running gateway. The original report came from live `/steer` and `/redirect` runs, and the fix is proven deterministically across both arrival orders in tests rather than by reproducing the race live.

Follow-up worth its own issue: the WeakMap side channel still earns its keep for the persisted-row → history → terminal order, because run attribution is rebuilt from raw messages on every snapshot and lost. Removing it properly means closing the upstream gap — the gateway knows the persisted `messageId` at `src/agents/session-tool-result-guard.ts:911` and drops it, so neither the terminal event nor the durable row ever carries run ownership.
