### PR TITLE
fix(onboard): infer gateway password authentication

### DIFF
--- a/src/commands/onboard-non-interactive/local/gateway-config.test.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.test.ts
@@ -121,6 +121,34 @@ describe("applyNonInteractiveGatewayConfig auth resolution", () => {
     expect(result?.nextConfig.gateway?.auth).toEqual({ mode: "token", token: "flag-token" });
   });
 
+  it.each([
+    { name: "a fresh gateway", nextConfig: {} },
+    { name: "an existing plaintext token", nextConfig: createTokenConfig("existing-user-token") },
+    { name: "an existing token SecretRef", nextConfig: createTokenConfig(SAMPLE_SECRET_REF) },
+  ])("selects password auth when --gateway-password overrides $name", ({ nextConfig }) => {
+    const result = applyGatewayConfig({
+      nextConfig,
+      opts: { gatewayPassword: "explicit-password" } as OnboardOptions,
+    });
+
+    expect(result?.nextConfig.gateway?.auth).toMatchObject({
+      mode: "password",
+      password: "explicit-password",
+    });
+    expect(randomToken).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "an explicit auth mode", opts: { gatewayAuth: "token" as const } },
+    { name: "an explicit token credential", opts: { gatewayToken: "flag-token" } },
+  ])("keeps $name authoritative over --gateway-password", ({ opts }) => {
+    const result = applyGatewayConfig({
+      opts: { ...opts, gatewayPassword: "explicit-password" } as OnboardOptions,
+    });
+
+    expect(result?.nextConfig.gateway?.auth?.mode).toBe("token");
+  });
+
   it("keeps password auth when a token-only rerun targets an existing Funnel", () => {
     const result = applyGatewayConfig({
       nextConfig: {

--- a/src/commands/onboard-non-interactive/local/gateway-config.ts
+++ b/src/commands/onboard-non-interactive/local/gateway-config.ts
@@ -56,7 +56,11 @@ export function applyNonInteractiveGatewayConfig(params: {
     opts.gatewayToken !== undefined || opts.gatewayTokenRefEnv !== undefined;
   let authMode =
     explicitAuthMode ??
-    (hasExplicitTokenAuthInput ? "token" : existingGateway?.auth?.mode) ??
+    (hasExplicitTokenAuthInput
+      ? "token"
+      : opts.gatewayPassword !== undefined
+        ? "password"
+        : existingGateway?.auth?.mode) ??
     "token";
   const tailscaleMode = opts.tailscale ?? existingGateway?.tailscale?.mode ?? "off";
 


### PR DESCRIPTION
## What Problem This Solves

Noninteractive `openclaw onboard --gateway-password <password>` silently discarded the explicitly supplied password, configured token authentication, and still exited successfully. The same bug affected `openclaw setup` and reruns against gateways already configured with either plaintext or SecretRef-backed token authentication.

## Root Cause

The noninteractive local Gateway configuration owner inferred token mode from explicit token credentials but never inferred password mode from an explicit password. Its interactive sibling already implemented the correct precedence: explicit auth mode, explicit token credential, explicit password, existing auth mode, then the default token mode.

## Fix

Mirror that established precedence directly in the noninteractive Gateway configuration owner. Preserve explicit token/auth-mode precedence, existing Tailscale/Funnel behavior, token SecretRefs, and the public `onboard` / `setup` entrypoints.

## Evidence

- Real isolated CLI before: `onboard --non-interactive --accept-risk --auth-choice skip --gateway-password <fixture> --no-install-daemon --skip-health --json` exited successfully with token auth and no persisted password; `setup` against an existing token-auth configuration reproduced the same silent loss.
- Real isolated CLI after projecting the exact repaired current-source owner expression into the installed launcher: fresh password onboarding selects `password`; rerunning `setup` against existing token auth selects `password`; simultaneous explicit token and password preserves token precedence.
- Actual dispatch-owner assertion fails on the original expression and passes after the repair, matching the existing interactive Gateway configuration sibling.
- Existing owner-boundary regression coverage now exercises fresh gateways, existing plaintext tokens, existing SecretRefs, explicit auth modes, and explicit token credentials.
- Targeted formatter/linter checks pass and independent Codex autoreview reports no actionable findings.
- The linked checkout intentionally has no physical `node_modules`; exact-head hosted CI runs the new regression matrix.
