### PR TITLE
fix(claude-cli): make a failed live turn diagnosable

### DIFF
--- a/src/agents/cli-runner/claude-live-turn.ts
+++ b/src/agents/cli-runner/claude-live-turn.ts
@@ -5,6 +5,7 @@ import {
   type DiagnosticToolParamsSummary,
   type DiagnosticToolSource,
 } from "../../infra/diagnostic-events.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import type {
   CliBackendConfig,
   CliBackendParseJsonlEvent,
@@ -136,9 +137,12 @@ export function failClaudeTurn(host: ClaudeLiveTurnHost, error: unknown): void {
   if (!turn) {
     return;
   }
-  const errorKind = error instanceof Error ? error.name : typeof error;
+  // error.name is "Error" for most provider and HTTP failures, so a 529, a socket
+  // reset and a parse failure all logged identically. Carry the message and the
+  // run ids the turn already holds so a failure can be read and correlated.
+  const refs = diagnosticBase(turn);
   cliBackendLog.warn(
-    `claude live session turn failed: provider=${host.providerId} model=${host.modelId} durationMs=${Date.now() - turn.startedAtMs} error=${errorKind}`,
+    `claude live session turn failed: provider=${host.providerId} model=${host.modelId} runId=${refs.runId} sessionId=${refs.sessionId} durationMs=${Date.now() - turn.startedAtMs} error=${formatErrorMessage(error)}`,
   );
   turn.streamingParser.finish();
   failActiveClaudeLiveTools(turn, error);


### PR DESCRIPTION
## What Problem This Solves

Fixes #126400.

When a Claude live-session turn fails, `failClaudeTurn` emits one warn line that cannot tell you what failed or which run it belonged to (`src/agents/cli-runner/claude-live-turn.ts:138`):

```ts
const errorKind = error instanceof Error ? error.name : typeof error;
cliBackendLog.warn(
  `claude live session turn failed: provider=${host.providerId} model=${host.modelId} durationMs=${...} error=${errorKind}`,
);
```

`error.name` is `"Error"` for most real provider and HTTP failures, so a 529 overload, a socket reset and a stream parse failure all log identically as `error=Error`. The line also carries no run identifier, so a failure cannot be correlated with the run that produced it.

## Why This Change Was Made

Both missing pieces were already in scope. The function starts from `host.currentTurn`, and this same file already has `diagnosticBase(turn)` reading `turn.diagnosticRefs` for the diagnostic event stream. So this is a formatting fix, not new plumbing.

The message now goes through `formatErrorMessage`, which redacts sensitive text (`src/infra/errors.ts:57`) and is already how the sibling cleanup path reports errors in this area (`claude-live-process.ts:113`), so the convention here is established rather than invented.

**One deliberate narrowing of the issue's ask.** The issue asks for `runId` and `sessionKey`. I added `runId` and `sessionId` and left `sessionKey` out: no plain log line in this repository emits `sessionKey=`, and a session key can carry a user-identifying target, so putting one into backend logs would be a new pattern rather than a fix. `runId` is what makes the line correlatable, and `sessionId` is opaque. Happy to add `sessionKey` if you would rather have it and consider that safe here.

I also could not confirm one detail in the issue: it says this module already imports `formatErrorMessage`. It did not, so this adds the import; the helper was being used in the sibling file.

## User Impact

An operator reading gateway logs after a failed Claude live turn now sees the actual failure text and the run it belongs to, instead of `error=Error` with no correlation. No behavior change to the turn itself: the same error is still rejected to the caller and the same cleanup runs.

## Evidence

Before and after, for the same failure:

```
before:  claude live session turn failed: provider=... model=... durationMs=812 error=Error
after:   claude live session turn failed: provider=... model=... runId=... sessionId=... durationMs=812 error=<redacted message>
```

```
node scripts/run-vitest.mjs src/agents/cli-runner/claude-live-turn.test.ts \
                            src/agents/cli-runner/claude-live-turn-diagnostics.test.ts   37 passed
node scripts/run-vitest.mjs src/agents/cli-runner                                       21 files, 404 passed
node scripts/run-oxlint.mjs src/agents/cli-runner/claude-live-turn.ts                    clean
node scripts/run-tsgo.mjs -p tsconfig.core.json                                          clean
./node_modules/.bin/oxfmt src/agents/cli-runner/claude-live-turn.ts                      clean
```

No test is added, deliberately. This changes the text of one log line, and the only test that could fail on the old code would assert that exact string, which is the brittle source-text style this repo's test guidance steers away from. The failure path itself is already covered by the 404 tests above, and they still pass. If you would rather have an assertion pinning `runId` into that line, say so and I will add one.

Production delta is +6/-2, three of the added lines being the comment explaining why `error.name` was insufficient.

Not live-verified against a real provider overload, since that needs a failing upstream I cannot trigger on demand. The change is a log format on an already-exercised path, so the proof here is the existing suites plus the code above.

AI-assisted: yes, with the source read by hand and every command above run by me.
