### PR TITLE
fix(ui): update approval history immediately after decisions resolve

### DIFF
--- a/ui/src/app/exec-approval.ts
+++ b/ui/src/app/exec-approval.ts
@@ -145,8 +145,16 @@ function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | nul
   };
 }
 
-export function parseExecApprovalResolved(payload: unknown): ExecApprovalResolved | null {
-  if (!isRecord(payload)) {
+export function parseApprovalResolvedEvent(
+  event: string,
+  payload: unknown,
+): ExecApprovalResolved | null {
+  if (
+    (event !== "exec.approval.resolved" &&
+      event !== "plugin.approval.resolved" &&
+      event !== "openclaw.approval.resolved") ||
+    !isRecord(payload)
+  ) {
     return null;
   }
   const id = normalizeOptionalString(payload.id) ?? "";

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -26,7 +26,7 @@ import {
   enqueueExecApprovalPrompt,
   isStaleApprovalResolutionError,
   parseApprovalRequestedEvent,
-  parseExecApprovalResolved,
+  parseApprovalResolvedEvent,
   resolveApprovalRequest,
   type ExecApprovalPromptState,
 } from "./exec-approval.ts";
@@ -441,16 +441,10 @@ export function createApplicationOverlays(
       publish();
       return;
     }
-    if (
-      event.event === "exec.approval.resolved" ||
-      event.event === "plugin.approval.resolved" ||
-      event.event === "openclaw.approval.resolved"
-    ) {
-      const resolved = parseExecApprovalResolved(event.payload);
-      if (resolved) {
-        clearResolvedExecApprovalPrompt(promptState, resolved.id);
-        publish();
-      }
+    const resolvedApproval = parseApprovalResolvedEvent(event.event, event.payload);
+    if (resolvedApproval) {
+      clearResolvedExecApprovalPrompt(promptState, resolvedApproval.id);
+      publish();
     }
   });
   synchronizeGateway(gateway.snapshot);

--- a/ui/src/pages/approvals/approvals-page.test.ts
+++ b/ui/src/pages/approvals/approvals-page.test.ts
@@ -2,7 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApprovalHistoryResult } from "../../../../packages/gateway-protocol/src/schema/approvals.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { i18n } from "../../i18n/index.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
@@ -35,6 +35,7 @@ function createPage(
   auth?: { role: string; scopes?: string[] },
 ): {
   page: TestApprovalsPage;
+  emitGatewayEvent: (event: string, payload: unknown) => void;
   updateGateway: (next: Partial<ApplicationGatewaySnapshot>) => void;
 } {
   const client = { request } as GatewayBrowserClient;
@@ -44,6 +45,7 @@ function createPage(
     ...(auth ? { hello: { auth } } : {}),
   } as ApplicationGatewaySnapshot;
   const listeners = new Set<(next: ApplicationGatewaySnapshot) => void>();
+  const eventListeners = new Set<(event: GatewayEventFrame) => void>();
   const gateway = {
     get snapshot() {
       return snapshot;
@@ -51,6 +53,10 @@ function createPage(
     subscribe(listener: (next: ApplicationGatewaySnapshot) => void) {
       listeners.add(listener);
       return () => listeners.delete(listener);
+    },
+    subscribeEvents(listener: (event: GatewayEventFrame) => void) {
+      eventListeners.add(listener);
+      return () => eventListeners.delete(listener);
     },
   } as unknown as ApplicationContext["gateway"];
   const provider = createApplicationContextProvider({
@@ -62,6 +68,12 @@ function createPage(
   document.body.append(provider);
   return {
     page,
+    emitGatewayEvent(event, payload) {
+      const frame = { event, payload, type: "event" } as GatewayEventFrame;
+      for (const listener of eventListeners) {
+        listener(frame);
+      }
+    },
     updateGateway(next) {
       snapshot = { ...snapshot, ...next };
       for (const listener of listeners) {
@@ -139,6 +151,64 @@ describe("ApprovalsPage", () => {
   });
 
   it.each([
+    { kind: "exec", event: "exec.approval.resolved" },
+    { kind: "plugin", event: "plugin.approval.resolved" },
+    { kind: "system-agent", event: "openclaw.approval.resolved" },
+  ])("shows a newly resolved $kind approval without leaving the page", async ({ event }) => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [] })
+      .mockResolvedValueOnce({ items: [terminal("newly-resolved", 2_000)] });
+    const { page, emitGatewayEvent } = createPage(request as GatewayBrowserClient["request"]);
+
+    await settle(page);
+    expect(page.querySelector(".approval-history-table")?.textContent).toContain(
+      "No resolved approvals",
+    );
+
+    emitGatewayEvent(event, { id: "newly-resolved", decision: "deny" });
+    await settle(page);
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenLastCalledWith("approval.history", { limit: 50 });
+    expect(page.querySelector(".approval-history-table")?.textContent).toContain(
+      "echo newly-resolved",
+    );
+  });
+
+  it("refreshes the newest history after an approval resolves during pagination", async () => {
+    let resolveOlderPage!: (result: ApprovalHistoryResult) => void;
+    const olderPage = new Promise<ApprovalHistoryResult>((resolve) => {
+      resolveOlderPage = resolve;
+    });
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [terminal("first", 2_000)], nextCursor: "next" })
+      .mockReturnValueOnce(olderPage)
+      .mockResolvedValueOnce({ items: [terminal("newest", 3_000), terminal("first", 2_000)] });
+    const { page, emitGatewayEvent } = createPage(request as GatewayBrowserClient["request"]);
+
+    await settle(page);
+    const loadMore = [...page.querySelectorAll("button")].find((button) =>
+      button.textContent?.includes("Load more"),
+    );
+    loadMore?.click();
+    await settle(page);
+    expect(request).toHaveBeenCalledTimes(2);
+
+    emitGatewayEvent("exec.approval.resolved", { id: "newest", decision: "deny" });
+    expect(request).toHaveBeenCalledTimes(2);
+
+    resolveOlderPage({ items: [terminal("older", 1_000)] });
+    await settle(page);
+    await settle(page);
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request).toHaveBeenLastCalledWith("approval.history", { limit: 50 });
+    expect(page.querySelector(".approval-history-table")?.textContent).toContain("echo newest");
+  });
+
+  it.each([
     { name: "read-only", scopes: ["operator.read"] },
     { name: "write-only", scopes: ["operator.write"] },
   ])("does not request or render approval history for a $name operator", async ({ scopes }) => {
@@ -179,10 +249,13 @@ describe("ApprovalsPage", () => {
       .fn()
       .mockReturnValueOnce(staleHistory)
       .mockResolvedValueOnce({ items: [terminal("current", 2_000)] });
-    const { page, updateGateway } = createPage(request as GatewayBrowserClient["request"], {
-      role: "operator",
-      scopes: ["operator.approvals"],
-    });
+    const { page, emitGatewayEvent, updateGateway } = createPage(
+      request as GatewayBrowserClient["request"],
+      {
+        role: "operator",
+        scopes: ["operator.approvals"],
+      },
+    );
 
     await settle(page);
     expect(request).toHaveBeenCalledOnce();
@@ -192,6 +265,8 @@ describe("ApprovalsPage", () => {
         auth: { role: "operator", scopes: ["operator.read"] },
       } as ApplicationGatewaySnapshot["hello"],
     });
+    await settle(page);
+    emitGatewayEvent("exec.approval.resolved", { id: "inaccessible", decision: "deny" });
     await settle(page);
     expect(request).toHaveBeenCalledOnce();
     expect(page.querySelector(".approval-history-table")).toBeNull();

--- a/ui/src/pages/approvals/approvals-page.ts
+++ b/ui/src/pages/approvals/approvals-page.ts
@@ -18,6 +18,7 @@ import {
   type ApplicationContext,
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
+import { parseApprovalResolvedEvent } from "../../app/exec-approval.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
 import { renderDocsLink, renderSettingsPage } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
@@ -133,6 +134,7 @@ class ApprovalsPage extends OpenClawLightDomElement {
   private gatewaySource: ApplicationContext["gateway"] | null = null;
   private requestGeneration = 0;
   private hasLoaded = false;
+  private historyRefreshPending = false;
   private readonly subscriptions = new SubscriptionsController(this).effect(
     () => this.context?.gateway,
     (gateway) => {
@@ -141,29 +143,55 @@ class ApprovalsPage extends OpenClawLightDomElement {
       // gateway's rows/cursor/error so stale history is not shown and "Load more"
       // cannot append across sources. Mirrors the client-change reset below.
       if (this.gatewaySource !== gateway) {
-        this.requestGeneration += 1;
-        this.loading = false;
-        this.loadingMore = false;
-        this.hasLoaded = false;
-        this.items = [];
-        this.nextCursor = null;
-        this.error = null;
+        this.resetHistory(true);
       }
       this.gatewaySource = gateway;
       this.applyGatewaySnapshot(gateway.snapshot);
-      return gateway.subscribe((snapshot) => {
+      const stopSnapshots = gateway.subscribe((snapshot) => {
         if (this.gatewaySource === gateway && this.context.gateway === gateway) {
           this.applyGatewaySnapshot(snapshot);
         }
       });
+      const stopEvents = gateway.subscribeEvents((event) => {
+        if (
+          this.gatewaySource !== gateway ||
+          this.context.gateway !== gateway ||
+          !this.approvalsAccess ||
+          !readGatewayOperatorAccess(gateway.snapshot).canReviewApprovals ||
+          !parseApprovalResolvedEvent(event.event, event.payload)
+        ) {
+          return;
+        }
+        this.historyRefreshPending = true;
+        if (!this.loading && !this.loadingMore) {
+          void this.loadPage(true);
+        }
+      });
+      return () => {
+        stopSnapshots();
+        stopEvents();
+      };
     },
   );
 
   override disconnectedCallback() {
     this.subscriptions.clear();
-    this.requestGeneration += 1;
+    this.resetHistory(false);
     this.gatewaySource = null;
     super.disconnectedCallback();
+  }
+
+  private resetHistory(clearData: boolean) {
+    this.requestGeneration += 1;
+    this.loading = false;
+    this.loadingMore = false;
+    this.historyRefreshPending = false;
+    if (clearData) {
+      this.hasLoaded = false;
+      this.items = [];
+      this.nextCursor = null;
+      this.error = null;
+    }
   }
 
   private applyGatewaySnapshot(snapshot: ApplicationGatewaySnapshot) {
@@ -175,17 +203,9 @@ class ApprovalsPage extends OpenClawLightDomElement {
     this.approvalsAccess = nextApprovalsAccess;
     if (clientChanged || approvalAccessChanged) {
       this.client = snapshot.client;
-      this.requestGeneration += 1;
-      this.items = [];
-      this.nextCursor = null;
-      this.error = null;
-      this.hasLoaded = false;
-      this.loading = false;
-      this.loadingMore = false;
+      this.resetHistory(true);
     } else if (connectionChanged) {
-      this.requestGeneration += 1;
-      this.loading = false;
-      this.loadingMore = false;
+      this.resetHistory(false);
       if (snapshot.phase === "connected") {
         this.hasLoaded = false;
       }
@@ -221,6 +241,7 @@ class ApprovalsPage extends OpenClawLightDomElement {
       return;
     }
     if (reset) {
+      this.historyRefreshPending = false;
       this.loading = true;
     } else {
       this.loadingMore = true;
@@ -259,6 +280,9 @@ class ApprovalsPage extends OpenClawLightDomElement {
       if (isCurrent()) {
         this.loading = false;
         this.loadingMore = false;
+        if (this.historyRefreshPending) {
+          void this.loadPage(true);
+        }
       }
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators reviewing Settings → Approvals would never see newly resolved approvals appear in the history while the page remained open. The Gateway had already saved the decision and removed its pending notification, but the history misleadingly continued to show no resolved approvals until operators left and reopened the page.

## Why This Change Was Made

Approval resolution events are now recognized once at their shared owner and consumed consistently by both the pending-approval overlay and the durable-history view. History refreshes for command, plugin, and system-agent approvals, coalesces events received during pagination or another request, and preserves the existing `operator.approvals` authorization and Gateway lifecycle boundaries.

## User Impact

Operators immediately see the durable outcome of an approval decision without navigating away, manually reloading, or guessing whether the decision was recorded. Existing pending-approval notifications continue to clear as before, and operators without approval-review access still cannot request or refresh approval history.

## Evidence

- Reproduced through two isolated Chromium tabs against an actual development Gateway and Control UI: a harmless synthetic `echo` approval was requested in one tab and denied in the other; the real Gateway returned the new durable history row and cleared its pending notification, while Settings → Approvals incorrectly remained empty.
- Before/after screenshots are temporarily unavailable: the pre-fix UI was captured locally, but the isolated Gateway and Vite server had to be stopped after the development machine reached critically low free disk space, so collecting a trustworthy post-fix live screenshot would require restarting those services. The focused component regressions below exercise the visible before/after row transition directly.
- Added focused failing-first coverage for all three approval families and for resolutions received during an in-flight paginated history request. Before the production repair, all four new regression cases failed while the nine existing cases passed; afterward all 13 pass.
- Extended the existing access-revocation coverage to prove a resolution event cannot trigger an unauthorized history request.
- Focused proof: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/openclaw-qa-approvals-vitest-cache-c3051d45 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/approvals/approvals-page.test.ts`.
- Production delta: +58/-32 lines (net +26) for canonical event recognition, lifecycle-owned subscription, and coalesced history invalidation; regression coverage: +80/-5 lines.
- Follow-up: the full-screen Settings shell does not render the global pending-approval attention indicator, so a newly requested pending approval can remain invisible while an operator is in Settings. This is a distinct shared-shell ownership issue and is intentionally not bundled into the durable-history repair.
