### PR TITLE
fix(ui): stabilize settings and update recovery E2E

### DIFF
--- a/ui/src/e2e/app-chrome-interaction.e2e.test.ts
+++ b/ui/src/e2e/app-chrome-interaction.e2e.test.ts
@@ -3,7 +3,10 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
-import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  installMockGateway,
+  waitForControlUiSettingsTakeover,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -155,11 +158,10 @@ suite.define(() => {
         // 650px even against the mock gateway's tiny config fixture; General
         // became short enough to fit once the host panel moved to Gateway.
         await page.goto(`${suite.server.baseUrl}settings/appearance`);
-        const settingsSidebar = page.locator(".settings-sidebar");
+        const { search: settingsSearch, sidebar: settingsSidebar } =
+          await waitForControlUiSettingsTakeover(page);
         const settingsTitle = settingsSidebar.locator(".settings-sidebar__title");
-        const settingsSearch = settingsSidebar.locator(".settings-sidebar__search-input");
         const content = page.locator(".content");
-        await settingsSidebar.waitFor();
         await expect
           .poll(() => content.evaluate((element) => element.scrollHeight))
           .toBeGreaterThan(await content.evaluate((element) => element.clientHeight));

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -448,10 +448,32 @@ describe("Control UI service-worker production update E2E", () => {
           "catalog" in request.params,
       );
       expect(catalogOpensBeforeWorkerActivation.length).toBeLessThanOrEqual(1);
+      if (catalogOpensBeforeWorkerActivation.length > 0) {
+        const currentConnect = (await gateway.getRequests("connect")).at(-1);
+        expect(currentConnect?.params).toMatchObject({ client: { buildId: buildB } });
+      }
       installGate.release();
       await reloaded;
       await ensureControlledPage(page, pageErrors, buildB);
-      await expect.poll(() => readWorkerUpdateVersions(page)).toContain(buildB);
+      await expect
+        .poll(async () => (await gateway.getRequests("connect")).at(-1)?.params)
+        .toMatchObject({ client: { buildId: buildB } });
+      await page.waitForFunction((expectedBuildId) => {
+        const controller = navigator.serviceWorker.controller;
+        return (
+          controller?.state === "activated" &&
+          new URL(controller.scriptURL).searchParams.get("v") === expectedBuildId
+        );
+      }, buildB);
+      expect(
+        await page.evaluate(() => {
+          const controller = navigator.serviceWorker.controller;
+          return {
+            buildId: controller ? new URL(controller.scriptURL).searchParams.get("v") : null,
+            state: controller?.state ?? null,
+          };
+        }),
+      ).toEqual({ buildId: buildB, state: "activated" });
 
       const terminal = page.locator("openclaw-terminal-panel[embedded]");
       await terminal.waitFor({ state: "attached" });
@@ -499,6 +521,18 @@ describe("Control UI service-worker production update E2E", () => {
         sha256: assetB.sha256,
       });
       expect(refreshedAsset.sha256).not.toBe(initialAsset.sha256);
+      await expect
+        .poll(() =>
+          page.evaluate(
+            async ({ assetPath, cacheName }) => {
+              const cache = await caches.open(cacheName);
+              const shell = await cache.match(new URL("./", window.location.origin));
+              return shell ? (await shell.text()).includes(assetPath) : false;
+            },
+            { assetPath: assetB.path, cacheName: `openclaw-control-${buildB}` },
+          ),
+        )
+        .toBe(true);
 
       if (captureUiProof) {
         await page.screenshot({


### PR DESCRIPTION
## What Problem This Solves

Resolves two independent current-main Control UI E2E ownership races that failed otherwise unrelated runner PR CI:

- the app-chrome test could observe the lazy settings placeholder before the real settings takeover owned its search/navigation surface;
- the service-worker update test required a transient build-B message even when stale-chunk recovery had already replaced the old document with a healthy build-B document.

Pre-fix evidence:

- Settings takeover failure: https://github.com/openclaw/openclaw/actions/runs/32328962387/job/96305923035
- Service-worker update failure: https://github.com/openclaw/openclaw/actions/runs/32328962387/job/96305923093

## Why This Change Was Made

The first commit adopts the canonical settings-takeover helper and preserves every existing scrollbar, overflow, drag, focus, and input-selection assertion. The second commit keeps the stable initial build-A worker-message proof, then proves the replacement document through its current/latest Gateway `connect.client.buildId`, fences any pre-activation terminal open to build B, and verifies the activated build-B controller plus the build-B cache's precached shell. It intentionally does not add an acknowledgement, persistent marker, timeout, retry, or stale-chunk bypass.

The mock Gateway request ledger is document-local and resets on navigation, so the latest request is the current document's request; carrying an `after` count across recovery would be ambiguous and could wait forever. The fetched build-B entry asset may legitimately have been cached while controller A was still active, so exact B ownership is asserted on B's install-owned shell while the asset remains independently proven by its exact hash under controller B.

Commits:

- `test(ui): await settings takeover in app chrome E2E`
- `test(ui): assert current build after update recovery`

Production LOC: +0/-0. Tests: +41/-5.

## User Impact

No product behavior changes. Maintainers get deterministic Control UI browser proof for settings takeover and service-worker recovery, and unrelated PRs no longer fail these two current-main assertions.

## Evidence

- App-chrome E2E: 20/20 independent CI-mode runs passed (40 tests).
- Service-worker update E2E: 20/20 independent CI-mode runs passed (40 tests), plus one focused settlement run after the initial failing controller-identity diagnostic.
- Exact current 11-way Control UI Vitest shard 5: 22 files / 83 tests passed.
- Service-worker/stale-chunk unit owners: 2 files / 75 tests passed.
- Real stale-chunk recovery siblings: 2 files / 5 tests passed.
- Actual `node scripts/check-changed.mjs`: passed.
- `pnpm tsgo:test:ui`: passed.
- Formatting and `git diff --check`: passed.
- Fresh branch Codex autoreview: clean, no accepted/actionable findings; patch correct (0.99).

Exact local shard 6 also exercised the changed app-chrome test successfully, but its aggregate result was red on the untouched current-main `native-nav-sidebar-toggle.e2e.test.ts`: pointer interception in the dark/light toast cases (one reproduced focused). That file has no diff from `origin/main`; the original runner CI's same shard passed it. Exact-head PR CI remains the authoritative aggregate shard proof.
