### PR TITLE
fix(agents): run code-mode exec when a model sends a blank code alias

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -418,7 +418,8 @@ Rules:
 - `code` is the documented model-facing field.
 - `command` is accepted as an exec-compatible alias for hook policies and
   trusted rewrites (the normal OpenClaw shell exec tool also uses a `command`
-  field); when both are present, the values must match.
+  field). Blank aliases are treated as absent; when both aliases are non-empty,
+  their values must match.
 - `language` defaults to `"javascript"`; the schema exposes it as a flat
   string enum (`"javascript" | "typescript"`), not a `oneOf`/`anyOf` union,
   since some providers reject those shapes.

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -962,6 +962,40 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     );
 
     beforeToolCallHook.mockClear();
+    const blankCodeAliasResult = await def.execute(
+      "call-code-mode-exec-blank-code",
+      { code: "", command: "return 3;" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(blankCodeAliasResult.details).toMatchObject({
+      status: "blocked",
+      reason: "blocked before code-mode execution",
+    });
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { code: "return 3;", command: "return 3;" },
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec-blank-code",
+      },
+      {
+        toolName: "exec",
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec-blank-code",
+      },
+    );
+
+    beforeToolCallHook.mockClear();
     const typescriptResult = await def.execute(
       "call-code-mode-exec-typescript",
       {
@@ -1274,6 +1308,49 @@ describe("before_tool_call hook deduplication (#15502)", () => {
       code: "return 2;",
       command: "return 2;",
     });
+  });
+
+  it("fails closed when a hook blanks one code-mode exec alias", async () => {
+    // A blank alias from the caller is treated as absent, but a hook that
+    // deliberately blanks `code` is a policy decision: mirror it so neither
+    // alias survives, rather than silently running the original command.
+    beforeToolCallHook = installBeforeToolCallHook({
+      runBeforeToolCallImpl: async () => ({ params: { code: "" } }),
+    });
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const tool = markCodeModeControlTool(
+      asAgentTool({
+        name: CODE_MODE_EXEC_TOOL_NAME,
+        execute,
+        description: "exec",
+        parameters: {},
+      }),
+    );
+    const [def] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionId: "session-main",
+      runId: "run-main",
+    });
+    if (!def) {
+      throw new Error("missing custom tool definition");
+    }
+    const extensionContext = {} as Parameters<typeof def.execute>[4];
+
+    await def.execute(
+      "call-code-mode-exec-blank-rewrite",
+      { code: "", command: "return 1;" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-code-mode-exec-blank-rewrite",
+      { code: "", command: "" },
+      undefined,
+      undefined,
+    );
   });
 
   it("renormalizes trusted policy rewrites before code-mode exec hooks observe params", async () => {

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -1385,6 +1385,9 @@ describe("before_tool_call hook deduplication (#15502)", () => {
                 },
               };
             }
+            if (eventValue.toolCallId === "call-code-mode-trusted-blank") {
+              return { params: { code: "", command: "return 4;" } };
+            }
             return undefined;
           },
         },
@@ -1433,6 +1436,13 @@ describe("before_tool_call hook deduplication (#15502)", () => {
       await def.execute(
         "call-code-mode-trusted-language",
         { code: "return 3;", command: "return 3;", language: "javascript" },
+        undefined,
+        undefined,
+        extensionContext,
+      );
+      await def.execute(
+        "call-code-mode-trusted-blank",
+        { code: "return 4;", command: "return 4;" },
         undefined,
         undefined,
         extensionContext,
@@ -1548,6 +1558,23 @@ describe("before_tool_call hook deduplication (#15502)", () => {
         undefined,
         undefined,
       );
+      expect(normalHook).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ params: { code: "", command: "" } }),
+        expect.anything(),
+      );
+      expect(trustedObserver).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ params: { code: "", command: "" } }),
+        expect.anything(),
+      );
+      expect(execute).toHaveBeenNthCalledWith(
+        3,
+        "call-code-mode-trusted-blank",
+        { code: "", command: "" },
+        undefined,
+        undefined,
+      );
       expect(
         consumeAdjustedParamsForToolCall("call-code-mode-trusted-command", "run-main"),
       ).toEqual({ command: "return 2;", code: "return 2;" });
