### PR TITLE
perf(test): route TUI PTY tests exclusively

### DIFF
--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -65,7 +65,7 @@ import {
   pluginSdkLightTestFiles,
   resolvePluginSdkLightIncludePattern,
 } from "../test/vitest/vitest.plugin-sdk-paths.mjs";
-import { fullSuiteVitestShards } from "../test/vitest/vitest.test-shards.mjs";
+import { fullSuiteVitestShards, tuiPtyTestFiles } from "../test/vitest/vitest.test-shards.mjs";
 import {
   isToolingIsolatedTestFile,
   toolingIsolatedTestFiles,
@@ -3264,7 +3264,7 @@ function classifyTarget(arg: string, cwd: string) {
   if (isPathAtOrUnder(relative, "ui")) {
     return "ui";
   }
-  if (relative.startsWith("src/tui/tui-pty-")) {
+  if (relative.startsWith("src/tui/tui-pty-") || tuiPtyTestFiles.includes(relative)) {
     return "tuiPty";
   }
   if (relative.endsWith(".e2e.test.ts")) {

--- a/src/infra/vitest-e2e-config.test.ts
+++ b/src/infra/vitest-e2e-config.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../test/helpers/vitest-config-paths.js";
 import { BUNDLED_PLUGIN_E2E_TEST_GLOB } from "../../test/vitest/vitest.bundled-plugin-paths.ts";
 import e2eConfig, { createE2EVitestConfig } from "../../test/vitest/vitest.e2e.config.ts";
+import tuiPtyConfig from "../../test/vitest/vitest.tui-pty.config.ts";
 
 describe("e2e vitest config", () => {
   it("runs as a standalone config instead of inheriting unit projects", () => {
@@ -22,8 +23,6 @@ describe("e2e vitest config", () => {
       "src/gateway/sessions-history-http.test.ts",
       BUNDLED_PLUGIN_E2E_TEST_GLOB,
     ]);
-    expect(e2eConfig.test?.exclude).toContain("src/tui/tui-pty-harness.e2e.test.ts");
-    expect(e2eConfig.test?.exclude).toContain("src/tui/tui-pty-local.e2e.test.ts");
     expect(e2eConfig.test?.pool).toBe("threads");
     expect(e2eConfig.test?.isolate).toBe(false);
     expect(normalizeConfigPath(e2eConfig.test?.runner)).toBe("test/non-isolated-runner.ts");
@@ -31,6 +30,25 @@ describe("e2e vitest config", () => {
       "test/setup.ts",
       "test/setup-openclaw-runtime.ts",
     ]);
+  });
+
+  it("keeps every terminal integration test exclusively in the serial PTY lane", () => {
+    const tuiPtyTests = [
+      "src/tui/tui-auth-child-pty.e2e.test.ts",
+      "src/tui/tui-pty-harness.e2e.test.ts",
+      "src/tui/tui-session-identity-pty.e2e.test.ts",
+      "src/tui/tui-reset-transition-pty.e2e.test.ts",
+      "src/tui/tui-pty-local.e2e.test.ts",
+    ];
+
+    expect(e2eConfig.test?.exclude).toEqual(expect.arrayContaining(tuiPtyTests));
+    expect(tuiPtyConfig.test?.include).toEqual(
+      tuiPtyTests
+        .filter((target) => !target.endsWith("tui-pty-local.e2e.test.ts"))
+        .map((target) => target.replace(/^src\//u, "")),
+    );
+    expect(tuiPtyConfig.test?.fileParallelism).toBe(false);
+    expect(tuiPtyConfig.test?.maxWorkers).toBe(1);
   });
 
   it("serializes default e2e runs while preserving explicit worker overrides", () => {

--- a/src/infra/vitest-e2e-config.test.ts
+++ b/src/infra/vitest-e2e-config.test.ts
@@ -6,7 +6,7 @@ import {
 } from "../../test/helpers/vitest-config-paths.js";
 import { BUNDLED_PLUGIN_E2E_TEST_GLOB } from "../../test/vitest/vitest.bundled-plugin-paths.ts";
 import e2eConfig, { createE2EVitestConfig } from "../../test/vitest/vitest.e2e.config.ts";
-import tuiPtyConfig from "../../test/vitest/vitest.tui-pty.config.ts";
+import { createTuiPtyVitestConfig } from "../../test/vitest/vitest.tui-pty.config.ts";
 
 describe("e2e vitest config", () => {
   it("runs as a standalone config instead of inheriting unit projects", () => {
@@ -33,6 +33,7 @@ describe("e2e vitest config", () => {
   });
 
   it("keeps every terminal integration test exclusively in the serial PTY lane", () => {
+    const tuiPtyConfig = createTuiPtyVitestConfig({});
     const tuiPtyTests = [
       "src/tui/tui-auth-child-pty.e2e.test.ts",
       "src/tui/tui-pty-harness.e2e.test.ts",

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2902,21 +2902,24 @@ describe("scripts/test-projects changed-target routing", () => {
     ]);
   });
 
-  it.each(["src/tui/tui-pty-harness.e2e.test.ts", "src/tui/tui-pty-local.e2e.test.ts"])(
-    "routes TUI PTY integration target %s to the PTY lane",
-    (target) => {
-      const plans = buildVitestRunPlans([target], process.cwd());
+  it.each([
+    "src/tui/tui-auth-child-pty.e2e.test.ts",
+    "src/tui/tui-pty-harness.e2e.test.ts",
+    "src/tui/tui-session-identity-pty.e2e.test.ts",
+    "src/tui/tui-reset-transition-pty.e2e.test.ts",
+    "src/tui/tui-pty-local.e2e.test.ts",
+  ])("routes TUI PTY integration target %s to the PTY lane", (target) => {
+    const plans = buildVitestRunPlans([target], process.cwd());
 
-      expect(plans).toEqual([
-        {
-          config: "test/vitest/vitest.tui-pty.config.ts",
-          forwardedArgs: [],
-          includePatterns: [target],
-          watchMode: false,
-        },
-      ]);
-    },
-  );
+    expect(plans).toEqual([
+      {
+        config: "test/vitest/vitest.tui-pty.config.ts",
+        forwardedArgs: [],
+        includePatterns: [target],
+        watchMode: false,
+      },
+    ]);
+  });
 });
 
 describe("scripts/test-projects full-suite sharding", () => {

--- a/test/vitest/vitest.e2e.config.ts
+++ b/test/vitest/vitest.e2e.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from "vitest/config";
 import { BUNDLED_PLUGIN_E2E_TEST_GLOB } from "./vitest.bundled-plugin-paths.ts";
 import baseConfig from "./vitest.config.ts";
 import { resolveRepoRootPath } from "./vitest.shared.config.ts";
+import { tuiPtyTestFiles } from "./vitest.test-shards.mjs";
 
 function resolveE2EWorkerCount(env: Record<string, string | undefined>): number {
   const requestedWorkers = Number.parseInt(env.OPENCLAW_E2E_WORKERS ?? "", 10);
@@ -20,12 +21,9 @@ const { projects: _projects, ...baseTest } = baseTestWithProjects as {
   projects?: string[];
   setupFiles?: string[];
 };
-// The dedicated TUI PTY config owns both terminal suites and emits per-test progress.
-// The local real-backend file can exceed the generic E2E silent-process watchdog.
-const tuiPtyExcludes = ["src/tui/tui-pty-harness.e2e.test.ts", "src/tui/tui-pty-local.e2e.test.ts"];
 const exclude = [
   ...(baseTest.exclude ?? []).filter((p) => p !== "**/*.e2e.test.ts"),
-  ...tuiPtyExcludes,
+  ...tuiPtyTestFiles,
 ];
 
 export function createE2EVitestConfig(env: Record<string, string | undefined> = process.env) {

--- a/test/vitest/vitest.test-shards.d.mts
+++ b/test/vitest/vitest.test-shards.d.mts
@@ -8,4 +8,5 @@ export const autoReplyCoreTestInclude: string[];
 export const autoReplyCoreTestExclude: string[];
 export const autoReplyTopLevelReplyTestInclude: string[];
 export const autoReplyReplySubtreeTestInclude: string[];
+export const tuiPtyTestFiles: string[];
 export const fullSuiteVitestShards: FullSuiteVitestShard[];

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -12,6 +12,14 @@ export const autoReplyTopLevelReplyTestInclude = ["src/auto-reply/reply*.test.ts
 
 export const autoReplyReplySubtreeTestInclude = ["src/auto-reply/reply/**/*.test.ts"];
 
+export const tuiPtyTestFiles = [
+  "src/tui/tui-auth-child-pty.e2e.test.ts",
+  "src/tui/tui-pty-harness.e2e.test.ts",
+  "src/tui/tui-session-identity-pty.e2e.test.ts",
+  "src/tui/tui-reset-transition-pty.e2e.test.ts",
+  "src/tui/tui-pty-local.e2e.test.ts",
+];
+
 export const fullSuiteVitestShards = [
   {
     config: "test/vitest/vitest.full-core-unit-fast.config.ts",

--- a/test/vitest/vitest.tui-pty.config.ts
+++ b/test/vitest/vitest.tui-pty.config.ts
@@ -13,7 +13,7 @@ function toTuiPtyIncludePatterns(patterns: string[] | null) {
   return patterns?.map((pattern) => pattern.replace(/^src\//u, "")) ?? null;
 }
 
-function createTuiPtyVitestConfig(env?: Record<string, string | undefined>) {
+export function createTuiPtyVitestConfig(env?: Record<string, string | undefined>) {
   const baseTest = sharedVitestConfig.test ?? {};
   const exclude = (baseTest.exclude ?? []).filter((pattern) => pattern !== "**/*.e2e.test.ts");
   const configEnv = env ?? process.env;

--- a/test/vitest/vitest.tui-pty.config.ts
+++ b/test/vitest/vitest.tui-pty.config.ts
@@ -2,21 +2,12 @@
 import { defineConfig } from "vitest/config";
 import { loadPatternListFromEnv, narrowIncludePatternsForCli } from "./vitest.pattern-file.ts";
 import { resolveRepoRootPath, sharedVitestConfig } from "./vitest.shared.config.ts";
+import { tuiPtyTestFiles } from "./vitest.test-shards.mjs";
 
 const targetableIncludes = [
   "src/tui/tui-pty-harness-assertion-test-support.test.ts",
-  "src/tui/tui-auth-child-pty.e2e.test.ts",
-  "src/tui/tui-pty-harness.e2e.test.ts",
-  "src/tui/tui-session-identity-pty.e2e.test.ts",
-  "src/tui/tui-pty-local.e2e.test.ts",
-  "src/tui/tui-reset-transition-pty.e2e.test.ts",
-  "tui/tui-pty-harness-assertion-test-support.test.ts",
-  "tui/tui-auth-child-pty.e2e.test.ts",
-  "tui/tui-pty-harness.e2e.test.ts",
-  "tui/tui-session-identity-pty.e2e.test.ts",
-  "tui/tui-pty-local.e2e.test.ts",
-  "tui/tui-reset-transition-pty.e2e.test.ts",
-];
+  ...tuiPtyTestFiles,
+].flatMap((target) => [target, target.replace(/^src\//u, "")]);
 
 function toTuiPtyIncludePatterns(patterns: string[] | null) {
   return patterns?.map((pattern) => pattern.replace(/^src\//u, "")) ?? null;
@@ -27,13 +18,9 @@ function createTuiPtyVitestConfig(env?: Record<string, string | undefined>) {
   const exclude = (baseTest.exclude ?? []).filter((pattern) => pattern !== "**/*.e2e.test.ts");
   const configEnv = env ?? process.env;
   const includeLocal = configEnv.OPENCLAW_TUI_PTY_INCLUDE_LOCAL === "1";
-  const include = [
-    "tui/tui-auth-child-pty.e2e.test.ts",
-    "tui/tui-pty-harness.e2e.test.ts",
-    "tui/tui-session-identity-pty.e2e.test.ts",
-    "tui/tui-reset-transition-pty.e2e.test.ts",
-    ...(includeLocal ? ["tui/tui-pty-local.e2e.test.ts"] : []),
-  ];
+  const include = tuiPtyTestFiles
+    .filter((target) => includeLocal || !target.endsWith("tui-pty-local.e2e.test.ts"))
+    .map((target) => target.replace(/^src\//u, ""));
   const includeFromEnv = toTuiPtyIncludePatterns(
     loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", configEnv),
   );


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer-owned branch; maintainers can update it directly.

</details>

## What Problem This Solves

Resolves an operational test-performance issue where three real-terminal integration suites were collected twice: once in their dedicated serial TUI PTY lane and again in generic E2E. Direct changed-test runs also selected generic E2E for the authentication-child, remembered-session identity, and reset-transition PTY suites, bypassing their intended isolated owner.

## Why This Change Was Made

A single canonical `tuiPtyTestFiles` inventory now drives dedicated PTY includes, generic E2E exclusions, and changed-target classification. All five terminal integration files have exactly one serial owner (`fileParallelism=false`, `maxWorkers=1`); the optional local-backend PTY smoke remains explicitly opt-in. This is bounded test/tooling configuration and regression coverage only, with no production behavior or dependencies changed.

## User Impact

No end-user behavior changes. Developers and maintainers get faster, correctly isolated test runs without deleting or weakening terminal integration coverage.

## Evidence

Controlled same-Linux-worker benchmark: https://github.com/openclaw/openclaw/actions/runs/32348671255. Warmup excluded; two retained samples per side, one worker, distinct caches, import diagnostics, and `/usr/bin/time -v`.

- Duplicate generic E2E collection before: 3 files / 10 tests; retained wall times 31.51 s and 36.43 s, median 33.97 s. Vitest: 31.12 / 35.94 s; test body: 25.72 / 29.06 s; imports: 4.54 / 5.98 s; maximum RSS: 921060 / 874916 KiB; user/system: 32.88 / 3.12 s and 39.43 / 3.92 s.
- Duplicate generic E2E collection after: 0 files / 0 tests; retained wall times 0.32 s and 0.30 s, median 0.31 s. Direct duplicate saving: **33.66 s / 99.09%**.
- Combined dedicated PTY plus generic E2E median: **151.015 s -> 123.38 s**, saving **27.635 s / 18.30%** despite normal real-PTY timing variation.
- Dedicated PTY coverage: **73 / 73 passed before and after**; retained post-fix dedicated wall times 125.96 s and 120.18 s. No tests removed.
- Pre-fix regression proof: the changed-target routing test failed for authentication-child, remembered-session identity, and reset-transition; the config-ownership test failed because the generic E2E exclusions were absent.
- Fault injection: temporarily removing authentication-child from the canonical inventory failed exactly its routing case and failed the config-ownership assertion; the inventory was restored exactly.
- Post-rebase focused routing: `env -u OPENCLAW_TESTBOX node scripts/run-vitest.mjs test/scripts/test-projects.test.ts` -> **275 / 275 passed**.
- Post-rebase focused config ownership: `env -u OPENCLAW_TESTBOX node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/infra/vitest-e2e-config.test.ts` -> **4 / 4 passed**.
- Complete pre-rebase changed gate: **coreTests, scripts, testRoot, and tooling passed**, including typechecks, deadcode, format, architecture guards, and core/scripts lint; rebasing preserved the exact patch and upstream touched none of the ownership surface.
- Seven-file formatting and `git diff --check`: **passed**. Production LOC **+0/-0**; tooling **+19/-25**; tests **+37/-16**; total **+56/-41** across seven files.
- Fresh structured branch autoreview: no accepted/actionable findings.
- No changelog or screenshots: test routing only, with no user-visible UI or runtime change. Proof environment: real Linux Testbox PTY lane; no additional platform-specific behavior is claimed.

AI-assisted and maintainer-reviewed.
