### PR TITLE
fix(macos): fail promptly after terminal gateway startup errors

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -1010,6 +1010,15 @@ extension GatewayProcessManager {
         let startGeneration = self.gatewayStartGeneration
         if await self.observeCurrentGatewayStart(generation: startGeneration) == true { return true }
         guard !Task.isCancelled, self.isCurrentGatewayStart(startGeneration) else { return false }
+        // Only a real launch candidate/install can recover after its owner reports failure.
+        if case .failed = self.status,
+           !launchAgentInstalled,
+           self.launchAgentReadinessCandidate == nil,
+           self.launchAgentReadinessFailure == nil,
+           self.launchAgentInstallGeneration != startGeneration
+        {
+            return false
+        }
         let readinessPort = self.launchAgentReadinessCandidate?.failure.port
             ?? GatewayEnvironment.gatewayPort()
         let context = self.gatewayReadinessContext(

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -1560,7 +1560,7 @@ struct GatewayProcessManagerTests {
 
     @Test func `readiness timeout preserves a concrete launch failure`() async throws {
         let url = try #require(URL(string: "ws://example.invalid"))
-        let (_, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
+        let (session, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
             GatewayTestWebSocketTask(
                 receiveHook: { _, receiveIndex in
                     if receiveIndex == 0 {
@@ -1581,6 +1581,7 @@ struct GatewayProcessManagerTests {
         }
 
         #expect(await manager.waitForGatewayReady(timeout: 0.1) == false)
+        #expect(session.snapshotMakeCount() == 0)
         #expect(manager.status == .failed("launchd install denied"))
         #expect(manager.lastFailureReason == "launchd install denied")
         await connection.shutdown()


### PR DESCRIPTION
## Summary

Prevent macOS onboarding and other local Gateway activation callers from stalling after startup has already reached a terminal failure with no process to recover.

`GatewayProcessManager.waitForGatewayReady` intentionally keeps probing after some owner failures because a launchd-managed process can become healthy after its initial readiness deadline. That recovery is correct when there is an installed LaunchAgent, a current-generation install, a pending readiness candidate, or a retained process-backed readiness failure. It is incorrect for terminal states such as attach-only/launchd-disabled startup, failed launchd installation, or configuration repair failure when no Gateway process exists. The CLI installer gives this readiness wait a 120-second migration budget, so first-run onboarding could keep spinning long after the actionable failure reason was known.

Teach the lifecycle owner to return immediately only when it is already failed and none of those recovery facts exists. Preserve the generation/cancellation guard and every legitimate delayed-start recovery path. Strengthen the existing owner regression to assert that a terminal failure does not create a Gateway WebSocket probe.

This is deliberately distinct from the healthy-Gateway reconciliation in #119850: this change handles only a terminal failure with no launched/recoverable process and does not change onboarding views or install-row ownership.

## Validation

- Demonstrated RED on the unmodified owner: the strengthened existing regression failed because `session.snapshotMakeCount()` was `1`, proving an unnecessary Gateway probe after the terminal startup failure.
- Demonstrated GREEN with the owner repair: all **43 GatewayProcessManagerTests** passed, including delayed owner recovery, pending readiness candidates, retained process-backed failures, launchd installation/replacement, cancellation, and foreign-listener coverage. The terminal-failure regression completed in **0.001 seconds**.
- Ran **50 additional CLIInstallerTests and OnboardingViewSmokeTests** successfully, including successful Gateway activation, failure-reason binding, local/remote first-run flow, and onboarding handoff.
- Built a real native macOS app from the repaired source, signed and deeply verified it with the installed application's matching Developer ID, and launched a fresh isolated named profile with private state, a compatible CLI, a unique unused Gateway port, and `--attach-only`.
- PID-scoped unified logs showed the real launchd-disabled owner failure at `07:53:51.321174`, followed by downstream control-channel configuration at `07:53:51.325855`: **4.681 ms** from terminal failure to completion of the shared readiness wait. The test profile never started a Gateway; the original app and operator Gateway stayed untouched.
- SwiftFormat lint passed for both changed files; independent structured autoreview reported no actionable findings.

Production LOC: +9/-0 (net +9); tests: +2/-1 (net +1). The production growth records the lifecycle-owner distinction between terminal no-process failure and four independent, existing sources of legitimate recovery evidence.

Release note: macOS onboarding now reports terminal local Gateway startup failures promptly instead of potentially waiting through the full startup migration timeout.
