### PR TITLE
fix(channels): stop Nostr and Buzz reusing buses during shutdown

### DIFF
--- a/extensions/buzz/src/gateway.lifecycle.test.ts
+++ b/extensions/buzz/src/gateway.lifecycle.test.ts
@@ -34,7 +34,12 @@ vi.mock("./inbound.js", () => ({
 }));
 
 import { BuzzDirectoryState } from "./directory-state.js";
-import { buzzOutboundAdapter, sendBuzzTyping, startBuzzGatewayAccount } from "./gateway.js";
+import {
+  buzzOutboundAdapter,
+  getActiveBuzzBus,
+  sendBuzzTyping,
+  startBuzzGatewayAccount,
+} from "./gateway.js";
 import { BUZZ_NORMAL_MESSAGE_KIND } from "./message-event.js";
 import { setBuzzRuntime } from "./runtime.js";
 import { resolveBuzzAccount } from "./types.js";
@@ -241,6 +246,118 @@ describe("Buzz gateway lifecycle", () => {
 
     expect(gatewayMocks.busSendTyping).not.toHaveBeenCalled();
     expect(gatewayMocks.sendBuzzTextOneShot).not.toHaveBeenCalled();
+  });
+
+  it.each(["resolves", "rejects"] as const)(
+    "retires the active bus before asynchronous shutdown %s",
+    async (closeOutcome) => {
+      let resolveClose: (() => void) | undefined;
+      let rejectClose: ((error: Error) => void) | undefined;
+      const closePending = new Promise<void>((resolve, reject) => {
+        resolveClose = resolve;
+        rejectClose = reject;
+      });
+      gatewayMocks.close.mockImplementationOnce(() => closePending);
+      const { abortController, cfg, account, lifecycle, setStatus } = startTestGateway();
+
+      try {
+        await vi.waitFor(() => expect(getActiveBuzzBus(account.accountId)).toBeDefined());
+        abortController.abort();
+        await vi.waitFor(() => expect(gatewayMocks.close).toHaveBeenCalledOnce());
+
+        expect(getActiveBuzzBus(account.accountId)).toBeUndefined();
+        expect(setStatus).not.toHaveBeenCalledWith({
+          accountId: account.accountId,
+          running: false,
+        });
+
+        const pendingResult = await buzzOutboundAdapter.sendText({
+          cfg,
+          to: `buzz:${CHANNEL_ID}`,
+          text: "while closing",
+          accountId: account.accountId,
+        });
+        await sendBuzzTyping({
+          cfg,
+          to: `buzz:${CHANNEL_ID}`,
+          accountId: account.accountId,
+        });
+
+        expect(pendingResult.messageId).toBe("standalone-event-id");
+        expect(gatewayMocks.sendBuzzTextOneShot).toHaveBeenCalledOnce();
+        expect(gatewayMocks.busSendText).not.toHaveBeenCalled();
+        expect(gatewayMocks.busSendTyping).not.toHaveBeenCalled();
+
+        if (closeOutcome === "rejects") {
+          const closeError = new Error("Buzz close failed");
+          rejectClose?.(closeError);
+          await expect(lifecycle).rejects.toBe(closeError);
+          expect(setStatus).not.toHaveBeenCalledWith({
+            accountId: account.accountId,
+            running: false,
+          });
+        } else {
+          resolveClose?.();
+          await expect(lifecycle).resolves.toBeUndefined();
+          expect(setStatus).toHaveBeenLastCalledWith({
+            accountId: account.accountId,
+            running: false,
+          });
+        }
+
+        expect(getActiveBuzzBus(account.accountId)).toBeUndefined();
+        await buzzOutboundAdapter.sendText({
+          cfg,
+          to: `buzz:${CHANNEL_ID}`,
+          text: "after closing",
+          accountId: account.accountId,
+        });
+        await sendBuzzTyping({
+          cfg,
+          to: `buzz:${CHANNEL_ID}`,
+          accountId: account.accountId,
+        });
+        expect(gatewayMocks.sendBuzzTextOneShot).toHaveBeenCalledTimes(2);
+        expect(gatewayMocks.busSendText).not.toHaveBeenCalled();
+        expect(gatewayMocks.busSendTyping).not.toHaveBeenCalled();
+      } finally {
+        abortController.abort();
+        resolveClose?.();
+        await lifecycle.catch(() => undefined);
+      }
+    },
+  );
+
+  it("does not retire a replacement bus when an earlier generation finishes closing", async () => {
+    let resolveClose: (() => void) | undefined;
+    const closePending = new Promise<void>((resolve) => {
+      resolveClose = resolve;
+    });
+    gatewayMocks.close.mockImplementationOnce(() => closePending);
+    const first = startTestGateway();
+    let replacement: ReturnType<typeof startTestGateway> | undefined;
+
+    try {
+      await vi.waitFor(() => expect(getActiveBuzzBus(first.account.accountId)).toBeDefined());
+      replacement = startTestGateway();
+      await vi.waitFor(() => expect(gatewayMocks.startBuzzBus).toHaveBeenCalledTimes(2));
+      const replacementBus = getActiveBuzzBus(first.account.accountId);
+      expect(replacementBus).toBeDefined();
+
+      first.abortController.abort();
+      await vi.waitFor(() => expect(gatewayMocks.close).toHaveBeenCalledOnce());
+      expect(getActiveBuzzBus(first.account.accountId)).toBe(replacementBus);
+
+      resolveClose?.();
+      await expect(first.lifecycle).resolves.toBeUndefined();
+      expect(getActiveBuzzBus(first.account.accountId)).toBe(replacementBus);
+    } finally {
+      first.abortController.abort();
+      resolveClose?.();
+      await first.lifecycle.catch(() => undefined);
+      replacement?.abortController.abort();
+      await replacement?.lifecycle.catch(() => undefined);
+    }
   });
 
   it("reuses the gateway bus for sends in the running process", async () => {

--- a/extensions/buzz/src/gateway.ts
+++ b/extensions/buzz/src/gateway.ts
@@ -174,10 +174,11 @@ export async function startBuzzGatewayAccount(ctx: ChannelGatewayContext<Resolve
       }
       cycleError = error instanceof Error ? error : new Error(String(error));
     } finally {
-      await bus?.close();
+      // Retire before fallible async shutdown so new work cannot reacquire this bus.
       if (activeBuses.get(account.accountId) === bus) {
         activeBuses.delete(account.accountId);
       }
+      await bus?.close();
       ctx.setStatus({
         accountId: account.accountId,
         running: false,

--- a/extensions/nostr/src/channel.lifecycle.test.ts
+++ b/extensions/nostr/src/channel.lifecycle.test.ts
@@ -8,7 +8,7 @@ import {
   waitForStartedMocks,
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getActiveNostrBuses, startNostrGatewayAccount } from "./gateway.js";
+import { getActiveNostrBuses, nostrOutboundAdapter, startNostrGatewayAccount } from "./gateway.js";
 import { setNostrRuntime } from "./runtime.js";
 import { buildResolvedNostrAccount } from "./test-fixtures.js";
 
@@ -90,6 +90,134 @@ describe("nostr gateway lifecycle", () => {
 
     expect(bus.close).toHaveBeenCalledOnce();
     expect(getActiveNostrBuses().has("default")).toBe(false);
+  });
+
+  it.each([
+    { outcome: "resolves", closeFails: false },
+    { outcome: "rejects", closeFails: true },
+  ])("retires the active bus before shutdown $outcome", async ({ closeFails }) => {
+    const bus = createMockBus();
+    let finishClose!: () => void;
+    let rejectClose!: (reason: Error) => void;
+    bus.close.mockReturnValueOnce(
+      new Promise<void>((resolve, reject) => {
+        finishClose = resolve;
+        rejectClose = reject;
+      }),
+    );
+    mocks.startNostrBus.mockResolvedValueOnce(bus as never);
+    const abort = new AbortController();
+    const context = bindChannelRuntime(
+      createStartAccountContext({
+        account: buildResolvedNostrAccount(),
+        abortSignal: abort.signal,
+      }),
+    );
+    const lifecycle = startNostrGatewayAccount(context);
+
+    await vi.waitFor(() => expect(getActiveNostrBuses().get("default")).toBe(bus));
+    abort.abort();
+    await vi.waitFor(() => expect(bus.close).toHaveBeenCalledOnce());
+
+    const activeBusWhileClosing = getActiveNostrBuses().get("default");
+    const sendWhileClosing = await nostrOutboundAdapter
+      .sendText({
+        cfg: context.cfg,
+        to: context.account.publicKey,
+        text: "hello",
+        accountId: context.account.accountId,
+      })
+      .then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+    const sendsWhileClosing = bus.sendDm.mock.calls.length;
+    expect(context.log?.info).not.toHaveBeenCalledWith("[default] Nostr provider stopped");
+
+    if (closeFails) {
+      const closeError = new Error("Nostr relay shutdown failed");
+      rejectClose(closeError);
+      await expect(lifecycle).rejects.toBe(closeError);
+      expect(context.log?.info).not.toHaveBeenCalledWith("[default] Nostr provider stopped");
+    } else {
+      finishClose();
+      await expect(lifecycle).resolves.toBeUndefined();
+      expect(context.log?.info).toHaveBeenCalledWith("[default] Nostr provider stopped");
+    }
+
+    expect(activeBusWhileClosing).toBeUndefined();
+    expect(sendWhileClosing).toEqual(new Error("Nostr bus not running for account default"));
+    expect(sendsWhileClosing).toBe(0);
+    expect(getActiveNostrBuses().has("default")).toBe(false);
+
+    if (closeFails) {
+      await expect(
+        nostrOutboundAdapter.sendText({
+          cfg: context.cfg,
+          to: context.account.publicKey,
+          text: "hello again",
+          accountId: context.account.accountId,
+        }),
+      ).rejects.toThrow("Nostr bus not running for account default");
+      expect(bus.sendDm).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not retire a replacement bus while the previous generation closes", async () => {
+    const firstBus = createMockBus();
+    const replacementBus = createMockBus();
+    let finishFirstClose!: () => void;
+    firstBus.close.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishFirstClose = resolve;
+      }),
+    );
+    mocks.startNostrBus
+      .mockResolvedValueOnce(firstBus as never)
+      .mockResolvedValueOnce(replacementBus as never);
+    const firstAbort = new AbortController();
+    const firstLifecycle = startNostrGatewayAccount(
+      bindChannelRuntime(
+        createStartAccountContext({
+          account: buildResolvedNostrAccount(),
+          abortSignal: firstAbort.signal,
+        }),
+      ),
+    );
+    let replacementAbort: AbortController | undefined;
+    let replacementLifecycle: typeof firstLifecycle | undefined;
+
+    try {
+      await vi.waitFor(() => expect(getActiveNostrBuses().get("default")).toBe(firstBus));
+      replacementAbort = new AbortController();
+      replacementLifecycle = startNostrGatewayAccount(
+        bindChannelRuntime(
+          createStartAccountContext({
+            account: buildResolvedNostrAccount(),
+            abortSignal: replacementAbort.signal,
+          }),
+        ),
+      );
+      await vi.waitFor(() => expect(getActiveNostrBuses().get("default")).toBe(replacementBus));
+
+      firstAbort.abort();
+      await vi.waitFor(() => expect(firstBus.close).toHaveBeenCalledOnce());
+      expect(getActiveNostrBuses().get("default")).toBe(replacementBus);
+
+      finishFirstClose();
+      await expect(firstLifecycle).resolves.toBeUndefined();
+      expect(getActiveNostrBuses().get("default")).toBe(replacementBus);
+
+      replacementAbort.abort();
+      await expect(replacementLifecycle).resolves.toBeUndefined();
+      expect(getActiveNostrBuses().has("default")).toBe(false);
+    } finally {
+      firstAbort.abort();
+      finishFirstClose();
+      await firstLifecycle.catch(() => undefined);
+      replacementAbort?.abort();
+      await replacementLifecycle?.catch(() => undefined);
+    }
   });
 
   it("stops immediately when startAccount receives an already-aborted signal", async () => {

--- a/extensions/nostr/src/gateway.ts
+++ b/extensions/nostr/src/gateway.ts
@@ -18,7 +18,7 @@ import {
 } from "openclaw/plugin-sdk/text-chunking";
 import type { PluginRuntime } from "../runtime-api.js";
 import type { ChannelOutboundAdapter, ChannelPlugin } from "./channel-api.js";
-import type { MetricEvent, MetricsSnapshot } from "./metrics.js";
+import type { MetricEvent } from "./metrics.js";
 import { startNostrBus, type NostrBusHandle } from "./nostr-bus.js";
 import { normalizePubkey } from "./nostr-key-utils.js";
 import { getNostrRuntime } from "./runtime.js";
@@ -35,7 +35,6 @@ type NostrOutboundAdapter = Pick<
   sanitizeText: NonNullable<ChannelOutboundAdapter["sanitizeText"]>;
 };
 const activeBuses = new Map<string, NostrBusHandle>();
-const metricsSnapshots = new Map<string, MetricsSnapshot>();
 const ACCESS_GROUP_PREFIX = "accessGroup:";
 
 function normalizeRelayLifecycleKey(relay: string): string {
@@ -135,7 +134,6 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
         : undefined,
     });
 
-  let busHandle: NostrBusHandle | null = null;
   const connectedRelays = new Set<string>();
 
   const authorizeSender = async (input: {
@@ -295,12 +293,8 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
           } else if (event.name === "relay.error") {
             ctx.log?.debug?.(`[${account.accountId}] Relay error: ${event.labels?.relay}`);
           }
-          if (busHandle) {
-            metricsSnapshots.set(account.accountId, busHandle.getMetrics());
-          }
         },
       });
