### PR TITLE
fix(skills): keep workshop revisions atomic

### DIFF
--- a/docs/tools/skill-workshop.md
+++ b/docs/tools/skill-workshop.md
@@ -34,6 +34,11 @@ plugin, ClawHub, extra-root, managed, personal-agent, or system skills.
   critical findings block apply; warn-level findings remain visible but do not
   block it.
 - **Recoverable:** apply writes rollback metadata before touching live files.
+- **Revision atomic:** create and revise flush a complete immutable proposal
+  generation, publish it with an atomic rename, then sync its parent directory
+  where supported before publishing the SQLite record and event together.
+  Process interruption exposes either the complete previous generation or the
+  complete new one.
 - **Consistent surfaces:** chat, CLI, and Gateway all call the same service.
 
 ## Lifecycle
@@ -430,19 +435,34 @@ proposals.
 <OPENCLAW_STATE_DIR>/
   state/openclaw.sqlite
   skill-workshop/proposals/<proposal-id>/
-    PROPOSAL.md
-    assets/
-    examples/
-    references/
-    scripts/
-    templates/
+    generations/<generation-id>/
+      PROPOSAL.md
+      assets/
+      examples/
+      references/
+      scripts/
+      templates/
 ```
 
 Default state directory: `~/.openclaw`.
 
-- `state/openclaw.sqlite`: canonical proposal records, lifecycle status, origin attribution, and apply rollback metadata.
-- `PROPOSAL.md`: pending skill proposal.
-- Support files remain beside `PROPOSAL.md` so operators can review the proposed skill as a normal directory.
+- `state/openclaw.sqlite`: canonical proposal records, the active generation
+  reference, lifecycle status, origin attribution, and apply rollback metadata.
+- Each generation contains one `PROPOSAL.md` and all of that revision's support
+  files. Revision publication never overwrites the active generation in place.
+- Generation files are flushed before publication. After the complete bundle is
+  renamed into place, OpenClaw syncs the `generations/` parent directory where
+  the platform supports directory flushing, before committing SQLite state.
+  Platforms that report directory synchronization as unsupported retain atomic
+  rename and process-interruption safety, but do not claim power-loss durability
+  for that directory entry.
+- Support files remain beside their generation's `PROPOSAL.md` so operators can
+  review the proposed skill as a normal directory.
+
+Proposals created by older releases can still reference the earlier root-level
+`PROPOSAL.md` layout. The stored record identifies that bundle directly; the
+next successful revision moves the proposal onto the generation layout and
+retires the previous bundle.
 
 `openclaw doctor --fix` imports the previous `proposals.json`, `proposal.json`, and
 `rollback.json` metadata into SQLite after verifying each proposal, then removes

--- a/src/agents/tools/skill-workshop-tool-helpers.ts
+++ b/src/agents/tools/skill-workshop-tool-helpers.ts
@@ -2,6 +2,7 @@ import {
   inspectSkillProposal,
   resolvePendingSkillProposal,
 } from "../../skills/workshop/service.js";
+import { PROPOSAL_DRAFT_FILE } from "../../skills/workshop/store-record.js";
 import type {
   SkillProposalReadResult,
   SkillProposalRecord,
@@ -115,7 +116,7 @@ export function proposalResult(
       kind: proposal.record.kind,
       skillName: proposal.record.target.skillName,
       skillKey: proposal.record.target.skillKey,
-      proposalFile: proposal.record.draftFile,
+      proposalFile: PROPOSAL_DRAFT_FILE,
       supportFileCount: proposal.record.supportFiles?.length ?? 0,
       targetSkillFile: proposal.record.target.skillFile,
       scanState: proposal.record.scan.state,

--- a/src/agents/tools/skill-workshop-tool-presentation.ts
+++ b/src/agents/tools/skill-workshop-tool-presentation.ts
@@ -1,5 +1,6 @@
 import { stableStringify } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { PROPOSAL_DRAFT_FILE } from "../../skills/workshop/store-record.js";
 import type {
   SkillProposalEvaluation,
   SkillProposalManifestEntry,
@@ -125,9 +126,9 @@ export function resolveProposalInspectArtifact(
   proposal: SkillProposalReadResult,
   artifactPath?: string,
 ): SkillProposalInspectArtifact | undefined {
-  if (!artifactPath || artifactPath === proposal.record.draftFile) {
+  if (!artifactPath || artifactPath === PROPOSAL_DRAFT_FILE) {
     return {
-      path: proposal.record.draftFile,
+      path: PROPOSAL_DRAFT_FILE,
       content: proposal.content,
       sizeBytes: Buffer.byteLength(proposal.content),
     };
@@ -150,7 +151,7 @@ export function formatProposalInspect(
   const evaluation = proposal.record.evaluation;
   const evaluationLines = evaluation ? [formatProposalEvaluation(evaluation)] : [];
   const artifacts = [
-    { path: proposal.record.draftFile, sizeBytes: Buffer.byteLength(proposal.content) },
+    { path: PROPOSAL_DRAFT_FILE, sizeBytes: Buffer.byteLength(proposal.content) },
     ...(proposal.record.supportFiles ?? []).map((file) => ({
       path: file.path,
       sizeBytes: file.sizeBytes,

--- a/src/agents/tools/skill-workshop-tool.list.test.ts
+++ b/src/agents/tools/skill-workshop-tool.list.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeWorkspaceSkills } from "../../skills/test-support/e2e-test-helpers.js";
+import { readSkillProposalRecord } from "../../skills/workshop/store.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -66,8 +67,12 @@ describe("skill_workshop list", () => {
       proposal_content: "# Missing Draft\n",
     });
     const proposalId = (created.details as { id: string }).id;
+    const record = await readSkillProposalRecord(proposalId, { env: testState.env });
+    if (!record) {
+      throw new Error(`expected stored proposal ${proposalId}`);
+    }
     await fs.rm(
-      path.join(testState.stateDir, "skill-workshop", "proposals", proposalId, "PROPOSAL.md"),
+      path.join(testState.stateDir, "skill-workshop", "proposals", proposalId, record.draftFile),
     );
 
     const listed = await tool.execute("call-list", { action: "list" });

--- a/src/agents/tools/skill-workshop-tool.test.ts
+++ b/src/agents/tools/skill-workshop-tool.test.ts
@@ -27,6 +27,25 @@ const tempDirs = createTrackedTempDirs();
 let testState: OpenClawTestState;
 let stateDir = "";
 
+async function proposalArtifactPath(
+  proposalId: string,
+  relativePath: string,
+  options: { stateDir?: string; env?: NodeJS.ProcessEnv } = {},
+): Promise<string> {
+  const record = await readSkillProposalRecord(proposalId, options.env ? { env: options.env } : {});
+  if (!record) {
+    throw new Error(`expected stored proposal ${proposalId}`);
+  }
+  return path.join(
+    options.stateDir ?? stateDir,
+    "skill-workshop",
+    "proposals",
+    proposalId,
+    path.dirname(record.draftFile),
+    relativePath,
+  );
+}
+
 beforeEach(async () => {
   testState = await createOpenClawTestState({
     layout: "state-only",
@@ -312,7 +331,10 @@ describe("skill_workshop tool", () => {
 
     await expect(
       fs.access(
-        path.join(isolatedStateDir, "skill-workshop", "proposals", proposalId, "PROPOSAL.md"),
+        await proposalArtifactPath(proposalId, "PROPOSAL.md", {
+          stateDir: isolatedStateDir,
+          env,
+        }),
       ),
     ).resolves.toBeUndefined();
     await expect(
@@ -521,6 +543,7 @@ describe("skill_workshop tool", () => {
       status: "pending",
       kind: "create",
       skillKey: "weather-planner",
+      proposalFile: "PROPOSAL.md",
       scanState: "clean",
       supportFileCount: 1,
     });
@@ -529,27 +552,13 @@ describe("skill_workshop tool", () => {
     );
     await expect(
       fs.readFile(
-        path.join(
-          stateDir,
-          "skill-workshop",
-          "proposals",
-          (result.details as { id: string }).id,
-          "PROPOSAL.md",
-        ),
+        await proposalArtifactPath((result.details as { id: string }).id, "PROPOSAL.md"),
         "utf8",
       ),
     ).resolves.toContain("status: proposal");
     await expect(
       fs
-        .readFile(
-          path.join(
-            stateDir,
-            "skill-workshop",
-            "proposals",
-            (result.details as { id: string }).id,
-            "PROPOSAL.md",
-          ),
-        )
+        .readFile(await proposalArtifactPath((result.details as { id: string }).id, "PROPOSAL.md"))
         .then((buffer) => buffer.at(-1)),
     ).resolves.toBe(0x0a);
     await expect(
@@ -563,14 +572,7 @@ describe("skill_workshop tool", () => {
     });
     await expect(
       fs.readFile(
-        path.join(
-          stateDir,
-          "skill-workshop",
-          "proposals",
-          (result.details as { id: string }).id,
-          "references",
-          "weather.md",
-        ),
+        await proposalArtifactPath((result.details as { id: string }).id, "references/weather.md"),
         "utf8",
       ),
     ).resolves.toContain("Use weather API details.");
@@ -615,13 +617,7 @@ describe("skill_workshop tool", () => {
     );
     await expect(
       fs.readFile(
-        path.join(
-          stateDir,
-          "skill-workshop",
-          "proposals",
-          (result.details as { id: string }).id,
-          "PROPOSAL.md",
-        ),
+        await proposalArtifactPath((result.details as { id: string }).id, "PROPOSAL.md"),
         "utf8",
       ),
     ).resolves.toContain('version: "v2"');
@@ -733,15 +729,7 @@ describe("skill_workshop tool", () => {
 
     await expect(
       fs
-        .readFile(
-          path.join(
-            stateDir,
-            "skill-workshop",
-            "proposals",
-            (result.details as { id: string }).id,
-            "PROPOSAL.md",
-          ),
-        )
+        .readFile(await proposalArtifactPath((result.details as { id: string }).id, "PROPOSAL.md"))
         .then((buffer) => buffer.at(-1)),
     ).resolves.toBe(0x0a);
   });

--- a/src/agents/tools/skill-workshop-tool.ts
+++ b/src/agents/tools/skill-workshop-tool.ts
@@ -24,6 +24,7 @@ import {
   reviseSkillProposal,
   SkillProposalStaleTargetError,
 } from "../../skills/workshop/service.js";
+import { PROPOSAL_DRAFT_FILE } from "../../skills/workshop/store-record.js";
 import type {
   SkillProposalOrigin,
   SkillProposalReadResult,
@@ -339,7 +340,7 @@ export function createSkillWorkshopTool(options: SkillWorkshopToolOptions): AnyA
         const artifact = resolveProposalInspectArtifact(proposal, artifactPath);
         if (!artifact) {
           const available = [
-            proposal.record.draftFile,
+            PROPOSAL_DRAFT_FILE,
             ...(proposal.record.supportFiles ?? []).map((file) => file.path),
           ];
           throw new ToolInputError(

--- a/src/gateway/server-methods/skills.proposals.test.ts
+++ b/src/gateway/server-methods/skills.proposals.test.ts
@@ -41,7 +41,10 @@ vi.mock("../../agents/agent-scope.js", () => ({
 
 vi.mock("../../skills/lifecycle/clawhub.js", () => ({
   installSkillFromClawHub: vi.fn(),
+  readClawHubSkillsLockfileStatusSync: vi.fn(() => ({ kind: "missing" })),
   readLocalSkillCardContentSync: vi.fn(),
+  resolveClawHubSkillStatusLinkSync: vi.fn(),
+  resolveLocalSkillCardStatusSync: vi.fn(),
   searchSkillsFromClawHub: vi.fn(),
   updateSkillsFromClawHub: vi.fn(),
 }));
@@ -120,7 +123,11 @@ describe("skills proposal gateway handlers", () => {
       outcomes: [],
     };
     mocks.evaluateSkillProposal.mockResolvedValue({
-      record: { id: "proposal-1", evaluation },
+      record: {
+        id: "proposal-1",
+        draftFile: "generations/123e4567-e89b-42d3-a456-426614174000/PROPOSAL.md",
+        evaluation,
+      },
       evaluation,
     });
     mocks.listSkillProposalEvents.mockReset();
@@ -151,9 +158,10 @@ describe("skills proposal gateway handlers", () => {
     });
     expect(create.ok).toBe(true);
     const created = create.response as {
-      record: { id: string; supportFiles?: Array<{ path: string }> };
+      record: { id: string; draftFile: string; supportFiles?: Array<{ path: string }> };
     };
     expect(created.record.id).toMatch(/^weather-planner-/);
+    expect(created.record.draftFile).toBe("PROPOSAL.md");
     expect(created.record.supportFiles?.[0]?.path).toBe("references/weather.md");
     expect(
       readSkillProposalEvents({
@@ -174,6 +182,9 @@ describe("skills proposal gateway handlers", () => {
     expect(inspect.ok).toBe(true);
     const reviewedRevisionHash = (inspect.response as { revisionHash: string }).revisionHash;
     expect((inspect.response as { content: string }).content).toContain("status: proposal");
+    expect((inspect.response as { record: { draftFile: string } }).record.draftFile).toBe(
+      "PROPOSAL.md",
+    );
     expect(
       (
         inspect.response as {
@@ -196,10 +207,15 @@ describe("skills proposal gateway handlers", () => {
     expect(revise.ok).toBe(true);
     const revisedRevisionHash = (revise.response as { revisionHash: string }).revisionHash;
     expect(
-      (revise.response as { record: { id: string; proposedVersion: string } }).record,
+      (
+        revise.response as {
+          record: { id: string; proposedVersion: string; draftFile: string };
+        }
+      ).record,
     ).toMatchObject({
       id: created.record.id,
       proposedVersion: "v2",
+      draftFile: "PROPOSAL.md",
     });
 
     const apply = await callHandler("skills.proposals.apply", {
@@ -207,6 +223,9 @@ describe("skills proposal gateway handlers", () => {
       expectedRevisionHash: revisedRevisionHash,
     });
     expect(apply.ok).toBe(true);
+    expect((apply.response as { record: { draftFile: string } }).record.draftFile).toBe(
+      "PROPOSAL.md",
+    );
     await expect(
       fs.readFile(path.join(mocks.workspaceDir, "skills", "weather-planner", "SKILL.md"), "utf8"),
     ).resolves.toContain("Use current weather and alerts.");
@@ -216,6 +235,16 @@ describe("skills proposal gateway handlers", () => {
         "utf8",
       ),
     ).resolves.toContain("Use current weather");
+
+    const update = await callHandler("skills.proposals.update", {
+      skillName: "weather-planner",
+      content: "# Weather Planner\n\nUse weather, alerts, and timing.\n",
+    });
+    expect(update.error).toBeUndefined();
+    expect(update.ok).toBe(true);
+    expect((update.response as { record: { draftFile: string } }).record.draftFile).toBe(
+      "PROPOSAL.md",
+    );
   });
 
   it("marks manually created create targets stale before list and inspect responses", async () => {
@@ -318,7 +347,10 @@ describe("skills proposal gateway handlers", () => {
     });
     expect(evaluate).toMatchObject({
       ok: true,
-      response: { evaluation: { id: "evaluation-1", trigger: "manual" } },
+      response: {
+        record: { draftFile: "PROPOSAL.md" },
+        evaluation: { id: "evaluation-1", trigger: "manual" },
+      },
     });
     expect(mocks.evaluateSkillProposal).toHaveBeenCalledWith({
       workspaceDir: mocks.workspaceDir,
@@ -351,7 +383,11 @@ describe("skills proposal gateway handlers", () => {
   it("passes expected revision hashes through proposal mutations", async () => {
     const expectedRevisionHash = "e".repeat(64);
     const correlationId = "correlation-mutation-1";
-    const record = { id: "proposal-1", draftHash: "d".repeat(64) };
+    const record = {
+      id: "proposal-1",
+      draftFile: "generations/123e4567-e89b-42d3-a456-426614174000/PROPOSAL.md",
+      draftHash: "d".repeat(64),
+    };
     mocks.reviseSkillProposal.mockResolvedValueOnce({
       record,
       revisionHash: expectedRevisionHash,
@@ -361,23 +397,23 @@ describe("skills proposal gateway handlers", () => {
     mocks.rejectSkillProposal.mockResolvedValueOnce(record);
     mocks.quarantineSkillProposal.mockResolvedValueOnce(record);
 
-    await callHandler("skills.proposals.revise", {
+    const revise = await callHandler("skills.proposals.revise", {
       proposalId: "proposal-1",
       expectedRevisionHash,
       correlationId,
       supportFiles: [{ path: "references/example.md", content: "Updated example.\n" }],
     });
-    await callHandler("skills.proposals.apply", {
+    const apply = await callHandler("skills.proposals.apply", {
       proposalId: "proposal-1",
       expectedRevisionHash,
       correlationId,
     });
-    await callHandler("skills.proposals.reject", {
+    const reject = await callHandler("skills.proposals.reject", {
       proposalId: "proposal-1",
       expectedRevisionHash,
       correlationId,
     });
-    await callHandler("skills.proposals.quarantine", {
+    const quarantine = await callHandler("skills.proposals.quarantine", {
       proposalId: "proposal-1",
       expectedRevisionHash,
       correlationId,
@@ -398,6 +434,10 @@ describe("skills proposal gateway handlers", () => {
         }),
       );
     }
+    expect(revise.response).toMatchObject({ record: { draftFile: "PROPOSAL.md" } });
+    expect(apply.response).toMatchObject({ record: { draftFile: "PROPOSAL.md" } });
+    expect(reject.response).toMatchObject({ draftFile: "PROPOSAL.md" });
+    expect(quarantine.response).toMatchObject({ draftFile: "PROPOSAL.md" });
   });
 
   it.each([

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -70,6 +70,8 @@ import {
   rejectSkillProposal,
   reviseSkillProposal,
 } from "../../skills/workshop/service.js";
+import { PROPOSAL_DRAFT_FILE } from "../../skills/workshop/store-record.js";
+import type { SkillProposalReadResult, SkillProposalRecord } from "../../skills/workshop/types.js";
 import { skillProposalHistoryHandlers } from "./skills-proposal-history.js";
 import { skillsUploadHandlers } from "./skills-upload.js";
 import {
@@ -85,6 +87,27 @@ type ClawHubInstallResult = Awaited<ReturnType<typeof installSkillFromClawHub>>;
 type ClawHubInstallParams = Parameters<typeof installSkillFromClawHub>[0];
 
 const clawHubInstallsInFlight = new Map<string, Promise<ClawHubInstallResult>>();
+
+function projectGatewaySkillProposalRecord(record: SkillProposalRecord): SkillProposalRecord {
+  return record.draftFile === PROPOSAL_DRAFT_FILE
+    ? record
+    : { ...record, draftFile: PROPOSAL_DRAFT_FILE };
+}
+
+function projectGatewaySkillProposalResult<T extends { record: SkillProposalRecord }>(result: T) {
+  return { ...result, record: projectGatewaySkillProposalRecord(result.record) };
+}
+
+function projectGatewaySkillProposalReadResult(proposal: SkillProposalReadResult) {
+  return {
+    ...projectGatewaySkillProposalResult(proposal),
+    ...(proposal.supportFiles
+      ? {
+          supportFiles: proposal.supportFiles.map(({ path, content }) => ({ path, content })),
+        }
+      : {}),
+  };
+}
 
 function installClawHubSkillDeduped(params: ClawHubInstallParams): Promise<ClawHubInstallResult> {
   // A WebSocket can disappear after the request reached the Gateway. Keep one
@@ -440,14 +463,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
           );
           return SKILL_PROPOSAL_RESPONSE_HANDLED;
         }
-        return {
-          ...proposal,
-          ...(proposal.supportFiles
-            ? {
-                supportFiles: proposal.supportFiles.map(({ path, content }) => ({ path, content })),
-              }
-            : {}),
-        };
+        return projectGatewaySkillProposalReadResult(proposal);
       },
     });
   },
@@ -467,7 +483,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
           expectedRevisionHash: parsedParams.expectedRevisionHash,
           correlationId: parsedParams.correlationId,
           trigger: "manual",
-        }),
+        }).then(projectGatewaySkillProposalResult),
     });
   },
   "skills.proposals.create": async ({ params, respond, context }) => {
@@ -490,7 +506,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
           createdBy: "gateway",
           goal: parsedParams.goal,
           evidence: parsedParams.evidence,
-        }),
+        }).then(projectGatewaySkillProposalReadResult),
     });
   },
   "skills.proposals.update": async ({ params, respond, context }) => {
@@ -513,7 +529,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
           createdBy: "gateway",
           goal: parsedParams.goal,
           evidence: parsedParams.evidence,
-        }),
+        }).then(projectGatewaySkillProposalReadResult),
     });
   },
   "skills.proposals.revise": async ({ params, respond, context }) => {
@@ -537,7 +553,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
           description: parsedParams.description,
           goal: parsedParams.goal,
           evidence: parsedParams.evidence,
-        }),
+        }).then(projectGatewaySkillProposalReadResult),
     });
   },
   "skills.proposals.requestRevision": async (opts) => {
@@ -611,7 +627,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
           expectedRevisionHash: parsedParams.expectedRevisionHash,
           correlationId: parsedParams.correlationId,
           reason: parsedParams.reason,
-        }),
+        }).then(projectGatewaySkillProposalResult),
     });
   },
   "skills.proposals.reject": async ({ params, respond, context }) => {
@@ -630,7 +646,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
           expectedRevisionHash: parsedParams.expectedRevisionHash,
           correlationId: parsedParams.correlationId,
           reason: parsedParams.reason,
-        }),
+        }).then(projectGatewaySkillProposalRecord),
     });
   },
   "skills.proposals.quarantine": async ({ params, respond, context }) => {
@@ -649,7 +665,7 @@ export const skillsHandlers: GatewayRequestHandlers = {
           expectedRevisionHash: parsedParams.expectedRevisionHash,
           correlationId: parsedParams.correlationId,
           reason: parsedParams.reason,
-        }),
+        }).then(projectGatewaySkillProposalRecord),
     });
   },
   "skills.install": async ({ params, respond, context }) => {

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -440,7 +440,14 @@ export const skillsHandlers: GatewayRequestHandlers = {
           );
           return SKILL_PROPOSAL_RESPONSE_HANDLED;
         }
-        return proposal;
+        return {
+          ...proposal,
+          ...(proposal.supportFiles
+            ? {
+                supportFiles: proposal.supportFiles.map(({ path, content }) => ({ path, content })),
+              }
+            : {}),
+        };
       },
     });
   },

--- a/src/skills/workshop/apply-transition.ts
+++ b/src/skills/workshop/apply-transition.ts
@@ -70,18 +70,12 @@ const SKILL_PROPOSAL_APPLY_TRANSITIONS: Readonly<
   stale: {},
 };
 
-type PreparedSkillProposalSupportFile = SkillProposalSupportFile & { content: string };
-
 export type SkillProposalApplyTransitionDependencies = {
   assertExpectedRevisionHash: (actual: string, expected?: string) => void;
   evaluateSkillProposal: (
     input: SkillProposalEvaluateInput,
   ) => Promise<SkillProposalEvaluateResult>;
   isCreateTargetConflict: (error: unknown) => boolean;
-  readProposalSupportFiles: (
-    record: SkillProposalRecord,
-    options?: SkillWorkshopStoreOptions,
-  ) => Promise<PreparedSkillProposalSupportFile[]>;
   readRequiredProposal: (
     proposalId: string,
     workspaceDir?: string,
@@ -213,10 +207,7 @@ export async function applySkillProposalTransition(
       if (hashSkillProposalContent(content) !== record.draftHash) {
         throw new Error("Proposal draft changed without updating proposal metadata.");
       }
-      const supportFiles = await dependencies.readProposalSupportFiles(
-        record,
-        storeOptions(input.env),
-      );
+      const supportFiles = read.supportFiles ?? [];
       if (!readProposalFrontmatter(content)) {
         throw new Error("Proposal draft must include proposal frontmatter.");
       }
@@ -376,7 +367,7 @@ export async function applySkillProposalTransition(
       });
       return {
         result: { record: applied, targetSkillFile: record.target.skillFile },
-        ...(commit.state === "committed" && commit.event ? { event: commit.event } : {}),
+        event: commit.event,
         skillChange: shouldDispatchSkillChange
           ? { before: beforeSkill, after: afterSkill }
           : undefined,
@@ -386,14 +377,12 @@ export async function applySkillProposalTransition(
   );
 
   const result = await withSkillProposalLifecycleDispatch(input, application);
-  if (result.event) {
-    await dispatchSkillProposalChanged({
-      event: result.event,
-      record: result.result.record,
-      workspaceDir: input.workspaceDir,
-      ...(input.agentId ? { agentId: input.agentId } : {}),
-    });
-  }
+  await dispatchSkillProposalChanged({
+    event: result.event,
+    record: result.result.record,
+    workspaceDir: input.workspaceDir,
+    ...(input.agentId ? { agentId: input.agentId } : {}),
+  });
   if (result.skillChange) {
     await dispatchCommittedSkillChangeBestEffort({
       action: result.result.record.kind === "create" ? "created" : "updated",
@@ -485,7 +474,7 @@ export function transitionPendingSkillProposalToStale(params: {
     store: storeOptions(params.input.env),
     operationLabel: "skill-workshop.stale.commit",
   });
-  if (commit.state !== "committed" || !commit.event) {
+  if (commit.state !== "committed") {
     throw new Error("Failed to record stale Skill Workshop proposal.");
   }
   return { record: stale, event: commit.event };
@@ -553,7 +542,7 @@ async function quarantineSkillProposalAfterScan(params: {
     store: storeOptions(params.input.env),
     operationLabel: "skill-workshop.quarantine.commit",
   });
-  if (commit.state !== "committed" || !commit.event) {
+  if (commit.state !== "committed") {
     throw new Error("Failed to record quarantined Skill Workshop proposal.");
   }
   throw new SkillProposalLifecycleError(
@@ -638,7 +627,7 @@ async function recoverAfterApplyCommitFailure(params: {
     store: storeOptions(params.env),
   });
   if (committed) {
-    return committed.event ?? null;
+    return committed.event;
   }
   const authoritative = readStoredProposal(params.expected.id, storeOptions(params.env));
   if (authoritative?.record.status === "applied") {

--- a/src/skills/workshop/collection-create-proposal.ts
+++ b/src/skills/workshop/collection-create-proposal.ts
@@ -117,14 +117,12 @@ export async function promoteCollectionCreateProposal(params: {
   if (commit.state !== "committed") {
     throw new Error(`Collection create proposal changed before apply: ${record.id}`);
   }
-  if (commit.event) {
-    await dispatchSkillProposalChanged({
-      event: commit.event,
-      record: applied,
-      workspaceDir: params.workspaceDir,
-      ...(record.origin?.agentId ? { agentId: record.origin.agentId } : {}),
-    });
-  }
+  await dispatchSkillProposalChanged({
+    event: commit.event,
+    record: applied,
+    workspaceDir: params.workspaceDir,
+    ...(record.origin?.agentId ? { agentId: record.origin.agentId } : {}),
+  });
   return applied;
 }
 
@@ -163,7 +161,7 @@ export async function retireCollectionCreateProposals(params: {
         operationLabel: "skill-collection.proposal.retire",
       });
       // Already-promoted proposals fail the expected-record guard and stay applied.
-      if (commit.state === "committed" && commit.event) {
+      if (commit.state === "committed") {
         await dispatchSkillProposalChanged({
           event: commit.event,
           record: rejected,

--- a/src/skills/workshop/collection-reconcile.test.ts
+++ b/src/skills/workshop/collection-reconcile.test.ts
@@ -625,30 +625,38 @@ describe("skill collection reconciliation", () => {
       { env: testState.env },
     );
     await acquired;
-    const startedAt = performance.now();
-    const clockSpy = vi
-      .spyOn(performance, "now")
-      .mockReturnValueOnce(startedAt)
-      .mockReturnValueOnce(startedAt + 5_001)
-      .mockReturnValueOnce(startedAt)
-      .mockReturnValue(startedAt + 5_001);
+    const expectCollectionLeaseTimeout = async (operation: () => Promise<unknown>) => {
+      const startedAt = performance.now();
+      const clockSpy = vi
+        .spyOn(performance, "now")
+        // Let the canonical bundle read acquire and release its target lease,
+        // then advance only the nested collection-lease acquisition past its budget.
+        .mockReturnValueOnce(startedAt)
+        .mockReturnValueOnce(startedAt)
+        .mockReturnValueOnce(startedAt)
+        .mockReturnValueOnce(startedAt)
+        .mockReturnValue(startedAt + 5_001);
+      try {
+        await expect(operation()).rejects.toMatchObject({
+          code: "OPENCLAW_STATE_LEASE_TIMEOUT",
+        });
+      } finally {
+        clockSpy.mockRestore();
+      }
+    };
 
     try {
-      await Promise.all([
-        expect(listSkillProposals({ workspaceDir, env: testState.env })).rejects.toMatchObject({
-          code: "OPENCLAW_STATE_LEASE_TIMEOUT",
-        }),
-        expect(
-          inspectSkillProposal(proposal.record.id, {
+      await expectCollectionLeaseTimeout(
+        async () => await listSkillProposals({ workspaceDir, env: testState.env }),
+      );
+      await expectCollectionLeaseTimeout(
+        async () =>
+          await inspectSkillProposal(proposal.record.id, {
             workspaceDir,
             env: testState.env,
           }),
-        ).rejects.toMatchObject({
-          code: "OPENCLAW_STATE_LEASE_TIMEOUT",
-        }),
-      ]);
+      );
     } finally {
-      clockSpy.mockRestore();
       releaseLock?.();
       await heldLock;
     }

--- a/src/skills/workshop/proposal-bundle.ts
+++ b/src/skills/workshop/proposal-bundle.ts
@@ -6,8 +6,7 @@ import type {
   PluginHookSkillBundleSnapshot,
 } from "../../plugins/hook-types.js";
 import { stripProposalFrontmatterForSkill } from "./frontmatter.js";
-import type { PreparedSkillProposalSupportFile } from "./store.js";
-import type { SkillProposalReadResult } from "./types.js";
+import type { PreparedSkillProposalSupportFile, SkillProposalReadResult } from "./types.js";
 
 const MAX_EVALUATION_FILES = 256;
 const MAX_EVALUATION_FILE_BYTES = 1024 * 1024;

--- a/src/skills/workshop/proposal-draft.ts
+++ b/src/skills/workshop/proposal-draft.ts
@@ -13,9 +13,12 @@ import {
   hashSkillProposalContent,
   MAX_PROPOSAL_SUPPORT_FILES,
   prepareSkillProposalSupportFiles,
-  type PreparedSkillProposalSupportFile,
 } from "./store.js";
-import type { SkillProposalScan, SkillProposalSupportFileInput } from "./types.js";
+import type {
+  PreparedSkillProposalSupportFile,
+  SkillProposalScan,
+  SkillProposalSupportFileInput,
+} from "./types.js";
 
 const MAX_PROPOSAL_DRAFT_BYTES = 1024 * 1024;
 const MAX_PROPOSAL_DIRECTORY_ENTRIES = MAX_PROPOSAL_SUPPORT_FILES * 4;

--- a/src/skills/workshop/proposal-generation.ts
+++ b/src/skills/workshop/proposal-generation.ts
@@ -60,14 +60,13 @@ export async function stageSkillProposalGeneration(params: {
   const generationDir = path.join(generationsDir, generationId);
   try {
     await stateRoot.mkdir(stagingDir);
-    await stateRoot.create(path.join(stagingDir, PROPOSAL_DRAFT_FILE), params.content, {
-      encoding: "utf8",
-    });
+    await createDurableGenerationFile(
+      stateRoot,
+      path.join(stagingDir, PROPOSAL_DRAFT_FILE),
+      params.content,
+    );
     for (const file of params.supportFiles ?? []) {
-      await stateRoot.create(path.join(stagingDir, file.path), file.content, {
-        encoding: "utf8",
-        mkdir: true,
-      });
+      await createDurableGenerationFile(stateRoot, path.join(stagingDir, file.path), file.content);
     }
     // The record only names the destination after this same-filesystem move, so
     // readers can never observe a partially populated generation.
@@ -77,6 +76,20 @@ export async function stageSkillProposalGeneration(params: {
     await removeGenerationPath(stateDir, stagingDir).catch(() => undefined);
     await removeGenerationPath(stateDir, generationDir).catch(() => undefined);
     throw error;
+  }
+}
+
+async function createDurableGenerationFile(
+  stateRoot: Awaited<ReturnType<typeof root>>,
+  relativePath: string,
+  content: string,
+): Promise<void> {
+  await stateRoot.create(relativePath, content, { encoding: "utf8", mkdir: true });
+  const opened = await stateRoot.openWritable(relativePath, { writeMode: "update" });
+  try {
+    await opened.handle.sync();
+  } finally {
+    await opened.handle.close();
   }
 }
 

--- a/src/skills/workshop/proposal-generation.ts
+++ b/src/skills/workshop/proposal-generation.ts
@@ -1,0 +1,161 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { resolveStateDir } from "../../config/paths.js";
+import { syncDirectoryIfSupported } from "../../infra/directory-durability.js";
+import { removePathWithinRoot } from "../../infra/fs-safe-remove.js";
+import { FsSafeError, root } from "../../infra/fs-safe.js";
+import { assertProposalId, PROPOSAL_DRAFT_FILE } from "./store-record.js";
+import type { SkillWorkshopStoreOptions } from "./store-sqlite-schema.js";
+import type {
+  PreparedSkillProposalSupportFile,
+  SkillProposalDraftFile,
+  SkillProposalRecord,
+} from "./types.js";
+
+const WORKSHOP_REL_DIR = "skill-workshop";
+const PROPOSALS_REL_DIR = path.join(WORKSHOP_REL_DIR, "proposals");
+const PROPOSAL_GENERATIONS_REL_DIR = "generations";
+const GENERATION_DRAFT_PATTERN =
+  /^generations\/([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\/PROPOSAL\.md$/u;
+
+export function resolveSkillWorkshopStateDir(options: SkillWorkshopStoreOptions = {}): string {
+  return path.resolve(options.stateDir ?? resolveStateDir(options.env));
+}
+
+function proposalRelativeDir(proposalId: string): string {
+  assertProposalId(proposalId);
+  return path.join(PROPOSALS_REL_DIR, proposalId);
+}
+
+export function createSkillProposalGenerationDraftFile(): SkillProposalDraftFile {
+  return `${PROPOSAL_GENERATIONS_REL_DIR}/${randomUUID()}/${PROPOSAL_DRAFT_FILE}`;
+}
+
+export function proposalBundleRelativePath(
+  record: SkillProposalRecord,
+  relativePath: string,
+): string {
+  return path.join(proposalRelativeDir(record.id), path.dirname(record.draftFile), relativePath);
+}
+
+export async function stageSkillProposalGeneration(params: {
+  record: SkillProposalRecord;
+  content: string;
+  supportFiles?: readonly PreparedSkillProposalSupportFile[];
+  store?: SkillWorkshopStoreOptions;
+}): Promise<void> {
+  const generationId = proposalGenerationId(params.record.draftFile);
+  if (!generationId) {
+    throw new Error("Revised Skill Workshop proposals require a generation draft path.");
+  }
+  const stateDir = resolveSkillWorkshopStateDir(params.store);
+  const stateRoot = await root(stateDir);
+  const proposalDir = proposalRelativeDir(params.record.id);
+  const stagingDir = path.join(
+    proposalDir,
+    PROPOSAL_GENERATIONS_REL_DIR,
+    `.staging-${generationId}`,
+  );
+  const generationsDir = path.join(proposalDir, PROPOSAL_GENERATIONS_REL_DIR);
+  const generationDir = path.join(generationsDir, generationId);
+  try {
+    await stateRoot.mkdir(stagingDir);
+    await stateRoot.create(path.join(stagingDir, PROPOSAL_DRAFT_FILE), params.content, {
+      encoding: "utf8",
+    });
+    for (const file of params.supportFiles ?? []) {
+      await stateRoot.create(path.join(stagingDir, file.path), file.content, {
+        encoding: "utf8",
+        mkdir: true,
+      });
+    }
+    // The record only names the destination after this same-filesystem move, so
+    // readers can never observe a partially populated generation.
+    await stateRoot.move(stagingDir, generationDir, { overwrite: true });
+    await syncDirectoryIfSupported(path.join(stateDir, generationsDir));
+  } catch (error) {
+    await removeGenerationPath(stateDir, stagingDir).catch(() => undefined);
+    await removeGenerationPath(stateDir, generationDir).catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function discardSkillProposalGeneration(
+  record: SkillProposalRecord,
+  store?: SkillWorkshopStoreOptions,
+): Promise<void> {
+  const generationId = proposalGenerationId(record.draftFile);
+  if (!generationId) {
+    return;
+  }
+  await removeGenerationPath(
+    resolveSkillWorkshopStateDir(store),
+    path.join(proposalRelativeDir(record.id), PROPOSAL_GENERATIONS_REL_DIR, generationId),
+  );
+}
+
+/** Removes generations left unowned by a pre-commit crash. Caller holds the target lease. */
+export async function cleanupSkillProposalGenerations(
+  record: SkillProposalRecord,
+  store?: SkillWorkshopStoreOptions,
+): Promise<void> {
+  const stateDir = resolveSkillWorkshopStateDir(store);
+  const stateRoot = await root(stateDir);
+  const proposalDir = proposalRelativeDir(record.id);
+  const generationsDir = path.join(proposalDir, PROPOSAL_GENERATIONS_REL_DIR);
+  let entries: string[];
+  try {
+    entries = await stateRoot.list(generationsDir);
+  } catch (error) {
+    if (error instanceof FsSafeError && error.code === "not-found") {
+      return;
+    }
+    throw error;
+  }
+  const activeGenerationId = proposalGenerationId(record.draftFile);
+  for (const entry of entries) {
+    if (entry === activeGenerationId) {
+      continue;
+    }
+    await removeGenerationPath(stateDir, path.join(generationsDir, entry));
+  }
+  if (!activeGenerationId) {
+    return;
+  }
+  await retireLegacyProposalBundle(record, store);
+}
+
+function proposalGenerationId(draftFile: SkillProposalDraftFile): string | null {
+  return GENERATION_DRAFT_PATTERN.exec(draftFile)?.[1] ?? null;
+}
+
+async function retireLegacyProposalBundle(
+  record: SkillProposalRecord,
+  store?: SkillWorkshopStoreOptions,
+): Promise<void> {
+  const stateDir = resolveSkillWorkshopStateDir(store);
+  const stateRoot = await root(stateDir);
+  const proposalDir = proposalRelativeDir(record.id);
+  let entries: string[];
+  try {
+    entries = await stateRoot.list(proposalDir);
+  } catch (error) {
+    if (error instanceof FsSafeError && error.code === "not-found") {
+      return;
+    }
+    throw error;
+  }
+  for (const entry of entries) {
+    if (entry !== PROPOSAL_GENERATIONS_REL_DIR) {
+      await removeGenerationPath(stateDir, path.join(proposalDir, entry));
+    }
+  }
+}
+
+async function removeGenerationPath(stateDir: string, relativePath: string): Promise<void> {
+  await removePathWithinRoot({
+    rootDir: stateDir,
+    relativePath,
+    recursive: true,
+  });
+}

--- a/src/skills/workshop/proposal-scan.ts
+++ b/src/skills/workshop/proposal-scan.ts
@@ -1,6 +1,5 @@
 import { scanSkillContent, scanSource } from "../security/scanner.js";
-import type { PreparedSkillProposalSupportFile } from "./store.js";
-import type { SkillProposalScan } from "./types.js";
+import type { PreparedSkillProposalSupportFile, SkillProposalScan } from "./types.js";
 
 export function scanProposalBundle(
   content: string,

--- a/src/skills/workshop/revision-atomicity.test.ts
+++ b/src/skills/workshop/revision-atomicity.test.ts
@@ -42,6 +42,30 @@ vi.mock("../../infra/fs-safe.js", async (importOriginal) => {
               revisionFault.trip("generation exclusive create");
             };
           }
+          if (property === "openWritable") {
+            return async (...openArgs: Parameters<typeof target.openWritable>) => {
+              const writable = await target.openWritable(...openArgs);
+              const handle = new Proxy(writable.handle, {
+                get(handleTarget, handleProperty, handleReceiver) {
+                  if (handleProperty === "sync") {
+                    return async () => {
+                      await handleTarget.sync();
+                      revisionFault.trip("generation file durability sync");
+                    };
+                  }
+                  const handleValue = Reflect.get(
+                    handleTarget,
+                    handleProperty,
+                    handleReceiver,
+                  ) as unknown;
+                  return typeof handleValue === "function"
+                    ? handleValue.bind(handleTarget)
+                    : handleValue;
+                },
+              });
+              return { ...writable, handle };
+            };
+          }
           if (property === "move") {
             return async (...moveArgs: Parameters<typeof target.move>) => {
               await target.move(...moveArgs);
@@ -192,6 +216,7 @@ describe("Skill Workshop revision generation atomicity", () => {
   it.each([
     "generation staging start",
     "generation exclusive create",
+    "generation file durability sync",
     "generation finalization",
     "generation parent durability sync",
     "CAS before commit",

--- a/src/skills/workshop/revision-atomicity.test.ts
+++ b/src/skills/workshop/revision-atomicity.test.ts
@@ -1,0 +1,289 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { createTrackedTempDirs } from "../../test-utils/tracked-temp-dirs.js";
+
+const revisionFault = vi.hoisted(() => ({
+  boundary: undefined as string | undefined,
+  directorySyncOutcome: undefined as
+    | { status: "synced" }
+    | { status: "unsupported"; code?: string }
+    | undefined,
+  trip(boundary: string) {
+    if (this.boundary !== boundary) {
+      return;
+    }
+    this.boundary = undefined;
+    throw new Error(`injected crash at ${boundary}`);
+  },
+}));
+
+vi.mock("../../infra/fs-safe.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/fs-safe.js")>();
+  return {
+    ...actual,
+    root: async (...args: Parameters<typeof actual.root>) => {
+      const opened = await actual.root(...args);
+      return new Proxy(opened, {
+        get(target, property, receiver) {
+          if (property === "mkdir") {
+            return async (...mkdirArgs: Parameters<typeof target.mkdir>) => {
+              await target.mkdir(...mkdirArgs);
+              revisionFault.trip("generation staging start");
+            };
+          }
+          if (property === "create") {
+            return async (...createArgs: Parameters<typeof target.create>) => {
+              await target.create(...createArgs);
+              revisionFault.trip("generation exclusive create");
+            };
+          }
+          if (property === "move") {
+            return async (...moveArgs: Parameters<typeof target.move>) => {
+              await target.move(...moveArgs);
+              revisionFault.trip("generation finalization");
+            };
+          }
+          if (property === "list") {
+            return async (...listArgs: Parameters<typeof target.list>) => {
+              const entries = await target.list(...listArgs);
+              revisionFault.trip("recovery cleanup");
+              return entries;
+            };
+          }
+          const value = Reflect.get(target, property, receiver) as unknown;
+          return typeof value === "function" ? value.bind(target) : value;
+        },
+      });
+    },
+  };
+});
+
+vi.mock("../../infra/directory-durability.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/directory-durability.js")>();
+  return {
+    ...actual,
+    syncDirectoryIfSupported: async (
+      ...args: Parameters<typeof actual.syncDirectoryIfSupported>
+    ) => {
+      revisionFault.trip("generation parent durability sync");
+      return revisionFault.directorySyncOutcome ?? (await actual.syncDirectoryIfSupported(...args));
+    },
+  };
+});
+
+vi.mock("../../infra/fs-safe-remove.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/fs-safe-remove.js")>();
+  return {
+    ...actual,
+    removePathWithinRoot: async (...args: Parameters<typeof actual.removePathWithinRoot>) => {
+      revisionFault.trip("prior generation retirement");
+      return await actual.removePathWithinRoot(...args);
+    },
+  };
+});
+
+vi.mock("./store-sqlite-transition.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./store-sqlite-transition.js")>();
+  return {
+    ...actual,
+    commitPendingSkillProposalTransition: (
+      ...args: Parameters<typeof actual.commitPendingSkillProposalTransition>
+    ) => {
+      revisionFault.trip("CAS before commit");
+      const result = actual.commitPendingSkillProposalTransition(...args);
+      revisionFault.trip("CAS after commit");
+      return result;
+    },
+  };
+});
+
+import {
+  evaluateSkillProposal,
+  inspectSkillProposal,
+  listSkillProposalEvents,
+  proposeCreateSkill,
+  reviseSkillProposal,
+} from "./service.js";
+import type { SkillProposalReadResult } from "./types.js";
+
+const tempDirs = createTrackedTempDirs();
+let testState: OpenClawTestState;
+
+beforeAll(async () => {
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-workshop-revision-atomicity-",
+  });
+});
+
+afterEach(async () => {
+  revisionFault.boundary = undefined;
+  revisionFault.directorySyncOutcome = undefined;
+  await tempDirs.cleanup();
+});
+
+afterAll(async () => {
+  await testState.cleanup();
+});
+
+describe("Skill Workshop revision generation atomicity", () => {
+  async function createProposal() {
+    const workspaceDir = await tempDirs.make("openclaw-workshop-revision-workspace-");
+    const proposal = await proposeCreateSkill({
+      workspaceDir,
+      env: testState.env,
+      name: "Atomic Revision",
+      description: "Keep proposal revisions whole across crashes",
+      content: "# Atomic Revision\n\nVersion 1.\n",
+      supportFiles: [{ path: "references/version.txt", content: "version 1\n" }],
+    });
+    return { proposal, workspaceDir };
+  }
+
+  async function reviseToVersion(
+    proposal: SkillProposalReadResult,
+    workspaceDir: string,
+    version: number,
+  ) {
+    return await reviseSkillProposal({
+      workspaceDir,
+      env: testState.env,
+      proposalId: proposal.record.id,
+      expectedRevisionHash: proposal.revisionHash,
+      content: `# Atomic Revision\n\nVersion ${version}.\n`,
+      supportFiles: [{ path: "references/version.txt", content: `version ${version}\n` }],
+    });
+  }
+
+  async function expectCompleteVersion(params: {
+    proposal: SkillProposalReadResult;
+    contentVersion: number;
+    workspaceDir: string;
+  }) {
+    await expect(
+      evaluateSkillProposal({
+        workspaceDir: params.workspaceDir,
+        env: testState.env,
+        proposalId: params.proposal.record.id,
+        expectedRevisionHash: params.proposal.revisionHash,
+      }),
+    ).resolves.toMatchObject({
+      record: { proposedVersion: params.proposal.record.proposedVersion },
+    });
+    await expect(
+      inspectSkillProposal(params.proposal.record.id, {
+        workspaceDir: params.workspaceDir,
+        env: testState.env,
+      }),
+    ).resolves.toMatchObject({
+      record: { proposedVersion: params.proposal.record.proposedVersion },
+      content: expect.stringContaining(`Version ${params.contentVersion}.`),
+      supportFiles: [
+        { path: "references/version.txt", content: `version ${params.contentVersion}\n` },
+      ],
+    });
+  }
+
+  it.each([
+    "generation staging start",
+    "generation exclusive create",
+    "generation finalization",
+    "generation parent durability sync",
+    "CAS before commit",
+  ])("keeps the complete previous generation after a crash at %s", async (boundary) => {
+    const { proposal, workspaceDir } = await createProposal();
+    revisionFault.boundary = boundary;
+
+    await expect(reviseToVersion(proposal, workspaceDir, 2)).rejects.toThrow(
+      `injected crash at ${boundary}`,
+    );
+    expect(
+      listSkillProposalEvents({
+        workspaceDir,
+        proposalId: proposal.record.id,
+        env: testState.env,
+      }).events.map((event) => event.type),
+    ).toEqual(["created"]);
+
+    await expectCompleteVersion({
+      proposal,
+      contentVersion: 1,
+      workspaceDir,
+    });
+  });
+
+  it("commits when generation directory sync is explicitly unsupported", async () => {
+    const { proposal, workspaceDir } = await createProposal();
+    revisionFault.directorySyncOutcome = { status: "unsupported", code: "EINVAL" };
+
+    const revised = await reviseToVersion(proposal, workspaceDir, 2);
+    expect(
+      listSkillProposalEvents({
+        workspaceDir,
+        proposalId: proposal.record.id,
+        env: testState.env,
+      }).events.map((event) => event.type),
+    ).toEqual(["created", "revised"]);
+    await expectCompleteVersion({
+      proposal: revised,
+      contentVersion: 2,
+      workspaceDir,
+    });
+  });
+
+  it("recovers a committed record and event after the transaction reports failure", async () => {
+    const { proposal, workspaceDir } = await createProposal();
+    revisionFault.boundary = "CAS after commit";
+
+    const revised = await reviseToVersion(proposal, workspaceDir, 2);
+    expect(
+      listSkillProposalEvents({
+        workspaceDir,
+        proposalId: proposal.record.id,
+        env: testState.env,
+      }).events.map((event) => event.type),
+    ).toEqual(["created", "revised"]);
+
+    await expectCompleteVersion({
+      proposal: revised,
+      contentVersion: 2,
+      workspaceDir,
+    });
+  });
+
+  it("keeps committed generations complete when retirement and recovery cleanup fail", async () => {
+    const { proposal, workspaceDir } = await createProposal();
+    revisionFault.boundary = "prior generation retirement";
+    const second = await reviseToVersion(proposal, workspaceDir, 2);
+    await expectCompleteVersion({
+      proposal: second,
+      contentVersion: 2,
+      workspaceDir,
+    });
+
+    revisionFault.boundary = "recovery cleanup";
+    const third = await reviseToVersion(second, workspaceDir, 3);
+    await expectCompleteVersion({
+      proposal: third,
+      contentVersion: 3,
+      workspaceDir,
+    });
+
+    const fourth = await reviseToVersion(third, workspaceDir, 4);
+    const proposalDir = path.join(
+      testState.stateDir,
+      "skill-workshop",
+      "proposals",
+      proposal.record.id,
+    );
+    await expect(fs.access(path.join(proposalDir, "PROPOSAL.md"))).rejects.toThrow();
+    await expect(fs.readdir(path.join(proposalDir, "generations"))).resolves.toEqual([
+      fourth.record.draftFile.split("/")[1],
+    ]);
+  });
+});

