### PR TITLE
fix(sessions): return JSON errors for invalid filters

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -20,6 +20,7 @@ import {
 } from "../agents/model-selection.js";
 import { resolveRuntimePolicySessionKey } from "../auto-reply/reply/runtime-policy-session-key.js";
 import { normalizeChatType } from "../channels/chat-type.js";
+import { formatCliJsonFailure } from "../cli/failure-output.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveFreshSessionTotalTokens, resolveSessionTotalTokens } from "../config/sessions.js";
 import { resolveProjectedSessionContextTokens } from "../config/sessions/context-token-provenance.js";
@@ -337,20 +338,18 @@ export async function sessionsCommand(
     return;
   }
 
-  let activeMinutes: number | undefined;
-  if (opts.active !== undefined) {
-    const parsed = parseStrictPositiveInteger(opts.active);
-    if (parsed === undefined) {
-      runtime.error("--active must be a positive number of minutes, for example --active 30.");
-      runtime.exit(1);
-      return;
-    }
-    activeMinutes = parsed;
-  }
-
+  const activeMinutes =
+    opts.active === undefined ? undefined : parseStrictPositiveInteger(opts.active);
   const limit = parseSessionsLimit(opts.limit);
-  if (limit === null) {
-    runtime.error('--limit must be a positive integer or "all", for example --limit 25.');
+  const invalidActive = opts.active !== undefined && activeMinutes === undefined;
+  if (invalidActive || limit === null) {
+    const message = invalidActive
+      ? "--active must be a positive number of minutes, for example --active 30."
+      : '--limit must be a positive integer or "all", for example --limit 25.';
+    if (opts.json) {
+      writeRuntimeJson(runtime, formatCliJsonFailure(message));
+    }
+    runtime.error(message);
     runtime.exit(1);
     return;
   }

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -276,6 +276,54 @@ describe("cli json stdout contract", () => {
     );
   });
 
+  it.each([
+    {
+      name: "route-first --active",
+      args: ["sessions", "--json", "--active", "0"],
+      commander: false,
+      message: "--active must be a positive number of minutes, for example --active 30.",
+    },
+    {
+      name: "Commander --active",
+      args: ["sessions", "--json", "--active", "0"],
+      commander: true,
+      message: "--active must be a positive number of minutes, for example --active 30.",
+    },
+    {
+      name: "route-first --limit",
+      args: ["sessions", "--json", "--limit", "0"],
+      commander: false,
+      message: '--limit must be a positive integer or "all", for example --limit 25.',
+    },
+    {
+      name: "Commander --limit",
+      args: ["sessions", "--json", "--limit", "0"],
+      commander: true,
+      message: '--limit must be a positive integer or "all", for example --limit 25.',
+    },
+  ])("keeps $name validation failures machine-readable", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        const result = runBuiltCli(
+          tempHome,
+          testCase.args,
+          testCase.commander ? { OPENCLAW_DISABLE_ROUTE_FIRST: "1" } : {},
+        );
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message: testCase.message,
+          },
+        });
+        expect(result.stderr).toBe(`${testCase.message}\n`);
+      },
+      { prefix: "openclaw-sessions-json-validation-e2e-" },
+    );
+  });
+
   it("returns one canonical document for a command that previously failed on stderr only", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw sessions --json` produced empty stdout for invalid `--active` or `--limit` values. Automation received exit code 1 and human-readable stderr but could not parse the promised JSON failure envelope.

## Why This Change Was Made

Both route-first and Commander paths end in `sessionsCommand`. Its legacy validation called `runtime.exit(1)` directly, which is `process.exit`, before the CLI entry layer could apply the canonical JSON error formatter.

This change consolidates the two validation exits and emits `formatCliJsonFailure` through the existing runtime JSON writer when `--json` is selected. Stderr text and exit status remain unchanged.

## User Impact

Scripts can reliably parse invalid sessions-filter failures from both route-first and Commander/list invocation shapes. Non-JSON output and valid session listing behavior are unchanged.

## Evidence

- Final base: `4b55192f818c0bfd00cd2bb2d9447fd38dca7e39`; commit: `1474b1dfddd7268035c3420af324d6ee10926ca0`.
- Red real-CLI matrix: route-first/Commander x `--active 0`/`--limit 0` all exited 1 with expected stderr but empty stdout; each JSON parse failed with `Unexpected end of JSON input`.
- Green real-CLI matrix on the repaired branch before the final no-conflict upstream refresh: 4/4 passed. Independent process probes returned exit 1, unchanged stderr, and `{ ok: false, error: { type: "cli_error", message } }` on stdout for all four cases.
- Green on the final head: `src/commands/sessions.test.ts` -> 22/22 passed.
- Re-running the real-CLI matrix on the final head did not reach assertions: the repository's stale-dist bootstrap twice hit its 900-second no-output build timeout. This is reported as an infrastructure limitation, not a passing result; Draft CI should rerun the committed E2E.
- Production LOC: `+12/-13` (net `-1`); tests: `+48`.
- `git diff --check` passed. No Testbox or AWS Crabbox was used.

AI-assisted: yes
