### PR TITLE
fix(ui): show mixed-role node connectivity

### DIFF
--- a/ui/src/lib/nodes/inventory.test.ts
+++ b/ui/src/lib/nodes/inventory.test.ts
@@ -30,6 +30,7 @@ describe("buildDeviceInventory", () => {
           deviceId: "node-1",
           displayName: "megaclaw",
           roles: ["operator", "node"],
+          connected: true,
           lastSeenAtMs: 1_000,
         }),
       ],
@@ -37,7 +38,7 @@ describe("buildDeviceInventory", () => {
         {
           nodeId: "node-1",
           displayName: "megaclaw",
-          connected: true,
+          connected: false,
           paired: true,
           caps: ["screen"],
           commands: ["system.run"],
@@ -54,6 +55,7 @@ describe("buildDeviceInventory", () => {
     const entry = firstGroup(groups).primary;
     expect(entry.id).toBe("node-1");
     expect(entry.connected).toBe(true);
+    expect(entry.node?.connected).toBe(false);
     expect(entry.roles).toEqual(["operator", "node"]);
     expect(entry.version).toBe("2026.6.11");
     expect(entry.node?.caps).toEqual(["screen"]);

--- a/ui/src/pages/devices/view-inventory.ts
+++ b/ui/src/pages/devices/view-inventory.ts
@@ -201,7 +201,7 @@ function entryWarnStatuses(
       </span>`,
     );
   }
-  if (isApprovedNode && !entry.connected && isWindowsPlatform(entry.platform)) {
+  if (isApprovedNode && entry.node?.connected === false && isWindowsPlatform(entry.platform)) {
     statuses.push(
       html`<span title=${t("devices.inventory.manualWakeTitle")}>
         ${renderSettingsStatus({ kind: "warn", label: t("devices.inventory.manualWake") })}
@@ -314,9 +314,10 @@ function renderInventoryEntry(entry: DeviceInventoryEntry, props: DevicesProps) 
     entry.node?.approvalState === "pending-reapproval"
       ? entry.node.pendingRequestId
       : undefined;
-  const connectionStatus = entry.connected
-    ? nothing
-    : renderSettingsStatus({ kind: "muted", label: t("devices.inventory.offline") });
+  const connectionStatus =
+    (entry.node?.connected ?? entry.connected)
+      ? nothing
+      : renderSettingsStatus({ kind: "muted", label: t("devices.inventory.offline") });
   return html`
     <div class="settings-row device-entry">
       ${renderDeviceTile(deviceIcon(entry))}

--- a/ui/src/pages/devices/view.devices.test.ts
+++ b/ui/src/pages/devices/view.devices.test.ts
@@ -532,6 +532,39 @@ describe("devices inventory rendering", () => {
     );
   });
 
+  it("shows node-only offline affordances while preserving mixed-role device liveness", () => {
+    const container = renderDevicesContainer({
+      devicesList: {
+        pending: [],
+        paired: [
+          {
+            deviceId: "windows-mixed",
+            displayName: "Mixed-role Windows",
+            platform: "Windows 11",
+            roles: ["operator", "node"],
+            connected: true,
+          },
+        ],
+      },
+      nodes: [
+        {
+          nodeId: "windows-mixed",
+          displayName: "Mixed-role Windows",
+          platform: "Windows 11",
+          connected: false,
+          paired: true,
+        },
+      ],
+    });
+    const section = getInventorySection(container);
+    const row = getSettingsRow(section, "Mixed-role Windows");
+
+    expect(section.textContent).toContain("1 of 1 connected");
+    expect(
+      Array.from(row.querySelectorAll(".settings-status"), (status) => status.textContent?.trim()),
+    ).toEqual(["offline", "manual wake required"]);
+  });
+
   it("shows token rows with rotate and revoke inside entry details", () => {
     const rotations: Array<{ deviceId: string; name: string; role: string }> = [];
     const revocations: Array<{ deviceId: string; role: string }> = [];


### PR DESCRIPTION
Closes #126426

## What Problem This Solves

Fixes an issue where operators viewing a mixed-role device in the Control UI Devices inventory would see the machine counted as connected while the offline node role and Windows manual-wake action were hidden whenever another role connection survived.

## Why This Change Was Made

The inventory's composite `connected` bit intentionally remains machine-wide (`node.connected || device.connected`) for connected-first grouping, summary counts, stale-cleanup safety, and operator-only presentation. Row presentation now reads the node projection's own connectivity for node-specific offline and manual-wake status, falling back to composite/device connectivity only when no node projection exists.

The owning boundary is the Devices row renderer. Gateway producers remain unchanged: `device.pair.list` reports device-wide liveness from any connected client for that device, while `node.list` reports node-role liveness from the live node session.

Regression provenance: #102810 intentionally introduced aggregate inventory liveness; #104735 later consumed that aggregate bit for Windows manual-wake presentation. Both PRs were authored and merged by @steipete, with the squash commits recorded by GitHub's `web-flow`; no automation trigger was involved.

No Gateway production code, protocol, config, schema, dependency, or device-token credential lifecycle code is changed. The separate device-token lifecycle repair remains out of scope.

## User Impact

Operators can still see that a mixed-role machine has a surviving connection, while the same row accurately says that its node role is offline and must be woken manually on Windows. Operator-only rows continue to use device-wide connectivity.

## Evidence

True-before regression:

- Focused UI run before the production fix: 45 passed, 1 failed.
- Expected row statuses: `["offline", "manual wake required"]`; received `[]`.

Final-diff proof:

- `node scripts/run-vitest.mjs ui/src/lib/nodes/inventory.test.ts ui/src/pages/devices/view.devices.test.ts` — 2 files, 46 tests passed.
- `node scripts/check-changed.mjs -- ui/src/lib/nodes/inventory.test.ts ui/src/pages/devices/view-inventory.ts ui/src/pages/devices/view.devices.test.ts` — conflict markers, ratchets, formatting, dependency/patch guards, dead exports, Control UI i18n, core-test/UI typechecks, oxlint, and stylelint passed.
- `git diff --check` — passed.
- Fresh Codex autoreview on the exact diff — no accepted/actionable findings; patch correctness 0.99.
- Production LOC: +5/−4 (net +1). Tests: +36/−1 (net +35). The single net production line expresses the node-projection fallback at the presentation owner without adding a duplicate connectivity field or changing a producer contract.

Production-bundle Chromium proof used a deterministic mocked current Gateway handshake and the actual `device.pair.list` plus `node.list` wire flow. It visibly shows `1 of 1 connected` while the mixed-role row shows `offline` and `manual wake required`. This is real Control UI bundle/browser proof against mocked Gateway responses, not an authenticated live provider or channel run.

![Mixed-role Windows row showing machine-wide connected summary and node-only offline/manual-wake status](https://github.com/user-attachments/assets/ae3eaa2b-f3ee-4845-b487-979f9a84d331)

https://github.com/user-attachments/assets/3c9c8bbd-30c9-432e-8935-f9e10064509f

AI-assisted: yes. The final behavior, source ownership, regression proof, visual proof, and review result were inspected before publication. No agent transcript is included.
