### PR TITLE
fix(ui): recover failed lazy surfaces

### DIFF
--- a/ui/config/control-ui-chunking.ts
+++ b/ui/config/control-ui-chunking.ts
@@ -14,17 +14,6 @@ function moduleIdIncludesPackage(id: string, packageName: string): boolean {
 export function controlUiStableChunkName(id: string): string | undefined {
   const normalized = normalizeModuleId(id);
 
-  // These entry-and-route helpers must stay together; separate shared chunks
-  // turn small route-graph changes into extra startup preload requests.
-  if (
-    normalized.endsWith("/ui/src/components/config-form.shared.ts") ||
-    normalized.endsWith("/ui/src/lib/clipboard.ts") ||
-    normalized.endsWith("/ui/src/build-info-normalizers.ts") ||
-    normalized.endsWith("/ui/src/build-info.ts")
-  ) {
-    return "control-ui-shared";
-  }
-
   if (normalized.endsWith("/ui/src/lib/gateway-methods.ts")) {
     return "gateway-runtime";
   }

--- a/ui/src/app/app-host.panel-toggles.test.ts
+++ b/ui/src/app/app-host.panel-toggles.test.ts
@@ -1,98 +1,64 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  BROWSER_PANEL_TOGGLE_EVENT,
-  CUSTODIAN_PANEL_TOGGLE_EVENT,
-  TERMINAL_PANEL_TOGGLE_EVENT,
-} from "../components/panel-toggle-contract.ts";
+import { TERMINAL_PANEL_TOGGLE_EVENT } from "../components/panel-toggle-contract.ts";
 import { takeSessionPanelToggle } from "../components/session-panel-toggle-buffer.ts";
+import { createStorageMock } from "../test-helpers/storage.ts";
 import {
   createLazyElementSpec,
   resetAppHostTestGlobals,
   type TestOptionalCustomElement,
 } from "./app-host.test-support.ts";
 import "./app-host.ts";
+import { ShellChromeOwner, type ShellChromeHost } from "./app-shell-chrome.ts";
 import type { ApplicationContext } from "./context.ts";
+import type { LazyCustomElementRequestController } from "./lazy-custom-element.ts";
+import { persistLazyShellAction, readLazyShellAction } from "./lazy-shell-action.ts";
 
 type ShellPanelToggleState = {
-  browserPanelElement: TestOptionalCustomElement;
-  custodianPanelElement: TestOptionalCustomElement;
-  handleDeferredBrowserToggle: (event: Event) => void;
-  handleDeferredCustodianToggle: (event: Event) => void;
-  handleDeferredTerminalToggle: (event: Event) => void;
+  lazyCustomElements: LazyCustomElementRequestController;
   routeState: { routeId: string };
   runtime: { context: ApplicationContext };
   terminalPanelElement: TestOptionalCustomElement;
 };
 
+function chromeOwner(shell: ShellPanelToggleState): ShellChromeOwner {
+  return new ShellChromeOwner(shell as unknown as ShellChromeHost);
+}
+
+function configureTerminalShell(terminalElement: TestOptionalCustomElement): ShellPanelToggleState {
+  window.history.replaceState(null, "", "/usage");
+  const shell = document.createElement("openclaw-app-shell") as unknown as ShellPanelToggleState;
+  shell.terminalPanelElement = terminalElement;
+  shell.routeState = { routeId: "usage" };
+  shell.runtime = {
+    context: {
+      gateway: {
+        snapshot: {
+          phase: "connected",
+          client: {},
+          hello: {
+            auth: { role: "operator", scopes: ["operator.admin"] },
+            features: { methods: ["terminal.open"] },
+          },
+        },
+      },
+      config: { current: { terminalEnabled: true } },
+    } as unknown as ApplicationContext,
+  };
+  Object.defineProperty(shell, "updateComplete", {
+    configurable: true,
+    get: () => Promise.resolve(true),
+  });
+  return shell;
+}
+
 afterEach(() => {
+  window.history.replaceState(null, "", "/");
   resetAppHostTestGlobals();
 });
 
 describe("OpenClaw shell panel toggles", () => {
-  it("delivers first panel toggles after their lazy modules load", async () => {
-    const terminalElement = createLazyElementSpec("terminal panel");
-    const browserElement = createLazyElementSpec("browser panel");
-    const custodianElement = createLazyElementSpec("custodian panel");
-    const terminalToggle = vi.fn();
-    const browserToggle = vi.fn();
-    const custodianToggle = vi.fn();
-    const shell = document.createElement("openclaw-app-shell") as unknown as ShellPanelToggleState;
-    shell.terminalPanelElement = terminalElement;
-    shell.browserPanelElement = browserElement;
-    shell.custodianPanelElement = custodianElement;
-    shell.runtime = {
-      context: {
-        gateway: {
-          snapshot: {
-            phase: "connected",
-            client: {},
-            hello: {
-              auth: { role: "operator", scopes: ["operator.admin"] },
-              features: { methods: ["terminal.open", "browser.request", "openclaw.chat"] },
-            },
-          },
-        },
-        config: { current: { terminalEnabled: true } },
-      } as unknown as ApplicationContext,
-    };
-    Object.defineProperty(shell, "updateComplete", {
-      configurable: true,
-      get: () => Promise.resolve(true),
-    });
-    Object.defineProperty(shell, "querySelector", {
-      configurable: true,
-      value: (selector: string) => {
-        if (selector === terminalElement.tagName) {
-          return { handleToggleRequest: terminalToggle };
-        }
-        if (selector === browserElement.tagName) {
-          return { handleToggleRequest: browserToggle };
-        }
-        if (selector === custodianElement.tagName) {
-          return { handleToggleRequest: custodianToggle };
-        }
-        return null;
-      },
-    });
-    const terminalEvent = new CustomEvent(TERMINAL_PANEL_TOGGLE_EVENT, {
-      detail: { dock: "right", open: true },
-    });
-    const browserEvent = new CustomEvent(BROWSER_PANEL_TOGGLE_EVENT);
-    const custodianEvent = new CustomEvent(CUSTODIAN_PANEL_TOGGLE_EVENT);
-
-    shell.handleDeferredTerminalToggle(terminalEvent);
-    shell.handleDeferredBrowserToggle(browserEvent);
-    shell.handleDeferredCustodianToggle(custodianEvent);
-
-    await vi.waitFor(() => {
-      expect(terminalToggle).toHaveBeenCalledWith(terminalEvent);
-      expect(browserToggle).toHaveBeenCalledWith(browserEvent);
-      expect(custodianToggle).toHaveBeenCalledWith(custodianEvent);
-    });
-  });
-
   it("buffers panel toggle events until the active chat pane mounts", () => {
     const terminalElement = createLazyElementSpec("session terminal panel");
     const shell = document.createElement("openclaw-app-shell") as unknown as ShellPanelToggleState;
@@ -100,9 +66,75 @@ describe("OpenClaw shell panel toggles", () => {
     shell.routeState = { routeId: "chat" };
 
     const event = new CustomEvent(TERMINAL_PANEL_TOGGLE_EVENT, { detail: { open: true } });
-    shell.handleDeferredTerminalToggle(event);
+    chromeOwner(shell).handleDeferredTerminalToggle(event);
 
     expect(customElements.get(terminalElement.tagName)).toBeUndefined();
     expect(takeSessionPanelToggle("terminal")).toBe(event);
+  });
+
+  it("retains the exact rejected panel request through in-place retry", async () => {
+    const error = new Error("terminal chunk unavailable");
+    const terminalElement = createLazyElementSpec("terminal panel", { firstError: error });
+    const terminalToggle = vi.fn();
+    const shell = configureTerminalShell(terminalElement);
+    const owner = chromeOwner(shell);
+    const event = new CustomEvent(TERMINAL_PANEL_TOGGLE_EVENT, {
+      detail: { dock: "right", open: true },
+    });
+    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, terminalToggle);
+
+    try {
+      owner.handleDeferredTerminalToggle(event);
+
+      await vi.waitFor(() => expect(shell.lazyCustomElements.visibleState?.status).toBe("error"));
+      expect(shell.lazyCustomElements.visibleState).toMatchObject({ error });
+      expect(terminalToggle).not.toHaveBeenCalled();
+
+      shell.lazyCustomElements.retry();
+
+      await vi.waitFor(() => expect(terminalToggle).toHaveBeenCalledOnce());
+    } finally {
+      window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, terminalToggle);
+    }
+    const delivered = terminalToggle.mock.calls[0]?.[0] as CustomEvent;
+    expect(delivered).not.toBe(event);
+    expect(delivered.type).toBe(TERMINAL_PANEL_TOGGLE_EVENT);
+    expect(delivered.detail).toEqual(event.detail);
+  });
+
+  it("restores a structured panel event once in a replacement shell", async () => {
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    const terminalElement = createLazyElementSpec("restored terminal");
+    const terminalToggle = vi.fn();
+    const detail = { dock: "right" as const, open: true, terminalSessionId: "terminal-1" };
+    persistLazyShellAction({
+      eventType: TERMINAL_PANEL_TOGGLE_EVENT,
+      detail,
+    });
+
+    const replacement = configureTerminalShell(terminalElement);
+    const owner = chromeOwner(replacement);
+    const restoreListener = (restored: Event) => owner.handleDeferredTerminalToggle(restored);
+    const panelListener = (restored: Event) => {
+      if (customElements.get(terminalElement.tagName)) {
+        terminalToggle(restored);
+      }
+    };
+    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, restoreListener);
+    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, panelListener);
+    try {
+      await vi.waitFor(() => {
+        owner.restorePendingLazyAction();
+        expect(terminalToggle).toHaveBeenCalledOnce();
+      });
+    } finally {
+      window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, restoreListener);
+      window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, panelListener);
+    }
+    const restored = terminalToggle.mock.calls[0]?.[0];
+    expect(restored).toBeInstanceOf(CustomEvent);
+    expect(restored?.type).toBe(TERMINAL_PANEL_TOGGLE_EVENT);
+    expect((restored as CustomEvent).detail).toEqual(detail);
+    expect(readLazyShellAction()).toBeNull();
   });
 });

