### PR TITLE
feat(qa): acknowledge Mantis PR requests

### DIFF
--- a/.github/workflows/mantis-discord-status-reactions.yml
+++ b/.github/workflows/mantis-discord-status-reactions.yml
@@ -1,8 +1,6 @@
 name: Mantis Discord Status Reactions
 
 on:
-  issue_comment:
-    types: [created]
   workflow_dispatch:
     inputs:
       baseline_ref:

--- a/.github/workflows/mantis-discord-thread-attachment.yml
+++ b/.github/workflows/mantis-discord-thread-attachment.yml
@@ -1,8 +1,6 @@
 name: Mantis Discord Thread Attachment
 
 on:
-  issue_comment:
-    types: [created]
   workflow_dispatch:
     inputs:
       candidate_ref:

--- a/.github/workflows/mantis-telegram-desktop-proof-dispatch.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof-dispatch.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   actions: write
+  issues: write
   pull-requests: read
 
 jobs:
@@ -40,14 +41,6 @@ jobs:
             let requestSource;
 
             if (eventName === "issue_comment") {
-              const normalized = (context.payload.comment?.body ?? "").toLowerCase();
-              const requestsDesktopProof =
-                /\b(?:telegram desktop proof|desktop proof|native telegram|visible proof|telegram-visible-proof)\b/u.test(
-                  normalized,
-                );
-              if (!requestsDesktopProof) {
-                return;
-              }
               const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
                 owner,
                 repo,
@@ -59,8 +52,18 @@ jobs:
                 );
                 return;
               }
+              await github.rest.reactions
+                .createForIssueComment({
+                  owner,
+                  repo,
+                  comment_id: context.payload.comment.id,
+                  content: "eyes",
+                })
+                .catch((error) => core.warning(`Could not add eyes reaction: ${error.message}`));
               prNumber = context.payload.issue.number;
-              instructions = context.payload.comment.body;
+              instructions = context.payload.comment.body
+                .replace(/(?:@|\/)openclaw-mantis/giu, "")
+                .trim();
               requestSource = "issue_comment";
             } else {
               const pr = context.payload.pull_request;

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -198,6 +198,7 @@ jobs:
           permission-pull-requests: write
 
       - name: Report Mantis run started
+        id: mantis_status_comment
         if: ${{ steps.mantis_status_token.outcome == 'success' }}
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -206,37 +207,75 @@ jobs:
         with:
           github-token: ${{ steps.mantis_status_token.outputs.token }}
           script: |
-            const marker = "<!-- mantis-telegram-desktop-proof -->";
+            const markerRoot = "<!-- mantis-telegram-desktop-proof:";
+            const runId = Number(process.env.GITHUB_RUN_ID);
+            const runAttempt = Number(process.env.GITHUB_RUN_ATTEMPT);
+            const marker = `${markerRoot}${runId}-${runAttempt} -->`;
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const body = `${marker}\nMantis started this proof. [Follow the active job](${runUrl}).`;
             const { owner, repo } = context.repo;
             const issueNumber = Number(process.env.TARGET_PR);
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number: issueNumber,
-              per_page: 100,
-            });
-            const existing = comments.findLast(
-              (comment) =>
-                comment.user?.login === "openclaw-mantis[bot]" &&
-                comment.body?.includes(marker),
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-              return;
-            }
             await github.rest.issues.createComment({
               owner,
               repo,
               issue_number: issueNumber,
               body,
             });
