### PR TITLE
test(gateway): isolate restart sentinel media mocks

### DIFF
--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -717,9 +717,9 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.mergeSessionDeliveryPreparedMediaBlocks.mockClear();
     mocks.markSessionDeliveryAttemptStarted.mockClear();
     mocks.markSessionDeliverySettlement.mockClear();
-    mocks.appendAssistantMessageToSessionTranscript.mockClear();
-    mocks.createManagedOutgoingMediaBlocks.mockClear();
-    mocks.attachManagedOutgoingMediaToMessage.mockClear();
+    mocks.appendAssistantMessageToSessionTranscript.mockReset();
+    mocks.createManagedOutgoingMediaBlocks.mockReset();
+    mocks.attachManagedOutgoingMediaToMessage.mockReset();
     mocks.removeCronRunContinuationSessionIfIdle.mockClear();
     mocks.settleCorrelatedSubagentDelivery.mockClear();
     mocks.loadPendingSessionDelivery.mockClear();
@@ -1623,7 +1623,7 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.appendAssistantMessageToSessionTranscript
       .mockImplementationOnce(transcriptActual.appendAssistantMessageToSessionTranscript)
       .mockImplementationOnce(transcriptActual.appendAssistantMessageToSessionTranscript);
-    mocks.createManagedOutgoingMediaBlocks.mockImplementationOnce(
+    mocks.createManagedOutgoingMediaBlocks.mockImplementation(
       managedMediaActual.createManagedOutgoingMediaBlocks,
     );
     mocks.attachManagedOutgoingMediaToMessage


### PR DESCRIPTION
## What Problem This Solves

Resolves a main-qualification flake where an unused queued one-shot media mock from an earlier non-isolated Gateway test can be consumed by restart-sentinel replay. The replay then fails before reaching the synthetic crash path the test is meant to exercise.

## Why This Change Was Made

Reset the transcript and media boundary mocks between tests, and keep the real managed-media creator installed for both calls in the crash-and-replay test. Parser, record, download, call-count, replay-order, and prepared-block assertions are unchanged. No production files or behavior change.

## User Impact

No user-visible behavior change. Maintainers get deterministic restart-sentinel coverage in the non-isolated gateway-server qualification shard.

## Evidence

- Seeded reproduction: queued an unused `mockImplementationOnce(async () => [])` in the preceding test; the target failed before the fix with `expected synthetic crash` versus `queued internal generated media could not be prepared`. The seed was removed.
- Current-main base at proof time: `7f68741cdd9bbcacf73e78ad307597dc66446480`.
- Exact target: 1 passed, 74 skipped.
- Full `server-restart-sentinel.test.ts`: 75 passed.
- Original affected four-file gateway-server shard: 10 successful bounded runs, 141 passed each.
- Two discarded runs on the saturated local host emitted only the existing slow-SQLite transaction warning into `logWarn`; each implicated test passed immediately when run focused.
- `node scripts/check-changed.mjs -- src/gateway/server-restart-sentinel.test.ts`: passed.
- `oxfmt --check`, `git diff --check`, and exact-head autoreview: passed.
- LOC: production 0; tests +4/-4, net 0.
