### PR TITLE
fix(apple): gate gateway RPC polling on the hello method catalog

### DIFF
--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -551,11 +551,9 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         try await self.requestHistory(sessionKey: sessionKey, agentID: nil, ifCurrentRoute: nil)
     }
 
-    func gatewayAdvertisesProgressCardStore() async -> Bool? {
+    func gatewayAdvertisesMethod(_ method: String) async -> Bool? {
         guard let route = await self.currentSessionMutationRoute() else { return nil }
-        return await self.gateway.supportsServerMethod(
-            "progressCard.get",
-            ifCurrentRoute: route)
+        return await self.gateway.supportsServerMethod(method, ifCurrentRoute: route)
     }
 
     func fetchProgressCard(sessionKey: String) async throws -> ProgressCard? {

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -771,8 +771,7 @@ extension GatewayConnection {
               self.serverLeaseMatchesCurrentState(lease),
               let snapshot = lastSnapshot
         else { return nil }
-        let methods = snapshot.features["methods"]?.value as? [AnyCodable] ?? []
-        return methods.contains { ($0.value as? String) == method }
+        return snapshot.advertisedServerMethods()?.contains(method)
     }
 
     func isCurrentServerLease(_ lease: ServerLease) async -> Bool {

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -144,11 +144,9 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
             agentID: target.agentID)
     }
 
-    func gatewayAdvertisesProgressCardStore() async -> Bool? {
+    func gatewayAdvertisesMethod(_ method: String) async -> Bool? {
         guard let lease = await self.connection.captureServerLease() else { return nil }
-        return await self.connection.supportsServerMethod(
-            "progressCard.get",
-            ifCurrentServerLease: lease)
+        return await self.connection.supportsServerMethod(method, ifCurrentServerLease: lease)
     }
 
     func fetchProgressCard(sessionKey: String) async throws -> ProgressCard? {

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatQuestionCard.swift
@@ -553,6 +553,17 @@ extension OpenClawChatViewModel {
     private func refreshQuestions(generation refreshGeneration: UInt64, retryIndex: Int) async {
         guard refreshGeneration == self.questionRefreshGeneration else { return }
         let stateRevision = self.questionStateRevision
+        // Released 2026.7.x gateways predate question.list and reject it with
+        // "missing scope: operator.admin" (authorization runs before dispatch),
+        // so an unadvertised method must resolve as unavailable without a call.
+        if await self.transport.gatewayAdvertisesMethod("question.list") == false {
+            guard self.questionRefreshSnapshotIsCurrent(
+                generation: refreshGeneration,
+                stateRevision: stateRevision)
+            else { return }
+            self.clearPendingQuestionsForUnavailableList()
+            return
+        }
         do {
             let records = try await self.transport.listQuestions()
             guard self.questionRefreshSnapshotIsCurrent(

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -706,7 +706,10 @@ public protocol OpenClawChatTransport: Sendable {
         worktreeBaseRef: String?) async throws -> OpenClawChatCreateSessionResponse
 
     func requestHistory(sessionKey: String) async throws -> OpenClawChatHistoryPayload
-    func gatewayAdvertisesProgressCardStore() async -> Bool?
+    /// Tri-state hello-catalog negotiation: true/false when the connected
+    /// gateway's advertised method set answers, nil when no catalog is known
+    /// (disconnected, pre-catalog gateway, or non-gateway transport).
+    func gatewayAdvertisesMethod(_ method: String) async -> Bool?
     func fetchProgressCard(sessionKey: String) async throws -> ProgressCard?
     func requestFullMessage(sessionKey: String, messageID: String) async throws -> OpenClawChatMessage?
     func listModels(agentID: String?) async throws -> [OpenClawChatModelChoice]
@@ -805,7 +808,7 @@ public protocol OpenClawChatTransport: Sendable {
 }
 
 extension OpenClawChatTransport {
-    public func gatewayAdvertisesProgressCardStore() async -> Bool? {
+    public func gatewayAdvertisesMethod(_: String) async -> Bool? {
         nil
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -64,14 +64,10 @@ extension OpenClawChatViewModel {
 
     static func branchListingIsUnsupported(_ error: Error) -> Bool {
         if error is BranchListingUnadvertisedError { return true }
-        if let gatewayError = error as? GatewayResponseError {
-            // Only the modern unknown-method rejection counts; a genuine scope
-            // denial ("missing scope: ...") must keep queued work parked.
-            return gatewayError.message.lowercased()
-                .contains("unknown method: sessions.branches.list")
-        }
-        let error = error as NSError
-        let message = error.localizedDescription.lowercased()
+        // GatewayResponseError bridges through errorDescription, which always
+        // prefixes the method name; the qualifier words decide. A genuine scope
+        // denial ("missing scope: ...") matches none, keeping queued work parked.
+        let message = (error as NSError).localizedDescription.lowercased()
         return message.contains("sessions.branches.list") &&
             (message.contains("not supported") || message.contains("unsupported") ||
                 message.contains("unimplemented") || message.contains("unknown method"))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -55,19 +55,39 @@ extension OpenClawChatViewModel {
         return leaf.isEmpty ? nil : leaf
     }
 
+    /// Marks a sessions.branches.list rejection decided from the hello method
+    /// catalog, without a network call. Released 2026.7.x gateways authorize
+    /// before dispatch and reject unknown methods with "missing scope:
+    /// operator.admin" — an error that never names the method, so text
+    /// matching alone can never detect them.
+    struct BranchListingUnadvertisedError: Error {}
+
     static func branchListingIsUnsupported(_ error: Error) -> Bool {
+        if error is BranchListingUnadvertisedError { return true }
         if let gatewayError = error as? GatewayResponseError {
-            let message = gatewayError.message.lowercased()
-            return message.contains("sessions.branches.list") &&
-                (gatewayError.code == "INVALID_REQUEST" ||
-                    message.contains("unsupported") ||
-                    message.contains("unimplemented"))
+            // Only the modern unknown-method rejection counts; a genuine scope
+            // denial ("missing scope: ...") must keep queued work parked.
+            return gatewayError.message.lowercased()
+                .contains("unknown method: sessions.branches.list")
         }
         let error = error as NSError
         let message = error.localizedDescription.lowercased()
         return message.contains("sessions.branches.list") &&
             (message.contains("not supported") || message.contains("unsupported") ||
                 message.contains("unimplemented") || message.contains("unknown method"))
+    }
+
+    /// Single dispatch point for sessions.branches.list: the hello catalog is
+    /// consulted first so paired clients never poll gateways that predate the
+    /// method (see BranchListingUnadvertisedError); nil catalog still calls.
+    func requestSessionBranchListing(
+        sessionKey: String,
+        agentID: String?) async throws -> OpenClawChatSessionBranchesResponse
+    {
+        if await self.transport.gatewayAdvertisesMethod("sessions.branches.list") == false {
+            throw Self.BranchListingUnadvertisedError()
+        }
+        return try await self.transport.listSessionBranches(sessionKey: sessionKey, agentID: agentID)
     }
 
     func outboxBranchScope(for session: SessionSnapshot) -> OpenClawChatOutboxScope? {
@@ -209,7 +229,7 @@ extension OpenClawChatViewModel {
                       let state = await outbox.branchState(for: scope)
                 else { continue }
                 do {
-                    let response = try await self.transport.listSessionBranches(
+                    let response = try await self.requestSessionBranchListing(
                         sessionKey: command.deliverySessionKey,
                         agentID: command.agentID)
                     let activeLeaf: String? = response.branches.isEmpty ? nil : Self

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+ProgressCard.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+ProgressCard.swift
@@ -21,15 +21,18 @@ extension OpenClawChatViewModel {
     func scheduleProgressCardFetch(for session: SessionSnapshot? = nil) {
         let session = session ?? self.currentSessionSnapshot()
         guard self.isCurrentSession(session) else { return }
-        Task { [weak self] in
-            guard let self else { return }
-            self.progressCardStoreAvailable = await self.transport.gatewayAdvertisesProgressCardStore()
-        }
         self.lastIssuedProgressCardRequestID &+= 1
         let requestID = self.lastIssuedProgressCardRequestID
         let generation = self.progressCardGeneration
         Task { [weak self] in
-            await self?.fetchProgressCard(
+            guard let self else { return }
+            let storeAvailable = await self.transport.gatewayAdvertisesMethod("progressCard.get")
+            self.progressCardStoreAvailable = storeAvailable
+            // Gateways without the durable store reject the fetch outright
+            // (2026.7.x: "missing scope: operator.admin"); the legacy
+            // stream:"plan" fallback owns the card there.
+            guard storeAvailable != false else { return }
+            await self.fetchProgressCard(
                 for: session,
                 generation: generation,
                 requestID: requestID)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+SessionActions.swift
@@ -484,7 +484,7 @@ extension OpenClawChatViewModel {
             }
         }
         do {
-            let response = try await self.transport.listSessionBranches(
+            let response = try await self.requestSessionBranchListing(
                 sessionKey: session.key,
                 agentID: self.outboxAgentID(for: session))
             guard self.isCurrentSession(session),

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayPush.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayPush.swift
@@ -6,8 +6,10 @@ public enum GatewayServerCapability: String, CaseIterable, Sendable {
 }
 
 extension HelloOk {
-    func advertisedServerMethods() -> Set<String> {
-        let values = features["methods"]?.value as? [AnyCodable] ?? []
+    /// nil when the hello carries no method catalog: gates must treat that as
+    /// unknown, not "advertises nothing", so pre-catalog gateways keep working.
+    public func advertisedServerMethods() -> Set<String>? {
+        guard let values = features["methods"]?.value as? [AnyCodable] else { return nil }
         return Set(values.compactMap { $0.value as? String })
     }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
@@ -62,6 +62,7 @@ private actor OutboxTransportState {
         case unsupportedTransport
         case legacyAdminScopeRejection
         case unknownMethodRejection
+        case unsupportedTextRejection
     }
 
     var sessionRoutingContract = "per-sender|main|main"
@@ -222,6 +223,12 @@ private final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransp
                 method: "sessions.branches.list",
                 code: "INVALID_REQUEST",
                 message: "unknown method: sessions.branches.list",
+                details: nil)
+        case .unsupportedTextRejection:
+            throw GatewayResponseError(
+                method: "sessions.branches.list",
+                code: "UNSUPPORTED",
+                message: "sessions.branches.list is unsupported on this gateway",
                 details: nil)
         }
     }
@@ -841,8 +848,34 @@ struct ChatViewModelOutboxTests {
             code: "INVALID_REQUEST",
             message: "unknown method: sessions.branches.list",
             details: nil)))
+        #expect(OpenClawChatViewModel.branchListingIsUnsupported(GatewayResponseError(
+            method: "sessions.branches.list",
+            code: "UNSUPPORTED",
+            message: "sessions.branches.list is unsupported on this gateway",
+            details: nil)))
         #expect(OpenClawChatViewModel.branchListingIsUnsupported(
             OpenClawChatViewModel.BranchListingUnadvertisedError()))
+    }
+
+    @Test func `explicit unsupported reply on a pre-catalog gateway still releases queued send`() async throws {
+        let (store, _, databaseDirectory) = try makeOutboxStore()
+        defer { try? FileManager.default.removeItem(at: databaseDirectory) }
+        let transport = OutboxTestTransport(healthy: false)
+        await transport.state.update {
+            $0.advertisedMethods = nil
+            $0.branchListingBehavior = .unsupportedTextRejection
+        }
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+        let text = "explicit unsupported still flushes"
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: text)
+        await transport.goOnline()
+
+        try await waitUntil("pre-catalog gateway dispatches queued send") {
+            await transport.state.sentMessages == [text]
+        }
+        #expect(await transport.state.branchListCalls >= 1)
     }
 
     @Test func `offline queue persists the effective thinking level`() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
@@ -58,8 +58,17 @@ private struct OutboxSendError: Error, LocalizedError {
 }
 
 private actor OutboxTransportState {
+    enum BranchListingBehavior: Sendable {
+        case unsupportedTransport
+        case legacyAdminScopeRejection
+        case unknownMethodRejection
+    }
+
     var sessionRoutingContract = "per-sender|main|main"
     var healthy: Bool
+    var advertisedMethods: Set<String>?
+    var branchListingBehavior: BranchListingBehavior = .unsupportedTransport
+    var branchListCalls = 0
     var routeGeneration = 0
     var sendFails: Bool
     var sendFailsAfterRecording = false
@@ -109,6 +118,11 @@ private actor OutboxTransportState {
     func recordHistoryRequest(agentID: String?) {
         self.historyRequestCount += 1
         self.historyRequestAgentIDs.append(agentID)
+    }
+
+    func recordBranchListing() -> BranchListingBehavior {
+        self.branchListCalls += 1
+        return self.branchListingBehavior
     }
 
     func recordSend(
@@ -169,6 +183,11 @@ private final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransp
         try await self.requestHistory(sessionKey: sessionKey, agentID: nil, expectedRoute: nil)
     }
 
+    func gatewayAdvertisesMethod(_ method: String) async -> Bool? {
+        let advertisedMethods = await self.state.advertisedMethods
+        return advertisedMethods.map { $0.contains(method) }
+    }
+
     var supportsSlashCommandCatalog: Bool {
         self.supportsSlashCommands
     }
@@ -180,6 +199,31 @@ private final class OutboxTestTransport: @unchecked Sendable, OpenClawChatTransp
     func listCommands(sessionKey _: String) async throws -> [OpenClawChatCommandChoice] {
         await self.state.awaitCommandListGate()
         return []
+    }
+
+    func listSessionBranches(
+        sessionKey _: String,
+        agentID _: String?) async throws -> OpenClawChatSessionBranchesResponse
+    {
+        switch await self.state.recordBranchListing() {
+        case .unsupportedTransport:
+            throw NSError(
+                domain: "OpenClawChatTransport",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "sessions.branches.list not supported by this transport"])
+        case .legacyAdminScopeRejection:
+            throw GatewayResponseError(
+                method: "sessions.branches.list",
+                code: "INVALID_REQUEST",
+                message: "missing scope: operator.admin",
+                details: nil)
+        case .unknownMethodRejection:
+            throw GatewayResponseError(
+                method: "sessions.branches.list",
+                code: "INVALID_REQUEST",
+                message: "unknown method: sessions.branches.list",
+                details: nil)
+        }
     }
 
     private func requestHistory(
@@ -740,6 +784,65 @@ struct ChatViewModelOutboxTests {
         }
         #expect(await store.loadCommands().map(\.status) == [.queued])
         #expect(await transport.state.sentMessages.isEmpty)
+    }
+
+    @Test func `released 2026.7.x gateway without branch listing dispatches queued send without polling branches`()
+        async throws
+    {
+        let (store, _, databaseDirectory) = try makeOutboxStore()
+        defer { try? FileManager.default.removeItem(at: databaseDirectory) }
+        let transport = OutboxTestTransport(healthy: false)
+        await transport.state.update {
+            $0.advertisedMethods = ["chat.send", "chat.history", "sessions.list"]
+            $0.branchListingBehavior = .legacyAdminScopeRejection
+        }
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+        let text = "legacy gateway must flush"
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: text)
+        await transport.goOnline()
+
+        try await waitUntil("legacy gateway dispatches queued send") {
+            await transport.state.sentMessages == [text]
+        }
+        #expect(await transport.state.branchListCalls == 0)
+    }
+
+    @Test func `modern gateway unknown-method rejection still releases queued send`() async throws {
+        let (store, _, databaseDirectory) = try makeOutboxStore()
+        defer { try? FileManager.default.removeItem(at: databaseDirectory) }
+        let transport = OutboxTestTransport(healthy: false)
+        await transport.state.update {
+            $0.advertisedMethods = nil
+            $0.branchListingBehavior = .unknownMethodRejection
+        }
+        let vm = await makeOutboxViewModel(transport: transport, outbox: store)
+        let text = "unknown method still flushes"
+
+        await MainActor.run { vm.load() }
+        try await sendWhileOffline(vm, text: text)
+        await transport.goOnline()
+
+        try await waitUntil("modern gateway dispatches queued send") {
+            await transport.state.sentMessages == [text]
+        }
+        #expect(await transport.state.branchListCalls >= 1)
+    }
+
+    @Test @MainActor func `branch listing unsupported matcher rejects scope denials and accepts definitive absence`() {
+        #expect(!OpenClawChatViewModel.branchListingIsUnsupported(GatewayResponseError(
+            method: "sessions.branches.list",
+            code: "INVALID_REQUEST",
+            message: "missing scope: operator.admin",
+            details: nil)))
+        #expect(OpenClawChatViewModel.branchListingIsUnsupported(GatewayResponseError(
+            method: "sessions.branches.list",
+            code: "INVALID_REQUEST",
+            message: "unknown method: sessions.branches.list",
+            details: nil)))
+        #expect(OpenClawChatViewModel.branchListingIsUnsupported(
+            OpenClawChatViewModel.BranchListingUnadvertisedError()))
     }
 
     @Test func `offline queue persists the effective thinking level`() async throws {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelTests.swift
@@ -352,6 +352,7 @@ private func makeViewModel(
     requestHistoryHook: (@Sendable (String) async throws -> Void)? = nil,
     fetchProgressCardHook: (@Sendable (String) async throws -> ProgressCard?)? = nil,
     progressCardStoreAvailable: Bool? = nil,
+    advertisedMethodHook: (@Sendable (String) -> Bool?)? = nil,
     historyResponseHook: (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)? = nil,
     setActiveSessionHook: (@Sendable (String) async throws -> Void)? = nil,
     createSessionHook: (@Sendable (String, String?) async throws -> Void)? = nil,
@@ -372,6 +373,7 @@ private func makeViewModel(
     acquireSessionSettingsRouteLeaseHook: (@Sendable () async -> Void)? = nil,
     swarmEnabledHook: (@Sendable (String) async throws -> Bool)? = nil,
     listChildSessionsHook: (@Sendable (String) async throws -> [OpenClawChatSessionEntry])? = nil,
+    listQuestionsHook: (@Sendable () async throws -> [QuestionRecord])? = nil,
     healthResponses: [Bool] = [true],
     initialThinkingLevel: String? = nil,
     initialVerboseLevel: String? = nil,
@@ -403,7 +405,8 @@ private func makeViewModel(
         commandResponses: commandResponses,
         requestHistoryHook: requestHistoryHook,
         fetchProgressCardHook: fetchProgressCardHook,
-        progressCardStoreAvailable: progressCardStoreAvailable,
+        advertisedMethodHook: advertisedMethodHook ?? progressCardStoreAvailable
+            .map { available in { @Sendable method in method == "progressCard.get" ? available : nil } },
         historyResponseHook: historyResponseHook,
         setActiveSessionHook: setActiveSessionHook,
         createSessionHook: createSessionHook,
@@ -422,6 +425,7 @@ private func makeViewModel(
         acquireSessionSettingsRouteLeaseHook: acquireSessionSettingsRouteLeaseHook,
         swarmEnabledHook: swarmEnabledHook,
         listChildSessionsHook: listChildSessionsHook,
+        listQuestionsHook: listQuestionsHook,
         healthResponses: healthResponses)
     let vm = OpenClawChatViewModel(
         sessionKey: sessionKey,
@@ -737,7 +741,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
     private let commandResponses: [[OpenClawChatCommandChoice]]
     private let requestHistoryHook: (@Sendable (String) async throws -> Void)?
     private let fetchProgressCardHook: (@Sendable (String) async throws -> ProgressCard?)?
-    private let progressCardStoreAvailable: Bool?
+    private let advertisedMethodHook: (@Sendable (String) -> Bool?)?
     private let historyResponseHook:
         (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)?
     private let setActiveSessionHook: (@Sendable (String) async throws -> Void)?
@@ -778,7 +782,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         commandResponses: [[OpenClawChatCommandChoice]] = [],
         requestHistoryHook: (@Sendable (String) async throws -> Void)? = nil,
         fetchProgressCardHook: (@Sendable (String) async throws -> ProgressCard?)? = nil,
-        progressCardStoreAvailable: Bool? = nil,
+        advertisedMethodHook: (@Sendable (String) -> Bool?)? = nil,
         historyResponseHook: (@Sendable (String, Int, [String]) async throws -> OpenClawChatHistoryPayload?)? = nil,
         setActiveSessionHook: (@Sendable (String) async throws -> Void)? = nil,
         createSessionHook: (@Sendable (String, String?) async throws -> Void)? = nil,
@@ -813,7 +817,7 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         self.commandResponses = commandResponses
         self.requestHistoryHook = requestHistoryHook
         self.fetchProgressCardHook = fetchProgressCardHook
-        self.progressCardStoreAvailable = progressCardStoreAvailable
+        self.advertisedMethodHook = advertisedMethodHook
         self.historyResponseHook = historyResponseHook
         self.setActiveSessionHook = setActiveSessionHook
         self.createSessionHook = createSessionHook
@@ -894,8 +898,8 @@ private final class TestChatTransport: @unchecked Sendable, OpenClawChatTranspor
         try await self.fetchProgressCardHook?(sessionKey)
     }
 
-    func gatewayAdvertisesProgressCardStore() async -> Bool? {
-        self.progressCardStoreAvailable
+    func gatewayAdvertisesMethod(_ method: String) async -> Bool? {
+        self.advertisedMethodHook?(method)
     }
 
     func sendMessage(
@@ -1605,17 +1609,47 @@ struct ChatViewModelTests {
         #expect(await MainActor.run { vm.progressCardStoreAvailable == nil })
     }
 
+    @Test func `unadvertised progress card store skips durable fetch`() async throws {
+        let fetchCalls = AsyncCounter()
+        let (_, vm) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            fetchProgressCardHook: { _ in
+                _ = await fetchCalls.increment()
+                return progressCard(revision: 1)
+            },
+            progressCardStoreAvailable: false)
+        try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
+        try await waitUntil("progress card capability resolves unavailable") {
+            await MainActor.run { vm.progressCardStoreAvailable == false }
+        }
+
+        await MainActor.run {
+            vm.progressCardStoreAvailable = nil
+            vm.handleTransportEvent(.progressCardChanged(ProgressCardChangedEvent(
+                sessionkey: "main",
+                revision: AnyCodable(1))))
+        }
+        try await waitUntil("progress card change rechecks unavailable capability") {
+            await MainActor.run { vm.progressCardStoreAvailable == false }
+        }
+
+        #expect(await fetchCalls.current() == 0)
+        #expect(await MainActor.run { vm.progressCard == nil })
+    }
+
     @Test func `empty legacy plan clears progress card`() async throws {
         let (_, vm) = await makeViewModel(
             historyResponses: [historyPayload()],
-            fetchProgressCardHook: { _ in progressCard(revision: 9, markdown: "Existing") },
             progressCardStoreAvailable: false)
         try await loadAndWaitBootstrap(vm: vm, sessionId: "sess-main")
-        try await waitUntil("initial progress card and legacy capability apply") {
-            await MainActor.run {
-                vm.progressCard?.revision == 9 && vm.progressCardStoreAvailable == false
-            }
+        try await waitUntil("progress card capability resolves unavailable") {
+            await MainActor.run { vm.progressCardStoreAvailable == false }
         }
+        await MainActor.run {
+            vm.handleTransportEvent(legacyPlanEvent(
+                steps: [legacyPlanStep("Existing", status: "in_progress")]))
+        }
+        #expect(await MainActor.run { vm.progressCard != nil })
 
         await MainActor.run {
             vm.handleTransportEvent(legacyPlanEvent(steps: []))
@@ -2108,6 +2142,29 @@ struct ChatViewModelTests {
         await viewModel.refreshQuestions()
 
         #expect(viewModel.questionCards.isEmpty)
+    }
+
+    @Test @MainActor func `unadvertised question.list clears stale pending cards without requesting`() async throws {
+        let listCalls = AsyncCounter()
+        let (_, viewModel) = await makeViewModel(
+            historyResponses: [historyPayload()],
+            advertisedMethodHook: { $0 == "question.list" ? false : nil },
+            listQuestionsHook: {
+                _ = await listCalls.increment()
+                throw GatewayResponseError(
+                    method: "question.list",
+                    code: "INVALID_REQUEST",
+                    message: "missing scope: operator.admin",
+                    details: nil)
+            })
+        try await loadAndWaitBootstrap(vm: viewModel)
+        viewModel.upsertQuestion(chatQuestionRecord(id: "ask_stale"))
+
+        await viewModel.refreshQuestions()
+
+        #expect(viewModel.visibleQuestionCards.isEmpty)
+        #expect(viewModel.questionCards.isEmpty)
+        #expect(await listCalls.current() == 0)
     }
 
     @Test @MainActor func `structured missing question scope clears stale cards`() async {


### PR DESCRIPTION
## What Problem This Solves

The shared Swift kit (iOS/macOS chat) has the same released-gateway compatibility bug fixed on Android in #126540: against a released `openclaw@2026.7.1-2` gateway, a queued send can wedge forever while the connection is healthy. Released 2026.7.x gateways authorize **before** method dispatch, and unknown methods default to requiring `operator.admin` (`resolveRequiredOperatorScopeForMethod(method) ?? ADMIN_SCOPE` in v2026.7.1-2 `src/gateway/method-scopes.ts`), so a paired non-admin client calling `sessions.branches.list`, `question.list`, or `progressCard.get` gets `INVALID_REQUEST` / `missing scope: operator.admin` — never `unknown method: X`.

On the Swift side that error is undetectable by the existing text matcher: `ChatViewModel+Outbox.swift` `branchListingIsUnsupported` requires the raw `GatewayResponseError.message` to contain `sessions.branches.list`, but the 2026.7.x message never names the method. The failing path (source-traced, then reproduced by regression test): `performOutboxFlush` sees a queued command whose branch scope is unreconciled → `reconcilePendingOutboxBranchScopes` → `sessions.branches.list` rejected with the missing-scope shape → not recognized as unsupported → scope stays unreconciled → `flushOutboxIfNeeded()` → repeat. Unlike Android's ~800 ms retry loop, the Swift pair ping-pongs with **no delay** — a tight infinite RPC loop with the send parked, an action ending in a silent non-outcome. `question.list` additionally burns its retry budget on every health event without ever clearing stale question cards, and `progressCard.get` fires a rejected fetch per event.

## Why This Change Was Made

Method availability is negotiated in the hello handshake (`features.methods`, 218 methods on released 2026.7.1-2) and already parsed into `GatewayNodeSession.serverMethods`. This ports the Android fix pattern: generalize the existing progressCard-specific transport seam (`gatewayAdvertisesProgressCardStore`) into one tri-state `gatewayAdvertisesMethod(_ method:) async -> Bool?` (nil = catalog unknown), and gate the three calls on it:

- `requestSessionBranchListing` (new single dispatch point used by both branch-refresh call sites) throws a typed `BranchListingUnadvertisedError` without any network call when the catalog lacks `sessions.branches.list`; both existing unsupported-handling paths treat it like the modern rejection, so branch scopes reconcile immediately and queued sends flush.
- `refreshQuestions` treats a catalog without `question.list` as unavailable without issuing the request (stale pending cards clear, same as the modern rejection path).
- `scheduleProgressCardFetch` resolves availability first and skips `progressCard.get` when unadvertised; the legacy `stream:"plan"` fallback keeps its exact semantics (`progressCardStoreAvailable == false` gate unchanged).

Error-text matching collapses onto one bridged-`localizedDescription` matcher (`GatewayResponseError.errorDescription` always prefixes the method name): a reply counts as unsupported only when it names the method **and** carries an unsupported qualifier (`unknown method`, `not supported`, `unsupported`, `unimplemented`). That preserves the shipped acceptance of explicit unsupported/unimplemented replies on pre-catalog gateways (ClawSweeper P1, addressed in f8f25cfb05a with a releasing-send regression test) while dropping the old false-positive-prone bare `INVALID_REQUEST` arm; `missing scope` shapes are deliberately **not** treated as unsupported, so a genuine scope denial on a current gateway keeps queued work parked. Tri-state correctness is now honest end to end: `HelloOk.advertisedServerMethods()` returns nil when the hello carries no catalog (previously an absent catalog read as an empty set, i.e. "advertises nothing"), and macOS `GatewayConnection.supportsServerMethod` reuses that helper instead of re-parsing `features["methods"]`.

## User Impact

Sending messages from the iOS/macOS apps against released 2026.7.x gateways works instead of parking silently in the outbox behind an infinite `sessions.branches.list` loop. The rejected `question.list` and `progressCard.get` calls per health event are gone; on gateways without branch support the branch UI simply stays hidden. Behavior against current gateways is unchanged (protected by the unknown-method fallback test).

## Evidence

Wire-shape proof against a real installed `openclaw@2026.7.1-2` gateway (paired operator role, scopes `operator.read,operator.write`) is in #126540's PR body: `features.methods` count 218; `advertises sessions.branches.list/question.list/progressCard.get: false`; each call rejected `INVALID_REQUEST` / `missing scope: operator.admin`.

Regression tests encode exactly that wire shape and fail on pre-fix code for the intended reason (verified by A/B run with the gates neutered):

- `released 2026.7.x gateway without branch listing dispatches queued send without polling branches` — pre-fix: `Timeout waiting for: legacy gateway dispatches queued send` (send parked 15 s in the reconcile loop); post-fix: dispatches in ~0.06 s with **zero** `sessions.branches.list` calls.
- `modern gateway unknown-method rejection still releases queued send` — protects the error-text fallback (passes pre- and post-fix).
- `branch listing unsupported matcher rejects scope denials and accepts definitive absence` — missing-scope shape is a denial, not "unsupported".
- `unadvertised question.list clears stale pending cards without requesting` — pre-fix: cards kept + `question.list` called; post-fix: cleared, zero calls.
- `unadvertised progress card store skips durable fetch` — pre-fix: fetch fired; post-fix: zero fetches, legacy plan fallback still renders (`empty legacy plan clears progress card` reworked to seed via the legacy event instead of a store fetch that contradicts the known-absent store).

Validation: `swift test --package-path apps/shared/OpenClawKit --parallel` — 1386 tests / 104 suites green; `swift build --package-path apps/macos --product OpenClaw` green (covers `GatewayConnection`/`WebChatSwiftUI`); `./scripts/format-swift.sh` clean.

Live on-device proof against a released gateway was not re-captured: it needs a paired physical device against an installed 2026.7.x gateway; the boundary tests above encode the exact wire shape live-proven in #126540 on 2026-08-17, which is the same changed path.

Production LOC delta: +34 (−26/+60; ~+14 excluding doc comments) — the catalog-negotiation seam and gates carry the hello-negotiation contract, matching the Android change (+13).

CI note: `macos-swift` attempt 1 on head `f8f25cf` died with `swiftpm-testing-helper ... signal code 13` (SIGPIPE) at unrelated tests across in-job retries — a pre-existing pipe race in process-spawning `OpenClawIPCTests` (production guards these descriptors with `F_SETNOSIGPIPE`; the tests do not). Rerun of the same head is green; test-side hardening is spawned as a separate task.

Follow-up noted in #126540 as the sibling-surface item; this PR is that follow-up.
