### PR TITLE
perf(test): trigger restart probe timeout deterministically

### DIFF
--- a/src/cli/daemon-cli/restart-health-probe.test.ts
+++ b/src/cli/daemon-cli/restart-health-probe.test.ts
@@ -31,6 +31,7 @@ describe("restart health", () => {
       const gateway = new WebSocketServer({ host: "127.0.0.1", port: 0 });
       await once(gateway, "listening");
       const port = (gateway.address() as AddressInfo).port;
+      const timeoutSpy = failure === "timeout" ? vi.spyOn(globalThis, "setTimeout") : undefined;
       gateway.on("connection", (socket) => {
         sendMinimalGatewayConnectChallenge(socket);
         socket.on("message", (data) => {
@@ -46,7 +47,9 @@ describe("restart health", () => {
               ...hello,
               server: { ...hello.server, version: "2026.8.1" },
             });
-          } else if (failure !== "timeout") {
+          } else if (failure === "timeout") {
+            timeoutSpy?.mock.calls.findLast(([, delay]) => delay === 3_000)?.[0]();
+          } else {
             socket.send(
               JSON.stringify({
                 type: "res",
@@ -88,6 +91,10 @@ describe("restart health", () => {
         expect(snapshot.gatewayVersion).toBe("2026.8.1");
         expect(snapshot.versionMismatch).toBeUndefined();
         expect(snapshot.probeError).toBe(failure);
+        expect(firstCallArg(probeGateway)).toMatchObject({
+          includeDetails: true,
+          timeoutMs: 3_000,
+        });
         expect(renderRestartDiagnostics(snapshot)).toContain(`Gateway probe failed: ${failure}`);
       } finally {
         await closeMinimalGatewayServer(gateway);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

The real Gateway restart-health regression test for a matching-version detail RPC timeout idles for the full production 3,000 ms deadline on every run, slowing the CLI test lane without adding behavioral coverage.

## Why This Change Was Made

Observe the real production timer only in the timeout variant and invoke its already-armed 3,000 ms callback after the real WebSocket server receives the genuine non-connect detail request. The TCP/socket boundary, connect challenge, authenticated hello and version, detail RPC, production Gateway probe implementation, error redaction, restart diagnostics, socket cleanup, and independent ECONNRESET response all remain real. Explicitly assert that the restart owner requests `includeDetails: true` and `timeoutMs: 3000`.

## User Impact

No product behavior changes. Developers and maintainers retain the same real-boundary restart-health regression protection while the measured test file runs 28.7% faster and the timeout case runs 66.7% faster.

## Evidence

Controlled Blacksmith benchmark: one excluded warmup plus two retained before/after samples, one worker, distinct caches, import diagnostics, and `/usr/bin/time -v`; benchmark lease `tbx_01m0fgq0wz6d9q7pvc7p4cbd3v` stopped after measurement.

- Retained file-wall mean: `11.545s -> 8.235s` (`-3.310s`, `-28.7%`); individual samples before `9.51s / 13.58s`, after `9.25s / 7.22s`.
- Retained timeout-case mean: `5.3515s -> 1.7825s` (`-3.569s`, `-66.7%`); every retained before/after comparison improves by more than `0.5s`.
- Peak RSS: `684,832 KiB -> 680,552 KiB` (directional only).
- Fault injection: temporarily suppressing owner `probeError` fails both timeout and ECONNRESET cases; changing the owner timeout from `3000` to `250` fails the exact timeout assertion. Both injected faults were restored.
- Fresh focused owner and sibling proof: `node scripts/run-vitest.mjs src/cli/daemon-cli/restart-health-probe.test.ts src/cli/daemon-cli/restart-health-external.test.ts src/cli/daemon-cli/restart-health.test.ts src/cli/daemon-cli/restart-health-wait.test.ts src/gateway/probe.test.ts` passed both Gateway and CLI shards: six collected files, `128/128` tests.
- Fresh complete changed core-test gate: `node scripts/check-changed.mjs -- src/cli/daemon-cli/restart-health-probe.test.ts` passed all guards, formatting, dead-export scans, full sharded core-test typechecking, and changed-file lint (`0 warnings`, `0 errors`) on Blacksmith Testbox lease `tbx_01m0fhs16pczbp5xwgbbeg1ass`, which stopped automatically after success. Hosted session: https://github.com/openclaw/openclaw/actions/runs/32368236954 (the delegated backing workflow may show cancelled after Blacksmith stops a successful one-shot lease; the wrapper exit code and timing JSON are the authoritative result).
- Fresh structured branch autoreview against `origin/main`: no accepted/actionable findings; confidence `0.99`.
- `git diff --check origin/main...HEAD` passed. Production LOC: `+0/-0`; tests: `+8/-1` in one file.
- No UI change or screenshots; no changelog, dependency, baseline, snapshot, protocol, SQLite, release, or production changes.

AI-assisted; reviewed and validated by the maintainer.
