### PR TITLE
fix(release): accept trusted Codex scan layouts

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -27,8 +27,6 @@ const execFileAsync = promisify(execFile);
 const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/acpx:dangerous-exec:src/codex-auth-bridge.ts", 1],
   ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs", 1],
-  ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/sandbox-child.ts", 1],
-  ["@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/doctor.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts", 1],
@@ -41,6 +39,22 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/signal:dangerous-exec:src/daemon.ts", 1],
   ["@openclaw/voice-call:dangerous-exec:src/tunnel.ts", 1],
 ]);
+
+const REVIEWED_CODEX_LEGACY_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+  ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/http.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/processes.ts", 1],
+]);
+const REVIEWED_CODEX_CURRENT_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+  ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/sandbox-child.ts", 1],
+  ["@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts", 1],
+]);
+const REVIEWED_CODEX_SOURCE_LAYOUTS: ReadonlyArray<ReadonlyMap<string, number>> = [
+  REVIEWED_CODEX_LEGACY_SOURCE_CRITICAL_FINDING_COUNTS,
+  REVIEWED_CODEX_CURRENT_SOURCE_CRITICAL_FINDING_COUNTS,
+];
+const REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>(
+  REVIEWED_CODEX_SOURCE_LAYOUTS.flatMap((layout) => [...layout]),
+);
 
 // Generated chunks can contain multiple reviewed execution sites. Counts are
 // part of the contract so an added or missing site fails the release scan.
@@ -111,6 +125,53 @@ function normalizePackedFindingPath(packedPath: string): string {
     }
   }
   return packedPath;
+}
+
+function expandReviewedFindingCounts(counts: ReadonlyMap<string, number>): string[] {
+  return [...counts].flatMap(([key, count]) => Array.from({ length: count }, () => key));
+}
+
+function resolveReviewedCodexSourceLayout(
+  reviewedCriticalFindings: readonly string[],
+): string[] | undefined {
+  const observedSourceFindings = reviewedCriticalFindings
+    .filter((key) => REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.has(key))
+    .toSorted();
+  return REVIEWED_CODEX_SOURCE_LAYOUTS.map(expandReviewedFindingCounts).find((layout) => {
+    const expectedSourceFindings = layout.toSorted();
+    return (
+      expectedSourceFindings.length === observedSourceFindings.length &&
+      expectedSourceFindings.every((key, index) => key === observedSourceFindings[index])
+    );
+  });
+}
+
+function requiredReviewedFindingsForPackage(
+  packageName: string,
+  reviewedCriticalFindings: readonly string[],
+): string[] {
+  const commonFindings = [...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS].flatMap(
+    ([key, count]) =>
+      key.startsWith(`${packageName}:`) ? Array.from({ length: count }, () => key) : [],
+  );
+  if (packageName !== "@openclaw/codex") {
+    return commonFindings;
+  }
+  const sourceLayout = resolveReviewedCodexSourceLayout(reviewedCriticalFindings);
+  if (!sourceLayout) {
+    throw new Error(
+      "@openclaw/codex: reviewed source findings must match exactly one complete known layout.",
+    );
+  }
+  return [...commonFindings, ...sourceLayout];
+}
+
+function isReviewedPublishableCriticalFinding(key: string): boolean {
+  return (
+    REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.has(key) ||
+    REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.has(key) ||
+    OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS.has(key)
+  );
 }
 
 function expectedOptionalReviewedFindingsForPackedPath(
@@ -261,10 +322,7 @@ async function scanPublishablePluginPackage(plugin: PublishablePluginPackage): P
     }
     const packedPath = normalizePackedFindingPath(toRepoPath(relative(stageDir, finding.file)));
     const key = `${plugin.packageName}:${finding.ruleId}:${packedPath}`;
-    if (
-      REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.has(key) ||
-      OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS.has(key)
-    ) {
+    if (isReviewedPublishableCriticalFinding(key)) {
       reviewedCriticalFindings.push(key);
       continue;
     }
@@ -358,6 +416,63 @@ describe("publishable plugin npm package install security scan", () => {
     ).toEqual([]);
   });
 
