### PR TITLE
perf(test): advance Buzz reconnect backoff

### DIFF
--- a/extensions/buzz/src/gateway.lifecycle.test.ts
+++ b/extensions/buzz/src/gateway.lifecycle.test.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelGatewayContext } from "../runtime-api.js";
 import type { BuzzBus } from "./buzz-bus.js";
 import type { ResolvedBuzzAccount } from "./types.js";
@@ -152,6 +152,10 @@ describe("Buzz gateway lifecycle", () => {
     );
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("invalidates cached room targets after initial discovery and newer room metadata", async () => {
     const invalidateDirectoryCache = vi.fn();
     const { abortController, lifecycle } = startTestGateway({
@@ -169,6 +173,7 @@ describe("Buzz gateway lifecycle", () => {
   });
 
   it("restarts the account lifecycle when the bus reports a failure", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     gatewayMocks.resolveAgentIdentity.mockReturnValue({ name: "Molt" });
     const setStatus = vi.fn();
     const { abortController, account, lifecycle } = startTestGateway({ setStatus });
@@ -189,6 +194,7 @@ describe("Buzz gateway lifecycle", () => {
       terminalDisconnect: undefined,
     });
     gatewayMocks.onFatalError?.(new Error("relay failed"));
+    await vi.advanceTimersByTimeAsync(1_200);
 
     await vi.waitFor(() => expect(gatewayMocks.startBuzzBus).toHaveBeenCalledTimes(2), {
       timeout: 3_000,
@@ -416,8 +422,10 @@ describe("Buzz gateway lifecycle", () => {
   });
 
   it("uses the rolling lookback after a failed initial session", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     gatewayMocks.startBuzzBus.mockRejectedValueOnce(new Error("connect failed"));
     const { abortController, lifecycle } = startTestGateway();
+    await vi.advanceTimersByTimeAsync(1_200);
 
     await vi.waitFor(() => expect(gatewayMocks.startBuzzBus).toHaveBeenCalledTimes(2), {
       timeout: 3_000,
@@ -450,6 +458,7 @@ describe("Buzz gateway lifecycle", () => {
   });
 
   it("reconnects with a rolling lookback without trusting sender time", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const invalidateDirectoryCache = vi.fn();
     const { abortController, lifecycle } = startTestGateway({ invalidateDirectoryCache });
 
@@ -470,6 +479,7 @@ describe("Buzz gateway lifecycle", () => {
     );
     const reconnectStartedAt = Math.floor(Date.now() / 1000);
     gatewayMocks.onFatalError?.(new Error("relay failed"));
+    await vi.advanceTimersByTimeAsync(1_200);
 
     await vi.waitFor(() => expect(gatewayMocks.startBuzzBus).toHaveBeenCalledTimes(2), {
       timeout: 3_000,


### PR DESCRIPTION
## What Problem This Solves

The Buzz plugin gateway lifecycle suite spends more than three seconds of real wall-clock time waiting for three production reconnect/backoff delays on every run. This slows focused plugin validation and CI without adding coverage.

## Why This Change Was Made

Use Vitest's existing selective fake-timer support in exactly the three reconnect cases and advance the first retry by its real production upper bound: 1,000 ms initial delay plus at most 20% positive jitter = 1,200 ms. Only `setTimeout` and `clearTimeout` are faked; `Date.now`, intervals, abort listeners, retry policy, lifecycle transitions, attempt order, and every existing lookback, invalidation, close, and status assertion remain real or unchanged. Restore real timers after every test.

This is a maintainer-requested, AI-assisted, coverage-preserving test-performance change. Production code, mocks, public surfaces, dependencies, snapshots, and baselines are unchanged.

## User Impact

No user-visible behavior changes. Developers and CI get faster Buzz plugin lifecycle tests while retaining their existing reconnect, rolling-lookback, sender-clock distrust, shutdown, and status coverage.

## Evidence

Controlled same-runner benchmark: [Blacksmith Testbox benchmark](https://github.com/openclaw/openclaw/actions/runs/32362081372). Same stopped Testbox, one worker, distinct caches, import diagnostics, `/usr/bin/time -v`, one excluded warmup, and two retained samples per side; every sample passed all 12 lifecycle tests.

- Retained mean wall time: **13.150 s → 10.035 s** (**-3.115 s / -23.69%**).
- Test-body time: **3.805 s → 0.386 s** (**-3.419 s / -89.86%**).
- Three reconnect cases: approximately **1,056–1,212 ms each → 1–5 ms each**.
- Vitest duration: **9.56 / 9.68 s → 6.48 / 6.70 s**.
- Import duration: **4.85 / 4.34 s → 5.11 / 5.22 s**, confirming the improvement is removed paid backoff rather than favorable import noise.
- Peak RSS differed by approximately +1.2%; this is directional noise, not a memory-improvement claim.
- Focused owner/sibling proof: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/buzz/src/gateway.lifecycle.test.ts extensions/buzz/src/buzz-bus.lifecycle.test.ts extensions/nostr/src/channel.lifecycle.test.ts` — **41/41 passed** across the correct messaging and extension shards.
- Complete clean-runner changed gate: `node scripts/check-changed.mjs -- extensions/buzz/src/gateway.lifecycle.test.ts` — passed extension test typecheck, type-aware lint (**0 warnings / 0 errors**), plugin boundaries, dead exports, formatting, and guards; [hosted changed-gate run](https://github.com/openclaw/openclaw/actions/runs/32364418579).
- Formatting and patch hygiene: `node_modules/.bin/oxfmt --check extensions/buzz/src/gateway.lifecycle.test.ts`; `git diff --check origin/main...HEAD`.
- Production LOC: **+0/-0**. Tests: **+11/-1** in one file. No changelog or screenshots: internal test-only change, no visual surface.
