### PR TITLE
fix(models): preserve Codex selection for catalog-seeded models

### DIFF
--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -4,6 +4,10 @@ import type { Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../../config/runtime-snapshot.js";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import type { TranscriptEntryAnchor } from "../../config/sessions/transcript-entry-anchor.js";
 import { OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST } from "../../context-engine/host-compat.js";
@@ -226,6 +230,7 @@ beforeEach(async () => {
 });
 
 afterEach(() => {
+  clearRuntimeConfigSnapshot();
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
   trajectoryTempDirs.cleanup();
@@ -2032,6 +2037,45 @@ describe("selectAgentHarness", () => {
         requestedRuntime: "codex",
       }).modelProvider,
     ).toMatchObject({
+      runtimePolicy: { compatibleIds: ["openclaw", "codex"] },
+    });
+  });
+
+  it("ignores catalog-seeded compatibility when selecting an official OpenAI route", () => {
+    const createConfig = (compat?: { supportsStore: boolean }) =>
+      ({
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                {
+                  id: "gpt-5.5",
+                  name: "GPT-5.5",
+                  reasoning: true,
+                  input: ["text"],
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  maxTokens: 8192,
+                  ...(compat ? { compat } : {}),
+                },
+              ],
+            },
+          },
+        },
+      }) satisfies OpenClawConfig;
+    const sourceConfig = createConfig();
+    const runtimeConfig = createConfig({ supportsStore: false });
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+
+    expect(
+      buildAgentHarnessSupportContext({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        requestedRuntime: "codex",
+        config: runtimeConfig,
+      }).modelProvider,
+    ).toMatchObject({
+      requestTransportOverrides: "none",
       runtimePolicy: { compatibleIds: ["openclaw", "codex"] },
     });
   });

--- a/src/agents/harness/support.ts
+++ b/src/agents/harness/support.ts
@@ -5,6 +5,7 @@ import {
   resolveMergedModelProviderModels,
   resolveModelProviderRouteOverridePresence,
 } from "../../config/model-provider-config.js";
+import { projectConfigOntoRuntimeSourceSnapshot } from "../../config/runtime-source-projection.js";
 import type { ModelApi } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