--- a/ui/src/app/app-host.test-support.ts
+++ b/ui/src/app/app-host.test-support.ts
@@ -25,13 +25,21 @@ export type TestOptionalCustomElement = {
 
 let lazyElementSequence = 0;
 
-export function createLazyElementSpec(label: string): TestOptionalCustomElement {
+export function createLazyElementSpec(
+  label: string,
+  options: { firstError?: Error } = {},
+): TestOptionalCustomElement {
   lazyElementSequence += 1;
   const tagName = `openclaw-app-host-lazy-${lazyElementSequence}`;
+  let attempt = 0;
   return {
     tagName,
     label,
     loadModule: async () => {
+      attempt += 1;
+      if (attempt === 1 && options.firstError) {
+        throw options.firstError;
+      }
       customElements.define(tagName, class extends HTMLElement {});
     },
   };

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -30,7 +30,12 @@ import type {
   ApplicationGatewaySnapshot,
 } from "./context.ts";
 import "./app-host.ts";
-import { DEBUG_OVERLAY_ELEMENT } from "./lazy-custom-element.ts";
+import type { LazyCustomElementRequestController } from "./lazy-custom-element.ts";
+import {
+  persistLazyShellAction,
+  readLazyShellAction,
+  SHELL_APPROVALS_OPEN_EVENT,
+} from "./lazy-shell-action.ts";
 import { shouldMergeChatChrome } from "./mobile-nav-layout.ts";
 import { resolveOnboardingMode } from "./onboarding-mode.ts";
 import { resetServerUiPrefsSync } from "./server-prefs.ts";
@@ -78,14 +83,19 @@ type ShellServerPreferencesState = {
   reconcileServerUiPrefs: (runtimeConfig: ApplicationContext["runtimeConfig"]) => void;
 };
 
-type ShellLazySurfaceState = ShellKeyboardState & {
-  commandPaletteElement: TestOptionalCustomElement;
-};
+type ShellLifecycle = Pick<ShellChromeEventState, "connectedCallback" | "disconnectedCallback">;
 
-type ShellApprovalLazyState = {
-  approvalOverlay?: { show: () => void };
-  execApprovalElement: TestOptionalCustomElement;
-  openApprovals: () => void;
+type ShellLazySurfaceState = ShellKeyboardState &
+  ShellLifecycle & {
+    commandPaletteElement: TestOptionalCustomElement;
+    lazyCustomElements: LazyCustomElementRequestController;
+    openPalette: () => void;
+    restorePendingLazyAction: () => void;
+  };
+
+type ShellLazyLifecycleState = {
+  resetForContextEpoch: () => void;
+  resetForDocumentDisconnect: () => void;
 };
 
 type ShellUiCommandState = ShellKeyboardState & {
@@ -176,6 +186,35 @@ type ShellSettingsSearchLoadState = {
   };
   handleSettingsSearchQueryChange: (query: string) => Promise<void>;
 };
+
+function configureLazyPaletteShell(
+  element: TestOptionalCustomElement,
+  openPalette: () => void,
+): ShellLazySurfaceState {
+  const shell = document.createElement("openclaw-app-shell") as unknown as ShellLazySurfaceState;
+  shell.commandPaletteElement = element;
+  Object.defineProperty(shell, "updateComplete", {
+    configurable: true,
+    get: () => Promise.resolve(true),
+  });
+  Object.defineProperty(shell, "commandPalette", {
+    configurable: true,
+    get: () =>
+      customElements.get(element.tagName)
+        ? { isOpen: false, openPalette, togglePalette: vi.fn() }
+        : undefined,
+  });
+  return shell;
+}
+
+async function withConnectedShell(shell: ShellLifecycle, run: () => void | Promise<void>) {
+  shell.connectedCallback();
+  try {
+    await run();
+  } finally {
+    shell.disconnectedCallback();
+  }
+}
 
 afterEach(() => {
   resetAppHostTestGlobals();
@@ -279,6 +318,20 @@ describe("OpenClaw app lifecycle", () => {
 });
 
 describe("OpenClaw shell source initialization", () => {
+  it("preserves reload intent on disconnect but clears it on context replacement", () => {
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    persistLazyShellAction({ eventType: COMMAND_PALETTE_OPEN_EVENT });
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellLazyLifecycleState;
+
+    shell.resetForDocumentDisconnect();
+    expect(readLazyShellAction()).toEqual({ eventType: COMMAND_PALETTE_OPEN_EVENT });
+
+    shell.resetForContextEpoch();
+    expect(readLazyShellAction()).toBeNull();
+  });
+
   it("delegates repeated locale import failures to guarded stale-chunk recovery", () => {
     const scheduleReload = vi.mocked(scheduleStaleChunkReload);
     scheduleReload.mockClear();
@@ -820,28 +873,31 @@ describe("OpenClaw shell keyboard shortcuts", () => {
       value: { isOpen: false, openPalette, togglePalette: vi.fn() },
     });
 
-    shell.handleShellNavDrawerToggle(
-      new CustomEvent(SHELL_NAV_DRAWER_TOGGLE_EVENT, { detail: { trigger } }),
-    );
-    shell.openPalette();
+    const handlePaletteOpen = () => openPalette();
+    window.addEventListener(COMMAND_PALETTE_OPEN_EVENT, handlePaletteOpen);
+    try {
+      shell.handleShellNavDrawerToggle(
+        new CustomEvent(SHELL_NAV_DRAWER_TOGGLE_EVENT, { detail: { trigger } }),
+      );
+      shell.openPalette();
 
-    expect(shell.navDrawerOpen).toBe(true);
-    expect(openPalette).toHaveBeenCalledOnce();
+      expect(shell.navDrawerOpen).toBe(true);
+      expect(openPalette).toHaveBeenCalledOnce();
+    } finally {
+      window.removeEventListener(COMMAND_PALETTE_OPEN_EVENT, handlePaletteOpen);
+    }
   });
 
-  it("loads and toggles the command palette on its first shortcut", async () => {
+  it("normalizes an unloaded palette toggle shortcut to open", async () => {
     const element = createLazyElementSpec("command palette");
-    const togglePalette = vi.fn();
     const shell = document.createElement("openclaw-app-shell") as unknown as ShellLazySurfaceState;
     shell.commandPaletteElement = element;
-    Object.defineProperty(shell, "updateComplete", {
-      get: () => Promise.resolve(true),
-    });
+    const openPalette = vi.fn();
+    Object.defineProperty(shell, "updateComplete", { get: () => Promise.resolve(true) });
     Object.defineProperty(shell, "commandPalette", {
-      configurable: true,
       get: () =>
         customElements.get(element.tagName)
-          ? { isOpen: false, openPalette: vi.fn(), togglePalette }
+          ? { isOpen: false, openPalette, togglePalette: vi.fn() }
           : undefined,
     });
     const event = new KeyboardEvent("keydown", {
@@ -854,66 +910,44 @@ describe("OpenClaw shell keyboard shortcuts", () => {
     shell.handleDocumentKeydown(event);
 
     expect(event.defaultPrevented).toBe(true);
-    await vi.waitFor(() => expect(togglePalette).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(openPalette).toHaveBeenCalledOnce());
   });
 
-  it("loads the debug overlay shortcut and ignores editable targets", async () => {
-    const toggled = vi.fn();
-    const shell = document.createElement("openclaw-app-shell") as unknown as ShellKeyboardState &
-      HTMLElement;
-    const overlay = document.createElement(DEBUG_OVERLAY_ELEMENT.tagName) as HTMLElement & {
-      toggle: () => void;
-    };
-    overlay.toggle = toggled;
-    shell.append(overlay);
-    Object.defineProperty(shell, "updateComplete", {
-      get: () => Promise.resolve(true),
+  it("clears a rejected command palette action on Close", async () => {
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    const element = createLazyElementSpec("cancelled command palette", {
+      firstError: new Error("command palette chunk unavailable"),
     });
-    const shortcut = new KeyboardEvent("keydown", {
-      key: "d",
-      code: "KeyD",
-      ctrlKey: true,
-      shiftKey: true,
-      cancelable: true,
+    const openPalette = vi.fn();
+    const shell = configureLazyPaletteShell(element, openPalette);
+
+    await withConnectedShell(shell, async () => {
+      shell.openPalette();
+      await vi.waitFor(() => expect(shell.lazyCustomElements.visibleState?.status).toBe("error"));
+      shell.lazyCustomElements.close();
+
+      expect(readLazyShellAction()).toBeNull();
+      const replacement = configureLazyPaletteShell(element, openPalette);
+      replacement.restorePendingLazyAction();
+      await Promise.resolve();
+      expect(openPalette).not.toHaveBeenCalled();
     });
-    shell.handleDocumentKeydown(shortcut);
-
-    expect(shortcut.defaultPrevented).toBe(true);
-    await vi.waitFor(() => expect(toggled).toHaveBeenCalledOnce());
-
-    const input = document.body.appendChild(document.createElement("input"));
-    input.addEventListener("keydown", (event) => shell.handleDocumentKeydown(event));
-    const editableShortcut = new KeyboardEvent("keydown", {
-      key: "d",
-      code: "KeyD",
-      ctrlKey: true,
-      shiftKey: true,
-      bubbles: true,
-      cancelable: true,
-    });
-    input.dispatchEvent(editableShortcut);
-
-    expect(editableShortcut.defaultPrevented).toBe(false);
-    expect(toggled).toHaveBeenCalledOnce();
   });
 
-  it("opens approvals after the modal module loads on demand", async () => {
-    const element = createLazyElementSpec("exec approval modal");
-    const show = vi.fn();
-    const shell = document.createElement("openclaw-app-shell") as unknown as ShellApprovalLazyState;
-    shell.execApprovalElement = element;
-    Object.defineProperty(shell, "updateComplete", {
-      configurable: true,
-      get: () => Promise.resolve(true),
-    });
-    Object.defineProperty(shell, "approvalOverlay", {
-      configurable: true,
-      get: () => (customElements.get(element.tagName) ? { show } : undefined),
-    });
+  it("does not clear an unrelated pending action from an already-loaded palette", async () => {
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    persistLazyShellAction({ eventType: SHELL_APPROVALS_OPEN_EVENT });
+    const element = createLazyElementSpec("loaded command palette");
+    customElements.define(element.tagName, class extends HTMLElement {});
+    const openPalette = vi.fn();
+    const shell = configureLazyPaletteShell(element, openPalette);
 
-    shell.openApprovals();
+    await withConnectedShell(shell, () => {
+      shell.openPalette();
 
-    await vi.waitFor(() => expect(show).toHaveBeenCalledOnce());
+      expect(openPalette).toHaveBeenCalledOnce();
+      expect(readLazyShellAction()).toEqual({ eventType: SHELL_APPROVALS_OPEN_EVENT });
+    });
   });
 
   it("routes UI commands to navigation, panels, and chat fallback", () => {

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -67,9 +67,10 @@ import {
   CUSTODIAN_PANEL_ELEMENT,
   DESKTOP_PANEL_ELEMENT,
   EXEC_APPROVAL_ELEMENT,
-  preloadOptionalElement,
+  LazyCustomElementRequestController,
   TERMINAL_PANEL_ELEMENT,
 } from "./lazy-custom-element.ts";
+import { hasStoredLazyShellAction } from "./lazy-shell-action.ts";
 import { postNativeNavState, type NativeNavState } from "./native-nav-state.ts";
 import { readNativeHistoryState, type NativeHistoryState } from "./native-web-chrome.ts";
 import { resolveOnboardingMode } from "./onboarding-mode.ts";
@@ -79,7 +80,11 @@ import {
   pushServerUiPrefs,
 } from "./server-prefs.ts";
 import { setSettingsChangeListener } from "./settings.ts";
-import { isStaleChunkImportError, scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
+import {
+  isStaleChunkImportError,
+  retryStaleChunkReloadWhenReachable,
+  scheduleStaleChunkReload,
+} from "./stale-chunk-reload.ts";
 
 type AppSidebarElement = HTMLElement & {
   dismissTransientMenus: () => boolean;
@@ -137,6 +142,12 @@ class OpenClawShell
   readonly desktopPanelElement = DESKTOP_PANEL_ELEMENT;
   readonly custodianPanelElement = CUSTODIAN_PANEL_ELEMENT;
   readonly execApprovalElement = EXEC_APPROVAL_ELEMENT;
+  readonly lazyCustomElements = new LazyCustomElementRequestController(
+    this,
+    () => this.shellChrome.cancelPendingLazyAction(),
+    () =>
+      hasStoredLazyShellAction() ? retryStaleChunkReloadWhenReachable() : Promise.resolve(false),
+  );
   @query("openclaw-command-palette") commandPalette: CommandPaletteElement | undefined;
   @query("openclaw-exec-approval")
   approvalOverlay: (HTMLElement & { show(): void; dialogOpen?: boolean }) | undefined;
@@ -285,12 +296,16 @@ class OpenClawShell
     this.subscriptions
       .effect(
         () => this.context,
-        () => {
+        (context) => {
           if (this.pendingNativeNewSession) {
             this.pendingNativeNewSession = false;
             this.handleNativeNewSession();
           }
-          return () => this.resetShellEpochState();
+          return () => {
+            if (this.context !== context) {
+              this.resetForContextEpoch();
+            }
+          };
         },
       )
       .watch(
@@ -418,7 +433,7 @@ class OpenClawShell
     this.outboxStoreUnsubscribe = null;
     this.lastLocalePrefSignature = null;
     setSettingsChangeListener(null);
-    this.resetShellEpochState();
+    this.resetForDocumentDisconnect();
     super.disconnectedCallback();
   }
 
@@ -434,7 +449,17 @@ class OpenClawShell
     this.requestUpdate();
   }
 
-  private resetShellEpochState() {
+  private resetForContextEpoch() {
+    this.shellChrome.abandonPendingLazyActionForContext();
+    this.resetShellState();
+  }
+
+  private resetForDocumentDisconnect() {
+    this.shellChrome.preservePendingLazyActionForReload();
+    this.resetShellState();
+  }
+
+  private resetShellState() {
     this.navDrawerOpen = false;
     this.desktopNavigationExpanded = false;
     this.navDrawerTrigger = null;
@@ -557,14 +582,9 @@ class OpenClawShell
   readonly handleShellNavDrawerToggle = (event: Event) =>
     this.shellChrome.handleShellNavDrawerToggle(event);
   readonly openApprovals = () => this.shellChrome.openApprovals();
-  readonly handleDeferredTerminalToggle = (event: Event) =>
-    this.shellChrome.handleDeferredTerminalToggle(event);
-  readonly handleDeferredBrowserToggle = (event: Event) =>
-    this.shellChrome.handleDeferredBrowserToggle(event);
-  readonly handleDeferredCustodianToggle = (event: Event) =>
-    this.shellChrome.handleDeferredCustodianToggle(event);
   readonly handleCommandPaletteSlashCommand = (command: string) =>
     this.shellChrome.handleCommandPaletteSlashCommand(command);
+  readonly restorePendingLazyAction = () => this.shellChrome.restorePendingLazyAction();
 
   nativeNavCollapsed(): boolean {
     return this.shellChrome.nativeNavCollapsed();
@@ -622,21 +642,22 @@ class OpenClawShell
         this.commandPalette.custodianAvailable = custodianAvailable;
       }
       if (isTerminalAvailable(gatewaySnapshot, context.config?.current.terminalEnabled ?? false)) {
-        preloadOptionalElement(this, this.terminalPanelElement);
+        this.lazyCustomElements.preload(this.terminalPanelElement);
       }
       if (isBrowserPanelAvailable(gatewaySnapshot)) {
-        preloadOptionalElement(this, this.browserPanelElement);
+        this.lazyCustomElements.preload(this.browserPanelElement);
       }
       if (desktopAvailable) {
-        preloadOptionalElement(this, this.desktopPanelElement);
+        this.lazyCustomElements.preload(this.desktopPanelElement);
       }
       if (custodianAvailable) {
-        preloadOptionalElement(this, this.custodianPanelElement);
+        this.lazyCustomElements.preload(this.custodianPanelElement);
       }
     }
     if ((context.overlays?.snapshot.approvalQueue.length ?? 0) > 0) {
-      preloadOptionalElement(this, this.execApprovalElement);
+      this.lazyCustomElements.preload(this.execApprovalElement);
     }
+    this.restorePendingLazyAction();
     const navState = {
       collapsed: this.nativeNavCollapsed(),
       width: context.navigation.snapshot.navWidth,

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -9,6 +9,7 @@ import "../components/gateway-url-confirmation.ts";
 import "../components/github-link-hovercard-registration.ts";
 import "../components/login-gate.ts";
 import "../components/openclaw-mascot.ts";
+import { renderLazyElementState } from "../components/lazy-view-error.ts";
 import { installNativeTitleGuard } from "../components/tooltip.ts";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
@@ -25,11 +26,11 @@ import {
   DASHBOARD_DOCUMENT_ELEMENT,
   DESKTOP_PANEL_ELEMENT,
   isOptionalElementDefined,
-  preloadOptionalElement,
+  LazyCustomElementRequestController,
+  type OptionalCustomElement,
   TERMINAL_PANEL_ELEMENT,
 } from "./lazy-custom-element.ts";
 import { resolveOnboardingMode } from "./onboarding-mode.ts";
-import { controlUiPublicAssetPath } from "./public-assets.ts";
 
 type FocusDashboardRouteState =
   | { kind: "loading" }
@@ -64,25 +65,6 @@ function renderConnectingSplash(status?: string) {
   `;
 }
 
-function renderApprovalDocument(runtime: ApplicationRuntime) {
-  const documentMode = runtime.documentMode;
-  if (documentMode?.kind !== "approval") {
-    return nothing;
-  }
-  return html`
-    <openclaw-approval-page .approvalId=${documentMode.approvalId ?? ""}>
-      <main class="approval-page approval-page--booting" role="status" aria-live="polite">
-        <img
-          class="connect-splash__logo"
-          src=${controlUiPublicAssetPath("favicon.svg", runtime.context.resourceBasePath)}
-          alt=""
-        />
-        <span>${t("common.loading")}</span>
-      </main>
-    </openclaw-approval-page>
-  `;
-}
-
 export class OpenClawApp extends OpenClawLightDomElement {
   // Pinned while a connect submitted from the visible login gate is in
   // flight, so a failed manual attempt cannot flash the shell in between.
@@ -104,6 +86,9 @@ export class OpenClawApp extends OpenClawLightDomElement {
   private loginGatewaySource: ApplicationContext["gateway"] | null = null;
   private loginConnectionClient: GatewayBrowserClient | null = null;
   private focusDashboardAbort: AbortController | null = null;
+  private readonly lazyCustomElements = new LazyCustomElementRequestController(this, () =>
+    this.closeDocument(this.context?.basePath ?? ""),
+  );
 
   private get context(): ApplicationContext<RouteId> | undefined {
     return this.runtime?.context;
@@ -145,16 +130,16 @@ export class OpenClawApp extends OpenClawLightDomElement {
     this.runtime = bootstrapApplication();
     const focusTarget = this.focusTarget;
     if (focusTarget?.kind === "terminal") {
-      preloadOptionalElement(this, TERMINAL_PANEL_ELEMENT);
+      this.requestLazyDocument(TERMINAL_PANEL_ELEMENT);
     }
     if (focusTarget?.kind === "desktop") {
-      preloadOptionalElement(this, DESKTOP_PANEL_ELEMENT);
+      this.requestLazyDocument(DESKTOP_PANEL_ELEMENT);
     }
     if (focusTarget?.kind === "dashboard") {
-      preloadOptionalElement(this, DASHBOARD_DOCUMENT_ELEMENT);
+      this.requestLazyDocument(DASHBOARD_DOCUMENT_ELEMENT);
     }
     if (this.runtime.documentMode?.kind === "approval") {
-      preloadOptionalElement(this, APPROVAL_PAGE_ELEMENT);
+      this.requestLazyDocument(APPROVAL_PAGE_ELEMENT);
     }
     const context = this.runtime.context;
     this.pendingGatewayUrl = this.runtime.pendingGatewayConnection?.gatewayUrl ?? null;
@@ -178,6 +163,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
     this.subscriptions.clear();
     this.focusDashboardAbort?.abort();
     this.focusDashboardAbort = null;
+    this.lazyCustomElements.abandon();
     this.runtime?.stop();
     this.runtime = undefined;
     this.loginGatewaySource = null;
@@ -245,6 +231,36 @@ export class OpenClawApp extends OpenClawLightDomElement {
     >
       ${label}
     </button>`;
+  }
+
+  private requestLazyDocument(element: OptionalCustomElement): void {
+    if (!isOptionalElementDefined(element)) {
+      this.lazyCustomElements.request(element);
+    }
+  }
+
+  private renderLazyDocumentState(element: OptionalCustomElement) {
+    const lazyState = this.lazyCustomElements.visibleState;
+    if (!lazyState || lazyState.element !== element) {
+      return nothing;
+    }
+    return html`<main class="connect-splash">
+      ${renderLazyElementState(
+        lazyState,
+        () => this.lazyCustomElements.retry(),
+        () => this.lazyCustomElements.close(),
+      )}
+    </main>`;
+  }
+
+  private renderApprovalDocument(runtime: ApplicationRuntime) {
+    const lazyState = this.lazyCustomElements.visibleState;
+    if (lazyState?.element === APPROVAL_PAGE_ELEMENT) {
+      return this.renderLazyDocumentState(APPROVAL_PAGE_ELEMENT);
+    }
+    const approvalId =
+      runtime.documentMode?.kind === "approval" ? runtime.documentMode.approvalId : "";
+    return html`<openclaw-approval-page .approvalId=${approvalId ?? ""}></openclaw-approval-page>`;
   }
 
   private replaceFocusDashboardLocation(location: RouteLocation, source: RouteLocation): void {
@@ -384,9 +400,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
       ${!gatewayConnected && gatewaySnapshot.lastError === null
         ? renderConnectingSplash(gatewayStartupStatus)
         : nothing}
-      ${!isOptionalElementDefined(DASHBOARD_DOCUMENT_ELEMENT) && gatewayConnected
-        ? renderConnectingSplash(gatewayStartupStatus)
-        : nothing}
+      ${gatewayConnected ? this.renderLazyDocumentState(DASHBOARD_DOCUMENT_ELEMENT) : nothing}
     `;
   }
 
@@ -448,9 +462,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
         ${!gatewayConnected && gatewaySnapshot.lastError === null
           ? renderConnectingSplash(gatewayStartupStatus)
           : nothing}
-        ${!isOptionalElementDefined(TERMINAL_PANEL_ELEMENT) && terminalAvailable
-          ? renderConnectingSplash(gatewayStartupStatus)
-          : nothing}
+        ${terminalAvailable ? this.renderLazyDocumentState(TERMINAL_PANEL_ELEMENT) : nothing}
         ${!terminalAvailable && (gatewayConnected || gatewaySnapshot.lastError)
           ? html`<div class="terminal-view-unavailable">
               <div class="stack">
@@ -481,9 +493,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
         ${!gatewayConnected && gatewaySnapshot.lastError === null
           ? renderConnectingSplash(gatewayStartupStatus)
           : nothing}
-        ${!isOptionalElementDefined(DESKTOP_PANEL_ELEMENT) && desktopAvailable
-          ? renderConnectingSplash(gatewayStartupStatus)
-          : nothing}
+        ${desktopAvailable ? this.renderLazyDocumentState(DESKTOP_PANEL_ELEMENT) : nothing}
         ${!desktopAvailable && (gatewayConnected || gatewaySnapshot.lastError)
           ? html`<div class="desktop-view-unavailable">
               <div class="stack">
@@ -564,7 +574,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
     if (runtime.documentMode?.kind === "approval") {
       return html`
         <openclaw-tooltip-provider>
-          ${gatewayUrlConfirmation} ${renderApprovalDocument(runtime)}
+          ${gatewayUrlConfirmation} ${this.renderApprovalDocument(runtime)}
         </openclaw-tooltip-provider>
       `;
     }

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -17,7 +17,6 @@ import {
   DESKTOP_PANEL_TOGGLE_EVENT,
   isTerminalPanelShortcut,
   TERMINAL_PANEL_TOGGLE_EVENT,
-  type PanelToggleElement,
 } from "../components/panel-toggle-contract.ts";
 import { rememberSessionPanelToggle } from "../components/session-panel-toggle-buffer.ts";
 import type { BoardFace } from "../lib/board/settings.ts";
@@ -29,10 +28,18 @@ import type { ShellRouteState } from "./app-host-route-state.ts";
 import type { ApplicationContext, ApplicationNavigationOptions } from "./context.ts";
 import {
   DEBUG_OVERLAY_ELEMENT,
-  ensureOptionalElementForHost,
   isOptionalElementDefined,
+  type LazyCustomElementRequestController,
   type OptionalCustomElement,
 } from "./lazy-custom-element.ts";
+import {
+  clearLazyShellAction,
+  lazyShellEvent,
+  persistLazyShellAction,
+  readLazyShellAction,
+  SHELL_APPROVALS_OPEN_EVENT,
+  type LazyShellEvent,
+} from "./lazy-shell-action.ts";
 import { isMobileNavLayout } from "./mobile-nav-layout.ts";
 import {
   NATIVE_HISTORY_STATE_EVENT,
@@ -75,6 +82,7 @@ export interface ShellChromeHost extends HTMLElement {
   readonly activeSessionKey: string;
   readonly onboardingMode: boolean;
   readonly updateComplete: Promise<boolean>;
+  readonly lazyCustomElements: LazyCustomElementRequestController;
   readonly commandPaletteElement: OptionalCustomElement;
   readonly terminalPanelElement: OptionalCustomElement;
   readonly browserPanelElement: OptionalCustomElement;
@@ -102,6 +110,8 @@ export interface ShellChromeHost extends HTMLElement {
 }
 
 export class ShellChromeOwner {
+  private pendingLazyAction = readLazyShellAction();
+
   constructor(private readonly host: ShellChromeHost) {}
 
   private isSessionRoute(): boolean {
@@ -116,7 +126,7 @@ export class ShellChromeOwner {
     const host = this.host;
     host.nativeHistoryState = readNativeHistoryState();
     host.addEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget);
-    window.addEventListener(COMMAND_PALETTE_OPEN_EVENT, this.openPalette);
+    window.addEventListener(COMMAND_PALETTE_OPEN_EVENT, this.handleCommandPaletteOpen);
     window.addEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, this.handleShellNavDrawerToggle);
     window.addEventListener(DEBUG_OVERLAY_REQUEST_EVENT, this.handleDebugOverlayRequest);
     document.addEventListener("keydown", this.handleDocumentKeydown);
@@ -134,12 +144,13 @@ export class ShellChromeOwner {
     window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     window.addEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle);
     window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
+    window.addEventListener(SHELL_APPROVALS_OPEN_EVENT, this.handleApprovalsOpen);
   }
 
   disconnect(): void {
     const host = this.host;
     host.removeEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget);
-    window.removeEventListener(COMMAND_PALETTE_OPEN_EVENT, this.openPalette);
+    window.removeEventListener(COMMAND_PALETTE_OPEN_EVENT, this.handleCommandPaletteOpen);
     window.removeEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, this.handleShellNavDrawerToggle);
     window.removeEventListener(DEBUG_OVERLAY_REQUEST_EVENT, this.handleDebugOverlayRequest);
     document.removeEventListener("keydown", this.handleDocumentKeydown);
@@ -156,6 +167,7 @@ export class ShellChromeOwner {
     window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
     window.removeEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle);
     window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
+    window.removeEventListener(SHELL_APPROVALS_OPEN_EVENT, this.handleApprovalsOpen);
   }
 
   toggleNavigationSurface(trigger?: HTMLElement): void {
@@ -379,7 +391,7 @@ export class ShellChromeOwner {
       isTerminalPanelShortcut(event)
     ) {
       event.preventDefault();
-      this.handleDeferredTerminalToggle(new CustomEvent(TERMINAL_PANEL_TOGGLE_EVENT));
+      window.dispatchEvent(new CustomEvent(TERMINAL_PANEL_TOGGLE_EVENT));
       return;
     }
     if (event.defaultPrevented) {
@@ -395,7 +407,7 @@ export class ShellChromeOwner {
         return;
       }
       event.preventDefault();
-      this.toggleDebugOverlay();
+      window.dispatchEvent(new CustomEvent(DEBUG_OVERLAY_REQUEST_EVENT));
       return;
     }
     const plainKey = !event.altKey && !event.shiftKey && !event.metaKey && !event.ctrlKey;
@@ -424,19 +436,16 @@ export class ShellChromeOwner {
     }
   };
 
-  private readonly handleDebugOverlayRequest = (): void => {
-    this.toggleDebugOverlay();
-  };
-
-  private toggleDebugOverlay(): void {
+  private readonly handleDebugOverlayRequest = (event: Event): void => {
     const host = this.host;
-    void ensureOptionalElementForHost(host, DEBUG_OVERLAY_ELEMENT)
-      .then(async () => {
-        await host.updateComplete;
-        host.querySelector<DebugOverlayElement>(DEBUG_OVERLAY_ELEMENT.tagName)?.toggle();
-      })
-      .catch(() => undefined);
-  }
+    const descriptor = lazyShellEvent(DEBUG_OVERLAY_REQUEST_EVENT, event);
+    if (isOptionalElementDefined(DEBUG_OVERLAY_ELEMENT)) {
+      host.querySelector<DebugOverlayElement>(DEBUG_OVERLAY_ELEMENT.tagName)?.toggle();
+      this.clearPendingLazyAction(descriptor);
+      return;
+    }
+    this.requestLazyElement(DEBUG_OVERLAY_ELEMENT, descriptor);
+  };
 
   /** Open overlays and editable controls own Escape before settings can exit. */
   shouldIgnoreSettingsEscape(event: KeyboardEvent): boolean {
@@ -459,26 +468,20 @@ export class ShellChromeOwner {
     );
   }
 
-  runWithCommandPalette(action: (palette: CommandPaletteElement) => void): void {
+  private readonly handleCommandPaletteOpen = (event: Event, replay?: () => void): void => {
     const host = this.host;
     const palette = host.commandPalette;
+    const descriptor = lazyShellEvent(COMMAND_PALETTE_OPEN_EVENT, event);
     if (palette) {
-      action(palette);
+      palette.openPalette();
+      this.clearPendingLazyAction(descriptor);
       return;
     }
-    void ensureOptionalElementForHost(host, host.commandPaletteElement)
-      .then(async () => {
-        await host.updateComplete;
-        const loadedPalette = host.commandPalette;
-        if (loadedPalette) {
-          action(loadedPalette);
-        }
-      })
-      .catch(() => undefined);
-  }
+    this.requestLazyElement(host.commandPaletteElement, descriptor, replay);
+  };
 
   readonly openPalette = (): void => {
-    this.runWithCommandPalette((palette) => palette.openPalette());
+    this.handleCommandPaletteOpen(new CustomEvent(COMMAND_PALETTE_OPEN_EVENT), this.openPalette);
   };
 
   readonly refreshControlUi = (): void => {
@@ -491,34 +494,28 @@ export class ShellChromeOwner {
   };
 
   readonly togglePalette = (): void => {
-    this.runWithCommandPalette((palette) => palette.togglePalette());
+    const palette = this.host.commandPalette;
+    if (palette) {
+      palette.togglePalette();
+    } else {
+      this.openPalette();
+    }
   };
 
   readonly openApprovals = (): void => {
-    const host = this.host;
-    const show = () => host.approvalOverlay?.show();
-    if (isOptionalElementDefined(host.execApprovalElement)) {
-      show();
-      return;
-    }
-    void ensureOptionalElementForHost(host, host.execApprovalElement)
-      .then(async () => {
-        await host.updateComplete;
-        show();
-      })
-      .catch(() => undefined);
+    window.dispatchEvent(new CustomEvent(SHELL_APPROVALS_OPEN_EVENT));
   };
 
-  deliverPanelEventAfterLoad(element: OptionalCustomElement, event: Event): void {
+  private readonly handleApprovalsOpen = (event: Event): void => {
     const host = this.host;
-    void ensureOptionalElementForHost(host, element)
-      .then(async () => {
-        // Wait for the host to apply availability after defining the mounted tag.
-        await host.updateComplete;
-        host.querySelector<PanelToggleElement>(element.tagName)?.handleToggleRequest(event);
-      })
-      .catch(() => undefined);
-  }
+    const descriptor = lazyShellEvent(SHELL_APPROVALS_OPEN_EVENT, event);
+    if (isOptionalElementDefined(host.execApprovalElement)) {
+      host.approvalOverlay?.show();
+      this.clearPendingLazyAction(descriptor);
+      return;
+    }
+    this.requestLazyElement(host.execApprovalElement, descriptor);
+  };
 
   readonly handleDeferredTerminalToggle = (event: Event): void => {
     const host = this.host;
@@ -535,9 +532,13 @@ export class ShellChromeOwner {
       !snapshot ||
       !isTerminalAvailable(snapshot, context.config.current.terminalEnabled ?? false)
     ) {
+      event.preventDefault();
       return;
     }
-    this.deliverPanelEventAfterLoad(host.terminalPanelElement, event);
+    this.requestLazyElement(
+      host.terminalPanelElement,
+      lazyShellEvent(TERMINAL_PANEL_TOGGLE_EVENT, event),
+    );
   };
 
   readonly handleDeferredBrowserToggle = (event: Event): void => {
@@ -551,7 +552,12 @@ export class ShellChromeOwner {
     }
     const snapshot = host.context?.gateway?.snapshot;
     if (snapshot && isBrowserPanelAvailable(snapshot)) {
-      this.deliverPanelEventAfterLoad(host.browserPanelElement, event);
+      this.requestLazyElement(
+        host.browserPanelElement,
+        lazyShellEvent(BROWSER_PANEL_TOGGLE_EVENT, event),
+      );
+    } else {
+      event.preventDefault();
     }
   };
 
@@ -563,13 +569,17 @@ export class ShellChromeOwner {
     }
     const context = host.context;
     if (!context || !isDesktopPanelAvailable(context.gateway.snapshot)) {
+      event.preventDefault();
       event.stopImmediatePropagation();
       return;
     }
     if (isOptionalElementDefined(host.desktopPanelElement)) {
       return;
     }
-    this.deliverPanelEventAfterLoad(host.desktopPanelElement, event);
+    this.requestLazyElement(
+      host.desktopPanelElement,
+      lazyShellEvent(DESKTOP_PANEL_TOGGLE_EVENT, event),
+    );
   };
 
   readonly handleDeferredCustodianToggle = (event: Event): void => {
@@ -579,9 +589,70 @@ export class ShellChromeOwner {
     }
     const snapshot = host.context?.gateway?.snapshot;
     if (canCallGatewayMethod(snapshot, "openclaw.chat", "operator.admin")) {
-      this.deliverPanelEventAfterLoad(host.custodianPanelElement, event);
+      this.requestLazyElement(
+        host.custodianPanelElement,
+        lazyShellEvent(CUSTODIAN_PANEL_TOGGLE_EVENT, event),
+      );
+    } else {
+      event.preventDefault();
     }
   };
+
+  restorePendingLazyAction(): void {
+    const event = this.pendingLazyAction;
+    if (
+      event &&
+      !this.host.lazyCustomElements.visibleState &&
+      this.dispatchLazyShellEvent(event) &&
+      !this.host.lazyCustomElements.visibleState
+    ) {
+      this.clearPendingLazyAction(event);
+    }
+  }
+
+  private requestLazyElement(
+    element: OptionalCustomElement,
+    event: LazyShellEvent,
+    replay: () => unknown = () => this.dispatchLazyShellEvent(event),
+  ): void {
+    this.pendingLazyAction = event;
+    persistLazyShellAction(event);
+    this.host.lazyCustomElements.request(element, () => {
+      replay();
+      this.clearPendingLazyAction(event);
+    });
+  }
+
+  private dispatchLazyShellEvent(event: LazyShellEvent): boolean {
+    return window.dispatchEvent(
+      new CustomEvent(event.eventType, { cancelable: true, detail: event.detail }),
+    );
+  }
+
+  private clearPendingLazyAction(event: LazyShellEvent): void {
+    if (JSON.stringify(this.pendingLazyAction) !== JSON.stringify(event)) {
+      return;
+    }
+    clearLazyShellAction();
+    this.pendingLazyAction = null;
+  }
+
+  cancelPendingLazyAction(): void {
+    const event = this.pendingLazyAction;
+    if (event) {
+      this.clearPendingLazyAction(event);
+    }
+  }
+
+  abandonPendingLazyActionForContext(): void {
+    this.pendingLazyAction = null;
+    clearLazyShellAction();
+    this.host.lazyCustomElements.abandon();
+  }
+
+  preservePendingLazyActionForReload(): void {
+    this.host.lazyCustomElements.abandon();
+  }
 
   readonly handleCommandPaletteSlashCommand = (command: string): void => {
     const host = this.host;

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -7,6 +7,7 @@ import type {
   SidebarWorkboardSnapshot,
 } from "../components/app-sidebar-workboard.ts";
 import { icons } from "../components/icons.ts";
+import { renderLazyElementModal } from "../components/lazy-view-error.ts";
 import { CUSTODIAN_PANEL_TOGGLE_EVENT } from "../components/panel-toggle-contract.ts";
 import {
   renderLazySettingsSidebar,
@@ -34,8 +35,8 @@ import {
 } from "./device-scope-upgrade.ts";
 import {
   DEBUG_OVERLAY_ELEMENT,
-  ensureOptionalElementForHost,
   isOptionalElementDefined,
+  type LazyCustomElementRequestController,
   type OptionalCustomElement,
 } from "./lazy-custom-element.ts";
 import { isMobileNavLayout, shouldMergeChatChrome } from "./mobile-nav-layout.ts";
@@ -51,7 +52,6 @@ import {
 } from "./settings.ts";
 import type { UpdateProgress } from "./update-confirmation.ts";
 
-const EMPTY_OUTBOX_ATTENTION_COUNT_FOR_SESSION = () => 0;
 const EMPTY_SESSION_HAS_DRAFT = () => false;
 const PALETTE_SHORTCUT = /Mac|iP(hone|ad|od)/i.test(globalThis.navigator?.platform ?? "")
   ? "⌘K"
@@ -74,7 +74,7 @@ function renderScopeUpgradeBanner(
   ) {
     return nothing;
   }
-  void ensureOptionalElementForHost(host, SCOPE_UPGRADE_BANNER_ELEMENT).catch(() => undefined);
+  host.lazyCustomElements.preload(SCOPE_UPGRADE_BANNER_ELEMENT);
   if (isOptionalElementDefined(SCOPE_UPGRADE_BANNER_ELEMENT)) {
     return html`<openclaw-device-scope-upgrade-banner
       .props=${{
@@ -100,6 +100,7 @@ export interface ShellViewHost {
   readonly custodianMinimizeRequestId: number;
   readonly desktopNavigationExpanded: boolean;
   readonly execApprovalElement: OptionalCustomElement;
+  readonly lazyCustomElements: LazyCustomElementRequestController;
   readonly nativeHistoryState: NativeHistoryState;
   readonly navDrawerOpen: boolean;
   readonly navigationSidebar: HTMLElement;
@@ -245,7 +246,7 @@ export function renderApplicationShell(host: ShellViewHost) {
         const scopeKey = outboxStoreRuntime.storedChatOutboxScopeKey(scope);
         return storedOutboxes?.attentionCountsByScope.get(scopeKey) ?? 0;
       }
-    : EMPTY_OUTBOX_ATTENTION_COUNT_FOR_SESSION;
+    : () => 0;
   const hasSessionDraft = outboxStoreRuntime
     ? (sessionKey: string) => {
         const scope = outboxStoreRuntime.resolveStoredChatOutboxScope(outboxScopeHost, sessionKey);
@@ -482,6 +483,7 @@ export function renderApplicationShell(host: ShellViewHost) {
   // Optional tags stay mounted before definition. Lit replays their properties on upgrade,
   // and the upgraded panels catch the first toggle instead of dropping the event.
   return html`
+    ${renderLazyElementModal(host.lazyCustomElements)}
     ${isOptionalElementDefined(host.commandPaletteElement)
       ? html`<openclaw-command-palette
           .onNavigate=${(routeId: RouteId) => host.navigate(routeId)}

--- a/ui/src/app/control-ui-chunking.test.ts
+++ b/ui/src/app/control-ui-chunking.test.ts
@@ -28,14 +28,12 @@ describe("Control UI build chunking", () => {
         "/tmp/openclaw-pnpm-node-modules/libphonenumber-js/max/exports/parsePhoneNumber.js",
       ),
     ).toBe("config-runtime");
-    expect(controlUiStableChunkName("/repo/ui/src/components/config-form.shared.ts")).toBe(
-      "control-ui-shared",
-    );
-    expect(controlUiStableChunkName("/repo/ui/src/lib/clipboard.ts")).toBe("control-ui-shared");
-    expect(controlUiStableChunkName("/repo/ui/src/build-info.ts")).toBe("control-ui-shared");
-    expect(controlUiStableChunkName("/repo/ui/src/build-info-normalizers.ts")).toBe(
-      "control-ui-shared",
-    );
+    expect(
+      controlUiStableChunkName("/repo/ui/src/components/config-form.shared.ts"),
+    ).toBeUndefined();
+    expect(controlUiStableChunkName("/repo/ui/src/lib/clipboard.ts")).toBeUndefined();
+    expect(controlUiStableChunkName("/repo/ui/src/build-info.ts")).toBeUndefined();
+    expect(controlUiStableChunkName("/repo/ui/src/build-info-normalizers.ts")).toBeUndefined();
     expect(
       controlUiStableChunkName("/tmp/openclaw-pnpm-node-modules/@noble/ed25519/index.js"),
     ).toBe("gateway-runtime");

--- a/ui/src/app/lazy-custom-element.test.ts
+++ b/ui/src/app/lazy-custom-element.test.ts
@@ -1,7 +1,10 @@
 /* @vitest-environment jsdom */
 
 import { describe, expect, it, vi } from "vitest";
-import { ensureCustomElementDefined } from "./lazy-custom-element.ts";
+import {
+  ensureCustomElementDefined,
+  LazyCustomElementRequestController,
+} from "./lazy-custom-element.ts";
 
 let tagSequence = 0;
 
@@ -48,5 +51,132 @@ describe("ensureCustomElementDefined", () => {
     await expect(ensureCustomElementDefined(tagName, async () => undefined)).rejects.toThrow(
       `Custom element module did not define ${tagName}`,
     );
+  });
+});
+
+describe("optional custom element requests", () => {
+  function createRequestHarness() {
+    const requestUpdate = vi.fn();
+    const host = { requestUpdate, updateComplete: Promise.resolve(true) };
+    const retryStale = vi.fn(async () => false);
+    const requests = new LazyCustomElementRequestController(host, undefined, retryStale);
+    return { requests, retryStale };
+  }
+
+  it("publishes loading and error before retrying the canonical load and replaying once", async () => {
+    const firstError = new Error("chunk unavailable");
+    const { requests } = createRequestHarness();
+    const continuation = vi.fn();
+    const tagName = uniqueTag();
+    const element = {
+      tagName,
+      label: "test panel",
+      loadModule: vi
+        .fn<() => Promise<void>>()
+        .mockRejectedValueOnce(firstError)
+        .mockImplementationOnce(async () => {
+          customElements.define(tagName, class extends HTMLElement {});
+        }),
+    };
+
+    requests.request(element, continuation);
+
+    expect(requests.visibleState).toMatchObject({ status: "loading", element });
+    await vi.waitFor(() =>
+      expect(requests.visibleState).toMatchObject({
+        status: "error",
+        element,
+        error: firstError,
+        stale: false,
+      }),
+    );
+    expect(continuation).not.toHaveBeenCalled();
+
+    requests.retry();
+
+    expect(requests.visibleState).toMatchObject({ status: "loading", element });
+    await vi.waitFor(() => expect(continuation).toHaveBeenCalledOnce());
+    expect(element.loadModule).toHaveBeenCalledTimes(2);
+    expect(requests.visibleState).toBeUndefined();
+  });
+
+  it("delegates stale recovery before falling back to the same in-place load", async () => {
+    const staleError = new Error("Failed to fetch dynamically imported module: panel-abc.js");
+    const { requests, retryStale } = createRequestHarness();
+    const continuation = vi.fn();
+    const tagName = uniqueTag();
+    const element = {
+      tagName,
+      label: "stale panel",
+      loadModule: vi
+        .fn<() => Promise<void>>()
+        .mockRejectedValueOnce(staleError)
+        .mockImplementationOnce(async () => {
+          customElements.define(tagName, class extends HTMLElement {});
+        }),
+    };
+
+    requests.request(element, continuation);
+    await vi.waitFor(() => expect(requests.visibleState?.status).toBe("error"));
+    expect(requests.visibleState).toMatchObject({ stale: true });
+
+    requests.retry();
+
+    await vi.waitFor(() => expect(continuation).toHaveBeenCalledOnce());
+    expect(retryStale).toHaveBeenCalledOnce();
+    expect(element.loadModule).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes a loading request without replaying after its late definition", async () => {
+    let resolveLoad: (() => void) | undefined;
+    const { requests } = createRequestHarness();
+    const continuation = vi.fn();
+    const tagName = uniqueTag();
+    const element = {
+      tagName,
+      label: "slow panel",
+      loadModule: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveLoad = () => {
+              customElements.define(tagName, class extends HTMLElement {});
+              resolve();
+            };
+          }),
+      ),
+    };
+
+    requests.request(element, continuation);
+    expect(requests.visibleState?.status).toBe("loading");
+    await vi.waitFor(() => expect(element.loadModule).toHaveBeenCalledOnce());
+
+    requests.close();
+    resolveLoad?.();
+
+    await vi.waitFor(() => expect(customElements.get(element.tagName)).toBeDefined());
+    expect(requests.visibleState).toBeUndefined();
+    expect(continuation).not.toHaveBeenCalled();
+  });
+
+  it("keeps preload failures silent until an explicit request owns visibility", async () => {
+    const error = new Error("chunk unavailable");
+    const { requests } = createRequestHarness();
+    const element = {
+      tagName: uniqueTag(),
+      label: "preloaded panel",
+      loadModule: vi.fn(async () => {
+        throw error;
+      }),
+    };
+
+    requests.preload(element);
+    requests.preload(element);
+
+    await vi.waitFor(() => expect(element.loadModule).toHaveBeenCalledOnce());
+    expect(requests.visibleState).toBeUndefined();
+
+    requests.request(element);
+    await vi.waitFor(() => expect(requests.visibleState?.status).toBe("error"));
+    expect(element.loadModule).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/app/lazy-custom-element.ts
+++ b/ui/src/app/lazy-custom-element.ts
@@ -1,3 +1,8 @@
+import {
+  isStaleChunkImportError,
+  retryStaleChunkReloadWhenReachable,
+} from "./stale-chunk-reload.ts";
+
 type CustomElementModuleLoader = () => Promise<unknown>;
 
 const pendingLoads = new Map<string, Promise<void>>();
@@ -36,7 +41,125 @@ export type OptionalCustomElement = {
 
 type UpdatingHost = {
   requestUpdate: () => unknown;
+  readonly updateComplete?: Promise<unknown>;
 };
+
+type LazyCustomElementRequestState =
+  | { status: "loading"; element: OptionalCustomElement }
+  | {
+      status: "error";
+      element: OptionalCustomElement;
+      error: unknown;
+      stale: boolean;
+    };
+
+type LazyCustomElementRequest = LazyCustomElementRequestState & {
+  action?: () => void;
+};
+
+/** Owns visible lazy-element requests while global registration stays deduplicated by tag. */
+export class LazyCustomElementRequestController {
+  private current: LazyCustomElementRequest | undefined;
+  private readonly preloads = new Set<string>();
+
+  constructor(
+    private readonly host: UpdatingHost,
+    private readonly onClose?: () => void,
+    private readonly retryStale = retryStaleChunkReloadWhenReachable,
+  ) {}
+
+  get visibleState(): LazyCustomElementRequestState | undefined {
+    return this.current;
+  }
+
+  preload(element: OptionalCustomElement): void {
+    if (isOptionalElementDefined(element) || this.preloads.has(element.tagName)) {
+      return;
+    }
+    this.preloads.add(element.tagName);
+    void ensureCustomElementDefined(element.tagName, element.loadModule)
+      .then(
+        () => this.host.requestUpdate(),
+        () => undefined,
+      )
+      .finally(() => this.preloads.delete(element.tagName));
+  }
+
+  request(element: OptionalCustomElement, action?: () => void): void {
+    const request = {
+      action,
+      element,
+      status: "loading",
+    } satisfies LazyCustomElementRequest;
+    this.current = request;
+    this.host.requestUpdate();
+    this.load(request);
+  }
+
+  retry(): void {
+    const request = this.current;
+    if (request?.status !== "error") {
+      return;
+    }
+    const retryRequest = {
+      action: request.action,
+      element: request.element,
+      status: "loading",
+    } satisfies LazyCustomElementRequest;
+    this.current = retryRequest;
+    this.host.requestUpdate();
+    void (request.stale ? this.retryStale() : Promise.resolve(false)).then((reloading) => {
+      if (!reloading && this.current === retryRequest) {
+        this.load(retryRequest);
+      }
+    });
+  }
+
+  close(): void {
+    if (this.current) {
+      this.onClose?.();
+      this.abandon();
+    }
+  }
+
+  abandon(): void {
+    if (this.current) {
+      this.current = undefined;
+      this.host.requestUpdate();
+    }
+  }
+
+  private load(request: LazyCustomElementRequest): void {
+    void ensureCustomElementDefined(request.element.tagName, request.element.loadModule).then(
+      async () => {
+        if (this.current !== request) {
+          return;
+        }
+        this.host.requestUpdate();
+        await this.host.updateComplete;
+        if (this.current === request) {
+          request.action?.();
+          if (this.current === request) {
+            this.abandon();
+          }
+        }
+      },
+      (error: unknown) => {
+        if (this.current !== request) {
+          return;
+        }
+        this.current = {
+          action: request.action,
+          element: request.element,
+          error,
+          stale: isStaleChunkImportError(error),
+          status: "error",
+        };
+        this.host.requestUpdate();
+      },
+    );
+  }
+}
 
 export const COMMAND_PALETTE_ELEMENT = {
   tagName: "openclaw-command-palette",
@@ -101,47 +224,6 @@ export const EXEC_APPROVAL_ELEMENT = {
   loadModule: () => import("../components/exec-approval.ts"),
 } satisfies OptionalCustomElement;
 
-const hostElementLoads = new WeakMap<UpdatingHost, Map<string, Promise<void>>>();
-
 export function isOptionalElementDefined(element: OptionalCustomElement): boolean {
   return customElements.get(element.tagName) !== undefined;
-}
-
-export function ensureOptionalElementForHost(
-  host: UpdatingHost,
-  element: OptionalCustomElement,
-): Promise<void> {
-  if (isOptionalElementDefined(element)) {
-    host.requestUpdate();
-    return Promise.resolve();
-  }
-  const existingLoads = hostElementLoads.get(host);
-  const loads = existingLoads ?? new Map<string, Promise<void>>();
-  if (!existingLoads) {
-    hostElementLoads.set(host, loads);
-  }
-  const pending = loads.get(element.tagName);
-  if (pending) {
-    return pending;
-  }
-  const load = ensureCustomElementDefined(element.tagName, element.loadModule)
-    .then(() => {
-      host.requestUpdate();
-    })
-    .catch((error: unknown) => {
-      console.error(`[openclaw] failed to load ${element.label}`, error);
-      throw error;
-    })
-    .finally(() => {
-      loads.delete(element.tagName);
-    });
-  loads.set(element.tagName, load);
-  return load;
-}
-
-export function preloadOptionalElement(host: UpdatingHost, element: OptionalCustomElement): void {
-  if (isOptionalElementDefined(element)) {
-    return;
-  }
-  void ensureOptionalElementForHost(host, element).catch(() => undefined);
 }

--- a/ui/src/app/lazy-shell-action.test.ts
+++ b/ui/src/app/lazy-shell-action.test.ts
@@ -1,0 +1,123 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { COMMAND_PALETTE_OPEN_EVENT } from "../components/command-palette-contract.ts";
+import { TERMINAL_PANEL_TOGGLE_EVENT } from "../components/panel-toggle-contract.ts";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import {
+  createLazyElementSpec,
+  resetAppHostTestGlobals,
+  type ShellKeyboardState,
+  type TestOptionalCustomElement,
+} from "./app-host.test-support.ts";
+import "./app-host.ts";
+import { DEBUG_OVERLAY_ELEMENT } from "./lazy-custom-element.ts";
+import { persistLazyShellAction, readLazyShellAction } from "./lazy-shell-action.ts";
+
+const storageKey = "openclaw:lazy-event";
+
+type ShellLifecycle = {
+  connectedCallback(): void;
+  disconnectedCallback(): void;
+};
+
+async function withConnectedShell(shell: ShellLifecycle, run: () => void | Promise<void>) {
+  shell.connectedCallback();
+  try {
+    await run();
+  } finally {
+    shell.disconnectedCallback();
+  }
+}
+
+afterEach(resetAppHostTestGlobals);
+
+describe("lazy shell action storage", () => {
+  it("round-trips a closed structured panel action", () => {
+    const storage = createStorageMock();
+    const action = {
+      eventType: TERMINAL_PANEL_TOGGLE_EVENT,
+      detail: { dock: "right", open: true },
+    } as const;
+    vi.stubGlobal("sessionStorage", storage);
+
+    persistLazyShellAction(action);
+    expect(readLazyShellAction()).toEqual(action);
+  });
+
+  it.each([
+    "{",
+    JSON.stringify({ eventType: COMMAND_PALETTE_OPEN_EVENT, extra: true }),
+    JSON.stringify({ eventType: "openclaw:unknown", detail: {} }),
+    JSON.stringify({ eventType: TERMINAL_PANEL_TOGGLE_EVENT, detail: [] }),
+  ])("discards malformed state: %s", (raw) => {
+    const storage = createStorageMock();
+    vi.stubGlobal("sessionStorage", storage);
+    storage.setItem(storageKey, raw);
+
+    expect(readLazyShellAction()).toBeNull();
+    expect(storage.getItem(storageKey)).toBeNull();
+  });
+});
+
+describe("shell lazy events", () => {
+  it("loads the debug overlay shortcut and ignores editable targets", async () => {
+    const toggled = vi.fn();
+    const shell = document.createElement("openclaw-app-shell") as unknown as ShellKeyboardState &
+      ShellLifecycle &
+      HTMLElement;
+    const overlay = document.createElement(DEBUG_OVERLAY_ELEMENT.tagName) as HTMLElement & {
+      toggle: () => void;
+    };
+    overlay.toggle = toggled;
+    shell.append(overlay);
+    Object.defineProperty(shell, "updateComplete", { get: () => Promise.resolve(true) });
+    const shortcut = new KeyboardEvent("keydown", {
+      key: "d",
+      code: "KeyD",
+      ctrlKey: true,
+      shiftKey: true,
+      cancelable: true,
+    });
+
+    await withConnectedShell(shell, async () => {
+      shell.handleDocumentKeydown(shortcut);
+      expect(shortcut.defaultPrevented).toBe(true);
+      await vi.waitFor(() => expect(toggled).toHaveBeenCalledOnce());
+
+      const input = document.body.appendChild(document.createElement("input"));
+      input.addEventListener("keydown", (event) => shell.handleDocumentKeydown(event));
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "d",
+          code: "KeyD",
+          ctrlKey: true,
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      expect(toggled).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("opens approvals after the modal module loads", async () => {
+    const element = createLazyElementSpec("exec approval modal");
+    const show = vi.fn();
+    const shell = document.createElement("openclaw-app-shell") as unknown as ShellLifecycle & {
+      approvalOverlay?: { show(): void };
+      execApprovalElement: TestOptionalCustomElement;
+      openApprovals(): void;
+    };
+    shell.execApprovalElement = element;
+    Object.defineProperty(shell, "updateComplete", { get: () => Promise.resolve(true) });
+    Object.defineProperty(shell, "approvalOverlay", {
+      get: () => (customElements.get(element.tagName) ? { show } : undefined),
+    });
+
+    await withConnectedShell(shell, async () => {
+      shell.openApprovals();
+      await vi.waitFor(() => expect(show).toHaveBeenCalledOnce());
+    });
+  });
+});

--- a/ui/src/app/lazy-shell-action.ts
+++ b/ui/src/app/lazy-shell-action.ts
@@ -1,0 +1,99 @@
+import { COMMAND_PALETTE_OPEN_EVENT } from "../components/command-palette-contract.ts";
+import {
+  BROWSER_PANEL_TOGGLE_EVENT,
+  CUSTODIAN_PANEL_TOGGLE_EVENT,
+  DEBUG_OVERLAY_REQUEST_EVENT,
+  DESKTOP_PANEL_TOGGLE_EVENT,
+  TERMINAL_PANEL_TOGGLE_EVENT,
+} from "../components/panel-toggle-contract.ts";
+import { getSafeSessionStorage } from "../local-storage.ts";
+
+const STORAGE_KEY = "openclaw:lazy-event";
+export const SHELL_APPROVALS_OPEN_EVENT = "openclaw:approvals-open";
+const eventTypes = [
+  COMMAND_PALETTE_OPEN_EVENT,
+  DEBUG_OVERLAY_REQUEST_EVENT,
+  TERMINAL_PANEL_TOGGLE_EVENT,
+  BROWSER_PANEL_TOGGLE_EVENT,
+  DESKTOP_PANEL_TOGGLE_EVENT,
+  CUSTODIAN_PANEL_TOGGLE_EVENT,
+  SHELL_APPROVALS_OPEN_EVENT,
+] as const;
+
+export type LazyShellEvent = {
+  eventType:
+    | typeof COMMAND_PALETTE_OPEN_EVENT
+    | typeof DEBUG_OVERLAY_REQUEST_EVENT
+    | typeof TERMINAL_PANEL_TOGGLE_EVENT
+    | typeof BROWSER_PANEL_TOGGLE_EVENT
+    | typeof DESKTOP_PANEL_TOGGLE_EVENT
+    | typeof CUSTODIAN_PANEL_TOGGLE_EVENT
+    | typeof SHELL_APPROVALS_OPEN_EVENT;
+  detail?: object;
+};
+
+export function lazyShellEvent(
+  eventType: LazyShellEvent["eventType"],
+  event?: Event,
+): LazyShellEvent {
+  const detail = event instanceof CustomEvent ? event.detail : null;
+  return detail !== null && typeof detail === "object" && !Array.isArray(detail)
+    ? { eventType, detail }
+    : { eventType };
+}
+
+export function hasStoredLazyShellAction(): boolean {
+  try {
+    return getSafeSessionStorage()?.getItem(STORAGE_KEY) !== null;
+  } catch {
+    return false;
+  }
+}
+
+export function readLazyShellAction(): LazyShellEvent | null {
+  try {
+    const stored = getSafeSessionStorage()?.getItem(STORAGE_KEY);
+    const parsed: unknown = stored ? JSON.parse(stored) : null;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      clearLazyShellAction();
+      return null;
+    }
+    const entries = Object.entries(parsed);
+    const eventTypeValue = entries.find(([key]) => key === "eventType")?.[1];
+    const eventType = eventTypes.find((candidate) => candidate === eventTypeValue);
+    if (eventType && entries.length === 1) {
+      return { eventType };
+    }
+    const detail = entries.find(([key]) => key === "detail")?.[1];
+    if (
+      eventType &&
+      entries.length === 2 &&
+      detail !== null &&
+      typeof detail === "object" &&
+      !Array.isArray(detail)
+    ) {
+      return { eventType, detail };
+    }
+  } catch {}
+  clearLazyShellAction();
+  return null;
+}
+
+function writeStoredAction(value?: string): void {
+  try {
+    const storage = getSafeSessionStorage();
+    if (value === undefined) {
+      storage?.removeItem(STORAGE_KEY);
+    } else {
+      storage?.setItem(STORAGE_KEY, value);
+    }
+  } catch {}
+}
+
+export function persistLazyShellAction(event: LazyShellEvent): void {
+  writeStoredAction(JSON.stringify(event));
+}
+
+export function clearLazyShellAction(): void {
+  writeStoredAction();
+}

--- a/ui/src/components/lazy-view-error.ts
+++ b/ui/src/components/lazy-view-error.ts
@@ -2,17 +2,60 @@ import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
 import { icon } from "./icons.ts";
+import { renderLoadingState } from "./loading-state.ts";
+
+type LazyElementState =
+  | { status: "loading"; element: { label: string } }
+  | { status: "error"; element: { label: string }; error: unknown; stale: boolean };
+
+export function renderLazyElementState(
+  state: LazyElementState,
+  onRetry: () => void,
+  onClose: () => void,
+) {
+  return state.status === "loading"
+    ? renderLoadingState()
+    : renderLazyViewError({
+        actionLabel: t("common.retry"),
+        error: state.error,
+        stale: state.stale,
+        subtitle: state.element.label,
+        onRetry,
+        onClose,
+      });
+}
+
+export function renderLazyElementModal(controller: {
+  visibleState: LazyElementState | undefined;
+  retry(): void;
+  close(): void;
+}) {
+  const state = controller.visibleState;
+  if (!state) {
+    return nothing;
+  }
+  const close = () => controller.close();
+  return html`<openclaw-modal-dialog label=${state.element.label} @modal-cancel=${close}>
+    ${renderLazyElementState(state, () => controller.retry(), close)}
+  </openclaw-modal-dialog>`;
+}
 
 export function renderLazyViewError({
+  actionLabel,
   error,
+  onClose,
   onRetry,
   render,
   stale = false,
+  subtitle,
 }: {
+  actionLabel?: string;
   error: unknown;
+  onClose?: (event: Event) => void;
   onRetry: (event: Event) => void;
   render?: () => unknown;
   stale?: boolean;
+  subtitle?: string;
 }) {
   const detail = formatUiError(error);
   const errorClasses = `lazy-view-error${render ? " lazy-view-error--inline" : ""}${stale ? " lazy-view-error--stale" : ""}`;
@@ -26,11 +69,16 @@ export function renderLazyViewError({
         ${stale ? t("lazyView.staleTitle") : t("lazyView.errorTitle")}
       </div>
       <div class="lazy-view-error__subtitle">
-        ${stale ? t("lazyView.staleSubtitle") : t("lazyView.genericSubtitle")}
+        ${subtitle ?? (stale ? t("lazyView.staleSubtitle") : t("lazyView.genericSubtitle"))}
       </div>
-      <button class="btn lazy-view-error__action" @click=${onRetry}>
-        ${stale ? t("common.reload") : t("lazyView.retry")}
-      </button>
+      <div class="lazy-view-error__actions">
+        <button class="btn lazy-view-error__action" @click=${onRetry}>
+          ${actionLabel ?? (stale ? t("common.reload") : t("lazyView.retry"))}
+        </button>
+        ${onClose
+          ? html`<button class="btn" type="button" @click=${onClose}>${t("common.close")}</button>`
+          : nothing}
+      </div>
       <code class="lazy-view-error__detail">${detail}</code>
     </div>
   `;

--- a/ui/src/e2e/lazy-custom-element-recovery.e2e.test.ts
+++ b/ui/src/e2e/lazy-custom-element-recovery.e2e.test.ts
@@ -1,0 +1,223 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import {
+  buildControlUiFocusPath,
+  type ControlUiFocusBuildTarget,
+} from "@openclaw/session-url-contract";
+import type { Page, Route, Video } from "playwright";
+import { expect, it } from "vitest";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import {
+  defaultControlUiFeatureMethods,
+  installMockGateway,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const artifactDir = path.resolve(".artifacts/control-ui-e2e/lazy-custom-element-recovery");
+const viewport = { height: 900, width: 1280 };
+const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI lazy custom-element recovery",
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
+});
+
+async function installChunkFailure(page: Page, chunk: RegExp) {
+  let headCount = 0;
+  let chunkRequestCount = 0;
+  await page.route("**/*", async (route) => {
+    if (route.request().method() !== "HEAD") {
+      await route.fallback();
+      return;
+    }
+    headCount += 1;
+    if (headCount === 1) {
+      await route.fulfill({ status: 503 });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.route(chunk, async (route: Route) => {
+    chunkRequestCount += 1;
+    if (chunkRequestCount === 1) {
+      await route.abort("internetdisconnected");
+      return;
+    }
+    await route.fallback();
+  });
+  return { chunkRequestCount: () => chunkRequestCount, headCount: () => headCount };
+}
+
+function focusPath(target: ControlUiFocusBuildTarget): string {
+  const resolvedPath = buildControlUiFocusPath(target, "");
+  if (!resolvedPath) {
+    throw new Error(`Could not build focus path for ${target.kind}`);
+  }
+  return resolvedPath;
+}
+
+async function expectRealChunkFailure(page: Page, label: string) {
+  const error = page.locator(".lazy-view-error");
+  await error.waitFor();
+  const text = await error.textContent();
+  expect(text).toContain(label);
+  expect(text).toContain("Failed to fetch dynamically imported module");
+  await error.getByRole("button", { name: "Retry", exact: true }).waitFor();
+  await error.getByRole("button", { name: "Close", exact: true }).waitFor();
+  return error;
+}
+
+async function retryThroughReload(page: Page, error: ReturnType<Page["locator"]>): Promise<void> {
+  const reloaded = page.waitForEvent("domcontentloaded");
+  await error.getByRole("button", { name: "Retry", exact: true }).click();
+  await reloaded;
+}
+
+const focusedCases = [
+  {
+    name: "terminal",
+    label: "terminal panel",
+    path: focusPath({ kind: "terminal" }),
+    chunk: /\/assets\/terminal-panel-registration-[^/?]+\.js(?:\?.*)?$/u,
+    gateway: {
+      featureMethods: [...defaultControlUiFeatureMethods, "terminal.open"],
+      methodResponses: {
+        "terminal.list": { sessions: [] },
+        "terminal.open": {
+          agentId: "main",
+          confined: false,
+          cwd: "/workspace",
+          sessionId: "lazy-terminal-e2e",
+          shell: "/bin/bash",
+        },
+      },
+      terminalEnabled: true,
+    },
+    ready: (page: Page) => page.locator("openclaw-terminal-panel .tp-header").waitFor(),
+  },
+  {
+    name: "desktop",
+    label: "desktop panel",
+    path: focusPath({ kind: "desktop", control: false }),
+    chunk: /\/assets\/desktop-panel-[^/?]+\.js(?:\?.*)?$/u,
+    gateway: {
+      featureMethods: [...defaultControlUiFeatureMethods, "desktop.observe", "environments.list"],
+      methodResponses: {
+        "environments.list": {
+          environments: [{ id: "gateway", type: "local", status: "available", desktop: true }],
+        },
+      },
+    },
+    ready: (page: Page) => page.getByText("Desktop sources", { exact: true }).waitFor(),
+  },
+  {
+    name: "dashboard",
+    label: "dashboard document",
+    path: focusPath({ kind: "dashboard", path: "/dashboard/main/12345678" }),
+    chunk: /\/assets\/board-document-[^/?]+\.js(?:\?.*)?$/u,
+    gateway: {
+      sessionKey,
+      featureMethods: [...defaultControlUiFeatureMethods, "board.get"],
+      methodResponses: {
+        "sessions.resolve": { ok: true, key: sessionKey },
+        "sessions.describe": {
+          session: {
+            key: sessionKey,
+            kind: "direct",
+            boardFace: "dashboard",
+            displayName: "Lazy dashboard",
+            updatedAt: 1,
+          },
+        },
+        "board.get": { sessionKey, revision: 1, tabs: [], widgets: [] },
+      },
+    },
+    ready: (page: Page) => page.locator("openclaw-board-document openclaw-board-view").waitFor(),
+  },
+];
+
+suite.define(() => {
+  for (const testCase of focusedCases) {
+    it(`reloads the focused ${testCase.name} after its real hashed chunk fails`, async () => {
+      await suite.withPage(
+        { locale: "en-US", serviceWorkers: "block", viewport },
+        async ({ page }) => {
+          const failure = await installChunkFailure(page, testCase.chunk);
+          await installMockGateway(page, testCase.gateway);
+          let documentRequests = 0;
+          page.on("request", (request) => {
+            if (request.resourceType() === "document") {
+              documentRequests += 1;
+            }
+          });
+
+          expect(
+            (await page.goto(new URL(testCase.path, suite.server.baseUrl).href))?.status(),
+          ).toBe(200);
+          const error = await expectRealChunkFailure(page, testCase.label);
+          const failedPathname = new URL(page.url()).pathname;
+          expect(failure.chunkRequestCount()).toBe(1);
+          await expect.poll(failure.headCount).toBe(1);
+          expect(documentRequests).toBe(1);
+
+          await retryThroughReload(page, error);
+          await testCase.ready(page);
+
+          await expect.poll(failure.chunkRequestCount).toBe(2);
+          expect(new URL(page.url()).pathname).toBe(failedPathname);
+          expect(documentRequests).toBe(2);
+        },
+      );
+    });
+  }
+
+  it("restores the command-palette action after a real stale-chunk reload", async () => {
+    await mkdir(artifactDir, { recursive: true });
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      recordVideo: { dir: artifactDir, size: viewport },
+      serviceWorkers: "block",
+      viewport,
+    });
+    let video: Video | null = null;
+    try {
+      const page = await context.newPage();
+      video = page.video();
+      const failure = await installChunkFailure(
+        page,
+        /\/assets\/command-palette-[^/?]+\.js(?:\?.*)?$/u,
+      );
+      await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await waitForControlUiGatewayReady(page);
+
+      await page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("openclaw:command-palette-open"));
+      });
+      const error = await expectRealChunkFailure(page, "command palette");
+      await expect.poll(failure.headCount).toBe(1);
+      expect(failure.chunkRequestCount()).toBe(1);
+      await page.screenshot({
+        fullPage: true,
+        path: path.join(artifactDir, "failure.png"),
+      });
+
+      await retryThroughReload(page, error);
+      await page.getByRole("combobox", { name: "Search chats and commands…" }).waitFor();
+
+      await expect.poll(failure.chunkRequestCount).toBe(2);
+      expect(await page.locator("openclaw-command-palette").count()).toBe(1);
+      await page.waitForTimeout(250);
+      await page.screenshot({
+        fullPage: true,
+        path: path.join(artifactDir, "recovered.png"),
+      });
+    } finally {
+      await suite.closeBrowserContext(context);
+      if (video) {
+        await video.saveAs(path.join(artifactDir, "recovery.webm"));
+      }
+    }
+  });
+});

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1678,7 +1678,9 @@ select.input {
   color: var(--muted);
 }
 
-.lazy-view-error__action {
+.lazy-view-error__actions {
+  display: flex;
+  gap: 8px;
   margin-top: 8px;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening an optional Control UI surface could leave users on a permanent mascot/loading state—or silently do nothing—when its hashed custom-element module failed to load. Standalone terminal, desktop, dashboard, and approval views could stall; command-palette, debug, approvals, and other non-session panel actions could disappear without an outcome.

## Why This Change Was Made

Optional custom-element loading previously owned only pending/defined state: rejected imports were logged and then discarded. This change makes loading and failure explicit, gives users visible Retry and Close actions, and records the exact shell action in a closed sessionStorage event descriptor so it can be replayed after the existing bounded reachable-document reload. Focused document URLs keep their own intent. Close fences late replay, context reset abandons it, and an ordinary document reload preserves it.

Chromium pins a failed hashed module URL for the document lifetime, so Retry deliberately uses the existing reachable-document reload owner. There is no gateway/version compatibility fallback and no alternate import path. The obsolete manual `control-ui-shared` chunk grouping was removed, reducing startup requests while keeping the new lifecycle below the existing byte budget.

Optional shell loading was introduced by b395dfca85a in #106243; later focused-document reuse carried that lifecycle forward.

## User Impact

A failed optional UI module now ends in a visible, actionable state. Users can retry through a safe document reload and return to the exact intended surface, or close the failed action without a delayed replay reopening it.

## Evidence

Before: the command-palette action disappears and leaves only the mascot/home surface, with no error or recovery action.

![Before: failed lazy action has no visible outcome](https://github.com/user-attachments/assets/517166a7-1ac2-47d5-9b02-8fa38a4842d8)

Failure: the real hashed import error is visible with Retry and Close.

![Failure: visible lazy-load error with Retry and Close](https://github.com/user-attachments/assets/2937ca91-70f4-4756-ac2c-8226df870361)

Recovered: Retry reloads the document and reopens the original command palette without another user action.

![Recovered: command palette restored after reload](https://github.com/user-attachments/assets/5e274a26-a63b-4536-b0cd-23418d0e7f25)

Recovery recording:

https://github.com/user-attachments/assets/5b82973d-035e-4a68-b368-d1e929f8f237

Production/tooling LOC: +494/-170 (net +324). Tests/test support: +703/-155 (net +548). The production growth is the missing explicit load/error lifecycle, durable reload-action ownership, and visible Retry/Close behavior; the old promise-only/error-swallowing paths and obsolete manual chunk grouping were deleted.

Validation on the committed bytes:

- Focused lazy/native Vitest selection: 31 passed; the broader focused architecture set previously passed 49/50 before the final focused run.
- `pnpm test:ui`: 710 files passed; 10,061 passed, 1 skipped.
- `node scripts/check-changed.mjs`: passed after the assertion fix.
- `pnpm ui:i18n:verify`: passed; keys=5,421, raw-copy baseline=79.
- `pnpm ui:build`: passed. Startup JS is 10 requests and 345,196 B gzip (337.1 KiB), below the unchanged 345,485 B (337.4 KiB) limit.
- `node scripts/run-vitest.mjs ui/src/e2e/lazy-custom-element-recovery.e2e.test.ts`: 4/4 passed against the production bundle in Chromium with a mocked Gateway. The test intercepts the actual hashed terminal, desktop, dashboard, and command-palette chunks: the first chunk request is aborted, the first HEAD probe returns 503, Retry succeeds on the next HEAD, the document reloads, the second chunk request succeeds, and the original action replays.
- `git diff --check`: passed.
- Fresh Codex autoreview had no accepted/actionable finding; the suggested panel replay loop was rejected by direct source verification because terminal, browser, desktop, and custodian handlers return at their `isOptionalElementDefined(...)` guard after replay. Broad UI and panel tests remain green.

AI-assisted: yes. The maintainer reviewed, understands, and owns the change.
