### PR TITLE
fix(memory): reject embedding results after timeout

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -770,7 +770,7 @@ extensions/memory-core/src/memory/manager-cache.ts	4
 extensions/memory-core/src/memory/manager-db.ts	5
 extensions/memory-core/src/memory/manager-embedding-cache.ts	1
 extensions/memory-core/src/memory/manager-embedding-errors.ts	2
-extensions/memory-core/src/memory/manager-embedding-ops.ts	3
+extensions/memory-core/src/memory/manager-embedding-ops.ts	2
 extensions/memory-core/src/memory/manager-keyword-retrieval.ts	1
 extensions/memory-core/src/memory/manager-reindex-lock.ts	1
 extensions/memory-core/src/memory/manager-search-orchestration.ts	3

--- a/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
@@ -12,6 +12,7 @@ type EmbeddingQueryRetryHarness = {
 
 function createEmbeddingQueryRetryHarness(
   embedQuery: EmbeddingProvider["embedQuery"],
+  timeoutMs = 60_000,
 ): EmbeddingQueryRetryHarness {
   const provider: EmbeddingProvider = {
     id: "test-provider",
@@ -24,7 +25,7 @@ function createEmbeddingQueryRetryHarness(
   // memory index or acquiring an external embedding provider.
   return Object.assign(Object.create(MemoryManagerEmbeddingOps.prototype), {
     provider,
-    resolveEmbeddingTimeout: () => 60_000,
+    resolveEmbeddingTimeout: () => timeoutMs,
     markLocalEmbeddingProviderDegraded: vi.fn(),
     withProviderUse: async <T>(_provider: EmbeddingProvider, run: () => Promise<T>) => await run(),
   }) as EmbeddingQueryRetryHarness;
@@ -74,5 +75,37 @@ describe("memory embedding query retry cancellation", () => {
       cause: abortReason,
     });
     expect(embedQuery).not.toHaveBeenCalled();
+  });
+
+  it("retries provider success that arrives after each embedding deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const operationSignals: AbortSignal[] = [];
+    const embedQuery = vi.fn<EmbeddingProvider["embedQuery"]>(async (_text, options) => {
+      if (options?.signal) {
+        operationSignals.push(options.signal);
+      }
+      vi.setSystemTime(Date.now() + 11);
+      return [1, 0, 0, 0];
+    });
+    const manager = createEmbeddingQueryRetryHarness(embedQuery, 10);
+    const pending = manager.embedQueryWithRetry("search terms");
+    void pending.catch(() => {});
+
+    await vi.runAllTimersAsync();
+
+    const timeoutMessage = "memory embeddings query timed out after 0s";
+    await expect(pending).rejects.toMatchObject({
+      code: "MEMORY_EMBEDDING_OPERATION_FAILED",
+      operation: "query",
+      cause: { message: timeoutMessage },
+    });
+    expect(embedQuery).toHaveBeenCalledTimes(3);
+    expect(operationSignals).toHaveLength(3);
+    expect(operationSignals.every((signal) => signal.aborted)).toBe(true);
+    expect(operationSignals.every((signal) => signal.reason?.message === timeoutMessage)).toBe(
+      true,
+    );
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -282,17 +282,25 @@ async function runEmbeddingOperationWithTimeout<T>(params: {
     return await params.run(signal);
   }
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
+  const timeoutError = new Error(params.message);
+  const deadlineStartedAt = Date.now();
   let timer: NodeJS.Timeout | null = null;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      const error = new Error(params.message);
-      reject(error);
-      controller.abort(error);
+      reject(timeoutError);
+      controller.abort(timeoutError);
     }, timeoutMs);
   });
   try {
     const operation = params.run(signal);
-    return (await Promise.race([operation, timeoutPromise])) as T;
+    const result = (await Promise.race([operation, timeoutPromise])) as T;
+    params.signal?.throwIfAborted();
+    // An overdue watchdog can run after provider success following an event-loop stall.
+    if (Date.now() - deadlineStartedAt >= timeoutMs) {
+      controller.abort(timeoutError);
+      throw timeoutError;
+    }
+    return result;
   } finally {
     if (timer) {
       clearTimeout(timer);
@@ -784,21 +792,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     timeoutMs: number,
     message: string,
   ): Promise<T> {
-    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-      return await promise;
-    }
-    const resolvedTimeoutMs = resolveTimerTimeoutMs(timeoutMs, 1);
-    let timer: NodeJS.Timeout | null = null;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timer = setTimeout(() => reject(new Error(message)), resolvedTimeoutMs);
-    });
-    try {
-      return (await Promise.race([promise, timeoutPromise])) as T;
-    } finally {
-      if (timer) {
-        clearTimeout(timer);
-      }
-    }
+    return await runEmbeddingOperationWithTimeout({ timeoutMs, message, run: () => promise });
   }
 
   private async withBatchFailureLock<T>(fn: () => Promise<T>): Promise<T> {


### PR DESCRIPTION
Closes #126666

## What Problem This Solves

Fixes an issue where memory embedding and vector-loading operations could return successfully after their configured deadline when the event loop was stalled until both the provider completion and watchdog timer were overdue.

## Why This Change Was Made

The shared embedding timeout owner now records elapsed wall time and rejects/aborts an overdue success before it can cross the operation boundary. The duplicate SQLite vector-loading timeout path reuses that same owner, so query, batch, structured-batch, and vector initialization all follow one fail-closed deadline rule. Caller cancellation still takes precedence.

## User Impact

Memory search and indexing now honor configured time budgets even during event-loop stalls. Late provider results cannot silently extend an operation beyond its deadline, and provider leases still remain valid until the admitted operation releases them.

## Evidence

- Pre-fix deterministic harness: a 100 ms provider result beat an overdue 10 ms watchdog and resolved after roughly 152 ms with `aborted=false`.
- The complete memory extension lane independently exposed the same failure before the fix: 1 failed, 1,149 passed, 3 skipped.
- Post-fix real-timer harness: rejected after the existing retry policy with `operationAborted=true`.
- Focused owner proof: 17/17 across embedding retry, provider lifecycle leases, and canonical memory-search deadlines.
- Complete memory extension lane: 1,151 passed, 3 skipped across 89 passing files and one skipped file.
- Changed-file gate passed: format, extension/test typecheck, extension lint, plugin boundaries, dead exports, import cycles, and repository guards.
- Fresh Codex autoreview on the rebased branch: clean, no accepted/actionable findings.
- Production LOC: +13/-19, net -6. Tests: +34/-1. Shrink-only assertion-safety baseline maintenance: +1/-1.
- No external provider, credential, protocol, config, schema, or UI change is involved.

AI-assisted: implementation and review used Codex, with maintainer inspection of the complete timeout, retry, provider-lease, vector-loading, and test paths.
