### PR TITLE
fix(opencode): auto-surface live models via shared projector

### DIFF
--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -485,7 +485,11 @@ describe("opencode-go provider plugin", () => {
       fetchGuard,
     });
 
-    expect(live.models.map((model) => model.id)).toEqual(activeModelIds);
+    // Shared projector now surfaces all ids present in the live response
+    // (deprecated/compatibility ids template from nearest active prefix).
+    expect(live.models.map((model: { id: string }) => model.id).toSorted()).toEqual(
+      [...compatibilityModelIds, ...activeModelIds].toSorted(),
+    );
   });
 
   it.each([

--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -250,11 +250,7 @@ export async function buildOpencodeGoLiveProviderConfig(
     timeoutMs: OPENCODE_GO_MODELS_TIMEOUT_MS,
     ttlMs: OPENCODE_GO_MODELS_CACHE_TTL_MS,
     auditContext: "opencode-go-model-discovery",
-    // SAFETY: buildOpenAICompatibleLiveModels returns ModelDefinitionConfig[] with
-    // opencode-go's discrete transport (api/baseUrl fixed in providerConfig) — safe
-    // to narrow to the provider-specific subtype for live discovery.
-    projectRows: (rows: readonly unknown[], fallback: ModelProviderConfig) =>
-      buildOpenAICompatibleLiveModels(rows, fallback) as OpencodeGoModelDefinition[],
+    projectRows: buildOpenAICompatibleLiveModels,
   });
 }
 

--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -3,6 +3,7 @@ import type { ModelCatalogEntry } from "openclaw/plugin-sdk/agent-runtime";
 import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import {
   buildLiveModelProviderConfig,
+  buildOpenAICompatibleLiveModels,
   fetchLiveProviderModelIds,
   type LiveModelCatalogFetchGuard,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
@@ -249,6 +250,11 @@ export async function buildOpencodeGoLiveProviderConfig(
     timeoutMs: OPENCODE_GO_MODELS_TIMEOUT_MS,
     ttlMs: OPENCODE_GO_MODELS_CACHE_TTL_MS,
     auditContext: "opencode-go-model-discovery",
+    // SAFETY: buildOpenAICompatibleLiveModels returns ModelDefinitionConfig[] with
+    // opencode-go's discrete transport (api/baseUrl fixed in providerConfig) — safe
+    // to narrow to the provider-specific subtype for live discovery.
+    projectRows: (rows: readonly unknown[], fallback: ModelProviderConfig) =>
+      buildOpenAICompatibleLiveModels(rows, fallback) as OpencodeGoModelDefinition[],
   });
 }
 

--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -769,7 +769,11 @@ describe("opencode provider plugin", () => {
       discoveryApiKey: "resolved-opencode-key",
       fetchGuard,
     });
-    expect(unknownOnly.models.map((model) => model.id)).toEqual(ACTIVE_MODEL_IDS);
+    // Shared projector templates bare unknown ids off the nearest active prefix
+    // (gpt-6-experimental ← gpt-*) instead of dropping them into static fallback.
+    expect(unknownOnly.models.map((model: { id: string }) => model.id)).toEqual([
+      "gpt-6-experimental",
+    ]);
 
     clearLiveCatalogCacheForTests();
     fetchGuard.mockRejectedValueOnce(new Error("network unavailable"));

--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -751,7 +751,9 @@ describe("opencode provider plugin", () => {
       baseUrl: "https://opencode.ai/zen",
       provider: "opencode",
     });
-    const liveOnlyModel = first.models.find((model: { id: string }) => model.id === "gpt-6-experimental");
+    const liveOnlyModel = first.models.find(
+      (model: { id: string }) => model.id === "gpt-6-experimental",
+    );
     expect(liveOnlyModel).toBeDefined();
 
     clearLiveCatalogCacheForTests();

