### PR TITLE
fix(memory-core): restore MEMORY.md when the in-place fallback write fails midway

### DIFF
--- a/extensions/memory-core/src/short-term-promotion-memory-write.test.ts
+++ b/extensions/memory-core/src/short-term-promotion-memory-write.test.ts
@@ -1,0 +1,95 @@
+import type { FileHandle } from "node:fs/promises";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { hashMemoryContent, writeMemoryContent } from "./short-term-promotion-memory-write.js";
+
+const openState = vi.hoisted(() => ({ failInPlaceWriteAfterBytes: null as number | null }));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  const open: typeof actual.open = async (...args) => {
+    const handle = await actual.open(...(args as Parameters<typeof actual.open>));
+    const partialBytes = openState.failInPlaceWriteAfterBytes;
+    if (args[1] !== "r+" || partialBytes === null) {
+      return handle;
+    }
+    openState.failInPlaceWriteAfterBytes = null;
+    const failingWriteFile = async (content: string) => {
+      const partial = Buffer.from(content, "utf-8").subarray(0, partialBytes);
+      await handle.write(partial, 0, partial.length, 0);
+      throw Object.assign(new Error("EFBIG: file too large, write"), { code: "EFBIG" });
+    };
+    return {
+      writeFile: failingWriteFile,
+      write: handle.write.bind(handle),
+      truncate: handle.truncate.bind(handle),
+      sync: handle.sync.bind(handle),
+      close: handle.close.bind(handle),
+    } as unknown as FileHandle;
+  };
+  return { ...actual, default: { ...actual, open }, open };
+});
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  openState.failInPlaceWriteAfterBytes = null;
+  while (cleanups.length > 0) {
+    await cleanups.pop()?.();
+  }
+});
+
+async function setupReadOnlyMemoryDir(originalContent: string): Promise<string> {
+  const tempRoot = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "memory-write-test-")),
+  );
+  const memoryDir = path.join(tempRoot, "workspace");
+  await fs.mkdir(memoryDir);
+  const memoryPath = path.join(memoryDir, "MEMORY.md");
+  await fs.writeFile(memoryPath, originalContent, "utf-8");
+  await fs.chmod(memoryDir, 0o555);
+  cleanups.push(async () => {
+    await fs.chmod(memoryDir, 0o755);
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+  return memoryPath;
+}
+
+it("keeps the original MEMORY.md when the in-place fallback write fails partway", async () => {
+  const original = "# Long-Term Memory\n\n- existing entry that must survive\n";
+  const memoryPath = await setupReadOnlyMemoryDir(original);
+  const promoted = `${original}${"- promoted entry\n".repeat(200)}`;
+  openState.failInPlaceWriteAfterBytes = 1024;
+
+  await expect(
+    writeMemoryContent({
+      memoryPath,
+      memoryWritePath: memoryPath,
+      expectedHash: hashMemoryContent(original),
+      expectedContent: original,
+      allowInPlaceFallback: true,
+      content: promoted,
+    }),
+  ).rejects.toMatchObject({ code: "EFBIG" });
+
+  expect(await fs.readFile(memoryPath, "utf-8")).toBe(original);
+});
+
+it("writes promoted content through the in-place fallback when the write succeeds", async () => {
+  const original = "# Long-Term Memory\n\n- existing entry\n";
+  const memoryPath = await setupReadOnlyMemoryDir(original);
+  const promoted = `${original}- promoted entry\n`;
+
+  await writeMemoryContent({
+    memoryPath,
+    memoryWritePath: memoryPath,
+    expectedHash: hashMemoryContent(original),
+    expectedContent: original,
+    allowInPlaceFallback: true,
+    content: promoted,
+  });
+
+  expect(await fs.readFile(memoryPath, "utf-8")).toBe(promoted);
+});

--- a/extensions/memory-core/src/short-term-promotion-memory-write.test.ts
+++ b/extensions/memory-core/src/short-term-promotion-memory-write.test.ts
@@ -1,4 +1,3 @@
-import type { FileHandle } from "node:fs/promises";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -21,23 +20,22 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     openState.failInPlaceWriteAfterBytes = null;
     let shortWriteArmed = openState.shortFirstRestoreWrite;
     openState.shortFirstRestoreWrite = false;
+    const realWrite = handle.write.bind(handle);
     const failingWriteFile = async (content: string) => {
       const partial = Buffer.from(content, "utf-8").subarray(0, partialBytes);
-      await handle.write(partial, 0, partial.length, 0);
+      await realWrite(partial, 0, partial.length, 0);
       throw Object.assign(new Error("EFBIG: file too large, write"), { code: "EFBIG" });
     };
     const write = async (buffer: Buffer, offset: number, length: number, position: number) => {
       const cappedLength = shortWriteArmed && length > 1 ? Math.floor(length / 2) : length;
       shortWriteArmed = false;
-      return await handle.write(buffer, offset, cappedLength, position);
+      return await realWrite(buffer, offset, cappedLength, position);
     };
-    return {
-      writeFile: failingWriteFile,
-      write,
-      truncate: handle.truncate.bind(handle),
-      sync: handle.sync.bind(handle),
-      close: handle.close.bind(handle),
-    } as unknown as FileHandle;
+    Object.defineProperties(handle, {
+      writeFile: { value: failingWriteFile },
+      write: { value: write },
+    });
+    return handle;
   };
   return { ...actual, default: { ...actual, open }, open };
 });
