### PR TITLE
fix(agents): stop duplicate replies after terminal question delivery failures

### DIFF
--- a/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.test.ts
@@ -393,18 +393,22 @@ describe("classifyEmbeddedAgentRunResultForModelFallback", () => {
     });
   });
 
-  it("does not fallback after a yielded empty result records potential side effects", () => {
+  it.each([
+    {
+      label: "a yielded empty result records potential side effects",
+      meta: { replayInvalid: true, yielded: true, stopReason: "end_turn" },
+    },
+    {
+      label: "an exact terminal tool batch intentionally completes the turn",
+      meta: { intentionalTerminalCompletion: "tool-batch" as const },
+    },
+  ])("does not fallback after $label", ({ meta }) => {
     const result = classifyEmbeddedAgentRunResultForModelFallback({
       provider: "openai",
       model: "gpt-5.5",
       result: {
         payloads: [],
-        meta: {
-          durationMs: 42,
-          replayInvalid: true,
-          yielded: true,
-          stopReason: "end_turn",
-        },
+        meta: { durationMs: 42, ...meta },
       },
     });
 

--- a/src/agents/embedded-agent-runner/result-fallback-classifier.ts
+++ b/src/agents/embedded-agent-runner/result-fallback-classifier.ts
@@ -78,6 +78,10 @@ export function hasDeliberateSilentTerminalReply(result: EmbeddedAgentRunResult)
   );
 }
 
+export function hasIntentionalTerminalCompletion(result: EmbeddedAgentRunResult): boolean {
+  return result.meta.intentionalTerminalCompletion === "tool-batch";
+}
+
 function hasDeliverableAssistantPayload(result: {
   payloads?: unknown;
   meta?: { finalAssistantVisibleText?: unknown };
@@ -201,6 +205,7 @@ export function classifyEmbeddedAgentRunResultForModelFallback(params: {
     return null;
   }
   if (
+    hasIntentionalTerminalCompletion(params.result) ||
     params.result.meta.aborted ||
     params.hasDirectlySentBlockReply === true ||
     params.hasBlockReplyPipelineOutput === true

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -191,6 +191,7 @@ export function resolveReasoningOnlyRetryInstruction(params: {
 }
 
 type SettledToolCall = { id: string | null; name: string | null };
+type SettledToolResult = { toolCallId?: unknown; toolName?: unknown; isError?: unknown };
 
 function readSettledToolCalls(
   message: EmbeddedRunAttemptResult["currentAttemptAssistant"] | null | undefined,
@@ -211,6 +212,63 @@ function readSettledToolCalls(
   });
 }
 
+/** Proves settlement and intentional termination for the exact current-turn tool-call batch. */
+export function resolveSettledToolBatchEvidence(attempt: IncompleteTurnAttempt) {
+  const snapshot = attempt.messagesSnapshot ?? [];
+  const latestUserIndex = snapshot.findLastIndex((message) => message.role === "user");
+  let assistant = attempt.currentAttemptAssistant;
+  let assistantIndex = assistant ? snapshot.indexOf(assistant) : -1;
+  if (assistantIndex <= latestUserIndex || readSettledToolCalls(assistant).length === 0) {
+    assistantIndex = snapshot.findLastIndex(
+      (message, index) =>
+        index > latestUserIndex &&
+        message.role === "assistant" &&
+        readSettledToolCalls(message).length > 0,
+    );
+    const candidate = assistantIndex >= 0 ? snapshot[assistantIndex] : undefined;
+    assistant = candidate?.role === "assistant" ? candidate : undefined;
+  }
+  const requestedToolCalls = readSettledToolCalls(assistant);
+  // Results must follow their owning assistant; session-wide reused ids cannot settle a new turn.
+  const settledToolResults = new Map(
+    (assistantIndex >= 0 ? snapshot.slice(assistantIndex + 1) : []).flatMap((message) => {
+      const { toolCallId, toolName, isError } = message as SettledToolResult;
+      return message.role === "toolResult" &&
+        typeof toolCallId === "string" &&
+        typeof toolName === "string"
+        ? [[toolCallId, { toolName, isError: isError === true }] as const]
+        : [];
+    }),
+  );
+  const allToolsProvenSettled =
+    attempt.itemLifecycle.startedCount > 0 &&
+    attempt.itemLifecycle.completedCount === attempt.itemLifecycle.startedCount &&
+    attempt.itemLifecycle.activeCount === 0 &&
+    requestedToolCalls.length > 0 &&
+    requestedToolCalls.every(
+      ({ id, name }) =>
+        id !== null && name !== null && settledToolResults.get(id)?.toolName === name,
+    );
+  const failedToolNames = new Set(
+    requestedToolCalls.flatMap(({ id, name }) =>
+      id !== null && name !== null && settledToolResults.get(id)?.isError === true ? [name] : [],
+    ),
+  );
+  const intentionalTermination =
+    allToolsProvenSettled &&
+    assistant?.stopReason === "toolUse" &&
+    failedToolNames.size === 0 &&
+    !attempt.lastToolError &&
+    !hasAsyncActivity(attempt.toolMetas) &&
+    requestedToolCalls.every(({ id, name }) => {
+      const metadata = attempt.toolMetas.findLast(
+        (entry) => entry.toolCallId === id && entry.toolName === name,
+      );
+      return metadata?.terminate === true && metadata.isError !== true;
+    });
+  return { assistant, allToolsProvenSettled, failedToolNames, intentionalTermination };
+}
+
 /** Builds one fresh continuation after settled tools ended without a visible final answer. */
 export function resolveSettledToolTerminalContinuationInstruction(params: {
   provider?: string;
@@ -224,118 +282,55 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
   timedOut: boolean;
   attempt: IncompleteTurnAttempt;
 }): string | null {
-  const currentAttemptAssistant = params.attempt.currentAttemptAssistant;
-  const snapshot = params.attempt.messagesSnapshot ?? [];
-  const latestUserIndex = snapshot.findLastIndex((message) => message.role === "user");
-  let assistant: EmbeddedRunAttemptResult["currentAttemptAssistant"] = currentAttemptAssistant;
-  let assistantIndex = assistant ? snapshot.indexOf(assistant) : -1;
-  if (assistantIndex <= latestUserIndex || readSettledToolCalls(assistant).length === 0) {
-    assistantIndex = snapshot.findLastIndex(
-      (message, index) =>
-        index > latestUserIndex &&
-        message.role === "assistant" &&
-        readSettledToolCalls(message).length > 0,
-    );
-    const assistantCandidate = assistantIndex >= 0 ? snapshot[assistantIndex] : undefined;
-    assistant = assistantCandidate?.role === "assistant" ? assistantCandidate : undefined;
-  }
-  const terminal = params.attempt.terminal;
+  const { attempt } = params;
+  const { assistant, allToolsProvenSettled, failedToolNames, intentionalTermination } =
+    resolveSettledToolBatchEvidence(attempt);
+  const terminal = attempt.terminal;
   const idlePromptTimeout =
     terminal.kind === "timeout" &&
     terminal.phase === "prompt" &&
     terminal.source === "idle" &&
-    params.attempt.currentAttemptReplayMetadata?.hadPotentialSideEffects === true;
+    attempt.currentAttemptReplayMetadata?.hadPotentialSideEffects === true;
   const emptyStopAfterSettledTools = Boolean(
     params.allowEmptyStopContinuation &&
-    currentAttemptAssistant?.stopReason === "stop" &&
-    params.attempt.toolMetas.length > 0 &&
-    params.attempt.toolMetas.every((tool) => tool.isError !== true && tool.asyncStarted !== true) &&
-    params.attempt.itemLifecycle.startedCount > 0 &&
-    params.attempt.itemLifecycle.completedCount === params.attempt.itemLifecycle.startedCount &&
-    params.attempt.itemLifecycle.activeCount === 0 &&
-    !hasAcceptedSessionSpawn(params.attempt.acceptedSessionSpawns) &&
+    attempt.currentAttemptAssistant?.stopReason === "stop" &&
+    attempt.toolMetas.length > 0 &&
+    attempt.toolMetas.every((tool) => tool.isError !== true && tool.asyncStarted !== true) &&
+    attempt.itemLifecycle.startedCount > 0 &&
+    attempt.itemLifecycle.completedCount === attempt.itemLifecycle.startedCount &&
+    attempt.itemLifecycle.activeCount === 0 &&
+    !hasAcceptedSessionSpawn(attempt.acceptedSessionSpawns) &&
     isEmptyResponseAssistantTurn({
       payloadCount: params.payloadCount,
-      attempt: params.attempt,
+      attempt,
     }),
   );
-  // Idle is not proof of settlement: skipped or partially dispatched tools must
-  // never be described as completed. Match each terminal call's id and owner to
-  // its own current-batch result; a reported failure is settled, not successful.
-  const requestedToolCalls = readSettledToolCalls(assistant);
-  // Scan only results AFTER the terminal assistant: the snapshot spans the whole
-  // session, and a prior turn's toolResult with a model-reused id would otherwise
-  // prove "completion" for a batch that never dispatched. Assistant not found in
-  // the snapshot fails closed to the existing incomplete-turn error.
-  const settledToolResults = new Map(
-    (assistantIndex >= 0 ? snapshot.slice(assistantIndex + 1) : []).flatMap((message) => {
-      const result = message as {
-        role?: unknown;
-        toolCallId?: unknown;
-        toolName?: unknown;
-        isError?: unknown;
-      };
-      return result.role === "toolResult" &&
-        typeof result.toolCallId === "string" &&
-        typeof result.toolName === "string"
-        ? [
-            [
-              result.toolCallId,
-              { toolName: result.toolName, isError: result.isError === true },
-            ] as const,
-          ]
-        : [];
-    }),
-  );
-  const allToolsProvenSettled =
-    params.attempt.itemLifecycle.startedCount > 0 &&
-    params.attempt.itemLifecycle.completedCount === params.attempt.itemLifecycle.startedCount &&
-    params.attempt.itemLifecycle.activeCount === 0 &&
-    requestedToolCalls.length > 0 &&
-    requestedToolCalls.every(
-      ({ id, name }) =>
-        id !== null && name !== null && settledToolResults.get(id)?.toolName === name,
-    );
-  const failedTerminalToolNames = new Set(
-    requestedToolCalls.flatMap(({ id, name }) =>
-      id !== null && name !== null && settledToolResults.get(id)?.isError === true ? [name] : [],
-    ),
-  );
-  const hasSettledTerminalToolFailure = allToolsProvenSettled && failedTerminalToolNames.size > 0;
-  const hasIntentionalTerminalToolBatch =
-    allToolsProvenSettled &&
-    requestedToolCalls.every(
-      ({ id, name }) =>
-        params.attempt.toolMetas.findLast(
-          (meta) => meta.toolCallId === id && meta.toolName === name,
-        )?.terminate === true,
-    );
   // ToolErrorSummary has no call id: its owner must match a failed result in the
   // proven terminal batch, or a stale/unrelated error could authorize finalization.
   const hasUnsettledToolError = Boolean(
-    params.attempt.lastToolError &&
+    attempt.lastToolError &&
     (assistant?.stopReason !== "toolUse" ||
-      !hasSettledTerminalToolFailure ||
-      !failedTerminalToolNames.has(params.attempt.lastToolError.toolName)),
+      !allToolsProvenSettled ||
+      !failedToolNames.has(attempt.lastToolError.toolName)),
   );
   if (
     params.payloadCount !== 0 ||
     params.hasTerminalToolPresentation ||
     params.aborted ||
-    ((params.timedOut || params.attempt.terminal.kind === "timeout") && !idlePromptTimeout) ||
-    (terminal.kind === "failed" && !params.attempt.settledTurnFinalizationContext) ||
+    ((params.timedOut || terminal.kind === "timeout") && !idlePromptTimeout) ||
+    (terminal.kind === "failed" && !attempt.settledTurnFinalizationContext) ||
     (assistant?.stopReason === "toolUse" ? !allToolsProvenSettled : !emptyStopAfterSettledTools) ||
-    hasIntentionalTerminalToolBatch ||
+    intentionalTermination ||
     hasUnsettledToolError ||
-    hasAsyncActivity(params.attempt.toolMetas) ||
-    hasAcceptedSessionSpawn(params.attempt.acceptedSessionSpawns) ||
-    params.attempt.clientToolCalls ||
-    params.attempt.yieldDetected ||
-    params.attempt.didSendDeterministicApprovalPrompt
+    hasAsyncActivity(attempt.toolMetas) ||
+    hasAcceptedSessionSpawn(attempt.acceptedSessionSpawns) ||
+    attempt.clientToolCalls ||
+    attempt.yieldDetected ||
+    attempt.didSendDeterministicApprovalPrompt
   ) {
     return null;
   }
-  if (hasCompletedMessagingToolDeliveryEvidence(params.attempt)) {
+  if (hasCompletedMessagingToolDeliveryEvidence(attempt)) {
     return null;
   }
   if (
@@ -348,7 +343,7 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
   ) {
     return null;
   }
-  return hasSettledTerminalToolFailure
+  return allToolsProvenSettled && failedToolNames.size > 0
     ? `${SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} ${TOOL_FAILURE_INSTRUCTION}`
     : SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION;
 }

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts
@@ -47,6 +47,7 @@ export function resolveIncompleteTurnPayloadText(params: {
   externalAbort: boolean;
   timedOut: boolean;
   hadPotentialSideEffects?: boolean;
+  hasIntentionalTerminalCompletion?: boolean;
   attempt: IncompleteTurnAttempt;
 }): string | null {
   // Prefer the current attempt's terminal message. The session fallback can
@@ -78,7 +79,8 @@ export function resolveIncompleteTurnPayloadText(params: {
     params.attempt.clientToolCalls ||
     params.attempt.yieldDetected ||
     params.attempt.didSendDeterministicApprovalPrompt ||
-    params.attempt.lastToolError
+    params.attempt.lastToolError ||
+    params.hasIntentionalTerminalCompletion
   ) {
     return null;
   }

--- a/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
@@ -348,9 +348,14 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       lastToolError: { toolName: "exec", error: "post-processing error" },
     },
     { label: "no remaining failure summary", lastToolError: undefined },
+    {
+      label: "a terminal-marked failed tool",
+      lastToolError: { toolName: "exec", error: "post-processing error" },
+      failedToolTerminate: true,
+    },
   ])(
     "recognizes successful and failed current-batch tools with $label (#118274)",
-    ({ lastToolError }) => {
+    ({ lastToolError, failedToolTerminate }) => {
       const toolUseAssistant = makeLastAssistant({
         stopReason: "toolUse",
         content: [
@@ -361,7 +366,15 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
       const instruction = resolveSettledToolTerminalContinuationInstruction(
         makeSettledContinuationParams({
           assistantTexts: [],
-          toolMetas: [{ toolName: "read" }, { toolName: "exec", isError: true }],
+          toolMetas: [
+            { toolName: "read" },
+            {
+              toolName: "exec",
+              toolCallId: "tool_failed",
+              isError: true,
+              ...(failedToolTerminate ? { terminate: true } : {}),
+            },
+          ],
           itemLifecycle: { startedCount: 2, completedCount: 2, activeCount: 0 },
           messagesSnapshot: [
             toolUseAssistant,

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -213,6 +213,114 @@ describe("terminal resolution", () => {
     expect(activateInternalPrompt).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { label: "an exactly settled terminal tool batch", expectedCompletion: "tool-batch" as const },
+    { label: "stale terminal metadata", metadata: { toolCallId: "stale-call" } },
+    { label: "a reused call id whose current occurrence is nonterminal", reusedCall: true },
+    {
+      label: "a partially settled batch",
+      lifecycle: { startedCount: 2, completedCount: 1, activeCount: 1 },
+    },
+    { label: "a mixed terminal and nonterminal batch", mixedBatch: true },
+    { label: "failed terminal metadata", metadata: { isError: true } },
+    {
+      label: "an asynchronously running terminal tool",
+      expectIncompleteTurn: false,
+      metadata: { asyncStarted: true },
+    },
+    { label: "a failed terminal result", result: { isError: true } },
+    { label: "a result with the wrong tool owner", result: { toolName: "another_tool" } },
+    { label: "a stale prior-turn result with the reused call id", staleResult: true },
+  ])("resolves $label from exact current-batch ownership", async (testCase) => {
+    const terminalCall = {
+      type: "toolCall" as const,
+      id: "terminal-tool-call",
+      name: "ask_user",
+      arguments: {},
+    };
+    const otherCall = { ...terminalCall, id: "nonterminal-tool-call", name: "another_tool" };
+    const assistant = buildEmbeddedRunnerAssistant({
+      stopReason: "toolUse",
+      content: [terminalCall, ...(testCase.mixedBatch ? [otherCall] : [])],
+    });
+    const toolResult = {
+      role: "toolResult" as const,
+      toolCallId: terminalCall.id,
+      toolName: terminalCall.name,
+      content: [{ type: "text", text: "The visible question was cancelled." }],
+      isError: false,
+      ...testCase.result,
+    };
+    const currentTurn = [
+      { role: "user", content: [{ type: "text", text: "Ask the current question." }] },
+      assistant,
+    ];
+    const messagesSnapshot = testCase.staleResult
+      ? [
+          buildEmbeddedRunnerAssistant({ stopReason: "toolUse", content: [terminalCall] }),
+          toolResult,
+          ...currentTurn,
+        ]
+      : [
+          ...currentTurn,
+          ...(testCase.expectedCompletion
+            ? [
+                buildEmbeddedRunnerAssistant({
+                  content: [{ type: "text", text: "The question was already shown." }],
+                }),
+              ]
+            : []),
+          toolResult,
+          ...(testCase.mixedBatch
+            ? [{ ...toolResult, toolCallId: otherCall.id, toolName: otherCall.name }]
+            : []),
+        ];
+    const attempt = makeEmbeddedRunnerAttempt({
+      assistantTexts: [],
+      toolMetas: [
+        {
+          toolName: terminalCall.name,
+          toolCallId: terminalCall.id,
+          terminate: true,
+          ...testCase.metadata,
+        },
+        ...(testCase.reusedCall
+          ? [{ toolName: terminalCall.name, toolCallId: terminalCall.id }]
+          : []),
+        ...(testCase.mixedBatch ? [{ toolName: otherCall.name, toolCallId: otherCall.id }] : []),
+      ],
+      itemLifecycle: testCase.lifecycle ?? {
+        startedCount: testCase.mixedBatch ? 2 : 1,
+        completedCount: testCase.mixedBatch ? 2 : 1,
+        activeCount: 0,
+      },
+      messagesSnapshot: messagesSnapshot as TerminalInput["attempt"]["messagesSnapshot"],
+      lastAssistant: assistant,
+      currentAttemptAssistant: assistant,
+    });
+    const input = makeTerminalInput({
+      attempt,
+      attemptAssistant: assistant,
+      replayState: { hadPotentialSideEffects: true, replayInvalid: true },
+    });
+    const resolved = await resolveEmbeddedRunTerminal(input);
+
+    expect(resolved.action).toBe("complete");
+    if (resolved.action === "complete") {
+      expect(resolved.result.meta.intentionalTerminalCompletion).toBe(testCase.expectedCompletion);
+      if (testCase.expectedCompletion) {
+        expect(resolved.result.meta.error).toBeUndefined();
+        expect(resolved.result.payloads).toBeUndefined();
+        expect(resolved.result.meta.livenessState).toBe("working");
+        expect(input.activateInternalPrompt).not.toHaveBeenCalled();
+        expect(attempt.messagesSnapshot.at(-1)).toBe(toolResult);
+      } else if (testCase.expectIncompleteTurn !== false) {
+        expect(resolved.result.meta.error?.kind).toBe("incomplete_turn");
+        expect(resolved.result.payloads?.[0]?.isError).toBe(true);
+      }
+    }
+  });
+
   it("completes a cron turn from a trailing silent tool result", async () => {
     const assistant = emptyAssistant();
     const attempt = makeEmbeddedRunnerAttempt({

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -26,6 +26,7 @@ import { resolveFinalAssistantVisibleText } from "./helpers.js";
 import {
   resolveEmptyResponseRetryInstruction,
   resolveReasoningOnlyRetryInstruction,
+  resolveSettledToolBatchEvidence,
   resolveSettledToolTerminalContinuationInstruction,
   shouldTreatEmptyAssistantReplyAsSilent,
 } from "./incomplete-turn-recovery.js";
@@ -249,6 +250,11 @@ export async function resolveEmbeddedRunTerminal(input: {
         ? [silentToolResultReplyPayload]
         : input.payloadsWithToolMedia;
   const payloadCount = payloadsForTerminalPath?.length ?? 0;
+  const intentionalTerminalCompletion =
+    !terminalAborted &&
+    !terminalTimedOut &&
+    payloadCount === 0 &&
+    resolveSettledToolBatchEvidence(attempt).intentionalTermination;
   // A failed isolated finalization is terminal for this user turn. Do not let
   // its settled side effects cascade into any ordinary retry family.
   const settledTurnFinalizationAttempted = input.settledTurnFinalizationOutcome !== "not-attempted";
@@ -348,6 +354,7 @@ export async function resolveEmbeddedRunTerminal(input: {
           externalAbort: externalAbort || signalOwnedInterruption,
           timedOut: terminalTimedOut,
           hadPotentialSideEffects: input.replayState.hadPotentialSideEffects,
+          hasIntentionalTerminalCompletion: intentionalTerminalCompletion,
           attempt,
         });
   const incompleteTurnFallbackSafe = Boolean(
@@ -464,6 +471,7 @@ export async function resolveEmbeddedRunTerminal(input: {
     payloadCount,
     payloadsForTerminalPath,
     emptyAssistantReplyIsSilent,
+    intentionalTerminalCompletion,
   });
 }
 
@@ -534,6 +542,7 @@ function completeEmbeddedRun(
     payloadCount: number;
     payloadsForTerminalPath: EmbeddedAgentRunResult["payloads"];
     emptyAssistantReplyIsSilent: boolean;
+    intentionalTerminalCompletion: boolean;
   },
 ): TerminalResolution {
   const terminalAborted = isEmbeddedRunTerminalAbort(input.terminalState.outcome);
@@ -639,6 +648,9 @@ function completeEmbeddedRun(
           : {}),
         ...(input.emptyAssistantReplyIsSilent
           ? { terminalReplyKind: "silent-empty" as const }
+          : {}),
+        ...(input.intentionalTerminalCompletion
+          ? { intentionalTerminalCompletion: "tool-batch" as const }
           : {}),
         stopReason,
         pendingToolCalls: input.attempt.clientToolCalls?.map((call) => ({

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -186,6 +186,8 @@ export type EmbeddedAgentRunMeta = {
   providerStarted?: boolean;
   agentHarnessResultClassification?: "empty" | "reasoning-only" | "planning-only";
   terminalReplyKind?: "silent-empty";
+  /** An exact, successfully settled tool batch intentionally completed the turn without a reply. */
+  intentionalTerminalCompletion?: "tool-batch";
   terminalReply?: AgentRunTerminalReplySnapshot;
   yielded?: boolean;
   /** Explicit user-facing waiting status supplied to sessions_yield. */

--- a/src/agents/tools/ask-user-tool.test.ts
+++ b/src/agents/tools/ask-user-tool.test.ts
@@ -16,6 +16,11 @@ import { resetPendingAskUserQuestionsForTest } from "./ask-user-tool.test-suppor
 
 type GatewayCall = NonNullable<Parameters<typeof createAskUserTool>[0]["gatewayCall"]>;
 
+const replyDispatchOutcomeModuleUrl = new URL(
+  "../../auto-reply/reply/reply-dispatch-outcome.ts",
+  import.meta.url,
+).href;
+
 const validArgs = {
   questions: [
     {
@@ -569,7 +574,7 @@ describe("ask_user execution", () => {
     );
   });
 
-  it("terminates after a visible prompt fails to attach its controls", async () => {
+  it("terminates when a separately loaded dispatcher reports visible control failure", async () => {
     const sessionKey = "agent:main:delivery-failure";
     const reservation = reserveAskUserPromptDelivery({
       toolCallId: "call-delivery-failure",
@@ -601,10 +606,12 @@ describe("ask_user execution", () => {
     );
     await vi.waitFor(() => expect(finishWait).toBeTypeOf("function"));
 
-    settleAskUserPromptDelivery(
-      reservation.questionId,
-      new ReplyDispatchDeliveryError("failed-deliver"),
-    );
+    const foreignModule = (await import(
+      `${replyDispatchOutcomeModuleUrl}?instance=ask-user-foreign`
+    )) as typeof import("../../auto-reply/reply/reply-dispatch-outcome.js");
+    const deliveryError = new foreignModule.ReplyDispatchDeliveryError("failed-deliver");
+    expect(deliveryError).not.toBeInstanceOf(ReplyDispatchDeliveryError);
+    settleAskUserPromptDelivery(reservation.questionId, deliveryError);
 
     await expect(pending).resolves.toMatchObject({
       terminate: true,

--- a/src/auto-reply/reply/agent-runner-failure-reply.test.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.test.ts
@@ -14,6 +14,7 @@ describe("buildEmptyInteractiveReplyPayload", () => {
     hasPendingContinuation: false,
     hasExplicitSilentReply: false,
     hasCommittedDelivery: false,
+    hasIntentionalTerminalCompletion: false,
     sessionCtx: {
       Provider: "discord",
       Surface: "discord",

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -332,6 +332,7 @@ export function buildEmptyInteractiveReplyPayload(params: {
   hasPendingContinuation: boolean;
   hasExplicitSilentReply: boolean;
   hasCommittedDelivery: boolean;
+  hasIntentionalTerminalCompletion: boolean;
   sessionCtx: ExternalFailureConversationContext;
   cfg?: OpenClawConfig;
 }): ReplyPayload | undefined {
@@ -342,7 +343,8 @@ export function buildEmptyInteractiveReplyPayload(params: {
     params.allowEmptyAssistantReplyAsSilent === true ||
     params.hasPendingContinuation ||
     params.hasExplicitSilentReply ||
-    params.hasCommittedDelivery
+    params.hasCommittedDelivery ||
+    params.hasIntentionalTerminalCompletion
   ) {
     return undefined;
   }

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -4,7 +4,10 @@ import {
   hasCompletedTerminalDeliveryEvidence,
   hasVisibleOutboundDeliveryEvidence,
 } from "../../agents/embedded-agent-runner/delivery-evidence.js";
-import { hasDeliberateSilentTerminalReply } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import {
+  hasDeliberateSilentTerminalReply,
+  hasIntentionalTerminalCompletion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { deriveContextPromptTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
@@ -169,6 +172,7 @@ export async function prepareReplyAgentPayloads(state: {
         hasPendingContinuation: pendingContinuation,
         hasExplicitSilentReply: deliberateSilentTerminalReply,
         hasCommittedDelivery: successfulTerminalDelivery,
+        hasIntentionalTerminalCompletion: hasIntentionalTerminalCompletion(runResult),
         sessionCtx,
         cfg,
       });

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -613,12 +613,21 @@ describe("runReplyAgent auto-compaction token update", () => {
   });
 
   it.each([
-    ["without side effects", { meta: { agentMeta: {} } }],
-    ["after hidden compaction", { meta: { agentMeta: { compactionCount: 1 } } }],
-  ] satisfies Array<[string, Record<string, unknown>]>)(
-    "surfaces empty interactive direct replies %s",
-    async (_label, agentResult) => {
+    ["without side effects", { meta: { agentMeta: {} } }, true],
+    ["after hidden compaction", { meta: { agentMeta: { compactionCount: 1 } } }, true],
+    [
+      "after an intentional terminal tool batch",
+      { meta: { agentMeta: {}, intentionalTerminalCompletion: "tool-batch" } },
+      false,
+    ],
+  ] satisfies Array<[string, Record<string, unknown>, boolean]>)(
+    "accounts for empty interactive direct replies %s",
+    async (_label, agentResult, fallback) => {
       const result = await runEmptyDirectReply(agentResult);
+      if (!fallback) {
+        expect(result).toBeUndefined();
+        return;
+      }
       const payload = expectRecordFields(result, { isError: true }, "empty interactive fallback");
       expect(payload.text).toContain("did not produce a visible reply");
     },

--- a/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
@@ -21,6 +21,15 @@ function createUntrackedDispatcher(overrides: Partial<ReplyDispatcher> = {}): Re
 }
 
 describe("requireQueuedReplyDelivery", () => {
+  it("rejects a branded delivery error with an invalid outcome", () => {
+    expect(
+      isReplyDispatchDeliveryError({
+        code: "REPLY_DISPATCH_DELIVERY_ERROR",
+        outcome: "invalid",
+      }),
+    ).toBe(false);
+  });
+
   it.each([
     ["delivered", true],
     ["delivered-not-visible", false],

--- a/src/auto-reply/reply/followup-delivery.test.ts
+++ b/src/auto-reply/reply/followup-delivery.test.ts
@@ -765,31 +765,45 @@ describe("resolveFollowupDeliveryDecision", () => {
     });
   });
 
-  it("delivers a sanitized fallback for an empty message-tool-only completion", () => {
-    const turn = createTurn();
-    turn.queued.run.sourceReplyDeliveryMode = "message_tool_only";
+  it.each([
+    { label: "accidental", intentionalTerminalCompletion: undefined },
+    { label: "intentional terminal tool", intentionalTerminalCompletion: "tool-batch" as const },
+  ])(
+    "accounts for an $label empty message-tool-only completion",
+    ({ intentionalTerminalCompletion }) => {
+      const turn = createTurn();
+      turn.queued.run.sourceReplyDeliveryMode = "message_tool_only";
+      const execution = createSettledExecution();
+      if (execution.outcome.kind === "settled" && intentionalTerminalCompletion) {
+        execution.outcome.result.meta.intentionalTerminalCompletion = intentionalTerminalCompletion;
+      }
 
-    const decision = resolveFollowupDeliveryDecision({
-      turn,
-      execution: createSettledExecution(),
-      accounting: createAccounting(),
-    });
+      const decision = resolveFollowupDeliveryDecision({
+        turn,
+        execution,
+        accounting: createAccounting(),
+      });
+      if (intentionalTerminalCompletion) {
+        expect(decision).toEqual({ kind: "suppress", reason: "message-tool-only" });
+        return;
+      }
 
-    expect(decision).toMatchObject({
-      kind: "deliver",
-      payloads: [
-        {
-          text: expect.stringContaining("did not produce a visible reply"),
-          isError: true,
-        },
-      ],
-    });
-    if (decision.kind === "deliver") {
-      expect(
-        getReplyPayloadMetadata(decision.payloads[0] ?? {})?.deliverDespiteSourceReplySuppression,
-      ).toBe(true);
-    }
-  });
+      expect(decision).toMatchObject({
+        kind: "deliver",
+        payloads: [
+          {
+            text: expect.stringContaining("did not produce a visible reply"),
+            isError: true,
+          },
+        ],
+      });
+      if (decision.kind === "deliver") {
+        expect(
+          getReplyPayloadMetadata(decision.payloads[0] ?? {})?.deliverDespiteSourceReplySuppression,
+        ).toBe(true);
+      }
+    },
+  );
 
   it("keeps a terminal failure when suppressed partial output is present", () => {
     const turn = createTurn();

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -7,7 +7,10 @@ import {
   hasVisibleCommittedMessagingToolDeliveryEvidence,
   hasVisibleOutboundDeliveryEvidence,
 } from "../../agents/embedded-agent-runner/delivery-evidence.js";
-import { hasDeliberateSilentTerminalReply } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import {
+  hasDeliberateSilentTerminalReply,
+  hasIntentionalTerminalCompletion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { buildAgentRuntimeDeliveryPlan } from "../../agents/runtime-plan/build.js";
 import { logVerbose } from "../../globals.js";
 import { isSubagentSessionKey } from "../../routing/session-key.js";
@@ -235,6 +238,7 @@ export function resolveFollowupDeliveryDecision(params: {
           result.meta?.yielded === true || (result.meta?.pendingToolCalls?.length ?? 0) > 0,
         hasExplicitSilentReply: hasDeliberateSilentTerminalReply(result),
         hasCommittedDelivery,
+        hasIntentionalTerminalCompletion: hasIntentionalTerminalCompletion(result),
         sessionCtx: {
           ChatType: turn.queued.originatingChatType,
           Provider: turn.queued.run.messageProvider,

--- a/src/auto-reply/reply/reply-dispatch-outcome.ts
+++ b/src/auto-reply/reply/reply-dispatch-outcome.ts
@@ -1,6 +1,8 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ReplyDispatchSettledCounts } from "./reply-dispatcher.types.js";
 
+const REPLY_DISPATCH_DELIVERY_ERROR_CODE = "REPLY_DISPATCH_DELIVERY_ERROR";
+
 export type ReplyDispatchDeliveryOutcome =
   | "delivered"
   | "delivered-not-visible"
@@ -9,6 +11,8 @@ export type ReplyDispatchDeliveryOutcome =
   | "failed-deliver";
 
 export class ReplyDispatchDeliveryError extends Error {
+  readonly code = REPLY_DISPATCH_DELIVERY_ERROR_CODE;
+
   constructor(readonly outcome: ReplyDispatchDeliveryOutcome) {
     super("queued reply delivery failed");
     this.name = "ReplyDispatchDeliveryError";
@@ -16,7 +20,15 @@ export class ReplyDispatchDeliveryError extends Error {
 }
 
 export function isReplyDispatchDeliveryError(error: unknown): error is ReplyDispatchDeliveryError {
-  return error instanceof ReplyDispatchDeliveryError;
+  return (
+    isRecord(error) &&
+    error.code === REPLY_DISPATCH_DELIVERY_ERROR_CODE &&
+    (error.outcome === "delivered" ||
+      error.outcome === "delivered-not-visible" ||
+      error.outcome === "cancelled" ||
+      error.outcome === "failed-before-deliver" ||
+      error.outcome === "failed-deliver")
+  );
 }
 
 export function isReplyDispatchProvenInvisible(outcome: ReplyDispatchDeliveryOutcome): boolean {

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -7,6 +7,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { hasAcceptedSessionSpawn } from "../../agents/accepted-session-spawn.js";
 import { resolveAuthoredModelContextTokens } from "../../agents/context-resolution.js";
 import { hasCommittedMessagingToolDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import { hasIntentionalTerminalCompletion } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
 import { deriveContextPromptTokens } from "../../agents/usage.js";
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
 import { SESSION_TOTAL_TOKENS_VERSION } from "../../config/sessions.js";
@@ -441,6 +442,7 @@ export async function finalizeCronRun(params: {
     !sourceDeliveryOutcome.satisfiesSourceDelivery &&
     !hasCommittedTerminalProgress &&
     !hasIntentionalSilentReply &&
+    !hasIntentionalTerminalCompletion(finalRunResult) &&
     deliveryPayloads.length === 0 &&
     normalizeOptionalString(synthesizedText) === undefined
   ) {

--- a/src/cron/isolated-agent/run.meta-error-status.test.ts
+++ b/src/cron/isolated-agent/run.meta-error-status.test.ts
@@ -132,12 +132,25 @@ describe("runCronIsolatedAgentTurn - meta.error status propagation", () => {
     expect(callGatewayMock).toHaveBeenCalledTimes(1);
   });
 
-  it("marks a completed embedded run with no final payload as a cron error", async () => {
-    mockAgentRun();
+  it.each([
+    { label: "accidental", intentionalTerminalCompletion: undefined },
+    { label: "intentional terminal tool", intentionalTerminalCompletion: "tool-batch" as const },
+  ])("accounts for an $label embedded run with no final payload", async (testCase) => {
+    mockAgentRun({
+      meta: testCase.intentionalTerminalCompletion
+        ? { intentionalTerminalCompletion: testCase.intentionalTerminalCompletion }
+        : {},
+    });
     mockAnnounceOutcome();
 
     const result = await runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture());
 
+    if (testCase.intentionalTerminalCompletion) {
+      expect(dispatchCronDeliveryMock).toHaveBeenCalled();
+      expect(result.status).toBe("ok");
+      expect(result.error).toBeUndefined();
+      return;
+    }
     expect(dispatchCronDeliveryMock).not.toHaveBeenCalled();
     expect(result.status).toBe("error");
     expect(result.error).toBe("cron isolated run completed without a final assistant payload");


### PR DESCRIPTION
Related: #126248 (merged Telegram streamed-question finalization; provenance only).

## What Problem This Solves

Fixes an issue where users responding to a streamed interactive Telegram question could receive a spurious failure warning, duplicate fallback reply, or unnecessary model continuation after the question preview became visible but attaching its controls failed. The same terminal-tool completion was also incorrectly reported as a failed empty response in queued follow-ups and scheduled runs.

## Why This Change Was Made

Classify reply-dispatch delivery errors by a stable error code and a closed set of delivery outcomes so their identity survives separately loaded runtime bundles. At the embedded-run terminal owner, prove that the exact current-turn tool-call batch settled successfully, belongs to the right calls and tool owners, contains only intentional terminal tools, and has no failed, asynchronous, stale, reused, mixed, or prior-turn evidence; record that single closed completion fact once and share it with model fallback, direct/follow-up auto-reply, and cron consumers.

The completion fact means only that an exactly proven terminal tool batch intentionally ended the turn. It does not assert visible delivery, silence, authority, or authorization, and existing fail-closed delivery evidence remains unchanged.

## User Impact

Streamed Telegram questions continue using the same preview message and receive one final response after a successful answer. If question controls cannot be attached after the preview is already visible, OpenClaw cancels the pending question cleanly without retrying the model, emitting a misleading warning, sending duplicate fallback text, or deleting the visible preview. Equivalent queued follow-up and scheduled-agent turns no longer misreport this intentional completion as an empty-response failure; accidental empty turns still surface their existing errors.

## Evidence

Rebased cleanly onto current `main` with an identical patch (`git range-diff` reports `=`); the merged-base pre-aborted-delivery regression and this fix's cross-bundle delivery regression both remain present. Scope: 19 files; production **+130/-90 (net +40)**, tests **+223/-45 (net +178)**. The production growth is the minimum shared ownership contract needed to prove one exact terminal tool batch once and make its closed completion fact available to model, auto-reply, follow-up, and cron consumers. No protocol, configuration, schema, generated/baseline, changelog, or dependency changes.

Five focused commands passed across 10 files and **306 tests** (the previous 305 plus the new pre-aborted-delivery regression already present on rebased `main`):

```sh
env OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/agents/embedded-agent-runner/result-fallback-classifier.test.ts src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts src/agents/embedded-agent-runner/run/terminal-resolution.test.ts src/agents/embedded-agent-runner/run/incomplete-turn-resolution.test.ts
env OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/agents/tools/ask-user-tool.test.ts src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts
env OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/auto-reply/reply/agent-runner-failure-reply.test.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
env OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/auto-reply/reply/followup-delivery.test.ts
env OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test src/cron/isolated-agent/run.meta-error-status.test.ts
pnpm check:changed -- src/agents/embedded-agent-runner/result-fallback-classifier.test.ts src/agents/embedded-agent-runner/result-fallback-classifier.ts src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts src/agents/embedded-agent-runner/run/incomplete-turn-resolution.ts src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts src/agents/embedded-agent-runner/run/terminal-resolution.test.ts src/agents/embedded-agent-runner/run/terminal-resolution.ts src/agents/embedded-agent-runner/types.ts src/agents/tools/ask-user-tool.test.ts src/auto-reply/reply/agent-runner-failure-reply.test.ts src/auto-reply/reply/agent-runner-failure-reply.ts src/auto-reply/reply/agent-runner-result-payloads.ts src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts src/auto-reply/reply/dispatch-from-config.turn-ledger.test.ts src/auto-reply/reply/followup-delivery.test.ts src/auto-reply/reply/followup-delivery.ts src/auto-reply/reply/reply-dispatch-outcome.ts src/cron/isolated-agent/run-finalize.ts src/cron/isolated-agent/run.meta-error-status.test.ts
git diff --check origin/main...HEAD
env OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --engine codex
```

Pre-rebase deterministic real-plugin/adapter proof used the actual Telegram adapter, Crabline transport, ephemeral Gateway, local Telegram API doubles, and a mock model provider: **1/1 scenario and 3/3 steps passed**. It proved direct-message topic routing with `direct_messages_topic_id=77` and no `message_thread_id`; a streamed `ask_user` question stayed on one message lifecycle and produced exactly one final answer; an injected control-edit failure produced one preview send, one rejected edit, a non-error terminal `delivery_failed` result, zero provider continuations/warnings/fallback replies/deletes, a cancelled question, and zero pending questions.

That disposable scenario is not tracked in Git and was not rerun after rebase. Its recorded source patch SHA-256 is `6b4bb58b0d8a57384d143768ccc2fe0fc7a3965c5f627e1696205978da513841`, exactly matching the original committed patch; `git range-diff` independently proves the rebased patch is identical. Local-only proof summaries are under `.artifacts/qa-e2e/telegram-final-19-f289685/`, including `verification-summary.json`, `harness-metadata.json`, and `channel-proof/telegram-routing-interactive-finals-verdict.json`; raw artifacts and secrets are not published.

**Known proof limitation:** authenticated Telegram Desktop and Discord live credentials were unavailable. The channel proof exercised real OpenClaw plugins/adapters and Crabline with local channel API doubles and a mock provider; it was not an authenticated live Telegram or Discord run.

AI-assisted; maintainer-reviewed implementation and proof.
