### PR TITLE
fix: copied Codex sessions stay resumable after upgrades

### DIFF
--- a/test/gateway-copied-codex-session-resume.e2e.test.ts
+++ b/test/gateway-copied-codex-session-resume.e2e.test.ts
@@ -1,0 +1,206 @@
+// A copied persisted Codex session must reactivate its installed harness owner on Gateway startup.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import { upsertSessionEntry } from "../src/plugin-sdk/session-store-runtime.js";
+import { closeOpenClawAgentDatabasesForTest } from "../src/plugin-sdk/sqlite-runtime-testing.js";
+import { writePersistedInstalledPluginIndexInstallRecords } from "../src/plugins/installed-plugin-index-records.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+
+const PLUGIN_ID = "codex";
+const SESSION_KEY = "agent:main:copied-codex-session";
+const VISIBLE_REPLY = "COPIED_CODEX_SESSION_RESUMED";
+const TEST_TIMEOUT_MS = 120_000;
+const instances: OpenClawTestInstance[] = [];
+
+afterEach(async () => {
+  await Promise.all(instances.splice(0).map(async (instance) => await instance.cleanup()));
+  closeOpenClawAgentDatabasesForTest();
+});
+
+function buildCopiedStateConfig(): OpenClawConfig {
+  return {
+    plugins: { enabled: true, slots: { memory: "none" } },
+    models: {
+      providers: {
+        "copied-session-proof": {
+          api: "openai-responses",
+          baseUrl: "https://example.invalid/v1",
+          models: [
+            {
+              id: "proof-model",
+              name: "Copied session proof model",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128_000,
+              maxTokens: 4_096,
+            },
+          ],
+        },
+      },
+    },
+    agents: { defaults: { model: { primary: "copied-session-proof/proof-model" } } },
+  };
+}
+
+async function installCodexHarnessFixture(stateDir: string, config: OpenClawConfig): Promise<void> {
+  const pluginDir = path.join(stateDir, "extensions", PLUGIN_ID);
+  await fs.mkdir(pluginDir, { recursive: true });
+  await fs.writeFile(
+    path.join(pluginDir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: PLUGIN_ID,
+      name: "Copied Codex session proof",
+      activation: { onStartup: false, onAgentHarnesses: [PLUGIN_ID] },
+      configSchema: { type: "object", additionalProperties: false },
+    }),
+  );
+  await fs.writeFile(
+    path.join(pluginDir, "package.json"),
+    JSON.stringify({
+      name: "@openclaw/codex",
+      version: "2026.8.1",
+      type: "module",
+      openclaw: { extensions: ["./index.js"] },
+    }),
+  );
+  await fs.writeFile(
+    path.join(pluginDir, "index.js"),
+    `export default {
+      id: "codex",
+      register(api) {
+        api.registerAgentHarness({
+          id: "codex",
+          label: "Copied Codex session proof",
+          authBootstrap: "harness",
+          supports: () => ({ supported: true, priority: 100 }),
+          async runAttempt() {
+            const text = ${JSON.stringify(VISIBLE_REPLY)};
+            const assistant = {
+              role: "assistant",
+              content: [{ type: "text", text }],
+              api: "openai-responses",
+              provider: "copied-session-proof",
+              model: "proof-model",
+              usage: {
+                input: 0,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+                totalTokens: 0,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+              },
+              stopReason: "stop",
+              timestamp: Date.now(),
+            };
+            return {
+              terminal: { kind: "ok" },
+              sessionIdUsed: "copied-codex-thread",
+              messagesSnapshot: [assistant],
+              assistantTexts: [text],
+              toolMetas: [],
+              lastAssistant: assistant,
+              didSendViaMessagingTool: false,
+              messagingToolSentTexts: [],
+              messagingToolSentMediaUrls: [],
+              messagingToolSentTargets: [],
+              cloudCodeAssistFormatError: false,
+              replayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+              itemLifecycle: { startedCount: 0, completedCount: 0, activeCount: 0 },
+            };
+          },
+        });
+      },
+    };\n`,
+  );
+  await writePersistedInstalledPluginIndexInstallRecords(
+    {
+      [PLUGIN_ID]: {
+        source: "path",
+        sourcePath: pluginDir,
+        installPath: pluginDir,
+      },
+    },
+    {
+      stateDir,
+      config,
+      candidates: [
+        {
+          idHint: PLUGIN_ID,
+          source: path.join(pluginDir, "index.js"),
+          rootDir: pluginDir,
+          origin: "global",
+        },
+      ],
+    },
+  );
+}
+
+describe("Gateway copied Codex session resume", () => {
+  it(
+    "resumes a copied persisted Codex session when config no longer selects its harness",
+    async () => {
+      const config = buildCopiedStateConfig();
+      const instance = await createOpenClawTestInstance({
+        name: "copied-codex-session-resume",
+        config,
+        env: {
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
+      });
+      instances.push(instance);
+      await installCodexHarnessFixture(instance.stateDir, config);
+
+      instance.state.applyEnv();
+      await upsertSessionEntry({
+        agentId: "main",
+        sessionKey: SESSION_KEY,
+        entry: {
+          sessionId: "copied-codex-thread",
+          updatedAt: Date.now(),
+          modelProvider: "copied-session-proof",
+          model: "proof-model",
+          modelSelectionLocked: true,
+          agentHarnessId: "codex",
+        },
+      });
+      closeOpenClawAgentDatabasesForTest();
+
+      await instance.startGateway();
+      const client = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+        requestTimeoutMs: 30_000,
+      });
+      try {
+        const payload = await client.request(
+          "agent",
+          {
+            sessionKey: SESSION_KEY,
+            idempotencyKey: "copied-codex-session-resume",
+            message: "Resume this copied conversation.",
+            deliver: false,
+            timeout: 30,
+          },
+          { expectFinal: true, timeoutMs: 30_000 },
+        );
+
+        expect(payload).toMatchObject({
+          status: "ok",
+          result: { payloads: [{ text: VISIBLE_REPLY }] },
+        });
+      } finally {
+        await disconnectGatewayClient(client).catch(() => undefined);
+      }
+    },
+    TEST_TIMEOUT_MS,
+  );
+});


