### PR TITLE
fix(ui): pending approvals disappear while Settings is open

### DIFF
--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -437,6 +437,7 @@ export function renderApplicationShell(host: ShellViewHost) {
         onExit: () => host.exitSettings(),
         onRetryConnect: () => context.gateway.connect(),
         onNavigate: (routeId, options) => host.navigate(routeId, options),
+        onOpenApprovals: () => host.openApprovals(),
         onPreload: (routeId) => context.preload(routeId),
         onSearchQueryChange: (nextQuery) => {
           void host.handleSettingsSearchQueryChange(nextQuery);

--- a/ui/src/components/settings-sidebar.test.ts
+++ b/ui/src/components/settings-sidebar.test.ts
@@ -535,6 +535,47 @@ describe("settings sidebar search", () => {
     expect(onNavigate).toHaveBeenCalledWith("about");
   });
 
+  it("keeps pending approvals actionable from the settings sidebar", () => {
+    const onNavigate = vi.fn();
+    const onOpenApprovals = vi.fn();
+    render(
+      renderSettingsSidebar({
+        basePath: "",
+        activeRouteId: "appearance",
+        offline: false,
+        lastError: null,
+        gatewayVersion: "1.0.0",
+        updateAvailable: null,
+        updateBusy: false,
+        onUpdate: vi.fn(),
+        ...inactiveRefresh,
+        searchQuery: "",
+        onExit: vi.fn(),
+        onRetryConnect: vi.fn(),
+        onNavigate,
+        onOpenApprovals,
+        onSearchQueryChange: vi.fn(),
+        preloadTimers: new Map(),
+        saveIndicator: saveIndicator(),
+      }),
+      container,
+    );
+
+    const attention = container.querySelector<
+      HTMLElement & {
+        onNavigate?: (routeId: string) => void;
+        onOpenApprovals?: () => void;
+      }
+    >("openclaw-sidebar-attention");
+    expect(attention).not.toBeNull();
+    expect(attention?.nextElementSibling?.tagName).toBe("OPENCLAW-SIDEBAR-UPDATE-CARD");
+
+    attention?.onOpenApprovals?.();
+    expect(onOpenApprovals).toHaveBeenCalledOnce();
+    attention?.onNavigate?.("approvals");
+    expect(onNavigate).toHaveBeenCalledWith("approvals");
+  });
+
   it("shows the offline retry action without an online status", () => {
     const onRetryConnect = vi.fn();
     const renderSidebar = (offline: boolean, lastError: string | null, queuedOutboxCount = 0) =>

--- a/ui/src/components/settings-sidebar.ts
+++ b/ui/src/components/settings-sidebar.ts
@@ -58,6 +58,7 @@ type SettingsSidebarProps = {
   onExit: () => void;
   onRetryConnect: () => void;
   onNavigate: (routeId: RouteId, options?: ApplicationNavigationOptions) => void;
+  onOpenApprovals?: () => void;
   onPreload?: (routeId: RouteId) => Promise<void> | void;
   onSearchQueryChange: (query: string) => void;
   preloadTimers: Map<EventTarget, ReturnType<typeof globalThis.setTimeout>>;
@@ -323,6 +324,10 @@ export function renderSettingsSidebar(props: SettingsSidebarProps) {
               `,
             )}
       </nav>
+      <openclaw-sidebar-attention
+        .onNavigate=${props.onNavigate}
+        .onOpenApprovals=${props.onOpenApprovals}
+      ></openclaw-sidebar-attention>
       <openclaw-sidebar-update-card
         .updateAvailable=${props.updateAvailable}
         .updateSchedule=${props.updateSchedule ?? null}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators reviewing Settings would miss pending execution approvals and other urgent Gateway alerts because the full-page Settings takeover replaced every visible attention surface.

## Why This Change Was Made

The Settings takeover deliberately keeps its navigation expanded, which suppresses the floating attention fallback. Its dedicated sidebar previously mounted update, save, and build indicators but omitted the existing application-owned attention component altogether. Mounting that canonical component beside the existing update card and forwarding the existing shell approval action restores the same Gateway-backed alert ownership and approval permissions without inventing a second queue or changing startup loading.

## User Impact

Operators can see pending approval alerts while changing Settings and open the existing approval dialog without leaving their current page. Automation failures, model-auth warnings, and other existing global alerts use the same restored surface. Desktop, open mobile drawers, and closed mobile drawers continue to have exactly one visible attention surface.

## Evidence

- Failing-first owner regression: the pre-fix Settings sidebar suite passed its 12 existing cases but failed the new user-visible approval case because no attention component existed.
- Fixed owner regression: all 13 Settings sidebar tests pass, including the existing approval action and navigation callback forwarded through the canonical attention component.
- Exact focused proof: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/components/settings-sidebar.test.ts`.
- Real-user proof: two isolated Chromium browser contexts connected to a real disposable, loopback-only Gateway at commit `267ffc4754a0`; one operator created a real `exec.approval.request`, the other saw `1 pending approval` in Settings and clicked it to open the real `Exec approval needed` dialog.
- Independent source review confirmed mobile drawer visibility, lazy component registration, existing authorization/revocation behavior, and the canonical overlay owner; fresh automated source review found no actionable issues.
- Targeted formatting, lint, and `git diff --check` are clean.
- Production: +6/-0; regression tests: +41/-0.

Before a pending approval arrives:

![Settings sidebar before a pending approval](https://github.com/user-attachments/assets/471f3432-c999-437e-a4c6-de0a76bf80e4)

After another real Gateway client requests approval:

![Settings sidebar showing the pending approval shield](https://github.com/user-attachments/assets/d7a23d4a-3ae7-41c6-93c1-4e217ab0f5b1)
