### PR TITLE
fix(tui): route usage cost correctly

### DIFF
--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -114,7 +114,7 @@ Session controls:
 - `/verbose <on|full|off>`
 - `/trace <on|off>`
 - `/reasoning <on|off|stream>`
-- `/usage <off|tokens|full|reset>` (`reset`/`inherit`/`clear`/`default` clears the session override)
+- `/usage <off|tokens|full|cost|reset>` (`cost` shows session, today, and 30-day costs; `reset`/`inherit`/`clear`/`default` clears the session override)
 - `/goal <objective> | /goal [status] | /goal start <objective> | /goal edit <objective> | /goal pause|resume|complete|block|clear`
 - `/btw <side question>` (alias: `/side`; asks without changing future session context)
 - `/elevated <on|off|ask|full>` (alias: `/elev`)

--- a/src/auto-reply/reply/commands-session-cost.runtime.ts
+++ b/src/auto-reply/reply/commands-session-cost.runtime.ts
@@ -1,0 +1,71 @@
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
+import { resolveSessionStorePathForScope } from "../../config/sessions/session-store-path.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadCostUsageSummary, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
+import { DEFAULT_AGENT_ID, isUnscopedSessionKeySentinel } from "../../routing/session-key.js";
+import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
+
+export async function formatSessionUsageCostSummary(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  agentId?: string;
+  sessionEntry?: SessionEntry;
+  storePath?: string;
+}): Promise<string> {
+  const sessionAgentId =
+    params.sessionKey && !isUnscopedSessionKeySentinel(params.sessionKey)
+      ? resolveSessionAgentId({
+          sessionKey: params.sessionKey,
+          config: params.cfg,
+          agentId: params.agentId,
+        })
+      : params.agentId;
+  const agentId = sessionAgentId ?? DEFAULT_AGENT_ID;
+  const sessionSummary = await loadSessionCostSummary({
+    sessionId: params.sessionEntry?.sessionId,
+    sessionEntry: params.sessionEntry,
+    ...(params.sessionEntry?.sessionId && params.sessionKey
+      ? {
+          sessionTarget: {
+            agentId,
+            sessionId: params.sessionEntry.sessionId,
+            sessionKey: params.sessionKey,
+            storePath: resolveSessionStorePathForScope({
+              agentId,
+              sessionKey: params.sessionKey,
+              storePath:
+                params.storePath ??
+                resolveSessionStorePathCore(params.cfg.session?.store, { agentId }),
+            }),
+          },
+        }
+      : {}),
+    config: params.cfg,
+    agentId,
+  });
+  const summary = await loadCostUsageSummary({ config: params.cfg, agentId });
+
+  const sessionCost = formatUsd(sessionSummary?.totalCost);
+  const sessionTokens = sessionSummary?.totalTokens
+    ? formatTokenCount(sessionSummary.totalTokens)
+    : undefined;
+  const sessionSuffix = (sessionSummary?.missingCostEntries ?? 0) > 0 ? " (partial)" : "";
+  const sessionLine =
+    sessionCost || sessionTokens
+      ? `Session ${sessionCost ?? "n/a"}${sessionSuffix}${sessionTokens ? ` · ${sessionTokens} tokens` : ""}`
+      : "Session n/a";
+
+  const todayKey = new Date().toLocaleDateString("en-CA");
+  const todayEntry = summary.daily.find((entry) => entry.date === todayKey);
+  const todayCost = formatUsd(todayEntry?.totalCost);
+  const todaySuffix = (todayEntry?.missingCostEntries ?? 0) > 0 ? " (partial)" : "";
+  const todayLine = `Today ${todayCost ?? "n/a"}${todaySuffix}`;
+
+  const last30Cost = formatUsd(summary.totals.totalCost);
+  const last30Suffix = summary.totals.missingCostEntries > 0 ? " (partial)" : "";
+  const last30Line = `Last 30d ${last30Cost ?? "n/a"}${last30Suffix}`;
+
+  return `💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}`;
+}