--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -712,8 +712,33 @@ describe("opencode provider plugin", () => {
 
     expect(fetchGuard).toHaveBeenCalledTimes(1);
     expect(first.apiKey).toBe("OPENCODE_API_KEY");
-    expect(first.models.map((model) => model.id)).toEqual(["kimi-k3", "claude-opus-4-7"]);
-    expect(second.models.map((model) => model.id)).toEqual(["kimi-k3", "claude-opus-4-7"]);
+    // Shared projector surfaces unknowns via findLiveModelTemplate (prefix >=4) —
+    // deprecated ids like claude-opus-4-8 now template from claude-opus-4-7
+    // and bare unknowns like gpt-6-experimental get fallback templating.
+    expect(first.models.map((model: { id: string }) => model.id).toSorted()).toEqual(
+      [
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-sonnet-4",
+        "gpt-5.5",
+        "gpt-6-experimental",
+        "kimi-k3",
+        "ling-3.0-flash-free",
+        "minimax-m2.7",
+      ].toSorted(),
+    );
+    expect(second.models.map((model: { id: string }) => model.id).toSorted()).toEqual(
+      [
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+        "claude-sonnet-4",
+        "gpt-5.5",
+        "gpt-6-experimental",
+        "kimi-k3",
+        "ling-3.0-flash-free",
+        "minimax-m2.7",
+      ].toSorted(),
+    );
     expect(first.models.find((model) => model.id === "kimi-k3")).toMatchObject({
       api: "openai-completions",
       baseUrl: "https://opencode.ai/zen/v1",
@@ -726,8 +751,8 @@ describe("opencode provider plugin", () => {
       baseUrl: "https://opencode.ai/zen",
       provider: "opencode",
     });
-    const liveOnlyModel = first.models.find((model) => model.id === "gpt-6-experimental");
-    expect(liveOnlyModel).toBeUndefined();
+    const liveOnlyModel = first.models.find((model: { id: string }) => model.id === "gpt-6-experimental");
+    expect(liveOnlyModel).toBeDefined();
 
     clearLiveCatalogCacheForTests();
     fetchGuard.mockResolvedValueOnce({

--- a/extensions/opencode/provider-catalog.ts
+++ b/extensions/opencode/provider-catalog.ts
@@ -3,6 +3,7 @@ import type { ModelCatalogEntry } from "openclaw/plugin-sdk/agent-runtime";
 import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import {
   buildLiveModelProviderConfig,
+  buildOpenAICompatibleLiveModels,
   fetchLiveProviderModelIds,
   type LiveModelCatalogFetchGuard,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
@@ -486,37 +487,14 @@ export async function resolveOpencodeZenStarterModel(params: {
   return liveModelIds.includes(preferredModelId) ? params.preferredModelRef : undefined;
 }
 
-function readLiveModelId(row: unknown): string | undefined {
-  if (!row || typeof row !== "object" || Array.isArray(row)) {
-    return undefined;
-  }
-  const candidate = row as { id?: unknown; object?: unknown };
-  if (candidate.object !== undefined && candidate.object !== "model") {
-    return undefined;
-  }
-  if (typeof candidate.id !== "string") {
-    return undefined;
-  }
-  const modelId = candidate.id.trim().toLowerCase();
-  return modelId || undefined;
-}
-
-function projectOpencodeZenLiveModels(rows: readonly unknown[]): OpencodeZenModelDefinition[] {
-  const staticModels = new Map(OPENCODE_ZEN_MODELS.map((model) => [model.id, model]));
-  const seen = new Set<string>();
-  const models: OpencodeZenModelDefinition[] = [];
-  for (const row of rows) {
-    const modelId = readLiveModelId(row);
-    if (!modelId || seen.has(modelId)) {
-      continue;
-    }
-    seen.add(modelId);
-    const model = staticModels.get(modelId);
-    if (model) {
-      models.push(model);
-    }
-  }
-  return models;
+function projectOpencodeZenLiveModels(
+  rows: readonly unknown[],
+  fallback: ModelProviderConfig,
+): OpencodeZenModelDefinition[] {
+  // SAFETY: buildOpenAICompatibleLiveModels returns ModelDefinitionConfig[] with
+  // resolved transport from opencode's fallback (api/baseUrl) — safe to narrow
+  // to the provider-specific subtype for live discovery.
+  return buildOpenAICompatibleLiveModels(rows, fallback) as OpencodeZenModelDefinition[];
 }
 
 export async function buildOpencodeZenLiveProviderConfig(

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -8,6 +8,7 @@ import type {
   ProviderPlugin,
 } from "../plugins/types.js";
 import {
+  buildOpenAICompatibleLiveModels,
   readLiveModelCatalogBooleanField,
   readLiveModelCatalogPositiveSafeIntegerField,
   readLiveModelCatalogRecord,
@@ -35,8 +36,8 @@ export type LiveModelCatalogHeaderContext = {
 };
 
 export { clearLiveCatalogCacheForTests };
-export { buildOpenAICompatibleLiveModels } from "./provider-catalog-live-normalize.internal.js";
 export {
+  buildOpenAICompatibleLiveModels,
   readLiveModelCatalogBooleanField,
   readLiveModelCatalogPositiveSafeIntegerField,
   readLiveModelCatalogStringField,

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -8,7 +8,6 @@ import type {
   ProviderPlugin,
 } from "../plugins/types.js";
 import {
-  buildOpenAICompatibleLiveModels,
   readLiveModelCatalogBooleanField,
   readLiveModelCatalogPositiveSafeIntegerField,
   readLiveModelCatalogRecord,
@@ -36,6 +35,7 @@ export type LiveModelCatalogHeaderContext = {
 };
 
 export { clearLiveCatalogCacheForTests };
+export { buildOpenAICompatibleLiveModels } from "./provider-catalog-live-normalize.internal.js";
 export {
   readLiveModelCatalogBooleanField,
   readLiveModelCatalogPositiveSafeIntegerField,


### PR DESCRIPTION
Endpoint already returns new ids but catalog dropped them:

- **Zen**: `projectOpencodeZenLiveModels` filtered to `staticModels.get(id)` only → `gemini-3.7-flash`, `grok-4.6`, `hy3-free`, `muse-spark-1.2` dropped (live 62 vs static 54 non-deprecated)
- **Go**: no `projectRows` → `buildLiveModelProviderConfig` filtered to static id set → `glm-5.3`, `muse-spark-1.2`, `qwen3.8-max` dropped (live 28 vs static 25)

Wire both through `buildOpenAICompatibleLiveModels` so unknowns template from nearest prefix (>=4 chars) and appear without hand-edits. Re-export projector from `provider-catalog-live-runtime` so bundled plugins can import it.

## What Problem This Solves
New models appear on https://opencode.ai/zen/v1/models and /zen/go/v1/models but never show in OpenClaw's model picker until someone hand-edits static catalog arrays. Root cause: Zen projector filtered to staticModels existence, Go had no projector — both now use shared OpenAI-compatible projector.

## Evidence
- Live endpoints verified: Zen 62 models, Go 28 models (curl /v1/models on 2026-08-20)
- Local tsx smoke: `buildOpenAICompatibleLiveModels` now surfaces `glm-5.3,muse-spark-1.2` (was empty filtered set)
- Lint: `oxlint` 0 errors on 3 changed source files; `check-wrapper-shadowing` passed
- Tests: updated `extensions/opencode/index.test.ts` and `opencode-go/index.test.ts` expectations for new projector behavior (was 2 failures in shard changed-extensions-config-5)
- CI: PR 126573 checks pending → watcher polling every 2m