### PR TITLE
improve(ui): simplify session sidebar indicators

### DIFF
--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -215,16 +215,6 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
         ? html`<openclaw-tooltip .content=${attentionLabel}>${homeGlyph}</openclaw-tooltip>`
         : homeGlyph}
       <span class="nav-item__text">${t("nav.home")}</span>
-      ${sessionHasBoard(mainKey)
-        ? html`<openclaw-tooltip .content=${t("sessionsView.dashboardAvailable")}>
-            <span
-              class="sidebar-board-glyph"
-              role="img"
-              aria-label=${t("sessionsView.dashboardAvailable")}
-              >${icons.layoutDashboard}</span
-            >
-          </openclaw-tooltip>`
-        : nothing}
       ${running || outboxAttentionCount > 0 || hasComposerDraft
         ? html`<span class="nav-item__state sidebar-home-session-states">
             ${running ? renderSessionRunSpinner() : nothing}
@@ -234,6 +224,16 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
               hasComposerDraft,
             })}
           </span>`
+        : nothing}
+      ${sessionHasBoard(mainKey)
+        ? html`<openclaw-tooltip .content=${t("sessionsView.dashboardAvailable")}>
+            <span
+              class="sidebar-board-glyph"
+              role="img"
+              aria-label=${t("sessionsView.dashboardAvailable")}
+              >${icons.layoutDashboard}</span
+            >
+          </openclaw-tooltip>`
         : nothing}
     </a>
   `;

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -31,6 +31,7 @@ import type { SessionDataController } from "./session-data-controller.ts";
 import {
   describeSessionTrailingState,
   renderSessionLeadingState,
+  renderSessionPullRequestIndicator,
 } from "./session-leading-indicator.ts";
 import type { SessionPullRequestIndicatorState } from "./session-menu-work.ts";
 import type { SessionOrganizerController } from "./session-organizer-controller.ts";
@@ -218,9 +219,10 @@ export function renderRecentSession(params: {
       session.participantCount,
       channelAvatarAuth,
     );
-  const trailingDescription = session.isChild
-    ? ""
-    : describeSessionTrailingState(session, pullRequestState);
+  const trailingDescription = session.isChild ? "" : describeSessionTrailingState(session);
+  const pullRequestIndicator = session.isChild
+    ? nothing
+    : renderSessionPullRequestIndicator(pullRequestState, false);
   const hasTrail = session.isChild && (session.runtimeMs != null || session.startedAt != null);
   const metaId = hasTrail ? sidebarSessionMetaId(session.key) : undefined;
   const stateId = trailingIndicator === nothing ? undefined : sidebarSessionStateId(session.key);
@@ -327,15 +329,6 @@ export function renderRecentSession(params: {
           <span class="sidebar-recent-session__details">
             ${renderSidebarSessionSubtitle({ subtitle, narration })}
             <span class="sidebar-recent-session__details-endcap">
-              ${!session.isChild && sessionHasBoard(session.key)
-                ? html`<span
-                    class="sidebar-board-glyph"
-                    role="img"
-                    aria-label=${t("sessionsView.dashboardAvailable")}
-                    title=${t("sessionsView.dashboardAvailable")}
-                    >${icons.layoutDashboard}</span
-                  >`
-                : nothing}
               <openclaw-viewer-facepile
                 .presencePayload=${host.sessionData.presencePayload}
                 .selfUserId=${host.sessionDataContext?.gateway.snapshot.selfUser?.id}
@@ -345,6 +338,7 @@ export function renderRecentSession(params: {
                 .maxVisible=${3}
                 variant="session"
               ></openclaw-viewer-facepile>
+              ${pullRequestIndicator}
               ${renderSessionRowBadges({
                 ...session,
                 hasComposerDraft: session.hasComposerDraft === true,
@@ -377,6 +371,15 @@ export function renderRecentSession(params: {
                           .startMs=${session.startedAt!}
                           .endMs=${session.endedAt ?? null}
                         ></openclaw-elapsed-time>`}</span
