### PR TITLE
fix(ollama): carry real Ollama Cloud context windows and capabilities

### DIFF
--- a/docs/providers/ollama-cloud.md
+++ b/docs/providers/ollama-cloud.md
@@ -36,7 +36,7 @@ Non-interactive onboarding accepts the key directly:
 openclaw onboard --auth-choice ollama-cloud --ollama-cloud-api-key "<key>"
 ```
 
-Onboarding sets the default model to `ollama-cloud/minimax-m2.7`.
+Onboarding sets the default model to `ollama-cloud/kimi-k3`.
 
 ## Defaults
 
@@ -44,7 +44,7 @@ Onboarding sets the default model to `ollama-cloud/minimax-m2.7`.
 - Base URL: `https://ollama.com`
 - Env var: `OLLAMA_API_KEY`
 - API style: Ollama native `/api/chat`
-- Onboarding default model: `ollama-cloud/minimax-m2.7`
+- Onboarding default model: `ollama-cloud/kimi-k3`
 
 ## When to choose Ollama Cloud
 
@@ -71,10 +71,10 @@ openclaw models set ollama-cloud/kimi-k2.6
 ```
 
 Hosted ids in the live catalog include `deepseek-v4-flash`, `glm-5.2`,
-`gpt-oss:20b`, `kimi-k2.6`, and `minimax-m2.7`. When live discovery returns
-nothing, OpenClaw falls back to the bundled rows `minimax-m2.7`, `glm-5.1`,
-and `glm-5.2`. The retiring `kimi-k2.5` model is hidden from model pickers but
-remains selectable by exact reference until Ollama retires it on July 31, 2026.
+`gpt-oss:20b`, `kimi-k3`, and `minimax-m2.7`. When live discovery returns
+nothing, OpenClaw falls back to the bundled rows `kimi-k3`, `minimax-m2.7`,
+`glm-5.1`, and `glm-5.2`. Retired `kimi-k2.5` remains marked deprecated for
+existing exact references, but is no longer a current hosted model.
 
 Model ids are cloud catalog ids, not local pull names. If a model name works in
 a local Ollama host but is absent from the hosted catalog, use the `ollama`

--- a/docs/providers/ollama-cloud.md
+++ b/docs/providers/ollama-cloud.md
@@ -36,7 +36,7 @@ Non-interactive onboarding accepts the key directly:
 openclaw onboard --auth-choice ollama-cloud --ollama-cloud-api-key "<key>"
 ```
 
-Onboarding sets the default model to `ollama-cloud/minimax-m3`.
+Onboarding sets the default model to `ollama-cloud/minimax-m2.7`.
 
 ## Defaults
 
@@ -44,7 +44,7 @@ Onboarding sets the default model to `ollama-cloud/minimax-m3`.
 - Base URL: `https://ollama.com`
 - Env var: `OLLAMA_API_KEY`
 - API style: Ollama native `/api/chat`
-- Onboarding default model: `ollama-cloud/minimax-m3`
+- Onboarding default model: `ollama-cloud/minimax-m2.7`
 
 ## When to choose Ollama Cloud
 
@@ -72,8 +72,8 @@ openclaw models set ollama-cloud/kimi-k2.6
 
 Hosted ids in the live catalog include `deepseek-v4-flash`, `glm-5.2`,
 `gpt-oss:20b`, `kimi-k3`, and `minimax-m3`. When live discovery returns
-nothing, OpenClaw falls back to the bundled rows `minimax-m3`, `kimi-k3`,
-`minimax-m2.7`, `glm-5.1`, and `glm-5.2`. Retired `kimi-k2.5` remains marked
+nothing, OpenClaw falls back to the bundled rows `minimax-m2.7`, `minimax-m3`,
+`kimi-k3`, `glm-5.1`, and `glm-5.2`. Retired `kimi-k2.5` remains marked
 deprecated for existing exact references, but is no longer a current hosted
 model.
 

--- a/docs/providers/ollama-cloud.md
+++ b/docs/providers/ollama-cloud.md
@@ -36,7 +36,7 @@ Non-interactive onboarding accepts the key directly:
 openclaw onboard --auth-choice ollama-cloud --ollama-cloud-api-key "<key>"
 ```
 
-Onboarding sets the default model to `ollama-cloud/kimi-k3`.
+Onboarding sets the default model to `ollama-cloud/minimax-m3`.
 
 ## Defaults
 
@@ -44,7 +44,7 @@ Onboarding sets the default model to `ollama-cloud/kimi-k3`.
 - Base URL: `https://ollama.com`
 - Env var: `OLLAMA_API_KEY`
 - API style: Ollama native `/api/chat`
-- Onboarding default model: `ollama-cloud/kimi-k3`
+- Onboarding default model: `ollama-cloud/minimax-m3`
 
 ## When to choose Ollama Cloud
 