@@ -68,60 +66,49 @@ async function setupReadOnlyMemoryDir(originalContent: string): Promise<string> 
   return memoryPath;
 }
 
-it("keeps the original MEMORY.md when the in-place fallback write fails partway", async () => {
-  const original = "# Long-Term Memory\n\n- existing entry that must survive\n";
-  const memoryPath = await setupReadOnlyMemoryDir(original);
-  const promoted = `${original}${"- promoted entry\n".repeat(200)}`;
-  openState.failInPlaceWriteAfterBytes = 1024;
+it.runIf(process.platform !== "win32")(
+  "keeps the original MEMORY.md when the in-place fallback write fails partway",
+  async () => {
+    const original = "# Long-Term Memory\n\n- existing entry that must survive\n";
+    const memoryPath = await setupReadOnlyMemoryDir(original);
+    const promoted = `${original}${"- promoted entry\n".repeat(200)}`;
+    openState.failInPlaceWriteAfterBytes = 1024;
 
-  await expect(
-    writeMemoryContent({
-      memoryPath,
-      memoryWritePath: memoryPath,
-      expectedHash: hashMemoryContent(original),
-      expectedContent: original,
-      allowInPlaceFallback: true,
-      content: promoted,
-    }),
-  ).rejects.toMatchObject({ code: "EFBIG" });
+    await expect(
+      writeMemoryContent({
+        memoryPath,
+        memoryWritePath: memoryPath,
+        expectedHash: hashMemoryContent(original),
+        expectedContent: original,
+        allowInPlaceFallback: true,
+        content: promoted,
+      }),
+    ).rejects.toMatchObject({ code: "EFBIG" });
 
-  expect(await fs.readFile(memoryPath, "utf-8")).toBe(original);
-});
+    expect(await fs.readFile(memoryPath, "utf-8")).toBe(original);
+  },
+);
 
-it("completes the restore across short writes before truncating", async () => {
-  const original = "# Long-Term Memory\n\n- existing entry that must survive\n";
-  const memoryPath = await setupReadOnlyMemoryDir(original);
-  const promoted = `# Long-Term Memory\n\n## 2026-08-19\n${"- promoted entry\n".repeat(200)}`;
-  openState.failInPlaceWriteAfterBytes = 1024;
-  openState.shortFirstRestoreWrite = true;
+it.runIf(process.platform !== "win32")(
+  "completes the restore across short writes before truncating",
+  async () => {
+    const original = "# Long-Term Memory\n\n- existing entry that must survive\n";
+    const memoryPath = await setupReadOnlyMemoryDir(original);
+    const promoted = `# Long-Term Memory\n\n## 2026-08-19\n${"- promoted entry\n".repeat(200)}`;
+    openState.failInPlaceWriteAfterBytes = 1024;
+    openState.shortFirstRestoreWrite = true;
 
-  await expect(
-    writeMemoryContent({
-      memoryPath,
-      memoryWritePath: memoryPath,
-      expectedHash: hashMemoryContent(original),
-      expectedContent: original,
-      allowInPlaceFallback: true,
-      content: promoted,
-    }),
-  ).rejects.toMatchObject({ code: "EFBIG" });
+    await expect(
+      writeMemoryContent({
+        memoryPath,
+        memoryWritePath: memoryPath,
+        expectedHash: hashMemoryContent(original),
+        expectedContent: original,
+        allowInPlaceFallback: true,
+        content: promoted,
+      }),
+    ).rejects.toMatchObject({ code: "EFBIG" });
 
-  expect(await fs.readFile(memoryPath, "utf-8")).toBe(original);
-});
-
-it("writes promoted content through the in-place fallback when the write succeeds", async () => {
-  const original = "# Long-Term Memory\n\n- existing entry\n";
-  const memoryPath = await setupReadOnlyMemoryDir(original);
-  const promoted = `${original}- promoted entry\n`;
-
-  await writeMemoryContent({
-    memoryPath,
-    memoryWritePath: memoryPath,
-    expectedHash: hashMemoryContent(original),
-    expectedContent: original,
-    allowInPlaceFallback: true,
-    content: promoted,
-  });
-
-  expect(await fs.readFile(memoryPath, "utf-8")).toBe(promoted);
-});
+    expect(await fs.readFile(memoryPath, "utf-8")).toBe(original);
+  },
+);

