### PR TITLE
fix(android): gate gateway RPC polling on the hello method catalog

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1326,7 +1326,7 @@ class NodeRuntime private constructor(
   // response from publishing into a replacement socket on the same stable endpoint.
   private val gatewayMethodsLock = Any()
   private var gatewayApprovalRpcFamily = GatewayApprovalRpcFamily.Unavailable
-  private var gatewayProgressCardAdvertised: Boolean? = null
+  private var gatewayAdvertisedMethods: Set<String>? = null
   private var gatewayMethodsEpoch = 0L
 
   @Volatile internal var gatewayDataRequestOverrideForTests: GatewayDataRequestOverride? = null
@@ -1918,7 +1918,7 @@ class NodeRuntime private constructor(
           cacheScope = ::chatCacheScope,
           currentDefaultAgentId = { gatewayDefaultAgentId.value },
           currentDefaultAgentRevision = gatewayDefaultAgentRevision::get,
-          gatewayAdvertisesProgressCard = ::gatewayAdvertisesProgressCard,
+          gatewayAdvertisesMethod = ::gatewayAdvertisesMethod,
           commandOutbox = chatCommandOutbox,
           recordModelRecent = prefs::recordModelRecent,
           onSessionDeleted = ::publishChatSessionDeletion,
@@ -1934,7 +1934,7 @@ class NodeRuntime private constructor(
           scope = scope,
           json = json,
           requestGateway = AndroidScreenshotFixture::request,
-          gatewayAdvertisesProgressCard = { true },
+          gatewayAdvertisesMethod = { _ -> true },
         )
     }.also {
       it.applyMainSessionKey(_mainSessionKey.value)
@@ -7400,8 +7400,8 @@ class NodeRuntime private constructor(
   private fun replaceGatewayMethods(methods: Set<String>?) {
     synchronized(gatewayMethodsLock) {
       val advertisedMethods = methods.orEmpty()
+      gatewayAdvertisedMethods = methods
       gatewayApprovalRpcFamily = selectGatewayApprovalRpcFamily(advertisedMethods)
-      gatewayProgressCardAdvertised = methods?.let { GatewayMethod.ProgressCardGet.rawValue in it }
       _clawHubSkillMethodsAvailable.value = supportsClawHubSkillManagement(advertisedMethods)
       _desktopObserveAvailable.value = GatewayMethod.DesktopObserve.rawValue in advertisedMethods
       systemAgentChatSupported.value = GatewayMethod.OpenclawChat.rawValue in advertisedMethods
@@ -7409,7 +7409,7 @@ class NodeRuntime private constructor(
     }
   }
 
-  private fun gatewayAdvertisesProgressCard(): Boolean? = synchronized(gatewayMethodsLock) { gatewayProgressCardAdvertised }
+  private fun gatewayAdvertisesMethod(method: String): Boolean? = synchronized(gatewayMethodsLock) { gatewayAdvertisedMethods?.let { method in it } }
 
   private fun captureGatewayMethods(): GatewayMethodsSnapshot =
     synchronized(gatewayMethodsLock) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1404,8 +1404,9 @@ class NodeRuntime private constructor(
         replaceGatewayMethods(hello.methods)
         val operatorScopes = normalizeOperatorScopes(hello.authScopes)
         _operatorScopes.value = operatorScopes
+        // Pairing capabilities require positive hello advertisement; an unknown catalog grants none.
         _devicePairingCapabilities.value =
-          selectGatewayDevicePairingCapabilities(hello.methods, operatorScopes)
+          selectGatewayDevicePairingCapabilities(hello.methods.orEmpty(), operatorScopes)
         _seamColorArgb.value = DEFAULT_SEAM_COLOR_ARGB
         val mainSessionKey =
           prepareMainSessionKey(resolveAgentIdFromMainSessionKey(hello.mainSessionKey))

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -101,6 +101,8 @@ private class MainSessionReadiness(
   var job: Job? = null
 }
 
+private class BranchListingUnsupportedException : IllegalStateException("sessions.branches.list is not supported by this gateway")
+
 class ChatController internal constructor(
   private val scope: CoroutineScope,
   private val json: Json,
@@ -109,7 +111,7 @@ class ChatController internal constructor(
     { method, paramsJson, _ -> requestGateway(method, paramsJson) },
   private val requestGatewayForGateway: suspend (gatewayId: String, method: String, paramsJson: String?) -> String =
     { _, method, paramsJson -> requestGateway(method, paramsJson) },
-  private val gatewayAdvertisesProgressCard: () -> Boolean? = { null },
+  private val gatewayAdvertisesMethod: (method: String) -> Boolean? = { null },
   private val captureSettingsRequestLease: (gatewayScope: ChatCacheScope?) -> GatewaySession.RequestLease? =
     { gatewayScope ->
       GatewaySession.RequestLease(endpointStableId = gatewayScope?.gatewayId.orEmpty()) { method, paramsJson, _ ->
@@ -152,7 +154,7 @@ class ChatController internal constructor(
     cacheScope: () -> ChatCacheScope? = { null },
     currentDefaultAgentId: () -> String? = { "main" },
     currentDefaultAgentRevision: () -> Long = { 0L },
-    gatewayAdvertisesProgressCard: () -> Boolean? = { null },
+    gatewayAdvertisesMethod: (method: String) -> Boolean? = { null },
     commandOutbox: ChatCommandOutbox? = null,
     recordModelRecent: (String) -> Unit = {},
     onSessionDeleted: (ChatSessionDeletion) -> Unit = {},
@@ -168,7 +170,7 @@ class ChatController internal constructor(
     requestGatewayForGateway = { gatewayId, method, paramsJson ->
       session.requestForEndpoint(gatewayId, method, paramsJson)
     },
-    gatewayAdvertisesProgressCard = gatewayAdvertisesProgressCard,
+    gatewayAdvertisesMethod = gatewayAdvertisesMethod,
     captureSettingsRequestLease = { gatewayScope ->
       session.captureRequestLease(gatewayScope?.gatewayId)
     },
@@ -1772,6 +1774,7 @@ class ChatController internal constructor(
     sessionKey: String,
     ownerAgentId: String,
   ): List<SessionBranch> {
+    if (gatewayAdvertisesMethod("sessions.branches.list") == false) throw BranchListingUnsupportedException()
     val params =
       buildJsonObject {
         put("sessionKey", JsonPrimitive(sessionKey))
@@ -1914,7 +1917,9 @@ class ChatController internal constructor(
     }
   }
 
-  private fun branchListingUnsupported(error: Throwable): Boolean = error.message?.contains("unknown method: sessions.branches.list", ignoreCase = true) == true
+  private fun branchListingUnsupported(error: Throwable): Boolean =
+    error is BranchListingUnsupportedException ||
+      error.message?.contains("unknown method: sessions.branches.list", ignoreCase = true) == true
 
   private suspend fun refreshHistoryForSessionAction(
     snapshot: SessionActionSnapshot,
@@ -3409,27 +3414,34 @@ class ChatController internal constructor(
     gatewayScope: ChatCacheScope?,
   ): Boolean {
     val response =
-      try {
-        requestGatewayBound(gatewayScope?.gatewayId, "question.list", "{}")
-      } catch (err: GatewayRequestRejected) {
-        val unavailable =
-          err.gatewayError.missingScope() == "operator.questions" ||
-            (
-              err.gatewayError.code == "INVALID_REQUEST" &&
-                err.gatewayError.message == "unknown method: question.list"
-            )
-        if (!unavailable) throw err
-        if (!questionRefreshIsCurrent(refreshGeneration, stateRevision, gatewayScope)) return false
-        return synchronized(questionStateLock) {
-          if (!questionRefreshIsCurrentLocked(refreshGeneration, stateRevision)) return@synchronized false
-          if (_questions.value.isNotEmpty()) {
-            _questions.value = emptyList()
-            questionStateRevision += 1
-          }
-          syncQuestionEvictionsLocked()
-          true
+      if (gatewayAdvertisesMethod("question.list") == false) {
+        null
+      } else {
+        try {
+          requestGatewayBound(gatewayScope?.gatewayId, "question.list", "{}")
+        } catch (err: GatewayRequestRejected) {
+          val unavailable =
+            err.gatewayError.missingScope() == "operator.questions" ||
+              (
+                err.gatewayError.code == "INVALID_REQUEST" &&
+                  err.gatewayError.message == "unknown method: question.list"
+              )
+          if (!unavailable) throw err
+          null
         }
       }
+    if (response == null) {
+      if (!questionRefreshIsCurrent(refreshGeneration, stateRevision, gatewayScope)) return false
+      return synchronized(questionStateLock) {
+        if (!questionRefreshIsCurrentLocked(refreshGeneration, stateRevision)) return@synchronized false
+        if (_questions.value.isNotEmpty()) {
+          _questions.value = emptyList()
+          questionStateRevision += 1
+        }
+        syncQuestionEvictionsLocked()
+        true
+      }
+    }
     if (!questionRefreshIsCurrent(refreshGeneration, stateRevision, gatewayScope)) return false
     val listedRecords = json.decodeFromString<QuestionListResult>(response).questions
     val listedIds = listedRecords.mapTo(mutableSetOf()) { it.id }
@@ -5889,7 +5901,7 @@ class ChatController internal constructor(
         // SUNSET 2026-10-18: this fallback is a fixed cutover window, not a permanent contract.
         // On that date delete it together with the Gateway's legacy stream:"plan" dual-emit and
         // the Apple twin in ChatViewModel+TransportEvents.swift. Tracked: #125639.
-        if (gatewayAdvertisesProgressCard() != false) return
+        if (gatewayAdvertisesMethod("progressCard.get") != false) return
         val planData = data ?: return
         if (planData["phase"].asStringOrNull() != "update") return
         val steps = parseChatPlanSteps(planData["steps"])
@@ -6098,6 +6110,7 @@ class ChatController internal constructor(
   }
 
   private fun refreshProgressCard() {
+    if (gatewayAdvertisesMethod("progressCard.get") == false) return
     val sessionKey = normalizeRequestedSessionKey(_sessionKey.value)
     val gatewayScope = currentCacheScope()
     val generation = progressCardFetchGeneration.incrementAndGet()

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -214,7 +214,7 @@ data class GatewayHelloSummary(
   val updateAvailable: GatewayUpdateAvailableSummary?,
   val authRole: String? = null,
   val authScopes: List<String> = emptyList(),
-  val methods: Set<String> = emptySet(),
+  val methods: Set<String>? = null,
 )
 
 data class GatewayUpdateAvailableSummary(
@@ -1441,7 +1441,6 @@ class GatewaySession(
           .asArrayOrNull()
           ?.mapNotNull { it.asStringOrNull()?.trim()?.takeIf { method -> method.isNotEmpty() } }
           ?.toSet()
-          .orEmpty()
       val authObj = obj["auth"].asObjectOrNull()
       val deviceToken = authObj?.get("deviceToken").asStringOrNull()
       val authRole = authObj?.get("role").asStringOrNull() ?: options.role

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
@@ -1,6 +1,8 @@
 package ai.openclaw.app.chat
 
 import ai.openclaw.app.gateway.GatewayRequestOutcomeUnknown
+import ai.openclaw.app.gateway.GatewayRequestRejected
+import ai.openclaw.app.gateway.GatewaySession
 import androidx.room.Room
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
@@ -53,6 +55,7 @@ class ChatControllerBranchCoordinationTest {
   private fun controller(
     gateway: ScriptedGateway,
     dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    gatewayAdvertisesMethod: (method: String) -> Boolean? = { null },
   ): ChatController {
     val controllerScope = CoroutineScope(SupervisorJob() + dispatcher)
     controllerScopes += controllerScope
@@ -61,6 +64,7 @@ class ChatControllerBranchCoordinationTest {
       json = json,
       requestGateway = gateway::request,
       cacheScope = { ChatCacheScope("gateway-a", 1) },
+      gatewayAdvertisesMethod = gatewayAdvertisesMethod,
       commandOutbox = outbox,
     )
   }
@@ -259,6 +263,47 @@ class ChatControllerBranchCoordinationTest {
 
       assertTrue(listCalls.get() >= 2)
       assertFalse(outbox.branchState("gateway-a", ChatOutboxScope("main", "main"))?.needsReconciliation == true)
+    }
+
+  @Test
+  fun gatewayWithoutBranchListingDispatchesQueuedInputWithoutRequestingBranches() =
+    runTest {
+      val gateway = ScriptedGateway(json)
+      gateway.respondWith("chat.history", historyResponse(sessionId = "main", messages = emptyList()))
+      gateway.respond("sessions.branches.list") {
+        throw GatewayRequestRejected(
+          GatewaySession.ErrorShape(
+            code = "INVALID_REQUEST",
+            message = "missing scope: operator.admin",
+          ),
+        )
+      }
+      gateway.respondChatSend("started")
+      val controller =
+        controller(
+          gateway,
+          StandardTestDispatcher(testScheduler),
+          gatewayAdvertisesMethod = { method -> method != "sessions.branches.list" },
+        )
+      runCurrent()
+      controller.awaitOutboxRestore()
+      controller.handleGatewayEvent("health", null)
+      runCurrent()
+      assertTrue(controller.healthOk.value)
+
+      assertTrue(controller.sendMessageAwaitAcceptance("dispatch without branches", "off", emptyList()))
+      withContext(Dispatchers.Default.limitedParallelism(1)) {
+        withTimeout(5_000) {
+          while (gateway.callCount("chat.send") == 0 && gateway.callCount("sessions.branches.list") == 0) {
+            runCurrent()
+            kotlinx.coroutines.delay(10)
+          }
+        }
+      }
+
+      assertEquals(0, gateway.callCount("sessions.branches.list"))
+      assertEquals(1, gateway.callCount("chat.send"))
+      assertFalse(outbox.load("gateway-a").single().status == ChatOutboxStatus.Queued)
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerProgressCardTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerProgressCardTest.kt
@@ -20,17 +20,20 @@ class ChatControllerProgressCardTest {
 
   private fun TestScope.newController(
     gateway: ScriptedGateway,
-    gatewayAdvertisesProgressCard: () -> Boolean? = { null },
+    gatewayAdvertisesMethod: (method: String) -> Boolean? = { null },
   ): ChatController =
     backgroundScope.createChatController(
       requestGateway = gateway::request,
-      gatewayAdvertisesProgressCard = gatewayAdvertisesProgressCard,
+      gatewayAdvertisesMethod = gatewayAdvertisesMethod,
     )
 
-  private suspend fun TestScope.startRun(gatewayAdvertisesProgressCard: Boolean?): StartedRun {
+  private suspend fun TestScope.startRun(progressCardAdvertised: Boolean?): StartedRun {
     val gateway = ScriptedGateway(chatControllerTestJson)
     gateway.respondChatSend(status = "started")
-    val controller = newController(gateway) { gatewayAdvertisesProgressCard }
+    val controller =
+      newController(gateway) { method ->
+        if (method == "progressCard.get") progressCardAdvertised else true
+      }
     controller.handleGatewayEvent("health", null)
     runCurrent()
     assertTrue(controller.sendMessageAwaitAcceptance("make a plan", "off", emptyList()))
@@ -59,7 +62,7 @@ class ChatControllerProgressCardTest {
   @Test
   fun legacyPlanRendersWhenGatewayLacksProgressCardStore() =
     runTest {
-      val (controller, _, runId) = startRun(gatewayAdvertisesProgressCard = false)
+      val (controller, _, runId) = startRun(progressCardAdvertised = false)
 
       controller.handleGatewayEvent(
         "agent",
@@ -88,7 +91,7 @@ class ChatControllerProgressCardTest {
   @Test
   fun emptyLegacyPlanClearsFallbackCard() =
     runTest {
-      val (controller, _, runId) = startRun(gatewayAdvertisesProgressCard = false)
+      val (controller, _, runId) = startRun(progressCardAdvertised = false)
       controller.handleGatewayEvent(
         "agent",
         planEvent(runId, """{"phase":"update","steps":[{"step":"Active","status":"in_progress"}]}"""),
@@ -109,7 +112,7 @@ class ChatControllerProgressCardTest {
   @Test
   fun capableGatewayIgnoresLegacyPlanDualEmit() =
     runTest {
-      val (controller, gateway, runId) = startRun(gatewayAdvertisesProgressCard = true)
+      val (controller, gateway, runId) = startRun(progressCardAdvertised = true)
       gateway.respondWith("progressCard.get", cardResponse(markdown = "Canonical"))
       controller.handleGatewayEvent("progressCard.changed", changedEvent("main", "1"))
       runCurrent()
@@ -126,7 +129,7 @@ class ChatControllerProgressCardTest {
   @Test
   fun unknownGatewayCapabilityIgnoresLegacyPlan() =
     runTest {
-      val (controller, _, runId) = startRun(gatewayAdvertisesProgressCard = null)
+      val (controller, _, runId) = startRun(progressCardAdvertised = null)
 
       controller.handleGatewayEvent(
         "agent",
@@ -137,9 +140,9 @@ class ChatControllerProgressCardTest {
     }
 
   @Test
-  fun failedStoreFetchPreservesLegacyFallbackCard() =
+  fun healthRefreshSkipsUnadvertisedStoreAndPreservesLegacyFallbackCard() =
     runTest {
-      val (controller, gateway, runId) = startRun(gatewayAdvertisesProgressCard = false)
+      val (controller, gateway, runId) = startRun(progressCardAdvertised = false)
       controller.handleGatewayEvent(
         "agent",
         planEvent(runId, """{"phase":"update","explanation":"Keep me","steps":[{"step":"Active","status":"in_progress"}]}"""),
@@ -151,6 +154,7 @@ class ChatControllerProgressCardTest {
       runCurrent()
 
       assertEquals(expected, controller.progressCard.value)
+      assertEquals(0, gateway.callCount("progressCard.get"))
     }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatQuestionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatQuestionTest.kt
@@ -179,6 +179,30 @@ class ChatQuestionTest {
     }
 
   @Test
+  fun gatewayWithoutQuestionListClearsStaleCardsWithoutRequestingQuestions() =
+    runTest {
+      val (controller, requests) =
+        chatControllerTestSetup {
+          gatewayAdvertisesMethod = { method -> method != "question.list" }
+          respond("question.list") {
+            throw GatewayRequestRejected(
+              GatewaySession.ErrorShape(
+                code = "INVALID_REQUEST",
+                message = "missing scope: operator.admin",
+              ),
+            )
+          }
+        }
+
+      controller.handleGatewayEvent("question.requested", json.encodeToString(record(id = "ask_stale")))
+      controller.handleGatewayEvent("health", null)
+      advanceUntilIdle()
+
+      assertTrue(requests.none { it.first == "question.list" })
+      assertTrue(controller.questions.value.isEmpty())
+    }
+
+  @Test
   fun pendingRefreshPreservesSubmissionLock() =
     runTest {
       val resolveStarted = CompletableDeferred<Unit>()

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatReplayHarness.kt
@@ -19,7 +19,7 @@ internal fun CoroutineScope.createChatController(
   cacheScope: () -> ChatCacheScope? = { null },
   currentDefaultAgentId: () -> String? = { "main" },
   currentDefaultAgentRevision: () -> Long = { 0L },
-  gatewayAdvertisesProgressCard: () -> Boolean? = { null },
+  gatewayAdvertisesMethod: (method: String) -> Boolean? = { null },
   recordModelRecent: (String) -> Unit = {},
   onSessionDeleted: (ChatSessionDeletion) -> Unit = {},
   onOfflineDefaultAgentRestored: (String) -> Unit = {},
@@ -48,7 +48,7 @@ internal fun CoroutineScope.createChatController(
     cacheScope = cacheScope,
     currentDefaultAgentId = currentDefaultAgentId,
     currentDefaultAgentRevision = currentDefaultAgentRevision,
-    gatewayAdvertisesProgressCard = gatewayAdvertisesProgressCard,
+    gatewayAdvertisesMethod = gatewayAdvertisesMethod,
     recordModelRecent = recordModelRecent,
     onSessionDeleted = onSessionDeleted,
     onOfflineDefaultAgentRestored = onOfflineDefaultAgentRestored,
@@ -61,6 +61,7 @@ internal class ChatControllerTestSetup(
 ) {
   val requests = mutableListOf<Pair<String, String?>>()
   var cacheScope: () -> ChatCacheScope? = { null }
+  var gatewayAdvertisesMethod: (method: String) -> Boolean? = { null }
   var recordModelRecent: (String) -> Unit = {}
 
   private val handlers = mutableMapOf<String, suspend (String?) -> String>()
@@ -82,6 +83,7 @@ internal class ChatControllerTestSetup(
   val controller: ChatController by lazy {
     scope.createChatController(
       cacheScope = cacheScope,
+      gatewayAdvertisesMethod = gatewayAdvertisesMethod,
       recordModelRecent = recordModelRecent,
       requestGateway = { method, paramsJson ->
         requests += method to paramsJson

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -239,6 +239,25 @@ class GatewaySessionReconnectTest {
     }
 
   @Test
+  fun connectedHelloKeepsMethodCatalogUnknownWhenHelloOmitsFeatures() =
+    runBlocking {
+      val json = Json { ignoreUnknownKeys = true }
+      val hello = CompletableDeferred<GatewayHelloSummary>()
+      val server =
+        startGatewayServer(json = json) { webSocket, id, method ->
+          if (method == "connect") webSocket.send(connectResponseFrame(id, methods = null))
+        }
+      val harness = createReconnectHarness(onHello = hello::complete)
+
+      try {
+        connectNodeSession(harness.session, server.port)
+        assertNull(withTimeout(LIFECYCLE_TEST_TIMEOUT_MS) { hello.await() }.methods)
+      } finally {
+        shutdownReconnectHarness(harness, server)
+      }
+    }
+
+  @Test
   fun disconnectAndJoinWaitsForNaturalFailureCallback() =
     runBlocking {
       val json = Json { ignoreUnknownKeys = true }
@@ -1100,8 +1119,11 @@ class GatewaySessionReconnectTest {
 
   private fun connectResponseFrame(
     id: String,
-    methods: Set<String> = emptySet(),
+    methods: Set<String>? = emptySet(),
   ): String {
+    if (methods == null) {
+      return """{"type":"res","id":"$id","ok":true,"payload":{"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}"""
+    }
     val encodedMethods = methods.joinToString(",") { JsonPrimitive(it).toString() }
     return """{"type":"res","id":"$id","ok":true,"payload":{"features":{"methods":[$encodedMethods]},"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}}"""
   }


### PR DESCRIPTION
## What Problem This Solves

The current Android app cannot send chat messages when paired with a released `openclaw@2026.7.1-2` gateway (live-reproduced 2026-08-17 on an isolated rig). The send parks in the outbox showing "Queued — sends when reconnected" while the connection is healthy (`chat.history` succeeds), and the app retry-loops `sessions.branches.list` at ~800ms plus `question.list` indefinitely. An action ending in a silent non-outcome is the worst bug class in this repo.

Root cause: the app detects "gateway does not support method X" by matching the modern error text `unknown method: X`. Released 2026.7.x gateways authorize **before** method dispatch, and unknown methods resolve no registered scope and default to requiring `operator.admin` (`resolveRequiredOperatorScopeForMethod(method) ?? ADMIN_SCOPE` in `src/gateway/method-scopes.ts` at v2026.7.1-2). A paired non-admin app therefore gets `INVALID_REQUEST` / `missing scope: operator.admin`, which neither detector recognizes:

- `ChatController.branchListingUnsupported` never matches, so `reconcilePendingOutboxBranchScopes` never marks the branch scope reconciled, its `finally` schedules an endless ~800ms reconciliation retry, and `nextFlushableRow` never releases the queued send.
- The `question.list` unavailable check (`operator.questions` scope or `unknown method: question.list`) never matches, so question refresh re-throws and retries on every health event.
- `refreshProgressCard` also fires a `progressCard.get` call the old gateway rejects on every health event.

## Why This Change Was Made

Method availability is negotiated in the hello handshake: `hello-ok.features.methods` is present on released 2026.7.x gateways (218 methods on 2026.7.1-2) and already flows into `NodeRuntime.replaceGatewayMethods`. This generalizes the existing `gatewayAdvertisesProgressCard` negotiation (commit 3377a21c4e2) into one tri-state `gatewayAdvertisesMethod(method)` seam (null = catalog unknown/disconnected) instead of adding another per-feature boolean:

- `requestSessionBranches` throws a marker `BranchListingUnsupportedException` without any network call when the catalog lacks `sessions.branches.list`; both existing unsupported-handling catch sites treat it like the modern `unknown method` rejection, so branch scopes reconcile immediately and queued sends flush.
- Question refresh treats a catalog without `question.list` as unavailable without issuing the request (same handling as the modern rejection: clear stale question cards and finish).
- `refreshProgressCard` skips `progressCard.get` when unadvertised; the legacy `stream:"plan"` fallback keeps its exact semantics through the new seam.

Error-text matching stays only as the fallback for the modern `unknown method:` shape; `missing scope` shapes are deliberately **not** treated as unsupported, so a genuine scope denial on a current gateway is unchanged.

## User Impact

Sending messages from the Android app works against released 2026.7.x gateways again: sends dispatch instead of parking silently in the outbox. The wasteful ~800ms `sessions.branches.list` retry loop and the rejected `question.list`/`progressCard.get` calls per health event are gone; on gateways without branch support the branch UI simply stays hidden. Behavior against current gateways is unchanged.

## Evidence

Wire-shape probe against a real released gateway (`npm install openclaw@2026.7.1-2` in a scratch dir, isolated `OPENCLAW_STATE_DIR`, `gateway run --auth token --bind loopback`; raw WS client, protocol 4, role=operator, scopes `operator.read,operator.write` — the paired-app shape, ed25519 device auth v3):

```text
HELLO protocol: 4 server version: 2026.7.1-2
HELLO auth scopes: ["operator.read","operator.write"]
HELLO features.methods count: 218
  advertises sessions.branches.list: false
  advertises question.list: false
  advertises progressCard.get: false
  advertises chat.send: true
  advertises chat.history: true
CALL sessions.branches.list -> ok=false error={"code":"INVALID_REQUEST","message":"missing scope: operator.admin"}
CALL question.list -> ok=false error={"code":"INVALID_REQUEST","message":"missing scope: operator.admin"}
CALL progressCard.get -> ok=false error={"code":"INVALID_REQUEST","message":"missing scope: operator.admin"}
```

Regression tests encode exactly that wire shape and fail on pre-fix code for the intended reason:

- `ChatControllerBranchCoordinationTest.gatewayWithoutBranchListingDispatchesQueuedInputWithoutRequestingBranches` — pre-fix: `expected:<0> but was:<1>` (the app called `sessions.branches.list` and the send stayed parked); post-fix: the send dispatches (`chat.send` count 1) with zero `sessions.branches.list` calls.
- `ChatQuestionTest.gatewayWithoutQuestionListClearsStaleCardsWithoutRequestingQuestions` — pre-fix failed at the never-requested assertion; post-fix: no `question.list` request, stale cards cleared.
- `ChatControllerProgressCardTest.healthRefreshSkipsUnadvertisedStoreAndPreservesLegacyFallbackCard` — asserts zero `progressCard.get` calls while the legacy plan fallback still renders.

Validation: `pnpm android:format`, `pnpm android:lint`, full `:app:testPlayDebugUnitTest` lane green (21/27-test classes for the touched suites; full lane BUILD SUCCESSFUL).

On-device video proof was not re-captured: it needs a paired physical device against a released gateway; the Robolectric boundary tests plus the released-gateway wire probe above cover the changed path end to end (the 2026-08-17 live repro on that rig is the before-state).

Production LOC delta: +13 (catalog seam replaces the progressCard-specific seam; gating lines carry the negotiation contract).

Follow-up (sibling surface): the shared Swift kit has the same bug class — `ChatViewModel+Outbox.swift` `branchListingIsUnsupported` matches `message.contains("sessions.branches.list")`, but `GatewayResponseError.message` is the raw gateway text (`missing scope: operator.admin`), which never contains the method name on 2026.7.x. iOS/macOS should gate on the advertised-method catalog the same way (`GatewayNodeSession.serverMethods` plumbing exists). Tracked as a named follow-up.
