### PR TITLE
chore(macos): update Peekaboo source

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9192d83763432d1dc27bc11b5af000b4c5f3d3515e3ddefb673899c4f97e0c31",
+  "originHash" : "949a355d05c2a77feedbaf17a498146c576e7e7c8b12a741670a37cfb2501561",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -60,7 +60,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/Peekaboo.git",
       "state" : {
-        "revision" : "05675b0b5e2c382146963e19493787d9dac0d45b"
+        "revision" : "028cd9eb2d7b413c26f02f169c5f6224b2fcb3e0"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
         .package(
             url: "https://github.com/openclaw/Peekaboo.git",
-            revision: "05675b0b5e2c382146963e19493787d9dac0d45b"),
+            revision: "028cd9eb2d7b413c26f02f169c5f6224b2fcb3e0"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.3.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),


### PR DESCRIPTION
## What Problem This Solves

OpenClaw's macOS app is still pinned to the released Peekaboo 4.2.2 source, so future macOS app and elevation-host builds miss the current Peekaboo Bridge hardening already present on upstream `main`.

## Why This Change Was Made

Pin Peekaboo to the exact reviewed upstream commit `028cd9eb2d7b413c26f02f169c5f6224b2fcb3e0` (`v4.2.2-8-g028cd9eb`) and regenerate the SwiftPM lockfile origin hash. All other dependency pins remain byte-identical; there is no vendoring or moving branch reference, and the existing `PeekabooBridge` and `PeekabooAutomationKit` package products are unchanged.

## User Impact

Future macOS app and elevation-host builds embed process-generation observation, receipt-bound mutation authority, stronger set-value target verification, and additive Peekaboo Bridge protocol 1.32 behavior. This PR does not package or release an app.

## Evidence

- Source pin: `05675b0b5e2c382146963e19493787d9dac0d45b` (`v4.2.2`) -> `028cd9eb2d7b413c26f02f169c5f6224b2fcb3e0` (`v4.2.2-8-g028cd9eb`).
- SwiftPM origin hash: `949a355d05c2a77feedbaf17a498146c576e7e7c8b12a741670a37cfb2501561`; every non-Peekaboo lockfile pin is unchanged.
- `swift package --package-path apps/macos resolve` passed.
- `swift build --package-path apps/macos --configuration release` passed; existing unrelated warnings only.
- `env OPENCLAW_PEEKABOO_HANDSHAKE_CLI=/opt/homebrew/bin/peekaboo swift test --package-path apps/macos -Xlinker -rpath -Xlinker '@loader_path/../../..' --filter 'PeekabooBridgeHostCoordinatorTests|ComputerRefLifecycleContractTests'` passed: 7 tests across 2 suites, including a real signed CLI socket handshake.
- `pnpm test:macos:ci` passed: 7 Vitest shards and 487 tests.
- `pnpm test:changed` found no precise targets and skipped cleanly.
- `./scripts/lint-swift.sh macos` passed: 334 root Swift files plus 22 Swabble files, with 0 violations.
- Native state schema version guard passed at v9.
- Dependency pin, patch, coercion, duplicate, conflict, changelog, doctor, wildcard, and formatting checks passed through the exact `check:changed` app plan. The monolithic wrapper twice exceeded the local 10-minute harness ceiling while scanning all native app Swift, so the same app plan was run in split commands and completed green.
- `git diff --check` passed, including after rebasing onto the latest `origin/main`.
- Production code: +0/-0. Tests: +0/-0. Dependency metadata: +3/-3.

AI-assisted: yes. I reviewed the exact dependency diff, upstream package/Bridge contracts, generated lockfile, macOS build, tests, and handshake.
