### PR TITLE
fix(ui): keep sidebar chat messages separated during resize

### DIFF
--- a/ui/src/e2e/board-split-transcript.e2e.test.ts
+++ b/ui/src/e2e/board-split-transcript.e2e.test.ts
@@ -26,6 +26,12 @@ let browser: Browser;
 let controlUi: ControlUiE2eServer;
 const contexts = new Set<BrowserContext>();
 
+type TranscriptGeometry = {
+  width: number;
+  rowGap: number;
+  assistantUserGap: number;
+};
+
 function boardSnapshot(chatDock: "right" | "hidden", revision = 1) {
   return {
     sessionKey,
@@ -56,6 +62,43 @@ async function visibleTranscriptState(page: Page) {
     ).length;
     return { present: true, intersectingRows };
   });
+}
+
+async function firstSidebarResizeFrame(page: Page, resize: () => Promise<void>) {
+  const firstFrame = page.evaluate(
+    () =>
+      new Promise<TranscriptGeometry>((resolve, reject) => {
+        const panel = document.querySelector<HTMLElement>(".side-panel");
+        if (!panel) {
+          throw new Error("Board chat side panel is missing");
+        }
+        const observer = new MutationObserver(() => {
+          observer.disconnect();
+          requestAnimationFrame(() => {
+            const [assistantRow, userRow] =
+              panel.querySelectorAll<HTMLElement>(".chat-virtual-row");
+            const assistant = assistantRow?.querySelector<HTMLElement>(
+              ".chat-group.assistant .chat-text",
+            );
+            const user = userRow?.querySelector<HTMLElement>(".chat-group.user .chat-bubble");
+            if (!assistantRow || !userRow || !assistant || !user) {
+              reject(new Error("Adjacent assistant and user transcript rows are missing"));
+              return;
+            }
+            resolve({
+              width: panel.getBoundingClientRect().width,
+              rowGap:
+                userRow.getBoundingClientRect().top - assistantRow.getBoundingClientRect().bottom,
+              assistantUserGap:
+                user.getBoundingClientRect().top - assistant.getBoundingClientRect().bottom,
+            });
+          });
+        });
+        observer.observe(panel, { attributes: true, attributeFilter: ["style"] });
+      }),
+  );
+  await resize();
+  return await firstFrame;
 }
 
 async function showDashboard(page: Page) {
@@ -159,6 +202,69 @@ describeControlUiE2e("Board split transcript restore", () => {
       .getByText("Message number 39:")
       .first()
       .waitFor({ state: "visible", timeout: 2_000 });
+  }, 120_000);
+
+  it("keeps adjacent Board chat rows separated throughout a real side-panel resize", async () => {
+    const context = await browser.newContext({ viewport: { width: 1720, height: 1250 } });
+    contexts.add(context);
+    try {
+      const page = await context.newPage();
+      const now = Date.now();
+      await installMockGateway(page, {
+        sessionKey,
+        featureMethods: ["board.get", "chat.history", "chat.metadata", "chat.startup"],
+        methodResponses: { "board.get": boardSnapshot("right") },
+        historyMessages: [
+          {
+            role: "assistant",
+            content:
+              "Created **Project Board** with a full-screen four-column dashboard:\n\n- Working\n- Idle\n- Review\n- Complete\n\nThe board can refresh active work and show a concise operator summary.\n\nSource: [project-board.html](project-board.html)\n\n" +
+              "Keep the work board visible while tracking active sessions, reviews, approvals, and completed tasks. ".repeat(
+                8,
+              ),
+            timestamp: now - 1,
+          },
+          {
+            role: "user",
+            content: "Please use the existing work board feature.",
+            timestamp: now,
+          },
+        ],
+      });
+
+      await showDashboard(page);
+      const sidePanel = page.locator(".side-panel");
+      await page.getByText("Source: project-board.html", { exact: false }).waitFor();
+      await page.getByText("Please use the existing work board feature.").waitFor();
+      const initialWidth = await sidePanel.evaluate(
+        (element) => element.getBoundingClientRect().width,
+      );
+
+      const divider = page.getByRole("separator", { name: "Resize side panel" });
+      const dividerBounds = await divider.boundingBox();
+      expect(dividerBounds).not.toBeNull();
+      const startX = dividerBounds!.x + dividerBounds!.width / 2;
+      const pointerY = dividerBounds!.y + Math.min(80, dividerBounds!.height / 2);
+      await page.mouse.move(startX, pointerY);
+      await page.mouse.down();
+      const frame = await firstSidebarResizeFrame(page, () =>
+        page.mouse.move(startX + 64, pointerY),
+      );
+      await page.mouse.up();
+
+      expect(frame.width).toBeLessThan(initialWidth);
+      expect(
+        frame.rowGap,
+        `first frame width=${frame.width}px; assistant-to-user gap=${frame.assistantUserGap}px`,
+      ).toBeGreaterThanOrEqual(0);
+      expect(
+        frame.assistantUserGap,
+        `assistant text overlaps the user bubble at width=${frame.width}px`,
+      ).toBeGreaterThanOrEqual(0);
+    } finally {
+      contexts.delete(context);
+      await context.close();
+    }
   }, 120_000);
 
   it("closes and reopens the whole multi-tab dashboard side panel", async () => {

--- a/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-region.runtime.ts
@@ -15,6 +15,7 @@ import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { sidebarPanelDefinitions } from "../chat-pane-embedded-panels.ts";
 import {
+  SIDEBAR_GEOMETRY_COMMIT_EVENT,
   SIDEBAR_MIN_HEIGHT_PX,
   SIDEBAR_MIN_WIDTH_PX,
   sidebarDock,
@@ -371,7 +372,13 @@ class ChatSidebarRegion extends OpenClawLightDomElement {
   protected override updated() {
     const root = this.parentElement?.querySelector<HTMLElement>(".sidebar-region__right-runtime");
     if (root) {
+      const previousWidth = root.querySelector<HTMLElement>(".side-panel")?.style.width;
       renderTemplate(this.renderPanel(), root);
+      const panel = root.querySelector<HTMLElement>(".side-panel");
+      // Wrapped row heights must update with their new width before the same paint.
+      if (panel && previousWidth !== undefined && panel.style.width !== previousWidth) {
+        panel.dispatchEvent(new Event(SIDEBAR_GEOMETRY_COMMIT_EVENT, { bubbles: true }));
+      }
     }
   }
 

--- a/ui/src/pages/chat/components/chat-transcript-controller.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.test.ts
@@ -5,8 +5,9 @@ import { html, nothing, render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../../test/helpers/promise.js";
 import { createTestTranscript, stubAnimationFrames } from "../chat-view.test-helpers.ts";
+import { SIDEBAR_GEOMETRY_COMMIT_EVENT } from "../sidebar-layout.ts";
 import { renderChatThread } from "./chat-thread.ts";
-import type { TranscriptRow } from "./chat-transcript-controller.ts";
+import { ChatTranscriptController, type TranscriptRow } from "./chat-transcript-controller.ts";
 import {
   flushDeferredRowPrune,
   installTranscriptDomMocks,
@@ -317,6 +318,64 @@ describe("chat transcript controller", () => {
 
     expect(transcriptRows(container)[1]?.style.transform).toBe("translateY(180px)");
     transcript.hostDisconnected();
+  });
+
+  it("remeasures every visible pane transcript while preserving hidden transcript rows", async () => {
+    const host = Object.assign(document.body.appendChild(document.createElement("div")), {
+      addController: vi.fn(),
+      removeController: vi.fn(),
+      requestUpdate: vi.fn(),
+      updateComplete: Promise.resolve(true),
+    });
+    const main = new ChatTranscriptController(host);
+    const detail = new ChatTranscriptController(host);
+    const mainPanel = host.appendChild(document.createElement("div"));
+    const detailPanel = host.appendChild(document.createElement("div"));
+    const mainProps = threadProps("pane-geometry-main", "agent:main:geometry-main");
+    const detailProps = threadProps("pane-geometry-detail", "agent:main:geometry-detail");
+    const renderTranscripts = () => {
+      render(renderChatThread(mainProps, main), mainPanel);
+      render(renderChatThread(detailProps, detail), detailPanel);
+      main.hostUpdated();
+      detail.hostUpdated();
+    };
+
+    renderTranscripts();
+    main.hostConnected();
+    detail.hostConnected();
+    await flushDeferredRowPrune();
+    renderTranscripts();
+
+    const mainScroller = expectDefined(
+      mainPanel.querySelector<HTMLElement>(".chat-thread"),
+      "main transcript scroll element",
+    );
+    const detailScroller = expectDefined(
+      detailPanel.querySelector<HTMLElement>(".chat-thread"),
+      "detail transcript scroll element",
+    );
+    mainScroller.getBoundingClientRect = () => new DOMRect(0, 0, 640, 600);
+    detailScroller.getBoundingClientRect = () =>
+      detailPanel.hidden ? new DOMRect() : new DOMRect(0, 0, 640, 600);
+
+    transcriptDomState.measuredRowHeight = 180;
+    detailPanel.dispatchEvent(new Event(SIDEBAR_GEOMETRY_COMMIT_EVENT, { bubbles: true }));
+    renderTranscripts();
+    expect(transcriptRows(mainPanel)[1]?.style.transform).toBe("translateY(180px)");
+    expect(transcriptRows(detailPanel)[1]?.style.transform).toBe("translateY(180px)");
+
+    detailPanel.hidden = true;
+    for (const row of transcriptRows(detailPanel)) {
+      Object.defineProperty(row, "offsetHeight", { configurable: true, value: 0 });
+    }
+    transcriptDomState.measuredRowHeight = 240;
+    detailPanel.dispatchEvent(new Event(SIDEBAR_GEOMETRY_COMMIT_EVENT, { bubbles: true }));
+    renderTranscripts();
+
+    expect(transcriptRows(mainPanel)[1]?.style.transform).toBe("translateY(240px)");
+    expect(transcriptRows(detailPanel)[1]?.style.transform).toBe("translateY(180px)");
+    main.hostDisconnected();
+    detail.hostDisconnected();
   });
 
   it.each([

--- a/ui/src/pages/chat/components/chat-transcript-controller.ts
+++ b/ui/src/pages/chat/components/chat-transcript-controller.ts
@@ -22,6 +22,7 @@ import {
   saveChatSessionScrollPosition,
   type ChatSessionScrollPosition,
 } from "../scroll.ts";
+import { SIDEBAR_GEOMETRY_COMMIT_EVENT } from "../sidebar-layout.ts";
 import { extractTranscriptRange, previewTranscriptRowKeys } from "./chat-transcript-range.ts";
 
 export type TranscriptRow<T = unknown> =
@@ -150,6 +151,15 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
       instance.resizeItem(index, size);
     }
   }
+  private readonly handleGeometryCommit = () => {
+    const rect = this.scrollElement?.getBoundingClientRect();
+    if (!rect || rect.width === 0 || rect.height === 0) {
+      return;
+    }
+    // The viewport observer must not repeat this committed width's row scan.
+    this.observedWidth = Math.round(rect.width);
+    this.measureConnectedRows();
+  };
   private queueConnectedRowMeasure(): void {
     if (this.pendingRowMeasureFrame !== null) {
       return;
@@ -303,6 +313,9 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
       return;
     }
     this.connected = true;
+    if (this.host instanceof HTMLElement) {
+      this.host.addEventListener(SIDEBAR_GEOMETRY_COMMIT_EVENT, this.handleGeometryCommit);
+    }
     for (const controller of this.controllers) {
       controller.hostConnected?.();
     }
@@ -333,6 +346,9 @@ class ChatSessionVirtualizerHost implements ReactiveControllerHost, ChatTranscri
       return;
     }
     this.connected = false;
+    if (this.host instanceof HTMLElement) {
+      this.host.removeEventListener(SIDEBAR_GEOMETRY_COMMIT_EVENT, this.handleGeometryCommit);
+    }
     for (const controller of this.controllers) {
       controller.hostDisconnected?.();
     }

--- a/ui/src/pages/chat/sidebar-layout.ts
+++ b/ui/src/pages/chat/sidebar-layout.ts
@@ -15,6 +15,7 @@ export type {
 
 const SIDEBAR_DEFAULT_WIDTH_PX = 480;
 const SIDEBAR_DEFAULT_HEIGHT_PX = 360;
+export const SIDEBAR_GEOMETRY_COMMIT_EVENT = "openclaw-sidebar-geometry-commit";
 export const SIDEBAR_MIN_WIDTH_PX = 260;
 export const SIDEBAR_MIN_HEIGHT_PX = 220;
 const SIDEBAR_MAX_WIDTH_PX = 1_200;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users narrowing the Control UI's Board chat sidebar could see assistant text bleed into the following user message bubble during the first frame after dragging the panel divider.

## Why This Change Was Made

Sidebar inline widths commit before TanStack's ResizeObserver reconciles virtual row heights, leaving wrapped assistant rows measured for the old, wider layout during that paint. The sidebar now emits one generic bubbling geometry-commit signal, and each pane-owned transcript independently remeasures its visible, connected rows through the existing `resizeItem(index, row.offsetHeight)` path; hidden transcripts retain their measurements, and the later observer skips a duplicate scan of the same width. This preserves transcript ownership without clipping content, introducing timers, clearing caches, or special-casing one transcript.

The latent timing gap followed the transcript-owner split in #122420 and became prominent in unified Board chat-sidebar flows including #124950. The earlier dashboard face-switch overlap addressed by #113356 was a different failure.

## User Impact

Assistant and user message rows remain visibly separated throughout sidebar-panel resizing, and sibling virtualized transcript surfaces preserve the same layout invariant independently.

Release-note context: Control UI Board and sidebar chats no longer let assistant text overlap the next user message while a sidebar is being resized.

## Evidence

### Before: assistant text intrudes into the following user bubble

![Before: assistant transcript text overlaps the following user bubble while the Board sidebar narrows](https://github.com/user-attachments/assets/fd903756-cb17-488e-aa3b-fa205687a982)

At the first frame after a real divider drag, the deterministic pre-fix reproduction measured a **-41.734375 px virtual-row gap** and **-11.734375 px assistant-to-user content gap**.

### After: adjacent messages stay separated throughout resize

![After: assistant and user transcript content remains separated while the Board sidebar narrows](https://github.com/user-attachments/assets/d26a713d-d45f-47a2-b79f-3feb7ecbce2a)

The repaired first frame measures a **+0.109375 px virtual-row gap** and **+30.109375 px assistant-to-user content gap**.

The authenticated hosted Chrome relay was unavailable, so the visual proof uses the repository's deterministic mocked Gateway with a real Chromium browser and an actual side-panel divider drag. This is mocked-Gateway browser proof, not hosted or live-service proof.

Post-rebase verification against the current `origin/main`:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/board-split-transcript.e2e.test.ts
Test Files  1 passed (1)
Tests       5 passed (5)

node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-isolated.config.ts --configLoader runner ui/src/pages/chat/components/chat-transcript-controller.test.ts
Test Files  1 passed (1)
Tests       15 passed (15)

node scripts/check-changed.mjs
PASS: changed-file guards, formatting, dead exports, Control UI i18n, core-test/UI typechecks, and scoped lint

git diff --check origin/main...HEAD
PASS
```

The earlier broader sibling coverage also passed: sidebar/task sibling suites **56/56**; `pnpm test:changed` covered **672 UI files (9,563 passed / 52 skipped)**, **3 isolated files (35 passed)**, and **1 E2E file (5 passed)**.

Production delta: **+24 lines** for the generic geometry-event contract, producer, and lifecycle-managed independent consumers; this replaces a rejected one-transcript special-case callback. Test delta: **+166 / -1 lines**. Mandatory autoreview: **clean; no actionable findings**.

AI-assisted: yes; maintainer-reviewed and independently verified.
