### PR TITLE
fix(qa): preserve terminal script failures

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
@@ -301,6 +301,84 @@ describe("qa test file scenario runner", () => {
     });
   });
 
+  it.each([
+    { producerStatus: "pass" as const, terminal: "exit" as const },
+    { producerStatus: "blocked" as const, terminal: "timeout" as const },
+    { producerStatus: "skipped" as const, terminal: "exit" as const },
+  ])(
+    "makes a real $terminal failure override colliding $producerStatus producer evidence",
+    async ({ producerStatus, terminal }) => {
+      const commandName = path.basename(process.execPath);
+      const tempRoot = await makeTempRepo(`qa-script-terminal-${terminal}-${producerStatus}-`);
+      const outputDir = path.join(tempRoot, "out");
+      const scriptPath = path.join(tempRoot, "terminal-evidence-producer.mjs");
+      const producerEvidence = buildScriptProducerEvidence({
+        additionalEntries: buildScriptProducerEvidence({
+          producerId: "producer-diagnostic",
+          status: "pass",
+        }).entries,
+        artifacts: [{ kind: "log", path: "producer.log" }],
+        producerId: "scenario-script",
+        status: producerStatus,
+      });
+      await fs.writeFile(
+        scriptPath,
+        [
+          "import fs from 'node:fs/promises';",
+          "import path from 'node:path';",
+          "const artifactBase = process.argv[process.argv.indexOf('--artifact-base') + 1];",
+          "const runRoot = path.join(artifactBase, 'run-1');",
+          "await fs.mkdir(runRoot, { recursive: true });",
+          "await fs.writeFile(path.join(runRoot, 'producer.log'), 'producer evidence\\n');",
+          `await fs.writeFile(path.join(runRoot, 'qa-evidence.json'), ${JSON.stringify(JSON.stringify(producerEvidence))});`,
+          "await fs.writeFile(path.join(artifactBase, 'latest-run.json'), JSON.stringify({ qaEvidence: 'run-1/qa-evidence.json' }));",
+          terminal === "timeout" ? "setInterval(() => {}, 1_000);" : "process.exitCode = 7;",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const result = await runQaTestFileScenarios({
+        repoRoot: process.cwd(),
+        outputDir,
+        ...QA_TEST_RUNNER_DEFAULTS,
+        scenarios: [makeTestFileScenario("script", scriptPath)],
+        commandTimeoutMs: 1_000,
+      });
+
+      expect(result.results[0]).toMatchObject({
+        failureMessage:
+          terminal === "timeout"
+            ? expect.stringContaining("timed out after 1000ms")
+            : `${commandName} exited with 7`,
+        status: "fail",
+      });
+      expect(result.evidence.entries).toHaveLength(2);
+      expect(
+        result.evidence.entries.find((entry) => entry.test.id === "scenario-script"),
+      ).toMatchObject({
+        coverage: [
+          { id: "qa.coverage", role: "primary" },
+          { id: "qa.reporting", role: "secondary" },
+        ],
+        execution: {
+          artifacts: [{ kind: "log", path: expect.stringContaining("producer.log") }],
+          runner: "evidence-producer-script",
+        },
+        result: {
+          failure: {
+            reason: `${commandName} ${
+              terminal === "timeout" ? "timed out after 1000ms" : "exited with 7"
+            }`,
+          },
+          status: "fail",
+        },
+      });
+      expect(
+        result.evidence.entries.find((entry) => entry.test.id === "producer-diagnostic"),
+      ).toMatchObject({ result: { status: "pass" } });
+    },
+  );
+
   it("fails script scenario results when imported producer evidence fails", async () => {
     const repoRoot = await makeTempRepo("qa-script-producer-fail-");
     const outputDir = path.join(repoRoot, ".artifacts", "qa-e2e", "scenario-script-producer-fail");

--- a/extensions/qa-lab/src/test-file-scenario-runner.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.ts
@@ -448,8 +448,8 @@ function buildTestFileEvidence(params: {
   );
   if (producerEntries.length > 0) {
     const definition = testFileRunnerDefinitions[params.kind];
-    // Failed scripts still need generic fallback evidence unless their producer
-    // already recorded that scenario identity at the authoritative boundary.
+    // Producer failures stay authoritative; parent terminal failures replace
+    // colliding non-fail results without discarding producer execution facts.
     const producerEntryIds = new Set(producerEntries.map((entry) => entry.test.id));
     const fallbackResults = params.results.filter(
       (result) => !result.producerEvidence || result.includeFallbackEvidence,
@@ -486,10 +486,17 @@ function buildTestFileEvidence(params: {
       profile: resolveQaEvidenceProfile({ env: params.env }),
       entries: [
         ...producerEntries.map((entry) => {
+          const fallbackFailure = fallbackEvidence?.entries.find(
+            (fallback) => fallback.test.id === entry.test.id && fallback.result.status === "fail",
+          );
+          const resolvedEntry =
+            entry.result.status !== "fail" && fallbackFailure
+              ? Object.assign({}, entry, { result: fallbackFailure.result })
+              : entry;
           if (evidenceMode !== "slim") {
-            return entry;
+            return resolvedEntry;
           }
-          const { execution: _execution, ...withoutExecution } = entry;
+          const { execution: _execution, ...withoutExecution } = resolvedEntry;
           return withoutExecution;
         }),
         ...(fallbackEvidence?.entries.filter((entry) => !producerEntryIds.has(entry.test.id)) ??


### PR DESCRIPTION
Related: #126407

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a non-Docker QA script scenario could write PASS, BLOCKED, or SKIPPED producer evidence for its scenario ID and then exit nonzero or time out, leaving the final evidence success-looking even though the parent runner correctly failed the scenario.

The generic terminal failure row was built, but ID-only deduplication discarded it whenever producer evidence used the same ID.

## Why This Change Was Made

The evidence merge boundary now lets a parent-observed terminal failure replace only a colliding non-fail producer result. Producer execution, artifacts, coverage, and unrelated diagnostics remain intact, while an existing producer-owned failure remains authoritative.

This is related to but distinct from #126407. That PR owns completed-summary publication, stale-run cleanup, whole-flow deadlines, and producer status precedence; it intentionally did not repair the existing ID-only collision rule in `buildTestFileEvidence`. Docker scenarios continue through their aggregate scheduler path unchanged.

The original deduplication in #117806 remains correct for duplicate rows; this change narrows its authority rule when the parent has a stronger terminal process fact.

## User Impact

QA operators and release automation now receive honest failed evidence when a script writes non-failing evidence and then crashes or exceeds its deadline. Existing producer failure evidence and diagnostic artifacts are preserved.

This is internal QA infrastructure only.

## Evidence

Exact head: `22117984b0f7c6e581478a3085f8fc69ff6c578a`

Current-main base: `7e0b599ca484067e1b0e4dffe2f797fa51509285`

Pre-fix current-main reproduction with the regression test retained:

```text
node scripts/run-vitest.mjs extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
FAIL: 3 failed / 20 passed
Observed colliding result statuses: pass, blocked, skipped
```

Post-fix proof:

```text
node scripts/run-vitest.mjs extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
PASS: 23/23

node scripts/check-changed.mjs -- extensions/qa-lab/src/test-file-scenario-runner.ts extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
PASS: extension production/test typecheck, lint, format, boundary, database-first, and import-cycle gates

node_modules/.bin/oxfmt --check extensions/qa-lab/src/test-file-scenario-runner.ts extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
PASS

git diff --check 7e0b599ca484067e1b0e4dffe2f797fa51509285...HEAD
PASS

.agents/skills/autoreview/scripts/autoreview --mode branch --base 7e0b599ca484067e1b0e4dffe2f797fa51509285
PASS: clean, no accepted/actionable findings, confidence 0.99
```

Real-behavior proof uses real child processes through the production command lifecycle: nonzero exit 7 and a 1000 ms timeout both produce the parent terminal failure. No external provider or channel is involved, so no authenticated live-provider run is needed.

Production LOC: `+11/-4` (net `+7`). Tests: `+78/-0`. The production growth records collision authority at the existing evidence merge owner; it adds no helper, API, fallback, or parallel path.

AI-assisted. I reviewed the implementation and validation results. No prompts or transcripts are included.
