### PR TITLE
fix(macos): install CLI automatically during remote onboarding

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingView+Monitoring.swift
@@ -31,7 +31,6 @@ extension OnboardingView {
         }
         guard Self.shouldAutoInstallCLI(
             onCLIPage: pageIndex == cliPageIndex,
-            isLocal: state.connectionMode == .local,
             visible: onboardingVisible,
             statusKnown: cliStatusKnown,
             executableReady: cliExecutableReady,
@@ -43,14 +42,13 @@ extension OnboardingView {
 
     static func shouldAutoInstallCLI(
         onCLIPage: Bool,
-        isLocal: Bool,
         visible: Bool,
         statusKnown: Bool,
         executableReady: Bool,
         installed: Bool,
         installing: Bool) -> Bool
     {
-        onCLIPage && isLocal && visible && statusKnown && !executableReady && !installed && !installing
+        onCLIPage && visible && statusKnown && !executableReady && !installed && !installing
     }
 
     func startExistingCLIActivationIfNeeded() {

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -145,6 +145,13 @@ struct OnboardingViewSmokeTests {
             requiresCLIInstall: true)
 
         #expect(order.contains(2))
+        #expect(OnboardingView.shouldAutoInstallCLI(
+            onCLIPage: order.contains(2),
+            visible: true,
+            statusKnown: true,
+            executableReady: false,
+            installed: false,
+            installing: false))
         #expect(!OnboardingView.shouldActivateLocalGateway(afterCLIInstallFor: .remote))
         #expect(OnboardingView.shouldActivateLocalGateway(afterCLIInstallFor: .local))
     }
@@ -185,7 +192,6 @@ struct OnboardingViewSmokeTests {
     @Test func `automatic CLI setup waits for the initial status probe`() {
         #expect(!OnboardingView.shouldAutoInstallCLI(
             onCLIPage: true,
-            isLocal: true,
             visible: true,
             statusKnown: false,
             executableReady: false,
@@ -193,7 +199,6 @@ struct OnboardingViewSmokeTests {
             installing: false))
         #expect(OnboardingView.shouldAutoInstallCLI(
             onCLIPage: true,
-            isLocal: true,
             visible: true,
             statusKnown: true,
             executableReady: false,
@@ -201,7 +206,6 @@ struct OnboardingViewSmokeTests {
             installing: false))
         #expect(!OnboardingView.shouldAutoInstallCLI(
             onCLIPage: true,
-            isLocal: true,
             visible: false,
             statusKnown: true,
             executableReady: false,
@@ -209,7 +213,6 @@ struct OnboardingViewSmokeTests {
             installing: false))
         #expect(!OnboardingView.shouldAutoInstallCLI(
             onCLIPage: true,
-            isLocal: true,
             visible: true,
             statusKnown: true,
             executableReady: true,


### PR DESCRIPTION
## Summary

Restore automatic CLI installation during fresh remote macOS onboarding.

Remote and local onboarding both require the matching CLI: local mode uses it to start the Gateway, while remote mode needs it for the Mac node without starting a second Gateway. #105642 added that remote-onboarding contract and the correct remote-safe installation completion path, but retained an older local-only predicate from the previous local-Gateway-only onboarding design.

Consequently, a fresh remote setup reached its mandatory CLI page, never started installation, and immediately showed the misleading `OpenClaw installation failed` card. Manually selecting `Try again` worked because the installer itself already correctly supports remote mode.

Delete the obsolete mode argument and local-only predicate. The canonical onboarding page order already excludes unconfigured mode, and the existing installation owner still activates the Gateway only for local mode. Strengthen the existing remote-onboarding smoke test to assert that its CLI page actually qualifies for automatic installation.

## Validation

- RED: the existing onboarding smoke suite failed on current main because `shouldAutoInstallCLI` returned `false` for a fresh remote CLI page.
- GREEN: **73 native Swift tests across OnboardingViewSmokeTests, CLIInstallerTests, and UpdateOrchestrationTests** passed after the owner-boundary repair.
- Existing sibling coverage independently verifies CLI management for both local and remote modes, but Gateway startup only for local mode.
- SwiftFormat lint passed for both changed files.
- Independent isolated structured autoreview found no actionable issues.
- Built the exact PR commit into a real macOS application, signed and deeply verified it with the installed application's matching Developer ID, then launched it in a fresh isolated remote named profile. PID-scoped unified logs confirmed remote-mode configuration (`control channel configure mode=remote`) and that the isolated node service was skipped; the production app and Gateway remained untouched.
- **Native GUI evidence limitation:** Computer Use returned `server error -10005: timeoutReached`; an independently healthy, fully permitted signed Peekaboo GUI bridge then inspected the protected isolated app by exact PID and returned `inventory_completeness: complete` with `windows: []`. There is no sanctioned onboarding page deep link, persisted page cursor, or IPC navigation command. Consequently no window screenshot, remote CLI-page interaction, or installer launch is claimed; changed behavior is covered by the demonstrated RED/GREEN native owner regression and all 73 sibling tests.

Production LOC: +1/-3 (**net -2**); tests: +7/-4 (net +3).

Release note: fresh remote macOS onboarding now automatically installs the matching CLI required by the Mac node instead of showing a false installation failure.
