### PR TITLE
fix(telegram): resolve General topic session-init retry loop via forum-flag cache

### DIFF
--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -112,11 +112,6 @@ export function getCachedTelegramForumFlag(
   return cached.isForum;
 }
 
-// Test-only: clear the in-memory forum-flag cache between cases.
-export function resetTelegramForumFlagCacheForTest(): void {
-  telegramForumFlagByChatId.clear();
-}
-
 function hadUnsafeTelegramText(raw: unknown, sanitized: string): boolean {
   return typeof raw === "string" && raw.trim().length > 0 && sanitized.trim().length === 0;
 }

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -96,6 +96,27 @@ function cacheTelegramForumFlag(chatId: string | number, isForum: boolean, nowMs
   });
 }
 
+export function getCachedTelegramForumFlag(
+  chatId: string | number,
+  nowMs?: number,
+): boolean | undefined {
+  const cacheKey = String(chatId);
+  const cached = telegramForumFlagByChatId.get(cacheKey);
+  if (!cached) {
+    return undefined;
+  }
+  const effectiveNow = nowMs ?? Date.now();
+  if (cached.expiresAtMs <= effectiveNow) {
+    return undefined;
+  }
+  return cached.isForum;
+}
+
+// Test-only: clear the in-memory forum-flag cache between cases.
+export function resetTelegramForumFlagCacheForTest(): void {
+  telegramForumFlagByChatId.clear();
+}
+
 function hadUnsafeTelegramText(raw: unknown, sanitized: string): boolean {
   return typeof raw === "string" && raw.trim().length > 0 && sanitized.trim().length === 0;
 }

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -1,8 +1,8 @@
 // Telegram tests cover sequential key plugin behavior.
 import type { Chat, Message } from "grammy/types";
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { buildTelegramApprovalCallbackData } from "./approval-callback-data.js";
-import { resetTelegramForumFlagCacheForTest, resolveTelegramForumFlag } from "./bot/helpers.js";
+import { resolveTelegramForumFlag } from "./bot/helpers.js";
 import { buildTelegramQuestionCallbackData } from "./question-callback-data.js";
 import { getTelegramSequentialConstraints, getTelegramSequentialKey } from "./sequential-key.js";
 
@@ -416,10 +416,6 @@ describe("getTelegramSequentialKey", () => {
   });
 
   describe("forum flag cache fallback", () => {
-    afterEach(() => {
-      resetTelegramForumFlagCacheForTest();
-    });
-
     it("uses cached forum flag to assign topic:1 lane when payload lacks is_forum and is_topic_message", async () => {
       // Prime the cache the way bot-message-context does: resolveTelegramForumFlag
       // calls cacheTelegramForumFlag internally when the hint is available.

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -445,6 +445,23 @@ describe("getTelegramSequentialKey", () => {
       };
       expect(getTelegramSequentialKey(ctx)).toBe("telegram:-9002");
     });
+
+    it("honors an explicit forum hint when the cached flag is stale", async () => {
+      await resolveTelegramForumFlag({
+        chatId: -9004,
+        chatType: "supergroup",
+        isGroup: true,
+        isForum: false,
+      });
+
+      const ctx = {
+        message: mockMessage({
+          chat: mockChat({ id: -9004, type: "supergroup" }),
+          is_topic_message: true,
+        }),
+      };
+      expect(getTelegramSequentialKey(ctx)).toBe("telegram:-9004:topic:1");
+    });
   });
 });
 

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -1,7 +1,8 @@
 // Telegram tests cover sequential key plugin behavior.
 import type { Chat, Message } from "grammy/types";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { buildTelegramApprovalCallbackData } from "./approval-callback-data.js";
+import { resetTelegramForumFlagCacheForTest, resolveTelegramForumFlag } from "./bot/helpers.js";
 import { buildTelegramQuestionCallbackData } from "./question-callback-data.js";
 import { getTelegramSequentialConstraints, getTelegramSequentialKey } from "./sequential-key.js";
 
