### PR TITLE
fix(plugin-sdk): published Firecrawl plugins load on current OpenClaw

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -292,7 +292,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/boolean-param` | Loose boolean param reader |
     | `plugin-sdk/dangerous-name-runtime` | Private-local after July 2026; Dangerous-name matching resolution helpers |
     | `plugin-sdk/device-bootstrap` | Device bootstrap and pairing token helpers, including `BOOTSTRAP_HANDOFF_OPERATOR_SCOPES` |
-    | `plugin-sdk/extension-shared` | Shared passive-channel, status, and ambient proxy helper primitives |
+    | `plugin-sdk/extension-shared` | Shared passive-channel, status, and ambient proxy helper primitives. Its `canResolveEnvSecretRefInReadOnlyPath` export is a deprecated load-compatibility alias for Firecrawl packages through 2026.7.1; new consumers must use `plugin-sdk/secret-ref-readonly`. |
     | `plugin-sdk/models-provider-runtime` | `/models` command/provider reply helpers |
     | `plugin-sdk/skill-commands-runtime` | Skill command listing helpers |
     | `plugin-sdk/native-command-registry` | Native command registry/build/serialize helpers |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -361,7 +361,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/boolean-param` | Loose boolean param reader |
     | `plugin-sdk/dangerous-name-runtime` | Private-local after July 2026; Dangerous-name matching resolution helpers |
     | `plugin-sdk/device-bootstrap` | Device bootstrap and pairing token helpers, including `BOOTSTRAP_HANDOFF_OPERATOR_SCOPES` |
-    | `plugin-sdk/extension-shared` | Shared passive-channel, status, and ambient proxy helper primitives |
+    | `plugin-sdk/extension-shared` | Shared passive-channel, status, and ambient proxy helper primitives. Its `canResolveEnvSecretRefInReadOnlyPath` export is a deprecated load-compatibility alias for Firecrawl packages through 2026.7.1; new consumers must use `plugin-sdk/secret-ref-readonly`. |
     | `plugin-sdk/models-provider-runtime` | `/models` command/provider reply helpers |
     | `plugin-sdk/skill-commands-runtime` | Skill command listing helpers |
     | `plugin-sdk/native-command-registry` | Native command registry/build/serialize helpers |

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -305,7 +305,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: typed guarded-fetch redirect error for direct-only plugin delivery.
       // -1: remove the test-only channel activity reset export.
       // +1: named bounded structured-input surface for native harness protocol adapters.
-      4336,
+      // +1: restore the read-only SecretRef guard for published extension-shared consumers.
+      4337,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -392,7 +393,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       //     runtimes render the same guidance instead of diverging prompt copies.
       // +1: shared harness visible-source-reply guidance.
       // -1: remove the test-only channel activity reset export.
