### PR TITLE
fix(cli): accept daemon --json before subcommands

### DIFF
--- a/docs/cli/daemon.md
+++ b/docs/cli/daemon.md
@@ -29,8 +29,10 @@ openclaw daemon uninstall
 | `install`   | `--port`, `--runtime <node>`, `--token`, `--wrapper <path>`, `--force`, `--json`                 |
 | `uninstall` | `--json`                                                                                         |
 | `start`     | `--json`                                                                                         |
-| `stop`      | `--json`, `--disable` (launchd only: persistently suppress KeepAlive/RunAtLoad until next start) |
+| `stop`      | `--force`, `--json`, `--disable` (launchd only: suppress KeepAlive/RunAtLoad until next start)   |
 | `restart`   | `--force`, `--safe`, `--skip-deferral`, `--wait <duration>`, `--json`                            |
+
+`--json` is accepted before or after every subcommand (for example, `daemon --json status` and `daemon status --json`).
 
 - `status`: shows service install state (launchd/systemd/schtasks) and probes Gateway health.
 - `install`: installs the service; `--force` reinstalls/overwrites an existing install.

--- a/src/cli/daemon-cli/register-service-commands.test.ts
+++ b/src/cli/daemon-cli/register-service-commands.test.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { addGatewayServiceCommands } from "./register-service-commands.js";
+import { registerDaemonCli } from "./register.js";
 
 const runDaemonInstall = vi.fn(async (_opts: unknown) => {});
 const runDaemonRestart = vi.fn(async (_opts: unknown) => {});
@@ -120,5 +121,26 @@ describe("addGatewayServiceCommands", () => {
     const gateway = createGatewayParentLikeCommand();
     await gateway.parseAsync(argv, { from: "user" });
     assert();
+  });
+
+  it.each(
+    [
+      { leaf: "status", runner: runDaemonStatus },
+      { leaf: "install", runner: runDaemonInstall },
+      { leaf: "uninstall", runner: runDaemonUninstall },
+      { leaf: "start", runner: runDaemonStart },
+      { leaf: "stop", runner: runDaemonStop },
+      { leaf: "restart", runner: runDaemonRestart },
+    ].flatMap(({ leaf, runner }) => [
+      { name: `daemon --json ${leaf}`, argv: ["daemon", "--json", leaf], runner },
+      { name: `daemon ${leaf} --json`, argv: ["daemon", leaf, "--json"], runner },
+    ]),
+  )("forwards JSON mode for $name", async ({ argv, runner }) => {
+    const program = new Command().enablePositionalOptions().exitOverride();
+    registerDaemonCli(program);
+
+    await program.parseAsync(argv, { from: "user" });
+
+    expect(expectSingleDaemonCall(runner).json).toBe(true);
   });
 });

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -20,6 +20,11 @@ function loadDaemonStatusModule() {
   return daemonStatusModuleLoader.load();
 }
 
+function resolveJsonOption(cmdOpts: { json?: boolean }, command?: Command): boolean {
+  const parentJson = inheritOptionFromParent<boolean>(command, "json", "cli");
+  return Boolean(cmdOpts.json || parentJson);
+}
+
 function resolveInstallOptions(
   cmdOpts: DaemonInstallOptions,
   command?: Command,
@@ -32,6 +37,7 @@ function resolveInstallOptions(
     force: Boolean(cmdOpts.force || parentForce),
     port: cmdOpts.port ?? parentPort,
     token: cmdOpts.token ?? parentToken,
+    json: resolveJsonOption(cmdOpts, command),
   };
 }
 
@@ -51,6 +57,7 @@ function resolveRestartOptions(cmdOpts: DaemonLifecycleOptions, command?: Comman
     ...cmdOpts,
     force: Boolean(cmdOpts.force || parentForce),
     safe: Boolean(cmdOpts.safe),
+    json: resolveJsonOption(cmdOpts, command),
   };
 }
 
@@ -59,6 +66,7 @@ function resolveStopOptions(cmdOpts: DaemonLifecycleOptions, command?: Command) 
   return {
     ...cmdOpts,
     force: Boolean(cmdOpts.force || parentForce),
+    json: resolveJsonOption(cmdOpts, command),
   };
 }
 
@@ -84,7 +92,7 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
         probe: Boolean(cmdOpts.probe),
         requireRpc: Boolean(cmdOpts.requireRpc),
         deep: Boolean(cmdOpts.deep),
-        json: Boolean(cmdOpts.json),
+        json: resolveJsonOption(cmdOpts, command),
       });
     });
 
@@ -106,18 +114,18 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
     .command("uninstall")
     .description("Uninstall the Gateway service (launchd/systemd/schtasks)")
     .option("--json", "Output JSON", false)
