### PR TITLE
fix(cli): CLI commands crash on multi-agent rosters without --agent

### DIFF
--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -317,7 +317,7 @@ export function registerModelsCli(program: Command) {
     .command("list")
     .description("List saved auth profiles")
     .option("--provider <id>", "Filter by provider id")
-    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option("--agent <id>", "Agent id (default: configured system agent)")
     .option("--json", "Output JSON", false)
     .action(async (opts, command) => {
       await withModelsRuntime(async ({ defaultRuntime, resolveModelAgentOption }) => {
@@ -499,7 +499,7 @@ export function registerModelsCli(program: Command) {
     .command("get")
     .description("Show per-agent auth profile order override")
     .requiredOption("--provider <name>", "Provider id (e.g. anthropic)")
-    .option("--agent <id>", "Agent id (default: configured default agent)")
+    .option("--agent <id>", "Agent id (default: configured system agent)")
     .option("--json", "Output JSON", false)
     .action(async (opts, command) => {
       await withModelsRuntime(async ({ defaultRuntime, resolveModelAgentOption }) => {

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -4100,6 +4100,48 @@ describe("runCli exit behavior", () => {
     });
   });
 
+  it("starts the local TUI when any explicit-roster agent has inference configured", async () => {
+    primeBareRootConfig({
+      agents: {
+        ownership: "explicit",
+        entries: {
+          alpha: { model: "openai/gpt-5.6-luna" },
+          beta: { model: "openai/gpt-5.6-sol" },
+        },
+      },
+    });
+    probeGatewayConfiguredModelMock.mockResolvedValueOnce({
+      kind: "unreachable",
+      detail: "offline",
+    });
+
+    await runBareCli();
+
+    expect(runTuiMock).toHaveBeenCalledWith({
+      deliver: false,
+      local: true,
+      forceProcessExitOnReturn: true,
+    });
+  });
+
+  it("routes an explicit roster with no configured inference to onboarding", async () => {
+    primeBareRootConfig({
+      agents: {
+        ownership: "explicit",
+        entries: { alpha: {}, beta: {} },
+      },
+    });
+    probeGatewayConfiguredModelMock.mockResolvedValueOnce({
+      kind: "unreachable",
+      detail: "offline",
+    });
+
+    await runBareCli();
+
+    expect(setupWizardCommandMock).toHaveBeenCalledWith({});
+    expect(runTuiMock).not.toHaveBeenCalled();
+  });
+
   it.each([
     { label: "LAN IP", url: "ws://192.168.1.10:18789" },
     { label: "mDNS", url: "ws://gateway.local:18789" },

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -444,9 +444,9 @@ async function resolveConfiguredTuiLaunchTarget(
     }
     return { kind: "onboarding" };
   }
-  const { resolveAgentEffectiveModelPrimary, resolveDefaultAgentId } =
+  const { listAgentIds, resolveAgentEffectiveModelPrimary } =
     await import("../agents/agent-scope.js");
-  if (!resolveAgentEffectiveModelPrimary(config, resolveDefaultAgentId(config))) {
+  if (!listAgentIds(config).some((agentId) => resolveAgentEffectiveModelPrimary(config, agentId))) {
     return { kind: "onboarding" };
   }
   return { kind: "tui", local: true };

--- a/src/commands/models/auth-list.test.ts
+++ b/src/commands/models/auth-list.test.ts
@@ -94,6 +94,9 @@ describe("modelsAuthListCommand", () => {
 
     await modelsAuthListCommand({ provider: "OpenAI", agent: "coder", json: true }, runtime);
 
+    expect(mocks.resolveModelsTargetAgent).toHaveBeenCalledWith(expect.anything(), "coder", {
+      kind: "read",
+    });
     expect(mocks.externalCliDiscoveryForProviderAuth).toHaveBeenCalledWith({
       cfg: {},
       provider: "openai",

--- a/src/commands/models/auth-list.ts
+++ b/src/commands/models/auth-list.ts
@@ -131,7 +131,7 @@ export async function modelsAuthListCommand(
   runtime: RuntimeEnv,
 ) {
   const cfg = await loadModelsConfig({ commandName: "models auth list", runtime });
-  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent);
+  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent, { kind: "read" });
   const providerFilter = resolveProviderFilter(opts.provider);
   const store = ensureAuthProfileStore(
     agentDir,

--- a/src/commands/models/auth-logout.ts
+++ b/src/commands/models/auth-logout.ts
@@ -56,7 +56,7 @@ export async function modelsAuthLogoutCommand(
   }
 
   const cfg = await loadModelsConfig({ commandName: "models auth logout", runtime });
-  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent);
+  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent, { kind: "mutation" });
   // External CLI overlays (Claude/Codex CLI) are not ours to delete, so the
   // removable set is exactly the persisted store.
   const store = ensureAuthProfileStoreWithoutExternalProfiles(agentDir);

--- a/src/commands/models/auth-order.test.ts
+++ b/src/commands/models/auth-order.test.ts
@@ -1,4 +1,4 @@
-// Covers `models auth order set/clear`: store writes and running-gateway refresh.
+// Covers `models auth order get/set/clear`: read targeting, store writes, and gateway refresh.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthProfileStore } from "../../agents/auth-profiles.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -8,6 +8,10 @@ const mocks = vi.hoisted(() => ({
   ensureAuthProfileStore: vi.fn(),
   setAuthProfileOrder: vi.fn(),
   loadModelsConfig: vi.fn(),
+  resolveModelsTargetAgent: vi.fn((_cfg: OpenClawConfig, rawAgentId?: string) => ({
+    agentId: rawAgentId ?? "main",
+    agentDir: `/tmp/agent-${rawAgentId ?? "main"}`,
+  })),
   refreshRunningGatewayAuthState: vi.fn(async () => undefined),
 }));
 
@@ -26,10 +30,7 @@ vi.mock("./shared.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./shared.js")>();
   return {
     ...actual,
-    resolveModelsTargetAgent: (_cfg: OpenClawConfig, rawAgentId?: string) => ({
-      agentId: rawAgentId ?? "main",
-      agentDir: `/tmp/agent-${rawAgentId ?? "main"}`,
-    }),
+    resolveModelsTargetAgent: mocks.resolveModelsTargetAgent,
   };
 });
 
@@ -37,7 +38,8 @@ vi.mock("./auth-refresh.js", () => ({
   refreshRunningGatewayAuthState: mocks.refreshRunningGatewayAuthState,
 }));
 
-const { modelsAuthOrderClearCommand, modelsAuthOrderSetCommand } = await import("./auth-order.js");
+const { modelsAuthOrderClearCommand, modelsAuthOrderGetCommand, modelsAuthOrderSetCommand } =
+  await import("./auth-order.js");
 
 function createRuntime(): RuntimeEnv & { logs: string[] } {
   const logs: string[] = [];
@@ -75,6 +77,16 @@ describe("models auth order", () => {
     );
   });
 
+  it("get resolves an omitted agent through the read target", async () => {
+    const runtime = createRuntime();
+    await modelsAuthOrderGetCommand({ provider: "anthropic" }, runtime);
+
+    expect(mocks.resolveModelsTargetAgent).toHaveBeenCalledWith(expect.anything(), undefined, {
+      kind: "read",
+    });
+    expect(runtime.logs).toContain("Agent: main");
+  });
+
   it("set writes the store order and refreshes a running gateway", async () => {
     const runtime = createRuntime();
     await modelsAuthOrderSetCommand(
@@ -86,6 +98,9 @@ describe("models auth order", () => {
       agentDir: "/tmp/agent-ops",
       provider: "anthropic",
       order: ["anthropic:b", "anthropic:a"],
+    });
+    expect(mocks.resolveModelsTargetAgent).toHaveBeenCalledWith(expect.anything(), "ops", {
+      kind: "mutation",
     });
     expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledWith("ops");
     expect(runtime.logs).toContain("Auth profile order override: anthropic:b, anthropic:a");
@@ -123,6 +138,9 @@ describe("models auth order", () => {
       agentDir: "/tmp/agent-main",
       provider: "anthropic",
       order: null,
+    });
+    expect(mocks.resolveModelsTargetAgent).toHaveBeenCalledWith(expect.anything(), undefined, {
+      kind: "mutation",
     });
     expect(mocks.refreshRunningGatewayAuthState).toHaveBeenCalledWith("main");
     expect(runtime.logs.some((line) => line.includes("Auth profile order override cleared"))).toBe(

--- a/src/commands/models/auth-order.ts
+++ b/src/commands/models/auth-order.ts
@@ -46,6 +46,7 @@ function describeOrderFallback(cfg: OpenClawConfig, provider: string): string {
 async function resolveAuthOrderContext(
   opts: { provider: string; agent?: string },
   runtime: RuntimeEnv,
+  kind: "read" | "mutation",
 ) {
   const rawProvider = opts.provider?.trim();
   if (!rawProvider) {
@@ -55,7 +56,7 @@ async function resolveAuthOrderContext(
   }
   const provider = normalizeProviderId(rawProvider);
   const cfg = await loadModelsConfig({ commandName: "models auth-order", runtime });
-  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent);
+  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent, { kind });
   return { cfg, agentId, agentDir, provider };
 }
 
@@ -64,7 +65,7 @@ export async function modelsAuthOrderGetCommand(
   opts: { provider: string; agent?: string; json?: boolean },
   runtime: RuntimeEnv,
 ) {
-  const { cfg, agentId, agentDir, provider } = await resolveAuthOrderContext(opts, runtime);
+  const { cfg, agentId, agentDir, provider } = await resolveAuthOrderContext(opts, runtime, "read");
   const store = ensureAuthProfileStore(agentDir, {
     externalCli: externalCliDiscoveryForProviderAuth({ cfg, provider }),
   });
@@ -96,7 +97,8 @@ export async function modelsAuthOrderClearCommand(
   opts: { provider: string; agent?: string },
   runtime: RuntimeEnv,
 ) {
-  const { cfg, agentId, agentDir, provider } = await resolveAuthOrderContext(opts, runtime);
+  const context = await resolveAuthOrderContext(opts, runtime, "mutation");
+  const { cfg, agentId, agentDir, provider } = context;
   const updated = await setAuthProfileOrder({
     agentDir,
     provider: resolveProviderIdForAuth(provider, { config: cfg }),
@@ -119,7 +121,8 @@ export async function modelsAuthOrderSetCommand(
   opts: { provider: string; agent?: string; order: string[] },
   runtime: RuntimeEnv,
 ) {
-  const { cfg, agentId, agentDir, provider } = await resolveAuthOrderContext(opts, runtime);
+  const context = await resolveAuthOrderContext(opts, runtime, "mutation");
+  const { cfg, agentId, agentDir, provider } = context;
 
   const store = ensureAuthProfileStore(agentDir, {
     externalCli: externalCliDiscoveryForProviderAuth({ cfg, provider }),

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -302,7 +302,7 @@ async function resolveModelsAuthContext(params?: {
 
 async function resolveModelsAuthAgent(rawAgentId?: string | null, config?: OpenClawConfig) {
   const cfg = config ?? (await loadValidConfigOrThrow());
-  return resolveModelsTargetAgent(cfg, rawAgentId ?? undefined);
+  return resolveModelsTargetAgent(cfg, rawAgentId ?? undefined, { kind: "mutation" });
 }
 
 function resolveRequestedProviderOrThrow(

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -425,7 +425,9 @@ describe("modelsListCommand forward-compat", () => {
 
     await modelsListCommand({ agent: "research", json: true }, createRuntime() as never);
 
-    expect(mocks.resolveModelsTargetAgent).toHaveBeenCalledWith(mocks.resolvedConfig, "research");
+    expect(mocks.resolveModelsTargetAgent).toHaveBeenCalledWith(mocks.resolvedConfig, "research", {
+      kind: "read",
+    });
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/openclaw-agent-research");
   });
 

--- a/src/commands/models/list.list-command.ts
+++ b/src/commands/models/list.list-command.ts
@@ -93,7 +93,9 @@ export async function modelsListCommand(
     commandName: "models list",
     runtime,
   });
-  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent);
+  const { agentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent, {
+    kind: "read",
+  });
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId) ?? resolveDefaultAgentWorkspaceDir();
   const metadataSnapshot = loadManifestMetadataSnapshot({
     config: cfg,

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -6,12 +6,11 @@ import {
 } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { colorize, theme } from "../../../packages/terminal-core/src/theme.js";
+import { listAgentIds } from "../../agents/agent-scope-config.js";
 import {
-  resolveAgentDir,
   resolveAgentExplicitModelPrimary,
   resolveAgentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
 } from "../../agents/agent-scope.js";
 import {
   buildAuthHealthSummary,
@@ -99,7 +98,7 @@ import {
   DEFAULT_MODEL,
   DEFAULT_PROVIDER,
   ensureFlagCompatibility,
-  resolveKnownAgentId,
+  resolveModelsTargetAgent,
 } from "./shared.js";
 
 type ProviderUsageRuntime = typeof import("../../infra/provider-usage.js");
@@ -367,11 +366,14 @@ export async function modelsStatusCommand(
     runtime,
     skipPluginValidation: opts.probe !== true,
   });
-  const agentId = resolveKnownAgentId({ cfg, rawAgentId: opts.agent });
-  const workspaceAgentId = agentId ?? resolveDefaultAgentId(cfg);
-  const agentDir = agentId
-    ? resolveAgentDir(cfg, agentId)
-    : (resolveEnvAgentDirOverride() ?? resolveAgentDir(cfg, workspaceAgentId));
+  const explicitAgentId = opts.agent?.trim();
+  const { agentId: workspaceAgentId, agentDir } = resolveModelsTargetAgent(cfg, opts.agent, {
+    agentDirOverride: explicitAgentId ? undefined : resolveEnvAgentDirOverride(),
+    kind: "read",
+  });
+  // Only an explicit --agent narrows the reported model/fallback overrides; an inferred
+  // system-agent target still reports unscoped defaults, matching this command's shipped output.
+  const agentId = explicitAgentId ? workspaceAgentId : undefined;
   const workspaceDir =
     resolveAgentWorkspaceDir(cfg, workspaceAgentId) ?? resolveDefaultAgentWorkspaceDir();
   const agentModelPrimary = agentId ? resolveAgentExplicitModelPrimary(cfg, agentId) : undefined;
@@ -648,9 +650,13 @@ export async function modelsStatusCommand(
         ...(probedProvider ? [normalizeProviderId(probedProvider)] : []),
       ]),
     ].toSorted((left, right) => left.localeCompare(right));
+    // Omitting agentId lets the catalog resolve its own owner, which still dead-ends on an
+    // ambiguous roster (prepared-model-catalog.ts resolveInputs). Keep the historical omission
+    // for single-agent installs and name the resolved owner only when the roster needs one.
+    const catalogAgentId = agentId ?? (listAgentIds(cfg).length > 1 ? workspaceAgentId : undefined);
     const catalog = await loadPreparedModelCatalogSnapshot({
       config: cfg,
-      ...(agentId ? { agentId } : {}),
+      ...(catalogAgentId ? { agentId: catalogAgentId } : {}),
       providerDiscoveryProviderIds,
       readOnly: true,
     });

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -747,6 +747,7 @@ describe("modelsStatusCommand auth overview", () => {
         readOnly: true,
       }),
     );
+    expect(mocks.loadModelCatalog.mock.calls.at(-1)?.[0]).not.toHaveProperty("agentId");
 
     expectResolveAgentDirCalledFor("main");
     expect(mocks.ensureAuthProfileStore).toHaveBeenCalled();
@@ -989,6 +990,51 @@ describe("modelsStatusCommand auth overview", () => {
         });
       },
     );
+  });
+
+  it("uses system-agent storage without changing unscoped model output", async () => {
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        ownership: "explicit",
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-6", fallbacks: [] },
+          systemAgent: { agentId: "jeremiah" },
+        },
+        entries: { main: {}, jeremiah: {} },
+      },
+      models: { providers: {} },
+    });
+    mocks.resolveAgentExplicitModelPrimary.mockClear();
+    mocks.resolveAgentModelFallbacksOverride.mockClear();
+    mocks.loadModelCatalog.mockClear();
+
+    try {
+      await withAgentScopeOverrides(
+        {
+          primary: "openai/gpt-5.6-luna",
+          fallbacks: ["openai/gpt-5.6-sol"],
+        },
+        async () => {
+          const localRuntime = createRuntime();
+          await modelsStatusCommand({ json: true }, localRuntime as never);
+
+          expectResolveAgentDirCalledFor("jeremiah");
+          expect(mocks.resolveAgentExplicitModelPrimary).not.toHaveBeenCalled();
+          expect(mocks.loadModelCatalog).toHaveBeenCalledWith(
+            expect.objectContaining({ agentId: "jeremiah", readOnly: true }),
+          );
+          expect(parseFirstJsonLog(localRuntime)).toMatchObject({
+            defaultModel: "anthropic/claude-opus-4-6",
+            fallbacks: [],
+          });
+        },
+      );
+    } finally {
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+    }
   });
 
   it("rejects API-key auth for subscription-only Codex Spark", async () => {

--- a/src/commands/models/shared.test.ts
+++ b/src/commands/models/shared.test.ts
@@ -44,9 +44,54 @@ describe("models/shared", () => {
 
   it("names only the supported model-command escape for an ambiguous roster", () => {
     expect(() =>
-      resolveModelsTargetAgent({
-        agents: { ownership: "explicit", entries: { main: {}, helper: {}, third: {} } },
-      }),
+      resolveModelsTargetAgent(
+        {
+          agents: { ownership: "explicit", entries: { main: {}, helper: {}, third: {} } },
+        },
+        undefined,
+        { kind: "mutation" },
+      ),
+    ).toThrow(
+      "Multiple agents are configured, but the model command has no explicit owner. Pass --agent <id>.",
+    );
+  });
+
+  it("resolves unscoped model reads through the configured system agent", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "helper" } },
+        entries: { main: {}, helper: {} },
+      },
+    };
+
+    expect(resolveModelsTargetAgent(cfg, undefined, { kind: "read" }).agentId).toBe("helper");
+    expect(resolveModelsTargetAgent(cfg, "main", { kind: "read" }).agentId).toBe("main");
+    expect(() => resolveModelsTargetAgent(cfg, "", { kind: "read" })).toThrow(
+      "--agent must not be blank",
+    );
+    expect(() =>
+      resolveModelsTargetAgent(
+        {
+          agents: {
+            ownership: "explicit",
+            defaults: { systemAgent: { agentId: "missing" } },
+            entries: { main: {}, helper: {} },
+          },
+        },
+        undefined,
+        { kind: "read" },
+      ),
+    ).toThrow('Unknown agent id "missing".');
+  });
+
+  it("keeps credential mutations explicit on an ambiguous roster", () => {
+    expect(() =>
+      resolveModelsTargetAgent(
+        { agents: { ownership: "explicit", entries: { main: {}, helper: {} } } },
+        undefined,
+        { kind: "mutation" },
+      ),
     ).toThrow(
       "Multiple agents are configured, but the model command has no explicit owner. Pass --agent <id>.",
     );

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -1,5 +1,7 @@
 /** Shared helpers for model commands that read or mutate model config. */
-import { resolveAgentDir, resolveDefaultAgentId, listAgentIds } from "../../agents/agent-scope.js";
+
+import { resolveSystemAgentTargetAgentId } from "../../agents/agent-scope-config.js";
+import { listAgentIds, resolveAgentDir, resolveSoleAgentId } from "../../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
 import {
   buildModelAliasIndex,
@@ -131,37 +133,43 @@ export function resolveModelKeysFromEntries(params: {
     .map((entry) => modelKey(entry.ref.provider, entry.ref.model));
 }
 
-/** Validates an optional agent id against configured agents. */
-export function resolveKnownAgentId(params: {
-  cfg: OpenClawConfig;
-  rawAgentId?: string | null;
-}): string | undefined {
-  const raw = params.rawAgentId?.trim();
-  if (!raw) {
-    return undefined;
-  }
-  const agentId = normalizeAgentId(raw);
-  const knownAgents = listAgentIds(params.cfg);
-  if (!knownAgents.includes(agentId)) {
+function resolveKnownAgentId(cfg: OpenClawConfig, rawAgentId: string): string {
+  const agentId = normalizeAgentId(rawAgentId);
+  if (!listAgentIds(cfg).includes(agentId)) {
     throw new Error(
-      `Unknown agent id "${raw}". Use "${formatCliCommand("openclaw agents list")}" to see configured agents.`,
+      `Unknown agent id "${rawAgentId}". Use "${formatCliCommand("openclaw agents list")}" to see configured agents.`,
     );
   }
   return agentId;
 }
 
+type ModelsTargetMode = { kind: "read"; agentDirOverride?: string } | { kind: "mutation" };
+
 /** Resolves the selected model-command agent and its profile directory. */
 export function resolveModelsTargetAgent(
   cfg: OpenClawConfig,
-  rawAgentId?: string,
+  rawAgentId: string | undefined,
+  mode: ModelsTargetMode,
 ): {
   agentId: string;
   agentDir: string;
 } {
-  const agentId =
-    resolveKnownAgentId({ cfg, rawAgentId }) ??
-    resolveDefaultAgentId(cfg, { surface: "the model command", hint: "Pass --agent <id>." });
-  const agentDir = resolveAgentDir(cfg, agentId);
+  const requested = rawAgentId?.trim();
+  if (rawAgentId !== undefined && !requested) {
+    throw new Error("--agent must not be blank");
+  }
+  const requestedAgentId = requested ? resolveKnownAgentId(cfg, requested) : undefined;
+  const resolvedAgentId =
+    mode.kind === "read"
+      ? resolveSystemAgentTargetAgentId(cfg, requestedAgentId, {
+          surface: "model inspection",
+          hint: "Pass --agent <id> or set agents.defaults.systemAgent.agentId.",
+        })
+      : (requestedAgentId ??
+        resolveSoleAgentId(cfg, { surface: "the model command", hint: "Pass --agent <id>." }));
+  const agentId = resolveKnownAgentId(cfg, resolvedAgentId);
+  const agentDirOverride = mode.kind === "read" ? mode.agentDirOverride : undefined;
+  const agentDir = agentDirOverride ?? resolveAgentDir(cfg, agentId);
   return { agentId, agentDir };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running an explicit multi-agent roster
(`agents.ownership: "explicit"` with two or more entries) would hit a hard
`AgentSelectionRequiredError` crash instead of a working command, whenever a CLI
surface tried to resolve a single implicit "default" agent that such a roster
deliberately does not define.

Affected surfaces:

- bare `openclaw` startup (no reachable Gateway) — crashed instead of launching the TUI
- `openclaw models status`
- `openclaw models list`
- `openclaw models auth list`
- `openclaw models auth-order get`

These call sites predate `agents.ownership: "explicit"` (introduced in #114388)
and were left on the deprecated `resolveDefaultAgentId`, which returns nothing
once ownership is explicit and more than one agent exists.

This also closes a documented-vs-shipped gap. `agents.defaults.systemAgent.agentId`
is documented in `schema.help.core.ts` as the owner used when `models.list` and
`models.authStatus` omit an agent id. The Gateway server methods honored that;
the local CLI twins did not.

## Why This Change Was Made

Two different repairs, because the two surfaces ask different questions.

Bare startup only needs to know whether inference is configured *at all* before
choosing TUI vs onboarding — it never needed to name an owner. It now asks that
directly across the roster and hands off to the TUI, which already owns agent
selection and resolves by workspace path first. Routing ambiguous rosters to
onboarding instead was considered and rejected: it would drop a fully configured
multi-agent install back into the setup wizard, trading a loud crash for a silent
wrong outcome.

The model commands genuinely need an owner, so `resolveModelsTargetAgent` now
takes a closed `{ kind: "read" | "mutation" }` mode. Reads resolve explicit
`--agent`, then the configured system agent, then a sole agent. Credential
mutations (`auth login`/`logout`, `auth-order set`/`clear`) deliberately still
refuse an ambiguous roster — silently guessing which agent to write credentials
into is worse than erroring — and now name `--agent <id>`, which is a real flag
on those commands. The deprecated resolver is gone from that owner.

Non-goal: `resolveInputs` in `src/agents/prepared-model-catalog.ts` still carries
the same deprecated fallback. It is a broadly used runtime path that deserves its
own caller audit, so it is filed as follow-up rather than widened into this PR.
The `catalogAgentId` conditional in `list.status-command.ts` exists only to avoid
that upstream dead-end and is commented as such, so it can be deleted with it.

A third reported surface, `src/cli/config-model-validation.ts:422`, was
investigated and found **not** reachable: `expandInheritedDefaultRefs` drops
unowned refs on explicit rosters and substitutes agent-scoped copies, so
`ref.agentId` is always populated by the time validation resolves. No change was
made there.

## User Impact

Operators on explicit multi-agent rosters can now run `openclaw`, `models status`,
`models list`, `models auth list`, and `models auth-order get` without passing
`--agent` on every invocation. Those reads follow
`agents.defaults.systemAgent.agentId` when set, matching the documented contract
and the Gateway's existing behavior; an explicit `--agent` still wins.

Credential-writing commands are unchanged in spirit but clearer: they still
require an explicit agent on an ambiguous roster, and now say which flag to pass.

No change for single-agent installs. `models status` output on the default path
is intentionally byte-identical to before.

## Evidence

Reproduced first against an isolated `OPENCLAW_STATE_DIR` with
`ownership: "explicit"` and two agents. Before:

```
[openclaw] Could not start the CLI.
[openclaw] Reason: Multiple agents are configured, but this operation has no explicit owner...
[ELIFECYCLE] Command failed with exit code 1.
```

After, with `agents.defaults.systemAgent.agentId: alpha`:

```
$ models status --plain
openai/gpt-5.6-luna

$ models status --plain --agent beta
anthropic/claude-sonnet-4-6

$ models auth list --json
{ "agentId": "alpha", "profiles": [] }
```

Mutation still requires an explicit owner:

```
$ models auth logout openai:missing --yes
Multiple agents are configured, but the model command has no explicit owner. Pass --agent <id>.
```

Bare startup now selects the TUI path on a configured explicit roster
(`OpenClaw TUI needs an interactive TTY...`) where it previously crashed, and a
roster with no configured inference still routes to onboarding.

Each regression test was confirmed to fail against pre-fix code for the intended
reason, including the `AgentSelectionRequiredError` raised at
`resolveConfiguredTuiLaunchTarget` and `resolveModelsTargetAgent`. Coverage for
the single-agent defaults startup path was kept alongside the new explicit-roster
cases rather than replaced.

Local validation: 300 focused tests green across the touched suites,
`node scripts/check-changed.mjs` exit 0, and a clean Codex autoreview on the
final tree.

Production LOC is `+59/-40` (net `+19`), tests `+150/-12`. The production growth
is the read/mutation ownership boundary that fixed four additional commands, plus
inline comments the repo guide requires for non-obvious invariants; it is stated
rather than optimized away.
