### PR TITLE
fix(logging): make clawlog JSON parseable

### DIFF
--- a/docs/platforms/mac/logging.md
+++ b/docs/platforms/mac/logging.md
@@ -20,6 +20,12 @@ The macOS app logs through swift-log (unified logging by default) and can also w
 
 Treat the file as sensitive; do not share it without review.
 
+## Export unified logs as JSON
+
+Run `./scripts/clawlog.sh --json` to write recent unified-log events as one JSON array to stdout, or add `--output logs.json` to write the array to a file without printing it. The default output contains the last 50 log records; use `--lines 1` for the most recent record or `--all` for every matching record. `--lines` counts complete records in JSON mode, not physical lines.
+
+JSON export cannot be combined with `--follow` or `--list-categories`. Use those options without `--json`.
+
 ## Unified logging private data on macOS
 
 Unified logging redacts most payloads unless a subsystem opts into `privacy -off`. This is controlled by a plist in `/Library/Preferences/Logging/Subsystems/` keyed by subsystem name. Only new log entries pick up the flag, so enable it before reproducing an issue. Background: [macOS logging privacy shenanigans](https://steipete.me/posts/2025/logging-privacy-shenanigans).

--- a/scripts/clawlog.sh
+++ b/scripts/clawlog.sh
@@ -40,11 +40,10 @@ LOG_LEVEL="$DEFAULT_LEVEL"
 SEARCH_TEXT=""
 OUTPUT_FILE=""
 ERRORS_ONLY=false
-SERVER_ONLY=false
 TAIL_LINES=50  # Default number of lines to show
 SHOW_TAIL=true
-SHOW_HELP=false
 STYLE_JSON=false
+LIST_CATEGORIES=false
 
 # Function to show usage
 show_usage() {
@@ -78,7 +77,7 @@ QUICK START:
 OPTIONS:
     -h, --help              Show this help message
     -f, --follow            Stream logs continuously (like tail -f)
-    -n, --lines NUM         Number of lines to show (default: 50)
+    -n, --lines NUM         Number of lines (or JSON records) to show (default: 50)
     -l, --last TIME         Time range to search (default: 5m)
                            Examples: 5m, 1h, 2d, 1w
     -c, --category CAT      Filter by category (e.g., ServerManager, SessionService)
@@ -88,8 +87,8 @@ OPTIONS:
     -o, --output FILE       Export logs to file
     --server                Show only server output logs
     --all                   Show all logs without tail limit
-    --list-categories       List all available log categories
-    --json                  Output in JSON format
+    --list-categories       List all available log categories (not with --json)
+    --json                  Output one JSON array (not with --follow or --list-categories)
 
 EXAMPLES:
     clawlog                   Show last 50 lines from past 5 minutes (default)
@@ -207,13 +206,12 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --server)
-            SERVER_ONLY=true
             CATEGORY="ServerOutput"
             shift
             ;;
         --list-categories)
-            list_categories
-            exit 0
+            LIST_CATEGORIES=true
+            shift
             ;;
         --json)
             STYLE_JSON=true
@@ -230,6 +228,16 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+if [[ "$STYLE_JSON" == true ]] && [[ "$STREAM_MODE" == true || "$LIST_CATEGORIES" == true ]]; then
+    echo "Error: --json cannot be combined with --follow or --list-categories" >&2
+    exit 1
+fi
+
+if [[ "$LIST_CATEGORIES" == true ]]; then
+    list_categories
+    exit 0
+fi
 
 # Build the predicate
 PREDICATE="subsystem == \"$SUBSYSTEM\""
@@ -273,37 +281,68 @@ else
     # Add time range
     LOG_CMD+=(--last "$TIME_RANGE")
 
-    if [[ "$SHOW_TAIL" == true ]]; then
-        echo -e "${GREEN}Showing last $TAIL_LINES log lines from the past $TIME_RANGE${NC}"
-    else
-        echo -e "${GREEN}Showing all logs from the past $TIME_RANGE${NC}"
-    fi
+    if [[ "$STYLE_JSON" == false ]]; then
+        if [[ "$SHOW_TAIL" == true ]]; then
+            echo -e "${GREEN}Showing last $TAIL_LINES log lines from the past $TIME_RANGE${NC}"
+        else
+            echo -e "${GREEN}Showing all logs from the past $TIME_RANGE${NC}"
+        fi
 
