### PR TITLE
fix(channels): keep started ingress deliveries admissible after their inherited root releases

### DIFF
--- a/src/channels/message/ingress-drain.ts
+++ b/src/channels/message/ingress-drain.ts
@@ -6,7 +6,11 @@
  */
 import { sleepWithAbort } from "@openclaw/retry";
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
-import { GatewayDrainingError } from "../../process/gateway-work-admission.js";
+import {
+  GatewayDrainingError,
+  retainGatewayRootWorkAdmissionContinuation,
+  runOutsideGatewayRootWorkAdmission,
+} from "../../process/gateway-work-admission.js";
 import {
   createIngressDrainOwnerId,
   deregisterLiveIngressDrainInstance,
@@ -546,9 +550,20 @@ export function createChannelIngressDrain<
     armStallWatchdog(state);
     armClaimRefresh(state);
 
+    // drainOnce starts dispatches without awaiting them, so this task outlives
+    // the admission context it inherits (a detached pump root or the transport
+    // request that enqueued the event). Retain a live root until the task
+    // settles; when the inherited root is already released, dispatch outside it
+    // so the dead lease cannot make session admission refuse the turn as
+    // draining. A real restart drain still refuses both paths at admission.
+    const releaseRootWork = retainGatewayRootWorkAdmissionContinuation();
     state.task = (async () => {
       try {
-        const result = await options.dispatchClaimedEvent(claim, lifecycle);
+        const result = await (releaseRootWork
+          ? options.dispatchClaimedEvent(claim, lifecycle)
+          : runOutsideGatewayRootWorkAdmission(() =>
+              options.dispatchClaimedEvent(claim, lifecycle),
+            ));
         // dispose() leaves claims for recovery. Session abort mid-flight
         // (skipped/void) also leaves the claim; a terminal completed/failed
         // result still settles even if abort raced the return.
@@ -616,6 +631,8 @@ export function createChannelIngressDrain<
         await state.settleOnce(async () => {
           await applyFailureDisposition(claim, err);
         });
+      } finally {
+        releaseRootWork?.();
       }
     })();
 

--- a/src/channels/message/ingress-monitor.test.ts
+++ b/src/channels/message/ingress-monitor.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   GatewayDrainingError,
+  isGatewaySubordinateWorkAdmissionClosed,
   markGatewayRestartDraining,
   resetGatewayWorkAdmission,
   runWithGatewayIndependentRootWorkAdmission,
+  runWithGatewayIndependentRootWorkContinuation,
 } from "../../process/gateway-work-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { sleep } from "../../utils/sleep.js";
@@ -68,6 +70,7 @@ function createMonitor(
         waitForDeliveryIdleBeforeRepump?: boolean;
         waitForDeliveryIdleOnStop?: boolean;
         retryPolicy?: IngressRetryPolicyConfig;
+        runPumpTask?: (work: () => Promise<void>) => Promise<void>;
       },
   onError?: (error: unknown) => void,
   abortSignal?: AbortSignal,
@@ -652,6 +655,111 @@ describe("channel ingress monitor", () => {
         expect.objectContaining({ id: "event-stop-retry", lastError: expect.any(String) }),
       ]);
       await expect(monitor.waitForIdle()).resolves.toBeUndefined();