+  it("accepts either complete reviewed Codex source layout", () => {
+    const legacyLayout = expandReviewedFindingCounts(
+      REVIEWED_CODEX_LEGACY_SOURCE_CRITICAL_FINDING_COUNTS,
+    );
+    const currentLayout = expandReviewedFindingCounts(
+      REVIEWED_CODEX_CURRENT_SOURCE_CRITICAL_FINDING_COUNTS,
+    );
+
+    expect(resolveReviewedCodexSourceLayout(legacyLayout)).toEqual(legacyLayout);
+    expect(resolveReviewedCodexSourceLayout(currentLayout)).toEqual(currentLayout);
+  });
+
+  const invalidCodexSourceLayouts: Array<[name: string, findings: string[]]> = [
+    ["absent", []],
+    [
+      "partial legacy",
+      ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/http.ts"],
+    ],
+    [
+      "partial current",
+      ["@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/sandbox-child.ts"],
+    ],
+    [
+      "mixed",
+      [
+        "@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/http.ts",
+        "@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts",
+      ],
+    ],
+    [
+      "both complete",
+      [
+        ...expandReviewedFindingCounts(REVIEWED_CODEX_LEGACY_SOURCE_CRITICAL_FINDING_COUNTS),
+        ...expandReviewedFindingCounts(REVIEWED_CODEX_CURRENT_SOURCE_CRITICAL_FINDING_COUNTS),
+      ],
+    ],
+    [
+      "duplicate occurrence",
+      [
+        ...expandReviewedFindingCounts(REVIEWED_CODEX_CURRENT_SOURCE_CRITICAL_FINDING_COUNTS),
+        "@openclaw/codex:dangerous-exec:src/app-server/transport-process-containment.ts",
+      ],
+    ],
+  ];
+
+  test.each(invalidCodexSourceLayouts)("rejects a %s Codex source layout", (_name, findings) => {
+    expect(resolveReviewedCodexSourceLayout(findings)).toBeUndefined();
+  });
+
+  it("does not review an unknown relocated Codex source finding", () => {
+    const relocatedFinding =
+      "@openclaw/codex:dangerous-exec:src/app-server/sandbox-exec-server/relocated.ts";
+
+    expect(isReviewedPublishableCriticalFinding(relocatedFinding)).toBe(false);
+    expect(resolveReviewedCodexSourceLayout([relocatedFinding])).toBeUndefined();
+  });
+
   test.concurrent.each(publishablePluginPackages)(
     "keeps $packageName files clear of unexpected critical hits",
     async (plugin) => {
@@ -365,14 +480,12 @@ describe("publishable plugin npm package install security scan", () => {
       if (!result) {
         throw new Error(`Missing package scan result for ${plugin.packageName}`);
       }
+      expect(result.unexpectedCriticalFindings.toSorted()).toStrictEqual([]);
       const expectedReviewedCriticalFindings = [
-        ...[...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS].flatMap(([key, count]) =>
-          key.startsWith(`${plugin.packageName}:`) ? Array.from({ length: count }, () => key) : [],
-        ),
+        ...requiredReviewedFindingsForPackage(plugin.packageName, result.reviewedCriticalFindings),
         ...result.expectedReviewedCriticalFindings,
       ];
 
-      expect(result.unexpectedCriticalFindings.toSorted()).toStrictEqual([]);
       expect(result.reviewedCriticalFindings.toSorted()).toEqual(
         expectedReviewedCriticalFindings.toSorted(),
       );


### PR DESCRIPTION
## What Problem This Solves

Resolves a release qualification failure where the trusted publishable-plugin security inventory rejected the frozen beta candidate's reviewed Codex execution sites after `main` moved those sites into a new source layout.

## Why This Change Was Made

The scan now recognizes the complete legacy Codex layout or the complete current layout as mutually exclusive reviewed alternatives. It still requires exact occurrence counts for the selected layout, all common required findings, and optional packed `dist` findings; partial, mixed, absent, duplicated, or unknown relocated layouts fail closed.

This is test-owned release tooling only. It does not change production code, the candidate branch, release workflows, package metadata, or changelog.

## User Impact

Maintainers can qualify the frozen beta candidate with current trusted tooling without weakening detection of new or relocated critical execution sites.

## Evidence

- `git diff --check`
- `oxfmt src/plugins/npm-install-security-scan.release.test.ts`
- Focused helper coverage accepts both complete layouts and rejects partial legacy, partial current, mixed, both-complete, duplicate, absent, and unknown relocated findings.
- Production LOC delta: `0`
- Local Vitest was not run because this linked worktree intentionally has no dependency symlink; exact-head hosted CI is the test proof.
- Direct upstream Codex contract check: `codex-rs/app-server/src/main.rs:25-32,95-105` and `codex-rs/app-server-transport/src/transport/stdio.rs:24-89`.

AI-assisted: yes.


## Exact frozen-candidate proof

- Full Release Validation slice: https://github.com/openclaw/openclaw/actions/runs/32345691337 (`success`)
- Plugin Prerelease child: https://github.com/openclaw/openclaw/actions/runs/32346841773 (`success`, 39 jobs)
- Trusted tooling SHA: `a69689495059972b1888a4d3b2a8df670151e9b0`
- Frozen candidate SHA: `9a6b1d63ff941d132a4bb7bbf3274e3004f83699`
- Trusted overlay scan: `npm-install-security-scan.release.test.ts` passed all 102 tests; aggregate agentic-plugin shard passed 3,716 tests with 1 skipped.
- Manifest artifact: `full-release-validation-32345691337` (artifact `9398847199`), `releaseProfile=beta`, `rerunGroup=plugin-prerelease`, `runReleaseSoak=false`, child `32346841773`.
- Direct Codex contract inspection: `../codex/codex-rs/exec-server/src/protocol.rs:14`, `../codex/codex-rs/exec-server/src/connection.rs:107`, `../codex/codex-rs/exec-server/src/client_transport.rs:292`.

This resolves the exact-candidate and dependency-contract proof requested by the exact-head ClawSweeper review. The PR head is unchanged.
