### PR TITLE
fix(memory): detect offline source drift in status

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -757,7 +757,7 @@ extensions/mattermost/src/setup-core.ts	2
 extensions/memory-core/index.ts	4
 extensions/memory-core/src/cli-index-search.runtime.ts	1
 extensions/memory-core/src/cli-rem.runtime.ts	1
-extensions/memory-core/src/cli-runtime-common.ts	8
+extensions/memory-core/src/cli-runtime-common.ts	2
 extensions/memory-core/src/cli-status.runtime.ts	2
 extensions/memory-core/src/cli.ts	1
 extensions/memory-core/src/concept-vocabulary.ts	1

--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -58,6 +58,7 @@ export async function runMemoryIndex(
     agent: opts.agent,
     allAgents: true,
     purpose: "cli",
+    inspectSources: true,
     ...hostOptions,
     run: async ({ manager, agentId }) => {
       try {
@@ -146,7 +147,7 @@ export async function runMemoryIndex(
           },
         );
         let postIndexStatus = manager.status();
-        const scan = await scanMemoryManagerSources(postIndexStatus, agentId);
+        const scan = await scanMemoryManagerSources(postIndexStatus);
         const outcome = formatMemoryIndexOutcome(postIndexStatus, scan, agentId);
         let semanticVectorAvailable = postIndexStatus.vector?.semanticAvailable;
         const vectorStoreAvailable =

--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -1,8 +1,4 @@
-import fsSync from "node:fs";
-import fs from "node:fs/promises";
-import path from "node:path";
 import { listAgentIds } from "openclaw/plugin-sdk/agent-runtime";
-import { isUsageCountedSessionTranscriptFileName } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import {
   normalizeExtraMemoryPathEntries,
   type MemoryExtraPath,
@@ -14,11 +10,8 @@ import {
   formatErrorMessage,
   getMemorySearchManager,
   getRuntimeConfig,
-  listMemoryFiles,
-  normalizeExtraMemoryPaths,
   resolveCommandSecretRefsViaGateway,
   resolveDefaultAgentId,
-  resolveSessionTranscriptsDirForAgent,
   shortenHomePath,
   theme,
   type OpenClawConfig,
@@ -165,6 +158,7 @@ async function withMemoryManagerForAgent(params: {
   cfg: OpenClawConfig;
   agentId: string;
   purpose?: MemoryManagerPurpose;
+  inspectSources?: boolean;
   acquireLocalService?: MemoryCoreAcquireLocalService;
   run: (manager: MemoryManager) => Promise<void>;
 }): Promise<void> {
@@ -174,6 +168,9 @@ async function withMemoryManagerForAgent(params: {
   };
   if (params.purpose) {
     managerParams.purpose = params.purpose;
+  }
+  if (params.inspectSources) {
+    managerParams.inspectSources = true;
   }
   if (params.acquireLocalService) {
     managerParams.acquireLocalService = params.acquireLocalService;
@@ -202,6 +199,7 @@ export async function withMemoryCommand(params: {
   allAgents?: boolean;
   diagnosticsToStderr?: boolean;
   purpose?: MemoryManagerPurpose;
+  inspectSources?: boolean;
   acquireLocalService?: MemoryCoreAcquireLocalService;
   run: (context: { manager: MemoryManager; cfg: OpenClawConfig; agentId: string }) => Promise<void>;
 }): Promise<OpenClawConfig> {
@@ -219,15 +217,15 @@ export async function withMemoryCommand(params: {
       cfg,
       agentId,
       purpose: params.purpose,
+      inspectSources: params.inspectSources,
       acquireLocalService: params.acquireLocalService,
       run: async (manager) => params.run({ manager, cfg, agentId }),
     });
   }
   return cfg;
 }
-type MemorySourceName = "memory" | "sessions";
 type SourceScan = {
-  source: MemorySourceName;
+  source: "memory" | "sessions";
   totalFiles: number | null;
   issues: string[];
 };
@@ -236,157 +234,23 @@ export type MemorySourceScan = {
   totalFiles: number | null;
   issues: string[];
 };
-async function checkReadableFile(pathname: string): Promise<{ exists: boolean; issue?: string }> {
-  try {
-    await fs.access(pathname, fsSync.constants.R_OK);
-    return { exists: true };
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") {
-      return { exists: false };
-    }
-    return {
-      exists: true,
-      issue: `${shortenHomePath(pathname)} not readable (${code ?? "error"})`,
-    };
-  }
-}
-async function scanSessionFiles(agentId: string): Promise<SourceScan> {
-  const issues: string[] = [];
-  const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId);
-  try {
-    const entries = await fs.readdir(sessionsDir, { withFileTypes: true });
-    const totalFiles = entries.filter(
-      (entry) => entry.isFile() && isUsageCountedSessionTranscriptFileName(entry.name),
-    ).length;
-    return { source: "sessions", totalFiles, issues };
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") {
-      issues.push(`sessions directory missing (${shortenHomePath(sessionsDir)})`);
-      return { source: "sessions", totalFiles: 0, issues };
-    }
-    issues.push(
-      `sessions directory not accessible (${shortenHomePath(sessionsDir)}): ${code ?? "error"}`,
-    );
-    return { source: "sessions", totalFiles: null, issues };
-  }
-}
-async function scanMemoryFiles(
-  workspaceDir: string,
-  extraPaths: MemoryExtraPath[] = [],
-): Promise<SourceScan> {
-  const issues: string[] = [];
-  const memoryFile = path.join(workspaceDir, "MEMORY.md");
-  const memoryDir = path.join(workspaceDir, "memory");
-  const primary = await checkReadableFile(memoryFile);
-  if (primary.issue) {
-    issues.push(primary.issue);
-  }
-  const resolvedExtraPaths = normalizeExtraMemoryPaths(workspaceDir, extraPaths);
-  for (const extraPath of resolvedExtraPaths) {
-    try {
-      const stat = await fs.lstat(extraPath);
-      if (stat.isSymbolicLink()) {
-        continue;
-      }
-      const extraCheck = await checkReadableFile(extraPath);
-      if (extraCheck.issue) {
-        issues.push(extraCheck.issue);
-      }
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ENOENT") {
-        issues.push(`additional memory path missing (${shortenHomePath(extraPath)})`);
-      } else {
-        issues.push(
-          `additional memory path not accessible (${shortenHomePath(extraPath)}): ${code ?? "error"}`,
-        );
-      }
-    }
-  }
-  let dirReadable: boolean | null;
-  try {
-    await fs.access(memoryDir, fsSync.constants.R_OK);
-    dirReadable = true;
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") {
-      issues.push(`memory directory missing (${shortenHomePath(memoryDir)})`);
-      dirReadable = false;
-    } else {
-      issues.push(
-        `memory directory not accessible (${shortenHomePath(memoryDir)}): ${code ?? "error"}`,
-      );
-      dirReadable = null;
-    }
-  }
-  let listed: string[] = [];
-  let listedOk = false;
-  try {
-    listed = await listMemoryFiles(workspaceDir, extraPaths);
-    listedOk = true;
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (dirReadable !== null) {
-      issues.push(
-        `memory directory scan failed (${shortenHomePath(memoryDir)}): ${code ?? "error"}`,
-      );
-      dirReadable = null;
-    }
-  }
-  let totalFiles: number | null;
-  if (dirReadable === null) {
-    totalFiles = null;
-  } else {
-    const files = new Set<string>(listedOk ? listed : []);
-    if (!listedOk) {
-      if (primary.exists) {
-        files.add(memoryFile);
-      }
-    }
-    totalFiles = files.size;
-  }
-  if ((totalFiles ?? 0) === 0 && issues.length === 0) {
-    issues.push(`no memory files found in ${shortenHomePath(workspaceDir)}`);
-  }
-  return { source: "memory", totalFiles, issues };
-}
-async function scanMemorySources(params: {
-  workspaceDir: string;
-  agentId: string;
-  sources: MemorySourceName[];
-  extraPaths?: MemoryExtraPath[];
-}): Promise<MemorySourceScan> {
-  const scans: SourceScan[] = [];
-  const extraPaths = params.extraPaths ?? [];
-  for (const source of params.sources) {
-    if (source === "memory") {
-      scans.push(await scanMemoryFiles(params.workspaceDir, extraPaths));
-    }
-    if (source === "sessions") {
-      scans.push(await scanSessionFiles(params.agentId));
-    }
-  }
-  const issues = scans.flatMap((scan) => scan.issues);
-  const totals = scans.map((scan) => scan.totalFiles);
-  const numericTotals = totals.filter((total): total is number => total !== null);
-  const totalFiles = totals.some((total) => total === null)
-    ? null
-    : numericTotals.reduce((sum, total) => sum + total, 0);
-  return { sources: scans, totalFiles, issues };
-}
-
 export async function scanMemoryManagerSources(
   status: ReturnType<MemoryManager["status"]>,
-  agentId: string,
 ): Promise<MemorySourceScan | undefined> {
-  const workspaceDir = status.workspaceDir;
-  if (!workspaceDir) {
+  if (!status.sourceCounts?.length) {
     return undefined;
   }
-  const sources = (status.sources?.length ? status.sources : ["memory"]) as MemorySourceName[];
-  return await scanMemorySources({ workspaceDir, agentId, sources, extraPaths: status.extraPaths });
+  const sources = status.sourceCounts.map(
+    (entry): SourceScan => ({
+      source: entry.source,
+      totalFiles: entry.eligible ?? null,
+      issues: entry.issues ?? [],
+    }),
+  );
+  const totalFiles = sources.some((entry) => entry.totalFiles === null)
+    ? null
+    : sources.reduce((total, entry) => total + (entry.totalFiles ?? 0), 0);
+  return { sources, totalFiles, issues: sources.flatMap((entry) => entry.issues) };
 }
 
 export function formatMemoryIndexOutcome(

--- a/extensions/memory-core/src/cli-status.runtime.ts
+++ b/extensions/memory-core/src/cli-status.runtime.ts
@@ -165,6 +165,7 @@ export async function runMemoryStatus(
     allAgents: true,
     diagnosticsToStderr: Boolean(opts.json),
     purpose: opts.index ? "cli" : "status",
+    inspectSources: true,
     ...hostOptions,
     run: async ({ manager, agentId }) => {
       const deep = Boolean(opts.deep || opts.index);
@@ -231,7 +232,7 @@ export async function runMemoryStatus(
         }
       }
       const status = manager.status();
-      const scan = await scanMemoryManagerSources(status, agentId);
+      const scan = await scanMemoryManagerSources(status);
       const workspaceDir = status.workspaceDir;
       let audit: ShortTermAuditSummary | undefined;
       let repair: RepairShortTermPromotionArtifactsResult | undefined;

--- a/extensions/memory-core/src/cli.host.runtime.ts
+++ b/extensions/memory-core/src/cli.host.runtime.ts
@@ -14,11 +14,6 @@ export {
 export {
   getRuntimeConfig,
   resolveDefaultAgentId,
-  resolveSessionTranscriptsDirForAgent,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
-export {
-  listMemoryFiles,
-  normalizeExtraMemoryPaths,
-} from "openclaw/plugin-sdk/memory-core-host-runtime-files";
 export { getMemorySearchManager } from "./memory/index.js";

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1368,6 +1368,7 @@ describe("memory cli", () => {
         cfg: {},
         agentId: "main",
         purpose: "cli",
+        inspectSources: true,
       });
       expectLogged(log, "Memory index updated (main): 1 file indexed.");
       expect(close).toHaveBeenCalled();
@@ -1383,7 +1384,20 @@ describe("memory cli", () => {
       probeVectorAvailability: vi.fn(async () => true),
       probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
       sync,
-      status: () => makeMemoryStatus({ workspaceDir, sources: ["memory"] }),
+      status: () =>
+        makeMemoryStatus({
+          workspaceDir,
+          sources: ["memory"],
+          sourceCounts: [
+            {
+              source: "memory",
+              files: 0,
+              chunks: 0,
+              eligible: 0,
+              issues: ["no eligible memory files found"],
+            },
+          ],
+        }),
       close,
     });
 
@@ -1405,7 +1419,20 @@ describe("memory cli", () => {
     const sync = vi.fn(async () => {});
     mockManager({
       sync,
-      status: () => makeMemoryStatus({ workspaceDir, sources: ["memory"] }),
+      status: () =>
+        makeMemoryStatus({
+          workspaceDir,
+          sources: ["memory"],
+          sourceCounts: [
+            {
+              source: "memory",
+              files: 0,
+              chunks: 0,
+              eligible: 0,
+              issues: ["no eligible memory files found"],
+            },
+          ],
+        }),
       close,
     });
 
@@ -1439,6 +1466,7 @@ describe("memory cli", () => {
         cfg: {},
         agentId: "main",
         purpose: "cli",
+        inspectSources: true,
       });
       expect(close).toHaveBeenCalled();
       expect(log).toHaveBeenCalledWith("Memory index updated (main): 1 file indexed.");

--- a/extensions/memory-core/src/memory-extra-file-path.windows.test.ts
+++ b/extensions/memory-core/src/memory-extra-file-path.windows.test.ts
@@ -6,7 +6,6 @@ import {
   readMemoryFile,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { scanMemoryManagerSources } from "./cli-runtime-common.js";
 import { resolveMemoryPathClassification } from "./memory/memory-path-provenance.js";
 
 describe.skipIf(process.platform !== "win32")("Windows explicit memory extra-file casing", () => {
@@ -38,7 +37,7 @@ describe.skipIf(process.platform !== "win32")("Windows explicit memory extra-fil
   });
 
   it.each(["physical", "alias"] as const)(
-    "lists, reads, and scans the configured %s spelling",
+    "lists and reads the configured %s spelling",
     async (spelling) => {
       const configuredPath = spelling === "physical" ? physicalPath : configuredAlias;
       await expect(listMemoryFiles(workspaceDir, [configuredPath])).resolves.toEqual([
@@ -51,18 +50,6 @@ describe.skipIf(process.platform !== "win32")("Windows explicit memory extra-fil
           relPath: configuredPath,
         }),
       ).resolves.toMatchObject({ text: "shared Windows memory" });
-      await expect(
-        scanMemoryManagerSources(
-          {
-            backend: "builtin",
-            provider: "none",
-            workspaceDir,
-            sources: ["memory"],
-            extraPaths: [configuredPath],
-          },
-          "main",
-        ),
-      ).resolves.toMatchObject({ totalFiles: 1, issues: [] });
     },
   );
 

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -2062,13 +2062,14 @@ describe("memory index", () => {
     await fs.mkdir(mediaDir, { recursive: true });
     await fs.writeFile(path.join(mediaDir, "diagram.png"), Buffer.from("png"));
     await fs.writeFile(path.join(mediaDir, "meeting.wav"), Buffer.from("wav"));
+    await fs.writeFile(path.join(mediaDir, "oversized.png"), Buffer.alloc(32, 1));
     await fs.writeFile(path.join(fixture.paths.memory, "default-diagram.png"), Buffer.from("png"));
 
     const cfg = createCfg({
       provider: "gemini",
       model: "gemini-embedding-2-preview",
       extraPaths: [mediaDir],
-      multimodal: { enabled: true, modalities: ["image", "audio"] },
+      multimodal: { enabled: true, modalities: ["image", "audio"], maxFileBytes: 16 },
     });
     const manager = await getPersistentManager(cfg);
     await manager.sync({ reason: "test" });
@@ -2091,6 +2092,44 @@ describe("memory index", () => {
 
     const audioResults = await manager.search("audio");
     expect(audioResults.some((result) => result.path.endsWith("meeting.wav"))).toBe(true);
+
+    await manager.close?.();
+    const statusManager = await getFreshManager(cfg, "status", true);
+    try {
+      const status = statusManager.status();
+      expect(status.sourceCounts?.find((entry) => entry.source === "memory")?.eligible).toBe(
+        status.files,
+      );
+    } finally {
+      await statusManager.close?.();
+    }
+  });
+
+  it("detects offline source edits only for explicit diagnostic status", async () => {
+    const cfg = createCfg({});
+    const indexedManager = await getFreshManager(cfg);
+    await indexedManager.sync({ reason: "test", force: true });
+    await indexedManager.close?.();
+
+    const sourcePath = path.join(fixture.paths.memory, "2026-01-12.md");
+    const edited = "# Offline edit\n\nThis changed outside the gateway.\n";
+    await fs.writeFile(sourcePath, edited);
+
+    const ordinaryStatus = await getFreshManager(cfg, "status");
+    expect(ordinaryStatus.status().sourceCounts?.[0]?.eligible).toBeUndefined();
+    await ordinaryStatus.close?.();
+
+    const diagnosticStatus = await getFreshManager(cfg, "status", true);
+    try {
+      expect(diagnosticStatus.status().dirty).toBe(true);
+      const db = Reflect.get(diagnosticStatus, "db") as DatabaseSync;
+      const indexed = db
+        .prepare("SELECT hash FROM memory_index_sources WHERE path = ? AND source = 'memory'")
+        .get("memory/2026-01-12.md") as { hash: string } | undefined;
+      expect(indexed?.hash).not.toBe(hashText(edited));
+    } finally {
+      await diagnosticStatus.close?.();
+    }
   });
 
   it("reports vector availability after probe", async () => {
@@ -2366,9 +2405,7 @@ describe("memory index", () => {
     }
   });
 
-  it("status-purpose manager detects unindexed session transcripts as dirty", async () => {
-    // Regression test for #97814: plain openclaw memory status (purpose: status)
-    // must report dirty=true when session files exist without index rows.
+  it("diagnostic status uses canonical session discovery for dirty state and counts", async () => {
     const cfg = createCfg({ sources: ["sessions"], sessionMemory: true });
     const stateDirName = ".state-status-dirty-test";
     fixture.setStateDir(path.join(fixture.paths.workspace, stateDirName));
@@ -2384,11 +2421,14 @@ describe("memory index", () => {
         ],
       });
 
-      const manager = await getFreshManager(cfg, "status");
+      const manager = await getFreshManager(cfg, "status", true);
       trackManager(manager);
 
       const result = manager.status();
       expect(result.dirty).toBe(true);
+      expect(result.sourceCounts).toEqual([
+        expect.objectContaining({ source: "sessions", eligible: 1 }),
+      ]);
     } finally {
       fixture.restoreStateDir();
     }
@@ -2454,7 +2494,7 @@ describe("memory index", () => {
         }),
       ).resolves.toBe(true);
 
-      const statusManager = await getFreshManager(cfg, "status");
+      const statusManager = await getFreshManager(cfg, "status", true);
       trackManager(statusManager);
       expect(statusManager.status().dirty).toBe(true);
 

--- a/extensions/memory-core/src/memory/manager-index.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-index.test-support.ts
@@ -102,6 +102,7 @@ export type ManagerIndexFixture = {
   getFreshManager: (
     cfg: ManagerConfig,
     purpose?: "default" | "status" | "cli",
+    inspectSources?: boolean,
   ) => Promise<MemoryIndexManager>;
   getFtsSessionManager: (params: { stateDirName: string }) => Promise<MemoryIndexManager | null>;
   seedSessionTranscript: (params: {
@@ -473,9 +474,10 @@ export function createManagerIndexFixture(deps: {
   const getFreshManager = async (
     cfg: ManagerConfig,
     purpose?: "default" | "status" | "cli",
+    inspectSources?: boolean,
   ): Promise<MemoryIndexManager> => {
     const manager = requireManager(
-      await deps.getMemorySearchManager({ cfg, agentId: "main", purpose }),
+      await deps.getMemorySearchManager({ cfg, agentId: "main", purpose, inspectSources }),
     );
     trackManager(manager);
     return manager;

--- a/extensions/memory-core/src/memory/manager-session-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-session-sync-ops.ts
@@ -24,7 +24,7 @@ import {
   resolveMemorySessionStartupState,
   type MemorySessionStartupFileState,
 } from "./manager-session-sync-state.js";
-import { loadMemorySourceFileState } from "./manager-source-state.js";
+import { inspectMemorySourceState, loadMemorySourceFileState } from "./manager-source-state.js";
 import { MemoryManagerWatchOps } from "./manager-watch-ops.js";
 
 const SESSION_DIRTY_DEBOUNCE_MS = 5000;
@@ -42,6 +42,32 @@ type MemorySessionTranscriptUpdate = {
 };
 
 export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps {
+  protected async inspectDiagnosticSourceState(): Promise<void> {
+    if (this.sources.has("memory")) {
+      try {
+        const inspection = await inspectMemorySourceState({
+          db: this.db,
+          workspaceDir: this.workspaceDir,
+          settings: this.settings,
+          concurrency: this.getIndexConcurrency(),
+        });
+        this.sourceInspections.set("memory", inspection);
+        this.dirty ||= inspection.dirty;
+      } catch (error) {
+        this.sourceInspections.set("memory", { eligible: null, issues: [String(error)] });
+        this.dirty = true;
+      }
+    }
+    if (this.sources.has("sessions")) {
+      try {
+        await this.markSessionStartupCatchupDirtyFiles(true);
+      } catch (error) {
+        this.sourceInspections.set("sessions", { eligible: null, issues: [String(error)] });
+        this.sessionsDirty = true;
+      }
+    }
+  }
+
   protected listSessionCorpusEntries(): Promise<SessionTranscriptCorpusEntry[]> {
     return listSessionTranscriptCorpusEntriesForAgent(this.agentId);
   }
@@ -123,7 +149,7 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
     });
   }
 
-  protected async markSessionStartupCatchupDirtyFiles(): Promise<string[]> {
+  protected async markSessionStartupCatchupDirtyFiles(inspectSources = false): Promise<string[]> {
     if (!this.sources.has("sessions") || this.closed) {
       return [];
     }
@@ -172,6 +198,12 @@ export abstract class MemoryManagerSessionSyncOps extends MemoryManagerWatchOps 
       files: fileStates,
       existingRows,
     });
+    if (inspectSources) {
+      this.sourceInspections.set("sessions", {
+        eligible: fileStates.length,
+        issues: fileStates.length === 0 ? ["no eligible session transcripts found"] : [],
+      });
+    }
     if (this.closed) {
       return dirtyFiles;
     }

--- a/extensions/memory-core/src/memory/manager-source-state.ts
+++ b/extensions/memory-core/src/memory/manager-source-state.ts
@@ -1,6 +1,13 @@
 // Memory Core plugin module implements manager source state behavior.
 import type { SQLInputValue } from "node:sqlite";
-import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import type { ResolvedMemorySearchConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import {
+  buildFileEntry,
+  listMemoryFiles,
+  runWithConcurrency,
+  type MemoryFileEntry,
+  type MemorySource,
+} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 
 export type MemorySourceFileStateRow = {
   path: string;
@@ -18,6 +25,63 @@ type MemorySourceStateDb = {
 
 const MEMORY_SOURCE_FILE_STATE_SQL = `SELECT path, hash, mtime, size FROM memory_index_sources WHERE source = ?`;
 const MEMORY_SOURCE_FILE_HASH_SQL = `SELECT hash FROM memory_index_sources WHERE path = ? AND source = ?`;
+
+type MemorySourceInspection = {
+  source: MemorySource;
+  dirty: boolean;
+  eligible: number | null;
+  issues: string[];
+};
+
+/** Resolve exactly the entries eligible for indexing, including validated multimodal files. */
+export async function resolveMemorySourceFileEntries(params: {
+  workspaceDir: string;
+  settings: Pick<ResolvedMemorySearchConfig, "extraPaths" | "multimodal">;
+  concurrency: number;
+}): Promise<MemoryFileEntry[]> {
+  const files = await listMemoryFiles(
+    params.workspaceDir,
+    params.settings.extraPaths,
+    params.settings.multimodal,
+  );
+  return (
+    await runWithConcurrency(
+      files.map(
+        (file) => async () =>
+          await buildFileEntry(file, params.workspaceDir, params.settings.multimodal),
+      ),
+      params.concurrency,
+    )
+  ).filter((entry): entry is MemoryFileEntry => entry !== null);
+}
+
+/** Compare a resolved source snapshot with the persisted index without writing either side. */
+function hasMemorySourceDrift(params: {
+  entries: readonly MemoryFileEntry[];
+  indexedRows: readonly MemorySourceFileStateRow[];
+}): boolean {
+  const indexedByPath = new Map(params.indexedRows.map((row) => [row.path, row]));
+  if (indexedByPath.size !== params.entries.length) {
+    return true;
+  }
+  return params.entries.some((entry) => indexedByPath.get(entry.path)?.hash !== entry.hash);
+}
+
+export async function inspectMemorySourceState(params: {
+  db: MemorySourceStateDb;
+  workspaceDir: string;
+  settings: Pick<ResolvedMemorySearchConfig, "extraPaths" | "multimodal">;
+  concurrency: number;
+}): Promise<MemorySourceInspection> {
+  const entries = await resolveMemorySourceFileEntries(params);
+  const indexedRows = loadMemorySourceFileState({ db: params.db, source: "memory" }).rows;
+  return {
+    source: "memory",
+    dirty: hasMemorySourceDrift({ entries, indexedRows }),
+    eligible: entries.length,
+    issues: entries.length === 0 ? ["no eligible memory files found"] : [],
+  };
+}
 
 export function loadMemorySourceFileState(params: {
   db: MemorySourceStateDb;

--- a/extensions/memory-core/src/memory/manager-source-sync-ops.ts
+++ b/extensions/memory-core/src/memory/manager-source-sync-ops.ts
@@ -6,8 +6,6 @@ import {
   type SessionTranscriptCorpusEntry,
 } from "openclaw/plugin-sdk/memory-core-host-engine-sessions";
 import {
-  buildFileEntry,
-  listMemoryFiles,
   MEMORY_INDEX_FTS_TABLE,
   runWithConcurrency,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
@@ -15,6 +13,7 @@ import { MemoryManagerSessionSyncOps } from "./manager-session-sync-ops.js";
 import { resolveMemorySessionSyncPlan } from "./manager-session-sync-state.js";
 import {
   loadMemorySourceFileState,
+  resolveMemorySourceFileEntries,
   resolveMemorySourceExistingHash,
 } from "./manager-source-state.js";
 import type {
@@ -58,20 +57,11 @@ export abstract class MemoryManagerSourceSyncOps extends MemoryManagerSessionSyn
         ? this.db.prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`)
         : null;
 
-    const files = await listMemoryFiles(
-      this.workspaceDir,
-      this.settings.extraPaths,
-      this.settings.multimodal,
-    );
-    const fileEntries = (
-      await runWithConcurrency(
-        files.map(
-          (file) => async () =>
-            await buildFileEntry(file, this.workspaceDir, this.settings.multimodal),
-        ),
-        this.getIndexConcurrency(),
-      )
-    ).filter((entry): entry is MemoryIndexEntry => entry !== null);
+    const fileEntries = await resolveMemorySourceFileEntries({
+      workspaceDir: this.workspaceDir,
+      settings: this.settings,
+      concurrency: this.getIndexConcurrency(),
+    });
     log.debug("memory sync: indexing memory files", {
       files: fileEntries.length,
       needsFullReindex: params.needsFullReindex,

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -123,6 +123,10 @@ export abstract class MemoryManagerSyncBase {
     timeoutMs: number;
   };
   protected readonly sources: Set<MemorySource> = new Set();
+  protected readonly sourceInspections = new Map<
+    MemorySource,
+    { eligible: number | null; issues: string[] }
+  >();
   protected providerKey: string | null = null;
   protected abstract readonly vector: {
     enabled: boolean;

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -137,6 +137,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
     cfg: OpenClawConfig;
     agentId: string;
     purpose?: MemoryIndexManagerPurpose;
+    inspectSources?: boolean;
     acquireLocalService?: MemoryCoreAcquireLocalService;
   }): Promise<MemoryIndexManager | null> {
     const agentId = normalizeAgentId(params.agentId);
@@ -178,12 +179,8 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
                 purpose: params.purpose,
                 acquireLocalService: params.acquireLocalService,
               });
-              if (purpose === "status" && manager.sources.has("sessions")) {
-                try {
-                  await manager.markSessionStartupCatchupDirtyFiles();
-                } catch (err) {
-                  log.warn("memory status session dirty detection failed: " + String(err));
-                }
+              if (params.inspectSources) {
+                await manager.inspectDiagnosticSourceState();
               }
               return manager;
             },
@@ -497,7 +494,9 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       requestedProvider: this.requestedProvider,
       sources: Array.from(this.sources),
       extraPaths: this.settings.extraPaths,
-      sourceCounts: aggregateState.sourceCounts,
+      sourceCounts: aggregateState.sourceCounts.map((entry) =>
+        Object.assign(entry, this.sourceInspections.get(entry.source) ?? {}),
+      ),
       cache: this.cache.enabled
         ? {
             enabled: true,

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -14,6 +14,7 @@ type MemorySearchManagerParams = {
   cfg: OpenClawConfig;
   agentId: string;
   purpose?: MemorySearchManagerPurpose;
+  inspectSources?: boolean;
   acquireLocalService?: MemoryCoreAcquireLocalService;
 };
 

--- a/extensions/memory-core/src/runtime-provider.test.ts
+++ b/extensions/memory-core/src/runtime-provider.test.ts
@@ -51,6 +51,24 @@ describe("memoryRuntime", () => {
     });
   });
 
+  it("forwards optional diagnostic source inspection", async () => {
+    const cfg = {} as OpenClawConfig;
+
+    await memoryRuntime.getMemorySearchManager({
+      cfg,
+      agentId: "main",
+      purpose: "status",
+      inspectSources: true,
+    });
+
+    expect(getMemorySearchManagerMock).toHaveBeenCalledWith({
+      cfg,
+      agentId: "main",
+      purpose: "status",
+      inspectSources: true,
+    });
+  });
+
   it("keeps local-service acquisition scoped to each runtime instance", async () => {
     const cfg = {} as OpenClawConfig;
     const firstAcquire = vi.fn(async () => undefined);

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -138,7 +138,13 @@ export type MemoryProviderStatus = {
   dbPath?: string;
   extraPaths?: MemoryExtraPath[];
   sources?: MemorySource[];
-  sourceCounts?: Array<{ source: MemorySource; files: number; chunks: number }>;
+  sourceCounts?: Array<{
+    source: MemorySource;
+    files: number;
+    chunks: number;
+    eligible?: number | null;
+    issues?: string[];
+  }>;
   cache?: { enabled: boolean; entries?: number; maxEntries?: number };
   fts?: { enabled: boolean; available: boolean; error?: string };
   fallback?: { from: string; reason?: string };

--- a/src/commands/status.scan.deps.runtime.ts
+++ b/src/commands/status.scan.deps.runtime.ts
@@ -20,6 +20,7 @@ export async function getMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
   purpose: "status";
+  inspectSources: true;
 }): Promise<{ manager: StatusMemoryManager | null }> {
   const { manager } = await getActiveMemorySearchManagerCore(params);
   if (!manager) {

--- a/src/commands/status.scan.fast-json.test.ts
+++ b/src/commands/status.scan.fast-json.test.ts
@@ -250,6 +250,7 @@ describe("scanStatusJsonFast", () => {
       cfg: createStatusMemorySearchConfig(),
       agentId: "main",
       purpose: "status",
+      inspectSources: true,
     });
   });
 

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -62,6 +62,7 @@ type MemorySearchManagerCall = {
     };
   };
   purpose?: string;
+  inspectSources?: boolean;
 };
 
 function readGatewayCall(): GatewayCall {
@@ -594,6 +595,7 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
         provider: "local",
         files: 0,
         chunks: 0,
+        dirty: true,
       })),
       close: vi.fn(async () => {}),
     };
@@ -613,8 +615,11 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
     });
 
     expect(resolveMemoryConfig).toHaveBeenCalledOnce();
-    expect(getMemorySearchManager).toHaveBeenCalledOnce();
+    expect(getMemorySearchManager).toHaveBeenCalledWith(
+      expect.objectContaining({ purpose: "status", inspectSources: true }),
+    );
     expect(result?.provider).toBe("local");
+    expect(result?.dirty).toBe(true);
   });
 
   it("asks custom memory-slot runtimes for status without requiring built-in memorySearch", async () => {
@@ -665,6 +670,7 @@ describe("resolveSharedMemoryStatusSnapshot", () => {
     expect(managerCall?.cfg.plugins?.slots).toEqual({ memory: "memory-lancedb-pro" });
     expect(managerCall?.agentId).toBe("main");
     expect(managerCall?.purpose).toBe("status");
+    expect(managerCall?.inspectSources).toBe(true);
     expect(manager.probeVectorStoreAvailability).toHaveBeenCalled();
     expect(manager.probeVectorAvailability).not.toHaveBeenCalled();
     expect(manager.status).toHaveBeenCalled();

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -152,6 +152,7 @@ type StatusMemorySearchManagerResolver = (params: {
   cfg: OpenClawConfig;
   agentId: string;
   purpose: "status";
+  inspectSources: true;
 }) => Promise<{
   manager: StatusMemorySearchManager | null;
 }>;
@@ -440,6 +441,7 @@ async function resolveMemoryManagerStatusSnapshot(
     cfg: params.cfg,
     agentId,
     purpose: "status",
+    inspectSources: true,
   });
   if (!manager) {
     return null;

--- a/src/commands/status.scan.test.ts
+++ b/src/commands/status.scan.test.ts
@@ -322,6 +322,7 @@ describe("scanStatus", () => {
       cfg: createStatusMemorySearchConfig(),
       agentId: "main",
       purpose: "status",
+      inspectSources: true,
     });
   });
 

--- a/src/plugins/memory-runtime.ts
+++ b/src/plugins/memory-runtime.ts
@@ -172,6 +172,7 @@ export async function getActiveMemorySearchManagerCore(params: {
   cfg: OpenClawConfig;
   agentId: string;
   purpose?: "default" | "status" | "cli";
+  inspectSources?: boolean;
 }) {
   const owner = ensureMemoryRuntime(params);
   if (!owner) {

--- a/src/plugins/registry-contribution-types.ts
+++ b/src/plugins/registry-contribution-types.ts
@@ -265,6 +265,7 @@ export type MemoryPluginRuntime = {
     cfg: OpenClawConfig;
     agentId: string;
     purpose?: "default" | "status" | "cli";
+    /** Request a read-only source freshness scan; runtimes may ignore unsupported diagnostics. */
     inspectSources?: boolean;
   }): Promise<{
     manager: RegisteredMemorySearchManager | null;

--- a/src/plugins/registry-contribution-types.ts
+++ b/src/plugins/registry-contribution-types.ts
@@ -265,6 +265,7 @@ export type MemoryPluginRuntime = {
     cfg: OpenClawConfig;
     agentId: string;
     purpose?: "default" | "status" | "cli";
+    inspectSources?: boolean;
   }): Promise<{
     manager: RegisteredMemorySearchManager | null;
     debug?: {


### PR DESCRIPTION
Related: #125978

AI-assisted implementation; reviewed and verified by the maintainer.

## What Problem This Solves

`openclaw memory status` could report a clean index after memory files were edited while the Gateway was offline, because status only projected in-memory dirty flags. Its file denominator also counted indexed rows rather than the same resolved, validated source set used by indexing, so enabled multimodal files could disappear from status totals.

## Why This Change Was Made

Diagnostic status now opts into a read-only source inspection at manager acquisition. Memory sources are resolved once through the same canonical discovery and `buildFileEntry` path used by indexing, including extra paths, multimodal validation, and file-size limits; their current hashes are compared with persisted source rows without writing either side. Session diagnostics reuse canonical transcript discovery and expose the same typed eligible-count/issues shape.

The CLI consumes `sourceCounts[].eligible` and `sourceCounts[].issues` directly, removing its duplicate filesystem scanner and the legacy `custom.sourceScan` projection. The shared `openclaw status --all` path now requests the same inspection through an additive `MemoryPluginRuntime` option, preserving existing session-drift warnings; ordinary runtime managers do not perform the diagnostic scan.

Maintainer decision: accept this optional public diagnostics seam. External memory runtimes may ignore `inspectSources` when unsupported, and the new `sourceCounts` fields remain optional. The SDK surface check and runtime forwarding coverage pass.

This is PR 3 of the split memory contract repair, following merged PRs #125979 and #126530.

Production LOC: +154/-191 (net -37). Tests/support: +107/-24 (net +83). The reduction comes primarily from deleting the duplicate CLI source scanner while moving source ownership into the manager; the small core addition preserves diagnostic inspection for general status scans.

## User Impact

Plain memory status now reports `dirty: true` after an offline source edit and exposes accurate eligible-file counts for text and multimodal memory sources. Status remains read-only, and indexing/status use the same resolved discovery rules, including oversized-media exclusion.

## Evidence

Validated on base `3fe833dfa4084ad79d4545093f39f192c2108317`; current head is `cb8434959185148e8609a32de9b0477aa1c6a02c`.

- Focused memory index and CLI suites: 143 tests passed, 3 skipped.
- Assertion-safety ratchet and `git diff --check`: passed.
- Fresh full-branch Codex autoreview after the shared-status fix: clean, no accepted/actionable findings; correctness 0.98.
- Additive Plugin SDK surface check passed.
- Isolated exact-head CLI proof with provider `none`:
  - after indexing, `dirty=false`, indexed files=3, and memory eligible=3;
  - after an offline `MEMORY.md` edit, a fresh status process reported `dirty=true`;
  - the persisted source hash was unchanged by status, proving the diagnostic path is read-only;
  - `custom.sourceScan` was absent and indexed search still returned the fixture marker.
- Isolated exact-head real Gemini multimodal proof with `gemini-embedding-2-preview`:
  - pre-index status discovered 3 eligible files (Markdown, extra Markdown, and a valid PNG);
  - indexing completed through the live provider;
  - post-index status reported files=3 and eligible=3 with `dirty=false`;
  - an oversized PNG was excluded identically by discovery and indexing.
- General `openclaw status --all --json` regression proof on an isolated unused Gateway port reported memory `dirty=true` with one eligible unindexed session transcript, preserving the existing operator warning path.
- Post-fix focused shared status/runtime suites: 99 tests passed on the first repair head; the final strict-adapter/runtime contract follow-up passed 69 focused tests.
- Exact-base clean changed-surface gate passed in a frozen-dependency clone: core/core-test and extension/extension-test typechecks, core/extension/script lint, format, plugin boundaries, assertion/max-lines ratchets, dead exports, native schema v9 guard, database-first guard, runtime-sidecar guard, import cycles, and pairing/webhook guards.

No operator Gateway or normal OpenClaw state was touched. No LanceDB path, SQLite schema version, protocol version, lockfile, docs, or changelog is changed.
