### PR TITLE
fix(ui): side chat stays active in dashboard split view

### DIFF
--- a/ui/src/e2e/board-split-transcript.e2e.test.ts
+++ b/ui/src/e2e/board-split-transcript.e2e.test.ts
@@ -1,6 +1,8 @@
 // Regression: the chat transcript must repaint after a dashboard -> split face
 // switch re-stamps it into the sidebar region (issue: virtualizer stayed
 // detached until an unrelated re-render, painting a blank pane).
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -18,6 +20,7 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const sessionKey = "agent:main:board-split-transcript";
+const proofDir = path.resolve(".artifacts/control-ui-e2e/dashboard-side-chat-tabs");
 
 let browser: Browser;
 let controlUi: ControlUiE2eServer;
@@ -214,6 +217,71 @@ describeControlUiE2e("Board split transcript restore", () => {
     await expectSidePanelTabs(page, expectedTabLabels);
     expect(await sidePanel.locator('[data-panel-slot="chat"]').count()).toBe(1);
     expect(await gateway.getRequests("board.update")).toEqual([]);
+  }, 120_000);
+
+  it("activates Side chat from a split dashboard panel", async () => {
+    const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
+    if (recordProof) {
+      await mkdir(proofDir, { recursive: true });
+    }
+    const context = await browser.newContext({
+      viewport: { width: 1400, height: 900 },
+      ...(recordProof
+        ? { recordVideo: { dir: proofDir, size: { width: 1400, height: 900 } } }
+        : {}),
+    });
+    contexts.add(context);
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      sessionKey,
+      featureMethods: [
+        "board.get",
+        "board.update",
+        "chat.history",
+        "chat.metadata",
+        "chat.startup",
+        "sessions.companion.ask",
+      ],
+      methodResponses: {
+        "board.get": boardSnapshot("right"),
+        "board.update": boardSnapshot("right", 2),
+      },
+      historyMessages: [
+        { role: "user", content: "Keep the dashboard visible while I open a side chat." },
+        { role: "assistant", content: "The board chat is currently active." },
+      ],
+    });
+
+    try {
+      await showDashboard(page);
+      const sidePanel = page.locator(".side-panel");
+      await sidePanel.waitFor();
+      await openChatSidePanelType(page, "Side chat");
+      await expectSidePanelTabs(page, ["Board chat", "Side chat"]);
+      if (recordProof) {
+        await page.screenshot({ path: path.join(proofDir, "01-side-chat-added.png") });
+      }
+
+      await sidePanel.locator("wa-tab").filter({ hasText: "Side chat" }).click();
+      await sidePanel.locator('[data-panel-slot="companion"]:not([hidden])').waitFor();
+      await expect
+        .poll(() =>
+          sidePanel
+            .locator('[data-panel-slot="chat"]')
+            .evaluate((panel) => panel.hasAttribute("hidden")),
+        )
+        .toBe(true);
+      if (recordProof) {
+        await page.screenshot({ path: path.join(proofDir, "02-side-chat-active.png") });
+      }
+    } finally {
+      const video = page.video();
+      await context.close();
+      contexts.delete(context);
+      if (recordProof && video) {
+        await video.saveAs(path.join(proofDir, "dashboard-side-chat-tabs.webm"));
+      }
+    }
   }, 120_000);
 
   it("closes and reopens sole projected Board chat from either close control", async () => {

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.test.ts
@@ -133,6 +133,19 @@ describe("chat pane sidebar layout", () => {
     expect(closed.open).toBe(false);
   });
 
+  it("does not reactivate projected Board chat over the selected side-panel tab", () => {
+    const selectedSideChat = openSlot(openSlot({ columns: [] }, "chat"), "companion");
+
+    const layout = resolveSidebarLayoutForBoard({
+      board: board("right"),
+      layout: selectedSideChat,
+      paneWidth: 1_400,
+    });
+
+    expect(layout.columns[0]?.panels.map((panel) => panel.slot)).toEqual(["chat", "companion"]);
+    expect(layout.columns[0]?.activePanelId).toBe("companion");
+  });
+
   it("keeps bottom and hidden board chat outside the side panel", () => {
     for (const dock of ["bottom", "hidden"] as const) {
       const layout = resolveSidebarLayoutForBoard({

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.ts
@@ -202,7 +202,14 @@ export function resolveSidebarLayoutForBoard(params: {
     return fitSidebarLayout(layout, params.paneWidth) ?? layout;
   }
   const explicitlyClosed = layout.columns.length > 0 && layout.open === false;
-  layout = { ...openSlot(layout, "chat"), open: !explicitlyClosed };
+  const selectedPanelId = layout.columns[0]?.activePanelId;
+  layout = openSlot(layout, "chat");
+  // Board projection must guarantee the chat tab exists without stealing the
+  // user's selected side-panel tab on every render.
+  if (selectedPanelId) {
+    layout = activatePanel(layout, selectedPanelId);
+  }
+  layout = { ...layout, open: !explicitlyClosed };
   return fitSidebarLayout(layout, params.paneWidth) ?? layout;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users clicking **Side chat** in the Control UI dashboard split view would remain on the original Board chat panel. The same Side chat action already worked outside dashboard view.

## Why This Change Was Made

Dashboard projection ensured Board chat existed by calling a helper that also activates Board chat on every render. This change remembers the selected side-panel slot, ensures Board chat exists, then restores the user's selection. Explicitly opening the dock still intentionally activates Board chat, and explicitly closing the panel remains preserved.

## User Impact

Users can open and select Side chat from a dashboard split view, and the selected tab now stays active. There are no config, protocol, or storage changes.

Release-note context: Fixed Control UI dashboard split view so selecting Side chat no longer snaps back to Board chat.

## Evidence

### Visual before/after

- [Team-only Crabbox proof page with both recordings and screenshots](https://crabdrop.openclaw.ai/drops/patrick-erichsen/openclaw-dashboard-side-chat-proof/)
- Before: [direct AWS Crabbox run `run_9ff5121fd861`](https://crabbox.openclaw.ai/portal/runs/run_9ff5121fd861) — expected regression failure; Side chat's companion panel never became visible (3 passed, 1 failed).
- After: [direct AWS Crabbox run `run_d146d103aa27`](https://crabbox.openclaw.ai/portal/runs/run_d146d103aa27) — 8/8 focused unit tests and 4/4 Playwright E2E tests passed, with the after recording captured in the same run.
- Provider/lease: direct AWS Crabbox, `cbx_770013b9df14` (released).

### Exact-head validation

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-sidebar-layout.test.ts` — 8 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/board-split-transcript.e2e.test.ts` — 4 passed.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs ui/src/pages/chat/chat-pane-sidebar-layout.ts ui/src/pages/chat/chat-pane-sidebar-layout.test.ts ui/src/e2e/board-split-transcript.e2e.test.ts` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Isolated Codex autoreview (`gpt-5.6-sol`, high reasoning) — no accepted/actionable findings; patch correct at 0.99 confidence.

<details>
<summary>Infrastructure note</summary>

Broader remote changed-gate attempts did not reach repository checks: direct AWS lost SSH during sync, and Blacksmith Testbox run [32319733393](https://github.com/openclaw/openclaw/actions/runs/32319733393) timed out during checkout sync. These were infrastructure failures, not test failures; the focused local and Crabbox proofs above completed successfully.

</details>

### Regression provenance

The dashboard projection path came from the unified tabbed side-panel work in #123874 (`aed4510bd094`, authored by @vyctorbrzezowski on 2026-08-15). The activating projection line was subsequently touched by #126397 (`5976e74d1cc8`, authored by @steipete on 2026-08-19). This PR repairs the projection owner boundary rather than adding a click-handler workaround.
