### PR TITLE
perf(tests): skip incidental Claude capture waits

### DIFF
--- a/src/agents/cli-runner/claude-live-process-capture.test.ts
+++ b/src/agents/cli-runner/claude-live-process-capture.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { markMcpLoopbackRequestStarted } from "../../gateway/mcp-http.loopback-runtime.js";
 import type { getProcessSupervisor } from "../../process/supervisor/index.js";
 import {
@@ -16,6 +17,23 @@ import { runClaudeTurn } from "./claude-live-session.js";
 import { resetClaudeLiveSessionsForTest } from "./claude-live-session.test-support.js";
 import { executePreparedCliRun } from "./execute.js";
 import { cliBackendLog } from "./log.js";
+
+// Gateway coverage owns quiet-admission timing; these cases preserve real capture draining.
+vi.mock("../../gateway/mcp-http.loopback-runtime.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../gateway/mcp-http.loopback-runtime.js")>();
+  return {
+    ...actual,
+    waitForMcpLoopbackToolCallCaptureIdle: (
+      captureKey: string,
+      options: Parameters<typeof actual.waitForMcpLoopbackToolCallCaptureIdle>[1],
+    ) =>
+      actual.waitForMcpLoopbackToolCallCaptureIdle(captureKey, {
+        ...options,
+        admissionGraceMs: 0,
+      }),
+  };
+});
 
 type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
 type SupervisorSpawnFn = ProcessSupervisor["spawn"];
@@ -328,7 +346,9 @@ describe("Claude live MCP capture lifetime", () => {
   });
 
   it("closes a captured Claude live process when MCP delivery capture cannot drain", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const logInfoSpy = vi.spyOn(cliBackendLog, "info").mockImplementation(() => undefined);
+    const requestStarted = createDeferred();
     const live = mockClaudeLiveRun(supervisorSpawnMock, {
       cancelable: true,
       onWrite: ({ data, emit }) => {
@@ -336,6 +356,7 @@ describe("Claude live MCP capture lifetime", () => {
           return;
         }
         markMcpLoopbackRequestStarted(live.spawnInput.env?.OPENCLAW_MCP_CLI_CAPTURE_KEY);
+        requestStarted.resolve();
         emit([
           { type: "system", subtype: "init", session_id: "captured-drain" },
           { type: "result", session_id: "captured-drain", result: "ok" },
@@ -349,9 +370,14 @@ describe("Claude live MCP capture lifetime", () => {
       mcpDeliveryCapture: true,
     });
 
-    await expect(executePreparedCliRun(context)).rejects.toThrow(
+    const pending = executePreparedCliRun(context);
+    await requestStarted.promise;
+    await vi.advanceTimersByTimeAsync(0);
+    const rejection = expect(pending).rejects.toThrow(
       "CLI message tool call remained in flight after exit",
     );
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejection;
     expect(live.lifecycle.cancel).toHaveBeenCalledWith("manual-cancel");
     expect(
       logInfoSpy.mock.calls


### PR DESCRIPTION
## What Problem This Solves

The recently added Claude live-process capture regression suite made every scoped agent-test run wait roughly 6.5 real seconds for timing windows that are already protected at their owning boundary.

## Why This Change Was Made

Keep the real Gateway capture, request admission, warm-process lifecycle, grant fencing, and failure cleanup while using the neighboring capture suite's existing zero-admission-grace wrapper. Advance only the deliberately stuck request's real drain timeout with Vitest's fake clock after the request has actually been admitted; use the existing repository deferred helper for that synchronization.

## User Impact

No user-visible or production behavior changes. Maintainers get faster agent-test and CI feedback without losing any Claude live-session, thinking-environment, capture, or fail-closed process coverage.

## Evidence

- Same Blacksmith Testbox `tbx_01m0fv90wywzpxg1dt1ph0x8rn`; one discarded warmup plus two retained one-worker samples on each side, with distinct module-cache paths, import-duration/breakdown reporting, and `/usr/bin/time -v`.
- Scoped wall time: **34.96 s / 27.61 s before -> 26.94 s / 19.83 s after**; means **31.29 s -> 23.39 s**, saving **7.90 s (25.3%)**.
- Vitest duration: **30.30 s / 23.40 s -> 22.07 s / 15.94 s**; actual test-body time: **6.76 s / 6.74 s -> 0.222 s / 0.165 s**. All six test cases remain unchanged.
- Import timing is noisy but comparable: **21.82 s / 15.59 s -> 20.70 s / 14.79 s**. CPU user/system: **30.48/3.77 s and 22.94/2.80 s -> 28.92/3.58 s and 21.40/2.64 s**. Peak RSS: **1,259,388 / 1,272,232 KiB -> 1,313,612 / 1,321,232 KiB**.
- Production-owner mutation proof: temporarily removing `closeClaudeSession(context, "mcp-capture-rotation")` makes the retained timeout regression fail specifically with `expected "vi.fn()" to be called with arguments: [ 'manual-cancel' ]`; the production owner was restored exactly.
- Focused owner/siblings: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/cli-runner/claude-live-process-capture.test.ts src/agents/cli-runner/execute.supervisor-capture.test.ts src/agents/cli-runner/claude-live-turn.test.ts src/agents/cli-runner/claude-live-background-tasks.test.ts --maxWorkers=1` -> **4 files, 97 tests passed**.
- Independent real quiet-admission boundary: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/mcp-http.test.ts --maxWorkers=1 -t 'waits through a quiet admission grace before clearing a failed-turn capture'` -> **2 routed gateway cases passed**.
- Complete clean-machine `pnpm check:changed` passed on the same Testbox, including all repository guards, full core-test typecheck, and core lint. Testbox run: https://github.com/openclaw/openclaw/actions/runs/32384033130
- Fresh structured autoreview: no accepted/actionable findings, including a repeat against the rebased branch.
- Production LOC **+0/-0**; tests **+27/-1**; one test file only. AI-assisted; no agent transcript.
