### PR TITLE
fix(mcp): restore channel media, event delivery, and lifecycle cleanup

### DIFF
--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -78,6 +78,8 @@ Use [`openclaw acp`](/cli/acp) instead when OpenClaw should host the coding runt
     - older transcript history is read with `messages_read`
     - Claude push notifications only exist while the MCP session is alive
     - when the client disconnects, the bridge exits and the live queue is gone
+    - cancelling an `events_wait` request immediately releases its server-side wait and timeout
+    - bridge or MCP transport close failures make `openclaw mcp serve` fail instead of reporting a clean shutdown
     - one-shot agent entry points such as `openclaw agent` and `openclaw infer model run` retire any bundled MCP runtimes they open when the reply completes, so repeated scripted runs do not accumulate stdio MCP child processes
     - stdio MCP servers launched by OpenClaw (bundled or user-configured) are torn down as a process tree on shutdown, so child subprocesses started by the server do not survive after the parent stdio client exits
     - deleting or resetting a session disposes that session's MCP clients through the shared runtime cleanup path, so there are no lingering stdio connections tied to a removed session
@@ -159,15 +161,16 @@ This gives MCP clients one place to:
     Reads recent transcript messages for one session-backed conversation. `limit` defaults to 20, max 200.
   </Accordion>
   <Accordion title="attachments_fetch">
-    Extracts non-text message content blocks from one transcript message. This is a metadata view over transcript content, not a standalone durable attachment blob store.
+    Extracts non-text message content blocks and canonical persisted media metadata from one transcript message. Persisted entries use `{ "type": "openclaw_media", "media": { ... } }`, where `media` can include `url`, `contentType`, `kind`, `fileName`, dimensions, duration, or size. This is a metadata view, not a standalone durable attachment blob store.
   </Accordion>
   <Accordion title="events_poll">
-    Reads queued live events since a numeric cursor. `limit` max 200.
+    Reads queued live events since a numeric cursor. `limit` max 200. If the requested cursor predates retained queue history, the result also includes `gap.requested_after_cursor` and `gap.oldest_available_cursor`.
   </Accordion>
   <Accordion title="events_wait">
     Long-polls until the next matching queued event arrives or a timeout expires (default 30s, max 300s).
 
     Use this when a generic MCP client needs near-real-time delivery without a Claude-specific push protocol.
+    A known cursor gap returns immediately with the same additive `gap` metadata, even when no matching event is currently retained.
 
   </Accordion>
   <Accordion title="messages_send">
@@ -209,6 +212,7 @@ Current event types:
 <Warning>
 - the queue is live-only; it starts when the MCP bridge starts
 - `events_poll` and `events_wait` do not replay older Gateway history by themselves
+- the queue is bounded; when `gap` is present, read durable history with `messages_read`, then resume with `after_cursor` set to one less than `gap.oldest_available_cursor`
 - durable backlog should be read with `messages_read`
 
 </Warning>
@@ -331,7 +335,7 @@ For broader testing context, see [Testing](/help/testing).
     Usually means the Gateway session is not already routable. Confirm that the underlying session has stored channel/provider, recipient, and optional account/thread route metadata.
   </Accordion>
   <Accordion title="events_poll or events_wait misses older messages">
-    Expected. The live queue starts when the bridge connects. Read older transcript history with `messages_read`.
+    The live queue starts when the bridge connects and retains a bounded window. If a result includes `gap`, read durable transcript history with `messages_read`, then resume with `after_cursor` set to one less than `gap.oldest_available_cursor`.
   </Accordion>
   <Accordion title="Claude notifications do not show up">
     Check all of these:

--- a/scripts/e2e/mcp-channels-seed.ts
+++ b/scripts/e2e/mcp-channels-seed.ts
@@ -79,18 +79,19 @@ async function main() {
       JSON.stringify({
         id: "msg-attachment",
         message: {
-          role: "assistant",
-          content: [
-            { type: "text", text: "seeded image attachment" },
-            {
-              type: "image",
-              source: {
-                type: "base64",
-                media_type: "image/png",
-                data: "abc",
+          role: "user",
+          content: "seeded image attachment",
+          __openclaw: {
+            media: [
+              {
+                url: "media://inbound/seeded-image.png",
+                contentType: "image/png",
+                kind: "image",
+                fileName: "seeded-image.png",
+                sizeBytes: 3,
               },
-            },
-          ],
+            ],
+          },
           timestamp: now + 1,
         },
       }),

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -877,4 +877,16 @@ describe("mcp cli", () => {
       });
     });
   });
