### PR TITLE
fix: group onboarding agent imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Onboarding migration menu:** group Claude, Codex, Hermes, and plugin-provided imports under a single **Import from another agent** setup choice while preserving detected source hints and manual paths. Fixes #126440. Thanks @shakkernerd.
 - **Onboarding provider hook loading:** scope selected-model hook fallback to the chosen provider so metadata-only setup providers do not load unrelated plugins before configuration completes. Fixes #126408. Thanks @shakkernerd.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Onboarding migration menu:** group Claude, Codex, Hermes, and plugin-provided imports under a single **Import from another agent** setup choice while preserving detected source hints and manual paths. Fixes #126440. Thanks @shakkernerd.
+- **Onboarding migration menu:** group Claude, Codex, Hermes, and plugin-provided imports under a single **Import from another agent** setup choice while preserving detected source hints, manual paths, and Back navigation before import begins. Fixes #126440. Thanks @shakkernerd.
 - **Onboarding provider hook loading:** scope selected-model hook fallback to the chosen provider so metadata-only setup providers do not load unrelated plugins before configuration completes. Fixes #126408. Thanks @shakkernerd.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -38,9 +38,12 @@ not install or modify anything on the remote host.
     - With a configured default model, **Keep existing model config** appears
       first and becomes the default, followed by **QuickStart (recommended)**
       and **Manual setup**.
-    - Each detected migration source adds an **Import from &lt;source&gt;** choice
-      after those setup choices. Explicit import flags dispatch the import
-      directly and skip this menu.
+    - When a migration provider is available, **Import from another agent**
+      appears after those setup choices. Selecting it opens a provider list
+      with entries such as **Import from Claude**, **Import from Codex**, and
+      **Import from Hermes**. Detected sources appear first with their paths;
+      other available providers ask for a source path. Explicit import flags
+      dispatch the import directly and skip this menu.
     - Re-running the wizard does not wipe anything unless you pass `--reset`.
       Reset is a command flag, not a setup-mode choice.
     - `--reset-scope` accepts `config` (config only),

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -43,7 +43,8 @@ not install or modify anything on the remote host.
       with entries such as **Import from Claude**, **Import from Codex**, and
       **Import from Hermes**. Detected sources appear first with their paths;
       other available providers ask for a source path. Explicit import flags
-      dispatch the import directly and skip this menu.
+      dispatch the import directly and skip this menu. Use Back from the
+      provider list to return to **Setup mode** before an import begins.
     - Re-running the wizard does not wipe anything unless you pass `--reset`.
       Reset is a command flag, not a setup-mode choice.
     - `--reset-scope` accepts `config` (config only),

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -128,7 +128,8 @@ menu is built from the current installation:
   after the setup choices. Selecting it opens provider-specific entries such as
   **Import from Claude**, **Import from Codex**, and **Import from Hermes**.
   Detected sources appear first with their paths; other available providers ask
-  for a source path.
+  for a source path. Use Back from the provider list to return to **Setup mode**
+  before an import begins.
 
 Pass `--flow quickstart` or `--flow manual` (alias `advanced`) to select a
 classic setup flow and skip that prompt. Import flags select the import flow

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -124,8 +124,11 @@ menu is built from the current installation:
 - With a configured default model, **Keep existing model config** appears first
   and is selected by default, followed by **QuickStart (recommended)** and
   **Manual setup**.
-- Each detected migration source adds an **Import from &lt;source&gt;** choice
-  after the setup choices.
+- When a migration provider is available, **Import from another agent** appears
+  after the setup choices. Selecting it opens provider-specific entries such as
+  **Import from Claude**, **Import from Codex**, and **Import from Hermes**.
+  Detected sources appear first with their paths; other available providers ask
+  for a source path.
 
 Pass `--flow quickstart` or `--flow manual` (alias `advanced`) to select a
 classic setup flow and skip that prompt. Import flags select the import flow

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -85,6 +85,9 @@ async function runNonInteractiveMigrationImport(params: {
       return committed.nextConfig;
     },
   });
