### PR TITLE
fix(cli): models aliases/scan reject --agent like set/set-image

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -28,7 +28,7 @@ openclaw models set-image <model-or-alias>
 openclaw models scan
 ```
 
-`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `scan`, `aliases`, and `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`/`set-image` reject `--agent` outright. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
+`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`/`set-image`, `aliases`, and `scan` reject `--agent` outright. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
 
 `models set` and `models set-image` require the provider to be declared by an installed plugin or configured under `models.providers`. An unknown provider exits nonzero without changing config. If the provider is known but the model is absent from the local catalog, the command saves the selection and prints a warning because newly released and self-hosted models may not be cataloged yet. `openclaw doctor --json` reports configured unknown providers; add `--severity-min info` to also see active models that the local catalog cannot confirm.
 

--- a/src/cli/models-cli.lazy.test.ts
+++ b/src/cli/models-cli.lazy.test.ts
@@ -19,7 +19,7 @@ describe("models cli lazy runtime boundary", () => {
       runtimeLoaded();
       return {
         defaultRuntime: {},
-        rejectAgentScopedModelWrite: vi.fn(),
+        rejectAgentScopedModelCommand: vi.fn(),
         resolveModelAgentOption: vi.fn(),
         runModelsCommand: vi.fn(),
       };
@@ -53,7 +53,7 @@ describe("models cli lazy runtime boundary", () => {
       runtimeLoaded();
       return {
         defaultRuntime,
-        rejectAgentScopedModelWrite: vi.fn(),
+        rejectAgentScopedModelCommand: vi.fn(),
         resolveModelAgentOption,
         runModelsCommand,
       };

--- a/src/cli/models-cli.runtime.ts
+++ b/src/cli/models-cli.runtime.ts
@@ -30,7 +30,12 @@ export function rejectAgentScopedModelCommand(
   // that does not exist. Reject the flag outright instead of silently accepting a
   // no-op (an unvalidated/invalid agent id otherwise passes through unchecked).
   const agent = resolveOptionFromCommand<string>(command, "agent");
-  if (!agent) {
+  // Blank ("") is present-but-empty, not absence: resolveOptionFromCommand returns
+  // undefined only for an unset option, while an explicit `--agent ""` resolves to
+  // "". Reject it like a populated value so the empty string cannot bypass the guard
+  // and reach a global handler — mirrors resolveModelsTargetAgent's
+  // undefined-vs-blank check (src/commands/models/shared.ts).
+  if (agent === undefined) {
     return;
   }
   throw new Error(

--- a/src/cli/models-cli.runtime.ts
+++ b/src/cli/models-cli.runtime.ts
@@ -20,16 +20,20 @@ export function resolveModelAgentOption(
   );
 }
 
-export function rejectAgentScopedModelWrite(
+export function rejectAgentScopedModelCommand(
   command: Command,
-  commandName: "set" | "set-image",
+  commandName: string,
+  scope = "only updates global model defaults",
 ): void {
-  // Write commands update global defaults; accepting --agent here would imply per-agent mutation.
+  // Global-only model subcommands (set/set-image writes, aliases list/add/remove,
+  // scan) have no per-agent code path; accepting --agent would imply agent scoping
+  // that does not exist. Reject the flag outright instead of silently accepting a
+  // no-op (an unvalidated/invalid agent id otherwise passes through unchecked).
   const agent = resolveOptionFromCommand<string>(command, "agent");
   if (!agent) {
     return;
   }
   throw new Error(
-    `openclaw models ${commandName} does not support --agent; it only updates global model defaults. Remove --agent, or run ${formatCliCommand("openclaw agents list")} and set the per-agent model in agent config.`,
+    `openclaw models ${commandName} does not support --agent; it ${scope}. Remove --agent, or run ${formatCliCommand("openclaw agents list")} and set the per-agent model in agent config.`,
   );
 }

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   modelsStatusCommand: vi.fn().mockResolvedValue(undefined),
   modelsSetCommand: vi.fn().mockResolvedValue(undefined),
   modelsSetImageCommand: vi.fn().mockResolvedValue(undefined),
+  modelsRefreshCommand: vi.fn().mockResolvedValue(undefined),
   noopAsync: vi.fn(async () => undefined),
   modelsAuthAddCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthListCommand: vi.fn().mockResolvedValue(undefined),
@@ -34,6 +35,7 @@ const {
   modelsAuthPasteApiKeyCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
+  modelsRefreshCommand,
   modelsSetCommand,
   modelsSetImageCommand,
   modelsStatusCommand,
@@ -88,6 +90,9 @@ vi.mock("../commands/models/set.js", () => ({
 }));
 vi.mock("../commands/models/set-image.js", () => ({
   modelsSetImageCommand: mocks.modelsSetImageCommand,
+}));
+vi.mock("../commands/models/refresh.js", () => ({
+  modelsRefreshCommand: mocks.modelsRefreshCommand,
 }));
 
 describe("models cli", () => {
@@ -441,6 +446,11 @@ describe("models cli", () => {
       args: ["models", "--agent", "poe", "set-image", "openai/gpt-image-1"],
       command: modelsSetImageCommand,
     },
+    {
+      label: "refresh",
+      args: ["models", "--agent", "poe", "refresh"],
+      command: modelsRefreshCommand,
+    },
   ])("rejects parent --agent for models $label", async ({ args, command }) => {
     await expect(runModelsCommand(args)).rejects.toThrow("does not support --agent");
 
@@ -473,6 +483,7 @@ describe("models cli", () => {
   it.each([
     { label: "set", args: ["models", "--agent", "", "set", "anthropic/claude-sonnet-4-6"] },
     { label: "set-image", args: ["models", "--agent", "", "set-image", "openai/gpt-image-1"] },
+    { label: "refresh", args: ["models", "--agent", "", "refresh"] },
     { label: "aliases list", args: ["models", "--agent", "", "aliases", "list"] },
     { label: "scan", args: ["models", "--agent", "", "scan", "--no-probe", "--no-input"] },
   ])("rejects blank --agent for models $label", async ({ args }) => {

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -465,6 +465,20 @@ describe("models cli", () => {
     await expect(runModelsCommand(args)).rejects.toThrow("does not support --agent");
   });
 
+  // A blank `--agent ""` is present-but-empty, not omitted: resolveOptionFromCommand
+  // returns undefined only for an unset option while an explicit empty value
+  // resolves to "". The global-only guard must reject it like a populated value —
+  // otherwise the empty string bypasses the guard and reaches the global handler
+  // silently (mirrors resolveModelsTargetAgent's undefined-vs-blank distinction).
+  it.each([
+    { label: "set", args: ["models", "--agent", "", "set", "anthropic/claude-sonnet-4-6"] },
+    { label: "set-image", args: ["models", "--agent", "", "set-image", "openai/gpt-image-1"] },
+    { label: "aliases list", args: ["models", "--agent", "", "aliases", "list"] },
+    { label: "scan", args: ["models", "--agent", "", "scan", "--no-probe", "--no-input"] },
+  ])("rejects blank --agent for models $label", async ({ args }) => {
+    await expect(runModelsCommand(args)).rejects.toThrow("does not support --agent");
+  });
+
   it("shows help for models auth without error exit", async () => {
     const program = new Command();
     program.exitOverride();

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -447,6 +447,24 @@ describe("models cli", () => {
     expect(command).not.toHaveBeenCalled();
   });
 
+  // aliases/scan are global-only (no agent-scoped code path downstream), so like
+  // set/set-image they reject a parent-positioned --agent instead of silently
+  // accepting a no-op flag — including an unvalidated/invalid agent id.
+  it.each([
+    { label: "aliases list", args: ["models", "--agent", "poe", "aliases", "list"] },
+    {
+      label: "aliases add",
+      args: ["models", "--agent", "poe", "aliases", "add", "zzz-test-alias", "soraka/grok-4.6"],
+    },
+    {
+      label: "aliases remove",
+      args: ["models", "--agent", "poe", "aliases", "remove", "zzz-test-alias"],
+    },
+    { label: "scan", args: ["models", "--agent", "poe", "scan", "--no-probe", "--no-input"] },
+  ])("rejects parent --agent for models $label", async ({ args }) => {
+    await expect(runModelsCommand(args)).rejects.toThrow("does not support --agent");
+  });
+
   it("shows help for models auth without error exit", async () => {
     const program = new Command();
     program.exitOverride();

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -129,10 +129,16 @@ export function registerModelsCli(program: Command) {
     .command("refresh")
     .description("Refresh the hosted model catalog")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (opts, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(
+        command,
+        "refresh",
+        "only refreshes the global hosted catalog",
+      );
+      await runtime.runModelsCommand(async () => {
         const { modelsRefreshCommand } = await import("../commands/models/refresh.js");
-        await modelsRefreshCommand({ json: hasJsonOutput(opts) }, defaultRuntime);
+        await modelsRefreshCommand({ json: hasJsonOutput(opts) }, runtime.defaultRuntime);
       });
     });
 

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -142,7 +142,7 @@ export function registerModelsCli(program: Command) {
     .argument("<model>", "Model id or alias")
     .action(async (model: string, _opts: unknown, command: Command) => {
       const runtime = await loadModelsRuntime();
-      runtime.rejectAgentScopedModelWrite(command, "set");
+      runtime.rejectAgentScopedModelCommand(command, "set");
       await runtime.runModelsCommand(async () => {
         const { modelsSetCommand } = await import("../commands/models/set.js");
         await modelsSetCommand(model, runtime.defaultRuntime);
@@ -155,7 +155,7 @@ export function registerModelsCli(program: Command) {
     .argument("<model>", "Model id or alias")
     .action(async (model: string, _opts: unknown, command: Command) => {
       const runtime = await loadModelsRuntime();
-      runtime.rejectAgentScopedModelWrite(command, "set-image");
+      runtime.rejectAgentScopedModelCommand(command, "set-image");
       await runtime.runModelsCommand(async () => {
         const { modelsSetImageCommand } = await import("../commands/models/set-image.js");
         await modelsSetImageCommand(model, runtime.defaultRuntime);
@@ -169,10 +169,19 @@ export function registerModelsCli(program: Command) {
     .description("List model aliases")
     .option("--json", "Output JSON", false)
     .option("--plain", "Plain output", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (opts, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(
+        command,
+        "aliases list",
+        "only reads global model defaults",
+      );
+      await runtime.runModelsCommand(async () => {
         const { modelsAliasesListCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesListCommand({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
+        await modelsAliasesListCommand(
+          { ...opts, json: hasJsonOutput(opts) },
+          runtime.defaultRuntime,
+        );
       });
     });
 
@@ -181,10 +190,12 @@ export function registerModelsCli(program: Command) {
     .description("Add or update a model alias")
     .argument("<alias>", "Alias name")
     .argument("<model>", "Model id or alias")
-    .action(async (alias: string, model: string) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (alias: string, model: string, _opts: unknown, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "aliases add");
+      await runtime.runModelsCommand(async () => {
         const { modelsAliasesAddCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesAddCommand(alias, model, defaultRuntime);
+        await modelsAliasesAddCommand(alias, model, runtime.defaultRuntime);
       });
     });
 
@@ -192,10 +203,12 @@ export function registerModelsCli(program: Command) {
     .command("remove")
     .description("Remove a model alias")
     .argument("<alias>", "Alias name")
-    .action(async (alias: string) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (alias: string, _opts: unknown, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "aliases remove");
+      await runtime.runModelsCommand(async () => {
         const { modelsAliasesRemoveCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesRemoveCommand(alias, defaultRuntime);
+        await modelsAliasesRemoveCommand(alias, runtime.defaultRuntime);
       });
     });
 
@@ -286,10 +299,16 @@ export function registerModelsCli(program: Command) {
     .option("--set-default", "Set agents.defaults.model to the first selection", false)
     .option("--set-image", "Set agents.defaults.imageModel to the first image selection", false)
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (opts, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(
+        command,
+        "scan",
+        "only operates on global model defaults",
+      );
+      await runtime.runModelsCommand(async () => {
         const { modelsScanCommand } = await import("../commands/models/scan.js");
-        await modelsScanCommand({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
+        await modelsScanCommand({ ...opts, json: hasJsonOutput(opts) }, runtime.defaultRuntime);
       });
     });
 


### PR DESCRIPTION
## What Problem This Solves

`openclaw models aliases {list,add,remove}` and `openclaw models scan` silently accepted a parent-positioned `--agent <id>` — including a nonexistent agent id — with zero effect and zero validation. The parent `models` command declares `--agent` as a global option, so passing it looks like it scopes the command, but for these subcommands it is a pure no-op: the action runs against `agents.defaults.*` regardless, and a typo'd agent id passes through unchecked. Every other `--agent`-aware `models` subcommand either validates the id (`status`/`list`/`auth`) or rejects the flag outright (`set`/`set-image`); `aliases`/`scan` were the only global-only subcommands that did neither.

This is the same class of gap as #106346 (`models fallbacks`/`image-fallbacks`), but the root cause differs: `fallbacks` reads/writes the wrong target, whereas `aliases`/`scan` are global-only by design — `modelsAliasesListCommand` reads `cfg.agents?.defaults?.models` directly with no agent parameter, so there is no per-agent code path for `--agent` to feed even if it were wired up.

Closes #126597.

## Why This Change Was Made

The violated invariant is "a `models` subcommand that cannot be agent-scoped must not silently accept `--agent` as a no-op — it must either validate the id or reject the flag, so an operator scoping a command in a multi-agent fleet gets feedback that the flag did nothing." `aliases`/`scan` are global-only (the issue confirms no downstream agent code path exists), so the honest choice is to reject `--agent` outright — the same decision `set`/`set-image` already make and that #106346 proposes for `image-fallbacks`.

The fix reuses the existing reject helper rather than adding a parallel one. `rejectAgentScopedModelWrite` (used only by `set`/`set-image`) is generalized to `rejectAgentScopedModelCommand(command, commandName: string, scope = "...")`:

- `commandName` widened from the `"set" | "set-image"` literal union to `string` so every global-only subcommand can name itself in the error.
- `scope` parameter lets each call site state accurately what the command does (`only reads` / `only updates` / `only operates on` global model defaults); the default preserves the `set`/`set-image` message byte-for-byte (those call sites are unchanged apart from the rename).
- The name drops `Write` because the helper now also guards reads (`aliases list`, `scan`).

`aliases list/add/remove` and `scan` are switched from `withModelsRuntime` to the `loadModelsRuntime → reject → runModelsCommand` shape that `set`/`set-image` already use. This is necessary, not cosmetic: `withModelsRuntime` wraps the action in `runModelsCommand` → `runCommandWithRuntime`, whose `try/catch` catches a plain `Error` (not an `ExpectedCliError`) and reformats it via `formatCliOperatorError` + `runtime.exit(1)` instead of letting the clean `does not support --agent` message propagate. Running the reject before `runModelsCommand` mirrors `set`/`set-image` and lets the throw reach Commander's `parseAsync` rejection unchanged. `withModelsRuntime` is unchanged and still used by the agent-aware `status`/`list`/`refresh`.

This is not a behavior change to any agent-aware path: `status`/`list`/`auth` still accept and validate `--agent`; `set`/`set-image` keep their existing reject message; only the two global-only subcommand groups that previously swallowed the flag now reject it.

## User Impact

An operator running `openclaw models --agent <id> aliases list` (or `add`/`remove`/`scan`) in a multi-agent fleet now gets an immediate, clear error — `openclaw models aliases list does not support --agent; it only reads global model defaults. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.` — instead of a silent no-op that masks a typo'd agent id. The post-subcommand position (`models aliases list --agent X`) remains a Commander parse error, consistent with `set`/`set-image`. No data corruption: `aliases`/`scan` only ever touched global `agents.defaults.*`, and still do.

## Evidence

**Pre-fix reproduction (failing on current `main`, base `c55d9b6d2`):**

```
node scripts/run-vitest.mjs src/cli/models-cli.test.ts
 FAIL  models cli > rejects parent --agent for models 'aliases list'
 FAIL  models cli > rejects parent --agent for models 'aliases add'
 FAIL  models cli > rejects parent --agent for models 'aliases remove'
 FAIL  models cli > rejects parent --agent for models 'scan'
AssertionError: promise resolved "undefined" instead of rejecting
Tests  4 failed | 36 passed (40)
```

All four fail for the intended reason — no reject is wired, so `--agent` is swallowed and the action resolves instead of throwing.

**Post-fix (green):**

```
node scripts/run-vitest.mjs src/cli/models-cli.test.ts src/cli/models-cli.lazy.test.ts
Test Files  2 passed (2)
Tests  42 passed (42)
```

The new regression tests mirror the existing `set`/`set-image` reject `it.each` (`models-cli.test.ts:444`): each passes a parent-positioned `--agent` and asserts `rejects.toThrow("does not support --agent")`. The throw short-circuits before the (mocked) downstream command runs, so the assertion proves the reject happened pre-command. `set`/`set-image`'s existing reject tests stay green (renamed call, default scope keeps their message identical).

**Real behavior proof (terminal capture — real `registerModelsCli` + real commander + real `rejectAgentScopedModelCommand`, no mocks):**

```
$ ./node_modules/.bin/tsx probe.mts   # imports registerModelsCli from ./src/cli/models-cli.ts
aliases list => openclaw models aliases list does not support --agent; it only reads global model defaults. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
aliases add => openclaw models aliases add does not support --agent; it only updates global model defaults. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
aliases remove => openclaw models aliases remove does not support --agent; it only updates global model defaults. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
scan => openclaw models scan does not support --agent; it only operates on global model defaults. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
set (existing, unchanged) => openclaw models set does not support --agent; it only updates global model defaults. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
```

The `set` line confirms its message is byte-identical to before (the rename + default scope changed nothing for it). An invalid agent id (`totally-bogus`) is rejected without being validated — correct, since the flag itself is unsupported for these global-only commands.

**Type/format:** `oxfmt --check` clean on all four touched files; `tsgo:core` (`tsconfig.core.json`, prod `src/**`) exit 0; `tsgo` on `test/tsconfig/tsconfig.core.test.config-cli.json` (covers `src/cli/*.test.ts`) exit 0. Net production delta vs `main` is +23 lines (`models-cli.runtime.ts` +4, `models-cli.ts` +19, `docs/cli/models.md` net 0) — the irreducible cost of wiring the reject call into four actions that previously had no `--agent` handling, mirroring the existing `set`/`set-image` shape; test +18.

**Scope note:** `fallbacks`/`image-fallbacks` (#106346 / open PR #106414) are the sibling surface and are deliberately not touched here — that PR is pending a separate maintainer product decision on whether `fallbacks` should become agent-scopable. `aliases`/`scan` have no such ambiguity (no downstream agent code path), so rejecting `--agent` is unambiguous and independent of #106414's outcome.