@@ -86,6 +87,9 @@ export function buildAgentHarnessSupportContext(params: {
   providerOwnership?: HarnessProviderOwnership;
 }): AgentHarnessSupportContext {
   const providerConfig = resolveMergedModelProviderConfig(params.config, params.provider);
+  const authoredConfig = params.config
+    ? projectConfigOntoRuntimeSourceSnapshot(params.config)
+    : undefined;
   const modelId = params.modelId ? normalizeModelId(params.provider, params.modelId) : undefined;
   const modelConfig = modelId
     ? resolveMergedModelProviderModels({
@@ -119,7 +123,7 @@ export function buildAgentHarnessSupportContext(params: {
         requestTransportOverrides: resolveModelProviderRouteOverridePresence({
           provider: params.provider,
           modelId: params.modelId,
-          config: params.config,
+          authoredConfig,
           canonicalizeModelId: (configuredModelId) =>
             canonicalizeProviderModelId(params.provider, configuredModelId),
         }),

--- a/src/config/defaults.test.ts
+++ b/src/config/defaults.test.ts
@@ -1,6 +1,8 @@
 // Verifies default config values and environment-sensitive overrides.
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderResolveModelRoutesContext } from "../plugin-sdk/provider-model-types.js";
+import { resolveProviderModelRoutes } from "../plugins/provider-model-routes.js";
 import {
   DEFAULT_SUBAGENT_ARCHIVE_AFTER_MINUTES,
   DEFAULT_SUBAGENT_MAX_CONCURRENT,
@@ -11,6 +13,8 @@ import {
   applyContextPruningDefaults,
   applyMessageDefaults,
 } from "./defaults.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "./runtime-snapshot.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
 
 const mocks = vi.hoisted(() => ({
   applyProviderConfigDefaultsForConfig: vi.fn(),
@@ -32,6 +36,7 @@ describe("config defaults", () => {
   });
 
   afterEach(() => {
+    clearRuntimeConfigSnapshot();
     vi.unstubAllEnvs();
   });
 
@@ -158,6 +163,7 @@ describe("applyModelDefaults catalog seeding", () => {
                   maxTokens: 128_000,
                   cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
                   thinkingLevelMap: { off: "none" },
+                  compat: { supportsStore: false },
                 },
               ],
             },
@@ -241,6 +247,46 @@ describe("applyModelDefaults catalog seeding", () => {
     expect(model.input).toEqual(["text"]);
     expect(model.reasoning).toBe(false);
     expect(model.maxTokens).toBe(4_096);
+  });
+
+  it("keeps catalog-seeded compatibility out of authored route overrides", async () => {
+    const { applyModelDefaults } = await import("./defaults.js");
+    const sourceConfig: OpenClawConfig = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            models: [
+              {
+                id: "gpt-5.6-sol",
+                name: "GPT-5.6 Sol",
+                reasoning: true,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    };
+    const runtimeConfig = applyModelDefaults(sourceConfig, { manifestRegistry: catalogRegistry });
+    setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+    const resolveModelRoutes = vi.fn((_context: ProviderResolveModelRoutesContext) => ({
+      kind: "indeterminate" as const,
+    }));
+
+    resolveProviderModelRoutes({
+      provider: "openai",
+      modelId: "gpt-5.6-sol",
+      config: runtimeConfig,
+      env: {},
+      surface: { resolveModelRoutes },
+    });
+
+    expect(resolveModelRoutes.mock.calls[0]?.[0]).toMatchObject({
+      requestTransportOverrides: "none",
+    });
   });
 
   it("preserves catalog tiered pricing when flat cost fields are authored", async () => {

--- a/src/config/model-provider-config.test.ts
+++ b/src/config/model-provider-config.test.ts
@@ -50,7 +50,7 @@ describe("resolveMergedModelProviderModels", () => {
 });
 
 describe("resolveModelProviderRouteOverridePresence", () => {
-  it("treats authored model compatibility as request behavior", () => {
+  it("does not treat model capability metadata as a route override", () => {
     const config = {
       models: {
         providers: {
@@ -70,7 +70,7 @@ describe("resolveModelProviderRouteOverridePresence", () => {
         modelId: "gpt-5.5",
         config,
       }),
-    ).toBe("present");
+    ).toBe("none");
     expect(
       resolveModelProviderRouteOverridePresence({
         provider: "openai",

--- a/src/config/model-provider-config.test.ts
+++ b/src/config/model-provider-config.test.ts
@@ -50,7 +50,7 @@ describe("resolveMergedModelProviderModels", () => {
 });
 
 describe("resolveModelProviderRouteOverridePresence", () => {
-  it("does not treat model capability metadata as a route override", () => {
+  it("treats authored model compatibility as request behavior", () => {
     const config = {
       models: {
         providers: {
@@ -68,14 +68,14 @@ describe("resolveModelProviderRouteOverridePresence", () => {
       resolveModelProviderRouteOverridePresence({
         provider: "openai",
         modelId: "gpt-5.5",
-        config,
+        authoredConfig: config,
       }),
-    ).toBe("none");
+    ).toBe("present");
     expect(
       resolveModelProviderRouteOverridePresence({
         provider: "openai",
         modelId: "gpt-5.5-empty",
-        config,
+        authoredConfig: config,
       }),
     ).toBe("none");
   });
@@ -85,7 +85,7 @@ describe("resolveModelProviderRouteOverridePresence", () => {
       resolveModelProviderRouteOverridePresence({
         provider: "openai",
         modelId: "gpt-5.5",
-        config: {
+        authoredConfig: {
           models: {
             providers: {
               openai: { baseUrl: "", timeoutSeconds: 90, models: [model("gpt-5.5")] },

--- a/src/config/model-provider-config.ts
+++ b/src/config/model-provider-config.ts
@@ -46,10 +46,10 @@ function hasNonEmptyRecord(value: unknown): boolean {
 export function resolveModelProviderRouteOverridePresence(params: {
   provider: string;
   modelId?: string;
-  config?: OpenClawConfig;
+  authoredConfig?: OpenClawConfig;
   canonicalizeModelId?: (modelId: string) => string;
 }): ProviderRouteOverridePresence {
-  const providerConfig = resolveMergedModelProviderConfig(params.config, params.provider);
+  const providerConfig = resolveMergedModelProviderConfig(params.authoredConfig, params.provider);
   if (!providerConfig) {
     return "none";
   }
@@ -77,7 +77,9 @@ export function resolveModelProviderRouteOverridePresence(params: {
     normalizeModelId: canonicalize,
   }).get(modelId);
   return configuredModel &&
-    (hasNonEmptyRecord(configuredModel.headers) || hasNonEmptyRecord(configuredModel.params))
+    (hasNonEmptyRecord(configuredModel.headers) ||
+      hasNonEmptyRecord(configuredModel.params) ||
+      hasNonEmptyRecord(configuredModel.compat))
     ? "present"
     : "none";
 }

--- a/src/config/model-provider-config.ts
+++ b/src/config/model-provider-config.ts
@@ -77,9 +77,7 @@ export function resolveModelProviderRouteOverridePresence(params: {
     normalizeModelId: canonicalize,
   }).get(modelId);
   return configuredModel &&
-    (hasNonEmptyRecord(configuredModel.headers) ||
-      hasNonEmptyRecord(configuredModel.params) ||
-      hasNonEmptyRecord(configuredModel.compat))
+    (hasNonEmptyRecord(configuredModel.headers) || hasNonEmptyRecord(configuredModel.params))
     ? "present"
     : "none";
 }

--- a/src/plugins/provider-model-routes.ts
+++ b/src/plugins/provider-model-routes.ts
@@ -5,6 +5,7 @@ import {
   resolveMergedModelProviderModels,
   resolveModelProviderRouteOverridePresence,
 } from "../config/model-provider-config.js";
+import { projectConfigOntoRuntimeSourceSnapshot } from "../config/runtime-source-projection.js";
 import type { ModelApi, ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
@@ -84,6 +85,11 @@ export function createProviderModelRoutesResolver(params: {
       : params.surface;
   const resolveModelRoutes = surface?.resolveModelRoutes;
   const providerConfig = resolveMergedModelProviderConfig(params.config, provider);
+  // Runtime defaults copy catalog capabilities into configured model rows. Route
+  // eligibility must read the authored view or metadata looks like request behavior.
+  const authoredConfig = params.config
+    ? projectConfigOntoRuntimeSourceSnapshot(params.config)
+    : undefined;
   const configuredProvider = providerConfig
     ? { api: providerConfig.api, baseUrl: providerConfig.baseUrl }
     : undefined;
@@ -105,7 +111,7 @@ export function createProviderModelRoutesResolver(params: {
       ? "present"
       : resolveModelProviderRouteOverridePresence({
           provider,
-          config: params.config,
+          authoredConfig,
         });
   const routeOverridePresenceByModel = new Map(
     [...configuredModels.keys()].map(
@@ -117,7 +123,7 @@ export function createProviderModelRoutesResolver(params: {
             : resolveModelProviderRouteOverridePresence({
                 provider,
                 modelId,
-                config: params.config,
+                authoredConfig,
                 canonicalizeModelId,
               }),
         ] as const,


### PR DESCRIPTION
Closes #126525

AI-assisted: investigation and patch preparation used Codex; I reviewed the code, reproduced the failure, and understand the change.

## What Problem This Solves

Fixes an issue where users who explicitly select the Codex harness for an OpenAI model can silently run through the embedded OpenClaw harness after the configured model inherits `compat` capability metadata from the plugin catalog.

This is a deterministic regression introduced by #126068. Partial configured-model rows correctly began inheriting catalog metadata, but the existing route classifier interpreted the inherited `compat` object as operator-authored request transport behavior and made the route OpenClaw-only.

## Why This Change Was Made

Model `compat` describes capabilities and payload-shaping metadata; it does not prove that the operator authored an unreproducible transport route. This change keeps #126068's catalog seeding intact while limiting configured-model transport override detection to actual model request overrides: `headers` and `params`.

Provider-level request behavior remains fail-closed exactly as before, including custom headers, `request`, `params`, local services, auth-header policy, and timeouts.

Production delta: **-2 lines**. Test delta: **0 net lines**.

## User Impact

Operators can use partial model overrides, retain catalog-derived capabilities such as image support and reasoning metadata, and still have an official OpenAI route honor `agentRuntime.id = "codex"`.

Actual custom request transport overrides continue to restrict the route to the embedded OpenClaw runtime when Codex cannot reproduce them.

## Evidence

### Regression boundary

- Last verified good: `54ebb307cdfc28f8c232162179b9734b19662dbd`
- First verified bad: `66c7d720bd88f11cc82a9e5405e0fb8716c674bf` (#126068)
- Current `main` before this patch: `916eef4e996008d387207c53044afd8cf02dcc30`

The on-disk affected model row had no `compat`. After `applyModelDefaults()` seeded catalog metadata:

```text
requestTransportOverrides=present
agentHarnessId=openclaw
runner=embedded
```

Adding only explicit `compat: {}` prevented catalog seeding and restored:

```text
requestTransportOverrides=none
agentHarnessId=codex
```

### Real runtime proof

A source-full runtime with this fix was exercised in isolated single-agent and multi-agent gateway clones:

- Fresh simple turns selected `agentHarnessId=codex`
- A browser-backed Codex turn completed successfully
- Browser tool calls: 4
- Browser tool failures: 0
- No production gateway was modified during the investigation

### Focused tests on current main

```text
pnpm exec vitest run \
  src/config/model-provider-config.test.ts \
  extensions/openai/provider-policy-api.test.ts \
  extensions/codex/harness.test.ts

Test Files  3 passed (3)
Tests       96 passed (96)
```

The updated regression assertion fails against the pre-fix implementation because non-empty model `compat` is classified as `present`.

### Repository checks

Under Node 24.15.0:

- Preflight/policy guards passed
- Core, UI, extension, script, and test-root typechecks passed
- Full lint passed
- Package-lock and package-patch guards passed
- Touched-file formatting check passed after applying `oxfmt`
- `git diff --check` passed

### Codex contract

Direct inspection of the sibling Codex source confirms this standard route does not require an OpenClaw-only transport override:

- `codex-rs/app-server-protocol/src/protocol/v2/thread.rs`: `ThreadStartParams` accepts optional `model` and `model_provider`
- `codex-rs/app-server/src/request_processors/thread_processor.rs`: `thread_start_inner` forwards both through typed config overrides

The incompatibility was therefore introduced by OpenClaw's route classification, not by the Codex app-server contract.
