### PR TITLE
docs(gateway): document incognito session authorization for compatibility endpoints

### DIFF
--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -105,6 +105,21 @@ By default the endpoint is **stateless per request** (a new session key is gener
 
 If the request includes an OpenAI `user` string, the Gateway derives a stable session key from it so repeated calls can share an agent session. For custom apps, reuse the same `user` value per conversation thread; avoid account-level identifiers unless you want multiple conversations/devices to share one OpenClaw session. Use `x-openclaw-session-key` only when you need explicit routing control across multiple clients/threads, with application-owned keys that avoid the reserved namespaces above.
 
+### Explicit incognito session continuation
+
+Explicitly selecting or continuing an incognito conversation with `x-openclaw-session-key` (the `sessionKey` override) requires effective `operator.admin` authority. This rule follows authority, not ingress: it denies both trusted-proxy callers without owner/admin authority and private `gateway.auth.mode="none"` callers that explicitly narrow `x-openclaw-scopes` below admin (for example, to `operator.write`). Either receives HTTP `403` with a `forbidden` error. A profile-less private no-auth caller on this path gets `missing scope: operator.admin`; for a profile-backed caller, the response hides the private target with this error shape (where `<sessionKey>` is the requested override):
+
+```json
+{
+  "error": {
+    "message": "Incognito session \"<sessionKey>\" was not found.",
+    "type": "forbidden"
+  }
+}
+```
+
+Owner/admin callers keep explicit incognito session continuation. A private no-auth request without `x-openclaw-scopes` receives the default operator scopes, including `operator.admin`, and is therefore treated as owner/admin. Reserved internal namespace overrides (`subagent:`, `cron:`, `acp:`) remain a separate validation failure and still return HTTP `400` with `invalid_request_error`.
+
 ## Request limits
 
 The endpoint uses built-in limits of 20 MB per request body, 8 `image_url`

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -39,6 +39,21 @@ If the request includes an OpenResponses `user` string, the Gateway derives a st
 
 `previous_response_id` reuses the earlier response's session when the request stays within the same agent/user/requested-session scope (matched by auth subject, agent id, and `x-openclaw-session-key`).
 
+### Explicit incognito session continuation
+
+Explicitly selecting or continuing an incognito conversation with `x-openclaw-session-key` (the `sessionKey` override) requires effective `operator.admin` authority. This rule follows authority, not ingress: it denies both trusted-proxy callers without owner/admin authority and private `gateway.auth.mode="none"` callers that explicitly narrow `x-openclaw-scopes` below admin (for example, to `operator.write`). Either receives HTTP `403` with a `forbidden` error. A profile-less private no-auth caller on this path gets `missing scope: operator.admin`; for a profile-backed caller, the response hides the private target with this error shape (where `<sessionKey>` is the requested override):
+
+```json
+{
+  "error": {
+    "message": "Incognito session \"<sessionKey>\" was not found.",
+    "type": "forbidden"
+  }
+}
+```
+
+Owner/admin callers keep explicit incognito session continuation. A private no-auth request without `x-openclaw-scopes` receives the default operator scopes, including `operator.admin`, and is therefore treated as owner/admin. Reserved internal namespace overrides (`subagent:`, `cron:`, `acp:`) remain a separate validation failure and still return HTTP `400` with `invalid_request_error`.
+
 ## Request shape
 
 | Field                                                            | Support                                                                                                                        |


### PR DESCRIPTION
> Devin Robison · GPT-5 Codex · via @drobison00

## What Problem This Solves

The Chat Completions and OpenResponses compatibility API pages described explicit incognito-session continuation as a trusted-proxy-only rule. The same effective-authority check also governs private `gateway.auth.mode="none"` requests that explicitly narrow `x-openclaw-scopes`, so the earlier wording left that caller class unclear.

## Why This Change Was Made

Current `main` derives compatibility-session ownership from effective `operator.admin`, not from ingress type. No-auth requests trust declared scopes; a narrowed `operator.write` request is not an owner, while an un-narrowed request receives the default scopes, including admin (`src/gateway/auth.ts:513-529`; `src/gateway/http-auth-utils.ts:619-630`, `701-725`, `749-769`; `src/gateway/method-scopes.ts:46-55`). The shared compatibility-session authorizer then denies a profile-less, non-owner incognito target with `missing scope: operator.admin` (`src/gateway/http-utils.ts:315-345`).

Both public pages now describe this existing authority boundary without changing runtime behavior.

## User Impact

Explicitly selecting or continuing an incognito conversation requires effective `operator.admin` authority on both compatibility endpoints.

- A trusted-proxy caller without owner/admin authority receives HTTP `403` with a `forbidden` error; profile-backed callers receive the privacy-preserving not-found message.
- A private `gateway.auth.mode="none"` caller that explicitly narrows `x-openclaw-scopes` below admin, such as to `operator.write`, also receives the HTTP `403` forbidden envelope, with `missing scope: operator.admin` on the profile-less path.
- A private no-auth request without `x-openclaw-scopes` receives the default operator scopes, including `operator.admin`, and keeps explicit continuation.
- Owner/admin callers keep explicit continuation. Reserved `subagent:`, `cron:`, and `acp:` overrides remain a separate HTTP `400 invalid_request_error` path.

## Evidence

- Both handlers call the shared session authorizer and emit HTTP `403` with `error.type: "forbidden"` on denial (`src/gateway/openai-http.ts:983-992`; `src/gateway/openresponses-http.ts:671-679`).
- The updated contract appears consistently in `docs/gateway/openai-http-api.md:108-121` and `docs/gateway/openresponses-http-api.md:42-55`.
- MDX validation passed: 752 files checked.
- Link validation passed: 7,254 internal links checked, 0 broken.
- Changed-file validation passed for both documentation files, including formatting; `git diff --check` passed.
- Published commit: `f6e82146288cc6cc678aedf51ecd7a65f4c23812`.
