### PR TITLE
fix(agents): fail closed on code-mode alias invalidation

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -419,8 +419,8 @@ Rules:
 - `command` is accepted as an exec-compatible alias for hook policies and
   trusted rewrites (the normal OpenClaw shell exec tool also uses a `command`
   field). Blank caller aliases are treated as absent; a hook or trusted policy
-  that blanks a populated alias clears both so execution fails closed. When both
-  aliases are non-empty, their values must match.
+  that invalidates one populated alias (blank or non-string) invalidates both so
+  execution fails closed. When both aliases are non-empty, their values must match.
 - `language` defaults to `"javascript"`; the schema exposes it as a flat
   string enum (`"javascript" | "typescript"`), not a `oneOf`/`anyOf` union,
   since some providers reject those shapes.

--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -418,8 +418,9 @@ Rules:
 - `code` is the documented model-facing field.
 - `command` is accepted as an exec-compatible alias for hook policies and
   trusted rewrites (the normal OpenClaw shell exec tool also uses a `command`
-  field). Blank aliases are treated as absent; when both aliases are non-empty,
-  their values must match.
+  field). Blank caller aliases are treated as absent; a hook or trusted policy
+  that blanks a populated alias clears both so execution fails closed. When both
+  aliases are non-empty, their values must match.
 - `language` defaults to `"javascript"`; the schema exposes it as a flat
   string enum (`"javascript" | "typescript"`), not a `oneOf`/`anyOf` union,
   since some providers reject those shapes.

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -1366,12 +1366,25 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     { stage: "hook after a trusted rewrite", alias: "command", replacement: "" },
     { stage: "hook after a trusted rewrite", alias: "code", replacement: null },
     { stage: "hook after a trusted rewrite", alias: "command", replacement: null },
