### PR TITLE
fix(ui): keep sidebar icon endcap intact in single-line session rows

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -454,7 +454,7 @@ function renderCatalogSessionRow(
     );
   return html`
     <div
-      class="sidebar-recent-session session-row-host ${active
+      class="sidebar-recent-session session-row-host sidebar-recent-session--single-line ${active
         ? "sidebar-recent-session--active"
         : ""} ${projectChild ? "sidebar-recent-session--catalog-project-child" : ""} ${running
         ? "session-row-host--running"

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -334,6 +334,7 @@ suite.define(() => {
     const page = await context.newPage();
     const busyKey = "agent:main:busy-session";
     const plainKey = "agent:main:plain-session";
+    const longKey = "agent:main:long-title-session";
     await installMockGateway(page, {
       methodResponses: {
         "sessions.list": chatSessionListResponse([
@@ -363,6 +364,17 @@ suite.define(() => {
             kind: "direct",
             label: "A session without secondary metadata",
             updatedAt: 1,
+          },
+          {
+            key: longKey,
+            kind: "direct",
+            label:
+              "An extremely long single-line session title that keeps going and going far past the sidebar width",
+            updatedAt: 1,
+            activeRunIds: ["run-long-title"],
+            hasActiveRun: true,
+            status: "running",
+            unread: true,
           },
         ]),
       },
@@ -446,6 +458,37 @@ suite.define(() => {
         expect(atom.top).toBeGreaterThanOrEqual(layout.endcap.top);
         expect(atom.bottom).toBeLessThanOrEqual(layout.endcap.bottom);
       }
+
+      // A long title must truncate instead of crushing the collapsed row's icon
+      // endcap: the spinner/unread icons keep their intrinsic width and stay
+      // inside the row, exactly like the two-line endcap under a long subtitle.
+      const longRow = page.locator(`.sidebar-recent-session[data-session-key="${longKey}"]`);
+      const longLayout = await longRow.evaluate((row) => {
+        const endcap = row.querySelector(".sidebar-recent-session__details-endcap");
+        const name = row.querySelector(".sidebar-recent-session__name");
+        if (!endcap || !name) {
+          throw new Error("Missing long-title session row fixture");
+        }
+        const endcapBox = endcap.getBoundingClientRect();
+        const rowBox = row.getBoundingClientRect();
+        return {
+          atoms: Array.from(
+            endcap.querySelectorAll(":scope :is(svg, .session-run-spinner, .session-unread-dot)"),
+            (element) => element.getBoundingClientRect().width,
+          ),
+          endcapWidth: endcapBox.width,
+          endcapRight: endcapBox.right,
+          nameOverflowing: name.scrollWidth > name.clientWidth,
+          rowRight: rowBox.right,
+          singleLine: row.classList.contains("sidebar-recent-session--single-line"),
+        };
+      });
+      expect(longLayout.singleLine).toBe(true);
+      expect(longLayout.nameOverflowing).toBe(true);
+      expect(longLayout.endcapRight).toBeLessThanOrEqual(longLayout.rowRight);
+      const intrinsicAtomWidth = longLayout.atoms.reduce((sum, width) => sum + width, 0);
+      expect(intrinsicAtomWidth).toBeGreaterThan(0);
+      expect(longLayout.endcapWidth).toBeGreaterThanOrEqual(intrinsicAtomWidth);
 
       await busyRow.hover();
       await expect

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -498,22 +498,18 @@ suite.define(() => {
         }),
       );
       expect(threadRowMetrics).toHaveLength(4);
-      // Gateway threads and native catalog children must stay density-identical, but a
-      // row with no preview text collapses to one line. Assert uniformity per shape, so
-      // the two sources drifting apart still fails while the collapse stays legal.
-      const singleLineHeights = new Set(
-        threadRowMetrics.filter((metric) => metric.singleLine).map((metric) => metric.height),
-      );
-      const twoLineHeights = new Set(
-        threadRowMetrics.filter((metric) => !metric.singleLine).map((metric) => metric.height),
-      );
+      // Gateway threads and native catalog children must stay density-identical.
+      // Catalog children never carry preview text, so every subtitle-less row —
+      // whichever source it came from — collapses to the same one-line height
+      // instead of reserving a phantom second line.
+      for (const metric of threadRowMetrics) {
+        expect(metric.singleLine).toBe(true);
+      }
+      const singleLineHeights = new Set(threadRowMetrics.map((metric) => metric.height));
       expect(singleLineHeights.size).toBe(1);
-      expect(twoLineHeights.size).toBe(1);
       const [collapsedHeight] = [...singleLineHeights];
-      const [expandedHeight] = [...twoLineHeights];
       // Collapsed rows sit on the 30px min-height floor; renderer sub-pixels vary.
       expect(collapsedHeight).toBeCloseTo(30, 1);
-      expect(expandedHeight).toBeGreaterThan(collapsedHeight!);
       for (const metric of threadRowMetrics) {
         expect(metric).toMatchObject({
           minHeight: "30px",

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4254,9 +4254,12 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   gap: var(--sidebar-row-gap);
 }
 
+/* Basis 0 mirrors the two-line subtitle contract: the title absorbs all
+   shrink, so the icon endcap keeps its intrinsic width until it alone
+   exceeds the row. Basis auto let long titles crush the endcap to ~0. */
 .sidebar-recent-session--single-line .sidebar-recent-session__name {
   width: auto;
-  flex: 1 1 auto;
+  flex: 1 1 0;
 }
 
 .sidebar-recent-session--single-line > .sidebar-recent-session__aside {


### PR DESCRIPTION
## What Problem This Solves

Audit of the sessions sidebar with **Show message preview** turned off (single-line rows). With preview off a row has only one line, but the icon logic that normally lives on the second row (running spinner, unread dot, badges, facepile, trail) must survive on that single line. Two defects broke that:

1. **Long titles crushed the icon endcap.** In `--single-line` rows the title used `flex: 1 1 auto` (flex basis = full text width), so when the title overflowed, shrink was distributed onto the icon endcap too — a 24px endcap collapsed to ~7px and the spinner/unread/badge icons were clipped away. The two-line layout never has this problem because the subtitle uses basis 0 and absorbs all shrink first.
2. **Native catalog session rows always rendered a phantom second line.** `renderCatalogSessionRow` emitted the two-line skeleton unconditionally and never received `--single-line`, so Codex/Claude Code catalog rows sat at 46px with an empty 18px details line under the title — misaligned with every other subtitle-less row (30px), in both preview modes.

## Why This Change Was Made

Preview-off is a supported display mode; the status icons are exactly what remains actionable in that mode and must never be silently clipped. Catalog rows never carry preview text at all, so they should always collapse to the one-line shape.

## User Impact

- Single-line rows keep every status icon visible; long titles truncate with an ellipsis instead of eating the icons (same contract as the two-line endcap under a long subtitle).
- Codex/Claude Code catalog rows now match gateway rows: 30px, one line, no dead whitespace.
- Rows that must stay two-line with preview off (attention/error text, queued explanation, critical observer headline) are unchanged — that carve-out is intentional (`session-row-subtitle.ts`) and verified.

## Evidence

Mocked Control UI (`pnpm dev:ui:mock`) + Playwright geometry audit across preview on/off, dark theme:

- Pre-fix: long-title single-line row endcap 24px -> 7.05px (icons clipped); catalog child rows h=46 with an empty details line. Post-fix: endcap stays 24px under the same title; catalog rows h=30, `--single-line`, uniform with gateway rows.
- Hover/touch overlays and child-row trails measured correct in single-line mode (action overlay centered, endcap fades on hover as designed).

Long-title row, before (spinner crushed to a sliver) vs after:

![before](https://github.com/user-attachments/assets/d5947f8d-54f2-440c-9314-0a778343b249)
![after](https://github.com/user-attachments/assets/aabc8271-c871-41eb-a3cb-7c1f46ffa366)

Catalog section (CODEX / CLAUDE CODE), before (phantom second line under each row) vs after:

<img src="https://github.com/user-attachments/assets/88e732e2-118d-409e-a1e3-a31f95447ac8" width="300" /> <img src="https://github.com/user-attachments/assets/3a3a715d-9846-4d95-90fa-c0297c0dd349" width="300" />

Validation:

- New regression in `chat-flow.sidebar-presentation.e2e.test.ts` (long-title row: endcap keeps intrinsic atom width, title reports overflow) — verified to FAIL on pre-fix CSS and pass after.
- `codex-sessions.e2e.test.ts` density assertions updated to the new contract (all subtitle-less rows single-line at ~30px).
- Focused suites green: `codex-sessions`, `chat-flow.sidebar-presentation`, `session-management.trailing-state` (17 tests).
- `pnpm check:changed` green (format, i18n verify, tsgo core+UI, lint lanes).
- Codex autoreview (Sol, high): clean, no findings.

Production LOC delta: net ~+4 (3 comment lines + 1 class token); the rest is test coverage.


## Opportunistic CI fix (called out per Pathfinder rule)

First CI attempt failed in `checks-node-compact-small-6` on `src/gateway/server.sessions.compaction-read-errors.test.ts` — unrelated to this UI diff and passing locally (also with `--isolate=false`). Residual flake class after e294c154a6c: a stray transcript read on a slow shared worker consumes the queued `mockRejectedValueOnce`, so the compaction read hits the real store and succeeds (`expected true to be false`). Fixed in this PR by making the rejection sticky (`mockRejectedValue`); `beforeEach` already resets the mock per test, so nothing leaks across tests.
