### PR TITLE
fix(onboard): keep OpenRouter API keys with their provider

### DIFF
--- a/extensions/arcee/index.test.ts
+++ b/extensions/arcee/index.test.ts
@@ -7,6 +7,7 @@ import { resolveProviderAuthEnvVarCandidates } from "openclaw/plugin-sdk/provide
 import { describe, expect, it } from "vitest";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import arceePlugin from "./index.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 describe("arcee provider plugin", () => {
   it("registers Arcee AI with direct and OpenRouter auth choices", async () => {
@@ -36,6 +37,13 @@ describe("arcee provider plugin", () => {
     }
     expect(orChoice.provider.id).toBe("arcee");
     expect(orChoice.method.id).toBe("openrouter");
+
+    const openRouterManifestChoice = manifest.providerAuthChoices.find(
+      (choice) => choice.choiceId === "arceeai-openrouter",
+    );
+    expect(openRouterManifestChoice).toMatchObject({ optionKey: "openrouterApiKey" });
+    expect(openRouterManifestChoice).not.toHaveProperty("cliFlag");
+    expect(openRouterManifestChoice).not.toHaveProperty("cliOption");
   });
 
   it("stores the OpenRouter onboarding path under the OpenRouter auth profile", async () => {

--- a/extensions/arcee/openclaw.plugin.json
+++ b/extensions/arcee/openclaw.plugin.json
@@ -44,10 +44,7 @@
       "groupId": "arcee",
       "groupLabel": "Arcee AI",
       "groupHint": "Direct API or OpenRouter",
-      "optionKey": "openrouterApiKey",
-      "cliFlag": "--openrouter-api-key",
-      "cliOption": "--openrouter-api-key <key>",
-      "cliDescription": "OpenRouter API key for Arcee AI models"
+      "optionKey": "openrouterApiKey"
     }
   ],
   "configSchema": {

--- a/scripts/lib/official-external-provider-catalog.json
+++ b/scripts/lib/official-external-provider-catalog.json
@@ -123,9 +123,6 @@
                 "groupLabel": "Arcee AI",
                 "groupHint": "Direct API or OpenRouter",
                 "optionKey": "openrouterApiKey",
-                "cliFlag": "--openrouter-api-key",
-                "cliOption": "--openrouter-api-key <key>",
-                "cliDescription": "OpenRouter API key for Arcee AI models",
                 "onboardingScopes": [
                   "text-inference"
                 ]

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -2602,6 +2602,24 @@ describe("official external plugin catalog", () => {
     });
   });
 
+  it("keeps the shared OpenRouter onboarding flag with its provider", () => {
+    const arceeChoices = expectCatalogEntry("arcee").openclaw?.providers?.find(
+      (provider) => provider.id === "arcee",
+    )?.authChoices;
+    const directChoice = arceeChoices?.find((choice) => choice.choiceId === "arceeai-api-key");
+    const openRouterChoice = arceeChoices?.find(
+      (choice) => choice.choiceId === "arceeai-openrouter",
+    );
+
+    expect(directChoice).toMatchObject({
+      optionKey: "arceeaiApiKey",
+      cliFlag: "--arceeai-api-key",
+    });
+    expect(openRouterChoice).toMatchObject({ optionKey: "openrouterApiKey" });
+    expect(openRouterChoice).not.toHaveProperty("cliFlag");
+    expect(openRouterChoice).not.toHaveProperty("cliOption");
+  });
+
   it("keeps Groq available through the cold-install auth catalog", () => {
     const groq = expectCatalogEntry("groq");
     const authChoice = groq.openclaw?.providers?.find((provider) => provider.id === "groq")


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who configured OpenRouter with `openclaw onboard --openrouter-api-key <key>` could silently receive an Arcee model and provider instead. The same ownership collision also mislabeled the generic OpenRouter option as an Arcee-specific API key in CLI help.

## Why This Change Was Made

Both the canonical OpenRouter provider and Arcee's optional OpenRouter-backed authentication method advertised ownership of the same onboarding CLI flag. Arcee sorts first, so shared provider discovery selected its authentication method. Arcee's metadata is represented both in its own plugin manifest and in the shipped external-provider catalog; both must stop claiming OpenRouter's flag.

The repair removes only duplicated CLI-flag metadata from both Arcee representations. Arcee retains the shared `openrouterApiKey` option, its explicit `arceeai-openrouter` authentication choice, and its existing runtime authentication method.

## User Impact

`--openrouter-api-key` now configures OpenRouter, as its name and documentation promise. Users who deliberately want Arcee through OpenRouter can continue to select `--auth-choice arceeai-openrouter --openrouter-api-key <key>`.

## Evidence

- Real isolated CLI before the fix: `onboard --non-interactive --accept-risk --openrouter-api-key <fixture> --skip-daemon --skip-health --json` exited successfully but reported `authChoice: arceeai-openrouter` and selected the Arcee default model.
- Real isolated CLI after loading the repaired current-checkout Arcee manifest: the same generic OpenRouter-key onboarding exits successfully with `authChoice: openrouter-api-key`, persists `agents.defaults.model.primary: openrouter/auto`, and creates an OpenRouter-owned auth profile.
- Dependency-free owner-boundary assertions failed on the original actual Arcee manifest and cold-install catalog, then passed after the repair while preserving explicit Arcee-via-OpenRouter and Arcee's own API-key flag.
- Existing explicit-choice controls independently confirmed that both OpenRouter and Arcee-via-OpenRouter authentication paths remain selectable.
- Regression coverage checks the actual shipped external-provider catalog and the Arcee plugin's manifest/runtime ownership boundary.
- Linked-worktree Vitest cannot collect locally because this checkout intentionally has no physical `node_modules`; exact-head GitHub CI runs both added regressions.
- Targeted formatter and lint checks pass; independent Codex autoreview reports no actionable findings.
