### PR TITLE
fix(context-engine): ignore terminal blocked outbox rows

### DIFF
--- a/src/agents/harness/context-engine-turn-attempt.test.ts
+++ b/src/agents/harness/context-engine-turn-attempt.test.ts
@@ -330,14 +330,16 @@ describe("accepted context-engine turn finalization", () => {
       ),
     ).toMatchObject({ state: "blocked", failure: "stale" });
 
+    const nextAdmission = {
+      ...admission,
+      logicalTurnId: "logical-turn-next",
+    };
     await drainPendingContextEngineTurnsBeforeRun({
-      admission,
+      admission: nextAdmission,
       lease,
       warn,
     });
-    expect(lease.degradeBeforeStart).toHaveBeenCalledWith(
-      "pending durable turn advancement could not be completed before the next turn",
-    );
+    expect(lease.degradeBeforeStart).not.toHaveBeenCalled();
 
     const sibling = await appendTranscriptMessage(target, {
       message: { role: "assistant", content: "sibling" },

--- a/src/agents/harness/context-engine-turn-outbox.test.ts
+++ b/src/agents/harness/context-engine-turn-outbox.test.ts
@@ -137,6 +137,50 @@ describe("context-engine turn outbox", () => {
     ).toBeUndefined();
   });
 
+  it("keeps a row pending when its persisted payload has no state", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-context-outbox-state-"));
+    tempDirs.push(stateDir);
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const payload = createPayload({
+      advancementKey: "session-a:missing-state",
+      databasePath: database.path,
+      sequence: 1,
+      sessionId: "session-a",
+    });
+    enqueueContextEngineTurnCommit({ database, engineId: "test", payload });
+    database.db
+      .prepare(
+        "UPDATE context_engine_turn_outbox SET payload_json = '{}' WHERE advancement_key = ?",
+      )
+      .run(payload.boundary.admission.logicalTurnId);
+    const commitTurn = vi.fn(async () => ({ status: "committed" as const }));
+    const engine = {
+      info: { id: "test", name: "Test" },
+      ingest: async () => ({ ingested: true }),
+      assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+      compact: async () => ({ ok: true, compacted: false }),
+      commitTurn,
+    } satisfies ContextEngine;
+
+    const result = await drainContextEngineTurnOutbox({
+      database,
+      engine,
+      engineId: "test",
+      warn: vi.fn(),
+    });
+
+    expect(result.pending).toBe(true);
+    expect(commitTurn).not.toHaveBeenCalled();
+    expect(
+      database.db
+        .prepare("SELECT 1 FROM context_engine_turn_outbox WHERE advancement_key = ?")
+        .get(payload.boundary.admission.logicalTurnId),
+    ).toBeDefined();
+  });
+
   it("drains prior work before fresh-turn assembly and records dispatch admission", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-context-outbox-recovery-"));
     tempDirs.push(stateDir);
@@ -372,7 +416,7 @@ describe("context-engine turn outbox", () => {
     });
   });
 