--- a/src/skills/workshop/service-evaluation.test.ts
+++ b/src/skills/workshop/service-evaluation.test.ts
@@ -455,7 +455,7 @@ describe("Skill Workshop proposal evaluation", () => {
         "skill-workshop",
         "proposals",
         proposal.record.id,
-        "PROPOSAL.md",
+        proposal.record.draftFile,
       ),
       "# Evaluation Drift\n\nUncommitted replacement.\n",
     );
@@ -511,7 +511,7 @@ describe("Skill Workshop proposal evaluation", () => {
         "skill-workshop",
         "proposals",
         proposal.record.id,
-        "PROPOSAL.md",
+        proposal.record.draftFile,
       ),
       "# Concurrent Drift\n\nReplaced while evaluating.\n",
     );

--- a/src/skills/workshop/service-evaluation.ts
+++ b/src/skills/workshop/service-evaluation.ts
@@ -21,11 +21,7 @@ import {
 import { readRequiredProposal } from "./service-query.js";
 import { readSkillProposalEvents, recordSkillProposalEvaluation } from "./store-evaluation.js";
 import { assertSkillProposalEvaluationWithinLimit } from "./store-record.js";
-import {
-  hashSkillProposalContent,
-  readProposalSupportFiles,
-  withSkillProposalTargetLock,
-} from "./store.js";
+import { hashSkillProposalContent, withSkillProposalTargetLock } from "./store.js";
 import type {
   SkillProposalEvaluateInput,
   SkillProposalEvaluateResult,
@@ -81,7 +77,6 @@ export async function evaluateSkillProposal(
       if (hashSkillProposalContent(read.content) !== read.record.draftHash) {
         throw new Error("Proposal draft changed without updating proposal metadata.");
       }
-      const supportFiles = await readProposalSupportFiles(read.record, storeOptions(input.env));
       if (
         shouldRunEvaluators &&
         read.record.kind === "create" &&
@@ -96,7 +91,7 @@ export async function evaluateSkillProposal(
         bundles: shouldRunEvaluators
           ? await buildSkillProposalEvaluationBundles({
               proposal: read,
-              supportFiles,
+              supportFiles: read.supportFiles ?? [],
             })
           : undefined,
       };
@@ -177,11 +172,6 @@ export async function evaluateSkillProposal(
         current.revisionHash !== read.revisionHash ||
         hashSkillProposalContent(current.content) !== current.record.draftHash
       ) {
-        throw new Error(`Skill proposal ${read.record.id} changed while evaluation was running.`);
-      }
-      try {
-        await readProposalSupportFiles(current.record, storeOptions(input.env));
-      } catch {
         throw new Error(`Skill proposal ${read.record.id} changed while evaluation was running.`);
       }
       if (bundles) {

--- a/src/skills/workshop/service-propose.ts
+++ b/src/skills/workshop/service-propose.ts
@@ -11,17 +11,18 @@ import { stripProposalFrontmatterForSkill } from "./frontmatter.js";
 import { isWorkshopOwnedSkillDir } from "./ownership.js";
 import { createSkillProposalEvent, dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { prepareSkillProposalDraft, resolveUpdateProposalDescription } from "./proposal-draft.js";
+import { createSkillProposalGenerationDraftFile } from "./proposal-generation.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
 import {
   createSkillProposalId,
   hashSkillProposalContent,
   resolveSkillProposalTarget,
   writeSkillProposal,
-  type PreparedSkillProposalSupportFile,
 } from "./store.js";
 import {
   MAX_SKILL_PROPOSAL_ORIGIN_RUN_IDS,
   SKILL_WORKSHOP_SCHEMA,
+  type PreparedSkillProposalSupportFile,
   type SkillProposalCreateInput,
   type SkillProposalOrigin,
   type SkillProposalReadResult,
@@ -141,7 +142,7 @@ export async function proposeCreateSkill(
     ...(origin ? { origin } : {}),
     ...originRunProvenance,
     proposedVersion: "v1",
-    draftFile: "PROPOSAL.md",
+    draftFile: createSkillProposalGenerationDraftFile(),
     draftHash,
     target: {
       skillName: name,
@@ -171,14 +172,12 @@ export async function proposeCreateSkill(
     }),
     store: proposalStoreOptions(input.env),
   });
-  if (event) {
-    await dispatchSkillProposalChanged({
-      event,
-      record,
-      workspaceDir: input.workspaceDir,
-      ...(input.agentId ? { agentId: input.agentId } : {}),
-    });
-  }
+  await dispatchSkillProposalChanged({
+    event,
+    record,
+    workspaceDir: input.workspaceDir,
+    ...(input.agentId ? { agentId: input.agentId } : {}),
+  });
   return { record, revisionHash: hashSkillProposalRevision(record), content: proposalContent };
 }
 
@@ -296,7 +295,7 @@ export async function proposeUpdateSkill(
     ...(origin ? { origin } : {}),
     ...originRunProvenance,
     proposedVersion: "v1",
-    draftFile: "PROPOSAL.md",
+    draftFile: createSkillProposalGenerationDraftFile(),
     draftHash,
     target: {
       skillName: targetSkill.name,
@@ -327,14 +326,12 @@ export async function proposeUpdateSkill(
     }),
     store: proposalStoreOptions(input.env),
   });
-  if (event) {
-    await dispatchSkillProposalChanged({
-      event,
-      record,
-      workspaceDir: input.workspaceDir,
-      ...(input.agentId ? { agentId: input.agentId } : {}),
-    });
-  }
+  await dispatchSkillProposalChanged({
+    event,
+    record,
+    workspaceDir: input.workspaceDir,
+    ...(input.agentId ? { agentId: input.agentId } : {}),
+  });
   return { record, revisionHash: hashSkillProposalRevision(record), content: proposalContent };
 }
 

--- a/src/skills/workshop/service-query.ts
+++ b/src/skills/workshop/service-query.ts
@@ -12,7 +12,6 @@ import { transitionPendingSkillProposalToStale } from "./apply-transition.js";
 import { dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
 import {
-  readProposalSupportFiles,
   SkillProposalDraftMissingError,
   readSkillProposal,
   readSkillProposalManifest,
@@ -113,10 +112,7 @@ export async function inspectSkillProposal(
   if (!read) {
     return null;
   }
-  return await hydrateProposalSupportFiles(
-    await reconcilePendingCreateProposal(read, options),
-    options.env,
-  );
+  return await reconcilePendingCreateProposal(read, options);
 }
 
 export async function resolvePendingSkillProposal(input: {
@@ -267,19 +263,6 @@ async function reconcilePendingCreateProposal(
     });
   }
   return reconciled.read;
-}
-
-async function hydrateProposalSupportFiles(
-  read: SkillProposalReadResult,
-  env?: NodeJS.ProcessEnv,
-): Promise<SkillProposalReadResult> {
-  const supportFiles = await readProposalSupportFiles(read.record, storeOptions(env));
-  return supportFiles.length === 0
-    ? read
-    : {
-        ...read,
-        supportFiles: supportFiles.map((file) => ({ path: file.path, content: file.content })),
-      };
 }
 
 function proposalMatchesName(

--- a/src/skills/workshop/service.test.ts
+++ b/src/skills/workshop/service.test.ts
@@ -607,6 +607,7 @@ describe("skill workshop proposals", () => {
           "skill-workshop",
           "proposals",
           proposal.record.id,
+          path.dirname(proposal.record.draftFile),
           "references",
           "original.md",
         ),
@@ -1233,7 +1234,13 @@ describe("skill workshop proposals", () => {
       "utf8",
     );
     await fs.writeFile(
-      path.join(stateDir, "skill-workshop", "proposals", proposal.record.id, "PROPOSAL.md"),
+      path.join(
+        stateDir,
+        "skill-workshop",
+        "proposals",
+        proposal.record.id,
+        proposal.record.draftFile,
+      ),
       proposal.content.replace(/date: .+/, 'date: "2099-01-01T00:00:00.000Z"'),
       "utf8",
     );
@@ -1784,6 +1791,7 @@ describe("skill workshop proposals", () => {
         "skill-workshop",
         "proposals",
         proposal.record.id,
+        path.dirname(proposal.record.draftFile),
         "references",
         "check.md",
       ),

--- a/src/skills/workshop/service.ts
+++ b/src/skills/workshop/service.ts
@@ -15,6 +15,7 @@ import {
 import { resolveSkillWorkshopConfig } from "./config.js";
 import { createSkillProposalEvent, dispatchSkillProposalChanged } from "./plugin-hooks.js";
 import { nextProposalVersion, prepareSkillProposalDraft } from "./proposal-draft.js";
+import { createSkillProposalGenerationDraftFile } from "./proposal-generation.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
 import {
   assertExpectedRevisionHash,
@@ -29,7 +30,6 @@ import {
 import { readRequiredProposal } from "./service-query.js";
 import {
   hashSkillProposalContent,
-  readProposalSupportFiles,
   readSkillProposalRecord,
   replaceSkillProposalDraft,
   updateSkillProposalRecord,
@@ -66,7 +66,6 @@ const APPLY_TRANSITION_DEPENDENCIES = {
   evaluateSkillProposal,
   isCreateTargetConflict: (error: unknown) =>
     error instanceof SkillProposalCreateTargetConflictError,
-  readProposalSupportFiles,
   readRequiredProposal,
 } satisfies SkillProposalApplyTransitionDependencies;
 
@@ -118,9 +117,7 @@ export async function reviseSkillProposal(
     }
 
     const supportFiles =
-      input.supportFiles === undefined
-        ? await readProposalSupportFiles(record, proposalStoreOptions(input.env))
-        : input.supportFiles;
+      input.supportFiles === undefined ? (read.supportFiles ?? []) : input.supportFiles;
     const requestedContent = input.content ?? read.content;
     const nextVersion = nextProposalVersion(record.proposedVersion);
     const description = normalizeOptionalString(input.description) ?? record.description;
@@ -157,12 +154,12 @@ export async function reviseSkillProposal(
         : [];
     const origin = normalizeProposalOrigin(input.origin);
     const originRunProvenance = mergeProposalOriginRunProvenance(record, origin);
-    const previousSupportFiles = record.supportFiles;
     const revised: SkillProposalRecord = {
       ...record,
       description,
       updatedAt: now,
       proposedVersion: nextVersion,
+      draftFile: createSkillProposalGenerationDraftFile(),
       draftHash,
       scan,
       ...(origin ? { origin } : {}),
@@ -185,8 +182,8 @@ export async function reviseSkillProposal(
       delete revised.evidence;
     }
     const event = await replaceSkillProposalDraft({
+      expected: record,
       record: revised,
-      previousSupportFiles,
       content: proposalContent,
       supportFiles: preparedSupportFiles,
       event: createSkillProposalEvent({
@@ -208,14 +205,12 @@ export async function reviseSkillProposal(
     };
   });
   const revisedResult = await withSkillProposalLifecycleDispatch(input, revision);
-  if (revisedResult.event) {
-    await dispatchSkillProposalChanged({
-      event: revisedResult.event,
-      record: revisedResult.read.record,
-      workspaceDir: input.workspaceDir,
-      ...(input.agentId ? { agentId: input.agentId } : {}),
-    });
-  }
+  await dispatchSkillProposalChanged({
+    event: revisedResult.event,
+    record: revisedResult.read.record,
+    workspaceDir: input.workspaceDir,
+    ...(input.agentId ? { agentId: input.agentId } : {}),
+  });
   return revisedResult.read;
 }
 

--- a/src/skills/workshop/store-record.test.ts
+++ b/src/skills/workshop/store-record.test.ts
@@ -96,6 +96,12 @@ describe("Skill Workshop persisted record validation", () => {
       value: shippedRollback,
     });
     expect(parseSkillProposalRecord(shippedProposal)).toBe(shippedProposal);
+    expect(
+      parseSkillProposalRecord({
+        ...shippedProposal,
+        draftFile: "generations/123e4567-e89b-42d3-a456-426614174000/PROPOSAL.md",
+      }),
+    ).not.toBeNull();
     expect(parseSkillProposalRollback(shippedRollback)).toBe(shippedRollback);
   });
 
@@ -117,6 +123,10 @@ describe("Skill Workshop persisted record validation", () => {
   });
 
   it.each([
+    {
+      name: "non-generation draft path",
+      value: { ...shippedProposal, draftFile: "generations/../PROPOSAL.md" },
+    },
     {
       name: "duplicate normalized support paths",
       value: {

--- a/src/skills/workshop/store-record.ts
+++ b/src/skills/workshop/store-record.ts
@@ -18,6 +18,8 @@ export const PROPOSAL_DRAFT_FILE = "PROPOSAL.md";
 export const MAX_PROPOSAL_SUPPORT_FILES = 64;
 export const MAX_SKILL_PROPOSAL_EVALUATION_BYTES = 512 * 1024;
 const PROPOSAL_ID_PATTERN = /^[a-z0-9][a-z0-9-]{5,120}$/;
+const PROPOSAL_DRAFT_FILE_PATTERN =
+  /^(?:PROPOSAL\.md|generations\/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/PROPOSAL\.md)$/u;
 
 type SkillProposalRecordValidationError = {
   code: "invalid-proposal-metadata" | "invalid-rollback-metadata";
@@ -137,7 +139,7 @@ const skillProposalRecordSchema = z
     updatedAt: z.string(),
     autonomousCapture: z.literal(true).optional(),
     draftHash: z.string(),
-    draftFile: z.literal(PROPOSAL_DRAFT_FILE),
+    draftFile: z.string().regex(PROPOSAL_DRAFT_FILE_PATTERN),
     origin: z.unknown().optional(),
     originRunIds: z.unknown().optional(),
     originRunMutationCounts: z.unknown().optional(),

--- a/src/skills/workshop/store-sqlite-transition.ts
+++ b/src/skills/workshop/store-sqlite-transition.ts
@@ -1,4 +1,8 @@
-import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
 import { runOpenClawStateWriteTransaction } from "../../state/openclaw-state-db.js";
 import {
   appendSkillProposalEvent,
@@ -19,15 +23,16 @@ import {
 import type { SkillProposalEvent, SkillProposalRecord } from "./types.js";
 
 export type PendingSkillProposalTransitionCommit =
-  | { state: "committed"; event?: SkillProposalEvent }
+  | { state: "committed"; event: SkillProposalEvent }
   | { state: "conflict"; current?: SkillProposalRecord };
 
 export function commitPendingSkillProposalTransition(params: {
   expected: SkillProposalRecord;
   record: SkillProposalRecord;
-  event?: NewSkillProposalEvent;
+  event: NewSkillProposalEvent;
   store?: SkillWorkshopStoreOptions;
   operationLabel: string;
+  invalidateRollback?: boolean;
 }): PendingSkillProposalTransitionCommit {
   ensureSkillWorkshopSchema(params.store);
   return runOpenClawStateWriteTransaction(
@@ -52,10 +57,18 @@ export function commitPendingSkillProposalTransition(params: {
           ...(currentRecord ? { current: currentRecord } : {}),
         };
       }
+      if (params.invalidateRollback) {
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .deleteFrom("skill_workshop_proposal_rollbacks")
+            .where("proposal_id", "=", params.expected.id),
+        );
+      }
       updateProposal(db, current, params.record);
       return {
         state: "committed" as const,
-        ...(params.event ? { event: appendSkillProposalEvent(db, params.event) } : {}),
+        event: appendSkillProposalEvent(db, params.event),
       };
     },
     databaseOptions(params.store),

--- a/src/skills/workshop/store.test.ts
+++ b/src/skills/workshop/store.test.ts
@@ -59,6 +59,7 @@ describe("Skill Workshop SQLite store", () => {
       commitPendingSkillProposalTransition({
         expected: proposal.record,
         record: applied,
+        event,
         operationLabel: "skill-workshop.test.conflict",
       }),
     ).toMatchObject({ state: "conflict", current: { status: "applied" } });

--- a/src/skills/workshop/store.ts
+++ b/src/skills/workshop/store.ts
@@ -1,14 +1,13 @@
 import crypto from "node:crypto";
 import path from "node:path";
-import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { removePathWithinRoot } from "../../infra/fs-safe-remove.js";
-import { FsSafeError, root, type ReadResult } from "../../infra/fs-safe.js";
+import { FsSafeError, root, type ReadResult, type Root } from "../../infra/fs-safe.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
+import { logWarn } from "../../logger.js";
 import { runOpenClawStateWriteTransaction } from "../../state/openclaw-state-db.js";
 import { normalizeSkillIndexName } from "../discovery/skill-index.js";
 import {
@@ -17,6 +16,13 @@ import {
   MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES,
   normalizeWorkspaceSkillSupportPath,
 } from "../lifecycle/workspace-skill-write.js";
+import {
+  cleanupSkillProposalGenerations,
+  discardSkillProposalGeneration,
+  proposalBundleRelativePath,
+  resolveSkillWorkshopStateDir,
+  stageSkillProposalGeneration,
+} from "./proposal-generation.js";
 import { hashSkillProposalContent } from "./proposal-hash.js";
 import { reconcileInterruptedSkillProposalApply } from "./reconcile-transition.js";
 import { hashSkillProposalRevision } from "./revision-hash.js";
@@ -42,19 +48,22 @@ import {
   type SkillWorkshopStoreOptions,
 } from "./store-sqlite-schema.js";
 import {
+  commitPendingSkillProposalTransition,
+  readCommittedSkillProposalTransition,
+} from "./store-sqlite-transition.js";
+import { withSkillProposalTargetLock } from "./target-lock.js";
+import {
   SKILL_WORKSHOP_MANIFEST_SCHEMA,
+  type PreparedSkillProposalSupportFile,
   type SkillProposalManifest,
   type SkillProposalManifestEntry,
   type SkillProposalReadResult,
   type SkillProposalRecord,
   type SkillProposalRollback,
-  type SkillProposalSupportFile,
   type SkillProposalSupportFileInput,
   type SkillProposalEvent,
 } from "./types.js";
 
-const WORKSHOP_REL_DIR = "skill-workshop";
-const PROPOSALS_REL_DIR = path.join(WORKSHOP_REL_DIR, "proposals");
 const MAX_PROPOSAL_BYTES = 1024 * 1024;
 const MAX_PROPOSAL_SUPPORT_FILES_TOTAL_BYTES = 2 * 1024 * 1024;
 export {
@@ -64,7 +73,7 @@ export {
 } from "./store-record.js";
 export { hashSkillProposalContent } from "./proposal-hash.js";
 export { readSkillProposalRollback };
-export { withSkillProposalTargetLock } from "./target-lock.js";
+export { withSkillProposalTargetLock };
 
 type SkillProposalLookupScope = {
   agentId?: string;
@@ -74,10 +83,6 @@ type SkillProposalLookupScope = {
 type SkillProposalReadOptions = {
   config?: OpenClawConfig;
   reconcile?: boolean;
-};
-
-export type PreparedSkillProposalSupportFile = SkillProposalSupportFile & {
-  content: string;
 };
 
 /** Creates a stable proposal id from skill name, date, and random suffix. */
@@ -96,15 +101,6 @@ function assertSkillProposalContentSize(content: string): void {
   if (contentSizeBytes(content) > MAX_PROPOSAL_BYTES) {
     throw new Error("Skill proposal is too large.");
   }
-}
-
-function resolveSkillWorkshopStateDir(options: SkillWorkshopStoreOptions = {}): string {
-  return path.resolve(options.stateDir ?? resolveStateDir(options.env));
-}
-
-function proposalRelativeDir(proposalId: string): string {
-  assertProposalId(proposalId);
-  return path.join(PROPOSALS_REL_DIR, proposalId);
 }
 
 export function prepareSkillProposalSupportFiles(
@@ -198,32 +194,25 @@ export async function readSkillProposal(
   if (!stored || !isStoredProposalVisible(stored.row, scope)) {
     return null;
   }
-  if (readOptions.reconcile !== false) {
-    await reconcileInterruptedApply(proposalId, options, readOptions.config);
+  if (readOptions.reconcile === false) {
+    return await readSkillProposalBundle(stored.record, options);
   }
-  stored = readStoredProposal(proposalId, options);
-  if (!stored || !isStoredProposalVisible(stored.row, scope)) {
-    return null;
-  }
-  const stateRoot = await root(resolveSkillWorkshopStateDir(options));
-  let draft: ReadResult;
-  try {
-    draft = await stateRoot.read(path.join(proposalRelativeDir(proposalId), PROPOSAL_DRAFT_FILE), {
-      hardlinks: "reject",
-      maxBytes: MAX_PROPOSAL_BYTES,
-      symlinks: "reject",
-    });
-  } catch (error) {
-    if (error instanceof FsSafeError && error.code === "not-found") {
-      throw new SkillProposalDraftMissingError(proposalId, { cause: error });
+  if (await reconcileInterruptedApply(proposalId, options, readOptions.config)) {
+    stored = readStoredProposal(proposalId, options);
+    if (!stored || !isStoredProposalVisible(stored.row, scope)) {
+      return null;
     }
-    throw error;
   }
-  return {
-    record: stored.record,
-    revisionHash: hashSkillProposalRevision(stored.record),
-    content: draft.buffer.toString("utf8"),
-  };
+  return await withSkillProposalTargetLock(
+    stored.record,
+    async () => {
+      const current = readStoredProposal(proposalId, options);
+      return current && isStoredProposalVisible(current.row, scope)
+        ? await readSkillProposalBundle(current.record, options)
+        : null;
+    },
+    options,
+  );
 }
 
 export async function readSkillProposalRecord(
@@ -250,24 +239,13 @@ export async function writeSkillProposal(params: {
   workspaceDir: string;
   ownerAgentId?: string;
   maxPending: number;
-  event?: NewSkillProposalEvent;
+  event: NewSkillProposalEvent;
   store?: SkillWorkshopStoreOptions;
-}): Promise<SkillProposalEvent | undefined> {
+}): Promise<SkillProposalEvent> {
   assertProposalId(params.record.id);
   assertSkillProposalContentSize(params.content);
   ensureSkillWorkshopSchema(params.store);
-  const stateRoot = await root(resolveSkillWorkshopStateDir(params.store));
-  const relativeDir = proposalRelativeDir(params.record.id);
-  await stateRoot.mkdir(relativeDir);
-  await stateRoot.write(path.join(relativeDir, PROPOSAL_DRAFT_FILE), params.content, {
-    encoding: "utf8",
-  });
-  for (const file of params.supportFiles ?? []) {
-    await stateRoot.write(path.join(relativeDir, file.path), file.content, {
-      encoding: "utf8",
-      mkdir: true,
-    });
-  }
+  await stageSkillProposalGeneration(params);
 
   try {
     return runOpenClawStateWriteTransaction(
@@ -299,56 +277,82 @@ export async function writeSkillProposal(params: {
           ownerAgentId: params.ownerAgentId ?? params.record.origin?.agentId ?? null,
           workspaceDir: params.workspaceDir,
         });
-        return params.event ? appendSkillProposalEvent(db, params.event) : undefined;
+        return appendSkillProposalEvent(db, params.event);
       },
       databaseOptions(params.store),
       { operationLabel: "skill-workshop.proposal.create" },
     );
   } catch (error) {
-    await removePathWithinRoot({
-      rootDir: resolveSkillWorkshopStateDir(params.store),
-      relativePath: relativeDir,
-      recursive: true,
-    }).catch(() => undefined);
+    const committed = readCommittedSkillProposalTransition({
+      record: params.record,
+      event: params.event,
+      store: params.store,
+    });
+    if (committed) {
+      return committed.event;
+    }
+    const authoritative = readStoredProposal(params.record.id, params.store);
+    if (authoritative?.row.record_json === JSON.stringify(params.record)) {
+      throw new Error("Created Skill Workshop proposal is missing its committed event.", {
+        cause: error,
+      });
+    }
+    await discardSkillProposalGeneration(params.record, params.store).catch(() => undefined);
     throw error;
   }
 }
 
 export async function replaceSkillProposalDraft(params: {
+  expected: SkillProposalRecord;
   record: SkillProposalRecord;
-  previousSupportFiles?: readonly SkillProposalSupportFile[];
   content: string;
   supportFiles?: readonly PreparedSkillProposalSupportFile[];
-  event?: NewSkillProposalEvent;
+  event: NewSkillProposalEvent;
   store?: SkillWorkshopStoreOptions;
-}): Promise<SkillProposalEvent | undefined> {
+}): Promise<SkillProposalEvent> {
   assertProposalId(params.record.id);
   assertSkillProposalContentSize(params.content);
-  const stateRoot = await root(resolveSkillWorkshopStateDir(params.store));
-  const relativeDir = proposalRelativeDir(params.record.id);
-  await stateRoot.write(path.join(relativeDir, PROPOSAL_DRAFT_FILE), params.content, {
-    encoding: "utf8",
+  await cleanupSkillProposalGenerations(params.expected, params.store).catch((error: unknown) => {
+    logWarn(`skill-workshop: failed to clean unowned proposal generations: ${String(error)}`);
   });
-  const nextSupportPaths = new Set<string>();
-  for (const file of params.supportFiles ?? []) {
-    nextSupportPaths.add(file.path);
-    await stateRoot.write(path.join(relativeDir, file.path), file.content, {
-      encoding: "utf8",
-      mkdir: true,
+  await stageSkillProposalGeneration(params);
+
+  let commit;
+  try {
+    commit = commitPendingSkillProposalTransition({
+      expected: params.expected,
+      record: params.record,
+      event: params.event,
+      store: params.store,
+      operationLabel: "skill-workshop.revision.commit",
+      invalidateRollback: true,
     });
-  }
-  for (const file of params.previousSupportFiles ?? []) {
-    const filePath = normalizeWorkspaceSkillSupportPath(file.path);
-    if (!nextSupportPaths.has(filePath)) {
-      await stateRoot.remove(path.join(relativeDir, filePath)).catch(() => undefined);
+  } catch (error) {
+    const committed = readCommittedSkillProposalTransition({
+      record: params.record,
+      event: params.event,
+      store: params.store,
+    });
+    if (!committed) {
+      const authoritative = readStoredProposal(params.record.id, params.store);
+      if (authoritative?.row.record_json === JSON.stringify(params.record)) {
+        throw new Error("Revised Skill Workshop proposal is missing its committed event.", {
+          cause: error,
+        });
+      }
+      await discardSkillProposalGeneration(params.record, params.store).catch(() => undefined);
+      throw error;
     }
+    commit = committed;
   }
-  return await updateSkillProposalRecord({
-    record: params.record,
-    store: params.store,
-    invalidateRollback: true,
-    event: params.event,
+  if (commit.state === "conflict") {
+    await discardSkillProposalGeneration(params.record, params.store).catch(() => undefined);
+    throw new Error("Skill proposal changed before revision commit.");
+  }
+  await cleanupSkillProposalGenerations(params.record, params.store).catch((error: unknown) => {
+    logWarn(`skill-workshop: failed to retire prior proposal generation: ${String(error)}`);
   });
+  return commit.event;
 }
 
 export async function updateSkillProposalRecord(params: {
@@ -458,7 +462,7 @@ async function reconcileInterruptedApply(
   try {
     const stateRoot = await root(resolveSkillWorkshopStateDir(options));
     const draft = await stateRoot.read(
-      path.join(proposalRelativeDir(proposalId), PROPOSAL_DRAFT_FILE),
+      proposalBundleRelativePath(stored.record, PROPOSAL_DRAFT_FILE),
       { hardlinks: "reject", maxBytes: MAX_PROPOSAL_BYTES, symlinks: "reject" },
     );
     draftContent = draft.buffer.toString("utf8");
@@ -475,15 +479,14 @@ async function reconcileInterruptedApply(
   });
 }
 
-export async function readProposalSupportFiles(
+async function readProposalSupportFiles(
   record: SkillProposalRecord,
-  options: SkillWorkshopStoreOptions = {},
+  stateRoot: Root,
 ): Promise<PreparedSkillProposalSupportFile[]> {
-  const stateRoot = await root(resolveSkillWorkshopStateDir(options));
   const out: PreparedSkillProposalSupportFile[] = [];
   for (const file of record.supportFiles ?? []) {
     const filePath = normalizeWorkspaceSkillSupportPath(file.path);
-    const read = await stateRoot.read(path.join(proposalRelativeDir(record.id), filePath), {
+    const read = await stateRoot.read(proposalBundleRelativePath(record, filePath), {
       hardlinks: "reject",
       maxBytes: MAX_WORKSPACE_SKILL_SUPPORT_FILE_BYTES,
       symlinks: "reject",
@@ -498,6 +501,33 @@ export async function readProposalSupportFiles(
   }
   assertWorkspaceSkillSupportPathSetIsFileOnly(out.map((file) => file.path));
   return out;
+}
+
+async function readSkillProposalBundle(
+  record: SkillProposalRecord,
+  options: SkillWorkshopStoreOptions,
+): Promise<SkillProposalReadResult> {
+  const stateRoot = await root(resolveSkillWorkshopStateDir(options));
+  let draft: ReadResult;
+  try {
+    draft = await stateRoot.read(proposalBundleRelativePath(record, PROPOSAL_DRAFT_FILE), {
+      hardlinks: "reject",
+      maxBytes: MAX_PROPOSAL_BYTES,
+      symlinks: "reject",
+    });
+  } catch (error) {
+    if (error instanceof FsSafeError && error.code === "not-found") {
+      throw new SkillProposalDraftMissingError(record.id, { cause: error });
+    }
+    throw error;
+  }
+  const supportFiles = await readProposalSupportFiles(record, stateRoot);
+  return {
+    record,
+    revisionHash: hashSkillProposalRevision(record),
+    content: draft.buffer.toString("utf8"),
+    ...(supportFiles.length > 0 ? { supportFiles } : {}),
+  };
 }
 
 export function importLegacySkillProposal(params: {

--- a/src/skills/workshop/types.ts
+++ b/src/skills/workshop/types.ts
@@ -139,6 +139,10 @@ export type SkillProposalSupportFile = {
   targetContentHash?: string;
 };
 
+export type PreparedSkillProposalSupportFile = SkillProposalSupportFile & { content: string };
+
+export type SkillProposalDraftFile = "PROPOSAL.md" | `generations/${string}/PROPOSAL.md`;
+
 export type SkillProposalRecord = {
   schema: typeof SKILL_WORKSHOP_SCHEMA;
   id: string;
@@ -157,7 +161,7 @@ export type SkillProposalRecord = {
   /** Durable mutation counts keyed by run id for bounded interrupted-run recovery. */
   originRunMutationCounts?: Record<string, number>;
   proposedVersion: string;
-  draftFile: "PROPOSAL.md";
+  draftFile: SkillProposalDraftFile;
   draftHash: string;
   supportFiles?: SkillProposalSupportFile[];
   target: SkillProposalTarget;
@@ -316,7 +320,7 @@ export type SkillProposalReadResult = {
   record: SkillProposalRecord;
   revisionHash: string;
   content: string;
-  supportFiles?: SkillProposalSupportFileInput[];
+  supportFiles?: PreparedSkillProposalSupportFile[];
 };
 
 export type SkillProposalApplyResult = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where revising a pending Skill Workshop proposal could leave SQLite describing the previous revision while `PROPOSAL.md` or support files were partially replaced by the new revision after a process interruption. The torn bundle caused inspect/evaluate/apply to reject the proposal until it was recreated.

## Why This Change Was Made

Skill Workshop now stages each complete revision as an immutable filesystem generation, exclusively creates and synchronizes every file, atomically publishes the directory, then CAS-commits the proposal record and lifecycle event together before retiring the prior generation. Reads follow the committed generation pointer under the proposal target lease. Existing root-level proposal bundles migrate on their next successful revision; no SQLite schema or protocol version changes are required. One centralized Gateway projection keeps internal generation paths and prepared support metadata behind the existing public proposal schemas.

## User Impact

Pending proposal revisions now recover as a complete old or complete new bundle rather than a mixed state. Evaluation and apply no longer wedge after an interrupted revision, existing proposals upgrade without operator action, and tool/Gateway consumers keep their shipped `PROPOSAL.md` artifact and response contracts.

## Evidence

- Pre-fix public-service regression reproduced the torn revision after the first v2 write: evaluation rejected it with `Proposal draft changed without updating proposal metadata.`
- The original focused Workshop revision/service/store suite passed 89/89 before follow-ups.
- `node scripts/run-vitest.mjs src/agents/tools/skill-workshop-tool.list.test.ts src/agents/tools/skill-workshop-tool.projection.test.ts src/agents/tools/skill-workshop-tool.test.ts src/skills/workshop/collection-reconcile.test.ts` — 51/51 passed across the affected tool projection and lease tests.
- `node scripts/run-vitest.mjs src/gateway/server-methods/skills.proposals.test.ts packages/gateway-protocol/src/schema/agents-models-skills.test.ts src/skills/workshop/revision-atomicity.test.ts src/skills/workshop/service.test.ts` — 101/101 passed across every Gateway lifecycle response, the closed protocol schema, and the revision owner.
- `node scripts/run-vitest.mjs src/skills/workshop/revision-atomicity.test.ts src/skills/workshop/service.test.ts` — 55/55 passed after adding explicit file synchronization.
- Focused and full task changed-path gates passed, including production/test typecheck, lint, dead exports, schema-v9, database-first, and import-cycle guards.
- `pnpm check:docs` — passed formatting, Markdown lint, MDX, glossary, 6,526 links, and 1,179 config examples.
- `pnpm build` — passed.
- Authenticated isolated Gateway flow passed: create v1 → separate CLI revise v2 → inspect v2 body and support metadata/content → Gateway evaluate with zero evaluators.
- Exactly one immutable generation remained after the live revision flow.
- Direct installed-source inspection confirmed fs-safe's exclusive `Root.create`, guarded same-root directory move requiring `overwrite: true`, and repository-owned unsupported-directory-sync policy. It also identified the native-off create fallback's missing file sync; the final generation owner now calls `FileHandle.sync()` before rename, covered by a new fault boundary.
- No SQLite table, column, schema-version, or protocol-version change.
- Exact-head CI follow-ups repaired stale root-path fixtures, deterministic lease-timeout proof, model/Gateway contract projection, and file durability. Final `openclaw/ci-gate` passed in run https://github.com/openclaw/openclaw/actions/runs/32322373341.
- `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 126485` passed with gate mode `hosted_exact_or_recent_parent`, reusing exact-head hosted CI; no standalone Testbox lease/run URL was allocated.
- Production: +414/-212 (net +202); tests: +446/-72; docs: +29/-9. Growth owns synchronized immutable generation publication, CAS/recovery, legacy upgrade handling, and centralized stable public projections while removing duplicate support reads and retirement policy.
- Fresh autoreview after every source fix: clean, with no accepted/actionable findings.
- AI-assisted: yes.
