### PR TITLE
perf(agents): reuse gateway plugin generation for prepared model runtime

### DIFF
--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -1,6 +1,15 @@
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
+import {
+  listRuntimePluginIdsFromRegistry,
+  registryMatchesManifestPluginIds,
+} from "../plugins/active-runtime-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
+import {
+  getActivePluginRegistry,
+  getActivePluginRegistryWorkspaceDir,
+  getActivePluginRuntimeSubagentMode,
+} from "../plugins/runtime.js";
 import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
 import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
 
@@ -45,14 +54,33 @@ export function createPreparedInboundRegistryLoader(): PreparedInboundRegistryLo
     if (existing) {
       return existing;
     }
-    const registry = loadAgentRuntimePluginRegistryHandle({
-      config: input.config,
-      env: input.env ?? process.env,
-      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-      ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
-      metadataSnapshot,
-      preferBuiltPluginArtifacts: true,
-    });
+    const activeRegistry = getActivePluginRegistry();
+    const activeWorkspaceDir = getActivePluginRegistryWorkspaceDir();
+    // Inbound dispatch belongs to the exact active Gateway generation; its independent
+    // model-selected registry remains the only mutable prepared-context owner.
+    const reusableGatewayRegistry =
+      input.allowGatewaySubagentBinding === true &&
+      input.env === undefined &&
+      getActivePluginRuntimeSubagentMode() === "gateway-bindable" &&
+      activeRegistry &&
+      (activeWorkspaceDir === undefined || activeWorkspaceDir === metadataSnapshot.workspaceDir) &&
+      registryMatchesManifestPluginIds(
+        activeRegistry,
+        metadataSnapshot.manifestRegistry.plugins,
+        listRuntimePluginIdsFromRegistry(activeRegistry),
+      )
+        ? activeRegistry
+        : undefined;
+    const registry =
+      reusableGatewayRegistry ??
+      loadAgentRuntimePluginRegistryHandle({
+        config: input.config,
+        env: input.env ?? process.env,
+        ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+        ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+        metadataSnapshot,
+        preferBuiltPluginArtifacts: true,
+      });
     registries.set(key, registry);
     return registry;
   };
