### PR TITLE
fix(normalization-core): preserve non-Error object causes with extra keys in formatErrorMessage

### DIFF
--- a/packages/normalization-core/src/error-coercion.test.ts
+++ b/packages/normalization-core/src/error-coercion.test.ts
@@ -69,7 +69,7 @@ describe("formatErrorMessage", () => {
           cause: { status: 503, code: "UNAVAILABLE", requestId: "abc" },
         }),
       ),
-    ).toContain("503");
+    ).toBe('request failed | {"status":503,"code":"UNAVAILABLE","requestId":"abc"}');
   });
 
   it("stringifies primitives and circular records without throwing", () => {

--- a/packages/normalization-core/src/error-coercion.test.ts
+++ b/packages/normalization-core/src/error-coercion.test.ts
@@ -55,9 +55,21 @@ describe("formatErrorMessage", () => {
     expect(format(new Error("request failed", { cause: { status: 429 } }))).toBe(
       "request failed | status=429 code=unknown",
     );
+    // A non-Error cause carrying recognized status/code fields alongside extra
+    // keys used to be dropped entirely: formatStatusAndCode returns undefined
+    // for any object with keys beyond status/code, and the cause-chain branch
+    // had no stringifyUnknown fallback (unlike the top-level branch). The
+    // structured detail now survives instead of being swallowed.
     expect(format(new Error("request failed", { cause: { statusCode: 429 } }))).toBe(
-      "request failed",
+      'request failed | {"statusCode":429}',
     );
+    expect(
+      format(
+        new Error("request failed", {
+          cause: { status: 503, code: "UNAVAILABLE", requestId: "abc" },
+        }),
+      ),
+    ).toContain("503");
   });
 
   it("stringifies primitives and circular records without throwing", () => {

--- a/packages/normalization-core/src/error-coercion.ts
+++ b/packages/normalization-core/src/error-coercion.ts
@@ -117,7 +117,10 @@ export function formatErrorMessage(value: unknown, options: FormatErrorMessageOp
         appendCauseMessage(cause);
         break;
       } else {
-        appendCauseMessage(formatStatusAndCode(cause));
+        // Mirror the top-level branch: an object cause with keys beyond
+        // status/code makes formatStatusAndCode return undefined, so fall
+        // back to stringifyUnknown rather than dropping the cause entirely.
+        appendCauseMessage(formatStatusAndCode(cause) ?? stringifyUnknown(cause));
         break;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Closes #126652. `formatErrorMessage` silently dropped a non-Error object `cause` when the cause carried any key beyond `status`/`code`. The cause-chain `else` branch called only `formatStatusAndCode(cause)` with no `stringifyUnknown` fallback, while the top-level branch correctly used `formatStatusAndCode(value) ?? stringifyUnknown(value)`. Since `formatStatusAndCode` returns `undefined` for any object whose keys are not exactly `status`/`code`, a cause like `{ statusCode: 429 }` or `{ status: 503, code: "UNAVAILABLE", requestId: "abc" }` was swallowed — `appendCauseMessage(undefined)` no-op'd and the loop broke, losing the diagnostic/retryable detail.

## Why This Change Was Made

This is an asymmetry bug within the canonical error-formatting owner (`packages/normalization-core/src/error-coercion.ts`). The fix mirrors the existing top-level branch in the cause-chain `else`:

```diff
       } else {
-        appendCauseMessage(formatStatusAndCode(cause));
+        appendCauseMessage(formatStatusAndCode(cause) ?? stringifyUnknown(cause));
         break;
       }
```

`stringifyUnknown` is a local helper in the same file (line 44). The change is behavior-neutral for causes that already render (`formatStatusAndCode` non-undefined) and only restores the dropped detail for the asymmetric case. No new helper, no new dependency, no consumer change.

Production LOC: +4 (1 expression widened + 3 inline-comment lines documenting the non-obvious top-level/cause-chain asymmetry per the inline-comment guideline). No net-neutral refactor absorbs this — it is a missing fallback added at the owner boundary, symmetric with the sibling branch two lines below.

## User Impact

Operators see complete error diagnostics instead of a bare `request failed` when a wrapped error's cause is a structured object (common with HTTP/response/error envelope causes that carry `statusCode`, `requestId`, etc.). The formatted message also feeds recoverability classification (`src/agents/run-wait.ts` → `isRecoverableAgentWaitError`), so a dropped object cause could previously misclassify a recoverable failure as permanent — a silent-failure regression on the default diagnostic path.

## Evidence

**Failing reproduction (pre-fix, on `origin/main`):**

```
extra-key cause (statusCode) => request failed
status+code+extra cause => request failed
```

Both object causes dropped entirely; `429`/`503`/`UNAVAILABLE`/`requestId` lost.

**Post-fix behavior (same probe):**

```
pure-status cause => request failed | status=429 code=unknown
extra-key cause (statusCode) => request failed | {"statusCode":429}
status+code+extra cause => request failed | {"status":503,"code":"UNAVAILABLE","requestId":"abc"}
```

The pure-status cause (which already rendered via `formatStatusAndCode`) is unchanged; the extra-key causes now preserve the structured detail.

**Regression test** (`packages/normalization-core/src/error-coercion.test.ts`): the existing `{ statusCode: 429 }` cause assertion was updated from `"request failed"` (bug behavior) to `'request failed | {"statusCode":429}'`, plus a new assertion that a `{ status: 503, code: "UNAVAILABLE", requestId: "abc" }` cause contains `"503"`. Pre-fix this test case failed (`AssertionError: expected 'request failed' to be 'request failed | {"statusCode":429}'`); post-fix all 18 tests in the file pass.

**Verification:**

- `node scripts/run-vitest.mjs packages/normalization-core/src/error-coercion.test.ts --isolate=false` → 18 passed
- `tsgo --noEmit --ignoreConfig packages/normalization-core/src/error-coercion.ts` → 0 errors
- `oxlint` + `oxfmt --check` → clean
