### PR TITLE
fix(process): keep signal forwarding through child errors

### DIFF
--- a/src/fleet/containers.runtime.test.ts
+++ b/src/fleet/containers.runtime.test.ts
@@ -1,5 +1,13 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+}));
 
 const profileMocks = vi.hoisted(() => ({
   buildCellRunArgs: vi.fn((_profile: unknown, options: { environmentFile: string }) => [
@@ -32,6 +40,23 @@ function successfulExecutor() {
     stderr: "",
     code: 0,
   }));
+}
+
+function createStreamChild(pid?: number): ChildProcess {
+  const stdout = Object.assign(new EventEmitter(), {
+    pause: vi.fn(),
+    resume: vi.fn(),
+  });
+  const stderr = Object.assign(new EventEmitter(), {
+    pause: vi.fn(),
+    resume: vi.fn(),
+  });
+  return Object.assign(new EventEmitter(), {
+    pid,
+    stdout,
+    stderr,
+    kill: vi.fn(() => true),
+  }) as unknown as ChildProcess;
 }
 
 describe("fleet container runtime", () => {
@@ -462,6 +487,39 @@ describe("fleet container runtime", () => {
     await expect(
       runtime.logs("podman", "cell-acme", { follow: true, redactValues: [] }),
     ).rejects.toThrow(/podman logs failed with signal SIGSEGV/iu);
+  });
+
+  it("rejects a log stream spawn error when the child has no pid", async () => {
+    const child = createStreamChild();
+    spawnMock.mockReturnValue(child);
+    const runtime = createFleetContainerRuntime(successfulExecutor());
+
+    const logs = runtime.logs("podman", "cell-acme", { follow: true, redactValues: [] });
+    child.emit("error", new Error("spawn failed"));
+
+    await expect(logs).rejects.toThrow("spawn failed");
+    child.emit("close", -2, null);
+  });
+
+  it("waits for log stream close across repeated operational errors", async () => {
+    const child = createStreamChild(4242);
+    spawnMock.mockReturnValue(child);
+    const runtime = createFleetContainerRuntime(successfulExecutor());
+    let settled = false;
+
+    const logs = runtime
+      .logs("podman", "cell-acme", { follow: true, redactValues: [] })
+      .finally(() => {
+        settled = true;
+      });
+    child.emit("error", new Error("first signal delivery failed"));
+    child.emit("error", new Error("second signal delivery failed"));
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+
+    child.emit("close", 0, null);
+    await expect(logs).resolves.toBeUndefined();
   });
 
   it("creates and removes a labeled per-cell network", async () => {

--- a/src/fleet/containers.runtime.ts
+++ b/src/fleet/containers.runtime.ts
@@ -521,7 +521,11 @@ const defaultFleetContainerStreamExecutor: FleetContainerStreamExecutor = (
     };
     pipeWithBackpressure(child.stdout, process.stdout, stdout);
     pipeWithBackpressure(child.stderr, process.stderr, stderr);
-    child.once("error", reject);
+    child.on("error", (error) => {
+      if (child.pid === undefined) {
+        reject(error);
+      }
+    });
     child.once("close", (code, signal) => {
       stdout.flush();
       stderr.flush();

--- a/src/process/child-process-bridge.test.ts
+++ b/src/process/child-process-bridge.test.ts
@@ -1,0 +1,39 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { attachChildProcessBridge } from "./child-process-bridge.js";
+
+describe("attachChildProcessBridge", () => {
+  it.each(["exit", "close"] as const)(
+    "keeps forwarding after operational errors until child %s",
+    (terminalEvent) => {
+      const signal: NodeJS.Signals = "SIGTERM";
+      const existingListeners = new Set(process.listeners(signal));
+      const kill = vi.fn(() => true);
+      const child = Object.assign(new EventEmitter(), {
+        pid: 4242,
+        kill,
+      }) as unknown as ChildProcess;
+      child.on("error", () => {});
+
+      const { detach } = attachChildProcessBridge(child, { signals: [signal] });
+      const signalListener = process
+        .listeners(signal)
+        .find((listener) => !existingListeners.has(listener));
+
+      try {
+        expect(signalListener).toBeDefined();
+        child.emit("error", new Error("signal delivery failed"));
+        expect(process.listeners(signal)).toContain(signalListener);
+
+        signalListener?.(signal);
+        expect(kill).toHaveBeenCalledWith(signal);
+
+        child.emit(terminalEvent, 0, null);
+        expect(process.listeners(signal)).not.toContain(signalListener);
+      } finally {
+        detach();
+      }
+    },
+  );
+});

--- a/src/process/child-process-bridge.ts
+++ b/src/process/child-process-bridge.ts
@@ -13,7 +13,7 @@ const defaultSignals: NodeJS.Signals[] =
     ? ["SIGTERM", "SIGINT", "SIGBREAK"]
     : ["SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT"];
 
-/** Forwards process termination signals to a child and detaches on child exit/error. */
+/** Forwards process termination signals to a child and detaches on terminal lifecycle events. */
 export function attachChildProcessBridge(
   child: ChildProcess,
   { signals = defaultSignals, onSignal }: ChildProcessBridgeOptions = {},
@@ -43,8 +43,10 @@ export function attachChildProcessBridge(
     listeners.clear();
   };
 
+  // Child errors can report failed signal/IPC operations while the PID stays live.
+  // Keep forwarding until exit, with close covering failed spawn and final handle cleanup.
   child.once("exit", detach);
-  child.once("error", detach);
+  child.once("close", detach);
 
   return { detach };
 }

--- a/src/process/respawn-child-runner.test.ts
+++ b/src/process/respawn-child-runner.test.ts
@@ -205,4 +205,68 @@ describe("runRespawnChildWithSignalBridge", () => {
       },
     );
   });
+
+  it("settles a spawn error when the child has no pid", () => {
+    const { child } = createChild();
+    const onError = vi.fn();
+    const exit = vi.fn();
+
+    runRespawnChildWithSignalBridge({
+      command: "missing-command",
+      args: [],
+      env: {},
+      runtime: {
+        spawn: vi.fn(() => child) as unknown as typeof spawn,
+        attachChildProcessBridge: vi.fn(),
+        exit: exit as unknown as (code?: number) => never,
+      },
+      onError,
+    });
+
+    const error = new Error("spawn failed");
+    child.emit("error", error);
+
+    expect(onError).toHaveBeenCalledWith(error);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("keeps escalation active across repeated operational errors", () => {
+    vi.useFakeTimers();
+    const { child, kill } = createChild(5678);
+    const onError = vi.fn();
+    const exit = vi.fn();
+    let onSignal: ((signal: NodeJS.Signals) => void) | undefined;
+
+    try {
+      runRespawnChildWithSignalBridge({
+        command: "/usr/bin/node",
+        args: ["/repo/openclaw/dist/entry.js"],
+        env: {},
+        runtime: {
+          spawn: vi.fn(() => child) as unknown as typeof spawn,
+          attachChildProcessBridge: vi.fn((_child, options) => {
+            onSignal = options?.onSignal;
+            return { detach: vi.fn() };
+          }),
+          exit: exit as unknown as (code?: number) => never,
+        },
+        onError,
+      });
+
+      onSignal?.("SIGTERM");
+      child.emit("error", new Error("first signal delivery failed"));
+      child.emit("error", new Error("second signal delivery failed"));
+      vi.advanceTimersByTime(2_000);
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(exit).not.toHaveBeenCalled();
+      expect(kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+      expect(kill).toHaveBeenNthCalledWith(2, process.platform === "win32" ? "SIGTERM" : "SIGKILL");
+
+      child.emit("exit", null, "SIGKILL");
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/process/respawn-child-runner.ts
+++ b/src/process/respawn-child-runner.ts
@@ -120,7 +120,10 @@ export function runRespawnChildWithSignalBridge(params: {
     runtime.exit(code ?? 1);
   });
 
-  child.once("error", (error) => {
+  child.on("error", (error) => {
+    if (child.pid !== undefined) {
+      return;
+    }
     clearSignalTimers();
     onError(error);
     runtime.exit(1);

--- a/src/tui/tui-launch.test.ts
+++ b/src/tui/tui-launch.test.ts
@@ -21,8 +21,8 @@ import { launchTuiCli } from "./tui-launch.js";
 const originalArgv = [...process.argv];
 const originalExecArgv = [...process.execArgv];
 
-function createChildProcess(): ChildProcess {
-  return new EventEmitter() as ChildProcess;
+function createChildProcess(pid?: number): ChildProcess {
+  return Object.assign(new EventEmitter(), { pid }) as ChildProcess;
 }
 
 function expectSpawned(expectedArgs: string[]): SpawnOptions {
@@ -186,5 +186,38 @@ describe("launchTuiCli", () => {
       "resolved-token",
     ]);
     expect(options.env).toBe(process.env);
+  });
+
+  it("rejects a spawn error when the child has no pid", async () => {
+    const child = createChildProcess();
+    spawnMock.mockImplementation(() => {
+      queueMicrotask(() => child.emit("error", new Error("spawn failed")));
+      return child;
+    });
+
+    await expect(launchTuiCli({ deliver: false })).rejects.toThrow(
+      "failed to launch TUI: spawn failed",
+    );
+    expect(detachMock).toHaveBeenCalledOnce();
+  });
+
+  it("waits for terminal exit across repeated operational errors", async () => {
+    const child = createChildProcess(4242);
+    spawnMock.mockReturnValue(child);
+    let settled = false;
+
+    const launched = launchTuiCli({ deliver: false }).finally(() => {
+      settled = true;
+    });
+    child.emit("error", new Error("first signal delivery failed"));
+    child.emit("error", new Error("second signal delivery failed"));
+    await Promise.resolve();
+
+    expect(settled).toBe(false);
+    expect(detachMock).not.toHaveBeenCalled();
+
+    child.emit("exit", 0, null);
+    await expect(launched).resolves.toBeUndefined();
+    expect(detachMock).toHaveBeenCalledOnce();
   });
 });

--- a/src/tui/tui-launch.ts
+++ b/src/tui/tui-launch.ts
@@ -59,7 +59,10 @@ export async function launchTuiCli(opts: TuiOptions): Promise<void> {
     });
     const { detach } = attachChildProcessBridge(child);
 
-    child.once("error", (error) => {
+    child.on("error", (error) => {
+      if (child.pid !== undefined) {
+        return;
+      }
       detach();
       reject(new Error(`failed to launch TUI: ${formatErrorMessage(error)}`));
     });


### PR DESCRIPTION
Closes #126488

## What Problem This Solves

Fixes an issue where a failed signal delivery or IPC operation could make a live CLI respawn, relaunched TUI, or `fleet logs --follow` child stop receiving later parent termination signals. Node reports those operational failures through the child's `error` event without necessarily ending the process, but OpenClaw treated every child error as terminal and released process ownership early.

## Why This Change Was Made

The shared child-process bridge now keeps signal forwarding installed until Node reports the terminal `exit` or `close` lifecycle event. The respawn runner, TUI launcher, and Fleet stream runner keep persistent error listeners and settle immediately only for a true spawn failure, identified by an undefined child PID. Successful exit and spawn-failure behavior remain unchanged, while post-spawn errors no longer cancel respawn escalation or release terminal/stream ownership.

This is the canonical owner-boundary repair: Node's `error` event is an operational report, while `exit` and `close` own terminal state. A shared exported helper or broader bridge API was rejected because the three local PID checks express the dependency contract without expanding the process API. Detaching only on `close` was also rejected because `exit` preserves prompt signal-listener cleanup for normally terminated children.

## User Impact

Supervisors and operators can continue to stop respawned CLI, TUI, and Fleet follow processes after a transient signal or IPC failure. Those children no longer risk being silently orphaned because one nonterminal error disabled later signal forwarding.

## Evidence

- Before the fix, the live bridge probe showed its signal listener count drop from 1 to 0 after an `EPERM`-style child error, and a later parent signal produced zero child kill calls. The new owner regressions failed on the frozen baseline for the same reason in the bridge, respawn, TUI, and Fleet paths.
- After the fix, the live bridge probe retained one listener across the error, forwarded the later signal, then detached on `close`.
- Node 24.19.0 and Node 26.7.0 contract/source probes confirm failed `kill()` and repeated IPC errors can leave the PID/handle live, while spawn failure has no PID and proceeds from `error` to `close`.
- Focused tests: process bridge 2/2, respawn runner 8/8, TUI launcher 8/8, Fleet container runtime 35/35, entry respawn 21/21, compile-cache respawn 15/15.
- `node scripts/check-changed.mjs -- <8 changed paths>` passed all selected formatting, typecheck, lint, architecture, state/database, import-cycle, and safety gates.
- P1 autoreview and a separate read-only owner/caller/dependency review reported no actionable findings and judged this the cleanest bounded repair.
- Exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/32318855839
- ClawSweeper exact-head review generated no findings or Rank-up moves, cleared security, and passed `pnpm openclaw --help`: https://github.com/openclaw/clawsweeper/actions/runs/32318951966. Its public comment publisher was still pending at landing time.
- Exact reviewed head: `3495ce55d8054fb29c39e23c326226590d372f73`.
- Production LOC: `+17/-5` (net `+12`). Tests: `+196/-2` (net `+194`).
- AI-assisted: yes. The implementation and tests were read and verified against the Node runtime contract.

Proof gap: no packaged supervisor or platform-specific end-to-end signal session was run. The repair is covered by deterministic owner-boundary regressions, live Node runtime probes on the two supported runtime lines, exact-head CI, and the ClawSweeper terminal smoke.