@@ -71,10 +71,11 @@ openclaw models set ollama-cloud/kimi-k2.6
 ```
 
 Hosted ids in the live catalog include `deepseek-v4-flash`, `glm-5.2`,
-`gpt-oss:20b`, `kimi-k3`, and `minimax-m2.7`. When live discovery returns
-nothing, OpenClaw falls back to the bundled rows `kimi-k3`, `minimax-m2.7`,
-`glm-5.1`, and `glm-5.2`. Retired `kimi-k2.5` remains marked deprecated for
-existing exact references, but is no longer a current hosted model.
+`gpt-oss:20b`, `kimi-k3`, and `minimax-m3`. When live discovery returns
+nothing, OpenClaw falls back to the bundled rows `minimax-m3`, `kimi-k3`,
+`minimax-m2.7`, `glm-5.1`, and `glm-5.2`. Retired `kimi-k2.5` remains marked
+deprecated for existing exact references, but is no longer a current hosted
+model.
 
 Model ids are cloud catalog ids, not local pull names. If a model name works in
 a local Ollama host but is absent from the hosted catalog, use the `ollama`

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -2118,12 +2118,20 @@ describe("ollama plugin", () => {
     }
     expect(result.provider.baseUrl).toBe("https://ollama.com");
     expect(result.provider.models?.map((model: { id: string }) => model.id)).toEqual([
+      "minimax-m3",
       "kimi-k3",
       "minimax-m2.7",
       "glm-5.1",
       "glm-5.2",
     ]);
     expect(result.provider.models).toEqual([
+      expect.objectContaining({
+        id: "minimax-m3",
+        contextWindow: 524_288,
+        reasoning: true,
+        input: ["text", "image"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
       expect.objectContaining({
         id: "kimi-k3",
         contextWindow: 1_048_576,

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -2118,13 +2118,20 @@ describe("ollama plugin", () => {
     }
     expect(result.provider.baseUrl).toBe("https://ollama.com");
     expect(result.provider.models?.map((model: { id: string }) => model.id)).toEqual([
+      "minimax-m2.7",
       "minimax-m3",
       "kimi-k3",
-      "minimax-m2.7",
       "glm-5.1",
       "glm-5.2",
     ]);
     expect(result.provider.models).toEqual([
+      expect.objectContaining({
+        id: "minimax-m2.7",
+        contextWindow: 196_608,
+        reasoning: true,
+        input: ["text"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
       expect.objectContaining({
         id: "minimax-m3",
         contextWindow: 524_288,
@@ -2137,13 +2144,6 @@ describe("ollama plugin", () => {
         contextWindow: 1_048_576,
         reasoning: true,
         input: ["text", "image"],
-        compat: { supportsTools: true, supportsUsageInStreaming: true },
-      }),
-      expect.objectContaining({
-        id: "minimax-m2.7",
-        contextWindow: 196_608,
-        reasoning: true,
-        input: ["text"],
         compat: { supportsTools: true, supportsUsageInStreaming: true },
       }),
       expect.objectContaining({

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -2118,11 +2118,19 @@ describe("ollama plugin", () => {
     }
     expect(result.provider.baseUrl).toBe("https://ollama.com");
     expect(result.provider.models?.map((model: { id: string }) => model.id)).toEqual([
+      "kimi-k3",
       "minimax-m2.7",
       "glm-5.1",
       "glm-5.2",
     ]);
     expect(result.provider.models).toEqual([
+      expect.objectContaining({
+        id: "kimi-k3",
+        contextWindow: 1_048_576,
+        reasoning: true,
+        input: ["text", "image"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
       expect.objectContaining({
         id: "minimax-m2.7",
         contextWindow: 196_608,

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -385,26 +385,6 @@
             }
           },
           {
-            "id": "gpt-oss",
-            "name": "gpt-oss",
-            "reasoning": true,
-            "input": [
-              "text"
-            ],
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "contextWindow": 131072,
-            "maxTokens": 8192,
-            "compat": {
-              "supportsTools": true,
-              "supportsUsageInStreaming": true
-            }
-          },
-          {
             "id": "gpt-oss:120b",
             "name": "gpt-oss:120b",
             "reasoning": true,
@@ -486,53 +466,12 @@
             }
           },
           {
-            "id": "mistral-large-3",
-            "name": "mistral-large-3",
-            "reasoning": false,
-            "input": [
-              "text",
-              "image"
-            ],
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "contextWindow": 262144,
-            "maxTokens": 8192,
-            "compat": {
-              "supportsTools": true,
-              "supportsUsageInStreaming": true
-            }
-          },
-          {
             "id": "mistral-large-3:675b",
             "name": "mistral-large-3:675b",
             "reasoning": false,
             "input": [
               "text",
               "image"
-            ],
-            "cost": {
-              "input": 0,
-              "output": 0,
-              "cacheRead": 0,
-              "cacheWrite": 0
-            },
-            "contextWindow": 262144,
-            "maxTokens": 8192,
-            "compat": {
-              "supportsTools": true,
-              "supportsUsageInStreaming": true
-            }
-          },
-          {
-            "id": "nemotron-3-nano",
-            "name": "nemotron-3-nano",
-            "reasoning": true,
-            "input": [
-              "text"
             ],
             "cost": {
               "input": 0,

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -118,8 +118,72 @@
             }
           },
           {
-            "id": "minimax-m2.7",
-            "name": "minimax-m2.7",
+            "id": "kimi-k2.6",
+            "name": "kimi-k2.6",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "kimi-k2.7-code",
+            "name": "kimi-k2.7-code",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true,
+              "codeMode": "capable"
+            }
+          },
+          {
+            "id": "kimi-k3",
+            "name": "kimi-k3",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1048576,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "deepseek-v4-flash",
+            "name": "deepseek-v4-flash",
             "reasoning": true,
             "input": [
               "text"
@@ -130,7 +194,48 @@
               "cacheRead": 0,
               "cacheWrite": 0
             },
-            "contextWindow": 196608,
+            "contextWindow": 1048576,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "deepseek-v4-pro",
+            "name": "deepseek-v4-pro",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1048576,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "gemma4",
+            "name": "gemma4",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
             "maxTokens": 8192,
             "compat": {
               "supportsTools": true,
@@ -177,6 +282,169 @@
               "supportsTools": true,
               "supportsUsageInStreaming": true,
               "codeMode": "capable"
+            }
+          },
+          {
+            "id": "gpt-oss",
+            "name": "gpt-oss",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 131072,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "minimax-m2.7",
+            "name": "minimax-m2.7",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 196608,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "minimax-m3",
+            "name": "minimax-m3",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 524288,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "mistral-large-3",
+            "name": "mistral-large-3",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "nemotron-3-nano",
+            "name": "nemotron-3-nano",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "nemotron-3-super",
+            "name": "nemotron-3-super",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "nemotron-3-ultra",
+            "name": "nemotron-3-ultra",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "qwen3.5",
+            "name": "qwen3.5",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
             }
           }
         ]

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -169,6 +169,25 @@
               "image"
             ],
             "cost": {
+              "input": 3,
+              "output": 15,
+              "cacheRead": 0.3
+            },
+            "contextWindow": 1048576,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "deepseek-v4-flash",
+            "name": "deepseek-v4-flash",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
               "input": 0,
               "output": 0,
               "cacheRead": 0,
@@ -182,8 +201,28 @@
             }
           },
           {
-            "id": "deepseek-v4-flash",
-            "name": "deepseek-v4-flash",
+            "id": "deepseek-v4-flash:0731",
+            "name": "deepseek-v4-flash:0731",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1048576,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "deepseek-v4-flash:preview",
+            "name": "deepseek-v4-flash:preview",
             "reasoning": true,
             "input": [
               "text"
@@ -222,8 +261,69 @@
             }
           },
           {
+            "id": "deepseek-v4-pro:0813",
+            "name": "deepseek-v4-pro:0813",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1048576,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "deepseek-v4-pro:preview",
+            "name": "deepseek-v4-pro:preview",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 524288,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
             "id": "gemma4",
             "name": "gemma4",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "gemma4:31b",
+            "name": "gemma4:31b",
             "reasoning": true,
             "input": [
               "text",
@@ -305,6 +405,46 @@
             }
           },
           {
+            "id": "gpt-oss:120b",
+            "name": "gpt-oss:120b",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 131072,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "gpt-oss:20b",
+            "name": "gpt-oss:20b",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 131072,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
             "id": "minimax-m2.7",
             "name": "minimax-m2.7",
             "reasoning": true,
@@ -367,8 +507,49 @@
             }
           },
           {
+            "id": "mistral-large-3:675b",
+            "name": "mistral-large-3:675b",
+            "reasoning": false,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
             "id": "nemotron-3-nano",
             "name": "nemotron-3-nano",
+            "reasoning": true,
+            "input": [
+              "text"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "nemotron-3-nano:30b",
+            "name": "nemotron-3-nano:30b",
             "reasoning": true,
             "input": [
               "text"
@@ -429,6 +610,27 @@
           {
             "id": "qwen3.5",
             "name": "qwen3.5",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 262144,
+            "maxTokens": 8192,
+            "compat": {
+              "supportsTools": true,
+              "supportsUsageInStreaming": true
+            }
+          },
+          {
+            "id": "qwen3.5:397b",
+            "name": "qwen3.5:397b",
             "reasoning": true,
             "input": [
               "text",

--- a/extensions/ollama/openclaw.plugin.json
+++ b/extensions/ollama/openclaw.plugin.json
@@ -8,10 +8,7 @@
     "onStartup": true
   },
   "enabledByDefault": true,
-  "providers": [
-    "ollama",
-    "ollama-cloud"
-  ],
+  "providers": ["ollama", "ollama-cloud"],
   "providerCatalogEntry": "./provider-discovery.ts",
   "providerRequest": {
     "providers": {
@@ -33,25 +30,17 @@
       }
     }
   },
-  "syntheticAuthRefs": [
-    "ollama"
-  ],
-  "nonSecretAuthMarkers": [
-    "ollama-local"
-  ],
+  "syntheticAuthRefs": ["ollama"],
+  "nonSecretAuthMarkers": ["ollama-local"],
   "setup": {
     "providers": [
       {
         "id": "ollama",
-        "envVars": [
-          "OLLAMA_API_KEY"
-        ]
+        "envVars": ["OLLAMA_API_KEY"]
       },
       {
         "id": "ollama-cloud",
-        "envVars": [
-          "OLLAMA_API_KEY"
-        ]
+        "envVars": ["OLLAMA_API_KEY"]
       }
     ]
   },
@@ -100,10 +89,7 @@
             "name": "kimi-k2.5",
             "status": "deprecated",
             "reasoning": true,
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -121,10 +107,7 @@
             "id": "kimi-k2.6",
             "name": "kimi-k2.6",
             "reasoning": true,
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -142,10 +125,7 @@
             "id": "kimi-k2.7-code",
             "name": "kimi-k2.7-code",
             "reasoning": true,
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -156,18 +136,14 @@
             "maxTokens": 8192,
             "compat": {
               "supportsTools": true,
-              "supportsUsageInStreaming": true,
-              "codeMode": "capable"
+              "supportsUsageInStreaming": true
             }
           },
           {
             "id": "kimi-k3",
             "name": "kimi-k3",
             "reasoning": true,
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "cost": {
               "input": 3,
               "output": 15,
@@ -177,16 +153,15 @@
             "maxTokens": 8192,
             "compat": {
               "supportsTools": true,
-              "supportsUsageInStreaming": true
+              "supportsUsageInStreaming": true,
+              "codeMode": "capable"
             }
           },
           {
             "id": "deepseek-v4-flash",
             "name": "deepseek-v4-flash",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -197,16 +172,15 @@
             "maxTokens": 8192,
             "compat": {
               "supportsTools": true,
-              "supportsUsageInStreaming": true
+              "supportsUsageInStreaming": true,
+              "codeMode": "capable"
             }
           },
           {
             "id": "deepseek-v4-flash:0731",
             "name": "deepseek-v4-flash:0731",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -224,9 +198,7 @@
             "id": "deepseek-v4-flash:preview",
             "name": "deepseek-v4-flash:preview",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -244,9 +216,7 @@
             "id": "deepseek-v4-pro",
             "name": "deepseek-v4-pro",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -257,16 +227,15 @@
             "maxTokens": 8192,
             "compat": {
               "supportsTools": true,
-              "supportsUsageInStreaming": true
+              "supportsUsageInStreaming": true,
+              "codeMode": "capable"
             }
           },
           {
             "id": "deepseek-v4-pro:0813",
             "name": "deepseek-v4-pro:0813",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -284,9 +253,7 @@
             "id": "deepseek-v4-pro:preview",
             "name": "deepseek-v4-pro:preview",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -304,10 +271,7 @@
             "id": "gemma4",
             "name": "gemma4",
             "reasoning": true,
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -325,10 +289,7 @@
             "id": "gemma4:31b",
             "name": "gemma4:31b",
             "reasoning": true,
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -346,9 +307,7 @@
             "id": "glm-5.1",
             "name": "glm-5.1",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -367,9 +326,7 @@
             "id": "glm-5.2",
             "name": "glm-5.2",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -388,9 +345,7 @@
             "id": "gpt-oss:120b",
             "name": "gpt-oss:120b",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -408,9 +363,7 @@
             "id": "gpt-oss:20b",
             "name": "gpt-oss:20b",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -428,9 +381,7 @@
             "id": "minimax-m2.7",
             "name": "minimax-m2.7",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -448,10 +399,7 @@
             "id": "minimax-m3",
             "name": "minimax-m3",
             "reasoning": true,
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -469,10 +417,7 @@
             "id": "mistral-large-3:675b",
             "name": "mistral-large-3:675b",
             "reasoning": false,
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -490,9 +435,7 @@
             "id": "nemotron-3-nano:30b",
             "name": "nemotron-3-nano:30b",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -510,9 +453,7 @@
             "id": "nemotron-3-super",
             "name": "nemotron-3-super",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -530,9 +471,7 @@
             "id": "nemotron-3-ultra",
             "name": "nemotron-3-ultra",
             "reasoning": true,
-            "input": [
-              "text"
-            ],
+            "input": ["text"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -550,10 +489,7 @@
             "id": "qwen3.5",
             "name": "qwen3.5",
             "reasoning": true,
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -571,10 +507,7 @@
             "id": "qwen3.5:397b",
             "name": "qwen3.5:397b",
             "reasoning": true,
-            "input": [
-              "text",
-              "image"
-            ],
+            "input": ["text", "image"],
             "cost": {
               "input": 0,
               "output": 0,
@@ -597,15 +530,9 @@
     }
   },
   "contracts": {
-    "embeddingProviders": [
-      "ollama"
-    ],
-    "tools": [
-      "node_inference"
-    ],
-    "webSearchProviders": [
-      "ollama"
-    ]
+    "embeddingProviders": ["ollama"],
+    "tools": ["node_inference"],
+    "webSearchProviders": ["ollama"]
   },
   "configSchema": {
     "type": "object",

--- a/extensions/ollama/src/defaults.ts
+++ b/extensions/ollama/src/defaults.ts
@@ -12,6 +12,11 @@ export const OLLAMA_GLM52_CLOUD_MODEL_ID = "glm-5.2";
  */
 export const OLLAMA_CLOUD_DEFAULT_MODELS = [
   {
+    id: "minimax-m2.7",
+    contextWindow: 196_608,
+    capabilities: ["completion", "thinking", "tools"],
+  },
+  {
     id: "minimax-m3",
     contextWindow: 524_288,
     capabilities: ["completion", "thinking", "tools", "vision"],
@@ -20,11 +25,6 @@ export const OLLAMA_CLOUD_DEFAULT_MODELS = [
     id: "kimi-k3",
     contextWindow: 1_048_576,
     capabilities: ["completion", "thinking", "tools", "vision"],
-  },
-  {
-    id: "minimax-m2.7",
-    contextWindow: 196_608,
-    capabilities: ["completion", "thinking", "tools"],
   },
   {
     id: "glm-5.1",

--- a/extensions/ollama/src/defaults.ts
+++ b/extensions/ollama/src/defaults.ts
@@ -5,7 +5,17 @@ const OLLAMA_DOCKER_HOST_BASE_URL = "http://host.docker.internal:11434";
 export const OLLAMA_CLOUD_BASE_URL = "https://ollama.com";
 export const OLLAMA_CLOUD_PROVIDER_ID = "ollama-cloud";
 export const OLLAMA_GLM52_CLOUD_MODEL_ID = "glm-5.2";
+/**
+ * Order is a contract: cloud onboarding merges this list ahead of live discovery and takes
+ * the first name as `defaultModel` (`setup.runtime.ts`). Reordering this array changes what
+ * every new setup selects, so keep the intended default at index 0.
+ */
 export const OLLAMA_CLOUD_DEFAULT_MODELS = [
+  {
+    id: "minimax-m3",
+    contextWindow: 524_288,
+    capabilities: ["completion", "thinking", "tools", "vision"],
+  },
   {
     id: "kimi-k3",
     contextWindow: 1_048_576,

--- a/extensions/ollama/src/defaults.ts
+++ b/extensions/ollama/src/defaults.ts
@@ -7,6 +7,11 @@ export const OLLAMA_CLOUD_PROVIDER_ID = "ollama-cloud";
 export const OLLAMA_GLM52_CLOUD_MODEL_ID = "glm-5.2";
 export const OLLAMA_CLOUD_DEFAULT_MODELS = [
   {
+    id: "kimi-k3",
+    contextWindow: 1_048_576,
+    capabilities: ["completion", "thinking", "tools", "vision"],
+  },
+  {
     id: "minimax-m2.7",
     contextWindow: 196_608,
     capabilities: ["completion", "thinking", "tools"],
@@ -22,6 +27,14 @@ export const OLLAMA_CLOUD_DEFAULT_MODELS = [
     capabilities: ["completion", "thinking", "tools"],
   },
 ] as const;
+
+/** Cloud models are referenced bare, `:cloud`-suffixed, and `-cloud`-suffixed. */
+export function normalizeOllamaCloudModelId(modelId: string): string {
+  return modelId
+    .trim()
+    .toLowerCase()
+    .replace(/(?::cloud|-cloud)$/, "");
+}
 
 export const OLLAMA_DEFAULT_CONTEXT_WINDOW = 128000;
 export const OLLAMA_LOCAL_CONTEXT_TOKENS = 32_768;

--- a/extensions/ollama/src/model-reasoning.ts
+++ b/extensions/ollama/src/model-reasoning.ts
@@ -1,14 +1,9 @@
 // Ollama plugin module owns model-specific native thinking contracts.
+import { normalizeOllamaCloudModelId } from "./defaults.js";
+
 export function supportsOllamaCloudFullThinkingEffort(modelId: string): boolean {
   // These hosted families accept low, medium, high, and max even when
   // lightweight catalog projections omit their reasoning metadata.
   const normalized = normalizeOllamaCloudModelId(modelId);
   return normalized === "glm-5.2" || /^deepseek-v4-(?:flash|pro)$/.test(normalized);
-}
-
-function normalizeOllamaCloudModelId(modelId: string): string {
-  return modelId
-    .trim()
-    .toLowerCase()
-    .replace(/(?::cloud|-cloud)$/, "");
 }

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -5,6 +5,7 @@ import type { Socket } from "node:net";
 import { expectDefined } from "@openclaw/normalization-core";
 import { jsonResponse, requestBodyText, requestUrl } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { OLLAMA_DEFAULT_CONTEXT_WINDOW } from "./defaults.js";
 import {
   buildOllamaProvider,
   buildOllamaModelDefinition,
@@ -246,6 +247,22 @@ describe("ollama provider models", () => {
         contextWindow: 1_000_000,
         maxTokens: 8192,
       }),
+    );
+  });
+
+  it("resolves known cloud context windows for bare and :cloud model refs", () => {
+    // A suffixed ref must not silently drop to the generic default when live
+    // inspection is unavailable; both spellings name the same cloud model.
+    for (const modelId of ["kimi-k3", "kimi-k3:cloud"]) {
+      expect(buildOllamaModelDefinition(modelId)).toEqual(
+        expect.objectContaining({ id: modelId, contextWindow: 1_048_576 }),
+      );
+    }
+  });
+
+  it("keeps the generic default for cloud models with no known context window", () => {
+    expect(buildOllamaModelDefinition("not-a-known-model:cloud")).toEqual(
+      expect.objectContaining({ contextWindow: OLLAMA_DEFAULT_CONTEXT_WINDOW }),
     );
   });
 

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -1,5 +1,6 @@
 // Ollama tests cover provider models plugin behavior.
 import { once } from "node:events";
+import { readFileSync } from "node:fs";
 import { createServer } from "node:http";
 import type { Socket } from "node:net";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -50,6 +51,62 @@ describe("ollama provider models", () => {
   it("strips /v1 when resolving the Ollama API base", () => {
     expect(resolveOllamaApiBase("http://127.0.0.1:11434/v1")).toBe("http://127.0.0.1:11434");
     expect(resolveOllamaApiBase("http://127.0.0.1:11434///")).toBe("http://127.0.0.1:11434");
+  });
+
+  it("declares every exact currently served Ollama Cloud model id", () => {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+    ) as {
+      modelCatalog: {
+        providers: Record<
+          string,
+          {
+            models: Array<{
+              id: string;
+              contextWindow: number;
+              input: string[];
+              reasoning: boolean;
+              cost?: {
+                input?: number;
+                output?: number;
+                cacheRead?: number;
+              };
+            }>;
+          }
+        >;
+      };
+    };
+    const models = manifest.modelCatalog.providers["ollama-cloud"]?.models ?? [];
+    const declared = new Map(models.map((model) => [model.id, model]));
+
+    (
+      [
+        ["glm-5.1", 202_752, ["text"], true],
+        ["glm-5.2", 1_000_000, ["text"], true],
+        ["minimax-m2.7", 196_608, ["text"], true],
+        ["deepseek-v4-flash:0731", 1_048_576, ["text"], true],
+        ["deepseek-v4-flash:preview", 1_048_576, ["text"], true],
+        ["deepseek-v4-pro", 1_048_576, ["text"], true],
+        ["deepseek-v4-pro:0813", 1_048_576, ["text"], true],
+        ["deepseek-v4-pro:preview", 524_288, ["text"], true],
+        ["gemma4:31b", 262_144, ["text", "image"], true],
+        ["gpt-oss:120b", 131_072, ["text"], true],
+        ["gpt-oss:20b", 131_072, ["text"], true],
+        ["kimi-k2.5", 262_144, ["text", "image"], true],
+        ["kimi-k2.6", 262_144, ["text", "image"], true],
+        ["kimi-k2.7-code", 262_144, ["text", "image"], true],
+        ["kimi-k3", 1_048_576, ["text", "image"], true],
+        ["minimax-m3", 524_288, ["text", "image"], true],
+        ["mistral-large-3:675b", 262_144, ["text", "image"], false],
+        ["nemotron-3-nano:30b", 262_144, ["text"], true],
+        ["nemotron-3-super", 262_144, ["text"], true],
+        ["nemotron-3-ultra", 262_144, ["text"], true],
+        ["qwen3.5:397b", 262_144, ["text", "image"], true],
+      ] as const
+    ).forEach(([id, contextWindow, input, reasoning]) => {
+      expect(declared.get(id)).toMatchObject({ contextWindow, input, reasoning });
+    });
+    expect(declared.get("kimi-k3")?.cost).toEqual({ input: 3, output: 15, cacheRead: 0.3 });
   });
 
   it("inspects local models using Ollama's canonical model request field", async () => {

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -63,6 +63,7 @@ describe("ollama provider models", () => {
           {
             models: Array<{
               id: string;
+              status?: string;
               contextWindow: number;
               input: string[];
               reasoning: boolean;
@@ -79,33 +80,38 @@ describe("ollama provider models", () => {
     const models = manifest.modelCatalog.providers["ollama-cloud"]?.models ?? [];
     const declared = new Map(models.map((model) => [model.id, model]));
 
-    (
-      [
-        ["glm-5.1", 202_752, ["text"], true],
-        ["glm-5.2", 1_000_000, ["text"], true],
-        ["minimax-m2.7", 196_608, ["text"], true],
-        ["deepseek-v4-flash:0731", 1_048_576, ["text"], true],
-        ["deepseek-v4-flash:preview", 1_048_576, ["text"], true],
-        ["deepseek-v4-pro", 1_048_576, ["text"], true],
-        ["deepseek-v4-pro:0813", 1_048_576, ["text"], true],
-        ["deepseek-v4-pro:preview", 524_288, ["text"], true],
-        ["gemma4:31b", 262_144, ["text", "image"], true],
-        ["gpt-oss:120b", 131_072, ["text"], true],
-        ["gpt-oss:20b", 131_072, ["text"], true],
-        ["kimi-k2.5", 262_144, ["text", "image"], true],
-        ["kimi-k2.6", 262_144, ["text", "image"], true],
-        ["kimi-k2.7-code", 262_144, ["text", "image"], true],
-        ["kimi-k3", 1_048_576, ["text", "image"], true],
-        ["minimax-m3", 524_288, ["text", "image"], true],
-        ["mistral-large-3:675b", 262_144, ["text", "image"], false],
-        ["nemotron-3-nano:30b", 262_144, ["text"], true],
-        ["nemotron-3-super", 262_144, ["text"], true],
-        ["nemotron-3-ultra", 262_144, ["text"], true],
-        ["qwen3.5:397b", 262_144, ["text", "image"], true],
-      ] as const
-    ).forEach(([id, contextWindow, input, reasoning]) => {
+    const servedModels = [
+      ["glm-5.1", 202_752, ["text"], true],
+      ["glm-5.2", 1_000_000, ["text"], true],
+      ["minimax-m2.7", 196_608, ["text"], true],
+      ["deepseek-v4-flash", 1_048_576, ["text"], true],
+      ["deepseek-v4-flash:0731", 1_048_576, ["text"], true],
+      ["deepseek-v4-flash:preview", 1_048_576, ["text"], true],
+      ["deepseek-v4-pro", 1_048_576, ["text"], true],
+      ["deepseek-v4-pro:0813", 1_048_576, ["text"], true],
+      ["deepseek-v4-pro:preview", 524_288, ["text"], true],
+      ["gemma4", 262_144, ["text", "image"], true],
+      ["gemma4:31b", 262_144, ["text", "image"], true],
+      ["gpt-oss:120b", 131_072, ["text"], true],
+      ["gpt-oss:20b", 131_072, ["text"], true],
+      ["kimi-k2.6", 262_144, ["text", "image"], true],
+      ["kimi-k2.7-code", 262_144, ["text", "image"], true],
+      ["kimi-k3", 1_048_576, ["text", "image"], true],
+      ["minimax-m3", 524_288, ["text", "image"], true],
+      ["mistral-large-3:675b", 262_144, ["text", "image"], false],
+      ["nemotron-3-nano:30b", 262_144, ["text"], true],
+      ["nemotron-3-super", 262_144, ["text"], true],
+      ["nemotron-3-ultra", 262_144, ["text"], true],
+      ["qwen3.5", 262_144, ["text", "image"], true],
+      ["qwen3.5:397b", 262_144, ["text", "image"], true],
+    ] as const;
+    servedModels.forEach(([id, contextWindow, input, reasoning]) => {
       expect(declared.get(id)).toMatchObject({ contextWindow, input, reasoning });
     });
+    expect([...declared.keys()].toSorted()).toEqual(
+      [...servedModels.map(([id]) => id), "kimi-k2.5"].toSorted(),
+    );
+    expect(declared.get("kimi-k2.5")).toMatchObject({ status: "deprecated" });
     expect(declared.get("kimi-k3")?.cost).toEqual({ input: 3, output: 15, cacheRead: 0.3 });
   });
 

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -15,6 +15,7 @@ import {
   OLLAMA_DEFAULT_COST,
   OLLAMA_DEFAULT_MAX_TOKENS,
   OLLAMA_LOCAL_CONTEXT_TOKENS,
+  normalizeOllamaCloudModelId,
 } from "./defaults.js";
 import { supportsOllamaCloudFullThinkingEffort } from "./model-reasoning.js";
 
@@ -340,6 +341,18 @@ export function isOllamaCloudModel(modelName: string | undefined): boolean {
   return isCloudModelRef(modelName);
 }
 
+/**
+ * Cloud models are referenced both bare (`kimi-k3`) and suffixed (`kimi-k3:cloud`).
+ * Both spellings must reach the same known context window, or a suffixed ref silently
+ * falls back to the generic default whenever live inspection is unavailable.
+ */
+export function resolveOllamaCloudDefaultModel(
+  modelId: string,
+): (typeof OLLAMA_CLOUD_DEFAULT_MODELS)[number] | undefined {
+  const normalized = normalizeOllamaCloudModelId(modelId);
+  return OLLAMA_CLOUD_DEFAULT_MODELS.find((model) => model.id === normalized);
+}
+
 export function isReasoningModelHeuristic(modelId: string): boolean {
   return /r1|reasoning|think|reason/i.test(modelId);
 }
@@ -371,12 +384,8 @@ export function buildOllamaModelDefinition(
     cost: OLLAMA_DEFAULT_COST,
     contextWindow:
       contextWindow ??
-      (modelId
-        .trim()
-        .toLowerCase()
-        .replace(/:cloud$/, "") === "glm-5.2"
-        ? 1_000_000
-        : OLLAMA_DEFAULT_CONTEXT_WINDOW),
+      resolveOllamaCloudDefaultModel(modelId)?.contextWindow ??
+      OLLAMA_DEFAULT_CONTEXT_WINDOW,
     maxTokens: OLLAMA_DEFAULT_MAX_TOKENS,
     compat,
   };

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -346,7 +346,7 @@ export function isOllamaCloudModel(modelName: string | undefined): boolean {
  * Both spellings must reach the same known context window, or a suffixed ref silently
  * falls back to the generic default whenever live inspection is unavailable.
  */
-export function resolveOllamaCloudDefaultModel(
+function resolveOllamaCloudDefaultModel(
   modelId: string,
 ): (typeof OLLAMA_CLOUD_DEFAULT_MODELS)[number] | undefined {
   const normalized = normalizeOllamaCloudModelId(modelId);

--- a/extensions/ollama/src/setup-model-selection.ts
+++ b/extensions/ollama/src/setup-model-selection.ts
@@ -1,6 +1,6 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { selectPreferredLocalModelId } from "openclaw/plugin-sdk/provider-model-shared";
-import { OLLAMA_CLOUD_DEFAULT_MODELS } from "./defaults.js";
+import { normalizeOllamaCloudModelId, OLLAMA_CLOUD_DEFAULT_MODELS } from "./defaults.js";
 import {
   buildDefaultOllamaCloudModelDefinition,
   buildOllamaModelDefinition,
@@ -126,8 +126,13 @@ export function buildOllamaModelsConfig(
 ) {
   return modelNames.map((name) => {
     const discovered = discoveredModelsByName?.get(name);
-    const defaultModel = defaultModels.find((model) => model.id === name);
-    if (defaultModel && !discovered) {
+    // Cloud suggestions arrive suffixed (`kimi-k3:cloud`); the default table is keyed bare.
+    // Match through the suffix for context/capabilities, but keep the requested id: the
+    // suffixed spelling is what gets written into config.
+    const defaultModel = defaultModels.find(
+      (model) => model.id === normalizeOllamaCloudModelId(name),
+    );
+    if (defaultModel && !discovered && defaultModel.id === name) {
       return buildDefaultOllamaCloudModelDefinition(defaultModel);
     }
     const capabilities =

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -462,29 +462,20 @@ describe("ollama setup", () => {
 
     expect(modelIds).toEqual(["minimax-m2.7", "minimax-m3", "kimi-k3", "glm-5.1", "glm-5.2"]);
     expect(models).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: "minimax-m2.7",
-          contextWindow: 196_608,
-          reasoning: true,
-          input: ["text"],
-          compat: { supportsTools: true, supportsUsageInStreaming: true },
-        }),
-        expect.objectContaining({
-          id: "glm-5.1",
-          contextWindow: 202_752,
-          reasoning: true,
-          input: ["text"],
-          compat: { supportsTools: true, supportsUsageInStreaming: true },
-        }),
-        expect.objectContaining({
-          id: "glm-5.2",
-          contextWindow: 1_000_000,
-          reasoning: true,
-          input: ["text"],
-          compat: { supportsTools: true, supportsUsageInStreaming: true },
-        }),
-      ]),
+      expect.arrayContaining(
+        [
+          { id: "minimax-m2.7", contextWindow: 196_608 },
+          { id: "glm-5.1", contextWindow: 202_752 },
+          { id: "glm-5.2", contextWindow: 1_000_000 },
+        ].map((model) =>
+          expect.objectContaining({
+            ...model,
+            reasoning: true,
+            input: ["text"],
+            compat: { supportsTools: true, supportsUsageInStreaming: true },
+          }),
+        ),
+      ),
     );
   });
 

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -204,10 +204,27 @@ describe("ollama setup", () => {
     });
     const modelIds = result.config.models?.providers?.ollama?.models?.map((m) => m.id);
 
-    expect(modelIds?.[0]).toBe("kimi-k3");
+    expect(modelIds?.[0]).toBe("minimax-m3");
+    // The resolved default follows OLLAMA_CLOUD_DEFAULT_MODELS[0]; pin the id itself so
+    // reordering that array cannot silently move what every new cloud setup selects.
+    expect(result.defaultModel).toBe("ollama/minimax-m3");
     expect(result.config.models?.providers?.ollama?.baseUrl).toBe("https://ollama.com");
     expect(result.config.models?.providers?.ollama?.apiKey).toBe("test-ollama-key");
     expect(result.credential).toBe("test-ollama-key");
+  });
+
+  it("keeps the resolved cloud default ahead of live discovery results", async () => {
+    const prompter = createCloudPrompter();
+    vi.stubGlobal("fetch", createOllamaFetchMock({ tags: ["some-other-cloud-model"] }));
+
+    const result = await promptAndConfigureOllama({
+      cfg: {},
+      env: {},
+      prompter,
+      allowSecretRefPrompt: false,
+    });
+
+    expect(result.defaultModel).toBe("ollama/minimax-m3");
   });
 
   it("uses generic token flags for cloud-only setup", async () => {
@@ -245,6 +262,7 @@ describe("ollama setup", () => {
 
     expect(modelIds).toEqual([
       "gemma4",
+      "minimax-m3:cloud",
       "kimi-k3:cloud",
       "minimax-m2.7:cloud",
       "glm-5.1:cloud",
@@ -458,8 +476,15 @@ describe("ollama setup", () => {
     const models = result.config.models?.providers?.ollama?.models;
     const modelIds = models?.map((m) => m.id);
 
-    expect(modelIds).toEqual(["kimi-k3", "minimax-m2.7", "glm-5.1", "glm-5.2"]);
+    expect(modelIds).toEqual(["minimax-m3", "kimi-k3", "minimax-m2.7", "glm-5.1", "glm-5.2"]);
     expect(models).toEqual([
+      expect.objectContaining({
+        id: "minimax-m3",
+        contextWindow: 524_288,
+        reasoning: true,
+        input: ["text", "image"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
       expect.objectContaining({
         id: "kimi-k3",
         contextWindow: 1_048_576,
@@ -509,6 +534,7 @@ describe("ollama setup", () => {
     const modelIds = models?.map((m) => m.id);
 
     expect(modelIds).toEqual([
+      "minimax-m3",
       "kimi-k3",
       "minimax-m2.7",
       "glm-5.1",

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -204,7 +204,7 @@ describe("ollama setup", () => {
     });
     const modelIds = result.config.models?.providers?.ollama?.models?.map((m) => m.id);
 
-    expect(modelIds?.[0]).toBe("minimax-m2.7");
+    expect(modelIds?.[0]).toBe("kimi-k3");
     expect(result.config.models?.providers?.ollama?.baseUrl).toBe("https://ollama.com");
     expect(result.config.models?.providers?.ollama?.apiKey).toBe("test-ollama-key");
     expect(result.credential).toBe("test-ollama-key");
@@ -245,6 +245,7 @@ describe("ollama setup", () => {
 
     expect(modelIds).toEqual([
       "gemma4",
+      "kimi-k3:cloud",
       "minimax-m2.7:cloud",
       "glm-5.1:cloud",
       "glm-5.2:cloud",
@@ -457,8 +458,15 @@ describe("ollama setup", () => {
     const models = result.config.models?.providers?.ollama?.models;
     const modelIds = models?.map((m) => m.id);
 
-    expect(modelIds).toEqual(["minimax-m2.7", "glm-5.1", "glm-5.2"]);
+    expect(modelIds).toEqual(["kimi-k3", "minimax-m2.7", "glm-5.1", "glm-5.2"]);
     expect(models).toEqual([
+      expect.objectContaining({
+        id: "kimi-k3",
+        contextWindow: 1_048_576,
+        reasoning: true,
+        input: ["text", "image"],
+        compat: { supportsTools: true, supportsUsageInStreaming: true },
+      }),
       expect.objectContaining({
         id: "minimax-m2.7",
         contextWindow: 196_608,
@@ -501,6 +509,7 @@ describe("ollama setup", () => {
     const modelIds = models?.map((m) => m.id);
 
     expect(modelIds).toEqual([
+      "kimi-k3",
       "minimax-m2.7",
       "glm-5.1",
       "glm-5.2",

--- a/extensions/ollama/src/setup.test.ts
+++ b/extensions/ollama/src/setup.test.ts
@@ -204,27 +204,11 @@ describe("ollama setup", () => {
     });
     const modelIds = result.config.models?.providers?.ollama?.models?.map((m) => m.id);
 
-    expect(modelIds?.[0]).toBe("minimax-m3");
-    // The resolved default follows OLLAMA_CLOUD_DEFAULT_MODELS[0]; pin the id itself so
-    // reordering that array cannot silently move what every new cloud setup selects.
-    expect(result.defaultModel).toBe("ollama/minimax-m3");
+    expect(modelIds?.[0]).toBe("minimax-m2.7");
+    expect(result.defaultModel).toBe("ollama/minimax-m2.7");
     expect(result.config.models?.providers?.ollama?.baseUrl).toBe("https://ollama.com");
     expect(result.config.models?.providers?.ollama?.apiKey).toBe("test-ollama-key");
     expect(result.credential).toBe("test-ollama-key");
-  });
-
-  it("keeps the resolved cloud default ahead of live discovery results", async () => {
-    const prompter = createCloudPrompter();
-    vi.stubGlobal("fetch", createOllamaFetchMock({ tags: ["some-other-cloud-model"] }));
-
-    const result = await promptAndConfigureOllama({
-      cfg: {},
-      env: {},
-      prompter,
-      allowSecretRefPrompt: false,
-    });
-
-    expect(result.defaultModel).toBe("ollama/minimax-m3");
   });
 
   it("uses generic token flags for cloud-only setup", async () => {
@@ -262,9 +246,9 @@ describe("ollama setup", () => {
 
     expect(modelIds).toEqual([
       "gemma4",
+      "minimax-m2.7:cloud",
       "minimax-m3:cloud",
       "kimi-k3:cloud",
-      "minimax-m2.7:cloud",
       "glm-5.1:cloud",
       "glm-5.2:cloud",
       "llama3:8b",
@@ -476,44 +460,32 @@ describe("ollama setup", () => {
     const models = result.config.models?.providers?.ollama?.models;
     const modelIds = models?.map((m) => m.id);
 
-    expect(modelIds).toEqual(["minimax-m3", "kimi-k3", "minimax-m2.7", "glm-5.1", "glm-5.2"]);
-    expect(models).toEqual([
-      expect.objectContaining({
-        id: "minimax-m3",
-        contextWindow: 524_288,
-        reasoning: true,
-        input: ["text", "image"],
-        compat: { supportsTools: true, supportsUsageInStreaming: true },
-      }),
-      expect.objectContaining({
-        id: "kimi-k3",
-        contextWindow: 1_048_576,
-        reasoning: true,
-        input: ["text", "image"],
-        compat: { supportsTools: true, supportsUsageInStreaming: true },
-      }),
-      expect.objectContaining({
-        id: "minimax-m2.7",
-        contextWindow: 196_608,
-        reasoning: true,
-        input: ["text"],
-        compat: { supportsTools: true, supportsUsageInStreaming: true },
-      }),
-      expect.objectContaining({
-        id: "glm-5.1",
-        contextWindow: 202_752,
-        reasoning: true,
-        input: ["text"],
-        compat: { supportsTools: true, supportsUsageInStreaming: true },
-      }),
-      expect.objectContaining({
-        id: "glm-5.2",
-        contextWindow: 1_000_000,
-        reasoning: true,
-        input: ["text"],
-        compat: { supportsTools: true, supportsUsageInStreaming: true },
-      }),
-    ]);
+    expect(modelIds).toEqual(["minimax-m2.7", "minimax-m3", "kimi-k3", "glm-5.1", "glm-5.2"]);
+    expect(models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "minimax-m2.7",
+          contextWindow: 196_608,
+          reasoning: true,
+          input: ["text"],
+          compat: { supportsTools: true, supportsUsageInStreaming: true },
+        }),
+        expect.objectContaining({
+          id: "glm-5.1",
+          contextWindow: 202_752,
+          reasoning: true,
+          input: ["text"],
+          compat: { supportsTools: true, supportsUsageInStreaming: true },
+        }),
+        expect.objectContaining({
+          id: "glm-5.2",
+          contextWindow: 1_000_000,
+          reasoning: true,
+          input: ["text"],
+          compat: { supportsTools: true, supportsUsageInStreaming: true },
+        }),
+      ]),
+    );
   });
 
   it("cloud mode populates models from ollama.com /api/tags when reachable", async () => {
@@ -534,9 +506,9 @@ describe("ollama setup", () => {
     const modelIds = models?.map((m) => m.id);
 
     expect(modelIds).toEqual([
+      "minimax-m2.7",
       "minimax-m3",
       "kimi-k3",
-      "minimax-m2.7",
       "glm-5.1",
       "glm-5.2",
       "qwen3-coder:480b-cloud",


### PR DESCRIPTION
## What Problem This Solves

The `ollama-cloud` model catalog described four models — `minimax-m2.7`, `glm-5.1`, `glm-5.2`, and the retired `kimi-k2.5`. Every other model Ollama Cloud serves was missing, including `kimi-k3`, the current flagship.

A model that is absent from the catalog is synthesized by core at the generic `DEFAULT_CONTEXT_TOKENS` (`src/agents/defaults.ts:6`, 200,000) via `synthesizeProviderRuntimeModel` (`src/plugins/provider-model-helpers.ts:121`). So a `kimi-k3` session ran with **200,000 of its real 1,048,576 token window — 80% of the context silently discarded**, with nothing in the product reporting it. Observed on a live gateway where `kimi-k3` is the configured primary model: every session row reported `contextTokens=200000`, while the provider's own `/api/show` reports `1048576`.

Suffixed refs had the same defect from the other side. `OLLAMA_CLOUD_DEFAULT_MODELS` is keyed bare, so `kimi-k3:cloud` never matched and fell to the plugin's 128k default. A hardcoded `glm-5.2` literal inside `buildOllamaModelDefinition` had been papering over that for exactly one model.

## Why This Change Was Made

The manifest is the owning surface for provider model metadata, so it should describe what the provider actually serves. Correcting only `kimi-k3` would leave the same silent truncation waiting for every other cloud model, so this describes the full current lineup, and replaces the single-model literal with a lookup through the canonical cloud-id normalizer that `model-reasoning.ts` already owned (the duplicate spelling of that helper is now gone).

Where a model page advertises a ceiling and `/api/show` reports a lower served value, the served value is used — that is what the API accepts.

## User Impact

Ollama Cloud models get their real context window instead of a 200k or 128k stand-in, both bare and `:cloud`-suffixed. Vision models are no longer described as text-only, so image input is offered where it exists. No config migration: the catalog is provider metadata.

| model | context | input | thinking |
|---|---|---|---|
| kimi-k3 | 1,048,576 | text, image | yes |
| kimi-k2.6 | 262,144 | text, image | yes |
| kimi-k2.7-code | 262,144 | text, image | yes |
| kimi-k2.5 (deprecated) | 262,144 | text, image | yes |
| deepseek-v4-flash | 1,048,576 | text | yes |
| deepseek-v4-pro | 1,048,576 | text | yes |
| gemma4 | 262,144 | text, image | yes |
| glm-5.1 | 202,752 | text | yes |
| glm-5.2 | 1,000,000 | text | yes |
| gpt-oss | 131,072 | text | yes |
| minimax-m2.7 | 196,608 | text | yes |
| minimax-m3 | 524,288 | text, image | yes |
| mistral-large-3 | 262,144 | text, image | **no** |
| nemotron-3-nano | 262,144 | text | yes |
| nemotron-3-super | 262,144 | text | yes |
| nemotron-3-ultra | 262,144 | text | yes |
| qwen3.5 | 262,144 | text, image | yes |

## Evidence

**Direct provider-endpoint verification.** Every `contextWindow`, `input` and `reasoning` value above is confirmed against Ollama Cloud's own `/api/show`, queried directly. That endpoint needs no credential and runs no inference, so this is reproducible by any reviewer:

```
curl -s -X POST https://ollama.com/api/show \
  -H 'Content-Type: application/json' -d '{"model":"kimi-k3:cloud"}'