-    # Show applied filters
-    if [[ "$ERRORS_ONLY" == true ]]; then
-        echo -e "${RED}Filter: Errors only${NC}"
+        # Show applied filters
+        if [[ "$ERRORS_ONLY" == true ]]; then
+            echo -e "${RED}Filter: Errors only${NC}"
+        fi
+        if [[ -n "$CATEGORY" ]]; then
+            echo -e "${BLUE}Category: $CATEGORY${NC}"
+        fi
+        if [[ -n "$SEARCH_TEXT" ]]; then
+            echo -e "${YELLOW}Search: \"$SEARCH_TEXT\"${NC}"
+        fi
+        echo ""  # Empty line for readability
     fi
-    if [[ -n "$CATEGORY" ]]; then
-        echo -e "${BLUE}Category: $CATEGORY${NC}"
-    fi
-    if [[ -n "$SEARCH_TEXT" ]]; then
-        echo -e "${YELLOW}Search: \"$SEARCH_TEXT\"${NC}"
-    fi
-    echo ""  # Empty line for readability
 fi
 
-# Add style arguments if specified
 if [[ "$STYLE_JSON" == true ]]; then
-    LOG_CMD+=(--style json)
+    LOG_CMD+=(--style ndjson)
+    sudo -n /usr/bin/log show --last 1s >/dev/null || exit $?
+
+    if [[ -n "$OUTPUT_FILE" ]]; then
+        if [[ -d "$OUTPUT_FILE" ]]; then
+            echo "Error: output path is a directory: $OUTPUT_FILE" >&2
+            exit 1
+        fi
+        STAGED_OUTPUT=$(mktemp -- "${OUTPUT_FILE}.tmp.XXXXXX")
+    else
+        STAGED_OUTPUT=$(mktemp "${TMPDIR:-/tmp}/clawlog.XXXXXX")
+    fi
+    trap 'rm -f -- "$STAGED_OUTPUT"' EXIT
+
+    TAIL_ARGS=(-n "$TAIL_LINES")
+    if [[ "$SHOW_TAIL" == false ]]; then
+        TAIL_ARGS=(-n +1)
+    fi
+
+    # macOS appends a documented "finished" metadata record after NDJSON events.
+    if "${LOG_CMD[@]}" | sed '$d' | tail "${TAIL_ARGS[@]}" | \
+        awk 'BEGIN { printf "[" } NR > 1 { printf "," } { printf "%s", $0 } END { print "]" }' > "$STAGED_OUTPUT"; then
+        if [[ -n "$OUTPUT_FILE" ]]; then
+            mv -f -- "$STAGED_OUTPUT" "$OUTPUT_FILE"
+        else
+            cat "$STAGED_OUTPUT"
+        fi
+    else
+        exit $?
+    fi
+    exit 0
+fi
+
+# First check if sudo works without password for the log command.
+if sudo -n /usr/bin/log show --last 1s 2>&1 | grep -q "password"; then
+    handle_sudo_error
 fi
 
 # Execute the command
 if [[ -n "$OUTPUT_FILE" ]]; then
-    # First check if sudo works without password for the log command
-    if sudo -n /usr/bin/log show --last 1s 2>&1 | grep -q "password"; then
-        handle_sudo_error
-    fi
-
     echo -e "${BLUE}Exporting logs to: $OUTPUT_FILE${NC}\n"
     if [[ "$SHOW_TAIL" == true ]] && [[ "$STREAM_MODE" == false ]]; then
         "${LOG_CMD[@]}" 2>&1 | tail -n "$TAIL_LINES" > "$OUTPUT_FILE"
@@ -320,11 +359,6 @@ if [[ -n "$OUTPUT_FILE" ]]; then
     fi
 else
     # Run interactively
