### PR TITLE
fix(status): bound macOS Gateway status timeout

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2418,7 +2418,6 @@ src/cli/cron-cli/register.cron-simple.ts	2
 src/cli/cron-cli/shared.ts	8
 src/cli/daemon-cli/launchd-recovery.ts	1
 src/cli/daemon-cli/lifecycle.ts	1
-src/cli/daemon-cli/probe.ts	1
 src/cli/daemon-cli/restart-health-probe.ts	9
 src/cli/daemon-cli/restart-health.ts	1
 src/cli/daemon-cli/start-repair.ts	1

--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -11,7 +11,8 @@ vi.mock("../../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => callGatewayMock(...args),
 }));
 
-vi.mock("../../gateway/probe.js", () => ({
+vi.mock("../../gateway/probe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../gateway/probe.js")>()),
   probeGateway: (...args: unknown[]) => probeGatewayMock(...args),
 }));
 
@@ -276,14 +277,12 @@ describe("probeGatewayStatus", () => {
   it("uses a real status RPC when requireRpc is enabled", async () => {
     callGatewayMock.mockReset();
     probeGatewayMock.mockReset();
-    callGatewayMock.mockResolvedValueOnce({ status: "ok" });
-    probeGatewayMock.mockResolvedValueOnce({
-      ok: true,
-      auth: {
-        role: "operator",
-        scopes: ["operator.admin"],
-        capability: "admin_capable",
-      },
+    callGatewayMock.mockImplementationOnce(async (opts) => {
+      opts.onHelloOk?.({
+        server: { version: "2026.8.1", buildId: "build-1", connId: "conn-1" },
+        auth: { role: "operator", scopes: ["operator.admin"] },
+      });
+      return { runtimeVersion: "2026.8.1", status: "ok" };
     });
 
     const result = await probeGatewayStatus({
@@ -305,41 +304,33 @@ describe("probeGatewayStatus", () => {
         scopes: ["operator.admin"],
         capability: "admin_capable",
       },
-    });
-    expect(probeGatewayMock).toHaveBeenCalledWith({
-      url: "ws://127.0.0.1:19191",
-      auth: {
-        token: "temp-token",
-        password: undefined,
+      server: {
+        version: "2026.8.1",
+        buildId: "build-1",
+        connId: "conn-1",
       },
-      tlsFingerprint: "abc123",
-      timeoutMs: 5_000,
-      includeDetails: false,
+      version: "2026.8.1",
     });
+    expect(probeGatewayMock).not.toHaveBeenCalled();
+    expect(callGatewayMock).toHaveBeenCalledOnce();
     expect(callGatewayMock).toHaveBeenCalledWith({
       url: "ws://127.0.0.1:19191",
       token: "temp-token",
       password: undefined,
       tlsFingerprint: "abc123",
+      preauthHandshakeTimeoutMs: undefined,
       method: "status",
       timeoutMs: 5_000,
       sharedStateMode: "read-only",
       configPath: "/tmp/openclaw-daemon/openclaw.json",
+      onHelloOk: expect.any(Function),
     });
   });
 
-  it("forwards the resolved handshake timeout to the connect probe and status RPC", async () => {
+  it("keeps required status to one timeout-bound RPC", async () => {
     callGatewayMock.mockReset();
     probeGatewayMock.mockReset();
     callGatewayMock.mockResolvedValueOnce({ status: "ok" });
-    probeGatewayMock.mockResolvedValueOnce({
-      ok: true,
-      auth: {
-        role: "operator",
-        scopes: ["operator.admin"],
-        capability: "admin_capable",
-      },
-    });
     const config = {};
 
     await probeGatewayStatus({
@@ -351,27 +342,19 @@ describe("probeGatewayStatus", () => {
       requireRpc: true,
     });
 
-    expect(probeGatewayMock).toHaveBeenCalledWith({
-      url: "ws://127.0.0.1:19191",
-      config,
-      auth: {
-        token: "temp-token",
-        password: undefined,
-      },
-      tlsFingerprint: undefined,
-      preauthHandshakeTimeoutMs: 30_000,
-      timeoutMs: 30_000,
-      includeDetails: false,
-    });
+    expect(probeGatewayMock).not.toHaveBeenCalled();
+    expect(callGatewayMock).toHaveBeenCalledOnce();
     expect(callGatewayMock).toHaveBeenCalledWith({
       url: "ws://127.0.0.1:19191",
       token: "temp-token",
       password: undefined,
       tlsFingerprint: undefined,
+      preauthHandshakeTimeoutMs: 30_000,
       config,
       method: "status",
       timeoutMs: 30_000,
       sharedStateMode: "read-only",
+      onHelloOk: expect.any(Function),
     });
   });
 
@@ -415,9 +398,11 @@ describe("probeGatewayStatus", () => {
       token: "temp-token",
       password: undefined,
       tlsFingerprint: undefined,
+      preauthHandshakeTimeoutMs: undefined,
       method: "status",
       timeoutMs: 5_000,
       sharedStateMode: "read-only",
+      onHelloOk: expect.any(Function),
     });
   });
 
@@ -456,17 +441,15 @@ describe("probeGatewayStatus", () => {
     expect(probeGatewayMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to read-only when the status RPC succeeds but the auth probe is inconclusive", async () => {
+  it("falls back to read-only when hello scopes are inconclusive", async () => {
     callGatewayMock.mockReset();
     probeGatewayMock.mockReset();
-    callGatewayMock.mockResolvedValueOnce({ status: "ok" });
-    probeGatewayMock.mockResolvedValueOnce({
-      ok: true,
-      auth: {
-        role: null,
-        scopes: [],
-        capability: "unknown",
-      },
+    callGatewayMock.mockImplementationOnce(async (opts) => {
+      opts.onHelloOk?.({
+        server: { version: "2026.8.1", connId: "conn-1" },
+        auth: { role: "operator", scopes: [] },
+      });
+      return { status: "ok" };
     });
 
     const result = await probeGatewayStatus({
@@ -480,51 +463,26 @@ describe("probeGatewayStatus", () => {
       ok: true,
       kind: "read",
       capability: "read_only",
-      auth: {
-        role: null,
-        scopes: [],
-        capability: "unknown",
-      },
-    });
-  });
-
-  it("uses status.runtimeVersion when read-probe handshake metadata is unavailable", async () => {
-    callGatewayMock.mockReset();
-    probeGatewayMock.mockReset();
-    callGatewayMock.mockResolvedValueOnce({ runtimeVersion: "2026.4.24", status: "ok" });
-    probeGatewayMock.mockRejectedValueOnce(new Error("probe timed out after status"));
-
-    const result = await probeGatewayStatus({
-      url: "ws://127.0.0.1:19191",
-      token: "temp-token",
-      timeoutMs: 5_000,
-      requireRpc: true,
-    });
-
-    expect(result).toEqual({
-      ok: true,
-      kind: "read",
-      capability: "read_only",
-      auth: undefined,
-      version: "2026.4.24",
-    });
-  });
-
-  it("prefers read-probe server metadata over status.runtimeVersion", async () => {
-    callGatewayMock.mockReset();
-    probeGatewayMock.mockReset();
-    callGatewayMock.mockResolvedValueOnce({ runtimeVersion: "2026.4.23", status: "ok" });
-    probeGatewayMock.mockResolvedValueOnce({
-      ok: true,
       auth: {
         role: "operator",
-        scopes: ["operator.read"],
-        capability: "read_only",
+        scopes: [],
+        capability: "unknown",
       },
-      server: {
-        version: "2026.4.24",
-        connId: "conn-1",
-      },
+      server: { version: "2026.8.1", connId: "conn-1" },
+      version: "2026.8.1",
+    });
+    expect(probeGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("prefers same-connection server metadata over status.runtimeVersion", async () => {
+    callGatewayMock.mockReset();
+    probeGatewayMock.mockReset();
+    callGatewayMock.mockImplementationOnce(async (opts) => {
+      opts.onHelloOk?.({
+        server: { version: "2026.4.24", connId: "conn-1" },
+        auth: { role: "operator", scopes: ["operator.read"] },
+      });
+      return { runtimeVersion: "2026.4.23", status: "ok" };
     });
 
     const result = await probeGatewayStatus({
@@ -549,6 +507,7 @@ describe("probeGatewayStatus", () => {
       },
       version: "2026.4.24",
     });
+    expect(probeGatewayMock).not.toHaveBeenCalled();
   });
 
   it("surfaces probe close details when the handshake fails", async () => {

--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -6,18 +6,12 @@ import {
   readConnectErrorDetailCode,
 } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import type { OpenClawConfig } from "../../config/types.js";
-import type { GatewayProbeResult } from "../../gateway/probe.js";
+import type { GatewayProbeAuthSummary, GatewayProbeServerSummary } from "../../gateway/probe.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { withProgress } from "../progress.js";
 
 type GatewayStatusProbeKind = "connect" | "read";
-type GatewayStatusRequireRpcProbeResult = {
-  ok: true;
-  authProbe: GatewayProbeResult | null;
-};
-type GatewayStatusProbeResult = GatewayProbeResult | GatewayStatusRequireRpcProbeResult;
-
 const probeGatewayModuleLoader = createLazyImportLoader(() => import("../../gateway/probe.js"));
 const CONNECT_ERROR_DETAIL_CODE_VALUES: ReadonlySet<string> = new Set(
   Object.values(ConnectErrorDetailCodes),
@@ -40,10 +34,6 @@ function resolveProbeFailureMessage(result: {
   return result.error ?? closeHint ?? "gateway probe failed";
 }
 
-function resolveGatewayStatusProbeDetails(result: GatewayStatusProbeResult) {
-  return "authProbe" in result ? result.authProbe : result;
-}
-
 function projectGatewayConnectFailure(params: {
   details?: unknown;
   message: string;
@@ -57,16 +47,6 @@ function projectGatewayConnectFailure(params: {
     kind: failure.kind,
     ...(detailCode && CONNECT_ERROR_DETAIL_CODE_VALUES.has(detailCode) ? { detailCode } : {}),
   };
-}
-
-function readRuntimeVersionFromStatusPayload(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object") {
-    return null;
-  }
-  const runtimeVersion = (payload as { runtimeVersion?: unknown }).runtimeVersion;
-  return typeof runtimeVersion === "string" && runtimeVersion.trim().length > 0
-    ? runtimeVersion.trim()
-    : null;
 }
 
 /** Probe Gateway connectivity or read-capability status with optional RPC verification. */
@@ -85,16 +65,48 @@ export async function probeGatewayStatus(opts: {
 }) {
   const kind = (opts.requireRpc ? "read" : "connect") satisfies GatewayStatusProbeKind;
   try {
-    let statusRuntimeVersion: string | null = null;
-    const result = await withProgress<GatewayStatusProbeResult>(
+    const result = await withProgress(
       {
         label: "Checking gateway status...",
         indeterminate: true,
         enabled: opts.json !== true,
       },
       async () => {
+        if (opts.requireRpc) {
+          const allowRpcConfigCredentials = opts.allowRpcConfigCredentials !== false;
+          if (!allowRpcConfigCredentials && !opts.token && !opts.password) {
+            throw new Error(
+              "gateway status RPC skipped because configured gateway credentials are disabled for this status request",
+            );
+          }
+          const { resolveProbeAuthSummary } = await loadProbeGatewayModule();
+          const { callGateway } = await import("../../gateway/call.js");
+          let auth: GatewayProbeAuthSummary | undefined;
+          let server: GatewayProbeServerSummary | undefined;
+          await callGateway({
+            url: opts.url,
+            token: opts.token,
+            password: opts.password,
+            tlsFingerprint: opts.tlsFingerprint,
+            preauthHandshakeTimeoutMs: opts.preauthHandshakeTimeoutMs,
+            ...(allowRpcConfigCredentials && opts.config ? { config: opts.config } : {}),
+            method: "status",
+            timeoutMs: opts.timeoutMs,
+            sharedStateMode: "read-only",
+            ...(opts.configPath ? { configPath: opts.configPath } : {}),
+            onHelloOk: (hello) => {
+              auth = resolveProbeAuthSummary({
+                role: hello.auth.role,
+                scopes: hello.auth.scopes,
+                authMetadataPresent: true,
+              });
+              server = hello.server;
+            },
+          });
+          return { ok: true as const, auth, server };
+        }
         const { probeGateway } = await loadProbeGatewayModule();
-        const probeOpts = {
+        return await probeGateway({
           url: opts.url,
           ...(opts.config ? { config: opts.config } : {}),
           auth: {
@@ -107,38 +119,13 @@ export async function probeGatewayStatus(opts: {
             : {}),
           timeoutMs: opts.timeoutMs,
           includeDetails: false,
-        };
-        if (opts.requireRpc) {
-          const allowRpcConfigCredentials = opts.allowRpcConfigCredentials !== false;
-          if (!allowRpcConfigCredentials && !opts.token && !opts.password) {
-            throw new Error(
-              "gateway status RPC skipped because configured gateway credentials are disabled for this status request",
-            );
-          }
-          const { callGateway } = await import("../../gateway/call.js");
-          const statusPayload = await callGateway({
-            url: opts.url,
-            token: opts.token,
-            password: opts.password,
-            tlsFingerprint: opts.tlsFingerprint,
-            ...(allowRpcConfigCredentials && opts.config ? { config: opts.config } : {}),
-            method: "status",
-            timeoutMs: opts.timeoutMs,
-            sharedStateMode: "read-only",
-            ...(opts.configPath ? { configPath: opts.configPath } : {}),
-          });
-          statusRuntimeVersion = readRuntimeVersionFromStatusPayload(statusPayload);
-          const authProbe = await probeGateway(probeOpts).catch(() => null);
-          return { ok: true as const, authProbe };
-        }
-        return await probeGateway(probeOpts);
+        });
       },
     );
-    const probeDetails = resolveGatewayStatusProbeDetails(result);
-    const auth = probeDetails?.auth;
-    const server = probeDetails?.server;
+    const auth = result.auth;
+    const server = result.server;
     const serverSummary = server ? { server } : {};
-    const version = server?.version ?? ("authProbe" in result ? statusRuntimeVersion : null);
+    const version = server?.version ?? null;
     if (result.ok) {
       return {
         ok: true,
@@ -163,9 +150,9 @@ export async function probeGatewayStatus(opts: {
       ...serverSummary,
       ...(version != null ? { version } : {}),
       connectFailure: projectGatewayConnectFailure({
-        details: probeDetails?.connectErrorDetails,
+        details: result.connectErrorDetails,
         message: error,
-        reason: probeDetails?.close?.reason,
+        reason: result.close?.reason,
       }),
       // Probe failure text can echo the credential-bearing target URL (close
       // reasons, transport errors); status renderers print it verbatim.

--- a/src/daemon/launchd-exec.ts
+++ b/src/daemon/launchd-exec.ts
@@ -7,11 +7,14 @@ import { execFileUtf8 } from "./exec-file.js";
 
 export type LaunchctlResult = { stdout: string; stderr: string; code: number };
 
-export async function execLaunchctl(args: string[]): Promise<LaunchctlResult> {
+export async function execLaunchctl(args: string[], timeoutMs?: number): Promise<LaunchctlResult> {
   const isWindows = process.platform === "win32";
   const file = isWindows ? getWindowsCmdExePath() : "launchctl";
   const fileArgs = isWindows ? ["/d", "/s", "/c", "launchctl", ...args] : args;
-  return await execFileUtf8(file, fileArgs, isWindows ? { windowsHide: true } : {});
+  return await execFileUtf8(file, fileArgs, {
+    ...(isWindows ? { windowsHide: true } : {}),
+    ...(timeoutMs && timeoutMs > 0 ? { timeout: timeoutMs, killSignal: "SIGKILL" as const } : {}),
+  });
 }
 
 export function isLaunchctlNotLoaded(result: Pick<LaunchctlResult, "stdout" | "stderr">): boolean {

--- a/src/daemon/launchd-runtime.ts
+++ b/src/daemon/launchd-runtime.ts
@@ -208,7 +208,7 @@ export async function isLaunchAgentEnabled(args: GatewayServiceEnvArgs): Promise
 export async function isLaunchAgentLoaded(args: GatewayServiceEnvArgs): Promise<boolean> {
   const domain = resolveLaunchAgentGuiDomain();
   const label = resolveLaunchAgentLabel(args.env);
-  const probe = await probeLaunchAgentState(`${domain}/${label}`);
+  const probe = await probeLaunchAgentState(`${domain}/${label}`, args.timeoutMs);
   if (probe.state === "running" || probe.state === "stopped") {
     return true;
   }
@@ -230,12 +230,13 @@ export async function launchAgentPlistExists(env: GatewayServiceEnv): Promise<bo
 
 export async function readLaunchAgentRuntime(
   env: Record<string, string | undefined>,
+  opts?: Pick<GatewayServiceEnvArgs, "timeoutMs">,
 ): Promise<GatewayServiceRuntime> {
   const domain = resolveLaunchAgentGuiDomain();
   const label = resolveLaunchAgentLabel(env);
   const [probe, systemOwnership] = await Promise.all([
-    probeLaunchAgentState(`${domain}/${label}`),
-    inspectSystemLaunchDaemonOwnership(label, { scanInstalledPlists: false }),
+    probeLaunchAgentState(`${domain}/${label}`, opts?.timeoutMs),
+    inspectSystemLaunchDaemonOwnership(label, { ...opts, scanInstalledPlists: false }),
   ]);
   if (systemOwnership.status !== "absent") {
     return {
@@ -329,10 +330,11 @@ type LaunchAgentProbeResult =
 
 export async function probeLaunchAgentState(
   serviceTarget: string,
+  timeoutMs?: number,
 ): Promise<LaunchAgentProbeResult> {
   // `launchctl print` output is not a stable API. Keep expected absence and
   // unexpected failures distinct so every caller applies one classification.
-  const probe = await execLaunchctl(["print", serviceTarget]);
+  const probe = await execLaunchctl(["print", serviceTarget], timeoutMs);
   if (probe.code !== 0) {
     if (isLaunchctlNotLoaded(probe)) {
       return { state: "not-loaded" };

--- a/src/daemon/launchd-system.test.ts
+++ b/src/daemon/launchd-system.test.ts
@@ -173,7 +173,7 @@ describe("system LaunchDaemon ownership", () => {
       status: "loaded",
       serviceTarget: "system/ai.openclaw.gateway",
     });
-    expect(execLaunchctl).toHaveBeenCalledWith(["print", "system/ai.openclaw.gateway"]);
+    expect(execLaunchctl).toHaveBeenCalledWith(["print", "system/ai.openclaw.gateway"], undefined);
   });
 
   it("fails closed when launchctl cannot classify system ownership", async () => {

--- a/src/daemon/launchd-system.ts
+++ b/src/daemon/launchd-system.ts
@@ -216,7 +216,7 @@ function classifySystemLaunchDaemonQuery(
 
 export async function inspectSystemLaunchDaemonOwnership(
   label: string,
-  options: { scanInstalledPlists?: boolean } = {},
+  options: { scanInstalledPlists?: boolean; timeoutMs?: number } = {},
 ): Promise<SystemLaunchDaemonOwnership> {
   const serviceTarget = `system/${label}`;
   if (process.platform !== "darwin") {
@@ -225,7 +225,7 @@ export async function inspectSystemLaunchDaemonOwnership(
 
   const initialQuery = classifySystemLaunchDaemonQuery(
     serviceTarget,
-    await execLaunchctl(["print", serviceTarget]),
+    await execLaunchctl(["print", serviceTarget], options.timeoutMs),
   );
   if (initialQuery.status !== "absent") {
     return initialQuery;
@@ -251,7 +251,7 @@ export async function inspectSystemLaunchDaemonOwnership(
   // activation paths therefore repeat this complete probe immediately before use.
   return classifySystemLaunchDaemonQuery(
     serviceTarget,
-    await execLaunchctl(["print", serviceTarget]),
+    await execLaunchctl(["print", serviceTarget], options.timeoutMs),
   );
 }
 

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -4,7 +4,7 @@ import { PassThrough } from "node:stream";
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PortListener } from "../infra/ports-types.js";
-import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { deleteTestEnvValue, setTestEnvValue, withEnvAsync } from "../test-utils/env.js";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "./constants.js";
 import {
   LAUNCH_AGENT_ENV_WRAPPER_SHELL,
@@ -66,6 +66,7 @@ const state = vi.hoisted(() => ({
   fileModes: new Map<string, number>(),
   fileWrites: [] as Array<{ path: string; data: string }>,
   cleanupProtectedPids: [] as Array<number | undefined>,
+  realExecFile: false,
 }));
 const launchdRestartHandoffState = vi.hoisted(() => ({
   scheduleDetachedLaunchdMaintenancePark: vi.fn<
@@ -444,9 +445,16 @@ vi.mock("node:child_process", async () => {
   );
 });
 
-vi.mock("./exec-file.js", () => ({
-  execFileUtf8: vi.fn(async (file: string, args: string[]) => executeLaunchctlMock(file, args)),
-}));
+vi.mock("./exec-file.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./exec-file.js")>();
+  return {
+    execFileUtf8: vi.fn(async (...args: Parameters<typeof actual.execFileUtf8>) =>
+      state.realExecFile
+        ? await actual.execFileUtf8(...args)
+        : executeLaunchctlMock(args[0], args[1]),
+    ),
+  };
+});
 
 vi.mock("./launchd-restart-handoff.js", () => ({
   scheduleDetachedLaunchdMaintenancePark: (params: unknown) =>
@@ -625,6 +633,7 @@ beforeEach(() => {
   state.fileModes.clear();
   state.fileWrites.length = 0;
   state.cleanupProtectedPids.length = 0;
+  state.realExecFile = false;
   state.serviceStates.clear();
   launchdConstantsState.legacyGatewayLabels.length = 0;
   launchctlSpawnSync.mockReset();
@@ -752,6 +761,28 @@ describe("launchd runtime parsing", () => {
 });
 
 describe("launchd runtime state", () => {
+  it.runIf(process.platform === "darwin")(
+    "fails soft within the supplied deadline when launchctl blocks",
+    async () => {
+      const realFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+      const tempDir = await realFs.mkdtemp(`${process.env.TMPDIR ?? "/tmp"}/openclaw-launchd-`);
+      await realFs.writeFile(`${tempDir}/launchctl`, "#!/bin/sh\nsleep 2\n", { mode: 0o755 });
+      state.realExecFile = true;
+
+      try {
+        await withEnvAsync({ PATH: `${tempDir}:${process.env.PATH ?? ""}` }, async () => {
+          const startedAt = Date.now();
+          const runtime = await readLaunchAgentRuntime({ HOME: tempDir }, { timeoutMs: 100 });
+          expect(Date.now() - startedAt).toBeLessThan(1_000);
+          expect(runtime.status).toBe("unknown");
+        });
+      } finally {
+        state.realExecFile = false;
+        await realFs.rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
+
   it("reports an installed but unloaded LaunchAgent as stopped", async () => {
     const env = createDefaultLaunchdEnv();
     state.files.set(resolveLaunchAgentPlistPath(env), "<plist/>");

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -1156,6 +1156,30 @@ describe("callGateway url resolution", () => {
     expect(loadOriginDeviceTokenMock).not.toHaveBeenCalled();
   });
 
+  it("isolates the accepted-hello observer from the RPC", async () => {
+    let observedHello: HelloOk | undefined;
+    const onHelloOk = vi.fn((hello: HelloOk) => {
+      observedHello = hello;
+      throw new Error("observer failed");
+    });
+
+    await expect(
+      callGateway({
+        method: "status",
+        scopes: ["operator.read"],
+        sharedStateMode: "read-only",
+        preauthHandshakeTimeoutMs: 2_345,
+        onHelloOk,
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    expect(onHelloOk).toHaveBeenCalledOnce();
+    expect(observedHello).toEqual(makeStubGatewayHello());
+    expect(lastRequestOptions?.method).toBe("status");
+    expect(lastClientOptions?.sharedStateMode).toBe("read-only");
+    expect(lastClientOptions?.preauthHandshakeTimeoutMs).toBe(2_345);
+  });
+
   it("uses stored device auth for the exact normalized url override origin", async () => {
     setLocalLoopbackGatewayConfig();
     loadOriginDeviceTokenMock.mockImplementation((...args: unknown[]) =>

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -62,6 +62,7 @@ import {
   GatewayClient,
   isGatewayConnectAssemblyError,
   type GatewayClientCloseInfo,
+  type GatewayClientOptions,
   type GatewayClientRequestOptions,
 } from "./client.js";
 import {
@@ -119,6 +120,7 @@ type CallGatewayBaseOptions = {
   token?: string;
   password?: string;
   tlsFingerprint?: string;
+  preauthHandshakeTimeoutMs?: number;
   config?: OpenClawConfig;
   method: string;
   params?: unknown;
@@ -138,6 +140,7 @@ type CallGatewayBaseOptions = {
   requiredStoredDeviceAuthScopes?: OperatorScope[];
   requireLocalBackendSharedAuth?: boolean;
   sharedStateMode?: "read-only";
+  onHelloOk?: GatewayClientOptions["onHelloOk"];
   deviceIdentity?: DeviceIdentity | null;
   instanceId?: string;
   minProtocol?: number;
@@ -854,7 +857,6 @@ async function executeGatewayRequestWithScopes<T>(params: {
   password?: string;
   edgeAuthHeaders?: Readonly<Record<string, string>>;
   tlsFingerprint?: string;
-  preauthHandshakeTimeoutMs?: number;
   timeoutMs: number | null;
   startupTimeoutMs: number;
   safeTimerTimeoutMs: number;
@@ -872,7 +874,6 @@ async function executeGatewayRequestWithScopes<T>(params: {
     password,
     edgeAuthHeaders,
     tlsFingerprint,
-    preauthHandshakeTimeoutMs,
     timeoutMs,
     startupTimeoutMs,
     safeTimerTimeoutMs,
@@ -955,7 +956,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       password,
       edgeAuthHeaders,
       tlsFingerprint,
-      preauthHandshakeTimeoutMs,
+      preauthHandshakeTimeoutMs: opts.preauthHandshakeTimeoutMs,
       instanceId: opts.instanceId ?? randomUUID(),
       clientName: opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI,
       clientDisplayName: resolveGatewayClientDisplayName(opts),
@@ -979,6 +980,9 @@ async function executeGatewayRequestWithScopes<T>(params: {
           clearTimeout(timer);
           timer = undefined;
         }
+        try {
+          opts.onHelloOk?.(hello);
+        } catch {}
         void (async () => {
           try {
             ensureGatewaySupportsRequiredMethods({

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -194,7 +194,7 @@ function makeDeviceRequiredShortCircuitResult(url: string): GatewayProbeResult {
   };
 }
 
-function resolveProbeAuthSummary(params: {
+export function resolveProbeAuthSummary(params: {
   role?: string | null;
   scopes?: string[];
   authMetadataPresent?: boolean;


### PR DESCRIPTION
Closes #126350

## What Problem This Solves

Fixes an issue where operators running `gateway status --require-rpc` on macOS could wait roughly twice the configured probe timeout when launchd inspection was slow or wedged. The command performed unbounded launchd reads before opening two separately bounded Gateway connections.

## Why This Change Was Made

The existing service-read timeout now reaches only launchd read probes, where `launchctl` is bounded with the timeout and `SIGKILL`; launchd lifecycle mutations remain unchanged. Required RPC status now uses one bounded `status` connection and captures auth, server, version, and handshake metadata from that same connection instead of opening a second probe.

## User Impact

Managed macOS status and recovery checks now fail soft to an unknown service state when launchd does not answer within the configured bound, and required RPC status no longer spends a second full connection budget. Normal launchd mutation behavior and successful status output remain unchanged.

## Evidence

- Pre-fix live evidence in #126350: a 30-second timeout completed after approximately 62 seconds under host pressure.
- `node scripts/run-vitest.mjs src/daemon/launchd.test.ts src/daemon/launchd-system.test.ts src/cli/daemon-cli/probe.test.ts src/gateway/call.test.ts src/gateway/probe.test.ts` — 379 tests passed across 3 shards. This includes the ordinary launchd suite's real blocking-`launchctl` regression.
- `node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main` — clean; the stale `src/cli/daemon-cli/probe.ts` baseline entry was removed.
- Targeted `oxfmt --check` on all 10 touched TypeScript files — clean.
- `git diff --check origin/main...HEAD` — clean.
- `/Users/steipete/.claude/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings.
- Production LOC: +58/-62 (net -4); tests: +103/-89; assertion-safety baseline: -1.

Proof limitation: the after-fix path is verified by deterministic owner-boundary regression tests rather than a second live host-pressure reproduction on a managed production Gateway.

AI-assisted; reviewed and validated by the maintainer.
