### PR TITLE
fix(gateway): prevent Tailscale orphan crash loops on launchd restart

### DIFF
--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -24,6 +24,7 @@ export {
   consumeGatewayRestartIntentSync,
 } from "../../infra/restart-intent.js";
 export { writeGatewayRestartHandoffSync } from "../../infra/restart-handoff.js";
+export { LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS } from "../../daemon/launchd-plist.js";
 export {
   cancelManagedServiceUpdateHandoff,
   claimManagedServiceUpdateHandoff,

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -24,7 +24,7 @@ export {
   consumeGatewayRestartIntentSync,
 } from "../../infra/restart-intent.js";
 export { writeGatewayRestartHandoffSync } from "../../infra/restart-handoff.js";
-export { LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS } from "../../daemon/launchd-plist.js";
+export { readLoadedLaunchAgentExitTimeoutSecondsSync } from "../../daemon/launchd-exit-timeout.js";
 export {
   cancelManagedServiceUpdateHandoff,
   claimManagedServiceUpdateHandoff,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -3641,6 +3641,52 @@ describe("runGatewayLoop", () => {
     }
   });
 
+  it("cancels an ordinary restart watchdog when a managed update takes over", async () => {
+    vi.clearAllMocks();
+    consumeGatewaySigusr1RestartIntent.mockReturnValueOnce(null).mockReturnValueOnce({
+      reason: "update.auto",
+      successorOwner: managedUpdateSuccessorOwner,
+    });
+    peekGatewaySigusr1RestartReason
+      .mockReturnValueOnce("config.patch")
+      .mockReturnValueOnce("update.auto");
+    requestManagedServiceUpdateHandoffPark.mockResolvedValueOnce(false);
+    const releaseDrain = blockActiveWorkDrain();
+    setPlatform("linux");
+    vi.useFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { start, runtime, exited } = await createOwnedLoop();
+        const sigusr1 = captureSignal("SIGUSR1");
+
+        sigusr1();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(armShutdownHardExitWatchdog).toHaveBeenCalledOnce();
+
+        sigusr1();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(cancelShutdownHardExitWatchdog).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS + 325_000);
+        expect(runtime.exit).not.toHaveBeenCalled();
+
+        releaseDrain();
+        await vi.advanceTimersByTimeAsync(0);
+        await vi.waitFor(() => expect(start).toHaveBeenCalledTimes(2));
+        expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledExactlyOnceWith(
+          managedUpdateSuccessorOwner,
+        );
+
+        captureSignal("SIGINT")();
+        await vi.advanceTimersByTimeAsync(0);
+        await expect(exited).resolves.toBe(0);
+      });
+    } finally {
+      releaseDrain();
+      vi.useRealTimers();
+    }
+  });
+
   it("reads an update upgrade after asynchronous lock release", async () => {
     vi.clearAllMocks();
     peekGatewaySigusr1RestartReason

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -378,14 +378,18 @@ async function withManagedLaunchdUpdateRestart(
     reason: "update.auto",
     successorOwner: managedUpdateSuccessorOwner,
   });
-  setPlatform("darwin");
-  process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-  vi.useFakeTimers();
+  useLaunchdFakeTimers();
   try {
     await withIsolatedSignals(run);
   } finally {
     vi.useRealTimers();
   }
+}
+
+function useLaunchdFakeTimers() {
+  setPlatform("darwin");
+  process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+  vi.useFakeTimers();
 }
 
 function createRuntimeWithExitSignal(exitCallOrder?: string[]) {
@@ -511,6 +515,22 @@ async function createOwnedLoop(close: GatewayCloseFn = createCloseMock()) {
   await runLoopWithStart({ start, runtime: lifecycle.runtime, ownsProcessLifecycle: true });
   await vi.advanceTimersByTimeAsync(0);
   await started;
+  return { start, ...lifecycle };
+}
+
+async function createBlockedStartupLoop() {
+  const startupEntered = createDeferredCore();
+  const lifecycle = createRuntimeWithExitSignal();
+  const start = vi.fn(async () => {
+    startupEntered.resolve();
+    return await new Promise<never>(() => {});
+  });
+  const { runGatewayLoop } = await import("./run-loop.js");
+  void runGatewayLoop({
+    start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+    runtime: lifecycle.runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+  });
+  await startupEntered.promise;
   return { start, ...lifecycle };
 }
 
@@ -1568,210 +1588,147 @@ describe("runGatewayLoop", () => {
     });
   });
 
-  it("keeps launchd SIGTERM restart inside the original ExitTimeOut deadline", async () => {
-    vi.clearAllMocks();
-    const close = vi.fn<GatewayCloseFn>(() => new Promise<void>(() => {}));
+  it.each([
+    { blockedStage: "handoff parking", signalOrder: "sigusr1-first" },
+    { blockedStage: "handoff cancellation", signalOrder: "sigterm-first" },
+    { blockedStage: "final handoff", signalOrder: "sigterm-first" },
+    { blockedStage: "final handoff", signalOrder: "sigusr1-first" },
+  ] as const)(
+    "keeps the launchd deadline when $blockedStage blocks ($signalOrder)",
+    async ({ blockedStage, signalOrder }) => {
+      vi.clearAllMocks();
+      let releaseStage = () => {};
+      const close = createCloseMock();
+      if (blockedStage === "handoff parking") {
+        requestManagedServiceUpdateHandoffPark.mockImplementationOnce(() =>
+          new Promise<void>((resolve) => {
+            releaseStage = resolve;
+          }).then(() => true),
+        );
+      } else if (blockedStage === "handoff cancellation") {
+        requestManagedServiceUpdateHandoffPark.mockResolvedValueOnce(false);
+        cancelManagedServiceUpdateHandoff.mockImplementationOnce(() => new Promise(() => {}));
+      } else if (blockedStage === "final handoff") {
+        commitManagedServiceUpdateHandoff.mockResolvedValueOnce(false);
+        cancelManagedServiceUpdateHandoff.mockResolvedValueOnce(false);
+      }
+      const releaseDrain =
+        blockedStage === "handoff cancellation" || blockedStage === "final handoff"
+          ? blockActiveWorkDrain()
+          : () => {};
+      try {
+        await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
+          const { runtime, exited } = await createOwnedLoop(close);
+          if (signalOrder === "sigterm-first") {
+            captureSignal("SIGTERM")();
+            await vi.advanceTimersByTimeAsync(10_000);
+          }
+          captureSignal("SIGUSR1")();
+          await vi.advanceTimersByTimeAsync(0);
+          releaseDrain();
+          await vi.advanceTimersByTimeAsync(0);
+          if (signalOrder === "sigusr1-first") {
+            captureSignal("SIGTERM")();
+          }
 
-    await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
-      const { runtime, exited } = await createOwnedLoop(close);
+          if (blockedStage === "handoff parking") {
+            expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledOnce();
+          } else if (blockedStage === "handoff cancellation") {
+            expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledExactlyOnceWith(
+              managedUpdateSuccessorOwner,
+            );
+            expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledExactlyOnceWith(
+              managedUpdateSuccessorOwner,
+            );
+          } else {
+            expect(commitManagedServiceUpdateHandoff).toHaveBeenCalledOnce();
+            expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledOnce();
+          }
 
-      captureSignal("SIGTERM")();
-      await vi.advanceTimersByTimeAsync(0);
-      expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(5_000);
-      expectRestartCloseCall(close, 5_000);
+          const remainingMs = signalOrder === "sigterm-first" ? 5_000 : 15_000;
+          await vi.advanceTimersByTimeAsync(remainingMs - 1);
+          expect(runtime.exit).not.toHaveBeenCalled();
+          await vi.advanceTimersByTimeAsync(1);
+          await expect(exited).resolves.toBe(1);
+        }, signalOrder);
+      } finally {
+        releaseDrain();
+        releaseStage();
+      }
+    },
+  );
 
