### PR TITLE
fix(plugins): keep default slots implicit

### DIFF
--- a/src/commands/doctor/shared/context-engine-host-compat.test.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.test.ts
@@ -172,25 +172,38 @@ describe("doctor context-engine host compatibility", () => {
     expect(warnings).toEqual([]);
   });
 
-  it("repairs an incompatible context engine by switching the global slot to legacy", async () => {
+  it("repairs an incompatible context engine by resetting the global slot to legacy", async () => {
     const engineId = registerEngine(["assemble-before-prompt"]);
-    const result = await maybeRepairContextEngineHostCompatibility({
-      cfg: configWithEngine(engineId, {
-        agents: {
-          defaults: {
-            model: "anthropic/claude-sonnet-4-6",
-            models: {
-              "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
-            },
+    const cfg = configWithEngine(engineId, {
+      plugins: {
+        slots: {
+          memory: "custom-memory",
+        },
+      },
+      agents: {
+        defaults: {
+          model: "anthropic/claude-sonnet-4-6",
+          models: {
+            "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
           },
         },
-      }),
+      },
+    });
+    const warnings = await collectContextEngineHostCompatibilityWarnings({
+      cfg,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+    const result = await maybeRepairContextEngineHostCompatibility({
+      cfg,
       doctorFixCommand: "openclaw doctor --fix",
     });
 
-    expect(result.config.plugins?.slots?.contextEngine).toBe("legacy");
+    expect(warnings.join("\n")).toContain(
+      'remove the plugins.slots.contextEngine override and restore the default "legacy"',
+    );
+    expect(result.config.plugins?.slots).toEqual({ memory: "custom-memory" });
     expect(result.changes).toEqual([
-      `Set plugins.slots.contextEngine to "legacy" because context engine "${engineId}" is incompatible with every configured agent-run host.`,
+      `Reset plugins.slots.contextEngine to the default "legacy" because context engine "${engineId}" is incompatible with every configured agent-run host.`,
     ]);
   });
 

--- a/src/commands/doctor/shared/context-engine-host-compat.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.ts
@@ -359,7 +359,7 @@ function formatCompatibilityWarnings(params: {
   const incompatibleAllHosts = params.issues.length === params.hostCount;
   lines.push(
     incompatibleAllHosts
-      ? `- Run "${params.doctorFixCommand}" to switch plugins.slots.contextEngine to "legacy", or configure a compatible runtime/harness for agent runs.`
+      ? `- Run "${params.doctorFixCommand}" to remove the plugins.slots.contextEngine override and restore the default "legacy", or configure a compatible runtime/harness for agent runs.`
       : `- Some configured runtimes support context engine "${params.info.id}" and others do not; doctor will not rewrite the global contextEngine slot automatically. Configure unsupported models to use a compatible runtime/harness or set plugins.slots.contextEngine to "legacy".`,
   );
   return [lines.join("\n")];
@@ -416,13 +416,17 @@ export async function maybeRepairContextEngineHostCompatibility(params: {
   }
 
   const next = structuredClone(params.cfg);
-  next.plugins ??= {};
-  next.plugins.slots ??= {};
-  next.plugins.slots.contextEngine = defaultSlotIdForKey("contextEngine");
+  const slots = next.plugins?.slots;
+  if (slots) {
+    delete slots.contextEngine;
+    if (Object.keys(slots).length === 0) {
+      delete next.plugins?.slots;
+    }
+  }
   return {
     config: next,
     changes: [
-      `Set plugins.slots.contextEngine to "legacy" because context engine "${resolved.info.id}" is incompatible with every configured agent-run host.`,
+      `Reset plugins.slots.contextEngine to the default "legacy" because context engine "${resolved.info.id}" is incompatible with every configured agent-run host.`,
     ],
     warnings: resolved.warnings,
   };

--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -161,10 +161,20 @@ describe("doctor stale plugin config helpers", () => {
     expect(result.changes).toEqual([
       "- plugins.slots: reset 2 stale plugin slots (memory: acpx -> memory-core, contextEngine: missing-engine -> legacy)",
     ]);
-    expect(result.config.plugins?.slots).toEqual({
-      memory: "memory-core",
-      contextEngine: "legacy",
-    });
+    expect(result.config.plugins?.slots).toBeUndefined();
+  });
+
+  it("preserves unrelated slot state when removing a stale slot override", () => {
+    const result = maybeRepairStalePluginConfig({
+      plugins: {
+        slots: {
+          memory: "missing-memory",
+          contextEngine: "none",
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(result.config.plugins?.slots).toEqual({ contextEngine: "none" });
   });
 
   it("preserves official external plugin config before installation", () => {
@@ -241,7 +251,7 @@ describe("doctor stale plugin config helpers", () => {
 
     expect(result.config.plugins?.allow).toEqual(["codex"]);
     expect(result.config.plugins?.entries?.codex?.enabled).toBe(false);
-    expect(result.config.plugins?.slots?.memory).toBe("memory-core");
+    expect(result.config.plugins?.slots).toBeUndefined();
     expect(result.changes).toEqual([
       "- plugins.slots: reset 1 stale plugin slot (memory: codex -> memory-core)",
     ]);

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -416,7 +416,10 @@ export function maybeRepairStalePluginConfig(
     const slots = asNullableRecord(nextPlugins?.slots);
     if (slots) {
       for (const hit of slotHits) {
-        slots[hit.slotKey] = defaultSlotIdForKey(hit.slotKey);
+        delete slots[hit.slotKey];
+      }
+      if (Object.keys(slots).length === 0 && nextPlugins) {
+        delete nextPlugins.slots;
       }
     }
   }

--- a/src/plugins/plugin-package-update.test.ts
+++ b/src/plugins/plugin-package-update.test.ts
@@ -116,7 +116,6 @@ describe("plugin package update policy reconciliation", () => {
       deny: ["other-denied"],
       entries: { "pack/one": { enabled: true }, other: { enabled: true } },
       load: { paths: ["/plugins/unrelated.js"] },
-      slots: { memory: "memory-core", contextEngine: "legacy" },
     });
     expect(result.config.channels).toEqual({
       shared: { enabled: true },

--- a/src/plugins/slots.test.ts
+++ b/src/plugins/slots.test.ts
@@ -16,7 +16,7 @@ describe("resetPluginSlotsToDefaults", () => {
         { memory: "dual-plugin", contextEngine: "dual-plugin" },
         "dual-plugin",
       ),
-    ).toEqual({ memory: "memory-core", contextEngine: "legacy" });
+    ).toBeUndefined();
   });
 
   it("preserves slot state when the plugin owns no slot", () => {
@@ -86,6 +86,47 @@ describe("applyExclusiveSlotSelection", () => {
     expect(result.changed).toBe(false);
     expect(result.warnings).toHaveLength(0);
   }
+
+  it("keeps the default memory selection implicit", () => {
+    const config: OpenClawConfig = {
+      plugins: { entries: { "memory-core": { enabled: true } } },
+    };
+
+    const result = applyExclusiveSlotSelection({
+      config,
+      selectedId: "memory-core",
+      selectedKind: "memory",
+      registry: { plugins: [{ id: "memory-core", kind: "memory" }] },
+    });
+
+    expectUnchangedSelection(result);
+    expect(result.config).toBe(config);
+  });
+
+  it("removes an explicit override when selecting the default memory plugin", () => {
+    const config: OpenClawConfig = {
+      plugins: {
+        slots: { memory: "memory" },
+        entries: { memory: { enabled: true }, "memory-core": { enabled: true } },
+      },
+    };
+
+    const result = applyExclusiveSlotSelection({
+      config,
+      selectedId: "memory-core",
+      selectedKind: "memory",
+      registry: {
+        plugins: [
+          { id: "memory", kind: "memory" },
+          { id: "memory-core", kind: "memory" },
+        ],
+      },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins).not.toHaveProperty("slots");
+    expect(result.config.plugins?.entries?.memory?.enabled).toBe(false);
+  });
 
   function buildSelectionRegistry(
     plugins: ReadonlyArray<{ id: string; kind?: PluginKind | PluginKind[] }>,

--- a/src/plugins/slots.ts
+++ b/src/plugins/slots.ts
@@ -94,7 +94,7 @@ export function resolveSlotSelection(slotKey: PluginSlotKey, value: unknown): Sl
   return normalized === null ? { kind: "off" } : { kind: "pinned", pluginId: normalized };
 }
 
-/** Resets every slot currently owned by a plugin to that slot's implicit default. */
+/** Resets every slot currently owned by a plugin to its implicit default. */
 export function resetPluginSlotsToDefaults(
   slots: PluginSlotsConfig | undefined,
   pluginId: string,
@@ -108,10 +108,10 @@ export function resetPluginSlotsToDefaults(
     if (slots[slotKey] !== pluginId) {
       continue;
     }
-    next[slotKey] = defaultSlotIdForKey(slotKey);
+    delete next[slotKey];
     changed = true;
   }
-  return changed ? next : slots;
+  return changed ? (Object.keys(next).length === 0 ? undefined : next) : slots;
 }
 
 type SlotSelectionResult = {
@@ -140,7 +140,13 @@ export function applyExclusiveSlotSelection(params: {
 
   for (const slotKey of slotKeys) {
     const prevSlot = slots[slotKey];
-    slots[slotKey] = params.selectedId;
+    const nextSlot =
+      params.selectedId === defaultSlotIdForKey(slotKey) ? undefined : params.selectedId;
+    if (nextSlot === undefined) {
+      delete slots[slotKey];
+    } else {
+      slots[slotKey] = nextSlot;
+    }
 
     const inferredPrevSlot = prevSlot ?? defaultSlotIdForKey(slotKey);
     if (inferredPrevSlot && inferredPrevSlot !== params.selectedId) {
@@ -183,7 +189,7 @@ export function applyExclusiveSlotSelection(params: {
       );
     }
 
-    if (prevSlot !== params.selectedId || disabledIds.length > 0) {
+    if (prevSlot !== nextSlot || disabledIds.length > 0) {
       anyChanged = true;
     }
   }
@@ -192,12 +198,14 @@ export function applyExclusiveSlotSelection(params: {
     return { config: params.config, warnings: [], changed: false };
   }
 
+  const { slots: _previousSlots, ...pluginsWithoutSlots } = pluginsConfig;
+
   return {
     config: {
       ...params.config,
       plugins: {
-        ...pluginsConfig,
-        slots,
+        ...pluginsWithoutSlots,
+        ...(Object.keys(slots).length > 0 ? { slots } : {}),
         entries,
       },
     },

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -389,7 +389,6 @@ describe("planPluginUninstall package ownership", () => {
     expect(result.config.plugins).toEqual({
       allow: ["other"],
       entries: { other: { enabled: true } },
-      slots: { memory: "memory-core" },
     });
     expect(result.actions).toMatchObject({
       entry: true,
@@ -586,7 +585,7 @@ describe("removePluginFromConfig", () => {
         },
       }),
       pluginId: "memory-plugin",
-      expectedMemory: "memory-core",
+      expectedMemory: undefined,
       expectedChanged: true,
     },
     {
@@ -620,7 +619,7 @@ describe("removePluginFromConfig", () => {
 
     const { config: result, actions } = removePluginFromConfig(config, "context-plugin");
 
-    expect(result.plugins?.slots?.contextEngine).toBe("legacy");
+    expect(result.plugins?.slots?.contextEngine).toBeUndefined();
     expect(actions.contextEngineSlot).toBe(true);
   });
 
@@ -979,7 +978,7 @@ describe("uninstallPlugin", () => {
     });
     expect(successfulResult.config.plugins?.allow).toEqual(["other-plugin"]);
     expect(successfulResult.config.plugins?.deny).toBeUndefined();
-    expect(successfulResult.config.plugins?.slots?.memory).toBe("memory-core");
+    expect(successfulResult.config.plugins?.slots?.memory).toBeUndefined();
     expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
   });
 
@@ -1090,10 +1089,6 @@ describe("uninstallPlugin", () => {
       expectedConfig: {
         plugins: {
           allow: ["other-plugin"],
-          slots: {
-            memory: "memory-core",
-            contextEngine: "legacy",
-          },
         },
       },
     },

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -2374,10 +2374,7 @@ describe("updateNpmInstalledPlugins", () => {
     });
     expect(result.config.plugins?.allow).toEqual(["lossless-claw", "keep"]);
     expect(result.config.plugins?.deny).toEqual(["lossless-claw", "blocked"]);
-    expect(result.config.plugins?.slots).toEqual({
-      memory: "memory-core",
-      contextEngine: "legacy",
-    });
+    expect(result.config.plugins?.slots).toBeUndefined();
     expect(result.outcomes).toEqual([
       {
         pluginId: "lossless-claw",
@@ -2474,7 +2471,7 @@ describe("updateNpmInstalledPlugins", () => {
     });
     expect(result.config.plugins?.allow).toEqual(["demo", "other"]);
     expect(result.config.plugins?.deny).toEqual(["demo", "blocked"]);
-    expect(result.config.plugins?.slots?.memory).toBe("memory-core");
+    expect(result.config.plugins?.slots?.memory).toBeUndefined();
     expect(result.outcomes).toEqual([
       {
         pluginId: "demo",
@@ -3002,10 +2999,7 @@ describe("updateNpmInstalledPlugins", () => {
     });
     expect(result.config.plugins?.allow).toEqual(["demo", "other"]);
     expect(result.config.plugins?.deny).toEqual(["blocked"]);
-    expect(result.config.plugins?.slots).toEqual({
-      memory: "memory-core",
-      contextEngine: "legacy",
-    });
+    expect(result.config.plugins?.slots).toBeUndefined();
     expect(result.config.plugins?.installs?.demo).toEqual(config.plugins.installs.demo);
     expect(result.outcomes).toEqual([
       {
@@ -3140,7 +3134,7 @@ describe("updateNpmInstalledPlugins", () => {
       config: { preserved: true },
     });
     expect(result.config.plugins?.allow).toEqual(["demo"]);
-    expect(result.config.plugins?.slots?.memory).toBe("memory-core");
+    expect(result.config.plugins?.slots?.memory).toBeUndefined();
     expect(result.outcomes).toEqual([
       {
         pluginId: "demo",
@@ -3173,9 +3167,7 @@ describe("updateNpmInstalledPlugins", () => {
       config: { preserved: true },
     });
     expect(result.config.plugins?.allow).toEqual(["demo"]);
-    expect(result.config.plugins?.slots).toEqual({
-      memory: "memory-core",
-    });
+    expect(result.config.plugins?.slots).toBeUndefined();
     const message =
       'Disabled "demo" after plugin update failure; OpenClaw will continue without it. Failed to update demo: ClawHub blocked this release; update was not started. (ClawHub clawhub:demo).';
     expect(warn).toHaveBeenCalledWith(message);


### PR DESCRIPTION
Related: #126008

## What Problem This Solves

Fixes an issue where plugin install, uninstall, failed-update recovery, or Doctor repair could persist default plugin selections as explicit slot overrides. During bundled plugin lifecycle validation, an explicit `plugins.slots.memory: memory-core` could then be treated as a user-selected dependency before `memory-core` was available, failing the install with `plugin not found: memory-core`.

## Why This Change Was Made

Default memory and context-engine ownership is now represented canonically by an omitted slot override. Selection and lifecycle reset paths delete overrides when returning to `memory-core` or `legacy`; the two Doctor repair paths do the same, prune empty slot state, and preserve unrelated slot configuration.

This is a replacement for #126008 because its branch is not editable by maintainers and the complete fix must also cover the Doctor writers identified by review. The implementation and commit preserve Dallin Romney (@RomneyDa) as co-author.

## User Impact

Bundled plugin lifecycle operations can return to the default memory or context engine without leaving validation-sensitive explicit pins. Operators running `openclaw doctor --fix` also keep the same canonical state instead of recreating those pins.

## Evidence

- Regression proof: the new slot-selection and package-lifecycle assertions failed on current `main` because it persisted `memory-core` and `legacy`.
- Focused local proof on exact head: 4 Vitest shards, 277 tests passed across:
  - `src/plugins/slots.test.ts`
  - `src/plugins/uninstall.test.ts`
  - `src/plugins/update.test.ts`
  - `src/plugins/plugin-package-update.test.ts`
  - `src/commands/doctor/shared/stale-plugin-config.test.ts`
  - `src/commands/doctor/shared/context-engine-host-compat.test.ts`
- `git diff --check`: passed.
- Targeted formatting: passed for all nine changed files.
- Final head: `4437353f10decef1ff37de1844cb4af331d88fff`.
- `node scripts/check-changed.mjs -- <changed files>` passed all guards, formatting, boundaries, dead-code scans, and production typecheck. Its serial core-test typecheck surfaced stale incremental state at `ui/src/pages/chat/route-loader.ts:712`; forced clean `core.test.other` rebuilds pass on current main and on the clean merged tree with this exact head.
- Both prior ClawSweeper P3 findings are fixed: the Doctor warning states that it removes the explicit context-engine override and restores the implicit `legacy` default, and default reselection now prunes the final empty `plugins.slots` container. Both have focused assertions.
- Exact-head CI is green: https://github.com/openclaw/openclaw/actions/runs/32347155667.
- Exact targeted Docker lane `bundled-plugin-install-uninstall-4` is green: https://github.com/openclaw/openclaw/actions/runs/32347369723.
- Blacksmith Testbox `tbx_01m0f3eekd8k78pp4hms6y5nvq` completed the exact bundled-plugin shard 4/24 with exit 0. The selected sequence was `azure-speech` -> `memory-core` -> `vault`; install, runtime, and uninstall passed for all three.
- Exact-head ClawSweeper review has no actionable findings and confirms the producer/Doctor repair as the best fix. Its only rank-up move was to complete exact-head checks; the checks above satisfy it: https://github.com/openclaw/openclaw/pull/126442#issuecomment-5348497661.

Production LOC: +28/-13 (net +15) for the canonical selection/reset ownership and both Doctor writers. Tests: +90/-40.

No config, protocol, storage, dependency, or public API surface was added.