+            const statuses = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const statusMarker = /<!-- mantis-telegram-desktop-proof:(\d+)-(\d+) -->/u;
+            const matching = statuses
+              .filter((comment) => comment.user?.login === "openclaw-mantis[bot]")
+              .flatMap((comment) => {
+                const match = comment.body?.match(statusMarker);
+                return match
+                  ? [{ comment, runAttempt: Number(match[2]), runId: Number(match[1]) }]
+                  : [];
+              })
+              .sort((left, right) => left.runId - right.runId || left.runAttempt - right.runAttempt);
+            const canonical = matching.at(-1);
+            for (const stale of matching.slice(0, -1)) {
+              await github.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: stale.comment.id,
+              });
+            }
+            if (!canonical) {
+              core.setFailed("Mantis status comment was not visible after publication.");
+            }
+
+      - name: Report Mantis start failure with workflow token
+        id: mantis_status_fallback
+        if: >-
+          ${{
+            always() &&
+            steps.resolve.outputs.request_source == 'issue_comment' &&
+            (
+              steps.mantis_status_token.outcome != 'success' ||
+              steps.mantis_status_comment.outcome != 'success'
+            )
+          }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          TARGET_PR: ${{ steps.resolve.outputs.pr_number }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const marker = "<!-- mantis-telegram-desktop-proof -->";
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const { owner, repo } = context.repo;
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: Number(process.env.TARGET_PR),
+              body: `${marker}\nMantis could not start this proof. [Open the failed job](${runUrl}).`,
+            });
+            core.setFailed("Mantis could not publish its durable status comment.");
 
       - name: Checkout preflight refs
         id: checkout
@@ -1214,6 +1253,7 @@ jobs:
           permission-pull-requests: read
 
       - name: Comment PR with inline QA evidence
+        id: publish_evidence
         if: ${{ always() && steps.trusted_evidence.outcome == 'success' && needs.resolve_request.outputs.pr_number != '' && steps.inspect.outputs.output_dir != '' }}
         env:
           ARTIFACT_URL: ${{ steps.upload_artifact.outputs.artifact-url }}
@@ -1242,10 +1282,48 @@ jobs:
             --manifest "$root/mantis-evidence.json" \
             --target-pr "$TARGET_PR" \
             --artifact-root "mantis/telegram-desktop/pr-${TARGET_PR}/run-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
-            --marker "<!-- mantis-telegram-desktop-proof -->" \
+            --marker "<!-- mantis-telegram-desktop-proof:${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT} -->" \
+            --create-missing false \
             "${artifact_url_args[@]}" \
             --run-url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             --request-source "$REQUEST_SOURCE"
+
+      - name: Report failed Mantis proof
+        if: ${{ always() && needs.resolve_request.outputs.request_source == 'issue_comment' && steps.publish_evidence.outcome != 'success' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          TARGET_PR: ${{ needs.resolve_request.outputs.pr_number }}
+        with:
+          github-token: ${{ steps.mantis_app_token.outputs.token }}
+          script: |
+            const marker = `<!-- mantis-telegram-desktop-proof:${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT} -->`;
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = `${marker}\nMantis could not complete this proof. [Open the failed job](${runUrl}).`;
+            const { owner, repo } = context.repo;
+            const issueNumber = Number(process.env.TARGET_PR);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const existing = comments.findLast(
+              (comment) =>
+                comment.user?.login === "openclaw-mantis[bot]" &&
+                comment.body?.includes(marker),
+            );
+            if (!existing) {
+              core.info("A newer Mantis run owns the PR status; skipping stale failure output.");
+              return;
+            }
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            }
 
       - name: Fail when Mantis Telegram desktop proof failed
         if: ${{ always() && steps.inspect.outputs.output_dir != '' && steps.inspect.outputs.comparison_status != 'pass' }}
@@ -1280,7 +1358,7 @@ jobs:
         with:
           github-token: ${{ steps.mantis_app_token.outputs.token }}
           script: |
-            const marker = "<!-- mantis-telegram-desktop-proof -->";
+            const marker = `<!-- mantis-telegram-desktop-proof:${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT} -->`;
             const body = `${marker}\nThere was nothing visible to test in this PR at all.`;
             const { owner, repo } = context.repo;
             const issueNumber = Number(process.env.TARGET_PR);
@@ -1295,20 +1373,16 @@ jobs:
                 comment.user?.login === "openclaw-mantis[bot]" &&
                 comment.body?.includes(marker),
             );
-            if (existing) {
-              try {
-                await github.rest.issues.updateComment({
-                  owner,
-                  repo,
-                  comment_id: existing.id,
-                  body,
-                });
-                return;
-              } catch {
-                core.warning(`Could not update Mantis comment ${existing.id}; creating a new one.`);
-              }
+            if (!existing) {
+              core.info("A newer Mantis run owns the PR status; skipping stale no-change output.");
+              return;
             }
-            await github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body });
+            await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: existing.id,
+              body,
+            });
 
   publish_existing_telegram_desktop_proof:
     name: Publish existing native Telegram proof

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -185,6 +185,59 @@ jobs:
               requestSource === "clawsweeper_label" || publishArtifactName ? "false" : "true",
             );
 
