### PR TITLE
refactor: share media and process runtime helpers

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -234,7 +234,7 @@ Use `isLoopbackHost(host)` when a plugin must accept only the local machine. It 
     | `plugin-sdk/plugin-runtime` | Deprecated broad barrel for plugin command/hook/http/interactive helpers; prefer focused plugin runtime subpaths |
     | `plugin-sdk/hook-runtime` | Deprecated broad barrel for webhook/internal hook pipeline helpers; prefer focused hook/plugin runtime subpaths |
     | `plugin-sdk/lazy-runtime` | Lazy runtime import/binding helpers such as `createLazyRuntimeModule`, `createLazyRuntimeMethod`, and `createLazyRuntimeSurface` |
-    | `plugin-sdk/process-runtime` | Private-local after July 2026; Process exec helpers |
+    | `plugin-sdk/process-runtime` | Private-local after July 2026; bounded process execution with per-stream and aggregate output caps, opt-in stream-error termination, and configurable TERM-to-KILL grace |
     | `plugin-sdk/node-host` | Private-local after July 2026; Node-host executable resolution and PTY resume helpers |
     | `plugin-sdk/node-selection-runtime` | Private-local bundled runtime facade for shared capability-gated node selection policy |
     | `plugin-sdk/cli-argv` | Dependency-light root-option parsing for CLI metadata, including `getRootOptionAwareCommandPath` and `consumeRootOptionToken` |

