### PR TITLE
fix(ui): dashboard side panel closes in split view

### DIFF
--- a/ui/src/e2e/board-split-transcript.e2e.test.ts
+++ b/ui/src/e2e/board-split-transcript.e2e.test.ts
@@ -11,6 +11,7 @@ import {
   startControlUiE2eServer,
   type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
+import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
 
 const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
@@ -52,6 +53,30 @@ async function visibleTranscriptState(page: Page) {
     ).length;
     return { present: true, intersectingRows };
   });
+}
+
+async function showDashboard(page: Page) {
+  const settingsKey = controlUiBundledSettingsStorageKey(controlUi.baseUrl);
+  await page.addInitScript(
+    ({ key, storageKey }) => {
+      const settings = JSON.parse(localStorage.getItem(storageKey) ?? "{}") as Record<
+        string,
+        unknown
+      >;
+      settings.boardSessionViews = { [key]: { activeTabId: "main" } };
+      localStorage.setItem(storageKey, JSON.stringify(settings));
+    },
+    { key: sessionKey, storageKey: settingsKey },
+  );
+  await page.goto(`${controlUi.baseUrl}dashboard`);
+}
+
+async function expectSidePanelTabs(page: Page, expected: string[]) {
+  const labels = page.locator(".side-panel > .side-panel__header .tabstrip-tab__label");
+  await expect
+    .poll(() => labels.allTextContents().then((values) => values.toSorted()))
+    .toEqual(expected.toSorted());
+  await labels.first().waitFor({ state: "visible" });
 }
 
 describeControlUiE2e("Board split transcript restore", () => {
@@ -96,19 +121,7 @@ describeControlUiE2e("Board split transcript restore", () => {
       })),
     });
 
-    const settingsKey = controlUiBundledSettingsStorageKey(controlUi.baseUrl);
-    await page.addInitScript(
-      ({ key, storageKey }) => {
-        const settings = JSON.parse(localStorage.getItem(storageKey) ?? "{}") as Record<
-          string,
-          unknown
-        >;
-        settings.boardSessionViews = { [key]: { activeTabId: "main" } };
-        localStorage.setItem(storageKey, JSON.stringify(settings));
-      },
-      { key: sessionKey, storageKey: settingsKey },
-    );
-    await page.goto(`${controlUi.baseUrl}dashboard`);
+    await showDashboard(page);
     await page.locator(".board-session-surface").waitFor();
     await page.getByText("Message number 39:").first().waitFor({ timeout: 15_000 });
 
