### PR TITLE
fix(telegram): recognize current-source message targets

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -75,7 +75,11 @@ import {
 } from "./group-policy.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import * as monitorModule from "./monitor.js";
-import { looksLikeTelegramTargetId, normalizeTelegramMessagingTarget } from "./normalize.js";
+import {
+  looksLikeTelegramTargetId,
+  normalizeTelegramMessagingTarget,
+  telegramMessagingTargetsMatch,
+} from "./normalize.js";
 import { createTelegramOutboundAdapter } from "./outbound-adapter.js";
 import { parseTelegramThreadId } from "./outbound-params.js";
 import { releaseStoppedTelegramPollingLease } from "./polling-lease.js";
@@ -1280,6 +1284,12 @@ export const telegramPlugin = createChatChannelPlugin({
   },
   security: telegramSecurityAdapter,
   threading: {
+    matchesToolContextTarget: ({ target, toolContext }) => {
+      return [toolContext.currentMessagingTarget, toolContext.currentChannelId].some(
+        (currentTarget) =>
+          currentTarget != null && telegramMessagingTargetsMatch(target, currentTarget),
+      );
+    },
     resolveReplyToMode: ({ cfg, accountId }) =>
       resolveTelegramConfigAccessorAccount({ cfg, accountId }).config.replyToMode ?? "off",
     buildToolContext: (params) => buildTelegramThreadingToolContext(params),

--- a/extensions/telegram/src/normalize.ts
+++ b/extensions/telegram/src/normalize.ts
@@ -15,25 +15,37 @@ function normalizeTelegramTargetBody(raw: string): string | undefined {
     return undefined;
   }
 
-  const parsed = parseTelegramTarget(trimmed);
-  const normalizedChatId = normalizeTelegramLookupTarget(parsed.chatId);
-  if (!normalizedChatId) {
+  const identity = resolveTelegramTargetIdentity(trimmed);
+  if (!identity) {
     return undefined;
   }
 
   const keepLegacyGroupPrefix = /^group:/i.test(prefixStripped);
   const hasTopicSuffix = /:topic:\d+$/i.test(prefixStripped);
-  const chatSegment = keepLegacyGroupPrefix ? `group:${normalizedChatId}` : normalizedChatId;
-  if (parsed.directMessagesTopicId != null) {
-    return `${chatSegment}:direct-topic:${parsed.directMessagesTopicId}`;
+  const chatSegment = keepLegacyGroupPrefix ? `group:${identity.chatId}` : identity.chatId;
+  if (identity.directMessagesTopicId != null) {
+    return `${chatSegment}:direct-topic:${identity.directMessagesTopicId}`;
   }
-  if (parsed.messageThreadId == null) {
+  if (identity.messageThreadId == null) {
     return chatSegment;
   }
   const threadSuffix = hasTopicSuffix
-    ? `:topic:${parsed.messageThreadId}`
-    : `:${parsed.messageThreadId}`;
+    ? `:topic:${identity.messageThreadId}`
+    : `:${identity.messageThreadId}`;
   return `${chatSegment}${threadSuffix}`;
+}
+
+function resolveTelegramTargetIdentity(raw: string) {
+  const parsed = parseTelegramTarget(raw);
+  const chatId = normalizeTelegramLookupTarget(parsed.chatId);
+  if (!chatId) {
+    return undefined;
+  }
+  return {
+    chatId: normalizeLowercaseStringOrEmpty(chatId),
+    messageThreadId: parsed.messageThreadId,
+    directMessagesTopicId: parsed.directMessagesTopicId,
+  };
 }
 
 export function normalizeTelegramMessagingTarget(raw: string): string | undefined {
@@ -46,4 +58,16 @@ export function normalizeTelegramMessagingTarget(raw: string): string | undefine
 
 export function looksLikeTelegramTargetId(raw: string): boolean {
   return normalizeTelegramTargetBody(raw) !== undefined;
+}
+
+export function telegramMessagingTargetsMatch(target: string, currentTarget: string): boolean {
+  const targetIdentity = resolveTelegramTargetIdentity(target);
+  const currentIdentity = resolveTelegramTargetIdentity(currentTarget);
+  return (
+    targetIdentity !== undefined &&
+    currentIdentity !== undefined &&
+    targetIdentity.chatId === currentIdentity.chatId &&
+    targetIdentity.messageThreadId === currentIdentity.messageThreadId &&
+    targetIdentity.directMessagesTopicId === currentIdentity.directMessagesTopicId
+  );
 }

--- a/extensions/telegram/src/threading-tool-context.test.ts
+++ b/extensions/telegram/src/threading-tool-context.test.ts
@@ -15,6 +15,14 @@ vi.mock("openclaw/plugin-sdk/secret-file-runtime", async (importOriginal) => ({
   tryReadSecretFileSync: tryReadSecretFileSyncMock,
 }));
 
+function requireTelegramToolContextTargetMatcher() {
+  const matchesToolContextTarget = telegramPlugin.threading?.matchesToolContextTarget;
+  if (!matchesToolContextTarget) {
+    throw new Error("Telegram tool context target matcher is unavailable");
+  }
+  return matchesToolContextTarget;
+}
+
 describe("telegramPlugin reply threading", () => {
   it.each([
     {
@@ -60,6 +68,42 @@ describe("telegramPlugin reply threading", () => {
     expect(resolveReplyToMode({ cfg, accountId: "sut" })).toBe(expected);
     expect(tryReadSecretFileSyncMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { target: "-100123", currentChannelId: "telegram:-100123", expected: true },
+    { target: "telegram:-100123", currentChannelId: "-100123", expected: true },
+    {
+      target: "-100123:topic:77",
+      currentChannelId: "telegram:-100123:77",
+      expected: true,
+    },
+    {
+      target: "-100123:direct-topic:77",
+      currentChannelId: "telegram:-100123:direct-topic:77",
+      expected: true,
+    },
+    {
+      target: "-100123:topic:77",
+      currentChannelId: "telegram:-100123:direct-topic:77",
+      expected: false,
+    },
+    {
+      target: "-100123:topic:77",
+      currentChannelId: "telegram:-100123:topic:78",
+      expected: false,
+    },
+    { target: "-100456", currentChannelId: "telegram:-100123", expected: false },
+  ])(
+    "matches canonical target $target against current channel $currentChannelId",
+    ({ target, currentChannelId, expected }) => {
+      expect(
+        requireTelegramToolContextTargetMatcher()({
+          target,
+          toolContext: { currentChannelId },
+        }),
+      ).toBe(expected);
+    },
+  );
 });
 
 describe("buildTelegramThreadingToolContext", () => {

--- a/src/infra/outbound/message-action-execution.source-reply.test.ts
+++ b/src/infra/outbound/message-action-execution.source-reply.test.ts
@@ -1,6 +1,7 @@
 // Covers core message-action send fallback, TTS application, and durable send
 // policy after plugin preparation is absent.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
@@ -17,6 +18,14 @@ vi.mock("../../tts/tts.runtime.js", () => ({
 const slackConfig = {
   channels: {
     slack: {
+      enabled: true,
+    },
+  },
+} as OpenClawConfig;
+
+const telegramConfig = {
+  channels: {
+    telegram: {
       enabled: true,
     },
   },
@@ -52,6 +61,41 @@ function registerSlackTextPlugin(accountIds: string[] = ["default"]) {
     ]),
   );
   return sendText;
+}
+
+function registerTelegramTextPlugin(
+  matchesToolContextTarget: NonNullable<
+    NonNullable<ChannelPlugin["threading"]>["matchesToolContextTarget"]
+  >,
+) {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "telegram",
+        source: "test",
+        plugin: {
+          ...createOutboundTestPlugin({
+            id: "telegram",
+            messaging: { targetResolver: { looksLikeId: () => true } },
+            outbound: {
+              deliveryMode: "direct",
+              sendText: vi.fn().mockResolvedValue({
+                channel: "telegram",
+                messageId: "m1",
+                chatId: "-100123",
+              }),
+            },
+          }),
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({ enabled: true }),
+            isConfigured: () => true,
+          },
+          threading: { matchesToolContextTarget },
+        },
+      },
+    ]),
+  );
 }
 
 describe("runMessageAction core send routing", () => {
@@ -121,6 +165,66 @@ describe("runMessageAction core send routing", () => {
 
     expect(result.kind).toBe("send");
     expect(result.payload).toMatchObject({ sourceReplyRoute: "current-source" });
+  });
+
+  it.each([
+    {
+      name: "an equivalent raw current-chat target",
+      target: "-100123",
+      currentChannelId: "telegram:-100123",
+      matcherResult: true,
+      expectedRoute: "current-source",
+    },
+    {
+      name: "a different chat",
+      target: "-100456",
+      currentChannelId: "telegram:-100123",
+      matcherResult: false,
+      expectedRoute: undefined,
+    },
+    {
+      name: "a different topic",
+      target: "-100123:topic:78",
+      currentChannelId: "telegram:-100123:topic:77",
+      matcherResult: false,
+      expectedRoute: undefined,
+    },
+  ])("uses the Telegram target matcher for $name", async (testCase) => {
+    const matchesToolContextTarget = vi.fn(() => testCase.matcherResult);
+    registerTelegramTextPlugin(matchesToolContextTarget);
+
+    const toolContext = {
+      currentChannelProvider: "telegram",
+      currentChannelId: testCase.currentChannelId,
+      currentSourceTurnId: "source-turn-1",
+    };
+    const result = await runMessageAction({
+      cfg: telegramConfig,
+      action: "send",
+      params: {
+        channel: "telegram",
+        target: testCase.target,
+        message: "visible source reply",
+      },
+      toolContext,
+      messageActionAuthorization: {
+        requesterAccountId: "default",
+        toolContext,
+      },
+      sessionKey: `agent:main:telegram:group:${testCase.currentChannelId}`,
+      defaultAccountId: "default",
+      sourceReplyDeliveryMode: "message_tool_only",
+      dryRun: false,
+    });
+
+    expect(result.kind).toBe("send");
+    expect((result.payload as { sourceReplyRoute?: unknown }).sourceReplyRoute).toBe(
+      testCase.expectedRoute,
+    );
+    expect(matchesToolContextTarget).toHaveBeenCalledWith({
+      target: testCase.target,
+      toolContext,
+    });
   });
 
   it("does not mark a message-scoped reply that enters a new thread as current-source", async () => {


### PR DESCRIPTION
## Problem

A Telegram agent can call `message.send` with an explicit raw chat target and `final: true`, successfully deliver the reply, then continue the same turn and send duplicate replies.

## Root cause

Telegram stores the inbound tool context as a provider-qualified target such as `telegram:<chat-id>`, while the message tool accepts the equivalent raw `<chat-id>`. Telegram did not implement `threading.matchesToolContextTarget`, so source-delivery annotation compared those strings literally, failed closed, and the embedded runner did not classify the successful send as the terminal current-source reply.

## Fix

Add Telegram's channel-owned semantic target matcher. It compares normalized chat identity plus forum/direct-message topic identity, so raw/provider-qualified and compact/explicit topic forms match without collapsing different chats or topics. Generic source-delivery and terminal-loop code remains unchanged.

PR #113554 covers a broader unsigned CLI/embedded route-resolution case. It does not add Telegram target equivalence or touch these files.

## Proof

Regression-first owner tests failed before the fix: the adapter suite failed 4/9 with no matcher, and the compact-vs-explicit topic case failed 1/9 against a string-only matcher. Both pass with the semantic matcher.

- Focused Telegram + source-delivery tests: 8 files, 122 passed
- `pnpm tsgo` — passed
- `pnpm check:test-types` — passed
- `pnpm build` — passed
- `pnpm check:changed` — passed
- `git diff --check` — passed
- Telegram extension import profile — passed, 351.6 MB max RSS

Changed-path Telegram E2E on `c2c62d08b86879a8b4f462f93188920477c968ba` used a real QA user and dedicated SUT bot in `message_tool` mode. The model sent to the equivalent raw Telegram target with `final: true`; the user saw exactly one durable `OPENCLAW_E2E_TERMINAL_RAW_TARGET` reply. One temporary progress message was deleted. OpenClaw recorded `tool_delivered`; no provider continuation or fallback/duplicate reply occurred. Recording completed.

<details>
<summary>Redacted Telegram E2E transcript</summary>

```text
+4.270s USER → SUT: Exercise OPENCLAW_E2E_RAW_TARGET_TERMINAL.
+4.271s SUT: typing start, then typing cancel
+4.276s SUT: temporary progress message
+4.276s SUT: OPENCLAW_E2E_TERMINAL_RAW_TARGET
+5.848s SUT: deleted temporary progress message

Recorder: complete
SUT totals: typing=2, message=2 (one progress + one durable reply), delete=1
Provider chat requests: 1 initial request, 0 continuation requests
Durable outcome: tool_delivered; runStatus=completed
Fallback marker: absent
```

All Telegram user, bot, chat, message, run, and session identifiers removed.

</details>

Production: +44/-10 lines. Tests: +148 lines.
