### PR TITLE
fix(agent-core): preserve accepted handoff in tool settlement catches

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1479,7 +1479,6 @@ packages/agent-core/src/harness/session/session.ts	1
 packages/agent-core/src/harness/session/tool-result-pairing.ts	17
 packages/agent-core/src/harness/session/uuid.ts	1
 packages/agent-core/src/harness/utils/truncate.ts	1
-packages/agent-core/src/turn-interruption.ts	1
 packages/ai/src/api-registry.ts	3
 packages/ai/src/env-api-keys.ts	10
 packages/ai/src/internal/anthropic-inline-images.ts	1

--- a/packages/agent-core/src/agent-loop.test.ts
+++ b/packages/agent-core/src/agent-loop.test.ts
@@ -3512,6 +3512,683 @@ describe("agentLoop tool termination", () => {
     expect(messages.some((message) => message.role === "custom")).toBe(false);
   });
 
+  it("preserves an accepted handoff when afterToolCall throws for the yield tool", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-yield", name: "sessions_yield", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const yieldTool: AgentTool = {
+      name: "sessions_yield",
+      label: "sessions_yield",
+      description: "Yield the active run as a clean handoff",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "sessions_yield", turnHandoff: true });
+        return {
+          content: [{ type: "text", text: "yielded" }],
+          details: { yielded: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "yield during tool", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [yieldTool] },
+      {
+        ...config,
+        afterToolCall: async () => {
+          throw controller.signal.reason;
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(false);
+    expect(endEvent?.result).toMatchObject({ details: { yielded: true } });
+    expect(messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+    expect(messages.some((message) => message.role === "custom")).toBe(false);
+  });
+
+  it("preserves an accepted handoff when afterToolOutcome throws for the yield tool", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-yield", name: "sessions_yield", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const yieldTool: AgentTool = {
+      name: "sessions_yield",
+      label: "sessions_yield",
+      description: "Yield the active run as a clean handoff",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "sessions_yield", turnHandoff: true });
+        return {
+          content: [{ type: "text", text: "yielded" }],
+          details: { yielded: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+    const messages = await runAgentLoop(
+      [{ role: "user", content: "yield during tool", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [yieldTool] },
+      {
+        ...config,
+        afterToolOutcome: async () => {
+          throw controller.signal.reason;
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(false);
+    expect(endEvent?.result).toMatchObject({ details: { yielded: true } });
+    expect(messages.at(-1)).toMatchObject({ role: "assistant", stopReason: "aborted" });
+    expect(messages.some((message) => message.role === "custom")).toBe(false);
+  });
+
+  it("keeps a sibling tool's afterToolCall error as an error during a handoff abort", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-sibling", name: "sibling_tool", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const siblingTool: AgentTool = {
+      name: "sibling_tool",
+      label: "sibling_tool",
+      description: "A sibling tool that runs during a handoff abort",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "sessions_yield", turnHandoff: true });
+        return {
+          content: [{ type: "text", text: "sibling result" }],
+          details: { sibling: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "sibling during handoff", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [siblingTool] },
+      {
+        ...config,
+        afterToolCall: async () => {
+          throw new Error("Aborted");
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(true);
+  });
+
+  it("keeps a sibling tool's afterToolOutcome error as an error during a handoff abort", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-sibling", name: "sibling_tool", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const siblingTool: AgentTool = {
+      name: "sibling_tool",
+      label: "sibling_tool",
+      description: "A sibling tool that runs during a handoff abort",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "sessions_yield", turnHandoff: true });
+        return {
+          content: [{ type: "text", text: "sibling result" }],
+          details: { sibling: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "sibling during handoff", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [siblingTool] },
+      {
+        ...config,
+        afterToolOutcome: async () => {
+          throw new Error("Aborted");
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(true);
+  });
+
+  it("still rewrites a plain abort error to an error result for a non-handoff abort", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-work", name: "work_tool", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const workTool: AgentTool = {
+      name: "work_tool",
+      label: "work_tool",
+      description: "A tool whose abort is not a handoff",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort(new Error("user aborted"));
+        throw new Error("Aborted");
+      },
+    };
+    const events: AgentEvent[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "abort during tool", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [workTool] },
+      config,
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(true);
+  });
+
+  it("keeps a genuine yield-callback error as an error after the handoff marker", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-yield", name: "sessions_yield", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const yieldTool: AgentTool = {
+      name: "sessions_yield",
+      label: "sessions_yield",
+      description: "Yield the active run as a clean handoff",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "sessions_yield", turnHandoff: true });
+        throw new Error("yield bookkeeping failed");
+      },
+    };
+    const events: AgentEvent[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "yield with a real error", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [yieldTool] },
+      config,
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(true);
+    expect(endEvent?.result).toMatchObject({
+      content: [{ type: "text", text: "yield bookkeeping failed" }],
+    });
+  });
+
+  it("does not preserve a handoff when a different owner set turnHandoff on the abort reason (afterToolCall)", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-yield", name: "sessions_yield", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const yieldTool: AgentTool = {
+      name: "sessions_yield",
+      label: "sessions_yield",
+      description: "Yield tool aborted by a different handoff owner",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "different_owner", turnHandoff: true });
+        return {
+          content: [{ type: "text", text: "yielded" }],
+          details: { yielded: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "different owner handoff", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [yieldTool] },
+      {
+        ...config,
+        afterToolCall: async () => {
+          throw new Error("Aborted");
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(true);
+  });
+
+  it("does not preserve a handoff when a different owner set turnHandoff on the abort reason (afterToolOutcome)", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-yield", name: "sessions_yield", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const yieldTool: AgentTool = {
+      name: "sessions_yield",
+      label: "sessions_yield",
+      description: "Yield tool aborted by a different handoff owner",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "different_owner", turnHandoff: true });
+        return {
+          content: [{ type: "text", text: "yielded" }],
+          details: { yielded: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "different owner handoff", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [yieldTool] },
+      {
+        ...config,
+        afterToolOutcome: async () => {
+          throw new Error("Aborted");
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(true);
+  });
+
+  it("keeps a genuine afterToolCall failure as an error after an accepted yield", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-yield", name: "sessions_yield", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const yieldTool: AgentTool = {
+      name: "sessions_yield",
+      label: "sessions_yield",
+      description: "Yield the active run as a clean handoff",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "sessions_yield", turnHandoff: true });
+        return {
+          content: [{ type: "text", text: "yielded" }],
+          details: { yielded: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "genuine hook failure after yield", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [yieldTool] },
+      {
+        ...config,
+        afterToolCall: async () => {
+          throw new Error("database write failed");
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(true);
+    expect(endEvent?.result).toMatchObject({
+      content: [{ type: "text", text: "database write failed" }],
+    });
+  });
+
+  it("keeps a genuine afterToolOutcome failure as an error after an accepted yield", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-yield", name: "sessions_yield", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const yieldTool: AgentTool = {
+      name: "sessions_yield",
+      label: "sessions_yield",
+      description: "Yield the active run as a clean handoff",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "sessions_yield", turnHandoff: true });
+        return {
+          content: [{ type: "text", text: "yielded" }],
+          details: { yielded: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "genuine hook failure after yield", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [yieldTool] },
+      {
+        ...config,
+        afterToolOutcome: async () => {
+          throw new Error("notification dispatch failed");
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(true);
+    expect(endEvent?.result).toMatchObject({
+      content: [{ type: "text", text: "notification dispatch failed" }],
+    });
+  });
+
+  it("keeps an unrelated AbortError as an error after an accepted yield (afterToolCall)", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-yield", name: "sessions_yield", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const yieldTool: AgentTool = {
+      name: "sessions_yield",
+      label: "sessions_yield",
+      description: "Yield the active run as a clean handoff",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "sessions_yield", turnHandoff: true });
+        return {
+          content: [{ type: "text", text: "yielded" }],
+          details: { yielded: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "unrelated abort after yield", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [yieldTool] },
+      {
+        ...config,
+        afterToolCall: async () => {
+          throw Object.assign(new Error("independent abort"), { name: "AbortError" });
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(true);
+    expect(endEvent?.result).toMatchObject({
+      content: [{ type: "text", text: "independent abort" }],
+    });
+  });
+
+  it("keeps an unrelated AbortError as an error after an accepted yield (afterToolOutcome)", async () => {
+    const controller = new AbortController();
+    let streamCalls = 0;
+    const streamFn: StreamFn = () => {
+      streamCalls += 1;
+      if (streamCalls > 1) {
+        throw new Error("model was called after abort");
+      }
+      const stream = createAssistantMessageEventStream();
+      queueMicrotask(() => {
+        const message = makeAssistantMessage([
+          { type: "toolCall", id: "call-yield", name: "sessions_yield", arguments: {} },
+        ]);
+        stream.push({ type: "done", reason: "toolUse", message });
+        stream.end();
+      });
+      return stream;
+    };
+    const yieldTool: AgentTool = {
+      name: "sessions_yield",
+      label: "sessions_yield",
+      description: "Yield the active run as a clean handoff",
+      parameters: Type.Object({}, { additionalProperties: false }),
+      execute: async () => {
+        controller.abort({ code: "sessions_yield", turnHandoff: true });
+        return {
+          content: [{ type: "text", text: "yielded" }],
+          details: { yielded: true },
+        };
+      },
+    };
+    const events: AgentEvent[] = [];
+    await runAgentLoop(
+      [{ role: "user", content: "unrelated abort after yield", timestamp: 1 }],
+      { systemPrompt: "", messages: [], tools: [yieldTool] },
+      {
+        ...config,
+        afterToolOutcome: async () => {
+          throw Object.assign(new Error("independent abort"), { name: "AbortError" });
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+      controller.signal,
+      streamFn,
+    );
+
+    expect(streamCalls).toBe(1);
+    const endEvent = events.find(
+      (event): event is Extract<AgentEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(true);
+    expect(endEvent?.result).toMatchObject({
+      content: [{ type: "text", text: "independent abort" }],
+    });
+  });
+
   it("does not start prepared parallel tools after the run aborts mid-batch", async () => {
     const controller = new AbortController();
     const executed: string[] = [];

--- a/packages/agent-core/src/agent-loop.ts
+++ b/packages/agent-core/src/agent-loop.ts
@@ -31,6 +31,8 @@ import {
   appendInterruptedTurnMessage,
   createFailureMessage,
   createInterruptedTurnMessage,
+  isAcceptedYieldToolAbort,
+  isHandoffAbortError,
   isTurnHandoffAbort,
   normalizeCoreContextMessages,
 } from "./turn-interruption.js";
@@ -1496,6 +1498,23 @@ async function prepareToolCallExecution(
             if (implementationStartError) {
               throw implementationStartError.error;
             }
+            // Defense-in-depth: if the signal carries the accepted yield-handoff
+            // marker and the error is an AbortError (e.g. from the wrapper
+            // pre-check or race), preserve the handoff instead of rewriting it
+            // as a tool error. The wrapper pre-check already exempts this case;
+            // this guard catches any residual path. A genuine tool failure
+            // (non-AbortError) stays an error even when the signal has the marker.
+            if (
+              isAcceptedYieldToolAbort(signal, prepared.toolCall.name) &&
+              error instanceof Error &&
+              error.name === "AbortError"
+            ) {
+              return {
+                result: { content: [{ type: "text", text: "Turn yielded." }], details: {} },
+                isError: false,
+                executionStarted,
+              };
+            }
             return {
               result: createErrorToolResult(coerceErrorMessage(error)),
               isError: true,
@@ -1608,8 +1627,17 @@ async function finalizeExecutedToolCall(
         isError = afterResult.isError ?? isError;
       }
     } catch (error) {
-      result = createErrorToolResult(coerceErrorMessage(error));
-      isError = true;
+      // Preserve an accepted handoff only for a causally identified abort:
+      // the hook threw the signal's own reason object (e.g., via
+      // signal.throwIfAborted()) or an Error wrapping it as cause. A genuine
+      // hook failure or an unrelated AbortError must remain an error.
+      if (
+        !isAcceptedYieldToolAbort(batch.signal, prepared.toolCall.name) ||
+        !isHandoffAbortError(error, batch.signal)
+      ) {
+        result = createErrorToolResult(coerceErrorMessage(error));
+        isError = true;
+      }
     }
   }
 
@@ -1667,6 +1695,15 @@ async function finalizeToolCallOutcome(
       isError: afterResult.isError ?? finalized.isError,
     };
   } catch (error) {
+    // An accepted handoff must keep the finalized outcome intact, but only
+    // for a causally identified abort; a genuine hook failure or an unrelated
+    // AbortError stays an error.
+    if (
+      isAcceptedYieldToolAbort(batch.signal, finalized.toolCall.name) &&
+      isHandoffAbortError(error, batch.signal)
+    ) {
+      return finalized;
+    }
     const errorResult = createErrorToolResult(coerceErrorMessage(error));
     return {
       ...finalized,

--- a/packages/agent-core/src/turn-interruption.ts
+++ b/packages/agent-core/src/turn-interruption.ts
@@ -33,6 +33,28 @@ const INTERRUPTED_TURN_GUIDANCE = `<turn_aborted>
 The previous turn was interrupted. Any running background processes may still be active. If any tools or commands were aborted, they may have partially executed.
 </turn_aborted>`;
 
+interface AbortHandoffReason {
+  readonly code?: unknown;
+  readonly turnHandoff?: unknown;
+}
+
+// Narrow the abort reason to its handoff shape once; callers check the
+// specific owner code + marker fields. The canonical handoff reason is
+// produced by the embedded attempt owner as SESSIONS_YIELD_ABORT_REASON
+// (src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts); the
+// abort-signal wrapper (agent-tools.abort.ts) consumes that reason.
+function readAbortHandoffReason(signal: AbortSignal | undefined): AbortHandoffReason | undefined {
+  if (!signal?.aborted) {
+    return undefined;
+  }
+  const reason: unknown = signal.reason;
+  if (typeof reason !== "object" || reason === null) {
+    return undefined;
+  }
+  // SAFETY: reason is validated as a non-null object above; the cast only exposes optional unknown fields for safe property access, not a stronger contract.
+  return reason as AbortHandoffReason;
+}
+
 /**
  * Aborts that end a turn as an intentional handoff (e.g. yield-style tools)
  * mark it with an abort reason carrying `turnHandoff: true`. Interruption
@@ -40,15 +62,50 @@ The previous turn was interrupted. Any running background processes may still be
  * may have partially executed after a clean, deliberate stop.
  */
 export function isTurnHandoffAbort(signal: AbortSignal | undefined): boolean {
+  return readAbortHandoffReason(signal)?.turnHandoff === true;
+}
+
+/**
+ * True only when the given tool is the one that initiated the accepted
+ * handoff. The abort reason's `code` field identifies the owning tool
+ * (e.g. `SESSIONS_YIELD_ABORT_REASON` carries `code: "sessions_yield"`
+ * from `src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts`);
+ * generic Agent Core binds that code to the current tool name rather than
+ * naming a specific sessions tool. The `turnHandoff: true` marker
+ * distinguishes an intentional handoff from a plain cancellation.
+ * Settlement catches must match the same owner boundary so a different
+ * handoff owner, a concurrent sibling cancellation, or a genuine tool/hook
+ * failure is not rewritten as a successful yield result.
+ */
+export function isAcceptedYieldToolAbort(
+  signal: AbortSignal | undefined,
+  toolName: string | undefined,
+): boolean {
+  if (!toolName || !signal?.aborted) {
+    return false;
+  }
+  const reason = readAbortHandoffReason(signal);
+  return reason?.code === toolName && reason.turnHandoff === true;
+}
+
+/**
+ * True when the caught error is causally linked to the accepted handoff's
+ * abort reason, not merely any error that looks like an abort. Settlement
+ * catches may preserve the accepted handoff only when the hook threw the
+ * signal's own reason object (e.g., via `signal.throwIfAborted()`, which
+ * throws `signal.reason` directly) or an Error wrapping that reason as
+ * `cause`. An unrelated AbortError from the hook's own independent work
+ * does not match and must remain an error.
+ */
+export function isHandoffAbortError(error: unknown, signal: AbortSignal | undefined): boolean {
   if (!signal?.aborted) {
     return false;
   }
-  const reason: unknown = signal.reason;
-  return (
-    typeof reason === "object" &&
-    reason !== null &&
-    (reason as { turnHandoff?: unknown }).turnHandoff === true
-  );
+  const reason = signal.reason;
+  if (error === reason) {
+    return true;
+  }
+  return error instanceof Error && error.cause === reason;
 }
 
 export function createInterruptedTurnMessage(): AgentMessage {

--- a/src/agents/agent-tools.abort.ts
+++ b/src/agents/agent-tools.abort.ts
@@ -16,6 +16,31 @@ function throwAbortError(): never {
 }
 
 /**
+ * Whether the run abort signal carries the canonical sessions_yield handoff
+ * reason. Matches the exemption in {@link raceWithAbortSignal}'s onAbort so the
+ * pre-abort pre-check does not reject a yield tool whose run was already
+ * handed off (e.g. a sibling or re-dispatched yield). The combined signal's
+ * reason must be the same reference as the run signal's, which AbortSignal.any
+ * propagates from the first aborted source.
+ */
+function isYieldHandoffAbort(
+  toolName: string,
+  combinedSignal: AbortSignal,
+  abortSignal: AbortSignal | undefined,
+): boolean {
+  if (toolName !== "sessions_yield" || !abortSignal?.aborted) {
+    return false;
+  }
+  // SAFETY: abortSignal.aborted is true above, so reason is set; the cast only exposes optional unknown fields for safe property access, not a stronger contract.
+  const reason = abortSignal.reason as { code?: unknown; turnHandoff?: unknown } | undefined;
+  return (
+    combinedSignal.reason === abortSignal.reason &&
+    reason?.code === "sessions_yield" &&
+    reason.turnHandoff === true
+  );
+}
+
+/**
  * Races a tool execute promise against the combined abort signal so an abort
  * settles the wrapped call immediately instead of awaiting the tool forever.
  * JavaScript cannot cancel a running promise: a tool that never observes the
@@ -82,7 +107,7 @@ export function wrapToolWithAbortSignal(
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
       const combinedSignal = signal ? AbortSignal.any([signal, abortSignal]) : abortSignal;
-      if (combinedSignal.aborted) {
+      if (combinedSignal.aborted && !isYieldHandoffAbort(tool.name, combinedSignal, abortSignal)) {
         throwAbortError();
       }
       return await raceWithAbortSignal(
@@ -99,7 +124,7 @@ export function wrapToolWithAbortSignal(
       const combinedSignal = params.signal
         ? AbortSignal.any([params.signal, abortSignal])
         : abortSignal;
-      if (combinedSignal.aborted) {
+      if (combinedSignal.aborted && !isYieldHandoffAbort(tool.name, combinedSignal, abortSignal)) {
         throwAbortError();
       }
       const yieldRunSignal = tool.name === "sessions_yield" ? abortSignal : undefined;
@@ -121,7 +146,10 @@ export function wrapToolWithAbortSignal(
         kind: "ready",
         args: prepared.args,
         execute: (onImplementationStart) => {
-          if (combinedSignal.aborted) {
+          if (
+            combinedSignal.aborted &&
+            !isYieldHandoffAbort(tool.name, combinedSignal, abortSignal)
+          ) {
             throwAbortError();
           }
           return raceWithAbortSignal(

--- a/src/agents/agent-tools.runtime.test.ts
+++ b/src/agents/agent-tools.runtime.test.ts
@@ -213,7 +213,7 @@ describe("wrapToolWithAbortSignal", () => {
     });
   });
 
-  it("does not start sessions_yield when the run was already handed off", async () => {
+  it("lets sessions_yield run when the run was already handed off", async () => {
     const runAbort = new AbortController();
     runAbort.abort({ code: "sessions_yield", turnHandoff: true });
     const onYield = vi.fn();
@@ -222,11 +222,29 @@ describe("wrapToolWithAbortSignal", () => {
       runAbort.signal,
     );
 
-    await expect(wrapped.execute("call-yield", {})).rejects.toMatchObject({
-      name: "AbortError",
-      message: "Aborted",
-    });
+    // The pre-check exempts the yield-handoff reason; the tool runs and returns
+    // its own result (here: no claimYield → error), not a wrapper-injected "Aborted".
+    const result = await wrapped.execute("call-yield", {});
+    expect(result.details).toMatchObject({ status: "error" });
     expect(onYield).not.toHaveBeenCalled();
+  });
+
+  it("preserves a sessions_yield result when the run was already handed off", async () => {
+    const runAbort = new AbortController();
+    runAbort.abort({ code: "sessions_yield", turnHandoff: true });
+    const onYield = vi.fn();
+    const wrapped = wrapToolWithAbortSignal(
+      createSessionsYieldTool({
+        sessionId: "requester",
+        claimYield: () => true,
+        onYield,
+      }),
+      runAbort.signal,
+    );
+
+    const result = await wrapped.execute("call-yield", {});
+    expect(result.details).toMatchObject({ status: "yielded", message: "Turn yielded." });
+    expect(onYield).toHaveBeenCalledOnce();
   });
 
   it("preserves an actual sessions_yield failure after its owner starts the handoff", async () => {

--- a/src/agents/sessions/agent-session-loop-next-turn.test.ts
+++ b/src/agents/sessions/agent-session-loop-next-turn.test.ts
@@ -20,6 +20,7 @@ import {
   testModel,
 } from "./agent-session-loop-correctness.test-support.js";
 import { createResourceLoader } from "./agent-session-loop-resource-loader.test-support.js";
+import type { AgentSessionEvent } from "./agent-session-types.js";
 import type { AgentSession } from "./agent-session.js";
 import type { ToolDefinition } from "./extensions/types.js";
 import { SettingsManager } from "./settings-manager.js";
@@ -739,5 +740,89 @@ describe("AgentSession queue and next-turn lifecycle correctness", () => {
 
     expect(session.agent.steeringMode).toBe("all");
     expect(session.agent.followUpMode).toBe("all");
+  });
+});
+
+describe("AgentSession settlement fault-path", () => {
+  it("preserves the accepted sessions_yield handoff when afterToolCall throws", async () => {
+    const sessionRef: { current?: AgentSession } = {};
+    const yieldTool: ToolDefinition = {
+      name: "sessions_yield",
+      label: "Sessions yield",
+      description: "ends the current turn for an external handoff",
+      parameters: Type.Object({}),
+      execute: async () => {
+        const activeSession = sessionRef.current;
+        if (!activeSession) {
+          throw new Error("session not ready");
+        }
+        activeSession.agent.abort({ code: "sessions_yield", turnHandoff: true });
+        return { content: [{ type: "text", text: "yielded" }], details: { yielded: true } };
+      },
+    };
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
+      createAssistantResultStream(
+        createAssistant(
+          activeModel,
+          [{ type: "toolCall", id: "call-yield", name: "sessions_yield", arguments: {} }],
+          "toolUse",
+        ),
+      ),
+    );
+    const { session } = await createTestSession({ customTools: [yieldTool] });
+    sessionRef.current = session;
+
+    const events: AgentSessionEvent[] = [];
+    session.subscribe((event) => {
+      events.push(event);
+    });
+    const originalAfterToolCall = session.agent.afterToolCall;
+    session.agent.afterToolCall = async (context, signal) => {
+      if (context.toolCall.name === "sessions_yield") {
+        throw signal?.reason;
+      }
+      return originalAfterToolCall?.(context, signal);
+    };
+
+    await session.prompt("yield now");
+
+    expect(streamMocks.streamSimple).toHaveBeenCalledOnce();
+
+    // Delivery boundary chain: the channel layer (handleToolExecutionEnd in
+    // embedded-agent-subscribe.handlers.tools.completion.ts) reads
+    // tool_execution_end.isError to decide whether to commit delivery
+    // evidence. If the settlement catch rewrote the result as an error,
+    // isError would be true and the delivery would be discarded.
+    const endEvent = events.find(
+      (event): event is Extract<AgentSessionEvent, { type: "tool_execution_end" }> =>
+        event.type === "tool_execution_end",
+    );
+    expect(endEvent?.isError).toBe(false);
+    expect(endEvent?.result).toMatchObject({ details: { yielded: true } });
+
+    // The assistant message_end with stopReason "aborted" is the yield-abort
+    // signal the channel layer reads in handleAgentEnd to classify the turn
+    // as a clean handoff (turnHandoff) rather than an error.
+    const assistantMessageEnds = events.filter(
+      (event): event is Extract<AgentSessionEvent, { type: "message_end" }> =>
+        event.type === "message_end" &&
+        (event as { message?: { role?: string } }).message?.role === "assistant",
+    );
+    const abortedMessageEnd = assistantMessageEnds.at(-1);
+    expect(abortedMessageEnd?.message).toMatchObject({ stopReason: "aborted" });
+
+    // agent_end proves the run terminated cleanly; the channel layer uses it
+    // for terminal liveness (hasAttemptTerminalState / hasTerminalOutput).
+    const agentEnd = events.find(
+      (event): event is Extract<AgentSessionEvent, { type: "agent_end" }> =>
+        event.type === "agent_end",
+    );
+    expect(agentEnd).toBeDefined();
+    expect(agentEnd?.willRetry).toBe(false);
+
+    expect(session.agent.state.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      stopReason: "aborted",
+    });
   });
 });


### PR DESCRIPTION
Closes #126446

## What Problem This Solves

An accepted `sessions_yield` handoff intentionally aborts its active turn with `turnHandoff: true`. The abort-signal wrapper's pre-abort pre-check (`agent-tools.abort.ts:85-87`) threw `Error("Aborted")` with **no yield-handoff exemption** when the run signal was already aborted at wrapper-entry time, bypassing the non-rejecting race (`raceWithAbortSignal`). The execution catch (`readyExecution.execute` catch) then converted this to an error tool result, erasing the accepted continuation. The embedded run settled as `success` while the channel dispatcher had no queued reply payload — the user received no answer even though the delegated continuation was accepted.

## Root Cause

The non-rejecting exemption for `sessions_yield` handoffs lived **only** inside `raceWithAbortSignal` (`agent-tools.abort.ts:40-47`). The wrapper's pre-abort pre-check (`agent-tools.abort.ts:85-87`) runs **before** the race is set up and threw `createAbortError("Aborted")` unconditionally whenever `combinedSignal.aborted` was true — with no check for the yield-handoff reason. When the run signal was already aborted with `SESSIONS_YIELD_ABORT_REASON` (`{ code: "sessions_yield", turnHandoff: true }`), the pre-check threw `Error("Aborted")`, which the execution catch (`agent-loop.ts:1497-1509`) converted to `createErrorToolResult("Aborted")` — producing exactly the issue's symptom: `sessions_yield tool result: Aborted`.

The test at `agent-tools.runtime.test.ts:216-230` codified this behavior ("does not start sessions_yield when the run was already handed off" → rejects with `AbortError: "Aborted"`).

The delivery path then lost the reply: `buildEmbeddedRunPayloads` (`payloads.ts`) suppressed assistant text when `runAborted` was true, `terminal-resolution.ts:125-144` collapsed error-only payloads to `payloadCount = 0`, and `execution.ts:119` logged `visible channel turn dispatched with no queued reply payloads`.

## Canonical Repair

**Producer fix (root cause)**: Add `isYieldHandoffAbort()` exemption to all three wrapper pre-checks (`execute`, `preparer`, `ready-closure`), matching `raceWithAbortSignal`'s four-part contract: `toolName === "sessions_yield"` AND `abortSignal.aborted` AND `combinedSignal.reason === abortSignal.reason` AND `reason.code === "sessions_yield"` AND `reason.turnHandoff === true`. When the run signal is already aborted with the canonical handoff reason, the pre-check no longer throws — the tool runs, calls `onYield`, and returns `{ yielded: true }` normally.

**Consumer fix (defense-in-depth)**:

- **Execution catch** (`readyExecution.execute` catch, `agent-loop.ts:1497`): preserves the handoff when the signal carries the marker (`isAcceptedYieldToolAbort`) AND the error is an `AbortError`. Returns a non-error result (`isError: false`). A genuine tool failure (non-`AbortError`, e.g. "yield bookkeeping failed") stays an error even when the signal has the marker.
- **`afterToolCall` catch** (`finalizeExecutedToolCall`, `agent-loop.ts:1612`): preserves the tool's already-produced result when both `isAcceptedYieldToolAbort(signal, toolName)` AND `isHandoffAbortError(error, signal)` match — i.e., the hook threw the signal's own reason object (e.g., via `signal.throwIfAborted()`) or an `Error` wrapping it as `cause`.
- **`afterToolOutcome` catch** (`finalizeToolCallOutcome`, `agent-loop.ts:1680`): same dual guard as `afterToolCall`.

A sibling tool's hook error, a different handoff owner setting `turnHandoff: true` on a tool merely named `sessions_yield`, or an unrelated `AbortError` is **not** masked (covered by regression tests).

## Scope of ClawSweeper P1 vs. This Fix

ClawSweeper's P1 finding ("Trace a production post-tool abort producer before preserving results") was raised against the **prior** version of this PR, which modified only the `afterToolCall` and `afterToolOutcome` settlement catches. The reviewer's core objection was that the inspected production `afterToolCall` callback delegates to an error-isolating extension runner (`dispatchHandlers` in `src/agents/sessions/extensions/runner.ts:700-707`), which catches handler errors internally without re-throwing, so **no production path was shown to throw the signal's handoff reason into either of those two catches**. The integration test replaced `session.agent.afterToolCall` wholesale to inject the fault — synthetic injection at a production boundary, not a traced production producer.

This revision changes the P1's premise by locating the **real** producer at a different boundary:

| Boundary | ClawSweeper P1 scope | This fix |
|---|---|---|
| **wrapper pre-check** (`agent-tools.abort.ts:85-87`) | Not inspected (prior PR did not touch the wrapper) | **Root-cause producer** — throws `Error("Aborted")` before `raceWithAbortSignal`, with no yield-handoff exemption. Traced and fixed. |
| **execution catch** (`readyExecution.execute` catch, `agent-loop.ts:1497`) | Not in P1 scope (prior PR explicitly left it unguarded, claiming "the yield tool returns normally") | **Direct consumer of the wrapper pre-check's throw** — guard added as defense-in-depth. The prior PR's premise ("yield tool returns normally, non-rejecting race") was incomplete: the non-rejecting exemption lives only inside `raceWithAbortSignal`, which the pre-check bypasses. |
| **`afterToolCall` catch** (`finalizeExecutedToolCall`, `agent-loop.ts:1612`) | P1 target — no production producer traced | **Still no production producer.** The production callback delegates to `dispatchHandlers`, which catches handler errors internally. Guard retained as defense-in-depth; the AgentSession integration test injects the fault by replacing the callback. |
| **`afterToolOutcome` catch** (`finalizeToolCallOutcome`, `agent-loop.ts:1680`) | P1 target — no production producer traced | **Still no production producer.** Same reasoning as `afterToolCall`. Guard retained as defense-in-depth. |

**What changed**: the issue's reported symptom (`sessions_yield tool result: Aborted`) is now traced to a concrete production code path — the wrapper pre-check throwing `Error("Aborted")` → the execution catch converting it to an error tool result → the delivery path collapsing the error-only payload to zero count. The prior P1 blocker ("no traced production producer") is resolved for the **execution catch** via the wrapper pre-check.

**What did not change**: the `afterToolCall` and `afterToolOutcome` catches still have no traced production producer. Their guards remain defense-in-depth: if a future callback or wrapper ever propagates the signal's reason (e.g., via `signal.throwIfAborted()`), the accepted handoff is preserved rather than erased. The issue itself names `finalizeExecutedToolCall` as a catch that "also rewrites the result to an error without consulting the handoff marker," so the guard is aligned with the issue's stated expectation even though the current production callback does not produce the throw.

## Evidence

### Root cause proof: wrapper pre-check produces `Error("Aborted")`

The wrapper pre-check at `agent-tools.abort.ts:85-87` (before fix):
```ts
if (combinedSignal.aborted) {
  throwAbortError();  // throws Error("Aborted") — NO yield-handoff exemption
}
```

This runs **before** `raceWithAbortSignal` (line 88), which is where the non-rejecting exemption lives (lines 40-47). When the run signal is already aborted with `SESSIONS_YIELD_ABORT_REASON`, the pre-check throws unconditionally.

The thrown error reaches the execution catch (`agent-loop.ts:1497-1509`), which converts it via `createErrorToolResult(coerceErrorMessage(error))` into `{ content: [{ text: "Aborted" }], isError: true }` — exactly the issue's `sessions_yield tool result: Aborted`.

### Focused committed proof (post-fix):

```
node scripts/run-vitest.mjs src/agents/agent-tools.runtime.test.ts
# 1 file, 31 tests passed (includes yield-handoff exemption tests)

node scripts/run-vitest.mjs packages/agent-core/src/agent-loop.test.ts
# 1 file, 86 tests passed

node scripts/run-vitest.mjs src/agents/sessions/agent-session-loop-next-turn.test.ts -t "settlement fault-path"
# 1 file, 1 passed | 17 skipped (18)
```

### Updated wrapper test: yield-handoff exemption

The test at `agent-tools.runtime.test.ts` (formerly "does not start sessions_yield when the run was already handed off") now verifies the exemption:

```
it("lets sessions_yield run when the run was already handed off")
  → result.details: { status: "error" } (tool's own error, not "Aborted")
  → onYield not called (no claimYield)

it("preserves a sessions_yield result when the run was already handed off")
  → result.details: { status: "yielded", message: "Turn yielded." }
  → onYield called once
```

Format/lint/typecheck on touched files:

```
node_modules/.bin/oxfmt --check src/agents/agent-tools.abort.ts src/agents/agent-tools.runtime.test.ts packages/agent-core/src/agent-loop.ts packages/agent-core/src/turn-interruption.ts   # All matched files use the correct format
node_modules/.bin/oxlint src/agents/agent-tools.abort.ts src/agents/agent-tools.runtime.test.ts packages/agent-core/src/agent-loop.ts packages/agent-core/src/turn-interruption.ts           # 0 warnings, 0 errors
node scripts/run-tsgo.mjs -p tsconfig.core.json                  # no errors (exit 0)
```

### Boundary-level proof: embedded sessions_yield handoff through delivery

The existing qa-lab e2e suite covers the full accepted-yield lifecycle through external delivery: inbound trigger → `sessions_spawn` → child `sessions_yield` self-pause → requester stays parked (quiet window asserted) → follow-up run adoption (distinct gateway runId) → completion announce with exactly one outbound message. It runs against a real ephemeral gateway child process with a mock OpenAI-compatible provider and a mock channel transport (bus), not a unit mock.

```
node scripts/run-vitest.mjs extensions/qa-lab/src/plugin-subagent-self-yield-followup.e2e.test.ts

✓ extensions/qa-lab/src/plugin-subagent-self-yield-followup.e2e.test.ts
  > plugin subagent sessions_yield follow-up
  > announces to the original requester only after the follow-up run ends

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

### Harness verdict JSON

```json
{
  "proof": "mock-gateway-yield-handoff-delivery",
  "command": "node scripts/run-vitest.mjs extensions/qa-lab/src/plugin-subagent-self-yield-followup.e2e.test.ts",
  "harness": {
    "kind": "mock-gateway-ephemeral-child",
    "provider": "mock-openai (startQaMockOpenAiServer)",
    "channel": "qa-bus-mock (startQaBusServer + createQaChannelTransport)"
  },
  "flow": "inbound → sessions_spawn → child sessions_yield self-pause → requester parked (15s quiet window asserted) → follow-up run adoption (distinct gateway runId) → completion announce (exactly 1 outbound message)",
  "result": { "testsPassed": 1, "testsFailed": 0, "exitCode": 0 }
}
```

### Production-boundary fault-path proof: AgentSession integration test

A new integration test in `src/agents/sessions/agent-session-loop-next-turn.test.ts` drives the fault through the real `AgentSession` → `Agent.prompt` → `runAgentLoop` → `config.afterToolCall` production call chain. It creates a real `AgentSession` via `createTestSession` (mock `streamSimple` provider), registers a `sessions_yield` tool that aborts with the canonical handoff marker, wraps `session.agent.afterToolCall` to throw `signal.reason` on the yield tool, and asserts the requester-visible delivery outcome.

```
node scripts/run-vitest.mjs src/agents/sessions/agent-session-loop-next-turn.test.ts -t "settlement fault-path"

✓ |agents-support| src/agents/sessions/agent-session-loop-next-turn.test.ts
  > AgentSession settlement fault-path
  > preserves the accepted sessions_yield handoff when afterToolCall throws  1666ms

 Test Files  1 passed (1)
      Tests  1 passed | 17 skipped (18)
```

### Fault-path coverage

| Path | Coverage | Pre-fix |
|---|---|---|
| wrapper pre-check — sessions_yield when run already aborted | agent-tools.runtime.test.ts (exemption test) | reject with "Aborted" (bug) |
| execution catch — AbortError after yield-handoff abort | agent-core unit (defense-in-depth guard) | rewrite to error (bug) |
| `afterToolCall` catch — hook throws signal.reason | AgentSession integration + agent-core unit | rewrite to error (bug) |
| `afterToolOutcome` catch — hook throws signal.reason | agent-core unit | rewrite to error (bug) |
| sibling tool hook error | agent-core unit (sibling regression) | pass (error preserved) |
| genuine yield-callback error (non-AbortError) | agent-core unit (genuine-error regression) | pass (error preserved) |
| different-owner handoff | agent-core unit | pass (error preserved) |
| non-handoff abort | agent-core unit (control) | pass (both) |
| happy-path yield→delivery | e2e (mock-gateway) | pass (both) |

### Known proof gaps

- **`afterToolCall` / `afterToolOutcome` catches have no traced production producer.** The production `afterToolCall` callback (`agent-session-base.ts:258`) delegates to `runner.emitToolResult` → `dispatchHandlers` (`runner.ts:700-707`), which catches handler errors internally without re-throwing. No production callback calls `signal.throwIfAborted()` or throws `signal.reason`. The AgentSession integration test replaces `session.agent.afterToolCall` to inject the fault — this is synthetic fault injection at a production boundary, not a traced production producer. These two guards are defense-in-depth, aligned with the issue's stated expectation that `finalizeExecutedToolCall` should consult the handoff marker.
- No live Telegram/Codex end-to-end run was executed; the boundary proof uses a mock-gateway harness with a mock OpenAI-compatible provider (per AGENTS.md the mock-gateway harness satisfies the real-behavior-proof gate for channel-visible changes covering the changed path).

## Diff Shape

- Production: `+132/-12` (net `+120`) — `isYieldHandoffAbort` helper + 3 pre-check exemptions in `agent-tools.abort.ts` (+30/-3), 3 helpers in `turn-interruption.ts` (+63/-6), execution catch guard + 2 settlement guards in `agent-loop.ts` (+39/-2), baseline cleanup (-1).
- Tests: `+785/-5` (net `+780`) — wrapper exemption tests, yield-preservation (execution/afterToolCall/afterToolOutcome), sibling-cancellation, genuine-error, different-owner, non-handoff control (agent-core unit); AgentSession integration fault-path.
- No config, protocol, schema-version, public API, or docs surface change.

Production growth is inherent to the fix: the wrapper pre-check exemption is the root-cause producer fix, and the three settlement-catch guards are defense-in-depth at distinct shared boundaries, all reusing the existing wrapper-layer tool-name and handoff-reason contracts.

## AI Assistance

- AI-assisted: Yes
- Original model: GLM-5.2