### PR DESCRIPTION
Related: #125626

## What Problem This Solves

Fixes an issue where operators upgrading copied OpenClaw state could pass Gateway readiness but then fail to resume an existing Codex conversation because the persisted session's installed harness owner was absent from that turn's prepared plugin generation.

This is the failure reported by Dallin Romney (`@RomneyDa`) in https://github.com/openclaw/openclaw/issues/125626#issuecomment-5334893569. Thank you for the exact source/candidate and first-turn evidence.

## Why This Change Was Made

The production lifecycle repair already landed in #125596 (`fd216cb5509e`): Gateway-prepared turns now reuse the lifecycle-owned plugin metadata snapshot, so a persisted `agentHarnessId: "codex"` can select its installed external owner without a runtime fallback or a new config signal.

This PR adds the missing regression at the public seam. It creates copied SQLite state with a persisted Codex session, installs an external Codex harness owner, starts a real Gateway with no authored Codex runtime selection, resumes through the public `agent` WebSocket RPC, and requires a visible usable reply. Bundled plugin discovery is disabled in the fixture so the repo's source Codex plugin cannot hide a missing installed owner.

## User Impact

No new production behavior. The test protects the existing upgrade repair so copied Codex conversations remain resumable after Gateway startup reports ready.

Production LOC: `+0/-0`. Test LOC: `+206/-0`.

## Evidence

### Red: reported candidate

The unchanged test fails against exact candidate `8f382a202ff1e15833394b481615dcdda99b04d7`:

```text
FAIL test/gateway-copied-codex-session-resume.e2e.test.ts
GatewayClientRequestError: Agent harness runtime "codex" is unavailable because its plugin registration is missing from this prepared run. Enable or reinstall the plugin that provides this runtime, restart the Gateway, then retry.
```

Command:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/gateway-copied-codex-session-resume.e2e.test.ts
```

### Green: current lifecycle owner

The same command passes on this branch from current `main`; `pnpm test:changed` selects and passes the same E2E shard.

Additional validation:

```text
pnpm check:changed  PASS (format, test-root typecheck, lint, guards)
pnpm build          PASS (performed by the real-process E2E entrypoint preparation)
autoreview          clean; no accepted/actionable findings (gpt-5.6-sol, high)
```

### Codex contract checked

Codex `d5e256ceb210dacbab9d8dcc7eafda58f90f6e51` confirms that `thread/resume` loads a persisted thread by ID and returns a full resume response; OpenClaw, not Codex, owns making the harness plugin available to the Gateway turn:

- [`thread.rs:313-327`](https://github.com/openai/codex/blob/d5e256ceb210dacbab9d8dcc7eafda58f90f6e51/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L313-L327) and [`thread.rs:406-455`](https://github.com/openai/codex/blob/d5e256ceb210dacbab9d8dcc7eafda58f90f6e51/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L406-L455)
- [`thread_processor.rs:3343-3456`](https://github.com/openai/codex/blob/d5e256ceb210dacbab9d8dcc7eafda58f90f6e51/codex-rs/app-server/src/request_processors/thread_processor.rs#L3343-L3456), [`thread_processor.rs:3533-3603`](https://github.com/openai/codex/blob/d5e256ceb210dacbab9d8dcc7eafda58f90f6e51/codex-rs/app-server/src/request_processors/thread_processor.rs#L3533-L3603), and [`thread_processor.rs:3710-3732`](https://github.com/openai/codex/blob/d5e256ceb210dacbab9d8dcc7eafda58f90f6e51/codex-rs/app-server/src/request_processors/thread_processor.rs#L3710-L3732)