@@ -1557,6 +1584,10 @@ describe("before_tool_call hook deduplication (#15502)", () => {
         code: "const value: number = 3;",
         command: "const value: number = 3;",
         language: "typescript",
+      });
+      expect(consumeAdjustedParamsForToolCall("call-code-mode-trusted-blank", "run-main")).toEqual({
+        code: "",
+        command: "",
       });
     } finally {
       setActivePluginRegistry(createEmptyPluginRegistry());

--- a/src/agents/agent-tools.before-tool-call.policy.ts
+++ b/src/agents/agent-tools.before-tool-call.policy.ts
@@ -48,7 +48,7 @@ import type {
 } from "./agent-tools.before-tool-call.types.js";
 import {
   getCodeModeExecBeforeHookMetadataForToolKind,
-  normalizeCodeModeExecBeforeHookParamsForToolKind,
+  reconcileCodeModeExecBeforeHookParams,
 } from "./code-mode-control-tools.js";
 import { admitSingleToolCallLoop } from "./tool-loop-admission.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
@@ -206,6 +206,9 @@ export async function runBeforeToolCallHook(args: {
       ...(args.ctx?.requester ? { requester: args.ctx.requester } : {}),
     });
     const toolContext = buildToolContext(toolIdentity);
+    // Policies form a mutation chain. Reconcile each decision against the prior
+    // alias pair so an explicit blank rewrite remains fail-closed.
+    let trustedPolicyParams = normalizedParams;
     const trustedPolicyResult = shouldRunTrustedPolicies
       ? await runTrustedToolPolicies(
           {
@@ -224,13 +227,16 @@ export async function runBeforeToolCallHook(args: {
             ...(args.ctx?.config ? { config: args.ctx.config } : {}),
             deriveEvent: deriveToolEventParams,
             normalizeEvent(eventValue) {
-              const normalizedEventParams = normalizeCodeModeExecBeforeHookParamsForToolKind({
-                toolKind: eventValue.toolKind,
-                params: eventValue.params,
+              const normalizedEventParams = reconcileCodeModeExecBeforeHookParams({
+                owner: { toolKind: eventValue.toolKind },
+                originalParams: trustedPolicyParams,
+                hookParams: trustedPolicyParams,
+                adjustedParams: eventValue.params,
               });
               if (!isPlainObject(normalizedEventParams)) {
                 return undefined;
               }
+              trustedPolicyParams = normalizedEventParams;
               const normalizedEventIdentity = getCodeModeExecBeforeHookMetadataForToolKind({
                 toolKind: eventValue.toolKind,
                 params: normalizedEventParams,
@@ -277,11 +283,7 @@ export async function runBeforeToolCallHook(args: {
         trustedApprovalResolution = approvalOutcome.approvalResolution;
       }
     }
-    const rawPolicyAdjustedParams = trustedApprovalParams ?? trustedPolicyResult?.params ?? params;
-    const policyAdjustedParams = normalizeCodeModeExecBeforeHookParamsForToolKind({
-      toolKind: args.toolKind,
-      params: rawPolicyAdjustedParams,
-    });
+    const policyAdjustedParams = trustedApprovalParams ?? trustedPolicyResult?.params ?? params;
     const policyAdjustedToolIdentity =
       getCodeModeExecBeforeHookMetadataForToolKind({
         toolKind: args.toolKind,

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -126,7 +126,7 @@ export function finalizeBeforeToolCallExecutionParams(params: {
   finalizerMode: "adapter" | "wrapped";
 }): unknown {
   const reconciledParams = reconcileCodeModeExecBeforeHookParams({
-    tool: params.tool,
+    owner: { tool: params.tool },
     originalParams: params.preparedParams,
     hookParams: params.hookParams,
     adjustedParams: params.adjustedParams,

--- a/src/agents/code-mode-control-tools.ts
+++ b/src/agents/code-mode-control-tools.ts
@@ -122,26 +122,21 @@ export function normalizeCodeModeExecBeforeHookParams(params: {
   return normalizeCodeModeExecParams(params.params);
 }
 
-/** Normalize before-hook params when only the code-mode tool kind is available. */
-export function normalizeCodeModeExecBeforeHookParamsForToolKind(params: {
-  toolKind: unknown;
-  params: unknown;
-}): unknown {
-  if (params.toolKind !== CODE_MODE_EXEC_TOOL_KIND) {
-    return params.params;
-  }
-  return normalizeCodeModeExecParams(params.params);
-}
+type CodeModeExecReconcileOwner = { tool: AnyAgentTool } | { toolKind: unknown };
 
-/** Reconcile hook-adjusted `code` and `command` fields after code-mode normalization. */
+/** Reconcile policy- or hook-adjusted aliases after raw-input normalization. */
 export function reconcileCodeModeExecBeforeHookParams(params: {
-  tool: AnyAgentTool;
+  owner: CodeModeExecReconcileOwner;
   originalParams: unknown;
   hookParams: unknown;
   adjustedParams: unknown;
 }): unknown {
+  const isCodeModeExecOwner =
+    "tool" in params.owner
+      ? isCodeModeExecTool(params.owner.tool)
+      : params.owner.toolKind === CODE_MODE_EXEC_TOOL_KIND;
   if (
-    !isCodeModeExecTool(params.tool) ||
+    !isCodeModeExecOwner ||
     !isPlainObject(params.originalParams) ||
     !isPlainObject(params.hookParams) ||
     !isPlainObject(params.adjustedParams)

--- a/src/agents/code-mode-control-tools.ts
+++ b/src/agents/code-mode-control-tools.ts
@@ -2,6 +2,7 @@
  * Tags Code Mode exec/wait control tools and normalizes hook params for the
  * exec-compatible before-tool-call surface.
  */
+import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import { isPlainObject } from "../utils.js";
 import { normalizeToolPolicyName } from "./tool-policy.js";
 import type { AnyAgentTool } from "./tools/common.js";
@@ -67,15 +68,18 @@ function normalizeCodeModeExecParams(params: unknown): unknown {
   if (!isPlainObject(params)) {
     return params;
   }
-  const code = params.code;
-  const command = params.command;
-  if (typeof code === "string" && typeof command !== "string") {
+  // Blank is not provided: a model that materializes every schema property sends
+  // `code: ""` alongside a real `command`, which must still pair rather than read
+  // as two divergent aliases.
+  const code = readNonBlankString(params.code);
+  const command = readNonBlankString(params.command);
+  if (code !== undefined && command === undefined) {
     // Code-mode accepts both `code` and generic exec `command`; keep them paired
     // so downstream hooks can read either shape.
-    return { ...params, command: params.code };
+    return { ...params, command: code };
   }
-  if (typeof command === "string" && typeof code !== "string") {
-    return { ...params, code: params.command };
+  if (command !== undefined && code === undefined) {
+    return { ...params, code: command };
   }
   return params;
 }

--- a/src/agents/code-mode-control-tools.ts
+++ b/src/agents/code-mode-control-tools.ts
@@ -68,9 +68,6 @@ function normalizeCodeModeExecParams(params: unknown): unknown {
   if (!isPlainObject(params)) {
     return params;
   }
-  // Blank is not provided: a model that materializes every schema property sends
-  // `code: ""` alongside a real `command`, which must still pair rather than read
-  // as two divergent aliases.
   const code = readNonBlankString(params.code);
   const command = readNonBlankString(params.command);
   if (code !== undefined && command === undefined) {

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -283,18 +283,15 @@ export function readCode(args: unknown): {
   restartSafe: boolean;
 } {
   const params = asToolParamsRecord(args);
-  const codeParam = params.code;
-  const commandParam = params.command;
-  // A blank alias is not a provided alias. Some models materialize every schema
-  // property, so a caller sending only `command` still emits `code: ""`; treating
-  // that as "provided" rejected the call before it ran.
-  const codeText = readNonBlankString(codeParam);
-  const commandText = readNonBlankString(commandParam);
-  if (codeText !== undefined && commandText !== undefined && codeText !== commandText) {
+  // Full-schema tool calls can materialize an unused alias as blank.
+  // Only nonblank aliases participate in divergence checks.
+  const codeAlias = readNonBlankString(params.code);
+  const commandAlias = readNonBlankString(params.command);
+  if (codeAlias !== undefined && commandAlias !== undefined && codeAlias !== commandAlias) {
     throw new ToolInputError("code and command must match when both are provided.");
   }
-  const code = commandText ?? codeText;
-  if (typeof code !== "string" || !code.trim()) {
+  const code = commandAlias ?? codeAlias;
+  if (code === undefined) {
     throw new ToolInputError("code or command must be a non-empty string.");
   }
   const language = params.language;

--- a/src/agents/code-mode-runtime.ts
+++ b/src/agents/code-mode-runtime.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
 import { parse, tokenizer } from "acorn";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -284,14 +285,15 @@ export function readCode(args: unknown): {
   const params = asToolParamsRecord(args);
   const codeParam = params.code;
   const commandParam = params.command;
-  if (
-    typeof codeParam === "string" &&
-    typeof commandParam === "string" &&
-    codeParam !== commandParam
-  ) {
+  // A blank alias is not a provided alias. Some models materialize every schema
+  // property, so a caller sending only `command` still emits `code: ""`; treating
+  // that as "provided" rejected the call before it ran.
+  const codeText = readNonBlankString(codeParam);
+  const commandText = readNonBlankString(commandParam);
+  if (codeText !== undefined && commandText !== undefined && codeText !== commandText) {
     throw new ToolInputError("code and command must match when both are provided.");
   }
-  const code = typeof commandParam === "string" ? commandParam : codeParam;
+  const code = commandText ?? codeText;
   if (typeof code !== "string" || !code.trim()) {
     throw new ToolInputError("code or command must be a non-empty string.");
   }

--- a/src/agents/code-mode.guest.test.ts
+++ b/src/agents/code-mode.guest.test.ts
@@ -66,6 +66,52 @@ describe("Code Mode guest execution", () => {
   });
 
   it.each([
+    { alias: "blank code", args: { code: "", command: "return 7;" } },
+    { alias: "whitespace code", args: { code: "   ", command: "return 7;" } },
+    { alias: "blank command", args: { code: "return 7;", command: "" } },
+    { alias: "whitespace command", args: { code: "return 7;", command: "  \n " } },
+  ])("runs the populated alias when the other is $alias", async ({ args }) => {
+    const { config, catalogRef, tools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...tools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    const result = resultDetails(
+      await expectDefined(tools[0], "tools[0] test invariant").execute(
+        "code-call-blank-alias",
+        args,
+      ),
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.value).toBe(7);
+  });
+
+  it("still rejects when both aliases are blank", async () => {
+    const { config, catalogRef, tools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...tools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    await expect(
+      expectDefined(tools[0], "tools[0] test invariant").execute("code-call-blank-both", {
+        code: "",
+        command: "   ",
+      }),
+    ).rejects.toThrow("code or command must be a non-empty string");
+  });
+
+  it.each([
     { code: "ls -la /workspace/" },
     { code: "ls -1" },
     { command: "ls -la /workspace/" },


### PR DESCRIPTION
Related: #118489

> Written with AI assistance (Claude Opus 5 and Codex). The contributor's full-schema alias behavior is preserved; this repair validated and simplified its owner-boundary implementation.

## What Problem This Solves

Some models materialize every Code Mode `exec` schema property. A command-only call can therefore arrive as `{ command: "<script>", code: "" }`. Runtime mismatch validation treated the blank alias as provided and rejected the call before guest execution. The before-tool hook normalizer used the same faulty presence rule, so policy hooks also saw divergent aliases.

## Fix

- Normalize caller aliases with `readNonBlankString` at both owners: hook presentation and runtime execution.
- Keep populated aliases paired for hooks and executable at runtime.
- Preserve rejection for two nonblank divergent aliases.
- Preserve fail-closed policy behavior: a hook or trusted policy that blanks one paired alias blanks both, then runtime rejects the empty command.
- Reconcile each trusted-policy mutation against the exact prior alias pair; raw model normalization is not reused for policy output.
- Remove redundant normalization paths and locals. Production delta: **−3 net lines**; regression coverage: `+154` test lines.

## Evidence

Pre-fix real Telegram reproduction on current `main`:

- Mock provider emitted `{ command: 'return "CODE_MODE_BLANK_ALIAS_VALUE";', code: "" }`.
- Gateway rejected it with `code and command must match when both are provided.`
- No second provider request carried a guest result; Telegram emitted the generic no-visible-reply fallback.

Exact pushed head: `19916d128b317776831bb1808baa249b563d5923`

- Code Mode and policy unit/plugin suites: **266 tests passed**.
- Before-tool policy E2E: **99 tests passed**.
- Before-tool integration E2E: **46 tests passed**.
- Trusted-policy security regression: failed before the repair because `{ code: "", command: "return 4;" }` became two populated aliases; passes after repair with both aliases blank downstream.
- Exact-head after-fix Code Mode guest proof:

  ```text
  node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts \
    src/agents/code-mode.guest.test.ts \
    -t "runs the populated alias when the other is" --reporter=verbose

  ✓ runs the populated alias when the other is 'blank code'
  ✓ runs the populated alias when the other is 'whitespace code'
  ✓ runs the populated alias when the other is 'blank command'
  ✓ runs the populated alias when the other is 'whitespace command'
  Test Files 1 passed · Tests 4 passed
  ```
- Exact-head ephemeral Gateway + mock-provider proof (`OpenClaw 2026.8.1 (19916d1)`):

  ```json
  {"tool":"exec","arguments":{"command":"return \"CODE_MODE_BLANK_ALIAS_VALUE\";","code":""}}
  {"toolResult":{"status":"completed","value":"CODE_MODE_BLANK_ALIAS_VALUE"}}
  {"agent":{"status":"ok","summary":"completed","finalText":"CODE_MODE_BLANK_ALIAS_EXECUTED","successfulToolNames":["exec"],"toolFailures":0}}
  ```

  This uses the real Gateway and embedded agent loop with the deterministic mock provider. The second provider request contains the completed guest result; the final reply proves the changed alias path executed rather than falling back.
- `pnpm tsgo`: passed.
- `pnpm check:test-types`: passed.
- `node scripts/check-changed.mjs -- docs/tools/code-mode.md src/agents/agent-tools.before-tool-call.integration.e2e.test.ts src/agents/agent-tools.before-tool-call.policy.ts src/agents/agent-tools.before-tool-call.wrapper.ts src/agents/code-mode-control-tools.ts src/agents/code-mode-runtime.ts src/agents/code-mode.guest.test.ts`: passed.
- Docs formatting, MDX, and link checks: passed (`6,524` internal links, `0` broken).
- `git diff --check`: passed.

- Exact-head CI: passed on rerun attempt 2 (`32356772242`). Attempt 1's sole failure was GitHub's `actions/checkout` download receiving HTTP 429 before repository checkout; the exact failed job passed unchanged on rerun.
- Exact-head local ClawSweeper: **PASS** — `0` findings, `0` security concerns, no maintainer decision, `0` Rank-up moves.
- Final real Telegram user proof with the reusable `code-mode-blank-alias` fixture: **PASS**. The provider emitted `{"command":"return \"CODE_MODE_BLANK_ALIAS_VALUE\";","code":""}`; the next provider request received `{ "status": "completed", "value": "CODE_MODE_BLANK_ALIAS_VALUE" }`; Telegram delivered `CODE_MODE_BLANK_ALIAS_EXECUTED`. Recorded timeline: one user message, two typing events, the temporary `Working / Exec` message, the final result, then deletion of the temporary message. No fallback reply.

`docs/tools/code-mode.md` now states the same public contract: blank aliases are absent; two non-empty aliases must match.
