### PR TITLE
fix(gateway): recover cloud workers without blocking paired-node startup

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -1366,6 +1366,46 @@ describe("Crabbox worker provider", () => {
     },
   );
 
+  it.each(["preparation", "completion"] as const)(
+    "preserves its fixed lease when the Gateway aborts enrollment %s",
+    async (phase) => {
+      const calls: string[][] = [];
+      const controller = new AbortController();
+      const provider = providerWithRunner(async (argv) => {
+        calls.push(argv);
+        return argv[1] === "inspect"
+          ? commandResult({ stdout: inspectJson({ sshHostKey: HOST_KEY }) })
+          : commandResult();
+      });
+
+      await expect(
+        provider.provision(PROFILE, OPERATION_ID, {
+          beginNodeEnrollment: async () => {
+            if (phase === "preparation") {
+              controller.abort();
+              controller.signal.throwIfAborted();
+            }
+            return {
+              mode: "resume" as const,
+              deviceId: "device-bound",
+              openclawVersion: "2026.8.1",
+              packageSpecs: ["openclaw@2026.8.1"],
+              displayName: "Bound worker",
+              signal: controller.signal,
+              waitForDeviceId: async () => {
+                controller.abort();
+                controller.signal.throwIfAborted();
+                return "device-bound";
+              },
+            };
+          },
+        }),
+      ).rejects.toMatchObject({ name: "AbortError" });
+
+      expect(calls.some((argv) => argv[1] === "stop")).toBe(false);
+    },
+  );
+
   it("runs one fixed warmup, ignores its output, and inspects only the canonical id", async () => {
     const calls: Array<{ argv: string[]; options: Parameters<CrabboxCommandRunner>[1] }> = [];
     const provider = providerWithRunner(async (argv, options) => {

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -609,6 +609,9 @@ export function createCrabboxWorkerProvider(
       try {
         enrollment = await beginNodeEnrollment();
       } catch (error) {
+        if (error instanceof Error && error.name === "AbortError") {
+          throw error;
+        }
         return await failProvisionAfterCleanup({ ...inspectedParams, id: leaseId }, error);
       }
       const nodeEnrollmentSetup = createCrabboxNodeEnrollmentSetup({ enrollment, leaseId });
@@ -625,6 +628,10 @@ export function createCrabboxWorkerProvider(
       try {
         deviceId = await enrollment.waitForDeviceId();
       } catch (error) {
+        // Gateway shutdown cancels its wait, not the fixed operation-owned provider lease.
+        if (enrollment.signal?.aborted) {
+          throw error;
+        }
         return await failProvisionAfterCleanup({ ...inspectedParams, id: leaseId }, error);
       }
       heartbeats.start({

--- a/src/gateway/server-http-upgrades.ts
+++ b/src/gateway/server-http-upgrades.ts
@@ -117,11 +117,18 @@ function handleBudgetedGatewayWebSocketUpgrade(params: {
   preauthConnectionBudget: PreauthConnectionBudget;
   preauthBudgetKey: string | undefined;
   ingressName: "Gateway" | "Worker";
+  isStartupPending?: () => boolean;
   prepareSocket?: (socket: GatewayIngressWebSocket) => void;
 }): void {
   const { req, socket, head, wss, preauthConnectionBudget, preauthBudgetKey, ingressName } = params;
+  const allowsRestartStartupPreauth =
+    ingressName === "Gateway" &&
+    isGatewayRestartDraining() &&
+    getGatewaySuspendAdmissionPhase() === "accepting" &&
+    params.isStartupPending?.() === true;
   if (
     isGatewayWorkAdmissionClosed() &&
+    !allowsRestartStartupPreauth &&
     (ingressName === "Worker" ||
       isGatewayRestartDraining() ||
       getGatewaySuspendAdmissionPhase() !== "prepared")
@@ -190,6 +197,7 @@ export function attachGatewayUpgradeHandler(opts: {
   desktopSessionRegistry?: DesktopSessionRegistry;
   nodeDesktopStreamBroker?: NodeDesktopStreamBroker;
   getGatewayRequestContext?: () => GatewayRequestContext | undefined;
+  isStartupPending?: () => boolean;
   ingressTransport?: GatewayIngressTransport;
   reportUnattributableProxy?: GatewayUnattributableProxyReporter;
 }) {
@@ -427,6 +435,7 @@ export function attachGatewayUpgradeHandler(opts: {
           preauthConnectionBudget,
           preauthBudgetKey: requestClientIp,
           ingressName: "Gateway",
+          isStartupPending: opts.isStartupPending,
         });
       } catch {
         throw new Error("gateway websocket upgrade failed");

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -422,7 +422,8 @@ export async function prepareGatewayKernelState(params: {
   });
   channelManager.setAutostartSuppression(opts.channelAutostartSuppression ?? null);
   const sidecarStartup = opts.sidecarStartup ?? "start";
-  const isGatewayStartupPending = () => !startupState.sidecarsReady;
+  const isGatewayStartupPending = () =>
+    !startupState.sidecarsReady && !lifecycle.closePreludeStarted;
   const startupCheckerDeps = {
     startedAt: serverStartedAt,
     getStartupPending: isGatewayStartupPending,
@@ -482,6 +483,7 @@ export async function prepareGatewayKernelState(params: {
     logPlugins,
     getReadiness,
     getStartup,
+    isStartupPending: isGatewayStartupPending,
     handleWatchNodeRequest: async (req: IncomingMessage, res: ServerResponse) =>
       (await watchNodeRequestHandler.current?.(req, res)) ?? false,
     handleNodeWorkerBundleTransferRequest,

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -121,6 +121,7 @@ export async function createGatewayHttpTransport(params: {
   logPlugins: ReturnType<typeof createSubsystemLogger>;
   getReadiness?: ReadinessChecker;
   getStartup?: StartupChecker;
+  isStartupPending?: () => boolean;
   isTerminalEnabled: () => boolean;
   handleWatchNodeRequest?: (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
   handleNodeWorkerBundleTransferRequest?: NodeWorkerBundleTransferHttpCallback;
@@ -338,6 +339,7 @@ export async function createGatewayHttpTransport(params: {
       desktopSessionRegistry: params.desktopSessionRegistry,
       nodeDesktopStreamBroker: params.nodeDesktopStreamBroker,
       getGatewayRequestContext: params.getGatewayRequestContext,
+      isStartupPending: params.isStartupPending,
       ingressTransport,
       reportUnattributableProxy,
     });

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -164,6 +164,7 @@ export async function finishGatewayStartup(params: {
       nodeReapprovalCoordinator,
       preauthHandshakeTimeoutMs,
       isStartupPending: isGatewayStartupPending,
+      isPendingWorkerNodeSetup: workerEnvironmentService?.hasPendingNodeEnrollmentSetup,
       gatewayMethods: runtimeState.gatewayMethods,
       events: GATEWAY_EVENTS,
       logGateway: log,

--- a/src/gateway/server-worker-environment-startup.ts
+++ b/src/gateway/server-worker-environment-startup.ts
@@ -272,6 +272,7 @@ export async function createGatewayWorkerEnvironmentRuntime(params: {
     ensureNodeWorkerBundle: async (deviceId) => await ensureNodeWorkerBundle({ deviceId }),
     prepareNodeEnrollment: nodeEnrollment.begin,
     retireNodeEnrollment: nodeEnrollment.retire,
+    stopNodeEnrollmentWaits: nodeEnrollment.stop,
     tunnelManager: workerTunnelManager,
     nodeTunnelManager: nodeWorkerTunnelManager,
     nodeDesktopCarrier: workerNodeDesktopCarrier,

--- a/src/gateway/server-worker-placement-reconcile-guard.ts
+++ b/src/gateway/server-worker-placement-reconcile-guard.ts
@@ -1,0 +1,39 @@
+import type { WorkerPlacementDispatchService } from "./worker-environments/placement-dispatch.js";
+import type { WorkerSessionPlacementStore } from "./worker-environments/placement-store.js";
+import type { WorkerEnvironmentService } from "./worker-environments/service.js";
+
+export function installWorkerPlacementReconcileGuard(params: {
+  placements: WorkerSessionPlacementStore;
+  environments: WorkerEnvironmentService;
+  dispatch: Pick<WorkerPlacementDispatchService, "resumeProvisioning">;
+  isStopping: () => boolean;
+}) {
+  return params.environments.installReconcileEnvironmentGuard(
+    async (environmentId, reconcileEnvironmentCore) => {
+      if (params.isStopping()) {
+        return;
+      }
+      const references = params.placements
+        .list()
+        .filter((placement) => placement.environmentId === environmentId);
+      if (references.length > 1) {
+        throw new Error(`Worker environment ${environmentId} has multiple placement owners`);
+      }
+      const owner = references[0];
+      if (owner?.state === "provisioning") {
+        await params.dispatch.resumeProvisioning(owner, reconcileEnvironmentCore);
+        return;
+      }
+      const environment = params.environments.get(environmentId);
+      if (
+        owner &&
+        (environment?.state === "requested" ||
+          environment?.state === "provisioning" ||
+          environment?.state === "bootstrapping")
+      ) {
+        throw new Error(`Worker environment ${environmentId} provisioning owner is ${owner.state}`);
+      }
+      await reconcileEnvironmentCore();
+    },
+  );
+}

--- a/src/gateway/server-worker-placement-session-target.ts
+++ b/src/gateway/server-worker-placement-session-target.ts
@@ -1,7 +1,79 @@
+import type { managedWorktrees } from "../agents/worktrees/service.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { runExclusiveSessionLifecycleMutation } from "../sessions/session-lifecycle-admission.js";
+import type * as sessionUtils from "./session-utils.js";
+import type { WorkerPlacementExecutionMode } from "./worker-environments/placement-record.js";
+import type * as placementSessionRuntime from "./worker-environments/placement-session-runtime.js";
 
 export class WorkerDispatchTargetChangedError extends Error {
   readonly code = "invalid_state";
+}
+
+type WorkerPlacementSessionRuntime = {
+  resolveWorkerPlacementExecutionMode: typeof placementSessionRuntime.resolveWorkerPlacementExecutionMode;
+  managedWorktrees: typeof managedWorktrees;
+  resolveWorkerPlacementSessionRuntime: typeof placementSessionRuntime.resolveWorkerPlacementSessionRuntime;
+  resolveCanonicalSessionEntryFromStoreKeys: typeof sessionUtils.resolveCanonicalSessionEntryFromStoreKeys;
+  resolveGatewaySessionStoreTargetWithStore: typeof sessionUtils.resolveGatewaySessionStoreTargetWithStore;
+};
+type WorkerPlacementWorktree = NonNullable<ReturnType<typeof managedWorktrees.findLiveByOwner>>;
+
+export async function runWorkerPlacementSessionBarrier<T>(params: {
+  sessionRuntime: WorkerPlacementSessionRuntime;
+  getConfig: () => OpenClawConfig;
+  sessionId: string;
+  sessionKey: string;
+  agentId: string;
+  executionMode: WorkerPlacementExecutionMode;
+  action: "activation" | "recovery";
+  run: (worktree: WorkerPlacementWorktree) => T | Promise<T>;
+}): Promise<T> {
+  const target = params.sessionRuntime.resolveGatewaySessionStoreTargetWithStore({
+    cfg: params.getConfig(),
+    key: params.sessionKey,
+    agentId: params.agentId,
+    clone: false,
+  });
+  return await runExclusiveSessionLifecycleMutation({
+    scope: target.storePath,
+    identities: [params.sessionKey, target.canonicalKey, ...target.storeKeys, params.sessionId],
+    run: async () => {
+      const {
+        config,
+        target: currentTarget,
+        entry,
+        worktree,
+      } = resolveWorkerPlacementSessionTarget({
+        sessionRuntime: params.sessionRuntime,
+        config: params.getConfig(),
+        sessionId: params.sessionId,
+        sessionKey: params.sessionKey,
+        agentId: params.agentId,
+        expectedTarget: target,
+        errorMessage: `Session ${params.sessionKey} changed before cloud worker ${params.action}. Retry.`,
+      });
+      if (entry.archivedAt !== undefined) {
+        throw new WorkerDispatchTargetChangedError(
+          `Session ${params.sessionKey} was archived before cloud worker ${params.action}. Retry.`,
+        );
+      }
+      const currentRuntime = params.sessionRuntime.resolveWorkerPlacementSessionRuntime({
+        cfg: config,
+        entry,
+        agentId: currentTarget.agentId,
+        sessionKey: currentTarget.canonicalKey,
+      });
+      if (
+        params.sessionRuntime.resolveWorkerPlacementExecutionMode(currentRuntime) !==
+        params.executionMode
+      ) {
+        throw new WorkerDispatchTargetChangedError(
+          `Session ${params.sessionKey} runtime changed to ${currentRuntime} before cloud worker ${params.action}. Retry.`,
+        );
+      }
+      return await params.run(worktree);
+    },
+  });
 }
 
 type SessionEntryShape = {

--- a/src/gateway/server-worker-placement-startup.test.ts
+++ b/src/gateway/server-worker-placement-startup.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { runExclusiveSessionLifecycleMutation } from "../sessions/session-lifecycle-admission.js";
 import { createDeferredCore } from "../shared/deferred.js";
 
 const runtimeFactoryMocks = vi.hoisted(() => ({
@@ -9,12 +10,29 @@ const runtimeFactoryMocks = vi.hoisted(() => ({
 }));
 const moveDestinationMocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(() => ({})),
+  findManagedWorktree: vi.fn(() => ({
+    id: "worktree-recovery",
+    ownerId: "agent:main:move-source",
+    path: "/gateway/workspace",
+  })),
+  resolveCanonicalSession: vi.fn(() => ({
+    sessionId: "session-recovery",
+    worktree: { id: "worktree-recovery" },
+  })),
   resolveExecutionMode: vi.fn(() => "remote-exec"),
+  resolveGatewaySessionTarget: vi.fn(() => ({
+    agentId: "main",
+    canonicalKey: "agent:main:move-source",
+    store: {},
+    storeKeys: ["agent:main:move-source"],
+    storePath: "/tmp/openclaw-worker-placement-session.sqlite",
+  })),
   resolveSessionRuntime: vi.fn(() => "codex"),
   resolveSessionTarget: vi.fn(() => ({
     config: {},
     entry: {},
     target: { agentId: "main", canonicalKey: "agent:main:move-source" },
+    worktree: { path: "/gateway/workspace" },
   })),
 }));
 
@@ -39,6 +57,25 @@ vi.mock("./worker-environments/placement-session-runtime.js", async (importOrigi
     ...actual,
     resolveWorkerPlacementExecutionMode: moveDestinationMocks.resolveExecutionMode,
     resolveWorkerPlacementSessionRuntime: moveDestinationMocks.resolveSessionRuntime,
+  };
+});
+
+vi.mock("./session-utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-utils.js")>();
+  return {
+    ...actual,
+    resolveCanonicalSessionEntryFromStoreKeys: moveDestinationMocks.resolveCanonicalSession,
+    resolveGatewaySessionStoreTargetWithStore: moveDestinationMocks.resolveGatewaySessionTarget,
+  };
+});
+
+vi.mock("../agents/worktrees/service.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../agents/worktrees/service.js")>();
+  return {
+    ...actual,
+    managedWorktrees: {
+      findLiveByOwner: moveDestinationMocks.findManagedWorktree,
+    },
   };
 });
 
@@ -95,6 +132,7 @@ describe("worker placement startup health lifetime", () => {
       reconcileActive,
     });
     const environments = {
+      installReconcileEnvironmentGuard: vi.fn(() => vi.fn()),
       start: vi.fn(),
       stop: vi.fn().mockResolvedValue(undefined),
     };
@@ -187,8 +225,10 @@ describe("worker placement startup health lifetime", () => {
       stateChangedAtMs: 1,
     } as const;
     const environments = {
+      installReconcileEnvironmentGuard: vi.fn(() => vi.fn()),
       start: vi.fn(),
       stop: vi.fn().mockResolvedValue(undefined),
+      stopNodeEnrollmentWaits: vi.fn(),
     };
     const runtime = createGatewayWorkerPlacementRuntime({
       placements: {
@@ -230,6 +270,7 @@ describe("worker placement startup health lifetime", () => {
     await Promise.resolve();
     expect(repeatedStop).toBe(stopping);
     expect(repeatedStopSettled).toBe(false);
+    expect(environments.stopNodeEnrollmentWaits).toHaveBeenCalledOnce();
     expect(environments.stop).not.toHaveBeenCalled();
     evidence.resolve("current");
     await expect(starting).resolves.toBeNull();
@@ -254,6 +295,7 @@ describe("worker placement startup health lifetime", () => {
       reconcileActive: vi.fn().mockResolvedValue(undefined),
     });
     const environments = {
+      installReconcileEnvironmentGuard: vi.fn(() => vi.fn()),
       start: vi.fn(),
       stop: vi.fn().mockRejectedValueOnce(stopError).mockResolvedValueOnce(undefined),
     };
@@ -287,6 +329,205 @@ describe("worker placement startup health lifetime", () => {
     await expect(sidecar.stop()).resolves.toBeUndefined();
 
     expect(environments.stop).toHaveBeenCalledTimes(2);
+  });
+
+  it("routes environment reconciliation through one exact provisioning owner", async () => {
+    type ReconcileGuard = (
+      environmentId: string,
+      reconcileCore: () => Promise<void>,
+    ) => Promise<void>;
+    let installedGuard: ReconcileGuard | undefined;
+    let placementRows: Array<{
+      sessionId: string;
+      state: "active" | "provisioning";
+      environmentId: string;
+    }> = [];
+    const resumeProvisioning = vi.fn(async (_placement, reconcileCore) => {
+      await reconcileCore();
+    });
+    const reconcile = vi.fn(async () => {
+      expect(installedGuard).toBeDefined();
+    });
+    runtimeFactoryMocks.createDiskSpace.mockReturnValue({
+      read: vi.fn(),
+      version: vi.fn(() => 0),
+      sweep: vi.fn().mockResolvedValue(undefined),
+    });
+    runtimeFactoryMocks.createDispatch.mockReturnValue({
+      dispatch: vi.fn(),
+      forceDestroyEnvironment: vi.fn(),
+      reclaim: vi.fn(),
+      reconcile,
+      reconcileActive: vi.fn().mockResolvedValue(undefined),
+      resumeProvisioning,
+    });
+    const environments = {
+      get: vi.fn((environmentId: string) => ({ environmentId, state: "provisioning" })),
+      installReconcileEnvironmentGuard: vi.fn((guard: ReconcileGuard) => {
+        installedGuard = guard;
+        return vi.fn();
+      }),
+      start: vi.fn(),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    const runtime = createGatewayWorkerPlacementRuntime({
+      placements: {
+        workspaceResultInstanceId: () => "gateway-test",
+        get: () => undefined,
+        list: () => placementRows,
+        retireSessionPlacement: vi.fn(),
+        pruneOrphanedWorkspaceReconciliations: () => [],
+        listWorkspaceReconciliationOwners: () => [],
+        listPendingWorkspaceResults: () => [],
+      } as never,
+      environments: environments as never,
+      gatewayNamespace: "gateway-test",
+      revokeSessionAuthority: vi.fn(),
+      warn: vi.fn(),
+    });
+    const sidecar = await runtime.startRuntime({
+      isClosePreludeStarted: () => false,
+      registerSidecar: vi.fn(),
+      unregisterSidecar: vi.fn(),
+    });
+    const guard = installedGuard;
+    if (!sidecar || !guard) {
+      throw new Error("worker placement reconcile guard was not installed");
+    }
+
+    const provisioning = {
+      sessionId: "session-guarded",
+      state: "provisioning" as const,
+      environmentId: "worker-guarded",
+    };
+    placementRows = [provisioning];
+    const exactCore = vi.fn(async () => {});
+    await guard(provisioning.environmentId, exactCore);
+    expect(resumeProvisioning).toHaveBeenCalledWith(provisioning, exactCore);
+    expect(exactCore).toHaveBeenCalledOnce();
+
+    placementRows = [];
+    const unrelatedCore = vi.fn(async () => {});
+    await guard("worker-unrelated", unrelatedCore);
+    expect(unrelatedCore).toHaveBeenCalledOnce();
+
+    placementRows = [
+      provisioning,
+      { sessionId: "session-duplicate", state: "active", environmentId: "worker-guarded" },
+    ];
+    const ambiguousCore = vi.fn(async () => {});
+    await expect(guard("worker-guarded", ambiguousCore)).rejects.toThrow(
+      "multiple placement owners",
+    );
+    expect(ambiguousCore).not.toHaveBeenCalled();
+
+    placementRows = [
+      { sessionId: "session-mismatch", state: "active", environmentId: "worker-mismatch" },
+    ];
+    const mismatchedCore = vi.fn(async () => {});
+    await expect(guard("worker-mismatch", mismatchedCore)).rejects.toThrow(
+      "provisioning owner is active",
+    );
+    expect(mismatchedCore).not.toHaveBeenCalled();
+    await sidecar.stop();
+  });
+
+  it("closes guarded recovery admission and drains it during environment stop", async () => {
+    type ReconcileGuard = (
+      environmentId: string,
+      reconcileCore: () => Promise<void>,
+    ) => Promise<void>;
+    const recoveryStarted = createDeferredCore();
+    const releaseRecovery = createDeferredCore();
+    const environmentStopStarted = createDeferredCore();
+    const events: string[] = [];
+    let installedGuard: ReconcileGuard | undefined;
+    const placement = {
+      sessionId: "session-close-guard",
+      state: "provisioning" as const,
+      environmentId: "worker-close-guard",
+    };
+    runtimeFactoryMocks.createDiskSpace.mockReturnValue({
+      read: vi.fn(),
+      version: vi.fn(() => 0),
+      sweep: vi.fn().mockResolvedValue(undefined),
+    });
+    runtimeFactoryMocks.createDispatch.mockReturnValue({
+      dispatch: vi.fn(),
+      forceDestroyEnvironment: vi.fn(),
+      reclaim: vi.fn(),
+      reconcile: vi.fn().mockResolvedValue(undefined),
+      reconcileActive: vi.fn().mockResolvedValue(undefined),
+      resumeProvisioning: vi.fn(async (_placement, reconcileCore) => {
+        events.push("recovery:start");
+        recoveryStarted.resolve();
+        await releaseRecovery.promise;
+        await reconcileCore();
+        events.push("recovery:end");
+      }),
+    });
+    const environments = {
+      get: vi.fn((environmentId: string) => ({ environmentId, state: "provisioning" })),
+      installReconcileEnvironmentGuard: vi.fn((guard: ReconcileGuard) => {
+        installedGuard = guard;
+        return async () => {
+          events.push("guard:uninstall");
+          await guardedRecovery;
+        };
+      }),
+      start: vi.fn(),
+      stop: vi.fn(async () => {
+        events.push("environments:stop");
+        environmentStopStarted.resolve();
+        await guardedRecovery;
+      }),
+    };
+    const runtime = createGatewayWorkerPlacementRuntime({
+      placements: {
+        workspaceResultInstanceId: () => "gateway-test",
+        get: () => placement,
+        list: () => [placement],
+        retireSessionPlacement: vi.fn(),
+        pruneOrphanedWorkspaceReconciliations: () => [],
+        listWorkspaceReconciliationOwners: () => [],
+        listPendingWorkspaceResults: () => [],
+      } as never,
+      environments: environments as never,
+      gatewayNamespace: "gateway-test",
+      revokeSessionAuthority: vi.fn(),
+      warn: vi.fn(),
+    });
+    const sidecar = await runtime.startRuntime({
+      isClosePreludeStarted: () => false,
+      registerSidecar: vi.fn(),
+      unregisterSidecar: vi.fn(),
+    });
+    const guard = installedGuard;
+    if (!sidecar || !guard) {
+      throw new Error("worker placement reconcile guard was not installed");
+    }
+    const reconcileCore = vi.fn(async () => {
+      events.push("reconcile:core");
+    });
+    const guardedRecovery = guard(placement.environmentId, reconcileCore);
+    await recoveryStarted.promise;
+
+    const stopping = sidecar.stop();
+    await environmentStopStarted.promise;
+    const postCloseCore = vi.fn(async () => {});
+    await guard("worker-after-close", postCloseCore);
+    expect(postCloseCore).not.toHaveBeenCalled();
+    expect(environments.stop).toHaveBeenCalledOnce();
+
+    releaseRecovery.resolve();
+    await Promise.all([guardedRecovery, stopping]);
+    expect(events).toEqual([
+      "recovery:start",
+      "environments:stop",
+      "reconcile:core",
+      "recovery:end",
+      "guard:uninstall",
+    ]);
   });
 });
 
@@ -350,5 +591,111 @@ describe("worker placement move destination", () => {
     expect(runMoveBarrier).not.toHaveBeenCalled();
     expect(reclaimSource).not.toHaveBeenCalled();
     expect(dispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("worker placement startup recovery authority", () => {
+  it("holds exact session authority through async recovery work", async () => {
+    runtimeFactoryMocks.createDiskSpace.mockReturnValue({
+      read: vi.fn(),
+      version: vi.fn(() => 0),
+      sweep: vi.fn().mockResolvedValue(undefined),
+    });
+    runtimeFactoryMocks.createDispatch.mockReturnValue({
+      dispatch: vi.fn(),
+      forceDestroyEnvironment: vi.fn(),
+      move: vi.fn(),
+      reclaim: vi.fn(),
+      reconcile: vi.fn(),
+      reconcileActive: vi.fn(),
+    });
+    const placement = {
+      state: "provisioning",
+      generation: 7,
+      environmentId: "worker-recovery",
+    };
+    createGatewayWorkerPlacementRuntime({
+      placements: {
+        workspaceResultInstanceId: () => "gateway-test",
+        get: () => placement,
+      } as never,
+      environments: {} as never,
+      gatewayNamespace: "gateway-test",
+      revokeSessionAuthority: vi.fn(),
+      warn: vi.fn(),
+    });
+    const dispatchOptions = runtimeFactoryMocks.createDispatch.mock.calls.at(-1)?.[0] as
+      | {
+          runRecoveryBarrier: (request: {
+            sessionId: string;
+            sessionKey: string;
+            agentId: string;
+            executionMode: "remote-exec";
+            environmentId: string;
+            expectedGeneration: number;
+            run: (localPath: string) => Promise<void>;
+          }) => Promise<void>;
+        }
+      | undefined;
+    if (!dispatchOptions) {
+      throw new Error("worker placement recovery barrier was not captured");
+    }
+    const request = {
+      sessionId: "session-recovery",
+      sessionKey: "agent:main:move-source",
+      agentId: "main",
+      executionMode: "remote-exec" as const,
+      environmentId: placement.environmentId,
+      expectedGeneration: placement.generation,
+    };
+    const releaseRecovery = createDeferredCore();
+    const events: string[] = [];
+    const recovery = dispatchOptions.runRecoveryBarrier({
+      ...request,
+      run: async (localPath) => {
+        events.push(`recovery:${localPath}`);
+        await releaseRecovery.promise;
+        events.push("recovery:done");
+      },
+    });
+    await vi.waitFor(() => expect(events).toEqual(["recovery:/gateway/workspace"]));
+    const contender = runExclusiveSessionLifecycleMutation({
+      scope: "/tmp/openclaw-worker-placement-session.sqlite",
+      identities: [
+        request.sessionKey,
+        "agent:main:move-source",
+        "agent:main:move-source",
+        request.sessionId,
+      ],
+      run: async () => {
+        events.push("contender");
+      },
+    });
+    await Promise.resolve();
+    expect(events).toEqual(["recovery:/gateway/workspace"]);
+    releaseRecovery.resolve();
+    await Promise.all([recovery, contender]);
+    expect(events).toEqual(["recovery:/gateway/workspace", "recovery:done", "contender"]);
+
+    moveDestinationMocks.resolveExecutionMode.mockReturnValueOnce("worker-turn");
+    await expect(
+      dispatchOptions.runRecoveryBarrier({ ...request, run: async () => {} }),
+    ).rejects.toThrow("runtime changed");
+
+    await expect(
+      dispatchOptions.runRecoveryBarrier({
+        ...request,
+        expectedGeneration: 8,
+        run: async () => {},
+      }),
+    ).rejects.toThrow("placement changed");
+
+    moveDestinationMocks.resolveCanonicalSession.mockReturnValueOnce({
+      sessionId: "session-replaced",
+      worktree: { id: "worktree-recovery" },
+    });
+    await expect(
+      dispatchOptions.runRecoveryBarrier({ ...request, run: async () => {} }),
+    ).rejects.toThrow("changed before cloud worker recovery");
   });
 });

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -15,9 +15,11 @@ import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { createGitHubPublicationRuntime } from "./github-publication-runtime.js";
 import type { NodeWorkerSupervisorTransport } from "./node-registry-private.js";
 import { createGatewayWorkerPlacementReclaimBarriers } from "./server-worker-placement-reclaim.js";
+import { installWorkerPlacementReconcileGuard } from "./server-worker-placement-reconcile-guard.js";
 import { createWorkerPlacementSessionEvidenceResolver } from "./server-worker-placement-session-evidence.js";
 import {
   resolveWorkerPlacementSessionTarget,
+  runWorkerPlacementSessionBarrier,
   WorkerDispatchTargetChangedError,
 } from "./server-worker-placement-session-target.js";
 import { createNodeWorkspaceRetainCoordinator } from "./worker-environments/node-workspace-retain-coordinator.js";
@@ -273,68 +275,51 @@ export function createGatewayWorkerPlacementRuntime(
         executionMode,
         authorize,
         activate,
-      }) => {
-        const sessionRuntime = await loadWorkerPlacementSessionRuntimeModule();
-        const {
-          resolveWorkerPlacementExecutionMode,
-          resolveGatewaySessionStoreTargetWithStore,
-          resolveWorkerPlacementSessionRuntime,
-        } = sessionRuntime;
-        const target = resolveGatewaySessionStoreTargetWithStore({
-          cfg: getRuntimeConfig(),
-          key: sessionKey,
-          agentId,
-          clone: false,
-        });
-        const lifecycleIdentities = [
-          sessionKey,
-          target.canonicalKey,
-          ...target.storeKeys,
+      }) =>
+        await runWorkerPlacementSessionBarrier({
+          sessionRuntime: await loadWorkerPlacementSessionRuntimeModule(),
+          getConfig: getRuntimeConfig,
           sessionId,
-        ];
-        let activePlacement: ReturnType<typeof activate> | undefined;
-        await runExclusiveSessionLifecycleMutation({
-          scope: target.storePath,
-          identities: lifecycleIdentities,
-          run: async () => {
-            const {
-              config: currentConfig,
-              target: currentTarget,
-              entry: currentEntry,
-            } = resolveWorkerPlacementSessionTarget({
-              sessionRuntime,
-              config: getRuntimeConfig(),
-              sessionId,
-              sessionKey,
-              agentId,
-              expectedTarget: target,
-              errorMessage: `Session ${sessionKey} changed before cloud worker activation. Retry.`,
-            });
-            if (currentEntry.archivedAt !== undefined) {
-              throw new WorkerDispatchTargetChangedError(
-                `Session ${sessionKey} was archived before cloud worker activation. Retry.`,
-              );
-            }
-            const currentRuntime = resolveWorkerPlacementSessionRuntime({
-              cfg: currentConfig,
-              entry: currentEntry,
-              agentId: currentTarget.agentId,
-              sessionKey: currentTarget.canonicalKey,
-            });
-            if (resolveWorkerPlacementExecutionMode(currentRuntime) !== executionMode) {
-              throw new WorkerDispatchTargetChangedError(
-                `Session ${sessionKey} runtime changed to ${currentRuntime} before cloud worker activation. Retry.`,
-              );
-            }
+          sessionKey,
+          agentId,
+          executionMode,
+          action: "activation",
+          run: () => {
             authorize?.();
-            activePlacement = activate();
+            return activate();
           },
-        });
-        if (!activePlacement) {
-          throw new Error(`Session ${sessionKey} activation barrier did not complete`);
-        }
-        return activePlacement;
-      },
+        }),
+      runRecoveryBarrier: async ({
+        sessionId,
+        sessionKey,
+        agentId,
+        executionMode,
+        environmentId,
+        expectedGeneration,
+        run,
+      }) =>
+        await runWorkerPlacementSessionBarrier({
+          sessionRuntime: await loadWorkerPlacementSessionRuntimeModule(),
+          getConfig: getRuntimeConfig,
+          sessionId,
+          sessionKey,
+          agentId,
+          executionMode,
+          action: "recovery",
+          run: async (worktree) => {
+            const placement = params.placements.get(sessionId);
+            if (
+              placement?.state !== "provisioning" ||
+              placement.generation !== expectedGeneration ||
+              placement.environmentId !== environmentId
+            ) {
+              throw new WorkerDispatchTargetChangedError(
+                `Session ${sessionKey} placement changed before cloud worker recovery. Retry.`,
+              );
+            }
+            await run(worktree.path);
+          },
+        }),
       onActivated: (request) => {
         if (request.deviceId) {
           void nodeWorkspaceRetention.schedule(request.deviceId);
@@ -545,6 +530,12 @@ export function createGatewayWorkerPlacementRuntime(
     const placementReconcile = { current: undefined as Promise<void> | undefined };
     const diskSpaceSweep = { current: undefined as Promise<void> | undefined };
     let stopped = false;
+    const uninstallEnvironmentReconcileGuard = installWorkerPlacementReconcileGuard({
+      placements: params.placements,
+      environments: params.environments,
+      dispatch: dispatchService,
+      isStopping: () => stopped,
+    });
     const trackOperation = (
       slot: { current: Promise<void> | undefined },
       current: Promise<void>,
@@ -614,6 +605,8 @@ export function createGatewayWorkerPlacementRuntime(
         }
         if (!stopped) {
           stopped = true;
+          // Cancel only enrollment: admitted recovery may still finish attaching before service stop.
+          params.environments.stopNodeEnrollmentWaits?.();
           clearInterval(placementReconcileInterval);
           placementReconcileInterval = undefined;
           uninstallSessionIdentityMutation();
@@ -627,6 +620,7 @@ export function createGatewayWorkerPlacementRuntime(
           );
           await nodeWorkspaceRetention.stop();
           await params.environments.stop();
+          await uninstallEnvironmentReconcileGuard();
         })();
         stopPromise = currentStop;
         void currentStop.catch(() => {

--- a/src/gateway/server-ws-runtime.ts
+++ b/src/gateway/server-ws-runtime.ts
@@ -33,6 +33,7 @@ export function attachGatewayWsHandlers(params: GatewayWsRuntimeParams) {
     nodeReapprovalCoordinator: params.nodeReapprovalCoordinator,
     preauthHandshakeTimeoutMs: params.preauthHandshakeTimeoutMs,
     isStartupPending: params.isStartupPending,
+    isPendingWorkerNodeSetup: params.isPendingWorkerNodeSetup,
     gatewayMethods: params.gatewayMethods,
     events: params.events,
     refreshHealthSnapshot: params.context.refreshHealthSnapshot,

--- a/src/gateway/server.node-pairing-rate-limit.test.ts
+++ b/src/gateway/server.node-pairing-rate-limit.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { describe, expect, test, vi } from "vitest";
 import { WebSocket } from "ws";
 import { ConnectErrorDetailCodes } from "../../packages/gateway-protocol/src/connect-error-details.js";
+import { GATEWAY_STARTUP_UNAVAILABLE_REASON } from "../../packages/gateway-protocol/src/startup-unavailable.js";
 import {
   loadOrCreateDeviceIdentity,
   publicKeyRawBase64UrlFromPem,
@@ -17,7 +18,7 @@ import {
   listNodePairing,
   requestNodePairing,
 } from "../infra/device-pairing-node.js";
-import { requestDevicePairing } from "../infra/device-pairing.js";
+import { listDevicePairing, requestDevicePairing } from "../infra/device-pairing.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import type { NodeRegistry } from "./node-registry.js";
 import * as gatewayWsRuntime from "./server-ws-runtime.js";
@@ -51,7 +52,7 @@ async function openWs(port: number) {
 async function attemptNodePairing(
   port: number,
   identityPath: string,
-  surface: { caps?: string[]; commands?: string[] } = {},
+  surface: { caps?: string[]; commands?: string[]; device?: null } = {},
 ) {
   const ws = await openWs(port);
   try {
@@ -61,7 +62,7 @@ async function attemptNodePairing(
       scopes: [],
       client: NODE_CLIENT,
       commands: surface.commands ?? ["system.run"],
-      deviceIdentityPath: identityPath,
+      ...(surface.device === null ? { device: null } : { deviceIdentityPath: identityPath }),
       ...(surface.caps ? { caps: surface.caps } : {}),
     });
   } finally {
@@ -152,6 +153,59 @@ describe("node pairing rate limit", () => {
       await rm(identityDir, { recursive: true, force: true });
     }
   });
+
+  test.each([
+    ["unpaired", false, false],
+    ["device-paired without an approved node surface", true, false],
+    ["without a device identity", false, true],
+  ] as const)(
+    "rejects a %s shared-token node during startup without creating pairing requests",
+    async (_pairingState, approveDevice, omitDevice) => {
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      const identityDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-node-startup-unpaired-"));
+      const attachGatewayWsHandlers = gatewayWsRuntime.attachGatewayWsHandlers;
+      const startupAdmission = vi
+        .spyOn(gatewayWsRuntime, "attachGatewayWsHandlers")
+        .mockImplementation((params) =>
+          attachGatewayWsHandlers({ ...params, isStartupPending: () => true }),
+        );
+
+      try {
+        await withGatewayServer(async ({ port }) => {
+          const identityPath = path.join(identityDir, "identity.sqlite");
+          if (approveDevice) {
+            const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+            const pairing = await requestDevicePairing({
+              deviceId: identity.deviceId,
+              publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+              role: "node",
+              roles: ["node"],
+              scopes: [],
+            });
+            await approveDevicePairing(pairing.request.requestId, { callerScopes: [] });
+          }
+          const response = await attemptNodePairing(
+            port,
+            identityPath,
+            omitDevice ? { device: null } : {},
+          );
+
+          expect(response).toMatchObject({
+            ok: false,
+            error: {
+              code: "UNAVAILABLE",
+              details: { reason: GATEWAY_STARTUP_UNAVAILABLE_REASON },
+            },
+          });
+          expect((await listDevicePairing()).pending).toHaveLength(0);
+          expect((await listNodePairing()).pending).toHaveLength(0);
+        });
+      } finally {
+        startupAdmission.mockRestore();
+        await rm(identityDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("limits concurrent first-time node pairing requests before the pairing lock", async () => {
     testState.gatewayAuth = {

--- a/src/gateway/server.preauth-hardening.test.ts
+++ b/src/gateway/server.preauth-hardening.test.ts
@@ -2,6 +2,7 @@
  * Gateway pre-auth hardening tests.
  */
 import http from "node:http";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer } from "ws";
 import {
@@ -526,6 +527,75 @@ describe("gateway pre-auth hardening", () => {
       });
     } finally {
       await harness.close();
+    }
+  });
+
+  it("opens only the startup generation core preauth transport during restart drain", async () => {
+    const clients = new Set<GatewayWsClient>();
+    const resolvedAuth: ResolvedGatewayAuth = { mode: "none", allowTailscale: false };
+    const httpServer = createGatewayHttpServer({
+      clients,
+      controlUiEnabled: false,
+      controlUiBasePath: "/__control__",
+      openAiChatCompletionsEnabled: false,
+      openResponsesEnabled: false,
+      handleHooksRequest: async () => false,
+      resolvedAuth,
+    });
+    const wss = new WebSocketServer({ maxPayload: 1024, noServer: true });
+    wss.on("connection", (socket) => {
+      socket.send(
+        JSON.stringify({
+          type: "event",
+          event: "connect.challenge",
+          payload: { nonce: "startup-preauth", ts: Date.now() },
+        }),
+      );
+    });
+    attachGatewayUpgradeHandler({
+      httpServer,
+      wss,
+      clients,
+      preauthConnectionBudget: createPreauthConnectionBudget(1),
+      resolvedAuth,
+      isStartupPending: () => true,
+      workerIngressEnabled: true,
+    });
+    await new Promise<void>((resolve) => {
+      httpServer.listen(0, "127.0.0.1", resolve);
+    });
+    const address = httpServer.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    markGatewayRestartDraining();
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    const challenge = new Promise<string>((resolve) => {
+      ws.once("message", (data) => {
+        const frame = JSON.parse(rawDataToString(data)) as { payload?: { nonce?: unknown } };
+        const nonce = frame.payload?.nonce;
+        resolve(typeof nonce === "string" ? nonce : "");
+      });
+    });
+
+    try {
+      await new Promise<void>((resolve) => {
+        ws.once("open", resolve);
+      });
+      await expect(challenge).resolves.toBe("startup-preauth");
+      await expect(requestUpgradeRejection(port, WORKER_PUBLIC_INGRESS_PATH)).resolves.toEqual({
+        status: 503,
+        body: "Worker websocket admission closed",
+      });
+    } finally {
+      ws.close();
+      await new Promise<void>((resolve) => {
+        ws.once("close", () => resolve());
+      });
+      await new Promise<void>((resolve) => {
+        wss.close(() => resolve());
+      });
+      await new Promise<void>((resolve, reject) => {
+        httpServer.close((error) => (error ? reject(error) : resolve()));
+      });
     }
   });
 

--- a/src/gateway/server.sessions.worker-original-order.test.ts
+++ b/src/gateway/server.sessions.worker-original-order.test.ts
@@ -411,6 +411,7 @@ test("preserves ordered fallback through restart, workspace sync, and safe sessi
     },
     workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
     runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+    runRecoveryBarrier: async ({ run }) => await run(localWorkspace),
     runActivationBarrier: async ({ activate }) => activate(),
     runMoveBarrier: async ({ begin }) => begin(),
     resolveMoveDestination: async () => undefined,

--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -26,6 +26,9 @@ import {
   publicKeyRawBase64UrlFromPem,
   signDevicePayload,
 } from "../../infra/device-identity.js";
+import { approveDevicePairing } from "../../infra/device-pairing-approval.js";
+import { approveNodePairing, requestNodePairing } from "../../infra/device-pairing-node.js";
+import { requestDevicePairing } from "../../infra/device-pairing.js";
 import { createSafeGatewayRestartPreflight } from "../../infra/restart-coordinator.js";
 import {
   getActiveGatewayRootWorkCount,
@@ -69,7 +72,9 @@ afterEach(() => {
 });
 
 async function attachStartupNodeConnect(params: {
-  bootstrapToken: string;
+  bootstrapToken?: string;
+  sharedToken?: string;
+  gatewayToken?: string;
   identityPath: string;
   isPendingWorkerNodeSetup: (setupId: string, deviceId: string) => boolean;
   rateLimiter?: ReturnType<typeof createAuthRateLimiter>;
@@ -134,7 +139,14 @@ async function attachStartupNodeConnect(params: {
     clients,
     socket,
     options: {
-      getResolvedAuth: () => ({ mode: "none", allowTailscale: false }),
+      getResolvedAuth: () =>
+        params.sharedToken
+          ? {
+              mode: "token",
+              token: params.gatewayToken ?? params.sharedToken,
+              allowTailscale: false,
+            }
+          : { mode: "none", allowTailscale: false },
       isStartupPending: () => true,
       isPendingWorkerNodeSetup: pendingSetup,
       rateLimiter: params.rateLimiter,
@@ -161,7 +173,7 @@ async function attachStartupNodeConnect(params: {
     role: "node",
     scopes: [],
     signedAtMs: signedAt,
-    token: params.bootstrapToken,
+    token: params.sharedToken ?? params.bootstrapToken,
     nonce,
   });
   markGatewayRestartDraining();
@@ -184,7 +196,10 @@ async function attachStartupNodeConnect(params: {
         scopes: [],
         caps: [],
         commands: [],
-        auth: { bootstrapToken: params.bootstrapToken },
+        auth: {
+          ...(params.bootstrapToken ? { bootstrapToken: params.bootstrapToken } : {}),
+          ...(params.sharedToken ? { token: params.sharedToken } : {}),
+        },
         device: {
           id: identity.deviceId,
           publicKey,
@@ -531,66 +546,94 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
     },
   );
 
-  it("keeps restart-startup authentication tracked until its node mutation and handshake settle", async () => {
-    await withOpenClawTestState(
-      { label: "gateway-startup-cloud-worker-drain-race", layout: "state-only" },
-      async (state) => {
-        const { store, setupId } = seedProvisioningNodeSetup();
-        const issued = await ensureDevicePairSetupBootstrapToken({
-          setupId,
-          profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
-        });
-        if (issued.status !== "pending") {
-          throw new Error("expected pending cloud-worker setup token");
-        }
-        const authenticationStarted = createDeferred();
-        const releaseAuthentication = createDeferred();
-        const registeredRootCounts: number[] = [];
-        const authorize = gatewayAuth.authorizeWsControlUiGatewayConnect;
-        const authentication = vi
-          .spyOn(gatewayAuth, "authorizeWsControlUiGatewayConnect")
-          .mockImplementationOnce(async (params) => {
-            authenticationStarted.resolve();
-            await releaseAuthentication.promise;
+  it.each(["cloud bootstrap", "paired shared-token"] as const)(
+    "keeps restart-startup %s authentication tracked until its node mutation and handshake settle",
+    async (connectionKind) => {
+      await withOpenClawTestState(
+        { label: "gateway-startup-cloud-worker-drain-race", layout: "state-only" },
+        async (state) => {
+          const { store, setupId } = seedProvisioningNodeSetup();
+          const issued = await ensureDevicePairSetupBootstrapToken({
+            setupId,
+            profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+          });
+          if (issued.status !== "pending") {
+            throw new Error("expected pending cloud-worker setup token");
+          }
+          const identityPath = state.path("startup-drain-race-node.sqlite");
+          if (connectionKind === "paired shared-token") {
+            const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+            const devicePairing = await requestDevicePairing({
+              deviceId: identity.deviceId,
+              publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+              role: "node",
+              roles: ["node"],
+              scopes: [],
+            });
+            await approveDevicePairing(devicePairing.request.requestId, { callerScopes: [] });
+            const nodePairing = await requestNodePairing({
+              nodeId: identity.deviceId,
+              platform: "linux",
+              caps: [],
+            });
+            await approveNodePairing(nodePairing.request.requestId, {
+              callerScopes: ["operator.pairing"],
+            });
+          }
+          const authenticationStarted = createDeferred();
+          const releaseAuthentication = createDeferred();
+          const registeredRootCounts: number[] = [];
+          const authorize = gatewayAuth.authorizeWsControlUiGatewayConnect;
+          const authentication = vi
+            .spyOn(gatewayAuth, "authorizeWsControlUiGatewayConnect")
+            .mockImplementationOnce(async (params) => {
+              authenticationStarted.resolve();
+              await releaseAuthentication.promise;
+              expect(getActiveGatewayRootWorkCount()).toBe(1);
+              return await authorize(params);
+            });
+          try {
+            const harness = await attachStartupNodeConnect({
+              ...(connectionKind === "cloud bootstrap"
+                ? { bootstrapToken: issued.token }
+                : { sharedToken: "startup-shared-token" }),
+              identityPath,
+              isPendingWorkerNodeSetup: (candidateSetupId, deviceId) =>
+                store.hasPendingNodeEnrollmentSetup(candidateSetupId, deviceId),
+              onNodeRegistered: () => registeredRootCounts.push(getActiveGatewayRootWorkCount()),
+            });
+
+            await authenticationStarted.promise;
             expect(getActiveGatewayRootWorkCount()).toBe(1);
-            return await authorize(params);
-          });
-        try {
-          const harness = await attachStartupNodeConnect({
-            bootstrapToken: issued.token,
-            identityPath: state.path("startup-drain-race-node.sqlite"),
-            isPendingWorkerNodeSetup: (candidateSetupId, deviceId) =>
-              store.hasPendingNodeEnrollmentSetup(candidateSetupId, deviceId),
-            onNodeRegistered: () => registeredRootCounts.push(getActiveGatewayRootWorkCount()),
-          });
+            expect(createSafeGatewayRestartPreflight()).toMatchObject({
+              safe: false,
+              counts: { rootRequests: 1 },
+            });
+            expect(harness.nodeRegistry.register).not.toHaveBeenCalled();
 
-          await authenticationStarted.promise;
-          expect(getActiveGatewayRootWorkCount()).toBe(1);
-          expect(createSafeGatewayRestartPreflight()).toMatchObject({
-            safe: false,
-            counts: { rootRequests: 1 },
-          });
-          expect(harness.nodeRegistry.register).not.toHaveBeenCalled();
-
-          releaseAuthentication.resolve();
-          await expect(harness.responseReceived).resolves.toMatchObject({ ok: true });
-          expect(registeredRootCounts).toEqual([1]);
-          await new Promise<void>((resolve) => {
-            setImmediate(resolve);
-          });
-          expect(getActiveGatewayRootWorkCount()).toBe(0);
-          expect(createSafeGatewayRestartPreflight()).toMatchObject({
-            safe: true,
-            counts: { rootRequests: 0 },
-          });
-          harness.socket.emit("close", 1000, Buffer.from("done"));
-        } finally {
-          releaseAuthentication.resolve();
-          authentication.mockRestore();
-        }
-      },
-    );
-  });
+            releaseAuthentication.resolve();
+            await expect(harness.responseReceived).resolves.toMatchObject({ ok: true });
+            expect(registeredRootCounts).toEqual([1]);
+            if (connectionKind === "paired shared-token") {
+              expect(harness.pendingSetup).not.toHaveBeenCalled();
+            }
+            await new Promise<void>((resolve) => {
+              setImmediate(resolve);
+            });
+            expect(getActiveGatewayRootWorkCount()).toBe(0);
+            expect(createSafeGatewayRestartPreflight()).toMatchObject({
+              safe: true,
+              counts: { rootRequests: 0 },
+            });
+            harness.socket.emit("close", 1000, Buffer.from("done"));
+          } finally {
+            releaseAuthentication.resolve();
+            authentication.mockRestore();
+          }
+        },
+      );
+    },
+  );
 
   it("keeps non-cloud and wrong cloud setup tokens startup-unavailable", async () => {
     await withOpenClawTestState(
@@ -652,44 +695,50 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
     );
   });
 
-  it("rate-limits an invalid startup token without consulting setup state", async () => {
-    await withOpenClawTestState(
-      { label: "gateway-startup-cloud-worker-invalid", layout: "state-only" },
-      async (state) => {
-        const { store } = seedProvisioningNodeSetup();
-        const rateLimiter = createAuthRateLimiter({
-          maxAttempts: 1,
-          windowMs: 60_000,
-          lockoutMs: 60_000,
-          exemptLoopback: false,
-        });
-        try {
-          const harness = await attachStartupNodeConnect({
-            bootstrapToken: "invalid-startup-token",
-            identityPath: state.path("invalid-token-node.sqlite"),
-            isPendingWorkerNodeSetup: (candidateSetupId, deviceId) =>
-              store.hasPendingNodeEnrollmentSetup(candidateSetupId, deviceId),
-            rateLimiter,
+  it.each(["exact bootstrap", "mixed bootstrap and shared token"] as const)(
+    "keeps an invalid %s opaque and rate-limited without consulting setup state",
+    async (credentialShape) => {
+      await withOpenClawTestState(
+        { label: "gateway-startup-cloud-worker-invalid", layout: "state-only" },
+        async (state) => {
+          const { store } = seedProvisioningNodeSetup();
+          const rateLimiter = createAuthRateLimiter({
+            maxAttempts: 1,
+            windowMs: 60_000,
+            lockoutMs: 60_000,
+            exemptLoopback: false,
           });
+          try {
+            const harness = await attachStartupNodeConnect({
+              bootstrapToken: "invalid-startup-token",
+              ...(credentialShape === "mixed bootstrap and shared token"
+                ? { sharedToken: "invalid-shared-token", gatewayToken: "expected-shared-token" }
+                : {}),
+              identityPath: state.path("invalid-token-node.sqlite"),
+              isPendingWorkerNodeSetup: (candidateSetupId, deviceId) =>
+                store.hasPendingNodeEnrollmentSetup(candidateSetupId, deviceId),
+              rateLimiter,
+            });
 
-          await expect(harness.response()).resolves.toMatchObject({
-            ok: false,
-            error: {
-              code: "UNAVAILABLE",
-              retryable: true,
-              details: { reason: GATEWAY_STARTUP_UNAVAILABLE_REASON },
-            },
-          });
-          expect(harness.pendingSetup).not.toHaveBeenCalled();
-          expect(harness.nodeRegistry.register).not.toHaveBeenCalled();
-          expect(
-            rateLimiter.check("127.0.0.1", AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN).allowed,
-          ).toBe(false);
-          harness.socket.emit("close", GATEWAY_STARTUP_CLOSE_CODE, Buffer.alloc(0));
-        } finally {
-          rateLimiter.dispose();
-        }
-      },
-    );
-  });
+            await expect(harness.response()).resolves.toMatchObject({
+              ok: false,
+              error: {
+                code: "UNAVAILABLE",
+                retryable: true,
+                details: { reason: GATEWAY_STARTUP_UNAVAILABLE_REASON },
+              },
+            });
+            expect(harness.pendingSetup).not.toHaveBeenCalled();
+            expect(harness.nodeRegistry.register).not.toHaveBeenCalled();
+            expect(
+              rateLimiter.check("127.0.0.1", AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN).allowed,
+            ).toBe(false);
+            harness.socket.emit("close", GATEWAY_STARTUP_CLOSE_CODE, Buffer.alloc(0));
+          } finally {
+            rateLimiter.dispose();
+          }
+        },
+      );
+    },
+  );
 });

--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -1,7 +1,7 @@
 /**
  * WebSocket connection startup regression tests.
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   GATEWAY_CLIENT_MODES,
   GATEWAY_CLIENT_NAMES,
@@ -14,6 +14,40 @@ import {
   GATEWAY_STARTUP_UNAVAILABLE_REASON,
 } from "../../../packages/gateway-protocol/src/startup-unavailable.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import {
+  consumeDeviceBootstrapTokenWithSetupCompletion,
+  ensureDevicePairSetupBootstrapToken,
+  issueDevicePairSetupBootstrapToken,
+  readDevicePairSetupCompletion,
+  verifyDeviceBootstrapToken,
+} from "../../infra/device-bootstrap.js";
+import {
+  loadOrCreateDeviceIdentity,
+  publicKeyRawBase64UrlFromPem,
+  signDevicePayload,
+} from "../../infra/device-identity.js";
+import { createSafeGatewayRestartPreflight } from "../../infra/restart-coordinator.js";
+import {
+  getActiveGatewayRootWorkCount,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+} from "../../process/gateway-work-admission.js";
+import {
+  CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+  NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+} from "../../shared/device-bootstrap-profile.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import {
+  AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN,
+  createAuthRateLimiter,
+} from "../auth-rate-limit.js";
+import * as gatewayAuth from "../auth.js";
+import { buildDeviceAuthPayload } from "../device-auth.js";
+import { createWorkerEnvironmentStore } from "../worker-environments/store.js";
 import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
 import {
   attachGatewayWsForTest,
@@ -21,6 +55,196 @@ import {
   createGatewayWsTestRequestContext,
   createGatewayWsTestSocket,
 } from "./ws-connection.test-helpers.js";
+
+type StartupConnectResponse = {
+  type?: unknown;
+  id?: unknown;
+  ok?: unknown;
+  error?: { code?: unknown; retryable?: unknown; details?: unknown };
+};
+
+afterEach(() => {
+  resetGatewayWorkAdmission();
+  closeOpenClawStateDatabaseForTest();
+});
+
+async function attachStartupNodeConnect(params: {
+  bootstrapToken: string;
+  identityPath: string;
+  isPendingWorkerNodeSetup: (setupId: string, deviceId: string) => boolean;
+  rateLimiter?: ReturnType<typeof createAuthRateLimiter>;
+  onNodeRegistered?: () => void;
+}) {
+  const sent: unknown[] = [];
+  const connectResponse = createDeferred<StartupConnectResponse>();
+  const clients = new Set<unknown>();
+  const socket = createGatewayWsTestSocket({
+    onSend: (data) => {
+      const frame = JSON.parse(data) as StartupConnectResponse;
+      sent.push(frame);
+      if (frame.id === "startup-node-connect") {
+        connectResponse.resolve(frame);
+      }
+    },
+  });
+  let registeredNode:
+    | {
+        nodeId: string;
+        connId: string;
+        displayName: string;
+        platform: string;
+        commands: string[];
+        connectedAtMs: number;
+        pairingGeneration?: string;
+      }
+    | undefined;
+  const nodeRegistry = {
+    register: vi.fn(
+      (client: { connId: string; connect: { device?: { id?: string } } }, options) => {
+        params.onNodeRegistered?.();
+        registeredNode = {
+          nodeId: client.connect.device?.id ?? "node-host",
+          connId: client.connId,
+          displayName: "Cloud worker",
+          platform: "linux",
+          commands: [],
+          connectedAtMs: Date.now(),
+          ...(options.pairingGeneration
+            ? { pairingGeneration: String(options.pairingGeneration) }
+            : {}),
+        };
+        return registeredNode;
+      },
+    ),
+    get: vi.fn(() => undefined),
+    getForPairingGeneration: vi.fn(() => undefined),
+    unregister: vi.fn(() => registeredNode?.nodeId ?? null),
+    sendEventRawForPairingGeneration: vi.fn(async () => {}),
+    sendEventForPairingIdentity: vi.fn(async () => {}),
+  };
+  const requestContext = {
+    ...createGatewayWsTestRequestContext(),
+    nodeRegistry,
+    broadcast: vi.fn(),
+    nodeUnsubscribeAll: vi.fn(),
+  };
+  const pendingSetup = vi.fn(params.isPendingWorkerNodeSetup);
+  attachGatewayWsForTest({
+    attach: attachGatewayWsConnectionHandler,
+    clients,
+    socket,
+    options: {
+      getResolvedAuth: () => ({ mode: "none", allowTailscale: false }),
+      isStartupPending: () => true,
+      isPendingWorkerNodeSetup: pendingSetup,
+      rateLimiter: params.rateLimiter,
+      buildRequestContext: () => requestContext as never,
+    },
+  });
+  const challenge = sent.find(
+    (frame) =>
+      typeof frame === "object" &&
+      frame !== null &&
+      (frame as { event?: unknown }).event === "connect.challenge",
+  ) as { payload?: { nonce?: unknown } } | undefined;
+  const nonce = challenge?.payload?.nonce;
+  if (typeof nonce !== "string") {
+    throw new Error("startup node connect challenge was not sent");
+  }
+  const identity = loadOrCreateDeviceIdentity({ path: params.identityPath });
+  const publicKey = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
+  const signedAt = Date.now();
+  const devicePayload = buildDeviceAuthPayload({
+    deviceId: identity.deviceId,
+    clientId: GATEWAY_CLIENT_NAMES.NODE_HOST,
+    clientMode: GATEWAY_CLIENT_MODES.NODE,
+    role: "node",
+    scopes: [],
+    signedAtMs: signedAt,
+    token: params.bootstrapToken,
+    nonce,
+  });
+  markGatewayRestartDraining();
+  socket.emit(
+    "message",
+    JSON.stringify({
+      type: "req",
+      id: "startup-node-connect",
+      method: "connect",
+      params: {
+        minProtocol: PROTOCOL_VERSION,
+        maxProtocol: PROTOCOL_VERSION,
+        client: {
+          id: GATEWAY_CLIENT_NAMES.NODE_HOST,
+          version: "dev",
+          platform: "linux",
+          mode: GATEWAY_CLIENT_MODES.NODE,
+        },
+        role: "node",
+        scopes: [],
+        caps: [],
+        commands: [],
+        auth: { bootstrapToken: params.bootstrapToken },
+        device: {
+          id: identity.deviceId,
+          publicKey,
+          signature: signDevicePayload(identity.privateKeyPem, devicePayload),
+          signedAt,
+          nonce,
+        },
+      },
+    }),
+  );
+  const response = async () => {
+    await vi.waitFor(() => {
+      expect(
+        sent.some(
+          (frame) =>
+            typeof frame === "object" &&
+            frame !== null &&
+            (frame as StartupConnectResponse).id === "startup-node-connect",
+        ),
+      ).toBe(true);
+    });
+    return sent.find(
+      (frame) =>
+        typeof frame === "object" &&
+        frame !== null &&
+        (frame as StartupConnectResponse).id === "startup-node-connect",
+    ) as StartupConnectResponse;
+  };
+  return {
+    clients,
+    identity,
+    nodeRegistry,
+    pendingSetup,
+    response,
+    responseReceived: connectResponse.promise,
+    sent,
+    socket,
+  };
+}
+
+function seedProvisioningNodeSetup() {
+  const store = createWorkerEnvironmentStore();
+  const intent = store.createIntent({
+    environmentId: "startup-worker-environment",
+    providerId: "startup-provider",
+    profileId: "startup-profile",
+    profileSnapshot: { settings: {} },
+    provisionOperationId: "provision:startup-worker-environment",
+  });
+  store.transition({
+    environmentId: intent.environmentId,
+    from: intent.state,
+    to: "provisioning",
+  });
+  const setupId = store.ensureNodeEnrollment(intent.environmentId).nodeSetupId;
+  if (!setupId) {
+    throw new Error("startup worker setup id was not persisted");
+  }
+  return { store, setupId };
+}
 
 describe("attachGatewayWsConnectionHandler startup readiness", () => {
   it("admits only one of two connect frames that race during lazy handler loading", async () => {
@@ -177,4 +401,295 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
       );
     },
   );
+
+  it("admits the exact cloud-worker setup node through restart startup", async () => {
+    await withOpenClawTestState(
+      { label: "gateway-startup-cloud-worker", layout: "state-only" },
+      async (state) => {
+        const { store, setupId } = seedProvisioningNodeSetup();
+        const issued = await ensureDevicePairSetupBootstrapToken({
+          setupId,
+          profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+        });
+        if (issued.status !== "pending") {
+          throw new Error("expected pending cloud-worker setup token");
+        }
+        const harness = await attachStartupNodeConnect({
+          bootstrapToken: issued.token,
+          identityPath: state.path("startup-node.sqlite"),
+          isPendingWorkerNodeSetup: (candidateSetupId, deviceId) =>
+            store.hasPendingNodeEnrollmentSetup(candidateSetupId, deviceId),
+        });
+
+        await expect(harness.response()).resolves.toMatchObject({
+          ok: true,
+          payload: { type: "hello-ok", auth: { role: "node", scopes: [] } },
+        });
+        expect(harness.clients.size).toBe(1);
+        expect(harness.nodeRegistry.register).toHaveBeenCalledOnce();
+        expect(harness.pendingSetup).toHaveBeenCalledWith(setupId, harness.identity.deviceId);
+        expect(store.get("startup-worker-environment")).toMatchObject({
+          state: "provisioning",
+          nodeSetupId: setupId,
+          nodeDeviceId: harness.identity.deviceId,
+          destroyRequestedAtMs: null,
+        });
+        expect(store.hasPendingNodeEnrollmentSetup(setupId, harness.identity.deviceId)).toBe(true);
+        harness.socket.emit("close", 1000, Buffer.from("done"));
+      },
+    );
+  });
+
+  it.each([
+    ["provisioning", false],
+    ["bootstrapping", false],
+    ["ready", false],
+    ["idle", false],
+    ["attached", false],
+    ["provisioning", true],
+  ] as const)(
+    "admits same-device uncertain startup setup retry in %s unless destroy was requested (%s)",
+    async (environmentState, destroyRequested) => {
+      await withOpenClawTestState(
+        { label: "gateway-startup-cloud-worker-uncertain-retry", layout: "state-only" },
+        async (state) => {
+          const { store, setupId } = seedProvisioningNodeSetup();
+          const issued = await ensureDevicePairSetupBootstrapToken({
+            setupId,
+            profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+          });
+          if (issued.status !== "pending") {
+            throw new Error("expected pending cloud-worker setup token");
+          }
+          const identityPath = state.path("startup-retrying-node.sqlite");
+          const identity = loadOrCreateDeviceIdentity({ path: identityPath });
+          const verification = {
+            token: issued.token,
+            deviceId: identity.deviceId,
+            publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+            role: "node",
+            scopes: [],
+          };
+          await expect(verifyDeviceBootstrapToken(verification)).resolves.toEqual({ ok: true });
+          await expect(
+            consumeDeviceBootstrapTokenWithSetupCompletion({
+              token: issued.token,
+              deviceId: identity.deviceId,
+              completedAtMs: Date.now(),
+            }),
+          ).resolves.toMatchObject({ completion: { deliveryState: "uncertain" } });
+          if (environmentState !== "provisioning") {
+            openOpenClawStateDatabase()
+              .db.prepare(
+                "UPDATE worker_environments SET state = ?, lease_id = ? WHERE node_setup_id = ?",
+              )
+              .run(environmentState, "startup-worker-lease", setupId);
+          }
+          if (destroyRequested) {
+            store.requestDestroy({
+              environmentId: "startup-worker-environment",
+              state: "provisioning",
+            });
+          }
+
+          const harness = await attachStartupNodeConnect({
+            bootstrapToken: issued.token,
+            identityPath,
+            isPendingWorkerNodeSetup: (candidateSetupId, deviceId) =>
+              store.hasPendingNodeEnrollmentSetup(candidateSetupId, deviceId),
+          });
+
+          const response = await harness.response();
+          expect(harness.pendingSetup).toHaveBeenCalledWith(setupId, identity.deviceId);
+          if (destroyRequested) {
+            expect(response).toMatchObject({
+              ok: false,
+              error: {
+                code: "UNAVAILABLE",
+                details: { reason: GATEWAY_STARTUP_UNAVAILABLE_REASON },
+              },
+            });
+            expect(harness.nodeRegistry.register).not.toHaveBeenCalled();
+            harness.socket.emit("close", GATEWAY_STARTUP_CLOSE_CODE, Buffer.alloc(0));
+            return;
+          }
+          expect(response).toMatchObject({
+            ok: true,
+            payload: { type: "hello-ok", auth: { role: "node", scopes: [] } },
+          });
+          await expect(readDevicePairSetupCompletion({ setupId })).resolves.toMatchObject({
+            deviceId: identity.deviceId,
+            deliveryState: "confirmed",
+          });
+          await expect(verifyDeviceBootstrapToken(verification)).resolves.toEqual({
+            ok: false,
+            reason: "bootstrap_token_invalid",
+          });
+          harness.socket.emit("close", 1000, Buffer.from("done"));
+        },
+      );
+    },
+  );
+
+  it("keeps restart-startup authentication tracked until its node mutation and handshake settle", async () => {
+    await withOpenClawTestState(
+      { label: "gateway-startup-cloud-worker-drain-race", layout: "state-only" },
+      async (state) => {
+        const { store, setupId } = seedProvisioningNodeSetup();
+        const issued = await ensureDevicePairSetupBootstrapToken({
+          setupId,
+          profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+        });
+        if (issued.status !== "pending") {
+          throw new Error("expected pending cloud-worker setup token");
+        }
+        const authenticationStarted = createDeferred();
+        const releaseAuthentication = createDeferred();
+        const registeredRootCounts: number[] = [];
+        const authorize = gatewayAuth.authorizeWsControlUiGatewayConnect;
+        const authentication = vi
+          .spyOn(gatewayAuth, "authorizeWsControlUiGatewayConnect")
+          .mockImplementationOnce(async (params) => {
+            authenticationStarted.resolve();
+            await releaseAuthentication.promise;
+            expect(getActiveGatewayRootWorkCount()).toBe(1);
+            return await authorize(params);
+          });
+        try {
+          const harness = await attachStartupNodeConnect({
+            bootstrapToken: issued.token,
+            identityPath: state.path("startup-drain-race-node.sqlite"),
+            isPendingWorkerNodeSetup: (candidateSetupId, deviceId) =>
+              store.hasPendingNodeEnrollmentSetup(candidateSetupId, deviceId),
+            onNodeRegistered: () => registeredRootCounts.push(getActiveGatewayRootWorkCount()),
+          });
+
+          await authenticationStarted.promise;
+          expect(getActiveGatewayRootWorkCount()).toBe(1);
+          expect(createSafeGatewayRestartPreflight()).toMatchObject({
+            safe: false,
+            counts: { rootRequests: 1 },
+          });
+          expect(harness.nodeRegistry.register).not.toHaveBeenCalled();
+
+          releaseAuthentication.resolve();
+          await expect(harness.responseReceived).resolves.toMatchObject({ ok: true });
+          expect(registeredRootCounts).toEqual([1]);
+          await new Promise<void>((resolve) => {
+            setImmediate(resolve);
+          });
+          expect(getActiveGatewayRootWorkCount()).toBe(0);
+          expect(createSafeGatewayRestartPreflight()).toMatchObject({
+            safe: true,
+            counts: { rootRequests: 0 },
+          });
+          harness.socket.emit("close", 1000, Buffer.from("done"));
+        } finally {
+          releaseAuthentication.resolve();
+          authentication.mockRestore();
+        }
+      },
+    );
+  });
+
+  it("keeps non-cloud and wrong cloud setup tokens startup-unavailable", async () => {
+    await withOpenClawTestState(
+      { label: "gateway-startup-cloud-worker-reject", layout: "state-only" },
+      async (state) => {
+        const { store, setupId } = seedProvisioningNodeSetup();
+        const nonCloud = await ensureDevicePairSetupBootstrapToken({
+          setupId,
+          profile: NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+        });
+        if (nonCloud.status !== "pending") {
+          throw new Error("expected pending node setup token");
+        }
+        const nonCloudHarness = await attachStartupNodeConnect({
+          bootstrapToken: nonCloud.token,
+          identityPath: state.path("non-cloud-node.sqlite"),
+          isPendingWorkerNodeSetup: (candidateSetupId, deviceId) =>
+            store.hasPendingNodeEnrollmentSetup(candidateSetupId, deviceId),
+        });
+
+        await expect(nonCloudHarness.response()).resolves.toMatchObject({
+          ok: false,
+          error: {
+            code: "UNAVAILABLE",
+            retryable: true,
+            details: { reason: GATEWAY_STARTUP_UNAVAILABLE_REASON },
+          },
+        });
+        expect(nonCloudHarness.pendingSetup).not.toHaveBeenCalled();
+        expect(nonCloudHarness.nodeRegistry.register).not.toHaveBeenCalled();
+        nonCloudHarness.socket.emit("close", GATEWAY_STARTUP_CLOSE_CODE, Buffer.alloc(0));
+
+        resetGatewayWorkAdmission();
+        const wrongSetup = await issueDevicePairSetupBootstrapToken({
+          profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+        });
+        const wrongSetupHarness = await attachStartupNodeConnect({
+          bootstrapToken: wrongSetup.token,
+          identityPath: state.path("wrong-setup-node.sqlite"),
+          isPendingWorkerNodeSetup: (candidateSetupId, deviceId) =>
+            store.hasPendingNodeEnrollmentSetup(candidateSetupId, deviceId),
+        });
+
+        await expect(wrongSetupHarness.response()).resolves.toMatchObject({
+          ok: false,
+          error: {
+            code: "UNAVAILABLE",
+            retryable: true,
+            details: { reason: GATEWAY_STARTUP_UNAVAILABLE_REASON },
+          },
+        });
+        expect(wrongSetupHarness.pendingSetup).toHaveBeenCalledWith(
+          wrongSetup.setupId,
+          wrongSetupHarness.identity.deviceId,
+        );
+        expect(wrongSetupHarness.nodeRegistry.register).not.toHaveBeenCalled();
+        wrongSetupHarness.socket.emit("close", GATEWAY_STARTUP_CLOSE_CODE, Buffer.alloc(0));
+      },
+    );
+  });
+
+  it("rate-limits an invalid startup token without consulting setup state", async () => {
+    await withOpenClawTestState(
+      { label: "gateway-startup-cloud-worker-invalid", layout: "state-only" },
+      async (state) => {
+        const { store } = seedProvisioningNodeSetup();
+        const rateLimiter = createAuthRateLimiter({
+          maxAttempts: 1,
+          windowMs: 60_000,
+          lockoutMs: 60_000,
+          exemptLoopback: false,
+        });
+        try {
+          const harness = await attachStartupNodeConnect({
+            bootstrapToken: "invalid-startup-token",
+            identityPath: state.path("invalid-token-node.sqlite"),
+            isPendingWorkerNodeSetup: (candidateSetupId, deviceId) =>
+              store.hasPendingNodeEnrollmentSetup(candidateSetupId, deviceId),
+            rateLimiter,
+          });
+
+          await expect(harness.response()).resolves.toMatchObject({
+            ok: false,
+            error: {
+              code: "UNAVAILABLE",
+              retryable: true,
+              details: { reason: GATEWAY_STARTUP_UNAVAILABLE_REASON },
+            },
+          });
+          expect(harness.pendingSetup).not.toHaveBeenCalled();
+          expect(harness.nodeRegistry.register).not.toHaveBeenCalled();
+          expect(
+            rateLimiter.check("127.0.0.1", AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN).allowed,
+          ).toBe(false);
+          harness.socket.emit("close", GATEWAY_STARTUP_CLOSE_CODE, Buffer.alloc(0));
+        } finally {
+          rateLimiter.dispose();
+        }
+      },
+    );
+  });
 });

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -94,6 +94,7 @@ type GatewayWsSharedHandlerParams = {
   nodeReapprovalCoordinator?: NodeReapprovalCoordinator;
   preauthHandshakeTimeoutMs?: number;
   isStartupPending?: () => boolean;
+  isPendingWorkerNodeSetup?: (setupId: string, deviceId: string) => boolean;
   gatewayMethods: string[];
   events: string[];
   refreshHealthSnapshot: GatewayRequestContext["refreshHealthSnapshot"];
@@ -187,6 +188,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
     browserRateLimiter,
     nodeReapprovalCoordinator,
     isStartupPending,
+    isPendingWorkerNodeSetup,
     gatewayMethods,
     events,
     refreshHealthSnapshot,
@@ -710,6 +712,7 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       browserRateLimiter,
       nodeReapprovalCoordinator,
       isStartupPending,
+      isPendingWorkerNodeSetup,
       gatewayMethods,
       events,
       extraHandlers,

--- a/src/gateway/server/ws-connection/auth-context.ts
+++ b/src/gateway/server/ws-connection/auth-context.ts
@@ -64,6 +64,7 @@ type ResolveConnectAuthDecisionParams = {
   publicKey?: string;
   role: string;
   scopes: string[];
+  requireBootstrapToken?: boolean;
   rateLimiter?: AuthRateLimiter;
   clientIp?: string;
   verifyBootstrapToken: (params: {
@@ -260,7 +261,8 @@ async function resolveConnectAuthDecisionCore(
       );
       if (!bootstrapRateCheck.allowed) {
         bootstrapRateLimited = true;
-        if (!authOk) {
+        if (!authOk || params.requireBootstrapToken) {
+          authOk = false;
           authResult = {
             ok: false,
             reason: "rate_limited",
@@ -289,7 +291,8 @@ async function resolveConnectAuthDecisionCore(
         params.rateLimiter?.reset(params.clientIp, AUTH_RATE_LIMIT_SCOPE_BOOTSTRAP_TOKEN);
       } else {
         pendingBootstrapFailure = true;
-        if (!authOk) {
+        if (!authOk || params.requireBootstrapToken) {
+          authOk = false;
           authResult = { ok: false, reason: tokenCheck.reason ?? "bootstrap_token_invalid" };
         }
       }

--- a/src/gateway/server/ws-connection/connect-admission.ts
+++ b/src/gateway/server/ws-connection/connect-admission.ts
@@ -40,14 +40,17 @@ function hasCredential(value: unknown): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+export function isStartupNodeConnect(connectParams: ConnectParams): boolean {
+  return connectParams.role === "node" && connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE;
+}
+
 /** Exact first-connect shape emitted by `openclaw connect` for a setup-code node. */
 export function isStartupNodeBootstrapConnect(connectParams: ConnectParams): boolean {
   const auth = connectParams.auth;
   const device = connectParams.device;
   return (
-    connectParams.role === "node" &&
+    isStartupNodeConnect(connectParams) &&
     connectParams.client.id === GATEWAY_CLIENT_IDS.NODE_HOST &&
-    connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE &&
     Array.isArray(connectParams.scopes) &&
     connectParams.scopes.length === 0 &&
     Boolean(device?.id.trim() && device.publicKey.trim()) &&
@@ -160,10 +163,9 @@ export async function admitGatewayConnect(context: GatewayConnectPhaseContext) {
     isWebchatConnect,
   } = context;
 
-  const isNodeClient =
-    connectParams.role === "node" && connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE;
+  const isNodeClient = isStartupNodeConnect(connectParams);
   const startupPending = isStartupPending?.() === true;
-  if (startupPending && !isStartupNodeBootstrapConnect(connectParams)) {
+  if (startupPending && !isNodeClient) {
     await rejectGatewayStartupConnect(context);
     return undefined;
   }

--- a/src/gateway/server/ws-connection/connect-admission.ts
+++ b/src/gateway/server/ws-connection/connect-admission.ts
@@ -1,6 +1,7 @@
 // Gateway WebSocket connect admission validates protocol, role, and browser origin.
 import type { IncomingMessage } from "node:http";
 import {
+  GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_MODES,
   hasGatewayClientCap,
@@ -12,6 +13,7 @@ import {
   MIN_NODE_PROTOCOL_VERSION,
   MIN_PROBE_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
+  type ConnectParams,
 } from "../../../../packages/gateway-protocol/src/index.js";
 import {
   gatewayStartupUnavailableDetails,
@@ -33,6 +35,49 @@ import { formatForLog } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
 import { isNativeAppUiClient } from "./handshake-auth-helpers.js";
 import type { GatewayConnectPhaseContext } from "./message-handler-types.js";
+
+function hasCredential(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Exact first-connect shape emitted by `openclaw connect` for a setup-code node. */
+export function isStartupNodeBootstrapConnect(connectParams: ConnectParams): boolean {
+  const auth = connectParams.auth;
+  const device = connectParams.device;
+  return (
+    connectParams.role === "node" &&
+    connectParams.client.id === GATEWAY_CLIENT_IDS.NODE_HOST &&
+    connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE &&
+    Array.isArray(connectParams.scopes) &&
+    connectParams.scopes.length === 0 &&
+    Boolean(device?.id.trim() && device.publicKey.trim()) &&
+    hasCredential(auth?.bootstrapToken) &&
+    !hasCredential(auth?.token) &&
+    !hasCredential(auth?.deviceToken) &&
+    !hasCredential(auth?.password) &&
+    !hasCredential(auth?.approvalRuntimeToken) &&
+    !hasCredential(auth?.agentRuntimeIdentityToken)
+  );
+}
+
+export async function rejectGatewayStartupConnect(
+  context: GatewayConnectPhaseContext,
+): Promise<void> {
+  const { close } = context.handler;
+  const { frame, markHandshakeFailure, sendFrame } = context;
+  markHandshakeFailure(GATEWAY_STARTUP_PENDING_CLOSE_CAUSE);
+  await sendFrame({
+    type: "res",
+    id: frame.id,
+    ok: false,
+    error: errorShape(ErrorCodes.UNAVAILABLE, "gateway starting; retry shortly", {
+      retryable: true,
+      retryAfterMs: GATEWAY_STARTUP_RETRY_AFTER_MS,
+      details: gatewayStartupUnavailableDetails(),
+    }),
+  }).catch(() => {});
+  queueMicrotask(() => close(GATEWAY_STARTUP_CLOSE_CODE, GATEWAY_STARTUP_CLOSE_REASON));
+}
 
 export function applyConnectionScopeCap(params: {
   scopes: string[];
@@ -113,26 +158,13 @@ export async function admitGatewayConnect(context: GatewayConnectPhaseContext) {
     markHandshakeFailure,
     sendHandshakeErrorResponse,
     isWebchatConnect,
-    frame,
-    sendFrame,
   } = context;
 
   const isNodeClient =
     connectParams.role === "node" && connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE;
-  // Startup awaits node enrollment; node authentication and pairing still run below.
-  if (isStartupPending?.() && !isNodeClient) {
-    markHandshakeFailure(GATEWAY_STARTUP_PENDING_CLOSE_CAUSE);
-    await sendFrame({
-      type: "res",
-      id: frame.id,
-      ok: false,
-      error: errorShape(ErrorCodes.UNAVAILABLE, "gateway starting; retry shortly", {
-        retryable: true,
-        retryAfterMs: GATEWAY_STARTUP_RETRY_AFTER_MS,
-        details: gatewayStartupUnavailableDetails(),
-      }),
-    }).catch(() => {});
-    queueMicrotask(() => close(GATEWAY_STARTUP_CLOSE_CODE, GATEWAY_STARTUP_CLOSE_REASON));
+  const startupPending = isStartupPending?.() === true;
+  if (startupPending && !isStartupNodeBootstrapConnect(connectParams)) {
+    await rejectGatewayStartupConnect(context);
     return undefined;
   }
 
@@ -283,5 +315,6 @@ export async function admitGatewayConnect(context: GatewayConnectPhaseContext) {
     isBrowserOperatorUi,
     isWebchat,
     isNativeAppUi,
+    startupPending,
   };
 }

--- a/src/gateway/server/ws-connection/connect-auth.ts
+++ b/src/gateway/server/ws-connection/connect-auth.ts
@@ -5,11 +5,15 @@ import {
 } from "../../../../packages/gateway-protocol/src/connect-error-details.js";
 import { ErrorCodes } from "../../../../packages/gateway-protocol/src/index.js";
 import {
-  getDeviceBootstrapTokenProfile,
+  getBoundDeviceBootstrapContext,
   verifyDeviceBootstrapToken,
 } from "../../../infra/device-bootstrap.js";
 import { verifyDeviceToken } from "../../../infra/device-pairing-tokens.js";
-import type { DeviceBootstrapProfile } from "../../../shared/device-bootstrap-profile.js";
+import {
+  CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+  deviceBootstrapProfilesEqual,
+  type DeviceBootstrapProfile,
+} from "../../../shared/device-bootstrap-profile.js";
 import { AUTH_RATE_LIMIT_SCOPE_SHARED_SECRET } from "../../auth-rate-limit.js";
 import type { GatewayAuthResult } from "../../auth.js";
 import { withSerializedCredentialFallbackAttempt } from "../../rate-limit-attempt-serialization.js";
@@ -18,7 +22,11 @@ import { truncateCloseReason } from "../close-reason.js";
 import { resolveSharedGatewaySessionGeneration } from "../ws-shared-generation.js";
 import { resolveConnectAuthDecision, resolveConnectAuthState } from "./auth-context.js";
 import { formatGatewayAuthFailureMessage } from "./auth-messages.js";
-import { admitGatewayConnect, applyConnectionScopeCap } from "./connect-admission.js";
+import {
+  admitGatewayConnect,
+  applyConnectionScopeCap,
+  rejectGatewayStartupConnect,
+} from "./connect-admission.js";
 import { emitGatewayAuthSecurityEvent } from "./connect-auth-security.js";
 import { isControlUiOperatorBootstrapProfile } from "./connect-device-metadata.js";
 import { verifyGatewayConnectDeviceProof } from "./connect-device-proof.js";
@@ -113,6 +121,7 @@ async function authenticateGatewayConnectCore(
     isBrowserOperatorUi,
     isWebchat,
     isNativeAppUi,
+    startupPending,
   } = admission;
 
   const deviceRaw = connectParams.device;
@@ -361,6 +370,7 @@ async function authenticateGatewayConnectCore(
     publicKey: device?.publicKey,
     role,
     scopes,
+    requireBootstrapToken: startupPending,
     rateLimiter: authRateLimiter,
     clientIp: browserRateLimitClientIp,
     async verifyBootstrapToken({
@@ -414,14 +424,45 @@ async function authenticateGatewayConnectCore(
     authMethod,
   });
   if (!authOk) {
+    if (startupPending) {
+      await rejectGatewayStartupConnect(context);
+      return undefined;
+    }
     rejectUnauthorized(authResult);
     return undefined;
   }
-  advanceHandshakePhase("auth_validated");
-  const issuedBootstrapProfile =
-    authMethod === "bootstrap-token" && bootstrapTokenCandidate
-      ? await getDeviceBootstrapTokenProfile({ token: bootstrapTokenCandidate })
+  const boundBootstrapContext =
+    authMethod === "bootstrap-token" && bootstrapTokenCandidate && device
+      ? await getBoundDeviceBootstrapContext({
+          token: bootstrapTokenCandidate,
+          deviceId: device.id,
+          publicKey: device.publicKey,
+        })
       : null;
+  if (startupPending) {
+    const setupId = boundBootstrapContext?.setupId?.trim();
+    const isCloudWorkerProfile = Boolean(
+      boundBootstrapContext &&
+      deviceBootstrapProfilesEqual(
+        boundBootstrapContext.profile,
+        CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+      ),
+    );
+    let pendingSetup = false;
+    if (isCloudWorkerProfile && setupId && device) {
+      try {
+        pendingSetup = context.handler.isPendingWorkerNodeSetup?.(setupId, device.id) === true;
+      } catch {
+        pendingSetup = false;
+      }
+    }
+    if (!isCloudWorkerProfile || !pendingSetup) {
+      await rejectGatewayStartupConnect(context);
+      return undefined;
+    }
+  }
+  advanceHandshakePhase("auth_validated");
+  const issuedBootstrapProfile = boundBootstrapContext?.profile ?? null;
   const usesSharedGatewayAuth =
     authMethod === "token" || authMethod === "password" || authMethod === "trusted-proxy";
   const sharedGatewaySessionGeneration = usesSharedGatewayAuth

--- a/src/gateway/server/ws-connection/connect-auth.ts
+++ b/src/gateway/server/ws-connection/connect-auth.ts
@@ -25,6 +25,7 @@ import { formatGatewayAuthFailureMessage } from "./auth-messages.js";
 import {
   admitGatewayConnect,
   applyConnectionScopeCap,
+  isStartupNodeBootstrapConnect,
   rejectGatewayStartupConnect,
 } from "./connect-admission.js";
 import { emitGatewayAuthSecurityEvent } from "./connect-auth-security.js";
@@ -123,6 +124,7 @@ async function authenticateGatewayConnectCore(
     isNativeAppUi,
     startupPending,
   } = admission;
+  const startupBootstrapConnect = startupPending && isStartupNodeBootstrapConnect(connectParams);
 
   const deviceRaw = connectParams.device;
   const hasTokenAuth = Boolean(connectParams.auth?.token);
@@ -338,6 +340,11 @@ async function authenticateGatewayConnectCore(
     close(1008, "device identity required");
     return false;
   };
+  if (startupPending && !device) {
+    await settleRejectedSharedAuthFailure();
+    await rejectGatewayStartupConnect(context);
+    return undefined;
+  }
   if (!handleMissingDeviceIdentity()) {
     await settleRejectedSharedAuthFailure();
     return undefined;
@@ -370,7 +377,7 @@ async function authenticateGatewayConnectCore(
     publicKey: device?.publicKey,
     role,
     scopes,
-    requireBootstrapToken: startupPending,
+    requireBootstrapToken: startupBootstrapConnect,
     rateLimiter: authRateLimiter,
     clientIp: browserRateLimitClientIp,
     async verifyBootstrapToken({
@@ -424,7 +431,7 @@ async function authenticateGatewayConnectCore(
     authMethod,
   });
   if (!authOk) {
-    if (startupPending) {
+    if (startupPending && bootstrapTokenCandidate) {
       await rejectGatewayStartupConnect(context);
       return undefined;
     }
@@ -439,7 +446,11 @@ async function authenticateGatewayConnectCore(
           publicKey: device.publicKey,
         })
       : null;
-  if (startupPending) {
+  if (startupPending && authMethod === "bootstrap-token" && !startupBootstrapConnect) {
+    await rejectGatewayStartupConnect(context);
+    return undefined;
+  }
+  if (startupBootstrapConnect) {
     const setupId = boundBootstrapContext?.setupId?.trim();
     const isCloudWorkerProfile = Boolean(
       boundBootstrapContext &&
@@ -533,6 +544,7 @@ async function authenticateGatewayConnectCore(
     isBrowserOperatorUi,
     isWebchat,
     isNativeAppUi,
+    startupPending,
     device,
     devicePublicKey: deviceProof.devicePublicKey,
     deviceAuthPayloadVersion: deviceProof.deviceAuthPayloadVersion,

--- a/src/gateway/server/ws-connection/connect-device-pairing.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.ts
@@ -36,7 +36,11 @@ import { shouldAutoApproveNodePairingFromTrustedCidrs } from "../../node-pairing
 import { normalizeChromeExtensionOrigin } from "../../origin-check.js";
 import { formatForLog } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
-import { applyConnectionScopeCap } from "./connect-admission.js";
+import {
+  applyConnectionScopeCap,
+  isStartupNodeBootstrapConnect,
+  rejectGatewayStartupConnect,
+} from "./connect-admission.js";
 import {
   isControlUiOwnerBootstrapProfile,
   isControlUiOperatorBootstrapProfile,
@@ -623,6 +627,14 @@ export async function authorizeGatewayConnectDevice(
 
     const paired = await getPairedDevice(device.id);
     const isPaired = paired?.publicKey === devicePublicKey;
+    if (
+      state.startupPending &&
+      !isStartupNodeBootstrapConnect(connectParams) &&
+      (!paired || !isPaired || !hasEffectivePairedDeviceRole(paired, "node") || !paired.nodeSurface)
+    ) {
+      await rejectGatewayStartupConnect(context);
+      return undefined;
+    }
     const pairingRecordDoesNotAuthorizeSession =
       skipLocalBackendSelfPairing || controlUiPairingKind === "auth-none";
     if (pairingRecordDoesNotAuthorizeSession) {

--- a/src/gateway/server/ws-connection/message-handler-types.ts
+++ b/src/gateway/server/ws-connection/message-handler-types.ts
@@ -58,6 +58,7 @@ export type GatewayWsMessageHandlerParams = {
   browserRateLimiter?: AuthRateLimiter;
   nodeReapprovalCoordinator?: NodeReapprovalCoordinator;
   isStartupPending?: () => boolean;
+  isPendingWorkerNodeSetup?: (setupId: string, deviceId: string) => boolean;
   gatewayMethods: string[];
   events: string[];
   extraHandlers: GatewayRequestHandlers;

--- a/src/gateway/server/ws-connection/message-handler-types.ts
+++ b/src/gateway/server/ws-connection/message-handler-types.ts
@@ -130,6 +130,7 @@ export type AuthenticatedGatewayConnect = {
   isBrowserOperatorUi: boolean;
   isWebchat: boolean;
   isNativeAppUi: boolean;
+  startupPending: boolean;
   device: ConnectParams["device"] | null | undefined;
   devicePublicKey: string | null;
   deviceAuthPayloadVersion: "v2" | "v3" | null;

--- a/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
@@ -57,7 +57,7 @@ function createLogger() {
   };
 }
 
-function attachHarness(params: { deferSocketSend?: boolean } = {}) {
+function attachHarness(params: { deferSocketSend?: boolean; startupPending?: boolean } = {}) {
   let onMessage: ((data: string) => void) | undefined;
   let finishSocketSend: (() => void) | undefined;
   let client: unknown = null;
@@ -106,6 +106,7 @@ function attachHarness(params: { deferSocketSend?: boolean } = {}) {
     requestHost: "127.0.0.1:19001",
     connectNonce: "suspension-connect-nonce",
     getResolvedAuth: () => ({ mode: "none", allowTailscale: false }),
+    isStartupPending: () => params.startupPending === true,
     gatewayMethods: [],
     events: [],
     extraHandlers: {},
@@ -186,6 +187,36 @@ function attachHarness(params: { deferSocketSend?: boolean } = {}) {
           id: "worker-connect",
           method: "connect",
           params: { role: "worker" },
+        }),
+      ),
+    sendStartupNodeConnect: () =>
+      onMessage?.(
+        JSON.stringify({
+          type: "req",
+          id: "startup-node-connect",
+          method: "connect",
+          params: {
+            minProtocol: PROTOCOL_VERSION,
+            maxProtocol: PROTOCOL_VERSION,
+            client: {
+              id: "node-host",
+              version: "dev",
+              platform: "linux",
+              mode: "node",
+            },
+            role: "node",
+            scopes: [],
+            caps: [],
+            commands: [],
+            auth: { bootstrapToken: "startup-bootstrap-token" },
+            device: {
+              id: "startup-node-device",
+              publicKey: "startup-node-public-key",
+              signature: "startup-node-signature",
+              signedAt: Date.now(),
+              nonce: "suspension-connect-nonce",
+            },
+          },
         }),
       ),
     send,
@@ -302,6 +333,34 @@ describe("WebSocket connect suspension admission", () => {
     await vi.waitFor(() => {
       expect(harness.close).toHaveBeenCalledWith(1013, "gateway restart in progress");
     });
+  });
+
+  it("keeps the old draining server closed to an exact startup node shape", async () => {
+    markGatewayRestartDraining();
+    const harness = attachHarness({ startupPending: false });
+
+    harness.sendStartupNodeConnect();
+
+    await vi.waitFor(() => expect(harness.socketSend).toHaveBeenCalledOnce());
+    expect(harness.setClient).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(harness.close).toHaveBeenCalledWith(1013, "gateway restart in progress");
+    });
+  });
+
+  it("keeps suspension closed to an exact startup node shape", async () => {
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    expect(suspension?.commit()).toBe(true);
+    const harness = attachHarness({ startupPending: true });
+
+    harness.sendStartupNodeConnect();
+
+    await vi.waitFor(() => expect(harness.socketSend).toHaveBeenCalledOnce());
+    expect(harness.setClient).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(harness.close).toHaveBeenCalledWith(1013, "gateway suspension in progress");
+    });
+    suspension?.release();
   });
 
   it("keeps an accepted handshake visible as root work until hello is sent", async () => {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -29,6 +29,7 @@ import {
   getGatewaySuspendAdmissionPhase,
   isGatewayRestartDraining,
   runWithGatewayIndependentRootWorkAdmission,
+  tryBeginGatewayRestartStartupRootWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
 } from "../../../process/gateway-work-admission.js";
 import { isWebchatClient } from "../../../utils/message-channel.js";
@@ -38,6 +39,7 @@ import { MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
 import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
+import { isStartupNodeBootstrapConnect } from "./connect-admission.js";
 import { authenticateGatewayConnect } from "./connect-auth.js";
 import { authorizeGatewayConnectDevice } from "./connect-device-pairing.js";
 import { attachAuthenticatedGatewayConnect } from "./connect-session.js";
@@ -385,7 +387,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     }
   };
 
-  const parsePreauthConnectFrame = (data: RawData) => {
+  const parsePreauthConnectFrame = (
+    data: RawData,
+  ): { id: string; params: ConnectParams } | null => {
     if (isClosed() || rawDataByteLength(data) > MAX_PREAUTH_PAYLOAD_BYTES) {
       return null;
     }
@@ -402,7 +406,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     ) {
       return null;
     }
-    return parsed;
+    return { id: parsed.id, params: parsed.params };
   };
 
   const isPreparedControlConnect = (data: RawData): boolean => {
@@ -412,6 +416,11 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     }
     const connectParams = parsed.params as { role?: unknown };
     return connectParams.role !== "node" && !claimsWorkerConnectionIdentity(parsed.params);
+  };
+
+  const isStartupNodeBootstrapPreauth = (data: RawData): boolean => {
+    const parsed = parsePreauthConnectFrame(data);
+    return parsed ? isStartupNodeBootstrapConnect(parsed.params) : false;
   };
 
   const rejectConnectForClosedAdmission = async (data: RawData): Promise<boolean> => {
@@ -457,6 +466,22 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     }
     const admission = tryBeginGatewayRootWorkAdmission();
     if (!admission) {
+      if (
+        isGatewayRestartDraining() &&
+        getGatewaySuspendAdmissionPhase() === "accepting" &&
+        params.isStartupPending?.() === true &&
+        isStartupNodeBootstrapPreauth(data)
+      ) {
+        const startupAdmission = tryBeginGatewayRestartStartupRootWorkAdmission();
+        if (startupAdmission) {
+          try {
+            await startupAdmission.run(() => handleMessage(data));
+          } finally {
+            startupAdmission.release();
+          }
+          return;
+        }
+      }
       if (
         !isGatewayRestartDraining() &&
         getGatewaySuspendAdmissionPhase() === "prepared" &&

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -39,7 +39,7 @@ import { MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
 import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
-import { isStartupNodeBootstrapConnect } from "./connect-admission.js";
+import { isStartupNodeConnect } from "./connect-admission.js";
 import { authenticateGatewayConnect } from "./connect-auth.js";
 import { authorizeGatewayConnectDevice } from "./connect-device-pairing.js";
 import { attachAuthenticatedGatewayConnect } from "./connect-session.js";
@@ -418,9 +418,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
     return connectParams.role !== "node" && !claimsWorkerConnectionIdentity(parsed.params);
   };
 
-  const isStartupNodeBootstrapPreauth = (data: RawData): boolean => {
+  const isStartupNodePreauth = (data: RawData): boolean => {
     const parsed = parsePreauthConnectFrame(data);
-    return parsed ? isStartupNodeBootstrapConnect(parsed.params) : false;
+    return parsed ? isStartupNodeConnect(parsed.params) : false;
   };
 
   const rejectConnectForClosedAdmission = async (data: RawData): Promise<boolean> => {
@@ -470,7 +470,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         isGatewayRestartDraining() &&
         getGatewaySuspendAdmissionPhase() === "accepting" &&
         params.isStartupPending?.() === true &&
-        isStartupNodeBootstrapPreauth(data)
+        isStartupNodePreauth(data)
       ) {
         const startupAdmission = tryBeginGatewayRestartStartupRootWorkAdmission();
         if (startupAdmission) {

--- a/src/gateway/server/ws-connection/message-handler.worker.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.worker.test.ts
@@ -194,6 +194,7 @@ function attachHarness(
     rateLimiter?: AuthRateLimiter;
     onInferenceLaunch?: (sink: InferenceSink) => void;
     onSessionTool?: (signal: AbortSignal | undefined) => Promise<WorkerSessionToolResult>;
+    startupPending?: () => boolean;
     validationFailure?: ReturnType<WorkerConnectionService["validateWorkerConnection"]>;
   } = {},
 ) {
@@ -257,6 +258,7 @@ function attachHarness(
     socket: socket as unknown as WebSocket,
     connId: "worker-connection",
     service,
+    isStartupPending: options.startupPending,
     publicAdmission: options.omitPublicAdmission
       ? undefined
       : { clientIp: "203.0.113.10", rateLimiter: options.rateLimiter },
@@ -315,6 +317,20 @@ describe("dedicated worker websocket protocol", () => {
     expect(harness.client()).toMatchObject({
       connectionKind: "worker",
       connect: { role: "worker" },
+    });
+  });
+
+  it("keeps unrelated worker admission closed while startup is pending", async () => {
+    const harness = attachHarness({ startupPending: () => true });
+    harness.sendConnect();
+
+    await waitForWorkerProtocol(() =>
+      expect(harness.close).toHaveBeenCalledWith(1013, "gateway-unavailable"),
+    );
+    expect(harness.service.admitWorker).not.toHaveBeenCalled();
+    expect(harness.responses[0]).toMatchObject({
+      ok: false,
+      error: { code: "UNAVAILABLE", retryable: true },
     });
   });
 

--- a/src/gateway/worker-environments/node-enrollment.test.ts
+++ b/src/gateway/worker-environments/node-enrollment.test.ts
@@ -90,4 +90,38 @@ describe("worker node enrollment", () => {
     }
     expect(decodePairingSetupCode(enrollment.setupCode, { nowMs: 0 }).url).toBe(expectedUrl);
   });
+
+  it("aborts pending enrollment waits idempotently and rejects enrollment after shutdown", async () => {
+    const intent = store.createIntent({
+      environmentId: "worker-enrollment-stop",
+      providerId: "fake-provider",
+      profileId: "test-profile",
+      profileSnapshot: { settings: {} },
+      provisionOperationId: "provision:worker-enrollment-stop",
+    });
+    const record = store.transition({
+      environmentId: intent.environmentId,
+      from: "requested",
+      to: "provisioning",
+      patch: { nodeDeviceId: "device-pending" },
+    });
+    const manager = createWorkerNodeEnrollmentManager({
+      store,
+      getConfig: () => createConfig(),
+      resolveAvailability: async () => ({ available: false }),
+    });
+    expect(manager).toHaveProperty("stop");
+    const enrollment = await manager.begin(record);
+    const waiting = enrollment.waitForDeviceId();
+    const waitRejected = expect(waiting).rejects.toMatchObject({ name: "AbortError" });
+
+    manager.stop();
+    manager.stop();
+
+    await waitRejected;
+    expect(enrollment.signal?.aborted).toBe(true);
+    const ensureEnrollment = vi.spyOn(store, "ensureNodeEnrollment");
+    await expect(manager.begin(record)).rejects.toMatchObject({ name: "AbortError" });
+    expect(ensureEnrollment).not.toHaveBeenCalled();
+  });
 });

--- a/src/gateway/worker-environments/node-enrollment.ts
+++ b/src/gateway/worker-environments/node-enrollment.ts
@@ -35,26 +35,31 @@ function resolveEnrollmentPackageSpecs(): string[] {
 export function createWorkerNodeEnrollmentManager(options: WorkerNodeEnrollmentManagerOptions) {
   const now = options.now ?? Date.now;
   const packageSpecs = resolveEnrollmentPackageSpecs();
+  const controller = new AbortController();
+  const { signal } = controller;
 
   const waitForDeviceId = async (environmentId: string): Promise<string> => {
     const deadline = now() + NODE_ENROLLMENT_TIMEOUT_MS;
     while (now() < deadline) {
+      signal.throwIfAborted();
       const record = options.store.ensureNodeEnrollment(environmentId);
       if (record.destroyRequestedAtMs !== null) {
         throw new Error("Worker node enrollment was canceled by environment teardown");
       }
       if (record.nodeDeviceId) {
         const availability = await options.resolveAvailability(record.nodeDeviceId);
+        signal.throwIfAborted();
         if (availability.available) {
           return record.nodeDeviceId;
         }
       }
-      await sleep(NODE_ENROLLMENT_POLL_MS);
+      await sleep(NODE_ENROLLMENT_POLL_MS, undefined, { signal });
     }
     throw new Error("Worker node did not connect before the enrollment deadline");
   };
 
   const begin = async (record: WorkerEnvironmentRecord): Promise<WorkerNodeEnrollment> => {
+    signal.throwIfAborted();
     let current = options.store.ensureNodeEnrollment(record.environmentId);
     const displayName = enrollmentDisplayName(current);
     const wait = async () => await waitForDeviceId(current.environmentId);
@@ -65,6 +70,7 @@ export function createWorkerNodeEnrollmentManager(options: WorkerNodeEnrollmentM
         openclawVersion: VERSION,
         packageSpecs,
         displayName,
+        signal,
         waitForDeviceId: wait,
       };
     }
@@ -75,6 +81,7 @@ export function createWorkerNodeEnrollmentManager(options: WorkerNodeEnrollmentM
       setupId: current.nodeSetupId,
       profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
     });
+    signal.throwIfAborted();
     if (issued.status === "completed") {
       current = options.store.ensureNodeEnrollment(current.environmentId);
       if (!current.nodeDeviceId || current.nodeDeviceId !== issued.deviceId) {
@@ -86,6 +93,7 @@ export function createWorkerNodeEnrollmentManager(options: WorkerNodeEnrollmentM
         openclawVersion: VERSION,
         packageSpecs,
         displayName,
+        signal,
         waitForDeviceId: wait,
       };
     }
@@ -98,6 +106,7 @@ export function createWorkerNodeEnrollmentManager(options: WorkerNodeEnrollmentM
       runCommandWithTimeout: async (argv, runOptions) =>
         await runCommandWithTimeout(argv, { timeoutMs: runOptions.timeoutMs }),
     });
+    signal.throwIfAborted();
     if (!resolved.ok) {
       throw new Error(resolved.error);
     }
@@ -111,6 +120,7 @@ export function createWorkerNodeEnrollmentManager(options: WorkerNodeEnrollmentM
       openclawVersion: VERSION,
       packageSpecs,
       displayName,
+      signal,
       waitForDeviceId: wait,
     };
   };
@@ -134,5 +144,5 @@ export function createWorkerNodeEnrollmentManager(options: WorkerNodeEnrollmentM
     await removePairedDeviceRole({ deviceId, role: "node" });
   };
 
-  return { begin, retire };
+  return { begin, retire, stop: () => controller.abort() };
 }

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.test.ts
@@ -1,3 +1,4 @@
+import { setImmediate as setImmediatePromise } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { coordinateWorkerPlacementDispatch } from "./placement-dispatch-coordinator.js";
@@ -231,4 +232,366 @@ describe("worker placement dispatch coordinator", () => {
 
     expect(reconcileActive.mock.calls).toEqual([[], ["worker-target"]]);
   });
+
+  it("fences external provisioning recovery behind fresh dispatch without self-deadlocking", async () => {
+    const dispatchStarted = createDeferredCore();
+    const releaseDispatch = createDeferredCore();
+    const dispatch = vi.fn(async () => {
+      dispatchStarted.resolve();
+      await releaseDispatch.promise;
+      return { state: "active" };
+    });
+    const resumeProvisioning = vi.fn(async (_placement, reconcileCore) => {
+      await reconcileCore();
+    });
+    const reconcile = vi.fn();
+    const service = {
+      dispatch,
+      forceDestroyEnvironment: vi.fn(),
+      reclaim: vi.fn(),
+      reconcile,
+      reconcileActive: vi.fn(),
+      resumeProvisioning,
+    } as unknown as DispatchService;
+    const coordinated = coordinateWorkerPlacementDispatch(service);
+    reconcile.mockImplementation(async () => {
+      await coordinated.resumeProvisioning({} as never, async () => {});
+    });
+
+    const dispatching = coordinated.dispatch(REQUEST);
+    await dispatchStarted.promise;
+    const recoveryCore = vi.fn(async () => {});
+    const recovering = coordinated.resumeProvisioning({} as never, recoveryCore);
+    await Promise.resolve();
+    expect(resumeProvisioning).not.toHaveBeenCalled();
+    releaseDispatch.resolve();
+    await Promise.all([dispatching, recovering]);
+    expect(resumeProvisioning).toHaveBeenCalledWith({}, recoveryCore);
+
+    await coordinated.reconcile();
+    expect(resumeProvisioning).toHaveBeenCalledTimes(2);
+  });
+
+  it("lets a full sweep own and join a preexisting environment recovery pass", async () => {
+    const dispatchStarted = createDeferredCore();
+    const releaseDispatch = createDeferredCore();
+    const environmentPassStarted = createDeferredCore();
+    const releaseEnvironmentGuard = createDeferredCore();
+    const environmentGuardEntered = createDeferredCore();
+    const fullSweepJoinedEnvironmentPass = createDeferredCore();
+    const recoveryCore = vi.fn(async () => {});
+    const resumeProvisioning = vi.fn(async (_placement, reconcileCore) => {
+      await reconcileCore();
+    });
+    const dispatch = vi.fn(async () => {
+      dispatchStarted.resolve();
+      await releaseDispatch.promise;
+      return { state: "active" };
+    });
+    let environmentPass: Promise<void> | undefined;
+    const reconcileEnvironmentOnce = () =>
+      (environmentPass ??= (async () => {
+        environmentPassStarted.resolve();
+        await releaseEnvironmentGuard.promise;
+        environmentGuardEntered.resolve();
+        await coordinated.resumeProvisioning({} as never, recoveryCore);
+      })().finally(() => {
+        environmentPass = undefined;
+      }));
+    const reconcile = vi.fn(async () => {
+      fullSweepJoinedEnvironmentPass.resolve();
+      await reconcileEnvironmentOnce();
+    });
+    const service = {
+      dispatch,
+      forceDestroyEnvironment: vi.fn(),
+      reclaim: vi.fn(),
+      reconcile,
+      reconcileActive: vi.fn(),
+      resumeProvisioning,
+    } as unknown as DispatchService;
+    const coordinated = coordinateWorkerPlacementDispatch(service);
+
+    const dispatching = coordinated.dispatch(REQUEST);
+    await dispatchStarted.promise;
+    const externalEnvironmentPass = reconcileEnvironmentOnce();
+    await environmentPassStarted.promise;
+    const fullSweep = coordinated.reconcile();
+    releaseEnvironmentGuard.resolve();
+    await environmentGuardEntered.promise;
+    await Promise.resolve();
+    expect(resumeProvisioning).not.toHaveBeenCalled();
+    releaseDispatch.resolve();
+    await dispatching;
+    await fullSweepJoinedEnvironmentPass.promise;
+    await Promise.resolve();
+
+    expect(resumeProvisioning).toHaveBeenCalledOnce();
+    await Promise.all([externalEnvironmentPass, fullSweep]);
+    expect(recoveryCore).toHaveBeenCalledOnce();
+    expect(reconcile).toHaveBeenCalledOnce();
+  });
+
+  it("lets environment recovery created by a full sweep join that sweep", async () => {
+    const environmentPassStarted = createDeferredCore();
+    const releaseEnvironmentGuard = createDeferredCore();
+    const resumeProvisioning = vi.fn(async (_placement, reconcileCore) => {
+      await reconcileCore();
+    });
+    const recoveryCore = vi.fn(async () => {});
+    const reconcile = vi.fn(async () => {
+      environmentPassStarted.resolve();
+      await releaseEnvironmentGuard.promise;
+      await coordinated.resumeProvisioning({} as never, recoveryCore);
+    });
+    const service = {
+      dispatch: vi.fn(),
+      forceDestroyEnvironment: vi.fn(),
+      reclaim: vi.fn(),
+      reconcile,
+      reconcileActive: vi.fn(),
+      resumeProvisioning,
+    } as unknown as DispatchService;
+    const coordinated = coordinateWorkerPlacementDispatch(service);
+
+    const fullSweep = coordinated.reconcile();
+    await environmentPassStarted.promise;
+    releaseEnvironmentGuard.resolve();
+    await fullSweep;
+
+    expect(resumeProvisioning).toHaveBeenCalledOnce();
+    expect(recoveryCore).toHaveBeenCalledOnce();
+  });
+
+  it("runs a full sweep requested behind external recovery", async () => {
+    const recoveryStarted = createDeferredCore();
+    const releaseRecovery = createDeferredCore();
+    const resumeProvisioning = vi.fn(async (_placement, reconcileCore) => {
+      recoveryStarted.resolve();
+      await releaseRecovery.promise;
+      await reconcileCore();
+    });
+    const reconcile = vi.fn(async () => {});
+    const service = {
+      dispatch: vi.fn(),
+      forceDestroyEnvironment: vi.fn(),
+      reclaim: vi.fn(),
+      reconcile,
+      reconcileActive: vi.fn(),
+      resumeProvisioning,
+    } as unknown as DispatchService;
+    const coordinated = coordinateWorkerPlacementDispatch(service);
+
+    const recovering = coordinated.resumeProvisioning({} as never, async () => {});
+    await recoveryStarted.promise;
+    const fullSweep = coordinated.reconcile();
+    expect(reconcile).not.toHaveBeenCalled();
+    releaseRecovery.resolve();
+    await Promise.all([recovering, fullSweep]);
+
+    expect(resumeProvisioning).toHaveBeenCalledOnce();
+    expect(reconcile).toHaveBeenCalledOnce();
+  });
+
+  it("finishes sweep-owned recovery before an exclusive barrier queued behind the sweep", async () => {
+    const environmentPassStarted = createDeferredCore();
+    const releaseEnvironmentGuard = createDeferredCore();
+    const recoveryStarted = createDeferredCore();
+    const releaseRecovery = createDeferredCore();
+    const exclusiveStarted = createDeferredCore();
+    const releaseExclusive = createDeferredCore();
+    const resumeProvisioning = vi.fn(async (_placement, reconcileCore) => {
+      recoveryStarted.resolve();
+      await reconcileCore();
+      await releaseRecovery.promise;
+    });
+    const forceDestroyEnvironment = vi.fn(async () => {
+      exclusiveStarted.resolve();
+      await releaseExclusive.promise;
+    });
+    const reconcile = vi.fn(async () => {
+      environmentPassStarted.resolve();
+      await releaseEnvironmentGuard.promise;
+      await coordinated.resumeProvisioning({} as never, async () => {});
+    });
+    const service = {
+      dispatch: vi.fn(),
+      forceDestroyEnvironment,
+      reclaim: vi.fn(),
+      reconcile,
+      reconcileActive: vi.fn(),
+      resumeProvisioning,
+    } as unknown as DispatchService;
+    const coordinated = coordinateWorkerPlacementDispatch(service);
+
+    const fullSweep = coordinated.reconcile();
+    await environmentPassStarted.promise;
+    const destroying = coordinated.forceDestroyEnvironment("worker-exclusive");
+    releaseEnvironmentGuard.resolve();
+    await recoveryStarted.promise;
+    expect(forceDestroyEnvironment).not.toHaveBeenCalled();
+    releaseRecovery.resolve();
+    await fullSweep;
+    await exclusiveStarted.promise;
+    releaseExclusive.resolve();
+    await destroying;
+
+    expect(resumeProvisioning).toHaveBeenCalledOnce();
+    expect(forceDestroyEnvironment).toHaveBeenCalledOnce();
+  });
+
+  it.each(["fulfilled", "rejected"] as const)(
+    "holds an exclusive fence until an independently joined late recovery settles (%s)",
+    async (outcome) => {
+      const sweepStarted = createDeferredCore();
+      const releaseSweep = createDeferredCore();
+      const recoveryStarted = createDeferredCore();
+      const releaseRecovery = createDeferredCore();
+      const recoveryError = new Error("joined recovery failed");
+      const reconcile = vi.fn(async () => {
+        sweepStarted.resolve();
+        await releaseSweep.promise;
+      });
+      const resumeProvisioning = vi.fn(async (_placement, reconcileCore) => {
+        recoveryStarted.resolve();
+        await reconcileCore();
+        await releaseRecovery.promise;
+      });
+      const forceDestroyEnvironment = vi.fn(async () => {});
+      const service = {
+        dispatch: vi.fn(),
+        forceDestroyEnvironment,
+        reclaim: vi.fn(),
+        reconcile,
+        reconcileActive: vi.fn(),
+        resumeProvisioning,
+      } as unknown as DispatchService;
+      const coordinated = coordinateWorkerPlacementDispatch(service);
+
+      const fullSweep = coordinated.reconcile();
+      await sweepStarted.promise;
+      const destroying = coordinated.forceDestroyEnvironment("worker-exclusive");
+      const recoveryOutcome = coordinated
+        .resumeProvisioning({} as never, async () => {})
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+      await recoveryStarted.promise;
+      releaseSweep.resolve();
+      await setImmediatePromise();
+
+      expect(forceDestroyEnvironment).not.toHaveBeenCalled();
+      if (outcome === "rejected") {
+        releaseRecovery.reject(recoveryError);
+      } else {
+        releaseRecovery.resolve();
+      }
+      await Promise.all([fullSweep, destroying]);
+
+      expect(await recoveryOutcome).toBe(outcome === "rejected" ? recoveryError : undefined);
+      expect(resumeProvisioning).toHaveBeenCalledOnce();
+      expect(forceDestroyEnvironment).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("queues recovery arriving after sweep join admission closes behind the exclusive fence", async () => {
+    const sweepStarted = createDeferredCore();
+    const releaseSweep = createDeferredCore();
+    const joinedRecoveryStarted = createDeferredCore();
+    const releaseJoinedRecovery = createDeferredCore();
+    const exclusiveStarted = createDeferredCore();
+    const releaseExclusive = createDeferredCore();
+    const reconcile = vi.fn(async () => {
+      sweepStarted.resolve();
+      await releaseSweep.promise;
+    });
+    const resumeProvisioning = vi.fn(async (_placement, reconcileCore) => {
+      await reconcileCore();
+    });
+    const forceDestroyEnvironment = vi.fn(async () => {
+      exclusiveStarted.resolve();
+      await releaseExclusive.promise;
+    });
+    const service = {
+      dispatch: vi.fn(),
+      forceDestroyEnvironment,
+      reclaim: vi.fn(),
+      reconcile,
+      reconcileActive: vi.fn(),
+      resumeProvisioning,
+    } as unknown as DispatchService;
+    const coordinated = coordinateWorkerPlacementDispatch(service);
+
+    const fullSweep = coordinated.reconcile();
+    await sweepStarted.promise;
+    const destroying = coordinated.forceDestroyEnvironment("worker-exclusive");
+    const joinedRecovery = coordinated.resumeProvisioning({} as never, async () => {
+      joinedRecoveryStarted.resolve();
+      await releaseJoinedRecovery.promise;
+    });
+    await joinedRecoveryStarted.promise;
+    releaseSweep.resolve();
+    await setImmediatePromise();
+
+    const lateRecovery = coordinated.resumeProvisioning({} as never, async () => {});
+    await setImmediatePromise();
+    expect(resumeProvisioning).toHaveBeenCalledOnce();
+    expect(forceDestroyEnvironment).not.toHaveBeenCalled();
+
+    releaseJoinedRecovery.resolve();
+    await Promise.all([fullSweep, joinedRecovery, exclusiveStarted.promise]);
+    expect(resumeProvisioning).toHaveBeenCalledOnce();
+    releaseExclusive.resolve();
+    await Promise.all([destroying, lateRecovery]);
+
+    expect(resumeProvisioning).toHaveBeenCalledTimes(2);
+    expect(forceDestroyEnvironment).toHaveBeenCalledOnce();
+  });
+
+  it.each(["move", "reclaim", "forceDestroyEnvironment"] as const)(
+    "keeps recovery behind an active exclusive %s barrier",
+    async (barrierKind) => {
+      const barrierStarted = createDeferredCore();
+      const releaseBarrier = createDeferredCore();
+      const exclusiveOperation = vi.fn(async () => {
+        barrierStarted.resolve();
+        await releaseBarrier.promise;
+        return {};
+      });
+      const resumeProvisioning = vi.fn(async (_placement, reconcileCore) => {
+        await reconcileCore();
+      });
+      const service = {
+        dispatch: vi.fn(),
+        forceDestroyEnvironment: exclusiveOperation,
+        move: exclusiveOperation,
+        reclaim: exclusiveOperation,
+        reconcile: vi.fn(),
+        reconcileActive: vi.fn(),
+        resumeProvisioning,
+      } as unknown as DispatchService;
+      const coordinated = coordinateWorkerPlacementDispatch(service);
+      const barrier =
+        barrierKind === "move"
+          ? coordinated.move(MOVE_REQUEST)
+          : barrierKind === "reclaim"
+            ? coordinated.reclaim({
+                sessionId: REQUEST.sessionId,
+                sessionKey: REQUEST.sessionKey,
+                agentId: REQUEST.agentId,
+              })
+            : coordinated.forceDestroyEnvironment("worker-exclusive");
+      await barrierStarted.promise;
+
+      const recovering = coordinated.resumeProvisioning({} as never, async () => {});
+      await Promise.resolve();
+      expect(resumeProvisioning).not.toHaveBeenCalled();
+      releaseBarrier.resolve();
+      await Promise.all([barrier, recovering]);
+
+      expect(exclusiveOperation).toHaveBeenCalledOnce();
+      expect(resumeProvisioning).toHaveBeenCalledOnce();
+    },
+  );
 });

--- a/src/gateway/worker-environments/placement-dispatch-coordinator.ts
+++ b/src/gateway/worker-environments/placement-dispatch-coordinator.ts
@@ -6,8 +6,18 @@ import type { WorkerPlacementDispatchRequest } from "./service-contract.js";
 export function coordinateWorkerPlacementDispatch(
   service: WorkerPlacementDispatchService,
 ): WorkerPlacementDispatchService {
+  type PlacementFence = { promise: Promise<void> };
+  type ReconciliationSweep = PlacementFence & {
+    predecessor: PlacementFence | undefined;
+    acceptingJoins: boolean;
+    joinedRecoveries: Set<Promise<void>>;
+  };
   let activeDispatchCount = 0;
-  let reconciliation: Promise<void> | undefined;
+  let placementFence: PlacementFence | undefined;
+  // A sweep can join an environment pass that began before the sweep. Keep its predecessor
+  // separate from the fence tail so recovery waits for older exclusive work, never the sweep
+  // it completes or exclusive work queued behind that sweep.
+  let reconciliationSweep: ReconciliationSweep | undefined;
   const dispatchIdleWaiters = new Set<() => void>();
   const waitForDispatchIdle = (): Promise<void> => {
     if (activeDispatchCount === 0) {
@@ -18,27 +28,45 @@ export function coordinateWorkerPlacementDispatch(
     });
   };
   const runReconciliation = (operation: () => Promise<void>): Promise<void> => {
-    if (reconciliation) {
-      return reconciliation;
+    if (reconciliationSweep) {
+      return reconciliationSweep.promise;
     }
-    const current = (async () => {
-      await waitForDispatchIdle();
-      await operation();
-    })();
-    reconciliation = current;
-    const clearCurrent = () => {
-      if (reconciliation === current) {
-        reconciliation = undefined;
-      }
+    const predecessor = placementFence;
+    const sweep: ReconciliationSweep = {
+      predecessor,
+      promise: Promise.resolve(),
+      acceptingJoins: true,
+      joinedRecoveries: new Set(),
     };
-    void current.then(clearCurrent, clearCurrent);
+    const current = (async () => {
+      try {
+        if (predecessor) {
+          await predecessor.promise.catch(() => undefined);
+        }
+        await waitForDispatchIdle();
+        await operation();
+      } finally {
+        // Close admission before draining so late recoveries queue behind the existing fence.
+        sweep.acceptingJoins = false;
+        await Promise.allSettled(sweep.joinedRecoveries);
+        if (reconciliationSweep === sweep) {
+          reconciliationSweep = undefined;
+        }
+        if (placementFence === sweep) {
+          placementFence = undefined;
+        }
+      }
+    })();
+    sweep.promise = current;
+    reconciliationSweep = sweep;
+    placementFence = sweep;
     return current;
   };
   const runExclusivePlacementOperation = <T>(operation: () => Promise<T>): Promise<T> => {
     const current = (async () => {
-      const pendingReconciliation = reconciliation;
-      if (pendingReconciliation) {
-        await pendingReconciliation.catch(() => undefined);
+      const pendingFence = placementFence;
+      if (pendingFence) {
+        await pendingFence.promise.catch(() => undefined);
       }
       await waitForDispatchIdle();
       return await operation();
@@ -47,20 +75,21 @@ export function coordinateWorkerPlacementDispatch(
       () => undefined,
       () => undefined,
     );
-    reconciliation = barrier;
+    const exclusive: PlacementFence = { promise: barrier };
+    placementFence = exclusive;
     return current.finally(() => {
-      if (reconciliation === barrier) {
-        reconciliation = undefined;
+      if (placementFence === exclusive) {
+        placementFence = undefined;
       }
     });
   };
   const runPlacementOperation = async <T>(operation: () => Promise<T>): Promise<T> => {
     for (;;) {
-      const pendingReconciliation = reconciliation;
-      if (!pendingReconciliation) {
+      const pendingFence = placementFence;
+      if (!pendingFence) {
         break;
       }
-      await pendingReconciliation.catch(() => undefined);
+      await pendingFence.promise.catch(() => undefined);
     }
     activeDispatchCount += 1;
     try {
@@ -151,5 +180,24 @@ export function coordinateWorkerPlacementDispatch(
       environmentId === undefined
         ? runReconciliation(() => service.reconcileActive())
         : runExclusivePlacementOperation(() => service.reconcileActive(environmentId)),
+    resumeProvisioning: (placement, reconcileEnvironmentCore) => {
+      const sweep = reconciliationSweep;
+      if (sweep?.acceptingJoins) {
+        const recovery = (async () => {
+          if (sweep.predecessor) {
+            await sweep.predecessor.promise.catch(() => undefined);
+          }
+          // The sweep fence blocks new dispatches. Its environment pass still joins only after
+          // dispatches admitted before that fence and older exclusive work have drained.
+          await waitForDispatchIdle();
+          return await service.resumeProvisioning(placement, reconcileEnvironmentCore);
+        })();
+        sweep.joinedRecoveries.add(recovery);
+        return recovery;
+      }
+      return runExclusivePlacementOperation(() =>
+        service.resumeProvisioning(placement, reconcileEnvironmentCore),
+      );
+    },
   };
 }

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -15,6 +15,10 @@ export type WorkerActiveDispatchPlacement = Extract<
   { state: "active" }
 >;
 export type WorkerFailedDispatchPlacement = Extract<WorkerDispatchPlacement, { state: "failed" }>;
+export type WorkerProvisioningDispatchPlacement = Extract<
+  WorkerDispatchPlacement,
+  { state: "provisioning" }
+>;
 type WorkerDrainingDispatchPlacement = Extract<WorkerDispatchPlacement, { state: "draining" }>;
 type WorkerReconcilingDispatchPlacement = Extract<
   WorkerDispatchPlacement,

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -5,7 +5,14 @@ import {
   type WorkerAdmissionHandshake,
 } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
-import { seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { createPlacementFailureActions } from "./placement-dispatch-failure.js";
+import { createWorkerPlacementDispatchStartup } from "./placement-dispatch-startup.js";
+import {
+  BUNDLE_HASH,
+  MANIFEST_REF,
+  REQUEST,
+  seedActivePlacement,
+} from "./placement-dispatch-test-fixtures.js";
 import { createHarness } from "./placement-dispatch-test-harness.js";
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
@@ -15,6 +22,386 @@ import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation
 
 describe("worker placement restart recovery", () => {
   support.setupWorkerEnvironmentServiceSuite();
+
+  it.each([
+    { creation: "profile", matchingEnvironmentExists: true },
+    { creation: "inherited", matchingEnvironmentExists: true },
+    { creation: "profile", matchingEnvironmentExists: false },
+  ] as const)(
+    "never tears down an unrelated environment returned by $creation creation (expected owner exists: $matchingEnvironmentExists)",
+    async ({ creation, matchingEnvironmentExists }) => {
+      const placements = createWorkerSessionPlacementStore({
+        database: support.testState.stateDb,
+        now: () => 1_000,
+      });
+      const harness = createHarness(placements);
+      const unrelatedEnvironment = {
+        ...harness.attached,
+        environmentId: "worker-unrelated-active",
+        ownerEpoch: 91,
+        attachedSessionIds: ["session-unrelated"],
+      };
+      vi.mocked(harness.environments.create).mockResolvedValue(unrelatedEnvironment);
+      vi.mocked(harness.environments.createFromProfileSnapshot).mockResolvedValue(
+        unrelatedEnvironment,
+      );
+      vi.mocked(harness.environments.get).mockImplementation((environmentId) => {
+        if (environmentId === unrelatedEnvironment.environmentId) {
+          return unrelatedEnvironment;
+        }
+        return matchingEnvironmentExists && environmentId === harness.ready.environmentId
+          ? harness.ready
+          : undefined;
+      });
+      const request =
+        creation === "inherited"
+          ? {
+              ...REQUEST,
+              inheritedProfile: {
+                providerId: "fake",
+                profileSnapshot: { install: "bundle" as const, settings: { region: "parent" } },
+              },
+            }
+          : REQUEST;
+
+      await expect(harness.service.dispatch(request)).rejects.toThrow(
+        "current execution-context contract",
+      );
+
+      expect(harness.placements.current()).toMatchObject({
+        state: "failed",
+        environmentId: harness.ready.environmentId,
+      });
+      expect(harness.environments.attachSession).not.toHaveBeenCalled();
+      expect(harness.environments.stopTunnel).not.toHaveBeenCalledWith(
+        unrelatedEnvironment.environmentId,
+        expect.anything(),
+      );
+      expect(harness.environments.destroy).not.toHaveBeenCalledWith(
+        unrelatedEnvironment.environmentId,
+      );
+      if (matchingEnvironmentExists) {
+        expect(harness.environments.stopTunnel).toHaveBeenCalledWith(
+          harness.ready.environmentId,
+          harness.ready.ownerEpoch,
+        );
+        expect(harness.environments.destroy).toHaveBeenCalledWith(harness.ready.environmentId);
+      } else {
+        expect(harness.environments.stopTunnel).not.toHaveBeenCalled();
+        expect(harness.environments.destroy).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("resumes an authoritative provisioning placement through the canonical dispatch stages", async () => {
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => 1_000,
+    });
+    const harness = createHarness(placements);
+    const provisioning = harness.placements.seedProvisioning();
+    if (provisioning.state !== "provisioning") {
+      throw new Error("recovery fixture did not produce a provisioning placement");
+    }
+    harness.log.length = 0;
+
+    await harness.service.resumeProvisioning(provisioning, async () => {
+      harness.log.push("environment:reconcile");
+    });
+
+    expect(harness.placements.current()).toMatchObject({
+      state: "active",
+      environmentId: harness.ready.environmentId,
+      activeOwnerEpoch: harness.attached.ownerEpoch,
+      workerBundleHash: harness.ready.bootstrapReceipt?.bundleHash,
+    });
+    expect(harness.placements.current()!.generation).toBeGreaterThan(provisioning.generation);
+    expect(harness.environments.create).not.toHaveBeenCalled();
+    expect(harness.environments.attachSession).toHaveBeenCalledOnce();
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+    expect(harness.log).toContain("recovery-barrier");
+    expect(harness.log).toContain("placement:syncing");
+    expect(harness.log).toContain("placement:starting");
+    expect(harness.log).toContain("placement:active");
+    expect(harness.log).not.toContain("activation");
+  });
+
+  it("fails a placement interrupted before its environment intent and permits redispatch", async () => {
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => 1_000,
+    });
+    const harness = createHarness(placements);
+    const provisioning = harness.placements.seedProvisioning();
+    vi.mocked(harness.environments.get).mockReturnValue(undefined);
+
+    await harness.service.reconcile();
+
+    const failed = harness.placements.current();
+    expect(failed).toMatchObject({
+      state: "failed",
+      environmentId: provisioning.environmentId,
+      recoveryError: expect.stringContaining("environment"),
+    });
+    expect(harness.environments.stopTunnel).not.toHaveBeenCalled();
+    expect(harness.environments.destroy).not.toHaveBeenCalled();
+    if (failed?.state !== "failed") {
+      throw new Error("restart recovery did not fail the interrupted provisioning placement");
+    }
+
+    const redispatch = createHarness(placements, {
+      environmentGeneration: failed.generation + 1,
+    });
+    const active = await redispatch.service.dispatch(REQUEST);
+
+    expect(active).toMatchObject({
+      state: "active",
+      environmentId: redispatch.ready.environmentId,
+    });
+    expect(active.environmentId).not.toBe(provisioning.environmentId);
+  });
+
+  it.each(["requested", "provisioning", "bootstrapping", "ready", "idle"] as const)(
+    "retains an exact replayable %s environment during provisioning recovery",
+    async (state) => {
+      const placements = createWorkerSessionPlacementStore({
+        database: support.testState.stateDb,
+        now: () => 1_000,
+      });
+      const harness = createHarness(placements);
+      const provisioning = harness.placements.seedProvisioning();
+      const environment =
+        state === "requested" || state === "provisioning"
+          ? {
+              ...harness.ready,
+              state,
+              leaseId: null,
+              sshEndpoint: null,
+              bootstrapReceipt: null,
+              sharedHost: null,
+              tunnelStatus: "stopped" as const,
+            }
+          : state === "bootstrapping"
+            ? { ...harness.ready, state, bootstrapReceipt: null }
+            : { ...harness.ready, state };
+      vi.mocked(harness.environments.get).mockReturnValue(environment);
+
+      await harness.service.reconcile();
+
+      expect(harness.placements.current()).toEqual(provisioning);
+      expect(harness.environments.destroy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["destroy-requested", { destroyRequestedAtMs: 1_000 }],
+    ["attached", { state: "attached" as const, attachedSessionIds: Array.of(REQUEST.sessionId) }],
+    ["draining", { state: "draining" as const }],
+    ["destroying", { state: "destroying" as const }],
+    ["destroyed", { state: "destroyed" as const }],
+    ["failed", { state: "failed" as const }],
+    ["orphaned", { state: "orphaned" as const }],
+    ["mismatched", { environmentId: "worker-different" }],
+    ["missing receipt", { bootstrapReceipt: null }],
+    [
+      "legacy launch dialect",
+      {
+        bootstrapReceipt: {
+          bundleHash: "a".repeat(64),
+          openclawVersion: "2026.7.2",
+          protocolFeatures: Array.of(WORKER_LAUNCH_V2_PROTOCOL_FEATURE),
+        },
+      },
+    ],
+  ] as const)("fails provisioning recovery for a %s environment", async (_kind, patch) => {
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => 1_000,
+    });
+    const harness = createHarness(placements);
+    harness.placements.seedProvisioning();
+    const environment =
+      "state" in patch && patch.state === "failed"
+        ? {
+            ...harness.ready,
+            ...patch,
+            leaseId: null,
+            sshEndpoint: null,
+            bootstrapReceipt: null,
+            sharedHost: null,
+            tunnelStatus: "stopped" as const,
+          }
+        : { ...harness.ready, ...patch };
+    vi.mocked(harness.environments.get).mockReturnValue(environment);
+
+    await harness.service.reconcile();
+
+    expect(harness.placements.current()).toMatchObject({ state: "failed" });
+  });
+
+  it.each([
+    ["session", "Session agent:main:session-1 changed before cloud worker recovery"],
+    ["runtime", "Session agent:main:session-1 runtime changed before cloud worker recovery"],
+    ["generation", "Session agent:main:session-1 placement generation changed before recovery"],
+  ] as const)("tears down provisioning when %s authority changed", async (_kind, message) => {
+    const placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => 1_000,
+    });
+    const harness = createHarness(placements, {
+      recoveryBarrierError: new Error(message),
+    });
+    const provisioning = harness.placements.seedProvisioning();
+    if (provisioning.state !== "provisioning") {
+      throw new Error("recovery fixture did not produce a provisioning placement");
+    }
+
+    await harness.service.resumeProvisioning(provisioning, async () => {});
+
+    expect(harness.placements.current()).toMatchObject({
+      state: "failed",
+      recoveryError: message,
+    });
+    expect(harness.environments.attachSession).not.toHaveBeenCalled();
+    expect(harness.environments.destroy).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { timing: "before", change: "generation", state: "provisioning" },
+    { timing: "before", change: "environment", state: "provisioning" },
+    { timing: "before", change: "environment", state: "syncing" },
+    { timing: "before", change: "environment", state: "starting" },
+    { timing: "before", change: "session", state: "provisioning" },
+    { timing: "after", change: "generation", state: "provisioning" },
+    { timing: "after", change: "environment", state: "provisioning" },
+    { timing: "after", change: "environment", state: "syncing" },
+    { timing: "after", change: "environment", state: "starting" },
+    { timing: "after", change: "session", state: "provisioning" },
+  ] as const)(
+    "never tears down a newer $state $change owner when recovery fails $timing its callback",
+    async ({ change, state, timing }) => {
+      const placements = createWorkerSessionPlacementStore({
+        database: support.testState.stateDb,
+        now: () => 1_000,
+      });
+      const harness = createHarness(placements);
+      const original = harness.placements.seedProvisioning();
+      if (original.state !== "provisioning" || !original.environmentId) {
+        throw new Error("recovery fixture did not produce an owned provisioning placement");
+      }
+      const replacementEnvironmentId =
+        change === "environment" ? "worker-newer-environment" : original.environmentId;
+      const pendingEnvironment = {
+        ...harness.ready,
+        state: "provisioning" as const,
+        leaseId: null,
+        sshEndpoint: null,
+        bootstrapReceipt: null,
+        sharedHost: null,
+        tunnelStatus: "stopped" as const,
+      };
+      vi.mocked(harness.environments.get).mockImplementation((environmentId) =>
+        environmentId === original.environmentId
+          ? pendingEnvironment
+          : environmentId === replacementEnvironmentId
+            ? { ...harness.ready, environmentId }
+            : undefined,
+      );
+      let replacement: ReturnType<typeof placements.get>;
+      const observedPlacements = {
+        ...placements,
+        get: (sessionId: string) => {
+          const current = placements.get(sessionId);
+          return change === "session" && replacement && current
+            ? { ...current, sessionKey: "agent:main:replacement-session" }
+            : current;
+        },
+      };
+      const replacePlacement = () => {
+        placements.fail({
+          sessionId: original.sessionId,
+          expectedGeneration: original.generation,
+          recoveryError: "superseded placement",
+        });
+        const requested = placements.startDispatch(REQUEST);
+        replacement = placements.transition({
+          sessionId: original.sessionId,
+          from: "requested",
+          to: "provisioning",
+          expectedGeneration: requested.generation,
+          patch: { environmentId: replacementEnvironmentId },
+        });
+        if (state === "syncing" || state === "starting") {
+          replacement = placements.transition({
+            sessionId: original.sessionId,
+            from: "provisioning",
+            to: "syncing",
+            expectedGeneration: replacement.generation,
+            patch: { workerBundleHash: BUNDLE_HASH },
+          });
+        }
+        if (state === "starting") {
+          replacement = placements.transition({
+            sessionId: original.sessionId,
+            from: "syncing",
+            to: "starting",
+            expectedGeneration: replacement.generation,
+            patch: {
+              workspaceBaseManifestRef: MANIFEST_REF,
+              remoteWorkspaceDir: "/worker/newer-workspace",
+            },
+          });
+        }
+      };
+      const startup = createWorkerPlacementDispatchStartup({
+        placements: observedPlacements,
+        environments: harness.environments,
+        failure: createPlacementFailureActions({
+          placements: observedPlacements,
+          environments: harness.environments,
+        }),
+        runRecoveryBarrier: async ({ run }) => {
+          if (timing === "after") {
+            await run("/gateway/workspace");
+          }
+          replacePlacement();
+          throw new Error("stale recovery lifecycle was replaced");
+        },
+        runActivationBarrier: async ({ activate }) => activate(),
+        reportTransition: (observer, placement) => observer?.(placement),
+      });
+
+      await startup.resumeProvisioning(original, async () => {});
+
+      expect(placements.get(original.sessionId)).toEqual(replacement);
+      expect(harness.environments.stopTunnel).not.toHaveBeenCalled();
+      expect(harness.environments.destroy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["attach", "tunnel:attached", "sync"] as const)(
+    "tears down only its exact owned placement when recovery fails during %s",
+    async (failAt) => {
+      const placements = createWorkerSessionPlacementStore({
+        database: support.testState.stateDb,
+        now: () => 1_000,
+      });
+      const harness = createHarness(placements, { failAt });
+      const provisioning = harness.placements.seedProvisioning();
+      if (provisioning.state !== "provisioning") {
+        throw new Error("recovery fixture did not produce a provisioning placement");
+      }
+
+      await harness.service.resumeProvisioning(provisioning, async () => {});
+
+      expect(harness.placements.current()).toMatchObject({
+        state: "failed",
+        environmentId: provisioning.environmentId,
+        recoveryError: expect.stringContaining("failed"),
+      });
+      expect(harness.environments.destroy).toHaveBeenCalledWith(provisioning.environmentId);
+    },
+  );
 
   it("does not recover a pending result through a worker with the legacy launch dialect", async () => {
     const placements = createWorkerSessionPlacementStore({
@@ -100,6 +487,7 @@ describe("worker placement restart recovery", () => {
         environments: workerService,
         workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
         runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+        runRecoveryBarrier: async ({ run }) => await run("/gateway/workspace"),
         runActivationBarrier: async ({ activate }) => activate(),
         runMoveBarrier: async ({ begin }) => begin(),
         resolveMoveDestination: async () => undefined,

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -1,3 +1,4 @@
+import { supportsWorkerExecutionContextLaunch } from "./admission.js";
 import {
   isCurrentActiveWorkerEnvironment,
   isUnavailableEnvironment,
@@ -134,6 +135,36 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
         continue;
       }
       if (placement.state === "local" || placement.state === "reclaimed") {
+        continue;
+      }
+      if (placement.state === "provisioning") {
+        const environment = placement.environmentId
+          ? environments.get(placement.environmentId)
+          : undefined;
+        const exactEnvironment =
+          environment?.environmentId === placement.environmentId ? environment : undefined;
+        if (
+          exactEnvironment &&
+          exactEnvironment.destroyRequestedAtMs === null &&
+          (exactEnvironment.state === "requested" ||
+            exactEnvironment.state === "provisioning" ||
+            exactEnvironment.state === "bootstrapping" ||
+            ((exactEnvironment.state === "ready" || exactEnvironment.state === "idle") &&
+              supportsWorkerExecutionContextLaunch(exactEnvironment.bootstrapReceipt)))
+        ) {
+          // Transient provider or node-enrollment failure retains its exact durable operation.
+          continue;
+        }
+        await failure.teardownEnvironment({
+          placement,
+          environmentId: exactEnvironment?.environmentId ?? null,
+          ownerEpoch: exactEnvironment?.ownerEpoch ?? null,
+          primaryError: new Error(
+            exactEnvironment
+              ? `Provisioning worker environment cannot be recovered from ${exactEnvironment.state}`
+              : "Provisioning worker environment record is missing",
+          ),
+        });
         continue;
       }
       if (placement.state === "active") {

--- a/src/gateway/worker-environments/placement-dispatch-startup.ts
+++ b/src/gateway/worker-environments/placement-dispatch-startup.ts
@@ -1,0 +1,286 @@
+import { supportsWorkerExecutionContextLaunch } from "./admission.js";
+import type {
+  PlacementFailureActions,
+  WorkerActivationBarrier,
+  WorkerActiveDispatchPlacement,
+  WorkerDispatchEnvironmentService,
+  WorkerDispatchPlacement,
+  WorkerDispatchPlacementStore,
+  WorkerProvisioningDispatchPlacement,
+} from "./placement-dispatch-failure.js";
+import type {
+  WorkerPlacementAuthorization,
+  WorkerPlacementDispatchRequest,
+} from "./service-contract.js";
+import type { WorkerEnvironmentReconcileCore, WorkerEnvironmentService } from "./service.js";
+
+export type WorkerPlacementRecoveryBarrier = (params: {
+  sessionId: string;
+  sessionKey: string;
+  agentId: string;
+  executionMode: WorkerPlacementDispatchRequest["executionMode"];
+  environmentId: string;
+  expectedGeneration: number;
+  run: (localPath: string) => Promise<void>;
+}) => Promise<void>;
+
+function isPendingProvisioningEnvironment(
+  environment: ReturnType<WorkerEnvironmentService["get"]>,
+  environmentId: string | null,
+): boolean {
+  return (
+    environment?.environmentId === environmentId &&
+    environment.destroyRequestedAtMs === null &&
+    (environment.state === "requested" ||
+      environment.state === "provisioning" ||
+      environment.state === "bootstrapping")
+  );
+}
+
+function requireProvisionedEnvironment(
+  environment: Awaited<ReturnType<WorkerEnvironmentService["create"]>>,
+  expectedEnvironmentId: string,
+): { environmentId: string; ownerEpoch: number; bundleHash: string } {
+  if (
+    (environment.state !== "ready" && environment.state !== "idle") ||
+    environment.environmentId !== expectedEnvironmentId ||
+    environment.destroyRequestedAtMs !== null ||
+    !environment.bootstrapReceipt ||
+    !supportsWorkerExecutionContextLaunch(environment.bootstrapReceipt)
+  ) {
+    throw new Error(
+      `Worker environment is not dispatchable with the current execution-context contract: ${environment.state}`,
+    );
+  }
+  return {
+    environmentId: environment.environmentId,
+    ownerEpoch: environment.ownerEpoch,
+    bundleHash: environment.bootstrapReceipt.bundleHash,
+  };
+}
+
+export function createWorkerPlacementDispatchStartup(options: {
+  placements: WorkerDispatchPlacementStore;
+  environments: WorkerDispatchEnvironmentService;
+  failure: PlacementFailureActions;
+  runRecoveryBarrier: WorkerPlacementRecoveryBarrier;
+  runActivationBarrier: WorkerActivationBarrier;
+  onActivated?: (request: WorkerPlacementDispatchRequest) => void;
+  resolveGitAuthor?: (agentId: string) => { name?: string; email?: string } | undefined;
+  reportTransition: (
+    observer: ((placement: WorkerDispatchPlacement) => void) | undefined,
+    placement: WorkerDispatchPlacement,
+  ) => void;
+}) {
+  const { environments, failure, placements } = options;
+
+  const continueProvisionedDispatch = async (params: {
+    request: WorkerPlacementDispatchRequest;
+    placement: WorkerDispatchPlacement;
+    environment: Awaited<ReturnType<WorkerEnvironmentService["create"]>>;
+    expectedEnvironmentId: string;
+    localPath: string;
+    onTransition?: (placement: WorkerDispatchPlacement) => void;
+    authorize?: WorkerPlacementAuthorization;
+    recovery?: true;
+  }): Promise<WorkerActiveDispatchPlacement> => {
+    if (params.placement.state !== "provisioning") {
+      throw new Error("Worker dispatch continuation requires a provisioning placement");
+    }
+    const { request } = params;
+    const provisioned = requireProvisionedEnvironment(
+      params.environment,
+      params.expectedEnvironmentId,
+    );
+    let placement = placements.transition({
+      sessionId: request.sessionId,
+      from: "provisioning",
+      to: "syncing",
+      expectedGeneration: params.placement.generation,
+      patch: {
+        environmentId: provisioned.environmentId,
+        workerBundleHash: provisioned.bundleHash,
+      },
+    });
+    options.reportTransition(params.onTransition, placement);
+    const credential = await environments.attachSession({
+      environmentId: provisioned.environmentId,
+      ownerEpoch: provisioned.ownerEpoch,
+      sessionId: request.sessionId,
+    });
+    const ownerEpoch = credential.ownerEpoch;
+    const tunnel = await environments.startTunnel({
+      environmentId: provisioned.environmentId,
+      ownerEpoch,
+    });
+    const gitAuthor = options.resolveGitAuthor?.(request.agentId);
+    const synced = await tunnel.syncWorkspace({
+      localPath: params.localPath,
+      sessionId: request.sessionId,
+      generation: placement.generation,
+      ...(gitAuthor ? { gitAuthor } : {}),
+    });
+    placement = placements.transition({
+      sessionId: request.sessionId,
+      from: "syncing",
+      to: "starting",
+      expectedGeneration: placement.generation,
+      patch: {
+        workspaceBaseManifestRef: synced.manifestRef,
+        remoteWorkspaceDir: synced.remoteWorkspaceDir,
+      },
+    });
+    options.reportTransition(params.onTransition, placement);
+    const startingPlacement = placement;
+    const attachedEnvironment = environments.get(provisioned.environmentId);
+    if (
+      !attachedEnvironment ||
+      attachedEnvironment.state !== "attached" ||
+      attachedEnvironment.ownerEpoch !== ownerEpoch ||
+      attachedEnvironment.attachedSessionIds.length !== 1 ||
+      attachedEnvironment.attachedSessionIds[0] !== request.sessionId ||
+      attachedEnvironment.bootstrapReceipt?.bundleHash !== provisioned.bundleHash
+    ) {
+      throw new Error("Worker dispatch lost its exact environment owner before activation");
+    }
+    const activate = (): WorkerActiveDispatchPlacement => {
+      const activated = placements.transition({
+        sessionId: request.sessionId,
+        from: "starting",
+        to: "active",
+        expectedGeneration: startingPlacement.generation,
+        patch: { activeOwnerEpoch: ownerEpoch },
+      });
+      if (activated.state !== "active") {
+        throw new Error("Worker dispatch activation did not produce an active placement");
+      }
+      options.reportTransition(params.onTransition, activated);
+      return activated;
+    };
+    // Recovery retains the exact session/placement lifecycle fence through activation.
+    const activePlacement = params.recovery
+      ? activate()
+      : await options.runActivationBarrier({
+          sessionId: request.sessionId,
+          sessionKey: request.sessionKey,
+          agentId: request.agentId,
+          executionMode: request.executionMode,
+          authorize: params.authorize,
+          activate,
+        });
+    try {
+      options.onActivated?.(request);
+    } catch {
+      // Maintenance scheduling cannot overturn a durable placement activation.
+    }
+    return activePlacement;
+  };
+
+  const resumeProvisioning = async (
+    placement: WorkerProvisioningDispatchPlacement,
+    reconcileEnvironmentCore: WorkerEnvironmentReconcileCore,
+  ): Promise<void> => {
+    const environmentId = placement.environmentId;
+    let recoveryRunStarted = false;
+    let recoveryOwnedPlacement: WorkerDispatchPlacement = placement;
+    const handleRecoveryFailure = async (error: unknown): Promise<void> => {
+      const current = placements.get(placement.sessionId);
+      if (
+        !current ||
+        (current.state !== "provisioning" &&
+          current.state !== "syncing" &&
+          current.state !== "starting") ||
+        current.state !== recoveryOwnedPlacement.state ||
+        current.generation !== recoveryOwnedPlacement.generation ||
+        current.environmentId !== environmentId ||
+        current.sessionKey !== placement.sessionKey ||
+        current.agentId !== placement.agentId ||
+        current.executionMode !== placement.executionMode
+      ) {
+        return;
+      }
+      const environment = environmentId ? environments.get(environmentId) : undefined;
+      // Only a provider replay entered with exact authority may retain its durable operation.
+      if (
+        recoveryRunStarted &&
+        current.state === "provisioning" &&
+        isPendingProvisioningEnvironment(environment, environmentId)
+      ) {
+        return;
+      }
+      const exactEnvironment = environment?.environmentId === environmentId ? environment : null;
+      await failure.teardownEnvironment({
+        placement: current,
+        environmentId: exactEnvironment?.environmentId ?? null,
+        ownerEpoch: exactEnvironment?.ownerEpoch ?? null,
+        primaryError: error,
+      });
+    };
+    try {
+      if (!environmentId) {
+        throw new Error("Provisioning worker placement has no environment owner");
+      }
+      await options.runRecoveryBarrier({
+        sessionId: placement.sessionId,
+        sessionKey: placement.sessionKey,
+        agentId: placement.agentId,
+        executionMode: placement.executionMode,
+        environmentId,
+        expectedGeneration: placement.generation,
+        run: async (localPath) => {
+          recoveryRunStarted = true;
+          try {
+            const initialEnvironment = environments.get(environmentId);
+            if (initialEnvironment?.environmentId !== environmentId) {
+              throw new Error("Provisioning worker environment record is missing");
+            }
+            if (initialEnvironment.destroyRequestedAtMs !== null) {
+              throw new Error("Provisioning worker environment destruction was requested");
+            }
+            await reconcileEnvironmentCore();
+            const current = placements.get(placement.sessionId);
+            if (
+              current?.state !== "provisioning" ||
+              current.generation !== placement.generation ||
+              current.environmentId !== environmentId
+            ) {
+              throw new Error("Provisioning worker placement changed during restart recovery");
+            }
+            const environment = environments.get(environmentId);
+            if (environment?.environmentId !== environmentId) {
+              throw new Error("Provisioning worker environment record is missing");
+            }
+            if (isPendingProvisioningEnvironment(environment, environmentId)) {
+              return;
+            }
+            await continueProvisionedDispatch({
+              request: {
+                sessionId: placement.sessionId,
+                sessionKey: placement.sessionKey,
+                agentId: placement.agentId,
+                profileId: environment.profileId,
+                executionMode: placement.executionMode,
+                ...(environment.nodeDeviceId ? { deviceId: environment.nodeDeviceId } : {}),
+              },
+              placement: current,
+              environment,
+              expectedEnvironmentId: environmentId,
+              localPath,
+              onTransition: (next) => {
+                recoveryOwnedPlacement = next;
+              },
+              recovery: true,
+            });
+          } catch (error) {
+            // Keep teardown under the same session lifecycle fence that admitted recovery.
+            await handleRecoveryFailure(error);
+          }
+        },
+      });
+    } catch (error) {
+      await handleRecoveryFailure(error);
+    }
+  };
+
+  return { continueProvisionedDispatch, resumeProvisioning };
+}

--- a/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-fixtures.ts
@@ -36,19 +36,27 @@ export const REQUEST: WorkerDispatchRequest = {
   executionMode: "worker-turn",
 };
 
+export function seedProvisioningPlacement(
+  store: PlacementStore,
+  environmentId: string,
+  executionMode: WorkerDispatchRequest["executionMode"] = REQUEST.executionMode,
+): WorkerSessionPlacementRecord {
+  const requested = store.startDispatch({ ...REQUEST, executionMode });
+  return store.transition({
+    sessionId: REQUEST.sessionId,
+    from: "requested",
+    to: "provisioning",
+    expectedGeneration: requested.generation,
+    patch: { environmentId },
+  });
+}
+
 export function seedSyncingPlacement(
   store: PlacementStore,
   environmentId: string,
   executionMode: WorkerDispatchRequest["executionMode"] = REQUEST.executionMode,
 ): WorkerSessionPlacementRecord {
-  let current = store.startDispatch({ ...REQUEST, executionMode });
-  current = store.transition({
-    sessionId: REQUEST.sessionId,
-    from: "requested",
-    to: "provisioning",
-    expectedGeneration: current.generation,
-    patch: { environmentId },
-  });
+  let current = seedProvisioningPlacement(store, environmentId, executionMode);
   current = store.transition({
     sessionId: REQUEST.sessionId,
     from: "provisioning",

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -12,6 +12,7 @@ import {
   type PlacementStore,
   REQUEST,
   seedActivePlacement,
+  seedProvisioningPlacement,
   seedStartingPlacement,
 } from "./placement-dispatch-test-fixtures.js";
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
@@ -49,6 +50,7 @@ export function createHarness(
     terminalizedReclaimError?: Error;
     environmentGeneration?: number;
     failMoveAfterBegin?: boolean;
+    recoveryBarrierError?: Error;
     prepareAcceptedWorkspacePublication?: Parameters<
       typeof createWorkerPlacementDispatchService
     >[0]["prepareAcceptedWorkspacePublication"];
@@ -361,6 +363,13 @@ export function createHarness(
       }
       return placement;
     },
+    runRecoveryBarrier: async ({ run }) => {
+      log.push("recovery-barrier");
+      if (options.recoveryBarrierError) {
+        throw options.recoveryBarrierError;
+      }
+      await run(options.workspacePath ?? "/gateway/workspace");
+    },
     runActivationBarrier: async ({ authorize, activate }) => {
       authorize?.();
       fail("activation");
@@ -408,6 +417,7 @@ export function createHarness(
     reconciledManifestRef,
     placements: {
       current: () => placementStore.get(REQUEST.sessionId),
+      seedProvisioning: () => seedProvisioningPlacement(placementStore, environmentId),
       seedStarting: () => seedStartingPlacement(placementStore, environmentId),
       seedActive: (ownerEpoch: number, executionMode?: "worker-turn" | "remote-exec") =>
         seedActivePlacement(placementStore, { environmentId, ownerEpoch, executionMode }),

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -581,7 +581,7 @@ describe("worker placement dispatch", () => {
     );
   });
 
-  it.each(["requested", "provisioning", "syncing"] as const)(
+  it.each(["requested", "syncing"] as const)(
     "allows explicit redispatch after restart recovery fails an interrupted %s placement",
     async (interruptedState) => {
       let interrupted = placementStore.startDispatch(REQUEST);

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { supportsWorkerExecutionContextLaunch } from "./admission.js";
 import * as device from "./device-provider.js";
 import {
   createPlacementFailureActions,
@@ -11,6 +10,10 @@ import {
   type WorkerDispatchPlacementStore,
 } from "./placement-dispatch-failure.js";
 import { createPlacementRecoveryActions } from "./placement-dispatch-recovery.js";
+import {
+  createWorkerPlacementDispatchStartup,
+  type WorkerPlacementRecoveryBarrier,
+} from "./placement-dispatch-startup.js";
 import { forceAbandonWorkerEnvironment } from "./placement-force-abandon.js";
 import type { WorkerPlacementMoveIntent } from "./placement-move-intent.js";
 import {
@@ -30,7 +33,6 @@ import type {
   WorkerPlacementReclaimRequest,
 } from "./service-contract.js";
 import { deriveEnvironmentIntent } from "./service-contract.js";
-import type { WorkerEnvironmentService } from "./service.js";
 import { isFailedWorkerPlacementEnvironmentGone } from "./session-placement-lifecycle.js";
 import { WorkerTunnelOwnerDisconnectedError } from "./tunnel-contract.js";
 import type { WorkerWorkspaceResultConflict } from "./workspace-conflicts.js";
@@ -88,6 +90,7 @@ type WorkerPlacementDispatchOptions = WorkerPlacementReclaimBarriers & {
   placements: WorkerDispatchPlacementStore;
   environments: WorkerDispatchEnvironmentService;
   runLocalBarrier: WorkerLocalDispatchBarrier;
+  runRecoveryBarrier: WorkerPlacementRecoveryBarrier;
   runActivationBarrier: WorkerActivationBarrier;
   runMoveBarrier: WorkerPlacementMoveBarrier;
   resolveMoveDestination: (
@@ -121,30 +124,6 @@ type WorkerPlacementDispatchOptions = WorkerPlacementReclaimBarriers & {
   resolveGitAuthor?: (agentId: string) => { name?: string; email?: string } | undefined;
 };
 
-function requireProvisionedEnvironment(
-  environment: Awaited<ReturnType<WorkerEnvironmentService["create"]>>,
-  expectedEnvironmentId: string,
-): { environmentId: string; ownerEpoch: number; bundleHash: string } {
-  // Node vs SSH transport is decided later from the environment itself; both
-  // arms of the old discriminated return carried identical fields, so this
-  // only validates dispatchability and hands back the prepared facts.
-  if (
-    (environment.state !== "ready" && environment.state !== "idle") ||
-    environment.environmentId !== expectedEnvironmentId ||
-    !environment.bootstrapReceipt ||
-    !supportsWorkerExecutionContextLaunch(environment.bootstrapReceipt)
-  ) {
-    throw new Error(
-      `Worker environment is not dispatchable with the current execution-context contract: ${environment.state}`,
-    );
-  }
-  return {
-    environmentId: environment.environmentId,
-    ownerEpoch: environment.ownerEpoch,
-    bundleHash: environment.bootstrapReceipt.bundleHash,
-  };
-}
-
 function isExactAttachedEnvironment(
   environment: ReturnType<WorkerDispatchEnvironmentService["get"]>,
   placement: WorkerActiveDispatchPlacement | WorkerDrainingDispatchPlacement,
@@ -163,6 +142,29 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
   const { environments, placements } = options;
   const failure = createPlacementFailureActions({ environments, placements });
   let recoverPlacementMoves = async (): Promise<Set<string>> => new Set();
+
+  const reportTransition = (
+    observer: ((placement: WorkerDispatchPlacement) => void) | undefined,
+    placement: WorkerDispatchPlacement,
+  ): void => {
+    try {
+      observer?.(placement);
+    } catch {
+      // Reporting cannot overturn the durable placement transition.
+    }
+  };
+
+  const startup = createWorkerPlacementDispatchStartup({
+    placements,
+    environments,
+    failure,
+    runRecoveryBarrier: options.runRecoveryBarrier,
+    runActivationBarrier: options.runActivationBarrier,
+    onActivated: options.onActivated,
+    resolveGitAuthor: options.resolveGitAuthor,
+    reportTransition,
+  });
+
   const recovery = createPlacementRecoveryActions({
     environments,
     failure,
@@ -180,25 +182,12 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
       : {}),
   });
 
-  const reportTransition = (
-    observer: ((placement: WorkerDispatchPlacement) => void) | undefined,
-    placement: WorkerDispatchPlacement,
-  ): void => {
-    try {
-      observer?.(placement);
-    } catch {
-      // Reporting cannot overturn the durable placement transition.
-    }
-  };
-
   const dispatch = async (
     request: WorkerPlacementDispatchRequest,
     onTransition?: (placement: WorkerDispatchPlacement) => void,
     authorize?: WorkerPlacementAuthorization,
   ): Promise<WorkerActiveDispatchPlacement> => {
     let placement: WorkerDispatchPlacement | undefined;
-    let environmentId: string | null = null;
-    let ownerEpoch: number | null = null;
     try {
       placement = await options.runLocalBarrier({
         sessionId: request.sessionId,
@@ -255,73 +244,15 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
             request.machineClass,
             request.executionMode,
           );
-      const provisioned = requireProvisionedEnvironment(environment, expectedEnvironmentId);
-      environmentId = provisioned.environmentId;
-      ownerEpoch = provisioned.ownerEpoch;
-      placement = placements.transition({
-        sessionId: request.sessionId,
-        from: "provisioning",
-        to: "syncing",
-        expectedGeneration: placement.generation,
-        patch: {
-          environmentId,
-          workerBundleHash: provisioned.bundleHash,
-        },
-      });
-      reportTransition(onTransition, placement);
-      const credential = await environments.attachSession({
-        environmentId,
-        ownerEpoch,
-        sessionId: request.sessionId,
-      });
-      ownerEpoch = credential.ownerEpoch;
-      const tunnel = await environments.startTunnel({ environmentId, ownerEpoch });
-      const gitAuthor = options.resolveGitAuthor?.(request.agentId);
-      const synced = await tunnel.syncWorkspace({
+      return await startup.continueProvisionedDispatch({
+        request,
+        placement,
+        environment,
+        expectedEnvironmentId,
         localPath,
-        sessionId: request.sessionId,
-        generation: placement.generation,
-        ...(gitAuthor ? { gitAuthor } : {}),
-      });
-      placement = placements.transition({
-        sessionId: request.sessionId,
-        from: "syncing",
-        to: "starting",
-        expectedGeneration: placement.generation,
-        patch: {
-          workspaceBaseManifestRef: synced.manifestRef,
-          remoteWorkspaceDir: synced.remoteWorkspaceDir,
-        },
-      });
-      reportTransition(onTransition, placement);
-      const startingPlacement = placement;
-      const activePlacement = await options.runActivationBarrier({
-        sessionId: request.sessionId,
-        sessionKey: request.sessionKey,
-        agentId: request.agentId,
-        executionMode: request.executionMode,
+        onTransition,
         authorize,
-        activate: () => {
-          const activated = placements.transition({
-            sessionId: request.sessionId,
-            from: "starting",
-            to: "active",
-            expectedGeneration: startingPlacement.generation,
-            patch: { activeOwnerEpoch: ownerEpoch },
-          });
-          if (activated.state !== "active") {
-            throw new Error("Worker dispatch activation did not produce an active placement");
-          }
-          reportTransition(onTransition, activated);
-          return activated;
-        },
       });
-      try {
-        options.onActivated?.(request);
-      } catch {
-        // Maintenance scheduling cannot overturn a durable placement activation.
-      }
-      return activePlacement;
     } catch (error) {
       try {
         const current = placement ? placements.get(request.sessionId) : undefined;
@@ -329,14 +260,17 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
           if (current.state === "active") {
             await failure.failActive(current, error);
           } else {
-            const currentEnvironmentId = environmentId ?? current.environmentId;
-            const currentEnvironment = currentEnvironmentId
-              ? environments.get(currentEnvironmentId)
+            const currentEnvironment = current.environmentId
+              ? environments.get(current.environmentId)
               : undefined;
+            const ownedEnvironment =
+              currentEnvironment?.environmentId === current.environmentId
+                ? currentEnvironment
+                : undefined;
             await failure.teardownEnvironment({
               placement: current,
-              environmentId: currentEnvironment?.environmentId ?? null,
-              ownerEpoch: ownerEpoch ?? currentEnvironment?.ownerEpoch ?? null,
+              environmentId: ownedEnvironment?.environmentId ?? null,
+              ownerEpoch: ownedEnvironment?.ownerEpoch ?? null,
               primaryError: error,
             });
           }
@@ -714,6 +648,7 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
     reclaim,
     reconcile: recovery.reconcile,
     reconcileActive: recovery.reconcileActive,
+    resumeProvisioning: startup.resumeProvisioning,
   };
 }
 

--- a/src/gateway/worker-environments/provider-bootstrap.test.ts
+++ b/src/gateway/worker-environments/provider-bootstrap.test.ts
@@ -182,6 +182,7 @@ describe("worker environment service", () => {
       environments: workerService,
       workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
       runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+      runRecoveryBarrier: async ({ run }) => await run("/gateway/workspace"),
       runActivationBarrier: async ({ activate }) => activate(),
       runMoveBarrier: async ({ begin }) => begin(),
       resolveMoveDestination: async () => undefined,

--- a/src/gateway/worker-environments/provider-provisioning.replay.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.replay.test.ts
@@ -3,13 +3,20 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
+import { WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { WorkerProviderError } from "../../plugins/types.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import { REQUEST } from "./placement-dispatch-test-fixtures.js";
+import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import { deriveEnvironmentIntent } from "./service-contract.js";
 import * as support from "./service.test-support.js";
 import { createWorkerEnvironmentStore } from "./store.js";
+import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
 
 type WorkerEnvironmentServiceError = support.WorkerEnvironmentServiceError;
 
@@ -95,6 +102,237 @@ describe("worker environment service provision replay", () => {
       state: "destroyed",
       leaseId: "lease-restarted",
     });
+  });
+
+  it("replays one node lease once across overlapping reconciliation and activates once", async () => {
+    const events: string[] = [];
+    const operationIds: string[] = [];
+    const physicalLeases = new Set<string>();
+    const enrollmentConnected = createDeferredCore<string>();
+    const destroy = vi.fn(async ({ leaseId }: { leaseId: string }) => {
+      physicalLeases.delete(leaseId);
+    });
+    let provisionCalls = 0;
+    let physicalAllocations = 0;
+    const provider = support.createProvider({
+      supportedExecutionModes: ["worker-turn"],
+      provisionBeforeInstallation: true,
+      requiresNodeEnrollment: true,
+      provision: async (_profile, operationId, options) => {
+        provisionCalls += 1;
+        events.push(`provision:${provisionCalls}`);
+        operationIds.push(operationId);
+        if (!physicalLeases.has("lease-node-replay")) {
+          physicalLeases.add("lease-node-replay");
+          physicalAllocations += 1;
+        }
+        if (provisionCalls === 1) {
+          throw new Error("provider response was lost after exact lease allocation");
+        }
+        let enrollment;
+        try {
+          enrollment = await options?.beginNodeEnrollment?.();
+        } catch (error) {
+          events.push(`enrollment:error:${error instanceof Error ? error.message : String(error)}`);
+          throw error;
+        }
+        if (!enrollment) {
+          throw new Error("node enrollment was not prepared");
+        }
+        events.push("enrollment:start");
+        return {
+          leaseId: "lease-node-replay",
+          node: { deviceId: await enrollment.waitForDeviceId() },
+          sharedHost: false,
+        };
+      },
+      destroy,
+    });
+    support.testState.prepareInstallation = vi.fn(async () => ({
+      ...support.BUNDLE_ARTIFACT,
+      protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+    }));
+    let placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const placement = placements.startDispatch(REQUEST);
+    const idempotencyKey = `session-dispatch:${REQUEST.sessionId}:${placement.generation}`;
+    const intent = deriveEnvironmentIntent(idempotencyKey);
+    placements.transition({
+      sessionId: placement.sessionId,
+      from: "requested",
+      to: "provisioning",
+      expectedGeneration: placement.generation,
+      patch: { environmentId: intent.environmentId },
+    });
+    const first = support.createService(provider, {
+      ensureNodeWorkerBundle: async () => ({
+        ...support.BOOTSTRAP_RECEIPT,
+        protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+      }),
+      prepareNodeEnrollment: async () => {
+        throw new Error("first provision reply was lost before node enrollment");
+      },
+    });
+
+    await expect(
+      first.create("development", idempotencyKey, undefined, REQUEST.executionMode),
+    ).rejects.toMatchObject({ code: "provider_failure" });
+    events.push("first:failed");
+    expect(support.testState.store.get(intent.environmentId)).toMatchObject({
+      state: "provisioning",
+      leaseId: null,
+      provisionOperationId: intent.provisionOperationId,
+    });
+
+    await first.stop();
+    events.push("first:stopped");
+    support.testState.service = undefined;
+    closeOpenClawStateDatabaseForTest();
+    support.testState.stateDb = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: support.testState.root },
+    });
+    support.testState.store = createWorkerEnvironmentStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const syncWorkspace = vi.fn(async () => ({
+      mode: "git" as const,
+      remoteWorkspaceDir: "/worker/workspace",
+      manifestRef: `sha256:${"b".repeat(64)}`,
+    }));
+    const nodeTunnelManager = {
+      status: () => "stopped" as const,
+      start: vi.fn(async ({ environmentId, ownerEpoch }) => ({
+        environmentId,
+        ownerEpoch,
+        launchTurn: vi.fn(),
+        runWorkspaceCommand: vi.fn(),
+        quiesceWorkspace: vi.fn(),
+        syncWorkspace,
+        reconcileWorkspace: vi.fn(),
+        stop: vi.fn(),
+      })),
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    };
+    const restarted = support.createService(provider, {
+      ensureNodeWorkerBundle: async () => ({
+        ...support.BOOTSTRAP_RECEIPT,
+        protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+      }),
+      prepareNodeEnrollment: async (record) => {
+        const enrolled = support.testState.store.ensureNodeEnrollment(record.environmentId);
+        return {
+          mode: "connect" as const,
+          setupCode: "setup-code",
+          setupId: enrolled.nodeSetupId!,
+          openclawVersion: "2026.8.19",
+          packageSpecs: ["openclaw@2026.8.19"],
+          displayName: "Cloud worker replay",
+          waitForDeviceId: async () => await enrollmentConnected.promise,
+        };
+      },
+      nodeTunnelManager: nodeTunnelManager as never,
+    });
+    const recoveryBarrier = vi.fn(async ({ expectedGeneration, environmentId, run }) => {
+      expect(placements.get(REQUEST.sessionId)).toMatchObject({
+        state: "provisioning",
+        generation: expectedGeneration,
+        environmentId,
+      });
+      await run("/gateway/workspace");
+    });
+    const activationBarrier = vi.fn(async ({ activate }) => activate());
+    const onActivated = vi.fn();
+    const attachSession = vi.spyOn(restarted, "attachSession");
+    const dispatch = createWorkerPlacementDispatchService({
+      placements,
+      environments: restarted,
+      workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
+      runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+      runRecoveryBarrier: recoveryBarrier,
+      runActivationBarrier: activationBarrier,
+      runMoveBarrier: async ({ begin }) => begin(),
+      resolveMoveDestination: async () => undefined,
+      runReclaimBarrier: async ({ begin, reclaim }) => await reclaim("/gateway/workspace", begin()),
+      runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
+      resolveWorkspacePath: async () => "/gateway/workspace",
+      reportWorkspaceResultConflict: async () => {},
+      resolveWorkspaceResultConflict: async () => undefined,
+      onActivated,
+    });
+    const uninstallReconcileGuard = restarted.installReconcileEnvironmentGuard(
+      async (environmentId, reconcileEnvironmentCore) => {
+        const owners = placements
+          .list()
+          .filter((candidate) => candidate.environmentId === environmentId);
+        if (owners.length !== 1 || owners[0]?.state !== "provisioning") {
+          await reconcileEnvironmentCore();
+          return;
+        }
+        await dispatch.resumeProvisioning(owners[0], reconcileEnvironmentCore);
+      },
+    );
+
+    let recoverySettled = false;
+    const recovery = dispatch.reconcile().finally(() => {
+      recoverySettled = true;
+    });
+    events.push("recovery:started");
+    await support.waitForFast(
+      () => {
+        if (!events.includes("enrollment:start")) {
+          throw new Error(`node enrollment did not start: ${events.join(",")}`);
+        }
+      },
+      { timeout: 2_000 },
+    );
+    expect(recoverySettled).toBe(false);
+    expect(placements.get(REQUEST.sessionId)).toMatchObject({
+      state: "provisioning",
+      environmentId: intent.environmentId,
+    });
+    expect(support.testState.store.get(intent.environmentId)).toMatchObject({
+      state: "provisioning",
+      leaseId: null,
+    });
+    expect(nodeTunnelManager.start).not.toHaveBeenCalled();
+    expect(destroy).not.toHaveBeenCalled();
+    const overlappingEnvironmentReconcile = restarted.reconcileEnvironment(intent.environmentId);
+    const overlappingPlacementReconcile = dispatch.reconcileActive(intent.environmentId);
+    await Promise.resolve();
+    expect(provisionCalls).toBe(2);
+
+    enrollmentConnected.resolve("device-node-replay");
+    await Promise.all([recovery, overlappingEnvironmentReconcile, overlappingPlacementReconcile]);
+    await uninstallReconcileGuard();
+
+    expect(placements.get(REQUEST.sessionId)).toMatchObject({
+      state: "active",
+      environmentId: intent.environmentId,
+      workerBundleHash: support.BUNDLE_HASH,
+    });
+    expect(support.testState.store.get(intent.environmentId)).toMatchObject({
+      state: "attached",
+      leaseId: "lease-node-replay",
+      nodeDeviceId: "device-node-replay",
+      attachedSessionIds: [REQUEST.sessionId],
+    });
+    expect(physicalAllocations).toBe(1);
+    expect(operationIds).toEqual([intent.provisionOperationId, intent.provisionOperationId]);
+    expect(recoveryBarrier).toHaveBeenCalled();
+    expect(activationBarrier).not.toHaveBeenCalled();
+    expect(attachSession).toHaveBeenCalledOnce();
+    expect(nodeTunnelManager.start).toHaveBeenCalledOnce();
+    expect(syncWorkspace).toHaveBeenCalledOnce();
+    expect(onActivated).toHaveBeenCalledOnce();
+    expect(destroy).not.toHaveBeenCalled();
   });
 
   it("preserves an allocated lease after indeterminate provision cleanup across restart", async () => {

--- a/src/gateway/worker-environments/provider-provisioning.shutdown-replay.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.shutdown-replay.test.ts
@@ -1,0 +1,228 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import { WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { createWorkerNodeEnrollmentManager } from "./node-enrollment.js";
+import { REQUEST } from "./placement-dispatch-test-fixtures.js";
+import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import { deriveEnvironmentIntent } from "./service-contract.js";
+import * as support from "./service.test-support.js";
+import { createWorkerEnvironmentStore } from "./store.js";
+import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
+
+describe("worker node provisioning shutdown replay", () => {
+  support.setupWorkerEnvironmentServiceSuite();
+
+  it("cancels guarded enrollment without releasing the exact lease and adopts it after restart", async () => {
+    const deviceId = "device-node-shutdown-replay";
+    const leaseId = "lease-node-shutdown-replay";
+    const operationIds: string[] = [];
+    const physicalLeases = new Set<string>();
+    const destroy = vi.fn(async ({ leaseId: destroyedLeaseId }: { leaseId: string }) => {
+      physicalLeases.delete(destroyedLeaseId);
+    });
+    let physicalAllocations = 0;
+    const provider = support.createProvider({
+      supportedExecutionModes: ["worker-turn"],
+      provisionBeforeInstallation: true,
+      requiresNodeEnrollment: true,
+      provision: async (_profile, operationId, options) => {
+        operationIds.push(operationId);
+        if (!physicalLeases.has(leaseId)) {
+          physicalLeases.add(leaseId);
+          physicalAllocations += 1;
+        }
+        const enrollment = await options?.beginNodeEnrollment?.();
+        if (!enrollment) {
+          throw new Error("node enrollment was not prepared");
+        }
+        return {
+          leaseId,
+          node: { deviceId: await enrollment.waitForDeviceId() },
+          sharedHost: false,
+        };
+      },
+      destroy,
+    });
+    support.testState.prepareInstallation = vi.fn(async () => ({
+      ...support.BUNDLE_ARTIFACT,
+      protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+    }));
+    let placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const requested = placements.startDispatch(REQUEST);
+    const intent = deriveEnvironmentIntent(
+      `session-dispatch:${REQUEST.sessionId}:${requested.generation}`,
+    );
+    const placement = placements.transition({
+      sessionId: requested.sessionId,
+      from: "requested",
+      to: "provisioning",
+      expectedGeneration: requested.generation,
+      patch: { environmentId: intent.environmentId },
+    });
+    const environment = support.testState.store.createIntent({
+      environmentId: intent.environmentId,
+      providerId: provider.id,
+      profileId: "development",
+      profileSnapshot: { install: "bundle", settings: { region: "test" } },
+      provisionOperationId: intent.provisionOperationId,
+    });
+    support.testState.store.transition({
+      environmentId: environment.environmentId,
+      from: "requested",
+      to: "provisioning",
+      patch: { nodeDeviceId: deviceId },
+    });
+    const unavailable = vi.fn(async () => ({ available: false as const }));
+    const firstEnrollment = createWorkerNodeEnrollmentManager({
+      store: support.testState.store,
+      getConfig: () => support.testState.config,
+      resolveAvailability: unavailable,
+    });
+    const receipt = {
+      ...support.BOOTSTRAP_RECEIPT,
+      protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+    };
+    const first = support.createService(provider, {
+      prepareNodeEnrollment: firstEnrollment.begin,
+      stopNodeEnrollmentWaits: firstEnrollment.stop,
+      ensureNodeWorkerBundle: async () => receipt,
+    });
+
+    const createDispatch = (environments: typeof first) =>
+      createWorkerPlacementDispatchService({
+        placements,
+        environments,
+        workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
+        runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+        runRecoveryBarrier: async ({ run }) => await run("/gateway/workspace"),
+        runActivationBarrier: async ({ activate }) => activate(),
+        runMoveBarrier: async ({ begin }) => begin(),
+        resolveMoveDestination: async () => undefined,
+        runReclaimBarrier: async ({ begin, reclaim }) =>
+          await reclaim("/gateway/workspace", begin()),
+        runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
+        resolveWorkspacePath: async () => "/gateway/workspace",
+        reportWorkspaceResultConflict: async () => {},
+        resolveWorkspaceResultConflict: async () => undefined,
+      });
+    const firstDispatch = createDispatch(first);
+    const uninstallFirstGuard = first.installReconcileEnvironmentGuard(
+      async (environmentId, reconcileCore) => {
+        const owner = placements
+          .list()
+          .find((candidate) => candidate.environmentId === environmentId);
+        if (owner?.state !== "provisioning") {
+          throw new Error("guarded recovery lost its provisioning owner");
+        }
+        await firstDispatch.resumeProvisioning(owner, reconcileCore);
+      },
+    );
+    const recovery = firstDispatch.reconcile();
+    await support.waitForFast(() => expect(unavailable).toHaveBeenCalled());
+
+    let stopped = false;
+    const stopping = first.stop().then(() => {
+      stopped = true;
+    });
+    await support.waitForFast(() => expect(stopped).toBe(true), { timeout: 1_000 });
+    await Promise.all([recovery, stopping]);
+    await uninstallFirstGuard();
+
+    expect(placements.get(REQUEST.sessionId)).toEqual(placement);
+    expect(support.testState.store.get(intent.environmentId)).toMatchObject({
+      state: "provisioning",
+      leaseId: null,
+      nodeDeviceId: deviceId,
+      destroyRequestedAtMs: null,
+      provisionOperationId: intent.provisionOperationId,
+    });
+    expect(physicalLeases).toEqual(new Set([leaseId]));
+    expect(destroy).not.toHaveBeenCalled();
+
+    support.testState.service = undefined;
+    closeOpenClawStateDatabaseForTest();
+    support.testState.stateDb = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: support.testState.root },
+    });
+    support.testState.store = createWorkerEnvironmentStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    placements = createWorkerSessionPlacementStore({
+      database: support.testState.stateDb,
+      now: () => support.testState.nowMs,
+    });
+    const restartedEnrollment = createWorkerNodeEnrollmentManager({
+      store: support.testState.store,
+      getConfig: () => support.testState.config,
+      resolveAvailability: async () => ({ available: true }),
+    });
+    const syncWorkspace = vi.fn(async () => ({
+      mode: "git" as const,
+      remoteWorkspaceDir: "/worker/workspace",
+      manifestRef: `sha256:${"b".repeat(64)}`,
+    }));
+    const nodeTunnelManager = {
+      status: () => "stopped" as const,
+      start: vi.fn(async ({ environmentId, ownerEpoch }) => ({
+        environmentId,
+        ownerEpoch,
+        launchTurn: vi.fn(),
+        runWorkspaceCommand: vi.fn(),
+        quiesceWorkspace: vi.fn(),
+        syncWorkspace,
+        reconcileWorkspace: vi.fn(),
+        stop: vi.fn(),
+      })),
+      stop: vi.fn(async () => {}),
+      stopAll: vi.fn(async () => {}),
+    };
+    const restarted = support.createService(provider, {
+      prepareNodeEnrollment: restartedEnrollment.begin,
+      stopNodeEnrollmentWaits: restartedEnrollment.stop,
+      ensureNodeWorkerBundle: async () => receipt,
+      nodeTunnelManager: nodeTunnelManager as never,
+    });
+    const restartedDispatch = createDispatch(restarted);
+    const uninstallRestartedGuard = restarted.installReconcileEnvironmentGuard(
+      async (environmentId, reconcileCore) => {
+        const owner = expectDefined(
+          placements.list().find((candidate) => candidate.environmentId === environmentId),
+          "restarted provisioning owner",
+        );
+        if (owner.state !== "provisioning") {
+          throw new Error("restarted recovery lost its provisioning placement");
+        }
+        await restartedDispatch.resumeProvisioning(owner, reconcileCore);
+      },
+    );
+
+    await restartedDispatch.reconcile();
+    await uninstallRestartedGuard();
+
+    expect(placements.get(REQUEST.sessionId)).toMatchObject({
+      state: "active",
+      environmentId: intent.environmentId,
+    });
+    expect(support.testState.store.get(intent.environmentId)).toMatchObject({
+      state: "attached",
+      leaseId,
+      nodeDeviceId: deviceId,
+      attachedSessionIds: [REQUEST.sessionId],
+      provisionOperationId: intent.provisionOperationId,
+    });
+    expect(operationIds).toEqual([intent.provisionOperationId, intent.provisionOperationId]);
+    expect(physicalAllocations).toBe(1);
+    expect(physicalLeases).toEqual(new Set([leaseId]));
+    expect(syncWorkspace).toHaveBeenCalledOnce();
+    expect(destroy).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/worker-environments/service-lifetime.test.ts
+++ b/src/gateway/worker-environments/service-lifetime.test.ts
@@ -118,6 +118,9 @@ describe("worker environment service", () => {
 
   it("owns and clears one periodic reconciliation timer", async () => {
     vi.useFakeTimers();
+    const environmentId = "worker-guarded-reconcile";
+    support.seedReady(environmentId);
+    const inspect = vi.fn(async () => ({ status: "active" as const }));
     const liveEvents = support.createLiveEvents();
     const unsubscribeTurnClaimClosed = vi.fn();
     const placementStore = {
@@ -127,21 +130,117 @@ describe("worker environment service", () => {
       updateAckCursors: vi.fn(),
       registerTurnClaimClosedHandler: vi.fn(() => unsubscribeTurnClaimClosed),
     };
-    const workerService = support.createService(support.createProvider(), {
+    const workerService = support.createService(support.createProvider({ inspect }), {
       liveEvents,
       placementStore,
     });
+    const guardedEnvironmentIds: string[] = [];
+    const uninstallGuard = workerService.installReconcileEnvironmentGuard(
+      async (guardedEnvironmentId, reconcileCore) => {
+        guardedEnvironmentIds.push(guardedEnvironmentId);
+        await reconcileCore();
+      },
+    );
 
     expect(placementStore.registerTurnClaimClosedHandler).toHaveBeenCalledOnce();
+    await workerService.reconcileEnvironment(environmentId);
     workerService.start();
     workerService.start();
+    await vi.advanceTimersByTimeAsync(0);
     expect(liveEvents.start).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(25);
+    expect(guardedEnvironmentIds).toEqual([environmentId, environmentId, environmentId]);
+    expect(inspect).toHaveBeenCalledTimes(3);
+    await uninstallGuard();
+    await workerService.reconcileEnvironment(environmentId);
+    expect(guardedEnvironmentIds).toHaveLength(3);
+    expect(inspect).toHaveBeenCalledTimes(4);
     await workerService.stop();
 
     expect(liveEvents.clear).toHaveBeenCalledTimes(2);
     expect(unsubscribeTurnClaimClosed).toHaveBeenCalledOnce();
     expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("closes new guarded reconciliation and drains the admitted operation on uninstall", async () => {
+    const environmentId = "worker-guard-uninstall";
+    support.seedReady(environmentId);
+    const inspect = vi.fn(async () => ({ status: "active" as const }));
+    const workerService = support.createService(support.createProvider({ inspect }));
+    let releaseGuard: (() => void) | undefined;
+    const guardPending = new Promise<void>((resolve) => {
+      releaseGuard = resolve;
+    });
+    let signalGuardStarted: (() => void) | undefined;
+    const guardStarted = new Promise<void>((resolve) => {
+      signalGuardStarted = resolve;
+    });
+    const uninstallGuard = workerService.installReconcileEnvironmentGuard(
+      async (_guardedEnvironmentId, reconcileCore) => {
+        signalGuardStarted?.();
+        await guardPending;
+        await reconcileCore();
+      },
+    );
+    const reconciliation = workerService.reconcileEnvironment(environmentId);
+    await guardStarted;
+    let uninstalled = false;
+    const uninstalling = uninstallGuard().then(() => {
+      uninstalled = true;
+    });
+    await workerService.reconcileEnvironment(environmentId);
+    await Promise.resolve();
+    expect(uninstalled).toBe(false);
+    expect(inspect).not.toHaveBeenCalled();
+
+    releaseGuard?.();
+    await Promise.all([reconciliation, uninstalling]);
+    expect(inspect).toHaveBeenCalledOnce();
+    await workerService.reconcileEnvironment(environmentId);
+    expect(inspect).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes guarded reconciliation admission and drains admitted recovery during stop", async () => {
+    const environmentId = "worker-guard-stop";
+    support.seedReady(environmentId);
+    const inspect = vi.fn(async () => ({ status: "active" as const }));
+    const workerService = support.createService(support.createProvider({ inspect }));
+    let releaseGuard: (() => void) | undefined;
+    const guardPending = new Promise<void>((resolve) => {
+      releaseGuard = resolve;
+    });
+    let signalGuardStarted: (() => void) | undefined;
+    const guardStarted = new Promise<void>((resolve) => {
+      signalGuardStarted = resolve;
+    });
+    let guardCompleted = false;
+    const uninstallGuard = workerService.installReconcileEnvironmentGuard(
+      async (_guardedEnvironmentId, reconcileCore) => {
+        signalGuardStarted?.();
+        await guardPending;
+        await reconcileCore();
+        guardCompleted = true;
+      },
+    );
+    const admitted = workerService.reconcileEnvironment(environmentId);
+    await guardStarted;
+
+    let stopped = false;
+    const stopping = workerService.stop().then(() => {
+      stopped = true;
+    });
+    await workerService.reconcileEnvironment(environmentId);
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    expect(guardCompleted).toBe(false);
+    expect(inspect).not.toHaveBeenCalled();
+
+    releaseGuard?.();
+    await Promise.all([admitted, stopping]);
+    await uninstallGuard();
+    expect(guardCompleted).toBe(true);
+    expect(inspect).not.toHaveBeenCalled();
   });
 
   it("rejects a create queued before service shutdown once its lock is acquired", async () => {

--- a/src/gateway/worker-environments/service.test-support.ts
+++ b/src/gateway/worker-environments/service.test-support.ts
@@ -170,6 +170,7 @@ export function createService(
       | "ensureNodeWorkerBundle"
       | "prepareNodeEnrollment"
       | "retireNodeEnrollment"
+      | "stopNodeEnrollmentWaits"
       | "tunnelManager"
       | "generateWorkerCredential"
       | "liveEvents"

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -67,6 +67,7 @@ type WorkerEnvironmentServiceOptions = WorkerProviderLifecycleInputOptions & {
   tunnelManager?: WorkerTunnelManager;
   nodeTunnelManager?: NodeWorkerTunnelManager;
   nodeDesktopCarrier?: WorkerNodeDesktopCarrier;
+  stopNodeEnrollmentWaits?: () => void;
   stopNodeWorkerBundleTransfers?: () => void;
   reconcileIntervalMs?: number;
   bootstrapCallTimeoutMs?: number;
@@ -111,6 +112,12 @@ type WorkerEnvironmentServiceOptions = WorkerProviderLifecycleInputOptions & {
   ) => Promise<WorkerSessionToolResult>;
 };
 
+export type WorkerEnvironmentReconcileCore = () => Promise<void>;
+type WorkerEnvironmentReconcileGuard = (
+  environmentId: string,
+  reconcileCore: WorkerEnvironmentReconcileCore,
+) => Promise<void>;
+
 export function createWorkerEnvironmentService(options: WorkerEnvironmentServiceOptions) {
   const { store } = options;
   const warn = (message: string) => options.logger?.warn(message);
@@ -144,6 +151,11 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
   let unsubscribeTurnClaimClosed = options.placementStore?.registerTurnClaimClosedHandler((claim) =>
     inference.cancelClaim(claim),
   );
+  let reconcileEnvironmentGuard: WorkerEnvironmentReconcileGuard | undefined;
+  let reconcileEnvironmentGuardClosing = false;
+  // Coalesce the whole guarded closure. Serializing only provider work would still let a
+  // losing recovery pass attach or sync after the winner advances the placement.
+  const guardedReconcileInFlight = new Map<string, Promise<void>>();
   let stopping = false;
 
   const inState = (record: WorkerEnvironmentRecord, ...states: WorkerEnvironmentState[]) =>
@@ -309,7 +321,7 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     withLock,
   });
 
-  const reconcileEnvironment = async (environmentId: string) => {
+  const reconcileEnvironmentCore = async (environmentId: string) => {
     if (stopping) {
       return;
     }
@@ -320,6 +332,60 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
       }
       await providerLifecycle.reconcileRecord(current);
     });
+  };
+
+  const reconcileEnvironment = async (environmentId: string) => {
+    if (stopping) {
+      return;
+    }
+    const guard = reconcileEnvironmentGuard;
+    if (!guard) {
+      await reconcileEnvironmentCore(environmentId);
+      return;
+    }
+    if (reconcileEnvironmentGuardClosing) {
+      return;
+    }
+    const active = guardedReconcileInFlight.get(environmentId);
+    if (active) {
+      await active;
+      return;
+    }
+    const operation = guard(environmentId, async () => {
+      await reconcileEnvironmentCore(environmentId);
+    });
+    guardedReconcileInFlight.set(environmentId, operation);
+    try {
+      await operation;
+    } finally {
+      if (guardedReconcileInFlight.get(environmentId) === operation) {
+        guardedReconcileInFlight.delete(environmentId);
+      }
+    }
+  };
+
+  const closeReconcileEnvironmentGuard = async (expected?: WorkerEnvironmentReconcileGuard) => {
+    const guard = reconcileEnvironmentGuard;
+    if (!guard || (expected && guard !== expected)) {
+      return;
+    }
+    reconcileEnvironmentGuardClosing = true;
+    while (guardedReconcileInFlight.size > 0) {
+      await Promise.allSettled(guardedReconcileInFlight.values());
+    }
+    if (reconcileEnvironmentGuard === guard) {
+      reconcileEnvironmentGuard = undefined;
+      reconcileEnvironmentGuardClosing = false;
+    }
+  };
+
+  const installReconcileEnvironmentGuard = (guard: WorkerEnvironmentReconcileGuard) => {
+    if (reconcileEnvironmentGuard) {
+      throw new Error("Worker environment reconciliation guard is already installed");
+    }
+    reconcileEnvironmentGuard = guard;
+    reconcileEnvironmentGuardClosing = false;
+    return async () => await closeReconcileEnvironmentGuard(guard);
   };
 
   const reconcilePass = async () => {
@@ -375,12 +441,16 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
 
   const stop = async () => {
     stopping = true;
+    options.stopNodeEnrollmentWaits?.();
     clearInterval(interval);
     interval = undefined;
     unsubscribeSessionIdentityMutation?.();
     unsubscribeSessionIdentityMutation = undefined;
     unsubscribeTurnClaimClosed?.();
     unsubscribeTurnClaimClosed = undefined;
+    // Shutdown owns the guard handoff: stop new admission and drain admitted recovery before
+    // inference or tunnel teardown can invalidate its closure-bound placement authority.
+    await closeReconcileEnvironmentGuard();
     await inference.stop();
     credentialBroker.clear();
     options.liveEvents?.clear();
@@ -430,6 +500,8 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
       return profile ? providerSupportsExecutionMode(profile.provider, mode) : false;
     },
     get: environmentAccess.get,
+    hasPendingNodeEnrollmentSetup: (setupId: string, deviceId: string) =>
+      store.hasPendingNodeEnrollmentSetup(setupId, deviceId),
     listMachineOptions: async (profileId: string) =>
       providerLifecycle.listMachineOptions(profileId),
     create: async (
@@ -508,6 +580,8 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     acknowledgeCredentialDelivery: credentialBroker.acknowledgeCredentialDelivery,
     startTunnel: environmentAccess.startTunnel,
     stopTunnel: environmentAccess.stopTunnel,
+    stopNodeEnrollmentWaits: options.stopNodeEnrollmentWaits,
+    installReconcileEnvironmentGuard,
     reconcileEnvironment,
     reconcileOnce,
     start,

--- a/src/gateway/worker-environments/store-node-enrollment.test.ts
+++ b/src/gateway/worker-environments/store-node-enrollment.test.ts
@@ -46,12 +46,38 @@ describe("worker environment node enrollment store", () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
+  function seedEnrollmentState(state: string, deviceId: string | null): string {
+    store.transition({
+      environmentId: "worker-enrollment",
+      from: "requested",
+      to: "provisioning",
+    });
+    const setupId = expectDefined(
+      store.ensureNodeEnrollment("worker-enrollment").nodeSetupId,
+      "worker node enrollment setup id",
+    );
+    database.db
+      .prepare(
+        "UPDATE worker_environments SET state = ?, node_device_id = ? WHERE node_setup_id = ?",
+      )
+      .run(state, deviceId, setupId);
+    return setupId;
+  }
+
   it("binds setup completion to the exact environment identity across restart", async () => {
+    expect(store.hasPendingNodeEnrollmentSetup("", "cloud-device-1")).toBe(false);
+    expect(store.hasPendingNodeEnrollmentSetup("missing-setup", "cloud-device-1")).toBe(false);
+    store.transition({
+      environmentId: "worker-enrollment",
+      from: "requested",
+      to: "provisioning",
+    });
     const pending = store.ensureNodeEnrollment("worker-enrollment");
     const setupId = expectDefined(pending.nodeSetupId, "worker node enrollment setup id");
     expect(setupId).toMatch(/^[0-9a-f-]{36}$/u);
     expect(pending.nodeDeviceId).toBeNull();
     expect(store.ensureNodeEnrollment("worker-enrollment").nodeSetupId).toBe(setupId);
+    expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-1")).toBe(true);
 
     const issued = await ensureDevicePairSetupBootstrapToken({
       baseDir: root,
@@ -80,7 +106,84 @@ describe("worker environment node enrollment store", () => {
       nodeSetupId: setupId,
       nodeDeviceId: "cloud-device-1",
     });
+    expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-1")).toBe(true);
+    expect(store.hasPendingNodeEnrollmentSetup(setupId, "different-cloud-device")).toBe(false);
   });
+
+  it("rejects a destroy-requested provisioning setup", async () => {
+    store.transition({
+      environmentId: "worker-enrollment",
+      from: "requested",
+      to: "provisioning",
+    });
+    const setupId = expectDefined(
+      store.ensureNodeEnrollment("worker-enrollment").nodeSetupId,
+      "worker node enrollment setup id",
+    );
+    expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-canceled")).toBe(true);
+    const issued = await ensureDevicePairSetupBootstrapToken({
+      baseDir: root,
+      setupId,
+      profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+    });
+    if (issued.status !== "pending") {
+      throw new Error("expected pending cloud worker setup");
+    }
+    await verifyDeviceBootstrapToken({
+      baseDir: root,
+      token: issued.token,
+      deviceId: "cloud-device-canceled",
+      publicKey: "cloud-public-key-canceled",
+      role: "node",
+      scopes: [],
+    });
+
+    store.requestDestroy({ environmentId: "worker-enrollment", state: "provisioning" });
+
+    expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-canceled")).toBe(false);
+    await expect(
+      consumeDeviceBootstrapTokenWithSetupCompletion({
+        baseDir: root,
+        token: issued.token,
+        deviceId: "cloud-device-canceled",
+        completedAtMs: 10,
+      }),
+    ).rejects.toThrow("Cloud worker setup completion owner is no longer pending");
+    expect(store.get("worker-enrollment")?.nodeDeviceId).toBeNull();
+  });
+
+  it.each(["provisioning", "bootstrapping", "ready", "idle", "attached"])(
+    "admits only the exact already-bound setup device in %s",
+    (state) => {
+      const setupId = seedEnrollmentState(state, "cloud-device-bound");
+
+      expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-bound")).toBe(true);
+      expect(store.hasPendingNodeEnrollmentSetup(setupId, "different-cloud-device")).toBe(false);
+      expect(store.hasPendingNodeEnrollmentSetup("missing-setup", "cloud-device-bound")).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each(["provisioning", "bootstrapping", "ready", "idle", "attached"])(
+    "allows first setup-device binding in %s only when provisioning",
+    (state) => {
+      const setupId = seedEnrollmentState(state, null);
+
+      expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-first")).toBe(
+        state === "provisioning",
+      );
+    },
+  );
+
+  it.each(["requested", "draining", "destroying", "destroyed", "failed", "orphaned"])(
+    "rejects an already-bound setup device in %s",
+    (state) => {
+      const setupId = seedEnrollmentState(state, "cloud-device-bound");
+
+      expect(store.hasPendingNodeEnrollmentSetup(setupId, "cloud-device-bound")).toBe(false);
+    },
+  );
 
   it("persists a credential-bound node receipt without SSH metadata", () => {
     store.transition({

--- a/src/gateway/worker-environments/store.ts
+++ b/src/gateway/worker-environments/store.ts
@@ -919,6 +919,33 @@ export function createWorkerEnvironmentStore(
       });
     },
     get: (environmentId: string) => find(read(), required(environmentId, "id")),
+    hasPendingNodeEnrollmentSetup(setupIdInput: string, deviceIdInput: string): boolean {
+      const setupId = setupIdInput.trim();
+      const deviceId = deviceIdInput.trim();
+      if (!setupId || !deviceId) {
+        return false;
+      }
+      const db = read();
+      const matches = executeSqliteQuerySync(
+        db,
+        query(db)
+          .selectFrom("worker_environments")
+          .select("environment_id")
+          .where("node_setup_id", "=", setupId)
+          .where("destroy_requested_at_ms", "is", null)
+          .where((eb) =>
+            eb.or([
+              eb.and([eb("state", "=", "provisioning"), eb("node_device_id", "is", null)]),
+              eb.and([
+                eb("state", "in", ["provisioning", "bootstrapping", "ready", "idle", "attached"]),
+                eb("node_device_id", "=", deviceId),
+              ]),
+            ]),
+          )
+          .limit(2),
+      ).rows;
+      return matches.length === 1;
+    },
     ensureNodeEnrollment(environmentIdInput: string): WorkerEnvironmentRecord {
       const environmentId = required(environmentIdInput, "id");
       return write((db) => {

--- a/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
@@ -209,6 +209,7 @@ describe("worker turn launcher failure recovery", () => {
       placements,
       environments,
       runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+      runRecoveryBarrier: async ({ run }) => await run(root),
       runActivationBarrier: async ({ activate }) => activate(),
       runMoveBarrier: async ({ begin }) => begin(),
       resolveMoveDestination: async () => undefined,

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 import { flushLogger } from "../logging/logger.js";
 import {
+  CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
   CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES,
   CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
   FULL_ACCESS_PAIRING_SETUP_BOOTSTRAP_PROFILE,
@@ -22,8 +23,8 @@ import {
   clearDeviceBootstrapTokens,
   confirmDevicePairSetupCompletionDelivery,
   consumeDeviceBootstrapTokenWithSetupCompletion,
+  getBoundDeviceBootstrapContext,
   getBoundDeviceBootstrapProfile,
-  getDeviceBootstrapTokenProfile,
   ensureDevicePairSetupBootstrapToken,
   issueDeviceBootstrapToken,
   issueDevicePairSetupBootstrapToken,
@@ -57,6 +58,24 @@ async function verifyBootstrapToken(
     baseDir,
     ...overrides,
   });
+}
+
+async function issueCloudWorkerSetupToken(baseDir: string) {
+  const issued = await issueDevicePairSetupBootstrapToken({
+    baseDir,
+    profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+  });
+  const { db } = openOpenClawStateDatabase({
+    env: { ...process.env, OPENCLAW_STATE_DIR: baseDir },
+  });
+  db.prepare(
+    `INSERT INTO worker_environments (
+      environment_id, provider_id, profile_id, profile_snapshot_json,
+      provision_operation_id, node_setup_id, state,
+      created_at_ms, updated_at_ms, state_changed_at_ms
+    ) VALUES (?, 'test-provider', 'test-profile', '{}', ?, ?, 'provisioning', ?, ?, ?)`,
+  ).run(issued.setupId, `provision:${issued.setupId}`, issued.setupId, 1_000, 1_000, 1_000);
+  return issued;
 }
 
 afterEach(async () => {
@@ -204,6 +223,10 @@ describe("device bootstrap tokens", () => {
       completedAtMs: 1_000,
       baseDir,
     });
+    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({
+      ok: false,
+      reason: "bootstrap_token_invalid",
+    });
 
     await expect(
       readDevicePairSetupCompletion({ baseDir, setupId: issued.setupId }),
@@ -224,6 +247,178 @@ describe("device bootstrap tokens", () => {
     await expect(
       readDevicePairSetupCompletion({ baseDir, setupId: "some-other-setup" }),
     ).resolves.toBeNull();
+  });
+
+  it("retains an uncertain cloud-worker setup only for its exact device until delivery", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueCloudWorkerSetupToken(baseDir);
+    const completion = {
+      baseDir,
+      token: issued.token,
+      deviceId: "device-123",
+      completedAtMs: 1_000,
+    };
+
+    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
+    await expect(consumeDeviceBootstrapTokenWithSetupCompletion(completion)).resolves.toMatchObject(
+      {
+        completion: { setupId: issued.setupId, deviceId: "device-123", deliveryState: "uncertain" },
+      },
+    );
+    expect(loadDeviceBootstrapTokenRecords(baseDir)[issued.token]?.deviceId).toBe("device-123");
+    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        deviceId: "different-device",
+        publicKey: "different-public-key",
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+    await expect(
+      consumeDeviceBootstrapTokenWithSetupCompletion({
+        ...completion,
+        deviceId: "different-device",
+      }),
+    ).resolves.toBeNull();
+
+    await expect(
+      consumeDeviceBootstrapTokenWithSetupCompletion({ ...completion, completedAtMs: 2_000 }),
+    ).resolves.toMatchObject({
+      completion: { deviceId: "device-123", completedAtMs: 2_000, deliveryState: "uncertain" },
+    });
+    await expect(
+      confirmDevicePairSetupCompletionDelivery({
+        baseDir,
+        setupId: issued.setupId,
+        deviceId: "device-123",
+      }),
+    ).resolves.toMatchObject({ deliveryState: "confirmed" });
+    expect(loadDeviceBootstrapTokenRecords(baseDir)[issued.token]).toBeUndefined();
+    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({
+      ok: false,
+      reason: "bootstrap_token_invalid",
+    });
+  });
+
+  it.each(["provisioning", "bootstrapping", "ready", "idle", "attached"])(
+    "replays uncertain cloud-worker setup for its bound device in %s until confirmation",
+    async (state) => {
+      const baseDir = await createTempDir();
+      const issued = await issueCloudWorkerSetupToken(baseDir);
+      const completion = {
+        baseDir,
+        token: issued.token,
+        deviceId: "device-123",
+        completedAtMs: 1_000,
+      };
+      await verifyBootstrapToken(baseDir, issued.token);
+      await consumeDeviceBootstrapTokenWithSetupCompletion(completion);
+      const { db } = openOpenClawStateDatabase({
+        env: { ...process.env, OPENCLAW_STATE_DIR: baseDir },
+      });
+      db.prepare("UPDATE worker_environments SET state = ? WHERE node_setup_id = ?").run(
+        state,
+        issued.setupId,
+      );
+
+      await expect(
+        consumeDeviceBootstrapTokenWithSetupCompletion({ ...completion, completedAtMs: 2_000 }),
+      ).resolves.toMatchObject({
+        completion: { deviceId: "device-123", completedAtMs: 2_000, deliveryState: "uncertain" },
+      });
+      await confirmDevicePairSetupCompletionDelivery({
+        baseDir,
+        setupId: issued.setupId,
+        deviceId: "device-123",
+      });
+      await expect(
+        consumeDeviceBootstrapTokenWithSetupCompletion({ ...completion, completedAtMs: 3_000 }),
+      ).resolves.toBeNull();
+      await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({
+        ok: false,
+        reason: "bootstrap_token_invalid",
+      });
+    },
+  );
+
+  it.each(["requested", "bootstrapping", "ready", "idle", "attached"])(
+    "rejects first cloud-worker setup-device binding outside provisioning in %s",
+    async (state) => {
+      const baseDir = await createTempDir();
+      const issued = await issueCloudWorkerSetupToken(baseDir);
+      await verifyBootstrapToken(baseDir, issued.token);
+      const { db } = openOpenClawStateDatabase({
+        env: { ...process.env, OPENCLAW_STATE_DIR: baseDir },
+      });
+      db.prepare("UPDATE worker_environments SET state = ? WHERE node_setup_id = ?").run(
+        state,
+        issued.setupId,
+      );
+
+      await expect(
+        consumeDeviceBootstrapTokenWithSetupCompletion({
+          baseDir,
+          token: issued.token,
+          deviceId: "device-123",
+          completedAtMs: 1_000,
+        }),
+      ).rejects.toThrow("Cloud worker setup completion owner is no longer pending");
+    },
+  );
+
+  it.each(["requested", "draining", "destroying", "destroyed", "failed", "orphaned"])(
+    "rejects an uncertain cloud-worker setup replay after its environment reaches %s",
+    async (state) => {
+      const baseDir = await createTempDir();
+      const issued = await issueCloudWorkerSetupToken(baseDir);
+      const completion = {
+        baseDir,
+        token: issued.token,
+        deviceId: "device-123",
+        completedAtMs: 1_000,
+      };
+      await verifyBootstrapToken(baseDir, issued.token);
+      await consumeDeviceBootstrapTokenWithSetupCompletion(completion);
+      const { db } = openOpenClawStateDatabase({
+        env: { ...process.env, OPENCLAW_STATE_DIR: baseDir },
+      });
+      db.prepare("UPDATE worker_environments SET state = ? WHERE node_setup_id = ?").run(
+        state,
+        issued.setupId,
+      );
+
+      await expect(
+        consumeDeviceBootstrapTokenWithSetupCompletion({ ...completion, completedAtMs: 2_000 }),
+      ).rejects.toThrow("Cloud worker setup completion owner is no longer pending");
+      await expect(
+        readDevicePairSetupCompletion({ baseDir, setupId: issued.setupId }),
+      ).resolves.toMatchObject({ deliveryState: "uncertain", completedAtMs: 1_000 });
+    },
+  );
+
+  it("rejects cloud-worker setup retries after their owner requests destruction", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueCloudWorkerSetupToken(baseDir);
+    const completion = {
+      baseDir,
+      token: issued.token,
+      deviceId: "device-123",
+      completedAtMs: 1_000,
+    };
+    await verifyBootstrapToken(baseDir, issued.token);
+    await consumeDeviceBootstrapTokenWithSetupCompletion(completion);
+    const { db } = openOpenClawStateDatabase({
+      env: { ...process.env, OPENCLAW_STATE_DIR: baseDir },
+    });
+    db.prepare(
+      "UPDATE worker_environments SET destroy_requested_at_ms = ? WHERE node_setup_id = ?",
+    ).run(2_000, issued.setupId);
+
+    await expect(
+      consumeDeviceBootstrapTokenWithSetupCompletion({ ...completion, completedAtMs: 2_000 }),
+    ).rejects.toThrow("Cloud worker setup completion owner is no longer pending");
+    await expect(
+      readDevicePairSetupCompletion({ baseDir, setupId: issued.setupId }),
+    ).resolves.toMatchObject({ deliveryState: "uncertain", completedAtMs: 1_000 });
   });
 
   it("prunes retained setup outcomes without a status lookup", async () => {
@@ -430,25 +625,6 @@ describe("device bootstrap tokens", () => {
     ).resolves.toEqual({ ok: true });
   });
 
-  it("loads the issued bootstrap profile for a valid token", async () => {
-    const baseDir = await createTempDir();
-    const issued = await issueDeviceBootstrapToken({ baseDir });
-
-    await expect(getDeviceBootstrapTokenProfile({ baseDir, token: issued.token })).resolves.toEqual(
-      {
-        roles: ["node", "operator"],
-        scopes: [
-          "operator.approvals",
-          "operator.questions",
-          "operator.read",
-          "operator.talk.secrets",
-          "operator.write",
-        ],
-      },
-    );
-    await expect(getDeviceBootstrapTokenProfile({ baseDir, token: "invalid" })).resolves.toBeNull();
-  });
-
   it("persists bootstrap profile purpose through binding", async () => {
     const baseDir = await createTempDir();
     const issued = await issueDeviceBootstrapToken({
@@ -478,6 +654,33 @@ describe("device bootstrap tokens", () => {
       scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
       purpose: "control-ui",
     });
+  });
+
+  it("reads an exact correlated setup only from its verified device binding", async () => {
+    const baseDir = await createTempDir();
+    const issued = await issueDevicePairSetupBootstrapToken({
+      baseDir,
+      profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+    });
+    const contextParams = {
+      baseDir,
+      token: issued.token,
+      deviceId: "device-123",
+      publicKey: "public-key-123",
+    };
+
+    await expect(getBoundDeviceBootstrapContext(contextParams)).resolves.toBeNull();
+    await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
+    await expect(getBoundDeviceBootstrapContext(contextParams)).resolves.toEqual({
+      profile: CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+      setupId: issued.setupId,
+    });
+    await expect(
+      getBoundDeviceBootstrapContext({ ...contextParams, deviceId: "other-device" }),
+    ).resolves.toBeNull();
+    await expect(getBoundDeviceBootstrapProfile(contextParams)).resolves.toEqual(
+      CLOUD_WORKER_PAIRING_SETUP_BOOTSTRAP_PROFILE,
+    );
   });
 
   it("persists bootstrap redemption state across verification reloads", async () => {
@@ -667,12 +870,23 @@ describe("device bootstrap tokens", () => {
       },
     });
 
-    await expect(getDeviceBootstrapTokenProfile({ baseDir, token: issued.token })).resolves.toEqual(
-      {
-        roles: ["node", "operator"],
-        scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
-      },
-    );
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        role: "operator",
+        scopes: ["operator.read"],
+      }),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      getBoundDeviceBootstrapProfile({
+        baseDir,
+        token: issued.token,
+        deviceId: "device-123",
+        publicKey: "public-key-123",
+      }),
+    ).resolves.toEqual({
+      roles: ["node", "operator"],
+      scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+    });
     await expect(
       verifyBootstrapToken(baseDir, issued.token, {
         role: "operator",
@@ -692,19 +906,24 @@ describe("device bootstrap tokens", () => {
       },
     });
 
-    await expect(getDeviceBootstrapTokenProfile({ baseDir, token: issued.token })).resolves.toEqual(
-      {
-        roles: ["node", "operator"],
-        scopes: ["operator.admin", "operator.read", "operator.write"],
-        purpose: "mobile-full",
-      },
-    );
     await expect(
       verifyBootstrapToken(baseDir, issued.token, {
         role: "operator",
         scopes: ["operator.admin"],
       }),
     ).resolves.toEqual({ ok: true });
+    await expect(
+      getBoundDeviceBootstrapProfile({
+        baseDir,
+        token: issued.token,
+        deviceId: "device-123",
+        publicKey: "public-key-123",
+      }),
+    ).resolves.toEqual({
+      roles: ["node", "operator"],
+      scopes: ["operator.admin", "operator.read", "operator.write"],
+      purpose: "mobile-full",
+    });
   });
 
   it("logs when issued bootstrap profiles strip overbroad scopes", async () => {

--- a/src/infra/device-bootstrap.ts
+++ b/src/infra/device-bootstrap.ts
@@ -308,9 +308,9 @@ export async function ensureDevicePairSetupBootstrapToken(params: {
 }
 
 /**
- * Retire one setup bearer and record that credential delivery is not yet known.
- * The transport confirms delivery only after its response finishes; a crash or
- * disconnect therefore cannot turn replay safety into a false operator success.
+ * Record that credential delivery is not yet known. Only cloud-worker setup
+ * keeps its device-bound bearer until delivery is confirmed, allowing the same
+ * worker to retry when its credential-bearing response never arrives.
  */
 export async function consumeDeviceBootstrapTokenWithSetupCompletion(params: {
   token: string;
@@ -452,7 +452,7 @@ export async function restoreGenericDeviceBootstrapToken(params: {
   baseDir?: string;
 }): Promise<boolean> {
   if (params.record.setupId) {
-    // Correlated setup credentials stay retired: their durable uncertain outcome owns recovery.
+    // Correlated setup credentials are settled only by their exact completion owner.
     return false;
   }
   return await withLock(async () => {
@@ -460,24 +460,6 @@ export async function restoreGenericDeviceBootstrapToken(params: {
     state[params.record.token] = params.record;
     persistState(state, params.baseDir);
     return true;
-  });
-}
-
-/** Read the issued profile for a valid token without binding or redeeming it. */
-export async function getDeviceBootstrapTokenProfile(params: {
-  token: string;
-  baseDir?: string;
-}): Promise<DeviceBootstrapProfile | null> {
-  return await withLock(async () => {
-    const providedToken = params.token.trim();
-    if (!providedToken) {
-      return null;
-    }
-    const state = await loadState(params.baseDir);
-    const found = Object.values(state).find((candidate) =>
-      verifyPairingToken(providedToken, candidate.token),
-    );
-    return found ? resolvePersistedBootstrapProfile(found) : null;
   });
 }
 
@@ -630,18 +612,23 @@ export async function verifyDeviceBootstrapToken(params: {
   });
 }
 
+type BoundDeviceBootstrapContext = {
+  profile: DeviceBootstrapProfile;
+  setupId?: string;
+};
+
 /**
- * Reads the already-bound bootstrap profile for a verified device identity.
+ * Reads already-bound bootstrap context for a verified device identity.
  *
  * Call this only after `verifyDeviceBootstrapToken()` has returned `{ ok: true }`
  * for the same `token` / `deviceId` / `publicKey` tuple in the current handshake.
  */
-export async function getBoundDeviceBootstrapProfile(params: {
+export async function getBoundDeviceBootstrapContext(params: {
   token: string;
   deviceId: string;
   publicKey: string;
   baseDir?: string;
-}): Promise<DeviceBootstrapProfile | null> {
+}): Promise<BoundDeviceBootstrapContext | null> {
   return await withLock(async () => {
     const state = await loadState(params.baseDir);
     const providedToken = params.token.trim();
@@ -667,6 +654,16 @@ export async function getBoundDeviceBootstrapProfile(params: {
     if (record.deviceId?.trim() !== deviceId || recordPublicKey !== publicKey) {
       return null;
     }
-    return resolvePersistedBootstrapProfile(record);
+    return {
+      profile: resolvePersistedBootstrapProfile(record),
+      ...(record.setupId ? { setupId: record.setupId } : {}),
+    };
   });
+}
+
+/** Read the profile from already-bound bootstrap context. */
+export async function getBoundDeviceBootstrapProfile(
+  params: Parameters<typeof getBoundDeviceBootstrapContext>[0],
+): Promise<DeviceBootstrapProfile | null> {
+  return (await getBoundDeviceBootstrapContext(params))?.profile ?? null;
 }

--- a/src/infra/device-pairing-cloud-worker.ts
+++ b/src/infra/device-pairing-cloud-worker.ts
@@ -18,17 +18,28 @@ export function bindCloudWorkerSetupCompletion(params: {
     params.db,
     kysely
       .selectFrom("worker_environments")
-      .select(["environment_id", "node_device_id", "updated_at_ms"])
+      .select([
+        "environment_id",
+        "state",
+        "destroy_requested_at_ms",
+        "node_device_id",
+        "updated_at_ms",
+      ])
       .where("node_setup_id", "=", params.completion.setupId),
   );
   if (!environment) {
     throw new Error("Cloud worker setup completion has no owning environment");
   }
+  const isFirstProvisioningDevice =
+    environment.state === "provisioning" && environment.node_device_id === null;
+  const isSameLiveDevice =
+    environment.node_device_id === params.completion.deviceId &&
+    ["provisioning", "bootstrapping", "ready", "idle", "attached"].includes(environment.state);
   if (
-    environment.node_device_id !== null &&
-    environment.node_device_id !== params.completion.deviceId
+    environment.destroy_requested_at_ms !== null ||
+    (!isFirstProvisioningDevice && !isSameLiveDevice)
   ) {
-    throw new Error("Cloud worker setup completion identity changed");
+    throw new Error("Cloud worker setup completion owner is no longer pending");
   }
   executeSqliteQuerySync(
     params.db,

--- a/src/infra/device-pairing-store.ts
+++ b/src/infra/device-pairing-store.ts
@@ -628,10 +628,14 @@ export function consumeDeviceBootstrapTokenWithSetupCompletionInTransaction(para
         }
       : undefined;
 
-    executeSqliteQuerySync(
-      db,
-      kysely.deleteFrom("device_bootstrap_tokens").where("token_key", "=", tokenRow.token_key),
-    );
+    // Cloud workers can retry an undelivered hello only with this exact bound bearer;
+    // delivery confirmation retires it atomically with the confirmed completion.
+    if (!completion || record.profile?.purpose !== "cloud-worker") {
+      executeSqliteQuerySync(
+        db,
+        kysely.deleteFrom("device_bootstrap_tokens").where("token_key", "=", tokenRow.token_key),
+      );
+    }
     if (completion) {
       if (record.profile?.purpose === "cloud-worker") {
         bindCloudWorkerSetupCompletion({ db, completion });
@@ -679,35 +683,35 @@ export function confirmDevicePairSetupCompletionDeliveryInTransaction(params: {
   return runOpenClawStateWriteTransaction(({ db }) => {
     ensureDevicePairSetupCompletionSchema(db);
     const kysely = getNodeSqliteKysely<OpenClawStateKyselyDatabase>(db);
-    executeSqliteQuerySync(
+    const row = executeSqliteQueryTakeFirstSync(
       db,
       kysely
         .updateTable("device_pair_setup_completions")
         .set({ delivery_state: "confirmed" })
         .where("setup_id", "=", setupId)
         .where("device_id", "=", deviceId)
-        .where("retain_until_ms", ">", params.nowMs),
+        .where("retain_until_ms", ">", params.nowMs)
+        .returningAll(),
     );
-    const row = executeSqliteQueryTakeFirstSync(
+    if (!row) {
+      return null;
+    }
+    executeSqliteQuerySync(
       db,
       kysely
-        .selectFrom("device_pair_setup_completions")
-        .selectAll()
+        .deleteFrom("device_bootstrap_tokens")
         .where("setup_id", "=", setupId)
-        .where("device_id", "=", deviceId)
-        .where("retain_until_ms", ">", params.nowMs),
+        .where("device_id", "=", deviceId),
     );
-    return row
-      ? {
-          setupId: row.setup_id,
-          deviceId: row.device_id,
-          ...optional("deviceName", row.device_name),
-          access: fromSetupCompletionAccessColumn(row.access),
-          completedAtMs: row.completed_at_ms,
-          deliveryState: fromSetupCompletionDeliveryStateColumn(row.delivery_state),
-          retainUntilMs: row.retain_until_ms,
-        }
-      : null;
+    return {
+      setupId: row.setup_id,
+      deviceId: row.device_id,
+      ...optional("deviceName", row.device_name),
+      access: fromSetupCompletionAccessColumn(row.access),
+      completedAtMs: row.completed_at_ms,
+      deliveryState: fromSetupCompletionDeliveryStateColumn(row.delivery_state),
+      retainUntilMs: row.retain_until_ms,
+    };
   }, resolveDevicePairingStateDbOptions(params.baseDir));
 }
 

--- a/src/plugins/capability-provider.types.ts
+++ b/src/plugins/capability-provider.types.ts
@@ -112,24 +112,17 @@ export type WorkerDesktopEndpoint = {
 export type WorkerExecutionMode = "worker-turn" | "remote-exec";
 
 /** Replay-safe node enrollment prepared only after a provider has allocated its machine. */
-export type WorkerNodeEnrollment =
-  | {
-      mode: "connect";
-      setupCode: string;
-      setupId: string;
-      openclawVersion: string;
-      packageSpecs: readonly string[];
-      displayName: string;
-      waitForDeviceId: () => Promise<string>;
-    }
-  | {
-      mode: "resume";
-      deviceId: string;
-      openclawVersion: string;
-      packageSpecs: readonly string[];
-      displayName: string;
-      waitForDeviceId: () => Promise<string>;
-    };
+export type WorkerNodeEnrollment = {
+  openclawVersion: string;
+  packageSpecs: readonly string[];
+  displayName: string;
+  /** Gateway shutdown cancels enrollment without releasing its replay-owned provider lease. */
+  signal?: AbortSignal;
+  waitForDeviceId: () => Promise<string>;
+} & (
+  | { mode: "connect"; setupCode: string; setupId: string }
+  | { mode: "resume"; deviceId: string }
+);
 
 /** Durable lease identity and endpoint returned by a successful provision operation. */
 export type WorkerLease = {

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -14,6 +14,7 @@ import {
   runWithGatewayIndependentRootWorkContinuation,
   runOutsideGatewayRootWorkAdmission,
   tryBeginGatewayPreparedRestartRootWorkAdmission,
+  tryBeginGatewayRestartStartupRootWorkAdmission,
   tryBeginGatewayRootWorkAdmission,
   tryBeginGatewaySuspendAdmission,
 } from "./gateway-work-admission.js";
@@ -82,6 +83,44 @@ it("admits a targeted restart root only from prepared suspension", () => {
 
   markGatewayRestartDraining();
   expect(tryBeginGatewayPreparedRestartRootWorkAdmission()).toBeNull();
+});
+
+it("admits a tracked restart-startup root only while restart fencing accepts recovery", async () => {
+  expect(tryBeginGatewayRestartStartupRootWorkAdmission()).toBeNull();
+
+  const suspension = tryBeginGatewaySuspendAdmission(() => {});
+  expect(tryBeginGatewayRestartStartupRootWorkAdmission()).toBeNull();
+  expect(suspension?.commit()).toBe(true);
+  const suspendedSignal = beginGatewayRestartSignalAdmission();
+  expect(suspendedSignal).not.toBeNull();
+  expect(tryBeginGatewayRestartStartupRootWorkAdmission()).toBeNull();
+  expect(suspendedSignal?.rollback()).toBe(true);
+  expect(suspension?.release()).toBe(true);
+
+  const signal = beginGatewayRestartSignalAdmission();
+  const signalRoot = tryBeginGatewayRestartStartupRootWorkAdmission();
+  expect(signalRoot?.ownsRoot).toBe(true);
+  await signalRoot?.run(async () => {
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+    expect(getActiveGatewayRootWorkCount({ excludeCurrent: true })).toBe(0);
+  });
+  signalRoot?.release();
+  expect(getActiveGatewayRootWorkCount()).toBe(0);
+  expect(signal?.rollback()).toBe(true);
+
+  markGatewayRestartDraining();
+  const restartRoot = tryBeginGatewayRestartStartupRootWorkAdmission();
+  expect(restartRoot?.ownsRoot).toBe(true);
+  await restartRoot?.run(async () => {
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+    expect(isGatewaySubordinateWorkAdmissionClosed()).toBe(true);
+    resetGatewayWorkAdmission();
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+    expect(isGatewaySubordinateWorkAdmissionClosed()).toBe(true);
+    expect(tryBeginGatewayRestartStartupRootWorkAdmission()).toBeNull();
+  });
+  restartRoot?.release();
+  expect(getActiveGatewayRootWorkCount()).toBe(0);
 });
 
 it("lets an admitted root cross only the reversible suspension fence", async () => {

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -258,6 +258,21 @@ export function tryBeginGatewayRootWorkAdmission(): GatewayRootWorkAdmissionLeas
 }
 
 /**
+ * Tracks a host-selected restart-startup recovery handshake without reopening admission.
+ * The caller still owns frame/auth validation; this lease grants no method authority.
+ */
+export function tryBeginGatewayRestartStartupRootWorkAdmission(): GatewayRootWorkAdmissionLease | null {
+  if (
+    (!GATEWAY_WORK_ADMISSION_STATE.restartDraining &&
+      !GATEWAY_WORK_ADMISSION_STATE.restartSignalPending) ||
+    GATEWAY_WORK_ADMISSION_STATE.suspendPhase !== "accepting"
+  ) {
+    return null;
+  }
+  return createGatewayRootWorkAdmission();
+}
+
+/**
  * Admits only the exact predecessor-bound restart selected by the RPC router.
  * The held root preserves signal-to-drain ordering without reopening suspension.
  */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators restarting a Gateway with cloud workers still provisioning could encounter a startup deadlock: startup recovery waited for a worker node connection while startup admission rejected the connection needed to finish recovery. Interrupted or competing recovery could also replay the wrong owner, duplicate a provider lease, or destroy work belonging to a newer placement.

Preserves the authenticated, already-paired node startup reconnect shipped by #126601. Closed issue #125157 is rollout context only; this PR does not close, reopen, or claim to resolve that issue.

## Why This Change Was Made

Startup admission now allows both existing authenticated paired-node reconnects and the exact first-time cloud-worker bootstrap handshake, while continuing to reject unrelated operator, browser, unpaired-node, raw-worker, and mixed-credential traffic. Worker recovery is owned by the existing session/placement/environment lifecycle boundaries: replay revalidates the exact session, placement generation, environment, owner epoch, and live authority; provider operations deterministically reuse their exact durable lease; cancellation and shutdown fence/drain recovery without releasing a lease that remains eligible for replay.

The change introduces no SQLite schema-version change, Gateway protocol-version change, or new configuration surface. Production growth is intentional because exact startup admission, closure-bound lifecycle ownership, deterministic lease replay, and non-destructive cancellation are distinct missing capabilities/security invariants, not compatibility shims or downstream guards.

## User Impact

Gateway restarts can finish recovering in-flight cloud workers without blocking startup, existing approved nodes keep reconnecting during startup, and interrupted/replayed provisioning resumes the correct lease without duplicating infrastructure or destroying a replacement session. Unauthorized or stale recovery attempts remain closed.

## Evidence

Pre-fix sibling regression reproduced against the current-main behavior preserved by #126601:

```text
node scripts/run-vitest.mjs src/gateway/server.node-pairing-rate-limit.test.ts -t 'admits an authenticated paired node while gateway startup is pending'
AssertionError: expected false to be true
```

The integrated worker/placement/provider regression suite passed **740 tests across 37 files and four Vitest shards**:

```text
node scripts/run-vitest.mjs src/gateway/server.node-pairing-rate-limit.test.ts src/gateway/server/ws-connection.startup.test.ts src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts src/gateway/server/ws-connection/message-handler.worker.test.ts src/gateway/server.preauth-hardening.test.ts src/process/gateway-work-admission.test.ts src/gateway/server-worker-placement-startup.test.ts src/gateway/server.sessions.worker-original-order.test.ts src/gateway/worker-environments/provider-provisioning.shutdown-replay.test.ts src/gateway/worker-environments/provider-provisioning.replay.test.ts src/gateway/worker-environments/provider-bootstrap.test.ts src/gateway/worker-environments/placement-dispatch-coordinator.test.ts src/gateway/worker-environments/placement-dispatch-recovery.test.ts src/gateway/worker-environments/placement-dispatch.test.ts src/gateway/worker-environments/service-lifetime.test.ts src/gateway/worker-environments/node-enrollment.test.ts src/gateway/worker-environments/store-node-enrollment.test.ts src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts src/infra/device-bootstrap.test.ts extensions/crabbox/src/crabbox-worker-provider.test.ts
```

The earlier combined startup proof passed **115 tests**. An additional fresh exact-head real-Gateway/startup/bootstrap rerun passed **226 tests across 11 files and two Vitest shards**:

```text
node scripts/run-vitest.mjs src/gateway/server.node-pairing-rate-limit.test.ts src/gateway/server/ws-connection.startup.test.ts src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts src/gateway/server/ws-connection/message-handler.worker.test.ts src/gateway/server.preauth-hardening.test.ts src/infra/device-bootstrap.test.ts
```

Additional complete green verification:

```text
node scripts/check-changed.mjs
node --max-old-space-size=8192 --import tsx scripts/plugin-sdk-surface-report.mts --check
node --import tsx scripts/build-all.mts
git diff --check origin/main...HEAD
```

Fresh independent autoreview: **no actionable findings**, overall confidence **0.88**. Exact `origin/main...HEAD` change accounting: production **+985/-289 (net +696; 30 files)**; regression tests **+2905/-41 (net +2864; 20 files)**; test support **+23/-4 (net +19; 3 files)**; combined tests/test support **+2928/-45 (net +2883; 23 files)**.

Authenticated live team-environment recovery is intentionally deferred until after merge because deployment is outside this PR's authorization; no live deployment is claimed or performed.