+                  >`
+                : nothing}
+              ${!session.isChild && sessionHasBoard(session.key)
+                ? html`<span
+                    class="sidebar-board-glyph"
+                    role="img"
+                    aria-label=${t("sessionsView.dashboardAvailable")}
+                    title=${t("sessionsView.dashboardAvailable")}
+                    >${icons.layoutDashboard}</span
                   >`
                 : nothing}
             </span>

--- a/ui/src/components/app-sidebar-session-types.test.ts
+++ b/ui/src/components/app-sidebar-session-types.test.ts
@@ -89,14 +89,14 @@ describe("collapsed sidebar sections preference", () => {
 });
 
 describe("sidebar session preview preference", () => {
-  it("defaults to showing previews and round-trips the stored choice", () => {
-    expect(loadStoredSidebarSessionsShowPreview()).toBe(true);
-
-    storeSidebarSessionsShowPreview(false);
+  it("defaults to compact rows and round-trips the stored choice", () => {
     expect(loadStoredSidebarSessionsShowPreview()).toBe(false);
 
     storeSidebarSessionsShowPreview(true);
     expect(loadStoredSidebarSessionsShowPreview()).toBe(true);
+
+    storeSidebarSessionsShowPreview(false);
+    expect(loadStoredSidebarSessionsShowPreview()).toBe(false);
   });
 });
 

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -273,7 +273,7 @@ export function loadStoredSidebarSessionsShowCron(): boolean {
 }
 
 export function loadStoredSidebarSessionsShowPreview(): boolean {
-  return getSafeLocalStorage()?.getItem(SIDEBAR_SESSION_SHOW_PREVIEW_STORAGE_KEY) !== "false";
+  return getSafeLocalStorage()?.getItem(SIDEBAR_SESSION_SHOW_PREVIEW_STORAGE_KEY) === "true";
 }
 
 export function loadStoredSidebarSessionsShowSystem(): boolean {

--- a/ui/src/components/session-leading-indicator.ts
+++ b/ui/src/components/session-leading-indicator.ts
@@ -58,7 +58,7 @@ function pullRequestStateLabel(
     : t("chat.pullRequests.merged");
 }
 
-function renderPullRequestIndicator(
+export function renderSessionPullRequestIndicator(
   pullRequestState: SessionPullRequestIndicatorState,
   showTitle = true,
 ) {
@@ -76,21 +76,13 @@ function renderPullRequestIndicator(
   >`;
 }
 