-    .action(async (cmdOpts) => {
+    .action(async (cmdOpts, command) => {
       const { runDaemonUninstall } = await loadDaemonLifecycleModule();
-      await runDaemonUninstall(cmdOpts);
+      await runDaemonUninstall({ ...cmdOpts, json: resolveJsonOption(cmdOpts, command) });
     });
 
   parent
     .command("start")
     .description("Start the Gateway service (launchd/systemd/schtasks)")
     .option("--json", "Output JSON", false)
-    .action(async (cmdOpts) => {
+    .action(async (cmdOpts, command) => {
       const { runDaemonStart } = await loadDaemonLifecycleModule();
-      await runDaemonStart(cmdOpts);
+      await runDaemonStart({ ...cmdOpts, json: resolveJsonOption(cmdOpts, command) });
     });
 
   parent

--- a/src/cli/daemon-cli/register.ts
+++ b/src/cli/daemon-cli/register.ts
@@ -9,6 +9,7 @@ export function registerDaemonCli(program: Command) {
   const daemon = program
     .command("daemon")
     .description("Manage the Gateway service (launchd/systemd/schtasks)")
+    .option("--json", "Output JSON", false)
     .addHelpText(
       "after",
       () =>

--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -47,7 +47,6 @@ const JSON_NOT_APPLICABLE = {
       "transcripts",
       "gateway restart-handoff",
       "gateway diagnostics",
-      "daemon",
       "system",
       "system heartbeat",
       "promos",

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -530,7 +530,7 @@ describe("cli json stdout contract", () => {
         const memoryCoreDir = path.join(bundledPluginsDir, "memory-core");
         await fs.mkdir(memoryCoreDir, { recursive: true });
         await fs.writeFile(
-          path.join(memoryCoreDir, "api.js"),
+          path.join(memoryCoreDir, "doctor-health-api.js"),
           [
             "export function registerMemoryCoreDoctorChecks(host) {",
             "  host.registerHealthCheck({",


### PR DESCRIPTION
Closes #126444

AI-assisted: Codex

## What Problem This Solves

Fixes an issue where operators using the legacy `openclaw daemon` lifecycle CLI could not place the universal `--json` flag before a subcommand. All six forms such as `openclaw daemon --json status` failed during parsing with `commander.unknownOption`, even though the corresponding after-subcommand forms worked.

## Why This Change Was Made

The daemon parent now declares `--json`, while every existing lifecycle leaf keeps its own declaration. The shared registration owner resolves JSON mode source-aware: an explicit leaf CLI value wins; otherwise the leaf inherits only a CLI-sourced parent value through `inheritOptionFromParent`. This preserves both placements without argv scanning, duplicate renderers, fallback paths, or service-runtime changes. The Gateway parent remains unchanged because JSON is not universal across its subcommands.

The daemon CLI reference now documents both JSON placements and includes the already-registered `stop --force` option. A one-line process-test fixture correction updates the Memory Core Doctor public artifact from `api.js` to `doctor-health-api.js`, matching the split introduced by `f8ba65636c23` and allowing the requested CLI JSON process sibling to exercise its intended contract.

## User Impact

Scripts and operators can use `--json` before or after any legacy daemon lifecycle subcommand. Existing human output, JSON envelopes, and after-subcommand behavior are unchanged.

Release-note context: legacy daemon lifecycle automation now accepts `--json` in either nested CLI position.

## Evidence

Before the fix, a real positional-parser table failed all six before-leaf cases with `commander.unknownOption`; all six after-leaf cases passed.

After the fix:

- `node scripts/run-vitest.mjs src/cli/daemon-cli/register-service-commands.test.ts --reporter=verbose` — 19/19 passed, covering all six leaves and both placements with mocked runner assertions for `json: true`.
- Focused daemon parser/coverage/lifecycle run — 68/68 passed.
- `OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/cli/command-options.test.ts test/cli-json-stdout.e2e.test.ts --reporter=verbose` — 48/48 passed.
- Built-CLI source-blind proof in isolated state: both `daemon --json status --no-probe` and `daemon status --json --no-probe` exited 0 with parseable JSON. Mutating lifecycle leaves remained mocked to avoid touching a live service.
- `pnpm check:docs` — passed formatting, lint, MDX, glossary, 6,524 internal links, and config-example validation.
- `node scripts/check-changed.mjs -- <five changed paths>` — passed the selected core, core-test, root-test, docs, and tooling gates.
- First exact-head CI run `32304925895` found one attributable stale inventory entry: `daemon` remained in `JSON_NOT_APPLICABLE` after gaining parent JSON support. Removing that obsolete exception made `root-command-descriptions.test.ts` and the parser suite pass 23/23 without weakening the guard.
- `git diff --check` — clean.
- Production LOC: +14/-5 (net +9); tests/test support: +23/-2; docs: +3/-1.
- Fresh P1 autoreview: clean, no accepted/actionable findings.
- Separate read-only Codex review of final diff SHA-256 `505f2f00873a4adfe86101e54cd5ca85c7411b88f36bcb59fa2258eeefa569bb`: no P1 findings; start/end guards matched.
