### PR TITLE
fix(ui): refresh hovercard avatars after reconnect

### DIFF
--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -32,6 +32,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private applicationContext: ApplicationContext | null = null;
   private applicationGateway: ApplicationGateway | null = null;
   private progressCards: SessionProgressCardStore | null = null;
+  private stopGatewayUpdates: (() => void) | null = null;
   private stopProgressCardUpdates: (() => void) | null = null;
   private pullRequests: SessionPullRequestSnapshotStore | null = null;
   private stopPullRequestUpdates: (() => void) | null = null;
@@ -44,6 +45,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
   private readonly hovercard = new PortaledHovercardController(() => this.close());
   private readonly sessionLinkTitler = new SessionLinkTitler(this);
   private loadGeneration = 0;
+  private gatewaySnapshotRevision = 0;
   private readonly activeTargetObserver = new MutationObserver(() => {
     if (this.activeTarget && !this.contains(this.activeTarget)) {
       this.close();
@@ -119,11 +121,14 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
     if (!this.applicationGateway || this.progressCards) {
       return;
     }
+    this.stopGatewayUpdates = this.applicationGateway.subscribe(this.handleGatewayUpdate);
     this.progressCards = sessionProgressCardsForGateway(this.applicationGateway);
     this.stopProgressCardUpdates = this.progressCards.subscribe(this.handleProgressCardUpdate);
   }
 
   private disconnectStore(): void {
+    this.stopGatewayUpdates?.();
+    this.stopGatewayUpdates = null;
     this.progressCards?.unwatch(this);
     this.stopProgressCardUpdates?.();
     this.stopProgressCardUpdates = null;
@@ -141,6 +146,13 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       this.lastProgressCard = card;
     }
     this.showCurrent();
+  };
+
+  private readonly handleGatewayUpdate = () => {
+    this.gatewaySnapshotRevision += 1;
+    if (this.open && this.hovercard.held) {
+      this.showCurrent();
+    }
   };
 
   private readonly handlePullRequestUpdate = () => {
@@ -311,6 +323,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
       ),
     };
     const revision = JSON.stringify({
+      gateway: this.gatewaySnapshotRevision,
       progress: this.lastProgressCard?.revision ?? null,
       pullRequests: pullRequests
         ? { branch: pullRequests.branch, pullRequests: pullRequests.pullRequests }

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -421,6 +421,82 @@ suite.define(() => {
     );
   });
 
+  it("refreshes a held avatar after Gateway authentication reconnects", async () => {
+    const sessionKey = "agent:main:avatar-auth-reconnect";
+    const channelAvatarUrl = `/__openclaw__/channel-avatar/${encodeURIComponent(sessionKey)}`;
+
+    await suite.withPage(
+      {
+        hasTouch: false,
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        let avatarAvailable = false;
+        await page.route(`**${channelAvatarUrl}`, async (route) => {
+          expect(await route.request().headerValue("authorization")).toBe(
+            "Bearer e2e-device-token",
+          );
+          if (!avatarAvailable) {
+            await route.fulfill({ status: 401 });
+            return;
+          }
+          await route.fulfill({
+            body: `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><rect width="64" height="64" rx="32" fill="#b84cff"/><circle cx="24" cy="27" r="5" fill="white"/><circle cx="43" cy="27" r="5" fill="white"/><path d="M19 43c8 6 19 6 27 0" fill="none" stroke="white" stroke-width="4" stroke-linecap="round"/></svg>`,
+            contentType: "image/svg+xml",
+            status: 200,
+          });
+        });
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
+          methodResponses: {
+            "progressCard.get": { card: null },
+            "sessions.list": chatSessionListResponse([
+              {
+                channelAvatarUrl,
+                createdActor: { type: "human", id: "profile-ada", label: "Ada King" },
+                key: sessionKey,
+                kind: "direct",
+                label: "Avatar reconnect",
+                updatedAt: 1,
+              },
+            ]),
+          },
+          sessionKey,
+        });
+
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+        const row = page.locator(`.sidebar-recent-session[data-session-key="${sessionKey}"]`);
+        await row.waitFor({ state: "visible" });
+        await row.hover();
+        const card = page.locator(".session-progress-hovercard");
+        await card.waitFor({ state: "visible" });
+        const avatar = card.locator("openclaw-channel-avatar.session-hovercard__avatar");
+        await expect
+          .poll(() => avatar.locator(".session-hovercard__avatar-fallback").textContent())
+          .toBe("AK");
+        expect(await avatar.locator("img.channel-avatar").count()).toBe(0);
+
+        avatarAvailable = true;
+        await gateway.setOnline(false);
+        await gateway.setOnline(true);
+
+        await expect.poll(() => avatar.locator("img.channel-avatar").count()).toBe(1);
+        await expect
+          .poll(() =>
+            avatar.locator("img.channel-avatar").evaluate((image: HTMLImageElement) => ({
+              complete: image.complete,
+              naturalWidth: image.naturalWidth,
+            })),
+          )
+          .toEqual({ complete: true, naturalWidth: 64 });
+        expect(await avatar.locator(".session-hovercard__avatar-fallback").count()).toBe(0);
+        await captureProof(page, "hovercard-avatar-after-reconnect.png");
+      },
+    );
+  });
+
   it("shows the latest turn when the session has no progress card", async () => {
     const now = Date.now();
     const sessionKey = "agent:main:no-progress-card";


### PR DESCRIPTION
Related: #126372

## What Problem This Solves

Fixes an issue where a session hovercard opened while its channel avatar was unavailable could remain on owner initials after the Gateway reconnected and the authenticated image became available. The same `ApplicationGateway` object survives snapshot changes, so the hovercard provider's object setter does not run again and its render revision previously stayed unchanged.

## Why This Change Was Made

The hovercard provider now subscribes to its existing Gateway lifecycle alongside its progress-card store, increments a private non-secret snapshot revision, and refreshes a held card when the Gateway publishes a new snapshot. Disconnection removes the subscription with the provider's other store listeners. This delivers current auth properties to the existing shared avatar component without adding a parallel auth or loading path.

## User Impact

A hovercard can stay open across a reconnect and automatically upgrade from initials to the real channel avatar as soon as authenticated loading is available; users no longer need to close and re-hover the session.

## Evidence

The captured mocked-Gateway flow starts with the avatar route rejecting authentication, keeps the hovercard open through offline/online recovery, then shows the same decoded purple face image in the row and hovercard without re-hovering:

![Held session hovercard refreshed to the real avatar after reconnect](https://github.com/user-attachments/assets/f12bbeaf-7b47-48e4-bbf0-f12a07cbb890)

- Pre-fix proof: the focused reconnect E2E failed because the held hovercard still had zero `img.channel-avatar` elements after reconnect.
- `node scripts/run-vitest.mjs ui/src/components/session-hovercard.test.ts` — 8 passed.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-progress-hovercard.e2e.test.ts` — 4 passed.
- `pnpm tsgo:ui`
- `pnpm lint:ui:styles`
- `pnpm check:assertion-safety`
- UI-scoped Knip production and export checks
- `pnpm ui:build` — startup remains within the existing JS/CSS budgets.
- Targeted oxfmt and `git diff --check`
- Branch autoreview — clean, no accepted/actionable findings.

Production LOC: +13/-0 | Tests: +76/-0. The production growth is the missing lifecycle subscription, cleanup, private invalidator, and held-card refresh; it reuses the existing Gateway and avatar owners.

AI-assisted by Codex; implementation, failing/passing behavior, and the screenshot were manually inspected.
