### PR TITLE
fix(codex): keep newer Desktop app-servers eligible

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -317,11 +317,11 @@ If the normal app-server runtime would be `danger-full-access`, enabling
 permission profile instead. Codex-managed network enforcement is sandboxed
 networking, so a full-access profile would not protect outbound traffic.
 
-The plugin ships Codex app-server `0.147.0` and accepts external versions through
-`0.148.0-alpha.15`. Versions outside that tested range and malformed or
-unversioned handshakes are rejected. Build metadata does not affect SemVer
-precedence. The same range applies to explicit custom executables, remote
-app-servers, and macOS desktop binaries; admission is not readiness proof.
+The plugin ships Codex app-server `0.147.0` and accepts external versions at or
+above that minimum. Older, malformed, and unversioned handshakes are rejected.
+Build metadata does not affect SemVer precedence. The same minimum applies to
+explicit custom executables, remote app-servers, and macOS desktop binaries;
+admission is not readiness proof.
 
 OpenClaw treats non-loopback WebSocket app-server URLs as remote and requires
 identity-bearing WebSocket auth through `appServer.authToken` or an

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -89,12 +89,12 @@ channel is the communication surface.
 
 - The official `@openclaw/codex` plugin installed. Include `codex` in
   `plugins.allow` if your config uses an allowlist.
-- Codex app-server `0.147.0` through `0.148.0-alpha.15`. The plugin still ships and manages the
+- Codex app-server `0.147.0` or newer. The plugin still ships and manages the
   exact `@openai/codex` `0.147.0` artifact, so a `codex` command on `PATH` does
   not affect normal startup. Explicit custom, remote, and macOS desktop-owned
-  app-servers must report valid SemVer inside that tested external range.
-  Versions above the managed artifact initialize with a warning; acceptance
-  permits an attempt and is not readiness or capability proof.
+  app-servers must report valid SemVer at or above that managed baseline.
+  Newer versions initialize with a warning; acceptance permits an attempt and
+  is not readiness or capability proof.
 - Node.js on the remote Codex app-server host when `remoteWorkspaceRoot` is set
   and cross-machine workspace attachments must be transferred.
 - Codex auth through `openclaw models auth login --provider openai`, an
@@ -1355,11 +1355,10 @@ instead of a plain OpenAI API-key failure.
 Doctor rewrites legacy model refs to `openai/*`, removes stale session and
 whole-agent runtime pins, and preserves existing auth-profile overrides.
 
-**The app-server is rejected:** use Codex `0.147.0` through
-`0.148.0-alpha.15`. OpenClaw rejects versions outside that tested range, plus
-malformed and unversioned servers. Same-version prereleases such as
+**The app-server is rejected:** use Codex `0.147.0` or newer. OpenClaw rejects
+older, malformed, and unversioned servers. Same-version prereleases such as
 `0.147.0-alpha.2` remain below the stable minimum; build metadata such as
-`0.147.0+desktop` does not affect precedence. An accepted external version is
+`0.147.0+desktop` does not affect precedence. A newer external version is
 permitted to initialize rather than treated as proof of compatibility, so
 startup and capability operations can still fail with their normal diagnostics.
 

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -22,10 +22,9 @@ working.
 - The agent runtime must be the native Codex harness.
 - `plugins.entries.codex.enabled` is `true`.
 - `plugins.entries.codex.config.codexPlugins.enabled` is `true`.
-- Codex app-server reports a version from `0.147.0` through
-  `0.148.0-alpha.15`. The official plugin still ships `@openai/codex`
-  `0.147.0`; accepted external versions remain subject to normal startup and
-  capability validation.
+- Codex app-server reports version `0.147.0` or newer. The official plugin
+  still ships `@openai/codex` `0.147.0`; accepted external versions remain
+  subject to normal startup and capability validation.
 - The target Codex app-server can see the expected marketplace, plugin, and
   app inventory.
 - Migration supports only `openai-curated` plugins that it observed as

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -319,9 +319,8 @@ For operator setup, model prefix examples, and Codex-only configs, see
 
 The Codex plugin enforces the minimum app-server version documented in
 [Codex Harness](/plugins/codex-harness). It checks the initialize handshake and
-blocks versions outside the tested external range plus malformed or unversioned
-servers. Admission permits startup to continue; it does not prove later runtime
-or capability operations will succeed.
+blocks older, malformed, or unversioned servers. Admission permits startup to
+continue; it does not prove later runtime or capability operations will succeed.
 
 ### Tool-result middleware
 

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -8,11 +8,7 @@ import {
 } from "./client.js";
 import { resetSharedCodexAppServerClientForTests } from "./shared-client.js";
 import { createClientHarness } from "./test-support.js";
