### PR TITLE
fix(sessions): preserve in-use groups on catalog put

### DIFF
--- a/src/gateway/server-methods/sessions-groups.test.ts
+++ b/src/gateway/server-methods/sessions-groups.test.ts
@@ -4,7 +4,9 @@ import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const groupMocks = vi.hoisted(() => ({
   NotFound: class SessionGroupNotFoundError extends Error {},
+  put: vi.fn(),
   rename: vi.fn(),
+  targetsByName: vi.fn(() => new Map()),
   update: vi.fn(),
 }));
 const pathMocks = vi.hoisted(() => ({
@@ -17,10 +19,13 @@ vi.mock("../session-groups.js", () => ({
   listSessionGroupDefaults: vi.fn(() => []),
   listSessionGroups: vi.fn(() => []),
   listSidebarSectionOrder: vi.fn(() => []),
-  putSessionGroups: vi.fn(() => []),
+  putSessionGroups: groupMocks.put,
   renameSessionGroup: groupMocks.rename,
   SessionGroupNotFoundError: groupMocks.NotFound,
   updateSessionGroupDefaults: groupMocks.update,
+}));
+vi.mock("../session-group-mutation-targets.js", () => ({
+  resolveSessionGroupMutationTargetsByName: groupMocks.targetsByName,
 }));
 vi.mock("./workspace-path-containment.js", () => ({
   isWorkspacePathContainmentCurrent: pathMocks.isCurrent,
@@ -52,6 +57,36 @@ function renameOptions(params: Record<string, unknown>, respond: ReturnType<type
     context: { getRuntimeConfig: () => ({}) },
   } as unknown as GatewayRequestHandlerOptions;
 }
+
+describe("sessions.groups.put", () => {
+  beforeEach(() => {
+    groupMocks.put.mockReset();
+    groupMocks.put.mockReturnValue([]);
+    groupMocks.targetsByName.mockReset();
+    groupMocks.targetsByName.mockReturnValue(new Map());
+  });
+
+  it("preserves assigned categories omitted by a stale reorder snapshot", async () => {
+    groupMocks.targetsByName.mockReturnValue(
+      new Map([["P1 issues from beta feedback", [{ sessionKey: "agent:main:child" }]]]),
+    );
+    const respond = vi.fn();
+    await expectDefined(
+      sessionGroupHandlers["sessions.groups.put"],
+      'sessionGroupHandlers["sessions.groups.put"] test invariant',
+    )(updateOptions({ names: ["Papercuts"] }, respond));
+
+    expect(groupMocks.put).toHaveBeenCalledWith(
+      ["Papercuts", "P1 issues from beta feedback"],
+      undefined,
+    );
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      { ok: true, groups: [], sectionOrder: [] },
+      undefined,
+    );
+  });
+});
 
 describe("sessions.groups.update", () => {
   beforeEach(() => {

--- a/src/gateway/server-methods/sessions-groups.ts
+++ b/src/gateway/server-methods/sessions-groups.ts
@@ -72,7 +72,14 @@ export const sessionGroupHandlers: GatewayRequestHandlers = {
     ) {
       return;
     }
-    const groups = putSessionGroups(params.names, params.sectionOrder);
+    // `put` also powers reorder-only clients. Their catalog snapshot can lag
+    // behind a category assignment, so preserve every group that still owns
+    // sessions. Explicit group deletion remains responsible for clearing
+    // memberships before removing the catalog entry.
+    const inUseNames = [
+      ...resolveSessionGroupMutationTargetsByName(context.getRuntimeConfig()).keys(),
+    ];
+    const groups = putSessionGroups([...params.names, ...inUseNames], params.sectionOrder);
     respond(true, { ok: true, groups, sectionOrder: listSidebarSectionOrder() }, undefined);
     // Catalog-only changes still need to reach other open clients.
     emitSessionsChanged(context, { reason: "groups" });


### PR DESCRIPTION
## Summary
- preserve category catalog entries that still own sessions during `sessions.groups.put`
- prevent stale reorder snapshots from creating visible-but-unregistered categories
- add a regression test covering the missing-category rename failure

## Root cause
`sessions.groups.put` replaced the entire catalog while deliberately leaving session category memberships unchanged. A client with a stale catalog snapshot could therefore remove a category that still contained sessions. The sidebar continued to discover it from session rows, but rename rejected it as an unknown catalog group.

## Validation
- `pnpm exec vitest run src/gateway/server-methods/sessions-groups.test.ts --config test/vitest/vitest.gateway-methods.config.ts`
- `pnpm check:changed`