-  it("retains unrecoverable accepted recovery as a blocking marker", async () => {
+  it("retains unrecoverable accepted recovery as a terminal marker without blocking later turns", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-context-outbox-blocked-"));
     tempDirs.push(stateDir);
     const database = openOpenClawAgentDatabase({
@@ -417,6 +461,17 @@ describe("context-engine turn outbox", () => {
       expect.stringContaining("blocked unrecoverable turn advancement"),
     );
 
+    enqueueContextEngineTurnCommit({
+      database,
+      engineId: "test",
+      payload: createPayload({
+        advancementKey: "session-a:later-ready",
+        databasePath: database.path,
+        sequence: 3,
+        sessionId: "session-a",
+      }),
+    });
+
     const engine = {
       info: {
         id: "test",
@@ -445,22 +500,43 @@ describe("context-engine turn outbox", () => {
       deferDisposalUntil: vi.fn(),
       dispose: vi.fn(async () => undefined),
     } satisfies ContextEngineLogicalTurnLease;
+    const currentAdmission = {
+      ...payload.boundary.admission,
+      logicalTurnId: "session-a:current",
+    };
 
     await drainPendingContextEngineTurnsBeforeRun({
-      admission: payload.boundary.admission,
+      admission: currentAdmission,
       lease,
       warn,
     });
 
-    expect(engine.commitTurn).not.toHaveBeenCalled();
-    expect(degradeBeforeStart).toHaveBeenCalledWith(
-      "pending durable turn advancement could not be completed before the next turn",
+    expect(engine.commitTurn).toHaveBeenCalledOnce();
+    expect(engine.commitTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ advancementKey: "session-a:later-ready" }),
     );
+    expect(degradeBeforeStart).not.toHaveBeenCalled();
     expect(
       database.db
         .prepare("SELECT 1 FROM context_engine_turn_outbox WHERE advancement_key = ?")
         .get(payload.boundary.admission.logicalTurnId),
     ).toBeDefined();
+    expect(
+      database.db
+        .prepare("SELECT 1 FROM context_engine_turn_outbox WHERE advancement_key = ?")
+        .get("session-a:later-ready"),
+    ).toBeUndefined();
+    expect(
+      JSON.parse(
+        (
+          database.db
+            .prepare(
+              "SELECT payload_json FROM context_engine_turn_outbox WHERE advancement_key = ?",
+            )
+            .get(currentAdmission.logicalTurnId) as { payload_json: string }
+        ).payload_json,
+      ),
+    ).toMatchObject({ state: "admitted" });
   });
 
   it("does not let later same-session turns overtake a failed commit", async () => {

--- a/src/agents/harness/context-engine-turn-outbox.ts
+++ b/src/agents/harness/context-engine-turn-outbox.ts
@@ -75,6 +75,12 @@ function oldestOutboxEnqueueSequence() {
   return /* kysely-allow-raw: Aggregate the closed implicit-rowid expression used for enqueue order. */ sql<number>`MIN(context_engine_turn_outbox.rowid)`;
 }
 
+function outboxPayloadRequiresAdvancement() {
+  // Blocked rows are terminal audit evidence, not retryable work. Keep them
+  // inspectable without letting them hold later same-session turns behind them.
+  return /* kysely-allow-raw: Payload state is owned by the closed outbox union above. */ sql<boolean>`json_extract(context_engine_turn_outbox.payload_json, '$.state') IS NOT 'blocked'`;
+}
+
 export function isRetryableContextEngineTurnReadFailure(
   kind: ContextEngineTurnReadFailureKind,
 ): kind is "projection-unavailable" {
@@ -356,7 +362,8 @@ export async function drainContextEngineTurnOutbox(params: {
     // Use it instead of wall-clock timestamps, which can collide.
     .select(oldestOutboxEnqueueSequence().as("oldest_enqueue_sequence"))
     .where("engine_id", "=", params.engineId)
-    .where("owner_plugin_id", params.ownerPluginId ? "=" : "is", params.ownerPluginId ?? null);
+    .where("owner_plugin_id", params.ownerPluginId ? "=" : "is", params.ownerPluginId ?? null)
+    .where(outboxPayloadRequiresAdvancement());
   if (params.sessionId) {
     pendingSessionsQuery = pendingSessionsQuery.where("session_id", "=", params.sessionId);
   }
@@ -382,6 +389,7 @@ export async function drainContextEngineTurnOutbox(params: {
           .where("engine_id", "=", params.engineId)
           .where("owner_plugin_id", params.ownerPluginId ? "=" : "is", params.ownerPluginId ?? null)
           .where("session_id", "=", sessionId)
+          .where(outboxPayloadRequiresAdvancement())
           .orderBy(outboxEnqueueSequence(), "asc")
           .limit(1),
       );
@@ -409,7 +417,8 @@ function hasPendingContextEngineTurn(
     .selectFrom("context_engine_turn_outbox")
     .select("advancement_key")
     .where("engine_id", "=", params.engineId)
-    .where("owner_plugin_id", params.ownerPluginId ? "=" : "is", params.ownerPluginId ?? null);
+    .where("owner_plugin_id", params.ownerPluginId ? "=" : "is", params.ownerPluginId ?? null)
+    .where(outboxPayloadRequiresAdvancement());
   if (params.sessionId) {
     query = query.where("session_id", "=", params.sessionId);
   }


### PR DESCRIPTION
Closes #126591

## What Problem This Solves

Fixes an issue where users whose context engine records one unrecoverable turn advancement would have later turns repeatedly degraded because the terminal outbox row was still counted as pending work.

## Why This Change Was Made

Blocked outbox payloads are terminal audit evidence, not retryable advancement work. This change excludes only rows whose persisted state is explicitly `blocked` from all pending/drain selection points while leaving those records stored and inspectable. Retryable failed rows keep their existing ordering behavior, and missing/unknown states remain pending (fail closed).

## User Impact

One unrecoverable context-engine advancement no longer forces later turns to degrade or prevents later ready advancement from committing. Operators retain the terminal record for diagnostics.

## Evidence

### Real setup, after fix

Verified on a running OpenClaw 2026.8.1 main-based installation at `8e0d1bce85d3`, with `lossless-claw` 1.0.0-beta.4 loaded as the active context engine. The installed build contains the same three-selector blocked-row exclusion exercised by this PR. The proof turn used the real Gateway and provider, did not use tools, and was not delivered to a channel.

Two supported `openclaw backup sqlite create --agent main` snapshots bracketed a turn targeted at a session with a retained blocked row. Identifiers below are one-way SHA-3 prefixes; no transcript or credential content is included.

```text
before snapshot sha256: a4d0239f1835c2143c69ff872d3f42f8a6387d084c2232d9e0aae435128a4865
session_hash | rowid | state   | failure | created_at
A552B1B3A436 | 52    | blocked | stale   | 1787215442326

gateway turn (no channel delivery):
OUTBOX_PROOF_OK
[lcm] commitTurn: tokenBudget not provided; using default 128000
[agents/agent-command] run <redacted> ended with stopReason=stop

after snapshot sha256: 61cfa093a05dfe3b9f4e7529668ef71b2609135af5d0c6b47ea59fd869006c53
session_hash | rowid | state   | failure | created_at
A552B1B3A436 | 52    | blocked | stale   | 1787215442326

after outbox state counts:
admitted | 15
blocked  | 22
ready/failed rows for the proof turn | 0

after snapshot checks:
PRAGMA quick_check       -> ok
PRAGMA integrity_check   -> ok
PRAGMA foreign_key_check -> 0 rows
```

The retained audit row is unchanged before/after. Lossless `commitTurn` ran, the proof turn ended normally, and no ready/failed row survived the commit. The bounded Gateway/Lossless trace contained no legacy selection or `degradeBeforeStart` event.

### Kysely/SQLite contract

The repository pins Kysely 0.29.4. In that exact version, [`sql<T>` returns `RawBuilder<T>`](https://github.com/kysely-org/kysely/blob/bcd6e4e3c60f8068da6de105bb2f2c82d3a6b04b/src/raw-builder/sql.ts#L121-L124), [`where` accepts an expression of `SqlBool`](https://github.com/kysely-org/kysely/blob/bcd6e4e3c60f8068da6de105bb2f2c82d3a6b04b/src/query-builder/select-query-builder.ts#L99-L110), and [`SqlBool` includes boolean/SQLite 0/1](https://github.com/kysely-org/kysely/blob/bcd6e4e3c60f8068da6de105bb2f2c82d3a6b04b/src/util/type-utils.ts#L188).

An isolated Node 24 + `node:sqlite` execution using OpenClaw's real synchronous Kysely adapter compiled and ran the exact predicate:

```json
{
  "kyselyVersion": "0.29.4",
  "compiledSql": "select \"advancement_key\" from \"context_engine_turn_outbox\" where json_extract(context_engine_turn_outbox.payload_json, '$.state') IS NOT 'blocked' order by \"advancement_key\"",
  "parameters": [],
  "selectedAdvancementKeys": ["later-ready"]
}
```

The expression is static (no user-controlled interpolation), TypeScript accepted it under NodeNext, and `IS NOT` is intentional: it excludes only an explicit `blocked` state, while a missing state remains pending.

### Regression and repository checks

- Focused Vitest lane: 3 files, 13 tests passed.
- The blocked row remains stored, a later ready row commits, and the current turn is admitted without degradation.
- A new fail-closed regression proves a persisted payload with no state remains pending.
- Existing coverage continues to prove that retryable failed rows prevent same-session overtaking.
- `node scripts/check-changed.mjs -- <three changed paths>`: passed, including formatting, type checks, lint, dead-code, dependency, plugin-boundary, import-cycle, and schema guards.
- Kysely contract script: runtime execution passed and standalone TypeScript check passed.
- `git diff --check`: passed.

This PR is AI-assisted. The diagnosis, runtime proof, code, and tests were manually reviewed, and the contributor understands the change.