```
```json
{"capabilities":["vision","thinking","completion","tools"],
 "model_info":{"kimi-k3.context_length":1048576, ...}}
```

The full per-model table of `context_length` and `capabilities` is posted as a comment on this PR. Every manifest value matches it, and `mistral-large-3` is confirmed at the source as the only model without `thinking` (`completion, tools, vision`), which is why it is the only `reasoning: false` entry.

The endpoint also corrected two numbers that the `ollama.com/library` pages state differently:
- **glm-5.2 is 1,000,000**, not the "976K context window" its page implies. The pre-existing manifest value was already right and is unchanged.
- **nemotron-3-nano is 262,144**, despite its readme mentioning a 1M context.

Where a page advertises a ceiling above the served value, the served value is used: `minimax-m3` (page: "up to 1M, guaranteed minimum 512K"; served 524,288) and `deepseek-v4-pro:preview` (page: 1M; served 524,288, while `:0813` and bare serve 1,048,576).

Cross-checked independently through the product path on a live gateway (`openclaw models list --provider ollama-cloud --json`, which enriches from `/api/show` for all 21 served tags); it agrees with the direct queries.

**Automated.** `extensions/ollama` 636 tests pass, including two new cases in `provider-models.test.ts`: bare and `:cloud` refs both resolve a known cloud context window, and an unknown cloud model still falls back to the generic default. `tsgo --noEmit` clean.

AI-assisted: yes. No credentials or private identifiers included.
