### PR TITLE
fix(gateway): preserve managed Tailscale ingress compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Tailscale managed ingress:** keep Funnel URLs usable from tailnet peers while still requiring the configured password, and release foreground Serve/Funnel claims when an interactive Gateway exits.
 - **Onboarding provider hook loading:** scope selected-model hook fallback to the chosen provider so metadata-only setup providers do not load unrelated plugins before configuration completes. Fixes #126408. Thanks @shakkernerd.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Tailscale managed ingress:** keep Funnel URLs usable from tailnet peers while still requiring the configured password, and release foreground Serve/Funnel claims when an interactive Gateway exits.
 - **Onboarding provider hook loading:** scope selected-model hook fallback to the chosen provider so metadata-only setup providers do not load unrelated plugins before configuration completes. Fixes #126408. Thanks @shakkernerd.
 - **Plugin setup diagnostics:** stop treating metadata-only provider setup descriptors as missing runtime registrations while retaining undeclared runtime and CLI drift warnings. Fixes #125506. Thanks @shakkernerd.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.

--- a/docs/gateway/tailscale.md
+++ b/docs/gateway/tailscale.md
@@ -76,6 +76,11 @@ When a bindable Tailnet IPv4 is present, the Gateway also requires `http://127.0
 
 Prefer `OPENCLAW_GATEWAY_PASSWORD` over committing a password to disk.
 
+The Funnel URL also remains usable from devices inside the tailnet. Tailscale marks public
+requests as Funnel traffic but sends tailnet peers through its Serve identity path instead;
+OpenClaw recognizes both paths on its dedicated listener and still requires the configured
+Funnel password.
+
 ## CLI examples
 
 ```bash
