### PR TITLE
fix(agents): construct exact screen allowlists

### DIFF
--- a/src/agents/core-tool-factory-descriptors.ts
+++ b/src/agents/core-tool-factory-descriptors.ts
@@ -28,6 +28,7 @@ const CORE_TOOL_FACTORY_DESCRIPTORS = [
   { name: "conversations_send", family: "openclaw" },
   { name: "conversations_turn", family: "openclaw" },
   { name: AUTOMATIONS_TOOL_NAME, family: "openclaw" },
+  { name: "screen", family: "openclaw" },
   { name: "dashboard", family: "openclaw" },
   { name: "gateway", family: "openclaw" },
   { name: "get_goal", family: "openclaw" },

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -380,7 +380,7 @@ describe("resolveEmbeddedAttemptToolConstructionPlan", () => {
         },
       },
     );
-    for (const toolName of ["suggest_task", "dismiss_task"]) {
+    for (const toolName of ["suggest_task", "dismiss_task", "screen"]) {
       expectConstructionPlan(
         resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: [toolName] }),
         {


### PR DESCRIPTION
Closes #126682

## What Problem This Solves

Fixes an issue where an exact `screen` tool allowlist silently omitted the shipped screen capability, even when the originating client advertised UI-command support.

## Why This Change Was Made

`screen` now carries the same static OpenClaw factory identity as the other core UI tools. This selects the existing owning factory during narrow construction while leaving the runtime `ui-commands` capability gate fully authoritative. No fallback or widened capability path was added.

## User Impact

Operators can use an exact `tools.allow: ["screen"]` policy without accidentally removing the tool from capable sessions. Unsupported clients still do not receive it.

## Evidence

- Pre-fix construction plan: `includeCoreTools=false`, `includeOpenClawTools=false`, and plugin/channel factories enabled for the canonical `screen` name.
- History: the centralized descriptor registry landed before `screen`; the later screen feature added catalog, factory, and capability coverage but omitted this identity.
- Post-fix focused owner proof: 26 construction-plan tests, 60 OpenClaw tool-registration tests, and 5 tool-catalog tests passed.
- Changed-file gate passed: format, core/test typecheck, core lint, plugin boundaries, dead exports, import cycles, schema and repository guards.
- A broad `test:changed` expansion passed 12,535 tests before four unrelated contention-sensitive cases failed under whole-core load; all four exact cases passed together on rerun and are tracked as separate follow-ups.
- Fresh rebased Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +1. Test LOC: one table-driven case entry modified, net zero.
- No protocol, config schema, authorization, persistence, dependency, or UI layout change is involved. No visual evidence is applicable.

AI-assisted: implementation and review used Codex, with maintainer inspection of the factory planner, core catalog, runtime capability gate, tool assembly, history, and tests.
