### PR TITLE
fix(agents): keep newest background process sessions visible

### DIFF
--- a/src/agents/bash-process-references.test.ts
+++ b/src/agents/bash-process-references.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { listActiveProcessSessionReferences } from "./bash-process-references.js";
 import { addSession, deleteSession } from "./bash-process-registry.js";
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 
-describe("bash-process-references truncation", () => {
+afterEach(() => {
+  resetProcessRegistryForTests();
+});
+
+describe("bash-process-references", () => {
+  function registerScopedSession(id: string, startedAt = 1_000) {
+    const session = createProcessSessionFixture({ id, startedAt, backgrounded: true });
+    session.scopeKey = "scope-a";
+    addSession(session);
+  }
+
   it("keeps scoped session labels valid when the limit bisects an emoji", () => {
     const command = `${"a".repeat(136)}😀xyz`;
     const session = createProcessSessionFixture({
@@ -16,12 +27,48 @@ describe("bash-process-references truncation", () => {
     session.scopeKey = "scope-a";
     addSession(session);
 
-    try {
-      const [reference] = listActiveProcessSessionReferences({ scopeKey: "scope-a", now: 2 });
-      expect(reference?.name).toBe(`${"a".repeat(136)}...`);
-      expect(reference?.pid).toBe(4242);
-    } finally {
-      deleteSession("emoji-proc-scoped");
+    const [reference] = listActiveProcessSessionReferences({ scopeKey: "scope-a", now: 2 });
+    expect(reference?.name).toBe(`${"a".repeat(136)}...`);
+    expect(reference?.pid).toBe(4242);
+  });
+
+  it("keeps the newest eight registrations when their start timestamps match", () => {
+    for (let index = 1; index <= 9; index += 1) {
+      registerScopedSession(`session-${index}`);
     }
+
+    expect(
+      listActiveProcessSessionReferences({ scopeKey: "scope-a", now: 2_000 }).map(
+        ({ sessionId }) => sessionId,
+      ),
+    ).toEqual(Array.from({ length: 8 }, (_, index) => `session-${9 - index}`));
+  });
+
+  it("preserves timestamp precedence when registration order differs", () => {
+    for (const [id, startedAt] of [
+      ["later-clock", 2_000],
+      ["earlier-clock", 1_000],
+    ] as const) {
+      registerScopedSession(id, startedAt);
+    }
+
+    expect(
+      listActiveProcessSessionReferences({ scopeKey: "scope-a", now: 3_000 }).map(
+        ({ sessionId }) => sessionId,
+      ),
+    ).toEqual(["later-clock", "earlier-clock"]);
+  });
+
+  it("keeps registration chronology unambiguous after removal and id reuse", () => {
+    registerScopedSession("removed-first");
+    registerScopedSession("retained-second");
+    deleteSession("removed-first");
+    registerScopedSession("removed-first");
+
+    expect(
+      listActiveProcessSessionReferences({ scopeKey: "scope-a", now: 2_000 }).map(
+        ({ sessionId }) => sessionId,
+      ),
+    ).toEqual(["removed-first", "retained-second"]);
   });
 });

--- a/src/agents/bash-process-references.ts
+++ b/src/agents/bash-process-references.ts
@@ -4,7 +4,7 @@
  * reconnect to prior long-running work.
  */
 import { truncateUtf16Safe, truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
-import { listRunningSessions } from "./bash-process-registry.js";
+import { compareProcessSessionStartOrder, listRunningSessions } from "./bash-process-registry.js";
 import { deriveSessionName } from "./bash-tools.shared.js";
 
 const DEFAULT_ACTIVE_PROCESS_LIMIT = 8;
@@ -50,9 +50,8 @@ export function listActiveProcessSessionReferences(params: {
       ? Math.floor(params.limit)
       : DEFAULT_ACTIVE_PROCESS_LIMIT;
   return listRunningSessions()
-    .filter((session) => session.backgrounded)
     .filter((session) => session.scopeKey === scopeKey)
-    .toSorted((left, right) => right.startedAt - left.startedAt)
+    .toSorted(compareProcessSessionStartOrder)
     .slice(0, limit)
     .map((session) => ({
       sessionId: session.id,

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -135,6 +135,9 @@ interface FinishedSession {
 const runningSessions = new Map<string, ProcessSession>();
 const finishedSessions = new Map<string, FinishedSession>();
 let finishedSessionsByProcess = new WeakMap<ProcessSession, FinishedSession>();
+// Keep start chronology private while snapshots retain their completion-order eviction contract.
+let processSessionStartOrders = new WeakMap<object, number>();
+let nextProcessSessionStartOrder = 0;
 const activeBackgroundExecSessionIds = new Set<string>();
 let finishedSessionOutputChars = 0;
 
@@ -149,8 +152,20 @@ export function isProcessSessionIdTaken(id: string): boolean {
 
 /** Adds a running session and starts retention sweeping if needed. */
 export function addSession(session: ProcessSession) {
+  processSessionStartOrders.set(session, nextProcessSessionStartOrder++);
   runningSessions.set(session.id, session);
   startSweeper();
+}
+
+/** Sorts registered process records newest-first, including same-millisecond starts. */
+export function compareProcessSessionStartOrder(
+  left: { startedAt: number },
+  right: { startedAt: number },
+): number {
+  return (
+    right.startedAt - left.startedAt ||
+    processSessionStartOrders.get(right)! - processSessionStartOrders.get(left)!
+  );
 }
 
 /** Returns a running session by id. */
@@ -368,6 +383,7 @@ function moveToFinished(session: ProcessSession, status: ProcessStatus) {
     ...(session.terminalPollObserved ? { terminalPollObserved: true } : {}),
     ...(session.notifyOnExitRemoval ? { notifyOnExitRemoval: session.notifyOnExitRemoval } : {}),
   };
+  processSessionStartOrders.set(finished, processSessionStartOrders.get(session)!);
   finishedSessionsByProcess.set(session, finished);
   finishedSessions.set(session.id, finished);
   finishedSessionOutputChars += session.aggregated.length;
@@ -440,6 +456,8 @@ function resetProcessRegistryForTests() {
   runningSessions.clear();
   finishedSessions.clear();
   finishedSessionsByProcess = new WeakMap();
+  processSessionStartOrders = new WeakMap();
+  nextProcessSessionStartOrder = 0;
   finishedSessionOutputChars = 0;
   activeBackgroundExecSessionIds.clear();
   stopSweeper();

--- a/src/agents/bash-tools.process.input-hints.test.ts
+++ b/src/agents/bash-tools.process.input-hints.test.ts
@@ -250,3 +250,57 @@ describe("process input-wait hints", () => {
     });
   });
 });
+
+describe("process session list chronology", () => {
+  async function expectProcessListOrder(processTool: ProcessTool, expectedIds: string[]) {
+    const result = await runProcessAction(processTool, { action: "list" });
+    const records = (result.details as { sessions: Array<{ sessionId: string }> }).sessions;
+    expect(records.map(({ sessionId }) => sessionId)).toEqual(expectedIds);
+    expect(
+      textOf(result)
+        .split("\n")
+        .map((line) => line.split(" ")[0]),
+    ).toEqual(expectedIds);
+    for (const record of records) {
+      expect(record).not.toHaveProperty("startOrder");
+    }
+  }
+
+  it("keeps equal-timestamp text and details newest-first across terminal transitions", async () => {
+    const sessions = ["z-oldest", "a-middle", "m-newest"].map((id) => {
+      const session = createProcessSessionFixture({
+        id,
+        startedAt: 1_000,
+        backgrounded: true,
+      });
+      addSession(session);
+      return session;
+    });
+    const processTool = createProcessTool();
+    const expectedIds = ["m-newest", "a-middle", "z-oldest"];
+
+    await expectProcessListOrder(processTool, expectedIds);
+    markExited(sessions[0]!, 0, null, "completed");
+    await expectProcessListOrder(processTool, expectedIds);
+    markExited(sessions[2]!, 0, null, "completed");
+    await expectProcessListOrder(processTool, expectedIds);
+    markExited(sessions[1]!, 0, null, "completed");
+    await expectProcessListOrder(processTool, expectedIds);
+  });
+
+  it("keeps actual start timestamps ahead of registration chronology", async () => {
+    for (const [id, startedAt] of [
+      ["middle-clock", 2_000],
+      ["later-clock", 3_000],
+      ["earlier-clock", 1_000],
+    ] as const) {
+      addSession(createProcessSessionFixture({ id, startedAt, backgrounded: true }));
+    }
+
+    await expectProcessListOrder(createProcessTool(), [
+      "later-clock",
+      "middle-clock",
+      "earlier-clock",
+    ]);
+  });
+});

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -11,6 +11,7 @@ import { cancelBackgroundExecSession } from "./bash-process-control.js";
 import {
   acknowledgeNotifyOnExit,
   type ProcessSession,
+  compareProcessSessionStartOrder,
   deleteSession,
   drainFinishedSession,
   drainSession,
@@ -316,9 +317,26 @@ export function createProcessTool(
       };
 
       if (params.action === "list") {
-        const running = listRunningSessions()
+        const sessions = [...listRunningSessions(), ...listFinishedSessions()]
           .filter((s) => isInScope(s))
+          .toSorted(compareProcessSessionStartOrder)
           .map((s) => {
+            if ("endedAt" in s) {
+              return {
+                sessionId: s.id,
+                status: s.status,
+                startedAt: s.startedAt,
+                endedAt: s.endedAt,
+                runtimeMs: s.endedAt - s.startedAt,
+                cwd: s.cwd,
+                command: s.command,
+                name: deriveSessionName(s.command),
+                tail: s.tail,
+                truncated: s.truncated,
+                exitCode: s.exitCode ?? undefined,
+                exitSignal: s.exitSignal ?? undefined,
+              };
+            }
             const runtime = describeRunningSession(s);
             return {
               sessionId: s.id,
@@ -337,31 +355,13 @@ export function createProcessTool(
               lastOutputAt: runtime.lastOutputAt,
             };
           });
-        const finished = listFinishedSessions()
-          .filter((s) => isInScope(s))
-          .map((s) => ({
-            sessionId: s.id,
-            status: s.status,
-            startedAt: s.startedAt,
-            endedAt: s.endedAt,
-            runtimeMs: s.endedAt - s.startedAt,
-            cwd: s.cwd,
-            command: s.command,
-            name: deriveSessionName(s.command),
-            tail: s.tail,
-            truncated: s.truncated,
-            exitCode: s.exitCode ?? undefined,
-            exitSignal: s.exitSignal ?? undefined,
-          }));
-        const lines = [...running, ...finished]
-          .toSorted((a, b) => b.startedAt - a.startedAt)
-          .map((s) => {
-            const label = s.name ? truncateMiddle(s.name, 80) : truncateMiddle(s.command, 120);
-            const marker = "waitingForInput" in s && s.waitingForInput ? " [input-wait]" : "";
-            return `${s.sessionId} ${padProcessStatus(s.status, 9)} ${
-              formatDurationCompact(s.runtimeMs) ?? "n/a"
-            }${marker} :: ${label}`;
-          });
+        const lines = sessions.map((s) => {
+          const label = s.name ? truncateMiddle(s.name, 80) : truncateMiddle(s.command, 120);
+          const marker = "waitingForInput" in s && s.waitingForInput ? " [input-wait]" : "";
+          return `${s.sessionId} ${padProcessStatus(s.status, 9)} ${
+            formatDurationCompact(s.runtimeMs) ?? "n/a"
+          }${marker} :: ${label}`;
+        });
         return {
           content: [
             {
@@ -369,7 +369,7 @@ export function createProcessTool(
               text: lines.join("\n") || "No running or recent sessions.",
             },
           ],
-          details: { status: "completed", sessions: [...running, ...finished] },
+          details: { status: "completed", sessions },
         };
       }
 

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -287,6 +287,25 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     }
   });
 
+  it("keeps same-timestamp process references newest-first in compaction context", () => {
+    for (const id of ["z-oldest", "a-middle", "m-newest"]) {
+      const session = createProcessSessionFixture({ id, startedAt: 1_000, backgrounded: true });
+      session.scopeKey = "agent:main:thread:1";
+      addSession(session);
+    }
+
+    const result = buildEmbeddedCompactionRuntimeContext({
+      sessionKey: "agent:main:thread:1",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(result.activeProcessSessions?.map(({ sessionId }) => sessionId)).toEqual([
+      "m-newest",
+      "a-middle",
+      "z-oldest",
+    ]);
+  });
+
   it("omits active process session references when no safe scope is available", () => {
     const active = createProcessSessionFixture({
       id: "sess-active",


### PR DESCRIPTION
Closes #126693

AI-assisted: yes

## What Problem This Solves

Fixes an issue where agents launching several background commands in the same millisecond would lose their newest reconnectable process from model-visible prompt and compaction context because the eight-session cap retained older registrations instead. The process tool could also reverse its visible order when a session finished, and its structured session list could disagree with its rendered text even when start timestamps differed.

## Why This Change Was Made

Record a private, monotonic start ordinal at the in-memory registry boundary that owns process registration, carry that fact onto each exact finished snapshot, and share one timestamp-first/newest-registration-first comparator between active prompt references and process-list presentation. Sort original running and finished records once before projecting them, then reuse that ordered projection for both process-tool text and structured details.

The ordinal is held in registry-private weak maps only: no session payload, public type, plugin SDK, persistence, configuration, protocol, or model-visible output gains a field. Finished-session retention continues to evict by completion order, and the existing registry test reset clears both private chronology and its counter.

## User Impact

Agents consistently see the eight newest reconnectable background processes, including simultaneous launches, and process-list text and structured details remain in identical newest-first order across running-to-finished transitions. Existing completion-based retention and ordinary unequal-timestamp ordering remain intact.

## Evidence

- Before the fix, focused regressions reproduced the missing ninth same-millisecond process, ID reuse ordering, contradictory structured process details, and misordered compaction context.
- After the fix, focused registry, process-reference, process-tool, prompt-stability, embedded-prompt, and compaction tests passed, including real background-process lifecycle E2E coverage and completion-order retention coverage.
- Three repeated non-isolated registry/process passes exercise module-state cleanup, equal timestamps, removal, ID reuse, lifecycle transitions, and timestamp precedence.
- The scoped changed-file gate covers formatting, production/test types, lint, and repository boundary guards.
- A fresh Codex-backed P1 autoreview and a separate independent adversarial owner-boundary review both reported no actionable findings.
- Production LOC: +47/-30, net +17. Test LOC: +128/-8, net +120. The small production increase is necessary because registration order otherwise disappears when a transient running record becomes a completion-ordered finished snapshot; random session IDs and map completion order cannot recover that fact.
- Risk: low; the change is limited to transient process-registry ordering and does not change retention, configuration, persistence, protocol, security, or public session shapes.
