### PR TITLE
fix(codex): short approvals repeat denied action scope

### DIFF
--- a/extensions/codex/src/app-server/event-projector-events.ts
+++ b/extensions/codex/src/app-server/event-projector-events.ts
@@ -27,6 +27,10 @@ import {
 } from "./event-projector-tool-progress.js";
 import { CodexToolTranscriptProjection } from "./event-projector-tool-transcript.js";
 import { readHookOutputEntries, readNullableString } from "./event-projector-values.js";
+import {
+  buildPendingGuardianDeniedAction,
+  type CodexPendingGuardianDeniedAction,
+} from "./guardian-denial-approval.js";
 import { isJsonObject, type CodexThreadItem, type JsonObject } from "./protocol.js";
 
 type AgentEvent = Parameters<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>[0];
@@ -112,13 +116,16 @@ export class CodexEventProjection {
     private readonly toolProgress: CodexToolProgressProjection,
     private readonly toolTranscript: CodexToolTranscriptProjection,
     private readonly onNativeToolResultRecorded?: () => void | Promise<void>,
+    private readonly onGuardianDeniedAction?: (
+      pending: CodexPendingGuardianDeniedAction,
+    ) => void | Promise<void>,
   ) {}
 
   get guardianReviewCount(): number {
     return this.reviewCount;
   }
 