+  if (outcome.kind === "back") {
+    throw new Error("Non-interactive migration import cannot navigate back.");
+  }
   await outcome.acknowledgePromotion?.();
 }
 

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -126,6 +126,7 @@ export const en = {
       complete: "Migration complete. Run `openclaw doctor` next.",
       continuing: "Migration complete. Continuing setup.",
       importFrom: "Import from {source}",
+      importFromAnotherAgent: "Import from another agent",
       includeCredentials: "Import supported auth credentials too?",
       previewTitle: "Migration preview",
       setupModelSeparately: "Set up a model separately",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -125,6 +125,7 @@ export const zh_CN = {
       complete: "迁移完成。下一步运行 `openclaw doctor`。",
       continuing: "迁移完成。继续设置。",
       importFrom: "从 {source} 导入",
+      importFromAnotherAgent: "从其他 agent 导入",
       includeCredentials: "同时导入支持的认证凭据？",
       previewTitle: "迁移预览",
       setupModelSeparately: "单独设置模型",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -125,6 +125,7 @@ export const zh_TW = {
       complete: "遷移完成。下一步執行 `openclaw doctor`。",
       continuing: "遷移完成。繼續設定。",
       importFrom: "從 {source} 匯入",
+      importFromAnotherAgent: "從其他 agent 匯入",
       includeCredentials: "也匯入支援的認證憑證？",
       previewTitle: "遷移預覽",
       setupModelSeparately: "另外設定模型",

--- a/src/wizard/setup.migration-import.test.ts
+++ b/src/wizard/setup.migration-import.test.ts
@@ -144,12 +144,12 @@ describe("setup migration import options", () => {
     });
   });
 
-  it("offers bundled manifest migration providers before plugin activation", () => {
+  it("lists bundled providers for the nested migration source picker", () => {
     expect(initialOptions).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ providerId: "codex", label: "Codex" }),
-        expect.objectContaining({ providerId: "claude", label: "Claude" }),
-        expect.objectContaining({ providerId: "hermes", label: "Hermes" }),
+        expect.objectContaining({ providerId: "codex", label: "Import from Codex" }),
+        expect.objectContaining({ providerId: "claude", label: "Import from Claude" }),
+        expect.objectContaining({ providerId: "hermes", label: "Import from Hermes" }),
       ]),
     );
   });

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -180,7 +180,7 @@ export async function listSetupMigrationOptions(params: {
   for (const detection of params.detections) {
     addOption({
       providerId: detection.providerId,
-      label: detection.label,
+      label: t("wizard.migration.importFrom", { source: detection.label }),
       ...(detection.source || detection.message
         ? { hint: detection.source ?? detection.message }
         : {}),
@@ -189,14 +189,14 @@ export async function listSetupMigrationOptions(params: {
   for (const provider of providers) {
     addOption({
       providerId: provider.id,
-      label: provider.label,
+      label: t("wizard.migration.importFrom", { source: provider.label }),
       hint: provider.description ?? t("wizard.migration.sourcePathHint"),
     });
   }
   for (const provider of resolveManifestSetupMigrationProviders(params.baseConfig)) {
     addOption({
       providerId: provider.providerId,
-      label: provider.label,
+      label: t("wizard.migration.importFrom", { source: provider.label }),
       hint: provider.description ?? t("wizard.migration.sourcePathHint"),
     });
   }

--- a/src/wizard/setup.migration-import.ts
+++ b/src/wizard/setup.migration-import.ts
@@ -15,6 +15,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { t } from "./i18n/index.js";
+import { runWizardWithPromptNavigationScope } from "./navigation-prompter.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
 import { offerLiveModelVerification } from "./setup.inference-verification.js";
 import {
@@ -209,7 +210,8 @@ async function selectSetupMigrationProvider(params: {
   baseConfig: OpenClawConfig;
   detections: readonly SetupMigrationDetection[];
   prompter: WizardPrompter;
-}): Promise<string> {
+  allowBack: boolean;
+}): Promise<string | undefined> {
   const options = await listSetupMigrationOptions({
     baseConfig: params.baseConfig,
     detections: params.detections,
@@ -223,9 +225,9 @@ async function selectSetupMigrationProvider(params: {
   if (options.length === 0) {
     throw new Error("No migration providers found.");
   }
-  const providerId =
-    requestedProviderId ||
-    (await params.prompter.select({
+  let providerId = requestedProviderId;
+  if (!providerId) {
+    const prompt = {
       message: t("wizard.migration.source"),
       options: options.map((option) => ({
         value: option.providerId,
@@ -233,7 +235,20 @@ async function selectSetupMigrationProvider(params: {
         ...(option.hint ? { hint: option.hint } : {}),
       })),
       initialValue: params.detections[0]?.providerId ?? options[0]?.providerId,
-    }));
+    };
+    if (!params.allowBack) {
+      params.prompter.disableBackNavigation?.();
+      return await params.prompter.select(prompt);
+    }
+    const selection = await runWizardWithPromptNavigationScope(
+      params.prompter,
+      async (prompter) => await prompter.select(prompt),
+    );
+    if (selection.status === "back") {
+      return undefined;
+    }
+    providerId = selection.value;
+  }
   if (!options.some((option) => option.providerId === providerId)) {
     throw new Error(
       `Migration provider "${providerId}" is not installed or bundled. Install it before starting the transactional import.`,
@@ -303,8 +318,9 @@ export async function runSetupMigrationImport(params: {
     config: OpenClawConfig,
     expectedConfig: OpenClawConfig,
   ) => Promise<OpenClawConfig>;
+  allowProviderBack?: boolean;
   continueOnboarding?: boolean;
-}): Promise<Awaited<ReturnType<typeof finalizeSetupMigrationPromotion>>> {
+}): Promise<{ kind: "back" } | Awaited<ReturnType<typeof finalizeSetupMigrationPromotion>>> {
   const [
     { applyLocalSetupWorkspaceConfig, applySkipBootstrapConfig },
     { createMigrationLogger, buildMigrationReportDir },
@@ -323,7 +339,12 @@ export async function runSetupMigrationImport(params: {
     baseConfig: params.baseConfig,
     detections: params.detections,
     prompter: params.prompter,
+    allowBack: params.allowProviderBack === true,
   });
+  if (!providerId) {
+    return { kind: "back" };
+  }
+  params.prompter.disableBackNavigation?.();
   const workspaceInput =
     params.opts.workspace ??
     (params.opts.nonInteractive

--- a/src/wizard/setup.migration-transaction.test.ts
+++ b/src/wizard/setup.migration-transaction.test.ts
@@ -16,7 +16,12 @@ import {
   listOpenClawRegisteredAgentDatabases,
   registerOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db-registry.js";
-import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
+import {
+  WizardCancelledError,
+  WizardNavigationError,
+  type WizardPrompter,
+  type WizardSelectParams,
+} from "./prompts.js";
 
 const mocks = vi.hoisted(() => ({
   canonicalMutateConfigFile: vi.fn(),
@@ -184,6 +189,7 @@ async function runImport(params: {
   root: string;
   source: string;
   currentConfig: { value: Record<string, unknown> };
+  interactivePrompter?: WizardPrompter;
   commit?: (
     config: Record<string, unknown>,
     expectedConfig: Record<string, unknown>,
@@ -194,15 +200,15 @@ async function runImport(params: {
   process.env.OPENCLAW_STATE_DIR = path.join(params.root, "openclaw-state");
   return await runSetupMigrationImport({
     opts: {
-      importFrom: "claude",
       importSource: params.source,
-      nonInteractive: true,
       workspace,
+      ...(params.interactivePrompter ? {} : { importFrom: "claude", nonInteractive: true }),
     },
     baseConfig: {},
     detections: [],
-    prompter: prompter(),
+    prompter: params.interactivePrompter ?? prompter(),
     runtime: runtime(),
+    allowProviderBack: params.interactivePrompter !== undefined,
     readConfigFile: async () => structuredClone(params.currentConfig.value),
     commitConfigFile: async (config, expectedConfig) => {
       const committed = params.commit
@@ -271,6 +277,29 @@ afterEach(async () => {
 });
 
 describe("transactional setup migration import", () => {
+  it("returns before migration side effects when the source picker goes back", async () => {
+    const root = tempRoots.make("openclaw-migration-back-");
+    const source = path.join(root, "source-memory.md");
+    await fs.writeFile(source, "remember this\n", "utf8");
+    mocks.provider = provider({ source });
+    const currentConfig = { value: {} };
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      expect(params.navigation).toMatchObject({ canGoBack: true });
+      throw new WizardNavigationError("back");
+    }) as WizardPrompter["select"];
+
+    await expect(
+      runImport({
+        root,
+        source,
+        currentConfig,
+        interactivePrompter: { ...prompter(), select },
+      }),
+    ).resolves.toEqual({ kind: "back" });
+    expect(currentConfig.value).toEqual({});
+    await expect(fs.access(path.join(root, "workspace", "MEMORY.md"))).rejects.toThrow();
+  });
+
   it("promotes a Claude import with no model and returns no imported inference", async () => {
     const root = tempRoots.make("openclaw-migration-transaction-");
     const source = path.join(root, "source-memory.md");

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1576,11 +1576,15 @@ describe("runSetupWizard", () => {
     },
   ])("returns to setup mode after an interactive import $label", async ({ error, detail }) => {
     const workspaceDir = await makeCaseDir("import-retry-");
-    listSetupMigrationOptions.mockResolvedValueOnce([{ providerId: "hermes", label: "Hermes" }]);
+    listSetupMigrationOptions.mockResolvedValueOnce([
+      { providerId: "hermes", label: "Import from Hermes" },
+    ]);
     runSetupMigrationImport.mockRejectedValueOnce(error);
-    const setupChoices: Array<"import:hermes" | "quickstart"> = ["import:hermes", "quickstart"];
-    const select = vi.fn(async ({ message }: WizardSelectParams<unknown>) => {
-      if (message === "Setup mode") {
+    const setupChoices: Array<"import" | "quickstart"> = ["import", "quickstart"];
+    const setupPrompts: WizardSelectParams<unknown>[] = [];
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      if (params.message === "Setup mode") {
+        setupPrompts.push(params);
         return setupChoices.shift();
       }
       return "__skip__";
@@ -1604,6 +1608,11 @@ describe("runSetupWizard", () => {
     );
 
     expect(select.mock.calls.filter(([params]) => params.message === "Setup mode")).toHaveLength(2);
+    expect(setupPrompts[0]?.options).toEqual([
+      expect.objectContaining({ value: "quickstart", label: "QuickStart (recommended)" }),
+      expect.objectContaining({ value: "advanced", label: "Manual setup" }),
+      expect.objectContaining({ value: "import", label: "Import from another agent" }),
+    ]);
     expect(runSetupMigrationImport).toHaveBeenCalledOnce();
     expect(prompter.note).toHaveBeenCalledWith(
       expect.stringContaining(detail),

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1581,10 +1581,13 @@ describe("runSetupWizard", () => {
     ]);
     runSetupMigrationImport.mockRejectedValueOnce(error);
     const setupChoices: Array<"import" | "quickstart"> = ["import", "quickstart"];
-    const setupPrompts: WizardSelectParams<unknown>[] = [];
     const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
       if (params.message === "Setup mode") {
-        setupPrompts.push(params);
+        expect(params.options).toEqual([
+          expect.objectContaining({ value: "quickstart", label: "QuickStart (recommended)" }),
+          expect.objectContaining({ value: "advanced", label: "Manual setup" }),
+          expect.objectContaining({ value: "import", label: "Import from another agent" }),
+        ]);
         return setupChoices.shift();
       }
       return "__skip__";
@@ -1608,16 +1611,44 @@ describe("runSetupWizard", () => {
     );
 
     expect(select.mock.calls.filter(([params]) => params.message === "Setup mode")).toHaveLength(2);
-    expect(setupPrompts[0]?.options).toEqual([
-      expect.objectContaining({ value: "quickstart", label: "QuickStart (recommended)" }),
-      expect.objectContaining({ value: "advanced", label: "Manual setup" }),
-      expect.objectContaining({ value: "import", label: "Import from another agent" }),
-    ]);
     expect(runSetupMigrationImport).toHaveBeenCalledOnce();
     expect(prompter.note).toHaveBeenCalledWith(
       expect.stringContaining(detail),
       "Existing config detected",
     );
+    expect(finalizeSetupWizard).toHaveBeenCalledOnce();
+  });
+
+  it("returns from the migration picker without restarting setup", async () => {
+    const workspaceDir = await makeCaseDir("import-back-");
+    listSetupMigrationOptions.mockResolvedValueOnce([
+      { providerId: "hermes", label: "Import from Hermes" },
+    ]);
+    runSetupMigrationImport.mockResolvedValueOnce({ kind: "back" });
+    const setupChoices: Array<"import" | "quickstart"> = ["import", "quickstart"];
+    const select = vi.fn(async ({ message }: WizardSelectParams<unknown>) =>
+      message === "Setup mode" ? setupChoices.shift() : "__skip__",
+    );
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        authChoice: "skip",
+        installDaemon: false,
+        skipChannels: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipUi: true,
+        workspace: workspaceDir,
+      },
+      createRuntime(),
+      buildWizardPrompter({ select: select as unknown as WizardPrompter["select"] }),
+    );
+
+    expect(select.mock.calls.filter(([params]) => params.message === "Setup mode")).toHaveLength(2);
+    expect(detectSetupMigrationSources).toHaveBeenCalledOnce();
+    expect(runSetupMigrationImport).toHaveBeenCalledOnce();
     expect(finalizeSetupWizard).toHaveBeenCalledOnce();
   });
 

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -224,7 +224,6 @@ async function runSetupWizardOnce(
   let importedInferenceVerified = false;
   while (opts.importFrom || flow === "import" || flow.startsWith("import:")) {
     const importFrom = opts.importFrom ?? (flow.startsWith("import:") ? flow.slice(7) : undefined);
-    prompter.disableBackNavigation?.();
     let migrationOutcome: Awaited<ReturnType<typeof runSetupMigrationImport>>;
     try {
       migrationOutcome = await runSetupMigrationImport({
@@ -252,8 +251,13 @@ async function runSetupWizardOnce(
             ...(latest.hash !== undefined ? { baseHash: latest.hash } : {}),
           });
         },
+        allowProviderBack: flowFromPrompt,
         continueOnboarding: true,
       });
+      if (migrationOutcome.kind === "back") {
+        ({ flow, keepExistingModelConfig } = await normalizeSetupFlow(await promptSetupFlow()));
+        continue;
+      }
     } catch (error) {
       const canReturnToSetupMode =
         error instanceof SetupMigrationFreshnessError ||

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -152,16 +152,6 @@ async function runSetupWizardOnce(
     baseConfig,
     detections: migrationDetections,
   });
-  const importOptions = migrationOptions.map((option) => {
-    const choice: { value: `import:${string}`; label: string; hint?: string } = {
-      value: `import:${option.providerId}`,
-      label: t("wizard.migration.importFrom", { source: option.label }),
-    };
-    if (option.hint) {
-      choice.hint = option.hint;
-    }
-    return choice;
-  });
   const explicitFlowRaw = opts.flow?.trim();
   const normalizedExplicitFlow = explicitFlowRaw === "manual" ? "advanced" : explicitFlowRaw;
   if (
@@ -202,7 +192,9 @@ async function runSetupWizardOnce(
         ...(keepModelOption ? [keepModelOption] : []),
         { value: "quickstart", label: t("wizard.setup.flowQuickstart"), hint: quickstartHint },
         { value: "advanced", label: t("wizard.setup.flowAdvanced"), hint: manualHint },
-        ...importOptions,
+        ...(migrationOptions.length > 0
+          ? [{ value: "import" as const, label: t("wizard.migration.importFromAnotherAgent") }]
+          : []),
       ],
       initialValue: hasExistingModelConfig ? "keep-model" : "quickstart",
     });


### PR DESCRIPTION
## Summary

- Replace provider-specific import rows in the main **Setup mode** menu with one **Import from another agent** choice.
- Preserve **Import from Claude**, **Import from Codex**, **Import from Hermes**, detected paths, and plugin-provided importers in the nested source picker.
- Allow users to go Back from **Migration source** to **Setup mode** before an import begins.
- Preserve explicit and non-interactive import flags.

## Problem

Classic onboarding presented every bundled migration provider as a top-level setup mode, even when no corresponding source state existed. This made available import capabilities look like locally detected agents.

After grouping those capabilities into a nested picker, the migration flow also disabled Back before displaying that picker, preventing users from returning to QuickStart or Manual setup.

## Solution

Setup mode now exposes one generic import entry whenever at least one migration provider is available.

The existing provider list remains manifest-driven and keeps the current provider-specific labels and hints. Detected sources remain first and reuse their detected paths; undetected providers continue to support manually supplied or copied source directories.

Back navigation remains enabled through provider and workspace selection. It is disabled only when the migration owner reaches the existing state-lock and recovery boundary, before any import side effects can begin.

## Commits

1. `fix: group agent imports in onboarding`
2. `fix: allow backing out of agent imports`

## Verification

- Captured focused pre-fix failures for the top-level menu shape and disabled nested Back navigation.
- 82 focused setup, migration option, and transactional import tests passed remotely.
- Full changed-file checks completed successfully.
- Full production build completed successfully.
- Live classic-onboarding verification confirmed the nested provider labels and detected source hint.
- Exact-head autoreview completed with no actionable findings.

Fixes #126440
