### PR TITLE
fix(gateway): harden node-carried worker desktops

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -507,9 +507,9 @@ setting, then restart the node host. Update-required hosts must be upgraded and
 restarted before selection.
 
 When a known session host disconnects, its paired-device record preserves only
-the last accepted current-v5 hosting consent. The offline row remains visible
-and disabled with status unavailable. A current disabled or empty v5
-publication records false; older v1-v4 and update-required dialects do not
+the last accepted current-v6 hosting consent. The offline row remains visible
+and disabled with status unavailable. A current disabled or empty v6
+publication records false; older v1-v5 and update-required dialects do not
 overwrite the last current fact. Connected inventory always wins over stored
 history, a missing stored value means false, and exact worker slots are never
 persisted or shown as offline capacity.

--- a/docs/plan/runners.md
+++ b/docs/plan/runners.md
@@ -390,9 +390,9 @@ speak. Additions:
   …", and the legacy/unclean-exit fallback "Last seen …". Connected rows stay
   silent. This adds no config, event, or SQLite schema-version surface.
 - **Offline host identity is producer-owned.** After accepting the current
-  generation's current v5 runner inventory, the paired-node transaction
+  generation's current v6 runner inventory, the paired-node transaction
   records its exact `workerHost.enabled` consent. An explicit disabled or
-  empty current publication records false; legacy v1-v4 and update-required
+  empty current publication records false; legacy v1-v5 and update-required
   dialects never overwrite the last current fact. Live inventory remains
   authoritative while connected. Offline catalog rows use the stored boolean,
   missing means false, and exact worker slots are never persisted. This adds

--- a/src/gateway/node-runner-inventory-runtime.ts
+++ b/src/gateway/node-runner-inventory-runtime.ts
@@ -1,11 +1,7 @@
 import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 import {
   NODE_RUNNER_UPDATE_REQUIRED_ISSUE,
-  NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE,
-  NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE,
-  NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE,
   NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
-  NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE,
   type NodeRunnerInventoryIssue,
   type NodeWorkerHostDeclaration,
 } from "../infra/node-runner-inventory.js";
@@ -109,11 +105,7 @@ export function resolveNodeRunnerInventoryIssue(
     declaration.clientId === GATEWAY_CLIENT_IDS.NODE_HOST &&
     declaration.clientMode === "node" &&
     declaration.protocolFeatures.length === 1 &&
-    (declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE ||
-      declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE ||
-      declaration.protocolFeatures[0] ===
-        NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE ||
-      declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE)
+    declaration.protocolFeatures[0] !== NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE
     ? NODE_RUNNER_UPDATE_REQUIRED_ISSUE
     : undefined;
 }

--- a/src/gateway/server-methods/nodes.read.test.ts
+++ b/src/gateway/server-methods/nodes.read.test.ts
@@ -2,10 +2,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import type { PairedDevice } from "../../infra/device-pairing.js";
 import { resolveNodePairingState } from "../../infra/device-pairing.js";
-import {
-  NODE_RUNNER_UPDATE_REQUIRED_ISSUE,
-  NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE,
-} from "../../infra/node-runner-inventory.js";
+import { NODE_RUNNER_UPDATE_REQUIRED_ISSUE } from "../../infra/node-runner-inventory.js";
 import { createNodeRegistryRuntime, updateNodeRunnerInventory } from "../node-registry-private.js";
 import { NodeRegistry } from "../node-registry.js";
 import { nodeReadHandlers } from "./nodes.read.js";
@@ -97,7 +94,7 @@ describe("node read projections", () => {
         registry: nodeRegistry,
         nodeId: remoteNodeId,
         connId: remoteClient?.connId,
-        declaration: { protocolFeatures: [NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE] },
+        declaration: { protocolFeatures: ["node-worker-supervisor-v1"] },
       }),
     ).toEqual({ changed: true });
     listDevicePairingMock.mockResolvedValue({ pending: [], paired: pairedNodes });

--- a/src/gateway/server-methods/nodes.read.ts
+++ b/src/gateway/server-methods/nodes.read.ts
@@ -15,10 +15,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import {
   formatNodeRunnerUpdateRequired,
   NODE_RUNNER_UPDATE_REQUIRED_ISSUE,
-  NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE,
-  NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE,
-  NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE,
-  NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE,
+  NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
   parseNodeRunnerInventoryDeclaration,
 } from "../../infra/node-runner-inventory.js";
 import { resolveLocalNodeId } from "../../node-host/local-id.js";
