### PR TITLE
test(ui): await anchored model picker geometry

### DIFF
--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -270,9 +270,9 @@ suite.define(() => {
         .toBe(true);
       const secondShortcut = secondModel.locator('[data-chat-model-shortcut-number="2"]');
       await expect.poll(() => secondShortcut.count()).toBe(1);
-      // Async page loads can still shift the whole layout mid-test; measure the
-      // menu and action relative to the picker anchor in one synchronous pass so
-      // only a focus-induced menu move can change the snapshot.
+      // wa-popup updates its anchored position asynchronously. Gate the atomic
+      // baseline on that settlement. After focus, poll the same exact geometry so
+      // transient frames settle before enforcing the opacity-only no-reflow contract.
       const menuGeometry = () =>
         page.evaluate(() => {
           const anchor = document.querySelector('[data-chat-model-select="true"]');
@@ -287,6 +287,7 @@ suite.define(() => {
           const menuBox = menu.getBoundingClientRect();
           const actionBox = action.getBoundingClientRect();
           return {
+            anchorGap: Math.round(anchorBox.top - menuBox.bottom),
             menu: {
               dx: menuBox.x - anchorBox.x,
               dy: menuBox.y - anchorBox.y,
@@ -301,6 +302,7 @@ suite.define(() => {
             },
           };
         });
+      await expect.poll(async () => (await menuGeometry())?.anchorGap).toBe(6);
       const geometryBeforeFocus = await menuGeometry();
       expect(geometryBeforeFocus).not.toBeNull();
       await expect
@@ -314,7 +316,7 @@ suite.define(() => {
       await expect
         .poll(() => secondShortcut.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("0");
-      expect(await menuGeometry()).toEqual(geometryBeforeFocus);
+      await expect.poll(menuGeometry).toEqual(geometryBeforeFocus);
       await search.press("1");
       await expect.poll(() => search.inputValue()).toBe("1");
       await expect.poll(() => picker.getAttribute("open")).toBe("");


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI-only problem where the new-session model-picker E2E could capture a stale anchored-overlay position before Web Awesome's asynchronous popup update settled, then report a false exact-geometry regression after search focus. In CI run 32295711885 / job 96206680184, the menu baseline expected `dy: -245` but the stable frame produced `dy: -209`; dimensions, horizontal placement, and action geometry were unchanged.

## Why This Change Was Made

The test keeps one atomic `page.evaluate` read for the trigger, menu, and action rectangles. It now derives the rounded menu-to-trigger gap from those same rectangles, waits for the production `distance = 6` anchored-overlay contract before capturing the baseline, and polls the complete exact geometry after focus so transient update frames settle.

No production code, tolerance, timeout override, or weakened assertion is introduced. The full menu and action dimensions and relative positions remain exact.

Related: #125755 can drop its narrower post-focus-only duplicate once this lands.

## User Impact

No runtime behavior changes. CI now waits for the actual anchored-overlay contract before judging the model picker, while continuing to catch any real focus-induced move or resize.

## Evidence

- Original failure: https://github.com/openclaw/openclaw/actions/runs/32295711885/job/96206680184 (`dy: -245` baseline versus stable `dy: -209`).
- Focused geometry test: 30 consecutive serial runs passed (`30/30`).
- Full `ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts`: 13/13 passed.
- Neighboring model-overlay E2Es (`chat-flow.models-reasoning`, `chat-composer-redesign`, `chat-only-model`): 15/15 passed.
- Model/picker-focused UI and real-browser tests: 100 passed, 247 unrelated tests filtered.
- Changed-file gate: passed, including test typecheck, UI i18n verification, lint, formatting, dependency/architecture ratchets, and dead-export checks.
- `oxfmt --check` and `git diff --check`: passed.
- Codex autoreview: clean; no accepted/actionable findings (`patch is correct`, 0.99).
- Test-audit authoring gate: protects the no-reflow focus contract against the observed stale-frame regression; existing sibling tests cover placement/containment but not exact focus geometry; no production seam added.
- Production LOC: +0/-0. Tests: +6/-4 (net +2).

AI-assisted: yes. The final patch and evidence were manually verified against the production overlay owner, Web Awesome popup update path, CSS action-slot contract, related tests, and relevant history.