+
+  it("points serve startup failures at the deep Gateway health diagnostic", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      serveOpenClawChannelMcp.mockRejectedValueOnce(new Error("gateway unavailable"));
+
+      await expect(runMcpCommand(["mcp", "serve"])).rejects.toThrow("__exit__:1");
+
+      expect(lastErrorLine()).toBe(
+        "MCP server failed to start: gateway unavailable. Run openclaw gateway status --deep --require-rpc to inspect Gateway health.",
+      );
+    });
+  });
 });

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -679,7 +679,7 @@ export function registerMcpCli(program: Command) {
         });
       } catch (err) {
         defaultRuntime.error(
-          `MCP server failed to start: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw mcp list")} to inspect configured servers.`,
+          `MCP server failed to start: ${formatErrorMessage(err)}. Run ${formatCliCommand("openclaw gateway status --deep --require-rpc")} to inspect Gateway health.`,
         );
         defaultRuntime.exit(1);
       }

--- a/src/mcp/channel-bridge.test.ts
+++ b/src/mcp/channel-bridge.test.ts
@@ -120,6 +120,42 @@ describe("OpenClawChannelBridge — Claude permission authorization", () => {
       await bridge.close();
     }
   });
+
+  test("keeps a permission retryable until its notification is delivered", async () => {
+    const bridge = makeBridge();
+    const notification = vi
+      .fn<(notification: unknown) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("transport closed"))
+      .mockResolvedValueOnce(undefined);
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    bridge.server = { server: { notification } };
+    const reply = {
+      sessionKey: "agent:main:telegram:group:-100123",
+      senderIsOwner: true,
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "yes abcde" }],
+      },
+    };
+    try {
+      await bridge.handleClaudePermissionRequest({
+        requestId: "abcde",
+        toolName: "Bash",
+        description: "run npm test",
+        inputPreview: "{}",
+      });
+
+      await bridge.handleSessionMessageEvent(reply);
+      await bridge.handleSessionMessageEvent(reply);
+      expect(notification).toHaveBeenCalledTimes(2);
+
+      await bridge.handleSessionMessageEvent(reply);
+      expect(notification).toHaveBeenCalledTimes(2);
+    } finally {
+      writeSpy.mockRestore();
+      await bridge.close();
+    }
+  });
 });
 
 describe("OpenClawChannelBridge — pendingClaudePermissions / pendingApprovals memory bounds", () => {
@@ -430,7 +466,7 @@ describe("OpenClawChannelBridge — pendingClaudePermissions / pendingApprovals 
       expect(resolved).toBe(false);
 
       vi.advanceTimersByTime(1);
-      await expect(waited).resolves.toBeNull();
+      await expect(waited).resolves.toEqual({ event: null });
       expect(resolved).toBe(true);
     } finally {
       await bridge.close();

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -17,6 +17,9 @@ import type {
   ChatHistoryResult,
   ClaudeChannelMode,
   ConversationDescriptor,
+  EventCursorGap,
+  EventPollResult,
+  EventWaitResult,
   PendingApproval,
   QueueEvent,
   SessionDescribeResult,
@@ -34,8 +37,7 @@ import { matchEventFilter, normalizeApprovalId, toConversation, toText } from ".
  */
 type PendingWaiter = {
   filter: WaitFilter;
-  resolve: (value: QueueEvent | null) => void;
-  timeout: NodeJS.Timeout | null;
+  settle: (event: QueueEvent | null) => void;
 };
 
 type PendingApprovalEntry = {
@@ -47,6 +49,8 @@ type ServerNotification = {
   method: string;
   params?: Record<string, unknown>;
 };
+
+type NotificationDeliveryOutcome = "delivered" | "unavailable" | "failed";
 
 const CLAUDE_PERMISSION_REPLY_RE = /^(yes|no)\s+([a-km-z]{5})$/i;
 const QUEUE_LIMIT = 1_000;
@@ -199,15 +203,11 @@ export class OpenClawChannelBridge {
     this.pendingClaudePermissions.clear();
     this.pendingApprovals.clear();
     for (const waiter of this.pendingWaiters) {
-      if (waiter.timeout) {
-        clearTimeout(waiter.timeout);
-      }
-      waiter.resolve(null);
+      waiter.settle(null);
     }
-    this.pendingWaiters.clear();
     const gateway = this.gateway;
     this.gateway = null;
-    await gateway?.stopAndWait().catch(() => undefined);
+    await gateway?.stopAndWait();
   }
 
   /** List Gateway sessions that have enough routing metadata to be channel conversations. */
@@ -318,38 +318,58 @@ export class OpenClawChannelBridge {
   }
 
   /** Poll queued events after a cursor without consuming them. */
-  pollEvents(filter: WaitFilter, limit = 20): { events: QueueEvent[]; nextCursor: number } {
+  pollEvents(filter: WaitFilter, limit = 20): EventPollResult {
     const eventLimit = resolveIntegerOption(limit, 20, { min: 1, max: EVENTS_POLL_LIMIT });
     const events = this.queue
       .filter((event) => matchEventFilter(event, filter))
       .slice(0, eventLimit);
-    const nextCursor = events.at(-1)?.cursor ?? filter.afterCursor;
-    return { events, nextCursor };
+    const gap = this.resolveCursorGap(filter.afterCursor);
+    const nextCursor =
+      events.at(-1)?.cursor ?? (gap ? gap.oldest_available_cursor - 1 : filter.afterCursor);
+    return { events, nextCursor, ...(gap ? { gap } : {}) };
   }
 
-  /** Wait for the next matching event, resolving null on timeout or bridge close. */
-  async waitForEvent(filter: WaitFilter, timeoutMs = 30_000): Promise<QueueEvent | null> {
+  /** Wait for the next matching event, returning a closed outcome on every settle path. */
+  async waitForEvent(
+    filter: WaitFilter,
+    timeoutMs = 30_000,
+    signal?: AbortSignal,
+  ): Promise<EventWaitResult> {
+    signal?.throwIfAborted();
     const existing = this.queue.find((event) => matchEventFilter(event, filter));
-    if (existing) {
-      return existing;
+    const gap = this.resolveCursorGap(filter.afterCursor);
+    if (existing || gap) {
+      return { event: existing ?? null, ...(gap ? { gap } : {}) };
     }
     const waitTimeoutMs = resolveIntegerOption(timeoutMs, 30_000, {
       min: 1,
       max: EVENTS_WAIT_TIMEOUT_LIMIT_MS,
     });
-    return await new Promise<QueueEvent | null>((resolve) => {
+    return await new Promise<EventWaitResult>((resolve) => {
+      let settled = false;
+      const onAbort = () => waiter.settle(null);
       const waiter: PendingWaiter = {
         filter,
-        resolve: (value) => {
+        settle: (event) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
           this.pendingWaiters.delete(waiter);
-          resolve(value);
+          clearTimeout(timeout);
+          signal?.removeEventListener("abort", onAbort);
+          const currentGap = this.resolveCursorGap(filter.afterCursor);
+          resolve({ event, ...(currentGap ? { gap: currentGap } : {}) });
         },
-        timeout: null,
       };
-      waiter.timeout = setTimeout(() => {
-        waiter.resolve(null);
+      const timeout = setTimeout(() => {
+        waiter.settle(null);
       }, waitTimeoutMs);
+      signal?.addEventListener("abort", onAbort, { once: true });
       this.pendingWaiters.add(waiter);
+      if (signal?.aborted) {
+        waiter.settle(null);
+      }
     });
   }
 
@@ -388,15 +408,18 @@ export class OpenClawChannelBridge {
     return await this.gateway.request<T>(method, params);
   }
 
-  private async sendNotification(notification: ServerNotification): Promise<void> {
+  private async sendNotification(
+    notification: ServerNotification,
+  ): Promise<NotificationDeliveryOutcome> {
     if (!this.server || this.closed) {
-      return;
+      return "unavailable";
     }
     try {
       await this.server.server.notification(notification);
+      return "delivered";
     } catch (error) {
       if (this.closed) {
-        return;
+        return "unavailable";
       }
       // Always surface a single low-noise record so swallowed delivery failures
       // remain observable; the spammy error detail stays behind --verbose.
@@ -406,6 +429,7 @@ export class OpenClawChannelBridge {
           `openclaw mcp: notification ${notification.method} error: ${String(error)}\n`,
         );
       }
+      return "failed";
     }
   }
 
@@ -440,6 +464,16 @@ export class OpenClawChannelBridge {
     return this.cursor;
   }
 
+  private resolveCursorGap(afterCursor: number): EventCursorGap | undefined {
+    const oldestAvailableCursor = this.queue[0]?.cursor;
+    return oldestAvailableCursor !== undefined && afterCursor < oldestAvailableCursor - 1
+      ? {
+          requested_after_cursor: afterCursor,
+          oldest_available_cursor: oldestAvailableCursor,
+        }
+      : undefined;
+  }
+
   private enqueue(event: QueueEvent): void {
     this.queue.push(event);
     // Retain enough history for cursor polling without letting a long MCP session grow unbounded.
@@ -447,13 +481,10 @@ export class OpenClawChannelBridge {
       this.queue.shift();
     }
     for (const waiter of this.pendingWaiters) {
-      if (!matchEventFilter(event, waiter.filter)) {
-        continue;
+      const matches = matchEventFilter(event, waiter.filter);
+      if (matches || this.resolveCursorGap(waiter.filter.afterCursor)) {
+        waiter.settle(matches ? event : null);
       }
-      if (waiter.timeout) {
-        clearTimeout(waiter.timeout);
-      }
-      waiter.resolve(event);
     }
   }
 
@@ -606,8 +637,7 @@ export class OpenClawChannelBridge {
     if (role === "user" && payload.senderIsOwner === true && permissionMatch) {
       const requestId = normalizeOptionalLowercaseString(permissionMatch[2]);
       if (requestId && this.pendingClaudePermissions.has(requestId)) {
-        this.pendingClaudePermissions.delete(requestId);
-        await this.sendNotification({
+        const delivery = await this.sendNotification({
           method: "notifications/claude/channel/permission",
           params: {
             request_id: requestId,
@@ -616,6 +646,9 @@ export class OpenClawChannelBridge {
               : "deny",
           },
         });
+        if (delivery === "delivered") {
+          this.pendingClaudePermissions.delete(requestId);
+        }
         return;
       }
     }

--- a/src/mcp/channel-server-runtime.ts
+++ b/src/mcp/channel-server-runtime.ts
@@ -61,8 +61,17 @@ export async function createChannelMcpRuntime(
       await bridge.start();
     },
     close: async () => {
-      await bridge.close();
-      await server.close();
+      // Both lifecycle owners must always close; one failure cannot strand the other.
+      const results = await Promise.allSettled([bridge.close(), server.close()]);
+      const errors = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "OpenClaw channel MCP shutdown failed");
+      }
     },
   };
 }

--- a/src/mcp/channel-server.shutdown-unhandled-rejection.test.ts
+++ b/src/mcp/channel-server.shutdown-unhandled-rejection.test.ts
@@ -111,7 +111,7 @@ describe("serveOpenClawChannelMcp shutdown", () => {
     bridgeState.handleClaudePermissionRequest.mockClear();
   });
 
-  it("does not leak unhandled rejections when shutdown close fails", async () => {
+  it("rejects without leaking unhandled rejections and attempts every cleanup owner", async () => {
     process.on("unhandledRejection", onUnhandledRejection);
     const { serveOpenClawChannelMcp } = await import("./channel-server.js");
 
@@ -119,12 +119,31 @@ describe("serveOpenClawChannelMcp shutdown", () => {
     const transport = await waitForTransport();
 
     transport.onclose?.();
-    await servePromise;
+    await expect(servePromise).rejects.toThrow("close boom");
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
 
     expect(unhandledRejections).toStrictEqual([]);
     expect(bridgeState.close).toHaveBeenCalledTimes(1);
+    expect(serverState.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("aggregates bridge and MCP server close failures", async () => {
+    serverState.close.mockRejectedValueOnce(new Error("server close boom"));
+    const { serveOpenClawChannelMcp } = await import("./channel-server.js");
+
+    const servePromise = serveOpenClawChannelMcp({ verbose: false });
+    const transport = await waitForTransport();
+    transport.onclose?.();
+
+    const error = await servePromise.catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([
+      expect.objectContaining({ message: "close boom" }),
+      expect.objectContaining({ message: "server close boom" }),
+    ]);
+    expect(bridgeState.close).toHaveBeenCalledTimes(1);
+    expect(serverState.close).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -203,6 +203,66 @@ describe("openclaw channel mcp server", () => {
         ).toBe(true);
       });
 
+      test("projects canonical persisted media from a text-only transcript message", async () => {
+        const mcp = await connectMcpWithoutGateway({ claudeChannelMode: "off" });
+        try {
+          attachReadyGateway(
+            mcp.bridge,
+            vi.fn(async (method: string) => {
+              if (method !== "sessions.get") {
+                throw new Error(`unexpected gateway method ${method}`);
+              }
+              return {
+                messages: [
+                  {
+                    id: "msg-canonical-media",
+                    role: "user",
+                    content: "text-only transcript content",
+                    __openclaw: {
+                      media: [
+                        {
+                          url: "media://inbound/photo.png",
+                          contentType: "image/png",
+                          kind: "image",
+                          fileName: "photo.png",
+                          sizeBytes: 123,
+                        },
+                      ],
+                    },
+                  },
+                ],
+              };
+            }),
+          );
+
+          const result = (await mcp.client.callTool({
+            name: "attachments_fetch",
+            arguments: {
+              session_key: "agent:main:main",
+              message_id: "msg-canonical-media",
+            },
+          })) as {
+            structuredContent?: { attachments?: unknown[] };
+          };
+
+          expect(result.structuredContent?.attachments).toEqual([
+            {
+              type: "openclaw_media",
+              media: {
+                url: "media://inbound/photo.png",
+                contentType: "image/png",
+                kind: "image",
+                fileName: "photo.png",
+                sizeBytes: 123,
+                transcribed: false,
+              },
+            },
+          ]);
+        } finally {
+          await mcp.close();
+        }
+      });
+
       test("clamps direct bridge session limits to the public MCP windows", async () => {
         const sessionKey = "agent:main:main";
         const gatewayRequest = vi.fn(async (method: string) => {
@@ -571,6 +631,105 @@ describe("openclaw channel mcp server", () => {
         expect(waited.structuredContent?.event?.text).toBe("inbound live message");
       } finally {
         await mcp.close();
+      }
+    });
+
+    test("reports cursor gaps and wakes filtered waits as queue eviction occurs", async () => {
+      const mcp = await connectMcpWithoutGateway({ claudeChannelMode: "off" });
+      try {
+        const handleSessionMessageEvent = (
+          mcp.bridge as unknown as {
+            handleSessionMessageEvent: (payload: Record<string, unknown>) => Promise<void>;
+          }
+        ).handleSessionMessageEvent.bind(mcp.bridge);
+        const pendingFilteredWait = mcp.client.callTool({
+          name: "events_wait",
+          arguments: {
+            after_cursor: 0,
+            session_key: "agent:main:filtered",
+            timeout_ms: 300_000,
+          },
+        });
+        await mcp.client.callTool({
+          name: "events_poll",
+          arguments: { after_cursor: 0, session_key: "agent:main:filtered" },
+        });
+        for (let index = 1; index <= 1_001; index += 1) {
+          await handleSessionMessageEvent({
+            sessionKey: "agent:main:main",
+            message: { role: "user", content: `event ${index}` },
+          });
+        }
+
+        const filteredWait = await Promise.race([
+          pendingFilteredWait,
+          new Promise<undefined>((resolve) => {
+            setImmediate(() => resolve(undefined));
+          }),
+        ]);
+        expect(filteredWait?.structuredContent).toEqual({
+          event: null,
+          gap: { requested_after_cursor: 0, oldest_available_cursor: 2 },
+        });
+
+        const polled = (await mcp.client.callTool({
+          name: "events_poll",
+          arguments: { after_cursor: 0, limit: 1 },
+        })) as {
+          structuredContent?: Record<string, unknown>;
+        };
+        expect(polled.structuredContent).toMatchObject({
+          gap: { requested_after_cursor: 0, oldest_available_cursor: 2 },
+          next_cursor: 2,
+        });
+
+        const filteredPoll = await mcp.client.callTool({
+          name: "events_poll",
+          arguments: { after_cursor: 0, session_key: "agent:main:filtered" },
+        });
+        expect(filteredPoll.structuredContent).toEqual({
+          events: [],
+          gap: { requested_after_cursor: 0, oldest_available_cursor: 2 },
+          next_cursor: 1,
+        });
+
+        const waited = (await mcp.client.callTool({
+          name: "events_wait",
+          arguments: { after_cursor: 0, timeout_ms: 250 },
+        })) as {
+          structuredContent?: Record<string, unknown>;
+        };
+        expect(waited.structuredContent).toMatchObject({
+          gap: { requested_after_cursor: 0, oldest_available_cursor: 2 },
+          event: { cursor: 2 },
+        });
+      } finally {
+        await mcp.close();
+      }
+    });
+
+    test("cancels an events_wait bridge waiter through the MCP request signal", async () => {
+      vi.useFakeTimers();
+      const mcp = await connectMcpWithoutGateway({ claudeChannelMode: "off" });
+      try {
+        const timerBaseline = vi.getTimerCount();
+        const controller = new AbortController();
+        const waiting = mcp.client.callTool(
+          {
+            name: "events_wait",
+            arguments: { after_cursor: 0, timeout_ms: 300_000 },
+          },
+          undefined,
+          { signal: controller.signal },
+        );
+        await vi.waitFor(() => expect(vi.getTimerCount()).toBeGreaterThan(timerBaseline));
+
+        controller.abort("client cancelled");
+        await expect(waiting).rejects.toThrow();
+        await vi.waitFor(() => expect(vi.getTimerCount()).toBe(timerBaseline));
+      } finally {
+        await mcp.close();
+        vi.useRealTimers();
       }
     });
   });

--- a/src/mcp/channel-server.ts
+++ b/src/mcp/channel-server.ts
@@ -15,6 +15,7 @@ export async function serveOpenClawChannelMcp(opts: OpenClawMcpServeOptions = {}
   const transport = new StdioServerTransport();
 
   let shuttingDown = false;
+  let closePromise: Promise<void> | undefined;
   let resolveClosed!: () => void;
   const closed = new Promise<void>((resolve) => {
     resolveClosed = resolve;
@@ -29,9 +30,9 @@ export async function serveOpenClawChannelMcp(opts: OpenClawMcpServeOptions = {}
     process.stdin.off("close", shutdown);
     process.off("SIGINT", shutdown);
     process.off("SIGTERM", shutdown);
-    // The MCP SDK exposes transport close as a mutable handler rather than an EventEmitter API.
-    transport["onclose"] = undefined;
-    close().then(resolveClosed, resolveClosed);
+    // Assign before cleanup starts so SDK transport-close reentry observes the same owner promise.
+    closePromise = Promise.resolve().then(close);
+    void closePromise.then(resolveClosed, resolveClosed);
   };
 
   transport["onclose"] = shutdown;
@@ -44,8 +45,10 @@ export async function serveOpenClawChannelMcp(opts: OpenClawMcpServeOptions = {}
     await server.connect(transport);
     await start();
     await closed;
+    await closePromise;
   } finally {
     shutdown();
     await closed;
+    await closePromise;
   }
 }

--- a/src/mcp/channel-shared.ts
+++ b/src/mcp/channel-shared.ts
@@ -5,6 +5,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { z } from "zod";
 import type { ChannelApprovalKind } from "../infra/approval-types.js";
+import { isMeaningfulMediaFact, readPersistedMediaFacts } from "../media/media-facts.js";
 
 /**
  * Shared channel MCP contracts and normalization helpers.
@@ -133,6 +134,25 @@ export type WaitFilter = {
   sessionKey?: string;
 };
 
+/** Retained queue boundary reported when a requested cursor can no longer be replayed. */
+export type EventCursorGap = {
+  requested_after_cursor: number;
+  oldest_available_cursor: number;
+};
+
+/** Closed result for one bounded event poll. */
+export type EventPollResult = {
+  events: QueueEvent[];
+  nextCursor: number;
+  gap?: EventCursorGap;
+};
+
+/** Closed result for one event wait, including timeout, close, or cursor-gap outcomes. */
+export type EventWaitResult = {
+  event: QueueEvent | null;
+  gap?: EventCursorGap;
+};
+
 /** Raw MCP notification schema emitted by Claude channel clients for permission prompts. */
 export const ClaudePermissionRequestSchema = z.object({
   method: z.literal("notifications/claude/channel/permission_request"),
@@ -221,21 +241,27 @@ export function matchEventFilter(event: QueueEvent, filter: WaitFilter): boolean
   return "sessionKey" in event && event.sessionKey === filter.sessionKey;
 }
 
-/** Return non-text content blocks from a raw message payload. */
+/** Return non-text content blocks plus canonical persisted media from a raw message payload. */
 export function extractAttachmentsFromMessage(message: unknown): unknown[] {
   if (!message || typeof message !== "object") {
     return [];
   }
   const content = (message as { content?: unknown }).content;
-  if (!Array.isArray(content)) {
-    return [];
-  }
-  return content.filter((entry) => {
-    if (!entry || typeof entry !== "object") {
-      return false;
-    }
-    return toText((entry as { type?: unknown }).type) !== "text";
-  });
+  const contentAttachments = Array.isArray(content)
+    ? content.filter((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return false;
+        }
+        return toText((entry as { type?: unknown }).type) !== "text";
+      })
+    : [];
+  const mediaAttachments = (readPersistedMediaFacts(message) ?? [])
+    .filter(isMeaningfulMediaFact)
+    .map((media) => ({
+      type: "openclaw_media" as const,
+      media: Object.fromEntries(Object.entries(media).filter(([, value]) => value !== undefined)),
+    }));
+  return [...contentAttachments, ...mediaAttachments];
 }
 
 /** Normalize approval identifiers before local tracking or resolution. */

--- a/src/mcp/channel-tools.ts
+++ b/src/mcp/channel-tools.ts
@@ -119,13 +119,17 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       limit: z.number().int().min(1).max(200).optional(),
     },
     async ({ after_cursor, session_key, limit }) => {
-      const { events, nextCursor } = bridge.pollEvents(
+      const { events, nextCursor, gap } = bridge.pollEvents(
         { afterCursor: after_cursor ?? 0, sessionKey: toText(session_key) },
         limit ?? 20,
       );
       return {
         ...summarizeResult("events", events.length),
-        structuredContent: { events, next_cursor: nextCursor },
+        structuredContent: {
+          events,
+          next_cursor: nextCursor,
+          ...(gap ? { gap } : {}),
+        },
       };
     },
   );
@@ -138,14 +142,24 @@ export function registerChannelMcpTools(server: McpServer, bridge: OpenClawChann
       session_key: z.string().optional(),
       timeout_ms: z.number().int().min(1).max(300_000).optional(),
     },
-    async ({ after_cursor, session_key, timeout_ms }) => {
-      const event = await bridge.waitForEvent(
+    async ({ after_cursor, session_key, timeout_ms }, extra) => {
+      const { event, gap } = await bridge.waitForEvent(
         { afterCursor: after_cursor ?? 0, sessionKey: toText(session_key) },
         timeout_ms ?? 30_000,
+        extra.signal,
       );
       return {
-        content: [{ type: "text", text: event ? `event ${event.cursor}` : "timeout" }],
-        structuredContent: { event },
+        content: [
+          {
+            type: "text",
+            text: event
+              ? `event ${event.cursor}`
+              : gap
+                ? `event gap before ${gap.oldest_available_cursor}`
+                : "timeout",
+          },
+        ],
+        structuredContent: { event, ...(gap ? { gap } : {}) },
       };
     },
   );

--- a/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
+++ b/test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts
@@ -233,6 +233,21 @@ async function main() {
       (attachments.structuredContent?.attachments?.length ?? 0) === 1,
       "expected one seeded attachment",
     );
+    assert(
+      JSON.stringify(attachments.structuredContent?.attachments?.[0]) ===
+        JSON.stringify({
+          type: "openclaw_media",
+          media: {
+            url: "media://inbound/seeded-image.png",
+            contentType: "image/png",
+            kind: "image",
+            fileName: "seeded-image.png",
+            sizeBytes: 3,
+            transcribed: false,
+          },
+        }),
+      `expected canonical persisted media attachment: ${JSON.stringify(attachments.structuredContent)}`,
+    );
 
     let waitCursor = 0;
     let lastWaitEvent: Record<string, unknown> | undefined;
@@ -498,6 +513,7 @@ async function main() {
           nonOwnerReplyForwarded: true,
           nonOwnerPermissionBlocked: true,
           ownerPermissionAllowed: permission.behavior === "allow",
+          canonicalMediaAttachmentFound: true,
           rawNotifications: connectedMcp.rawMessages.filter(
             (entry) =>
               ClaudeChannelNotificationSchema.safeParse(entry).success ||

--- a/test/scripts/docker-e2e-seeds.test.ts
+++ b/test/scripts/docker-e2e-seeds.test.ts
@@ -29,7 +29,11 @@ describe("Docker E2E seed scripts", () => {
     expect(source).toContain('channel: "imessage"');
     expect(source).toContain('accountId: "imessage-default"');
     expect(source).toContain('"hello from seeded transcript"');
-    expect(source).toContain('media_type: "image/png"');
+    expect(source).toContain('content: "seeded image attachment"');
+    expect(source).toContain("__openclaw: {");
+    expect(source).toContain("media: [");
+    expect(source).toContain('url: "media://inbound/seeded-image.png"');
+    expect(source).toContain('contentType: "image/png"');
   });
 
   it("keeps cron MCP cleanup config wired to its probe server artifacts", () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users connecting an MCP client to OpenClaw channels could lose persisted media attachments, leave cancelled long-poll requests running, permanently consume an undelivered permission response, silently miss evicted events, overlook shutdown failures, or receive an unrelated diagnostic when the Gateway could not start the MCP bridge.

## Why This Change Was Made

The MCP bridge now repairs each lifecycle at its actual owner boundary: canonical persisted `__openclaw.media` is projected alongside existing content attachments as distinguishable `openclaw_media` entries; the MCP SDK request abort signal settles the bridge waiter, timer, and listener exactly once; permission requests remain pending until their notification is actually delivered; bounded queue eviction reports an additive cursor gap, promptly wakes filtered waits, and provides filtered polls the first recoverable cursor; bridge and MCP server shutdown both run and aggregate multiple failures without leaking unhandled rejections; and startup failures direct operators to `openclaw gateway status --deep --require-rpc`.

Existing MCP attachment items, event fields, and cursor behavior remain compatible; the media item variant and optional `gap` fields are additive, with no protocol or schema version change. The packaged fixture and client exercise the canonical persisted representation instead of a synthetic content block. AI-assisted; reviewed with no accepted or actionable findings.

## User Impact

Channel-connected MCP clients can retrieve real persisted inbound media, cancel waits without stranding server resources, retry owner permission delivery after a transport failure, detect and recover from live-event queue eviction, and reliably observe shutdown/startup failures with an actionable Gateway health command. Owner/non-owner permission boundaries remain unchanged.

## Evidence

- Focused bridge/server/shutdown/Docker-seed regression suite: `node scripts/run-vitest.mjs run src/mcp/channel-bridge.test.ts src/mcp/channel-server.test.ts src/mcp/channel-server.shutdown-unhandled-rejection.test.ts test/scripts/docker-e2e-seeds.test.ts` (38 tests passing).
- Targeted CLI diagnostic regression: `node scripts/run-vitest.mjs run src/cli/mcp-cli.test.ts -t 'points serve startup failures at the deep Gateway health diagnostic'`.
- Changed-surface validation: `node scripts/check-changed.mjs -- docs/cli/mcp.md scripts/e2e/mcp-channels-seed.ts src/cli/mcp-cli.test.ts src/cli/mcp-cli.ts src/mcp/channel-bridge.test.ts src/mcp/channel-bridge.ts src/mcp/channel-server-runtime.ts src/mcp/channel-server.shutdown-unhandled-rejection.test.ts src/mcp/channel-server.test.ts src/mcp/channel-server.ts src/mcp/channel-shared.ts src/mcp/channel-tools.ts test/e2e/qa-lab/runtime/mcp-channels-docker-client.ts test/scripts/docker-e2e-seeds.test.ts`.
- Documentation/build/patch checks: `pnpm docs:check-mdx`, `pnpm build`, and `git diff --check`.
- Exact-current packaged Docker proof: `pnpm test:docker:mcp-channels` passed with `{ "ok": true, "canonicalMediaAttachmentFound": true, "nonOwnerReplyForwarded": true, "nonOwnerPermissionBlocked": true, "ownerPermissionAllowed": true }`; this is packaged/mock-Gateway end-to-end proof, not a live authenticated external-channel run.
- Direct upstream contract inspection: the installed MCP SDK `dist/esm/shared/protocol.js:169-175,314-320,670-685` and `dist/esm/shared/protocol.d.ts:170-177` establish cancellation-to-request-signal ownership; the sibling Codex source `codex-rs/rmcp-client/src/rmcp_client.rs:756-812`, `codex-rs/rmcp-client/src/event_notification_transport.rs:121-145`, and `codex-rs/mcp-server/src/message_processor.rs:533-575` verify MCP tool-result and cancellation lifecycle contracts. Canonical persisted media ownership is `src/media/media-facts.ts:69-81`.
- Production LOC: `+139/-54` (net `+85`); tests/proof: `+262/-15`; docs: `+7/-3`. The production growth is required by additive media/gap result contracts, single-owner cancellation settlement, retryable delivery ownership, and complete multi-owner shutdown across six independently reproduced defects; no compatibility shim, dependency, version, protocol bump, or changelog change is introduced.