-      busHandle = bus;
       activeBuses.set(account.accountId, bus);
 
       ctx.log?.info?.(
@@ -309,14 +303,11 @@ export const startNostrGatewayAccount: NostrGatewayStart = async (ctx) => {
 
       return {
         stop: async () => {
-          await bus.close();
-          if (busHandle === bus) {
-            busHandle = null;
-          }
+          // Retire before fallible async shutdown so new work cannot reacquire this bus.
           if (activeBuses.get(account.accountId) === bus) {
             activeBuses.delete(account.accountId);
           }
-          metricsSnapshots.delete(account.accountId);
+          await bus.close();
           ctx.log?.info?.(`[${account.accountId}] Nostr provider stopped`);
         },
       };


### PR DESCRIPTION
Closes #126636

## What Problem This Solves

Fixes an issue where users sending Nostr direct messages or Buzz room messages during channel shutdown could reuse a stopping connection. If asynchronous shutdown failed, the stale connection could remain discoverable indefinitely and continue attracting new outbound or typing work.

## Why This Change Was Made

Both channel lifecycle owners now retire only their exact active bus generation before awaiting its existing asynchronous close. This preserves replacement generations, the original close rejection, and success-only shutdown logging/status while leaving all existing transport fallback and persistence behavior untouched. The Nostr owner also removes a private write-only metrics snapshot cache and handle bookkeeping whose only reader was removed in a previous release; live bus metrics and metric logging remain intact.

Nostr's ordering regression was introduced by #110653. Buzz shared the same owner-boundary lifecycle invariant independently.

## User Impact

Stopping buses no longer receive new messages, typing, profile, or directory work. Nostr retains its established bus-not-running error; Buzz text retains its established one-shot connection fallback and typing retains its existing no-bus drop. Failed shutdown still surfaces the original error, replacement generations remain available, and cursor persistence during close is unchanged.

## Evidence

- Before the repair, new owner-boundary regressions failed for both Nostr and Buzz with both resolving and rejecting deferred closes because the stopping bus remained registered.
- After the repair, Nostr passes 272 tests across 19 files and Buzz passes 160 tests across 29 files. Coverage includes pending and rejected close, outbound/typing behavior, original error propagation, successful-stop log/status ordering, empty registries after failure, and replacement registration before stale-generation shutdown.
- Full focused commands: `node scripts/run-vitest.mjs --configLoader runner extensions/nostr` and `node scripts/run-vitest.mjs --configLoader runner extensions/buzz`.
- Full changed-file gate: `node scripts/check-changed.mjs -- extensions/nostr/src/gateway.ts extensions/nostr/src/channel.lifecycle.test.ts extensions/buzz/src/gateway.ts extensions/buzz/src/gateway.lifecycle.test.ts`; extension production/test typechecks, targeted lint, formatting, plugin boundaries, dead exports, database/media guards, focused doctor-contract tests, and runtime import cycles all pass.
- Fresh Codex-backed P1 structured review and a separate read-only adversarial review both report no actionable findings.
- Production: +5/-13 lines (net -8). Tests: +247/-2 lines (net +245). Four files; no config, protocol, Plugin SDK, persistence, security, dependency, or public API changes.
- Authenticated external Nostr/Buzz relay validation is unavailable in this isolated maintenance flow; deterministic real lifecycle/outbound boundaries and complete affected plugin suites provide the direct behavior proof.

AI-assisted: yes
