### PR TITLE
fix(ui): recover newer builds after stale probes

### DIFF
--- a/ui/src/app/stale-chunk-reload.test.ts
+++ b/ui/src/app/stale-chunk-reload.test.ts
@@ -104,7 +104,7 @@ describe("scheduleStaleChunkReload", () => {
     expect(storage.getItem(GUARD_KEY)).toBe("build-a");
   });
 
-  it("never auto-reloads twice for the same build, but recovers on a newer build", async () => {
+  it("never lets a persisted build guard suppress recovery for a newer build", async () => {
     const reload = vi.fn();
     const storage = memoryStorage({ [GUARD_KEY]: "build-a" });
     stubDocumentFetch(new Response(null, { status: 200 }));
@@ -119,7 +119,7 @@ describe("scheduleStaleChunkReload", () => {
     expect(reload).not.toHaveBeenCalled();
     await expect(
       scheduleStaleChunkReload({
-        now: () => 7000,
+        now: () => 2000,
         buildId: "build-b",
         storage,
         reload,
@@ -179,18 +179,71 @@ describe("scheduleStaleChunkReload", () => {
     await expect(
       scheduleStaleChunkReload({
         now: () => 1000,
+        buildId: "build-a",
         storage,
         reload,
       }),
     ).resolves.toBe(false);
-    await expect(scheduleStaleChunkReload({ now: () => 2000, storage, reload })).resolves.toBe(
-      false,
-    );
+    await expect(
+      scheduleStaleChunkReload({ now: () => 2000, buildId: "build-a", storage, reload }),
+    ).resolves.toBe(false);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    await expect(scheduleStaleChunkReload({ now: () => 7000, storage, reload })).resolves.toBe(
-      true,
-    );
+    await expect(
+      scheduleStaleChunkReload({ now: () => 7000, buildId: "build-a", storage, reload }),
+    ).resolves.toBe(true);
     expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("probes a newer build immediately after an older build was unreachable", async () => {
+    const reload = vi.fn();
+    const storage = memoryStorage();
+    const fetchMock = stubDocumentFetch(
+      new Response(null, { status: 503 }),
+      new Response(null, { status: 200 }),
+    );
+
+    await expect(
+      scheduleStaleChunkReload({ now: () => 1000, buildId: "build-a", storage, reload }),
+    ).resolves.toBe(false);
+    await expect(
+      scheduleStaleChunkReload({ now: () => 2000, buildId: "build-b", storage, reload }),
+    ).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(GUARD_KEY)).toBe("build-b");
+  });
+
+  it("reprobes a newer build after its joined older-build probe fails", async () => {
+    const olderProbe = deferred<Response>();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(async () => olderProbe.promise)
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const reload = vi.fn();
+    const storage = memoryStorage();
+
+    const olderBuild = scheduleStaleChunkReload({
+      now: () => 1000,
+      buildId: "build-a",
+      storage,
+      reload,
+    });
+    const newerBuild = scheduleStaleChunkReload({
+      now: () => 2000,
+      buildId: "build-b",
+      storage,
+      reload,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    olderProbe.resolve(new Response(null, { status: 503 }));
+    await expect(Promise.all([olderBuild, newerBuild])).resolves.toEqual([false, true]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(GUARD_KEY)).toBe("build-b");
   });
 
   it("settles and aborts a hanging document probe after its deadline", async () => {

--- a/ui/src/app/stale-chunk-reload.test.ts
+++ b/ui/src/app/stale-chunk-reload.test.ts
@@ -246,6 +246,35 @@ describe("scheduleStaleChunkReload", () => {
     expect(storage.getItem(GUARD_KEY)).toBe("build-b");
   });
 
+  it("reloads only the newest build after a shared document probe succeeds", async () => {
+    const sharedProbe = deferred<Response>();
+    const fetchMock = vi.fn<typeof fetch>(async () => sharedProbe.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const reload = vi.fn();
+    const storage = memoryStorage();
+
+    const olderBuild = scheduleStaleChunkReload({
+      now: () => 1000,
+      buildId: "build-a",
+      storage,
+      reload,
+    });
+    const newerBuild = scheduleStaleChunkReload({
+      now: () => 2000,
+      buildId: "build-b",
+      storage,
+      reload,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    sharedProbe.resolve(new Response(null, { status: 200 }));
+    await expect(Promise.all([olderBuild, newerBuild])).resolves.toEqual([false, true]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(GUARD_KEY)).toBe("build-b");
+  });
+
   it("settles and aborts a hanging document probe after its deadline", async () => {
     vi.useFakeTimers();
     const reload = vi.fn();

--- a/ui/src/app/stale-chunk-reload.ts
+++ b/ui/src/app/stale-chunk-reload.ts
@@ -38,9 +38,9 @@ type MissingStylesheetRecoveryDeps = {
   retry?: () => Promise<boolean>;
 };
 
-const lastAttemptAtByStorage = new WeakMap<object, number>();
-let lastAttemptWithoutStorage: number | null = null;
-let inFlightDocumentProbe: Promise<boolean> | null = null;
+const lastAttemptAtByStorage = new WeakMap<object, Map<string, number>>();
+const unavailableStorage = {};
+let inFlightDocumentProbe: { buildId?: string; promise: Promise<boolean> } | null = null;
 
 export function isStaleChunkImportError(error: unknown): boolean {
   return (
@@ -65,9 +65,9 @@ function sessionStorageOrNull(): Pick<Storage, "getItem" | "setItem"> | null {
   }
 }
 
-function probeControlUiDocument(): Promise<boolean> {
+function probeControlUiDocument(buildId?: string): Promise<boolean> {
   if (inFlightDocumentProbe) {
-    return inFlightDocumentProbe;
+    return inFlightDocumentProbe.promise;
   }
   const probe = (async () => {
     const controller = new AbortController();
@@ -86,11 +86,11 @@ function probeControlUiDocument(): Promise<boolean> {
     }
   })();
   const settledProbe = probe.finally(() => {
-    if (inFlightDocumentProbe === settledProbe) {
+    if (inFlightDocumentProbe?.promise === settledProbe) {
       inFlightDocumentProbe = null;
     }
   });
-  inFlightDocumentProbe = settledProbe;
+  inFlightDocumentProbe = { buildId, promise: settledProbe };
   return settledProbe;
 }
 
@@ -125,19 +125,7 @@ function persistGuardBuildId(
  * app webviews) instead of the recoverable panel error.
  */
 export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}): Promise<boolean> {
-  const now = deps.now?.() ?? Date.now();
   const storage = deps.storage === undefined ? sessionStorageOrNull() : deps.storage;
-  const lastAttemptAt = storage
-    ? (lastAttemptAtByStorage.get(storage) ?? null)
-    : lastAttemptWithoutStorage;
-  if (lastAttemptAt !== null && now - lastAttemptAt < ATTEMPT_COOLDOWN_MS) {
-    return false;
-  }
-  if (storage) {
-    lastAttemptAtByStorage.set(storage, now);
-  } else {
-    lastAttemptWithoutStorage = now;
-  }
   const buildId = deps.buildId ?? CONTROL_UI_BUILD_INFO.buildId;
   // One automatic reload per build id: if the reloaded document still fails
   // with the same build, the build itself is broken and reloading cannot help.
@@ -145,7 +133,27 @@ export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}):
   if (readGuardBuildId(storage) === buildId) {
     return false;
   }
-  if (!(await probeControlUiDocument())) {
+  const now = deps.now?.() ?? Date.now();
+  const storageIdentity = storage ?? unavailableStorage;
+  const attemptsByBuild = lastAttemptAtByStorage.get(storageIdentity) ?? new Map<string, number>();
+  for (const [attemptedBuildId, attemptedAt] of attemptsByBuild) {
+    if (now - attemptedAt >= ATTEMPT_COOLDOWN_MS) {
+      attemptsByBuild.delete(attemptedBuildId);
+    }
+  }
+  if (attemptsByBuild.has(buildId)) {
+    return false;
+  }
+  attemptsByBuild.set(buildId, now);
+  lastAttemptAtByStorage.set(storageIdentity, attemptsByBuild);
+  // A newer build cannot inherit the failed probe started for an older build.
+  const joinedOlderBuildProbe = Boolean(
+    inFlightDocumentProbe && inFlightDocumentProbe.buildId !== buildId,
+  );
+  if (
+    !(await probeControlUiDocument(buildId)) &&
+    (!joinedOlderBuildProbe || !(await probeControlUiDocument(buildId)))
+  ) {
     return false;
   }
   // A reload resets the in-memory state, so without a persisted guard a broken

--- a/ui/src/app/stale-chunk-reload.ts
+++ b/ui/src/app/stale-chunk-reload.ts
@@ -38,7 +38,10 @@ type MissingStylesheetRecoveryDeps = {
   retry?: () => Promise<boolean>;
 };
 
-const lastAttemptAtByStorage = new WeakMap<object, Map<string, number>>();
+const recoveryByStorage = new WeakMap<
+  object,
+  { attemptsByBuild: Map<string, number>; latestBuildId: string }
+>();
 const unavailableStorage = {};
 let inFlightDocumentProbe: { buildId?: string; promise: Promise<boolean> } | null = null;
 
@@ -135,7 +138,11 @@ export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}):
   }
   const now = deps.now?.() ?? Date.now();
   const storageIdentity = storage ?? unavailableStorage;
-  const attemptsByBuild = lastAttemptAtByStorage.get(storageIdentity) ?? new Map<string, number>();
+  const recovery = recoveryByStorage.get(storageIdentity) ?? {
+    attemptsByBuild: new Map<string, number>(),
+    latestBuildId: buildId,
+  };
+  const { attemptsByBuild } = recovery;
   for (const [attemptedBuildId, attemptedAt] of attemptsByBuild) {
     if (now - attemptedAt >= ATTEMPT_COOLDOWN_MS) {
       attemptsByBuild.delete(attemptedBuildId);
@@ -145,7 +152,8 @@ export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}):
     return false;
   }
   attemptsByBuild.set(buildId, now);
-  lastAttemptAtByStorage.set(storageIdentity, attemptsByBuild);
+  recovery.latestBuildId = buildId;
+  recoveryByStorage.set(storageIdentity, recovery);
   // A newer build cannot inherit the failed probe started for an older build.
   const joinedOlderBuildProbe = Boolean(
     inFlightDocumentProbe && inFlightDocumentProbe.buildId !== buildId,
@@ -159,7 +167,7 @@ export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}):
   // A reload resets the in-memory state, so without a persisted guard a broken
   // build would reload forever. When storage is unavailable or rejects the
   // write, leave recovery to the manual Retry path instead of reloading.
-  if (!persistGuardBuildId(storage, buildId)) {
+  if (recovery.latestBuildId !== buildId || !persistGuardBuildId(storage, buildId)) {
     return false;
   }
   (deps.reload ?? reloadControlUiDocument)();


### PR DESCRIPTION
Closes #126612

## What Problem This Solves

Fixes an issue where users with an already-open Control UI could remain stranded after a gateway update when an earlier stale-build document probe failed or was still in flight. The browser had already stopped reconnecting, but a storage-wide cooldown incorrectly prevented the authoritative newer build from probing and recovering.

## Why This Change Was Made

Scope automatic recovery attempts and latest-target ownership to their storage identity, check the persistent same-build guard before recording a build-keyed cooldown, and prune expired attempt entries. Preserve a single shared bounded document probe while allowing a newer build that joined an older failed probe exactly one fresh serialized attempt; after either probe outcome, only the latest accepted build may persist its guard and reload.

## User Impact

Open dashboards recover automatically when a newer build becomes reachable, including preserved deep links, query parameters, and fragments. Same-build reload-loop prevention, unavailable-storage safety, manual retry, service-worker recovery, and stale-document RPC fencing remain unchanged.

## Evidence

Exact reviewed head: `29f8ef25352c0ad69957578bac8aa30074566b93`.

- `node scripts/run-vitest.mjs ui/src/app/stale-chunk-reload.test.ts` — 29/29 owner regressions, including shared-success latest-build winner election.
- Focused Gateway, browser transport, service-worker, mount, and E2E-helper suites — 253/253 tests across 11 files.
- Existing Control UI Playwright recovery suites — 6 targeted scenarios across 4 files.
- `env pnpm_config_pm_on_fail=ignore node scripts/check-changed.mjs -- ui/src/app/stale-chunk-reload.ts ui/src/app/stale-chunk-reload.test.ts` — changed-file guards, core-test/UI typechecks, and lint.
- `env pnpm_config_pm_on_fail=ignore pnpm ui:build` — exact-head production bundle and asset/performance guards.
- Deterministic Playwright recording against `dist/control-ui`: build A HEAD 503, authoritative build B HEAD 200 after 151 ms, exactly one cache-busted document navigation, original deep-link/query/fragment restored, successful reconnect, and stale-document RPCs limited to `connect`.
- Additional deterministic real-browser shared-success proof: build B joins build A's in-flight HEAD 200; exactly one probe and one cache-busted navigation occur, only build B's guard persists, the original deep link reconnects, and stale-document RPCs contain only `connect`.
- Fresh Codex autoreview: clean, with no accepted/actionable findings.
- Production LOC: +37/-21 (net +16); tests: +89/-7 (net +82).
- Exact-head `pull_request` CI: [run 32361027413](https://github.com/openclaw/openclaw/actions/runs/32361027413) — green on attempt 2 after rerunning an unrelated existing CLI updater test flake; the complete updater suite also passed locally (246/246).

### Before: authoritative new build cannot recover

![Before: new build recovery suppressed](https://github.com/user-attachments/assets/c2b2df6c-3dcc-4111-a181-51b5de72889c)

### After: build B reconnects automatically

![After: build B reconnected](https://github.com/user-attachments/assets/847227bf-ca9a-4b9f-a771-e08f7f1efed4)

### Recorded recovery transition

https://github.com/user-attachments/assets/2cc33b5e-cb32-4697-ba6b-f8844eb1bed2
