### PR TITLE
fix(diffs): use canonical auth rate limiter

### DIFF
--- a/extensions/diffs/src/http.ts
+++ b/extensions/diffs/src/http.ts
@@ -2,6 +2,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { isLoopbackHost } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { createAuthRateLimiter, type AuthRateLimiter } from "openclaw/plugin-sdk/webhook-ingress";
 import type { PluginLogger } from "../api.js";
 import { resolveRequestClientIp } from "../runtime-api.js";
 import type { DiffArtifactStore } from "./store.js";
@@ -38,7 +39,14 @@ export function createDiffsHttpHandler(params: {
     allowRealIpFallback?: boolean;
   };
 }) {
-  const viewerFailureLimiter = new ViewerFailureLimiter();
+  const viewerFailureLimiter = createAuthRateLimiter({
+    maxAttempts: VIEWER_MAX_FAILURES_PER_WINDOW,
+    windowMs: VIEWER_FAILURE_WINDOW_MS,
+    lockoutMs: VIEWER_LOCKOUT_MS,
+    exemptLoopback: false,
+    pruneIntervalMs: 0,
+    maxEntries: VIEWER_LIMITER_MAX_KEYS,
+  });
 
   return async (req: IncomingMessage, res: ServerResponse): Promise<boolean> => {
     const parsed = parseRequestUrl(req.url);
@@ -243,7 +251,7 @@ function resolveViewerAccess(
 }
 
 function recordRemoteFailure(
-  limiter: ViewerFailureLimiter,
+  limiter: AuthRateLimiter,
   access: { remoteKey: string; localRequest: boolean },
 ): void {
   if (!access.localRequest) {
@@ -252,85 +260,10 @@ function recordRemoteFailure(
 }
 
 function resetRemoteFailures(
-  limiter: ViewerFailureLimiter,
+  limiter: AuthRateLimiter,
   access: { remoteKey: string; localRequest: boolean },
 ): void {
   if (!access.localRequest) {
     limiter.reset(access.remoteKey);
-  }
-}
-
-type RateLimitCheckResult = {
-  allowed: boolean;
-  retryAfterMs: number;
-};
-
-type ViewerFailureState = {
-  windowStartMs: number;
-  failures: number;
-  lockUntilMs: number;
-};
-
-class ViewerFailureLimiter {
-  private readonly failures = new Map<string, ViewerFailureState>();
-
-  check(key: string): RateLimitCheckResult {
-    this.prune();
-    const state = this.failures.get(key);
-    if (!state) {
-      return { allowed: true, retryAfterMs: 0 };
-    }
-    const now = Date.now();
-    if (state.lockUntilMs > now) {
-      return { allowed: false, retryAfterMs: state.lockUntilMs - now };
-    }
-    if (now - state.windowStartMs >= VIEWER_FAILURE_WINDOW_MS) {
-      this.failures.delete(key);
-      return { allowed: true, retryAfterMs: 0 };
-    }
-    return { allowed: true, retryAfterMs: 0 };
-  }
-
-  recordFailure(key: string): void {
-    this.prune();
-    const now = Date.now();
-    const current = this.failures.get(key);
-    const next =
-      !current || now - current.windowStartMs >= VIEWER_FAILURE_WINDOW_MS
-        ? {
-            windowStartMs: now,
-            failures: 1,
-            lockUntilMs: 0,
-          }
-        : {
-            ...current,
-            failures: current.failures + 1,
-          };
-    if (next.failures >= VIEWER_MAX_FAILURES_PER_WINDOW) {
-      next.lockUntilMs = now + VIEWER_LOCKOUT_MS;
-    }
-    this.failures.set(key, next);
-  }
-
-  reset(key: string): void {
-    this.failures.delete(key);
-  }
-
-  private prune(): void {
-    if (this.failures.size < VIEWER_LIMITER_MAX_KEYS) {
-      return;
-    }
-    const now = Date.now();
-    for (const [key, state] of this.failures) {
-      if (state.lockUntilMs <= now && now - state.windowStartMs >= VIEWER_FAILURE_WINDOW_MS) {
-        this.failures.delete(key);
-      }
-      if (this.failures.size < VIEWER_LIMITER_MAX_KEYS) {
-        return;
-      }
-    }
-    if (this.failures.size >= VIEWER_LIMITER_MAX_KEYS) {
-      this.failures.clear();
-    }
   }
 }

--- a/extensions/diffs/src/store.test.ts
+++ b/extensions/diffs/src/store.test.ts
@@ -310,6 +310,7 @@ describe("DiffArtifactStore", () => {
 });
 
 describe("createDiffsHttpHandler", () => {
+  const missingViewerPath = "/plugins/diffs/view/not-a-real-id/not-a-real-token";
   let store: DiffArtifactStore;
   let cleanupRootDir: () => Promise<void>;
 
@@ -331,6 +332,7 @@ describe("createDiffsHttpHandler", () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     await cleanupRootDir();
   });
 
@@ -511,7 +513,7 @@ describe("createDiffsHttpHandler", () => {
     expect(res.statusCode).toBe(expectedStatusCode);
   });
 
-  it("rate-limits repeated remote misses", async () => {
+  it("allows the at-capacity remote miss and blocks the next request", async () => {
     const handler = createDiffsHttpHandler({ store, allowRemoteViewer: true });
 
     for (let i = 0; i < 40; i++) {
@@ -519,7 +521,7 @@ describe("createDiffsHttpHandler", () => {
       await handler(
         remoteReq({
           method: "GET",
-          url: "/plugins/diffs/view/aaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          url: missingViewerPath,
         }),
         miss,
       );
@@ -530,11 +532,48 @@ describe("createDiffsHttpHandler", () => {
     await handler(
       remoteReq({
         method: "GET",
-        url: "/plugins/diffs/view/aaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        url: missingViewerPath,
       }),
       limited,
     );
     expect(limited.statusCode).toBe(429);
+  });
+
+  it("slides the remote failure window across the original window boundary", async () => {
+    vi.useFakeTimers();
+    const startedAt = new Date("2026-08-19T12:00:00Z").getTime();
+    vi.setSystemTime(startedAt);
+    const handler = createDiffsHttpHandler({ store, allowRemoteViewer: true });
+
+    const recordMisses = async (count: number) => {
+      for (let i = 0; i < count; i++) {
+        const miss = createMockServerResponse();
+        await handler(remoteReq({ method: "GET", url: missingViewerPath }), miss);
+        expect(miss.statusCode).toBe(404);
+      }
+    };
+
+    await recordMisses(20);
+    vi.setSystemTime(startedAt + 59_000);
+    await recordMisses(19);
+    vi.setSystemTime(startedAt + 61_000);
+    await recordMisses(1);
+    vi.setSystemTime(startedAt + 118_000);
+    await recordMisses(20);
+
+    const limited = createMockServerResponse();
+    await handler(remoteReq({ method: "GET", url: missingViewerPath }), limited);
+    expect(limited.statusCode).toBe(429);
+  });
+
+  it("keeps loopback viewer requests outside the remote failure limiter", async () => {
+    const handler = createDiffsHttpHandler({ store, allowRemoteViewer: true });
+
+    for (let i = 0; i < 41; i++) {
+      const miss = createMockServerResponse();
+      await handler(localReq({ method: "GET", url: missingViewerPath }), miss);
+      expect(miss.statusCode).toBe(404);
+    }
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

The Diffs remote viewer carried its own anchored-window failure limiter. At the 2,048-client capacity boundary, that implementation could clear the entire map, including active lockouts, so a sufficiently broad miss flood erased the protection it was meant to enforce.

## Why This Change Was Made

The viewer now uses the canonical `createAuthRateLimiter` through the public plugin SDK. It preserves the shipped Diffs contract—40 failures in 60 seconds, a 60-second lockout, and a 2,048-client cap—while keeping limiter calls restricted to non-loopback viewer requests.

| Behavior | Before | After | Impact |
| --- | --- | --- | --- |
| Failure window | 60-second window anchored to the first retained failure | Rolling 60-second window | Security tightening: recent failures remain counted across the old anchor boundary |
| Capacity handling | Cleared all entries when the 2,048-key map could not prune | Preserves active lockouts and fails closed until capacity is available | Security tightening: a client-identity flood cannot erase live lockouts |
| Remote threshold | 40th miss returns the ordinary not-found response; the next request is blocked | Unchanged | No threshold change |
| Loopback requests | Excluded before limiter checks and updates | Unchanged; the limiter itself is non-exempt but is called only for remote paths | Local viewer access cannot consume or hit the remote budget |
| Window / lockout / cap | 60 seconds / 60 seconds / 2,048 clients | Unchanged | No configuration or operator action |

The old local limiter and its duplicate state-management policy are removed.

## User Impact

Remote token-guess misses are now consistently throttled over a true rolling window, and capacity pressure fails closed instead of dropping active lockouts. Direct loopback viewer behavior and the documented threshold, window, and retry timing remain unchanged.

## Evidence

- Pre-fix regression: the cross-boundary sequence returned `404` where the rolling-window contract requires `429`; the same focused file passed 36/36 after the migration.
- Complete Diffs plugin suite: 12 files, 152 tests passed.
- `node scripts/check-changed.mjs`: passed all selected extension production/test typechecks, lint, formatting, boundary, dead-export, database-first, import-cycle, and guard lanes.
- Real HTTP behavior contract: exact 40th/41st remote boundary passed; a real 118-second rolling-window sequence passed; 41 direct loopback misses remained outside the limiter.
- Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +11/-78 (net -67). Tests: +42/-3 (net +39).
- AI-assisted: yes.
