### PR TITLE
fix(test): use activated service worker build signal

### DIFF
--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -458,22 +458,7 @@ describe("Control UI service-worker production update E2E", () => {
       await expect
         .poll(async () => (await gateway.getRequests("connect")).at(-1)?.params)
         .toMatchObject({ client: { buildId: buildB } });
-      await page.waitForFunction((expectedBuildId) => {
-        const controller = navigator.serviceWorker.controller;
-        return (
-          controller?.state === "activated" &&
-          new URL(controller.scriptURL).searchParams.get("v") === expectedBuildId
-        );
-      }, buildB);
-      expect(
-        await page.evaluate(() => {
-          const controller = navigator.serviceWorker.controller;
-          return {
-            buildId: controller ? new URL(controller.scriptURL).searchParams.get("v") : null,
-            state: controller?.state ?? null,
-          };
-        }),
-      ).toEqual({ buildId: buildB, state: "activated" });
+      await expect.poll(() => readWorkerUpdateVersions(page)).toContain(buildB);
 
       const terminal = page.locator("openclaw-terminal-panel[embedded]");
       await terminal.waitFor({ state: "attached" });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where otherwise healthy pull requests and `main` fail Control UI browser CI when a reconnect correctly installs an updated Service Worker under its existing registration URL.

## Why This Change Was Made

Commit f289685bf311d32205a92bb762c10775c30d64ed (#126538) replaced this test's working `readWorkerUpdateVersions(page)` assertion with a wait for the controlling worker's `scriptURL` query to equal the new build ID. The browser API intentionally fetches replacement bytes from the existing registration script URL, and `ServiceWorker.scriptURL` remains readonly. An activated build-B worker can therefore correctly retain the old build-A URL forever.

The production worker embeds its actual build version and emits `sw-updated` only after `clients.claim()` completes. Restoring that already-existing signal checks the real activated build instead of an unrelated immutable URL. The change removes 15 net lines of test code and changes no production code.

## User Impact

Maintainers and contributors regain meaningful Control UI browser CI without changing shipped behavior. The existing activated-controller, Gateway build identity, restored-terminal, new-asset SHA-256, and updated-cache shell assertions remain intact.

## Evidence

The pre-fix failure is demonstrated independently in these exact hosted jobs:

- https://github.com/openclaw/openclaw/actions/runs/32342056919/job/96343165291
- https://github.com/openclaw/openclaw/actions/runs/32343003677/job/96345891614

Both fail `ui/src/e2e/service-worker-update.e2e.test.ts:461` with `page.waitForFunction: Timeout 30000ms exceeded` while waiting for the old worker URL to become the new build ID.

- `node_modules/.bin/oxfmt --check ui/src/e2e/service-worker-update.e2e.test.ts`
- `node_modules/.bin/oxlint --deny-warnings ui/src/e2e/service-worker-update.e2e.test.ts`
- `git diff --check`
- `node scripts/check-changed.mjs --dry-run -- ui/src/e2e/service-worker-update.e2e.test.ts`
- Independent source/dependency-contract review: approved, no actionable findings.
- Fresh isolated source-only Codex autoreview: clean.
- The heavyweight local browser E2E lane was not run because its execution was explicitly declined in this environment; this PR's exact-head hosted browser CI is the required post-fix behavioral proof.
