### PR TITLE
fix(mcp): surface resolved tool failures to clients

### DIFF
--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -8,6 +8,7 @@ import {
   wrapToolWithBeforeToolCallHook,
 } from "../agents/agent-tools.before-tool-call.js";
 import { BEFORE_TOOL_CALL_HOOK_CONTEXT } from "../agents/before-tool-call-metadata.js";
+import { isToolResultError } from "../agents/tool-result-error.js";
 import { isAutomationsToolName } from "../agents/tools/automations-tool-name.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -104,6 +105,7 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
       const toolCallId = `mcp-${randomUUID()}`;
       try {
         const result = await entry.tool.execute(toolCallId, params.arguments ?? {}, signal);
+        const isError = isToolResultError(result);
         const rawContent =
           result && typeof result === "object" && "content" in result
             ? (result as { content?: unknown }).content
@@ -112,6 +114,7 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
           content: Array.isArray(rawContent)
             ? rawContent.map(toMcpContentBlock)
             : [{ type: "text", text: coerceChatContentText(rawContent) }],
+          ...(isError ? { isError: true } : {}),
         };
       } catch (err) {
         return {

--- a/src/mcp/plugin-tools-mcp-client.test.ts
+++ b/src/mcp/plugin-tools-mcp-client.test.ts
@@ -59,4 +59,37 @@ describe("plugin tools MCP client bridge", () => {
       await server.close();
     }
   });
+
+  it("delivers resolved tool failures as MCP errors", async () => {
+    const content = [{ type: "text", text: "backend unavailable" }];
+    const tool = {
+      name: "memory_search",
+      description: "Search memory",
+      parameters: { type: "object", properties: {} },
+      execute: vi.fn().mockResolvedValue({
+        content,
+        details: { status: "failed", error: "backend unavailable" },
+      }),
+    } as unknown as AnyAgentTool;
+    const server = createPluginToolsMcpServer({
+      config: { plugins: { enabled: true } } as OpenClawConfig,
+      tools: [tool],
+    });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client(
+      { name: "plugin-tools-error-test-client", version: "0.0.0" },
+      { capabilities: {} },
+    );
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      const result = await client.callTool({ name: "memory_search", arguments: {} });
+
+      expect(result.content).toEqual(content);
+      expect(result.isError).toBe(true);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
 });

--- a/src/mcp/plugin-tools-serve.test.ts
+++ b/src/mcp/plugin-tools-serve.test.ts
@@ -370,6 +370,34 @@ describe("plugin tools MCP server", () => {
     ]);
   });
 
+  it.each([
+    ["failed status", { status: "failed", error: "backend unavailable" }, true],
+    ["blocked status", { status: "blocked" }, true],
+    ["timeout flag", { timedOut: true }, true],
+    ["explicit failure", { ok: false }, true],
+    ["successful status", { status: "success" }, undefined],
+    ["completed nonzero shell exit", { status: "completed", exitCode: 23 }, undefined],
+  ])(
+    "projects a resolved %s through the canonical error contract",
+    async (_label, details, isError) => {
+      const content = [{ type: "text", text: "original tool result" }];
+      const execute = vi.fn().mockResolvedValue({ content, details });
+      const handlers = createPluginToolsMcpHandlers([
+        {
+          name: "result_probe",
+          description: "Return a structured result",
+          parameters: { type: "object", properties: {} },
+          execute,
+        } as unknown as AnyAgentTool,
+      ]);
+
+      const result = await handlers.callTool({ name: "result_probe", arguments: {} });
+
+      expect(result.content).toEqual(content);
+      expect(result.isError).toBe(isError);
+    },
+  );
+
   it("returns MCP errors for unknown tools and thrown tool errors", async () => {
     const failingTool = {
       name: "memory_forget",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where MCP clients could receive a resolved OpenClaw tool failure as an ordinary successful tool result. Plugin tools, built-in OpenClaw tools, and Codex supervision tools share this server path, so a failed or blocked tool could be shown to the calling agent without MCP's failure signal.

## Why This Change Was Made

The shared MCP handler now projects OpenClaw's canonical resolved tool-result failure classification into MCP's `isError: true` field while preserving the original result content. Successful results remain unchanged, including the intentional contract that a completed shell result with a nonzero exit code is not automatically a tool failure.

This reuses the existing `isToolResultError` owner instead of introducing a second MCP-specific classifier.

## User Impact

MCP clients can now distinguish resolved tool failures from successful tool results and let the agent respond or self-correct appropriately. There is no configuration, protocol-version, storage, or migration change.

## Evidence

Exact PR head: `38f5444305723e2058b8958339bce17c314ba1ad`

Exact-head CI: run 32313158695 is green, including `openclaw/ci-gate`: https://github.com/openclaw/openclaw/actions/runs/32313158695

- Pre-fix regression proof: the new resolved-failure cases produced five expected failures because `isError` was absent.
- `node scripts/run-vitest.mjs src/mcp/plugin-tools-serve.test.ts src/mcp/plugin-tools-mcp-client.test.ts` — 21/21 passed on the exact head.
- `node scripts/run-vitest.mjs src/mcp` — 66/66 passed on the exact head, covering all current MCP server surfaces after rebasing onto `origin/main`.
- The linked `@modelcontextprotocol/sdk` in-memory client/server test proves the error bit survives real MCP framing while result content remains intact.
- `node scripts/check-changed.mjs -- src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-mcp-client.test.ts src/mcp/plugin-tools-serve.test.ts` — passed, including core/core-test types, targeted lint, boundary guards, dead-export checks, and import-cycle architecture.
- `./node_modules/.bin/oxfmt --check src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-mcp-client.test.ts src/mcp/plugin-tools-serve.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings; correctness confidence 0.99.
- Production LOC: +3/-0. Tests: +61/-0. The production growth is the single canonical import, classification, and conditional MCP projection needed to preserve the existing tool-result contract at the shared framing boundary.
- External live proof is not needed: this is a deterministic local protocol-framing defect with no provider, network, credential, channel, or platform dependency.

AI-assisted: yes. I reviewed the complete handler, its three server callers, adjacent tests, the MCP SDK contract, and the Codex MCP client behavior, and I understand the change.
