### PR TITLE
fix(logging): report unavailable log tails

### DIFF
--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -6,6 +6,16 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const metadataBoundaries = [
+  "configured stat",
+  "rolling readdir",
+  "candidate stat",
+  "final stat",
+] as const;
+const operationalErrorCodes = ["EACCES", "EIO", "EMFILE"] as const;
+const operationalMetadataFailures = metadataBoundaries.flatMap((boundary) =>
+  operationalErrorCodes.map((code) => ({ boundary, code })),
+);
 
 const resolvedRedaction = { mode: "tools" as const, patterns: [/custom-secret-[a-z]+/g] };
 type PositionalRead = (
@@ -122,6 +132,44 @@ describe("readConfiguredLogTail", () => {
     expect(result.lines).toHaveLength(5000);
     expect(result.lines[0]?.trimEnd()).toBe("first-line-in-window");
   });
+
+  it.each(operationalMetadataFailures)(
+    "rethrows $code from the $boundary boundary",
+    async ({ boundary, code }) => {
+      const tempDir = tempDirs.make("openclaw-log-tail-");
+      const configured = path.join(tempDir, "openclaw-2026-01-22.log");
+      const candidate = path.join(tempDir, "openclaw-2026-01-21.log");
+      const error = Object.assign(new Error(`${code} injected`), { code });
+      const realStat = fs.stat.bind(fs);
+
+      if (boundary === "candidate stat") {
+        await fs.writeFile(candidate, "candidate\n");
+      } else if (boundary !== "rolling readdir") {
+        await fs.writeFile(configured, "configured\n");
+      }
+      setLoggerOverride({ file: configured });
+
+      if (boundary === "configured stat") {
+        vi.spyOn(fs, "stat").mockRejectedValueOnce(error);
+      } else if (boundary === "rolling readdir") {
+        vi.spyOn(fs, "readdir").mockRejectedValueOnce(error);
+      } else if (boundary === "candidate stat") {
+        vi.spyOn(fs, "stat").mockImplementation(async (...args: Parameters<typeof fs.stat>) => {
+          if (String(args[0]) === candidate) {
+            throw error;
+          }
+          return realStat(...args);
+        });
+      } else {
+        vi.spyOn(fs, "stat")
+          .mockImplementationOnce((...args: Parameters<typeof fs.stat>) => realStat(...args))
+          .mockRejectedValueOnce(error);
+      }
+
+      const { readConfiguredLogTail } = await import("./log-tail.js");
+      await expect(readConfiguredLogTail()).rejects.toBe(error);
+    },
+  );
 
   it("falls back only within the active profile's rolling log family", async () => {
     const tempDir = tempDirs.make("openclaw-log-tail-");

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -1,6 +1,7 @@
 // Log tail helpers read recent log lines with optional parsing and redaction.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isMissingPathError } from "../infra/errno.js";
 import { readFileWindowFully } from "../infra/file-read.js";
 import { clamp } from "../utils.js";
 import { isRollingLogFilePath, isSameRollingLogFileFamily } from "./log-file-path.js";
@@ -14,6 +15,13 @@ const DEFAULT_LIMIT = 500;
 const DEFAULT_MAX_BYTES = 250_000;
 const MAX_LIMIT = 5000;
 const MAX_BYTES = 1_000_000;
+
+function missingPathToNull(error: unknown): null {
+  if (!isMissingPathError(error)) {
+    throw error;
+  }
+  return null;
+}
 
 /** Payload returned to log-tail callers with cursor and truncation metadata. */
 export type LogTailPayload = {
@@ -32,7 +40,7 @@ type ParsedLogTailPayload = Omit<LogTailPayload, "lines"> & {
 
 /** Resolves a rolling daily log path to the newest existing rolling log when needed. */
 async function resolveLogFile(file: string, options?: { rolling?: boolean }): Promise<string> {
-  const stat = await fs.stat(file).catch(() => null);
+  const stat = await fs.stat(file).catch(missingPathToNull);
   if (stat) {
     return file;
   }
@@ -41,7 +49,7 @@ async function resolveLogFile(file: string, options?: { rolling?: boolean }): Pr
   }
 
   const dir = path.dirname(file);
-  const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => null);
+  const entries = await fs.readdir(dir, { withFileTypes: true }).catch(missingPathToNull);
   if (!entries) {
     return file;
   }
@@ -51,7 +59,7 @@ async function resolveLogFile(file: string, options?: { rolling?: boolean }): Pr
       .filter((entry) => entry.isFile() && isSameRollingLogFileFamily(file, entry.name))
       .map(async (entry) => {
         const fullPath = path.join(dir, entry.name);
-        const fileStat = await fs.stat(fullPath).catch(() => null);
+        const fileStat = await fs.stat(fullPath).catch(missingPathToNull);
         return fileStat ? { path: fullPath, mtimeMs: fileStat.mtimeMs } : null;
       }),
   );
@@ -68,7 +76,7 @@ async function readLogSlice(params: {
   maxBytes: number;
   filter?: (line: string) => boolean;
 }): Promise<Omit<LogTailPayload, "file">> {
-  const stat = await fs.stat(params.file).catch(() => null);
+  const stat = await fs.stat(params.file).catch(missingPathToNull);
   if (!stat) {
     return {
       cursor: 0,


### PR DESCRIPTION
Closes #126467

AI-assisted: yes

## What Problem This Solves

Fixes an issue where operators reading Gateway logs could receive a successful empty or stale tail when the filesystem returned an operational metadata error such as `EACCES`, `EIO`, or `EMFILE`.

That false success bypassed the existing unavailable/error states in Gateway RPC, the Control UI, CLI and channel log commands, and diagnostic exports.

## Why This Change Was Made

The log-tail owner now uses the existing missing-path classifier through one local missing-to-null projector at all four metadata boundaries: configured-file stat, rolling-directory scan, rolling-candidate stat, and final-file stat. `ENOENT`, `ENOTDIR`, and the existing `not-found` sentinel still mean absence; every other error is rethrown unchanged.

This keeps missing-file empty success and rolling fallback intact without adding retries, consumer guards, protocol/UI/config changes, or another fallback path. A consumer-side CLI wording issue remains out of scope because this repair does not own or naturally resolve that text.

Alternatives rejected: handling errors in Gateway/UI/CLI consumers would duplicate policy and leave direct readers broken; retrying metadata calls would hide the ownership bug and alter failure semantics.

Production LOC: +12/-4 (net +8) | Tests: +48/-0. The production growth is the shared projector plus the existing classifier import; the four former catch-all sites are otherwise direct replacements.

Provenance: the catch-all behavior originated in direct commit `d19a0249f8b973132711475e2d6aee0b51fdf0e1` on 2026-01-22 and was carried into the shared reader by `306fe841f54b4c11c93831d8aff3fabb619dd511` on 2026-04-04. Both were authored and committed by Peter Steinberger; no associated PR was returned by GitHub.

## User Impact

Unavailable log storage is now reported as unavailable instead of being presented as an empty/current log. Missing log files continue to behave as an empty log, including selection of the latest matching rolling file when the configured daily file is absent.

## Evidence

Exact head: `60d555a036b41c5933c9db08fb67c87f39ff14ce`

- Before the source fix, `node scripts/run-vitest.mjs src/logging/log-tail.test.ts` failed all 12 injected operational-error cases for the intended reason: each promise resolved instead of rejecting.
- After the fix, the same command passes 18/18, including all 12 `EACCES`/`EIO`/`EMFILE` cases and the existing missing-file and rolling-family controls.
- Gateway handler: 210/210 passed.
- Logging plus diagnostic export: 31/31 passed.
- CLI logs command: 39/39 passed.
- Channel logs command: 14/14 passed.
- Control UI log unit tests: 19/19 passed.
- Control UI log E2E: autofollow and layout passed. The lifecycle scenario twice timed out waiting for its initial Gateway-ready handshake before reaching log behavior; no UI code changed.
- `node scripts/check-changed.mjs -- src/logging/log-tail.ts src/logging/log-tail.test.ts` passed all selected core/core-test gates, including both typecheck lanes, lint, import-cycle, database/storage, and authorization guards.
- P1 autoreview: clean, no accepted/actionable findings.
- Independent ephemeral read-only review: clean; best-fix verdict was the owner-boundary repair.

Additional unrelated local gap: `src/cli/logs-cli.runtime.test.ts` twice failed its untouched `execFileUtf8Tail` 64 KiB UTF-8 boundary assertion. The log command suite itself is green, and this repair does not modify that runtime helper or test.
