### PR TITLE
fix(doctor): repair markerless legacy multi-agent rosters

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1858,6 +1858,33 @@ describe("doctor config flow", () => {
     expect(result.cfg.agents).not.toHaveProperty("list");
   });
 
+  it("stamps explicit ownership when Doctor migrates a markerless multi-agent list", async () => {
+    const rawConfig = {
+      agents: {
+        list: [{ id: "ops" }, { id: "research", model: "openai/research" }],
+      },
+    };
+    const result = await runDoctorConfigWithInput({
+      config: migratePersistedImplicitMainRoster(rawConfig).config as OpenClawConfig,
+      parsedConfig: rawConfig,
+      repair: true,
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(result.shouldWriteConfig).toBe(true);
+    expect(result.explicitSetPaths).toEqual([
+      ["agents", "entries"],
+      ["agents", "ownership"],
+    ]);
+    expect(result.cfg.agents).toEqual({
+      ownership: "explicit",
+      entries: {
+        ops: {},
+        research: { model: "openai/research" },
+      },
+    });
+  });
+
   it("materializes ambient roles for a multi-agent configured default", async () => {
     const rawConfig = {
       agents: {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -266,8 +266,7 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     const migratedRoster = readAgentRosterProperty(migrated);
     const migratedEntries = migratedRoster?.kind === "entries" ? migratedRoster.value : undefined;
     const { list: _legacyList, ...candidateAgents } = migrated.agents ?? {};
-    const stampsExplicitOwnership =
-      legacyDefaultAgentId !== undefined && Object.keys(migratedEntries ?? {}).length > 1;
+    const stampsExplicitOwnership = Object.keys(migratedEntries ?? {}).length > 1;
     const rosterRepair = {
       config: {
         ...migrated,


### PR DESCRIPTION
Closes #126571

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --fix` on a markerless legacy multi-agent roster would receive another validation error instead of a repaired configuration.

## Why This Change Was Made

Doctor now records explicit ownership whenever it canonicalizes a legacy roster with multiple agents. It still materializes ambient ownership only when the legacy configuration identifies a unique default agent.

## User Impact

Operators can migrate markerless legacy multi-agent configurations with Doctor without manually adding `agents.ownership`.

## Evidence

Before the fix, the focused regression failed because Doctor planned only the `agents.entries` write. The resulting multi-agent candidate had no `agents.ownership` and could not satisfy config validation.

After the fix, the same Doctor config-flow regression passes and verifies both canonical keyed entries and `agents.ownership: "explicit"`.

### Isolated Doctor proof

An isolated state directory started with this markerless legacy roster:

```json
{
  "agents": {
    "list": [
      { "id": "ops" },
      { "id": "research", "model": "openai/research" }
    ]
  }
}
```

`openclaw doctor --fix --yes` exited successfully and persisted:

```json
{
  "agents": {
    "entries": {
      "ops": {},
      "research": { "model": "openai/research" }
    },
    "ownership": "explicit"
  }
}
```

The repaired file then passed standalone schema validation:

```text
$ pnpm openclaw config validate
Config valid: $OPENCLAW_HOME/openclaw.json
1 warning(s):
  ! agents.defaults.heartbeat.agentId: Multi-agent config has no ambient heartbeat owner; heartbeats stay disabled until agents.defaults.heartbeat.agentId or agents.defaults.systemAgent.agentId is set.
```

Doctor also reported that its optional Gateway health check lacked credentials in the isolated environment. That did not affect the config write, Doctor's successful exit, or standalone schema validation.

Validation:

```text
pnpm vitest run src/commands/doctor-config-flow.test.ts --reporter=dot
Test Files 1 passed (1)
Tests 66 passed (66)

pnpm vitest run src/config/legacy.roster.test.ts --reporter=dot
Test Files 1 passed (1)
Tests 27 passed (27)

pnpm vitest run src/config/io.write-prepare.test.ts --reporter=dot
Test Files 1 passed (1)
Tests 99 passed (99)

pnpm tsgo:core
pnpm tsgo:core:test
pnpm tsgo:extensions:test
pnpm tsgo:test:root
pnpm exec oxfmt --check src/commands/doctor-config-flow.ts src/commands/doctor-config-flow.test.ts
pnpm exec oxlint src/commands/doctor-config-flow.ts src/commands/doctor-config-flow.test.ts
git diff --check origin/main...HEAD
```

Disclosure: AI was used to understand the codebase and review the fix.