+      - name: Create Mantis status token
+        id: mantis_status_token
+        if: ${{ steps.resolve.outputs.request_source == 'issue_comment' }}
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.MANTIS_GITHUB_APP_ID }}
+          private-key: ${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-pull-requests: write
+
+      - name: Report Mantis run started
+        if: ${{ steps.mantis_status_token.outcome == 'success' }}
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          TARGET_PR: ${{ steps.resolve.outputs.pr_number }}
+        with:
+          github-token: ${{ steps.mantis_status_token.outputs.token }}
+          script: |
+            const marker = "<!-- mantis-telegram-desktop-proof -->";
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = `${marker}\nMantis started this proof. [Follow the active job](${runUrl}).`;
+            const { owner, repo } = context.repo;
+            const issueNumber = Number(process.env.TARGET_PR);
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number: issueNumber,
+              per_page: 100,
+            });
+            const existing = comments.findLast(
+              (comment) =>
+                comment.user?.login === "openclaw-mantis[bot]" &&
+                comment.body?.includes(marker),
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              return;
+            }
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body,
+            });
+
       - name: Checkout preflight refs
         id: checkout
         if: ${{ steps.resolve.outputs.should_run == 'true' && steps.resolve.outputs.requires_preflight == 'true' }}

--- a/.github/workflows/mantis-telegram-live.yml
+++ b/.github/workflows/mantis-telegram-live.yml
@@ -1,8 +1,6 @@
 name: Mantis Telegram Live
 
 on:
-  issue_comment:
-    types: [created]
   workflow_dispatch:
     inputs:
       candidate_ref:

--- a/.github/workflows/mantis-web-ui-chat-proof.yml
+++ b/.github/workflows/mantis-web-ui-chat-proof.yml
@@ -1,8 +1,6 @@
 name: Mantis Web UI Chat Proof
 
 on:
-  issue_comment: # zizmor: ignore[dangerous-triggers] maintainer-only Mantis command; candidate refs are trusted before execution and publishing runs in a separate job
-    types: [created]
   workflow_dispatch:
     inputs:
       candidate_ref:

