### PR TITLE
perf(test): settle partial reply drains deterministically

### DIFF
--- a/src/agents/embedded-agent-subscribe.partial-reply-lifecycle.test.ts
+++ b/src/agents/embedded-agent-subscribe.partial-reply-lifecycle.test.ts
@@ -105,13 +105,17 @@ describe("subscribeEmbeddedAgentSession partial reply lifecycle", () => {
     // waitForPendingEvents, which also awaits pendingPartialReplyTasks; a
     // stalled callback would block the drain until the bounded liveness
     // deadline (120s) elapsed.
-    const onPartialReply = vi.fn(() => new Promise<void>(() => {}));
+    let resolvePartialReply!: () => void;
+    const partialReply = new Promise<void>((resolve) => {
+      resolvePartialReply = resolve;
+    });
+    const onPartialReply = vi.fn(() => partialReply);
     const { emit, subscription } = createSubscribedSessionHarness({
       runId: "run-stalled-partial-callback",
       onPartialReply,
     });
 
-    // First delta fires the partial-reply callback (stalled, never resolves).
+    // First delta keeps the partial-reply callback pending through the queue-only drain.
     emit({
       type: "message_update",
       message: { role: "assistant" },
@@ -126,26 +130,18 @@ describe("subscribeEmbeddedAgentSession partial reply lifecycle", () => {
       assistantMessageEvent: { type: "text_delta", delta: "answer" },
     });
 
-    // Queue-only drain completes promptly: the event chain is null once both
-    // deltas are processed, regardless of the stalled fan-out callback.
-    await expect(
-      Promise.race([
-        subscription.waitForPendingEvents({ includePartialReplies: false }).then(() => "drained"),
-        new Promise<"timeout">((resolve) => {
-          setTimeout(() => resolve("timeout"), 1000);
-        }),
-      ]),
-    ).resolves.toBe("drained");
+    let broadDrained = false;
+    const broadDrain = subscription.waitForPendingEvents().then(() => {
+      broadDrained = true;
+    });
 
-    // The broad join still observes the stalled callback (proving the two
-    // drains are genuinely distinct and the queue-only split is meaningful).
-    const broad = Promise.race([
-      subscription.waitForPendingEvents().then(() => "drained"),
-      new Promise<"timeout">((resolve) => {
-        setTimeout(() => resolve("timeout"), 1000);
-      }),
-    ]);
-    await expect(broad).resolves.toBe("timeout");
+    // The event chain drains while the broad join still waits for the callback.
+    await subscription.waitForPendingEvents({ includePartialReplies: false });
+    expect(broadDrained).toBe(false);
+
+    resolvePartialReply();
+    await broadDrain;
+    expect(broadDrained).toBe(true);
 
     subscription.unsubscribe();
   });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

A maintainer-requested embedded-agent lifecycle regression test spent a full real second waiting for watchdog timers on every run. That unnecessary wall-clock delay slowed the focused agent test lane without providing stronger protection for timeout salvage or normal terminal settlement.

## Why This Change Was Made

Replace both real one-second watchdog races with one manually controlled partial-reply callback in the existing subscription harness. Start ordinary broad settlement, prove the queue-only drain completes while that callback is still pending, then resolve the exact callback and prove broad settlement completes. This preserves the direct same-subscription comparison without fake timers, new seams, extra mocks, production changes, or weakened lifecycle coverage.

## User Impact

No user-visible behavior changes. Developers and CI receive faster, deterministic coverage of the existing distinction between run-budget timeout salvage and complete terminal settlement.

## Evidence

- Controlled stopped Testbox lease `tbx_01m0fazzcb83naepyxy126fxgz`: excluded warmup, two retained before/after samples, one worker, distinct module caches, import diagnostics, and `/usr/bin/time -v`; every sample passed one file and three tests.
- Target test: **1,002 ms -> 1 ms** (**-1,001 ms; -99.90%**).
- Retained mean wall time: **11.465 s -> 10.600 s** (**-0.865 s; -7.54%**).
- Vitest duration: **8.235 s -> 7.235 s** (**-1.000 s; -12.14%**).
- Test-body duration: **1.095 s -> 0.0985 s** (**-0.9965 s; -91.0%**).
- Import duration: **6.260 s -> 6.250 s**, isolating the improvement to removal of the real wait.
- RSS: **988,564 KiB -> 982,294 KiB**, directional only; CPU user/system: **11.405/1.265 s -> 11.600/1.155 s**.
- Fault injection temporarily changed the real production owner so broad settlement dropped tracked partial-reply tasks; this test failed at the pending-state assertion (`expected true to be false`). The production owner was restored and the final production diff is empty.
- Same-Testbox owner/sibling coverage passed **3 files / 24 tests**, covering partial-reply lifecycle, before-terminal delivery, and attempt-stream finalization.
- Same-Testbox changed gate passed the complete target `coreTests` plan, including the full core test typecheck, lint, guards, formatting, and dead-export checks.
- Rebased owner/sibling proof: `node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.partial-reply-lifecycle.test.ts src/agents/embedded-agent-subscribe.before-terminal-delivery.test.ts src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts`.
- Formatting and whitespace: `node_modules/.bin/oxfmt --check src/agents/embedded-agent-subscribe.partial-reply-lifecycle.test.ts`; `git diff origin/main...HEAD --check`.
- Fresh structured branch review completed with no accepted/actionable findings.
- Production: **+0/-0**. Tests: **+17/-21 (net -4)**. No changelog or UI/screenshots: this is a test-only, behavior-neutral change.
- AI-assisted; reviewed and verified by the maintainer.
