### PR TITLE
fix(gateway): prevent interrupt failures from blocking session lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- **Gateway chat interruption recovery:** release chat-abort, session-admission, and request-root ownership when interrupt cancellation fails so session reset, archive, deletion, and Gateway drain recover immediately. Thanks @NianJiuZst.
 - **Secret egress host binding:** bind each shared-store secret to exact HTTPS destination hosts across CLI, Gateway RPC, and Control UI so unbound sentinel substitution fails closed before plaintext egress.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
 - **macOS app profiles:** isolate named app instances across state, preferences, Keychain, Gateway services, and duplicate-instance ownership while keeping host-global login and node services untouched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- **Gateway chat interruption recovery:** release chat-abort, session-admission, and request-root ownership when interrupt cancellation fails so session reset, archive, deletion, and Gateway drain recover immediately. Thanks @NianJiuZst.
 - **Secret egress host binding:** bind each shared-store secret to exact HTTPS destination hosts across CLI, Gateway RPC, and Control UI so unbound sentinel substitution fails closed before plaintext egress.
 - **Release validation:** defer beta candidate Parallels smoke to postpublish `release:beta-smoke` by default, keep stable/full prepublish coverage, and bound nested release workflow monitors with explicit job timeouts.
 - **macOS app profiles:** isolate named app instances across state, preferences, Keychain, Gateway services, and duplicate-instance ownership while keeping host-global login and node services untouched.

--- a/src/gateway/server-methods/chat-send-admission.ts
+++ b/src/gateway/server-methods/chat-send-admission.ts
@@ -411,36 +411,46 @@ export async function admitChatSend(params: {
     });
     return { ok: false as const };
   }