@@ -143,5 +156,107 @@ describeControlUiE2e("Board split transcript restore", () => {
       .getByText("Message number 39:")
       .first()
       .waitFor({ state: "visible", timeout: 2_000 });
+  }, 120_000);
+
+  it("closes and reopens the whole multi-tab dashboard side panel", async () => {
+    const context = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+    contexts.add(context);
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      sessionKey,
+      terminalEnabled: true,
+      featureMethods: [
+        "board.get",
+        "board.update",
+        "browser.request",
+        "chat.metadata",
+        "chat.startup",
+        "terminal.open",
+      ],
+      methodResponses: {
+        "board.get": boardSnapshot("right"),
+        "board.update": boardSnapshot("right", 2),
+        "browser.request": {
+          cases: [
+            { match: { method: "GET", path: "/tabs" }, response: { running: false, tabs: [] } },
+          ],
+        },
+      },
+    });
+    await showDashboard(page);
+    await page.locator(".side-panel").waitFor();
+    await openChatSidePanelType(page, "Browser");
+    await openChatSidePanelType(page, "Terminal");
+
+    const board = page.locator(".board-session-surface__board");
+    const sidePanel = page.locator(".side-panel");
+    await sidePanel.waitFor();
+    const expectedTabLabels = ["Board chat", "Browser", "Terminal"];
+    await expectSidePanelTabs(page, expectedTabLabels);
+    await sidePanel
+      .locator(".side-panel-type-menu wa-dropdown-item")
+      .first()
+      .waitFor({ state: "hidden" });
+    const widthBeforeClose = await board.evaluate(
+      (element) => element.getBoundingClientRect().width,
+    );
+
+    await sidePanel.getByRole("button", { name: "Close", exact: true }).click();
+
+    await expect.poll(() => sidePanel.count()).toBe(0);
+    await expect
+      .poll(() => board.evaluate((element) => element.getBoundingClientRect().width))
+      .toBeGreaterThan(widthBeforeClose);
+    expect(await gateway.getRequests("board.update")).toEqual([]);
+
+    await page.getByRole("button", { name: "Side panel", exact: true }).click();
+    await sidePanel.waitFor();
+    await expectSidePanelTabs(page, expectedTabLabels);
+    expect(await sidePanel.locator('[data-panel-slot="chat"]').count()).toBe(1);
+    expect(await gateway.getRequests("board.update")).toEqual([]);
+  }, 120_000);
+
+  it("closes and reopens sole projected Board chat from either close control", async () => {
+    const context = await browser.newContext({ viewport: { width: 1400, height: 900 } });
+    contexts.add(context);
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      sessionKey,
+      featureMethods: ["board.get", "board.update", "chat.metadata", "chat.startup"],
+      methodResponses: {
+        "board.get": boardSnapshot("right"),
+        "board.update": boardSnapshot("right", 2),
+      },
+    });
+    await showDashboard(page);
+
+    const sidePanel = page.locator(".side-panel");
+    const headerToggle = page.locator(".chat-side-panel-toggle").first();
+    await sidePanel.waitFor();
+    await expectSidePanelTabs(page, ["Board chat"]);
+    await expect.poll(() => headerToggle.getAttribute("aria-expanded")).toBe("true");
+    await expect.poll(() => headerToggle.getAttribute("aria-label")).toBe("Minimize side panel");
+
+    await sidePanel.getByRole("button", { name: "Close", exact: true }).click();
+
+    await expect.poll(() => sidePanel.count()).toBe(0);
+    expect(await headerToggle.getAttribute("aria-expanded")).toBe("false");
+    expect(await headerToggle.getAttribute("aria-label")).toBe("Side panel");
+    expect(await gateway.getRequests("board.update")).toEqual([]);
+
+    await headerToggle.click();
+    await sidePanel.waitFor();
+    await expectSidePanelTabs(page, ["Board chat"]);
+    expect(await headerToggle.getAttribute("aria-expanded")).toBe("true");
+    expect(await gateway.getRequests("board.update")).toEqual([]);
+
+    await headerToggle.click();
+    await expect.poll(() => sidePanel.count()).toBe(0);
+    expect(await headerToggle.getAttribute("aria-expanded")).toBe("false");
+    expect(await gateway.getRequests("board.update")).toEqual([]);
+
+    await headerToggle.click();
+    await sidePanel.waitFor();
+    await expectSidePanelTabs(page, ["Board chat"]);
   }, 120_000);
 });

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -66,6 +66,7 @@ import { ChatTranscriptController } from "./components/chat-transcript-controlle
 import type { SessionDiscussionPanelConfig } from "./components/session-discussion-panel.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
 import type { SessionSnapshotStore } from "./session-snapshot-store.ts";
+import type { SidebarLayout } from "./sidebar-layout-types.ts";
 import { closeSlot, isSidebarSlotVisible, openSlot, setSidebarOpen } from "./sidebar-layout.ts";
 
 export abstract class ChatPaneBase extends OpenClawLightDomElement {
@@ -276,15 +277,16 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
     return visible ? "expanded" : "hidden";
   }
 
