### PR TITLE
improve(ui): explain session selection in split view

### DIFF
--- a/ui/src/app/settings.node.test.ts
+++ b/ui/src/app/settings.node.test.ts
@@ -814,9 +814,10 @@ describe("loadSettings default gateway URL derivation", () => {
       activePaneId: "p2",
     };
 
-    saveSettings({ ...settings, chatSplitLayout });
+    saveSettings({ ...settings, chatSplitLayout, chatSplitOnboardingDismissed: true });
 
     expect(loadSettings().chatSplitLayout).toEqual(chatSplitLayout);
+    expect(loadSettings().chatSplitOnboardingDismissed).toBe(true);
   });
 
   it("preserves an opted-in bottom workspace dock", () => {

--- a/ui/src/app/settings.ts
+++ b/ui/src/app/settings.ts
@@ -203,6 +203,9 @@ export type UiSettings = {
   // Camera intent is device-local, not per-agent or synced through config ui.prefs.
   talkCameraAutoEnable?: boolean;
   chatSplitLayout?: ChatSplitLayout;
+  // The split-view onboarding opt-out is browser-local and intentionally stays
+  // outside the synced config ui.prefs surface.
+  chatSplitOnboardingDismissed?: boolean;
   chatWorkspaceDock?: ChatWorkspaceDock; // Session workspace rail dock edge (default "right")
   boardSessionViews?: BoardSessionViews; // Per-device active dashboard tab and dock state
   sidebarSessionLayouts?: SidebarSessionLayouts; // Sidebar columns and widths per session
@@ -523,6 +526,9 @@ export function loadSettings(): UiSettings {
       talkCameraAutoEnable:
         typeof parsed.talkCameraAutoEnable === "boolean" ? parsed.talkCameraAutoEnable : undefined,
       chatSplitLayout: normalizeChatSplitLayout(parsed.chatSplitLayout),
+      ...(parsed.chatSplitOnboardingDismissed === true
+        ? { chatSplitOnboardingDismissed: true }
+        : {}),
       chatWorkspaceDock: normalizeChatWorkspaceDock(parsed.chatWorkspaceDock),
       boardSessionViews: normalizeBoardSessionViews(parsed.boardSessionViews),
       sidebarSessionLayouts: normalizeSidebarSessionLayouts(parsed.sidebarSessionLayouts),
@@ -669,6 +675,7 @@ function persistSettings(next: UiSettings, options: { selectGateway?: boolean } 
       ? { talkCameraAutoEnable: next.talkCameraAutoEnable }
       : {}),
     ...(next.chatSplitLayout ? { chatSplitLayout: next.chatSplitLayout } : {}),
+    ...(next.chatSplitOnboardingDismissed === true ? { chatSplitOnboardingDismissed: true } : {}),
     // Right dock is the default; only the opt-in bottom dock persists.
     ...(next.chatWorkspaceDock === "bottom" ? { chatWorkspaceDock: "bottom" as const } : {}),
     ...(next.boardSessionViews && Object.keys(next.boardSessionViews).length > 0

--- a/ui/src/e2e/chat-split-onboarding.e2e.test.ts
+++ b/ui/src/e2e/chat-split-onboarding.e2e.test.ts
@@ -161,7 +161,7 @@ suite.define(() => {
       await page.getByRole("button", { name: "Open split view" }).click();
       const panes = page.locator("openclaw-chat-pane.chat-split-view__pane");
       await expect.poll(() => panes.count()).toBe(2);
-      const onboarding = panes.first().locator(".chat-split-onboarding");
+      const onboarding = panes.last().locator(".chat-split-onboarding");
       await expect.poll(() => onboarding.count()).toBe(1);
       const metrics = await onboarding.evaluate((hint) => ({
         clientWidth: hint.clientWidth,

--- a/ui/src/e2e/chat-split-onboarding.e2e.test.ts
+++ b/ui/src/e2e/chat-split-onboarding.e2e.test.ts
@@ -44,22 +44,22 @@ suite.define(() => {
       await expect.poll(() => panes.count()).toBe(2);
       const onboarding = page.locator(".chat-split-onboarding");
       await expect.poll(() => onboarding.count()).toBe(1);
-      const firstPane = panes.first();
-      const secondPane = panes.last();
-      await expect.poll(() => firstPane.locator(".chat-split-onboarding").count()).toBe(1);
-      expect(await secondPane.locator(".chat-split-onboarding").count()).toBe(0);
+      const inactivePane = panes.first();
+      const activePane = panes.last();
+      await expect.poll(() => activePane.locator(".chat-split-onboarding").count()).toBe(1);
+      expect(await inactivePane.locator(".chat-split-onboarding").count()).toBe(0);
 
-      const copy = firstPane.locator(".chat-split-onboarding__copy");
+      const copy = activePane.locator(".chat-split-onboarding__copy");
       await expect
         .poll(() => copy.textContent())
         .toBe("Select another session to show it in this column.");
-      const dismiss = firstPane.getByRole("button", { name: "Don't show again" });
+      const dismiss = activePane.getByRole("button", { name: "Don't show again" });
       await expect.poll(() => dismiss.isVisible()).toBe(true);
       expect(await page.evaluate(() => document.activeElement?.className ?? "")).not.toContain(
         "chat-split-onboarding__dismiss",
       );
 
-      const placement = await firstPane.evaluate((pane) => {
+      const placement = await activePane.evaluate((pane) => {
         const header = pane.querySelector<HTMLElement>(".chat-pane__header");
         const hint = pane.querySelector<HTMLElement>(".chat-split-onboarding");
         const cell = pane.closest<HTMLElement>(".chat-split-view__cell");

--- a/ui/src/e2e/chat-split-onboarding.e2e.test.ts
+++ b/ui/src/e2e/chat-split-onboarding.e2e.test.ts
@@ -1,0 +1,184 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { controlUiBundledSettingsStorageKey } from "../test-helpers/control-ui-e2e.ts";
+import {
+  chatSessionListResponse,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "split-onboarding");
+
+suite.define(() => {
+  it("shows the split-view onboarding once and persists dismissal", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ type: "text", text: "Split onboarding proof." }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+      methodResponses: { "sessions.list": chatSessionListResponse() },
+      sessionKey: "agent:main:session-a",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.getByText("Split onboarding proof.").waitFor();
+
+      const splitEntry = page.getByRole("button", { name: "Open split view" });
+      await expect.poll(() => splitEntry.isVisible()).toBe(true);
+      expect(await page.locator(".chat-split-onboarding").count()).toBe(0);
+
+      await splitEntry.click();
+      const panes = page.locator("openclaw-chat-pane.chat-split-view__pane");
+      await expect.poll(() => panes.count()).toBe(2);
+      const onboarding = page.locator(".chat-split-onboarding");
+      await expect.poll(() => onboarding.count()).toBe(1);
+      const firstPane = panes.first();
+      const secondPane = panes.last();
+      await expect.poll(() => firstPane.locator(".chat-split-onboarding").count()).toBe(1);
+      expect(await secondPane.locator(".chat-split-onboarding").count()).toBe(0);
+
+      const copy = firstPane.locator(".chat-split-onboarding__copy");
+      await expect
+        .poll(() => copy.textContent())
+        .toBe("Select another session to show it in this column.");
+      const dismiss = firstPane.getByRole("button", { name: "Don't show again" });
+      await expect.poll(() => dismiss.isVisible()).toBe(true);
+      expect(await page.evaluate(() => document.activeElement?.className ?? "")).not.toContain(
+        "chat-split-onboarding__dismiss",
+      );
+
+      const placement = await firstPane.evaluate((pane) => {
+        const header = pane.querySelector<HTMLElement>(".chat-pane__header");
+        const hint = pane.querySelector<HTMLElement>(".chat-split-onboarding");
+        const cell = pane.closest<HTMLElement>(".chat-split-view__cell");
+        if (!header || !hint || !cell) {
+          throw new Error("split onboarding placement is incomplete");
+        }
+        const headerBox = header.getBoundingClientRect();
+        const hintBox = hint.getBoundingClientRect();
+        const cellBox = cell.getBoundingClientRect();
+        return {
+          hintTop: hintBox.top,
+          headerBottom: headerBox.bottom,
+          hintRight: hintBox.right,
+          cellRight: cellBox.right,
+          position: getComputedStyle(hint).position,
+          overflow: hint.scrollWidth > hint.clientWidth || hint.scrollHeight > hint.clientHeight,
+        };
+      });
+      expect(placement.hintTop).toBeGreaterThanOrEqual(placement.headerBottom);
+      expect(placement.hintRight).toBeLessThanOrEqual(placement.cellRight + 1);
+      expect(placement.position).toBe("static");
+      expect(placement.overflow).toBe(false);
+
+      await mkdir(artifactDir, { recursive: true });
+      await page.screenshot({
+        fullPage: true,
+        path: path.join(artifactDir, "split-onboarding-light.png"),
+      });
+
+      await dismiss.focus();
+      await page.keyboard.press("Tab");
+      await page.keyboard.press("Shift+Tab");
+      const focusProof = await dismiss.evaluate((button) => ({
+        active: document.activeElement === button,
+        outlineStyle: getComputedStyle(button).outlineStyle,
+        outlineWidth: getComputedStyle(button).outlineWidth,
+      }));
+      expect(focusProof.active).toBe(true);
+      expect(focusProof.outlineStyle).toBe("solid");
+      expect(focusProof.outlineWidth).toBe("2px");
+
+      await dismiss.click();
+      await expect.poll(() => onboarding.count()).toBe(0);
+      const settingsKey = controlUiBundledSettingsStorageKey(suite.server.baseUrl);
+      expect(
+        await page.evaluate((key) => {
+          const raw = localStorage.getItem(key);
+          return raw ? (JSON.parse(raw) as { chatSplitOnboardingDismissed?: boolean }) : null;
+        }, settingsKey),
+      ).toMatchObject({ chatSplitOnboardingDismissed: true });
+
+      await page.reload();
+      await page.getByText("Split onboarding proof.").first().waitFor();
+      await expect.poll(() => panes.count()).toBe(2);
+      expect(await page.locator(".chat-split-onboarding").count()).toBe(0);
+
+      await panes
+        .last()
+        .locator(".chat-pane__header")
+        .getByRole("button", { name: "Close pane" })
+        .click();
+      await expect.poll(() => panes.count()).toBe(0);
+      await expect
+        .poll(() => page.getByRole("button", { name: "Open split view" }).isVisible())
+        .toBe(true);
+      expect(await page.locator(".chat-split-onboarding").count()).toBe(0);
+
+      await page.getByRole("button", { name: "Open split view" }).click();
+      await expect.poll(() => panes.count()).toBe(2);
+      expect(await page.locator(".chat-split-onboarding").count()).toBe(0);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("keeps the onboarding legible in dark mode at the side-by-side width", async () => {
+    const context = await suite.newBrowserContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1100 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          content: [{ type: "text", text: "Dark split onboarding proof." }],
+          role: "assistant",
+          timestamp: Date.now(),
+        },
+      ],
+      methodResponses: { "sessions.list": chatSessionListResponse() },
+      sessionKey: "agent:main:session-a",
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.getByText("Dark split onboarding proof.").waitFor();
+      await page.getByRole("button", { name: "Open split view" }).click();
+      const panes = page.locator("openclaw-chat-pane.chat-split-view__pane");
+      await expect.poll(() => panes.count()).toBe(2);
+      const onboarding = panes.first().locator(".chat-split-onboarding");
+      await expect.poll(() => onboarding.count()).toBe(1);
+      const metrics = await onboarding.evaluate((hint) => ({
+        clientWidth: hint.clientWidth,
+        scrollWidth: hint.scrollWidth,
+        clientHeight: hint.clientHeight,
+        scrollHeight: hint.scrollHeight,
+      }));
+      expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+      expect(metrics.scrollHeight).toBeLessThanOrEqual(metrics.clientHeight);
+
+      await mkdir(artifactDir, { recursive: true });
+      await page.screenshot({
+        fullPage: true,
+        path: path.join(artifactDir, "split-onboarding-dark.png"),
+      });
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5486,6 +5486,8 @@ export const en: TranslationMap = {
       closePane: "Close pane",
       dropSplit: "Split",
       dropOpenHere: "Open here",
+      onboarding: "Select another session to show it in this column.",
+      dismissOnboarding: "Don't show again",
     },
     sidebar: {
       updateMacAndGateway: "Update Mac app + Gateway",

--- a/ui/src/pages/chat/chat-page-pane-render.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.ts
@@ -26,6 +26,7 @@ type ChatPagePaneRenderOptions = {
   narrow: boolean;
   navDrawerOpen: boolean;
   onboarding: boolean;
+  onDismissSplitOnboarding?: () => void;
   onClosePane?: (paneId: string) => void;
   onFaceChange: (paneId: string, sessionKey: string, face: BoardFace) => void;
   onFocusPane: (paneId: string) => void;
@@ -43,6 +44,7 @@ type ChatPagePaneRenderOptions = {
   pane: ChatSplitPane;
   sessionKeys: readonly string[];
   showGatewayPicker: boolean;
+  splitOnboardingVisible: boolean;
   splitMode: boolean;
   weight: number;
 };
@@ -111,6 +113,8 @@ export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
               .nativeGateways=${nativeGateways}
               .gatewaysSnapshot=${nativeGateways?.snapshot ?? null}
               .onboarding=${options.onboarding}
+              .splitOnboardingVisible=${options.splitOnboardingVisible && presented}
+              .onDismissSplitOnboarding=${options.onDismissSplitOnboarding}
               .onOpenSplitView=${options.onOpenSplitView}
               .onSplitDown=${options.onSplitDown}
               .onSplitRight=${options.onSplitRight}

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -643,8 +643,7 @@ export class ChatPage extends OpenClawLightDomElement {
                     pane,
                     sessionKeys: retainedSessions.get(pane.id) ?? [],
                     showGatewayPicker: pane.id === rightmostPane?.id,
-                    splitOnboardingVisible:
-                      onboardingPaneId !== undefined && pane.id === onboardingPaneId,
+                    splitOnboardingVisible: pane.id === onboardingPaneId,
                     splitMode,
                     weight: splitWeight(
                       column.paneWeights,

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -60,6 +60,7 @@ export class ChatPage extends OpenClawLightDomElement {
   @property({ attribute: false }) data!: SessionChatRouteData;
   @property({ attribute: false }) navDrawerOpen = false;
   @state() private layout: ChatSplitLayout | undefined;
+  @state() private splitOnboardingDismissed = false;
   @state() private narrow = false;
   @state() private mergedChrome = false;
   @state() private dropIndicator: DropIndicator | null = null;
@@ -105,7 +106,9 @@ export class ChatPage extends OpenClawLightDomElement {
     this.snapshotStore.connect();
     observeChatCache(this.messageCache, this.snapshotStore);
     this.routeHref = window.location.href;
-    this.layout = loadSettings().chatSplitLayout;
+    const settings = loadSettings();
+    this.layout = settings.chatSplitLayout;
+    this.splitOnboardingDismissed = settings.chatSplitOnboardingDismissed === true;
     this.mediaQuery = window.matchMedia("(max-width: 1099px)");
     this.narrow = this.mediaQuery.matches;
     this.mediaQuery.addEventListener("change", this.handleViewportChange);
@@ -401,6 +404,14 @@ export class ChatPage extends OpenClawLightDomElement {
     patchSettings({ chatSplitLayout: layout });
   }
 
+  private readonly dismissSplitOnboarding = () => {
+    if (this.splitOnboardingDismissed) {
+      return;
+    }
+    this.splitOnboardingDismissed = true;
+    patchSettings({ chatSplitOnboardingDismissed: true });
+  };
+
   private updateRoute(sessionKey: string, replace = false, face = this.data.face ?? "chat") {
     const data = this.data;
     if (
@@ -582,6 +593,10 @@ export class ChatPage extends OpenClawLightDomElement {
   ) {
     const activeLocation = findPane(layout, layout.activePaneId);
     const rightmostPane = this.narrow ? activeLocation?.pane : layout.columns.at(-1)?.panes.at(-1);
+    const onboardingPaneId =
+      splitMode && !this.splitOnboardingDismissed && layout.columns.length > 1
+        ? layout.columns[0]?.panes[0]?.id
+        : undefined;
     return html`
       <div class="chat-split-view ${this.narrow ? "chat-split-view--narrow" : ""}">
         ${repeat(
@@ -615,6 +630,7 @@ export class ChatPage extends OpenClawLightDomElement {
                     narrow: this.narrow,
                     navDrawerOpen: this.navDrawerOpen,
                     onboarding: this.closest(".shell--onboarding") !== null,
+                    onDismissSplitOnboarding: this.dismissSplitOnboarding,
                     onClosePane: splitMode ? this.handleClosePane : undefined,
                     onFaceChange: this.handlePaneFaceChange,
                     onFocusPane: this.handleFocusPane,
@@ -627,6 +643,8 @@ export class ChatPage extends OpenClawLightDomElement {
                     pane,
                     sessionKeys: retainedSessions.get(pane.id) ?? [],
                     showGatewayPicker: pane.id === rightmostPane?.id,
+                    splitOnboardingVisible:
+                      onboardingPaneId !== undefined && pane.id === onboardingPaneId,
                     splitMode,
                     weight: splitWeight(
                       column.paneWeights,

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -595,7 +595,7 @@ export class ChatPage extends OpenClawLightDomElement {
     const rightmostPane = this.narrow ? activeLocation?.pane : layout.columns.at(-1)?.panes.at(-1);
     const onboardingPaneId =
       splitMode && !this.splitOnboardingDismissed && layout.columns.length > 1
-        ? layout.columns[0]?.panes[0]?.id
+        ? layout.activePaneId
         : undefined;
     return html`
       <div class="chat-split-view ${this.narrow ? "chat-split-view--narrow" : ""}">

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -183,6 +183,8 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   @property({ attribute: false }) nativeGateways?: NativeGatewaysCapability | null;
   @property({ attribute: false }) gatewaysSnapshot?: NativeGatewaysSnapshot | null;
   @property({ attribute: false }) onboarding = false;
+  @property({ attribute: false }) splitOnboardingVisible = false;
+  @property({ attribute: false }) onDismissSplitOnboarding?: () => void;
   @property({ attribute: false }) onOpenSplitView?: () => void;
   @property({ attribute: false }) onSplitDown?: (paneId: string) => void;
   @property({ attribute: false }) onSplitRight?: (paneId: string) => void;

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -85,7 +85,18 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       workspaceGit,
       sidebarLayout,
     );
-    const splitOnboarding = this.renderSplitOnboarding();
+    const splitOnboarding = this.splitOnboardingVisible
+      ? html`<div class="chat-split-onboarding">
+          <p class="chat-split-onboarding__copy">${t("chat.splitView.onboarding")}</p>
+          <button
+            class="btn btn--ghost chat-split-onboarding__dismiss"
+            type="button"
+            @click=${this.onDismissSplitOnboarding}
+          >
+            ${t("chat.splitView.dismissOnboarding")}
+          </button>
+        </div>`
+      : nothing;
     const chat = renderChat({
       ...chatProps,
       header: board.face === "dashboard" ? nothing : html`${header}${splitOnboarding}`,
@@ -175,21 +186,5 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       state.imageLightbox,
       state.handleCloseImage,
     )}${this.renderResetConfirmation()}`;
-  }
-
-  private renderSplitOnboarding() {
-    if (!this.splitOnboardingVisible) {
-      return nothing;
-    }
-    return html`<div class="chat-split-onboarding">
-      <p class="chat-split-onboarding__copy">${t("chat.splitView.onboarding")}</p>
-      <button
-        class="btn btn--ghost chat-split-onboarding__dismiss"
-        type="button"
-        @click=${this.onDismissSplitOnboarding}
-      >
-        ${t("chat.splitView.dismissOnboarding")}
-      </button>
-    </div>`;
   }
 }

--- a/ui/src/pages/chat/chat-pane-layout-render.ts
+++ b/ui/src/pages/chat/chat-pane-layout-render.ts
@@ -5,6 +5,7 @@ import type {
 } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { isDesktopPanelAvailable } from "../../app/app-shell-chrome.ts";
+import { t } from "../../i18n/index.ts";
 import { ChatPaneBrowserAnnotationRender } from "./chat-pane-browser-annotation-render.ts";
 import {
   availableSidebarSlots,
@@ -84,14 +85,17 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       workspaceGit,
       sidebarLayout,
     );
+    const splitOnboarding = this.renderSplitOnboarding();
     const chat = renderChat({
       ...chatProps,
-      header: board.face === "dashboard" ? nothing : header,
+      header: board.face === "dashboard" ? nothing : html`${header}${splitOnboarding}`,
     });
     // Keep this root stable across board face changes so the guarded board runtime
     // remains connected while Chat is active.
     const primary = html`<div class="chat-pane-primary-column">
-      ${board.face === "dashboard" ? header : nothing}${this.renderBoardPrimary(board, chat)}
+      ${board.face === "dashboard" ? header : nothing}
+      ${board.face === "dashboard" ? splitOnboarding : nothing}
+      ${this.renderBoardPrimary(board, chat)}
     </div>`;
     const discussion = this.buildSessionDiscussionPanel(state, state.sessionKey.trim());
     const desktopAvailable = isDesktopPanelAvailable(this.context.gateway.snapshot);
@@ -171,5 +175,21 @@ export abstract class ChatPaneLayoutRender extends ChatPaneBrowserAnnotationRend
       state.imageLightbox,
       state.handleCloseImage,
     )}${this.renderResetConfirmation()}`;
+  }
+
+  private renderSplitOnboarding() {
+    if (!this.splitOnboardingVisible) {
+      return nothing;
+    }
+    return html`<div class="chat-split-onboarding">
+      <p class="chat-split-onboarding__copy">${t("chat.splitView.onboarding")}</p>
+      <button
+        class="btn btn--ghost chat-split-onboarding__dismiss"
+        type="button"
+        @click=${this.onDismissSplitOnboarding}
+      >
+        ${t("chat.splitView.dismissOnboarding")}
+      </button>
+    </div>`;
   }
 }

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -6,4 +6,5 @@
 @import "./chat/question-card.css";
 @import "./chat/sidebar.css";
 @import "./chat/split-view.css";
+@import "./chat/split-onboarding.css";
 @import "./chat/board.css";

--- a/ui/src/styles/chat/split-onboarding.css
+++ b/ui/src/styles/chat/split-onboarding.css
@@ -1,5 +1,4 @@
 .chat-split-onboarding {
-  box-sizing: border-box;
   display: grid;
   justify-items: center;
   gap: 2px;
@@ -17,8 +16,7 @@
 .chat-split-onboarding__copy {
   max-width: 100%;
   margin: 0;
-  color: var(--text);
-  font-size: var(--control-ui-text-sm, 12px);
+  font-size: var(--control-ui-text-sm);
   line-height: 1.45;
   overflow-wrap: anywhere;
 }
@@ -28,11 +26,6 @@
   max-width: 100%;
   line-height: 1.3;
   white-space: normal;
-}
-
-.chat-split-onboarding__dismiss:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
 }
 
 @media (max-width: 640px) {

--- a/ui/src/styles/chat/split-onboarding.css
+++ b/ui/src/styles/chat/split-onboarding.css
@@ -1,0 +1,43 @@
+.chat-split-onboarding {
+  box-sizing: border-box;
+  display: grid;
+  justify-items: center;
+  gap: 2px;
+  width: min(420px, calc(100% - 24px));
+  margin: 12px auto 0;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+  border-radius: var(--radius-md);
+  background: var(--chat-surface);
+  box-shadow: var(--overlay-shadow);
+  color: var(--text);
+  text-align: center;
+}
+
+.chat-split-onboarding__copy {
+  max-width: 100%;
+  margin: 0;
+  color: var(--text);
+  font-size: var(--control-ui-text-sm, 12px);
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.chat-split-onboarding__dismiss {
+  min-height: 40px;
+  max-width: 100%;
+  line-height: 1.3;
+  white-space: normal;
+}
+
+.chat-split-onboarding__dismiss:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .chat-split-onboarding {
+    width: calc(100% - 16px);
+    padding-inline: 8px;
+  }
+}


### PR DESCRIPTION
Closes #126689

## What Problem This Solves

When the Control UI enters side-by-side split view, the effect of selecting another session in a column is not self-evident.

## Why This Change Was Made

This draft proposes a localized, in-flow coachmark beneath the active pane topbar. It explains that selecting another session shows it in that column and offers a localized “Don’t show again” action. The dismissal uses the existing browser-local UI settings owner, stays outside synced config and SQLite schema, does not take focus or block chat, and is absent outside split view.

## User Impact

The first split-view entry has a short contextual explanation in one column; the permanent dismissal survives reload and re-opening split view.

## Evidence

- Issue: #126689
- Proposed implementation is based on the current split-view owner and existing browser-local preference persistence.
- Closeout will add remote behavioral proof and visual captures after visual approval.