--- a/extensions/codex/src/node-cli-sessions.test.ts
+++ b/extensions/codex/src/node-cli-sessions.test.ts
@@ -12,11 +12,23 @@ import {
 
 const CODEX_CLI_SESSIONS_LIST_COMMAND = "codex.cli.sessions.list";
 
+type RunCommandBuffered =
+  (typeof import("openclaw/plugin-sdk/process-runtime"))["runCommandBuffered"];
+const processRuntimeMocks = vi.hoisted(() => ({
+  runCommandBuffered: vi.fn<RunCommandBuffered>(),
+}));
+
+vi.mock("openclaw/plugin-sdk/process-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/process-runtime")>()),
+  runCommandBuffered: processRuntimeMocks.runCommandBuffered,
+}));
+
 let tempDir: string;
 let previousCodexHome: string | undefined;
 
 describe("codex cli node sessions", () => {
   beforeEach(async () => {
+    processRuntimeMocks.runCommandBuffered.mockReset();
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-cli-sessions-"));
     previousCodexHome = process.env.CODEX_HOME;
     process.env.CODEX_HOME = tempDir;
@@ -75,6 +87,62 @@ describe("codex cli node sessions", () => {
         messageCount: 2,
       },
     ]);
+  });
+
+  it("resumes through the bounded process owner without changing the Codex CLI contract", async () => {
+    processRuntimeMocks.runCommandBuffered.mockImplementation(async (argv) => {
+      const outputFlag = argv.indexOf("--output-last-message");
+      const outputPath = argv[outputFlag + 1];
+      if (outputFlag < 0 || !outputPath) {
+        throw new Error("missing Codex output path");
+      }
+      await fs.writeFile(outputPath, "final answer\n", "utf8");
+      return {
+        stdout: Buffer.from("diagnostic"),
+        stderr: Buffer.alloc(0),
+        code: 0,
+        signal: null,
+        killed: false,
+        termination: "exit",
+      };
+    });
+
+    const command = createCodexCliSessionNodeHostCommands().find(
+      (entry) => entry.command === "codex.cli.session.resume",
+    );
+    const raw = await command?.handle(
+      JSON.stringify({
+        sessionId: "session-123",
+        prompt: "continue this task",
+        cwd: tempDir,
+        timeoutMs: 12_345,
+      }),
+    );
+
+    expect(JSON.parse(raw ?? "{}")).toEqual({
+      ok: true,
+      sessionId: "session-123",
+      text: "final answer",
+    });
+    const [argv, options] = processRuntimeMocks.runCommandBuffered.mock.calls[0] ?? [];
+    const execIndex = argv?.indexOf("exec") ?? -1;
+    expect(argv?.slice(execIndex, execIndex + 7)).toEqual([
+      "exec",
+      "resume",
+      "--skip-git-repo-check",
+      "--output-last-message",
+      expect.any(String),
+      "session-123",
+      "-",
+    ]);
+    expect(options).toMatchObject({
+      cwd: tempDir,
+      input: "continue this task",
+      killGraceMs: 2_000,
+      killProcessTree: false,
+      terminateOnOutputError: true,
+      timeoutMs: 12_345,
+    });
   });
 
   it("ignores Date-invalid Codex history timestamps", async () => {

--- a/extensions/codex/src/node-cli-sessions.ts
+++ b/extensions/codex/src/node-cli-sessions.ts
@@ -1,5 +1,4 @@
 // Codex plugin module implements node cli sessions behavior.
-import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -11,6 +10,7 @@ import type {
   OpenClawPluginNodeInvokePolicy,
 } from "openclaw/plugin-sdk/plugin-entry";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
+import { runCommandBuffered } from "openclaw/plugin-sdk/process-runtime";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
@@ -56,18 +56,6 @@ type CodexCliSessionNodeInfo = {
   remoteIp?: string;
   connected?: boolean;
   commands?: string[];
-};
-
-type CodexCliResumeSpawnRuntime = {
-  platform: NodeJS.Platform;
-  env: NodeJS.ProcessEnv;
-  execPath: string;
-};
-
-const DEFAULT_RESUME_SPAWN_RUNTIME: CodexCliResumeSpawnRuntime = {
-  platform: process.platform,
-  env: process.env,
-  execPath: process.execPath,
 };
 
 export function createCodexCliSessionNodeHostCommands(): OpenClawPluginNodeHostCommand[] {
@@ -273,74 +261,42 @@ async function runCodexExecResume(params: {
       params.sessionId,
       "-",
     ];
-    const invocation = resolveCodexCliResumeSpawnInvocation(args, {
-      platform: process.platform,
-      env: process.env,
-      execPath: process.execPath,
-    });
-    const child = spawn(invocation.command, invocation.args, {
+    const invocation = materializeWindowsSpawnProgram(
+      resolveWindowsSpawnProgram({
+        command: "codex",
+        platform: process.platform,
+        env: process.env,
+        execPath: process.execPath,
+        packageName: "@openai/codex",
+      }),
+      args,
+    );
+    const result = await runCommandBuffered([invocation.command, ...invocation.argv], {
       cwd: params.cwd || process.cwd(),
-      stdio: ["pipe", "pipe", "pipe"],
+      input: params.prompt,
       env: process.env,
-      shell: invocation.shell,
-      windowsHide: invocation.windowsHide,
+      killGraceMs: 2_000,
+      killProcessTree: false,
+      terminateOnOutputError: true,
+      timeoutMs: params.timeoutMs,
     });
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-    let timedOut = false;
-    let forceKillTimeout: NodeJS.Timeout | undefined;
-    const timeout = setTimeout(() => {
-      timedOut = true;
-      child.kill("SIGTERM");
-      forceKillTimeout = setTimeout(() => child.kill("SIGKILL"), 2_000);
-      forceKillTimeout.unref?.();
-    }, params.timeoutMs);
-    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
-    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
-    child.stdin.end(params.prompt);
-    const exitCode = await new Promise<number | null>((resolve, reject) => {
-      child.on("error", reject);
-      child.on("exit", (code) => resolve(code));
-    }).finally(() => {
-      clearTimeout(timeout);
-      if (forceKillTimeout) {
-        clearTimeout(forceKillTimeout);
-      }
-    });
-    if (timedOut) {
+    if (result.termination === "timeout") {
       throw new Error(`codex exec resume timed out after ${String(params.timeoutMs)}ms`);
     }
-    if (exitCode !== 0) {
+    if (result.termination === "error" && result.error) {
+      throw result.error;
+    }
+    if (result.code !== 0) {
       const message =
-        Buffer.concat(stderr).toString("utf8").trim() ||
-        Buffer.concat(stdout).toString("utf8").trim() ||
-        `codex exec resume exited with code ${String(exitCode)}`;
+        result.stderr.toString("utf8").trim() ||
+        result.stdout.toString("utf8").trim() ||
+        `codex exec resume exited with code ${String(result.code)}`;
       throw new Error(message);
     }
     return await fs.readFile(outputPath, "utf8");
   } finally {
     await fs.rm(path.dirname(outputPath), { recursive: true, force: true });
   }
-}
-
-function resolveCodexCliResumeSpawnInvocation(
-  args: string[],
-  runtime: CodexCliResumeSpawnRuntime = DEFAULT_RESUME_SPAWN_RUNTIME,
-): { command: string; args: string[]; shell?: boolean; windowsHide?: boolean } {
-  const program = resolveWindowsSpawnProgram({
-    command: "codex",
-    platform: runtime.platform,
-    env: runtime.env,
-    execPath: runtime.execPath,
-    packageName: "@openai/codex",
-  });
-  const resolved = materializeWindowsSpawnProgram(program, args);
-  return {
-    command: resolved.command,
-    args: resolved.argv,
-    shell: resolved.shell,
-    windowsHide: resolved.windowsHide,
-  };
 }
 
 async function readHistorySessions(

--- a/extensions/moonshot/media-understanding-provider.ts
+++ b/extensions/moonshot/media-understanding-provider.ts
@@ -1,21 +1,11 @@
 // Moonshot provider module implements model/runtime integration.
 import {
-  buildOpenAiCompatibleVideoRequestBody,
-  coerceOpenAiCompatibleVideoText,
+  describeOpenAiCompatibleVideo,
   describeImageWithModel,
   describeImagesWithModel,
-  resolveMediaUnderstandingString,
   type MediaUnderstandingProvider,
-  type OpenAiCompatibleVideoPayload,
   type VideoDescriptionRequest,
-  type VideoDescriptionResult,
 } from "openclaw/plugin-sdk/media-understanding";
-import {
-  assertOkOrThrowHttpError,
-  postJsonRequest,
-  readProviderJsonResponse,
-  resolveProviderHttpRequestConfig,
-} from "openclaw/plugin-sdk/provider-http";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { MOONSHOT_BASE_URL } from "./provider-catalog.js";
 
@@ -28,60 +18,15 @@ const DEFAULT_MOONSHOT_VIDEO_PROMPT = "Describe the video.";
 
 async function describeMoonshotVideo(
   params: VideoDescriptionRequest,
-): Promise<VideoDescriptionResult> {
-  const fetchFn = params.fetchFn ?? fetch;
-  const model = resolveMediaUnderstandingString(params.model, DEFAULT_MOONSHOT_VIDEO_MODEL);
-  const mime = resolveMediaUnderstandingString(params.mime, "video/mp4");
-  const prompt = resolveMediaUnderstandingString(params.prompt, DEFAULT_MOONSHOT_VIDEO_PROMPT);
-  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
-    resolveProviderHttpRequestConfig({
-      baseUrl: params.baseUrl,
-      defaultBaseUrl: MOONSHOT_BASE_URL,
-      headers: params.headers,
-      request: params.request,
-      defaultHeaders: {
-        "content-type": "application/json",
-        authorization: `Bearer ${params.apiKey}`,
-      },
-      provider: "moonshot",
-      api: "openai-completions",
-      capability: "video",
-      transport: "media-understanding",
-    });
-  const url = `${baseUrl}/chat/completions`;
-
-  const body = buildOpenAiCompatibleVideoRequestBody({
-    model,
-    prompt,
-    mime,
-    buffer: params.buffer,
+): ReturnType<typeof describeOpenAiCompatibleVideo> {
+  return describeOpenAiCompatibleVideo({
+    ...params,
+    defaultBaseUrl: MOONSHOT_BASE_URL,
+    defaultModel: DEFAULT_MOONSHOT_VIDEO_MODEL,
+    defaultPrompt: DEFAULT_MOONSHOT_VIDEO_PROMPT,
+    provider: "moonshot",
+    providerLabel: "Moonshot",
   });
-
-  const { response: res, release } = await postJsonRequest({
-    url,
-    headers,
-    body,
-    timeoutMs: params.timeoutMs,
-    ...(params.signal ? { signal: params.signal } : {}),
-    fetchFn,
-    allowPrivateNetwork,
-    dispatcherPolicy,
-  });
-
-  try {
-    await assertOkOrThrowHttpError(res, "Moonshot video description failed");
-    const payload = await readProviderJsonResponse<OpenAiCompatibleVideoPayload>(
-      res,
-      "Moonshot video description failed",
-    );
-    const text = coerceOpenAiCompatibleVideoText(payload);
-    if (!text) {
-      throw new Error("Moonshot video description response missing content");
-    }
-    return { text, model };
-  } finally {
-    await release();
-  }
 }
 
 export const moonshotMediaUnderstandingProvider: MediaUnderstandingProvider = {

--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -1,5 +1,3 @@
-import type { ChildProcess } from "node:child_process";
-import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -11,6 +9,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 type ResolveAcpSessionAvailability =
   (typeof import("openclaw/plugin-sdk/acp-runtime"))["resolveAcpSessionAvailability"];
+type RunCommandBuffered =
+  (typeof import("openclaw/plugin-sdk/process-runtime"))["runCommandBuffered"];
 type RegisteredSessionCatalogProvider = Parameters<OpenClawPluginApi["registerSessionCatalog"]>[0];
 type OptionalCatalogAgent<T extends { agentId?: string }> = Omit<T, "agentId"> & {
   agentId?: string;
@@ -76,22 +76,17 @@ const nodeHostMocks = vi.hoisted(() => ({
 const acpRuntimeMocks = vi.hoisted(() => ({
   resolveAcpSessionAvailability: vi.fn<ResolveAcpSessionAvailability>(() => ({ available: true })),
 }));
-const childProcessMocks = vi.hoisted(() => ({
-  children: [] as ChildProcess[],
-  spawn: vi.fn(),
+const processRuntimeMocks = vi.hoisted(() => ({
+  runCommandBuffered: vi.fn<RunCommandBuffered>(),
 }));
 const transcriptMocks = vi.hoisted(() => ({
   messages: [] as Array<Record<string, unknown>>,
 }));
 
-vi.mock("node:child_process", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:child_process")>();
-  childProcessMocks.spawn.mockImplementation((...args: Parameters<typeof actual.spawn>) => {
-    const child = actual.spawn(...args);
-    childProcessMocks.children.push(child);
-    return child;
-  });
-  return { ...actual, spawn: childProcessMocks.spawn };
+vi.mock("openclaw/plugin-sdk/process-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/process-runtime")>();
+  processRuntimeMocks.runCommandBuffered.mockImplementation(actual.runCommandBuffered);
+  return { ...actual, runCommandBuffered: processRuntimeMocks.runCommandBuffered };
 });
 
 vi.mock("openclaw/plugin-sdk/acp-runtime", async (importOriginal) => ({
@@ -384,48 +379,6 @@ if (args[0] === "--pure" && args[1] === "db" && args.includes("--format") && arg
   return directory;
 }
 
-async function installHangingOpenCode(): Promise<void> {
-  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-opencode-stream-"));
-  temporaryDirectories.push(directory);
-  const executableName = process.platform === "win32" ? "opencode.js" : "opencode";
-  await fs.writeFile(
-    path.join(directory, executableName),
-    `${process.platform === "win32" ? "" : "#!/usr/bin/env node\n"}setTimeout(() => process.stdout.write("ready\\n"), 50);
-setInterval(() => {}, 1_000);
-`,
-  );
-  if (process.platform !== "win32") {
-    await fs.chmod(path.join(directory, executableName), 0o755);
-  }
-  process.env.PATH = `${directory}${path.delimiter}${originalPath ?? ""}`;
-  if (process.platform === "win32") {
-    // The production resolver converts a PATHEXT-resolved .js command into
-    // process.execPath plus the script path, so this remains a direct real-child spawn.
-    process.env.PATHEXT = `.JS;${originalPathExt ?? ".EXE;.CMD;.BAT;.COM"}`;
-  }
-}
-
-function isProcessRunning(pid: number | undefined): boolean {
-  if (!pid) {
-    return false;
-  }
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function stopChild(child: ChildProcess | undefined): Promise<void> {
-  if (!child || !isProcessRunning(child.pid)) {
-    return;
-  }
-  const closed = once(child, "close");
-  child.kill("SIGKILL");
-  await closed;
-}
-
 function restoreEnv(name: string, value: string | undefined) {
   Reflect.deleteProperty(process.env, name);
   if (value !== undefined) {
@@ -436,9 +389,8 @@ function restoreEnv(name: string, value: string | undefined) {
 afterEach(async () => {
   acpRuntimeMocks.resolveAcpSessionAvailability.mockReset().mockReturnValue({ available: true });
   nodeHostMocks.runNodePtyCommand.mockClear();
-  childProcessMocks.spawn.mockClear();
+  processRuntimeMocks.runCommandBuffered.mockClear();
   transcriptMocks.messages.length = 0;
-  await Promise.all(childProcessMocks.children.splice(0).map((child) => stopChild(child)));
   process.env.PATH = originalPath;
   restoreEnv("PATHEXT", originalPathExt);
   restoreEnv("CATALOG_UNRELATED_ENV", originalUnrelatedEnv);
@@ -559,21 +511,21 @@ describe("OpenCode session catalog", () => {
       try {
         await listLocalOpenCodeSessionPage({ limit: 20 }, { configIdentity });
         await listLocalOpenCodeSessionPage({ limit: 20 }, { configIdentity });
-        expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+        expect(processRuntimeMocks.runCommandBuffered).toHaveBeenCalledOnce();
 
         now += 31_999;
         await listLocalOpenCodeSessionPage({ limit: 20 }, { configIdentity });
-        expect(childProcessMocks.spawn).toHaveBeenCalledOnce();
+        expect(processRuntimeMocks.runCommandBuffered).toHaveBeenCalledOnce();
 
         await listLocalOpenCodeSessionPage({ limit: 20 }, { configIdentity, forceRefresh: true });
-        expect(childProcessMocks.spawn).toHaveBeenCalledTimes(2);
+        expect(processRuntimeMocks.runCommandBuffered).toHaveBeenCalledTimes(2);
 
         await listLocalOpenCodeSessionPage({ limit: 20 }, { configIdentity: {} });
-        expect(childProcessMocks.spawn).toHaveBeenCalledTimes(3);
+        expect(processRuntimeMocks.runCommandBuffered).toHaveBeenCalledTimes(3);
 
         now += 32_001;
         await listLocalOpenCodeSessionPage({ limit: 20 }, { configIdentity });
-        expect(childProcessMocks.spawn).toHaveBeenCalledTimes(4);
+        expect(processRuntimeMocks.runCommandBuffered).toHaveBeenCalledTimes(4);
       } finally {
         nowSpy.mockRestore();
       }
@@ -929,31 +881,27 @@ describe("OpenCode session catalog", () => {
   });
 
   it.each(["stdout", "stderr"] as const)(
-    "rejects and reaps the real OpenCode child when its %s pipe fails",
+    "maps a shared-runtime %s pipe failure to the OpenCode-owned error",
     async (streamName) => {
-      await installHangingOpenCode();
-      const uncaughtException = vi.fn();
-      process.on("uncaughtExceptionMonitor", uncaughtException);
-      let child: ChildProcess | undefined;
-      try {
-        const listing = listLocalOpenCodeSessionPage({ limit: 20 });
-        await vi.waitFor(() => expect(childProcessMocks.spawn).toHaveBeenCalledTimes(1));
-        child = childProcessMocks.children[0];
-        expect(child?.pid).toBeTypeOf("number");
-        await once(child!.stdout!, "data");
+      processRuntimeMocks.runCommandBuffered.mockResolvedValueOnce({
+        stdout: Buffer.alloc(0),
+        stderr: Buffer.alloc(0),
+        code: null,
+        signal: null,
+        killed: true,
+        termination: "error",
+        errorStream: streamName,
+        error: new Error(`${streamName} EPIPE`),
+      });
 
-        child![streamName]!.destroy(new Error(`${streamName} EPIPE`));
-
-        await expectRejects(listing, `OpenCode ${streamName} stream failed: ${streamName} EPIPE`);
-        await new Promise<void>((resolve) => {
-          setImmediate(resolve);
-        });
-        expect(uncaughtException).not.toHaveBeenCalled();
-        expect(isProcessRunning(child!.pid)).toBe(false);
-      } finally {
-        process.off("uncaughtExceptionMonitor", uncaughtException);
-        await stopChild(child);
-      }
+      await expectRejects(
+        listLocalOpenCodeSessionPage({ limit: 20 }),
+        `OpenCode ${streamName} stream failed: ${streamName} EPIPE`,
+      );
+      expect(processRuntimeMocks.runCommandBuffered).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ terminateOnOutputError: true }),
+      );
     },
   );
 

--- a/extensions/opencode/session-catalog.ts
+++ b/extensions/opencode/session-catalog.ts
@@ -1,5 +1,5 @@
-import { spawn } from "node:child_process";
 import process from "node:process";
+import { runCommandBuffered } from "openclaw/plugin-sdk/process-runtime";
 import type {
   SessionCatalogSession,
   SessionCatalogTranscriptItem,
@@ -94,76 +94,49 @@ const OPENCODE_PARAMETER_MESSAGES = {
   invalidThreadId: "threadId is invalid",
 };
 
-function resolveSpawnInvocation(args: string[]): {
-  command: string;
-  argv: string[];
-  shell?: boolean;
-  windowsHide?: boolean;
-} {
-  const program = resolveWindowsSpawnProgram({
-    command: "opencode",
-    platform: process.platform,
-    env: process.env,
-    execPath: process.execPath,
-    packageName: "opencode-ai",
-  });
-  return materializeWindowsSpawnProgram(program, args);
-}
-
 async function runOpenCode(args: string[]): Promise<string> {
-  const invocation = resolveSpawnInvocation(args);
+  const invocation = materializeWindowsSpawnProgram(
+    resolveWindowsSpawnProgram({
+      command: "opencode",
+      platform: process.platform,
+      env: process.env,
+      execPath: process.execPath,
+      packageName: "opencode-ai",
+    }),
+    args,
+  );
   const env: NodeJS.ProcessEnv = { OPENCODE_PURE: "1", NO_COLOR: "1" };
   for (const key of SAFE_ENV_KEYS) {
     if (process.env[key] !== undefined) {
       env[key] = process.env[key];
     }
   }
-  const child = spawn(invocation.command, invocation.argv, {
+  const result = await runCommandBuffered([invocation.command, ...invocation.argv], {
+    baseEnv: {},
     env,
-    shell: invocation.shell,
-    windowsHide: invocation.windowsHide,
-    stdio: ["ignore", "pipe", "pipe"],
+    input: "",
+    maxCombinedOutputBytes: MAX_CLI_OUTPUT_BYTES,
+    maxOutputBytes: MAX_CLI_OUTPUT_BYTES,
+    terminateOnOutputError: true,
+    timeoutMs: CLI_TIMEOUT_MS,
   });
-  const stdout: Buffer[] = [];
-  const stderr: Buffer[] = [];
-  let bytes = 0;
-  let overflow = false;
-  const timeout = setTimeout(() => child.kill("SIGKILL"), CLI_TIMEOUT_MS);
-  timeout.unref?.();
-  let outputError: Error | undefined;
-  const failFromOutputError = (source: "stdout" | "stderr", error: unknown) => {
-    const message = error instanceof Error ? error.message : String(error);
-    outputError ??= new Error(`OpenCode ${source} stream failed: ${message}`, { cause: error });
-    child.kill("SIGKILL");
-  };
-  const collect = (target: Buffer[], chunk: Buffer) => {
-    bytes += chunk.length;
-    if (bytes > MAX_CLI_OUTPUT_BYTES) {
-      overflow = true;
-      child.kill("SIGKILL");
-      return;
-    }
-    target.push(chunk);
-  };
-  child.stdout.once("error", (error) => failFromOutputError("stdout", error));
-  child.stderr.once("error", (error) => failFromOutputError("stderr", error));
-  child.stdout.on("data", (chunk: Buffer) => collect(stdout, chunk));
-  child.stderr.on("data", (chunk: Buffer) => collect(stderr, chunk));
-  const exitCode = await new Promise<number | null>((resolve, reject) => {
-    child.on("error", reject);
-    child.on("close", resolve);
-  }).finally(() => clearTimeout(timeout));
-  if (overflow) {
+  if (result.termination === "output-limit") {
     throw new Error("OpenCode session output exceeded the safety limit");
   }
-  if (outputError) {
-    throw outputError;
+  if (result.errorStream) {
+    const message = result.error?.message ?? "unknown error";
+    throw new Error(`OpenCode ${result.errorStream} stream failed: ${message}`, {
+      cause: result.error,
+    });
   }
-  if (exitCode !== 0) {
-    const detail = Buffer.concat(stderr).toString("utf8").trim();
-    throw new Error(detail || `OpenCode exited with code ${String(exitCode)}`);
+  if (result.termination === "error" && result.error) {
+    throw result.error;
   }
-  return Buffer.concat(stdout).toString("utf8");
+  if (result.code !== 0) {
+    const detail = result.stderr.toString("utf8").trim();
+    throw new Error(detail || `OpenCode exited with code ${String(result.code)}`);
+  }
+  return result.stdout.toString("utf8");
 }
 
 export async function queryOpenCodeDatabase(query: string): Promise<unknown> {

--- a/extensions/qwen/media-understanding-provider.ts
+++ b/extensions/qwen/media-understanding-provider.ts
@@ -1,81 +1,25 @@
 // Qwen provider module implements model/runtime integration.
 import {
-  buildOpenAiCompatibleVideoRequestBody,
-  coerceOpenAiCompatibleVideoText,
+  describeOpenAiCompatibleVideo,
   describeImageWithModel,
   describeImagesWithModel,
-  resolveMediaUnderstandingString,
   type MediaUnderstandingProvider,
-  type OpenAiCompatibleVideoPayload,
   type VideoDescriptionRequest,
-  type VideoDescriptionResult,
 } from "openclaw/plugin-sdk/media-understanding";
-import {
-  assertOkOrThrowHttpError,
-  postJsonRequest,
-  readProviderJsonResponse,
-  resolveProviderHttpRequestConfig,
-} from "openclaw/plugin-sdk/provider-http";
 import { QWEN_STANDARD_GLOBAL_BASE_URL } from "./models.js";
 
 const DEFAULT_QWEN_MEDIA_MODEL = "qwen3.6-plus";
 const DEFAULT_QWEN_VIDEO_PROMPT = "Describe the video in detail.";
 
-async function describeQwenVideo(params: VideoDescriptionRequest): Promise<VideoDescriptionResult> {
-  const fetchFn = params.fetchFn ?? fetch;
-  const model = resolveMediaUnderstandingString(params.model, DEFAULT_QWEN_MEDIA_MODEL);
-  const mime = resolveMediaUnderstandingString(params.mime, "video/mp4");
-  const prompt = resolveMediaUnderstandingString(params.prompt, DEFAULT_QWEN_VIDEO_PROMPT);
-  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
-    resolveProviderHttpRequestConfig({
-      baseUrl: params.baseUrl,
-      defaultBaseUrl: QWEN_STANDARD_GLOBAL_BASE_URL,
-      headers: params.headers,
-      request: params.request,
-      defaultHeaders: {
-        "content-type": "application/json",
-        authorization: `Bearer ${params.apiKey}`,
-      },
-      provider: "qwen",
-      api: "openai-completions",
-      capability: "video",
-      transport: "media-understanding",
-    });
-
-  const { response: res, release } = await postJsonRequest({
-    url: `${baseUrl}/chat/completions`,
-    headers,
-    body: buildOpenAiCompatibleVideoRequestBody({
-      model,
-      prompt,
-      mime,
-      buffer: params.buffer,
-    }),
-    timeoutMs: params.timeoutMs,
-    ...(params.signal ? { signal: params.signal } : {}),
-    fetchFn,
-    allowPrivateNetwork,
-    dispatcherPolicy,
+function describeQwenVideo(params: VideoDescriptionRequest) {
+  return describeOpenAiCompatibleVideo({
+    ...params,
+    defaultBaseUrl: QWEN_STANDARD_GLOBAL_BASE_URL,
+    defaultModel: DEFAULT_QWEN_MEDIA_MODEL,
+    defaultPrompt: DEFAULT_QWEN_VIDEO_PROMPT,
+    provider: "qwen",
+    providerLabel: "Qwen",
   });
-
-  try {
-    await assertOkOrThrowHttpError(res, "Qwen video description failed");
-    // Read the success body through the shared byte-bounded JSON reader (16 MiB cap +
-    // stream cancel on overflow) so a hostile or buggy endpoint cannot force the runtime
-    // to buffer an unbounded body. Malformed JSON keeps the
-    // `Qwen video description failed: malformed JSON response` wrapping.
-    const payload = await readProviderJsonResponse<OpenAiCompatibleVideoPayload>(
-      res,
-      "Qwen video description failed",
-    );
-    const text = coerceOpenAiCompatibleVideoText(payload);
-    if (!text) {
-      throw new Error("Qwen video description response missing content");
-    }
-    return { text, model };
-  } finally {
-    await release();
-  }
 }
 
 export function buildQwenMediaUnderstandingProvider(): MediaUnderstandingProvider {

--- a/extensions/raft/src/gateway.test.ts
+++ b/extensions/raft/src/gateway.test.ts
@@ -12,8 +12,17 @@ import type { ResolvedRaftAccount } from "./accounts.js";
 import { startRaftGatewayAccount } from "./gateway.js";
 import { dispatchRaftWake } from "./inbound.js";
 
+const processRuntimeMocks = vi.hoisted(() => ({
+  killProcessTree: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/process-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/process-runtime")>()),
+  killProcessTree: processRuntimeMocks.killProcessTree,
+}));
+
 class FakeBridge extends EventEmitter {
-  kill = vi.fn(() => true);
+  pid = 4242;
 }
 
 const tempWorkspaces: TempWorkspaceSync[] = [];
@@ -139,6 +148,7 @@ async function waitFor<T>(getValue: () => T | undefined): Promise<T> {
 }
 
 afterEach(() => {
+  processRuntimeMocks.killProcessTree.mockReset();
   resetPluginStateStoreForTests();
   for (const workspace of tempWorkspaces.splice(0)) {
     workspace.cleanup();
@@ -313,7 +323,11 @@ describe("Raft wake gateway", () => {
 
     controller.abort();
     await start;
-    expect(bridge.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(processRuntimeMocks.killProcessTree).toHaveBeenCalledOnce();
+    expect(processRuntimeMocks.killProcessTree).toHaveBeenCalledWith(bridge.pid, {
+      graceMs: 5_000,
+      detached: process.platform !== "win32",
+    });
   });
 
   it("returns the Raft bridge runtime session for accepted wakes", async () => {

--- a/extensions/raft/src/gateway.ts
+++ b/extensions/raft/src/gateway.ts
@@ -4,11 +4,13 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 import type { EventEmitter } from "node:events";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { Socket } from "node:net";
+import process from "node:process";
 import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
 import { keepHttpServerTaskAlive, waitUntilAbort } from "openclaw/plugin-sdk/channel-outbound";
 import { channelReadyPatch } from "openclaw/plugin-sdk/gateway-runtime";
 import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { createChannelReplayGuard } from "openclaw/plugin-sdk/persistent-dedupe";
+import { killProcessTree } from "openclaw/plugin-sdk/process-runtime";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import {
   readJsonBodyWithLimit,
@@ -45,7 +47,7 @@ const WAKE_EVENT_ID_FIELDS = [
   "id",
 ] as const;
 
-type RaftBridgeProcess = Pick<ChildProcess, "kill"> & Pick<EventEmitter, "once">;
+type RaftBridgeProcess = Pick<ChildProcess, "pid"> & Pick<EventEmitter, "once">;
 
 type RaftWakeReplayEvent = { accountId: string; key: string };
 
@@ -114,6 +116,7 @@ function spawnRaftBridge(params: {
         ...process.env,
         RAFT_CHANNEL_TOKEN: params.token,
       },
+      detached: process.platform !== "win32",
       stdio: "ignore",
       windowsHide: true,
     },
@@ -205,10 +208,13 @@ function closeServer(server: Server, sockets: Set<Socket>) {
 }
 
 function stopBridge(child: RaftBridgeProcess) {
-  child.kill("SIGTERM");
-  const forceKill = setTimeout(() => child.kill("SIGKILL"), 5_000);
-  forceKill.unref();
-  child.once("exit", () => clearTimeout(forceKill));
+  if (typeof child.pid !== "number") {
+    return;
+  }
+  killProcessTree(child.pid, {
+    graceMs: 5_000,
+    detached: process.platform !== "win32",
+  });
 }
 
 async function listenLoopback(server: Server): Promise<number> {

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -305,7 +305,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: typed guarded-fetch redirect error for direct-only plugin delivery.
       // -1: remove the test-only channel activity reset export.
       // +1: named bounded structured-input surface for native harness protocol adapters.
-      4336,
+      // +1: OpenAI-compatible video execution in the existing media-understanding owner.
+      4337,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -392,7 +393,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       //     runtimes render the same guidance instead of diverging prompt copies.
       // +1: shared harness visible-source-reply guidance.
       // -1: remove the test-only channel activity reset export.
-      2577,
+      // +1: OpenAI-compatible video execution in the existing media-understanding owner.
+      2578,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/media-understanding/openai-compatible-video.ts
+++ b/src/media-understanding/openai-compatible-video.ts
@@ -1,2 +1,79 @@
 // Core facade for shared OpenAI-compatible video request helpers.
+import {
+  buildOpenAiCompatibleVideoRequestBody,
+  coerceOpenAiCompatibleVideoText,
+  resolveMediaUnderstandingString,
+  type OpenAiCompatibleVideoPayload,
+} from "../../packages/media-understanding-common/src/openai-compatible-video.js";
+import {
+  assertOkOrThrowHttpError,
+  postJsonRequest,
+  readProviderJsonResponse,
+  resolveProviderHttpRequestConfig,
+} from "./shared.js";
+import type { VideoDescriptionRequest, VideoDescriptionResult } from "./types.js";
+
 export * from "../../packages/media-understanding-common/src/openai-compatible-video.js";
+
+/** Describe a video through an OpenAI-compatible chat-completions endpoint. */
+export async function describeOpenAiCompatibleVideo(
+  params: VideoDescriptionRequest & {
+    defaultBaseUrl: string;
+    defaultModel: string;
+    defaultPrompt: string;
+    provider: string;
+    providerLabel: string;
+  },
+): Promise<VideoDescriptionResult> {
+  const fetchFn = params.fetchFn ?? fetch;
+  const model = resolveMediaUnderstandingString(params.model, params.defaultModel);
+  const mime = resolveMediaUnderstandingString(params.mime, "video/mp4");
+  const prompt = resolveMediaUnderstandingString(params.prompt, params.defaultPrompt);
+  const errorPrefix = `${params.providerLabel} video description`;
+  const { baseUrl, allowPrivateNetwork, headers, dispatcherPolicy } =
+    resolveProviderHttpRequestConfig({
+      baseUrl: params.baseUrl,
+      defaultBaseUrl: params.defaultBaseUrl,
+      headers: params.headers,
+      request: params.request,
+      defaultHeaders: {
+        "content-type": "application/json",
+        authorization: `Bearer ${params.apiKey}`,
+      },
+      provider: params.provider,
+      api: "openai-completions",
+      capability: "video",
+      transport: "media-understanding",
+    });
+
+  const { response, release } = await postJsonRequest({
+    url: `${baseUrl}/chat/completions`,
+    headers,
+    body: buildOpenAiCompatibleVideoRequestBody({
+      model,
+      prompt,
+      mime,
+      buffer: params.buffer,
+    }),
+    timeoutMs: params.timeoutMs,
+    ...(params.signal ? { signal: params.signal } : {}),
+    fetchFn,
+    allowPrivateNetwork,
+    dispatcherPolicy,
+  });
+
+  try {
+    await assertOkOrThrowHttpError(response, `${errorPrefix} failed`);
+    const payload = await readProviderJsonResponse<OpenAiCompatibleVideoPayload>(
+      response,
+      `${errorPrefix} failed`,
+    );
+    const text = coerceOpenAiCompatibleVideoText(payload);
+    if (!text) {
+      throw new Error(`${errorPrefix} response missing content`);
+    }
+    return { text, model };
+  } finally {
+    await release();
+  }
+}

--- a/src/plugin-sdk/media-understanding.ts
+++ b/src/plugin-sdk/media-understanding.ts
@@ -31,6 +31,7 @@ export {
 export {
   buildOpenAiCompatibleVideoRequestBody,
   coerceOpenAiCompatibleVideoText,
+  describeOpenAiCompatibleVideo,
   resolveMediaUnderstandingString,
   type OpenAiCompatibleVideoPayload,
 } from "../media-understanding/openai-compatible-video.ts";

--- a/src/process/exec-output.ts
+++ b/src/process/exec-output.ts
@@ -11,6 +11,7 @@ export type CommandOutputCaptureOption =
 export type CommandOutputLimitOption =
   | boolean
   | { stdout?: boolean; stderr?: boolean; combined?: boolean };
+export type CommandOutputErrorOption = boolean | { stdout?: boolean; stderr?: boolean };
 export type PreserveOutputLine = (line: string, stream: CommandOutputStream) => boolean;
 
 export type CapturedOutputBuffers = {
@@ -62,6 +63,13 @@ export function shouldTerminateOnOutputLimit(
   limit: CommandOutputStream | "combined",
 ): boolean {
   return typeof value === "boolean" ? value : value?.[limit] === true;
+}
+
+export function shouldTerminateOnOutputError(
+  value: CommandOutputErrorOption | undefined,
+  stream: CommandOutputStream,
+): boolean {
+  return typeof value === "boolean" ? value : value?.[stream] === true;
 }
 
 export function appendCapturedOutput(

--- a/src/process/exec-runner.ts
+++ b/src/process/exec-runner.ts
@@ -16,10 +16,12 @@ import {
   MAX_PRESERVED_PENDING_LINE_BYTES,
   resolveMaxOutputBytes,
   resolveOutputCapture,
+  shouldTerminateOnOutputError,
   shouldTerminateOnOutputLimit,
   type CapturedOutputBuffers,
   type CommandOutputCaptureMode,
   type CommandOutputCaptureOption,
+  type CommandOutputErrorOption,
   type CommandOutputLimitOption,
   type CommandOutputStream,
   type PreserveOutputLine,
@@ -57,12 +59,16 @@ export type CommandOptions = {
   onOutputChunk?: (chunk: Buffer, stream: CommandOutputStream) => boolean | void;
   /** Accept a successful exit when only the selected diagnostic output stream failed. */
   tolerateOutputError?: { stdout?: boolean; stderr?: boolean };
+  /** Terminate when the selected output stream emits an error. */
+  terminateOnOutputError?: CommandOutputErrorOption;
   terminateOnOutputLimit?: CommandOutputLimitOption;
   maxPreservedOutputLines?: number;
   preserveOutputLine?: PreserveOutputLine;
   killProcessTree?: boolean;
   /** Signal used when terminating the direct child; tree termination owns its own grace policy. */
   killSignal?: NodeJS.Signals | number;
+  /** Grace between graceful termination and the force-kill fallback. */
+  killGraceMs?: number;
 };
 
 export async function runCommandWithTimeout(
@@ -97,11 +103,17 @@ async function runCommandWithOutputEncoding(
     signal,
     killProcessTree,
     killSignal,
+    killGraceMs,
   } = options;
   const resolvedTimeoutMs =
     typeof timeoutMs === "number" ? resolveTimerTimeoutMs(timeoutMs, 1) : undefined;
   const hasInput = input !== undefined;
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
+  const resolvedKillGraceMs = resolveTimerTimeoutMs(
+    killGraceMs,
+    COMMAND_PROCESS_TREE_KILL_GRACE_MS,
+    0,
+  );
 
   if (signal?.aborted) {
     return {
@@ -153,6 +165,7 @@ async function runCommandWithOutputEncoding(
   let noOutputTimer: NodeJS.Timeout | undefined;
   let outputObserverError: unknown;
   let outputErrorStream: CommandOutputStream | undefined;
+  let terminatingOutputError: Error | undefined;
 
   const { child, invocation } = spawnCommandWithInvocation(argv, {
     buffer: false,
@@ -162,7 +175,7 @@ async function runCommandWithOutputEncoding(
     encoding: "buffer",
     baseEnv,
     env,
-    forceKillAfterDelay: COMMAND_PROCESS_TREE_KILL_GRACE_MS,
+    forceKillAfterDelay: resolvedKillGraceMs,
     killSignal,
     ...(hasInput ? { input } : {}),
     reject: false,
@@ -184,6 +197,7 @@ async function runCommandWithOutputEncoding(
     killProcessTree,
     isChildExited: () => childExited,
     isCommandSettled: () => commandSettled,
+    killGraceMs: resolvedKillGraceMs,
   });
 
   const clearNoOutputTimer = () => {
@@ -324,12 +338,21 @@ async function runCommandWithOutputEncoding(
     return buffer;
   };
 
-  child.stdout?.once("error", () => {
-    outputErrorStream ??= "stdout";
-  });
-  child.stderr?.once("error", () => {
-    outputErrorStream ??= "stderr";
-  });
+  const onOutputError = (error: unknown, stream: CommandOutputStream) => {
+    outputErrorStream ??= stream;
+    if (
+      termination ||
+      options.tolerateOutputError?.[stream] === true ||
+      !shouldTerminateOnOutputError(options.terminateOnOutputError, stream)
+    ) {
+      return;
+    }
+    terminatingOutputError = toErrorObject(error, `Command ${stream} stream failed`);
+    Object.assign(terminatingOutputError, { outputErrorStream: stream });
+    cancel("signal");
+  };
+  child.stdout?.once("error", (error) => onOutputError(error, "stdout"));
+  child.stderr?.once("error", (error) => onOutputError(error, "stderr"));
   child.stdout?.on("data", (chunk) => {
     const buffer = observeOutputChunk(chunk, "stdout");
     appendPreservedOutputLines({
@@ -367,6 +390,9 @@ async function runCommandWithOutputEncoding(
     releaseOutput();
   });
   await terminationController.settle();
+  if (terminatingOutputError) {
+    throw terminatingOutputError;
+  }
   if (outputObserverError !== undefined) {
     throw toErrorObject(outputObserverError, "Command output observer failed");
   }

--- a/src/process/exec-termination.ts
+++ b/src/process/exec-termination.ts
@@ -18,6 +18,7 @@ export function createCommandTerminationController(params: {
   baseEnv?: NodeJS.ProcessEnv;
   env?: NodeJS.ProcessEnv;
   killProcessTree?: boolean;
+  killGraceMs: number;
   isChildExited: () => boolean;
   isCommandSettled: () => boolean;
 }): { terminate: () => boolean; settle: () => Promise<void> } {
@@ -70,7 +71,7 @@ export function createCommandTerminationController(params: {
       if (graceful) {
         startTaskkill(["/PID", String(childPid), "/T"]);
         await new Promise<void>((resolve) => {
-          const timer = setTimeout(resolve, COMMAND_PROCESS_TREE_KILL_GRACE_MS);
+          const timer = setTimeout(resolve, params.killGraceMs);
           timer.unref();
         });
         if (isDirectChildAlive()) {
@@ -97,13 +98,13 @@ export function createCommandTerminationController(params: {
       return false;
     }
     if (params.killProcessTree && typeof childPid === "number") {
-      processTreeSettleAt ??= Date.now() + COMMAND_PROCESS_TREE_KILL_GRACE_MS;
+      processTreeSettleAt ??= Date.now() + params.killGraceMs;
       if (process.platform === "win32") {
         startWindowsTermination(childPid, true);
         return true;
       }
       terminateProcessTree(childPid, {
-        graceMs: COMMAND_PROCESS_TREE_KILL_GRACE_MS,
+        graceMs: params.killGraceMs,
         detached: true,
       });
       return false;

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -494,6 +494,25 @@ describe("runCommandBuffered", () => {
     expect(result.stdout.byteLength).toBeLessThanOrEqual(16);
   });
 
+  it("caps stdout and stderr under one aggregate output budget", async () => {
+    const result = await runCommandBuffered(
+      [
+        process.execPath,
+        "-e",
+        "process.stdout.write('abcd'); setImmediate(() => process.stderr.write('efgh'))",
+      ],
+      {
+        maxCombinedOutputBytes: 6,
+        maxOutputBytes: 8,
+        timeoutMs: 3_000,
+      },
+    );
+
+    expect(result.termination).toBe("output-limit");
+    expect(result.outputLimitStream).toBe("stderr");
+    expect(result.stdout.byteLength + result.stderr.byteLength).toBe(6);
+  });
+
   it("maps timeout and pre-aborted signals without throwing", async () => {
     const timedOut = await runCommandBuffered(
       [process.execPath, "-e", "setInterval(() => {}, 1_000)"],

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -130,8 +130,12 @@ type BufferedCommandOptions = {
   env?: NodeJS.ProcessEnv;
   signal?: AbortSignal;
   maxOutputBytes?: number | { stdout?: number; stderr?: number };
+  maxCombinedOutputBytes?: number;
   discardOutput?: { stdout?: boolean; stderr?: boolean };
   tolerateOutputError?: { stdout?: boolean; stderr?: boolean };
+  terminateOnOutputError?: boolean | { stdout?: boolean; stderr?: boolean };
+  killProcessTree?: boolean;
+  killGraceMs?: number;
 };
 
 type BufferedCommandResult = {
@@ -165,13 +169,24 @@ export async function runCommandBuffered(
 
   const chunks: Record<CommandOutputStream, Buffer[]> = { stdout: [], stderr: [] };
   const capturedBytes: Record<CommandOutputStream, number> = { stdout: 0, stderr: 0 };
+  const maxCombinedOutputBytes =
+    typeof options.maxCombinedOutputBytes === "number" &&
+    Number.isFinite(options.maxCombinedOutputBytes) &&
+    options.maxCombinedOutputBytes > 0
+      ? Math.max(1, Math.floor(options.maxCombinedOutputBytes))
+      : undefined;
   let outputLimitStream: CommandOutputStream | undefined;
   const appendChunk = (chunk: Buffer, stream: CommandOutputStream): boolean => {
     if (options.discardOutput?.[stream]) {
       return true;
     }
     const maxBytes = resolveMaxOutputBytes(options.maxOutputBytes, stream);
-    const remaining = Math.max(0, maxBytes - capturedBytes[stream]);
+    const combinedBytes = capturedBytes.stdout + capturedBytes.stderr;
+    const combinedRemaining =
+      maxCombinedOutputBytes === undefined
+        ? Number.POSITIVE_INFINITY
+        : Math.max(0, maxCombinedOutputBytes - combinedBytes);
+    const remaining = Math.max(0, Math.min(maxBytes - capturedBytes[stream], combinedRemaining));
     if (remaining > 0) {
       const captured = Buffer.from(chunk.subarray(0, remaining));
       chunks[stream].push(captured);
@@ -192,7 +207,8 @@ export async function runCommandBuffered(
       cwd: options.cwd,
       env: options.env,
       input: options.input,
-      killProcessTree: true,
+      killProcessTree: options.killProcessTree ?? true,
+      killGraceMs: options.killGraceMs,
       onOutputChunk: appendChunk,
       outputCapture: "discard",
       signal: options.signal,
@@ -201,6 +217,7 @@ export async function runCommandBuffered(
         stdout: options.discardOutput?.stdout || options.tolerateOutputError?.stdout,
         stderr: options.discardOutput?.stderr || options.tolerateOutputError?.stderr,
       },
+      terminateOnOutputError: options.terminateOnOutputError,
     });
     const termination: BufferedCommandResult["termination"] = result.outputLimitExceeded
       ? "output-limit"

--- a/src/process/exec.windows.test.ts
+++ b/src/process/exec.windows.test.ts
@@ -128,6 +128,7 @@ function expectCmdWrappedInvocation(call: ExecaCall, commandFragment = "pnpm.cmd
 }
 
 let runCommandWithTimeout: typeof import("./exec.js").runCommandWithTimeout;
+let runCommandBuffered: typeof import("./exec.js").runCommandBuffered;
 let runUtf8CommandWithTimeout: typeof import("./exec.js").runUtf8CommandWithTimeout;
 let runExec: typeof import("./exec.js").runExec;
 let spawnCommand: typeof import("./exec.js").spawnCommand;
@@ -163,8 +164,13 @@ describe("Windows command execution", () => {
     });
     ({ getWindowsInstallRoots, getWindowsSystem32ExePath } =
       await import("../infra/windows-install-roots.js"));
-    ({ runCommandWithTimeout, runExec, runUtf8CommandWithTimeout, spawnCommand } =
-      await import("./exec.js"));
+    ({
+      runCommandBuffered,
+      runCommandWithTimeout,
+      runExec,
+      runUtf8CommandWithTimeout,
+      spawnCommand,
+    } = await import("./exec.js"));
   });
 
   afterAll(() => {
@@ -410,6 +416,7 @@ describe("Windows command execution", () => {
 
     await withMockedWindowsPlatform(async () => {
       const resultPromise = runCommandWithTimeout(["node", "idle.js"], {
+        killGraceMs: 40,
         killProcessTree: true,
         timeoutMs: 80,
       });
@@ -420,13 +427,41 @@ describe("Windows command execution", () => {
       ]);
       expect(command.kill).not.toHaveBeenCalled();
 
-      await vi.advanceTimersByTimeAsync(300);
+      await vi.advanceTimersByTimeAsync(40);
       expect(requireExecaCall(2)[1]).toEqual(["/PID", "1234", "/T", "/F"]);
       command.finish({ signal: "SIGKILL" });
 
       await expect(resultPromise).resolves.toMatchObject({ code: 124, termination: "timeout" });
     });
   });
+
+  it.each(["stdout", "stderr"] as const)(
+    "terminates a Windows process tree when its %s stream fails",
+    async (stream) => {
+      vi.useFakeTimers();
+      const command = createMockSubprocess({ autoFinish: false });
+      execaMock
+        .mockImplementationOnce(() => command)
+        .mockImplementation(() => createMockSubprocess());
+
+      await withMockedWindowsPlatform(async () => {
+        const resultPromise = runCommandBuffered(["node", "idle.js"], {
+          terminateOnOutputError: true,
+          timeoutMs: 10_000,
+        });
+        command[stream].destroy(new Error(`${stream} EPIPE`));
+
+        await vi.advanceTimersByTimeAsync(301);
+        command.finish({ signal: "SIGKILL" });
+
+        await expect(resultPromise).resolves.toMatchObject({
+          error: { message: `${stream} EPIPE` },
+          errorStream: stream,
+          termination: "error",
+        });
+      });
+    },
+  );
 
   it("keeps forced Windows tree escalation after graceful taskkill returns nonzero", async () => {
     vi.useFakeTimers();


### PR DESCRIPTION
## What Problem This Solves

Moonshot and Qwen independently maintained the same OpenAI-compatible video-description request lifecycle, while OpenCode, Codex CLI resume, and Raft each carried local child-process capture or termination policy that overlapped the process runtime.

This maintainer-requested consolidation removes those duplicate owners without changing the normal provider or session behavior.

## Why This Change Was Made

The media change completes the existing OpenAI-compatible video owner with one request helper and keeps provider defaults, attribution, errors, and priorities local to Moonshot and Qwen. It reuses the existing narrow media-understanding subpath; it does not add another SDK entrypoint.

The process change extends the existing buffered command primitive with aggregate output capture, opt-in stream-error termination, and configurable TERM-to-KILL grace. OpenCode and Codex now use that one primitive, while Raft uses the existing process-tree terminator. QA Lab PGID ownership, ACPX reaping, Browser Chrome cleanup, Signal daemon lifecycle, and Voice Call tunnel ownership remain intentionally local and untouched.

## User Impact

Normal output is unchanged. Moonshot/Qwen video descriptions keep the same endpoints, payloads, model/prompt defaults, bounded response parsing, and provider-owned errors. OpenCode keeps its 32 MiB combined output limit and stream-error messages. Codex keeps its Windows launcher resolution, stdin resume prompt, output-last-message reply, diagnostic precedence, and 2-second TERM-to-KILL grace. Raft shutdown now terminates the bridge's owned process tree rather than only its root process.

| Surface | Before | After |
| --- | --- | --- |
| Moonshot/Qwen video request | Two equivalent request/response implementations | One media-understanding owner plus provider-local defaults |
| OpenCode CLI | Local stdout/stderr aggregation and pipe-error kill | Buffered runtime options with the same 32 MiB aggregate contract |
| Codex CLI resume | Local spawn, buffers, and timeout timers | Buffered runtime with the same argv/stdin/output file and 2s escalation |
| Raft bridge shutdown | Direct-child TERM then KILL | Detached tree TERM then KILL after 5s |

Production LOC: media +96/-129 (net -33); process +131/-144 (net -13); total net -46. Tests: +175/-91. Docs/tooling: +5/-3.

## Evidence

- `node scripts/run-vitest.mjs extensions/moonshot/media-understanding-provider.test.ts extensions/qwen/media-understanding-provider.test.ts` — 8 passed
- `node scripts/run-vitest.mjs src/process/exec.test.ts src/process/exec.windows.test.ts extensions/codex/src/node-cli-sessions.test.ts extensions/opencode/session-catalog.test.ts extensions/raft/src/gateway.test.ts` — 99 passed, 1 skipped across four shards
- `node scripts/check-changed.mjs -- <changed paths>` — full changed-path plan passed
- `pnpm plugin-sdk:surface:check` — 146 public subpaths verified; exact surface budgets passed
- `pnpm docs:check-mdx` and `pnpm docs:check-links` — 777 files and 6,524 links checked; zero broken links
- `pnpm build` — passed, including 61 external plugin local distributions and all SDK declaration checks
- Autoreview — clean before each commit; no accepted/actionable findings

Codex CLI protocol behavior was checked directly against the pinned `openai/codex` source and current upstream: exec resume still accepts the global `--skip-git-repo-check` and `--output-last-message` options and reads `-` from stdin.

Live Moonshot/Qwen provider calls were not run because no provider key is available in the ambient environment. The existing provider transport tests exercise the unchanged request payload, headers, response extraction, 16 MiB bounded JSON reader, cancellation, and error labels.

AI-assisted: yes. The implementation and tests were reviewed and understood by the maintainer workflow.
