### PR TITLE
fix(control-ui): config form save corrupts 64-bit id strings in string|number fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ""
         type: string
+      capture_ui_proof:
+        description: Capture and upload sanitized Control UI screenshots from real-Gateway tests.
+        required: false
+        default: false
+        type: boolean
       include_android:
         description: Run Android lanes for this manual CI dispatch.
         required: false
@@ -1754,11 +1759,23 @@ jobs:
           ui/src/e2e/mcp-app-conformance.e2e.test.ts
 
       - name: Test Control UI auth transports with a real Gateway
+        env:
+          OPENCLAW_CAPTURE_UI_PROOF: ${{ github.event_name == 'workflow_dispatch' && inputs.capture_ui_proof && '1' || '0' }}
+          OPENCLAW_UI_E2E_ARTIFACT_DIR: .artifacts/control-ui-e2e/real-gateway
         run: >-
           node scripts/run-vitest.mjs run
           --config test/vitest/vitest.ui-e2e.config.ts
           --configLoader runner
           ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+
+      - name: Upload sanitized Control UI real-Gateway proof
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.capture_ui_proof
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: control-ui-real-gateway-proof-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/control-ui-e2e/real-gateway
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Test Control UI Logs lifecycle with a real Gateway
         run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1751,6 +1751,9 @@ jobs:
       - *cache_playwright_chromium
       - *install_playwright_chromium
 
+      - name: Build Control UI bundle for real-Gateway tests
+        run: pnpm ui:build
+
       - name: Test MCP app conformance with a real Gateway
         run: >-
           node scripts/run-vitest.mjs run

--- a/ui/src/components/config-form-array-integrity.browser.test.ts
+++ b/ui/src/components/config-form-array-integrity.browser.test.ts
@@ -134,7 +134,7 @@ describe("config form array integrity", () => {
     expect(onPatch).toHaveBeenCalledWith(["values"], []);
   });
 
