### PR TITLE
docs: add release validation handoff

### DIFF
--- a/.agents/skills/openclaw-release-validation/SKILL.md
+++ b/.agents/skills/openclaw-release-validation/SKILL.md
@@ -350,5 +350,19 @@ When the tester says `finish validation`:
 4. Remove local paths, gateway names, secrets, user identifiers, raw logs, OCM
    notes, setup details, and cleanup details from the comment.
 5. Post the comment once with `gh` and show the tester its URL.
+6. Give the tester this concise copy-ready Discord summary, populated only from
+   the same release-facing worksheet evidence and final comment:
+
+   ```md
+   **Release validation — <tag>**
+   Tested: <surfaces with non-empty Testing notes, or "No manual surface testing completed">
+   Key findings: <concise release findings, or "None reported">
+   Recommendation: <yes / no>
+   Details: <GitHub comment URL>
+   ```
+
+   Keep it to these five lines. Exclude source gateway details, local paths,
+   OCM/setup information, cleanup, credentials, and untested surface guidance.
+   This is a copy/paste handoff for the tester; do not post it automatically.
 
 The skill collects release feedback; it does not make the go/no-go decision.

--- a/.agents/skills/openclaw-release-validation/SKILL.md
+++ b/.agents/skills/openclaw-release-validation/SKILL.md
@@ -362,7 +362,10 @@ When the tester says `finish validation`:
    the source of observed results; do not report the other table rows as evidence.
 4. Remove local paths, gateway names, secrets, user identifiers, raw logs, OCM
    notes, setup details, and cleanup details from the comment.
-5. Post the comment once with `gh` and show the tester its URL.
+5. Read and apply the [structured report contract](references/structured-report.md).
+   Append its hidden v1 payload to the visible Markdown, validate it, then create
+   or update this GitHub user's one report comment for the release. Show the
+   tester the resulting comment URL.
 6. Give the tester this concise copy-ready Discord summary, populated only from
    the same release-facing worksheet evidence and final comment:
 

--- a/.agents/skills/openclaw-release-validation/SKILL.md
+++ b/.agents/skills/openclaw-release-validation/SKILL.md
@@ -85,8 +85,20 @@ format above, then read its body and use the worksheet between
 `<!-- validation-worksheet:end -->`. Keep its release priorities and template
 unchanged. Those exact bytes are the canonical campaign template for this run.
 
-In **Initialize campaign**, reuse the current issue unchanged when it already
-exists. When it does not exist, generate it:
+In **Initialize campaign**, first ensure the repository has a
+`release-validation` label. Check for the exact label with
+`gh label list --search release-validation --json name`; create it only when
+absent with `gh label create release-validation --color 0E8A16 --description
+"OpenClaw release-validation campaign"`. Do not use `--force` or alter an
+existing label. Apply `release-validation` with `gh issue edit <number>
+--add-label release-validation` to the canonical issue whether it is reused or
+newly created, then verify the label through `gh issue view <number> --json
+labels`. This makes active campaigns discoverable with `gh issue list --state
+open --label release-validation` while the exact hidden marker remains the
+canonical matching rule.
+
+Reuse the current issue's body unchanged when it already exists. When it does
+not exist, generate it:
 
 1. Read the GitHub release notes for the exact tag. If they are empty or
    incomplete, also read that tag's section of `CHANGELOG.md`.
@@ -158,11 +170,11 @@ exists. When it does not exist, generate it:
    priority reflects release change volume, size, impact, upgrade risk, and
    maturity expectations. Remove the campaign-creator comment and ensure no
    template placeholder remains except `{{TEST_ENV}}` inside OCM commands.
-8. Create the issue with the stable marker, a short participation note, and the
-   completed worksheet verbatim between the worksheet markers. Read it back and
-   require the marker contents to equal the rendered worksheet before treating
-   campaign initialization as complete. Re-query open issues for the marker
-   after creation and fail on duplicates.
+8. Create the issue with the stable marker, a short participation note, the
+   `release-validation` label, and the completed worksheet verbatim between the
+   worksheet markers. Read it back and require the marker contents to equal the
+   rendered worksheet before treating campaign initialization as complete.
+   Re-query open issues for the marker after creation and fail on duplicates.
 
 After the current issue exists, find open campaign issues whose marker names a
 release published before the current candidate. Comment on each with the current

--- a/.agents/skills/openclaw-release-validation/SKILL.md
+++ b/.agents/skills/openclaw-release-validation/SKILL.md
@@ -87,8 +87,9 @@ unchanged. Those exact bytes are the canonical campaign template for this run.
 
 In **Initialize campaign**, first ensure the repository has a
 `release-validation` label. Check for the exact label with