-import {
-  CODEX_APP_SERVER_VERSION,
-  MAX_SUPPORTED_CODEX_APP_SERVER_VERSION,
-  MIN_SUPPORTED_CODEX_APP_SERVER_VERSION,
-} from "./version.js";
+import { CODEX_APP_SERVER_VERSION, MIN_SUPPORTED_CODEX_APP_SERVER_VERSION } from "./version.js";
 
 const CODEX_DYNAMIC_TOOL_SERVER_REQUEST_TIMEOUT_MS = 660_000;
 
@@ -365,7 +361,7 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(initializing).rejects.toThrow(
-      `A Codex app-server from ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} through ${MAX_SUPPORTED_CODEX_APP_SERVER_VERSION} is required, but detected 0.146.9`,
+      `Codex app-server ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} or newer is required, but detected 0.146.9`,
     );
     expect(harness.writes).toHaveLength(1);
   });
@@ -378,7 +374,7 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(initializing).rejects.toThrow(
-      `A Codex app-server from ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} through ${MAX_SUPPORTED_CODEX_APP_SERVER_VERSION} is required, but detected 0.146.0`,
+      `Codex app-server ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} or newer is required, but detected 0.146.0`,
     );
     expect(harness.writes).toHaveLength(1);
   });
@@ -391,7 +387,7 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(initializing).rejects.toThrow(
-      `A Codex app-server from ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} through ${MAX_SUPPORTED_CODEX_APP_SERVER_VERSION} is required, but detected 0.147.0-alpha.2`,
+      `Codex app-server ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} or newer is required, but detected 0.147.0-alpha.2`,
     );
     expect(harness.writes).toHaveLength(1);
   });
@@ -418,7 +414,7 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(initializing).rejects.toThrow(
-      `A Codex app-server from ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} through ${MAX_SUPPORTED_CODEX_APP_SERVER_VERSION} is required`,
+      `Codex app-server ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} or newer is required`,
     );
     expect(harness.writes).toHaveLength(1);
   });
@@ -431,13 +427,13 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(initializing).rejects.toThrow(
-      `A Codex app-server from ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} through ${MAX_SUPPORTED_CODEX_APP_SERVER_VERSION} is required`,
+      `Codex app-server ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} or newer is required`,
     );
     expect(harness.writes).toHaveLength(1);
   });
 