@@ -412,6 +413,42 @@ describe("getTelegramSequentialKey", () => {
 
   it("keeps malformed message updates on the unknown lane", () => {
     expect(getTelegramSequentialKey({ message: {} as Message })).toBe("telegram:unknown");
+  });
+
+  describe("forum flag cache fallback", () => {
+    afterEach(() => {
+      resetTelegramForumFlagCacheForTest();
+    });
+
+    it("uses cached forum flag to assign topic:1 lane when payload lacks is_forum and is_topic_message", async () => {
+      // Prime the cache the way bot-message-context does: resolveTelegramForumFlag
+      // calls cacheTelegramForumFlag internally when the hint is available.
+      await resolveTelegramForumFlag({
+        chatId: -9001,
+        chatType: "supergroup",
+        isGroup: true,
+        isForum: true,
+      });
+
+      // General topic message: no is_forum, no is_topic_message, no message_thread_id.
+      // Without the cache, getTelegramSequentialKey returns the base lane.
+      // With the cache primed, it must return topic:1.
+      const generalTopicCtx = {
+        message: mockMessage({
+          chat: mockChat({ id: -9001, type: "supergroup" }),
+        }),
+      };
+      expect(getTelegramSequentialKey(generalTopicCtx)).toBe("telegram:-9001:topic:1");
+    });
+
+    it("falls back to base lane when cache is empty and payload lacks is_forum hint", () => {
+      const ctx = {
+        message: mockMessage({
+          chat: mockChat({ id: -9002, type: "supergroup" }),
+        }),
+      };
+      expect(getTelegramSequentialKey(ctx)).toBe("telegram:-9002");
+    });
   });
 });
 

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -221,11 +221,20 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   // to the in-memory cache (populated by earlier messages or getChat calls)
   // so the lane key resolves to `telegram:${chatId}:topic:1` rather than the
   // base lane, preventing a cross-lane session-init race.
+  const forumHint = msg?.chat
+    ? resolveTelegramMessageForumFlagHint({
+        chatType: msg.chat.type,
+        isForum: msg.chat.is_forum,
+        isTopicMessage: msg.is_topic_message,
+      })
+    : undefined;
   const cachedForumFlag =
-    msg?.chat?.type === "supergroup" && typeof msg.chat.id === "number"
+    forumHint === undefined && msg?.chat?.type === "supergroup" && typeof msg.chat.id === "number"
       ? getCachedTelegramForumFlag(msg.chat.id)
       : undefined;
