### PR TITLE
fix(ui): refresh device labels after rename

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -669,6 +669,7 @@ enum class GatewayEvent(
   NodeInvokeCancel("node.invoke.cancel"),
   NodeInvokeInput("node.invoke.input"),
   NodeInvokeRequest("node.invoke.request"),
+  DevicePairChanged("device.pair.changed"),
   DevicePairRequested("device.pair.requested"),
   DevicePairResolved("device.pair.resolved"),
   DevicePairSetupCompleted("device.pair.setup.completed"),

--- a/scripts/protocol-event-coverage.allowlist.json
+++ b/scripts/protocol-event-coverage.allowlist.json
@@ -3,6 +3,7 @@
   "ios": {
     "controlUi.sessionPullRequests.changed": "Sidebar PR indicators are a Control UI surface; native apps do not render session PR chips.",
     "cron": "Cron run activity is not surfaced in the iOS app.",
+    "device.pair.changed": "Device label projection refresh is a Control UI surface; iOS does not render the Gateway Devices page.",
     "device.pair.requested": "Device pairing flows poll via device.pair.* methods on iOS.",
     "device.pair.resolved": "Device pairing flows poll via device.pair.* methods on iOS.",
     "device.pair.setup.completed": "Generated setup lifecycle is a Control UI surface; iOS direct Watch setup completes through Watch connectivity.",
@@ -36,6 +37,7 @@
   "android": {
     "controlUi.sessionPullRequests.changed": "Sidebar PR indicators are a Control UI surface; native apps do not render session PR chips.",
     "cron": "Cron run activity is not surfaced in the Android app.",
+    "device.pair.changed": "Device label projection refresh is a Control UI surface; Android does not render the Gateway Devices page.",
     "device.pair.requested": "Device pairing flows poll via device.pair.* methods on Android.",
     "device.pair.resolved": "Device pairing flows poll via device.pair.* methods on Android.",
     "device.pair.setup.completed": "Generated setup lifecycle is a Control UI surface; Android consumes setup codes but does not issue or track them.",

--- a/src/gateway/events.ts
+++ b/src/gateway/events.ts
@@ -6,6 +6,9 @@ import type {
 import { roleScopesAllow } from "../shared/operator-scope-compat.js";
 import { READ_SCOPE } from "./operator-scopes.js";
 
+/** Event name emitted when the paired-device projection changes. */
+export const GATEWAY_EVENT_DEVICE_PAIR_CHANGED = "device.pair.changed" as const;
+
 /** Event name emitted when a node's private runner declaration changes. */
 export const GATEWAY_EVENT_NODE_RUNNER_INVENTORY_CHANGED = "node.runnerInventory.changed" as const;
 

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -530,42 +530,35 @@ describe("gateway broadcaster", () => {
   });
 
   it("filters approval and pairing events by scope", () => {
-    const approvalsSocket: TestSocket = {
-      bufferedAmount: 0,
-      send: vi.fn(),
-      close: vi.fn(),
-    };
-    const pairingSocket: TestSocket = {
-      bufferedAmount: 0,
-      send: vi.fn(),
-      close: vi.fn(),
-    };
-    const readSocket: TestSocket = {
-      bufferedAmount: 0,
-      send: vi.fn(),
-      close: vi.fn(),
-    };
+    const approvalsSocket = makeRecordingSocket();
+    const pairingSocket = makeRecordingSocket();
+    const readSocket = makeRecordingSocket();
+    const adminSocket = makeRecordingSocket();
 
     const clients = new Set<GatewayWsClient>([
       makeOperatorWsClient("c-approvals", approvalsSocket, ["operator.approvals"]),
       makeOperatorWsClient("c-pairing", pairingSocket, ["operator.pairing"]),
       makeOperatorWsClient("c-read", readSocket, ["operator.read"]),
+      makeOperatorWsClient("c-admin", adminSocket, ["operator.admin"]),
     ]);
 
     const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
 
     broadcast("exec.approval.requested", { id: "1" });
     broadcast("device.pair.requested", { requestId: "r1" });
+    broadcast("device.pair.changed", {});
 
     expect(approvalsSocket.send).toHaveBeenCalledTimes(1);
-    expect(pairingSocket.send).toHaveBeenCalledTimes(1);
+    expect(pairingSocket.send).toHaveBeenCalledTimes(2);
     expect(readSocket.send).toHaveBeenCalledTimes(0);
+    expect(adminSocket.send).toHaveBeenCalledTimes(3);
 
     broadcastToConnIds("tick", { ts: 1 }, new Set(["c-read"]));
     broadcastToConnIds("talk.event", { type: "session.ready" }, new Set(["c-read"]));
     expect(readSocket.send).toHaveBeenCalledTimes(2);
     expect(approvalsSocket.send).toHaveBeenCalledTimes(1);
-    expect(pairingSocket.send).toHaveBeenCalledTimes(1);
+    expect(pairingSocket.send).toHaveBeenCalledTimes(2);
+    expect(adminSocket.send).toHaveBeenCalledTimes(3);
   });
 
   it("requires operator.read for chat-class broadcast events", () => {

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -9,7 +9,10 @@ import { logRejectedLargePayload } from "../logging/diagnostic-payload.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { queuePluginSessionsChanged } from "../plugins/gateway-events.js";
 import { isBrowserCopilotClient } from "../utils/message-channel.js";
-import { GATEWAY_EVENT_NODE_RUNNER_INVENTORY_CHANGED } from "./events.js";
+import {
+  GATEWAY_EVENT_DEVICE_PAIR_CHANGED,
+  GATEWAY_EVENT_NODE_RUNNER_INVENTORY_CHANGED,
+} from "./events.js";
 import {
   ADMIN_SCOPE,
   APPROVALS_SCOPE,
@@ -69,6 +72,7 @@ const EVENT_SCOPE_GUARDS: Record<string, string[]> = {
   "skills.changed": [READ_SCOPE],
   "voicewake.changed": [READ_SCOPE],
   "voicewake.routing.changed": [READ_SCOPE],
+  [GATEWAY_EVENT_DEVICE_PAIR_CHANGED]: [PAIRING_SCOPE],
   "device.pair.requested": [PAIRING_SCOPE],
   "device.pair.resolved": [PAIRING_SCOPE],
   "device.pair.setup.completed": [PAIRING_SCOPE],

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -21,6 +21,7 @@ describe("GATEWAY_EVENTS", () => {
   it("advertises node topology updates", () => {
     expect(GATEWAY_EVENTS).toContain("node.presence");
     expect(GATEWAY_EVENTS).toContain("device.pair.setup.completed");
+    expect(GATEWAY_EVENTS).toContain("device.pair.changed");
     expect(GATEWAY_EVENTS).toContain("node.runnerInventory.changed");
   });
 

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -2,6 +2,7 @@
 // Lists advertised core, auxiliary, channel plugin methods, and websocket events.
 import { listLoadedChannelPlugins } from "../channels/plugins/registry-loaded.js";
 import {
+  GATEWAY_EVENT_DEVICE_PAIR_CHANGED,
   GATEWAY_EVENT_NODE_RUNNER_INVENTORY_CHANGED,
   GATEWAY_EVENT_UPDATE_AVAILABLE,
 } from "./events.js";
@@ -71,6 +72,7 @@ export const GATEWAY_EVENTS = [
   "node.invoke.cancel",
   "node.invoke.input",
   "node.invoke.request",
+  GATEWAY_EVENT_DEVICE_PAIR_CHANGED,
   "device.pair.requested",
   "device.pair.resolved",
   "device.pair.setup.completed",

--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -1657,6 +1657,11 @@ describe("deviceHandlers", () => {
     expect(opts.context.logGateway.info).toHaveBeenCalledWith(
       "device pairing renamed device=device-1 label=Kitchen Mac",
     );
+    expect(opts.context.broadcast).toHaveBeenCalledWith(
+      "device.pair.changed",
+      {},
+      { dropIfSlow: true },
+    );
   });
 
   it("rejects renaming another device from a non-admin device session", async () => {
@@ -1690,6 +1695,7 @@ describe("deviceHandlers", () => {
     expect(updatePairedDeviceMetadataMock).toHaveBeenCalledWith("missing-device", {
       operatorLabel: "Ghost",
     });
+    expect(opts.context.broadcast).not.toHaveBeenCalled();
     expectRespondedErrorMessage(opts, "unknown deviceId");
   });
 

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -32,6 +32,7 @@ import {
 } from "../../infra/device-pairing.js";
 import type { DiagnosticSecurityEventInput } from "../../infra/diagnostic-events.js";
 import { reconcileRevokedDeviceWorker } from "../device-worker-revocation.js";
+import { GATEWAY_EVENT_DEVICE_PAIR_CHANGED } from "../events.js";
 import { clearRemovedNodeRuntimeState } from "../node-runtime-state.js";
 import { invalidateNodeWakeState } from "../node-wake-state.js";
 import {
@@ -551,6 +552,7 @@ export const deviceHandlers: GatewayRequestHandlers = {
       targetDeviceId: deviceId,
       controlId: "device.pair.rename",
     });
+    context.broadcast(GATEWAY_EVENT_DEVICE_PAIR_CHANGED, {}, { dropIfSlow: true });
     respond(true, { deviceId, label: trimmed }, undefined);
   },
   "device.token.rotate": async ({ params, respond, context, client }) => {

--- a/ui/src/pages/devices/devices-page.test.ts
+++ b/ui/src/pages/devices/devices-page.test.ts
@@ -6,7 +6,6 @@ import type { PresenceEntry } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import {
-  approveDevicePairing,
   createInitialDevicesState,
   loadDevices,
   loadNodes,
@@ -266,12 +265,15 @@ describe("DevicesPage gateway lifecycle", () => {
     page.remove();
   });
 
-  it("coalesces a device refresh requested while an older list is loading", async () => {
+  it("refetches a changed device label after an older list response", async () => {
     const stale = deferred<{
-      paired: [];
-      pending: Array<{ requestId: string; deviceId: string }>;
+      paired: Array<{ deviceId: string; displayName: string }>;
+      pending: [];
     }>();
-    const refreshed = deferred<{ paired: []; pending: [] }>();
+    const refreshed = deferred<{
+      paired: Array<{ deviceId: string; displayName: string; operatorLabel: string }>;
+      pending: [];
+    }>();
     let listCalls = 0;
     const request = vi.fn((method: string) => {
       if (method === "device.pair.list") {
@@ -281,23 +283,55 @@ describe("DevicesPage gateway lifecycle", () => {
       return Promise.resolve({});
     });
     const client = { request } as unknown as GatewayBrowserClient;
-    const state = createInitialDevicesState({ client, connected: true });
+    const snapshot = {
+      ...gatewaySnapshot(client, true),
+      hello: {
+        type: "hello-ok",
+        protocol: 1,
+        auth: { role: "operator", scopes: ["operator.pairing"] },
+        features: { methods: ["device.pair.list"] },
+      },
+    } as ApplicationGatewaySnapshot;
+    let onEvent: ((event: { event: string; payload?: unknown }) => void) | undefined;
+    const currentGateway = gateway(client, snapshot);
+    currentGateway.subscribeEvents = vi.fn((listener) => {
+      onEvent = listener as typeof onEvent;
+      return () => undefined;
+    });
+    const page = document.createElement("openclaw-devices-page") as TestDevicesPage;
+    page.context = {
+      gateway: currentGateway,
+      runtimeConfig: {
+        state: { configSnapshot: {}, configLoading: false },
+        subscribe: vi.fn(() => () => undefined),
+      },
+    } as unknown as ApplicationContext;
+    page.pageState = createInitialDevicesState({ client, connected: true });
+    document.body.append(page);
+    await vi.waitFor(() => expect(onEvent).toBeDefined());
 
-    const initialLoad = loadDevices(state);
+    const initialLoad = loadDevices(page.pageState);
     await vi.waitFor(() => expect(request).toHaveBeenCalledWith("device.pair.list", {}));
-    const approval = approveDevicePairing(state, "request-1");
-    await vi.waitFor(() =>
-      expect(request).toHaveBeenCalledWith("device.pair.approve", { requestId: "request-1" }),
-    );
+    onEvent?.({ event: "device.pair.changed", payload: {} });
 
-    stale.resolve({ paired: [], pending: [{ requestId: "request-1", deviceId: "device-1" }] });
+    stale.resolve({
+      paired: [{ deviceId: "device-1", displayName: "Kitchen Mac" }],
+      pending: [],
+    });
     await vi.waitFor(() => expect(listCalls).toBe(2));
-    expect(state.devicesLoading).toBe(true);
+    expect(page.pageState.devicesLoading).toBe(true);
 
-    refreshed.resolve({ paired: [], pending: [] });
-    await Promise.all([initialLoad, approval]);
-    expect(state.devicesList).toEqual({ paired: [], pending: [] });
-    expect(state.devicesLoading).toBe(false);
+    refreshed.resolve({
+      paired: [{ deviceId: "device-1", displayName: "Kitchen Mac", operatorLabel: "Studio Mac" }],
+      pending: [],
+    });
+    await initialLoad;
+    expect(page.pageState.devicesList).toEqual({
+      paired: [{ deviceId: "device-1", displayName: "Kitchen Mac", operatorLabel: "Studio Mac" }],
+      pending: [],
+    });
+    expect(page.pageState.devicesLoading).toBe(false);
+    page.remove();
   });
 
   it("coalesces a node refresh requested while an older list is loading", async () => {
@@ -357,7 +391,7 @@ describe("DevicesPage gateway lifecycle", () => {
     expect(request.mock.calls.map(([method]) => method)).not.toContain("exec.approvals.get");
   });
 
-  it("keeps presence-driven device reloads gated on pairing access", async () => {
+  it("keeps event-driven device reloads gated on pairing access", async () => {
     const request = vi.fn(async (method: string) => (method === "node.list" ? { nodes: [] } : {}));
     const client = { request } as unknown as GatewayBrowserClient;
     const snapshot = {
@@ -397,6 +431,10 @@ describe("DevicesPage gateway lifecycle", () => {
         request.mock.calls.filter(([method]) => method === "node.list").length,
       ).toBeGreaterThan(nodeListCallsBefore.length),
     );
+    expect(request.mock.calls.map(([method]) => method)).not.toContain("device.pair.list");
+
+    onEvent?.({ event: "device.pair.changed", payload: {} });
+    await Promise.resolve();
     expect(request.mock.calls.map(([method]) => method)).not.toContain("device.pair.list");
     page.remove();
   });

--- a/ui/src/pages/devices/devices-page.ts
+++ b/ui/src/pages/devices/devices-page.ts
@@ -2,6 +2,7 @@ import { consume } from "@lit/context";
 import { initialState, Task } from "@lit/task";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
+import { GATEWAY_EVENT_DEVICE_PAIR_CHANGED } from "../../../../src/gateway/events.js";
 import type { PresenceEntry } from "../../api/types.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import {
@@ -166,7 +167,11 @@ class DevicesPage extends OpenClawLightDomElement {
               void this.runPageTask((pageState) => loadNodes(pageState, { quiet: true }));
             }
           }
-          if (event.event === "device.pair.requested" || event.event === "device.pair.resolved") {
+          if (
+            event.event === GATEWAY_EVENT_DEVICE_PAIR_CHANGED ||
+            event.event === "device.pair.requested" ||
+            event.event === "device.pair.resolved"
+          ) {
             if (this.canManagePairing) {
               void this.runPageTask((pageState) => loadDevices(pageState, { quiet: true }));
             }


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

AI-assisted with Claude Code and Codex. I reviewed and understand the change.

## What Problem This Solves

Fixes an issue where an already-open Devices page kept showing the old operator-assigned device label until the 30-second poll after another client ran `device rename`.

## Why This Change Was Made

After the durable rename succeeds, the Gateway now publishes the minimal pairing-scoped `device.pair.changed` invalidation event. The Devices page responds by refetching the authoritative `device.pair.list` projection through its existing coalescing loader.

The rename feature came from commit `7eacd78c01c` / PR #94517. Its durable write and label precedence were correct, but the mutation emitted no projection invalidation. Producer-owned invalidation plus an authoritative consumer refetch is the best ownership boundary: optimistic UI-only patching would leave other clients stale, while overloading the requested/resolved pairing handshake events would blur their existing lifecycle meaning.

Explicit non-goal: this does not change device-token rotation, revocation, or any other credential lifecycle behavior.

## User Impact

Device labels now refresh promptly on an already-open Devices page after another client renames a device, without requiring a reload or waiting for the periodic poll.

## Evidence

- Pre-fix regression proof: the UI scenario observed one `device.pair.list` request instead of the expected two, confirming that the open page stayed stale after rename.
- Post-fix focused Gateway tests: 125/125 passed.
- Post-fix Devices page tests: 21/21 passed.
- `pnpm test:bundled` passed 206/206 and `pnpm protocol:check` passed with stable generated protocol artifacts.
- `node scripts/check-protocol-event-coverage.mts` passed: all 52 advertised events are handled or intentionally classified for iOS and Android. The new event is Control UI-only because native clients do not render the Gateway Devices page.
- `node scripts/check-changed.mjs` passed the `core`, `coreTests`, `ui`, and `tooling` lanes.
- Fresh Codex-backed autoreview reported no accepted/actionable findings, including the mobile protocol classification added after CI exposed the missing coverage declaration.
- Production LOC: +18/-2 (net +16). Tests: +73/-35. Tooling classification: +2/-0. Generated Android protocol: +1/-0.
- Live isolated Gateway proof on port 63387 showed the visible label update in 1,286 ms. CDP observed `device.pair.changed` at 930 ms and the authoritative `device.pair.list` refetch at 931 ms, well before the 30,000 ms poll.
- The served Control UI bundle SHA-256 `d09a8a521605a41e97fe52fde404fcf9c95b67fbd80e6224cf2412e8fffd5861` matched the local build exactly.
- The isolated state was removed and all proof processes were stopped afterward.

Before:

![Devices page before rename](https://github.com/user-attachments/assets/297e29b9-7ae9-4865-a279-28f1a781a8ef)

After:

![Devices page after rename](https://github.com/user-attachments/assets/ad6044a7-5c3c-4f96-8222-e8f7394b08e3)

https://github.com/user-attachments/assets/84d50105-e9f4-4bea-b694-65d755f6f223
