### PR TITLE
perf(test): fake TUI auth child timers

### DIFF
--- a/src/tui/tui-auth-child.test.ts
+++ b/src/tui/tui-auth-child.test.ts
@@ -30,6 +30,7 @@ function emitExit(
 
 describe("TUI auth child owner", () => {
   afterEach(() => {
+    vi.useRealTimers();
     killTreeMocks.signalProcessTree.mockReset();
   });
 
@@ -60,6 +61,7 @@ describe("TUI auth child owner", () => {
   });
 
   it("cancels gracefully, then force-kills only the still-active child", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const owner = createTuiAuthChildOwner();
     const child = createChild(103);
     const result = owner.spawnAndWait(() => child);
@@ -71,10 +73,14 @@ describe("TUI auth child owner", () => {
     expect(killTreeMocks.signalProcessTree).toHaveBeenCalledWith(103, "SIGTERM", {
       detached: false,
     });
-    await new Promise((resolve) => {
-      setTimeout(resolve, 1_050);
+    vi.advanceTimersByTime(999);
+    expect(killTreeMocks.signalProcessTree).toHaveBeenCalledTimes(1);
+    expect(killTreeMocks.signalProcessTree).not.toHaveBeenCalledWith(103, "SIGKILL", {
+      detached: false,
     });
-    expect(killTreeMocks.signalProcessTree).toHaveBeenLastCalledWith(103, "SIGKILL", {
+    vi.advanceTimersByTime(1);
+    expect(killTreeMocks.signalProcessTree).toHaveBeenCalledTimes(2);
+    expect(killTreeMocks.signalProcessTree).toHaveBeenNthCalledWith(2, 103, "SIGKILL", {
       detached: false,
     });
 
@@ -83,6 +89,7 @@ describe("TUI auth child owner", () => {
   });
 
   it("clears force escalation when the owned child exits", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const owner = createTuiAuthChildOwner();
     const child = createChild(104);
     const result = owner.spawnAndWait(() => child);
@@ -90,9 +97,10 @@ describe("TUI auth child owner", () => {
     emitExit(child, null, "SIGTERM");
 
     await expect(result).resolves.toEqual({ exitCode: null, signal: "SIGTERM" });
-    await new Promise((resolve) => {
-      setTimeout(resolve, 1_050);
-    });
+    vi.advanceTimersByTime(1_001);
     expect(killTreeMocks.signalProcessTree).toHaveBeenCalledTimes(1);
+    expect(killTreeMocks.signalProcessTree).toHaveBeenCalledWith(104, "SIGTERM", {
+      detached: false,
+    });
   });
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The TUI auth-child unit suite spends more than two seconds waiting for real
one-second cancellation timers, slowing every selected maintainer and CI test
run without improving its process-lifecycle coverage.

## Why This Change Was Made

This maintainer-requested, AI-assisted test-performance change selectively fakes
only `setTimeout` and `clearTimeout` in the two timing-sensitive unit tests. It
preserves all four existing tests and strengthens the escalation boundary: no
`SIGKILL` at 999 ms, exactly one `SIGKILL` at 1,000 ms, and no escalation through
1,001 ms after the child exits. The separate real PTY sibling continues to cover
actual child-process behavior; production code and product behavior are unchanged.

## User Impact

There is no user-visible behavior change. Developers and CI get faster,
deterministic TUI auth-child unit tests while real-process integration coverage
remains independently intact.

## Evidence

- Controlled same-Testbox A/B: `tbx_01m0ewexxkdy1pnsbkj6tbw94v`, with one worker,
  distinct caches, import diagnostics, `/usr/bin/time -v`, one excluded warmup,
  and two retained runs per side:
  https://github.com/openclaw/openclaw/actions/runs/32338236379
  - Wall time: baseline 6.01 s and 6.15 s (mean 6.08 s); candidate 3.96 s and
    4.27 s (mean 4.115 s): **1.965 s faster, a 32.3% improvement**.
  - Every candidate sample is at least 1.74 s faster than every baseline sample.
  - Vitest mean: 2.90 s → 0.856 s; test-body mean: 2.13 s → 28 ms; RSS slightly lower.
- Independent proof Testbox: `tbx_01m0ex1ah2jsk3vz3bp93rhpb1`:
  https://github.com/openclaw/openclaw/actions/runs/32338929522
- Focused owner unit suite: 4/4 passing.
  `node scripts/run-vitest.mjs src/tui/tui-auth-child.test.ts`
- Real PTY sibling suite: 2/2 passing; it exercises the real TUI/child process,
  not a fake process lifecycle.
  `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-auth-child-pty.e2e.test.ts`
- Complete changed gate: green in 9m51s with zero lint warnings/errors.
  `node scripts/check-changed.mjs -- src/tui/tui-auth-child.test.ts`
- Fault injection: advancing only 999 ms fails exactly at the expected second
  `SIGKILL` call assertion; the approved patch was restored afterward.
- Fresh branch autoreview: no findings.
- `git diff --check`: clean.
- Production LOC: +0/−0. Test LOC: +14/−6. All four existing unit tests retained.
- Documentation, changelog, screenshots, and release notes: not applicable; this
  changes test execution only. No agent transcript is included.
