### PR TITLE
feat(plugins): add invocation-bound run-context for host hooks and tools

### DIFF
--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -397,6 +397,36 @@ plugins.
 | `api.session.controls.registerSessionAction(...)`                                    | Typed session actions clients can dispatch through the Gateway                                                                                             |
 | `api.registerBoardWidgetContentKind(...)`                                            | Sandboxed board widget source validation, renderer resources, and document composition                                                                     |
 
+### Callback-scoped run context
+
+`before_tool_call` hook handlers and plugin tool `execute` callbacks receive a
+host-owned `runContext` in their context (`ctx.runContext`) whenever the active
+host run supplies a run identity (`ctx.runId`). This is a short-lived scratch
+surface for exactly one callback invocation and is separate from the per-run
+`api.runContext.*` store described above.
+
+| Method                                              | Contract                                                                                           |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `runContext.set(namespace, value)`                  | Writes a JSON-compatible value for the current `(runId, pluginId)` tuple                           |
+| `runContext.get(namespace)`                         | Reads a value written for the current `(runId, pluginId)` tuple                                    |
+| `runContext.compareAndConsume(namespace, expected)` | Atomically compares and consumes a value; a later attempt on the same namespace returns `CONSUMED` |
+
+Lifecycle and identity rules:
+
+- The capability is valid only while the owning callback is running. For async
+  callbacks, the window closes when the returned promise settles; background
+  work that outlives the callback receives `FORBIDDEN`.
+- After the run ends or errors out, access returns `CLOSED_RUN`.
+- Process restarts and lost runtime state fail closed; values are never
+  reconstructed.
+- `runId` and `pluginId` are host-owned. Plugin code cannot supply or override
+  them, and cross-run or cross-plugin lookups return `NOT_FOUND`.
+- `compareAndConsume` is synchronous and atomic under the current in-process run
+  store: a mismatch does not consume, and a successful consume is exactly once.
+  If the run-context store ever becomes asynchronous or cross-process, this
+  atomicity argument no longer holds and the operation must move to a
+  CAS/mutex/transaction primitive.
+
 `registerBoardWidgetContentKind(...)` is for plugins that own a declarative
 widget source format. The registration supplies a globally unique lowercase
 `kind`, a short label, one capability-scoped plugin surface plus its renderer

