### PR TITLE
fix(replies): aborted reply turns stall when delivery settlement starts after cancellation

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
@@ -174,4 +174,27 @@ describe("createReplyTurnLedger", () => {
     dispatcher.markComplete();
     await dispatcher.waitForIdle();
   });
+
+  it("settles immediately when the abort signal already fired", async () => {
+    let releaseDeliver!: () => void;
+    const stalled = new Promise<void>((resolve) => {
+      releaseDeliver = resolve;
+    });
+    const dispatcher = createReplyDispatcher({ deliver: () => stalled });
+    const ledger = createReplyTurnLedger(dispatcher);
+    ledger.sendQueued("final", { text: "hello" });
+    const abortController = new AbortController();
+    abortController.abort();
+    const settled = ledger.settleQueued(abortController.signal);
+
+    try {
+      await expect(Promise.race([settled, Promise.resolve("pending")])).resolves.toBe("aborted");
+      expect(ledger.hasVisibleDelivery()).toBe(false);
+    } finally {
+      releaseDeliver();
+      dispatcher.markComplete();
+      await dispatcher.waitForIdle();
+      await settled;
+    }
+  });
 });

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.ts
@@ -101,6 +101,9 @@ export function createReplyTurnLedger(dispatcher: ReplyDispatcher): ReplyTurnLed
       }
     },
     async settleQueued(abortSignal) {
+      if (abortSignal?.aborted) {
+        return "aborted";
+      }
       let timedOut = false;
       let timer: ReturnType<typeof setTimeout> | undefined;
       const deadline = new Promise<void>((resolve) => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

Closes #126581

## What Problem This Solves

Fixes an issue where aborted reply turns with a stalled delivery would remain in finalization for up to 30 seconds when cancellation happened before reply-turn settlement began.

## Why This Change Was Made

Abort events are not replayed to listeners registered after cancellation. Check the existing abort state at the reply-turn ledger owner before allocating its deadline or listener and immediately return the same `aborted` result that the old path eventually produced after its 30-second timeout. The canonical dispatcher idle waiter already uses this owner-boundary pattern.

The finalizer runs core fallback and exposes channel recovery eligibility only for a `settled` result, so returning the existing `aborted` result sooner cannot widen fallback, replay, visibility, recipient delivery, or double-send. The outer dispatcher continues to drain deliveries and run its existing cleanup lifecycle unchanged.

## User Impact

Cancelled reply turns finish their own settlement promptly instead of waiting on the 30-second deadline. Operators get faster finalization and idle cleanup with no change to cancellation outcomes, fallback policy, replay ownership, configuration, protocol, persistence, or plugin contracts.

## Evidence

- Authentic owner-boundary regression uses the real reply dispatcher and a genuinely stalled delivery, aborts before settlement, and races settlement against an already-resolved `pending` sentinel without advancing the 30-second deadline. Before: `Expected: "aborted"; Received: "pending"`. After: the owner suite passes all 15 tests and preserves after-registration abort coverage.
- Focused owner, ACP cancellation, canonical idle-waiter, Telegram fallback, and Feishu broadcast/replay proof: `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts src/auto-reply/reply/reply-flow.test.ts extensions/telegram/src/bot-message-dispatch.fallback-topic-media.test.ts extensions/feishu/src/bot.broadcast.test.ts` — 454 tests passed across six files and three Vitest shards.
- Actual changed gate: `node scripts/check-changed.mjs -- src/auto-reply/reply/dispatch-from-config.turn-ledger.ts src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts` — passed all core/coreTests format, production/test typecheck, lint, architecture, schema, storage, dependency, import-cycle, and ownership guards.
- Targeted formatting and `git diff --check` pass. Production LOC: +3/-0; tests: +23/-0. The production growth is the necessary early owner precheck before deadline/listener allocation; removing the existing post-race check or hiding the guard would weaken cancellation ordering or clarity.
- Fresh P1 Codex-backed structured autoreview: no accepted/actionable findings. Separate independent read-only adversarial review: no findings; fallback, replay, double-send, visibility, operation cleanup, and outer dispatcher-drain invariants verified directly.
- Direct authenticated Telegram/Feishu live traffic is not applicable: this is a deterministic provider-independent settlement-ordering defect proved with the real dispatcher plus existing channel-boundary tests; no channel transport or external API behavior changed.
- Regression provenance: #124773 (`eb38d5e4863a66d881c3fc1aa785ff53898088e7`). Risk: low; existing outcome and all downstream contracts unchanged.
- AI-assisted: yes
