### PR TITLE
fix(mcp): stop revoked App actions after catalog waits

### DIFF
--- a/extensions/browser/src/browser/chrome.test.ts
+++ b/extensions/browser/src/browser/chrome.test.ts
@@ -7,6 +7,7 @@ import type { AddressInfo } from "node:net";
 import { rawDataToString } from "openclaw/plugin-sdk/webhook-ingress";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
+import { CHROME_STOP_PROBE_TIMEOUT_MS } from "./cdp-timeouts.js";
 import { diagnoseChromeCdp, formatChromeCdpDiagnostic } from "./chrome.diagnostics.js";
 import {
   parseBrowserMajorVersion,
@@ -764,7 +765,7 @@ describe("browser chrome helpers", () => {
             return jsonResponse({ webSocketDebuggerUrl: browserWsUrl });
           }),
         );
-        await stopChromeWithProc(proc, 20);
+        await stopChromeWithProc(proc, CHROME_STOP_PROBE_TIMEOUT_MS);
 
         expect(closeRequested).toBe(true);
         expect(proc.kill).not.toHaveBeenCalled();

--- a/src/gateway/mcp-app-operations.ts
+++ b/src/gateway/mcp-app-operations.ts
@@ -187,6 +187,7 @@ export async function executeMcpAppOperation(
     case "tools/call":
       return await withMcpAppActiveView(active, "tool", async () => {
         await requireCallableTool(runtime, view, operation.params.name);
+        await requireMcpAppInteraction(view);
         return await runtime.callTool(
           view.serverName,
           operation.params.name,
@@ -216,12 +217,14 @@ export async function executeMcpAppOperation(
             )
             .map((tool) => tool.toolName),
         );
-        return {
+        const result = {
           ...listed,
           tools: listed.tools.filter(
             (tool) => allowed.has(tool.name.trim()) && isAppCallableListedTool(tool),
           ),
         };
+        await requireMcpAppInteraction(view);
+        return result;
       });
     case "resources/list":
       return await withMcpAppActiveView(active, "read", async () => {

--- a/src/gateway/mcp-app-standalone.test.ts
+++ b/src/gateway/mcp-app-standalone.test.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage } from "node:http";
 import { Readable } from "node:stream";
 import { runInNewContext } from "node:vm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { makeMockHttpResponse } from "./test-http-response.js";
 
 const mocks = vi.hoisted(() => ({
@@ -81,6 +82,7 @@ const view = {
   html: "<!doctype html><p>private fixture</p>",
   csp: { connectDomains: ["https://api.example.com"] },
   allowedAppToolNames: new Set(["shared", "app-only"]),
+  authorizeAppInteraction: undefined as (() => boolean | Promise<boolean>) | undefined,
   toolInput: { city: "Paris" },
   toolResult: { content: [{ type: "text", text: "sunny" }] },
   requestTimeoutMs: 60_000,
@@ -128,6 +130,7 @@ describe("MCP App standalone host", () => {
     mocks.completeRetirement.mockResolvedValue(undefined);
     Object.assign(view, {
       allowedAppToolNames: new Set(["shared", "app-only"]),
+      authorizeAppInteraction: undefined,
       readOnly: undefined,
       requestTimeoutMs: 60_000,
       requestWindowStartedAtMs: nowMs,
@@ -402,6 +405,36 @@ describe("MCP App standalone host", () => {
     expect(runtime.callTool).toHaveBeenCalledTimes(1);
     expect(releaseRuntimeLease).toHaveBeenCalled();
     expect(mocks.completeRetirement).toHaveBeenCalledWith(runtime);
+  });
+
+  it("inherits post-catalog grant revalidation from the shared operation boundary", async () => {
+    const catalogStarted = createDeferred();
+    const releaseCatalog = createDeferred<Awaited<ReturnType<typeof runtime.getCatalog>>>();
+    runtime.getCatalog.mockImplementationOnce(async () => {
+      catalogStarted.resolve();
+      return await releaseCatalog.promise;
+    });
+    let grantActive = true;
+    view.authorizeAppInteraction = vi.fn(async () => grantActive);
+    const issued = issueTicket({ sessionKey: "agent:main:main", view, nowMs, secret });
+
+    const pending = request({
+      url: "/__openclaw__/mcp-app/view",
+      method: "POST",
+      authorization: `MCP-App ${issued.ticket}`,
+      body: { method: "tools/call", params: { name: "app-only", arguments: {} } },
+    });
+    await catalogStarted.promise;
+    expect(view.authorizeAppInteraction).toHaveBeenCalledOnce();
+    grantActive = false;
+    releaseCatalog.resolve({
+      tools: [{ serverName: "demo", toolName: "app-only", uiVisibility: ["app"] }],
+    });
+
+    const denied = await pending;
+    expect(denied.res.statusCode).toBe(403);
+    expect(view.authorizeAppInteraction).toHaveBeenCalledTimes(2);
+    expect(runtime.callTool).not.toHaveBeenCalled();
   });
 
   it("keeps reconstructed views read-only while preserving resource reads", async () => {

--- a/src/gateway/server-methods/board.runtime-boundaries.test.ts
+++ b/src/gateway/server-methods/board.runtime-boundaries.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resetBoardEventNoticeStateForTest } from "../../boards/board-notices.js";
+import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
+import { replaceSessionEntrySync } from "../../config/sessions/session-accessor.entry.js";
+import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createBoardHarness as createHarness } from "./board.test-support.js";
+import { sessionMutationHandlers } from "./sessions-mutations.js";
+import type { GatewayRequestContext, RespondFn } from "./types.js";
+
+vi.mock("./sessions.runtime.js", () => ({
+  performGatewaySessionReset: vi.fn(async ({ key, reason }: { key: string; reason: string }) => ({
+    ok: true,
+    key,
+    agentId: "main",
+    entry: { sessionId: `reset-${reason}` },
+    resolved: {},
+  })),
+}));
+
+describe("board gateway runtime boundaries", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  beforeEach(() => {
+    resetBoardEventNoticeStateForTest();
+    resetSystemEventsForTest();
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("enforces data bindings against the granted tool set", async () => {
+    const readDataBinding = vi.fn(async () => ({ sessions: ["one"] }));
+    const { invoke, store } = createHarness(undefined, { readDataBinding });
+    await invoke("board.widget.put", {
+      sessionKey: "session",
+      name: "reader",
+      content: { kind: "html", html: "reader" },
+    });
+    let board = await invoke("board.get", { sessionKey: "session" });
+    let snapshot = board.mock.calls[0]?.[1] as BoardSnapshot;
+    const denied = await invoke("board.data.read", {
+      ticket: snapshot.widgets[0]?.viewTicket,
+      bindingId: "sessions.list",
+      params: { limit: 2 },
+    });
+    expect(denied.mock.calls[0]?.[0]).toBe(false);
+    expect(readDataBinding).not.toHaveBeenCalled();
+
+    await invoke("board.widget.put", {
+      sessionKey: "session",
+      name: "reader",
+      content: { kind: "html", html: "reader" },
+      declared: { tools: ["sessions.list"] },
+    });
+    await invoke("board.widget.grant", {
+      sessionKey: "session",
+      name: "reader",
+      decision: "granted",
+      revision: 2,
+      instanceId: store.getSnapshot("session").widgets[0]?.instanceId,
+    });
+    board = await invoke("board.get", { sessionKey: "session" });
+    snapshot = board.mock.calls[0]?.[1] as BoardSnapshot;
+    const allowed = await invoke("board.data.read", {
+      ticket: snapshot.widgets[0]?.viewTicket,
+      bindingId: "sessions.list",
+      params: { limit: 2 },
+    });
+    expect(allowed.mock.calls[0]?.[1]).toEqual({ sessions: ["one"] });
+    expect(readDataBinding).toHaveBeenCalledWith(
+      "sessions.list",
+      { limit: 2 },
+      expect.objectContaining({ params: expect.any(Object) }),
+    );
+  });
+
+  it("rejects unknown data bindings inside the gateway allowlist boundary", async () => {
+    const { invoke, store } = createHarness();
+    await invoke("board.widget.put", {
+      sessionKey: "session",
+      name: "reader",
+      content: { kind: "html", html: "reader" },
+      declared: { tools: ["secrets.dump"] },
+    });
+    await invoke("board.widget.grant", {
+      sessionKey: "session",
+      name: "reader",
+      decision: "granted",
+      revision: 1,
+      instanceId: store.getSnapshot("session").widgets[0]?.instanceId,
+    });
+    const board = await invoke("board.get", { sessionKey: "session" });
+    const snapshot = board.mock.calls[0]?.[1] as BoardSnapshot;
+    const response = await invoke("board.data.read", {
+      ticket: snapshot.widgets[0]?.viewTicket,
+      bindingId: "secrets.dump",
+    });
+    expect(response).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ message: expect.stringContaining("not allowed") }),
+    );
+  });
+
+  it("runs only the exact granted cron job capability", async () => {
+    const triggerCronJob = vi.fn(async (jobId: string) => ({ ok: true, jobId }));
+    const { invoke, store } = createHarness(undefined, { triggerCronJob });
+    await invoke("board.widget.put", {
+      sessionKey: "session",
+      name: "runner",
+      content: { kind: "html", html: "runner" },
+      declared: { tools: ["cron.trigger:job-1"] },
+    });
+    await invoke("board.widget.grant", {
+      sessionKey: "session",
+      name: "runner",
+      decision: "granted",
+      revision: 1,
+      instanceId: store.getSnapshot("session").widgets[0]?.instanceId,
+    });
+    const board = await invoke("board.get", { sessionKey: "session" });
+    const snapshot = board.mock.calls[0]?.[1] as BoardSnapshot;
+    const ticket = snapshot.widgets[0]?.viewTicket;
+
+    const denied = await invoke("board.action", {
+      ticket,
+      action: "cron.trigger",
+      jobId: "job-2",
+    });
+    expect(denied.mock.calls[0]?.[0]).toBe(false);
+    expect(triggerCronJob).not.toHaveBeenCalled();
+
+    const allowed = await invoke("board.action", {
+      ticket,
+      action: "cron.trigger",
+      jobId: "job-1",
+    });
+    expect(allowed.mock.calls[0]?.[1]).toEqual({ ok: true, jobId: "job-1" });
+    expect(triggerCronJob).toHaveBeenCalledWith("job-1", expect.any(Object));
+  });
+
+  it("caps board.event payloads and preserves Unicode at the notice boundary", async () => {
+    const { invoke } = createHarness();
+    await invoke("board.widget.put", {
+      sessionKey: "session",
+      name: "counter",
+      content: { kind: "html", html: "ok" },
+    });
+    const clippedCodeUnits = 500 - "[dashboard] ".length - " on widget counter".length - 1;
+    // JSON's opening quote places the emoji across the legacy slice boundary.
+    const payload = `${"x".repeat(clippedCodeUnits - 2)}😀tail`;
+    await invoke("board.event", { sessionKey: "session", widget: "counter", payload });
+    const unicodeNotice = peekSystemEvents("agent:main:session")[0] ?? "";
+    expect(unicodeNotice.length).toBeLessThanOrEqual(500);
+    expect(unicodeNotice).not.toContain(String.fromCharCode(0xd83d));
+    expect(unicodeNotice).toMatch(/… on widget counter$/u);
+    await invoke("board.event", {
+      sessionKey: "session",
+      widget: "counter",
+      payload: "x".repeat(1_000),
+    });
+    expect(peekSystemEvents("agent:main:session")[1]).toHaveLength(500);
+    const oversized = await invoke("board.event", {
+      sessionKey: "session",
+      widget: "counter",
+      payload: "x".repeat(8_193),
+    });
+    expect(oversized.mock.calls[0]?.[0]).toBe(false);
+  });
+
+  it("keeps board state across the real sessions.reset handler", async () => {
+    const sessionKey = "agent:main:board-reset-proof";
+    const stateDir = tempDirs.make("openclaw-board-reset-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const database = openOpenClawAgentDatabase({ agentId: "main", env });
+    replaceSessionEntrySync(
+      { agentId: "main", sessionKey, storePath: database.path },
+      { sessionId: "board-reset-proof", updatedAt: Date.now() },
+    );
+    const boardStore = new SqliteBoardStore({
+      resolveSession: () => ({ agentId: "main", sessionKey }),
+      env,
+    });
+    boardStore.putWidget({
+      sessionKey,
+      name: "status",
+      content: { kind: "html", html: "ok" },
+    });
+    const respond = vi.fn<RespondFn>();
+    await sessionMutationHandlers["sessions.reset"]!({
+      req: { type: "req", id: "reset", method: "sessions.reset", params: {} },
+      params: { key: sessionKey, reason: "reset" },
+      client: null,
+      isWebchatConnect: () => false,
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        getSessionEventSubscriberConnIds: () => new Set<string>(),
+      } as unknown as GatewayRequestContext,
+    });
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    expect(boardStore.getSnapshot(sessionKey).widgets).toHaveLength(1);
+  });
+});

--- a/src/gateway/server-methods/board.test.ts
+++ b/src/gateway/server-methods/board.test.ts
@@ -1,44 +1,18 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BoardSnapshot } from "../../../packages/gateway-protocol/src/index.js";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { resetBoardEventNoticeStateForTest } from "../../boards/board-notices.js";
-import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
-import { replaceSessionEntrySync } from "../../config/sessions/session-accessor.entry.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
-import {
-  closeOpenClawAgentDatabasesForTest,
-  openOpenClawAgentDatabase,
-} from "../../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { resolveCoreOperatorGatewayMethodScope } from "../methods/core-descriptors.js";
 import {
   createBoardHarness as createHarness,
   createMcpAppDependencies,
 } from "./board.test-support.js";
-import { sessionMutationHandlers } from "./sessions-mutations.js";
-import type { GatewayRequestContext, RespondFn } from "./types.js";
-
-vi.mock("./sessions.runtime.js", () => ({
-  performGatewaySessionReset: vi.fn(async ({ key, reason }: { key: string; reason: string }) => ({
-    ok: true,
-    key,
-    agentId: "main",
-    entry: { sessionId: `reset-${reason}` },
-    resolved: {},
-  })),
-}));
 
 describe("board gateway methods", () => {
-  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-
   beforeEach(() => {
     resetBoardEventNoticeStateForTest();
     resetSystemEventsForTest();
-  });
-
-  afterEach(() => {
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
   });
 
   it("registers every contract method with its required scope", () => {
@@ -428,6 +402,76 @@ describe("board gateway methods", () => {
       interactive: false,
       declaredTools: [],
     });
+  });
+
+  it("downgrades an MCP App pin when its grant is revoked during tool resolution", async () => {
+    const resolutionStarted = createDeferred();
+    const releaseResolution = createDeferred<string[]>();
+    let grantActive = true;
+    const authorizeAppInteraction = vi.fn(async () => grantActive);
+    const mcpApp = createMcpAppDependencies();
+    vi.mocked(mcpApp.resolveActiveView).mockResolvedValueOnce({
+      runtime: { getCatalog: vi.fn() },
+      view: {
+        viewId: "mcp-app-revoked-during-resolution",
+        serverName: "server",
+        toolName: "tool",
+        uiResourceUri: "ui://resource",
+        toolCallId: "call",
+        allowedAppToolNames: new Set(["server.refresh"]),
+        authorizeAppInteraction,
+      },
+    } as never);
+    vi.mocked(mcpApp.resolveAllowedToolNames).mockImplementationOnce(async () => {
+      resolutionStarted.resolve();
+      return await releaseResolution.promise;
+    });
+    const { invoke, store } = createHarness(undefined, mcpApp);
+
+    const pending = invoke("board.widget.put", {
+      sessionKey: "agent:main:main",
+      name: "revoked-during-resolution",
+      content: { kind: "mcp-app", viewId: "mcp-app-revoked-during-resolution" },
+    });
+    await resolutionStarted.promise;
+    expect(authorizeAppInteraction).toHaveBeenCalledOnce();
+    grantActive = false;
+    releaseResolution.resolve(["server.refresh"]);
+
+    const response = await pending;
+    expect(response.mock.calls[0]?.[0]).toBe(true);
+    expect(authorizeAppInteraction).toHaveBeenCalledTimes(2);
+    expect(response.mock.calls[0]?.[1]).toMatchObject({
+      widgets: [
+        expect.objectContaining({
+          name: "revoked-during-resolution",
+          grantState: "none",
+        }),
+      ],
+    });
+    expect(store.readWidgetMcpApp("agent:main:main", "revoked-during-resolution")).toMatchObject({
+      interactive: false,
+      declaredTools: [],
+    });
+  });
+
+  it("keeps MCP App catalog failures as pin failures", async () => {
+    const mcpApp = createMcpAppDependencies();
+    vi.mocked(mcpApp.resolveAllowedToolNames).mockRejectedValueOnce(new Error("catalog failed"));
+    const { invoke, store } = createHarness(undefined, mcpApp);
+
+    const response = await invoke("board.widget.put", {
+      sessionKey: "agent:main:main",
+      name: "catalog-failure",
+      content: { kind: "mcp-app", viewId: "mcp-app-source" },
+    });
+
+    expect(response.mock.calls[0]?.[0]).toBe(false);
+    expect(response.mock.calls[0]?.[2]).toMatchObject({
+      code: "UNAVAILABLE",
+      message: "Error: catalog failed",
+    });
+    expect(store.getSnapshot("agent:main:main").widgets).toEqual([]);
   });
 
   it("keeps zero-tool MCP Apps read-only until an explicit grant", async () => {
@@ -882,179 +926,5 @@ describe("board gateway methods", () => {
       ticket: snapshot.widgets.find((widget) => widget.name === "approved")?.viewTicket,
     });
     expect(approved.mock.calls[0]?.[1]).toEqual({ confirmationRequired: false });
-  });
-
-  it("enforces data bindings against the granted tool set", async () => {
-    const readDataBinding = vi.fn(async () => ({ sessions: ["one"] }));
-    const { invoke, store } = createHarness(undefined, { readDataBinding });
-    await invoke("board.widget.put", {
-      sessionKey: "session",
-      name: "reader",
-      content: { kind: "html", html: "reader" },
-    });
-    let board = await invoke("board.get", { sessionKey: "session" });
-    let snapshot = board.mock.calls[0]?.[1] as BoardSnapshot;
-    const denied = await invoke("board.data.read", {
-      ticket: snapshot.widgets[0]?.viewTicket,
-      bindingId: "sessions.list",
-      params: { limit: 2 },
-    });
-    expect(denied.mock.calls[0]?.[0]).toBe(false);
-    expect(readDataBinding).not.toHaveBeenCalled();
-
-    await invoke("board.widget.put", {
-      sessionKey: "session",
-      name: "reader",
-      content: { kind: "html", html: "reader" },
-      declared: { tools: ["sessions.list"] },
-    });
-    await invoke("board.widget.grant", {
-      sessionKey: "session",
-      name: "reader",
-      decision: "granted",
-      revision: 2,
-      instanceId: store.getSnapshot("session").widgets[0]?.instanceId,
-    });
-    board = await invoke("board.get", { sessionKey: "session" });
-    snapshot = board.mock.calls[0]?.[1] as BoardSnapshot;
-    const allowed = await invoke("board.data.read", {
-      ticket: snapshot.widgets[0]?.viewTicket,
-      bindingId: "sessions.list",
-      params: { limit: 2 },
-    });
-    expect(allowed.mock.calls[0]?.[1]).toEqual({ sessions: ["one"] });
-    expect(readDataBinding).toHaveBeenCalledWith(
-      "sessions.list",
-      { limit: 2 },
-      expect.objectContaining({ params: expect.any(Object) }),
-    );
-  });
-
-  it("rejects unknown data bindings inside the gateway allowlist boundary", async () => {
-    const { invoke, store } = createHarness();
-    await invoke("board.widget.put", {
-      sessionKey: "session",
-      name: "reader",
-      content: { kind: "html", html: "reader" },
-      declared: { tools: ["secrets.dump"] },
-    });
-    await invoke("board.widget.grant", {
-      sessionKey: "session",
-      name: "reader",
-      decision: "granted",
-      revision: 1,
-      instanceId: store.getSnapshot("session").widgets[0]?.instanceId,
-    });
-    const board = await invoke("board.get", { sessionKey: "session" });
-    const snapshot = board.mock.calls[0]?.[1] as BoardSnapshot;
-    const response = await invoke("board.data.read", {
-      ticket: snapshot.widgets[0]?.viewTicket,
-      bindingId: "secrets.dump",
-    });
-    expect(response).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({ message: expect.stringContaining("not allowed") }),
-    );
-  });
-
-  it("runs only the exact granted cron job capability", async () => {
-    const triggerCronJob = vi.fn(async (jobId: string) => ({ ok: true, jobId }));
-    const { invoke, store } = createHarness(undefined, { triggerCronJob });
-    await invoke("board.widget.put", {
-      sessionKey: "session",
-      name: "runner",
-      content: { kind: "html", html: "runner" },
-      declared: { tools: ["cron.trigger:job-1"] },
-    });
-    await invoke("board.widget.grant", {
-      sessionKey: "session",
-      name: "runner",
-      decision: "granted",
-      revision: 1,
-      instanceId: store.getSnapshot("session").widgets[0]?.instanceId,
-    });
-    const board = await invoke("board.get", { sessionKey: "session" });
-    const snapshot = board.mock.calls[0]?.[1] as BoardSnapshot;
-    const ticket = snapshot.widgets[0]?.viewTicket;
-
-    const denied = await invoke("board.action", {
-      ticket,
-      action: "cron.trigger",
-      jobId: "job-2",
-    });
-    expect(denied.mock.calls[0]?.[0]).toBe(false);
-    expect(triggerCronJob).not.toHaveBeenCalled();
-
-    const allowed = await invoke("board.action", {
-      ticket,
-      action: "cron.trigger",
-      jobId: "job-1",
-    });
-    expect(allowed.mock.calls[0]?.[1]).toEqual({ ok: true, jobId: "job-1" });
-    expect(triggerCronJob).toHaveBeenCalledWith("job-1", expect.any(Object));
-  });
-
-  it("caps board.event payloads and preserves Unicode at the notice boundary", async () => {
-    const { invoke } = createHarness();
-    await invoke("board.widget.put", {
-      sessionKey: "session",
-      name: "counter",
-      content: { kind: "html", html: "ok" },
-    });
-    const clippedCodeUnits = 500 - "[dashboard] ".length - " on widget counter".length - 1;
-    // JSON's opening quote places the emoji across the legacy slice boundary.
-    const payload = `${"x".repeat(clippedCodeUnits - 2)}😀tail`;
-    await invoke("board.event", { sessionKey: "session", widget: "counter", payload });
-    const unicodeNotice = peekSystemEvents("agent:main:session")[0] ?? "";
-    expect(unicodeNotice.length).toBeLessThanOrEqual(500);
-    expect(unicodeNotice).not.toContain(String.fromCharCode(0xd83d));
-    expect(unicodeNotice).toMatch(/… on widget counter$/u);
-    await invoke("board.event", {
-      sessionKey: "session",
-      widget: "counter",
-      payload: "x".repeat(1_000),
-    });
-    expect(peekSystemEvents("agent:main:session")[1]).toHaveLength(500);
-    const oversized = await invoke("board.event", {
-      sessionKey: "session",
-      widget: "counter",
-      payload: "x".repeat(8_193),
-    });
-    expect(oversized.mock.calls[0]?.[0]).toBe(false);
-  });
-
-  it("keeps board state across the real sessions.reset handler", async () => {
-    const sessionKey = "agent:main:board-reset-proof";
-    const stateDir = tempDirs.make("openclaw-board-reset-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const database = openOpenClawAgentDatabase({ agentId: "main", env });
-    replaceSessionEntrySync(
-      { agentId: "main", sessionKey, storePath: database.path },
-      { sessionId: "board-reset-proof", updatedAt: Date.now() },
-    );
-    const boardStore = new SqliteBoardStore({
-      resolveSession: () => ({ agentId: "main", sessionKey }),
-      env,
-    });
-    boardStore.putWidget({
-      sessionKey,
-      name: "status",
-      content: { kind: "html", html: "ok" },
-    });
-    const respond = vi.fn<RespondFn>();
-    await sessionMutationHandlers["sessions.reset"]!({
-      req: { type: "req", id: "reset", method: "sessions.reset", params: {} },
-      params: { key: sessionKey, reason: "reset" },
-      client: null,
-      isWebchatConnect: () => false,
-      respond,
-      context: {
-        broadcast: vi.fn(),
-        getSessionEventSubscriberConnIds: () => new Set<string>(),
-      } as unknown as GatewayRequestContext,
-    });
-    expect(respond.mock.calls[0]?.[0]).toBe(true);
-    expect(boardStore.getSnapshot(sessionKey).widgets).toHaveLength(1);
   });
 });

--- a/src/gateway/server-methods/board.ts
+++ b/src/gateway/server-methods/board.ts
@@ -320,6 +320,13 @@ export function createBoardHandlers(
             // Reconstructed or revoked source leases may be pinned only as read-only content.
           }
           const allowedTools = interactive ? await mcpApp.resolveAllowedToolNames(active) : [];
+          if (interactive) {
+            try {
+              await requireMcpAppInteraction(view);
+            } catch {
+              interactive = false;
+            }
+          }
           content = {
             kind: "mcp-app",
             descriptor: {
@@ -330,7 +337,7 @@ export function createBoardHandlers(
             },
             interactive,
           };
-          declared = allowedTools.length > 0 ? { tools: allowedTools } : undefined;
+          declared = interactive && allowedTools.length > 0 ? { tools: allowedTools } : undefined;
         } else if (requestParams.content.kind === "registered") {
           const registration = resolveBoardWidgetContentKind(
             getActivePluginRegistry(),

--- a/src/gateway/server-methods/mcp-app.test.ts
+++ b/src/gateway/server-methods/mcp-app.test.ts
@@ -1,6 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayErrorDetailCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 
 const mocks = vi.hoisted(() => ({
   completeDeferredSessionMcpRuntimeRetirement: vi.fn(),
@@ -438,6 +439,52 @@ describe("MCP App gateway bridge", () => {
     expect(denied.mock.calls[0]?.[0]).toBe(false);
     expect(view.authorizeAppInteraction).toHaveBeenCalledOnce();
     expect(mocks.peekSessionMcpRuntime.mock.results[0]?.value.callTool).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      capability: "calling an App tool",
+      method: "mcp.app.callTool" as const,
+      params: { toolName: "shared" },
+      assertNoToolCall: true,
+    },
+    {
+      capability: "returning App tools",
+      method: "mcp.app.listTools" as const,
+      params: {},
+      assertNoToolCall: false,
+    },
+  ])("rechecks the widget grant after discovery before $capability", async (testCase) => {
+    const catalogStarted = createDeferred();
+    const releaseCatalog =
+      createDeferred<Awaited<ReturnType<ReturnType<typeof runtime>["getCatalog"]>>>();
+    const activeRuntime = runtime();
+    mocks.peekSessionMcpRuntime.mockReturnValue(activeRuntime);
+    activeRuntime.getCatalog.mockImplementationOnce(async () => {
+      catalogStarted.resolve();
+      return await releaseCatalog.promise;
+    });
+    let grantActive = true;
+    view.authorizeAppInteraction = vi.fn(async () => grantActive);
+
+    const pending = invoke(testCase.method, {
+      sessionKey: "agent:main:main",
+      viewId: "cv_app",
+      ...testCase.params,
+    });
+    await catalogStarted.promise;
+    expect(view.authorizeAppInteraction).toHaveBeenCalledOnce();
+    grantActive = false;
+    releaseCatalog.resolve({
+      tools: [{ serverName: "demo", toolName: "shared" }],
+    });
+
+    const denied = await pending;
+    expect(denied.mock.calls[0]?.[0]).toBe(false);
+    expect(view.authorizeAppInteraction).toHaveBeenCalledTimes(2);
+    if (testCase.assertNoToolCall) {
+      expect(activeRuntime.callTool).not.toHaveBeenCalled();
+    }
   });
 
   it("captures only app-visible tools allowed by the originating view", async () => {

--- a/test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts
@@ -1,16 +1,16 @@
 import { randomUUID } from "node:crypto";
 import { watch } from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { startQaGatewayChild, startQaMockOpenAiServer } from "../../../../extensions/qa-lab/api.js";
 import type {
   BoardWidgetAppViewResult,
   BoardWidgetPutResult,
 } from "../../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 import {
   TEST_TIMEOUT_MS,
   createChildEnv,
@@ -20,6 +20,7 @@ import {
   type HttpFixture,
 } from "./gateway-node-mcp.test-support.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const GATE_WAIT_TIMEOUT_MS = 30_000;
 const APP_TOOL_NAME = "streamableHttp__parity_app";
 const POST_REVOCATION_MARKER = "post-revocation";
@@ -134,9 +135,7 @@ describe("Gateway MCP App board grant revalidation", () => {
     { timeout: TEST_TIMEOUT_MS },
     async () => {
       const repoRoot = process.cwd();
-      const taskRoot = await fs.mkdtemp(
-        path.join(os.tmpdir(), "openclaw-mcp-app-grant-revalidation-"),
-      );
+      const taskRoot = tempDirs.make("openclaw-mcp-app-grant-revalidation-");
       const fixtureRoot = path.join(taskRoot, "fixture");
       const fixtureHome = path.join(fixtureRoot, "home");
       const fixtureTemp = path.join(fixtureRoot, "tmp");
@@ -298,9 +297,6 @@ describe("Gateway MCP App board grant revalidation", () => {
         cleanupErrors.push(
           ...stopped.flatMap((result) => (result.status === "rejected" ? [result.reason] : [])),
         );
-        await fs.rm(taskRoot, { recursive: true, force: true }).catch((error) => {
-          cleanupErrors.push(error);
-        });
       }
 
       const failures = proofError === undefined ? cleanupErrors : [proofError, ...cleanupErrors];

--- a/test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts
@@ -1,0 +1,315 @@
+import { randomUUID } from "node:crypto";
+import { watch } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { describe, expect, it } from "vitest";
+import { startQaGatewayChild, startQaMockOpenAiServer } from "../../../../extensions/qa-lab/api.js";
+import type {
+  BoardWidgetAppViewResult,
+  BoardWidgetPutResult,
+} from "../../../../packages/gateway-protocol/src/index.js";
+import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+import {
+  TEST_TIMEOUT_MS,
+  createChildEnv,
+  startHttpFixture,
+  stopChild,
+  type GatewayHandle,
+  type HttpFixture,
+} from "./gateway-node-mcp.test-support.js";
+
+const GATE_WAIT_TIMEOUT_MS = 30_000;
+const APP_TOOL_NAME = "streamableHttp__parity_app";
+const POST_REVOCATION_MARKER = "post-revocation";
+
+async function waitForFile(filePath: string): Promise<void> {
+  try {
+    await fs.access(filePath);
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      watcher.close();
+      reject(new Error(`timed out waiting for fixture gate: ${path.basename(filePath)}`));
+    }, GATE_WAIT_TIMEOUT_MS);
+    timeout.unref();
+    const finish = (error?: unknown) => {
+      clearTimeout(timeout);
+      watcher.close();
+      error ? reject(error) : resolve();
+    };
+    const inspect = () => {
+      void fs.access(filePath).then(
+        () => finish(),
+        (error: NodeJS.ErrnoException) => {
+          if (error.code !== "ENOENT") {
+            finish(error);
+          }
+        },
+      );
+    };
+    const watcher = watch(path.dirname(filePath), (_event, filename) => {
+      if (!filename || filename.toString() === path.basename(filePath)) {
+        inspect();
+      }
+    });
+    watcher.once("error", finish);
+    inspect();
+  });
+}
+
+function requireMcpAppViewId(messages: unknown[]): string {
+  for (const message of messages) {
+    if (!isRecord(message) || message.toolName !== APP_TOOL_NAME || !isRecord(message.details)) {
+      continue;
+    }
+    const preview = message.details.mcpAppPreview;
+    const mcpApp = isRecord(preview) ? preview.mcpApp : undefined;
+    if (isRecord(mcpApp) && typeof mcpApp.viewId === "string") {
+      return mcpApp.viewId;
+    }
+  }
+  throw new Error(`chat.history omitted the persisted MCP App view for ${APP_TOOL_NAME}`);
+}
+
+async function readExecutedMarkers(eventPath: string): Promise<string[]> {
+  const content = await fs.readFile(eventPath, "utf8");
+  return content
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as unknown)
+    .flatMap((event) =>
+      isRecord(event) && typeof event.marker === "string" ? [event.marker] : [],
+    );
+}
+
+function appConfig(cfg: OpenClawConfig, fixture: HttpFixture): OpenClawConfig {
+  return {
+    ...cfg,
+    mcp: {
+      ...cfg.mcp,
+      apps: { ...cfg.mcp?.apps, enabled: true },
+      servers: {
+        streamableHttp: {
+          transport: "streamable-http",
+          url: fixture.urls.streamableHttp,
+          connectionTimeoutMs: 30_000,
+          requestTimeoutMs: 30_000,
+          toolFilter: { include: ["parity_app"] },
+        },
+      },
+    },
+    tools: { ...cfg.tools, profile: "full", toolSearch: false, codeMode: false },
+    channels: {},
+  };
+}
+
+async function postStandalone(params: {
+  gateway: GatewayHandle;
+  ticket: string;
+  marker: string;
+}): Promise<Response> {
+  return await fetch(new URL("/__openclaw__/mcp-app/view", params.gateway.baseUrl), {
+    method: "POST",
+    headers: {
+      Authorization: `MCP-App ${params.ticket}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      method: "tools/call",
+      params: { name: "parity_app", arguments: { marker: params.marker } },
+    }),
+  });
+}
+
+describe("Gateway MCP App board grant revalidation", () => {
+  it(
+    "rejects a standalone tool call revoked during a real catalog refresh",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const repoRoot = process.cwd();
+      const taskRoot = await fs.mkdtemp(
+        path.join(os.tmpdir(), "openclaw-mcp-app-grant-revalidation-"),
+      );
+      const fixtureRoot = path.join(taskRoot, "fixture");
+      const fixtureHome = path.join(fixtureRoot, "home");
+      const fixtureTemp = path.join(fixtureRoot, "tmp");
+      const gateDir = path.join(fixtureRoot, "catalog-gate");
+      const eventPath = path.join(fixtureRoot, "app-calls.jsonl");
+      const armPath = path.join(gateDir, "arm");
+      const startedPath = path.join(gateDir, "started");
+      const releasePath = path.join(gateDir, "release");
+      const gatewayParent = path.join(taskRoot, "gateway");
+      const fixturePath = path.join(
+        repoRoot,
+        "test/e2e/qa-lab/runtime/gateway-node-mcp.fixture.mjs",
+      );
+      let fixture: HttpFixture | undefined;
+      let mock: Awaited<ReturnType<typeof startQaMockOpenAiServer>> | undefined;
+      let gateway: GatewayHandle | undefined;
+      let pendingCall: Promise<Response> | undefined;
+      let proofError: unknown;
+      const cleanupErrors: unknown[] = [];
+
+      try {
+        await Promise.all(
+          [fixtureHome, fixtureTemp, gateDir, gatewayParent].map((directory) =>
+            fs.mkdir(directory, { recursive: true }),
+          ),
+        );
+        fixture = await startHttpFixture({
+          fixturePath,
+          labelPrefix: "session",
+          env: createChildEnv({
+            home: fixtureHome,
+            tempDir: fixtureTemp,
+            extra: {
+              MCP_APP_GRANT_REVALIDATION_FIXTURE: "1",
+              MCP_APP_CATALOG_GATE_DIR: gateDir,
+              MCP_APP_EVENT_PATH: eventPath,
+            },
+          }),
+        });
+        mock = await startQaMockOpenAiServer();
+        const activeFixture = fixture;
+        gateway = await startQaGatewayChild({
+          repoRoot,
+          command: {
+            executablePath: process.execPath,
+            argsPrefix: ["dist/index.js"],
+            cwd: repoRoot,
+            tempParentDir: gatewayParent,
+            usePackagedPlugins: true,
+          },
+          providerBaseUrl: `${mock.baseUrl}/v1`,
+          providerMode: "mock-openai",
+          primaryModel: "mock-openai/gpt-5.6-luna",
+          transportBaseUrl: "http://127.0.0.1",
+          controlUiEnabled: false,
+          runtimeEnvPatch: { OPENCLAW_SKIP_CHANNELS: "1" },
+          mutateConfig: (cfg) => appConfig(cfg, activeFixture),
+        });
+
+        const sessionKey = `agent:qa:mcp-app-grant-${randomUUID()}`;
+        const started = (await gateway.call(
+          "agent",
+          {
+            sessionKey,
+            message: `Tool search QA check target=${APP_TOOL_NAME}. Call exactly that tool once and then summarize.`,
+            deliver: false,
+            idempotencyKey: randomUUID(),
+          },
+          { timeoutMs: 30_000 },
+        )) as { runId?: unknown; status?: unknown };
+        if (started.status !== "accepted" || typeof started.runId !== "string") {
+          throw new Error(`mock-provider App turn did not start: ${JSON.stringify(started)}`);
+        }
+        await expect(
+          gateway.call(
+            "agent.wait",
+            { runId: started.runId, timeoutMs: 60_000 },
+            { timeoutMs: 65_000 },
+          ),
+        ).resolves.toMatchObject({ runId: started.runId, status: "ok" });
+        const history = (await gateway.call("chat.history", {
+          sessionKey,
+          limit: 50,
+        })) as { messages?: unknown[] };
+        const sourceViewId = requireMcpAppViewId(history.messages ?? []);
+
+        const pinned = (await gateway.call("board.widget.put", {
+          sessionKey,
+          name: "grant-proof",
+          content: { kind: "mcp-app", viewId: sourceViewId },
+        })) as BoardWidgetPutResult;
+        const widget = pinned.widgets.find((candidate) => candidate.name === "grant-proof");
+        if (!widget?.instanceId) {
+          throw new Error("board.widget.put omitted the exact widget revision identity");
+        }
+        expect(widget.grantState).toBe("pending");
+        await gateway.call("board.widget.grant", {
+          sessionKey,
+          name: widget.name,
+          decision: "granted",
+          revision: widget.revision,
+          instanceId: widget.instanceId,
+        });
+        const reminted = (await gateway.call("board.widget.appView", {
+          sessionKey,
+          name: widget.name,
+          revision: widget.revision,
+          instanceId: widget.instanceId,
+        })) as BoardWidgetAppViewResult;
+        const appView = (await gateway.call("mcp.app.view", {
+          sessionKey,
+          viewId: reminted.viewId,
+        })) as { standaloneUrl?: unknown };
+        if (typeof appView.standaloneUrl !== "string") {
+          throw new Error("mcp.app.view omitted the standalone ticket URL");
+        }
+        const standaloneUrl = new URL(appView.standaloneUrl, gateway.baseUrl);
+        const ticket = standaloneUrl.hash.slice(1);
+        expect(ticket).not.toBe("");
+
+        await fs.writeFile(armPath, "armed\n");
+        const notificationCall = await postStandalone({
+          gateway,
+          ticket,
+          marker: "notify-list-changed",
+        });
+        expect(notificationCall.status).toBe(200);
+
+        pendingCall = postStandalone({ gateway, ticket, marker: POST_REVOCATION_MARKER });
+        await waitForFile(startedPath);
+        await gateway.call("board.update", {
+          sessionKey,
+          ops: [{ kind: "widget_remove", name: widget.name }],
+        });
+        await fs.writeFile(releasePath, "released\n");
+
+        const denied = await pendingCall;
+        const deniedBody: unknown = await denied.json();
+        const executedMarkers = await readExecutedMarkers(eventPath);
+        expect({
+          status: denied.status,
+          error: isRecord(deniedBody) ? deniedBody.error : undefined,
+          postRevocationExecuted: executedMarkers.includes(POST_REVOCATION_MARKER),
+        }).toEqual({
+          status: 403,
+          error: "MCP App widget grant is no longer active",
+          postRevocationExecuted: false,
+        });
+      } catch (error) {
+        proofError = error;
+      } finally {
+        await fs.writeFile(releasePath, "released\n").catch(() => {});
+        await pendingCall?.catch(() => {});
+        const stopped = await Promise.allSettled([
+          ...(gateway ? [Promise.resolve(gateway.stop())] : []),
+          ...(fixture ? [stopChild(fixture)] : []),
+          ...(mock ? [Promise.resolve(mock.stop())] : []),
+        ]);
+        cleanupErrors.push(
+          ...stopped.flatMap((result) => (result.status === "rejected" ? [result.reason] : [])),
+        );
+        await fs.rm(taskRoot, { recursive: true, force: true }).catch((error) => {
+          cleanupErrors.push(error);
+        });
+      }
+
+      const failures = proofError === undefined ? cleanupErrors : [proofError, ...cleanupErrors];
+      if (failures.length === 1) {
+        throw failures[0];
+      }
+      if (failures.length > 1) {
+        throw new AggregateError(failures, "MCP App grant revalidation proof failed");
+      }
+    },
+  );
+});

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.fixture.mjs
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.fixture.mjs
@@ -2,6 +2,7 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
+import path from "node:path";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
@@ -11,6 +12,7 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import * as z from "zod/v4";
 
 const READY_TYPE = "openclaw-mcp-parity-ready";
+const APP_URI = "ui://parity/app";
 
 function readOption(name) {
   const index = process.argv.indexOf(name);
@@ -65,6 +67,43 @@ function buildProbeResult({ label, marker, generation, expiryCalls }) {
     : response;
 }
 
+function waitForFile(filePath) {
+  if (fs.existsSync(filePath)) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve, reject) => {
+    const directory = path.dirname(filePath);
+    const filename = path.basename(filePath);
+    const watcher = fs.watch(directory, (_event, changed) => {
+      if (changed && changed.toString() !== filename) {
+        return;
+      }
+      if (fs.existsSync(filePath)) {
+        watcher.close();
+        resolve();
+      }
+    });
+    watcher.once("error", reject);
+    if (fs.existsSync(filePath)) {
+      watcher.close();
+      resolve();
+    }
+  });
+}
+
+async function holdNextCatalogList(catalogGate) {
+  if (
+    !catalogGate?.notificationSent ||
+    catalogGate.claimed ||
+    !fs.existsSync(path.join(catalogGate.directory, "arm"))
+  ) {
+    return;
+  }
+  catalogGate.claimed = true;
+  fs.writeFileSync(path.join(catalogGate.directory, "started"), "started\n", { flag: "wx" });
+  await waitForFile(path.join(catalogGate.directory, "release"));
+}
+
 function createProbeServer(label, catalogState = { rotated: false }, control = {}) {
   catalogState.generations ??= {};
   const generation = (catalogState.generations[label] ?? 0) + 1;
@@ -105,6 +144,38 @@ function createProbeServer(label, catalogState = { rotated: false }, control = {
   server.registerTool("parity_hidden", initialToolConfig, async ({ marker }) =>
     buildProbeResult({ label: `${label}-hidden`, marker, generation }),
   );
+  if (control.appFixture) {
+    const appTool = server.registerTool("parity_app", initialToolConfig, async ({ marker }) => {
+      fs.appendFileSync(
+        control.appFixture.eventPath,
+        `${JSON.stringify({ type: "parity_app_call", marker })}\n`,
+      );
+      if (marker === "notify-list-changed") {
+        control.appFixture.catalogGate.notificationSent = true;
+        server.sendToolListChanged();
+        // The SDK helper is fire-and-forget. Yield once so the notification is
+        // queued before the successful call lets the next request begin.
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      return buildProbeResult({ label: `${label}-app`, marker, generation });
+    });
+    appTool.update({ _meta: { ui: { resourceUri: APP_URI } } });
+    server.registerResource(
+      "parity_app",
+      APP_URI,
+      { mimeType: "text/html;profile=mcp-app" },
+      async (uri) => ({
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "text/html;profile=mcp-app",
+            text: "<!doctype html><main>Parity MCP App</main>",
+            _meta: { ui: { csp: { connectDomains: [] } } },
+          },
+        ],
+      }),
+    );
+  }
   return server;
 }
 
@@ -236,6 +307,17 @@ async function runHttp() {
   const sessions = new Map();
   const records = new Set();
   const catalogState = { rotated: false, expiryCalls: 0 };
+  const appFixtureEnabled = process.env.MCP_APP_GRANT_REVALIDATION_FIXTURE === "1";
+  const catalogGateDirectory = process.env.MCP_APP_CATALOG_GATE_DIR;
+  const appEventPath = process.env.MCP_APP_EVENT_PATH;
+  if (appFixtureEnabled && (!catalogGateDirectory || !appEventPath)) {
+    throw new Error("MCP App grant fixture requires catalog gate and event paths");
+  }
+  const catalogGate = appFixtureEnabled
+    ? { directory: catalogGateDirectory, notificationSent: false, claimed: false }
+    : undefined;
+  const appFixture =
+    catalogGate && appEventPath ? { catalogGate, eventPath: appEventPath } : undefined;
   let failStreamableGets = 0;
   let terminalSseOnce = false;
   const route = (handler) => (req, res, next) => void handler(req, res).catch(next);
@@ -295,6 +377,7 @@ async function runHttp() {
           },
         });
         const server = createProbeServer(`${labelPrefix}-streamable-http`, catalogState, {
+          appFixture,
           breakNotifications: () => {
             failStreamableGets = 2;
             setTimeout(() => createdTransport.closeStandaloneSSEStream(), 25);
@@ -306,6 +389,9 @@ async function runHttp() {
       } else {
         rpcError(res, -32000, "Missing Streamable HTTP session");
         return;
+      }
+      if (req.method === "POST" && req.body?.method === "tools/list") {
+        await holdNextCatalogList(catalogGate);
       }
       await transport.handleRequest(req, res, req.body);
     } catch (error) {


### PR DESCRIPTION
AI-assisted: Yes. The implementation and validation used AI coding tools, with a clean final autoreview.

## What Problem This Solves

Fixes an issue where a board-granted MCP App interaction could remain effective after the operator removed or replaced the granting widget while the request was waiting for MCP catalog work. An in-flight App tool call could therefore execute after revocation, tool discovery could return stale capability inventory, and a pin operation could persist stale interactive authority.

## Why This Change Was Made

Interactive MCP App boundaries now revalidate the exact live board grant after awaited catalog/list work and immediately before tool dispatch, capability return, or interactive pin persistence. Pinning that loses authority during tool resolution downgrades to the existing read-only representation; ordinary catalog failures retain their existing error behavior. Resource reads and reconstructed read-only Apps are unchanged.

## User Impact

Removing or replacing a granted board App now reliably stops delayed interactive work before it crosses the MCP boundary. Operators no longer see a revoked App complete a side-effecting call after removal, and stale pins cannot retain interactive tool declarations.

## Evidence

- Pre-fix deterministic Gateway regressions: delayed `mcp.app.callTool` and `mcp.app.listTools` returned success after revocation; board pinning checked the grant once and remained interactive; the standalone bridge returned HTTP 200.
- Pre-fix real-process proof: a real mock-provider turn created an interactive App view, a real Streamable HTTP MCP catalog refresh was held, the widget was removed, and release produced HTTP 200 with `postRevocationExecuted: true`.
- Post-fix real-process proof: `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts` — 1/1 passed on the final local tree; the same flow returned HTTP 403 with `MCP App widget grant is no longer active`, and the MCP child recorded no post-revocation call.
- Focused owner proof: `node scripts/run-vitest.mjs src/gateway/server-methods/mcp-app.test.ts src/gateway/server-methods/board.test.ts src/gateway/server-methods/board.runtime-boundaries.test.ts src/gateway/mcp-app-standalone.test.ts` — 66/66 passed.
- `node scripts/check-changed.mjs -- <nine changed paths>` — passed for core, coreTests, extensionTests, testRoot, and tooling lanes.
- `git diff --check` — passed.
- Final Codex autoreview after all follow-up edits — clean, no accepted/actionable findings.
- The first CI head exposed an unrelated flaky Chrome helper test: its real loopback WebSocket shutdown path used a 20 ms budget despite the owning Chrome probe contract being 200 ms. The final head uses the canonical budget; the exact case passed 10/10 repetitions and the full `chrome.test.ts` file passed 36/36.

Production LOC: +12/-2 (net +10), justified by post-await authorization at the shared dispatch/list and board-persistence owners. Tests and test support: +764/-203; 213 added lines are a mechanical split of pre-existing runtime-boundary board tests required to bring the touched test owner below its line limit.
