### PR TITLE
docs(plugins): show root CLI commands

### DIFF
--- a/docs/plugins/reference/browser.md
+++ b/docs/plugins/reference/browser.md
@@ -16,7 +16,7 @@ Adds agent-callable tools.
 
 ## Surface
 
-contracts: `tools`; skills
+CLI commands: `openclaw browser`; contracts: `tools`; skills
 
 ## Related docs
 

--- a/docs/plugins/reference/codex.md
+++ b/docs/plugins/reference/codex.md
@@ -16,7 +16,7 @@ Codex app-server harness and native session catalog.
 
 ## Surface
 
-commands: `/codex`; contracts: `mediaUnderstandingProviders`, `migrationProviders`, `tools`, `webSearchProviders`
+CLI commands: `openclaw codex`; slash commands: `/codex`; contracts: `mediaUnderstandingProviders`, `migrationProviders`, `tools`, `webSearchProviders`
 
 ## Related docs
 

--- a/docs/plugins/reference/device-pair.md
+++ b/docs/plugins/reference/device-pair.md
@@ -16,4 +16,4 @@ Generate setup codes and approve device pairing requests.
 
 ## Surface
 
-commands: `/pair`
+slash commands: `/pair`

--- a/docs/plugins/reference/google-meet.md
+++ b/docs/plugins/reference/google-meet.md
@@ -16,7 +16,7 @@ OpenClaw Google Meet participant plugin for joining calls through Chrome or Twil
 
 ## Surface
 
-contracts: `tools`, `transcriptSourceProviders`
+CLI commands: `openclaw googlemeet`; contracts: `tools`, `transcriptSourceProviders`
 
 ## Related docs
 

--- a/docs/plugins/reference/matrix.md
+++ b/docs/plugins/reference/matrix.md
@@ -16,7 +16,7 @@ OpenClaw Matrix channel plugin for rooms and direct messages.
 
 ## Surface
 
-channels: `matrix`
+channels: `matrix`; CLI commands: `openclaw matrix`
 
 ## Related docs
 

--- a/docs/plugins/reference/memory-core.md
+++ b/docs/plugins/reference/memory-core.md
@@ -16,4 +16,4 @@ Adds agent-callable tools.
 
 ## Surface
 
-commands: `/dreaming`; contracts: `tools`
+CLI commands: `openclaw memory`; slash commands: `/dreaming`; contracts: `tools`

--- a/docs/plugins/reference/memory-lancedb.md
+++ b/docs/plugins/reference/memory-lancedb.md
@@ -16,7 +16,7 @@ OpenClaw LanceDB-backed long-term memory plugin with auto-recall, auto-capture, 
 
 ## Surface
 
-contracts: `tools`
+CLI commands: `openclaw ltm`; contracts: `tools`
 
 ## Related docs
 

--- a/docs/plugins/reference/memory-wiki.md
+++ b/docs/plugins/reference/memory-wiki.md
@@ -16,7 +16,7 @@ Persistent wiki compiler and Obsidian-friendly knowledge vault for OpenClaw.
 
 ## Surface
 
-contracts: `tools`; skills
+CLI commands: `openclaw wiki`; contracts: `tools`; skills
 
 ## Related docs
 

--- a/docs/plugins/reference/oc-path.md
+++ b/docs/plugins/reference/oc-path.md
@@ -16,7 +16,7 @@ Adds the openclaw path CLI for oc:// workspace file addressing.
 
 ## Surface
 
-plugin
+CLI commands: `openclaw path`
 
 ## Related docs
 

--- a/docs/plugins/reference/onepassword.md
+++ b/docs/plugins/reference/onepassword.md
@@ -16,7 +16,7 @@ title: "Onepassword plugin"
 
 ## Surface
 
-contracts: `tools`
+CLI commands: `openclaw onepassword`; contracts: `tools`
 
 ## Related docs
 

--- a/docs/plugins/reference/policy.md
+++ b/docs/plugins/reference/policy.md
@@ -16,7 +16,7 @@ Adds policy-backed doctor checks for workspace conformance.
 
 ## Surface
 
-plugin
+CLI commands: `openclaw policy`
 
 <!-- openclaw-plugin-reference:manual-start -->
 

--- a/docs/plugins/reference/qa-lab.md
+++ b/docs/plugins/reference/qa-lab.md
@@ -16,4 +16,4 @@ OpenClaw QA lab plugin with private debugger UI and scenario runner.
 
 ## Surface
 
-contracts: `tools`, `webSearchProviders`, `workerProviders`
+CLI commands: `openclaw qa`; contracts: `tools`, `webSearchProviders`, `workerProviders`

--- a/docs/plugins/reference/reef.md
+++ b/docs/plugins/reference/reef.md
@@ -16,7 +16,7 @@ Guarded end-to-end encrypted claw channel.
 
 ## Surface
 
