### PR TITLE
docs(gateway): recommend Access service tokens over route exemption

### DIFF
--- a/docs/gateway/cloudflare-access.md
+++ b/docs/gateway/cloudflare-access.md
@@ -117,7 +117,7 @@ worker route. Both enforce their own short-lived credentials — a join code is 
 with a TTL, rate-limited per IP, and answers failures with an opaque 404; worker admission
 carries its own expiring credential. This keeps join links paste-and-go, at the cost of
 making those two routes publicly reachable. Prefer the service token unless you need that
-onboarding flow. See [Nodes](/nodes#edge-routing).
+onboarding flow. See [Nodes](/nodes#gateway-deployments-that-cannot-host-nodes).
 
 If you do neither, `openclaw connect` fails against the tunnel even though the browser
 works, because the join request is redirected to the Access login page.

--- a/docs/gateway/cloudflare-access.md
+++ b/docs/gateway/cloudflare-access.md
@@ -92,14 +92,32 @@ the only path for external traffic.
 
 ## Step 4: Decide how nodes and workers get in
 
-Access protects every route on the hostname, including the ones nodes use. Pick one:
+Access protects every route on the hostname, including the ones nodes use. A node can
+authenticate to Access on every leg it needs — the join request, the main Gateway
+WebSocket, the worker socket, and worker transfers — so the recommended path exposes
+nothing publicly.
 
-- **Exempt the self-authenticating routes.** Allow `/j/*` and `/__openclaw__/worker`
-  without Access identity, and keep WebSocket upgrade enabled on the worker route. Both
-  enforce their own short-lived credentials, so they do not depend on Access. See
-  [Nodes](/nodes#gateway-deployments-that-cannot-host-nodes).
-- **Use an Access service token.** Add a Service Auth policy and give the node
-  `gateway.cloudflareAccess.clientId` / `clientSecret`. See [Node CLI](/cli/node).
+**Recommended: give the node an Access service token.** Add a Service Auth policy to the
+application, then on the node host:
+
+```bash
+export CF_ACCESS_CLIENT_ID="<client-id>"
+export CF_ACCESS_CLIENT_SECRET="<client-secret>"
+openclaw connect https://gateway.example/j/<code> --service
+```
+
+`openclaw connect` persists these as env SecretRefs under
+`gateway.cloudflareAccess.clientId` / `clientSecret`; see [Node CLI](/cli/node). The only
+cost is that the node needs those two values before the join command, so a join link is no
+longer paste-and-go on its own.
+
+**Alternative: exempt the self-authenticating routes.** Allow `/j/*` and
+`/__openclaw__/worker` without Access identity, keeping WebSocket upgrade enabled on the
+worker route. Both enforce their own short-lived credentials — a join code is single-use
+with a TTL, rate-limited per IP, and answers failures with an opaque 404; worker admission
+carries its own expiring credential. This keeps join links paste-and-go, at the cost of
+making those two routes publicly reachable. Prefer the service token unless you need that
+onboarding flow. See [Nodes](/nodes#edge-routing).
 
 If you do neither, `openclaw connect` fails against the tunnel even though the browser
 works, because the join request is redirected to the Access login page.


### PR DESCRIPTION
Follow-up to #126029.

## What Problem This Solves

The Cloudflare guide presented two ways to let nodes through Access as near-equals and led with
route exemption, implying a bypass is normally needed. It is not. A node can authenticate to Access
on every leg it uses, so the default advice should expose nothing publicly.

## Why This Change Was Made

Verified in source that Access service-token headers are sent on all four legs:

- join request — `src/cli/connect-cli.ts:87`
- main Gateway WebSocket — `src/node-host/gateway-candidate-connection.ts`
- worker socket — `src/worker/worker-connection-endpoint.ts:157`
- worker bundle/workspace transfers — `src/node-host/node-worker-transfer-client.ts`

So the service token is now the recommendation, with the concrete command, and exemption is the
stated alternative with its tradeoff: it keeps join links paste-and-go, at the cost of making
`/j/*` and `/__openclaw__/worker` publicly reachable. The properties that make exemption defensible
are stated rather than implied — the join code is single-use with a TTL, rate-limited per IP, and
returns an opaque 404 on failure (`src/gateway/device-pairing-join-http.ts`,
`src/infra/device-pairing-join-code.ts`), and worker admission carries its own expiring credential.

## User Impact

Operators following the guide keep a closed surface by default and only open those two routes when
they specifically want paste-and-go node onboarding.

## Evidence

Docs-only. `node scripts/check-changed.mjs` exit 0 (docs-only lane).
