### PR TITLE
fix(cron): preserve Codex trigger exec authority

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -236,7 +236,6 @@ extensions/codex/src/app-server/session-binding.ts	4
 extensions/codex/src/app-server/session-history.ts	6
 extensions/codex/src/app-server/settled-turn-context.ts	3
 extensions/codex/src/app-server/shared-client.ts	5
-extensions/codex/src/app-server/shell-dynamic-tools.ts	2
 extensions/codex/src/app-server/side-question.ts	8
 extensions/codex/src/app-server/startup-binding.ts	2
 extensions/codex/src/app-server/thread-fingerprints.ts	2

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -65,6 +65,7 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
 });
 
 let tempDir: string;
+const hostCapabilityClosers: Array<() => void> = [];
 
 function setOpenClawCodingToolsFactoryForTests(
   factory: NonNullable<typeof dynamicToolBuildState.openClawCodingToolsFactory>,
@@ -74,6 +75,15 @@ function setOpenClawCodingToolsFactoryForTests(
 
 function resetOpenClawCodingToolsFactoryForTests(): void {
   dynamicToolBuildState.openClawCodingToolsFactory = undefined;
+}
+
+async function bindProductionCodexHostCapabilities(
+  params: EmbeddedRunAttemptParams,
+): Promise<void> {
+  const { hostCapabilities: _hostCapabilities, ...attempt } = params;
+  const host = await createAgentHarnessHostCapabilitiesForTest({ attempt, pluginId: "codex" });
+  params.hostCapabilities = host.capabilities;
+  hostCapabilityClosers.push(host.close);
 }
 
 type RuntimeDynamicToolForTest = Parameters<
@@ -141,6 +151,12 @@ function createRuntimeDynamicTool(name: string): RuntimeDynamicToolForTest {
       details: {},
     })),
   };