+    });
+  });
+
+  it("keeps a started delivery admissible after its detached pump root releases", async () => {
+    await withQueue(async (queue) => {
+      let releaseDeliver = () => {};
+      const deliverGate = new Promise<void>((resolve) => {
+        releaseDeliver = resolve;
+      });
+      let admissionClosedDuringDelivery: boolean | undefined;
+      const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+        await deliverGate;
+        admissionClosedDuringDelivery = isGatewaySubordinateWorkAdmissionClosed();
+        await lifecycle.onAdopted();
+      });
+      let markPumpTaskSettled = () => {};
+      const pumpTaskSettled = new Promise<void>((resolve) => {
+        markPumpTaskSettled = resolve;
+      });
+      // Mirror the production webhook-spool combination: the pump runs on its
+      // own detached root and does not wait for deliveries before returning.
+      const monitor = createMonitor(queue, deliver, {
+        waitForDeliveryIdleBeforeRepump: false,
+        runPumpTask: (work) =>
+          runWithGatewayIndependentRootWorkContinuation(work).finally(() => markPumpTaskSettled()),
+      });
+      monitor.start();
+      try {
+        // Admit inside its own root and let it release right away, the way an
+        // ack-first webhook request root releases once the 200 is written.
+        await runWithGatewayIndependentRootWorkAdmission(async () => {
+          await monitor.admit({ id: "event-detached-root", lane: "a", text: "hello" });
+        });
+        await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+        // The pump returns while the delivery is still in flight; every root
+        // the dispatch could have inherited is released at this point.
+        await pumpTaskSettled;
+        releaseDeliver();
+
+        await vi.waitFor(() => expect(admissionClosedDuringDelivery).toBeDefined());
+        expect(admissionClosedDuringDelivery).toBe(false);
+        await monitor.waitForIdle();
+        await expect(queue.listPending()).resolves.toEqual([]);
+        await expect(queue.listClaims()).resolves.toEqual([]);
+      } finally {
+        releaseDeliver();
+        await monitor.stop();
+      }
+    });
+  });
+
+  it("dispatches outside an already-released inherited root instead of refusing", async () => {
+    await withQueue(async (queue) => {
+      let releaseDeliver = () => {};
+      const deliverGate = new Promise<void>((resolve) => {
+        releaseDeliver = resolve;
+      });
+      let admissionClosedDuringDelivery: boolean | undefined;
+      const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+        await deliverGate;
+        admissionClosedDuringDelivery = isGatewaySubordinateWorkAdmissionClosed();
+        await lifecycle.onAdopted();
+      });
+      // No runPumpTask: the pump chain inherits the admitting caller's context,
+      // the way a transport request that enqueues an event does.
+      const monitor = createMonitor(queue, deliver, {}, undefined, undefined, 60_000);
+      let markPendingScanStarted = () => {};
+      const pendingScanStarted = new Promise<void>((resolve) => {
+        markPendingScanStarted = resolve;
+      });
+      let releasePendingScan = () => {};
+      const pendingScanGate = new Promise<void>((resolve) => {
+        releasePendingScan = resolve;
+      });
+      const listPending = queue.listPending.bind(queue);
+      let gateNextPendingScan = true;
+      queue.listPending = async (...args) => {
+        if (gateNextPendingScan) {
+          gateNextPendingScan = false;
+          markPendingScanStarted();
+          await pendingScanGate;
+        }
+        return await listPending(...args);
+      };
+      monitor.start();
+      try {
+        // Admit inside a root that releases as soon as the enqueue returns;
+        // the gated scan keeps the claim from happening until after that.
+        await runWithGatewayIndependentRootWorkAdmission(async () => {
+          await monitor.admit({ id: "event-released-root", lane: "a", text: "hello" });
+          await pendingScanStarted;
+        });
+        releasePendingScan();
+        await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+        releaseDeliver();
+
+        await vi.waitFor(() => expect(admissionClosedDuringDelivery).toBeDefined());
+        expect(admissionClosedDuringDelivery).toBe(false);
+        await monitor.waitForIdle();
+        await expect(queue.listClaims()).resolves.toEqual([]);
+      } finally {
+        releaseDeliver();
+        releasePendingScan();
+        await monitor.stop();
+      }
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #126441.

On `2026.8.1-beta.2` and current `main`, every inbound LINE message is refused in 10-18 ms with `GatewayDrainingError: Gateway is draining; new tasks are not accepted` on a gateway that was never asked to stop or restart. The gateway reports itself healthy the whole time — `ready`, `channels status --probe` returns `works` — while the sender only sees the LINE loading indicator and never receives a reply. The durable queue retries each event on its backoff and every attempt fails identically, so events walk their budget toward dead-letter. The same message on `2026.7.1-2` is delivered normally.

The defect lives in the shared durable ingress drain, so every channel on it is exposed — the 16 extension channels using `createChannelIngressMonitor` (LINE, Discord, WhatsApp, Signal, iMessage, Feishu, Mattermost, MS Teams, IRC, Twitch, Nostr, Tlon, SMS, Nextcloud Talk, Zalo, Zalo Personal) plus the plugin registry runtime.

## Why This Change Was Made

`drainOnce` starts each claimed dispatch without awaiting it (`runClaimed(claimed, laneKey)` in `ingress-drain.ts`), so the dispatch task outlives whatever admission context it inherits — the detached pump root (released when `runPump` returns, while deliveries are still in flight) or the transport request that enqueued the event (released once the webhook 200 is written). `isGatewaySubordinateWorkAdmissionClosed()` treats an inherited *released* root as closed (`gateway-work-admission.ts` branch `return current.released`), so `beginSessionWorkAdmission` refuses the turn as if the gateway were draining. No `admission closed` is ever logged because no admission fence was ever raised — the failing runs contain zero admission-closure lines across their whole lifetime, which is how the refusal was isolated to that branch by elimination.

The fix gives the dispatch task an admission context whose lifetime matches its own, at the single point where it detaches:

- inherited root still live → `retainGatewayRootWorkAdmissionContinuation()` holds it until the task settles, so a real restart drain keeps waiting for in-flight deliveries;
- inherited root already released (or absent) → the dispatch runs via `runOutsideGatewayRootWorkAdmission`, so the dead lease cannot poison it, while a real restart drain still refuses it at admission and the existing `GatewayDrainingError` disposition releases the claim without spending an attempt (preserving #125919's semantics — the two changes compose).

This is the same released-root class fixed four times before, each by applying one of these helpers at the affected call site: #116040, #116094, #117505, #118105. The ingress drain was the remaining caller without that treatment. The exposure dates to the durable drain engine itself (`fc6b9dad0b1` starts dispatches without awaiting them) and reached all channels with the shared monitor (`c163daa4ed0`, #111249, whose `waitForDeliveryIdleBeforeRepump: false` production default releases the pump root while deliveries run); `2026.7.1-2` predates both, and its `@openclaw/line@2026.7.1` dist contains none of the shared-monitor entry points, which is why the control is immune.

Alternatives considered and rejected: wrapping the dispatch in `runWithGatewayIndependentRootWorkContinuation` adds microtask hops after dispatch resolution, which lets `dispose()` win the settlement race on stop and breaks the pre-adoption release contract (two existing tests catch this); making the pump wait for delivery idle before returning changes pump throughput semantics; and relaxing the released-root check in session admission would weaken the reset-retirement invariant globally.

One disclosed trade-off: a dispatch that starts on the outside path is not tracked in `activeRootWork`, so a restart drain does not wait for it. Today such a dispatch cannot run at all, and if a restart cuts it mid-flight the claim is recovered by the stale-lease path and redelivered — ordinary crash semantics for the durable queue.

## User Impact

Inbound messages on durable-ingress channels reach the agent again. Before the fix, on an affected gateway every inbound message was silently lost from the sender's point of view while all health surfaces reported green; recovery required reading gateway logs. After the fix, messages are admitted, turns run, and a genuine restart drain still refuses or waits exactly as designed.

## Evidence

Controlled three-version comparison, one variable (the OpenClaw version), same host, tunnel, port, LINE channel, config shape, webhook URL:

| Version | Result |
| --- | --- |
| `2026.7.1-2` + `@openclaw/line@2026.7.1` | reply delivered (`[model-fetch] response ... status=200 elapsedMs=2014`); 0 `draining` errors |
| `2026.8.1-beta.2` + `@openclaw/line@2026.8.1-beta.2` (version-matched) | every message refused; 28 `draining` errors |
| `main` at `0f1670d8951` (source run) | every message refused; 20 `draining` errors |

Failing shape (identical on both bad versions, first attempt and every durable retry):

```
[diagnostic] message processed: channel=line ... outcome=error duration=16ms
  error="GatewayDrainingError: Gateway is draining; new tasks are not accepted"
[line] spooled update message:628040302011613237 failed; keeping for retry: Gateway is draining
```

Zero `admission closed` / `admission reopened` lines across both failing runs' lifetimes (checked in the file log), which excludes every fence-based closure and leaves only the inherited released root.

With this fix applied to the same source tree, the same live LINE channel delivers again: five inbound events (three sent from a real LINE client, two self-signed webhook posts) all passed admission — 0 `draining` errors — and the turn ran to a model response:

```
[provider-transport-fetch] [model-fetch] response provider=openrouter api=openai-completions
  model=anthropic/claude-haiku-4-5 status=200 elapsedMs=3095
```

One of the live events also demonstrated the durable path end to end: the gateway was stopped while the event was mid-retry, and the successor process recovered the claim and redelivered it. (During the fixed-run verification an unrelated failure surfaced after admission — the prepared model catalog worker rejects source runs because its reconstructed registry index diverges from the persisted one; that is a separate defect, reported separately, and was locally bypassed only to let the turn complete for this evidence. The admission counts above are unaffected by it.)

Red/green, both fix paths, deterministic:

- `keeps a started delivery admissible after its detached pump root releases` — mirrors the production webhook-spool combination (`runPumpTask` + `waitForDeliveryIdleBeforeRepump: false`, admit inside a root that releases after the enqueue, delivery gated until the pump task settles). Without the fix: `expected true to be false` (admission observed closed during delivery). With it: passes.
- `dispatches outside an already-released inherited root instead of refusing` — no `runPumpTask`, the pump chain inherits the admitting caller's released root via a gated pending scan. Without the fix: `expected true to be false`. With it: passes.

Both prior contract tests that constrain this area pass unchanged — `defers a claimed event across restart drain without consuming retry budget` (#125919) and `releases a pre-adoption delivery for retry before disposing on stop` — i.e. restart-drain refusal and stop-release ordering are preserved, not worked around.

Full runs: `src/channels/message/` 171/171; `tsgo:core` and `tsgo:test:src` clean; `oxlint` clean; `oxfmt --check` clean.
