### PR TITLE
fix(talk): activate configured realtime voice provider

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -173,6 +173,7 @@ See [Plugins](/tools/plugin) for the full plugin system guide, and [Capability m
 | `configContracts`                    | No       | `object`                     | Manifest-owned config behavior consumed by generic core helpers: dangerous-flag detection, SecretRef migration targets, and legacy config-path narrowing. See [configContracts reference](#configcontracts-reference).                                                                                                                                                                           |
 | `mediaUnderstandingProviderMetadata` | No       | `Record<string, object>`     | Cheap media-understanding defaults for provider ids declared in `contracts.mediaUnderstandingProviders`.                                                                                                                                                                                                                                                                                         |
 | `imageGenerationProviderMetadata`    | No       | `Record<string, object>`     | Cheap image-generation auth metadata for provider ids declared in `contracts.imageGenerationProviders`, including provider-owned auth aliases and base-url guards.                                                                                                                                                                                                                               |
+| `realtimeVoiceProviderMetadata`      | No       | `Record<string, object>`     | Cheap realtime-voice metadata for provider ids declared in `contracts.realtimeVoiceProviders`, including provider-owned aliases used by startup activation before runtime loads.                                                                                                                                                                                                                 |
 | `videoGenerationProviderMetadata`    | No       | `Record<string, object>`     | Cheap video-generation auth metadata for provider ids declared in `contracts.videoGenerationProviders`, including provider-owned auth aliases and base-url guards.                                                                                                                                                                                                                               |
 | `musicGenerationProviderMetadata`    | No       | `Record<string, object>`     | Cheap music-generation auth metadata for provider ids declared in `contracts.musicGenerationProviders`, including provider-owned auth aliases and base-url guards.                                                                                                                                                                                                                               |
 | `toolMetadata`                       | No       | `Record<string, object>`     | Cheap availability metadata for plugin-owned tools declared in `contracts.tools`. Use it when a tool should not load runtime unless config, env, or auth evidence exists.                                                                                                                                                                                                                        |
@@ -214,6 +215,25 @@ both. One declaration covers the complete config-repair artifact.
 ```
 
 OpenClaw includes these servers only while the owning plugin is enabled. Relative `command`, `args`, `cwd`, and `workingDirectory` paths resolve from the plugin root. User configuration remains authoritative: `mcp.servers.<name>` can replace a plugin default or set `enabled: false` to omit it. MCP App rendering and server-tool calls still require the normal MCP Apps setting and effective tool policy; declaring a server does not bypass either boundary.
+
+## Realtime voice provider metadata reference
+
+Use `realtimeVoiceProviderMetadata` when a realtime voice provider has aliases that Gateway startup must recognize before plugin runtime loads. Keys must also be declared in `contracts.realtimeVoiceProviders`; aliases are alternate provider ids for the same runtime provider, not separate auth providers or plugin ids.
+
+```json
+{
+  "contracts": {
+    "realtimeVoiceProviders": ["example-realtime"]
+  },
+  "realtimeVoiceProviderMetadata": {
+    "example-realtime": {
+      "aliases": ["example-voice"]
+    }
+  }
+}
+```
+
+OpenClaw uses this metadata only for cheap cold-start ownership matching. Runtime behavior still comes from `api.registerRealtimeVoiceProvider(...)`, and the registered provider should expose the same aliases it declares here.
 
 ## dashboard reference
 

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -209,6 +209,11 @@
       }
     }
   },
+  "realtimeVoiceProviderMetadata": {
+    "xai": {
+      "aliases": ["xai-realtime-voice", "grok-voice"]
+    }
+  },
   "toolMetadata": {
     "code_execution": {
       "authSignals": [

--- a/extensions/xai/openclaw.plugin.test.ts
+++ b/extensions/xai/openclaw.plugin.test.ts
@@ -12,6 +12,7 @@ const manifest = JSON.parse(
     suppressions?: Array<{ provider?: string; model?: string }>;
   };
   mediaUnderstandingProviderMetadata?: Record<string, { defaultModels?: Record<string, string> }>;
+  realtimeVoiceProviderMetadata?: Record<string, { aliases?: string[] }>;
 };
 
 const XAI_MULTI_AGENT_MODELS = [
@@ -72,5 +73,12 @@ describe("xAI plugin manifest", () => {
 
   it("does not advertise a batch STT model selector", () => {
     expect(manifest.mediaUnderstandingProviderMetadata?.xai?.defaultModels).toBeUndefined();
+  });
+
+  it("advertises realtime voice aliases for manifest-driven startup", () => {
+    expect(manifest.realtimeVoiceProviderMetadata?.xai?.aliases).toEqual([
+      "xai-realtime-voice",
+      "grok-voice",
+    ]);
   });
 });

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -173,6 +173,19 @@ function createManifestRegistryFixture(): PluginManifestRegistry {
         musicGenerationProviders: ["google"],
       },
     },
+    {
+      id: "xai",
+      enabledByDefault: true,
+      providers: ["xai"],
+      contracts: {
+        realtimeVoiceProviders: ["xai"],
+      },
+      realtimeVoiceProviderMetadata: {
+        xai: {
+          aliases: ["xai-realtime-voice", "grok-voice"],
+        },
+      },
+    },
     { id: "amazon-bedrock", enabledByDefault: true, providers: ["amazon-bedrock"] },
     { id: "brave", origin: "global", contracts: { webSearchProviders: ["brave"] } },
     { id: "codex", providers: ["codex"], activation: { onAgentHarnesses: ["codex"] } },
@@ -755,6 +768,139 @@ describe("resolveGatewayStartupPluginIdsFromRegistry", () => {
         },
       } as OpenClawConfig,
       ["browser", "openai", "google", "memory-core"],
+    ],
+    [
+      "includes bundled realtime voice providers configured by Talk realtime provider at startup",
+      {
+        channels: {},
+        talk: {
+          realtime: {
+            provider: "openai",
+            providers: {
+              openai: { model: "gpt-live-1-codex" },
+            },
+            mode: "realtime",
+            transport: "webrtc",
+          },
+        },
+      } as OpenClawConfig,
+      ["browser", "openai", "memory-core"],
+    ],
+    [
+      "includes bundled realtime voice providers configured by Talk realtime provider map at startup",
+      {
+        channels: {},
+        talk: {
+          realtime: {
+            provider: "openai",
+            providers: {
+              openai: { model: "gpt-live-1-codex" },
+              google: { model: "gemini-live-2.5-flash-preview" },
+            },
+            mode: "realtime",
+            transport: "webrtc",
+          },
+        },
+      } as OpenClawConfig,
+      ["browser", "openai", "google", "memory-core"],
+    ],
+    [
+      "includes bundled realtime voice providers configured by single Talk realtime provider block",
+      {
+        channels: {},
+        talk: {
+          realtime: {
+            providers: {
+              google: { model: "gemini-live-2.5-flash-preview" },
+            },
+            mode: "realtime",
+          },
+        },
+      } as OpenClawConfig,
+      ["browser", "google", "memory-core"],
+    ],
+    [
+      "includes bundled realtime voice providers configured by Talk realtime alias at startup",
+      {
+        channels: {},
+        talk: {
+          realtime: {
+            provider: "grok-voice",
+            providers: {
+              "grok-voice": { model: "grok-voice" },
+            },
+            mode: "realtime",
+            transport: "webrtc",
+          },
+        },
+      } as OpenClawConfig,
+      ["browser", "xai", "memory-core"],
+    ],
+    [
+      "includes bundled realtime voice providers configured by legacy Voice Call realtime at startup",
+      {
+        channels: {},
+        plugins: {
+          entries: {
+            "voice-call": {
+              config: {
+                realtime: {
+                  enabled: true,
+                  provider: "google",
+                  providers: {
+                    google: { model: "gemini-live-2.5-flash-preview" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      ["browser", "google", "memory-core"],
+    ],
+    [
+      "includes legacy Voice Call realtime provider maps for automatic selection at startup",
+      {
+        channels: {},
+        plugins: {
+          entries: {
+            "voice-call": {
+              config: {
+                realtime: {
+                  enabled: true,
+                  providers: {
+                    openai: { model: "gpt-live-1-codex" },
+                    google: { model: "gemini-live-2.5-flash-preview" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      ["browser", "openai", "google", "memory-core"],
+    ],
+    [
+      "does not include disabled legacy Voice Call realtime provider maps at startup",
+      {
+        channels: {},
+        plugins: {
+          entries: {
+            "voice-call": {
+              config: {
+                realtime: {
+                  enabled: false,
+                  providers: {
+                    openai: { model: "gpt-live-1-codex" },
+                    google: { model: "gemini-live-2.5-flash-preview" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      ["browser", "memory-core"],
     ],
     [
       "honors explicit plugin disablement for configured voice providers",

--- a/src/plugins/gateway-startup-plugin-activation.ts
+++ b/src/plugins/gateway-startup-plugin-activation.ts
@@ -179,11 +179,22 @@ function manifestOwnsConfiguredContract(
   contractKey: StartupContractKey,
   configuredProviderIds: ReadonlySet<string>,
 ): boolean {
+  const providerAliases =
+    contractKey === "realtimeVoiceProviders" ? manifest?.realtimeVoiceProviderMetadata : undefined;
   return (
     configuredProviderIds.size > 0 &&
     (manifest?.contracts?.[contractKey] ?? []).some((providerId) => {
       const normalized = normalizeOptionalLowercaseString(providerId);
-      return normalized ? configuredProviderIds.has(normalized) : false;
+      if (!normalized) {
+        return false;
+      }
+      if (configuredProviderIds.has(normalized)) {
+        return true;
+      }
+      return (providerAliases?.[normalized]?.aliases ?? []).some((alias) => {
+        const normalizedAlias = normalizeOptionalLowercaseString(alias);
+        return normalizedAlias ? configuredProviderIds.has(normalizedAlias) : false;
+      });
     })
   );
 }

--- a/src/plugins/gateway-startup-plugin-providers.ts
+++ b/src/plugins/gateway-startup-plugin-providers.ts
@@ -212,14 +212,62 @@ export function collectConfiguredGenerationProviderIds(
   };
 }
 
+function collectRealtimeProviderIdsFromConfigValue(
+  value: unknown,
+  options: { includeConfiguredProvidersForAutomaticSelection?: boolean } = {},
+): ReadonlySet<string> {
+  const realtime = isRecord(value) ? value : undefined;
+  if (!realtime) {
+    return new Set();
+  }
+
+  const explicitProvider = normalizeOptionalLowercaseString(
+    typeof realtime.provider === "string" ? realtime.provider : undefined,
+  );
+  const configuredProviders = isRecord(realtime.providers)
+    ? Object.keys(realtime.providers)
+        .map((providerId) => normalizeOptionalLowercaseString(providerId))
+        .filter((providerId): providerId is string => Boolean(providerId))
+    : [];
+  if (explicitProvider) {
+    return new Set([explicitProvider, ...configuredProviders]);
+  }
+  if (options.includeConfiguredProvidersForAutomaticSelection) {
+    return new Set(configuredProviders);
+  }
+  return configuredProviders.length === 1 ? new Set(configuredProviders) : new Set();
+}
+
+function collectConfiguredRealtimeVoiceProviderIds(config: OpenClawConfig): ReadonlySet<string> {
+  const voiceCallEntry = isRecord(config.plugins?.entries?.["voice-call"])
+    ? config.plugins.entries["voice-call"]
+    : undefined;
+  const voiceCallConfig = isRecord(voiceCallEntry?.config) ? voiceCallEntry.config : undefined;
+  const voiceCallRealtime = isRecord(voiceCallConfig?.realtime)
+    ? voiceCallConfig.realtime
+    : undefined;
+  return new Set([
+    ...collectRealtimeProviderIdsFromConfigValue(config.talk?.realtime),
+    ...(voiceCallRealtime?.enabled === true
+      ? collectRealtimeProviderIdsFromConfigValue(voiceCallRealtime, {
+          includeConfiguredProvidersForAutomaticSelection: true,
+        })
+      : []),
+  ]);
+}
+
 export function collectConfiguredVoiceProviderIds(
   config: OpenClawConfig,
 ): ConfiguredVoiceProviderIds {
   const providerIds = collectModelProviderIds(config.agents?.defaults?.voiceModel);
+  const realtimeVoiceProviderIds = new Set([
+    ...providerIds,
+    ...collectConfiguredRealtimeVoiceProviderIds(config),
+  ]);
   return {
     speechProviders: providerIds,
     realtimeTranscriptionProviders: providerIds,
-    realtimeVoiceProviders: providerIds,
+    realtimeVoiceProviders: realtimeVoiceProviderIds,
   };
 }
 

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -2426,6 +2426,11 @@ describe("loadPluginManifestRegistry", () => {
           ],
         },
       },
+      realtimeVoiceProviderMetadata: {
+        openai: {
+          aliases: ["openai-realtime"],
+        },
+      },
       mediaUnderstandingProviderMetadata: {
         openai: {
           capabilities: ["image", "audio", "unknown"],
@@ -2533,6 +2538,11 @@ describe("loadPluginManifestRegistry", () => {
             image: false,
           },
         },
+      },
+    });
+    expect(registry.plugins[0]?.realtimeVoiceProviderMetadata).toEqual({
+      openai: {
+        aliases: ["openai-realtime"],
       },
     });
     expect(registry.plugins[0]?.toolMetadata).toEqual({

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -282,6 +282,7 @@ export type PluginManifestRecord = {
     PluginManifestMediaUnderstandingProviderMetadata
   >;
   imageGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
+  realtimeVoiceProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   videoGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   musicGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   toolMetadata?: Record<string, PluginManifestToolMetadata>;
@@ -638,6 +639,7 @@ function buildRecord(params: {
     ),
     mediaUnderstandingProviderMetadata: params.manifest.mediaUnderstandingProviderMetadata,
     imageGenerationProviderMetadata: params.manifest.imageGenerationProviderMetadata,
+    realtimeVoiceProviderMetadata: params.manifest.realtimeVoiceProviderMetadata,
     videoGenerationProviderMetadata: params.manifest.videoGenerationProviderMetadata,
     musicGenerationProviderMetadata: params.manifest.musicGenerationProviderMetadata,
     toolMetadata: params.manifest.toolMetadata,

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -437,6 +437,8 @@ export type PluginManifest = {
   >;
   /** Cheap image-generation provider auth metadata without importing plugin runtime. */
   imageGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
+  /** Cheap realtime voice provider metadata without importing plugin runtime. */
+  realtimeVoiceProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   /** Cheap video-generation provider auth metadata without importing plugin runtime. */
   videoGenerationProviderMetadata?: Record<string, PluginManifestCapabilityProviderMetadata>;
   /** Cheap music-generation provider auth metadata without importing plugin runtime. */

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -308,6 +308,9 @@ export function loadPluginManifest(
       imageGenerationProviderMetadata: capabilityNormalizers.normalizeCapabilityProviderMetadata(
         raw.imageGenerationProviderMetadata,
       ),
+      realtimeVoiceProviderMetadata: capabilityNormalizers.normalizeCapabilityProviderMetadata(
+        raw.realtimeVoiceProviderMetadata,
+      ),
       videoGenerationProviderMetadata: capabilityNormalizers.normalizeCapabilityProviderMetadata(
         raw.videoGenerationProviderMetadata,
       ),


### PR DESCRIPTION
Closes #126594

## What Problem This Solves

Fixes an issue where users configuring Realtime Talk through `talk.realtime` would fail to start a bundled realtime voice provider unless they also configured an unrelated `agents.defaults.voiceModel`.

## Why This Change Was Made

Gateway startup plugin planning now treats the effective `talk.realtime` provider as a required realtime voice provider. The change reuses the existing configured-provider startup path and keeps speech/transcription provider activation tied to the existing voice model defaults.

## User Impact

Users can configure Realtime Talk with `talk.realtime.provider` or a single `talk.realtime.providers` block and have the owning bundled provider plugin activated at Gateway startup, including its realtime browser broker routes.

## Evidence

- Added regression coverage for explicit `talk.realtime.provider`.
- Added regression coverage for a single `talk.realtime.providers` block.
- `pnpm test src/plugins/channel-plugin-ids.test.ts`
- `pnpm test src/plugins/capability-provider-runtime.test.ts`
- `pnpm test src/gateway/server-methods/talk.test.ts`
- `pnpm format src/plugins/gateway-startup-plugin-providers.ts src/plugins/channel-plugin-ids.test.ts`
- `git diff --check`
---

Latest review repair (head `6d484dd4df0a4496a11fb03a7ab68fb601fd0a34`):

- Legacy Voice Call realtime startup planning now treats an omitted `plugins.entries["voice-call"].config.realtime.provider` as automatic selection and includes every configured provider owner from the legacy `realtime.providers` map.
- Talk realtime multi-provider behavior remains unchanged: Talk still includes all configured providers when a provider is pinned, and only singleton provider maps when no explicit provider is set.
- Added the exact regression requested by ClawSweeper: legacy Voice Call with `openai` and `google` realtime provider blocks, no explicit provider, and no `agents.defaults.voiceModel` now starts both provider owners.

Behavior proof for the repaired automatic legacy case:

```json
{
  "voiceCallRealtimeProvider": null,
  "voiceCallRealtimeProviders": ["openai", "google"],
  "startupPluginIds": ["browser", "google", "memory-core", "openai"],
  "includesOpenAI": true,
  "includesGoogle": true
}
```

Validation:

- `node scripts/run-vitest.mjs src/plugins/channel-plugin-ids.test.ts` -> 1 file passed, 177 tests passed
- `node scripts/run-vitest.mjs src/gateway/server-methods/talk.test.ts` -> 2 files passed, 132 tests passed
- `node scripts/run-vitest.mjs src/plugins/manifest-registry.test.ts extensions/xai/openclaw.plugin.test.ts extensions/xai/index.test.ts` -> passed both plugin shards
- `oxfmt --write --threads=1 src/plugins/gateway-startup-plugin-providers.ts src/plugins/channel-plugin-ids.test.ts`
- `git diff --check`
---

Latest review repair: legacy Voice Call enablement boundary

- Legacy Voice Call realtime provider-map startup collection is now gated on `realtime.enabled === true`, matching the runtime path that only loads realtime when enabled.
- Positive legacy fixtures now set `realtime.enabled: true`.
- Added a disabled legacy provider-map regression that keeps both `openai` and `google` out of the startup plan.

Behavior proof:

```json
{
  "enabledPlan": ["browser", "google", "memory-core", "openai"],
  "disabledPlan": ["browser", "memory-core"]
}
```

Validation:

- `node scripts/run-vitest.mjs src/plugins/channel-plugin-ids.test.ts` -> 1 file passed, 178 tests passed
- `node scripts/run-vitest.mjs src/plugins/manifest-registry.test.ts extensions/xai/openclaw.plugin.test.ts extensions/xai/index.test.ts` -> passed both plugin shards
- `git diff --check`