-  protected setChatSidePanelOpen(open: boolean): void {
+  protected setChatSidePanelOpen(open: boolean, layout?: SidebarLayout): void {
     const state = this.state;
     if (!state) {
       return;
     }
-    if (state.sidebarLayout.columns[0]?.panels.some((panel) => panel.slot === "companion")) {
+    const renderedLayout = layout ?? state.sidebarLayout;
+    if (renderedLayout.columns[0]?.panels.some((panel) => panel.slot === "companion")) {
       this.setSessionObserverVisibility(open);
     }
-    state.updateSidebarLayout(setSidebarOpen(state.sidebarLayout, open));
+    state.updateSidebarLayout(setSidebarOpen(renderedLayout, open));
   }
 
   protected requestSessionRail(intent: "open" | "toggle"): void {

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -43,6 +43,7 @@ import { renderChatSessionSharing } from "./components/chat-session-sharing.ts";
 import type { SessionWorkspaceProps } from "./components/chat-session-workspace.ts";
 import { renderContinueInTerminalDialog } from "./components/continue-in-terminal-dialog.ts";
 import { hasAbortableSessionRun } from "./run-lifecycle.ts";
+import type { SidebarLayout } from "./sidebar-layout.ts";
 
 export abstract class ChatPaneHeader extends ChatPaneDiscussion {
   /** Gateway-served project icon for a session workspace, on the same credentials as agent avatars. */
@@ -70,6 +71,7 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
     catalog: boolean,
     agentWorkspace: string | undefined,
     workspaceGit: boolean,
+    sidebarLayout?: SidebarLayout,
   ) {
     const board = this.resolveBoardView();
     const canChangeBoardDock = board.hasBoard && board.provider.canMutate;
@@ -191,13 +193,8 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       desktopEnvironmentId !== null && isDesktopPanelAvailable(this.context.gateway.snapshot);
     const openDesktopPanel = sessionWorkspace.onToggleDesktop ?? (() => undefined);
     const discussion = this.resolveSessionDiscussionAction();
-    const sidePanelOpen = this.state?.sidebarLayout.open === true;
-    const toggleSidePanel = () => {
-      const state = this.state;
-      if (state) {
-        this.setChatSidePanelOpen(!sidePanelOpen);
-      }
-    };
+    const sidePanelOpen = (sidebarLayout ?? this.state?.sidebarLayout)?.open === true;
+    const toggleSidePanel = () => this.setChatSidePanelOpen(!sidePanelOpen, sidebarLayout);
     const sidePanelAction = html`<openclaw-tooltip
       .content=${t(sidePanelOpen ? "chat.sidePanel.minimize" : "chat.sidePanel.label")}
     >

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -82,6 +82,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       catalog,
       agentWorkspace,
       workspaceGit,
+      sidebarLayout,
     );
     const chat = renderChat({
       ...chatProps,
@@ -155,7 +156,7 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
         forgetDiscussionUrl: () => this.sessionDiscussionOpenUrls.delete(state.sessionKey.trim()),
         resizePanel: (columnId, size) =>
           this.commitSidebarPanelResize(sidebarLayout, columnId, size),
-        setPanelOpen: (open) => this.setChatSidePanelOpen(open),
+        setPanelOpen: (open) => this.setChatSidePanelOpen(open, sidebarLayout),
       }),
       layout: sidebarLayout,
       panelDefinitions,

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
@@ -114,6 +114,23 @@ describe("chat pane sidebar layout", () => {
     expect(layout.columns).toHaveLength(1);
     expect(layout.columns[0]?.side).toBe("right");
     expect(layout.columns[0]?.panels[0]?.slot).toBe("chat");
+    expect(layout.open).toBe(true);
+
+    const closedBoardChat = resolveSidebarLayoutForBoard({
+      board: board("right"),
+      layout: { ...layout, open: false },
+      paneWidth: 1_400,
+    });
+    expect(closedBoardChat.columns[0]?.panels.map((panel) => panel.slot)).toEqual(["chat"]);
+    expect(closedBoardChat.open).toBe(false);
+
+    const closed = resolveSidebarLayoutForBoard({
+      board: board("right"),
+      layout: { ...openSlot({ columns: [] }, "browser"), open: false },
+      paneWidth: 1_400,
+    });
+    expect(closed.columns[0]?.panels.map((panel) => panel.slot)).toEqual(["browser", "chat"]);
+    expect(closed.open).toBe(false);
   });
 
   it("keeps bottom and hidden board chat outside the side panel", () => {

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.ts
@@ -201,7 +201,8 @@ export function resolveSidebarLayoutForBoard(params: {
     layout = closeSlot(layout, "chat");
     return fitSidebarLayout(layout, params.paneWidth) ?? layout;
   }
-  layout = openSlot(layout, "chat");
+  const explicitlyClosed = layout.columns.length > 0 && layout.open === false;
+  layout = { ...openSlot(layout, "chat"), open: !explicitlyClosed };
   return fitSidebarLayout(layout, params.paneWidth) ?? layout;
 }
 


### PR DESCRIPTION
Related: #123874

## What Problem This Solves

Fixes an issue where users clicking the far-right close button in dashboard Split view saw no result because Board chat was immediately re-projected open.

## Why This Change Was Made

The rendered sidebar layout is the owner of close and toggle state. Both close surfaces now update that rendered layout, preserving its tabs and leaving `chatDock` untouched. A fresh dashboard projection still opens by default, while a projected layout that the user explicitly closed stays closed.

Regression provenance: this is a clear regression from the unified tabbed panel change in #123874. The projection line came from `aed4510bd0943d847031c20a7c0bb4f399b250bd`, authored by @vyctorbrzezowski and merged by @fuller-stack-dev on 2026-08-16. This repair is authored by @steipete.

## User Impact

The whole side panel now closes, the dashboard reclaims its width, and reopening restores the existing Board chat, Browser, and Terminal tabs. For a Board-chat-only panel, both the far-right close control and header toggle behave consistently. The header `aria-expanded` state and label now match the rendered panel visibility.

## Evidence

Focused sidebar layout and persistence units:

```bash
node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-sidebar-layout.test.ts ui/src/pages/chat/sidebar-layout.test.ts ui/src/pages/chat/sidebar-layout-persistence.test.ts ui/src/pages/chat/sidebar-layout-legacy-migration.test.ts ui/src/pages/chat/chat-pane-sidebar-layout.lazy.test.ts
```

Result: 5 files passed; 26 tests passed.

Mocked Control UI Chromium E2E:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/board-split-transcript.e2e.test.ts
```

Result: 1 file passed; 3 tests passed. This covers the reported multi-tab panel, width reclamation, tab restoration, no `board.update`/`chatDock` mutation, header accessibility state, and the Board-chat-only sibling case.

Changed gate and patch checks:

```bash
node scripts/check-changed.mjs
git diff --check origin/main...HEAD
.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output
```

Results: changed gate passed; diff check passed; fresh autoreview was clean with 0 actionable findings.

Production LOC: +13/-12 (net +1). Tests: +145/-13.

The extension-backed Chrome relay was unavailable, so signed-in `team.openclaw.ai` was not re-clicked. The deterministic mocked Chromium proof above covers the reported state and its Board-chat-only sibling, but is not live authenticated browser proof.

### Before closing

![Dashboard Split view with Board chat, Browser, and Terminal tabs open](https://github.com/user-attachments/assets/7ade4d6b-c2e3-4b76-a7b2-d3daff9a5991)

### Closed

![Dashboard Split view after the whole side panel closes and the board reclaims width](https://github.com/user-attachments/assets/ebe19d23-aa69-404d-8867-670c6e6178cc)

### Reopened

![Dashboard Split view after reopening restores Board chat, Browser, and Terminal tabs](https://github.com/user-attachments/assets/bfccdcba-1bee-495d-8e14-cdd1daa656cc)

AI assistance was used during investigation, implementation, review, and validation. The maintainer reviewed the resulting code and evidence. No agent transcript is included.
