### PR TITLE
fix: scope selected provider hook loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Onboarding provider hook loading:** scope selected-model hook fallback to the chosen provider so metadata-only setup providers do not load unrelated plugins before configuration completes. Fixes #126408. Thanks @shakkernerd.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.

--- a/src/plugins/provider-wizard.test.ts
+++ b/src/plugins/provider-wizard.test.ts
@@ -85,12 +85,14 @@ function expectProviderResolutionCall(params?: {
   config?: object;
   env?: NodeJS.ProcessEnv;
   workspaceDir?: string;
+  providerRefs?: readonly string[];
   count?: number;
 }) {
   expect(resolvePluginProvidersCore).toHaveBeenCalledTimes(params?.count ?? 1);
   expect(resolvePluginProvidersCore).toHaveBeenCalledWith({
     ...createWizardRuntimeParams(params),
     mode: "setup",
+    ...(params?.providerRefs ? { providerRefs: params.providerRefs } : {}),
   });
 }
 
@@ -336,6 +338,7 @@ describe("provider wizard boundaries", () => {
     expectProviderResolutionCall({
       config: {},
       env,
+      providerRefs: ["vllm"],
     });
     expect(matchingHook).toHaveBeenCalledWith({
       config: {},

--- a/src/plugins/provider-wizard.ts
+++ b/src/plugins/provider-wizard.ts
@@ -42,6 +42,7 @@ type ProviderWizardProvidersResolver = (params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  providerRefs?: readonly string[];
 }) => ProviderPlugin[];
 
 let providerWizardProvidersResolverForTest: ProviderWizardProvidersResolver | undefined;
@@ -134,6 +135,7 @@ function resolveProviderWizardProviders(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  providerRefs?: readonly string[];
 }): ProviderPlugin[] {
   if (providerWizardProvidersResolverForTest) {
     return providerWizardProvidersResolverForTest(params);
@@ -143,6 +145,7 @@ function resolveProviderWizardProviders(params: {
     workspaceDir: params.workspaceDir,
     env: params.env,
     mode: "setup",
+    ...(params.providerRefs?.length ? { providerRefs: params.providerRefs } : {}),
   });
 }
 
@@ -334,6 +337,7 @@ export async function runProviderModelSelectedHookCore(params: {
       config: params.config,
       workspaceDir: params.workspaceDir,
       env: params.env,
+      providerRefs: [selectedProviderId],
     }).find((entry) => normalizeProviderId(entry.id) === selectedProviderId);
   if (!provider?.onModelSelected) {
     return;


### PR DESCRIPTION
## Summary

Scope selected-model hook fallback loading to the provider that owns the selected model.

This prevents onboarding from importing every provider plugin before displaying **Model configured** when the selected provider has no separate lightweight setup runtime.

## Problem

After Ollama setup selects `ollama/minimax-m2.7:cloud`, OpenClaw runs the provider’s optional `onModelSelected` callback before rendering the configured-model note.

The resolver first checks for a lightweight setup provider. Ollama validly has setup metadata without a separate setup runtime, so that lookup returns nothing.

The fallback then loads every provider plugin instead of only Ollama. This delays onboarding, scales with the installed plugin set, and can expose unrelated plugin loading failures.

Declining the recommended Ollama download does not call the pull API. The pause occurs afterward during selected-model hook resolution.

## Root cause

`runProviderModelSelectedHookCore()` calls `resolveProviderWizardProviders()` without carrying the normalized selected provider id.

The existing provider loader already supports scoped ownership resolution through `providerRefs`, including:

- setup provider descriptors;
- top-level provider ownership;
- provider aliases;
- configured providers using a plugin-owned native API;
- plugin enablement and allowlist policy.

The selected-model path was failing to provide that known ownership fact.

## Changes

- Extend the shared wizard provider resolver to accept provider references.
- Pass the normalized selected provider as the fallback scope.
- Preserve the lightweight setup-provider lookup as the preferred path.
- Keep full provider loading available for providers without lightweight setup runtimes.
- Add regression coverage requiring the selected provider reference during hook resolution.
- Add a changelog entry for the onboarding latency fix.

No provider-specific condition, cache, retry, timeout increase, or error suppression is introduced.

## Behavior after this change

The selected-model flow now behaves as follows:

```text
Check the selected provider’s lightweight setup runtime
  ↓ unavailable
Resolve the selected provider’s owning plugin
  ↓
Load only that provider
  ↓
Run its onModelSelected callback
  ↓
Display Model configured
```

Providers with lightweight setup runtimes retain their existing path. Providers without `onModelSelected` return without broad discovery.

## Performance

Measured using the same installed plugin state:

| Path | Before | After |
| --- | ---: | ---: |
| Confirmation to **Model configured** | 18.6 seconds | 572 ms |
| Selected-provider hook resolution | 18.6 seconds | 459 ms |

The scoped provider loader itself previously measured approximately 537 ms, with Ollama’s callback taking 9 ms.

## Verification

- Captured a pre-fix regression failure showing the hook resolver omitted `providerRefs`.
- Verified the regression passes after scoping the fallback.
- Verified declining the Ollama pull performs no pull request.
- Verified Ollama still selects `ollama/minimax-m2.7:cloud`.
- Verified provider aliases, setup ownership, configured API ownership, disabled-plugin policy, and workspace trust filtering through existing loader coverage.
- 117 focused provider, auth-choice, and Ollama setup tests passed remotely.
- Full changed-file gate passed.
- Full production build passed.
- Autoreview completed with no actionable findings.

Fixes #126408
