### PR TITLE
fix(sessions): avoid startup stalls with many empty agent stores

### DIFF
--- a/src/infra/state-migrations.orphan-keys.test.ts
+++ b/src/infra/state-migrations.orphan-keys.test.ts
@@ -727,6 +727,29 @@ describe("migrateOrphanedSessionKeys", () => {
     });
   });
 
+  it("checks missing agent stores without comparing every earlier path", async () => {
+    await withStateFixture(async ({ tmpDir, stateDir }) => {
+      const agentCount = 100;
+      const cfg = {
+        session: { store: path.join(tmpDir, "stores", "{agentId}", "sessions.json") },
+        agents: {
+          list: Array.from({ length: agentCount }, (_, index) => ({ id: `agent-${index}` })),
+        },
+      } as OpenClawConfig;
+      const statSpy = vi.spyOn(fs, "statSync");
+
+      try {
+        expect(await migrateFixtureState(stateDir, cfg)).toEqual({ changes: [], warnings: [] });
+        const storeProbes = statSpy.mock.calls.filter(([candidate]) =>
+          candidate.toString().endsWith("sessions.json"),
+        );
+        expect(storeProbes).toHaveLength(agentCount);
+      } finally {
+        statSpy.mockRestore();
+      }
+    });
+  });
+
   it("does not prepare channel migration surfaces without a legacy store", async () => {
     await withStateFixture(async ({ stateDir }) => {
       const prepareLegacySessionSurfaces = vi.fn(() => EMPTY_LEGACY_SESSION_SURFACES);

--- a/src/infra/state-migrations.session-store.ts
+++ b/src/infra/state-migrations.session-store.ts
@@ -630,12 +630,17 @@ export async function migrateOrphanedSessionKeys(params: {
     });
   const pluginAgentIdSet = new Set(pluginAgentIds.map((id) => normalizeAgentId(id)));
 
-  // Collect all known agent store paths with their owning agentIds.
-  // A single path may be shared by multiple agents when session.store
-  // does not contain {agentId}.
+  // Fixed session.store paths can be shared by several agent owners.
   const storeMap = new Map<string, Set<string>>();
   const storeAliasCandidates = new Map<string, Set<string>>();
   const addToStoreMap = (p: string, id: string) => {
+    try {
+      if (!fs.statSync(p, { throwIfNoEntry: false })?.isFile()) {
+        return;
+      }
+    } catch {
+      // Inaccessible paths must stay in their fail-closed alias group.
+    }
     // A fixed-store owner is durable migration provenance. Keep other configured
     // agents from making that store's unscoped rows look ambiguous.
     const ownerId =
@@ -649,12 +654,7 @@ export async function migrateOrphanedSessionKeys(params: {
     const aliasCandidates = storeAliasCandidates.get(storePath) ?? new Set([storePath]);
     aliasCandidates.add(p);
     storeAliasCandidates.set(storePath, aliasCandidates);
-    const existing = storeMap.get(storePath);
-    if (existing) {
-      existing.add(ownerId);
-    } else {
-      storeMap.set(storePath, new Set([ownerId]));
-    }
+    storeMap.set(storePath, (storeMap.get(storePath) ?? new Set<string>()).add(ownerId));
   };
   // Configured ownership includes normal agents plus ACP runtime/default hints.
   for (const configuredAgentId of listConfiguredSessionStoreAgentIds(params.cfg)) {


### PR DESCRIPTION
Closes #126676.

## What Problem This Solves

Gateway session migration performs quadratic filesystem alias detection when many configured agents have no existing session stores. A 500-agent state previously performed 124,750 filesystem probes and stalled the migration owner for approximately 5.5 seconds; larger deployments scale significantly worse.

## Why This Change Was Made

Check whether each candidate session-store path actually exists before adding it to physical-path alias grouping. Definitely absent paths are skipped immediately, while existing files and inaccessible paths preserve the original conservative, fail-closed alias ownership and warning behavior. Reuse the existing owner map to keep the production change net-neutral.

Production LOC: +9/-9 (net 0). Regression tests: +23.

## User Impact

Session-store migration now scales linearly with absent per-agent stores. Existing aliases, shared stores, symlinks, hardlinks, inaccessible paths, and migration idempotence retain their previous behavior.

## Evidence

- Before repair: the real production migration owner performs 4,950 probes for 100 agents, 31,125 for 250 agents, and 124,750 for 500 agents; the focused 100-agent linear-bound regression fails.
- After repair: the same actual production migration owner performs exactly one filesystem probe per configured agent, including a 10,000-agent isolated run; the complete inspectable command and actual stdout appear below.
- All 46 focused migration and startup sibling tests pass, including inaccessible-path fail-closed behavior, readable aliases, symlinks, hardlinks, shared-owner stores, and idempotence.
- Full trusted production build passes.
- Complete local changed gate passes all 27 guards without skips, including production/test typechecking, lint, formatting, dead-code checks, unchanged SQLite schema baseline, database-first rules, and import cycles.
- Fresh structured autoreview: clean; independent reviewer approved the exact owner repair and failure semantics.
- Whole-Gateway 10,000-agent before/after timing is not claimed: unrelated configuration/bootstrap overhead occurs before the migration owner, so the measured results below invoke the actual production migration owner with actual configured agent lists and isolated missing state.
- Exact reviewed head: `509eb2c53f055f75eb1fdeb6cff92de374b4f60d`.
- Original contributor attribution is preserved as `Co-authored-by: goutamadwant <workwithgoutam@gmail.com>`.

### Inspectable real production-owner terminal proof

```bash
node --import tsx --input-type=module -e 'import fs from "node:fs"; import os from "node:os"; import path from "node:path"; import { performance } from "node:perf_hooks"; import { migrateOrphanedSessionKeys } from "./src/infra/state-migrations.session-store.ts"; import { EMPTY_LEGACY_SESSION_SURFACES } from "./src/plugins/legacy-session-surfaces.types.ts"; for (const agents of [100,250,500,10000]) { const state=fs.mkdtempSync(path.join(os.tmpdir(),"openclaw-session-proof-")); const stat=fs.statSync; let probes=0; fs.statSync=function(candidate,...args){ if(String(candidate).endsWith("sessions.json"))probes++; return stat.call(fs,candidate,...args) }; const started=performance.now(); try { const result=await migrateOrphanedSessionKeys({cfg:{session:{store:path.join(state,"stores","{agentId}","sessions.json")},agents:{list:Array.from({length:agents},(_,index)=>({id:`agent-${index}`}))}},env:{OPENCLAW_STATE_DIR:state},additionalAgentIds:[],legacySessionSurfaces:EMPTY_LEGACY_SESSION_SURFACES}); console.log(JSON.stringify({agents,sessionStoreStatProbes:probes,durationMs:Math.round(performance.now()-started),changes:result.changes.length,warnings:result.warnings.length})); } finally {fs.statSync=stat;fs.rmSync(state,{recursive:true,force:true})} }'
{"agents":100,"sessionStoreStatProbes":100,"durationMs":1,"changes":0,"warnings":0}
{"agents":250,"sessionStoreStatProbes":250,"durationMs":1,"changes":0,"warnings":0}
{"agents":500,"sessionStoreStatProbes":500,"durationMs":1,"changes":0,"warnings":0}
{"agents":10000,"sessionStoreStatProbes":10000,"durationMs":26,"changes":0,"warnings":0}
```

This is real production migration-owner execution against genuine configured agent lists and isolated temporary filesystem state. It is not a full Gateway startup measurement and does not require or expose provider credentials.


Disclosure: AI was used to understand the codebase and review the fix.
