### PR TITLE
fix(onboard): keep named first-agent state on created owner

### DIFF
--- a/src/commands/onboard-non-interactive/local.default-agent.test.ts
+++ b/src/commands/onboard-non-interactive/local.default-agent.test.ts
@@ -176,21 +176,50 @@ describe("runNonInteractiveLocalSetup default-agent ownership", () => {
     expect(mocks.ensureOnboardingAgent).toHaveBeenCalledWith(
       expect.objectContaining({ firstAgent: { name: "main" } }),
     );
+    expect(mocks.ensureWorkspaceAndSessions).toHaveBeenCalledWith(
+      workspace,
+      runtime,
+      expect.objectContaining({ agentId: "main" }),
+    );
     expect(mocks.commitConfig.mock.invocationCallOrder[0]).toBeGreaterThan(
       mocks.ensureOnboardingAgent.mock.invocationCallOrder[0]!,
     );
   });
 
-  it("passes an explicit first-agent name into the single creation step", async () => {
+  it("provisions and reports the named first agent returned by creation", async () => {
+    const workspace = "/tmp/robby-workspace";
+    mocks.ensureOnboardingAgent.mockImplementationOnce(
+      async ({ config }: { config: OpenClawConfig }) => ({
+        config: {
+          ...config,
+          agents: {
+            ...config.agents,
+            entries: {
+              robby: {
+                name: "robby",
+                workspace,
+                agentDir: "/tmp/robby-agent",
+              },
+            },
+          },
+        },
+        agentId: "robby",
+        bootstrapPending: true,
+        createdAgent: true,
+      }),
+    );
+
     await runNonInteractiveLocalSetup({
       opts: {
         nonInteractive: true,
         mode: "local",
         agentName: "robby",
+        workspace,
         authChoice: "skip",
         skipHooks: true,
         skipSkills: true,
         skipHealth: true,
+        json: true,
       },
       runtime,
       baseConfig: {},
@@ -199,6 +228,17 @@ describe("runNonInteractiveLocalSetup default-agent ownership", () => {
     expect(mocks.ensureOnboardingAgent).toHaveBeenCalledOnce();
     expect(mocks.ensureOnboardingAgent).toHaveBeenCalledWith(
       expect.objectContaining({ firstAgent: { name: "robby" } }),
+    );
+    expect(mocks.ensureWorkspaceAndSessions).toHaveBeenCalledWith(
+      workspace,
+      runtime,
+      expect.objectContaining({ agentId: "robby" }),
+    );
+    expect(mocks.ensureWorkspaceAndSessions.mock.calls.map(([dir]) => dir)).not.toContain(
+      `${workspace}/main`,
+    );
+    expect(mocks.logJson).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: workspace }),
     );
   });
 

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -176,7 +176,7 @@ export async function runNonInteractiveLocalSetup(params: {
 }) {
   const { opts, runtime, baseConfig, baseHash } = params;
   const mode = "local" as const;
-  const selectedAgentId = resolveOnboardingAgentTarget(baseConfig).agentId;
+  const preCreationAgentId = resolveOnboardingAgentTarget(baseConfig).agentId;
 
   const requestedWorkspaceDir = resolveNonInteractiveWorkspaceDir({
     opts,
@@ -205,7 +205,7 @@ export async function runNonInteractiveLocalSetup(params: {
   }
   // Workspace defaults are already staged above; provider discovery must use
   // that requested owner before first-agent creation is allowed to write.
-  const authTarget = resolveOnboardingAgentTarget(nextConfig, selectedAgentId);
+  const authTarget = resolveOnboardingAgentTarget(nextConfig, preCreationAgentId);
 
   const inferredAuthChoice = opts.authChoice
     ? undefined
@@ -283,7 +283,7 @@ export async function runNonInteractiveLocalSetup(params: {
     nextConfig = applySkipBootstrapConfig(nextConfig);
   }
 
-  const finalTarget = resolveOnboardingAgentTarget(nextConfig, selectedAgentId);
+  const finalTarget = resolveOnboardingAgentTarget(nextConfig, created.agentId);
   await ensureOnboardingAgentWorkspace(finalTarget, runtime, {
     skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
     skipOptionalBootstrapFiles: nextConfig.agents?.defaults?.skipOptionalBootstrapFiles,


### PR DESCRIPTION
Closes #126454

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where fresh installations using non-interactive `--agent-name` onboarding would provision and report a stale `main` workspace after creating the requested named agent.

## Why This Change Was Made

Final workspace/session provisioning now resolves from the agent id returned by first-agent creation. The pre-creation owner remains limited to provider-auth discovery, preserving existing-roster behavior without adding config, migration, compatibility, or cleanup logic.

## User Impact

Automated named-agent onboarding now leaves config, bootstrap workspace, session ownership, and JSON output on the same created agent. It no longer creates a stray `<workspace>/main` or `agents/main/sessions` path for the fresh named-agent flow.

## Evidence

- Current-main process repro before the fix exited successfully but printed `Workspace OK: <workspace>/main`, created `agents/main/sessions`, and returned the same stale workspace in JSON while the roster contained only `robby` at `<workspace>`.
- The same isolated `pnpm openclaw onboard --non-interactive --agent-name robby ... --json` flow after the fix printed `<workspace>`, created only `agents/robby/sessions`, returned `<workspace>` in JSON, and left both stale paths absent.
- The regression failed before the production edit with expected `robby`/`<workspace>` versus observed `main`/`<workspace>/main`; it passes after the edit.
- Focused onboarding, agent persistence/provisioning, CLI parser/JSON, and process-fixture coverage: 151 tests passed across 8 files and 3 Vitest shards.
- Full changed-path gate passed, including production/test types, changed lint, formatting, dependency/patch guards, database-first, import-cycle, and ownership-related checks.
- `git diff --check` passed.
- Fresh P1 Codex autoreview: no accepted/actionable findings, patch correct (0.94 confidence).
- Separate read-only Codex review: no P0/P1 findings; best-fix verdict confirmed `created.agentId` as the authoritative lifecycle result.
- Production LOC: +3/-3 (net 0). Tests: +41/-1 (net +40).
- No docs change: `docs/cli/onboard.md` already specifies that `--agent-name` names the first agent; this repair makes runtime behavior match that contract.
