### PR TITLE
fix(claws): unchanged owned skills no longer block updates

### DIFF
--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -481,7 +481,7 @@ export async function buildClawAddPlan(params: {
     }
   }
 
-  for (const pkg of params.manifest.packages) {
+  for (const [index, pkg] of params.manifest.packages.entries()) {
     const preflight: ClawPackagePreflightResult = context.packagePreflight
       ? await context.packagePreflight(pkg, workspace)
       : {
@@ -493,7 +493,7 @@ export async function buildClawAddPlan(params: {
       ? undefined
       : blocker(
           preflight.code ?? "package_install_unavailable",
-          "$.packages",
+          `$.packages[${index}]`,
           preflight.message ?? "Package preflight failed.",
         );
     if (diagnostic) {

--- a/src/claws/update-apply.packages.test.ts
+++ b/src/claws/update-apply.packages.test.ts
@@ -1,0 +1,255 @@
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { PersistedClawInstall } from "./provenance.js";
+import type {
+  ClawManifest,
+  ClawOpenClawProfile,
+  ClawPackage,
+  ClawPackagePreflight,
+  ClawSourceIdentity,
+} from "./types.js";
+import { applyClawUpdatePlan } from "./update-apply.js";
+import type { ClawUpdateAction, ClawUpdatePlan } from "./update-plan.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const source: ClawSourceIdentity = {
+  kind: "package",
+  name: "@acme/worker",
+  version: "2.0.0",
+  packageRoot: "/tmp/target",
+  manifestPath: "/tmp/target/openclaw.claw.json",
+  integrityKind: "artifact",
+  integrity: "sha256:target",
+  byteLength: 1,
+};
+const manifest: ClawManifest = {
+  schemaVersion: 1,
+  agent: { id: "worker", name: "Worker v2" },
+  workspace: { bootstrapFiles: {}, files: [] },
+  packages: [],
+  mcpServers: {},
+  cronJobs: [],
+};
+const install: PersistedClawInstall = {
+  schemaVersion: "openclaw.clawInstallRecord.v1",
+  claw: { ...source, version: "1.0.0", integrity: "sha256:current" },
+  manifestSchemaVersion: 1,
+  planIntegrity: "sha256:current-add-plan",
+  agentId: "worker",
+  workspace: "/tmp/workspace-worker",
+  agentConfigDigest: "sha256:current-agent",
+  agentOwnedPaths: ['agents.entries["worker"]'],
+  status: "complete",
+  addedAtMs: 1,
+  updatedAtMs: 1,
+};
+const weatherPackage: ClawPackage = {
+  kind: "skill",
+  source: "clawhub",
+  ref: "@acme/weather",
+  version: "1.0.0",
+};
+
+function plan(actions: ClawUpdateAction[]): ClawUpdatePlan {
+  return {
+    schemaVersion: "openclaw.clawUpdatePlan.v1",
+    stability: "experimental",
+    dryRun: true,
+    mutationAllowed: false,
+    planIntegrity: "sha256:update-plan",
+    found: true,
+    agentId: "worker",
+    currentClaw: { name: source.name, version: "1.0.0", integrity: "sha256:current" },
+    targetClaw: { name: source.name, version: source.version, integrity: source.integrity },
+    summary: {
+      totalActions: actions.length,
+      added: actions.filter((action) => action.action === "add").length,
+      changed: 0,
+      removed: 0,
+      released: 0,
+      unchanged: actions.filter((action) => action.action === "unchanged").length,
+      manual: 0,
+      blocked: 0,
+      capabilityChanges: 0,
+      capabilityEscalations: 0,
+    },
+    actions,
+    capabilityChanges: [],
+    readiness: { ready: true, requirements: [] },
+    blockers: [],
+    diagnostics: [],
+  };
+}
+
+function unchanged(id = "skill:@acme/weather"): ClawUpdateAction {
+  return {
+    kind: "package",
+    id,
+    action: "unchanged",
+    target: "clawhub:@acme/weather@1.0.0",
+    blocked: false,
+    reason: "Recorded package reference already matches the exact target version.",
+    currentDigest: "sha256:current-package",
+    desiredDigest: "sha256:target-package",
+  };
+}
+
+function targetSource(): ClawSourceIdentity {
+  const packageRoot = tempDirs.make("openclaw-claw-update-package-");
+  return {
+    ...source,
+    packageRoot,
+    manifestPath: join(packageRoot, "openclaw.claw.json"),
+  };
+}
+
+function options(updatePlan: ClawUpdatePlan, packagePreflight: ClawPackagePreflight) {
+  return {
+    config: {},
+    sourceMcpServers: {},
+    consentPlanIntegrity: updatePlan.planIntegrity,
+    rebuildPlan: vi.fn(async () => updatePlan),
+    readInstall: vi.fn(() => install),
+    packagePreflight,
+  };
+}
+
+describe("applyClawUpdatePlan package compatibility", () => {
+  it("does not rematerialize an unchanged Claw-owned skill during apply", async () => {
+    const updatePlan = plan([unchanged()]);
+    const applyPackage = vi.fn(async () => ({
+      appliedIds: [],
+      rollback: vi.fn(async () => undefined),
+    }));
+    const result = await applyClawUpdatePlan(
+      updatePlan,
+      {
+        targetManifest: { ...manifest, packages: [weatherPackage] },
+        targetSource: targetSource(),
+      },
+      {
+        ...options(
+          updatePlan,
+          vi.fn(async () => ({
+            ok: false,
+            code: "skill_version_conflict",
+            message: "The already installed skill cannot be added again.",
+          })),
+        ),
+        applyWorkspace: vi.fn(async () => ({
+          appliedPaths: [],
+          rollback: vi.fn(async () => undefined),
+        })),
+        applyMcp: vi.fn(async () => ({
+          appliedNames: [],
+          rollback: vi.fn(async () => undefined),
+        })),
+        applyCron: vi.fn(async () => ({
+          appliedIds: [],
+          rollback: vi.fn(async () => undefined),
+        })),
+        applyPackage,
+        persistInstall: vi.fn(() => ({ ...install, claw: source })),
+      },
+    );
+
+    expect(result.status).toBe("complete");
+    expect(result.appliedActions).toEqual([]);
+    expect(applyPackage).not.toHaveBeenCalled();
+  });
+
+  it("keeps package blockers for mutations when another package is unchanged", async () => {
+    const alertsPackage: ClawPackage = {
+      kind: "skill",
+      source: "clawhub",
+      ref: "@acme/alerts",
+      version: "1.0.0",
+    };
+    const updatePlan = plan([
+      unchanged(),
+      {
+        kind: "package",
+        id: "skill:@acme/alerts",
+        action: "add",
+        target: "clawhub:@acme/alerts@1.0.0",
+        blocked: false,
+        reason: "The target adds a skill.",
+        desiredDigest: "sha256:target-alerts",
+      },
+    ]);
+
+    await expect(
+      applyClawUpdatePlan(
+        updatePlan,
+        {
+          targetManifest: { ...manifest, packages: [weatherPackage, alertsPackage] },
+          targetSource: targetSource(),
+        },
+        options(
+          updatePlan,
+          vi.fn(async (pkg) => ({
+            ok: false,
+            code: "skill_version_conflict",
+            message: `${pkg.ref} cannot be materialized.`,
+          })),
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "update_target_blocked" });
+  });
+
+  it("rejects an unchanged package that disappears after planning", async () => {
+    const updatePlan = plan([unchanged()]);
+    await expect(
+      applyClawUpdatePlan(
+        updatePlan,
+        {
+          targetManifest: { ...manifest, packages: [weatherPackage] },
+          targetSource: targetSource(),
+        },
+        options(
+          updatePlan,
+          vi.fn(async () => ({
+            ok: true,
+            action: "install" as const,
+            integrity: "sha256:resolved-package",
+            installId: "@acme/weather",
+          })),
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "update_changed" });
+  });
+
+  it("keeps provenance blockers for unchanged profile extensions", async () => {
+    const targetOpenClawProfile: ClawOpenClawProfile = {
+      schemaVersion: 1,
+      agent: {},
+      extensions: [
+        {
+          id: "weather",
+          kind: "plugin",
+          format: "openclaw",
+          source: "clawhub",
+          ref: "@acme/weather",
+          version: "1.0.0",
+        },
+      ],
+    };
+    const updatePlan = plan([unchanged("plugin:@acme/weather")]);
+
+    await expect(
+      applyClawUpdatePlan(
+        updatePlan,
+        {
+          targetManifest: manifest,
+          targetOpenClawProfile,
+          targetSource: targetSource(),
+        },
+        options(
+          updatePlan,
+          vi.fn(async () => ({ ok: true, action: "reuse" as const })),
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "update_target_blocked" });
+  });
+});

--- a/src/claws/update-apply.ts
+++ b/src/claws/update-apply.ts
@@ -87,6 +87,21 @@ function comparablePlan(plan: ClawUpdatePlan): unknown {
   };
 }
 
+function unchangedPackagePaths(plan: ClawUpdatePlan, manifest: ClawManifest): Set<string> {
+  const unchangedIds = new Set(
+    plan.actions
+      .filter((action) => action.kind === "package" && action.action === "unchanged")
+      .map((action) => action.id),
+  );
+  const paths = new Set<string>();
+  manifest.packages.forEach((pkg, index) => {
+    if (unchangedIds.has(`${pkg.kind}:${pkg.ref}`)) {
+      paths.add(`$.packages[${index}]`);
+    }
+  });
+  return paths;
+}
+
 export async function applyClawUpdatePlan(
   plan: ClawUpdatePlan,
   params: {
@@ -221,9 +236,13 @@ export async function applyClawUpdatePlan(
       },
     },
   });
+  const unchangedPaths = unchangedPackagePaths(fresh, params.targetManifest);
   if (
     targetAddPlan.blockers.some(
-      (blocker) => blocker.code !== "agent_id_collision" && blocker.code !== "workspace_collision",
+      (blocker) =>
+        blocker.code !== "agent_id_collision" &&
+        blocker.code !== "workspace_collision" &&
+        !(blocker.code === "skill_version_conflict" && unchangedPaths.has(blocker.path)),
     )
   ) {
     throw new ClawUpdateMutationError(
@@ -231,10 +250,24 @@ export async function applyClawUpdatePlan(
       "The target Claw cannot be safely materialized for update.",
     );
   }
+  for (const action of fresh.actions.filter(
+    (candidate) => candidate.kind === "package" && candidate.action === "unchanged",
+  )) {
+    const addAction = targetAddPlan.actions.find(
+      (candidate) => candidate.kind === "package" && candidate.id === action.id,
+    );
+    if (!addAction || addAction.details?.expectedState === "absent") {
+      throw new ClawUpdateMutationError(
+        "update_changed",
+        `Package ${JSON.stringify(action.id)} is no longer present; build a new dry-run plan.`,
+      );
+    }
+  }
   const targetPackages = clawTargetPackages(params.targetManifest, params.targetOpenClawProfile);
   for (const action of fresh.actions.filter(
     (candidate) =>
       candidate.kind === "package" &&
+      candidate.action !== "unchanged" &&
       candidate.action !== "release" &&
       candidate.action !== "remove",
   )) {
@@ -272,7 +305,10 @@ export async function applyClawUpdatePlan(
       targetPackages.get(action.id)?.kind === "plugin",
   );
   const remainingPackageActions = fresh.actions.filter(
-    (action) => action.kind === "package" && !requirementActions.includes(action),
+    (action) =>
+      action.kind === "package" &&
+      action.action !== "unchanged" &&
+      !requirementActions.includes(action),
   );
   const applyPackageActions = async (
     actions: ClawUpdateAction[],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where updating a Claw could fail with `update_target_blocked` when an exact, unchanged Claw-owned skill was already installed.

## Why This Change Was Made

Align update apply with the consented update plan: exact unchanged owned skills are not rematerialized, while blockers for package mutations, extension provenance, and concurrent package disappearance remain fail-closed. Portable package diagnostics now identify the exact manifest declaration so only the intended unchanged skill conflict can be ignored.

## User Impact

Claws such as Public Safety Monitor can update without failing on their own unchanged skills. Added or changed packages and stale package state continue to block unsafe updates.

## Evidence

- Added four production-path regressions using the real add-plan builder:
  - unchanged owned skill is not rematerialized;
  - a concurrent added-package blocker remains enforced;
  - disappearance of an unchanged package fails with `update_changed`;
  - unchanged profile-extension provenance blockers remain enforced.
- Package compatibility regressions: 4/4 passed.
- Application schema and update-plan suites: 27/27 passed.
- Core and source-test TypeScript checks passed.
- Core lint passed.
