### PR TITLE
fix(tailscale): report existing managed route conflicts

### DIFF
--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, watch } from "node:fs";
+import { existsSync, symlinkSync, watch } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 // Covers Tailscale whois, Serve, and Funnel helpers.
@@ -46,6 +46,7 @@ describe("tailscale helpers", () => {
       "OPENCLAW_TEST_TAILSCALE_BINARY",
       "OPENCLAW_TEST_TAILSCALE_FIXTURE_MARKER",
       "NODE_ENV",
+      "PATH",
       "VITEST",
     ]);
     process.env.OPENCLAW_TEST_TAILSCALE_BINARY = "tailscale";
@@ -222,6 +223,23 @@ describe("tailscale helpers", () => {
       await claim.stop();
       await expect(claim.exited).resolves.toBeUndefined();
       expect(claim.isActive()).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves an ownership conflict from the privileged route retry",
+    async () => {
+      const fixture = fileURLToPath(
+        new URL("../../test/fixtures/tailscale-sudo-conflict-fixture.mjs", import.meta.url),
+      );
+      const fakeBin = tempDirs.make("openclaw-tailscale-bin-");
+      symlinkSync(fixture, path.join(fakeBin, "sudo"));
+      process.env.PATH = `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`;
+      process.env.OPENCLAW_TEST_TAILSCALE_BINARY = fixture;
+
+      await expect(claimTailscaleRoute("serve", 18789)).rejects.toThrow(
+        "ownership OpenClaw cannot prove; it was not modified",
+      );
     },
   );
 

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -405,11 +405,7 @@ export async function claimTailscaleRoute(
     if (!isPermissionDeniedError(error)) {
       throw error;
     }
-    try {
-      return await startTailscaleRouteOwner(["sudo", "-n", tailscaleBin, ...args]);
-    } catch {
-      throw error;
-    }
+    return await startTailscaleRouteOwner(["sudo", "-n", tailscaleBin, ...args]);
   }
 }
 

--- a/test/fixtures/tailscale-sudo-conflict-fixture.mjs
+++ b/test/fixtures/tailscale-sudo-conflict-fixture.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+if (process.argv[2] === "-n") {
+  process.stderr.write("listener already exists for port 443\n");
+} else {
+  process.stderr.write("Access denied: serve config denied\nUse 'sudo tailscale serve'.\n");
+}
+process.exit(1);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators starting a managed Tailscale Serve or Funnel route could receive a misleading permission error when the unprivileged claim was denied but the privileged retry found an existing port-443 route owned outside OpenClaw.

The existing route was already left untouched, but the hidden ownership conflict prevented OpenClaw from showing the targeted cleanup guidance and expected configuration exit status.

## Why This Change Was Made

The privileged retry is the authoritative attempt after an unprivileged permission failure, so its diagnostic now propagates unchanged. The route-ownership boundary remains fail-closed: OpenClaw neither resets nor replaces an unattributable route.

The fix removes the catch that restored the stale permission error and adds a process-boundary regression fixture covering the two different failures.

## User Impact

Operators with a pre-existing Tailscale route now receive the ownership-conflict explanation and targeted cleanup command instead of being told only to retry with elevated permissions. Existing Tailscale configuration remains unchanged until the operator explicitly removes that route.

Production delta: -4 lines. No config, protocol, or persistence surface changes.

## Evidence

- Captured the failure before editing: an unprivileged managed Serve claim returned access denied; its `sudo -n` retry found the existing port-443 listener; OpenClaw discarded that conflict and exited 1 with the stale permission message.
- The new regression test failed on the pre-fix implementation because it received access denied instead of `TailscaleRouteOwnershipConflictError`; it passes after the repair.
- Live off-host upgrade proof:
  - created a persistent Serve route with published OpenClaw `2026.7.1-2`;
  - started the exact branch build without removing that route;
  - observed exit 78 with targeted cleanup guidance;
  - verified the canonical Tailscale route JSON hash was byte-identical before and after the failed claim;
  - removed only the documented root handler, then proved managed Serve startup, peer reachability, graceful shutdown, and route release.
- Additional disposable-host coverage passed for current Tailscale managed Serve, managed Funnel from an internet-only verifier, forced-owner termination cleanup, externally managed Serve/Funnel fanout to two ordinary Gateway listeners, authenticated requests, unauthenticated rejection, and unattributable proxy rejection.
- Tailscale 1.52.0 minimum managed-foreground Serve proof passed, including peer reachability and owner-bound release.
- Compatibility boundary: Tailscale 1.52.0 Funnel started and obtained a certificate but did not publish public DNS during the proof window, so legacy-client Funnel success remains unclaimed. Current stable Tailscale 1.102.2 passed the public Funnel lane from an internet-only verifier.
- Exact-head cross-platform CI passed both Windows Node process/path shards and the macOS Node lane. The broader manual dispatch was canceled after those forced OS lanes completed because regular PR CI had already covered the remaining suite.
- `pnpm check:changed`
- 145 focused Tailscale, Gateway, ingress, Doctor, and supervised-run tests
- Structured autoreview: clean, no actionable findings

All Tailscale behavior proof ran on disposable off-host machines; the development host's Tailscale configuration was not read or modified.
