### PR TITLE
fix(outbound): preserve selected plugin for target resolution

### DIFF
--- a/src/infra/outbound/message-action-routing.ts
+++ b/src/infra/outbound/message-action-routing.ts
@@ -162,6 +162,7 @@ function resolveTargetBoundAccountId(params: {
 async function resolveActionTarget(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
+  channelPlugin?: ChannelPlugin;
   action: ChannelMessageActionName;
   args: Record<string, unknown>;
   accountId?: string | null;
@@ -174,6 +175,7 @@ async function resolveActionTarget(params: {
       channel: params.channel,
       input: toRaw,
       accountId: params.accountId ?? undefined,
+      plugin: params.channelPlugin,
     });
     params.args.to = resolved.to;
     resolvedTarget = resolved;
@@ -185,6 +187,7 @@ async function resolveActionTarget(params: {
       channel: params.channel,
       input: channelIdRaw,
       accountId: params.accountId ?? undefined,
+      plugin: params.channelPlugin,
       preferredKind: "group",
       validateResolvedTarget: (target) =>
         target.kind === "user"
@@ -205,6 +208,7 @@ async function resolveResolvedTargetOrThrow(params: {
   channel: ChannelId;
   input: string;
   accountId?: string;
+  plugin?: ChannelPlugin;
   preferredKind?: "group" | "user" | "channel";
   validateResolvedTarget?: (target: ResolvedMessagingTarget) => string | undefined;
 }): Promise<ResolvedMessagingTarget> {
@@ -213,6 +217,7 @@ async function resolveResolvedTargetOrThrow(params: {
     channel: params.channel,
     input: params.input,
     accountId: params.accountId,
+    plugin: params.plugin,
     preferredKind: params.preferredKind,
   });
   if (!resolved.ok) {
@@ -451,6 +456,7 @@ export async function prepareMessageRoute(params: {
 export async function resolveMessageTarget(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;
+  channelPlugin?: ChannelPlugin;
   action: ChannelMessageActionName;
   args: Record<string, unknown>;
   accountId?: string | null;
@@ -463,6 +469,7 @@ export async function resolveMessageTarget(params: {
     : await resolveActionTarget({
         cfg: params.cfg,
         channel: params.channel,
+        channelPlugin: params.channelPlugin,
         action: params.action,
         args: params.args,
         accountId: params.accountId,

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -48,6 +48,54 @@ describe("runMessageAction plugin dispatch", () => {
       handleAction.mockClear();
     });
 
+    it("uses the selected operation-local plugin for target resolution", async () => {
+      const resolveTarget = vi.fn(async ({ input }: { input: string }) => ({
+        to: `user:${input}`,
+        kind: "user" as const,
+      }));
+      const handleScopedAction = vi.fn(async () => jsonResult({ ok: true }));
+      const scopedPlugin = createGatewayActionPlugin({
+        pluginId: "operation-local",
+        label: "Operation Local",
+        blurb: "Operation-local target resolution test plugin.",
+        actions: ["react"],
+        gatewayActions: [],
+        messaging: {
+          targetResolver: {
+            looksLikeId: () => true,
+            resolveTarget,
+          },
+        },
+        handleAction: handleScopedAction,
+      });
+
+      setActivePluginRegistry(createTestRegistry([]));
+      mocks.resolveOutboundChannelPlugin.mockReturnValue(scopedPlugin);
+      const result = await runMessageAction({
+        cfg: {
+          channels: {
+            "operation-local": {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        action: "react",
+        params: {
+          channel: "operation-local",
+          target: "plugin-alias",
+          messageId: "message-1",
+          emoji: "eyes",
+        },
+        dryRun: true,
+      });
+
+      expect(result).toMatchObject({ kind: "action", action: "react", handledBy: "dry-run" });
+      expect(resolveTarget).toHaveBeenCalledWith(
+        expect.objectContaining({ input: "plugin-alias", normalized: "plugin-alias" }),
+      );
+      expect(handleScopedAction).not.toHaveBeenCalled();
+    });
+
     afterEach(() => {
       setActivePluginRegistry(createTestRegistry([]));
       vi.clearAllMocks();

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -96,6 +96,69 @@ describe("runMessageAction plugin dispatch", () => {
       expect(handleScopedAction).not.toHaveBeenCalled();
     });
 
+    it("uses the selected operation-local plugin for broadcast target resolution", async () => {
+      const resolveTarget = vi.fn(async ({ input }: { input: string }) => ({
+        to: `user:${input}`,
+        kind: "user" as const,
+      }));
+      const handleScopedAction = vi.fn(async () => jsonResult({ ok: true }));
+      const scopedPlugin = createGatewayActionPlugin({
+        pluginId: "operation-local",
+        label: "Operation Local",
+        blurb: "Operation-local broadcast target resolution test plugin.",
+        actions: ["send"],
+        gatewayActions: [],
+        messaging: {
+          targetResolver: {
+            looksLikeId: () => true,
+            resolveTarget,
+          },
+        },
+        handleAction: handleScopedAction,
+      });
+
+      setActivePluginRegistry(createTestRegistry([]));
+      mocks.resolveOutboundChannelPlugin.mockReturnValue(scopedPlugin);
+      mocks.executeSendAction.mockResolvedValue({
+        handledBy: "core",
+        payload: { ok: true },
+        sendResult: {
+          channel: "operation-local",
+          to: "user:plugin-alias",
+          via: "direct",
+          mediaUrl: null,
+        },
+      });
+      const result = await runMessageAction({
+        cfg: {
+          channels: {
+            "operation-local": {
+              enabled: true,
+            },
+          },
+        } as OpenClawConfig,
+        action: "broadcast",
+        params: {
+          channel: "operation-local",
+          targets: ["plugin-alias"],
+          message: "hello",
+        },
+        dryRun: true,
+      });
+
+      expect(result).toMatchObject({
+        kind: "broadcast",
+        action: "broadcast",
+        payload: {
+          results: [{ channel: "operation-local", to: "user:plugin-alias", ok: true }],
+        },
+      });
+      expect(resolveTarget).toHaveBeenCalledWith(
+        expect.objectContaining({ input: "plugin-alias", normalized: "plugin-alias" }),
+      );
+      expect(handleScopedAction).not.toHaveBeenCalled();
+    });
+
     afterEach(() => {
       setActivePluginRegistry(createTestRegistry([]));
       vi.clearAllMocks();

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -426,6 +426,7 @@ export async function runMessageAction(input: MessageActionInput): Promise<Messa
   const resolvedTarget = await resolveMessageTarget({
     cfg,
     channel,
+    channelPlugin,
     action,
     args: params,
     accountId,

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -8,7 +8,7 @@ import type { AgentToolResult } from "../../agents/runtime/index.js";
 import { readStringArrayParam, readToolStringParam } from "../../agents/tools/common.js";
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
-import type { ChannelId } from "../../channels/plugins/types.public.js";
+import type { ChannelId, ChannelPlugin } from "../../channels/plugins/types.public.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
@@ -114,26 +114,24 @@ async function handleBroadcastAction(
   if (input.broadcastAccountPlan && input.broadcastAccountPlan.accountId !== explicitAccountId) {
     throw new Error("Broadcast account plan does not match the requested account.");
   }
-  const targetChannels =
+  const targetChannels: Array<{ channel: ChannelId; plugin?: ChannelPlugin }> =
     channelHint && normalizeOptionalLowercaseString(channelHint) !== "all"
       ? [
-          (
-            await resolveMessageChannelSelection({
-              cfg: input.cfg,
-              channel: channelHint,
-              fallbackChannel: input.toolContext?.currentChannelProvider,
-              agentId: input.agentId,
-            })
-          ).channel,
+          await resolveMessageChannelSelection({
+            cfg: input.cfg,
+            channel: channelHint,
+            fallbackChannel: input.toolContext?.currentChannelProvider,
+            agentId: input.agentId,
+          }),
         ]
       : input.broadcastAccountPlan
-        ? input.broadcastAccountPlan.candidateChannels
+        ? input.broadcastAccountPlan.candidateChannels.map((channel) => ({ channel }))
         : await (async () => {
             const configured = await listConfiguredMessageChannels(input.cfg);
             if (configured.length === 0) {
               throw new Error("Broadcast requires at least one configured channel.");
             }
-            return configured;
+            return configured.map((channel) => ({ channel }));
           })();
   if (targetChannels.length === 0) {
     throw new Error("Broadcast requires at least one configured channel.");
@@ -149,7 +147,7 @@ async function handleBroadcastAction(
   }> = [];
   const isAbortError = (err: unknown): boolean => err instanceof Error && err.name === "AbortError";
   let attemptIndex = 0;
-  for (const targetChannel of targetChannels) {
+  for (const { channel: targetChannel, plugin: targetChannelPlugin } of targetChannels) {
     throwIfAborted(input.abortSignal);
     for (const target of rawTargets) {
       throwIfAborted(input.abortSignal);
@@ -164,6 +162,7 @@ async function handleBroadcastAction(
         const resolved = await resolveMessageTarget({
           cfg: input.cfg,
           channel: targetChannel,
+          channelPlugin: targetChannelPlugin,
           action: "send",
           args: targetArgs,
           accountId: targetAccountId,
@@ -214,7 +213,8 @@ async function handleBroadcastAction(
   }
   return {
     kind: "broadcast",
-    channel: targetChannels[0] ?? normalizeOptionalLowercaseString(channelHint) ?? "unknown",
+    channel:
+      targetChannels[0]?.channel ?? normalizeOptionalLowercaseString(channelHint) ?? "unknown",
     action: "broadcast",
     handledBy: input.dryRun ? "dry-run" : "core",
     payload: { results },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending messages through an npm-installed channel plugin would get an `Unknown target` error even though the plugin was selected and its target resolver accepted the target. The same selected-plugin propagation now covers both direct send and broadcast target resolution.

Fixes #126646

## Why This Change Was Made

The message route already selects the operation-local channel plugin, but direct and broadcast target resolution discarded it and fell back to the process-global registry. The selected plugin now flows through both singular target forms and explicit-channel broadcast target resolution into the existing resolver override seam.

## User Impact

`openclaw message send` and `openclaw message broadcast --channel <channel>` can resolve targets using the installed channel plugin that owns the active operation.

## Evidence

- Base regression: the focused runner test failed with `Unknown target "plugin-alias" for operation-local` when the plugin was not passed to target resolution.
- Head regression: the same test passed after the selected plugin was forwarded into target resolution.
- Broadcast regression: with an empty global plugin registry, the new broadcast test failed before the fix and passed after the selected operation-local plugin was forwarded.
- Focused validation: `pnpm exec vitest run src/infra/outbound/message-action-runner.plugin-dispatch.test.ts src/infra/outbound/target-resolver.test.ts src/infra/outbound/message-action-runner.core-send.test.ts` — 39 tests passed.
- Real CLI A/B proof, base `e1051ceea3027d668686ed266bb211e5d953c457` versus head `9998af9eac67d7ceafdab6660e494486ab063ff0`, used the same isolated state, LINE plugin fixture, target, and command for both direct send and broadcast. Base rejected valid targets; head produced dry-run core payloads. The malformed-target broadcast negative control remained rejected with the LINE hint.
- Canonical precedent: `resolveChannelTarget` already accepts a prepared plugin override in `src/infra/outbound/target-resolver.ts`, with plugin-specific coverage in `src/infra/outbound/target-resolver.test.ts`.

```text
$ OPENCLAW_STATE_DIR=$STATE_DIR pnpm openclaw message broadcast --channel line --targets U0123456789abcdef0123456789abcdef --message hi --dry-run --json
base: exit 1, {"ok":false,"payload":{"results":[{"channel":"line","to":"U0123456789abcdef0123456789abcdef","ok":false,"error":"Unknown target ... for line."}]}}
head: exit 0, {"ok":true,"payload":{"results":[{"channel":"line","to":"U0123456789abcdef0123456789abcdef","ok":true,"payload":{"channel":"line","to":"U0123456789abcdef0123456789abcdef","via":"direct","dryRun":true}}]}}
negative-control: exit 1, Unknown target "not-a-line-id" for LINE. Hint: <userId|groupId|roomId>
```

<details>
<summary>Proof / Testing</summary>

The following repository-root script exercises the real CLI entrypoint against an isolated state that loads the LINE channel plugin fixture. The valid direct and broadcast targets are expected to print dry-run payloads; the malformed broadcast target is expected to exit nonzero.

```bash
#!/usr/bin/env bash
set -euo pipefail

: "${OPENCLAW_STATE_DIR:?set an isolated state with the LINE plugin enabled}"
valid_target="U0123456789abcdef0123456789abcdef"

pnpm openclaw message send \
  --channel line \
  --target "$valid_target" \
  --message hi \
  --dry-run \
  --json

pnpm openclaw message broadcast \
  --channel line \
  --targets "$valid_target" \
  --message hi \
  --dry-run \
  --json

if pnpm openclaw message send \
  --channel line \
  --target not-a-line-id \
  --message hi \
  --dry-run \
  --json
then
  echo "negative control unexpectedly succeeded" >&2
  exit 1
fi

if pnpm openclaw message broadcast \
  --channel line \
  --targets not-a-line-id \
  --message hi \
  --dry-run \
  --json
then
  echo "broadcast negative control unexpectedly succeeded" >&2
  exit 1
fi
```

</details>

AI-assisted: built with Codex