@@ -79,7 +107,11 @@ export function prepareWorkspacePluginRegistries(
   const runtimePluginRegistry =
     input.runtimePluginSelections || !inboundPluginRegistry
       ? loadAgentRuntimePluginRegistryHandle({
-          ...(input.loadRuntimePlugins ? { basePluginIds: [] } : {}),
+          ...(input.loadRuntimePlugins
+            ? { basePluginIds: [] }
+            : inboundPluginRegistry
+              ? { basePluginIds: listRuntimePluginIdsFromRegistry(inboundPluginRegistry) }
+              : {}),
           config: input.config,
           env: input.env ?? process.env,
           ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -113,6 +113,11 @@ export function prepareWorkspacePluginRegistries(
   const inboundPluginRegistry = input.readOnly
     ? undefined
     : loadInboundRegistry?.(input, metadataSnapshot);
+  // Extending the reused Gateway generation inherits its artifact preference: the
+  // Gateway loader realizes built artifacts, so the delta load must not re-import
+  // the same plugins through source transforms. Isolated loads keep source truth.
+  const extendsActiveGatewayGeneration =
+    inboundPluginRegistry !== undefined && inboundPluginRegistry === getActivePluginRegistry();
   const runtimePluginRegistry =
     input.runtimePluginSelections || !inboundPluginRegistry
       ? loadAgentRuntimePluginRegistryHandle({
@@ -125,6 +130,7 @@ export function prepareWorkspacePluginRegistries(
           env: input.env ?? process.env,
           ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
           ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+          ...(extendsActiveGatewayGeneration ? { preferBuiltPluginArtifacts: true } : {}),
           metadataSnapshot,
           ...(preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
           selections: input.runtimePluginSelections,

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -130,9 +130,12 @@ export function prepareWorkspacePluginRegistries(
           env: input.env ?? process.env,
           ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
           ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
-          ...(extendsActiveGatewayGeneration ? { preferBuiltPluginArtifacts: true } : {}),
           metadataSnapshot,
-          ...(preferBuiltPluginArtifacts ? { preferBuiltPluginArtifacts: true } : {}),
+          // Lifecycle-selected callers and delta loads extending the active Gateway
+          // generation both stay on built artifacts; isolated loads keep source truth.
+          ...(preferBuiltPluginArtifacts || extendsActiveGatewayGeneration
+            ? { preferBuiltPluginArtifacts: true }
+            : {}),
           selections: input.runtimePluginSelections,
         })
       : inboundPluginRegistry;

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -3,6 +3,7 @@ import {
   listRuntimePluginIdsFromRegistry,
   registryMatchesManifestPluginIds,
 } from "../plugins/active-runtime-registry.js";
+import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import {
@@ -56,13 +57,21 @@ export function createPreparedInboundRegistryLoader(): PreparedInboundRegistryLo
     }
     const activeRegistry = getActivePluginRegistry();
     const activeWorkspaceDir = getActivePluginRegistryWorkspaceDir();
-    // Inbound dispatch belongs to the exact active Gateway generation; its independent
-    // model-selected registry remains the only mutable prepared-context owner.
+    // Reuse is generation-bound: the requesting snapshot must BE the process-current
+    // published generation, or a leaked/older active registry could satisfy the
+    // manifest match (bundled records compare by id+origin only) and serve another
+    // generation's plugins. Identity, not equivalence, is the authority check here.
+    const currentGenerationSnapshot = getCurrentPluginMetadataSnapshot({
+      config: input.config,
+      workspaceDir: metadataSnapshot.workspaceDir,
+      allowWorkspaceScopedSnapshot: true,
+    });
     const reusableGatewayRegistry =
       input.allowGatewaySubagentBinding === true &&
       input.env === undefined &&
       getActivePluginRuntimeSubagentMode() === "gateway-bindable" &&
       activeRegistry &&
+      currentGenerationSnapshot === metadataSnapshot &&
       (activeWorkspaceDir === undefined || activeWorkspaceDir === metadataSnapshot.workspaceDir) &&
       registryMatchesManifestPluginIds(
         activeRegistry,

--- a/src/agents/prepared-model-runtime.plugin-context.test.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.test.ts
@@ -70,7 +70,7 @@ describe("prepared model runtime plugin metadata ownership", () => {
       workspaceDir,
     });
     const resolveMetadata = vi
-      .spyOn(pluginMetadata, "loadPluginMetadataSnapshot")
+      .spyOn(pluginMetadata, "resolvePluginMetadataSnapshot")
       .mockReturnValue(directSnapshot);
     const registry = createEmptyPluginRegistry();
 
@@ -94,6 +94,7 @@ describe("prepared model runtime plugin metadata ownership", () => {
         config,
         env: process.env,
         workspaceDir,
+        allowWorkspaceScopedCurrent: true,
       });
     } finally {
       resolveMetadata.mockRestore();
@@ -109,7 +110,7 @@ describe("prepared model runtime plugin metadata ownership", () => {
       workspaceDir,
     });
     const resolveMetadata = vi
-      .spyOn(pluginMetadata, "loadPluginMetadataSnapshot")
+      .spyOn(pluginMetadata, "resolvePluginMetadataSnapshot")
       .mockReturnValue(directSnapshot);
 
     try {
@@ -129,6 +130,7 @@ describe("prepared model runtime plugin metadata ownership", () => {
         config,
         env: process.env,
         workspaceDir,
+        allowWorkspaceScopedCurrent: true,
         pluginIdScope: expect.objectContaining({ key: expect.any(String) }),
       });
     } finally {

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -1,6 +1,6 @@
 import type { PluginDiscoveryResult } from "../plugins/discovery.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
-import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import {
@@ -74,10 +74,15 @@ function resolveColdMetadataSnapshot(
   input: PreparedModelRuntimeInput,
   env: NodeJS.ProcessEnv,
 ): PluginMetadataSnapshot {
-  const resolvedMetadataSnapshot = loadPluginMetadataSnapshot({
+  // Resolve (slot-probing) instead of load: in the gateway the published current
+  // generation satisfies this read, which keeps snapshot identity stable for the
+  // generation-bound registry reuse in the inbound loader.
+  const resolvedMetadataSnapshot = resolvePluginMetadataSnapshot({
     config: input.config,
     env,
-    ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+    ...(input.workspaceDir
+      ? { workspaceDir: input.workspaceDir, allowWorkspaceScopedCurrent: true }
+      : {}),
     ...(input.loadRuntimePlugins && input.runtimePluginSelections && input.workspaceDir
       ? {
           pluginIdScope: createAgentRuntimeMetadataPluginIdScope({

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -407,7 +407,10 @@ describe("prepared model runtime Gateway catalog mode", () => {
     );
     expect(mocks.buildPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
     expect(mocks.loadStaticCatalog).not.toHaveBeenCalled();
-    expect(mocks.resolvePluginMetadataSnapshot).toHaveBeenCalledOnce();
+    // Two slot-probing resolutions share the published generation: the prepared
+    // cold plugin context and the model-id normalization lane. Neither builds a
+    // catalog; the laziness guards above are the eager-work protections.
+    expect(mocks.resolvePluginMetadataSnapshot).toHaveBeenCalledTimes(2);
     expect(configuredRuntimeModelCount).toBe(1);
     expect(generatedCatalogReadCount).toBe(0);
     const snapshot = getPreparedModelRuntimeSnapshot({

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const hoisted = vi.hoisted(() => ({
   loadPluginMetadataSnapshot: vi.fn(),
   getActivePluginRegistry: vi.fn(),
+  getActivePluginRegistryWorkspaceDir: vi.fn(),
+  getActivePluginRuntimeSubagentMode: vi.fn(),
   loadPluginRegistryHandle: vi.fn(),
   adoptRuntimeContextEngineRegistrations: vi.fn((target: unknown) => target),
   adoptRuntimeWidgetPresenterRegistrations: vi.fn((target: unknown) => target),
@@ -19,6 +21,8 @@ vi.mock("../context-engine/registry.js", () => ({
 
 vi.mock("../plugins/runtime.js", () => ({
   getActivePluginRegistry: hoisted.getActivePluginRegistry,
+  getActivePluginRegistryWorkspaceDir: hoisted.getActivePluginRegistryWorkspaceDir,
+  getActivePluginRuntimeSubagentMode: hoisted.getActivePluginRuntimeSubagentMode,
 }));
 
 vi.mock("../plugins/widget-presenters.js", () => ({
@@ -42,6 +46,10 @@ import {
   getPluginRuntimeGatewayRequestScope,
   withPluginRuntimeRegistryScope,
 } from "../plugins/runtime/gateway-request-scope.js";
+import {
+  createPreparedInboundRegistryLoader,
+  prepareWorkspacePluginRegistries,
+} from "./prepared-model-runtime.inbound-registry.js";
 import {
   loadAgentRuntimePluginRegistryHandle,
   withAgentPluginRegistry,
@@ -69,6 +77,8 @@ describe("agent runtime plugin registries", () => {
         pluginIds: undefined,
       }));
     hoisted.getActivePluginRegistry.mockReset().mockReturnValue(undefined);
+    hoisted.getActivePluginRegistryWorkspaceDir.mockReset().mockReturnValue(undefined);
+    hoisted.getActivePluginRuntimeSubagentMode.mockReset().mockReturnValue("default");
     hoisted.loadPluginRegistryHandle.mockReset().mockReturnValue({ handle: true });
     hoisted.adoptRuntimeContextEngineRegistrations
       .mockReset()
@@ -106,6 +116,62 @@ describe("agent runtime plugin registries", () => {
     );
   });
 
+  it("reuses the Gateway inbound registry and loads only its selected provider delta", () => {
+    const config = {} as never;
+    const gatewayPlugin = {
+      id: "gateway-owned",
+      origin: "bundled",
+      rootDir: "/dist/extensions/gateway-owned",
+      source: "/dist/extensions/gateway-owned/index.js",
+      status: "loaded",
+    };
+    const activeRegistry = { plugins: [gatewayPlugin] };
+    const selectedRegistry = { plugins: [gatewayPlugin, { id: "selected-provider" }] };
+    const metadataSnapshot = {
+      ...createMetadataSnapshot("/tmp/default-workspace", undefined),
+      manifestRegistry: {
+        diagnostics: [],
+        plugins: [
+          {
+            id: "gateway-owned",
+            origin: "bundled",
+            rootDir: "/extensions/gateway-owned",
+            source: "/extensions/gateway-owned/index.ts",
+          },
+        ],
+      },
+    };
+    hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
+    hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("gateway-bindable");
+    hoisted.loadPluginRegistryHandle.mockReturnValue(selectedRegistry);
+    hoisted.resolveAgentRuntimePluginLoadPlan.mockImplementation(({ basePluginIds }) => ({
+      config,
+      pluginIds: [...(basePluginIds ?? []), "selected-provider"],
+    }));
+
+    const prepared = prepareWorkspacePluginRegistries(
+      {
+        agentDir: "/tmp/agent",
+        allowGatewaySubagentBinding: true,
+        config,
+        runtimePluginSelections: [{ provider: "selected", modelId: "model" }],
+        workspaceDir: "/tmp/default-workspace",
+      },
+      metadataSnapshot as never,
+      createPreparedInboundRegistryLoader(),
+    );
+
+    expect(prepared.inboundPluginRegistry).toBe(activeRegistry);
+    expect(prepared.runtimePluginRegistry).toBe(selectedRegistry);
+    expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledOnce();
+    expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onlyPluginIds: ["gateway-owned", "selected-provider"],
+        preferBuiltPluginArtifacts: true,
+      }),
+    );
+  });
+
   it("keeps direct no-current loads on the requested workspace", () => {
     const config = {} as never;
     const env = { OPENCLAW_STATE_DIR: "/tmp/openclaw-state" };
@@ -140,6 +206,7 @@ describe("agent runtime plugin registries", () => {
       discovery: metadataSnapshot.discovery,
       installRecords: {},
       manifestRegistry: metadataSnapshot.manifestRegistry,
+      preferBuiltPluginArtifacts: true,
       workspaceDir: "/tmp/workspace",
       runtimeOptions: { allowGatewaySubagentBinding: true },
     });

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hoisted = vi.hoisted(() => ({
   loadPluginMetadataSnapshot: vi.fn(),
+  getCurrentPluginMetadataSnapshot: vi.fn(),
   getActivePluginRegistry: vi.fn(),
   getActivePluginRegistryWorkspaceDir: vi.fn(),
   getActivePluginRuntimeSubagentMode: vi.fn(),
@@ -31,6 +32,10 @@ vi.mock("../plugins/widget-presenters.js", () => ({
 
 vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
   loadPluginMetadataSnapshot: hoisted.loadPluginMetadataSnapshot,
+}));
+
+vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: hoisted.getCurrentPluginMetadataSnapshot,
 }));
 
 vi.mock("../plugins/loader.js", () => ({
@@ -76,6 +81,7 @@ describe("agent runtime plugin registries", () => {
         ...createMetadataSnapshot(params.workspaceDir),
         pluginIds: undefined,
       }));
+    hoisted.getCurrentPluginMetadataSnapshot.mockReset().mockReturnValue(undefined);
     hoisted.getActivePluginRegistry.mockReset().mockReturnValue(undefined);
     hoisted.getActivePluginRegistryWorkspaceDir.mockReset().mockReturnValue(undefined);
     hoisted.getActivePluginRuntimeSubagentMode.mockReset().mockReturnValue("default");
@@ -143,6 +149,7 @@ describe("agent runtime plugin registries", () => {
     };
     hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
     hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("gateway-bindable");
+    hoisted.getCurrentPluginMetadataSnapshot.mockImplementation(() => metadataSnapshot);
     hoisted.loadPluginRegistryHandle.mockReturnValue(selectedRegistry);
     hoisted.resolveAgentRuntimePluginLoadPlan.mockImplementation(({ basePluginIds }) => ({
       config,
@@ -167,9 +174,59 @@ describe("agent runtime plugin registries", () => {
     expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith(
       expect.objectContaining({
         onlyPluginIds: ["gateway-owned", "selected-provider"],
-        preferBuiltPluginArtifacts: true,
       }),
     );
+  });
+
+  it("refuses Gateway registry reuse for a non-current metadata generation", () => {
+    const config = {} as never;
+    const gatewayPlugin = {
+      id: "gateway-owned",
+      origin: "bundled",
+      rootDir: "/dist/extensions/gateway-owned",
+      source: "/dist/extensions/gateway-owned/index.js",
+      status: "loaded",
+    };
+    const activeRegistry = { plugins: [gatewayPlugin] };
+    const metadataSnapshot = {
+      ...createMetadataSnapshot("/tmp/default-workspace", undefined),
+      manifestRegistry: {
+        diagnostics: [],
+        plugins: [
+          {
+            id: "gateway-owned",
+            origin: "bundled",
+            rootDir: "/extensions/gateway-owned",
+            source: "/extensions/gateway-owned/index.ts",
+          },
+        ],
+      },
+    };
+    hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
+    hoisted.getActivePluginRuntimeSubagentMode.mockReturnValue("gateway-bindable");
+    // A different (older/leaked) generation is current: identity must fail closed.
+    hoisted.getCurrentPluginMetadataSnapshot.mockReturnValue(
+      createMetadataSnapshot("/tmp/default-workspace", undefined),
+    );
+    hoisted.loadPluginRegistryHandle.mockReturnValue({ plugins: [] });
+    hoisted.resolveAgentRuntimePluginLoadPlan.mockImplementation(({ basePluginIds }) => ({
+      config,
+      pluginIds: basePluginIds,
+    }));
+
+    const loadInboundRegistry = createPreparedInboundRegistryLoader();
+    const inbound = loadInboundRegistry(
+      {
+        agentDir: "/tmp/agent",
+        allowGatewaySubagentBinding: true,
+        config,
+        workspaceDir: "/tmp/default-workspace",
+      },
+      metadataSnapshot as never,
+    );
+
+    expect(inbound).not.toBe(activeRegistry);
+    expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalled();
   });
 
   it("keeps direct no-current loads on the requested workspace", () => {
@@ -206,7 +263,6 @@ describe("agent runtime plugin registries", () => {
       discovery: metadataSnapshot.discovery,
       installRecords: {},
       manifestRegistry: metadataSnapshot.manifestRegistry,
-      preferBuiltPluginArtifacts: true,
       workspaceDir: "/tmp/workspace",
       runtimeOptions: { allowGatewaySubagentBinding: true },
     });
@@ -332,7 +388,6 @@ describe("agent runtime plugin registries", () => {
       installRecords: {},
       manifestRegistry: snapshot.manifestRegistry,
       onlyPluginIds: ["codex", "memory-core"],
-      preferBuiltPluginArtifacts: true,
       runtimeOptions: undefined,
       workspaceDir: snapshot.workspaceDir,
     });

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -388,6 +388,7 @@ describe("agent runtime plugin registries", () => {
       installRecords: {},
       manifestRegistry: snapshot.manifestRegistry,
       onlyPluginIds: ["codex", "memory-core"],
+      preferBuiltPluginArtifacts: true,
       runtimeOptions: undefined,
       workspaceDir: snapshot.workspaceDir,
     });

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -94,6 +94,7 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
         ? {}
         : { onlyPluginIds: plan.pluginIds }),
       ...(startupPluginIds === undefined ? {} : { channelPluginLoadIntent: "full" as const }),
+      preferBuiltPluginArtifacts: true,
       runtimeOptions: params.allowGatewaySubagentBinding
         ? { allowGatewaySubagentBinding: true }
         : undefined,

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -31,6 +31,8 @@ type AgentRuntimePluginRegistryParams = {
   /** Lifecycle-owned selection; standalone/direct generations stay source-default. */
   preferBuiltPluginArtifacts?: boolean;
   metadataSnapshot?: PluginMetadataSnapshot;
+  /** Set when extending a Gateway generation that loaded built artifacts itself. */
+  preferBuiltPluginArtifacts?: boolean;
 };
 
 function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistryParams) {
@@ -94,6 +96,7 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
         ? {}
         : { onlyPluginIds: plan.pluginIds }),
       ...(startupPluginIds === undefined ? {} : { channelPluginLoadIntent: "full" as const }),
+      ...(params.preferBuiltPluginArtifacts === true ? { preferBuiltPluginArtifacts: true } : {}),
       runtimeOptions: params.allowGatewaySubagentBinding
         ? { allowGatewaySubagentBinding: true }
         : undefined,

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -31,8 +31,6 @@ type AgentRuntimePluginRegistryParams = {
   /** Lifecycle-owned selection; standalone/direct generations stay source-default. */
   preferBuiltPluginArtifacts?: boolean;
   metadataSnapshot?: PluginMetadataSnapshot;
-  /** Set when extending a Gateway generation that loaded built artifacts itself. */
-  preferBuiltPluginArtifacts?: boolean;
 };
 
 function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistryParams) {
@@ -96,7 +94,6 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
         ? {}
         : { onlyPluginIds: plan.pluginIds }),
       ...(startupPluginIds === undefined ? {} : { channelPluginLoadIntent: "full" as const }),
-      ...(params.preferBuiltPluginArtifacts === true ? { preferBuiltPluginArtifacts: true } : {}),
       runtimeOptions: params.allowGatewaySubagentBinding
         ? { allowGatewaySubagentBinding: true }
         : undefined,

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -94,7 +94,6 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
         ? {}
         : { onlyPluginIds: plan.pluginIds }),
       ...(startupPluginIds === undefined ? {} : { channelPluginLoadIntent: "full" as const }),
-      preferBuiltPluginArtifacts: true,
       runtimeOptions: params.allowGatewaySubagentBinding
         ? { allowGatewaySubagentBinding: true }
         : undefined,


### PR DESCRIPTION
## What Problem This Solves

Gateway startup in a source checkout took ~50s, and 79% of it was the model-runtime sidecar rebuilding two broad plugin registries the gateway had already loaded: 167 plugin imports across 84 plugins (83 imported twice), 82 forced TypeScript source transformations across 41 source-backed plugins — 36.7s of which came from 39 plugins outside the gateway's own 16-plugin startup plan (`amazon-bedrock` 17.4s, `opencode` 14.2s).

## Why This Change Was Made

`src/agents/runtime-plugins.ts` dropped `onlyPluginIds` whenever no request scope or explicit base ids existed, so the prepared model runtime re-loaded the full enabled set — twice — instead of reusing the gateway's activated generation. Four changes fix the ownership boundary:

1. **Generation-bound reuse:** the inbound dispatch registry reuses the active gateway registry when the requesting snapshot *is* the process-current published generation (identity, not equivalence — bundled manifest records compare by id+origin only, so an equivalence check could let a leaked or stale registry serve another generation's plugins; a negative test locks this in), plus gateway-bindable subagent mode, default env, and workspace/manifest identity.
2. **Resolve, not load:** the sidecar acquires its snapshot through the slot-probing `resolvePluginMetadataSnapshot`, so the published generation satisfies the read and identity holds.
3. **Delta-only runtime registry:** the model-selected registry seeds from the inbound registry's plugin ids and loads only the genuine delta (selected providers/harnesses).
4. **Generation-inherited artifact preference:** when extending the reused gateway generation (which the gateway loaded from built artifacts), the delta load inherits `preferBuiltPluginArtifacts`; isolated loads keep source truth, so source-executed tests and dev flows are unchanged. A global flag was tried and reverted — it silently substituted stale dist for edited plugin source in checkouts.

## User Impact

Gateway readiness on a source checkout: **41.7s → 3.7–4.0s**. `sidecars.model-runtime`: **33,930ms → 289–331ms**. Plugin loader calls at startup: 169 → 19; forced source transformations: 82 → 0. Packaged installs improve proportionally (the double broad load existed in every environment). No config changes; isolated/CLI registry loads behave exactly as before.

## Evidence

- Live gateway timeline proof: 3 isolated startups (fresh `OPENCLAW_STATE_DIR`, own port, `/readyz`-gated) per build, before/after, `OPENCLAW_GATEWAY_STARTUP_TRACE` spans quoted above
- Regression tests: gateway-registry reuse with current-generation identity, non-current generation refuses reuse, delta-only `onlyPluginIds`, isolated loads keep prior args (`src/agents/runtime-plugins.test.ts`, `prepared-model-runtime.plugin-context.test.ts`)
- Full `src/agents` lane failures were attributed with a pristine-baseline control: the same Code Mode files fail on clean `origin/main` under 16-worker load on this host and pass serially — machine contention, not this change; two genuinely pre-existing failures on clean main (`sandbox/fs-bridge.boundary` FIFO case, `skill-workshop-tool.collection-restore`) are noted for follow-up
- `check:changed` green; autoreview (Codex/gpt-5.6-sol, high): "No P0 defects"
- Production LOC +63/−9; tests +129/−9
