### PR TITLE
fix(macos): restart Codex catalog after child exit

### DIFF
--- a/apps/macos/Sources/OpenClaw/ManagedProcess.swift
+++ b/apps/macos/Sources/OpenClaw/ManagedProcess.swift
@@ -112,9 +112,17 @@ final class ManagedProcess: @unchecked Sendable {
                         identifier: pid,
                         eventMask: .exit,
                         queue: .global(qos: .userInitiated))
-                    exitSource.setEventHandler { wakeContinuation.yield(.exited) }
+                    exitSource.setEventHandler {
+                        // The leader's exit is the operational liveness boundary; group cleanup
+                        // may continue afterward, but callers must not reuse the dead process.
+                        state.finish()
+                        wakeContinuation.yield(.exited)
+                    }
                     exitSource.resume()
-                    if State.hasExited(pid) { wakeContinuation.yield(.exited) }
+                    if State.hasExited(pid) {
+                        state.finish()
+                        wakeContinuation.yield(.exited)
+                    }
                     var wakeIterator = wakeEvents.makeAsyncIterator()
                     let wakeReason = await wakeIterator.next() ?? .terminate(gracefully: true)
                     exitSource.cancel()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS Codex session catalog could send a follow-up request to an App Server process that had already exited while process-group cleanup was still finishing. The request could then fail or hang instead of transparently starting a fresh App Server.

## Why This Change Was Made

Managed process liveness now flips at the authoritative leader-exit event. Descendant cleanup and reaping still finish through the existing completion task, while callers stop treating the dead leader as reusable during that cleanup window.

## User Impact

Codex session browsing on macOS recovers reliably when the owned App Server exits between requests.

## Evidence

- Pre-fix exact-main failure: macOS Swift CI failed all three attempts in `restarts the lifecycle client after the child exits`: https://github.com/openclaw/openclaw/actions/runs/32285349201/job/96173643728
- Focused macOS catalog suite: 41/41 passed.
- Managed process sibling suite: 4/4 passed.
- Required changed-file checks passed, including Swift lint and 7 Vitest shards (481 tests).
- `git diff --check` passed.
- Production LOC: +10/-2; tests: +0/-0. Existing owner-boundary regression coverage caught the defect, so no duplicate test was added.
- Autoreview completed cleanly with no accepted actionable findings.