@@ -128,7 +133,8 @@ This compatibility path does not grant managed Tailscale semantics: `gateway.aut
 ### Tailscale prerequisites and limits
 
 - Serve requires HTTPS enabled for your tailnet; the CLI prompts if it is missing.
-- Serve injects Tailscale identity headers; Funnel does not.
+- Tailnet Serve traffic injects Tailscale identity headers. Public Funnel traffic uses a Funnel
+  marker instead, while tailnet access to the same Funnel URL follows the Serve identity path.
 - OpenClaw-managed Serve/Funnel proxy to a dedicated `127.0.0.1:<ephemeral-port>` listener while ordinary local clients keep the configured Gateway port. Startup fails closed rather than sharing listener provenance, and the foreground claim releases the route when its Gateway owner disappears.
 - Funnel requires Tailscale v1.38.3+, MagicDNS, HTTPS enabled, and a funnel node attribute.
 - Funnel only supports ports `443`, `8443`, and `10000` over TLS.

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -768,6 +768,33 @@ describe("gateway auth", () => {
     ).resolves.toMatchObject({ ok: true, method: "password" });
   });
 
+  it("uses password auth for tailnet peers on managed Funnel", async () => {
+    const req = createTailscaleForwardedReq(false);
+    markGatewayIngressTransport(req, { kind: "managed-tailscale", mode: "funnel" });
+
+    await expect(
+      authorizeWsControlUiGatewayConnect({
+        auth: { mode: "password", password: "secret", allowTailscale: false },
+        connectAuth: { password: "secret" },
+        req,
+      }),
+    ).resolves.toMatchObject({ ok: true, method: "password" });
+  });
+
+  it("requires the Funnel password when Tailscale header auth is explicitly enabled", async () => {
+    const req = createTailscaleForwardedReq(false);
+    markGatewayIngressTransport(req, { kind: "managed-tailscale", mode: "funnel" });
+
+    await expect(
+      authorizeWsControlUiGatewayConnect({
+        auth: { mode: "password", password: "secret", allowTailscale: true },
+        connectAuth: null,
+        tailscaleWhois: createTailscaleWhois(),
+        req,
+      }),
+    ).resolves.toMatchObject({ ok: false, reason: "password_missing" });
+  });
+
   it("allows an origin-less same-origin image through the profile avatar surface", async () => {
     const limiter = createLimiterSpy();
     const req = createTailscaleForwardedReq();

--- a/src/gateway/ingress-attribution.test.ts
+++ b/src/gateway/ingress-attribution.test.ts
@@ -136,8 +136,19 @@ describe("gateway ingress attribution", () => {
     });
   });
 
-  it("requires the Tailscale Funnel marker on the managed Funnel listener", async () => {
+  it("attributes unmarked tailnet traffic to the managed Funnel policy", async () => {
+    const req = request({ forwardedFor: "100.64.0.10", login: "alice@example.com" });
+    markGatewayIngressTransport(req, { kind: "managed-tailscale", mode: "funnel" });
+
+    expect(prepareGatewayIngressAttribution({ req })).toMatchObject({
+      kind: "tailscale-funnel",
+      clientIp: "100.64.0.10",
+    });
+  });
+
+  it("rejects an invalid marker on the managed Funnel listener", async () => {
     const req = request({ forwardedFor: "203.0.113.10" });
+    req.headers["tailscale-funnel-request"] = "?0";
     markGatewayIngressTransport(req, { kind: "managed-tailscale", mode: "funnel" });
 
     expect(prepareGatewayIngressAttribution({ req })).toMatchObject({

--- a/src/gateway/ingress-attribution.ts
+++ b/src/gateway/ingress-attribution.ts
@@ -162,7 +162,7 @@ function resolveManagedTailscaleIngress(params: {
   }
   const funnelMarker = headerValue(req.headers?.["tailscale-funnel-request"]);
   if (mode === "funnel") {
-    return funnelMarker === "?1"
+    return !funnelMarker || funnelMarker === "?1"
       ? attributed("tailscale-funnel", clientIp)
       : unattributableProxy(remoteAddress);
   }

--- a/src/gateway/server-runtime-state.tailscale.test.ts
+++ b/src/gateway/server-runtime-state.tailscale.test.ts
@@ -145,7 +145,7 @@ describe("managed Tailscale gateway ingress", () => {
     expect(managed.status).toBe(200);
   });
 
-  it("requires the Funnel marker on the dedicated Funnel listener", async () => {
+  it("accepts tailnet and public ingress on the dedicated Funnel listener", async () => {
     const runtime = await createGatewayRuntimeStateForTest(undefined, {
       tailscaleMode: "funnel",
       getReadiness: () => ({ ready: true, failing: [], uptimeMs: 1 }),
@@ -174,9 +174,16 @@ describe("managed Tailscale gateway ingress", () => {
       path: "/ready",
       headers: { ...baseHeaders, "tailscale-funnel-request": "?1" },
     });
+    const malformedMarker = await requestStatus({
+      host: endpoint.host,
+      port: endpoint.port,
+      path: "/ready",
+      headers: { ...baseHeaders, "tailscale-funnel-request": "true" },
+    });
 
-    expect(missingMarker.status).toBe(403);
+    expect(missingMarker.status).toBe(200);
     expect(marked.status).toBe(200);
+    expect(malformedMarker.status).toBe(403);
   });
 
   it("rejects external Funnel ingress when gateway auth is disabled", async () => {

--- a/src/infra/tailscale-route-owner.worker.test.ts
+++ b/src/infra/tailscale-route-owner.worker.test.ts
@@ -8,6 +8,24 @@ import {
 } from "./tailscale-route-owner-protocol.js";
 import { runTailscaleRouteOwner } from "./tailscale-route-owner.worker.js";
 
+function spawnRouteOwnerFixture() {
+  const workerPath = fileURLToPath(new URL("./tailscale-route-owner.worker.ts", import.meta.url));
+  const fixturePath = fileURLToPath(
+    new URL("../../test/fixtures/tailscale-foreground-fixture.mjs", import.meta.url),
+  );
+  const worker = fork(
+    workerPath,
+    [
+      TAILSCALE_ROUTE_OWNER_ARG,
+      JSON.stringify({ argv: [fixturePath, "serve", "--yes", "--bg=false", "18789"] }),
+    ],
+    { execArgv: ["--import", "tsx"], stdio: ["ignore", "ignore", "ignore", "ipc"] },
+  );
+  const messages: TailscaleRouteOwnerMessage[] = [];
+  worker.on("message", (message: TailscaleRouteOwnerMessage) => messages.push(message));
+  return { messages, worker };
+}
+
 describe("Tailscale route owner", () => {
   it("reports readiness and terminates the foreground claim when its owner stops", async () => {
     const messages: TailscaleRouteOwnerMessage[] = [];
@@ -49,22 +67,7 @@ describe("Tailscale route owner", () => {
   it.runIf(process.platform !== "win32")(
     "terminates the claim when the Gateway IPC owner disappears",
     async () => {
-      const workerPath = fileURLToPath(
-        new URL("./tailscale-route-owner.worker.ts", import.meta.url),
-      );
-      const fixturePath = fileURLToPath(
-        new URL("../../test/fixtures/tailscale-foreground-fixture.mjs", import.meta.url),
-      );
-      const worker = fork(
-        workerPath,
-        [
-          TAILSCALE_ROUTE_OWNER_ARG,
-          JSON.stringify({ argv: [fixturePath, "serve", "--yes", "--bg=false", "18789"] }),
-        ],
-        { execArgv: ["--import", "tsx"], stdio: ["ignore", "ignore", "ignore", "ipc"] },
-      );
-      const messages: TailscaleRouteOwnerMessage[] = [];
-      worker.on("message", (message: TailscaleRouteOwnerMessage) => messages.push(message));
+      const { messages, worker } = spawnRouteOwnerFixture();
       try {
         await vi.waitFor(() => {
           expect(messages).toContainEqual({ type: "ready" });
@@ -80,6 +83,46 @@ describe("Tailscale route owner", () => {
       } finally {
         if (worker.exitCode === null && worker.signalCode === null) {
           worker.kill("SIGKILL");
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "terminates the claim before exiting on an interactive interrupt",
+    async () => {
+      const { messages, worker } = spawnRouteOwnerFixture();
+      let routePid: number | undefined;
+      try {
+        await vi.waitFor(() => {
+          expect(messages).toContainEqual({ type: "ready" });
+        });
+        const spawned = messages.find((message) => message.type === "spawned");
+        if (!spawned) {
+          throw new Error("route owner did not report its claim process");
+        }
+        routePid = spawned.pid;
+        const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+          (resolve) => {
+            worker.once("exit", (code, signal) => resolve({ code, signal }));
+          },
+        );
+        worker.kill("SIGINT");
+
+        await expect(exit).resolves.toEqual({ code: 0, signal: null });
+        await vi.waitFor(() => {
+          expect(() => process.kill(spawned.pid, 0)).toThrow();
+        });
+      } finally {
+        if (worker.exitCode === null && worker.signalCode === null) {
+          worker.kill("SIGKILL");
+        }
+        if (routePid) {
+          try {
+            process.kill(routePid, "SIGKILL");
+          } catch {
+            // Already released by the worker.
+          }
         }
       }
     },

--- a/src/infra/tailscale-route-owner.worker.ts
+++ b/src/infra/tailscale-route-owner.worker.ts
@@ -137,6 +137,11 @@ export function runTailscaleRouteOwner(
 if (process.argv[2] === TAILSCALE_ROUTE_OWNER_ARG) {
   try {
     const owner = runTailscaleRouteOwner(parseStart(process.argv[3]));
+    // Terminal signals reach this worker with the Gateway process group. Drain the
+    // detached route child first or the HTTPS port remains claimed after Gateway exit.
+    for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"] as const) {
+      process.once(signal, owner.stop);
+    }
     process.once("disconnect", owner.stop);
     process.once("message", (message: unknown) => {
       if (isRecord(message) && message.type === "stop") {


### PR DESCRIPTION
## What Problem This Solves

Fixes two upgrade-sensitive managed Tailscale regressions found during cross-platform release testing:

- Tailnet peers opening a managed Funnel URL were rejected even with the configured Gateway password.
- Interrupting an interactive managed Serve/Funnel Gateway could leave the foreground Tailscale route claimed.

## Why This Change Was Made

Tailscale distinguishes public Funnel ingress from tailnet access to the same Funnel hostname: public requests carry `Tailscale-Funnel-Request: ?1`, while authenticated tailnet requests use the Serve identity-header path without that marker. Managed Funnel now accepts both of those upstream-defined forms while continuing to require password authentication for both. Missing-marker acceptance remains scoped to the dedicated managed Funnel listener; malformed markers and unattributable ordinary-listener proxy traffic still fail closed.

The route-owner worker now drains its detached Tailscale child when the worker itself receives a terminal signal. This preserves the existing single route owner and cleanup flow instead of adding a parallel recovery path.

Upstream contract checked directly: [Tailscale Serve/Funnel request handling](https://github.com/tailscale/tailscale/blob/c87680a0bf4c66f455a5b6f2c1cb56bf4a15ae76/ipn/ipnlocal/serve.go#L1078-L1106) and [tailnet identity-header coverage](https://github.com/tailscale/tailscale/blob/c87680a0bf4c66f455a5b6f2c1cb56bf4a15ae76/ipn/ipnlocal/serve_test.go#L778-L810).

Production LOC: `+6/-1` (net `+5`) | Tests: `+98/-17` | Docs/changelog: `+8/-1`

The five added production lines are the terminal-signal handoff at the route-lifecycle owner. The Funnel attribution repair is net neutral.

## User Impact

Operators can use the same managed Funnel URL from both the public internet and their tailnet after upgrading, with the configured password required in both cases. Interactive Gateway shutdown no longer leaves the managed Tailscale port claimed.

## Evidence

Frozen base: `6eb9344e7df680e668152c39054bab450437107d`  
Exact tested head: `e8d12aa0a2a4bbcac795dcbbeb0cf722ca571c96`

- Regression captured before editing: the candidate build returned `403 proxy_attribution_required` to an authenticated tailnet peer on a managed Funnel hostname; the latest stable comparison accepted the same flow.
- Focused tests: `122` Gateway attribution/auth tests and `4` route-owner worker tests pass.
- The process-level SIGINT regression test fails on the pre-fix worker with `{ code: null, signal: "SIGINT" }`, then passes on this head and verifies that the child PID is gone.
- Full build, package creation, tarball integrity, and installed-package import graph pass. Tested tarball SHA-256: `82b6a99d60a23733a8da58e86b637659d67b6cc7f7b8fdab9c775c2f5ee3700f`.
- Cross-platform installed-package campaign:
  - macOS 26.6.2 arm64, Node 24.19.0, Tailscale 1.102.2
  - Ubuntu 26.04 x64, Node 24.15.0, Tailscale 1.102.3
  - Windows Server 2022 x64, Node 24.15.0, Tailscale 1.102.3
- Managed Funnel, tailnet path: no auth `401`; password-authenticated canonical HTTP route reached (`404` for a deliberately nonexistent profile); password-authenticated WebSocket health returned `ok: true`.
- Managed Funnel, public path: no auth `401`; password-authenticated canonical HTTP route reached (`404`); password-authenticated WebSocket health returned `ok: true`. macOS and Windows-backed Funnel nodes were both exercised.
- IPv4 and IPv6 tailnet requests passed on macOS-backed Funnel.
- Ordinary-listener and same-host forged Tailscale headers remain rejected; the dedicated managed listener still requires the password even when `gateway.auth.allowTailscale=true`.
- Native/external Serve remained compatible on Linux with explicit trusted-proxy configuration; removing that trust kept external/forged Tailscale headers rejected.
- Exact-head macOS Ctrl-C removed the managed route and route-owner/claim processes within two seconds. Windows hard-disconnect cleanup also left `{}` route state and no route-owner/Funnel process.
- Existing-route upgrade behavior remained non-destructive: a conflicting stable-managed route made the candidate exit without replacing or mutating that route.

The Windows public DNS record had not propagated during the proof window, so public-edge requests were pinned to both active Funnel edge IPs inside the disposable Linux test guest. TLS, HTTP authentication, routing, and WebSocket health all succeeded; the temporary guest-only host mapping was restored immediately afterward.
