### PR TITLE
fix(beam): stop mirroring after service shutdown

### DIFF
--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -587,7 +587,7 @@ describe("createBeamMirrorRunner", () => {
     }
   });
 
-  it("waits for a paused transcript read and does not upload after stop", async () => {
+  it("stops before a paused transcript read settles without resuming mirror work", async () => {
     const readStarted = createDeferred<void>();
     const releaseRead = createDeferred<void>();
     const list = vi.fn();
@@ -624,11 +624,11 @@ describe("createBeamMirrorRunner", () => {
       const stop = firstStop.then(() => {
         stopSettled = true;
       });
-      await Promise.resolve();
-      expect(stopSettled).toBe(false);
+      await vi.waitFor(() => expect(stopSettled).toBe(true), { timeout: 100 });
+      await tick;
 
       releaseRead.resolve();
-      await Promise.all([tick, stop]);
+      await Promise.all([read.mock.results[0]?.value, stop]);
 
       expect(read).toHaveBeenCalledOnce();
       expect(sent).toEqual([]);
@@ -911,17 +911,18 @@ describe("createBeamMirrorRunner", () => {
 });
 
 describe("createBeamMirrorService", () => {
-  it("does not read or upload after stop while catalog listing is paused", async () => {
+  it("stops before catalog listing settles without starting reads or uploads", async () => {
     const listingStarted = createDeferred<void>();
     const releaseListing = createDeferred<void>();
+    const list = vi.fn(async () => {
+      listingStarted.resolve();
+      await releaseListing.promise;
+    });
     const read = vi.fn();
     const catalog = fakeCatalog({
       id: "claude",
       sessions: [{ threadId: "t1", recencyAt: Date.now() }],
-      onList: async () => {
-        listingStarted.resolve();
-        await releaseListing.promise;
-      },
+      onList: list,
       onRead: read,
     });
     const listCatalogs = vi
@@ -932,10 +933,7 @@ describe("createBeamMirrorService", () => {
       finalUrl: "https://team.example/api/v1/beam/sessions",
       release: vi.fn(async () => undefined),
     });
-    let config = mirrorConfig();
-    const service = createBeamMirrorService({
-      runtime: { config: { current: () => config } } as unknown as PluginRuntime,
-    });
+    const service = createBeamMirrorService({ runtime: fakeRuntime(mirrorConfig()) });
 
     try {
       service.start({ logger: silentLogger });
@@ -945,18 +943,15 @@ describe("createBeamMirrorService", () => {
       const stop = service.stop().then(() => {
         stopSettled = true;
       });
-      await Promise.resolve();
-      const stopSettledWhileListing = stopSettled;
-      config = {};
+      await vi.waitFor(() => expect(stopSettled).toBe(true), { timeout: 100 });
+      expect(read).not.toHaveBeenCalled();
+      expect(upload).not.toHaveBeenCalled();
+
       releaseListing.resolve();
-      if (stopSettledWhileListing) {
-        await vi.waitFor(() => expect(upload).toHaveBeenCalledOnce());
-      }
-      await stop;
+      await Promise.all([list.mock.results[0]?.value, stop]);
 
       expect(read).not.toHaveBeenCalled();
       expect(upload).not.toHaveBeenCalled();
-      expect(stopSettledWhileListing).toBe(false);
     } finally {
       releaseListing.resolve();
       upload.mockRestore();

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -618,17 +618,12 @@ describe("createBeamMirrorRunner", () => {
     try {
       const tick = runner.tick();
       await readStarted.promise;
-      let stopSettled = false;
       const firstStop = runner.stop();
       expect(runner.stop()).toBe(firstStop);
-      const stop = firstStop.then(() => {
-        stopSettled = true;
-      });
-      await vi.waitFor(() => expect(stopSettled).toBe(true), { timeout: 100 });
-      await tick;
+      await Promise.all([firstStop, tick]);
 
       releaseRead.resolve();
-      await Promise.all([read.mock.results[0]?.value, stop]);
+      await read.mock.results[0]?.value;
 
       expect(read).toHaveBeenCalledOnce();
       expect(sent).toEqual([]);
@@ -939,16 +934,12 @@ describe("createBeamMirrorService", () => {
       service.start({ logger: silentLogger });
       await listingStarted.promise;
 
-      let stopSettled = false;
-      const stop = service.stop().then(() => {
-        stopSettled = true;
-      });
-      await vi.waitFor(() => expect(stopSettled).toBe(true), { timeout: 100 });
+      await service.stop();
       expect(read).not.toHaveBeenCalled();
       expect(upload).not.toHaveBeenCalled();
 
       releaseListing.resolve();
-      await Promise.all([list.mock.results[0]?.value, stop]);
+      await list.mock.results[0]?.value;
 
       expect(read).not.toHaveBeenCalled();
       expect(upload).not.toHaveBeenCalled();

--- a/extensions/beam/src/mirror.test.ts
+++ b/extensions/beam/src/mirror.test.ts
@@ -1,10 +1,12 @@
 import { createServer, type IncomingMessage, type Server } from "node:http";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type {
   SessionCatalogHost,
   SessionCatalogTranscriptItem,
   SessionsCatalogReadResult,
 } from "openclaw/plugin-sdk/session-catalog";
+import * as sessionCatalogRuntime from "openclaw/plugin-sdk/session-catalog-runtime";
 import type { ActiveSessionCatalog } from "openclaw/plugin-sdk/session-catalog-runtime";
 import * as ssrfRuntime from "openclaw/plugin-sdk/ssrf-runtime";
 import { describe, expect, it, vi } from "vitest";
@@ -12,11 +14,18 @@ import {
   beamMirrorId,
   buildBeamMirrorItems,
   createBeamMirrorRunner,
+  createBeamMirrorService,
   fitBeamMirrorUpload,
   parseBeamMirrorConfig,
   type BeamMirrorUpload,
 } from "./mirror.js";
 import { BEAM_MAX_ITEMS, parseBeamUpload } from "./types.js";
+
+vi.mock("openclaw/plugin-sdk/session-catalog-runtime", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/session-catalog-runtime")>();
+  return { ...actual, listActiveSessionCatalogs: vi.fn(actual.listActiveSessionCatalogs) };
+});
 
 const NOW = Date.parse("2026-07-27T12:00:00.000Z");
 
@@ -44,7 +53,8 @@ function fakeCatalog(params: {
   sessions: Array<{ threadId: string; name?: string; recencyAt: number }>;
   items?: SessionCatalogTranscriptItem[];
   hostKind?: string;
-  onRead?: (threadId: string) => void;
+  onList?: () => unknown;
+  onRead?: (threadId: string) => unknown;
 }): ActiveSessionCatalog {
   const host: SessionCatalogHost = {
     hostId: "gateway:local",
@@ -67,9 +77,12 @@ function fakeCatalog(params: {
     pluginId: params.id,
     id: params.id,
     label: params.id,
-    list: async () => [host],
+    list: async () => {
+      await params.onList?.();
+      return [host];
+    },
     read: async ({ threadId }): Promise<SessionsCatalogReadResult> => {
-      params.onRead?.(threadId);
+      await params.onRead?.(threadId);
       return {
         hostId: "gateway:local",
         label: "Local",
@@ -574,6 +587,209 @@ describe("createBeamMirrorRunner", () => {
     }
   });
 
+  it("waits for a paused transcript read and does not upload after stop", async () => {
+    const readStarted = createDeferred<void>();
+    const releaseRead = createDeferred<void>();
+    const list = vi.fn();
+    const read = vi.fn(async () => {
+      readStarted.resolve();
+      await releaseRead.promise;
+    });
+    const sent: SentRequest[] = [];
+    const warnings: string[] = [];
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: { warn: (message) => warnings.push(message), info: () => {} },
+      fetchFn: captureFetch(sent),
+      now: () => NOW,
+      listCatalogs: () => [
+        fakeCatalog({
+          id: "claude",
+          sessions: [
+            { threadId: "t1", recencyAt: NOW },
+            { threadId: "t2", recencyAt: NOW },
+          ],
+          onList: list,
+          onRead: read,
+        }),
+      ],
+    });
+
+    try {
+      const tick = runner.tick();
+      await readStarted.promise;
+      let stopSettled = false;
+      const firstStop = runner.stop();
+      expect(runner.stop()).toBe(firstStop);
+      const stop = firstStop.then(() => {
+        stopSettled = true;
+      });
+      await Promise.resolve();
+      expect(stopSettled).toBe(false);
+
+      releaseRead.resolve();
+      await Promise.all([tick, stop]);
+
+      expect(read).toHaveBeenCalledOnce();
+      expect(sent).toEqual([]);
+      expect(warnings).toEqual([]);
+      await runner.tick();
+      expect(list).toHaveBeenCalledOnce();
+    } finally {
+      releaseRead.resolve();
+      await runner.stop();
+    }
+  });
+
+  it("joins overlapping ticks into one catalog and upload path", async () => {
+    const listStarted = createDeferred<void>();
+    const releaseList = createDeferred<void>();
+    const list = vi.fn(async () => {
+      listStarted.resolve();
+      await releaseList.promise;
+    });
+    const read = vi.fn();
+    const sent: SentRequest[] = [];
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: silentLogger,
+      fetchFn: captureFetch(sent),
+      now: () => NOW,
+      listCatalogs: () => [
+        fakeCatalog({
+          id: "claude",
+          sessions: [{ threadId: "t1", recencyAt: NOW }],
+          onList: list,
+          onRead: read,
+        }),
+      ],
+    });
+
+    try {
+      const first = runner.tick();
+      await listStarted.promise;
+      const second = runner.tick();
+      await Promise.resolve();
+      expect(list).toHaveBeenCalledOnce();
+
+      releaseList.resolve();
+      await Promise.all([first, second]);
+
+      expect(read).toHaveBeenCalledOnce();
+      expect(sent).toHaveLength(1);
+    } finally {
+      releaseList.resolve();
+      await runner.stop();
+    }
+  });
+
+  it("waits for guarded response cleanup after lifecycle abort without warning", async () => {
+    const fetchStarted = createDeferred<void>();
+    const cleanupStarted = createDeferred<void>();
+    const releaseCleanup = createDeferred<void>();
+    const cancel = vi.fn();
+    const release = vi.fn(async () => {
+      cleanupStarted.resolve();
+      await releaseCleanup.promise;
+    });
+    const warnings: string[] = [];
+    let signal: AbortSignal | undefined;
+    const guardedFetch = vi
+      .spyOn(ssrfRuntime, "fetchWithSsrFGuard")
+      .mockImplementation(async (options) => {
+        const abortSignal = options.signal;
+        fetchStarted.resolve();
+        if (!abortSignal) {
+          throw new Error("guarded fetch did not receive the runner abort signal");
+        }
+        signal = abortSignal;
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return {
+          response: new Response(new ReadableStream<Uint8Array>({ cancel }), { status: 200 }),
+          finalUrl: options.url,
+          release,
+        };
+      });
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig()),
+      logger: { warn: (message) => warnings.push(message), info: () => {} },
+      now: () => NOW,
+      listCatalogs: () => [
+        fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW }] }),
+      ],
+    });
+
+    try {
+      const tick = runner.tick();
+      await fetchStarted.promise;
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(false);
+
+      let stopSettled = false;
+      const stop = runner.stop().then(() => {
+        stopSettled = true;
+      });
+      expect(signal?.aborted).toBe(true);
+      await cleanupStarted.promise;
+      await Promise.resolve();
+      expect(stopSettled).toBe(false);
+
+      releaseCleanup.resolve();
+      await Promise.all([tick, stop]);
+
+      expect(cancel).toHaveBeenCalledOnce();
+      expect(release).toHaveBeenCalledOnce();
+      expect(warnings).toEqual([]);
+    } finally {
+      releaseCleanup.resolve();
+      guardedFetch.mockRestore();
+      await runner.stop();
+    }
+  });
+
+  it("aborts a stalled loopback transport on stop", async () => {
+    const requestStarted = createDeferred<void>();
+    const requestClosed = createDeferred<void>();
+    const server = createServer((req) => {
+      requestStarted.resolve();
+      req.socket.once("close", requestClosed.resolve);
+    });
+    const origin = await listenOnLoopback(server);
+    const warnings: string[] = [];
+    let signal: AbortSignal | undefined;
+    const fetchFn = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      signal = init?.signal ?? undefined;
+      return fetch(input, init);
+    }) as unknown as typeof fetch;
+    const runner = createBeamMirrorRunner({
+      runtime: fakeRuntime(mirrorConfig({ endpoint: `${origin}/beam` })),
+      logger: { warn: (message) => warnings.push(message), info: () => {} },
+      fetchFn,
+      now: () => NOW,
+      listCatalogs: () => [
+        fakeCatalog({ id: "claude", sessions: [{ threadId: "t1", recencyAt: NOW }] }),
+      ],
+    });
+
+    try {
+      const tick = runner.tick();
+      await requestStarted.promise;
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(false);
+
+      const stop = runner.stop();
+      expect(signal?.aborted).toBe(true);
+      await Promise.all([requestClosed.promise, tick, stop]);
+
+      expect(warnings).toEqual([]);
+    } finally {
+      await runner.stop();
+      await closeTestServer(server);
+    }
+  });
+
   it("ignores idle sessions, node hosts, the beam catalog, and unlisted catalogs", async () => {
     const sent: SentRequest[] = [];
     const idle = fakeCatalog({
@@ -691,5 +907,61 @@ describe("createBeamMirrorRunner", () => {
     });
     await runner.tick();
     expect(sent).toHaveLength(0);
+  });
+});
+
+describe("createBeamMirrorService", () => {
+  it("does not read or upload after stop while catalog listing is paused", async () => {
+    const listingStarted = createDeferred<void>();
+    const releaseListing = createDeferred<void>();
+    const read = vi.fn();
+    const catalog = fakeCatalog({
+      id: "claude",
+      sessions: [{ threadId: "t1", recencyAt: Date.now() }],
+      onList: async () => {
+        listingStarted.resolve();
+        await releaseListing.promise;
+      },
+      onRead: read,
+    });
+    const listCatalogs = vi
+      .spyOn(sessionCatalogRuntime, "listActiveSessionCatalogs")
+      .mockReturnValue([catalog]);
+    const upload = vi.spyOn(ssrfRuntime, "fetchWithSsrFGuard").mockResolvedValue({
+      response: new Response("{}", { status: 200 }),
+      finalUrl: "https://team.example/api/v1/beam/sessions",
+      release: vi.fn(async () => undefined),
+    });
+    let config = mirrorConfig();
+    const service = createBeamMirrorService({
+      runtime: { config: { current: () => config } } as unknown as PluginRuntime,
+    });
+
+    try {
+      service.start({ logger: silentLogger });
+      await listingStarted.promise;
+
+      let stopSettled = false;
+      const stop = service.stop().then(() => {
+        stopSettled = true;
+      });
+      await Promise.resolve();
+      const stopSettledWhileListing = stopSettled;
+      config = {};
+      releaseListing.resolve();
+      if (stopSettledWhileListing) {
+        await vi.waitFor(() => expect(upload).toHaveBeenCalledOnce());
+      }
+      await stop;
+
+      expect(read).not.toHaveBeenCalled();
+      expect(upload).not.toHaveBeenCalled();
+      expect(stopSettledWhileListing).toBe(false);
+    } finally {
+      releaseListing.resolve();
+      upload.mockRestore();
+      listCatalogs.mockRestore();
+      await service.stop();
+    }
   });
 });

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -284,18 +284,26 @@ export function createBeamMirrorRunner(params: {
   let redirectBlockedEndpoint: string | undefined;
   let activeTick: Promise<void> | undefined;
   let stopPromise: Promise<void> | undefined;
+  const stopError = new Error("Beam mirror stopped");
 
-  const raceCatalog = <T>(operation: Promise<T>): Promise<T> =>
-    new Promise((resolve, reject) => {
-      const abort = () => reject(new Error("Beam mirror stopped"));
-      signal.addEventListener("abort", abort, { once: true });
-      void operation
-        .then(resolve, reject)
-        .finally(() => signal.removeEventListener("abort", abort));
+  // Catalog work cannot be cancelled, so detach its late result after stop.
+  // Guarded transport cleanup remains joined to the active scan in upload().
+  const raceCatalog = async <T>(operation: Promise<T>): Promise<T> => {
+    let rejectAbort: (error: Error) => void;
+    const aborted = new Promise<never>((_, reject) => {
+      rejectAbort = reject;
+    });
+    const abort = () => rejectAbort(stopError);
+    signal.addEventListener("abort", abort, { once: true });
+    try {
       if (signal.aborted) {
         abort();
       }
-    });
+      return await Promise.race([operation, aborted]);
+    } finally {
+      signal.removeEventListener("abort", abort);
+    }
+  };
 
   const warnThrottled = (message: string) => {
     if (now() - lastWarnAt >= MIRROR_WARN_INTERVAL_MS) {

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -285,6 +285,18 @@ export function createBeamMirrorRunner(params: {
   let activeTick: Promise<void> | undefined;
   let stopPromise: Promise<void> | undefined;
 
+  const raceCatalog = <T>(operation: Promise<T>): Promise<T> =>
+    new Promise((resolve, reject) => {
+      const abort = () => reject(new Error("Beam mirror stopped"));
+      signal.addEventListener("abort", abort, { once: true });
+      void operation
+        .then(resolve, reject)
+        .finally(() => signal.removeEventListener("abort", abort));
+      if (signal.aborted) {
+        abort();
+      }
+    });
+
   const warnThrottled = (message: string) => {
     if (now() - lastWarnAt >= MIRROR_WARN_INTERVAL_MS) {
       lastWarnAt = now();
@@ -360,12 +372,14 @@ export function createBeamMirrorRunner(params: {
     candidate: BeamMirrorCandidate,
     completed: boolean,
   ): Promise<BeamMirrorUpload> => {
-    const transcript = await catalog.read({
-      agentId,
-      hostId: candidate.hostId,
-      threadId: candidate.threadId,
-      limit: MIRROR_READ_LIMIT,
-    });
+    const transcript = await raceCatalog(
+      catalog.read({
+        agentId,
+        hostId: candidate.hostId,
+        threadId: candidate.threadId,
+        limit: MIRROR_READ_LIMIT,
+      }),
+    );
     signal.throwIfAborted();
     const reduced = buildBeamMirrorItems(transcript.items);
     const items = reduced.items.length
@@ -441,7 +455,9 @@ export function createBeamMirrorRunner(params: {
       for (const catalog of catalogs) {
         signal.throwIfAborted();
         try {
-          const hosts = await catalog.list({ agentId, limitPerHost: MIRROR_LIST_LIMIT });
+          const hosts = await raceCatalog(
+            catalog.list({ agentId, limitPerHost: MIRROR_LIST_LIMIT }),
+          );
           signal.throwIfAborted();
           candidates.push(...hostCandidates(catalog.id, hosts, activeSinceMs));
         } catch (error) {

--- a/extensions/beam/src/mirror.ts
+++ b/extensions/beam/src/mirror.ts
@@ -263,6 +263,7 @@ type TrackedMirrorSession = {
 
 type BeamMirrorRunner = {
   tick: () => Promise<void>;
+  stop: () => Promise<void>;
 };
 
 export function createBeamMirrorRunner(params: {
@@ -277,9 +278,12 @@ export function createBeamMirrorRunner(params: {
   const now = params.now ?? Date.now;
   const listCatalogs = params.listCatalogs ?? listActiveSessionCatalogs;
   const tracked = new Map<string, TrackedMirrorSession>();
+  const controller = new AbortController();
+  const { signal } = controller;
   let lastWarnAt = 0;
   let redirectBlockedEndpoint: string | undefined;
-  let running = false;
+  let activeTick: Promise<void> | undefined;
+  let stopPromise: Promise<void> | undefined;
 
   const warnThrottled = (message: string) => {
     if (now() - lastWarnAt >= MIRROR_WARN_INTERVAL_MS) {
@@ -293,7 +297,7 @@ export function createBeamMirrorRunner(params: {
     token: string | undefined,
     payload: BeamMirrorUpload,
   ): Promise<boolean> => {
-    if (redirectBlockedEndpoint === endpoint) {
+    if (signal.aborted || redirectBlockedEndpoint === endpoint) {
       return false;
     }
     redirectBlockedEndpoint = undefined;
@@ -304,6 +308,7 @@ export function createBeamMirrorRunner(params: {
         url: endpoint,
         fetchImpl: params.fetchFn,
         timeoutMs: MIRROR_UPLOAD_TIMEOUT_MS,
+        signal,
         policy: ssrfPolicyFromHttpBaseUrlAllowedOrigin(endpoint),
         auditContext: "beam.mirror_upload",
         // Only the configured receiver can acknowledge delivery. Following a redirect
@@ -319,6 +324,7 @@ export function createBeamMirrorRunner(params: {
         },
       });
     } catch (error) {
+      signal.throwIfAborted();
       if (error instanceof GuardedFetchRedirectError) {
         // Repeating the same poll cannot satisfy direct-only delivery. Hold this exact
         // endpoint for this service instance; a fresh instance probes once so a receiver
@@ -334,6 +340,7 @@ export function createBeamMirrorRunner(params: {
 
     const { response, release } = guarded;
     try {
+      signal.throwIfAborted();
       if (!response.ok) {
         warnThrottled(`beam mirror upload failed (${response.status}) for ${payload.source}`);
         return false;
@@ -359,6 +366,7 @@ export function createBeamMirrorRunner(params: {
       threadId: candidate.threadId,
       limit: MIRROR_READ_LIMIT,
     });
+    signal.throwIfAborted();
     const reduced = buildBeamMirrorItems(transcript.items);
     const items = reduced.items.length
       ? reduced.items
@@ -385,11 +393,7 @@ export function createBeamMirrorRunner(params: {
       )
       .digest("hex");
 
-  const tick = async (): Promise<void> => {
-    if (running) {
-      return;
-    }
-    running = true;
+  const scan = async (): Promise<void> => {
     try {
       const config = params.runtime.config.current();
       const mirror = parseBeamMirrorConfig(config);
@@ -416,6 +420,7 @@ export function createBeamMirrorRunner(params: {
           value: mirror.token,
           path: MIRROR_TOKEN_PATH,
         });
+        signal.throwIfAborted();
         if (!resolved.value) {
           warnThrottled(
             `beam mirror token unresolved${resolved.unresolvedRefReason ? `: ${resolved.unresolvedRefReason}` : ""}`,
@@ -434,10 +439,13 @@ export function createBeamMirrorRunner(params: {
       const catalogById = new Map(catalogs.map((catalog) => [catalog.id, catalog]));
       const candidates: BeamMirrorCandidate[] = [];
       for (const catalog of catalogs) {
+        signal.throwIfAborted();
         try {
           const hosts = await catalog.list({ agentId, limitPerHost: MIRROR_LIST_LIMIT });
+          signal.throwIfAborted();
           candidates.push(...hostCandidates(catalog.id, hosts, activeSinceMs));
         } catch (error) {
+          signal.throwIfAborted();
           warnThrottled(`beam mirror list failed for ${catalog.id}: ${String(error)}`);
         }
       }
@@ -445,6 +453,7 @@ export function createBeamMirrorRunner(params: {
       const selected = candidates.slice(0, MIRROR_MAX_SESSIONS);
       const selectedKeys = new Set<string>();
       for (const candidate of selected) {
+        signal.throwIfAborted();
         const key = `${candidate.catalogId}\0${candidate.hostId}\0${candidate.threadId}`;
         selectedKeys.add(key);
         const catalog = catalogById.get(candidate.catalogId);
@@ -453,20 +462,25 @@ export function createBeamMirrorRunner(params: {
         }
         try {
           const payload = await buildUpload(agentId, catalog, candidate, false);
+          signal.throwIfAborted();
           const fingerprint = mirrorFingerprint(payload);
           if (tracked.get(key)?.fingerprint === fingerprint) {
             continue;
           }
-          if (await upload(mirror.endpoint, token, payload)) {
+          const uploaded = await upload(mirror.endpoint, token, payload);
+          signal.throwIfAborted();
+          if (uploaded) {
             tracked.set(key, { candidate, fingerprint });
           }
         } catch (error) {
+          signal.throwIfAborted();
           warnThrottled(`beam mirror upload failed for ${candidate.catalogId}: ${String(error)}`);
         }
       }
       // Sessions that left the active window get one final completed upload so
       // remote rows flip from live to completed instead of lingering until TTL.
       for (const [key, entry] of tracked) {
+        signal.throwIfAborted();
         if (selectedKeys.has(key)) {
           continue;
         }
@@ -477,25 +491,47 @@ export function createBeamMirrorRunner(params: {
         }
         try {
           const payload = await buildUpload(agentId, catalog, entry.candidate, true);
+          signal.throwIfAborted();
           await upload(mirror.endpoint, token, payload);
         } catch {
           // The session store may already be gone; the receiver TTL cleans up.
         }
       }
-    } finally {
-      running = false;
+    } catch (error) {
+      if (!signal.aborted) {
+        throw error;
+      }
     }
   };
 
-  return { tick };
+  return {
+    tick: () => {
+      if (signal.aborted) {
+        return stopPromise ?? Promise.resolve();
+      }
+      activeTick ??= scan().finally(() => {
+        activeTick = undefined;
+      });
+      return activeTick;
+    },
+    stop: () => {
+      if (!stopPromise) {
+        // Publish ownership before abort listeners run so reentrant shutdown joins this scan.
+        stopPromise = activeTick ?? Promise.resolve();
+        controller.abort();
+      }
+      return stopPromise;
+    },
+  };
 }
 
 export function createBeamMirrorService(params: { runtime: PluginRuntime }): {
   id: string;
   start: (ctx: { logger: { warn: (m: string) => void; info: (m: string) => void } }) => void;
-  stop: () => void;
+  stop: () => Promise<void>;
 } {
   let interval: ReturnType<typeof setInterval> | undefined;
+  let runner: BeamMirrorRunner | undefined;
   return {
     id: "beam-mirror",
     start(ctx) {
@@ -507,12 +543,12 @@ export function createBeamMirrorService(params: { runtime: PluginRuntime }): {
         ctx.logger.warn(`beam mirror disabled: ${mirror}`);
         return;
       }
-      const runner = createBeamMirrorRunner({ runtime: params.runtime, logger: ctx.logger });
+      runner = createBeamMirrorRunner({ runtime: params.runtime, logger: ctx.logger });
       // The catalog poll is this service's lifecycle-owned freshness exception:
       // local coding sessions change outside gateway events, so a bounded
       // unref'd interval is the only way to observe them.
       interval = setInterval(() => {
-        void runner.tick();
+        void runner?.tick();
       }, mirror.pollSeconds * 1_000);
       interval.unref?.();
       ctx.logger.info(`beam mirror active: ${mirror.catalogs.join(", ")} -> ${mirror.endpoint}`);
@@ -523,6 +559,7 @@ export function createBeamMirrorService(params: { runtime: PluginRuntime }): {
         clearInterval(interval);
         interval = undefined;
       }
+      return runner?.stop() ?? Promise.resolve();
     },
   };
 }


### PR DESCRIPTION
AI-assisted: yes

## What Problem This Solves
Fixes an issue where disabling or reloading the Beam mirror while a catalog scan was already running could let that scan continue processing local session data after the service had stopped, or leave Gateway reload waiting for a stalled catalog operation.

## Why This Change Was Made
The Beam runner owns one abortable active scan and races non-cancellable session-catalog list/read operations against its lifecycle signal, so shutdown completes promptly even when catalog I/O remains pending. Late catalog results cannot resume transcript reads, uploads, or session updates. Guarded network delivery receives the same signal, but shutdown still awaits response-body cancellation and guarded resource release after transport abort. Overlapping timer ticks join the same active scan.

## User Impact
Removing mirror consent, stopping the plugin, or reloading its configuration now takes effect promptly as a terminal lifecycle boundary: no later transcript read or mirror delivery begins from the retired service instance, while in-flight network resources are cleaned up before shutdown completes.

## Evidence
- Before the catalog-abort fix, the service-level stalled-list regression failed with `AssertionError: expected false to be true` because service shutdown remained pending while the catalog promise was unreleased.
- `node scripts/run-vitest.mjs extensions/beam/src/mirror.test.ts` (32 tests passed)
- `node_modules/.bin/oxfmt extensions/beam/src/mirror.ts extensions/beam/src/mirror.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/beam/src/mirror.test.ts extensions/beam/src/mirror.ts`
- `git diff --check`
- Focused coverage proves prompt stop while catalog list/read remain pending, ignores late catalog results, joins overlapping ticks, awaits guarded cleanup, and aborts a real stalled loopback transport.
- Codex autoreview: clean, no accepted/actionable findings.
- Production LOC +82/-21 (net +61), required for Beam-owned lifecycle cancellation and safe guarded transport cleanup; tests +261/-3 (net +258).