-    # First check if sudo works without password for the log command
-    if sudo -n /usr/bin/log show --last 1s 2>&1 | grep -q "password"; then
-        handle_sudo_error
-    fi
-
     if [[ "$SHOW_TAIL" == true ]] && [[ "$STREAM_MODE" == false ]]; then
         # Apply tail for non-streaming mode
         "${LOG_CMD[@]}" 2>&1 | tail -n "$TAIL_LINES"

--- a/test/scripts/clawlog.test.ts
+++ b/test/scripts/clawlog.test.ts
@@ -2,7 +2,14 @@
 // These tests do not require a real macOS log(1) binary; they verify that the
 // script reaches the expected code paths before any platform-specific command.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
@@ -11,22 +18,62 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const SCRIPT_PATH = fileURLToPath(new URL("../../scripts/clawlog.sh", import.meta.url));
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-function runClawlog(args: string[] = []) {
+type MockLogOptions = {
+  stdout?: string;
+  stderr?: string;
+  status?: number;
+  preflightStderr?: string;
+  preflightStatus?: number;
+  existingOutput?: string;
+};
+
+function runClawlog(args: string[] = [], options: MockLogOptions = {}) {
   const cwd = tempDirs.make("openclaw-clawlog-test-");
   const binDir = path.join(cwd, "bin");
+  const callsPath = path.join(cwd, "backend-calls");
   mkdirSync(binDir);
   const sudoPath = path.join(binDir, "sudo");
-  writeFileSync(sudoPath, "#!/bin/sh\nexit 0\n");
+  writeFileSync(
+    sudoPath,
+    [
+      "#!/bin/sh",
+      '[ "$1" = "-n" ] && { printf "%s" "$MOCK_PREFLIGHT_STDERR" >&2; exit "$MOCK_PREFLIGHT_STATUS"; }',
+      'printf "%s\\n" "$@" >> "$MOCK_LOG_CALLS"',
+      'printf "%s" "$MOCK_LOG_STDOUT"',
+      'printf "%s" "$MOCK_LOG_STDERR" >&2',
+      'exit "$MOCK_LOG_STATUS"',
+      "",
+    ].join("\n"),
+  );
   chmodSync(sudoPath, 0o755);
+  if (options.existingOutput !== undefined) {
+    writeFileSync(path.join(cwd, "logs.json"), options.existingOutput);
+  }
 
-  return spawnSync("bash", [SCRIPT_PATH, ...args], {
+  const result = spawnSync("/bin/bash", [SCRIPT_PATH, ...args], {
     cwd,
     encoding: "utf8",
     env: {
       ...process.env,
       PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      TMPDIR: cwd,
+      MOCK_LOG_CALLS: callsPath,
+      MOCK_LOG_STDOUT: options.stdout ?? "",
+      MOCK_LOG_STDERR: options.stderr ?? "",
+      MOCK_LOG_STATUS: String(options.status ?? 0),
+      MOCK_PREFLIGHT_STDERR: options.preflightStderr ?? "",
+      MOCK_PREFLIGHT_STATUS: String(options.preflightStatus ?? 0),
     },
   });
+
+  return { ...result, cwd, callsPath };
+}
+
+function encodeRecords(count: number): string {
+  const records = Array.from({ length: count }, (_, index) =>
+    JSON.stringify({ index, message: `line ${index}\ncontinued` }),
+  );
+  return [...records, JSON.stringify({ count, finished: 1 })].join("\n");
 }
 
 describe("clawlog.sh argument parsing", () => {
@@ -68,9 +115,144 @@ describe("clawlog.sh argument parsing", () => {
     expect(result.stderr).not.toContain("requires a value");
   });
 
-  it("accepts dash-prefixed output path", () => {
-    const result = runClawlog(["-o", "-debug.log"]);
+  it.each([
+    ["-o", "-debug.log"],
+    ["--json", "-o", "-debug.log"],
+  ])("accepts dash-prefixed output path with %s", (...args) => {
+    const result = runClawlog(args);
 
+    expect(result.status).toBe(0);
     expect(result.stderr).not.toContain("requires a value");
+  });
+});
+
+describe("clawlog.sh JSON output", () => {
+  it("frames newline-delimited records as one clean JSON array", () => {
+    const result = runClawlog(["--json"], { stdout: encodeRecords(3) });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual([
+      { index: 0, message: "line 0\ncontinued" },
+      { index: 1, message: "line 1\ncontinued" },
+      { index: 2, message: "line 2\ncontinued" },
+    ]);
+    expect(readFileSync(result.callsPath, "utf8")).toContain("--style\nndjson\n");
+  });
+
+  it.each([
+    { args: ["--json", "--all"], total: 0, expected: 0, first: undefined },
+    { args: ["--json"], expected: 50, first: 10 },
+    { args: ["--json", "--lines", "1"], expected: 1, first: 59 },
+    { args: ["--json", "--all"], expected: 60, first: 0 },
+  ])("limits complete records for $args", ({ args, total = 60, expected, first }) => {
+    const result = runClawlog(args, { stdout: encodeRecords(total) });
+    const records = JSON.parse(result.stdout) as Array<{ index: number }>;
+
+    expect(result.status).toBe(0);
+    expect(records).toHaveLength(expected);
+    expect(records[0]?.index).toBe(first);
+  });
+
+  it("keeps backend diagnostics on stderr", () => {
+    const result = runClawlog(["--json"], {
+      stdout: encodeRecords(2),
+      stderr: "backend warning\n",
+    });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toHaveLength(2);
+    expect(result.stdout).not.toContain("backend warning");
+    expect(result.stderr).toBe("backend warning\n");
+  });
+
+  it("atomically writes an output file without printing JSON or status to stdout", () => {
+    const result = runClawlog(["--json", "--output", "logs.json"], {
+      stdout: encodeRecords(2),
+      stderr: "backend warning\n",
+      existingOutput: "previous output",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("backend warning\n");
+    expect(JSON.parse(readFileSync(path.join(result.cwd, "logs.json"), "utf8"))).toHaveLength(2);
+    expect(readdirSync(result.cwd).filter((name) => name.includes(".tmp."))).toEqual([]);
+  });
+
+  it("preserves the exact backend failure and publishes no partial stdout", () => {
+    const result = runClawlog(["--json"], {
+      stdout: encodeRecords(2),
+      stderr: "backend failed\n",
+      status: 23,
+    });
+
+    expect(result.status).toBe(23);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("backend failed\n");
+    expect(readdirSync(result.cwd).filter((name) => name.startsWith("clawlog."))).toEqual([]);
+  });
+
+  it("leaves an existing destination unchanged when the backend fails", () => {
+    const result = runClawlog(["--json", "--output", "logs.json"], {
+      stdout: encodeRecords(2),
+      stderr: "backend failed\n",
+      status: 37,
+      existingOutput: "previous output",
+    });
+
+    expect(result.status).toBe(37);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("backend failed\n");
+    expect(readFileSync(path.join(result.cwd, "logs.json"), "utf8")).toBe("previous output");
+    expect(readdirSync(result.cwd).filter((name) => name.includes(".tmp."))).toEqual([]);
+  });
+
+  it.each([64, 65])("preserves failed preflight status %s without staging output", (status) => {
+    const result = runClawlog(["--json", "--output", "logs.json"], {
+      preflightStderr: "log preflight failed\n",
+      preflightStatus: status,
+      existingOutput: "previous output",
+    });
+
+    expect(result.status).toBe(status);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("log preflight failed\n");
+    expect(readFileSync(path.join(result.cwd, "logs.json"), "utf8")).toBe("previous output");
+    expect(existsSync(result.callsPath)).toBe(false);
+    expect(readdirSync(result.cwd).filter((name) => name.includes(".tmp."))).toEqual([]);
+  });
+
+  it("rejects directory output without moving a staged file into it", () => {
+    const result = runClawlog(["--json", "--output", "bin"], { stdout: encodeRecords(1) });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("directory");
+    expect(readdirSync(path.join(result.cwd, "bin"))).toEqual(["sudo"]);
+    expect(readdirSync(result.cwd).filter((name) => name.includes(".tmp."))).toEqual([]);
+  });
+
+  it("preserves physical-line limits in human mode", () => {
+    const result = runClawlog(["--lines", "1"], { stdout: "first\nsecond\n" });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("second\n");
+    expect(result.stdout).not.toContain("first\n");
+    expect(result.stdout).toContain("Showing last 1 lines");
+  });
+
+  it.each([
+    ["--json", "--follow"],
+    ["--follow", "--json"],
+    ["--json", "--list-categories"],
+    ["--list-categories", "--json"],
+  ])("rejects incompatible JSON options before backend invocation: %s %s", (...args) => {
+    const result = runClawlog(args);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("--json");
+    expect(result.stderr).toContain(args.includes("--follow") ? "--follow" : "--list-categories");
+    expect(existsSync(result.callsPath)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #126650

## What Problem This Solves

Fixes an issue where macOS operators using `./scripts/clawlog.sh --json` received human ANSI banners, footer text, stderr diagnostics, or physically truncated pretty-printed JSON instead of one parseable machine-readable document. Failed exports could also overwrite an existing output file.

## Why This Change Was Made

The native macOS `log show --style json` format is one multiline array, so applying `tail` to its physical lines cannot select complete events. `log show --style ndjson` instead emits one event per line plus a documented final `finished` control record. The logging script now removes that control record, applies the requested limit to complete events, frames the events as one JSON array, and stages the complete document before publishing it to stdout or atomically replacing a destination on the same filesystem.

Backend diagnostics remain on stderr, failures preserve their exact exit status, existing destination files survive failed exports, and successful `--output` mode leaves stdout empty. `--json --follow` and `--json --list-categories` are rejected explicitly in either argument order because those modes cannot honor the single-document contract. Existing human-readable output and filtering remain unchanged.

## User Impact

Mac operators and automation can reliably parse `clawlog --json`, use `--lines` as a log-record limit, and export JSON files without partial replacement or diagnostic contamination. Empty results are correctly represented as `[]`, including on macOS versions whose NDJSON backend emits a mandatory completion record.

## Evidence

- Baseline source-blind regression run: 13 newly added checks failed against the original script for invalid JSON framing, structural record limits, diagnostic separation, failed exports, and incompatible option combinations.
- Independent adversarial review additionally reproduced and fixed directory-target staging leakage and lost preflight exit statuses; both were covered by three failing-before-fix regressions.
- Focused Apple Bash regression matrix: 28 passing tests via `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts --configLoader runner test/scripts/clawlog.test.ts`.
- Actual changed gate: `node scripts/check-changed.mjs -- scripts/clawlog.sh test/scripts/clawlog.test.ts docs/platforms/mac/logging.md`.
- Shell validation: `/bin/bash -n scripts/clawlog.sh` and `shellcheck scripts/clawlog.sh`.
- Documentation validation: `pnpm docs:list`, `pnpm docs:check-mdx`, `pnpm docs:check-links`, `pnpm docs:check-i18n-glossary`, and `pnpm format:docs:check`.
- Native macOS proof: the installed `log(1)` manual and live impossible-match NDJSON queries confirmed the mandatory `finished` completion record; the repaired utility produced parseable `[]` on stdout and in an atomically replaced output file against the real `/usr/bin/log` backend. Passwordless sudo is unavailable on the proof host, so only the privilege wrapper was substituted; the native backend, portable BSD tools, and Apple `/bin/bash` were real.
- Independent read-only adversarial review: clean after both findings were resolved. Fresh Codex-backed P1 structured autoreview: clean.
- Size: script +67/-33 (net +34); tests +188/-6 (net +182); docs +6/-0. Script growth provides the public single-document contract, failure-atomic same-filesystem publication, exact backend statuses, and documented NDJSON completion-record handling; two dead legacy flags and duplicated human sudo preflights were removed.
- Risk: limited to the existing macOS logging helper, its boundary-level regression suite, and matching operator documentation. No protocol, configuration, persistence, security, deployment, release, version, or changelog changes.

AI-assisted: yes
