### PR TITLE
fix(skills): reuse plugin metadata for execution workspaces

### DIFF
--- a/src/skills/lifecycle/upload-store.test.ts
+++ b/src/skills/lifecycle/upload-store.test.ts
@@ -668,9 +668,11 @@ describe("skill upload store", () => {
   });
 
   it("renews the install lease and preserves an expired leased upload", async () => {
+    let now = 1000;
     const { databasePath, store } = await makeStore({
       installLeaseHeartbeatMs: 10,
       installLeaseMs: 100,
+      now: () => now,
     });
     const archive = Buffer.from("abc");
     const committed = await store.begin({
@@ -687,47 +689,53 @@ describe("skill upload store", () => {
 
     const entered = deferred();
     const release = deferred();
+    vi.useFakeTimers();
     const pinned = store.withCommittedUpload(committed.uploadId, async () => {
       entered.resolve();
       await release.promise;
     });
-    await entered.promise;
-    const db = stateDatabase(databasePath);
-    const initialHeartbeat = (
-      db
-        .prepare(
-          "SELECT heartbeat_at FROM state_leases WHERE scope = 'skill-upload-install' AND lease_key = ?",
-        )
-        .get(committed.uploadId) as { heartbeat_at: number }
-    ).heartbeat_at;
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 40);
-    });
-    const renewedHeartbeat = (
-      db
-        .prepare(
-          "SELECT heartbeat_at FROM state_leases WHERE scope = 'skill-upload-install' AND lease_key = ?",
-        )
-        .get(committed.uploadId) as { heartbeat_at: number }
-    ).heartbeat_at;
-    expect(renewedHeartbeat).toBeGreaterThan(initialHeartbeat);
+    try {
+      await entered.promise;
+      const db = stateDatabase(databasePath);
+      const initialHeartbeat = (
+        db
+          .prepare(
+            "SELECT heartbeat_at FROM state_leases WHERE scope = 'skill-upload-install' AND lease_key = ?",
+          )
+          .get(committed.uploadId) as { heartbeat_at: number }
+      ).heartbeat_at;
+      now += 10;
+      await vi.advanceTimersByTimeAsync(10);
+      const renewedHeartbeat = (
+        db
+          .prepare(
+            "SELECT heartbeat_at FROM state_leases WHERE scope = 'skill-upload-install' AND lease_key = ?",
+          )
+          .get(committed.uploadId) as { heartbeat_at: number }
+      ).heartbeat_at;
+      expect(renewedHeartbeat).toBeGreaterThan(initialHeartbeat);
 
-    db.prepare("UPDATE skill_uploads SET expires_at = ? WHERE upload_id = ?").run(
-      Date.now() - 1,
-      committed.uploadId,
-    );
-    expect(
-      deleteExpiredSkillUploadUnlessLeased({
-        uploadId: committed.uploadId,
-        nowMs: Date.now(),
-        options: { path: databasePath },
-      }),
-    ).toBe("leased");
-    expect(uploadCount(databasePath)).toBe(1);
-    expect(installLeaseCount(databasePath, committed.uploadId)).toBe(1);
-
-    release.resolve();
-    await pinned;
+      db.prepare("UPDATE skill_uploads SET expires_at = ? WHERE upload_id = ?").run(
+        now - 1,
+        committed.uploadId,
+      );
+      expect(
+        deleteExpiredSkillUploadUnlessLeased({
+          uploadId: committed.uploadId,
+          nowMs: now,
+          options: { path: databasePath },
+        }),
+      ).toBe("leased");
+      expect(uploadCount(databasePath)).toBe(1);
+      expect(installLeaseCount(databasePath, committed.uploadId)).toBe(1);
+    } finally {
+      release.resolve();
+      try {
+        await pinned;
+      } finally {
+        vi.useRealTimers();
+      }
+    }
     expect(installLeaseCount(databasePath, committed.uploadId)).toBe(0);
   });
 

--- a/src/skills/runtime/session-snapshot.test.ts
+++ b/src/skills/runtime/session-snapshot.test.ts
@@ -2,6 +2,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { WORKSPACE_SKILLS_PROMPT_FORMAT_VERSION } from "../types.js";
 import type { SkillSnapshot } from "../types.js";
 
@@ -20,6 +21,7 @@ const {
   buildWorkspaceSkillSnapshotMock,
   ensureSkillsWatcherMock,
   getSkillsSnapshotVersionMock,
+  loadMergedWorkspaceSkillsMock,
   shouldRefreshSnapshotForVersionMock,
 } = vi.hoisted(() => ({
   buildWorkspaceSkillSnapshotMock: vi.fn((..._args: unknown[]) => ({
@@ -29,9 +31,20 @@ const {
   })),
   ensureSkillsWatcherMock: vi.fn(),
   getSkillsSnapshotVersionMock: vi.fn(() => 1),
+  loadMergedWorkspaceSkillsMock: vi.fn(
+    (_params: { pluginMetadataSnapshot?: PluginMetadataSnapshot }) => [],
+  ),
   shouldRefreshSnapshotForVersionMock: vi.fn((cached = 0, next = 0) =>
     next === 0 ? cached > 0 : cached < next,
   ),
+}));
+
+vi.mock("../loading/workspace-skill-loader.js", () => ({
+  loadMergedWorkspaceSkills: loadMergedWorkspaceSkillsMock,
+  normalizeWorkspaceSkillRoots: (roots: {
+    agentWorkspaceDir: string;
+    executionSkillsDir?: string;
+  }) => roots,
 }));
 
 vi.mock("../loading/workspace-skill-prompt.js", () => ({
@@ -59,6 +72,22 @@ describe("resolveReusableWorkspaceSkillSnapshot", () => {
     getSkillsSnapshotVersionMock.mockReturnValue(1);
     shouldRefreshSnapshotForVersionMock.mockImplementation((cached = 0, next = 0) =>
       next === 0 ? cached > 0 : cached < next,
+    );
+  });
+
+  it("reuses prepared plugin metadata when loading execution-workspace skills", () => {
+    const pluginMetadataSnapshot = { policyHash: "prepared" } as PluginMetadataSnapshot;
+
+    resolveReusableWorkspaceSkillSnapshot({
+      workspaceDir: TEST_WORKSPACE_DIR,
+      executionSkillsDir: "/tmp/execution/skills",
+      config: {},
+      pluginMetadataSnapshot,
+    });
+
+    expect(loadMergedWorkspaceSkillsMock).toHaveBeenCalledOnce();
+    expect(loadMergedWorkspaceSkillsMock.mock.calls[0]?.[0].pluginMetadataSnapshot).toBe(
+      pluginMetadataSnapshot,
     );
   });
 

--- a/src/skills/runtime/session-snapshot.ts
+++ b/src/skills/runtime/session-snapshot.ts
@@ -101,6 +101,7 @@ export function resolveReusableWorkspaceSkillSnapshot(
           skillFilter: params.skillFilter,
           skillOverrides: params.skillOverrides,
           eligibility: params.eligibility,
+          pluginMetadataSnapshot: params.pluginMetadataSnapshot,
         })
       : undefined;
     const snapshot = buildSkillSnapshot(params.workspaceDir, {


### PR DESCRIPTION
Related: #125595

## What Problem This Solves

Fixes an issue where sessions with an execution workspace rebuilt plugin metadata while loading merged skills even though Gateway lifecycle preparation had already supplied the authoritative immutable snapshot.

## Why This Change Was Made

The execution-workspace skill loader now receives the same prepared plugin metadata object already passed to the later snapshot builder. This completes the existing lifecycle-ownership handoff without adding a cache, fallback, freshness check, or new invalidation path. A nearby upload-lease test exposed by broad validation also replaces real timer ordering with its existing injected clock.

## User Impact

Execution-workspace sessions avoid an unnecessary plugin metadata rebuild before prompt construction, reducing synchronous filesystem and manifest work on a hot session path while preserving skill precedence, filtering, and reload semantics.

## Evidence

- Current-main ownership gap: regular workspace snapshot construction receives `pluginMetadataSnapshot`, while the preceding `loadMergedWorkspaceSkills` call in the execution-workspace branch omitted it.
- Pre-fix regression: expected the exact prepared metadata object, received `undefined`.
- Post-fix focused proof: 70/70 across session snapshot, merged workspace skill loading, plugin skill loading, and upload-store lease behavior.
- The metadata regression asserts object identity at the loader boundary; no production test seam was added.
- Opportunistic nearby test repair: the upload install-lease test no longer relies on a real 40 ms sleep beating a 10 ms interval under whole-suite load. It uses fake timers plus the existing injected clock, preserves heartbeat/expiry/cleanup assertions, and guarantees callback and timer cleanup. Production lease behavior is unchanged.
- Changed-file gate passed after the documented one-time `pnpm install` recovery for a new mainline dependency: format, core/test typecheck, core lint, plugin boundaries, dead exports, import cycles, native schema, and repository guards.
- Rebased onto the landed current-main UI budget heal from #126722. `pnpm ui:build` passes at 335.7 KiB startup gzip against the unchanged 341.2 KiB limit.
- Fresh rebased Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +1. Tests: +74/-37, net +37.
- No config, protocol, storage, authorization, provider, dependency, or UI change is involved.

AI-assisted: implementation and review used Codex, with maintainer inspection of the Gateway metadata ownership repair, execution-workspace merge path, skill-loader contract, history, and focused tests.