-  it("preserves unquoted 64-bit strings added to string-number arrays", async () => {
+  it("preserves unquoted strings and decodes quoted strings in string-number arrays", async () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
     document.body.append(container);
@@ -142,7 +142,7 @@ describe("config form array integrity", () => {
       schema: {
         type: "array",
         items: {
-          oneOf: [{ type: "string", pattern: "^[0-9]+$" }, { type: "number" }],
+          oneOf: [{ type: "string" }, { type: "number" }],
         },
       },
       value: [],
@@ -154,22 +154,31 @@ describe("config form array integrity", () => {
       container.querySelector<ConfigFormCollectionDraft>("openclaw-config-form-collection-draft"),
       "string-number array draft",
     );
-    expectElement(findAddButton(container), "string-number array add").click();
-    await draftHost.updateComplete;
-    const draftValue = expectElement(
-      draftHost.querySelector<HTMLInputElement | HTMLTextAreaElement>(
-        "[data-collection-draft-value]",
-      ),
-      "string-number array draft value",
-    );
-    const identifier = "1048113311314608148";
-    draftValue.value = identifier;
-    draftValue.dispatchEvent(new Event("input", { bubbles: true }));
-    await draftHost.updateComplete;
-    expectElement(findAddButton(draftHost), "string-number array draft commit").click();
+    const addDraftValue = async (value: string) => {
+      expectElement(findAddButton(container), "string-number array add").click();
+      await draftHost.updateComplete;
+      const draftValue = expectElement(
+        draftHost.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+          "[data-collection-draft-value]",
+        ),
+        "string-number array draft value",
+      );
+      draftValue.value = value;
+      draftValue.dispatchEvent(new Event("input", { bubbles: true }));
+      await draftHost.updateComplete;
+      expectElement(findAddButton(draftHost), "string-number array draft commit").click();
+    };
 
+    const identifier = "1048113311314608148";
+    await addDraftValue(identifier);
     expect(onPatch).toHaveBeenCalledWith(["allowFrom"], [identifier]);
     expect(onPatch.mock.calls[0]?.[1]?.[0]).not.toBe(Number(identifier));
+    onPatch.mockClear();
+    await addDraftValue(JSON.stringify(identifier));
+    expect(onPatch).toHaveBeenCalledWith(["allowFrom"], [identifier]);
+    onPatch.mockClear();
+    await addDraftValue("1e5");
+    expect(onPatch).toHaveBeenCalledWith(["allowFrom"], ["1e5"]);
     container.remove();
   });
 

--- a/ui/src/components/config-form-array-integrity.browser.test.ts
+++ b/ui/src/components/config-form-array-integrity.browser.test.ts
@@ -179,7 +179,7 @@ describe("config form array integrity", () => {
     expect(onPatch).toHaveBeenCalledWith(["allowFrom"], [identifier]);
     onPatch.mockClear();
     await addDraftValue("1e5");
-    expect(onPatch).toHaveBeenCalledWith(["allowFrom"], ["1e5"]);
+    expect(onPatch).toHaveBeenCalledWith(["allowFrom"], [100_000]);
     container.remove();
   });
 

--- a/ui/src/components/config-form-array-integrity.browser.test.ts
+++ b/ui/src/components/config-form-array-integrity.browser.test.ts
@@ -138,11 +138,12 @@ describe("config form array integrity", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");
     document.body.append(container);
+    const identifier = "1048113311314608148";
     renderArrayFixture(container, {
       schema: {
         type: "array",
         items: {
-          oneOf: [{ type: "string", minLength: 1 }, { type: "number" }],
+          oneOf: [{ enum: [identifier] }, { type: "number" }],
         },
       },
       value: [],
@@ -170,7 +171,6 @@ describe("config form array integrity", () => {
       await draftHost.updateComplete;
     };
 
-    const identifier = "1048113311314608148";
     await addDraftValue(identifier);
     expect(onPatch).toHaveBeenCalledWith(["allowFrom"], [identifier]);
     expect(onPatch.mock.calls[0]?.[1]?.[0]).not.toBe(Number(identifier));

--- a/ui/src/components/config-form-array-integrity.browser.test.ts
+++ b/ui/src/components/config-form-array-integrity.browser.test.ts
@@ -142,7 +142,7 @@ describe("config form array integrity", () => {
       schema: {
         type: "array",
         items: {
-          oneOf: [{ type: "string" }, { type: "number" }],
+          oneOf: [{ type: "string", minLength: 1 }, { type: "number" }],
         },
       },
       value: [],
@@ -167,6 +167,7 @@ describe("config form array integrity", () => {
       draftValue.dispatchEvent(new Event("input", { bubbles: true }));
       await draftHost.updateComplete;
       expectElement(findAddButton(draftHost), "string-number array draft commit").click();
+      await draftHost.updateComplete;
     };
 
     const identifier = "1048113311314608148";

--- a/ui/src/components/config-form-array-integrity.browser.test.ts
+++ b/ui/src/components/config-form-array-integrity.browser.test.ts
@@ -134,6 +134,45 @@ describe("config form array integrity", () => {
     expect(onPatch).toHaveBeenCalledWith(["values"], []);
   });
 
+  it("preserves unquoted 64-bit strings added to string-number arrays", async () => {
+    const onPatch = vi.fn();
+    const container = document.createElement("div");
+    document.body.append(container);
+    renderArrayFixture(container, {
+      schema: {
+        type: "array",
+        items: {
+          oneOf: [{ type: "string", pattern: "^[0-9]+$" }, { type: "number" }],
+        },
+      },
+      value: [],
+      path: ["allowFrom"],
+      onPatch,
+    });
+
+    const draftHost = expectElement(
+      container.querySelector<ConfigFormCollectionDraft>("openclaw-config-form-collection-draft"),
+      "string-number array draft",
+    );
+    expectElement(findAddButton(container), "string-number array add").click();
+    await draftHost.updateComplete;
+    const draftValue = expectElement(
+      draftHost.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+        "[data-collection-draft-value]",
+      ),
+      "string-number array draft value",
+    );
+    const identifier = "1048113311314608148";
+    draftValue.value = identifier;
+    draftValue.dispatchEvent(new Event("input", { bubbles: true }));
+    await draftHost.updateComplete;
+    expectElement(findAddButton(draftHost), "string-number array draft commit").click();
+
+    expect(onPatch).toHaveBeenCalledWith(["allowFrom"], [identifier]);
+    expect(onPatch.mock.calls[0]?.[1]?.[0]).not.toBe(Number(identifier));
+    container.remove();
+  });
+
   it("keeps large and unique array minimums incrementally editable", async () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");

--- a/ui/src/components/config-form-collection-draft.ts
+++ b/ui/src/components/config-form-collection-draft.ts
@@ -94,6 +94,16 @@ export class ConfigFormCollectionDraft extends OpenClawLightDomElement {
     const stringNumberUnion =
       variants.some((variant) => schemaType(variant) === "string") &&
       variants.some((variant) => ["number", "integer"].includes(schemaType(variant) ?? ""));
+    if (stringNumberUnion) {
+      try {
+        const parsed = JSON.parse(this.draftValue) as unknown;
+        if (typeof parsed === "string" && isSupportedConfigValueValid(schema, parsed)) {
+          return { ok: true, value: parsed };
+        }
+      } catch {
+        // Unquoted string-capable input is handled by the raw fallback below.
+      }
+    }
     if (
       (valueType === "string" || stringNumberUnion) &&
       isSupportedConfigValueValid(schema, this.draftValue)

--- a/ui/src/components/config-form-collection-draft.ts
+++ b/ui/src/components/config-form-collection-draft.ts
@@ -3,6 +3,7 @@ import { property, state } from "lit/decorators.js";
 import { t } from "../i18n/index.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { configValuesEqual, isSupportedConfigValueValid } from "./config-form.constraints.ts";
+import { coerceConfigFormNumberString } from "./config-form.numeric.ts";
 import { schemaType, type JsonSchema } from "./config-form.shared.ts";
 
 export type ConfigFormCollectionDraftProps = {
@@ -89,17 +90,34 @@ export class ConfigFormCollectionDraft extends OpenClawLightDomElement {
       return { ok: true, value: null };
     }
     const valueType = schemaType(schema);
+    const variants = schema.anyOf ?? schema.oneOf ?? [];
+    const stringNumberUnion =
+      variants.some((variant) => schemaType(variant) === "string") &&
+      variants.some((variant) => ["number", "integer"].includes(schemaType(variant) ?? ""));
+    if (
+      (valueType === "string" || stringNumberUnion) &&
+      isSupportedConfigValueValid(schema, this.draftValue)
+    ) {
+      return { ok: true, value: this.draftValue };
+    }
     if (valueType === "string") {
       return { ok: true, value: this.draftValue };
     }
     if (valueType === "number" || valueType === "integer") {
-      const value = Number(this.draftValue);
-      return this.draftValue.trim() && Number.isFinite(value)
-        ? { ok: true, value }
+      const coerced = coerceConfigFormNumberString(this.draftValue, valueType === "integer");
+      return typeof coerced === "number"
+        ? { ok: true, value: coerced }
         : { ok: false, message: t("configForm.invalidNumber") };
     }
     try {
-      return { ok: true, value: JSON.parse(this.draftValue) };
+      const parsed = JSON.parse(this.draftValue) as unknown;
+      if (typeof parsed === "number") {
+        const coerced = coerceConfigFormNumberString(this.draftValue, false);
+        return typeof coerced === "number"
+          ? { ok: true, value: coerced }
+          : { ok: false, message: t("configForm.invalidNumber") };
+      }
+      return { ok: true, value: parsed };
     } catch {
       return { ok: false, message: t("configForm.invalidJson") };
     }

--- a/ui/src/components/config-form-collection-draft.ts
+++ b/ui/src/components/config-form-collection-draft.ts
@@ -4,7 +4,7 @@ import { t } from "../i18n/index.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { configValuesEqual, isSupportedConfigValueValid } from "./config-form.constraints.ts";
 import { coerceConfigFormNumberString } from "./config-form.numeric.ts";
-import { schemaType, type JsonSchema } from "./config-form.shared.ts";
+import { schemaMayAcceptString, schemaType, type JsonSchema } from "./config-form.shared.ts";
 
 export type ConfigFormCollectionDraftProps = {
   schema: JsonSchema;
@@ -92,7 +92,7 @@ export class ConfigFormCollectionDraft extends OpenClawLightDomElement {
     const valueType = schemaType(schema);
     const variants = schema.anyOf ?? schema.oneOf ?? [];
     const stringNumberUnion =
-      variants.some((variant) => schemaType(variant) === "string") &&
+      variants.some(schemaMayAcceptString) &&
       variants.some((variant) => ["number", "integer"].includes(schemaType(variant) ?? ""));
     if (valueType === "string") {
       return { ok: true, value: this.draftValue };

--- a/ui/src/components/config-form-collection-draft.ts
+++ b/ui/src/components/config-form-collection-draft.ts
@@ -94,22 +94,6 @@ export class ConfigFormCollectionDraft extends OpenClawLightDomElement {
     const stringNumberUnion =
       variants.some((variant) => schemaType(variant) === "string") &&
       variants.some((variant) => ["number", "integer"].includes(schemaType(variant) ?? ""));
-    if (stringNumberUnion) {
-      try {
-        const parsed = JSON.parse(this.draftValue) as unknown;
-        if (typeof parsed === "string" && isSupportedConfigValueValid(schema, parsed)) {
-          return { ok: true, value: parsed };
-        }
-      } catch {
-        // Unquoted string-capable input is handled by the raw fallback below.
-      }
-    }
-    if (
-      (valueType === "string" || stringNumberUnion) &&
-      isSupportedConfigValueValid(schema, this.draftValue)
-    ) {
-      return { ok: true, value: this.draftValue };
-    }
     if (valueType === "string") {
       return { ok: true, value: this.draftValue };
     }
@@ -123,13 +107,20 @@ export class ConfigFormCollectionDraft extends OpenClawLightDomElement {
       const parsed = JSON.parse(this.draftValue) as unknown;
       if (typeof parsed === "number") {
         const coerced = coerceConfigFormNumberString(this.draftValue, false);
-        return typeof coerced === "number"
-          ? { ok: true, value: coerced }
+        if (typeof coerced === "number") {
+          return { ok: true, value: coerced };
+        }
+        // JSON.parse has already rounded unsafe integer spellings. Preserve
+        // the source text only when the union accepts it as a string.
+        return stringNumberUnion && isSupportedConfigValueValid(schema, this.draftValue)
+          ? { ok: true, value: this.draftValue }
           : { ok: false, message: t("configForm.invalidNumber") };
       }
       return { ok: true, value: parsed };
     } catch {
-      return { ok: false, message: t("configForm.invalidJson") };
+      return stringNumberUnion && isSupportedConfigValueValid(schema, this.draftValue)
+        ? { ok: true, value: this.draftValue }
+        : { ok: false, message: t("configForm.invalidJson") };
     }
   }
 

--- a/ui/src/components/config-form-scalar-integrity.browser.test.ts
+++ b/ui/src/components/config-form-scalar-integrity.browser.test.ts
@@ -369,6 +369,43 @@ describe("config form scalar integrity", () => {
     expect(input.getAttribute("aria-invalid")).toBe("true");
   });
 
+  it("commits explicit boolean branches without retyping numeric strings", () => {
+    const container = document.createElement("div");
+    const onPatch = vi.fn();
+    render(
+      renderTextInput({
+        schema: {
+          anyOf: [{ type: "string" }, { type: "number" }, { const: false }],
+        },
+        value: "500mb",
+        path: ["maxDiskBytes"],
+        hints: {},
+        unsupported: new Set(),
+        disabled: false,
+        inputType: "text",
+        onPatch,
+      }),
+      container,
+    );
+    const input = expectElement(
+      container.querySelector<HTMLInputElement>("input[type='text']"),
+      "string-number-boolean union input",
+    );
+
+    input.value = "false";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["maxDiskBytes"], false);
+
+    input.value = "true";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["maxDiskBytes"], "true");
+
+    const identifier = "1048113311314608148";
+    input.value = identifier;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["maxDiskBytes"], identifier);
+  });
+
   it("does not commit a clear while a number input holds partial numeric text", () => {
     // Browsers report value === "" with validity.badInput while the user is
     // mid-keystroke ("0." on the way to "0.5"). Committing undefined here

--- a/ui/src/components/config-form-scalar-integrity.browser.test.ts
+++ b/ui/src/components/config-form-scalar-integrity.browser.test.ts
@@ -496,69 +496,76 @@ describe("config form scalar integrity", () => {
     );
   });
 
-  it("keeps an unset branch hint stable while an identifier is typed across rerenders", () => {
-    const container = document.createElement("div");
-    document.body.append(container);
-    const identifier = "1048113311314608148";
-    const schema = {
-      anyOf: [{ type: "string", pattern: "^[0-9]{19}$" }, { type: "number" }],
-    };
-    const patches: unknown[] = [];
-    let persisted: unknown;
-    let value: unknown = undefined;
+  it.each([
+    ["unset", undefined],
+    ["number", 0],
+  ] as const)(
+    "keeps an initial %s branch stable while an identifier is typed",
+    (_name, initial) => {
+      const container = document.createElement("div");
+      document.body.append(container);
+      const identifier = "1048113311314608148";
+      const schema = {
+        anyOf: [{ type: "string", pattern: "^[0-9]{19}$" }, { type: "number" }],
+      };
+      const patches: unknown[] = [];
+      let persisted: unknown = initial;
+      let value: unknown = initial;
 
-    const renderValue = () => {
-      render(
-        renderTextInput({
-          schema,
-          value,
-          path: ["allowFrom"],
-          hints: {},
-          unsupported: new Set(),
-          disabled: false,
-          inputType: "text",
-          onPatch: (_path, nextValue) => {
-            patches.push(nextValue);
-            persisted = nextValue;
-            value = nextValue;
-            // Model application immediately refreshes the rendered field.
-            renderValue();
-          },
-        }),
-        container,
-      );
-    };
-
-    try {
-      renderValue();
-      let input = expectElement(
-        container.querySelector<HTMLInputElement>("input[type='text']"),
-        "incremental string-number input",
-      );
-      input.focus();
-      for (const [index, digit] of Array.from(identifier).entries()) {
-        input.value += digit;
-        input.dispatchEvent(new Event("input", { bubbles: true }));
-        // A background refresh can land even when the prefix is not yet a
-        // valid string branch; the focused edit must survive that repaint.
-        renderValue();
-        input = expectElement(
-          container.querySelector<HTMLInputElement>("input[type='text']"),
-          `incremental string-number input ${index + 1}`,
+      const renderValue = () => {
+        render(
+          renderTextInput({
+            schema,
+            value,
+            path: ["allowFrom"],
+            hints: {},
+            unsupported: new Set(),
+            disabled: false,
+            inputType: "text",
+            onPatch: (_path, nextValue) => {
+              patches.push(nextValue);
+              persisted = nextValue;
+              value = nextValue;
+              // Model application immediately refreshes the rendered field.
+              renderValue();
+            },
+          }),
+          container,
         );
-      }
+      };
 
-      expect(patches.length).toBeGreaterThan(1);
-      expect(patches.slice(0, -1).every((candidate) => typeof candidate === "number")).toBe(true);
-      expect(patches.at(-1)).toBe(identifier);
-      expect(persisted).toBe(identifier);
-      expect(value).toBe(identifier);
-      expect(input.value).toBe(identifier);
-      input.blur();
-    } finally {
-      container.remove();
-    }
-  });
+      try {
+        renderValue();
+        let input = expectElement(
+          container.querySelector<HTMLInputElement>("input[type='text']"),
+          "incremental string-number input",
+        );
+        input.focus();
+        input.value = "";
+        for (const [index, digit] of Array.from(identifier).entries()) {
+          input.value += digit;
+          input.dispatchEvent(new Event("input", { bubbles: true }));
+          // A background refresh can land even when the prefix is not yet a
+          // valid string branch; the focused edit must survive that repaint.
+          renderValue();
+          input = expectElement(
+            container.querySelector<HTMLInputElement>("input[type='text']"),
+            `incremental string-number input ${index + 1}`,
+          );
+        }
+
+        expect(patches.length).toBeGreaterThan(1);
+        expect(patches.slice(0, -1).every((candidate) => typeof candidate === "number")).toBe(true);
+        expect(patches.at(-1)).toBe(identifier);
+        expect(persisted).toBe(identifier);
+        expect(value).toBe(identifier);
+        expect(input.value).toBe(identifier);
+        input.blur();
+      } finally {
+        container.remove();
+      }
+    },
+  );
 
   it("does not commit a clear while a number input holds partial numeric text", () => {
     // Browsers report value === "" with validity.badInput while the user is
@@ -665,6 +672,45 @@ describe("config form scalar integrity", () => {
     expect(onPatch).toHaveBeenCalledWith(["numeric"], 9_007_199_254_740_992);
     expect(input.getAttribute("aria-invalid")).toBe("false");
   });
+
+  it.each(["mixed", "number"] as const)(
+    "renders an exact large integer as parser-valid text in a %s input",
+    (kind) => {
+      const container = document.createElement("div");
+      const onPatch = vi.fn();
+      const exactValue = Number("1000000000000000128");
+      const params = {
+        value: exactValue,
+        path: ["numeric"],
+        hints: {},
+        unsupported: new Set<string>(),
+        disabled: false,
+        onPatch,
+      };
+      render(
+        kind === "mixed"
+          ? renderTextInput({
+              ...params,
+              schema: { anyOf: [{ type: "string" }, { type: "number" }] },
+              inputType: "text",
+            })
+          : renderNumberInput({ ...params, schema: { type: "integer" } }),
+        container,
+      );
+      const input = expectElement(
+        container.querySelector<HTMLInputElement>(
+          `input[type='${kind === "mixed" ? "text" : "number"}']`,
+        ),
+        `${kind} exact large number input`,
+      );
+
+      expect(input.value).toBe("1000000000000000128");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+
+      expect(onPatch).toHaveBeenCalledWith(["numeric"], exactValue);
+      expect(input.getAttribute("aria-invalid")).toBe("false");
+    },
+  );
 
   it("keeps restore disabled while a sensitive value is concealed", () => {
     const container = document.createElement("div");

--- a/ui/src/components/config-form-scalar-integrity.browser.test.ts
+++ b/ui/src/components/config-form-scalar-integrity.browser.test.ts
@@ -496,6 +496,70 @@ describe("config form scalar integrity", () => {
     );
   });
 
+  it("keeps an unset branch hint stable while an identifier is typed across rerenders", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const identifier = "1048113311314608148";
+    const schema = {
+      anyOf: [{ type: "string", pattern: "^[0-9]{19}$" }, { type: "number" }],
+    };
+    const patches: unknown[] = [];
+    let persisted: unknown;
+    let value: unknown = undefined;
+
+    const renderValue = () => {
+      render(
+        renderTextInput({
+          schema,
+          value,
+          path: ["allowFrom"],
+          hints: {},
+          unsupported: new Set(),
+          disabled: false,
+          inputType: "text",
+          onPatch: (_path, nextValue) => {
+            patches.push(nextValue);
+            persisted = nextValue;
+            value = nextValue;
+            // Model application immediately refreshes the rendered field.
+            renderValue();
+          },
+        }),
+        container,
+      );
+    };
+
+    try {
+      renderValue();
+      let input = expectElement(
+        container.querySelector<HTMLInputElement>("input[type='text']"),
+        "incremental string-number input",
+      );
+      input.focus();
+      for (const [index, digit] of Array.from(identifier).entries()) {
+        input.value += digit;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        // A background refresh can land even when the prefix is not yet a
+        // valid string branch; the focused edit must survive that repaint.
+        renderValue();
+        input = expectElement(
+          container.querySelector<HTMLInputElement>("input[type='text']"),
+          `incremental string-number input ${index + 1}`,
+        );
+      }
+
+      expect(patches.length).toBeGreaterThan(1);
+      expect(patches.slice(0, -1).every((candidate) => typeof candidate === "number")).toBe(true);
+      expect(patches.at(-1)).toBe(identifier);
+      expect(persisted).toBe(identifier);
+      expect(value).toBe(identifier);
+      expect(input.value).toBe(identifier);
+      input.blur();
+    } finally {
+      container.remove();
+    }
+  });
+
   it("does not commit a clear while a number input holds partial numeric text", () => {
     // Browsers report value === "" with validity.badInput while the user is
     // mid-keystroke ("0." on the way to "0.5"). Committing undefined here

--- a/ui/src/components/config-form-scalar-integrity.browser.test.ts
+++ b/ui/src/components/config-form-scalar-integrity.browser.test.ts
@@ -406,6 +406,87 @@ describe("config form scalar integrity", () => {
     expect(onPatch).toHaveBeenLastCalledWith(["maxDiskBytes"], identifier);
   });
 
+  it("preserves the current branch type in unconstrained primitive unions", () => {
+    const container = document.createElement("div");
+    const onPatch = vi.fn();
+    const schema = {
+      anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }],
+    };
+    const renderValue = (value: unknown, defaultValue?: unknown) => {
+      render(
+        renderTextInput({
+          schema: defaultValue === undefined ? schema : { ...schema, default: defaultValue },
+          value,
+          path: ["providerOptions", "deepgram", "temperature"],
+          hints: {},
+          unsupported: new Set(),
+          disabled: false,
+          inputType: "text",
+          onPatch,
+        }),
+        container,
+      );
+      return expectElement(
+        container.querySelector<HTMLInputElement>("input[type='text']"),
+        "mixed primitive union input",
+      );
+    };
+
+    let input = renderValue(42);
+    input.value = "43";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["providerOptions", "deepgram", "temperature"], 43);
+
+    onPatch.mockClear();
+    input = renderValue("42");
+    input.value = "43";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["providerOptions", "deepgram", "temperature"], "43");
+
+    onPatch.mockClear();
+    input = renderValue(undefined);
+    input.value = "43";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["providerOptions", "deepgram", "temperature"], 43);
+
+    onPatch.mockClear();
+    input = renderValue(undefined, 42);
+    input.value = "43";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["providerOptions", "deepgram", "temperature"], 43);
+
+    onPatch.mockClear();
+    input = renderValue(undefined, "42");
+    input.value = "43";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["providerOptions", "deepgram", "temperature"], "43");
+
+    onPatch.mockClear();
+    input = renderValue("false");
+    input.value = "true";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(
+      ["providerOptions", "deepgram", "temperature"],
+      "true",
+    );
+
+    onPatch.mockClear();
+    input = renderValue(false);
+    input.value = "true";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["providerOptions", "deepgram", "temperature"], true);
+
+    onPatch.mockClear();
+    const identifier = "1048113311314608148";
+    input = renderValue(undefined);
+    input.value = identifier;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(
+      ["providerOptions", "deepgram", "temperature"],
+      identifier,
+    );
+  });
+
   it("does not commit a clear while a number input holds partial numeric text", () => {
     // Browsers report value === "" with validity.badInput while the user is
     // mid-keystroke ("0." on the way to "0.5"). Committing undefined here

--- a/ui/src/components/config-form-scalar-integrity.browser.test.ts
+++ b/ui/src/components/config-form-scalar-integrity.browser.test.ts
@@ -327,6 +327,48 @@ describe("config form scalar integrity", () => {
     ).toBe("Default: balanced");
   });
 
+  it("commits the valid branch type for constrained text unions", () => {
+    const container = document.createElement("div");
+    const onPatch = vi.fn();
+    render(
+      renderTextInput({
+        schema: {
+          anyOf: [
+            { type: "string", const: "auto" },
+            { type: "integer", minimum: 0 },
+          ],
+        },
+        value: "auto",
+        path: ["mode"],
+        hints: {},
+        unsupported: new Set(),
+        disabled: false,
+        inputType: "text",
+        onPatch,
+      }),
+      container,
+    );
+    const input = expectElement(
+      container.querySelector<HTMLInputElement>("input[type='text']"),
+      "constrained union input",
+    );
+
+    input.value = "42";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["mode"], 42);
+    expect(input.getAttribute("aria-invalid")).toBe("false");
+
+    input.value = "auto";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).toHaveBeenLastCalledWith(["mode"], "auto");
+
+    onPatch.mockClear();
+    input.value = "invalid";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(onPatch).not.toHaveBeenCalled();
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+  });
+
   it("does not commit a clear while a number input holds partial numeric text", () => {
     // Browsers report value === "" with validity.badInput while the user is
     // mid-keystroke ("0." on the way to "0.5"). Committing undefined here

--- a/ui/src/components/config-form-scalar-integrity.browser.test.ts
+++ b/ui/src/components/config-form-scalar-integrity.browser.test.ts
@@ -533,6 +533,39 @@ describe("config form scalar integrity", () => {
     expect(onPatch).toHaveBeenCalledWith(["sampleRate"], undefined);
   });
 
+  it.each([
+    ["unsafe integer", { type: "integer" }, "9007199254740993"],
+    ["lossy decimal", { type: "number" }, "1.0000000000000001"],
+    ["underflow", { type: "number" }, "1e-324"],
+  ])("rejects %s text before a pure numeric input can round it", (_name, schema, raw) => {
+    const container = document.createElement("div");
+    const onPatch = vi.fn();
+    render(
+      renderNumberInput({
+        schema,
+        value: 0,
+        path: ["numeric"],
+        hints: {},
+        unsupported: new Set(),
+        disabled: false,
+        onPatch,
+      }),
+      container,
+    );
+    const input = expectElement(
+      container.querySelector<HTMLInputElement>("input[type='number']"),
+      "lossless number input",
+    );
+
+    input.value = raw;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(onPatch).not.toHaveBeenCalled();
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.value).toBe(raw);
+  });
+
   it("keeps restore disabled while a sensitive value is concealed", () => {
     const container = document.createElement("div");
 

--- a/ui/src/components/config-form-scalar-integrity.browser.test.ts
+++ b/ui/src/components/config-form-scalar-integrity.browser.test.ts
@@ -438,6 +438,15 @@ describe("config form scalar integrity", () => {
     expect(onPatch).toHaveBeenLastCalledWith(["providerOptions", "deepgram", "temperature"], 43);
 
     onPatch.mockClear();
+    input = renderValue(1);
+    input.value = "1.0000000000000001";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(onPatch).not.toHaveBeenCalled();
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(input.value).toBe("1.0000000000000001");
+
+    onPatch.mockClear();
     input = renderValue("42");
     input.value = "43";
     input.dispatchEvent(new Event("input", { bubbles: true }));
@@ -564,6 +573,33 @@ describe("config form scalar integrity", () => {
     expect(onPatch).not.toHaveBeenCalled();
     expect(input.getAttribute("aria-invalid")).toBe("true");
     expect(input.value).toBe(raw);
+  });
+
+  it("accepts an exactly represented integer above the safe-integer range", () => {
+    const container = document.createElement("div");
+    const onPatch = vi.fn();
+    render(
+      renderNumberInput({
+        schema: { type: "integer" },
+        value: 0,
+        path: ["numeric"],
+        hints: {},
+        unsupported: new Set(),
+        disabled: false,
+        onPatch,
+      }),
+      container,
+    );
+    const input = expectElement(
+      container.querySelector<HTMLInputElement>("input[type='number']"),
+      "exact large number input",
+    );
+
+    input.value = "9007199254740992";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+
+    expect(onPatch).toHaveBeenCalledWith(["numeric"], 9_007_199_254_740_992);
+    expect(input.getAttribute("aria-invalid")).toBe("false");
   });
 
   it("keeps restore disabled while a sensitive value is concealed", () => {

--- a/ui/src/components/config-form.constraints.test.ts
+++ b/ui/src/components/config-form.constraints.test.ts
@@ -64,6 +64,19 @@ describe("config form schema constraints", () => {
     expect(coerceConfigFormNumberString("42.5", true)).toBe("42.5");
   });
 
+  it("compares integer spellings against the exact binary double", () => {
+    expect(coerceConfigFormNumberString("1000000000000000100", true)).toBe("1000000000000000100");
+    expect(coerceConfigFormNumberString("1000000000000000100", false)).toBe("1000000000000000100");
+    expect(coerceConfigFormNumberString("-1000000000000000100", false)).toBe(
+      "-1000000000000000100",
+    );
+    expect(coerceConfigFormNumberString("1000000000000000127", true)).toBe("1000000000000000127");
+    expect(coerceConfigFormNumberString("1000000000000000128", true)).toBe(
+      1_000_000_000_000_000_128,
+    );
+    expect(coerceConfigFormNumberString("9007199254740994", true)).toBe(9_007_199_254_740_994);
+  });
+
   it("rejects non-finite decimal rationals and schema multiples", () => {
     expect(numericInputConstraints({ type: "number", multipleOf: Number.NaN }).step).toBe("any");
     expect(

--- a/ui/src/components/config-form.constraints.test.ts
+++ b/ui/src/components/config-form.constraints.test.ts
@@ -23,6 +23,23 @@ describe("config form schema constraints", () => {
     expect(coerceConfigFormNumberString("-2.5E-3", false)).toBe(-0.0025);
     expect(coerceConfigFormNumberString("1e5", true)).toBe(100_000);
     expect(coerceConfigFormNumberString("", false)).toBeUndefined();
+    expect(coerceConfigFormNumberString("9007199254740991", true)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(coerceConfigFormNumberString("9.007199254740991e15", true)).toBe(
+      Number.MAX_SAFE_INTEGER,
+    );
+    expect(coerceConfigFormNumberString("9007199254740992", true)).toBe("9007199254740992");
+    expect(coerceConfigFormNumberString("9007199254740993", true)).toBe("9007199254740993");
+    expect(coerceConfigFormNumberString("-9007199254740993", false)).toBe("-9007199254740993");
+    expect(coerceConfigFormNumberString("9007199254740992.0", true)).toBe("9007199254740992.0");
+    expect(coerceConfigFormNumberString("9007199254740993.0", true)).toBe("9007199254740993.0");
+    expect(coerceConfigFormNumberString("10481133113146081487e0", true)).toBe(
+      "10481133113146081487e0",
+    );
+    expect(coerceConfigFormNumberString("9.007199254740993e15", true)).toBe("9.007199254740993e15");
+    expect(coerceConfigFormNumberString("-9.007199254740993e15", true)).toBe(
+      "-9.007199254740993e15",
+    );
+    expect(coerceConfigFormNumberString("0.10", false)).toBe(0.1);
 
     for (const spelling of [
       "0x10",

--- a/ui/src/components/config-form.constraints.test.ts
+++ b/ui/src/components/config-form.constraints.test.ts
@@ -40,6 +40,10 @@ describe("config form schema constraints", () => {
       "-9.007199254740993e15",
     );
     expect(coerceConfigFormNumberString("0.10", false)).toBe(0.1);
+    expect(coerceConfigFormNumberString("1.0000000000000002", false)).toBe(1.0000000000000002);
+    expect(coerceConfigFormNumberString("1.0000000000000001", false)).toBe("1.0000000000000001");
+    expect(coerceConfigFormNumberString("9007199254740991.1", false)).toBe("9007199254740991.1");
+    expect(coerceConfigFormNumberString("1e-324", false)).toBe("1e-324");
 
     for (const spelling of [
       "0x10",

--- a/ui/src/components/config-form.constraints.test.ts
+++ b/ui/src/components/config-form.constraints.test.ts
@@ -27,15 +27,16 @@ describe("config form schema constraints", () => {
     expect(coerceConfigFormNumberString("9.007199254740991e15", true)).toBe(
       Number.MAX_SAFE_INTEGER,
     );
-    expect(coerceConfigFormNumberString("9007199254740992", true)).toBe("9007199254740992");
+    expect(coerceConfigFormNumberString("9007199254740992", true)).toBe(9_007_199_254_740_992);
     expect(coerceConfigFormNumberString("9007199254740993", true)).toBe("9007199254740993");
     expect(coerceConfigFormNumberString("-9007199254740993", false)).toBe("-9007199254740993");
-    expect(coerceConfigFormNumberString("9007199254740992.0", true)).toBe("9007199254740992.0");
+    expect(coerceConfigFormNumberString("9007199254740992.0", true)).toBe(9_007_199_254_740_992);
     expect(coerceConfigFormNumberString("9007199254740993.0", true)).toBe("9007199254740993.0");
     expect(coerceConfigFormNumberString("10481133113146081487e0", true)).toBe(
       "10481133113146081487e0",
     );
     expect(coerceConfigFormNumberString("9.007199254740993e15", true)).toBe("9.007199254740993e15");
+    expect(coerceConfigFormNumberString("9.007199254740992e15", true)).toBe(9_007_199_254_740_992);
     expect(coerceConfigFormNumberString("-9.007199254740993e15", true)).toBe(
       "-9.007199254740993e15",
     );
@@ -44,6 +45,8 @@ describe("config form schema constraints", () => {
     expect(coerceConfigFormNumberString("1.0000000000000001", false)).toBe("1.0000000000000001");
     expect(coerceConfigFormNumberString("9007199254740991.1", false)).toBe("9007199254740991.1");
     expect(coerceConfigFormNumberString("1e-324", false)).toBe("1e-324");
+    expect(coerceConfigFormNumberString("0e-1025", false)).toBe(0);
+    expect(Object.is(coerceConfigFormNumberString("-0e2000", false), -0)).toBe(true);
 
     for (const spelling of [
       "0x10",

--- a/ui/src/components/config-form.constraints.test.ts
+++ b/ui/src/components/config-form.constraints.test.ts
@@ -13,7 +13,7 @@ import {
   objectPropertySchema,
   requiredPropertyKeys,
 } from "./config-form.constraints.ts";
-import { coerceConfigFormNumberString } from "./config-form.numeric.ts";
+import { coerceConfigFormNumberString, formatConfigFormNumber } from "./config-form.numeric.ts";
 import type { JsonSchema } from "./config-form.shared.ts";
 
 describe("config form schema constraints", () => {
@@ -65,14 +65,19 @@ describe("config form schema constraints", () => {
   });
 
   it("compares integer spellings against the exact binary double", () => {
+    const exactLargeInteger = Number("1000000000000000128");
     expect(coerceConfigFormNumberString("1000000000000000100", true)).toBe("1000000000000000100");
     expect(coerceConfigFormNumberString("1000000000000000100", false)).toBe("1000000000000000100");
     expect(coerceConfigFormNumberString("-1000000000000000100", false)).toBe(
       "-1000000000000000100",
     );
     expect(coerceConfigFormNumberString("1000000000000000127", true)).toBe("1000000000000000127");
-    expect(coerceConfigFormNumberString("1000000000000000128", true)).toBe(
-      1_000_000_000_000_000_128,
+    expect(coerceConfigFormNumberString("1000000000000000128", true)).toBe(exactLargeInteger);
+    expect(formatConfigFormNumber(exactLargeInteger)).toBe("1000000000000000128");
+    expect(formatConfigFormNumber(-0)).toBe("0");
+    expect(formatConfigFormNumber(0.1)).toBe("0.1");
+    expect(coerceConfigFormNumberString(formatConfigFormNumber(exactLargeInteger), true)).toBe(
+      exactLargeInteger,
     );
     expect(coerceConfigFormNumberString("9007199254740994", true)).toBe(9_007_199_254_740_994);
   });

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -21,7 +21,10 @@ import {
   wrapSensitiveControl,
   type ConfigNodeRenderParams,
 } from "./config-form.node.shared.ts";
-import { coerceConfigFormNumberString } from "./config-form.numeric.ts";
+import {
+  coerceConfigFormNumberString,
+  isConfigFormDecimalNumberString,
+} from "./config-form.numeric.ts";
 import { resolveConfigFieldMeta as resolveFieldMeta } from "./config-form.search.ts";
 import {
   configFieldId,
@@ -99,7 +102,7 @@ function coerceTextInputValue(
   value: string,
   schema: ConfigNodeRenderParams["schema"],
   currentValue?: unknown,
-): string | number | boolean {
+): string | number | boolean | undefined {
   const trimmed = value.trim();
   const variants = schema.anyOf ?? schema.oneOf ?? [];
   const stringCandidateValid = isSupportedConfigValueValid(schema, value);
@@ -139,8 +142,13 @@ function coerceTextInputValue(
       break;
     }
   }
-  if (typeof currentValue === "number" && numberCandidate !== undefined) {
-    return numberCandidate;
+  if (typeof currentValue === "number") {
+    if (numberCandidate !== undefined) {
+      return numberCandidate;
+    }
+    if (isConfigFormDecimalNumberString(value)) {
+      return undefined;
+    }
   }
   if (typeof currentValue === "string" && stringCandidateValid) {
     return value;

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -25,6 +25,15 @@ import {
   coerceConfigFormNumberString,
   isConfigFormDecimalNumberString,
 } from "./config-form.numeric.ts";
+import {
+  beginScalarEdit,
+  finishScalarEdit,
+  finishScalarEditFromEvent,
+  scalarEditHintForInput,
+  scalarValueBranch,
+  syncScalarEditIdentity,
+  type ScalarEditHint,
+} from "./config-form.scalar-edit.ts";
 import { resolveConfigFieldMeta as resolveFieldMeta } from "./config-form.search.ts";
 import {
   configFieldId,
@@ -32,12 +41,6 @@ import {
   redactedPlaceholder,
   schemaType,
 } from "./config-form.shared.ts";
-
-type ScalarValueBranch = "string" | "number" | "boolean";
-
-type ScalarEditHint = {
-  branch?: ScalarValueBranch;
-};
 
 const scalarInputState = new WeakMap<
   HTMLInputElement,
@@ -48,7 +51,6 @@ const scalarInputState = new WeakMap<
     pathKey: string;
     presentationIdentity: string;
     renderedValue: string;
-    edit?: ScalarEditHint;
   }
 >();
 
@@ -72,11 +74,6 @@ function syncScalarInputIdentity(
     return;
   }
   const previous = scalarInputState.get(element);
-  const preserveEdit =
-    previous?.edit !== undefined &&
-    element.matches(":focus") &&
-    previous.pathKey === pathKey &&
-    previous.presentationIdentity === presentationIdentity;
   if (previous) {
     if (
       !Object.is(previous.sourceIdentity, sourceIdentity) ||
@@ -107,50 +104,7 @@ function syncScalarInputIdentity(
     pathKey,
     presentationIdentity,
     renderedValue,
-    edit: preserveEdit ? previous?.edit : undefined,
   });
-}
-
-function scalarValueBranch(value: unknown): ScalarValueBranch | undefined {
-  if (typeof value === "string") {
-    return "string";
-  }
-  if (typeof value === "number") {
-    return "number";
-  }
-  if (typeof value === "boolean") {
-    return "boolean";
-  }
-  return undefined;
-}
-
-function beginScalarEdit(
-  target: HTMLInputElement,
-  initialBranch: ScalarValueBranch | undefined,
-): ScalarEditHint {
-  const state = scalarInputState.get(target);
-  if (!state) {
-    return { branch: initialBranch };
-  }
-  if (state.edit === undefined) {
-    state.edit = { branch: initialBranch };
-  }
-  return state.edit;
-}
-
-function scalarEditHintForInput(
-  target: HTMLInputElement,
-  initialBranch: ScalarValueBranch | undefined,
-): ScalarEditHint {
-  const state = scalarInputState.get(target);
-  return state?.edit ?? { branch: initialBranch };
-}
-
-function finishScalarEdit(target: HTMLInputElement): void {
-  const state = scalarInputState.get(target);
-  if (state) {
-    state.edit = undefined;
-  }
 }
 
 function coerceTextInputValue(
@@ -399,7 +353,8 @@ export function renderTextInput(
 
   const inputControl = html`
     <input
-      ${ref((element) =>
+      ${ref((element) => {
+        syncScalarEditIdentity(element, params.rowIdentity, controlPathKey, presentationIdentity);
         syncScalarInputIdentity(
           element,
           controlIdentity,
@@ -409,8 +364,8 @@ export function renderTextInput(
           presentationIdentity,
           renderedValue,
           revalidate,
-        ),
-      )}
+        );
+      })}
       type=${effectiveInputType}
       class="settings-input${effectiveRedacted ? " cfg-redacted" : ""}"
       aria-label=${label}
@@ -507,7 +462,7 @@ export function renderTextInput(
         );
         finishScalarEdit(target);
       }}
-      @blur=${(event: Event) => finishScalarEdit(event.target as HTMLInputElement)}
+      @blur=${finishScalarEditFromEvent}
     />
   `;
   const revealToggle = isStructuredSecretRef

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -33,6 +33,12 @@ import {
   schemaType,
 } from "./config-form.shared.ts";
 
+type ScalarValueBranch = "string" | "number" | "boolean";
+
+type ScalarEditHint = {
+  branch?: ScalarValueBranch;
+};
+
 const scalarInputState = new WeakMap<
   HTMLInputElement,
   {
@@ -42,6 +48,7 @@ const scalarInputState = new WeakMap<
     pathKey: string;
     presentationIdentity: string;
     renderedValue: string;
+    edit?: ScalarEditHint;
   }
 >();
 
@@ -65,6 +72,11 @@ function syncScalarInputIdentity(
     return;
   }
   const previous = scalarInputState.get(element);
+  const preserveEdit =
+    previous?.edit !== undefined &&
+    element.matches(":focus") &&
+    previous.pathKey === pathKey &&
+    previous.presentationIdentity === presentationIdentity;
   if (previous) {
     if (
       !Object.is(previous.sourceIdentity, sourceIdentity) ||
@@ -95,17 +107,62 @@ function syncScalarInputIdentity(
     pathKey,
     presentationIdentity,
     renderedValue,
+    edit: preserveEdit ? previous?.edit : undefined,
   });
+}
+
+function scalarValueBranch(value: unknown): ScalarValueBranch | undefined {
+  if (typeof value === "string") {
+    return "string";
+  }
+  if (typeof value === "number") {
+    return "number";
+  }
+  if (typeof value === "boolean") {
+    return "boolean";
+  }
+  return undefined;
+}
+
+function beginScalarEdit(
+  target: HTMLInputElement,
+  initialBranch: ScalarValueBranch | undefined,
+): ScalarEditHint {
+  const state = scalarInputState.get(target);
+  if (!state) {
+    return { branch: initialBranch };
+  }
+  if (state.edit === undefined) {
+    state.edit = { branch: initialBranch };
+  }
+  return state.edit;
+}
+
+function scalarEditHintForInput(
+  target: HTMLInputElement,
+  initialBranch: ScalarValueBranch | undefined,
+): ScalarEditHint {
+  const state = scalarInputState.get(target);
+  return state?.edit ?? { branch: initialBranch };
+}
+
+function finishScalarEdit(target: HTMLInputElement): void {
+  const state = scalarInputState.get(target);
+  if (state) {
+    state.edit = undefined;
+  }
 }
 
 function coerceTextInputValue(
   value: string,
   schema: ConfigNodeRenderParams["schema"],
   currentValue?: unknown,
+  editHint?: ScalarEditHint,
 ): string | number | boolean | undefined {
   const trimmed = value.trim();
   const variants = schema.anyOf ?? schema.oneOf ?? [];
   const stringCandidateValid = isSupportedConfigValueValid(schema, value);
+  const currentBranch = editHint ? editHint.branch : scalarValueBranch(currentValue);
   const booleanCandidate = trimmed === "true" ? true : trimmed === "false" ? false : undefined;
   if (booleanCandidate !== undefined && isSupportedConfigValueValid(schema, booleanCandidate)) {
     let booleanBranchValid = false;
@@ -125,7 +182,7 @@ function coerceTextInputValue(
     }
     if (
       booleanBranchValid &&
-      (typeof currentValue !== "string" || explicitBooleanBranchValid || !stringCandidateValid)
+      (currentBranch !== "string" || explicitBooleanBranchValid || !stringCandidateValid)
     ) {
       return booleanCandidate;
     }
@@ -142,7 +199,7 @@ function coerceTextInputValue(
       break;
     }
   }
-  if (typeof currentValue === "number") {
+  if (currentBranch === "number") {
     if (numberCandidate !== undefined) {
       return numberCandidate;
     }
@@ -150,7 +207,7 @@ function coerceTextInputValue(
       return undefined;
     }
   }
-  if (typeof currentValue === "string" && stringCandidateValid) {
+  if (currentBranch === "string" && stringCandidateValid) {
     return value;
   }
   if (numberCandidate !== undefined) {
@@ -166,8 +223,12 @@ function stringConstraintMessage(
   value: string,
   schema: ConfigNodeRenderParams["schema"],
   currentValue?: unknown,
+  editHint?: ScalarEditHint,
 ): string {
-  return isSupportedConfigValueValid(schema, coerceTextInputValue(value, schema, currentValue))
+  return isSupportedConfigValueValid(
+    schema,
+    coerceTextInputValue(value, schema, currentValue, editHint),
+  )
     ? ""
     : t("configForm.invalidString");
 }
@@ -177,9 +238,12 @@ function shouldClearOptionalEmpty(
   schema: ConfigNodeRenderParams["schema"],
   isRequired: boolean,
   currentValue?: unknown,
+  editHint?: ScalarEditHint,
 ): boolean {
   return (
-    value === "" && !isRequired && Boolean(stringConstraintMessage(value, schema, currentValue))
+    value === "" &&
+    !isRequired &&
+    Boolean(stringConstraintMessage(value, schema, currentValue, editHint))
   );
 }
 
@@ -281,6 +345,7 @@ export function renderTextInput(
       ? jsonValue(value)
       : (value ?? "");
   const effectiveValue = value !== undefined ? value : schema.default;
+  const initialBranch = scalarValueBranch(effectiveValue);
   const effectiveInputType = sensitiveState.isSensitive && !effectiveRedacted ? "text" : inputType;
   const isPhonePresentation = hint?.presentation === "phone-number";
   const phonePresentation =
@@ -310,15 +375,17 @@ export function renderTextInput(
       return;
     }
     const raw = target.value;
+    const editHint = scalarEditHintForInput(target, initialBranch);
     const optionalEmpty = shouldClearOptionalEmpty(
       raw,
       schema,
       params.isRequired === true,
       effectiveValue,
+      editHint,
     );
     setControlValidity(
       target,
-      optionalEmpty ? "" : stringConstraintMessage(raw, schema, effectiveValue),
+      optionalEmpty ? "" : stringConstraintMessage(raw, schema, effectiveValue, editHint),
     );
   };
   const commitScalarValue = (target: HTMLInputElement, candidate: unknown) => {
@@ -373,13 +440,22 @@ export function renderTextInput(
           );
           return;
         }
-        if (shouldClearOptionalEmpty(raw, schema, params.isRequired === true, effectiveValue)) {
+        const editHint = beginScalarEdit(target, initialBranch);
+        if (
+          shouldClearOptionalEmpty(
+            raw,
+            schema,
+            params.isRequired === true,
+            effectiveValue,
+            editHint,
+          )
+        ) {
           setControlValidity(target, "");
           commitScalarValue(target, undefined);
         } else if (
-          setControlValidity(target, stringConstraintMessage(raw, schema, effectiveValue))
+          setControlValidity(target, stringConstraintMessage(raw, schema, effectiveValue, editHint))
         ) {
-          commitScalarValue(target, coerceTextInputValue(raw, schema, effectiveValue));
+          commitScalarValue(target, coerceTextInputValue(raw, schema, effectiveValue, editHint));
         }
       }}
       @change=${(event: Event) => {
@@ -387,31 +463,51 @@ export function renderTextInput(
           return;
         }
         const target = event.target as HTMLInputElement;
+        const editHint = beginScalarEdit(target, initialBranch);
         const raw = target.value;
-        const rawMessage = stringConstraintMessage(raw, schema, effectiveValue);
+        const rawMessage = stringConstraintMessage(raw, schema, effectiveValue, editHint);
         if (!rawMessage && !isPhonePresentation) {
           setControlValidity(target, "");
-          commitScalarValue(target, coerceTextInputValue(raw, schema, effectiveValue));
+          commitScalarValue(target, coerceTextInputValue(raw, schema, effectiveValue, editHint));
+          finishScalarEdit(target);
           return;
         }
         const normalized = raw.trim();
         if (
-          shouldClearOptionalEmpty(normalized, schema, params.isRequired === true, effectiveValue)
+          shouldClearOptionalEmpty(
+            normalized,
+            schema,
+            params.isRequired === true,
+            effectiveValue,
+            editHint,
+          )
         ) {
           target.value = normalized;
           setControlValidity(target, "");
           commitScalarValue(target, undefined);
+          finishScalarEdit(target);
           return;
         }
-        const normalizedMessage = stringConstraintMessage(normalized, schema, effectiveValue);
+        const normalizedMessage = stringConstraintMessage(
+          normalized,
+          schema,
+          effectiveValue,
+          editHint,
+        );
         if (normalizedMessage) {
           setControlValidity(target, rawMessage);
+          finishScalarEdit(target);
           return;
         }
         target.value = normalized;
         setControlValidity(target, "");
-        commitScalarValue(target, coerceTextInputValue(normalized, schema, effectiveValue));
+        commitScalarValue(
+          target,
+          coerceTextInputValue(normalized, schema, effectiveValue, editHint),
+        );
+        finishScalarEdit(target);
       }}
+      @blur=${(event: Event) => finishScalarEdit(event.target as HTMLInputElement)}
     />
   `;
   const revealToggle = isStructuredSecretRef

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -21,8 +21,14 @@ import {
   wrapSensitiveControl,
   type ConfigNodeRenderParams,
 } from "./config-form.node.shared.ts";
+import { coerceConfigFormNumberString } from "./config-form.numeric.ts";
 import { resolveConfigFieldMeta as resolveFieldMeta } from "./config-form.search.ts";
-import { configFieldId, hintForPath, redactedPlaceholder } from "./config-form.shared.ts";
+import {
+  configFieldId,
+  hintForPath,
+  redactedPlaceholder,
+  schemaType,
+} from "./config-form.shared.ts";
 
 const scalarInputState = new WeakMap<
   HTMLInputElement,
@@ -89,8 +95,30 @@ function syncScalarInputIdentity(
   });
 }
 
+function coerceTextInputValue(
+  value: string,
+  schema: ConfigNodeRenderParams["schema"],
+): string | number {
+  if (isSupportedConfigValueValid(schema, value)) {
+    return value;
+  }
+  for (const variant of schema.anyOf ?? schema.oneOf ?? []) {
+    const type = schemaType(variant);
+    if (type !== "number" && type !== "integer") {
+      continue;
+    }
+    const candidate = coerceConfigFormNumberString(value, type === "integer");
+    if (typeof candidate === "number" && isSupportedConfigValueValid(schema, candidate)) {
+      return candidate;
+    }
+  }
+  return value;
+}
+
 function stringConstraintMessage(value: string, schema: ConfigNodeRenderParams["schema"]): string {
-  return isSupportedConfigValueValid(schema, value) ? "" : t("configForm.invalidString");
+  return isSupportedConfigValueValid(schema, coerceTextInputValue(value, schema))
+    ? ""
+    : t("configForm.invalidString");
 }
 
 function shouldClearOptionalEmpty(
@@ -279,7 +307,7 @@ export function renderTextInput(
           setControlValidity(target, "");
           commitScalarValue(target, undefined);
         } else if (setControlValidity(target, stringConstraintMessage(raw, schema))) {
-          commitScalarValue(target, raw);
+          commitScalarValue(target, coerceTextInputValue(raw, schema));
         }
       }}
       @change=${(event: Event) => {
@@ -291,7 +319,7 @@ export function renderTextInput(
         const rawMessage = stringConstraintMessage(raw, schema);
         if (!rawMessage && !isPhonePresentation) {
           setControlValidity(target, "");
-          commitScalarValue(target, raw);
+          commitScalarValue(target, coerceTextInputValue(raw, schema));
           return;
         }
         const normalized = raw.trim();
@@ -308,7 +336,7 @@ export function renderTextInput(
         }
         target.value = normalized;
         setControlValidity(target, "");
-        commitScalarValue(target, normalized);
+        commitScalarValue(target, coerceTextInputValue(normalized, schema));
       }}
     />
   `;

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -98,7 +98,23 @@ function syncScalarInputIdentity(
 function coerceTextInputValue(
   value: string,
   schema: ConfigNodeRenderParams["schema"],
-): string | number {
+): string | number | boolean {
+  const trimmed = value.trim();
+  const booleanCandidate =
+    trimmed === "true" ? true : trimmed === "false" ? false : undefined;
+  if (
+    booleanCandidate !== undefined &&
+    (schema.anyOf ?? schema.oneOf ?? []).some(
+      (variant) =>
+        (schemaType(variant) === "boolean" ||
+          typeof variant.const === "boolean" ||
+          variant.enum?.some((entry) => typeof entry === "boolean")) &&
+        isSupportedConfigValueValid(variant, booleanCandidate),
+    ) &&
+    isSupportedConfigValueValid(schema, booleanCandidate)
+  ) {
+    return booleanCandidate;
+  }
   if (isSupportedConfigValueValid(schema, value)) {
     return value;
   }

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -23,6 +23,7 @@ import {
 } from "./config-form.node.shared.ts";
 import {
   coerceConfigFormNumberString,
+  formatConfigFormNumber,
   isConfigFormDecimalNumberString,
 } from "./config-form.numeric.ts";
 import {
@@ -58,6 +59,10 @@ function setControlValidity(target: HTMLInputElement, message: string): boolean 
   target.setCustomValidity(message);
   target.setAttribute("aria-invalid", String(Boolean(message)));
   return !message;
+}
+
+function formatScalarInputValue(value: unknown): string {
+  return typeof value === "number" ? formatConfigFormNumber(value) : formatUnknownText(value);
 }
 
 function syncScalarInputIdentity(
@@ -158,7 +163,11 @@ function coerceTextInputValue(
       return numberCandidate;
     }
     if (isConfigFormDecimalNumberString(value)) {
-      return undefined;
+      return stringCandidateValid &&
+        /^-?\d+$/u.test(trimmed) &&
+        !Number.isSafeInteger(Number(trimmed))
+        ? value
+        : undefined;
     }
   }
   if (currentBranch === "string" && stringCandidateValid) {
@@ -291,7 +300,7 @@ export function renderTextInput(
       : redactedPlaceholder()
     : (hint?.placeholder ??
       (schema.default !== undefined
-        ? t("configForm.defaultValue", { value: formatUnknownText(schema.default) })
+        ? t("configForm.defaultValue", { value: formatScalarInputValue(schema.default) })
         : ""));
   const displayValue = effectiveRedacted
     ? ""
@@ -309,7 +318,7 @@ export function renderTextInput(
   const controlIdentity = params.controlIdentity ?? params.sourceIdentity ?? value;
   const sourceIdentity = params.sourceIdentity ?? value;
   const controlPathKey = configFieldId(path, "scalar-identity");
-  const renderedValue = formatUnknownText(displayValue);
+  const renderedValue = formatScalarInputValue(displayValue);
   const presentationIdentity = [
     effectiveRedacted ? "redacted" : "visible",
     effectiveInputType,
@@ -515,7 +524,7 @@ export function renderNumberInput(params: ConfigNodeRenderParams): TemplateResul
   const controlIdentity = params.controlIdentity ?? params.sourceIdentity ?? value;
   const sourceIdentity = params.sourceIdentity ?? value;
   const controlPathKey = configFieldId(path, "scalar-identity");
-  const renderedValue = formatUnknownText(displayValue);
+  const renderedValue = formatScalarInputValue(displayValue);
   const revalidate = (target: HTMLInputElement) => {
     setControlValidity(
       target,
@@ -573,7 +582,7 @@ export function renderNumberInput(params: ConfigNodeRenderParams): TemplateResul
       aria-describedby=${helpId ?? nothing}
       aria-invalid="false"
       placeholder=${schema.default !== undefined
-        ? t("configForm.defaultValue", { value: formatUnknownText(schema.default) })
+        ? t("configForm.defaultValue", { value: formatScalarInputValue(schema.default) })
         : nothing}
       min=${constraints.min ?? nothing}
       max=${constraints.max ?? nothing}
@@ -607,7 +616,7 @@ export function renderNumberInput(params: ConfigNodeRenderParams): TemplateResul
           return;
         }
         const normalized = normalizeNumericValue(state.parsed, schema);
-        target.value = formatUnknownText(normalized);
+        target.value = formatConfigFormNumber(normalized);
         if (setControlValidity(target, numericConstraintMessage(normalized, schema))) {
           commitScalarValue(target, normalized);
         }

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -100,8 +100,7 @@ function coerceTextInputValue(
   schema: ConfigNodeRenderParams["schema"],
 ): string | number | boolean {
   const trimmed = value.trim();
-  const booleanCandidate =
-    trimmed === "true" ? true : trimmed === "false" ? false : undefined;
+  const booleanCandidate = trimmed === "true" ? true : trimmed === "false" ? false : undefined;
   if (
     booleanCandidate !== undefined &&
     (schema.anyOf ?? schema.oneOf ?? []).some(

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -3,7 +3,6 @@ import { formatInternationalPhoneNumberForDisplay } from "@openclaw/normalizatio
 import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { i18n, t } from "../i18n/index.ts";
-import { formatUnknownText } from "../lib/format.ts";
 import {
   isSupportedConfigValueValid,
   normalizeNumericValue,
@@ -11,6 +10,7 @@ import {
 } from "./config-form.constraints.ts";
 import {
   configEnumOptionLabel,
+  formatConfigValueText,
   getSensitiveRenderState,
   isSecretRefObject,
   jsonValue,
@@ -23,8 +23,8 @@ import {
 } from "./config-form.node.shared.ts";
 import {
   coerceConfigFormNumberString,
-  formatConfigFormNumber,
   isConfigFormDecimalNumberString,
+  isConfigFormUnsafeIntegerString,
 } from "./config-form.numeric.ts";
 import {
   beginScalarEdit,
@@ -59,10 +59,6 @@ function setControlValidity(target: HTMLInputElement, message: string): boolean 
   target.setCustomValidity(message);
   target.setAttribute("aria-invalid", String(Boolean(message)));
   return !message;
-}
-
-function formatScalarInputValue(value: unknown): string {
-  return typeof value === "number" ? formatConfigFormNumber(value) : formatUnknownText(value);
 }
 
 function syncScalarInputIdentity(
@@ -163,11 +159,7 @@ function coerceTextInputValue(
       return numberCandidate;
     }
     if (isConfigFormDecimalNumberString(value)) {
-      return stringCandidateValid &&
-        /^-?\d+$/u.test(trimmed) &&
-        !Number.isSafeInteger(Number(trimmed))
-        ? value
-        : undefined;
+      return stringCandidateValid && isConfigFormUnsafeIntegerString(trimmed) ? value : undefined;
     }
   }
   if (currentBranch === "string" && stringCandidateValid) {
@@ -300,7 +292,7 @@ export function renderTextInput(
       : redactedPlaceholder()
     : (hint?.placeholder ??
       (schema.default !== undefined
-        ? t("configForm.defaultValue", { value: formatScalarInputValue(schema.default) })
+        ? t("configForm.defaultValue", { value: formatConfigValueText(schema.default) })
         : ""));
   const displayValue = effectiveRedacted
     ? ""
@@ -318,7 +310,7 @@ export function renderTextInput(
   const controlIdentity = params.controlIdentity ?? params.sourceIdentity ?? value;
   const sourceIdentity = params.sourceIdentity ?? value;
   const controlPathKey = configFieldId(path, "scalar-identity");
-  const renderedValue = formatScalarInputValue(displayValue);
+  const renderedValue = formatConfigValueText(displayValue);
   const presentationIdentity = [
     effectiveRedacted ? "redacted" : "visible",
     effectiveInputType,
@@ -524,7 +516,7 @@ export function renderNumberInput(params: ConfigNodeRenderParams): TemplateResul
   const controlIdentity = params.controlIdentity ?? params.sourceIdentity ?? value;
   const sourceIdentity = params.sourceIdentity ?? value;
   const controlPathKey = configFieldId(path, "scalar-identity");
-  const renderedValue = formatScalarInputValue(displayValue);
+  const renderedValue = formatConfigValueText(displayValue);
   const revalidate = (target: HTMLInputElement) => {
     setControlValidity(
       target,
@@ -582,7 +574,7 @@ export function renderNumberInput(params: ConfigNodeRenderParams): TemplateResul
       aria-describedby=${helpId ?? nothing}
       aria-invalid="false"
       placeholder=${schema.default !== undefined
-        ? t("configForm.defaultValue", { value: formatScalarInputValue(schema.default) })
+        ? t("configForm.defaultValue", { value: formatConfigValueText(schema.default) })
         : nothing}
       min=${constraints.min ?? nothing}
       max=${constraints.max ?? nothing}
@@ -616,7 +608,7 @@ export function renderNumberInput(params: ConfigNodeRenderParams): TemplateResul
           return;
         }
         const normalized = normalizeNumericValue(state.parsed, schema);
-        target.value = formatConfigFormNumber(normalized);
+        target.value = formatConfigValueText(normalized);
         if (setControlValidity(target, numericConstraintMessage(normalized, schema))) {
           commitScalarValue(target, normalized);
         }
@@ -706,7 +698,7 @@ export function renderSelect(
         ?disabled=${params.isRequired && schema.default === undefined}
       >
         ${schema.default !== undefined
-          ? t("configForm.defaultValue", { value: formatUnknownText(schema.default) })
+          ? t("configForm.defaultValue", { value: formatConfigValueText(schema.default) })
           : t("configForm.select")}
       </option>
       ${canSelectNull

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -182,6 +182,7 @@ function numericConstraintMessage(value: number, schema: ConfigNodeRenderParams[
 type NumericInputState =
   | { kind: "badInput" }
   | { kind: "empty" }
+  | { kind: "invalid" }
   | { kind: "value"; parsed: number; message: string };
 
 // Partial numeric text ("3.", "-", "1e") reports value === "" with
@@ -195,13 +196,19 @@ function resolveNumericInputState(
   if (raw.trim() === "") {
     return target.validity.badInput ? { kind: "badInput" } : { kind: "empty" };
   }
-  const parsed = Number(raw);
+  const parsed = coerceConfigFormNumberString(raw, schemaType(schema) === "integer");
+  if (typeof parsed !== "number") {
+    return { kind: "invalid" };
+  }
   return { kind: "value", parsed, message: numericConstraintMessage(parsed, schema) };
 }
 
 function numericStateMessage(state: NumericInputState, isRequired: boolean): string {
   if (state.kind === "value") {
     return state.message;
+  }
+  if (state.kind === "invalid") {
+    return t("configForm.invalidNumber");
   }
   return state.kind === "badInput" || isRequired ? t("configForm.invalidNumber") : "";
 }
@@ -218,7 +225,7 @@ function applyNumericInputState(
   if (state.kind === "empty") {
     commit(undefined);
   } else if (state.kind === "value") {
-    commit(Number.isNaN(state.parsed) ? target.value : state.parsed);
+    commit(state.parsed);
   }
 }
 
@@ -535,18 +542,12 @@ export function renderNumberInput(params: ConfigNodeRenderParams): TemplateResul
       }}
       @change=${(event: Event) => {
         const target = event.target as HTMLInputElement;
-        if (target.value === "") {
-          if (target.validity.badInput) {
-            setControlValidity(target, t("configForm.invalidNumber"));
-          }
+        const state = resolveNumericInputState(target, schema);
+        if (state.kind !== "value") {
+          setControlValidity(target, numericStateMessage(state, params.isRequired === true));
           return;
         }
-        const parsed = Number(target.value);
-        if (!Number.isFinite(parsed)) {
-          setControlValidity(target, t("configForm.invalidNumber"));
-          return;
-        }
-        const normalized = normalizeNumericValue(parsed, schema);
+        const normalized = normalizeNumericValue(state.parsed, schema);
         target.value = formatUnknownText(normalized);
         if (setControlValidity(target, numericConstraintMessage(normalized, schema))) {
           commitScalarValue(target, normalized);

--- a/ui/src/components/config-form.node.scalar.ts
+++ b/ui/src/components/config-form.node.scalar.ts
@@ -98,40 +98,68 @@ function syncScalarInputIdentity(
 function coerceTextInputValue(
   value: string,
   schema: ConfigNodeRenderParams["schema"],
+  currentValue?: unknown,
 ): string | number | boolean {
   const trimmed = value.trim();
+  const variants = schema.anyOf ?? schema.oneOf ?? [];
+  const stringCandidateValid = isSupportedConfigValueValid(schema, value);
   const booleanCandidate = trimmed === "true" ? true : trimmed === "false" ? false : undefined;
-  if (
-    booleanCandidate !== undefined &&
-    (schema.anyOf ?? schema.oneOf ?? []).some(
-      (variant) =>
-        (schemaType(variant) === "boolean" ||
-          typeof variant.const === "boolean" ||
-          variant.enum?.some((entry) => typeof entry === "boolean")) &&
-        isSupportedConfigValueValid(variant, booleanCandidate),
-    ) &&
-    isSupportedConfigValueValid(schema, booleanCandidate)
-  ) {
-    return booleanCandidate;
+  if (booleanCandidate !== undefined && isSupportedConfigValueValid(schema, booleanCandidate)) {
+    let booleanBranchValid = false;
+    let explicitBooleanBranchValid = false;
+    for (const variant of variants) {
+      const booleanBranch =
+        schemaType(variant) === "boolean" ||
+        typeof variant.const === "boolean" ||
+        variant.enum?.some((entry) => typeof entry === "boolean");
+      if (!booleanBranch || !isSupportedConfigValueValid(variant, booleanCandidate)) {
+        continue;
+      }
+      booleanBranchValid = true;
+      explicitBooleanBranchValid ||=
+        Object.is(variant.const, booleanCandidate) ||
+        Boolean(variant.enum?.some((entry) => Object.is(entry, booleanCandidate)));
+    }
+    if (
+      booleanBranchValid &&
+      (typeof currentValue !== "string" || explicitBooleanBranchValid || !stringCandidateValid)
+    ) {
+      return booleanCandidate;
+    }
   }
-  if (isSupportedConfigValueValid(schema, value)) {
-    return value;
-  }
-  for (const variant of schema.anyOf ?? schema.oneOf ?? []) {
+  let numberCandidate: number | undefined;
+  for (const variant of variants) {
     const type = schemaType(variant);
     if (type !== "number" && type !== "integer") {
       continue;
     }
     const candidate = coerceConfigFormNumberString(value, type === "integer");
     if (typeof candidate === "number" && isSupportedConfigValueValid(schema, candidate)) {
-      return candidate;
+      numberCandidate = candidate;
+      break;
     }
+  }
+  if (typeof currentValue === "number" && numberCandidate !== undefined) {
+    return numberCandidate;
+  }
+  if (typeof currentValue === "string" && stringCandidateValid) {
+    return value;
+  }
+  if (numberCandidate !== undefined) {
+    return numberCandidate;
+  }
+  if (stringCandidateValid) {
+    return value;
   }
   return value;
 }
 
-function stringConstraintMessage(value: string, schema: ConfigNodeRenderParams["schema"]): string {
-  return isSupportedConfigValueValid(schema, coerceTextInputValue(value, schema))
+function stringConstraintMessage(
+  value: string,
+  schema: ConfigNodeRenderParams["schema"],
+  currentValue?: unknown,
+): string {
+  return isSupportedConfigValueValid(schema, coerceTextInputValue(value, schema, currentValue))
     ? ""
     : t("configForm.invalidString");
 }
@@ -140,8 +168,11 @@ function shouldClearOptionalEmpty(
   value: string,
   schema: ConfigNodeRenderParams["schema"],
   isRequired: boolean,
+  currentValue?: unknown,
 ): boolean {
-  return value === "" && !isRequired && Boolean(stringConstraintMessage(value, schema));
+  return (
+    value === "" && !isRequired && Boolean(stringConstraintMessage(value, schema, currentValue))
+  );
 }
 
 function numericConstraintMessage(value: number, schema: ConfigNodeRenderParams["schema"]): string {
@@ -234,6 +265,7 @@ export function renderTextInput(
     : isStructuredValue
       ? jsonValue(value)
       : (value ?? "");
+  const effectiveValue = value !== undefined ? value : schema.default;
   const effectiveInputType = sensitiveState.isSensitive && !effectiveRedacted ? "text" : inputType;
   const isPhonePresentation = hint?.presentation === "phone-number";
   const phonePresentation =
@@ -263,8 +295,16 @@ export function renderTextInput(
       return;
     }
     const raw = target.value;
-    const optionalEmpty = shouldClearOptionalEmpty(raw, schema, params.isRequired === true);
-    setControlValidity(target, optionalEmpty ? "" : stringConstraintMessage(raw, schema));
+    const optionalEmpty = shouldClearOptionalEmpty(
+      raw,
+      schema,
+      params.isRequired === true,
+      effectiveValue,
+    );
+    setControlValidity(
+      target,
+      optionalEmpty ? "" : stringConstraintMessage(raw, schema, effectiveValue),
+    );
   };
   const commitScalarValue = (target: HTMLInputElement, candidate: unknown) => {
     if (onPatch(path, candidate) !== false) {
@@ -318,11 +358,13 @@ export function renderTextInput(
           );
           return;
         }
-        if (shouldClearOptionalEmpty(raw, schema, params.isRequired === true)) {
+        if (shouldClearOptionalEmpty(raw, schema, params.isRequired === true, effectiveValue)) {
           setControlValidity(target, "");
           commitScalarValue(target, undefined);
-        } else if (setControlValidity(target, stringConstraintMessage(raw, schema))) {
-          commitScalarValue(target, coerceTextInputValue(raw, schema));
+        } else if (
+          setControlValidity(target, stringConstraintMessage(raw, schema, effectiveValue))
+        ) {
+          commitScalarValue(target, coerceTextInputValue(raw, schema, effectiveValue));
         }
       }}
       @change=${(event: Event) => {
@@ -331,27 +373,29 @@ export function renderTextInput(
         }
         const target = event.target as HTMLInputElement;
         const raw = target.value;
-        const rawMessage = stringConstraintMessage(raw, schema);
+        const rawMessage = stringConstraintMessage(raw, schema, effectiveValue);
         if (!rawMessage && !isPhonePresentation) {
           setControlValidity(target, "");
-          commitScalarValue(target, coerceTextInputValue(raw, schema));
+          commitScalarValue(target, coerceTextInputValue(raw, schema, effectiveValue));
           return;
         }
         const normalized = raw.trim();
-        if (shouldClearOptionalEmpty(normalized, schema, params.isRequired === true)) {
+        if (
+          shouldClearOptionalEmpty(normalized, schema, params.isRequired === true, effectiveValue)
+        ) {
           target.value = normalized;
           setControlValidity(target, "");
           commitScalarValue(target, undefined);
           return;
         }
-        const normalizedMessage = stringConstraintMessage(normalized, schema);
+        const normalizedMessage = stringConstraintMessage(normalized, schema, effectiveValue);
         if (normalizedMessage) {
           setControlValidity(target, rawMessage);
           return;
         }
         target.value = normalized;
         setControlValidity(target, "");
-        commitScalarValue(target, coerceTextInputValue(normalized, schema));
+        commitScalarValue(target, coerceTextInputValue(normalized, schema, effectiveValue));
       }}
     />
   `;

--- a/ui/src/components/config-form.node.shared.ts
+++ b/ui/src/components/config-form.node.shared.ts
@@ -9,6 +9,7 @@ import "../components/tooltip.ts";
 import { REDACTED_SENTINEL } from "../lib/config-form-utils.ts";
 import { formatUnknownText } from "../lib/format.ts";
 import { configValuesEqual, isSupportedConfigValueValid } from "./config-form.constraints.ts";
+import { formatConfigFormNumber } from "./config-form.numeric.ts";
 import type { ConfigSearchCriteria } from "./config-form.search.ts";
 import {
   configFieldId,
@@ -82,6 +83,10 @@ export function jsonValue(value: unknown): string {
   } catch {
     return "";
   }
+}
+
+export function formatConfigValueText(value: unknown): string {
+  return typeof value === "number" ? formatConfigFormNumber(value) : formatUnknownText(value);
 }
 
 export function schemaWithDefault(schema: JsonSchema, value: unknown): JsonSchema {
@@ -315,7 +320,7 @@ export function renderSchemaDefaultDescription(
     return nothing;
   }
   return html`${t(value === undefined ? "configForm.usingDefault" : "configForm.defaultValue", {
-    value: formatUnknownText(schema.default),
+    value: formatConfigValueText(schema.default),
   })}`;
 }
 
@@ -384,7 +389,7 @@ export function renderSegmentedControl(params: {
 export function configEnumOptionLabel(option: unknown, options: readonly unknown[]): string {
   const presentsBooleanState = options.includes(true) && options.includes(false);
   if (!presentsBooleanState) {
-    return formatUnknownText(option);
+    return formatConfigValueText(option);
   }
   if (option === true) {
     return t("configForm.enumOn");
@@ -392,7 +397,7 @@ export function configEnumOptionLabel(option: unknown, options: readonly unknown
   if (option === false) {
     return t("configForm.enumOff");
   }
-  return option === "auto" ? t("configForm.enumAuto") : formatUnknownText(option);
+  return option === "auto" ? t("configForm.enumAuto") : formatConfigValueText(option);
 }
 
 export function renderJsonTextareaControl(params: {

--- a/ui/src/components/config-form.numeric.ts
+++ b/ui/src/components/config-form.numeric.ts
@@ -4,7 +4,6 @@ type DecimalRational = {
 };
 
 const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
-const CONFIG_FORM_INTEGER_TEXT_RE = /^-?\d+$/u;
 
 export function coerceConfigFormNumberString(
   value: string,
@@ -21,13 +20,9 @@ export function coerceConfigFormNumberString(
   if (!Number.isFinite(parsed) || (integer && !Number.isInteger(parsed))) {
     return value;
   }
-  // 64-bit ids (Discord/Telegram snowflakes) exceed Number's 2^53 integer
-  // precision; a lossy parse would silently rewrite the id, so keep the string.
-  if (
-    CONFIG_FORM_INTEGER_TEXT_RE.test(trimmed) &&
-    !Number.isSafeInteger(parsed) &&
-    BigInt(trimmed) !== BigInt(parsed)
-  ) {
+  // JSON numbers cannot safely carry integer magnitudes beyond 2^53, even
+  // when the input used exponent or fractional notation.
+  if (Number.isInteger(parsed) && !Number.isSafeInteger(parsed)) {
     return value;
   }
   return parsed;

--- a/ui/src/components/config-form.numeric.ts
+++ b/ui/src/components/config-form.numeric.ts
@@ -4,6 +4,7 @@ type DecimalRational = {
 };
 
 const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
+const CONFIG_FORM_INTEGER_TEXT_RE = /^-?\d+$/u;
 
 export function coerceConfigFormNumberString(
   value: string,
@@ -18,6 +19,15 @@ export function coerceConfigFormNumberString(
   }
   const parsed = Number(trimmed);
   if (!Number.isFinite(parsed) || (integer && !Number.isInteger(parsed))) {
+    return value;
+  }
+  // 64-bit ids (Discord/Telegram snowflakes) exceed Number's 2^53 integer
+  // precision; a lossy parse would silently rewrite the id, so keep the string.
+  if (
+    CONFIG_FORM_INTEGER_TEXT_RE.test(trimmed) &&
+    !Number.isSafeInteger(parsed) &&
+    BigInt(trimmed) !== BigInt(parsed)
+  ) {
     return value;
   }
   return parsed;

--- a/ui/src/components/config-form.numeric.ts
+++ b/ui/src/components/config-form.numeric.ts
@@ -5,6 +5,13 @@ type DecimalRational = {
 
 const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
 const MAX_CONFIG_FORM_DECIMAL_RATIONAL_DIGITS = 1024;
+const DOUBLE_FRACTION_BITS = 52n;
+const DOUBLE_FRACTION_MASK = (1n << DOUBLE_FRACTION_BITS) - 1n;
+const DOUBLE_EXPONENT_MASK = 0x7ffn;
+const DOUBLE_EXPONENT_BIAS = 1023;
+const DOUBLE_SIGN_MASK = 1n << 63n;
+const DOUBLE_SUBNORMAL_DENOMINATOR = 2n ** 1074n;
+const DOUBLE_BITS_VIEW = new DataView(new ArrayBuffer(8));
 
 function decimalStringRational(value: string): DecimalRational | undefined {
   if (!CONFIG_FORM_DECIMAL_NUMBER_RE.test(value)) {
@@ -63,13 +70,56 @@ export function coerceConfigFormNumberString(
     return value;
   }
   const authored = decimalStringRational(trimmed);
-  const represented = decimalRational(parsed);
-  if (!authored || !represented || !decimalRationalsEqual(authored, represented)) {
+  if (!authored) {
+    return value;
+  }
+  const represented = binaryDoubleRational(parsed);
+  const decimalSpelling = Number.isInteger(parsed) ? undefined : decimalRational(parsed);
+  // Integer-valued doubles need bit-exact comparison: shortest-decimal output
+  // can hide a rounded integer. Fractional values retain decimal-spelling
+  // comparison so ordinary JSON decimals such as 0.10 keep their old type.
+  const matchesRepresentedValue = Number.isInteger(parsed)
+    ? represented && decimalRationalsEqual(authored, represented)
+    : decimalSpelling && decimalRationalsEqual(authored, decimalSpelling);
+  if (!matchesRepresentedValue) {
     return value;
   }
   return parsed;
 }
 
+function binaryDoubleRational(value: number): DecimalRational | undefined {
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+  DOUBLE_BITS_VIEW.setFloat64(0, value);
+  const bits = DOUBLE_BITS_VIEW.getBigUint64(0);
+  const negative = (bits & DOUBLE_SIGN_MASK) !== 0n;
+  const fraction = bits & DOUBLE_FRACTION_MASK;
+  const exponentBits = Number((bits >> DOUBLE_FRACTION_BITS) & DOUBLE_EXPONENT_MASK);
+  if (exponentBits === 0) {
+    if (fraction === 0n) {
+      return { numerator: 0n, denominator: 1n };
+    }
+    return {
+      numerator: negative ? -fraction : fraction,
+      denominator: DOUBLE_SUBNORMAL_DENOMINATOR,
+    };
+  }
+
+  const significand = (1n << DOUBLE_FRACTION_BITS) | fraction;
+  const exponent = exponentBits - DOUBLE_EXPONENT_BIAS - Number(DOUBLE_FRACTION_BITS);
+  if (exponent >= 0) {
+    const numerator = significand * 2n ** BigInt(exponent);
+    return { numerator: negative ? -numerator : numerator, denominator: 1n };
+  }
+  return {
+    numerator: negative ? -significand : significand,
+    denominator: 2n ** BigInt(-exponent),
+  };
+}
+
+// Keep this decimal-spelling form for JSON Schema step arithmetic; scalar
+// integer coercion uses binaryDoubleRational above to detect hidden rounding.
 export function decimalRational(value: number): DecimalRational | undefined {
   if (!Number.isFinite(value)) {
     return undefined;

--- a/ui/src/components/config-form.numeric.ts
+++ b/ui/src/components/config-form.numeric.ts
@@ -5,13 +5,6 @@ type DecimalRational = {
 
 const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
 const MAX_CONFIG_FORM_DECIMAL_RATIONAL_DIGITS = 1024;
-const DOUBLE_FRACTION_BITS = 52n;
-const DOUBLE_FRACTION_MASK = (1n << DOUBLE_FRACTION_BITS) - 1n;
-const DOUBLE_EXPONENT_MASK = 0x7ffn;
-const DOUBLE_EXPONENT_BIAS = 1023;
-const DOUBLE_SIGN_MASK = 1n << 63n;
-const DOUBLE_SUBNORMAL_DENOMINATOR = 2n ** 1074n;
-const DOUBLE_BITS_VIEW = new DataView(new ArrayBuffer(8));
 
 function decimalStringRational(value: string): DecimalRational | undefined {
   if (!CONFIG_FORM_DECIMAL_NUMBER_RE.test(value)) {
@@ -73,13 +66,12 @@ export function coerceConfigFormNumberString(
   if (!authored) {
     return value;
   }
-  const represented = binaryDoubleRational(parsed);
   const decimalSpelling = Number.isInteger(parsed) ? undefined : decimalRational(parsed);
   // Integer-valued doubles need bit-exact comparison: shortest-decimal output
   // can hide a rounded integer. Fractional values retain decimal-spelling
   // comparison so ordinary JSON decimals such as 0.10 keep their old type.
   const matchesRepresentedValue = Number.isInteger(parsed)
-    ? represented && decimalRationalsEqual(authored, represented)
+    ? authored.numerator === BigInt(parsed) * authored.denominator
     : decimalSpelling && decimalRationalsEqual(authored, decimalSpelling);
   if (!matchesRepresentedValue) {
     return value;
@@ -87,39 +79,12 @@ export function coerceConfigFormNumberString(
   return parsed;
 }
 
-function binaryDoubleRational(value: number): DecimalRational | undefined {
-  if (!Number.isFinite(value)) {
-    return undefined;
-  }
-  DOUBLE_BITS_VIEW.setFloat64(0, value);
-  const bits = DOUBLE_BITS_VIEW.getBigUint64(0);
-  const negative = (bits & DOUBLE_SIGN_MASK) !== 0n;
-  const fraction = bits & DOUBLE_FRACTION_MASK;
-  const exponentBits = Number((bits >> DOUBLE_FRACTION_BITS) & DOUBLE_EXPONENT_MASK);
-  if (exponentBits === 0) {
-    if (fraction === 0n) {
-      return { numerator: 0n, denominator: 1n };
-    }
-    return {
-      numerator: negative ? -fraction : fraction,
-      denominator: DOUBLE_SUBNORMAL_DENOMINATOR,
-    };
-  }
-
-  const significand = (1n << DOUBLE_FRACTION_BITS) | fraction;
-  const exponent = exponentBits - DOUBLE_EXPONENT_BIAS - Number(DOUBLE_FRACTION_BITS);
-  if (exponent >= 0) {
-    const numerator = significand * 2n ** BigInt(exponent);
-    return { numerator: negative ? -numerator : numerator, denominator: 1n };
-  }
-  return {
-    numerator: negative ? -significand : significand,
-    denominator: 2n ** BigInt(-exponent),
-  };
+export function formatConfigFormNumber(value: number): string {
+  return Number.isInteger(value) ? BigInt(value).toString() : String(value);
 }
 
 // Keep this decimal-spelling form for JSON Schema step arithmetic; scalar
-// integer coercion uses binaryDoubleRational above to detect hidden rounding.
+// integer coercion uses BigInt above to detect hidden rounding.
 export function decimalRational(value: number): DecimalRational | undefined {
   if (!Number.isFinite(value)) {
     return undefined;

--- a/ui/src/components/config-form.numeric.ts
+++ b/ui/src/components/config-form.numeric.ts
@@ -11,15 +11,18 @@ function decimalStringRational(value: string): DecimalRational | undefined {
     return undefined;
   }
   const [coefficientText = "", exponentText] = value.toLowerCase().split("e");
-  const exponent = Number(exponentText ?? 0);
-  if (!Number.isSafeInteger(exponent)) {
-    return undefined;
-  }
   const negative = coefficientText.startsWith("-");
   const coefficient = negative ? coefficientText.slice(1) : coefficientText;
   const [wholeText = "", fraction = ""] = coefficient.split(".");
   const whole = wholeText || "0";
   const digitsText = `${whole}${fraction}`;
+  if (/^0+$/u.test(digitsText)) {
+    return { numerator: 0n, denominator: 1n };
+  }
+  const exponent = Number(exponentText ?? 0);
+  if (!Number.isSafeInteger(exponent)) {
+    return undefined;
+  }
   const fractionalPlaces = fraction.length - exponent;
   if (
     digitsText.length > MAX_CONFIG_FORM_DECIMAL_RATIONAL_DIGITS ||
@@ -39,6 +42,11 @@ function decimalRationalsEqual(left: DecimalRational, right: DecimalRational): b
   return left.numerator * right.denominator === right.numerator * left.denominator;
 }
 
+export function isConfigFormDecimalNumberString(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed !== "" && CONFIG_FORM_DECIMAL_NUMBER_RE.test(trimmed);
+}
+
 export function coerceConfigFormNumberString(
   value: string,
   integer: boolean,
@@ -47,7 +55,7 @@ export function coerceConfigFormNumberString(
   if (trimmed === "") {
     return undefined;
   }
-  if (!CONFIG_FORM_DECIMAL_NUMBER_RE.test(trimmed)) {
+  if (!isConfigFormDecimalNumberString(trimmed)) {
     return value;
   }
   const parsed = Number(trimmed);
@@ -57,11 +65,6 @@ export function coerceConfigFormNumberString(
   const authored = decimalStringRational(trimmed);
   const represented = decimalRational(parsed);
   if (!authored || !represented || !decimalRationalsEqual(authored, represented)) {
-    return value;
-  }
-  // JSON numbers cannot safely carry integer magnitudes beyond 2^53, even
-  // when the input used exponent or fractional notation.
-  if (Number.isInteger(parsed) && !Number.isSafeInteger(parsed)) {
     return value;
   }
   return parsed;

--- a/ui/src/components/config-form.numeric.ts
+++ b/ui/src/components/config-form.numeric.ts
@@ -47,6 +47,11 @@ export function isConfigFormDecimalNumberString(value: string): boolean {
   return trimmed !== "" && CONFIG_FORM_DECIMAL_NUMBER_RE.test(trimmed);
 }
 
+export function isConfigFormUnsafeIntegerString(value: string): boolean {
+  const trimmed = value.trim();
+  return /^-?\d+$/u.test(trimmed) && !Number.isSafeInteger(Number(trimmed));
+}
+
 export function coerceConfigFormNumberString(
   value: string,
   integer: boolean,

--- a/ui/src/components/config-form.numeric.ts
+++ b/ui/src/components/config-form.numeric.ts
@@ -4,6 +4,40 @@ type DecimalRational = {
 };
 
 const CONFIG_FORM_DECIMAL_NUMBER_RE = /^-?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/u;
+const MAX_CONFIG_FORM_DECIMAL_RATIONAL_DIGITS = 1024;
+
+function decimalStringRational(value: string): DecimalRational | undefined {
+  if (!CONFIG_FORM_DECIMAL_NUMBER_RE.test(value)) {
+    return undefined;
+  }
+  const [coefficientText = "", exponentText] = value.toLowerCase().split("e");
+  const exponent = Number(exponentText ?? 0);
+  if (!Number.isSafeInteger(exponent)) {
+    return undefined;
+  }
+  const negative = coefficientText.startsWith("-");
+  const coefficient = negative ? coefficientText.slice(1) : coefficientText;
+  const [wholeText = "", fraction = ""] = coefficient.split(".");
+  const whole = wholeText || "0";
+  const digitsText = `${whole}${fraction}`;
+  const fractionalPlaces = fraction.length - exponent;
+  if (
+    digitsText.length > MAX_CONFIG_FORM_DECIMAL_RATIONAL_DIGITS ||
+    Math.abs(fractionalPlaces) > MAX_CONFIG_FORM_DECIMAL_RATIONAL_DIGITS
+  ) {
+    return undefined;
+  }
+  const digits = BigInt(digitsText);
+  const numerator = fractionalPlaces < 0 ? digits * 10n ** BigInt(-fractionalPlaces) : digits;
+  return {
+    numerator: negative ? -numerator : numerator,
+    denominator: fractionalPlaces > 0 ? 10n ** BigInt(fractionalPlaces) : 1n,
+  };
+}
+
+function decimalRationalsEqual(left: DecimalRational, right: DecimalRational): boolean {
+  return left.numerator * right.denominator === right.numerator * left.denominator;
+}
 
 export function coerceConfigFormNumberString(
   value: string,
@@ -20,6 +54,11 @@ export function coerceConfigFormNumberString(
   if (!Number.isFinite(parsed) || (integer && !Number.isInteger(parsed))) {
     return value;
   }
+  const authored = decimalStringRational(trimmed);
+  const represented = decimalRational(parsed);
+  if (!authored || !represented || !decimalRationalsEqual(authored, represented)) {
+    return value;
+  }
   // JSON numbers cannot safely carry integer magnitudes beyond 2^53, even
   // when the input used exponent or fractional notation.
   if (Number.isInteger(parsed) && !Number.isSafeInteger(parsed)) {
@@ -32,16 +71,5 @@ export function decimalRational(value: number): DecimalRational | undefined {
   if (!Number.isFinite(value)) {
     return undefined;
   }
-  const [coefficientText = "", exponentText] = String(value).toLowerCase().split("e");
-  const negative = coefficientText.startsWith("-");
-  const coefficient = negative ? coefficientText.slice(1) : coefficientText;
-  const [whole = "0", fraction = ""] = coefficient.split(".");
-  const exponent = Number(exponentText ?? 0);
-  const digits = BigInt(`${whole}${fraction}`);
-  const fractionalPlaces = fraction.length - exponent;
-  const numerator = fractionalPlaces < 0 ? digits * 10n ** BigInt(-fractionalPlaces) : digits;
-  return {
-    numerator: negative ? -numerator : numerator,
-    denominator: fractionalPlaces > 0 ? 10n ** BigInt(fractionalPlaces) : 1n,
-  };
+  return decimalStringRational(String(value));
 }

--- a/ui/src/components/config-form.scalar-edit.ts
+++ b/ui/src/components/config-form.scalar-edit.ts
@@ -1,5 +1,5 @@
 // Scalar edit sessions keep their initial primitive branch while focused rerenders apply patches.
-export type ScalarValueBranch = "string" | "number" | "boolean";
+type ScalarValueBranch = "string" | "number" | "boolean";
 
 export type ScalarEditHint = {
   branch?: ScalarValueBranch;

--- a/ui/src/components/config-form.scalar-edit.ts
+++ b/ui/src/components/config-form.scalar-edit.ts
@@ -1,0 +1,84 @@
+// Scalar edit sessions keep their initial primitive branch while focused rerenders apply patches.
+export type ScalarValueBranch = "string" | "number" | "boolean";
+
+export type ScalarEditHint = {
+  branch?: ScalarValueBranch;
+};
+
+type ScalarEditState = {
+  edit?: ScalarEditHint;
+  pathKey: string;
+  presentationIdentity: string;
+  rowIdentity: unknown;
+};
+
+const scalarEditState = new WeakMap<HTMLInputElement, ScalarEditState>();
+
+export function scalarValueBranch(value: unknown): ScalarValueBranch | undefined {
+  if (typeof value === "string") {
+    return "string";
+  }
+  if (typeof value === "number") {
+    return "number";
+  }
+  if (typeof value === "boolean") {
+    return "boolean";
+  }
+  return undefined;
+}
+
+export function syncScalarEditIdentity(
+  element: Element | undefined,
+  rowIdentity: unknown,
+  pathKey: string,
+  presentationIdentity: string,
+): void {
+  if (!(element instanceof HTMLInputElement)) {
+    return;
+  }
+  const previous = scalarEditState.get(element);
+  const preserveEdit =
+    previous?.edit !== undefined &&
+    element.matches(":focus") &&
+    Object.is(previous.rowIdentity, rowIdentity) &&
+    previous.pathKey === pathKey &&
+    previous.presentationIdentity === presentationIdentity;
+  scalarEditState.set(element, {
+    edit: preserveEdit ? previous.edit : undefined,
+    pathKey,
+    presentationIdentity,
+    rowIdentity,
+  });
+}
+
+export function beginScalarEdit(
+  target: HTMLInputElement,
+  initialBranch: ScalarValueBranch | undefined,
+): ScalarEditHint {
+  const state = scalarEditState.get(target);
+  if (!state) {
+    return { branch: initialBranch };
+  }
+  state.edit ??= { branch: initialBranch };
+  return state.edit;
+}
+
+export function scalarEditHintForInput(
+  target: HTMLInputElement,
+  initialBranch: ScalarValueBranch | undefined,
+): ScalarEditHint {
+  return scalarEditState.get(target)?.edit ?? { branch: initialBranch };
+}
+
+export function finishScalarEdit(target: HTMLInputElement): void {
+  const state = scalarEditState.get(target);
+  if (state) {
+    state.edit = undefined;
+  }
+}
+
+export function finishScalarEditFromEvent(event: Event): void {
+  if (event.currentTarget instanceof HTMLInputElement) {
+    finishScalarEdit(event.currentTarget);
+  }
+}

--- a/ui/src/components/config-form.scalar-edit.ts
+++ b/ui/src/components/config-form.scalar-edit.ts
@@ -39,7 +39,7 @@ export function syncScalarEditIdentity(
   const previous = scalarEditState.get(element);
   const preserveEdit =
     previous?.edit !== undefined &&
-    element.matches(":focus") &&
+    element.ownerDocument.activeElement === element &&
     Object.is(previous.rowIdentity, rowIdentity) &&
     previous.pathKey === pathKey &&
     previous.presentationIdentity === presentationIdentity;

--- a/ui/src/components/config-form.shared.ts
+++ b/ui/src/components/config-form.shared.ts
@@ -45,6 +45,29 @@ export function schemaType(schema: JsonSchema): string | undefined {
   return schema.type;
 }
 
+export function schemaMayAcceptString(schema: JsonSchema): boolean {
+  const declaredTypes = Array.isArray(schema.type) ? schema.type : schema.type ? [schema.type] : [];
+  if (declaredTypes.length > 0 && !declaredTypes.includes("string")) {
+    return false;
+  }
+  if (schema.const !== undefined && typeof schema.const !== "string") {
+    return false;
+  }
+  if (schema.enum && !schema.enum.some((entry) => typeof entry === "string")) {
+    return false;
+  }
+  if (schema.allOf && !schema.allOf.every(schemaMayAcceptString)) {
+    return false;
+  }
+  if (schema.anyOf && !schema.anyOf.some(schemaMayAcceptString)) {
+    return false;
+  }
+  if (schema.oneOf && !schema.oneOf.some(schemaMayAcceptString)) {
+    return false;
+  }
+  return true;
+}
+
 export function configFieldId(path: Array<string | number>, suffix: string): string {
   const key =
     path.length === 0

--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -1,5 +1,5 @@
 // Control UI browser proof covers the config snapshot and guarded-write lifecycle.
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
@@ -59,6 +59,22 @@ function configSchemaResponse() {
         tools: {
           type: "object",
           title: "Tools",
+          properties: {
+            elevated: {
+              type: "object",
+              properties: {
+                allowFrom: {
+                  type: "object",
+                  additionalProperties: {
+                    type: "array",
+                    items: {
+                      anyOf: [{ type: "string", pattern: "^[0-9]+$" }, { type: "number" }],
+                    },
+                  },
+                },
+              },
+            },
+          },
           additionalProperties: true,
         },
       },
@@ -442,6 +458,75 @@ suite.define(() => {
         );
         await gateway.resolveDeferred("config.set", { hash: "hmac-sha256:v1:opaque-next" });
         await expect.poll(() => endpoint.inputValue()).toBe("retained-draft");
+      },
+    );
+  });
+
+  it("preserves untouched 64-bit identifier strings during an unrelated form save", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        recordVideo: captureUiProofEnabled
+          ? { dir: uiProofArtifactDir, size: { height: 1000, width: 1440 } }
+          : undefined,
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
+      },
+      async ({ page }) => {
+        const identifier = "1048113311314608148";
+        const initialConfig = {
+          laboratory: { endpoint: "before-save", retryBudget: 2 },
+          tools: { elevated: { allowFrom: { discord: [identifier, 42] } } },
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": configResponse(initialConfig, "id-snapshot-1"),
+            "config.schema": configSchemaResponse(),
+          },
+        });
+
+        expect(
+          (
+            await page.goto(`${suite.server.baseUrl}settings/advanced?section=laboratory`)
+          )?.status(),
+        ).toBe(200);
+        const endpoint = page.getByRole("textbox", { name: "Endpoint", exact: true });
+        await expect.poll(() => endpoint.inputValue()).toBe("before-save");
+        await capture(page, "08-id-before-unrelated-save.png");
+
+        await gateway.deferNext("config.set");
+        await endpoint.fill("after-save");
+        const save = mutationParams(await gateway.waitForRequest("config.set"));
+        const submitted = JSON.parse(String(save.raw)) as typeof initialConfig;
+        expect(save.baseHash).toBe("id-snapshot-1");
+        expect(String(save.raw)).toContain(`"${identifier}"`);
+        expect(String(save.raw)).not.toContain(String(Number(identifier)));
+        expect(submitted).toEqual({
+          laboratory: { endpoint: "after-save", retryBudget: 2 },
+          tools: { elevated: { allowFrom: { discord: [identifier, 42] } } },
+        });
+        expect(submitted.tools.elevated.allowFrom.discord[0]).toBe(identifier);
+        expect(typeof submitted.tools.elevated.allowFrom.discord[0]).toBe("string");
+
+        if (captureUiProofEnabled) {
+          await mkdir(uiProofArtifactDir, { recursive: true });
+          await writeFile(
+            path.join(uiProofArtifactDir, "09-id-config-set-payload.json"),
+            `${JSON.stringify({ before: initialConfig, submitted }, null, 2)}\n`,
+          );
+        }
+        await gateway.resolveDeferred("config.set");
+        const saveIndicator = page.locator("openclaw-settings-save-indicator");
+        await expect.poll(() => saveIndicator.textContent()).toContain("Saved");
+
+        await page.reload();
+        await expect.poll(() => endpoint.inputValue()).toBe("after-save");
+        await page.getByRole("button", { name: "Raw", exact: true }).click();
+        const rawEditor = page.locator(".config-raw-field textarea");
+        await rawEditor.waitFor();
+        await expect.poll(() => rawEditor.inputValue()).toContain(`"${identifier}"`);
+        await capture(page, "10-id-after-unrelated-save.png");
       },
     );
   });

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -651,7 +651,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
       .locator("openclaw-app-shell")
       .waitFor({ timeout: controlUiSettleTimeoutMs });
 
-    const settingsUrl = new URL("settings/advanced", allowedUi.baseUrl);
+    const settingsUrl = new URL("settings/communications", allowedUi.baseUrl);
     settingsUrl.searchParams.set("section", "messages");
     expect((await connected.page.goto(settingsUrl.toString()))?.status()).toBe(200);
     const prefix = connected.page.getByRole("textbox", {

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -1,5 +1,5 @@
 // Control UI tests prove trusted-proxy and browser-origin auth through real transports.
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage } from "node:http";
 import net from "node:net";
 import path from "node:path";
@@ -34,6 +34,9 @@ const artifactDir = path.resolve(
 );
 const viewport = { height: 900, width: 1280 };
 const trustedProxyUser = "qa-operator";
+const configProofIdentifier = "9223372036854775807";
+const configProofPrefixBefore = "proof-before";
+const configProofPrefixAfter = "proof-after";
 const controlUiSettleTimeoutMs = 60_000;
 const originProxyHeaderBlocklist = new Set([
   "connection",
@@ -66,6 +69,7 @@ type ProxyConnectionEvidence = {
   browserOrigin: string | null;
   gatewayResult?: GatewayResultEvidence;
   identityInjected: boolean;
+  requestMethods: string[];
   requiredHeaderInjected: boolean;
   route: ProxyRoute;
   upstreamHandshakeStatus?: number;
@@ -165,6 +169,7 @@ function sanitizeProxyEvidence(evidence: ProxyConnectionEvidence) {
     browserOriginPresent: Boolean(evidence.browserOrigin),
     gatewayResult: evidence.gatewayResult,
     identityInjected: evidence.identityInjected,
+    requestMethods: evidence.requestMethods,
     requiredHeaderInjected: evidence.requiredHeaderInjected,
     route: evidence.route,
     upstreamHandshakeStatus: evidence.upstreamHandshakeStatus,
@@ -199,6 +204,10 @@ function startProxyConnection(
     const frame = parseJsonFrame(data);
     if (frame) {
       connectRequestId = captureBrowserConnect(evidence, frame) ?? connectRequestId;
+      const method = frame.type === "req" ? stringValue(frame.method) : null;
+      if (method && method !== "connect") {
+        evidence.requestMethods.push(method);
+      }
     }
     if (upstream.readyState === WebSocket.OPEN) {
       upstream.send(data, { binary: isBinary });
@@ -280,6 +289,7 @@ async function startRealTransportProxy(gatewayUrl: string): Promise<RealTranspor
       const connectionEvidence: ProxyConnectionEvidence = {
         browserOrigin: stringValue(request.headers.origin),
         identityInjected: route === "trusted",
+        requestMethods: [],
         requiredHeaderInjected: route === "trusted",
         route,
       };
@@ -404,6 +414,12 @@ async function startRealGateway(allowedOrigin: string): Promise<RealGateway> {
     userHeader: "x-forwarded-user",
   };
   await state.writeConfig({
+    messages: { responsePrefix: configProofPrefixBefore },
+    tools: {
+      elevated: {
+        allowFrom: { discord: [configProofIdentifier] },
+      },
+    },
     gateway: {
       auth: {
         mode: "trusted-proxy",
@@ -524,6 +540,19 @@ async function captureChromiumScreenshot(page: Page, fileName: string): Promise<
   }
 }
 
+async function readConfigProofSnapshot(): Promise<{ identifier: unknown; prefix: string | null }> {
+  const config = asNullableRecord(JSON.parse(await readFile(gateway.state.configPath, "utf8")));
+  const messages = asNullableRecord(config?.messages);
+  const tools = asNullableRecord(config?.tools);
+  const elevated = asNullableRecord(tools?.elevated);
+  const allowFrom = asNullableRecord(elevated?.allowFrom);
+  const discord = Array.isArray(allowFrom?.discord) ? allowFrom.discord : [];
+  return {
+    identifier: discord[0],
+    prefix: stringValue(messages?.responsePrefix),
+  };
+}
+
 async function waitForConnectionEvidence(
   predicate: (entry: ProxyConnectionEvidence) => boolean,
   evidenceStartIndex: number,
@@ -563,6 +592,7 @@ async function isPortClosed(host: string, port: number): Promise<boolean> {
 
 describeControlUiE2e("Control UI real auth transports E2E", () => {
   beforeAll(async () => {
+    console.info("[real-config-id-proof] setup-start");
     if (!chromiumAvailable) {
       throw new Error(
         `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}.`,
@@ -576,6 +606,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     gateway = await startRealGateway(new URL(allowedUi.baseUrl).origin);
     proxy = await startRealTransportProxy(gateway.url);
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    console.info("[real-config-id-proof] setup-ready");
   }, 120_000);
 
   afterAll(async () => {
@@ -612,6 +643,64 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
   afterEach(async () => {
     await Promise.all([...openContexts].map((context) => context.close().catch(() => {})));
     openContexts.clear();
+  });
+
+  it("preserves a 64-bit identifier through a real Gateway form save", async () => {
+    const connected = await createBrowserPage(allowedUi.baseUrl, proxy.trustedUrl);
+    await connected.page
+      .locator("openclaw-app-shell")
+      .waitFor({ timeout: controlUiSettleTimeoutMs });
+
+    const settingsUrl = new URL("settings/advanced", allowedUi.baseUrl);
+    settingsUrl.searchParams.set("section", "messages");
+    expect((await connected.page.goto(settingsUrl.toString()))?.status()).toBe(200);
+    const prefix = connected.page.getByRole("textbox", {
+      name: "Outbound Response Prefix",
+      exact: true,
+    });
+    await expect.poll(() => prefix.inputValue()).toBe(configProofPrefixBefore);
+    const configSetCount = () =>
+      proxy.evidence
+        .slice(connected.evidenceStartIndex)
+        .flatMap((entry) => entry.requestMethods)
+        .filter((method) => method === "config.set").length;
+    const configSetCountBefore = configSetCount();
+    await prefix.fill(configProofPrefixAfter);
+
+    await expect.poll(configSetCount, { timeout: 15_000 }).toBeGreaterThan(configSetCountBefore);
+    await expect
+      .poll(async () => (await readConfigProofSnapshot()).prefix)
+      .toBe(configProofPrefixAfter);
+    const persisted = await readConfigProofSnapshot();
+    expect(persisted.identifier).toBe(configProofIdentifier);
+    expect(typeof persisted.identifier).toBe("string");
+
+    await connected.page.reload({ waitUntil: "domcontentloaded" });
+    await connected.page
+      .locator("openclaw-app-shell")
+      .waitFor({ timeout: controlUiSettleTimeoutMs });
+    await connected.page.getByRole("button", { name: "Raw", exact: true }).click();
+    const rawEditor = connected.page.locator(".config-raw-field textarea");
+    await rawEditor.waitFor();
+    await expect.poll(() => rawEditor.inputValue()).toContain(`"${configProofIdentifier}"`);
+
+    const proof = {
+      configSetRequests: configSetCount() - configSetCountBefore,
+      identifierMatches: persisted.identifier === configProofIdentifier,
+      identifierType: typeof persisted.identifier,
+      method: "config.set",
+      persistedPrefix: persisted.prefix,
+      rawReadbackQuoted: true,
+    };
+    await writeFile(
+      path.join(artifactDir, "real-gateway-config-id-proof.json"),
+      `${JSON.stringify(proof, null, 2)}\n`,
+      "utf8",
+    );
+    console.info(`[real-config-id-proof] ${JSON.stringify(proof)}`);
+    await captureChromiumScreenshot(connected.page, "03-real-config-id-preserved.png");
+    expect(connected.errors).toEqual([]);
+    await closeConnectedContext(connected.context);
   });
 
   it("connects through the trusted path and rejects the untrusted proxy path", async () => {

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -657,6 +657,16 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
       .locator("openclaw-app-shell")
       .waitFor({ timeout: controlUiSettleTimeoutMs });
 
+    const rawSettingsUrl = new URL("settings/advanced", allowedUi.baseUrl);
+    rawSettingsUrl.searchParams.set("section", "env");
+    expect((await connected.page.goto(rawSettingsUrl.toString()))?.status()).toBe(200);
+    await connected.page.getByRole("button", { name: "Raw", exact: true }).click();
+    const rawEditorBefore = connected.page.locator(".config-raw-field textarea");
+    await rawEditorBefore.waitFor();
+    await expect.poll(() => rawEditorBefore.inputValue()).toContain(`"${configProofIdentifier}"`);
+    await expect.poll(() => rawEditorBefore.inputValue()).toContain(configProofPrefixBefore);
+    await captureChromiumScreenshot(connected.page, "01-real-config-id-before.png");
+
     const settingsUrl = new URL("settings/communications", allowedUi.baseUrl);
     settingsUrl.searchParams.set("section", "messages");
     expect((await connected.page.goto(settingsUrl.toString()))?.status()).toBe(200);
@@ -685,13 +695,12 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     await connected.page
       .locator("openclaw-app-shell")
       .waitFor({ timeout: controlUiSettleTimeoutMs });
-    const rawSettingsUrl = new URL("settings/advanced", allowedUi.baseUrl);
-    rawSettingsUrl.searchParams.set("section", "env");
     expect((await connected.page.goto(rawSettingsUrl.toString()))?.status()).toBe(200);
     await connected.page.getByRole("button", { name: "Raw", exact: true }).click();
     const rawEditor = connected.page.locator(".config-raw-field textarea");
     await rawEditor.waitFor();
     await expect.poll(() => rawEditor.inputValue()).toContain(`"${configProofIdentifier}"`);
+    await expect.poll(() => rawEditor.inputValue()).toContain(configProofPrefixAfter);
 
     const proof = {
       configSetRequests: configSetCount() - configSetCountBefore,
@@ -707,7 +716,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
       "utf8",
     );
     console.info(`[real-config-id-proof] ${JSON.stringify(proof)}`);
-    await captureChromiumScreenshot(connected.page, "03-real-config-id-preserved.png");
+    await captureChromiumScreenshot(connected.page, "02-real-config-id-after.png");
     expect(connected.errors).toEqual([]);
     await closeConnectedContext(connected.context);
   });

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -665,6 +665,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     await rawEditorBefore.waitFor();
     await expect.poll(() => rawEditorBefore.inputValue()).toContain(`"${configProofIdentifier}"`);
     await expect.poll(() => rawEditorBefore.inputValue()).toContain(configProofPrefixBefore);
+    await rawEditorBefore.scrollIntoViewIfNeeded();
     await captureChromiumScreenshot(connected.page, "01-real-config-id-before.png");
 
     const settingsUrl = new URL("settings/communications", allowedUi.baseUrl);
@@ -701,6 +702,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     await rawEditor.waitFor();
     await expect.poll(() => rawEditor.inputValue()).toContain(`"${configProofIdentifier}"`);
     await expect.poll(() => rawEditor.inputValue()).toContain(configProofPrefixAfter);
+    await rawEditor.scrollIntoViewIfNeeded();
 
     const proof = {
       configSetRequests: configSetCount() - configSetCountBefore,

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -408,7 +408,13 @@ async function startRealGateway(allowedOrigin: string): Promise<RealGateway> {
     allowUsers: [trustedProxyUser],
     deviceAutoApprove: {
       enabled: true,
-      scopes: ["operator.approvals", "operator.questions", "operator.read", "operator.write"],
+      scopes: [
+        "operator.admin",
+        "operator.approvals",
+        "operator.questions",
+        "operator.read",
+        "operator.write",
+      ],
     },
     requiredHeaders: ["x-forwarded-proto"],
     userHeader: "x-forwarded-user",

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -1,4 +1,5 @@
 // Control UI tests prove trusted-proxy and browser-origin auth through real transports.
+import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage } from "node:http";
 import net from "node:net";
@@ -85,6 +86,7 @@ type RealTransportProxy = {
 
 type RealGateway = {
   cleanup: () => Promise<void>;
+  httpUrl: string;
   port: number;
   server: GatewayServer;
   state: OpenClawTestState;
@@ -387,6 +389,7 @@ async function getFreePort(): Promise<number> {
 
 async function startRealGateway(allowedOrigin: string): Promise<RealGateway> {
   const port = await getFreePort();
+  const httpUrl = `http://127.0.0.1:${port}/`;
   const state = await createOpenClawTestState({
     label: "control-ui-auth-transports",
     layout: "home",
@@ -432,8 +435,9 @@ async function startRealGateway(allowedOrigin: string): Promise<RealGateway> {
         trustedProxy,
       },
       controlUi: {
-        allowedOrigins: [allowedOrigin],
-        enabled: false,
+        allowedOrigins: [allowedOrigin, new URL(httpUrl).origin],
+        enabled: true,
+        root: path.resolve("dist/control-ui"),
       },
       port,
       trustedProxies: ["127.0.0.1", "::1"],
@@ -448,7 +452,7 @@ async function startRealGateway(allowedOrigin: string): Promise<RealGateway> {
         trustedProxy,
       },
       bind: "loopback",
-      controlUiEnabled: false,
+      controlUiEnabled: true,
       sidecarStartup: "defer",
     });
     return {
@@ -456,6 +460,7 @@ async function startRealGateway(allowedOrigin: string): Promise<RealGateway> {
         await server.close({ reason: "control ui auth transports test cleanup" });
         await state.cleanup();
       },
+      httpUrl,
       port,
       server,
       state,
@@ -500,8 +505,8 @@ async function createBrowserPage(
     waitUntil: "domcontentloaded",
   });
   expect(response?.status()).toBe(200);
-  // Source-served UI startup shares CI shard CPU. Bound navigation and the
-  // first rendered interaction separately; transport assertions stay narrow.
+  // Browser startup shares CI shard CPU. Bound navigation and the first
+  // rendered interaction separately; transport assertions stay narrow.
   const confirmation = page.locator("openclaw-gateway-url-confirmation");
   await confirmation.waitFor({ timeout: controlUiSettleTimeoutMs });
   expect(await confirmation.textContent()).toContain(gatewayUrl);
@@ -544,6 +549,29 @@ async function captureChromiumScreenshot(page: Page, fileName: string): Promise<
   } finally {
     await session.detach();
   }
+}
+
+async function verifyGatewayServedControlUiBundle(httpUrl: string): Promise<{
+  assetPath: string;
+  assetSha256: string;
+}> {
+  const distRoot = path.resolve("dist/control-ui");
+  const builtIndex = await readFile(path.join(distRoot, "index.html"), "utf8");
+  const assetPath = builtIndex.match(/<script[^>]+src="\.\/(assets\/[^"]+\.js)"/u)?.[1];
+  if (!assetPath) {
+    throw new Error("built Control UI index has no JavaScript asset path");
+  }
+  const servedIndexResponse = await fetch(httpUrl);
+  expect(servedIndexResponse.status).toBe(200);
+  expect(await servedIndexResponse.text()).toContain(`src="/${assetPath}"`);
+  const servedAssetResponse = await fetch(new URL(assetPath, httpUrl));
+  expect(servedAssetResponse.status).toBe(200);
+  const servedAsset = Buffer.from(await servedAssetResponse.arrayBuffer());
+  const builtAsset = await readFile(path.join(distRoot, assetPath));
+  const hash = (value: Buffer) => createHash("sha256").update(value).digest("hex");
+  const assetSha256 = hash(builtAsset);
+  expect(hash(servedAsset)).toBe(assetSha256);
+  return { assetPath, assetSha256 };
 }
 
 async function readConfigProofSnapshot(): Promise<{ identifier: unknown; prefix: string | null }> {
@@ -652,12 +680,21 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
   });
 
   it("preserves a 64-bit identifier through a real Gateway form save", async () => {
-    const connected = await createBrowserPage(allowedUi.baseUrl, proxy.trustedUrl);
+    const servedBundle = await verifyGatewayServedControlUiBundle(gateway.httpUrl);
+    const connected = await createBrowserPage(gateway.httpUrl, proxy.trustedUrl);
     await connected.page
       .locator("openclaw-app-shell")
       .waitFor({ timeout: controlUiSettleTimeoutMs });
+    const servedAssetLoaded = await connected.page.evaluate(
+      (assetPath) =>
+        performance
+          .getEntriesByType("resource")
+          .some((entry) => new URL(entry.name).pathname.endsWith(`/${assetPath}`)),
+      servedBundle.assetPath,
+    );
+    expect(servedAssetLoaded).toBe(true);
 
-    const rawSettingsUrl = new URL("settings/advanced", allowedUi.baseUrl);
+    const rawSettingsUrl = new URL("settings/advanced", gateway.httpUrl);
     rawSettingsUrl.searchParams.set("section", "env");
     expect((await connected.page.goto(rawSettingsUrl.toString()))?.status()).toBe(200);
     await connected.page.getByRole("button", { name: "Raw", exact: true }).click();
@@ -668,7 +705,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     await rawEditorBefore.scrollIntoViewIfNeeded();
     await captureChromiumScreenshot(connected.page, "01-real-config-id-before.png");
 
-    const settingsUrl = new URL("settings/communications", allowedUi.baseUrl);
+    const settingsUrl = new URL("settings/communications", gateway.httpUrl);
     settingsUrl.searchParams.set("section", "messages");
     expect((await connected.page.goto(settingsUrl.toString()))?.status()).toBe(200);
     const prefix = connected.page.getByRole("textbox", {
@@ -711,6 +748,10 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
       method: "config.set",
       persistedPrefix: persisted.prefix,
       rawReadbackQuoted: true,
+      servedAssetLoaded,
+      servedAssetPath: servedBundle.assetPath,
+      servedAssetSha256: servedBundle.assetSha256,
+      uiSource: "gateway-dist-control-ui",
     };
     await writeFile(
       path.join(artifactDir, "real-gateway-config-id-proof.json"),

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -685,6 +685,9 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     await connected.page
       .locator("openclaw-app-shell")
       .waitFor({ timeout: controlUiSettleTimeoutMs });
+    const rawSettingsUrl = new URL("settings/advanced", allowedUi.baseUrl);
+    rawSettingsUrl.searchParams.set("section", "env");
+    expect((await connected.page.goto(rawSettingsUrl.toString()))?.status()).toBe(200);
     await connected.page.getByRole("button", { name: "Raw", exact: true }).click();
     const rawEditor = connected.page.locator(".config-raw-field textarea");
     await rawEditor.waitFor();

--- a/ui/src/lib/config/config-draft-model.test.ts
+++ b/ui/src/lib/config/config-draft-model.test.ts
@@ -142,6 +142,15 @@ describe("config draft model", () => {
               fractionalInteger: { type: "integer" },
               unionRadix: { anyOf: [{ type: "integer" }, { type: "string" }] },
               unionScientific: { anyOf: [{ type: "integer" }, { type: "string" }] },
+              unionDigits: {
+                oneOf: [{ type: "integer" }, { type: "string", pattern: "^[0-9]+$" }],
+              },
+              unionEnum: {
+                anyOf: [
+                  { type: "number", const: 60 },
+                  { type: "string", enum: ["60"] },
+                ],
+              },
             },
           },
           uiHints: {},
@@ -165,6 +174,8 @@ describe("config draft model", () => {
     runtimeConfig.patchForm(["fractionalInteger"], "42.5");
     runtimeConfig.patchForm(["unionRadix"], "0o17");
     runtimeConfig.patchForm(["unionScientific"], "1e5");
+    runtimeConfig.patchForm(["unionDigits"], "00123");
+    runtimeConfig.patchForm(["unionEnum"], "60");
 
     await expect(runtimeConfig.save()).resolves.toBe(true);
     const submission = submitted.find((entry) => entry.method === "config.set");
@@ -180,9 +191,10 @@ describe("config draft model", () => {
       decimal: 0.5,
       fractionalInteger: "42.5",
       unionRadix: "0o17",
-      // Unions with a string variant keep the string: the input is already
-      // schema-valid, and numeric parses can be lossy (64-bit ids).
+      // String-capable unions keep the text input; the Gateway owns constraints.
       unionScientific: "1e5",
+      unionDigits: "00123",
+      unionEnum: "60",
     });
     runtimeConfig.dispose();
   });
@@ -210,7 +222,16 @@ describe("config draft model", () => {
                 type: "object",
                 additionalProperties: {
                   type: "array",
-                  items: { anyOf: [{ type: "string" }, { type: "number" }] },
+                  items: {
+                    oneOf: [
+                      {
+                        type: "string",
+                        allOf: [{ pattern: "^[0-9]+$" }],
+                        not: { const: "never" },
+                      },
+                      { type: "number" },
+                    ],
+                  },
                 },
               },
               bigInteger: { type: "integer" },
@@ -239,7 +260,7 @@ describe("config draft model", () => {
     expect(typeof raw).toBe("string");
     expect(JSON.parse(raw as string)).toEqual({
       allowFrom: { discord: ["1048113311314608148", 42] },
-      // Beyond 2^53 a lossy integer parse must not happen even for pure
+      // Beyond 2^53 an unsafe integer parse must not happen even for pure
       // integer fields; the string is kept for the gateway to reject loudly.
       bigInteger: "10481133113146081487",
       label: "after",

--- a/ui/src/lib/config/config-draft-model.test.ts
+++ b/ui/src/lib/config/config-draft-model.test.ts
@@ -151,6 +151,11 @@ describe("config draft model", () => {
                   { type: "string", enum: ["60"] },
                 ],
               },
+              unionConstOnly: { anyOf: [{ const: "60" }, { type: "number" }] },
+              unionEnumOnly: { oneOf: [{ enum: ["60"] }, { type: "number" }] },
+              unionBooleanConstOnly: {
+                anyOf: [{ const: "true" }, { type: "boolean" }],
+              },
             },
           },
           uiHints: {},
@@ -176,6 +181,9 @@ describe("config draft model", () => {
     runtimeConfig.patchForm(["unionScientific"], "1e5");
     runtimeConfig.patchForm(["unionDigits"], "00123");
     runtimeConfig.patchForm(["unionEnum"], "60");
+    runtimeConfig.patchForm(["unionConstOnly"], "60");
+    runtimeConfig.patchForm(["unionEnumOnly"], "60");
+    runtimeConfig.patchForm(["unionBooleanConstOnly"], "true");
 
     await expect(runtimeConfig.save()).resolves.toBe(true);
     const submission = submitted.find((entry) => entry.method === "config.set");
@@ -195,6 +203,9 @@ describe("config draft model", () => {
       unionScientific: "1e5",
       unionDigits: "00123",
       unionEnum: "60",
+      unionConstOnly: "60",
+      unionEnumOnly: "60",
+      unionBooleanConstOnly: "true",
     });
     runtimeConfig.dispose();
   });

--- a/ui/src/lib/config/config-draft-model.test.ts
+++ b/ui/src/lib/config/config-draft-model.test.ts
@@ -180,7 +180,69 @@ describe("config draft model", () => {
       decimal: 0.5,
       fractionalInteger: "42.5",
       unionRadix: "0o17",
-      unionScientific: 100_000,
+      // Unions with a string variant keep the string: the input is already
+      // schema-valid, and numeric parses can be lossy (64-bit ids).
+      unionScientific: "1e5",
+    });
+    runtimeConfig.dispose();
+  });
+
+  it("preserves 64-bit id strings through the form submit roundtrip", async () => {
+    const submitted: Array<{ method: string; params: unknown }> = [];
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "config.get") {
+        return {
+          config: {
+            allowFrom: { discord: ["1048113311314608148", 42] },
+            label: "before",
+          },
+          hash: "hash-1",
+          valid: true,
+          issues: [],
+        };
+      }
+      if (method === "config.schema") {
+        return {
+          schema: {
+            type: "object",
+            properties: {
+              allowFrom: {
+                type: "object",
+                additionalProperties: {
+                  type: "array",
+                  items: { anyOf: [{ type: "string" }, { type: "number" }] },
+                },
+              },
+              bigInteger: { type: "integer" },
+              label: { type: "string" },
+            },
+          },
+          uiHints: {},
+        };
+      }
+      submitted.push({ method, params });
+      return { hash: "hash-2" };
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const { gateway } = createGatewayHarness(client);
+    const runtimeConfig = createRuntimeConfigCapability(gateway);
+
+    await Promise.all([runtimeConfig.ensureLoaded(), runtimeConfig.ensureSchemaLoaded()]);
+    // Only the unrelated label is edited; the untouched allowFrom entry must
+    // come back byte-identical instead of collapsing to Number precision.
+    runtimeConfig.patchForm(["label"], "after");
+    runtimeConfig.patchForm(["bigInteger"], "10481133113146081487");
+
+    await expect(runtimeConfig.save()).resolves.toBe(true);
+    const submission = submitted.find((entry) => entry.method === "config.set");
+    const raw = (submission?.params as { raw?: unknown } | undefined)?.raw;
+    expect(typeof raw).toBe("string");
+    expect(JSON.parse(raw as string)).toEqual({
+      allowFrom: { discord: ["1048113311314608148", 42] },
+      // Beyond 2^53 a lossy integer parse must not happen even for pure
+      // integer fields; the string is kept for the gateway to reject loudly.
+      bigInteger: "10481133113146081487",
+      label: "after",
     });
     runtimeConfig.dispose();
   });

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -208,8 +208,9 @@ function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
       return variant ? coerceFormValues(value, variant) : value;
     }
     if (typeof value === "string") {
-      // Editors commit branch-validated types, and loaded values already passed
-      // Gateway validation. Preserve strings instead of guessing again here.
+      // Editors commit branch-validated types (including boolean literals),
+      // and loaded values already passed Gateway validation. Preserve strings
+      // instead of guessing again here.
       if (variants.some((variant) => schemaType(variant) === "string")) {
         return value;
       }

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -1,4 +1,3 @@
-import { isJsonSchemaValueValid } from "@openclaw/normalization-core/json-schema";
 import {
   asNullableRecord as asConfigRecord,
   isRecord,
@@ -209,13 +208,10 @@ function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
       return variant ? coerceFormValues(value, variant) : value;
     }
     if (typeof value === "string") {
-      // A string that already satisfies a string variant must stay a string:
-      // union id fields (e.g. tools.elevated.allowFrom.*) hold 64-bit
-      // snowflakes whose numeric parse exceeds 2^53 and rewrites the value.
-      for (const variant of variants) {
-        if (schemaType(variant) === "string" && isJsonSchemaValueValid(variant, value)) {
-          return value;
-        }
+      // Mixed primitive unions render through text controls when strings are
+      // allowed. Preserve the authored type; the Gateway owns constraints.
+      if (variants.some((variant) => schemaType(variant) === "string")) {
+        return value;
       }
       for (const variant of variants) {
         const variantType = schemaType(variant);

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -208,8 +208,8 @@ function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
       return variant ? coerceFormValues(value, variant) : value;
     }
     if (typeof value === "string") {
-      // Mixed primitive unions render through text controls when strings are
-      // allowed. Preserve the authored type; the Gateway owns constraints.
+      // Editors commit branch-validated types, and loaded values already passed
+      // Gateway validation. Preserve strings instead of guessing again here.
       if (variants.some((variant) => schemaType(variant) === "string")) {
         return value;
       }

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -1,3 +1,4 @@
+import { isJsonSchemaValueValid } from "@openclaw/normalization-core/json-schema";
 import {
   asNullableRecord as asConfigRecord,
   isRecord,
@@ -208,6 +209,14 @@ function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
       return variant ? coerceFormValues(value, variant) : value;
     }
     if (typeof value === "string") {
+      // A string that already satisfies a string variant must stay a string:
+      // union id fields (e.g. tools.elevated.allowFrom.*) hold 64-bit
+      // snowflakes whose numeric parse exceeds 2^53 and rewrites the value.
+      for (const variant of variants) {
+        if (schemaType(variant) === "string" && isJsonSchemaValueValid(variant, value)) {
+          return value;
+        }
+      }
       for (const variant of variants) {
         const variantType = schemaType(variant);
         if (variantType === "number" || variantType === "integer") {

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -5,7 +5,11 @@ import {
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { ConfigSnapshot } from "../../api/types.ts";
 import { coerceConfigFormNumberString } from "../../components/config-form.numeric.ts";
-import { schemaType, type JsonSchema } from "../../components/config-form.shared.ts";
+import {
+  schemaMayAcceptString,
+  schemaType,
+  type JsonSchema,
+} from "../../components/config-form.shared.ts";
 import { t } from "../../i18n/index.ts";
 import {
   cloneConfigObject,
@@ -177,29 +181,6 @@ function coerceBooleanString(value: string): boolean | string {
     return false;
   }
   return value;
-}
-
-function schemaMayAcceptString(schema: JsonSchema): boolean {
-  const declaredTypes = Array.isArray(schema.type) ? schema.type : schema.type ? [schema.type] : [];
-  if (declaredTypes.length > 0 && !declaredTypes.includes("string")) {
-    return false;
-  }
-  if (schema.const !== undefined && typeof schema.const !== "string") {
-    return false;
-  }
-  if (schema.enum && !schema.enum.some((entry) => typeof entry === "string")) {
-    return false;
-  }
-  if (schema.allOf && !schema.allOf.every(schemaMayAcceptString)) {
-    return false;
-  }
-  if (schema.anyOf && !schema.anyOf.some(schemaMayAcceptString)) {
-    return false;
-  }
-  if (schema.oneOf && !schema.oneOf.some(schemaMayAcceptString)) {
-    return false;
-  }
-  return true;
 }
 
 function coerceFormValues(value: unknown, schema: JsonSchema): unknown {

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -179,6 +179,29 @@ function coerceBooleanString(value: string): boolean | string {
   return value;
 }
 
+function schemaMayAcceptString(schema: JsonSchema): boolean {
+  const declaredTypes = Array.isArray(schema.type) ? schema.type : schema.type ? [schema.type] : [];
+  if (declaredTypes.length > 0 && !declaredTypes.includes("string")) {
+    return false;
+  }
+  if (schema.const !== undefined && typeof schema.const !== "string") {
+    return false;
+  }
+  if (schema.enum && !schema.enum.some((entry) => typeof entry === "string")) {
+    return false;
+  }
+  if (schema.allOf && !schema.allOf.every(schemaMayAcceptString)) {
+    return false;
+  }
+  if (schema.anyOf && !schema.anyOf.some(schemaMayAcceptString)) {
+    return false;
+  }
+  if (schema.oneOf && !schema.oneOf.some(schemaMayAcceptString)) {
+    return false;
+  }
+  return true;
+}
+
 function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
   if (value === null || value === undefined) {
     return value;
@@ -211,7 +234,7 @@ function coerceFormValues(value: unknown, schema: JsonSchema): unknown {
       // Editors commit branch-validated types (including boolean literals),
       // and loaded values already passed Gateway validation. Preserve strings
       // instead of guessing again here.
-      if (variants.some((variant) => schemaType(variant) === "string")) {
+      if (variants.some(schemaMayAcceptString)) {
         return value;
       }
       for (const variant of variants) {


### PR DESCRIPTION
Closes #126401

## What Problem This Solves

The schema-driven Control UI settings form could silently change stored 64-bit identifier strings into rounded JavaScript numbers when any unrelated form field auto-saved. The observed value `"1048113311314608148"` became `1048113311314608100`, which broke the elevated-exec approver match without a visible error.

The historical write path is now reconciled with source: at 2026-08-19 13:01:13 JST the Gateway recorded a successful `config.set` whose changed paths included `tools.elevated.allowFrom.discord`; nearby `config.patch` writes changed only UI preferences or `tools.swarm` and were not the destructive write.

## Why This Change Was Made

Form submission serialized the whole draft and offered numeric-looking strings to a number branch before retaining the authored string branch. Collection drafts had a second loss path: an unquoted string-or-number array item was passed through `JSON.parse`, which rounds large integers before submit-time code can recover the original text.

This change keeps the repair at form serialization and the input producer boundaries:

- Loaded strings in mixed primitive unions remain strings; text editors preserve the current/default branch type and use the numeric branch for newly authored exactly representable numbers.
- Numeric coercion compares integer-valued input with the actual integer represented by the IEEE-754 double via `BigInt(number)` instead of trusting `Number.toString()`. Exact values (including `2^53` and zero with large exponents) remain numbers; genuinely lossy values fail validation or use an allowed string branch, while ordinary decimal spellings retain their established form semantics.
- String-or-number collection drafts honor explicit JSON branch syntax: quoted input is a string, safe unquoted JSON numbers remain numbers, and unsafe integer spellings fall back to the exact string instead of a rounded number.
- Text editors use the current or inherited-default JS type as the branch hint, so editing an existing provider option number keeps it numeric while existing numeric strings remain strings. Schema-valid explicit boolean branches still commit as booleans.
- Focused text editors retain the branch hint from the start of the edit across model-driven rerenders. An unset mixed field can therefore accept exact numeric prefixes while typing, then commit the completed unsafe identifier as an exact string instead of leaving a partial numeric prefix persisted.
- Existing numeric branches switch to a string only when the completed input is a schema-valid unsafe integer spelling; lossy decimals, exponents, and safe numbers that violate numeric constraints remain invalid. Loaded exact large numbers render from their actual integer value, so the UI never displays a spelling that its own parser rejects.
- The full TypeBox JSON Schema validator is not imported into the startup-loaded config runtime; the prior version of this PR exceeded the Control UI startup bundle gate by about 41 KiB gzip.

Non-goal: this PR does not change form dirty-state tracking.

## User Impact

Existing and newly added Discord/Telegram/channel/approval identifiers in string-or-number config fields survive Control UI saves byte-identical and retain string type. Exactly representable number and boolean fields continue to coerce from text as before.

## Evidence

- Focused serializer regression: an untouched constrained `oneOf: string | number` identifier survives an unrelated save; non-representable numeric-only text remains a string for Gateway rejection.
- Collection browser regression: quoted and unquoted 64-bit identifiers are committed as the exact string, while safe unquoted JSON numeric text such as `1e5` remains numeric.
- Scalar browser regression: current and default string/number/boolean branch types survive edits, a valid `false` literal commits as boolean, and a newly authored unsafe 64-bit identifier remains a string. A focused 19-digit edit is typed one character at a time with a rerender after every accepted patch; the final persisted value is the exact string.
- Numeric boundary table covers `Number.MAX_SAFE_INTEGER`, `2^53`, negative values, exponent notation, and `.0` notation.
- Exact-number regression rejects spellings that `Number()` would silently round to a different integer, decimal, or zero (including `1.0000000000000001`, `9007199254740991.1`, `1e-324`, and the shortest-decimal masking case `1000000000000000100` whose actual double integer is `1000000000000000128`).
- Pure number inputs use the same lossless parser, keep invalid source text visible, and refuse to commit lossy integer, decimal, or underflowed values.
- Chromium Control UI regression drives a real Settings form autosave, inspects the emitted `config.set` payload, resolves the mocked Gateway write, reloads the page, and reads the exact quoted identifier back from Raw mode.
- The real isolated Gateway proof builds `dist/control-ui`, serves that directory from the Gateway, matches the Gateway-served fingerprinted JS bytes to the built file by SHA-256, confirms Chromium loaded that asset path, then changes an unrelated response prefix through the Settings form. It observes one successful `config.set`, reads the temp config file, reconnects, and confirms quoted Raw-mode read-back.
- [Sanitized exact-head visual proof artifact](https://github.com/solavrc/openclaw/actions/runs/32376001892/artifacts/9409348698) from [manual run 32376001892](https://github.com/solavrc/openclaw/actions/runs/32376001892) at `578605eca79df982d8b581af3e16c4bf4d029f79`: before/after screenshots visibly show the same quoted synthetic ID `"9223372036854775807"` while only `proof-before` changes to `proof-after`. The redacted trace records `{"configSetRequests":1,"identifierMatches":true,"identifierType":"string","method":"config.set","persistedPrefix":"proof-after","rawReadbackQuoted":true,"servedAssetLoaded":true,"servedAssetPath":"assets/index-BLuV7lQc.js","servedAssetSha256":"0b309e2d2c8aca1dae709c6eec48c0b3a752161dc056fd7fb5a4bf3e75969f3c","uiSource":"gateway-dist-control-ui"}`. The proof job and artifact succeeded; remaining fork jobs were intentionally cancelled afterward.
- Exact-head CI is green at `578605eca79df982d8b581af3e16c4bf4d029f79`: all 149 jobs completed with no failures in [run 32375940965](https://github.com/openclaw/openclaw/actions/runs/32375940965), including the final [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/32375940965/job/96451991810).
- [Control UI unit/browser job](https://github.com/openclaw/openclaw/actions/runs/32375940965/job/96448066386): all 713 files / 10,141 tests passed, including array-integrity 15 tests, scalar-integrity 20 tests, numeric constraints 18 tests, and config-draft-model 32 tests.
- [Control UI Chromium E2E shard](https://github.com/openclaw/openclaw/actions/runs/32375940965/job/96448066831): `config-safe-write.e2e.test.ts` passed 4/4, including the unrelated-save identifier round-trip.
- [Compact runtime/UI shard](https://github.com/openclaw/openclaw/actions/runs/32375940965/job/96448070328): 222 files / 3,099 tests passed, including config-form rejection/rerender coverage with no detached-input DOM error.
- [Real-Gateway Control UI lane](https://github.com/openclaw/openclaw/actions/runs/32375940965/job/96448066177): the built-bundle proof recorded `uiSource: gateway-dist-control-ui`, a loaded asset path and matching SHA-256, one `config.set`, exact string type/value, quoted Raw-mode read-back, and clean shutdown; all 3 auth/transport tests passed.
- The same real-Gateway lane enforces the production bundle budget: startup JS is 339.7 KiB gzip against a 339.9 KiB limit; 347819 B is 796 B over the 347023 B baseline and within the 1056 B tolerance.
- Review follow-up: quoted/type-less collection strings, explicit boolean literals, existing numeric provider-option branches, lossy decimal/pure-number spellings, exact zero/`2^53` boundaries, type-less string `const`/`enum` branches, edit-session branch stability, and hidden IEEE-754 integer rounding were independently reproduced and fixed without retyping loaded identifier strings.
- Delta against the rebased base: source +404/-59, tests +769/-10, workflow +20/-0.

🤖 Generated with [Codex](https://openai.com/codex/)
