### PR TITLE
fix(ui): give embedded settings sections the shared section rhythm

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -397,6 +397,9 @@ vi.mock("../skills/discovery/chat-commands.runtime.js", () => ({
 
 vi.mock("../config/runtime-snapshot.js", () => ({
   getRuntimeConfigSnapshot: () => state.runtimeConfigMock ?? state.defaultRuntimeConfig,
+  // No source snapshot: runtime-source projection no-ops and resolvers read the
+  // provided config directly, matching this suite's pre-projection world.
+  getRuntimeConfigSourceSnapshot: () => null,
   registerRuntimeConfigSnapshotPreparer: vi.fn(),
   setRuntimeConfigSnapshot: vi.fn(),
 }));

--- a/ui/docs/design-system/settings-design.md
+++ b/ui/docs/design-system/settings-design.md
@@ -14,6 +14,7 @@ Every settings surface (the `/settings` takeover pages plus the Plugins/Skills h
 ```
 
 - **Sections are typography, not chrome.** Grouping comes from whitespace + a small uppercase heading — never a card header.
+- **Embedded surfaces keep the rhythm.** A container that hosts sections without `.settings-page`'s centered column (tab panels, split layouts) takes `.settings-stack`; never re-space sections with page-local margin rules.
 - **Exactly one level of elevation.** A group never contains another card, callout, or bordered box. Nested detail uses `.settings-subrows` (indented rows), a stacked row, or a drill-in nav row.
 - **Row anatomy:** left is title (`--control-ui-text-md`, weight 500) over an optional one-line description (muted, sm). Right is exactly one control: toggle, select, segmented, button, plain value, or chevron (nav). Wide editors use the `stacked` variant.
 - **Lists are rows too.** An entity list (plugin, device, session) is a group whose rows carry an action cluster in the control slot — same anatomy as a toggle row.

--- a/ui/src/pages/agents/view.ts
+++ b/ui/src/pages/agents/view.ts
@@ -330,6 +330,7 @@ export function renderAgents(props: AgentsProps) {
               )}
               <div
                 id="agent-panel"
+                class="settings-stack"
                 role="tabpanel"
                 aria-labelledby=${`agents-tab-${props.activePanel}`}
               >

--- a/ui/src/styles/agents.css
+++ b/ui/src/styles/agents.css
@@ -15,9 +15,3 @@
 .agents-panel-body + .settings-kv {
   border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
 }
-
-/* .agents-main is a 14px-gap grid (components.css); settings sections need
-   more whitespace between each other than panel chrome does. */
-.agents-main > .settings-section:not(:first-child) {
-  margin-top: var(--space-4);
-}

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -87,6 +87,15 @@
   max-width: 1120px;
 }
 
+/* Section rhythm for embedded surfaces (tab panels, split layouts) that host
+   settings sections without .settings-page's centered column. Sections crammed
+   into a plain wrapper collapse to zero separation. */
+.settings-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
 .settings-page__intro {
   margin: 0;
   font-size: var(--control-ui-text-sm);
@@ -128,6 +137,12 @@
   font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);
+}
+
+/* Control-height header actions overhang the one-line heading; keep the
+   description's negative pull from squeezing it against the button row. */
+.settings-section__header:has(.settings-section__actions) + .settings-section__desc {
+  margin-top: 0;
 }
 
 .settings-section__actions {


### PR DESCRIPTION
## What Problem This Solves

On the agents settings page (Tools tab and siblings), settings sections stacked with **zero vertical separation**: section titles sat directly against the previous section's card, and section descriptions were pulled to 4px underneath control-height header buttons — the Verify/Save button rows looked squeezed against the text around them.

Root cause: the agent tab panel hosts settings sections in a bare `div`, outside `.settings-page`, so it never received the design language's section rhythm. The compensating rule in `agents.css` (`.agents-main > .settings-section:not(:first-child)`) missed the nested tabpanel entirely — a page-local fork of the design system that silently failed.

## Why This Change Was Made

Per `ui/docs/design-system/settings-design.md` ("extend the system, don't fork it"), the fix extends the shared design language instead of patching the page:

- `settings.css`: new `.settings-stack` primitive — section rhythm (`gap: var(--space-8)`) for embedded surfaces (tab panels, split layouts) that host sections without `.settings-page`'s centered column.
- `agents/view.ts`: the agent tab panel takes `class="settings-stack"`, fixing all seven tabs at once.
- `agents.css`: the bespoke margin fork is deleted.
- `settings.css`: descriptions after action-bearing section headers no longer pull up with the negative margin, so text clears the button row (12px instead of 4px). This also improves e.g. the Channels page's "DM access requests" header for free.

## User Impact

Agents settings tabs now read with the same 40px section rhythm as every other settings page; section titles and header action buttons (Verify, Save, Refresh…) have proper breathing room everywhere.

## Evidence

Verified live on the mocked Control UI dev server (`pnpm dev:ui:mock`), plus measured DOM geometry: section gaps 0px → 40px, header-actions→description gap 4px → 12px. Checked agents Overview/Tools/Skills tabs and the Channels page for regressions.

Before:

![before](https://github.com/user-attachments/assets/d5ec5c6b-053b-47ab-874a-fae0d3ec034d)

After:

![after](https://github.com/user-attachments/assets/805d1c73-7908-4bfc-aafb-a07d99fc0bfc)

Validation: `pnpm check:changed` (stylelint, tsgo core+UI, i18n verify, deadcode) green; `ui/src/pages/agents/view.test.ts` 24/24 passed; autoreview (Codex gpt-5.6-sol, high) clean.

## CI Heal (unrelated main breakage fixed here)

Main's `checks-node-compact-large` shard was red before this PR: #126531 routed `provider-model-routes` through `projectConfigOntoRuntimeSourceSnapshot`, which reads `getRuntimeConfigSourceSnapshot`, and `src/agents/agent-command.live-model-switch.test.ts`'s explicit `vi.mock` factory did not export it — 24 failures (repro'd on `origin/main`, also red on commit 9441e3fe6e5). Fixed in this PR per repo policy by exporting the missing binding (returns `null`, so the projection no-ops). Suite is 126/126 locally after the fix.