--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -1207,6 +1207,35 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+  it("forwards the host run id into plugin-only tool construction", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+    const resolvePluginToolsSpy = vi
+      .spyOn(openClawPluginTools, "resolveOpenClawPluginToolsForOptions")
+      .mockReturnValue([]);
+
+    try {
+      createOpenClawCodingTools({
+        config: testConfig,
+        includeCoreTools: false,
+        runId: "run-plugin-only",
+        toolConstructionPlan: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: false,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      });
+
+      expect(createOpenClawToolsMock).not.toHaveBeenCalled();
+      expect(resolvePluginToolsSpy).toHaveBeenCalledTimes(1);
+      expect(resolvePluginToolsSpy.mock.calls[0]?.[0].options?.runId).toBe("run-plugin-only");
+    } finally {
+      resolvePluginToolsSpy.mockRestore();
+    }
+  });
+
   it("includes plugin tools declared for the active built-in profile", () => {
     const resolvePluginToolsSpy = vi
       .spyOn(openClawPluginTools, "resolveOpenClawPluginToolsForOptions")

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -704,6 +704,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       : resolveOpenClawPluginToolsForOptions({
           options: {
             agentSessionKey: options?.sessionKey,
+            runId: options?.runId,
             agentChannel: resolveGatewayMessageChannel(
               options?.messageChannel ?? options?.messageProvider,
             ),

--- a/src/agents/openclaw-tools.plugin-context.test.ts
+++ b/src/agents/openclaw-tools.plugin-context.test.ts
@@ -42,6 +42,17 @@ describe("openclaw plugin tool context", () => {
     expect(result.context.nativeChannelId).toBe("oc_native_chat");
   });
 
+  it("forwards the host-owned run id into the plugin tool context", () => {
+    const result = resolveOpenClawPluginToolInputs({
+      options: {
+        config: {} as never,
+        runId: "run-1",
+      },
+    });
+
+    expect(result.context.runId).toBe("run-1");
+  });
+
   it("defaults missing and unknown conversation-read origins to delegated", () => {
     const missing = resolveOpenClawPluginToolInputs({
       options: { config: {} as never },

--- a/src/agents/openclaw-tools.plugin-context.ts
+++ b/src/agents/openclaw-tools.plugin-context.ts
@@ -38,6 +38,8 @@ export type OpenClawPluginToolOptions = {
   conversationReadOrigin?: ConversationReadInvocationOrigin;
   requesterAgentIdOverride?: string;
   sessionId?: string;
+  /** Host-owned run identity for the active agent run. */
+  runId?: string;
   conversationRecall?: ConversationRecallContext;
   /**
    * Explicit one-shot local CLI runs should not keep plugin-owned process
@@ -100,6 +102,7 @@ export function resolveOpenClawPluginToolInputs(params: {
       agentId: sessionAgentId,
       sessionKey: options?.agentSessionKey,
       sessionId: options?.sessionId,
+      runId: options?.runId,
       toolBindings: options?.toolBindings,
       activeProjectKeys: options?.activeProjectKeys,
       conversationRecall: options?.conversationRecall,

--- a/src/plugins/contracts/run-context-invocation.contract.test.ts
+++ b/src/plugins/contracts/run-context-invocation.contract.test.ts
@@ -169,5 +169,57 @@ describe("invocation-bound plugin run-context capability", () => {
       const result = invocation.withActive(() => invocation.compareAndConsume(NS, { token: "t1" }));
       expect(result).toEqual({ status: "CLOSED_RUN" });
     });
+
+    it("keeps the window open for the lifetime of a resolving async callback", async () => {
+      const invocation = createPluginRunContextInvocation({ runId: RUN_A, pluginId: PLUGIN_X });
+
+      const observed = await invocation.withActive(async () => {
+        invocation.set(NS, { token: "t1" });
+        return invocation.get(NS);
+      });
+
+      expect(observed).toEqual({ status: "OK", value: { token: "t1" } });
+      expect(invocation.get(NS)).toEqual({ status: "FORBIDDEN" });
+    });
+
+    it("closes the window after a rejecting async callback without an extra unhandled rejection", async () => {
+      const invocation = createPluginRunContextInvocation({ runId: RUN_A, pluginId: PLUGIN_X });
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on("unhandledRejection", onUnhandled);
+      try {
+        const error = new Error("callback failed");
+        const run = invocation.withActive(() => Promise.reject(error));
+        await expect(run).rejects.toBe(error);
+        await new Promise((resolve) => {
+          setTimeout(resolve, 25);
+        });
+        expect(unhandled).toEqual([]);
+        expect(invocation.get(NS)).toEqual({ status: "FORBIDDEN" });
+      } finally {
+        process.off("unhandledRejection", onUnhandled);
+      }
+    });
+
+    it("keeps the window open until every overlapping callback settles", async () => {
+      const invocation = createPluginRunContextInvocation({ runId: RUN_A, pluginId: PLUGIN_X });
+      let releaseLongCallback!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        releaseLongCallback = resolve;
+      });
+      const longRunning = invocation.withActive(async () => {
+        invocation.set(NS, { token: "t1" });
+        await gate;
+        return invocation.get(NS);
+      });
+      const shortRunning = invocation.withActive(async () => invocation.get(NS));
+
+      await expect(shortRunning).resolves.toEqual({ status: "OK", value: { token: "t1" } });
+      releaseLongCallback();
+      await expect(longRunning).resolves.toEqual({ status: "OK", value: { token: "t1" } });
+      expect(invocation.get(NS)).toEqual({ status: "FORBIDDEN" });
+    });
   });
 });

--- a/src/plugins/contracts/run-context-invocation.contract.test.ts
+++ b/src/plugins/contracts/run-context-invocation.contract.test.ts
@@ -1,0 +1,173 @@
+// Invocation-bound plugin run-context capability contract tests.
+//
+// These tests pin the host-authoritative, exactly-once semantics of the
+// invocation-bound run-context capability: identity is host-owned (runId +
+// pluginId), compare-and-consume is atomic, and closed runs / restarts /
+// cross-run / cross-plugin lookups all fail closed.
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentEventPayload } from "../../infra/agent-events.js";
+import type { PluginJsonValue } from "../host-hook-json.js";
+import {
+  clearPluginHostRuntimeState,
+  compareAndConsumePluginRunContext,
+  dispatchPluginAgentEventSubscriptions,
+  getPluginRunContext,
+  setPluginRunContext,
+} from "../host-hook-runtime.js";
+import { createPluginRunContextInvocation } from "../run-context-invocation.js";
+
+const RUN_A = "run-a";
+const RUN_B = "run-b";
+const PLUGIN_X = "plugin-x";
+const PLUGIN_Y = "plugin-y";
+const NS = "lease";
+
+function seed(runId: string, pluginId: string, namespace: string, value: PluginJsonValue): void {
+  setPluginRunContext({ pluginId, patch: { runId, namespace, value } });
+}
+
+function closeRun(runId: string): void {
+  const event: AgentEventPayload = {
+    runId,
+    seq: 1,
+    stream: "lifecycle",
+    ts: Date.now(),
+    data: { phase: "end" },
+  };
+  dispatchPluginAgentEventSubscriptions({ registry: undefined, event });
+}
+
+describe("invocation-bound plugin run-context capability", () => {
+  afterEach(() => {
+    clearPluginHostRuntimeState();
+  });
+
+  describe("atomic compare-and-consume", () => {
+    it("consumes exactly once and returns the consumed value", () => {
+      seed(RUN_A, PLUGIN_X, NS, { token: "t1" });
+
+      const first = compareAndConsumePluginRunContext({
+        runId: RUN_A,
+        pluginId: PLUGIN_X,
+        namespace: NS,
+        expected: { token: "t1" },
+      });
+      expect(first).toEqual({ status: "OK", value: { token: "t1" } });
+
+      const second = compareAndConsumePluginRunContext({
+        runId: RUN_A,
+        pluginId: PLUGIN_X,
+        namespace: NS,
+        expected: { token: "t1" },
+      });
+      expect(second).toEqual({ status: "CONSUMED" });
+      expect(
+        getPluginRunContext({ pluginId: PLUGIN_X, get: { runId: RUN_A, namespace: NS } }),
+      ).toBe(undefined);
+    });
+
+    it("does not consume on mismatch", () => {
+      seed(RUN_A, PLUGIN_X, NS, { token: "t1" });
+
+      const mismatch = compareAndConsumePluginRunContext({
+        runId: RUN_A,
+        pluginId: PLUGIN_X,
+        namespace: NS,
+        expected: { token: "other" },
+      });
+      expect(mismatch).toEqual({ status: "MISMATCH" });
+      expect(
+        getPluginRunContext({ pluginId: PLUGIN_X, get: { runId: RUN_A, namespace: NS } }),
+      ).toEqual({ token: "t1" });
+    });
+
+    it("fails closed for cross-run and cross-plugin lookups", () => {
+      seed(RUN_A, PLUGIN_X, NS, { token: "t1" });
+
+      expect(
+        compareAndConsumePluginRunContext({
+          runId: RUN_B,
+          pluginId: PLUGIN_X,
+          namespace: NS,
+          expected: { token: "t1" },
+        }),
+      ).toEqual({ status: "NOT_FOUND" });
+      expect(
+        compareAndConsumePluginRunContext({
+          runId: RUN_A,
+          pluginId: PLUGIN_Y,
+          namespace: NS,
+          expected: { token: "t1" },
+        }),
+      ).toEqual({ status: "NOT_FOUND" });
+    });
+
+    it("fails closed for a closed run and an invalid namespace", () => {
+      seed(RUN_A, PLUGIN_X, NS, { token: "t1" });
+      closeRun(RUN_A);
+
+      expect(
+        compareAndConsumePluginRunContext({
+          runId: RUN_A,
+          pluginId: PLUGIN_X,
+          namespace: NS,
+          expected: { token: "t1" },
+        }),
+      ).toEqual({ status: "CLOSED_RUN" });
+      expect(
+        compareAndConsumePluginRunContext({
+          runId: RUN_A,
+          pluginId: PLUGIN_X,
+          namespace: " ",
+          expected: { token: "t1" },
+        }),
+      ).toEqual({ status: "INVALID" });
+    });
+
+    it("clears the tombstone when a new host-authorized set writes the namespace", () => {
+      seed(RUN_A, PLUGIN_X, NS, { token: "t1" });
+      compareAndConsumePluginRunContext({
+        runId: RUN_A,
+        pluginId: PLUGIN_X,
+        namespace: NS,
+        expected: { token: "t1" },
+      });
+      seed(RUN_A, PLUGIN_X, NS, { token: "t2" });
+
+      expect(
+        compareAndConsumePluginRunContext({
+          runId: RUN_A,
+          pluginId: PLUGIN_X,
+          namespace: NS,
+          expected: { token: "t2" },
+        }),
+      ).toEqual({ status: "OK", value: { token: "t2" } });
+    });
+  });
+
+  describe("invocation window", () => {
+    it("allows access only inside the active callback and forbids afterwards", () => {
+      const invocation = createPluginRunContextInvocation({ runId: RUN_A, pluginId: PLUGIN_X });
+      let leaked: ReturnType<typeof invocation.get> | undefined;
+      invocation.withActive(() => {
+        invocation.set(NS, { token: "t1" });
+        leaked = invocation.get(NS);
+      });
+
+      expect(leaked).toEqual({ status: "OK", value: { token: "t1" } });
+      expect(invocation.get(NS)).toEqual({ status: "FORBIDDEN" });
+      expect(invocation.set(NS, { token: "t2" })).toEqual({ status: "FORBIDDEN" });
+    });
+
+    it("fails closed after a closed run", () => {
+      const invocation = createPluginRunContextInvocation({ runId: RUN_A, pluginId: PLUGIN_X });
+      invocation.withActive(() => {
+        invocation.set(NS, { token: "t1" });
+      });
+      closeRun(RUN_A);
+
+      const result = invocation.withActive(() => invocation.compareAndConsume(NS, { token: "t1" }));
+      expect(result).toEqual({ status: "CLOSED_RUN" });
+    });
+  });
+});

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -42,6 +42,7 @@ import type {
   PluginHeartbeatPromptContributionEvent,
   PluginHeartbeatPromptContributionResult,
 } from "./host-hook-turn-types.js";
+import type { PluginRunContextInvocation } from "./host-hooks.js";
 
 export type {
   PluginHookBeforeModelResolveAttachment,
@@ -661,6 +662,11 @@ export type PluginHookToolContext = {
   sessionKey?: string;
   sessionId?: string;
   runId?: string;
+  /**
+   * Invocation-bound run-context capability valid only for the duration of the
+   * current hook callback. Identity is host-owned (current run + owning plugin).
+   */
+  runContext?: PluginRunContextInvocation;
   /** Aborts when the owning tool call is cancelled. Hook timeout expiry does not abort this signal. */
   abortSignal?: AbortSignal;
   trace?: DiagnosticTraceContext;

--- a/src/plugins/hooks.before-tool-call.test.ts
+++ b/src/plugins/hooks.before-tool-call.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createHookRunner } from "./hooks.js";
 import { addStaticTestHooks } from "./hooks.test-fixtures.js";
 import { addTestHook } from "./hooks.test-helpers.js";
+import { clearPluginHostRuntimeState, setPluginRunContext } from "./host-hook-runtime.js";
 import { createEmptyPluginRegistry, type PluginRegistry } from "./registry.js";
 import type {
   PluginHookBeforeToolCallEvent,
@@ -502,6 +503,38 @@ describe("before_tool_call hook merger — requireApproval", () => {
 
     await expect(run).rejects.toThrow("before_tool_call mutable input isolation failed");
     expect(lowerPriorityHook).not.toHaveBeenCalled();
+  });
+});
+
+describe("before_tool_call hook run-context capability", () => {
+  it("injects an invocation-bound run-context capability scoped to the owning plugin", async () => {
+    const registry = createEmptyPluginRegistry();
+    const observed: { runId?: string; consumed?: unknown } = {};
+    addTestHook({
+      registry,
+      pluginId: "hook-owner",
+      hookName: "before_tool_call",
+      handler: (_event: PluginHookBeforeToolCallEvent, ctx: PluginHookToolContext) => {
+        observed.runId = ctx.runId;
+        if (ctx.runContext) {
+          observed.consumed = ctx.runContext.compareAndConsume("lease", { token: "t1" });
+        }
+        return undefined;
+      },
+    });
+    setPluginRunContext({
+      pluginId: "hook-owner",
+      patch: { runId: "run-hook", namespace: "lease", value: { token: "t1" } },
+    });
+
+    await createHookRunner(registry).runBeforeToolCall(
+      { toolName: "bash", params: {}, runId: "run-hook" },
+      { ...stubCtx, runId: "run-hook" },
+    );
+
+    expect(observed.runId).toBe("run-hook");
+    expect(observed.consumed).toEqual({ status: "OK", value: { token: "t1" } });
+    clearPluginHostRuntimeState();
   });
 });
 

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -108,6 +108,7 @@ import type {
   PluginHookSkillProposalEvaluateResult,
   PluginHookSkillProposalEvaluationOutcome,
 } from "./hook-types.js";
+import { createPluginRunContextInvocation } from "./run-context-invocation.js";
 import {
   type PluginSubagentRequesterContext,
   withPluginSubagentRequesterContext,
@@ -223,6 +224,20 @@ type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
   shouldStop?: (result: TResult) => boolean;
   terminalLabel?: string;
   onTerminal?: (params: { hookName: K; pluginId: string; result: TResult }) => void;
+  /**
+   * Optional per-handler invocation seam. When provided, the hook runner calls
+   * `invokeHandler` with the handler registration and base context, and expects
+   * it to build a per-handler context and invoke `invoke` within it. This is
+   * how `before_tool_call` injects an invocation-bound run-context capability
+   * scoped to each owning plugin.
+   */
+  invokeHandler?: (
+    registration: PluginHookRegistration<K>,
+    baseContext: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[1],
+    invoke: (
+      handlerContext: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[1],
+    ) => Promise<TResult>,
+  ) => Promise<TResult>;
 };
 
 type PluginTargetedInboundClaimOutcome =
@@ -727,7 +742,12 @@ export function createHookRunner(
         const handlerEvent = policy.isolateEventPerHandler
           ? cloneHookIsolationValue(hookName, event)
           : event;
-        const promise = Promise.resolve(handler(handlerEvent, ctx));
+        const invokeHandler = (
+          handlerContext: Parameters<NonNullable<PluginHookRegistration<K>["handler"]>>[1],
+        ): Promise<TResult> => Promise.resolve(handler(handlerEvent, handlerContext));
+        const promise = policy.invokeHandler
+          ? policy.invokeHandler(hook, ctx, invokeHandler)
+          : invokeHandler(ctx);
         const timeoutMs = getModifyingHookTimeoutMs(hookName, hook);
         const handlerResult = timeoutMs ? await withHookTimeout(promise, timeoutMs) : await promise;
 
@@ -1291,6 +1311,18 @@ export function createHookRunner(
         },
         shouldStop: (result) => result.block === true,
         terminalLabel: "block=true",
+        invokeHandler: (registration, baseContext, invoke) => {
+          const runId = event.runId ?? ctx.runId;
+          if (!runId) {
+            return invoke(baseContext);
+          }
+          const controller = createPluginRunContextInvocation({
+            runId,
+            pluginId: registration.pluginId,
+          });
+          const handlerContext = { ...baseContext, runContext: controller };
+          return controller.withActive(() => invoke(handlerContext));
+        },
       },
       event.toolName,
     );

--- a/src/plugins/host-hook-runtime.ts
+++ b/src/plugins/host-hook-runtime.ts
@@ -1,4 +1,5 @@
 /** Stores plugin host-hook run context, scheduler jobs, and pending event cleanup state. */
+import { isDeepStrictEqual } from "node:util";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { AgentEventPayload } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -9,6 +10,7 @@ import {
   type PluginAgentEventSubscriptionRegistration,
   type PluginHostCleanupReason,
   type PluginJsonValue,
+  type PluginRunContextInvocationFailureStatus,
   type PluginRunContextGetParams,
   type PluginRunContextPatch,
   type PluginSessionSchedulerJobHandle,
@@ -18,6 +20,7 @@ import type { PluginRegistry } from "./registry-types.js";
 
 type PluginRunContextNamespaces = Map<string, PluginJsonValue>;
 type PluginRunContextByPlugin = Map<string, PluginRunContextNamespaces>;
+type PluginRunContextTombstones = Map<string, Map<string, Set<string>>>;
 type PluginAgentEventSubscriptionContext = Parameters<
   PluginAgentEventSubscriptionRegistration["handle"]
 >[1];
@@ -32,6 +35,7 @@ type SchedulerJobRecord = {
 
 type PluginHostRuntimeState = {
   runContextByRunId: Map<string, PluginRunContextByPlugin>;
+  consumedRunContextTombstones: PluginRunContextTombstones;
   schedulerJobsByPlugin: Map<string, Map<string, SchedulerJobRecord>>;
   nextSchedulerJobGeneration: number;
   pendingAgentEventHandlersByRunId: Map<string, Set<Promise<void>>>;
@@ -47,6 +51,7 @@ const log = createSubsystemLogger("plugins/host-hooks");
 function getPluginHostRuntimeState(): PluginHostRuntimeState {
   return resolveGlobalSingleton<PluginHostRuntimeState>(PLUGIN_HOST_RUNTIME_STATE_KEY, () => ({
     runContextByRunId: new Map(),
+    consumedRunContextTombstones: new Map(),
     schedulerJobsByPlugin: new Map(),
     nextSchedulerJobGeneration: 1,
     pendingAgentEventHandlersByRunId: new Map(),
@@ -80,7 +85,7 @@ function markPluginRunClosed(runId: string): void {
   rememberBoundedRunId(getPluginHostRuntimeState().closedRunIds, runId);
 }
 
-function isPluginRunClosed(runId: string): boolean {
+export function isPluginRunClosed(runId: string): boolean {
   return getPluginHostRuntimeState().closedRunIds.has(runId);
 }
 
@@ -168,6 +173,85 @@ function getPluginRunContextNamespaces(params: {
   return namespaces;
 }
 
+function getRunContextTombstones(
+  runId: string,
+  pluginId: string,
+  create = false,
+): Set<string> | undefined {
+  const state = getPluginHostRuntimeState();
+  let byPlugin = state.consumedRunContextTombstones.get(runId);
+  if (!byPlugin && create) {
+    byPlugin = new Map();
+    state.consumedRunContextTombstones.set(runId, byPlugin);
+  }
+  if (!byPlugin) {
+    return undefined;
+  }
+  let namespaces = byPlugin.get(pluginId);
+  if (!namespaces && create) {
+    namespaces = new Set();
+    byPlugin.set(pluginId, namespaces);
+  }
+  return namespaces;
+}
+
+function addRunContextTombstone(runId: string, pluginId: string, namespace: string): void {
+  getRunContextTombstones(runId, pluginId, true)?.add(namespace);
+}
+
+function clearRunContextTombstone(runId: string, pluginId: string, namespace: string): void {
+  const namespaces = getRunContextTombstones(runId, pluginId);
+  if (!namespaces) {
+    return;
+  }
+  namespaces.delete(namespace);
+  if (namespaces.size === 0) {
+    getPluginHostRuntimeState().consumedRunContextTombstones.get(runId)?.delete(pluginId);
+    if (getPluginHostRuntimeState().consumedRunContextTombstones.get(runId)?.size === 0) {
+      getPluginHostRuntimeState().consumedRunContextTombstones.delete(runId);
+    }
+  }
+}
+
+function clearRunContextTombstones(params: {
+  pluginId?: string;
+  runId?: string;
+  namespace?: string;
+}): void {
+  const state = getPluginHostRuntimeState();
+  const normalizedNamespace =
+    params.namespace !== undefined ? normalizeNamespace(params.namespace) : undefined;
+  const namespaceFilter =
+    normalizedNamespace !== undefined && normalizedNamespace !== ""
+      ? normalizedNamespace
+      : undefined;
+  const runIds = params.runId ? [params.runId] : [...state.consumedRunContextTombstones.keys()];
+  for (const runId of runIds) {
+    const byPlugin = state.consumedRunContextTombstones.get(runId);
+    if (!byPlugin) {
+      continue;
+    }
+    const pluginIds = params.pluginId ? [params.pluginId] : [...byPlugin.keys()];
+    for (const pluginId of pluginIds) {
+      const namespaces = byPlugin.get(pluginId);
+      if (!namespaces) {
+        continue;
+      }
+      if (namespaceFilter !== undefined) {
+        namespaces.delete(namespaceFilter);
+      } else {
+        namespaces.clear();
+      }
+      if (namespaces.size === 0) {
+        byPlugin.delete(pluginId);
+      }
+    }
+    if (byPlugin.size === 0) {
+      state.consumedRunContextTombstones.delete(runId);
+    }
+  }
+}
+
 /** Stores JSON-compatible plugin run context for one run/plugin/namespace tuple. */
 export function setPluginRunContext(params: {
   pluginId: string;
@@ -205,6 +289,7 @@ export function setPluginRunContext(params: {
     create: true,
   });
   namespaces?.set(namespace, copyJsonValue(params.patch.value));
+  clearRunContextTombstone(runId, params.pluginId, namespace);
   return true;
 }
 
@@ -223,6 +308,48 @@ export function getPluginRunContext(params: {
     pluginId: params.pluginId,
   })?.get(namespace);
   return value === undefined ? undefined : copyJsonValue(value);
+}
+
+/**
+ * Atomically compares and consumes a stored run-context namespace for one
+ * run/plugin tuple.
+ *
+ * The compare, delete, and tombstone write are all synchronous in-process
+ * mutations with no `await` between them, so JavaScript cannot interleave
+ * another invocation into the middle of the operation.
+ */
+export function compareAndConsumePluginRunContext(params: {
+  runId: string;
+  pluginId: string;
+  namespace: string;
+  expected: PluginJsonValue;
+}): { status: "OK"; value: PluginJsonValue } | { status: PluginRunContextInvocationFailureStatus } {
+  const runId = normalizeOptionalString(params.runId);
+  const namespace = normalizeNamespace(params.namespace);
+  if (!runId || !namespace) {
+    return { status: "INVALID" };
+  }
+  if (!isPluginJsonValue(params.expected)) {
+    return { status: "INVALID" };
+  }
+  if (isPluginRunClosed(runId)) {
+    return { status: "CLOSED_RUN" };
+  }
+  const tombstone = getRunContextTombstones(runId, params.pluginId);
+  if (tombstone?.has(namespace)) {
+    return { status: "CONSUMED" };
+  }
+  const namespaces = getPluginRunContextNamespaces({ runId, pluginId: params.pluginId });
+  const value = namespaces?.get(namespace);
+  if (!namespaces || value === undefined) {
+    return { status: "NOT_FOUND" };
+  }
+  if (!isDeepStrictEqual(value, params.expected)) {
+    return { status: "MISMATCH" };
+  }
+  namespaces.delete(namespace);
+  addRunContextTombstone(runId, params.pluginId, namespace);
+  return { status: "OK", value: copyJsonValue(value) };
 }
 
 export function clearPluginRunContext(params: {
@@ -272,6 +399,11 @@ export function clearPluginRunContext(params: {
   if (params.runId && !params.pluginId && namespaceFilter === undefined) {
     state.pendingAgentEventHandlersByRunId.delete(params.runId);
   }
+  clearRunContextTombstones({
+    pluginId: params.pluginId,
+    runId: params.runId,
+    namespace: params.namespace,
+  });
 }
 
 function isTerminalAgentRunEvent(event: AgentEventPayload): boolean {

--- a/src/plugins/host-hooks.ts
+++ b/src/plugins/host-hooks.ts
@@ -202,6 +202,40 @@ export type PluginRunContextGetParams = {
   namespace: string;
 };
 
+/** Failure statuses returned by the invocation-bound run-context capability. */
+export type PluginRunContextInvocationFailureStatus =
+  | "CLOSED_RUN"
+  | "CONSUMED"
+  | "FORBIDDEN"
+  | "INVALID"
+  | "MISMATCH"
+  | "NOT_FOUND";
+
+/**
+ * Invocation-bound run-context capability handed to plugin hook/tool callbacks
+ * for the duration of a single host invocation.
+ *
+ * Identity is host-owned: the host constructs the capability from the current
+ * run id and owning plugin id, and the public API accepts neither `runId` nor
+ * `pluginId` from plugin code. `compareAndConsume` provides exactly-once,
+ * atomically-compared consumption of a stored namespace.
+ */
+export type PluginRunContextInvocation = {
+  set(
+    namespace: string,
+    value: PluginJsonValue,
+  ): { status: "OK" } | { status: "CLOSED_RUN" | "FORBIDDEN" | "INVALID" };
+  get(
+    namespace: string,
+  ):
+    | { status: "OK"; value: PluginJsonValue }
+    | { status: "CLOSED_RUN" | "FORBIDDEN" | "INVALID" | "NOT_FOUND" };
+  compareAndConsume(
+    namespace: string,
+    expected: PluginJsonValue,
+  ): { status: "OK"; value: PluginJsonValue } | { status: PluginRunContextInvocationFailureStatus };
+};
+
 export type PluginSessionSchedulerJobRegistration = {
   id: string;
   sessionKey: string;

--- a/src/plugins/run-context-invocation.ts
+++ b/src/plugins/run-context-invocation.ts
@@ -2,7 +2,7 @@
  * Invocation-bound plugin run-context capability controller.
  *
  * The host constructs one capability per (runId, pluginId) for a single
- * invocation. The mutable active flag enforces the callback window: access is
+ * invocation. A reference-counted window enforces the callback window: access is
  * allowed only while the owning callback is running (for async callbacks, until
  * the returned promise settles), and is `FORBIDDEN` afterwards, including for
  * background work that outlives the callback.
@@ -36,10 +36,10 @@ export function createPluginRunContextInvocation(params: {
   pluginId: string;
 }): PluginRunContextInvocationController {
   const { runId, pluginId } = params;
-  const window = { active: false };
+  const window = { depth: 0 };
 
   function activeGate(): { status: "OK" } | { status: "FORBIDDEN" } | { status: "CLOSED_RUN" } {
-    if (!window.active) {
+    if (window.depth === 0) {
       return { status: "FORBIDDEN" };
     }
     if (isPluginRunClosed(runId)) {
@@ -81,21 +81,25 @@ export function createPluginRunContextInvocation(params: {
   return {
     ...invocation,
     withActive<T>(run: () => T): T {
-      window.active = true;
+      window.depth += 1;
       let result: T;
       try {
         result = run();
       } catch (error) {
-        window.active = false;
+        window.depth -= 1;
         throw error;
       }
       if (isPromiseLike(result)) {
-        void Promise.resolve(result).finally(() => {
-          window.active = false;
-        });
+        const cleanup = () => {
+          window.depth -= 1;
+        };
+        // Attach cleanup to both settlement paths without replacing the promise
+        // returned to the caller, so a rejecting callback never produces an
+        // additional unobserved rejection from the cleanup chain.
+        void Promise.resolve(result).then(cleanup, cleanup);
         return result;
       }
-      window.active = false;
+      window.depth -= 1;
       return result;
     },
   };

--- a/src/plugins/run-context-invocation.ts
+++ b/src/plugins/run-context-invocation.ts
@@ -1,0 +1,102 @@
+/**
+ * Invocation-bound plugin run-context capability controller.
+ *
+ * The host constructs one capability per (runId, pluginId) for a single
+ * invocation. The mutable active flag enforces the callback window: access is
+ * allowed only while the owning callback is running (for async callbacks, until
+ * the returned promise settles), and is `FORBIDDEN` afterwards, including for
+ * background work that outlives the callback.
+ */
+import {
+  compareAndConsumePluginRunContext,
+  getPluginRunContext,
+  isPluginRunClosed,
+  setPluginRunContext,
+} from "./host-hook-runtime.js";
+import {
+  isPluginJsonValue,
+  type PluginJsonValue,
+  type PluginRunContextInvocation,
+} from "./host-hooks.js";
+
+export type PluginRunContextInvocationController = PluginRunContextInvocation & {
+  /** Opens the capability window for the duration of `run` (sync or async). */
+  withActive<T>(run: () => T): T;
+};
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  if (value === null || (typeof value !== "object" && typeof value !== "function")) {
+    return false;
+  }
+  return "then" in value && typeof value.then === "function";
+}
+
+export function createPluginRunContextInvocation(params: {
+  runId: string;
+  pluginId: string;
+}): PluginRunContextInvocationController {
+  const { runId, pluginId } = params;
+  const window = { active: false };
+
+  function activeGate(): { status: "OK" } | { status: "FORBIDDEN" } | { status: "CLOSED_RUN" } {
+    if (!window.active) {
+      return { status: "FORBIDDEN" };
+    }
+    if (isPluginRunClosed(runId)) {
+      return { status: "CLOSED_RUN" };
+    }
+    return { status: "OK" };
+  }
+
+  const invocation: PluginRunContextInvocation = {
+    set(namespace, value: PluginJsonValue) {
+      const gate = activeGate();
+      if (gate.status !== "OK") {
+        return gate;
+      }
+      if (!isPluginJsonValue(value)) {
+        return { status: "INVALID" };
+      }
+      return setPluginRunContext({ pluginId, patch: { runId, namespace, value } })
+        ? { status: "OK" }
+        : { status: "INVALID" };
+    },
+    get(namespace: string) {
+      const gate = activeGate();
+      if (gate.status !== "OK") {
+        return gate;
+      }
+      const value = getPluginRunContext({ pluginId, get: { runId, namespace } });
+      return value === undefined ? { status: "NOT_FOUND" } : { status: "OK", value };
+    },
+    compareAndConsume(namespace: string, expected: PluginJsonValue) {
+      const gate = activeGate();
+      if (gate.status !== "OK") {
+        return gate;
+      }
+      return compareAndConsumePluginRunContext({ runId, pluginId, namespace, expected });
+    },
+  };
+
+  return {
+    ...invocation,
+    withActive<T>(run: () => T): T {
+      window.active = true;
+      let result: T;
+      try {
+        result = run();
+      } catch (error) {
+        window.active = false;
+        throw error;
+      }
+      if (isPromiseLike(result)) {
+        void Promise.resolve(result).finally(() => {
+          window.active = false;
+        });
+        return result;
+      }
+      window.active = false;
+      return result;
+    },
+  };
+}

--- a/src/plugins/tool-types.ts
+++ b/src/plugins/tool-types.ts
@@ -6,6 +6,7 @@ import type { ConversationReadInvocationOrigin } from "../channels/plugins/conve
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HookEntry } from "../hooks/types.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import type { PluginRunContextInvocation } from "./host-hooks.js";
 
 export type OpenClawPluginActiveModelContext = {
   provider?: string;
@@ -28,6 +29,14 @@ export type OpenClawPluginToolContext = {
   sessionKey?: string;
   /** Ephemeral session UUID - regenerated on /new and /reset. Use for per-conversation isolation. */
   sessionId?: string;
+  /** Host-owned run identity for the active tool run. */
+  runId?: string;
+  /**
+   * Invocation-bound run-context capability valid only for the duration of the
+   * current tool `execute` callback. Identity is host-owned (current run +
+   * owning plugin).
+   */
+  runContext?: PluginRunContextInvocation;
   /** Out-of-band plugin-owned bindings attached by the current run initiator. */
   toolBindings?: Readonly<Record<string, unknown>>;
   /** Host-prepared repository identities for project-aware tool behavior. */

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -5,9 +5,11 @@ import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY } from "../agents/tool-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
+import { clearPluginHostRuntimeState } from "./host-hook-runtime.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { appendRuntimePluginToolGrant } from "./tool-grant-allowlist.js";
+import type { OpenClawPluginToolContext } from "./tool-types.js";
 
 type MockRegistryToolEntry = {
   pluginId: string;
@@ -172,6 +174,7 @@ function createToolRegistry(entries: MockRegistryToolEntry[]) {
       status: "loaded",
     })),
     tools: entries,
+    memoryCapabilities: [],
     diagnostics: [] as Array<{
       level: string;
       pluginId: string;
@@ -3350,6 +3353,206 @@ describe("resolvePluginTools optional tools", () => {
     const tools = resolvePluginTools(createResolveToolsParams({ toolAllowlist: ["*"] }));
 
     expectResolvedToolNames(tools, ["optional_tool"]);
+  });
+});
+
+describe("invocation-bound plugin tool run context", () => {
+  beforeAll(async () => {
+    ({ resolvePluginTools } = await import("./tools.js"));
+    ({ getActivePluginRegistry, resetPluginRuntimeStateForTest, setActivePluginRegistry } =
+      await import("./runtime.js"));
+    ({ setCurrentPluginMetadataSnapshot } = await import("./current-plugin-metadata-snapshot.js"));
+    ({ clearPluginMetadataLifecycleCaches } = await import("./plugin-metadata-lifecycle.js"));
+    ({ resetPluginToolDescriptorCacheForTest } = await import("./tools.test-fixtures.js"));
+    loadContextMocks.resolve.mockImplementation((...args: unknown[]) => {
+      if (!loadContextMocks.actualResolve) {
+        throw new Error("load-context mock was not initialized");
+      }
+      return loadContextMocks.actualResolve(...(args as [never]));
+    });
+  });
+
+  beforeEach(() => {
+    resolveCompatibleRuntimePluginRegistryMock.mockReset();
+    resolveCompatibleRuntimePluginRegistryMock.mockImplementation(() =>
+      getActivePluginRegistry?.(),
+    );
+    applyPluginAutoEnableMock.mockReset();
+    applyPluginAutoEnableMock.mockImplementation(({ config }: { config: unknown }) => ({
+      config,
+      changes: [],
+    }));
+  });
+
+  afterEach(() => {
+    clearPluginHostRuntimeState();
+    resetPluginRuntimeStateForTest?.();
+    clearPluginMetadataLifecycleCaches?.();
+    resetPluginToolDescriptorCacheForTest?.();
+  });
+
+  function createRunContextToolEntry(params: {
+    pluginId: string;
+    toolName: string;
+    contexts: OpenClawPluginToolContext[];
+  }): MockRegistryToolEntry {
+    return {
+      pluginId: params.pluginId,
+      optional: false,
+      source: `/tmp/${params.pluginId}.js`,
+      names: [params.toolName],
+      factory: (rawCtx: unknown) => {
+        const ctx = rawCtx as OpenClawPluginToolContext;
+        params.contexts.push(ctx);
+        return {
+          name: params.toolName,
+          description: `${params.toolName} tool`,
+          parameters: { type: "object", properties: {} },
+          async execute() {
+            const runContext = ctx.runContext;
+            if (!runContext) {
+              return { content: [{ type: "text", text: "missing" }] };
+            }
+            runContext.set("lease", { token: "t1" });
+            const first = runContext.compareAndConsume("lease", { token: "t1" });
+            const second = runContext.compareAndConsume("lease", { token: "t1" });
+            return {
+              content: [{ type: "text", text: JSON.stringify({ first, second }) }],
+            };
+          },
+        };
+      },
+    };
+  }
+
+  function consumedLeasePayload(result: unknown): { first: unknown; second: unknown } {
+    const content = (result as { content?: readonly { text?: unknown }[] }).content;
+    const rawText = content?.[0]?.text;
+    const text = typeof rawText === "string" ? rawText : "";
+    return JSON.parse(text) as { first: unknown; second: unknown };
+  }
+
+  it("injects an invocation-bound run context into ordinary plugin tools", async () => {
+    const contexts: OpenClawPluginToolContext[] = [];
+    setRegistry([createRunContextToolEntry({ pluginId: "multi", toolName: "ctx_tool", contexts })]);
+    const context = { ...createContext(), runId: "run-ordinary" };
+
+    const [tool] = resolvePluginTools(createResolveToolsParams({ context }));
+
+    expect(contexts).toHaveLength(1);
+    expect(contexts[0]?.runContext).toBeDefined();
+    const result = await expectDefined(tool, "ordinary run context tool").execute(
+      "call",
+      {},
+      undefined,
+    );
+    expect(consumedLeasePayload(result)).toEqual({
+      first: { status: "OK", value: { token: "t1" } },
+      second: { status: "CONSUMED" },
+    });
+    expect(contexts[0]?.runContext?.get("lease")).toEqual({ status: "FORBIDDEN" });
+  });
+
+  it("injects the same capability into cached descriptor plugin tools", async () => {
+    const contexts: OpenClawPluginToolContext[] = [];
+    setRegistry([
+      createRunContextToolEntry({
+        pluginId: "cache-rc",
+        toolName: "cached_rc_tool",
+        contexts,
+      }),
+    ]);
+    const context = { ...createContext(), runId: "run-cached" };
+
+    const fresh = resolvePluginTools(createResolveToolsParams({ context }));
+    const cached = resolvePluginTools(createResolveToolsParams({ context }));
+
+    expect(cached[0]).not.toBe(fresh[0]);
+    expect(contexts).toHaveLength(1);
+    const result = await expectDefined(cached[0], "cached run context tool").execute(
+      "call",
+      {},
+      undefined,
+    );
+    expect(contexts).toHaveLength(2);
+    expect(consumedLeasePayload(result)).toEqual({
+      first: { status: "OK", value: { token: "t1" } },
+      second: { status: "CONSUMED" },
+    });
+    expect(contexts[1]?.runContext).toBeDefined();
+    expect(contexts[1]?.runContext?.get("lease")).toEqual({ status: "FORBIDDEN" });
+  });
+
+  it("leaves the plugin tool context untouched when no host run id exists", async () => {
+    const contexts: OpenClawPluginToolContext[] = [];
+    setRegistry([
+      createRunContextToolEntry({ pluginId: "multi", toolName: "no_run_tool", contexts }),
+    ]);
+
+    const [tool] = resolvePluginTools(createResolveToolsParams());
+
+    expect(contexts[0]?.runContext).toBeUndefined();
+    await expect(tool?.execute("call", {}, undefined)).resolves.toEqual({
+      content: [{ type: "text", text: "missing" }],
+    });
+  });
+
+  it("applies the same lifecycle contract to ordinary and cached tools", async () => {
+    const contexts: OpenClawPluginToolContext[] = [];
+    setRegistry([
+      createRunContextToolEntry({ pluginId: "same-rc", toolName: "same_rc_tool", contexts }),
+    ]);
+    const context = { ...createContext(), runId: "run-same" };
+
+    const fresh = resolvePluginTools(createResolveToolsParams({ context }));
+    const cached = resolvePluginTools(createResolveToolsParams({ context }));
+    const freshResult = await expectDefined(fresh[0], "fresh tool").execute("call", {}, undefined);
+    const cachedResult = await expectDefined(cached[0], "cached tool").execute(
+      "call",
+      {},
+      undefined,
+    );
+
+    expect(consumedLeasePayload(cachedResult)).toEqual(consumedLeasePayload(freshResult));
+    expect(contexts).toHaveLength(2);
+    expect(contexts[0]?.runContext?.get("lease")).toEqual({ status: "FORBIDDEN" });
+    expect(contexts[1]?.runContext?.get("lease")).toEqual({ status: "FORBIDDEN" });
+  });
+
+  it("delivers the capability through the plugin-only construction plan", async () => {
+    const contexts: OpenClawPluginToolContext[] = [];
+    setRegistry([
+      createRunContextToolEntry({ pluginId: "plan-rc", toolName: "plan_rc_tool", contexts }),
+    ]);
+    const { createOpenClawCodingTools } = await import("../agents/agent-tools.js");
+
+    const tools = createOpenClawCodingTools({
+      config: createContext().config,
+      workspaceDir: "/tmp",
+      includeCoreTools: false,
+      runId: "run-plugin-only-proof",
+      toolConstructionPlan: {
+        includeBaseCodingTools: false,
+        includeShellTools: false,
+        includeChannelTools: false,
+        includeOpenClawTools: false,
+        includePluginTools: true,
+      },
+    });
+
+    expect(tools.map((candidate) => candidate.name)).toEqual(["plan_rc_tool"]);
+    const result = await expectDefined(tools[0], "plugin-only run context tool").execute(
+      "call",
+      {},
+      undefined,
+    );
+
+    expect(consumedLeasePayload(result)).toEqual({
+      first: { status: "OK", value: { token: "t1" } },
+      second: { status: "CONSUMED" },
+    });
+    expect(contexts.at(-1)?.runContext).toBeDefined();
+    expect(contexts.at(-1)?.runContext?.get("lease")).toEqual({ status: "FORBIDDEN" });
   });
 });
 

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -33,6 +33,7 @@ import type { PluginManifestRecord } from "./manifest-registry.js";
 import { hasManifestToolAvailability } from "./manifest-tool-availability.js";
 import type { PluginMetadataManifestView } from "./plugin-metadata-snapshot.types.js";
 import type { PluginRegistry, PluginToolRegistration } from "./registry-types.js";
+import { createPluginRunContextInvocation } from "./run-context-invocation.js";
 import {
   withPluginRuntimePluginScope,
   withPluginRuntimeRegistryScope,
@@ -843,6 +844,12 @@ function createCachedDescriptorPluginTool(params: {
       ? { resultContentSource: params.descriptor.resultContentSource }
       : {}),
     async execute(toolCallId, executeParams, signal, onUpdate) {
+      const runId = params.ctx.runId;
+      const runContext =
+        runId && pluginId ? createPluginRunContextInvocation({ runId, pluginId }) : undefined;
+      const toolContext: OpenClawPluginToolContext = runContext
+        ? { ...params.ctx, runContext }
+        : params.ctx;
       const loadOptions = buildPluginRuntimeLoadOptions(params.loadContext, {
         activate: false,
         toolDiscovery: true,
@@ -890,7 +897,7 @@ function createCachedDescriptorPluginTool(params: {
         ) {
           return undefined;
         }
-        const resolved = resolvePluginToolFactory(candidate, registry, params.ctx);
+        const resolved = resolvePluginToolFactory(candidate, registry, toolContext);
         const listRaw: unknown[] = Array.isArray(resolved) ? resolved : resolved ? [resolved] : [];
         for (const toolRaw of listRaw) {
           const malformedReason = describeMalformedPluginTool(toolRaw);
@@ -912,7 +919,8 @@ function createCachedDescriptorPluginTool(params: {
           continue;
         }
         if (matchedTool) {
-          return matchedTool.execute(toolCallId, executeParams, signal, onUpdate);
+          const invoke = () => matchedTool.execute(toolCallId, executeParams, signal, onUpdate);
+          return runContext ? runContext.withActive(invoke) : invoke();
         }
       }
       throw new Error(`plugin tool runtime missing (${pluginId}): ${toolName}`);

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -33,7 +33,10 @@ import type { PluginManifestRecord } from "./manifest-registry.js";
 import { hasManifestToolAvailability } from "./manifest-tool-availability.js";
 import type { PluginMetadataManifestView } from "./plugin-metadata-snapshot.types.js";
 import type { PluginRegistry, PluginToolRegistration } from "./registry-types.js";
-import { createPluginRunContextInvocation } from "./run-context-invocation.js";
+import {
+  createPluginRunContextInvocation,
+  type PluginRunContextInvocationController,
+} from "./run-context-invocation.js";
 import {
   withPluginRuntimePluginScope,
   withPluginRuntimeRegistryScope,
@@ -246,14 +249,72 @@ function wrapPluginToolFactoryResult(
   return isAgentTool(result) ? wrapPluginToolCallbacks(entry, pluginRegistry, result) : result;
 }
 
+function wrapPluginToolInvocationWindow(
+  tool: AnyAgentTool,
+  invocation: PluginRunContextInvocationController,
+): AnyAgentTool {
+  const execute = tool.execute;
+  const windowedExecute = (
+    toolCallId: string,
+    params: unknown,
+    signal?: AbortSignal,
+    onUpdate?: unknown,
+  ) =>
+    invocation.withActive(
+      () =>
+        // SAFETY: the invoked function is the target tool's own execute, so the runtime promise matches the erased AnyAgentTool execute contract this wrapper declares.
+        Reflect.apply(execute, tool, [toolCallId, params, signal, onUpdate]) as ReturnType<
+          AnyAgentTool["execute"]
+        >,
+    );
+  const wrapped = new Proxy<AnyAgentTool>(tool, {
+    get(target, prop) {
+      if (prop === "execute") {
+        return windowedExecute;
+      }
+      return Reflect.get(target, prop, target);
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      if (prop === "execute") {
+        return {
+          configurable: true,
+          enumerable: Object.prototype.propertyIsEnumerable.call(target, prop),
+          value: windowedExecute,
+          writable: true,
+        };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+  });
+  copyPluginToolMeta(tool, wrapped);
+  return wrapped;
+}
+
+function wrapPluginToolInvocationResult(
+  result: PluginToolFactoryResult,
+  invocation: PluginRunContextInvocationController,
+): PluginToolFactoryResult {
+  if (Array.isArray(result)) {
+    return result.map((tool) =>
+      isAgentTool(tool) ? wrapPluginToolInvocationWindow(tool, invocation) : tool,
+    );
+  }
+  return isAgentTool(result) ? wrapPluginToolInvocationWindow(result, invocation) : result;
+}
+
 function resolvePluginToolFactory(
   entry: PluginToolRegistration,
   pluginRegistry: PluginRegistry | undefined,
   ctx: OpenClawPluginToolContext,
 ) {
-  return runWithPluginToolScope(entry, pluginRegistry, () =>
-    wrapPluginToolFactoryResult(entry, pluginRegistry, entry.factory(ctx)),
-  );
+  const invocation = ctx.runId
+    ? createPluginRunContextInvocation({ runId: ctx.runId, pluginId: entry.pluginId })
+    : undefined;
+  const factoryCtx = invocation ? { ...ctx, runContext: invocation } : ctx;
+  return runWithPluginToolScope(entry, pluginRegistry, () => {
+    const resolved = wrapPluginToolFactoryResult(entry, pluginRegistry, entry.factory(factoryCtx));
+    return invocation ? wrapPluginToolInvocationResult(resolved, invocation) : resolved;
+  });
 }
 
 function blocksHostRestrictedConversationReadTool(params: {
@@ -844,12 +905,6 @@ function createCachedDescriptorPluginTool(params: {
       ? { resultContentSource: params.descriptor.resultContentSource }
       : {}),
     async execute(toolCallId, executeParams, signal, onUpdate) {
-      const runId = params.ctx.runId;
-      const runContext =
-        runId && pluginId ? createPluginRunContextInvocation({ runId, pluginId }) : undefined;
-      const toolContext: OpenClawPluginToolContext = runContext
-        ? { ...params.ctx, runContext }
-        : params.ctx;
       const loadOptions = buildPluginRuntimeLoadOptions(params.loadContext, {
         activate: false,
         toolDiscovery: true,
@@ -897,7 +952,7 @@ function createCachedDescriptorPluginTool(params: {
         ) {
           return undefined;
         }
-        const resolved = resolvePluginToolFactory(candidate, registry, toolContext);
+        const resolved = resolvePluginToolFactory(candidate, registry, params.ctx);
         const listRaw: unknown[] = Array.isArray(resolved) ? resolved : resolved ? [resolved] : [];
         for (const toolRaw of listRaw) {
           const malformedReason = describeMalformedPluginTool(toolRaw);
@@ -919,8 +974,7 @@ function createCachedDescriptorPluginTool(params: {
           continue;
         }
         if (matchedTool) {
-          const invoke = () => matchedTool.execute(toolCallId, executeParams, signal, onUpdate);
-          return runContext ? runContext.withActive(invoke) : invoke();
+          return matchedTool.execute(toolCallId, executeParams, signal, onUpdate);
         }
       }
       throw new Error(`plugin tool runtime missing (${pluginId}): ${toolName}`);


### PR DESCRIPTION
## What

Exposes an invocation-bound run-context capability to plugin host hooks and tools:

- `before_tool_call` hooks receive `ctx.runContext`.
- Plugin tool `execute` callbacks receive `ctx.runContext` together with a host-owned `ctx.runId`.

The capability is valid only for the duration of the owning callback. Identity is host-owned: the host constructs it from the current run id and the owning plugin id, and plugin code can neither supply nor forge `runId` / `pluginId`.

## API

`runContext` exposes:

- `set(namespace, value)` — host-scoped write for `(runId, pluginId)`.
- `get(namespace)` — read while the callback window is active.
- `compareAndConsume(namespace, expected)` — atomically compares, deletes, and tombstones a namespace for exactly-once consumption.

## Semantics

- Outside the callback window (including background work that outlives an async callback), every operation returns `FORBIDDEN`.
- After the run closes, operations return `CLOSED_RUN`.
- Consumption is exactly-once (`CONSUMED` on repeat), survives mismatches (`MISMATCH`), and the tombstone clears only when the host writes a new value to the namespace.
- Cross-run and cross-plugin lookups fail closed (`NOT_FOUND`).

## Files

- `src/plugins/run-context-invocation.ts` (new): capability controller with a `withActive` callback window.
- `src/plugins/host-hook-runtime.ts`: atomic compare-and-consume plus tombstones; exports `isPluginRunClosed`.
- `src/plugins/host-hooks.ts`, `src/plugins/hook-types.ts`, `src/plugins/hooks.ts`: types and `before_tool_call` wiring.
- `src/plugins/tool-types.ts`, `src/plugins/tools.ts`, `src/agents/openclaw-tools.plugin-context.ts`: tool-context wiring.
- Contract and integration tests for atomic, exactly-once, and fail-closed behavior.

## Validation

- `pnpm check`: PASS
- `pnpm build`: PASS

Verified against upstream `main` at `0606e31d`.

Note: `pnpm check` on the current upstream tree requires a one-line local `maxBuffer` bump in `scripts/check-temp-path-guardrails.ts` because `git ls-files -- src extensions` output now exceeds Node's 1 MiB default buffer. That workaround is intentionally not part of this PR.

## After-review fixes

- Rejected async callback cleanup no longer discards a rejecting derived promise: the window closes on both settlement paths without an extra unhandled rejection, and the original callback promise keeps its exact resolve/reject semantics.
- The callback window is reference-counted, so overlapping executions on the same host tool keep the capability open until every callback settles.
- Run-context construction now lives at the shared plugin tool factory boundary (`resolvePluginToolFactory`), so ordinary registry-factory tools, cached descriptor tools, and plugin-only plan tools all receive the same host-owned `ctx.runContext`; the cached path's duplicate lifecycle code was removed.
- Plugin-only tool plans now forward the active host `runId` into the plugin tool context.
- The SDK lifecycle contract is documented in `docs/plugins/sdk-overview.md`.

## After-fix behavior proof

Commands run on the review-fix head:

```text
node scripts/run-vitest.mjs run src/plugins/contracts/run-context-invocation.contract.test.ts src/plugins/tools.optional.test.ts src/plugins/hooks.before-tool-call.test.ts
node scripts/run-vitest.mjs run src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/agents/openclaw-tools.plugin-context.test.ts
pnpm check
pnpm build
```

Results:

- `src/plugins/contracts/run-context-invocation.contract.test.ts`: 10 passed
- `src/plugins/tools.optional.test.ts`: 90 passed
- `src/plugins/hooks.before-tool-call.test.ts`: 21 passed
- `src/agents/agent-tools.create-openclaw-coding-tools.test.ts`: 123 passed
- `src/agents/openclaw-tools.plugin-context.test.ts`: 25 passed
- `pnpm check`: PASS
- `pnpm build`: PASS

Tests proving each reviewed path:

- ordinary path: `injects an invocation-bound run context into ordinary plugin tools`
- cached descriptor path: `injects the same capability into cached descriptor plugin tools`
- plugin-only plan: `delivers the capability through the plugin-only construction plan`
- rejected callback with no extra unhandled rejection: `closes the window after a rejecting async callback without an extra unhandled rejection`
- exactly-once consumption: `consumes exactly once and returns the consumed value`
