### PR TITLE
fix(agent): retry transient settled finalization

### DIFF
--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import { createTestAdmittedRunContext } from "../../admitted-run-context.test-support.js";
+import { RetryableSettledTurnFinalizationAttemptError } from "../../harness/settled-turn-finalization-result.js";
 import {
   buildEmbeddedRunnerAssistant,
   makeEmbeddedRunnerAttempt,
@@ -237,5 +238,34 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
     expect(result.finalizationOutcome).toBe("failed");
     expect(result.attempt).toBe(attempt);
     expect(result.prepared.payloadsWithToolMedia?.[0]).toMatchObject({ isError: true });
+  });
+
+  it("retries one transient capability-free provider failure and accounts for it", async () => {
+    const attempt = settledFailedAttempt();
+    const failedAttempt = makeEmbeddedRunnerAttempt({
+      terminal: { kind: "timeout", phase: "prompt", source: "idle" },
+      currentAttemptCompletedAssistant: undefined,
+      attemptUsage: { input: 10, output: 2, total: 12 },
+      assistantTurns: 1,
+    });
+    const finalAssistant = buildEmbeddedRunnerAssistant({
+      content: [{ type: "text", text: "Recovered final answer." }],
+    });
+    backendMocks.runSettledFinalization
+      .mockRejectedValueOnce(new RetryableSettledTurnFinalizationAttemptError(failedAttempt))
+      .mockResolvedValueOnce({
+        outcome: "answered",
+        result: { assistant: finalAssistant, usage: finalAssistant.usage },
+      });
+
+    const result = await prepareTerminalWithSettledTurnFinalization(finalizationInput(attempt));
+
+    expect(backendMocks.runSettledFinalization).toHaveBeenCalledTimes(2);
+    expect(result.finalizationOutcome).toBe("answered");
+    expect(result.prepared.payloadsWithToolMedia?.[0]).toMatchObject({
+      text: "Recovered final answer.",
+    });
+    expect(result.prepared.agentMeta).toMatchObject({ assistantTurns: 3 });
+    expect(result.prepared.agentMeta?.usage).toMatchObject({ input: 10, output: 2 });
   });
 });

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -113,6 +113,7 @@ function finalizationInput(attempt: ReturnType<typeof settledFailedAttempt>) {
         workspaceDir: "/tmp/openclaw-test",
         prompt: "finish the task",
         timeoutMs: 60_000,
+        model: {},
       },
       harness: {
         id: "test-harness",
@@ -155,6 +156,7 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
       backendMocks.runSettledFinalization.mock.calls[0] ?? [];
     expect(preparedAttempt).toMatchObject({
       operation: "settled-tool-finalization",
+      model: { requestTimeoutMs: 300_000 },
       disableTools: true,
       skipPreparedUserTurnMessage: true,
       suppressNextUserMessagePersistence: true,
@@ -190,6 +192,25 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
       code: "SYSTEM_RUN_DENIED",
       message: "post-processing error",
       fatalForCron: true,
+    });
+  });
+
+  it("preserves an explicit provider request timeout for finalization", async () => {
+    const attempt = settledFailedAttempt();
+    const input = finalizationInput(attempt);
+    input.finalization.preparedAttempt.model = { requestTimeoutMs: 45_000 } as never;
+    const finalAssistant = buildEmbeddedRunnerAssistant({
+      content: [{ type: "text", text: "Final answer." }],
+    });
+    backendMocks.runSettledFinalization.mockResolvedValueOnce({
+      outcome: "answered",
+      result: { assistant: finalAssistant, usage: finalAssistant.usage },
+    });
+
+    await prepareTerminalWithSettledTurnFinalization(input);
+
+    expect(backendMocks.runSettledFinalization.mock.calls[0]?.[0]).toMatchObject({
+      model: { requestTimeoutMs: 45_000 },
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import { createTestAdmittedRunContext } from "../../admitted-run-context.test-support.js";
 import { RetryableSettledTurnFinalizationAttemptError } from "../../harness/settled-turn-finalization-result.js";
@@ -9,6 +9,7 @@ import {
 import { createUsageAccumulator } from "../usage-accumulator.js";
 import type { EmbeddedRunAttemptWithReceiptEvidence } from "./attempt-result.js";
 import { createEmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
+import { resolveLlmIdleTimeoutMs } from "./llm-idle-timeout.js";
 import { prepareTerminalWithSettledTurnFinalization } from "./settled-turn-finalization.js";
 import { resolveEmbeddedRunAttemptTerminalState } from "./terminal-outcome.js";
 
@@ -135,8 +136,13 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
     backendMocks.runSettledFinalization.mockReset();
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("replaces a settled failed-tool warning with failure-honest final output", async () => {
     const attempt = settledFailedAttempt();
+    const input = finalizationInput(attempt);
     const finalAssistant = buildEmbeddedRunnerAssistant({
       content: [{ type: "text", text: "The exec tool failed: post-processing error." }],
     });
@@ -149,19 +155,21 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
       },
     });
 
-    const result = await prepareTerminalWithSettledTurnFinalization(finalizationInput(attempt));
+    const result = await prepareTerminalWithSettledTurnFinalization(input);
 
     expect(backendMocks.runSettledFinalization).toHaveBeenCalledOnce();
     const [preparedAttempt, settledAttempt] =
       backendMocks.runSettledFinalization.mock.calls[0] ?? [];
     expect(preparedAttempt).toMatchObject({
       operation: "settled-tool-finalization",
-      model: { requestTimeoutMs: 300_000 },
       disableTools: true,
       skipPreparedUserTurnMessage: true,
       suppressNextUserMessagePersistence: true,
       initialReplayState: { replayInvalid: false, hadPotentialSideEffects: false },
     });
+    expect(preparedAttempt.model).toBe(input.finalization.preparedAttempt.model);
+    expect(preparedAttempt.model).not.toHaveProperty("requestTimeoutMs");
+    expect(preparedAttempt.abortSignal).toBeInstanceOf(AbortSignal);
     expect(settledAttempt).toBe(attempt);
     expect(result.finalizationOutcome).toBe("answered");
     expect(result.prepared.payloadsWithToolMedia).toEqual([
@@ -212,6 +220,55 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
     expect(backendMocks.runSettledFinalization.mock.calls[0]?.[0]).toMatchObject({
       model: { requestTimeoutMs: 45_000 },
     });
+  });
+
+  it("bounds finalization separately while preserving the local post-event idle exemption", async () => {
+    const attempt = settledFailedAttempt();
+    const input = finalizationInput(attempt);
+    const parent = new AbortController();
+    const deadline = new AbortController();
+    input.finalization.preparedAttempt.abortSignal = parent.signal;
+    input.finalization.preparedAttempt.model = {
+      provider: "custom-local",
+      id: "local-model",
+      baseUrl: "http://127.0.0.1:11434/v1",
+    } as never;
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(deadline.signal);
+    backendMocks.runSettledFinalization.mockImplementationOnce(async (preparedAttempt) => {
+      expect(preparedAttempt.model).not.toHaveProperty("requestTimeoutMs");
+      expect(
+        resolveLlmIdleTimeoutMs({
+          modelRequestTimeoutMs: (preparedAttempt.model as { requestTimeoutMs?: number })
+            .requestTimeoutMs,
+          model: {
+            baseUrl: preparedAttempt.model.baseUrl,
+            id: preparedAttempt.modelId,
+            provider: preparedAttempt.provider,
+          },
+        }),
+      ).toBe(0);
+      return await new Promise((resolve, reject) => {
+        preparedAttempt.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            const reason = preparedAttempt.abortSignal?.reason;
+            reject(
+              reason instanceof Error ? reason : new Error("finalizer aborted", { cause: reason }),
+            );
+          },
+          { once: true },
+        );
+      });
+    });
+
+    const resultPromise = prepareTerminalWithSettledTurnFinalization(input);
+    await vi.waitFor(() => expect(backendMocks.runSettledFinalization).toHaveBeenCalledOnce());
+    deadline.abort(new DOMException("finalizer deadline", "TimeoutError"));
+    const result = await resultPromise;
+
+    expect(timeoutSpy).toHaveBeenCalledWith(300_000);
+    expect(parent.signal.aborted).toBe(false);
+    expect(result.finalizationOutcome).toBe("failed");
   });
 
   it("preserves the settled runtime context window through isolated finalization", async () => {

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -1,6 +1,9 @@
 import { markReplyPayloadForSourceSuppressionDelivery } from "../../../auto-reply/reply-payload.js";
 import { formatErrorMessage } from "../../../infra/errors.js";
-import { resolveSettledTurnFinalizationText } from "../../harness/settled-turn-finalization-result.js";
+import {
+  resolveSettledTurnFinalizationText,
+  RetryableSettledTurnFinalizationAttemptError,
+} from "../../harness/settled-turn-finalization-result.js";
 import type {
   AgentHarness,
   AgentHarnessSettledTurnFinalizationResult,
@@ -102,13 +105,32 @@ export async function prepareTerminalWithSettledTurnFinalization(input: {
       `provider=${errorContext.provider}/${errorContext.model} — running isolated finalization`,
   );
   try {
-    const finalization = await runPreparedSettledTurnFinalization({
-      attempt: input.finalization.preparedAttempt,
-      settledAttempt: initial.attempt,
-      harness: input.finalization.harness,
-      prompt,
-      noteLaneTaskProgress: input.finalization.noteLaneTaskProgress,
-    });
+    const runFinalization = async () =>
+      await runPreparedSettledTurnFinalization({
+        attempt: input.finalization.preparedAttempt,
+        settledAttempt: initial.attempt,
+        harness: input.finalization.harness,
+        prompt,
+        noteLaneTaskProgress: input.finalization.noteLaneTaskProgress,
+      });
+    let finalization;
+    try {
+      finalization = await runFinalization();
+    } catch (error) {
+      if (
+        !(error instanceof RetryableSettledTurnFinalizationAttemptError) ||
+        input.finalization.preparedAttempt.abortSignal?.aborted
+      ) {
+        throw error;
+      }
+      mergeUsageIntoAccumulator(input.terminalBase.usageAccumulator, error.attempt.attemptUsage);
+      mergeAttemptRunStatsIntoAccumulator(input.terminalBase.usageAccumulator, error.attempt);
+      log.warn(
+        `settled-turn finalization hit a transient provider failure: runId=${runParams.runId} ` +
+          `sessionId=${runParams.sessionId} provider=${errorContext.provider}/${errorContext.model} — retrying once`,
+      );
+      finalization = await runFinalization();
+    }
     attempt = finalization.attempt;
     mergeUsageIntoAccumulator(input.terminalBase.usageAccumulator, attempt.attemptUsage);
     mergeAttemptRunStatsIntoAccumulator(input.terminalBase.usageAccumulator, attempt);

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -29,8 +29,8 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 
 type TerminalPreparationInput = Parameters<typeof prepareEmbeddedRunTerminal>[0];
 // A tool-free finalizer may need to reread a large settled context before its first event.
-// Keep the parent run as the hard bound and never replace an operator-configured provider timeout.
-const DEFAULT_SETTLED_FINALIZATION_REQUEST_TIMEOUT_MS = 300_000;
+// Bound this operation without mutating provider request/idle-timeout policy.
+const DEFAULT_SETTLED_FINALIZATION_TIMEOUT_MS = 300_000;
 type TerminalPreparationBase = Omit<
   TerminalPreparationInput,
   | "attempt"
@@ -205,17 +205,14 @@ async function runPreparedSettledTurnFinalization(input: {
   noteLaneTaskProgress: () => void;
 }): Promise<{ outcome: "answered" | "empty"; attempt: EmbeddedRunAttemptWithReceiptEvidence }> {
   return await withEmbeddedRunLaneProgressHeartbeat(input.noteLaneTaskProgress, async () => {
-    const configuredRequestTimeoutMs = Reflect.get(input.attempt.model, "requestTimeoutMs");
-    const modelWithDefaultRequestTimeout = Object.assign({}, input.attempt.model, {
-      requestTimeoutMs: DEFAULT_SETTLED_FINALIZATION_REQUEST_TIMEOUT_MS,
-    });
+    const finalizationDeadline = AbortSignal.timeout(DEFAULT_SETTLED_FINALIZATION_TIMEOUT_MS);
+    const abortSignal = input.attempt.abortSignal
+      ? AbortSignal.any([input.attempt.abortSignal, finalizationDeadline])
+      : finalizationDeadline;
     const finalization = await runEmbeddedSettledTurnFinalizationWithBackend(
       {
         ...input.attempt,
-        model:
-          configuredRequestTimeoutMs === undefined
-            ? modelWithDefaultRequestTimeout
-            : input.attempt.model,
+        abortSignal,
         operation: "settled-tool-finalization",
         prompt: input.prompt,
         disableTools: true,

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -28,6 +28,9 @@ import {
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
 type TerminalPreparationInput = Parameters<typeof prepareEmbeddedRunTerminal>[0];
+// A tool-free finalizer may need to reread a large settled context before its first event.
+// Keep the parent run as the hard bound and never replace an operator-configured provider timeout.
+const DEFAULT_SETTLED_FINALIZATION_REQUEST_TIMEOUT_MS = 300_000;
 type TerminalPreparationBase = Omit<
   TerminalPreparationInput,
   | "attempt"
@@ -202,9 +205,17 @@ async function runPreparedSettledTurnFinalization(input: {
   noteLaneTaskProgress: () => void;
 }): Promise<{ outcome: "answered" | "empty"; attempt: EmbeddedRunAttemptWithReceiptEvidence }> {
   return await withEmbeddedRunLaneProgressHeartbeat(input.noteLaneTaskProgress, async () => {
+    const configuredRequestTimeoutMs = Reflect.get(input.attempt.model, "requestTimeoutMs");
+    const modelWithDefaultRequestTimeout = Object.assign({}, input.attempt.model, {
+      requestTimeoutMs: DEFAULT_SETTLED_FINALIZATION_REQUEST_TIMEOUT_MS,
+    });
     const finalization = await runEmbeddedSettledTurnFinalizationWithBackend(
       {
         ...input.attempt,
+        model:
+          configuredRequestTimeoutMs === undefined
+            ? modelWithDefaultRequestTimeout
+            : input.attempt.model,
         operation: "settled-tool-finalization",
         prompt: input.prompt,
         disableTools: true,

--- a/src/agents/harness/settled-turn-finalization-result.test.ts
+++ b/src/agents/harness/settled-turn-finalization-result.test.ts
@@ -181,6 +181,23 @@ describe("assertSettledTurnFinalizationResult", () => {
     ).toThrow("reported capability activity");
   });
 
+  it("does not retry an idle Codex app-server failure with unsafe replay state", () => {
+    expect(() =>
+      projectSettledTurnFinalizationAttemptResult(
+        successfulAttempt({
+          terminal: { kind: "timeout", phase: "prompt", source: "idle" },
+          currentAttemptCompletedAssistant: undefined,
+          codexAppServerFailure: {
+            kind: "turn_completion_idle_timeout",
+            transport: "stdio",
+            replaySafe: false,
+            replayBlockedReason: "potential_side_effect",
+          },
+        }),
+      ),
+    ).toThrow("did not complete successfully");
+  });
+
   it("rejects a full attempt that compacted before producing its answer", () => {
     expect(() =>
       projectSettledTurnFinalizationAttemptResult(successfulAttempt({ compactionCount: 1 })),

--- a/src/agents/harness/settled-turn-finalization-result.test.ts
+++ b/src/agents/harness/settled-turn-finalization-result.test.ts
@@ -147,6 +147,36 @@ describe("assertSettledTurnFinalizationResult", () => {
     ).toThrow(RetryableSettledTurnFinalizationAttemptError);
   });
 
+  it("does not retry a long-window rate limit", () => {
+    expect(() =>
+      projectSettledTurnFinalizationAttemptResult(
+        successfulAttempt({
+          terminal: {
+            kind: "failed",
+            source: "prompt",
+            error: new Error("HTTP 429: quota exceeded; Retry-After: 3600 seconds"),
+          },
+          currentAttemptCompletedAssistant: undefined,
+        }),
+      ),
+    ).toThrow("did not complete successfully");
+  });
+
+  it("retries a short-window rate limit", () => {
+    expect(() =>
+      projectSettledTurnFinalizationAttemptResult(
+        successfulAttempt({
+          terminal: {
+            kind: "failed",
+            source: "prompt",
+            error: new Error("HTTP 429: too many requests; Retry-After: 2 seconds"),
+          },
+          currentAttemptCompletedAssistant: undefined,
+        }),
+      ),
+    ).toThrow(RetryableSettledTurnFinalizationAttemptError);
+  });
+
   it("does not retry a non-transient prompt failure", () => {
     expect(() =>
       projectSettledTurnFinalizationAttemptResult(

--- a/src/agents/harness/settled-turn-finalization-result.test.ts
+++ b/src/agents/harness/settled-turn-finalization-result.test.ts
@@ -5,6 +5,7 @@ import { EmptySettledTurnFinalizationError } from "./settled-turn-finalization-o
 import {
   assertSettledTurnFinalizationResult,
   projectSettledTurnFinalizationAttemptResult,
+  RetryableSettledTurnFinalizationAttemptError,
 } from "./settled-turn-finalization-result.js";
 import type { AgentHarnessSettledTurnFinalizationResult } from "./types.js";
 
@@ -135,7 +136,29 @@ describe("assertSettledTurnFinalizationResult", () => {
     });
   });
 
-  it("rejects a failed full attempt even when it contains visible assistant text", () => {
+  it("marks a prompt failure without a completed assistant as retryable", () => {
+    expect(() =>
+      projectSettledTurnFinalizationAttemptResult(
+        successfulAttempt({
+          terminal: { kind: "failed", source: "prompt", error: new Error("Internal server error") },
+          currentAttemptCompletedAssistant: undefined,
+        }),
+      ),
+    ).toThrow(RetryableSettledTurnFinalizationAttemptError);
+  });
+
+  it("does not retry a non-transient prompt failure", () => {
+    expect(() =>
+      projectSettledTurnFinalizationAttemptResult(
+        successfulAttempt({
+          terminal: { kind: "failed", source: "prompt", error: new Error("invalid API key") },
+          currentAttemptCompletedAssistant: undefined,
+        }),
+      ),
+    ).toThrow("did not complete successfully");
+  });
+
+  it("does not retry a failed full attempt that contains a completed assistant", () => {
     expect(() =>
       projectSettledTurnFinalizationAttemptResult(
         successfulAttempt({
@@ -143,6 +166,19 @@ describe("assertSettledTurnFinalizationResult", () => {
         }),
       ),
     ).toThrow("did not complete successfully");
+  });
+
+  it("does not retry an idle timeout that reported capability activity", () => {
+    expect(() =>
+      projectSettledTurnFinalizationAttemptResult(
+        successfulAttempt({
+          terminal: { kind: "timeout", phase: "prompt", source: "idle" },
+          currentAttemptCompletedAssistant: undefined,
+          toolMetas: [{ toolName: "write" }],
+          itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        }),
+      ),
+    ).toThrow("reported capability activity");
   });
 
   it("rejects a full attempt that compacted before producing its answer", () => {

--- a/src/agents/harness/settled-turn-finalization-result.ts
+++ b/src/agents/harness/settled-turn-finalization-result.ts
@@ -124,6 +124,16 @@ export function projectSettledTurnFinalizationAttemptResult(
     throw new Error("Settled-turn finalization attempt reported capability activity");
   }
   if (
+    (result.compactionCount ?? 0) > 0 ||
+    result.promptTimeoutOutcome ||
+    result.preflightRecovery ||
+    result.beforeAgentFinalizeRevisionReason ||
+    result.codexAppServerFailure ||
+    result.cloudCodeAssistFormatError
+  ) {
+    throw new Error("Settled-turn finalization attempt did not complete successfully");
+  }
+  if (
     !result.currentAttemptCompletedAssistant &&
     ((terminal.kind === "timeout" && terminal.source === "idle") ||
       (terminal.kind === "failed" &&
@@ -132,15 +142,7 @@ export function projectSettledTurnFinalizationAttemptResult(
   ) {
     throw new RetryableSettledTurnFinalizationAttemptError(result);
   }
-  if (
-    terminal.kind !== "ok" ||
-    (result.compactionCount ?? 0) > 0 ||
-    result.promptTimeoutOutcome ||
-    result.preflightRecovery ||
-    result.beforeAgentFinalizeRevisionReason ||
-    result.codexAppServerFailure ||
-    result.cloudCodeAssistFormatError
-  ) {
+  if (terminal.kind !== "ok") {
     throw new Error("Settled-turn finalization attempt did not complete successfully");
   }
   const assistant = result.currentAttemptCompletedAssistant;

--- a/src/agents/harness/settled-turn-finalization-result.ts
+++ b/src/agents/harness/settled-turn-finalization-result.ts
@@ -2,7 +2,12 @@ import { isSilentReplyText } from "../../auto-reply/tokens.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { normalizeAgentRunAttemptTerminal } from "../agent-run-terminal-outcome.js";
 import { resolveFinalAssistantVisibleText } from "../embedded-agent-runner/run/helpers.js";
-import { hasTransientRetryEvidence } from "../failover/retry-evidence.js";
+import { classifyFailoverSignal } from "../failover/classify.js";
+import {
+  extractFailoverHttpStatus,
+  hasTransientRetryEvidence,
+  shouldRetryFailoverSignal,
+} from "../failover/retry-evidence.js";
 import { EmptySettledTurnFinalizationError } from "./settled-turn-finalization-outcome.js";
 import type {
   AgentHarnessAttemptResult,
@@ -35,6 +40,17 @@ function assistantContainsToolCall(
   return assistant.content.some(
     (block) => block !== null && typeof block === "object" && block.type === "toolCall",
   );
+}
+
+function isRetryableFinalizerPromptFailure(error: unknown): boolean {
+  const message = formatErrorMessage(error);
+  const status = extractFailoverHttpStatus(message);
+  const signal = { message, ...(status === undefined ? {} : { status }) };
+  return shouldRetryFailoverSignal({
+    classification: classifyFailoverSignal(signal),
+    hasTransientEvidence: hasTransientRetryEvidence(signal),
+    signal,
+  });
 }
 
 /**
@@ -138,7 +154,7 @@ export function projectSettledTurnFinalizationAttemptResult(
     ((terminal.kind === "timeout" && terminal.source === "idle") ||
       (terminal.kind === "failed" &&
         terminal.source === "prompt" &&
-        hasTransientRetryEvidence({ message: formatErrorMessage(terminal.error) })))
+        isRetryableFinalizerPromptFailure(terminal.error)))
   ) {
     throw new RetryableSettledTurnFinalizationAttemptError(result);
   }

--- a/src/agents/harness/settled-turn-finalization-result.ts
+++ b/src/agents/harness/settled-turn-finalization-result.ts
@@ -1,11 +1,24 @@
 import { isSilentReplyText } from "../../auto-reply/tokens.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { normalizeAgentRunAttemptTerminal } from "../agent-run-terminal-outcome.js";
 import { resolveFinalAssistantVisibleText } from "../embedded-agent-runner/run/helpers.js";
+import { hasTransientRetryEvidence } from "../failover/retry-evidence.js";
 import { EmptySettledTurnFinalizationError } from "./settled-turn-finalization-outcome.js";
 import type {
   AgentHarnessAttemptResult,
   AgentHarnessSettledTurnFinalizationResult,
 } from "./types.js";
+
+/** Carries a capability-free transient finalizer attempt into its one safe retry. */
+export class RetryableSettledTurnFinalizationAttemptError extends Error {
+  readonly attempt: AgentHarnessAttemptResult;
+
+  constructor(attempt: AgentHarnessAttemptResult) {
+    super("Settled-turn finalization hit a transient provider failure");
+    this.name = "RetryableSettledTurnFinalizationAttemptError";
+    this.attempt = attempt;
+  }
+}
 
 const ALLOWED_SETTLED_FINALIZATION_RESULT_KEYS = new Set([
   "assistant",
@@ -80,18 +93,7 @@ export function projectSettledTurnFinalizationAttemptResult(
 ): AgentHarnessSettledTurnFinalizationResult {
   const terminal =
     "terminal" in result ? result.terminal : normalizeAgentRunAttemptTerminal(result);
-  if (
-    terminal.kind !== "ok" ||
-    (result.compactionCount ?? 0) > 0 ||
-    result.promptTimeoutOutcome ||
-    result.preflightRecovery ||
-    result.beforeAgentFinalizeRevisionReason ||
-    result.codexAppServerFailure ||
-    result.cloudCodeAssistFormatError
-  ) {
-    throw new Error("Settled-turn finalization attempt did not complete successfully");
-  }
-  if (
+  const hasCapabilityActivity =
     result.toolMetas.length > 0 ||
     result.itemLifecycle.startedCount > 0 ||
     result.itemLifecycle.completedCount > 0 ||
@@ -117,9 +119,29 @@ export function projectSettledTurnFinalizationAttemptResult(
     result.hasToolMediaBlockReply ||
     result.lastToolError ||
     (result.successfulCronAdds ?? 0) > 0 ||
-    result.yieldDetected
-  ) {
+    result.yieldDetected;
+  if (hasCapabilityActivity) {
     throw new Error("Settled-turn finalization attempt reported capability activity");
+  }
+  if (
+    !result.currentAttemptCompletedAssistant &&
+    ((terminal.kind === "timeout" && terminal.source === "idle") ||
+      (terminal.kind === "failed" &&
+        terminal.source === "prompt" &&
+        hasTransientRetryEvidence({ message: formatErrorMessage(terminal.error) })))
+  ) {
+    throw new RetryableSettledTurnFinalizationAttemptError(result);
+  }
+  if (
+    terminal.kind !== "ok" ||
+    (result.compactionCount ?? 0) > 0 ||
+    result.promptTimeoutOutcome ||
+    result.preflightRecovery ||
+    result.beforeAgentFinalizeRevisionReason ||
+    result.codexAppServerFailure ||
+    result.cloudCodeAssistFormatError
+  ) {
+    throw new Error("Settled-turn finalization attempt did not complete successfully");
   }
   const assistant = result.currentAttemptCompletedAssistant;
   if (!assistant) {


### PR DESCRIPTION
Related: #126255

## What Problem This Solves

After a tool turn is fully settled, OpenClaw can need one isolated, tool-free request to produce a visible final answer. A transient stream-idle or retryable provider interruption in that request can otherwise discard a completed browser task.

## Design

- Retry settled-turn finalization at most once.
- Retry only a typed transient/rate-limit or idle failure with no completed assistant message, no capability activity, and no canonical replay/recovery blocker.
- Preserve all existing settlement, side-effect, delivery, compaction, Codex app-server, timeout, and cancellation gates.
- Keep both attempts tool-free; tool calls, empty responses, non-retryable failures, and unsafe state fail closed.
- Bound the finalization operation with its own 300-second AbortSignal composed with the live parent signal.
- Do not mutate the model's `requestTimeoutMs`; explicit provider policy and the local-provider post-event idle exemption remain unchanged.

## Evidence

- 4 files, 286 insertions / 25 deletions against current upstream `main`.
- Current head: `9a3fffeab9008cc7a9b7c2a49f0e4dacba35aa37`, rebased onto `3ae680f7143336e6918f8819163a3cbf21882e92`.
- `pnpm check:changed` passed after rebase.
- Focused finalizer/harness suites and both core typecheck lanes pass.
- Required branch autoreview found no finding and rated the patch correct at 0.97 confidence.

## Evaluation result

Combined with #126255 and #127796, [full run 32556602972](https://github.com/browser-use/new-eval-platform/actions/runs/32556602972) scored **86/106 (81.13%)**, above historical Laith OpenClaw at 82/106. Browser lifecycle was clean on all 106 tasks, with zero Harness IPC/capture timeout signatures. A final exact-current-head smoke/full rerun is being recorded separately before merge.