--- a/docs/concepts/mantis.md
+++ b/docs/concepts/mantis.md
@@ -357,45 +357,36 @@ marker comment as the upsert key.
 | Workflow                          | Trigger                                                                                         | What it does                                                                                                                                                                                                                                                                                                     |
 | --------------------------------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Mantis Discord Smoke`            | manual dispatch                                                                                 | Runs `discord-smoke` against a chosen ref.                                                                                                                                                                                                                                                                       |
-| `Mantis Discord Status Reactions` | PR comment or manual dispatch                                                                   | Builds separate baseline/candidate worktrees, runs `discord-status-reactions-tool-only` on each, renders each lane's timeline in a Crabbox desktop browser, generates motion-trimmed GIF/MP4 previews with `crabbox media preview`, uploads artifacts, posts inline PR evidence.                                 |
+| `Mantis Discord Status Reactions` | manual dispatch                                                                                 | Builds separate baseline/candidate worktrees, runs `discord-status-reactions-tool-only` on each, renders each lane's timeline in a Crabbox desktop browser, generates motion-trimmed GIF/MP4 previews with `crabbox media preview`, uploads artifacts, posts inline PR evidence.                                 |
 | `Mantis Scenario`                 | manual dispatch                                                                                 | Generic dispatcher: takes `scenario_id` (`discord-status-reactions-tool-only`, `discord-thread-reply-filepath-attachment`, `slack-desktop-smoke`, `telegram-live`, `telegram-desktop-proof`, `web-ui-chat-proof`), `baseline_ref`, `candidate_ref`, `pr_number`, and forwards to the matching scenario workflow. |
 | `Mantis Slack Desktop Smoke`      | manual dispatch                                                                                 | Leases a Crabbox Linux desktop (defaults to `aws`, choice of `hetzner`), runs `slack-desktop-smoke --gateway-setup` against the candidate, records the desktop, generates a motion preview, uploads artifacts, posts PR evidence when a PR number is given.                                                      |
-| `Mantis Telegram Live`            | PR comment or manual dispatch                                                                   | Runs the bot-API Telegram live QA lane (`openclaw qa telegram`), writes `mantis-evidence.json` from the QA summary, renders redacted evidence HTML through a Crabbox desktop browser, generates a motion GIF, posts PR evidence. Telegram Web login is not required for this lane.                               |
+| `Mantis Telegram Live`            | manual dispatch                                                                                 | Runs the bot-API Telegram live QA lane (`openclaw qa telegram`), writes `mantis-evidence.json` from the QA summary, renders redacted evidence HTML through a Crabbox desktop browser, generates a motion GIF, posts PR evidence. Telegram Web login is not required for this lane.                               |
 | `Mantis Telegram Desktop Proof`   | ClawSweeper label (`mantis: telegram-visible-proof`), maintainer PR comment, or manual dispatch | Agentic native Telegram Desktop before/after proof. Hands the PR, baseline/candidate refs, and maintainer instructions to Codex, which runs each container-isolated SUT against a local Docker desktop recorder and posts a 2-column PR evidence table.                                                          |
-| `Mantis Web UI Chat Proof`        | PR comment or manual dispatch                                                                   | Runs the focused OpenClaw Control UI chat Playwright proof against the candidate, verifies the browser sends through the mocked Gateway, captures screenshot/video artifacts, and posts PR evidence. This lane is web chat proof only, not WinUI/native-app or arbitrary visual proof.                           |
+| `Mantis Web UI Chat Proof`        | manual dispatch                                                                                 | Runs the focused OpenClaw Control UI chat Playwright proof against the candidate, verifies the browser sends through the mocked Gateway, captures screenshot/video artifacts, and posts PR evidence. This lane is web chat proof only, not WinUI/native-app or arbitrary visual proof.                           |
 
 `Mantis Discord Status Reactions` and `Mantis Telegram Live` both accept
-`baseline_ref`/`candidate_ref` (or `baseline=`/`candidate=` in a PR comment)
-and validate that the resolved SHA is either an ancestor of `origin/main`, a
-release tag (`v*`), or the head of an open PR before running with
-secret-bearing credentials.
+`baseline_ref`/`candidate_ref` and validate that the resolved SHA is either an
+ancestor of `origin/main`, a release tag (`v*`), or the head of an open PR
+before running with secret-bearing credentials.
 
 Comment triggers, from a PR with write/maintain/admin access:
 
 ```text
-@openclaw-mantis discord status reactions
-@openclaw-mantis discord status reactions baseline=origin/main candidate=HEAD
-@openclaw-mantis telegram
-@openclaw-mantis telegram scenario=telegram-status-command
-@openclaw-mantis telegram scenarios=telegram-status-command,channel-canary
-@openclaw-mantis web ui chat
-@openclaw-mantis web-ui-chat candidate=HEAD
+@openclaw-mantis
+@openclaw-mantis verify the streamed reply stays visible while it arrives
 ```
 
-Telegram comment triggers default to the PR head SHA as candidate and
-`telegram-status-command` as scenario; they accept `provider=aws|hetzner` and
-`lease=<cbx_...>` to target a specific Crabbox provider or a pre-warmed
-desktop. `Mantis Telegram Desktop Proof` only responds to a PR comment when
-the commenter has write, maintain, or admin access. ClawSweeper's
+`Mantis Telegram Desktop Proof` only responds to a PR comment when
+the commenter has write, maintain, or admin access. A bare mention starts the
+desktop proof; any remaining text becomes optional proof guidance. Mantis
+reacts with 👀 when it accepts the request, then posts the active run link in
+its evidence comment and replaces that same comment with the result. ClawSweeper's
 `mantis: telegram-visible-proof` label starts the proof automatically for
 branches in `openclaw/openclaw`; fork PRs still require an explicit maintainer
 comment. Manual runs first inspect the diff and stop before desktop setup when
 there is no Telegram-visible behavior to test.
 
-Web UI chat comment triggers default to the PR head SHA as candidate. They run
-the Control UI mocked-Gateway chat proof and publish browser artifacts; use
-normal Playwright/browser proof, maintainer screenshots, Crabbox, or local
-artifacts for other web pages and native app surfaces.
+The other scenario workflows remain available through manual Actions dispatch.
 
 ClawSweeper can also dispatch a scenario directly:
 

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -453,13 +453,7 @@ redacted QA report/evidence bundle in a Crabbox desktop browser, records MP4
 evidence, generates a motion-trimmed GIF, uploads the artifact bundle, and
 posts inline PR evidence through the Mantis GitHub App when `pr_number` is
 set. Maintainers can start it from the Actions UI through `Mantis Scenario`
-(`scenario_id: telegram-live`) or directly from a pull request comment:
-
-```text
-@openclaw-mantis telegram
-@openclaw-mantis telegram scenario=telegram-status-command
-@openclaw-mantis telegram scenarios=telegram-status-command,channel-canary
-```
+(`scenario_id: telegram-live`).
 
 `Mantis Telegram Desktop Proof` is the agentic native Telegram Desktop
 before/after wrapper for PR visual proof. Start it from the Actions UI with
@@ -467,12 +461,16 @@ freeform `instructions`, through `Mantis Scenario` (`scenario_id:
 telegram-desktop-proof`), or from a maintainer PR comment:
 
 ```text