-  it.each(["0.148.0-alpha.9", MAX_SUPPORTED_CODEX_APP_SERVER_VERSION])(
-    "accepts tested Codex Desktop prerelease %s for normal startup validation",
+  it.each(["0.148.0-alpha.9", "0.148.0-alpha.15", "0.148.0-alpha.23", "0.148.0", "1.0.0"])(
+    "accepts a newer app-server version %s for normal startup validation",
     async (newerVersion) => {
       const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
       const { harness, initializing, outbound } = startInitialize();
@@ -459,22 +455,6 @@ describe("CodexAppServerClient", () => {
     },
   );
 
-  it.each(["0.148.0-alpha.16", "0.148.0", "1.0.0"])(
-    "blocks unverified future app-server version %s during initialize",
-    async (version) => {
-      const { harness, initializing, outbound } = startInitialize();
-      harness.send({
-        id: outbound.id,
-        result: { userAgent: `openclaw/${version} (macOS; test)` },
-      });
-
-      await expect(initializing).rejects.toThrow(
-        `through ${MAX_SUPPORTED_CODEX_APP_SERVER_VERSION} is required`,
-      );
-      expect(harness.writes).toHaveLength(1);
-    },
-  );
-
   it.each(["0.147.00", "0.148.0-alpha..9", "0.148.0-alpha.09"])(
     "blocks malformed app-server version %s during initialize",
     async (version) => {
@@ -485,7 +465,7 @@ describe("CodexAppServerClient", () => {
       });
 
       await expect(initializing).rejects.toThrow(
-        `A Codex app-server from ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} through ${MAX_SUPPORTED_CODEX_APP_SERVER_VERSION} is required`,
+        `Codex app-server ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} or newer is required`,
       );
       expect(harness.writes).toHaveLength(1);
     },
@@ -496,7 +476,7 @@ describe("CodexAppServerClient", () => {
     harness.send({ id: outbound.id, result: {} });
 
     await expect(initializing).rejects.toThrow(
-      `A Codex app-server from ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} through ${MAX_SUPPORTED_CODEX_APP_SERVER_VERSION} is required`,
+      `Codex app-server ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} or newer is required`,
     );
     expect(harness.writes).toHaveLength(1);
   });

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -31,11 +31,7 @@ import {
   closeCodexAppServerTransportAndWait,
   type CodexAppServerTransport,
 } from "./transport.js";
-import {
-  CODEX_APP_SERVER_VERSION,
-  MAX_SUPPORTED_CODEX_APP_SERVER_VERSION,
-  MIN_SUPPORTED_CODEX_APP_SERVER_VERSION,
-} from "./version.js";
+import { CODEX_APP_SERVER_VERSION, MIN_SUPPORTED_CODEX_APP_SERVER_VERSION } from "./version.js";
 
 const CODEX_APP_SERVER_PARSE_LOG_MAX = 500;
 const CODEX_APP_SERVER_PARSE_BUFFER_MAX = 8 * 1024 * 1024;
@@ -1004,7 +1000,7 @@ class CodexAppServerVersionError extends Error {
       ? `detected ${detectedVersion}`
       : "OpenClaw could not determine the running Codex version";
     super(
-      `A Codex app-server from ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} through ${MAX_SUPPORTED_CODEX_APP_SERVER_VERSION} is required, but ${detected}. Update the configured Codex app-server binary, or remove custom command overrides to use the managed binary.`,
+      `Codex app-server ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} or newer is required, but ${detected}. Update the configured Codex app-server binary, or remove custom command overrides to use the managed binary.`,
     );
     this.name = "CodexAppServerVersionError";
     this.detectedVersion = detectedVersion;
@@ -1017,11 +1013,7 @@ function assertSupportedCodexAppServerVersion(response: CodexInitializeResponse)
     throw new CodexAppServerVersionError(detectedVersion);
   }
   const detected = parseSemver(detectedVersion);
-  if (
-    !detected ||
-    detected.compare(MIN_SUPPORTED_CODEX_APP_SERVER_VERSION) < 0 ||
-    detected.compare(MAX_SUPPORTED_CODEX_APP_SERVER_VERSION) > 0
-  ) {
+  if (!detected || detected.compare(MIN_SUPPORTED_CODEX_APP_SERVER_VERSION) < 0) {
     throw new CodexAppServerVersionError(detectedVersion);
   }
   if (detected.compare(CODEX_APP_SERVER_VERSION) > 0) {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -9,11 +9,7 @@ import type { CodexAppServerStartOptions } from "./config.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
 import { codexNativeSubagentMonitorRuntime } from "./native-subagent-monitor.js";
 import { createClientHarness } from "./test-support.js";
-import {
-  CODEX_APP_SERVER_VERSION,
-  MAX_SUPPORTED_CODEX_APP_SERVER_VERSION,
-  MIN_SUPPORTED_CODEX_APP_SERVER_VERSION,
-} from "./version.js";
+import { CODEX_APP_SERVER_VERSION, MIN_SUPPORTED_CODEX_APP_SERVER_VERSION } from "./version.js";
 
 const mocks = vi.hoisted(() => ({
   bridgeCodexAppServerStartOptions: vi.fn(async ({ startOptions }) => startOptions),
@@ -283,7 +279,7 @@ describe("shared Codex app-server client", () => {
     await sendInitializeResult(harness, "openclaw/0.117.9 (macOS; test)");
 
     await expect(listPromise).rejects.toThrow(
-      `A Codex app-server from ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} through ${MAX_SUPPORTED_CODEX_APP_SERVER_VERSION} is required`,
+      `Codex app-server ${MIN_SUPPORTED_CODEX_APP_SERVER_VERSION} or newer is required`,
     );
     expect(harness.process.stdin.destroyed).toBe(true);
     startSpy.mockRestore();
@@ -518,7 +514,7 @@ describe("shared Codex app-server client", () => {
     const startOptions = configureManagedDesktopFallback();
 
     const acquire = getSharedCodexAppServerClient({ startOptions, timeoutMs: 1_000 });
-    await sendInitializeResult(desktop, "openclaw/0.148.0-alpha.9 (macOS; test)");
+    await sendInitializeResult(desktop, "openclaw/0.148.0-alpha.23 (macOS; test)");
     const client = await acquire;
 
     expect(client).toBe(desktop.client);
@@ -532,7 +528,7 @@ describe("shared Codex app-server client", () => {
     expect(mocks.embeddedAgentLog.warn).toHaveBeenCalledWith(
       "codex app-server is newer than OpenClaw's managed runtime; continuing with normal startup validation",
       {
-        detectedVersion: "0.148.0-alpha.9",
+        detectedVersion: "0.148.0-alpha.23",
         validatedVersion: CODEX_APP_SERVER_VERSION,
       },
     );

--- a/extensions/codex/src/app-server/version.ts
+++ b/extensions/codex/src/app-server/version.ts
@@ -5,9 +5,5 @@
 export const CODEX_APP_SERVER_VERSION = "0.147.0";
 /** Inclusive runtime compatibility floor for external app-server binaries. */
 export const MIN_SUPPORTED_CODEX_APP_SERVER_VERSION = "0.147.0";
-/** Inclusive runtime compatibility ceiling for external app-server binaries. */
-// The ceiling is the newest Desktop build covered by upstream source inspection and
-// a live Computer Use flow. Raising it requires equivalent protocol and live proof.
-export const MAX_SUPPORTED_CODEX_APP_SERVER_VERSION = "0.148.0-alpha.15";
 /** npm package name for the managed Codex app-server binary. */
 export const MANAGED_CODEX_APP_SERVER_PACKAGE = "@openai/codex";


### PR DESCRIPTION
Related: #125882
Follow-up to #125883

AI-assisted: yes. I reviewed the implementation and its upstream Codex contract directly.

## What Problem This Solves

Fixes an issue where users starting Codex Computer Use through Codex Desktop would again lose the Desktop runtime after a routine update beyond `0.148.0-alpha.15`. OpenClaw treated that release-specific ceiling as an incompatibility and fell back to the managed `0.147.0` package before normal readiness and capability validation.

The ceiling was already stale when it merged: Codex had released `0.148.0-alpha.23`.

## Why This Change Was Made

The managed `@openai/codex` artifact remains exactly pinned to `0.147.0`. External app-servers must still report valid SemVer at or above the stable `0.147.0` floor, but newer versions may initialize with the existing warning and proceed through normal startup, readiness, and required-operation validation.

This is an availability tradeoff, not a forward-compatibility guarantee. Upstream Codex initialization exposes the CLI build version through `userAgent`, but no server protocol/schema version or server-declared capability contract. OpenClaw also opts into Codex's explicitly unstable experimental API. A CLI-version ceiling therefore has no upstream compatibility semantics and guarantees recurring rejection as Desktop advances.

The separate selected-distribution provisioning/fallback invariant remains owned by #126080. This PR does not change provisioning or fallback mechanics; it removes only upper-bound-triggered fallbacks.

## User Impact

Codex Desktop app-server releases newer than `0.148.0-alpha.15`, including `0.148.0-alpha.23`, remain selected long enough to run OpenClaw's normal readiness and Computer Use checks. Older, malformed, unversioned, and same-core prerelease versions remain rejected. Genuine runtime incompatibilities still surface through their normal startup or capability diagnostics.

## Evidence

- Failed first on merged `main`: the focused client suite rejected `0.148.0-alpha.23`, `0.148.0`, and `1.0.0` at the former maximum-version branch (3 failures; 40 tests passed).
- Focused post-fix proof: `102/102` client and managed-fallback tests passed. Coverage confirms `0.148.0-alpha.23` remains the selected Desktop client without package fallback and retains rejection for missing, malformed, below-floor, and same-core prerelease versions.
- `pnpm check:changed` passed, including extension typecheck, test typecheck, lint, import-cycle, dependency, formatting, and architecture guards.
- `pnpm build` passed.
- `pnpm docs:list` passed; all four Codex compatibility docs now describe the minimum-only admission policy.
- Fresh Codex autoreview: 0 findings; patch correct with 0.98 confidence.
- Direct upstream inspection: `../codex/codex-rs/app-server-protocol/src/protocol/v1.rs` and `../codex/codex-rs/app-server/src/request_processors/initialize_processor.rs` expose no server protocol version or server capability set; `../codex/codex-rs/login/src/auth/default_client.rs` builds `userAgent` from `CARGO_PKG_VERSION`; `../codex/codex-rs/app-server/README.md` explicitly gives experimental APIs no backward-compatibility guarantee. The initialize files are unchanged from `rust-v0.147.0` through `rust-v0.148.0-alpha.23` while V2 surfaces continue evolving.
- Existing macOS production proof on #125883 exercised the restored floor-only policy through Desktop `0.148.0-alpha.15`, initialize, readiness, `thread/start`, a normal turn, and native Computer Use operations. This follow-up adds no new live Desktop run.
- Delta: production `-12` lines, tests `-24`, docs `-3`; no dependency or lockfile change.
