### PR TITLE
fix(ui): keep empty session groups compact

### DIFF
--- a/ui/src/components/app-sidebar-session-list-render.ts
+++ b/ui/src/components/app-sidebar-session-list-render.ts
@@ -205,11 +205,6 @@ function renderSessionSection(params: {
       ${collapsed
         ? nothing
         : html`
-            ${group && totalRowCount === 0
-              ? html`<span class="sidebar-session-empty-hint sidebar-session-empty-placeholder"
-                  >${t("chat.sidebar.noSessionsForAgent")}</span
-                >`
-              : nothing}
             ${section.rows.length > 0
               ? html`<div class="sidebar-recent-sessions__list" role="list" aria-label=${label}>
                   ${section.rows.map((session) => renderSessionTree({ host, session }))}

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -963,7 +963,7 @@ suite.define(() => {
     }
   });
 
-  it("explains empty gateway groups for the selected agent", async () => {
+  it("keeps empty gateway groups compact for the selected agent", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -1011,22 +1011,40 @@ suite.define(() => {
 
       const emptyGroups = page.locator('[data-session-section^="category:"]');
       await expect.poll(() => emptyGroups.count()).toBe(2);
-      await captureUiProof(page, "sidebar-empty-cross-agent-groups.png");
+
+      for (const name of ["Email intake", "Customer replies"]) {
+        const group = page.locator(`[data-session-section="category:${name}"]`);
+        await group.waitFor({ state: "visible" });
+        await expect
+          .poll(() => group.locator(":scope > .sidebar-recent-sessions__head").count())
+          .toBe(1);
+        const toggle = group.getByRole("button", { name, exact: true });
+        await toggle.waitFor({ state: "visible" });
+        await expect.poll(() => toggle.getAttribute("aria-expanded")).toBe("true");
+      }
+
+      await expect.poll(() => emptyGroups.locator(".sidebar-session-empty-hint").count()).toBe(0);
       await expect
-        .poll(() => emptyGroups.locator(".sidebar-session-empty-placeholder").allTextContents())
-        .toEqual(["No sessions found for this agent", "No sessions found for this agent"]);
+        .poll(() => emptyGroups.locator(".sidebar-recent-sessions__list").count())
+        .toBe(0);
+
       const firstEmptyGroup = emptyGroups.first();
-      const textLeft = (selector: string) =>
-        firstEmptyGroup.locator(selector).evaluate((element) => {
-          const range = document.createRange();
-          range.selectNodeContents(element);
-          return range.getBoundingClientRect().x;
-        });
-      const [titleLeft, placeholderLeft] = await Promise.all([
-        textLeft(".sidebar-recent-sessions__label-text"),
-        textLeft(".sidebar-session-empty-placeholder"),
-      ]);
-      expect(placeholderLeft).toBeCloseTo(titleLeft, 0);
+      const groupHeight = () =>
+        firstEmptyGroup.evaluate((element) => element.getBoundingClientRect().height);
+      await expect.poll(groupHeight).toBeGreaterThan(0);
+      const expandedHeight = await groupHeight();
+      await captureUiProof(page, "sidebar-empty-cross-agent-groups.png");
+
+      const toggle = firstEmptyGroup.locator(".sidebar-session-group-toggle");
+      await toggle.click();
+      await expect.poll(() => toggle.getAttribute("aria-expanded")).toBe("false");
+      await expect.poll(groupHeight).toBe(expandedHeight);
+      await expect
+        .poll(() => firstEmptyGroup.locator(".sidebar-session-empty-hint").count())
+        .toBe(0);
+      await expect
+        .poll(() => firstEmptyGroup.locator(".sidebar-recent-sessions__list").count())
+        .toBe(0);
     } finally {
       await context.close();
     }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5494,7 +5494,6 @@ export const en: TranslationMap = {
       otherSessions: "Other",
       groups: "Groups",
       coding: "Coding",
-      noSessionsForAgent: "No sessions found for this agent",
       catalogViewOptions: "View options",
       hideFromSidebar: "Hide from sidebar",
       sectionHidden: "{section} hidden.",

--- a/ui/src/test-helpers/app-sidebar-cases/session-list-sections.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-list-sections.ts
@@ -142,7 +142,19 @@ describe("AppSidebar session section visibility", () => {
 
     // Empty user-created groups stay visible (creation and drag targets);
     // only the bare Other header disappears while nothing lives in it.
-    expect(sidebar.querySelector('[data-session-section="category:Empty"]')).not.toBeNull();
+    const emptyCategory = sidebar.querySelector('[data-session-section="category:Empty"]');
+    const emptyCategoryHeader = emptyCategory?.querySelector(
+      ":scope > .sidebar-recent-sessions__head",
+    );
+    expect(emptyCategory).not.toBeNull();
+    expect(emptyCategoryHeader).not.toBeNull();
+    expect(emptyCategory?.querySelector(".sidebar-session-group-toggle")?.textContent).toContain(
+      "Empty",
+    );
+    expect(emptyCategory?.querySelector(".sidebar-session-empty-hint")).toBeNull();
+    expect(emptyCategory?.querySelector(".sidebar-recent-sessions__list")).toBeNull();
+    expect(emptyCategory?.children).toHaveLength(1);
+    expect(emptyCategory?.firstElementChild).toBe(emptyCategoryHeader);
     expect(sidebar.querySelector('[data-session-section="ungrouped"]')).toBeNull();
 
     sidebar.sessionOrganizer.draggingSessionKey = "agent:main:alpha";


### PR DESCRIPTION
Related: #122805

## What Problem This Solves

Fixes an issue where empty custom session groups repeated “No sessions found for this agent” and reserved extra vertical space when the selected agent had no rows in those groups.

## Why This Change Was Made

Empty groups remain visible as headers, creation targets, and drag destinations, but they no longer render a placeholder row. Expanded and collapsed empty groups now occupy the same compact height. Archived-session empty-state guidance and session membership behavior are unchanged; #122805 remains open for its separate pinned-session move inconsistency.

## User Impact

The Sessions sidebar is denser and easier to scan: empty groups show only their existing header and controls instead of repeated explanatory text.

## Evidence

**Before**

![Empty sidebar groups before the fix](https://github.com/user-attachments/assets/0e4fcf53-3efc-428f-93c0-222bea80effb)

**After**

![Compact empty sidebar groups after the fix](https://github.com/user-attachments/assets/2e349f0b-9657-4623-afa8-fa2d3fe0d9ae)

- Pre-fix mocked browser reproduction captured two visible empty groups with the repeated placeholder text; both screenshots above were inspected before upload.
- The updated browser regression fails against the old renderer with `expected 0, received 2` empty hints, then passes with the fix and verifies equal expanded/collapsed height.
- `ui/src/components/app-sidebar.test.ts`: 282/282 passed.
- `ui/src/e2e/session-management.groups.e2e.test.ts`: 11/11 passed against the mocked Gateway in Chromium.
- `node scripts/check-changed.mjs -- <changed files>` passed, including format, UI i18n, typechecks, lint, and repository guards.
- Codex-backed autoreview reported no accepted/actionable findings (confidence 0.99).
- Production LOC: +0/-6. Tests: +46/-16.

AI-assisted: yes.