-`gh label list --search release-validation --json name`; create it only when
-absent with `gh label create release-validation --color 0E8A16 --description
+`gh label list --search release-validation --json name --jq
+'any(.[]; .name == "release-validation")'`; create it only when that exact-name
+check returns `false` with `gh label create release-validation --color 0E8A16 --description
 "OpenClaw release-validation campaign"`. Do not use `--force` or alter an
 existing label. Apply `release-validation` with `gh issue edit <number>
 --add-label release-validation` to the canonical issue whether it is reused or

--- a/.agents/skills/openclaw-release-validation/references/structured-report.md
+++ b/.agents/skills/openclaw-release-validation/references/structured-report.md
@@ -1,0 +1,121 @@
+# Structured release report
+
+Apply this contract only while publishing final feedback. The visible Markdown
+remains the human report. Append one hidden, versioned payload so dashboards can
+consume the same evidence without interpreting prose.
+
+## Build the current run
+
+Derive both representations from the sanitized worksheet evidence. Turn each
+distinct tester observation into one finding. Split multiple behaviors into
+separate findings; keep expected and observed behavior only when the tester
+provided them. A positive check is a `pass`, candidate misbehavior is a
+`problem`, and useful neutral context is an `observation`.
+
+Use the surface's live-taxonomy URL fragment as its stable `id`. Use `unmapped`
+only when no scorecard surface fits. Include only surfaces with non-empty
+**Testing notes**. Do not infer severity, cross-user cluster ids, or whether a
+finding is fixed on `main`; dashboard analysis owns those judgments.
+
+Append this envelope after the visible Markdown:
+
+```md
+<!-- openclaw-release-validation-report:v1
+<compact JSON object>
+-->
+```
+
+The JSON object has this exact shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "openclaw-release-validation-report",
+  "release": {
+    "tag": "vYYYY.M.D-beta.N",
+    "candidateCommit": "full candidate commit"
+  },
+  "revision": 1,
+  "updatedAt": "ISO-8601 timestamp",
+  "currentRunId": "random UUID",
+  "runs": [
+    {
+      "runId": "random UUID",
+      "submittedAt": "ISO-8601 timestamp",
+      "source": {
+        "version": "privacy-safe source version",
+        "commit": null
+      },
+      "upgrade": {
+        "result": "pass",
+        "findings": []
+      },
+      "surfaces": [
+        {
+          "id": "models",
+          "name": "Models",
+          "findings": []
+        }
+      ],
+      "overallFeedback": "tester feedback",
+      "promotionVote": "yes"
+    }
+  ]
+}
+```
+
+Allowed `upgrade.result` values are `pass`, `problem`, `blocked`, and `unknown`.
+Allowed `promotionVote` values are `yes`, `no`, and `unknown`. Use `null` for an
+unknown source commit.
+
+Every `findings` item has:
+
+```json
+{
+  "surfaceId": "models",
+  "result": "problem",
+  "summary": "Selected model reverted after restart",
+  "expected": "The selected model remains active",
+  "observed": "The default model was restored",
+  "issueUrl": "https://github.com/openclaw/openclaw/issues/123"
+}
+```
+
+`result` is `pass`, `problem`, or `observation`. `surfaceId`, `result`, and
+`summary` are required. Omit `expected`, `observed`, and `issueUrl` when the
+tester did not provide them. Public OpenClaw issue URLs are allowed; other URLs
+are plain text only when essential release evidence.
+
+## Keep one report per tester
+
+Resolve the authenticated login with `gh api user`. Enumerate the campaign's
+comments and find comments authored by that login containing the exact v1
+marker. The login is lookup metadata only; never include it in the payload.
+
+- No matching comment: create one with `revision: 1` and the current run.
+- One valid matching comment: retain its `runs`, append the current run, set
+  `currentRunId` to the new UUID, increment `revision`, update `updatedAt`, and
+  replace that comment. The visible Markdown summarizes the current run.
+- Multiple matches, invalid JSON, a different release, or an unsupported schema:
+  stop and show the conflicting comment URLs instead of creating another vote.
+
+Consumers count the current run's promotion vote once per GitHub author. Older
+runs remain evidence but do not add votes.
+
+## Validate before publishing
+
+The hidden payload is public GitHub content. Apply the visible comment's privacy
+filter to every string: no local paths, gateway or environment names,
+credentials, raw logs, user identifiers, OCM/setup details, or cleanup details.
+
+Serialize compact JSON. Escape `<`, `>`, and `&` inside JSON strings as Unicode
+escapes so content cannot terminate the HTML comment. Parse the serialized bytes
+again with `jq -e`, require the exact schema and enum values above, and require
+the complete comment to remain below 60,000 UTF-8 bytes. Stop and ask rather
+than discard older runs when retaining them would exceed that bound. If any
+other validation fails, repair the payload before a GitHub write; never publish
+prose without its matching valid payload.
+
+After the create or update, read the comment back. Completion requires the
+visible Markdown, marker, JSON, current run id, and promotion vote to match the
+locally validated comment exactly.


### PR DESCRIPTION
## Summary
- give testers a concise Discord-ready handoff after validation
- label release-validation campaigns with an exact-name existence check
- append a hidden v1 JSON report to each human-readable final comment
- keep one report comment per GitHub user while preserving prior runs as evidence

## Validation
- `python3 skills/skill-creator/scripts/quick_validate.py .agents/skills/openclaw-release-validation`
- parsed the documented v1 schema example with `jq -e`
- ran the exact label lookup against `openclaw/openclaw`
- `git diff --check`