-channels: `reef`
+channels: `reef`; CLI commands: `openclaw reef`
 
 ## Related docs
 

--- a/docs/plugins/reference/talk-voice.md
+++ b/docs/plugins/reference/talk-voice.md
@@ -16,7 +16,7 @@ Manage Talk voice selection (list/set).
 
 ## Surface
 
-commands: `/voice`
+slash commands: `/voice`
 
 <!-- openclaw-plugin-reference:manual-start -->
 

--- a/docs/plugins/reference/teams-meetings.md
+++ b/docs/plugins/reference/teams-meetings.md
@@ -16,7 +16,7 @@ Join Microsoft Teams meetings as a Chrome browser guest.
 
 ## Surface
 
-contracts: `tools`, `transcriptSourceProviders`
+CLI commands: `openclaw teamsmeetings`; contracts: `tools`, `transcriptSourceProviders`
 
 ## Related docs
 

--- a/docs/plugins/reference/vault.md
+++ b/docs/plugins/reference/vault.md
@@ -16,7 +16,7 @@ HashiCorp Vault SecretRef provider integration.
 
 ## Surface
 
-plugin
+CLI commands: `openclaw vault`
 
 ## Related docs
 

--- a/docs/plugins/reference/voice-call.md
+++ b/docs/plugins/reference/voice-call.md
@@ -16,7 +16,7 @@ OpenClaw voice-call plugin for Twilio, Telnyx, and Plivo phone calls.
 
 ## Surface
 
-contracts: `tools`; skills
+CLI commands: `openclaw voicecall`; contracts: `tools`; skills
 
 ## Related docs
 

--- a/docs/plugins/reference/workboard.md
+++ b/docs/plugins/reference/workboard.md
@@ -16,7 +16,7 @@ Dashboard workboard for agent-owned issues and sessions.
 
 ## Surface
 
-contracts: `tools`; dashboard data bindings: `workboard.cards.list`, `workboard.stats`, `workboard.boards.list`; dashboard action verbs: `workboard.dispatch`
+CLI commands: `openclaw workboard`; contracts: `tools`; dashboard data bindings: `workboard.cards.list`, `workboard.stats`, `workboard.boards.list`; dashboard action verbs: `workboard.dispatch`
 
 ## Related docs
 

--- a/docs/plugins/reference/zoom-meetings.md
+++ b/docs/plugins/reference/zoom-meetings.md
@@ -16,7 +16,7 @@ Join Zoom meetings as a Chrome browser guest.
 
 ## Surface
 
-contracts: `tools`, `transcriptSourceProviders`
+CLI commands: `openclaw zoommeetings`; contracts: `tools`, `transcriptSourceProviders`
 
 ## Related docs
 