-@openclaw-mantis telegram desktop proof
+@openclaw-mantis
+@openclaw-mantis verify the streamed reply stays visible while it arrives
 ```
 
 ClawSweeper's `mantis: telegram-visible-proof` label starts this workflow
 automatically for branches in `openclaw/openclaw`. Fork PRs require the
-maintainer comment. Manual requests stop before desktop setup and comment
+maintainer comment. Mantis reacts with 👀 when it accepts a comment, then
+posts the active workflow link in its evidence comment and replaces that same
+comment with the result. Any text after the mention is optional proof guidance.
+Manual requests stop before desktop setup and comment
 `There was nothing visible to test in this PR at all.` when the diff has no
 Telegram-visible behavior.
 

--- a/scripts/mantis/publish-pr-evidence.mjs
+++ b/scripts/mantis/publish-pr-evidence.mjs
@@ -592,14 +592,14 @@ export async function publishArtifactFiles({
     treeUrl: artifactUrl(publicRoot, indexArtifact),
   };
 }
-function upsertPrComment({ body, marker, prNumber, repo }) {
+function upsertPrComment({ body, createMissing, marker, prNumber, repo }) {
   run("gh", ["api", `repos/${repo}/pulls/${prNumber}`, "--jq", ".number"]);
   const commentId = run("gh", [
     "api",
     "--paginate",
     `repos/${repo}/issues/${prNumber}/comments`,
     "--jq",
-    `.[] | select(.body | contains("${marker}")) | .id`,
+    `.[] | select(.user.login == "openclaw-mantis[bot]" and (.body | contains("${marker}"))) | .id`,
   ])
     .trim()
     .split("\n")
@@ -622,10 +622,22 @@ function upsertPrComment({ body, marker, prNumber, repo }) {
         console.log(`Updated Mantis QA evidence comment on PR #${prNumber}.`);
         return;
       } catch {
+        if (!createMissing) {
+          console.log(
+            "Skipped stale Mantis QA evidence comment because its status is no longer active.",
+          );
+          return;
+        }
         console.warn(
           `Could not update existing Mantis QA evidence comment ${commentId}; creating a new one.`,
         );
       }
+    }
+    if (!createMissing) {
+      console.log(
+        "Skipped stale Mantis QA evidence comment because its status is no longer active.",
+      );
+      return;
     }
     run("gh", ["pr", "comment", prNumber, "--body-file", bodyFile], { stdio: "inherit" });
     console.log(`Created Mantis QA evidence comment on PR #${prNumber}.`);
