### PR TITLE
fix(qa): reject incomplete evidence runs

### DIFF
--- a/extensions/qa-lab/src/character-eval.test.ts
+++ b/extensions/qa-lab/src/character-eval.test.ts
@@ -97,6 +97,7 @@ async function makeSuiteResult(params: {
   resultStatus?: "pass" | "fail";
   summaryStatus?: "pass" | "fail";
   summaryFailedCount?: number;
+  runStatus?: "running" | "completed";
 }) {
   const resultStatus = params.resultStatus ?? "pass";
   const summaryStatus = params.summaryStatus ?? resultStatus;
@@ -107,6 +108,7 @@ async function makeSuiteResult(params: {
     summaryPath,
     `${JSON.stringify(
       {
+        run: { status: params.runStatus ?? "completed" },
         counts: {
           total: 1,
           passed: summaryFailedCount > 0 ? 0 : 1,
@@ -612,6 +614,30 @@ describe("runQaCharacterEval", () => {
 
     expect(result.runs[0]?.status).toBe("fail");
     expect(result.runs[0]?.error).toBeUndefined();
+  });
+
+  it("rejects a candidate whose suite summary is still running", async () => {
+    const model = "openai/gpt-5.6-luna";
+    const result = await runQaCharacterEval({
+      repoRoot: tempRoot,
+      outputDir: path.join(tempRoot, "character"),
+      models: [model],
+      judgeModels: [model],
+      runSuite: async (params) =>
+        makeSuiteResult({
+          outputDir: params.outputDir,
+          model,
+          transcript: "USER Alice: hi\n\nASSISTANT openclaw: partial reply",
+          runStatus: "running",
+        }),
+      runJudge: makeRunJudge([{ model, rank: 1, score: 0.5, summary: "failed" }]),
+    });
+
+    expect(result.runs[0]).toMatchObject({
+      model,
+      status: "fail",
+      error: expect.stringContaining("still running"),
+    });
   });
 
   it.each([

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -321,6 +321,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 1,
           passed: 1,
@@ -334,6 +335,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       telegramSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 1,
           passed: 1,
@@ -487,6 +489,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
         scenarios: [optionalScenario],
       }),
@@ -511,6 +514,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 2, passed: 1, failed: 0, skipped: 0 },
         scenarios: [{ status: "pass" }],
       }),
@@ -534,6 +538,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
         scenarios: [{ status: "pass" }],
         evidence: { entries: [{ result: { status: "fail" } }] },
@@ -560,6 +565,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
         scenarios: [{ status: "pass" }],
         evidence: {
@@ -596,6 +602,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 2, passed: 1, failed: 0, skipped: 1 },
         scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
       }),
@@ -628,6 +635,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
         scenarios: [optionalScenario],
       }),
@@ -693,6 +701,7 @@ describe("qa cli runtime", () => {
         await fs.writeFile(
           suiteSummaryPath,
           JSON.stringify({
+            run: { status: "completed" },
             counts: { total: 0, passed: 0, failed: 0, skipped: 0 },
             scenarios: [],
           }),
@@ -702,6 +711,7 @@ describe("qa cli runtime", () => {
         await fs.writeFile(
           suiteSummaryPath,
           JSON.stringify({
+            run: { status: "completed" },
             counts:
               summary === "required-skip"
                 ? { total: 1, passed: 0, failed: 0, skipped: 1 }
@@ -986,6 +996,7 @@ describe("qa cli runtime", () => {
       await fs.writeFile(
         suiteSummaryPath,
         JSON.stringify({
+          run: { status: "completed" },
           counts: { total: 2, passed: 1, failed: 0, skipped: 1 },
           scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
         }),
@@ -1765,6 +1776,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       telegramSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 1, passed: 1, failed: 0 },
         scenarios: [{ status: "fail" }],
       }),
@@ -1793,6 +1805,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       telegramSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 1, passed: 0, failed: 1 },
         scenarios: [{ status: "fail" }],
       }),
@@ -1856,6 +1869,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 1,
           passed: 0,
@@ -1888,6 +1902,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
         scenarios: [
           {
@@ -1927,6 +1942,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 2, passed: 1, failed: 0, skipped: 1 },
         scenarios: [QA_PASSING_SUITE_SCENARIO, optionalScenario],
       }),
@@ -1954,6 +1970,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
         scenarios: [
           {
@@ -1989,6 +2006,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 1,
           passed: 0,
@@ -2022,6 +2040,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 1,
           passed: 0,
@@ -2120,6 +2139,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 1,
           passed: 0,
@@ -2184,6 +2204,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 1,
           passed: 0,
@@ -2216,6 +2237,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 1,
           passed: 0,
@@ -2440,6 +2462,7 @@ describe("qa cli runtime", () => {
       await fs.writeFile(
         path.join(repoRoot, "candidate.json"),
         JSON.stringify({
+          run: { status: "completed" },
           scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
         }),
         "utf8",
@@ -2447,6 +2470,7 @@ describe("qa cli runtime", () => {
       await fs.writeFile(
         path.join(repoRoot, "baseline.json"),
         JSON.stringify({
+          run: { status: "completed" },
           scenarios: [{ name: "Approval turn tool followthrough", status: "pass" }],
         }),
         "utf8",
@@ -2511,6 +2535,7 @@ describe("qa cli runtime", () => {
           ],
           counts: { total: 1, passed: 1, failed: 0 },
           run: {
+            status: "completed",
             providerMode: "mock-openai",
             primaryModel: "openai/gpt-5.6-luna",
             runtimePair: ["openclaw", "codex"],
@@ -2586,6 +2611,7 @@ describe("qa cli runtime", () => {
           ],
           counts: { total: 1, passed: 1, failed: 0 },
           run: {
+            status: "completed",
             providerMode: "live-frontier",
             primaryModel: "openai/gpt-5.6-luna",
             runtimePair: ["openclaw", "codex"],
@@ -2680,6 +2706,27 @@ describe("qa cli runtime", () => {
     expectWriteContains(stdoutWrite, "codex-native-workspace");
   });
 
+  it("rejects null tool coverage summary JSON", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-tool-coverage-null-"));
+    await fs.writeFile(path.join(repoRoot, "runtime-summary.json"), "null\n", "utf8");
+    const priorExitCode = process.exitCode;
+    process.exitCode = undefined;
+    try {
+      await expect(
+        runQaCoverageReportCommand({
+          repoRoot,
+          tools: true,
+          summary: "runtime-summary.json",
+          json: true,
+        }),
+      ).rejects.toMatchObject({ code: "summary_not_completed" });
+      expect(process.exitCode).toBeUndefined();
+    } finally {
+      process.exitCode = priorExitCode;
+      await fs.rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
   it("writes a curated mock JSONL replay report and summary", async () => {
     const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-jsonl-replay-cli-"));
     try {
@@ -2767,7 +2814,7 @@ describe("qa cli runtime", () => {
               },
             },
           ],
-          run: { runtimePair: ["openclaw", "codex"] },
+          run: { status: "completed", runtimePair: ["openclaw", "codex"] },
         }),
         "utf8",
       );
@@ -3069,6 +3116,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       summaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 2,
           passed: 1,
@@ -3108,6 +3156,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       summaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 2,
           passed: 1,
@@ -3138,6 +3187,38 @@ describe("qa cli runtime", () => {
       expect(process.exitCode).toBe(1);
     } finally {
       process.exitCode = priorExitCode;
+      await fs.rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a running multipass summary", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
+    const summaryPath = path.join(repoRoot, "qa-suite-summary.json");
+    await fs.writeFile(
+      summaryPath,
+      JSON.stringify({
+        run: { status: "running" },
+        counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
+        scenarios: [{ status: "pass" }],
+      }),
+      "utf8",
+    );
+    runQaMultipass.mockResolvedValueOnce({
+      outputDir: repoRoot,
+      reportPath: path.join(repoRoot, "qa-suite-report.md"),
+      summaryPath,
+      hostLogPath: path.join(repoRoot, "multipass-host.log"),
+      bootstrapLogPath: path.join(repoRoot, "multipass-guest-bootstrap.log"),
+      guestScriptPath: path.join(repoRoot, "multipass-guest-run.sh"),
+      vmName: "openclaw-qa-test",
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    try {
+      await expect(
+        runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo", runner: "multipass" }),
+      ).rejects.toMatchObject({ code: "summary_not_completed" });
+    } finally {
       await fs.rm(repoRoot, { recursive: true, force: true });
     }
   });
@@ -3198,7 +3279,11 @@ describe("qa cli runtime", () => {
   it("rejects partial multipass summary JSON without failure fields", async () => {
     const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-multipass-summary-"));
     const summaryPath = path.join(repoRoot, "qa-suite-summary.json");
-    await fs.writeFile(summaryPath, JSON.stringify({ counts: { total: 2, passed: 2 } }), "utf8");
+    await fs.writeFile(
+      summaryPath,
+      JSON.stringify({ run: { status: "completed" }, counts: { total: 2, passed: 2 } }),
+      "utf8",
+    );
     runQaMultipass.mockResolvedValueOnce({
       outputDir: repoRoot,
       reportPath: path.join(repoRoot, "qa-suite-report.md"),
@@ -3230,6 +3315,7 @@ describe("qa cli runtime", () => {
     await fs.writeFile(
       summaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: 2,
           passed: 1,

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -105,6 +105,7 @@ import {
 } from "./suite-launch.runtime.js";
 import { resolveQaSuiteScenarioChannel, resolveQaSuiteScenarioChannels } from "./suite-planning.js";
 import {
+  readCompletedQaSuiteSummaryFile,
   readQaSuiteFailedOrSkippedScenarioCountFromFile,
   resolveQaReportOnlyOptionalScenarioNames as resolveQaReportOnlyOptionalScenarioNamesFromCatalog,
 } from "./suite-summary.js";
@@ -1145,9 +1146,9 @@ export async function runQaParityReportCommand(opts: {
       throw new Error("--runtime-axis requires --summary.");
     }
     const summaryPath = path.resolve(repoRoot, opts.summary);
-    const summary = JSON.parse(
-      await fs.readFile(summaryPath, "utf8"),
-    ) as QaRuntimeParitySuiteSummary;
+    const summary = (await readCompletedQaSuiteSummaryFile(
+      summaryPath,
+    )) as QaRuntimeParitySuiteSummary;
     const reportPayload: QaRuntimeParityReport = buildQaRuntimeParityReport({ summary });
     const report = renderQaRuntimeParityMarkdownReport(reportPayload);
     const reportPath = path.join(outputDir, "qa-runtime-parity-report.md");
@@ -1190,12 +1191,12 @@ export async function runQaParityReportCommand(opts: {
   }
   const candidateSummaryPath = path.resolve(repoRoot, opts.candidateSummary);
   const baselineSummaryPath = path.resolve(repoRoot, opts.baselineSummary);
-  const candidateSummary = JSON.parse(
-    await fs.readFile(candidateSummaryPath, "utf8"),
-  ) as QaParitySuiteSummary;
-  const baselineSummary = JSON.parse(
-    await fs.readFile(baselineSummaryPath, "utf8"),
-  ) as QaParitySuiteSummary;
+  const candidateSummary = (await readCompletedQaSuiteSummaryFile(
+    candidateSummaryPath,
+  )) as QaParitySuiteSummary;
+  const baselineSummary = (await readCompletedQaSuiteSummaryFile(
+    baselineSummaryPath,
+  )) as QaParitySuiteSummary;
 
   const comparison = buildQaAgenticParityComparison({
     candidateLabel: opts.candidateLabel?.trim() || QA_FRONTIER_PARITY_CANDIDATE_LABEL,
@@ -1289,9 +1290,9 @@ export async function runQaCoverageReportCommand(opts: {
       throw new Error("--match cannot be combined with --tools.");
     }
     const summary = opts.summary?.trim()
-      ? (JSON.parse(
-          await fs.readFile(path.resolve(repoRoot, opts.summary), "utf8"),
-        ) as QaToolCoverageSuiteSummary)
+      ? ((await readCompletedQaSuiteSummaryFile(
+          path.resolve(repoRoot, opts.summary),
+        )) as QaToolCoverageSuiteSummary)
       : undefined;
     const report = buildQaToolCoverageReport({ scenarios, summary });
     body = opts.json

--- a/extensions/qa-lab/src/confidence-report.test.ts
+++ b/extensions/qa-lab/src/confidence-report.test.ts
@@ -25,7 +25,15 @@ describe("qa confidence report", () => {
   async function writeJson(relativePath: string, payload: unknown) {
     const filePath = path.join(tempRoot, relativePath);
     await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    const value =
+      relativePath.endsWith("qa-suite-summary.json") &&
+      payload &&
+      typeof payload === "object" &&
+      !Array.isArray(payload) &&
+      !("run" in payload)
+        ? { run: { status: "completed" }, ...payload }
+        : payload;
+    await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
     return filePath;
   }
 
@@ -108,12 +116,13 @@ describe("qa confidence report", () => {
       ],
     };
     for (const [runStatus, expectedPass, expectedLaneStatus, expectedDetails] of [
+      ["missing", false, "unknown", "missing run.status"],
       ["running", false, "unknown", "still running"],
       ["completed", true, "pass", "counts.failed=0"],
       ["paused", false, "unknown", "unsupported run.status=paused"],
     ] as const) {
       await writeJson("suite/qa-suite-summary.json", {
-        run: { status: runStatus },
+        run: runStatus === "missing" ? {} : { status: runStatus },
         counts: { total: 1, passed: 1, skipped: 0, failed: 0 },
         scenarios: [{ name: "completed prefix", status: "pass" }],
       });

--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -26,7 +26,10 @@ import {
   type RuntimeParityResult,
   type RuntimeParityToolCall,
 } from "./runtime-parity.js";
-import { findQaSuiteSummaryAccountingError } from "./suite-summary.js";
+import {
+  findQaSuiteSummaryAccountingError,
+  findQaSuiteSummaryCompletionError,
+} from "./suite-summary.js";
 import { buildTokenEfficiencyReport } from "./token-efficiency-report.js";
 
 const QA_CONFIDENCE_VERDICTS = [
@@ -365,15 +368,12 @@ function evaluateQaSuiteSummary(payload: unknown): QaConfidenceLaneEvaluation {
       details: "qa-suite-summary payload was not an object",
     };
   }
-  const runStatus = isRecord(payload.run) ? payload.run.status : undefined;
-  if (runStatus !== undefined && runStatus !== "completed") {
+  const completionError = findQaSuiteSummaryCompletionError(payload);
+  if (completionError) {
     return {
       passed: false,
       status: "unknown",
-      details:
-        runStatus === "running"
-          ? "qa-suite-summary is still running"
-          : `qa-suite-summary has unsupported run.status=${readString(runStatus) ?? typeof runStatus}`,
+      details: `qa-suite-summary ${completionError}`,
     };
   }
   const accountingError = findQaSuiteSummaryAccountingError(payload);

--- a/extensions/qa-lab/src/errors.ts
+++ b/extensions/qa-lab/src/errors.ts
@@ -11,6 +11,7 @@ type QaSuiteArtifactErrorCode =
   | "summary_missing"
   | "summary_read_failed"
   | "summary_parse_failed"
+  | "summary_not_completed"
   | "summary_counts_invalid"
   | "summary_failure_count_missing"
   | "summary_blocking_count_missing";

--- a/extensions/qa-lab/src/lab-server.test.ts
+++ b/extensions/qa-lab/src/lab-server.test.ts
@@ -379,6 +379,7 @@ async function createQaLabSuiteResultFixture(params?: {
     writeFile(
       summaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: {
           total: scenarios.length,
           passed: scenarios.filter((scenario) => scenario.status === "pass").length,
@@ -571,6 +572,7 @@ describe("qa-lab server", () => {
     {
       label: "empty",
       summary: JSON.stringify({
+        run: { status: "completed" },
         counts: { total: 0, passed: 0, failed: 0, skipped: 0 },
         scenarios: [],
       }),

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
@@ -70,6 +70,7 @@ describe("Telegram live QA scenario gate", () => {
     writeFileSync(
       summaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts,
         scenarios: [{ name: "channel-canary", status }],
       }),
@@ -158,6 +159,7 @@ describe("Telegram live QA scenario gate", () => {
         writeFileSync(
           summaryPath,
           JSON.stringify({
+            run: { status: "completed" },
             counts: { total: 0, passed: 0, failed: 0, skipped: 0 },
             scenarios: [],
           }),

--- a/extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts
@@ -1,8 +1,81 @@
 import { describe, expect, it, vi } from "vitest";
 import { createQaBusState } from "./bus-state.js";
+import type { QaScenarioFlow } from "./scenario-catalog.js";
 import { runScenarioFlow } from "./scenario-flow-runner.js";
 
+type QaFlowAction = QaScenarioFlow["steps"][number]["actions"][number];
+
+const delayedSideEffectCases: Array<[name: string, action: QaFlowAction]> = [
+  ["generic call", { call: "sideEffect", args: [{ expr: "await resolveInput()" }] }],
+  ["sendInbound", { sendInbound: { expr: "await resolveInput()" } }],
+  ["sendNativeCommand", { sendNativeCommand: { expr: "await resolveInput()" } }],
+  ["waitForOutbound", { waitForOutbound: { expr: "await resolveInput()" } }],
+  ["waitForOutboundSequence", { waitForOutboundSequence: { expr: "await resolveInput()" } }],
+  ["waitForNoOutbound", { waitForNoOutbound: { expr: "await resolveInput()" } }],
+];
+
 describe("scenario flow deadline", () => {
+  it.each(delayedSideEffectCases)(
+    "does not invoke %s after aborting during async input resolution",
+    async (_name, action) => {
+      const controller = new AbortController();
+      const timeoutError = new Error("scenario deadline expired");
+      const sideEffect = vi.fn();
+      let markInputStarted!: () => void;
+      let releaseInput!: (value: unknown) => void;
+      const inputStarted = new Promise<void>((resolve) => {
+        markInputStarted = resolve;
+      });
+      const input = new Promise<unknown>((resolve) => {
+        releaseInput = resolve;
+      });
+
+      const pending = runScenarioFlow({
+        api: {
+          signal: controller.signal,
+          state: createQaBusState(),
+          scenario: {
+            id: "flow-post-resolution-abort-fence",
+            title: "flow-post-resolution-abort-fence",
+            sourcePath: "qa/scenarios/flow-post-resolution-abort-fence.yaml",
+            surface: "test",
+            objective: "test",
+            successCriteria: ["test"],
+            execution: { kind: "flow" },
+          },
+          config: {},
+          resolveInput: async () => {
+            markInputStarted();
+            return await input;
+          },
+          sideEffect,
+          transport: {
+            sendInbound: sideEffect,
+            sendNativeCommand: sideEffect,
+            waitForOutbound: sideEffect,
+            waitForOutboundSequence: sideEffect,
+            waitForNoOutbound: sideEffect,
+          },
+          runScenario: async (name, steps) => {
+            for (const step of steps) {
+              await step.run();
+            }
+            return { name, status: "pass", steps: [] };
+          },
+        },
+        scenarioTitle: "flow-post-resolution-abort-fence",
+        flow: { steps: [{ name: "resolve input", actions: [action] }] },
+      });
+
+      await inputStarted;
+      controller.abort(timeoutError);
+      releaseInput({});
+
+      await expect(pending).rejects.toBe(timeoutError);
+      expect(sideEffect).not.toHaveBeenCalled();
+    },
+  );
+
   it("runs finally cleanup without advancing other actions after abort", async () => {
     const controller = new AbortController();
     const timeoutError = new Error("scenario deadline expired");

--- a/extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+import { createQaBusState } from "./bus-state.js";
+import { runScenarioFlow } from "./scenario-flow-runner.js";
+
+describe("scenario flow deadline", () => {
+  it("runs finally cleanup without advancing other actions after abort", async () => {
+    const controller = new AbortController();
+    const timeoutError = new Error("scenario deadline expired");
+    const nestedMutation = vi.fn();
+    const catchMutation = vi.fn();
+    const finallyMutation = vi.fn();
+    const laterMutation = vi.fn();
+    const detailsMutation = vi.fn(() => "details");
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    const thenKey = ["th", "en"].join("");
+    const ifAction = Object.fromEntries([
+      ["expr", "true"],
+      [
+        thenKey,
+        [
+          {
+            forEach: {
+              items: [1],
+              item: "item",
+              actions: [{ call: "delayedAction" }, { call: "nestedMutation" }],
+            },
+          },
+        ],
+      ],
+    ]);
+
+    const result = await runScenarioFlow({
+      api: {
+        signal: controller.signal,
+        state: createQaBusState(),
+        scenario: {
+          id: "flow-abort-fence",
+          title: "flow-abort-fence",
+          sourcePath: "qa/scenarios/flow-abort-fence.yaml",
+          surface: "test",
+          objective: "test",
+          successCriteria: ["test"],
+          execution: { kind: "flow" },
+        },
+        config: {},
+        delayedAction: async () => {
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, 40);
+          });
+        },
+        nestedMutation,
+        catchMutation,
+        finallyMutation,
+        laterMutation,
+        detailsMutation,
+        runScenario: async (name, steps) => {
+          const deadline = new Promise<never>((_resolve, reject) => {
+            deadlineTimer = setTimeout(() => {
+              controller.abort(timeoutError);
+              reject(timeoutError);
+            }, 10);
+          });
+          try {
+            await Promise.race([steps[0]?.run(), deadline]);
+            return { name, status: "pass", steps: [] };
+          } catch (error) {
+            return {
+              name,
+              status: "fail",
+              details: error instanceof Error ? error.message : String(error),
+              steps: [],
+            };
+          } finally {
+            clearTimeout(deadlineTimer);
+          }
+        },
+      },
+      scenarioTitle: "flow-abort-fence",
+      flow: {
+        steps: [
+          {
+            name: "aborted nested flow",
+            actions: [
+              {
+                try: {
+                  actions: [{ if: ifAction }],
+                  catch: [{ call: "catchMutation" }],
+                  finally: [{ call: "finallyMutation" }],
+                },
+              },
+              { call: "laterMutation" },
+            ],
+            detailsExpr: "detailsMutation()",
+          },
+        ],
+      },
+    });
+
+    expect(result).toMatchObject({ status: "fail", details: timeoutError.message });
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 60);
+    });
+    expect(nestedMutation).not.toHaveBeenCalled();
+    expect(catchMutation).not.toHaveBeenCalled();
+    expect(finallyMutation).toHaveBeenCalledOnce();
+    expect(laterMutation).not.toHaveBeenCalled();
+    expect(detailsMutation).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/qa-lab/src/scenario-flow-runner.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.ts
@@ -198,11 +198,13 @@ function resolveCallable(path: string, api: QaFlowApi, vars: QaFlowVars) {
   return parent ? value.bind(parent) : value;
 }
 
-function throwIfFlowAborted(api: QaFlowApi) {
-  api.signal?.throwIfAborted();
-}
-
 type QaFlowActionOptions = { allowAfterAbort?: boolean };
+
+function throwIfFlowAborted(api: QaFlowApi, options: QaFlowActionOptions = {}) {
+  if (!options.allowAfterAbort) {
+    api.signal?.throwIfAborted();
+  }
+}
 
 async function runFlowAction(
   action: unknown,
@@ -210,15 +212,11 @@ async function runFlowAction(
   vars: QaFlowVars,
   options: QaFlowActionOptions = {},
 ) {
-  if (!options.allowAfterAbort) {
-    throwIfFlowAborted(api);
-  }
+  throwIfFlowAborted(api, options);
   try {
     await runFlowActionBody(action, api, vars, options);
   } finally {
-    if (!options.allowAfterAbort) {
-      throwIfFlowAborted(api);
-    }
+    throwIfFlowAborted(api, options);
   }
 }
 
@@ -236,6 +234,8 @@ async function runFlowActionBody(
     const args = Array.isArray(action.args)
       ? await Promise.all(action.args.map((entry) => resolveValue(entry, api, vars)))
       : [];
+    // Value resolution may cross the deadline, so fence every callable at invocation time.
+    throwIfFlowAborted(api, options);
     const result = await callable(...args);
     if (typeof action.saveAs === "string" && action.saveAs.trim()) {
       vars[action.saveAs.trim()] = result;
@@ -251,7 +251,9 @@ async function runFlowActionBody(
   ] as const) {
     if (name in action) {
       const callable = resolveCallable(`transport.${name}`, api, vars);
-      const result = await callable(await resolveValue(action[name], api, vars));
+      const input = await resolveValue(action[name], api, vars);
+      throwIfFlowAborted(api, options);
+      const result = await callable(input);
       if (typeof action.saveAs === "string" && action.saveAs.trim()) {
         vars[action.saveAs.trim()] = result;
       }
@@ -260,6 +262,7 @@ async function runFlowActionBody(
   }
   if (action.resetTransport === true) {
     const reset = resolveCallable("transport.reset", api, vars);
+    throwIfFlowAborted(api, options);
     await reset();
     return;
   }

--- a/extensions/qa-lab/src/scenario-flow-runner.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.ts
@@ -21,6 +21,7 @@ type QaSuiteScenarioResult = {
 };
 
 type QaFlowApi = Record<string, unknown> & {
+  signal?: AbortSignal;
   state: QaTransportState;
   scenario: QaSeedScenarioWithSource;
   config: Record<string, unknown>;
@@ -197,7 +198,36 @@ function resolveCallable(path: string, api: QaFlowApi, vars: QaFlowVars) {
   return parent ? value.bind(parent) : value;
 }
 
-async function runFlowAction(action: unknown, api: QaFlowApi, vars: QaFlowVars) {
+function throwIfFlowAborted(api: QaFlowApi) {
+  api.signal?.throwIfAborted();
+}
+
+type QaFlowActionOptions = { allowAfterAbort?: boolean };
+
+async function runFlowAction(
+  action: unknown,
+  api: QaFlowApi,
+  vars: QaFlowVars,
+  options: QaFlowActionOptions = {},
+) {
+  if (!options.allowAfterAbort) {
+    throwIfFlowAborted(api);
+  }
+  try {
+    await runFlowActionBody(action, api, vars, options);
+  } finally {
+    if (!options.allowAfterAbort) {
+      throwIfFlowAborted(api);
+    }
+  }
+}
+
+async function runFlowActionBody(
+  action: unknown,
+  api: QaFlowApi,
+  vars: QaFlowVars,
+  options: QaFlowActionOptions,
+) {
   if (!isPlainObject(action)) {
     throw new Error(`invalid qa flow action: ${JSON.stringify(action)}`);
   }
@@ -287,7 +317,7 @@ async function runFlowAction(action: unknown, api: QaFlowApi, vars: QaFlowVars) 
     const passed = Boolean(await evalExpr(ifAction.expr, api, vars));
     const branch = passed ? ifAction.then : (ifAction.else ?? []);
     for (const nested of branch) {
-      await runFlowAction(nested, api, vars);
+      await runFlowAction(nested, api, vars, options);
     }
     return;
   }
@@ -308,7 +338,7 @@ async function runFlowAction(action: unknown, api: QaFlowApi, vars: QaFlowVars) 
         vars[forEachAction.index] = index;
       }
       for (const nested of forEachAction.actions) {
-        await runFlowAction(nested, api, vars);
+        await runFlowAction(nested, api, vars, options);
       }
     }
     return;
@@ -322,7 +352,7 @@ async function runFlowAction(action: unknown, api: QaFlowApi, vars: QaFlowVars) 
     };
     try {
       for (const nested of tryAction.actions) {
-        await runFlowAction(nested, api, vars);
+        await runFlowAction(nested, api, vars, options);
       }
     } catch (error) {
       if (!tryAction.catch && !tryAction.finally) {
@@ -333,7 +363,7 @@ async function runFlowAction(action: unknown, api: QaFlowApi, vars: QaFlowVars) 
       }
       if (tryAction.catch) {
         for (const nested of tryAction.catch) {
-          await runFlowAction(nested, api, vars);
+          await runFlowAction(nested, api, vars, options);
         }
       } else {
         throw error;
@@ -341,7 +371,7 @@ async function runFlowAction(action: unknown, api: QaFlowApi, vars: QaFlowVars) 
     } finally {
       if (tryAction.finally) {
         for (const nested of tryAction.finally) {
-          await runFlowAction(nested, api, vars);
+          await runFlowAction(nested, api, vars, { allowAfterAbort: true });
         }
       }
     }
@@ -366,8 +396,12 @@ export async function runScenarioFlow(params: {
       if (!step.detailsExpr) {
         return undefined;
       }
-      const details = await evalExpr(step.detailsExpr, params.api, vars);
-      return formatFlowDetails(details);
+      throwIfFlowAborted(params.api);
+      try {
+        return formatFlowDetails(await evalExpr(step.detailsExpr, params.api, vars));
+      } finally {
+        throwIfFlowAborted(params.api);
+      }
     },
   }));
   const result = await params.api.runScenario(params.scenarioTitle, steps);

--- a/extensions/qa-lab/src/suite-artifacts.ts
+++ b/extensions/qa-lab/src/suite-artifacts.ts
@@ -48,6 +48,12 @@ export async function publishQaSuiteArtifactFiles(params: {
   }
 }
 
+export async function invalidateQaSuiteArtifactGeneration(outputDir: string) {
+  for (const fileName of ["qa-suite-summary.json", QA_EVIDENCE_FILENAME, "qa-suite-report.md"]) {
+    await fs.rm(path.join(outputDir, fileName), { force: true });
+  }
+}
+
 export type QaSuiteSummaryJsonParams = {
   status?: QaSuiteSummaryJson["run"]["status"];
   scenarios: QaSuiteScenarioResult[];
@@ -290,7 +296,10 @@ export async function writeQaSuiteArtifacts(params: {
       "utf8",
     );
   }
-  const writeEvidenceFile = params.writeEvidenceFile ?? true;
+  const writeEvidenceFile = params.status !== "running" && (params.writeEvidenceFile ?? true);
+  if (!writeEvidenceFile) {
+    await fs.rm(evidencePath, { force: true });
+  }
   await publishQaSuiteArtifactFiles({
     outputDir: params.outputDir,
     files: [

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -1180,6 +1180,40 @@ describe("qa suite runtime launcher", () => {
     );
   });
 
+  it("projects a skipped native producer as a skipped unified scenario", async () => {
+    const repoRoot = await makeTempRepo("qa-suite-native-skip-");
+    const defaultImplementation = runQaTestFileScenarios.getMockImplementation();
+    if (!defaultImplementation) {
+      throw new Error("expected default QA test-file scenario mock implementation");
+    }
+    runQaTestFileScenarios.mockImplementationOnce(async (params) => {
+      const result = await defaultImplementation(params);
+      return {
+        ...result,
+        results: result.results.map(
+          (scenarioResult: QaTestFileScenarioRunResult["results"][number]) =>
+            Object.assign({}, scenarioResult, { status: "skipped" as const }),
+        ),
+      };
+    });
+
+    const result = await runQaSuite({
+      repoRoot,
+      outputDir: ".artifacts/qa-e2e/native-skip",
+      scenarioIds: ["control-ui-chat-flow-playwright"],
+    });
+    if (result.executionKind !== "suite") {
+      throw new Error("expected unified suite result");
+    }
+    expect(result.result.scenarios).toMatchObject([
+      { name: "Control UI chat flow Playwright coverage", status: "skip" },
+    ]);
+    const summary = JSON.parse(await fs.readFile(result.result.summaryPath, "utf8")) as {
+      counts: { failed: number; skipped: number };
+    };
+    expect(summary.counts).toMatchObject({ failed: 0, skipped: 1 });
+  });
+
   it("serializes test-file runner partitions in one checkout", async () => {
     const repoRoot = await makeTempRepo("qa-suite-test-file-serial-");
     let releaseVitest!: () => void;
@@ -1323,29 +1357,6 @@ describe("qa suite runtime launcher", () => {
             alternateModel: "mock-openai/gpt-5.6-luna-alt",
             fastMode: true,
             concurrency: 1,
-          }),
-      });
-    },
-  );
-
-  it.each([
-    { kind: "evidence", fileName: "qa-evidence.json" },
-    { kind: "report", fileName: "qa-suite-report.md" },
-    { kind: "summary", fileName: "qa-suite-summary.json" },
-  ])(
-    "preserves the prior unified $kind artifact when atomic publication fails",
-    async ({ fileName }) => {
-      const repoRoot = await makeTempRepo("qa-suite-unified-artifact-atomic-");
-      const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "artifact-atomic");
-      await expectArtifactPublicationFailurePreservesPrior({
-        canonicalFileNames: ["qa-evidence.json", "qa-suite-report.md", "qa-suite-summary.json"],
-        failedFileName: fileName,
-        outputDir,
-        publish: async () =>
-          await runQaSuite({
-            repoRoot,
-            outputDir: ".artifacts/qa-e2e/artifact-atomic",
-            scenarioIds: ["control-ui-chat-flow-playwright"],
           }),
       });
     },
@@ -2583,6 +2594,16 @@ describe("qa suite runtime launcher", () => {
 
   it("waits for already-started partitions before recording a unified failure", async () => {
     const repoRoot = await makeTempRepo("qa-suite-reject-settle-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "reject-settle");
+    const priorArtifactPaths = [
+      path.join(outputDir, "qa-suite-summary.json"),
+      path.join(outputDir, "qa-evidence.json"),
+      path.join(outputDir, "qa-suite-report.md"),
+    ];
+    await fs.mkdir(outputDir, { recursive: true });
+    await Promise.all(
+      priorArtifactPaths.map((artifactPath) => fs.writeFile(artifactPath, "stale")),
+    );
     let releaseTestFile!: () => void;
     let markTestFileStarted!: () => void;
     const testFileStarted = new Promise<void>((resolve) => {
@@ -2635,6 +2656,9 @@ describe("qa suite runtime launcher", () => {
     await Promise.resolve();
 
     expect(completed).toBe(false);
+    for (const artifactPath of priorArtifactPaths) {
+      await expect(fs.access(artifactPath)).rejects.toMatchObject({ code: "ENOENT" });
+    }
 
     releaseTestFile();
     const result = await runPromise;

--- a/extensions/qa-lab/src/suite-launch.runtime.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.ts
@@ -27,7 +27,10 @@ import {
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
 import { expandQaScenarioExecutionCells, type QaScenarioExecutionCell } from "./scenario-lane.js";
-import { publishQaSuiteArtifactFiles } from "./suite-artifacts.js";
+import {
+  invalidateQaSuiteArtifactGeneration,
+  publishQaSuiteArtifactFiles,
+} from "./suite-artifacts.js";
 import {
   mapQaSuiteWithConcurrency,
   normalizeQaSuiteConcurrency,
@@ -622,8 +625,9 @@ function testFileScenarioResultToSuiteScenario(
   result: QaTestFileScenarioRunResult["results"][number],
   repoRoot: string,
 ): QaSuiteScenarioResult {
-  const suiteStatus = result.status === "pass" ? "pass" : "fail";
-  const stepStatus = result.status === "skipped" ? "skip" : suiteStatus;
+  const suiteStatus =
+    result.status === "pass" ? "pass" : result.status === "skipped" ? "skip" : "fail";
+  const stepStatus = suiteStatus;
   const logPath = toRepoRelativePath(repoRoot, result.logPath);
   const details = [
     `execution.kind=${result.scenario.execution.kind}`,
@@ -731,6 +735,7 @@ async function runUnifiedQaSuite(params: {
   const startedAt = new Date();
   const repoRoot = path.resolve(params.runParams?.repoRoot ?? process.cwd());
   const outputDir = await resolveQaSuiteOutputDir(repoRoot, params.runParams?.outputDir);
+  await invalidateQaSuiteArtifactGeneration(outputDir);
   // Only an explicitly selected single flow may replace the unified suite's mock default.
   const [selectedScenario] = params.plan.scenarios;
   const selectedProviderMode =

--- a/extensions/qa-lab/src/suite-provider-selection.test.ts
+++ b/extensions/qa-lab/src/suite-provider-selection.test.ts
@@ -1,5 +1,5 @@
 // QA Lab suite selection keeps scenario requirements on their declared provider lane.
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -109,6 +109,37 @@ describe("qa suite provider selection", () => {
         }),
       ).rejects.toThrow("selected provider lane reached lab startup");
       expect(startLab).toHaveBeenCalledOnce();
+    } finally {
+      await rm(repoRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("invalidates prior terminal artifacts before replacement startup fails", async () => {
+    const repoRoot = await mkdtemp(path.join(os.tmpdir(), "qa-suite-generation-"));
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "replacement");
+    const artifactPaths = [
+      path.join(outputDir, "qa-suite-summary.json"),
+      path.join(outputDir, "qa-evidence.json"),
+      path.join(outputDir, "qa-suite-report.md"),
+    ];
+    await mkdir(outputDir, { recursive: true });
+    await Promise.all(artifactPaths.map((artifactPath) => writeFile(artifactPath, "stale\n")));
+
+    try {
+      await expect(
+        runQaFlowSuiteFromRuntime({
+          repoRoot,
+          outputDir,
+          scenarioIds: ["goal-context-next-turn"],
+          concurrency: 1,
+          startLab: async () => {
+            throw new Error("replacement startup failed");
+          },
+        }),
+      ).rejects.toThrow("replacement startup failed");
+      for (const artifactPath of artifactPaths) {
+        await expect(access(artifactPath)).rejects.toMatchObject({ code: "ENOENT" });
+      }
     } finally {
       await rm(repoRoot, { recursive: true, force: true });
     }

--- a/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts
@@ -97,7 +97,7 @@ describe("isolated QA suite transport cleanup", () => {
     mocks.disposeRegisteredAgentHarnesses.mockResolvedValue(undefined);
   });
 
-  it("retains passing artifacts and finishes owned cleanup before reporting teardown failure", async () => {
+  it("leaves only running progress when parent cleanup fails after worker completion", async () => {
     const lab = createCleanupTestLab();
     const release = vi.fn(async () => {});
     const factory: QaTransportAdapterFactory = {
@@ -162,17 +162,18 @@ describe("isolated QA suite transport cleanup", () => {
       1,
       expect.objectContaining({ status: "running" }),
     );
-    expect(mocks.writeQaSuiteArtifacts).toHaveBeenLastCalledWith(
-      expect.not.objectContaining({ status: "running" }),
+    expect(mocks.writeQaSuiteArtifacts).toHaveBeenCalledTimes(1);
+    expect(mocks.writeQaSuiteArtifacts).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "running", writeEvidenceFile: false }),
+    );
+    expect(lab.setScenarioRun).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "completed" }),
     );
     expect((thrown as Error).message.split("\n")[0]).toBe(
       "QA scenarios passed, but cleanup failed",
     );
     expect((thrown as Error).message).toContain(
       "failed cleanup phases: agent harnesses: agent harness disposal failed",
-    );
-    expect((thrown as Error).message).toContain(
-      "retained artifacts: output=/qa-output report=/qa-output/qa-suite-report.md summary=/qa-output/qa-suite-summary.json",
     );
     expect((thrown as Error).cause).toBe(cleanupError);
     expect(stderrWrite.mock.calls.flat().join("")).not.toContain("run complete");

--- a/extensions/qa-lab/src/suite-run-isolated.ts
+++ b/extensions/qa-lab/src/suite-run-isolated.ts
@@ -116,7 +116,7 @@ export async function runQaFlowSuiteIsolated(
           channelDriver: transportFactoryResult.driver,
           channelDriverSelection: params?.channelDriverSelection,
           isolatedWorkers: true,
-          writeEvidenceFile: params?.writeEvidenceFile,
+          writeEvidenceFile: false,
           scenarioIds:
             params?.scenarioIds && params.scenarioIds.length > 0
               ? selectedScenarios.map((scenario) => scenario.id)
@@ -139,9 +139,8 @@ export async function runQaFlowSuiteIsolated(
   let isolatedRunFailed = false;
   let isolatedRunError: unknown;
   let parentTransportCleaned = false;
-  let result: QaSuiteResult | undefined;
   let completionProgress: string | undefined;
-  let evidenceWritten = false;
+  let terminalScenarios: QaSuiteScenarioResult[] | undefined;
   try {
     if (params?.channelDriver === "live") {
       // The parent only renders aggregate artifacts. Release its live credentials
@@ -263,64 +262,8 @@ export async function runQaFlowSuiteIsolated(
       },
     );
     await artifactWriteQueue;
-    const finishedAt = new Date();
-    lab.setScenarioRun({
-      kind: "suite",
-      status: "completed",
-      startedAt: startedAt.toISOString(),
-      finishedAt: finishedAt.toISOString(),
-      scenarios: [...liveScenarioOutcomes],
-    });
-    const { evidence, evidencePath, report, reportPath, summaryPath } = await writeQaSuiteArtifacts(
-      {
-        repoRoot,
-        outputDir,
-        startedAt,
-        finishedAt,
-        scenarios,
-        scenarioDefinitions: selectedScenarios,
-        evidenceMode: params?.evidenceMode,
-        transport,
-        providerMode,
-        primaryModel,
-        alternateModel,
-        fastMode,
-        concurrency,
-        channel: params?.channelId ?? params?.channelDriverSelection?.channel ?? transport.id,
-        channelDriver: transportFactoryResult.driver,
-        channelDriverSelection: params?.channelDriverSelection,
-        isolatedWorkers: true,
-        writeEvidenceFile: params?.writeEvidenceFile,
-        // When the caller supplied an explicit non-empty --scenario filter,
-        // record the executed (post-selectQaFlowSuiteScenarios-normalized) ids
-        // so the summary matches what actually ran. When the caller passed
-        // nothing or an empty array ("no filter, full lane catalog"),
-        // preserve the unfiltered = null semantic so the summary stays
-        // distinguishable from an explicit all-scenarios selection.
-        scenarioIds:
-          params?.scenarioIds && params.scenarioIds.length > 0
-            ? selectedScenarios.map((scenario) => scenario.id)
-            : undefined,
-      },
-    );
-    lab.setLatestReport({
-      outputPath: reportPath,
-      markdown: report,
-      generatedAt: finishedAt.toISOString(),
-    } satisfies QaLabLatestReport);
+    terminalScenarios = scenarios;
     completionProgress = "run complete";
-    evidenceWritten = evidence !== undefined && (params?.writeEvidenceFile ?? true);
-    result = {
-      outputDir,
-      evidence,
-      evidencePath,
-      reportPath,
-      summaryPath,
-      report,
-      scenarios,
-      startedScenarioIds: [...startedScenarioIds],
-      watchUrl: lab.baseUrl,
-    } satisfies QaSuiteResult;
   } catch (error) {
     isolatedRunFailed = true;
     isolatedRunError = error;
@@ -340,13 +283,60 @@ export async function runQaFlowSuiteIsolated(
       cleanupFailures,
       runFailed: isolatedRunFailed,
       runError: isolatedRunError,
-      result,
-      evidenceWritten,
+      scenarios: terminalScenarios,
     });
   }
-  if (!result || !completionProgress) {
+  if (!terminalScenarios || !completionProgress) {
     throw new Error("QA suite completed without terminal result metadata");
   }
+  const terminalFinishedAt = new Date();
+  const { evidence, evidencePath, report, reportPath, summaryPath } = await writeQaSuiteArtifacts({
+    repoRoot,
+    outputDir,
+    startedAt,
+    finishedAt: terminalFinishedAt,
+    scenarios: terminalScenarios,
+    scenarioDefinitions: selectedScenarios,
+    evidenceMode: params?.evidenceMode,
+    transport,
+    providerMode,
+    primaryModel,
+    alternateModel,
+    fastMode,
+    concurrency,
+    channel: params?.channelId ?? params?.channelDriverSelection?.channel ?? transport.id,
+    channelDriver: transportFactoryResult.driver,
+    channelDriverSelection: params?.channelDriverSelection,
+    isolatedWorkers: true,
+    writeEvidenceFile: params?.writeEvidenceFile,
+    scenarioIds:
+      params?.scenarioIds && params.scenarioIds.length > 0
+        ? selectedScenarios.map((scenario) => scenario.id)
+        : undefined,
+  });
+  lab.setLatestReport({
+    outputPath: reportPath,
+    markdown: report,
+    generatedAt: terminalFinishedAt.toISOString(),
+  } satisfies QaLabLatestReport);
+  lab.setScenarioRun({
+    kind: "suite",
+    status: "completed",
+    startedAt: startedAt.toISOString(),
+    finishedAt: terminalFinishedAt.toISOString(),
+    scenarios: [...liveScenarioOutcomes],
+  });
+  const result = {
+    outputDir,
+    evidence,
+    evidencePath,
+    reportPath,
+    summaryPath,
+    report,
+    scenarios: terminalScenarios,
+    startedScenarioIds: [...startedScenarioIds],
+    watchUrl: lab.baseUrl,
+  } satisfies QaSuiteResult;
   writeQaSuiteProgress(progressEnabled, completionProgress);
   return result;
 }

--- a/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
+++ b/extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts
@@ -200,7 +200,7 @@ describe("QA suite Control UI ownership", () => {
 });
 
 describe("QA runtime parity scenario retry isolation", () => {
-  it("does not report terminal success when cleanup fails after writing artifacts", async () => {
+  it("does not publish terminal artifacts when cleanup fails", async () => {
     const lab = makeRetryTestLab();
     const cleanupError = Object.assign(new Error("gateway shutdown socket reset"), {
       code: "ECONNRESET",
@@ -225,12 +225,11 @@ describe("QA runtime parity scenario retry isolation", () => {
     expect((thrown as Error).message).toContain(
       "failed cleanup phases: gateway stop: gateway shutdown socket reset",
     );
-    expect((thrown as Error).message).toContain(
-      "retained artifacts: output=/qa-output report=/qa-output/qa-suite-report.md summary=/qa-output/qa-suite-summary.json",
-    );
     expect((thrown as Error).cause).toBe(cleanupError);
-    expect(lab.setLatestReport).toHaveBeenCalledWith(
-      expect.objectContaining({ outputPath: "/qa-output/qa-suite-report.md" }),
+    expect(mocks.writeQaSuiteArtifacts).not.toHaveBeenCalled();
+    expect(lab.setLatestReport).not.toHaveBeenCalled();
+    expect(lab.setScenarioRun).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "completed" }),
     );
     expect(
       mocks.writeQaSuiteProgress.mock.calls.filter(([, message]) =>

--- a/extensions/qa-lab/src/suite-run-standard.ts
+++ b/extensions/qa-lab/src/suite-run-standard.ts
@@ -108,9 +108,9 @@ export async function runQaFlowSuiteStandard(
   let preserveGatewayRuntimeDir: string | undefined;
   let runFailed = false;
   let runError: unknown;
-  let result: QaSuiteResult | undefined;
   let completionProgress: string | undefined;
-  let evidenceWritten = false;
+  let terminalScenarios: QaSuiteScenarioResult[] | undefined;
+  let publishTerminalResult: (() => Promise<QaSuiteResult>) | undefined;
   const startedScenarioIds: string[] = [];
   try {
     writeQaSuiteProgress(progressEnabled, `provider start: ${providerMode}`);
@@ -358,11 +358,11 @@ export async function runQaFlowSuiteStandard(
             mockBaseUrl: activeMock?.baseUrl,
           })
         : undefined;
-    const finishedAt = new Date();
+    const scenarioFinishedAt = new Date();
     await captureGatewayHeapCheckpoint("suite-finish");
     const metrics = buildQaSuiteRuntimeMetrics({
       startedAt,
-      finishedAt,
+      finishedAt: scenarioFinishedAt,
       gatewayProcessCpuStartMs,
       gatewayProcessCpuEndMs: activeGateway.getProcessCpuMs?.() ?? null,
       gatewayProcessRssStartBytes,
@@ -378,62 +378,63 @@ export async function runQaFlowSuiteStandard(
     ) {
       preserveGatewayRuntimeDir = path.join(outputDir, "artifacts", "gateway-runtime");
     }
-    lab.setScenarioRun({
-      kind: "suite",
-      status: "completed",
-      startedAt: startedAt.toISOString(),
-      finishedAt: finishedAt.toISOString(),
-      scenarios: [...liveScenarioOutcomes],
-    });
-    const { evidence, evidencePath, report, reportPath, summaryPath } = await writeQaSuiteArtifacts(
-      {
-        repoRoot,
-        outputDir,
-        startedAt,
-        finishedAt,
-        scenarios,
-        metrics,
-        scenarioDefinitions: selectedScenarios,
-        evidenceMode: params?.evidenceMode,
-        transport,
-        providerMode,
-        primaryModel,
-        alternateModel,
-        fastMode,
-        concurrency,
-        channel: params?.channelId ?? params?.channelDriverSelection?.channel ?? transport.id,
-        channelDriver: transportFactoryResult.driver,
-        channelDriverSelection: params?.channelDriverSelection,
-        isolatedWorkers: false,
-        writeEvidenceFile: params?.writeEvidenceFile,
-        // Same "filtered → executed list, unfiltered → null" convention as
-        // the concurrent-path writeQaSuiteArtifacts call above.
-        scenarioIds:
-          params?.scenarioIds && params.scenarioIds.length > 0
-            ? selectedScenarios.map((scenario) => scenario.id)
-            : undefined,
-      },
-    );
-    const latestReport = {
-      outputPath: reportPath,
-      markdown: report,
-      generatedAt: finishedAt.toISOString(),
-    } satisfies QaLabLatestReport;
-    lab.setLatestReport(latestReport);
+    terminalScenarios = scenarios;
     completionProgress = `run complete: passed=${scenarios.length - failedCount - skippedCount} failed=${failedCount} skipped=${skippedCount} total=${scenarios.length}`;
-    evidenceWritten = evidence !== undefined && (params?.writeEvidenceFile ?? true);
-    result = {
-      outputDir,
-      evidence,
-      evidencePath,
-      reportPath,
-      summaryPath,
-      report,
-      scenarios,
-      startedScenarioIds,
-      watchUrl: lab.baseUrl,
-      ...(runtimeParityCell ? { runtimeParityCell } : {}),
-    } satisfies QaSuiteResult;
+    publishTerminalResult = async () => {
+      const finishedAt = new Date();
+      const { evidence, evidencePath, report, reportPath, summaryPath } =
+        await writeQaSuiteArtifacts({
+          repoRoot,
+          outputDir,
+          startedAt,
+          finishedAt,
+          scenarios,
+          metrics,
+          scenarioDefinitions: selectedScenarios,
+          evidenceMode: params?.evidenceMode,
+          transport,
+          providerMode,
+          primaryModel,
+          alternateModel,
+          fastMode,
+          concurrency,
+          channel: params?.channelId ?? params?.channelDriverSelection?.channel ?? transport.id,
+          channelDriver: transportFactoryResult.driver,
+          channelDriverSelection: params?.channelDriverSelection,
+          isolatedWorkers: false,
+          writeEvidenceFile: params?.writeEvidenceFile,
+          // Same "filtered → executed list, unfiltered → null" convention as
+          // the concurrent-path writeQaSuiteArtifacts call above.
+          scenarioIds:
+            params?.scenarioIds && params.scenarioIds.length > 0
+              ? selectedScenarios.map((scenario) => scenario.id)
+              : undefined,
+        });
+      lab.setLatestReport({
+        outputPath: reportPath,
+        markdown: report,
+        generatedAt: finishedAt.toISOString(),
+      } satisfies QaLabLatestReport);
+      lab.setScenarioRun({
+        kind: "suite",
+        status: "completed",
+        startedAt: startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        scenarios: [...liveScenarioOutcomes],
+      });
+      return {
+        outputDir,
+        evidence,
+        evidencePath,
+        reportPath,
+        summaryPath,
+        report,
+        scenarios,
+        startedScenarioIds,
+        watchUrl: lab.baseUrl,
+        ...(runtimeParityCell ? { runtimeParityCell } : {}),
+      } satisfies QaSuiteResult;
+    };
   } catch (error) {
     runFailed = true;
     runError = error;
@@ -468,11 +469,17 @@ export async function runQaFlowSuiteStandard(
             }
           },
     });
-    throwQaSuiteCleanupErrors({ cleanupFailures, runFailed, runError, result, evidenceWritten });
+    throwQaSuiteCleanupErrors({
+      cleanupFailures,
+      runFailed,
+      runError,
+      scenarios: terminalScenarios,
+    });
   }
-  if (!result || !completionProgress) {
+  if (!publishTerminalResult || !completionProgress) {
     throw new Error("QA suite completed without terminal result metadata");
   }
+  const result = await publishTerminalResult();
   if (!params?.captureRuntimeParityCell && !isQaSuiteNestedRun(params)) {
     writeQaSuiteProgress(progressEnabled, completionProgress);
   }

--- a/extensions/qa-lab/src/suite-run.runtime.ts
+++ b/extensions/qa-lab/src/suite-run.runtime.ts
@@ -5,6 +5,7 @@ import {
   qaTransportSupportsModuleFlows,
 } from "./qa-transport-registry.js";
 import { readQaBootstrapScenarioCatalog } from "./scenario-catalog.js";
+import { invalidateQaSuiteArtifactGeneration } from "./suite-artifacts.js";
 import { resolveRequestedQaSuiteModels } from "./suite-model-selection.js";
 import {
   collectQaSuiteGatewayConfigPatches,
@@ -69,6 +70,7 @@ export async function runQaFlowSuiteFromRuntime(params?: QaSuiteRunParams): Prom
   if (params?.roundTripProbe && params.runtimePair) {
     throw new Error("QA round-trip probes are not supported with runtime-pair runs.");
   }
+  await invalidateQaSuiteArtifactGeneration(outputDir);
   const enabledPluginIds = [
     ...new Set([
       ...collectQaSuitePluginIds(selectedScenarios),

--- a/extensions/qa-lab/src/suite-runtime-flow.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.test.ts
@@ -155,7 +155,7 @@ describe("qa suite runtime flow", () => {
     const runScenario = vi.fn();
     const splitModelRef = vi.fn((raw: string) => parseModelRef(raw, "openai"));
     const formatErrorMessage = vi.fn();
-    const liveTurnTimeoutMs = vi.fn();
+    const liveTurnTimeoutMs = vi.fn(() => 60_000);
     const resolveQaLiveTurnTimeoutMs = vi.fn();
     createQaScenarioRuntimeApi.mockReturnValue({ api: "ok" });
 
@@ -170,7 +170,7 @@ describe("qa suite runtime flow", () => {
       constants: qaSuiteRuntimeFlowTestConstants,
     });
 
-    expect(result).toEqual({ api: "ok" });
+    expect(result).toMatchObject({ api: "ok", signal: expect.any(AbortSignal) });
     expect(createQaScenarioRuntimeApi).toHaveBeenCalledTimes(1);
     const call = createQaScenarioRuntimeApi.mock.calls[0]?.[0] as {
       env: typeof env;
@@ -193,7 +193,7 @@ describe("qa suite runtime flow", () => {
     };
     expect(call.env).toBe(env);
     expect(call.scenario).toBe(scenario);
-    expect(call.deps.runScenario).toBe(runScenario);
+    expect(call.deps.runScenario).toBeTypeOf("function");
     for (const dependencyModule of [
       suiteRuntimeAgent,
       suiteRuntimeGateway,
@@ -329,9 +329,10 @@ describe("qa suite runtime flow", () => {
 
     expect(runScenario).toHaveBeenCalledWith("Matrix preparation", [
       { name: "Prepare Matrix live", run: expect.any(Function) },
-      { name: "Scenario", run: scenarioStep },
+      { name: "Scenario", run: expect.any(Function) },
     ]);
     expect(prepareFlow).toHaveBeenCalledWith({
+      signal: expect.any(AbortSignal),
       config: { expected: "value" },
       gateway: env.gateway,
       outputDir: "/artifacts",
@@ -342,5 +343,108 @@ describe("qa suite runtime flow", () => {
       waitForConfigRestartSettle: expect.any(Function),
     });
     expect(scenarioStep).not.toHaveBeenCalled();
+  });
+
+  it("does not turn the preparation fallback into a whole-flow deadline", async () => {
+    const prepareFlow = vi.fn(async () => undefined);
+    const env = createQaSuiteRuntimeFlowTestEnv({ prepareFlow });
+    const scenario = makeQaSuiteTestScenario("flow-without-explicit-deadline", { config: {} });
+    const liveTurnTimeoutMs = vi.fn(() => 5);
+    createQaScenarioRuntimeApi.mockImplementationOnce(
+      (params: { deps: { runScenario: typeof runQaSuiteScenarioSteps } }) => ({
+        runScenario: params.deps.runScenario,
+      }),
+    );
+    runScenarioFlow.mockImplementationOnce(async (params) => {
+      const api = params.api as { runScenario: typeof runQaSuiteScenarioSteps };
+      return await api.runScenario("No explicit deadline", [
+        {
+          name: "Longer than preparation fallback",
+          run: async () => {
+            await new Promise<void>((resolve) => {
+              setTimeout(resolve, 20);
+            });
+          },
+        },
+      ]);
+    });
+
+    const result = await runQaSuiteScenarioDefinition({
+      env,
+      scenario,
+      runScenario: runQaSuiteScenarioSteps,
+      splitModelRef: (raw) => parseModelRef(raw, "openai"),
+      formatErrorMessage: (error) => String(error),
+      liveTurnTimeoutMs,
+      resolveQaLiveTurnTimeoutMs: liveTurnTimeoutMs,
+      constants: qaSuiteRuntimeFlowTestConstants,
+    });
+
+    expect(result.status).toBe("pass");
+    expect(liveTurnTimeoutMs).toHaveBeenCalledOnce();
+    expect(prepareFlow).toHaveBeenCalledWith(
+      expect.objectContaining({ signal: expect.any(AbortSignal), timeoutMs: 5 }),
+    );
+  });
+
+  it("bounds preparation and actions with one aborting scenario deadline", async () => {
+    let preparationSignal: AbortSignal | undefined;
+    let actionSignal: AbortSignal | undefined;
+    const prepareFlow = vi.fn(async (input: { signal?: AbortSignal }) => {
+      preparationSignal = input.signal;
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 10);
+      });
+    });
+    const env = createQaSuiteRuntimeFlowTestEnv({ prepareFlow });
+    const scenario = makeQaSuiteTestScenario("flow-deadline", { config: {} });
+    if (scenario.execution.kind !== "flow") {
+      throw new Error("expected flow scenario");
+    }
+    scenario.execution.timeoutMs = 30;
+    createQaScenarioRuntimeApi.mockImplementationOnce(
+      (params: { deps: { runScenario: typeof runQaSuiteScenarioSteps } }) => ({
+        runScenario: params.deps.runScenario,
+      }),
+    );
+    runScenarioFlow.mockImplementationOnce(async (params) => {
+      const api = params.api as {
+        runScenario: typeof runQaSuiteScenarioSteps;
+        signal?: AbortSignal;
+      };
+      return await api.runScenario("Flow deadline", [
+        {
+          name: "Never settles without abort",
+          run: async () =>
+            await new Promise<void>(() => {
+              actionSignal = api.signal;
+              api.signal?.addEventListener("abort", () => {}, { once: true });
+            }),
+        },
+      ]);
+    });
+
+    let boundedTimer: ReturnType<typeof setTimeout> | undefined;
+    const result = await Promise.race([
+      runQaSuiteScenarioDefinition({
+        env,
+        scenario,
+        runScenario: runQaSuiteScenarioSteps,
+        splitModelRef: (raw) => parseModelRef(raw, "openai"),
+        formatErrorMessage: (error) => String(error),
+        liveTurnTimeoutMs: () => 60_000,
+        resolveQaLiveTurnTimeoutMs: () => 60_000,
+        constants: qaSuiteRuntimeFlowTestConstants,
+      }),
+      new Promise<"bounded-window-expired">((resolve) => {
+        boundedTimer = setTimeout(() => resolve("bounded-window-expired"), 250);
+      }),
+    ]);
+    clearTimeout(boundedTimer);
+
+    expect(result).not.toBe("bounded-window-expired");
+    expect(result).toMatchObject({ status: "fail", details: expect.stringContaining("30ms") });
+    expect(preparationSignal).toBe(actionSignal);
+    expect(actionSignal?.aborted).toBe(true);
   });
 });

--- a/extensions/qa-lab/src/suite-runtime-flow.ts
+++ b/extensions/qa-lab/src/suite-runtime-flow.ts
@@ -234,26 +234,57 @@ function createQaSuiteScenarioDeps(params: QaSuiteScenarioDepsParams) {
   } satisfies QaScenarioRuntimeDeps;
 }
 
-function createQaSuiteScenarioFlowApi(params: QaSuiteScenarioFlowApiParams) {
-  return createQaScenarioRuntimeApi({
-    env: params.env,
-    scenario: params.scenario,
-    deps: createQaSuiteScenarioDeps({
+function createQaSuiteScenarioFlowApi(
+  params: QaSuiteScenarioFlowApiParams & { signal: AbortSignal },
+) {
+  return {
+    ...createQaScenarioRuntimeApi({
       env: params.env,
-      runScenario: params.runScenario,
-      splitModelRef: params.splitModelRef,
-      formatErrorMessage: params.formatErrorMessage,
-      liveTurnTimeoutMs: params.liveTurnTimeoutMs,
-      resolveQaLiveTurnTimeoutMs: params.resolveQaLiveTurnTimeoutMs,
+      scenario: params.scenario,
+      deps: createQaSuiteScenarioDeps({
+        env: params.env,
+        runScenario: params.runScenario,
+        splitModelRef: params.splitModelRef,
+        formatErrorMessage: params.formatErrorMessage,
+        liveTurnTimeoutMs: params.liveTurnTimeoutMs,
+        resolveQaLiveTurnTimeoutMs: params.resolveQaLiveTurnTimeoutMs,
+      }),
+      constants: params.constants,
     }),
-    constants: params.constants,
-  });
+    signal: params.signal,
+  };
+}
+
+function createQaScenarioDeadline(timeoutMs?: number) {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline =
+    timeoutMs === undefined
+      ? undefined
+      : new Promise<never>((_resolve, reject) => {
+          const timeoutError = new Error(`QA scenario flow timed out after ${timeoutMs}ms`);
+          timer = setTimeout(() => {
+            controller.abort(timeoutError);
+            reject(timeoutError);
+          }, timeoutMs);
+        });
+  return {
+    signal: controller.signal,
+    run: async <T>(operation: () => Promise<T>) => {
+      controller.signal.throwIfAborted();
+      // In-flight calls abort cooperatively. The flow runner fences later actions and
+      // preserves DSL finally cleanup; the suite owner then tears down runtime resources.
+      return deadline ? await Promise.race([operation(), deadline]) : await operation();
+    },
+    dispose: () => clearTimeout(timer),
+  };
 }
 
 function createQaSuiteScenarioStepRunner(
   env: QaSuiteScenarioFlowEnv,
   scenario: QaSeedScenarioWithSource,
   vars: Record<string, unknown>,
+  deadline: ReturnType<typeof createQaScenarioDeadline>,
   deps: {
     liveTurnTimeoutMs: QaSuiteScenarioDepsParams["liveTurnTimeoutMs"];
     runScenario: QaSuiteScenarioDepsParams["runScenario"];
@@ -264,36 +295,45 @@ function createQaSuiteScenarioStepRunner(
 ): QaSuiteScenarioDepsParams["runScenario"] {
   const prepareFlow = env.transport.prepareFlow;
   const execution = scenario.execution;
-  if (!prepareFlow || execution.kind !== "flow") {
-    return deps.runScenario;
-  }
-  return async (name, steps) =>
-    await deps.runScenario(name, [
-      {
-        name: `Prepare ${env.transport.label}`,
-        run: async () => {
-          const prepared = await prepareFlow({
-            config: execution.config ?? {},
-            gateway: env.gateway,
-            outputDir: env.outputDir,
-            primaryModel: env.primaryModel,
-            scenarioId: scenario.id,
-            scenarioTitle: scenario.title,
-            timeoutMs: execution.timeoutMs ?? deps.liveTurnTimeoutMs(env, 60_000),
-            waitForConfigRestartSettle: async (options) =>
-              await suiteRuntimeGateway.waitForConfigRestartSettle(
-                env,
-                options?.restartDelayMs,
-                options?.timeoutMs,
-              ),
-          });
-          if (prepared) {
-            Object.assign(vars, prepared);
-          }
-        },
-      },
-      ...steps,
-    ]);
+  return async (name, steps) => {
+    const preparedSteps =
+      prepareFlow && execution.kind === "flow"
+        ? [
+            {
+              name: `Prepare ${env.transport.label}`,
+              run: async () => {
+                const prepared = await prepareFlow({
+                  signal: deadline.signal,
+                  config: execution.config ?? {},
+                  gateway: env.gateway,
+                  outputDir: env.outputDir,
+                  primaryModel: env.primaryModel,
+                  scenarioId: scenario.id,
+                  scenarioTitle: scenario.title,
+                  timeoutMs: execution.timeoutMs ?? deps.liveTurnTimeoutMs(env, 60_000),
+                  waitForConfigRestartSettle: async (options) =>
+                    await suiteRuntimeGateway.waitForConfigRestartSettle(
+                      env,
+                      options?.restartDelayMs,
+                      options?.timeoutMs,
+                    ),
+                });
+                deadline.signal.throwIfAborted();
+                if (prepared) {
+                  Object.assign(vars, prepared);
+                }
+              },
+            },
+            ...steps,
+          ]
+        : steps;
+    return await deps.runScenario(
+      name,
+      preparedSteps.map((step) =>
+        Object.assign({}, step, { run: async () => await deadline.run(step.run) }),
+      ),
+    );
+  };
 }
 
 export async function runQaSuiteScenarioDefinition(params: QaSuiteScenarioFlowApiParams) {
@@ -304,17 +344,23 @@ export async function runQaSuiteScenarioDefinition(params: QaSuiteScenarioFlowAp
     throw new Error(`scenario missing flow: ${params.scenario.id}`);
   }
   const vars: Record<string, unknown> = {};
-  const api = createQaSuiteScenarioFlowApi({
-    ...params,
-    runScenario: createQaSuiteScenarioStepRunner(params.env, params.scenario, vars, {
-      liveTurnTimeoutMs: params.liveTurnTimeoutMs,
-      runScenario: params.runScenario,
-    }),
-  });
-  return await runScenarioFlow({
-    api,
-    flow: params.scenario.execution.flow,
-    scenarioTitle: params.scenario.title,
-    vars,
-  });
+  const deadline = createQaScenarioDeadline(params.scenario.execution.timeoutMs);
+  try {
+    const api = createQaSuiteScenarioFlowApi({
+      ...params,
+      signal: deadline.signal,
+      runScenario: createQaSuiteScenarioStepRunner(params.env, params.scenario, vars, deadline, {
+        liveTurnTimeoutMs: params.liveTurnTimeoutMs,
+        runScenario: params.runScenario,
+      }),
+    });
+    return await runScenarioFlow({
+      api,
+      flow: params.scenario.execution.flow,
+      scenarioTitle: params.scenario.title,
+      vars,
+    });
+  } finally {
+    deadline.dispose();
+  }
 }

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts
@@ -162,7 +162,7 @@ function runCleanupTestSuite(params: {
 }
 
 describe("runtime parity suite transport cleanup", () => {
-  it("keeps parent artifacts discoverable when owned lab cleanup fails", async () => {
+  it("does not publish parent artifacts when owned lab cleanup fails", async () => {
     const cleanupError = Object.assign(new Error("owned lab shutdown reset"), {
       code: "ECONNRESET",
     });
@@ -205,20 +205,16 @@ describe("runtime parity suite transport cleanup", () => {
       }).catch((error: unknown) => error);
 
       expect(cleanup).toHaveBeenCalledOnce();
-      expect(setLatestReport).toHaveBeenCalledWith(
-        expect.objectContaining({ outputPath: "/qa-output/qa-suite-report.md" }),
-      );
-      expect(setLatestReport.mock.invocationCallOrder[0]).toBeLessThan(
-        stopLab.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+      expect(mocks.writeQaSuiteArtifacts).not.toHaveBeenCalled();
+      expect(setLatestReport).not.toHaveBeenCalled();
+      expect(lab.setScenarioRun).not.toHaveBeenCalledWith(
+        expect.objectContaining({ status: "completed" }),
       );
       expect((thrown as Error).message.split("\n")[0]).toBe(
         "QA scenarios passed, but cleanup failed",
       );
       expect((thrown as Error).message).toContain(
         "failed cleanup phases: lab stop: owned lab shutdown reset",
-      );
-      expect((thrown as Error).message).toContain(
-        "retained artifacts: output=/qa-output report=/qa-output/qa-suite-report.md summary=/qa-output/qa-suite-summary.json evidence=/qa-output/qa-evidence.json",
       );
       expect((thrown as Error).cause).toBe(cleanupError);
       expect(stderrWrite.mock.calls.flat().join("")).not.toContain("run complete");

--- a/extensions/qa-lab/src/suite-runtime-parity-runner.ts
+++ b/extensions/qa-lab/src/suite-runtime-parity-runner.ts
@@ -109,8 +109,8 @@ export async function runQaRuntimeParitySuite(params: {
   let runFailed = false;
   let runError: unknown;
   let parentTransportCleaned = false;
-  let result: QaSuiteResult | undefined;
-  let evidenceWritten = false;
+  let terminalScenarios: QaSuiteScenarioResult[] | undefined;
+  let publishTerminalResult: (() => Promise<QaSuiteResult>) | undefined;
   const startedScenarioIds = new Set<string>();
   try {
     if (params.channelDriver === "live") {
@@ -255,59 +255,60 @@ export async function runQaRuntimeParitySuite(params: {
       },
     );
 
-    const finishedAt = new Date();
-    const { evidence, evidencePath, report, reportPath, summaryPath } = await writeQaSuiteArtifacts(
-      {
-        repoRoot: params.repoRoot,
+    terminalScenarios = scenarios;
+    publishTerminalResult = async () => {
+      const finishedAt = new Date();
+      const { evidence, evidencePath, report, reportPath, summaryPath } =
+        await writeQaSuiteArtifacts({
+          repoRoot: params.repoRoot,
+          outputDir: params.outputDir,
+          startedAt: params.startedAt,
+          finishedAt,
+          scenarios,
+          scenarioDefinitions: params.selectedScenarios,
+          evidenceMode: params.evidenceMode,
+          transport,
+          providerMode: params.providerMode,
+          primaryModel: params.primaryModel,
+          alternateModel: params.alternateModel,
+          fastMode: params.fastMode,
+          concurrency: params.concurrency,
+          channel: params.channelId ?? params.channelDriverSelection?.channel ?? transport.id,
+          channelDriver: transportFactoryResult.driver,
+          channelDriverSelection: params.channelDriverSelection,
+          scenarioIds:
+            params.scenarioIds && params.scenarioIds.length > 0
+              ? params.selectedScenarios.map((scenario) => scenario.id)
+              : undefined,
+          runtimePair: params.runtimePair,
+          writeEvidenceFile: params.writeEvidenceFile,
+        });
+      lab.setLatestReport({
+        outputPath: reportPath,
+        markdown: report,
+        generatedAt: finishedAt.toISOString(),
+      } satisfies QaLabLatestReport);
+      lab.setScenarioRun({
+        kind: "suite",
+        status: "completed",
+        startedAt: params.startedAt.toISOString(),
+        finishedAt: finishedAt.toISOString(),
+        scenarios: [...liveScenarioOutcomes],
+      });
+      return {
         outputDir: params.outputDir,
-        startedAt: params.startedAt,
-        finishedAt,
+        evidence,
+        evidencePath,
+        reportPath,
+        summaryPath,
+        report,
         scenarios,
-        scenarioDefinitions: params.selectedScenarios,
-        evidenceMode: params.evidenceMode,
-        transport,
-        providerMode: params.providerMode,
-        primaryModel: params.primaryModel,
-        alternateModel: params.alternateModel,
-        fastMode: params.fastMode,
-        concurrency: params.concurrency,
-        channel: params.channelId ?? params.channelDriverSelection?.channel ?? transport.id,
-        channelDriver: transportFactoryResult.driver,
-        channelDriverSelection: params.channelDriverSelection,
-        scenarioIds:
-          params.scenarioIds && params.scenarioIds.length > 0
-            ? params.selectedScenarios.map((scenario) => scenario.id)
-            : undefined,
-        runtimePair: params.runtimePair,
-        writeEvidenceFile: params.writeEvidenceFile,
-      },
-    );
-    lab.setLatestReport({
-      outputPath: reportPath,
-      markdown: report,
-      generatedAt: finishedAt.toISOString(),
-    } satisfies QaLabLatestReport);
-    lab.setScenarioRun({
-      kind: "suite",
-      status: "completed",
-      startedAt: params.startedAt.toISOString(),
-      finishedAt: finishedAt.toISOString(),
-      scenarios: [...liveScenarioOutcomes],
-    });
-    evidenceWritten = evidence !== undefined && (params.writeEvidenceFile ?? true);
-    result = {
-      outputDir: params.outputDir,
-      evidence,
-      evidencePath,
-      reportPath,
-      summaryPath,
-      report,
-      scenarios,
-      startedScenarioIds: params.selectedScenarios
-        .map((scenario) => scenario.id)
-        .filter((scenarioId) => startedScenarioIds.has(scenarioId)),
-      watchUrl: lab.baseUrl,
-    } satisfies QaSuiteResult;
+        startedScenarioIds: params.selectedScenarios
+          .map((scenario) => scenario.id)
+          .filter((scenarioId) => startedScenarioIds.has(scenarioId)),
+        watchUrl: lab.baseUrl,
+      } satisfies QaSuiteResult;
+    };
   } catch (error) {
     runFailed = true;
     runError = error;
@@ -319,11 +320,17 @@ export async function runQaRuntimeParitySuite(params: {
         : []),
       ...(ownsLab ? [{ phase: "lab stop", run: () => lab.stop() }] : []),
     ]);
-    throwQaSuiteCleanupErrors({ cleanupFailures, runFailed, runError, result, evidenceWritten });
+    throwQaSuiteCleanupErrors({
+      cleanupFailures,
+      runFailed,
+      runError,
+      scenarios: terminalScenarios,
+    });
   }
-  if (!result) {
+  if (!publishTerminalResult) {
     throw new Error("QA runtime parity suite completed without a result");
   }
+  const result = await publishTerminalResult();
   writeQaSuiteProgress(params.progressEnabled, "run complete");
   return result;
 }

--- a/extensions/qa-lab/src/suite-summary.test.ts
+++ b/extensions/qa-lab/src/suite-summary.test.ts
@@ -15,7 +15,11 @@ async function readSummary<T>(
 ): Promise<T> {
   const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-suite-summary-inline-"));
   const summaryPath = path.join(outputDir, "qa-suite-summary.json");
-  await fs.writeFile(summaryPath, JSON.stringify(summary), "utf8");
+  const payload =
+    summary && typeof summary === "object" && !Array.isArray(summary)
+      ? { run: { status: "completed" }, ...summary }
+      : summary;
+  await fs.writeFile(summaryPath, JSON.stringify(payload), "utf8");
   try {
     return await reader(summaryPath);
   } finally {
@@ -24,6 +28,50 @@ async function readSummary<T>(
 }
 
 describe("qa suite summary helpers", () => {
+  it.each([
+    ["running", { run: { status: "running" } }],
+    ["missing", {}],
+    ["unsupported", { run: { status: "paused" } }],
+  ])("rejects %s lifecycle state in every canonical count reader", async (_name, lifecycle) => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-suite-summary-lifecycle-"));
+    const summaryPath = path.join(outputDir, "qa-suite-summary.json");
+    await fs.writeFile(
+      summaryPath,
+      JSON.stringify({
+        ...lifecycle,
+        counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
+        scenarios: [{ status: "pass" }],
+      }),
+      "utf8",
+    );
+    try {
+      for (const reader of [
+        readQaSuiteFailedScenarioCountFromFile,
+        readQaSuiteFailedOrSkippedScenarioCountFromFile,
+      ]) {
+        await expect(reader(summaryPath)).rejects.toMatchObject({ code: "summary_not_completed" });
+      }
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    ["null", null],
+    ["array", []],
+    ["string", "not-json-object"],
+    ["number", 1],
+  ])("rejects a %s summary as an invalid completion state", async (_name, summary) => {
+    for (const reader of [
+      readQaSuiteFailedScenarioCountFromFile,
+      readQaSuiteFailedOrSkippedScenarioCountFromFile,
+    ]) {
+      await expect(readSummary(summary, reader)).rejects.toMatchObject({
+        code: "summary_not_completed",
+      });
+    }
+  });
+
   it("counts failed scenarios from scenario statuses", () => {
     expect(
       countQaSuiteFailedScenarios([{ status: "pass" }, { status: "fail" }, { status: "fail" }]),
@@ -540,7 +588,7 @@ describe("qa suite summary helpers", () => {
     ).rejects.toThrow("did not include counts.failed");
     await expect(
       readSummary("not-json-object", readQaSuiteFailedScenarioCountFromFile),
-    ).rejects.toThrow("did not include counts.failed");
+    ).rejects.toMatchObject({ code: "summary_not_completed" });
   });
 
   it("reads failed scenario counts from summary files", async () => {
@@ -549,6 +597,7 @@ describe("qa suite summary helpers", () => {
     await fs.writeFile(
       summaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { failed: 0 },
         scenarios: [{ status: "fail" }],
       }),
@@ -568,6 +617,7 @@ describe("qa suite summary helpers", () => {
     await fs.writeFile(
       summaryPath,
       JSON.stringify({
+        run: { status: "completed" },
         counts: { failed: 0, skipped: 1 },
         scenarios: [{ status: "pass" }],
       }),
@@ -584,7 +634,11 @@ describe("qa suite summary helpers", () => {
   it("fails summary files without a failure signal", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-suite-summary-"));
     const summaryPath = path.join(outputDir, "qa-suite-summary.json");
-    await fs.writeFile(summaryPath, JSON.stringify({ counts: { total: 1, passed: 1 } }), "utf8");
+    await fs.writeFile(
+      summaryPath,
+      JSON.stringify({ run: { status: "completed" }, counts: { total: 1, passed: 1 } }),
+      "utf8",
+    );
 
     try {
       await expect(readQaSuiteFailedScenarioCountFromFile(summaryPath)).rejects.toThrow(

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -93,7 +93,24 @@ function isQaSuiteFailureStatus(status: unknown): boolean {
   return status !== "pass" && status !== "skip" && status !== "skipped";
 }
 
-async function readQaSuiteSummaryFile(summaryPath: string): Promise<unknown> {
+export function findQaSuiteSummaryCompletionError(summary: unknown): string | undefined {
+  if (!isRecord(summary)) {
+    return "has invalid completion state";
+  }
+  if (!isRecord(summary.run) || !Object.hasOwn(summary.run, "status")) {
+    return "is missing run.status";
+  }
+  const status = summary.run.status;
+  if (status === "completed") {
+    return undefined;
+  }
+  if (status === "running") {
+    return "is still running";
+  }
+  return `has unsupported run.status=${typeof status === "string" ? status : typeof status}`;
+}
+
+export async function readCompletedQaSuiteSummaryFile(summaryPath: string): Promise<unknown> {
   let summaryText: string;
   try {
     summaryText = await fs.readFile(summaryPath, "utf8");
@@ -105,8 +122,19 @@ async function readQaSuiteSummaryFile(summaryPath: string): Promise<unknown> {
     );
   }
   try {
-    return JSON.parse(summaryText) as unknown;
+    const summary = JSON.parse(summaryText) as unknown;
+    const completionError = findQaSuiteSummaryCompletionError(summary);
+    if (completionError) {
+      throw new QaSuiteArtifactError(
+        "summary_not_completed",
+        `QA summary at ${summaryPath} ${completionError}.`,
+      );
+    }
+    return summary;
   } catch (error) {
+    if (error instanceof QaSuiteArtifactError) {
+      throw error;
+    }
     throw new QaSuiteArtifactError(
       "summary_parse_failed",
       `Could not parse QA summary JSON at ${summaryPath}: ${formatErrorMessage(error)}`,
@@ -427,7 +455,7 @@ function readQaSuiteFailedOrSkippedScenarioCountFromSummary(summary: unknown): n
 }
 
 export async function readQaSuiteFailedScenarioCountFromFile(summaryPath: string): Promise<number> {
-  const payload = await readQaSuiteSummaryFile(summaryPath);
+  const payload = await readCompletedQaSuiteSummaryFile(summaryPath);
   assertQaSuiteSummaryHasExecutedScenarios(payload, summaryPath, "summary_failure_count_missing");
   const failedScenarioCount = readQaSuiteFailedScenarioCountFromSummary(payload);
   if (failedScenarioCount !== null) {
@@ -443,7 +471,7 @@ export async function readQaSuiteFailedOrSkippedScenarioCountFromFile(
   summaryPath: string,
   options?: { optionalScenarioNames?: ReadonlySet<string>; requireExecutedScenario?: boolean },
 ): Promise<number> {
-  const payload = await readQaSuiteSummaryFile(summaryPath);
+  const payload = await readCompletedQaSuiteSummaryFile(summaryPath);
   assertQaSuiteSummaryHasExecutedScenarios(
     payload,
     summaryPath,

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -591,6 +591,7 @@ describe("qa suite", () => {
   it("can return evidence without writing duplicate child evidence files", async () => {
     const outputDir = await tempDirs.makeTempDir("qa-suite-artifacts-memory-evidence-");
     try {
+      await fs.writeFile(path.join(outputDir, QA_EVIDENCE_FILENAME), "stale evidence\n", "utf8");
       const artifacts = await writeQaSuiteArtifacts({
         outputDir,
         startedAt: new Date("2026-04-11T00:00:00.000Z"),
@@ -625,6 +626,7 @@ describe("qa suite", () => {
       startedAt: new Date("2026-04-11T00:00:00.000Z"),
       finishedAt: new Date("2026-04-11T00:01:00.000Z"),
       scenarios: [{ name: "Baseline", status: "pass" as const, steps: [] }],
+      scenarioDefinitions: [makeQaSuiteTestScenario("baseline")],
       transport: {
         id: "qa-channel",
         createReportNotes: () => [],
@@ -642,6 +644,10 @@ describe("qa suite", () => {
       expect(partial.report).toContain("- Status: running");
       expect(partial.report).toContain("- Updated: 2026-04-11T00:01:00.000Z");
       expect(partial.report).not.toContain("- Finished:");
+      await expect(fs.access(partial.evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readFile(partial.summaryPath, "utf8")).resolves.toContain(
+        '"status": "running"',
+      );
 
       const terminal = await writeQaSuiteArtifacts(baseParams);
       expect(terminal.report).toContain("# OpenClaw QA Scenario Suite\n");

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -308,24 +308,26 @@ export function throwQaSuiteCleanupErrors(params: {
   runFailed: boolean;
   runError: unknown;
   result?: QaSuiteResult;
+  scenarios?: readonly QaSuiteScenarioResult[];
   evidenceWritten?: boolean;
 }) {
   if (params.cleanupFailures.length === 0) {
     return;
   }
   const result = params.result;
-  const scenarios = result?.scenarios ?? [];
+  const scenarios = result?.scenarios ?? params.scenarios ?? [];
+  const scenariosCompleted = result !== undefined || params.scenarios !== undefined;
   const failed = scenarios.filter((scenario) => scenario.status === "fail").length;
   const skipped = scenarios.filter((scenario) => scenario.status === "skip").length;
   const passed = scenarios.length - failed - skipped;
-  const cleanupHeadline = !result
+  const cleanupHeadline = !scenariosCompleted
     ? "QA suite cleanup failed before scenarios completed"
     : failed === 0 && skipped === 0
       ? "QA scenarios passed, but cleanup failed"
       : "QA scenarios completed, but cleanup failed";
   const message = [
     params.runFailed ? "QA suite and cleanup failed" : cleanupHeadline,
-    ...(result
+    ...(scenariosCompleted
       ? [
           `scenario counts: passed=${passed} failed=${failed} skipped=${skipped} total=${scenarios.length}`,
         ]

--- a/extensions/qa-lab/src/test-file-scenario-runner.native.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.native.test.ts
@@ -123,11 +123,14 @@ describe("qa test file scenario runner", () => {
     });
   });
 
-  it("can return aggregate evidence without writing a duplicate evidence file", async () => {
+  it("can return aggregate evidence without retaining a duplicate evidence file", async () => {
     const repoRoot = await makeTempRepo("qa-playwright-memory-evidence-");
+    const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "scenario-playwright");
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(path.join(outputDir, "qa-evidence.json"), "stale evidence\n", "utf8");
     const result = await runQaTestFileScenarios({
       repoRoot,
-      outputDir: path.join(repoRoot, ".artifacts", "qa-e2e", "scenario-playwright"),
+      outputDir,
       ...QA_TEST_RUNNER_DEFAULTS,
       scenarios: [makeTestFileScenario("playwright", "ui/src/e2e/chat-flow.e2e.test.ts")],
       writeEvidenceFile: false,

--- a/extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
@@ -471,6 +471,70 @@ describe("qa test file scenario runner", () => {
     });
   });
 
+  it.each([
+    {
+      name: "blocked plus skipped without a pass",
+      statuses: ["blocked", "skipped"] as const,
+      allowBlockedEvidence: true,
+      expectedStatus: "blocked",
+    },
+    {
+      name: "all skipped",
+      statuses: ["skipped"] as const,
+      allowBlockedEvidence: false,
+      expectedStatus: "skipped",
+    },
+    {
+      name: "pass plus skipped",
+      statuses: ["pass", "skipped"] as const,
+      allowBlockedEvidence: false,
+      expectedStatus: "skipped",
+    },
+    {
+      name: "allowed blocked plus pass plus skipped",
+      statuses: ["blocked", "pass", "skipped"] as const,
+      allowBlockedEvidence: true,
+      expectedStatus: "skipped",
+    },
+  ])(
+    "keeps $name producer precedence",
+    async ({ statuses, allowBlockedEvidence, expectedStatus }) => {
+      const repoRoot = await makeTempRepo("qa-script-producer-skipped-");
+      const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "scenario-script-skipped");
+      const [firstStatus, ...additionalStatuses] = statuses;
+      const scenario = makeTestFileScenario("script", "scripts/evidence-producer.ts");
+      if (scenario.execution.kind !== "script") {
+        throw new Error("expected script scenario");
+      }
+      scenario.execution.allowBlockedEvidence = allowBlockedEvidence;
+      const result = await runQaTestFileScenarios({
+        repoRoot,
+        outputDir,
+        ...QA_TEST_RUNNER_DEFAULTS,
+        scenarios: [scenario],
+        runCommand: async () => {
+          await writeScriptProducerEvidence({
+            additionalEntries: additionalStatuses.flatMap(
+              (status, index) =>
+                buildScriptProducerEvidence({
+                  producerId: `script-producer.web-ui.additional-${index}`,
+                  status,
+                }).entries,
+            ),
+            outputDir,
+            status: firstStatus,
+          });
+          return { exitCode: 0, stdout: "script completed\n", stderr: "" };
+        },
+      });
+
+      expect(result.results[0]).toMatchObject({ status: expectedStatus });
+      expect(
+        result.results[0]?.producerEvidence?.entries.map((entry) => entry.result.status),
+      ).toEqual(statuses);
+    },
+  );
+
   it("carries the suite profile into merged producer evidence", async () => {
     const repoRoot = await makeTempRepo("qa-script-profile-");
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "scenario-script-profile");

--- a/extensions/qa-lab/src/test-file-scenario-runner.test-support.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.test-support.ts
@@ -143,7 +143,7 @@ type ScriptProducerEvidenceParams = {
   failureReason?: string;
   producerId?: string;
   profile?: string;
-  status: "blocked" | "fail" | "pass";
+  status: "blocked" | "fail" | "pass" | "skipped";
 };
 
 export function buildScriptProducerEvidence(

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -394,31 +394,24 @@ function statusFromProducerEvidence(params: {
       status: "fail",
     };
   }
-  const blockingEntry = producerEvidence.entries.find(
-    (entry) =>
-      entry.result.status === "fail" ||
-      (!allowBlockedEvidence && entry.result.status === "blocked"),
-  );
-  if (blockingEntry) {
+  const failedEntry = producerEvidence.entries.find((entry) => entry.result.status === "fail");
+  const blockedEntry = producerEvidence.entries.find((entry) => entry.result.status === "blocked");
+  if (failedEntry) {
     return {
       failureMessage:
-        blockingEntry.result.failure?.reason ??
-        `${blockingEntry.test.id} reported ${blockingEntry.result.status}`,
-      status: blockingEntry.result.status,
+        failedEntry.result.failure?.reason ?? `${failedEntry.test.id} reported failed`,
+      status: "fail",
     };
   }
-  if (!producerEvidence.entries.some((entry) => entry.result.status === "pass")) {
-    // Allowing blocked checks does not make an entirely unexecuted producer a successful run.
-    const blockedEntry = producerEvidence.entries.find(
-      (entry) => entry.result.status === "blocked",
-    );
-    if (blockedEntry) {
-      return {
-        failureMessage:
-          blockedEntry.result.failure?.reason ?? `${blockedEntry.test.id} reported blocked`,
-        status: "blocked",
-      };
-    }
+  const hasPassed = producerEvidence.entries.some((entry) => entry.result.status === "pass");
+  if (blockedEntry && (!allowBlockedEvidence || !hasPassed)) {
+    return {
+      failureMessage:
+        blockedEntry.result.failure?.reason ?? `${blockedEntry.test.id} reported blocked`,
+      status: "blocked",
+    };
+  }
+  if (producerEvidence.entries.some((entry) => entry.result.status === "skipped")) {
     return { status: "skipped" };
   }
   return { status: "pass" };
@@ -550,6 +543,8 @@ async function writeTestFileEvidenceFile(params: {
   if (params.writeEvidenceFile ?? true) {
     await fs.writeFile(evidencePath, `${JSON.stringify(params.evidence, null, 2)}\n`, "utf8");
     await assertQaSuiteArtifactWritten("evidence", evidencePath);
+  } else {
+    await fs.rm(evidencePath, { force: true });
   }
   return { evidencePath };
 }

--- a/scripts/lib/plugin-gateway-gauntlet.mts
+++ b/scripts/lib/plugin-gateway-gauntlet.mts
@@ -621,6 +621,11 @@ function validateQaSuiteSummary(summary: unknown) {
   if (!isRecord(summary.run)) {
     throw new Error("QA suite summary missing run metadata");
   }
+  if (summary.run.status !== "completed") {
+    throw new Error(
+      `QA suite summary run.status must be completed, got ${String(summary.run.status)}`,
+    );
+  }
   const statusCounts = { failed: 0, passed: 0, skipped: 0 };
   for (const scenario of scenarios) {
     if (!isRecord(scenario)) {

--- a/scripts/validate-qa-runtime-pair-summary.mts
+++ b/scripts/validate-qa-runtime-pair-summary.mts
@@ -175,6 +175,9 @@ export function validateQaRuntimePairSummary(
   if (!isRecord(summary) || !isRecord(summary.run) || !Array.isArray(summary.scenarios)) {
     throw new Error("runtime-pair summary is missing run or scenario evidence");
   }
+  if (summary.run.status !== "completed") {
+    throw new Error("runtime-pair summary is not completed");
+  }
   if (!requireCanonicalRuntimePair(summary.run.runtimePair)) {
     throw new Error("runtime-pair summary must compare openclaw and codex in canonical order");
   }

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -82,6 +82,7 @@ type QaRunnerCredentialHost = {
 };
 
 type QaRunnerTransportFlowPreparationInput = {
+  signal?: AbortSignal;
   config: Record<string, unknown>;
   scenarioId: string;
   scenarioTitle: string;

--- a/test/scripts/check-gateway-cpu-scenarios.test.ts
+++ b/test/scripts/check-gateway-cpu-scenarios.test.ts
@@ -42,7 +42,11 @@ function writeQaSuiteSummary(
     `${JSON.stringify({
       counts,
       metrics: { gatewayCpuCoreRatio: 0, wallMs: 1 },
-      run: { completedAt: "2026-01-01T00:00:01.000Z", startedAt: "2026-01-01T00:00:00.000Z" },
+      run: {
+        status: "completed",
+        completedAt: "2026-01-01T00:00:01.000Z",
+        startedAt: "2026-01-01T00:00:00.000Z",
+      },
       scenarios: [
         {
           id: "channel-chat-baseline",

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -467,14 +467,12 @@ describe("package Telegram live Docker E2E", () => {
   it.each(["fail", "skip", "skipped", "timeout"])(
     "fails package Telegram QA when a scenario has %s status",
     async (status) => {
-      const summaryPath = path.join(mkTempRoot(), "qa-evidence.json");
+      const summaryPath = path.join(mkTempRoot(), "qa-suite-summary.json");
       writeFileSync(
         summaryPath,
         JSON.stringify({
-          kind: "openclaw.qa.evidence-summary",
-          schemaVersion: 2,
-          generatedAt: "2026-05-01T00:00:00.000Z",
-          entries: [{ result: { status } }],
+          run: { status: "completed" },
+          scenarios: [{ status }],
         }),
         "utf8",
       );
@@ -489,14 +487,12 @@ describe("package Telegram live Docker E2E", () => {
   );
 
   it("passes package Telegram QA when every scenario passes", async () => {
-    const summaryPath = path.join(mkTempRoot(), "qa-evidence.json");
+    const summaryPath = path.join(mkTempRoot(), "qa-suite-summary.json");
     writeFileSync(
       summaryPath,
       JSON.stringify({
-        kind: "openclaw.qa.evidence-summary",
-        schemaVersion: 2,
-        generatedAt: "2026-05-01T00:00:00.000Z",
-        entries: [{ result: { status: "pass" } }],
+        run: { status: "completed" },
+        scenarios: [{ status: "pass" }],
       }),
       "utf8",
     );

--- a/test/scripts/plugin-gateway-gauntlet.test.ts
+++ b/test/scripts/plugin-gateway-gauntlet.test.ts
@@ -150,6 +150,7 @@ describe("plugin gateway gauntlet helpers", () => {
       counts: { failed: 0, passed: 1, total: 1 },
       metrics,
       run: {
+        status: "completed",
         concurrency: 1,
         fastMode: false,
         finishedAt: "2026-05-30T00:00:01.000Z",
@@ -1715,6 +1716,7 @@ process.exit(7);
         counts: { failed: 1, passed: 1, total: 2 },
         metrics: { gatewayCpuCoreRatio: 0, wallMs: 1 },
         run: {
+          status: "completed",
           concurrency: 1,
           fastMode: false,
           finishedAt: "2026-05-30T00:00:01.000Z",
@@ -1737,12 +1739,32 @@ process.exit(7);
     });
   });
 
+  it("fails successful QA chunks whose summary is still running", async () => {
+    await runQaSummaryFailureScenario({
+      qaSummary: {
+        counts: { failed: 0, passed: 1, total: 1 },
+        run: { status: "running" },
+        scenarios: [
+          {
+            name: "channel-chat-baseline",
+            status: "pass",
+            steps: [{ name: "reply", status: "pass" }],
+          },
+        ],
+      },
+      scenarioIds: ["channel-chat-baseline"],
+      diagnosticFailure: "qa-summary-invalid",
+      diagnosticDetail: "QA suite summary run.status must be completed, got running",
+    });
+  });
+
   it("fails successful QA chunks whose passed scenarios have no step evidence", async () => {
     await runQaSummaryFailureScenario({
       qaSummary: {
         counts: { failed: 0, passed: 1, total: 1 },
         metrics: { gatewayCpuCoreRatio: 0, wallMs: 1 },
         run: {
+          status: "completed",
           concurrency: 1,
           fastMode: false,
           finishedAt: "2026-05-30T00:00:01.000Z",
@@ -1768,6 +1790,7 @@ process.exit(7);
         counts: { failed: 0, passed: 1, total: 2 },
         metrics: { gatewayCpuCoreRatio: 0, wallMs: 1 },
         run: {
+          status: "completed",
           concurrency: 1,
           fastMode: false,
           finishedAt: "2026-05-30T00:00:01.000Z",

--- a/test/scripts/validate-qa-runtime-pair-summary.test.ts
+++ b/test/scripts/validate-qa-runtime-pair-summary.test.ts
@@ -52,6 +52,7 @@ function scenario(params: ScenarioParams) {
 function summary(scenarios: ReturnType<typeof scenario>[]) {
   return {
     run: {
+      status: "completed",
       runtimePair: ["openclaw", "codex"],
       scenarioIds: scenarios.map((entry) => entry.runtimeParity.scenarioId),
     },
@@ -125,6 +126,15 @@ function frozenCoreSummary() {
 }
 
 describe("frozen QA runtime-pair summary validation", () => {
+  it("rejects a nonterminal runtime-pair summary", () => {
+    const fixture = summary([scenario({ name: "running", status: "pass" })]);
+    fixture.run.status = "running";
+
+    expect(() => validateQaRuntimePairSummary(fixture)).toThrow(
+      "runtime-pair summary is not completed",
+    );
+  });
+
   it("accepts only passing scenarios and explicit one-sided Codex-native gaps", () => {
     const fixture = summary([
       scenario({ name: "passing", status: "pass" }),


### PR DESCRIPTION
Related: #119957
Related: #120632

## What Problem This Solves

QA Lab could expose canonical valid-looking evidence from partial or replaced runs: isolated progress wrote canonical evidence, canonical readers accepted running or missing lifecycle state, and cleanup failure could leave terminal-looking artifacts.

`flow execution.timeoutMs` bounded optional preparation but not the complete YAML flow, so a hanging action could keep the suite alive indefinitely. Script-producer skipped evidence could also be swallowed as pass or projected as fail.

## Why This Change Was Made

This establishes one terminal contract: only `run.status=completed` is consumable; stale generations are invalidated before execution; progress remains explicitly running and never publishes canonical evidence; standard, isolated, and runtime-pair terminal artifacts publish only after cleanup succeeds; and the summary remains the last completion marker.

An explicit `execution.timeoutMs` is now one shared whole-flow deadline. It exposes `AbortSignal` to preparation and runtime, fences all later and nested actions after abort, preserves DSL `finally` cleanup, and lets the suite cleanup owner tear down runtime resources. In-flight JavaScript callables cancel cooperatively; this is not child-Gateway teardown, and that separately owned issue is excluded from this PR.

Script-producer precedence is now fail; blocking blocked; skipped; pass, preserving allowed blocked-plus-pass behavior while keeping skipped mixed evidence visible. Canonical CLI, confidence, parity, coverage, and plugin-gauntlet readers reject nonterminal summaries.

Open drafts #119957 and #120632 overlap canonical evidence lifecycle ownership. This PR intentionally must not merge until that cluster's owner decides consolidation or supersession. #125303 covers the outer workflow timeout budget only and is not a substitute for this function-level repair.

## User Impact

QA operators and release automation can no longer treat partial or interrupted runs as successful terminal evidence. Hanging flows terminate with honest failed scenario evidence, while skipped checks remain visible and blocking according to existing policy.

This is internal QA infrastructure only; no CHANGELOG entry is needed.

## Evidence

Pre-fix regression proof in `/tmp/qa-evidence-lifecycle-prefx.txt`: expected failure with 12 failures and 236 passes. The intended failures covered canonical readers accepting running, missing, and unsupported lifecycle state; confidence and character evaluation accepting incomplete summaries; running progress publishing canonical evidence; standard, isolated, and runtime-pair cleanup failures leaving terminal artifacts; a whole-flow deadline failing to bound a hanging action; pass-plus-skipped producer evidence becoming pass; and a skipped native producer becoming unified fail. The existing all-skipped producer case passed and remains preserved.

Pre-publication focused lifecycle proof: 519 tests passed. Follow-up focused proof: 113 tests passed and 25 tests passed. `node scripts/check-changed.mjs` passed all selected typecheck, lint, boundary, and guard lanes. `git diff --check` passed. Final Codex autoreview was clean with correctness 0.98.

Post-rebase proof on `a277409809bb59b80d4eb176e8a88d2543097255`:

```text
node scripts/run-vitest.mjs extensions/qa-lab/src/suite-summary.test.ts extensions/qa-lab/src/confidence-report.test.ts extensions/qa-lab/src/character-eval.test.ts extensions/qa-lab/src/cli.runtime.test.ts extensions/qa-lab/src/suite.test.ts extensions/qa-lab/src/suite-provider-selection.test.ts extensions/qa-lab/src/suite-run-isolated.cleanup.test.ts extensions/qa-lab/src/suite-run-standard.parity-retry.test.ts extensions/qa-lab/src/suite-runtime-parity-runner.cleanup.test.ts extensions/qa-lab/src/suite-runtime-flow.test.ts extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts extensions/qa-lab/src/test-file-scenario-runner.native.test.ts extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts extensions/qa-lab/src/suite-launch.runtime.test.ts test/scripts/plugin-gateway-gauntlet.test.ts test/scripts/validate-qa-runtime-pair-summary.test.ts test/scripts/npm-telegram-live.test.ts
PASS: 538 tests across 17 files

node scripts/check-changed.mjs
PASS: selected core, plugin, scripts, tooling, and test-support typecheck/lint/guard lanes

git diff --check origin/main...HEAD
PASS
```

The first exact-head CI run found one attributable stale test fixture: the Gateway CPU scenario harness emitted a synthetic QA summary without the newly required terminal status. Commit `06e7c9e0078e17d7429e55804f6c466ccd84c321` updated that fixture; its focused test passed 15/15, its changed gate passed, and a fresh autoreview was clean at 0.99.

Exact-head CI is green on `06e7c9e0078e17d7429e55804f6c466ccd84c321`: https://github.com/openclaw/openclaw/actions/runs/32291304176

Final branch LOC split: production/tooling `+429/-293` (net `+136`); tests/support `+618/-69` (net `+549`). Production growth owns the shared terminal-publication, stale-generation invalidation, canonical-reader, and whole-flow deadline contracts, replacing per-consumer acceptance and pre-cleanup publication behavior.

A real source-checkout QA product-path run on the exact head also passed through a real Gateway child and the deterministic mock provider:

```text
pnpm openclaw qa suite --provider-mode mock-openai --scenario channel-chat-baseline --output-dir .artifacts/qa-e2e/terminal-lifecycle-proof
PASS: run.status=completed; counts total=1 passed=1 failed=0 skipped=0; evidence entries=1; declared artifacts=2
```

No live provider or external channel run was performed. This is deterministic QA harness lifecycle behavior covered at its producer, cleanup, runner, and canonical-reader owner boundaries; it is not live authenticated proof.

AI-assisted. I reviewed the implementation and validation results. No prompts or transcripts are included.
