### PR TITLE
fix(ui): refresh mixed-role node status

### DIFF
--- a/ui/src/pages/devices/devices-page.test.ts
+++ b/ui/src/pages/devices/devices-page.test.ts
@@ -439,6 +439,167 @@ describe("DevicesPage gateway lifecycle", () => {
     page.remove();
   });
 
+  it.each([
+    {
+      name: "node disconnects while its operator stays connected",
+      role: "node",
+      previousReason: "connect",
+      nextReason: "disconnect",
+      operatorRoles: ["operator"],
+    },
+    {
+      name: "node reconnects while its operator stays connected",
+      role: "node",
+      previousReason: "disconnect",
+      nextReason: "connect",
+      operatorRoles: ["operator"],
+    },
+    {
+      name: "merged node-role presence disconnects while its operator stays connected",
+      role: "node",
+      previousReason: "connect",
+      nextReason: "disconnect",
+      nodeRoles: ["operator", "node"],
+      operatorRoles: ["operator"],
+    },
+    {
+      name: "operator disconnects while its node stays connected",
+      role: "operator",
+      previousReason: "connect",
+      nextReason: "disconnect",
+      operatorRoles: ["operator"],
+    },
+    {
+      name: "operator reconnects while its node stays connected",
+      role: "operator",
+      previousReason: "disconnect",
+      nextReason: "connect",
+      operatorRoles: ["operator"],
+    },
+    {
+      name: "node disconnects while a roleless device stays connected",
+      role: "node",
+      previousReason: "connect",
+      nextReason: "disconnect",
+      operatorRoles: undefined,
+    },
+    {
+      name: "node disconnects while a device with empty roles stays connected",
+      role: "node",
+      previousReason: "connect",
+      nextReason: "disconnect",
+      operatorRoles: [],
+    },
+  ])("reloads mixed-role inventory when $name", async (scenario) => {
+    const request = vi.fn(async (method: string) =>
+      method === "node.list" ? { nodes: [] } : { paired: [], pending: [] },
+    );
+    const client = { request } as unknown as GatewayBrowserClient;
+    const snapshot = {
+      ...gatewaySnapshot(client, true),
+      hello: {
+        type: "hello-ok",
+        protocol: 1,
+        auth: { role: "operator", scopes: ["operator.read", "operator.pairing"] },
+        features: { methods: ["node.list", "device.pair.list"] },
+      },
+    } as ApplicationGatewaySnapshot;
+    let onEvent: ((event: { event: string; payload?: unknown }) => void) | undefined;
+    const currentGateway = gateway(client, snapshot);
+    currentGateway.subscribeEvents = vi.fn((listener) => {
+      onEvent = listener as typeof onEvent;
+      return () => undefined;
+    });
+    const page = document.createElement("openclaw-devices-page") as TestDevicesPage;
+    page.context = {
+      gateway: currentGateway,
+      runtimeConfig: {
+        state: { configSnapshot: {}, configLoading: false },
+        subscribe: vi.fn(() => () => undefined),
+      },
+    } as unknown as ApplicationContext;
+    document.body.append(page);
+    await vi.waitFor(() => expect(onEvent).toBeDefined());
+
+    const nodePresence: PresenceEntry = {
+      deviceId: "mixed-role-device",
+      instanceId: "mixed-role-device",
+      roles: "nodeRoles" in scenario ? scenario.nodeRoles : ["node"],
+      reason: scenario.role === "node" ? scenario.previousReason : "connect",
+      ts: 2_000,
+    };
+    const operatorPresence: PresenceEntry = {
+      deviceId: "mixed-role-device",
+      instanceId: "operator-session",
+      ...(scenario.operatorRoles ? { roles: scenario.operatorRoles } : {}),
+      reason: scenario.role === "operator" ? scenario.previousReason : "connect",
+      ts: 1_000,
+    };
+    page.presence = [nodePresence, operatorPresence];
+    request.mockClear();
+
+    onEvent?.({
+      event: "presence",
+      payload: {
+        presence: [
+          scenario.role === "node"
+            ? { ...nodePresence, reason: scenario.nextReason }
+            : nodePresence,
+          scenario.role === "operator"
+            ? { ...operatorPresence, reason: scenario.nextReason }
+            : operatorPresence,
+        ],
+      },
+    });
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledWith("node.list", {}));
+    expect(request).toHaveBeenCalledWith("device.pair.list", {});
+    page.remove();
+  });
+
+  it("does not reload mixed-role inventory for presence activity updates", async () => {
+    const request = vi.fn(async (method: string) =>
+      method === "node.list" ? { nodes: [] } : { paired: [], pending: [] },
+    );
+    const client = { request } as unknown as GatewayBrowserClient;
+    let onEvent: ((event: { event: string; payload?: unknown }) => void) | undefined;
+    const currentGateway = gateway(client, gatewaySnapshot(client, true));
+    currentGateway.subscribeEvents = vi.fn((listener) => {
+      onEvent = listener as typeof onEvent;
+      return () => undefined;
+    });
+    const page = document.createElement("openclaw-devices-page") as TestDevicesPage;
+    page.context = {
+      gateway: currentGateway,
+      runtimeConfig: {
+        state: { configSnapshot: {}, configLoading: false },
+        subscribe: vi.fn(() => () => undefined),
+      },
+    } as unknown as ApplicationContext;
+    document.body.append(page);
+    await vi.waitFor(() => expect(onEvent).toBeDefined());
+
+    const presence: PresenceEntry[] = [
+      { deviceId: "mixed-role-device", roles: ["node"], reason: "connect", ts: 2_000 },
+      { deviceId: "mixed-role-device", roles: ["operator"], reason: "connect", ts: 1_000 },
+    ];
+    page.presence = presence;
+    request.mockClear();
+
+    onEvent?.({
+      event: "presence",
+      payload: {
+        presence: presence.map((entry) =>
+          Object.assign({}, entry, { lastInputSeconds: 3, ts: entry.ts + 100 }),
+        ),
+      },
+    });
+    await Promise.resolve();
+
+    expect(request).not.toHaveBeenCalled();
+    page.remove();
+  });
+
   it("retries a node load after a same-client disconnect", async () => {
     const first = deferred<{ nodes: Array<Record<string, unknown>> }>();
     const second = deferred<{ nodes: Array<Record<string, unknown>> }>();

--- a/ui/src/pages/devices/devices-page.ts
+++ b/ui/src/pages/devices/devices-page.ts
@@ -75,7 +75,8 @@ function presenceConnectivitySignature(entries: PresenceEntry[]): string {
     if (!id || entry.mode?.trim().toLowerCase() === "gateway") {
       continue;
     }
-    states.set(id, entry.reason?.trim().toLowerCase() === "disconnect" ? "offline" : "connected");
+    const key = entry.roles?.includes("node") ? `${id}:node` : id;
+    states.set(key, entry.reason?.trim().toLowerCase() === "disconnect" ? "offline" : "connected");
   }
   return JSON.stringify([...states].toSorted(([left], [right]) => left.localeCompare(right)));
 }


### PR DESCRIPTION
Closes #126675

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators viewing Settings → Devices would see a mixed-role Windows node remain online and miss its manual-wake warning when the node session disconnects while an operator session on the same device remains connected.

## Why This Change Was Made

The Gateway intentionally maintains separate node and operator presence rows, while device pairing reports whether any role is connected and node inventory reports whether its node runtime is connected. The Devices page collapsed both presence rows into one device-only connectivity signature, so an unchanged connected operator masked the node disconnect. Distinguishing node-role presence inside the existing UI-owned signature restores the existing coalesced inventory refresh without changing Gateway behavior, protocol, configuration, persistence, security, product policy, polling, or the renderer.

## User Impact

Node disconnects and reconnects immediately update the Devices inventory. A disconnected Windows node now shows **offline** and **manual wake required** even when another connection keeps its paired device connected; ordinary presence timestamps and activity updates still do not cause unnecessary requests.

## Evidence

Real source-mode Control UI + real isolated loopback development Gateway + clean-profile Chromium, with only synthetic device identities:

- Before: the genuine node disconnect event reached the browser, the Gateway returned `node.list.connected=false` and `device.pair.list.connected=true`, but browser `node.list` requests stayed at **1 → 1** and the offline/manual-wake badges were absent.
- After: the same producer-side disconnect immediately changed browser `node.list` requests to **1 → 2** and displayed both **offline** and **manual wake required** while aggregate device connectivity remained connected.
- Screenshots were inspected for personal data, tokens, network addresses, real hosts, and real devices before upload.

### Before

![Before: the synthetic Windows node remains visually online after its node session disconnects](https://github.com/user-attachments/assets/73e43667-cffd-4a6b-b8bb-1b6e381c098b)

### After

![After: the synthetic Windows node immediately shows offline and manual wake required](https://github.com/user-attachments/assets/e1313014-d515-4da3-b0ba-a915153bd9e9)

Focused tests, including the existing mixed-role offline/manual-wake renderer and inventory contracts:

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/autoqa-164/vitest-cache node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/pages/devices/devices-page.test.ts ui/src/pages/devices/view.devices.test.ts ui/src/lib/nodes/inventory.test.ts
```

Result: **75 passing tests**, covering node/operator disconnect and reconnect, missing/empty/merged role arrays, activity-only suppression, existing refresh coalescing, and mixed-role Windows rendering.

```bash
node scripts/check-changed.mjs -- ui/src/pages/devices/devices-page.ts ui/src/pages/devices/devices-page.test.ts
OPENCLAW_BUILD_ALL_NO_PNPM=1 node scripts/ui.js build --configLoader runner
git diff --check
```

The changed gate covers formatting, UI/core-test typechecks, targeted lint, i18n, and repository ownership guards. The UI build also verifies compressed sidecars and performance budgets. Fresh Codex-backed P1 autoreview and a separate independent adversarial review reported no actionable findings.

Production LOC: **+2/-1 (net +1)**. Tests: **+161/-0**. Risk: low; UI-owned presence invalidation only. Follow-up outside this focused repair: inspect the separate New Session placement presence signature for the same mixed-role collision.

AI-assisted: yes
