### PR TITLE
fix(ci): wait for outbox readiness in macOS chat test

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatViewModelOutboxTests.swift
@@ -770,10 +770,11 @@ struct ChatViewModelOutboxTests {
         let vm = await makeOutboxViewModel(transport: transport, outbox: store)
 
         await MainActor.run { vm.load() }
-        try await waitUntil("empty outbox restore completes") {
-            await MainActor.run { vm.hasRestoredOutboxMessages }
+        try await waitUntil("empty outbox becomes ready") {
+            await MainActor.run {
+                vm.healthOK && !vm.isLoading && vm.hasRestoredOutboxMessages
+            }
         }
-        try await Task.sleep(for: .milliseconds(50))
         #expect(await MainActor.run { vm.healthOK })
         #expect(await MainActor.run { vm.errorText == nil })
 
@@ -783,10 +784,11 @@ struct ChatViewModelOutboxTests {
         #expect(await store.enqueueCommand(parked))
         let parkedVM = await makeOutboxViewModel(transport: transport, outbox: store)
         await MainActor.run { parkedVM.load() }
-        try await waitUntil("parked outbox restore completes") {
-            await MainActor.run { parkedVM.hasRestoredOutboxMessages }
+        try await waitUntil("parked outbox becomes ready") {
+            await MainActor.run {
+                parkedVM.healthOK && !parkedVM.isLoading && parkedVM.hasRestoredOutboxMessages
+            }
         }
-        try await Task.sleep(for: .milliseconds(50))
         #expect(await MainActor.run { parkedVM.healthOK })
         #expect(await MainActor.run { parkedVM.errorText == nil })
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS Swift qualification test could fail intermittently because it asserted chat health after a fixed 50 ms delay instead of waiting for the view model's complete ready state.

## Why This Change Was Made

The two affected setup paths now wait for health, loading completion, and outbox restoration together. The existing nil-error assertions remain unchanged; production behavior and timeouts are untouched.

## User Impact

No production behavior changes. Main qualification gets deterministic coverage for healthy live chat with empty and parked outbox state.

## Evidence

- Focused test stress: 20/20 passes on Xcode 26.6 / Swift 6.3.3.
- SwiftFormat 0.62.1: clean.
- SwiftLint 0.65.0: no new violations; six existing warnings are outside the changed lines.
- `git diff --check`: clean.
- Production LOC: 0. Test LOC: +8/-6.
- Exact-head `macos-swift` CI: passed in run 32352732323, including the parallel OpenClawKit suite.
- Hosted ClawSweeper: no actionable findings on head `9eab29cbff62`.