-  let interruptedActiveRun = false;
-  let interruptionSettled = true;
-  if (runInterruptTarget) {
-    interruptedActiveRun = true;
-    interruptionSettled = (
-      await interruptReplyRunTarget(runInterruptTarget, REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS)
-    ).settled;
-  } else if (p.queueMode === "interrupt") {
-    const identities = [sessionKey, backingSessionId, admittedSessionId];
-    // The fallback runs inside the new admission so the lifecycle owner excludes itself.
-    // A captured reply operation never falls through to this identity-scoped path.
-    const fallback = await gatewayWorkAdmission.run(async () => {
-      if (!isCompetingSessionWorkAdmissionActive(storePath, identities)) {
-        return { interrupted: false, settled: true };
-      }
-      return {
-        interrupted: true,
-        settled: await interruptSessionWorkAdmissions({
-          scope: storePath,
-          identities,
-          timeoutMs: REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
-        }),
-      };
-    });
-    interruptedActiveRun = fallback.interrupted;
-    interruptionSettled = fallback.settled;
-  }
-  if (!interruptionSettled) {
+  // Cancellation is outside this request's owner boundary and may throw. Until
+  // dispatch takes custody, every such failure must release both admitted owners.
+  const cleanupPreDispatchAdmission = () => {
     activeRunAbort.cleanup({ force: true });
     gatewayWorkAdmission.release();
+  };
+  let interruptedActiveRun = false;
+  let interruptionSettled = true;
+  try {
+    if (runInterruptTarget) {
+      interruptedActiveRun = true;
+      interruptionSettled = (
+        await interruptReplyRunTarget(runInterruptTarget, REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS)
+      ).settled;
+    } else if (p.queueMode === "interrupt") {
+      const identities = [sessionKey, backingSessionId, admittedSessionId];
+      // The fallback runs inside the new admission so the lifecycle owner excludes itself.
+      // A captured reply operation never falls through to this identity-scoped path.
+      const fallback = await gatewayWorkAdmission.run(async () => {
+        if (!isCompetingSessionWorkAdmissionActive(storePath, identities)) {
+          return { interrupted: false, settled: true };
+        }
+        return {
+          interrupted: true,
+          settled: await interruptSessionWorkAdmissions({
+            scope: storePath,
+            identities,
+            timeoutMs: REPLY_RUN_IDLE_SETTLE_TIMEOUT_MS,
+          }),
+        };
+      });
+      interruptedActiveRun = fallback.interrupted;
+      interruptionSettled = fallback.settled;
+    }
+  } catch (error) {
+    cleanupPreDispatchAdmission();
+    throw error;
+  }
+  if (!interruptionSettled) {
+    cleanupPreDispatchAdmission();
     respond(
       false,
       undefined,
@@ -462,14 +472,12 @@ export async function admitChatSend(params: {
     try {
       proceed = await gatewayWorkAdmission.run(params.onAdmissionOwned);
     } catch (error) {
-      activeRunAbort.cleanup({ force: true });
-      gatewayWorkAdmission.release();
+      cleanupPreDispatchAdmission();
       releaseGatewayRootContinuation();
       throw error;
     }
     if (!proceed) {
-      activeRunAbort.cleanup({ force: true });
-      gatewayWorkAdmission.release();
+      cleanupPreDispatchAdmission();
       releaseGatewayRootContinuation();
       return { ok: false as const };
     }

--- a/src/gateway/server-methods/chat-send-admission.ts
+++ b/src/gateway/server-methods/chat-send-admission.ts
@@ -411,15 +411,16 @@ export async function admitChatSend(params: {
     });
     return { ok: false as const };
   }
-  // Cancellation is outside this request's owner boundary and may throw. Until
-  // dispatch takes custody, every such failure must release both admitted owners.
+  let releaseGatewayRootContinuation = () => {};
+  // Until dispatch takes custody, interruption and callback failures own the same three resources.
   const cleanupPreDispatchAdmission = () => {
     activeRunAbort.cleanup({ force: true });
     gatewayWorkAdmission.release();
+    releaseGatewayRootContinuation();
   };
   let interruptedActiveRun = false;
-  let interruptionSettled = true;
   try {
+    let interruptionSettled = true;
     if (runInterruptTarget) {
       interruptedActiveRun = true;
       interruptionSettled = (
@@ -445,42 +446,28 @@ export async function admitChatSend(params: {
       interruptedActiveRun = fallback.interrupted;
       interruptionSettled = fallback.settled;
     }
+    if (!interruptionSettled) {
+      cleanupPreDispatchAdmission();
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.UNAVAILABLE,
+          "Previous run is still shutting down. Please try again in a moment.",
+          { retryable: true, retryAfterMs: 250 },
+        ),
+      );
+      return { ok: false as const };
+    }
+    // Reserve while the request root is live: detached dispatch retains it until terminal persistence.
+    releaseGatewayRootContinuation = retainGatewayRootWorkAdmissionContinuation() ?? (() => {});
+    if (params.onAdmissionOwned && !(await gatewayWorkAdmission.run(params.onAdmissionOwned))) {
+      cleanupPreDispatchAdmission();
+      return { ok: false as const };
+    }
   } catch (error) {
     cleanupPreDispatchAdmission();
     throw error;
-  }
-  if (!interruptionSettled) {
-    cleanupPreDispatchAdmission();
-    respond(
-      false,
-      undefined,
-      errorShape(
-        ErrorCodes.UNAVAILABLE,
-        "Previous run is still shutting down. Please try again in a moment.",
-        { retryable: true, retryAfterMs: 250 },
-      ),
-    );
-    return { ok: false as const };
-  }
-  // Reserved here, while the request's root is provably live, rather than after the ACK: the
-  // detached dispatch must keep that root until terminal persistence settles or restart drain
-  // completes early and loses the session's terminal state. Callers outside a Gateway request
-  // envelope (internal chat entries) hold no root, so there is nothing to extend for them.
-  const releaseGatewayRootContinuation = retainGatewayRootWorkAdmissionContinuation() ?? (() => {});
-  if (params.onAdmissionOwned) {
-    let proceed: boolean;
-    try {
-      proceed = await gatewayWorkAdmission.run(params.onAdmissionOwned);
-    } catch (error) {
-      cleanupPreDispatchAdmission();
-      releaseGatewayRootContinuation();
-      throw error;
-    }
-    if (!proceed) {
-      cleanupPreDispatchAdmission();
-      releaseGatewayRootContinuation();
-      return { ok: false as const };
-    }
   }
 
   const acquiredGatewayWorkAdmission = gatewayWorkAdmission;

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -483,6 +483,46 @@ describe("gateway server chat", () => {
       });
       expect(res.ok).toBe(false);
       await waitForFast(() => expect(getActiveSessionWorkAdmissionCount()).toBe(0));
+      await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+
+      const reset = await rpcReq(ws, "sessions.reset", { key: "main", reason: "new" });
+      expect(reset.ok).toBe(true);
+    });
+  });
+
+  test("chat.send interrupt releases its admission when session interruption throws", async () => {
+    await withMainSessionStore(async () => {
+      const storePath = testState.sessionStorePath;
+      if (!storePath) {
+        throw new Error("session store path was not initialized");
+      }
+      const activeAdmission = await beginSessionWorkAdmission({
+        scope: storePath,
+        identities: ["agent:main:main", "sess-main"],
+        assertAllowed: () => {},
+        onInterrupt: () => {
+          activeAdmission.release();
+          throw new Error("session interruption failed");
+        },
+      });
+
+      try {
+        const res = await rpcReq(ws, "chat.send", {
+          sessionKey: "main",
+          message: "replace non-reply session work",
+          queueMode: "interrupt",
+          idempotencyKey: "idem-chat-interrupt-non-reply-throw",
+        });
+
+        expect(res.ok).toBe(false);
+        await waitForFast(() => expect(getActiveSessionWorkAdmissionCount()).toBe(0));
+        await waitForFast(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+
+        const reset = await rpcReq(ws, "sessions.reset", { key: "main", reason: "new" });
+        expect(reset.ok).toBe(true);
+      } finally {
+        activeAdmission.release();
+      }
     });
   });
 

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { replyRunRegistry } from "../auto-reply/reply/reply-run-registry.js";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
 import { replaceTranscriptEvents } from "../config/sessions/session-accessor.sqlite-transcript-write.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
@@ -22,7 +23,10 @@ import {
   resetGatewayWorkAdmission,
   tryBeginGatewaySuspendAdmission,
 } from "../process/gateway-work-admission.js";
-import { beginSessionWorkAdmission } from "../sessions/session-lifecycle-admission.js";
+import {
+  beginSessionWorkAdmission,
+  getActiveSessionWorkAdmissionCount,
+} from "../sessions/session-lifecycle-admission.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -438,6 +442,47 @@ describe("gateway server chat", () => {
         interruptedActiveRun: true,
       });
       await waitForAgentRunDrained("idem-chat-interrupt-active");
