### PR TITLE
fix(discord): validate plugin command names

### DIFF
--- a/extensions/discord/src/monitor/provider.commands.test.ts
+++ b/extensions/discord/src/monitor/provider.commands.test.ts
@@ -4,6 +4,7 @@ import type { NativeCommandSpec } from "openclaw/plugin-sdk/native-command-regis
 import { registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   createTestRegistry,
+  getActivePluginRegistry,
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
@@ -12,7 +13,9 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { discordSetupPlugin } from "../channel.setup.js";
 import { DISCORD_VOICE_COMMAND_SPEC } from "../voice/command.js";
+import { createDiscordNativeCommand } from "./native-command.js";
 import { resolveDiscordProviderCommandSpecs } from "./provider.commands.js";
+import { createNoopThreadBindingManager } from "./thread-bindings.manager.js";
 
 const retainNativeCatalog = vi.hoisted(() => vi.fn());
 
@@ -36,6 +39,7 @@ vi.mock("openclaw/plugin-sdk/plugin-command-runtime", async (importOriginal) => 
 
 type ResolverParams = Parameters<typeof resolveDiscordProviderCommandSpecs>[0];
 type SkillCommands = ReturnType<NonNullable<ResolverParams["listSkillCommandsForAgents"]>>;
+type PluginCommandSpec = NativeCommandSpec & { nativeNames?: Partial<Record<string, string>> };
 
 const cfg: OpenClawConfig = {};
 const skillCommands = [
@@ -45,7 +49,7 @@ const skillCommands = [
 
 function createResolverHarness(
   options: {
-    pluginCommandSpecs?: NativeCommandSpec[];
+    pluginCommandSpecs?: PluginCommandSpec[];
     voiceEnabled?: boolean;
     nativeCommandSpecs?: NativeCommandSpec[];
     skillCommands?: SkillCommands;
@@ -82,6 +86,7 @@ function createResolverHarness(
         description: spec.description,
         descriptionLocalizations: spec.descriptionLocalizations,
         acceptsArgs: spec.acceptsArgs,
+        nativeNames: spec.nativeNames,
         channels: ["discord"],
         handler: async () => ({ text: "ok" }),
       }),
@@ -115,6 +120,162 @@ describe("resolveDiscordProviderCommandSpecs", () => {
 
   afterEach(() => {
     resetPluginRuntimeStateForTest();
+  });
+
+  it.each([
+    {
+      label: "primary name",
+      name: "MiXeDPrimary",
+      nativeNames: undefined,
+      expectedName: "mixedprimary",
+    },
+    {
+      label: "default alias",
+      name: "primary-default",
+      nativeNames: { default: "MiXeDDefault" },
+      expectedName: "mixeddefault",
+    },
+    {
+      label: "Discord alias",
+      name: "primary-discord",
+      nativeNames: { default: "MiXeDDefault", discord: "MiXeDDiscord" },
+      expectedName: "mixeddiscord",
+    },
+  ])("deploys the normalized $label", async ({ name, nativeNames, expectedName }) => {
+    const harness = createResolverHarness({
+      nativeSkillsEnabled: false,
+      pluginCommandSpecs: [
+        { name, nativeNames, description: "Mixed-case command", acceptsArgs: false },
+      ],
+    });
+
+    const resolved = await harness.resolve();
+    const candidate = resolved.commandSpecs[1]!;
+    expect(candidate.name).toBe(expectedName);
+    const command = createDiscordNativeCommand({
+      command: candidate,
+      cfg,
+      discordConfig: {},
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+    expect(command.serialize().name).toBe(expectedName);
+    expect(harness.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps 32-character names and rejects 33-character names before command-cap planning", async () => {
+    const exactLimitName = "a".repeat(32);
+    const overLimitName = "b".repeat(33);
+    const harness = createResolverHarness({
+      maxDiscordCommands: 4,
+      pluginCommandSpecs: [
+        { name: exactLimitName, description: "At the limit", acceptsArgs: false },
+        { name: overLimitName, description: "Over the limit", acceptsArgs: false },
+      ],
+    });
+
+    const resolved = await harness.resolve();
+
+    expect(resolved.skillCommands).toEqual(skillCommands);
+    expect(resolved.commandSpecs.map((command) => command.name)).toEqual([
+      "built-in",
+      "skill-only",
+      "extra-skill",
+      exactLimitName,
+    ]);
+    expect(harness.error).toHaveBeenCalledOnce();
+    expect(harness.error).toHaveBeenCalledWith(
+      danger(
+        `discord: plugin command "/${"b".repeat(32)}…" exceeds the 32-character name limit. Set a shorter Discord native alias. Skipping.`,
+      ),
+    );
+    expect(harness.log).not.toHaveBeenCalled();
+    expect(harness.listNativeCommandSpecsForConfig).toHaveBeenCalledOnce();
+  });
+
+  it("isolates an invalid plugin name and retains a later valid command's original dispatch", async () => {
+    const overLimitName = "x".repeat(33);
+    const harness = createResolverHarness({
+      nativeSkillsEnabled: false,
+      pluginCommandSpecs: [
+        { name: overLimitName, description: "Invalid command", acceptsArgs: false },
+        { name: "LaTeRValid", description: "Later valid command", acceptsArgs: false },
+      ],
+    });
+
+    const resolved = await harness.resolve();
+
+    expect(resolved.commandSpecs.map((command) => command.name)).toEqual([
+      "built-in",
+      "latervalid",
+    ]);
+    expect(harness.error).toHaveBeenCalledOnce();
+    expect(retainNativeCatalog).toHaveBeenCalledExactlyOnceWith("discord");
+    const candidate = resolved.commandSpecs[1]!;
+    expect("prepareDispatch" in candidate).toBe(true);
+    if (!("prepareDispatch" in candidate)) {
+      throw new Error("expected the retained plugin command candidate");
+    }
+    const dispatch = candidate.prepareDispatch();
+    expect(dispatch.kind).toBe("plugin");
+    if (dispatch.kind !== "plugin") {
+      throw new Error("expected the original plugin command dispatch");
+    }
+    await expect(
+      dispatch.execute({
+        channel: "discord",
+        isAuthorizedSender: true,
+        commandBody: "/latervalid",
+        config: cfg,
+      }),
+    ).resolves.toEqual({ text: "ok" });
+  });
+
+  it("accepts a long primary command when its selected Discord alias is safe", async () => {
+    const longPrimaryName = "p".repeat(40);
+    const harness = createResolverHarness({
+      nativeSkillsEnabled: false,
+      pluginCommandSpecs: [
+        {
+          name: longPrimaryName,
+          nativeNames: { default: "d".repeat(40), discord: "SaFeAlias" },
+          description: "Long primary command",
+          acceptsArgs: false,
+        },
+      ],
+    });
+
+    const resolved = await harness.resolve();
+
+    expect(resolved.commandSpecs.map((command) => command.name)).toEqual(["built-in", "safealias"]);
+    expect(getActivePluginRegistry()?.commands[0]?.command.name).toBe(longPrimaryName);
+    expect(harness.error).not.toHaveBeenCalled();
+  });
+
+  it("preserves built-in precedence for a normalized Discord alias", async () => {
+    const harness = createResolverHarness({
+      nativeSkillsEnabled: false,
+      pluginCommandSpecs: [
+        {
+          name: "plugin-shadow",
+          nativeNames: { discord: "BuIlT-In" },
+          description: "Built-in collision",
+          acceptsArgs: false,
+        },
+        { name: "MiXeDSafe", description: "Safe command", acceptsArgs: false },
+      ],
+    });
+
+    const resolved = await harness.resolve();
+
+    expect(resolved.commandSpecs.map((command) => command.name)).toEqual(["built-in", "mixedsafe"]);
+    expect(harness.error).toHaveBeenCalledExactlyOnceWith(
+      danger(
+        'discord: plugin command "/built-in" duplicates an existing native command. Skipping.',
+      ),
+    );
   });
 
   it("discards provisional skill collisions when command overflow removes skills", async () => {

--- a/extensions/discord/src/monitor/provider.commands.ts
+++ b/extensions/discord/src/monitor/provider.commands.ts
@@ -19,6 +19,7 @@ import { DISCORD_VOICE_COMMAND_SPEC } from "../voice/command.js";
 
 export type DiscordProviderCommandSpec = NativeCommandSpec | PluginCommandNativeCandidate;
 
+const DISCORD_COMMAND_NAME_MAX_LENGTH = 32;
 const loadPluginCommandRuntime = createLazyRuntimeModule(
   () => import("openclaw/plugin-sdk/plugin-command-runtime"),
 );
@@ -44,7 +45,19 @@ export async function resolveDiscordProviderCommandSpecs(params: {
   if (params.nativeEnabled) {
     pluginCommandRuntime = (await loadPluginCommandRuntime()).createPluginCommandRuntime();
   }
-  const pluginCommandSpecs = pluginCommandRuntime?.listNativeCandidates("discord") ?? [];
+  const pluginCommandSpecs = (pluginCommandRuntime?.listNativeCandidates("discord") ?? []).filter(
+    (command) => {
+      if (command.name.length <= DISCORD_COMMAND_NAME_MAX_LENGTH) {
+        return true;
+      }
+      params.runtime.error?.(
+        danger(
+          `discord: plugin command "/${command.name.slice(0, DISCORD_COMMAND_NAME_MAX_LENGTH)}…" exceeds the ${DISCORD_COMMAND_NAME_MAX_LENGTH}-character name limit. Set a shorter Discord native alias. Skipping.`,
+        ),
+      );
+      return false;
+    },
+  );
   const onCollision = (normalizedName: string) => {
     params.runtime.error?.(
       danger(

--- a/src/plugins/plugin-command-metadata.ts
+++ b/src/plugins/plugin-command-metadata.ts
@@ -51,7 +51,7 @@ export function projectPluginCommandNativeMetadata(
     ? Object.freeze({ ...command.descriptionLocalizations })
     : undefined;
   return Object.freeze({
-    name,
+    name: normalizeOptionalLowercaseString(name) ?? name,
     description: command.description.trim(),
     ...(descriptionLocalizations ? { descriptionLocalizations } : {}),
     acceptsArgs: command.acceptsArgs ?? false,

--- a/src/plugins/plugin-command-runtime.test.ts
+++ b/src/plugins/plugin-command-runtime.test.ts
@@ -7,6 +7,7 @@ vi.mock("./host-hook-cleanup.js", () => ({ cleanupReplacedPluginHostRegistry }))
 
 import { getPluginCommandExecutionCount } from "./command-execution-lock.js";
 import { registerPluginCommandInRegistry } from "./command-registration.js";
+import { listProviderPluginCommandSpecs } from "./command-specs.js";
 import { withPluginCommandAccountStartScope } from "./plugin-command-account-start-scope.js";
 import {
   createPluginCommandRuntime,
@@ -38,7 +39,7 @@ function registerCommand(
     pluginId: string;
     name: string;
     channels?: string[];
-    nativeNames?: Record<string, string>;
+    nativeNames?: Partial<Record<string, string>>;
     acceptsArgs?: boolean;
     handler: (args?: string) => Promise<{ text: string }>;
   },
@@ -130,6 +131,71 @@ describe("plugin command runtime", () => {
     expect(scopedHandler).toHaveBeenCalledOnce();
     expect(ambientHandler).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      label: "primary name",
+      name: "MiXeDPrimary",
+      nativeNames: undefined,
+      provider: "discord",
+      expectedName: "mixedprimary",
+    },
+    {
+      label: "default alias",
+      name: "OriginalDefault",
+      nativeNames: { default: "MiXeDDefault" },
+      provider: "telegram",
+      expectedName: "mixeddefault",
+    },
+    {
+      label: "provider alias",
+      name: "OriginalProvider",
+      nativeNames: { default: "MiXeDDefault", discord: "MiXeDDiscord" },
+      provider: "discord",
+      expectedName: "mixeddiscord",
+    },
+  ])(
+    "normalizes the $label native identity while preserving dispatch and collision ownership",
+    async ({ name, nativeNames, provider, expectedName }) => {
+      const registry = createEmptyPluginRegistry();
+      const handler = vi.fn(async (args?: string) => ({ text: `original:${args}` }));
+      registerCommand(registry, {
+        pluginId: "original-plugin",
+        name,
+        nativeNames,
+        acceptsArgs: true,
+        handler,
+      });
+      setActivePluginRegistry(registry);
+
+      expect(registry.commands[0]?.command.name).toBe(name);
+      expect(registry.commands[0]?.command.nativeNames).toEqual(nativeNames);
+      expect(
+        registerPluginCommandInRegistry(registry, "colliding-plugin", {
+          name: expectedName.toUpperCase(),
+          description: "Colliding command",
+          handler: async () => ({ text: "wrong handler" }),
+        }),
+      ).toEqual({
+        ok: false,
+        error: `Command "${expectedName}" already registered by plugin "original-plugin"`,
+      });
+      expect(listProviderPluginCommandSpecs(provider).map((spec) => spec.name)).toEqual([
+        expectedName,
+      ]);
+
+      const candidate = createPluginCommandRuntime().listNativeCandidates(provider)[0]!;
+      expect(candidate.name).toBe(expectedName);
+      await expect(
+        requirePluginDispatch(candidate, "payload").execute({
+          ...executionContext,
+          channel: provider,
+          commandBody: `/${expectedName} payload`,
+        }),
+      ).resolves.toEqual({ text: "original:payload" });
+      expect(handler).toHaveBeenCalledExactlyOnceWith("payload");
+    },
+  );
 
   it("rejects forged, cross-runtime, wrong-channel, and retired selections", async () => {
     const registry = createEmptyPluginRegistry();


### PR DESCRIPTION
Closes #126633

## What Problem This Solves

Fixes an issue where a plugin command could pass OpenClaw registration but reach Discord with uppercase spelling or more than 32 characters. Discord rejects those application-command names, which can leave native slash-command catalogs incomplete even though ordinary messaging remains available.

## Why This Change Was Made

The repair keeps ownership split at the right boundaries:

- shared provider-native plugin metadata lowercases only the selected advertised identity, while preserving the original registered definition and handler for dispatch;
- Discord filters selected names over its documented 32-character limit before collision merging, command-cap planning, catalog retention, and deployment.

Names are not truncated because that can manufacture collisions. Discord's length limit is not imposed globally, so a long primary command remains valid when it supplies a safe Discord alias.

## User Impact

Plugins with mixed-case command names now advertise a valid lowercase Discord identity. An oversized Discord command is skipped with an actionable diagnostic instead of aborting later catalog reconciliation, so later valid commands can still deploy. Existing built-in precedence and plugin dispatch behavior remain unchanged.

## Evidence

- Direct installed `discord-api-types` contract: Discord chat-input names are lowercase and 1–32 characters; bulk overwrite submits the complete command catalog.
- Pre-fix shared metadata tests failed for mixed-case primary/default/provider aliases.
- Pre-fix Discord planner tests failed 7 cases covering casing, 32/33 boundary, invalid-candidate isolation, safe aliases, skills, and collisions.
- Post-fix focused owner tests: 28/28 passed; parent reran both owner shards successfully.
- Expanded core/Discord/Telegram/plugin/channel contract coverage: 466 passed across six shards, including in-memory Discord REST/deployer and native-dispatch tests.
- Complete Discord extension lane: 2,802 passed across 225 files.
- `node scripts/check-changed.mjs -- <four changed files>`: passed.
- `git diff --check`: passed.
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +15/-2 (net +13). Tests: +229/-2.

No live Discord mutation was performed because no dedicated non-production Discord application/guild was selected. Current proof consists of direct installed dependency types, in-memory REST/deployer and native-dispatch coverage, and the complete Discord extension lane. This is not live Discord proof; landing requires the parent's explicit external-API proof decision and must not touch an operator's production command catalog.

This is a non-visual command-catalog validation fix; no UI layout changed.

AI-assisted: implementation and review used Codex, with maintainer inspection of the complete registration/metadata/catalog/deployment path and direct dependency types.
