### PR TITLE
fix(xai): doctor migrates retired image models in tools.media.models

### DIFF
--- a/extensions/xai/doctor-contract-api.test.ts
+++ b/extensions/xai/doctor-contract-api.test.ts
@@ -116,10 +116,21 @@ describe("xAI doctor contract", () => {
         media: {
           models: [
             { provider: "xai", model: "grok-4-fast", capabilities: ["image"] },
-            { provider: "xai", model: "grok-3", capabilities: ["image", "audio"] },
+            { provider: "x-ai", model: "grok-4-fast", capabilities: ["image"] },
+            {
+              provider: "xai",
+              model: "grok-4-fast-non-reasoning",
+              capabilities: ["image"],
+            },
             { provider: "xai", model: "grok-4.3", capabilities: ["image"] },
             { provider: "openai", model: "grok-4-fast", capabilities: ["image"] },
             { type: "cli", provider: "xai", model: "grok-4-fast", command: "vision" },
+            {
+              provider: "xai",
+              model: "grok-4-fast",
+              command: "vision",
+              capabilities: ["image"],
+            },
             { provider: "xai", model: "custom-vision", capabilities: ["image"] },
             { provider: "xai", model: "grok-4-fast", capabilities: ["audio"] },
             { provider: "xai", model: "grok-4-fast" },
@@ -140,10 +151,21 @@ describe("xAI doctor contract", () => {
     expect(result.config).not.toBe(config);
     expect(result.config.tools?.media?.models).toEqual([
       { provider: "xai", model: "grok-4.3", capabilities: ["image"] },
-      { provider: "xai", model: "grok-4.3", capabilities: ["image", "audio"] },
+      { provider: "x-ai", model: "grok-4.3", capabilities: ["image"] },
+      {
+        provider: "xai",
+        model: "grok-4-fast-non-reasoning",
+        capabilities: ["image"],
+      },
       { provider: "xai", model: "grok-4.3", capabilities: ["image"] },
       { provider: "openai", model: "grok-4-fast", capabilities: ["image"] },
       { type: "cli", provider: "xai", model: "grok-4-fast", command: "vision" },
+      {
+        provider: "xai",
+        model: "grok-4-fast",
+        command: "vision",
+        capabilities: ["image"],
+      },
       { provider: "xai", model: "custom-vision", capabilities: ["image"] },
       { provider: "xai", model: "grok-4-fast", capabilities: ["audio"] },
       { provider: "xai", model: "grok-4-fast" },
@@ -190,7 +212,7 @@ describe("xAI doctor contract", () => {
       { type: "provider", provider: "xai", model: "custom-stt" },
       { type: "provider", provider: "openai", model: "grok-stt" },
       { type: "cli", provider: "xai", model: "grok-stt", command: "whisper" },
-      { provider: "x-ai", model: "grok-stt" },
+      { provider: "x-ai" },
       { provider: "xai" },
     ]);
     expect(config.tools?.media?.models?.[0]).toHaveProperty("model", " GROK-STT ");

--- a/extensions/xai/doctor-contract-api.test.ts
+++ b/extensions/xai/doctor-contract-api.test.ts
@@ -115,12 +115,15 @@ describe("xAI doctor contract", () => {
       tools: {
         media: {
           models: [
-            { provider: "xai", model: "grok-4-fast", capability: "image" },
-            { provider: "xai", model: "grok-3", capability: "image" },
-            { provider: "xai", model: "grok-4.3", capability: "image" },
-            { provider: "openai", model: "grok-4-fast", capability: "image" },
+            { provider: "xai", model: "grok-4-fast", capabilities: ["image"] },
+            { provider: "xai", model: "grok-3", capabilities: ["image", "audio"] },
+            { provider: "xai", model: "grok-4.3", capabilities: ["image"] },
+            { provider: "openai", model: "grok-4-fast", capabilities: ["image"] },
             { type: "cli", provider: "xai", model: "grok-4-fast", command: "vision" },
-            { provider: "xai", model: "custom-vision" },
+            { provider: "xai", model: "custom-vision", capabilities: ["image"] },
+            { provider: "xai", model: "grok-4-fast", capabilities: ["audio"] },
+            { provider: "xai", model: "grok-4-fast" },
+            { provider: "xai", model: "grok-4-fast", capability: "image" },
           ],
         },
       },
@@ -136,12 +139,15 @@ describe("xAI doctor contract", () => {
     expect(result.changes[0]).toMatch(/Migrated 2 retired xAI image models/);
     expect(result.config).not.toBe(config);
     expect(result.config.tools?.media?.models).toEqual([
-      { provider: "xai", model: "grok-4.3", capability: "image" },
-      { provider: "xai", model: "grok-4.3", capability: "image" },
-      { provider: "xai", model: "grok-4.3", capability: "image" },
-      { provider: "openai", model: "grok-4-fast", capability: "image" },
+      { provider: "xai", model: "grok-4.3", capabilities: ["image"] },
+      { provider: "xai", model: "grok-4.3", capabilities: ["image", "audio"] },
+      { provider: "xai", model: "grok-4.3", capabilities: ["image"] },
+      { provider: "openai", model: "grok-4-fast", capabilities: ["image"] },
       { type: "cli", provider: "xai", model: "grok-4-fast", command: "vision" },
-      { provider: "xai", model: "custom-vision" },
+      { provider: "xai", model: "custom-vision", capabilities: ["image"] },
+      { provider: "xai", model: "grok-4-fast", capabilities: ["audio"] },
+      { provider: "xai", model: "grok-4-fast" },
+      { provider: "xai", model: "grok-4-fast", capability: "image" },
     ]);
     expect(config.tools?.media?.models?.[0]).toHaveProperty("model", "grok-4-fast");
     expect(normalizeCompatibilityConfig({ cfg: result.config })).toEqual({

--- a/extensions/xai/doctor-contract-api.test.ts
+++ b/extensions/xai/doctor-contract-api.test.ts
@@ -110,6 +110,46 @@ describe("xAI doctor contract", () => {
     expect(normalizeCompatibilityConfig({ cfg: config })).toEqual({ config, changes: [] });
   });
 
+  it("migrates retired xAI image models in tools.media.models to grok-4.3", () => {
+    const config = {
+      tools: {
+        media: {
+          models: [
+            { provider: "xai", model: "grok-4-fast", capability: "image" },
+            { provider: "xai", model: "grok-3", capability: "image" },
+            { provider: "xai", model: "grok-4.3", capability: "image" },
+            { provider: "openai", model: "grok-4-fast", capability: "image" },
+            { type: "cli", provider: "xai", model: "grok-4-fast", command: "vision" },
+            { provider: "xai", model: "custom-vision" },
+          ],
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(
+      legacyConfigRules.filter((rule) => rule.match(readPathForTest(config, rule.path))),
+    ).toHaveLength(1);
+
+    const result = normalizeCompatibilityConfig({ cfg: config });
+
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toMatch(/Migrated 2 retired xAI image models/);
+    expect(result.config).not.toBe(config);
+    expect(result.config.tools?.media?.models).toEqual([
+      { provider: "xai", model: "grok-4.3", capability: "image" },
+      { provider: "xai", model: "grok-4.3", capability: "image" },
+      { provider: "xai", model: "grok-4.3", capability: "image" },
+      { provider: "openai", model: "grok-4-fast", capability: "image" },
+      { type: "cli", provider: "xai", model: "grok-4-fast", command: "vision" },
+      { provider: "xai", model: "custom-vision" },
+    ]);
+    expect(config.tools?.media?.models?.[0]).toHaveProperty("model", "grok-4-fast");
+    expect(normalizeCompatibilityConfig({ cfg: result.config })).toEqual({
+      config: result.config,
+      changes: [],
+    });
+  });
+
   it("removes only the obsolete xAI STT model selector from media entries", () => {
     const config = {
       tools: {

--- a/extensions/xai/doctor-contract-api.ts
+++ b/extensions/xai/doctor-contract-api.ts
@@ -2,6 +2,7 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { asObjectRecord } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 import { isLegacyXaiBuiltinModel } from "./model-definitions.js";
+import { isXaiProviderId } from "./provider-id.js";
 
 type LegacyConfigRule = {
   path: Array<string | number>;
@@ -77,17 +78,17 @@ function hasLegacyBuiltinCatalogRows(value: unknown): boolean {
   return Array.isArray(value) && value.some((model) => isLegacyXaiBuiltinModel(model));
 }
 
-const RETIRED_XAI_MEDIA_MODELS = new Set([
-  ...RETIRED_REASONING_MODELS,
-  ...RETIRED_NON_REASONING_MODELS,
-]);
-
 function asXaiProviderMediaEntry(value: unknown) {
   const entry = asObjectRecord(value);
-  if (!entry || (entry.type !== undefined && entry.type !== "provider")) {
+  // An omitted type plus a command is a CLI entry at runtime. Its model is an arbitrary label.
+  if (
+    !entry ||
+    (entry.type !== undefined && entry.type !== "provider") ||
+    (entry.type === undefined && entry.command)
+  ) {
     return undefined;
   }
-  if (typeof entry.provider !== "string" || entry.provider.trim().toLowerCase() !== "xai") {
+  if (!isXaiProviderId(entry.provider)) {
     return undefined;
   }
   return entry;
@@ -104,12 +105,13 @@ function hasImageCapability(entry: { capabilities?: unknown }): boolean {
 
 function isRetiredXaiImageMediaEntry(value: unknown): boolean {
   const entry = asXaiProviderMediaEntry(value);
+  // Media entries cannot preserve "reasoning disabled", so migrate only compatible redirects.
   // Shared xAI media entries without capabilities infer audio from provider
   // metadata, so rewriting them to grok-4.3 would mutate audio config.
   // Require an explicit capabilities tag that includes image.
   return (
     typeof entry?.model === "string" &&
-    RETIRED_XAI_MEDIA_MODELS.has(entry.model.trim().toLowerCase()) &&
+    RETIRED_REASONING_MODELS.has(entry.model.trim().toLowerCase()) &&
     hasImageCapability(entry)
   );
 }
@@ -178,34 +180,10 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
   }
 
   for (const path of XAI_MEDIA_MODEL_LIST_PATHS) {
-    if (hasRetiredXaiImageMediaEntries(readPath(next, path))) {
-      if (next === cfg) {
-        next = structuredClone(cfg);
-      }
-      const entries = readPath(next, path);
-      if (Array.isArray(entries)) {
-        let migrated = 0;
-        for (const entry of entries) {
-          if (!isRetiredXaiImageMediaEntry(entry)) {
-            continue;
-          }
-          const rec = asObjectRecord(entry);
-          if (rec) {
-            rec.model = "grok-4.3";
-            migrated += 1;
-          }
-        }
-        if (migrated > 0) {
-          changes.push(
-            `Migrated ${migrated} retired xAI image model${migrated === 1 ? "" : "s"} in ${path.join(".")} to grok-4.3.`,
-          );
-        }
-      }
-    }
-  }
-
-  for (const path of XAI_MEDIA_MODEL_LIST_PATHS) {
-    if (!hasLegacyXaiSttEntries(readPath(next, path))) {
+    const currentEntries = readPath(next, path);
+    const hasRetiredImages = hasRetiredXaiImageMediaEntries(currentEntries);
+    const hasLegacyStt = hasLegacyXaiSttEntries(currentEntries);
+    if (!hasRetiredImages && !hasLegacyStt) {
       continue;
     }
     if (next === cfg) {
@@ -215,17 +193,30 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
     if (!Array.isArray(entries)) {
       continue;
     }
+    let migrated = 0;
     let removed = 0;
     for (const entry of entries) {
-      if (!isLegacyXaiSttEntry(entry)) {
+      const rec = asObjectRecord(entry);
+      if (isRetiredXaiImageMediaEntry(entry) && rec) {
+        rec.model = "grok-4.3";
+        migrated += 1;
         continue;
       }
-      delete asObjectRecord(entry)?.model;
-      removed += 1;
+      if (isLegacyXaiSttEntry(entry) && rec) {
+        delete rec.model;
+        removed += 1;
+      }
     }
-    changes.push(
-      `Removed the obsolete xAI grok-stt model selector from ${removed} ${path.join(".")} entr${removed === 1 ? "y" : "ies"}.`,
-    );
+    if (migrated > 0) {
+      changes.push(
+        `Migrated ${migrated} retired xAI image model${migrated === 1 ? "" : "s"} in ${path.join(".")} to grok-4.3.`,
+      );
+    }
+    if (removed > 0) {
+      changes.push(
+        `Removed the obsolete xAI grok-stt model selector from ${removed} ${path.join(".")} entr${removed === 1 ? "y" : "ies"}.`,
+      );
+    }
   }
 
   const modelsPath = ["models", "providers", "xai", "models"];

--- a/extensions/xai/doctor-contract-api.ts
+++ b/extensions/xai/doctor-contract-api.ts
@@ -55,7 +55,7 @@ const PLUGIN_MODEL_MIGRATIONS: PluginModelMigration[] = [
     ["plugins", "entries", "xai", "config", "xSearch"],
   ].map((path) => ({ path, retiredModels: RETIRED_CODE_MODELS, targetModel: "grok-build-0.1" })),
 ];
-const XAI_STT_MODEL_LIST_PATHS = [["tools", "media", "models"]] as const;
+const XAI_MEDIA_MODEL_LIST_PATHS = [["tools", "media", "models"]] as const;
 
 function readPath(root: unknown, path: readonly string[]): unknown {
   let current = root;
@@ -82,34 +82,45 @@ const RETIRED_XAI_MEDIA_MODELS = new Set([
   ...RETIRED_NON_REASONING_MODELS,
 ]);
 
-function isRetiredXaiMediaEntry(value: unknown): boolean {
+function asXaiProviderMediaEntry(value: unknown) {
   const entry = asObjectRecord(value);
   if (!entry || (entry.type !== undefined && entry.type !== "provider")) {
-    return false;
+    return undefined;
   }
+  if (typeof entry.provider !== "string" || entry.provider.trim().toLowerCase() !== "xai") {
+    return undefined;
+  }
+  return entry;
+}
+
+function hasImageCapability(entry: { capabilities?: unknown }): boolean {
   return (
-    typeof entry.provider === "string" &&
-    entry.provider.trim().toLowerCase() === "xai" &&
-    typeof entry.model === "string" &&
-    RETIRED_XAI_MEDIA_MODELS.has(entry.model.trim().toLowerCase())
+    Array.isArray(entry.capabilities) &&
+    entry.capabilities.some(
+      (capability) => typeof capability === "string" && capability.trim().toLowerCase() === "image",
+    )
   );
 }
 
-function hasRetiredXaiMediaEntries(value: unknown): boolean {
-  return Array.isArray(value) && value.some(isRetiredXaiMediaEntry);
+function isRetiredXaiImageMediaEntry(value: unknown): boolean {
+  const entry = asXaiProviderMediaEntry(value);
+  // Shared xAI media entries without capabilities infer audio from provider
+  // metadata, so rewriting them to grok-4.3 would mutate audio config.
+  // Require an explicit capabilities tag that includes image.
+  return (
+    typeof entry?.model === "string" &&
+    RETIRED_XAI_MEDIA_MODELS.has(entry.model.trim().toLowerCase()) &&
+    hasImageCapability(entry)
+  );
+}
+
+function hasRetiredXaiImageMediaEntries(value: unknown): boolean {
+  return Array.isArray(value) && value.some(isRetiredXaiImageMediaEntry);
 }
 
 function isLegacyXaiSttEntry(value: unknown): boolean {
-  const entry = asObjectRecord(value);
-  if (!entry || (entry.type !== undefined && entry.type !== "provider")) {
-    return false;
-  }
-  return (
-    typeof entry.provider === "string" &&
-    entry.provider.trim().toLowerCase() === "xai" &&
-    typeof entry.model === "string" &&
-    entry.model.trim().toLowerCase() === "grok-stt"
-  );
+  const entry = asXaiProviderMediaEntry(value);
+  return typeof entry?.model === "string" && entry.model.trim().toLowerCase() === "grok-stt";
 }
 
 function hasLegacyXaiSttEntries(value: unknown): boolean {
@@ -122,12 +133,12 @@ export const legacyConfigRules: LegacyConfigRule[] = [
     message: `${migration.path.join(".")}.model uses a retired xAI model; run "openclaw doctor --fix" to use ${migration.targetModel}.`,
     match: (value: unknown) => isRetiredToolModel(value, migration.retiredModels),
   })),
-  ...XAI_STT_MODEL_LIST_PATHS.map((path) => ({
+  ...XAI_MEDIA_MODEL_LIST_PATHS.map((path) => ({
     path: [...path],
-    message: `${path.join(".")} contains an xAI entry with a retired model; run "openclaw doctor --fix" to migrate it to grok-4.3.`,
-    match: hasRetiredXaiMediaEntries,
+    message: `${path.join(".")} contains an xAI image entry with a retired model; run "openclaw doctor --fix" to migrate it to grok-4.3.`,
+    match: hasRetiredXaiImageMediaEntries,
   })),
-  ...XAI_STT_MODEL_LIST_PATHS.map((path) => ({
+  ...XAI_MEDIA_MODEL_LIST_PATHS.map((path) => ({
     path: [...path],
     message: `${path.join(".")} contains the obsolete xAI grok-stt model selector; run "openclaw doctor --fix" to remove it.`,
     match: hasLegacyXaiSttEntries,
@@ -166,8 +177,8 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
     );
   }
 
-  for (const path of XAI_STT_MODEL_LIST_PATHS) {
-    if (hasRetiredXaiMediaEntries(readPath(next, path))) {
+  for (const path of XAI_MEDIA_MODEL_LIST_PATHS) {
+    if (hasRetiredXaiImageMediaEntries(readPath(next, path))) {
       if (next === cfg) {
         next = structuredClone(cfg);
       }
@@ -175,7 +186,7 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
       if (Array.isArray(entries)) {
         let migrated = 0;
         for (const entry of entries) {
-          if (!isRetiredXaiMediaEntry(entry)) {
+          if (!isRetiredXaiImageMediaEntry(entry)) {
             continue;
           }
           const rec = asObjectRecord(entry);
@@ -193,7 +204,7 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
     }
   }
 
-  for (const path of XAI_STT_MODEL_LIST_PATHS) {
+  for (const path of XAI_MEDIA_MODEL_LIST_PATHS) {
     if (!hasLegacyXaiSttEntries(readPath(next, path))) {
       continue;
     }

--- a/extensions/xai/doctor-contract-api.ts
+++ b/extensions/xai/doctor-contract-api.ts
@@ -77,6 +77,28 @@ function hasLegacyBuiltinCatalogRows(value: unknown): boolean {
   return Array.isArray(value) && value.some((model) => isLegacyXaiBuiltinModel(model));
 }
 
+const RETIRED_XAI_MEDIA_MODELS = new Set([
+  ...RETIRED_REASONING_MODELS,
+  ...RETIRED_NON_REASONING_MODELS,
+]);
+
+function isRetiredXaiMediaEntry(value: unknown): boolean {
+  const entry = asObjectRecord(value);
+  if (!entry || (entry.type !== undefined && entry.type !== "provider")) {
+    return false;
+  }
+  return (
+    typeof entry.provider === "string" &&
+    entry.provider.trim().toLowerCase() === "xai" &&
+    typeof entry.model === "string" &&
+    RETIRED_XAI_MEDIA_MODELS.has(entry.model.trim().toLowerCase())
+  );
+}
+
+function hasRetiredXaiMediaEntries(value: unknown): boolean {
+  return Array.isArray(value) && value.some(isRetiredXaiMediaEntry);
+}
+
 function isLegacyXaiSttEntry(value: unknown): boolean {
   const entry = asObjectRecord(value);
   if (!entry || (entry.type !== undefined && entry.type !== "provider")) {
@@ -99,6 +121,11 @@ export const legacyConfigRules: LegacyConfigRule[] = [
     path: migration.path,
     message: `${migration.path.join(".")}.model uses a retired xAI model; run "openclaw doctor --fix" to use ${migration.targetModel}.`,
     match: (value: unknown) => isRetiredToolModel(value, migration.retiredModels),
+  })),
+  ...XAI_STT_MODEL_LIST_PATHS.map((path) => ({
+    path: [...path],
+    message: `${path.join(".")} contains an xAI entry with a retired model; run "openclaw doctor --fix" to migrate it to grok-4.3.`,
+    match: hasRetiredXaiMediaEntries,
   })),
   ...XAI_STT_MODEL_LIST_PATHS.map((path) => ({
     path: [...path],
@@ -137,6 +164,33 @@ export function normalizeCompatibilityConfig({ cfg }: { cfg: OpenClawConfig }): 
     changes.push(
       `Updated ${migration.path.join(".")}.model from ${JSON.stringify(previous)} to ${JSON.stringify(migration.targetModel)}.`,
     );
+  }
+
+  for (const path of XAI_STT_MODEL_LIST_PATHS) {
+    if (hasRetiredXaiMediaEntries(readPath(next, path))) {
+      if (next === cfg) {
+        next = structuredClone(cfg);
+      }
+      const entries = readPath(next, path);
+      if (Array.isArray(entries)) {
+        let migrated = 0;
+        for (const entry of entries) {
+          if (!isRetiredXaiMediaEntry(entry)) {
+            continue;
+          }
+          const rec = asObjectRecord(entry);
+          if (rec) {
+            rec.model = "grok-4.3";
+            migrated += 1;
+          }
+        }
+        if (migrated > 0) {
+          changes.push(
+            `Migrated ${migrated} retired xAI image model${migrated === 1 ? "" : "s"} in ${path.join(".")} to grok-4.3.`,
+          );
+        }
+      }
+    }
   }
 
   for (const path of XAI_STT_MODEL_LIST_PATHS) {

--- a/extensions/xai/provider-id.ts
+++ b/extensions/xai/provider-id.ts
@@ -1,4 +1,4 @@
-import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+import { normalizeProviderId } from "openclaw/plugin-sdk/model-ref-parse";
 
 const XAI_PROVIDER_IDS = new Set(["xai", "x-ai"]);
 

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -754,48 +754,7 @@ describe("doctor-contract-registry module loader", () => {
     ).toEqual(["gemini", "openai", "xai"]);
   });
 
-  it("loads a provider doctor contract through its manifest alias", () => {
-    const pluginRoot = makeTempDir();
-    fs.writeFileSync(path.join(pluginRoot, "doctor-contract-api.ts"), "export {};\n", "utf-8");
-    mocks.createJiti.mockImplementation(() => () => ({
-      normalizeCompatibilityConfig: ({ cfg }: { cfg: Record<string, unknown> }) => ({
-        config: { ...cfg, repaired: true },
-        changes: ["repaired aliased provider model"],
-      }),
-    }));
-    mocks.loadPluginManifestRegistry.mockReturnValue({
-      plugins: [
-        {
-          id: "xai",
-          rootDir: pluginRoot,
-          channels: [],
-          providers: ["xai"],
-          providerAuthAliases: { "x-ai": "xai" },
-          doctorContract: { configRepair: true },
-        },
-      ],
-      diagnostics: [],
-    });
-    const config = {
-      tools: {
-        media: {
-          models: [{ provider: "x-ai", model: "grok-4-fast", capabilities: ["image"] }],
-        },
-      },
-    };
-    const pluginIds = collectRelevantDoctorPluginIds(config);
-
-    expect(pluginIds).toEqual(["x-ai"]);
-    expect(
-      applyPluginDoctorCompatibilityMigrations(config, { config, env: {}, pluginIds }),
-    ).toEqual({
-      config: { ...config, repaired: true },
-      changes: ["repaired aliased provider model"],
-    });
-    expect(mocks.createJiti).toHaveBeenCalledTimes(1);
-  });
-
-  it("loads a plugin doctor contract when scoped by a contributed provider id", () => {
+  it("loads a plugin doctor contract when scoped by a contributed provider alias", () => {
     const pluginRoot = makeTempDir();
     fs.writeFileSync(path.join(pluginRoot, "doctor-contract-api.ts"), "export {};\n", "utf-8");
     mocks.createJiti.mockImplementation(() => () => ({
@@ -826,7 +785,8 @@ describe("doctor-contract-registry module loader", () => {
           id: "ollama",
           rootDir: pluginRoot,
           channels: [],
-          providers: ["ollama", "ollama-cloud"],
+          providers: ["ollama"],
+          providerAuthAliases: { "ollama-cloud": "ollama" },
         },
       ],
       diagnostics: [],

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -754,6 +754,47 @@ describe("doctor-contract-registry module loader", () => {
     ).toEqual(["gemini", "openai", "xai"]);
   });
 
+  it("loads a provider doctor contract through its manifest alias", () => {
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(pluginRoot, "doctor-contract-api.ts"), "export {};\n", "utf-8");
+    mocks.createJiti.mockImplementation(() => () => ({
+      normalizeCompatibilityConfig: ({ cfg }: { cfg: Record<string, unknown> }) => ({
+        config: { ...cfg, repaired: true },
+        changes: ["repaired aliased provider model"],
+      }),
+    }));
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [
+        {
+          id: "xai",
+          rootDir: pluginRoot,
+          channels: [],
+          providers: ["xai"],
+          providerAuthAliases: { "x-ai": "xai" },
+          doctorContract: { configRepair: true },
+        },
+      ],
+      diagnostics: [],
+    });
+    const config = {
+      tools: {
+        media: {
+          models: [{ provider: "x-ai", model: "grok-4-fast", capabilities: ["image"] }],
+        },
+      },
+    };
+    const pluginIds = collectRelevantDoctorPluginIds(config);
+
+    expect(pluginIds).toEqual(["x-ai"]);
+    expect(
+      applyPluginDoctorCompatibilityMigrations(config, { config, env: {}, pluginIds }),
+    ).toEqual({
+      config: { ...config, repaired: true },
+      changes: ["repaired aliased provider model"],
+    });
+    expect(mocks.createJiti).toHaveBeenCalledTimes(1);
+  });
+
   it("loads a plugin doctor contract when scoped by a contributed provider id", () => {
     const pluginRoot = makeTempDir();
     fs.writeFileSync(path.join(pluginRoot, "doctor-contract-api.ts"), "export {};\n", "utf-8");

--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -756,8 +756,10 @@ describe("doctor-contract-registry module loader", () => {
 
   it("loads a plugin doctor contract when scoped by a contributed provider alias", () => {
     const pluginRoot = makeTempDir();
+    const unrelatedRoot = makeTempDir();
     fs.writeFileSync(path.join(pluginRoot, "doctor-contract-api.ts"), "export {};\n", "utf-8");
-    mocks.createJiti.mockImplementation(() => () => ({
+    fs.writeFileSync(path.join(unrelatedRoot, "doctor-contract-api.ts"), "export {};\n", "utf-8");
+    mocks.createJiti.mockImplementation(() => (modulePath: string) => ({
       normalizeCompatibilityConfig: ({
         cfg,
       }: {
@@ -776,7 +778,11 @@ describe("doctor-contract-registry module loader", () => {
             },
           },
         },
-        changes: ["normalized ollama cloud provider endpoint"],
+        changes: [
+          modulePath.startsWith(unrelatedRoot)
+            ? "wrong unrelated provider contract"
+            : "normalized ollama cloud provider endpoint",
+        ],
       }),
     }));
     mocks.loadPluginManifestRegistry.mockReturnValue({
@@ -785,8 +791,15 @@ describe("doctor-contract-registry module loader", () => {
           id: "ollama",
           rootDir: pluginRoot,
           channels: [],
-          providers: ["ollama"],
-          providerAuthAliases: { "ollama-cloud": "ollama" },
+          providers: ["OlLaMa"],
+          providerAuthAliases: { "Ollama-Cloud": "OLLAMA" },
+        },
+        {
+          id: "unrelated",
+          rootDir: unrelatedRoot,
+          channels: [],
+          providers: ["unrelated"],
+          providerAuthAliases: { "ollama-cloud": "missing" },
         },
       ],
       diagnostics: [],
@@ -813,6 +826,7 @@ describe("doctor-contract-registry module loader", () => {
       baseUrl: "https://ollama.com",
       models: [],
     });
+    expect(mocks.createJiti).toHaveBeenCalledTimes(1);
   });
 
   it("loads a provider doctor contract when a media preference is its only activation", () => {

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -284,7 +284,8 @@ function resolvePluginDoctorManifestRecords(params: {
         !(record.packageName && scopedPluginIds.has(record.packageName)) &&
         !record.legacyPluginIds?.some((pluginId) => scopedPluginIds.has(pluginId)) &&
         !record.channels.some((channelId) => scopedPluginIds.has(channelId)) &&
-        !record.providers.some((providerId) => scopedPluginIds.has(providerId))
+        !record.providers.some((providerId) => scopedPluginIds.has(providerId)) &&
+        !Object.keys(record.providerAuthAliases ?? {}).some((alias) => scopedPluginIds.has(alias))
       ),
   );
 }

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -141,6 +141,20 @@ function collectConfiguredModelProviderIds(params: {
   }
 }
 
+function hasScopedProviderAuthAlias(
+  record: PluginManifestRegistryRecord,
+  scopedProviderIds: ReadonlySet<string>,
+): boolean {
+  return Object.entries(record.providerAuthAliases ?? {}).some(([rawAlias, rawTarget]) => {
+    const target = normalizeProviderId(rawTarget);
+    return (
+      scopedProviderIds.has(normalizeProviderId(rawAlias)) &&
+      target !== "" &&
+      record.providers.some((providerId) => normalizeProviderId(providerId) === target)
+    );
+  });
+}
+
 export function collectRelevantDoctorPluginIds(raw: unknown): string[] {
   const ids = new Set<string>();
   const root = asNullableRecord(raw);
@@ -276,6 +290,9 @@ function resolvePluginDoctorManifestRecords(params: {
   });
 
   const scopedPluginIds = params?.pluginIds ? new Set(params.pluginIds) : null;
+  const scopedProviderIds = params?.pluginIds
+    ? new Set(params.pluginIds.map(normalizeProviderId).filter(Boolean))
+    : null;
   return manifestRegistry.plugins.filter(
     (record) =>
       !(
@@ -285,7 +302,7 @@ function resolvePluginDoctorManifestRecords(params: {
         !record.legacyPluginIds?.some((pluginId) => scopedPluginIds.has(pluginId)) &&
         !record.channels.some((channelId) => scopedPluginIds.has(channelId)) &&
         !record.providers.some((providerId) => scopedPluginIds.has(providerId)) &&
-        !Object.keys(record.providerAuthAliases ?? {}).some((alias) => scopedPluginIds.has(alias))
+        !(scopedProviderIds && hasScopedProviderAuthAlias(record, scopedProviderIds))
       ),
   );
 }


### PR DESCRIPTION
Closes #124527

## What Problem This Solves

`openclaw doctor --fix` could leave retired xAI vision model IDs in `tools.media.models`. The generic media runtime then forwarded that stale configured model.

## Why This Change Was Made

The xAI plugin owns retired model knowledge, so its Doctor contract now repairs the saved image entry before runtime use.

The repair only changes provider entries with an explicit `image` capability and a retired reasoning-model ID whose replacement keeps the same reasoning behavior. It supports the shipped `xai` and `x-ai` provider IDs. It preserves audio-only, untagged, non-reasoning, custom, and command-line entries.

Doctor contract selection now honors normalized manifest-declared provider aliases only when the alias target is owned by that manifest. The xAI provider ID helper also uses the light model-reference entry point so Doctor does not load the runtime provider barrel or state database.

## User Impact

After `openclaw doctor --fix`, affected xAI image entries use `grok-4.3`. Operators do not need to edit JSON manually.

## Evidence

**Current-main red:** On `c89c333ef94bf98ec3a45f63ba3fc2253d8fa882`, an isolated real `pnpm openclaw doctor --fix --yes --non-interactive` run left `xai/grok-4-fast` unchanged in an explicit image entry. Audio-only and untagged controls also stayed unchanged.

**Exact-head green:** On `d505e2eee15468fa81d40f9dbdcd9fb14144943e`, the same real Doctor flow migrated explicit `xai` and `x-ai` image entries to `grok-4.3`. It preserved audio-only, untagged, non-reasoning, and implicit command-line entries. A second run made no further model change.

**Regression proof:** The new alias contract-selection test fails on the prior PR head because no Doctor contract loads for an `x-ai`-only media configuration. It passes on this head.

**Local checks:**

- `node scripts/run-vitest.mjs extensions/xai/doctor-contract-api.test.ts src/plugins/doctor-contract-registry.test.ts src/plugins/doctor-contract-declarations.test.ts src/plugins/doctor-contract-closure-guard.test.ts`
- `node scripts/run-vitest.mjs extensions/xai/provider-policy-api.test.ts extensions/xai/openclaw.plugin.test.ts`
- `node scripts/run-oxlint.mjs extensions/xai/doctor-contract-api.ts extensions/xai/doctor-contract-api.test.ts extensions/xai/provider-id.ts src/plugins/doctor-contract-registry.ts src/plugins/doctor-contract-registry.test.ts`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`

All checks passed. Hosted continuous integration is running on the exact head.

**Code size:** Production `+74` net and tests `+83` net versus current main. The production growth adds the provider-owned migration and a normalized, target-owned manifest-alias selection rule. The media mutation shares one pass with the existing xAI speech-to-text cleanup.

Co-authored-by: Cursor <cursoragent@cursor.com>