@@ -671,6 +683,7 @@ export async function publishEvidence(rawArgs = process.argv.slice(2)) {
   }
   upsertPrComment({
     body,
+    createMissing: args.create_missing !== "false",
     marker,
     prNumber: targetPr,
     repo,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -30,7 +30,7 @@ const UPLOAD_ARTIFACT_V7 = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64
 const DOWNLOAD_ARTIFACT_V8 = "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c";
 const CREATE_GITHUB_APP_TOKEN_V3 =
   "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1";
-const MANTIS_ISSUE_COMMENT_REACTION_WORKFLOWS = [
+const MANTIS_MANUAL_ONLY_WORKFLOWS = [
   ".github/workflows/mantis-web-ui-chat-proof.yml",
   ".github/workflows/mantis-discord-status-reactions.yml",
   ".github/workflows/mantis-discord-thread-attachment.yml",
@@ -4945,29 +4945,13 @@ server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.addre
     );
   });
 
-  it.each(MANTIS_ISSUE_COMMENT_REACTION_WORKFLOWS)(
-    "routes Mantis reaction ownership through shared workflows in %s",
+  it.each(MANTIS_MANUAL_ONLY_WORKFLOWS)(
+    "keeps legacy Mantis scenarios on manual dispatch in %s",
     (workflowPath) => {
       const workflow = parse(readFileSync(workflowPath, "utf8"));
-      const resolveJob = workflow.jobs.resolve_request;
-      const cleanupJob = workflow.jobs.clear_issue_comment_reaction;
-      const expectedSecrets = {
-        MANTIS_GITHUB_APP_ID: "${{ secrets.MANTIS_GITHUB_APP_ID }}",
-        MANTIS_GITHUB_APP_PRIVATE_KEY: "${{ secrets.MANTIS_GITHUB_APP_PRIVATE_KEY }}",
-      };
 
-      expect(resolveJob.uses, workflowPath).toBe("./.github/workflows/mantis-resolve-request.yml");
-      expect(resolveJob.secrets, workflowPath).toEqual(expectedSecrets);
-      expect(cleanupJob.uses, workflowPath).toBe("./.github/workflows/mantis-clear-reaction.yml");
-      expect(cleanupJob.if, workflowPath).toContain(
-        "needs.resolve_request.outputs.reaction_id != ''",
-      );
-      expect(cleanupJob.permissions, workflowPath).toEqual({});
-      expect(cleanupJob.with, workflowPath).toMatchObject({
-        "comment-id": "${{ format('{0}', github.event.comment.id) }}",
-        "reaction-id": "${{ needs.resolve_request.outputs.reaction_id }}",
-      });
-      expect(cleanupJob.secrets, workflowPath).toEqual(expectedSecrets);
+      expect(workflow.on.workflow_dispatch, workflowPath).toBeDefined();
+      expect(workflow.on.issue_comment, workflowPath).toBeUndefined();
     },
   );
 

--- a/test/scripts/mantis-publish-pr-evidence.test.ts
+++ b/test/scripts/mantis-publish-pr-evidence.test.ts
@@ -1,5 +1,5 @@
 // Mantis Publish Pr Evidence tests cover mantis publish pr evidence script behavior.
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -79,6 +79,12 @@ function writeFixtureManifest() {
 }
 
 describe("scripts/mantis/publish-pr-evidence", () => {
+  it("selects only Mantis-owned status comments", () => {
+    const source = readFileSync("scripts/mantis/publish-pr-evidence.mjs", "utf8");
+
+    expect(source).toContain('.user.login == "openclaw-mantis[bot]"');
+  });
+
   it("renders a manifest-driven PR comment with inline screenshots and video links", () => {
     const manifest = loadEvidenceManifest(writeFixtureManifest());
     const body = renderEvidenceComment({

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -23,6 +23,7 @@ const DOCS = ["docs/help/testing.md", "docs/concepts/qa-e2e-automation.md"];
 
 type WorkflowStep = {
   "continue-on-error"?: boolean;
+  id?: string;
   if?: string;
   env?: Record<string, string>;
   name?: string;
@@ -360,14 +361,42 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     const startedComment = resolver?.steps?.find(
       (step) => step.name === "Report Mantis run started",
     );
+    const fallbackComment = resolver?.steps?.find(
+      (step) => step.name === "Report Mantis start failure with workflow token",
+    );
     expect(startedToken?.if).toContain("request_source == 'issue_comment'");
     expect(startedToken?.with?.["permission-pull-requests"]).toBe("write");
     expect(startedComment?.["continue-on-error"]).toBe(true);
     expect(startedComment?.with?.script).toContain("Mantis started this proof.");
     expect(startedComment?.with?.script).toContain("actions/runs/${process.env.GITHUB_RUN_ID}");
-    expect(startedComment?.with?.script).toContain("mantis-telegram-desktop-proof");
-    expect(startedComment?.with?.script).toContain("issues.updateComment");
+    expect(startedComment?.with?.script).toContain("mantis-telegram-desktop-proof:");
+    expect(startedComment?.with?.script).toContain("GITHUB_RUN_ATTEMPT");
     expect(startedComment?.with?.script).toContain("issues.createComment");
+    expect(startedComment?.with?.script).toContain("issues.deleteComment");
+    expect(fallbackComment?.if).toContain("steps.mantis_status_token.outcome != 'success'");
+    expect(fallbackComment?.if).toContain("steps.mantis_status_comment.outcome != 'success'");
+    expect(fallbackComment?.with?.["github-token"]).toBe("${{ github.token }}");
+    expect(fallbackComment?.["continue-on-error"]).toBeUndefined();
+    expect(fallbackComment?.with?.script).toContain("mantis-telegram-desktop-proof");
+    expect(fallbackComment?.with?.script).toContain("Mantis could not start this proof.");
+    expect(fallbackComment?.with?.script).toContain("core.setFailed");
+
+    const proofSteps = workflow.jobs?.run_telegram_desktop_proof?.steps ?? [];
+    const evidenceComment = proofSteps.find(
+      (step) => step.name === "Comment PR with inline QA evidence",
+    );
+    const failureComment = proofSteps.find((step) => step.name === "Report failed Mantis proof");
+    expect(evidenceComment?.id).toBe("publish_evidence");
+    expect(failureComment?.if).toContain("always()");
+    expect(failureComment?.if).toContain("request_source == 'issue_comment'");
+    expect(failureComment?.if).toContain("steps.publish_evidence.outcome != 'success'");
+    expect(failureComment?.with?.script).toContain("Mantis could not complete this proof.");
+    expect(failureComment?.with?.script).toContain("issues.updateComment");
+    expect(failureComment?.with?.script).toContain("skipping stale failure output");
+    expect(evidenceComment?.run).toContain(
+      "mantis-telegram-desktop-proof:${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}",
+    );
+    expect(evidenceComment?.run).toContain("--create-missing false");
 
     const preflightCheckout = resolver?.steps?.find(
       (step) => step.name === "Checkout preflight refs",
@@ -405,12 +434,14 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(noVisibleComment?.with?.script).toContain(
       "There was nothing visible to test in this PR at all.",
     );
-    expect(noVisibleComment?.with?.script).toContain("mantis-telegram-desktop-proof");
+    expect(noVisibleComment?.with?.script).toContain("mantis-telegram-desktop-proof:");
+    expect(noVisibleComment?.with?.script).toContain("GITHUB_RUN_ATTEMPT");
     expect(noVisibleComment?.with?.script).toContain(
       'comment.user?.login === "openclaw-mantis[bot]"',
     );
-    expect(noVisibleComment?.with?.script).toContain("Could not update Mantis comment");
-    expect(noVisibleComment?.with?.script).toContain("issues.createComment");
+    expect(noVisibleComment?.with?.script).toContain("skipping stale no-change output");
+    expect(noVisibleComment?.with?.script).toContain("issues.updateComment");
+    expect(noVisibleComment?.with?.script).not.toContain("issues.createComment");
     expect(workflowStep("Upload Mantis Telegram desktop artifacts").if).toContain(
       "steps.trusted_evidence.outcome == 'success'",
     );

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -322,10 +322,14 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(dispatchWorkflow.on?.pull_request_target?.types).toEqual(["labeled"]);
     expect(dispatchWorkflow.permissions).toEqual({
       actions: "write",
+      issues: "write",
       "pull-requests": "read",
     });
     expect(dispatchText).toContain("@openclaw-mantis");
-    expect(dispatchText).toContain("telegram desktop proof");
+    expect(dispatchText).not.toContain("requestsDesktopProof");
+    expect(dispatchText).toContain("createForIssueComment");
+    expect(dispatchText).toContain('content: "eyes"');
+    expect(dispatchText).toContain('.replace(/(?:@|\\/)openclaw-mantis/giu, "")');
     expect(dispatchText).toContain('new Set(["admin", "maintain", "write"])');
     expect(dispatchText).toContain('context.actor !== "clawsweeper[bot]"');
     expect(dispatchText).toContain("Ignoring Mantis label applied by");
@@ -349,6 +353,21 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(workflowText).toContain("allow-bot-users: github-actions[bot]");
     expect(workflowText).not.toContain("allow-bot-users: github-actions[bot],clawsweeper[bot]");
     expect(workflowText).toContain("inputs.approved_head_sha !== candidateRevision");
+
+    const startedToken = resolver?.steps?.find(
+      (step) => step.name === "Create Mantis status token",
+    );
+    const startedComment = resolver?.steps?.find(
+      (step) => step.name === "Report Mantis run started",
+    );
+    expect(startedToken?.if).toContain("request_source == 'issue_comment'");
+    expect(startedToken?.with?.["permission-pull-requests"]).toBe("write");
+    expect(startedComment?.["continue-on-error"]).toBe(true);
+    expect(startedComment?.with?.script).toContain("Mantis started this proof.");
+    expect(startedComment?.with?.script).toContain("actions/runs/${process.env.GITHUB_RUN_ID}");
+    expect(startedComment?.with?.script).toContain("mantis-telegram-desktop-proof");
+    expect(startedComment?.with?.script).toContain("issues.updateComment");
+    expect(startedComment?.with?.script).toContain("issues.createComment");
 
     const preflightCheckout = resolver?.steps?.find(
       (step) => step.name === "Checkout preflight refs",


### PR DESCRIPTION
## What Problem This Solves

A maintainer could mention Mantis on a pull request and see no acknowledgement. The Telegram desktop proof also required extra command wording even though the mention has one default job.

## Why This Change Was Made

This adopts the small, proven ClawSweeper interaction pattern: acknowledge an authorized request immediately, expose the active workflow, and keep one durable result comment. A bare `@openclaw-mantis` mention now dispatches the agentic Telegram Desktop proof; remaining text is optional proof guidance. Older scenario workflows remain available through manual Actions dispatch so they cannot compete for the same mention.

## User Impact

Authorized maintainers now get an immediate 👀 reaction followed by a Mantis comment linking to the active workflow. The proof, short-circuit result, and subsequent runs update that same marker-backed comment instead of adding PR comment noise.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/mantis-telegram-desktop-proof-workflow.test.ts test/scripts/ci-workflow-guards.test.ts` (149 tests passed)
- `node scripts/check-changed.mjs -- <changed paths>` (passed)
- `pnpm docs:list` (passed)
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` (clean, no actionable findings)

Live GitHub acknowledgement proof requires the workflow to exist on the default branch; exact-head CI and local ClawSweeper review are the pre-merge gates.

## Rank-up moves

- `Repair the fallback status ownership and add a focused regression that proves terminal replacement.` — applied as a simpler terminal path: if the Mantis App cannot create its durable comment, the workflow-token fallback posts a visible failure linked to the run and fails request resolution. No proof job starts, so there is no second terminal comment or cross-owner update.
- `Capture a redacted default-branch authorized-comment run showing the acknowledgement and durable status update.` — skipped pre-merge because GitHub resolves `issue_comment` workflows from the default branch, where this trigger change does not exist yet. The focused workflow regressions cover bare-mention dispatch, 👀 acknowledgement, exact run-link publication, and marker-backed in-place result updates; a live invocation becomes possible only after landing.
- `Confirm whether scenario-specific Mantis PR comments remain supported, then align routing tests and documentation with that decision.` — owner decision confirmed by Ayaan: PR comments invoke the single agentic Mantis Telegram Desktop proof. Scenario-specific PR comment routing is intentionally retired; the scenario workflows remain available through manual Actions dispatch. Workflow triggers, routing tests, and docs all enforce that decision.
