### PR TITLE
fix(file-transfer): report fetched directory counts accurately

### DIFF
--- a/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.test.ts
@@ -61,7 +61,7 @@ async function importTool(tarBuffer: Buffer) {
         tarBase64: tarBuffer.toString("base64"),
         tarBytes: tarBuffer.byteLength,
         sha256: crypto.createHash("sha256").update(tarBuffer).digest("hex"),
-        fileCount: 1,
+        fileCount: 3,
       },
       startedAt: Date.now(),
     })),
@@ -84,9 +84,11 @@ async function executeDirFetch(module: typeof import("./dir-fetch-tool.js")) {
 describe("dir.fetch archive extraction", () => {
   it("extracts a bounded tar and returns the plugin-side manifest", async () => {
     const tarBuffer = await createTarBuffer({
-      entries: ["ok.txt"],
+      entries: ["ok.txt", "nested"],
       setup: async (sourceDir) => {
         await fs.writeFile(path.join(sourceDir, "ok.txt"), "ok");
+        await fs.mkdir(path.join(sourceDir, "nested"));
+        await fs.writeFile(path.join(sourceDir, "nested", "also-ok.txt"), "also ok");
       },
     });
     const { appendFileTransferAudit, module, saveMediaBuffer } = await importTool(tarBuffer);
@@ -94,20 +96,30 @@ describe("dir.fetch archive extraction", () => {
     const result = await executeDirFetch(module);
 
     expect(result).toMatchObject({
+      content: [{ type: "text", text: expect.stringContaining("Fetched 2 files") }],
       details: {
         path: "/tmp/project",
-        fileCount: 1,
-        files: [
-          {
-            relPath: "ok.txt",
-            size: 2,
-            sha256: crypto.createHash("sha256").update("ok").digest("hex"),
-          },
-        ],
+        fileCount: 2,
       },
     });
-    const localPath = (result.details as { files: Array<{ localPath: string }> }).files[0]
-      ?.localPath;
+    const files = (result.details as { files: Array<{ relPath: string; localPath: string }> })
+      .files;
+    expect(files).toHaveLength(2);
+    expect(files).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          relPath: "ok.txt",
+          size: 2,
+          sha256: crypto.createHash("sha256").update("ok").digest("hex"),
+        }),
+        expect.objectContaining({
+          relPath: path.join("nested", "also-ok.txt"),
+          size: 7,
+          sha256: crypto.createHash("sha256").update("also ok").digest("hex"),
+        }),
+      ]),
+    );
+    const localPath = files.find((file) => file.relPath === "ok.txt")?.localPath;
     await expect(fs.readFile(localPath!, "utf8")).resolves.toBe("ok");
     expect(saveMediaBuffer).toHaveBeenCalledWith(
       tarBuffer,

--- a/extensions/file-transfer/src/tools/dir-fetch-tool.ts
+++ b/extensions/file-transfer/src/tools/dir-fetch-tool.ts
@@ -153,7 +153,6 @@ export function createDirFetchTool(): AnyAgentTool {
       const tarBase64 = typeof payload.tarBase64 === "string" ? payload.tarBase64 : "";
       const tarBytes = typeof payload.tarBytes === "number" ? payload.tarBytes : -1;
       const sha256 = typeof payload.sha256 === "string" ? payload.sha256 : "";
-      const fileCount = typeof payload.fileCount === "number" ? payload.fileCount : 0;
 
       if (!canonicalPath || !tarBase64 || tarBytes < 0 || !sha256) {
         throw new Error("invalid dir.fetch payload (missing fields)");
@@ -236,6 +235,7 @@ export function createDirFetchTool(): AnyAgentTool {
         const fileSha256 = await computeFileSha256(absPath);
         files.push({ relPath, size, mimeType, sha256: fileSha256, localPath: absPath });
       }
+      const fileCount = files.length;
 
       const imageFiles = files.filter((f) => IMAGE_MIME_INLINE_SET.has(f.mimeType));
       const nonImageFiles = files.filter((f) => !IMAGE_MIME_INLINE_SET.has(f.mimeType));


### PR DESCRIPTION
Closes #126433

AI-assisted with Codex. The change and its tests were reviewed and understood.

## What Problem This Solves

Fixes an issue where users fetching a directory would see directory entries counted as files when the node's tar archive included them. The transfer succeeded, but the model-visible summary and `details.fileCount` could exceed the regular-file manifest.

## Why This Change Was Made

The gateway already builds the authoritative manifest after safe extraction, including only regular files that were actually retained. This change derives both public counts from that manifest and stops reading the node's coarse tar-pathname count. The wire field remains unchanged for mixed-version node compatibility; there is no protocol, SDK, config, dependency, or archive-policy change.

This is the best owner-boundary fix because reparsing tar types would duplicate archive policy, changing the node field would risk older gateway behavior, and correcting only text or structured details would preserve conflicting answers.

## User Impact

Successful `dir_fetch` results now report the number of files actually present in `details.files`, so agents and operators receive consistent summary and structured metadata even when the archive contains directories.

## Evidence

Pre-fix tool-boundary reproduction used an archive containing one directory and two regular files while the mocked node reported three tar pathnames. It failed with `Fetched 3 files` and `details.fileCount: 3` against a two-file manifest. The same fixture passes after the repair with `Fetched 2 files`, `details.fileCount: 2`, and manifest length 2.

- `node scripts/run-vitest.mjs extensions/file-transfer/src/tools/dir-fetch-tool.test.ts` — 4/4 passed after the authentic pre-fix failure.
- `node scripts/run-vitest.mjs extensions/file-transfer/src/node-host/dir-fetch.test.ts extensions/file-transfer/src/tools/dir-fetch-tool.test.ts extensions/file-transfer/src/shared/node-invoke-policy.test.ts extensions/file-transfer/src/shared/policy.test.ts` — 75/75 passed.
- `pnpm test:extension file-transfer` — 188/188 passed.
- `node scripts/check-changed.mjs` — passed all extension production/test gates after installing the fresh worktree dependencies; the first run stopped only because the worktree-local `node_modules/playwright-core` path was absent.
- `git diff --check` — passed.
- Fresh P1 autoreview and a separate independent read-only Codex review — no actionable findings; both judged this the best owner-boundary fix.

Production LOC: +1/-1 (net 0). Tests: +24/-12 (net +12).

Live paired-node proof was not run because this isolated task checkout has no task-owned paired node or file-transfer policy state. The focused boundary test exercises real tar extraction, manifest construction, summary text, and structured details without touching the operator's running Gateway.
