### PR TITLE
fix(e2e): use packaged CLI in git fixtures

### DIFF
--- a/scripts/e2e/lib/package-git-fixture.mjs
+++ b/scripts/e2e/lib/package-git-fixture.mjs
@@ -43,9 +43,14 @@ function prepare(root) {
   ensureDependencyIgnores(root);
   const packageJsonPath = path.join(root, "package.json");
   const packageJson = readJson(packageJsonPath);
+  packageJson.scripts = {
+    ...packageJson.scripts,
+    openclaw: "node openclaw.mjs",
+  };
   const aiRuntimeSource = path.join(root, "node_modules", "@openclaw", "ai");
   const aiRuntimePackageJson = path.join(aiRuntimeSource, "package.json");
   if (!fs.existsSync(aiRuntimePackageJson)) {
+    writeJson(packageJsonPath, packageJson);
     return;
   }
 

--- a/test/scripts/package-git-fixture.test.ts
+++ b/test/scripts/package-git-fixture.test.ts
@@ -18,6 +18,10 @@ describe("package git fixture", () => {
         {
           dependencies: { "@openclaw/ai": "2026.6.11", chalk: "5.6.2" },
           bundleDependencies: ["@openclaw/ai", "chalk"],
+          scripts: {
+            build: "node build.mjs",
+            openclaw: "node scripts/run-node.mjs",
+          },
         },
         null,
         2,
@@ -48,6 +52,10 @@ describe("package git fixture", () => {
     const packageJson = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
     expect(packageJson.dependencies["@openclaw/ai"]).toBe("file:.openclaw-fixture/packages/ai");
     expect(packageJson.bundleDependencies).toEqual(["chalk"]);
+    expect(packageJson.scripts).toEqual({
+      build: "node build.mjs",
+      openclaw: "node openclaw.mjs",
+    });
     const relocatedAiPackage = JSON.parse(
       readFileSync(path.join(root, ".openclaw-fixture", "packages", "ai", "package.json"), "utf8"),
     );
@@ -78,5 +86,40 @@ describe("package git fixture", () => {
     expect(staged.status).toBe(0);
     expect(staged.stdout).not.toContain("node_modules");
     expect(staged.stdout).not.toContain("pnpm-lock.yaml");
+  });
+
+  it("uses the packed entrypoint without a bundled ai runtime", () => {
+    const root = tempDirs.make("openclaw-package-git-fixture-no-ai-");
+    writeFileSync(
+      path.join(root, "package.json"),
+      `${JSON.stringify(
+        {
+          dependencies: { chalk: "5.6.2" },
+          scripts: {
+            lint: "node lint.mjs",
+            openclaw: "node scripts/run-node.mjs",
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/e2e/lib/package-git-fixture.mjs", "prepare", root],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    const packageJson = JSON.parse(readFileSync(path.join(root, "package.json"), "utf8"));
+    expect(packageJson).toMatchObject({
+      dependencies: { chalk: "5.6.2" },
+      scripts: {
+        lint: "node lint.mjs",
+        openclaw: "node openclaw.mjs",
+      },
+    });
+    expect(packageJson.dependencies).not.toHaveProperty("@openclaw/ai");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the package-to-development update-channel Docker workflow failed when its synthetic git checkout tried to run a source-only CLI wrapper that is not included in the packed artifact.

## Why This Change Was Made

The package-derived fixture now points its existing `openclaw` script at the shipped `openclaw.mjs` entrypoint before the optional bundled AI runtime relocation. Other package scripts are preserved, including when `@openclaw/ai` is absent.

## User Impact

Release qualification can exercise package-to-git channel switching against the actual packed CLI entrypoint. Production runtime behavior and package contents are unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/package-git-fixture.test.ts` (2/2 passed)
- targeted format, oxlint, `git diff --check`, and changed-check lanes passed
- AWS Crabbox run `run_dd99e31c925b`: `pnpm test:docker:update-channel-switch` passed
  - formerly failing preflight: `$ node openclaw.mjs config validate --json` exited 0
- same AWS Crabbox run: `pnpm test:docker:doctor-switch` passed
- production delta: +5 lines in the E2E fixture helper; tests: +43 lines
- no changelog entry: test/E2E fixture-only repair
