### PR TITLE
fix(qa): clean up exited Telegram observers safely

### DIFF
--- a/scripts/e2e/telegram-user-driver.py
+++ b/scripts/e2e/telegram-user-driver.py
@@ -990,9 +990,20 @@ def command_terminate_observer(args):
     pgid = int(value.get("pgid") or 0)
     if value.get("socket") != args.socket or pid <= 0 or pgid <= 0 or pgid == os.getpgrp():
         raise DriverError("Telegram observer pid file is invalid.")
+    process_stat = Path(f"/proc/{pid}/stat")
+
+    def running():
+        try:
+            return process_stat.read_text().rsplit(")", 1)[1].split()[0] not in {"X", "Z"}
+        except FileNotFoundError:
+            return False
+
     try:
         command_line = Path(f"/proc/{pid}/cmdline").read_bytes()
     except FileNotFoundError:
+        command_line = b""
+    # Zombies retain their proc entry with an empty command line; they are not reused PIDs.
+    if not running():
         pid_path.unlink(missing_ok=True)
         return
     if b"telegram-user-driver" not in command_line or args.socket.encode() not in command_line or b"serve" not in command_line:
@@ -1001,14 +1012,6 @@ def command_terminate_observer(args):
         os.killpg(pgid, signal.SIGTERM)
     except ProcessLookupError:
         pass
-    process_stat = Path(f"/proc/{pid}/stat")
-
-    def running():
-        try:
-            return process_stat.read_text().rsplit(")", 1)[1].split()[0] != "Z"
-        except FileNotFoundError:
-            return False
-
     deadline = time.monotonic() + 2
     while running() and time.monotonic() < deadline:
         time.sleep(0.05)

--- a/test/scripts/telegram-user-observer.test.ts
+++ b/test/scripts/telegram-user-observer.test.ts
@@ -153,20 +153,74 @@ with tempfile.TemporaryDirectory() as root:
         "action": {"@type": "chatActionTyping"},
     })
     observer.close()
-    child = subprocess.Popen(
-        [sys.executable, "-c", "import time; time.sleep(60)", "telegram-user-driver", "serve", str(Path(root) / "observer.sock")],
-        start_new_session=True,
-    )
+    socket_path = str(Path(root) / "observer.sock")
     pid_file = Path(root) / "observer.pid.json"