@@ -438,11 +435,8 @@ export const nodeReadHandlers: GatewayRequestHandlers = {
       return;
     }
     if (
-      declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE ||
-      declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE ||
-      declaration.protocolFeatures[0] ===
-        NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE ||
-      declaration.protocolFeatures[0] === NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE
+      declaration.protocolFeatures.length === 1 &&
+      declaration.protocolFeatures[0] !== NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE
     ) {
       respond(
         false,

--- a/src/gateway/server-methods/nodes.runner-inventory.test.ts
+++ b/src/gateway/server-methods/nodes.runner-inventory.test.ts
@@ -4,10 +4,6 @@ import { WORKER_PROTOCOL_FEATURES } from "../../../packages/gateway-protocol/src
 import { NODE_WORKER_SUPERVISOR_STATUS_COMMAND } from "../../infra/node-commands.js";
 import {
   NODE_RUNNER_UPDATE_REQUIRED_ISSUE,
-  NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE,
-  NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE,
-  NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE,
-  NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE,
   NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
 } from "../../infra/node-runner-inventory.js";
 import {
@@ -453,7 +449,7 @@ describe("nodeHandlers node.runnerInventory.update", () => {
       nodeRegistry: runtime.nodeRegistry,
       client: legacyClient,
       declaration: {
-        protocolFeatures: [NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE],
+        protocolFeatures: ["node-worker-supervisor-v1"],
         workerRuns: LEGACY_WORKER_RUNS,
       },
     });
@@ -525,22 +521,29 @@ describe("nodeHandlers node.runnerInventory.update", () => {
     [
       "v2 build-shaped",
       {
-        protocolFeatures: [NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE],
+        protocolFeatures: ["node-worker-supervisor-v2"],
         workerRuns: { ...LEGACY_WORKER_RUNS, bundlePrewarm: 1 },
       },
     ],
     [
       "v3 execution-context",
       {
-        protocolFeatures: [NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE],
+        protocolFeatures: ["node-worker-supervisor-v3"],
         workerHost: { enabled: true, capacity: "available", bundlePrewarm: 1 },
       },
     ],
     [
       "v4 binary-capacity",
       {
-        protocolFeatures: [NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE],
+        protocolFeatures: ["node-worker-supervisor-v4"],
         workerHost: { enabled: true, capacity: "full", bundlePrewarm: 1 },
+      },
+    ],
+    [
+      "v5 exact-capacity",
+      {
+        protocolFeatures: ["node-worker-supervisor-v5"],
+        workerHost: { enabled: true, capacity: AVAILABLE_CAPACITY, bundlePrewarm: 1 },
       },
     ],
   ] as const)("routes the shipped %s inventory to update recovery", async (_name, declaration) => {

--- a/src/gateway/server-worker-environment-startup.test.ts
+++ b/src/gateway/server-worker-environment-startup.test.ts
@@ -1,10 +1,18 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { GATEWAY_CLIENT_IDS } from "../../packages/gateway-protocol/src/client-info.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../infra/node-runner-inventory.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { createNodeDesktopStreamBroker } from "./desktop/node-stream-broker.js";
 import { createDesktopSessionRegistry } from "./desktop/session-registry.js";
+import type {
+  NodeWorkerSupervisorNodeProof,
+  NodeWorkerSupervisorTransport,
+} from "./node-registry-private.js";
 import {
   createGatewayWorkerEnvironmentRuntime,
   loadGatewayWorkerEnvironmentStartupState,
@@ -20,6 +28,7 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
   closeOpenClawStateDatabaseForTest();
+  resetConfigRuntimeState();
 });
 
 describe("gateway worker environment startup", () => {
@@ -115,5 +124,89 @@ describe("gateway worker environment startup", () => {
     } finally {
       closeOpenClawStateDatabaseForTest();
     }
+  });
+
+  it("composes node desktop control into the worker environment runtime", async () => {
+    const stateDir = tempDirs.make("openclaw-worker-node-desktop-startup-");
+    await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+      setRuntimeConfigSnapshot({ cloudWorkers: { desktop: true } });
+      const startup = await loadGatewayWorkerEnvironmentStartupState();
+      const intent = startup.store.createIntent({
+        environmentId: "node-desktop-environment",
+        providerId: "fake-provider",
+        profileId: "desktop-profile",
+        profileSnapshot: { settings: { desktop: true } },
+        provisionOperationId: "provision:node-desktop-environment",
+      });
+      const provisioning = startup.store.transition({
+        environmentId: intent.environmentId,
+        from: intent.state,
+        to: "provisioning",
+      });
+      const nodeId = "node-desktop-device";
+      const app = { id: "terminal" as const, executablePath: "/usr/bin/true" };
+      const record = startup.store.transition({
+        environmentId: provisioning.environmentId,
+        from: provisioning.state,
+        to: "ready",
+        patch: {
+          leaseId: "node-desktop-lease",
+          nodeDeviceId: nodeId,
+          sshEndpoint: null,
+          sharedHost: true,
+          desktop: { protocol: "rfb", port: 5900, apps: [app] },
+          bootstrapReceipt: {
+            bundleHash: "a".repeat(64),
+            openclawVersion: "2026.8.14",
+            protocolFeatures: ["worker-heartbeat-v1"],
+            installKind: "bundle",
+          },
+          credential: {
+            credentialHash: hashWorkerCredential("node-desktop-credential"),
+            sessionId: null,
+            rpcSetVersion: 1,
+            expiresAtMs: Date.now() + 60_000,
+          },
+        },
+      });
+      const proof: NodeWorkerSupervisorNodeProof = {
+        nodeId,
+        connId: "node-desktop-conn",
+        pairingIdentity: "node-desktop-pairing",
+        pairingGeneration: "node-desktop-generation",
+        clientId: GATEWAY_CLIENT_IDS.NODE_HOST,
+        clientMode: "node",
+        protocolFeature: NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
+        workerHost: { enabled: true, capacity: { total: 1, available: 0 } },
+        commands: [],
+      };
+      const transport: NodeWorkerSupervisorTransport = {
+        listCurrentNodes: async () => [proof],
+        isCurrent: () => true,
+        invoke: async (request) => {
+          expect(request.isDispatchAuthorized()).toBe(true);
+          return { ok: true, payloadJSON: '{"status":"ready"}' };
+        },
+      };
+      const runtime = await createGatewayWorkerEnvironmentRuntime({
+        getPluginRegistry: () => ({ workerProviders: new Map() }),
+        desktopSessionRegistry: createDesktopSessionRegistry({ lingerMs: 1 }),
+        nodeDesktopStreamBroker: createNodeDesktopStreamBroker(),
+        startup,
+        log: { child: () => ({ warn: () => {} }) },
+      });
+      const service = runtime.workerEnvironmentService;
+      if (!service || !runtime.bindWorkerNodeDesktopControl) {
+        throw new Error("worker node desktop runtime was not composed");
+      }
+      runtime.bindWorkerNodeDesktopControl(transport);
+      try {
+        await expect(
+          service.launchDesktopApp({ environmentId: record.environmentId, app: "terminal" }),
+        ).resolves.toEqual({ app: "terminal", status: "ready" });
+      } finally {
+        await service.stop();
+      }
+    });
   });
 });

--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -503,7 +503,6 @@ describe("worker environment service", () => {
         desktop: support.DESKTOP,
       }),
       control: true,
-      nowMs: support.testState.nowMs,
     });
 
     await expect(

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -260,7 +260,6 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
         nodeStartup = nodeDesktop.observe({
           record,
           control: request.control,
-          nowMs: now(),
         });
         return;
       }

