### PR TITLE
fix(agents): keep turns on their admitted plugin generation

### DIFF
--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -83,6 +83,16 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
       existing?.needsRefresh &&
       !existing.pending &&
       (existing.provenance === "run" || existing.provenance === "ephemeral");
+    const pluginGenerationChanged =
+      options.pluginGeneration !== undefined &&
+      (existing?.pending ? existing.pendingPluginGeneration : existing?.pluginGeneration) !==
+        options.pluginGeneration;
+    if (existing?.pending && pluginGenerationChanged) {
+      // Do not supersede active discovery. Wait for its owner to settle, then retry against
+      // the published identity so same-generation callers still coalesce.
+      await existing.pending.catch(() => undefined);
+      continue;
+    }
     if (
       context.getGatewayLifecycleActive() &&
       provenance === "run" &&
@@ -114,7 +124,17 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
       }
     }
     try {
-      if (existing && !staleDynamicOwner) {
+      if (existing?.pending && !pluginGenerationChanged) {
+        // Matching callers lease the immutable generation they joined even if a queued
+        // mismatched caller publishes the next owner immediately after this one settles.
+        snapshot = await existing.pending;
+        if (existing.snapshot !== snapshot || existing.needsRefresh) {
+          continue;
+        }
+        owner = existing;
+        break;
+      }
+      if (existing && !staleDynamicOwner && !pluginGenerationChanged) {
         snapshot = await context.prepareSnapshot(input);
       } else {
         // Fresh keys publish a first generation; stale dynamic owners publish a distinct

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -226,6 +226,61 @@ describe("prepared model runtime owner selection", () => {
     expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
   });
 
+  it("sequences pending owners by their explicit plugin generation", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const generationA = (await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }))
+      ?.pluginGeneration;
+    expect(generationA).toBeDefined();
+    const generationB = {
+      ...generationA!,
+      pluginMetadataSnapshot: { ...generationA!.pluginMetadataSnapshot },
+    };
+    let finishGenerationA!: () => void;
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
+      async () =>
+        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+          finishGenerationA = () =>
+            resolve({ agentDir: "/tmp/dynamic-generation-agent", wrote: false });
+        }),
+    );
+    const input = {
+      config,
+      agentId: "default",
+      agentDir: "/tmp/dynamic-generation-agent",
+      workspaceDir: "/tmp/dynamic-generation-workspace",
+    };
+
+    const pendingA = acquireAgentRunPreparedModelRuntime(input, {
+      pluginGeneration: generationA!,
+    });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const matchingPendingA = acquireAgentRunPreparedModelRuntime(input, {
+      pluginGeneration: generationA!,
+    });
+    const pendingB = acquireAgentRunPreparedModelRuntime(input, {
+      pluginGeneration: generationB,
+    });
+    await Promise.resolve();
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2);
+    finishGenerationA();
+    const [leaseA, matchingLeaseA, leaseB] = await Promise.all([
+      pendingA,
+      matchingPendingA,
+      pendingB,
+    ]);
+
+    expect(matchingLeaseA.snapshot).toBe(leaseA.snapshot);
+    expect(leaseB.snapshot).not.toBe(leaseA.snapshot);
+    expect(leaseA.snapshot.metadataSnapshot).toBe(generationA!.pluginMetadataSnapshot);
+    expect(leaseB.snapshot.metadataSnapshot).toBe(generationB.pluginMetadataSnapshot);
+    leaseA.release();
+    matchingLeaseA.release();
+    await expect(prepareModelRuntimeSnapshot(input)).resolves.toBe(leaseB.snapshot);
+    leaseB.release();
+  });
+
   it("bounds retained gateway run owners while reusing recent selections", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -414,6 +414,9 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
     owner.generation += 1;
     owner.needsRefresh = true;
     owner.refreshError = undefined;
+    owner.pendingPluginGeneration = params.reusePluginGenerations
+      ? owner.pluginGeneration
+      : undefined;
     const generation = owner.generation;
     const key = ownerKey(input);
     let registered = params.owners.get(key) === owner;
@@ -431,6 +434,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         owner.generation === generation &&
         params.owners.get(key) === owner,
       key,
+      generation,
       markRegistered: () => {
         registered = true;
       },
@@ -525,6 +529,9 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         }
       }
       for (const candidate of candidates) {
+        if (candidate.owner.generation === candidate.generation) {
+          candidate.owner.pendingPluginGeneration = undefined;
+        }
         if (!candidate.isCurrent()) {
           continue;
         }
@@ -542,6 +549,9 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
     } catch (error) {
       const refreshError = toStringifiedError(error);
       for (const candidate of candidates) {
+        if (candidate.owner.generation === candidate.generation) {
+          candidate.owner.pendingPluginGeneration = undefined;
+        }
         if (!candidate.isCurrent()) {
           continue;
         }
@@ -590,6 +600,7 @@ export async function publishModelRuntimeSnapshot(
   owner.needsRefresh = true;
   owner.refreshError = undefined;
   owner.pluginGeneration = undefined;
+  owner.pendingPluginGeneration = reusablePluginGeneration;
   const generation = owner.generation;
   const build = startSerializedSnapshotBuild(
     input,
@@ -618,11 +629,15 @@ export async function publishModelRuntimeSnapshot(
       }
       owner.snapshot = result.snapshot;
       owner.pluginGeneration = result.pluginGeneration;
+      owner.pendingPluginGeneration = undefined;
       owner.pending = undefined;
       owner.needsRefresh = false;
       return result.snapshot;
     } catch (error) {
       const refreshError = toStringifiedError(error);
+      if (owner.generation === generation) {
+        owner.pendingPluginGeneration = undefined;
+      }
       if (owner.generation === generation && owners.get(key) === owner) {
         owner.pending = undefined;
         owner.needsRefresh = true;

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -150,6 +150,8 @@ export type PreparedModelRuntimeOwner = {
   refreshError?: Error;
   snapshot?: PreparedModelRuntimeSnapshot;
   pluginGeneration?: PreparedModelRuntimePluginGeneration;
+  /** Explicit generation admitted for the current publication, when known. */
+  pendingPluginGeneration?: PreparedModelRuntimePluginGeneration;
   pending?: Promise<PreparedModelRuntimeSnapshot>;
   buildCompletion?: Promise<void>;
   leaseCount?: number;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway turns admitted under a new plugin generation could reuse a same-key prepared runtime from an older settled or in-flight generation and abort before provider execution.

## Why This Change Was Made

Prepared runtime owners now retain the generation identity associated with pending publication. Same-generation callers coalesce, while callers pinned to a different or unknown generation wait for the current publication to settle and then publish a distinct owner. Existing release identity guards keep the newer generation published when older leases are released.

## User Impact

Gateway turns continue with the exact plugin generation admitted for that turn instead of failing before the model runtime starts during generation changes.

## Evidence

- `node scripts/run-vitest.mjs src/agents/prepared-model-runtime.lifecycle.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts`: 67 passed locally.
- Exact-head CI run `32360166840`: success at `d9eae655bbc0e8a31596d5fe75bdef1fbd5e11e7`, including core production/test types, lint, changed test shards, and the aggregate CI gate.
- `git diff --check`, targeted `oxfmt`, and exact final-branch P1 autoreview: passed with no actionable findings.
- Testbox lease `tbx_01m0fbbv99cy4fe8nc3bczwxwc`, run `32359008962`, on the byte-identical pre-rebase patch: commands did not start because delegated Blacksmith file sync exceeded its fixed two-minute deadline. The unchanged infrastructure failure was not retried; clean-checkout exact-head CI supplies the authoritative type/lint/test proof.
- Production delta: `+38/-1`; test delta: `+55/-0`.
- Codex `origin/main` `312b62ac95335e1762b70ceb8910374965bd2785` inspected directly: `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:59`, `codex-rs/app-server/src/message_processor.rs:1103`, and `codex-rs/app-server/src/request_processors/thread_processor.rs:1056`, `:1386`, `:1507` confirm `thread/start` is validated, routed, started, and acknowledged only after OpenClaw runtime admission. The owner repair therefore belongs before `extensions/codex/src/app-server/thread-lifecycle-io.ts:467`, without changing the Codex protocol or weakening the orchestrator guard.

Disclosure: AI tooling was used to inspect the codebase, implement the fix, and review the change.