+    { stage: "trusted policy", alias: "code", replacement: null, otherReplacement: "return 4;" },
+    {
+      stage: "trusted policy",
+      alias: "command",
+      replacement: null,
+      otherReplacement: "return 4;",
+    },
+    { stage: "hook", alias: "code", replacement: null, otherReplacement: "return 4;" },
+    { stage: "hook", alias: "command", replacement: null, otherReplacement: "return 4;" },
     { stage: "hook after a trusted rewrite", alias: "code", replacement: "return 3;" },
     { stage: "hook after a trusted rewrite", alias: "command", replacement: "return 3;" },
   ])(
     "handles a $stage changing the $alias code-mode exec alias to $replacement",
-    async ({ stage, alias, replacement }) => {
+    async ({ stage, alias, replacement, otherReplacement }) => {
       resetGlobalHookRunner();
+      const pairedReplacement =
+        otherReplacement === undefined
+          ? {}
+          : { [alias === "code" ? "command" : "code"]: otherReplacement };
       const registry = createEmptyPluginRegistry();
       registry.trustedToolPolicies =
         stage === "hook"
@@ -1397,7 +1410,11 @@ describe("before_tool_call hook deduplication (#15502)", () => {
             id: "code-mode-invalidate-policy",
             description: "invalidate one code-mode exec alias",
             evaluate: (eventValue) => ({
-              params: { ...eventValue.params, [alias]: replacement },
+              params: {
+                ...eventValue.params,
+                [alias]: replacement,
+                ...pairedReplacement,
+              },
             }),
           },
         });
@@ -1407,7 +1424,10 @@ describe("before_tool_call hook deduplication (#15502)", () => {
           pluginId: "normal-plugin",
           hookName: "before_tool_call",
           handler: (async () => ({
-            params: { [alias]: replacement },
+            params: {
+              [alias]: replacement,
+              ...pairedReplacement,
+            },
           })) as PluginHookRegistration["handler"],
         });
       }

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import {
@@ -1357,35 +1358,44 @@ describe("before_tool_call hook deduplication (#15502)", () => {
   it.each([
     { stage: "trusted policy", alias: "code", replacement: "" },
     { stage: "trusted policy", alias: "command", replacement: "" },
+    { stage: "trusted policy", alias: "code", replacement: null },
+    { stage: "trusted policy", alias: "command", replacement: null },
+    { stage: "hook", alias: "code", replacement: null },
+    { stage: "hook", alias: "command", replacement: null },
     { stage: "hook after a trusted rewrite", alias: "code", replacement: "" },
     { stage: "hook after a trusted rewrite", alias: "command", replacement: "" },
+    { stage: "hook after a trusted rewrite", alias: "code", replacement: null },
+    { stage: "hook after a trusted rewrite", alias: "command", replacement: null },
     { stage: "hook after a trusted rewrite", alias: "code", replacement: "return 3;" },
     { stage: "hook after a trusted rewrite", alias: "command", replacement: "return 3;" },
   ])(
-    "handles a $stage changing the $alias code-mode exec alias to '$replacement'",
+    "handles a $stage changing the $alias code-mode exec alias to $replacement",
     async ({ stage, alias, replacement }) => {
       resetGlobalHookRunner();
       const registry = createEmptyPluginRegistry();
-      registry.trustedToolPolicies = [
-        {
-          pluginId: "trusted-plugin",
-          pluginName: "Trusted Plugin",
-          source: "test",
-          policy: {
-            id: "code-mode-rewrite-policy",
-            description: "rewrite both code-mode exec aliases",
-            evaluate: () => ({ params: { code: "return 2;", command: "return 2;" } }),
-          },
-        },
-      ];
+      registry.trustedToolPolicies =
+        stage === "hook"
+          ? []
+          : [
+              {
+                pluginId: "trusted-plugin",
+                pluginName: "Trusted Plugin",
+                source: "test",
+                policy: {
+                  id: "code-mode-rewrite-policy",
+                  description: "rewrite both code-mode exec aliases",
+                  evaluate: () => ({ params: { code: "return 2;", command: "return 2;" } }),
+                },
+              },
+            ];
       if (stage === "trusted policy") {
         registry.trustedToolPolicies.push({
           pluginId: "trusted-plugin",
           pluginName: "Trusted Plugin",
           source: "test",
           policy: {
-            id: "code-mode-blank-policy",
-            description: "blank one code-mode exec alias",
+            id: "code-mode-invalidate-policy",
+            description: "invalidate one code-mode exec alias",
             evaluate: (eventValue) => ({
               params: { ...eventValue.params, [alias]: replacement },
             }),
@@ -1404,7 +1414,7 @@ describe("before_tool_call hook deduplication (#15502)", () => {
       setActivePluginRegistry(registry);
       initializeGlobalHookRunner(registry);
       try {
-        const codeModeConfig = { tools: { codeMode: true } } as never;
+        const codeModeConfig: OpenClawConfig = { tools: { codeMode: true } };
         const catalogRef = createToolSearchCatalogRef();
         registerHeadlessToolSearchCatalog({ catalogRef, tools: [] });
         const execTool = createCodeModeTools({
@@ -1438,14 +1448,14 @@ describe("before_tool_call hook deduplication (#15502)", () => {
         }
 
         const result = await def.execute(
-          `call-code-mode-${stage}-${alias}-${replacement ? "rewrite" : "blank"}`,
+          `call-code-mode-${stage}-${alias}-${replacement === "return 3;" ? "rewrite" : "invalidate"}`,
           { code: "return 1;", command: "return 1;" },
           undefined,
           undefined,
           {} as Parameters<typeof def.execute>[4],
         );
 
-        if (replacement) {
+        if (replacement === "return 3;") {
           expect(result.details).toMatchObject({ status: "completed", value: 3 });
         } else {
           expect(result.details).toEqual({

--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -64,6 +64,7 @@ import { getInternalToolExecutionPreparer } from "./runtime/internal-hooks.js";
 import type { ExtensionContext } from "./sessions/index.js";
 import { wrapToolDefinition } from "./sessions/tools/tool-definition-wrapper.js";
 import { hashToolCall, recordToolCall } from "./tool-loop-detection.js";
+import { createToolSearchCatalogRef, registerHeadlessToolSearchCatalog } from "./tool-search.js";
 import { setToolTerminalPresentation } from "./tool-terminal-presentation.js";
 
 type BeforeToolCallHandlerMock = ReturnType<typeof vi.fn>;
@@ -1352,6 +1353,113 @@ describe("before_tool_call hook deduplication (#15502)", () => {
       undefined,
     );
   });
+
+  it.each([
+    { stage: "trusted policy", alias: "code", replacement: "" },
+    { stage: "trusted policy", alias: "command", replacement: "" },
+    { stage: "hook after a trusted rewrite", alias: "code", replacement: "" },
+    { stage: "hook after a trusted rewrite", alias: "command", replacement: "" },
+    { stage: "hook after a trusted rewrite", alias: "code", replacement: "return 3;" },
+    { stage: "hook after a trusted rewrite", alias: "command", replacement: "return 3;" },
+  ])(
+    "handles a $stage changing the $alias code-mode exec alias to '$replacement'",
+    async ({ stage, alias, replacement }) => {
+      resetGlobalHookRunner();
+      const registry = createEmptyPluginRegistry();
+      registry.trustedToolPolicies = [
+        {
+          pluginId: "trusted-plugin",
+          pluginName: "Trusted Plugin",
+          source: "test",
+          policy: {
+            id: "code-mode-rewrite-policy",
+            description: "rewrite both code-mode exec aliases",
+            evaluate: () => ({ params: { code: "return 2;", command: "return 2;" } }),
+          },
+        },
+      ];
+      if (stage === "trusted policy") {
+        registry.trustedToolPolicies.push({
+          pluginId: "trusted-plugin",
+          pluginName: "Trusted Plugin",
+          source: "test",
+          policy: {
+            id: "code-mode-blank-policy",
+            description: "blank one code-mode exec alias",
+            evaluate: (eventValue) => ({
+              params: { ...eventValue.params, [alias]: replacement },
+            }),
+          },
+        });
+      } else {
+        addTestHook({
+          registry,
+          pluginId: "normal-plugin",
+          hookName: "before_tool_call",
+          handler: (async () => ({
+            params: { [alias]: replacement },
+          })) as PluginHookRegistration["handler"],
+        });
+      }
+      setActivePluginRegistry(registry);
+      initializeGlobalHookRunner(registry);
+      try {
+        const codeModeConfig = { tools: { codeMode: true } } as never;
+        const catalogRef = createToolSearchCatalogRef();
+        registerHeadlessToolSearchCatalog({ catalogRef, tools: [] });
+        const execTool = createCodeModeTools({
+          config: codeModeConfig,
+          runtimeConfig: codeModeConfig,
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sessionId: "session-main",
+          runId: "run-main",
+          abortSignal: new AbortController().signal,
+          catalogRef,
+          executeTool: async () => {
+            throw new Error("catalog tool execution should not be reached");
+          },
+        }).find((tool) => tool.name === CODE_MODE_EXEC_TOOL_NAME);
+        if (!execTool) {
+          throw new Error("missing code-mode exec tool");
+        }
+        const [def] = splitSdkTools({
+          tools: [execTool],
+          sandboxEnabled: false,
+          toolHookContext: {
+            agentId: "main",
+            sessionKey: "agent:main:main",
+            sessionId: "session-main",
+            runId: "run-main",
+          },
+        }).customTools;
+        if (!def) {
+          throw new Error("missing custom tool definition");
+        }
+
+        const result = await def.execute(
+          `call-code-mode-${stage}-${alias}-${replacement ? "rewrite" : "blank"}`,
+          { code: "return 1;", command: "return 1;" },
+          undefined,
+          undefined,
+          {} as Parameters<typeof def.execute>[4],
+        );
+
+        if (replacement) {
+          expect(result.details).toMatchObject({ status: "completed", value: 3 });
+        } else {
+          expect(result.details).toEqual({
+            status: "error",
+            tool: "exec",
+            error: "code or command must be a non-empty string.",
+          });
+        }
+      } finally {
+        setActivePluginRegistry(createEmptyPluginRegistry());
+        resetGlobalHookRunner();
+      }
+    },
+  );
 
   it("renormalizes trusted policy rewrites before code-mode exec hooks observe params", async () => {
     resetGlobalHookRunner();

--- a/src/agents/agent-tools.before-tool-call.policy.ts
+++ b/src/agents/agent-tools.before-tool-call.policy.ts
@@ -365,7 +365,12 @@ export async function runBeforeToolCallHook(args: {
     }
 
     if (hookResult?.params) {
-      finalParams = mergeParamsWithApprovalOverrides(finalParams, hookResult.params);
+      finalParams = reconcileCodeModeExecBeforeHookParams({
+        owner: { toolKind: args.toolKind },
+        originalParams: policyAdjustedParams,
+        hookParams: policyAdjustedParams,
+        adjustedParams: mergeParamsWithApprovalOverrides(finalParams, hookResult.params),
+      });
     }
     const finalApprovalOutcome = await resolveSkillWorkshopApprovalForFinalParams({
       toolName,

--- a/src/agents/code-mode-control-tools.ts
+++ b/src/agents/code-mode-control-tools.ts
@@ -151,9 +151,10 @@ export function reconcileCodeModeExecBeforeHookParams(params: {
 
   const adjustedCode = params.adjustedParams.code;
   const adjustedCommand = params.adjustedParams.command;
-  const adjustedCodeChanged = typeof adjustedCode === "string" && adjustedCode !== hookCode;
+  const adjustedCodeChanged =
+    Object.hasOwn(params.adjustedParams, "code") && adjustedCode !== hookCode;
   const adjustedCommandChanged =
-    typeof adjustedCommand === "string" && adjustedCommand !== hookCode;
+    Object.hasOwn(params.adjustedParams, "command") && adjustedCommand !== hookCode;
   if (adjustedCodeChanged === adjustedCommandChanged) {
     return params.adjustedParams;
   }

--- a/src/agents/code-mode-control-tools.ts
+++ b/src/agents/code-mode-control-tools.ts
@@ -155,6 +155,14 @@ export function reconcileCodeModeExecBeforeHookParams(params: {
     Object.hasOwn(params.adjustedParams, "code") && adjustedCode !== hookCode;
   const adjustedCommandChanged =
     Object.hasOwn(params.adjustedParams, "command") && adjustedCommand !== hookCode;
+  // Invalidation must dominate a simultaneous valid rewrite; otherwise runtime
+  // ignores the invalid alias and executes the other one.
+  if (adjustedCodeChanged && readNonBlankString(adjustedCode) === undefined) {
+    return { ...params.adjustedParams, command: adjustedCode };
+  }
+  if (adjustedCommandChanged && readNonBlankString(adjustedCommand) === undefined) {
+    return { ...params.adjustedParams, code: adjustedCommand };
+  }
   if (adjustedCodeChanged === adjustedCommandChanged) {
     return params.adjustedParams;
   }


### PR DESCRIPTION
Related: #126599
Closes #126661

> Written with AI assistance (Codex). The contributor's intended post-policy hook behavior is preserved; this repair extends the same owner-boundary invariant to explicit non-string invalidation.

## What Problem This Solves

Code Mode exposes `code` and `command` as aliases for the same script. The shared hook reconciler only recognized changed aliases when the new value was a string. A hook or trusted policy could explicitly replace one populated alias with `null`; reconciliation ignored that mutation, and Code Mode executed the surviving alias instead of failing closed.

The original PR also fixes the staged form: after a trusted policy rewrites both aliases, a normal hook must reconcile against that policy-adjusted pair rather than the raw caller pair.

## Root Cause

`reconcileCodeModeExecBeforeHookParams` conflated two different states:

- an omitted key, which is a valid single-alias rewrite and must be mirrored; and
- an explicitly present invalid value, which must invalidate the paired alias.

Its string-only change predicate discarded the second state.

## Fix

- Reconcile normal-hook output against the exact trusted-policy-adjusted alias pair.
- Detect explicit alias mutations by own-property presence, regardless of value type.
- Preserve omitted-key single-alias rewrites.
- Mirror a one-sided blank or non-string invalidation so the canonical Code Mode validator rejects it.
- Document the fail-closed alias contract.
- Add owner-boundary coverage for both aliases across plain hooks, trusted policies, and hooks after trusted rewrites.

Production delta: **+6 net lines** (`src/agents/**` excluding tests). The growth is the missing lifecycle-boundary reconciliation call plus presence-aware mutation detection; it adds no parallel execution path, state, I/O, cache, or compatibility behavior.

## Evidence

Exact pushed head: `e90a0bb59bd506a06929d157d99826eced977c61`

- Pre-fix regression: **6/6 explicit `null` cases failed**. Code Mode completed with the surviving alias (`value: 1` or `2`) instead of returning `code or command must be a non-empty string.`
- Post-fix changed-path matrix: **13/13 passed**, including omitted-key rewrites and explicit invalidations.
- Code Mode owner suites: **455 tests passed** across 17 files.
- Before-tool policy E2E: **99 tests passed**.
- Before-tool integration E2E: **58 tests passed**.
- `pnpm tsgo`: passed.
- `pnpm check:test-types`: passed.
- Targeted Oxfmt and Oxlint: passed.
- Docs formatting and link audit: passed (`6,524` internal links, `0` broken).
- `git diff --check`: passed.
- `$distill`: one canonical reconciler; omitted-key and explicit-mutation states remain distinct.
- `$greybeard`: two constant-time own-property checks; no allocation, I/O, query, cache, or asymptotic change.
- Exact-head CI: **passed** on unchanged rerun attempt 2 (`32371713498`). Attempt 1 lost 14 self-hosted runners; every annotation reported lost server communication before or during shard setup, and all failed jobs passed unchanged on rerun.
- Exact-head ephemeral Gateway + mock-provider proof (`OpenClaw 2026.8.1 (e90a0bb)`):

  ```json
  {"tool":"exec","arguments":{"command":"return \"CODE_MODE_NULL_HOOK_MUST_NOT_EXECUTE\";","code":""}}
  {"hookEffectiveParams":{"command":null,"code":null}}
  {"toolResult":{"status":"error","tool":"exec","error":"code or command must be a non-empty string."}}
  {"agent":{"status":"ok","finalText":"CODE_MODE_ALIAS_INVALIDATION_REJECTED","successfulToolNames":[],"toolFailures":1}}
  ```

  A temporary loaded `before_tool_call` plugin set `code` to `null`. The Gateway log records both effective aliases as `null`; the second provider request carries the validation failure, not a completed guest value. The sentinel script value never appears as a result, proving rejection before guest execution.

Upstream Codex contract check at `4642370542739d5dd080b0c87a9de06a6435d3db`: function arguments remain opaque and correlated by `call_id` in `codex-rs/core/src/tools/router.rs` and `codex-rs/core/src/tools/parallel.rs`; output correlation lives in `codex-rs/protocol/src/models.rs`. Code/command alias reconciliation is therefore correctly owned by OpenClaw's before-tool boundary.

- Exact-head local ClawSweeper: **passed** with 0 findings, 0 security concerns, no maintainer decision, and 0 Rank-up moves.
- Final real-Telegram changed-path proof: **passed**. A recorded DM run loaded the temporary hook, rewrote `code` to `null`, observed both effective aliases as `null`, returned `code or command must be a non-empty string.`, and delivered `CODE_MODE_ALIAS_INVALIDATION_REJECTED`. Recording captured 2 typing events, 2 SUT messages, and 1 cleanup deletion; the forbidden guest sentinel never returned. Harness verdict: `completed: true`, expectation satisfied, exit 0.

## Exact-head follow-up proof (`8fe0b63f19f`)

The latest hosted review found a full-pair gap: a hook could explicitly invalidate one alias while simultaneously changing the other to a valid script. The regression test failed on the prior head by completing the forbidden `return 4;` value for trusted-policy and hook paths, in both alias directions.

The owner now makes an explicit invalid alias dominant before applying the existing changed-pair rule. Final local proof on this head: 455/455 Code Mode tests; 161/161 before-tool E2E tests; Oxfmt, Oxlint, `pnpm tsgo`, `pnpm check:test-types`, and `git diff --check` passed.

Redacted current-head Gateway + real Telegram trace:

```json
{"trustedPolicyOutput":{"code":"return 2;","command":"return 2;"}}
{"hookOutput":{"code":null,"command":"return 4;"}}
{"gatewayEffectiveParams":{"code":null,"command":null}}
{"toolResult":{"status":"error","error":"code or command must be a non-empty string."}}
{"telegram":{"finalText":"CODE_MODE_ALIAS_INVALIDATION_REJECTED","recordingComplete":true,"sutMessages":2,"typingEvents":2,"cleanupDeletes":1}}
```

The provider received the validation failure and no completed guest value; `CODE_MODE_FULL_PAIR_MUST_NOT_EXECUTE` never returned. The reusable Telegram harness now accepts repeatable `--code-mode-trusted-rewrite ALIAS=JSON` and `--code-mode-hook-rewrite ALIAS=JSON` flags for this sequence.

Direct Codex-source verification repeated at `4642370542739d5dd080b0c87a9de06a6435d3db`: `codex-rs/core/src/tools/router.rs:153-169` preserves function arguments as an opaque payload, `codex-rs/core/src/tools/parallel.rs:226-253` correlates failure output by `call_id`, and `codex-rs/protocol/src/models.rs:683-687` defines that output correlation. Alias reconciliation therefore remains OpenClaw-owned.

## Final landing gates

- Exact-head CI: **passed** on unchanged rerun attempt 2 of run `32382241437`; attempt 1 had one unrelated `extensions/browser/src/browser/chrome.test.ts` port-reuse timing flake (2,617 sibling tests passed), and the same shard passed unchanged.
- Exact-head local ClawSweeper: **passed** — patch correct, 0 findings, security cleared with 0 concerns, no maintainer decision, 0 Rank-up moves.
- Final Telegram proof: **passed** on `8fe0b63f19f`. The recorded DM repeated trusted `code`/`command` → `return 2;`, then hook `code=null` plus `command="return 4;"`; Gateway recorded both effective aliases as `null`, the provider received `code or command must be a non-empty string.`, the forbidden guest value never returned, and Telegram delivered `CODE_MODE_ALIAS_INVALIDATION_REJECTED`. Timeline: 2 typing events, 2 SUT messages, 1 cleanup deletion; expectation satisfied; exit 0.