--- a/src/gateway/worker-environments/node-desktop-carrier.test.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.test.ts
@@ -1,5 +1,5 @@
 import { PassThrough } from "node:stream";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-runner-inventory.js";
 import type { NodeDesktopStreamBroker } from "../desktop/node-stream-broker.js";
@@ -101,9 +101,12 @@ function pendingTransport(params: {
 
 describe("worker node desktop carrier", () => {
   support.setupWorkerEnvironmentServiceSuite();
+  afterEach(() => vi.restoreAllMocks());
 
   it("observes an exact durable node desktop without SSH and preauthenticates it", async () => {
     const record = support.seedReadyNodeDesktop("worker-node-desktop-observe");
+    let nowMs = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => nowMs);
     let current: WorkerEnvironmentRecord | undefined = record;
     let proofCurrent = true;
     const proof = nodeProof(record.nodeDeviceId!);
@@ -116,13 +119,15 @@ describe("worker node desktop carrier", () => {
     });
     carrier.bindRuntime({ transport: transport.transport, streamBroker: streamed.broker });
 
-    const observing = carrier.observe({ record, control: false, nowMs: support.testState.nowMs });
+    const observing = carrier.observe({ record, control: false });
     await support.waitForFast(() => expect(transport.invoke).toHaveBeenCalledOnce());
+    nowMs = 50_000;
     streamed.attachNext();
 
     await expect(observing).resolves.toMatchObject({
       transport: "rfb",
       wsPath: expect.stringMatching(/^\/desktop\/observe\?token=[a-f0-9]{48}$/u),
+      expiresAtMs: 110_000,
       control: false,
     });
     expect(await observing).not.toHaveProperty("vncPassword");
@@ -178,11 +183,7 @@ describe("worker node desktop carrier", () => {
     });
     carrier.bindRuntime({ transport: transport.transport, streamBroker: streamed.broker });
 
-    const observing = carrier.observe({
-      record,
-      control: true,
-      nowMs: support.testState.nowMs,
-    });
+    const observing = carrier.observe({ record, control: true });
     await support.waitForFast(() => expect(transport.invoke).toHaveBeenCalledOnce());
     current = mutate(record) as WorkerEnvironmentRecord;
     const stream = streamed.attachNext();
@@ -205,11 +206,7 @@ describe("worker node desktop carrier", () => {
     });
     carrier.bindRuntime({ transport: transport.transport, streamBroker: streamed.broker });
 
-    const observing = carrier.observe({
-      record,
-      control: true,
-      nowMs: support.testState.nowMs,
-    });
+    const observing = carrier.observe({ record, control: true });
     await support.waitForFast(() => expect(transport.invoke).toHaveBeenCalledOnce());
     proofCurrent = false;
     const stream = streamed.attachNext();
@@ -287,4 +284,41 @@ describe("worker node desktop carrier", () => {
     }
     expect(invoke).toHaveBeenCalledOnce();
   });
+
+  it.each(["durable owner", "pairing proof"] as const)(
+    "rejects a successful launch receipt after the %s becomes stale",
+    async (staleBoundary) => {
+      const record = support.seedReadyNodeDesktop(`worker-node-launch-stale-${staleBoundary}`);
+      let current: WorkerEnvironmentRecord | undefined = record;
+      let proofCurrent = true;
+      const proof = nodeProof(record.nodeDeviceId!);
+      const invocation = deferred<{ ok: boolean; payloadJSON: string }>();
+      const invoke = vi.fn<NodeWorkerSupervisorTransport["invoke"]>(
+        async () => await invocation.promise,
+      );
+      const carrier = createWorkerNodeDesktopCarrier({
+        store: { get: () => current },
+        desktopRegistry: createDesktopSessionRegistry({ lingerMs: 1 }),
+      });
+      carrier.bindRuntime({
+        transport: {
+          listCurrentNodes: async () => [proof],
+          isCurrent: () => proofCurrent,
+          invoke,
+        },
+        streamBroker: fakeBroker().broker,
+      });
+
+      const launched = carrier.launchApp({ record, app: support.DESKTOP.apps![0]! });
+      await support.waitForFast(() => expect(invoke).toHaveBeenCalledOnce());
+      if (staleBoundary === "durable owner") {
+        current = { ...record, ownerEpoch: record.ownerEpoch + 1 };
+      } else {
+        proofCurrent = false;
+      }
+      invocation.resolve({ ok: true, payloadJSON: '{"status":"ready"}' });
+
+      await expect(launched).rejects.toThrow("launch owner changed");
+    },
+  );
 });

--- a/src/gateway/worker-environments/node-desktop-carrier.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.ts
@@ -265,7 +265,6 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
   const observe = async (request: {
     record: WorkerEnvironmentRecord;
     control: boolean;
-    nowMs: number;
   }): Promise<WorkerDesktopObserveResult> => {
     const binding = snapshotNodeDesktopBinding(request.record);
     const active: ActiveNodeDesktopStream = {
@@ -348,6 +347,7 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
         throw new Error("Worker environment node desktop owner changed before publication");
       }
       active.reservationTransferred = true;
+      const issuedAtMs = Date.now();
       const minted = mintDesktopObserverToken({
         sourceKey: binding.environmentId,
         ownerEpoch: binding.ownerEpoch,
@@ -357,7 +357,7 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
           auth: "vnc-password",
           credentials: { password: attached.vncPassword },
         },
-        nowMs: request.nowMs,
+        nowMs: issuedAtMs,
       });
       active.unclaimedTimer = setTimeout(
         () => {
@@ -365,7 +365,7 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
             void stopStream(active);
           }
         },
-        Math.max(0, minted.expiresAtMs - request.nowMs),
+        Math.max(0, minted.expiresAtMs - Date.now()),
       );
       active.unclaimedTimer.unref?.();
       void active.invocation.finally(() => retireStream(active)).catch(() => undefined);

--- a/src/infra/node-runner-inventory.ts
+++ b/src/infra/node-runner-inventory.ts
@@ -3,12 +3,12 @@ import { validateWorkerAdmissionHandshake } from "../../packages/gateway-protoco
 import { WORKER_BUNDLE_PREWARM_VERSION } from "../../packages/gateway-protocol/src/schema/worker-admission.js";
 
 export const NODE_RUNNER_INVENTORY_UPDATE_METHOD = "node.runnerInventory.update";
-export const NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE = "node-worker-supervisor-v5";
-export const NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE = "node-worker-supervisor-v4";
-export const NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE =
-  "node-worker-supervisor-v3";
-export const NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE = "node-worker-supervisor-v2";
-export const NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE = "node-worker-supervisor-v1";
+export const NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE = "node-worker-supervisor-v6";
+const NODE_WORKER_SUPERVISOR_EXACT_CAPACITY_PROTOCOL_FEATURE = "node-worker-supervisor-v5";
+const NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE = "node-worker-supervisor-v4";
+const NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE = "node-worker-supervisor-v3";
+const NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE = "node-worker-supervisor-v2";
+const NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE = "node-worker-supervisor-v1";
 export const NODE_WORKER_BUNDLE_RETENTION_VERSION = 1;
 export const NODE_WORKER_BUNDLE_STATUS_VERSION = 1;
 export const NODE_WORKER_CAPACITY_MAX = 1_024;
@@ -43,7 +43,8 @@ export type NodeRunnerInventoryDeclaration =
         | typeof NODE_WORKER_SUPERVISOR_LEGACY_PROTOCOL_FEATURE
         | typeof NODE_WORKER_SUPERVISOR_BUILD_PROTOCOL_FEATURE
         | typeof NODE_WORKER_SUPERVISOR_EXECUTION_CONTEXT_V1_PROTOCOL_FEATURE
-        | typeof NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE,
+        | typeof NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE
+        | typeof NODE_WORKER_SUPERVISOR_EXACT_CAPACITY_PROTOCOL_FEATURE,
       ];
     }
   | {
@@ -187,6 +188,11 @@ export function parseNodeRunnerInventoryDeclaration(
     feature === NODE_WORKER_SUPERVISOR_BINARY_CAPACITY_PROTOCOL_FEATURE
   ) {
     return keys.length === 2 && isBinaryCapacityWorkerHostDeclaration(value.workerHost)
+      ? { protocolFeatures: [feature] }
+      : null;
+  }
+  if (feature === NODE_WORKER_SUPERVISOR_EXACT_CAPACITY_PROTOCOL_FEATURE) {
+    return keys.length === 2 && parseWorkerHostDeclaration(value.workerHost)
       ? { protocolFeatures: [feature] }
       : null;
   }

--- a/src/node-host/desktop-stream-command.test.ts
+++ b/src/node-host/desktop-stream-command.test.ts
@@ -1,5 +1,8 @@
+import fs from "node:fs/promises";
 import http from "node:http";
 import net from "node:net";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import {
@@ -84,6 +87,55 @@ describe("node desktop stream command", () => {
     ).rejects.toThrow("refusing unauthenticated loopback RFB server");
   });
 
+  it("bounds the provider-owned VNC password file", async () => {
+    const port = await listenRfbSecurity(2);
+    const root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "desktop-password-"));
+    const oversized = path.join(root, "oversized");
+    await fs.writeFile(oversized, "x".repeat(4 * 1024 + 1));
+    cleanups.push(async () => fs.rm(root, { recursive: true, force: true }));
+
+    for (const [passwordFilePath, message] of [
+      [root, "must be a regular file"],
+      [oversized, "is too large"],
+    ] as const) {
+      await expect(
+        invokeNodeWorkerDesktopStream({
+          paramsJSON: JSON.stringify({
+            ticket: TICKET,
+            attachPath: `/node-desktop/attach?ticket=${TICKET}`,
+            port,
+            passwordFilePath,
+          }),
+          gatewayUrl: "ws://127.0.0.1:1",
+          signal: new AbortController().signal,
+        }),
+      ).rejects.toThrow(message);
+    }
+  });
+
+  it("honors cancellation before reading a VNC password file", async () => {
+    const port = await listenRfbSecurity(2);
+    const root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "desktop-password-"));
+    const passwordFilePath = path.join(root, "password");
+    await fs.writeFile(passwordFilePath, "secret");
+    cleanups.push(async () => fs.rm(root, { recursive: true, force: true }));
+    const controller = new AbortController();
+    controller.abort(new Error("desktop owner closed"));
+
+    await expect(
+      invokeNodeWorkerDesktopStream({
+        paramsJSON: JSON.stringify({
+          ticket: TICKET,
+          attachPath: `/node-desktop/attach?ticket=${TICKET}`,
+          port,
+          passwordFilePath,
+        }),
+        gatewayUrl: "ws://127.0.0.1:1",
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("desktop owner closed");
+  });
+
   it("refuses a caller-selected RFB target before dialing", async () => {
     await expect(
       invokeNodeDesktopStream({
@@ -113,7 +165,7 @@ describe("node desktop stream command", () => {
     ).rejects.toThrow("ticket and attachPath required");
   });
 
-  it("tears down both splice sockets when the invoke is cancelled", async () => {
+  it("authenticates public and worker attaches and tears down both sockets when cancelled", async () => {
     const rfbPeers = new Set<net.Socket>();
     const rfbServer = net.createServer((socket) => {
       rfbPeers.add(socket);
@@ -142,10 +194,21 @@ describe("node desktop stream command", () => {
 
     const httpServer = http.createServer();
     const wss = new WebSocketServer({ server: httpServer });
-    let streamClosed = false;
-    wss.on("connection", (ws) => {
+    const streams: Array<{
+      accessHeaders: [string | undefined, string | undefined];
+      closed: boolean;
+    }> = [];
+    wss.on("connection", (ws, request) => {
+      const stream = {
+        accessHeaders: [
+          request.headers["cf-access-client-id"],
+          request.headers["cf-access-client-secret"],
+        ] as [string | undefined, string | undefined],
+        closed: false,
+      };
+      streams.push(stream);
       ws.once("close", () => {
-        streamClosed = true;
+        stream.closed = true;
       });
     });
     await new Promise<void>((resolve) => {
@@ -162,24 +225,45 @@ describe("node desktop stream command", () => {
         }),
     );
 
-    const controller = new AbortController();
-    const emitStatus = vi.fn(async () => undefined);
-    const running = invokeNodeDesktopStream({
-      paramsJSON: JSON.stringify({
-        ticket: TICKET,
-        attachPath: `/node-desktop/attach?ticket=${TICKET}`,
-      }),
-      gatewayUrl: `ws://127.0.0.1:${gatewayAddress.port}`,
-      config: { enabled: true, port: rfbAddress.port },
-      signal: controller.signal,
-      emitStatus,
-    });
-    await vi.waitFor(() => expect(emitStatus).toHaveBeenCalledWith("desktop stream attached\n"));
+    for (const kind of ["public", "worker"] as const) {
+      const controller = new AbortController();
+      const emitStatus = vi.fn(async () => undefined);
+      const connection = {
+        paramsJSON: JSON.stringify({
+          ticket: TICKET,
+          attachPath: `/node-desktop/attach?ticket=${TICKET}`,
+          ...(kind === "worker" ? { port: rfbAddress.port } : {}),
+        }),
+        gatewayUrl: `ws://127.0.0.1:${gatewayAddress.port}`,
+        gatewayCloudflareAccess: {
+          clientId: "desktop-client-id",
+          clientSecret: "desktop-client-secret",
+        },
+        signal: controller.signal,
+      };
+      const running =
+        kind === "worker"
+          ? invokeNodeWorkerDesktopStream(connection)
+          : invokeNodeDesktopStream({
+              ...connection,
+              config: { enabled: true, port: rfbAddress.port },
+              emitStatus,
+            });
+      await vi.waitFor(() => expect(streams).toHaveLength(kind === "public" ? 1 : 2));
+      const stream = streams.at(-1);
+      if (!stream) {
+        throw new Error("expected desktop stream attachment");
+      }
+      expect(stream.accessHeaders).toEqual(["desktop-client-id", "desktop-client-secret"]);
+      if (kind === "public") {
+        expect(emitStatus).toHaveBeenCalledWith("desktop stream attached\n");
+      }
 
-    controller.abort();
+      controller.abort();
 
-    await expect(running).resolves.toBeUndefined();
-    await vi.waitFor(() => expect(streamClosed).toBe(true));
-    await vi.waitFor(() => expect(rfbPeers.size).toBe(0));
+      await expect(running).resolves.toBeUndefined();
+      await vi.waitFor(() => expect(stream.closed).toBe(true));
+      await vi.waitFor(() => expect(rfbPeers.size).toBe(0));
+    }
   });
 });

--- a/src/node-host/desktop-stream-command.ts
+++ b/src/node-host/desktop-stream-command.ts
@@ -1,9 +1,14 @@
+import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import net from "node:net";
 import type { TLSSocket } from "node:tls";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { WebSocket, type ClientOptions, type RawData } from "ws";
 import { normalizeTlsFingerprint } from "../../packages/gateway-client/src/client-address-utils.js";
+import {
+  buildCloudflareAccessHeaders,
+  type CloudflareAccessCredentials,
+} from "../../packages/gateway-client/src/cloudflare-access.js";
 import type { DesktopHostConfig } from "../config/types.desktop.js";
 import { classifyRfbSecurity, probeRfbServer } from "../gateway/desktop/rfb-probe.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
@@ -16,6 +21,7 @@ const MAX_PAYLOAD_BYTES = 1024 * 1024;
 const PAUSE_BUFFERED_BYTES = 4 * 1024 * 1024;
 const RESUME_CHECK_MS = 25;
 const TICKET_PATTERN = /^[a-f0-9]{48}$/u;
+const MAX_VNC_PASSWORD_BYTES = 4 * 1024;
 
 type NodeDesktopStreamCommandParams = {
   ticket: string;
@@ -103,12 +109,20 @@ function createPinnedRequestFinisher(
   };
 }
 
-function websocketOptions(url: string, tlsFingerprint?: string): ClientOptions {
+function websocketOptions(
+  url: string,
+  tlsFingerprint?: string,
+  cloudflareAccess?: CloudflareAccessCredentials,
+): ClientOptions {
+  const edgeHeaders = cloudflareAccess
+    ? { headers: buildCloudflareAccessHeaders(cloudflareAccess) }
+    : {};
   if (!url.startsWith("wss:") || !tlsFingerprint?.trim()) {
-    return { maxPayload: MAX_PAYLOAD_BYTES };
+    return { maxPayload: MAX_PAYLOAD_BYTES, ...edgeHeaders };
   }
   return {
     maxPayload: MAX_PAYLOAD_BYTES,
+    ...edgeHeaders,
     rejectUnauthorized: false,
     finishRequest: createPinnedRequestFinisher(tlsFingerprint),
   };
@@ -130,16 +144,43 @@ function assertGatewayTlsFingerprint(ws: WebSocket, expectedRaw?: string): void 
   }
 }
 
-async function readVncPassword(passwordFile?: string): Promise<string | undefined> {
+async function readVncPassword(
+  passwordFile: string | undefined,
+  signal: AbortSignal,
+): Promise<string | undefined> {
   if (!passwordFile) {
     return undefined;
   }
-  const password = (await fs.readFile(passwordFile, "utf8")).replace(/[\r\n]+$/u, "");
-  if (!password) {
-    throw new Error("desktop.host.passwordFile is empty");
+  signal.throwIfAborted();
+  const handle = await fs.open(passwordFile, fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
+  const buffer = Buffer.alloc(MAX_VNC_PASSWORD_BYTES + 1);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new Error("desktop password file must be a regular file");
+    }
+    if (stat.size > MAX_VNC_PASSWORD_BYTES) {
+      throw new Error("desktop password file is too large");
+    }
+    signal.throwIfAborted();
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    signal.throwIfAborted();
+    if (bytesRead > MAX_VNC_PASSWORD_BYTES) {
+      throw new Error("desktop password file is too large");
+    }
+    const password = buffer
+      .subarray(0, bytesRead)
+      .toString("utf8")
+      .replace(/[\r\n]+$/u, "");
+    if (!password) {
+      throw new Error("desktop password file is empty");
+    }
+    registerSecretValueForRedaction(password);
+    return password;
+  } finally {
+    buffer.fill(0);
+    await handle.close();
   }
-  registerSecretValueForRedaction(password);
-  return password;
 }
 
 async function waitForSocketConnect(socket: net.Socket): Promise<void> {
@@ -239,6 +280,7 @@ async function runNodeDesktopStreamCommand(params: {
   command: NodeDesktopStreamCommandParams;
   gatewayUrl: string;
   gatewayTlsFingerprint?: string;
+  gatewayCloudflareAccess?: CloudflareAccessCredentials;
   target: NodeDesktopStreamTarget;
   passwordFile?: string;
   signal: AbortSignal;
@@ -275,7 +317,7 @@ async function runNodeDesktopStreamCommand(params: {
     throw new Error("loopback RFB server security is unsupported");
   }
   const vncPassword =
-    auth === "vnc-password" ? await readVncPassword(params.passwordFile) : undefined;
+    auth === "vnc-password" ? await readVncPassword(params.passwordFile, params.signal) : undefined;
   if (params.signal.aborted) {
     return;
   }
@@ -285,7 +327,10 @@ async function runNodeDesktopStreamCommand(params: {
   // attach metadata is accepted so no stateful handshake bytes are lost.
   rfbSocket.pause();
   const wsUrl = attachWebSocketUrl(params.gatewayUrl, params.command.attachPath);
-  const ws = new WebSocket(wsUrl, websocketOptions(wsUrl, params.gatewayTlsFingerprint));
+  const ws = new WebSocket(
+    wsUrl,
+    websocketOptions(wsUrl, params.gatewayTlsFingerprint, params.gatewayCloudflareAccess),
+  );
   let aborted: boolean = params.signal.aborted;
   let resolveAbort!: () => void;
   const abort = new Promise<void>((resolve) => {
@@ -334,6 +379,7 @@ export async function invokeNodeDesktopStream(params: {
   paramsJSON?: string | null;
   gatewayUrl?: string;
   gatewayTlsFingerprint?: string;
+  gatewayCloudflareAccess?: CloudflareAccessCredentials;
   config?: DesktopHostConfig;
   signal?: AbortSignal;
   emitStatus?: (status: string) => Promise<void>;
@@ -351,6 +397,9 @@ export async function invokeNodeDesktopStream(params: {
     ...(params.gatewayTlsFingerprint
       ? { gatewayTlsFingerprint: params.gatewayTlsFingerprint }
       : {}),
+    ...(params.gatewayCloudflareAccess
+      ? { gatewayCloudflareAccess: params.gatewayCloudflareAccess }
+      : {}),
     target: {
       host: "127.0.0.1",
       port: params.config.port ?? DEFAULT_DESKTOP_PORT,
@@ -366,6 +415,7 @@ export async function invokeNodeWorkerDesktopStream(params: {
   paramsJSON?: string | null;
   gatewayUrl?: string;
   gatewayTlsFingerprint?: string;
+  gatewayCloudflareAccess?: CloudflareAccessCredentials;
   signal?: AbortSignal;
 }): Promise<void> {
   if (!params.gatewayUrl || !params.signal) {
@@ -377,6 +427,9 @@ export async function invokeNodeWorkerDesktopStream(params: {
     gatewayUrl: params.gatewayUrl,
     ...(params.gatewayTlsFingerprint
       ? { gatewayTlsFingerprint: params.gatewayTlsFingerprint }
+      : {}),
+    ...(params.gatewayCloudflareAccess
+      ? { gatewayCloudflareAccess: params.gatewayCloudflareAccess }
       : {}),
     target: { host: "127.0.0.1", port: command.port },
     ...(command.passwordFilePath ? { passwordFile: command.passwordFilePath } : {}),

--- a/src/node-host/invoke-worker-supervisor.test.ts
+++ b/src/node-host/invoke-worker-supervisor.test.ts
@@ -291,6 +291,42 @@ describe("node-host worker supervisor commands", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "kills an in-flight desktop launcher when its invoke owner closes",
+    async () => {
+      const root = tempDirs.make("node-worker-desktop-launch-abort-");
+      const executablePath = path.join(root, "launcher");
+      const pidPath = `${executablePath}.pid`;
+      fs.writeFileSync(
+        executablePath,
+        '#!/bin/sh\nprintf \'%s\\n\' "$$" > "$0.pid"\nexec sleep 300\n',
+        { mode: 0o755 },
+      );
+      const controller = new AbortController();
+
+      const running = invokePrivate({
+        command: NODE_WORKER_DESKTOP_LAUNCH_COMMAND,
+        paramsJSON: JSON.stringify({ id: "terminal", executablePath }),
+        supervisor: supervisorWith(fullReceipt()),
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(fs.existsSync(pidPath)).toBe(true));
+      const pid = Number(fs.readFileSync(pidPath, "utf8").trim());
+      try {
+        controller.abort(new Error("desktop owner closed"));
+
+        await expect(running).resolves.toMatchObject({ result: undefined });
+        await vi.waitFor(() => expect(() => process.kill(pid, 0)).toThrow());
+      } finally {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // The expected path already reaped the launcher.
+        }
+      }
+    },
+  );
+
   it("dispatches bundle installation before a colliding plugin command", async () => {
     const build = {
       bundleHash: "a".repeat(64),

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -652,6 +652,7 @@ async function dispatchInvoke(
         paramsJSON: frame.paramsJSON,
         gatewayUrl: runtime.gatewayUrl,
         gatewayTlsFingerprint: runtime.gatewayTlsFingerprint,
+        gatewayCloudflareAccess: runtime.gatewayCloudflareAccess,
         config: runtime.desktopHostConfig,
         signal: runtime.signal,
         emitStatus: runtime.emitProgress,

--- a/src/node-host/node-worker-supervisor-commands.ts
+++ b/src/node-host/node-worker-supervisor-commands.ts
@@ -240,6 +240,7 @@ export async function invokeNodeWorkerSupervisorCommand(params: {
         paramsJSON: params.paramsJSON,
         gatewayUrl: params.gatewayUrl,
         gatewayTlsFingerprint: params.gatewayTlsFingerprint,
+        gatewayCloudflareAccess: params.gatewayCloudflareAccess,
         signal: params.signal,
       });
       return { handled: true, ok: true, payload: null };


### PR DESCRIPTION
Related: #126393

## What Problem This Solves

Fixes several upgrade and transport edge cases in the node-carried Cloud Worker Desktop path: existing v5 node hosts could be treated as current despite lacking the new desktop commands, Cloudflare Access headers were omitted from the private attach socket, a slow attachment could receive an expired observer token, and provider-owned VNC password files were read without a strict file/size boundary.

## Why This Change Was Made

This follow-up advances only the private node worker-supervisor dialect to v6, routing parsed v1-v5 nodes through the existing update-required path. It also propagates Access credentials, mints observer tokens at publication time, bounds password reads to regular files under 4 KiB, and revalidates durable/pairing authority after launch completion. The public Gateway protocol and SQLite schema are unchanged.

## User Impact

Existing v5 worker nodes must update/reconnect or be reprovisioned before hosting the restored Desktop capability. Desktop streaming now works through Cloudflare Access, slow node attachment receives a full observer window, and malformed or blocking credential paths fail closed. Browser and Terminal launchers are terminated when their invoke owner closes.

## Evidence

- Focused and sibling desktop/node/Gateway Vitest suites passed.
- `pnpm tsgo:core` and `pnpm tsgo:test:src` passed.
- Core lint, `pnpm check:changed`, `pnpm build`, and `git diff --check` passed.
- Cloudflare headers were verified through real local WebSocket upgrade and loopback RFB sockets.
- Existing fresh AWS and Hetzner node-backed Desktop launch/stream/restart/teardown proof landed with #126393.
- Fresh coordinator autoreview: no accepted/actionable P0/P1 findings (0.90).

This changes only the private node-supervisor execution-context dialect (`node-worker-supervisor-v6`), not the public Gateway protocol, storage schema, plugin SDK, or package version.

AI-assisted; I reviewed the implementation and proof.
