### PR TITLE
fix(memory): keep expected owner gating quiet

### DIFF
--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -337,6 +337,13 @@ describe("memory-core plugin runtime registration", () => {
 
     expect(intentFactory({ config: {}, senderIsOwner: false })).toBeNull();
     expect(intentFactory({ config: {} })).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+
+    expect(intentFactory({ senderIsOwner: true })).toBeNull();
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      "memory-core: intent tool unavailable: runtime config is unavailable for this turn",
+    );
+
     const ownerTool = intentFactory({ config: {}, senderIsOwner: true }) as {
       name?: string;
       parameters?: {
@@ -346,8 +353,7 @@ describe("memory-core plugin runtime registration", () => {
     expect(ownerTool).toMatchObject({ name: "intent" });
     expect(ownerTool.parameters?.properties?.scope?.default).toBe("channel");
     expect(ownerTool.parameters?.properties?.senderScope?.default).toBe("sender");
-    expect(warn).toHaveBeenCalledTimes(2);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("owner authorization"));
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it("keeps memory manager initialization demand-driven", () => {

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -99,7 +99,6 @@ function createLazyStandingIntentTool(
   reportUnavailable: (reason: string) => void,
 ): AnyAgentTool | null {
   if (ctx.senderIsOwner !== true) {
-    reportUnavailable("owner authorization is unavailable for this turn");
     return null;
   }
   const cfg = ctx.getRuntimeConfig?.() ?? ctx.runtimeConfig ?? ctx.config;


### PR DESCRIPTION
Closes #126678

## What Problem This Solves

Fixes an issue where gateways with non-owner turns logged expected omission of the owner-only memory `intent` tool as a plugin-unavailable warning every time the tool catalog was built.

## Why This Change Was Made

The strict owner gate remains unchanged and still returns no tool without affirmative owner evidence. The plugin now reports only genuine construction failures, such as an authorized turn lacking runtime configuration, matching the generic plugin runtime's normal handling of context-gated null tool factories.

## User Impact

Operators no longer receive warning floods for correct authorization behavior, so real memory-plugin failures remain visible. Non-owner users gain no tool or capability, and owner behavior is unchanged.

## Evidence

- Production log evidence: 283 copies across the bounded two-day team Gateway corpus; eight more shortly after a fresh restart.
- Pre-fix owner-boundary regression required two warnings for false and missing owner evidence.
- Post-fix owner test proves false/missing ownership returns `null` with no warning; an owner lacking runtime config returns `null` and emits exactly the runtime-config warning; a configured owner still receives the `intent` tool and existing defaults.
- Focused owner suite: 28/28 passed.
- Complete memory extension lane: 1,151 passed, 3 skipped across 89 passing files and one skipped file.
- Changed-file gate passed: format, extension/test typecheck, extension lint, plugin boundaries, dead exports, import cycles, and repository guards.
- Fresh rebased Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +0/-1. Tests: +8/-2.
- No authorization, prompt schema, API, config, protocol, storage, external provider, or UI change is involved.

AI-assisted: implementation and review used Codex, with maintainer inspection of the complete tool registration, owner gate, plugin null-factory handling, tests, and production logs.
