### PR TITLE
fix(acp): prevent lost prompts and preserve conversation bindings

### DIFF
--- a/extensions/acpx/register.runtime.test.ts
+++ b/extensions/acpx/register.runtime.test.ts
@@ -24,6 +24,7 @@ const { realRuntime, realServiceStartMock, realServiceStopMock, createRealServic
       startTurn(input: { requestId: string }) {
         return {
           requestId: input.requestId,
+          promptStarted: Promise.resolve(),
           events: (async function* () {})(),
           result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
           cancel: async () => {},
@@ -128,6 +129,7 @@ describe("acpx register runtime service", () => {
         mode: string;
         requestId: string;
       }): {
+        promptStarted: Promise<void>;
         events: AsyncIterable<unknown>;
         result: Promise<unknown>;
       };
@@ -171,6 +173,7 @@ describe("acpx register runtime service", () => {
       mode: "prompt",
       requestId: "turn-1",
     });
+    await expect(turn.promptStarted).resolves.toBeUndefined();
     await expect(turn.result).resolves.toEqual({
       status: "completed",
       stopReason: "end_turn",

--- a/extensions/acpx/src/runtime-proxy.test.ts
+++ b/extensions/acpx/src/runtime-proxy.test.ts
@@ -1,6 +1,7 @@
 // ACPX tests protect the lazy proxy contract: every hook forwards to the
 // resolved runtime, and an absent hook fails loudly instead of fabricating
 // success (regression for silently no-op doctor/status/prepareFreshSession).
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { describe, expect, it, vi } from "vitest";
 import type { AcpRuntimeEvent } from "../runtime-api.js";
 import { createLazyAcpRuntimeProxy, type CompleteAcpRuntime } from "./runtime-proxy.js";
@@ -11,9 +12,10 @@ const handle = {
   runtimeSessionName: "acp:test",
 };
 
-function createCompleteRuntime() {
+function createCompleteRuntime(promptStarted: Promise<void> = Promise.resolve()) {
   const startTurn = vi.fn((input: { requestId: string }) => ({
     requestId: input.requestId,
+    promptStarted,
     events: (async function* (): AsyncGenerator<AcpRuntimeEvent> {})(),
     result: Promise.resolve({ status: "completed" as const, stopReason: "end_turn" }),
     cancel: vi.fn(async () => {}),
@@ -38,7 +40,10 @@ function createCompleteRuntime() {
 
 describe("createLazyAcpRuntimeProxy", () => {
   it("forwards every hook to the resolved runtime without rewriting results", async () => {
-    const { runtime, startTurn, prepareFreshSession } = createCompleteRuntime();
+    const promptStarted = createDeferred<void>();
+    const { runtime, startTurn, prepareFreshSession } = createCompleteRuntime(
+      promptStarted.promise,
+    );
     const proxy = createLazyAcpRuntimeProxy(async () => runtime);
 
     await expect(proxy.doctor()).resolves.toEqual({
@@ -58,7 +63,16 @@ describe("createLazyAcpRuntimeProxy", () => {
       mode: "prompt",
       requestId: "turn-1",
     });
+    expect(turn.promptStarted).toBeDefined();
+    let submitted = false;
+    const observedPromptStarted = turn.promptStarted.then(() => {
+      submitted = true;
+    });
     await expect(turn.result).resolves.toEqual({ status: "completed", stopReason: "end_turn" });
+    expect(submitted).toBe(false);
+    promptStarted.resolve();
+    await observedPromptStarted;
+    expect(submitted).toBe(true);
     expect(startTurn).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/acpx/src/runtime-proxy.ts
+++ b/extensions/acpx/src/runtime-proxy.ts
@@ -4,6 +4,9 @@
  */
 import type { AcpRuntime, AcpRuntimeTurn, AcpRuntimeTurnInput } from "../runtime-api.js";
 
+export type CompleteAcpRuntimeTurn = AcpRuntimeTurn &
+  Required<Pick<AcpRuntimeTurn, "promptStarted">>;
+
 /**
  * Contract for runtimes this extension resolves behind the lazy proxy. The
  * SDK keeps these hooks optional for third-party backends, but every ACPX
@@ -11,11 +14,10 @@ import type { AcpRuntime, AcpRuntimeTurn, AcpRuntimeTurnInput } from "../runtime
  * implements the full surface. Requiring them here turns an absent hook into
  * a compile error instead of a silently fabricated success at runtime.
  */
-export type CompleteAcpRuntime = AcpRuntime &
+export type CompleteAcpRuntime = Omit<AcpRuntime, "startTurn"> &
   Required<
     Pick<
       AcpRuntime,
-      | "startTurn"
       | "getCapabilities"
       | "getStatus"
       | "setMode"
@@ -23,16 +25,21 @@ export type CompleteAcpRuntime = AcpRuntime &
       | "doctor"
       | "prepareFreshSession"
     >
-  >;
+  > & {
+    startTurn(input: AcpRuntimeTurnInput): CompleteAcpRuntimeTurn;
+  };
 
 /** Start an ACP turn through a lazy runtime resolver without awaiting resolution up front. */
 function lazyStartRuntimeTurn(
   resolveRuntime: () => Promise<CompleteAcpRuntime>,
   input: AcpRuntimeTurnInput,
-): AcpRuntimeTurn {
+): CompleteAcpRuntimeTurn {
   const turnPromise = resolveRuntime().then((runtime) => runtime.startTurn(input));
   return {
     requestId: input.requestId,
+    get promptStarted() {
+      return turnPromise.then((turn) => turn.promptStarted);
+    },
     events: {
       async *[Symbol.asyncIterator]() {
         yield* (await turnPromise).events;

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { RequestedModelUnsupportedError } from "acpx/runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AcpRuntimeError,
@@ -938,6 +939,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
   });
 
   it("adds Codex wrapper stderr tail to generic startTurn failure results", async () => {
+    const promptStarted = createDeferred<void>();
     const wrapperRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acpx-runtime-"));
     await fs.writeFile(
       path.join(wrapperRoot, "codex-acp-wrapper.stderr.lease-start-turn.log"),
@@ -963,6 +965,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     vi.spyOn(delegate, "startTurn").mockImplementation(
       (input): AcpRuntimeTurn => ({
         requestId: input.requestId,
+        promptStarted: promptStarted.promise,
         events: (async function* () {
           yield {
             type: "text_delta" as const,
@@ -993,10 +996,19 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       mode: "prompt",
       requestId: "turn-1",
     });
+    expect(turn.promptStarted).toBeDefined();
+    let submitted = false;
+    const observedPromptStarted = turn.promptStarted.then(() => {
+      submitted = true;
+    });
     const events: AcpRuntimeEvent[] = [];
     for await (const event of turn.events) {
       events.push(event);
     }
+    expect(submitted).toBe(false);
+    promptStarted.resolve();
+    await observedPromptStarted;
+    expect(submitted).toBe(true);
 
     await expect(turn.result).resolves.toMatchObject({
       status: "failed",
@@ -1054,6 +1066,13 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       requestId: "turn-1",
     });
 
+    const promptStarted = turn.promptStarted;
+    expect(promptStarted).toBeDefined();
+    await expect(promptStarted).rejects.toMatchObject({
+      name: "AcpRuntimeError",
+      code: "ACP_TURN_FAILED",
+      message: expect.stringContaining("adapter failed before returning turn"),
+    });
     await expect(turn.result).rejects.toMatchObject({
       name: "AcpRuntimeError",
       code: "ACP_TURN_FAILED",
@@ -1082,6 +1101,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     const startTurn = vi.spyOn(delegate, "startTurn").mockImplementation(
       (input): AcpRuntimeTurn => ({
         requestId: input.requestId,
+        promptStarted: Promise.resolve(),
         events: (async function* () {
           yield { type: "done" as const, stopReason: "end_turn" };
         })(),
@@ -2780,6 +2800,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       });
       return {
         requestId: input.requestId,
+        promptStarted: Promise.resolve(),
         events: (async function* () {})(),
         result: Promise.resolve({ status: "completed" }),
         cancel: vi.fn(async () => {}),
@@ -2827,6 +2848,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
       expectPendingLease();
       return {
         requestId: input.requestId,
+        promptStarted: Promise.resolve(),
         events: (async function* () {})(),
         result: Promise.resolve({ status: "completed" }),
         cancel: vi.fn(async () => {}),

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -27,12 +27,7 @@ import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import {
-  AcpRuntimeError,
-  type AcpRuntime,
-  type AcpRuntimeErrorCode,
-  type AcpRuntimeTurn as OpenClawAcpRuntimeTurn,
-} from "../runtime-api.js";
+import { AcpRuntimeError, type AcpRuntime, type AcpRuntimeErrorCode } from "../runtime-api.js";
 import { CODEX_ACP_PACKAGE, OPENCLAW_CODEX_CONFIG_ARG } from "./codex-adapter.js";
 import { splitCommandParts } from "./command-line.js";
 import {
@@ -51,7 +46,7 @@ import {
   isOpenClawLeaseAwareAcpxProcessCommand,
   type AcpxProcessCleanupDeps,
 } from "./process-reaper.js";
-import type { CompleteAcpRuntime } from "./runtime-proxy.js";
+import type { CompleteAcpRuntime, CompleteAcpRuntimeTurn } from "./runtime-proxy.js";
 
 type AcpSessionStore = AcpRuntimeOptions["sessionStore"];
 type AcpSessionRecord = Parameters<AcpSessionStore["save"]>[0];
@@ -1626,7 +1621,7 @@ export class AcpxRuntime implements CompleteAcpRuntime {
     }
   }
 
-  startTurn(input: OpenClawRuntimeTurnInput): OpenClawAcpRuntimeTurn {
+  startTurn(input: OpenClawRuntimeTurnInput): CompleteAcpRuntimeTurn {
     const readCodexTurnFailureStderr = () =>
       this.readCodexTurnFailureStderr({
         handle: input.handle,
@@ -1661,6 +1656,9 @@ export class AcpxRuntime implements CompleteAcpRuntime {
 
     return {
       requestId: input.requestId,
+      get promptStarted() {
+        return turnPromise.then(({ turn }) => turn.promptStarted);
+      },
       events: {
         async *[Symbol.asyncIterator](): AsyncIterator<AcpRuntimeEvent> {
           const { command, turn } = await turnPromise;

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -721,6 +721,7 @@ describe("createAcpxRuntimeService", () => {
     const ctx = createServiceContext(workspaceDir);
     const startTurn = vi.fn((input: { requestId: string }) => ({
       requestId: input.requestId,
+      promptStarted: Promise.resolve(),
       events: (async function* () {
         yield {
           type: "text_delta" as const,
@@ -760,6 +761,7 @@ describe("createAcpxRuntimeService", () => {
         mode: string;
         requestId: string;
       }): {
+        promptStarted: Promise<void>;
         events: AsyncIterable<unknown>;
         result: Promise<unknown>;
       };
@@ -774,6 +776,7 @@ describe("createAcpxRuntimeService", () => {
       mode: "prompt",
       requestId: "turn-1",
     });
+    await expect(turn.promptStarted).resolves.toBeUndefined();
     await expect(turn.result).resolves.toEqual({
       status: "completed",
       stopReason: "end_turn",

--- a/extensions/imessage/src/conversation-route.test.ts
+++ b/extensions/imessage/src/conversation-route.test.ts
@@ -1,10 +1,20 @@
 // Imessage tests cover conversation route plugin behavior.
+import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   testing as sessionBindingTesting,
   registerSessionBindingAdapter,
 } from "openclaw/plugin-sdk/conversation-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  matchIMessageAcpConversation,
+  normalizeIMessageAcpConversationId,
+} from "./conversation-id.js";
 import { resolveIMessageConversationRoute } from "./conversation-route.js";
 
 const baseCfg = {
@@ -15,9 +25,69 @@ const baseCfg = {
   bindings: [{ agentId: "main", match: { channel: "imessage", accountId: "default" } }],
 } satisfies OpenClawConfig;
 
+const configuredCfg = {
+  ...baseCfg,
+  bindings: [
+    ...baseCfg.bindings,
+    {
+      type: "acp",
+      agentId: "codex",
+      match: {
+        channel: "imessage",
+        accountId: "default",
+        peer: { kind: "direct", id: "+15555550123" },
+      },
+    },
+  ],
+} satisfies OpenClawConfig;
+
 describe("resolveIMessageConversationRoute", () => {
   beforeEach(() => {
     sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "imessage",
+          source: "test",
+          plugin: {
+            id: "imessage",
+            bindings: {
+              compileConfiguredBinding: ({ conversationId }) =>
+                normalizeIMessageAcpConversationId(conversationId),
+              matchInboundConversation: ({ compiledBinding, conversationId }) =>
+                matchIMessageAcpConversation({
+                  bindingConversationId: compiledBinding.conversationId,
+                  conversationId,
+                }),
+            } satisfies NonNullable<ChannelPlugin["bindings"]>,
+          },
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("preserves configured ACP binding ownership for deferred target readiness", () => {
+    const result = resolveIMessageConversationRoute({
+      cfg: configuredCfg,
+      accountId: "default",
+      isGroup: false,
+      peerId: "+15555550123",
+      sender: "+15555550123",
+    });
+
+    expect(result.route.agentId).toBe("codex");
+    expect(result.bindingResolution?.record.conversation).toEqual({
+      channel: "imessage",
+      accountId: "default",
+      conversationId: "+15555550123",
+      parentConversationId: undefined,
+    });
+    expect(result.bindingResolution?.record.targetSessionKey).toBe(result.route.sessionKey);
   });
 
   it("lets runtime iMessage conversation bindings override default routing", () => {
@@ -45,17 +115,18 @@ describe("resolveIMessageConversationRoute", () => {
       touch,
     });
 
-    const route = resolveIMessageConversationRoute({
-      cfg: baseCfg,
+    const result = resolveIMessageConversationRoute({
+      cfg: configuredCfg,
       accountId: "default",
       isGroup: false,
       peerId: "+15555550123",
       sender: "+15555550123",
     });
 
-    expect(route.agentId).toBe("codex");
-    expect(route.sessionKey).toBe("agent:codex:acp:bound-1");
-    expect(route.matchedBy).toBe("binding.channel");
+    expect(result.route.agentId).toBe("codex");
+    expect(result.route.sessionKey).toBe("agent:codex:acp:bound-1");
+    expect(result.route.matchedBy).toBe("binding.channel");
+    expect(result.bindingResolution).toBeNull();
     expect(touch).toHaveBeenCalledWith("default:+15555550123", undefined);
   });
 });

--- a/extensions/imessage/src/conversation-route.ts
+++ b/extensions/imessage/src/conversation-route.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   resolveConfiguredBindingRoute,
   resolveRuntimeConversationBindingRoute,
+  type ConfiguredBindingRouteResult,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -15,8 +16,8 @@ export function resolveIMessageConversationRoute(params: {
   peerId: string;
   sender: string;
   chatId?: number;
-}): ReturnType<typeof resolveAgentRoute> {
-  let route = resolveAgentRoute({
+}): ConfiguredBindingRouteResult {
+  const route = resolveAgentRoute({
     cfg: params.cfg,
     channel: "imessage",
     accountId: params.accountId,
@@ -32,10 +33,10 @@ export function resolveIMessageConversationRoute(params: {
     chatId: params.chatId,
   });
   if (!conversationId) {
-    return route;
+    return { route, bindingResolution: null };
   }
 
-  route = resolveConfiguredBindingRoute({
+  const configuredRoute = resolveConfiguredBindingRoute({
     cfg: params.cfg,
     route,
     conversation: {
@@ -43,17 +44,16 @@ export function resolveIMessageConversationRoute(params: {
       accountId: params.accountId,
       conversationId,
     },
-  }).route;
+  });
 
   const runtimeRoute = resolveRuntimeConversationBindingRoute({
-    route,
+    route: configuredRoute.route,
     conversation: {
       channel: "imessage",
       accountId: params.accountId,
       conversationId,
     },
   });
-  route = runtimeRoute.route;
   if (runtimeRoute.bindingRecord && !runtimeRoute.boundSessionKey) {
     logVerbose(`imessage: plugin-bound conversation ${conversationId}`);
   } else if (runtimeRoute.boundSessionKey) {
@@ -61,5 +61,8 @@ export function resolveIMessageConversationRoute(params: {
       `imessage: routed via bound conversation ${conversationId} -> ${runtimeRoute.boundSessionKey}`,
     );
   }
-  return route;
+  return {
+    route: runtimeRoute.route,
+    bindingResolution: runtimeRoute.bindingRecord ? null : configuredRoute.bindingResolution,
+  };
 }

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -3,16 +3,31 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import * as channelInbound from "openclaw/plugin-sdk/channel-inbound";
 import { createTestInboundDebounceFlush } from "openclaw/plugin-sdk/channel-test-helpers";
-import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  recordInboundSession,
+  type ensureConfiguredBindingRouteReady,
+} from "openclaw/plugin-sdk/conversation-runtime";
+import {
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { dispatchReplyWithBufferedBlockDispatcher } from "openclaw/plugin-sdk/reply-runtime";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { createIMessageRpcClient } from "./client.js";
+import {
+  matchIMessageAcpConversation,
+  normalizeIMessageAcpConversationId,
+} from "./conversation-id.js";
 import { monitorIMessageProvider } from "./monitor.js";
+import * as iMessageMediaStaging from "./monitor/media-staging.js";
 import {
   advanceIMessageRecoveryCursor,
   loadIMessageRecoveryCursor,
@@ -47,6 +62,7 @@ type MonitorRunParams = {
   session?: Record<string, unknown>;
   messages?: Record<string, unknown>;
   agents?: Record<string, unknown>;
+  bindings?: OpenClawConfig["bindings"];
   runtime?: MonitorIMessageOpts["runtime"];
   allowlist?: boolean;
 };
@@ -144,6 +160,9 @@ const waitForTransportReadyMock = vi.hoisted(() =>
 );
 const createIMessageRpcClientMock = vi.hoisted(() => vi.fn<typeof createIMessageRpcClient>());
 const readChannelAllowFromStoreMock = vi.hoisted(() => vi.fn(async () => [] as string[]));
+const ensureConfiguredBindingRouteReadyMock = vi.hoisted(() =>
+  vi.fn<typeof ensureConfiguredBindingRouteReady>(async () => ({ ok: true })),
+);
 const dispatchReplyWithBufferedBlockDispatcherMock = vi.hoisted(() =>
   vi.fn<typeof dispatchReplyWithBufferedBlockDispatcher>(async () => ({
     queuedFinal: false,
@@ -207,6 +226,7 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
   return {
     ...actual,
+    ensureConfiguredBindingRouteReady: ensureConfiguredBindingRouteReadyMock,
     readChannelAllowFromStore: readChannelAllowFromStoreMock,
     upsertChannelPairingRequest: vi.fn(),
   };
@@ -268,6 +288,7 @@ describe("iMessage monitor last-route updates", () => {
     waitForTransportReadyMock.mockReset().mockResolvedValue(undefined);
     createIMessageRpcClientMock.mockReset();
     readChannelAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    ensureConfiguredBindingRouteReadyMock.mockReset().mockResolvedValue({ ok: true });
     dispatchReplyWithBufferedBlockDispatcherMock.mockClear();
     createChannelInboundDebouncerMock.mockClear();
     debouncerControl.reset();
@@ -276,6 +297,7 @@ describe("iMessage monitor last-route updates", () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    resetPluginRuntimeStateForTest();
     vi.useRealTimers();
     await Promise.all(openClawStates.splice(0).map((state) => state.cleanup()));
     vi.unstubAllEnvs();
@@ -574,6 +596,7 @@ describe("iMessage monitor last-route updates", () => {
         },
         messages: { inbound: { debounceMs: 0 }, ...params.messages },
         ...(params.agents ? { agents: params.agents } : {}),
+        ...(params.bindings ? { bindings: params.bindings } : {}),
         session: { mainKey: "main", ...params.session },
       } as never,
       runtime: params.runtime ?? { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
@@ -618,6 +641,150 @@ describe("iMessage monitor last-route updates", () => {
     await runIMessageMonitor(monitor);
     return client;
   }
+
+  function createConfiguredBindingMonitor(
+    overrides: Omit<MonitorRunParams, "bindings"> = {},
+  ): MonitorRunParams {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "imessage",
+          source: "test",
+          plugin: {
+            id: "imessage",
+            bindings: {
+              compileConfiguredBinding: ({ conversationId }) =>
+                normalizeIMessageAcpConversationId(conversationId),
+              matchInboundConversation: ({ compiledBinding, conversationId }) =>
+                matchIMessageAcpConversation({
+                  bindingConversationId: compiledBinding.conversationId,
+                  conversationId,
+                }),
+            } satisfies NonNullable<ChannelPlugin["bindings"]>,
+          },
+        },
+      ]),
+    );
+    return {
+      ...overrides,
+      agents: { list: [{ id: "main" }, { id: "codex" }] },
+      bindings: [
+        { agentId: "main", match: { channel: "imessage", accountId: "default" } },
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "imessage",
+            accountId: "default",
+            peer: { kind: "direct", id: DEFAULT_SENDER },
+          },
+        },
+      ],
+    };
+  }
+
+  it("waits for configured ACP target readiness before dispatching an authorized message", async () => {
+    let releaseReadiness: ((value: { ok: true }) => void) | undefined;
+    ensureConfiguredBindingRouteReadyMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseReadiness = resolve;
+        }),
+    );
+    createIMessageWatchClient({
+      onClose: async (notify) => {
+        notify(createInboundMessage({ id: 81, guid: "acp-ready-81", text: "start the agent" }));
+        await vi.waitFor(() => {
+          expect(ensureConfiguredBindingRouteReadyMock).toHaveBeenCalledTimes(1);
+        });
+        expect(dispatchReplyWithBufferedBlockDispatcherMock).not.toHaveBeenCalled();
+        releaseReadiness?.({ ok: true });
+        await vi.waitFor(() => {
+          expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(1);
+        });
+      },
+    });
+
+    await runIMessageMonitor(createConfiguredBindingMonitor());
+
+    expect(ensureConfiguredBindingRouteReadyMock).toHaveBeenCalledWith({
+      cfg: expect.any(Object),
+      bindingResolution: expect.objectContaining({
+        record: expect.objectContaining({
+          conversation: expect.objectContaining({
+            channel: "imessage",
+            accountId: "default",
+            conversationId: DEFAULT_SENDER,
+          }),
+        }),
+      }),
+    });
+    expect(ensureConfiguredBindingRouteReadyMock.mock.invocationCallOrder[0]).toBeLessThan(
+      dispatchReplyWithBufferedBlockDispatcherMock.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("drops unavailable configured ACP messages before typing, reads, media, history, or dispatch", async () => {
+    setAvailablePrivateApiMethods(["watch.subscribe", "typing", "read"]);
+    const stageAttachments = vi.spyOn(iMessageMediaStaging, "stageIMessageAttachments");
+    ensureConfiguredBindingRouteReadyMock.mockResolvedValueOnce({
+      ok: false,
+      error: "ACP backend unavailable",
+    });
+    const runtime = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
+    const stateDir = createTestStateDir("openclaw-imsg-acp-readiness-effects-");
+
+    const client = await runMessageCase({
+      requests: {
+        "watch.subscribe": { subscription: 1 },
+        "messages.history": { messages: [] },
+      },
+      auxiliaryRequests: { typing: { ok: true }, read: { ok: true } },
+      message: {
+        ...createInboundMessage({ id: 82, guid: "acp-failed-82", text: "start the agent" }),
+        attachments: [{ mime_type: "image/png", missing: true }],
+      },
+      monitor: createConfiguredBindingMonitor({
+        runtime,
+        imessage: { includeAttachments: true, dmHistoryLimit: 3 },
+        session: { dmScope: "per-channel-peer", store: path.join(stateDir, "sessions.json") },
+      }),
+    });
+
+    expect(ensureConfiguredBindingRouteReadyMock).toHaveBeenCalledTimes(1);
+    expect({
+      nativeEffects: client.auxiliaryClient!.request.mock.calls.map(([method]) => method),
+      historyLoads: client.request.mock.calls.filter(([method]) => method === "messages.history")
+        .length,
+      mediaLoads: stageAttachments.mock.calls.length,
+      dispatches: dispatchReplyWithBufferedBlockDispatcherMock.mock.calls.length,
+    }).toEqual({ nativeEffects: [], historyLoads: 0, mediaLoads: 0, dispatches: 0 });
+    expect([...runtime.error.mock.calls, ...runtime.log.mock.calls].flat()).toContainEqual(
+      expect.stringContaining("ACP backend unavailable"),
+    );
+  });
+
+  it("does not provision configured ACP targets for unauthorized or reflected messages", async () => {
+    await runMessageCase({
+      messages: [
+        createInboundMessage({
+          id: 83,
+          guid: "acp-unauthorized-83",
+          sender: "+15550009999",
+          text: "unauthorized sender",
+        }),
+        createInboundMessage({
+          id: 84,
+          guid: "acp-reflected-84",
+          text: "<thinking>echoed internal content</thinking>",
+        }),
+      ],
+      monitor: createConfiguredBindingMonitor(),
+    });
+
+    expect(ensureConfiguredBindingRouteReadyMock).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcherMock).not.toHaveBeenCalled();
+  });
 
   function expectWatchSubscription(
     client: ReturnType<typeof createIMessageWatchClient>,

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -29,6 +29,7 @@ import {
 import { hasControlCommand } from "openclaw/plugin-sdk/command-auth-native";
 import type { DmPolicy, GroupPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context-visibility-runtime";
+import type { ConfiguredBindingRouteResult } from "openclaw/plugin-sdk/conversation-runtime";
 import { createChannelHistoryWindow, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -361,6 +362,7 @@ type IMessageInboundDispatchDecision = {
   sender: string;
   senderNormalized: string;
   route: ReturnType<typeof resolveAgentRoute>;
+  bindingResolution?: ConfiguredBindingRouteResult["bindingResolution"];
   bodyText: string;
   agentBodyText?: string;
   createdAt?: number;
@@ -540,7 +542,7 @@ export async function resolveIMessageInboundDecision(params: {
   const groupAllowFromForAccess = isGroup
     ? groupAllowFromWithLegacyChatTargets
     : params.groupAllowFrom;
-  const route = resolveIMessageConversationRoute({
+  const { route, bindingResolution } = resolveIMessageConversationRoute({
     cfg: params.cfg,
     accountId: params.accountId,
     isGroup,
@@ -879,6 +881,7 @@ export async function resolveIMessageInboundDecision(params: {
     sender,
     senderNormalized,
     route,
+    bindingResolution,
     bodyText,
     createdAt,
     replyContext: filteredReplyContext,

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -21,6 +21,7 @@ import {
 import { createChannelPairingChallengeIssuer } from "openclaw/plugin-sdk/channel-pairing";
 import { registerChannelRuntimeContext } from "openclaw/plugin-sdk/channel-runtime-context";
 import {
+  ensureConfiguredBindingRouteReady,
   readChannelAllowFromStore,
   upsertChannelPairingRequest,
 } from "openclaw/plugin-sdk/conversation-runtime";
@@ -911,6 +912,19 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       }
       enqueueIMessageReactionSystemEvent({ decision, runtime, logVerbose });
       return;
+    }
+
+    if (decision.bindingResolution) {
+      const readiness = await ensureConfiguredBindingRouteReady({
+        cfg,
+        bindingResolution: decision.bindingResolution,
+      });
+      if (!readiness.ok) {
+        runtime.error?.(
+          `imessage: dropped inbound message; configured ACP binding unavailable for ${decision.bindingResolution.record.conversation.conversationId}: ${readiness.error}`,
+        );
+        return;
+      }
     }
 
     const storePath = resolveStorePath(cfg.session?.store, {

--- a/extensions/imessage/src/test-plugin.test.ts
+++ b/extensions/imessage/src/test-plugin.test.ts
@@ -15,6 +15,7 @@ import {
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
+import { getSessionBindingService } from "openclaw/plugin-sdk/session-binding-runtime";
 import { withStateDirEnv } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -121,6 +122,55 @@ describe("imessagePlugin contracts", () => {
         normalized: "auto:AliceSmith",
       }),
     ).resolves.toMatchObject({ kind: "user", to: "auto:AliceSmith" });
+  });
+
+  it("keeps account-prefixed conversation bindings and opaque metadata across manager recreation", async () => {
+    await withStateDirEnv("openclaw-imessage-conversation-binding-", async () => {
+      const createManager = imessagePlugin.conversationBindings?.createManager;
+      expect(createManager).toBeTypeOf("function");
+      if (!createManager) {
+        throw new Error("iMessage conversation binding manager is unavailable");
+      }
+
+      const cfg = {
+        channels: { imessage: { accounts: { default: {} } } },
+      } satisfies OpenClawConfig;
+      const conversation = {
+        channel: "imessage",
+        accountId: "default",
+        conversationId: "+15555550999",
+      };
+      const opaqueMetadata = {
+        label: "persisted iMessage binding",
+        opaque: { owner: "channel", flags: ["durable", "account-scoped"] },
+      };
+      let manager = await createManager({ cfg, accountId: "default" });
+
+      try {
+        const binding = await getSessionBindingService().bind({
+          conversation,
+          targetKind: "session",
+          targetSessionKey: "agent:main:acp:imessage-durable",
+          placement: "current",
+          metadata: opaqueMetadata,
+        });
+
+        expect(binding.bindingId).toBe("default:+15555550999");
+        expect(binding.metadata).toMatchObject(opaqueMetadata);
+
+        await manager.stop();
+        manager = await createManager({ cfg, accountId: "default" });
+
+        expect(getSessionBindingService().resolveByConversation(conversation)).toMatchObject({
+          bindingId: binding.bindingId,
+          targetKind: "session",
+          targetSessionKey: binding.targetSessionKey,
+          metadata: opaqueMetadata,
+        });
+      } finally {
+        await manager.stop();
+      }
+    });
   });
 
   it("declares durable final delivery capabilities", () => {

--- a/packages/acp-core/src/runtime/types.ts
+++ b/packages/acp-core/src/runtime/types.ts
@@ -210,6 +210,8 @@ export type AcpRuntimeTurnResult =
 
 export interface AcpRuntimeTurn {
   readonly requestId: string;
+  /** Resolves when the backend has submitted this prompt; older third-party runtimes may omit it. */
+  readonly promptStarted?: Promise<void>;
   readonly events: AsyncIterable<AcpRuntimeEvent>;
   readonly result: Promise<AcpRuntimeTurnResult>;
   /** Requests backend cancellation while keeping result/error reporting adapter-owned. */

--- a/packages/acp-core/src/session.test.ts
+++ b/packages/acp-core/src/session.test.ts
@@ -43,6 +43,29 @@ describe("acp session manager", () => {
     expect(store.getSessionByRunId("run-new")?.sessionId).toBe(session.sessionId);
   });
 
+  it.each(["clear", "cancel"] as const)(
+    "does not let stale %s ownership remove a replacement run",
+    (operation) => {
+      const session = store.createSession({
+        sessionKey: "acp:replacement",
+        cwd: "/tmp",
+      });
+      store.setActiveRun(session.sessionId, "run-old", new AbortController());
+      const replacementController = new AbortController();
+      store.setActiveRun(session.sessionId, "run-new", replacementController);
+
+      if (operation === "clear") {
+        store.clearActiveRun(session.sessionId, "run-old");
+      } else {
+        expect(store.cancelActiveRun(session.sessionId, "run-old")).toBe(false);
+      }
+
+      expect(session.activeRunId).toBe("run-new");
+      expect(replacementController.signal.aborted).toBe(false);
+      expect(store.getSessionByRunId("run-new")?.sessionId).toBe(session.sessionId);
+    },
+  );
+
   it("deletes sessions and aborts active runs on close", () => {
     const session = store.createSession({
       sessionId: "close-me",

--- a/packages/acp-core/src/session.ts
+++ b/packages/acp-core/src/session.ts
@@ -16,8 +16,8 @@ export type AcpSessionStore = {
   getSessionByRunId: (runId: string) => AcpSession | undefined;
   /** Binds an active runtime run to a session so cancel/close can abort it later. */
   setActiveRun: (sessionId: string, runId: string, abortController: AbortController) => void;
-  clearActiveRun: (sessionId: string) => void;
-  cancelActiveRun: (sessionId: string) => boolean;
+  clearActiveRun: (sessionId: string, expectedRunId?: string) => void;
+  cancelActiveRun: (sessionId: string, expectedRunId?: string) => boolean;
   deleteSession: (sessionId: string) => boolean;
 };
 
@@ -165,9 +165,9 @@ export function createInMemorySessionStore(
     touchSession(session, now());
   };
 
-  const clearActiveRun: AcpSessionStore["clearActiveRun"] = (sessionId) => {
+  const clearActiveRun: AcpSessionStore["clearActiveRun"] = (sessionId, expectedRunId) => {
     const session = sessions.get(sessionId);
-    if (!session) {
+    if (!session || (expectedRunId !== undefined && session.activeRunId !== expectedRunId)) {
       return;
     }
     if (session.activeRunId) {
@@ -178,9 +178,12 @@ export function createInMemorySessionStore(
     touchSession(session, now());
   };
 
-  const cancelActiveRun: AcpSessionStore["cancelActiveRun"] = (sessionId) => {
+  const cancelActiveRun: AcpSessionStore["cancelActiveRun"] = (sessionId, expectedRunId) => {
     const session = sessions.get(sessionId);
-    if (!session?.abortController) {
+    if (
+      !session?.abortController ||
+      (expectedRunId !== undefined && session.activeRunId !== expectedRunId)
+    ) {
       return false;
     }
     session.abortController.abort();

--- a/src/acp/control-plane/manager.backend-failover.test.ts
+++ b/src/acp/control-plane/manager.backend-failover.test.ts
@@ -32,6 +32,7 @@ describe("ACP manager backend failover helpers", () => {
         backend: "primary",
         code: "ACP_TURN_FAILED",
         error: "backend temporarily overloaded",
+        promptStarted: false,
         sawOutput: false,
       }),
     ).toBe(true);
@@ -40,6 +41,7 @@ describe("ACP manager backend failover helpers", () => {
         backend: "primary",
         code: "ACP_TURN_FAILED",
         error: "backend temporarily overloaded",
+        promptStarted: false,
         sawOutput: true,
       }),
     ).toBe(false);
@@ -48,6 +50,16 @@ describe("ACP manager backend failover helpers", () => {
         backend: "primary",
         code: "ACP_BACKEND_MISSING",
         error: "backend unavailable",
+        promptStarted: false,
+        sawOutput: false,
+      }),
+    ).toBe(false);
+    expect(
+      isFailoverWorthyBackendError({
+        backend: "primary",
+        code: "ACP_TURN_FAILED",
+        error: "backend temporarily overloaded",
+        promptStarted: true,
         sawOutput: false,
       }),
     ).toBe(false);

--- a/src/acp/control-plane/manager.backend-failover.ts
+++ b/src/acp/control-plane/manager.backend-failover.ts
@@ -7,6 +7,7 @@ export type BackendAttempt = {
   backend: string;
   error: string;
   code: AcpRuntimeErrorCode;
+  promptStarted: boolean;
   sawOutput: boolean;
 };
 
@@ -41,6 +42,7 @@ export function resolveBackendCandidatePlan(params: {
 /** Returns true for early transient backend errors where trying another backend is safe. */
 export function isFailoverWorthyBackendError(attempt: BackendAttempt): boolean {
   return (
+    !attempt.promptStarted &&
     !attempt.sawOutput &&
     (attempt.code === "ACP_TURN_FAILED" ||
       attempt.code === "ACP_SESSION_INIT_FAILED" ||

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -386,6 +386,7 @@ export class AcpSessionManager {
     cfg: OpenClawConfig;
     sessionKey: string;
     meta: SessionAcpMeta;
+    selectedBackend?: string;
   }): Promise<{ runtime: AcpRuntime; handle: AcpRuntimeHandle; meta: SessionAcpMeta }> {
     return await ensureManagerRuntimeHandle({
       ...params,

--- a/src/acp/control-plane/manager.failover.test.ts
+++ b/src/acp/control-plane/manager.failover.test.ts
@@ -1,5 +1,5 @@
 /** Tests ACP manager backend failover across initialization and turn execution. */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionAcpMeta } from "../../config/sessions/types.js";
 import {
@@ -234,6 +234,81 @@ describe("AcpSessionManager backend failover", () => {
 
     expect(harness.primaryRuntime.runTurn).toHaveBeenCalledTimes(1);
     expect(harness.fallbackRuntime.runTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fail over after prompt submission even when no output was emitted", async () => {
+    const harness = setupFailoverBackends();
+    const startTurn = vi.fn<NonNullable<typeof harness.primaryRuntime.runtime.startTurn>>(
+      (input) => ({
+        requestId: input.requestId,
+        promptStarted: Promise.resolve(),
+        events: (async function* () {})(),
+        result: Promise.resolve({
+          status: "failed" as const,
+          error: { code: "ACP_TURN_FAILED", message: "backend unavailable" },
+        }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      }),
+    );
+    harness.primaryRuntime.runtime.startTurn = startTurn;
+
+    await expect(
+      new AcpSessionManager().runTurn({
+        provenance: "system",
+        cfg: harness.cfg,
+        sessionKey: harness.sessionKey,
+        text: "do not replay submitted prompt",
+        mode: "prompt",
+        requestId: "r-submitted-no-failover",
+      }),
+    ).rejects.toMatchObject({ code: "ACP_TURN_FAILED", message: "backend unavailable" });
+
+    expect(startTurn).toHaveBeenCalledOnce();
+    expect(harness.fallbackRuntime.runTurn).not.toHaveBeenCalled();
+  });
+
+  it("fails over only after rejected prompt readiness reaches canonical terminal cleanup", async () => {
+    const harness = setupFailoverBackends();
+    const transitions: string[] = [];
+    const readinessFailure = new Error("backend unavailable");
+    const promptStarted = Promise.reject(readinessFailure);
+    promptStarted.catch(() => {});
+    harness.primaryRuntime.runtime.startTurn = vi.fn((input) => ({
+      requestId: input.requestId,
+      promptStarted,
+      events: (async function* () {})(),
+      result: Promise.resolve().then(() => {
+        transitions.push("primary-cleaned-up");
+        return {
+          status: "failed" as const,
+          error: { code: "ACP_TURN_FAILED", message: "backend unavailable" },
+        };
+      }),
+      cancel: vi.fn(async () => {}),
+      closeStream: vi.fn(async () => {}),
+    }));
+    harness.fallbackRuntime.runTurn.mockImplementation(async function* () {
+      transitions.push("fallback-started");
+      yield { type: "done" as const };
+    });
+    const lifecycleEvents: string[] = [];
+
+    await new AcpSessionManager().runTurn({
+      provenance: "system",
+      cfg: harness.cfg,
+      sessionKey: harness.sessionKey,
+      text: "fail over an unsubmitted prompt",
+      mode: "prompt",
+      requestId: "r-unsubmitted-failover",
+      onLifecycle: (event) => {
+        lifecycleEvents.push(event.type);
+      },
+    });
+
+    expect(transitions).toEqual(["primary-cleaned-up", "fallback-started"]);
+    expect(lifecycleEvents).toEqual(["prompt_submitted"]);
+    expect(harness.fallbackRuntime.runTurn).toHaveBeenCalledOnce();
   });
 
   it("does not fail over after a backend has emitted output", async () => {

--- a/src/acp/control-plane/manager.runtime-handle-ensure.ts
+++ b/src/acp/control-plane/manager.runtime-handle-ensure.ts
@@ -32,6 +32,7 @@ export async function ensureManagerRuntimeHandle(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   meta: SessionAcpMeta;
+  selectedBackend?: string;
   deps: Pick<AcpSessionManagerDeps, "requireRuntimeBackend">;
   runtimeHandles: ManagerRuntimeHandleCache;
   enforceConcurrentSessionLimit: (params: { cfg: OpenClawConfig; sessionKey: string }) => void;
@@ -44,7 +45,12 @@ export async function ensureManagerRuntimeHandle(params: {
   const cwd = runtimeOptions.cwd ?? normalizeText(params.meta.cwd);
   const model = normalizeText(runtimeOptions.model);
   const thinking = normalizeText(runtimeOptions.thinking);
-  const configuredBackend = (params.meta.backend || params.cfg.acp?.backend || "").trim();
+  const configuredBackend = (
+    params.selectedBackend ||
+    params.meta.backend ||
+    params.cfg.acp?.backend ||
+    ""
+  ).trim();
   const configSignature = resolveRuntimeConfigCacheKey(params.cfg);
   const cached = params.runtimeHandles.get(params.sessionKey);
   if (cached) {
@@ -90,7 +96,10 @@ export async function ensureManagerRuntimeHandle(params: {
   const backend = params.deps.requireRuntimeBackend(configuredBackend || undefined);
   const runtime = backend.runtime;
   const previousMeta = params.meta;
-  const previousIdentity = resolveSessionIdentityFromMeta(previousMeta);
+  const persistedIdentity = resolveSessionIdentityFromMeta(previousMeta);
+  // Identifiers belong to their persisted backend; a new backend may recover its own named session.
+  const backendOwnsPreviousIdentity = previousMeta.backend === backend.id;
+  const previousIdentity = backendOwnsPreviousIdentity ? persistedIdentity : undefined;
   let identityForEnsure = previousIdentity;
   const persistedResumeSessionId =
     mode === "persistent" ? resolveRuntimeResumeSessionId(previousIdentity) : undefined;
@@ -193,7 +202,7 @@ export async function ensureManagerRuntimeHandle(params: {
   const shouldPersistMeta =
     previousMeta.backend !== nextMeta.backend ||
     previousMeta.runtimeSessionName !== nextMeta.runtimeSessionName ||
-    !identityEquals(previousIdentity, nextIdentity) ||
+    !identityEquals(persistedIdentity, nextIdentity) ||
     previousMeta.agent !== nextMeta.agent ||
     previousMeta.cwd !== nextMeta.cwd ||
     !runtimeOptionsEqual(previousMeta.runtimeOptions, nextMeta.runtimeOptions) ||

--- a/src/acp/control-plane/manager.runtime-handles.test.ts
+++ b/src/acp/control-plane/manager.runtime-handles.test.ts
@@ -18,6 +18,30 @@ import {
 describe("AcpSessionManager runtime handles", () => {
   installAcpSessionManagerTestLifecycle();
 
+  function installPersistedSession(sessionKey: string, initialMeta: SessionAcpMeta) {
+    let currentMeta = initialMeta;
+    hoisted.readAcpSessionEntryMock.mockImplementation(() => ({
+      sessionKey,
+      storeSessionKey: sessionKey,
+      acp: currentMeta,
+    }));
+    hoisted.upsertAcpSessionMetaMock.mockImplementation(async (paramsUnknown: unknown) => {
+      const params = paramsUnknown as {
+        mutate: (
+          current: SessionAcpMeta | undefined,
+          entry: { acp?: SessionAcpMeta } | undefined,
+        ) => SessionAcpMeta | null | undefined;
+      };
+      currentMeta = params.mutate(currentMeta, { acp: currentMeta }) ?? currentMeta;
+      return { sessionId: "session-1", updatedAt: Date.now(), acp: currentMeta };
+    });
+    return {
+      get currentMeta() {
+        return currentMeta;
+      },
+    };
+  }
+
   it("reuses runtime session handles for repeat turns in the same manager process", async () => {
     const runtimeState = createRuntime();
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
@@ -423,6 +447,248 @@ describe("AcpSessionManager runtime handles", () => {
       agent: "codex",
       resumeSessionId: "acpx-sid-1",
     });
+    expect(runtimeState.prepareFreshSession).not.toHaveBeenCalled();
+  });
+
+  it("never resumes or merges another backend's persisted session identity when returning to the primary", async () => {
+    const primaryRuntime = createRuntime();
+    primaryRuntime.ensureSession.mockImplementation(async (input) => ({
+      sessionKey: input.sessionKey,
+      backend: "primary-backend",
+      runtimeSessionName: "primary-runtime",
+      acpxRecordId: "primary-record",
+      backendSessionId: "primary-session",
+    }));
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "primary-backend",
+      runtime: primaryRuntime.runtime,
+    });
+    const sessionKey = "agent:codex:acp:binding:backend-transition";
+    const persisted = installPersistedSession(
+      sessionKey,
+      readySessionMeta({
+        backend: "fallback-backend",
+        runtimeSessionName: "fallback-runtime",
+        identity: {
+          state: "resolved",
+          source: "status",
+          acpxRecordId: "fallback-record",
+          acpxSessionId: "fallback-session",
+          agentSessionId: "fallback-agent-session",
+          lastUpdatedAt: Date.now(),
+        },
+      }),
+    );
+    const cfg = {
+      acp: { ...baseCfg.acp, backend: "primary-backend", fallbacks: ["fallback-backend"] },
+    } satisfies OpenClawConfig;
+
+    await new AcpSessionManager().runTurn({
+      provenance: "system",
+      cfg,
+      sessionKey,
+      text: "return to primary",
+      mode: "prompt",
+      requestId: "r-return-primary",
+    });
+
+    expect(mockCallArg(primaryRuntime.ensureSession).resumeSessionId).toBeUndefined();
+    expect(primaryRuntime.prepareFreshSession).not.toHaveBeenCalled();
+    expect(mockCallArg(primaryRuntime.runTurn).handle).toEqual(
+      expect.objectContaining({
+        acpxRecordId: "primary-record",
+        backendSessionId: "primary-session",
+      }),
+    );
+    expect(mockCallArg(primaryRuntime.runTurn).handle).not.toHaveProperty("agentSessionId");
+    expect(persisted.currentMeta.backend).toBe("primary-backend");
+    expect(persisted.currentMeta.identity).toEqual(
+      expect.objectContaining({
+        acpxRecordId: "primary-record",
+        acpxSessionId: "primary-session",
+      }),
+    );
+    expect(persisted.currentMeta.identity).not.toHaveProperty("agentSessionId");
+  });
+
+  it("recovers a destination-owned named session during failover without crossing source identity", async () => {
+    const fallbackRuntime = createRuntime();
+    fallbackRuntime.ensureSession.mockImplementation(async (input) => ({
+      sessionKey: input.sessionKey,
+      backend: "fallback-backend",
+      runtimeSessionName: "fallback-recovered-runtime",
+      acpxRecordId: "fallback-recovered-record",
+      backendSessionId: "fallback-recovered-session",
+    }));
+    hoisted.requireAcpRuntimeBackendMock.mockImplementation((backendId?: string) => {
+      if (backendId === "primary-backend") {
+        throw new AcpRuntimeError("ACP_BACKEND_UNAVAILABLE", "primary backend unavailable");
+      }
+      if (backendId === "fallback-backend") {
+        return { id: backendId, runtime: fallbackRuntime.runtime };
+      }
+      throw new Error(`unexpected backend ${backendId ?? "<auto>"}`);
+    });
+    const sessionKey = "agent:codex:acp:binding:backend-failover";
+    const persisted = installPersistedSession(
+      sessionKey,
+      readySessionMeta({
+        backend: "primary-backend",
+        runtimeSessionName: "primary-runtime",
+        identity: {
+          state: "resolved",
+          source: "status",
+          acpxRecordId: "primary-record",
+          acpxSessionId: "primary-session",
+          agentSessionId: "primary-agent-session",
+          lastUpdatedAt: Date.now(),
+        },
+      }),
+    );
+    const cfg = {
+      acp: { ...baseCfg.acp, backend: "primary-backend", fallbacks: ["fallback-backend"] },
+    } satisfies OpenClawConfig;
+
+    await new AcpSessionManager().runTurn({
+      provenance: "system",
+      cfg,
+      sessionKey,
+      text: "fail over",
+      mode: "prompt",
+      requestId: "r-backend-failover",
+    });
+
+    expect(fallbackRuntime.prepareFreshSession).not.toHaveBeenCalled();
+    expect(mockCallArg(fallbackRuntime.ensureSession).resumeSessionId).toBeUndefined();
+    expect(mockCallArg(fallbackRuntime.runTurn).handle).toEqual(
+      expect.objectContaining({
+        acpxRecordId: "fallback-recovered-record",
+        backendSessionId: "fallback-recovered-session",
+      }),
+    );
+    expect(mockCallArg(fallbackRuntime.runTurn).handle).not.toHaveProperty("agentSessionId");
+    expect(persisted.currentMeta.backend).toBe("fallback-backend");
+    expect(persisted.currentMeta.identity).toEqual(
+      expect.objectContaining({
+        acpxRecordId: "fallback-recovered-record",
+        acpxSessionId: "fallback-recovered-session",
+      }),
+    );
+    expect(persisted.currentMeta.identity).not.toHaveProperty("agentSessionId");
+    expect(persisted.currentMeta.runtimeSessionName).toBe("fallback-recovered-runtime");
+  });
+
+  it.each([
+    { label: "no identifiers", identifiers: {}, expectedIdentity: undefined },
+    {
+      label: "only a record identifier",
+      identifiers: { acpxRecordId: "destination-record" },
+      expectedIdentity: { acpxRecordId: "destination-record" },
+    },
+    {
+      label: "only a backend session identifier",
+      identifiers: { backendSessionId: "destination-session" },
+      expectedIdentity: { acpxSessionId: "destination-session" },
+    },
+  ])("does not resurrect source identity when the destination reports $label", async (testCase) => {
+    const destinationRuntime = createRuntime();
+    destinationRuntime.ensureSession.mockImplementation(async (input) => ({
+      sessionKey: input.sessionKey,
+      backend: "primary-backend",
+      runtimeSessionName: "destination-runtime",
+      ...testCase.identifiers,
+    }));
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "primary-backend",
+      runtime: destinationRuntime.runtime,
+    });
+    const sessionKey = "agent:codex:acp:binding:destination-partial-identity";
+    const persisted = installPersistedSession(
+      sessionKey,
+      readySessionMeta({
+        backend: "fallback-backend",
+        runtimeSessionName: "source-runtime",
+        identity: {
+          state: "resolved",
+          source: "status",
+          acpxRecordId: "source-record",
+          acpxSessionId: "source-session",
+          agentSessionId: "source-agent-session",
+          lastUpdatedAt: Date.now(),
+        },
+      }),
+    );
+
+    await new AcpSessionManager().runTurn({
+      provenance: "system",
+      cfg: { acp: { ...baseCfg.acp, backend: "primary-backend" } },
+      sessionKey,
+      text: "recover destination identity",
+      mode: "prompt",
+      requestId: `r-destination-${testCase.label.replaceAll(" ", "-")}`,
+    });
+
+    expect(destinationRuntime.prepareFreshSession).not.toHaveBeenCalled();
+    expect(mockCallArg(destinationRuntime.ensureSession).resumeSessionId).toBeUndefined();
+    expect(mockCallArg(destinationRuntime.runTurn).handle).not.toHaveProperty("agentSessionId");
+    expect(persisted.currentMeta.backend).toBe("primary-backend");
+    expect(persisted.currentMeta.runtimeSessionName).toBe("destination-runtime");
+    if (testCase.expectedIdentity) {
+      expect(persisted.currentMeta.identity).toEqual(
+        expect.objectContaining(testCase.expectedIdentity),
+      );
+      expect(persisted.currentMeta.identity).not.toHaveProperty("agentSessionId");
+    } else {
+      expect(persisted.currentMeta.identity).toBeUndefined();
+    }
+  });
+
+  it("preserves the persisted backend owner and identity when destination initialization fails", async () => {
+    const destinationRuntime = createRuntime();
+    const sessionKey = "agent:codex:acp:binding:destination-init-failure";
+    const sourceIdentity = {
+      state: "resolved" as const,
+      source: "status" as const,
+      acpxRecordId: "source-record",
+      acpxSessionId: "source-session",
+      agentSessionId: "source-agent-session",
+      lastUpdatedAt: Date.now(),
+    };
+    const persisted = installPersistedSession(
+      sessionKey,
+      readySessionMeta({
+        backend: "fallback-backend",
+        runtimeSessionName: "source-runtime",
+        identity: sourceIdentity,
+      }),
+    );
+    destinationRuntime.ensureSession.mockImplementation(async () => {
+      expect(persisted.currentMeta.backend).toBe("fallback-backend");
+      expect(persisted.currentMeta.runtimeSessionName).toBe("source-runtime");
+      expect(persisted.currentMeta.identity).toEqual(sourceIdentity);
+      throw new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "destination unavailable");
+    });
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "primary-backend",
+      runtime: destinationRuntime.runtime,
+    });
+
+    await expect(
+      new AcpSessionManager().runTurn({
+        provenance: "system",
+        cfg: { acp: { ...baseCfg.acp, backend: "primary-backend" } },
+        sessionKey,
+        text: "leave source ownership intact",
+        mode: "prompt",
+        requestId: "r-destination-init-failure",
+      }),
+    ).rejects.toMatchObject({ code: "ACP_SESSION_INIT_FAILED" });
+
+    expect(destinationRuntime.prepareFreshSession).not.toHaveBeenCalled();
+    expect(mockCallArg(destinationRuntime.ensureSession).resumeSessionId).toBeUndefined();
+    expect(persisted.currentMeta.backend).toBe("fallback-backend");
+    expect(persisted.currentMeta.runtimeSessionName).toBe("source-runtime");
+    expect(persisted.currentMeta.identity).toEqual(sourceIdentity);
   });
 
   it("prefers the persisted agent session id when reopening an ACP runtime after restart", async () => {

--- a/src/acp/control-plane/manager.runtime-resume-state.ts
+++ b/src/acp/control-plane/manager.runtime-resume-state.ts
@@ -41,19 +41,20 @@ function isRecoverableMissingManagerPersistentSessionError(error: AcpRuntimeErro
   return false;
 }
 
-/** Prepares a one-time fresh-handle retry for recoverable pre-output runtime failures. */
+/** Prepares a one-time fresh-handle retry only before authoritative prompt submission. */
 export async function prepareFreshManagerRuntimeHandleRetry(params: {
   attempt: number;
   cfg: OpenClawConfig;
   sessionKey: string;
   error: AcpRuntimeError;
+  promptStarted: boolean;
   sawTurnOutput: boolean;
   runtime?: AcpRuntime;
   meta?: SessionAcpMeta;
   runtimeHandles: ManagerRuntimeHandleCache;
   writeSessionMeta: WriteManagerSessionMeta;
 }): Promise<boolean> {
-  if (params.attempt > 0 || params.sawTurnOutput) {
+  if (params.attempt > 0 || params.promptStarted || params.sawTurnOutput) {
     return false;
   }
   if (isRecoverableManagerAcpxExitError(params.error.message)) {

--- a/src/acp/control-plane/manager.turn-results.test.ts
+++ b/src/acp/control-plane/manager.turn-results.test.ts
@@ -25,6 +25,357 @@ import {
 describe("AcpSessionManager turn results", () => {
   installAcpSessionManagerTestLifecycle();
 
+  function setupPromptStartedRuntime() {
+    const runtimeState = createRuntime();
+    const sessionKey = "agent:codex:acp:session-1";
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey,
+      storeSessionKey: sessionKey,
+      acp: readySessionMeta(),
+    });
+    return { runtimeState, sessionKey };
+  }
+
+  it("emits prompt_submitted only after the runtime confirms prompt submission", async () => {
+    const { runtimeState, sessionKey } = setupPromptStartedRuntime();
+    const transitions: string[] = [];
+    runtimeState.runtime.startTurn = vi.fn((input) => {
+      transitions.push("turn-created");
+      const promptStarted = Promise.resolve().then(() => {
+        transitions.push("prompt-started");
+      });
+      return {
+        requestId: input.requestId,
+        promptStarted,
+        events: (async function* () {})(),
+        result: promptStarted.then(() => ({ status: "completed" as const })),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      };
+    });
+
+    await new AcpSessionManager().runTurn({
+      provenance: "system",
+      cfg: baseCfg,
+      sessionKey,
+      text: "submit once",
+      mode: "prompt",
+      requestId: "prompt-started-lifecycle",
+      onBeforePrompt: () => {
+        transitions.push("admission-accepted");
+      },
+      onLifecycle: () => {
+        transitions.push("prompt-submitted");
+      },
+    });
+
+    expect(transitions).toEqual([
+      "admission-accepted",
+      "turn-created",
+      "prompt-started",
+      "prompt-submitted",
+    ]);
+  });
+
+  it.each(["startTurn", "runTurn"] as const)(
+    "rejects expired gateway admission before calling runtime %s",
+    async (runtimeApi) => {
+      const { runtimeState, sessionKey } = setupPromptStartedRuntime();
+      const startTurn = vi.fn<NonNullable<typeof runtimeState.runtime.startTurn>>((input) => ({
+        requestId: input.requestId,
+        promptStarted: Promise.resolve(),
+        events: (async function* () {})(),
+        result: Promise.resolve({ status: "completed" as const }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      }));
+      if (runtimeApi === "startTurn") {
+        runtimeState.runtime.startTurn = startTurn;
+      }
+      const rejectExpiredAdmission = vi.fn(() => {
+        throw new Error("gateway admission deadline elapsed");
+      });
+
+      await expect(
+        new AcpSessionManager().runTurn({
+          provenance: "system",
+          cfg: baseCfg,
+          sessionKey,
+          text: "do not submit expired work",
+          mode: "prompt",
+          requestId: `expired-admission-${runtimeApi}`,
+          onBeforePrompt: rejectExpiredAdmission,
+        }),
+      ).rejects.toThrow("gateway admission deadline elapsed");
+
+      expect(rejectExpiredAdmission).toHaveBeenCalledOnce();
+      expect(startTurn).not.toHaveBeenCalled();
+      expect(runtimeState.runTurn).not.toHaveBeenCalled();
+    },
+  );
+
+  it("finishes submitted work when its lifecycle observer fails", async () => {
+    const { runtimeState, sessionKey } = setupPromptStartedRuntime();
+    const transitions: string[] = [];
+    let finishTurn!: (result: { status: "completed" }) => void;
+    const result = new Promise<{ status: "completed" }>((resolve) => {
+      finishTurn = resolve;
+    });
+    const startTurn = vi.fn<NonNullable<typeof runtimeState.runtime.startTurn>>((input) => ({
+      requestId: input.requestId,
+      promptStarted: Promise.resolve().then(() => {
+        transitions.push("prompt-started");
+      }),
+      events: (async function* () {})(),
+      result,
+      cancel: vi.fn(async () => {}),
+      closeStream: vi.fn(async () => {}),
+    }));
+    runtimeState.runtime.startTurn = startTurn;
+
+    await expect(
+      new AcpSessionManager().runTurn({
+        provenance: "system",
+        cfg: baseCfg,
+        sessionKey,
+        text: "finish submitted work",
+        mode: "prompt",
+        requestId: "prompt-started-observer-failure",
+        onLifecycle: () => {
+          transitions.push("observer-failed");
+          queueMicrotask(() => {
+            transitions.push("turn-cleaned-up");
+            finishTurn({ status: "completed" });
+          });
+          throw new Error("lifecycle observer unavailable");
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(transitions).toEqual(["prompt-started", "observer-failed", "turn-cleaned-up"]);
+    expect(startTurn).toHaveBeenCalledOnce();
+    expect(runtimeState.ensureSession).toHaveBeenCalledOnce();
+  });
+
+  it.each(["completed", "failed"] as const)(
+    "settles a %s terminal result when prompt readiness never resolves",
+    async (terminalStatus) => {
+      const { runtimeState, sessionKey } = setupPromptStartedRuntime();
+      let resolveAbandonedReadiness!: () => void;
+      const promptStarted = new Promise<void>((resolve) => {
+        resolveAbandonedReadiness = resolve;
+      });
+      const result =
+        terminalStatus === "completed"
+          ? { status: "completed" as const }
+          : {
+              status: "failed" as const,
+              error: { code: "ACP_TURN_FAILED", message: "terminal failure before submission" },
+            };
+      runtimeState.runtime.startTurn = vi.fn((input) => ({
+        requestId: input.requestId,
+        promptStarted,
+        events: (async function* () {})(),
+        result: Promise.resolve(result),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      }));
+      const onLifecycle = vi.fn();
+      const outcome = new AcpSessionManager()
+        .runTurn({
+          provenance: "system",
+          cfg: baseCfg,
+          sessionKey,
+          text: "settle terminal work without readiness",
+          mode: "prompt",
+          requestId: `pending-readiness-${terminalStatus}`,
+          onLifecycle,
+        })
+        .then(
+          () => ({ status: "completed" as const }),
+          (error: unknown) => ({ status: "failed" as const, error }),
+        );
+
+      try {
+        const observed = await Promise.race([
+          outcome,
+          new Promise<{ status: "pending" }>((resolve) => {
+            setTimeout(() => resolve({ status: "pending" }), 0);
+          }),
+        ]);
+
+        expect(observed.status).toBe(terminalStatus);
+        if (terminalStatus === "failed") {
+          expect(observed).toMatchObject({
+            error: { code: "ACP_TURN_FAILED", message: "terminal failure before submission" },
+          });
+        }
+        expect(onLifecycle).not.toHaveBeenCalled();
+
+        resolveAbandonedReadiness();
+        await Promise.resolve();
+        expect(onLifecycle).not.toHaveBeenCalled();
+        expect(runtimeState.ensureSession).toHaveBeenCalledOnce();
+      } finally {
+        resolveAbandonedReadiness();
+        await outcome;
+      }
+    },
+  );
+
+  it("retries cleaned-up terminal failures without publishing abandoned prompt readiness", async () => {
+    const { runtimeState, sessionKey } = setupPromptStartedRuntime();
+    let resolveAbandonedReadiness!: () => void;
+    const abandonedReadiness = new Promise<void>((resolve) => {
+      resolveAbandonedReadiness = resolve;
+    });
+    let attempt = 0;
+    const startTurn = vi.fn<NonNullable<typeof runtimeState.runtime.startTurn>>((input) => {
+      attempt += 1;
+      const firstAttempt = attempt === 1;
+      return {
+        requestId: input.requestId,
+        promptStarted: firstAttempt ? abandonedReadiness : Promise.resolve(),
+        events: (async function* () {})(),
+        result: Promise.resolve(
+          firstAttempt
+            ? {
+                status: "failed" as const,
+                error: { code: "ACP_TURN_FAILED", message: "acpx exited with code 1" },
+              }
+            : { status: "completed" as const },
+        ),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      };
+    });
+    runtimeState.runtime.startTurn = startTurn;
+    const onLifecycle = vi.fn();
+    const turn = new AcpSessionManager().runTurn({
+      provenance: "system",
+      cfg: baseCfg,
+      sessionKey,
+      text: "retry only terminally cleaned-up work",
+      mode: "prompt",
+      requestId: "pending-readiness-safe-retry",
+      onLifecycle,
+    });
+
+    try {
+      const outcome = await Promise.race([
+        turn.then(() => "completed" as const),
+        new Promise<"pending">((resolve) => {
+          setTimeout(() => resolve("pending"), 0);
+        }),
+      ]);
+
+      expect(outcome).toBe("completed");
+      expect(startTurn).toHaveBeenCalledTimes(2);
+      expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+      expect(onLifecycle).toHaveBeenCalledOnce();
+
+      resolveAbandonedReadiness();
+      await Promise.resolve();
+      expect(onLifecycle).toHaveBeenCalledOnce();
+    } finally {
+      resolveAbandonedReadiness();
+      await turn.catch(() => {});
+    }
+  });
+
+  it("does not retry a submitted prompt even when the runtime exits before producing output", async () => {
+    const { runtimeState, sessionKey } = setupPromptStartedRuntime();
+    const startTurn = vi.fn<NonNullable<typeof runtimeState.runtime.startTurn>>((input) => ({
+      requestId: input.requestId,
+      promptStarted: Promise.resolve(),
+      events: (async function* () {})(),
+      result: Promise.resolve({
+        status: "failed" as const,
+        error: { code: "ACP_TURN_FAILED", message: "acpx exited with code 1" },
+      }),
+      cancel: vi.fn(async () => {}),
+      closeStream: vi.fn(async () => {}),
+    }));
+    runtimeState.runtime.startTurn = startTurn;
+
+    await expect(
+      new AcpSessionManager().runTurn({
+        provenance: "system",
+        cfg: baseCfg,
+        sessionKey,
+        text: "never replay a submitted prompt",
+        mode: "prompt",
+        requestId: "prompt-started-no-retry",
+      }),
+    ).rejects.toMatchObject({ code: "ACP_TURN_FAILED", message: "acpx exited with code 1" });
+
+    expect(runtimeState.ensureSession).toHaveBeenCalledOnce();
+    expect(startTurn).toHaveBeenCalledOnce();
+  });
+
+  it("waits for rejected readiness cleanup before a fresh retry and only publishes the real submission", async () => {
+    const { runtimeState, sessionKey } = setupPromptStartedRuntime();
+    const transitions: string[] = [];
+    let attempt = 0;
+    runtimeState.runtime.startTurn = vi.fn((input) => {
+      attempt += 1;
+      const firstAttempt = attempt === 1;
+      transitions.push(firstAttempt ? "first-turn-created" : "retry-turn-created");
+      const promptStarted = firstAttempt
+        ? Promise.reject(new Error("acpx exited with code 1"))
+        : Promise.resolve().then(() => {
+            transitions.push("retry-prompt-started");
+          });
+      promptStarted.catch(() => {});
+      return {
+        requestId: input.requestId,
+        promptStarted,
+        events: (async function* () {})(),
+        result: firstAttempt
+          ? new Promise<{
+              status: "failed";
+              error: { code: string; message: string };
+            }>((resolve) => {
+              setTimeout(() => {
+                transitions.push("first-turn-cleaned-up");
+                resolve({
+                  status: "failed",
+                  error: { code: "ACP_TURN_FAILED", message: "acpx exited with code 1" },
+                });
+              }, 0);
+            })
+          : promptStarted.then(() => ({ status: "completed" as const })),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      };
+    });
+
+    await new AcpSessionManager().runTurn({
+      provenance: "system",
+      cfg: baseCfg,
+      sessionKey,
+      text: "retry only an unsubmitted prompt",
+      mode: "prompt",
+      requestId: "prompt-started-safe-retry",
+      onLifecycle: () => {
+        transitions.push("prompt-submitted");
+      },
+    });
+
+    expect(transitions).toEqual([
+      "first-turn-created",
+      "first-turn-cleaned-up",
+      "retry-turn-created",
+      "retry-prompt-started",
+      "prompt-submitted",
+    ]);
+    expect(runtimeState.ensureSession).toHaveBeenCalledTimes(2);
+  });
+
   it("uses startTurn terminal results instead of progress-only events for parented tasks", async () => {
     await withAcpManagerTaskStateDir(async () => {
       const runtimeState = createRuntime();

--- a/src/acp/control-plane/manager.turn-runner.ts
+++ b/src/acp/control-plane/manager.turn-runner.ts
@@ -195,9 +195,6 @@ export async function runManagerTurn(params: {
                 sessionKey,
               });
         const resolvedMeta = requireReadySessionMeta(resolution);
-        const metaWithBackend: SessionAcpMeta = currentBackend
-          ? { ...resolvedMeta, backend: currentBackend }
-          : resolvedMeta;
         let runtime: AcpRuntime | undefined;
         let handle: AcpRuntimeHandle | undefined;
         let meta: SessionAcpMeta | undefined;
@@ -205,6 +202,7 @@ export async function runManagerTurn(params: {
         let internalAbortController: AbortController | undefined;
         let onCallerAbort: (() => void) | undefined;
         let activeTurnStarted = false;
+        let promptStarted = false;
         let sawTurnOutput = false;
         let retryFreshHandle = false;
         let skipPostTurnCleanup = false;
@@ -212,7 +210,8 @@ export async function runManagerTurn(params: {
           const ensured = await params.ensureRuntimeHandle({
             cfg: input.cfg,
             sessionKey,
-            meta: metaWithBackend,
+            meta: resolvedMeta,
+            selectedBackend: currentBackend,
           });
           runtime = ensured.runtime;
           handle = ensured.handle;
@@ -253,10 +252,6 @@ export async function runManagerTurn(params: {
             ? AbortSignal.any([input.signal, internalAbortController.signal])
             : internalAbortController.signal;
           const eventGate = { open: true };
-          await input.onLifecycle?.({
-            type: "prompt_submitted",
-            at: Date.now(),
-          });
           const turnPromise = consumeAcpTurnStream({
             runtime,
             turn: {
@@ -269,6 +264,20 @@ export async function runManagerTurn(params: {
               onElicitation: input.onElicitation,
             },
             eventGate,
+            onBeforePrompt: input.onBeforePrompt,
+            onPromptStarted: async ({ authoritative }) => {
+              promptStarted = authoritative;
+              try {
+                await input.onLifecycle?.({
+                  type: "prompt_submitted",
+                  at: Date.now(),
+                });
+              } catch (error) {
+                logVerbose(
+                  `acp-manager: prompt submission observer failed for ${sessionKey}: ${String(error)}`,
+                );
+              }
+            },
             onOutputEvent: (event) => {
               sawTurnOutput = true;
               if (event.type === "text_delta" && event.stream !== "thought" && event.text) {
@@ -366,6 +375,7 @@ export async function runManagerTurn(params: {
             cfg: input.cfg,
             sessionKey,
             error: acpError,
+            promptStarted,
             sawTurnOutput,
             runtime,
             meta,
@@ -380,6 +390,7 @@ export async function runManagerTurn(params: {
             backend: describeBackendCandidate(currentBackend),
             error: acpError.message,
             code: acpError.code,
+            promptStarted,
             sawOutput: sawTurnOutput,
           };
           backendAttempts.push(backendAttempt);

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -121,14 +121,31 @@ export async function consumeAcpTurnStream(params: {
   runtime: AcpRuntime;
   turn: AcpRuntimeTurnInput;
   eventGate: AcpTurnEventGate;
+  onBeforePrompt?: () => Promise<void> | void;
+  onPromptStarted?: (params: { authoritative: boolean }) => Promise<void> | void;
   onEvent?: (event: AcpRuntimeEvent) => Promise<void> | void;
   onOutputEvent?: (
     event: Extract<AcpRuntimeEvent, { type: "text_delta" | "tool_call" }>,
   ) => Promise<void> | void;
 }): Promise<AcpTurnStreamOutcome> {
+  // Gateway admission can still close while runtime preparation is awaited.
+  if (params.onBeforePrompt) {
+    await params.onBeforePrompt();
+  }
   if (params.runtime.startTurn) {
-    // startTurn exposes result and event streams separately; coordinate both before reporting done.
+    // Submission readiness and terminal cleanup are independent backend-owned turn boundaries.
     const turn = params.runtime.startTurn(params.turn);
+    let promptReadinessOpen = true;
+    const readinessPromise = turn.promptStarted?.then(
+      async () => {
+        if (!promptReadinessOpen) {
+          return { kind: "prompt-start-closed" as const };
+        }
+        await params.onPromptStarted?.({ authoritative: true });
+        return { kind: "prompt-started" as const };
+      },
+      (error: unknown) => ({ kind: "prompt-start-error" as const, error }),
+    );
     const eventsPromise = consumeAcpTurnEvents({
       events: turn.events,
       eventGate: params.eventGate,
@@ -139,9 +156,30 @@ export async function consumeAcpTurnStream(params: {
       (error: unknown) => ({ kind: "event-error" as const, error }),
     );
     const resultPromise = turn.result.then(
-      (result) => ({ kind: "result" as const, result }),
-      (error: unknown) => ({ kind: "result-error" as const, error }),
+      (result) => {
+        promptReadinessOpen = false;
+        return { kind: "result" as const, result };
+      },
+      (error: unknown) => {
+        promptReadinessOpen = false;
+        return { kind: "result-error" as const, error };
+      },
     );
+
+    if (readinessPromise) {
+      const readiness = await Promise.race([readinessPromise, resultPromise]);
+      if (readiness.kind === "prompt-start-error") {
+        await turn.closeStream({ reason: "turn-prompt-start-error" }).catch(() => {});
+        // The canonical result settles only after backend persistence and client cleanup finish.
+        const terminalOutcome = await resultPromise;
+        if (terminalOutcome.kind === "result" && terminalOutcome.result.status === "completed") {
+          throw readiness.error;
+        }
+      }
+    } else {
+      // Third-party adapters predating readiness retain their existing output-based replay rules.
+      await params.onPromptStarted?.({ authoritative: false });
+    }
 
     let eventOutcome: AcpTurnStreamOutcome | null = null;
     let result: AcpRuntimeTurnResult | null = null;
@@ -198,8 +236,10 @@ export async function consumeAcpTurnStream(params: {
     };
   }
 
+  const events = params.runtime.runTurn(params.turn);
+  await params.onPromptStarted?.({ authoritative: false });
   return await consumeAcpTurnEvents({
-    events: params.runtime.runTurn(params.turn),
+    events,
     eventGate: params.eventGate,
     onEvent: params.onEvent,
     onOutputEvent: params.onOutputEvent,

--- a/src/acp/control-plane/manager.types.ts
+++ b/src/acp/control-plane/manager.types.ts
@@ -71,6 +71,8 @@ export type AcpRunTurnInput = {
   requestId: string;
   signal?: AbortSignal;
   onElicitation?: AcpElicitationHandler;
+  /** Throwable host admission fence immediately before runtime prompt submission. */
+  onBeforePrompt?: () => Promise<void> | void;
   onLifecycle?: (event: AcpTurnLifecycleEvent) => Promise<void> | void;
   onEvent?: (event: AcpRuntimeEvent) => Promise<void> | void;
 };
@@ -180,6 +182,7 @@ export type EnsureManagerRuntimeHandle = (params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   meta: SessionAcpMeta;
+  selectedBackend?: string;
 }) => Promise<{ runtime: AcpRuntime; handle: AcpRuntimeHandle; meta: SessionAcpMeta }>;
 
 export type ReconcileManagerRuntimeSessionIdentifiers = (params: {

--- a/src/acp/runtime/session-meta.test.ts
+++ b/src/acp/runtime/session-meta.test.ts
@@ -447,7 +447,15 @@ describe("ACP session metadata SQLite store", () => {
       const storedEntry = readStoredAcpSessionEntry({ storePath, sessionKey });
       expect(storedEntry?.sessionId).toEqual(expect.any(String));
       expect(storedEntry?.updatedAt).toEqual(expect.any(Number));
+      expect(storedEntry?.sessionStartedAt).toBeGreaterThan(200);
       expect(storedEntry?.acp).toBeUndefined();
+      expect(readAcpSessionEntry({ cfg, databasePath, sessionKey })?.acp?.runtimeSessionName).toBe(
+        "codex-new",
+      );
+      expect(readAcpSessionMeta({ cfg, databasePath, sessionKey })?.runtimeSessionName).toBe(
+        "codex-new",
+      );
+      expect(await listAcpSessionEntries({ cfg, databasePath })).toHaveLength(1);
     });
   });
 

--- a/src/acp/runtime/session-meta.ts
+++ b/src/acp/runtime/session-meta.ts
@@ -689,7 +689,7 @@ export async function upsertAcpSessionMeta(params: {
           sessionId: persisted.entry.sessionId,
           lifecycleRevision: persisted.entry.lifecycleRevision,
           meta: metaToPersist,
-          updatedAt,
+          updatedAt: persisted.entry.updatedAt,
         }),
       );
       if (persistedDatabaseSessionKey !== databaseSessionKey) {

--- a/src/acp/translator.cancel-scoping.test.ts
+++ b/src/acp/translator.cancel-scoping.test.ts
@@ -1,8 +1,13 @@
-import type { CancelNotification, PromptRequest, PromptResponse } from "@agentclientprotocol/sdk";
+import type {
+  AgentSideConnection,
+  CancelNotification,
+  PromptRequest,
+  PromptResponse,
+} from "@agentclientprotocol/sdk";
 import { createInMemorySessionStore } from "@openclaw/acp-core/session";
 /** Tests prompt cancellation scoping across concurrent ACP sessions and Gateway runs. */
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, type Mock, vi } from "vitest";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
 import type { GatewayClient } from "../gateway/client.js";
 import { AcpGatewayAgent } from "./translator.js";
@@ -10,8 +15,10 @@ import { createAcpConnection, createAcpGateway } from "./translator.test-helpers
 
 type Harness = {
   agent: AcpGatewayAgent;
-  requestSpy: ReturnType<typeof vi.fn>;
-  sessionUpdateSpy: ReturnType<typeof vi.fn>;
+  requestSpy: Mock<
+    (method: string, params?: Record<string, unknown>) => Promise<Record<string, unknown>>
+  >;
+  sessionUpdateSpy: Mock<AgentSideConnection["sessionUpdate"]>;
   sessionStore: ReturnType<typeof createInMemorySessionStore>;
   sentRunIds: string[];
 };
@@ -50,7 +57,10 @@ function createToolEvent(payload: Record<string, unknown>): EventFrame {
   } as EventFrame;
 }
 
-function createHarness(sessions: Array<{ sessionId: string; sessionKey: string }>): Harness {
+function createHarness(
+  sessions: Array<{ sessionId: string; sessionKey: string }>,
+  options: { provenanceMode?: "meta" | "meta+receipt" } = {},
+): Harness {
   const sentRunIds: string[] = [];
   const requestSpy = vi.fn(async (method: string, params?: Record<string, unknown>) => {
     if (method === "chat.send") {
@@ -63,6 +73,8 @@ function createHarness(sessions: Array<{ sessionId: string; sessionKey: string }
     return {};
   });
   const connection = createAcpConnection();
+  const sessionUpdateSpy = vi.fn<AgentSideConnection["sessionUpdate"]>(async () => {});
+  connection.sessionUpdate = sessionUpdateSpy;
   const sessionStore = createInMemorySessionStore();
   for (const session of sessions) {
     sessionStore.createSession({
@@ -75,13 +87,13 @@ function createHarness(sessions: Array<{ sessionId: string; sessionKey: string }
   const agent = new AcpGatewayAgent(
     connection,
     createAcpGateway(requestSpy as unknown as GatewayClient["request"]),
-    { sessionStore },
+    { sessionStore, ...options },
   );
 
   return {
     agent,
     requestSpy,
-    sessionUpdateSpy: connection["sessionUpdate"] as unknown as ReturnType<typeof vi.fn>,
+    sessionUpdateSpy,
     sessionStore,
     sentRunIds,
   };
@@ -143,6 +155,298 @@ function sessionUpdatePayloadAt(harness: Harness, index: number): SessionUpdateP
 }
 
 describe("acp translator cancel and run scoping", () => {
+  it("aborts and settles an overlapping prompt before submitting its replacement", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const first = await startPendingPrompt(harness, "session-1");
+
+    const replacement = await startPendingPrompt(harness, "session-1");
+
+    expect(harness.requestSpy.mock.calls.map(([method]) => method)).toEqual([
+      "chat.send",
+      "chat.abort",
+      "chat.send",
+    ]);
+    expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
+      sessionKey,
+      runId: first.runId,
+    });
+    await expect(first.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+    expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(replacement.runId);
+
+    await deliverFinalChatEventAndExpectEndTurn(harness, sessionKey, replacement, 1);
+  });
+
+  it.each([
+    {
+      closure: "cancel",
+      close: (harness: Harness) => harness.agent.cancel({ sessionId: "session-1" }),
+    },
+    {
+      closure: "closeSession",
+      close: (harness: Harness) =>
+        harness.agent.closeSession({ sessionId: "session-1", _meta: {} }),
+    },
+    {
+      closure: "shutdown",
+      close: (harness: Harness) => harness.agent.shutdown(),
+    },
+  ])(
+    "does not submit a replacement closed by $closure while its prior abort is pending",
+    async ({ close, closure }) => {
+      const sessionKey = "agent:main:shared";
+      const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+      const first = await startPendingPrompt(harness, "session-1");
+      let releaseAbort: (() => void) | undefined;
+      harness.requestSpy.mockImplementationOnce(async (method: string) => {
+        expect(method).toBe("chat.abort");
+        await new Promise<void>((resolve) => {
+          releaseAbort = resolve;
+        });
+        return {};
+      });
+
+      const replacement = harness.agent.prompt(createPromptRequest("session-1"));
+      await vi.waitFor(() => {
+        expect(releaseAbort).toBeDefined();
+      });
+      const closed = close(harness);
+
+      expect(harness.sentRunIds).toEqual([first.runId]);
+      expectDefined(releaseAbort, `${closure} owns the blocked prior abort`)();
+      await closed;
+      await Promise.resolve();
+
+      expect(harness.sentRunIds).toEqual([first.runId]);
+      await expect(first.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+      await expect(replacement).resolves.toEqual({ stopReason: "cancelled" });
+      expect(harness.sessionStore.getSession("session-1")?.activeRunId).not.toBeTruthy();
+    },
+  );
+
+  it("settles shutdown when a superseded prompt's abort never returns", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const first = await startPendingPrompt(harness, "session-1");
+    harness.requestSpy.mockImplementationOnce(async (method: string) => {
+      expect(method).toBe("chat.abort");
+      return await new Promise<Record<string, unknown>>(() => {});
+    });
+
+    const replacement = harness.agent.prompt(createPromptRequest("session-1"));
+    await vi.waitFor(() => {
+      expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
+        sessionKey,
+        runId: first.runId,
+      });
+    });
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const shutdownResult = await Promise.race([
+      harness.agent.shutdown().then(() => "closed" as const),
+      new Promise<"still pending">((resolve) => {
+        timeout = setTimeout(() => resolve("still pending"), 25);
+      }),
+    ]);
+    clearTimeout(timeout);
+
+    expect(shutdownResult).toBe("closed");
+    expect(harness.sentRunIds).toEqual([first.runId]);
+    await expect(replacement).resolves.toEqual({ stopReason: "cancelled" });
+  });
+
+  it("closes every queued overlapping admission when cancellation wins the blocked abort", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const first = await startPendingPrompt(harness, "session-1");
+    let releaseAbort: (() => void) | undefined;
+    harness.requestSpy.mockImplementationOnce(async (method: string) => {
+      expect(method).toBe("chat.abort");
+      await new Promise<void>((resolve) => {
+        releaseAbort = resolve;
+      });
+      return {};
+    });
+
+    const second = harness.agent.prompt(createPromptRequest("session-1"));
+    await vi.waitFor(() => {
+      expect(releaseAbort).toBeDefined();
+    });
+    const third = harness.agent.prompt(createPromptRequest("session-1"));
+    const cancellation = harness.agent.cancel({ sessionId: "session-1" });
+
+    expectDefined(releaseAbort, "blocked prior abort")();
+    await cancellation;
+    await Promise.resolve();
+
+    expect(harness.sentRunIds).toEqual([first.runId]);
+    await expect(first.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(second).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(third).resolves.toEqual({ stopReason: "cancelled" });
+  });
+
+  it("serializes three overlapping prompts while the first abort is still pending", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const first = await startPendingPrompt(harness, "session-1");
+    let releaseAbort: (() => void) | undefined;
+    harness.requestSpy.mockImplementationOnce(async (method: string) => {
+      expect(method).toBe("chat.abort");
+      await new Promise<void>((resolve) => {
+        releaseAbort = resolve;
+      });
+      return {};
+    });
+
+    const secondPrompt = harness.agent.prompt({
+      ...createPromptRequest("session-1"),
+      prompt: [{ type: "text", text: "second" }],
+    });
+    await vi.waitFor(() => {
+      expect(releaseAbort).toBeDefined();
+    });
+    const thirdPrompt = harness.agent.prompt({
+      ...createPromptRequest("session-1"),
+      prompt: [{ type: "text", text: "third" }],
+    });
+    await Promise.resolve();
+    const sendsWhileAbortPending = [...harness.sentRunIds];
+
+    expectDefined(releaseAbort, "blocked first chat.abort request")();
+    await vi.waitFor(() => {
+      expect(harness.sentRunIds).toHaveLength(3);
+    });
+
+    expect(sendsWhileAbortPending).toEqual([first.runId]);
+    await expect(first.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(secondPrompt).resolves.toEqual({ stopReason: "cancelled" });
+    const thirdRunId = expectDefined(
+      harness.sentRunIds[2],
+      "third prompt remains the final admitted run",
+    );
+    expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(thirdRunId);
+    await deliverFinalChatEventAndExpectEndTurn(
+      harness,
+      sessionKey,
+      { promptPromise: thirdPrompt, runId: thirdRunId },
+      1,
+    );
+  });
+
+  it("does not replay a superseded prompt after its delayed provenance rejection", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }], {
+      provenanceMode: "meta",
+    });
+    let rejectFirstSend: ((error: Error) => void) | undefined;
+    harness.requestSpy.mockImplementation(async (method, params) => {
+      if (method !== "chat.send") {
+        return {};
+      }
+      const runId = params?.idempotencyKey;
+      if (typeof runId === "string") {
+        harness.sentRunIds.push(runId);
+      }
+      if (harness.sentRunIds.length === 1) {
+        return await new Promise<Record<string, unknown>>((_, reject) => {
+          rejectFirstSend = reject;
+        });
+      }
+      return await new Promise<Record<string, unknown>>(() => {});
+    });
+    const first = await startPendingPrompt(harness, "session-1");
+    const replacement = await startPendingPrompt(harness, "session-1");
+    await expect(first.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+
+    expectDefined(
+      rejectFirstSend,
+      "blocked first chat.send request",
+    )(
+      Object.assign(new Error("system provenance fields require admin scope"), {
+        name: "GatewayClientRequestError",
+        gatewayCode: "INVALID_REQUEST",
+      }),
+    );
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(harness.sentRunIds).toEqual([first.runId, replacement.runId]);
+    expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(replacement.runId);
+    await deliverFinalChatEventAndExpectEndTurn(harness, sessionKey, replacement, 1);
+  });
+
+  it("does not let a stale final event clear a replacement admitted during client delivery", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const first = await startPendingPrompt(harness, "session-1");
+    let releaseDelivery: (() => void) | undefined;
+    harness.sessionUpdateSpy.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseDelivery = resolve;
+        }),
+    );
+
+    const staleFinal = harness.agent.handleGatewayEvent(
+      createChatEvent({
+        runId: first.runId,
+        sessionKey,
+        seq: 1,
+        state: "final",
+        message: { content: [{ type: "text", text: "old response" }] },
+      }),
+    );
+    await vi.waitFor(() => {
+      expect(releaseDelivery).toBeDefined();
+    });
+
+    const replacement = await startPendingPrompt(harness, "session-1");
+    expectDefined(releaseDelivery, "blocked session-update delivery")();
+    await staleFinal;
+
+    expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(replacement.runId);
+    await expect(first.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+    await deliverFinalChatEventAndExpectEndTurn(harness, sessionKey, replacement, 2);
+  });
+
+  it("does not let a stale cancel completion remove a newer prompt", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const first = await startPendingPrompt(harness, "session-1");
+    let releaseAbort: (() => void) | undefined;
+    harness.requestSpy.mockImplementationOnce(async (method: string) => {
+      expect(method).toBe("chat.abort");
+      await new Promise<void>((resolve) => {
+        releaseAbort = resolve;
+      });
+      return {};
+    });
+
+    const cancellation = harness.agent.cancel({ sessionId: "session-1" } as CancelNotification);
+    await vi.waitFor(() => {
+      expect(releaseAbort).toBeDefined();
+    });
+    const replacement = await startPendingPrompt(harness, "session-1");
+
+    expectDefined(releaseAbort, "blocked chat.abort request")();
+    await cancellation;
+    await expect(first.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+    expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(replacement.runId);
+
+    await harness.agent.handleGatewayEvent(
+      createChatEvent({
+        runId: replacement.runId,
+        sessionKey,
+        seq: 1,
+        state: "final",
+      }),
+    );
+    await expect(
+      Promise.race([replacement.promptPromise, Promise.resolve("still pending")]),
+    ).resolves.toEqual({ stopReason: "end_turn" });
+  });
+
   it("cancel passes active runId to chat.abort", async () => {
     const sessionKey = "agent:main:shared";
     const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
@@ -250,6 +554,52 @@ describe("acp translator cancel and run scoping", () => {
       text: "Final visible reply",
     });
   });
+
+  it.each(["delta", "final"] as const)(
+    "drops stale text from a mixed %s snapshot after replacement during thought delivery",
+    async (state) => {
+      const sessionKey = "agent:main:shared";
+      const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+      const first = await startPendingPrompt(harness, "session-1");
+      let releaseThought: (() => void) | undefined;
+      harness.sessionUpdateSpy.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseThought = resolve;
+          }),
+      );
+
+      const staleSnapshot = harness.agent.handleGatewayEvent(
+        createChatEvent({
+          runId: first.runId,
+          sessionKey,
+          seq: 1,
+          state,
+          message: {
+            content: [
+              { type: "thinking", thinking: "old hidden thought" },
+              { type: "text", text: "old visible response" },
+            ],
+          },
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(releaseThought).toBeDefined();
+      });
+
+      const replacement = await startPendingPrompt(harness, "session-1");
+      expectDefined(releaseThought, "blocked stale thought delivery")();
+      await staleSnapshot;
+
+      const visibleChunks = harness.sessionUpdateSpy.mock.calls.filter(
+        ([payload]) => payload.update.sessionUpdate === "agent_message_chunk",
+      );
+      expect(visibleChunks).toEqual([]);
+      expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(replacement.runId);
+      await expect(first.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+      await deliverFinalChatEventAndExpectEndTurn(harness, sessionKey, replacement, 2);
+    },
+  );
 
   it("drops tool events when runId does not match the active prompt", async () => {
     const sessionKey = "agent:main:shared";

--- a/src/acp/translator.cancel-scoping.test.ts
+++ b/src/acp/translator.cancel-scoping.test.ts
@@ -99,6 +99,41 @@ function createHarness(
   };
 }
 
+function blockAcceptedPromptAbort(harness: Harness) {
+  const firstSettlement = vi.fn();
+  let releaseAbort: (() => void) | undefined;
+  harness.requestSpy.mockImplementation(async (method, params) => {
+    if (method === "chat.send") {
+      const runId = expectDefined(
+        params?.idempotencyKey as string | undefined,
+        "accepted Gateway run id",
+      );
+      harness.sentRunIds.push(runId);
+      return { runId, status: "started" };
+    }
+    if (method === "chat.abort") {
+      expect(firstSettlement).not.toHaveBeenCalled();
+      await new Promise<void>((resolve) => {
+        releaseAbort = resolve;
+      });
+    }
+    return {};
+  });
+  return {
+    observeFirstSettlement(promise: Promise<PromptResponse>) {
+      void promise.then(firstSettlement);
+    },
+    async waitForAbort() {
+      await vi.waitFor(() => {
+        expect(releaseAbort).toBeDefined();
+      });
+    },
+    releaseAbort() {
+      expectDefined(releaseAbort, "blocked exact Gateway abort")();
+    },
+  };
+}
+
 async function startPendingPrompt(
   harness: Harness,
   sessionId: string,
@@ -155,22 +190,35 @@ function sessionUpdatePayloadAt(harness: Harness, index: number): SessionUpdateP
 }
 
 describe("acp translator cancel and run scoping", () => {
-  it("aborts and settles an overlapping prompt before submitting its replacement", async () => {
+  it("aborts an accepted active prompt before settlement and replacement submission", async () => {
     const sessionKey = "agent:main:shared";
     const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const blockedAbort = blockAcceptedPromptAbort(harness);
     const first = await startPendingPrompt(harness, "session-1");
+    blockedAbort.observeFirstSettlement(first.promptPromise);
 
-    const replacement = await startPendingPrompt(harness, "session-1");
+    const replacementPromise = harness.agent.prompt(createPromptRequest("session-1"));
+    await blockedAbort.waitForAbort();
+
+    expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
+      sessionKey,
+      runId: first.runId,
+    });
+    expect(harness.sentRunIds).toEqual([first.runId]);
+    blockedAbort.releaseAbort();
+    await vi.waitFor(() => {
+      expect(harness.sentRunIds).toHaveLength(2);
+    });
+    const replacement = {
+      promptPromise: replacementPromise,
+      runId: expectDefined(harness.sentRunIds[1], "accepted replacement Gateway run id"),
+    };
 
     expect(harness.requestSpy.mock.calls.map(([method]) => method)).toEqual([
       "chat.send",
       "chat.abort",
       "chat.send",
     ]);
-    expect(harness.requestSpy).toHaveBeenCalledWith("chat.abort", {
-      sessionKey,
-      runId: first.runId,
-    });
     await expect(first.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
     expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(replacement.runId);
 
@@ -255,6 +303,48 @@ describe("acp translator cancel and run scoping", () => {
     await expect(replacement).resolves.toEqual({ stopReason: "cancelled" });
   });
 
+  it("closes an admitted prompt when shutdown interrupts its blocked final snapshot", async () => {
+    const sessionKey = "agent:main:shared";
+    const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    let releaseSnapshot: (() => void) | undefined;
+    harness.requestSpy.mockImplementation(async (method, params) => {
+      if (method === "chat.send") {
+        const runId = expectDefined(
+          params?.idempotencyKey as string | undefined,
+          "accepted terminal Gateway run id",
+        );
+        harness.sentRunIds.push(runId);
+        return { runId, status: "started" };
+      }
+      if (method === "sessions.list") {
+        return await new Promise<Record<string, unknown>>((resolve) => {
+          releaseSnapshot = () => resolve({ sessions: [] });
+        });
+      }
+      return {};
+    });
+    const pending = await startPendingPrompt(harness, "session-1");
+    const terminalEvent = harness.agent.handleGatewayEvent(
+      createChatEvent({ runId: pending.runId, sessionKey, seq: 1, state: "final" }),
+    );
+    await vi.waitFor(() => {
+      expect(releaseSnapshot).toBeDefined();
+    });
+
+    const shutdownSettled = vi.fn();
+    const shutdown = harness.agent.shutdown().then(shutdownSettled);
+    try {
+      await vi.waitFor(() => {
+        expect(shutdownSettled).toHaveBeenCalledOnce();
+      });
+      await expect(pending.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+    } finally {
+      expectDefined(releaseSnapshot, "blocked terminal session snapshot")();
+      await terminalEvent;
+      await shutdown;
+    }
+  });
+
   it("closes every queued overlapping admission when cancellation wins the blocked abort", async () => {
     const sessionKey = "agent:main:shared";
     const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
@@ -285,43 +375,41 @@ describe("acp translator cancel and run scoping", () => {
     await expect(third).resolves.toEqual({ stopReason: "cancelled" });
   });
 
-  it("serializes three overlapping prompts while the first abort is still pending", async () => {
+  it("submits only the latest of three overlapping prompts after the active abort settles", async () => {
     const sessionKey = "agent:main:shared";
     const harness = createHarness([{ sessionId: "session-1", sessionKey }]);
+    const blockedAbort = blockAcceptedPromptAbort(harness);
     const first = await startPendingPrompt(harness, "session-1");
-    let releaseAbort: (() => void) | undefined;
-    harness.requestSpy.mockImplementationOnce(async (method: string) => {
-      expect(method).toBe("chat.abort");
-      await new Promise<void>((resolve) => {
-        releaseAbort = resolve;
-      });
-      return {};
-    });
+    blockedAbort.observeFirstSettlement(first.promptPromise);
 
     const secondPrompt = harness.agent.prompt({
       ...createPromptRequest("session-1"),
       prompt: [{ type: "text", text: "second" }],
     });
-    await vi.waitFor(() => {
-      expect(releaseAbort).toBeDefined();
-    });
+    await blockedAbort.waitForAbort();
     const thirdPrompt = harness.agent.prompt({
       ...createPromptRequest("session-1"),
       prompt: [{ type: "text", text: "third" }],
     });
     await Promise.resolve();
-    const sendsWhileAbortPending = [...harness.sentRunIds];
+    expect(harness.sentRunIds).toEqual([first.runId]);
 
-    expectDefined(releaseAbort, "blocked first chat.abort request")();
+    blockedAbort.releaseAbort();
     await vi.waitFor(() => {
-      expect(harness.sentRunIds).toHaveLength(3);
+      const sendCalls = harness.requestSpy.mock.calls.filter(([method]) => method === "chat.send");
+      expect(sendCalls.at(-1)?.[1]?.message).toContain("third");
     });
 
-    expect(sendsWhileAbortPending).toEqual([first.runId]);
     await expect(first.promptPromise).resolves.toEqual({ stopReason: "cancelled" });
     await expect(secondPrompt).resolves.toEqual({ stopReason: "cancelled" });
+    expect(harness.sentRunIds).toHaveLength(2);
+    expect(
+      harness.requestSpy.mock.calls
+        .filter(([method]) => method === "chat.send")
+        .map(([, params]) => params?.message),
+    ).toEqual(["[Working directory: /tmp]\n\nhello", "[Working directory: /tmp]\n\nthird"]);
     const thirdRunId = expectDefined(
-      harness.sentRunIds[2],
+      harness.sentRunIds[1],
       "third prompt remains the final admitted run",
     );
     expect(harness.sessionStore.getSession("session-1")?.activeRunId).toBe(thirdRunId);

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -14,6 +14,7 @@ import type { AcpServerOptions } from "@openclaw/acp-core/types";
 import { normalizeLowercaseStringOrEmpty as normalizedChatSendAckStatus } from "@openclaw/normalization-core/string-coerce";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
 import type { GatewayClient } from "../gateway/client.js";
+import { createDeferredCore, type Deferred } from "../shared/deferred.js";
 import { shortenHomePath } from "../utils.js";
 import { extractAttachmentsFromPrompt, extractTextFromPrompt } from "./event-mapper.js";
 import { parseSessionMeta } from "./session-mapper.js";
@@ -33,6 +34,14 @@ const ACP_SHUTDOWN_ABORT_TIMEOUT_MS = 1_000;
 type ChatSendAck = {
   runId?: unknown;
   status?: unknown;
+};
+
+type AcpPendingPromptAdmission = {
+  session: NonNullable<ReturnType<AcpSessionStore["getSession"]>>;
+  previous?: AcpPendingPromptAdmission;
+  closed: boolean;
+  closure: Deferred;
+  settled: Deferred;
 };
 
 function isTerminalChatSendAckFailure(status: unknown): boolean {
@@ -92,9 +101,11 @@ function buildSystemProvenanceReceipt(params: {
 
 export class AcpTranslatorPromptStream {
   private readonly pendingPrompts = new Map<string, AcpPendingPrompt>();
+  private readonly pendingPromptAdmissions = new Map<string, AcpPendingPromptAdmission>();
   private readonly settlingPromptKeys = new Set<string>();
   private readonly agentEvents: AcpTranslatorAgentEvents;
   private readonly disconnects: AcpTranslatorDisconnects;
+  private stopped = false;
 
   constructor(
     connection: AgentSideConnection,
@@ -127,17 +138,25 @@ export class AcpTranslatorPromptStream {
   }
 
   async shutdown(): Promise<void> {
+    this.stopped = true;
     this.disconnects.shutdown();
+    const sessions = new Map<
+      string,
+      { sessionId: string; sessionKey: string; activeRunId: string | null }
+    >();
+    for (const pending of this.pendingPrompts.values()) {
+      sessions.set(pending.sessionId, {
+        sessionId: pending.sessionId,
+        sessionKey: pending.sessionKey,
+        activeRunId: pending.idempotencyKey,
+      });
+    }
+    for (const admission of this.pendingPromptAdmissions.values()) {
+      sessions.set(admission.session.sessionId, admission.session);
+    }
     await Promise.all(
-      [...this.pendingPrompts.values()].map((pending) =>
-        this.cancelSessionWork(
-          {
-            sessionId: pending.sessionId,
-            sessionKey: pending.sessionKey,
-            activeRunId: pending.idempotencyKey,
-          },
-          ACP_SHUTDOWN_ABORT_TIMEOUT_MS,
-        ),
+      [...sessions.values()].map((session) =>
+        this.cancelSessionWork(session, ACP_SHUTDOWN_ABORT_TIMEOUT_MS),
       ),
     );
   }
@@ -170,10 +189,45 @@ export class AcpTranslatorPromptStream {
       throw new Error(`Session ${params.sessionId} not found`);
     }
 
-    if (session.abortController) {
-      this.sessionStore.cancelActiveRun(params.sessionId);
-    }
+    const admission: AcpPendingPromptAdmission = {
+      session,
+      previous: this.pendingPromptAdmissions.get(params.sessionId),
+      closed: this.stopped,
+      closure: createDeferredCore(),
+      settled: createDeferredCore(),
+    };
+    this.pendingPromptAdmissions.set(params.sessionId, admission);
 
+    try {
+      if (admission.previous) {
+        await admission.previous.settled.promise;
+      }
+      if (!this.ownsPromptAdmission(admission)) {
+        return { stopReason: "cancelled" };
+      }
+      if (session.abortController || this.pendingPrompts.has(params.sessionId)) {
+        await Promise.race([
+          this.cancelSessionWork(session, undefined, admission),
+          admission.closure.promise,
+        ]);
+        // Cancellation or session closure can win while the previous Gateway abort is pending.
+        if (!this.ownsPromptAdmission(admission)) {
+          return { stopReason: "cancelled" };
+        }
+      }
+      return this.submitPrompt(params, session);
+    } finally {
+      admission.settled.resolve();
+      if (this.pendingPromptAdmissions.get(params.sessionId) === admission) {
+        this.pendingPromptAdmissions.delete(params.sessionId);
+      }
+    }
+  }
+
+  private submitPrompt(
+    params: PromptRequest,
+    session: AcpPendingPromptAdmission["session"],
+  ): Promise<PromptResponse> {
     const meta = parseSessionMeta(params["_meta"]);
     // Pass MAX_PROMPT_BYTES so extractTextFromPrompt rejects oversized content
     // block-by-block, before the full string is ever assembled in memory (CWE-400)
@@ -225,11 +279,13 @@ export class AcpTranslatorPromptStream {
       this.disconnects.armForActiveContext();
 
       const sendWithProvenanceFallback = async () => {
-        const markSendAccepted = () => {
+        const markSendAccepted = (): boolean => {
           const pending = this.getPendingPrompt(params.sessionId, runId);
-          if (pending) {
-            pending.sendAccepted = true;
+          if (!pending) {
+            return false;
           }
+          pending.sendAccepted = true;
+          return true;
         };
         const applyTerminalAck = async (ack: ChatSendAck | undefined): Promise<boolean> => {
           const status = normalizedChatSendAckStatus(ack?.status);
@@ -252,7 +308,9 @@ export class AcpTranslatorPromptStream {
             return true;
           }
           if (status === "ok") {
-            markSendAccepted();
+            if (!markSendAccepted()) {
+              return true;
+            }
             await this.sessionUpdates.recordUserPrompt(session, runId, params.prompt);
             const current = pending();
             if (current) {
@@ -279,18 +337,25 @@ export class AcpTranslatorPromptStream {
           if (terminal) {
             return;
           }
-          markSendAccepted();
+          if (!markSendAccepted()) {
+            return;
+          }
           await this.sessionUpdates.recordUserPrompt(session, runId, params.prompt);
         } catch (err) {
           if (
             (systemInputProvenance || systemProvenanceReceipt) &&
             isAdminScopeProvenanceRejection(err)
           ) {
+            if (!this.getPendingPrompt(params.sessionId, runId)) {
+              return;
+            }
             const terminal = await sendChat(requestParams);
             if (terminal) {
               return;
             }
-            markSendAccepted();
+            if (!markSendAccepted()) {
+              return;
+            }
             await this.sessionUpdates.recordUserPrompt(session, runId, params.prompt);
             return;
           }
@@ -310,9 +375,7 @@ export class AcpTranslatorPromptStream {
         const current = this.getPendingPrompt(params.sessionId, runId);
         if (current) {
           await this.rejectPendingPrompt(current, error);
-          return;
         }
-        reject(error);
       });
     });
   }
@@ -332,36 +395,62 @@ export class AcpTranslatorPromptStream {
       activeRunId: string | null;
     },
     abortTimeoutMs?: number,
+    retainedAdmission?: AcpPendingPromptAdmission,
   ): Promise<void> {
-    // Capture runId before cancelActiveRun clears session.activeRunId.
-    const activeRunId = session.activeRunId;
-
-    this.sessionStore.cancelActiveRun(session.sessionId);
-    const pending = this.pendingPrompts.get(session.sessionId);
-    const scopedRunId = activeRunId ?? pending?.idempotencyKey;
-
-    if (scopedRunId) {
-      try {
-        const abortParams = {
-          sessionKey: session.sessionKey,
-          runId: scopedRunId,
-        };
-        await (abortTimeoutMs === undefined
-          ? this.gateway.request("chat.abort", abortParams)
-          : this.gateway.request("chat.abort", abortParams, { timeoutMs: abortTimeoutMs }));
-      } catch (err) {
-        this.log(`cancel error: ${String(err)}`);
+    const closingAdmissions: Promise<void>[] = [];
+    if (!retainedAdmission) {
+      let admission = this.pendingPromptAdmissions.get(session.sessionId);
+      while (admission) {
+        admission.closed = true;
+        admission.closure.resolve();
+        closingAdmissions.push(admission.settled.promise);
+        admission = admission.previous;
       }
     }
 
-    if (pending) {
-      this.agentEvents.clearApprovalRelaysForPrompt(session.sessionId, pending.idempotencyKey, {
-        denyActive: true,
-      });
-      this.pendingPrompts.delete(session.sessionId);
-      this.disconnects.clearWhenIdle();
+    const pending = this.pendingPrompts.get(session.sessionId);
+    const scopedRunId = session.activeRunId ?? pending?.idempotencyKey;
+
+    if (!scopedRunId) {
+      await Promise.all(closingAdmissions);
+      return;
+    }
+
+    this.sessionStore.cancelActiveRun(session.sessionId, scopedRunId);
+    if (pending?.idempotencyKey === scopedRunId && this.claimPendingPrompt(pending)) {
       pending.resolve({ stopReason: "cancelled" });
     }
+
+    try {
+      const abortParams = {
+        sessionKey: session.sessionKey,
+        runId: scopedRunId,
+      };
+      await (abortTimeoutMs === undefined
+        ? this.gateway.request("chat.abort", abortParams)
+        : this.gateway.request("chat.abort", abortParams, { timeoutMs: abortTimeoutMs }));
+    } catch (err) {
+      this.log(`cancel error: ${String(err)}`);
+    }
+    await Promise.all(closingAdmissions);
+  }
+
+  private ownsPromptAdmission(admission: AcpPendingPromptAdmission): boolean {
+    if (
+      this.stopped ||
+      admission.closed ||
+      this.sessionStore.getSession(admission.session.sessionId) !== admission.session
+    ) {
+      return false;
+    }
+    let current = this.pendingPromptAdmissions.get(admission.session.sessionId);
+    while (current) {
+      if (current === admission) {
+        return true;
+      }
+      current = current.previous;
+    }
+    return false;
   }
 
   private pendingPromptKey(sessionId: string, runId: string): string {
@@ -374,6 +463,19 @@ export class AcpTranslatorPromptStream {
       return undefined;
     }
     return pending;
+  }
+
+  private claimPendingPrompt(pending: AcpPendingPrompt): boolean {
+    if (this.getPendingPrompt(pending.sessionId, pending.idempotencyKey) !== pending) {
+      return false;
+    }
+    this.agentEvents.clearApprovalRelaysForPrompt(pending.sessionId, pending.idempotencyKey, {
+      denyActive: true,
+    });
+    this.pendingPrompts.delete(pending.sessionId);
+    this.sessionStore.clearActiveRun(pending.sessionId, pending.idempotencyKey);
+    this.disconnects.clearWhenIdle();
+    return true;
   }
 
   private async handleChatEvent(evt: EventFrame): Promise<void> {
@@ -400,8 +502,12 @@ export class AcpTranslatorPromptStream {
       // Gateway chat events can carry the latest full assistant snapshot on both
       // incremental updates and the terminal final event. Process the snapshot
       // first so ACP clients never drop the last visible assistant text.
-      await this.handleDeltaEvent(pending.sessionId, messageData);
-      if (state === "delta") {
+      const ownsSnapshot = await this.handleDeltaEvent(pending, messageData);
+      if (
+        !ownsSnapshot ||
+        this.getPendingPrompt(pending.sessionId, pending.idempotencyKey) !== pending ||
+        state === "delta"
+      ) {
         return;
       }
     }
@@ -424,13 +530,13 @@ export class AcpTranslatorPromptStream {
   }
 
   private async handleDeltaEvent(
-    sessionId: string,
+    pending: AcpPendingPrompt,
     messageData: Record<string, unknown>,
-  ): Promise<void> {
+  ): Promise<boolean> {
     const content = messageData.content as GatewayChatContentBlock[] | undefined;
-    const pending = this.pendingPrompts.get(sessionId);
-    if (!pending) {
-      return;
+    const sessionId = pending.sessionId;
+    if (this.getPendingPrompt(sessionId, pending.idempotencyKey) !== pending) {
+      return false;
     }
 
     const fullThought = content
@@ -454,6 +560,9 @@ export class AcpTranslatorPromptStream {
           content: { type: "text", text: newThought },
         },
       });
+      if (this.getPendingPrompt(sessionId, pending.idempotencyKey) !== pending) {
+        return false;
+      }
     }
 
     const fullText = content
@@ -463,7 +572,7 @@ export class AcpTranslatorPromptStream {
       .trimEnd();
     const sentSoFar = pending.sentTextLength ?? 0;
     if (!fullText || fullText.length <= sentSoFar) {
-      return;
+      return true;
     }
 
     const newText = fullText.slice(sentSoFar);
@@ -480,6 +589,7 @@ export class AcpTranslatorPromptStream {
         content: { type: "text", text: newText },
       },
     });
+    return this.getPendingPrompt(sessionId, pending.idempotencyKey) === pending;
   }
 
   private async finishPrompt(
@@ -487,15 +597,12 @@ export class AcpTranslatorPromptStream {
     pending: AcpPendingPrompt,
     stopReason: StopReason,
   ): Promise<void> {
+    if (!this.claimPendingPrompt(pending)) {
+      return;
+    }
     const promptKey = this.pendingPromptKey(sessionId, pending.idempotencyKey);
     this.settlingPromptKeys.add(promptKey);
     try {
-      this.agentEvents.clearApprovalRelaysForPrompt(sessionId, pending.idempotencyKey, {
-        denyActive: true,
-      });
-      this.pendingPrompts.delete(sessionId);
-      this.sessionStore.clearActiveRun(sessionId);
-      this.disconnects.clearWhenIdle();
       const sessionSnapshot = await this.sessionState.getSnapshot(pending.sessionKey);
       try {
         await this.sessionState.sendSnapshotUpdate(
@@ -562,20 +669,12 @@ export class AcpTranslatorPromptStream {
     error: Error,
     options: { recordDisconnectNotice?: boolean } = {},
   ): Promise<void> {
-    const currentPending = this.getPendingPrompt(pending.sessionId, pending.idempotencyKey);
-    if (currentPending !== pending) {
+    if (!this.claimPendingPrompt(pending)) {
       return;
     }
 
     const promptKey = this.pendingPromptKey(pending.sessionId, pending.idempotencyKey);
-    // Claim before emitting so late Gateway events cannot settle this prompt twice.
     this.settlingPromptKeys.add(promptKey);
-    this.agentEvents.clearApprovalRelaysForPrompt(pending.sessionId, pending.idempotencyKey, {
-      denyActive: true,
-    });
-    this.pendingPrompts.delete(pending.sessionId);
-    this.sessionStore.clearActiveRun(pending.sessionId);
-    this.disconnects.clearWhenIdle();
 
     try {
       if (options.recordDisconnectNotice) {

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -197,11 +197,12 @@ export class AcpTranslatorPromptStream {
       settled: createDeferredCore(),
     };
     this.pendingPromptAdmissions.set(params.sessionId, admission);
+    // Supersession keeps the predecessor's abort barrier; explicit closure alone releases it.
+    for (let previous = admission.previous; previous; previous = previous.previous) {
+      previous.closed = true;
+    }
 
     try {
-      if (admission.previous) {
-        await admission.previous.settled.promise;
-      }
       if (!this.ownsPromptAdmission(admission)) {
         return { stopReason: "cancelled" };
       }
@@ -215,7 +216,17 @@ export class AcpTranslatorPromptStream {
           return { stopReason: "cancelled" };
         }
       }
-      return this.submitPrompt(params, session);
+      if (admission.previous) {
+        // Abort the active owner first; explicit closure can still release a blocked predecessor.
+        await Promise.race([admission.previous.settled.promise, admission.closure.promise]);
+        if (!this.ownsPromptAdmission(admission)) {
+          return { stopReason: "cancelled" };
+        }
+      }
+      return await Promise.race([
+        this.submitPrompt(params, session),
+        admission.closure.promise.then(() => ({ stopReason: "cancelled" as const })),
+      ]);
     } finally {
       admission.settled.resolve();
       if (this.pendingPromptAdmissions.get(params.sessionId) === admission) {
@@ -436,21 +447,12 @@ export class AcpTranslatorPromptStream {
   }
 
   private ownsPromptAdmission(admission: AcpPendingPromptAdmission): boolean {
-    if (
-      this.stopped ||
-      admission.closed ||
-      this.sessionStore.getSession(admission.session.sessionId) !== admission.session
-    ) {
-      return false;
-    }
-    let current = this.pendingPromptAdmissions.get(admission.session.sessionId);
-    while (current) {
-      if (current === admission) {
-        return true;
-      }
-      current = current.previous;
-    }
-    return false;
+    return (
+      !this.stopped &&
+      !admission.closed &&
+      this.pendingPromptAdmissions.get(admission.session.sessionId) === admission &&
+      this.sessionStore.getSession(admission.session.sessionId) === admission.session
+    );
   }
 
   private pendingPromptKey(sessionId: string, runId: string): string {

--- a/src/acp/translator.stop-reason.test.ts
+++ b/src/acp/translator.stop-reason.test.ts
@@ -531,7 +531,7 @@ describe("acp translator stop reason mapping", () => {
     }
   });
 
-  it("rejects a superseded pre-ack prompt when a newer prompt has replaced the session entry", async () => {
+  it("cancels a superseded pre-ack prompt before admitting its replacement", async () => {
     let promptCount = 0;
     const request = vi.fn(async (method: string) => {
       if (method !== "chat.send") {
@@ -550,11 +550,11 @@ describe("acp translator stop reason mapping", () => {
 
     const secondPrompt = promptAgent(agent, sessionId, "second");
 
-    await expect(firstPrompt).rejects.toThrow("gateway closed (1006): connection lost");
+    await expect(firstPrompt).resolves.toEqual({ stopReason: "cancelled" });
     await expect(Promise.race([secondPrompt, Promise.resolve("pending")])).resolves.toBe("pending");
   });
 
-  it("rejects stale pre-ack prompts when a superseded send resolves late", async () => {
+  it("keeps replacement disconnect handling isolated when a cancelled send resolves late", async () => {
     vi.useFakeTimers();
     try {
       let firstSendResolve: (() => void) | undefined;
@@ -583,8 +583,14 @@ describe("acp translator stop reason mapping", () => {
 
       const secondPrompt = promptAgent(agent, sessionId, "second");
       void secondPrompt.catch(() => {});
-      await Promise.resolve();
-      expect(sendCount).toBe(2);
+      await expect(firstPrompt).resolves.toEqual({ stopReason: "cancelled" });
+      await vi.waitFor(() => {
+        expect(sendCount).toBe(2);
+      });
+      expect(request).toHaveBeenCalledWith(
+        "chat.abort",
+        expect.objectContaining({ sessionKey: "agent:main:main", runId: expect.any(String) }),
+      );
 
       resolveFirstSend();
       await Promise.resolve();

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -4943,15 +4943,18 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     expect(transcriptParams.transcriptBody).not.toContain(INTERNAL_RUNTIME_CONTEXT_END);
   });
 
-  it("marks ACP execution start when the prompt is submitted", async () => {
+  it("marks ACP execution start before prompt submission", async () => {
     setupAcpSession();
     const onExecutionStarted = vi.fn();
     state.acpRunTurnMock.mockImplementationOnce(async (params: unknown) => {
       const callbacks = params as {
+        onBeforePrompt?: () => void;
         onLifecycle?: (event: { type: string; at: number }) => void;
         onEvent?: (event: unknown) => void;
       };
       expect(onExecutionStarted).not.toHaveBeenCalled();
+      callbacks.onBeforePrompt?.();
+      expect(onExecutionStarted).toHaveBeenCalledOnce();
       callbacks.onLifecycle?.({ type: "prompt_submitted", at: Date.now() });
       callbacks.onEvent?.({ type: "done", stopReason: "end_turn" });
     });

--- a/src/agents/command/acp-execution.ts
+++ b/src/agents/command/acp-execution.ts
@@ -157,9 +157,9 @@ export async function runAcpAgentCommand(params: {
       requestId: params.runId,
       signal: params.opts.abortSignal,
       onElicitation,
+      onBeforePrompt: params.opts.onExecutionStarted,
       onLifecycle: (event) => {
         if (event.type === "prompt_submitted") {
-          params.opts.onExecutionStarted?.();
           attemptExecutionRuntime.emitAcpPromptSubmitted({
             runId: params.runId,
             sessionKey: params.sessionKey,

--- a/src/agents/subagents/spawn/acp-spawn-requester.ts
+++ b/src/agents/subagents/spawn/acp-spawn-requester.ts
@@ -1,4 +1,7 @@
-import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
 import { readAcpSessionMeta } from "../../../acp/runtime/session-meta.js";
 import { resolveSessionStorePathCore } from "../../../config/sessions/paths.js";
 import {
@@ -206,6 +209,7 @@ function sessionEntryIsOwnedByRequester(params: {
 export function validateAcpResumeSessionOwnership(params: {
   cfg: OpenClawConfig;
   targetAgentId: string;
+  backendId?: string;
   requesterSessionKey?: string;
   resumeSessionId?: string;
 }): { ok: true } | { ok: false; error: string } {
@@ -221,12 +225,17 @@ export function validateAcpResumeSessionOwnership(params: {
     };
   }
 
+  const configuredBackend = normalizeOptionalLowercaseString(params.backendId);
   const storePath = resolveSessionStorePathCore(params.cfg.session?.store, {
     agentId: params.targetAgentId,
   });
   for (const { sessionKey, entry } of listSessionEntriesReadOnly({ storePath, clone: false })) {
     const acp = readAcpSessionMeta({ sessionKey, cfg: params.cfg });
-    if (!sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)) {
+    // Resume identifiers are backend-local; requester ownership cannot authorize another backend.
+    if (
+      (configuredBackend && normalizeOptionalLowercaseString(acp?.backend) !== configuredBackend) ||
+      !sessionEntryMatchesAcpResumeSessionId(acp, resumeSessionId)
+    ) {
       continue;
     }
     if (

--- a/src/agents/subagents/spawn/acp-spawn-runtime.ts
+++ b/src/agents/subagents/spawn/acp-spawn-runtime.ts
@@ -147,6 +147,7 @@ export async function initializeAcpSpawnRuntime(params: {
   sessionKey: string;
   targetAgentId: string;
   runtimeMode: AcpRuntimeSessionMode;
+  backendId?: string;
   resumeSessionId?: string;
   runtimeOptions?: AcpSpawnRuntimeOptions;
   modelExplicit?: boolean;
@@ -181,7 +182,7 @@ export async function initializeAcpSpawnRuntime(params: {
     runtimeOptions: params.runtimeOptions,
     modelExplicit: params.modelExplicit,
     cwd: params.cwd,
-    backendId: params.cfg.acp?.backend,
+    backendId: params.backendId,
   });
 
   return {

--- a/src/agents/subagents/spawn/acp-spawn-target.ts
+++ b/src/agents/subagents/spawn/acp-spawn-target.ts
@@ -1,12 +1,39 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { getAcpRuntimeBackend } from "../../../acp/runtime/registry.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { normalizeAgentIdStrict, normalizeOptionalAgentId } from "../../../routing/session-key.js";
 import { listAgentEntries } from "../../agent-scope-config.js";
 import { listAgentIds } from "../../agent-scope.js";
 
+type ResolvedAcpAgentTarget = {
+  ok: true;
+  agentId: string;
+  configAgentId?: string;
+  backendId?: string;
+};
+
+function resolveAcpAgentTarget(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  configAgentId?: string;
+  agentBackend?: string;
+}): ResolvedAcpAgentTarget {
+  const backendId =
+    normalizeOptionalString(params.agentBackend) ??
+    normalizeOptionalString(params.cfg.acp?.backend) ??
+    getAcpRuntimeBackend()?.id;
+  return {
+    ok: true,
+    agentId: params.agentId,
+    ...(params.configAgentId ? { configAgentId: params.configAgentId } : {}),
+    ...(backendId ? { backendId } : {}),
+  };
+}
+
 export function resolveTargetAcpAgentId(params: {
   requestedAgentId?: string;
   cfg: OpenClawConfig;
-}): { ok: true; agentId: string; configAgentId?: string } | { ok: false; error: string } {
+}): ResolvedAcpAgentTarget | { ok: false; error: string } {
   const normalizedRequest =
     params.requestedAgentId === undefined ? null : normalizeAgentIdStrict(params.requestedAgentId);
   if (normalizedRequest && !normalizedRequest.ok) {
@@ -18,11 +45,12 @@ export function resolveTargetAcpAgentId(params: {
       (agent) => normalizeOptionalAgentId(agent.id) === requested,
     );
     if (configuredAgent?.runtime?.type === "acp") {
-      return {
-        ok: true,
+      return resolveAcpAgentTarget({
+        cfg: params.cfg,
         agentId: normalizeOptionalAgentId(configuredAgent.runtime.acp?.agent) ?? requested,
         configAgentId: requested,
-      };
+        agentBackend: configuredAgent.runtime.acp?.backend,
+      });
     }
     if (configuredAgent && !isExplicitlyAllowedAcpAgent(params.cfg, requested)) {
       return {
@@ -33,16 +61,24 @@ export function resolveTargetAcpAgentId(params: {
           'Use runtime="acp" only with external ACP harness ids such as codex, claude, droid, gemini, or opencode, or configure agents.entries.*.runtime.type="acp" with runtime.acp.agent.',
       };
     }
-    return {
-      ok: true,
+    return resolveAcpAgentTarget({
+      cfg: params.cfg,
       agentId: requested,
       ...(configuredAgent ? { configAgentId: requested } : {}),
-    };
+    });
   }
 
   const configuredDefault = normalizeOptionalAgentId(params.cfg.acp?.defaultAgent);
   if (configuredDefault) {
-    return { ok: true, agentId: configuredDefault };
+    const configuredAgent = listAgentEntries(params.cfg).find(
+      (agent) => normalizeOptionalAgentId(agent.id) === configuredDefault,
+    );
+    return resolveAcpAgentTarget({
+      cfg: params.cfg,
+      agentId: configuredDefault,
+      agentBackend:
+        configuredAgent?.runtime?.type === "acp" ? configuredAgent.runtime.acp?.backend : undefined,
+    });
   }
 
   return {

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -2,9 +2,14 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { AcpRuntime } from "@openclaw/acp-core/runtime/types";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AcpInitializeSessionInput } from "../../../acp/control-plane/manager.types.js";
+import {
+  registerAcpRuntimeBackend,
+  testing as acpRuntimeRegistryTesting,
+} from "../../../acp/runtime/registry.js";
 import { createExecutionIdentityAdmissionToken } from "../../../audit/execution-identity-admission.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
@@ -703,6 +708,7 @@ function enableTelegramCurrentConversationBindings(): void {
 
 describe("spawnAcpDirect", () => {
   beforeEach(() => {
+    acpRuntimeRegistryTesting.resetAcpRuntimeBackendsForTests();
     replaceSpawnConfig(createDefaultSpawnConfig());
     hoisted.areHeartbeatsEnabledMock.mockReset().mockReturnValue(true);
     hoisted.getChannelPluginMock.mockReset().mockReturnValue(undefined);
@@ -852,6 +858,7 @@ describe("spawnAcpDirect", () => {
   });
 
   afterEach(() => {
+    acpRuntimeRegistryTesting.resetAcpRuntimeBackendsForTests();
     sessionBindingServiceTesting.resetSessionBindingAdaptersForTests();
   });
 
@@ -998,51 +1005,142 @@ describe("spawnAcpDirect", () => {
     }
   });
 
-  it("allows ACP resume IDs recorded for the requester session", async () => {
-    const resumeSessionId = "codex-inner-resume";
-    const ownedSessionKey = "agent:codex:acp:owned";
-    hoisted.loadSessionStoreMock.mockReturnValue({
-      [ownedSessionKey]: {
-        sessionId: "sess-owned",
-        updatedAt: Date.now(),
-        spawnedBy: "agent:main:main",
-      } satisfies SessionEntry,
-    });
-    hoisted.readAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
-      const params = paramsUnknown as { sessionKey?: string };
-      return params.sessionKey === ownedSessionKey
-        ? {
-            backend: "acpx",
-            agent: "codex",
-            runtimeSessionName: "codex",
-            identity: {
-              state: "resolved",
-              source: "ensure",
-              agentSessionId: resumeSessionId,
-              acpxSessionId: "acpx-owned",
-              lastUpdatedAt: Date.now(),
-            },
-            mode: "oneshot",
-            state: "idle",
-            lastActivityAt: Date.now(),
-          }
-        : undefined;
-    });
+  it.each([
+    {
+      scenario: "explicit global backend accepts its owner",
+      persistedBackend: "acpx",
+      accepted: true,
+      expectedBackend: "acpx",
+    },
+    {
+      scenario: "explicit global backend rejects another owner",
+      persistedBackend: "fallback",
+      accepted: false,
+      expectedBackend: "acpx",
+    },
+    {
+      scenario: "target agent backend overrides the global backend",
+      persistedBackend: "fallback",
+      targetBackend: "fallback",
+      accepted: true,
+      expectedBackend: "fallback",
+    },
+    {
+      scenario: "target agent backend rejects the global backend owner",
+      persistedBackend: "acpx",
+      targetBackend: "fallback",
+      accepted: false,
+      expectedBackend: "fallback",
+    },
+    {
+      scenario: "auto-selected healthy backend rejects another owner",
+      persistedBackend: "fallback",
+      autoSelectBackend: true,
+      accepted: false,
+      expectedBackend: "primary",
+    },
+    {
+      scenario: "auto-selected healthy backend accepts its owner",
+      persistedBackend: "primary",
+      autoSelectBackend: true,
+      accepted: true,
+      expectedBackend: "primary",
+    },
+  ])(
+    "allows requester-owned ACP resume IDs only for the effective backend ($scenario)",
+    async ({ persistedBackend, targetBackend, autoSelectBackend, accepted, expectedBackend }) => {
+      if (targetBackend) {
+        replaceSpawnConfig({
+          ...hoisted.state.cfg,
+          agents: {
+            ...hoisted.state.cfg.agents,
+            list: [
+              {
+                id: "reviewer",
+                runtime: {
+                  type: "acp",
+                  acp: { agent: "codex", backend: targetBackend },
+                },
+              },
+            ],
+          },
+        });
+      }
+      if (autoSelectBackend) {
+        const { backend: _configuredBackend, ...acpWithoutBackend } = hoisted.state.cfg.acp ?? {};
+        replaceSpawnConfig({ ...hoisted.state.cfg, acp: acpWithoutBackend });
+        const runtime: AcpRuntime = {
+          async ensureSession(input) {
+            return {
+              sessionKey: input.sessionKey,
+              backend: "primary",
+              runtimeSessionName: input.sessionKey,
+            };
+          },
+          async *runTurn() {},
+          async cancel() {},
+          async close() {},
+        };
+        registerAcpRuntimeBackend({ id: "unhealthy", runtime, healthy: () => false });
+        registerAcpRuntimeBackend({ id: "primary", runtime, healthy: () => true });
+        registerAcpRuntimeBackend({ id: "fallback", runtime, healthy: () => true });
+      }
 
-    const result = await spawnAcpDirect(
-      {
-        task: "Resume owned ACP session",
-        agentId: "codex",
-        resumeSessionId,
-      },
-      {
-        agentSessionKey: "agent:main:main",
-      },
-    );
+      const resumeSessionId = "codex-inner-resume";
+      const ownedSessionKey = "agent:codex:acp:owned";
+      hoisted.loadSessionStoreMock.mockReturnValue({
+        [ownedSessionKey]: {
+          sessionId: "sess-owned",
+          updatedAt: Date.now(),
+          spawnedBy: "agent:main:main",
+        } satisfies SessionEntry,
+      });
+      hoisted.readAcpSessionMetaMock.mockImplementation((paramsUnknown: unknown) => {
+        const params = paramsUnknown as { sessionKey?: string };
+        return params.sessionKey === ownedSessionKey
+          ? {
+              backend: persistedBackend,
+              agent: "codex",
+              runtimeSessionName: "codex",
+              identity: {
+                state: "resolved",
+                source: "ensure",
+                agentSessionId: resumeSessionId,
+                acpxSessionId: "acpx-owned",
+                lastUpdatedAt: Date.now(),
+              },
+              mode: "oneshot",
+              state: "idle",
+              lastActivityAt: Date.now(),
+            }
+          : undefined;
+      });
 
-    expectAcceptedSpawn(result);
-    expectInitializeSessionFields({ resumeSessionId });
-  });
+      const result = await spawnAcpDirect(
+        {
+          task: "Resume owned ACP session",
+          agentId: targetBackend ? "reviewer" : "codex",
+          resumeSessionId,
+        },
+        {
+          agentSessionKey: "agent:main:main",
+        },
+      );
+
+      if (accepted) {
+        expectAcceptedSpawn(result);
+        expectInitializeSessionFields({ resumeSessionId, backendId: expectedBackend });
+        return;
+      }
+
+      expectRecordFields(result, {
+        status: "forbidden",
+        errorCode: "resume_forbidden",
+      });
+      expect(hoisted.initializeSessionMock).not.toHaveBeenCalled();
+      expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects ACP resume IDs not recorded for the requester session", async () => {
     const otherSessionKey = "agent:codex:acp:other";

--- a/src/agents/subagents/spawn/acp-spawn.ts
+++ b/src/agents/subagents/spawn/acp-spawn.ts
@@ -320,7 +320,7 @@ export async function spawnAcpDirect(
       error: targetAgentResult.error,
     });
   }
-  const targetAgentId = targetAgentResult.agentId;
+  const { agentId: targetAgentId, backendId } = targetAgentResult;
   const agentPolicyError = resolveAcpAgentPolicyError(cfg, targetAgentId);
   if (agentPolicyError) {
     return createAcpSpawnFailure({
@@ -367,6 +367,7 @@ export async function spawnAcpDirect(
   const resumeAuthorization = validateAcpResumeSessionOwnership({
     cfg,
     targetAgentId,
+    backendId,
     requesterSessionKey: requesterInternalKey,
     resumeSessionId: params.resumeSessionId,
   });
@@ -528,6 +529,7 @@ export async function spawnAcpDirect(
         sessionKey,
         targetAgentId,
         runtimeMode,
+        backendId,
         resumeSessionId: params.resumeSessionId,
         runtimeOptions: runtimeOptionsResult.runtimeOptions,
         modelExplicit: runtimeOptionsResult.modelExplicit,
@@ -715,16 +717,13 @@ export async function spawnAcpDirect(
       runId: pipelineResult.runId,
     });
   }
-  const childRunId = pipelineResult.runId;
-  const deliveryPlan = pipelineResult.state.deliveryPlan;
-
   return {
     status: "accepted",
     childSessionKey: sessionKey,
-    runId: childRunId,
+    runId: pipelineResult.runId,
     mode: spawnMode,
     runTimeoutSeconds,
-    ...(deliveryPlan?.useInlineDelivery ? { inlineDelivery: true } : {}),
+    ...(pipelineResult.state.deliveryPlan?.useInlineDelivery ? { inlineDelivery: true } : {}),
     note: spawnMode === "session" ? ACP_SPAWN_SESSION_ACCEPTED_NOTE : ACP_SPAWN_ACCEPTED_NOTE,
   };
 }

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -159,7 +159,8 @@ vi.mock("../../infra/outbound/session-binding-service.js", async () => {
 
 const { handleAcpCommand } = await import("./commands-acp.js");
 const { buildCommandTestParams } = await import("./commands-spawn.test-harness.js");
-const { testing: acpManagerTesting } = await import("../../acp/control-plane/manager.js");
+const { AcpSessionManager, testing: acpManagerTesting } =
+  await import("../../acp/control-plane/manager.js");
 const { resolveEffectiveResetTargetSessionKey } = await import("./acp-reset-target.js");
 const { testing: acpResetTargetTesting } = await import("./acp-reset-target.test-support.js");
 const { createTaskRecord } = await import("../../tasks/task-registry.js");
@@ -1409,6 +1410,67 @@ describe("/acp command", () => {
         conversationId: "user:U123",
       },
     });
+  });
+
+  it("keeps freshly spawned Slack-bound ACP metadata readable for the immediate follow-up", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-acp-bound-followup-"));
+    const databasePath = path.join(directory, "state", "openclaw.sqlite");
+    const cfg = {
+      ...baseCfg,
+      session: { ...baseCfg.session, store: path.join(directory, "sessions.json") },
+    } satisfies OpenClawConfig;
+    const sessionMeta = await vi.importActual<typeof import("../../acp/runtime/session-meta.js")>(
+      "../../acp/runtime/session-meta.js",
+    );
+    const { createTestAdmittedRunContext } =
+      await import("../../agents/admitted-run-context.test-support.js");
+    const { closeOpenClawAgentDatabasesForTest } = await import("../../state/openclaw-agent-db.js");
+    const { closeOpenClawStateDatabaseForTest } = await import("../../state/openclaw-state-db.js");
+
+    hoisted.upsertAcpSessionMetaMock.mockImplementation((input) =>
+      sessionMeta.upsertAcpSessionMeta({ ...input, cfg, databasePath, now: () => 1 }),
+    );
+    hoisted.readAcpSessionEntryMock.mockImplementation((input) =>
+      sessionMeta.readAcpSessionEntry({ ...input, cfg, databasePath }),
+    );
+    const manager = new AcpSessionManager();
+    acpManagerTesting.setAcpSessionManagerForTests(manager);
+
+    try {
+      const result = await runSlackDmAcpCommand("/acp spawn codex --bind here", cfg);
+      expect(result?.reply?.text).toContain("Bound this conversation to");
+      const binding = expectBindingBindCall({
+        placement: "current",
+        conversation: {
+          channel: "slack",
+          accountId: "default",
+          conversationId: "user:U123",
+        },
+      });
+      const requestId = "immediate-bound-followup";
+      const sessionKey = binding.targetSessionKey;
+      if (typeof sessionKey !== "string") {
+        throw new Error("Expected the published binding to own an ACP session key");
+      }
+
+      await expect(
+        manager.runTurn({
+          admittedRunContext: createTestAdmittedRunContext(requestId),
+          cfg,
+          sessionKey,
+          provenance: "human",
+          text: "continue the bound ACP session",
+          mode: "prompt",
+          requestId,
+        }),
+      ).resolves.toBeUndefined();
+      expect(hoisted.runTurnMock).toHaveBeenCalledTimes(1);
+    } finally {
+      acpManagerTesting.resetAcpSessionManagerForTests();
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      await fs.rm(directory, { recursive: true, force: true });
+    }
   });
 
   it("binds Telegram topic ACP spawns to full conversation ids", async () => {

--- a/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
+++ b/src/channels/plugins/contracts/test-helpers/registry-session-binding.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { expect } from "vitest";
 import type { OpenClawConfig } from "../../../../config/config.js";
+import { testing as currentConversationBindingTesting } from "../../../../infra/outbound/current-conversation-bindings.js";
 import {
   getSessionBindingService,
   type SessionBindingRecord,
@@ -162,6 +163,7 @@ type ChannelConversationBindingManager = Awaited<
 >;
 let discordSessionBindingManager: ChannelConversationBindingManager | null = null;
 let feishuSessionBindingManager: ChannelConversationBindingManager | null = null;
+let imessageSessionBindingManager: ChannelConversationBindingManager | null = null;
 let matrixSessionBindingManager: ChannelConversationBindingManager | null = null;
 let telegramSessionBindingManager: ChannelConversationBindingManager | null = null;
 
@@ -177,10 +179,7 @@ type FeishuContractApi = {
 };
 
 type IMessageContractApi = {
-  createIMessageConversationBindingManager: ChannelConversationBindingManagerFactory;
-  imessageConversationBindingTesting: {
-    resetIMessageConversationBindingsForTests: () => void;
-  };
+  imessagePlugin: ChannelPlugin;
 };
 
 type MatrixContractApi = {
@@ -199,41 +198,12 @@ type TelegramContractApi = {
   telegramPlugin: ChannelPlugin;
 };
 
-function setRegistryBackedConversationBindingPlugin(params: {
-  id: SessionBindingContractChannelId;
-  createManager: ChannelConversationBindingManagerFactory;
-}) {
-  const plugin = {
-    id: params.id,
-    meta: {
-      id: params.id,
-      label: params.id,
-      selectionLabel: params.id,
-      blurb: "session binding contract fixture",
-    },
-    capabilities: { chatTypes: ["direct"] },
-    config: {
-      listAccountIds: () => ["default"],
-      resolveAccount: () => ({}),
-    },
-    conversationBindings: {
-      supportsCurrentConversationBinding: true,
-      createManager: params.createManager,
-    },
-  } as unknown as ChannelPlugin;
-  setActivePluginRegistry(
-    createTestRegistry([
-      {
-        pluginId: params.id,
-        plugin,
-        source: "test",
-      },
-    ]),
-  );
-}
-
 async function getDiscordContractApi() {
   return await getContractApi<DiscordContractApi>("discord", "channel-plugin-api");
+}
+
+async function getIMessageContractApi() {
+  return await getContractApi<IMessageContractApi>("imessage", "channel-plugin-api");
 }
 
 async function getTelegramContractApi() {
@@ -251,6 +221,11 @@ async function stopDiscordSessionBindingManager() {
 async function stopFeishuSessionBindingManager() {
   await feishuSessionBindingManager?.stop();
   feishuSessionBindingManager = null;
+}
+
+async function stopIMessageSessionBindingManager() {
+  await imessageSessionBindingManager?.stop();
+  imessageSessionBindingManager = null;
 }
 
 async function stopMatrixSessionBindingManager() {
@@ -282,12 +257,28 @@ async function prepareFeishuSessionBindingContract() {
 }
 
 async function prepareIMessageSessionBindingContract() {
-  const api = await getContractApi<IMessageContractApi>("imessage");
-  api.imessageConversationBindingTesting.resetIMessageConversationBindingsForTests();
-  setRegistryBackedConversationBindingPlugin({
-    id: "imessage",
-    createManager: api.createIMessageConversationBindingManager,
+  await stopIMessageSessionBindingManager();
+  const { imessagePlugin } = await getIMessageContractApi();
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "imessage",
+        plugin: imessagePlugin,
+        source: "test",
+      },
+    ]),
+  );
+}
+
+async function ensureIMessageSessionBindingManager() {
+  imessageSessionBindingManager ??= await createContractChannelConversationBindingManager({
+    channelId: "imessage",
+    cfg: baseSessionBindingCfg,
+    accountId: "default",
   });
+  if (!imessageSessionBindingManager) {
+    throw new Error("iMessage session binding manager is unavailable");
+  }
 }
 
 async function prepareMatrixSessionBindingContract() {
@@ -315,6 +306,7 @@ type SessionBindingContractFixture = {
   conversationId: string;
   parentConversationId?: string;
   targetSessionKey: string;
+  expectedBindingId?: string;
   targetKind: SessionBindingRecord["targetKind"];
   label: string;
   placements: SessionBindingCapabilities["placements"];
@@ -322,6 +314,7 @@ type SessionBindingContractFixture = {
   beforeEach: () => Promise<void>;
   ensureManager: () => Promise<void>;
   stopManager?: () => Promise<void>;
+  resetProcessMemory?: () => Promise<void>;
 };
 
 function createSessionBindingContractEntry(
@@ -361,10 +354,20 @@ function createSessionBindingContractEntry(
         placement: "current",
         metadata: { agentId: fixture.id, label: fixture.label },
       });
+      if (fixture.expectedBindingId) {
+        expect(binding.bindingId).toBe(fixture.expectedBindingId);
+      }
       expectResolvedSessionBinding({
         ...conversation,
         targetSessionKey: fixture.targetSessionKey,
       });
+      if (fixture.resetProcessMemory) {
+        await fixture.resetProcessMemory();
+        expectResolvedSessionBinding({
+          ...conversation,
+          targetSessionKey: fixture.targetSessionKey,
+        });
+      }
       return binding;
     },
     unbindAndVerify: unbindAndExpectClearedSessionBinding,
@@ -424,25 +427,18 @@ const sessionBindingContractEntries = {
     accountId: "default",
     conversationId: "+15555550124",
     targetSessionKey: "agent:imessage:current",
+    expectedBindingId: "default:+15555550124",
     targetKind: "session",
     label: "imessage-main",
     placements: ["current"],
-    preload: () => getContractApi<IMessageContractApi>("imessage"),
+    preload: getIMessageContractApi,
     beforeEach: prepareIMessageSessionBindingContract,
-    ensureManager: async () => {
-      await createContractChannelConversationBindingManager({
-        channelId: "imessage",
-        cfg: baseSessionBindingCfg,
-        accountId: "default",
-      });
-    },
-    stopManager: async () => {
-      const manager = await createContractChannelConversationBindingManager({
-        channelId: "imessage",
-        cfg: baseSessionBindingCfg,
-        accountId: "default",
-      });
-      await manager?.stop();
+    ensureManager: ensureIMessageSessionBindingManager,
+    stopManager: stopIMessageSessionBindingManager,
+    resetProcessMemory: async () => {
+      await stopIMessageSessionBindingManager();
+      currentConversationBindingTesting.resetCurrentConversationBindingsForTests();
+      await ensureIMessageSessionBindingManager();
     },
   }),
   matrix: createSessionBindingContractEntry({

--- a/src/channels/plugins/contracts/test-helpers/session-binding-registry-backed-contract.ts
+++ b/src/channels/plugins/contracts/test-helpers/session-binding-registry-backed-contract.ts
@@ -11,6 +11,10 @@ import {
 } from "../../../../infra/outbound/session-binding-service.js";
 import type { SessionBindingCapabilities } from "../../../../infra/outbound/session-binding.types.js";
 import { resetPluginRuntimeStateForTest } from "../../../../plugins/runtime.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../../../test-utils/openclaw-test-state.js";
 import { getSessionBindingContractRegistry } from "./registry-session-binding.js";
 
 function resolveSessionBindingContractRuntimeConfig(id: string) {
@@ -63,11 +67,17 @@ export function describeSessionBindingRegistryBackedContract(id: string) {
   }
 
   describe(`${entry.id} session binding contract`, () => {
+    let testState: OpenClawTestState | undefined;
+
     beforeAll(async () => {
       await entry.preload?.();
     });
 
     beforeEach(async () => {
+      testState = await createOpenClawTestState({
+        label: `${entry.id}-session-binding-contract`,
+        layout: "state-only",
+      });
       resetPluginRuntimeStateForTest();
       clearRuntimeConfigSnapshot();
       // Keep the suite hermetic; some contract helpers resolve runtime artifacts through config-aware
@@ -79,8 +89,10 @@ export function describeSessionBindingRegistryBackedContract(id: string) {
       sessionBindingTesting.resetSessionBindingAdaptersForTests();
       await entry.beforeEach?.();
     });
-    afterEach(() => {
+    afterEach(async () => {
       clearRuntimeConfigSnapshot();
+      await testState?.cleanup();
+      testState = undefined;
     });
 
     installSessionBindingContractSuite({

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -247,7 +247,7 @@ async function handleChatHistoryRequest({
   const selectedAgent = validateChatSelectedAgent({
     cfg,
     requestedSessionKey: sessionKey,
-    agentId: requestedAgentId,
+    explicitAgentId: agentIdOverride,
   });
   if (!selectedAgent.ok) {
     respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, selectedAgent.error));

--- a/src/gateway/server-methods/chat-message-get-handler.ts
+++ b/src/gateway/server-methods/chat-message-get-handler.ts
@@ -86,7 +86,7 @@ export const chatMessageGetHandlers: GatewayRequestHandlers = {
     const selectedAgent = validateChatSelectedAgent({
       cfg,
       requestedSessionKey: sessionKey,
-      agentId: requestedAgentId,
+      explicitAgentId: agentIdOverride,
     });
     if (!selectedAgent.ok) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, selectedAgent.error));

--- a/src/gateway/server-methods/chat-origin-routing.test.ts
+++ b/src/gateway/server-methods/chat-origin-routing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveRequestedChatAgentId } from "./chat-origin-routing.js";
+import { resolveRequestedChatAgentId, validateChatSelectedAgent } from "./chat-origin-routing.js";
 
 describe("chat session owner resolution", () => {
   it("uses configured fixed-store ownership for bare keys", () => {
@@ -28,5 +28,75 @@ describe("chat session owner resolution", () => {
       ok: false,
       error: { code: "INVALID_REQUEST", message: expect.stringContaining("has no explicit owner") },
     });
+  });
+
+  it("preserves an inferred ACP runtime owner through chat session validation", () => {
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: { default: true } } },
+    };
+    const requestedSessionKey = "agent:codex:acp:11111111-1111-4111-8111-111111111111";
+
+    const requestedAgent = resolveRequestedChatAgentId({ cfg, requestedSessionKey });
+
+    expect(requestedAgent).toEqual({ ok: true, agentId: "codex" });
+    if (!requestedAgent.ok) {
+      throw new Error("Expected the ACP session key to resolve its runtime owner");
+    }
+    expect(
+      validateChatSelectedAgent({
+        cfg,
+        requestedSessionKey,
+      }),
+    ).toEqual({ ok: true, agentId: "codex" });
+  });
+
+  it("still rejects an explicitly selected unconfigured ACP runtime owner", () => {
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: { default: true } } },
+    };
+
+    expect(
+      resolveRequestedChatAgentId({
+        cfg,
+        requestedSessionKey: "agent:codex:acp:11111111-1111-4111-8111-111111111111",
+        agentId: "codex",
+      }),
+    ).toMatchObject({
+      ok: false,
+      error: { code: "INVALID_REQUEST", message: 'Unknown agent id "codex"' },
+    });
+    expect(
+      validateChatSelectedAgent({
+        cfg,
+        requestedSessionKey: "agent:codex:acp:11111111-1111-4111-8111-111111111111",
+        explicitAgentId: "codex",
+      }),
+    ).toEqual({ ok: false, error: 'Unknown agent id "codex"' });
+  });
+
+  it.each([
+    ["ordinary configured owner", "agent:main:main"],
+    ["configured ACP binding owner", "agent:main:acp:binding:slack:default:thread"],
+  ])("preserves %s across chat session validation", (_name, requestedSessionKey) => {
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: { default: true } } },
+    };
+    const requestedAgent = resolveRequestedChatAgentId({
+      cfg,
+      requestedSessionKey,
+      agentId: "main",
+    });
+
+    expect(requestedAgent).toEqual({ ok: true, agentId: "main" });
+    if (!requestedAgent.ok) {
+      throw new Error("Expected the configured chat session owner to resolve");
+    }
+    expect(
+      validateChatSelectedAgent({
+        cfg,
+        requestedSessionKey,
+        explicitAgentId: "main",
+      }),
+    ).toEqual({ ok: true, agentId: "main" });
   });
 });

--- a/src/gateway/server-methods/chat-origin-routing.ts
+++ b/src/gateway/server-methods/chat-origin-routing.ts
@@ -102,12 +102,12 @@ export function normalizeExplicitChatSendOrigin(
 export function validateChatSelectedAgent(params: {
   cfg: OpenClawConfig;
   requestedSessionKey: string;
-  agentId?: string;
+  explicitAgentId?: string;
 }): { ok: true; agentId?: string } | { ok: false; error: string } {
   const resolved = resolveRequestedSessionAgentId(
     params.cfg,
     params.requestedSessionKey,
-    params.agentId,
+    params.explicitAgentId,
   );
   return resolved.ok
     ? { ok: true, agentId: resolved.agentId }

--- a/src/gateway/server-methods/chat-send-session.ts
+++ b/src/gateway/server-methods/chat-send-session.ts
@@ -99,6 +99,7 @@ function loadChatSendSessionContext(params: {
       legacyKey,
       sessionRoutingChanged,
       expectedLeafEntryId,
+      agentIdOverride,
       requestedAgentId,
     },
   };
@@ -117,7 +118,7 @@ export function prepareChatSendSession(params: {
   const loadedValue = loaded.value;
   const { request, client } = params;
   const { p, explicitOrigin, normalizedAttachments, turnKind, rawMessage } = request;
-  const { cfg, sessionKey, entry, legacyKey, rawSessionKey, requestedAgentId } = loadedValue;
+  const { cfg, sessionKey, entry, legacyKey, rawSessionKey, agentIdOverride } = loadedValue;
   if (isIncognitoSessionKey(sessionKey) && !entry) {
     return { ok: false as const, error: `Incognito session "${sessionKey}" was not found.` };
   }
@@ -129,7 +130,7 @@ export function prepareChatSendSession(params: {
   const selectedAgent = validateChatSelectedAgent({
     cfg,
     requestedSessionKey: rawSessionKey,
-    agentId: requestedAgentId,
+    explicitAgentId: agentIdOverride,
   });
   if (!selectedAgent.ok) {
     return { ok: false as const, error: selectedAgent.error };

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -72,11 +72,10 @@ export const chatHandlers: GatewayRequestHandlers = {
       respond(false, undefined, requestedAgent.error);
       return;
     }
-    const requestedAgentId = requestedAgent.agentId;
     const selectedAgent = validateChatSelectedAgent({
       cfg,
       requestedSessionKey: params.sessionKey,
-      agentId: requestedAgentId,
+      explicitAgentId: agentIdOverride,
     });
     if (!selectedAgent.ok) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, selectedAgent.error));
@@ -124,10 +123,11 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     // Load session to find transcript file
     const rawSessionKey = p.sessionKey;
+    const agentIdOverride = normalizeOptionalText(p.agentId);
     const requestedAgent = resolveRequestedChatAgentId({
       cfg: (context as { getRuntimeConfig?: () => OpenClawConfig }).getRuntimeConfig?.(),
       requestedSessionKey: rawSessionKey,
-      agentId: p.agentId,
+      agentId: agentIdOverride,
     });
     if (!requestedAgent.ok) {
       respond(false, undefined, requestedAgent.error);
@@ -144,7 +144,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     const selectedAgent = validateChatSelectedAgent({
       cfg,
       requestedSessionKey: rawSessionKey,
-      agentId: requestedAgentId,
+      explicitAgentId: agentIdOverride,
     });
     if (!selectedAgent.ok) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, selectedAgent.error));

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -1,11 +1,13 @@
 // Gateway chat integration tests cover dashboard chat requests, transcript
 // history limits, model overrides, inbound dispatch, and streaming event fanout.
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { upsertAcpSessionMeta } from "../acp/runtime/session-meta.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
 import { createSessionsHistoryTool } from "../agents/tools/sessions-history-tool.js";
 import type { GetReplyOptions } from "../auto-reply/get-reply-options.types.js";
@@ -683,7 +685,122 @@ async function prepareMainHistoryHarness(params: {
   return sessionDir;
 }
 
+async function prepareUnconfiguredAcpHarnessSession(options?: { withMetadata?: boolean }) {
+  openDirectChatSession();
+  const sessionKey = `agent:codex:acp:${randomUUID()}`;
+  const config: OpenClawConfig = {
+    agents: { entries: { main: { default: true } } },
+    acp: { enabled: true, backend: "acpx", allowedAgents: ["codex"] },
+  };
+  testState.agentsConfig = config.agents;
+  await writeGatewayConfig(config);
+  if (options?.withMetadata === false) {
+    await writeSessionStore({
+      agentId: "codex",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-acp-codex",
+          updatedAt: Date.now(),
+        },
+      },
+    });
+  } else {
+    await upsertAcpSessionMeta({
+      sessionKey,
+      agentId: "codex",
+      cfg: getRuntimeConfig(),
+      now: () => 1,
+      mutate: () => ({
+        backend: "acpx",
+        agent: "codex",
+        runtimeSessionName: sessionKey,
+        mode: "persistent",
+        state: "idle",
+        lastActivityAt: Date.now(),
+      }),
+    });
+  }
+  return sessionKey;
+}
+
 describe("gateway server chat", () => {
+  test.each(["chat.history", "chat.startup"] as const)(
+    "%s reads a persisted ACP harness session without configuring its harness as an ordinary agent",
+    async (method) => {
+      try {
+        const sessionKey = await prepareUnconfiguredAcpHarnessSession();
+        const responses: CapturedChatResponse[] = [];
+        await callDirectChat(method, {
+          id: `acp-harness-${method}`,
+          params: { sessionKey },
+          respond: captureChatResponse(responses),
+          context: createDirectChatContext({ getRuntimeConfig }),
+        });
+
+        expect(responses).toHaveLength(1);
+        expect(responses[0]?.ok, JSON.stringify(responses[0]?.error ?? null)).toBe(true);
+      } finally {
+        testState.agentsConfig = undefined;
+        resetDirectChatSession();
+      }
+    },
+  );
+
+  test("chat.send accepts a persisted ACP harness without configuring it as an ordinary agent", async () => {
+    try {
+      const sessionKey = await prepareUnconfiguredAcpHarnessSession();
+      const responses: CapturedChatResponse[] = [];
+      const context = createDirectChatContext({ getRuntimeConfig });
+      await callDirectChat("chat.send", {
+        id: "acp-harness-send",
+        params: {
+          sessionKey,
+          message: "continue the bound ACP session",
+          idempotencyKey: "acp-harness-send",
+        },
+        respond: captureChatResponse(responses),
+        context,
+      });
+
+      expect(responses).toHaveLength(1);
+      expect(responses[0]?.ok, JSON.stringify(responses[0]?.error ?? null)).toBe(true);
+      expect(responses[0]?.payload).toMatchObject({ status: "started" });
+      await waitForFast(
+        () => expect(context.removeChatRun).toHaveBeenCalledTimes(1),
+        FAST_WAIT_OPTS,
+      );
+    } finally {
+      testState.agentsConfig = undefined;
+      resetDirectChatSession();
+    }
+  });
+
+  test("chat.send rejects an unconfigured ACP-shaped session without authoritative ACP metadata", async () => {
+    try {
+      const sessionKey = await prepareUnconfiguredAcpHarnessSession({ withMetadata: false });
+      const responses: CapturedChatResponse[] = [];
+      await callDirectChat("chat.send", {
+        id: "acp-harness-forged",
+        params: {
+          sessionKey,
+          message: "reject an unconfirmed ACP session",
+          idempotencyKey: "acp-harness-forged",
+        },
+        respond: captureChatResponse(responses),
+        context: createDirectChatContext({ getRuntimeConfig }),
+      });
+
+      expect(responses).toHaveLength(1);
+      expect(responses[0]).toMatchObject({
+        ok: false,
+        error: { message: 'Agent "codex" no longer exists in configuration' },
+      });
+    } finally {
+      testState.agentsConfig = undefined;
+      resetDirectChatSession();
+    }
+  });
+
   test.each(["chat.history", "chat.startup"] as const)(
     "%s projects the session's durable worker placement",
     async (method) => {

--- a/src/gateway/server/hooks.early-failure.test.ts
+++ b/src/gateway/server/hooks.early-failure.test.ts
@@ -1,6 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Readable } from "node:stream";
+import type { AcpRuntime, AcpRuntimeTurnInput } from "@openclaw/acp-core/runtime/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { consumeAcpTurnStream } from "../../acp/control-plane/manager.turn-stream.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveSystemEventOptionsOwnerAgentId } from "../../infra/system-event-ownership.js";
 import {
@@ -39,7 +42,10 @@ function createConfig(global: boolean): OpenClawConfig {
   };
 }
 
-async function postAgentHook(global: boolean) {
+async function postAgentHook(
+  global: boolean,
+  options: { admissionTimeoutMs?: number; rejectInitialConfig?: boolean } = {},
+) {
   const config = createConfig(global);
   const hooksConfig = resolveHooksConfig(config);
   if (!hooksConfig) {
@@ -52,6 +58,7 @@ async function postAgentHook(global: boolean) {
     bindHost: "127.0.0.1",
     port: 18789,
     logHooks: { warn: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn() } as never,
+    agentStartAdmissionTimeoutMs: options.admissionTimeoutMs,
   });
   const req = Object.assign(
     Readable.from([JSON.stringify({ message: "Dispatch", name: "Recovery", agentId: "hooks" })]),
@@ -74,11 +81,12 @@ async function postAgentHook(global: boolean) {
     }),
   } as unknown as ServerResponse;
 
-  mocks.getRuntimeConfig
-    .mockImplementationOnce(() => {
+  if (options.rejectInitialConfig !== false) {
+    mocks.getRuntimeConfig.mockImplementationOnce(() => {
       throw new Error("required system config unavailable");
-    })
-    .mockReturnValue(config);
+    });
+  }
+  mocks.getRuntimeConfig.mockReturnValue(config);
   expect(await handler(req, res)).toBe(true);
   return { body: JSON.parse(responseBody) as unknown, status: res.statusCode };
 }
@@ -125,4 +133,73 @@ describe("gateway hook early-failure recovery", () => {
     });
     await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
   });
+
+  it.each(["startTurn", "runTurn"] as const)(
+    "does not invoke ACP %s after the final Gateway admission deadline rejects the prompt",
+    async (runtimeApi) => {
+      const releasePreparation = createDeferred();
+      const handle = {
+        sessionKey: "agent:hooks:acp:gateway-admission",
+        backend: "test-acp",
+        runtimeSessionName: "gateway-admission",
+      };
+      const startTurn = vi.fn((turn: AcpRuntimeTurnInput) => ({
+        requestId: turn.requestId,
+        promptStarted: Promise.resolve(),
+        events: (async function* () {})(),
+        result: Promise.resolve({ status: "completed" as const }),
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {}),
+      }));
+      const runTurn = vi.fn((_turn: AcpRuntimeTurnInput) => (async function* () {})());
+      const runtime = {
+        ensureSession: vi.fn(async () => handle),
+        ...(runtimeApi === "startTurn" ? { startTurn } : {}),
+        runTurn,
+        cancel: vi.fn(async () => {}),
+        close: vi.fn(async () => {}),
+      } satisfies AcpRuntime;
+
+      mocks.runCronIsolatedAgentTurn.mockImplementationOnce(
+        async (params: { onExecutionStarted?: () => void; abortSignal?: AbortSignal }) => {
+          await releasePreparation.promise;
+          const streamOptions = {
+            runtime,
+            turn: {
+              handle,
+              text: "Dispatch",
+              mode: "prompt" as const,
+              requestId: `gateway-admission-${runtimeApi}`,
+              signal: params.abortSignal,
+            },
+            eventGate: { open: true },
+            onBeforePrompt: params.onExecutionStarted,
+            onPromptStarted: () => params.onExecutionStarted?.(),
+          };
+          await consumeAcpTurnStream(streamOptions);
+          return { status: "ok", summary: "done" };
+        },
+      );
+
+      try {
+        const response = await postAgentHook(false, {
+          admissionTimeoutMs: 10,
+          rejectInitialConfig: false,
+        });
+
+        expect(response.status).toBe(503);
+        expect(response.body).toMatchObject({
+          ok: false,
+          error: "hook agent run did not start before admission timeout",
+        });
+      } finally {
+        releasePreparation.resolve();
+      }
+
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+      expect(mocks.runCronIsolatedAgentTurn).toHaveBeenCalledOnce();
+      expect(startTurn).not.toHaveBeenCalled();
+      expect(runTurn).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/infra/outbound/account-scoped-conversation-bindings.test.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.test.ts
@@ -1,10 +1,18 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
 import {
   createAccountScopedConversationBindingManager,
   resetAccountScopedConversationBindingsForTests,
   type AccountScopedConversationBindingManager,
 } from "./account-scoped-conversation-bindings.js";
+import { testing as currentConversationBindingTesting } from "./current-conversation-bindings.js";
 import { getSessionBindingService } from "./session-binding-service.js";
 
 type TestBindingKind = "subagent" | "acp";
@@ -47,13 +55,127 @@ function bindConversation(
 }
 
 describe("account-scoped conversation binding expiry", () => {
-  beforeEach(() => {
+  let previousStateDir: string | undefined;
+  let testStateDir = "";
+
+  beforeEach(async () => {
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    testStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-account-bindings-"));
+    process.env.OPENCLAW_STATE_DIR = testStateDir;
     resetAccountScopedConversationBindingsForTests({ stateKey });
+    currentConversationBindingTesting.resetCurrentConversationBindingsForTests({
+      deletePersistedFile: true,
+    });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     resetAccountScopedConversationBindingsForTests({ stateKey });
+    currentConversationBindingTesting.resetCurrentConversationBindingsForTests({
+      deletePersistedFile: true,
+    });
+    closeOpenClawStateDatabaseForTest();
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    await fs.rm(testStateDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+  });
+
+  it("preserves account-owned bindings after stop, manager recreation, and database reopen", () => {
+    const manager = createManager();
+    const binding = bindConversation(manager, { conversationId: "chat:durable-owner" });
+    const conversation = {
+      channel: "imessage",
+      accountId: manager.accountId,
+      conversationId: binding.conversationId,
+    };
+
+    expect(getSessionBindingService().resolveByConversation(conversation)?.bindingId).toBe(
+      "ttl-owner:chat:durable-owner",
+    );
+
+    manager.stop();
+    currentConversationBindingTesting.resetCurrentConversationBindingsForTests();
+    closeOpenClawStateDatabaseForTest();
+
+    const restarted = createManager();
+    expect(restarted.getByConversationId(binding.conversationId)).toEqual(binding);
+    expect(getSessionBindingService().resolveByConversation(conversation)).toMatchObject({
+      bindingId: "ttl-owner:chat:durable-owner",
+      targetKind: "subagent",
+      targetSessionKey: binding.targetSessionKey,
+    });
+  });
+
+  it("preserves the complete opaque adapter metadata envelope through recreation", async () => {
+    const manager = createManager();
+    const metadata = {
+      agentId: "main",
+      label: "durable label",
+      boundBy: "operator",
+      pluginBindingOwner: "owner-plugin",
+      pluginId: "opaque-plugin",
+      nested: { ownerEpoch: 7, capabilities: ["approve", "resume"] },
+    };
+    const conversation = {
+      channel: "imessage",
+      accountId: manager.accountId,
+      conversationId: "chat:opaque-metadata",
+    };
+    const bound = await getSessionBindingService().bind({
+      targetSessionKey: "agent:main:acp:opaque-session",
+      targetKind: "session",
+      conversation,
+      metadata,
+    });
+
+    expect(bound.bindingId).toBe("ttl-owner:chat:opaque-metadata");
+    expect(bound.metadata).toMatchObject(metadata);
+    expect(manager.getByConversationId(conversation.conversationId)?.targetKind).toBe("acp");
+
+    manager.stop();
+    currentConversationBindingTesting.resetCurrentConversationBindingsForTests();
+    closeOpenClawStateDatabaseForTest();
+    createManager();
+
+    expect(getSessionBindingService().resolveByConversation(conversation)).toMatchObject({
+      bindingId: "ttl-owner:chat:opaque-metadata",
+      targetKind: "session",
+      metadata,
+    });
+  });
+
+  it("keeps the previously committed account binding visible when its replacement write fails", () => {
+    const manager = createManager();
+    const original = bindConversation(manager, {
+      conversationId: "chat:write-failure",
+      targetSessionKey: "agent:main:subagent:committed-owner",
+    });
+    const { db } = openOpenClawStateDatabase();
+    db.exec("PRAGMA query_only = ON");
+    try {
+      expect(() =>
+        manager.bindConversation({
+          conversationId: original.conversationId,
+          targetKind: "session",
+          targetSessionKey: "agent:main:acp:uncommitted-owner",
+          metadata: { label: "must-not-leak" },
+        }),
+      ).toThrow();
+    } finally {
+      db.exec("PRAGMA query_only = OFF");
+    }
+
+    expect(manager.getByConversationId(original.conversationId)).toEqual(original);
+    expect(
+      getSessionBindingService().resolveByConversation({
+        channel: "imessage",
+        accountId: manager.accountId,
+        conversationId: original.conversationId,
+      })?.targetSessionKey,
+    ).toBe(original.targetSessionKey);
   });
 
   it("expires idle bindings from both manager and session-service lookups", () => {
@@ -129,7 +251,7 @@ describe("account-scoped conversation binding expiry", () => {
 
     expect(replacement.label).toBeUndefined();
     expect(replacement.targetSessionKey).toBe("agent:main:subagent:replacement");
-    expect(manager.getByConversationId(expired.conversationId)).toBe(replacement);
+    expect(manager.getByConversationId(expired.conversationId)).toEqual(replacement);
   });
 
   it("prunes only the expired account when accounts share a conversation id", () => {
@@ -144,7 +266,7 @@ describe("account-scoped conversation binding expiry", () => {
     now.mockReturnValue(startedAt + 60 * 60_000);
 
     expect(expiredManager.getByConversationId(expired.conversationId)).toBeUndefined();
-    expect(activeManager.getByConversationId(active.conversationId)).toBe(active);
+    expect(activeManager.getByConversationId(active.conversationId)).toEqual(active);
     expect(activeManager.listBySessionKey(active.targetSessionKey)).toEqual([active]);
   });
 
@@ -157,7 +279,7 @@ describe("account-scoped conversation binding expiry", () => {
 
     now.mockReturnValue(startedAt + 10 * 365 * 24 * 60 * 60_000);
 
-    expect(manager.getByConversationId(binding.conversationId)).toBe(binding);
+    expect(manager.getByConversationId(binding.conversationId)).toEqual(binding);
     expect(manager.listBySessionKey(binding.targetSessionKey)).toEqual([binding]);
     expect(manager.touchConversation(binding.conversationId)?.lastActivityAt).toBe(Date.now());
     expect(manager.unbindConversation(binding.conversationId)?.targetSessionKey).toBe(

--- a/src/infra/outbound/account-scoped-conversation-bindings.ts
+++ b/src/infra/outbound/account-scoped-conversation-bindings.ts
@@ -1,7 +1,4 @@
-import { isFutureDateTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-// Account-scoped conversation binding managers adapt channel-local thread maps
-// into the shared session binding service.
 import { resolveThreadBindingConversationIdFromBindingId } from "../../channels/thread-binding-id.js";
 import {
   resolveThreadBindingIdleTimeoutMsForChannel,
@@ -11,6 +8,12 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import {
+  deleteCurrentConversationBindingRecordsBySession,
+  listCurrentConversationBindingRecordsBySession,
+  resolveCurrentConversationBindingRecord,
+  updateCurrentConversationBindingRecord,
+} from "./current-conversation-bindings.js";
+import {
   registerSessionBindingAdapter,
   unregisterSessionBindingAdapter,
   type BindingTargetKind,
@@ -18,7 +21,7 @@ import {
   type SessionBindingRecord,
 } from "./session-binding-service.js";
 
-/** In-memory binding record scoped to one channel account and conversation id. */
+/** Binding record scoped to one channel account and conversation id. */
 export type AccountScopedConversationBindingRecord<TKind extends string = string> = {
   accountId: string;
   conversationId: string;
@@ -57,7 +60,6 @@ export type AccountScopedConversationBindingManager<TKind extends string = strin
 
 type AccountScopedConversationBindingsState<TKind extends string> = {
   managersByAccountId: Map<string, AccountScopedConversationBindingManager<TKind>>;
-  bindingsByAccountConversation: Map<string, AccountScopedConversationBindingRecord<TKind>>;
 };
 
 function getState<TKind extends string>(
@@ -65,7 +67,6 @@ function getState<TKind extends string>(
 ): AccountScopedConversationBindingsState<TKind> {
   return resolveGlobalSingleton(stateKey, () => ({
     managersByAccountId: new Map(),
-    bindingsByAccountConversation: new Map(),
   }));
 }
 
@@ -79,6 +80,7 @@ function toSessionBindingRecord<TKind extends string>(params: {
   idleTimeoutMs: number;
   maxAgeMs: number;
   toSessionBindingTargetKind: (raw: TKind) => BindingTargetKind;
+  metadata?: Record<string, unknown>;
 }): SessionBindingRecord {
   const idleExpiresAt =
     params.idleTimeoutMs > 0 ? params.record.lastActivityAt + params.idleTimeoutMs : undefined;
@@ -100,6 +102,7 @@ function toSessionBindingRecord<TKind extends string>(params: {
     boundAt: params.record.boundAt,
     expiresAt,
     metadata: {
+      ...params.metadata,
       agentId: params.record.agentId,
       label: params.record.label,
       boundBy: params.record.boundBy,
@@ -121,11 +124,11 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
 }): AccountScopedConversationBindingManager<TKind> {
   const accountId = normalizeAccountId(params.accountId);
   const state = getState<TKind>(params.stateKey);
-  const existing = state.managersByAccountId.get(accountId);
-  if (existing) {
+  const existingManager = state.managersByAccountId.get(accountId);
+  if (existingManager) {
     // Manager state is account-scoped and process-global so repeated channel
     // setup calls reuse the same binding adapter instead of double-registering.
-    return existing;
+    return existingManager;
   }
 
   const idleTimeoutMs = resolveThreadBindingIdleTimeoutMsForChannel({
@@ -140,6 +143,7 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
   });
   const asSessionBindingRecord = (
     record: AccountScopedConversationBindingRecord<TKind>,
+    metadata?: Record<string, unknown>,
   ): SessionBindingRecord =>
     toSessionBindingRecord({
       channel: params.channel,
@@ -147,114 +151,119 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
       idleTimeoutMs,
       maxAgeMs,
       toSessionBindingTargetKind: params.toSessionBindingTargetKind,
+      metadata,
     });
-  const resolveActiveBinding = (
-    record: AccountScopedConversationBindingRecord<TKind> | undefined,
-    now = Date.now(),
-  ): AccountScopedConversationBindingRecord<TKind> | undefined => {
-    if (!record) {
-      return undefined;
-    }
-    const { expiresAt } = asSessionBindingRecord(record);
-    if (expiresAt === undefined || isFutureDateTimestampMs(expiresAt, { nowMs: now })) {
-      return record;
-    }
-
-    // Prune at the account owner so SDK lookups and touches cannot revive stale bindings.
-    state.bindingsByAccountConversation.delete(resolveBindingKey(accountId, record.conversationId));
-    return undefined;
+  const conversationRef = (conversationId: string) => ({
+    channel: params.channel,
+    accountId,
+    conversationId,
+  });
+  const asAccountBindingRecord = (
+    record: SessionBindingRecord,
+  ): AccountScopedConversationBindingRecord<TKind> => {
+    const metadata = record.metadata;
+    return {
+      accountId,
+      conversationId: record.conversation.conversationId,
+      targetKind: params.toStoredTargetKind(record.targetKind),
+      targetSessionKey: record.targetSessionKey,
+      agentId: typeof metadata?.agentId === "string" ? metadata.agentId : undefined,
+      label: typeof metadata?.label === "string" ? metadata.label : undefined,
+      boundBy: typeof metadata?.boundBy === "string" ? metadata.boundBy : undefined,
+      boundAt: record.boundAt,
+      lastActivityAt:
+        typeof metadata?.lastActivityAt === "number" ? metadata.lastActivityAt : record.boundAt,
+    };
   };
+  const bindConversationRecord = (input: {
+    conversationId: string;
+    targetKind: BindingTargetKind;
+    targetSessionKey: string;
+    metadata?: Record<string, unknown>;
+  }): SessionBindingRecord | null => {
+    const normalizedConversationId = input.conversationId.trim();
+    const normalizedTargetSessionKey = input.targetSessionKey.trim();
+    if (!normalizedConversationId || !normalizedTargetSessionKey) {
+      return null;
+    }
+    const now = Date.now();
+    const { current } = updateCurrentConversationBindingRecord(
+      conversationRef(normalizedConversationId),
+      (existing) => {
+        const existingLocal = existing ? asAccountBindingRecord(existing) : undefined;
+        const record: AccountScopedConversationBindingRecord<TKind> = {
+          accountId,
+          conversationId: normalizedConversationId,
+          targetKind: params.toStoredTargetKind(input.targetKind),
+          targetSessionKey: normalizedTargetSessionKey,
+          agentId:
+            (typeof input.metadata?.agentId === "string" && input.metadata.agentId.trim()
+              ? input.metadata.agentId.trim()
+              : existingLocal?.agentId) ??
+            resolveSessionAgentId({
+              config: params.cfg,
+              sessionKey: normalizedTargetSessionKey,
+            }),
+          label:
+            typeof input.metadata?.label === "string" && input.metadata.label.trim()
+              ? input.metadata.label.trim()
+              : existingLocal?.label,
+          boundBy:
+            typeof input.metadata?.boundBy === "string" && input.metadata.boundBy.trim()
+              ? input.metadata.boundBy.trim()
+              : existingLocal?.boundBy,
+          boundAt: now,
+          lastActivityAt: now,
+        };
+        return asSessionBindingRecord(record, {
+          ...existing?.metadata,
+          ...input.metadata,
+        });
+      },
+    );
+    return current;
+  };
+  const accountScope = { channel: params.channel, accountId };
   const manager: AccountScopedConversationBindingManager<TKind> = {
     accountId,
-    getByConversationId: (conversationId) =>
-      resolveActiveBinding(
-        state.bindingsByAccountConversation.get(resolveBindingKey(accountId, conversationId)),
-      ),
-    listBySessionKey: (targetSessionKey) => {
-      const now = Date.now();
-      return [...state.bindingsByAccountConversation.values()].filter(
-        (record) =>
-          record.accountId === accountId &&
-          record.targetSessionKey === targetSessionKey &&
-          resolveActiveBinding(record, now) !== undefined,
-      );
+    getByConversationId: (conversationId) => {
+      const record = resolveCurrentConversationBindingRecord(conversationRef(conversationId));
+      return record ? asAccountBindingRecord(record) : undefined;
     },
-    bindConversation: ({ conversationId, targetKind, targetSessionKey, metadata }) => {
-      const normalizedConversationId = conversationId.trim();
-      const normalizedTargetSessionKey = targetSessionKey.trim();
-      if (!normalizedConversationId || !normalizedTargetSessionKey) {
-        return null;
-      }
-      const existingLocal = manager.getByConversationId(normalizedConversationId);
-      const now = Date.now();
-      const record: AccountScopedConversationBindingRecord<TKind> = {
-        accountId,
-        conversationId: normalizedConversationId,
-        targetKind: params.toStoredTargetKind(targetKind),
-        targetSessionKey: normalizedTargetSessionKey,
-        agentId:
-          (typeof metadata?.agentId === "string" && metadata.agentId.trim()
-            ? metadata.agentId.trim()
-            : existingLocal?.agentId) ??
-          resolveSessionAgentId({
-            config: params.cfg,
-            sessionKey: normalizedTargetSessionKey,
-          }),
-        label:
-          typeof metadata?.label === "string" && metadata.label.trim()
-            ? metadata.label.trim()
-            : existingLocal?.label,
-        boundBy:
-          typeof metadata?.boundBy === "string" && metadata.boundBy.trim()
-            ? metadata.boundBy.trim()
-            : existingLocal?.boundBy,
-        boundAt: now,
-        lastActivityAt: now,
-      };
-      state.bindingsByAccountConversation.set(
-        resolveBindingKey(accountId, normalizedConversationId),
-        record,
-      );
-      return record;
+    listBySessionKey: (targetSessionKey) =>
+      listCurrentConversationBindingRecordsBySession(targetSessionKey, accountScope).map(
+        asAccountBindingRecord,
+      ),
+    bindConversation: (input) => {
+      const record = bindConversationRecord(input);
+      return record ? asAccountBindingRecord(record) : null;
     },
     touchConversation: (conversationId, at = Date.now()) => {
-      const key = resolveBindingKey(accountId, conversationId);
-      const existingRecord = manager.getByConversationId(conversationId);
-      if (!existingRecord) {
-        return null;
-      }
-      const updated = { ...existingRecord, lastActivityAt: at };
-      state.bindingsByAccountConversation.set(key, updated);
-      return updated;
+      const { current } = updateCurrentConversationBindingRecord(
+        conversationRef(conversationId),
+        (existing) => {
+          if (!existing) {
+            return null;
+          }
+          const updated = { ...asAccountBindingRecord(existing), lastActivityAt: at };
+          return asSessionBindingRecord(updated, existing.metadata);
+        },
+      );
+      return current ? asAccountBindingRecord(current) : null;
     },
     unbindConversation: (conversationId) => {
-      const key = resolveBindingKey(accountId, conversationId);
-      const existingRecord = state.bindingsByAccountConversation.get(key);
-      if (!existingRecord) {
-        return null;
-      }
-      state.bindingsByAccountConversation.delete(key);
-      return existingRecord;
+      const { previous } = updateCurrentConversationBindingRecord(
+        conversationRef(conversationId),
+        () => null,
+      );
+      return previous ? asAccountBindingRecord(previous) : null;
     },
-    unbindBySessionKey: (targetSessionKey) => {
-      const removed: AccountScopedConversationBindingRecord<TKind>[] = [];
-      for (const record of state.bindingsByAccountConversation.values()) {
-        if (record.accountId !== accountId || record.targetSessionKey !== targetSessionKey) {
-          continue;
-        }
-        state.bindingsByAccountConversation.delete(
-          resolveBindingKey(accountId, record.conversationId),
-        );
-        removed.push(record);
-      }
-      return removed;
-    },
+    unbindBySessionKey: (targetSessionKey) =>
+      deleteCurrentConversationBindingRecordsBySession(targetSessionKey, accountScope).map(
+        asAccountBindingRecord,
+      ),
     stop: () => {
-      for (const key of state.bindingsByAccountConversation.keys()) {
-        if (key.startsWith(`${accountId}:`)) {
-          state.bindingsByAccountConversation.delete(key);
-        }
-      }
+      // Registrations are process-local; SQLite-owned bindings must survive manager shutdown.
       state.managersByAccountId.delete(accountId);
       unregisterSessionBindingAdapter({
         channel: params.channel,
@@ -274,22 +283,20 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
       if (input.conversation.channel !== params.channel || input.placement === "child") {
         return null;
       }
-      const bound = manager.bindConversation({
+      return bindConversationRecord({
         conversationId: input.conversation.conversationId,
         targetKind: input.targetKind,
         targetSessionKey: input.targetSessionKey,
         metadata: input.metadata,
       });
-      return bound ? asSessionBindingRecord(bound) : null;
     },
     listBySession: (targetSessionKey) =>
-      manager.listBySessionKey(targetSessionKey).map(asSessionBindingRecord),
+      listCurrentConversationBindingRecordsBySession(targetSessionKey, accountScope),
     resolveByConversation: (ref) => {
       if (ref.channel !== params.channel) {
         return null;
       }
-      const found = manager.getByConversationId(ref.conversationId);
-      return found ? asSessionBindingRecord(found) : null;
+      return resolveCurrentConversationBindingRecord(conversationRef(ref.conversationId));
     },
     touch: (bindingId, at) => {
       const conversationId = resolveThreadBindingConversationIdFromBindingId({
@@ -302,9 +309,10 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
     },
     unbind: async (input) => {
       if (input.targetSessionKey?.trim()) {
-        return manager
-          .unbindBySessionKey(input.targetSessionKey.trim())
-          .map(asSessionBindingRecord);
+        return deleteCurrentConversationBindingRecordsBySession(
+          input.targetSessionKey.trim(),
+          accountScope,
+        );
       }
       const conversationId = resolveThreadBindingConversationIdFromBindingId({
         accountId,
@@ -313,8 +321,11 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
       if (!conversationId) {
         return [];
       }
-      const removed = manager.unbindConversation(conversationId);
-      return removed ? [asSessionBindingRecord(removed)] : [];
+      const { previous } = updateCurrentConversationBindingRecord(
+        conversationRef(conversationId),
+        () => null,
+      );
+      return previous ? [previous] : [];
     },
   };
 
@@ -323,12 +334,11 @@ export function createAccountScopedConversationBindingManager<TKind extends stri
   return manager;
 }
 
-/** Stops registered managers and clears account-scoped binding state for one test key. */
+/** Stops registered account-scoped adapters for one test key without clearing durable bindings. */
 export function resetAccountScopedConversationBindingsForTests(params: { stateKey: symbol }) {
   const state = getState(params.stateKey);
   for (const manager of state.managersByAccountId.values()) {
     manager.stop();
   }
   state.managersByAccountId.clear();
-  state.bindingsByAccountConversation.clear();
 }

--- a/src/infra/outbound/current-conversation-bindings.test.ts
+++ b/src/infra/outbound/current-conversation-bindings.test.ts
@@ -91,6 +91,42 @@ function seedPersistedBinding(record: SessionBindingRecord): void {
   });
 }
 
+function replacePersistedBinding(record: SessionBindingRecord): void {
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(db);
+    executeSqliteQuerySync(
+      db,
+      bindingDb
+        .updateTable("current_conversation_bindings")
+        .set({
+          binding_id: record.bindingId,
+          target_session_key: record.targetSessionKey,
+          target_kind: record.targetKind,
+          status: record.status,
+          bound_at: record.boundAt,
+          expires_at: record.expiresAt ?? null,
+          metadata_json: record.metadata ? JSON.stringify(record.metadata) : null,
+          record_json: JSON.stringify(record),
+          updated_at: Date.now(),
+        })
+        .where("binding_key", "=", buildConversationKey(record.conversation)),
+    );
+  });
+}
+
+function readPersistedBinding(conversationId: string): SessionBindingRecord | null {
+  const { db } = openOpenClawStateDatabase();
+  const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(db);
+  const row = executeSqliteQuerySync(
+    db,
+    bindingDb
+      .selectFrom("current_conversation_bindings")
+      .select("record_json")
+      .where("binding_key", "=", buildConversationKey(workspaceConversation(conversationId))),
+  ).rows[0];
+  return row ? (JSON.parse(row.record_json) as SessionBindingRecord) : null;
+}
+
 function setMinimalCurrentConversationRegistry(): void {
   setActivePluginRegistry(
     createTestRegistry([
@@ -300,6 +336,197 @@ describe("generic current-conversation bindings", () => {
     expectBindingMetadata(resolved, { label: "workspace-dm" });
   });
 
+  describe("independent SQLite owners", () => {
+    it.each(["bind", "touch", "expiry cleanup", "unbind"] as const)(
+      "preserves independently inserted and updated rows during %s",
+      async (mutation) => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(1_000_000));
+        const owned = expectSessionBinding(await bindWorkspaceConversation("user:owner"));
+        const previousExternal = expectSessionBinding(
+          await bindWorkspaceConversation("user:updated", {
+            targetSessionKey: "agent:codex:acp:old-target",
+            metadata: { version: "before" },
+          }),
+        );
+        await bindWorkspaceConversation("user:expired", { ttlMs: 1_000 });
+
+        const latestExternal: SessionBindingRecord = {
+          ...previousExternal,
+          targetSessionKey: "agent:codex:acp:latest-target",
+          metadata: { version: "latest", opaque: { nested: true } },
+        };
+        replacePersistedBinding(latestExternal);
+        seedPersistedBinding({
+          ...owned,
+          bindingId: "generic:workspace\u241fdefault\u241f\u241fuser:inserted",
+          targetSessionKey: "agent:codex:acp:inserted-target",
+          conversation: workspaceConversation("user:inserted"),
+          metadata: { opaque: "external owner" },
+        });
+
+        switch (mutation) {
+          case "bind":
+            await bindWorkspaceConversation("user:replacement");
+            break;
+          case "touch":
+            touchGenericCurrentConversationBinding(owned.bindingId, 1_000_500);
+            break;
+          case "expiry cleanup":
+            vi.setSystemTime(new Date(1_002_000));
+            expect(resolveWorkspaceConversation("user:expired")).toBeNull();
+            break;
+          case "unbind":
+            await unbindGenericCurrentConversationBindings({
+              bindingId: owned.bindingId,
+              reason: "owner cleanup",
+            });
+            break;
+        }
+
+        expectBindingFields(readPersistedBinding("user:inserted"), {
+          targetSessionKey: "agent:codex:acp:inserted-target",
+        });
+        expectBindingFields(readPersistedBinding("user:updated"), {
+          targetSessionKey: "agent:codex:acp:latest-target",
+        });
+        expectBindingMetadata(readPersistedBinding("user:updated"), {
+          version: "latest",
+          opaque: { nested: true },
+        });
+
+        testing.resetCurrentConversationBindingsForTests();
+        closeOpenClawStateDatabaseForTest();
+        expect(resolveWorkspaceConversation("user:inserted")?.targetSessionKey).toBe(
+          "agent:codex:acp:inserted-target",
+        );
+        expect(resolveWorkspaceConversation("user:updated")?.targetSessionKey).toBe(
+          "agent:codex:acp:latest-target",
+        );
+      },
+    );
+
+    it("touches the latest committed target and complete opaque metadata", async () => {
+      const initial = expectSessionBinding(
+        await bindWorkspaceConversation("user:owner", {
+          targetSessionKey: "agent:codex:acp:old-target",
+          metadata: { stale: true },
+        }),
+      );
+      replacePersistedBinding({
+        ...initial,
+        targetSessionKey: "agent:codex:acp:latest-target",
+        metadata: {
+          opaque: { nested: ["latest", { preserved: true }] },
+          lastActivityAt: 10,
+        },
+      });
+
+      touchGenericCurrentConversationBinding(initial.bindingId, 20);
+
+      expectBindingFields(readPersistedBinding("user:owner"), {
+        targetSessionKey: "agent:codex:acp:latest-target",
+      });
+      expectBindingMetadata(readPersistedBinding("user:owner"), {
+        opaque: { nested: ["latest", { preserved: true }] },
+        lastActivityAt: 20,
+      });
+      expect(resolveWorkspaceConversation("user:owner")?.targetSessionKey).toBe(
+        "agent:codex:acp:latest-target",
+      );
+    });
+
+    it.each(["rebind", "delete"] as const)(
+      "never restores a stale row when another owner commits a %s during normalization",
+      (mutation) => {
+        const initial: SessionBindingRecord = {
+          bindingId: "generic:workspace\u241fdefault\u241f\u241fuser:normalization-race",
+          targetSessionKey: " agent:codex:acp:stale-target ",
+          targetKind: "session",
+          conversation: workspaceConversation("user:normalization-race"),
+          status: "active",
+          boundAt: 1_000,
+          metadata: { version: "stale" },
+        };
+        seedPersistedBinding(initial);
+        const latest: SessionBindingRecord = {
+          ...initial,
+          targetSessionKey: "agent:codex:acp:latest-target",
+          metadata: { version: "latest", opaque: { preserved: true } },
+        };
+        const parseJson = JSON.parse;
+        let committed = false;
+        const parseSpy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+          const parsed = parseJson(text, reviver);
+          if (!committed && text.includes("user:normalization-race")) {
+            committed = true;
+            if (mutation === "rebind") {
+              replacePersistedBinding(latest);
+            } else {
+              runOpenClawStateWriteTransaction(({ db }) => {
+                const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(db);
+                executeSqliteQuerySync(
+                  db,
+                  bindingDb
+                    .deleteFrom("current_conversation_bindings")
+                    .where("binding_key", "=", buildConversationKey(initial.conversation)),
+                );
+              });
+            }
+          }
+          return parsed;
+        });
+
+        try {
+          const resolved = resolveWorkspaceConversation("user:normalization-race");
+          if (mutation === "delete") {
+            expect(resolved).toBeNull();
+            expect(readPersistedBinding("user:normalization-race")).toBeNull();
+            return;
+          }
+          expectBindingFields(resolved, {
+            targetSessionKey: "agent:codex:acp:latest-target",
+          });
+          expectBindingMetadata(readPersistedBinding("user:normalization-race"), {
+            version: "latest",
+            opaque: { preserved: true },
+          });
+        } finally {
+          parseSpy.mockRestore();
+        }
+      },
+    );
+
+    it("does not hide another owner's committed row after a failed write", async () => {
+      const owned = expectSessionBinding(await bindWorkspaceConversation("user:owner"));
+      seedPersistedBinding({
+        ...owned,
+        bindingId: "generic:workspace\u241fdefault\u241f\u241fuser:external",
+        targetSessionKey: "agent:codex:acp:external-target",
+        conversation: workspaceConversation("user:external"),
+        metadata: { opaque: { survives: true } },
+      });
+
+      await expect(
+        withReadOnlyStateDatabase(() =>
+          bindWorkspaceConversation("user:owner", {
+            targetSessionKey: "agent:codex:acp:failed-target",
+          }),
+        ),
+      ).rejects.toThrow();
+
+      expect(resolveWorkspaceConversation("user:owner")?.targetSessionKey).toBe(
+        owned.targetSessionKey,
+      );
+      expect(resolveWorkspaceConversation("user:external")?.targetSessionKey).toBe(
+        "agent:codex:acp:external-target",
+      );
+      expectBindingMetadata(readPersistedBinding("user:external"), {
+        opaque: { survives: true },
+      });
+    });
+  });
+
   it("normalizes persisted target session keys on reload", async () => {
     seedPersistedBinding({
       bindingId: "generic:workspace\u241fdefault\u241f\u241fuser:U123",
@@ -336,6 +563,13 @@ describe("generic current-conversation bindings", () => {
       bindingId: "generic:workspace\u241fdefault\u241f\u241fuser:U123",
       targetSessionKey: "agent:codex:acp:workspace-dm",
     });
+  });
+
+  it("returns no generic bindings for session keys without an indexable agent owner", async () => {
+    await bindWorkspaceConversation("user:U123");
+
+    expect(listGenericCurrentConversationBindingsBySession("agent:main")).toEqual([]);
+    expect(listGenericCurrentConversationBindingsBySession("main")).toEqual([]);
   });
 
   it("drops self-parent conversation refs when storing generic current bindings", async () => {
@@ -424,6 +658,84 @@ describe("generic current-conversation bindings", () => {
         conversationId: "6098642967",
       }),
     ).toBeNull();
+  });
+
+  it.each(["touch", "unbind"] as const)(
+    "supports %s by the canonical id returned for an unrepaired legacy self-parent row",
+    async (operation) => {
+      const conversation = {
+        channel: "forum",
+        accountId: "default",
+        conversationId: "6098642967",
+        parentConversationId: "6098642967",
+      };
+      seedPersistedBinding({
+        bindingId: "generic:forum\u241fdefault\u241f6098642967\u241f6098642967",
+        targetSessionKey: "agent:codex:acp:forum-dm",
+        targetKind: "session",
+        conversation,
+        status: "active",
+        boundAt: 1_234,
+        metadata: { opaque: { preserved: true } },
+      });
+
+      const listed = expectSessionBinding(
+        listGenericCurrentConversationBindingsBySession("agent:codex:acp:forum-dm")[0] ?? null,
+      );
+      expect(listed.bindingId).toBe("generic:forum\u241fdefault\u241f\u241f6098642967");
+
+      if (operation === "touch") {
+        touchGenericCurrentConversationBinding(listed.bindingId, 9_876);
+        expectBindingMetadata(resolveGenericCurrentConversationBinding(conversation), {
+          opaque: { preserved: true },
+          lastActivityAt: 9_876,
+        });
+        return;
+      }
+
+      const removed = await unbindGenericCurrentConversationBindings({
+        bindingId: listed.bindingId,
+        reason: "legacy owner cleanup",
+      });
+      expect(removed).toHaveLength(1);
+      expect(listGenericCurrentConversationBindingsBySession("agent:codex:acp:forum-dm")).toEqual(
+        [],
+      );
+    },
+  );
+
+  it("unbinds durable generic rows without invoking reentrant plugin policy in a write transaction", async () => {
+    const targetSessionKey = "agent:codex:acp:workspace-dm";
+    const bound = expectSessionBinding(await bindWorkspaceConversation("user:policy-owner"));
+    const policy = vi.fn(() => {
+      runOpenClawStateWriteTransaction(() => undefined);
+      return true;
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "workspace",
+          source: "test",
+          plugin: {
+            id: "workspace",
+            meta: { aliases: [] },
+            conversationBindings: {
+              supportsCurrentConversationBinding: true,
+              isCurrentConversationBindingSupported: policy,
+            },
+          },
+        },
+      ]),
+    );
+
+    const removed = await unbindGenericCurrentConversationBindings({
+      targetSessionKey,
+      reason: "owner cleanup",
+    });
+
+    expect(removed).toEqual([bound]);
+    expect(policy).not.toHaveBeenCalled();
+    expect(readPersistedBinding("user:policy-owner")).toBeNull();
   });
 
   it("removes persisted bindings on unbind", async () => {
@@ -677,15 +989,13 @@ describe("generic current-conversation bindings", () => {
       expect(listGenericCurrentConversationBindingsBySession(targetSessionKey)).toHaveLength(2);
     });
 
-    it("retries the initial cache load after its SQLite cleanup fails", async () => {
+    it("reads an unexpired binding without requiring a SQLite cleanup write", async () => {
       await bindWorkspaceConversation("user:U1");
       testing.resetCurrentConversationBindingsForTests();
 
       await expect(
         withReadOnlyStateDatabase(() => resolveWorkspaceConversation("user:U1")),
-      ).rejects.toThrow();
-
-      expect(resolveWorkspaceConversation("user:U1")).not.toBeNull();
+      ).resolves.not.toBeNull();
     });
   });
 });

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -1,5 +1,6 @@
 // Generic current-conversation bindings persist lightweight conversation ->
 // session links for plugin channels without a custom binding adapter.
+import type { DatabaseSync } from "node:sqlite";
 import {
   asDateTimestampMs,
   isFutureDateTimestampMs,
@@ -9,15 +10,18 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { normalizeConversationText } from "../../acp/conversation-id.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
 import { getActivePluginChannelRegistryFromState } from "../../plugins/runtime-channel-state.js";
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
-import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel-constants.js";
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../kysely-sync.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../kysely-sync.js";
 import { normalizeConversationRef } from "./session-binding-normalization.js";
 import type {
   ConversationRef,
@@ -35,19 +39,13 @@ type CurrentConversationBindingDatabase = Pick<
   "current_conversation_bindings"
 >;
 
-type CurrentConversationBindingsState = {
-  loaded: boolean;
-  byConversationKey: Map<string, SessionBindingRecord>;
+type CurrentConversationBindingScope = { channel: string; accountId: string };
+type CurrentConversationBindingRow = {
+  binding_key: string;
+  binding_id: string;
+  target_session_key: string;
+  record_json: string;
 };
-
-const currentConversationBindingsState = resolveGlobalSingleton<CurrentConversationBindingsState>(
-  Symbol.for("openclaw.currentConversationBindings"),
-  () => ({ loaded: false, byConversationKey: new Map() }),
-  (state) => {
-    state.loaded = false;
-    state.byConversationKey.clear();
-  },
-);
 
 function buildConversationKey(ref: ConversationRef): string {
   const normalized = normalizeConversationRef(ref);
@@ -78,7 +76,7 @@ function isBindingExpired(record: SessionBindingRecord, now = Date.now()): boole
 function normalizePersistedBindingRecord(
   record: SessionBindingRecord,
 ): SessionBindingRecord | null {
-  if (!record?.bindingId || !record?.conversation?.conversationId || isBindingExpired(record)) {
+  if (!record?.bindingId || !record?.conversation?.conversationId) {
     return null;
   }
   const conversation = normalizeConversationRef(record.conversation);
@@ -88,14 +86,12 @@ function normalizePersistedBindingRecord(
   }
   return {
     ...record,
-    bindingId: buildBindingId(conversation),
+    bindingId: record.bindingId.startsWith(CURRENT_BINDINGS_ID_PREFIX)
+      ? buildBindingId(conversation)
+      : record.bindingId,
     targetSessionKey,
     conversation,
   };
-}
-
-function openBindingDatabase() {
-  return openOpenClawStateDatabase();
 }
 
 function bindingRowsToRecords(rows: Array<{ record_json: string }>): SessionBindingRecord[] {
@@ -110,89 +106,213 @@ function bindingRowsToRecords(rows: Array<{ record_json: string }>): SessionBind
   });
 }
 
-function readPersistedBindings(): SessionBindingRecord[] {
-  const database = openBindingDatabase();
-  const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(database.db);
-  const now = Date.now();
-  executeSqliteQuerySync(
-    database.db,
-    bindingDb
-      .deleteFrom("current_conversation_bindings")
-      .where("expires_at", "is not", null)
-      .where("expires_at", "<=", now),
-  );
-  const rows = executeSqliteQuerySync(
-    database.db,
-    bindingDb
-      .selectFrom("current_conversation_bindings")
-      .select(["record_json"])
-      .orderBy("binding_id", "asc"),
-  ).rows;
-  return bindingRowsToRecords(rows);
-}
-
 function targetAgentIdForSessionKey(targetSessionKey: string): string {
   return resolveAgentIdFromSessionKey(targetSessionKey);
 }
 
-function writePersistedBindings(nextBindings: ReadonlyMap<string, SessionBindingRecord>): void {
-  const records = [...nextBindings.values()]
-    .filter((record) => !isBindingExpired(record))
-    .toSorted((a, b) => a.bindingId.localeCompare(b.bindingId));
-  const updatedAt = Date.now();
-  runOpenClawStateWriteTransaction(({ db }) => {
-    const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(db);
-    executeSqliteQuerySync(db, bindingDb.deleteFrom("current_conversation_bindings"));
-    if (records.length === 0) {
-      return;
-    }
-    executeSqliteQuerySync(
-      db,
-      bindingDb.insertInto("current_conversation_bindings").values(
-        records.map((record) => {
-          const conversation = normalizeConversationRef(record.conversation);
-          return {
-            binding_key: buildConversationKey(conversation),
-            binding_id: record.bindingId,
-            target_agent_id: targetAgentIdForSessionKey(record.targetSessionKey),
-            target_session_id: null,
-            target_session_key: record.targetSessionKey,
-            channel: conversation.channel,
-            account_id: conversation.accountId,
-            conversation_kind: CURRENT_BINDING_CONVERSATION_KIND,
-            parent_conversation_id: conversation.parentConversationId ?? null,
-            conversation_id: conversation.conversationId,
-            target_kind: record.targetKind,
-            status: record.status,
-            bound_at: record.boundAt,
-            expires_at: record.expiresAt ?? null,
-            metadata_json: record.metadata ? JSON.stringify(record.metadata) : null,
-            record_json: JSON.stringify(record),
-            updated_at: updatedAt,
-          };
-        }),
-      ),
-    );
+function readCurrentConversationBindingRow(
+  db: DatabaseSync,
+  ref: ConversationRef,
+): CurrentConversationBindingRow | undefined {
+  const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(db);
+  const conversation = normalizeConversationRef(ref);
+  const bindingKey = buildConversationKey(conversation);
+  const exact = executeSqliteQueryTakeFirstSync(
+    db,
+    bindingDb
+      .selectFrom("current_conversation_bindings")
+      .select(["binding_key", "binding_id", "target_session_key", "record_json"])
+      .where("binding_key", "=", bindingKey),
+  );
+  if (exact) {
+    return exact;
+  }
+  // Shipped self-parent rows have a stale key; use the existing conversation
+  // index and normalize the candidate before accepting the same conversation.
+  const candidates = executeSqliteQuerySync(
+    db,
+    bindingDb
+      .selectFrom("current_conversation_bindings")
+      .select(["binding_key", "binding_id", "target_session_key", "record_json"])
+      .where("channel", "=", conversation.channel)
+      .where("account_id", "=", conversation.accountId)
+      .where("conversation_kind", "=", CURRENT_BINDING_CONVERSATION_KIND)
+      .where("conversation_id", "=", conversation.conversationId),
+  ).rows;
+  return candidates.find((candidate) => {
+    const record = bindingRowsToRecords([candidate])[0];
+    return record !== undefined && buildConversationKey(record.conversation) === bindingKey;
   });
 }
 
-function commitBindings(nextBindings: Map<string, SessionBindingRecord>): void {
-  // SQLite is canonical: publish the prepared map only after its transaction
-  // commits, so a storage error cannot leave runtime routing ahead of disk.
-  writePersistedBindings(nextBindings);
-  currentConversationBindingsState.byConversationKey = nextBindings;
+function currentConversationBindingRow(record: SessionBindingRecord) {
+  const conversation = normalizeConversationRef(record.conversation);
+  return {
+    binding_key: buildConversationKey(conversation),
+    binding_id: record.bindingId,
+    target_agent_id: targetAgentIdForSessionKey(record.targetSessionKey),
+    target_session_id: null,
+    target_session_key: record.targetSessionKey,
+    channel: conversation.channel,
+    account_id: conversation.accountId,
+    conversation_kind: CURRENT_BINDING_CONVERSATION_KIND,
+    parent_conversation_id: conversation.parentConversationId ?? null,
+    conversation_id: conversation.conversationId,
+    target_kind: record.targetKind,
+    status: record.status,
+    bound_at: record.boundAt,
+    expires_at: record.expiresAt ?? null,
+    metadata_json: record.metadata ? JSON.stringify(record.metadata) : null,
+    record_json: JSON.stringify(record),
+    updated_at: Date.now(),
+  };
 }
 
-function loadBindingsIntoMemory(): void {
-  if (currentConversationBindingsState.loaded) {
-    return;
+function deleteCurrentConversationBindingRow(db: DatabaseSync, bindingKey: string): void {
+  const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(db);
+  executeSqliteQuerySync(
+    db,
+    bindingDb.deleteFrom("current_conversation_bindings").where("binding_key", "=", bindingKey),
+  );
+}
+
+/** Updates one binding from its currently committed row in one synchronous transaction. */
+export function updateCurrentConversationBindingRecord(
+  ref: ConversationRef,
+  update: (current: SessionBindingRecord | null) => SessionBindingRecord | null,
+): { previous: SessionBindingRecord | null; current: SessionBindingRecord | null } {
+  const conversation = normalizeConversationRef(ref);
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const existingRow = readCurrentConversationBindingRow(db, conversation);
+    const existing = existingRow ? (bindingRowsToRecords([existingRow])[0] ?? null) : null;
+    const previous = existing && !isBindingExpired(existing) ? existing : null;
+    const current = update(previous);
+    if (!current) {
+      if (existingRow) {
+        deleteCurrentConversationBindingRow(db, existingRow.binding_key);
+      }
+      return { previous, current: null };
+    }
+
+    const bindingKey = buildConversationKey(conversation);
+    if (buildConversationKey(current.conversation) !== bindingKey) {
+      throw new Error("Current conversation binding update changed its conversation owner");
+    }
+    if (existingRow && existingRow.binding_key !== bindingKey) {
+      deleteCurrentConversationBindingRow(db, existingRow.binding_key);
+    }
+    const row = currentConversationBindingRow(current);
+    const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(db);
+    executeSqliteQuerySync(
+      db,
+      bindingDb
+        .insertInto("current_conversation_bindings")
+        .values(row)
+        .onConflict((conflict) => conflict.column("binding_key").doUpdateSet(row)),
+    );
+    return { previous, current };
+  });
+}
+
+/** Reads the latest durable binding and prunes only the exact expired conversation row. */
+export function resolveCurrentConversationBindingRecord(
+  ref: ConversationRef,
+): SessionBindingRecord | null {
+  const { db } = openOpenClawStateDatabase();
+  const row = readCurrentConversationBindingRow(db, ref);
+  if (!row) {
+    return null;
   }
-  const nextBindings = new Map<string, SessionBindingRecord>();
-  for (const record of readPersistedBindings()) {
-    nextBindings.set(buildConversationKey(record.conversation), record);
+  const record = bindingRowsToRecords([row])[0];
+  if (!record) {
+    return null;
   }
-  currentConversationBindingsState.byConversationKey = nextBindings;
-  currentConversationBindingsState.loaded = true;
+  if (isBindingExpired(record)) {
+    return updateCurrentConversationBindingRecord(ref, (current) => current).current;
+  }
+  if (
+    row.binding_key !== buildConversationKey(record.conversation) ||
+    row.binding_id !== record.bindingId ||
+    row.target_session_key !== record.targetSessionKey
+  ) {
+    return updateCurrentConversationBindingRecord(ref, (current) => current).current;
+  }
+  return record;
+}
+
+function listCurrentConversationBindingRowsBySession(
+  db: DatabaseSync,
+  targetSessionKey: string,
+  scope?: CurrentConversationBindingScope,
+): CurrentConversationBindingRow[] {
+  if (!parseAgentSessionKey(targetSessionKey)) {
+    return [];
+  }
+  const bindingDb = getNodeSqliteKysely<CurrentConversationBindingDatabase>(db);
+  let query = bindingDb
+    .selectFrom("current_conversation_bindings")
+    .select(["binding_key", "binding_id", "target_session_key", "record_json"])
+    .where("target_agent_id", "=", targetAgentIdForSessionKey(targetSessionKey))
+    .where("target_session_key", "=", targetSessionKey);
+  if (scope) {
+    const normalized = normalizeConversationRef({
+      ...scope,
+      conversationId: "binding-scope",
+    });
+    query = query
+      .where("channel", "=", normalized.channel)
+      .where("account_id", "=", normalized.accountId);
+  }
+  return executeSqliteQuerySync(db, query.orderBy("binding_id", "asc")).rows;
+}
+
+/** Lists latest durable bindings using the indexed session owner and optional account scope. */
+export function listCurrentConversationBindingRecordsBySession(
+  targetSessionKey: string,
+  scope?: CurrentConversationBindingScope,
+): SessionBindingRecord[] {
+  const { db } = openOpenClawStateDatabase();
+  const rows = listCurrentConversationBindingRowsBySession(db, targetSessionKey, scope);
+  const records = bindingRowsToRecords(rows);
+  if (!records.some((record) => isBindingExpired(record))) {
+    return records;
+  }
+  return runOpenClawStateWriteTransaction(({ db: transactionDb }) => {
+    const latestRows = listCurrentConversationBindingRowsBySession(
+      transactionDb,
+      targetSessionKey,
+      scope,
+    );
+    const active: SessionBindingRecord[] = [];
+    for (const row of latestRows) {
+      const record = bindingRowsToRecords([row])[0];
+      if (!record || isBindingExpired(record)) {
+        deleteCurrentConversationBindingRow(transactionDb, row.binding_key);
+      } else {
+        active.push(record);
+      }
+    }
+    return active;
+  });
+}
+
+/** Deletes one account's exact current session rows without disturbing sibling owners. */
+export function deleteCurrentConversationBindingRecordsBySession(
+  targetSessionKey: string,
+  scope: CurrentConversationBindingScope,
+): SessionBindingRecord[] {
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const rows = listCurrentConversationBindingRowsBySession(db, targetSessionKey, scope);
+    const removed: SessionBindingRecord[] = [];
+    for (const row of rows) {
+      const record = bindingRowsToRecords([row])[0];
+      deleteCurrentConversationBindingRow(db, row.binding_key);
+      if (record && !isBindingExpired(record)) {
+        removed.push(record);
+      }
+    }
+    return removed;
+  });
 }
 
 function resolveChannelSupportsCurrentConversationBinding(params: {
@@ -245,14 +365,22 @@ function supportsGenericCurrentConversationBinding(ref: {
   });
 }
 
-function bindingRefFromId(bindingId: string): { channel: string; accountId: string } | null {
+function bindingRefFromId(bindingId: string): ConversationRef | null {
   if (!bindingId.startsWith(CURRENT_BINDINGS_ID_PREFIX)) {
     return null;
   }
-  const [channel, accountId] = bindingId
+  const [channel, accountId, parentConversationId, conversationId] = bindingId
     .slice(CURRENT_BINDINGS_ID_PREFIX.length)
-    .split("\u241f", 2);
-  return channel && accountId ? { channel, accountId } : null;
+    .split("\u241f");
+  if (!channel || !accountId || !conversationId) {
+    return null;
+  }
+  return {
+    channel,
+    accountId,
+    conversationId,
+    ...(parentConversationId ? { parentConversationId } : {}),
+  };
 }
 
 /** Reports generic current-conversation binding support for plugin-owned channels. */
@@ -285,7 +413,6 @@ export async function bindGenericCurrentConversation(
   ) {
     return null;
   }
-  loadBindingsIntoMemory();
   const rawNow = Date.now();
   const now = asDateTimestampMs(rawNow);
   if (now === undefined) {
@@ -304,10 +431,7 @@ export async function bindGenericCurrentConversation(
   if (ttlMs !== undefined && expiresAt === undefined) {
     return null;
   }
-  const key = buildConversationKey(conversation);
-  const existing = currentConversationBindingsState.byConversationKey.get(key);
-  const activeExisting = existing && !isBindingExpired(existing) ? existing : undefined;
-  const record: SessionBindingRecord = {
+  return updateCurrentConversationBindingRecord(conversation, (existing) => ({
     bindingId: buildBindingId(conversation),
     targetSessionKey,
     targetKind: input.targetKind,
@@ -316,15 +440,11 @@ export async function bindGenericCurrentConversation(
     boundAt: now,
     ...(expiresAt !== undefined ? { expiresAt } : {}),
     metadata: {
-      ...activeExisting?.metadata,
+      ...existing?.metadata,
       ...input.metadata,
       lastActivityAt: now,
     },
-  };
-  const nextBindings = new Map(currentConversationBindingsState.byConversationKey);
-  nextBindings.set(key, record);
-  commitBindings(nextBindings);
-  return record;
+  })).current;
 }
 
 /** Resolves a current-conversation binding and prunes it if its TTL has expired. */
@@ -334,120 +454,99 @@ export function resolveGenericCurrentConversationBinding(
   if (!supportsGenericCurrentConversationBinding(ref)) {
     return null;
   }
-  loadBindingsIntoMemory();
-  const key = buildConversationKey(ref);
-  const record = currentConversationBindingsState.byConversationKey.get(key) ?? null;
-  if (!record || !isBindingExpired(record)) {
-    return record;
-  }
-  const nextBindings = new Map(currentConversationBindingsState.byConversationKey);
-  nextBindings.delete(key);
-  commitBindings(nextBindings);
-  return null;
+  const record = resolveCurrentConversationBindingRecord(ref);
+  return record?.bindingId.startsWith(CURRENT_BINDINGS_ID_PREFIX) ? record : null;
 }
 
 /** Lists non-expired current-conversation bindings owned by one target session. */
 export function listGenericCurrentConversationBindingsBySession(
   targetSessionKey: string,
 ): SessionBindingRecord[] {
-  loadBindingsIntoMemory();
-  const results: SessionBindingRecord[] = [];
-  let nextBindings: Map<string, SessionBindingRecord> | undefined;
-  for (const [key, record] of currentConversationBindingsState.byConversationKey) {
-    if (isBindingExpired(record)) {
-      nextBindings ??= new Map(currentConversationBindingsState.byConversationKey);
-      nextBindings.delete(key);
-      continue;
-    }
-    if (
-      record.targetSessionKey !== targetSessionKey ||
-      !supportsGenericCurrentConversationBinding(record.conversation)
-    ) {
-      continue;
-    }
-    results.push(record);
-  }
-  if (nextBindings) {
-    commitBindings(nextBindings);
-  }
-  return results;
+  return listCurrentConversationBindingRecordsBySession(targetSessionKey).filter(
+    (record) =>
+      record.bindingId.startsWith(CURRENT_BINDINGS_ID_PREFIX) &&
+      supportsGenericCurrentConversationBinding(record.conversation),
+  );
 }
 
 /** Persists last-activity metadata for an existing generic current-conversation binding. */
 export function touchGenericCurrentConversationBinding(bindingId: string, at = Date.now()): void {
-  const bindingRef = bindingRefFromId(bindingId);
-  if (!bindingRef || !supportsGenericCurrentConversationBinding(bindingRef)) {
-    return;
-  }
-  loadBindingsIntoMemory();
-  const key = bindingId.slice(CURRENT_BINDINGS_ID_PREFIX.length);
-  const record = currentConversationBindingsState.byConversationKey.get(key);
+  const record = resolveGenericCurrentConversationBindingById(bindingId);
   if (!record) {
     return;
   }
-  const nextBindings = new Map(currentConversationBindingsState.byConversationKey);
-  if (isBindingExpired(record)) {
-    nextBindings.delete(key);
-  } else {
-    nextBindings.set(key, {
-      ...record,
-      metadata: {
-        ...record.metadata,
-        lastActivityAt: at,
-      },
-    });
+  updateCurrentConversationBindingRecord(record.conversation, (current) =>
+    current?.bindingId === bindingId
+      ? {
+          ...current,
+          metadata: {
+            ...current.metadata,
+            lastActivityAt: at,
+          },
+        }
+      : current,
+  );
+}
+
+function resolveGenericCurrentConversationBindingById(
+  bindingId: string,
+): SessionBindingRecord | undefined {
+  const bindingRef = bindingRefFromId(bindingId);
+  if (!bindingRef || !supportsGenericCurrentConversationBinding(bindingRef)) {
+    return undefined;
   }
-  commitBindings(nextBindings);
+  const { db } = openOpenClawStateDatabase();
+  const row = readCurrentConversationBindingRow(db, bindingRef);
+  const record = row ? bindingRowsToRecords([row])[0] : undefined;
+  return record?.bindingId === bindingId ? record : undefined;
+}
+
+function unbindCurrentConversationBindingById(bindingId: string): SessionBindingRecord[] {
+  const record = resolveGenericCurrentConversationBindingById(bindingId);
+  if (!record) {
+    return [];
+  }
+  const { previous, current } = updateCurrentConversationBindingRecord(
+    record.conversation,
+    (latest) => (latest?.bindingId === bindingId ? null : latest),
+  );
+  return previous && !current ? [previous] : [];
+}
+
+function unbindGenericCurrentConversationBindingsBySession(
+  targetSessionKey: string,
+): SessionBindingRecord[] {
+  return runOpenClawStateWriteTransaction(({ db }) => {
+    const rows = listCurrentConversationBindingRowsBySession(db, targetSessionKey);
+    const removed: SessionBindingRecord[] = [];
+    for (const row of rows) {
+      const record = bindingRowsToRecords([row])[0];
+      if (!record?.bindingId.startsWith(CURRENT_BINDINGS_ID_PREFIX)) {
+        continue;
+      }
+      if (isBindingExpired(record)) {
+        deleteCurrentConversationBindingRow(db, row.binding_key);
+        continue;
+      }
+      deleteCurrentConversationBindingRow(db, row.binding_key);
+      removed.push(record);
+    }
+    return removed;
+  });
 }
 
 /** Removes generic current-conversation bindings by binding id or target session key. */
 export async function unbindGenericCurrentConversationBindings(
   input: SessionBindingUnbindInput,
 ): Promise<SessionBindingRecord[]> {
-  const removed: SessionBindingRecord[] = [];
   const normalizedBindingId = input.bindingId?.trim();
-  const normalizedTargetSessionKey = input.targetSessionKey?.trim();
   if (normalizedBindingId?.startsWith(CURRENT_BINDINGS_ID_PREFIX)) {
-    const bindingRef = bindingRefFromId(normalizedBindingId);
-    if (!bindingRef || !supportsGenericCurrentConversationBinding(bindingRef)) {
-      return removed;
-    }
-    loadBindingsIntoMemory();
-    const key = normalizedBindingId.slice(CURRENT_BINDINGS_ID_PREFIX.length);
-    const record = currentConversationBindingsState.byConversationKey.get(key);
-    if (record) {
-      const nextBindings = new Map(currentConversationBindingsState.byConversationKey);
-      nextBindings.delete(key);
-      if (!isBindingExpired(record)) {
-        removed.push(record);
-      }
-      commitBindings(nextBindings);
-    }
-    return removed;
+    return unbindCurrentConversationBindingById(normalizedBindingId);
   }
-  if (!normalizedTargetSessionKey) {
-    return removed;
-  }
-  loadBindingsIntoMemory();
-  const nextBindings = new Map(currentConversationBindingsState.byConversationKey);
-  for (const [key, record] of currentConversationBindingsState.byConversationKey) {
-    if (isBindingExpired(record)) {
-      nextBindings.delete(key);
-      continue;
-    }
-    if (
-      record.targetSessionKey !== normalizedTargetSessionKey ||
-      !supportsGenericCurrentConversationBinding(record.conversation)
-    ) {
-      continue;
-    }
-    nextBindings.delete(key);
-    removed.push(record);
-  }
-  if (nextBindings.size !== currentConversationBindingsState.byConversationKey.size) {
-    commitBindings(nextBindings);
-  }
-  return removed;
+  const normalizedTargetSessionKey = input.targetSessionKey?.trim();
+  return normalizedTargetSessionKey
+    ? unbindGenericCurrentConversationBindingsBySession(normalizedTargetSessionKey)
+    : [];
 }
 
 export const testing = {
@@ -455,8 +554,6 @@ export const testing = {
     deletePersistedFile?: boolean;
     env?: NodeJS.ProcessEnv;
   }) {
-    currentConversationBindingsState.loaded = false;
-    currentConversationBindingsState.byConversationKey.clear();
     if (params?.deletePersistedFile) {
       runOpenClawStateWriteTransaction(
         ({ db }) => {

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -1,8 +1,11 @@
-import { findStructuredAuthParamRanges, redactStructuredAuthHeaders } from "@openclaw/acp-core";
 import { isSensitiveUrlQueryParamName } from "@openclaw/net-policy/redact-sensitive-url";
 import { expectDefined } from "@openclaw/normalization-core";
 // Redaction helpers scrub secrets and sensitive identifiers from log output.
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import {
+  findStructuredAuthParamRanges,
+  redactStructuredAuthHeaders,
+} from "../../packages/acp-core/src/structured-auth-redaction.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { compileConfigRegex } from "../security/config-regex.js";
 import { readLoggingConfig } from "./config.js";


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting or resuming an ACP-backed agent, binding it to a conversation, or immediately sending the next message could lose prompts, interrupt the wrong turn, reuse another backend's session identity, route the follow-up incorrectly, or encounter an unavailable iMessage binding. Conversation bindings and opaque channel metadata could also disappear when their owning manager was recreated.

## Why This Change Was Made

The ACP translator now admits, replaces, cancels, and settles prompts under the exact active session/run owner, and the control plane distinguishes authoritative backend prompt readiness from terminal cleanup so failover cannot replay an already-submitted prompt. Backend selection and resume identifiers remain scoped to their actual backend owner, while account-scoped conversation managers persist and resolve bindings through the existing canonical SQLite owner rather than process-local maps. iMessage carries configured-binding resolution to inbound dispatch and verifies readiness before accepting the message.

Live verification exposed two additional owner-boundary defects fixed in the same flow: inferred ACP harness ownership is kept distinct from explicit agent selection, and newly created ACP metadata now uses the authoritative committed session timestamp instead of an earlier pre-commit timestamp that immediately invalidated fresh bindings.

The SQLite schema remains at v9. There is no migration, protocol change, dependency change, or configuration-surface change. Native binding persistence for Feishu, Matrix, and Discord is separate follow-up work; those channel-specific improvements are not gaps in the repaired ACP/iMessage flow.

## User Impact

Operators can start or resume the intended ACP-backed agent, bind the current conversation, immediately continue that same conversation, retain transcript continuity and image classification, and keep durable conversation bindings across manager recreation. Cancellation, backend failover, and iMessage routing now respect the active owner and report unavailable configured bindings instead of silently dispatching to an unready target.

## Evidence

- Production: +800/-446 lines (net +354); tests: +2,450/-82 lines (net +2,368); test support: +66/-58 lines (net +8). Production growth implements closure-bound prompt admission/readiness and the canonical durable-binding ownership boundary; the larger change is regression coverage.
- Deterministic proof: 794 focused tests passed, including 320 Gateway tests and 77 ACP spawn tests, alongside ACPX and iMessage suites, plugin SDK surface checks, schema-v9 guards, changed-file/type/lint gates, formatting, and clean diff checks.
- ClawSweeper P1 addressed: replacement aborts the exact active run before settlement; superseded admissions never submit, with latest-only three-way overlap and cancel/close/shutdown terminal-snapshot coverage. Focused and sibling rerun: 268 tests passed; both changed files passed the full changed gate, formatting, and diff checks.
- Post-rebase owner-boundary rerun: 141 tests passed across 77 ACP spawn tests and 64 iMessage plugin, conversation-routing, and inbound-monitor tests.
- Clean production build completed successfully.
- Startup-memory repair: replacing the broad ACP barrel import fixed the plugin-list failure; the build and all four local startup-memory checks pass without changing baselines or limits.
- Isolated live gateway flow reran after the P1 repair and remains 8/8 green, covering ACP spawn and bind, immediate conversation rerouting, transcript continuity, and image classification.
- Optional cron MCP verification was advisory; no cron MCP job was observed. It is not claimed as passing coverage.
- The branch was rebased onto current main while preserving upstream iMessage recipient-validation coverage together with the durable-binding regression.
- AI-assisted implementation and review used Codex; no actionable review findings remained.
