### PR TITLE
perf(plugins): reuse lifecycle metadata on secrets hot paths

### DIFF
--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -779,6 +779,7 @@ export function resolveConfiguredPluginAutoEnableCandidates(params: {
       config: params.config,
       env: params.env,
       pluginIds: setupPluginIds,
+      manifestRegistry: params.registry,
     })) {
       changes.push({
         pluginId: entry.pluginId,

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -5763,26 +5763,38 @@ describe("gateway plugin hot reload handlers", () => {
       stopChannel,
       reloadPlugins,
     });
+    const sourceConfig: OpenClawConfig = {
+      plugins: { enabled: false, allow: ["discord"] },
+    };
 
     try {
-      await applyHotReload(createPluginReloadPlan(), {
-        plugins: {
-          enabled: false,
+      await applyHotReload(
+        createPluginReloadPlan(),
+        {
+          plugins: {
+            enabled: false,
+          },
         },
-      });
+        {
+          sourceConfig,
+          isCurrent: () => true,
+          publish: async (commit) => await commit(),
+        },
+      );
     } finally {
       restoreChannelReloadEnv();
     }
 
     const [reloadParams] = reloadPlugins.mock.calls.at(-1) ?? [];
     const reloadParamsRecord = reloadParams as
-      | { nextConfig?: unknown; changedPaths?: unknown }
+      | { nextConfig?: unknown; sourceConfig?: unknown; changedPaths?: unknown }
       | undefined;
     expect(reloadParamsRecord?.nextConfig).toEqual({
       plugins: {
         enabled: false,
       },
     });
+    expect(reloadParamsRecord?.sourceConfig).toBe(sourceConfig);
     expect(reloadParamsRecord?.changedPaths).toEqual(["plugins.enabled"]);
     expect(stopChannel).toHaveBeenCalledWith("discord", undefined, { manual: false });
     expect(startChannel).not.toHaveBeenCalled();

--- a/src/plugins/bundled-manifest-contract-plugins.ts
+++ b/src/plugins/bundled-manifest-contract-plugins.ts
@@ -32,14 +32,15 @@ export function resolveEnabledBundledManifestContractPlugins(params: {
   env?: NodeJS.ProcessEnv;
   onlyPluginIds?: readonly string[];
   contract: PluginManifestContractListKey;
+  manifestRecords?: readonly PluginManifestRecord[];
 }): PluginManifestRecord[] {
   if (params.config?.plugins?.enabled === false) {
     return [];
   }
-  let manifestRecords: readonly PluginManifestRecord[] | undefined;
-  const loadManifestRecords = (config?: OpenClawConfig) => {
+  let manifestRecords = params.manifestRecords;
+  const loadManifestRecords = () => {
     manifestRecords ??= loadManifestContractSnapshot({
-      config,
+      config: params.config,
       workspaceDir: params.workspaceDir,
       env: params.env,
     }).plugins;
@@ -54,13 +55,13 @@ export function resolveEnabledBundledManifestContractPlugins(params: {
     applyAutoEnable: true,
     resolveBundledPluginIds: (compatParams) =>
       listBundledManifestContractPluginIds({
-        plugins: loadManifestRecords(compatParams.config),
+        plugins: loadManifestRecords(),
         contract: params.contract,
         onlyPluginIds: compatParams.onlyPluginIds,
       }),
   });
   const onlyPluginIdSet = createPluginIdScopeSet(params.onlyPluginIds);
-  return loadManifestRecords(activation.config).filter((plugin) => {
+  return loadManifestRecords().filter((plugin) => {
     if (
       plugin.origin !== "bundled" ||
       (onlyPluginIdSet && !onlyPluginIdSet.has(plugin.id)) ||

--- a/src/plugins/manifest-contract-eligibility.test.ts
+++ b/src/plugins/manifest-contract-eligibility.test.ts
@@ -270,7 +270,7 @@ describe("loadManifestContractSnapshot", () => {
     expect(mocks.loadPluginMetadataSnapshot).not.toHaveBeenCalled();
   });
 
-  it("normalizes omitted config before checking unscoped snapshot compatibility", () => {
+  it("preserves configless default-discovery snapshot compatibility", () => {
     const env = { HOME: "/home/default-config" } as NodeJS.ProcessEnv;
     const snapshot = {
       index: { plugins: [{ pluginId: "demo" }] },
@@ -284,12 +284,12 @@ describe("loadManifestContractSnapshot", () => {
     });
 
     expect(mocks.resolvePluginMetadataSnapshot).toHaveBeenCalledWith({
-      config: {},
+      config: undefined,
       env,
       allowWorkspaceScopedCurrent: true,
     });
     expect(mocks.loadPluginMetadataSnapshot).toHaveBeenCalledWith({
-      config: {},
+      config: undefined,
       env,
       allowWorkspaceScopedCurrent: true,
     });

--- a/src/plugins/manifest-contract-eligibility.ts
+++ b/src/plugins/manifest-contract-eligibility.ts
@@ -155,11 +155,9 @@ export function loadManifestMetadataSnapshot(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }): PluginMetadataSnapshot {
-  const config = params.config ?? {};
-  const env = params.env ?? process.env;
   return resolvePluginMetadataSnapshot({
-    config,
-    env,
+    config: params.config,
+    env: params.env ?? process.env,
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     allowWorkspaceScopedCurrent: params.workspaceDir === undefined,
   });

--- a/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
+++ b/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
@@ -5,13 +5,19 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
+import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
-import { loadPluginManifestRegistryForPluginRegistry } from "./plugin-registry-contributions.js";
+import {
+  loadPluginManifestRegistryForPluginRegistry,
+  resolveManifestContractOwnerPluginId,
+  resolveManifestContractPluginIds,
+} from "./plugin-registry-contributions.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
 
 afterEach(() => {
+  vi.restoreAllMocks();
   clearPluginMetadataLifecycleCaches();
 });
 
@@ -40,7 +46,7 @@ function createManifest(id: string): PluginManifestRecord {
     channels: [],
     channelConfigs: {},
     cliBackends: [],
-    contracts: {},
+    contracts: { webSearchProviders: [`${id}-search`] },
   } as unknown as PluginManifestRecord;
 }
 
@@ -95,6 +101,74 @@ function createSnapshot(params: {
 }
 
 describe("loadPluginManifestRegistryForPluginRegistry current snapshot", () => {
+  it("reuses an allowlisted published snapshot for configless manifest reads", () => {
+    const config: OpenClawConfig = { plugins: { allow: ["enabled"] } };
+    const env = {
+      HOME: "/tmp/openclaw-test-home",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    };
+    const workspaceDir = "/workspace";
+    const snapshot = createSnapshot({ config, workspaceDir });
+    setCurrentPluginMetadataSnapshot(snapshot, { config, env, workspaceDir });
+    const readDirectory = vi.spyOn(fs, "readdirSync");
+    const readFile = vi.spyOn(fs, "readFileSync");
+
+    expect(loadManifestMetadataSnapshot({ env })).toBe(snapshot);
+    expect(readDirectory).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("projects supplied contract manifests without dropping disabled owners", () => {
+    const config: OpenClawConfig = { plugins: { allow: ["enabled"] } };
+    const env = {
+      HOME: "/tmp/openclaw-test-home",
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    };
+    const workspaceDir = "/workspace";
+    const snapshot = createSnapshot({ config, workspaceDir });
+    setCurrentPluginMetadataSnapshot(snapshot, { config, env, workspaceDir });
+    const readDirectory = vi.spyOn(fs, "readdirSync");
+    const readFile = vi.spyOn(fs, "readFileSync");
+
+    expect(
+      resolveManifestContractPluginIds({
+        contract: "webSearchProviders",
+        config,
+        env,
+        workspaceDir,
+      }),
+    ).toEqual(["disabled", "enabled"]);
+    expect(
+      resolveManifestContractOwnerPluginId({
+        contract: "webSearchProviders",
+        value: " DISABLED-SEARCH ",
+        config,
+        env,
+        workspaceDir,
+      }),
+    ).toBe("disabled");
+    expect(
+      resolveManifestContractPluginIds({
+        contract: "webSearchProviders",
+        config: { plugins: { allow: ["incompatible-policy"] } },
+        env,
+        manifestRecords: snapshot.plugins,
+        onlyPluginIds: ["disabled"],
+      }),
+    ).toEqual(["disabled"]);
+    expect(
+      resolveManifestContractOwnerPluginId({
+        contract: "webSearchProviders",
+        value: "disabled-search",
+        config: { plugins: { allow: ["incompatible-policy"] } },
+        env,
+        manifestRecords: snapshot.plugins,
+      }),
+    ).toBe("disabled");
+    expect(readDirectory).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
   it("reuses compatible current manifest metadata", () => {
     const config: OpenClawConfig = {};
     const env = {

--- a/src/plugins/plugin-registry-contributions.ts
+++ b/src/plugins/plugin-registry-contributions.ts
@@ -13,6 +13,7 @@ import type {
   PluginManifestRecord,
   PluginManifestRegistry,
 } from "./manifest-registry.js";
+import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 import {
@@ -62,13 +63,17 @@ type ListPluginContributionIdsParams = PluginRegistryContributionOptions & {
   contribution: PluginRegistryContributionKey;
 };
 
-type ResolveManifestContractPluginIdsParams = LoadPluginRegistryParams & {
+type ManifestContractLookupParams = LoadPluginRegistryParams & {
+  manifestRecords?: readonly PluginManifestRecord[];
+};
+
+type ResolveManifestContractPluginIdsParams = ManifestContractLookupParams & {
   contract: PluginManifestContractListKey;
   origin?: PluginOrigin;
   onlyPluginIds?: readonly string[];
 };
 
-type ResolveManifestContractOwnerPluginIdParams = LoadPluginRegistryParams & {
+type ResolveManifestContractOwnerPluginIdParams = ManifestContractLookupParams & {
   contract: PluginManifestContractListKey;
   value: string | undefined;
   origin?: PluginOrigin;
@@ -99,16 +104,44 @@ function listManifestContractValues(
   return plugin.contracts?.[contract] ?? [];
 }
 
-function loadManifestContractRegistry(
-  params: LoadPluginRegistryParams & {
+function loadManifestContractRecords(
+  params: ManifestContractLookupParams & {
     onlyPluginIds?: readonly string[];
   },
-): PluginManifestRegistry {
-  return loadPluginManifestRegistryForPluginRegistry({
-    ...params,
-    pluginIds: params.onlyPluginIds,
-    includeDisabled: true,
-  });
+): readonly PluginManifestRecord[] {
+  let records = params.manifestRecords;
+  if (!records) {
+    const requiresExplicitRegistry =
+      params.index !== undefined ||
+      params.preferPersisted === false ||
+      params.allowCurrent === false ||
+      params.stateDir !== undefined ||
+      params.filePath !== undefined ||
+      params.pluginIndexFilePath !== undefined ||
+      params.installRecords !== undefined ||
+      params.candidates !== undefined ||
+      params.diagnostics !== undefined ||
+      params.discovery !== undefined ||
+      params.now !== undefined;
+    if (requiresExplicitRegistry) {
+      return loadPluginManifestRegistryForPluginRegistry({
+        ...params,
+        pluginIds: params.onlyPluginIds,
+        includeDisabled: true,
+      }).plugins;
+    }
+    records = resolvePluginMetadataSnapshot({
+      config: params.config,
+      env: params.env,
+      ...(params.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
+      allowWorkspaceScopedCurrent: params.workspaceDir === undefined,
+    }).plugins;
+  }
+  if (params.onlyPluginIds === undefined) {
+    return records;
+  }
+  const pluginIds = new Set(params.onlyPluginIds);
+  return records.filter((record) => pluginIds.has(record.id));
 }
 
 function listManifestContributionIds(
@@ -308,8 +341,8 @@ export function resolvePluginContributionOwners(
 export function resolveManifestContractPluginIds(
   params: ResolveManifestContractPluginIdsParams,
 ): string[] {
-  return loadManifestContractRegistry(params)
-    .plugins.filter(
+  return loadManifestContractRecords(params)
+    .filter(
       (plugin) =>
         (!params.origin || plugin.origin === params.origin) &&
         listManifestContractValues(plugin, params.contract).length > 0,
@@ -325,7 +358,7 @@ export function resolveManifestContractOwnerPluginId(
   if (!normalizedValue) {
     return undefined;
   }
-  return loadManifestContractRegistry(params).plugins.find(
+  return loadManifestContractRecords(params).find(
     (plugin) =>
       (!params.origin || plugin.origin === params.origin) &&
       listManifestContractValues(plugin, params.contract).some(

--- a/src/plugins/web-fetch-providers.runtime.ts
+++ b/src/plugins/web-fetch-providers.runtime.ts
@@ -27,6 +27,7 @@ function resolveWebFetchCandidatePluginIds(params: {
   onlyPluginIds?: readonly string[];
   origin?: PluginManifestRecord["origin"];
   sandboxed?: boolean;
+  manifestRecords?: readonly PluginManifestRecord[];
 }): string[] | undefined {
   return resolveManifestDeclaredWebProviderCandidatePluginIds({
     contract: "webFetchProviders",
@@ -37,6 +38,7 @@ function resolveWebFetchCandidatePluginIds(params: {
     onlyPluginIds: params.onlyPluginIds,
     origin: params.origin,
     sandboxed: params.sandboxed,
+    manifestRecords: params.manifestRecords,
   });
 }
 
@@ -62,6 +64,7 @@ export function resolvePluginWebFetchProviders(params: {
   mode?: "runtime" | "setup";
   origin?: PluginManifestRecord["origin"];
   sandboxed?: boolean;
+  manifestRecords?: readonly PluginManifestRecord[];
 }): PluginWebFetchProviderEntry[] {
   return resolvePluginWebProviders(params, {
     resolveBundledResolutionConfig: resolveBundledWebFetchResolutionConfig,
@@ -80,6 +83,7 @@ export function resolveRuntimeWebFetchProviders(params: {
   env?: PluginLoadOptions["env"];
   onlyPluginIds?: readonly string[];
   origin?: PluginManifestRecord["origin"];
+  manifestRecords?: readonly PluginManifestRecord[];
 }): PluginWebFetchProviderEntry[] {
   return resolveRuntimeWebProviders(params, {
     resolveBundledResolutionConfig: resolveBundledWebFetchResolutionConfig,

--- a/src/plugins/web-fetch-providers.shared.ts
+++ b/src/plugins/web-fetch-providers.shared.ts
@@ -1,5 +1,6 @@
 // Shares web fetch provider loading helpers across provider plugins.
 import type { PluginLoadOptions } from "./loader.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginWebFetchProviderEntry } from "./types.js";
 import {
   resolveBundledWebProviderResolutionConfig,
@@ -23,15 +24,18 @@ export function resolveBundledWebFetchResolutionConfig(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  manifestRecords?: readonly PluginManifestRecord[];
 }): {
   config: PluginLoadOptions["config"];
   activationSourceConfig?: PluginLoadOptions["config"];
   autoEnabledReasons: Record<string, string[]>;
+  manifestRecords?: readonly PluginManifestRecord[];
 } {
   return resolveBundledWebProviderResolutionConfig({
     contract: "webFetchProviders",
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    manifestRecords: params.manifestRecords,
   });
 }

--- a/src/plugins/web-provider-public-artifacts.ts
+++ b/src/plugins/web-provider-public-artifacts.ts
@@ -6,6 +6,7 @@ import { resolveEnabledBundledManifestContractPlugins } from "./bundled-manifest
 import { normalizePluginId } from "./config-state.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginWebFetchProviderEntry, PluginWebSearchProviderEntry } from "./types.js";
 import { resolveBundledWebFetchResolutionConfig } from "./web-fetch-providers.shared.js";
 import {
@@ -23,6 +24,7 @@ type BundledWebProviderPublicArtifactParams = {
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
   onlyPluginIds?: readonly string[];
+  manifestRecords?: readonly PluginManifestRecord[];
 };
 
 function filterAllowlistedBundledPluginIds(
@@ -51,12 +53,14 @@ function resolveBundledCandidatePluginIds(params: {
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
   onlyPluginIds?: readonly string[];
+  manifestRecords?: readonly PluginManifestRecord[];
 }) {
   if (params.onlyPluginIds !== undefined) {
     return {
       pluginIds: filterAllowlistedBundledPluginIds(params.config, [
         ...new Set(params.onlyPluginIds),
       ]).toSorted((left, right) => left.localeCompare(right)),
+      ...(params.manifestRecords ? { manifestRecords: params.manifestRecords } : {}),
     };
   }
   const resolvedConfig =
@@ -66,11 +70,12 @@ function resolveBundledCandidatePluginIds(params: {
   const candidates = resolveManifestDeclaredWebProviderCandidates({
     contract: params.contract,
     configKey: params.configKey,
-    config: resolvedConfig,
+    config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
     onlyPluginIds: params.onlyPluginIds,
     origin: "bundled",
+    manifestRecords: params.manifestRecords,
   });
   return {
     pluginIds: filterAllowlistedBundledPluginIds(resolvedConfig, candidates.pluginIds ?? []),
@@ -83,15 +88,17 @@ function resolveBundledRuntimeCandidatePluginIds(params: {
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
   onlyPluginIds: readonly string[];
+  manifestRecords?: readonly PluginManifestRecord[];
 }): string[] | null {
   const resolvedConfig = resolveBundledWebFetchResolutionConfig(params).config;
   const candidates = resolveManifestDeclaredWebProviderCandidates({
     contract: "webFetchProviders",
     configKey: "webFetch",
-    config: resolvedConfig,
+    config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
     onlyPluginIds: params.onlyPluginIds,
+    manifestRecords: params.manifestRecords,
   });
   const pluginIds = filterAllowlistedBundledPluginIds(resolvedConfig, candidates.pluginIds ?? []);
   const recordsByPluginId = new Map(
@@ -109,6 +116,7 @@ function resolveBundledRuntimeCandidatePluginIds(params: {
       env: params.env,
       onlyPluginIds: pluginIds,
       contract: "webFetchProviders",
+      manifestRecords: candidates.manifestRecords,
     }).map((plugin) => plugin.id),
   );
   return pluginIds.filter((pluginId) => enabledPluginIds.has(pluginId));
@@ -128,6 +136,7 @@ function resolveBundledWebProvidersFromPublicArtifacts<TProvider>(params: {
     workspaceDir: params.resolution.workspaceDir,
     env: params.resolution.env,
     onlyPluginIds: params.resolution.onlyPluginIds,
+    manifestRecords: params.resolution.manifestRecords,
   });
   if (candidates.pluginIds.length === 0) {
     return [];
@@ -142,6 +151,7 @@ function resolveBundledWebProvidersFromPublicArtifacts<TProvider>(params: {
   const recordsByPluginId = new Map(
     (
       candidates.manifestRecords ??
+      params.resolution.manifestRecords ??
       loadManifestMetadataSnapshot({
         config: params.resolution.config,
         workspaceDir: params.resolution.workspaceDir,
@@ -205,6 +215,7 @@ export function resolveBundledRuntimeWebFetchProvidersFromPublicArtifacts(
     workspaceDir: params.workspaceDir,
     env: params.env,
     onlyPluginIds: params.onlyPluginIds,
+    manifestRecords: params.manifestRecords,
   });
   if (!pluginIds) {
     return null;

--- a/src/plugins/web-provider-resolution-shared.ts
+++ b/src/plugins/web-provider-resolution-shared.ts
@@ -1,5 +1,6 @@
 // Shares web-provider plugin resolution helpers without eager runtime imports.
 import { resolveBundledCompatActivationInputs } from "./activation-context.js";
+import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import type { PluginLoadOptions } from "./loader.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
@@ -68,12 +69,15 @@ function loadInstalledWebProviderManifestRecords(params: {
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
   pluginIds?: readonly string[];
+  manifestRecords?: readonly PluginManifestRecord[];
 }): readonly PluginManifestRecord[] {
-  const records = loadManifestMetadataSnapshot({
-    config: params.config ?? {},
-    workspaceDir: params.workspaceDir,
-    env: params.env ?? process.env,
-  }).plugins;
+  const records =
+    params.manifestRecords ??
+    loadManifestMetadataSnapshot({
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      env: params.env ?? process.env,
+    }).plugins;
   const pluginIdSet = createPluginIdScopeSet(params.pluginIds);
   return pluginIdSet ? records.filter((plugin) => pluginIdSet.has(plugin.id)) : records;
 }
@@ -88,6 +92,7 @@ export function resolveManifestDeclaredWebProviderCandidatePluginIds(params: {
   onlyPluginIds?: readonly string[];
   origin?: PluginManifestRecord["origin"];
   sandboxed?: boolean;
+  manifestRecords?: readonly PluginManifestRecord[];
 }): string[] | undefined {
   return resolveManifestDeclaredWebProviderCandidates(params).pluginIds;
 }
@@ -147,6 +152,7 @@ function resolveBundledWebProviderCompatPluginIds(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  manifestRecords?: readonly PluginManifestRecord[];
 }): string[] {
   return loadInstalledWebProviderManifestRecords(params)
     .filter(
@@ -163,27 +169,48 @@ export function resolveBundledWebProviderResolutionConfig(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  manifestRecords?: readonly PluginManifestRecord[];
 }): {
   config: PluginLoadOptions["config"];
   activationSourceConfig?: PluginLoadOptions["config"];
   autoEnabledReasons: Record<string, string[]>;
+  manifestRecords?: readonly PluginManifestRecord[];
 } {
+  const currentSnapshot = getCurrentPluginMetadataSnapshot({
+    config: params.config,
+    env: params.env,
+    workspaceDir: params.workspaceDir,
+    allowWorkspaceScopedSnapshot: true,
+  });
+  let manifestRecords = params.manifestRecords ?? currentSnapshot?.plugins;
   const activation = resolveBundledCompatActivationInputs({
     rawConfig: params.config,
     env: params.env,
     workspaceDir: params.workspaceDir,
     applyAutoEnable: true,
-    resolveBundledPluginIds: (compatParams) =>
-      resolveBundledWebProviderCompatPluginIds({
+    ...(manifestRecords
+      ? { manifestRegistry: { plugins: [...manifestRecords], diagnostics: [] } }
+      : {}),
+    ...(currentSnapshot?.discovery ? { discovery: currentSnapshot.discovery } : {}),
+    resolveBundledPluginIds: (compatParams) => {
+      manifestRecords ??= loadInstalledWebProviderManifestRecords({
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      });
+      return resolveBundledWebProviderCompatPluginIds({
         contract: params.contract,
         ...compatParams,
-      }),
+        manifestRecords,
+      });
+    },
   });
 
   return {
     config: activation.config,
     activationSourceConfig: activation.activationSourceConfig,
     autoEnabledReasons: activation.autoEnabledReasons,
+    manifestRecords,
   };
 }
 

--- a/src/plugins/web-provider-runtime-shared.test.ts
+++ b/src/plugins/web-provider-runtime-shared.test.ts
@@ -1,6 +1,7 @@
 // Covers shared web provider runtime helpers.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 
 const mocks = vi.hoisted(() => ({
   isPluginRegistryLoadInFlight: vi.fn(() => false),
@@ -156,27 +157,31 @@ describe("web-provider-runtime-shared", () => {
     expect(mockArg(mapRegistryProviders).onlyPluginIds).toEqual(["alpha"]);
   });
 
-  it("reuses the active registry after deriving web provider candidates from resolved config", () => {
+  it("resolves provider candidates from the original config and prepared manifests", () => {
     const activeRegistry = { source: "active" };
+    const config = { plugins: { entries: {} } };
     const resolvedConfig = { plugins: { entries: { brave: { enabled: true } } } };
+    const manifestRecords: PluginManifestRecord[] = [];
     const resolveCandidatePluginIds = vi.fn(() => ["brave"]);
     const mapRegistryProviders = vi.fn(() => ["provider"]);
     mocks.getLoadedRuntimePluginRegistry.mockReturnValue(activeRegistry);
 
     const providers = resolvePluginWebProviders(
       {
-        config: { plugins: { entries: {} } },
+        config,
         env: { BRAVE_API_KEY: "key" },
         onlyPluginIds: ["brave", "firecrawl"],
         origin: "bundled",
         sandboxed: true,
         workspaceDir: "/workspace",
+        manifestRecords,
       },
       {
         resolveBundledResolutionConfig: () => ({
           config: resolvedConfig,
-          activationSourceConfig: { plugins: { entries: {} } },
+          activationSourceConfig: config,
           autoEnabledReasons: { brave: ["env"] },
+          manifestRecords,
         }),
         resolveCandidatePluginIds,
         mapRegistryProviders,
@@ -185,16 +190,21 @@ describe("web-provider-runtime-shared", () => {
 
     expect(providers).toEqual(["provider"]);
     expect(resolveCandidatePluginIds).toHaveBeenCalledWith({
-      config: resolvedConfig,
+      config,
       workspaceDir: "/workspace",
       env: { BRAVE_API_KEY: "key" },
       onlyPluginIds: ["brave", "firecrawl"],
       origin: "bundled",
       sandboxed: true,
+      manifestRecords,
     });
     expect(mapRegistryProviders).toHaveBeenCalledWith({
       registry: activeRegistry,
       onlyPluginIds: ["brave"],
+    });
+    expect(mockArg(mocks.buildPluginRuntimeLoadOptionsFromValues).manifestRegistry).toEqual({
+      plugins: manifestRecords,
+      diagnostics: [],
     });
     expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });

--- a/src/plugins/web-provider-runtime-shared.ts
+++ b/src/plugins/web-provider-runtime-shared.ts
@@ -1,9 +1,10 @@
 // Shares web provider runtime helpers across plugin-owned providers.
 import { withActivatedPluginIds } from "./activation-context.js";
 import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
+import { normalizePluginId } from "./config-state.js";
 import { isPluginRegistryLoadInFlight, loadOpenClawPlugins } from "./loader.js";
 import type { PluginLoadOptions } from "./loader.js";
-import type { PluginManifestRecord } from "./manifest-registry.js";
+import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
 import { hasExplicitPluginIdScope, normalizePluginIdScope } from "./plugin-scope.js";
 import type { PluginRegistry } from "./registry.js";
 import { getActivePluginRegistryWorkspaceDir } from "./runtime.js";
@@ -23,6 +24,7 @@ type ResolvePluginWebProvidersParams = {
   mode?: "runtime" | "setup";
   origin?: PluginManifestRecord["origin"];
   sandboxed?: boolean;
+  manifestRecords?: readonly PluginManifestRecord[];
 };
 
 type ResolveWebProviderRuntimeDeps<TEntry> = {
@@ -30,10 +32,12 @@ type ResolveWebProviderRuntimeDeps<TEntry> = {
     config?: PluginLoadOptions["config"];
     workspaceDir?: string;
     env?: PluginLoadOptions["env"];
+    manifestRecords?: readonly PluginManifestRecord[];
   }) => {
     config: PluginLoadOptions["config"];
     activationSourceConfig?: PluginLoadOptions["config"];
     autoEnabledReasons: Record<string, string[]>;
+    manifestRecords?: readonly PluginManifestRecord[];
   };
   resolveCandidatePluginIds: (params: {
     config?: PluginLoadOptions["config"];
@@ -42,6 +46,7 @@ type ResolveWebProviderRuntimeDeps<TEntry> = {
     onlyPluginIds?: readonly string[];
     origin?: PluginManifestRecord["origin"];
     sandboxed?: boolean;
+    manifestRecords?: readonly PluginManifestRecord[];
   }) => string[] | undefined;
   mapRegistryProviders: (params: {
     registry: PluginRegistry;
@@ -52,12 +57,14 @@ type ResolveWebProviderRuntimeDeps<TEntry> = {
     workspaceDir?: string;
     env?: PluginLoadOptions["env"];
     onlyPluginIds?: readonly string[];
+    manifestRecords?: readonly PluginManifestRecord[];
   }) => TEntry[] | null;
   resolveBundledRuntimeArtifactProviders?: (params: {
     config?: PluginLoadOptions["config"];
     workspaceDir?: string;
     env?: PluginLoadOptions["env"];
     onlyPluginIds: readonly string[];
+    manifestRecords?: readonly PluginManifestRecord[];
   }) => TEntry[] | null;
 };
 
@@ -67,6 +74,8 @@ type WebProviderRuntimeContext = {
   config: PluginLoadOptions["config"];
   activationSourceConfig?: PluginLoadOptions["config"];
   autoEnabledReasons: Record<string, string[]>;
+  manifestRecords?: readonly PluginManifestRecord[];
+  preparedManifestRegistry?: PluginManifestRegistry;
   loadPluginIds?: string[];
   onlyPluginIds?: string[];
 };
@@ -87,27 +96,42 @@ function resolveWebProviderRuntimeContext<TEntry>(
     params.onlyPluginIds !== undefined ||
     params.origin !== undefined ||
     params.sandboxed === true;
-  const { config, activationSourceConfig, autoEnabledReasons } =
+  const { config, activationSourceConfig, autoEnabledReasons, manifestRecords } =
     deps.resolveBundledResolutionConfig({
       ...params,
       workspaceDir,
       env,
     });
-  const candidatePluginIds = normalizePluginIdScope(
+  const discoveredPluginIds = normalizePluginIdScope(
     deps.resolveCandidatePluginIds({
-      config,
+      config: params.config,
       workspaceDir,
       env,
       onlyPluginIds: params.onlyPluginIds,
       origin: params.origin,
       sandboxed: params.sandboxed,
+      ...(manifestRecords ? { manifestRecords } : {}),
     }),
   );
+  const allowedPluginIds = config?.plugins?.allow;
+  const allowSet = allowedPluginIds?.length
+    ? new Set(allowedPluginIds.map((pluginId) => normalizePluginId(pluginId)))
+    : undefined;
+  const allowlistedPluginIds = allowSet
+    ? discoveredPluginIds?.filter((pluginId) => allowSet.has(normalizePluginId(pluginId)))
+    : discoveredPluginIds;
+  const candidatePluginIds = allowlistedPluginIds?.length
+    ? allowlistedPluginIds
+    : discoveredPluginIds;
   return {
     activationSourceConfig,
     autoEnabledReasons,
     config,
     env,
+    manifestRecords,
+    ...(params.manifestRecords
+      ? { preparedManifestRegistry: { plugins: [...params.manifestRecords], diagnostics: [] } }
+      : {}),
     loadPluginIds: candidatePluginIds,
     onlyPluginIds: shouldFilterProviders ? candidatePluginIds : undefined,
     workspaceDir,
@@ -126,6 +150,9 @@ function resolveWebProviderLoadOptions(
       autoEnabledReasons: context.autoEnabledReasons,
       workspaceDir: context.workspaceDir,
       logger: createPluginRuntimeLoaderLogger(),
+      ...(context.preparedManifestRegistry
+        ? { manifestRegistry: context.preparedManifestRegistry }
+        : {}),
     },
     {
       cache: params.cache ?? true,
@@ -172,6 +199,7 @@ export function resolvePluginWebProviders<TEntry>(
         onlyPluginIds: params.onlyPluginIds,
         origin: params.origin,
         sandboxed: params.sandboxed,
+        ...(params.manifestRecords ? { manifestRecords: params.manifestRecords } : {}),
       }) ?? [];
     if (pluginIds.length === 0) {
       return [];
@@ -182,6 +210,7 @@ export function resolvePluginWebProviders<TEntry>(
         workspaceDir,
         env,
         onlyPluginIds: pluginIds,
+        ...(params.manifestRecords ? { manifestRecords: params.manifestRecords } : {}),
       });
       if (bundledArtifactProviders) {
         return bundledArtifactProviders;
@@ -199,6 +228,9 @@ export function resolvePluginWebProviders<TEntry>(
           workspaceDir,
           env,
           logger: createPluginRuntimeLoaderLogger(),
+          ...(params.manifestRecords
+            ? { manifestRegistry: { plugins: [...params.manifestRecords], diagnostics: [] } }
+            : {}),
         },
         {
           onlyPluginIds: pluginIds,
@@ -253,6 +285,7 @@ export function resolvePluginWebProviders<TEntry>(
       workspaceDir: context.workspaceDir,
       env: context.env,
       onlyPluginIds: context.loadPluginIds,
+      ...(context.manifestRecords ? { manifestRecords: context.manifestRecords } : {}),
     });
     if (bundledArtifactProviders) {
       return bundledArtifactProviders;

--- a/src/plugins/web-search-providers.runtime.ts
+++ b/src/plugins/web-search-providers.runtime.ts
@@ -23,6 +23,7 @@ function resolveWebSearchCandidatePluginIds(params: {
   env?: PluginLoadOptions["env"];
   onlyPluginIds?: readonly string[];
   origin?: PluginManifestRecord["origin"];
+  manifestRecords?: readonly PluginManifestRecord[];
 }): string[] | undefined {
   return resolveManifestDeclaredWebProviderCandidatePluginIds({
     contract: "webSearchProviders",
@@ -32,6 +33,7 @@ function resolveWebSearchCandidatePluginIds(params: {
     env: params.env,
     onlyPluginIds: params.onlyPluginIds,
     origin: params.origin,
+    manifestRecords: params.manifestRecords,
   });
 }
 
@@ -55,6 +57,7 @@ export function resolvePluginWebSearchProviders(params: {
   cache?: boolean;
   mode?: "runtime" | "setup";
   origin?: PluginManifestRecord["origin"];
+  manifestRecords?: readonly PluginManifestRecord[];
 }): PluginWebSearchProviderEntry[] {
   return resolvePluginWebProviders(params, {
     resolveBundledResolutionConfig: resolveBundledWebSearchResolutionConfig,
@@ -70,6 +73,7 @@ export function resolveRuntimeWebSearchProviders(params: {
   env?: PluginLoadOptions["env"];
   onlyPluginIds?: readonly string[];
   origin?: PluginManifestRecord["origin"];
+  manifestRecords?: readonly PluginManifestRecord[];
 }): PluginWebSearchProviderEntry[] {
   return resolveRuntimeWebProviders(params, {
     resolveBundledResolutionConfig: resolveBundledWebSearchResolutionConfig,

--- a/src/plugins/web-search-providers.shared.ts
+++ b/src/plugins/web-search-providers.shared.ts
@@ -1,5 +1,6 @@
 // Shares web-search provider loading helpers across runtime paths.
 import type { PluginLoadOptions } from "./loader.js";
+import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginWebSearchProviderEntry } from "./types.js";
 import {
   resolveBundledWebProviderResolutionConfig,
@@ -23,15 +24,18 @@ export function resolveBundledWebSearchResolutionConfig(params: {
   config?: PluginLoadOptions["config"];
   workspaceDir?: string;
   env?: PluginLoadOptions["env"];
+  manifestRecords?: readonly PluginManifestRecord[];
 }): {
   config: PluginLoadOptions["config"];
   activationSourceConfig?: PluginLoadOptions["config"];
   autoEnabledReasons: Record<string, string[]>;
+  manifestRecords?: readonly PluginManifestRecord[];
 } {
   return resolveBundledWebProviderResolutionConfig({
     contract: "webSearchProviders",
     config: params.config,
     workspaceDir: params.workspaceDir,
     env: params.env,
+    manifestRecords: params.manifestRecords,
   });
 }

--- a/src/secrets/runtime-config-collectors-plugins.ts
+++ b/src/secrets/runtime-config-collectors-plugins.ts
@@ -54,16 +54,18 @@ export function collectPluginConfigAssignments(params: {
       config: params.config,
       env: params.context.env,
     });
-  const bundledLoadablePluginIds = [...(params.loadablePluginOrigins?.entries() ?? [])]
-    .filter(([, origin]) => origin === "bundled")
-    .map(([pluginId]) => pluginId);
+  const bundledLoadablePluginIds = params.context.manifestRegistry
+    ? []
+    : [...(params.loadablePluginOrigins?.entries() ?? [])]
+        .filter(([, origin]) => origin === "bundled")
+        .map(([pluginId]) => pluginId);
   const pluginSecretInputs = new Map(
     [
       ...resolvePluginConfigContractsById({
         config: params.config,
         env: params.context.env,
         fallbackToBundledMetadata: true,
-        fallbackToBundledMetadataForResolvedBundled: true,
+        fallbackToBundledMetadataForResolvedBundled: !params.context.manifestRegistry,
         fallbackBundledPluginIds: bundledLoadablePluginIds,
         pluginIds: Object.keys(entries),
         manifestRegistry,

--- a/src/secrets/runtime-web-tools.shared.ts
+++ b/src/secrets/runtime-web-tools.shared.ts
@@ -260,6 +260,7 @@ export async function resolveRuntimeWebProviderSurface<
       origin: "bundled",
       config: params.sourceConfig,
       env: { ...process.env, ...params.context.env },
+      manifestRecords: params.context.manifestRegistry?.plugins,
     });
   }
   let allProviders = params.sortProviders(
@@ -287,6 +288,7 @@ export async function resolveRuntimeWebProviderSurface<
       origin: "bundled",
       config: params.sourceConfig,
       env: { ...process.env, ...params.context.env },
+      manifestRecords: params.context.manifestRegistry?.plugins,
     });
     allProviders = params.sortProviders(
       await params.resolveProviders({

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -4,6 +4,7 @@ import { sortUniqueStrings } from "@openclaw/normalization-core/string-normaliza
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "../plugins/installed-plugin-index-records.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import type {
   PluginWebFetchProviderEntry,
   PluginWebSearchProviderEntry,
@@ -367,6 +368,7 @@ async function hasCustomWebProviderPluginRisk(params: {
   contract: WebProviderContract;
   config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
+  manifestRecords?: readonly PluginManifestRecord[];
 }): Promise<boolean> {
   const installRecords = loadInstalledPluginIndexInstallRecordsSync({ env: params.env });
   if (Object.keys(installRecords).length > 0) {
@@ -387,6 +389,7 @@ async function hasCustomWebProviderPluginRisk(params: {
       origin: "bundled",
       config: params.config,
       env: params.env,
+      manifestRecords: params.manifestRecords,
     }),
   );
   // Public artifacts are complete only for bundled providers. Any configured non-bundled
@@ -596,6 +599,7 @@ async function resolveBundledWebSearchProviders(params: {
       env,
       onlyPluginIds,
       origin: "bundled",
+      manifestRecords: params.context.manifestRegistry?.plugins,
     });
   }
   if (!params.hasCustomWebSearchPluginRisk) {
@@ -604,6 +608,7 @@ async function resolveBundledWebSearchProviders(params: {
     const bundled = resolveBundledWebSearchProvidersFromPublicArtifacts({
       config: params.sourceConfig,
       env,
+      manifestRecords: params.context.manifestRegistry?.plugins,
     });
     if (bundled && bundled.length > 0) {
       return bundled;
@@ -613,12 +618,14 @@ async function resolveBundledWebSearchProviders(params: {
       config: params.sourceConfig,
       env,
       origin: "bundled",
+      manifestRecords: params.context.manifestRegistry?.plugins,
     });
   }
   const { resolvePluginWebSearchProviders } = await loadRuntimeWebToolsFallbackProviders();
   return resolvePluginWebSearchProviders({
     config: params.sourceConfig,
     env,
+    manifestRecords: params.context.manifestRegistry?.plugins,
   });
 }
 
@@ -644,6 +651,7 @@ async function resolveBundledWebFetchProviders(params: {
       env,
       onlyPluginIds: [params.configuredBundledPluginId],
       origin: "bundled",
+      manifestRecords: params.context.manifestRegistry?.plugins,
     });
   }
   if (!params.hasCustomWebFetchPluginRisk) {
@@ -652,6 +660,7 @@ async function resolveBundledWebFetchProviders(params: {
     const bundled = resolveBundledWebFetchProvidersFromPublicArtifacts({
       config: params.sourceConfig,
       env,
+      manifestRecords: params.context.manifestRegistry?.plugins,
     });
     if (bundled && bundled.length > 0) {
       return bundled;
@@ -661,6 +670,7 @@ async function resolveBundledWebFetchProviders(params: {
       config: params.sourceConfig,
       env,
       origin: "bundled",
+      manifestRecords: params.context.manifestRegistry?.plugins,
     });
   }
   const { resolvePluginWebFetchProviders } = await loadRuntimeWebToolsFallbackProviders();
@@ -670,6 +680,7 @@ async function resolveBundledWebFetchProviders(params: {
     // Runtime credential resolution may load only bundled providers or verified
     // official installs. Arbitrary external providers must not gain SecretRef access.
     sandboxed: true,
+    manifestRecords: params.context.manifestRegistry?.plugins,
   });
 }
 
@@ -775,6 +786,7 @@ export async function resolveRuntimeWebTools(params: {
       contract: "webSearchProviders",
       config: params.sourceConfig,
       env,
+      manifestRecords: params.context.manifestRegistry?.plugins,
     });
     return hasCustomWebSearchRisk;
   };
@@ -784,6 +796,7 @@ export async function resolveRuntimeWebTools(params: {
       contract: "webFetchProviders",
       config: params.sourceConfig,
       env,
+      manifestRecords: params.context.manifestRegistry?.plugins,
     });
     return hasCustomWebFetchRisk;
   };

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -1,5 +1,5 @@
 /** Tests secrets runtime fast-path decisions and skip conditions. */
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import fs, { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -13,18 +13,23 @@ import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.j
 import { clearSecretsRuntimeSnapshot } from "./runtime.js";
 import { asConfig } from "./runtime.test-support.js";
 
-const { resolveRuntimeWebToolsMock, runtimePrepareImportMock } = vi.hoisted(() => ({
-  resolveRuntimeWebToolsMock: vi.fn(async () => ({
-    metadata: {
-      search: { providerSource: "none", diagnostics: [] },
-      fetch: { providerSource: "none", diagnostics: [] },
-      diagnostics: [],
-    },
-    degradedOwners: [],
-    secretOwners: [],
-  })),
-  runtimePrepareImportMock: vi.fn(),
-}));
+const { collectConfigAssignmentsMock, resolveRuntimeWebToolsMock, runtimePrepareImportMock } =
+  vi.hoisted(() => ({
+    collectConfigAssignmentsMock:
+      vi.fn<typeof import("./runtime-config-collectors.js").collectConfigAssignments>(),
+    resolveRuntimeWebToolsMock: vi.fn<
+      typeof import("./runtime-web-tools.js").resolveRuntimeWebTools
+    >(async () => ({
+      metadata: {
+        search: { providerSource: "none", diagnostics: [] },
+        fetch: { providerSource: "none", diagnostics: [] },
+        diagnostics: [],
+      },
+      degradedOwners: [],
+      secretOwners: [],
+    })),
+    runtimePrepareImportMock: vi.fn(),
+  }));
 
 function explicitMainRoster() {
   return { agents: { list: [{ id: "main" }] } };
@@ -33,15 +38,24 @@ function explicitMainRoster() {
 vi.mock("./runtime-prepare.runtime.js", () => {
   runtimePrepareImportMock();
   return {
-    createResolverContext: ({ sourceConfig, env }: { sourceConfig: unknown; env: unknown }) => ({
+    createResolverContext: ({
+      sourceConfig,
+      env,
+      manifestRegistry,
+    }: {
+      sourceConfig: unknown;
+      env: unknown;
+      manifestRegistry?: unknown;
+    }) => ({
       sourceConfig,
       env,
       cache: {},
+      ...(manifestRegistry ? { manifestRegistry } : {}),
       warnings: [],
       warningKeys: new Set<string>(),
       assignments: [],
     }),
-    collectConfigAssignments: () => undefined,
+    collectConfigAssignments: collectConfigAssignmentsMock,
     collectAuthStoreAssignments: () => undefined,
     resolveRuntimeWebTools: resolveRuntimeWebToolsMock,
   };
@@ -89,6 +103,7 @@ function writeAuthProfileStore(agentDir: string): void {
 
 describe("secrets runtime fast path", () => {
   afterEach(() => {
+    collectConfigAssignmentsMock.mockReset();
     runtimePrepareImportMock.mockClear();
     resolveRuntimeWebToolsMock.mockClear();
     setActivePluginRegistry(createEmptyPluginRegistry());
@@ -222,6 +237,67 @@ describe("secrets runtime fast path", () => {
     });
 
     expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses published plugin metadata without reopening manifests for configured web search", async () => {
+    const { prepareSecretsRuntimeSnapshot } = await import("./runtime.js");
+    const { collectConfigAssignments } = await import("./runtime-config-collectors.js");
+    const { resolveRuntimeWebTools } = await import("./runtime-web-tools.js");
+    const { loadPluginMetadataSnapshot } = await import("../plugins/plugin-metadata-snapshot.js");
+    const { setCurrentPluginMetadataSnapshot } =
+      await import("../plugins/current-plugin-metadata-snapshot.js");
+    const { listAgentWorkspaceDirs } = await import("../agents/workspace-dirs.js");
+    const config = asConfig({
+      ...explicitMainRoster(),
+      tools: { web: { search: { provider: "webiq" } } },
+      plugins: {
+        enabled: true,
+        allow: ["workiq-code-mode", "tools-code-mode", "webiq", "diagnostics-otel", "brave"],
+        entries: {
+          "workiq-code-mode": { config: { enabledNamespaces: ["m365", "search"] } },
+          "tools-code-mode": { enabled: true },
+          webiq: { enabled: true, config: { webSearch: { omitAuth: true, region: "US" } } },
+          "diagnostics-otel": { enabled: true },
+        },
+      },
+    });
+    const workspaceDir = listAgentWorkspaceDirs(config, process.env)[0];
+    const pluginMetadataSnapshot = loadPluginMetadataSnapshot({
+      config,
+      env: process.env,
+      workspaceDir,
+    });
+    expect(pluginMetadataSnapshot.plugins.length).toBeGreaterThan(0);
+    setCurrentPluginMetadataSnapshot(pluginMetadataSnapshot, {
+      config,
+      env: process.env,
+      workspaceDir,
+    });
+    collectConfigAssignmentsMock.mockImplementationOnce(collectConfigAssignments);
+    resolveRuntimeWebToolsMock.mockImplementationOnce(resolveRuntimeWebTools);
+    const openSyncSpy = vi.spyOn(fs, "openSync");
+    const probeDescriptor = fs.openSync(pluginMetadataSnapshot.plugins[0]!.manifestPath, "r");
+    fs.closeSync(probeDescriptor);
+    expect(openSyncSpy).toHaveBeenCalledOnce();
+    openSyncSpy.mockClear();
+
+    try {
+      const snapshot = await prepareSecretsRuntimeSnapshot({
+        config,
+        env: process.env,
+        agentDirs: ["/tmp/openclaw-agent-main"],
+        loadAuthStore: emptyAuthStore,
+      });
+
+      const manifestOpens = openSyncSpy.mock.calls.filter(
+        ([filePath]) => typeof filePath === "string" && filePath.endsWith("/openclaw.plugin.json"),
+      );
+      expect(snapshot.webTools.search.diagnostics).toEqual(expect.any(Array));
+      expect(manifestOpens).toHaveLength(0);
+    } finally {
+      openSyncSpy.mockRestore();
+      setCurrentPluginMetadataSnapshot(undefined);
+    }
   });
 
   it("skips the startup-only fast path when the inherited main auth store exists", async () => {


### PR DESCRIPTION
## What Problem This Solves

One secrets prepare call (`prepareSecretsRuntimeSnapshot` → `resolveRuntimeWebTools`) with a keyless external web-search provider config re-scanned all 148 bundled plugin manifests up to 16 times — ~2,368 manifest opens, ~2.1s per call on an M3 Ultra, and warm calls stayed just as slow. The cost repeated on every prepare/refresh even though the gateway publishes a complete, lifecycle-owned plugin metadata snapshot at startup.

This is also the root-cause answer to the downstream ask in #107155 (Microsoft Lobster patch 0003): keyless host-proxied web search stays fast **without** any new config key (`omitAuth`), manifest field, or fast-path carve-out.

## Why This Change Was Made

The published snapshot cache was missed on the key, not bypassed by import: web-provider discovery mints bundled-compat activation configs (rewritten `plugins.allow`/`entries[].enabled`) whose policy hash never matches; `loadManifestMetadataSnapshot` minted `config ?? {}`, turning configless readers into incompatible explicit-policy readers; hot reload published a narrower compatibility envelope than startup; and the manifest-contract lane rebuilt registries outside the snapshot entirely.

The fix follows the repo doctrine "hot paths carry prepared facts forward": thread the prepared manifest registry through all web-provider discovery lanes (pattern copied from `providers.runtime.ts`), use the original config for snapshot lookups with activation applied as a projection, pass `undefined` config through as a configless default-context read, and publish the same compatibility envelope on hot reload as on startup.

## User Impact

Gateway secrets preparation with any web-search/web-fetch config gets dramatically cheaper: zero plugin-manifest disk opens per prepare when the published snapshot is live (was 1,332–2,368), and CLI-style processes without a published snapshot drop from ~1.3s to ~0.25s per warm call (one scan instead of sixteen). No config surface changes; no behavior changes to provider selection, credential resolution, or SSRF/cache policy.

## Evidence

- fs-counting regression test asserts zero `openclaw.plugin.json` opens during a warm prepare with a published snapshot and a keyless external provider config (`src/secrets/runtime.fast-path.test.ts`)
- Gateway reload regression proves the restored compatibility envelope (`src/gateway/server-reload-handlers.test.ts`)
- 256 targeted tests + `check:changed` green; measured 20.5× (210ms → 10.3ms) warm prepare in-harness, 1,332 → 0 manifest opens
- Autoreview (Codex/gpt-5.6-sol, high): "patch is correct (0.97), no P0"
- Production LOC +181/−40; tests +201/−29
