### PR TITLE
fix(macos): keep elevation computer control active

### DIFF
--- a/apps/macos/Sources/OpenClaw/AppLaunchPresentationPolicy.swift
+++ b/apps/macos/Sources/OpenClaw/AppLaunchPresentationPolicy.swift
@@ -168,6 +168,18 @@ struct AppLaunchRuntimePlan: Equatable {
         self.mode == .elevationHost
     }
 
+    func resolvePaused(_ storedValue: Bool) -> Bool {
+        self.isElevationHost ? false : storedValue
+    }
+
+    func resolveComputerControlEnabled(_ storedValue: Bool) -> Bool {
+        self.isElevationHost || storedValue
+    }
+
+    func resolvePeekabooBridgeEnabled(_ storedValue: Bool) -> Bool {
+        self.isElevationHost || storedValue
+    }
+
     var allowsAutomaticPresentation: Bool {
         self.mode == .interactive
     }

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -493,7 +493,7 @@ final class AppState {
         self.execApprovalsReadRetryDelay = execApprovalsReadRetryDelay
         self.gatewayConfigSaver = gatewayConfigSaver
         let onboardingSeen = AppDefaults.standard.bool(forKey: onboardingSeenKey)
-        self.isPaused = AppDefaults.standard.bool(forKey: pauseDefaultsKey)
+        self.isPaused = AppLaunchRuntimePlan.current.resolvePaused(AppDefaults.standard.bool(forKey: pauseDefaultsKey))
         self.launchAtLogin = false
         self.onboardingSeen = onboardingSeen
         self.debugPaneEnabled = AppDefaults.standard.bool(forKey: debugPaneEnabledKey)
@@ -606,8 +606,8 @@ final class AppState {
         self.activeComputerPresenceEnabled = Self.resolveActiveComputerPresenceEnabled()
         self.execApprovalMode = .deny
         self.execApprovalPolicyLoadState = .loading
-        self.peekabooBridgeEnabled = AppDefaults.standard
-            .object(forKey: peekabooBridgeEnabledKey) as? Bool ?? true
+        self.peekabooBridgeEnabled = AppLaunchRuntimePlan.current.resolvePeekabooBridgeEnabled(
+            AppDefaults.standard.object(forKey: peekabooBridgeEnabledKey) as? Bool ?? true)
         if !self.isPreview, !AppProfile.current.isActive {
             Task.detached(priority: .utility) { [weak self] in
                 let current = await LaunchAgentManager.status()

--- a/apps/macos/Sources/OpenClaw/Constants.swift
+++ b/apps/macos/Sources/OpenClaw/Constants.swift
@@ -48,9 +48,13 @@ let cookieSyncEnabledKey = "openclaw.cookieSyncEnabled"
 let cookieSyncIntoProfileKey = "openclaw.cookieSyncIntoProfile"
 let cookieSyncDomainsKey = "openclaw.cookieSyncDomains"
 
-func isComputerControlEnabled(defaults: UserDefaults = AppDefaults.standard) -> Bool {
+func isComputerControlEnabled(
+    defaults: UserDefaults = AppDefaults.standard,
+    launchPlan: AppLaunchRuntimePlan = .current) -> Bool
+{
     // object(forKey:) preserves an explicit false; bool(forKey:) would conflate it with an unset default.
-    defaults.object(forKey: computerControlEnabledKey) as? Bool ?? true
+    let storedValue = defaults.object(forKey: computerControlEnabledKey) as? Bool ?? true
+    return launchPlan.resolveComputerControlEnabled(storedValue)
 }
 
 let activeComputerPresenceEnabledKey = "openclaw.activeComputerPresenceEnabled"

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -173,7 +173,8 @@ final class MacNodeModeCoordinator: NSObject {
         self.nodeHostWorkerRetryPolicy = nodeHostWorkerRetryPolicy
         self.refreshEvents = refreshEvents.stream
         self.refreshContinuation = refreshEvents.continuation
-        self.lastObservedPaused = initialPaused ?? AppDefaults.standard.bool(forKey: pauseDefaultsKey)
+        self.lastObservedPaused = initialPaused ?? AppLaunchRuntimePlan.current.resolvePaused(
+            AppDefaults.standard.bool(forKey: pauseDefaultsKey))
         self.lastObservedComputerControlEnabled = initialComputerControlEnabled ??
             isComputerControlEnabled()
         self.lastObservedComputerControlProvider = initialComputerControlProvider ??
@@ -297,7 +298,8 @@ final class MacNodeModeCoordinator: NSObject {
 
     func refresh() {
         self.refresh(
-            isPaused: AppDefaults.standard.bool(forKey: pauseDefaultsKey),
+            isPaused: AppLaunchRuntimePlan.current.resolvePaused(
+                AppDefaults.standard.bool(forKey: pauseDefaultsKey)),
             computerControlEnabled: isComputerControlEnabled(),
             computerControlProvider: ComputerControlProvider.current())
     }

--- a/apps/macos/Tests/OpenClawIPCTests/AppLaunchPresentationPolicyTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppLaunchPresentationPolicyTests.swift
@@ -126,6 +126,20 @@ struct AppLaunchRuntimePlanTests {
             hasVisibleWindows: true) == .accessory)
     }
 
+    @Test func `elevation host derives its mandatory computer control role in memory`() {
+        let interactive = AppLaunchRuntimePlan(arguments: ["OpenClaw"])
+        let elevation = AppLaunchRuntimePlan(arguments: ["OpenClaw", "--elevation-host"])
+
+        for storedValue in [false, true] {
+            #expect(interactive.resolvePaused(storedValue) == storedValue)
+            #expect(interactive.resolveComputerControlEnabled(storedValue) == storedValue)
+            #expect(interactive.resolvePeekabooBridgeEnabled(storedValue) == storedValue)
+        }
+        #expect(!elevation.resolvePaused(true))
+        #expect(elevation.resolveComputerControlEnabled(false))
+        #expect(elevation.resolvePeekabooBridgeEnabled(false))
+    }
+
     @Test func `attach-only does not change presentation behavior`() {
         let arguments = ["OpenClaw", "--attach-only", "--dashboard"]
         let policy = AppLaunchRuntimePlan(arguments: arguments)

--- a/apps/macos/Tests/OpenClawIPCTests/ComputerControlSettingsTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ComputerControlSettingsTests.swift
@@ -35,6 +35,8 @@ struct ComputerControlSettingsTests {
         let suiteName = "ComputerControlElevationHostTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
+        let interactivePlan = AppLaunchRuntimePlan(arguments: ["OpenClaw"])
+        let elevationPlan = AppLaunchRuntimePlan(arguments: ["OpenClaw", "--elevation-host"])
         defaults.set(true, forKey: computerControlEnabledKey)
         defaults.set(ComputerControlProvider.cua.rawValue, forKey: computerControlProviderKey)
 
@@ -42,11 +44,15 @@ struct ComputerControlSettingsTests {
         #expect(ComputerControlProvider.current(
             defaults: defaults,
             cuaAvailable: true,
-            launchPlan: AppLaunchRuntimePlan(arguments: ["OpenClaw"])) == .cua)
+            launchPlan: interactivePlan) == .cua)
         #expect(ComputerControlProvider.current(
             defaults: defaults,
             cuaAvailable: true,
-            launchPlan: AppLaunchRuntimePlan(arguments: ["OpenClaw", "--elevation-host"])) == .peekaboo)
+            launchPlan: elevationPlan) == .peekaboo)
+
+        defaults.set(false, forKey: computerControlEnabledKey)
+        #expect(!isComputerControlEnabled(defaults: defaults, launchPlan: interactivePlan))
+        #expect(isComputerControlEnabled(defaults: defaults, launchPlan: elevationPlan))
     }
 
     @Test func `bundled CUA locator accepts only a regular executable and never follows a symlink`() throws {


### PR DESCRIPTION
## What Problem This Solves

The managed `--elevation-host` launch selected Peekaboo but still inherited the ordinary GUI app's persisted paused, Computer Control off, and Peekaboo Bridge off preferences. A correctly signed elevation artifact could therefore fail Bridge/node readiness and roll back solely because of unrelated interactive settings.

## Why This Change Was Made

Makes `AppLaunchRuntimePlan` the owner of the three elevation-only runtime preference resolutions. Elevation launches derive an in-memory unpaused, Computer Control enabled, Peekaboo Bridge enabled state; interactive and ordinary background launches preserve the stored values exactly. The derived state is never written back to UserDefaults.

The prior portable migration/rollback stack is already present on `main` and was not replayed. This PR changes neither its authenticated artifact/receipt contract nor its native exclusive-rename and durability helpers.

## User Impact

The Foundation-signed unattended elevation host reliably starts its embedded Peekaboo 4.2.2 Bridge and advertises the expected computer-control node surface even when the normal app was previously paused or disabled. Ordinary OpenClaw launches keep the user's existing preferences unchanged.

## Evidence

- Old closeout audit: all nine files from the preserved 24-commit elevation stack are byte-identical to landed squash `b77671ced26f`; current `main` also contains the later CUA-free and signing hardening.
- `swift test --package-path apps/macos --filter 'AppLaunchPresentationPolicyTests|ComputerControlSettingsTests'`: 15 tests passed.
- `pnpm check:changed`: all selected app, dependency, Swift lint, packaging, signing, elevation, and native-state gates passed.
- `swift build --package-path apps/macos --configuration release`: passed on the rebased head.
- SwiftFormat and SwiftLint: clean, zero serious findings.
- Codex Autoreview on the rebased branch: clean at 0.98, no accepted or actionable findings.

AI-assisted: yes. I reviewed the full elevation launch, Bridge host, macOS node, portable installer, recovery, and signing owner paths and verified the focused native behavior.
