### PR TITLE
fix(matrix): recover providers after late operations finish

### DIFF
--- a/extensions/matrix/src/matrix/client/shared.test.ts
+++ b/extensions/matrix/src/matrix/client/shared.test.ts
@@ -318,6 +318,34 @@ describe("shared Matrix client generations", () => {
     ]);
   });
 
+  it("retries admission when retirement starts after state resolution", async () => {
+    const retiringClient = createMockClient("retiring");
+    const replacementClient = createMockClient("replacement");
+    createMatrixClientMock
+      .mockResolvedValueOnce(retiringClient)
+      .mockResolvedValueOnce(replacementClient);
+    const auth = authFor("main");
+    const monitor = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    monitor.registerMonitorRetirement(createMonitorRetirement([]));
+
+    const racingAcquire = acquireSharedMatrixClient({ auth, startClient: false });
+    let retirement: Promise<void> | undefined;
+    queueMicrotask(() => {
+      retirement = monitor.release({ mode: "discard" });
+    });
+
+    const racingLease = await racingAcquire;
+    await racingLease.release({ mode: "discard" });
+    await retirement;
+
+    expect(racingLease.client).toBe(replacementClient);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(2);
+  });
+
   it("signals cooperative transient work and persists after it drains", async () => {
     const callOrder: string[] = [];
     const client = createMockClient("main", callOrder);
@@ -360,18 +388,24 @@ describe("shared Matrix client generations", () => {
     expect(client.stopWithoutPersist).not.toHaveBeenCalled();
   });
 
-  it("bounds non-cooperative transient drain and makes late release harmless", async () => {
+  it("bounds non-cooperative transient drain and replaces after every late release", async () => {
     vi.useFakeTimers();
     const callOrder: string[] = [];
     const client = createMockClient("main", callOrder);
-    createMatrixClientMock.mockResolvedValue(client);
+    const replacementClient = createMockClient("replacement");
+    createMatrixClientMock.mockResolvedValueOnce(client).mockResolvedValueOnce(replacementClient);
     const auth = authFor("main");
     const monitor = await acquireSharedMatrixClient({
       auth,
       role: "monitor",
       startClient: false,
     });
-    const transient = await acquireSharedMatrixClient({
+    const firstTransient = await acquireSharedMatrixClient({
+      auth,
+      role: "transient",
+      startClient: false,
+    });
+    const finalTransient = await acquireSharedMatrixClient({
       auth,
       role: "transient",
       startClient: false,
@@ -390,7 +424,8 @@ describe("shared Matrix client generations", () => {
     await expect(retirementError).resolves.toMatchObject({
       message: "Matrix transient leases did not drain within 5000ms",
     });
-    expect(transient.abortSignal.aborted).toBe(true);
+    expect(firstTransient.abortSignal.aborted).toBe(true);
+    expect(finalTransient.abortSignal.aborted).toBe(true);
     expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
     expect(client.stopAndPersist).not.toHaveBeenCalled();
     await expect(acquireSharedMatrixClient({ auth })).rejects.toMatchObject({
@@ -398,12 +433,100 @@ describe("shared Matrix client generations", () => {
     });
     expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
 
-    const firstLateRelease = transient.release({ mode: "persist" });
-    const secondLateRelease = transient.release({ mode: "persist" });
-    expect(secondLateRelease).toBe(firstLateRelease);
+    const firstLateRelease = firstTransient.release({ mode: "persist" });
+    const duplicateLateRelease = firstTransient.release({ mode: "persist" });
+    expect(duplicateLateRelease).toBe(firstLateRelease);
     await firstLateRelease;
     expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
     expect(client.stopAndPersist).not.toHaveBeenCalled();
+    await expect(acquireSharedMatrixClient({ auth })).rejects.toMatchObject({
+      message: "Matrix transient leases did not drain within 5000ms",
+    });
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+
+    await finalTransient.release({ mode: "persist" });
+
+    const [firstReplacement, secondReplacement] = await Promise.all([
+      acquireSharedMatrixClient({ auth, startClient: false }),
+      acquireSharedMatrixClient({ auth, startClient: false }),
+    ]);
+    expect(firstReplacement.client).toBe(replacementClient);
+    expect(secondReplacement.client).toBe(replacementClient);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(2);
+    await firstReplacement.release({ mode: "discard" });
+    await secondReplacement.release({ mode: "discard" });
+  });
+
+  it("keeps monitor cleanup poison after every late transient releases", async () => {
+    vi.useFakeTimers();
+    const cause = new Error("monitor cleanup failed");
+    const client = createMockClient("main");
+    createMatrixClientMock.mockResolvedValue(client);
+    const auth = authFor("main");
+    const monitor = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    const transient = await acquireSharedMatrixClient({
+      auth,
+      role: "transient",
+      startClient: false,
+    });
+    const monitorRetirement = createMonitorRetirement([]);
+    monitorRetirement.cleanup.mockRejectedValue(cause);
+    monitor.registerMonitorRetirement(monitorRetirement);
+
+    const retirementError = monitor.release({ mode: "persist" }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(retirementError).resolves.toBe(cause);
+    await transient.release();
+
+    await expect(acquireSharedMatrixClient({ auth })).rejects.toBe(cause);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps poison when the poisoned decryption drain fails before a late release", async () => {
+    vi.useFakeTimers();
+    const cause = new Error("poisoned decryption drain failed");
+    const client = createMockClient("main");
+    client.drainPendingDecryptions.mockImplementation(async (reason: string) => {
+      if (reason === "matrix poisoned client shutdown") {
+        throw cause;
+      }
+    });
+    createMatrixClientMock.mockResolvedValue(client);
+    const auth = authFor("main");
+    const monitor = await acquireSharedMatrixClient({
+      auth,
+      role: "monitor",
+      startClient: false,
+    });
+    const transient = await acquireSharedMatrixClient({
+      auth,
+      role: "transient",
+      startClient: false,
+    });
+    monitor.registerMonitorRetirement(createMonitorRetirement([]));
+
+    const retirementError = monitor.release({ mode: "persist" }).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+    await expect(retirementError).resolves.toMatchObject({
+      message: "Matrix transient leases did not drain within 5000ms",
+    });
+    await transient.release();
+
+    await expect(acquireSharedMatrixClient({ auth })).rejects.toMatchObject({
+      message: "Matrix transient leases did not drain within 5000ms",
+    });
+    expect(client.stopWithoutPersist).toHaveBeenCalledTimes(1);
+    expect(createMatrixClientMock).toHaveBeenCalledTimes(1);
   });
 
   it("quiesces and cleans up the monitor before waiting for an existing transient lease", async () => {

--- a/extensions/matrix/src/matrix/client/shared.ts
+++ b/extensions/matrix/src/matrix/client/shared.ts
@@ -36,7 +36,14 @@ export type SharedMatrixClientLease = {
   release: (params?: { mode?: MatrixClientReleaseMode }) => Promise<void>;
 };
 
-type SharedMatrixClientPhase = "open" | "quiescing" | "closing";
+type SharedMatrixClientPhase =
+  | "open"
+  | "quiescing"
+  | "closing"
+  | "late-drain"
+  | "late-drain-stopped";
+
+type PoisonDisposition = "replace-after-stop" | "replace-after-late-drain" | "retain";
 
 type SharedMatrixClientLeaseState = {
   abortController: AbortController;
@@ -131,6 +138,12 @@ function deleteSharedClientState(state: SharedMatrixClientState): void {
     sharedClientStates.delete(state.key);
   }
   sharedClientPromises.delete(state.key);
+}
+
+function deleteSharedClientStateAfterLateDrain(state: SharedMatrixClientState): void {
+  if (state.phase === "late-drain-stopped" && state.leases.size === 0) {
+    deleteSharedClientState(state);
+  }
 }
 
 async function ensureSharedClientStarted(
@@ -319,6 +332,10 @@ async function waitForLeaseDrain(state: SharedMatrixClientState): Promise<void> 
       state.noLeases.promise,
       new Promise<never>((_, reject) => {
         deadline = setTimeout(() => {
+          if (state.leases.size === 0) {
+            return;
+          }
+          state.phase = "late-drain";
           reject(
             new Error(
               `Matrix transient leases did not drain within ${MATRIX_TRANSIENT_LEASE_DRAIN_TIMEOUT_MS}ms`,
@@ -345,21 +362,20 @@ function beginGenerationRetirement(params: {
   }
   state.phase = "quiescing";
   state.retirementPromise = Promise.resolve().then(async () => {
-    let canReplacePoisonedGeneration = false;
+    let poisonDisposition: PoisonDisposition = "replace-after-stop";
     try {
       await state.client.quiesceSync();
       state.started = false;
       await state.client.drainPendingDecryptions("matrix monitor sync quiesce");
     } catch (error) {
       state.poisonError = toRetirementError(error);
-      canReplacePoisonedGeneration = true;
     }
 
     try {
       await retireMonitorLeases(state, params.monitorLeases ?? []);
     } catch (error) {
       state.poisonError ??= toRetirementError(error);
-      canReplacePoisonedGeneration = false;
+      poisonDisposition = "retain";
     }
 
     state.phase = "closing";
@@ -367,8 +383,9 @@ function beginGenerationRetirement(params: {
       await waitForLeaseDrain(state);
     } catch (error) {
       state.poisonError ??= toRetirementError(error);
-      canReplacePoisonedGeneration = false;
-      forceReleaseLeases(state);
+      if (poisonDisposition !== "retain") {
+        poisonDisposition = "replace-after-late-drain";
+      }
     }
 
     if (state.poisonError) {
@@ -379,10 +396,15 @@ function beginGenerationRetirement(params: {
           () => false,
         );
       state.client.stopWithoutPersist();
-      // Only sync/decryption poison is replaceable, after every other owner retired
-      // and the discarded client conclusively drained and stopped.
-      if (canReplacePoisonedGeneration && decryptionsDrained) {
-        deleteSharedClientState(state);
+      if (decryptionsDrained) {
+        if (poisonDisposition === "replace-after-stop") {
+          deleteSharedClientState(state);
+        } else if (poisonDisposition === "replace-after-late-drain") {
+          // The timeout cannot revoke ownership. Keep the stopped generation keyed
+          // until every operation that crossed the deadline genuinely returns.
+          state.phase = "late-drain-stopped";
+          deleteSharedClientStateAfterLateDrain(state);
+        }
       }
       throw state.poisonError;
     }
@@ -417,7 +439,12 @@ function beginGenerationRetirement(params: {
 function createSharedMatrixClientLease(
   state: SharedMatrixClientState,
   role: MatrixClientLeaseRole,
-): SharedMatrixClientLease {
+): SharedMatrixClientLease | null {
+  // Resolution awaits auth/retirement and can yield after observing an open state.
+  // Recheck synchronously at admission so retirement cannot miss a late-added owner.
+  if (state.phase !== "open" || state.poisonError) {
+    return null;
+  }
   const leaseState: SharedMatrixClientLeaseState = {
     abortController: new AbortController(),
     monitorRetirement: null,
@@ -465,6 +492,12 @@ function createSharedMatrixClientLease(
         state.noLeases.resolve();
       }
 
+      if (state.phase === "late-drain" || state.phase === "late-drain-stopped") {
+        leaseState.releasePromise = Promise.resolve();
+        deleteSharedClientStateAfterLateDrain(state);
+        return leaseState.releasePromise;
+      }
+
       const finalMonitor =
         role === "monitor" && !Array.from(state.leases).some((lease) => lease.role === "monitor");
       if (role === "monitor" && !finalMonitor) {
@@ -488,17 +521,22 @@ function createSharedMatrixClientLease(
 export async function acquireSharedMatrixClient(
   params: SharedMatrixClientParams = {},
 ): Promise<SharedMatrixClientLease> {
-  const state = await resolveOpenSharedMatrixClientState(params);
-  const lease = createSharedMatrixClientLease(state, params.role ?? "transient");
-  if (params.startClient !== false) {
-    try {
-      await lease.start(params.abortSignal);
-    } catch (error) {
-      await lease.release({ mode: "stop" }).catch(() => undefined);
-      throw error;
+  while (true) {
+    const state = await resolveOpenSharedMatrixClientState(params);
+    const lease = createSharedMatrixClientLease(state, params.role ?? "transient");
+    if (!lease) {
+      continue;
     }
+    if (params.startClient !== false) {
+      try {
+        await lease.start(params.abortSignal);
+      } catch (error) {
+        await lease.release({ mode: "stop" }).catch(() => undefined);
+        throw error;
+      }
+    }
+    return lease;
   }
-  return lease;
 }
 
 async function forceRetireState(state: SharedMatrixClientState): Promise<void> {

--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -16,8 +16,15 @@ import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { installMatrixTestRuntime } from "../test-runtime.js";
+import type { CoreConfig } from "../types.js";
 import { readMatrixRecoveryKeyStateForPath } from "./crypto-state-store.js";
 import { MatrixDecryptBridge } from "./sdk/decrypt-bridge.js";
+
+const createSharedMatrixClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client/create-client.js", () => ({
+  createMatrixClient: createSharedMatrixClientMock,
+}));
 
 const requireMatrixJsSdkPackage = createRequire(import.meta.url);
 
@@ -1572,6 +1579,130 @@ describe("MatrixClient request hardening", () => {
       expect(matrixJsClient.classicSyncStop).toHaveBeenCalledTimes(1);
       expect(matrixJsClient.stopClient).toHaveBeenCalledTimes(1);
       expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it.each([SyncState.Error, SyncState.Reconnecting])(
+    "does not replace a poisoned %s generation until late transient work really releases",
+    async (syncState) => {
+      const accountId = `sdk-retirement-${syncState.toLowerCase()}`;
+      const cfg = {
+        channels: {
+          matrix: {
+            defaultAccount: accountId,
+            accounts: {
+              [accountId]: {
+                homeserver: "https://matrix.example.org",
+                userId: "@bot:example.org",
+                accessToken: "token",
+                deviceId: "DEVICE123",
+                encryption: false,
+              },
+            },
+          },
+        },
+      } satisfies CoreConfig;
+      const { resolveMatrixAuth } = await import("./client/config.js");
+      const auth = await resolveMatrixAuth({ cfg, accountId });
+      const gate = createDeferred<string>();
+      const entered = createDeferred<void>();
+      const firstClient = new MatrixClient(auth.homeserver, auth.accessToken);
+      const firstSdkClient = matrixJsClient;
+      let replacementClient: InstanceType<typeof MatrixClient> | undefined;
+      let operationOutcome:
+        | Promise<{ ok: true; value: string } | { ok: false; error: unknown }>
+        | undefined;
+      const { acquireSharedMatrixClient, stopSharedClientForAccount } =
+        await import("./client/shared.js");
+      const { withResolvedRuntimeMatrixClient } = await import("./client-bootstrap.js");
+      let replacementLease: Awaited<ReturnType<typeof acquireSharedMatrixClient>> | undefined;
+
+      createSharedMatrixClientMock.mockReset();
+      createSharedMatrixClientMock
+        .mockResolvedValueOnce(firstClient)
+        .mockImplementationOnce(async () => {
+          matrixJsClient = createMatrixJsClientStub();
+          replacementClient = new MatrixClient(auth.homeserver, auth.accessToken);
+          return replacementClient;
+        });
+
+      const keepalive = createDeferred<boolean>();
+      const keepaliveOutcome = keepalive.promise.then(
+        () => "resolved",
+        (error: unknown) => error,
+      );
+      const syncInternals = requireMatrixSyncApiTestInternals(firstSdkClient.syncApi);
+
+      try {
+        const monitor = await acquireSharedMatrixClient({ auth, role: "monitor" });
+        monitor.registerMonitorRetirement({
+          closeTaskAdmission: () => {},
+          detachListeners: () => {},
+          waitForTasks: async () => {},
+          cleanup: async () => {},
+        });
+        vi.spyOn(firstSdkClient.syncApi, "getSyncState").mockReturnValue(syncState);
+        syncInternals.connectionReturnedResolvers = keepalive;
+        firstSdkClient.classicSyncStop.mockImplementation(() => {});
+
+        let borrowedClient: unknown;
+        let borrowedSignal: AbortSignal | undefined;
+        const operation = withResolvedRuntimeMatrixClient(
+          { cfg, accountId: auth.accountId, readiness: "none" },
+          async (client, abortSignal) => {
+            borrowedClient = client;
+            borrowedSignal = abortSignal;
+            entered.resolve();
+            return await gate.promise;
+          },
+          "persist",
+        );
+        operationOutcome = operation.then(
+          (value) => ({ ok: true as const, value }),
+          (error: unknown) => ({ ok: false as const, error }),
+        );
+        await entered.promise;
+        expect(borrowedClient).toBe(firstClient);
+
+        const monitorOutcome = monitor.release({ mode: "persist" }).then(
+          () => ({ ok: true as const }),
+          (error: unknown) => ({ ok: false as const, error }),
+        );
+        await vi.waitFor(() => {
+          expect(firstSdkClient.classicSyncStop).toHaveBeenCalledOnce();
+        });
+        expect(borrowedSignal?.aborted).toBe(true);
+        await expect(keepaliveOutcome).resolves.toBe("SyncApi.stop() was called");
+        expect(syncInternals.connectionReturnedResolvers).toBeUndefined();
+
+        expect(createSharedMatrixClientMock).toHaveBeenCalledOnce();
+        await expect(monitorOutcome).resolves.toMatchObject({
+          ok: false,
+          error: { message: "Matrix transient leases did not drain within 5000ms" },
+        });
+        await expect(acquireSharedMatrixClient({ auth, startClient: false })).rejects.toThrow(
+          "Matrix transient leases did not drain within 5000ms",
+        );
+        expect(createSharedMatrixClientMock).toHaveBeenCalledOnce();
+
+        gate.resolve("late-result");
+        await expect(operationOutcome).resolves.toEqual({ ok: true, value: "late-result" });
+        replacementLease = await acquireSharedMatrixClient({ auth, startClient: false });
+        expect(replacementLease.client).toBe(replacementClient);
+        expect(replacementLease.client).not.toBe(firstClient);
+        expect(createSharedMatrixClientMock).toHaveBeenCalledTimes(2);
+      } finally {
+        syncInternals.connectionReturnedResolvers = undefined;
+        keepalive.resolve(false);
+        gate.resolve("cleanup");
+        await operationOutcome?.catch(() => undefined);
+        if (replacementLease) {
+          clearMatrixSyncApiForNeverStartedClient();
+        }
+        await replacementLease?.release({ mode: "discard" }).catch(() => undefined);
+        await stopSharedClientForAccount(auth).catch(() => undefined);
+        createSharedMatrixClientMock.mockReset();
+      }
     },
   );
 


### PR DESCRIPTION
Related: #125362

## What Problem This Solves

Fixes an issue where Matrix users could remain unable to reconnect in the same gateway process after an in-flight operation exceeded the 5-second shared-client retirement deadline, even after that operation later finished.

#125362 correctly retained a poisoned generation when transient work did not drain in time, preventing a replacement client from overlapping work that might still be using the old client. However, the timeout also force-completed the lease bookkeeping. A real late completion therefore had no way to prove that ownership had ended, so ordinary provider retries kept replaying the cached timeout for the rest of the process lifetime.

## Why This Change Was Made

The timeout now aborts cooperative transient work but does not manufacture its release. A safely stopped poisoned generation remains keyed while any real late lease exists and becomes replaceable only when the final lease actually releases. An atomic admission recheck also prevents a new lease from slipping onto a generation after retirement has started.

The existing fail-closed boundaries remain intact: monitor-cleanup failure and a failed poisoned-client decryption drain still retain poison after late leases finish. If an operation never returns, the generation remains quarantined rather than allowing overlapping Matrix clients. Request cancellation and the explicit terminal/test forced-teardown API are separate lifecycle contracts and are intentionally unchanged here; the ordinary-retirement guarantee in this PR does not rely on that break-glass API.

## User Impact

After a disconnected Matrix sync and a slow in-flight operation, provider retries can create a fresh client as soon as all actual old-client work has finished, without requiring a gateway restart. No replacement client is created while any late operation still owns the old generation.

If old work truly never returns, the account remains fail-closed until terminal process teardown. That is the deliberate safety side of this narrow liveness fix; cooperative cancellation can be addressed separately without weakening ownership accounting.

## Evidence

Development and validation used base `923e972564cec0d2ce1dd9e46325a571ac52818e` from 2026-08-20.

### Failing before

The late-release regression was added first and run against the unmodified base. It reproduced the permanent poison replay after the operation returned:

```text
FAIL  shared Matrix client generations > bounds non-cooperative transient drain and replaces after late release
Error: Matrix transient leases did not drain within 5000ms
  at extensions/matrix/src/matrix/client/shared.ts:323
```

The admission-race regression then failed on the unguarded implementation, proving retirement could begin between state resolution and lease insertion:

```text
FAIL  shared Matrix client generations > retries admission when retirement starts after state resolution
AssertionError: expected { name: 'retiring' } to be { name: 'replacement' }
```

### Passing after

The focused composed test uses the real shared registry, runtime lease wrapper, OpenClaw Matrix client, and pinned `matrix-js-sdk` sync internals for both `ERROR` and `RECONNECTING`. It proves all of the following in one lifecycle:

- the parked SDK keepalive resolver is rejected with `SyncApi.stop() was called` even when no later `STOPPED` event arrives;
- the transient lease is aborted and the 5-second deadline fails closed;
- acquisition stays poisoned and the client factory remains at one call before the late callback returns;
- the late callback keeps its original result when its real `finally` release runs;
- only then is one distinct replacement generation created.

Additional shared-state regressions prove that two late owners require two real releases, concurrent post-drain acquires share one replacement, a resolution/admission race retries onto the replacement, and monitor-cleanup or poisoned-decryption-drain failure remains poisoned.

```text
# Exact focused surface
Test Files  2 passed (2)
Tests       169 passed (169)

# Wider Matrix lifecycle surface: SDK, shared client, bootstrap, send client, monitor
Test Files  5 passed (5)
Tests       220 passed (220)

# Repository-prescribed changed-file validation
check-changed: passed
  conflict/safety ratchets, dependency guards, formatting,
  extension + extension-test typechecks, changed-file lint,
  dead-export scan, plugin boundaries, database/media/runtime guards,
  and import-cycle check (0 runtime value cycles)

# Additional order/isolation proof
sdk.test.ts + shared.test.ts --no-isolate: 169 passed
same pair with shuffled-file seed 1729: 169 passed
git diff --check: passed
```

### After-fix live Matrix recovery — disposable runtime

Tested exact PR head `9f42ea0f2218854c661aa9a60916323beb1a3958` on 2026-08-20 at 16:30 UTC.

This focused proof loaded the production Matrix shared-client registry, the production `withResolvedRuntimeMatrixClient` wrapper used by provider operations, OpenClaw's production `MatrixClient`, and the repository-pinned `matrix-js-sdk`. It used the repository's recording/fault proxy and a real disposable Tuwunel homeserver:

- host/runtime: macOS arm64, Node v26.5.0;
- isolated container runtime: Colima profile dedicated to this proof, Docker 29.5.2 on Ubuntu 24.04.4 arm64;
- homeserver: `ghcr.io/matrix-construct/tuwunel:v1.8.2@sha256:6f950bb139411a7964781e986321e395e045e4a6a52240a4dda9d23d04075f78`;
- no Matrix transport, client, shared registry, or SDK mock;
- no package-manager invocation, build, install, or process restart.

The proxy forwarded the first real Matrix send to Tuwunel and received HTTP 200, but held that response before returning it to the OpenClaw client. An independent Matrix observer saw the event while the response was still held, proving the runtime operation and its transient lease were genuinely outstanding after server acceptance. Releasing the final monitor then exercised the real five-second retirement deadline. The first retry stayed quarantined and never entered its callback. Only after the held response was released and the production wrapper completed its real `finally` lease release did a distinct client generation start and complete a second live Matrix round-trip.

```text
2026-08-20T16:30:43.142Z [+00000ms] proof.start head="9f42ea0f2218854c661aa9a60916323beb1a3958" process="P1" nodeVersion="v26.5.0" platform="darwin-arm64" tuwunelDigest="6f950bb139411a7964781e986321e395e045e4a6a52240a4dda9d23d04075f78"
2026-08-20T16:30:58.800Z [+15658ms] matrix.homeserver.ready realHomeserver=true recordingProxy=true
2026-08-20T16:30:59.429Z [+16287ms] generation.first.ready client="C1" monitorStarted=true
2026-08-20T16:30:59.432Z [+16290ms] runtime.first_operation.entered client="C1"
2026-08-20T16:30:59.439Z [+16297ms] matrix.first_send.accepted upstreamStatus=200 responseHeld=true
2026-08-20T16:30:59.443Z [+16301ms] matrix.first_event.observed whileResponseHeld=true
2026-08-20T16:30:59.443Z [+16301ms] retirement.started transientAbortSignal=true
2026-08-20T16:31:04.448Z [+21306ms] retirement.timed_out elapsedMs=5005 exactError="Matrix transient leases did not drain within 5000ms" lateOperationStillOutstanding=true
2026-08-20T16:31:04.453Z [+21311ms] runtime.retry_before_release.blocked callbackEntered=false samePoisonObject=true replacementCreated=false
2026-08-20T16:31:04.453Z [+21311ms] matrix.first_send.response_released afterLeaseTimeout=true
2026-08-20T16:31:04.457Z [+21315ms] runtime.first_operation.completed productionFinallyReleasedLease=true result="success"
2026-08-20T16:31:04.489Z [+21347ms] generation.replacement.ready client="C2" distinctFromC1=true monitorStarted=true
2026-08-20T16:31:04.506Z [+21364ms] runtime.recovery_operation.completed client="C2" result="success"
2026-08-20T16:31:04.514Z [+21372ms] matrix.recovery_event.observed realRoundTrip=true
2026-08-20T16:31:04.515Z [+21373ms] proof.pass clientReplacement="C1-to-C2" processUnchanged=true realMatrixRoundTrips=2
RESULT PASS exact_head=9f42ea0f2218854c661aa9a60916323beb1a3958 timeout_error="Matrix transient leases did not drain within 5000ms" process=P1 process_unchanged=true real_matrix_sends=2
```

The recording proxy independently produced these redacted request/response records. Dynamic room and transaction identifiers were normalized by the repository's recorder; bodies are represented only by field shape.

```json
[
  {
    "sequence": 18,
    "scenarioId": "pr126712-live-late-release",
    "categories": [],
    "request": {
      "method": "PUT",
      "route": "/_matrix/client/v3/rooms/{roomId}/send/m.room.message/{transactionId}",
      "query": {},
      "body": { "kind": "json", "fields": ["body", "msgtype"] }
    },
    "response": {
      "status": 200,
      "body": { "kind": "json", "fields": ["event_id"] }
    }
  },
  {
    "sequence": 28,
    "scenarioId": "pr126712-live-late-release",
    "categories": [],
    "request": {
      "method": "PUT",
      "route": "/_matrix/client/v3/rooms/{roomId}/send/m.room.message/{transactionId}",
      "query": {},
      "body": { "kind": "json", "fields": ["body", "msgtype"] }
    },
    "response": {
      "status": 200,
      "body": { "kind": "json", "fields": ["event_id"] }
    }
  }
]
```

Result: **PASS**. The deadline stayed fail-closed: no replacement was admitted while the real late operation owned `C1`. After the operation returned and the runtime wrapper's `finally` released that ownership, a started monitor held distinct client `C2`, and a provider-facing runtime operation borrowed `C2` for the second successful send. The isolated Node process remained `P1` throughout; there was no process replacement or restart.

The trace was generated from curated event fields and scanned against all actual disposable credentials and identifiers, plus generic bearer-token, Matrix-ID, dynamic-port, and local-path patterns. Access tokens, user/room/device/event IDs, event contents, ports, and filesystem paths are absent. SHA-256 of the exact redacted text trace above: `634e12bc3c79bf91c1495c9df974cfc55805247da4d7718acc47eeabc3b62d58`.

Isolation boundary: this was a focused in-process Matrix runtime proof, not a launch of the separately serving gateway. Its homeserver, users, room, state, configuration, and container runtime were disposable and dedicated to this run. The serving OpenClaw installation and its Matrix account were not used, changed, stopped, restarted, rebuilt, or reinstalled. Not tested here: encrypted rooms, the explicit break-glass forced-teardown API, or a full child-gateway provider lifecycle.


