### PR TITLE
fix(sessions): keep retry identity on active rewrite branch

### DIFF
--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import {
+  appendTranscriptMessage,
   loadTranscriptEvents,
   replaceSessionEntry,
 } from "../../config/sessions/session-accessor.js";
@@ -389,6 +390,22 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
         }
       }
       expect(reopened.getLeafId()).toBe(activeBranch.at(-1)?.id);
+      if (keyed) {
+        const activeKeyedEntry = activeBranch.find(
+          (entry) =>
+            entry.type === "message" &&
+            "idempotencyKey" in entry.message &&
+            entry.message.idempotencyKey === "rewrite-later-user",
+        );
+        if (!activeKeyedEntry || activeKeyedEntry.type !== "message") {
+          throw new Error("expected active keyed replay entry");
+        }
+        const retry = await appendTranscriptMessage(target, { message: activeKeyedEntry.message });
+        expect(retry).toMatchObject({
+          appended: false,
+          messageId: activeKeyedEntry.id,
+        });
+      }
     },
   );
 });

--- a/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
@@ -143,9 +143,12 @@ export function appendTranscriptMessageInTransaction<TMessage>(
     message: finalMessage,
   };
   const appended = appendTranscriptEventInTransaction(database, resolved, event, {
-    dedupeByMessageIdempotency:
-      options.idempotencyLookup !== "caller-checked" &&
-      options.idempotencyLookup !== "scan-assistant",
+    idempotencyKeyMode:
+      options.idempotencyLookup === "caller-checked"
+        ? "relocate-owner"
+        : options.idempotencyLookup === "scan-assistant"
+          ? "preserve-owner"
+          : "dedupe",
   });
   if (!appended && idempotencyKey && options.idempotencyLookup !== "caller-checked") {
     const existing = readTranscriptMessageByScopedIdempotencyKey(

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -51,7 +51,7 @@ import { resolveVisibleTranscriptAppendParentId } from "./transcript-visible-eve
 
 type TranscriptAppendOptions = {
   allowStoredAlias?: boolean;
-  dedupeByMessageIdempotency?: boolean;
+  idempotencyKeyMode?: "dedupe" | "preserve-owner" | "relocate-owner";
   onProjectionReconcileNeeded?: () => void;
   scheduleProjectionReconcile?: boolean;
   touchMutation?: boolean;
@@ -97,15 +97,10 @@ function appendTranscriptEvent(
   if (identity && readTranscriptIdentityByEventId(database, scope.sessionId, identity.eventId)) {
     return false;
   }
-  if (
-    identity?.messageIdempotencyKey &&
-    options.dedupeByMessageIdempotency &&
-    readTranscriptIdentityByMessageIdempotencyKey(
-      database,
-      scope.sessionId,
-      identity.messageIdempotencyKey,
-    )
-  ) {
+  const idempotencyKeyOwner = identity?.messageIdempotencyKey
+    ? readIdempotencyKeyOwner(database, scope.sessionId, identity.messageIdempotencyKey)
+    : undefined;
+  if (idempotencyKeyOwner && options.idempotencyKeyMode === "dedupe") {
     return false;
   }
   const seq = cursor.nextSeq ?? readNextTranscriptSeq(database, scope.sessionId);
@@ -133,16 +128,20 @@ function appendTranscriptEvent(
     options.onProjectionReconcileNeeded?.();
   }
   if (identity) {
-    // Caller-checked appends may retain a duplicate key in the payload, but the
-    // identity index can point at only one row.
+    // Replayed copies take ownership so later retries resolve on the active branch.
+    // scan-assistant preserves a colliding user's ownership instead.
+    if (idempotencyKeyOwner && options.idempotencyKeyMode === "relocate-owner") {
+      executeSqliteQuerySync(
+        database.db,
+        db
+          .updateTable("transcript_event_identities")
+          .set({ message_idempotency_key: null })
+          .where("session_id", "=", scope.sessionId)
+          .where("event_id", "=", idempotencyKeyOwner.eventId),
+      );
+    }
     const indexedMessageIdempotencyKey =
-      identity.messageIdempotencyKey &&
-      !options.dedupeByMessageIdempotency &&
-      readTranscriptIdentityByMessageIdempotencyKey(
-        database,
-        scope.sessionId,
-        identity.messageIdempotencyKey,
-      )
+      idempotencyKeyOwner && options.idempotencyKeyMode !== "relocate-owner"
         ? undefined
         : identity.messageIdempotencyKey;
     executeSqliteQuerySync(
@@ -580,7 +579,7 @@ export function readTranscriptIdentityByEventId(
   return row ? { eventId: row.event_id, parentId: row.parent_id, seq: row.seq } : undefined;
 }
 
-function readTranscriptIdentityByMessageIdempotencyKey(
+function readIdempotencyKeyOwner(
   database: OpenClawAgentDatabase,
   sessionId: string,
   idempotencyKey: string,
@@ -604,11 +603,7 @@ function readTranscriptMessageByIdempotencyKey(
   scope: ResolvedTranscriptScope,
   idempotencyKey: string,
 ): { messageId: string; message: unknown } | undefined {
-  const identity = readTranscriptIdentityByMessageIdempotencyKey(
-    database,
-    scope.sessionId,
-    idempotencyKey,
-  );
+  const identity = readIdempotencyKeyOwner(database, scope.sessionId, idempotencyKey);
   return identity ? readTranscriptMessageByIdentity(database, scope, identity) : undefined;
 }
 


### PR DESCRIPTION
## Problem

Fixes #126469.

Transcript maintenance copies the active suffix to a new branch. Current `main`
already marks those copies as caller-checked, so the rewrite itself no longer
re-runs ingress deduplication. The SQLite identity index still kept each copied
message's idempotency key on the abandoned row.

A later channel retry therefore found the abandoned row instead of the copied
active row. The retry had no active transcript anchor and could not continue
safely.

## Root cause

The transcript append owner used one boolean for three different contracts:

- ordinary appends deduplicate against the current key owner;
- scan-assistant appends preserve a colliding user's key owner;
- caller-checked replay appends must transfer key ownership to the copied row.

The boolean could express only deduplicate or do not deduplicate. It could not
express which row must own the key after a deliberate replay.

## Fix

Replace the boolean with one closed three-mode policy. Caller-checked replay now
clears the old row's indexed key and assigns it to the copied row in the same
SQLite transaction. Ordinary deduplication and scan-assistant collision behavior
remain unchanged.

The existing persisted rewrite table test now retries both keyed replay forms and
requires the copied active row.

## Live proof

Both runs used a Convex-leased Telegram Test Server account, an isolated source
Gateway, a real on-disk SQLite session store, and one recorded mock-provider
request.

| Revision | Telegram result | Rewrite retry result |
| --- | --- | --- |
| `a8c8c8270836` (`main`) | Bot returned `OPENCLAW_E2E_REWRITE_RED` | Retry resolved the abandoned row and returned no active anchor. |
| `2cc501ad0264` (this PR) | Bot returned `OPENCLAW_E2E_REWRITE_GREEN` | Retry resolved the copied active row, returned its active anchor, and preserved the complete branch. |

## Validation

- `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/transcript-rewrite.test.ts`
- `node scripts/run-vitest.mjs src/agents/sessions/session-manager.user-idempotency.test.ts src/gateway/server-methods/chat.abort-persistence.test.ts src/config/sessions/session-accessor.test.ts src/config/sessions/session-accessor.sqlite-transcript-store.test.ts`
- targeted type-aware Oxlint and all permitted changed-scope repository ratchets
- `git diff --check`

Production code is net `-2` lines. Test code adds 17 lines to an existing
auto-cleaned SQLite fixture.

## AI disclosure

This repair was prepared with AI assistance and verified by a maintainer-run
test and live-proof workflow.
