### PR TITLE
fix(qa): prevent character eval model artifact collisions

### DIFF
--- a/extensions/qa-lab/src/character-eval.test.ts
+++ b/extensions/qa-lab/src/character-eval.test.ts
@@ -258,6 +258,66 @@ describe("runQaCharacterEval", () => {
     expect(report).not.toContain("Judge Raw Reply");
   });
 
+  it("isolates artifacts for model refs with colliding readable slugs", async () => {
+    const firstModel = "ollama/qwen3.5:9b";
+    const secondModel = "ollama/qwen3.5/9b";
+    const models = [firstModel, secondModel];
+    let releaseSecondRun: () => void = () => {};
+    let releaseFirstRun: () => void = () => {};
+    const firstRunWritten = new Promise<void>((resolve) => {
+      releaseSecondRun = resolve;
+    });
+    const secondRunWritten = new Promise<void>((resolve) => {
+      releaseFirstRun = resolve;
+    });
+    const runSuite = vi.fn(async (params: CharacterRunSuiteParams) => {
+      const markerPath = path.join(params.outputDir, "model-marker.txt");
+      await fs.mkdir(params.outputDir, { recursive: true });
+      if (params.primaryModel === secondModel) {
+        await firstRunWritten;
+      }
+      await fs.writeFile(markerPath, `${params.primaryModel}\n`, "utf8");
+      const result = await makeReplySuiteResult(params);
+      if (params.primaryModel === firstModel) {
+        releaseSecondRun();
+        await secondRunWritten;
+      } else {
+        releaseFirstRun();
+      }
+      return result;
+    });
+
+    const result = await runQaCharacterEval({
+      repoRoot: tempRoot,
+      outputDir: path.join(tempRoot, "character"),
+      models,
+      candidateConcurrency: 2,
+      judgeModels: ["openai/gpt-5.6-luna"],
+      runSuite,
+      runJudge: makeRunJudge([
+        { model: firstModel, rank: 1, score: 8, summary: "first" },
+        { model: secondModel, rank: 2, score: 7, summary: "second" },
+      ]),
+    });
+
+    expect(runSuite).toHaveBeenCalledTimes(2);
+    expect.soft(new Set(result.runs.map((run) => run.outputDir)).size).toBe(models.length);
+    expect
+      .soft(
+        new Set(result.runs.flatMap((run) => ("summaryPath" in run ? [run.summaryPath] : []))).size,
+      )
+      .toBe(models.length);
+    await expect
+      .soft(
+        Promise.all(
+          result.runs.map((run) =>
+            fs.readFile(path.join(run.outputDir, "model-marker.txt"), "utf8"),
+          ),
+        ),
+      )
+      .resolves.toEqual(models.map((model) => `${model}\n`));
+  });
+
   it("creates a unique default output directory under repo artifacts", async () => {
     const runSuite = vi.fn(async (params: CharacterRunSuiteParams) =>
       makeSuiteResult({

--- a/extensions/qa-lab/src/character-eval.ts
+++ b/extensions/qa-lab/src/character-eval.ts
@@ -529,7 +529,7 @@ export async function runQaCharacterEval(params: QaCharacterEvalParams) {
         candidateFastMode: params.candidateFastMode,
         candidateModelOptions: params.candidateModelOptions,
       });
-      const modelOutputDir = path.join(runsDir, sanitizePathPart(model));
+      const modelOutputDir = path.join(runsDir, `${index + 1}-${sanitizePathPart(model)}`);
       const runStartedAt = Date.now();
       logCharacterEvalProgress(
         params.progress,


### PR DESCRIPTION
Closes #126557

<details>
<summary>Additional instructions</summary>

This same-repository branch remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where QA Lab operators comparing distinct model references would silently lose or misattribute candidate reports, summaries, evidence, and other artifacts when those references sanitize to the same readable directory name. Concurrent evaluations could also race while deleting and republishing the shared files even when both candidate records reported success.

## Why This Change Was Made

The character-evaluation artifact owner used only a lossy sanitized model slug for its per-candidate directory. Prefix the already-authoritative candidate index to the existing readable slug, producing one deterministic, unique directory per accepted candidate without adding hashes, helpers, compatibility paths, configuration, or public-contract changes.

## User Impact

Each accepted character-evaluation model keeps its own report, summary, evidence, and other artifacts, including when valid references such as `ollama/qwen3.5:9b` and `ollama/qwen3.5/9b` share a sanitized slug. Top-level report names, CLI options, model selection, and evaluation ordering remain unchanged.

## Evidence

- Pre-fix deterministic concurrent regression failed for all three expected reasons: one output directory instead of two, one summary path instead of two, and both real filesystem markers containing the second model.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/character-eval.test.ts extensions/qa-lab/src/cli.runtime.test.ts`: **172 tests passed** across the artifact owner and CLI caller.
- `node scripts/check-changed.mjs -- extensions/qa-lab/src/character-eval.ts extensions/qa-lab/src/character-eval.test.ts`: **passed**, including format, both extension TypeScript graphs, focused lint, embedded plugin guard tests, package/boundary/dead-code/storage guards, and zero runtime import cycles.
- Fresh Codex-backed P1 autoreview: **clean**. Separate independent adversarial review verified artifact consumers, current main, concurrency ownership, path compatibility, and the regression's real marker writes: **approved with no remaining findings**.
- Production LOC: **+1/-1 (net zero)**. Regression tests: **+60/-0**.
- Risk: low; this changes only a private per-candidate artifact subdirectory inside the private QA Lab plugin. No public configuration, protocol, Plugin SDK, persistence, security, package, deployment, version, or changelog surface changes.
- Live provider execution was not run because this deterministic artifact-owner defect is proven with real concurrent filesystem writes through the existing suite boundary, and live provider credentials are outside the authorized repair scope.

AI-assisted: yes