-function renderSessionTrailingState(
-  session: SidebarRecentSession,
-  pullRequestState: SessionPullRequestIndicatorState,
-) {
+function renderSessionTrailingState(session: SidebarRecentSession) {
   const sessionState = renderSessionState(session, false);
   const concurrentUnreadState = session.hasActiveRun ? renderSessionUnreadState(session) : nothing;
-  if (
-    pullRequestState === "none" &&
-    sessionState === nothing &&
-    concurrentUnreadState === nothing
-  ) {
+  if (sessionState === nothing && concurrentUnreadState === nothing) {
     return nothing;
   }
-  return html`${renderPullRequestIndicator(pullRequestState, false)} ${sessionState}
-  ${concurrentUnreadState}`;
+  return html`${sessionState} ${concurrentUnreadState}`;
 }
 
 function renderPersistentSessionIcon(icon: string) {
@@ -100,13 +92,9 @@ function renderPersistentSessionIcon(icon: string) {
     : html`<span class="session-glyph__emoji" aria-hidden="true">${icon}</span>`;
 }
 
-export function describeSessionTrailingState(
-  session: SidebarRecentSession,
-  pullRequestState: SessionPullRequestIndicatorState,
-) {
+export function describeSessionTrailingState(session: SidebarRecentSession) {
   return [
     session.forkSource ? t("sessionsView.forkedSession") : "",
-    pullRequestState === "none" ? "" : pullRequestStateLabel(pullRequestState),
     session.hasActiveRun
       ? t(session.status === "queued" ? "sessionsView.statusQueued" : "sessionsView.activeRun")
       : "",
@@ -132,9 +120,7 @@ export function renderSessionLeadingState(
   renderedOwnerId?: string;
 } {
   const running = session.hasActiveRun;
-  const trailingIndicator = session.isChild
-    ? nothing
-    : renderSessionTrailingState(session, pullRequestState);
+  const trailingIndicator = session.isChild ? nothing : renderSessionTrailingState(session);
   // Transient attention always outranks the persistent decorative icon.
   if (session.isChild) {
     if (session.attention.kind !== "none") {
@@ -186,7 +172,7 @@ export function renderSessionLeadingState(
     if (pullRequestState !== "none") {
       return {
         running,
-        leadingIndicator: renderPullRequestIndicator(pullRequestState),
+        leadingIndicator: renderSessionPullRequestIndicator(pullRequestState),
         trailingIndicator,
       };
     }

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -1,6 +1,8 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
+import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import {
   captureUiProofEnabled,
   chatSessionListResponse,
@@ -24,6 +26,12 @@ const sessionSecondRowProofDir = path.join(
   "control-ui-e2e",
   "session-status-second-row-implementation",
 );
+const sessionIconRailProofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "session-icon-rail",
+);
 const subtitleStabilityProofDir = path.join(
   process.cwd(),
   ".artifacts",
@@ -43,6 +51,9 @@ suite.define(() => {
       ...(captureUiProofEnabled
         ? { recordVideo: { dir: subtitleStabilityProofDir, size: { height: 900, width: 1280 } } }
         : {}),
+    });
+    await context.addInitScript(() => {
+      localStorage.setItem("openclaw:sidebar:sessions:show-preview", "true");
     });
     const page = await context.newPage();
     const proofVideo = page.video();
@@ -135,6 +146,9 @@ suite.define(() => {
       ...(captureUiProofEnabled
         ? { recordVideo: { dir: terminalMetadataProofDir, size: { height: 900, width: 1280 } } }
         : {}),
+    });
+    await context.addInitScript(() => {
+      localStorage.setItem("openclaw:sidebar:sessions:show-preview", "true");
     });
     const page = await context.newPage();
     const key = "agent:main:session-a";
@@ -331,6 +345,9 @@ suite.define(() => {
         ? { recordVideo: { dir: sessionSecondRowProofDir, size: { height: 900, width: 1280 } } }
         : {}),
     });
+    await context.addInitScript(() => {
+      localStorage.setItem("openclaw:sidebar:sessions:show-preview", "true");
+    });
     const page = await context.newPage();
     const busyKey = "agent:main:busy-session";
     const plainKey = "agent:main:plain-session";
@@ -512,6 +529,233 @@ suite.define(() => {
         });
       }
       await plainRow.waitFor();
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("defaults to compact rows with an aligned dashboard-last icon rail", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(sessionIconRailProofDir, { recursive: true });
+    }
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+      ...(captureUiProofEnabled
+        ? { recordVideo: { dir: sessionIconRailProofDir, size: { height: 900, width: 1280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const dashboardKey = "agent:main:dashboard-icon";
+    const pullRequestKey = "agent:main:pull-request-icon";
+    const cloudKey = "agent:main:cloud-icon";
+    const combinedKey = "agent:main:combined-icons";
+    const emptyBoard = (sessionKey: string) => ({ sessionKey, revision: 1, tabs: [], widgets: [] });
+    const dashboardBoard = (sessionKey: string) => ({
+      sessionKey,
+      revision: 1,
+      tabs: [{ tabId: "main", title: "Main", position: 0, chatDock: "right" }],
+      widgets: [],
+    });
+    const activePlacement = {
+      state: "active",
+      generation: 1,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      stateChangedAtMs: 1,
+      environmentId: "environment-1",
+      activeOwnerEpoch: 1,
+      workerBundleHash: "0".repeat(64),
+      workspaceBaseManifestRef: "base-ref",
+      remoteWorkspaceDir: "/workspace",
+    };
+    const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "board.get",
+        "chat.metadata",
+        "chat.startup",
+        SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
+      ],
+      methodResponses: {
+        [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD]: { subscribed: true },
+        "board.get": {
+          cases: [
+            { match: { sessionKey: dashboardKey }, response: dashboardBoard(dashboardKey) },
+            { match: { sessionKey: pullRequestKey }, response: emptyBoard(pullRequestKey) },
+            { match: { sessionKey: cloudKey }, response: emptyBoard(cloudKey) },
+            { match: { sessionKey: combinedKey }, response: dashboardBoard(combinedKey) },
+          ],
+        },
+        "sessions.list": chatSessionListResponse([
+          {
+            key: dashboardKey,
+            kind: "direct",
+            label: "Dashboard session",
+            lastMessagePreview: "Dashboard preview should be opt-in",
+            updatedAt: 4,
+          },
+          {
+            key: pullRequestKey,
+            kind: "direct",
+            label: "Pull request session",
+            lastMessagePreview: "Pull request preview should be opt-in",
+            worktree: {
+              id: "pull-request-worktree",
+              branch: "fix/pull-request-icon",
+              repoRoot: "/tmp/openclaw",
+            },
+            updatedAt: 3,
+          },
+          {
+            key: cloudKey,
+            kind: "direct",
+            label: "Cloud worker session",
+            lastMessagePreview: "Cloud preview should be opt-in",
+            placement: activePlacement,
+            updatedAt: 2,
+          },
+          {
+            key: combinedKey,
+            kind: "direct",
+            label: "Combined metadata session",
+            lastMessagePreview: "Combined preview should be opt-in",
+            placement: activePlacement,
+            worktree: {
+              id: "combined-worktree",
+              branch: "fix/combined-icons",
+              repoRoot: "/tmp/openclaw",
+            },
+            updatedAt: 1,
+          },
+        ]),
+      },
+      sessionKey: dashboardKey,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const codingToggle = page.locator(
+        '[data-session-section="work"] .sidebar-session-group-toggle',
+      );
+      await codingToggle.waitFor({ state: "visible" });
+      await codingToggle.click();
+      await expect
+        .poll(async () => {
+          const requests = await gateway.getRequests(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD);
+          return requests.some((request) => {
+            const params = request.params;
+            if (!params || typeof params !== "object" || !("sessionKeys" in params)) {
+              return false;
+            }
+            const sessionKeys = params.sessionKeys;
+            return (
+              Array.isArray(sessionKeys) &&
+              sessionKeys.includes(pullRequestKey) &&
+              sessionKeys.includes(combinedKey)
+            );
+          });
+        })
+        .toBe(true);
+      await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, {
+        sessions: Object.fromEntries(
+          [pullRequestKey, combinedKey].map((sessionKey, index) => [
+            sessionKey,
+            {
+              pullRequests: [
+                {
+                  branch: index === 0 ? "fix/pull-request-icon" : "fix/combined-icons",
+                  number: 126_567 + index,
+                  owner: "openclaw",
+                  repo: "openclaw",
+                  state: "open",
+                  title: "Align sidebar metadata icons",
+                  url: `https://example.test/openclaw/openclaw/pull/${126_567 + index}`,
+                },
+              ],
+              rateLimited: false,
+              status: "ready",
+            },
+          ]),
+        ),
+      });
+      const dashboardRow = page.locator(
+        `.sidebar-recent-session[data-session-key="${dashboardKey}"]`,
+      );
+      const pullRequestRow = page.locator(
+        `.sidebar-recent-session[data-session-key="${pullRequestKey}"]`,
+      );
+      const cloudRow = page.locator(`.sidebar-recent-session[data-session-key="${cloudKey}"]`);
+      const combinedRow = page.locator(
+        `.sidebar-recent-session[data-session-key="${combinedKey}"]`,
+      );
+      await dashboardRow.locator(".sidebar-board-glyph").waitFor();
+      await pullRequestRow.locator(".sidebar-session-pr-indicator").waitFor();
+      await cloudRow.locator(".session-row-badge--cloud").waitFor();
+      await combinedRow.locator(".sidebar-board-glyph").waitFor();
+      if (captureUiProofEnabled) {
+        await page.locator(".sidebar").screenshot({
+          path: path.join(sessionIconRailProofDir, "session-icon-rail.png"),
+        });
+      }
+
+      expect(
+        await page.evaluate(() => localStorage.getItem("openclaw:sidebar:sessions:show-preview")),
+      ).toBeNull();
+      for (const row of [dashboardRow, pullRequestRow, cloudRow, combinedRow]) {
+        await expect.poll(() => row.getAttribute("class")).toContain("--single-line");
+        expect(await row.locator(".sidebar-recent-session__subtitle").count()).toBe(0);
+      }
+
+      const aligned = await Promise.all(
+        [
+          [dashboardRow, ".sidebar-board-glyph"],
+          [pullRequestRow, ".sidebar-session-pr-indicator"],
+          [cloudRow, ".session-row-badge--cloud"],
+        ].map(async ([row, selector]) =>
+          (row as typeof dashboardRow).evaluate((element, iconSelector) => {
+            const icon = element.querySelector<HTMLElement>(iconSelector);
+            if (!icon) {
+              throw new Error(`Missing icon rail fixture ${iconSelector}`);
+            }
+            const rowBox = element.getBoundingClientRect();
+            const iconBox = icon.getBoundingClientRect();
+            return {
+              color: getComputedStyle(icon).color,
+              height: iconBox.height,
+              right: iconBox.right,
+              rowCenter: (rowBox.top + rowBox.bottom) / 2,
+              iconCenter: (iconBox.top + iconBox.bottom) / 2,
+              width: iconBox.width,
+            };
+          }, selector as string),
+        ),
+      );
+      for (const icon of aligned) {
+        expect(icon.height).toBe(16);
+        expect(icon.width).toBe(16);
+        expect(icon.iconCenter).toBeCloseTo(icon.rowCenter, 1);
+        expect(icon.right).toBeCloseTo(aligned[0]!.right, 1);
+        expect(icon.color).toBe(aligned[0]!.color);
+      }
+
+      const combinedOrder = await combinedRow.evaluate((row) => {
+        const center = (selector: string) => {
+          const element = row.querySelector<HTMLElement>(selector);
+          if (!element) {
+            throw new Error(`Missing combined icon rail fixture ${selector}`);
+          }
+          const box = element.getBoundingClientRect();
+          return (box.left + box.right) / 2;
+        };
+        return {
+          dashboard: center(".sidebar-board-glyph"),
+          placement: center(".session-row-badge--cloud"),
+          pullRequest: center(".sidebar-session-pr-indicator"),
+        };
+      });
+      expect(combinedOrder.pullRequest).toBeLessThan(combinedOrder.placement);
+      expect(combinedOrder.placement).toBeLessThan(combinedOrder.dashboard);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -842,6 +842,9 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
     });
+    await context.addInitScript(() => {
+      localStorage.setItem("openclaw:sidebar:sessions:show-preview", "true");
+    });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -21,6 +21,9 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
     });
+    await context.addInitScript(() => {
+      localStorage.setItem("openclaw:sidebar:sessions:show-preview", "true");
+    });
     const page = await context.newPage();
     await installMockGateway(page, {
       methodResponses: {
@@ -281,6 +284,9 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
     });
+    await context.addInitScript(() => {
+      localStorage.setItem("openclaw:sidebar:sessions:show-preview", "true");
+    });
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       featureMethods: [
@@ -359,14 +365,13 @@ suite.define(() => {
         )
         .toBe(true);
       await expect.poll(() => state.locator('[aria-label="Forked session"]').count()).toBe(0);
-      await expect
-        .poll(() => state.locator("[data-session-pr-state='open']").isVisible())
-        .toBe(true);
+      const pullRequest = row.locator("[data-session-pr-state='open']");
+      await expect.poll(() => pullRequest.isVisible()).toBe(true);
       await expect.poll(() => state.locator(".session-run-spinner").isVisible()).toBe(true);
       await expect.poll(() => state.locator(".session-unread-dot").isVisible()).toBe(true);
       const [endcapBounds, openPullRequestBounds, spinnerBounds, unreadBounds] = await Promise.all([
         row.locator(".sidebar-recent-session__details-endcap").boundingBox(),
-        state.locator("[data-session-pr-state='open'] svg").boundingBox(),
+        pullRequest.locator("svg").boundingBox(),
         state.locator(".session-run-spinner").boundingBox(),
         state.locator(".session-unread-dot").boundingBox(),
       ]);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -5776,23 +5776,20 @@ td.data-table-key-col {
 .session-row-badge {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
   color: var(--muted);
 }
 
 .session-row-badge--attention {
+  width: auto;
+  min-width: 16px;
   gap: 2px;
   color: var(--warn);
   font-size: 10px;
   font-variant-numeric: tabular-nums;
-}
-
-.session-row-badge--pull-request[data-pull-request-state="open"],
-.session-row-badge--cloud[data-placement-state="active"] {
-  color: var(--ok);
-}
-
-.session-row-badge--pull-request[data-pull-request-state="merged"] {
-  color: var(--accent);
 }
 
 .session-row-badge--approval {
@@ -5803,17 +5800,6 @@ td.data-table-key-col {
 
 .session-row-badge--cloud[data-placement-state="failed"] {
   color: var(--danger);
-}
-
-.session-row-badge--cloud:is(
-  [data-placement-state="requested"],
-  [data-placement-state="provisioning"],
-  [data-placement-state="syncing"],
-  [data-placement-state="starting"],
-  [data-placement-state="draining"],
-  [data-placement-state="reconciling"]
-) {
-  color: var(--accent);
 }
 
 .session-row-badge--cloud[data-workspace-conflicts] {
@@ -5829,8 +5815,8 @@ td.data-table-key-col {
 }
 
 .session-row-badge svg {
-  width: 12px;
-  height: 12px;
+  width: 13px;
+  height: 13px;
   stroke: currentColor;
   fill: none;
   stroke-width: 1.6px;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2173,8 +2173,12 @@ body.update-dialog-open .sidebar-update-card__status {
 
 .sidebar-board-glyph {
   display: inline-flex;
-  flex: 0 0 auto;
-  color: color-mix(in srgb, var(--accent) 76%, var(--muted));
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  color: var(--muted);
 }
 
 .sidebar-board-glyph svg {
@@ -4213,17 +4217,19 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
   font-size: 6px;
 }
 
-.sidebar-session-pr-indicator--open {
-  color: var(--ok);
-}
-
-.sidebar-session-pr-indicator--merged {
-  color: var(--pr-merged);
+.sidebar-session-pr-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  color: var(--muted);
 }
 
 .sidebar-session-pr-indicator svg {
-  width: 16px;
-  height: 16px;
+  width: 13px;
+  height: 13px;
   fill: none;
   stroke: currentColor;
   stroke-width: 1.7px;

--- a/ui/src/test-helpers/app-sidebar-cases/attention.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/attention.ts
@@ -202,6 +202,8 @@ describe("AppSidebar session attention", () => {
       createGateway({} as GatewayBrowserClient),
       sessionsHarness.sessions,
     );
+    sidebar.sessionsShowPreview = true;
+    await sidebar.updateComplete;
 
     expect(sidebar.textContent).toContain("Deploying to staging");
     expect(sidebar.querySelector('[data-session-attention="agent"]')).toBeNull();

--- a/ui/src/test-helpers/app-sidebar-cases/narration.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/narration.ts
@@ -40,6 +40,7 @@ describe("AppSidebar live narration", () => {
     const sessions = createSessionsHarness("main", [key]);
     sessions.publishList({ result: sessionsResult([runningRow(key, 5)]), agentId: "main" });
     const { sidebar } = await mountSidebar(gateway.gateway, sessions.sessions);
+    sidebar.sessionsShowPreview = true;
     sidebar.connected = true;
     await sidebar.updateComplete;
 
@@ -91,6 +92,7 @@ describe("AppSidebar live narration", () => {
     const sessions = createSessionsHarness("main", [key]);
     sessions.publishList({ result: sessionsResult([runningRow(key, 5)]), agentId: "main" });
     const { sidebar } = await mountSidebar(gateway.gateway, sessions.sessions);
+    sidebar.sessionsShowPreview = true;
     sidebar.connected = true;
     await sidebar.updateComplete;
 

--- a/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-indicators.ts
@@ -552,7 +552,9 @@ describe("AppSidebar session indicators", () => {
     for (const key of [keys.openPullRequest, keys.mergedPullRequest]) {
       const row = sidebar.querySelector(`[data-session-key="${key}"]`);
       expectEmptyLead(row);
-      expect(row?.querySelector(".session-row-state [data-session-pr-state]")).not.toBeNull();
+      expect(
+        row?.querySelector(".sidebar-recent-session__details-endcap > [data-session-pr-state]"),
+      ).not.toBeNull();
       expect(row?.querySelector("a")?.hasAttribute("title")).toBe(false);
       expect(row?.querySelector("[data-session-pr-state]")?.hasAttribute("title")).toBe(false);
     }

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -63,6 +63,7 @@ export type SidebarLifecycleState = HTMLElement & {
   workboardBoardsReady: boolean;
   workboardRenderers?: SidebarWorkboardRenderers;
   sidebarLiveActivity: boolean;
+  sessionsShowPreview: boolean;
   onUpdateSidebarEntries?: (entries: string[]) => void;
   pinnedAgentIds: readonly string[];
   sessionKey: string;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the session sidebar defaulted to two-line rows and mixed pull request, cloud placement, and dashboard indicators with different widths, colors, and ordering. The same semantic position could land on a different visual axis from row to row, making the compact session list noisy and harder to scan.

## Why This Change Was Made

The untouched-browser default now keeps message previews off while preserving an explicit stored opt-in. Session metadata uses one right-aligned rail with 16px slots and 13px glyphs: collaboration first, pull request metadata before placement, operational state after metadata, and dashboard availability always last. Normal states are muted while warning and failure colors remain semantic. Pull request metadata is separated from the wider runtime-state wrapper instead of being aligned with an icon-specific offset.

AI-assisted implementation; the author reviewed the code, tests, browser output, and remote proof.

## User Impact

The default session sidebar is denser and calmer: ordinary sessions occupy one line, Git/cloud/dashboard indicators align consistently, and dashboard availability is predictable at the far right. Users who previously enabled message previews retain that stored choice, and actionable attention text remains visible even with previews off.

Production LOC: +57/-76 (net -19) | Tests and test support: +268/-9

## Evidence

| Before | After |
| --- | --- |
| ![Before: two-line rows with colorful, uneven dashboard, cloud, and pull request indicators](https://github.com/user-attachments/assets/0044e7f5-0bb3-41f7-8d01-e0a871b1f1da) | ![After: compact one-line rows with muted aligned indicators and dashboard last](https://github.com/user-attachments/assets/f550ba08-e42f-4134-944f-d0e3015f9c5e) |

- Pre-fix browser regression failed because the untouched row was not single-line; the same scenario passes after the repair.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts ui/src/components/app-sidebar-session-types.test.ts ui/src/components/session-row-badges.test.ts` — 316 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts ui/src/e2e/session-management.trailing-state.e2e.test.ts` — 11 browser tests passed locally and on AWS Crabbox.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.sidebar.e2e.test.ts` — the exact CI-failed file passed 11/11 after its subtitle-specific scenario explicitly opted into previews.
- Remote browser proof: [run_7080fa88d9c7](https://crabbox.openclaw.ai/portal/runs/run_7080fa88d9c7), provider `aws`, lease `cbx_1508c8facd7a`, 11/11 passed.
- Remote changed gate: [run_da09944fe013](https://crabbox.openclaw.ai/portal/runs/run_da09944fe013), including core-test types, UI types, format, Oxlint, stylelint, i18n, dead exports, and repository guards. The only later change is the focused E2E opt-in above.
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean for the production patch and the focused follow-up; no accepted/actionable findings.
- `git diff --check` — passed.