-    pid_file.write_text(json.dumps({"pid": child.pid, "pgid": os.getpgid(child.pid), "socket": str(Path(root) / "observer.sock")}))
+    terminate_args = type("Args", (), {"pid_file": str(pid_file), "socket": socket_path})()
+
+    terminal = subprocess.Popen(
+        [sys.executable, "-c", "pass", "telegram-user-driver", "serve", socket_path],
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    pid_file.write_text(json.dumps({"pid": terminal.pid, "pgid": terminal.pid, "socket": socket_path}))
     pid_file.chmod(0o600)
-    module.command_terminate_observer(type("Args", (), {"pid_file": str(pid_file), "socket": str(Path(root) / "observer.sock")})())
-    child.wait(timeout=10)
+    os.waitid(os.P_PID, terminal.pid, os.WEXITED | os.WNOWAIT)
+    try:
+        module.command_terminate_observer(terminate_args)
+        terminal_marker_removed = not pid_file.exists()
+        module.command_terminate_observer(terminate_args)
+    finally:
+        terminal.wait(timeout=10)
+        pid_file.unlink(missing_ok=True)
+
+    child = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import json, os, sys, time; "
+            "marker = os.fdopen(os.open(sys.argv[1], os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600), 'w'); "
+            "json.dump({'pid': os.getpid(), 'pgid': os.getpgrp(), 'socket': sys.argv[2]}, marker); "
+            "marker.close(); print('ready', flush=True); time.sleep(60)",
+            str(pid_file),
+            socket_path,
+            "telegram-user-driver",
+            "serve",
+        ],
+        start_new_session=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    try:
+        if child.stdout.readline() != "ready\n":
+            raise AssertionError("The observer did not publish its owned marker.")
+        owned_marker = json.loads(pid_file.read_text())
+        pid_file.write_text(json.dumps({**owned_marker, "pid": os.getpid()}))
+        try:
+            module.command_terminate_observer(terminate_args)
+            raise AssertionError("Cleanup signaled a process with a mismatched identity.")
+        except module.DriverError as error:
+            foreign_error = str(error)
+        foreign_alive = child.poll() is None
+        foreign_marker_retained = pid_file.exists()
+        pid_file.write_text(json.dumps(owned_marker))
+        module.command_terminate_observer(terminate_args)
+        child.wait(timeout=10)
+        module.command_terminate_observer(terminate_args)
+    finally:
+        if child.poll() is None:
+            child.terminate()
+            child.wait(timeout=10)
+        child.stdout.close()
     print(json.dumps({
         "bystanderError": bystander_error,
         "deleted": deleted,
         "documentContent": module.UserDriver.document_content(None, "/tmp/proof.txt", "proof"),
         "events": observer.events,
+        "foreignAlive": foreign_alive,
+        "foreignError": foreign_error,
+        "foreignMarkerRetained": foreign_marker_retained,
         "mediaError": media_error,
         "pressed": pressed,
         "requests": driver.client.requests,
@@ -175,6 +229,7 @@ with tempfile.TemporaryDirectory() as root:
         "stagedMediaPrivate": staged_media_private,
         "stagedMediaName": staged_media_name,
         "truncated": observer.truncated,
+        "terminalMarkerRemoved": terminal_marker_removed,
         "terminated": child.returncode is not None,
     }))
 `;
@@ -210,7 +265,11 @@ describe("Telegram user observer", () => {
     expect(result.stdout).not.toContain("private bystander text");
     expect(result.stdout).not.toContain("pending duplicate");
     expect(value.truncated).toBe(true);
+    expect(value.terminalMarkerRemoved).toBe(true);
     expect(value.terminated).toBe(true);
+    expect(value.foreignAlive).toBe(true);
+    expect(value.foreignMarkerRetained).toBe(true);
+    expect(value.foreignError).toBe("Telegram observer process identity changed before cleanup.");
     expect(value.bystanderError).toBe("Message 125 was not observed in this session.");
     expect(value.mediaError).toBe(
       "Media must be a regular file inside the Mantis output directory.",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where the Telegram Desktop QA observer cleanup could fail an otherwise successful proof or main CI run when its process had already exited but had not yet been reaped. The observed failure was `Telegram observer process identity changed before cleanup.` in [main CI run 32379506517](https://github.com/openclaw/openclaw/actions/runs/32379506517).

## Why This Change Was Made

Linux zombies retain `/proc/<pid>/stat` with terminal state `Z` while exposing an empty `/proc/<pid>/cmdline`. The existing observer terminator checked that empty command line before consulting its own process-state helper, so it mistook an already-terminal owned observer for PID reuse. Reuse the existing authoritative terminal-state check before rejecting process identity, retain the unchanged fail-closed error for a live mismatched process, and make the regression fixture wait for the child itself to publish its private owned marker.

## User Impact

No OpenClaw product behavior or configuration changes. Telegram Desktop proof cleanup becomes idempotent after natural observer exit, main CI no longer depends on a child startup race, and unrelated live process groups remain protected from signals.

## Evidence

- Reproduced the exact exception before changing the driver with a real Linux child: `os.waitid(os.P_PID, pid, os.WEXITED | os.WNOWAIT)` produced `terminal-state=Z`, `cmdline-bytes=0`, and the original `DriverError`.
- Added the regression first and confirmed `node scripts/run-vitest.mjs test/scripts/telegram-user-observer.test.ts` failed on the unmodified driver with the same traceback; after the fix it passed once and then passed five consecutive bounded reruns on Linux.
- The real-process regression also proves that a live foreign PID retains its marker, the unrelated observer child remains alive, an owned live child is terminated, an already-terminal child removes its marker, and repeated cleanup is harmless.
- Related owner/sibling coverage: `node scripts/run-vitest.mjs test/scripts/telegram-user-observer.test.ts test/scripts/telegram-mantis-lane.test.ts test/scripts/vitest-process-group.test.ts test/scripts/managed-child-process.test.ts` — observer plus 71 sibling tests passed.
- Shared-state coverage: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/managed-child-process.test.ts test/scripts/vitest-process-group.test.ts test/scripts/telegram-mantis-lane.test.ts test/scripts/telegram-user-observer.test.ts --isolate=false` — 71 selected tooling tests passed in one non-isolated process.
- Reconstructed and reran the exact original `checks-node-compact-large-19` / `core-unit-fast-2` CI stripe through `scripts/ci-run-node-test-shard.mts`, preserving all 637 ordered files, observer position 628, four workers, and explicit `--isolate=false` — **636 files passed, one skipped; 7,128 tests passed, six skipped**.
- Linux evidence ran on task-owned Blacksmith Testbox lease `tbx_01m0ftf6xp1r6e2rv7vhb4pxn6`, which was stopped after proof.
- `node scripts/check-changed.mjs -- scripts/e2e/telegram-user-driver.py test/scripts/telegram-user-observer.test.ts` — formatting, guards, root-test typechecking, and script lint passed.
- `PYTHONPYCACHEPREFIX=/private/tmp/openclaw-autoqa25-python-cache python3 -m py_compile scripts/e2e/telegram-user-driver.py` and `git diff --check` passed.
- Fresh Codex autoreview completed with no accepted or actionable findings.
- Tooling LOC: `+11/-8` (net `+3`, required to distinguish terminal owned processes from live PID reuse); regression-test LOC: `+65/-6`.

AI-assisted; no agent transcript included.