-  handleGuardianReview(method: string, params: JsonObject): void {
+  async handleGuardianReview(method: string, params: JsonObject): Promise<void> {
     this.reviewCount += 1;
     const review = isJsonObject(params.review) ? params.review : undefined;
     const action = isJsonObject(params.action) ? params.action : undefined;
@@ -129,6 +136,12 @@ export class CodexEventProjection {
     const riskLevel = review ? readString(review, "riskLevel") : undefined;
     const userAuthorization = review ? readString(review, "userAuthorization") : undefined;
     const rationale = review ? readNullableString(review, "rationale") : undefined;
+    if (method === "item/autoApprovalReview/completed") {
+      const pending = buildPendingGuardianDeniedAction(params);
+      if (pending) {
+        await this.onGuardianDeniedAction?.(pending);
+      }
+    }
     // Codex emits the routine warning immediately before its structured terminal fact.
     // Exact byte equality consumes only that duplicate; every other warning is flushed.
     const expectedWarning =

--- a/extensions/codex/src/app-server/event-projector-options.ts
+++ b/extensions/codex/src/app-server/event-projector-options.ts
@@ -1,4 +1,5 @@
 import type { AgentPlanStep } from "openclaw/plugin-sdk/channel-outbound";
+import type { CodexPendingGuardianDeniedAction } from "./guardian-denial-approval.js";
 import type { CodexThreadItem, JsonValue } from "./protocol.js";
 import type { CodexRemoteWorkspaceFileReader } from "./remote-workspace-media.js";
 import type { CodexTrajectoryRecorder } from "./trajectory.js";
@@ -7,6 +8,7 @@ export type CodexAppServerEventProjectorOptions = {
   initialContextTokens?: number;
   nativePostToolUseRelayEnabled?: boolean;
   onNativeToolResultRecorded?: () => void | Promise<void>;
+  onGuardianDeniedAction?: (pending: CodexPendingGuardianDeniedAction) => void | Promise<void>;
   onNativePlanUpdate?: (update: {
     markdown?: string;
     steps: AgentPlanStep[];

--- a/extensions/codex/src/app-server/event-projector.native-audit.test.ts
+++ b/extensions/codex/src/app-server/event-projector.native-audit.test.ts
@@ -20,6 +20,55 @@ import {
 registerCodexEventProjectorTestLifecycle();
 
 describe("CodexAppServerEventProjector native tool audit projection", () => {
+  it("binds one exact completed Guardian denial for the next user turn", async () => {
+    const onGuardianDeniedAction = vi.fn(async () => undefined);
+    const projector = await createProjector(undefined, { onGuardianDeniedAction });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/autoApprovalReview/completed", {
+        reviewId: "review-1",
+        startedAtMs: 1_000,
+        completedAtMs: 1_042,
+        targetItemId: "item-1",
+        decisionSource: "agent",
+        review: {
+          status: "denied",
+          riskLevel: "medium",
+          userAuthorization: "low",
+          rationale: "The exact action needs approval.",
+        },
+        action: {
+          type: "command",
+          source: "unifiedExec",
+          command: "git push origin subject:portable-v15-export",
+          cwd: "/workspace",
+        },
+      }),
+    );
+
+    expect(onGuardianDeniedAction).toHaveBeenCalledWith({
+      recordedAtMs: expect.any(Number),
+      event: {
+        id: "review-1",
+        target_item_id: "item-1",
+        turn_id: "turn-1",
+        started_at_ms: 1_000,
+        completed_at_ms: 1_042,
+        status: "denied",
+        risk_level: "medium",
+        user_authorization: "low",
+        rationale: "The exact action needs approval.",
+        decision_source: "agent",
+        action: {
+          type: "command",
+          source: "unified_exec",
+          command: "git push origin subject:portable-v15-export",
+          cwd: "/workspace",
+        },
+      },
+    });
+  });
+
   it("synthesizes normalized tool progress for Codex-native tool items", async () => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({ ...(await createParams()), onAgentEvent });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -132,6 +132,7 @@ export class CodexAppServerEventProjector {
       this.toolProgressProjection,
       this.toolTranscriptProjection,
       options.onNativeToolResultRecorded,
+      options.onGuardianDeniedAction,
     );
     this.assistantProjection = new CodexAssistantProjection(
       params,
@@ -270,7 +271,7 @@ export class CodexAppServerEventProjector {
         break;
       case "item/autoApprovalReview/started":
       case "item/autoApprovalReview/completed":
-        this.eventProjection.handleGuardianReview(notification.method, params);
+        await this.eventProjection.handleGuardianReview(notification.method, params);
         break;
       case "guardianWarning":
         this.eventProjection.handleGuardianWarning(params);

--- a/extensions/codex/src/app-server/guardian-denial-approval.test.ts
+++ b/extensions/codex/src/app-server/guardian-denial-approval.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildPendingGuardianDeniedAction,
+  consumePendingGuardianDeniedAction,
+  isContextualGuardianApproval,
+} from "./guardian-denial-approval.js";
+
+const deniedNotification = {
+  threadId: "thread-1",
+  turnId: "turn-1",
+  reviewId: "review-1",
+  startedAtMs: 1_000,
+  completedAtMs: 1_042,
+  targetItemId: "item-1",
+  decisionSource: "agent",
+  review: {
+    status: "denied",
+    riskLevel: "medium",
+    userAuthorization: "low",
+    rationale: "The user has not approved this exact push.",
+  },
+  action: {
+    type: "command",
+    source: "unifiedExec",
+    command: "git push origin subject:portable-v15-export",
+    cwd: "/workspace",
+  },
+};
+
+describe("buildPendingGuardianDeniedAction", () => {
+  it("preserves the exact denied action in Codex core wire format", () => {
+    expect(buildPendingGuardianDeniedAction(deniedNotification, 2_000)).toEqual({
+      recordedAtMs: 2_000,
+      event: {
+        id: "review-1",
+        target_item_id: "item-1",
+        turn_id: "turn-1",
+        started_at_ms: 1_000,
+        completed_at_ms: 1_042,
+        status: "denied",
+        risk_level: "medium",
+        user_authorization: "low",
+        rationale: "The user has not approved this exact push.",
+        decision_source: "agent",
+        action: {
+          type: "command",
+          source: "unified_exec",
+          command: "git push origin subject:portable-v15-export",
+          cwd: "/workspace",
+        },
+      },
+    });
+  });
+
+  it("ignores non-denial review notifications", () => {
+    expect(
+      buildPendingGuardianDeniedAction({
+        ...deniedNotification,
+        review: { ...deniedNotification.review, status: "approved" },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("isContextualGuardianApproval", () => {
+  it.each(["yes", "Approved", "go ahead", "yes & fix the connector issue"])(
+    "accepts %s as an affirmative reply",
+    (prompt) => expect(isContextualGuardianApproval(prompt)).toBe(true),
+  );
+
+  it.each(["no", "what does this do?", "continue the analysis", "not approved"])(
+    "does not treat %s as approval",
+    (prompt) => expect(isContextualGuardianApproval(prompt)).toBe(false),
+  );
+});
+
+describe("consumePendingGuardianDeniedAction", () => {
+  it("approves and consumes only the exact pending event", async () => {
+    const pending = buildPendingGuardianDeniedAction(deniedNotification, 2_000);
+    expect(pending).toBeDefined();
+    const request = vi.fn(async () => ({}));
+    const clear = vi.fn(async () => true);
+
+    await expect(
+      consumePendingGuardianDeniedAction({
+        pending,
+        prompt: "approved",
+        threadId: "thread-1",
+        nowMs: 2_100,
+        request,
+        clear,
+      }),
+    ).resolves.toBe("approved");
+
+    expect(request).toHaveBeenCalledWith("thread/approveGuardianDeniedAction", {
+      threadId: "thread-1",
+      event: pending?.event,
+    });
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("expires rather than approving stale context", async () => {
+    const pending = buildPendingGuardianDeniedAction(deniedNotification, 2_000);
+    const request = vi.fn(async () => ({}));
+    const clear = vi.fn(async () => true);
+
+    await expect(
+      consumePendingGuardianDeniedAction({
+        pending,
+        prompt: "yes",
+        threadId: "thread-1",
+        nowMs: 2_000 + 10 * 60_000 + 1,
+        request,
+        clear,
+      }),
+    ).resolves.toBe("expired");
+
+    expect(request).not.toHaveBeenCalled();
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("discards the pending event after an unrelated next reply", async () => {
+    const pending = buildPendingGuardianDeniedAction(deniedNotification, 2_000);
+    const request = vi.fn(async () => ({}));
+    const clear = vi.fn(async () => true);
+
+    await expect(
+      consumePendingGuardianDeniedAction({
+        pending,
+        prompt: "what does this do?",
+        threadId: "thread-1",
+        nowMs: 2_100,
+        request,
+        clear,
+      }),
+    ).resolves.toBe("unrelated");
+
+    expect(request).not.toHaveBeenCalled();
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when stale context cannot be cleared", async () => {
+    const pending = buildPendingGuardianDeniedAction(deniedNotification, 2_000);
+    const request = vi.fn(async () => ({}));
+    const clear = vi.fn(async () => false);
+
+    await expect(
+      consumePendingGuardianDeniedAction({
+        pending,
+        prompt: "yes",
+        threadId: "thread-1",
+        nowMs: 2_000 + 10 * 60_000 + 1,
+        request,
+        clear,
+      }),
+    ).rejects.toThrow("could not be cleared");
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/codex/src/app-server/guardian-denial-approval.ts
+++ b/extensions/codex/src/app-server/guardian-denial-approval.ts
@@ -1,0 +1,205 @@
+import { z } from "zod";
+import { isJsonObject, type JsonObject, type JsonValue } from "./protocol.js";
+
+const CONTEXTUAL_GUARDIAN_APPROVAL_MAX_AGE_MS = 10 * 60_000;
+
+const guardianDeniedEventSchema = z
+  .object({
+    id: z.string().trim().min(1),
+    target_item_id: z.string().trim().min(1).optional(),
+    turn_id: z.string().trim().min(1),
+    started_at_ms: z.number().finite(),
+    completed_at_ms: z.number().finite(),
+    status: z.literal("denied"),
+    risk_level: z.string().trim().min(1).optional(),
+    user_authorization: z.string().trim().min(1).optional(),
+    rationale: z.string().optional(),
+    decision_source: z.string().trim().min(1).optional(),
+    action: z.record(z.string(), z.custom<JsonValue>()),
+  })
+  .strict();
+
+export const pendingGuardianDeniedActionSchema = z
+  .object({
+    recordedAtMs: z.number().finite().nonnegative(),
+    event: guardianDeniedEventSchema,
+  })
+  .strict();
+
+export type CodexPendingGuardianDeniedAction = z.infer<typeof pendingGuardianDeniedActionSchema>;
+
+type GuardianApprovalRequest = (
+  method: "thread/approveGuardianDeniedAction",
+  params: { threadId: string; event: CodexPendingGuardianDeniedAction["event"] },
+) => Promise<unknown>;
+
+function readString(record: JsonObject, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function readNumber(record: JsonObject, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readStringArray(record: JsonObject, key: string): string[] | undefined {
+  const value = record[key];
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string")
+    ? value
+    : undefined;
+}
+
+function readOptionalString(record: JsonObject, key: string): string | null | undefined {
+  const value = record[key];
+  return value === null || typeof value === "string" ? value : undefined;
+}
+
+function normalizeGuardianCommandSource(source: string | undefined): string | undefined {
+  return source === "unifiedExec" ? "unified_exec" : source === "shell" ? source : undefined;
+}
+
+function normalizeGuardianAction(action: JsonObject): JsonObject | undefined {
+  const type = readString(action, "type");
+  if (type === "command") {
+    const source = normalizeGuardianCommandSource(readString(action, "source"));
+    const command = readString(action, "command");
+    const cwd = readString(action, "cwd");
+    return source && command && cwd ? { type, source, command, cwd } : undefined;
+  }
+  if (type === "execve") {
+    const source = normalizeGuardianCommandSource(readString(action, "source"));
+    const program = readString(action, "program");
+    const argv = readStringArray(action, "argv");
+    const cwd = readString(action, "cwd");
+    return source && program && argv && cwd ? { type, source, program, argv, cwd } : undefined;
+  }
+  if (type === "applyPatch") {
+    const cwd = readString(action, "cwd");
+    const files = readStringArray(action, "files");
+    return cwd && files ? { type: "apply_patch", cwd, files } : undefined;
+  }
+  if (type === "networkAccess") {
+    const target = readString(action, "target");
+    const host = readString(action, "host");
+    const protocol = readString(action, "protocol");
+    const port = readNumber(action, "port");
+    return target && host && protocol && port !== undefined
+      ? { type: "network_access", target, host, protocol, port }
+      : undefined;
+  }
+  if (type === "mcpToolCall") {
+    const server = readString(action, "server");
+    const toolName = readString(action, "toolName");
+    const connectorId = readOptionalString(action, "connectorId");
+    const connectorName = readOptionalString(action, "connectorName");
+    const toolTitle = readOptionalString(action, "toolTitle");
+    return server && toolName && connectorId !== undefined && connectorName !== undefined
+      ? {
+          type: "mcp_tool_call",
+          server,
+          tool_name: toolName,
+          connector_id: connectorId,
+          connector_name: connectorName,
+          tool_title: toolTitle ?? null,
+        }
+      : undefined;
+  }
+  if (type === "requestPermissions") {
+    const reason = readOptionalString(action, "reason");
+    const permissions = isJsonObject(action.permissions) ? action.permissions : undefined;
+    return reason !== undefined && permissions
+      ? { type: "request_permissions", reason, permissions }
+      : undefined;
+  }
+  return undefined;
+}
+
+/** Converts one terminal Codex Guardian denial notification into its exact approval RPC payload. */
+export function buildPendingGuardianDeniedAction(
+  params: JsonObject,
+  recordedAtMs = Date.now(),
+): CodexPendingGuardianDeniedAction | undefined {
+  const review = isJsonObject(params.review) ? params.review : undefined;
+  const action = isJsonObject(params.action) ? normalizeGuardianAction(params.action) : undefined;
+  const id = readString(params, "reviewId");
+  const turnId = readString(params, "turnId");
+  const startedAtMs = readNumber(params, "startedAtMs");
+  const completedAtMs = readNumber(params, "completedAtMs");
+  if (
+    !review ||
+    readString(review, "status") !== "denied" ||
+    !action ||
+    !id ||
+    !turnId ||
+    startedAtMs === undefined ||
+    completedAtMs === undefined
+  ) {
+    return undefined;
+  }
+  const targetItemId = readString(params, "targetItemId");
+  const riskLevel = readString(review, "riskLevel");
+  const userAuthorization = readString(review, "userAuthorization");
+  const rationale = readOptionalString(review, "rationale");
+  const decisionSource = readString(params, "decisionSource");
+  return pendingGuardianDeniedActionSchema.parse({
+    recordedAtMs,
+    event: {
+      id,
+      ...(targetItemId ? { target_item_id: targetItemId } : {}),
+      turn_id: turnId,
+      started_at_ms: startedAtMs,
+      completed_at_ms: completedAtMs,
+      status: "denied",
+      ...(riskLevel ? { risk_level: riskLevel } : {}),
+      ...(userAuthorization ? { user_authorization: userAuthorization } : {}),
+      ...(rationale !== undefined && rationale !== null ? { rationale } : {}),
+      ...(decisionSource ? { decision_source: decisionSource } : {}),
+      action,
+    },
+  });
+}
+
+/** Recognizes a narrow affirmative reply without accepting negation or generic continuation. */
+export function isContextualGuardianApproval(prompt: string): boolean {
+  return /^(?:yes|approved|approve|go ahead|do it)(?:[.!]|\s*(?:&|and\b).*)?$/iu.test(
+    prompt.trim(),
+  );
+}
+
+/** Applies one exact pending denial approval, then consumes it only after Codex accepts it. */
+export async function consumePendingGuardianDeniedAction(params: {
+  pending: CodexPendingGuardianDeniedAction | undefined;
+  prompt: string;
+  threadId: string;
+  nowMs?: number;
+  request: GuardianApprovalRequest;
+  clear: () => Promise<boolean>;
+}): Promise<"absent" | "approved" | "expired" | "unrelated"> {
+  if (!params.pending) {
+    return "absent";
+  }
+  const nowMs = params.nowMs ?? Date.now();
+  if (nowMs - params.pending.recordedAtMs > CONTEXTUAL_GUARDIAN_APPROVAL_MAX_AGE_MS) {
+    if (!(await params.clear())) {
+      throw new Error("expired Codex Guardian approval could not be cleared");
+    }
+    return "expired";
+  }
+  if (!isContextualGuardianApproval(params.prompt)) {
+    if (!(await params.clear())) {
+      throw new Error("unrelated reply could not clear the pending Codex Guardian approval");
+    }
+    return "unrelated";
+  }
+  await params.request("thread/approveGuardianDeniedAction", {
+    threadId: params.threadId,
+    event: params.pending.event,
+  });
+  if (!(await params.clear())) {
+    throw new Error(
+      "Codex Guardian approval was accepted but its pending binding could not be consumed",
+    );
+  }
+  return "approved";
+}

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -186,6 +186,11 @@ export type CodexThreadStartParams = JsonObject & {
   ephemeral?: boolean;
 };
 
+export type CodexThreadApproveGuardianDeniedActionParams = {
+  threadId: string;
+  event: JsonObject;
+};
+
 export type CodexThreadResumeParams = JsonObject & {
   threadId: string;
   cwd?: string | null;
@@ -649,6 +654,7 @@ type CodexAppServerRequestParamsOverride = {
   "plugin/read": CodexPluginReadParams;
   "thread/fork": CodexThreadForkParams;
   "thread/archive": CodexThreadArchiveParams;
+  "thread/approveGuardianDeniedAction": CodexThreadApproveGuardianDeniedActionParams;
   "thread/delete": CodexThreadDeleteParams;
   "thread/inject_items": CodexThreadInjectItemsParams;
   "thread/list": CodexThreadListParams;
@@ -697,6 +703,7 @@ type CodexAppServerRequestResultMap = {
   "skills/list": CodexSkillsListResponse;
   "thread/compact/start": JsonValue;
   "thread/archive": JsonValue;
+  "thread/approveGuardianDeniedAction": JsonValue;
   "thread/delete": CodexThreadDeleteResponse;
   "thread/fork": CodexThreadForkResponse;
   "thread/inject_items": JsonValue;

--- a/extensions/codex/src/app-server/run-attempt-active-turn.ts
+++ b/extensions/codex/src/app-server/run-attempt-active-turn.ts
@@ -117,6 +117,16 @@ export async function activateCodexAttemptTurn(
       trajectoryRecorder,
       resolveDynamicToolResultContentSource: toolBridge.resultContentSourceForTool,
       onNativeToolResultRecorded: maybeAnnounceFastModeAutoOff,
+      onGuardianDeniedAction: async (pending) => {
+        const persisted = await bindingStore.mutate(bindingIdentity, {
+          kind: "patch",
+          threadId: resourceState.thread.threadId,
+          patch: { pendingGuardianDeniedAction: pending },
+        });
+        if (!persisted) {
+          throw new Error("failed to bind Codex Guardian denial to its native thread");
+        }
+      },
       ...(progressCardTool
         ? {
             onNativePlanUpdate: async (update: {

--- a/extensions/codex/src/app-server/run-attempt-turn-request.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-request.ts
@@ -9,6 +9,7 @@ import {
 } from "./attempt-diagnostics.js";
 import { isCodexAppServerIndeterminateRequestCancellationError } from "./client.js";
 import { resolveCodexExplicitSkillInputs } from "./explicit-skill-input.js";
+import { consumePendingGuardianDeniedAction } from "./guardian-denial-approval.js";
 import { assertCodexTurnStartResponse } from "./protocol-validators.js";
 import type { CodexTurnStartResponse } from "./protocol.js";
 import { readCodexRateLimitsRevision } from "./rate-limit-cache.js";
@@ -41,6 +42,8 @@ export async function prepareCodexAttemptTurnRequest(
     codexModelContentCapture,
     appServer,
     runAbortController,
+    bindingStore,
+    bindingIdentity,
   } = connection;
   const { state } = turnRuntime;
   const explicitSkillInputs = await resolveCodexExplicitSkillInputs({
@@ -98,6 +101,22 @@ export async function prepareCodexAttemptTurnRequest(
     throw error;
   };
   const startCodexTurn = async (): Promise<CodexTurnStartResponse> => {
+    await consumePendingGuardianDeniedAction({
+      pending: resourceState.thread.pendingGuardianDeniedAction,
+      prompt: params.prompt,
+      threadId: resourceState.thread.threadId,
+      request: (method, requestParams) =>
+        resourceState.client.request(method, requestParams, {
+          timeoutMs: appServer.requestTimeoutMs,
+          signal: runAbortController.signal,
+        }),
+      clear: () =>
+        bindingStore.mutate(bindingIdentity, {
+          kind: "patch",
+          threadId: resourceState.thread.threadId,
+          patch: { pendingGuardianDeniedAction: undefined },
+        }),
+    });
     const activeTurnRoute = (await ensureCurrentThreadRoute()) as {
       armTurn(): void;
       cancelTurn(): Promise<void>;

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -18,6 +18,7 @@ import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-s
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { z } from "zod";
 import { CODEX_PLUGIN_MARKETPLACE_NAME_PATTERN, normalizeCodexServiceTier } from "./config.js";
+import { pendingGuardianDeniedActionSchema } from "./guardian-denial-approval.js";
 import type { PluginAppPolicyContext } from "./plugin-thread-config.js";
 import type { CodexServiceTier } from "./protocol.js";
 
@@ -258,6 +259,7 @@ const threadBindingSchema = z
     /** Durable fact preventing a later unrestricted turn from widening this thread. */
     nativeToolPolicyRestricted: z.literal(true).optional().catch(undefined),
     nativeHookRelayGeneration: optionalNonBlankStringSchema,
+    pendingGuardianDeniedAction: pendingGuardianDeniedActionSchema.optional().catch(undefined),
     appServerRuntimeFingerprint: optionalStringSchema,
     pluginAppsFingerprint: optionalStringSchema,
     pluginAppsInputFingerprint: optionalStringSchema,


### PR DESCRIPTION
Closes #126505

## What Problem This Solves

Fixes an issue where users replying with a short approval such as `yes` or `approved` immediately after a Codex Guardian denial would be asked to repeat the already-disclosed action scope.

## Why This Change Was Made

The Codex app-server already exposes an exact-action approval RPC. This change preserves one completed denial on the bound native thread, recognizes only a narrow affirmative on the immediately following user turn, and calls that RPC before starting the new turn. Pending approvals expire after ten minutes, are single-use, and are discarded on an unrelated reply.

## User Impact

Users can approve the exact action they were just shown with a natural short reply. They are no longer required to restate a scripted approval phrase, while unrelated or stale replies cannot authorize an action.

## Evidence

- Added focused unit coverage for exact-action normalization, narrow affirmative recognition, expiry, unrelated replies, and fail-closed binding cleanup.
- Added event-projector coverage proving a completed denial is persisted with the exact native action.
- `104` focused Codex app-server tests pass.
- `pnpm check:changed` passes with the network-dependent dead-export scan skipped; the first run reached only that scan and failed because the registry was unavailable.
- Extension production and test typechecks, extension lint, formatting, import-cycle checks, and repository guardrails pass.
