### PR TITLE
fix(scripts): avoid temp guardrail git buffer overflow

### DIFF
--- a/scripts/check-temp-path-guardrails.ts
+++ b/scripts/check-temp-path-guardrails.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import pMap, { pMapSkip } from "p-map";
-
 import { listRepoFilesSync } from "./check-file-utils.js";
 
 type QuoteChar = "'" | '"' | "`";

--- a/scripts/check-temp-path-guardrails.ts
+++ b/scripts/check-temp-path-guardrails.ts
@@ -1,8 +1,9 @@
 // Check Temp Path Guardrails script supports OpenClaw repository automation.
-import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import pMap, { pMapSkip } from "p-map";
+
+import { listRepoFilesSync } from "./check-file-utils.js";
 
 type QuoteChar = "'" | '"' | "`";
 
@@ -210,16 +211,12 @@ function hasDynamicTmpdirJoin(source: string): boolean {
 }
 
 function listTrackedRuntimeSourceFiles(repoRoot: string): string[] {
-  const stdout = execFileSync("git", ["-C", repoRoot, "ls-files", "--", "src", "extensions"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "inherit"],
-  });
-  return stdout
-    .split(/\r?\n/u)
-    .filter(Boolean)
-    .filter((relativePath) => relativePath.endsWith(".ts") || relativePath.endsWith(".tsx"))
-    .filter((relativePath) => !shouldSkipGuardrailRuntimeSource(relativePath))
-    .map((relativePath) => path.join(repoRoot, relativePath));
+  return listRepoFilesSync(repoRoot, {
+    roots: ["src", "extensions"],
+    includeFile: (relativePath) =>
+      (relativePath.endsWith(".ts") || relativePath.endsWith(".tsx")) &&
+      !shouldSkipGuardrailRuntimeSource(relativePath),
+  }).map((relativePath) => path.join(repoRoot, relativePath));
 }
 
 async function readRuntimeSourceFiles(


### PR DESCRIPTION
## Summary

- route the temp-path guardrail's tracked-file scan through the existing repository scanner
- inherit its bounded 64 MiB Git capture and filesystem fallback instead of Node's 1 MiB `execFileSync` default
- remove the duplicate raw `git ls-files` subprocess path

## Root cause

`check:temp-path-guardrails` captured the complete `src` + `extensions` tracked-file list with the default Node child-process buffer. Current `main` emits 1,054,843 bytes, exceeding the 1 MiB default and crashing npm preflight with `ENOBUFS` before the guardrail could inspect any files. The owning shared scanner in `scripts/check-file-utils.ts` already handles repository-scale tracked lists with a bounded 64 MiB capture.

## Validation

- pre-fix release evidence: npm preflight run 32375572018 fails in `check:temp-path-guardrails` with `spawnSync git ENOBUFS`
- `git ls-files -- src extensions | wc -c` => `1054843`
- `git diff --check`
- local runtime execution unavailable on this host because Node/pnpm are absent; exact-head CI is the runtime proof path
- autoreview attempted; blocked before model review because TruffleHog is not installed on this host

## Repair closeout

- architectural owner: shared repository file scanner (`scripts/check-file-utils.ts`)
- canonical fix: reuse `listRepoFilesSync`; no new subprocess wrapper or fallback
- removed path: duplicate raw `execFileSync("git", ...)`
- production LOC delta: +8 / -11 (net -3)
- sibling coverage: existing script inventories already consume the same shared scanner
