### PR TITLE
fix(onboard): keep token suppression in guided setup

### DIFF
--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -962,6 +962,7 @@ describe("setupWizardCommand", () => {
     ["--agent-name", { agentName: "robby" }],
     ["--tui", { tui: true }],
     ["--skip-ui", { skipUi: true }],
+    ["--suppress-gateway-token-output", { suppressGatewayTokenOutput: true }],
   ])("keeps %s on guided onboarding", async (_label, opts) => {
     const runtime = makeRuntime();
 

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -426,6 +426,7 @@ const GUIDED_SAFE_ONBOARD_KEYS = new Set([
   "agentName",
   "tui",
   "skipUi",
+  "suppressGatewayTokenOutput",
 ]);
 
 function wantsClassicInteractiveSetup(opts: OnboardOptions): boolean {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who passed the documented `--suppress-gateway-token-output` option were unexpectedly sent into the classic onboarding wizard instead of remaining in guided onboarding.

## Why This Change Was Made

The flag is already parsed by both `openclaw onboard` and `openclaw setup`, and guided onboarding already forwards it to the Control UI browser handoff. The onboarding dispatcher simply omitted it from the set of options that guided setup supports, incorrectly treating it as a classic-only option.

## User Impact

Users can disable the guided Control UI handoff without changing onboarding modes. Existing classic onboarding, explicit `--classic`, `--tui`, `--skip-ui`, and the browser-handoff credential-suppression behavior are unchanged.

## Evidence

- Real isolated interactive CLI before the fix: plain `openclaw onboard` displayed the guided welcome, while `openclaw onboard --suppress-gateway-token-output` incorrectly displayed `OpenClaw setup` from the classic wizard.
- Real isolated interactive CLI after the fix: a built-in in-memory Node loader projected the exact repaired current-source guided allowlist into the installed CLI owner; the same suppression flag then displayed the guided welcome and setup choices. The run stopped at the first risk prompt without opening a browser, issuing credentials, or touching a daemon.
- Actual dispatch-owner allowlist assertion failed on the original source and now passes for the suppression flag plus the existing `--tui` and `--skip-ui` siblings.
- The existing table-driven onboarding-dispatch test gains the documented suppression flag alongside `--tui` and `--skip-ui`.
- Existing browser-handoff coverage already verifies that token suppression does not open a browser or issue credentials.
- Targeted formatting and lint checks pass; independent Codex autoreview found no actionable findings.
- Linked-worktree Vitest cannot collect locally because this checkout intentionally has no physical `node_modules`; exact-head GitHub CI runs the focused dispatch regression.