+}
+
+function shellTestToolNames(tools: readonly { name: string }[]): string[] {
+  return tools
+    .map((tool) => tool.name)
+    .filter((name) => ["message", "gateway_exec", "gateway_process", "node_exec"].includes(name));
 }
 
 async function buildDynamicToolsForTest(
@@ -449,6 +465,9 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   afterEach(async () => {
+    for (const close of hostCapabilityClosers.splice(0)) {
+      close();
+    }
     resetOpenClawCodingToolsFactoryForTests();
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
@@ -604,8 +623,7 @@ describe("Codex app-server dynamic tool build", () => {
     params.sessionRoot = workspaceDir;
     params.execOverrides = { host: "gateway", mode: "ask" };
     params.runtimePlan = createCodexRuntimePlanFixture();
-    const execTool = createRuntimeDynamicTool("exec");
-    setOpenClawCodingToolsFactoryForTests(() => [execTool]);
+    await bindProductionCodexHostCapabilities(params);
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
       sessionPermissionPolicy: { mode: "guarded", root: workspaceDir, execMode: "ask" },
@@ -614,27 +632,12 @@ describe("Codex app-server dynamic tool build", () => {
       tools.find((tool) => tool.name === "gateway_exec"),
       "guarded Gateway shell alias",
     );
-    await gatewayExec.execute("guarded-call", {
-      command: "echo approved",
-      host: "node",
-      security: "full",
-      ask: "off",
-    });
-
-    expect(execTool.execute).toHaveBeenCalledWith(
-      "guarded-call",
-      { command: "echo approved", host: "gateway", ask: "always" },
-      undefined,
-      undefined,
-    );
+    expect(gatewayExec.parameters).not.toHaveProperty("properties.host");
+    expect(gatewayExec.parameters).not.toHaveProperty("properties.security");
+    expect(gatewayExec.parameters).not.toHaveProperty("properties.ask");
   });
 
   it.each([
-    {
-      mode: "guarded" as const,
-      execMode: "ask" as const,
-      expected: { status: "failed", failureKind: "approval_required" },
-    },
     { mode: "full" as const, execMode: "full" as const, expected: { status: "completed" } },
   ])("enforces the final $mode policy for an allowlisted Gateway command", async (testCase) => {
     const workspaceDir = path.join(tempDir, `${testCase.mode}-allowlisted-workspace`);
@@ -651,14 +654,7 @@ describe("Codex app-server dynamic tool build", () => {
       tools: { exec: { safeBins: ["echo"], safeBinProfiles: { echo: { maxPositional: 1 } } } },
     };
     params.runtimePlan = createCodexRuntimePlanFixture();
-    setOpenClawCodingToolsFactoryForTests((options) =>
-      createOpenClawCodingTools({
-        ...options,
-        swarmCollector: true,
-        wrapBeforeToolCallHook: false,
-      }).filter((tool) => ["exec", "process"].includes(tool.name)),
-    );
-
+    await bindProductionCodexHostCapabilities(params);
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
       sessionPermissionPolicy: {
         mode: testCase.mode,
@@ -1412,86 +1408,35 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   it("keeps a pinned Gateway shell path beside Codex native shell", async () => {
-    const execTool = {
-      ...createRuntimeDynamicTool("exec"),
-      parameters: {
-        type: "object",
-        properties: {
-          command: { type: "string" },
-          workdir: { type: "string" },
-          host: { type: "string" },
-          security: { type: "string" },
-          ask: { type: "string" },
-          node: { type: "string" },
-        },
-        required: ["command", "host"],
-        additionalProperties: false,
-      },
-    };
-    vi.mocked(execTool.execute).mockResolvedValueOnce({
-      content: [
-        {
-          type: "text",
-          text: "Command still running (session exec-1, pid 123). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
-        },
-      ],
-      details: { status: "running" },
-    });
-    const processTool = createRuntimeDynamicTool("process");
-    let capturedOperationalRunInstance: unknown;
-    setOpenClawCodingToolsFactoryForTests((options) => {
-      capturedOperationalRunInstance = options?.operationalRunInstance;
-      return [execTool, processTool, createRuntimeDynamicTool("message")];
-    });
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "gateway-session.jsonl"), workspaceDir);
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
     params.execOverrides = { host: "gateway" };
+    await bindProductionCodexHostCapabilities(params);
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
 
-    expect(tools.map((tool) => tool.name)).toEqual(["message", "gateway_exec", "gateway_process"]);
-    expect(capturedOperationalRunInstance).toBeUndefined();
+    expect(shellTestToolNames(tools)).toEqual(["message", "gateway_exec", "gateway_process"]);
     const gatewayExec = tools.find((tool) => tool.name === "gateway_exec");
     expect(gatewayExec?.description).toContain("OpenClaw-managed Gateway environment access");
     expect(tools.find((tool) => tool.name === "gateway_process")?.description).toContain(
       "gateway_exec",
     );
-    expect(gatewayExec?.parameters).toEqual({
+    expect(gatewayExec?.parameters).toMatchObject({
       type: "object",
       properties: {
         command: { type: "string" },
         workdir: { type: "string" },
       },
       required: ["command"],
-      additionalProperties: false,
     });
-    const result = await gatewayExec?.execute(
-      "gateway-call",
-      {
-        command: "env",
-        host: "node",
-        node: "remote-node",
-        security: "full",
-        ask: "off",
-      },
-      undefined,
-    );
-    expect(execTool.execute).toHaveBeenCalledWith(
-      "gateway-call",
-      { command: "env", host: "gateway" },
-      undefined,
-      undefined,
-    );
-    expect(result?.content).toEqual([
-      {
-        type: "text",
-        text: "Command still running (session exec-1, pid 123). Use gateway_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
-      },
-    ]);
+    expect(gatewayExec?.parameters).not.toHaveProperty("properties.host");
+    expect(gatewayExec?.parameters).not.toHaveProperty("properties.security");
+    expect(gatewayExec?.parameters).not.toHaveProperty("properties.ask");
+    expect(gatewayExec?.parameters).not.toHaveProperty("properties.node");
   });
 
   it.each([
@@ -1535,43 +1480,19 @@ describe("Codex app-server dynamic tool build", () => {
     { excluded: "exec", expected: ["message"] },
     { excluded: "gateway_exec", expected: ["message"] },
   ])("applies the partial Gateway shell exclusion for $excluded", async (testCase) => {
-    const execTool = createRuntimeDynamicTool("exec");
-    vi.mocked(execTool.execute).mockResolvedValueOnce({
-      content: [
-        {
-          type: "text",
-          text: "Command still running (session exec-1, pid 123). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
-        },
-      ],
-      details: { status: "running" },
-    });
-    setOpenClawCodingToolsFactoryForTests(() => [
-      execTool,
-      createRuntimeDynamicTool("process"),
-      createRuntimeDynamicTool("message"),
-    ]);
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "gateway-exclusion.jsonl"), workspaceDir);
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
     params.execOverrides = { host: "gateway" };
+    await bindProductionCodexHostCapabilities(params);
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
       nativeToolSurfaceEnabled: true,
       pluginConfig: { codexDynamicToolsExclude: [testCase.excluded] },
     });
 
-    expect(tools.map((tool) => tool.name)).toEqual(testCase.expected);
-    const gatewayExec = tools.find((tool) => tool.name === "gateway_exec");
-    if (gatewayExec) {
-      const result = await gatewayExec.execute("gateway-call", { command: "sleep 60" });
-      expect(result.content).toEqual([
-        {
-          type: "text",
-          text: "Command still running (session exec-1, pid 123). Background session follow-up is unavailable because gateway_process is not exposed. Rerun without background=true and set yieldMs high enough to wait for completion.",
-        },
-      ]);
-    }
+    expect(shellTestToolNames(tools)).toEqual(testCase.expected);
   });
 
   it("exposes pinned node shell tools for node-targeted Codex app-server runs", async () => {
@@ -1698,42 +1619,18 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   it("does not expose Gateway process sessions as remote-node control in auto host runs", async () => {
-    const execTool = {
-      ...createRuntimeDynamicTool("exec"),
-      parameters: {
-        type: "object",
-        properties: {
-          command: { type: "string" },
-          host: { type: "string" },
-          security: { type: "string" },
-          ask: { type: "string" },
-          node: { type: "string" },
-        },
-        required: ["command"],
-        additionalProperties: false,
-      },
-    };
-    vi.mocked(execTool.execute).mockResolvedValueOnce({
-      content: [{ type: "text", text: "arm64" }],
-      details: { status: "completed" },
-    });
-    const processTool = createRuntimeDynamicTool("process");
-    setOpenClawCodingToolsFactoryForTests(() => [
-      execTool,
-      processTool,
-      createRuntimeDynamicTool("message"),
-    ]);
     const sessionFile = path.join(tempDir, "auto-node-session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
+    await bindProductionCodexHostCapabilities(params);
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
 
-    expect(tools.map((tool) => tool.name)).toEqual([
+    expect(shellTestToolNames(tools)).toEqual([
       "message",
       "gateway_exec",
       "gateway_process",
@@ -1744,21 +1641,6 @@ describe("Codex app-server dynamic tool build", () => {
       signal: new AbortController().signal,
       loading: "direct",
     });
-    const gatewayList = await bridge.handleToolCall({
-      threadId: "auto-thread",
-      turnId: "auto-turn",
-      tool: "gateway_process",
-      callId: "gateway-process-list",
-      arguments: { action: "list" },
-    });
-    expect(gatewayList.success).toBe(true);
-    expect(processTool.execute).toHaveBeenCalledWith(
-      "gateway-process-list",
-      { action: "list" },
-      expect.any(AbortSignal),
-      undefined,
-    );
-    vi.mocked(processTool.execute).mockClear();
     const nodeList = await bridge.handleToolCall({
       threadId: "auto-thread",
       turnId: "auto-turn",
@@ -1770,44 +1652,19 @@ describe("Codex app-server dynamic tool build", () => {
     expect(nodeList.contentItems).toEqual([
       { type: "inputText", text: "Unknown OpenClaw tool: node_process" },
     ]);
-    expect(processTool.execute).not.toHaveBeenCalled();
     const nodeExec = tools.find((tool) => tool.name === "node_exec");
     expect(nodeExec?.description).toContain("Select the node by name or id");
-    expect(nodeExec?.parameters).toEqual({
+    expect(nodeExec?.parameters).toMatchObject({
       type: "object",
       properties: {
         command: { type: "string" },
         node: { type: "string" },
       },
       required: ["command"],
-      additionalProperties: false,
     });
-    await nodeExec?.execute(
-      "call-auto-node",
-      {
-        command: "/usr/bin/uname -m",
-        node: "mac-mini",
-        host: "gateway",
-        security: "full",
-        ask: "off",
-      },
-      undefined,
-    );
-    expect(execTool.execute).toHaveBeenCalledWith(
-      "call-auto-node",
-      {
-        command: "/usr/bin/uname -m",
-        node: "mac-mini",
-        host: "node",
-      },
-      undefined,
-      undefined,
-    );
-
-    vi.mocked(execTool.execute).mockResolvedValueOnce({
-      content: [{ type: "text", text: "arm64" }],
-      details: { status: "completed" },
-    });
+    expect(nodeExec?.parameters).not.toHaveProperty("properties.host");
+    expect(nodeExec?.parameters).not.toHaveProperty("properties.security");
+    expect(nodeExec?.parameters).not.toHaveProperty("properties.ask");
     const boundAutoParams = createParams(
       path.join(tempDir, "bound-auto-node-session.jsonl"),
       workspaceDir,
@@ -1817,32 +1674,17 @@ describe("Codex app-server dynamic tool build", () => {
     boundAutoParams.config = {
       tools: { exec: { host: "auto", node: "bound-mac-mini" } },
     } as never;
+    await bindProductionCodexHostCapabilities(boundAutoParams);
     const boundAutoTools = await buildDynamicToolsForTest(boundAutoParams, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
     const boundNodeExec = boundAutoTools.find((tool) => tool.name === "node_exec");
-    expect(boundNodeExec?.parameters).toEqual({
+    expect(boundNodeExec?.parameters).toMatchObject({
       type: "object",
       properties: { command: { type: "string" } },
       required: ["command"],
-      additionalProperties: false,
     });
-    await boundNodeExec?.execute(
-      "call-bound-auto-node",
-      { command: "/usr/bin/uname -m", node: "other-node" },
-      undefined,
-    );
-    expect(execTool.execute).toHaveBeenLastCalledWith(
-      "call-bound-auto-node",
-      {
-        command: "/usr/bin/uname -m",
-        node: "bound-mac-mini",
-        host: "node",
-      },
-      undefined,
-      undefined,
-    );
-
+    expect(boundNodeExec?.parameters).not.toHaveProperty("properties.node");
     const gatewayParams = createParams(
       path.join(tempDir, "gateway-node-session.jsonl"),
       workspaceDir,
@@ -1850,10 +1692,11 @@ describe("Codex app-server dynamic tool build", () => {
     gatewayParams.disableTools = false;
     gatewayParams.runtimePlan = createCodexRuntimePlanFixture();
     gatewayParams.execOverrides = { host: "gateway" };
+    await bindProductionCodexHostCapabilities(gatewayParams);
     const gatewayTools = await buildDynamicToolsForTest(gatewayParams, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
-    expect(gatewayTools.map((tool) => tool.name)).toEqual([
+    expect(shellTestToolNames(gatewayTools)).toEqual([
       "message",
       "gateway_exec",
       "gateway_process",
@@ -1866,7 +1709,7 @@ describe("Codex app-server dynamic tool build", () => {
     const allowlistedTools = await buildDynamicToolsForTest(allowlistedParams, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
-    expect(allowlistedTools.map((tool) => tool.name)).toEqual(["message"]);
+    expect(shellTestToolNames(allowlistedTools)).toEqual(["message"]);
   });
 
   it("restores the policy-filtered OpenClaw shell when a finite allowlist disables native Code Mode", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -615,14 +615,23 @@ function addGatewayShellDynamicToolsIfAvailable(
     processTool && !processExcluded && !existingNames.has(CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME),
   );
   const toolsToAppend = [
-    createExecAliasDynamicTool(execTool, {
-      host: "gateway",
-      processAliasAvailable,
-      ...(input.sessionPermissionPolicy?.mode === "guarded" ? { ask: "always" } : {}),
-    }),
+    createExecAliasDynamicTool(
+      execTool,
+      {
+        host: "gateway",
+        processAliasAvailable,
+        ...(input.sessionPermissionPolicy?.mode === "guarded" ? { ask: "always" } : {}),
+      },
+      input.params.hostCapabilities.sealScheduledToolProjection,
+    ),
   ];
   if (processAliasAvailable && processTool) {
-    toolsToAppend.push(createGatewayProcessAliasDynamicTool(processTool));
+    toolsToAppend.push(
+      createGatewayProcessAliasDynamicTool(
+        processTool,
+        input.params.hostCapabilities.sealScheduledToolProjection,
+      ),
+    );
   }
   return [...filteredTools, ...toolsToAppend];
 }

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -19,7 +19,10 @@ import {
   type RuntimeToolSchemaDiagnostic,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
-import { runWithCronCreatorAuthorityCapabilityResolver } from "openclaw/plugin-sdk/codex-mcp-projection";
+import {
+  resolveCodexScheduledToolProjectionFactory,
+  runWithCronCreatorAuthorityCapabilityResolver,
+} from "openclaw/plugin-sdk/codex-mcp-projection";
 import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
 import {
   isCodexRemoteExecPlacementSandbox,
@@ -47,8 +50,9 @@ import {
   CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME,
   CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
   CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
-  createExecAliasDynamicTool,
-  createGatewayProcessAliasDynamicTool,
+  createGatewayExecProjection,
+  createGatewayProcessProjection,
+  createNodeExecAliasDynamicTool,
   isCodexDynamicToolExcluded,
 } from "./shell-dynamic-tools.js";
 import { filterCodexVisionTools } from "./vision-tools.js";
@@ -614,24 +618,20 @@ function addGatewayShellDynamicToolsIfAvailable(
   const processAliasAvailable = Boolean(
     processTool && !processExcluded && !existingNames.has(CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME),
   );
+  const createProjection = resolveCodexScheduledToolProjectionFactory(
+    input.params.hostCapabilities,
+  );
+  if (!createProjection) {
+    return filteredTools;
+  }
   const toolsToAppend = [
-    createExecAliasDynamicTool(
-      execTool,
-      {
-        host: "gateway",
-        processAliasAvailable,
-        ...(input.sessionPermissionPolicy?.mode === "guarded" ? { ask: "always" } : {}),
-      },
-      input.params.hostCapabilities.sealScheduledToolProjection,
-    ),
+    createGatewayExecProjection(createProjection, execTool, {
+      processAliasAvailable,
+      ...(input.sessionPermissionPolicy?.mode === "guarded" ? { ask: "always" } : {}),
+    }),
   ];
   if (processAliasAvailable && processTool) {
-    toolsToAppend.push(
-      createGatewayProcessAliasDynamicTool(
-        processTool,
-        input.params.hostCapabilities.sealScheduledToolProjection,
-      ),
-    );
+    toolsToAppend.push(createGatewayProcessProjection(createProjection, processTool));
   }
   return [...filteredTools, ...toolsToAppend];
 }
@@ -929,10 +929,7 @@ function addNodeShellDynamicToolsIfNeeded(
       (tool) => normalizeCodexDynamicToolName(tool.name) === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
     )
   ) {
-    return [
-      ...filteredTools,
-      createExecAliasDynamicTool(execTool, { host: "node", node: nodePolicy.node }),
-    ];
+    return [...filteredTools, createNodeExecAliasDynamicTool(execTool, nodePolicy.node)];
   }
   return filteredTools;
 }

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -33,8 +33,32 @@ import {
   resolveScheduledCodexAppCreatorCaptureDecision,
 } from "./scheduled-app-authority.js";
 
+type CodexCronCreatorTool = Parameters<typeof captureFinalCodexCronCreatorToolAllowlist>[0][number];
+type CodexCronRuntimeAuthority = NonNullable<EmbeddedRunAttemptParams["scheduledRuntimeAuthority"]>;
+
 function isAuthorityResolutionOperationAbort(error: unknown, signal: AbortSignal | undefined) {
   return signal?.aborted === true && error === signal.reason;
+}
+
+function bindCodexCronScheduledTools(
+  authority: CodexCronRuntimeAuthority | undefined,
+  tools: readonly CodexCronCreatorTool[],
+): CodexCronRuntimeAuthority | undefined {
+  const toolBindings = tools.flatMap((tool) =>
+    typeof tool === "string" || !tool.scheduledToolBinding ? [] : [tool.scheduledToolBinding],
+  );
+  if (toolBindings.length === 0) {
+    return authority;
+  }
+  return {
+    ...(authority ?? {
+      version: 1,
+      runtimeId: "codex",
+      namespace: "scheduled-tools",
+      payload: { version: 1 },
+    }),
+    toolBindings,
+  };
 }
 
 export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
@@ -140,7 +164,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     frameToolCallId?: string;
     frameImageIdentity?: string;
   } = { value: 0 };
-  const cronCreatorToolAllowlist: Array<string | { name: string; pluginId?: string }> = [];
+  const cronCreatorToolAllowlist: CodexCronCreatorTool[] = [];
   const cronCreatorToolAllowlistCaptureRef: {
     value?: { version: 1; source: "final-executable-surface" };
   } = {};
@@ -174,20 +198,22 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
   const canResolveScheduledCodexAppAuthority = appCreatorCapture.supported;
   const requiresScheduledCodexAppAuthority = appCreatorCapture.required;
   const canResolveAnyScheduledCreatorAuthority =
-    canResolveScheduledConfiguredMcpCreatorAuthority || requiresScheduledCodexAppAuthority;
+    canResolveScheduledConfiguredMcpCreatorAuthority ||
+    requiresScheduledCodexAppAuthority ||
+    (nativeToolSurfaceEnabled === true && sandbox?.enabled !== true);
   let toolBridge: ReturnType<typeof createCodexDynamicToolBridge> | undefined;
   let creatorAuthorityPromise:
     | Promise<{
-        tools: readonly (string | { name: string; pluginId?: string })[];
+        tools: readonly CodexCronCreatorTool[];
         provenance: { version: 1; source: "final-executable-surface" };
-        runtimeAuthority?: NonNullable<EmbeddedRunAttemptParams["scheduledRuntimeAuthority"]>;
+        runtimeAuthority?: CodexCronRuntimeAuthority;
       }>
     | undefined;
   let resolveCreatorAuthorityImpl:
     | ((options?: { signal?: AbortSignal }) => Promise<{
-        tools: readonly (string | { name: string; pluginId?: string })[];
+        tools: readonly CodexCronCreatorTool[];
         provenance: { version: 1; source: "final-executable-surface" };
-        runtimeAuthority?: NonNullable<EmbeddedRunAttemptParams["scheduledRuntimeAuthority"]>;
+        runtimeAuthority?: CodexCronRuntimeAuthority;
       }>)
     | undefined;
   const runtimeYieldCompletionClaim: { current?: () => boolean } = {};
@@ -224,7 +250,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
       ? {
           resolveCronCreatorToolAuthority: (options?: { signal?: AbortSignal }) => {
             if (!resolveCreatorAuthorityImpl) {
-              throw new Error("configured MCP authority resolver was invoked before tool setup");
+              throw new Error("cron creator authority resolver was invoked before tool setup");
             }
             options?.signal?.throwIfAborted();
             if (creatorAuthorityPromise) {
@@ -449,7 +475,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         if (!toolBridge) {
           throw new Error("cron creator authority resolver lost the active tool bridge");
         }
-        const authorityTools: Array<string | { name: string; pluginId?: string }> = [];
+        const authorityTools: CodexCronCreatorTool[] = [];
         const captureRef: {
           value?: { version: 1; source: "final-executable-surface" };
         } = {};
@@ -462,7 +488,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
           throw new Error("cron creator authority snapshot did not produce provenance");
         }
         const appSource = scheduledAppAuthoritySourceRef.current;
-        const runtimeAuthority =
+        const appRuntimeAuthority =
           canResolveScheduledCodexAppAuthority && preparedChatgptAuth
             ? appSource
               ? await captureScheduledCodexAppAuthority({
@@ -476,6 +502,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
                   );
                 })()
             : undefined;
+        const runtimeAuthority = bindCodexCronScheduledTools(appRuntimeAuthority, authorityTools);
         if (!canResolveScheduledConfiguredMcpCreatorAuthority) {
           options?.signal?.throwIfAborted();
           return Object.freeze({

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -35,30 +35,11 @@ import {
 
 type CodexCronCreatorTool = Parameters<typeof captureFinalCodexCronCreatorToolAllowlist>[0][number];
 type CodexCronRuntimeAuthority = NonNullable<EmbeddedRunAttemptParams["scheduledRuntimeAuthority"]>;
-
+type CodexCronScheduledToolAuthority = NonNullable<
+  Awaited<ReturnType<typeof captureFinalCodexCronCreatorToolAllowlist>>
+>;
 function isAuthorityResolutionOperationAbort(error: unknown, signal: AbortSignal | undefined) {
   return signal?.aborted === true && error === signal.reason;
-}
-
-function bindCodexCronScheduledTools(
-  authority: CodexCronRuntimeAuthority | undefined,
-  tools: readonly CodexCronCreatorTool[],
-): CodexCronRuntimeAuthority | undefined {
-  const toolBindings = tools.flatMap((tool) =>
-    typeof tool === "string" || !tool.scheduledToolBinding ? [] : [tool.scheduledToolBinding],
-  );
-  if (toolBindings.length === 0) {
-    return authority;
-  }
-  return {
-    ...(authority ?? {
-      version: 1,
-      runtimeId: "codex",
-      namespace: "scheduled-tools",
-      payload: { version: 1 },
-    }),
-    toolBindings,
-  };
 }
 
 export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
@@ -207,6 +188,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         tools: readonly CodexCronCreatorTool[];
         provenance: { version: 1; source: "final-executable-surface" };
         runtimeAuthority?: CodexCronRuntimeAuthority;
+        scheduledToolAuthority?: CodexCronScheduledToolAuthority;
       }>
     | undefined;
   let resolveCreatorAuthorityImpl:
@@ -214,6 +196,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         tools: readonly CodexCronCreatorTool[];
         provenance: { version: 1; source: "final-executable-surface" };
         runtimeAuthority?: CodexCronRuntimeAuthority;
+        scheduledToolAuthority?: CodexCronScheduledToolAuthority;
       }>)
     | undefined;
   const runtimeYieldCompletionClaim: { current?: () => boolean } = {};
@@ -479,7 +462,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         const captureRef: {
           value?: { version: 1; source: "final-executable-surface" };
         } = {};
-        await captureFinalCodexCronCreatorToolAllowlist(
+        let scheduledToolAuthority = await captureFinalCodexCronCreatorToolAllowlist(
           authorityTools,
           captureRef,
           toolBridge.availableTools,
@@ -502,13 +485,13 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
                   );
                 })()
             : undefined;
-        const runtimeAuthority = bindCodexCronScheduledTools(appRuntimeAuthority, authorityTools);
         if (!canResolveScheduledConfiguredMcpCreatorAuthority) {
           options?.signal?.throwIfAborted();
           return Object.freeze({
             tools: Object.freeze(authorityTools.map((entry) => Object.freeze(entry))),
             provenance: Object.freeze(captureRef.value),
-            ...(runtimeAuthority ? { runtimeAuthority } : {}),
+            ...(appRuntimeAuthority ? { runtimeAuthority: appRuntimeAuthority } : {}),
+            ...(scheduledToolAuthority ? { scheduledToolAuthority } : {}),
           });
         }
         const authorityRuntimeId = `cron-authority:${params.runId}`;
@@ -552,10 +535,11 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
             tools: filterCodexDynamicTools(materialized.tools, pluginConfig),
             hookContext,
           });
-          await captureFinalCodexCronCreatorToolAllowlist(authorityTools, captureRef, [
-            ...toolBridge.availableTools,
-            ...projectedConfiguredMcp.availableTools,
-          ]);
+          scheduledToolAuthority = await captureFinalCodexCronCreatorToolAllowlist(
+            authorityTools,
+            captureRef,
+            [...toolBridge.availableTools, ...projectedConfiguredMcp.availableTools],
+          );
           if (!captureRef.value) {
             throw new Error("configured MCP authority snapshot did not produce provenance");
           }
@@ -563,7 +547,8 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
           return Object.freeze({
             tools: Object.freeze(authorityTools.map((entry) => Object.freeze(entry))),
             provenance: Object.freeze(captureRef.value),
-            ...(runtimeAuthority ? { runtimeAuthority } : {}),
+            ...(appRuntimeAuthority ? { runtimeAuthority: appRuntimeAuthority } : {}),
+            ...(scheduledToolAuthority ? { scheduledToolAuthority } : {}),
           });
         } finally {
           await materialized.dispose();

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -200,7 +200,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
   const canResolveAnyScheduledCreatorAuthority =
     canResolveScheduledConfiguredMcpCreatorAuthority ||
     requiresScheduledCodexAppAuthority ||
-    (nativeToolSurfaceEnabled === true && sandbox?.enabled !== true);
+    (nativeToolSurfaceEnabled && sandbox?.enabled !== true);
   let toolBridge: ReturnType<typeof createCodexDynamicToolBridge> | undefined;
   let creatorAuthorityPromise:
     | Promise<{

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -33,8 +33,32 @@ import {
   resolveScheduledCodexAppCreatorCaptureDecision,
 } from "./scheduled-app-authority.js";
 
+type CodexCronCreatorTool = Parameters<typeof captureFinalCodexCronCreatorToolAllowlist>[0][number];
+type CodexCronRuntimeAuthority = NonNullable<EmbeddedRunAttemptParams["scheduledRuntimeAuthority"]>;
+
 function isAuthorityResolutionOperationAbort(error: unknown, signal: AbortSignal | undefined) {
   return signal?.aborted === true && error === signal.reason;
+}
+
+function bindCodexCronScheduledTools(
+  authority: CodexCronRuntimeAuthority | undefined,
+  tools: readonly CodexCronCreatorTool[],
+): CodexCronRuntimeAuthority | undefined {
+  const toolBindings = tools.flatMap((tool) =>
+    typeof tool === "string" || !tool.scheduledToolBinding ? [] : [tool.scheduledToolBinding],
+  );
+  if (toolBindings.length === 0) {
+    return authority;
+  }
+  return {
+    ...(authority ?? {
+      version: 1,
+      runtimeId: "codex",
+      namespace: "scheduled-tools",
+      payload: { version: 1 },
+    }),
+    toolBindings,
+  };
 }
 
 export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
@@ -139,7 +163,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
     frameToolCallId?: string;
     frameImageIdentity?: string;
   } = { value: 0 };
-  const cronCreatorToolAllowlist: Array<string | { name: string; pluginId?: string }> = [];
+  const cronCreatorToolAllowlist: CodexCronCreatorTool[] = [];
   const cronCreatorToolAllowlistCaptureRef: {
     value?: { version: 1; source: "final-executable-surface" };
   } = {};
@@ -173,20 +197,22 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
   const canResolveScheduledCodexAppAuthority = appCreatorCapture.supported;
   const requiresScheduledCodexAppAuthority = appCreatorCapture.required;
   const canResolveAnyScheduledCreatorAuthority =
-    canResolveScheduledConfiguredMcpCreatorAuthority || requiresScheduledCodexAppAuthority;
+    canResolveScheduledConfiguredMcpCreatorAuthority ||
+    requiresScheduledCodexAppAuthority ||
+    (nativeToolSurfaceEnabled === true && sandbox?.enabled !== true);
   let toolBridge: ReturnType<typeof createCodexDynamicToolBridge> | undefined;
   let creatorAuthorityPromise:
     | Promise<{
-        tools: readonly (string | { name: string; pluginId?: string })[];
+        tools: readonly CodexCronCreatorTool[];
         provenance: { version: 1; source: "final-executable-surface" };
-        runtimeAuthority?: NonNullable<EmbeddedRunAttemptParams["scheduledRuntimeAuthority"]>;
+        runtimeAuthority?: CodexCronRuntimeAuthority;
       }>
     | undefined;
   let resolveCreatorAuthorityImpl:
     | ((options?: { signal?: AbortSignal }) => Promise<{
-        tools: readonly (string | { name: string; pluginId?: string })[];
+        tools: readonly CodexCronCreatorTool[];
         provenance: { version: 1; source: "final-executable-surface" };
-        runtimeAuthority?: NonNullable<EmbeddedRunAttemptParams["scheduledRuntimeAuthority"]>;
+        runtimeAuthority?: CodexCronRuntimeAuthority;
       }>)
     | undefined;
   const runtimeYieldCompletionClaim: { current?: () => boolean } = {};
@@ -222,7 +248,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
       ? {
           resolveCronCreatorToolAuthority: (options?: { signal?: AbortSignal }) => {
             if (!resolveCreatorAuthorityImpl) {
-              throw new Error("configured MCP authority resolver was invoked before tool setup");
+              throw new Error("cron creator authority resolver was invoked before tool setup");
             }
             options?.signal?.throwIfAborted();
             if (creatorAuthorityPromise) {
@@ -447,7 +473,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
         if (!toolBridge) {
           throw new Error("cron creator authority resolver lost the active tool bridge");
         }
-        const authorityTools: Array<string | { name: string; pluginId?: string }> = [];
+        const authorityTools: CodexCronCreatorTool[] = [];
         const captureRef: {
           value?: { version: 1; source: "final-executable-surface" };
         } = {};
@@ -460,7 +486,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
           throw new Error("cron creator authority snapshot did not produce provenance");
         }
         const appSource = scheduledAppAuthoritySourceRef.current;
-        const runtimeAuthority =
+        const appRuntimeAuthority =
           canResolveScheduledCodexAppAuthority && preparedChatgptAuth
             ? appSource
               ? await captureScheduledCodexAppAuthority({
@@ -474,6 +500,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
                   );
                 })()
             : undefined;
+        const runtimeAuthority = bindCodexCronScheduledTools(appRuntimeAuthority, authorityTools);
         if (!canResolveScheduledConfiguredMcpCreatorAuthority) {
           options?.signal?.throwIfAborted();
           return Object.freeze({

--- a/extensions/codex/src/app-server/run-attempt-tool-setup.ts
+++ b/extensions/codex/src/app-server/run-attempt-tool-setup.ts
@@ -199,7 +199,7 @@ export async function prepareCodexAttemptTools(runtime: CodexAttemptRuntime) {
   const canResolveAnyScheduledCreatorAuthority =
     canResolveScheduledConfiguredMcpCreatorAuthority ||
     requiresScheduledCodexAppAuthority ||
-    (nativeToolSurfaceEnabled === true && sandbox?.enabled !== true);
+    (nativeToolSurfaceEnabled && sandbox?.enabled !== true);
   let toolBridge: ReturnType<typeof createCodexDynamicToolBridge> | undefined;
   let creatorAuthorityPromise:
     | Promise<{

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -226,6 +226,26 @@ function admitLocalOperatorCronAuthority(params: ReturnType<typeof createParams>
 }
 
 describe("runCodexAppServerAttempt configured MCP ownership", () => {
+  it("preserves host-pinned shell aliases in scheduler authority capture", async () => {
+    const sessionFile = path.join(tempDir, "session-cron-shell-aliases.jsonl");
+    const params = createParams(sessionFile, path.join(tempDir, "workspace-cron-shell-aliases"));
+    setCodexTestModelSupportsTools(params, true);
+    params.disableTools = false;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+
+    const harness = createStartedThreadHarness();
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await expect(run).resolves.toBeDefined();
+
+    expect(mcpMocks.captureCalls).toHaveLength(1);
+    expect(mcpMocks.captureCalls[0]?.storedNames).toEqual(mcpMocks.captureCalls[0]?.sourceNames);
+    expect(mcpMocks.captureCalls[0]?.storedNames).toContain("gateway_exec");
+    expect(mcpMocks.captureCalls[0]?.storedNames).toContain("gateway_process");
+    expect(mcpMocks.captureCalls[0]?.storedNames).not.toContain("exec");
+  });
+
   it("does not replace bundle discovery with partial prepared plugin metadata", async () => {
     const sessionFile = path.join(tempDir, "session-partial-manifest-registry.jsonl");
     const params = createParams(sessionFile, path.join(tempDir, "workspace-partial-registry"));

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -5,14 +5,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mcpMocks = vi.hoisted(() => ({
   authorityResolvers: [] as Array<
     (options?: { signal?: AbortSignal }) => Promise<{
-      tools: readonly (string | { name: string; pluginId?: string })[];
+      tools: readonly (
+        | string
+        | { name: string; pluginId?: string; scheduledToolBinding?: unknown }
+      )[];
       provenance: { version: 1; source: "final-executable-surface" };
+      runtimeAuthority?: unknown;
     }>
   >,
   captureCalls: [] as Array<{
     sourceNames: string[];
     storedNames: string[];
     provenance?: unknown;
+    storedBindings: unknown[];
   }>,
   captureRefs: [] as Array<{
     value?: { version: 1; source: "final-executable-surface" };
@@ -127,21 +132,18 @@ vi.mock("openclaw/plugin-sdk/codex-mcp-projection", async (importOriginal) => {
       const [target, captureRef, tools] = args;
       mcpMocks.captureRefs.push(captureRef);
       mcpMocks.captureFacade(target, captureRef, tools);
-      target.length = 0;
-      for (const tool of tools) {
-        if (
-          !target.some((entry) => (typeof entry === "string" ? entry : entry.name) === tool.name)
-        ) {
-          target.push({ name: tool.name });
-        }
-      }
-      captureRef.value = { version: 1, source: "final-executable-surface" };
+      await actual.captureFinalCodexCronCreatorToolAllowlist(target, captureRef, tools);
       mcpMocks.captureCalls.push({
         sourceNames: tools.map((tool) => tool.name).toSorted(),
         storedNames: target
           .map((entry) => (typeof entry === "string" ? entry : entry.name))
           .toSorted(),
         provenance: captureRef.value,
+        storedBindings: target.flatMap((entry) =>
+          typeof entry === "string" || !entry.scheduledToolBinding
+            ? []
+            : [entry.scheduledToolBinding],
+        ),
       });
     },
   };
@@ -232,6 +234,7 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     setCodexTestModelSupportsTools(params, true);
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
+    admitLocalOperatorCronAuthority(params);
 
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(params);
@@ -244,6 +247,22 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     expect(mcpMocks.captureCalls[0]?.storedNames).toContain("gateway_exec");
     expect(mcpMocks.captureCalls[0]?.storedNames).toContain("gateway_process");
     expect(mcpMocks.captureCalls[0]?.storedNames).not.toContain("exec");
+    expect(mcpMocks.captureCalls[0]?.storedBindings).toEqual([
+      {
+        sourceTool: "gateway_exec",
+        targetTool: "exec",
+        execTarget: { host: "gateway" },
+      },
+      { sourceTool: "gateway_process", targetTool: "process" },
+    ]);
+
+    const authority = await mcpMocks.authorityResolvers[0]!();
+    expect(authority.runtimeAuthority).toMatchObject({
+      version: 1,
+      runtimeId: "codex",
+      namespace: "scheduled-tools",
+      toolBindings: mcpMocks.captureCalls[0]?.storedBindings,
+    });
   });
 
   it("does not replace bundle discovery with partial prepared plugin metadata", async () => {

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { openFileBackedSessionManagerForTest } from "openclaw/plugin-sdk/agent-runtime-test-contracts";
+import { normalizeOpenAIToolSchemas } from "openclaw/plugin-sdk/provider-tools";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mcpMocks = vi.hoisted(() => ({
@@ -233,7 +234,22 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     const params = createParams(sessionFile, path.join(tempDir, "workspace-cron-shell-aliases"));
     setCodexTestModelSupportsTools(params, true);
     params.disableTools = false;
-    params.runtimePlan = createCodexRuntimePlanFixture();
+    const runtimePlan = createCodexRuntimePlanFixture();
+    let strictNormalizerClonedAliases = false;
+    runtimePlan.tools.normalize = (tools) => {
+      const normalized = normalizeOpenAIToolSchemas({
+        tools,
+        provider: "openai",
+        modelId: "gpt-5.4-codex",
+        modelApi: "openai-chatgpt-responses",
+      });
+      strictNormalizerClonedAliases = ["gateway_exec", "gateway_process"].every((name) => {
+        const source = tools.find((tool) => tool.name === name);
+        return source !== undefined && normalized.find((tool) => tool.name === name) !== source;
+      });
+      return normalized as typeof tools;
+    };
+    params.runtimePlan = runtimePlan;
     admitLocalOperatorCronAuthority(params);
 
     const harness = createStartedThreadHarness();
@@ -242,6 +258,7 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await expect(run).resolves.toBeDefined();
 
+    expect(strictNormalizerClonedAliases).toBe(true);
     expect(mcpMocks.captureCalls).toHaveLength(1);
     expect(mcpMocks.captureCalls[0]?.storedNames).toEqual(mcpMocks.captureCalls[0]?.sourceNames);
     expect(mcpMocks.captureCalls[0]?.storedNames).toContain("gateway_exec");

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -6,19 +6,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mcpMocks = vi.hoisted(() => ({
   authorityResolvers: [] as Array<
     (options?: { signal?: AbortSignal }) => Promise<{
-      tools: readonly (
-        | string
-        | { name: string; pluginId?: string; scheduledToolBinding?: unknown }
-      )[];
+      tools: readonly (string | { name: string; pluginId?: string })[];
       provenance: { version: 1; source: "final-executable-surface" };
       runtimeAuthority?: unknown;
+      scheduledToolAuthority?: unknown;
     }>
   >,
   captureCalls: [] as Array<{
     sourceNames: string[];
     storedNames: string[];
     provenance?: unknown;
-    storedBindings: unknown[];
+    scheduledToolAuthority?: unknown;
   }>,
   captureRefs: [] as Array<{
     value?: { version: 1; source: "final-executable-surface" };
@@ -133,25 +131,27 @@ vi.mock("openclaw/plugin-sdk/codex-mcp-projection", async (importOriginal) => {
       const [target, captureRef, tools] = args;
       mcpMocks.captureRefs.push(captureRef);
       mcpMocks.captureFacade(target, captureRef, tools);
-      await actual.captureFinalCodexCronCreatorToolAllowlist(target, captureRef, tools);
+      const scheduledToolAuthority = await actual.captureFinalCodexCronCreatorToolAllowlist(
+        target,
+        captureRef,
+        tools,
+      );
       mcpMocks.captureCalls.push({
         sourceNames: tools.map((tool) => tool.name).toSorted(),
         storedNames: target
           .map((entry) => (typeof entry === "string" ? entry : entry.name))
           .toSorted(),
         provenance: captureRef.value,
-        storedBindings: target.flatMap((entry) =>
-          typeof entry === "string" || !entry.scheduledToolBinding
-            ? []
-            : [entry.scheduledToolBinding],
-        ),
+        ...(scheduledToolAuthority ? { scheduledToolAuthority } : {}),
       });
+      return scheduledToolAuthority;
     },
   };
 });
 
 import {
   assistantMessage,
+  bindProductionHarnessHostCapabilitiesForTest,
   createParams,
   createCodexRuntimePlanFixture,
   createStartedThreadHarness,
@@ -251,35 +251,35 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     };
     params.runtimePlan = runtimePlan;
     admitLocalOperatorCronAuthority(params);
+    const closeHostCapabilities = await bindProductionHarnessHostCapabilitiesForTest(params);
 
-    const harness = createStartedThreadHarness();
-    const run = runCodexAppServerAttempt(params);
-    await harness.waitForMethod("turn/start");
-    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
-    await expect(run).resolves.toBeDefined();
+    try {
+      const harness = createStartedThreadHarness();
+      const run = runCodexAppServerAttempt(params);
+      await harness.waitForMethod("turn/start");
+      await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+      await expect(run).resolves.toBeDefined();
 
-    expect(strictNormalizerClonedAliases).toBe(true);
-    expect(mcpMocks.captureCalls).toHaveLength(1);
-    expect(mcpMocks.captureCalls[0]?.storedNames).toEqual(mcpMocks.captureCalls[0]?.sourceNames);
-    expect(mcpMocks.captureCalls[0]?.storedNames).toContain("gateway_exec");
-    expect(mcpMocks.captureCalls[0]?.storedNames).toContain("gateway_process");
-    expect(mcpMocks.captureCalls[0]?.storedNames).not.toContain("exec");
-    expect(mcpMocks.captureCalls[0]?.storedBindings).toEqual([
-      {
-        sourceTool: "gateway_exec",
-        targetTool: "exec",
-        execTarget: { host: "gateway" },
-      },
-      { sourceTool: "gateway_process", targetTool: "process" },
-    ]);
+      expect(strictNormalizerClonedAliases).toBe(true);
+      expect(mcpMocks.captureCalls).toHaveLength(1);
+      expect(mcpMocks.captureCalls[0]?.storedNames).toEqual(mcpMocks.captureCalls[0]?.sourceNames);
+      expect(mcpMocks.captureCalls[0]?.storedNames).toContain("gateway_exec");
+      expect(mcpMocks.captureCalls[0]?.storedNames).toContain("gateway_process");
+      expect(mcpMocks.captureCalls[0]?.storedNames).not.toContain("exec");
+      expect(mcpMocks.captureCalls[0]?.scheduledToolAuthority).toMatchObject({
+        kind: "cron-scheduled-tool-authority-capture",
+      });
 
-    const authority = await mcpMocks.authorityResolvers[0]!();
-    expect(authority.runtimeAuthority).toMatchObject({
-      version: 1,
-      runtimeId: "codex",
-      namespace: "scheduled-tools",
-      toolBindings: mcpMocks.captureCalls[0]?.storedBindings,
-    });
+      const authority = await mcpMocks.authorityResolvers[0]!();
+      expect(authority).toMatchObject({
+        scheduledToolAuthority: {
+          kind: "cron-scheduled-tool-authority-capture",
+        },
+      });
+      expect(authority.runtimeAuthority).toBeUndefined();
+    } finally {
+      closeHostCapabilities();
+    }
   });
 
   it("does not replace bundle discovery with partial prepared plugin metadata", async () => {

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -1,10 +1,14 @@
-import { bindCronScheduledTool, pinExecToolTarget } from "openclaw/plugin-sdk/codex-mcp-projection";
+import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { pinExecToolTarget } from "openclaw/plugin-sdk/codex-mcp-projection";
 import type { CodexPluginConfig } from "./config.js";
 import { normalizeCodexDynamicToolName } from "./dynamic-tool-profile.js";
 
 type OpenClawCodingToolsFactory =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
 type OpenClawDynamicTool = ReturnType<OpenClawCodingToolsFactory>[number];
+type SealScheduledToolProjection = NonNullable<
+  EmbeddedRunAttemptParams["hostCapabilities"]["sealScheduledToolProjection"]
+>;
 type ExecAliasParams =
   | { host: "gateway"; processAliasAvailable: boolean; ask?: "always" }
   | { host: "node"; node?: string };
@@ -29,6 +33,7 @@ export function isCodexDynamicToolExcluded(
 export function createExecAliasDynamicTool(
   execTool: OpenClawDynamicTool,
   params: ExecAliasParams,
+  sealScheduledToolProjection?: SealScheduledToolProjection,
 ): OpenClawDynamicTool {
   const pinnedNode = params.host === "node" ? params.node?.trim() : undefined;
   const nodeAlias = params.host === "node";
@@ -69,28 +74,20 @@ export function createExecAliasDynamicTool(
     description,
     execute,
   };
-  return nodeAlias
+  return nodeAlias || !sealScheduledToolProjection
     ? alias
-    : bindCronScheduledTool(alias, {
-        sourceTool: CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME,
-        targetTool: "exec",
-        execTarget: { host: "gateway" },
-      });
+    : sealScheduledToolProjection(execTool, alias);
 }
 
 export function createGatewayProcessAliasDynamicTool(
   processTool: OpenClawDynamicTool,
+  sealScheduledToolProjection?: SealScheduledToolProjection,
 ): OpenClawDynamicTool {
-  return bindCronScheduledTool(
-    {
-      ...processTool,
-      name: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
-      description:
-        "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.",
-    },
-    {
-      sourceTool: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
-      targetTool: "process",
-    },
-  );
+  const alias = {
+    ...processTool,
+    name: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
+    description:
+      "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.",
+  };
+  return sealScheduledToolProjection ? sealScheduledToolProjection(processTool, alias) : alias;
 }

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -1,17 +1,13 @@
-import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
-import { pinExecToolTarget } from "openclaw/plugin-sdk/codex-mcp-projection";
+import {
+  pinExecToolTarget,
+  type CodexScheduledToolProjectionFactory,
+} from "openclaw/plugin-sdk/codex-mcp-projection";
 import type { CodexPluginConfig } from "./config.js";
 import { normalizeCodexDynamicToolName } from "./dynamic-tool-profile.js";
 
 type OpenClawCodingToolsFactory =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
 type OpenClawDynamicTool = ReturnType<OpenClawCodingToolsFactory>[number];
-type SealScheduledToolProjection = NonNullable<
-  EmbeddedRunAttemptParams["hostCapabilities"]["sealScheduledToolProjection"]
->;
-type ExecAliasParams =
-  | { host: "gateway"; processAliasAvailable: boolean; ask?: "always" }
-  | { host: "node"; node?: string };
 
 export const CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME = "node_exec";
 export const CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME = "gateway_exec";
@@ -30,31 +26,15 @@ export function isCodexDynamicToolExcluded(
   );
 }
 
-export function createExecAliasDynamicTool(
+export function createNodeExecAliasDynamicTool(
   execTool: OpenClawDynamicTool,
-  params: ExecAliasParams,
-  sealScheduledToolProjection?: SealScheduledToolProjection,
+  node?: string,
 ): OpenClawDynamicTool {
-  const pinnedNode = params.host === "node" ? params.node?.trim() : undefined;
-  const nodeAlias = params.host === "node";
-  const gatewayProcessAliasAvailable = params.host === "gateway" && params.processAliasAvailable;
-  const name = nodeAlias ? CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME : CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME;
-  const description = nodeAlias
-    ? pinnedNode
-      ? "Run a shell command to completion on the OpenClaw configured remote node for this session. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work."
-      : "Run a shell command to completion on an OpenClaw remote node. Select the node by name or id when multiple nodes are available. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work."
-    : "Run a shell command through OpenClaw on the Gateway host for OpenClaw-managed Gateway environment access, including Secret Store agent-readable environment values and protected egress sentinels. Native Codex shell remains preferred for ordinary local work. This tool always uses OpenClaw host=gateway internally and follows Gateway exec approval and allowlist policy.";
-  const followupText = nodeAlias
-    ? "Remote-node background follow-up is unavailable. Wait for the command to complete."
-    : gatewayProcessAliasAvailable
-      ? "Use gateway_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up."
-      : "Background session follow-up is unavailable because gateway_process is not exposed. Rerun without background=true and set yieldMs high enough to wait for completion.";
-  const pinnedTool = pinExecToolTarget(
-    execTool,
-    nodeAlias
-      ? { host: "node", ...(pinnedNode ? { node: pinnedNode } : {}) }
-      : { host: "gateway", ...(params.ask ? { ask: params.ask } : {}) },
-  );
+  const pinnedNode = node?.trim();
+  const pinnedTool = pinExecToolTarget(execTool, {
+    host: "node",
+    ...(pinnedNode ? { node: pinnedNode } : {}),
+  });
   const execute: OpenClawDynamicTool["execute"] = async (toolCallId, args, signal, onUpdate) => {
     const result = await pinnedTool.execute(toolCallId, args, signal, onUpdate);
     return {
@@ -62,32 +42,50 @@ export function createExecAliasDynamicTool(
       content: result.content.map((item) =>
         item.type === "text"
           ? Object.assign({}, item, {
-              text: item.text.replace(PROCESS_FOLLOWUP_TEXT, followupText),
+              text: item.text.replace(
+                PROCESS_FOLLOWUP_TEXT,
+                "Remote-node background follow-up is unavailable. Wait for the command to complete.",
+              ),
             })
           : item,
       ),
     };
   };
-  const alias = {
+  return {
     ...pinnedTool,
-    name,
-    description,
+    name: CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
+    description: pinnedNode
+      ? "Run a shell command to completion on the OpenClaw configured remote node for this session. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work."
+      : "Run a shell command to completion on an OpenClaw remote node. Select the node by name or id when multiple nodes are available. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work.",
     execute,
   };
-  return nodeAlias || !sealScheduledToolProjection
-    ? alias
-    : sealScheduledToolProjection(execTool, alias);
 }
 
-export function createGatewayProcessAliasDynamicTool(
-  processTool: OpenClawDynamicTool,
-  sealScheduledToolProjection?: SealScheduledToolProjection,
+export function createGatewayExecProjection(
+  createProjection: CodexScheduledToolProjectionFactory,
+  execTool: OpenClawDynamicTool,
+  params: { processAliasAvailable: boolean; ask?: "always" },
 ): OpenClawDynamicTool {
-  const alias = {
-    ...processTool,
+  return createProjection(execTool, {
+    kind: "exec",
+    name: CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME,
+    description:
+      "Run a shell command through OpenClaw on the Gateway host for OpenClaw-managed Gateway environment access, including Secret Store agent-readable environment values and protected egress sentinels. Native Codex shell remains preferred for ordinary local work. This tool always uses OpenClaw host=gateway internally and follows Gateway exec approval and allowlist policy.",
+    followupText: params.processAliasAvailable
+      ? "Use gateway_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up."
+      : "Background session follow-up is unavailable because gateway_process is not exposed. Rerun without background=true and set yieldMs high enough to wait for completion.",
+    ...(params.ask ? { ask: params.ask } : {}),
+  });
+}
+
+export function createGatewayProcessProjection(
+  createProjection: CodexScheduledToolProjectionFactory,
+  processTool: OpenClawDynamicTool,
+): OpenClawDynamicTool {
+  return createProjection(processTool, {
+    kind: "process",
     name: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
     description:
       "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.",
-  };
-  return sealScheduledToolProjection ? sealScheduledToolProjection(processTool, alias) : alias;
+  });
 }

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -1,3 +1,4 @@
+import { pinExecToolTarget } from "openclaw/plugin-sdk/codex-mcp-projection";
 import type { CodexPluginConfig } from "./config.js";
 import { normalizeCodexDynamicToolName } from "./dynamic-tool-profile.js";
 
@@ -11,14 +12,6 @@ type ExecAliasParams =
 export const CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME = "node_exec";
 export const CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME = "gateway_exec";
 export const CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME = "gateway_process";
-const CODEX_EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
-const CODEX_NODE_EXEC_PARAMETER_NAMES = new Set([
-  "command",
-  "workdir",
-  "env",
-  "timeoutSeconds",
-  "node",
-]);
 const PROCESS_FOLLOWUP_TEXT =
   "Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.";
 
@@ -51,22 +44,18 @@ export function createExecAliasDynamicTool(
     : gatewayProcessAliasAvailable
       ? "Use gateway_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up."
       : "Background session follow-up is unavailable because gateway_process is not exposed. Rerun without background=true and set yieldMs high enough to wait for completion.";
+  const pinnedTool = pinExecToolTarget(
+    execTool,
+    nodeAlias
+      ? { host: "node", ...(pinnedNode ? { node: pinnedNode } : {}) }
+      : { host: "gateway", ...(params.ask ? { ask: params.ask } : {}) },
+  );
   return {
-    ...execTool,
+    ...pinnedTool,
     name,
     description,
-    parameters: hideExecDynamicToolParameters(
-      execTool.parameters,
-      !nodeAlias || Boolean(pinnedNode),
-      nodeAlias,
-    ),
     execute: async (toolCallId, args, signal, onUpdate) => {
-      const result = await execTool.execute(
-        toolCallId,
-        pinExecDynamicToolArgs(args, params, pinnedNode),
-        signal,
-        onUpdate,
-      );
+      const result = await pinnedTool.execute(toolCallId, args, signal, onUpdate);
       return {
         ...result,
         content: result.content.map((item) =>
@@ -92,61 +81,3 @@ export function createGatewayProcessAliasDynamicTool(
   };
 }
 
-function pinExecDynamicToolArgs(
-  args: unknown,
-  params: ExecAliasParams,
-  configuredNode?: string,
-): unknown {
-  const source = normalizeExecDynamicToolArgs(args);
-  const { host: _host, security: _security, ask: _ask, node: requestedNode, ...rest } = source;
-  if (params.host === "gateway") {
-    return { ...rest, host: params.host, ...(params.ask ? { ask: params.ask } : {}) };
-  }
-  const nodeArgs = Object.fromEntries(
-    Object.entries(rest).filter(([name]) => CODEX_NODE_EXEC_PARAMETER_NAMES.has(name)),
-  );
-  const node = configuredNode ?? (typeof requestedNode === "string" ? requestedNode.trim() : "");
-  return {
-    ...nodeArgs,
-    host: params.host,
-    ...(node ? { node } : {}),
-  };
-}
-
-function normalizeExecDynamicToolArgs(args: unknown): Record<string, unknown> {
-  return args && typeof args === "object" && !Array.isArray(args)
-    ? (args as Record<string, unknown>)
-    : {};
-}
-
-function hideExecDynamicToolParameters(
-  parameters: OpenClawDynamicTool["parameters"],
-  hideNode: boolean,
-  nodeOnly: boolean,
-) {
-  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
-    return parameters;
-  }
-  const schema = parameters as Record<string, unknown>;
-  const rawProperties = schema.properties;
-  if (!rawProperties || typeof rawProperties !== "object" || Array.isArray(rawProperties)) {
-    return parameters;
-  }
-  const includeParameter = (name: string) =>
-    nodeOnly
-      ? CODEX_NODE_EXEC_PARAMETER_NAMES.has(name) && !(hideNode && name === "node")
-      : !CODEX_EXEC_POLICY_PARAMETER_NAMES.has(normalizeCodexDynamicToolName(name)) &&
-        !(hideNode && normalizeCodexDynamicToolName(name) === "node");
-  const nextProperties = Object.fromEntries(
-    Object.entries(rawProperties).filter(([name]) => includeParameter(name)),
-  );
-  const rawRequired = schema.required;
-  const nextRequired = Array.isArray(rawRequired)
-    ? rawRequired.filter((name) => typeof name !== "string" || includeParameter(name))
-    : rawRequired;
-  return {
-    ...schema,
-    properties: nextProperties,
-    ...(Array.isArray(rawRequired) ? { required: nextRequired } : {}),
-  };
-}

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -1,4 +1,4 @@
-import { pinExecToolTarget } from "openclaw/plugin-sdk/codex-mcp-projection";
+import { bindCronScheduledTool, pinExecToolTarget } from "openclaw/plugin-sdk/codex-mcp-projection";
 import type { CodexPluginConfig } from "./config.js";
 import { normalizeCodexDynamicToolName } from "./dynamic-tool-profile.js";
 
@@ -50,34 +50,48 @@ export function createExecAliasDynamicTool(
       ? { host: "node", ...(pinnedNode ? { node: pinnedNode } : {}) }
       : { host: "gateway", ...(params.ask ? { ask: params.ask } : {}) },
   );
-  return {
+  const execute: OpenClawDynamicTool["execute"] = async (toolCallId, args, signal, onUpdate) => {
+    const result = await pinnedTool.execute(toolCallId, args, signal, onUpdate);
+    return {
+      ...result,
+      content: result.content.map((item) =>
+        item.type === "text"
+          ? Object.assign({}, item, {
+              text: item.text.replace(PROCESS_FOLLOWUP_TEXT, followupText),
+            })
+          : item,
+      ),
+    };
+  };
+  const alias = {
     ...pinnedTool,
     name,
     description,
-    execute: async (toolCallId, args, signal, onUpdate) => {
-      const result = await pinnedTool.execute(toolCallId, args, signal, onUpdate);
-      return {
-        ...result,
-        content: result.content.map((item) =>
-          item.type === "text"
-            ? Object.assign({}, item, {
-                text: item.text.replace(PROCESS_FOLLOWUP_TEXT, followupText),
-              })
-            : item,
-        ),
-      };
-    },
+    execute,
   };
+  return nodeAlias
+    ? alias
+    : bindCronScheduledTool(alias, {
+        sourceTool: CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME,
+        targetTool: "exec",
+        execTarget: { host: "gateway" },
+      });
 }
 
 export function createGatewayProcessAliasDynamicTool(
   processTool: OpenClawDynamicTool,
 ): OpenClawDynamicTool {
-  return {
-    ...processTool,
-    name: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
-    description:
-      "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.",
-  };
+  return bindCronScheduledTool(
+    {
+      ...processTool,
+      name: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
+      description:
+        "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.",
+    },
+    {
+      sourceTool: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
+      targetTool: "process",
+    },
+  );
 }
 

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -94,4 +94,3 @@ export function createGatewayProcessAliasDynamicTool(
     },
   );
 }
-

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -1,4 +1,4 @@
-import { pinExecToolTarget } from "openclaw/plugin-sdk/codex-mcp-projection";
+import { bindCronScheduledTool, pinExecToolTarget } from "openclaw/plugin-sdk/codex-mcp-projection";
 import type { CodexPluginConfig } from "./config.js";
 import { normalizeCodexDynamicToolName } from "./dynamic-tool-profile.js";
 
@@ -48,33 +48,47 @@ export function createExecAliasDynamicTool(
     execTool,
     nodeAlias ? { host: "node", ...(pinnedNode ? { node: pinnedNode } : {}) } : { host: "gateway" },
   );
-  return {
+  const execute: OpenClawDynamicTool["execute"] = async (toolCallId, args, signal, onUpdate) => {
+    const result = await pinnedTool.execute(toolCallId, args, signal, onUpdate);
+    return {
+      ...result,
+      content: result.content.map((item) =>
+        item.type === "text"
+          ? Object.assign({}, item, {
+              text: item.text.replace(PROCESS_FOLLOWUP_TEXT, followupText),
+            })
+          : item,
+      ),
+    };
+  };
+  const alias = {
     ...pinnedTool,
     name,
     description,
-    execute: async (toolCallId, args, signal, onUpdate) => {
-      const result = await pinnedTool.execute(toolCallId, args, signal, onUpdate);
-      return {
-        ...result,
-        content: result.content.map((item) =>
-          item.type === "text"
-            ? Object.assign({}, item, {
-                text: item.text.replace(PROCESS_FOLLOWUP_TEXT, followupText),
-              })
-            : item,
-        ),
-      };
-    },
+    execute,
   };
+  return nodeAlias
+    ? alias
+    : bindCronScheduledTool(alias, {
+        sourceTool: CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME,
+        targetTool: "exec",
+        execTarget: { host: "gateway" },
+      });
 }
 
 export function createGatewayProcessAliasDynamicTool(
   processTool: OpenClawDynamicTool,
 ): OpenClawDynamicTool {
-  return {
-    ...processTool,
-    name: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
-    description:
-      "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.",
-  };
+  return bindCronScheduledTool(
+    {
+      ...processTool,
+      name: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
+      description:
+        "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.",
+    },
+    {
+      sourceTool: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
+      targetTool: "process",
+    },
+  );
 }

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -1,3 +1,4 @@
+import { pinExecToolTarget } from "openclaw/plugin-sdk/codex-mcp-projection";
 import type { CodexPluginConfig } from "./config.js";
 import { normalizeCodexDynamicToolName } from "./dynamic-tool-profile.js";
 
@@ -11,14 +12,6 @@ type ExecAliasParams =
 export const CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME = "node_exec";
 export const CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME = "gateway_exec";
 export const CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME = "gateway_process";
-const CODEX_EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
-const CODEX_NODE_EXEC_PARAMETER_NAMES = new Set([
-  "command",
-  "workdir",
-  "env",
-  "timeoutSeconds",
-  "node",
-]);
 const PROCESS_FOLLOWUP_TEXT =
   "Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.";
 
@@ -51,22 +44,16 @@ export function createExecAliasDynamicTool(
     : gatewayProcessAliasAvailable
       ? "Use gateway_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up."
       : "Background session follow-up is unavailable because gateway_process is not exposed. Rerun without background=true and set yieldMs high enough to wait for completion.";
+  const pinnedTool = pinExecToolTarget(
+    execTool,
+    nodeAlias ? { host: "node", ...(pinnedNode ? { node: pinnedNode } : {}) } : { host: "gateway" },
+  );
   return {
-    ...execTool,
+    ...pinnedTool,
     name,
     description,
-    parameters: hideExecDynamicToolParameters(
-      execTool.parameters,
-      !nodeAlias || Boolean(pinnedNode),
-      nodeAlias,
-    ),
     execute: async (toolCallId, args, signal, onUpdate) => {
-      const result = await execTool.execute(
-        toolCallId,
-        pinExecDynamicToolArgs(args, params.host, pinnedNode),
-        signal,
-        onUpdate,
-      );
+      const result = await pinnedTool.execute(toolCallId, args, signal, onUpdate);
       return {
         ...result,
         content: result.content.map((item) =>
@@ -89,64 +76,5 @@ export function createGatewayProcessAliasDynamicTool(
     name: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
     description:
       "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.",
-  };
-}
-
-function pinExecDynamicToolArgs(
-  args: unknown,
-  host: "gateway" | "node",
-  configuredNode?: string,
-): unknown {
-  const source = normalizeExecDynamicToolArgs(args);
-  const { host: _host, security: _security, ask: _ask, node: requestedNode, ...rest } = source;
-  if (host === "gateway") {
-    return { ...rest, host };
-  }
-  const nodeArgs = Object.fromEntries(
-    Object.entries(rest).filter(([name]) => CODEX_NODE_EXEC_PARAMETER_NAMES.has(name)),
-  );
-  const node = configuredNode ?? (typeof requestedNode === "string" ? requestedNode.trim() : "");
-  return {
-    ...nodeArgs,
-    host,
-    ...(node ? { node } : {}),
-  };
-}
-
-function normalizeExecDynamicToolArgs(args: unknown): Record<string, unknown> {
-  return args && typeof args === "object" && !Array.isArray(args)
-    ? (args as Record<string, unknown>)
-    : {};
-}
-
-function hideExecDynamicToolParameters(
-  parameters: OpenClawDynamicTool["parameters"],
-  hideNode: boolean,
-  nodeOnly: boolean,
-) {
-  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
-    return parameters;
-  }
-  const schema = parameters as Record<string, unknown>;
-  const rawProperties = schema.properties;
-  if (!rawProperties || typeof rawProperties !== "object" || Array.isArray(rawProperties)) {
-    return parameters;
-  }
-  const includeParameter = (name: string) =>
-    nodeOnly
-      ? CODEX_NODE_EXEC_PARAMETER_NAMES.has(name) && !(hideNode && name === "node")
-      : !CODEX_EXEC_POLICY_PARAMETER_NAMES.has(normalizeCodexDynamicToolName(name)) &&
-        !(hideNode && normalizeCodexDynamicToolName(name) === "node");
-  const nextProperties = Object.fromEntries(
-    Object.entries(rawProperties).filter(([name]) => includeParameter(name)),
-  );
-  const rawRequired = schema.required;
-  const nextRequired = Array.isArray(rawRequired)
-    ? rawRequired.filter((name) => typeof name !== "string" || includeParameter(name))
-    : rawRequired;
-  return {
-    ...schema,
-    properties: nextProperties,
-    ...(Array.isArray(rawRequired) ? { required: nextRequired } : {}),
   };
 }

--- a/src/agents/agent-tool-metadata.ts
+++ b/src/agents/agent-tool-metadata.ts
@@ -3,6 +3,7 @@ import type { AnyAgentTool } from "./agent-tools.types.js";
 import { copyBeforeToolCallHookMarker } from "./before-tool-call-metadata.js";
 import { copyChannelAgentToolMeta } from "./channel-tool-metadata.js";
 import { copyCodeModeControlToolIdentity } from "./code-mode-control-tools.js";
+import { copyCronScheduledToolBinding } from "./exec-tool-target-pinning.js";
 import { copyInternalToolExecutionPreparer } from "./runtime/internal-hooks.js";
 import { copyToolTerminalPresentation } from "./tool-terminal-presentation.js";
 
@@ -19,6 +20,7 @@ export function copyAgentToolMetadata<T extends AnyAgentTool>(source: AnyAgentTo
   copyBeforeToolCallHookMarker(source, target);
   copyToolTerminalPresentation(source, target);
   copyCodeModeControlToolIdentity(source, target);
+  copyCronScheduledToolBinding(source, target);
   copyInternalToolExecutionPreparer(source, target);
   return target;
 }

--- a/src/agents/agent-tool-metadata.ts
+++ b/src/agents/agent-tool-metadata.ts
@@ -3,7 +3,7 @@ import type { AnyAgentTool } from "./agent-tools.types.js";
 import { copyBeforeToolCallHookMarker } from "./before-tool-call-metadata.js";
 import { copyChannelAgentToolMeta } from "./channel-tool-metadata.js";
 import { copyCodeModeControlToolIdentity } from "./code-mode-control-tools.js";
-import { copyCronScheduledToolBinding } from "./exec-tool-target-pinning.js";
+import { copyCronScheduledToolProjection } from "./exec-tool-target-pinning.js";
 import { copyInternalToolExecutionPreparer } from "./runtime/internal-hooks.js";
 import { copyToolTerminalPresentation } from "./tool-terminal-presentation.js";
 
@@ -20,7 +20,7 @@ export function copyAgentToolMetadata<T extends AnyAgentTool>(source: AnyAgentTo
   copyBeforeToolCallHookMarker(source, target);
   copyToolTerminalPresentation(source, target);
   copyCodeModeControlToolIdentity(source, target);
-  copyCronScheduledToolBinding(source, target);
+  copyCronScheduledToolProjection(source, target);
   copyInternalToolExecutionPreparer(source, target);
   return target;
 }

--- a/src/agents/cron-creator-authority-context.ts
+++ b/src/agents/cron-creator-authority-context.ts
@@ -8,6 +8,7 @@ import {
   revokeCronCreatorAuthorityRunScope,
   type CronCreatorAuthorityRunScope,
 } from "../gateway/cron-creator-authority-grant.js";
+import { redeemCronScheduledToolAuthority } from "./exec-tool-target-pinning.js";
 import type {
   CronCreatorToolAuthorityMaterialization,
   CronToolOptions,
@@ -116,10 +117,14 @@ function bindCronCreatorAuthorityResolver(params: {
     if (!authority.active) {
       authority.signal.throwIfAborted();
     }
+    const runtimeAuthority = redeemCronScheduledToolAuthority(
+      snapshot.scheduledToolAuthority,
+      snapshot.runtimeAuthority,
+    );
     return Object.freeze({
       tools: snapshot.tools,
       provenance: snapshot.provenance,
-      grant: mintCronCreatorAuthorityGrant(authority, operationSignal, snapshot.runtimeAuthority),
+      grant: mintCronCreatorAuthorityGrant(authority, operationSignal, runtimeAuthority),
     });
   };
 }

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -1,33 +1,134 @@
 import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
-import type { CronScheduledToolBinding } from "../cron/runtime-authority.js";
+import {
+  normalizeCronRuntimeAuthority,
+  normalizeCronScheduledToolBindings,
+  type CronRuntimeAuthority,
+  type CronScheduledToolBinding,
+} from "../cron/runtime-authority.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
-const scheduledToolBindings = new WeakMap<AnyAgentTool, CronScheduledToolBinding>();
+type CronScheduledToolProjection = Readonly<{
+  assertActive: () => void;
+  binding: CronScheduledToolBinding;
+  execute: AnyAgentTool["execute"];
+}>;
+
+export type CronScheduledToolAuthorityCapture = Readonly<{
+  kind: "cron-scheduled-tool-authority-capture";
+}>;
+
+const scheduledToolProjections = new WeakMap<AnyAgentTool, CronScheduledToolProjection>();
+const scheduledToolAuthorityCaptures = new WeakMap<
+  CronScheduledToolAuthorityCapture,
+  Readonly<{
+    projections: readonly CronScheduledToolProjection[];
+    fallbackAuthority: CronRuntimeAuthority;
+  }>
+>();
 
 const EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
 const NODE_EXEC_PARAMETER_NAMES = new Set(["command", "workdir", "env", "timeoutSeconds", "node"]);
 
 type PinnedExecToolTarget = { host: "gateway"; ask?: "always" } | { host: "node"; node?: string };
 
-export function bindCronScheduledTool(
-  tool: AnyAgentTool,
-  binding: CronScheduledToolBinding,
+/** Core-only producer boundary for an alias of an exact host-created shell tool. */
+export function sealCronScheduledToolProjection(
+  projectedTool: AnyAgentTool,
+  assertActive: () => void,
+  targetTool: "exec" | "process",
 ): AnyAgentTool {
-  scheduledToolBindings.set(tool, binding);
-  return tool;
+  assertActive();
+  const binding: CronScheduledToolBinding =
+    targetTool === "exec"
+      ? {
+          sourceTool: projectedTool.name,
+          targetTool: "exec",
+          execTarget: { host: "gateway" },
+        }
+      : { sourceTool: projectedTool.name, targetTool: "process" };
+  scheduledToolProjections.set(
+    projectedTool,
+    Object.freeze({ assertActive, binding, execute: projectedTool.execute }),
+  );
+  return projectedTool;
 }
 
-export function getCronScheduledToolBinding(
-  tool: AnyAgentTool,
-): CronScheduledToolBinding | undefined {
-  return scheduledToolBindings.get(tool);
-}
-
-export function copyCronScheduledToolBinding(source: AnyAgentTool, target: AnyAgentTool): void {
-  const binding = scheduledToolBindings.get(source);
-  if (binding) {
-    scheduledToolBindings.set(target, binding);
+export function copyCronScheduledToolProjection(source: AnyAgentTool, target: AnyAgentTool): void {
+  const projection = scheduledToolProjections.get(source);
+  if (
+    projection &&
+    source.name === projection.binding.sourceTool &&
+    target.name === projection.binding.sourceTool &&
+    source.execute === projection.execute &&
+    target.execute === projection.execute
+  ) {
+    scheduledToolProjections.set(target, projection);
   }
+}
+
+/** Captures only host-sealed projections present on the final executable surface. */
+export function captureCronScheduledToolAuthority(
+  tools: readonly AnyAgentTool[],
+  fallbackAuthority: CronRuntimeAuthority,
+): CronScheduledToolAuthorityCapture | undefined {
+  const projections = tools.flatMap((tool) => {
+    const projection = scheduledToolProjections.get(tool);
+    if (!projection) {
+      return [];
+    }
+    projection.assertActive();
+    if (tool.name !== projection.binding.sourceTool || tool.execute !== projection.execute) {
+      throw new Error("scheduled tool projection executable changed after host sealing");
+    }
+    return [projection];
+  });
+  const bindings = normalizeCronScheduledToolBindings(
+    projections.map((projection) => projection.binding),
+  );
+  const normalizedFallback = normalizeCronRuntimeAuthority(fallbackAuthority);
+  if (projections.length === 0) {
+    return undefined;
+  }
+  if (!bindings || !normalizedFallback) {
+    throw new Error("scheduled tool projection capture is invalid");
+  }
+  const capture = Object.freeze({
+    kind: "cron-scheduled-tool-authority-capture" as const,
+  });
+  scheduledToolAuthorityCaptures.set(
+    capture,
+    Object.freeze({
+      projections: Object.freeze(projections),
+      fallbackAuthority: normalizedFallback,
+    }),
+  );
+  return capture;
+}
+
+/** Redeems host-owned evidence immediately before minting the one-shot cron grant. */
+export function redeemCronScheduledToolAuthority(
+  capture: CronScheduledToolAuthorityCapture | undefined,
+  authority: CronRuntimeAuthority | undefined,
+): CronRuntimeAuthority | undefined {
+  if (!capture) {
+    return authority;
+  }
+  const captured = scheduledToolAuthorityCaptures.get(capture);
+  if (!captured) {
+    throw new Error("scheduled tool authority capture is not host-issued");
+  }
+  for (const projection of captured.projections) {
+    projection.assertActive();
+  }
+  const runtimeAuthority = authority ?? captured.fallbackAuthority;
+  const normalized = normalizeCronRuntimeAuthority({
+    ...runtimeAuthority,
+    toolBindings: captured.projections.map((projection) => projection.binding),
+  });
+  if (!normalized) {
+    throw new Error("scheduled tool authority redemption is invalid");
+  }
+  return normalized;
 }
 
 /** Restricts an exec tool to one host target even when callers submit broader arguments. */

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -1,0 +1,74 @@
+import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
+import type { AnyAgentTool } from "./tools/common.js";
+
+const EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
+const NODE_EXEC_PARAMETER_NAMES = new Set(["command", "workdir", "env", "timeoutSeconds", "node"]);
+
+type PinnedExecToolTarget =
+  | { host: "gateway"; ask?: "always" }
+  | { host: "node"; node?: string };
+
+/** Restricts an exec tool to one host target even when callers submit broader arguments. */
+export function pinExecToolTarget(tool: AnyAgentTool, target: PinnedExecToolTarget): AnyAgentTool {
+  const pinnedNode = target.host === "node" ? target.node?.trim() : undefined;
+  return {
+    ...tool,
+    parameters: restrictExecToolParameters(tool.parameters, target.host, Boolean(pinnedNode)),
+    execute: (toolCallId, args, signal, onUpdate) =>
+      tool.execute(toolCallId, pinExecToolArgs(args, target, pinnedNode), signal, onUpdate),
+  };
+}
+
+function pinExecToolArgs(
+  args: unknown,
+  target: PinnedExecToolTarget,
+  pinnedNode: string | undefined,
+): Record<string, unknown> {
+  const source = asNonArrayRecord(args);
+  const { host: _host, security: _security, ask: _ask, node: requestedNode, ...rest } = source;
+  if (target.host === "gateway") {
+    return { ...rest, host: "gateway", ...(target.ask ? { ask: target.ask } : {}) };
+  }
+  const nodeArgs = Object.fromEntries(
+    Object.entries(rest).filter(([name]) => NODE_EXEC_PARAMETER_NAMES.has(name)),
+  );
+  const node = pinnedNode ?? (typeof requestedNode === "string" ? requestedNode.trim() : "");
+  return {
+    ...nodeArgs,
+    host: "node",
+    ...(node ? { node } : {}),
+  };
+}
+
+function restrictExecToolParameters(
+  parameters: AnyAgentTool["parameters"],
+  host: PinnedExecToolTarget["host"],
+  hasPinnedNode: boolean,
+): AnyAgentTool["parameters"] {
+  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
+    return parameters;
+  }
+  // SAFETY: the guards above establish a non-array object schema before field inspection.
+  const schema = parameters as Record<string, unknown>;
+  const rawProperties = schema.properties;
+  if (!rawProperties || typeof rawProperties !== "object" || Array.isArray(rawProperties)) {
+    return parameters;
+  }
+  const includeParameter = (name: string) =>
+    host === "node"
+      ? NODE_EXEC_PARAMETER_NAMES.has(name) && !(hasPinnedNode && name === "node")
+      : !EXEC_POLICY_PARAMETER_NAMES.has(name) && name !== "node";
+  const properties = Object.fromEntries(
+    Object.entries(rawProperties).filter(([name]) => includeParameter(name)),
+  );
+  const rawRequired = schema.required;
+  const required = Array.isArray(rawRequired)
+    ? rawRequired.filter((name) => typeof name !== "string" || includeParameter(name))
+    : rawRequired;
+  return {
+    ...schema,
+    properties,
+    ...(Array.isArray(rawRequired) ? { required } : {}),
+    // SAFETY: this preserves the original schema shape and only removes properties and required names.
+  } as AnyAgentTool["parameters"];
+}

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -28,16 +28,36 @@ const scheduledToolAuthorityCaptures = new WeakMap<
 
 const EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
 const NODE_EXEC_PARAMETER_NAMES = new Set(["command", "workdir", "env", "timeoutSeconds", "node"]);
+const PROCESS_FOLLOWUP_TEXT =
+  "Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.";
 
 type PinnedExecToolTarget = { host: "gateway"; ask?: "always" } | { host: "node"; node?: string };
 
-/** Core-only producer boundary for an alias of an exact host-created shell tool. */
-export function sealCronScheduledToolProjection(
-  projectedTool: AnyAgentTool,
+export type CronScheduledToolProjectionRequest =
+  | Readonly<{
+      kind: "exec";
+      name: string;
+      description: string;
+      followupText: string;
+      ask?: "always";
+    }>
+  | Readonly<{ kind: "process"; name: string; description: string }>;
+
+/** Constructs and seals an alias from an exact host-owned shell source. */
+export function createCronScheduledToolProjection(
+  sourceTool: AnyAgentTool,
   assertActive: () => void,
   targetTool: "exec" | "process",
+  projection: CronScheduledToolProjectionRequest,
 ): AnyAgentTool {
   assertActive();
+  if (projection.kind !== targetTool) {
+    throw new Error("scheduled tool projection does not match its host-created source");
+  }
+  const projectedTool =
+    projection.kind === "exec"
+      ? createScheduledExecProjection(sourceTool, projection)
+      : { ...sourceTool, name: projection.name, description: projection.description };
   const binding: CronScheduledToolBinding =
     targetTool === "exec"
       ? {
@@ -51,6 +71,39 @@ export function sealCronScheduledToolProjection(
     Object.freeze({ assertActive, binding, execute: projectedTool.execute }),
   );
   return projectedTool;
+}
+
+function createScheduledExecProjection(
+  sourceTool: AnyAgentTool,
+  projection: Readonly<{
+    name: string;
+    description: string;
+    followupText: string;
+    ask?: "always";
+  }>,
+): AnyAgentTool {
+  const pinnedTool = pinExecToolTarget(sourceTool, {
+    host: "gateway",
+    ...(projection.ask ? { ask: projection.ask } : {}),
+  });
+  return {
+    ...pinnedTool,
+    name: projection.name,
+    description: projection.description,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const result = await pinnedTool.execute(toolCallId, args, signal, onUpdate);
+      return {
+        ...result,
+        content: result.content.map((item) =>
+          item.type === "text"
+            ? Object.assign({}, item, {
+                text: item.text.replace(PROCESS_FOLLOWUP_TEXT, projection.followupText),
+              })
+            : item,
+        ),
+      };
+    },
+  };
 }
 
 export function copyCronScheduledToolProjection(source: AnyAgentTool, target: AnyAgentTool): void {

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -7,9 +7,7 @@ const scheduledToolBindings = new WeakMap<AnyAgentTool, CronScheduledToolBinding
 const EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
 const NODE_EXEC_PARAMETER_NAMES = new Set(["command", "workdir", "env", "timeoutSeconds", "node"]);
 
-type PinnedExecToolTarget =
-  | { host: "gateway"; ask?: "always" }
-  | { host: "node"; node?: string };
+type PinnedExecToolTarget = { host: "gateway"; ask?: "always" } | { host: "node"; node?: string };
 
 export function bindCronScheduledTool(
   tool: AnyAgentTool,
@@ -23,6 +21,13 @@ export function getCronScheduledToolBinding(
   tool: AnyAgentTool,
 ): CronScheduledToolBinding | undefined {
   return scheduledToolBindings.get(tool);
+}
+
+export function copyCronScheduledToolBinding(source: AnyAgentTool, target: AnyAgentTool): void {
+  const binding = scheduledToolBindings.get(source);
+  if (binding) {
+    scheduledToolBindings.set(target, binding);
+  }
 }
 
 /** Restricts an exec tool to one host target even when callers submit broader arguments. */

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -1,5 +1,8 @@
 import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
+import type { CronScheduledToolBinding } from "../cron/runtime-authority.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
+const scheduledToolBindings = new WeakMap<AnyAgentTool, CronScheduledToolBinding>();
 
 const EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
 const NODE_EXEC_PARAMETER_NAMES = new Set(["command", "workdir", "env", "timeoutSeconds", "node"]);
@@ -7,6 +10,20 @@ const NODE_EXEC_PARAMETER_NAMES = new Set(["command", "workdir", "env", "timeout
 type PinnedExecToolTarget =
   | { host: "gateway"; ask?: "always" }
   | { host: "node"; node?: string };
+
+export function bindCronScheduledTool(
+  tool: AnyAgentTool,
+  binding: CronScheduledToolBinding,
+): AnyAgentTool {
+  scheduledToolBindings.set(tool, binding);
+  return tool;
+}
+
+export function getCronScheduledToolBinding(
+  tool: AnyAgentTool,
+): CronScheduledToolBinding | undefined {
+  return scheduledToolBindings.get(tool);
+}
 
 /** Restricts an exec tool to one host target even when callers submit broader arguments. */
 export function pinExecToolTarget(tool: AnyAgentTool, target: PinnedExecToolTarget): AnyAgentTool {

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -1,0 +1,72 @@
+import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
+import type { AnyAgentTool } from "./tools/common.js";
+
+const EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
+const NODE_EXEC_PARAMETER_NAMES = new Set(["command", "workdir", "env", "timeoutSeconds", "node"]);
+
+type PinnedExecToolTarget = { host: "gateway" } | { host: "node"; node?: string };
+
+/** Restricts an exec tool to one host target even when callers submit broader arguments. */
+export function pinExecToolTarget(tool: AnyAgentTool, target: PinnedExecToolTarget): AnyAgentTool {
+  const pinnedNode = target.host === "node" ? target.node?.trim() : undefined;
+  return {
+    ...tool,
+    parameters: restrictExecToolParameters(tool.parameters, target.host, Boolean(pinnedNode)),
+    execute: (toolCallId, args, signal, onUpdate) =>
+      tool.execute(toolCallId, pinExecToolArgs(args, target, pinnedNode), signal, onUpdate),
+  };
+}
+
+function pinExecToolArgs(
+  args: unknown,
+  target: PinnedExecToolTarget,
+  pinnedNode: string | undefined,
+): Record<string, unknown> {
+  const source = asNonArrayRecord(args);
+  const { host: _host, security: _security, ask: _ask, node: requestedNode, ...rest } = source;
+  if (target.host === "gateway") {
+    return { ...rest, host: "gateway" };
+  }
+  const nodeArgs = Object.fromEntries(
+    Object.entries(rest).filter(([name]) => NODE_EXEC_PARAMETER_NAMES.has(name)),
+  );
+  const node = pinnedNode ?? (typeof requestedNode === "string" ? requestedNode.trim() : "");
+  return {
+    ...nodeArgs,
+    host: "node",
+    ...(node ? { node } : {}),
+  };
+}
+
+function restrictExecToolParameters(
+  parameters: AnyAgentTool["parameters"],
+  host: PinnedExecToolTarget["host"],
+  hasPinnedNode: boolean,
+): AnyAgentTool["parameters"] {
+  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
+    return parameters;
+  }
+  // SAFETY: the guards above establish a non-array object schema before field inspection.
+  const schema = parameters as Record<string, unknown>;
+  const rawProperties = schema.properties;
+  if (!rawProperties || typeof rawProperties !== "object" || Array.isArray(rawProperties)) {
+    return parameters;
+  }
+  const includeParameter = (name: string) =>
+    host === "node"
+      ? NODE_EXEC_PARAMETER_NAMES.has(name) && !(hasPinnedNode && name === "node")
+      : !EXEC_POLICY_PARAMETER_NAMES.has(name) && name !== "node";
+  const properties = Object.fromEntries(
+    Object.entries(rawProperties).filter(([name]) => includeParameter(name)),
+  );
+  const rawRequired = schema.required;
+  const required = Array.isArray(rawRequired)
+    ? rawRequired.filter((name) => typeof name !== "string" || includeParameter(name))
+    : rawRequired;
+  return {
+    ...schema,
+    properties,
+    ...(Array.isArray(rawRequired) ? { required } : {}),
+    // SAFETY: this preserves the original schema shape and only removes properties and required names.
+  } as AnyAgentTool["parameters"];
+}

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -1,10 +1,27 @@
 import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
+import type { CronScheduledToolBinding } from "../cron/runtime-authority.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
+const scheduledToolBindings = new WeakMap<AnyAgentTool, CronScheduledToolBinding>();
 
 const EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
 const NODE_EXEC_PARAMETER_NAMES = new Set(["command", "workdir", "env", "timeoutSeconds", "node"]);
 
 type PinnedExecToolTarget = { host: "gateway" } | { host: "node"; node?: string };
+
+export function bindCronScheduledTool(
+  tool: AnyAgentTool,
+  binding: CronScheduledToolBinding,
+): AnyAgentTool {
+  scheduledToolBindings.set(tool, binding);
+  return tool;
+}
+
+export function getCronScheduledToolBinding(
+  tool: AnyAgentTool,
+): CronScheduledToolBinding | undefined {
+  return scheduledToolBindings.get(tool);
+}
 
 /** Restricts an exec tool to one host target even when callers submit broader arguments. */
 export function pinExecToolTarget(tool: AnyAgentTool, target: PinnedExecToolTarget): AnyAgentTool {

--- a/src/agents/harness/host-capability-types.ts
+++ b/src/agents/harness/host-capability-types.ts
@@ -47,6 +47,11 @@ export type AgentHarnessHostCapabilities = Readonly<{
     options: AgentHarnessToolSurfaceOptions,
     bindingOptions?: Readonly<{ cwd?: string }>,
   ) => AnyAgentTool[];
+  /** Seals an alias only when its source came from this exact host-created surface. */
+  sealScheduledToolProjection?: (
+    sourceTool: AnyAgentTool,
+    projectedTool: AnyAgentTool,
+  ) => AnyAgentTool;
   /** Core-owned byte binding for a native command approval, scoped to this admitted run. */
   prepareMutableFileApproval?: (request: { command: string; cwd?: string }) => Promise<
     | {

--- a/src/agents/harness/host-capability-types.ts
+++ b/src/agents/harness/host-capability-types.ts
@@ -47,11 +47,6 @@ export type AgentHarnessHostCapabilities = Readonly<{
     options: AgentHarnessToolSurfaceOptions,
     bindingOptions?: Readonly<{ cwd?: string }>,
   ) => AnyAgentTool[];
-  /** Seals an alias only when its source came from this exact host-created surface. */
-  sealScheduledToolProjection?: (
-    sourceTool: AnyAgentTool,
-    projectedTool: AnyAgentTool,
-  ) => AnyAgentTool;
   /** Core-owned byte binding for a native command approval, scoped to this admitted run. */
   prepareMutableFileApproval?: (request: { command: string; cwd?: string }) => Promise<
     | {

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../agent-tools.before-tool-call.js";
 import {
   captureCronScheduledToolAuthority,
+  createCronScheduledToolProjection,
   redeemCronScheduledToolAuthority,
 } from "../exec-tool-target-pinning.js";
 import {
@@ -37,6 +38,7 @@ import {
   createAgentHarnessHostCapabilities,
   retainBeforeToolCallForNativeHookRelay,
 } from "./host-capability.js";
+import { resolveAgentHarnessScheduledToolProjectionCapability } from "./host-private-capabilities.js";
 
 vi.mock("../agent-tools.before-tool-call.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../agent-tools.before-tool-call.js")>()),
@@ -135,13 +137,40 @@ describe("agent harness host capability", () => {
     const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
     const sourceTools = host.capabilities.createToolSurface?.({}) ?? [];
     const execTool = sourceTools.find((tool) => tool.name === "exec");
-    if (!execTool || !host.capabilities.sealScheduledToolProjection) {
+    const createProjection = resolveAgentHarnessScheduledToolProjectionCapability({
+      hostCapabilities: host.capabilities,
+      ownerPluginId: "codex",
+    });
+    if (!execTool || !createProjection) {
       throw new Error("expected host-created exec projection test surface");
     }
-    const alias = host.capabilities.sealScheduledToolProjection(execTool, {
-      ...execTool,
+    const alias = createProjection(execTool, {
+      kind: "exec",
       name: "gateway_exec",
+      description: "Gateway exec",
+      followupText: "Use gateway_process for follow-up.",
     });
+    const forgedExecute = vi.fn(async () => ({ content: [], details: {} }));
+    const forgedRequest = {
+      kind: "exec",
+      name: "forged_gateway_exec",
+      description: "Forged Gateway exec",
+      followupText: "none",
+      execute: forgedExecute,
+    } as const;
+    const forgedAlias = createProjection(execTool, forgedRequest);
+    expect(forgedAlias.execute).not.toBe(forgedExecute);
+    const sourceExecute = execTool.execute;
+    execTool.execute = forgedExecute;
+    expect(() =>
+      createProjection(execTool, {
+        kind: "exec",
+        name: "mutated_gateway_exec",
+        description: "Mutated Gateway exec",
+        followupText: "none",
+      }),
+    ).toThrow("was not created by this host capability");
+    execTool.execute = sourceExecute;
     const capture = captureCronScheduledToolAuthority([alias], {
       version: 1,
       runtimeId: "test",
@@ -175,9 +204,11 @@ describe("agent harness host capability", () => {
     const pluginExec = { ...execTool, name: "exec" };
     const [boundPluginExec] = host.capabilities.bindToolSurface([pluginExec]);
     expect(() =>
-      host.capabilities.sealScheduledToolProjection?.(boundPluginExec!, {
-        ...boundPluginExec!,
+      createProjection(boundPluginExec!, {
+        kind: "exec",
         name: "colliding_gateway_exec",
+        description: "Colliding Gateway exec",
+        followupText: "none",
       }),
     ).toThrow("was not created by this host capability");
 
@@ -189,14 +220,73 @@ describe("agent harness host capability", () => {
     }
     nonShellTool.name = "exec";
     expect(() =>
-      host.capabilities.sealScheduledToolProjection?.(nonShellTool, {
-        ...nonShellTool,
+      createProjection(nonShellTool, {
+        kind: "exec",
         name: "forged_gateway_exec",
+        description: "Forged Gateway exec",
+        followupText: "none",
       }),
     ).toThrow("was not created by this host capability");
 
     host.close();
     expect(() => redeemCronScheduledToolAuthority(capture, undefined)).toThrow("no longer active");
+  });
+
+  it("keeps scheduled shell issuance private to the registered Codex owner", async () => {
+    const { attempt } = await admittedAttempt("run-non-codex-projection");
+    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "other-harness" });
+
+    expect(host.capabilities).not.toHaveProperty("createScheduledToolProjection");
+    expect(
+      resolveAgentHarnessScheduledToolProjectionCapability({
+        hostCapabilities: host.capabilities,
+        ownerPluginId: "codex",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("constructs scheduled exec projections with host-owned policy", async () => {
+    const execute = vi.fn(async () => ({
+      content: [
+        {
+          type: "text" as const,
+          text: "Command still running. Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
+        },
+      ],
+      details: {},
+    }));
+    const source = {
+      name: "exec",
+      label: "Exec",
+      description: "exec",
+      parameters: Type.Object({}),
+      execute,
+    } satisfies AnyAgentTool;
+    const alias = createCronScheduledToolProjection(source, () => {}, "exec", {
+      kind: "exec",
+      name: "gateway_exec",
+      description: "Gateway exec",
+      followupText: "Use gateway_process for follow-up.",
+      ask: "always",
+    });
+
+    const result = await alias.execute("call-1", {
+      command: "echo safe",
+      host: "node",
+      node: "remote",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-1",
+      { command: "echo safe", host: "gateway", ask: "always" },
+      undefined,
+      undefined,
+    );
+    expect(result.content).toEqual([
+      { type: "text", text: "Command still running. Use gateway_process for follow-up." },
+    ]);
   });
 
   it("overwrites plugin policy fields with the host snapshot and revokes lexically", async () => {

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -22,6 +22,10 @@ import {
   runBeforeToolCallHook,
 } from "../agent-tools.before-tool-call.js";
 import {
+  captureCronScheduledToolAuthority,
+  redeemCronScheduledToolAuthority,
+} from "../exec-tool-target-pinning.js";
+import {
   attachInternalToolExecutionPreparer,
   getInternalToolExecutionPreparer,
   type InternalToolExecutionPreparer,
@@ -126,6 +130,75 @@ describe("agent harness host capability", () => {
     mockCallGatewayTool.mockReset();
   });
 
+  it("seals scheduled shell authority only from this host-created tool surface", async () => {
+    const { attempt } = await admittedAttempt("run-scheduled-tool-projection");
+    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
+    const sourceTools = host.capabilities.createToolSurface?.({}) ?? [];
+    const execTool = sourceTools.find((tool) => tool.name === "exec");
+    if (!execTool || !host.capabilities.sealScheduledToolProjection) {
+      throw new Error("expected host-created exec projection test surface");
+    }
+    const alias = host.capabilities.sealScheduledToolProjection(execTool, {
+      ...execTool,
+      name: "gateway_exec",
+    });
+    const capture = captureCronScheduledToolAuthority([alias], {
+      version: 1,
+      runtimeId: "test",
+      namespace: "scheduled-tools",
+      payload: { version: 1 },
+    });
+    expect(redeemCronScheduledToolAuthority(capture, undefined)?.toolBindings).toEqual([
+      {
+        sourceTool: "gateway_exec",
+        targetTool: "exec",
+        execTarget: { host: "gateway" },
+      },
+    ]);
+
+    const collidingPluginTool = { ...alias };
+    expect(
+      captureCronScheduledToolAuthority([collidingPluginTool], {
+        version: 1,
+        runtimeId: "test",
+        namespace: "scheduled-tools",
+        payload: { version: 1 },
+      }),
+    ).toBeUndefined();
+    expect(() =>
+      redeemCronScheduledToolAuthority(
+        { kind: "cron-scheduled-tool-authority-capture" },
+        undefined,
+      ),
+    ).toThrow("is not host-issued");
+
+    const pluginExec = { ...execTool, name: "exec" };
+    const [boundPluginExec] = host.capabilities.bindToolSurface([pluginExec]);
+    expect(() =>
+      host.capabilities.sealScheduledToolProjection?.(boundPluginExec!, {
+        ...boundPluginExec!,
+        name: "colliding_gateway_exec",
+      }),
+    ).toThrow("was not created by this host capability");
+
+    const nonShellTool = sourceTools.find(
+      (tool) => tool.name !== "exec" && tool.name !== "process",
+    );
+    if (!nonShellTool) {
+      throw new Error("expected a non-shell host-created tool");
+    }
+    nonShellTool.name = "exec";
+    expect(() =>
+      host.capabilities.sealScheduledToolProjection?.(nonShellTool, {
+        ...nonShellTool,
+        name: "forged_gateway_exec",
+      }),
+    ).toThrow("was not created by this host capability");
+
+    host.close();
+    expect(() => redeemCronScheduledToolAuthority(capture, undefined)).toThrow("no longer active");
+  });
+
   it("overwrites plugin policy fields with the host snapshot and revokes lexically", async () => {
     const { attempt, admission } = await admittedAttempt();
     const authority = getAdmittedRunDelegatedAuthority(attempt.admittedRunContext);
@@ -171,7 +244,7 @@ describe("agent harness host capability", () => {
     host.close();
     expect(getAdmittedRunDelegatedAuthority(attempt.admittedRunContext)).toBe(authority);
     expect(() => host.capabilities.bindToolSurface([tool])).toThrow("no longer active");
-    expect(() => host.capabilities.createToolSurface?.({} as never)).toThrow("no longer active");
+    expect(() => host.capabilities.createToolSurface?.({})).toThrow("no longer active");
     expect(() => host.capabilities.assertActive()).toThrow("no longer active");
     await expect(bound.execute("call-1", {})).rejects.toThrow("no longer active");
     expect(execute).not.toHaveBeenCalled();

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -16,6 +16,7 @@ import {
 } from "../agent-tools.before-tool-call.js";
 import { createOpenClawCodingTools } from "../agent-tools.js";
 import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
+import { sealCronScheduledToolProjection } from "../exec-tool-target-pinning.js";
 import { prepareGitHubToolEnvironment } from "../github-tool-identity.js";
 import {
   attachInternalToolExecutionPreparer,
@@ -291,6 +292,7 @@ export function createAgentHarnessHostCapabilities(params: {
   });
 
   const trajectoryRecorder = attempt.trajectoryRecorder;
+  const scheduledToolTargets = new WeakMap<AnyAgentTool, "exec" | "process">();
   const bindToolSurface: AgentHarnessHostCapabilities["bindToolSurface"] = (tools, options) => {
     assertActive();
     const boundAbortSignal = attempt.abortSignal
@@ -342,10 +344,24 @@ export function createAgentHarnessHostCapabilities(params: {
     bindToolSurface,
     createToolSurface: (options, bindingOptions) => {
       assertActive();
-      return bindToolSurface(
+      const tools = bindToolSurface(
         createOpenClawCodingTools({ ...options, operationalRunInstance }),
         bindingOptions,
       );
+      for (const tool of tools) {
+        if (tool.name === "exec" || tool.name === "process") {
+          scheduledToolTargets.set(tool, tool.name);
+        }
+      }
+      return tools;
+    },
+    sealScheduledToolProjection: (sourceTool, projectedTool) => {
+      assertActive();
+      const targetTool = scheduledToolTargets.get(sourceTool);
+      if (!targetTool) {
+        throw new Error("scheduled tool projection source was not created by this host capability");
+      }
+      return sealCronScheduledToolProjection(projectedTool, assertActive, targetTool);
     },
     prepareMutableFileApproval: async (request) => {
       assertActive();

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -16,7 +16,7 @@ import {
 } from "../agent-tools.before-tool-call.js";
 import { createOpenClawCodingTools } from "../agent-tools.js";
 import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
-import { sealCronScheduledToolProjection } from "../exec-tool-target-pinning.js";
+import { createCronScheduledToolProjection } from "../exec-tool-target-pinning.js";
 import { prepareGitHubToolEnvironment } from "../github-tool-identity.js";
 import {
   attachInternalToolExecutionPreparer,
@@ -32,6 +32,7 @@ import {
 } from "../tools/gateway-caller-context.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import type { AgentHarnessHostCapabilities } from "./host-capability-types.js";
+import { registerAgentHarnessScheduledToolProjectionCapability } from "./host-private-capabilities.js";
 
 type AgentHarnessHostAttempt = Partial<EmbeddedRunAttemptParams> &
   Pick<EmbeddedRunAttemptParams, "admittedRunContext" | "runId">;
@@ -292,7 +293,10 @@ export function createAgentHarnessHostCapabilities(params: {
   });
 
   const trajectoryRecorder = attempt.trajectoryRecorder;
-  const scheduledToolTargets = new WeakMap<AnyAgentTool, "exec" | "process">();
+  const scheduledToolSources = new WeakMap<
+    AnyAgentTool,
+    Readonly<{ targetTool: "exec" | "process"; execute: AnyAgentTool["execute"] }>
+  >();
   const bindToolSurface: AgentHarnessHostCapabilities["bindToolSurface"] = (tools, options) => {
     assertActive();
     const boundAbortSignal = attempt.abortSignal
@@ -350,18 +354,13 @@ export function createAgentHarnessHostCapabilities(params: {
       );
       for (const tool of tools) {
         if (tool.name === "exec" || tool.name === "process") {
-          scheduledToolTargets.set(tool, tool.name);
+          scheduledToolSources.set(
+            tool,
+            Object.freeze({ targetTool: tool.name, execute: tool.execute }),
+          );
         }
       }
       return tools;
-    },
-    sealScheduledToolProjection: (sourceTool, projectedTool) => {
-      assertActive();
-      const targetTool = scheduledToolTargets.get(sourceTool);
-      if (!targetTool) {
-        throw new Error("scheduled tool projection source was not created by this host capability");
-      }
-      return sealCronScheduledToolProjection(projectedTool, assertActive, targetTool);
     },
     prepareMutableFileApproval: async (request) => {
       assertActive();
@@ -434,6 +433,27 @@ export function createAgentHarnessHostCapabilities(params: {
         decision: result.decision,
         terminalReason: result.terminalReason,
       };
+    },
+  });
+  registerAgentHarnessScheduledToolProjectionCapability({
+    hostCapabilities: capabilities,
+    ownerPluginId: params.pluginId,
+    create: (sourceTool, projection) => {
+      assertActive();
+      const source = scheduledToolSources.get(sourceTool);
+      if (
+        !source ||
+        sourceTool.name !== source.targetTool ||
+        sourceTool.execute !== source.execute
+      ) {
+        throw new Error("scheduled tool projection source was not created by this host capability");
+      }
+      return createCronScheduledToolProjection(
+        sourceTool,
+        assertActive,
+        source.targetTool,
+        projection,
+      );
     },
   });
   return {

--- a/src/agents/harness/host-private-capabilities.ts
+++ b/src/agents/harness/host-private-capabilities.ts
@@ -1,0 +1,36 @@
+import type { CronScheduledToolProjectionRequest } from "../exec-tool-target-pinning.js";
+import type { AnyAgentTool } from "../tools/common.js";
+import type { AgentHarnessHostCapabilities } from "./host-capability-types.js";
+
+export type AgentHarnessScheduledToolProjectionFactory = (
+  sourceTool: AnyAgentTool,
+  projection: CronScheduledToolProjectionRequest,
+) => AnyAgentTool;
+
+const scheduledToolProjectionCapabilities = new WeakMap<
+  AgentHarnessHostCapabilities,
+  Readonly<{
+    ownerPluginId: string;
+    create: AgentHarnessScheduledToolProjectionFactory;
+  }>
+>();
+
+export function registerAgentHarnessScheduledToolProjectionCapability(params: {
+  hostCapabilities: AgentHarnessHostCapabilities;
+  ownerPluginId: string;
+  create: AgentHarnessScheduledToolProjectionFactory;
+}): void {
+  scheduledToolProjectionCapabilities.set(
+    params.hostCapabilities,
+    Object.freeze({ ownerPluginId: params.ownerPluginId, create: params.create }),
+  );
+}
+
+/** Resolves a private issuer only for the exact authoritative plugin owner. */
+export function resolveAgentHarnessScheduledToolProjectionCapability(params: {
+  hostCapabilities: AgentHarnessHostCapabilities;
+  ownerPluginId: string;
+}): AgentHarnessScheduledToolProjectionFactory | undefined {
+  const capability = scheduledToolProjectionCapabilities.get(params.hostCapabilities);
+  return capability?.ownerPluginId === params.ownerPluginId ? capability.create : undefined;
+}

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -1,3 +1,4 @@
+import type { CronScheduledToolBinding } from "../../cron/runtime-authority.js";
 import { isRecord } from "../../utils.js";
 import { isToolAllowedByPolicyName } from "../tool-policy-match.js";
 import {
@@ -43,7 +44,9 @@ export function assertInheritedCronToolCaptureReady(
 export function replaceWithEffectiveCronCreatorToolAllowlist<T extends { name: string }>(
   target: CronCreatorToolAllowlistEntry[],
   tools: readonly T[],
-  toolMeta?: (tool: T) => { pluginId?: string } | undefined,
+  toolMeta?: (
+    tool: T,
+  ) => { pluginId?: string; scheduledToolBinding?: CronScheduledToolBinding } | undefined,
 ): void {
   target.length = 0;
   const seen = new Set<string>();
@@ -56,7 +59,12 @@ export function replaceWithEffectiveCronCreatorToolAllowlist<T extends { name: s
     const meta = toolMeta?.(tool);
     const pluginId =
       typeof meta?.pluginId === "string" ? normalizeToolPolicyName(meta.pluginId) : undefined;
-    target.push(pluginId ? { name, pluginId } : { name });
+    const scheduledToolBinding = meta?.scheduledToolBinding;
+    target.push({
+      name,
+      ...(pluginId ? { pluginId } : {}),
+      ...(scheduledToolBinding ? { scheduledToolBinding } : {}),
+    });
   }
 }
 
@@ -65,7 +73,9 @@ export function captureFinalEffectiveCronCreatorToolAllowlist<T extends { name: 
   target: CronCreatorToolAllowlistEntry[],
   captureRef: CronToolsAllowCaptureRef,
   tools: readonly T[],
-  toolMeta?: (tool: T) => { pluginId?: string } | undefined,
+  toolMeta?: (
+    tool: T,
+  ) => { pluginId?: string; scheduledToolBinding?: CronScheduledToolBinding } | undefined,
 ): void {
   replaceWithEffectiveCronCreatorToolAllowlist(target, tools, toolMeta);
   captureRef.value = { version: 1, source: "final-executable-surface" };

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -1,4 +1,3 @@
-import type { CronScheduledToolBinding } from "../../cron/runtime-authority.js";
 import { isRecord } from "../../utils.js";
 import { isToolAllowedByPolicyName } from "../tool-policy-match.js";
 import {
@@ -44,9 +43,7 @@ export function assertInheritedCronToolCaptureReady(
 export function replaceWithEffectiveCronCreatorToolAllowlist<T extends { name: string }>(
   target: CronCreatorToolAllowlistEntry[],
   tools: readonly T[],
-  toolMeta?: (
-    tool: T,
-  ) => { pluginId?: string; scheduledToolBinding?: CronScheduledToolBinding } | undefined,
+  toolMeta?: (tool: T) => { pluginId?: string } | undefined,
 ): void {
   target.length = 0;
   const seen = new Set<string>();
@@ -59,11 +56,9 @@ export function replaceWithEffectiveCronCreatorToolAllowlist<T extends { name: s
     const meta = toolMeta?.(tool);
     const pluginId =
       typeof meta?.pluginId === "string" ? normalizeToolPolicyName(meta.pluginId) : undefined;
-    const scheduledToolBinding = meta?.scheduledToolBinding;
     target.push({
       name,
       ...(pluginId ? { pluginId } : {}),
-      ...(scheduledToolBinding ? { scheduledToolBinding } : {}),
     });
   }
 }
@@ -73,9 +68,7 @@ export function captureFinalEffectiveCronCreatorToolAllowlist<T extends { name: 
   target: CronCreatorToolAllowlistEntry[],
   captureRef: CronToolsAllowCaptureRef,
   tools: readonly T[],
-  toolMeta?: (
-    tool: T,
-  ) => { pluginId?: string; scheduledToolBinding?: CronScheduledToolBinding } | undefined,
+  toolMeta?: (tool: T) => { pluginId?: string } | undefined,
 ): void {
   replaceWithEffectiveCronCreatorToolAllowlist(target, tools, toolMeta);
   captureRef.value = { version: 1, source: "final-executable-surface" };

--- a/src/agents/tools/cron-tool.types.ts
+++ b/src/agents/tools/cron-tool.types.ts
@@ -1,6 +1,9 @@
 // Cron tool type declarations shared with the cron tool implementation.
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { CronRuntimeAuthority } from "../../cron/runtime-authority.js";
+import type {
+  CronRuntimeAuthority,
+  CronScheduledToolBinding,
+} from "../../cron/runtime-authority.js";
 import type { CronCreatorAuthorityGrant } from "../../gateway/cron-creator-authority-grant.js";
 import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
 import type { callGatewayTool } from "./gateway.js";
@@ -10,6 +13,7 @@ export type CronCreatorToolAllowlistEntry =
   | {
       name: string;
       pluginId?: string;
+      scheduledToolBinding?: CronScheduledToolBinding;
     };
 
 type CronToolsAllowCaptureProvenance = {

--- a/src/agents/tools/cron-tool.types.ts
+++ b/src/agents/tools/cron-tool.types.ts
@@ -1,11 +1,9 @@
 // Cron tool type declarations shared with the cron tool implementation.
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type {
-  CronRuntimeAuthority,
-  CronScheduledToolBinding,
-} from "../../cron/runtime-authority.js";
+import type { CronRuntimeAuthority } from "../../cron/runtime-authority.js";
 import type { CronCreatorAuthorityGrant } from "../../gateway/cron-creator-authority-grant.js";
 import type { DeliveryContext } from "../../utils/delivery-context.shared.js";
+import type { CronScheduledToolAuthorityCapture } from "../exec-tool-target-pinning.js";
 import type { callGatewayTool } from "./gateway.js";
 
 export type CronCreatorToolAllowlistEntry =
@@ -13,7 +11,6 @@ export type CronCreatorToolAllowlistEntry =
   | {
       name: string;
       pluginId?: string;
-      scheduledToolBinding?: CronScheduledToolBinding;
     };
 
 type CronToolsAllowCaptureProvenance = {
@@ -30,11 +27,13 @@ export type CronCreatorToolAuthorityMaterialization = {
   provenance: CronToolsAllowCaptureProvenance;
   /** Opaque runtime-owned authority captured with the same exact executable surface. */
   runtimeAuthority?: CronRuntimeAuthority;
+  /** Host-issued projection evidence redeemed only by the active run owner. */
+  scheduledToolAuthority?: CronScheduledToolAuthorityCapture;
 };
 
 export type CronCreatorToolAuthoritySnapshot = Omit<
   CronCreatorToolAuthorityMaterialization,
-  "runtimeAuthority"
+  "runtimeAuthority" | "scheduledToolAuthority"
 > & {
   /** Gateway-process one-shot proof consumed only at the matching cron write. */
   grant: CronCreatorAuthorityGrant;

--- a/src/claws/read-only-state-compat.test.ts
+++ b/src/claws/read-only-state-compat.test.ts
@@ -4,6 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -42,16 +43,7 @@ function createBaseShapeState(params: {
   for (const column of OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY.allowedMissingColumns ??
     []) {
     const [table, name] = column.split(".");
-    if (!table || !name) {
-      continue;
-    }
-    // Additive columns can belong to tables that are stripped from claw-scoped
-    // schemas entirely (e.g. node_worker_launches); base shape only drops
-    // columns whose owning table exists here.
-    const tableExists = database.db
-      .prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`)
-      .get(table);
-    if (!tableExists) {
+    if (!table || !tableExists(database.db, table)) {
       continue;
     }
     database.db.exec(`ALTER TABLE ${table} DROP COLUMN ${name};`);

--- a/src/claws/read-only-state-compat.test.ts
+++ b/src/claws/read-only-state-compat.test.ts
@@ -4,6 +4,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -42,6 +43,9 @@ function createBaseShapeState(params: {
   for (const column of OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY.allowedMissingColumns ??
     []) {
     const [table, name] = column.split(".");
+    if (!table || !tableExists(database.db, table)) {
+      continue;
+    }
     database.db.exec(`ALTER TABLE ${table} DROP COLUMN ${name};`);
   }
   closeOpenClawStateDatabaseForTest();

--- a/src/cron/runtime-authority-input.ts
+++ b/src/cron/runtime-authority-input.ts
@@ -1,0 +1,84 @@
+import { createHash } from "node:crypto";
+import {
+  normalizeCronScheduledToolCallerOrigin,
+  normalizeCronScheduledToolPolicy,
+  resolveCronScheduledToolPolicy,
+} from "./scheduled-tool-policy.js";
+import { cronJobUsesToolRuntime } from "./tools-allow.js";
+import type { CronStoredJob, CronToolsAllowProvenance } from "./types.js";
+
+const CRON_RUNTIME_AUTHORITY_ROW_FINGERPRINT_VERSION = 1;
+const CRON_RUNTIME_AUTHORITY_BINDING_FINGERPRINT_VERSION = 2;
+
+function sha256Fingerprint(version: number, canonical: unknown): string {
+  return `v${version}:${createHash("sha256")
+    .update(JSON.stringify(canonical), "utf8")
+    .digest("hex")}`;
+}
+
+function normalizedToolsAllow(job: CronStoredJob): string[] | null {
+  const toolsAllow = job.payload.toolsAllow;
+  return toolsAllow === undefined ? null : [...toolsAllow].toSorted();
+}
+
+function normalizedRowProvenance(
+  value: CronToolsAllowProvenance | undefined,
+): CronToolsAllowProvenance | null {
+  return value?.version === 1 && value.source === "final-executable-surface"
+    ? { version: 1, source: "final-executable-surface" }
+    : null;
+}
+
+/** Exact v1 shape retained for readers from before tool-binding persistence. */
+export function cronRuntimeAuthorityRowFingerprint(job: CronStoredJob): string {
+  const canonical = {
+    version: CRON_RUNTIME_AUTHORITY_ROW_FINGERPRINT_VERSION,
+    usesToolRuntime: cronJobUsesToolRuntime(job),
+    toolsAllow: normalizedToolsAllow(job),
+    toolsAllowIsDefault: job.payload.toolsAllowIsDefault === true,
+    // Keep the historical raw-policy normalization here. Downgraded readers
+    // must compute byte-identical v1 fingerprints for unchanged jobs.
+    scheduledToolPolicy: normalizeCronScheduledToolPolicy(job.scheduledToolPolicy) ?? null,
+    toolsAllowProvenance: normalizedRowProvenance(job.toolsAllowProvenance),
+  };
+  return sha256Fingerprint(CRON_RUNTIME_AUTHORITY_ROW_FINGERPRINT_VERSION, canonical);
+}
+
+/** Complete authorization meaning for runtime-owned scheduled tool bindings. */
+export function cronRuntimeAuthorityBindingFingerprint(job: CronStoredJob): string {
+  const effectiveScheduledToolPolicy =
+    resolveCronScheduledToolPolicy({
+      toolsAllow: job.payload.toolsAllow,
+      scheduledToolPolicy: job.scheduledToolPolicy,
+      owner: job.owner,
+    }) ?? null;
+  const provenance = normalizedRowProvenance(job.toolsAllowProvenance);
+  const canonical = {
+    version: CRON_RUNTIME_AUTHORITY_BINDING_FINGERPRINT_VERSION,
+    rowFingerprint: cronRuntimeAuthorityRowFingerprint(job),
+    owner: {
+      agentId: job.owner?.agentId ?? null,
+      sessionKey: job.owner?.sessionKey ?? null,
+      accountId: job.owner?.accountId ?? null,
+    },
+    target: {
+      agentId: job.agentId ?? null,
+      sessionKey: job.sessionKey ?? null,
+      sessionTarget: job.sessionTarget,
+    },
+    executionSurface: {
+      payloadKind: job.payload.kind,
+      triggerScript: job.trigger?.script.trim() || null,
+    },
+    effectiveScheduledToolPolicy,
+    toolsAllowProvenance: provenance
+      ? {
+          ...provenance,
+          callerOrigin: normalizeCronScheduledToolCallerOrigin(
+            job.toolsAllowProvenance?.callerOrigin,
+          ),
+        }
+      : null,
+  };
+  return sha256Fingerprint(CRON_RUNTIME_AUTHORITY_BINDING_FINGERPRINT_VERSION, canonical);
+}

--- a/src/cron/runtime-authority.test.ts
+++ b/src/cron/runtime-authority.test.ts
@@ -26,7 +26,45 @@ describe("normalizeCronRuntimeAuthority", () => {
     expect(Object.isFrozen((normalized.payload.apps as unknown[])[0])).toBe(true);
   });
 
+  it("normalizes producer-bound scheduled tool bindings", () => {
+    const input = {
+      ...authority({ version: 1 }),
+      toolBindings: [
+        {
+          sourceTool: "gateway_exec",
+          targetTool: "exec",
+          execTarget: { host: "gateway" },
+        },
+        { sourceTool: "gateway_process", targetTool: "process" },
+      ],
+    };
+
+    const normalized = normalizeCronRuntimeAuthority(input);
+
+    expect(normalized).toEqual(input);
+    expect(Object.isFrozen(normalized?.toolBindings)).toBe(true);
+    expect(Object.isFrozen(normalized?.toolBindings?.[0])).toBe(true);
+  });
+
   it.each([
+    {
+      ...authority({}),
+      toolBindings: [
+        {
+          sourceTool: "gateway_exec",
+          targetTool: "exec",
+          execTarget: { host: "node" },
+        },
+      ],
+    },
+    {
+      ...authority({}),
+      toolBindings: [
+        { sourceTool: "gateway_exec", targetTool: "process" },
+        { sourceTool: "gateway_exec", targetTool: "process" },
+      ],
+    },
+    { ...authority({}), toolBindings: [{ sourceTool: "gateway_exec", targetTool: "write" }] },
     authority({ value: Number.NaN }),
     authority({ value: Number.POSITIVE_INFINITY }),
     authority({ value: undefined }),

--- a/src/cron/runtime-authority.ts
+++ b/src/cron/runtime-authority.ts
@@ -5,10 +5,28 @@ const CRON_RUNTIME_AUTHORITY_MAX_BYTES = 64 * 1024;
 const CRON_RUNTIME_AUTHORITY_MAX_ID_LENGTH = 128;
 const CRON_RUNTIME_AUTHORITY_MAX_DEPTH = 16;
 const CRON_RUNTIME_AUTHORITY_ID_PATTERN = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/u;
-const CRON_RUNTIME_AUTHORITY_KEYS = new Set(["version", "runtimeId", "namespace", "payload"]);
+const CRON_RUNTIME_AUTHORITY_KEYS = new Set([
+  "version",
+  "runtimeId",
+  "namespace",
+  "payload",
+  "toolBindings",
+]);
+const CRON_RUNTIME_AUTHORITY_MAX_TOOL_BINDINGS = 16;
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
+export type CronScheduledToolBinding =
+  | Readonly<{
+      sourceTool: string;
+      targetTool: "exec";
+      execTarget: Readonly<{ host: "gateway" }>;
+    }>
+  | Readonly<{
+      sourceTool: string;
+      targetTool: "process";
+    }>;
 
 export type CronRuntimeAuthority = Readonly<{
   version: 1;
@@ -17,6 +35,8 @@ export type CronRuntimeAuthority = Readonly<{
   /** Runtime-owned payload discriminator; core never interprets its value. */
   namespace: string;
   payload: Readonly<Record<string, unknown>>;
+  /** Host-validated projections from runtime-specific creator tools to scheduled tools. */
+  toolBindings?: readonly CronScheduledToolBinding[];
 }>;
 
 function normalizeAuthorityId(value: unknown): string | undefined {
@@ -99,6 +119,55 @@ function deepFreezeJson(value: JsonValue): JsonValue {
   return value;
 }
 
+function normalizeToolBindings(value: unknown): readonly CronScheduledToolBinding[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || value.length > CRON_RUNTIME_AUTHORITY_MAX_TOOL_BINDINGS) {
+    return undefined;
+  }
+  const bindings: CronScheduledToolBinding[] = [];
+  const seenSources = new Set<string>();
+  for (const candidate of value) {
+    if (!isRecord(candidate)) {
+      return undefined;
+    }
+    const sourceTool = normalizeAuthorityId(candidate.sourceTool);
+    if (!sourceTool || seenSources.has(sourceTool)) {
+      return undefined;
+    }
+    if (
+      candidate.targetTool === "exec" &&
+      Object.keys(candidate).every((key) =>
+        ["sourceTool", "targetTool", "execTarget"].includes(key),
+      ) &&
+      isRecord(candidate.execTarget) &&
+      Object.keys(candidate.execTarget).length === 1 &&
+      candidate.execTarget.host === "gateway"
+    ) {
+      seenSources.add(sourceTool);
+      bindings.push(
+        Object.freeze({
+          sourceTool,
+          targetTool: "exec",
+          execTarget: Object.freeze({ host: "gateway" }),
+        }),
+      );
+      continue;
+    }
+    if (
+      candidate.targetTool === "process" &&
+      Object.keys(candidate).every((key) => key === "sourceTool" || key === "targetTool")
+    ) {
+      seenSources.add(sourceTool);
+      bindings.push(Object.freeze({ sourceTool, targetTool: "process" }));
+      continue;
+    }
+    return undefined;
+  }
+  return Object.freeze(bindings);
+}
+
 /** Validates the private persisted transport without learning runtime-owned payload semantics. */
 export function normalizeCronRuntimeAuthority(value: unknown): CronRuntimeAuthority | undefined {
   if (
@@ -114,7 +183,8 @@ export function normalizeCronRuntimeAuthority(value: unknown): CronRuntimeAuthor
   const runtimeId = normalizeAuthorityId(value.runtimeId);
   const namespace = normalizeAuthorityId(value.namespace);
   const payload = cloneJsonObject(value.payload);
-  if (!runtimeId || !namespace || !payload) {
+  const toolBindings = normalizeToolBindings(value.toolBindings);
+  if (!runtimeId || !namespace || !payload || (value.toolBindings !== undefined && !toolBindings)) {
     return undefined;
   }
   const normalized = {
@@ -122,6 +192,7 @@ export function normalizeCronRuntimeAuthority(value: unknown): CronRuntimeAuthor
     runtimeId,
     namespace,
     payload: deepFreezeJson(payload) as Readonly<Record<string, unknown>>,
+    ...(toolBindings ? { toolBindings } : {}),
   } as const;
   if (Buffer.byteLength(JSON.stringify(normalized), "utf8") > CRON_RUNTIME_AUTHORITY_MAX_BYTES) {
     return undefined;

--- a/src/cron/runtime-authority.ts
+++ b/src/cron/runtime-authority.ts
@@ -12,6 +12,12 @@ const CRON_RUNTIME_AUTHORITY_KEYS = new Set([
   "payload",
   "toolBindings",
 ]);
+const CRON_PERSISTED_RUNTIME_AUTHORITY_KEYS = new Set([
+  "version",
+  "runtimeId",
+  "namespace",
+  "payload",
+]);
 const CRON_RUNTIME_AUTHORITY_MAX_TOOL_BINDINGS = 16;
 
 type JsonPrimitive = string | number | boolean | null;
@@ -119,7 +125,9 @@ function deepFreezeJson(value: JsonValue): JsonValue {
   return value;
 }
 
-function normalizeToolBindings(value: unknown): readonly CronScheduledToolBinding[] | undefined {
+export function normalizeCronScheduledToolBindings(
+  value: unknown,
+): readonly CronScheduledToolBinding[] | undefined {
   if (value === undefined) {
     return undefined;
   }
@@ -183,7 +191,7 @@ export function normalizeCronRuntimeAuthority(value: unknown): CronRuntimeAuthor
   const runtimeId = normalizeAuthorityId(value.runtimeId);
   const namespace = normalizeAuthorityId(value.namespace);
   const payload = cloneJsonObject(value.payload);
-  const toolBindings = normalizeToolBindings(value.toolBindings);
+  const toolBindings = normalizeCronScheduledToolBindings(value.toolBindings);
   if (!runtimeId || !namespace || !payload || (value.toolBindings !== undefined && !toolBindings)) {
     return undefined;
   }
@@ -198,6 +206,37 @@ export function normalizeCronRuntimeAuthority(value: unknown): CronRuntimeAuthor
     return undefined;
   }
   return Object.freeze(normalized);
+}
+
+type CronPersistedRuntimeAuthority = Omit<CronRuntimeAuthority, "toolBindings">;
+
+/** Reads the downgrade-stable authority shape understood by older binaries. */
+export function normalizeCronPersistedRuntimeAuthority(
+  value: unknown,
+): CronPersistedRuntimeAuthority | undefined {
+  if (
+    !isRecord(value) ||
+    Object.keys(value).some((key) => !CRON_PERSISTED_RUNTIME_AUTHORITY_KEYS.has(key))
+  ) {
+    return undefined;
+  }
+  return normalizeCronRuntimeAuthority(value);
+}
+
+/** Separates newer binding metadata from the older authority JSON envelope. */
+export function serializeCronRuntimeAuthority(
+  value: CronRuntimeAuthority,
+): CronPersistedRuntimeAuthority | undefined {
+  const normalized = normalizeCronRuntimeAuthority(value);
+  if (!normalized) {
+    return undefined;
+  }
+  return normalizeCronPersistedRuntimeAuthority({
+    version: normalized.version,
+    runtimeId: normalized.runtimeId,
+    namespace: normalized.namespace,
+    payload: normalized.payload,
+  });
 }
 
 export function cloneCronRuntimeAuthority(

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -16,13 +16,11 @@ import {
 } from "../active-jobs.js";
 import { resolveCronJobConfigRevision } from "../config-revision.js";
 import { isHeartbeatTaskDeclarationKey } from "../heartbeat-task.js";
-import { cloneCronRuntimeAuthority, type CronRuntimeAuthority } from "../runtime-authority.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { removeCronJobBaseSession } from "../session-reaper.js";
 import { removeStaleCronJobFamilyRows } from "../store.js";
 import { createCronStreamSourceIdentity, cronStreamScheduleKey } from "../stream-schedule.js";
 import { normalizeCronTaskRunJobId } from "../task-run-history.js";
-import { cronJobUsesToolRuntime } from "../tools-allow.js";
 import type { CronJob, CronJobCreate, CronJobPatch, CronStoredJob } from "../types.js";
 import {
   computeJobNextRunAtMs,
@@ -42,6 +40,7 @@ import {
 import { normalizeOptionalAgentId } from "./normalize.js";
 import { resolveCurrentDefaultAgentId, resolveEffectiveJobAgentId } from "./ops-shared.js";
 import { cronRunReceiptOwnerMutationHooks } from "./run-receipts.js";
+import { reconcileCronRuntimeAuthority } from "./runtime-authority-mutation.js";
 import type {
   CronAddResult,
   CronAddOptions,
@@ -271,49 +270,9 @@ function declarativeFields(job: CronStoredJob, includeEnabled: boolean) {
   };
 }
 
-function reconcileRuntimeAuthority(params: {
-  job: CronStoredJob;
-  captured: boolean;
-  runtimeAuthority?: CronRuntimeAuthority;
-  explicitlyMutatesToolsAllow: boolean;
-}): void {
-  if (!cronJobUsesToolRuntime(params.job)) {
-    // Runtime authority cannot survive a payload transition into a path that
-    // does not execute the captured tool surface and later reappear on reuse.
-    delete params.job.runtimeAuthority;
-    delete params.job.runtimeAuthorityRecoveryRequired;
-    return;
-  }
-  if (params.captured) {
-    delete params.job.runtimeAuthorityRecoveryRequired;
-    const runtimeAuthority = params.runtimeAuthority
-      ? cloneCronRuntimeAuthority(params.runtimeAuthority)
-      : undefined;
-    if (params.runtimeAuthority && !runtimeAuthority) {
-      throw new TypeError("captured cron runtime authority is invalid");
-    }
-    if (runtimeAuthority) {
-      params.job.runtimeAuthority = runtimeAuthority;
-    } else {
-      // A fresh exact-surface capture with no runtime authority intentionally
-      // replaces any older runtime-specific grant instead of retaining it.
-      delete params.job.runtimeAuthority;
-    }
-    return;
-  }
-  if (params.explicitlyMutatesToolsAllow) {
-    // Explicit tool caps are a complete replacement. Runtime-owned authority
-    // may be restored only by another authenticated exact-surface capture.
-    if (params.job.runtimeAuthority) {
-      params.job.runtimeAuthorityRecoveryRequired = true;
-      delete params.job.runtimeAuthority;
-    }
-  }
-}
-
 function consumeRuntimeAuthorityMutationOptions(
   opts: CronAddOptions | CronUpdateOptions | undefined,
-): Pick<Parameters<typeof reconcileRuntimeAuthority>[0], "captured" | "runtimeAuthority"> {
+): Pick<Parameters<typeof reconcileCronRuntimeAuthority>[0], "captured" | "runtimeAuthority"> {
   // Validation-only guards must not look like an empty fresh capture: that
   // would erase an existing runtime ceiling during an otherwise routine edit.
   opts?.commitGuard?.();
@@ -389,8 +348,9 @@ export async function add(
         configuredChannels,
       });
       const runtimeAuthorityMutation = consumeRuntimeAuthorityMutationOptions(opts);
-      reconcileRuntimeAuthority({
+      reconcileCronRuntimeAuthority({
         job: nextJob,
+        previousJob: existing,
         ...runtimeAuthorityMutation,
         explicitlyMutatesToolsAllow: normalizedInput.payload.toolsAllow !== undefined,
       });
@@ -434,7 +394,7 @@ export async function add(
       configuredChannels,
     });
     const runtimeAuthorityMutation = consumeRuntimeAuthorityMutationOptions(opts);
-    reconcileRuntimeAuthority({
+    reconcileCronRuntimeAuthority({
       job,
       ...runtimeAuthorityMutation,
       explicitlyMutatesToolsAllow: normalizedInput.payload.toolsAllow !== undefined,
@@ -551,8 +511,9 @@ async function updateLoadedJob(params: {
     explicitTriggerState: patch.state,
   });
   const runtimeAuthorityMutation = consumeRuntimeAuthorityMutationOptions(opts);
-  reconcileRuntimeAuthority({
+  reconcileCronRuntimeAuthority({
     job: nextJob,
+    previousJob: job,
     ...runtimeAuthorityMutation,
     explicitlyMutatesToolsAllow:
       patch.payload !== undefined && Object.hasOwn(patch.payload, "toolsAllow"),

--- a/src/cron/service/ops.test.ts
+++ b/src/cron/service/ops.test.ts
@@ -399,6 +399,81 @@ describe("scheduled tool policy provenance", () => {
     }
   });
 
+  it("retires retained authority when its execution surface or target changes", async () => {
+    const { storePath } = await makeStorePath();
+    const state = createOkIsolatedCronState({
+      storePath,
+      now: Date.now(),
+      triggersEnabled: true,
+    });
+    const authority = {
+      version: 1 as const,
+      runtimeId: "codex",
+      namespace: "scheduled-tools",
+      payload: { version: 1 },
+      toolBindings: [
+        {
+          sourceTool: "gateway_exec",
+          targetTool: "exec" as const,
+          execTarget: { host: "gateway" as const },
+        },
+      ],
+    };
+    const created = await add(
+      state,
+      {
+        name: "surface-bound authority",
+        enabled: true,
+        agentId: "main",
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        trigger: { script: "return true" },
+        payload: { kind: "agentTurn", message: "run", toolsAllow: ["gateway_exec"] },
+      },
+      { captureRuntimeAuthority: () => authority },
+    );
+
+    const withoutTrigger = await update(state, created.id, { trigger: null });
+    expect(withoutTrigger.runtimeAuthority).toBeUndefined();
+    expect(withoutTrigger.runtimeAuthorityRecoveryRequired).toBe(true);
+
+    const restoredTrigger = await update(state, created.id, {
+      trigger: { script: "return true" },
+    });
+    expect(restoredTrigger.runtimeAuthority).toBeUndefined();
+    expect(restoredTrigger.runtimeAuthorityRecoveryRequired).toBe(true);
+
+    const recaptured = await update(
+      state,
+      created.id,
+      { description: "fresh authority" },
+      { captureRuntimeAuthority: () => authority },
+    );
+    expect(recaptured.runtimeAuthority).toEqual(authority);
+
+    const rewrittenTrigger = await update(state, created.id, {
+      trigger: { script: "return false" },
+    });
+    expect(rewrittenTrigger.runtimeAuthority).toBeUndefined();
+    expect(rewrittenTrigger.runtimeAuthorityRecoveryRequired).toBe(true);
+
+    const recapturedAfterRewrite = await update(
+      state,
+      created.id,
+      { description: "recaptured after trigger rewrite" },
+      { captureRuntimeAuthority: () => authority },
+    );
+    expect(recapturedAfterRewrite.runtimeAuthority).toEqual(authority);
+
+    const retargeted = await update(state, created.id, { agentId: "other" });
+    expect(retargeted.runtimeAuthority).toBeUndefined();
+    expect(retargeted.runtimeAuthorityRecoveryRequired).toBe(true);
+    if (state.timer) {
+      clearTimeout(state.timer);
+    }
+  });
+
   it("stamps trusted and authenticated-account creates", async () => {
     const { storePath } = await makeStorePath();
     const now = Date.parse("2026-07-23T12:00:00.000Z");

--- a/src/cron/service/runtime-authority-mutation.ts
+++ b/src/cron/service/runtime-authority-mutation.ts
@@ -1,0 +1,50 @@
+import { cronRuntimeAuthorityBindingFingerprint } from "../runtime-authority-input.js";
+import { cloneCronRuntimeAuthority, type CronRuntimeAuthority } from "../runtime-authority.js";
+import { cronJobUsesToolRuntime } from "../tools-allow.js";
+import type { CronStoredJob } from "../types.js";
+
+/** Reconciles runtime-private authority at the store-locked cron mutation owner. */
+export function reconcileCronRuntimeAuthority(params: {
+  job: CronStoredJob;
+  previousJob?: CronStoredJob;
+  captured: boolean;
+  runtimeAuthority?: CronRuntimeAuthority;
+  explicitlyMutatesToolsAllow: boolean;
+}): void {
+  if (!cronJobUsesToolRuntime(params.job)) {
+    delete params.job.runtimeAuthority;
+    delete params.job.runtimeAuthorityRecoveryRequired;
+    return;
+  }
+  if (params.captured) {
+    delete params.job.runtimeAuthorityRecoveryRequired;
+    const runtimeAuthority = params.runtimeAuthority
+      ? cloneCronRuntimeAuthority(params.runtimeAuthority)
+      : undefined;
+    if (params.runtimeAuthority && !runtimeAuthority) {
+      throw new TypeError("captured cron runtime authority is invalid");
+    }
+    if (runtimeAuthority) {
+      params.job.runtimeAuthority = runtimeAuthority;
+    } else {
+      delete params.job.runtimeAuthority;
+    }
+    return;
+  }
+  if (
+    params.job.runtimeAuthority &&
+    params.previousJob &&
+    cronRuntimeAuthorityBindingFingerprint(params.previousJob) !==
+      cronRuntimeAuthorityBindingFingerprint(params.job)
+  ) {
+    // Only a fresh exact-run capture may carry authority across an owner,
+    // target, policy, script, or executable-surface change.
+    params.job.runtimeAuthorityRecoveryRequired = true;
+    delete params.job.runtimeAuthority;
+    return;
+  }
+  if (params.explicitlyMutatesToolsAllow && params.job.runtimeAuthority) {
+    params.job.runtimeAuthorityRecoveryRequired = true;
+    delete params.job.runtimeAuthority;
+  }
+}

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -101,7 +101,7 @@ export type CronServiceDeps = {
   /** List enabled, configured channel ids without exposing channel machinery to cron core. */
   listConfiguredChannels?: () => readonly string[] | Promise<readonly string[]>;
   evaluateCronTrigger?: (params: {
-    job: CronJob;
+    job: CronStoredJob;
     script: string;
     state: unknown;
     streamBatch?: string;
@@ -219,7 +219,7 @@ export type CronServiceDeps = {
     } & CronRunOutcome
   >;
   runScriptJob?: (params: {
-    job: CronJob;
+    job: CronStoredJob;
     streamBatch?: string;
     abortSignal?: AbortSignal;
   }) => Promise<

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -99,6 +99,13 @@ function makeAuthorityStore(jobId: string): CronStoreFile {
     runtimeId: "codex",
     namespace: "codex.apps",
     payload: { apps: [{ id: "calendar" }] },
+    toolBindings: [
+      {
+        sourceTool: "gateway_exec",
+        targetTool: "exec",
+        execTarget: { host: "gateway" },
+      },
+    ],
   };
   return store;
 }

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -878,6 +878,31 @@ describe("cron store", () => {
     expect(readOnly?.runtimeAuthority).toEqual(job.runtimeAuthority);
   });
 
+  it("loads populated legacy authority tables before the bindings column exists", async () => {
+    const { storePath } = await makeStorePath();
+    const authorityStore = makeAuthorityStore("legacy-authority-table");
+    const job = expectDefined(authorityStore.jobs[0], "authority job test invariant");
+    await saveCronStore(storePath, authorityStore);
+
+    const database = openOpenClawStateDatabase().db;
+    database
+      .prepare("UPDATE cron_job_runtime_authorities SET authority_json = ? WHERE job_id = ?")
+      .run(JSON.stringify(job.runtimeAuthority), job.id);
+    database.exec("ALTER TABLE cron_job_runtime_authorities DROP COLUMN tool_bindings_json");
+
+    const readOnly = (await loadCronJobsStoreWithConfigJobsReadOnly(storePath)).store.jobs[0];
+    expect(readOnly?.runtimeAuthority).toEqual(job.runtimeAuthority);
+    expect(
+      database
+        .prepare("SELECT 1 FROM pragma_table_info('cron_job_runtime_authorities') WHERE name = ?")
+        .get("tool_bindings_json"),
+    ).toBeUndefined();
+
+    const writable = (await loadCronStore(storePath)).jobs[0];
+    expect(writable?.runtimeAuthority).toEqual(job.runtimeAuthority);
+    expect(writable?.runtimeAuthorityRecoveryRequired).toBeUndefined();
+  });
+
   it("retires authority when an older writer changes its tool cap", async () => {
     const { storePath } = await makeStorePath();
     const authorityStore = makeAuthorityStore("downgrade-cap-change");

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -830,9 +830,116 @@ describe("cron store", () => {
     expect(reloaded?.runtimeAuthorityRecoveryRequired).toBe(true);
     expect(
       database
-        .prepare("SELECT recovery_required FROM cron_job_runtime_authorities WHERE job_id = ?")
+        .prepare(
+          "SELECT recovery_required, tool_bindings_json FROM cron_job_runtime_authorities WHERE job_id = ?",
+        )
         .get(job.id),
-    ).toEqual({ recovery_required: 1 });
+    ).toEqual({ recovery_required: 1, tool_bindings_json: null });
+  });
+
+  it("rejects bindings preserved by an older writer across creator-origin changes", async () => {
+    const { storePath } = await makeStorePath();
+    const authorityStore = makeAuthorityStore("downgrade-stale-origin-binding");
+    const job = expectDefined(authorityStore.jobs[0], "authority job test invariant");
+    job.toolsAllowProvenance = {
+      version: 1,
+      source: "final-executable-surface",
+      callerOrigin: { kind: "external", channel: "discord" },
+    };
+    await saveCronStore(storePath, authorityStore);
+
+    const database = openOpenClawStateDatabase().db;
+    const row = database.prepare("SELECT job_json FROM cron_jobs WHERE job_id = ?").get(job.id) as {
+      job_json: string;
+    };
+    const downgradedJob = JSON.parse(row.job_json) as Record<string, unknown>;
+    const provenance = downgradedJob.toolsAllowProvenance as Record<string, unknown>;
+    provenance.callerOrigin = { kind: "local" };
+
+    // A downgraded writer can rewrite the parent while preserving the unknown
+    // sidecar and its row-compatible v1 fingerprint.
+    database
+      .prepare("UPDATE cron_jobs SET job_json = ? WHERE job_id = ?")
+      .run(JSON.stringify(downgradedJob), job.id);
+
+    const readOnly = (await loadCronJobsStoreWithConfigJobsReadOnly(storePath)).store.jobs[0];
+    expect(readOnly?.runtimeAuthority).toBeUndefined();
+    expect(readOnly?.runtimeAuthorityRecoveryRequired).toBe(true);
+    expect(
+      database
+        .prepare(
+          "SELECT recovery_required, tool_bindings_json IS NOT NULL AS has_bindings FROM cron_job_runtime_authorities WHERE job_id = ?",
+        )
+        .get(job.id),
+    ).toEqual({ recovery_required: 0, has_bindings: 1 });
+
+    const reloaded = (await loadCronStore(storePath)).jobs[0];
+    expect(reloaded?.runtimeAuthority).toBeUndefined();
+    expect(reloaded?.runtimeAuthorityRecoveryRequired).toBe(true);
+    expect(
+      database
+        .prepare(
+          "SELECT recovery_required, tool_bindings_json FROM cron_job_runtime_authorities WHERE job_id = ?",
+        )
+        .get(job.id),
+    ).toEqual({ recovery_required: 1, tool_bindings_json: null });
+  });
+
+  it("clears preserved bindings from downgrade recovery rows before recapture", async () => {
+    const { storePath } = await makeStorePath();
+    const authorityStore = makeAuthorityStore("downgrade-recovery-sidecar");
+    const job = expectDefined(authorityStore.jobs[0], "authority job test invariant");
+    await saveCronStore(storePath, authorityStore);
+
+    const database = openOpenClawStateDatabase().db;
+    const original = database
+      .prepare(
+        "SELECT authority_json, authority_input_fingerprint FROM cron_job_runtime_authorities WHERE job_id = ?",
+      )
+      .get(job.id) as { authority_json: string; authority_input_fingerprint: string };
+
+    // A downgraded writer does not know the sidecar column, so its recovery
+    // upsert can leave the old binding envelope attached to a recovery row.
+    database
+      .prepare(
+        "UPDATE cron_job_runtime_authorities SET authority_json = NULL, authority_input_fingerprint = NULL, recovery_required = 1 WHERE job_id = ?",
+      )
+      .run(job.id);
+
+    const readOnly = (await loadCronJobsStoreWithConfigJobsReadOnly(storePath)).store.jobs[0];
+    expect(readOnly?.runtimeAuthority).toBeUndefined();
+    expect(readOnly?.runtimeAuthorityRecoveryRequired).toBe(true);
+    expect(
+      database
+        .prepare(
+          "SELECT recovery_required, tool_bindings_json IS NOT NULL AS has_bindings FROM cron_job_runtime_authorities WHERE job_id = ?",
+        )
+        .get(job.id),
+    ).toEqual({ recovery_required: 1, has_bindings: 1 });
+
+    await loadCronStore(storePath);
+    expect(
+      database
+        .prepare("SELECT tool_bindings_json FROM cron_job_runtime_authorities WHERE job_id = ?")
+        .get(job.id),
+    ).toEqual({ tool_bindings_json: null });
+
+    // Even if the old writer later recaptures the same legacy authority fields,
+    // the retired shell binding cannot reappear after another upgrade.
+    database
+      .prepare(
+        "UPDATE cron_job_runtime_authorities SET authority_json = ?, authority_input_fingerprint = ?, recovery_required = 0 WHERE job_id = ?",
+      )
+      .run(original.authority_json, original.authority_input_fingerprint, job.id);
+
+    const recaptured = (await loadCronStore(storePath)).jobs[0];
+    expect(recaptured?.runtimeAuthority).toEqual({
+      version: 1,
+      runtimeId: "codex",
+      namespace: "codex.apps",
+      payload: { apps: [{ id: "calendar" }] },
+    });
+    expect(recaptured?.runtimeAuthorityRecoveryRequired).toBeUndefined();
   });
 
   it("stores authority outside job_json and restores it after reopen", async () => {
@@ -865,8 +972,10 @@ describe("cron store", () => {
     );
     expect(JSON.parse(child.authority_json)).toEqual(expectedPersistedAuthority);
     expect(JSON.parse(child.tool_bindings_json)).toEqual({
-      version: 1,
+      version: 2,
       authoritySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      authorityInputFingerprint: child.authority_input_fingerprint,
+      bindingInputFingerprint: expect.stringMatching(/^v2:[a-f0-9]{64}$/u),
       bindings: expectedToolBindings,
     });
     expect(child.authority_input_fingerprint).toMatch(/^v1:[a-f0-9]{64}$/u);

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -752,6 +752,45 @@ describe("cron store", () => {
     const row = database.prepare("SELECT job_json FROM cron_jobs WHERE job_id = ?").get(job.id) as {
       job_json: string;
     };
+    const authorityRow = database
+      .prepare(
+        "SELECT store_key, authority_json, authority_input_fingerprint, recovery_required, tool_bindings_json FROM cron_job_runtime_authorities WHERE job_id = ?",
+      )
+      .get(job.id) as {
+      store_key: string;
+      authority_json: string;
+      authority_input_fingerprint: string;
+      recovery_required: number;
+      tool_bindings_json: string;
+    };
+    expect(JSON.parse(authorityRow.authority_json)).toEqual({
+      version: 1,
+      runtimeId: "codex",
+      namespace: "codex.apps",
+      payload: { apps: [{ id: "calendar" }] },
+    });
+    database
+      .prepare(
+        `INSERT INTO cron_job_runtime_authorities
+          (store_key, job_id, authority_json, authority_input_fingerprint, recovery_required)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT (store_key, job_id) DO UPDATE SET
+           authority_json = excluded.authority_json,
+           authority_input_fingerprint = excluded.authority_input_fingerprint,
+           recovery_required = excluded.recovery_required`,
+      )
+      .run(
+        authorityRow.store_key,
+        job.id,
+        authorityRow.authority_json,
+        authorityRow.authority_input_fingerprint,
+        authorityRow.recovery_required,
+      );
+    expect(
+      database
+        .prepare("SELECT tool_bindings_json FROM cron_job_runtime_authorities WHERE job_id = ?")
+        .get(job.id),
+    ).toEqual({ tool_bindings_json: authorityRow.tool_bindings_json });
     const downgradedJob = JSON.parse(row.job_json) as Record<string, unknown>;
     delete downgradedJob.runtimeAuthority;
     delete downgradedJob.runtimeAuthorityRecoveryRequired;
@@ -764,6 +803,35 @@ describe("cron store", () => {
     expect(reloaded?.description).toBe("edited by an older build");
     expect(reloaded?.runtimeAuthority).toEqual(job.runtimeAuthority);
     expect(reloaded?.runtimeAuthorityRecoveryRequired).toBeUndefined();
+  });
+
+  it("rejects stale bindings after an older writer replaces authority_json", async () => {
+    const { storePath } = await makeStorePath();
+    const authorityStore = makeAuthorityStore("downgrade-stale-bindings");
+    const job = expectDefined(authorityStore.jobs[0], "authority job test invariant");
+    await saveCronStore(storePath, authorityStore);
+
+    const database = openOpenClawStateDatabase().db;
+    database
+      .prepare("UPDATE cron_job_runtime_authorities SET authority_json = ? WHERE job_id = ?")
+      .run(
+        JSON.stringify({
+          version: 1,
+          runtimeId: "codex",
+          namespace: "codex.apps",
+          payload: { apps: [{ id: "mail" }] },
+        }),
+        job.id,
+      );
+
+    const reloaded = (await loadCronStore(storePath)).jobs[0];
+    expect(reloaded?.runtimeAuthority).toBeUndefined();
+    expect(reloaded?.runtimeAuthorityRecoveryRequired).toBe(true);
+    expect(
+      database
+        .prepare("SELECT recovery_required FROM cron_job_runtime_authorities WHERE job_id = ?")
+        .get(job.id),
+    ).toEqual({ recovery_required: 1 });
   });
 
   it("stores authority outside job_json and restores it after reopen", async () => {
@@ -782,14 +850,24 @@ describe("cron store", () => {
     expect(parentJson).not.toHaveProperty("runtimeAuthorityRecoveryRequired");
     const child = database
       .prepare(
-        "SELECT authority_json, authority_input_fingerprint, recovery_required FROM cron_job_runtime_authorities WHERE job_id = ?",
+        "SELECT authority_json, authority_input_fingerprint, recovery_required, tool_bindings_json FROM cron_job_runtime_authorities WHERE job_id = ?",
       )
       .get(job.id) as {
       authority_json: string;
       authority_input_fingerprint: string;
       recovery_required: number;
+      tool_bindings_json: string;
     };
-    expect(JSON.parse(child.authority_json)).toEqual(job.runtimeAuthority);
+    const { toolBindings: expectedToolBindings, ...expectedPersistedAuthority } = expectDefined(
+      job.runtimeAuthority,
+      "runtime authority test invariant",
+    );
+    expect(JSON.parse(child.authority_json)).toEqual(expectedPersistedAuthority);
+    expect(JSON.parse(child.tool_bindings_json)).toEqual({
+      version: 1,
+      authoritySha256: expect.stringMatching(/^[a-f0-9]{64}$/u),
+      bindings: expectedToolBindings,
+    });
     expect(child.authority_input_fingerprint).toMatch(/^v1:[a-f0-9]{64}$/u);
     expect(child.recovery_required).toBe(0);
 

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -886,13 +886,14 @@ describe("cron store", () => {
     await saveCronStore(storePath, authorityStore);
 
     const database = openOpenClawStateDatabase().db;
-    database
-      .prepare("UPDATE cron_job_runtime_authorities SET authority_json = ? WHERE job_id = ?")
-      .run(JSON.stringify(job.runtimeAuthority), job.id);
     database.exec("ALTER TABLE cron_job_runtime_authorities DROP COLUMN tool_bindings_json");
 
     const readOnly = (await loadCronJobsStoreWithConfigJobsReadOnly(storePath)).store.jobs[0];
-    expect(readOnly?.runtimeAuthority).toEqual(job.runtimeAuthority);
+    const { toolBindings: _toolBindings, ...persistedAuthority } = expectDefined(
+      job.runtimeAuthority,
+      "runtime authority test invariant",
+    );
+    expect(readOnly?.runtimeAuthority).toEqual(persistedAuthority);
     expect(
       database
         .prepare("SELECT 1 FROM pragma_table_info('cron_job_runtime_authorities') WHERE name = ?")
@@ -900,8 +901,62 @@ describe("cron store", () => {
     ).toBeUndefined();
 
     const writable = (await loadCronStore(storePath)).jobs[0];
-    expect(writable?.runtimeAuthority).toEqual(job.runtimeAuthority);
+    expect(writable?.runtimeAuthority).toEqual(persistedAuthority);
     expect(writable?.runtimeAuthorityRecoveryRequired).toBeUndefined();
+  });
+
+  it("rejects unsealed inline bindings from a predecessor authority table", async () => {
+    const { storePath } = await makeStorePath();
+    const authorityStore = makeAuthorityStore("legacy-inline-bindings");
+    const job = expectDefined(authorityStore.jobs[0], "authority job test invariant");
+    if (job.payload.kind !== "agentTurn") {
+      throw new Error("authority job payload test invariant");
+    }
+    job.payload.toolsAllow = ["gateway_exec"];
+    job.payload.toolsAllowIsDefault = false;
+    await saveCronStore(storePath, authorityStore);
+
+    const database = openOpenClawStateDatabase().db;
+    database
+      .prepare("UPDATE cron_job_runtime_authorities SET authority_json = ? WHERE job_id = ?")
+      .run(JSON.stringify(job.runtimeAuthority), job.id);
+    database.exec("ALTER TABLE cron_job_runtime_authorities DROP COLUMN tool_bindings_json");
+
+    const reloaded = (await loadCronStore(storePath)).jobs[0];
+    expect(reloaded?.runtimeAuthority).toBeUndefined();
+    expect(reloaded?.runtimeAuthorityRecoveryRequired).toBe(true);
+
+    const forbiddenMarker = path.join(path.dirname(storePath), "unsealed-inline-binding-forbidden");
+    const forbiddenCommand = `printf forbidden > ${JSON.stringify(forbiddenMarker)}`;
+    const result = await createCronScriptRuntime({
+      config: {
+        agents: { defaults: { workspace: path.dirname(storePath) } },
+        tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+      },
+    }).evaluateTrigger({
+      jobId: job.id,
+      script: `await exec({ command: ${JSON.stringify(forbiddenCommand)} }); return { fire: false };`,
+      state: null,
+      toolsAllow: reloaded?.payload.toolsAllow,
+      runtimeAuthority: reloaded?.runtimeAuthority,
+      scheduledToolPolicy: { version: 1, mode: "trusted" },
+    });
+    expect(result).toMatchObject({ kind: "error", code: "internal_error" });
+    expect(result.kind === "error" ? result.error : "").toContain("exec is not defined");
+    await expectPathMissing(forbiddenMarker);
+
+    expect(
+      database
+        .prepare(
+          "SELECT authority_json, authority_input_fingerprint, recovery_required, tool_bindings_json FROM cron_job_runtime_authorities WHERE job_id = ?",
+        )
+        .get(job.id),
+    ).toEqual({
+      authority_json: null,
+      authority_input_fingerprint: null,
+      recovery_required: 1,
+      tool_bindings_json: null,
+    });
   });
 
   it("retires drifted authority from a predecessor table after adding the bindings column", async () => {

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -24,6 +24,7 @@ import {
   saveCronStore,
 } from "./store.js";
 import { saveCronJobsStoreWithTransactionHooks } from "./store/transaction-hooks.js";
+import { createCronScriptRuntime } from "./trigger-script.js";
 import type { CronStoreFile } from "./types.js";
 
 let fixtureRoot = "";
@@ -901,6 +902,119 @@ describe("cron store", () => {
     const writable = (await loadCronStore(storePath)).jobs[0];
     expect(writable?.runtimeAuthority).toEqual(job.runtimeAuthority);
     expect(writable?.runtimeAuthorityRecoveryRequired).toBeUndefined();
+  });
+
+  it("retires drifted authority from a predecessor table after adding the bindings column", async () => {
+    const { storePath } = await makeStorePath();
+    const authorityStore = makeAuthorityStore("legacy-authority-recovery");
+    const job = expectDefined(authorityStore.jobs[0], "authority job test invariant");
+    await saveCronStore(storePath, authorityStore);
+
+    const database = openOpenClawStateDatabase().db;
+    database
+      .prepare("UPDATE cron_job_runtime_authorities SET authority_json = ? WHERE job_id = ?")
+      .run(JSON.stringify(job.runtimeAuthority), job.id);
+    database.exec("ALTER TABLE cron_job_runtime_authorities DROP COLUMN tool_bindings_json");
+    database
+      .prepare(
+        "UPDATE cron_job_runtime_authorities SET authority_input_fingerprint = ? WHERE job_id = ?",
+      )
+      .run("v1:stale", job.id);
+
+    const reloaded = (await loadCronStore(storePath)).jobs[0];
+    expect(reloaded?.runtimeAuthority).toBeUndefined();
+    expect(reloaded?.runtimeAuthorityRecoveryRequired).toBe(true);
+    expect(
+      database
+        .prepare(
+          "SELECT authority_json, authority_input_fingerprint, recovery_required, tool_bindings_json FROM cron_job_runtime_authorities WHERE job_id = ?",
+        )
+        .get(job.id),
+    ).toEqual({
+      authority_json: null,
+      authority_input_fingerprint: null,
+      recovery_required: 1,
+      tool_bindings_json: null,
+    });
+  });
+
+  it("allows persisted exec authority and blocks its final effect after invalidation", async () => {
+    const { storePath } = await makeStorePath();
+    const authorityStore = makeAuthorityStore("persisted-authority-final-effect");
+    const job = expectDefined(authorityStore.jobs[0], "authority job test invariant");
+    if (job.payload.kind !== "agentTurn") {
+      throw new Error("authority job payload test invariant");
+    }
+    job.payload.toolsAllow = ["gateway_exec"];
+    job.payload.toolsAllowIsDefault = false;
+    await saveCronStore(storePath, authorityStore);
+
+    const workspaceDir = path.dirname(storePath);
+    const evaluate = createCronScriptRuntime({
+      config: {
+        agents: { defaults: { workspace: workspaceDir } },
+        tools: {
+          exec: {
+            host: "node",
+            node: "configured-node-must-not-run",
+            security: "full",
+            ask: "off",
+          },
+        },
+      },
+    }).evaluateTrigger;
+    const allowedMarker = path.join(workspaceDir, "persisted-authority-allowed");
+    const allowedCommand = `printf allowed > ${JSON.stringify(allowedMarker)}`;
+    const loaded = expectDefined(
+      (await loadCronStore(storePath)).jobs[0],
+      "persisted authority reload test invariant",
+    );
+
+    await expect(
+      evaluate({
+        jobId: loaded.id,
+        script: `await exec({ command: ${JSON.stringify(allowedCommand)} }); return { fire: false };`,
+        state: null,
+        toolsAllow: loaded.payload.toolsAllow,
+        runtimeAuthority: loaded.runtimeAuthority,
+        scheduledToolPolicy: { version: 1, mode: "trusted" },
+      }),
+    ).resolves.toEqual({ kind: "evaluated", fire: false });
+    await expect(fs.readFile(allowedMarker, "utf8")).resolves.toBe("allowed");
+
+    const database = openOpenClawStateDatabase().db;
+    database
+      .prepare("UPDATE cron_job_runtime_authorities SET authority_json = ? WHERE job_id = ?")
+      .run(
+        JSON.stringify({
+          version: 1,
+          runtimeId: "codex",
+          namespace: "scheduled-tools",
+          payload: { version: 2 },
+        }),
+        job.id,
+      );
+    const invalidated = expectDefined(
+      (await loadCronStore(storePath)).jobs[0],
+      "invalidated authority reload test invariant",
+    );
+    expect(invalidated.runtimeAuthority).toBeUndefined();
+    expect(invalidated.runtimeAuthorityRecoveryRequired).toBe(true);
+
+    const forbiddenMarker = path.join(workspaceDir, "persisted-authority-forbidden");
+    const forbiddenCommand = `printf forbidden > ${JSON.stringify(forbiddenMarker)}`;
+    const result = await evaluate({
+      jobId: invalidated.id,
+      script: `await exec({ command: ${JSON.stringify(forbiddenCommand)} }); return { fire: false };`,
+      state: null,
+      toolsAllow: invalidated.payload.toolsAllow,
+      runtimeAuthority: invalidated.runtimeAuthority,
+      scheduledToolPolicy: { version: 1, mode: "trusted" },
+    });
+
+    expect(result).toMatchObject({ kind: "error", code: "internal_error" });
+    expect(result.kind === "error" ? result.error : "").toContain("exec is not defined");
+    await expect(fs.access(forbiddenMarker)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("retires authority when an older writer changes its tool cap", async () => {

--- a/src/cron/store/runtime-authority-store.ts
+++ b/src/cron/store/runtime-authority-store.ts
@@ -166,24 +166,7 @@ function loadCronRuntimeAuthorityRows(
         "recovery_required",
       ])
       .where("store_key", "=", storeKey),
-  ).rows.map((row) => {
-    const legacyAuthority = normalizeCronRuntimeAuthority(safeParseJson(row.authority_json ?? ""));
-    const persistedAuthority = legacyAuthority
-      ? serializeCronRuntimeAuthority(legacyAuthority)
-      : undefined;
-    if (!legacyAuthority || !persistedAuthority) {
-      return Object.assign(row, { tool_bindings_json: null });
-    }
-    const authorityJson = JSON.stringify(persistedAuthority);
-    const toolBindingsJson = serializeStoredToolBindings(
-      legacyAuthority.toolBindings,
-      authorityJson,
-    );
-    return Object.assign(row, {
-      authority_json: authorityJson,
-      tool_bindings_json: toolBindingsJson,
-    });
-  });
+  ).rows.map((row) => Object.assign(row, { tool_bindings_json: null }));
 }
 
 function applyCronRuntimeAuthorityRow(

--- a/src/cron/store/runtime-authority-store.ts
+++ b/src/cron/store/runtime-authority-store.ts
@@ -4,21 +4,28 @@ import type { DatabaseSync } from "node:sqlite";
 import { safeParseJson } from "@openclaw/normalization-core";
 import type { Selectable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
-import { tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
+import { ensureColumn, tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
-import { normalizeCronRuntimeAuthority } from "../runtime-authority.js";
+import {
+  normalizeCronPersistedRuntimeAuthority,
+  normalizeCronRuntimeAuthority,
+  normalizeCronScheduledToolBindings,
+  serializeCronRuntimeAuthority,
+} from "../runtime-authority.js";
 import { normalizeCronScheduledToolPolicy } from "../scheduled-tool-policy.js";
 import { cronJobUsesToolRuntime } from "../tools-allow.js";
 import type { CronStoredJob, CronToolsAllowProvenance } from "../types.js";
 
 const CRON_RUNTIME_AUTHORITY_TABLE = "cron_job_runtime_authorities";
 const CRON_RUNTIME_AUTHORITY_FINGERPRINT_VERSION = 1;
+const CRON_TOOL_BINDINGS_STORAGE_VERSION = 1;
 
 const CRON_RUNTIME_AUTHORITY_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS cron_job_runtime_authorities (
   store_key TEXT NOT NULL,
   job_id TEXT NOT NULL,
   authority_json TEXT,
+  tool_bindings_json TEXT,
   authority_input_fingerprint TEXT,
   recovery_required INTEGER NOT NULL,
   PRIMARY KEY (store_key, job_id),
@@ -78,10 +85,39 @@ function cronRuntimeAuthorityInputFingerprint(job: CronStoredJob): string {
     .digest("hex")}`;
 }
 
+function authorityJsonSha256(authorityJson: string): string {
+  return createHash("sha256").update(authorityJson, "utf8").digest("hex");
+}
+
+function parseStoredToolBindings(
+  value: unknown,
+  authorityJson: string,
+): ReturnType<typeof normalizeCronScheduledToolBindings> {
+  // Unshipped raw-array prototypes carry no authority association, so accepting
+  // them after a downgrade could restore stale exec authority.
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    !("version" in value) ||
+    value.version !== CRON_TOOL_BINDINGS_STORAGE_VERSION ||
+    !("authoritySha256" in value) ||
+    value.authoritySha256 !== authorityJsonSha256(authorityJson) ||
+    !("bindings" in value) ||
+    Object.keys(value).some(
+      (key) => key !== "version" && key !== "authoritySha256" && key !== "bindings",
+    )
+  ) {
+    return undefined;
+  }
+  return normalizeCronScheduledToolBindings(value.bindings);
+}
+
 /** Creates the additive table only when authority state is first persisted. */
 function ensureCronRuntimeAuthorityTable(db: DatabaseSync): void {
   // sqlite-allow-raw -- feature-local additive schema DDL; data access uses Kysely.
   db.exec(CRON_RUNTIME_AUTHORITY_SCHEMA_SQL);
+  ensureColumn(db, CRON_RUNTIME_AUTHORITY_TABLE, "tool_bindings_json TEXT");
 }
 
 function loadCronRuntimeAuthorityRows(
@@ -110,7 +146,21 @@ function applyCronRuntimeAuthorityRow(
     job.runtimeAuthorityRecoveryRequired = true;
     return "ok";
   }
-  const authority = normalizeCronRuntimeAuthority(safeParseJson(row.authority_json ?? ""));
+  const persistedAuthority = normalizeCronPersistedRuntimeAuthority(
+    safeParseJson(row.authority_json ?? ""),
+  );
+  const authorityJson = row.authority_json ?? "";
+  const toolBindings =
+    row.tool_bindings_json == null
+      ? undefined
+      : parseStoredToolBindings(safeParseJson(row.tool_bindings_json), authorityJson);
+  const authority =
+    persistedAuthority && (row.tool_bindings_json == null || toolBindings)
+      ? normalizeCronRuntimeAuthority({
+          ...persistedAuthority,
+          ...(toolBindings ? { toolBindings } : {}),
+        })
+      : undefined;
   if (!authority || row.authority_input_fingerprint !== cronRuntimeAuthorityInputFingerprint(job)) {
     job.runtimeAuthorityRecoveryRequired = true;
     return "repair";
@@ -148,12 +198,14 @@ function writeRecoveryRow(db: DatabaseSync, storeKey: string, jobId: string): vo
         store_key: storeKey,
         job_id: jobId,
         authority_json: null,
+        tool_bindings_json: null,
         authority_input_fingerprint: null,
         recovery_required: 1,
       })
       .onConflict((conflict) =>
         conflict.columns(["store_key", "job_id"]).doUpdateSet({
           authority_json: null,
+          tool_bindings_json: null,
           authority_input_fingerprint: null,
           recovery_required: 1,
         }),
@@ -211,7 +263,19 @@ export function replaceCronRuntimeAuthorityRows(params: {
     }
     const authority = normalizeCronRuntimeAuthority(job.runtimeAuthority);
     if (authority) {
-      const authorityJson = JSON.stringify(authority);
+      const persistedAuthority = serializeCronRuntimeAuthority(authority);
+      if (!persistedAuthority) {
+        writeRecoveryRow(params.db, params.storeKey, job.id);
+        continue;
+      }
+      const authorityJson = JSON.stringify(persistedAuthority);
+      const toolBindingsJson = authority.toolBindings
+        ? JSON.stringify({
+            version: CRON_TOOL_BINDINGS_STORAGE_VERSION,
+            authoritySha256: authorityJsonSha256(authorityJson),
+            bindings: authority.toolBindings,
+          })
+        : null;
       const authorityInputFingerprint = cronRuntimeAuthorityInputFingerprint(job);
       executeSqliteQuerySync(
         params.db,
@@ -221,12 +285,14 @@ export function replaceCronRuntimeAuthorityRows(params: {
             store_key: params.storeKey,
             job_id: job.id,
             authority_json: authorityJson,
+            tool_bindings_json: toolBindingsJson,
             authority_input_fingerprint: authorityInputFingerprint,
             recovery_required: 0,
           })
           .onConflict((conflict) =>
             conflict.columns(["store_key", "job_id"]).doUpdateSet({
               authority_json: authorityJson,
+              tool_bindings_json: toolBindingsJson,
               authority_input_fingerprint: authorityInputFingerprint,
               recovery_required: 0,
             }),

--- a/src/cron/store/runtime-authority-store.ts
+++ b/src/cron/store/runtime-authority-store.ts
@@ -273,6 +273,7 @@ export function repairCronRuntimeAuthorityRows(params: {
   if (!tableExists(params.db, CRON_RUNTIME_AUTHORITY_TABLE)) {
     return false;
   }
+  ensureColumn(params.db, CRON_RUNTIME_AUTHORITY_TABLE, "tool_bindings_json TEXT");
   const requested = new Set(params.jobIds);
   const jobsById = new Map(params.jobs.map((job) => [job.id, job] as const));
   let repaired = false;

--- a/src/cron/store/runtime-authority-store.ts
+++ b/src/cron/store/runtime-authority-store.ts
@@ -11,18 +11,19 @@ import {
 } from "../../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
+  cronRuntimeAuthorityBindingFingerprint,
+  cronRuntimeAuthorityRowFingerprint,
+} from "../runtime-authority-input.js";
+import {
   normalizeCronPersistedRuntimeAuthority,
   normalizeCronRuntimeAuthority,
   normalizeCronScheduledToolBindings,
   serializeCronRuntimeAuthority,
 } from "../runtime-authority.js";
-import { normalizeCronScheduledToolPolicy } from "../scheduled-tool-policy.js";
-import { cronJobUsesToolRuntime } from "../tools-allow.js";
-import type { CronStoredJob, CronToolsAllowProvenance } from "../types.js";
+import type { CronStoredJob } from "../types.js";
 
 const CRON_RUNTIME_AUTHORITY_TABLE = "cron_job_runtime_authorities";
-const CRON_RUNTIME_AUTHORITY_FINGERPRINT_VERSION = 1;
-const CRON_TOOL_BINDINGS_STORAGE_VERSION = 1;
+const CRON_TOOL_BINDINGS_STORAGE_VERSION = 2;
 
 const CRON_RUNTIME_AUTHORITY_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS cron_job_runtime_authorities (
@@ -60,35 +61,6 @@ function getCronAuthorityKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<CronAuthorityDatabase>(db);
 }
 
-function normalizedToolsAllow(job: CronStoredJob): string[] | null {
-  const toolsAllow = job.payload.toolsAllow;
-  return toolsAllow === undefined ? null : [...toolsAllow].toSorted();
-}
-
-function normalizedToolsAllowProvenance(
-  value: CronToolsAllowProvenance | undefined,
-): CronToolsAllowProvenance | null {
-  return value?.version === 1 && value.source === "final-executable-surface"
-    ? { version: 1, source: "final-executable-surface" }
-    : null;
-}
-
-/** Binds authority to only the canonical inputs that can change its authorization meaning. */
-function cronRuntimeAuthorityInputFingerprint(job: CronStoredJob): string {
-  const scheduledToolPolicy = normalizeCronScheduledToolPolicy(job.scheduledToolPolicy) ?? null;
-  const canonical = {
-    version: CRON_RUNTIME_AUTHORITY_FINGERPRINT_VERSION,
-    usesToolRuntime: cronJobUsesToolRuntime(job),
-    toolsAllow: normalizedToolsAllow(job),
-    toolsAllowIsDefault: job.payload.toolsAllowIsDefault === true,
-    scheduledToolPolicy,
-    toolsAllowProvenance: normalizedToolsAllowProvenance(job.toolsAllowProvenance),
-  };
-  return `v${CRON_RUNTIME_AUTHORITY_FINGERPRINT_VERSION}:${createHash("sha256")
-    .update(JSON.stringify(canonical), "utf8")
-    .digest("hex")}`;
-}
-
 function authorityJsonSha256(authorityJson: string): string {
   return createHash("sha256").update(authorityJson, "utf8").digest("hex");
 }
@@ -96,19 +68,23 @@ function authorityJsonSha256(authorityJson: string): string {
 function serializeStoredToolBindings(
   bindings: ReturnType<typeof normalizeCronScheduledToolBindings>,
   authorityJson: string,
-): string | null {
-  return bindings
-    ? JSON.stringify({
-        version: CRON_TOOL_BINDINGS_STORAGE_VERSION,
-        authoritySha256: authorityJsonSha256(authorityJson),
-        bindings,
-      })
-    : null;
+  authorityInputFingerprint: string,
+  bindingInputFingerprint: string,
+): string {
+  return JSON.stringify({
+    version: CRON_TOOL_BINDINGS_STORAGE_VERSION,
+    authoritySha256: authorityJsonSha256(authorityJson),
+    authorityInputFingerprint,
+    bindingInputFingerprint,
+    bindings: bindings ?? [],
+  });
 }
 
 function parseStoredToolBindings(
   value: unknown,
   authorityJson: string,
+  authorityInputFingerprint: string,
+  bindingInputFingerprint: string,
 ): ReturnType<typeof normalizeCronScheduledToolBindings> {
   // Unshipped raw-array prototypes carry no authority association, so accepting
   // them after a downgrade could restore stale exec authority.
@@ -120,9 +96,18 @@ function parseStoredToolBindings(
     value.version !== CRON_TOOL_BINDINGS_STORAGE_VERSION ||
     !("authoritySha256" in value) ||
     value.authoritySha256 !== authorityJsonSha256(authorityJson) ||
+    !("authorityInputFingerprint" in value) ||
+    value.authorityInputFingerprint !== authorityInputFingerprint ||
+    !("bindingInputFingerprint" in value) ||
+    value.bindingInputFingerprint !== bindingInputFingerprint ||
     !("bindings" in value) ||
     Object.keys(value).some(
-      (key) => key !== "version" && key !== "authoritySha256" && key !== "bindings",
+      (key) =>
+        key !== "version" &&
+        key !== "authoritySha256" &&
+        key !== "authorityInputFingerprint" &&
+        key !== "bindingInputFingerprint" &&
+        key !== "bindings",
     )
   ) {
     return undefined;
@@ -177,24 +162,31 @@ function applyCronRuntimeAuthorityRow(
   delete job.runtimeAuthorityRecoveryRequired;
   if (row.recovery_required === 1) {
     job.runtimeAuthorityRecoveryRequired = true;
-    return "ok";
+    return row.tool_bindings_json == null ? "ok" : "repair";
   }
   const persistedAuthority = normalizeCronPersistedRuntimeAuthority(
     safeParseJson(row.authority_json ?? ""),
   );
   const authorityJson = row.authority_json ?? "";
+  const authorityInputFingerprint = cronRuntimeAuthorityRowFingerprint(job);
+  const bindingInputFingerprint = cronRuntimeAuthorityBindingFingerprint(job);
   const toolBindings =
     row.tool_bindings_json == null
       ? undefined
-      : parseStoredToolBindings(safeParseJson(row.tool_bindings_json), authorityJson);
+      : parseStoredToolBindings(
+          safeParseJson(row.tool_bindings_json),
+          authorityJson,
+          authorityInputFingerprint,
+          bindingInputFingerprint,
+        );
   const authority =
     persistedAuthority && (row.tool_bindings_json == null || toolBindings)
       ? normalizeCronRuntimeAuthority({
           ...persistedAuthority,
-          ...(toolBindings ? { toolBindings } : {}),
+          ...(toolBindings?.length ? { toolBindings } : {}),
         })
       : undefined;
-  if (!authority || row.authority_input_fingerprint !== cronRuntimeAuthorityInputFingerprint(job)) {
+  if (!authority || row.authority_input_fingerprint !== authorityInputFingerprint) {
     job.runtimeAuthorityRecoveryRequired = true;
     return "repair";
   }
@@ -303,8 +295,14 @@ export function replaceCronRuntimeAuthorityRows(params: {
         continue;
       }
       const authorityJson = JSON.stringify(persistedAuthority);
-      const toolBindingsJson = serializeStoredToolBindings(authority.toolBindings, authorityJson);
-      const authorityInputFingerprint = cronRuntimeAuthorityInputFingerprint(job);
+      const authorityInputFingerprint = cronRuntimeAuthorityRowFingerprint(job);
+      const bindingInputFingerprint = cronRuntimeAuthorityBindingFingerprint(job);
+      const toolBindingsJson = serializeStoredToolBindings(
+        authority.toolBindings,
+        authorityJson,
+        authorityInputFingerprint,
+        bindingInputFingerprint,
+      );
       executeSqliteQuerySync(
         params.db,
         database

--- a/src/cron/store/runtime-authority-store.ts
+++ b/src/cron/store/runtime-authority-store.ts
@@ -4,7 +4,11 @@ import type { DatabaseSync } from "node:sqlite";
 import { safeParseJson } from "@openclaw/normalization-core";
 import type { Selectable } from "kysely";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
-import { ensureColumn, tableExists } from "../../state/openclaw-state-db-schema-helpers.js";
+import {
+  ensureColumn,
+  tableExists,
+  tableHasColumn,
+} from "../../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
   normalizeCronPersistedRuntimeAuthority,
@@ -89,6 +93,19 @@ function authorityJsonSha256(authorityJson: string): string {
   return createHash("sha256").update(authorityJson, "utf8").digest("hex");
 }
 
+function serializeStoredToolBindings(
+  bindings: ReturnType<typeof normalizeCronScheduledToolBindings>,
+  authorityJson: string,
+): string | null {
+  return bindings
+    ? JSON.stringify({
+        version: CRON_TOOL_BINDINGS_STORAGE_VERSION,
+        authoritySha256: authorityJsonSha256(authorityJson),
+        bindings,
+      })
+    : null;
+}
+
 function parseStoredToolBindings(
   value: unknown,
   authorityJson: string,
@@ -127,13 +144,46 @@ function loadCronRuntimeAuthorityRows(
   if (!tableExists(db, CRON_RUNTIME_AUTHORITY_TABLE)) {
     return [];
   }
+  const database = getCronAuthorityKysely(db);
+  if (tableHasColumn(db, CRON_RUNTIME_AUTHORITY_TABLE, "tool_bindings_json")) {
+    return executeSqliteQuerySync(
+      db,
+      database
+        .selectFrom("cron_job_runtime_authorities")
+        .selectAll()
+        .where("store_key", "=", storeKey),
+    ).rows;
+  }
   return executeSqliteQuerySync(
     db,
-    getCronAuthorityKysely(db)
+    database
       .selectFrom("cron_job_runtime_authorities")
-      .selectAll()
+      .select([
+        "store_key",
+        "job_id",
+        "authority_json",
+        "authority_input_fingerprint",
+        "recovery_required",
+      ])
       .where("store_key", "=", storeKey),
-  ).rows;
+  ).rows.map((row) => {
+    const legacyAuthority = normalizeCronRuntimeAuthority(safeParseJson(row.authority_json ?? ""));
+    const persistedAuthority = legacyAuthority
+      ? serializeCronRuntimeAuthority(legacyAuthority)
+      : undefined;
+    if (!legacyAuthority || !persistedAuthority) {
+      return Object.assign(row, { tool_bindings_json: null });
+    }
+    const authorityJson = JSON.stringify(persistedAuthority);
+    const toolBindingsJson = serializeStoredToolBindings(
+      legacyAuthority.toolBindings,
+      authorityJson,
+    );
+    return Object.assign(row, {
+      authority_json: authorityJson,
+      tool_bindings_json: toolBindingsJson,
+    });
+  });
 }
 
 function applyCronRuntimeAuthorityRow(
@@ -269,13 +319,7 @@ export function replaceCronRuntimeAuthorityRows(params: {
         continue;
       }
       const authorityJson = JSON.stringify(persistedAuthority);
-      const toolBindingsJson = authority.toolBindings
-        ? JSON.stringify({
-            version: CRON_TOOL_BINDINGS_STORAGE_VERSION,
-            authoritySha256: authorityJsonSha256(authorityJson),
-            bindings: authority.toolBindings,
-          })
-        : null;
+      const toolBindingsJson = serializeStoredToolBindings(authority.toolBindings, authorityJson);
       const authorityInputFingerprint = cronRuntimeAuthorityInputFingerprint(job);
       executeSqliteQuerySync(
         params.db,

--- a/src/cron/trigger-script.test.ts
+++ b/src/cron/trigger-script.test.ts
@@ -92,9 +92,44 @@ describe("cron trigger script evaluator", () => {
         script: 'await exec({ command: "printf openclaw-cron-alias-ok" }); return { fire: false };',
         state: null,
         toolsAllow: ["gateway_exec", "gateway_process"],
+        runtimeAuthority: {
+          version: 1,
+          runtimeId: "codex",
+          namespace: "scheduled-tools",
+          payload: { version: 1 },
+          toolBindings: [
+            {
+              sourceTool: "gateway_exec",
+              targetTool: "exec",
+              execTarget: { host: "gateway" },
+            },
+            { sourceTool: "gateway_process", targetTool: "process" },
+          ],
+        },
         scheduledToolPolicy: { version: 1, mode: "trusted" },
       }),
     ).resolves.toEqual({ kind: "evaluated", fire: false });
+  });
+
+  it("does not project a colliding raw alias without producer-bound authority", async () => {
+    const workspaceDir = tempDirs.make("openclaw-cron-codex-alias-collision-");
+    const evaluate = createCronScriptRuntime({
+      config: {
+        agents: { defaults: { workspace: workspaceDir } },
+        tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+      } as OpenClawConfig,
+    }).evaluateTrigger;
+
+    const result = await evaluate({
+      jobId: "job-colliding-gateway-exec",
+      script: 'await exec({ command: "printf must-not-run" }); return { fire: false };',
+      state: null,
+      toolsAllow: ["gateway_exec"],
+      scheduledToolPolicy: { version: 1, mode: "trusted" },
+    });
+
+    expect(result).toMatchObject({ kind: "error", code: "internal_error" });
+    expect(result.kind === "error" ? result.error : "").toContain("exec is not defined");
   });
 
   it.each(["node_exec", "sandbox_exec"])(

--- a/src/cron/trigger-script.test.ts
+++ b/src/cron/trigger-script.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { wrapToolWithBeforeToolCallHook } from "../agents/agent-tools.before-tool-call.js";
 import { BEFORE_TOOL_CALL_HOOK_CONTEXT } from "../agents/before-tool-call-metadata.js";
 import type { CodeModeHeadlessResult } from "../agents/code-mode.js";
@@ -11,6 +12,7 @@ type HeadlessParams = Parameters<NonNullable<EvaluatorDeps["runHeadless"]>>[0];
 type PrepareParams = Parameters<NonNullable<EvaluatorDeps["prepareRuntime"]>>[0];
 
 const beforeToolCallTesting = { BEFORE_TOOL_CALL_HOOK_CONTEXT };
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function completed(params: { value: unknown; output?: unknown[] }): CodeModeHeadlessResult {
   return {
@@ -69,6 +71,55 @@ function createCronTriggerEvaluator(deps: EvaluatorDeps) {
 }
 
 describe("cron trigger script evaluator", () => {
+  it("executes a gateway-pinned creator alias through the documented exec name", async () => {
+    const workspaceDir = tempDirs.make("openclaw-cron-codex-alias-");
+    const config = {
+      agents: { defaults: { workspace: workspaceDir } },
+      tools: {
+        exec: {
+          host: "node",
+          node: "configured-node-must-not-run",
+          security: "full",
+          ask: "off",
+        },
+      },
+    } as OpenClawConfig;
+    const evaluate = createCronScriptRuntime({ config }).evaluateTrigger;
+
+    await expect(
+      evaluate({
+        jobId: "job-codex-exec-alias",
+        script: 'await exec({ command: "printf openclaw-cron-alias-ok" }); return { fire: false };',
+        state: null,
+        toolsAllow: ["gateway_exec", "gateway_process"],
+        scheduledToolPolicy: { version: 1, mode: "trusted" },
+      }),
+    ).resolves.toEqual({ kind: "evaluated", fire: false });
+  });
+
+  it.each(["node_exec", "sandbox_exec"])(
+    "does not widen %s into generic exec authority",
+    async (creatorAlias) => {
+      const workspaceDir = tempDirs.make("openclaw-cron-codex-alias-denied-");
+      const config = {
+        agents: { defaults: { workspace: workspaceDir } },
+        tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+      } as OpenClawConfig;
+      const evaluate = createCronScriptRuntime({ config }).evaluateTrigger;
+
+      const result = await evaluate({
+        jobId: `job-codex-${creatorAlias}`,
+        script: 'await exec({ command: "printf must-not-run" }); return { fire: false };',
+        state: null,
+        toolsAllow: [creatorAlias],
+        scheduledToolPolicy: { version: 1, mode: "trusted" },
+      });
+
+      expect(result).toMatchObject({ kind: "error", code: "internal_error" });
+      expect(result.kind === "error" ? result.error : "").toContain("exec is not defined");
+    },
+  );
+
   it("prefers a valid returned value and injects trigger state", async () => {
     const runHeadless = vi.fn(async (_params: HeadlessParams) =>
       completed({

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -26,6 +26,7 @@ import {
   applyEmbeddedAttemptToolsAllow,
   resolveEmbeddedAttemptToolConstructionPlan,
 } from "../agents/embedded-agent-runner/run/attempt-tool-construction-plan.js";
+import { pinExecToolTarget } from "../agents/exec-tool-target-pinning.js";
 import { loadAgentRuntimePluginRegistryHandle } from "../agents/runtime-plugins.js";
 import { resolveSandboxContext } from "../agents/sandbox.js";
 import {
@@ -65,6 +66,8 @@ const MAX_TRIGGER_STATE_BYTES = 16 * 1024;
 const MAX_CACHED_TRIGGER_RUNTIMES = 128;
 const HEADLESS_TRIGGER_WALL_CLOCK_MS = 30_000;
 const HEADLESS_TRIGGER_TOOL_BUDGET = 5;
+const GATEWAY_EXEC_CREATOR_ALIAS = "gateway_exec";
+const GATEWAY_PROCESS_CREATOR_ALIAS = "gateway_process";
 
 let activeTriggerEvaluations = 0;
 
@@ -109,6 +112,24 @@ type TriggerRuntimeCacheEntry = {
 
 function resolveTriggerAgentId(config: OpenClawConfig, agentId?: string): string {
   return agentId?.trim() ? normalizeAgentId(agentId) : resolveDefaultAgentId(config);
+}
+
+function projectTriggerToolAuthority(toolsAllow: string[] | undefined): {
+  toolsAllow: string[] | undefined;
+  pinGatewayExec: boolean;
+} {
+  if (!toolsAllow?.includes(GATEWAY_EXEC_CREATOR_ALIAS)) {
+    return { toolsAllow, pinGatewayExec: false };
+  }
+  const projected = new Set(
+    toolsAllow.map((name) => {
+      if (name === GATEWAY_EXEC_CREATOR_ALIAS) {
+        return "exec";
+      }
+      return name === GATEWAY_PROCESS_CREATOR_ALIAS ? "process" : name;
+    }),
+  );
+  return { toolsAllow: [...projected], pinGatewayExec: true };
 }
 
 async function prepareTriggerRuntime(params: {
@@ -158,16 +179,20 @@ async function prepareTriggerRuntime(params: {
     params.signal?.throwIfAborted();
     const effectiveWorkspace =
       sandbox?.enabled && sandbox.workspaceAccess !== "rw" ? sandbox.workspaceDir : workspaceDir;
+    const projectedAuthority = projectTriggerToolAuthority(params.toolsAllow);
     const toolPlan = resolveEmbeddedAttemptToolConstructionPlan({
       toolsEnabled: true,
-      toolsAllow: params.toolsAllow,
+      toolsAllow: projectedAuthority.toolsAllow,
     });
     // Bundle MCP tools are source:"mcp", which the headless bridge excludes.
     // LSP runtimes are session-scoped and intentionally outside trigger v1.
     const allTools = toolPlan.constructTools
       ? createOpenClawCodingTools({
           agentId,
-          exec: { config },
+          exec: {
+            config,
+            ...(projectedAuthority.pinGatewayExec ? { host: "gateway" as const } : {}),
+          },
           sandbox,
           sessionKey,
           trigger: "cron",
@@ -182,15 +207,24 @@ async function prepareTriggerRuntime(params: {
           runtimeToolAllowlist: toolPlan.runtimeToolAllowlist,
           inheritRuntimeToolAllowlist: Boolean(toolPlan.runtimeToolAllowlist),
           scheduledToolPolicy: resolveScheduledToolPolicyContext({
-            toolsAllow: params.toolsAllow,
+            toolsAllow: projectedAuthority.toolsAllow,
             scheduledToolPolicy: params.scheduledToolPolicy,
           }),
           toolConstructionPlan: toolPlan.codingToolConstructionPlan,
         })
       : [];
-    const tools = applyEmbeddedAttemptToolsAllow(allTools, params.toolsAllow, {
-      toolMeta: (tool) => getPluginToolMeta(tool),
-    });
+    const authorityBoundTools = projectedAuthority.pinGatewayExec
+      ? allTools.map((tool) =>
+          tool.name === "exec" ? pinExecToolTarget(tool, { host: "gateway" }) : tool,
+        )
+      : allTools;
+    const tools = applyEmbeddedAttemptToolsAllow(
+      authorityBoundTools,
+      projectedAuthority.toolsAllow,
+      {
+        toolMeta: (tool) => getPluginToolMeta(tool),
+      },
+    );
     const hookContext: HookContext = {
       agentId,
       config,

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -53,6 +53,7 @@ import {
   resolveCronAgentConfig,
 } from "./isolated-agent/run-config.js";
 import { resolveCronAgentSessionKey } from "./isolated-agent/session-key.js";
+import type { CronRuntimeAuthority } from "./runtime-authority.js";
 import {
   DEFAULT_CRON_SCRIPT_TIMEOUT_SECONDS,
   DEFAULT_CRON_SCRIPT_TOOL_BUDGET,
@@ -66,8 +67,6 @@ const MAX_TRIGGER_STATE_BYTES = 16 * 1024;
 const MAX_CACHED_TRIGGER_RUNTIMES = 128;
 const HEADLESS_TRIGGER_WALL_CLOCK_MS = 30_000;
 const HEADLESS_TRIGGER_TOOL_BUDGET = 5;
-const GATEWAY_EXEC_CREATOR_ALIAS = "gateway_exec";
-const GATEWAY_PROCESS_CREATOR_ALIAS = "gateway_process";
 
 let activeTriggerEvaluations = 0;
 
@@ -93,6 +92,7 @@ type PrepareTriggerRuntime = (params: {
   jobId: string;
   agentId?: string;
   toolsAllow?: string[];
+  runtimeAuthority?: CronRuntimeAuthority;
   scheduledToolPolicy?: ScheduledToolPolicyContext;
   signal?: AbortSignal;
 }) => Promise<PreparedTriggerRuntime>;
@@ -114,22 +114,30 @@ function resolveTriggerAgentId(config: OpenClawConfig, agentId?: string): string
   return agentId?.trim() ? normalizeAgentId(agentId) : resolveDefaultAgentId(config);
 }
 
-function projectTriggerToolAuthority(toolsAllow: string[] | undefined): {
+function projectTriggerToolAuthority(
+  toolsAllow: string[] | undefined,
+  runtimeAuthority: CronRuntimeAuthority | undefined,
+): {
   toolsAllow: string[] | undefined;
   pinGatewayExec: boolean;
 } {
-  if (!toolsAllow?.includes(GATEWAY_EXEC_CREATOR_ALIAS)) {
+  if (!toolsAllow || !runtimeAuthority?.toolBindings?.length) {
     return { toolsAllow, pinGatewayExec: false };
   }
+  const bindingsBySource = new Map(
+    runtimeAuthority.toolBindings.map((binding) => [binding.sourceTool, binding]),
+  );
+  let pinGatewayExec = false;
   const projected = new Set(
     toolsAllow.map((name) => {
-      if (name === GATEWAY_EXEC_CREATOR_ALIAS) {
-        return "exec";
+      const binding = bindingsBySource.get(name);
+      if (binding?.targetTool === "exec") {
+        pinGatewayExec = binding.execTarget.host === "gateway";
       }
-      return name === GATEWAY_PROCESS_CREATOR_ALIAS ? "process" : name;
+      return binding?.targetTool ?? name;
     }),
   );
-  return { toolsAllow: [...projected], pinGatewayExec: true };
+  return { toolsAllow: [...projected], pinGatewayExec };
 }
 
 async function prepareTriggerRuntime(params: {
@@ -137,6 +145,7 @@ async function prepareTriggerRuntime(params: {
   jobId: string;
   agentId?: string;
   toolsAllow?: string[];
+  runtimeAuthority?: CronRuntimeAuthority;
   scheduledToolPolicy?: ScheduledToolPolicyContext;
   signal?: AbortSignal;
 }): Promise<PreparedTriggerRuntime> {
@@ -179,7 +188,10 @@ async function prepareTriggerRuntime(params: {
     params.signal?.throwIfAborted();
     const effectiveWorkspace =
       sandbox?.enabled && sandbox.workspaceAccess !== "rw" ? sandbox.workspaceDir : workspaceDir;
-    const projectedAuthority = projectTriggerToolAuthority(params.toolsAllow);
+    const projectedAuthority = projectTriggerToolAuthority(
+      params.toolsAllow,
+      params.runtimeAuthority,
+    );
     const toolPlan = resolveEmbeddedAttemptToolConstructionPlan({
       toolsEnabled: true,
       toolsAllow: projectedAuthority.toolsAllow,
@@ -381,6 +393,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
     requestedAgentId?: string;
     agentId: string;
     toolsAllow?: string[];
+    runtimeAuthority?: CronRuntimeAuthority;
     scheduledToolPolicy?: ScheduledToolPolicyContext;
     toolsAllowKey: string;
     signal: AbortSignal;
@@ -416,6 +429,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
       jobId: request.jobId,
       agentId: request.requestedAgentId,
       toolsAllow: request.toolsAllow,
+      runtimeAuthority: request.runtimeAuthority,
       scheduledToolPolicy: request.scheduledToolPolicy,
       signal: request.signal,
     });
@@ -442,6 +456,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
     agentId?: string;
     script: string;
     toolsAllow?: string[];
+    runtimeAuthority?: CronRuntimeAuthority;
     scheduledToolPolicy?: ScheduledToolPolicyContext;
     abortSignal?: AbortSignal;
     wallClockMs: number;
@@ -462,6 +477,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
       const agentId = resolveTriggerAgentId(runtimeConfig, params.agentId);
       const toolsAllowKey = JSON.stringify([
         params.toolsAllow ?? null,
+        params.runtimeAuthority?.toolBindings ?? null,
         params.scheduledToolPolicy ?? null,
       ]);
       const runtime = await resolveCachedRuntime({
@@ -470,6 +486,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
         requestedAgentId: params.agentId,
         agentId,
         toolsAllow: params.toolsAllow,
+        runtimeAuthority: params.runtimeAuthority,
         scheduledToolPolicy: params.scheduledToolPolicy,
         toolsAllowKey,
         signal: evaluationScope.signal,
@@ -643,6 +660,7 @@ export function createCronScriptRuntime(deps: CronTriggerEvaluatorDeps) {
       state: unknown;
       streamBatch?: string;
       toolsAllow?: string[];
+      runtimeAuthority?: CronRuntimeAuthority;
       scheduledToolPolicy?: ScheduledToolPolicyContext;
       abortSignal?: AbortSignal;
     }): Promise<CronTriggerEvaluationResult> => {
@@ -670,6 +688,7 @@ export function createCronScriptRuntime(deps: CronTriggerEvaluatorDeps) {
       state: unknown;
       streamBatch?: string;
       toolsAllow?: string[];
+      runtimeAuthority?: CronRuntimeAuthority;
       scheduledToolPolicy?: ScheduledToolPolicyContext;
       timeoutSeconds?: number;
       toolBudget?: number;

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -726,6 +726,7 @@ export function buildGatewayCronService(params: {
               state,
               streamBatch,
               toolsAllow: job.payload.toolsAllow,
+              runtimeAuthority: job.runtimeAuthority,
               scheduledToolPolicy: resolveCronScheduledToolPolicy({
                 toolsAllow: job.payload.toolsAllow,
                 scheduledToolPolicy: job.scheduledToolPolicy,
@@ -927,6 +928,7 @@ export function buildGatewayCronService(params: {
         state: job.state.triggerState,
         streamBatch,
         toolsAllow: job.payload.toolsAllow,
+        runtimeAuthority: job.runtimeAuthority,
         scheduledToolPolicy: resolveCronScheduledToolPolicy({
           toolsAllow: job.payload.toolsAllow,
           scheduledToolPolicy: job.scheduledToolPolicy,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -8,6 +8,7 @@ import {
   tryResolveAmbientOwnerAgentId,
 } from "../agents/agent-scope.js";
 import { abortAndDrainEmbeddedAgentRun } from "../agents/embedded-agent.js";
+import { resolveScheduledToolPolicyContext } from "../agents/scheduled-tool-policy.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { getRuntimeConfig } from "../config/io.js";
@@ -55,7 +56,7 @@ import {
 import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
 import { cronStreamScheduleKey } from "../cron/stream-schedule.js";
 import { createCronScriptRuntime } from "../cron/trigger-script.js";
-import type { CronJob, CronPayload } from "../cron/types.js";
+import type { CronJob, CronPayload, CronStoredJob } from "../cron/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveMainScopedEventSessionKey } from "../infra/event-session-routing.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
@@ -107,6 +108,19 @@ import {
 } from "./session-automation-index.js";
 import { buildGatewaySessionEventFields } from "./session-event-payload.js";
 import { loadGatewaySessionRow } from "./session-utils.js";
+
+function resolveCronJobScheduledToolPolicyContext(job: CronStoredJob) {
+  const scheduledToolPolicy = resolveCronScheduledToolPolicy({
+    toolsAllow: job.payload.toolsAllow,
+    scheduledToolPolicy: job.scheduledToolPolicy,
+    owner: job.owner,
+  });
+  return resolveScheduledToolPolicyContext({
+    toolsAllow: job.payload.toolsAllow,
+    scheduledToolPolicy,
+    callerOrigin: job.toolsAllowProvenance?.callerOrigin,
+  });
+}
 
 export type GatewayCronState = {
   cron: GatewayCronServiceContract;
@@ -727,11 +741,7 @@ export function buildGatewayCronService(params: {
               streamBatch,
               toolsAllow: job.payload.toolsAllow,
               runtimeAuthority: job.runtimeAuthority,
-              scheduledToolPolicy: resolveCronScheduledToolPolicy({
-                toolsAllow: job.payload.toolsAllow,
-                scheduledToolPolicy: job.scheduledToolPolicy,
-                owner: job.owner,
-              }),
+              scheduledToolPolicy: resolveCronJobScheduledToolPolicyContext(job),
               abortSignal,
             }),
         }
@@ -929,11 +939,7 @@ export function buildGatewayCronService(params: {
         streamBatch,
         toolsAllow: job.payload.toolsAllow,
         runtimeAuthority: job.runtimeAuthority,
-        scheduledToolPolicy: resolveCronScheduledToolPolicy({
-          toolsAllow: job.payload.toolsAllow,
-          scheduledToolPolicy: job.scheduledToolPolicy,
-          owner: job.owner,
-        }),
+        scheduledToolPolicy: resolveCronJobScheduledToolPolicyContext(job),
         timeoutSeconds: job.payload.timeoutSeconds,
         toolBudget: job.payload.toolBudget,
         abortSignal,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -711,6 +711,7 @@ export function buildGatewayCronService(params: {
               state,
               streamBatch,
               toolsAllow: job.payload.toolsAllow,
+              runtimeAuthority: job.runtimeAuthority,
               scheduledToolPolicy: resolveCronScheduledToolPolicy({
                 toolsAllow: job.payload.toolsAllow,
                 scheduledToolPolicy: job.scheduledToolPolicy,
@@ -912,6 +913,7 @@ export function buildGatewayCronService(params: {
         state: job.state.triggerState,
         streamBatch,
         toolsAllow: job.payload.toolsAllow,
+        runtimeAuthority: job.runtimeAuthority,
         scheduledToolPolicy: resolveCronScheduledToolPolicy({
           toolsAllow: job.payload.toolsAllow,
           scheduledToolPolicy: job.scheduledToolPolicy,

--- a/src/plugin-sdk/codex-mcp-projection.test.ts
+++ b/src/plugin-sdk/codex-mcp-projection.test.ts
@@ -1,0 +1,34 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import type { AnyAgentTool } from "../agents/tools/common.js";
+
+describe("codex MCP projection", () => {
+  it("does not expose scheduled authority minting", async () => {
+    const projection = await import("./codex-mcp-projection.js");
+
+    expect(projection).not.toHaveProperty("bindCronScheduledTool");
+  });
+
+  it("does not capture a colliding plugin-created gateway exec tool", async () => {
+    const projection = await import("./codex-mcp-projection.js");
+    const tools: Array<string | { name: string; pluginId?: string }> = [];
+    const captureRef: { value?: { version: 1; source: "final-executable-surface" } } = {};
+    const collidingTool = {
+      name: "gateway_exec",
+      label: "Plugin gateway exec",
+      description: "A plugin-created tool with the same name as the Codex alias.",
+      parameters: Type.Object({}),
+      execute: async () => ({ content: [], details: {} }),
+    } satisfies AnyAgentTool;
+
+    const authority = await projection.captureFinalCodexCronCreatorToolAllowlist(
+      tools,
+      captureRef,
+      [collidingTool],
+    );
+
+    expect(tools).toEqual([{ name: "gateway_exec" }]);
+    expect(captureRef.value).toEqual({ version: 1, source: "final-executable-surface" });
+    expect(authority).toBeUndefined();
+  });
+});

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -2,13 +2,18 @@
 // runtime's user-mcp-server projection so the bundled Codex app-server harness
 // can attach the same user `mcp.servers` entries to its thread config without
 // deep-importing core helpers.
+import {
+  bindCronScheduledTool,
+  getCronScheduledToolBinding,
+  pinExecToolTarget,
+} from "../agents/exec-tool-target-pinning.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type {
   CronCreatorToolAllowlistEntry,
   CronToolsAllowCaptureRef,
 } from "../agents/tools/cron-tool.types.js";
 
-export { pinExecToolTarget } from "../agents/exec-tool-target-pinning.js";
+export { bindCronScheduledTool, getCronScheduledToolBinding, pinExecToolTarget };
 export {
   buildCodexUserMcpServersThreadConfigPatch,
   buildCodexUserMcpServersThreadConfigPatchForRuntime,
@@ -38,5 +43,11 @@ export async function captureFinalCodexCronCreatorToolAllowlist(
 ) {
   const [{ captureFinalEffectiveCronCreatorToolAllowlist: capture }, { getPluginToolMeta }] =
     await Promise.all([import("../agents/tools/cron-tool.js"), import("../plugins/tools.js")]);
-  return capture(target, captureRef, tools, (tool) => getPluginToolMeta(tool));
+  return capture(target, captureRef, tools, (tool) => {
+    const scheduledToolBinding = getCronScheduledToolBinding(tool);
+    return {
+      ...getPluginToolMeta(tool),
+      ...(scheduledToolBinding ? { scheduledToolBinding } : {}),
+    };
+  });
 }

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -8,6 +8,7 @@ import type {
   CronToolsAllowCaptureRef,
 } from "../agents/tools/cron-tool.types.js";
 
+export { pinExecToolTarget } from "../agents/exec-tool-target-pinning.js";
 export {
   buildCodexUserMcpServersThreadConfigPatch,
   buildCodexUserMcpServersThreadConfigPatchForRuntime,

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -3,8 +3,7 @@
 // can attach the same user `mcp.servers` entries to its thread config without
 // deep-importing core helpers.
 import {
-  bindCronScheduledTool,
-  getCronScheduledToolBinding,
+  captureCronScheduledToolAuthority,
   pinExecToolTarget,
 } from "../agents/exec-tool-target-pinning.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
@@ -13,7 +12,7 @@ import type {
   CronToolsAllowCaptureRef,
 } from "../agents/tools/cron-tool.types.js";
 
-export { bindCronScheduledTool, getCronScheduledToolBinding, pinExecToolTarget };
+export { pinExecToolTarget };
 export {
   buildCodexUserMcpServersThreadConfigPatch,
   buildCodexUserMcpServersThreadConfigPatchForRuntime,
@@ -43,11 +42,11 @@ export async function captureFinalCodexCronCreatorToolAllowlist(
 ) {
   const [{ captureFinalEffectiveCronCreatorToolAllowlist: capture }, { getPluginToolMeta }] =
     await Promise.all([import("../agents/tools/cron-tool.js"), import("../plugins/tools.js")]);
-  return capture(target, captureRef, tools, (tool) => {
-    const scheduledToolBinding = getCronScheduledToolBinding(tool);
-    return {
-      ...getPluginToolMeta(tool),
-      ...(scheduledToolBinding ? { scheduledToolBinding } : {}),
-    };
+  capture(target, captureRef, tools, (tool) => getPluginToolMeta(tool));
+  return captureCronScheduledToolAuthority(tools, {
+    version: 1,
+    runtimeId: "codex",
+    namespace: "scheduled-tools",
+    payload: { version: 1 },
   });
 }

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -6,6 +6,11 @@ import {
   captureCronScheduledToolAuthority,
   pinExecToolTarget,
 } from "../agents/exec-tool-target-pinning.js";
+import type { AgentHarnessHostCapabilities } from "../agents/harness/host-capability-types.js";
+import {
+  resolveAgentHarnessScheduledToolProjectionCapability,
+  type AgentHarnessScheduledToolProjectionFactory,
+} from "../agents/harness/host-private-capabilities.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type {
   CronCreatorToolAllowlistEntry,
@@ -13,6 +18,7 @@ import type {
 } from "../agents/tools/cron-tool.types.js";
 
 export { pinExecToolTarget };
+export type CodexScheduledToolProjectionFactory = AgentHarnessScheduledToolProjectionFactory;
 export {
   buildCodexUserMcpServersThreadConfigPatch,
   buildCodexUserMcpServersThreadConfigPatchForRuntime,
@@ -22,6 +28,16 @@ export {
   runWithCronCreatorAuthorityCapabilityResolver,
   runWithCronCreatorAuthorityResolver,
 } from "../agents/cron-creator-authority-context.js";
+
+/** Resolve the private scheduled-tool issuer for the registered Codex harness owner. */
+export function resolveCodexScheduledToolProjectionFactory(
+  hostCapabilities: AgentHarnessHostCapabilities,
+): CodexScheduledToolProjectionFactory | undefined {
+  return resolveAgentHarnessScheduledToolProjectionCapability({
+    hostCapabilities,
+    ownerPluginId: "codex",
+  });
+}
 
 /** Materialize static configured MCP under a scheduled Codex authority envelope. */
 export async function materializeStaticMcpToolsForScheduledHarnessRun(

--- a/src/state/openclaw-database-maintenance.test.ts
+++ b/src/state/openclaw-database-maintenance.test.ts
@@ -185,6 +185,7 @@ describe("OpenClaw database maintenance schema validation", () => {
       "device_bootstrap_tokens.setup_id TEXT",
       "session_groups.cwd TEXT",
       "session_groups.worktree INTEGER",
+      "cron_job_runtime_authorities.tool_bindings_json TEXT",
       "installed_plugin_index.workspace_dir TEXT",
       "secret_store_entries.allowed_hosts TEXT",
       "skill_workshop_proposals.claim_released_time INTEGER",

--- a/src/state/openclaw-state-db-additive-columns.ts
+++ b/src/state/openclaw-state-db-additive-columns.ts
@@ -37,6 +37,11 @@ export const CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS = [
   { columnName: "setup_id", dataType: "TEXT", tableName: "device_bootstrap_tokens" },
   { columnName: "cwd", dataType: "TEXT", tableName: "session_groups" },
   { columnName: "worktree", dataType: "INTEGER", tableName: "session_groups" },
+  {
+    columnName: "tool_bindings_json",
+    dataType: "TEXT",
+    tableName: "cron_job_runtime_authorities",
+  },
   { columnName: "workspace_dir", dataType: "TEXT", tableName: "installed_plugin_index" },
   { columnName: "allowed_hosts", dataType: "TEXT", tableName: "secret_store_entries" },
   {
@@ -53,6 +58,7 @@ function isFirstUseAdditiveStateColumn({
   return (
     (tableName === "device_bootstrap_tokens" && columnName === "setup_id") ||
     (tableName === "skill_workshop_proposals" && columnName === "claim_released_time") ||
+    (tableName === "cron_job_runtime_authorities" && columnName === "tool_bindings_json") ||
     (tableName === "worker_session_placement_moves" &&
       (columnName === "abandon_source" || columnName === "target_machine_class")) ||
     (tableName === "session_groups" && (columnName === "cwd" || columnName === "worktree"))

--- a/src/state/openclaw-state-db.generated.d.ts
+++ b/src/state/openclaw-state-db.generated.d.ts
@@ -401,6 +401,7 @@ export interface CronJobRuntimeAuthorities {
   job_id: string;
   recovery_required: number;
   store_key: string;
+  tool_bindings_json: string | null;
 }
 
 export interface CronJobScratch {

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1628,6 +1628,7 @@ CREATE TABLE IF NOT EXISTS cron_job_runtime_authorities (
   store_key TEXT NOT NULL,
   job_id TEXT NOT NULL,
   authority_json TEXT,
+  tool_bindings_json TEXT,
   authority_input_fingerprint TEXT,
   recovery_required INTEGER NOT NULL,
   PRIMARY KEY (store_key, job_id),

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1623,6 +1623,7 @@ CREATE TABLE IF NOT EXISTS cron_job_runtime_authorities (
   store_key TEXT NOT NULL,
   job_id TEXT NOT NULL,
   authority_json TEXT,
+  tool_bindings_json TEXT,
   authority_input_fingerprint TEXT,
   recovery_required INTEGER NOT NULL,
   PRIMARY KEY (store_key, job_id),


### PR DESCRIPTION
Related: #92238

## What Problem This Solves

Fixes cron triggers created from a Codex-backed turn failing with `Unknown tool id: exec` when they use the documented `exec(...)` contract.

It also preserves the creator's execution boundary: a Codex Gateway alias must remain Gateway-pinned, and an unrelated tool that happens to use the same name must not acquire shell authority.

## Why This Change Was Made

Codex exposes constrained shell capabilities under runtime-specific names such as `gateway_exec`. Creator capture records a host-owned scheduled-tool binding from the concrete Codex alias object.

At trigger evaluation, cron projects a runtime-specific name to script-facing `exec` or `process` only when that validated binding is present. Reconstructed exec remains pinned to `host: gateway`; host, node, security, and approval overrides are removed from its schema and ignored at runtime. A raw or colliding `gateway_exec` name without the producer-bound binding fails closed.

The original four-key `authority_json` shape remains unchanged for older readers. Bindings are stored in a nullable `tool_bindings_json TEXT` sidecar column and sealed to the exact authority JSON with SHA-256. Older upserts omit and preserve that column. If an older writer replaces the authority, the seal no longer matches and the new reader retires the authority instead of attaching stale shell authority.

Predecessor tables without the sidecar load only the shipped four-key authority envelope. Inline `toolBindings` are rejected as unsealed input and trigger fail-closed recovery; they are never converted into executable authority. Writable recovery adds the nullable column in the recovery transaction before recording `recovery_required`. Read-only loads never mutate the database.

Node and sandbox aliases remain unavailable because their exact creator-time bindings cannot be reconstructed safely.

This PR is AI-assisted. I reviewed the implementation and validation results and understand the change.

## User Impact

Cron triggers created from a Gateway-pinned Codex session can call `exec(...)` without manually widening the job's tool allowlist. The command remains pinned to the Gateway even when cron's configured default exec host differs. Same-name non-Codex tools, unsealed predecessor bindings, stale downgrade-era bindings, node aliases, and sandbox aliases fail closed.

## Evidence

Before the fix, automation `9fed2dac-f5fc-431d-903f-8479b1cf279d` recorded five consecutive trigger-evaluation failures with `Unknown tool id: exec`; no payload turn ran.

Validation on commit `0a478dac8df`:

- Focused persistence, trigger, read-only compatibility, and Codex capture suites: 109/109 tests passed.
- A shipped four-key predecessor row loads without bindings in both read-only and writable paths.
- An unsealed predecessor row containing inline `toolBindings` is durably retired with `recovery_required = 1`; the trigger cannot resolve `exec`, and filesystem verification returns `ENOENT` for the forbidden marker.
- The predecessor-schema recovery regression failed before the repair with `table cron_job_runtime_authorities has no column named tool_bindings_json`; after the repair it adds the sidecar and durably records recovery.
- Sealed persisted-authority final-effect proof: the allowed restored binding executed Gateway-pinned `exec` and wrote an `allowed` marker. After changing persisted `authority_json` so the sidecar seal no longer matched, reload removed runtime authority and recorded recovery; rerunning the same `gateway_exec`-capped job returned `exec is not defined`, and filesystem verification returned `ENOENT` for the forbidden marker.
- Core production typecheck passed.
- Targeted core lint passed with 0 warnings/errors; focused formatting and diff checks passed.
- `pnpm check:changed -- src/cron/store/runtime-authority-store.ts src/cron/store.test.ts` passed every lane through core-test typechecking. Its aggregate core-test typecheck was blocked by this worktree's pre-existing shared dependency mismatch: `ui/vite.config.ts` could not find the `pako` declaration. The changed tests compile and pass under Vitest.
- Exact rebased branch autoreview reported no accepted/actionable findings and rated the patch correct at 0.97 confidence; TruffleHog was clean.

A standalone unmanaged production-module attempt was discarded: trigger shell execution did not complete without the managed Gateway lifecycle. No result from that attempt is claimed as proof.

Direct Codex contract inspection used the exact pinned `@openai/codex` 0.148.0 source: tag `rust-v0.148.0`, commit `3ba0f711642a888aec92a611a3f3b2211157ff89`.

- [`dynamic_tools.rs:21-55`](https://github.com/openai/codex/blob/3ba0f711642a888aec92a611a3f3b2211157ff89/codex-rs/protocol/src/dynamic_tools.rs#L21-L55) defines registration with name/description/schema/defer and call delivery with call ID, turn ID, optional namespace, tool name, and arguments—no producer identity.
- [`thread_processor.rs:326-351`](https://github.com/openai/codex/blob/3ba0f711642a888aec92a611a3f3b2211157ff89/codex-rs/app-server/src/request_processors/thread_processor.rs#L326-L351) validates exact names and rejects duplicates within a namespace.
- [`dynamic.rs:50-81`](https://github.com/openai/codex/blob/3ba0f711642a888aec92a611a3f3b2211157ff89/codex-rs/core/src/tools/handlers/dynamic.rs#L50-L81) constructs the runtime tool identity from namespace and name; [`dynamic.rs:135-142`](https://github.com/openai/codex/blob/3ba0f711642a888aec92a611a3f3b2211157ff89/codex-rs/core/src/tools/handlers/dynamic.rs#L135-L142) dispatches that identity.
- [`dynamic.rs:171-204`](https://github.com/openai/codex/blob/3ba0f711642a888aec92a611a3f3b2211157ff89/codex-rs/core/src/tools/handlers/dynamic.rs#L171-L204) reduces the event to namespace, name, and arguments; [`bespoke_event_handling.rs:991-999`](https://github.com/openai/codex/blob/3ba0f711642a888aec92a611a3f3b2211157ff89/codex-rs/app-server/src/bespoke_event_handling.rs#L991-L999) forwards those same fields.

The exact pinned runtime therefore does not carry OpenClaw producer identity after registration. OpenClaw must capture the binding from the concrete producer tool before the protocol reduces it to name/namespace.