--- a/src/auto-reply/reply/commands-session.ts
+++ b/src/auto-reply/reply/commands-session.ts
@@ -22,8 +22,6 @@ import { formatThreadBindingDurationLabel } from "../../channels/thread-bindings
 import { parseDurationMs } from "../../cli/parse-duration.js";
 import { isRestartEnabled } from "../../config/commands.flags.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
-import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
-import { resolveSessionStorePathForScope } from "../../config/sessions/session-store-path.js";
 import { logVerbose } from "../../globals.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
@@ -35,9 +33,6 @@ import {
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart, triggerOpenClawRestart } from "../../infra/restart.js";
-import { loadCostUsageSummary, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
-import { DEFAULT_AGENT_ID, isUnscopedSessionKeySentinel } from "../../routing/session-key.js";
-import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
 import { parseActivationCommand } from "../group-activation.js";
 import { parseSendPolicyCommand } from "../send-policy.js";
 import {
@@ -288,69 +283,16 @@ export const handleUsageCommand: CommandHandler = defineAuthorizedTextCommand(
   async (params, rawArgs) => {
     const requested = rawArgs ? normalizeUsageDisplay(rawArgs) : undefined;
     if (normalizeLowercaseStringOrEmpty(rawArgs).startsWith("cost")) {
-      const targetSessionEntry = params.sessionStore?.[params.sessionKey] ?? params.sessionEntry;
-      const sessionAgentId =
-        params.sessionKey && !isUnscopedSessionKeySentinel(params.sessionKey)
-          ? resolveSessionAgentId({
-              sessionKey: params.sessionKey,
-              config: params.cfg,
-              agentId: params.agentId,
-            })
-          : params.agentId;
-      const usageAgentId = sessionAgentId ?? DEFAULT_AGENT_ID;
-      const sessionSummary = await loadSessionCostSummary({
-        sessionId: targetSessionEntry?.sessionId,
-        sessionEntry: targetSessionEntry,
-        ...(targetSessionEntry?.sessionId && params.sessionKey
-          ? {
-              sessionTarget: {
-                agentId: usageAgentId,
-                sessionId: targetSessionEntry.sessionId,
-                sessionKey: params.sessionKey,
-                storePath: resolveSessionStorePathForScope({
-                  agentId: usageAgentId,
-                  sessionKey: params.sessionKey,
-                  storePath:
-                    params.storePath ??
-                    resolveSessionStorePathCore(params.cfg.session?.store, {
-                      agentId: usageAgentId,
-                    }),
-                }),
-              },
-            }
-          : {}),
-        config: params.cfg,
-        agentId: usageAgentId,
-      });
-      const summary = await loadCostUsageSummary({
-        config: params.cfg,
-        agentId: usageAgentId,
-      });
-
-      const sessionCost = formatUsd(sessionSummary?.totalCost);
-      const sessionTokens = sessionSummary?.totalTokens
-        ? formatTokenCount(sessionSummary.totalTokens)
-        : undefined;
-      const sessionMissing = sessionSummary?.missingCostEntries ?? 0;
-      const sessionSuffix = sessionMissing > 0 ? " (partial)" : "";
-      const sessionLine =
-        sessionCost || sessionTokens
-          ? `Session ${sessionCost ?? "n/a"}${sessionSuffix}${sessionTokens ? ` · ${sessionTokens} tokens` : ""}`
-          : "Session n/a";
-
-      const todayKey = new Date().toLocaleDateString("en-CA");
-      const todayEntry = summary.daily.find((entry) => entry.date === todayKey);
-      const todayCost = formatUsd(todayEntry?.totalCost);
-      const todayMissing = todayEntry?.missingCostEntries ?? 0;
-      const todaySuffix = todayMissing > 0 ? " (partial)" : "";
-      const todayLine = `Today ${todayCost ?? "n/a"}${todaySuffix}`;
-
-      const last30Cost = formatUsd(summary.totals.totalCost);
-      const last30Missing = summary.totals.missingCostEntries;
-      const last30Suffix = last30Missing > 0 ? " (partial)" : "";
-      const last30Line = `Last 30d ${last30Cost ?? "n/a"}${last30Suffix}`;
-
-      return sessionCommandReply(`💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}`);
+      const { formatSessionUsageCostSummary } = await import("./commands-session-cost.runtime.js");
+      return sessionCommandReply(
+        await formatSessionUsageCostSummary({
+          cfg: params.cfg,
+          sessionKey: params.sessionKey,
+          agentId: params.agentId,
+          sessionEntry: params.sessionStore?.[params.sessionKey] ?? params.sessionEntry,
+          storePath: params.storePath,
+        }),
+      );
     }
 
     const isReset = rawArgs ? isSessionDefaultDirectiveValue(rawArgs) : false;

--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -56,6 +56,16 @@ describe("getSlashCommands", () => {
     ]);
   });
 
+  it.each([{}, { local: true }])("exposes usage cost in completion and help", (options) => {
+    const commands = getSlashCommands(options);
+    const usage = commands.find((command) => command.name === "usage");
+
+    expect(usage?.description).toContain("cost summary");
+    expect(usage?.getArgumentCompletions?.("co")).toEqual([{ value: "cost", label: "cost" }]);
+    expect(shouldSubmitExactArgumentCompletion("/usage cost", commands)).toBe(true);
+    expect(helpText(options)).toContain("/usage <off|tokens|full|cost|reset|");
+  });
+
   it.each([
     { commandName: "verbose", level: "full", description: "Set verbose on/off/full" },
     { commandName: "reasoning", level: "stream", description: "Set reasoning on/off/stream" },

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -21,7 +21,16 @@ const FAST_LEVELS = ["status", "auto", "on", "off"];
 const REASONING_LEVELS = ["on", "off", "stream"] satisfies ReasoningLevel[];
 const ELEVATED_LEVELS = ["on", "off", "ask", "full"];
 const ACTIVATION_LEVELS = ["mention", "always"];
-const USAGE_FOOTER_LEVELS = ["off", "tokens", "full", "reset", "inherit", "clear", "default"];
+const USAGE_COMMAND_VALUES = [
+  "off",
+  "tokens",
+  "full",
+  "cost",
+  "reset",
+  "inherit",
+  "clear",
+  "default",
+];
 
 type ParsedCommand = {
   name: string;
@@ -123,9 +132,9 @@ const TUI_COMMAND_ROWS = [
   ],
   [
     "usage",
-    "Toggle per-response usage line",
-    "/usage <off|tokens|full|reset|inherit|clear|default>",
-    USAGE_FOOTER_LEVELS,
+    "Toggle per-response usage line or show cost summary",
+    "/usage <off|tokens|full|cost|reset|inherit|clear|default>",
+    USAGE_COMMAND_VALUES,
   ],
   [
     "elevated",

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -18,6 +18,7 @@ const agentCommandFromIngressMock = vi.fn();
 const queueEmbeddedAgentMessageWithOutcomeAsyncMock = vi.fn();
 const resolveActiveEmbeddedRunSessionIdMock = vi.fn();
 const runBtwSideQuestionMock = vi.fn();
+const formatSessionUsageCostSummaryMock = vi.fn();
 const updateSessionStoreMock = vi.fn();
 const applySessionPatchProjectionMock = vi.fn();
 const projectSessionsPatchEntryMock = vi.fn();
@@ -101,6 +102,10 @@ vi.mock("../agents/embedded-agent-runner/runs.js", () => ({
 
 vi.mock("../agents/btw.js", () => ({
   runBtwSideQuestion: (...args: unknown[]) => runBtwSideQuestionMock(...args),
+}));
+
+vi.mock("../auto-reply/reply/commands-session-cost.runtime.js", () => ({
+  formatSessionUsageCostSummary: (...args: unknown[]) => formatSessionUsageCostSummaryMock(...args),
 }));
 
 vi.mock("../infra/agent-events.js", () => ({
@@ -319,6 +324,8 @@ describe("EmbeddedTuiBackend", () => {
     resolveActiveEmbeddedRunSessionIdMock.mockReset();
     resolveActiveEmbeddedRunSessionIdMock.mockReturnValue(undefined);
     runBtwSideQuestionMock.mockReset();
+    formatSessionUsageCostSummaryMock.mockReset();
+    formatSessionUsageCostSummaryMock.mockResolvedValue("💸 Usage cost\nSession $1.23");
     updateSessionStoreMock.mockReset();
     updateSessionStoreMock.mockImplementation(
       async (_storePath: string, update: (store: Record<string, unknown>) => unknown) =>
@@ -1120,6 +1127,35 @@ describe("EmbeddedTuiBackend", () => {
       sessionKey: "global",
       storePath: "/tmp/openclaw-work-sessions.json",
     });
+  });
+
+  it("runs local usage cost with the canonical session entry and selected agent", async () => {
+    const cfg = { session: { scope: "global" } };
+    const sessionEntry = { sessionId: "session-work", updatedAt: embeddedEventTimestamp };
+    loadSessionEntryMock.mockReturnValueOnce({
+      cfg,
+      canonicalKey: "global",
+      storePath: "/tmp/openclaw-work-sessions.json",
+      entry: sessionEntry,
+    });
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const backend = new EmbeddedTuiBackend();
+
+    await expect(
+      backend.runUsageCostCommand({ sessionKey: "global", agentId: "work" }),
+    ).resolves.toEqual({
+      text: "💸 Usage cost\nSession $1.23",
+    });
+
+    expect(loadSessionEntryMock).toHaveBeenCalledWith("global", { agentId: "work" });
+    expect(formatSessionUsageCostSummaryMock).toHaveBeenCalledWith({
+      cfg,
+      sessionKey: "global",
+      agentId: "work",
+      sessionEntry,
+      storePath: "/tmp/openclaw-work-sessions.json",
+    });
+    expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
   });
 
   it("loads history thinking defaults from configured replace-mode models", async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -958,6 +958,25 @@ export class EmbeddedTuiBackend implements TuiBackend {
       : { text: result.text };
   }
 
+  async runUsageCostCommand(opts: Parameters<NonNullable<TuiBackend["runUsageCostCommand"]>>[0]) {
+    await this.ready;
+    const { cfg, canonicalKey, storePath, entry } = loadSessionEntry(
+      opts.sessionKey,
+      opts.agentId ? { agentId: opts.agentId } : undefined,
+    );
+    const { formatSessionUsageCostSummary } =
+      await import("../auto-reply/reply/commands-session-cost.runtime.js");
+    return {
+      text: await formatSessionUsageCostSummary({
+        cfg,
+        sessionKey: canonicalKey ?? opts.sessionKey,
+        agentId: opts.agentId,
+        sessionEntry: entry,
+        storePath,
+      }),
+    };
+  }
+
   private enqueuePendingLocalMessage(params: {
     runScope: { sessionKey: string; agentId?: string };
     message: string;

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -226,4 +226,8 @@ export type TuiBackend = {
   runGoalCommand?: (
     opts: TuiGoalCommandOptions,
   ) => Promise<{ text: string; continuationPrompt?: string }>;
+  runUsageCostCommand?: (opts: {
+    sessionKey: string;
+    agentId?: string;
+  }) => Promise<{ text: string }>;
 };

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -103,6 +103,7 @@ function createHarness(params?: {
   createSession?: ReturnType<typeof vi.fn>;
   resetSession?: ReturnType<typeof vi.fn>;
   runGoalCommand?: ReturnType<typeof vi.fn>;
+  runUsageCostCommand?: ReturnType<typeof vi.fn> | null;
   runAuthFlow?: RunAuthFlow;
   setSession?: SetSessionMock;
   loadHistory?: LoadHistoryMock;
@@ -144,6 +145,10 @@ function createHarness(params?: {
     }));
   const resetSession = params?.resetSession ?? vi.fn().mockResolvedValue({ ok: true });
   const runGoalCommand = params?.runGoalCommand ?? vi.fn().mockResolvedValue({ text: "Goal" });
+  const runUsageCostCommand =
+    params?.runUsageCostCommand === null
+      ? undefined
+      : (params?.runUsageCostCommand ?? vi.fn().mockResolvedValue({ text: "💸 Usage cost" }));
   const setSession = params?.setSession ?? (vi.fn().mockResolvedValue(undefined) as SetSessionMock);
   const addUser = vi.fn();
   const addPendingUser = vi.fn();
@@ -209,6 +214,7 @@ function createHarness(params?: {
       createSession,
       resetSession,
       runGoalCommand,
+      runUsageCostCommand,
     } as never,
     chatLog: {
       addUser,
@@ -263,6 +269,7 @@ function createHarness(params?: {
     createSession,
     resetSession,
     runGoalCommand,
+    runUsageCostCommand,
     setSession,
     addUser,
     addPendingUser,
@@ -2753,6 +2760,96 @@ describe("tui command handlers", () => {
     // until refreshSessionInfo() repopulates the inherited default.
     expect(sessionInfo.responseUsage).toBeUndefined();
     expect(sessionInfo.effectiveResponseUsage).toBeUndefined();
+  });
+
+  it("forwards /usage cost to the Gateway without patching the usage footer", async () => {
+    const { handleCommand, sendChat, patchSession, addSystem, runUsageCostCommand } =
+      createHarness();
+
+    await handleCommand("/usage cost");
+
+    expect({
+      systemMessages: addSystem.mock.calls.map(([message]) => message),
+      sessionPatches: patchSession.mock.calls.length,
+      gatewaySends: sendChat.mock.calls.length,
+    }).toEqual({ systemMessages: [], sessionPatches: 0, gatewaySends: 1 });
+    expectSendChatFields(sendChat, { message: "/usage cost" });
+    expect(runUsageCostCommand).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { sessionKey: "agent:main:main", agentId: "main" },
+    { sessionKey: "global", agentId: "work" },
+  ])(
+    "runs /usage cost locally for $sessionKey without submitting a model turn",
+    async (selection) => {
+      const harness = createHarness({
+        opts: { local: true },
+        currentSessionKey: selection.sessionKey,
+        currentAgentId: selection.agentId,
+      });
+
+      await harness.handleCommand("/usage cost");
+
+      expect(harness.runUsageCostCommand).toHaveBeenCalledWith(selection);
+      expect(harness.addSystem).toHaveBeenCalledWith("💸 Usage cost");
+      expect(harness.sendChat).not.toHaveBeenCalled();
+      expect(harness.patchSession).not.toHaveBeenCalled();
+      expect(harness.addPendingUser).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps an unavailable local usage-cost operation out of model prompts", async () => {
+    const harness = createHarness({ opts: { local: true }, runUsageCostCommand: null });
+
+    await harness.handleCommand("/usage cost");
+
+    expect(harness.addSystem).toHaveBeenCalledWith(
+      "/usage cost is not available in local embedded mode; message not sent",
+    );
+    expect(harness.sendChat).not.toHaveBeenCalled();
+    expect(harness.patchSession).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "session result", sessionKey: "agent:main:first", agentId: "main", fails: false },
+    { name: "global-agent result", sessionKey: "global", agentId: "main", fails: false },
+    { name: "session failure", sessionKey: "agent:main:first", agentId: "main", fails: true },
+  ])("suppresses a stale usage-cost $name", async ({ sessionKey, agentId, fails }) => {
+    const deferred = createDeferred<{ text: string }>();
+    const runUsageCostCommand = vi.fn(() => deferred.promise);
+    const harness = createHarness({
+      opts: { local: true },
+      currentSessionKey: sessionKey,
+      currentAgentId: agentId,
+      runUsageCostCommand,
+    });
+
+    const pending = harness.handleCommand("/usage cost");
+    if (sessionKey === "global") {
+      harness.state.currentAgentId = "work";
+    } else {
+      harness.state.currentSessionKey = "agent:main:second";
+    }
+    if (fails) {
+      deferred.reject(new Error("stale cost failure"));
+    } else {
+      deferred.resolve({ text: "stale usage cost" });
+    }
+    await pending;
+
+    expect(harness.addSystem).not.toHaveBeenCalled();
+    expect(harness.sendChat).not.toHaveBeenCalled();
+  });
+
+  it("shows current-session usage-cost failures without invoking the model", async () => {
+    const runUsageCostCommand = vi.fn().mockRejectedValue(new Error("session costs unavailable"));
+    const harness = createHarness({ opts: { local: true }, runUsageCostCommand });
+
+    await harness.handleCommand("/usage cost");
+
+    expect(harness.addSystem).toHaveBeenCalledWith("usage cost failed: session costs unavailable");
+    expect(harness.sendChat).not.toHaveBeenCalled();
   });
 
   it("/usage no-arg toggle cycles from effectiveResponseUsage when the session override is unset", async () => {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -680,11 +680,33 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         "reasoning failed",
       );
     },
-    usage: async (args) => {
+    usage: async (args, raw) => {
+      if (args.toLowerCase() === "cost") {
+        if (!opts.local) {
+          await sendMessage(raw);
+          return;
+        }
+        if (!client.runUsageCostCommand) {
+          addUnsupportedLocalCommand("usage cost");
+          return;
+        }
+        const selection = captureSessionSelection();
+        try {
+          const result = await client.runUsageCostCommand(selection);
+          if (isCurrentSessionSelection(selection)) {
+            chatLog.addSystem(result.text);
+          }
+        } catch (err) {
+          if (isCurrentSessionSelection(selection)) {
+            chatLog.addSystem(`usage cost failed: ${formatTuiErrorMessage(err)}`);
+          }
+        }
+        return;
+      }
       const isReset = args ? isSessionDefaultDirectiveValue(args) : false;
       const normalized = args && !isReset ? normalizeUsageDisplay(args) : undefined;
       if (args && !normalized && !isReset) {
-        chatLog.addSystem("usage: /usage <off|tokens|full|reset>");
+        chatLog.addSystem("usage: /usage <off|tokens|full|cost|reset>");
         return;
       }
       if (isReset) {

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -1111,6 +1111,23 @@ describe("TUI PTY real backends", () => {
   );
 
   it(
+    "prints local usage costs without submitting a model request",
+    async ({ onTestFinished }) => {
+      const fixture = await startLocalModeTui(onTestFinished);
+      try {
+        await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+        await fixture.run.write("/usage cost\r", { delay: false });
+        await fixture.run.waitForOutput("Usage cost", LOCAL_OUTPUT_TIMEOUT_MS);
+        await fixture.run.waitForOutput("Last 30d", LOCAL_OUTPUT_TIMEOUT_MS);
+        expect(fixture.mockModel.requests()).toHaveLength(0);
+      } finally {
+        await fixture.cleanup();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
+
+  it(
     "drives and steers the real local backend with a mocked model endpoint",
     async ({ onTestFinished }) => {
       const fixture = await startLocalModeTui(onTestFinished, {
@@ -1694,6 +1711,47 @@ export default {
       it(name, run, timeoutMs);
     });
   }
+
+  registerGatewayTest(
+    "routes usage cost through Gateway chat.send without patching or invoking the model",
+    async ({ onTestFinished }) => {
+      const shared = await requireSharedGatewayFixture();
+      const scenario = GATEWAY_SCENARIOS.command;
+      const sessionKey = `agent:${scenario.agentId}:tui-pty-usage-cost`;
+      await shared.controlClient.createSession({ key: sessionKey, agentId: scenario.agentId });
+      const initialModelRequests = shared.mockModel.requests().length;
+      const proxy = await startGatewayRpcDelayProxy(shared.gateway.url, []);
+      const cleanupProxy = registerIdempotentCleanup(
+        onTestFinished,
+        async () => await proxy.stop(),
+      );
+      const fixture = await startIsolatedGatewayPty({
+        gateway: shared.gateway,
+        registerCleanup: onTestFinished,
+        sessionKey,
+        url: proxy.url,
+      });
+      try {
+        await fixture.run.waitForOutput("gateway connected", LOCAL_STARTUP_TIMEOUT_MS);
+        const requestOffset = proxy.requests.length;
+        await fixture.run.write("/usage cost\r", { delay: false });
+        await fixture.run.waitForOutput("Last 30d", LOCAL_OUTPUT_TIMEOUT_MS);
+
+        const requests = proxy.requests.slice(requestOffset);
+        expect(requests.filter((request) => request.method === "chat.send")).toEqual([
+          expect.objectContaining({
+            params: expect.objectContaining({ sessionKey, message: "/usage cost" }),
+          }),
+        ]);
+        expect(requests.some((request) => request.method === "sessions.patch")).toBe(false);
+        expect(shared.mockModel.requests()).toHaveLength(initialModelRequests);
+      } finally {
+        await fixture.cleanup();
+        await cleanupProxy();
+      }
+    },
+    LOCAL_TEST_TIMEOUT_MS,
+  );
 
   registerGatewayTest(
     "authenticates valid tokens and rejects invalid tokens through a real Gateway PTY",


### PR DESCRIPTION
Closes #126665

AI-assisted: yes

## What Problem This Solves

Fixes an issue where users entering the documented `/usage cost` command in a Gateway-connected or local terminal session received an invalid usage-footer error instead of the existing session, today, and 30-day cost summary. TUI completion and help also omitted the supported `cost` argument.

## Why This Change Was Made

The TUI owns fast local usage-footer updates, while cost presentation belongs to the existing session-command owner. Gateway-connected sessions now forward the exact command through the existing authorized `chat.send` path; embedded sessions use a narrow internal operation that dynamically imports the same canonical cost-summary formatter without submitting a model turn. Selected session/agent identity is captured before asynchronous work, stale results and failures are discarded after selection changes, and an unavailable embedded operation fails visibly without leaking the command to a model.

No Gateway RPC, public API, protocol, configuration, persistence, security, or product-behavior surface was added. Existing footer modes and reset aliases remain local and unchanged.

## User Impact

`/usage cost` now displays the existing session, today, and 30-day cost summary in both Gateway-connected and local TUI sessions. The argument is visible in completion and `/help`, and local execution never generates an unnecessary model request. The dedicated TUI guide now documents the command.

## Evidence

Before the repair, the focused executable regression produced `usage: /usage <off|tokens|full|reset>`, zero session patches, and zero Gateway sends. The same regression now forwards the exact raw command without a session patch.

Focused production-boundary and sibling coverage:

```text
node scripts/run-vitest.mjs src/tui/commands.test.ts src/tui/tui-command-handlers.test.ts src/tui/embedded-backend.test.ts src/auto-reply/reply/commands-session-usage.test.ts --configLoader runner
296 tests passed across 4 files and 2 Vitest shards.

OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts --configLoader runner src/tui/tui-pty-local.e2e.test.ts -t 'usage cost'
2 real PTY tests passed: embedded cost summary with zero model requests; authenticated Gateway cost summary with exactly one recorded chat.send, zero sessions.patch calls, and zero requests across every mock-model route.

pnpm build
node scripts/check-changed.mjs -- docs/web/tui.md src/auto-reply/reply/commands-session-cost.runtime.ts src/auto-reply/reply/commands-session.ts src/tui/commands.test.ts src/tui/commands.ts src/tui/embedded-backend.test.ts src/tui/embedded-backend.ts src/tui/tui-backend.ts src/tui/tui-command-handlers.test.ts src/tui/tui-command-handlers.ts src/tui/tui-pty-local.e2e.test.ts
git diff --check
```

The built embedded and session-command bundles both retain a dynamic import of the single separately emitted cost-runtime chunk; no ineffective-dynamic-import warning was produced. A fresh Codex-backed P1 structured review and a separate read-only adversarial owner-boundary review are clean.

Judged production delta: **+67 lines**, justified solely by the missing internal embedded execution seam and shared lazy owner boundary. Regression/integration tests: **+201 lines**. Documentation: **+1/-1 lines**. Risk is bounded to the existing documented TUI usage command; real Gateway, real embedded, selected global agent, stale success/error, missing local capability, footer/reset, and both-mode command metadata are covered.