-  const threadSpec = msg?.chat ? resolveTelegramMessageThreadSpec(msg, cachedForumFlag) : undefined;
+  const threadSpec = msg?.chat
+    ? resolveTelegramMessageThreadSpec(msg, forumHint ?? cachedForumFlag)
+    : undefined;
   const threadId =
     threadSpec?.scope === "dm"
       ? shouldUseTelegramDmThreadSession({

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/command-primitives-runtime";
 import { hasTelegramApprovalCallbackPrefix } from "./approval-callback-data.js";
 import {
+  getCachedTelegramForumFlag,
   resolveTelegramBotHasTopicsEnabled,
   resolveTelegramMessageForumFlagHint,
   resolveTelegramMessageThreadSpec,
@@ -214,7 +215,17 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   // Raw durable-ingress fixtures and malformed updates can carry a partial
   // message. Treat missing chat identity as an unknown lane instead of
   // crashing before the queue records the update.
-  const threadSpec = msg?.chat ? resolveTelegramMessageThreadSpec(msg) : undefined;
+  //
+  // General forum topic (topic:1) messages lack both `is_topic_message` and
+  // `is_forum` in the payload, so the forum flag hint is undefined. Fall back
+  // to the in-memory cache (populated by earlier messages or getChat calls)
+  // so the lane key resolves to `telegram:${chatId}:topic:1` rather than the
+  // base lane, preventing a cross-lane session-init race.
+  const cachedForumFlag =
+    msg?.chat?.type === "supergroup" && typeof msg.chat.id === "number"
+      ? getCachedTelegramForumFlag(msg.chat.id)
+      : undefined;
+  const threadSpec = msg?.chat ? resolveTelegramMessageThreadSpec(msg, cachedForumFlag) : undefined;
   const threadId =
     threadSpec?.scope === "dm"
       ? shouldUseTelegramDmThreadSession({

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -199,6 +199,9 @@ describe("createTelegramIngressMonitor", () => {
       await queue.enqueue(eventId, payload, { laneKey: "telegram:-9003" });
 
       const dispatch = vi.fn(async (_update, lifecycle) => {
+        expect(await queue.listClaims()).toEqual([
+          expect.objectContaining({ laneKey: "telegram:-9003:topic:1" }),
+        ]);
         await lifecycle.onAdopted();
         return { kind: "completed" as const };
       });

--- a/extensions/telegram/src/telegram-ingress-drain.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.test.ts
@@ -10,6 +10,7 @@ import {
   createTelegramSpooledReplayDeferredParticipant,
   type TelegramSpooledReplayDeferredParticipant,
 } from "./bot-processing-outcome.js";
+import { resolveTelegramForumFlag } from "./bot/helpers.js";
 import { createTelegramIngressMonitor } from "./telegram-ingress-drain.js";
 import { resolveTelegramIngressNonRetryableFailure } from "./telegram-ingress-non-retryable.js";
 import {
@@ -162,6 +163,58 @@ describe("createTelegramIngressMonitor", () => {
       const pending = await queue.listPending({ limit: "all" });
       expect(pending.some((row) => row.id === eventId)).toBe(true);
 
+      await monitor.stop();
+    });
+  });
+
+  it("reconciles a cached General topic when private bot topics are disabled", async () => {
+    await withTempState(async (stateDir) => {
+      const queue = createChannelIngressQueueForTests<TelegramSpooledUpdatePayload>({
+        channelId: "telegram",
+        accountId: "default",
+        stateDir,
+      });
+      const updateId = 9;
+      const eventId = String(updateId).padStart(16, "0");
+      const update = {
+        update_id: updateId,
+        message: {
+          text: "hello",
+          from: { id: 111 },
+          chat: { id: -9003, type: "supergroup" },
+        },
+      };
+      const payload: TelegramSpooledUpdatePayload = {
+        version: 1,
+        updateId,
+        receivedAt: updateId,
+        update,
+      };
+      await resolveTelegramForumFlag({
+        chatId: -9003,
+        chatType: "supergroup",
+        isGroup: true,
+        isForum: true,
+      });
+      await queue.enqueue(eventId, payload, { laneKey: "telegram:-9003" });
+
+      const dispatch = vi.fn(async (_update, lifecycle) => {
+        await lifecycle.onAdopted();
+        return { kind: "completed" as const };
+      });
+      const monitor = createTelegramIngressMonitor({
+        queue,
+        cfg,
+        accountId: "default",
+        botInfo: { id: 999, has_topics_enabled: false } as never,
+        dispatch,
+      });
+
+      monitor.start();
+      await monitor.waitForIdle();
+
+      expect(dispatch).toHaveBeenCalledOnce();
+      expect(await queue.listPending({ limit: "all" })).toEqual([]);
       await monitor.stop();
     });
   });

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -192,16 +192,26 @@ function canReconcileTelegramLegacyLane(params: {
     (chatType === "group" || chatType === "supergroup") && typeof chatId === "number" && chatId < 0;
   const hasValidThreadId =
     typeof threadId === "number" && Number.isSafeInteger(threadId) && threadId > 0;
-  // Allow group chats with no message_thread_id to bypass the hasValidThreadId
-  // guard: General forum topic (topic:1) messages never carry message_thread_id,
-  // so blocking them here would permanently prevent reconciliation of events
-  // that were stored in the base lane before the forum flag was known.
-  const isForumGroupWithNoThread = isGroupChat && !typedApproval && !hasValidThreadId;
+  const chatTypeHint =
+    chatType === "channel" ||
+    chatType === "group" ||
+    chatType === "private" ||
+    chatType === "supergroup"
+      ? chatType
+      : undefined;
+  const forumFlag =
+    resolveTelegramMessageForumFlagHint({
+      chatType: chatTypeHint,
+      isForum: typeof message.chat?.is_forum === "boolean" ? message.chat.is_forum : undefined,
+      isTopicMessage:
+        typeof message.is_topic_message === "boolean" ? message.is_topic_message : undefined,
+    }) ?? (typeof chatId === "number" ? getCachedTelegramForumFlag(chatId) : undefined);
+  const isForumGroup = isGroupChat && forumFlag === true;
   if (
     typeof chatId !== "number" ||
     !Number.isSafeInteger(chatId) ||
-    (typedApproval ? !isPrivateChat && !isGroupChat : !isPrivateChat) ||
-    (!typedApproval && !hasValidThreadId && !isForumGroupWithNoThread) ||
+    (typedApproval ? !isPrivateChat && !isGroupChat : !isPrivateChat && !isForumGroup) ||
+    (!typedApproval && !hasValidThreadId && !isForumGroup) ||
     (typedApproval && threadId !== undefined && !hasValidThreadId)
   ) {
     return false;
@@ -209,17 +219,7 @@ function canReconcileTelegramLegacyLane(params: {
   const baseLaneKey = `telegram:${chatId}`;
   const legacyThreadId = isGroupChat
     ? resolveTelegramForumThreadId({
-        isForum:
-          resolveTelegramMessageForumFlagHint({
-            chatType,
-            isForum:
-              typeof message.chat?.is_forum === "boolean" ? message.chat.is_forum : undefined,
-            isTopicMessage:
-              typeof message.is_topic_message === "boolean" ? message.is_topic_message : undefined,
-          }) ??
-          // Fall back to cache: General topic payloads lack is_forum and
-          // is_topic_message, but getChat or a later message may have populated it.
-          getCachedTelegramForumFlag(chatId),
+        isForum: forumFlag,
         messageThreadId: hasValidThreadId ? threadId : undefined,
       })
     : hasValidThreadId
@@ -228,7 +228,7 @@ function canReconcileTelegramLegacyLane(params: {
   const topicLaneKey = legacyThreadId ? `${baseLaneKey}:topic:${legacyThreadId}` : undefined;
   const canonicalLaneKey = typedApproval
     ? `${baseLaneKey}:approval`
-    : params.botInfo?.has_topics_enabled === true
+    : isForumGroup || params.botInfo?.has_topics_enabled === true
       ? topicLaneKey
       : baseLaneKey;
   const previousLaneKey = canonicalLaneKey === baseLaneKey ? topicLaneKey : baseLaneKey;

--- a/extensions/telegram/src/telegram-ingress-drain.ts
+++ b/extensions/telegram/src/telegram-ingress-drain.ts
@@ -18,6 +18,7 @@ import {
   type TelegramMessageProcessingResult,
 } from "./bot-processing-outcome.js";
 import {
+  getCachedTelegramForumFlag,
   resolveTelegramForumThreadId,
   resolveTelegramMessageForumFlagHint,
 } from "./bot/helpers.js";
@@ -191,11 +192,16 @@ function canReconcileTelegramLegacyLane(params: {
     (chatType === "group" || chatType === "supergroup") && typeof chatId === "number" && chatId < 0;
   const hasValidThreadId =
     typeof threadId === "number" && Number.isSafeInteger(threadId) && threadId > 0;
+  // Allow group chats with no message_thread_id to bypass the hasValidThreadId
+  // guard: General forum topic (topic:1) messages never carry message_thread_id,
+  // so blocking them here would permanently prevent reconciliation of events
+  // that were stored in the base lane before the forum flag was known.
+  const isForumGroupWithNoThread = isGroupChat && !typedApproval && !hasValidThreadId;
   if (
     typeof chatId !== "number" ||
     !Number.isSafeInteger(chatId) ||
     (typedApproval ? !isPrivateChat && !isGroupChat : !isPrivateChat) ||
-    (!typedApproval && !hasValidThreadId) ||
+    (!typedApproval && !hasValidThreadId && !isForumGroupWithNoThread) ||
     (typedApproval && threadId !== undefined && !hasValidThreadId)
   ) {
     return false;
@@ -203,12 +209,17 @@ function canReconcileTelegramLegacyLane(params: {
   const baseLaneKey = `telegram:${chatId}`;
   const legacyThreadId = isGroupChat
     ? resolveTelegramForumThreadId({
-        isForum: resolveTelegramMessageForumFlagHint({
-          chatType,
-          isForum: typeof message.chat?.is_forum === "boolean" ? message.chat.is_forum : undefined,
-          isTopicMessage:
-            typeof message.is_topic_message === "boolean" ? message.is_topic_message : undefined,
-        }),
+        isForum:
+          resolveTelegramMessageForumFlagHint({
+            chatType,
+            isForum:
+              typeof message.chat?.is_forum === "boolean" ? message.chat.is_forum : undefined,
+            isTopicMessage:
+              typeof message.is_topic_message === "boolean" ? message.is_topic_message : undefined,
+          }) ??
+          // Fall back to cache: General topic payloads lack is_forum and
+          // is_topic_message, but getChat or a later message may have populated it.
+          getCachedTelegramForumFlag(chatId),
         messageThreadId: hasValidThreadId ? threadId : undefined,
       })
     : hasValidThreadId


### PR DESCRIPTION
Closes #126655

## What Problem This Solves

Telegram forum General-topic messages can omit topic fields. They were routed to the base session lane, then remained stuck in session-init retries.

## Why This Change Was Made

The contributor change uses the cached forum flag when the update has no topic fields. The completion repairs durable-lane reconciliation so cached forum state selects `topic:1` even when `getMe.has_topics_enabled` is false. Explicit payload forum hints take precedence over stale cache values.

## User Impact

General-topic messages in Telegram forum supergroups use the correct session lane and can receive a reply.

## Evidence

- Focused regression: `extensions/telegram/src/sequential-key.test.ts` and `extensions/telegram/src/telegram-ingress-drain.test.ts`, 79/79 passed.
- Durable-ingress reproduction on the contributor head: a redacted General-topic payload with no topic fields, cached `isForum=true`, and `has_topics_enabled=false` stayed undispatched; the row was dead-lettered after identity mismatch.
- The same durable row on this head dispatches once to `telegram:-9003:topic:1` and leaves no pending row.
- Targeted formatting, lint, and diff checks passed.
- Generic real-user Telegram probe replied `OPENCLAW_E2E_OK`; recorded proof includes the event stream and provider request log.
- The userbot runner cannot synthesize the missing General-topic update shape, so forum-specific live proof remains unverified.

- [x] AI-assisted (OpenClaw / Claude)
