### PR TITLE
fix(plugins): retire executable plugin caches on metadata lifecycle clears

### DIFF
--- a/src/media/document-extractors.runtime.test.ts
+++ b/src/media/document-extractors.runtime.test.ts
@@ -1,5 +1,6 @@
 // Document extractor runtime tests cover lazy document extraction adapters.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 
 const { resolvePluginDocumentExtractorsMock } = vi.hoisted(() => ({
   resolvePluginDocumentExtractorsMock: vi.fn(),
@@ -84,5 +85,38 @@ describe("extractDocumentContent", () => {
     }
     expect(extractionError.message).toBe("Document extraction failed for application/pdf");
     expect(extractionError.cause).toBe(cause);
+  });
+
+  it("replaces cached document extractor callbacks when plugin metadata changes", async () => {
+    const oldExtract = vi.fn().mockResolvedValue({ text: "retired", images: [] });
+    const newExtract = vi.fn().mockResolvedValue({ text: "replacement", images: [] });
+    const config = {};
+    const createExtractor = (extract: typeof oldExtract) => ({
+      id: "pdf",
+      pluginId: "document-extract",
+      label: "PDF",
+      mimeTypes: ["application/pdf"],
+      extract,
+    });
+    resolvePluginDocumentExtractorsMock
+      .mockReturnValueOnce([createExtractor(oldExtract)])
+      .mockReturnValueOnce([createExtractor(newExtract)]);
+    const request = {
+      buffer: Buffer.from("pdf"),
+      mimeType: "application/pdf",
+      maxPages: 1,
+      maxPixels: 100,
+      minTextChars: 10,
+      config,
+    };
+
+    await expect(extractDocumentContent(request)).resolves.toMatchObject({ text: "retired" });
+
+    clearPluginMetadataLifecycleCaches();
+
+    await expect(extractDocumentContent(request)).resolves.toMatchObject({ text: "replacement" });
+    expect(resolvePluginDocumentExtractorsMock).toHaveBeenCalledTimes(2);
+    expect(oldExtract).toHaveBeenCalledOnce();
+    expect(newExtract).toHaveBeenCalledOnce();
   });
 });

