### PR TITLE
fix(release): dispatch validation by full SHA

### DIFF
--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -75,7 +75,7 @@ function usage() {
   console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--target-ref <canonical-release-branch-or-tag>] [--workflow-sha <trusted-main-ref>] [--keep-branch] [--dry-run] [-- -f key=value ...]
 
 Creates temporary remote branches pinned to the exact Tooling SHA and Validation SHA,
-dispatches Full Release Validation with the Validation SHA branch as its ref input
+dispatches Full Release Validation with the full Validation SHA as its ref input
 and expected_sha as its immutable identity,
 watches the parent run, verifies all child workflow head SHAs match the trusted
 workflow lineage through the release evidence manifest, then deletes both
@@ -674,7 +674,7 @@ function main() {
   const targetBranch = `validation/target-${targetSha.slice(0, 12)}-${Date.now()}`;
   const remoteTargetBranchRef = `refs/heads/${targetBranch}`;
   const dispatchInputs = {
-    ref: targetBranch,
+    ref: targetSha,
     expected_sha: targetSha,
     ...(targetContextRef !== targetSha ? { target_context_ref: targetContextRef } : {}),
     ...args.inputs,

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -515,7 +515,7 @@ describe("full-release-validation-at-sha", () => {
     ).toBe(false);
   });
 
-  it("pushes an exact target ref, dispatches it, prints the run URL, and cleans both refs", () => {
+  it("pushes the target transport ref, dispatches the candidate SHA, and cleans both refs", () => {
     const fixture = createDispatchFixture();
     try {
       const result = fixture.run(["--workflow-sha", fixture.workflowSha]);
@@ -563,7 +563,7 @@ describe("full-release-validation-at-sha", () => {
         dispatchInputs[assignment.slice(0, separatorIndex)] = assignment.slice(separatorIndex + 1);
       }
       expect(dispatchInputs).toMatchObject({
-        ref: targetBranch,
+        ref: fixture.targetSha,
         expected_sha: fixture.targetSha,
         target_context_ref: fixture.releaseRef,
         allow_unreleased_changelog: "false",


### PR DESCRIPTION
Related: #126622

## What Problem This Solves

Fixes an issue where release operators validating a frozen release candidate immediately fail Full Release Validation before any child workflows start. The stricter candidate-identity guard introduced by #126622 rejects the helper's temporary transport branch because release-context dispatches must identify the candidate by its full Validation SHA.

Affected runs:

- https://github.com/openclaw/openclaw/actions/runs/32369244651
- https://github.com/openclaw/openclaw/actions/runs/32369480105

## Why This Change Was Made

The release helper now dispatches the resolved full candidate SHA as the workflow `ref` input while retaining its temporary candidate branch strictly for Git object transport and reachability. The explicit Tooling SHA, `expected_sha`, canonical release context, branch/tag ancestry checks, evidence verification, temporary-ref cleanup, and workflow validation semantics are unchanged; the helper's usage text now describes the same contract.

## User Impact

Release operators can validate the intended frozen candidate without changing candidate code or weakening the release-isolation guard. Both temporary transport refs remain available throughout validation and are removed after verified success as before.

## Evidence

- Red/green regression: the existing end-to-end helper fixture failed against pre-fix code because `ref` was `validation/target-...` instead of the full candidate SHA; after the owner-boundary fix, it also verifies both transport refs are pushed and cleaned.
- `node scripts/run-vitest.mjs test/scripts/full-release-validation-at-sha.test.ts` — 22 passed.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts --testNamePattern 'direct Full Release Validation identity|exact-SHA helper target|exact-SHA release contexts|runs full release children from the trusted workflow ref'` — 14 passed; 193 unrelated cases skipped.
- `node scripts/check-changed.mjs -- scripts/full-release-validation-at-sha.mts test/scripts/full-release-validation-at-sha.test.ts` — all formatting, script/test typechecks, lint, script-erasability, dependency, and repository guard lanes passed.
- `node_modules/.bin/oxfmt --check scripts/full-release-validation-at-sha.mts test/scripts/full-release-validation-at-sha.test.ts` — passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/full-release-validation-at-sha.mts` — passed.
- `git diff --check` — passed.
- Global autoreview — clean; no accepted/actionable findings.
- Production/tooling: +2/-2 (net 0). Tests: +2/-2 (net 0).
- AI-assisted.
