### PR TITLE
fix(sessions): scope legacy-main owner notice to real legacy rows

### DIFF
--- a/src/agents/agent-create.test.ts
+++ b/src/agents/agent-create.test.ts
@@ -256,6 +256,27 @@ describe("createAgent", () => {
     });
   });
 
+  it("creates main when an unarmed scan proves every legacy store clean", async () => {
+    mocks.config = { agents: { entries: { robby: { id: "robby" } } } };
+    mocks.migrateLegacyMainSessionKeys.mockResolvedValueOnce({
+      armed: false,
+      changes: [],
+      complete: true,
+      ledgerComplete: false,
+      legacyAgentId: "main",
+      mainKey: "main",
+      outcomes: [{ kind: "no-legacy-rows", detail: "no configured owner" }],
+      warnings: [],
+    });
+
+    await expect(createAgent({ name: "main" })).resolves.toMatchObject({
+      status: "created",
+      agentId: "main",
+    });
+    expect(mocks.resolveSharedAuthStoreOwnership).toHaveBeenCalledOnce();
+    expect(mocks.transformConfigFileWithRetry).toHaveBeenCalledOnce();
+  });
+
   it("defaults the workspace through the agent-scoped resolver", async () => {
     const result = await createAgent({ name: "Researcher" });
 

--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -176,7 +176,10 @@ async function evaluateMainCreationGate(
     legacyAgentId: BOOTSTRAP_AGENT_ID,
     mode: "detect",
   });
-  if (!migration.armed || !migration.ledgerComplete) {
+  // An unarmed scan can proceed only when every candidate store proved collision-free.
+  const provenClean = migration.outcomes.every((outcome) => outcome.kind === "no-legacy-rows");
+  const blocked = migration.armed ? !migration.ledgerComplete : !provenClean;
+  if (blocked) {
     const details = migration.outcomes.map(describeLegacySessionOutcome).join("; ");
     return createError(
       "legacy-session-migration-required",

--- a/src/config/sessions/legacy-main-session-key-scan.ts
+++ b/src/config/sessions/legacy-main-session-key-scan.ts
@@ -1,0 +1,77 @@
+import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
+import { readClaim } from "./legacy-main-session-migration-operations.js";
+import type { PhysicalStore, SessionClaim } from "./legacy-main-session-migration.contract.js";
+import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
+
+/** Returns the stored `agent:<id>:` prefix when the key is owned by the legacy agent. */
+function legacyAgentKeyPrefix(key: string, legacyAgentId: string): string | null {
+  const parsed = parseAgentSessionKey(key);
+  if (!parsed || normalizeAgentId(parsed.agentId) !== legacyAgentId) {
+    return null;
+  }
+  const prefix = `agent:${parsed.agentId}:`;
+  return key.startsWith(prefix) ? prefix : null;
+}
+
+function canonicalKeyFor(key: string, legacyAgentId: string, ownerAgentId: string): string | null {
+  const prefix = legacyAgentKeyPrefix(key, legacyAgentId);
+  return prefix ? `agent:${ownerAgentId}:${key.slice(prefix.length)}` : null;
+}
+
+export function storeHasLegacyAgentSessionKey(params: {
+  legacyAgentId: string;
+  store: PhysicalStore;
+  env: NodeJS.ProcessEnv;
+}): boolean {
+  const result = withOpenClawAgentDatabaseReadOnly(
+    (database) =>
+      executeSqliteQuerySync(
+        database.db,
+        getSessionKysely(database.db).selectFrom("session_nodes").select("session_key"),
+      ).rows.some((row) => legacyAgentKeyPrefix(row.session_key, params.legacyAgentId) !== null),
+    { agentId: params.store.databaseAgentId, env: params.env, path: params.store.path },
+  );
+  // A missing database, schema, or table proves absence exactly as the armed claim
+  // reader does below; only genuine read failures throw and let the caller fail open.
+  return result.found ? result.value : false;
+}
+
+export function readClaimsFromStore(params: {
+  legacyAgentId: string;
+  ownerAgentId: string;
+  store: PhysicalStore;
+  env: NodeJS.ProcessEnv;
+}): { canonical: SessionClaim[]; legacy: SessionClaim[] } {
+  const result = withOpenClawAgentDatabaseReadOnly(
+    (database) => {
+      const keys = executeSqliteQuerySync(
+        database.db,
+        getSessionKysely(database.db).selectFrom("session_nodes").select("session_key"),
+      ).rows.map((row) => row.session_key);
+      const legacy: SessionClaim[] = [];
+      const canonical: SessionClaim[] = [];
+      for (const key of keys) {
+        const canonicalKey = canonicalKeyFor(key, params.legacyAgentId, params.ownerAgentId);
+        if (canonicalKey) {
+          const claim = readClaim(database, params.store, key, canonicalKey);
+          if (claim) {
+            legacy.push(claim);
+          }
+          continue;
+        }
+        const parsed = parseAgentSessionKey(key);
+        if (parsed && normalizeAgentId(parsed.agentId) === params.ownerAgentId) {
+          const claim = readClaim(database, params.store, key, key);
+          if (claim) {
+            canonical.push(claim);
+          }
+        }
+      }
+      return { canonical, legacy };
+    },
+    { agentId: params.store.databaseAgentId, env: params.env, path: params.store.path },
+  );
+  return result.found ? result.value : { canonical: [], legacy: [] };
+}

--- a/src/config/sessions/legacy-main-session-migration.test.ts
+++ b/src/config/sessions/legacy-main-session-migration.test.ts
@@ -559,6 +559,11 @@ describe("legacy main session migration", () => {
     const unresolved = createFixture({
       agents: { ownership: "explicit", entries: { ops: {}, research: {} } },
     });
+    seedClaim({
+      databaseAgentId: "main",
+      databasePath: databasePath(unresolved.stateDir, "main"),
+      key: "agent:main:chat",
+    });
     const perAgentPinned = createFixture({
       agents: {
         ownership: "explicit",
@@ -590,6 +595,49 @@ describe("legacy main session migration", () => {
     });
     expect(perAgentArmed).toMatchObject({ armed: true, ownerAgentId: "ops" });
     expect(notArmed.warnings[0]).toContain("agents.defaults.sessionStore.agentId");
+  });
+
+  it("proves an unresolved-owner store clean when it has no legacy rows", async () => {
+    const fixture = createFixture({
+      agents: { ownership: "explicit", entries: { ops: {}, research: {} } },
+    });
+
+    const result = await migrateLegacyMainSessionKeys({
+      cfg: fixture.cfg,
+      env: fixture.env,
+      mode: "detect",
+    });
+
+    expect(result).toMatchObject({
+      armed: false,
+      complete: true,
+      ledgerComplete: false,
+      outcomes: [{ kind: "no-legacy-rows", detail: "no configured owner" }],
+      warnings: [],
+    });
+  });
+
+  it("keeps unresolved ownership advisory when a candidate store is unreadable", async () => {
+    const unreadablePath = path.join(tempDirs.make("unresolved-unreadable-"), "sessions.sqlite");
+    fs.symlinkSync(`${unreadablePath}.missing`, unreadablePath);
+    const fixture = createFixture({
+      agents: { ownership: "explicit", entries: { ops: {}, research: {} } },
+      session: { store: unreadablePath },
+    });
+
+    const result = await migrateLegacyMainSessionKeys({
+      cfg: fixture.cfg,
+      env: fixture.env,
+      mode: "automatic",
+    });
+
+    expect(result).toMatchObject({
+      armed: false,
+      complete: false,
+      ledgerComplete: false,
+      outcomes: [{ kind: "not-armed", detail: "owner-unresolved" }],
+    });
+    expect(result.warnings[0]).toContain("agents.defaults.sessionStore.agentId");
   });
 
   it("uses an explicit migration owner for retired main rows in per-agent stores", async () => {

--- a/src/config/sessions/legacy-main-session-migration.ts
+++ b/src/config/sessions/legacy-main-session-migration.ts
@@ -8,12 +8,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
-import {
-  normalizeAgentId,
-  normalizeMainKey,
-  parseAgentSessionKey,
-} from "../../routing/session-key.js";
-import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
+import { normalizeAgentId, normalizeMainKey } from "../../routing/session-key.js";
 import { isSameOpenClawAgentDatabasePath } from "../../state/openclaw-agent-db-registry.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../../state/openclaw-state-db-readonly.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
@@ -21,9 +16,12 @@ import { runOpenClawStateWriteTransaction } from "../../state/openclaw-state-db.
 import { resolveStateDir } from "../paths.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import {
+  readClaimsFromStore,
+  storeHasLegacyAgentSessionKey,
+} from "./legacy-main-session-key-scan.js";
+import {
   claimsMatch,
   processIdenticalClaims,
-  readClaim,
   repairDivergentClaims,
   samePhysicalStore,
   warningForDivergence,
@@ -36,11 +34,11 @@ import type {
   SessionClaim,
 } from "./legacy-main-session-migration.contract.js";
 import { resolveSessionStorePathCore } from "./paths.js";
-import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import {
   resolveAllAgentSessionStoreCandidateTargetsSync,
   resolveAgentSessionStoreTargetsSync,
+  resolveSessionStoreCompatibilityAgentId,
 } from "./targets.js";
 
 const SOURCE_KEY = "legacy-main-session-keys";
@@ -80,15 +78,6 @@ function resolveArmingDecision(cfg: OpenClawConfig, legacyAgentId: string): Armi
     }
   }
   return { armed: false, reason: "owner-unresolved" };
-}
-
-function canonicalKeyFor(key: string, legacyAgentId: string, ownerAgentId: string): string | null {
-  const parsed = parseAgentSessionKey(key);
-  if (!parsed || normalizeAgentId(parsed.agentId) !== legacyAgentId) {
-    return null;
-  }
-  const prefix = `agent:${parsed.agentId}:`;
-  return key.startsWith(prefix) ? `agent:${ownerAgentId}:${key.slice(prefix.length)}` : null;
 }
 
 function addPhysicalStore(stores: PhysicalStore[], candidate: PhysicalStore): void {
@@ -160,7 +149,7 @@ function resolvePhysicalStores(params: {
   env: NodeJS.ProcessEnv;
   legacyAgentId: string;
   mode: LegacyMainSessionMigrationMode;
-  ownerAgentId: string;
+  ownerAgentId?: string;
 }): ResolvedPhysicalStores {
   const logicalTargets = [
     ...resolveAllAgentSessionStoreCandidateTargetsSync(params.cfg, { env: params.env }),
@@ -172,14 +161,17 @@ function resolvePhysicalStores(params: {
         env: params.env,
       }),
     },
-    {
+  ];
+  if (params.ownerAgentId) {
+    logicalTargets.push({
       agentId: params.ownerAgentId,
       storePath: resolveSessionStorePathCore(params.cfg.session?.store, {
         agentId: params.ownerAgentId,
         env: params.env,
       }),
-    },
-  ];
+    });
+  }
+  const defaultAgentId = params.ownerAgentId ?? resolveSessionStoreCompatibilityAgentId(params.cfg);
   const stores: PhysicalStore[] = [];
   const jsonPaths = new Set<string>();
   const unreadable: LegacyMainSessionMigrationOutcome[] = [];
@@ -190,7 +182,7 @@ function resolvePhysicalStores(params: {
       }
       const resolved = resolveSqliteTargetFromSessionStorePath(target.storePath, {
         agentId: target.agentId,
-        defaultAgentId: params.ownerAgentId,
+        defaultAgentId,
         env: params.env,
       });
       const physical: PhysicalStore = {
@@ -227,47 +219,6 @@ function resolveSourceLayout(resolved: ResolvedPhysicalStores): string[] {
       ...resolved.jsonPaths.map((pathname) => `json:${resolvePhysicalPathIdentity(pathname)}`),
     ]),
   ].toSorted();
-}
-
-function readClaimsFromStore(params: {
-  legacyAgentId: string;
-  ownerAgentId: string;
-  store: PhysicalStore;
-  env: NodeJS.ProcessEnv;
-}): { canonical: SessionClaim[]; legacy: SessionClaim[] } {
-  if (inspectPath(params.store.path) === "missing") {
-    return { canonical: [], legacy: [] };
-  }
-  const result = withOpenClawAgentDatabaseReadOnly(
-    (database) => {
-      const keys = executeSqliteQuerySync(
-        database.db,
-        getSessionKysely(database.db).selectFrom("session_nodes").select("session_key"),
-      ).rows.map((row) => row.session_key);
-      const legacy: SessionClaim[] = [];
-      const canonical: SessionClaim[] = [];
-      for (const key of keys) {
-        const canonicalKey = canonicalKeyFor(key, params.legacyAgentId, params.ownerAgentId);
-        if (canonicalKey) {
-          const claim = readClaim(database, params.store, key, canonicalKey);
-          if (claim) {
-            legacy.push(claim);
-          }
-          continue;
-        }
-        const parsed = parseAgentSessionKey(key);
-        if (parsed && normalizeAgentId(parsed.agentId) === params.ownerAgentId) {
-          const claim = readClaim(database, params.store, key, key);
-          if (claim) {
-            canonical.push(claim);
-          }
-        }
-      }
-      return { canonical, legacy };
-    },
-    { agentId: params.store.databaseAgentId, env: params.env, path: params.store.path },
-  );
-  return result.found ? result.value : { canonical: [], legacy: [] };
 }
 
 function readLedger(env: NodeJS.ProcessEnv): { report: LedgerReport; status: string } | undefined {
@@ -420,6 +371,38 @@ async function migrateLegacyMainSessionKeysInternal(params: {
     warnings: [] as string[],
   };
   if (!arming.armed) {
+    if (arming.reason === "owner-unresolved") {
+      // Owner guidance is useful only when legacy rows may exist; unreadable or JSON
+      // candidates fail open because they cannot prove the fleet is clean.
+      let rowsMayExist: boolean;
+      try {
+        const resolved = resolvePhysicalStores({
+          cfg: params.cfg,
+          env,
+          legacyAgentId,
+          mode: params.mode,
+        });
+        rowsMayExist =
+          resolved.unreadable.length > 0 ||
+          resolved.jsonPaths.length > 0 ||
+          resolved.stores.some(
+            (store) =>
+              inspectPath(store.path) === "present" &&
+              storeHasLegacyAgentSessionKey({ env, legacyAgentId, store }),
+          );
+      } catch {
+        rowsMayExist = true;
+      }
+      if (!rowsMayExist) {
+        return {
+          ...base,
+          armed: false,
+          complete: true,
+          ledgerComplete: false,
+          outcomes: [{ kind: "no-legacy-rows", detail: "no configured owner" }],
+        };
+      }
+    }
     const unresolved = arming.reason === "owner-unresolved";
     return {
       ...base,
@@ -497,6 +480,9 @@ async function migrateLegacyMainSessionKeysInternal(params: {
   const allCanonical: SessionClaim[] = [];
   for (const store of resolved.stores) {
     try {
+      if (inspectPath(store.path) === "missing") {
+        continue;
+      }
       const claims = readClaimsFromStore({ env, legacyAgentId, ownerAgentId, store });
       allLegacy.push(...claims.legacy);
       allCanonical.push(...claims.canonical);

--- a/src/gateway/server.sessions.compaction-read-errors.test.ts
+++ b/src/gateway/server.sessions.compaction-read-errors.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, expect, test, vi } from "vitest";
+import { beforeAll, beforeEach, expect, test, vi } from "vitest";
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
@@ -13,31 +13,31 @@ import {
 type LoadTranscriptEvents =
   (typeof import("../config/sessions/session-accessor.sqlite-read.js"))["loadTranscriptEvents"];
 
-const transcriptReads = vi.hoisted(() => ({
-  actual: undefined as LoadTranscriptEvents | undefined,
-  load: vi.fn<LoadTranscriptEvents>(),
-}));
+const transcriptReads = vi.hoisted(() => ({ load: vi.fn<LoadTranscriptEvents>() }));
 
 vi.mock("../config/sessions/session-accessor.sqlite-read.js", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../config/sessions/session-accessor.sqlite-read.js")>();
-  transcriptReads.actual = actual.loadTranscriptEvents;
-  transcriptReads.load.mockImplementation(actual.loadTranscriptEvents);
   return { ...actual, loadTranscriptEvents: transcriptReads.load };
 });
 
 const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
 
-function requireTranscriptReader(): LoadTranscriptEvents {
-  if (!transcriptReads.actual) {
-    throw new Error("transcript reader mock was not initialized");
-  }
-  return transcriptReads.actual;
-}
+// Resolve the real reader explicitly: deriving it from the vi.mock factory made the
+// default implementation depend on whether that factory had run for this file yet,
+// which is not guaranteed once a shard shares a worker (--isolate=false).
+let loadTranscriptEventsActual: LoadTranscriptEvents;
+
+beforeAll(async () => {
+  const actual = await vi.importActual<
+    typeof import("../config/sessions/session-accessor.sqlite-read.js")
+  >("../config/sessions/session-accessor.sqlite-read.js");
+  loadTranscriptEventsActual = actual.loadTranscriptEvents;
+});
 
 beforeEach(() => {
   transcriptReads.load.mockReset();
-  transcriptReads.load.mockImplementation(requireTranscriptReader());
+  transcriptReads.load.mockImplementation(loadTranscriptEventsActual);
 });
 
 async function seedCompactionSession(params: {
@@ -112,7 +112,7 @@ test("sessions.compact reports model compaction transcript re-read failures as u
     storePath,
     nativeHarness: true,
   });
-  const events = await requireTranscriptReader()(scope);
+  const events = await loadTranscriptEventsActual(scope);
   transcriptReads.load.mockResolvedValueOnce(events).mockRejectedValueOnce(transcriptReadError());
 
   const { ws } = await openClient();

--- a/src/gateway/server.sessions.compaction-read-errors.test.ts
+++ b/src/gateway/server.sessions.compaction-read-errors.test.ts
@@ -1,9 +1,14 @@
-import { beforeAll, beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
+// Force the mocked module to load here: the factory below captures the real reader as a
+// side effect, and beforeEach needs that capture. Without this import the factory only ran
+// if some other module in the graph pulled it in first, which is not guaranteed once a
+// shard shares a worker (--isolate=false).
+import "../config/sessions/session-accessor.sqlite-read.js";
 import { rpcReq } from "./test-helpers.js";
 import {
   sessionStoreEntry,
@@ -13,31 +18,31 @@ import {
 type LoadTranscriptEvents =
   (typeof import("../config/sessions/session-accessor.sqlite-read.js"))["loadTranscriptEvents"];
 
-const transcriptReads = vi.hoisted(() => ({ load: vi.fn<LoadTranscriptEvents>() }));
+const transcriptReads = vi.hoisted(() => ({
+  actual: undefined as LoadTranscriptEvents | undefined,
+  load: vi.fn<LoadTranscriptEvents>(),
+}));
 
 vi.mock("../config/sessions/session-accessor.sqlite-read.js", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("../config/sessions/session-accessor.sqlite-read.js")>();
+  transcriptReads.actual = actual.loadTranscriptEvents;
+  transcriptReads.load.mockImplementation(actual.loadTranscriptEvents);
   return { ...actual, loadTranscriptEvents: transcriptReads.load };
 });
 
 const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
 
-// Resolve the real reader explicitly: deriving it from the vi.mock factory made the
-// default implementation depend on whether that factory had run for this file yet,
-// which is not guaranteed once a shard shares a worker (--isolate=false).
-let loadTranscriptEventsActual: LoadTranscriptEvents;
-
-beforeAll(async () => {
-  const actual = await vi.importActual<
-    typeof import("../config/sessions/session-accessor.sqlite-read.js")
-  >("../config/sessions/session-accessor.sqlite-read.js");
-  loadTranscriptEventsActual = actual.loadTranscriptEvents;
-});
+function requireTranscriptReader(): LoadTranscriptEvents {
+  if (!transcriptReads.actual) {
+    throw new Error("transcript reader mock was not initialized");
+  }
+  return transcriptReads.actual;
+}
 
 beforeEach(() => {
   transcriptReads.load.mockReset();
-  transcriptReads.load.mockImplementation(loadTranscriptEventsActual);
+  transcriptReads.load.mockImplementation(requireTranscriptReader());
 });
 
 async function seedCompactionSession(params: {
@@ -112,7 +117,7 @@ test("sessions.compact reports model compaction transcript re-read failures as u
     storePath,
     nativeHarness: true,
   });
-  const events = await loadTranscriptEventsActual(scope);
+  const events = await requireTranscriptReader()(scope);
   transcriptReads.load.mockResolvedValueOnce(events).mockRejectedValueOnce(transcriptReadError());
 
   const { ws } = await openClient();

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -976,6 +976,16 @@ describe("state migrations", () => {
     const cfg: OpenClawConfig = {
       agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
     };
+    runOpenClawAgentWriteTransaction(
+      (database) =>
+        writeSessionEntry(
+          database,
+          "agent:main:chat",
+          { sessionId: "legacy-main-session", updatedAt: 100 },
+          { allowStoredAliases: true, previousEntry: null },
+        ),
+      { agentId: "main", env },
+    );
 
     const result = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
 
@@ -983,6 +993,22 @@ describe("state migrations", () => {
     expect(result.notices).toEqual([
       expect.stringContaining("legacy main rows have no unambiguous configured owner"),
     ]);
+  });
+
+  it("starts a new explicit-ownership fleet without a legacy-main owner notice", async () => {
+    const root = await createTempDir();
+    const stateDir = path.join(root, ".openclaw");
+    const env = createEnv(stateDir);
+    const cfg: OpenClawConfig = {
+      agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
+    };
+
+    const result = await autoMigrateLegacyState({ cfg, env, homedir: () => root });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.notices ?? []).not.toContainEqual(
+      expect.stringContaining("legacy main rows have no unambiguous configured owner"),
+    );
   });
 
   it("ignores a schema-only legacy agent database without selecting an owner", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators starting a correctly configured multi-agent fleet would see a Doctor notice claiming legacy `main` session rows needed an owner, on a brand-new install with zero session data.

Every gateway startup printed:

```
[gateway] session: retired main-agent session migration warnings:
- session: legacy main rows have no unambiguous configured owner; preserve them and run openclaw doctor after assigning agents.defaults.sessionStore.agentId
```

The wording implies data exists and asks the operator to assign ownership for nothing. Running `openclaw doctor` cannot clear it, because there is nothing to migrate.

The same unresolved-owner result also dead-ended agent creation. `openclaw agents create main` failed with `legacy main sessions have no unambiguous configured owner ... Run openclaw doctor --fix, then retry`, on a fleet with no legacy rows. `doctor --fix` could never resolve it, so the only escape was configuring `agents.defaults.sessionStore.agentId` to satisfy a check about data that did not exist.

## Why This Change Was Made

`resolveArmingDecision` decides ownership purely from config and returns before any session store is read, so the notice and the creation gate had never been conditional on data. Neither surface had ever checked whether a legacy row exists.

The unresolved-owner branch now probes the candidate stores and reports `no-legacy-rows` when every store proves clean. Absence must be proven: unreadable stores, legacy JSON stores, and genuine read failures still fail open and keep the notice, so the precaution survives exactly where the fleet cannot be shown clean.

Store scanning moved into `legacy-main-session-key-scan.ts` so the probe and the armed claim reader share one normalization-aware key predicate. This matters for correctness: `normalizeAgentId` falls back to `main` for unrepresentable ids, so keys such as `agent:---:chat` are genuine legacy rows. A raw `LIKE 'agent:main:%'` probe would have missed them and silenced a real pending migration. The extraction also keeps `legacy-main-session-migration.ts` under the max-lines limit (703 -> 689) without adding a suppression.

The creation gate now blocks an unarmed run only when the scan did not prove the fleet clean. Armed runs still require a completed ledger, so every previously blocked outcome still blocks.

## User Impact

A correctly configured new fleet starts clean, and `agents create main` is no longer blocked by a migration that has nothing to migrate. Operators with real legacy `main` rows see exactly the same notice and the same gate as before.

## Evidence

Live gateway startup, isolated `OPENCLAW_STATE_DIR`, non-default port, identical config both runs:

Before (pre-fix build):

```
2026-08-19T22:26:08.377 [gateway] session: retired main-agent session migration warnings:
- session: legacy main rows have no unambiguous configured owner; preserve them and run openclaw doctor after assigning agents.defaults.sessionStore.agentId
```

After (rebuilt from the fixed sources, same command and config):

```
2026-08-19T22:30:27.868 [gateway] starting HTTP server...
2026-08-19T22:30:29.563 [gateway] http server listening (16 plugins ...)
```

No migration warning block. The gateway reaches listening normally.

Config used for both runs:

```json
{ "gateway": { "mode": "local", "port": 19199 },
  "agents": { "ownership": "explicit",
    "defaults": { "systemAgent": { "agentId": "ops" } },
    "entries": { "ops": {}, "research": {}, "support": {} } } }
```

Regression coverage. The new `state-migrations` case fails on pre-fix code for the right reason:

```
FAIL src/infra/state-migrations.test.ts > starts a new explicit-ownership fleet without a legacy-main owner notice
AssertionError: expected [ Array(1) ] to not deep equally contain StringContaining{...}
+ Received: [ "session: legacy main rows have no unambiguous configured owner; ..." ]
```

The pre-existing unresolved-owner tests were changed to seed a real `agent:main:chat` row before asserting the notice, since they previously asserted it on an empty store. New cases cover the proven-clean store, the unreadable-store fail-open, and unarmed-but-clean agent creation.

Test and check runs:

```
node scripts/run-vitest.mjs src/config/sessions/legacy-main-session-migration   27 passed
node scripts/run-vitest.mjs src/infra/state-migrations                          521 passed | 2 skipped
node scripts/run-vitest.mjs src/agents/agent-create                             50 passed
node scripts/run-vitest.mjs src/commands/doctor-session-transcripts             14 passed
node scripts/check-changed.mjs                                                  exit 0
```

Codex autoreview on the full diff: clean, no accepted or actionable findings.

Production LOC delta is +66 (tests +95). This is a bug fix, so the growth is called out deliberately rather than left for review to find. Proving absence is a capability that did not exist anywhere in this module: the arming decision is config-only by design, and it must stay that way because the exported error path calls it from a `catch` where store I/O would be wrong. The absorbing refactor was attempted and taken as far as it goes: the probe reuses `resolvePhysicalStores` for discovery instead of adding a second path, the armed reader and the probe now share one key predicate instead of two copies, and a double parse of every session key was removed along the way. What remains is the probe itself, the owner-optional plumbing, and the import header of the extracted module.

## Unrelated CI heal included

`main` was already red when this branch was cut. Base commit `0a8226c3` fails `checks-node-compact-small-4` with the same five tests and the same error as this PR's first run:

```
FAIL src/gateway/server.sessions.compaction-read-errors.test.ts (5 tests)
Error: transcript reader mock was not initialized
```

That file captures the real `loadTranscriptEvents` as a side effect of its `vi.mock` factory and requires it in `beforeEach`. The factory only runs when the mocked module is first imported, and nothing in the file imported it directly, so once a shard shares a worker (`--isolate=false`) the capture could still be unset. Flaky by construction, not by timing.

Fixed here rather than waited out, per the repo rule that red `main` gets fixed in the landing PR: the file now imports the mocked module for its side effect, so the factory always runs.

The first attempt in this branch resolved the reader with `vi.importActual` instead, and CI caught that it was wrong. `importActual` returns a separately instantiated, unmocked copy that does not share the module-level SQLite state the harness sets up, so it read no events, compaction no-opped successfully, and the three rejection tests failed on `response.ok` while the two empty-transcript tests passed. Capturing through `importOriginal` keeps the harness's own module instance; only the import was missing.

Honest limitation: this does not reproduce locally, including with the exact 25-file shard composition taken from the failing CI log (25 files, 300 tests, green before and after). CI on the Linux runners is the verification for this part.