--- a/scripts/lib/plugin-inventory-doc.mts
+++ b/scripts/lib/plugin-inventory-doc.mts
@@ -2,6 +2,7 @@ type PluginSurfaceManifest = {
   id?: string;
   channels?: string[];
   providers?: string[];
+  cliCommands?: Array<{ name?: string }>;
   commandAliases?: Array<{ name?: string; kind?: string }>;
   contracts?: Record<string, unknown>;
   dashboard?: Partial<Record<"actionVerbs" | "dataBindings", Array<{ id?: string }>>>;
@@ -83,7 +84,17 @@ export function resolvePluginSurface(manifest: PluginSurfaceManifest) {
   if (Array.isArray(manifest.providers) && manifest.providers.length > 0) {
     parts.push(`providers: ${formatIdentifiers(manifest.providers)}`);
   }
-  const commands = [
+  const cliCommands = [
+    ...new Set(
+      (manifest.cliCommands ?? [])
+        .map((command) => command.name?.trim())
+        .filter((name): name is string => Boolean(name)),
+    ),
+  ].toSorted((left, right) => left.localeCompare(right));
+  if (cliCommands.length > 0) {
+    parts.push(`CLI commands: ${formatIdentifiers(cliCommands.map((name) => `openclaw ${name}`))}`);
+  }
+  const slashCommands = [
     ...new Set(
       (manifest.commandAliases ?? [])
         .filter((alias) => alias.kind === "runtime-slash")
@@ -91,8 +102,8 @@ export function resolvePluginSurface(manifest: PluginSurfaceManifest) {
         .filter((name): name is string => Boolean(name)),
     ),
   ].toSorted((left, right) => left.localeCompare(right));
-  if (commands.length > 0) {
-    parts.push(`commands: ${formatIdentifiers(commands.map((name) => `/${name}`))}`);
+  if (slashCommands.length > 0) {
+    parts.push(`slash commands: ${formatIdentifiers(slashCommands.map((name) => `/${name}`))}`);
   }
   const contracts = Object.keys(manifest.contracts ?? {}).toSorted((left, right) =>
     left.localeCompare(right),

--- a/test/scripts/plugin-inventory-doc.test.ts
+++ b/test/scripts/plugin-inventory-doc.test.ts
@@ -30,15 +30,23 @@ describe("resolvePluginSurface", () => {
     expect(resolvePluginSurface({})).toBe("plugin");
   });
 
-  it("renders only runtime slash command aliases", () => {
+  it("renders root CLI commands separately from runtime slash command aliases", () => {
     expect(
       resolvePluginSurface({
+        cliCommands: [
+          { name: " voicecall " },
+          { name: "browser" },
+          { name: "voicecall" },
+          { name: " " },
+        ],
         commandAliases: [
           { name: "voice", kind: "runtime-slash" },
+          { name: " voice ", kind: "runtime-slash" },
+          { name: " ", kind: "runtime-slash" },
           { name: "internal", kind: "activation-only" },
         ],
       }),
-    ).toBe("commands: `/voice`");
+    ).toBe("CLI commands: `openclaw browser`, `openclaw voicecall`; slash commands: `/voice`");
   });
 
   it("escapes dashboard plugin owner delimiters and literal escape markers", () => {


### PR DESCRIPTION
Closes #126620

## What Problem This Solves

Fixes an issue where operators reading generated plugin-reference pages could not discover valid plugin-owned root CLI commands, even though those commands already appeared in OpenClaw root help through canonical manifest metadata. Existing chat slash commands were also labeled ambiguously as generic `commands:`.

Affected plugins: browser, codex, google-meet, matrix, memory-core, memory-lancedb, memory-wiki, oc-path, onepassword, policy, qa-lab, reef, teams-meetings, vault, voice-call, workboard, and zoom-meetings.

## Why This Change Was Made

The manifest-first root-help path consumes `cliCommands`, but the generated plugin-reference projector predates that metadata and projected only `commandAliases` with `kind: "runtime-slash"`. Teach the canonical projector to trim, drop blanks, deduplicate, and deterministically sort root command names; render actionable `CLI commands: openclaw <name>` entries before distinctly labeled `slash commands: /<name>` entries.

This preserves existing metadata, runtime behavior, plugin ownership, and all other reference-page presentation. #124562 introduced manifest root-command descriptors after #121354 added the independent slash-command projection. Existing draft #117582 overlaps generated-reference ownership but uses an older generator shape and does not project either modern command surface.

## User Impact

Plugin-reference readers can now distinguish executable terminal commands such as `openclaw browser`, `openclaw voicecall`, and `openclaw memory` from in-chat commands such as `/codex`, `/dreaming`, `/pair`, and `/voice`.

All 17 plugins declaring root CLI commands are represented. Four plugins have runtime slash commands, with two overlaps, producing exactly 19 regenerated reference pages. Each generated page changes one Surface line; both inventory indexes remain unchanged.

## Evidence

- Pre-fix owner-boundary regression: the expanded existing projector test failed with `Expected: "CLI commands: openclaw browser, openclaw voicecall; slash commands: /voice"` versus `Received: "commands: /voice"` before the generator change.
- `pnpm test test/scripts/plugin-inventory-doc.test.ts` — 6 passed, including sorting, trimming, blank rejection, deduplication, non-slash alias exclusion, and simultaneous CLI/slash rendering.
- `pnpm test src/cli/program/root-help.test.ts src/plugins/cli.test.ts` — 27 passed across the root-help and plugin-manifest contract suites.
- `pnpm plugins:inventory:gen` — canonical regeneration only.
- `pnpm plugins:inventory:check` — passed.
- `pnpm docs:list` — passed.
- `pnpm check:docs` — passed; 762 Markdown files linted, 6,524 internal links checked, 1,180 config examples validated.
- `node scripts/check-changed.mjs --dry-run -- <changed files>` — classified `scripts`, `testRoot`, `docs`, and `tooling`.
- `pnpm check:changed` — passed, including script/root-test typechecking, formatting, script lint, and repository guards.
- Targeted formatting check across all 21 changed files and `git diff --check` — passed.
- Fresh Codex-backed P0/P1 autoreview — clean.
- Separate independent, read-only adversarial review of the frozen final diff — clean.
- Independent manifest-to-generated-page audit — 17/17 CLI manifests documented; four slash-command pages correctly labeled; exact generated union 19 pages.

Risk: documentation generator and generated references only; no root-help, runtime, manifest, config, schema, protocol, Plugin SDK, persistence, security, or changelog changes. Runtime production LOC: +0/-0. Tooling: +14/-3. Tests: +10/-2. Generated references: +19/-19 across 19 pages.

AI-assisted: yes
