### PR TITLE
fix(policy): keep unknown-agent guidance runnable under profiles

### DIFF
--- a/extensions/policy/src/cli.agent-owner.test.ts
+++ b/extensions/policy/src/cli.agent-owner.test.ts
@@ -167,12 +167,45 @@ describe("policy CLI agent ownership", () => {
     expect(output.join("\n")).toContain("Pass --agent <id>.");
   });
 
-  it("rejects an unknown explicit owner", async () => {
+  it.each([
+    {
+      name: "check without root options",
+      args: ["check", "--agent", "ghost", "--json"],
+      profile: "",
+      container: "",
+      hint: "openclaw agents list",
+    },
+    {
+      name: "check with an active profile",
+      args: ["check", "--agent", "ghost", "--json"],
+      profile: "testprof",
+      container: "",
+      hint: "openclaw --profile testprof agents list",
+    },
+    {
+      name: "watch with an active profile",
+      args: ["watch", "--agent", "ghost", "--once", "--json"],
+      profile: "testprof",
+      container: "",
+      hint: "openclaw --profile testprof agents list",
+    },
+    {
+      name: "relative compare with an active container",
+      args: ["compare", "--agent", "ghost", "--baseline", "baseline.policy.jsonc", "--json"],
+      profile: "testprof",
+      container: "testbox",
+      hint: "openclaw --container testbox agents list",
+    },
+  ])("rejects an unknown explicit owner for $name with runnable guidance", async (testCase) => {
     await writeExplicitFleetConfig();
+    vi.stubEnv("OPENCLAW_PROFILE", testCase.profile);
+    vi.stubEnv("OPENCLAW_CONTAINER_HINT", testCase.container);
 
-    const { exitCode, output } = await runPolicyCli(["check", "--agent", "ghost", "--json"]);
+    const { exitCode, output } = await runPolicyCli(testCase.args);
 
     expect(exitCode).toBe(2);
-    expect(output.join("\n")).toContain('Unknown agent id "ghost"');
+    expect(output.join("\n")).toContain(
+      `Unknown agent id "ghost". Run ${testCase.hint} to see configured agents.`,
+    );
   });
 });

--- a/extensions/policy/src/cli.ts
+++ b/extensions/policy/src/cli.ts
@@ -2,19 +2,19 @@
 import { isAbsolute, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import type { Command } from "commander";
-import { listAgentIds } from "openclaw/plugin-sdk/agent-runtime";
+import { listAgentIds, resolveDefaultAgentId } from "openclaw/plugin-sdk/agent-scope-runtime";
 import {
   exitCodeFromFindings,
   healthFindingMeetsSeverity,
   parseHealthFindingSeverity,
   readConfigFileSnapshot,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
   type HealthCheckContext,
   type HealthFinding,
 } from "openclaw/plugin-sdk/health";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { defaultRuntime as cliRuntime } from "openclaw/plugin-sdk/runtime";
+import { formatCliCommand } from "openclaw/plugin-sdk/setup-tools";
 import { POLICY_FIX_METADATA_BY_CHECK_ID } from "./doctor/fix-metadata.js";
 import { POLICY_CHECK_IDS, evaluatePolicy } from "./doctor/register.js";
 import {
@@ -290,7 +290,7 @@ function resolvePolicyCommandAgentId(
     const agentId = normalizeAgentId(requestedAgentId);
     if (!listAgentIds(cfg).includes(agentId)) {
       throw new Error(
-        `Unknown agent id "${requestedAgentId}". Run \`openclaw agents list\` to see configured agents.`,
+        `Unknown agent id "${requestedAgentId}". Run ${formatCliCommand("openclaw agents list")} to see configured agents.`,
       );
     }
     return agentId;


### PR DESCRIPTION
Related: #126570

## What Problem This Solves

Fixes an issue where operators selecting an unknown agent on `openclaw policy check`, `watch`, or `compare` received an `openclaw agents list` recovery command that dropped their active profile or container and could not be pasted back successfully.

## Why This Change Was Made

The policy plugin now formats its recovery command through the existing narrow `setup-tools` Plugin SDK entrypoint and reads both agent-selection helpers through the existing narrow `agent-scope-runtime` entrypoint. This removes its deprecated broad `agent-runtime` import without adding any public SDK exports, compatibility surface, or production lines.

## User Impact

An unknown policy agent now recommends the runnable command for the actual invocation, including `openclaw --profile testprof agents list` or `openclaw --container testbox agents list`. Container guidance correctly takes precedence when both hints exist.

## Evidence

- Before the fix, the four registered-CLI regression cases failed: default `check`, profiled `check`, profiled `watch`, and container-over-profile `compare`.
- After the fix, `OPENCLAW_STATE_DIR=/tmp/openclaw-policy-profile-vitest-b5c8 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-policy-vitest-cache-b5c8 node scripts/run-vitest.mjs extensions/policy/src/cli.agent-owner.test.ts extensions/policy/src/cli.test.ts --configLoader runner` passed **46 tests across 2 files**.
- Live source-backed policy CLI with isolated state returned `Unknown agent id "nope-zzz". Run openclaw --profile testprof agents list to see configured agents.` and, with both hints active, `Unknown agent id "nope-zzz". Run openclaw --container testbox agents list to see configured agents.` Both exited nonzero as intended.
- `node scripts/check-changed.mjs -- extensions/policy/src/cli.ts extensions/policy/src/cli.agent-owner.test.ts` passed on Blacksmith Testbox `tbx_01m0fvfmprzxr9p190a71pr82f`: https://github.com/openclaw/openclaw/actions/runs/32384388330.
- Mandatory structured autoreview: clean, no accepted/actionable findings.
- Production LOC: `+3/-3` (net `0`); tests: `+36/-3`.
- AI-assisted; no changelog changes.