--- a/extensions/memory-core/src/short-term-promotion-memory-write.test.ts
+++ b/extensions/memory-core/src/short-term-promotion-memory-write.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import { hashMemoryContent, writeMemoryContent } from "./short-term-promotion-memory-write.js";
 
-const openState = vi.hoisted(() => ({ failInPlaceWriteAfterBytes: null as number | null }));
+const openState = vi.hoisted(() => ({
+  failInPlaceWriteAfterBytes: null as number | null,
+  shortFirstRestoreWrite: false,
+}));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
@@ -16,14 +19,21 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       return handle;
     }
     openState.failInPlaceWriteAfterBytes = null;
+    let shortWriteArmed = openState.shortFirstRestoreWrite;
+    openState.shortFirstRestoreWrite = false;
     const failingWriteFile = async (content: string) => {
       const partial = Buffer.from(content, "utf-8").subarray(0, partialBytes);
       await handle.write(partial, 0, partial.length, 0);
       throw Object.assign(new Error("EFBIG: file too large, write"), { code: "EFBIG" });
     };
+    const write = async (buffer: Buffer, offset: number, length: number, position: number) => {
+      const cappedLength = shortWriteArmed && length > 1 ? Math.floor(length / 2) : length;
+      shortWriteArmed = false;
+      return await handle.write(buffer, offset, cappedLength, position);
+    };
     return {
       writeFile: failingWriteFile,
-      write: handle.write.bind(handle),
+      write,
       truncate: handle.truncate.bind(handle),
       sync: handle.sync.bind(handle),
       close: handle.close.bind(handle),
@@ -36,6 +46,7 @@ const cleanups: Array<() => Promise<void>> = [];
 
 afterEach(async () => {
   openState.failInPlaceWriteAfterBytes = null;
+  openState.shortFirstRestoreWrite = false;
   while (cleanups.length > 0) {
     await cleanups.pop()?.();
   }
@@ -62,6 +73,27 @@ it("keeps the original MEMORY.md when the in-place fallback write fails partway"
   const memoryPath = await setupReadOnlyMemoryDir(original);
   const promoted = `${original}${"- promoted entry\n".repeat(200)}`;
   openState.failInPlaceWriteAfterBytes = 1024;
+
+  await expect(
+    writeMemoryContent({
+      memoryPath,
+      memoryWritePath: memoryPath,
+      expectedHash: hashMemoryContent(original),
+      expectedContent: original,
+      allowInPlaceFallback: true,
+      content: promoted,
+    }),
+  ).rejects.toMatchObject({ code: "EFBIG" });
+
+  expect(await fs.readFile(memoryPath, "utf-8")).toBe(original);
+});
+
+it("completes the restore across short writes before truncating", async () => {
+  const original = "# Long-Term Memory\n\n- existing entry that must survive\n";
+  const memoryPath = await setupReadOnlyMemoryDir(original);
+  const promoted = `# Long-Term Memory\n\n## 2026-08-19\n${"- promoted entry\n".repeat(200)}`;
+  openState.failInPlaceWriteAfterBytes = 1024;
+  openState.shortFirstRestoreWrite = true;
 
   await expect(
     writeMemoryContent({

--- a/extensions/memory-core/src/short-term-promotion-memory-write.ts
+++ b/extensions/memory-core/src/short-term-promotion-memory-write.ts
@@ -82,6 +82,19 @@ async function writeExistingMemoryInPlace(params: {
     await handle.truncate(Buffer.byteLength(params.content));
     await handle.sync();
     return true;
+  } catch (error) {
+    const original = Buffer.from(params.expectedContent, "utf-8");
+    try {
+      await handle.write(original, 0, original.length, 0);
+      await handle.truncate(original.length);
+      await handle.sync();
+    } catch (restoreError) {
+      throw new Error(
+        "MEMORY.md in-place write failed and restoring the original content also failed",
+        { cause: restoreError },
+      );
+    }
+    throw error;
   } finally {
     await handle.close();
   }

--- a/extensions/memory-core/src/short-term-promotion-memory-write.ts
+++ b/extensions/memory-core/src/short-term-promotion-memory-write.ts
@@ -85,7 +85,19 @@ async function writeExistingMemoryInPlace(params: {
   } catch (error) {
     const original = Buffer.from(params.expectedContent, "utf-8");
     try {
-      await handle.write(original, 0, original.length, 0);
+      let restored = 0;
+      while (restored < original.length) {
+        const { bytesWritten } = await handle.write(
+          original,
+          restored,
+          original.length - restored,
+          restored,
+        );
+        if (bytesWritten <= 0) {
+          throw new Error("MEMORY.md restore write made no progress", { cause: error });
+        }
+        restored += bytesWritten;
+      }
       await handle.truncate(original.length);
       await handle.sync();
     } catch (restoreError) {


### PR DESCRIPTION
## Problem

When Memory Core cannot replace `MEMORY.md` atomically because the directory blocks temporary files or rename, it falls back to updating the existing writable file in place. If that write fails partway with `EFBIG`, `ENOSPC`, or another write error, the old file is left partially overwritten.

This is user-data corruption. The recall store does not mark the promotion as complete, but the lost `MEMORY.md` bytes are not recoverable downstream.

## Root cause

`writeExistingMemoryInPlace` verifies the current file against `expectedContent`, opens it with `r+`, and calls `writeFile`. The old implementation closed the file after a partial write error without restoring the verified preimage.

Only the append-only promotion path enables this ACL-compatible fallback. Consolidation uses atomic replacement and does not write in place.

## Fix

The in-place writer now restores the verified preimage before it returns the original write error. The restore uses positional writes and advances by `bytesWritten` until every byte is back. It then truncates to the original byte length and synchronizes the file.

The offset loop is required because a restore write can make partial progress without throwing. A zero-progress write stops with an explicit recovery error instead of looping forever.

## Proof

Real kernel `EFBIG` proof used the production `writeMemoryContent` entry point, a real read-only directory, a writable existing `MEMORY.md`, and `ulimit -f 2`.

- Current main `2a76736fcb77440e98b2569a63d27a46f5683482`: `EFBIG`; 55-byte preimage became a 1,024-byte partial file; `afterEqualsOriginal=false`.
- Final head `c3f3e8008ab5491b79a6ff24bebfaa9b4d8d5af8`: `EFBIG`; file stayed 55 bytes; `afterEqualsOriginal=true`.
- The same two recovery tests fail against current-main writer code for the corrupted-content assertion.
- The short-write test fails against the first one-shot restore commit with a spliced file, then passes with the full offset loop.
- `node scripts/run-vitest.mjs extensions/memory-core/src/short-term-promotion-memory-write.test.ts extensions/memory-core/src/short-term-promotion.test.ts`: 2 files passed, 93 tests passed.
- `node_modules/.bin/oxfmt --check ...`: passed.
- `node_modules/.bin/oxlint ...`: passed.

The existing `short-term-promotion.test.ts` integration covers the successful append-only ACL fallback through the full promotion owner. Telegram cannot observe this filesystem failure, so the required default direct-message probe is collateral only; the kernel `EFBIG` run is authoritative.

## Scope

- Production: +25 lines for failure-only preimage recovery.
- Tests: +114 lines for partial failure and short restore writes.
- Normal successful writes keep the same path and cost.
- No config, schema, protocol, or migration changes.

## Telegram collateral

The generic default direct-message probe passed on the final head. The dedicated QA user sent `Please answer with OPENCLAW_E2E_BASIC only.`; the TDLib timeline recorded the user message, two typing events, and the bot reply `OPENCLAW_E2E_BASIC`. The gateway log recorded readiness and clean shutdown. The mock-provider log recorded one `POST /v1/responses` request.

This filesystem durability bug is not Telegram-observable. The real kernel `EFBIG` writer proof above is authoritative.