### PR TITLE
fix: exec treats empty workdir from models as omitted

### DIFF
--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -50,7 +50,8 @@ describe("direct exec tool schema", () => {
     const descriptions = Object.values(fields).map((field) => field.description ?? "");
 
     expect(descriptions.join("").length).toBeLessThan(550);
-    expect(describeField("workdir")).toContain("Blank/whitespace");
+    expect(describeField("workdir")).toContain("empty string");
+    expect(describeField("workdir")).toContain("whitespace-only");
     expect(describeField("yieldMs")).toContain("Milliseconds");
     expect(describeField("timeoutSeconds")).toContain("seconds");
     expect(describeField("pty")).toContain("PTY");

--- a/src/agents/bash-tools.exec-workdir.test.ts
+++ b/src/agents/bash-tools.exec-workdir.test.ts
@@ -108,6 +108,31 @@ describe("resolveExecWorkdir", () => {
     });
   });
 
+  it("treats exact empty workdir as omitted when a local cwd default exists", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "gateway",
+          workdir: "",
+          defaultCwd: workspaceDir,
+        }),
+      ).resolves.toEqual({ kind: "local", hostCwd: workspaceDir });
+    });
+  });
+
+  it("treats exact empty workdir as omitted when no local cwd default exists", async () => {
+    await withTempDir(async (workspaceDir) => {
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await expect(
+        resolveExecWorkdir({
+          host: "gateway",
+          workdir: "",
+        }),
+      ).resolves.toEqual({ kind: "local", hostCwd: workspaceDir });
+    });
+  });
+
   it("uses current cwd for omitted local workdir only when no default exists", async () => {
     await withTempDir(async (workspaceDir) => {
       vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
@@ -151,6 +176,23 @@ describe("resolveExecWorkdir", () => {
       await expect(
         resolveExecWorkdir({
           host: "sandbox",
+          sandbox: sandboxConfig(workspaceDir),
+        }),
+      ).resolves.toEqual({
+        kind: "sandbox",
+        hostCwd: workspaceDir,
+        containerCwd: "/workspace",
+        scriptPreflightCwd: workspaceDir,
+      });
+    });
+  });
+
+  it("treats exact empty workdir as omitted for sandbox hosts", async () => {
+    await withTempDir(async (workspaceDir) => {
+      await expect(
+        resolveExecWorkdir({
+          host: "sandbox",
+          workdir: "",
           sandbox: sandboxConfig(workspaceDir),
         }),
       ).resolves.toEqual({
@@ -980,6 +1022,26 @@ describe("resolveExecWorkdir", () => {
         nodeCwd: "/remote/node/default",
       }),
     ).resolves.toEqual({ kind: "node", remoteCwd: "/remote/node/workspace" });
+  });
+
+  it("treats exact empty workdir as omitted for node hosts with a node cwd", async () => {
+    await expect(
+      resolveExecWorkdir({
+        host: "node",
+        workdir: "",
+        nodeCwd: "/remote/node/default",
+      }),
+    ).resolves.toEqual({ kind: "node", remoteCwd: "/remote/node/default" });
+  });
+
+  it("treats exact empty workdir as omitted for node hosts without a node cwd", async () => {
+    await expect(
+      resolveExecWorkdir({
+        host: "node",
+        workdir: "",
+        defaultCwd: "/gateway/default",
+      }),
+    ).resolves.toEqual({ kind: "node" });
   });
 
   it("rejects blank explicit node workdirs", async () => {

--- a/src/agents/bash-tools.exec-workdir.ts
+++ b/src/agents/bash-tools.exec-workdir.ts
@@ -47,7 +47,7 @@ type ExistingHostPathResult =
   | { kind: "invalid" };
 
 function normalizeExplicitWorkdirInput(workdir: string | undefined): NormalizedWorkdirInput {
-  if (workdir === undefined) {
+  if (workdir === undefined || workdir === "") {
     return { kind: "omitted" };
   }
   const value = normalizeOptionalString(workdir);

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -26,7 +26,8 @@ export const execSchema = Type.Object({
   command: Type.String({ description: "Shell command to execute" }),
   workdir: Type.Optional(
     Type.String({
-      description: "Working directory; omit for default. Blank/whitespace is invalid.",
+      description:
+        "Working directory; omit for default. An empty string means omitted; whitespace-only is invalid.",
     }),
   ),
   env: Type.Optional(Type.Record(Type.String(), Type.String())),


### PR DESCRIPTION
Closes #126390

## What Problem This Solves

Fixes an issue where users running small tool-calling models (e.g. local Ollama models like `gpt-oss:20b`) would see `exec` commands **fail** because the model fills every optional field of the exec schema instead of omitting them — `exec` arrived with `workdir: ""`, and OpenClaw treated the empty string as a literal path and refused to run the command.

Measured impact from the report: 10 failed `exec` steps out of 16 across 6 runs, with 6 of those failures caused by the empty `workdir`. Each failure costs wasted agent turns, surfaces as `⚠️ 🛠️ Exec failed` under an otherwise correct answer, and can mislead the model into wrong conclusions (e.g. "the node runtime is not available").

## Why This Change Was Made

Normalize only the **exact empty string** `""` to "omitted" at the workdir input boundary (`normalizeExplicitWorkdirInput`). An empty string can never be a valid directory, so coercing it to omitted is lossless. Whitespace-only (`"   "`) and nonempty invalid explicit paths remain **fail-closed** — the existing rejection behavior is preserved.

The model-facing exec schema previously still told models that blank input is invalid; it now states that an empty string means omitted and only whitespace-only values are invalid (`bash-tools.schemas.ts`), with the schema assertion updated accordingly.

Scope is intentionally limited to `workdir`; `node` and `security` fields from the same cause are left for a follow-up.

## User Impact

- `exec` commands now run in the default cwd when a model sends `workdir: ""`, identical to omitting the field.
- No wasted agent turns and no misleading "command failed" surfaced to users in this case.
- Whitespace-only workdirs are still rejected — no safety or validation regression.

## Evidence

### Real execution proof (after fix)

`execTool.execute()` with `workdir: ""` on this branch — real process spawn, Windows 11, repo checkout cwd:

```text
$ node --import tsx -e "… execTool.execute('proof-empty-workdir', { command: 'node --version', workdir: '', host: 'gateway', timeoutSeconds: 30 })"

RESULT: {"content":[{"type":"text","text":"v24.19.0"}],"details":{"status":"completed","exitCode":0,"exitSignal":null,"exitReason":"exit","durationMs":1972,"aggregated":"v24.19.0","noOutputTimedOut":false,"cwd":"C:\\Users\\hcode\\Documents\\openclaw"}}
```

Command executed successfully with `exitCode: 0` in the default cwd — same result as omitting `workdir`.

### Before fix (same invocation, resolver reverted to `workdir === undefined` only)

```text
RESULT: {"content":[{"type":"text","text":"workdir \"\" is unavailable or not a directory: command was not executed. workdir is treated as a literal path; shell expansions such as \"~\" are not applied. Use an existing directory, omit an explicit workdir to use the default cwd, or update the configured default cwd."}],"details":{"status":"failed","exitCode":null,"failureKind":"runtime-error","durationMs":447,"cwd":""}}
```

### Regression tests (all passing)

Added to `src/agents/bash-tools.exec-workdir.test.ts`:
- exact empty `workdir` treated as omitted for local/gateway hosts (with and without a configured default cwd)
- exact empty `workdir` treated as omitted for sandbox hosts
- exact empty `workdir` treated as omitted for node hosts (with and without a node cwd)

Focused run (`vitest.agents.config.ts` → `bash-tools.exec-workdir.test.ts` + `agent-tools.schema.test.ts`): **113 passed / 6 failed**. The 6 failures are pre-existing Windows symlink-permission failures — verified by re-running them on clean `main` (via `git stash`): they fail there too, unrelated to this change. CI runs on Linux where they pass.

### Checks

- `oxfmt --write` clean on all changed files.
- `check:changed` fast lanes pass (assertion safety, changelog attributions, coercion helpers, dependency pins, deprecated API usage, plugin boundaries, wrapper shadowing, formatting).
- CI note: the only failing check on the first push (`checks-node-compact-large-20`) failed at the checkout/cache step (infra), not in tests; the schema-alignment push re-triggers CI.

**AI-assisted contribution**: this change was prepared with an AI coding assistant (Hermes Agent). The fix follows the exact recommendation from the issue and the ClawSweeper review: normalize only exact `""`, preserve whitespace rejection, and align the model-facing schema.
