### PR TITLE
perf(test): inject QA evidence command runner

### DIFF
--- a/extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.script-evidence.test.ts
@@ -306,7 +306,7 @@ describe("qa test file scenario runner", () => {
     { producerStatus: "blocked" as const, terminal: "timeout" as const },
     { producerStatus: "skipped" as const, terminal: "exit" as const },
   ])(
-    "makes a real $terminal failure override colliding $producerStatus producer evidence",
+    "makes a $terminal failure override colliding $producerStatus producer evidence",
     async ({ producerStatus, terminal }) => {
       const commandName = path.basename(process.execPath);
       const tempRoot = await makeTempRepo(`qa-script-terminal-${terminal}-${producerStatus}-`);
@@ -321,28 +321,48 @@ describe("qa test file scenario runner", () => {
         producerId: "scenario-script",
         status: producerStatus,
       });
-      await fs.writeFile(
-        scriptPath,
-        [
-          "import fs from 'node:fs/promises';",
-          "import path from 'node:path';",
-          "const artifactBase = process.argv[process.argv.indexOf('--artifact-base') + 1];",
-          "const runRoot = path.join(artifactBase, 'run-1');",
-          "await fs.mkdir(runRoot, { recursive: true });",
-          "await fs.writeFile(path.join(runRoot, 'producer.log'), 'producer evidence\\n');",
-          `await fs.writeFile(path.join(runRoot, 'qa-evidence.json'), ${JSON.stringify(JSON.stringify(producerEvidence))});`,
-          "await fs.writeFile(path.join(artifactBase, 'latest-run.json'), JSON.stringify({ qaEvidence: 'run-1/qa-evidence.json' }));",
-          terminal === "timeout" ? "setInterval(() => {}, 1_000);" : "process.exitCode = 7;",
-        ].join("\n"),
-        "utf8",
-      );
-
       const result = await runQaTestFileScenarios({
         repoRoot: process.cwd(),
         outputDir,
         ...QA_TEST_RUNNER_DEFAULTS,
         scenarios: [makeTestFileScenario("script", scriptPath)],
         commandTimeoutMs: 1_000,
+        runCommand: async (command) => {
+          const artifactBase = path.join(outputDir, "scenario-script");
+          expect(command.args).toEqual([
+            "--import",
+            "tsx",
+            scriptPath,
+            "--once",
+            "--artifact-base",
+            artifactBase,
+          ]);
+          expect(command.timeoutMs).toBe(1_000);
+
+          const runRoot = path.join(artifactBase, "run-1");
+          await fs.mkdir(runRoot, { recursive: true });
+          await fs.writeFile(path.join(runRoot, "producer.log"), "producer evidence\n", "utf8");
+          await fs.writeFile(
+            path.join(runRoot, "qa-evidence.json"),
+            JSON.stringify(producerEvidence),
+            "utf8",
+          );
+          await fs.writeFile(
+            path.join(artifactBase, "latest-run.json"),
+            JSON.stringify({ qaEvidence: "run-1/qa-evidence.json" }),
+            "utf8",
+          );
+
+          return {
+            exitCode: terminal === "timeout" ? 1 : 7,
+            signal: null,
+            stdout: "",
+            stderr: "",
+            ...(terminal === "timeout"
+              ? { failureMessage: `${commandName} timed out after ${command.timeoutMs}ms` }
+              : {}),
+          };
+        },
       });
 
       expect(result.results[0]).toMatchObject({


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The QA evidence scenario test spends approximately one unnecessary second launching and timing out three real subprocesses solely to verify terminal-failure precedence over colliding producer evidence. This makes the maintainer-owned test lane slower without adding subprocess-lifecycle coverage beyond stronger existing sibling tests.

## Why This Change Was Made

Reuse the QA scenario runner's existing `runCommand` injection for the three collision rows while preserving real temporary directories, producer artifacts, evidence import, command arguments and timeout, terminal failures, collision precedence, coverage, and diagnostic assertions. Real exit, timeout, termination, descendant cleanup, parent-signal handling, and the real structured-evidence producer lifecycle remain covered by untouched sibling or same-file tests; no production seam or production code changes.

## User Impact

Developers and maintainers get a faster QA evidence test lane with unchanged production behavior and preserved observable evidence contracts. This is an explicitly requested, AI-assisted maintainer test-performance change; there is no user-facing product change.

## Evidence

- Controlled Blacksmith Testbox run: https://github.com/openclaw/openclaw/actions/runs/32345517185 (lease `tbx_01m0f24bcaqp2g9g5zm5wrjvrp`); one worker, distinct caches, explicit imports and `/usr/bin/time -v`, one excluded warmup and two retained runs per revision.
- Mean wall time: **5.285 s → 4.240 s**, an improvement of **1.045 s / 19.8%**; measured test body: **1.24 s → 143.5 ms**. The three collision rows improved from approximately **49 / 1,012 / 47 ms** to **4 / 4 / 4 ms**, with lower peak RSS.
- Focused target: **23 passing tests**. Fault injection replacing the failed terminal result with success made all three collision assertions fail; restoring the failure result returned the suite to green.
- Final owner-and-sibling proof: **36 passing tests** across the evidence target, real command lifecycle, and process sibling suites; complete changed-file gate passed, including plugin test typechecking and lint. Formatting and `git diff --check` passed.
- Fresh branch autoreview: **zero findings**, **0.99 confidence**. Production LOC: **+0/-0**. Tests: **+37/-17** in one existing test file. No documentation, changelog, screenshots, or production changes are required.
