### PR TITLE
fix(gateway): scope startup runtime plugin loading

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -12,6 +12,7 @@ import type {
 } from "../plugins/hook-types.js";
 import { registerPluginHttpRoute } from "../plugins/http-registry.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import type { OpenClawPluginServiceContext } from "../plugins/types.js";
 import {
@@ -2478,6 +2479,28 @@ describe("startGatewayPostAttachRuntime", () => {
         ["fullCatalogConcurrencyLimitCount", 1],
       ],
     });
+  });
+
+  it("prepares the model runtime with the active Gateway plugin registry", async () => {
+    const pluginRegistry = createPostAttachParams().pluginRegistry;
+    const prewarmPrimaryModel = vi.fn(async () => {
+      expect(getPluginRuntimeGatewayRequestScope()?.pluginRegistry).toBe(pluginRegistry);
+    });
+
+    await startGatewaySidecars({
+      cfg: { hooks: { internal: { enabled: false } } } as never,
+      pluginRegistry,
+      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      deps: {} as never,
+      startChannels: vi.fn(async () => {}),
+      log: { warn: vi.fn() },
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      prewarmPrimaryModel,
+    });
+
+    expect(prewarmPrimaryModel).toHaveBeenCalledOnce();
+    expect(getPluginRuntimeGatewayRequestScope()).toBeUndefined();
   });
 
   it("marks startup main-session orphans before model runtime and channel startup", async () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -20,6 +20,7 @@ import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { getPluginModuleLoaderStats } from "../plugins/plugin-module-loader-cache.js";
 import type { PluginRegistry } from "../plugins/registry.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { sweepSessionStateWatchNotices } from "../sessions/session-state-events.js";
@@ -655,17 +656,19 @@ export async function startGatewaySidecars(params: {
   // Agent RPC remains available when transports are disabled. Publish configured/static facts before
   // accepting work; live provider catalogs stay advisory and never enter the Gateway lifecycle.
   await measureStartup(params.startupTrace, "sidecars.model-runtime", () =>
-    publishStartupModelRuntime(
-      {
-        cfg: params.cfg,
-        ...(params.pluginMetadataSnapshot
-          ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
-          : {}),
-        workspaceDir: params.defaultWorkspaceDir,
-        log: params.log,
-        startupTrace: params.startupTrace,
-      },
-      params.prewarmPrimaryModel,
+    withPluginRuntimeRegistryScope(params.pluginRegistry, () =>
+      publishStartupModelRuntime(
+        {
+          cfg: params.cfg,
+          ...(params.pluginMetadataSnapshot
+            ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
+            : {}),
+          workspaceDir: params.defaultWorkspaceDir,
+          log: params.log,
+          startupTrace: params.startupTrace,
+        },
+        params.prewarmPrimaryModel,
+      ),
     ),
   );
   // Gateway readiness owns process-stable reply module activation so the first operator turn


### PR DESCRIPTION
## Summary

- keep startup model-runtime preparation inside the active Gateway plugin registry scope
- avoid rebuilding runtime registries for every discovered plugin during readiness
- cover scope visibility and cleanup at the Gateway lifecycle boundary

## Root cause

`startGatewaySidecars` already owns the process-stable plugin registry, but its model-runtime publication ran outside `withPluginRuntimeRegistryScope`. The runtime-plugin loader therefore fell back from the active registry to every ID in the metadata snapshot. In the release-validation startup case that meant 167 plugin loader calls while only 15 plugins were active, delaying `/readyz` and retaining hundreds of MB in the Gateway process.

The existing registry scope is the canonical owner boundary. This change applies it around startup publication; it does not add a cache, fallback, retry, timeout, or threshold change.

## Validation

- Regression-first proof: the new lifecycle test failed before the production change because the model prewarm observed no active plugin registry.
- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts src/agents/runtime-plugins.test.ts` (171 tests passed)
- `pnpm build`
- Identical heap-profiled default startup benchmark:
  - before: 25.04s completion, 1,937.4 MB peak RSS, 20.42s runtime-plugin work, 167 loader calls
  - after: 12.44s completion, 1,517.4 MB peak RSS, 7.86s runtime-plugin work, 34 loader calls
- Two non-profiled fixed runs: 12.10–12.19s completion, 1,437.3–1,450.8 MB peak RSS, 34 loader calls
- Autoreview: clean, no actionable findings

## Scope

- Production delta: +3 lines net (14 added, 11 removed)
- Net-neutral attempt: the publication helper is also directly exercised by startup-selection tests, so deleting or inlining it would move/duplicate that owner contract. No obsolete branch exists at this boundary to absorb the repair. The three net lines are the existing scope-helper import plus the two delimiters required to bind an async operation; removing unrelated comments or behavior solely to reach zero would not simplify the owner.
- Test delta: +23 lines
- Sibling behavior: `src/agents/runtime-plugins.test.ts` confirms the runtime loader consumes a supplied registry scope; this change makes Gateway startup supply the lifecycle-owned instance and verifies the async scope is cleared afterward.
