### PR TITLE
fix(acp): close unhealthy runtime handles [AI]

### DIFF
--- a/src/acp/control-plane/manager.runtime-handle-cache.ts
+++ b/src/acp/control-plane/manager.runtime-handle-cache.ts
@@ -155,7 +155,6 @@ export class ManagerRuntimeHandleCache {
         handle: params.handle,
       });
       if (isRuntimeStatusUnavailable(status)) {
-        this.clear(params.sessionKey);
         logVerbose(
           `acp-manager: evicting cached runtime handle for ${params.sessionKey} after unhealthy status probe: ${status.summary ?? "status unavailable"}`,
         );
@@ -163,7 +162,6 @@ export class ManagerRuntimeHandleCache {
       }
       return true;
     } catch (error) {
-      this.clear(params.sessionKey);
       logVerbose(
         `acp-manager: evicting cached runtime handle for ${params.sessionKey} after status probe failed: ${String(error)}`,
       );

--- a/src/acp/control-plane/manager.runtime-handles.test.ts
+++ b/src/acp/control-plane/manager.runtime-handles.test.ts
@@ -50,6 +50,7 @@ describe("AcpSessionManager runtime handles", () => {
 
     expect(runtimeState.ensureSession).toHaveBeenCalledTimes(1);
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
+    expect(runtimeState.close).not.toHaveBeenCalled();
   });
 
   it("disposes every retained runtime handle", async () => {
@@ -200,6 +201,27 @@ describe("AcpSessionManager runtime handles", () => {
 
   it("re-ensures cached runtime handles when the backend reports the session is dead", async () => {
     const runtimeState = createRuntime();
+    const lifecycle: string[] = [];
+    runtimeState.ensureSession
+      .mockImplementationOnce(async (input) => {
+        lifecycle.push("ensure:old");
+        return {
+          sessionKey: input.sessionKey,
+          backend: "acpx",
+          runtimeSessionName: "runtime-old",
+        };
+      })
+      .mockImplementationOnce(async (input) => {
+        lifecycle.push("ensure:new");
+        return {
+          sessionKey: input.sessionKey,
+          backend: "acpx",
+          runtimeSessionName: "runtime-new",
+        };
+      });
+    runtimeState.close.mockImplementation(async ({ handle }) => {
+      lifecycle.push(`close:${handle.runtimeSessionName}`);
+    });
     runtimeState.getStatus
       .mockResolvedValueOnce({
         summary: "status=alive",
@@ -244,6 +266,12 @@ describe("AcpSessionManager runtime handles", () => {
     expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
     expect(runtimeState.getStatus).toHaveBeenCalledTimes(3);
     expect(runtimeState.runTurn).toHaveBeenCalledTimes(2);
+    expect(runtimeState.close).toHaveBeenCalledOnce();
+    expectRecordFields(mockCallArg(runtimeState.close), {
+      handle: expect.objectContaining({ runtimeSessionName: "runtime-old" }),
+      reason: "runtime-handle-replaced",
+    });
+    expect(lifecycle).toEqual(["ensure:old", "close:runtime-old", "ensure:new"]);
   });
 
   it("re-ensures cached runtime handles when persisted ACP session identity changes", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an ACP session whose cached runtime became unhealthy could start a replacement without closing the old runtime handle. That could retain an ACPX delegate, its adapter process tree, and the associated process lease after the successor was published.

## Why This Change Was Made

`ManagerRuntimeHandleCache.isReusable` now remains a pure health predicate. When it reports an unhealthy status or a probe error, the existing replacement owner retains the old cache entry, closes that exact runtime handle, clears it in `finally`, and only then ensures and publishes the successor.

The separate dispose-vs-new-ensure task #51 remains a known follow-up and is intentionally outside this change.

## User Impact

Operators replacing a dead ACP runtime no longer risk leaving its ACPX delegate or subprocess tree behind. Healthy-handle reuse is unchanged, and this adds no configuration, protocol, storage, or public API surface.

## Evidence

- Pre-fix reproduction: the dead-session replacement scenario observed zero runtime closes because the health predicate removed the cache entry before replacement cleanup.
- `node scripts/run-vitest.mjs src/acp/control-plane/manager.runtime-handles.test.ts` — 14/14 passed; the regression asserts the old handle is closed exactly once before the successor is ensured.
- `node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts src/acp/control-plane/manager.failover.test.ts` — 33/33 passed across manager concurrency and failover behavior.
- `node scripts/run-vitest.mjs extensions/acpx/src/runtime.test.ts -t "marks the session fresh after discardPersistentState close|releases managed OpenClaw tools MCP delegates after close|cleans up OpenClaw-owned ACPX process trees after close"` — 3/3 passed.
- `node scripts/check-changed.mjs` — passed.
- `pnpm check:architecture` — passed.
- `node_modules/.bin/oxfmt --check src/acp/control-plane/manager.runtime-handle-cache.ts src/acp/control-plane/manager.runtime-handles.test.ts` and `git diff --check origin/main...HEAD` — passed.
- Direct dependency inspection: published `acpx` 0.13.1 close ownership, the OpenClaw ACPX delegate/process-tree/lease cleanup path, and sibling Codex delegate shutdown behavior were inspected.
- Fresh Codex autoreview: clean, zero accepted/actionable findings, 0.99 confidence.
- LOC: production +0/-2 (net -2); tests +28/-0.

AI-assisted: yes. I understand the lifecycle change and verified the owner, dependency, cleanup, and sibling shutdown paths directly.
