### PR TITLE
fix(ui): read-only Agents identity editor stays stuck on Saving

### DIFF
--- a/ui/src/e2e/operator-admin.e2e.test.ts
+++ b/ui/src/e2e/operator-admin.e2e.test.ts
@@ -377,7 +377,7 @@ suite.define(() => {
       const setDefault = page.locator(".agents-toolbar-actions button").nth(1);
       await expect.poll(() => setDefault.isDisabled()).toBe(true);
       const identitySave = page.locator(".agent-identity-editor__actions button");
-      await expect.poll(() => identitySave.innerText()).toBe("Save");
+      await expect.poll(async () => (await identitySave.textContent())?.trim()).toBe("Save");
       await expect.poll(() => identitySave.isDisabled()).toBe(true);
       await setDefault.click({ force: true });
       expect(await gateway.getRequests("config.set")).toHaveLength(0);

--- a/ui/src/e2e/operator-admin.e2e.test.ts
+++ b/ui/src/e2e/operator-admin.e2e.test.ts
@@ -373,8 +373,12 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}agents`);
       await gateway.waitForRequest("agents.list");
       await selectAgentOnAgentsPage(page, "Reviewer");
+      await page.locator("#agents-tab-overview").click();
       const setDefault = page.locator(".agents-toolbar-actions button").nth(1);
       await expect.poll(() => setDefault.isDisabled()).toBe(true);
+      const identitySave = page.locator(".agent-identity-editor__actions button");
+      await expect.poll(() => identitySave.innerText()).toBe("Save");
+      await expect.poll(() => identitySave.isDisabled()).toBe(true);
       await setDefault.click({ force: true });
       expect(await gateway.getRequests("config.set")).toHaveLength(0);
       await screenshot(page, "05-read-only-agents.png");

--- a/ui/src/pages/agents/panels-overview.test.ts
+++ b/ui/src/pages/agents/panels-overview.test.ts
@@ -4,6 +4,31 @@ import { expect, it } from "vitest";
 import { createAgentViewTestProps as createProps } from "./agents-view.test-helpers.ts";
 import { renderAgents } from "./view.ts";
 
+it.each([
+  { label: "a read-only editor", canUpdateIdentity: false, identitySaving: false, text: "Save" },
+  {
+    label: "an active identity save",
+    canUpdateIdentity: true,
+    identitySaving: true,
+    text: "Saving…",
+  },
+])("shows the actual save state for $label", ({ canUpdateIdentity, identitySaving, text }) => {
+  const container = document.createElement("div");
+  const props = createProps();
+  render(
+    renderAgents({
+      ...props,
+      access: { ...props.access, canUpdateIdentity },
+      identitySaving,
+    }),
+    container,
+  );
+
+  const save = container.querySelector<HTMLButtonElement>(".agent-identity-editor__actions button");
+  expect(save?.textContent?.trim()).toBe(text);
+  expect(save?.disabled).toBe(true);
+});
+
 it("shows inherited skills in the Agent Context overview", () => {
   const container = document.createElement("div");
   render(

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -215,7 +215,7 @@ export function renderAgentOverview(params: {
               ?disabled=${identityBusy || !identityDirty || identityInvalid}
               @click=${() => params.onIdentitySave()}
             >
-              ${identityBusy ? t("common.saving") : t("common.save")}
+              ${params.identitySaving ? t("common.saving") : t("common.save")}
             </button>
           </div>
           <div class="settings-row__desc agent-identity-editor__hint">


### PR DESCRIPTION
AI-assisted.

<details>
<summary>Additional instructions</summary>

**Allow edits from maintainers** is available: this branch lives in the OpenClaw repository.

</details>

## What Problem This Solves

Fixes an issue where users browsing **Agents → Overview** with read-only operator access would see a permanently disabled **Saving…** identity button even though no save was running.

## Why This Change Was Made

The identity editor combined an in-progress save and missing edit permission into one disabled-state flag, then accidentally reused that flag as the progress label. Keep permission and busy-state enforcement unchanged, but render **Saving…** only from the actual identity-save lifecycle. Production delta: +1/-1, net zero.

## User Impact

Read-only operators now see an accurate disabled **Save** action. Administrators retain editable identity controls, and genuine in-progress identity saves still display **Saving…**. No authorization, Gateway, configuration, or storage behavior changes.

## Evidence

- Reproduced against a real isolated Gateway and the Control UI, with the Gateway itself granting exactly `operator.read` through its existing connection scope cap. Before the fix the disabled button read **Saving…**; after the fix it reads **Save** while both the button and editor remain disabled. The administrator sibling still receives `operator.admin` and keeps an editable identity editor.
- Confirmed the live Vite server served the repaired task checkout, not the original QA checkout.
- Failing-first focused owner regression: the new read-only case failed on the original source with `expected 'Saving…' to be 'Save'`; after the one-line repair, all three focused cases passed, including the genuine active-save state.

  ```bash
  OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/agents/panels-overview.test.ts
  ```

- Extended the existing read-only operator browser scenario to navigate to **Overview** and assert that **Save** remains disabled. The heavyweight Vitest browser lane could not be rerun after that scenario adjustment because the host disk-safety approval gate explicitly rejected it; the direct real-Gateway Chrome proof above was completed instead.
- Independent source review: no actionable findings.
- Mandatory repository autoreview: clean, no accepted/actionable findings.
- Formatting: `./node_modules/.bin/oxfmt --check ui/src/pages/agents/panels-overview.ts ui/src/pages/agents/panels-overview.test.ts ui/src/e2e/operator-admin.e2e.test.ts` passed.

### Before

![Read-only Agents identity editor incorrectly showing Saving](https://github.com/user-attachments/assets/0b2b660a-3970-44db-a5e8-dda355e64973)

### After

![Read-only Agents identity editor correctly showing disabled Save](https://github.com/user-attachments/assets/e55f2be8-2ac5-46d8-ab80-365957417580)
