### PR TITLE
fix(gateway): preserve agent owner for live events

### DIFF
--- a/extensions/codex/src/app-server/native-subagent-monitor.test.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.test.ts
@@ -1170,15 +1170,16 @@ describe("CodexNativeSubagentMonitor", () => {
     client.close();
   });
 
-  it("publishes child assistant and tool activity under the mirrored thread run id", async () => {
-    const events: Array<{ runId: string; stream: string; data: Record<string, unknown> }> = [];
+  it("publishes parent-owned child activity without projecting it into the parent session", async () => {
+    const events: Parameters<Parameters<typeof onAgentEvent>[0]>[0][] = [];
     const unsubscribe = onAgentEvent((event) => events.push(event));
     const client = createClient();
     const runtime = createRuntime();
     const monitor = new CodexNativeSubagentMonitor(client as never, runtime);
     try {
-      registerParent(monitor);
+      const parent = registerParent(monitor);
       await notifyChildStarted(client);
+      parent.unregister();
       await client.notify({
         method: "item/agentMessage/delta",
         params: {
@@ -1217,16 +1218,19 @@ describe("CodexNativeSubagentMonitor", () => {
         expect.arrayContaining([
           expect.objectContaining({
             runId: "codex-thread:child-thread",
+            agentId: "main",
             stream: "assistant",
             data: expect.objectContaining({ delta: "Inspecting the registry" }),
           }),
           expect.objectContaining({
             runId: "codex-thread:child-thread",
+            agentId: "main",
             stream: "thinking",
             data: expect.objectContaining({ delta: "Planning the fix" }),
           }),
           expect.objectContaining({
             runId: "codex-thread:child-thread",
+            agentId: "main",
             stream: "tool",
             data: expect.objectContaining({
               phase: "start",
@@ -1236,6 +1240,40 @@ describe("CodexNativeSubagentMonitor", () => {
           }),
         ]),
       );
+      for (const event of events) {
+        expect(event.sessionKey).toBeUndefined();
+      }
+    } finally {
+      unsubscribe();
+      client.close();
+    }
+  });
+
+  it("does not retroactively assign a newly registered parent agent to an existing child", async () => {
+    const events: Parameters<Parameters<typeof onAgentEvent>[0]>[0][] = [];
+    const unsubscribe = onAgentEvent((event) => events.push(event));
+    const client = createClient();
+    const monitor = new CodexNativeSubagentMonitor(client as never, createRuntime());
+    try {
+      const parent = monitor.registerParent({ parentThreadId: "parent-thread" });
+      await notifyChildStarted(client, "parent-thread", "ownerless-child");
+      parent.unregister();
+      monitor.registerParent({ parentThreadId: "parent-thread", agentId: "research" });
+      await notifyChildStarted(client, "parent-thread", "owned-child");
+
+      for (const threadId of ["ownerless-child", "owned-child"]) {
+        await client.notify({
+          method: "item/agentMessage/delta",
+          params: { threadId, turnId: "child-turn", itemId: "assistant-1", delta: "progress" },
+        });
+      }
+
+      expect(
+        events.map(({ runId, agentId, sessionKey }) => ({ runId, agentId, sessionKey })),
+      ).toEqual([
+        { runId: "codex-thread:ownerless-child", agentId: undefined, sessionKey: undefined },
+        { runId: "codex-thread:owned-child", agentId: "research", sessionKey: undefined },
+      ]);
     } finally {
       unsubscribe();
       client.close();

--- a/extensions/codex/src/app-server/native-subagent-monitor.ts
+++ b/extensions/codex/src/app-server/native-subagent-monitor.ts
@@ -84,6 +84,7 @@ type DirectSpawnEvidence = {
 type ChildState = {
   childThreadId: string;
   parentThreadId: string;
+  readonly agentId?: string;
   agentPathKeys: Set<string>;
   assistantMessagesByTurn: Map<string, ChildAssistantMessages>;
   recoveryAttempt: number;
@@ -534,7 +535,7 @@ class Monitor {
       this.resumeChild(childState);
     }
     if (childState && !childState.terminal) {
-      this.emitChildTaskActivity(notification, childState.childThreadId);
+      this.emitChildTaskActivity(notification, childState);
     }
     this.captureChildAssistantMessage(notification);
     await this.handleChildTurnCompletion(notification);
@@ -569,24 +570,27 @@ class Monitor {
 
   private emitChildTaskActivity(
     notification: CodexServerNotification,
-    childThreadId: string,
+    childState: ChildState,
   ): void {
     const params = isJsonObject(notification.params) ? notification.params : undefined;
     if (!params) {
       return;
     }
-    const runId = codexNativeSubagentRunId(childThreadId);
+    const owner = {
+      runId: codexNativeSubagentRunId(childState.childThreadId),
+      ...(childState.agentId ? { agentId: childState.agentId } : {}),
+    };
     if (notification.method === "item/agentMessage/delta") {
       const delta = readString(params, "delta");
       if (delta) {
-        emitAgentEvent({ runId, stream: "assistant", data: { delta } });
+        emitAgentEvent({ ...owner, stream: "assistant", data: { delta } });
       }
       return;
     }
     if (notification.method === "item/reasoning/summaryTextDelta") {
       const delta = readString(params, "delta");
       if (delta) {
-        emitAgentEvent({ runId, stream: "thinking", data: { delta } });
+        emitAgentEvent({ ...owner, stream: "thinking", data: { delta } });
       }
       return;
     }
@@ -595,14 +599,14 @@ class Monitor {
     }
     const item = readItem(params.item);
     if (item?.type === "agentMessage" && notification.method === "item/completed" && item.text) {
-      emitAgentEvent({ runId, stream: "assistant", data: { text: item.text } });
+      emitAgentEvent({ ...owner, stream: "assistant", data: { text: item.text } });
     }
     const projection = projectNormalizedToolItem({
       phase: notification.method === "item/started" ? "start" : "result",
       item,
     });
     if (projection?.event) {
-      emitAgentEvent({ runId, ...projection.event });
+      emitAgentEvent({ ...owner, ...projection.event });
     }
   }
 
@@ -811,7 +815,7 @@ class Monitor {
       const state = parentThreadId ? this.parentStates.get(parentThreadId) : undefined;
       if (state && childThreadId && parentThreadId) {
         return this.registerChildThread(
-          parentThreadId,
+          state,
           childThreadId,
           agentPath === undefined ? {} : { agentPath },
         )
@@ -889,7 +893,7 @@ class Monitor {
                     { parentThreadId, childThreadId },
                     owner,
                   )
-                : this.registerChildThread(parentThreadId, childThreadId),
+                : this.registerChildThread(state, childThreadId),
             ) && accepted;
         }
         if (!accepted) {
@@ -1310,14 +1314,14 @@ class Monitor {
   }
 
   private registerChildThread(
-    parentThreadIdInput: string,
+    state: ParentState,
     childThreadIdInput: string,
     options: {
       agentPath?: string;
       claimDirectChild?: (threadId: string) => (() => void) | undefined;
     } = {},
   ): ChildState | undefined {
-    const parentThreadId = parentThreadIdInput.trim();
+    const parentThreadId = state.parentThreadId;
     const childThreadId = childThreadIdInput.trim();
     if (!parentThreadId || !childThreadId || this.disposed) {
       return undefined;
@@ -1350,6 +1354,7 @@ class Monitor {
       childState = {
         childThreadId,
         parentThreadId,
+        agentId: state.agentId,
         agentPathKeys: new Set<string>(),
         assistantMessagesByTurn: new Map<string, ChildAssistantMessages>(),
         recoveryAttempt: 0,
@@ -1377,9 +1382,7 @@ class Monitor {
       childState.releaseDirectChild = options.claimDirectChild(childThreadId);
     }
     this.registerAgentPath(childState, childThreadId);
-    this.parentStates
-      .get(parentThreadId)
-      ?.mirror?.markAuthoritativeCompletionExpected(childThreadId);
+    state.mirror?.markAuthoritativeCompletionExpected(childThreadId);
     const agentPath = normalizeOptionalString(options.agentPath);
     if (agentPath) {
       this.registerAgentPath(childState, agentPath);
@@ -1406,7 +1409,7 @@ class Monitor {
     evidence: DirectSpawnEvidence,
     owner: ParentOwner | undefined,
   ): ChildState | undefined {
-    const childState = this.registerChildThread(state.parentThreadId, evidence.childThreadId, {
+    const childState = this.registerChildThread(state, evidence.childThreadId, {
       ...(evidence.agentPath === undefined ? {} : { agentPath: evidence.agentPath }),
       ...(owner?.claimDirectChild ? { claimDirectChild: owner.claimDirectChild } : {}),
     });
@@ -1457,7 +1460,7 @@ class Monitor {
     }
     for (const evidence of pending) {
       if (evidence.parentThreadId === state.parentThreadId) {
-        const childState = this.registerChildThread(state.parentThreadId, evidence.childThreadId, {
+        const childState = this.registerChildThread(state, evidence.childThreadId, {
           ...(evidence.agentPath === undefined ? {} : { agentPath: evidence.agentPath }),
           claimDirectChild: owner.claimDirectChild,
         });
@@ -1923,7 +1926,7 @@ class Monitor {
         this.prepareParentTaskRuntime(state);
         this.parentStates.set(parentThreadId, state);
       }
-      const childState = this.registerChildThread(parentThreadId, candidate.childThreadId);
+      const childState = this.registerChildThread(state, candidate.childThreadId);
       if (!childState) {
         this.pruneParentIfUnused(state);
         return;

--- a/src/agents/embedded-agent-runner/run/lane-controller.lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.lifecycle.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  emitAgentEvent,
   getAgentEventLifecycleGeneration,
+  onAgentRuntimeEvent,
   resetAgentEventsForTest,
   rotateAgentEventLifecycleGeneration,
 } from "../../../infra/agent-events.js";
@@ -49,6 +51,7 @@ function createController(options: {
   trigger?: LaneParams["trigger"];
   abortSignal?: AbortSignal;
   runId?: string;
+  params?: Pick<LaneParams, "agentId" | "sessionKey">;
 }) {
   let lifecycleGeneration = options.lifecycleGeneration;
   const runId = options.runId ?? "run-1";
@@ -66,6 +69,7 @@ function createController(options: {
     trigger: options.trigger,
     enqueue: options.enqueue,
     abortSignal: options.abortSignal,
+    ...options.params,
   };
   const controller = createEmbeddedRunLaneController({
     getLifecycleGeneration: () => lifecycleGeneration,
@@ -108,6 +112,31 @@ describe("createEmbeddedRunLaneController lifecycle admission", () => {
     await controller.enqueueSession(async () => undefined);
 
     expect(priorities).toEqual([expected]);
+  });
+
+  it("preserves the selected agent for sessionless admitted runtime events", async () => {
+    const runId = "sessionless-owned-run";
+    const { controller } = createController({
+      lifecycleGeneration: getAgentEventLifecycleGeneration(),
+      enqueue: async (task) => await task(),
+      runId,
+      params: { agentId: "research", sessionKey: undefined },
+    });
+    const events: Array<{ agentId?: string; sessionKey?: string }> = [];
+    const unsubscribe = onAgentRuntimeEvent((event) => events.push(event));
+
+    try {
+      await controller.enqueueGlobal(async () => {
+        emitAgentEvent({ runId, stream: "assistant", data: { delta: "owned progress" } });
+        return completedResult;
+      });
+
+      expect(getAgentRunContext(runId)).toMatchObject({ agentId: "research" });
+      expect(getAgentRunContext(runId)?.sessionKey).toBeUndefined();
+      expect(events).toMatchObject([{ agentId: "research", sessionKey: undefined }]);
+    } finally {
+      unsubscribe();
+    }
   });
 
   it("rebinds foreground work that was queued before lifecycle rotation", async () => {

--- a/src/agents/embedded-agent-runner/run/lane-controller.ts
+++ b/src/agents/embedded-agent-runner/run/lane-controller.ts
@@ -181,6 +181,7 @@ export function createEmbeddedRunLaneController<TParams extends LaneParams>(opti
             // Queue-stage rotation may rebind, but placement admitted into a retired runtime must fail.
             claimAgentRunContext(params.runId, {
               ...existingContext,
+              agentId: params.agentId ?? existingContext?.agentId,
               sessionKey: params.sessionKey ?? existingContext?.sessionKey,
               sessionId: params.sessionId ?? existingContext?.sessionId,
               lifecycleGeneration,

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -4,6 +4,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
@@ -16,6 +17,7 @@ import {
   resetAgentEventsForTest,
 } from "../infra/agent-events.js";
 import {
+  clearAgentRunContext as clearRegisteredAgentRunContext,
   claimAgentRunContext,
   registerAgentRunContext,
   releaseAgentRunContext,
@@ -141,7 +143,7 @@ describe("agent event handler", () => {
 
   function createHarness(params?: {
     now?: number;
-    resolveSessionKeyForRun?: (runId: string) => string | undefined;
+    resolveSessionKeyForRun?: (runId: string, options?: { agentId?: string }) => string | undefined;
     lifecycleErrorRetryGraceMs?: number;
     isChatSendRunActive?: (runId: string) => boolean;
     clearTrackedActiveRun?: AgentEventHandlerOptions["clearTrackedActiveRun"];
@@ -4250,6 +4252,116 @@ describe("agent event handler", () => {
     expect(persistEvent.runId).toBe("run-hidden");
     expect(requireRecord(persistEvent.data, "persist lifecycle event data").phase).toBe("end");
   });
+
+  it.each([
+    ["assistant", { text: "owned reply", delta: "owned reply", phase: "commentary" }],
+    ["tool", { phase: "start", name: "read", toolCallId: "owned-tool" }],
+    ["lifecycle", { phase: "end" }],
+  ] as const)(
+    "routes owner-scoped %s events after their run context disappears",
+    async (stream, data) => {
+      const hidden = stream !== "lifecycle";
+      const config = {
+        agents: { ownership: "explicit" as const, list: [{ id: "main" }, { id: "work" }] },
+      };
+      vi.mocked(getRuntimeConfig).mockReturnValue(config);
+      const runId = `run-owned-${stream}`;
+      const resolveSessionKeyForRun = vi.fn(
+        (_runId: string, options?: { agentId?: string }) =>
+          `agent:${options?.agentId ?? resolveDefaultAgentId(config)}:shared`,
+      );
+      const {
+        agentRunSeq,
+        broadcast,
+        broadcastToConnIds,
+        clearAgentRunContext: clearHandledRunContext,
+        nodeSendToSession,
+        sessionEventSubscribers,
+        sessionMessageSubscribers,
+        handler,
+      } = createHarness({ resolveSessionKeyForRun });
+      sessionMessageSubscribers.subscribe("conn-main", "agent:main:shared");
+      sessionMessageSubscribers.subscribe("conn-work", "agent:work:shared");
+      sessionEventSubscribers.subscribe("conn-session");
+
+      if (hidden) {
+        registerAgentRunContext(runId, {
+          agentId: "work",
+          sessionKey: "agent:work:shared",
+          isControlUiVisible: false,
+        });
+      }
+      let event: Parameters<typeof handler>[0] | undefined;
+      const unsubscribe = onAgentRuntimeEvent((received) => {
+        event = received;
+      });
+      emitRuntimeAgentEvent({ runId, stream, data, agentId: "work" });
+      unsubscribe();
+      if (hidden) {
+        clearRegisteredAgentRunContext(runId);
+      }
+      const received = expectDefined(event, "owner-scoped runtime event");
+      expect(received.sessionKey).toBeUndefined();
+
+      handler(received);
+
+      expect(resolveSessionKeyForRun.mock.calls).toEqual(
+        Array.from({ length: stream === "lifecycle" ? 2 : 1 }, () => [runId, { agentId: "work" }]),
+      );
+      if (hidden) {
+        expect(broadcast).not.toHaveBeenCalled();
+        expect(nodeSendToSession).not.toHaveBeenCalled();
+        const delivered = broadcastToConnIds.mock.calls.filter(
+          ([eventName]) => eventName === "agent" || eventName === "chat",
+        );
+        expect(delivered.length).toBeGreaterThan(0);
+        for (const [, payload, recipients] of delivered) {
+          expect(payload).toEqual(
+            expect.objectContaining({ agentId: "work", sessionKey: "agent:work:shared" }),
+          );
+          expect(recipients).toEqual(new Set(["conn-work"]));
+        }
+        return;
+      }
+
+      expect(chatBroadcastCalls(broadcast)).toEqual([
+        [
+          "chat",
+          expect.objectContaining({
+            agentId: "work",
+            runId,
+            sessionKey: "agent:work:shared",
+            state: "final",
+          }),
+          expect.objectContaining({ sessionKeys: ["agent:work:shared"] }),
+        ],
+      ]);
+      expect(nodeSendToSession.mock.calls.map(([sessionKey]) => sessionKey)).toEqual([
+        "agent:work:shared",
+        "agent:work:shared",
+      ]);
+      expect(clearHandledRunContext).toHaveBeenCalledWith(runId);
+      expect(agentRunSeq.has(runId)).toBe(false);
+      expect(persistGatewaySessionLifecycleEventMock).toHaveBeenCalledWith({
+        agentId: "work",
+        event: received,
+        sessionKey: "agent:work:shared",
+      });
+      await waitForFast(() => {
+        expect(broadcastToConnIds).toHaveBeenCalledWith(
+          "sessions.changed",
+          expect.objectContaining({
+            agentId: "work",
+            phase: "end",
+            runId,
+            sessionKey: "agent:work:shared",
+          }),
+          new Set(["conn-session"]),
+          { dropIfSlow: true },
+        );
+      });
+    },
+  );
 
   it("does not project maintenance child lifecycle onto its parent session", () => {
     const { handler } = createHarness({

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -333,7 +333,7 @@ export type AgentEventHandlerOptions = {
   nodeSendToSession: NodeSendToSession;
   agentRunSeq: Map<string, number>;
   chatRunState: ChatRunState;
-  resolveSessionKeyForRun: (runId: string) => string | undefined;
+  resolveSessionKeyForRun: (runId: string, options?: { agentId?: string }) => string | undefined;
   clearAgentRunContext: (
     runId: string,
     lifecycleGeneration?: string,
@@ -477,6 +477,18 @@ export function createAgentEventHandler({
       return;
     }
     clearAgentRunContext(evt.runId);
+  };
+  const resolveEventSession = (evt: AgentEventRuntimePayload) => {
+    const chatLink = evt.contextClaimId ? undefined : chatRunState.registry.peek(evt.runId);
+    const sessionAgentId = chatLink?.agentId ?? evt.agentId;
+    const eventSessionKey =
+      evt.deliverySessionKey ??
+      (typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined);
+    const sessionKey =
+      chatLink?.sessionKey ??
+      eventSessionKey ??
+      resolveSessionKeyForRun(evt.runId, sessionAgentId ? { agentId: sessionAgentId } : undefined);
+    return { chatLink, sessionAgentId, eventSessionKey, sessionKey };
   };
 
   type TerminalLifecycleOptions = {
@@ -762,17 +774,11 @@ export function createAgentEventHandler({
     const currentLifecycleGeneration =
       activeLifecycleGeneration ?? currentRunContext?.lifecycleGeneration;
 
-    const chatLink = evt.contextClaimId ? undefined : chatRunState.registry.peek(evt.runId);
-    const sessionAgentId = chatLink?.agentId ?? evt.agentId;
-    const eventSessionKey =
-      evt.deliverySessionKey ??
-      (typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined);
+    const { chatLink, sessionAgentId, eventSessionKey, sessionKey } = resolveEventSession(evt);
     const isControlUiVisible =
       evt.controlUiVisible ?? currentRunContext?.isControlUiVisible ?? true;
     const projectSessionLifecycle =
       evt.projectSessionLifecycle ?? currentRunContext?.projectSessionLifecycle ?? true;
-    const sessionKey =
-      chatLink?.sessionKey ?? eventSessionKey ?? resolveSessionKeyForRun(evt.runId);
     const restartRecoverySessionKey = eventSessionKey ?? sessionKey;
     const restartRecoveryAgentId = evt.agentId ?? sessionAgentId;
     const clientRunId = chatLink?.clientRunId ?? evt.runId;
@@ -1384,19 +1390,13 @@ export function createAgentEventHandler({
     const lifecyclePhase =
       evt.stream === "lifecycle" && typeof evt.data?.phase === "string" ? evt.data.phase : null;
 
-    const chatLink = evt.contextClaimId ? undefined : chatRunState.registry.peek(evt.runId);
-    const sessionAgentId = chatLink?.agentId ?? evt.agentId;
-    const eventSessionKey =
-      evt.deliverySessionKey ??
-      (typeof evt.sessionKey === "string" && evt.sessionKey.trim() ? evt.sessionKey : undefined);
+    const { chatLink, sessionAgentId, eventSessionKey, sessionKey } = resolveEventSession(evt);
     const runContext = getAgentRunContext(evt.runId);
     const activeLifecycleGeneration = resolveActiveLifecycleGenerationForRun(evt.runId);
     const isControlUiVisible = evt.controlUiVisible ?? runContext?.isControlUiVisible ?? true;
     const projectSessionLifecycle =
       evt.projectSessionLifecycle ?? runContext?.projectSessionLifecycle ?? true;
     const isHeartbeat = runContext?.isHeartbeat;
-    const sessionKey =
-      chatLink?.sessionKey ?? eventSessionKey ?? resolveSessionKeyForRun(evt.runId);
     const restartRecoverySessionKey = eventSessionKey ?? sessionKey;
     const restartRecoveryAgentId = evt.agentId ?? sessionAgentId;
     const clientRunId = chatLink?.clientRunId ?? evt.runId;

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -487,6 +487,7 @@ export function createAgentEventHandler({
     const sessionKey =
       chatLink?.sessionKey ??
       eventSessionKey ??
+      getAgentRunContext(evt.runId)?.sessionKey ??
       resolveSessionKeyForRun(evt.runId, sessionAgentId ? { agentId: sessionAgentId } : undefined);
     return { chatLink, sessionAgentId, eventSessionKey, sessionKey };
   };


### PR DESCRIPTION
Closes #126576

## What Problem This Solves

Fixes an issue where explicit multi-agent Gateways could drop live assistant, tool, and lifecycle events after the run context disappeared. The observed team deployment emitted 6,076 `Agent event dispatch failed` warnings across only 28 runs; terminal failures could occur before lifecycle persistence and cleanup.

## Why This Change Was Made

The selected agent owner now travels through every boundary that already knows it:

- sessionless embedded admission preserves `agentId` in run context;
- native Codex child activity snapshots the authoritative parent agent into immutable child state without inventing a parent session;
- Gateway chat routing uses one shared owner-scoped session-resolution path for ordinary and terminal events.

Truly ownerless work remains fail-closed. The change does not invent a default/system agent, synthesize sessions, retry dropped events, or weaken scoped delivery.

## User Impact

Multi-agent operators no longer lose Gateway WebSocket live activity when an event has an agent owner but no session key. Assistant/tool events stay isolated to the correct agent subscribers, while terminal events complete cleanup, lifecycle persistence, and session-change notification. Direct channel, HTTP streaming, `agent.wait`, plugin hook, and background-task subscribers were already unaffected and remain unchanged.

## Evidence

- Production evidence: 6,076 redacted failures across 28 runs (4,610 assistant, 1,458 tool, 8 lifecycle).
- Pre-fix dispatcher regression: assistant/tool/lifecycle cases all failed with `AgentSelectionRequiredError`.
- Pre-fix embedded producer regression: sessionless admitted activity omitted selected `agentId`.
- Pre-fix native Codex regression: child assistant/thinking/tool activity omitted parent-owned `agentId`.
- Accepted autoreview finding fixed: `ChildState` now snapshots immutable ownership, and an ownerless child cannot retroactively adopt a later parent registration's agent.
- Final head: `b37e3e37d0fec1bde2f524ff8b2aea3333e5684e`.
- Exact-head pull_request CI: [run 32353246641](https://github.com/openclaw/openclaw/actions/runs/32353246641), attempt 2, success.
- Final owner proof: lane-controller lifecycle 8 passed; Gateway event owner suites 298 passed; native Codex monitor 79 passed.
- Real Gateway WebSocket session-message suites: 56 passed, including worker commit fanout and equivalent hidden local-agent delivery.
- CI surfaced a genuine hidden local delivery regression: agent-scoped persisted-run lookup normalized `agent:main:worker` to `worker`; the shared owner path now preserves the authoritative live run-context session key before scoped fallback.
- Two CI shards initially failed before checkout on GitHub codeload HTTP 429; rerunning only failed jobs produced the exact-head green attempt above.
- Focused owner/sibling total: 366 passed.
- Complete Codex extension lane: 3,914 passed.
- `node scripts/check-changed.mjs -- <six changed files>`: passed.
- `git diff --check`: passed.
- Fresh Codex P1 autoreview after the CI finding fix: clean, no accepted/actionable findings.
- Production LOC: +37/-32 (net +5). Tests: +183/-4.

Direct Codex contract inspection confirmed app-server notifications carry thread/turn/item identifiers, not OpenClaw agent or session ownership, so OpenClaw must attach this routing fact itself.

A separate provider/browser launch was not used: the defect is below provider execution and the regression drives the real OpenClaw event bus, session resolver boundary, subscriber delivery, terminal cleanup, and lifecycle persistence that failed in production.

This is a non-visual routing/lifecycle fix; no UI rendering or layout changed.

AI-assisted: implementation and review used Codex, with maintainer verification of the full owner path, sibling Codex protocol source, regression behavior, and final diff.
