### PR TITLE
fix(gateway): prevent enrolled node recovery from blocking startup

### DIFF
--- a/src/gateway/server.node-pairing-rate-limit.test.ts
+++ b/src/gateway/server.node-pairing-rate-limit.test.ts
@@ -1,9 +1,10 @@
 // Node pairing rate-limit tests protect repeated pairing attempts, pending
 // request cleanup, and protocol error details for node clients.
 import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
 import {
@@ -18,6 +19,8 @@ import {
 } from "../infra/device-pairing-node.js";
 import { requestDevicePairing } from "../infra/device-pairing.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import type { NodeRegistry } from "./node-registry.js";
+import * as gatewayWsRuntime from "./server-ws-runtime.js";
 import {
   connectReq,
   installGatewayTestHooks,
@@ -100,6 +103,56 @@ async function approveNodeIdentity(params: { identityPath: string; caps: string[
 }
 
 describe("node pairing rate limit", () => {
+  test("admits an authenticated paired node while gateway startup is pending", async () => {
+    testState.gatewayAuth = { mode: "token", token: "secret" };
+    const identityDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-node-startup-"));
+    const identityPath = path.join(identityDir, "identity.sqlite");
+    const attachGatewayWsHandlers = gatewayWsRuntime.attachGatewayWsHandlers;
+    let nodeRegistry: NodeRegistry | undefined;
+    const startupAdmission = vi
+      .spyOn(gatewayWsRuntime, "attachGatewayWsHandlers")
+      .mockImplementation((params) => {
+        nodeRegistry = params.context.nodeRegistry;
+        return attachGatewayWsHandlers({ ...params, isStartupPending: () => true });
+      });
+
+    try {
+      await withGatewayServer(async ({ port }) => {
+        const identity = await approveNodeIdentity({ identityPath, caps: [] });
+        const ws = await openWs(port);
+        try {
+          const response = await connectReq(ws, {
+            token: "secret",
+            role: "node",
+            scopes: [],
+            client: NODE_CLIENT,
+            caps: [],
+            commands: [],
+            deviceIdentityPath: identityPath,
+          });
+
+          expect(response.ok).toBe(true);
+          expect(response.payload).toMatchObject({ type: "hello-ok" });
+          expect(nodeRegistry?.get(identity.deviceId)).toMatchObject({
+            nodeId: identity.deviceId,
+          });
+        } finally {
+          ws.close();
+          await new Promise<void>((resolve) => {
+            if (ws.readyState === WebSocket.CLOSED) {
+              resolve();
+              return;
+            }
+            ws.once("close", () => resolve());
+          });
+        }
+      });
+    } finally {
+      startupAdmission.mockRestore();
+      await rm(identityDir, { recursive: true, force: true });
+    }
+  });
+
   test("limits concurrent first-time node pairing requests before the pairing lock", async () => {
     testState.gatewayAuth = {
       mode: "token",

--- a/src/gateway/server/ws-connection/connect-admission.ts
+++ b/src/gateway/server/ws-connection/connect-admission.ts
@@ -117,7 +117,10 @@ export async function admitGatewayConnect(context: GatewayConnectPhaseContext) {
     sendFrame,
   } = context;
 
-  if (isStartupPending?.()) {
+  const isNodeClient =
+    connectParams.role === "node" && connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE;
+  // Startup awaits node enrollment; node authentication and pairing still run below.
+  if (isStartupPending?.() && !isNodeClient) {
     markHandshakeFailure(GATEWAY_STARTUP_PENDING_CLOSE_CAUSE);
     await sendFrame({
       type: "res",
@@ -144,8 +147,7 @@ export async function admitGatewayConnect(context: GatewayConnectPhaseContext) {
   // Protocol v4 changed chat deltas, not node RPC frames. Keep N-1 limited to
   // the node role+mode so stale operator/UI clients cannot enter the v4 surface.
   const supportsPreviousNodeProtocol =
-    connectParams.role === "node" &&
-    connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE &&
+    isNodeClient &&
     maxProtocol >= MIN_NODE_PROTOCOL_VERSION &&
     minProtocol <= MIN_NODE_PROTOCOL_VERSION;
   const usesLegacyNodeProtocol = !supportsCurrentProtocol && supportsPreviousNodeProtocol;

--- a/src/test-helpers/state-dir-env.ts
+++ b/src/test-helpers/state-dir-env.ts
@@ -35,6 +35,6 @@ export async function withStateDirEnv<T>(
     // that cleanup failure hide the original test error or skip env restoration.
     await cleanupSessionStateForTest({ stateDir }).catch(() => undefined);
     restoreStateDirEnv(snapshot);
-    await fs.rm(tempRoot, { recursive: true, force: true });
+    await fs.rm(tempRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   }
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators restarting a Gateway with persisted worker environments could see recovery hang because a previously enrolled node could not reconnect while startup was still pending.

## Why This Change Was Made

Gateway startup synchronously reconciles persisted worker environments before sidecars and overall readiness. Worker provisioning waits for its enrolled node to become paired and connected, but generic WebSocket connect admission previously rejected every client during pending startup before node authentication and pairing could run. Those two lifecycle owners consequently waited on each other.

Allow only the existing exact node protocol identity, `role=node` plus `client.mode=node`, past the startup routing gate. The normal protocol, authentication, device pairing, scope, lifecycle, and node-owner checks still run unchanged afterward. Operators, UI clients, probes, and unknown clients remain unavailable until startup completes; reserved raw-worker ingress also remains startup-gated and is not part of provisioning before a lease returns. There are no configuration, environment, schema, dependency, timeout, retry, or fallback changes.

## User Impact

Previously enrolled nodes can reconnect during Gateway startup so persisted worker-environment recovery can complete normally. Existing authentication and pairing requirements remain intact, and all other client categories retain their existing startup-unavailable behavior. This is preventive application code only; the PR does not modify or deploy any running production environment.

## Evidence

- Real-WebSocket regression pre-approves an authenticated node identity, forces startup pending, receives `hello-ok`, and observes registration in `NodeRegistry`.
- The same regression fails on pre-fix code for the intended startup-unavailable reason.
- Post-rebase `node scripts/run-vitest.mjs src/gateway/server.node-pairing-rate-limit.test.ts` passed **8 tests across 2 Gateway projects**; broader focused Gateway validation previously passed **64 tests** across the routed suites.
- Changed-file validation completed **23 substantive checks**, including production and test typechecking, lint/format, dead-export guards, and database guards. Its only remaining gap is environmental: the runtime-sidecar-loader guard cannot start because this fresh linked worktree has no local `node_modules/playwright-core`; dependencies were intentionally not installed or reconciled for that guard.
- Exact-head CI exposed an unrelated `ENOTEMPTY` race while recursively removing a temporary state directory. The shared test helper now uses Node's bounded recursive-removal retries; `sessions-resolve-store.test.ts` then passed **10/10 repeated runs** (**26 tests per run**).
- Targeted formatting and `git diff --check` passed.
- Fresh structured AI-assisted Codex reviews reported no actionable findings for the node fix (**0.97 confidence**) or cleanup retry (**0.99 confidence**).
- Production delta: **+5/-3, net +2 lines**. Regression-test delta: **+54/-1, net +53 lines**. Test-support cleanup is **+1/-1, net neutral**. Raw-worker ingress is unchanged.