--- a/src/plugin-sdk/facade-loader.test.ts
+++ b/src/plugin-sdk/facade-loader.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
 import {
   listImportedBundledPluginFacadeIds,
@@ -369,6 +370,34 @@ describe("plugin-sdk facade loader", () => {
     expect(first.marker).toBe("identity-check");
     expect(listImportedBundledPluginFacadeIds()).toEqual([fixture.pluginId]);
     expect(listImportedFacadeRuntimeIds()).toEqual([fixture.pluginId]);
+  });
+
+  it("reloads replaced facade artifacts and dependencies without erasing imported-plugin history", () => {
+    const pluginRoot = fs.realpathSync(createTempDirSync("openclaw-facade-replacement-"));
+    const modulePath = path.join(pluginRoot, "api.js");
+    const dependencyPath = path.join(pluginRoot, "dependency.js");
+    fs.writeFileSync(path.join(pluginRoot, "package.json"), '{"type":"commonjs"}\n', "utf8");
+
+    const writeArtifact = (marker: string) => {
+      fs.writeFileSync(dependencyPath, `module.exports = ${JSON.stringify(marker)};\n`, "utf8");
+      fs.writeFileSync(modulePath, 'module.exports = { marker: require("./dependency.js") };\n');
+    };
+    const loadArtifact = () =>
+      loadFacadeModuleAtLocationSync<{ marker: string }>({
+        location: { modulePath, boundaryRoot: pluginRoot },
+        trackedPluginId: "replacement-plugin",
+      }).marker;
+
+    writeArtifact("retired");
+    expect(loadArtifact()).toBe("retired");
+
+    writeArtifact("replacement");
+    expect(loadArtifact()).toBe("retired");
+
+    clearPluginMetadataLifecycleCaches();
+
+    expect(listImportedBundledPluginFacadeIds()).toContain("replacement-plugin");
+    expect(loadArtifact()).toBe("replacement");
   });
 
   it("uses native require for Windows dist facade loads", () => {

--- a/src/plugin-sdk/facade-loader.ts
+++ b/src/plugin-sdk/facade-loader.ts
@@ -5,7 +5,9 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { openRootFileSync } from "../infra/boundary-file-read.js";
 import { resolveBundledPluginsDir } from "../plugins/bundled-dir.js";
 import { shouldRejectHardlinkedPluginFiles } from "../plugins/hardlink-policy.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "../plugins/plugin-metadata-lifecycle.js";
 import {
+  clearPluginModuleLoaderLifecycleCache,
   getCachedPluginModuleLoader,
   type PluginModuleLoaderCache,
   type PluginModuleLoaderFactory,
@@ -25,9 +27,16 @@ const CURRENT_MODULE_PATH = fileURLToPath(import.meta.url);
 
 const moduleLoaders: PluginModuleLoaderCache = new Map();
 const loadedFacadeModules = new Map<string, unknown>();
+const loadedFacadeModuleRoots = new Map<string, string>();
 const loadedFacadePluginIds = new Set<string>();
 let facadeLoaderSourceTransformFactory: PluginModuleLoaderFactory | undefined;
 let cachedOpenClawPackageRoot: string | undefined;
+
+// Facade exports and native loader closures must retire with their plugin; imported ids are history.
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  loadedFacadeModules.clear();
+  clearPluginModuleLoaderLifecycleCache({ moduleLoaders, moduleRoots: loadedFacadeModuleRoots });
+});
 
 function getOpenClawPackageRoot() {
   if (cachedOpenClawPackageRoot) {
@@ -196,6 +205,7 @@ export function loadFacadeModuleAtLocationSync<T extends object>(params: {
     loaded =
       params.loadModule?.(location.modulePath) ??
       (getModuleLoader(location.modulePath)(location.modulePath) as T);
+    loadedFacadeModuleRoots.set(location.modulePath, location.boundaryRoot);
     Object.assign(sentinel, loaded);
     loadedFacadePluginIds.add(
       typeof params.trackedPluginId === "function"
@@ -261,6 +271,7 @@ export async function loadBundledPluginPublicSurfaceModule<T extends object>(par
   fs.closeSync(opened.fd);
 
   try {
+    // Native ESM imports cannot be evicted; bundled core-dist artifacts change only on restart.
     const loaded = (await import(pathToFileURL(preparedLocation.modulePath).href)) as T;
     loadedFacadeModules.set(preparedLocation.modulePath, loaded);
     loadedFacadePluginIds.add(
@@ -286,7 +297,7 @@ export function listImportedBundledPluginFacadeIds(): string[] {
 export function resetFacadeLoaderStateForTest(): void {
   loadedFacadeModules.clear();
   loadedFacadePluginIds.clear();
-  moduleLoaders.clear();
+  clearPluginModuleLoaderLifecycleCache({ moduleLoaders, moduleRoots: loadedFacadeModuleRoots });
   facadeLoaderSourceTransformFactory = undefined;
   cachedOpenClawPackageRoot = undefined;
 }

--- a/src/plugins/doctor-contract-registry-loader-state.ts
+++ b/src/plugins/doctor-contract-registry-loader-state.ts
@@ -1,7 +1,7 @@
 /** Shared loader state for plugin doctor contracts and test fixtures. */
-import { clearNativeRequireJavaScriptModuleCache } from "./native-module-require.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import {
+  clearPluginModuleLoaderLifecycleCache,
   createPluginModuleLoaderCache,
   type PluginModuleLoaderFactory,
 } from "./plugin-module-loader-cache.js";
@@ -13,12 +13,6 @@ export const pluginDoctorContractRegistryLoaderState = {
   moduleLoaderFactory: undefined as PluginModuleLoaderFactory | undefined,
 };
 
-function clearPluginDoctorContractRegistryLoaderState(): void {
-  pluginDoctorContractRegistryLoaderState.moduleLoaders.clear();
-  for (const [modulePath, rootDir] of pluginDoctorContractRegistryLoaderState.moduleRoots) {
-    clearNativeRequireJavaScriptModuleCache(modulePath, { dependencyRoot: rootDir });
-  }
-  pluginDoctorContractRegistryLoaderState.moduleRoots.clear();
-}
-
-registerPluginMetadataProcessMemoLifecycleClear(clearPluginDoctorContractRegistryLoaderState);
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  clearPluginModuleLoaderLifecycleCache(pluginDoctorContractRegistryLoaderState);
+});

--- a/src/plugins/plugin-cache-primitives.test.ts
+++ b/src/plugins/plugin-cache-primitives.test.ts
@@ -7,6 +7,7 @@ import {
   resolveConfigScopedRuntimeCacheValue,
   type ConfigScopedRuntimeCache,
 } from "./plugin-cache-primitives.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 
 describe("PluginLruCache", () => {
   it("evicts the least recently used entry", () => {
@@ -128,6 +129,22 @@ describe("createConfigScopedPromiseLoader", () => {
     await expect(loader.load(config)).resolves.toBe("config-2");
 
     loader.clear();
+
+    await expect(loader.load()).resolves.toBe("default-3");
+    await expect(loader.load(config)).resolves.toBe("config-4");
+  });
+
+  it("drops default and config-scoped executable promises when plugin metadata changes", async () => {
+    const config = {} as OpenClawConfig;
+    let calls = 0;
+    const loader = createConfigScopedPromiseLoader(
+      async (owner?: OpenClawConfig) => `${owner ? "config" : "default"}-${++calls}`,
+    );
+
+    await expect(loader.load()).resolves.toBe("default-1");
+    await expect(loader.load(config)).resolves.toBe("config-2");
+
+    clearPluginMetadataLifecycleCaches();
 
     await expect(loader.load()).resolves.toBe("default-3");
     await expect(loader.load(config)).resolves.toBe("config-4");

--- a/src/plugins/plugin-cache-primitives.ts
+++ b/src/plugins/plugin-cache-primitives.ts
@@ -1,6 +1,7 @@
 // Defines lifecycle-owned cache primitives for plugin metadata.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 
 /** Result shape for cache lookups that need to distinguish a miss from cached `undefined`. */
 type PluginLruCacheResult<T> = { hit: true; value: T } | { hit: false };
@@ -105,7 +106,7 @@ export function createConfigScopedPromiseLoader<T>(
     return promise;
   };
 
-  return {
+  const loader: ConfigScopedPromiseLoader<T> = {
     async load(config?: OpenClawConfig): Promise<T> {
       if (!config) {
         defaultPromise ??= createPromise();
@@ -124,6 +125,9 @@ export function createConfigScopedPromiseLoader<T>(
       promisesByConfig = new WeakMap<OpenClawConfig, Promise<T>>();
     },
   };
+  // Resolved values can retain executable plugin callbacks past install, replacement, or removal.
+  registerPluginMetadataProcessMemoLifecycleClear(() => loader.clear());
+  return loader;
 }
 
 function normalizeMaxEntries(value: number, fallback: number): number {

--- a/src/plugins/plugin-module-loader-cache.test.ts
+++ b/src/plugins/plugin-module-loader-cache.test.ts
@@ -856,3 +856,34 @@ describe("getCachedPluginModuleLoader", () => {
     );
   });
 });
+
+describe("clearPluginModuleLoaderLifecycleCache", () => {
+  it.each([
+    { boundaryRoot: "/repo/dist/extensions/demo", dependencyRoot: "/repo/dist" },
+    { boundaryRoot: "/repo/dist/extensions", dependencyRoot: "/repo/dist" },
+    { boundaryRoot: "/repo/installed/demo", dependencyRoot: "/repo/installed/demo" },
+  ])("evicts native dependencies under $dependencyRoot for $boundaryRoot", async (params) => {
+    const clearNativeRequireJavaScriptModuleCache = vi.fn();
+    vi.doMock("./native-module-require.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./native-module-require.js")>()),
+      clearNativeRequireJavaScriptModuleCache,
+    }));
+    const { clearPluginModuleLoaderLifecycleCache } = await importFreshModule<
+      typeof import("./plugin-module-loader-cache.js")
+    >(
+      import.meta.url,
+      `./plugin-module-loader-cache.js?scope=lifecycle-${params.boundaryRoot.replaceAll("/", "-")}`,
+    );
+    const modulePath = "/repo/dist/extensions/demo/api.js";
+    const moduleLoaders = new Map([[modulePath, () => ({ marker: "retired" })]]);
+    const moduleRoots = new Map([[modulePath, params.boundaryRoot]]);
+
+    clearPluginModuleLoaderLifecycleCache({ moduleLoaders, moduleRoots });
+
+    expect(clearNativeRequireJavaScriptModuleCache).toHaveBeenCalledWith(modulePath, {
+      dependencyRoot: params.dependencyRoot,
+    });
+    expect(moduleLoaders.size).toBe(0);
+    expect(moduleRoots.size).toBe(0);
+  });
+});

--- a/src/plugins/plugin-module-loader-cache.ts
+++ b/src/plugins/plugin-module-loader-cache.ts
@@ -4,7 +4,10 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { createJiti } from "jiti";
 import { toSafeImportPath } from "../shared/import-specifier.js";
-import { tryNativeRequireJavaScriptModule } from "./native-module-require.js";
+import {
+  clearNativeRequireJavaScriptModuleCache,
+  tryNativeRequireJavaScriptModule,
+} from "./native-module-require.js";
 import { PluginLruCache } from "./plugin-cache-primitives.js";
 import { installOpenClawInternalCorePackageNativeResolver } from "./plugin-sdk-native-resolver.js";
 import {
@@ -115,6 +118,24 @@ export function createPluginModuleLoaderCache(
   maxEntries = DEFAULT_PLUGIN_MODULE_LOADER_CACHE_ENTRIES,
 ): PluginModuleLoaderCache {
   return new PluginLruCache<PluginModuleLoader>(maxEntries);
+}
+
+/** Evicts loader closures and native modules, including bundled chunks hoisted into dist. */
+export function clearPluginModuleLoaderLifecycleCache(params: {
+  moduleLoaders: PluginModuleLoaderCache;
+  moduleRoots: Map<string, string>;
+}): void {
+  params.moduleLoaders.clear();
+  for (const [modulePath, rootDir] of params.moduleRoots) {
+    const extensionsDir = path.basename(rootDir) === "extensions" ? rootDir : path.dirname(rootDir);
+    const distDir = path.dirname(extensionsDir);
+    const dependencyRoot =
+      path.basename(extensionsDir) === "extensions" && path.basename(distDir) === "dist"
+        ? distDir
+        : rootDir;
+    clearNativeRequireJavaScriptModuleCache(modulePath, { dependencyRoot });
+  }
+  params.moduleRoots.clear();
 }
 
 function toSourceTransformImportPath(specifier: string): string {

--- a/src/plugins/provider-discovery.runtime.test.ts
+++ b/src/plugins/provider-discovery.runtime.test.ts
@@ -38,12 +38,14 @@ vi.mock("./providers.runtime.js", () => ({
   resolvePluginProvidersCore: mocks.resolvePluginProvidersCore,
 }));
 
-vi.mock("./plugin-module-loader-cache.js", () => ({
+vi.mock("./plugin-module-loader-cache.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./plugin-module-loader-cache.js")>()),
   createPluginModuleLoaderCache: mocks.createPluginModuleLoaderCache,
   getCachedPluginModuleLoader: mocks.getCachedPluginModuleLoader,
 }));
 
-vi.mock("./native-module-require.js", () => ({
+vi.mock("./native-module-require.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./native-module-require.js")>()),
   clearNativeRequireJavaScriptModuleCache: mocks.clearNativeRequireJavaScriptModuleCache,
 }));
 

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -1,5 +1,4 @@
 // Runtime boundary for provider discovery through plugin entrypoints.
-import path from "node:path";
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { sortUniqueStrings } from "../../packages/normalization-core/src/string-normalization.js";
@@ -8,11 +7,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { planEffectiveModelCatalogRows } from "../model-catalog/index.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
-import { clearNativeRequireJavaScriptModuleCache } from "./native-module-require.js";
 import { withProfile } from "./plugin-load-profile.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
 import {
+  clearPluginModuleLoaderLifecycleCache,
   createPluginModuleLoaderCache,
   getCachedPluginModuleLoader,
 } from "./plugin-module-loader-cache.js";
@@ -41,26 +40,12 @@ type ProviderDiscoveryEntryResult = {
 const providerDiscoveryModuleLoaders = createPluginModuleLoaderCache();
 const providerDiscoveryModuleRoots = new Map<string, string>();
 
-function resolveProviderDiscoveryDependencyRoot(rootDir: string): string {
-  const extensionsDir = path.dirname(rootDir);
-  const distDir = path.dirname(extensionsDir);
-  // Bundled dist provider entries import hoisted dist/*.js chunks outside
-  // dist/extensions/<plugin>; lifecycle clears must evict those chunks too.
-  if (path.basename(extensionsDir) === "extensions" && path.basename(distDir) === "dist") {
-    return distDir;
-  }
-  return rootDir;
-}
-
-function clearProviderDiscoveryModuleLoaders(): void {
-  providerDiscoveryModuleLoaders.clear();
-  for (const [modulePath, rootDir] of providerDiscoveryModuleRoots) {
-    clearNativeRequireJavaScriptModuleCache(modulePath, { dependencyRoot: rootDir });
-  }
-  providerDiscoveryModuleRoots.clear();
-}
-
-registerPluginMetadataProcessMemoLifecycleClear(clearProviderDiscoveryModuleLoaders);
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  clearPluginModuleLoaderLifecycleCache({
+    moduleLoaders: providerDiscoveryModuleLoaders,
+    moduleRoots: providerDiscoveryModuleRoots,
+  });
+});
 
 function normalizeDiscoveryModule(value: ProviderDiscoveryModule): ProviderPlugin[] {
   const resolved =
@@ -90,10 +75,7 @@ function loadProviderDiscoveryModule(params: {
   modulePath: string;
   rootDir: string;
 }): ProviderDiscoveryModule {
-  providerDiscoveryModuleRoots.set(
-    params.modulePath,
-    resolveProviderDiscoveryDependencyRoot(params.rootDir),
-  );
+  providerDiscoveryModuleRoots.set(params.modulePath, params.rootDir);
   const moduleLoader = getCachedPluginModuleLoader({
     cache: providerDiscoveryModuleLoaders,
     modulePath: params.modulePath,

--- a/src/plugins/provider-policy-surface.test.ts
+++ b/src/plugins/provider-policy-surface.test.ts
@@ -42,4 +42,53 @@ describe("direct provider policy surface", () => {
     });
     expect(manifestRegistryModuleFactory).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { owner: "bundled", initial: "surface" },
+    { owner: "bundled", initial: "missing" },
+    { owner: "external", initial: "surface" },
+    { owner: "external", initial: "missing" },
+  ] as const)(
+    "drops cached $owner provider policy $initial entries when plugin metadata changes",
+    async ({ owner, initial }) => {
+      const retiredHook = vi.fn();
+      const replacementHook = vi.fn();
+      const loadArtifact = vi
+        .fn()
+        .mockReturnValueOnce(initial === "surface" ? { resolveModelRoutes: retiredHook } : {})
+        .mockReturnValueOnce({ resolveModelRoutes: replacementHook });
+
+      vi.doMock("./bundled-dir.js", () => ({
+        resolveBundledPluginsDir: () => "/tmp/bundled-plugins",
+      }));
+      vi.doMock("./public-surface-loader.js", () => ({
+        loadBundledPluginPublicArtifactModuleSync: loadArtifact,
+        loadPluginPublicArtifactModuleSync: loadArtifact,
+      }));
+
+      const policySurface = await importFreshModule<typeof import("./provider-policy-surface.js")>(
+        import.meta.url,
+        `./provider-policy-surface.js?scope=lifecycle-${owner}-${initial}`,
+      );
+      const { clearPluginMetadataLifecycleCaches } = await import("./plugin-metadata-lifecycle.js");
+      const resolveSurface = () =>
+        owner === "bundled"
+          ? policySurface.resolveDirectBundledProviderPolicySurface("demo")
+          : policySurface.resolveTrustedExternalProviderPolicySurface({
+              pluginId: "demo",
+              pluginRoot: "/tmp/demo",
+              trustedOfficialInstall: true,
+            });
+
+      const expectedInitial = initial === "surface" ? retiredHook : undefined;
+      expect(resolveSurface()?.resolveModelRoutes).toBe(expectedInitial);
+      expect(resolveSurface()?.resolveModelRoutes).toBe(expectedInitial);
+      expect(loadArtifact).toHaveBeenCalledOnce();
+
+      clearPluginMetadataLifecycleCaches();
+
+      expect(resolveSurface()?.resolveModelRoutes).toBe(replacementHook);
+      expect(loadArtifact).toHaveBeenCalledTimes(2);
+    },
+  );
 });

--- a/src/plugins/provider-policy-surface.ts
+++ b/src/plugins/provider-policy-surface.ts
@@ -8,6 +8,7 @@ import type {
   ProviderResolveModelRoutesContext,
 } from "../plugin-sdk/provider-model-types.js";
 import { resolveBundledPluginsDir } from "./bundled-dir.js";
+import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import type {
   ProviderApplyConfigDefaultsContext,
   ProviderNormalizeConfigContext,
@@ -82,6 +83,12 @@ const bundledProviderPolicySurfaceByPluginId = new Map<
   BundledProviderPolicySurface | null
 >();
 const externalProviderPolicySurfaceByPluginId = new Map<string, ProviderPolicySurface | null>();
+
+// Policy hooks and negative lookups must not outlive plugin replacement or installation.
+registerPluginMetadataProcessMemoLifecycleClear(() => {
+  bundledProviderPolicySurfaceByPluginId.clear();
+  externalProviderPolicySurfaceByPluginId.clear();
+});
 
 const PROVIDER_POLICY_HOOK_KEYS = [
   "normalizeConfig",

--- a/src/plugins/public-surface-loader.test.ts
+++ b/src/plugins/public-surface-loader.test.ts
@@ -301,6 +301,39 @@ describe("bundled plugin public surface loader", () => {
     },
   );
 
+  it("reloads a replaced installed public artifact and its dependencies after plugin metadata changes", async () => {
+    const publicSurfaceLoader = await importFreshModule<
+      typeof import("./public-surface-loader.js")
+    >(import.meta.url, "./public-surface-loader.js?scope=installed-artifact-replacement");
+    const { clearPluginMetadataLifecycleCaches } = await import("./plugin-metadata-lifecycle.js");
+    const tempRoot = fs.realpathSync(tempDirs.make("openclaw-public-surface-replacement-"));
+    const pluginRoot = path.join(tempRoot, "installed-plugin");
+    const modulePath = path.join(pluginRoot, "api.js");
+    const dependencyPath = path.join(pluginRoot, "dependency.js");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    fs.writeFileSync(path.join(pluginRoot, "package.json"), '{"type":"commonjs"}\n', "utf8");
+
+    const writeArtifact = (marker: string) => {
+      fs.writeFileSync(dependencyPath, `module.exports = ${JSON.stringify(marker)};\n`, "utf8");
+      fs.writeFileSync(modulePath, 'module.exports = { marker: require("./dependency.js") };\n');
+    };
+    const loadArtifact = () =>
+      publicSurfaceLoader.loadPluginPublicArtifactModuleSync<{ marker: string }>({
+        pluginRoot,
+        artifactBasename: "api.js",
+      }).marker;
+
+    writeArtifact("retired");
+    expect(loadArtifact()).toBe("retired");
+
+    writeArtifact("replacement");
+    expect(loadArtifact()).toBe("retired");
+
+    clearPluginMetadataLifecycleCaches();
+
+    expect(loadArtifact()).toBe("replacement");
+  });
+
   it.runIf(process.platform !== "win32")(
     "allows hardlinked bundled public artifacts under the trusted bundled root",
     async () => {

--- a/src/plugins/public-surface-loader.ts
+++ b/src/plugins/public-surface-loader.ts
@@ -10,6 +10,7 @@ import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import {
+  clearPluginModuleLoaderLifecycleCache,
   createPluginModuleLoaderCache,
   getCachedPluginModuleLoader,
   type PluginModuleLoaderCache,
@@ -33,9 +34,13 @@ type PublicSurfaceLocation = {
 };
 const publicSurfaceLocationCache = new Map<string, PublicSurfaceLocation>();
 const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
+const publicSurfaceModuleRoots = new Map<string, string>();
 
+// Replaced plugin artifacts retain executable exports in both loader closures and native require.
 registerPluginMetadataProcessMemoLifecycleClear(() => {
   publicSurfaceLocationCache.clear();
+  publicSurfaceModuleCache.clear();
+  clearPluginModuleLoaderLifecycleCache({ moduleLoaders, moduleRoots: publicSurfaceModuleRoots });
 });
 
 function isSourceArtifactPath(modulePath: string): boolean {
@@ -162,6 +167,7 @@ function loadValidatedPublicSurfaceModule(params: {
   publicSurfaceModuleCache.set(validatedPath, sentinel);
   try {
     const loaded = loadPublicSurfaceModule(validatedPath) as object;
+    publicSurfaceModuleRoots.set(validatedPath, params.boundaryRoot);
     Object.assign(sentinel, loaded);
     return sentinel;
   } catch (error) {

--- a/src/web-fetch/content-extractors.runtime.test.ts
+++ b/src/web-fetch/content-extractors.runtime.test.ts
@@ -1,0 +1,45 @@
+/** Protects plugin-owned web extractor callbacks across metadata lifecycle changes. */
+import { describe, expect, it, vi } from "vitest";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+
+const { resolvePluginWebContentExtractorsMock } = vi.hoisted(() => ({
+  resolvePluginWebContentExtractorsMock: vi.fn(),
+}));
+
+vi.mock("../plugins/web-content-extractors.runtime.js", () => ({
+  resolvePluginWebContentExtractors: resolvePluginWebContentExtractorsMock,
+}));
+
+import { extractReadableContent } from "./content-extractors.runtime.js";
+
+describe("extractReadableContent", () => {
+  it("replaces cached web content extractor callbacks when plugin metadata changes", async () => {
+    const oldExtract = vi.fn().mockResolvedValue({ text: "retired" });
+    const newExtract = vi.fn().mockResolvedValue({ text: "replacement" });
+    const config = {};
+    const createExtractor = (extract: typeof oldExtract) => ({
+      id: "readable",
+      pluginId: "web-content-extract",
+      label: "Readable",
+      extract,
+    });
+    resolvePluginWebContentExtractorsMock
+      .mockReturnValueOnce([createExtractor(oldExtract)])
+      .mockReturnValueOnce([createExtractor(newExtract)]);
+    const request = {
+      html: "<p>content</p>",
+      url: "https://example.test/page",
+      extractMode: "text" as const,
+      config,
+    };
+
+    await expect(extractReadableContent(request)).resolves.toMatchObject({ text: "retired" });
+
+    clearPluginMetadataLifecycleCaches();
+
+    await expect(extractReadableContent(request)).resolves.toMatchObject({ text: "replacement" });
+    expect(resolvePluginWebContentExtractorsMock).toHaveBeenCalledTimes(2);
+    expect(oldExtract).toHaveBeenCalledOnce();
+    expect(newExtract).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where retired or replaced plugins could keep executing after being uninstalled or replaced. Four executable-authority caches — the document/web-content extractor loader, the provider policy hook maps, the public surface module loader, and the SDK facade loader — never registered with the existing plugin metadata lifecycle clear seam, so a plugin install, replacement, or uninstall left their cached callbacks, module exports, and native `require` entries in place and still reachable at runtime.

## Why This Change Was Made

`registerPluginMetadataProcessMemoLifecycleClear` (fired by `clearPluginMetadataLifecycleCaches()` on every installed-plugin-index write) is the repo's existing canonical invalidation seam; sibling caches such as `facade-runtime.ts`'s location cache and `provider-discovery.runtime.ts`'s module loaders already register with it. This change wires the four gap caches to that same seam instead of introducing a second invalidation mechanism (registry epochs were considered and rejected — those are closure-authority primitives for channel runtimes, not memo invalidation).

`createConfigScopedPromiseLoader` now self-registers its own `clear()` at the factory in `src/plugins/plugin-cache-primitives.ts`, so both extractor loaders were fixed by one change and the bug class is closed for future callers. The provider policy surface maps (including cached negative lookups) now clear on lifecycle changes. For the two module-serving caches (`public-surface-loader.ts`, `facade-loader.ts`), clearing the outer map alone would be cosmetic — Node's `require` cache would still serve stale code for a same-path plugin replacement — so both now track loaded module roots and evict the native `require` subtree via a shared `clearPluginModuleLoaderLifecycleCache` helper extracted into `plugin-module-loader-cache.ts`. That extraction also absorbed two pre-existing near-copies of the same tracked-roots+evict pattern in `provider-discovery.runtime.ts` and `doctor-contract-registry-loader-state.ts`, keeping net production growth to +25 lines despite fixing four independent leaks.

One known limitation is documented inline rather than fixed: the async bundled-facade path uses raw `await import()`, whose native ESM cache cannot be evicted. This is acceptable because bundled core-dist artifacts only change on process restart, not on install/replace/uninstall.

## User Impact

Operators and plugin authors get correct isolation: uninstalling or replacing a plugin now reliably retires its document/web-content extractors, provider policy hooks, and public/facade API exports in the same process, instead of leaving old executable code reachable until the process restarts.

## Evidence

- Regression tests were run against unchanged production code first and failed for the intended reason (stale/retired callback still executing), including an on-disk artifact-replacement test that proves native `require` cache invalidation, not just outer-map clearing.
- `node scripts/check-changed.mjs`: pass (formatting, typecheck, lint, guards).
- `pnpm check:import-cycles`: pass, zero runtime value cycles.
- `pnpm build`: pass, including all bundled/external plugins and public SDK subpaths, no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings.
- Full touched/sibling suite: 93 tests passing across `plugin-cache-primitives`, `plugin-module-loader-cache`, `provider-discovery.runtime`, `provider-policy-surface`, `public-surface-loader`, `facade-loader`, `document-extractors.runtime`, `content-extractors.runtime`, and `management-service.lifecycle-cache`.
- Codex autoreview (`gpt-5.6-sol`, high reasoning) on the final diff: clean, no accepted/actionable findings, overall correctness 0.98.