+    });
+  });
+
+  test("chat.send interrupt releases its admission when backend cancellation throws", async () => {
+    await withMainSessionStore(async () => {
+      const activeRunStarted = createDeferred();
+      mockGetReplyFromConfigOnce(async (_ctx, opts) => {
+        activeRunStarted.resolve(undefined);
+        if (!opts?.abortSignal?.aborted) {
+          await new Promise<void>((resolve) => {
+            opts?.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+          });
+        }
+        return undefined;
+      });
+      const active = await rpcReq(ws, "chat.send", {
+        sessionKey: "main",
+        message: "captured active turn",
+        idempotencyKey: "idem-chat-interrupt-throw-old",
+      });
+      expect(active.ok).toBe(true);
+      await activeRunStarted.promise;
+
+      const operation = replyRunRegistry.get("agent:main:main");
+      expect(operation).toBeDefined();
+      operation?.attachBackend({
+        kind: "embedded",
+        cancel: () => {
+          throw new Error("cancel failed");
+        },
+        isStreaming: () => true,
+      });
+
+      const res = await rpcReq(ws, "chat.send", {
+        sessionKey: "main",
+        message: "replace the captured turn",
+        queueMode: "interrupt",
+        idempotencyKey: "idem-chat-interrupt-throw-new",
+      });
+      expect(res.ok).toBe(false);
+      await waitForFast(() => expect(getActiveSessionWorkAdmissionCount()).toBe(0));
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

An interrupting `chat.send` could leave a hidden session-work admission and abort registration behind when either an existing reply backend or another active session admission threw during cancellation. Subsequent session reset, archive, and deletion could hang behind that leaked ownership, and Gateway shutdown could remain blocked until its drain timeout.

## Why This Change Was Made

`admitChatSend` acquires its new session admission and abort registration before invoking either direct reply cancellation or identity-scoped session-work interruption. Both interruption contracts may throw, but the previous owner did not clean up those resources on either exception path.

The admission owner now has one canonical pre-dispatch cleanup path for its abort registration, session admission, and optional Gateway-root continuation. Direct interruption, fallback interruption, an unsettled predecessor, and rejected or throwing admission-owner callbacks all release the same resources before returning or propagating their original error. This replaces duplicated cleanup branches and removes five production lines overall.

## User Impact

Cancellation failures still surface to the operator, but normal session lifecycle actions and Gateway drain recover immediately. Successful sends, ordinary interruptions, and retained post-admission request ownership keep their existing behavior.

## Evidence

- Exact reviewed head: `e234b446817dca6b8686cc718bcb493d960811a4`.
- Both new owner-boundary regressions were first run against the unchanged current-main implementation and failed: direct reply cancellation left one active session admission, and identity-scoped fallback interruption left a second leaked admission.
- Both then passed through the real in-process Gateway and authenticated WebSocket `chat.send` flow. Each independently verifies the session-admission and Gateway-root counts return to zero, then successfully performs a real `sessions.reset` RPC.
- Full focused owner and sibling verification:

  ```bash
  node scripts/run-vitest.mjs \
    src/gateway/server.chat.gateway-server-chat.test.ts \
    src/gateway/server.sessions.worker-placement-lifecycle.test.ts \
    src/sessions/session-lifecycle-admission.test.ts \
    src/auto-reply/reply/reply-run-registry.test.ts \
    --reporter=dot
  ```

  Result: **206 tests passed** across Gateway chat, cloud-worker session lifecycle, session admission, and reply-run cancellation.
- Targeted formatting, core lint, and `git diff --check` passed.
- Fresh independent structured review completed with no actionable findings.
- Production LOC: `+52/-57` (**net -5**); tests: `+86/-1`.
- No external provider or cloud lease is required for this Gateway-owned failure; the live product proof is the actual Gateway/WebSocket/session lifecycle with a deliberately failing cancellation backend.

Original fix and regression by @NianJiuZst; contributor authorship and co-author credit are preserved.

AI-assisted: yes
