### PR TITLE
fix(feishu): honor disabled default tool accounts

### DIFF
--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -6,10 +6,8 @@ import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import { Type, type TSchema } from "typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
-import { createFeishuClient } from "./client.js";
-import { resolveAnyEnabledFeishuToolsConfig, resolveFeishuToolAccount } from "./tool-account.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import { feishuExternalToolResult as json } from "./tool-result.js";
-import { resolveToolsConfig } from "./tools-config.js";
 
 type LarkResponse<T = unknown> = { code?: number; msg?: string; data?: T };
 type BitableRecordCreatePayload = NonNullable<
@@ -600,13 +598,13 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
 
   type AccountAwareParams = { accountId?: string };
 
-  const getClient = (params: AccountAwareParams | undefined, defaultAccountId?: string) => {
-    const account = resolveFeishuToolAccount({ api, executeParams: params, defaultAccountId });
-    if (!resolveToolsConfig(account.config.tools).bitable) {
-      throw new Error(`Feishu Bitable tools are disabled for account "${account.accountId}"`);
-    }
-    return createFeishuClient(account);
-  };
+  const getClient = (params: AccountAwareParams | undefined, defaultAccountId?: string) =>
+    createFeishuToolClient({
+      api,
+      executeParams: params,
+      defaultAccountId,
+      requiredTool: { family: "bitable", label: "Bitable" },
+    });
 
   const registerBitableTool = <
     // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Tool params bind each schema-specific executor to its registered tool.

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -44,6 +44,7 @@ function createConfig(params: {
     bitable?: boolean;
   };
   defaultAccount?: string;
+  enabledA?: boolean;
 }): OpenClawPluginApi["config"] {
   return {
     channels: {
@@ -53,6 +54,7 @@ function createConfig(params: {
         tools: params.topTools,
         accounts: {
           a: {
+            enabled: params.enabledA,
             appId: "app-a",
             appSecret: "sec-a", // pragma: allowlist secret
             tools: params.toolsA,
@@ -145,6 +147,23 @@ describe("feishu tool account routing", () => {
     await tool.execute("call", { action: "search" });
 
     expect(lastClientAppId()).toBe("app-a");
+  });
+
+  test("wiki tool skips a disabled configured defaultAccount", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        defaultAccount: "a",
+        enabledA: false,
+        toolsA: { wiki: true },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki");
+    await tool.execute("call", { action: "search" });
+
+    expect(lastClientAppId()).toBe("app-b");
   });
 
   test("wiki tool rejects number-typed space IDs before Lark receives precision-corrupted values", async () => {
@@ -278,6 +297,23 @@ describe("feishu tool account routing", () => {
     await tool.execute("call", { url: "invalid-url" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
+  });
+
+  test("bitable tool skips a disabled configured defaultAccount", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        defaultAccount: "a",
+        enabledA: false,
+        toolsA: { bitable: true },
+        toolsB: { bitable: true },
+      }),
+    );
+    registerFeishuBitableTools(api);
+
+    const tool = resolveTool("feishu_bitable_get_meta");
+    await tool.execute("call", { url: "invalid-url" });
+
+    expect(lastClientAppId()).toBe("app-b");
   });
 
   test("bitable tool rejects a disabled contextual account when another account enables it", async () => {

--- a/extensions/feishu/src/tool-account.test.ts
+++ b/extensions/feishu/src/tool-account.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { resolveFeishuToolAccount } from "./tool-account.js";
 
 describe("resolveFeishuToolAccount", () => {
+  const requiredTool = { family: "wiki", label: "Wiki" } as const;
   const cfg = {
     channels: {
       feishu: {
@@ -35,6 +36,7 @@ describe("resolveFeishuToolAccount", () => {
     const resolved = resolveFeishuToolAccount({
       api: { config: cfg },
       defaultAccountId: "work",
+      requiredTool,
     });
 
     expect(resolved.accountId).toBe("work");
@@ -43,15 +45,54 @@ describe("resolveFeishuToolAccount", () => {
   it("falls back to configured defaultAccount when there is no contextual account", () => {
     const resolved = resolveFeishuToolAccount({
       api: { config: cfg },
+      requiredTool,
     });
 
     expect(resolved.accountId).toBe("ops");
+  });
+
+  it("skips a disabled configured defaultAccount", () => {
+    const resolved = resolveFeishuToolAccount({
+      api: {
+        config: {
+          channels: {
+            feishu: {
+              ...cfg.channels.feishu,
+              defaultAccount: "disabled",
+            },
+          },
+        },
+      },
+      requiredTool,
+    });
+
+    expect(resolved.accountId).toBe("default");
+    expect(resolved.appId).toBe("base-app-id");
+  });
+
+  it("rejects tool account resolution when the channel is disabled", () => {
+    expect(() =>
+      resolveFeishuToolAccount({
+        api: {
+          config: {
+            channels: {
+              feishu: {
+                ...cfg.channels.feishu,
+                enabled: false,
+              },
+            },
+          },
+        },
+        requiredTool,
+      }),
+    ).toThrow("No usable Feishu account has Wiki tools enabled");
   });
 
   it("allows an explicit configured account", () => {
     const resolved = resolveFeishuToolAccount({
       api: { config: cfg },
       executeParams: { accountId: "WORK" },
+      requiredTool,
     });
 
     expect(resolved.accountId).toBe("work");
@@ -71,6 +112,7 @@ describe("resolveFeishuToolAccount", () => {
         },
       },
       executeParams: { accountId: "OPS" },
+      requiredTool,
     });
 
     expect(resolved.accountId).toBe("ops");
@@ -86,6 +128,7 @@ describe("resolveFeishuToolAccount", () => {
       resolveFeishuToolAccount({
         api: { config: cfg },
         executeParams: { accountId: testCase.accountId },
+        requiredTool,
       }),
     ).toThrow(testCase.error);
   });

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -24,8 +24,8 @@ function resolveImplicitToolAccountId(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
-  requiredTool?: FeishuToolRequirement;
-}): string | undefined {
+  requiredTool: FeishuToolRequirement;
+}): string {
   const explicitAccountId = normalizeOptionalString(params.executeParams?.accountId);
   if (explicitAccountId) {
     const normalizedAccountId = normalizeOptionalAccountId(explicitAccountId);
@@ -73,11 +73,15 @@ function resolveImplicitToolAccountId(params: {
     (params.api.config?.channels?.feishu as { defaultAccount?: unknown } | undefined)
       ?.defaultAccount,
   );
-  if (configuredDefaultAccountId) {
+  // A routing preference must not reactivate credentials that the operator disabled.
+  if (
+    configuredDefaultAccountId &&
+    resolveFeishuAccount({ cfg: params.api.config, accountId: configuredDefaultAccountId }).enabled
+  ) {
     return configuredDefaultAccountId;
   }
 
-  if (params.requiredTool && params.api.config) {
+  if (params.api.config) {
     for (const accountId of listFeishuAccountIds(params.api.config)) {
       const account = resolveFeishuAccount({ cfg: params.api.config, accountId });
       if (
@@ -90,14 +94,14 @@ function resolveImplicitToolAccountId(params: {
     }
   }
 
-  return undefined;
+  throw new Error(`No usable Feishu account has ${params.requiredTool.label} tools enabled`);
 }
 
 export function resolveFeishuToolAccount(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
-  requiredTool?: FeishuToolRequirement;
+  requiredTool: FeishuToolRequirement;
 }): ResolvedFeishuAccount {
   if (!params.api.config) {
     throw new Error("Feishu config unavailable");
@@ -106,10 +110,7 @@ export function resolveFeishuToolAccount(params: {
     cfg: params.api.config,
     accountId: resolveImplicitToolAccountId(params),
   });
-  if (
-    params.requiredTool &&
-    !resolveToolsConfig(account.config.tools)[params.requiredTool.family]
-  ) {
+  if (!resolveToolsConfig(account.config.tools)[params.requiredTool.family]) {
     throw new Error(
       `Feishu ${params.requiredTool.label} tools are disabled for account "${account.accountId}"`,
     );
@@ -121,7 +122,7 @@ export function createFeishuToolClient(params: {
   api: Pick<OpenClawPluginApi, "config">;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
-  requiredTool?: FeishuToolRequirement;
+  requiredTool: FeishuToolRequirement;
 }): Lark.Client {
   return createFeishuClient(resolveFeishuToolAccount(params));
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Feishu model tools could continue selecting a configured default account after an operator disabled that account, when another enabled account kept the same tool family available.

## Why This Change Was Made

Tool account routing now treats the requested tool family as required selection context, skips disabled configured defaults, and either selects an eligible account or returns an actionable error. Bitable now uses the same shared account-selection path as the other Feishu tool families.

## User Impact

Operators can disable a Feishu account without its retained credentials being reused by model tools. Multi-account installations continue routing eligible calls to an enabled account.

## Evidence

- Added owner-level and production-handler regressions that failed against the previous behavior and pass with this change.
- Focused Feishu account-routing tests: 31 passed.
- Full Feishu plugin shard: 96 test files, 1,573 tests passed.
- `node scripts/check-changed.mjs`: passed, including extension production/test typechecks, lint, formatting, boundary guards, and import-cycle checks.
- Source probe changed from selecting the disabled default to selecting the enabled sibling.
- Production code delta: net -1 line.
