### PR TITLE
fix(ui): honor categories for child sessions

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation-logic.test.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.test.ts
@@ -286,6 +286,43 @@ describe("sidebar navigation lineage ownership", () => {
     ]);
   });
 
+  it("promotes an explicitly categorized child to a sidebar section root", () => {
+    const categorizedChild = { ...child, category: "P1 issues from beta feedback" };
+    const projected = projectSessionTree({
+      roots: [navigationParent, categorizedChild],
+      agentRows: [navigationParent, categorizedChild],
+      childRowsByParent: {},
+      loadingChildKeys: new Set(),
+      knownSessionAttention: [],
+      toSidebarSession: (row, isChild) =>
+        ({
+          key: row.key,
+          category: row.category,
+          isChild,
+          attention: { kind: "none" },
+          runningChildCount: 0,
+          failedChildCount: 0,
+        }) as SidebarRecentSession,
+    });
+
+    expect(
+      projected.map((row) => ({
+        key: row.key,
+        category: row.category,
+        isChild: row.isChild,
+        children: row.children.map((entry) => entry.key),
+      })),
+    ).toEqual([
+      { key: navigationParent.key, category: undefined, isChild: false, children: [] },
+      {
+        key: categorizedChild.key,
+        category: categorizedChild.category,
+        isChild: false,
+        children: [],
+      },
+    ]);
+  });
+
   it.each([
     ["legacy active child", { status: "running" }, 1, 0],
     ["stale running child", { status: "running", hasActiveRun: false }, 0, 0],

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -495,6 +495,19 @@ export function resolveLatestSidebarAgentSession(input: {
   });
 }
 
+export function collectSidebarSessionCandidateRows(input: {
+  rows: readonly GatewaySessionRow[];
+  childRowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>>;
+}): GatewaySessionRow[] {
+  return [
+    ...new Map(
+      [...Object.values(input.childRowsByParent).flat(), ...input.rows].map(
+        (row) => [row.key, row] as const,
+      ),
+    ).values(),
+  ];
+}
+
 /**
  * Promote the hidden main session's children to top-level threads, with the
  * same visibility rules as ordinary roots so archived, cron, or
@@ -502,13 +515,12 @@ export function resolveLatestSidebarAgentSession(input: {
  */
 export function collectPromotedMainChildRows(input: {
   rows: readonly GatewaySessionRow[];
-  childRowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>>;
   mainSessionKeys: ReadonlySet<string>;
   scopedRootKeys: ReadonlySet<string>;
   showCron: boolean;
   showSystem: boolean;
 }): GatewaySessionRow[] {
-  return [...input.rows, ...Object.values(input.childRowsByParent).flat()].filter((row) => {
+  return input.rows.filter((row) => {
     const parentKey = resolveUiSessionNavigationParentKey(row);
     return (
       parentKey != null &&

--- a/ui/src/components/app-sidebar-session-navigation-logic.ts
+++ b/ui/src/components/app-sidebar-session-navigation-logic.ts
@@ -23,6 +23,7 @@ import {
   filterVisibleSessionRows,
   isSystemCreatedSessionRow,
   resolveSessionNavigation,
+  sessionMatchesVisibleSessionScope,
 } from "../lib/sessions/index.ts";
 import {
   resolveSessionPreferredFace,
@@ -518,6 +519,21 @@ export function collectPromotedMainChildRows(input: {
       (input.showSystem || !isSystemCreatedSessionRow(row))
     );
   });
+}
+
+export function collectCategorizedChildRootRows(input: {
+  rows: readonly GatewaySessionRow[];
+  scopedRoots: readonly GatewaySessionRow[];
+  visibilityOptions: Parameters<typeof filterVisibleSessionRows>[1];
+}): GatewaySessionRow[] {
+  const scopedRootKeys = new Set(input.scopedRoots.map((row) => row.key));
+  return input.rows.filter(
+    (row) =>
+      !scopedRootKeys.has(row.key) &&
+      normalizeOptionalString(row.category) != null &&
+      resolveUiSessionNavigationParentKey(row) != null &&
+      sessionMatchesVisibleSessionScope(row, input.visibilityOptions),
+  );
 }
 
 export function resolveSidebarAgentResumeKey(

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -31,6 +31,7 @@ import {
   buildSidebarSessionNavigationState,
   collectCategorizedChildRootRows,
   collectPromotedMainChildRows,
+  collectSidebarSessionCandidateRows,
   compareSidebarSessionRowsByMode,
   collectKnownSidebarSessionCatalogIds,
   collectKnownSidebarSessionGroups,
@@ -653,16 +654,19 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     ) {
       scopedRootRows.push(lineageRoot);
     }
-    const categorizedChildRows = collectCategorizedChildRootRows({
+    const sessionCandidateRows = collectSidebarSessionCandidateRows({
       rows,
+      childRowsByParent: this.sessionData.childSessionRowsByParent,
+    });
+    const categorizedChildRows = collectCategorizedChildRootRows({
+      rows: sessionCandidateRows,
       scopedRoots: scopedRootRows,
       visibilityOptions,
     });
     scopedRootRows.push(...categorizedChildRows);
     const scopedRootKeys = new Set(scopedRootRows.map((row) => row.key));
     const promotedRows = collectPromotedMainChildRows({
-      rows,
-      childRowsByParent: this.sessionData.childSessionRowsByParent,
+      rows: sessionCandidateRows,
       mainSessionKeys,
       scopedRootKeys,
       showCron: this.sessionsShowCron,

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -7,7 +7,11 @@ import { isSessionRouteId } from "../app-route-paths.ts";
 import { t } from "../i18n/index.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { SidebarSessionsGrouping } from "../lib/sessions/grouping.ts";
-import { filterVisibleSessionRows, sessionMatchesArchivedFilter } from "../lib/sessions/index.ts";
+import {
+  filterVisibleSessionRows,
+  sessionMatchesArchivedFilter,
+  sessionMatchesVisibleSessionScope,
+} from "../lib/sessions/index.ts";
 import { runSessionNavigationIntent } from "../lib/sessions/navigation-handoff.ts";
 import {
   composerDraftSearch,
@@ -19,6 +23,7 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
   resolveUiDefaultAgentId,
+  resolveUiSessionNavigationParentKey,
 } from "../lib/sessions/session-key.ts";
 import { AppSidebarBase } from "./app-sidebar-base.ts";
 import {
@@ -588,6 +593,10 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const selected = this.expandedAgentId();
     const loadedAgentId = normalizeAgentId(this.sessionData.sessionsAgentId ?? "");
     const routeAgentId = normalizeAgentId(navigationState.selectedAgentId);
+    const defaultAgentId = resolveUiDefaultAgentId({
+      agentsList: this.context?.agents.state.agentsList,
+      hello: this.context?.gateway.snapshot.hello,
+    });
     const rows =
       selected === loadedAgentId
         ? (this.sessionData.sessionsResult?.sessions ?? [])
@@ -601,10 +610,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
           })
         : filterVisibleSessionRows(rows, {
             agentId: selected,
-            defaultAgentId: resolveUiDefaultAgentId({
-              agentsList: this.context?.agents.state.agentsList,
-              hello: this.context?.gateway.snapshot.hello,
-            }),
+            defaultAgentId,
             filterByAgent: true,
             showCron: this.sessionsShowCron,
             showSystem: this.sessionsShowSystem,
@@ -650,6 +656,26 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       scopedRootRows.push(lineageRoot);
     }
     const scopedRootKeys = new Set(scopedRootRows.map((row) => row.key));
+    let addedCategorizedChildRoot = false;
+    for (const row of rows) {
+      if (
+        !scopedRootKeys.has(row.key) &&
+        normalizeOptionalString(row.category) &&
+        resolveUiSessionNavigationParentKey(row) &&
+        sessionMatchesVisibleSessionScope(row, {
+          agentId: selected,
+          defaultAgentId,
+          filterByAgent: true,
+          showCron: this.sessionsShowCron,
+          showSystem: this.sessionsShowSystem,
+          archivedFilter: this.sessionsStatusFilter,
+        })
+      ) {
+        scopedRootKeys.add(row.key);
+        scopedRootRows.push(row);
+        addedCategorizedChildRoot = true;
+      }
+    }
     const promotedRows = collectPromotedMainChildRows({
       rows,
       childRowsByParent: this.sessionData.childSessionRowsByParent,
@@ -665,7 +691,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       }
     }
     const orderedRootRows =
-      promotedRows.length > 0
+      promotedRows.length > 0 || addedCategorizedChildRoot
         ? scopedRootRows.toSorted(this.compareSidebarSessionRows)
         : scopedRootRows;
     // `adopted` holds only catalog-bound keys (adoptedCatalogSessionKeys), not

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -7,11 +7,7 @@ import { isSessionRouteId } from "../app-route-paths.ts";
 import { t } from "../i18n/index.ts";
 import { shouldHandleNavigationClick } from "../lib/navigation-click.ts";
 import type { SidebarSessionsGrouping } from "../lib/sessions/grouping.ts";
-import {
-  filterVisibleSessionRows,
-  sessionMatchesArchivedFilter,
-  sessionMatchesVisibleSessionScope,
-} from "../lib/sessions/index.ts";
+import { filterVisibleSessionRows, sessionMatchesArchivedFilter } from "../lib/sessions/index.ts";
 import { runSessionNavigationIntent } from "../lib/sessions/navigation-handoff.ts";
 import {
   composerDraftSearch,
@@ -23,7 +19,6 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
   resolveUiDefaultAgentId,
-  resolveUiSessionNavigationParentKey,
 } from "../lib/sessions/session-key.ts";
 import { AppSidebarBase } from "./app-sidebar-base.ts";
 import {
@@ -34,6 +29,7 @@ import {
   applySidebarSessionOwnerFilter,
   buildReconciledSidebarZone,
   buildSidebarSessionNavigationState,
+  collectCategorizedChildRootRows,
   collectPromotedMainChildRows,
   compareSidebarSessionRowsByMode,
   collectKnownSidebarSessionCatalogIds,
@@ -593,10 +589,17 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     const selected = this.expandedAgentId();
     const loadedAgentId = normalizeAgentId(this.sessionData.sessionsAgentId ?? "");
     const routeAgentId = normalizeAgentId(navigationState.selectedAgentId);
-    const defaultAgentId = resolveUiDefaultAgentId({
-      agentsList: this.context?.agents.state.agentsList,
-      hello: this.context?.gateway.snapshot.hello,
-    });
+    const visibilityOptions = {
+      agentId: selected,
+      defaultAgentId: resolveUiDefaultAgentId({
+        agentsList: this.context?.agents.state.agentsList,
+        hello: this.context?.gateway.snapshot.hello,
+      }),
+      filterByAgent: true,
+      showCron: this.sessionsShowCron,
+      showSystem: this.sessionsShowSystem,
+      archivedFilter: this.sessionsStatusFilter,
+    } as const;
     const rows =
       selected === loadedAgentId
         ? (this.sessionData.sessionsResult?.sessions ?? [])
@@ -608,14 +611,9 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
             const row = rowsByKey.get(session.key);
             return row ? [row] : [];
           })
-        : filterVisibleSessionRows(rows, {
-            agentId: selected,
-            defaultAgentId,
-            filterByAgent: true,
-            showCron: this.sessionsShowCron,
-            showSystem: this.sessionsShowSystem,
-            archivedFilter: this.sessionsStatusFilter,
-          }).toSorted(this.compareSidebarSessionRows);
+        : filterVisibleSessionRows(rows, visibilityOptions).toSorted(
+            this.compareSidebarSessionRows,
+          );
     // The identity card replaces the main row; promote children under all equivalent aliases.
     const mainSessionKey = this.selectedAgentMainSessionKey(selected);
     const lineageRoot = this.sessionData.activeSessionLineageRoot;
@@ -655,27 +653,13 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     ) {
       scopedRootRows.push(lineageRoot);
     }
+    const categorizedChildRows = collectCategorizedChildRootRows({
+      rows,
+      scopedRoots: scopedRootRows,
+      visibilityOptions,
+    });
+    scopedRootRows.push(...categorizedChildRows);
     const scopedRootKeys = new Set(scopedRootRows.map((row) => row.key));
-    let addedCategorizedChildRoot = false;
-    for (const row of rows) {
-      if (
-        !scopedRootKeys.has(row.key) &&
-        normalizeOptionalString(row.category) &&
-        resolveUiSessionNavigationParentKey(row) &&
-        sessionMatchesVisibleSessionScope(row, {
-          agentId: selected,
-          defaultAgentId,
-          filterByAgent: true,
-          showCron: this.sessionsShowCron,
-          showSystem: this.sessionsShowSystem,
-          archivedFilter: this.sessionsStatusFilter,
-        })
-      ) {
-        scopedRootKeys.add(row.key);
-        scopedRootRows.push(row);
-        addedCategorizedChildRoot = true;
-      }
-    }
     const promotedRows = collectPromotedMainChildRows({
       rows,
       childRowsByParent: this.sessionData.childSessionRowsByParent,
@@ -691,7 +675,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       }
     }
     const orderedRootRows =
-      promotedRows.length > 0 || addedCategorizedChildRoot
+      promotedRows.length > 0 || categorizedChildRows.length > 0
         ? scopedRootRows.toSorted(this.compareSidebarSessionRows)
         : scopedRootRows;
     // `adopted` holds only catalog-bound keys (adoptedCatalogSessionKeys), not

--- a/ui/src/components/app-sidebar-session-tree.ts
+++ b/ui/src/components/app-sidebar-session-tree.ts
@@ -44,6 +44,8 @@ export function projectSessionTree(params: {
     rowsByKey.set(row.key, row);
   }
   const childKeysByParent = new Map<string, string[]>();
+  const hasExplicitCategory = (row: GatewaySessionRow | undefined) =>
+    typeof row?.category === "string" && row.category.trim().length > 0;
   const appendChild = (parentKey: string, childKey: string) => {
     const keys = childKeysByParent.get(parentKey) ?? [];
     if (!keys.includes(childKey)) {
@@ -54,6 +56,12 @@ export function projectSessionTree(params: {
   for (const row of rowsByKey.values()) {
     for (const childKey of row.childSessions ?? []) {
       const child = rowsByKey.get(childKey);
+      // Manual category placement is a first-class sidebar destination. Once
+      // a child is explicitly categorized, render it as a section root rather
+      // than hiding it behind its lineage parent.
+      if (hasExplicitCategory(child)) {
+        continue;
+      }
       const navigationParentKey = resolveUiSessionNavigationParentKey(child);
       // Runtime control and sidebar navigation can have different parents;
       // known children belong to their explicit navigation parent only.
@@ -64,7 +72,7 @@ export function projectSessionTree(params: {
   }
   for (const row of rowsByKey.values()) {
     const parentKey = resolveUiSessionNavigationParentKey(row);
-    if (parentKey) {
+    if (parentKey && !hasExplicitCategory(row)) {
       appendChild(parentKey, row.key);
     }
   }
@@ -147,6 +155,9 @@ export function projectSessionTree(params: {
   const rootKeys = new Set(roots.map((row) => row.key));
   return roots
     .filter((row) => {
+      if (hasExplicitCategory(row)) {
+        return true;
+      }
       const parentKey = resolveUiSessionNavigationParentKey(row);
       return !parentKey || !rootKeys.has(parentKey);
     })

--- a/ui/src/components/app-sidebar.test.ts
+++ b/ui/src/components/app-sidebar.test.ts
@@ -15,6 +15,7 @@ import "../test-helpers/app-sidebar-cases/catalog-live-state.ts";
 import "../test-helpers/app-sidebar-cases/catalog-ownership.ts";
 import "../test-helpers/app-sidebar-cases/catalog-terminal-owner.ts";
 import "../test-helpers/app-sidebar-cases/catalog-pages.ts";
+import "../test-helpers/app-sidebar-cases/categorized-child-sessions.ts";
 import "../test-helpers/app-sidebar-cases/child-sessions-cap.ts";
 import "../test-helpers/app-sidebar-cases/child-sessions.ts";
 import "../test-helpers/app-sidebar-cases/group-mutations.ts";

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -52,6 +52,7 @@ export {
   isSystemCreatedSessionRow,
   resolveSessionNavigation,
   sessionMatchesArchivedFilter,
+  sessionMatchesVisibleSessionScope,
   scopedAgentIdForSession,
   scopedAgentListParamsForRefreshTarget,
   scopedAgentListParamsForSession,

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -273,6 +273,21 @@ export function sessionMatchesArchivedFilter(
   return (row.archived === true) === (archivedFilter === "archived");
 }
 
+export function sessionMatchesVisibleSessionScope(
+  row: GatewaySessionRow,
+  options: VisibleSessionRowOptions,
+): boolean {
+  return (
+    sessionMatchesArchivedFilter(row, options.archivedFilter) &&
+    row.kind !== "global" &&
+    row.kind !== "unknown" &&
+    (options.showCron === true || !isCronSessionKey(row.key)) &&
+    (options.showSystem === true || !isSystemCreatedSessionRow(row)) &&
+    (!options.filterByAgent ||
+      isSessionKeyTiedToAgent(row.key, options.agentId, options.defaultAgentId))
+  );
+}
+
 export function filterVisibleSessionRows(
   rows: readonly GatewaySessionRow[],
   options: VisibleSessionRowOptions,
@@ -286,15 +301,9 @@ export function filterVisibleSessionRows(
       return true;
     }
     return (
-      sessionMatchesArchivedFilter(row, options.archivedFilter) &&
-      row.kind !== "global" &&
-      row.kind !== "unknown" &&
-      (options.showCron === true || !isCronSessionKey(row.key)) &&
-      (options.showSystem === true || !isSystemCreatedSessionRow(row)) &&
+      sessionMatchesVisibleSessionScope(row, options) &&
       !isSubagentSessionKey(row.key) &&
-      !row.spawnedBy &&
-      (!options.filterByAgent ||
-        isSessionKeyTiedToAgent(row.key, options.agentId, options.defaultAgentId))
+      !row.spawnedBy
     );
   });
 }

--- a/ui/src/test-helpers/app-sidebar-cases/categorized-child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/categorized-child-sessions.ts
@@ -1,9 +1,72 @@
 import { describe, expect, it } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createGateway, createSessionsHarness, mountSidebar } from "../app-sidebar.ts";
+import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar categorized child sessions", () => {
+  it("promotes a categorized child loaded through the expanded-parent cache", async () => {
+    const parentKey = "agent:main:parent";
+    const categorizedKey = "agent:main:cached-categorized-child";
+    const ordinaryKey = "agent:main:cached-ordinary-child";
+    const archivedKey = "agent:main:cached-archived-child";
+    const harness = createSessionsHarness("main", [parentKey]);
+    const parent = harness.sessions.state.result?.sessions[0];
+    Object.assign(parent ?? {}, {
+      childSessions: [categorizedKey, ordinaryKey, archivedKey],
+      label: "Parent task",
+    });
+    harness.list.mockResolvedValue({
+      count: 3,
+      defaults: { contextTokens: null, model: null, modelProvider: null },
+      path: "",
+      sessions: [
+        {
+          category: "Research",
+          key: categorizedKey,
+          kind: "direct",
+          label: "Cached categorized child",
+          spawnedBy: parentKey,
+          updatedAt: 3,
+        },
+        {
+          key: ordinaryKey,
+          kind: "direct",
+          label: "Cached ordinary child",
+          spawnedBy: parentKey,
+          updatedAt: 2,
+        },
+        {
+          archived: true,
+          category: "Research",
+          key: archivedKey,
+          kind: "direct",
+          label: "Cached archived child",
+          spawnedBy: parentKey,
+          updatedAt: 1,
+        },
+      ],
+      ts: 1,
+    });
+    harness.publish({ groups: ["Research"] });
+
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, harness.sessions);
+    sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledOnce());
+
+    const research = sidebar.querySelector('[data-session-section="category:Research"]');
+    await waitForFast(() =>
+      expect(research?.querySelectorAll(`[data-session-key="${categorizedKey}"]`)).toHaveLength(1),
+    );
+    expect(
+      sidebar.querySelector(
+        `[data-session-tree="${parentKey}"] [data-session-key="${ordinaryKey}"]`,
+      ),
+    ).not.toBeNull();
+    expect(sidebar.querySelector(`[data-session-key="${archivedKey}"]`)).toBeNull();
+  });
+
   it("places a categorized child in its section while keeping ordinary siblings nested", async () => {
     const harness = createSessionsHarness("main", [
       "agent:main:parent",

--- a/ui/src/test-helpers/app-sidebar-cases/categorized-child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/categorized-child-sessions.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createGateway, createSessionsHarness, mountSidebar } from "../app-sidebar.ts";
+import "../../components/app-sidebar.ts";
+
+describe("AppSidebar categorized child sessions", () => {
+  it("places a categorized child in its section while keeping ordinary siblings nested", async () => {
+    const harness = createSessionsHarness("main", [
+      "agent:main:parent",
+      "agent:main:categorized-child",
+      "agent:main:ordinary-child",
+      "agent:main:archived-child",
+    ]);
+    const result = harness.sessions.state.result;
+    if (!result) {
+      throw new Error("expected child session fixtures");
+    }
+    const rowsByKey = new Map(result.sessions.map((row) => [row.key, row]));
+    Object.assign(rowsByKey.get("agent:main:parent") ?? {}, {
+      label: "Parent task",
+      childSessions: [
+        "agent:main:categorized-child",
+        "agent:main:ordinary-child",
+        "agent:main:archived-child",
+      ],
+    });
+    Object.assign(rowsByKey.get("agent:main:categorized-child") ?? {}, {
+      spawnedBy: "agent:main:parent",
+      label: "Categorized child",
+      category: "Research",
+    });
+    Object.assign(rowsByKey.get("agent:main:ordinary-child") ?? {}, {
+      spawnedBy: "agent:main:parent",
+      label: "Ordinary child",
+    });
+    Object.assign(rowsByKey.get("agent:main:archived-child") ?? {}, {
+      spawnedBy: "agent:main:parent",
+      label: "Archived child",
+      category: "Research",
+      archived: true,
+    });
+    harness.publish({ groups: ["Research"] });
+
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, harness.sessions);
+
+    const research = sidebar.querySelector('[data-session-section="category:Research"]');
+    expect(
+      research?.querySelectorAll('[data-session-key="agent:main:categorized-child"]'),
+    ).toHaveLength(1);
+    expect(
+      research?.querySelector('[data-session-key="agent:main:categorized-child"]')?.classList,
+    ).not.toContain("sidebar-recent-session--child");
+    expect(sidebar.querySelector('[data-session-key="agent:main:archived-child"]')).toBeNull();
+
+    const parentTree = sidebar.querySelector('[data-session-tree="agent:main:parent"]');
+    parentTree?.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
+    await sidebar.updateComplete;
+
+    expect(
+      parentTree?.querySelectorAll('[data-session-key="agent:main:ordinary-child"]'),
+    ).toHaveLength(1);
+    expect(
+      parentTree?.querySelector('[data-session-key="agent:main:categorized-child"]'),
+    ).toBeNull();
+  });
+});

--- a/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
@@ -12,6 +12,67 @@ import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar agent chip", () => {
+  it("places a categorized child in its section while keeping ordinary siblings nested", async () => {
+    const harness = createSessionsHarness("main", [
+      "agent:main:parent",
+      "agent:main:categorized-child",
+      "agent:main:ordinary-child",
+      "agent:main:archived-child",
+    ]);
+    const result = harness.sessions.state.result;
+    if (!result) {
+      throw new Error("expected child session fixtures");
+    }
+    const rowsByKey = new Map(result.sessions.map((row) => [row.key, row]));
+    Object.assign(rowsByKey.get("agent:main:parent") ?? {}, {
+      label: "Parent task",
+      childSessions: [
+        "agent:main:categorized-child",
+        "agent:main:ordinary-child",
+        "agent:main:archived-child",
+      ],
+    });
+    Object.assign(rowsByKey.get("agent:main:categorized-child") ?? {}, {
+      spawnedBy: "agent:main:parent",
+      label: "Categorized child",
+      category: "Research",
+    });
+    Object.assign(rowsByKey.get("agent:main:ordinary-child") ?? {}, {
+      spawnedBy: "agent:main:parent",
+      label: "Ordinary child",
+    });
+    Object.assign(rowsByKey.get("agent:main:archived-child") ?? {}, {
+      spawnedBy: "agent:main:parent",
+      label: "Archived child",
+      category: "Research",
+      archived: true,
+    });
+    harness.publish({ groups: ["Research"] });
+
+    const gateway = createGateway({} as GatewayBrowserClient);
+    const { sidebar } = await mountSidebar(gateway, harness.sessions);
+
+    const research = sidebar.querySelector('[data-session-section="category:Research"]');
+    expect(
+      research?.querySelectorAll('[data-session-key="agent:main:categorized-child"]'),
+    ).toHaveLength(1);
+    expect(
+      research?.querySelector('[data-session-key="agent:main:categorized-child"]')?.classList,
+    ).not.toContain("sidebar-recent-session--child");
+    expect(sidebar.querySelector('[data-session-key="agent:main:archived-child"]')).toBeNull();
+
+    const parentTree = sidebar.querySelector('[data-session-tree="agent:main:parent"]');
+    parentTree?.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
+    await sidebar.updateComplete;
+
+    expect(
+      parentTree?.querySelectorAll('[data-session-key="agent:main:ordinary-child"]'),
+    ).toHaveLength(1);
+    expect(
+      parentTree?.querySelector('[data-session-key="agent:main:categorized-child"]'),
+    ).toBeNull();
+  });
+
   it("loads and expands child sessions with menus but without root placement controls", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const harness = createSessionsHarness("main", ["agent:main:parent"]);

--- a/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/child-sessions.ts
@@ -12,67 +12,6 @@ import { waitForFast } from "../wait-for.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar agent chip", () => {
-  it("places a categorized child in its section while keeping ordinary siblings nested", async () => {
-    const harness = createSessionsHarness("main", [
-      "agent:main:parent",
-      "agent:main:categorized-child",
-      "agent:main:ordinary-child",
-      "agent:main:archived-child",
-    ]);
-    const result = harness.sessions.state.result;
-    if (!result) {
-      throw new Error("expected child session fixtures");
-    }
-    const rowsByKey = new Map(result.sessions.map((row) => [row.key, row]));
-    Object.assign(rowsByKey.get("agent:main:parent") ?? {}, {
-      label: "Parent task",
-      childSessions: [
-        "agent:main:categorized-child",
-        "agent:main:ordinary-child",
-        "agent:main:archived-child",
-      ],
-    });
-    Object.assign(rowsByKey.get("agent:main:categorized-child") ?? {}, {
-      spawnedBy: "agent:main:parent",
-      label: "Categorized child",
-      category: "Research",
-    });
-    Object.assign(rowsByKey.get("agent:main:ordinary-child") ?? {}, {
-      spawnedBy: "agent:main:parent",
-      label: "Ordinary child",
-    });
-    Object.assign(rowsByKey.get("agent:main:archived-child") ?? {}, {
-      spawnedBy: "agent:main:parent",
-      label: "Archived child",
-      category: "Research",
-      archived: true,
-    });
-    harness.publish({ groups: ["Research"] });
-
-    const gateway = createGateway({} as GatewayBrowserClient);
-    const { sidebar } = await mountSidebar(gateway, harness.sessions);
-
-    const research = sidebar.querySelector('[data-session-section="category:Research"]');
-    expect(
-      research?.querySelectorAll('[data-session-key="agent:main:categorized-child"]'),
-    ).toHaveLength(1);
-    expect(
-      research?.querySelector('[data-session-key="agent:main:categorized-child"]')?.classList,
-    ).not.toContain("sidebar-recent-session--child");
-    expect(sidebar.querySelector('[data-session-key="agent:main:archived-child"]')).toBeNull();
-
-    const parentTree = sidebar.querySelector('[data-session-tree="agent:main:parent"]');
-    parentTree?.querySelector<HTMLButtonElement>("[data-child-session-toggle]")?.click();
-    await sidebar.updateComplete;
-
-    expect(
-      parentTree?.querySelectorAll('[data-session-key="agent:main:ordinary-child"]'),
-    ).toHaveLength(1);
-    expect(
-      parentTree?.querySelector('[data-session-key="agent:main:categorized-child"]'),
-    ).toBeNull();
-  });
-
   it("loads and expands child sessions with menus but without root placement controls", async () => {
     const gateway = createGateway({} as GatewayBrowserClient);
     const harness = createSessionsHarness("main", ["agent:main:parent"]);


### PR DESCRIPTION
## What Problem This Solves

Child sessions with an explicit sidebar category could disappear from that category or remain hidden behind their lineage parent. The failure affected both children present in the main session list and children fetched lazily after expanding a parent.

## Why This Change Was Made

Category grouping runs after selected-agent root admission. The original tree-only change could not recover a categorized child that had already been excluded from roots, and the first root-admission repair considered only main-list rows. This version:

- keeps explicit category placement ahead of lineage nesting in tree projection;
- builds one deduplicated candidate set from main-list and lazy child-cache rows;
- admits otherwise eligible categorized children through the selected-agent root boundary;
- preserves the existing archive, agent, cron, system, global, and unknown visibility rules.

This is narrower than globally exposing child sessions and avoids separate policy for cached children.

## User Impact

- Categorized child sessions appear exactly once as roots in their assigned section.
- Ordinary children remain nested beneath their parent.
- Archived children remain hidden from the active-session view.
- The behavior is consistent whether the child arrived in the initial list or through parent expansion.

## Evidence

- Exact head: `70f0b4a7ddd6c71e683e4ce2c79f6657a587ba9f`
- Caller-level direct-list and lazy-cache regressions: red before repair, green after repair.
- Sidebar/navigation-logic suites: 304 passed; navigation visibility suite: 26 passed.
- Autoreview: clean; source-blind lazy-cache behavior validation: PASS.
- Exact-head CI run `32304094004`: green, including all UI E2E shards, real-Gateway UI E2E, lint, and `openclaw/ci-gate`.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 126388`: passed with exact hosted gates.

### Canonical-base direct-list failure

https://github.com/user-attachments/assets/40c98485-29e4-4842-b93c-d66fc38985fa

### Prior-head lazy-cache failure

https://github.com/user-attachments/assets/162ea20d-75f1-4f8b-916f-dae529044679

### Exact-head lazy-cache repair

https://github.com/user-attachments/assets/27e93dce-77c7-400c-96f5-0196a73c3e2b