-      await vi.advanceTimersByTimeAsync(10_000);
-      captureSignal("SIGUSR1")();
-      await vi.advanceTimersByTimeAsync(4_999);
-      expect(runtime.exit).not.toHaveBeenCalled();
-      await vi.advanceTimersByTimeAsync(1);
-
-      await expect(exited).resolves.toBe(1);
-      expect(gatewayLog.info).toHaveBeenCalledWith(
-        "received SIGUSR1 during shutdown; upgrading to update.auto",
+  it.each([
+    { managedUpgrade: true, initialDrainMs: DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS, closeMs: 5_000 },
+    { managedUpgrade: false, initialDrainMs: 2_500, closeMs: 2_500 },
+  ])(
+    "applies a late launchd deadline without weakening a $initialDrainMs ms cutoff",
+    async ({ managedUpgrade, initialDrainMs, closeMs }) => {
+      vi.clearAllMocks();
+      consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce(
+        managedUpgrade ? null : { waitMs: initialDrainMs },
       );
-    });
-  });
-
-  it("retains the launchd deadline when managed handoff cancellation stalls", async () => {
-    vi.clearAllMocks();
-    requestManagedServiceUpdateHandoffPark.mockResolvedValueOnce(false);
-    cancelManagedServiceUpdateHandoff.mockImplementationOnce(() => new Promise(() => {}));
-    const releaseDrain = blockActiveWorkDrain();
-
-    try {
-      await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
-        const { runtime } = await createOwnedLoop();
-
-        captureSignal("SIGTERM")();
-        await vi.advanceTimersByTimeAsync(10_000);
-        captureSignal("SIGUSR1")();
-        await vi.advanceTimersByTimeAsync(0);
+      consumeGatewaySigusr1RestartIntent.mockReturnValueOnce(null);
+      peekGatewaySigusr1RestartReason.mockReturnValueOnce("config.patch");
+      if (managedUpgrade) {
+        consumeGatewayRestartIntentPayloadSync
+          .mockReturnValueOnce(null)
+          .mockReturnValueOnce({ reason: "update.auto" });
+        consumeGatewaySigusr1RestartIntent.mockReturnValueOnce({
+          reason: "update.auto",
+          successorOwner: managedUpdateSuccessorOwner,
+        });
+        requestManagedServiceUpdateHandoffPark.mockResolvedValueOnce(false);
+        peekGatewaySigusr1RestartReason.mockReturnValueOnce("update.auto");
+      }
+      const releaseDrain = blockActiveWorkDrain();
+      const close = createCloseMock();
+      useLaunchdFakeTimers();
+      try {
+        await withIsolatedSignals(async ({ captureSignal }) => {
+          const { runtime, start } = await createOwnedLoop(close);
+          const sigusr1 = captureSignal("SIGUSR1");
+          sigusr1();
+          await vi.advanceTimersByTimeAsync(0);
+          expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBe(initialDrainMs);
+          if (managedUpgrade) {
+            sigusr1();
+            await vi.advanceTimersByTimeAsync(0);
+          }
+          captureSignal("SIGTERM")();
+          await vi.advanceTimersByTimeAsync(0);
+          if (!managedUpgrade) {
+            expect(close).not.toHaveBeenCalled();
+          }
+          releaseDrain();
+          await vi.advanceTimersByTimeAsync(0);
+          expectRestartCloseCall(close, closeMs);
+          if (managedUpgrade) {
+            expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledExactlyOnceWith(
+              managedUpdateSuccessorOwner,
+            );
+            expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledExactlyOnceWith(
+              managedUpdateSuccessorOwner,
+            );
+            expect(start).toHaveBeenCalledTimes(2);
+            await vi.advanceTimersByTimeAsync(15_000);
+            expect(runtime.exit).toHaveBeenCalledWith(1);
+          }
+        });
+      } finally {
         releaseDrain();
-        await vi.advanceTimersByTimeAsync(0);
-
-        expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledExactlyOnceWith(
-          managedUpdateSuccessorOwner,
-        );
-        expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledExactlyOnceWith(
-          managedUpdateSuccessorOwner,
-        );
-        await vi.advanceTimersByTimeAsync(4_999);
-        expect(runtime.exit).not.toHaveBeenCalled();
-        await vi.advanceTimersByTimeAsync(1);
-
-        expect(runtime.exit).toHaveBeenCalledWith(1);
-        expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledTimes(1);
-        expect(gatewayLog.error).toHaveBeenCalledWith(
-          "launchd shutdown deadline reached with managed update handoff ownership; exiting for supervisor recovery",
-        );
-      });
-    } finally {
-      releaseDrain();
-    }
-  });
-
-  it("bounds a managed restart when launchd SIGTERM follows SIGUSR1", async () => {
-    vi.clearAllMocks();
-    let releasePark: () => void = () => {};
-    requestManagedServiceUpdateHandoffPark.mockImplementationOnce(() =>
-      new Promise<void>((resolve) => {
-        releasePark = resolve;
-      }).then(() => true),
-    );
-
-    try {
-      await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
-        const { runtime } = await createOwnedLoop();
-
-        captureSignal("SIGUSR1")();
-        await vi.advanceTimersByTimeAsync(0);
-        expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledOnce();
-        captureSignal("SIGTERM")();
-        await vi.advanceTimersByTimeAsync(15_000);
-
-        expect(runtime.exit).toHaveBeenCalledWith(1);
-      }, "sigusr1-first");
-    } finally {
-      releasePark();
-    }
-  });
-
-  it("keeps a late launchd deadline after an ordinary restart gains a managed owner", async () => {
-    vi.clearAllMocks();
-    consumeGatewayRestartIntentPayloadSync
-      .mockReturnValueOnce(null)
-      .mockReturnValueOnce(null)
-      .mockReturnValueOnce({
-        reason: "update.auto",
-      });
-    consumeGatewaySigusr1RestartIntent.mockReturnValueOnce(null).mockReturnValueOnce({
-      reason: "update.auto",
-      successorOwner: managedUpdateSuccessorOwner,
-    });
-    peekGatewaySigusr1RestartReason
-      .mockReturnValueOnce("config.patch")
-      .mockReturnValueOnce("update.auto");
-    const releaseDrain = blockActiveWorkDrain();
-    let releaseClose: () => void = () => {};
-    const close = vi.fn<GatewayCloseFn>(
-      () =>
-        new Promise<void>((resolve) => {
-          releaseClose = resolve;
-        }),
-    );
-    setPlatform("darwin");
-    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    vi.useFakeTimers();
-
-    try {
-      await withIsolatedSignals(async ({ captureSignal }) => {
-        const { runtime } = await createOwnedLoop(close);
-        const sigusr1 = captureSignal("SIGUSR1");
-
-        sigusr1();
-        await vi.advanceTimersByTimeAsync(0);
-        expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBe(
-          DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS,
-        );
-        sigusr1();
-        await vi.advanceTimersByTimeAsync(0);
-        captureSignal("SIGTERM")();
-        await vi.advanceTimersByTimeAsync(0);
-        expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledExactlyOnceWith(
-          managedUpdateSuccessorOwner,
-        );
-        expectRestartCloseCall(close, 5_000);
-
-        await vi.advanceTimersByTimeAsync(14_999);
-        expect(runtime.exit).not.toHaveBeenCalled();
-        await vi.advanceTimersByTimeAsync(1);
-
-        expect(runtime.exit).toHaveBeenCalledWith(1);
-      });
-    } finally {
-      releaseDrain();
-      releaseClose();
-      vi.useRealTimers();
-    }
-  });
-
-  it("keeps a stricter active-work cutoff when launchd SIGTERM arrives", async () => {
-    vi.clearAllMocks();
-    consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ waitMs: 2_500 });
-    peekGatewaySigusr1RestartReason.mockReturnValueOnce("config.patch");
-    const releaseDrain = blockActiveWorkDrain();
-    const close = createCloseMock();
-    setPlatform("darwin");
-    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    vi.useFakeTimers();
-
-    try {
-      await withIsolatedSignals(async ({ captureSignal }) => {
-        await createOwnedLoop(close);
-
-        captureSignal("SIGUSR1")();
-        await vi.advanceTimersByTimeAsync(0);
-        expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBe(2_500);
-        captureSignal("SIGTERM")();
-        await vi.advanceTimersByTimeAsync(0);
-        expect(close).not.toHaveBeenCalled();
-
-        releaseDrain();
-        await vi.advanceTimersByTimeAsync(0);
-        expectRestartCloseCall(close, 2_500);
-      });
-    } finally {
-      releaseDrain();
-      vi.useRealTimers();
-    }
-  });
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("lets launchd SIGTERM override an ordinary restart queued during startup", async () => {
     vi.clearAllMocks();
     peekGatewaySigusr1RestartReason.mockReturnValue("config.patch");
-    setPlatform("darwin");
-    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    vi.useFakeTimers();
-
+    useLaunchdFakeTimers();
     try {
       await withIsolatedSignals(async ({ captureSignal }) => {
-        let markStartupEntered: () => void = () => {};
-        const startupEntered = new Promise<void>((resolve) => {
-          markStartupEntered = resolve;
-        });
-        const start = vi.fn(async () => {
-          markStartupEntered();
-          await new Promise<void>(() => {});
-          return createGatewayServer(createCloseMock());
-        });
-        const { runtime } = createRuntimeWithExitSignal();
-        const { runGatewayLoop } = await import("./run-loop.js");
-        void runGatewayLoop({
-          start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
-          runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
-        });
-        await startupEntered;
+        const { runtime } = await createBlockedStartupLoop();
 
         captureSignal("SIGUSR1")();
         await vi.advanceTimersByTimeAsync(0);
@@ -1787,37 +1744,6 @@ describe("runGatewayLoop", () => {
       vi.useRealTimers();
     }
   });
-
-  it.each(["sigterm-first", "sigusr1-first"] as const)(
-    "bounds failed final handoff recovery when %s",
-    async (signalOrder) => {
-      vi.clearAllMocks();
-      commitManagedServiceUpdateHandoff.mockResolvedValueOnce(false);
-      cancelManagedServiceUpdateHandoff.mockResolvedValueOnce(false);
-      const releaseDrain = blockActiveWorkDrain();
-
-      await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
-        const { runtime } = await createOwnedLoop();
-
-        if (signalOrder === "sigterm-first") {
-          captureSignal("SIGTERM")();
-          await vi.advanceTimersByTimeAsync(10_000);
-        }
-        captureSignal("SIGUSR1")();
-        await vi.advanceTimersByTimeAsync(0);
-        releaseDrain();
-        await vi.advanceTimersByTimeAsync(0);
-        expect(commitManagedServiceUpdateHandoff).toHaveBeenCalledOnce();
-        expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledOnce();
-        if (signalOrder === "sigusr1-first") {
-          captureSignal("SIGTERM")();
-        }
-        await vi.advanceTimersByTimeAsync(signalOrder === "sigterm-first" ? 5_000 : 15_000);
-
-        expect(runtime.exit).toHaveBeenCalledWith(1);
-      }, signalOrder);
-    },
-  );
 
   it("uses restart intent wait overrides for SIGTERM drain", async () => {
     vi.clearAllMocks();
@@ -2367,24 +2293,7 @@ describe("runGatewayLoop", () => {
     cancelManagedServiceUpdateHandoff.mockImplementationOnce(() => new Promise(() => {}));
 
     await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
-      let markStartupEntered: () => void = () => {};
-      const startupEntered = new Promise<void>((resolve) => {
-        markStartupEntered = resolve;
-      });
-      const { runtime, exited } = createRuntimeWithExitSignal();
-      const start = vi.fn(async () => {
-        markStartupEntered();
-        await new Promise<void>(() => {});
-        return createGatewayServer(vi.fn(async () => {}));
-      });
-
-      const { runGatewayLoop } = await import("./run-loop.js");
-      void runGatewayLoop({
-        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
-        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
-      });
-      await vi.advanceTimersByTimeAsync(0);
-      await startupEntered;
+      const { runtime, exited, start } = await createBlockedStartupLoop();
 
       captureSignal("SIGTERM")();
       await vi.advanceTimersByTimeAsync(10_000);
@@ -3421,15 +3330,12 @@ describe("runGatewayLoop", () => {
       .mockReturnValueOnce("config.patch")
       .mockReturnValueOnce("update.auto");
 
-    let releaseReacquire: () => void = () => {};
-    const reacquireBlocked = new Promise<void>((resolve) => {
-      releaseReacquire = resolve;
-    });
+    const reacquire = createDeferredCore();
     const staleLockRelease = vi.fn(async () => {});
     acquireGatewayLock
       .mockResolvedValueOnce({ release: vi.fn(async () => {}) })
       .mockImplementationOnce(async () => {
-        await reacquireBlocked;
+        await reacquire.promise;
         return { release: staleLockRelease };
       })
       .mockResolvedValueOnce({ release: vi.fn(async () => {}) });
@@ -3440,20 +3346,11 @@ describe("runGatewayLoop", () => {
         const sigusr1 = captureSignal("SIGUSR1");
 
         sigusr1();
-        await waitForLoopCondition(
-          () => acquireGatewayLock.mock.calls.length === 2,
-          "ordinary restart did not reach lock reacquisition",
-        );
+        await vi.waitFor(() => expect(acquireGatewayLock).toHaveBeenCalledTimes(2));
         sigusr1();
-        await waitForLoopCondition(
-          () => consumeGatewaySigusr1RestartIntent.mock.calls.length === 2,
-          "managed upgrade was not admitted during lock reacquisition",
-        );
-        releaseReacquire();
-        await waitForLoopCondition(
-          () => start.mock.calls.length === 2,
-          "managed upgrade did not resume in process",
-        );
+        await vi.waitFor(() => expect(consumeGatewaySigusr1RestartIntent).toHaveBeenCalledTimes(2));
+        reacquire.resolve();
+        await vi.waitFor(() => expect(start).toHaveBeenCalledTimes(2));
 
         expect(staleLockRelease).toHaveBeenCalledOnce();
         expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledExactlyOnceWith(
@@ -3466,7 +3363,7 @@ describe("runGatewayLoop", () => {
         await expect(exited).resolves.toBe(0);
       });
     } finally {
-      releaseReacquire();
+      reacquire.resolve();
     }
   });
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -30,6 +30,15 @@ vi.mock("../../daemon/hosted-stop.js", () => ({
   prepareHostedGatewayStop: (...args: Parameters<typeof hostedStopPrepare>) =>
     hostedStopPrepare(...args),
 }));
+const readLoadedLaunchAgentExitTimeoutSecondsSync = vi.fn<() => number | undefined>(() => 20);
+vi.mock("../../daemon/launchd-exit-timeout.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../daemon/launchd-exit-timeout.js")>();
+  return {
+    ...actual,
+    readLoadedLaunchAgentExitTimeoutSecondsSync: () =>
+      readLoadedLaunchAgentExitTimeoutSecondsSync(),
+  };
+});
 const consumeGatewayRestartIntentPayloadSync = vi.fn<
   () => { reason?: string; force?: boolean; waitMs?: number } | null
 >(() => null);
@@ -386,10 +395,24 @@ async function withManagedLaunchdUpdateRestart(
   }
 }
 
+let restoreLaunchdMonotonicClock = () => {};
+
 function useLaunchdFakeTimers() {
   setPlatform("darwin");
   process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-  vi.useFakeTimers();
+  vi.useFakeTimers({
+    toFake: [
+      "setTimeout",
+      "clearTimeout",
+      "setInterval",
+      "clearInterval",
+      "setImmediate",
+      "clearImmediate",
+      "Date",
+    ],
+  });
+  const monotonicClock = vi.spyOn(performance, "now").mockImplementation(() => Date.now());
+  restoreLaunchdMonotonicClock = () => monotonicClock.mockRestore();
 }
 
 function createRuntimeWithExitSignal(exitCallOrder?: string[]) {
@@ -441,6 +464,13 @@ function expectRestartCloseCall(
   const closeArgs = close.mock.calls[0]?.[0];
   expect(closeArgs?.drainTimeoutMs).toBeLessThanOrEqual(maxDrainTimeoutMs);
   expect(closeArgs?.drainTimeoutMs).toBeGreaterThanOrEqual(0);
+}
+
+function expectActiveWorkDrainTimeout(maxTimeoutMs: number) {
+  const [timeoutMs, options] = waitForGatewayActiveWork.mock.calls[0] ?? [];
+  expect(timeoutMs).toBeGreaterThanOrEqual(maxTimeoutMs - 1_000);
+  expect(timeoutMs).toBeLessThanOrEqual(maxTimeoutMs);
+  expect(options?.onSnapshot).toEqual(expect.any(Function));
 }
 
 function createSignaledStart(close: GatewayCloseFn, startupSettled = Promise.resolve()) {
@@ -609,6 +639,8 @@ beforeEach(async () => {
   hasManagedProviderLocalServices.mockReturnValue(false);
   stopManagedProviderLocalServices.mockReset();
   stopManagedProviderLocalServices.mockResolvedValue(undefined);
+  readLoadedLaunchAgentExitTimeoutSecondsSync.mockReset();
+  readLoadedLaunchAgentExitTimeoutSecondsSync.mockReturnValue(20);
 
   gatewayWorkAdmissionActual = await vi.importActual("../../process/gateway-work-admission.js");
   gatewayWorkAdmissionActual.resetGatewayWorkAdmission();
@@ -633,6 +665,8 @@ beforeEach(async () => {
 afterEach(() => {
   supervisorEnvSnapshot?.restore();
   supervisorEnvSnapshot = undefined;
+  restoreLaunchdMonotonicClock();
+  restoreLaunchdMonotonicClock = () => {};
   vi.useRealTimers();
   if (originalPlatformDescriptor) {
     Object.defineProperty(process, "platform", originalPlatformDescriptor);
@@ -716,9 +750,7 @@ describe("runGatewayLoop", () => {
           expect(hostedStopExecute).not.toHaveBeenCalled();
           finishJoin();
           await expect(exited).resolves.toBe(0);
-          expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, {
-            onSnapshot: expect.any(Function),
-          });
+          expectActiveWorkDrainTimeout(315_000);
           expect(hostedStopExecute).toHaveBeenCalledTimes(mode === "native" ? 1 : 0);
           await expect(host!.request("start", () => {})).resolves.toMatchObject({ ok: false });
         } finally {
@@ -1423,9 +1455,7 @@ describe("runGatewayLoop", () => {
       captureSignal("SIGTERM")();
 
       await expect(exited).resolves.toBe(0);
-      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, {
-        onSnapshot: expect.any(Function),
-      });
+      expectActiveWorkDrainTimeout(315_000);
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "gateway active-work drain timeout reached; proceeding with shutdown: embeddedRuns=2",
       );
@@ -1447,9 +1477,7 @@ describe("runGatewayLoop", () => {
       captureSignal("SIGTERM")();
 
       await expect(exited).resolves.toBe(0);
-      expect(waitForGatewayActiveWork).toHaveBeenCalledWith(315_000, {
-        onSnapshot: expect.any(Function),
-      });
+      expectActiveWorkDrainTimeout(315_000);
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "gateway active-work drain failed; proceeding with shutdown: active-work drain unavailable",
       );
@@ -1498,6 +1526,249 @@ describe("runGatewayLoop", () => {
       }
     });
   });
+
+  it("applies a late launchd deadline to an active stop", async () => {
+    vi.clearAllMocks();
+    waitForGatewayActiveWork.mockImplementation(() => new Promise(() => {}));
+    useLaunchdFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { runtime, exited } = await createOwnedLoop();
+
+        captureSignal("SIGINT")();
+        await vi.advanceTimersByTimeAsync(10_000);
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(waitForGatewayActiveWork.mock.calls[1]?.[0]).toBe(5_000);
+        await vi.advanceTimersByTimeAsync(14_999);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        await expect(exited).resolves.toBe(1);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let a late launchd deadline extend an active stop", async () => {
+    vi.clearAllMocks();
+    readLoadedLaunchAgentExitTimeoutSecondsSync.mockReturnValue(600);
+    waitForGatewayActiveWork.mockImplementation(() => new Promise(() => {}));
+    useLaunchdFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { runtime, exited } = await createOwnedLoop();
+
+        captureSignal("SIGINT")();
+        await vi.advanceTimersByTimeAsync(10_000);
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(314_999);
+
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        await expect(exited).resolves.toBe(1);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a late launchd deadline armed through final log flush", async () => {
+    vi.clearAllMocks();
+    readLoadedLaunchAgentExitTimeoutSecondsSync.mockReturnValue(6);
+    let releaseFlush = () => {};
+    flushLogger.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFlush = resolve;
+        }),
+    );
+    useLaunchdFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { runtime, exited } = await createOwnedLoop();
+
+        captureSignal("SIGINT")();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(flushLogger).toHaveBeenCalledOnce();
+
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(999);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        await expect(exited).resolves.toBe(1);
+      });
+    } finally {
+      releaseFlush();
+      vi.useRealTimers();
+    }
+  });
+
+  it("re-reads the loaded launchd deadline for every SIGTERM", async () => {
+    vi.clearAllMocks();
+    readLoadedLaunchAgentExitTimeoutSecondsSync
+      .mockReturnValueOnce(600)
+      .mockReturnValueOnce(undefined);
+    waitForGatewayActiveWork.mockImplementation(() => new Promise(() => {}));
+    useLaunchdFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { runtime, exited } = await createOwnedLoop();
+        const sigterm = captureSignal("SIGTERM");
+
+        sigterm();
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(runtime.exit).not.toHaveBeenCalled();
+
+        sigterm();
+        await vi.advanceTimersByTimeAsync(0);
+        await expect(exited).resolves.toBe(1);
+        expect(readLoadedLaunchAgentExitTimeoutSecondsSync).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("arms the launchd deadline before classifying a SIGTERM restart intent", async () => {
+    vi.clearAllMocks();
+    readLoadedLaunchAgentExitTimeoutSecondsSync.mockReturnValue(undefined);
+    useLaunchdFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { exited } = await createOwnedLoop();
+
+        captureSignal("SIGTERM")();
+
+        expect(readLoadedLaunchAgentExitTimeoutSecondsSync).toHaveBeenCalledOnce();
+        expect(consumeGatewayRestartIntentPayloadSync).not.toHaveBeenCalled();
+        expect(armShutdownHardExitWatchdog).toHaveBeenCalledWith(
+          expect.objectContaining({ delayMs: 2_000 }),
+        );
+        await vi.advanceTimersByTimeAsync(0);
+        await expect(exited).resolves.toBe(0);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { loadedExitTimeoutSeconds: 10, shutdownTimeoutMs: 5_000, drainTimeoutMs: 0 },
+    { loadedExitTimeoutSeconds: 60, shutdownTimeoutMs: 55_000, drainTimeoutMs: 45_000 },
+    { loadedExitTimeoutSeconds: undefined, shutdownTimeoutMs: 0, drainTimeoutMs: 0 },
+  ])(
+    "uses loaded launchd ExitTimeOut $loadedExitTimeoutSeconds for shutdown",
+    async ({ loadedExitTimeoutSeconds, shutdownTimeoutMs, drainTimeoutMs }) => {
+      vi.clearAllMocks();
+      readLoadedLaunchAgentExitTimeoutSecondsSync.mockReturnValue(loadedExitTimeoutSeconds);
+      waitForGatewayActiveWork.mockImplementation(() => new Promise(() => {}));
+      useLaunchdFakeTimers();
+      try {
+        await withIsolatedSignals(async ({ captureSignal }) => {
+          const { runtime, exited } = await createOwnedLoop();
+
+          captureSignal("SIGTERM")();
+          await vi.advanceTimersByTimeAsync(0);
+
+          expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBe(drainTimeoutMs);
+          if (shutdownTimeoutMs > 0) {
+            await vi.advanceTimersByTimeAsync(shutdownTimeoutMs - 1);
+            expect(runtime.exit).not.toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(1);
+          }
+          await expect(exited).resolves.toBe(1);
+        });
+      } finally {
+        restoreLaunchdMonotonicClock();
+        restoreLaunchdMonotonicClock = () => {};
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("treats loaded launchd ExitTimeOut 0 as unbounded", async () => {
+    vi.clearAllMocks();
+    readLoadedLaunchAgentExitTimeoutSecondsSync.mockReturnValue(0);
+    const releaseDrain = blockActiveWorkDrain();
+    useLaunchdFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { runtime, exited } = await createOwnedLoop();
+
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(60_000);
+
+        expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBe(315_000);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        releaseDrain();
+        await vi.advanceTimersByTimeAsync(0);
+        await expect(exited).resolves.toBe(0);
+      });
+    } finally {
+      releaseDrain();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps launchd deadlines beyond Node's maximum timer delay", async () => {
+    vi.clearAllMocks();
+    const exitTimeoutSeconds = 30 * 24 * 60 * 60;
+    const shutdownTimeoutMs = exitTimeoutSeconds * 1_000 - 5_000;
+    readLoadedLaunchAgentExitTimeoutSecondsSync.mockReturnValue(exitTimeoutSeconds);
+    waitForGatewayActiveWork.mockImplementation(() => new Promise(() => {}));
+    useLaunchdFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { runtime, exited } = await createOwnedLoop();
+
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(1);
+        expect(runtime.exit).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(shutdownTimeoutMs - 2);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        await expect(exited).resolves.toBe(1);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([60_000, -60_000])(
+    "keeps a launchd deadline through a %s ms wall-clock step",
+    async (clockStepMs) => {
+      vi.clearAllMocks();
+      readLoadedLaunchAgentExitTimeoutSecondsSync.mockReturnValue(10);
+      waitForGatewayActiveWork.mockImplementation(() => new Promise(() => {}));
+      useLaunchdFakeTimers();
+      restoreLaunchdMonotonicClock();
+      let elapsedMs = 0;
+      const monotonicClock = vi.spyOn(performance, "now").mockImplementation(() => elapsedMs);
+      restoreLaunchdMonotonicClock = () => monotonicClock.mockRestore();
+      try {
+        await withIsolatedSignals(async ({ captureSignal }) => {
+          const { runtime, exited } = await createOwnedLoop();
+
+          captureSignal("SIGTERM")();
+          await vi.advanceTimersByTimeAsync(0);
+          vi.setSystemTime(Date.now() + clockStepMs);
+          elapsedMs = 4_999;
+          await vi.advanceTimersByTimeAsync(4_999);
+          expect(runtime.exit).not.toHaveBeenCalled();
+          elapsedMs = 5_000;
+          await vi.advanceTimersByTimeAsync(1);
+          await expect(exited).resolves.toBe(1);
+        });
+      } finally {
+        restoreLaunchdMonotonicClock();
+        restoreLaunchdMonotonicClock = () => {};
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("bounds the file-log flush before a graceful SIGTERM exit", async () => {
     vi.clearAllMocks();
@@ -1590,6 +1861,7 @@ describe("runGatewayLoop", () => {
 
   it.each([
     { blockedStage: "handoff parking", signalOrder: "sigusr1-first" },
+    { blockedStage: "handoff parking", signalOrder: "sigterm-first" },
     { blockedStage: "handoff cancellation", signalOrder: "sigterm-first" },
     { blockedStage: "final handoff", signalOrder: "sigterm-first" },
     { blockedStage: "final handoff", signalOrder: "sigusr1-first" },
@@ -1722,6 +1994,47 @@ describe("runGatewayLoop", () => {
     },
   );
 
+  it("waits until a tightened launchd drain deadline", async () => {
+    vi.clearAllMocks();
+    const snapshot = createActiveWorkSnapshot({ activeTasks: 1 }, [
+      { kind: "task", count: 1, message: "1 active background task run(s)" },
+    ]);
+    createGatewayActiveWorkSnapshot.mockReturnValue(snapshot);
+    waitForGatewayActiveWork
+      .mockImplementationOnce((_timeoutMs, options) => {
+        options?.onSnapshot?.(snapshot);
+        return new Promise(() => {});
+      })
+      .mockImplementationOnce((timeoutMs, options) => {
+        options?.onSnapshot?.(snapshot);
+        return new Promise((resolve) => {
+          setTimeout(() => resolve({ drained: false, snapshot }), timeoutMs);
+        });
+      });
+    peekGatewaySigusr1RestartReason.mockReturnValue("config.patch");
+    const close = createCloseMock();
+    useLaunchdFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        await createOwnedLoop(close);
+
+        captureSignal("SIGUSR1")();
+        await vi.advanceTimersByTimeAsync(10_000);
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(waitForGatewayActiveWork.mock.calls[1]?.[0]).toBe(5_000);
+        expect(close).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(4_999);
+        expect(close).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        expectRestartCloseCall(close, 0);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("lets launchd SIGTERM override an ordinary restart queued during startup", async () => {
     vi.clearAllMocks();
     peekGatewaySigusr1RestartReason.mockReturnValue("config.patch");
@@ -1738,6 +2051,59 @@ describe("runGatewayLoop", () => {
         expect(runtime.exit).toHaveBeenCalledWith(0);
         expect(gatewayLog.info).toHaveBeenCalledWith(
           "received SIGTERM; overriding pending startup restart with shutdown",
+        );
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let a launchd startup override extend the queued restart deadline", async () => {
+    vi.clearAllMocks();
+    readLoadedLaunchAgentExitTimeoutSecondsSync.mockReturnValue(600);
+    peekGatewaySigusr1RestartReason.mockReturnValue("config.patch");
+    waitForGatewayActiveWork.mockImplementation(() => new Promise(() => {}));
+    useLaunchdFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { runtime, exited } = await createBlockedStartupLoop();
+
+        captureSignal("SIGUSR1")();
+        await vi.advanceTimersByTimeAsync(10_000);
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(314_999);
+
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        await expect(exited).resolves.toBe(1);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds a launchd stop that overrides a queued startup restart", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({}).mockReturnValueOnce(null);
+    waitForGatewayActiveWork.mockImplementationOnce(() => new Promise(() => {}));
+    useLaunchdFakeTimers();
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { runtime, exited } = await createBlockedStartupLoop();
+        const sigterm = captureSignal("SIGTERM");
+
+        sigterm();
+        await vi.advanceTimersByTimeAsync(10_000);
+        sigterm();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBe(0);
+        await vi.advanceTimersByTimeAsync(4_999);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+        await expect(exited).resolves.toBe(1);
+        expect(gatewayLog.error).toHaveBeenCalledWith(
+          "shutdown timed out; exiting without full cleanup",
         );
       });
     } finally {

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1657,6 +1657,137 @@ describe("runGatewayLoop", () => {
     }
   });
 
+  it("keeps a late launchd deadline after an ordinary restart gains a managed owner", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce({
+        reason: "update.auto",
+      });
+    consumeGatewaySigusr1RestartIntent.mockReturnValueOnce(null).mockReturnValueOnce({
+      reason: "update.auto",
+      successorOwner: managedUpdateSuccessorOwner,
+    });
+    peekGatewaySigusr1RestartReason
+      .mockReturnValueOnce("config.patch")
+      .mockReturnValueOnce("update.auto");
+    const releaseDrain = blockActiveWorkDrain();
+    let releaseClose: () => void = () => {};
+    const close = vi.fn<GatewayCloseFn>(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseClose = resolve;
+        }),
+    );
+    setPlatform("darwin");
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    vi.useFakeTimers();
+
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { runtime } = await createOwnedLoop(close);
+        const sigusr1 = captureSignal("SIGUSR1");
+
+        sigusr1();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBe(
+          DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS,
+        );
+        sigusr1();
+        await vi.advanceTimersByTimeAsync(0);
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledExactlyOnceWith(
+          managedUpdateSuccessorOwner,
+        );
+        expectRestartCloseCall(close, 5_000);
+
+        await vi.advanceTimersByTimeAsync(14_999);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+
+        expect(runtime.exit).toHaveBeenCalledWith(1);
+      });
+    } finally {
+      releaseDrain();
+      releaseClose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a stricter active-work cutoff when launchd SIGTERM arrives", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ waitMs: 2_500 });
+    peekGatewaySigusr1RestartReason.mockReturnValueOnce("config.patch");
+    const releaseDrain = blockActiveWorkDrain();
+    const close = createCloseMock();
+    setPlatform("darwin");
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    vi.useFakeTimers();
+
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        await createOwnedLoop(close);
+
+        captureSignal("SIGUSR1")();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBe(2_500);
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(close).not.toHaveBeenCalled();
+
+        releaseDrain();
+        await vi.advanceTimersByTimeAsync(0);
+        expectRestartCloseCall(close, 2_500);
+      });
+    } finally {
+      releaseDrain();
+      vi.useRealTimers();
+    }
+  });
+
+  it("lets launchd SIGTERM override an ordinary restart queued during startup", async () => {
+    vi.clearAllMocks();
+    peekGatewaySigusr1RestartReason.mockReturnValue("config.patch");
+    setPlatform("darwin");
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    vi.useFakeTimers();
+
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        let markStartupEntered: () => void = () => {};
+        const startupEntered = new Promise<void>((resolve) => {
+          markStartupEntered = resolve;
+        });
+        const start = vi.fn(async () => {
+          markStartupEntered();
+          await new Promise<void>(() => {});
+          return createGatewayServer(createCloseMock());
+        });
+        const { runtime } = createRuntimeWithExitSignal();
+        const { runGatewayLoop } = await import("./run-loop.js");
+        void runGatewayLoop({
+          start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+          runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+        });
+        await startupEntered;
+
+        captureSignal("SIGUSR1")();
+        await vi.advanceTimersByTimeAsync(0);
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(runtime.exit).toHaveBeenCalledWith(0);
+        expect(gatewayLog.info).toHaveBeenCalledWith(
+          "received SIGTERM; overriding pending startup restart with shutdown",
+        );
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it.each(["sigterm-first", "sigusr1-first"] as const)(
     "bounds failed final handoff recovery when %s",
     async (signalOrder) => {
@@ -3277,6 +3408,65 @@ describe("runGatewayLoop", () => {
     } finally {
       releaseLock();
       delete process.env.OPENCLAW_SUPERVISOR_MODE;
+    }
+  });
+
+  it("cancels a managed upgrade that arrives while reacquiring the gateway lock", async () => {
+    vi.clearAllMocks();
+    consumeGatewaySigusr1RestartIntent.mockReturnValueOnce(null).mockReturnValueOnce({
+      reason: "update.auto",
+      successorOwner: managedUpdateSuccessorOwner,
+    });
+    peekGatewaySigusr1RestartReason
+      .mockReturnValueOnce("config.patch")
+      .mockReturnValueOnce("update.auto");
+
+    let releaseReacquire: () => void = () => {};
+    const reacquireBlocked = new Promise<void>((resolve) => {
+      releaseReacquire = resolve;
+    });
+    const staleLockRelease = vi.fn(async () => {});
+    acquireGatewayLock
+      .mockResolvedValueOnce({ release: vi.fn(async () => {}) })
+      .mockImplementationOnce(async () => {
+        await reacquireBlocked;
+        return { release: staleLockRelease };
+      })
+      .mockResolvedValueOnce({ release: vi.fn(async () => {}) });
+
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const { start, runtime, exited } = await createSignaledLoopHarness();
+        const sigusr1 = captureSignal("SIGUSR1");
+
+        sigusr1();
+        await waitForLoopCondition(
+          () => acquireGatewayLock.mock.calls.length === 2,
+          "ordinary restart did not reach lock reacquisition",
+        );
+        sigusr1();
+        await waitForLoopCondition(
+          () => consumeGatewaySigusr1RestartIntent.mock.calls.length === 2,
+          "managed upgrade was not admitted during lock reacquisition",
+        );
+        releaseReacquire();
+        await waitForLoopCondition(
+          () => start.mock.calls.length === 2,
+          "managed upgrade did not resume in process",
+        );
+
+        expect(staleLockRelease).toHaveBeenCalledOnce();
+        expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledExactlyOnceWith(
+          managedUpdateSuccessorOwner,
+        );
+        expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
+        expect(runtime.exit).not.toHaveBeenCalled();
+
+        captureSignal("SIGINT")();
+        await expect(exited).resolves.toBe(0);
+      });
+    } finally {
+      releaseReacquire();
     }
   });
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -367,6 +367,27 @@ async function withIsolatedSignals(
   }
 }
 
+async function withManagedLaunchdUpdateRestart(
+  run: Parameters<typeof withIsolatedSignals>[0],
+  signalOrder: "sigterm-first" | "sigusr1-first" = "sigterm-first",
+) {
+  consumeGatewayRestartIntentPayloadSync
+    .mockReturnValueOnce({})
+    .mockReturnValueOnce(signalOrder === "sigterm-first" ? { reason: "update.auto" } : null);
+  consumeGatewaySigusr1RestartIntent.mockReturnValueOnce({
+    reason: "update.auto",
+    successorOwner: managedUpdateSuccessorOwner,
+  });
+  setPlatform("darwin");
+  process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+  vi.useFakeTimers();
+  try {
+    await withIsolatedSignals(run);
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 function createRuntimeWithExitSignal(exitCallOrder?: string[]) {
   let resolveExit: (code: number) => void = () => {};
   const exited = new Promise<number>((resolve) => {
@@ -482,6 +503,30 @@ async function createSignaledLoopHarness(exitCallOrder?: string[], ownsProcessLi
   const { loopPromise } = await runLoopWithStart({ start, runtime, ownsProcessLifecycle });
   await waitForStart(started);
   return { close, start, runtime, exited, loopPromise };
+}
+
+async function createOwnedLoop(close: GatewayCloseFn = createCloseMock()) {
+  const { start, started } = createSignaledStart(close);
+  const lifecycle = createRuntimeWithExitSignal();
+  await runLoopWithStart({ start, runtime: lifecycle.runtime, ownsProcessLifecycle: true });
+  await vi.advanceTimersByTimeAsync(0);
+  await started;
+  return { start, ...lifecycle };
+}
+
+function blockActiveWorkDrain() {
+  const snapshot = createActiveWorkSnapshot({ activeTasks: 1 }, [
+    { kind: "task", count: 1, message: "1 active background task run(s)" },
+  ]);
+  createGatewayActiveWorkSnapshot.mockReturnValue(snapshot);
+  let release = () => {};
+  waitForGatewayActiveWork.mockImplementationOnce((_timeoutMs, options) =>
+    new Promise<void>((resolve) => {
+      release = resolve;
+      options?.onSnapshot?.(snapshot);
+    }).then(() => ({ drained: true, snapshot: idleActiveWorkSnapshot })),
+  );
+  return () => release();
 }
 
 function expectRestartHandoffCall(expected: {
@@ -1523,6 +1568,126 @@ describe("runGatewayLoop", () => {
     });
   });
 
+  it("keeps launchd SIGTERM restart inside the original ExitTimeOut deadline", async () => {
+    vi.clearAllMocks();
+    const close = vi.fn<GatewayCloseFn>(() => new Promise<void>(() => {}));
+
+    await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
+      const { runtime, exited } = await createOwnedLoop(close);
+
+      captureSignal("SIGTERM")();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(5_000);
+      expectRestartCloseCall(close, 5_000);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      captureSignal("SIGUSR1")();
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(runtime.exit).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+
+      await expect(exited).resolves.toBe(1);
+      expect(gatewayLog.info).toHaveBeenCalledWith(
+        "received SIGUSR1 during shutdown; upgrading to update.auto",
+      );
+    });
+  });
+
+  it("retains the launchd deadline when managed handoff cancellation stalls", async () => {
+    vi.clearAllMocks();
+    requestManagedServiceUpdateHandoffPark.mockResolvedValueOnce(false);
+    cancelManagedServiceUpdateHandoff.mockImplementationOnce(() => new Promise(() => {}));
+    const releaseDrain = blockActiveWorkDrain();
+
+    try {
+      await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
+        const { runtime } = await createOwnedLoop();
+
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(10_000);
+        captureSignal("SIGUSR1")();
+        await vi.advanceTimersByTimeAsync(0);
+        releaseDrain();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledExactlyOnceWith(
+          managedUpdateSuccessorOwner,
+        );
+        expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledExactlyOnceWith(
+          managedUpdateSuccessorOwner,
+        );
+        await vi.advanceTimersByTimeAsync(4_999);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+
+        expect(runtime.exit).toHaveBeenCalledWith(1);
+        expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledTimes(1);
+        expect(gatewayLog.error).toHaveBeenCalledWith(
+          "launchd shutdown deadline reached with managed update handoff ownership; exiting for supervisor recovery",
+        );
+      });
+    } finally {
+      releaseDrain();
+    }
+  });
+
+  it("bounds a managed restart when launchd SIGTERM follows SIGUSR1", async () => {
+    vi.clearAllMocks();
+    let releasePark: () => void = () => {};
+    requestManagedServiceUpdateHandoffPark.mockImplementationOnce(() =>
+      new Promise<void>((resolve) => {
+        releasePark = resolve;
+      }).then(() => true),
+    );
+
+    try {
+      await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
+        const { runtime } = await createOwnedLoop();
+
+        captureSignal("SIGUSR1")();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(requestManagedServiceUpdateHandoffPark).toHaveBeenCalledOnce();
+        captureSignal("SIGTERM")();
+        await vi.advanceTimersByTimeAsync(15_000);
+
+        expect(runtime.exit).toHaveBeenCalledWith(1);
+      }, "sigusr1-first");
+    } finally {
+      releasePark();
+    }
+  });
+
+  it.each(["sigterm-first", "sigusr1-first"] as const)(
+    "bounds failed final handoff recovery when %s",
+    async (signalOrder) => {
+      vi.clearAllMocks();
+      commitManagedServiceUpdateHandoff.mockResolvedValueOnce(false);
+      cancelManagedServiceUpdateHandoff.mockResolvedValueOnce(false);
+      const releaseDrain = blockActiveWorkDrain();
+
+      await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
+        const { runtime } = await createOwnedLoop();
+
+        if (signalOrder === "sigterm-first") {
+          captureSignal("SIGTERM")();
+          await vi.advanceTimersByTimeAsync(10_000);
+        }
+        captureSignal("SIGUSR1")();
+        await vi.advanceTimersByTimeAsync(0);
+        releaseDrain();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(commitManagedServiceUpdateHandoff).toHaveBeenCalledOnce();
+        expect(cancelManagedServiceUpdateHandoff).toHaveBeenCalledOnce();
+        if (signalOrder === "sigusr1-first") {
+          captureSignal("SIGTERM")();
+        }
+        await vi.advanceTimersByTimeAsync(signalOrder === "sigterm-first" ? 5_000 : 15_000);
+
+        expect(runtime.exit).toHaveBeenCalledWith(1);
+      }, signalOrder);
+    },
+  );
+
   it("uses restart intent wait overrides for SIGTERM drain", async () => {
     vi.clearAllMocks();
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ waitMs: 2_500 });
@@ -2064,6 +2229,46 @@ describe("runGatewayLoop", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("exits at the queued launchd deadline when managed handoff cancellation would stall", async () => {
+    vi.clearAllMocks();
+    cancelManagedServiceUpdateHandoff.mockImplementationOnce(() => new Promise(() => {}));
+
+    await withManagedLaunchdUpdateRestart(async ({ captureSignal }) => {
+      let markStartupEntered: () => void = () => {};
+      const startupEntered = new Promise<void>((resolve) => {
+        markStartupEntered = resolve;
+      });
+      const { runtime, exited } = createRuntimeWithExitSignal();
+      const start = vi.fn(async () => {
+        markStartupEntered();
+        await new Promise<void>(() => {});
+        return createGatewayServer(vi.fn(async () => {}));
+      });
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      void runGatewayLoop({
+        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      await startupEntered;
+
+      captureSignal("SIGTERM")();
+      await vi.advanceTimersByTimeAsync(10_000);
+      captureSignal("SIGUSR1")();
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(runtime.exit).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+
+      await expect(exited).resolves.toBe(1);
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(cancelManagedServiceUpdateHandoff).not.toHaveBeenCalled();
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        "launchd shutdown deadline reached with managed update handoff ownership; exiting for supervisor recovery",
+      );
+    });
   });
 
   it("processes SIGINT immediately before startup returns a server", async () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -45,6 +45,7 @@ const LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS = 1500;
 const DEFAULT_RESTART_DRAIN_TIMEOUT_MS = 300_000;
 const RESTART_DRAIN_STILL_PENDING_WARN_MS = 30_000;
 const RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS = 10_000;
+const LAUNCHD_SHUTDOWN_RESERVE_MS = 5_000;
 const UPDATE_RESPAWN_HEALTH_TIMEOUT_MS = 10_000;
 const UPDATE_RESPAWN_HEALTH_POLL_MS = 200;
 const LOG_FLUSH_EXIT_TIMEOUT_MS = 4_000;
@@ -54,6 +55,7 @@ type GatewayRunSignalAction = "stop" | "restart";
 type GatewayRunSignalRequest = {
   action: GatewayRunSignalAction;
   signal: string;
+  launchdShutdownDeadlineAt?: number;
   restartReason?: string;
   restartIntent?: GatewayRestartIntent;
   hostedStop?: ReturnType<typeof createGatewayHostLifecycle>;
@@ -159,6 +161,7 @@ export async function runGatewayLoop(params: {
   let pendingStartupForceExitTimer: ReturnType<typeof setTimeout> | null = null;
   let restartDrainingMarked = false;
   let startupFailedWithoutServerHandle = false;
+  let exitRequested = false;
   const processInstanceId = randomUUID();
   const waitForHealthyChild = params.waitForHealthyChild ?? waitForHealthyGatewayChild;
   const getManagedUpdateOwner = () =>
@@ -177,6 +180,7 @@ export async function runGatewayLoop(params: {
     process.removeListener("SIGUSR1", onSigusr1);
   };
   const exitProcess = (code: number) => {
+    exitRequested = true;
     void hostLifecycle?.retire();
     cleanupSignals();
     params.runtime.exit(code);
@@ -318,22 +322,30 @@ export async function runGatewayLoop(params: {
       return false;
     }
   };
-  const forceExitAfterStabilityBundle = async (reason: string) => {
+  const forceExitAfterStabilityBundle = async (
+    reason: string,
+    options: { exitOnActiveManagedCancellation?: boolean } = {},
+  ) => {
     void hostLifecycle?.retire();
     try {
       writeStabilityBundle(reason);
     } finally {
       const owner = getManagedUpdateOwner();
-      if (owner) {
-        forceActiveRestartExit?.();
-      }
-      const restoration = await cancelManagedUpdateHandoffBeforeRecovery(owner);
-      if (restoration) {
+      if (owner && options.exitOnActiveManagedCancellation) {
+        gatewayLog.error(
+          "launchd shutdown deadline reached with managed update handoff ownership; exiting for supervisor recovery",
+        );
         params.completeBoot?.({ outcome: "forced_stop", reason });
-        if (restoration === "restart-after-exit") {
-          await exitProcessAfterLogFlush(1, owner, "restore");
-        } else {
-          exitProcess(1);
+        exitProcess(1);
+      } else {
+        const restoration = await cancelManagedUpdateHandoffBeforeRecovery(owner);
+        if (restoration) {
+          params.completeBoot?.({ outcome: "forced_stop", reason });
+          if (restoration === "restart-after-exit") {
+            await exitProcessAfterLogFlush(1, owner, "restore");
+          } else {
+            exitProcess(1);
+          }
         }
       }
     }
@@ -516,7 +528,11 @@ export async function runGatewayLoop(params: {
     clearTimeout(pendingStartupForceExitTimer ?? undefined);
     pendingStartupForceExitTimer = null;
   };
-  const armPendingStartupForceExitTimer = () => {
+  const resolveRequestShutdownTimeoutMs = (request: GatewayRunSignalRequest) =>
+    request.launchdShutdownDeadlineAt === undefined
+      ? SHUTDOWN_TIMEOUT_MS
+      : Math.max(0, request.launchdShutdownDeadlineAt - Date.now());
+  const armPendingStartupForceExitTimer = (request: GatewayRunSignalRequest) => {
     if (pendingStartupForceExitTimer) {
       return;
     }
@@ -525,8 +541,10 @@ export async function runGatewayLoop(params: {
       gatewayLog.error(
         "startup restart request timed out before gateway returned a close handle; exiting for supervisor recovery",
       );
-      void forceExitAfterStabilityBundle("gateway.restart_startup_request_timeout");
-    }, SHUTDOWN_TIMEOUT_MS);
+      void forceExitAfterStabilityBundle("gateway.restart_startup_request_timeout", {
+        exitOnActiveManagedCancellation: request.launchdShutdownDeadlineAt !== undefined,
+      });
+    }, resolveRequestShutdownTimeoutMs(request));
     pendingStartupForceExitTimer.unref?.();
   };
   const resolveRestartDrainTimeoutMs = (
@@ -610,6 +628,8 @@ export async function runGatewayLoop(params: {
   const runAcceptedRequest = (acceptedRequest: GatewayRunSignalRequest) => {
     const { action, restartIntent } = acceptedRequest;
     const isRestart = action === "restart";
+    const isLaunchdSigtermRestart = acceptedRequest.launchdShutdownDeadlineAt !== undefined;
+    const resolveRestartShutdownTimeoutMs = () => resolveRequestShutdownTimeoutMs(acceptedRequest);
     if (isRestart) {
       activeRestartRequest = acceptedRequest;
     } else {
@@ -625,6 +645,10 @@ export async function runGatewayLoop(params: {
         gatewayLog.error("shutdown timed out; exiting without full cleanup");
         void forceExitAfterStabilityBundle(
           isRestart ? "gateway.restart_shutdown_timeout" : "gateway.stop_shutdown_timeout",
+          {
+            exitOnActiveManagedCancellation:
+              acceptedRequest.launchdShutdownDeadlineAt !== undefined,
+          },
         );
       }, forceExitMs);
       if (params.ownsProcessLifecycle === true) {
@@ -647,8 +671,8 @@ export async function runGatewayLoop(params: {
     if (isRestart) {
       forceActiveRestartExit = () => {
         clearForceExitTimer();
-        if (!getManagedUpdateOwner()) {
-          armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
+        if (acceptedRequest.launchdShutdownDeadlineAt !== undefined || !getManagedUpdateOwner()) {
+          armForceExitTimer(resolveRestartShutdownTimeoutMs());
         }
       };
     }
@@ -661,7 +685,16 @@ export async function runGatewayLoop(params: {
         | "restart-after-exit"
         | undefined;
       let shutdownFailed = false;
-      const restartDrainTimeoutMs = isRestart ? resolveRestartDrainTimeoutMs(restartIntent) : 0;
+      const requestedRestartDrainTimeoutMs = isRestart
+        ? resolveRestartDrainTimeoutMs(restartIntent)
+        : 0;
+      const restartShutdownTimeoutMs = resolveRestartShutdownTimeoutMs();
+      const restartDrainTimeoutMs = isLaunchdSigtermRestart
+        ? Math.min(
+            requestedRestartDrainTimeoutMs ?? restartShutdownTimeoutMs,
+            Math.max(0, restartShutdownTimeoutMs - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS),
+          )
+        : requestedRestartDrainTimeoutMs;
       const restartDrainDeadlineAt =
         isRestart && restartDrainTimeoutMs !== undefined
           ? Date.now() + restartDrainTimeoutMs
@@ -669,6 +702,8 @@ export async function runGatewayLoop(params: {
       // Managed helpers must reach native parking before either exit watchdog can arm.
       if (!isRestart) {
         armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
+      } else if (isLaunchdSigtermRestart && !getManagedUpdateOwner()) {
+        armForceExitTimer(restartShutdownTimeoutMs);
       } else if (restartDrainTimeoutMs !== undefined && !getManagedUpdateOwner()) {
         // Allow extra time for draining active turns on explicitly capped restarts.
         armForceExitTimer(restartDrainTimeoutMs + SHUTDOWN_TIMEOUT_MS);
@@ -798,7 +833,6 @@ export async function runGatewayLoop(params: {
               throw new Error("managed update helper lost exact ownership during service parking");
             }
           } catch (err) {
-            clearForceExitTimer();
             gatewayLog.error(
               `managed update handoff could not park ${supervisorMode}: ${String(err)}`,
             );
@@ -820,7 +854,7 @@ export async function runGatewayLoop(params: {
           !forceExitTimer &&
           (!managedUpdateOwner || managedUpdateCancellation === "restored-in-process")
         ) {
-          armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
+          armForceExitTimer(resolveRestartShutdownTimeoutMs());
         }
         const closeDrainTimeoutMs = !isRestart
           ? null
@@ -853,8 +887,16 @@ export async function runGatewayLoop(params: {
               );
             }
           } finally {
-            clearForceExitTimer();
-            forceActiveRestartExit = null;
+            if (
+              acceptedRequest.launchdShutdownDeadlineAt === undefined ||
+              !shuttingDown ||
+              exitRequested
+            ) {
+              clearForceExitTimer();
+            }
+            if (!shuttingDown || exitRequested) {
+              forceActiveRestartExit = null;
+            }
           }
         } else if (acceptedRequest.hostedStop) {
           try {
@@ -894,10 +936,37 @@ export async function runGatewayLoop(params: {
     restartReason?: string,
     restartIntent?: GatewayRestartIntent,
     hostedStop?: ReturnType<typeof createGatewayHostLifecycle>,
+    receivedAt = Date.now(),
   ) => {
-    const acceptedRequest = { action, signal, restartReason, restartIntent, hostedStop };
+    const launchdSignalDeadlineAt =
+      signal === "SIGTERM" && supervisorMode === "launchd"
+        ? receivedAt +
+          eagerLifecycleRuntime.LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000 -
+          LAUNCHD_SHUTDOWN_RESERVE_MS
+        : undefined;
+    const launchdShutdownDeadlineAt = action === "restart" ? launchdSignalDeadlineAt : undefined;
+    const acceptedRequest = {
+      action,
+      signal,
+      launchdShutdownDeadlineAt,
+      restartReason,
+      restartIntent,
+      hostedStop,
+    };
     if (shuttingDown) {
       const currentRestartRequest = pendingStartupRequest ?? activeRestartRequest;
+      if (launchdSignalDeadlineAt !== undefined && currentRestartRequest?.action === "restart") {
+        currentRestartRequest.launchdShutdownDeadlineAt = Math.min(
+          currentRestartRequest.launchdShutdownDeadlineAt ?? Number.POSITIVE_INFINITY,
+          launchdSignalDeadlineAt,
+        );
+        if (pendingStartupRequest) {
+          clearPendingStartupForceExitTimer();
+          armPendingStartupForceExitTimer(currentRestartRequest);
+        } else {
+          forceActiveRestartExit?.();
+        }
+      }
       if (
         action === "restart" &&
         isUpdateProcessRestartReason(restartReason) &&
@@ -927,6 +996,10 @@ export async function runGatewayLoop(params: {
           forceActiveRestartExit?.();
         }
         gatewayLog.info(`received ${signal} during shutdown; upgrading to ${restartReason}`);
+        return;
+      }
+      if (launchdSignalDeadlineAt !== undefined && currentRestartRequest?.action === "restart") {
+        gatewayLog.info(`received ${signal} during shutdown; enforcing launchd deadline`);
         return;
       }
       if (action === "stop" && pendingStartupRequest && !server) {
@@ -968,13 +1041,14 @@ export async function runGatewayLoop(params: {
     }
     if (!server || !restartResolver) {
       pendingStartupRequest = acceptedRequest;
-      armPendingStartupForceExitTimer();
+      armPendingStartupForceExitTimer(acceptedRequest);
       return;
     }
     runAcceptedRequest(acceptedRequest);
   };
 
   const onSigterm = () => {
+    const receivedAt = Date.now();
     // Debug-level: every accepted signal is announced by request()'s
     // "received <signal>; ..." line, so an info pre-log would double up.
     gatewayLog.debug("signal SIGTERM received");
@@ -992,10 +1066,12 @@ export async function runGatewayLoop(params: {
         "SIGTERM",
         restartIntent?.reason,
         restartIntent ?? undefined,
+        undefined,
+        receivedAt,
       );
     })().catch((err: unknown) => {
       gatewayLog.error(`failed to handle SIGTERM: ${String(err)}`);
-      request("stop", "SIGTERM");
+      request("stop", "SIGTERM", undefined, undefined, undefined, receivedAt);
     });
   };
   const onSigint = () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -50,6 +50,36 @@ const UPDATE_RESPAWN_HEALTH_TIMEOUT_MS = 10_000;
 const UPDATE_RESPAWN_HEALTH_POLL_MS = 200;
 const LOG_FLUSH_EXIT_TIMEOUT_MS = 4_000;
 const HARD_EXIT_WATCHDOG_GRACE_MS = 2_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+function scheduleDeadlineTimer(params: {
+  deadlineAt: number;
+  onTimer: (timer: ReturnType<typeof setTimeout>) => void;
+  onDeadline: () => void;
+  unref?: boolean;
+}) {
+  const arm = (remainingCapMs = Number.POSITIVE_INFINITY) => {
+    const remainingMs = Math.min(
+      remainingCapMs,
+      Math.max(0, Math.ceil(params.deadlineAt - performance.now())),
+    );
+    const delayMs = Math.min(MAX_TIMER_DELAY_MS, remainingMs);
+    const timer = setTimeout(() => {
+      if (remainingMs > MAX_TIMER_DELAY_MS) {
+        // The absolute monotonic deadline accounts for a late callback; the cap
+        // also prevents a broken clock source from extending the original budget.
+        arm(remainingMs - delayMs);
+        return;
+      }
+      params.onDeadline();
+    }, delayMs);
+    params.onTimer(timer);
+    if (params.unref) {
+      timer.unref?.();
+    }
+  };
+  arm();
+}
 
 type GatewayRunSignalAction = "stop" | "restart";
 type GatewayRunSignalRequest = {
@@ -58,6 +88,7 @@ type GatewayRunSignalRequest = {
   restartDeadline: {
     launchdShutdownDeadlineAt?: number;
     activeWorkDrainDeadlineAt?: number;
+    forceExitDeadlineAt?: number;
     interruptActiveWorkDrain?: () => void;
   };
   restartReason?: string;
@@ -160,9 +191,17 @@ export async function runGatewayLoop(params: {
   // Defer lifecycle signals from that window until the loop can close and advance.
   let pendingStartupRequest: GatewayRunSignalRequest | null = null;
   let activeRestartRequest: GatewayRunSignalRequest | null = null;
+  let activeStopRequest: GatewayRunSignalRequest | null = null;
   let committedGenericSuccessor: ChildProcess | true | null = null;
   let forceActiveRestartExit: (() => void) | null = null;
+  let forceActiveStopExit: (() => void) | null = null;
   let pendingStartupForceExitTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingStartupForceExitDeadlineAt: number | undefined;
+  let pendingSigtermDeadlineGuard: {
+    deadlineAt: number;
+    timer: ReturnType<typeof setTimeout> | null;
+    hardExitWatchdog: ShutdownHardExitWatchdog | null;
+  } | null = null;
   let restartDrainingMarked = false;
   let startupFailedWithoutServerHandle = false;
   let exitRequested = false;
@@ -531,26 +570,48 @@ export async function runGatewayLoop(params: {
   const clearPendingStartupForceExitTimer = () => {
     clearTimeout(pendingStartupForceExitTimer ?? undefined);
     pendingStartupForceExitTimer = null;
+    pendingStartupForceExitDeadlineAt = undefined;
   };
   const resolveRequestShutdownTimeoutMs = (request: GatewayRunSignalRequest) =>
     request.restartDeadline.launchdShutdownDeadlineAt === undefined
       ? SHUTDOWN_TIMEOUT_MS
-      : Math.max(0, request.restartDeadline.launchdShutdownDeadlineAt - Date.now());
+      : Math.max(
+          0,
+          Math.ceil(request.restartDeadline.launchdShutdownDeadlineAt - performance.now()),
+        );
   const armPendingStartupForceExitTimer = (request: GatewayRunSignalRequest) => {
-    if (pendingStartupForceExitTimer) {
+    const requestedDeadlineAt = performance.now() + resolveRequestShutdownTimeoutMs(request);
+    const deadlineAt = Math.min(
+      request.restartDeadline.forceExitDeadlineAt ?? Number.POSITIVE_INFINITY,
+      requestedDeadlineAt,
+    );
+    if (
+      pendingStartupForceExitDeadlineAt !== undefined &&
+      pendingStartupForceExitDeadlineAt <= deadlineAt
+    ) {
       return;
     }
-    pendingStartupForceExitTimer = setTimeout(() => {
-      pendingStartupForceExitTimer = null;
-      gatewayLog.error(
-        "startup restart request timed out before gateway returned a close handle; exiting for supervisor recovery",
-      );
-      void forceExitAfterStabilityBundle("gateway.restart_startup_request_timeout", {
-        exitOnActiveManagedCancellation:
-          request.restartDeadline.launchdShutdownDeadlineAt !== undefined,
-      });
-    }, resolveRequestShutdownTimeoutMs(request));
-    pendingStartupForceExitTimer.unref?.();
+    clearPendingStartupForceExitTimer();
+    request.restartDeadline.forceExitDeadlineAt = deadlineAt;
+    pendingStartupForceExitDeadlineAt = deadlineAt;
+    scheduleDeadlineTimer({
+      deadlineAt,
+      onTimer: (timer) => {
+        pendingStartupForceExitTimer = timer;
+      },
+      onDeadline: () => {
+        pendingStartupForceExitTimer = null;
+        pendingStartupForceExitDeadlineAt = undefined;
+        gatewayLog.error(
+          "startup restart request timed out before gateway returned a close handle; exiting for supervisor recovery",
+        );
+        void forceExitAfterStabilityBundle("gateway.restart_startup_request_timeout", {
+          exitOnActiveManagedCancellation:
+            request.restartDeadline.launchdShutdownDeadlineAt !== undefined,
+        });
+      },
+      unref: true,
+    });
   };
   const resolveRestartDrainTimeoutMs = (
     restartIntent?: GatewayRestartIntent,
@@ -633,33 +694,57 @@ export async function runGatewayLoop(params: {
   const runAcceptedRequest = (acceptedRequest: GatewayRunSignalRequest) => {
     const { action, restartIntent } = acceptedRequest;
     const isRestart = action === "restart";
-    const isLaunchdSigtermRestart =
+    const hasLaunchdShutdownDeadline =
       acceptedRequest.restartDeadline.launchdShutdownDeadlineAt !== undefined;
-    const resolveRestartShutdownTimeoutMs = () => resolveRequestShutdownTimeoutMs(acceptedRequest);
+    const resolveShutdownTimeoutMs = () => resolveRequestShutdownTimeoutMs(acceptedRequest);
     if (isRestart) {
       activeRestartRequest = acceptedRequest;
     } else {
+      activeStopRequest = acceptedRequest;
       startGatewayRestartTrace("stop.signal.received", [["signal", acceptedRequest.signal]]);
     }
     let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
+    let armedForceExitDeadlineAt: number | undefined;
     let hardExitWatchdog: ShutdownHardExitWatchdog | null = null;
+    const clearForceExitTimer = () => {
+      clearTimeout(forceExitTimer ?? undefined);
+      forceExitTimer = null;
+      armedForceExitDeadlineAt = undefined;
+      hardExitWatchdog?.cancel();
+      hardExitWatchdog = null;
+    };
     const armForceExitTimer = (forceExitMs: number) => {
-      if (forceExitTimer) {
+      const requestedDeadlineAt = performance.now() + forceExitMs;
+      const deadlineAt = Math.min(
+        acceptedRequest.restartDeadline.forceExitDeadlineAt ?? Number.POSITIVE_INFINITY,
+        requestedDeadlineAt,
+      );
+      if (armedForceExitDeadlineAt !== undefined && armedForceExitDeadlineAt <= deadlineAt) {
         return;
       }
-      forceExitTimer = setTimeout(() => {
-        gatewayLog.error("shutdown timed out; exiting without full cleanup");
-        void forceExitAfterStabilityBundle(
-          isRestart ? "gateway.restart_shutdown_timeout" : "gateway.stop_shutdown_timeout",
-          {
-            exitOnActiveManagedCancellation:
-              acceptedRequest.restartDeadline.launchdShutdownDeadlineAt !== undefined,
-          },
-        );
-      }, forceExitMs);
+      acceptedRequest.restartDeadline.forceExitDeadlineAt = deadlineAt;
+      clearForceExitTimer();
+      armedForceExitDeadlineAt = deadlineAt;
+      const delayMs = Math.max(0, Math.ceil(deadlineAt - performance.now()));
+      scheduleDeadlineTimer({
+        deadlineAt,
+        onTimer: (timer) => {
+          forceExitTimer = timer;
+        },
+        onDeadline: () => {
+          gatewayLog.error("shutdown timed out; exiting without full cleanup");
+          void forceExitAfterStabilityBundle(
+            isRestart ? "gateway.restart_shutdown_timeout" : "gateway.stop_shutdown_timeout",
+            {
+              exitOnActiveManagedCancellation:
+                acceptedRequest.restartDeadline.launchdShutdownDeadlineAt !== undefined,
+            },
+          );
+        },
+      });
       if (params.ownsProcessLifecycle === true) {
         hardExitWatchdog = armShutdownHardExitWatchdog({
-          delayMs: forceExitMs + HARD_EXIT_WATCHDOG_GRACE_MS,
+          delayMs: delayMs + HARD_EXIT_WATCHDOG_GRACE_MS,
           onError: (error) => {
             gatewayLog.warn(
               `hard-exit watchdog failed; retaining main-thread shutdown timer: ${formatErrorMessage(error)}`,
@@ -668,21 +753,24 @@ export async function runGatewayLoop(params: {
         });
       }
     };
-    const clearForceExitTimer = () => {
-      clearTimeout(forceExitTimer ?? undefined);
-      forceExitTimer = null;
-      hardExitWatchdog?.cancel();
-      hardExitWatchdog = null;
+    const clearActiveStopRequest = () => {
+      if (!isRestart && activeStopRequest === acceptedRequest) {
+        activeStopRequest = null;
+        forceActiveStopExit = null;
+      }
     };
     if (isRestart) {
       forceActiveRestartExit = () => {
-        clearForceExitTimer();
         if (
           acceptedRequest.restartDeadline.launchdShutdownDeadlineAt !== undefined ||
           !getManagedUpdateOwner()
         ) {
-          armForceExitTimer(resolveRestartShutdownTimeoutMs());
+          armForceExitTimer(resolveShutdownTimeoutMs());
         }
+      };
+    } else {
+      forceActiveStopExit = () => {
+        armForceExitTimer(resolveShutdownTimeoutMs());
       };
     }
 
@@ -697,30 +785,30 @@ export async function runGatewayLoop(params: {
       const requestedRestartDrainTimeoutMs = isRestart
         ? resolveRestartDrainTimeoutMs(restartIntent)
         : 0;
-      const restartShutdownTimeoutMs = resolveRestartShutdownTimeoutMs();
-      const restartDrainTimeoutMs = isLaunchdSigtermRestart
-        ? Math.min(
-            requestedRestartDrainTimeoutMs ?? restartShutdownTimeoutMs,
-            Math.max(0, restartShutdownTimeoutMs - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS),
-          )
-        : requestedRestartDrainTimeoutMs;
+      const shutdownTimeoutMs = resolveShutdownTimeoutMs();
+      const restartDrainTimeoutMs =
+        isRestart && hasLaunchdShutdownDeadline
+          ? Math.min(
+              requestedRestartDrainTimeoutMs ?? shutdownTimeoutMs,
+              Math.max(0, shutdownTimeoutMs - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS),
+            )
+          : requestedRestartDrainTimeoutMs;
+      const drainTimeoutMs = isRestart
+        ? restartDrainTimeoutMs
+        : Math.max(0, shutdownTimeoutMs - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS);
       acceptedRequest.restartDeadline.activeWorkDrainDeadlineAt =
-        isRestart && restartDrainTimeoutMs !== undefined
-          ? Date.now() + restartDrainTimeoutMs
-          : undefined;
-      // Managed helpers must reach native parking before either exit watchdog can arm.
+        drainTimeoutMs === undefined ? undefined : performance.now() + drainTimeoutMs;
+      // Managed helpers without a supervisor deadline must reach native parking
+      // before either exit watchdog can arm.
       if (!isRestart) {
-        armForceExitTimer(SHUTDOWN_TIMEOUT_MS);
-      } else if (isLaunchdSigtermRestart && !getManagedUpdateOwner()) {
-        armForceExitTimer(restartShutdownTimeoutMs);
+        armForceExitTimer(shutdownTimeoutMs);
+      } else if (hasLaunchdShutdownDeadline) {
+        armForceExitTimer(shutdownTimeoutMs);
       } else if (restartDrainTimeoutMs !== undefined && !getManagedUpdateOwner()) {
         // Allow extra time for draining active turns on explicitly capped restarts.
         armForceExitTimer(restartDrainTimeoutMs + SHUTDOWN_TIMEOUT_MS);
       }
 
-      const drainTimeoutMs = isRestart
-        ? restartDrainTimeoutMs
-        : Math.max(0, SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS);
       const drainBudget =
         drainTimeoutMs === undefined ? "without a timeout" : `with timeout ${drainTimeoutMs}ms`;
       // The canonical inventory owns these category counts. Blocker descriptions
@@ -748,6 +836,54 @@ export async function runGatewayLoop(params: {
           gatewayLog.warn(
             `still draining active work before ${action}: ${formatDrainCounts(snapshot)}`,
           );
+        }
+      };
+      const waitForInterruptibleActiveWorkDrain = async (
+        waitForActiveWork: typeof eagerLifecycleRuntime.waitForGatewayActiveWork,
+        initialSnapshot?: GatewayActiveWorkSnapshot,
+      ) => {
+        let latestSnapshot = initialSnapshot;
+        for (;;) {
+          const activeWorkDrainDeadlineAt =
+            acceptedRequest.restartDeadline.activeWorkDrainDeadlineAt;
+          const remainingDrainTimeoutMs =
+            activeWorkDrainDeadlineAt === undefined
+              ? undefined
+              : Math.max(0, Math.ceil(activeWorkDrainDeadlineAt - performance.now()));
+          const activeWorkDrainInterrupted = new Error("active-work drain interrupted");
+          let acceptActiveWorkSnapshots = true;
+          let interruptActiveWorkDrain = () => {};
+          const interruptedDrain = new Promise<null>((resolve) => {
+            interruptActiveWorkDrain = () => resolve(null);
+            acceptedRequest.restartDeadline.interruptActiveWorkDrain = interruptActiveWorkDrain;
+          });
+          const activeWorkDrain = waitForActiveWork(remainingDrainTimeoutMs, {
+            onSnapshot: (snapshot) => {
+              latestSnapshot = snapshot;
+              if (!acceptActiveWorkSnapshots) {
+                throw activeWorkDrainInterrupted;
+              }
+              reportDrainSnapshot(snapshot);
+            },
+          }).catch((err: unknown) => {
+            if (err === activeWorkDrainInterrupted) {
+              if (!latestSnapshot) {
+                throw err;
+              }
+              return { drained: false, snapshot: latestSnapshot };
+            }
+            throw err;
+          });
+          const drain = await Promise.race([activeWorkDrain, interruptedDrain]);
+          acceptActiveWorkSnapshots = false;
+          if (
+            acceptedRequest.restartDeadline.interruptActiveWorkDrain === interruptActiveWorkDrain
+          ) {
+            acceptedRequest.restartDeadline.interruptActiveWorkDrain = undefined;
+          }
+          if (drain) {
+            return drain;
+          }
         }
       };
       try {
@@ -781,40 +917,10 @@ export async function runGatewayLoop(params: {
                 return;
               }
 
-              let latestSnapshot = initialSnapshot;
-              const activeWorkDrainDeadlineAt =
-                acceptedRequest.restartDeadline.activeWorkDrainDeadlineAt;
-              const remainingDrainTimeoutMs =
-                activeWorkDrainDeadlineAt === undefined
-                  ? undefined
-                  : Math.max(0, activeWorkDrainDeadlineAt - Date.now());
-              let drain: Awaited<ReturnType<typeof waitForGatewayActiveWork>>;
-              const activeWorkDrainInterrupted = new Error("active-work drain interrupted");
-              let acceptActiveWorkSnapshots = true;
-              const interruptedDrain = new Promise<typeof drain>((resolve) => {
-                acceptedRequest.restartDeadline.interruptActiveWorkDrain = () =>
-                  resolve({ drained: false, snapshot: latestSnapshot });
-              });
-              try {
-                const activeWorkDrain = waitForGatewayActiveWork(remainingDrainTimeoutMs, {
-                  onSnapshot: (snapshot) => {
-                    if (!acceptActiveWorkSnapshots) {
-                      throw activeWorkDrainInterrupted;
-                    }
-                    latestSnapshot = snapshot;
-                    reportDrainSnapshot(snapshot);
-                  },
-                }).catch((err: unknown) => {
-                  if (err === activeWorkDrainInterrupted) {
-                    return { drained: false, snapshot: latestSnapshot };
-                  }
-                  throw err;
-                });
-                drain = await Promise.race([activeWorkDrain, interruptedDrain]);
-              } finally {
-                acceptActiveWorkSnapshots = false;
-                acceptedRequest.restartDeadline.interruptActiveWorkDrain = undefined;
-              }
+              const drain = await waitForInterruptibleActiveWorkDrain(
+                waitForGatewayActiveWork,
+                initialSnapshot,
+              );
               if (drain.drained) {
                 if (!initialSnapshot.idle) {
                   gatewayLog.info("all active work drained");
@@ -839,9 +945,7 @@ export async function runGatewayLoop(params: {
           try {
             markGatewayRestartTrace("stop.drain.begin");
             const activeWorkDrain = await measureGatewayRestartTrace("stop.drain", () =>
-              eagerLifecycleRuntime.waitForGatewayActiveWork(drainTimeoutMs, {
-                onSnapshot: reportDrainSnapshot,
-              }),
+              waitForInterruptibleActiveWorkDrain(eagerLifecycleRuntime.waitForGatewayActiveWork),
             );
             if (!activeWorkDrain.drained) {
               gatewayLog.warn(
@@ -890,13 +994,18 @@ export async function runGatewayLoop(params: {
           !forceExitTimer &&
           (!managedUpdateOwner || managedUpdateCancellation === "restored-in-process")
         ) {
-          armForceExitTimer(resolveRestartShutdownTimeoutMs());
+          armForceExitTimer(resolveShutdownTimeoutMs());
         }
         const closeDrainTimeoutMs = !isRestart
           ? null
           : acceptedRequest.restartDeadline.activeWorkDrainDeadlineAt === undefined
             ? SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS
-            : Math.max(0, acceptedRequest.restartDeadline.activeWorkDrainDeadlineAt - Date.now());
+            : Math.max(
+                0,
+                Math.ceil(
+                  acceptedRequest.restartDeadline.activeWorkDrainDeadlineAt - performance.now(),
+                ),
+              );
         await server?.close({
           reason: isRestart ? "gateway restarting" : "gateway stopping",
           restartExpectedMs: isRestart ? 1500 : null,
@@ -937,17 +1046,21 @@ export async function runGatewayLoop(params: {
           try {
             await handleHostedStopAfterServerClose(acceptedRequest.hostedStop, shutdownFailed);
           } finally {
+            clearActiveStopRequest();
             clearForceExitTimer();
           }
         } else {
           await hostLifecycle?.retire();
-          clearForceExitTimer();
           params.completeBoot?.({
             outcome: shutdownFailed ? "forced_stop" : "clean_stop",
             reason: shutdownFailed ? "gateway.stop_close_failed" : "gateway.stop",
           });
           await releaseLockIfHeld();
           await exitProcessAfterLogFlush(shutdownFailed ? 1 : 0);
+          if (exitRequested) {
+            clearActiveStopRequest();
+            clearForceExitTimer();
+          }
         }
       }
     })();
@@ -965,22 +1078,68 @@ export async function runGatewayLoop(params: {
     startupFailedWithoutServerHandle = false;
     runAcceptedRequest(request);
   };
+  const armSigtermDeadlineBeforeClassification = (deadlineAt: number | undefined) => {
+    if (
+      deadlineAt === undefined ||
+      (pendingSigtermDeadlineGuard && pendingSigtermDeadlineGuard.deadlineAt <= deadlineAt)
+    ) {
+      return () => {};
+    }
+    if (pendingSigtermDeadlineGuard) {
+      clearTimeout(pendingSigtermDeadlineGuard.timer ?? undefined);
+      pendingSigtermDeadlineGuard.hardExitWatchdog?.cancel();
+    }
+    const guard: {
+      deadlineAt: number;
+      timer: ReturnType<typeof setTimeout> | null;
+      hardExitWatchdog: ShutdownHardExitWatchdog | null;
+    } = {
+      deadlineAt,
+      timer: null,
+      hardExitWatchdog: null,
+    };
+    pendingSigtermDeadlineGuard = guard;
+    scheduleDeadlineTimer({
+      deadlineAt,
+      onTimer: (timer) => {
+        guard.timer = timer;
+      },
+      onDeadline: () => {
+        void forceExitAfterStabilityBundle("gateway.stop_signal_classification_timeout", {
+          exitOnActiveManagedCancellation: true,
+        });
+      },
+    });
+    if (params.ownsProcessLifecycle === true) {
+      guard.hardExitWatchdog = armShutdownHardExitWatchdog({
+        delayMs:
+          Math.max(0, Math.ceil(deadlineAt - performance.now())) + HARD_EXIT_WATCHDOG_GRACE_MS,
+        onError: (error) => {
+          gatewayLog.warn(
+            `hard-exit watchdog failed; retaining main-thread SIGTERM timer: ${formatErrorMessage(error)}`,
+          );
+        },
+      });
+    }
+    return () => {
+      if (pendingSigtermDeadlineGuard !== guard) {
+        return;
+      }
+      clearTimeout(guard.timer ?? undefined);
+      guard.hardExitWatchdog?.cancel();
+      pendingSigtermDeadlineGuard = null;
+    };
+  };
   const request = (
     action: GatewayRunSignalAction,
     signal: string,
     restartReason?: string,
     restartIntent?: GatewayRestartIntent,
     hostedStop?: ReturnType<typeof createGatewayHostLifecycle>,
-    receivedAt = Date.now(),
+    launchdSignalDeadlineAt?: number,
   ) => {
-    const launchdSignalDeadlineAt =
-      signal === "SIGTERM" && supervisorMode === "launchd"
-        ? receivedAt +
-          eagerLifecycleRuntime.LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS * 1_000 -
-          LAUNCHD_SHUTDOWN_RESERVE_MS
-        : undefined;
-    const launchdShutdownDeadlineAt = action === "restart" ? launchdSignalDeadlineAt : undefined;
-    const acceptedRequest = {
+    const launchdShutdownDeadlineAt = launchdSignalDeadlineAt;
+    const acceptedRequest: GatewayRunSignalRequest = {
       action,
       signal,
       restartDeadline: { launchdShutdownDeadlineAt },
@@ -989,9 +1148,10 @@ export async function runGatewayLoop(params: {
       hostedStop,
     };
     if (shuttingDown) {
-      const currentRestartRequest = pendingStartupRequest ?? activeRestartRequest;
-      if (launchdSignalDeadlineAt !== undefined && currentRestartRequest?.action === "restart") {
-        const restartDeadline = currentRestartRequest.restartDeadline;
+      const currentSignalRequest =
+        pendingStartupRequest ?? activeRestartRequest ?? activeStopRequest;
+      if (launchdSignalDeadlineAt !== undefined && currentSignalRequest) {
+        const restartDeadline = currentSignalRequest.restartDeadline;
         const previousLaunchdDeadlineAt = restartDeadline.launchdShutdownDeadlineAt;
         const previousActiveWorkDrainDeadlineAt = restartDeadline.activeWorkDrainDeadlineAt;
         restartDeadline.launchdShutdownDeadlineAt = Math.min(
@@ -1006,29 +1166,30 @@ export async function runGatewayLoop(params: {
           restartDeadline.interruptActiveWorkDrain?.();
         }
         if (pendingStartupRequest) {
-          clearPendingStartupForceExitTimer();
-          armPendingStartupForceExitTimer(currentRestartRequest);
-        } else {
+          armPendingStartupForceExitTimer(currentSignalRequest);
+        } else if (currentSignalRequest.action === "restart") {
           forceActiveRestartExit?.();
+        } else {
+          forceActiveStopExit?.();
         }
       }
       if (
         action === "restart" &&
         isUpdateProcessRestartReason(restartReason) &&
-        currentRestartRequest?.action === "restart" &&
-        (!isUpdateProcessRestartReason(currentRestartRequest.restartReason) ||
+        currentSignalRequest?.action === "restart" &&
+        (!isUpdateProcessRestartReason(currentSignalRequest.restartReason) ||
           (restartIntent?.successorOwner &&
             !sameManagedUpdateOwner(
               restartIntent.successorOwner,
-              currentRestartRequest.restartIntent?.successorOwner,
+              currentSignalRequest.restartIntent?.successorOwner,
             )))
       ) {
         const upgradedRequest = {
-          ...currentRestartRequest,
+          ...currentSignalRequest,
           signal,
           restartReason,
           restartIntent: {
-            ...currentRestartRequest.restartIntent,
+            ...currentSignalRequest.restartIntent,
             ...restartIntent,
             force: true,
             reason: restartReason,
@@ -1044,6 +1205,19 @@ export async function runGatewayLoop(params: {
         return;
       }
       if (action === "stop" && pendingStartupRequest && !server) {
+        const pendingRestartDeadline = pendingStartupRequest.restartDeadline;
+        if (pendingRestartDeadline.launchdShutdownDeadlineAt !== undefined) {
+          acceptedRequest.restartDeadline.launchdShutdownDeadlineAt = Math.min(
+            acceptedRequest.restartDeadline.launchdShutdownDeadlineAt ?? Number.POSITIVE_INFINITY,
+            pendingRestartDeadline.launchdShutdownDeadlineAt,
+          );
+        }
+        if (pendingRestartDeadline.forceExitDeadlineAt !== undefined) {
+          acceptedRequest.restartDeadline.forceExitDeadlineAt = Math.min(
+            acceptedRequest.restartDeadline.forceExitDeadlineAt ?? Number.POSITIVE_INFINITY,
+            pendingRestartDeadline.forceExitDeadlineAt,
+          );
+        }
         gatewayLog.info(`received ${signal}; overriding pending startup restart with shutdown`);
         pendingStartupRequest = null;
         clearPendingStartupForceExitTimer();
@@ -1051,7 +1225,7 @@ export async function runGatewayLoop(params: {
         runAcceptedRequest(acceptedRequest);
         return;
       }
-      if (launchdSignalDeadlineAt !== undefined && currentRestartRequest?.action === "restart") {
+      if (launchdSignalDeadlineAt !== undefined && currentSignalRequest) {
         gatewayLog.info(`received ${signal} during shutdown; enforcing launchd deadline`);
         return;
       }
@@ -1093,13 +1267,28 @@ export async function runGatewayLoop(params: {
   };
 
   const onSigterm = () => {
-    const receivedAt = Date.now();
+    const receivedAt = performance.now();
+    const loadedLaunchdExitTimeoutSeconds =
+      supervisorMode === "launchd"
+        ? eagerLifecycleRuntime.readLoadedLaunchAgentExitTimeoutSecondsSync(process.env)
+        : undefined;
+    const launchdSignalDeadlineAt =
+      supervisorMode !== "launchd" || loadedLaunchdExitTimeoutSeconds === 0
+        ? undefined
+        : receivedAt +
+          // If the loaded job cannot be inspected, no plist/default value proves how soon
+          // launchd may hard-kill us. Fail closed; only an observed zero is unbounded.
+          Math.max(0, (loadedLaunchdExitTimeoutSeconds ?? 0) * 1_000 - LAUNCHD_SHUTDOWN_RESERVE_MS);
+    const releaseClassificationGuard =
+      armSigtermDeadlineBeforeClassification(launchdSignalDeadlineAt);
     // Debug-level: every accepted signal is announced by request()'s
     // "received <signal>; ..." line, so an info pre-log would double up.
     gatewayLog.debug("signal SIGTERM received");
     if (terminalHostedStop && terminalHostedStop === hostLifecycle) {
       // Kernel cleanup is already joined. A native stop signal belongs to this
       // terminal continuation, not to restart-intent storage in the closed kernel.
+      request("stop", "SIGTERM", undefined, undefined, undefined, launchdSignalDeadlineAt);
+      releaseClassificationGuard();
       terminalHostedStop.notifyStopSignal();
       return;
     }
@@ -1112,11 +1301,16 @@ export async function runGatewayLoop(params: {
         restartIntent?.reason,
         restartIntent ?? undefined,
         undefined,
-        receivedAt,
+        launchdSignalDeadlineAt,
       );
+      releaseClassificationGuard();
     })().catch((err: unknown) => {
       gatewayLog.error(`failed to handle SIGTERM: ${String(err)}`);
-      request("stop", "SIGTERM", undefined, undefined, undefined, receivedAt);
+      try {
+        request("stop", "SIGTERM", undefined, undefined, undefined, launchdSignalDeadlineAt);
+      } finally {
+        releaseClassificationGuard();
+      }
     });
   };
   const onSigint = () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -55,7 +55,11 @@ type GatewayRunSignalAction = "stop" | "restart";
 type GatewayRunSignalRequest = {
   action: GatewayRunSignalAction;
   signal: string;
-  launchdShutdownDeadlineAt?: number;
+  restartDeadline: {
+    launchdShutdownDeadlineAt?: number;
+    activeWorkDrainDeadlineAt?: number;
+    interruptActiveWorkDrain?: () => void;
+  };
   restartReason?: string;
   restartIntent?: GatewayRestartIntent;
   hostedStop?: ReturnType<typeof createGatewayHostLifecycle>;
@@ -529,9 +533,9 @@ export async function runGatewayLoop(params: {
     pendingStartupForceExitTimer = null;
   };
   const resolveRequestShutdownTimeoutMs = (request: GatewayRunSignalRequest) =>
-    request.launchdShutdownDeadlineAt === undefined
+    request.restartDeadline.launchdShutdownDeadlineAt === undefined
       ? SHUTDOWN_TIMEOUT_MS
-      : Math.max(0, request.launchdShutdownDeadlineAt - Date.now());
+      : Math.max(0, request.restartDeadline.launchdShutdownDeadlineAt - Date.now());
   const armPendingStartupForceExitTimer = (request: GatewayRunSignalRequest) => {
     if (pendingStartupForceExitTimer) {
       return;
@@ -542,7 +546,8 @@ export async function runGatewayLoop(params: {
         "startup restart request timed out before gateway returned a close handle; exiting for supervisor recovery",
       );
       void forceExitAfterStabilityBundle("gateway.restart_startup_request_timeout", {
-        exitOnActiveManagedCancellation: request.launchdShutdownDeadlineAt !== undefined,
+        exitOnActiveManagedCancellation:
+          request.restartDeadline.launchdShutdownDeadlineAt !== undefined,
       });
     }, resolveRequestShutdownTimeoutMs(request));
     pendingStartupForceExitTimer.unref?.();
@@ -628,7 +633,8 @@ export async function runGatewayLoop(params: {
   const runAcceptedRequest = (acceptedRequest: GatewayRunSignalRequest) => {
     const { action, restartIntent } = acceptedRequest;
     const isRestart = action === "restart";
-    const isLaunchdSigtermRestart = acceptedRequest.launchdShutdownDeadlineAt !== undefined;
+    const isLaunchdSigtermRestart =
+      acceptedRequest.restartDeadline.launchdShutdownDeadlineAt !== undefined;
     const resolveRestartShutdownTimeoutMs = () => resolveRequestShutdownTimeoutMs(acceptedRequest);
     if (isRestart) {
       activeRestartRequest = acceptedRequest;
@@ -647,7 +653,7 @@ export async function runGatewayLoop(params: {
           isRestart ? "gateway.restart_shutdown_timeout" : "gateway.stop_shutdown_timeout",
           {
             exitOnActiveManagedCancellation:
-              acceptedRequest.launchdShutdownDeadlineAt !== undefined,
+              acceptedRequest.restartDeadline.launchdShutdownDeadlineAt !== undefined,
           },
         );
       }, forceExitMs);
@@ -671,7 +677,10 @@ export async function runGatewayLoop(params: {
     if (isRestart) {
       forceActiveRestartExit = () => {
         clearForceExitTimer();
-        if (acceptedRequest.launchdShutdownDeadlineAt !== undefined || !getManagedUpdateOwner()) {
+        if (
+          acceptedRequest.restartDeadline.launchdShutdownDeadlineAt !== undefined ||
+          !getManagedUpdateOwner()
+        ) {
           armForceExitTimer(resolveRestartShutdownTimeoutMs());
         }
       };
@@ -695,7 +704,7 @@ export async function runGatewayLoop(params: {
             Math.max(0, restartShutdownTimeoutMs - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS),
           )
         : requestedRestartDrainTimeoutMs;
-      const restartDrainDeadlineAt =
+      acceptedRequest.restartDeadline.activeWorkDrainDeadlineAt =
         isRestart && restartDrainTimeoutMs !== undefined
           ? Date.now() + restartDrainTimeoutMs
           : undefined;
@@ -772,13 +781,40 @@ export async function runGatewayLoop(params: {
                 return;
               }
 
+              let latestSnapshot = initialSnapshot;
+              const activeWorkDrainDeadlineAt =
+                acceptedRequest.restartDeadline.activeWorkDrainDeadlineAt;
               const remainingDrainTimeoutMs =
-                restartDrainDeadlineAt === undefined
+                activeWorkDrainDeadlineAt === undefined
                   ? undefined
-                  : Math.max(0, restartDrainDeadlineAt - Date.now());
-              const drain = await waitForGatewayActiveWork(remainingDrainTimeoutMs, {
-                onSnapshot: reportDrainSnapshot,
+                  : Math.max(0, activeWorkDrainDeadlineAt - Date.now());
+              let drain: Awaited<ReturnType<typeof waitForGatewayActiveWork>>;
+              const activeWorkDrainInterrupted = new Error("active-work drain interrupted");
+              let acceptActiveWorkSnapshots = true;
+              const interruptedDrain = new Promise<typeof drain>((resolve) => {
+                acceptedRequest.restartDeadline.interruptActiveWorkDrain = () =>
+                  resolve({ drained: false, snapshot: latestSnapshot });
               });
+              try {
+                const activeWorkDrain = waitForGatewayActiveWork(remainingDrainTimeoutMs, {
+                  onSnapshot: (snapshot) => {
+                    if (!acceptActiveWorkSnapshots) {
+                      throw activeWorkDrainInterrupted;
+                    }
+                    latestSnapshot = snapshot;
+                    reportDrainSnapshot(snapshot);
+                  },
+                }).catch((err: unknown) => {
+                  if (err === activeWorkDrainInterrupted) {
+                    return { drained: false, snapshot: latestSnapshot };
+                  }
+                  throw err;
+                });
+                drain = await Promise.race([activeWorkDrain, interruptedDrain]);
+              } finally {
+                acceptActiveWorkSnapshots = false;
+                acceptedRequest.restartDeadline.interruptActiveWorkDrain = undefined;
+              }
               if (drain.drained) {
                 if (!initialSnapshot.idle) {
                   gatewayLog.info("all active work drained");
@@ -858,9 +894,9 @@ export async function runGatewayLoop(params: {
         }
         const closeDrainTimeoutMs = !isRestart
           ? null
-          : restartDrainTimeoutMs === undefined
+          : acceptedRequest.restartDeadline.activeWorkDrainDeadlineAt === undefined
             ? SHUTDOWN_TIMEOUT_MS - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS
-            : Math.max(0, (restartDrainDeadlineAt ?? Date.now()) - Date.now());
+            : Math.max(0, acceptedRequest.restartDeadline.activeWorkDrainDeadlineAt - Date.now());
         await server?.close({
           reason: isRestart ? "gateway restarting" : "gateway stopping",
           restartExpectedMs: isRestart ? 1500 : null,
@@ -888,7 +924,7 @@ export async function runGatewayLoop(params: {
             }
           } finally {
             if (
-              acceptedRequest.launchdShutdownDeadlineAt === undefined ||
+              acceptedRequest.restartDeadline.launchdShutdownDeadlineAt === undefined ||
               !shuttingDown ||
               exitRequested
             ) {
@@ -948,7 +984,7 @@ export async function runGatewayLoop(params: {
     const acceptedRequest = {
       action,
       signal,
-      launchdShutdownDeadlineAt,
+      restartDeadline: { launchdShutdownDeadlineAt },
       restartReason,
       restartIntent,
       hostedStop,
@@ -956,10 +992,20 @@ export async function runGatewayLoop(params: {
     if (shuttingDown) {
       const currentRestartRequest = pendingStartupRequest ?? activeRestartRequest;
       if (launchdSignalDeadlineAt !== undefined && currentRestartRequest?.action === "restart") {
-        currentRestartRequest.launchdShutdownDeadlineAt = Math.min(
-          currentRestartRequest.launchdShutdownDeadlineAt ?? Number.POSITIVE_INFINITY,
+        const restartDeadline = currentRestartRequest.restartDeadline;
+        const previousLaunchdDeadlineAt = restartDeadline.launchdShutdownDeadlineAt;
+        const previousActiveWorkDrainDeadlineAt = restartDeadline.activeWorkDrainDeadlineAt;
+        restartDeadline.launchdShutdownDeadlineAt = Math.min(
+          previousLaunchdDeadlineAt ?? Number.POSITIVE_INFINITY,
           launchdSignalDeadlineAt,
         );
+        restartDeadline.activeWorkDrainDeadlineAt = Math.min(
+          restartDeadline.activeWorkDrainDeadlineAt ?? Number.POSITIVE_INFINITY,
+          launchdSignalDeadlineAt - RESTART_CLOSE_REPLY_DRAIN_SHUTDOWN_RESERVE_MS,
+        );
+        if (restartDeadline.activeWorkDrainDeadlineAt !== previousActiveWorkDrainDeadlineAt) {
+          restartDeadline.interruptActiveWorkDrain?.();
+        }
         if (pendingStartupRequest) {
           clearPendingStartupForceExitTimer();
           armPendingStartupForceExitTimer(currentRestartRequest);
@@ -998,16 +1044,16 @@ export async function runGatewayLoop(params: {
         gatewayLog.info(`received ${signal} during shutdown; upgrading to ${restartReason}`);
         return;
       }
-      if (launchdSignalDeadlineAt !== undefined && currentRestartRequest?.action === "restart") {
-        gatewayLog.info(`received ${signal} during shutdown; enforcing launchd deadline`);
-        return;
-      }
       if (action === "stop" && pendingStartupRequest && !server) {
         gatewayLog.info(`received ${signal}; overriding pending startup restart with shutdown`);
         pendingStartupRequest = null;
         clearPendingStartupForceExitTimer();
         startupFailedWithoutServerHandle = false;
         runAcceptedRequest(acceptedRequest);
+        return;
+      }
+      if (launchdSignalDeadlineAt !== undefined && currentRestartRequest?.action === "restart") {
+        gatewayLog.info(`received ${signal} during shutdown; enforcing launchd deadline`);
         return;
       }
       gatewayLog.info(`received ${signal} during shutdown; ignoring`);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -766,7 +766,10 @@ export async function runGatewayLoop(params: {
           !getManagedUpdateOwner()
         ) {
           armForceExitTimer(resolveShutdownTimeoutMs());
+          return;
         }
+        clearForceExitTimer();
+        acceptedRequest.restartDeadline.forceExitDeadlineAt = undefined;
       };
     } else {
       forceActiveStopExit = () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -925,7 +925,6 @@ export async function runGatewayLoop(params: {
           } finally {
             if (
               acceptedRequest.restartDeadline.launchdShutdownDeadlineAt === undefined ||
-              !shuttingDown ||
               exitRequested
             ) {
               clearForceExitTimer();

--- a/src/cli/gateway-cli/shutdown-hard-exit.ts
+++ b/src/cli/gateway-cli/shutdown-hard-exit.ts
@@ -19,7 +19,24 @@ export function armShutdownHardExitWatchdog(params: {
   try {
     worker = new Worker(
       `const { parentPort, workerData } = require("node:worker_threads");
-       const timer = setTimeout(() => process.kill(process.pid, "SIGKILL"), workerData.delayMs);
+       const maxDelayMs = 2147483647;
+       const deadlineAt = performance.now() + workerData.delayMs;
+       let remainingCapMs = workerData.delayMs;
+       let timer;
+       const arm = () => {
+         const remainingMs = Math.min(
+           remainingCapMs,
+           Math.max(0, Math.ceil(deadlineAt - performance.now())),
+         );
+         const delayMs = Math.min(maxDelayMs, remainingMs);
+         timer = setTimeout(() => {
+           if (remainingMs > maxDelayMs) {
+             remainingCapMs = remainingMs - delayMs;
+             arm();
+           } else process.kill(process.pid, "SIGKILL");
+         }, delayMs);
+       };
+       arm();
        parentPort.once("message", () => {
          clearTimeout(timer);
          parentPort.close();

--- a/src/daemon/launchd-exit-timeout.test.ts
+++ b/src/daemon/launchd-exit-timeout.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnSync = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({ spawnSync }));
+
+import { readLoadedLaunchAgentExitTimeoutSecondsSync } from "./launchd-exit-timeout.js";
+
+describe("readLoadedLaunchAgentExitTimeoutSecondsSync", () => {
+  beforeEach(() => {
+    spawnSync.mockReset();
+  });
+
+  it.each([
+    { output: "exit timeout = 20\n", expected: 20 },
+    { output: "\texit timeout = 0\n", expected: 0 },
+    { output: "exit timeout = -1\n", expected: undefined },
+    { output: "state = running\n", expected: undefined },
+    { output: "exit timeout = nope\n", expected: undefined },
+  ])("parses loaded ExitTimeOut from $output", ({ output, expected }) => {
+    spawnSync.mockReturnValue({ error: undefined, status: 0, stdout: output, stderr: "" });
+
+    expect(
+      readLoadedLaunchAgentExitTimeoutSecondsSync({
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway.test",
+      }),
+    ).toBe(expected);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "launchctl",
+      ["print", expect.stringMatching(/^gui\/\d+\/ai\.openclaw\.gateway\.test$/)],
+      { encoding: "utf8", timeout: 2_000 },
+    );
+  });
+
+  it.each([
+    { error: new Error("timed out"), status: null },
+    { error: undefined, status: 1 },
+  ])("fails closed when launchctl cannot read the loaded job", ({ error, status }) => {
+    spawnSync.mockReturnValue({ error, status, stdout: "", stderr: "unavailable" });
+
+    expect(
+      readLoadedLaunchAgentExitTimeoutSecondsSync({
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway.test",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/daemon/launchd-exit-timeout.ts
+++ b/src/daemon/launchd-exit-timeout.ts
@@ -1,0 +1,35 @@
+/** Reads the loaded LaunchAgent's stop deadline without depending on its plist. */
+import { spawnSync } from "node:child_process";
+import { parseStrictInteger } from "@openclaw/normalization-core/number-coercion";
+import { resolveLaunchAgentLabel } from "./launchd-label.js";
+import { parseKeyValueOutput } from "./runtime-parse.js";
+
+const LAUNCHCTL_PRINT_TIMEOUT_MS = 2_000;
+
+function parseLoadedLaunchAgentExitTimeoutSeconds(output: string): number | undefined {
+  const value = parseKeyValueOutput(output, "=")["exit timeout"];
+  if (value === undefined) {
+    return undefined;
+  }
+  const seconds = parseStrictInteger(value);
+  return seconds !== undefined && seconds >= 0 ? seconds : undefined;
+}
+
+export function readLoadedLaunchAgentExitTimeoutSecondsSync(
+  env: Record<string, string | undefined> = process.env,
+): number | undefined {
+  try {
+    const uid = typeof process.getuid === "function" ? process.getuid() : 501;
+    const serviceTarget = `gui/${uid}/${resolveLaunchAgentLabel(env)}`;
+    const probe = spawnSync("launchctl", ["print", serviceTarget], {
+      encoding: "utf8",
+      timeout: LAUNCHCTL_PRINT_TIMEOUT_MS,
+    });
+    if (probe.error || probe.status !== 0) {
+      return undefined;
+    }
+    return parseLoadedLaunchAgentExitTimeoutSeconds(probe.stdout ?? probe.stderr ?? "");
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION
Fixes #126445

## What Problem This Solves

Fixes a macOS launchd restart crash loop where active Gateway work can outlive launchd's loaded `ExitTimeOut`. launchd may then SIGKILL the Gateway before Tailscale cleanup, leaving the old claimant on port 443 so the replacement cannot start.

## Why This Change Was Made

Launchd-managed SIGTERM restarts now read the active loaded job's `ExitTimeOut` at signal receipt and share one monotonic absolute deadline across restart-intent classification, active-work draining, server/resource cleanup, managed-update handoff parking/cancellation/commit, startup before a close handle exists, final log flushing, and in-process recovery.

A positive loaded timeout reserves the last five seconds for launchd. An explicit loaded value of zero remains unbounded. If the loaded job cannot be read or has no valid timeout, the path fails closed with an immediate deadline because no generated/default value proves how soon launchd may hard-kill the process. Repeated signals may tighten but never extend an existing cutoff.

The foreground Tailscale claimant remains detached from its cleanup worker, allowing cleanup to target the claimant's process group. This does not imply that the worker survives a hard Gateway process-group kill. The live proof below covers graceful claimant shutdown and replacement, not that hard-kill path. Generic unmanaged, systemd, Windows, and SIGUSR1-only restart behavior is unchanged.

## User Impact

LaunchAgent restarts reserve enough time to release the Tailscale listener, allowing the replacement Gateway to start instead of entering a KeepAlive crash loop.

## Evidence

- Exact head: `5817467d30a50e4fadfbfeed0b7b5bfaefaa1235`; merge base: `903980a972d4ea2652290bcd7bc9a8f71ef7624a`.
- Current `main`: `66fa0bd2be4f811a6c6dbee8bd5dd102dae8e544`; it has zero changes on the six PR paths since the merge base, and a local merge-tree reports no conflict.
- Scope: 6 files, +1204/-82: production +444/-73 and focused tests +760/-9.
- Scope decision: keep one PR. Loaded-deadline discovery, signal/request ownership, bounded timers, hard-exit fallback, and the race regressions are one launchd restart-availability invariant. Independent review found no materially removable scope without weakening that boundary.
- Focused tests: 125/125 passed (run-loop 99, managed-handoff single-flight 18, loaded-timeout parser 7, hard-exit process 1).
- `check-changed`: passed formatting, production/test typecheck, lint, dead-export, import-cycle, dependency, boundary, and structural guards.
- Full build: passed runtime/plugin builds, CLI bootstrap, SDK declarations/exports, postbuild checks, and Control UI.
- Independent exact-head P0-P3 review: no actionable defect, 0.88 confidence; specifically confirmed that managed takeover cancels an inherited generic watchdog, while launchd absolute deadlines remain non-extending and survive handoff, recovery, and final log flushing.
- Hosted exact-head CI: pending publication of this SHA; local changed-surface checks and the full build are green.
- Real macOS LaunchAgent proof on this exact head: active work observed; restart completed in 11.542s under loaded `ExitTimeOut=20`; old Gateway/wrapper/claimant exited; replacement listener was reacquired; health was true before and after; temporary label/plist/state/listeners and all proof processes were removed; production Gateway, real Tailscale, and public port 443 were untouched. Result SHA-256: `041305bc6825244fd54f90a0167b64d695fccad321b3d49d50f5249da2bed9f1`.

<details>
<summary>Inspectable exact-head macOS LaunchAgent trace (redacted)</summary>

Captured from `candidate.sha`, the generated plist, `launchctl` before/after snapshots, stalled-provider events, fake-claimant events, listener snapshots, lifecycle log, health snapshots, and uninstall readback. Redaction replaces only the local user/path, temporary label/profile, and isolated loopback ports; the SHA, UTC timestamps, PIDs, states, and timing are unchanged.

```text
$ git rev-parse HEAD
5817467d30a50e4fadfbfeed0b7b5bfaefaa1235

$ plutil -p <generated-isolated-plist> | grep ExitTimeOut
"ExitTimeOut" => 20

$ launchctl print <isolated-label>  # before restart
state = running
exit timeout = 20
runs = 1
pid = 13430
last exit code = (never exited)

$ jq '{ok,ts,durationMs}' health.before.json
{"ok":true,"ts":1788564951205,"durationMs":1}

$ tail provider.events.jsonl
{"at":"2026-09-04T23:35:52.197Z","event":"request-stalled","method":"POST","url":"/v1/responses","bytes":8183}

$ lsof -nP -iTCP:<isolated-route-port> -sTCP:LISTEN  # before restart
node  13486  ...  TCP 127.0.0.1:<isolated-route-port> (LISTEN)

$ openclaw gateway restart --json
{"action":"restart","ok":true,"result":"restarted","service":{"label":"LaunchAgent","loaded":true}}
restart.elapsed_ms=11542

$ cat gateway-restart.log
[2026-09-04T23:35:53.204Z] openclaw gateway lifecycle source=cli action=restart mode=enable interactive=0
[2026-09-04T23:36:00Z] openclaw restart attempt source=handoff mode=start-after-exit target=<isolated-label> pid=13430 interactive=0
[2026-09-04T23:36:01.939Z] openclaw gateway lifecycle source=cli action=restart mode=kickstart interactive=0
[2026-09-04T23:36:02Z] openclaw restart done source=handoff mode=start-after-exit interactive=0

$ grep -E 'claimant-(ready|signal)|wrapper-child-exit' fake-tailscale.events.jsonl
{"at":"2026-09-04T23:35:50.060Z","event":"claimant-ready","pid":13486,"ppid":13484,"pgid":13484,"routePort":"<isolated-route-port>"}
{"at":"2026-09-04T23:35:58.297Z","event":"claimant-signal","pid":13486,"ppid":13484,"pgid":13484,"signal":"SIGTERM"}
{"at":"2026-09-04T23:35:58.302Z","event":"wrapper-child-exit","pid":13484,"ppid":13483,"pgid":13484,"childPid":13486,"code":0,"signal":null}
{"at":"2026-09-04T23:36:03.631Z","event":"claimant-ready","pid":13852,"ppid":13850,"pgid":13850,"routePort":"<isolated-route-port>"}

$ launchctl print <isolated-label>  # after restart
state = running
exit timeout = 20
runs = 2
pid = 13733
last exit code = 0

$ lsof -nP -iTCP:<isolated-route-port> -sTCP:LISTEN  # after restart
node  13852  ...  TCP 127.0.0.1:<isolated-route-port> (LISTEN)

$ jq '{ok,ts,durationMs}' health.after.json
{"ok":true,"ts":1788564964548,"durationMs":2}

$ cat agent.stdout
{"status":"timeout","summary":"aborted","stopReason":"restart","timeoutPhase":"gateway_draining"}

$ openclaw gateway uninstall --json
{"action":"uninstall","ok":true,"result":"uninstalled","service":{"label":"LaunchAgent","loaded":false}}

$ teardown-readback
launchagent=absent plist=absent state_dir=absent isolated_listeners=0 proof_processes=0
```

</details>

### Owner acceptance

- **Assurance:** Elevated; blast radius is launchd-managed Gateway restart availability.
- **Maintainer decision:** accept the current fail-closed immediate cutoff when the loaded job is unreadable or lacks a valid `ExitTimeOut`, or require a bounded graceful compatibility path. The patch intentionally chooses fail-closed because no fallback value proves the supervisor's remaining kill budget.
- **Falsifier:** restart exceeds the loaded supervisor budget; an old claimant survives; replacement cannot reacquire the listener; signal classification delays enforcement; a later signal weakens a stricter cutoff; or deadline enforcement is disarmed during cleanup, handoff, recovery, or log flushing.
- **Rollback:** revert this PR; no persisted-state or public API migration.

## Worked on by

- PollyBot13

AI-assisted: yes.
