### PR TITLE
fix(package): bound installed worker artifact parsing

### DIFF
--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -105,6 +105,10 @@ type DistJavaScriptFileListResult =
   | { files: string[]; limitExceeded: false }
   | { files: string[]; limit: number; limitExceeded: true };
 
+type InstalledRootDistJavaScriptReadResult =
+  | { error: string; ok: false }
+  | { ok: true; relativePath: string; source: string };
+
 type PublishedInstallScenario = {
   name: string;
   installSpecs: string[];
@@ -474,7 +478,7 @@ export function collectInstalledPackageErrors(params: {
   errors.push(...collectInstalledPluginSdkDeclarationErrors(params.packageRoot));
   errors.push(...collectInstalledRootDependencyManifestErrors(params.packageRoot));
 
-  return errors;
+  return [...new Set(errors)];
 }
 
 export function collectInstalledAlwaysAllowedRuntimeFacadeErrors(packageRoot: string): string[] {
@@ -534,13 +538,7 @@ export function normalizeInstalledBinaryVersion(output: string): string {
   return versionMatch?.[0] ?? trimmed;
 }
 
-function listDistJavaScriptFiles(
-  packageRoot: string,
-  opts: {
-    maxFiles?: number;
-    skipRelativePath?: (relativePath: string) => boolean;
-  } = {},
-): DistJavaScriptFileListResult {
+function listInstalledRootDistJavaScriptFiles(packageRoot: string): DistJavaScriptFileListResult {
   const distDir = join(packageRoot, "dist");
   if (!existsSync(distDir)) {
     return { files: [], limitExceeded: false };
@@ -563,7 +561,7 @@ function listDistJavaScriptFiles(
 
         const entryPath = join(currentDir, entry.name);
         const relativePath = relative(distDir, entryPath).replaceAll("\\", "/");
-        if (opts.skipRelativePath?.(relativePath)) {
+        if (relativePath === "extensions" || relativePath.startsWith("extensions/")) {
           continue;
         }
         if (entry.isDirectory()) {
@@ -572,10 +570,10 @@ function listDistJavaScriptFiles(
         }
         if (entry.isFile() && ROOT_DIST_JAVASCRIPT_MODULE_FILE_RE.test(entry.name)) {
           files.push(entryPath);
-          if (opts.maxFiles !== undefined && files.length > opts.maxFiles) {
+          if (files.length > MAX_INSTALLED_ROOT_DIST_JS_FILES) {
             return {
               files,
-              limit: opts.maxFiles,
+              limit: MAX_INSTALLED_ROOT_DIST_JS_FILES,
               limitExceeded: true,
             };
           }
@@ -593,25 +591,43 @@ function formatInstalledDistFileScanLimitError(scope: string, limit: number): st
   return `installed package ${scope} contains more than ${limit} JavaScript files; refusing to scan unbounded package contents.`;
 }
 
+function readInstalledRootDistJavaScriptFile(
+  packageRoot: string,
+  filePath: string,
+): InstalledRootDistJavaScriptReadResult {
+  const relativePath = relative(join(packageRoot, "dist"), filePath).replaceAll("\\", "/");
+  const maxBytes = SELF_CONTAINED_WORKER_DEPLOY_DIST_PATHS.has(relativePath)
+    ? MAX_INSTALLED_WORKER_DEPLOY_DIST_JS_BYTES
+    : MAX_INSTALLED_ROOT_DIST_JS_BYTES;
+  const fileStat = lstatSync(filePath);
+  if (!fileStat.isFile() || fileStat.size > maxBytes) {
+    return {
+      error: `installed package root dist file '${relativePath}' is invalid or exceeds ${maxBytes} bytes.`,
+      ok: false,
+    };
+  }
+  return { ok: true, relativePath, source: readFileSync(filePath, "utf8") };
+}
+
 export function collectInstalledContextEngineRuntimeErrors(packageRoot: string): string[] {
-  const errors: string[] = [];
-  const distFiles = listDistJavaScriptFiles(packageRoot, {
-    maxFiles: MAX_INSTALLED_ROOT_DIST_JS_FILES,
-  });
+  const distFiles = listInstalledRootDistJavaScriptFiles(packageRoot);
   if (distFiles.limitExceeded) {
-    return [formatInstalledDistFileScanLimitError("dist", distFiles.limit)];
+    return [formatInstalledDistFileScanLimitError("root dist", distFiles.limit)];
   }
 
+  // The legacy marker is a root runtime bundling contract; extension assets are plugin-owned.
   for (const filePath of distFiles.files) {
-    const contents = readFileSync(filePath, "utf8");
-    if (contents.includes(LEGACY_CONTEXT_ENGINE_UNRESOLVED_RUNTIME_MARKER)) {
-      errors.push(
+    const file = readInstalledRootDistJavaScriptFile(packageRoot, filePath);
+    if (!file.ok) {
+      return [file.error];
+    }
+    if (file.source.includes(LEGACY_CONTEXT_ENGINE_UNRESOLVED_RUNTIME_MARKER)) {
+      return [
         "installed package includes unresolved legacy context engine runtime loader; rebuild with a bundler-traceable LegacyContextEngine import.",
-      );
-      break;
+      ];
     }
   }
-  return errors;
+  return [];
 }
 
 function collectInstalledPluginSdkDeclarationErrors(packageRoot: string): string[] {
@@ -640,14 +656,6 @@ function collectInstalledPluginSdkDeclarationErrors(packageRoot: string): string
   }
 
   return errors;
-}
-
-function listInstalledRootDistJavaScriptFiles(packageRoot: string): DistJavaScriptFileListResult {
-  return listDistJavaScriptFiles(packageRoot, {
-    maxFiles: MAX_INSTALLED_ROOT_DIST_JS_FILES,
-    skipRelativePath: (relativePath) =>
-      relativePath === "extensions" || relativePath.startsWith("extensions/"),
-  });
 }
 
 type ParsedImportSpecifiersResult =
@@ -757,21 +765,14 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
     collectBundledExtensionRuntimeDependencyOwners(packageRoot);
 
   for (const filePath of distFiles.files) {
-    const fileStat = lstatSync(filePath);
-    const relativePath = relative(join(packageRoot, "dist"), filePath).replaceAll("\\", "/");
-    const maxBytes = SELF_CONTAINED_WORKER_DEPLOY_DIST_PATHS.has(relativePath)
-      ? MAX_INSTALLED_WORKER_DEPLOY_DIST_JS_BYTES
-      : MAX_INSTALLED_ROOT_DIST_JS_BYTES;
-    if (!fileStat.isFile() || fileStat.size > maxBytes) {
-      return [
-        `installed package root dist file '${relativePath}' is invalid or exceeds ${maxBytes} bytes.`,
-      ];
+    const file = readInstalledRootDistJavaScriptFile(packageRoot, filePath);
+    if (!file.ok) {
+      return [file.error];
     }
-    const source = readFileSync(filePath, "utf8");
-    const parsedSpecifiers = extractJavaScriptImportSpecifiers(source);
+    const parsedSpecifiers = extractJavaScriptImportSpecifiers(file.source);
     if (!parsedSpecifiers.ok) {
       return [
-        `installed package root dist file '${relativePath}' could not be parsed for runtime dependency verification: ${parsedSpecifiers.error}.`,
+        `installed package root dist file '${file.relativePath}' could not be parsed for runtime dependency verification: ${parsedSpecifiers.error}.`,
       ];
     }
     for (const specifier of parsedSpecifiers.specifiers) {
@@ -784,13 +785,13 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
         isBundledExtensionOwnedRuntimeImport({
           dependencyName,
           ownersByDependency: bundledExtensionRuntimeDependencyOwners,
-          source,
+          source: file.source,
         })
       ) {
         continue;
       }
       const importers = missingImporters.get(dependencyName) ?? new Set<string>();
-      importers.add(relativePath);
+      importers.add(file.relativePath);
       missingImporters.set(dependencyName, importers);
     }
   }

--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -69,11 +69,11 @@ const PUBLISHED_BUNDLED_RUNTIME_SIDECAR_PATHS = BUNDLED_RUNTIME_SIDECAR_PATHS.fi
 const NODE_BUILTIN_MODULES = new Set(builtinModules.map((name) => name.replace(/^node:/u, "")));
 const MAX_INSTALLED_ROOT_PACKAGE_JSON_BYTES = 1024 * 1024;
 const MAX_INSTALLED_ROOT_DIST_JS_BYTES = 6 * 1024 * 1024;
+const MAX_INSTALLED_WORKER_DEPLOY_DIST_JS_BYTES = 80 * 1024 * 1024;
 // Keep the dependency scan bounded while allowing headroom for generated root chunks.
 const MAX_INSTALLED_ROOT_DIST_JS_FILES = 10_000;
 const ROOT_DIST_JAVASCRIPT_MODULE_FILE_RE = /\.(?:c|m)?js$/u;
-// These artifacts bundle their full runtime closure and have a dedicated layout/import guard.
-// Keep the generic parser bound on every other installed dist file.
+// The ~69 MB self-contained worker needs extra headroom, but synchronous read/parse stays bounded.
 const SELF_CONTAINED_WORKER_DEPLOY_DIST_PATHS = new Set([
   `worker/${WORKER_BUNDLE_ENTRY_PATH}`,
   `worker/${WORKER_BUNDLE_RSYNC_RECEIVER_PATH}`,
@@ -759,13 +759,12 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
   for (const filePath of distFiles.files) {
     const fileStat = lstatSync(filePath);
     const relativePath = relative(join(packageRoot, "dist"), filePath).replaceAll("\\", "/");
-    if (
-      !fileStat.isFile() ||
-      (fileStat.size > MAX_INSTALLED_ROOT_DIST_JS_BYTES &&
-        !SELF_CONTAINED_WORKER_DEPLOY_DIST_PATHS.has(relativePath))
-    ) {
+    const maxBytes = SELF_CONTAINED_WORKER_DEPLOY_DIST_PATHS.has(relativePath)
+      ? MAX_INSTALLED_WORKER_DEPLOY_DIST_JS_BYTES
+      : MAX_INSTALLED_ROOT_DIST_JS_BYTES;
+    if (!fileStat.isFile() || fileStat.size > maxBytes) {
       return [
-        `installed package root dist file '${relativePath}' is invalid or exceeds ${MAX_INSTALLED_ROOT_DIST_JS_BYTES} bytes.`,
+        `installed package root dist file '${relativePath}' is invalid or exceeds ${maxBytes} bytes.`,
       ];
     }
     const source = readFileSync(filePath, "utf8");

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -600,6 +600,32 @@ describe("collectInstalledPackageErrors", () => {
     );
   });
 
+  it("rejects an oversized worker before the full verifier reads its contents", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      writeFileSync(join(packageRoot, "package.json"), '{"version":"2026.3.23"}\n', "utf8");
+      const workerPath = join(packageRoot, "dist", "worker", WORKER_BUNDLE_ENTRY_PATH);
+      mkdirSync(dirname(workerPath), { recursive: true });
+      writeFileSync(workerPath, "/* Failed to load legacy context engine runtime. */\n", "utf8");
+      truncateSync(workerPath, 80 * 1024 * 1024 + 1);
+
+      const errors = collectInstalledPackageErrors({
+        expectedVersion: "2026.3.23",
+        installedVersion: "2026.3.23",
+        packageRoot,
+      });
+      const sizeError = `installed package root dist file 'worker/${WORKER_BUNDLE_ENTRY_PATH}' is invalid or exceeds 83886080 bytes.`;
+
+      expect(errors.filter((error) => error === sizeError)).toEqual([sizeError]);
+      expect(errors).not.toContain(
+        "installed package includes unresolved legacy context engine runtime loader; rebuild with a bundler-traceable LegacyContextEngine import.",
+      );
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
   it.each(["ollama", "lmstudio"])(
     "rejects a missing installed bundled %s provider directory",
     (providerId) => {
@@ -893,6 +919,31 @@ describe("collectInstalledContextEngineRuntimeErrors", () => {
     }
   });
 
+  it("ignores extension-owned JavaScript assets", () => {
+    const packageRoot = makeInstalledPackageRoot();
+
+    try {
+      const viewerPath = join(
+        packageRoot,
+        "dist",
+        "extensions",
+        "diffs",
+        "assets",
+        "viewer-runtime.js",
+      );
+      mkdirSync(dirname(viewerPath), { recursive: true });
+      writeFileSync(
+        viewerPath,
+        'throw new Error("Failed to load legacy context engine runtime.");\n',
+        "utf8",
+      );
+
+      expect(collectInstalledContextEngineRuntimeErrors(packageRoot)).toStrictEqual([]);
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
   it("refuses unbounded packaged dist scans", () => {
     const packageRoot = makeInstalledPackageRoot();
 
@@ -900,7 +951,7 @@ describe("collectInstalledContextEngineRuntimeErrors", () => {
       writeDistJavaScriptFiles(packageRoot, INSTALLED_ROOT_DIST_JS_FILE_SCAN_LIMIT + 1);
 
       expect(collectInstalledContextEngineRuntimeErrors(packageRoot)).toEqual([
-        `installed package dist contains more than ${INSTALLED_ROOT_DIST_JS_FILE_SCAN_LIMIT} JavaScript files; refusing to scan unbounded package contents.`,
+        `installed package root dist contains more than ${INSTALLED_ROOT_DIST_JS_FILE_SCAN_LIMIT} JavaScript files; refusing to scan unbounded package contents.`,
       ]);
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { generateKeyPairSync, sign } from "node:crypto";
 // OpenClaw npm postpublish tests validate postpublish verification behavior.
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -1184,7 +1184,15 @@ describe("collectInstalledRootDependencyManifestErrors", () => {
       name: "accepts the oversized worker rsync receiver",
       relativePath: `worker/${WORKER_BUNDLE_RSYNC_RECEIVER_PATH}`,
     },
-  ])("$name", ({ expected, relativePath }) => {
+    {
+      expected: [
+        `installed package root dist file 'worker/${WORKER_BUNDLE_ENTRY_PATH}' is invalid or exceeds 83886080 bytes.`,
+      ],
+      name: "rejects the worker deploy entrypoint above its dedicated parser bound",
+      relativePath: `worker/${WORKER_BUNDLE_ENTRY_PATH}`,
+      sparseSize: 80 * 1024 * 1024 + 1,
+    },
+  ])("$name", ({ expected, relativePath, sparseSize }) => {
     const packageRoot = makeInstalledPackageRoot();
 
     try {
@@ -1194,7 +1202,12 @@ describe("collectInstalledRootDependencyManifestErrors", () => {
       });
       const filePath = join(packageRoot, "dist", relativePath);
       mkdirSync(dirname(filePath), { recursive: true });
-      writeFileSync(filePath, `/* ${"x".repeat(6 * 1024 * 1024)} */\n`, "utf8");
+      if (sparseSize) {
+        writeFileSync(filePath, "/*", "utf8");
+        truncateSync(filePath, sparseSize);
+      } else {
+        writeFileSync(filePath, `/* ${"x".repeat(6 * 1024 * 1024)} */\n`, "utf8");
+      }
 
       expect(collectInstalledRootDependencyManifestErrors(packageRoot)).toEqual(expected);
     } finally {


### PR DESCRIPTION
Related: #126448

## What Problem This Solves

Fixes a release-verifier resource gap where a malformed canonical worker artifact could bypass the generic 6 MiB file limit and be synchronously read and parsed up to the root package's overall size ceiling. It also closes the earlier context-engine reader that ran before the dependency parser.

## Why This Change Was Made

Every installed root-dist JavaScript read now goes through one shared pre-read policy: canonical self-contained worker artifacts use an 80 MiB limit, while all other root files retain the existing 6 MiB limit. The legacy context-engine marker scan now follows its root-runtime ownership boundary and skips plugin-owned extension assets; the public verifier deduplicates identical errors from its independent checks.

## User Impact

Release and postpublish verification still accepts the current ~68.8 MB self-contained worker with 21.9% headroom, while rejecting unexpectedly bloated worker artifacts before either verifier pass can read or parse them.

## Evidence

- Public-flow sparse-worker regression proves an 80 MiB-plus-one worker returns the structured 83,886,080-byte error exactly once and does not expose the embedded legacy context-engine marker.
- Generic direct and nested root files still reject above 6 MiB; canonical workers below 80 MiB remain accepted.
- Extension-owned JavaScript assets are excluded from the root context-engine marker contract.
- Focused verifier/release tests: 123 passed on the full-flow repair.
- Changed-path checks and `pnpm build` passed.
- Clean current-main root npm tarball: 211,485,321 bytes, 327,031 under the unchanged 211,812,352-byte budget.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/32320304919) passed on `d5acc875b27cf633dbe5f36742c29101b6e3b1f0`.
- [Package Acceptance](https://github.com/openclaw/openclaw/actions/runs/32320323139) passed on the exact package candidate (`source=ref`, `suite_profile=package`).
- Fresh Codex autoreview: no accepted/actionable findings after both repair rounds.
- Whole PR delta: production +47/−47; tests +68/−4.

The earlier apparent package overage was traced to stale local `dist/` output, not this change. That build-hygiene issue is tracked separately.

AI-assisted: yes. The full verifier read graph, resource boundary, sparse-file behavior, package inventory, and review findings were manually inspected.