-      2577,
+      // +1: restore the read-only SecretRef guard for published extension-shared consumers.
+      2578,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -176,6 +176,8 @@ const defaultPublicDeprecatedExportsByEntrypointBudget = Object.freeze({
   "reply-history": 6,
   "provider-auth": 19,
   "telegram-account": 3,
+  // +1: read-only SecretRef guard retained for published Firecrawl consumers.
+  "extension-shared": 1,
 } satisfies Record<string, number>);
 
 export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env) {

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -363,7 +363,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // -1: one exec policy object replaces two deprecated comparator exports.
       // +1: approved bounded TAR inspection through the archive admission owner.
       // +1: canonical runtime-context classifier for native history projection.
-      4447,
+      // +1: restore the read-only SecretRef guard for published extension-shared consumers.
+      4448,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -495,7 +496,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // -2: exec comparators are members of the shared policy object.
       // +1: approved bounded TAR inspection through the archive admission owner.
       // +1: canonical runtime-context classifier for native history projection.
-      2629,
+      // +1: restore the read-only SecretRef guard for published extension-shared consumers.
+      2630,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/extension-shared.test.ts
+++ b/src/plugin-sdk/extension-shared.test.ts
@@ -12,7 +12,31 @@ vi.mock("@openclaw/proxyline", () => ({
   hasAmbientNodeProxyConfigured: hasAmbientNodeProxyConfiguredMock,
 }));
 
-import { resolveAmbientNodeProxyAgent } from "./extension-shared.js";
+import {
+  canResolveEnvSecretRefInReadOnlyPath,
+  resolveAmbientNodeProxyAgent,
+} from "./extension-shared.js";
+
+describe("extension-shared compatibility exports", () => {
+  it("keeps the read-only env SecretRef guard available to published plugins", () => {
+    expect(
+      canResolveEnvSecretRefInReadOnlyPath({
+        cfg: {
+          secrets: {
+            providers: {
+              restricted: {
+                source: "env",
+                allowlist: ["FIRECRAWL_API_KEY"],
+              },
+            },
+          },
+        },
+        provider: "restricted",
+        id: "FIRECRAWL_API_KEY",
+      }),
+    ).toBe(true);
+  });
+});
 
 describe("resolveAmbientNodeProxyAgent", () => {
   const envKeys = [

--- a/src/plugin-sdk/extension-shared.ts
+++ b/src/plugin-sdk/extension-shared.ts
@@ -8,6 +8,7 @@ import { runPassiveAccountLifecycle } from "./channel-lifecycle.core.js";
 import { createLoggerBackedRuntime } from "./runtime-logger.internal.js";
 export { safeParseJsonWithSchema, safeParseWithSchema } from "../utils/zod-parse.js";
 export { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
+export { canResolveEnvSecretRefInReadOnlyPath } from "./secret-ref-readonly.internal.js";
 
 type PassiveChannelStatusSnapshot = {
   configured?: boolean;

--- a/src/plugin-sdk/extension-shared.ts
+++ b/src/plugin-sdk/extension-shared.ts
@@ -6,9 +6,20 @@ import { resolveActiveManagedProxyTlsOptions } from "../infra/net/proxy/managed-
 import { createDeferredCore } from "../shared/deferred.js";
 import { runPassiveAccountLifecycle } from "./channel-lifecycle.core.js";
 import { createLoggerBackedRuntime } from "./runtime-logger.internal.js";
+import {
+  canResolveEnvSecretRefInReadOnlyPath as canResolveEnvSecretRefInReadOnlyPathInternal,
+} from "./secret-ref-readonly.internal.js";
 export { safeParseJsonWithSchema, safeParseWithSchema } from "../utils/zod-parse.js";
 export { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
-export { canResolveEnvSecretRefInReadOnlyPath } from "./secret-ref-readonly.internal.js";
+
+/**
+ * @deprecated Import from `openclaw/plugin-sdk/secret-ref-readonly`. This alias
+ * keeps published Firecrawl plugins through 2026.7.1 loadable. Remove it only
+ * after supported releases no longer import the legacy subpath and the normal
+ * Plugin SDK deprecation window has elapsed.
+ */
+export const canResolveEnvSecretRefInReadOnlyPath =
+  canResolveEnvSecretRefInReadOnlyPathInternal;
 
 type PassiveChannelStatusSnapshot = {
   configured?: boolean;

--- a/src/plugin-sdk/extension-shared.ts
+++ b/src/plugin-sdk/extension-shared.ts
@@ -6,9 +6,7 @@ import { resolveActiveManagedProxyTlsOptions } from "../infra/net/proxy/managed-
 import { createDeferredCore } from "../shared/deferred.js";
 import { runPassiveAccountLifecycle } from "./channel-lifecycle.core.js";
 import { createLoggerBackedRuntime } from "./runtime-logger.internal.js";
-import {
-  canResolveEnvSecretRefInReadOnlyPath as canResolveEnvSecretRefInReadOnlyPathInternal,
-} from "./secret-ref-readonly.internal.js";
+import { canResolveEnvSecretRefInReadOnlyPath as canResolveEnvSecretRefInReadOnlyPathInternal } from "./secret-ref-readonly.internal.js";
 export { safeParseJsonWithSchema, safeParseWithSchema } from "../utils/zod-parse.js";
 export { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
 
@@ -18,8 +16,7 @@ export { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
  * after supported releases no longer import the legacy subpath and the normal
  * Plugin SDK deprecation window has elapsed.
  */
-export const canResolveEnvSecretRefInReadOnlyPath =
-  canResolveEnvSecretRefInReadOnlyPathInternal;
+export const canResolveEnvSecretRefInReadOnlyPath = canResolveEnvSecretRefInReadOnlyPathInternal;
 
 type PassiveChannelStatusSnapshot = {
   configured?: boolean;

--- a/src/plugin-sdk/extension-shared.ts
+++ b/src/plugin-sdk/extension-shared.ts
@@ -6,7 +6,6 @@ import { resolveActiveManagedProxyTlsOptions } from "../infra/net/proxy/managed-
 import { createDeferredCore } from "../shared/deferred.js";
 import { runPassiveAccountLifecycle } from "./channel-lifecycle.core.js";
 import { createLoggerBackedRuntime } from "./runtime-logger.internal.js";
-import { canResolveEnvSecretRefInReadOnlyPath as canResolveEnvSecretRefInReadOnlyPathInternal } from "./secret-ref-readonly.internal.js";
 export { safeParseJsonWithSchema, safeParseWithSchema } from "../utils/zod-parse.js";
 export { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
 
@@ -16,7 +15,7 @@ export { buildTimeoutAbortSignal } from "../utils/fetch-timeout.js";
  * after supported releases no longer import the legacy subpath and the normal
  * Plugin SDK deprecation window has elapsed.
  */
-export const canResolveEnvSecretRefInReadOnlyPath = canResolveEnvSecretRefInReadOnlyPathInternal;
+export { canResolveEnvSecretRefInReadOnlyPath } from "./secret-ref-readonly.js";
 
 type PassiveChannelStatusSnapshot = {
   configured?: boolean;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users loading already-published Firecrawl plugins would see module-load failures on current OpenClaw because the plugin imports a previously available Plugin SDK symbol.

## Why This Change Was Made

Restore the legacy `extension-shared` named export by re-exporting the existing read-only SecretRef guard. The secret-resolution policy remains implemented and owned by `secret-ref-readonly`; this change adds no duplicate policy or new behavior.

## User Impact

Published `@openclaw/firecrawl-plugin` releases can load on current OpenClaw without requiring an immediate republish.

## Evidence

- Pinned package proof: `@openclaw/firecrawl-plugin@2026.7.1`
  (`sha256:093cee0c870a82a10761d3131ce288591cafc17fd9a351cdf71358e89de8eeba`)
  imports `canResolveEnvSecretRefInReadOnlyPath` from
  `openclaw/plugin-sdk/extension-shared` in
  `dist/firecrawl-client-xZqyVUBg.js`.
- Before this change, the full-catalog canary failed while loading that
  published package because current OpenClaw did not provide the named export.
- With this change, Website Evidence Collector passes OpenClaw inspect, adapter
  preview, and add preview; the later add-apply attempt reached package
  installation and was blocked by this Windows host's npm network path.
- `src/plugin-sdk/extension-shared.test.ts`: 2/2 passed.
- `test/scripts/plugin-sdk-surface-report.test.ts`: 10/10 passed.
- The compatibility alias and SDK subpath reference explicitly mark the broad
  import as deprecated and direct new consumers to `secret-ref-readonly`.
- Core TypeScript check passed.
- Plugin SDK declaration build and all 146 public subpath export checks passed.
- Core lint passed.

## Compatibility Exception

This is a temporary compatibility alias for already-published consumers, not a
second policy implementation. New consumers should use
`openclaw/plugin-sdk/secret-ref-readonly`. Remove the alias only through the
normal deprecated-SDK lifecycle after supported Firecrawl releases no longer
import the legacy path. Because this expands a public Plugin SDK surface, do not
merge without explicit SDK-owner approval.
