### PR TITLE
fix(macos): bind elevation runtime to app source

### DIFF
--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -95,7 +95,10 @@ shasum -a 256 -c "$PREFIX-installer.sh.sha256"
 
 The elevation package is ZIP-only, notarized and stapled, contains exactly
 `OpenClaw.app`, omits Apple Events entitlements, records an immutable receipt,
-and verifies a freshly extracted copy. The same source-addressed artifact set
+and verifies a freshly extracted copy. It also embeds a CUA-free node-host
+worker whose signed manifest, file digest, and startup identity must match the
+app's exact OpenClaw source commit; elevation mode never selects an unrelated
+installed CLI for that runtime. The same source-addressed artifact set
 includes a portable installer copied from that exact Git commit plus separate
 archive and installer checksum files. Transfer the archive, receipt, portable
 installer, and both checksums; the target Mac does not need a source checkout.

--- a/apps/macos/Sources/OpenClaw/CommandResolver.swift
+++ b/apps/macos/Sources/OpenClaw/CommandResolver.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 
 enum CommandResolver {
     private static let projectRootDefaultsKey = "openclaw.gatewayProjectRootPath"
@@ -294,6 +295,52 @@ enum CommandResolver {
         #else
         return nil
         #endif
+    }
+
+    static func elevationNodeHostWorkerLaunch(
+        bundle: Bundle = .main,
+        searchPaths: [String]? = nil,
+        requireValidBundleSignature: Bool = true) async throws -> MacNodeHostWorkerLaunch
+    {
+        let build = ArtifactBuildInfo(infoDictionary: bundle.infoDictionary ?? [:])
+        guard let sourceCommit = build.gitCommit, let resourceRoot = bundle.resourceURL else {
+            throw MacNodeHostWorker.WorkerError.unavailable(
+                "elevation app has no source-bound node-host worker metadata")
+        }
+        if requireValidBundleSignature,
+           !MacNodeHostWorkerArtifact.validateSignedBundle(at: bundle.bundleURL)
+        {
+            throw MacNodeHostWorker.WorkerError.unavailable(
+                "elevation app signature does not cover its node-host worker")
+        }
+        return try await self.elevationNodeHostWorkerLaunch(
+            resourceRoot: resourceRoot,
+            expectedSourceCommit: sourceCommit,
+            searchPaths: searchPaths)
+    }
+
+    static func elevationNodeHostWorkerLaunch(
+        resourceRoot: URL,
+        expectedSourceCommit: String,
+        searchPaths: [String]? = nil) async throws -> MacNodeHostWorkerLaunch
+    {
+        let worker: URL
+        do {
+            worker = try MacNodeHostWorkerArtifact.resolve(
+                resourceRoot: resourceRoot,
+                expectedSourceCommit: expectedSourceCommit)
+        } catch {
+            throw MacNodeHostWorker.WorkerError.unavailable(error.localizedDescription)
+        }
+        switch await self.runtimeResolution(searchPaths: searchPaths) {
+        case let .success(runtime):
+            return MacNodeHostWorkerLaunch(
+                command: [runtime.path, worker.path],
+                currentDirectoryURL: resourceRoot,
+                expectedSourceCommit: expectedSourceCommit)
+        case let .failure(error):
+            throw MacNodeHostWorker.WorkerError.unavailable(RuntimeLocator.describeFailure(error))
+        }
     }
 
     static func nodeHostWorkerCommand(

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorker.swift
@@ -38,17 +38,20 @@ struct MacNodeHostWorkerLaunch: Equatable, Sendable {
     let currentDirectoryURL: URL?
     let environment: [String: String]
     let configurationGeneration: UInt64
+    let expectedSourceCommit: String?
 
     init(
         command: [String],
         currentDirectoryURL: URL? = nil,
         environment: [String: String] = [:],
-        configurationGeneration: UInt64 = 0)
+        configurationGeneration: UInt64 = 0,
+        expectedSourceCommit: String? = nil)
     {
         self.command = command
         self.currentDirectoryURL = currentDirectoryURL
         self.environment = environment
         self.configurationGeneration = configurationGeneration
+        self.expectedSourceCommit = expectedSourceCommit
     }
 }
 
@@ -494,6 +497,12 @@ final class MacNodeHostWorker: MacNodeHostWorking, @unchecked Sendable {
                   let pathEnv = rawManifest["pathEnv"] as? String
             else {
                 self.stopLocked(reason: "worker returned invalid manifest")
+                return
+            }
+            if let expectedSourceCommit = self.launchedWorker?.expectedSourceCommit,
+               message["sourceCommit"] as? String != expectedSourceCommit
+            {
+                self.stopLocked(reason: "worker source identity does not match the elevation app")
                 return
             }
             let computerUse: AnyCodable?

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorkerArtifact.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeHostWorkerArtifact.swift
@@ -1,0 +1,93 @@
+import CryptoKit
+import Foundation
+import Security
+
+enum MacNodeHostWorkerArtifact {
+    private struct Manifest: Decodable {
+        let schemaVersion: Int
+        let kind: String
+        let sourceCommit: String
+        let sha256: String
+    }
+
+    enum ArtifactError: LocalizedError {
+        case invalid(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .invalid(message): message
+            }
+        }
+    }
+
+    static func validateSignedBundle(at bundleURL: URL) -> Bool {
+        var code: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(bundleURL as CFURL, SecCSFlags(), &code) == errSecSuccess,
+              let code
+        else { return false }
+        return SecStaticCodeCheckValidity(
+            code,
+            SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSCheckNestedCode),
+            nil) == errSecSuccess
+    }
+
+    static func resolve(
+        resourceRoot: URL,
+        expectedSourceCommit: String,
+        fileManager: FileManager = .default) throws -> URL
+    {
+        guard expectedSourceCommit.range(of: "^[0-9a-f]{40}$", options: .regularExpression) != nil else {
+            throw ArtifactError.invalid("elevation app has no exact OpenClaw source identity")
+        }
+        let root = resourceRoot.appendingPathComponent("OpenClawNodeHostWorker", isDirectory: true)
+        let manifestURL = root.appendingPathComponent("manifest.json")
+        let workerURL = root.appendingPathComponent("node-host-worker.mjs")
+        let expectedNames = Set([manifestURL.lastPathComponent, workerURL.lastPathComponent])
+        let names = try Set(fileManager.contentsOfDirectory(atPath: root.path))
+        guard names == expectedNames else {
+            throw ArtifactError.invalid("elevation node-host worker contains unexpected entries")
+        }
+        for url in [root, manifestURL, workerURL] {
+            let values = try url.resourceValues(forKeys: [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey])
+            guard values.isSymbolicLink != true else {
+                throw ArtifactError.invalid("elevation node-host worker must not contain symbolic links")
+            }
+            if url == root {
+                guard values.isDirectory == true else {
+                    throw ArtifactError.invalid("elevation node-host worker root is not a directory")
+                }
+            } else if values.isRegularFile != true {
+                throw ArtifactError.invalid("elevation node-host worker resource is not a regular file")
+            }
+        }
+
+        let manifestData = try Data(contentsOf: manifestURL, options: [.mappedIfSafe])
+        guard let raw = try JSONSerialization.jsonObject(with: manifestData) as? [String: Any],
+              Set(raw.keys) == Set(["schemaVersion", "kind", "sourceCommit", "sha256"])
+        else {
+            throw ArtifactError.invalid("elevation node-host worker manifest has an invalid shape")
+        }
+        let manifest = try JSONDecoder().decode(Manifest.self, from: manifestData)
+        guard manifest.schemaVersion == 1,
+              manifest.kind == "openclaw-macos-node-host-worker",
+              manifest.sourceCommit == expectedSourceCommit,
+              manifest.sha256.range(of: "^[0-9a-f]{64}$", options: .regularExpression) != nil
+        else {
+            throw ArtifactError.invalid("elevation node-host worker manifest does not match this app")
+        }
+        guard try self.sha256(of: workerURL) == manifest.sha256 else {
+            throw ArtifactError.invalid("elevation node-host worker digest does not match its signed manifest")
+        }
+        return workerURL
+    }
+
+    private static func sha256(of url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+            hasher.update(data: data)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeModeCoordinator.swift
@@ -946,7 +946,9 @@ extension MacNodeModeCoordinator {
         }
         let launch: MacNodeHostWorkerLaunch
         do {
-            if let projectLaunch = try await CommandResolver.projectNodeHostWorkerLaunch() {
+            if AppLaunchRuntimePlan.current.isElevationHost {
+                launch = try await CommandResolver.elevationNodeHostWorkerLaunch()
+            } else if let projectLaunch = try await CommandResolver.projectNodeHostWorkerLaunch() {
                 launch = projectLaunch
             } else {
                 switch await CLIInstaller.status() {
@@ -968,7 +970,8 @@ extension MacNodeModeCoordinator {
             command: launch.command,
             currentDirectoryURL: launch.currentDirectoryURL,
             environment: workerEnvironment,
-            configurationGeneration: self.nodeHostWorkerConfigurationGeneration)
+            configurationGeneration: self.nodeHostWorkerConfigurationGeneration,
+            expectedSourceCommit: launch.expectedSourceCommit)
         let input = MacNodeHostWorkerRetryPolicy.Input(launch: effectiveLaunch)
         try self.nodeHostWorkerRetryPolicy.prepareForStart(input)
         self.activeNodeHostWorkerInput = input

--- a/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CommandResolverTests.swift
@@ -1,4 +1,5 @@
 import Darwin
+import CryptoKit
 import Foundation
 import Testing
 @testable import OpenClaw
@@ -68,6 +69,68 @@ import Testing
         #expect(!launch.command.contains(sourceEntrypoint.path))
         #expect(!launch.command.contains(distEntrypoint.path))
         #expect(!launch.command.contains(projectExecutable.path))
+    }
+
+    @Test func `elevation worker is source bound and wins over a stale external CLI`() async throws {
+        let root = try makeTempDirForTests()
+        let resources = root.appendingPathComponent("Resources", isDirectory: true)
+        let artifact = resources.appendingPathComponent("OpenClawNodeHostWorker", isDirectory: true)
+        let worker = artifact.appendingPathComponent("node-host-worker.mjs")
+        let manifest = artifact.appendingPathComponent("manifest.json")
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        let node = bin.appendingPathComponent("node")
+        let staleCLI = bin.appendingPathComponent("openclaw")
+        let sourceCommit = String(repeating: "a", count: 40)
+        try FileManager().createDirectory(at: artifact, withIntermediateDirectories: true)
+        try FileManager().createDirectory(at: bin, withIntermediateDirectories: true)
+        let workerData = Data("export {};\n".utf8)
+        try workerData.write(to: worker)
+        let workerSHA = SHA256.hash(data: workerData).map { String(format: "%02x", $0) }.joined()
+        let manifestData = try JSONSerialization.data(withJSONObject: [
+            "schemaVersion": 1,
+            "kind": "openclaw-macos-node-host-worker",
+            "sourceCommit": sourceCommit,
+            "sha256": workerSHA,
+        ])
+        try manifestData.write(to: manifest)
+        try "#!/bin/sh\necho v22.22.3\n".write(to: node, atomically: true, encoding: .utf8)
+        try "#!/bin/sh\nexit 99\n".write(to: staleCLI, atomically: true, encoding: .utf8)
+        for executable in [node, staleCLI] {
+            try FileManager().setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        }
+
+        let launch = try await CommandResolver.elevationNodeHostWorkerLaunch(
+            resourceRoot: resources,
+            expectedSourceCommit: sourceCommit,
+            searchPaths: [bin.path])
+
+        #expect(launch.command == [node.path, worker.path])
+        #expect(launch.expectedSourceCommit == sourceCommit)
+        #expect(!launch.command.contains(staleCLI.path))
+    }
+
+    @Test func `elevation worker rejects source and digest substitution`() throws {
+        let resources = try makeTempDirForTests()
+        let artifact = resources.appendingPathComponent("OpenClawNodeHostWorker", isDirectory: true)
+        let worker = artifact.appendingPathComponent("node-host-worker.mjs")
+        let manifest = artifact.appendingPathComponent("manifest.json")
+        try FileManager().createDirectory(at: artifact, withIntermediateDirectories: true)
+        try Data("export {};\n".utf8).write(to: worker)
+        let expectedCommit = String(repeating: "b", count: 40)
+        let wrongCommit = String(repeating: "c", count: 40)
+        let payload: [String: Any] = [
+            "schemaVersion": 1,
+            "kind": "openclaw-macos-node-host-worker",
+            "sourceCommit": wrongCommit,
+            "sha256": String(repeating: "0", count: 64),
+        ]
+        try JSONSerialization.data(withJSONObject: payload).write(to: manifest)
+
+        #expect(throws: (any Error).self) {
+            try MacNodeHostWorkerArtifact.resolve(
+                resourceRoot: resources,
+                expectedSourceCommit: expectedCommit)
+        }
     }
 
     @Test func `falls back to node and script`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -129,6 +129,21 @@ struct MacNodeHostWorkerTests {
         await worker.stop()
     }
 
+    @Test func `source-bound worker refuses a mismatched ready identity`() async throws {
+        let worker = MacNodeHostWorker(session: GatewayNodeSession(), startupTimeout: 1)
+        let script = """
+        printf '%s\n' '{"type":"ready","version":"test","sourceCommit":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","manifest":{"caps":[],"commands":[],"pathEnv":"/usr/bin:/bin"}}'
+        while IFS= read -r line; do :; done
+        """
+
+        await #expect(throws: (any Error).self) {
+            _ = try await worker.start(launch: MacNodeHostWorkerLaunch(
+                command: ["/bin/sh", "-c", script],
+                expectedSourceCommit: String(repeating: "a", count: 40)))
+        }
+        await worker.stop()
+    }
+
     @Test(arguments: [
         OpenClawSystemCommand.run.rawValue,
         "mcp.tools.call.v1",

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatViewModel+Outbox.swift
@@ -906,7 +906,7 @@ extension OpenClawChatViewModel {
         } catch is OpenClawChatTransportSendError {
             // The transport proved this payload never reached its request
             // channel, so it is safe to retry automatically.
-            await outbox.markCommandQueued(
+            _ = await outbox.markCommandQueued(
                 id: command.id,
                 attemptVersion: command.attemptVersion,
                 retryCount: command.retryCount,

--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -192,6 +192,9 @@ const rootEntries = [
   "src/plugins/runtime-sidecar-paths-baseline.ts!",
   // Imported by scripts/tsdown-build.mts as the AI package build configuration.
   "tsdown.ai.config.ts!",
+  // Invoked by the macOS app packager to build the source-bound node-host worker.
+  "tsdown.mac-node-host-worker.config.ts!",
+  "src/node-host/mac-node-host-worker-entry.ts!",
   // Maintainer-owned compatibility data referenced by release/docs workflows.
   "src/commands/doctor/shared/deprecation-compat.ts!",
   // Compiled as the package-boundary failure canary by the extension checker.

--- a/scripts/check-duplicates.mts
+++ b/scripts/check-duplicates.mts
@@ -25,6 +25,7 @@ const targets = [
   "openclaw.mjs",
   "tsdown.ai.config.ts",
   "tsdown.config.ts",
+  "tsdown.mac-node-host-worker.config.ts",
   "vitest.config.ts",
 ];
 

--- a/scripts/lib/mac-node-host-worker-build-plugin.mts
+++ b/scripts/lib/mac-node-host-worker-build-plugin.mts
@@ -43,13 +43,9 @@ export function createMacNodeHostWorkerBuildPlugin(rootDir = process.cwd()) {
         ([, enabledByDefault], index) =>
           `{ definition: plugin${index}, enabledByDefault: ${enabledByDefault} }`,
       );
-      const ids = PLUGIN_SPECS.map(([pluginId]) => pluginId);
-      const defaults = Object.fromEntries(PLUGIN_SPECS);
       return [
         ...imports,
         `export const MAC_NODE_HOST_PLUGIN_DEFINITIONS = [${definitions.join(",")}];`,
-        `export const MAC_NODE_HOST_PLUGIN_IDS = ${JSON.stringify(ids)};`,
-        `export const MAC_NODE_HOST_PLUGIN_DEFAULTS = ${JSON.stringify(defaults)};`,
       ].join("\n");
     },
   };

--- a/scripts/lib/mac-node-host-worker-build-plugin.mts
+++ b/scripts/lib/mac-node-host-worker-build-plugin.mts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const PLUGIN_SPECS = [
+  ["acpx", true],
+  ["anthropic", true],
+  ["browser", true],
+  ["codex", false],
+  ["file-transfer", true],
+  ["google-meet", true],
+  ["logbook", false],
+  ["ollama", true],
+  ["opencode", true],
+  ["teams-meetings", true],
+  ["zoom-meetings", true],
+] as const;
+
+/** Injects audited bundled plugin entrypoints only into the signed macOS worker build. */
+export function createMacNodeHostWorkerBuildPlugin(rootDir = process.cwd()) {
+  const definitionsPath = fs.realpathSync(
+    path.resolve(rootDir, "src/node-host/mac-node-host-plugin-definitions.ts"),
+  );
+  return {
+    name: "openclaw:mac-node-host-worker",
+    transform(code: string, id: string) {
+      let resolved: string;
+      try {
+        resolved = fs.realpathSync(path.resolve(id));
+      } catch {
+        return null;
+      }
+      if (resolved !== definitionsPath) {
+        return null;
+      }
+      if (!code.includes("MAC_NODE_HOST_PLUGIN_DEFINITIONS")) {
+        throw new Error("macOS node-host plugin placeholder contract changed");
+      }
+      const imports = PLUGIN_SPECS.map(
+        ([pluginId], index) =>
+          `import plugin${index} from ${JSON.stringify(`../../extensions/${pluginId}/index.js`)};`,
+      );
+      const definitions = PLUGIN_SPECS.map(
+        ([, enabledByDefault], index) =>
+          `{ definition: plugin${index}, enabledByDefault: ${enabledByDefault} }`,
+      );
+      const ids = PLUGIN_SPECS.map(([pluginId]) => pluginId);
+      const defaults = Object.fromEntries(PLUGIN_SPECS);
+      return [
+        ...imports,
+        `export const MAC_NODE_HOST_PLUGIN_DEFINITIONS = [${definitions.join(",")}];`,
+        `export const MAC_NODE_HOST_PLUGIN_IDS = ${JSON.stringify(ids)};`,
+        `export const MAC_NODE_HOST_PLUGIN_DEFAULTS = ${JSON.stringify(defaults)};`,
+      ].join("\n");
+    },
+  };
+}

--- a/scripts/mac-elevation-host.sh
+++ b/scripts/mac-elevation-host.sh
@@ -60,6 +60,7 @@ CUTOVER_ADOPTION_STOPPED=0
 CUTOVER_ADOPTION_TERMINATION_SENT=0
 CUTOVER_RECOVERY_ATTEMPTED=0
 ROLLBACK_APP_PATH=""
+ROLLBACK_APP_ARCHITECTURES=""
 ROLLBACK_APP_CDHASH_ARM64=""
 ROLLBACK_APP_CDHASH_X86_64=""
 ROLLBACK_ELEVATION_PLIST=""
@@ -95,6 +96,7 @@ UPGRADE_EXPECTED_NODE_ID=""
 UPGRADE_EXPECTED_NODE_PROFILE=""
 RECOVERY_CURRENT_APP_CDHASH_ARM64=""
 RECOVERY_CURRENT_APP_CDHASH_X86_64=""
+RECOVERY_CURRENT_APP_ARCHITECTURES=""
 RECOVERY_CURRENT_APP_IDENTITY=""
 RECOVERY_CURRENT_APP_STATE=""
 RECOVERY_CURRENT_PLIST=""
@@ -408,7 +410,8 @@ elevation_receipt_binds_app() {
       .appPath == $appPath and
       .plistPath == $plistPath and
       (
-        (.schemaVersion == 3 and .kind == "openclaw-elevation-install") or
+        ((.schemaVersion == 3 or .schemaVersion == 4) and
+          .kind == "openclaw-elevation-install") or
         (
           (has("schemaVersion") | not) and (has("kind") | not) and
           keys == ["appPath","archiveSha256","backupPath","peekabooCommit","plistPath","previousPlist","sourceCommit"]
@@ -568,6 +571,7 @@ verify_elevation_app() {
   [[ "$peekaboo_commit" =~ ^[0-9a-f]{40}$ ]] || fail 'elevation app has invalid PeekabooSourceCommit'
   verify_signed_app_identity "$app" ||
     fail "elevation app must be signed for every architecture by $EXPECTED_AUTHORITY"
+  verify_elevation_node_host_worker "$app"
   codesign --verify --strict --test-requirement='=notarized' "$app"
   xcrun stapler validate "$app" >/dev/null
   spctl --assess --type execute "$app"
@@ -575,32 +579,111 @@ verify_elevation_app() {
   verify_universal_machos "$app"
 }
 
+verify_elevation_node_host_worker() {
+  local app="$1"
+  local resource_root="$app/Contents/Resources/OpenClawNodeHostWorker"
+  local worker="$resource_root/node-host-worker.mjs"
+  local manifest="$resource_root/manifest.json"
+  [[ -d "$resource_root" && ! -L "$resource_root" ]] ||
+    fail 'elevation app has no source-bound node-host worker directory'
+  [[ -f "$worker" && ! -L "$worker" && -f "$manifest" && ! -L "$manifest" ]] ||
+    fail 'elevation app node-host worker resources are missing or symlinked'
+  [[ "$(find "$resource_root" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')" == "2" ]] ||
+    fail 'elevation app node-host worker directory contains unexpected entries'
+  jq -e --arg sourceCommit "$(plist_value "$app" OpenClawGitCommit)" '
+    type == "object" and
+    keys == ["kind","schemaVersion","sha256","sourceCommit"] and
+    .schemaVersion == 1 and
+    .kind == "openclaw-macos-node-host-worker" and
+    .sourceCommit == $sourceCommit and
+    (.sha256 | type == "string" and test("^[0-9a-f]{64}$"))
+  ' "$manifest" >/dev/null 2>&1 || fail 'elevation app node-host worker manifest is invalid'
+  [[ "$(jq -r '.sha256' "$manifest")" == "$(shasum -a 256 "$worker" | awk '{print $1}')" ]] ||
+    fail 'elevation app node-host worker digest mismatch'
+}
+
 verify_signed_app_identity() {
-  local app="$1" arch
+  local app="$1"
+  [[ "$(canonical_app_architectures "$app")" == "arm64 x86_64" ]] || return 1
+  verify_signed_app_identity_for_architectures "$app" "arm64 x86_64"
+}
+
+canonical_app_architectures() {
+  local app="$1" raw arch has_arm64=0 has_x86_64=0
+  if ! raw="$(lipo -archs "$app/Contents/MacOS/OpenClaw" 2>/dev/null)"; then
+    printf 'ERROR: could not inspect OpenClaw app architectures at %s\n' "$app" >&2
+    return 1
+  fi
+  for arch in $raw; do
+    case "$arch" in
+      arm64) [[ "$has_arm64" == "0" ]] || return 1; has_arm64=1 ;;
+      x86_64) [[ "$has_x86_64" == "0" ]] || return 1; has_x86_64=1 ;;
+      *) printf 'ERROR: unsupported OpenClaw app architecture: %s\n' "$arch" >&2; return 1 ;;
+    esac
+  done
+  [[ "$has_arm64" == "1" || "$has_x86_64" == "1" ]] || return 1
+  local canonical=()
+  [[ "$has_arm64" == "1" ]] && canonical+=(arm64)
+  [[ "$has_x86_64" == "1" ]] && canonical+=(x86_64)
+  printf '%s' "${canonical[*]}"
+}
+
+capture_app_cdhash() {
+  local app="$1" arch="$2" description="$3" output_variable="$4" value
+  if ! value="$(codesign_value_for_arch "$app" CDHash "$arch")"; then
+    printf 'ERROR: could not inspect %s %s CDHash\n' "$description" "$arch" >&2
+    return 1
+  fi
+  if [[ -z "$value" ]]; then
+    printf 'ERROR: %s has no %s CDHash\n' "$description" "$arch" >&2
+    return 1
+  fi
+  printf -v "$output_variable" '%s' "$value"
+}
+
+verify_signed_app_identity_for_architectures() {
+  local app="$1" architectures="$2" arch
   codesign --verify --deep --strict --all-architectures "$app" >/dev/null 2>&1 || return 1
-  for arch in arm64 x86_64; do
+  for arch in $architectures; do
     [[ "$(codesign_value_for_arch "$app" TeamIdentifier "$arch")" == "$EXPECTED_TEAM_ID" ]] || return 1
     [[ "$(codesign_value_for_arch "$app" Authority "$arch")" == "$EXPECTED_AUTHORITY" ]] || return 1
   done
 }
 
 verify_rollback_app() {
-  local app="$1" expected_arm64_cdhash="$2" expected_x86_64_cdhash="$3"
+  local app="$1" expected_architectures="$2" expected_arm64_cdhash="$3" expected_x86_64_cdhash="$4"
+  local actual_architectures
   [[ -d "$app" && ! -L "$app" ]] || return 1
   [[ "$(plist_value "$app" CFBundleIdentifier)" == "$EXPECTED_BUNDLE_ID" ]] || return 1
   [[ "$(plist_value "$app" OpenClawGitCommit)" =~ ^[0-9a-f]{40}$ ]] || return 1
-  verify_signed_app_identity "$app" || return 1
-  [[ -n "$expected_arm64_cdhash" && -n "$expected_x86_64_cdhash" ]] || return 1
-  [[ "$(codesign_value_for_arch "$app" CDHash arm64)" == "$expected_arm64_cdhash" ]] || return 1
-  [[ "$(codesign_value_for_arch "$app" CDHash x86_64)" == "$expected_x86_64_cdhash" ]]
+  [[ "$expected_architectures" == "arm64" || "$expected_architectures" == "x86_64" ||
+    "$expected_architectures" == "arm64 x86_64" ]] || return 1
+  actual_architectures="$(canonical_app_architectures "$app")" || return 1
+  [[ "$actual_architectures" == "$expected_architectures" ]] || return 1
+  verify_signed_app_identity_for_architectures "$app" "$expected_architectures" || return 1
+  if [[ " $expected_architectures " == *" arm64 "* ]]; then
+    [[ -n "$expected_arm64_cdhash" ]] || return 1
+    [[ "$(codesign_value_for_arch "$app" CDHash arm64)" == "$expected_arm64_cdhash" ]] || return 1
+  else
+    [[ -z "$expected_arm64_cdhash" ]] || return 1
+  fi
+  if [[ " $expected_architectures " == *" x86_64 "* ]]; then
+    [[ -n "$expected_x86_64_cdhash" ]] || return 1
+    [[ "$(codesign_value_for_arch "$app" CDHash x86_64)" == "$expected_x86_64_cdhash" ]] || return 1
+  else
+    [[ -z "$expected_x86_64_cdhash" ]] || return 1
+  fi
 }
 
 verify_recorded_rollback_app() {
-  verify_rollback_app "$1" "$ROLLBACK_APP_CDHASH_ARM64" "$ROLLBACK_APP_CDHASH_X86_64"
+  verify_rollback_app \
+    "$1" "$ROLLBACK_APP_ARCHITECTURES" "$ROLLBACK_APP_CDHASH_ARM64" "$ROLLBACK_APP_CDHASH_X86_64"
 }
 
 verify_recorded_current_app() {
-  verify_rollback_app "$1" "$RECOVERY_CURRENT_APP_CDHASH_ARM64" "$RECOVERY_CURRENT_APP_CDHASH_X86_64"
+  verify_rollback_app \
+    "$1" "$RECOVERY_CURRENT_APP_ARCHITECTURES" \
+    "$RECOVERY_CURRENT_APP_CDHASH_ARM64" "$RECOVERY_CURRENT_APP_CDHASH_X86_64"
 }
 
 backup_file_matches() {
@@ -1756,7 +1839,7 @@ write_install_receipt() {
   mkdir -p "$STATE_DIR"
   local tmp="${target}.tmp.$$"
   jq -n \
-    --argjson schemaVersion 3 \
+    --argjson schemaVersion 4 \
     --arg kind 'openclaw-elevation-install' \
     --arg transactionState "$transaction_state" \
     --arg transactionId "$INSTALL_TRANSACTION_ID" \
@@ -1766,6 +1849,7 @@ write_install_receipt() {
     --arg stateDir "$STATE_DIR" \
     --arg configPath "$CONFIG_PATH" \
     --arg backupPath "$ROLLBACK_APP_PATH" \
+    --arg backupArchitectures "$ROLLBACK_APP_ARCHITECTURES" \
     --arg backupArm64CDHash "$ROLLBACK_APP_CDHASH_ARM64" \
     --arg backupX8664CDHash "$ROLLBACK_APP_CDHASH_X86_64" \
     --arg plistPath "$PLIST_PATH" \
@@ -1797,7 +1881,7 @@ write_install_receipt() {
     --argjson migrationWasLoaded "$ROLLBACK_MIGRATION_WAS_LOADED" \
     --argjson adoptedAppWasRunning "$ROLLBACK_ADOPTED_APP_WAS_RUNNING" \
     --argjson adoptedAppAttachOnly "$ROLLBACK_ADOPTED_APP_ATTACH_ONLY" \
-    '{schemaVersion:$schemaVersion,kind:$kind,transactionState:$transactionState,transactionId:$transactionId,sourceCommit:$sourceCommit,peekabooCommit:$peekabooCommit,archiveSha256:$archiveSha256,artifactReceiptSha256:$artifactReceiptSha256,installerSha256:$installerSha256,cdhashes:{arm64:$arm64CDHash,x86_64:$x8664CDHash},nodeId:$nodeId,nodeProfile:$nodeProfile,appPath:$appPath,stateDir:$stateDir,configPath:$configPath,backupPath:$backupPath,backupCDHashes:{arm64:$backupArm64CDHash,x86_64:$backupX8664CDHash},plistPath:$plistPath,previousPlist:$previousPlist,previousPlistSha256:$previousPlistSha256,previousPlistWasLoaded:($previousPlistWasLoaded == 1),previousReceipt:$previousReceipt,previousReceiptSha256:$previousReceiptSha256,migration:(if $migrationSource == "" then null else {kind:$migrationKind,sourcePlist:$migrationSource,sourceIdentity:$migrationSourceIdentity,custodyPath:$migrationCustodyPath,backupPlist:$migrationBackup,backupSha256:$migrationBackupSha256,label:$migrationLabel,wasLoaded:($migrationWasLoaded == 1),nodeEnvPath:$migrationNodeEnvPath,nodeEnvSha256:$migrationNodeEnvSha256,nodeEnvIdentity:$migrationNodeEnvIdentity,nodeWrapperPath:$migrationNodeWrapperPath,nodeWrapperSha256:$migrationNodeWrapperSha256,nodeWrapperIdentity:$migrationNodeWrapperIdentity} end),adoptedApp:{wasRunning:($adoptedAppWasRunning == 1),attachOnly:($adoptedAppAttachOnly == 1)}}' >"$tmp"
+    '{schemaVersion:$schemaVersion,kind:$kind,transactionState:$transactionState,transactionId:$transactionId,sourceCommit:$sourceCommit,peekabooCommit:$peekabooCommit,archiveSha256:$archiveSha256,artifactReceiptSha256:$artifactReceiptSha256,installerSha256:$installerSha256,cdhashes:{arm64:$arm64CDHash,x86_64:$x8664CDHash},nodeId:$nodeId,nodeProfile:$nodeProfile,appPath:$appPath,stateDir:$stateDir,configPath:$configPath,backupPath:$backupPath,backupArchitectures:(if $backupArchitectures == "" then [] else ($backupArchitectures | split(" ")) end),backupCDHashes:({} + (if $backupArm64CDHash == "" then {} else {arm64:$backupArm64CDHash} end) + (if $backupX8664CDHash == "" then {} else {x86_64:$backupX8664CDHash} end)),plistPath:$plistPath,previousPlist:$previousPlist,previousPlistSha256:$previousPlistSha256,previousPlistWasLoaded:($previousPlistWasLoaded == 1),previousReceipt:$previousReceipt,previousReceiptSha256:$previousReceiptSha256,migration:(if $migrationSource == "" then null else {kind:$migrationKind,sourcePlist:$migrationSource,sourceIdentity:$migrationSourceIdentity,custodyPath:$migrationCustodyPath,backupPlist:$migrationBackup,backupSha256:$migrationBackupSha256,label:$migrationLabel,wasLoaded:($migrationWasLoaded == 1),nodeEnvPath:$migrationNodeEnvPath,nodeEnvSha256:$migrationNodeEnvSha256,nodeEnvIdentity:$migrationNodeEnvIdentity,nodeWrapperPath:$migrationNodeWrapperPath,nodeWrapperSha256:$migrationNodeWrapperSha256,nodeWrapperIdentity:$migrationNodeWrapperIdentity} end),adoptedApp:{wasRunning:($adoptedAppWasRunning == 1),attachOnly:($adoptedAppAttachOnly == 1)}}' >"$tmp"
   chmod 600 "$tmp"
   if ! fsync_file_and_parent "$tmp"; then
     rm -f "$tmp"
@@ -1856,13 +1940,18 @@ verify_install_receipt() {
   then
     INSTALL_RECEIPT_SCHEMA="legacy"
     INSTALL_RECEIPT_TRANSACTION_STATE="installed"
-  # Schema 3 first ships with the exact migration-sidecar binding below. Earlier
+  # Schema 3 first shipped with the exact migration-sidecar binding below. Schema 4
+  # adds architecture-aware rollback receipts. Earlier
   # five-key migration objects existed only on this unmerged branch and cannot
   # safely authorize recovery, so they are intentionally not compatibility input.
   elif jq -e '
     type == "object" and
-    keys == ["adoptedApp","appPath","archiveSha256","artifactReceiptSha256","backupCDHashes","backupPath","cdhashes","configPath","installerSha256","kind","migration","nodeId","nodeProfile","peekabooCommit","plistPath","previousPlist","previousPlistSha256","previousPlistWasLoaded","previousReceipt","previousReceiptSha256","schemaVersion","sourceCommit","stateDir","transactionId","transactionState"] and
-    .schemaVersion == 3 and
+    (
+      (.schemaVersion == 3 and
+        keys == ["adoptedApp","appPath","archiveSha256","artifactReceiptSha256","backupCDHashes","backupPath","cdhashes","configPath","installerSha256","kind","migration","nodeId","nodeProfile","peekabooCommit","plistPath","previousPlist","previousPlistSha256","previousPlistWasLoaded","previousReceipt","previousReceiptSha256","schemaVersion","sourceCommit","stateDir","transactionId","transactionState"]) or
+      (.schemaVersion == 4 and
+        keys == ["adoptedApp","appPath","archiveSha256","artifactReceiptSha256","backupArchitectures","backupCDHashes","backupPath","cdhashes","configPath","installerSha256","kind","migration","nodeId","nodeProfile","peekabooCommit","plistPath","previousPlist","previousPlistSha256","previousPlistWasLoaded","previousReceipt","previousReceiptSha256","schemaVersion","sourceCommit","stateDir","transactionId","transactionState"])
+    ) and
     .kind == "openclaw-elevation-install" and
     (.transactionState == "installing" or .transactionState == "installed") and
     (.transactionId | type == "string" and test("^[0-9A-F-]{36}$")) and
@@ -1874,10 +1963,24 @@ verify_install_receipt() {
     (.cdhashes | type == "object" and keys == ["arm64","x86_64"] and all(.[]; type == "string" and length > 0)) and
     (.nodeId | type == "string" and length > 0) and
     (.nodeProfile == "primary" or .nodeProfile == "node") and
-    (.backupCDHashes | type == "object" and keys == ["arm64","x86_64"] and all(.[]; type == "string")) and
     (
-      (.backupPath == "" and all(.backupCDHashes[]; . == "")) or
-      ((.backupPath | type == "string" and startswith("/")) and all(.backupCDHashes[]; length > 0))
+      (.schemaVersion == 3 and
+        (.backupCDHashes | type == "object" and keys == ["arm64","x86_64"] and all(.[]; type == "string")) and
+        (
+          (.backupPath == "" and all(.backupCDHashes[]; . == "")) or
+          ((.backupPath | type == "string" and startswith("/")) and all(.backupCDHashes[]; length > 0))
+        )) or
+      (.schemaVersion == 4 and
+        (.backupArchitectures | type == "array") and
+        (.backupArchitectures == [] or .backupArchitectures == ["arm64"] or
+          .backupArchitectures == ["x86_64"] or .backupArchitectures == ["arm64","x86_64"]) and
+        (.backupCDHashes | type == "object") and
+        (.backupCDHashes | keys) == (.backupArchitectures | sort) and
+        all(.backupCDHashes[]; type == "string" and length > 0) and
+        (
+          (.backupPath == "" and .backupArchitectures == [] and .backupCDHashes == {}) or
+          ((.backupPath | type == "string" and startswith("/")) and (.backupArchitectures | length) > 0)
+        ))
     ) and
     (.previousPlistSha256 | type == "string") and
     (.previousReceipt | type == "string") and
@@ -1907,7 +2010,7 @@ verify_install_receipt() {
     (.adoptedApp | type == "object" and (.wasRunning | type == "boolean") and (.attachOnly | type == "boolean"))
   ' "$RECEIPT_PATH" >/dev/null 2>&1
   then
-    INSTALL_RECEIPT_SCHEMA="3"
+    INSTALL_RECEIPT_SCHEMA="$(jq -r '.schemaVersion' "$RECEIPT_PATH")"
     INSTALL_RECEIPT_TRANSACTION_STATE="$(jq -r '.transactionState' "$RECEIPT_PATH")"
     INSTALL_TRANSACTION_ID="$(jq -r '.transactionId' "$RECEIPT_PATH")"
   else
@@ -2079,6 +2182,7 @@ install_host() {
   fi
 
   ROLLBACK_APP_PATH=""
+  ROLLBACK_APP_ARCHITECTURES=""
   ROLLBACK_APP_CDHASH_ARM64=""
   ROLLBACK_APP_CDHASH_X86_64=""
   if [[ -e "$APP_PATH" || -L "$APP_PATH" ]]; then
@@ -2092,10 +2196,17 @@ install_host() {
     # appears before custody atomically refuses without nesting or overwrite.
     [[ ! -e "$ROLLBACK_APP_PATH" && ! -L "$ROLLBACK_APP_PATH" ]] ||
       fail "could not reserve a unique elevation backup path: $ROLLBACK_APP_PATH"
-    ROLLBACK_APP_CDHASH_ARM64="$(codesign_value_for_arch "$APP_PATH" CDHash arm64)"
-    ROLLBACK_APP_CDHASH_X86_64="$(codesign_value_for_arch "$APP_PATH" CDHash x86_64)"
-    [[ -n "$ROLLBACK_APP_CDHASH_ARM64" && -n "$ROLLBACK_APP_CDHASH_X86_64" ]] ||
-      fail 'installed OpenClaw app has no signed per-architecture CDHashes'
+    if ! ROLLBACK_APP_ARCHITECTURES="$(canonical_app_architectures "$APP_PATH")"; then
+      fail 'installed OpenClaw app architecture inventory could not be recorded before mutation'
+    fi
+    if [[ " $ROLLBACK_APP_ARCHITECTURES " == *" arm64 "* ]]; then
+      capture_app_cdhash "$APP_PATH" arm64 'installed OpenClaw app' ROLLBACK_APP_CDHASH_ARM64 ||
+        fail 'installed OpenClaw app CDHash inventory could not be recorded before mutation'
+    fi
+    if [[ " $ROLLBACK_APP_ARCHITECTURES " == *" x86_64 "* ]]; then
+      capture_app_cdhash "$APP_PATH" x86_64 'installed OpenClaw app' ROLLBACK_APP_CDHASH_X86_64 ||
+        fail 'installed OpenClaw app CDHash inventory could not be recorded before mutation'
+    fi
     verify_recorded_rollback_app "$APP_PATH" ||
       fail 'installed OpenClaw app does not pass strict signature and identity validation'
   fi
@@ -2414,7 +2525,7 @@ recover_install() {
   wait_for_app_binary_exit || return 1
   [[ "$(job_loaded_state "$job_domain")" == "absent" ]] || return 1
   if [[ "$CUTOVER_APP_MUTATED" == "1" && -d "$APP_PATH" &&
-    -n "$ROLLBACK_APP_CDHASH_ARM64" && -n "$ROLLBACK_APP_CDHASH_X86_64" &&
+    -n "$ROLLBACK_APP_ARCHITECTURES" &&
     ! -d "$ROLLBACK_APP_PATH" ]] &&
     verify_recorded_rollback_app "$APP_PATH"
   then
@@ -2916,6 +3027,13 @@ recover_host() {
   ROLLBACK_APP_PATH="$(jq -r '.backupPath // empty' "$RECEIPT_PATH")"
   ROLLBACK_APP_CDHASH_ARM64="$(jq -r '.backupCDHashes.arm64 // empty' "$RECEIPT_PATH")"
   ROLLBACK_APP_CDHASH_X86_64="$(jq -r '.backupCDHashes.x86_64 // empty' "$RECEIPT_PATH")"
+  if [[ "$INSTALL_RECEIPT_SCHEMA" == "4" ]]; then
+    ROLLBACK_APP_ARCHITECTURES="$(jq -r '.backupArchitectures | join(" ")' "$RECEIPT_PATH")"
+  elif [[ -n "$ROLLBACK_APP_PATH" && "$INSTALL_RECEIPT_SCHEMA" == "3" ]]; then
+    ROLLBACK_APP_ARCHITECTURES="arm64 x86_64"
+  else
+    ROLLBACK_APP_ARCHITECTURES=""
+  fi
   ROLLBACK_ELEVATION_PLIST="$(jq -r '.previousPlist // empty' "$RECEIPT_PATH")"
   ROLLBACK_ELEVATION_PLIST_SHA="$(jq -r '.previousPlistSha256 // empty' "$RECEIPT_PATH")"
   ROLLBACK_ELEVATION_WAS_LOADED="$(jq -r 'if .previousPlistWasLoaded then 1 else 0 end' "$RECEIPT_PATH")"
@@ -3001,6 +3119,7 @@ recover_host() {
     RECOVERY_RESTORED_MIGRATION_IDENTITY="$migration_identity"
   fi
   if [[ "$INSTALL_RECEIPT_SCHEMA" != "legacy" ]]; then
+    RECOVERY_CURRENT_APP_ARCHITECTURES="arm64 x86_64"
     RECOVERY_CURRENT_APP_CDHASH_ARM64="$(jq -r '.cdhashes.arm64' "$RECEIPT_PATH")"
     RECOVERY_CURRENT_APP_CDHASH_X86_64="$(jq -r '.cdhashes.x86_64' "$RECEIPT_PATH")"
   fi
@@ -3024,8 +3143,18 @@ recover_host() {
     if [[ "$RECOVERY_PENDING_INSTALL" == "1" && "$current_app_valid" == "1" &&
       "$current_app_matches_receipt" != "1" ]]
     then
-      RECOVERY_CURRENT_APP_CDHASH_ARM64="$(codesign_value_for_arch "$APP_PATH" CDHash arm64)"
-      RECOVERY_CURRENT_APP_CDHASH_X86_64="$(codesign_value_for_arch "$APP_PATH" CDHash x86_64)"
+      RECOVERY_CURRENT_APP_ARCHITECTURES="$(canonical_app_architectures "$APP_PATH")" ||
+        fail 'could not inspect current app architectures during recovery'
+      RECOVERY_CURRENT_APP_CDHASH_ARM64=""
+      RECOVERY_CURRENT_APP_CDHASH_X86_64=""
+      if [[ " $RECOVERY_CURRENT_APP_ARCHITECTURES " == *" arm64 "* ]]; then
+        capture_app_cdhash "$APP_PATH" arm64 'current recovery app' RECOVERY_CURRENT_APP_CDHASH_ARM64 ||
+          fail 'could not inspect current app CDHashes during recovery'
+      fi
+      if [[ " $RECOVERY_CURRENT_APP_ARCHITECTURES " == *" x86_64 "* ]]; then
+        capture_app_cdhash "$APP_PATH" x86_64 'current recovery app' RECOVERY_CURRENT_APP_CDHASH_X86_64 ||
+          fail 'could not inspect current app CDHashes during recovery'
+      fi
     fi
   else
     [[ -z "$ARCHIVE" && -z "$ARTIFACT_RECEIPT" && -z "$EXPECTED_ARTIFACT_RECEIPT_SHA256" ]] ||
@@ -3056,18 +3185,28 @@ recover_host() {
     if [[ "$INSTALL_RECEIPT_SCHEMA" == 'legacy' ]]; then
       [[ -d "$ROLLBACK_APP_PATH" && ! -L "$ROLLBACK_APP_PATH" ]] ||
         fail 'legacy recovery cannot resume after its unauthenticated backup path moved'
-      ROLLBACK_APP_CDHASH_ARM64="$(codesign_value_for_arch "$ROLLBACK_APP_PATH" CDHash arm64)"
-      ROLLBACK_APP_CDHASH_X86_64="$(codesign_value_for_arch "$ROLLBACK_APP_PATH" CDHash x86_64)"
+      ROLLBACK_APP_ARCHITECTURES="$(canonical_app_architectures "$ROLLBACK_APP_PATH")" ||
+        fail 'legacy recovery could not inspect rollback app architectures'
+      ROLLBACK_APP_CDHASH_ARM64=""
+      ROLLBACK_APP_CDHASH_X86_64=""
+      if [[ " $ROLLBACK_APP_ARCHITECTURES " == *" arm64 "* ]]; then
+        capture_app_cdhash "$ROLLBACK_APP_PATH" arm64 'legacy rollback app' ROLLBACK_APP_CDHASH_ARM64 ||
+          fail 'legacy recovery could not inspect rollback app CDHashes'
+      fi
+      if [[ " $ROLLBACK_APP_ARCHITECTURES " == *" x86_64 "* ]]; then
+        capture_app_cdhash "$ROLLBACK_APP_PATH" x86_64 'legacy rollback app' ROLLBACK_APP_CDHASH_X86_64 ||
+          fail 'legacy recovery could not inspect rollback app CDHashes'
+      fi
     fi
-    [[ -n "$ROLLBACK_APP_CDHASH_ARM64" && -n "$ROLLBACK_APP_CDHASH_X86_64" ]] ||
-      fail 'receipt has no recoverable per-architecture app CDHashes'
+    [[ -n "$ROLLBACK_APP_ARCHITECTURES" ]] ||
+      fail 'receipt has no recoverable app architecture inventory'
     if [[ -e "$ROLLBACK_APP_PATH" || -L "$ROLLBACK_APP_PATH" ]]; then
       if [[ ! -d "$ROLLBACK_APP_PATH" || -L "$ROLLBACK_APP_PATH" ]] ||
         ! verify_recorded_rollback_app "$ROLLBACK_APP_PATH"
       then
         fail 'receipt app backup does not pass strict signature and identity validation'
       fi
-    elif [[ "$RECOVERY_PENDING_INSTALL" == "1" && "$current_app_valid" == "1" ]] &&
+    elif [[ "$RECOVERY_PENDING_INSTALL" == "1" ]] &&
       verify_recorded_rollback_app "$APP_PATH"
     then
       : # The install transaction was persisted before the prior app moved into custody.
@@ -3078,7 +3217,8 @@ recover_host() {
       fail 'receipt app backup is missing, symlinked, or not a bundle directory'
     fi
   else
-    [[ -z "$ROLLBACK_APP_CDHASH_ARM64" && -z "$ROLLBACK_APP_CDHASH_X86_64" ]] ||
+    [[ -z "$ROLLBACK_APP_ARCHITECTURES" &&
+      -z "$ROLLBACK_APP_CDHASH_ARM64" && -z "$ROLLBACK_APP_CDHASH_X86_64" ]] ||
       fail 'receipt has per-architecture CDHashes without an app backup'
   fi
   if [[ -n "$ROLLBACK_ELEVATION_PLIST" ]]; then
@@ -3161,9 +3301,22 @@ recover_host() {
     local recovery_current_app_candidate="$APP_PATH"
     [[ -z "$RECOVERED_FAILED_APP_PATH" ]] ||
       recovery_current_app_candidate="$RECOVERED_FAILED_APP_PATH"
-    RECOVERY_CURRENT_APP_CDHASH_ARM64="$(codesign_value_for_arch "$recovery_current_app_candidate" CDHash arm64)"
-    RECOVERY_CURRENT_APP_CDHASH_X86_64="$(codesign_value_for_arch "$recovery_current_app_candidate" CDHash x86_64)"
+    RECOVERY_CURRENT_APP_ARCHITECTURES="$(canonical_app_architectures "$recovery_current_app_candidate")" ||
+      fail 'legacy recovery could not inspect current app architectures'
+    RECOVERY_CURRENT_APP_CDHASH_ARM64=""
+    RECOVERY_CURRENT_APP_CDHASH_X86_64=""
+    if [[ " $RECOVERY_CURRENT_APP_ARCHITECTURES " == *" arm64 "* ]]; then
+      capture_app_cdhash \
+        "$recovery_current_app_candidate" arm64 'legacy current app' RECOVERY_CURRENT_APP_CDHASH_ARM64 ||
+        fail 'legacy recovery could not inspect current app CDHashes'
+    fi
+    if [[ " $RECOVERY_CURRENT_APP_ARCHITECTURES " == *" x86_64 "* ]]; then
+      capture_app_cdhash \
+        "$recovery_current_app_candidate" x86_64 'legacy current app' RECOVERY_CURRENT_APP_CDHASH_X86_64 ||
+        fail 'legacy recovery could not inspect current app CDHashes'
+    fi
   elif [[ "$INSTALL_RECEIPT_SCHEMA" == "legacy" ]]; then
+    RECOVERY_CURRENT_APP_ARCHITECTURES=""
     RECOVERY_CURRENT_APP_CDHASH_ARM64=""
     RECOVERY_CURRENT_APP_CDHASH_X86_64=""
   fi

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -136,8 +136,8 @@ stage_elevation_node_host_worker() {
   local metadata worker_sha
 
   echo "🧩 Building source-bound elevation node-host worker"
-  node --import tsx "$ROOT_DIR/scripts/tsdown-build.mts" \
-    --config "$ROOT_DIR/tsdown.mac-node-host-worker.config.ts"
+  (cd "$ROOT_DIR" && node --import tsx "$ROOT_DIR/scripts/tsdown-build.mts" \
+    --config "$ROOT_DIR/tsdown.mac-node-host-worker.config.ts")
   [[ -f "$built_worker" && ! -L "$built_worker" ]] || {
     echo "ERROR: source-bound node-host worker build is missing or symlinked" >&2
     return 1

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -129,6 +129,49 @@ PY
   printf '%s' "$revision"
 }
 
+stage_elevation_node_host_worker() {
+  local build_root="$ROOT_DIR/apps/macos/.build/node-host-worker"
+  local built_worker="$build_root/node-host-worker.mjs"
+  local resource_root="$APP_ROOT/Contents/Resources/OpenClawNodeHostWorker"
+  local metadata worker_sha
+
+  echo "🧩 Building source-bound elevation node-host worker"
+  node --import tsx "$ROOT_DIR/scripts/tsdown-build.mts" \
+    --config "$ROOT_DIR/tsdown.mac-node-host-worker.config.ts"
+  [[ -f "$built_worker" && ! -L "$built_worker" ]] || {
+    echo "ERROR: source-bound node-host worker build is missing or symlinked" >&2
+    return 1
+  }
+  if ! metadata="$(node "$built_worker" --build-metadata)"; then
+    echo "ERROR: source-bound node-host worker metadata probe failed" >&2
+    return 1
+  fi
+  jq -e --arg sourceCommit "$BUILD_GIT_COMMIT" '
+    type == "object" and
+    keys == ["kind","schemaVersion","sourceCommit","version"] and
+    .schemaVersion == 1 and
+    .kind == "openclaw-macos-node-host-worker" and
+    .sourceCommit == $sourceCommit and
+    (.version | type == "string" and length > 0)
+  ' <<<"$metadata" >/dev/null || {
+    echo "ERROR: source-bound node-host worker does not match the packaged OpenClaw commit" >&2
+    return 1
+  }
+
+  worker_sha="$(shasum -a 256 "$built_worker" | awk '{print $1}')"
+  rm -rf "$resource_root"
+  mkdir -p "$resource_root"
+  cp "$built_worker" "$resource_root/node-host-worker.mjs"
+  jq -n \
+    --argjson schemaVersion 1 \
+    --arg kind "openclaw-macos-node-host-worker" \
+    --arg sourceCommit "$BUILD_GIT_COMMIT" \
+    --arg sha256 "$worker_sha" \
+    '{schemaVersion:$schemaVersion,kind:$kind,sourceCommit:$sourceCommit,sha256:$sha256}' \
+    >"$resource_root/manifest.json"
+  chmod 0444 "$resource_root/node-host-worker.mjs" "$resource_root/manifest.json"
+}
+
 sparkle_canonical_build_from_version() {
   (cd "$ROOT_DIR" && node --import tsx "$ROOT_DIR/scripts/sparkle-build.ts" canonical-build "$1")
 }
@@ -896,6 +939,7 @@ cp -R "$PROVIDER_ICONS_SRC" "$APP_ROOT/Contents/Resources/ProviderIcons"
 
 if [[ "$SIGNING_VARIANT" == "elevation-host" ]]; then
   echo "🖥  Omitting embedded CUA driver from elevation-host package"
+  stage_elevation_node_host_worker
 else
   echo "🖥  Staging embedded CUA driver"
   "$ROOT_DIR/scripts/stage-cua-driver-macos.sh" "$APP_ROOT/Contents/Resources/cua-driver"

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -54,6 +54,8 @@ const TERMINATION_GRACE_MS = 250;
 const PROCESS_GROUP_EXIT_POLL_MS = 25;
 const POST_FORCE_KILL_WAIT_MS = 250;
 const ROOT_TSDOWN_OUTPUT_ROOTS = ["dist", "dist-runtime"];
+const MAC_NODE_HOST_WORKER_CONFIG_PATH = path.resolve("tsdown.mac-node-host-worker.config.ts");
+const MAC_NODE_HOST_WORKER_OUTPUT_ROOT = "apps/macos/.build/node-host-worker";
 const PRESERVED_TSDOWN_OUTPUT_FILES = ["dist/cli-startup-metadata.json"];
 const PRESERVE_CLI_STARTUP_METADATA_ENV = "OPENCLAW_PRESERVE_CLI_STARTUP_METADATA";
 const GENERATED_SOURCE_DECLARATION_PATHSPEC = ":(glob)extensions/**/*.d.ts";
@@ -324,6 +326,9 @@ export function resolveTsdownCleanOutputRoots(args: string[] = []) {
 
   if (configPath === aiConfigPath) {
     return [aiRoot];
+  }
+  if (configPath === MAC_NODE_HOST_WORKER_CONFIG_PATH) {
+    return [MAC_NODE_HOST_WORKER_OUTPUT_ROOT];
   }
   if (configPath === mainConfigPath) {
     if (filter === TSDOWN_PACKAGE_CONFIG_GROUP) {

--- a/src/node-host/mac-node-host-plugin-definitions.ts
+++ b/src/node-host/mac-node-host-plugin-definitions.ts
@@ -1,0 +1,36 @@
+import type { OpenClawPluginDefinition } from "../plugins/types.js";
+
+export type BundledNodeHostPlugin = {
+  definition: OpenClawPluginDefinition & { id: string; name: string };
+  enabledByDefault: boolean;
+};
+
+// The macOS worker build replaces this source-only placeholder with static
+// extension imports. Core typechecking must not absorb extension DOM graphs.
+export const MAC_NODE_HOST_PLUGIN_DEFINITIONS: readonly BundledNodeHostPlugin[] = [];
+export const MAC_NODE_HOST_PLUGIN_IDS = [
+  "acpx",
+  "anthropic",
+  "browser",
+  "codex",
+  "file-transfer",
+  "google-meet",
+  "logbook",
+  "ollama",
+  "opencode",
+  "teams-meetings",
+  "zoom-meetings",
+] as const;
+export const MAC_NODE_HOST_PLUGIN_DEFAULTS: Readonly<Record<string, boolean>> = {
+  acpx: true,
+  anthropic: true,
+  browser: true,
+  codex: false,
+  "file-transfer": true,
+  "google-meet": true,
+  logbook: false,
+  ollama: true,
+  opencode: true,
+  "teams-meetings": true,
+  "zoom-meetings": true,
+};

--- a/src/node-host/mac-node-host-plugin-definitions.ts
+++ b/src/node-host/mac-node-host-plugin-definitions.ts
@@ -8,29 +8,3 @@ export type BundledNodeHostPlugin = {
 // The macOS worker build replaces this source-only placeholder with static
 // extension imports. Core typechecking must not absorb extension DOM graphs.
 export const MAC_NODE_HOST_PLUGIN_DEFINITIONS: readonly BundledNodeHostPlugin[] = [];
-export const MAC_NODE_HOST_PLUGIN_IDS = [
-  "acpx",
-  "anthropic",
-  "browser",
-  "codex",
-  "file-transfer",
-  "google-meet",
-  "logbook",
-  "ollama",
-  "opencode",
-  "teams-meetings",
-  "zoom-meetings",
-] as const;
-export const MAC_NODE_HOST_PLUGIN_DEFAULTS: Readonly<Record<string, boolean>> = {
-  acpx: true,
-  anthropic: true,
-  browser: true,
-  codex: false,
-  "file-transfer": true,
-  "google-meet": true,
-  logbook: false,
-  ollama: true,
-  opencode: true,
-  "teams-meetings": true,
-  "zoom-meetings": true,
-};

--- a/src/node-host/mac-node-host-plugin-runtime.test.ts
+++ b/src/node-host/mac-node-host-plugin-runtime.test.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { BundledNodeHostPlugin } from "./mac-node-host-plugin-definitions.js";
 import { createMacNodeHostPluginRegistry } from "./mac-node-host-plugin-runtime.js";
 
-const tempRoots: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function availableCommands(
   registry: ReturnType<
@@ -35,14 +35,10 @@ function plugin(id: string, command: string, enabledByDefault = true): BundledNo
 
 afterEach(() => {
   vi.unstubAllEnvs();
-  for (const root of tempRoots.splice(0)) {
-    fs.rmSync(root, { recursive: true, force: true });
-  }
 });
 
 function useIsolatedState(): void {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-mac-node-host-plugins-"));
-  tempRoots.push(root);
+  const root = tempDirs.make("openclaw-mac-node-host-plugins-");
   const home = path.join(root, "home");
   fs.mkdirSync(home);
   vi.stubEnv("HOME", home);

--- a/src/node-host/mac-node-host-plugin-runtime.test.ts
+++ b/src/node-host/mac-node-host-plugin-runtime.test.ts
@@ -3,11 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { BundledNodeHostPlugin } from "./mac-node-host-plugin-definitions.js";
-import {
-  createMacNodeHostPluginRegistry,
-  MAC_NODE_HOST_PLUGIN_DEFAULTS,
-  MAC_NODE_HOST_PLUGIN_IDS,
-} from "./mac-node-host-plugin-runtime.js";
+import { createMacNodeHostPluginRegistry } from "./mac-node-host-plugin-runtime.js";
 
 const tempRoots: string[] = [];
 
@@ -64,27 +60,6 @@ describe("macOS bundled node-host plugin runtime", () => {
       plugin("zoom-meetings", "zoommeetings.chrome"),
     ]);
 
-    expect(MAC_NODE_HOST_PLUGIN_IDS).not.toContain("cua-computer");
-    expect(MAC_NODE_HOST_PLUGIN_IDS).not.toContain("linux-node");
-    expect(MAC_NODE_HOST_PLUGIN_IDS).toEqual([
-      "acpx",
-      "anthropic",
-      "browser",
-      "codex",
-      "file-transfer",
-      "google-meet",
-      "logbook",
-      "ollama",
-      "opencode",
-      "teams-meetings",
-      "zoom-meetings",
-    ]);
-    for (const id of MAC_NODE_HOST_PLUGIN_IDS) {
-      const manifest = JSON.parse(
-        fs.readFileSync(path.join("extensions", id, "openclaw.plugin.json"), "utf8"),
-      ) as { enabledByDefault?: boolean };
-      expect(MAC_NODE_HOST_PLUGIN_DEFAULTS[id]).toBe(manifest.enabledByDefault === true);
-    }
     expect(availableCommands(registry, {})).toEqual([
       "googlemeet.chrome",
       "ollama.chat",

--- a/src/node-host/mac-node-host-plugin-runtime.test.ts
+++ b/src/node-host/mac-node-host-plugin-runtime.test.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BundledNodeHostPlugin } from "./mac-node-host-plugin-definitions.js";
+import {
+  createMacNodeHostPluginRegistry,
+  MAC_NODE_HOST_PLUGIN_DEFAULTS,
+  MAC_NODE_HOST_PLUGIN_IDS,
+} from "./mac-node-host-plugin-runtime.js";
+
+const tempRoots: string[] = [];
+
+function availableCommands(
+  registry: ReturnType<
+    (typeof import("./mac-node-host-plugin-runtime.js"))["createMacNodeHostPluginRegistry"]
+  >,
+  config: Record<string, unknown>,
+): string[] {
+  const context = { config, env: process.env } as never;
+  return registry.nodeHostCommands
+    .filter((entry) => entry.command.isAvailable?.(context) !== false)
+    .map((entry) => entry.command.command)
+    .toSorted();
+}
+
+function plugin(id: string, command: string, enabledByDefault = true): BundledNodeHostPlugin {
+  return {
+    enabledByDefault,
+    definition: {
+      id,
+      name: id,
+      register(api) {
+        api.registerNodeHostCommand({ command, handle: async () => "{}" });
+      },
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  for (const root of tempRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function useIsolatedState(): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-mac-node-host-plugins-"));
+  tempRoots.push(root);
+  const home = path.join(root, "home");
+  fs.mkdirSync(home);
+  vi.stubEnv("HOME", home);
+  vi.stubEnv("OPENCLAW_STATE_DIR", path.join(root, "state"));
+}
+
+describe("macOS bundled node-host plugin runtime", () => {
+  it("matches the default external worker command surface without CUA", () => {
+    useIsolatedState();
+    const registry = createMacNodeHostPluginRegistry({}, [
+      plugin("google-meet", "googlemeet.chrome"),
+      plugin("ollama", "ollama.chat"),
+      plugin("ollama-extra", "ollama.models"),
+      plugin("teams-meetings", "teamsmeetings.chrome"),
+      plugin("zoom-meetings", "zoommeetings.chrome"),
+    ]);
+
+    expect(MAC_NODE_HOST_PLUGIN_IDS).not.toContain("cua-computer");
+    expect(MAC_NODE_HOST_PLUGIN_IDS).not.toContain("linux-node");
+    expect(MAC_NODE_HOST_PLUGIN_IDS).toEqual([
+      "acpx",
+      "anthropic",
+      "browser",
+      "codex",
+      "file-transfer",
+      "google-meet",
+      "logbook",
+      "ollama",
+      "opencode",
+      "teams-meetings",
+      "zoom-meetings",
+    ]);
+    for (const id of MAC_NODE_HOST_PLUGIN_IDS) {
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join("extensions", id, "openclaw.plugin.json"), "utf8"),
+      ) as { enabledByDefault?: boolean };
+      expect(MAC_NODE_HOST_PLUGIN_DEFAULTS[id]).toBe(manifest.enabledByDefault === true);
+    }
+    expect(availableCommands(registry, {})).toEqual([
+      "googlemeet.chrome",
+      "ollama.chat",
+      "ollama.models",
+      "teamsmeetings.chrome",
+      "zoommeetings.chrome",
+    ]);
+  });
+
+  it("preserves plugin enablement policy inside the signed composition", () => {
+    useIsolatedState();
+    const registry = createMacNodeHostPluginRegistry(
+      { plugins: { entries: { "google-meet": { enabled: false } } } },
+      [
+        plugin("google-meet", "googlemeet.chrome"),
+        plugin("teams-meetings", "teamsmeetings.chrome"),
+      ],
+    );
+
+    const commands = availableCommands(registry, {
+      plugins: { entries: { "google-meet": { enabled: false } } },
+    });
+    expect(commands).not.toContain("googlemeet.chrome");
+    expect(commands).toContain("teamsmeetings.chrome");
+  });
+});

--- a/src/node-host/mac-node-host-plugin-runtime.ts
+++ b/src/node-host/mac-node-host-plugin-runtime.ts
@@ -1,0 +1,78 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { normalizePluginsConfig, resolvePluginActivationState } from "../plugins/config-state.js";
+import { runPluginRegisterSyncInRegistry } from "../plugins/loader-module-runtime.js";
+import { createPluginRecord } from "../plugins/loader-records.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import { createPluginRegistry } from "../plugins/registry.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import {
+  type BundledNodeHostPlugin,
+  MAC_NODE_HOST_PLUGIN_DEFINITIONS,
+  MAC_NODE_HOST_PLUGIN_DEFAULTS,
+  MAC_NODE_HOST_PLUGIN_IDS,
+} from "./mac-node-host-plugin-definitions.js";
+
+export { MAC_NODE_HOST_PLUGIN_DEFAULTS, MAC_NODE_HOST_PLUGIN_IDS };
+
+/** Builds the non-CUA plugin command registry entirely from signed bundle code. */
+export function createMacNodeHostPluginRegistry(
+  config: OpenClawConfig,
+  plugins: readonly BundledNodeHostPlugin[] = MAC_NODE_HOST_PLUGIN_DEFINITIONS,
+): PluginRegistry {
+  const runtime = createPluginRuntime();
+  const logger = createSubsystemLogger("node-host/macos-bundled-plugins");
+  const normalized = normalizePluginsConfig(config.plugins);
+  const builder = createPluginRegistry({
+    logger,
+    runtime,
+    activateGlobalSideEffects: false,
+  });
+  const { registry } = builder;
+
+  for (const { definition, enabledByDefault } of plugins) {
+    const activation = resolvePluginActivationState({
+      id: definition.id,
+      origin: "bundled",
+      config: normalized,
+      rootConfig: config,
+      enabledByDefault,
+    });
+    const source = `embedded://mac-node-host/${definition.id}`;
+    const record = createPluginRecord({
+      id: definition.id,
+      name: definition.name,
+      version: definition.version,
+      description: definition.description,
+      source,
+      origin: "bundled",
+      enabled: activation.enabled,
+      activationState: activation,
+      configSchema: definition.configSchema !== undefined,
+    });
+    if (!activation.enabled || typeof definition.register !== "function") {
+      registry.plugins.push(record);
+      continue;
+    }
+    const pluginConfig = asOptionalRecord(normalized.entries[definition.id]?.config);
+    const api = builder.createApi(record, {
+      config,
+      ...(pluginConfig ? { pluginConfig } : {}),
+      registrationMode: "discovery",
+    });
+    try {
+      runPluginRegisterSyncInRegistry(definition.register, api, registry, definition.id);
+      registry.plugins.push(record);
+    } catch (error) {
+      builder.rollbackPluginGlobalSideEffects(definition.id, record);
+      record.status = "error";
+      record.error = formatErrorMessage(error);
+      record.failurePhase = "register";
+      registry.plugins.push(record);
+      logger.warn(`bundled node-host plugin ${definition.id} failed: ${record.error}`);
+    }
+  }
+  return registry;
+}

--- a/src/node-host/mac-node-host-plugin-runtime.ts
+++ b/src/node-host/mac-node-host-plugin-runtime.ts
@@ -11,11 +11,7 @@ import { createPluginRuntime } from "../plugins/runtime/index.js";
 import {
   type BundledNodeHostPlugin,
   MAC_NODE_HOST_PLUGIN_DEFINITIONS,
-  MAC_NODE_HOST_PLUGIN_DEFAULTS,
-  MAC_NODE_HOST_PLUGIN_IDS,
 } from "./mac-node-host-plugin-definitions.js";
-
-export { MAC_NODE_HOST_PLUGIN_DEFAULTS, MAC_NODE_HOST_PLUGIN_IDS };
 
 /** Builds the non-CUA plugin command registry entirely from signed bundle code. */
 export function createMacNodeHostPluginRegistry(

--- a/src/node-host/mac-node-host-worker-entry.ts
+++ b/src/node-host/mac-node-host-worker-entry.ts
@@ -1,0 +1,26 @@
+import { flushCompileCache } from "node:module";
+import "../worker/worker-deploy-runtime.js";
+import { VERSION } from "../version.js";
+import { createMacNodeHostPluginRegistry } from "./mac-node-host-plugin-runtime.js";
+import { runNodeHostWorker } from "./worker.js";
+
+declare const MAC_NODE_HOST_WORKER_SOURCE_COMMIT: string;
+
+const sourceCommit = MAC_NODE_HOST_WORKER_SOURCE_COMMIT;
+const args = process.argv.slice(2);
+
+if (args.length === 1 && args[0] === "--build-metadata") {
+  process.stdout.write(
+    `${JSON.stringify({
+      schemaVersion: 1,
+      kind: "openclaw-macos-node-host-worker",
+      sourceCommit,
+      version: VERSION,
+    })}\n`,
+  );
+} else if (args.length === 0) {
+  await runNodeHostWorker({ sourceCommit, createPluginRegistry: createMacNodeHostPluginRegistry });
+  flushCompileCache();
+} else {
+  throw new Error("macOS node-host worker received unsupported arguments");
+}

--- a/src/node-host/plugin-node-host.ts
+++ b/src/node-host/plugin-node-host.ts
@@ -48,6 +48,11 @@ export async function ensureNodeHostPluginRegistry(params: {
   });
 }
 
+/** Installs a composition-root-owned registry without filesystem plugin discovery. */
+export function installNodeHostPluginRegistry(registry: PluginRegistry): void {
+  nodeHostPluginRegistry = registry;
+}
+
 /** List registered node-host capabilities and command ids in deterministic order. */
 export function listRegisteredNodeHostCapsAndCommands(
   context: OpenClawPluginNodeHostCommandAvailabilityContext,

--- a/src/node-host/runtime.test.ts
+++ b/src/node-host/runtime.test.ts
@@ -3,7 +3,11 @@ import { NODE_DEVICE_APPS_COMMAND } from "../infra/node-commands.js";
 import type { OpenClawPluginNodeHostCommandIo } from "../plugins/types.js";
 import { NODE_DESKTOP_STREAM_COMMAND } from "../shared/node-desktop-stream.js";
 import type { NodeHostClient } from "./client.js";
-import { listRegisteredNodeHostCapsAndCommands } from "./plugin-node-host.js";
+import {
+  ensureNodeHostPluginRegistry,
+  installNodeHostPluginRegistry,
+  listRegisteredNodeHostCapsAndCommands,
+} from "./plugin-node-host.js";
 import { prepareNodeHostRuntime } from "./runtime.js";
 
 const mocks = vi.hoisted(() => {
@@ -59,6 +63,7 @@ vi.mock("./node-worker-workspace.js", () => ({
 
 vi.mock("./plugin-node-host.js", () => ({
   ensureNodeHostPluginRegistry: vi.fn(async () => undefined),
+  installNodeHostPluginRegistry: vi.fn(),
   isRegisteredNodeHostCommandDuplex: vi.fn((command: string) => command === "test.duplex"),
   listRegisteredNodeHostCapsAndCommands: vi.fn(() => ({
     caps: ["terminal"],
@@ -127,6 +132,21 @@ function holdInvoke() {
 }
 
 describe("node-host worker manifest", () => {
+  it("uses a signed in-bundle registry without filesystem plugin discovery", async () => {
+    const registry = { nodeHostCommands: [] } as never;
+    const prepared = await prepareNodeHostRuntime({
+      config: { nodeHost: { skills: { enabled: false } } },
+      env: { PATH: "/usr/bin" },
+      enableDuplexPluginCommands: true,
+      pluginRegistry: registry,
+    });
+
+    expect(ensureNodeHostPluginRegistry).not.toHaveBeenCalled();
+    expect(installNodeHostPluginRegistry).toHaveBeenCalledWith(registry);
+    expect(listRegisteredNodeHostCapsAndCommands).toHaveBeenCalled();
+    expect(prepared.manifest.commands).toContain("test.duplex");
+  });
+
   it("allows environment-managed processes to force worker hosting without durable config", async () => {
     const prepared = await prepareNodeHostRuntime({
       config: { nodeHost: { skills: { enabled: false }, workerRuns: { enabled: false } } },

--- a/src/node-host/runtime.ts
+++ b/src/node-host/runtime.ts
@@ -34,6 +34,7 @@ import { createNodeWorkerSupervisor } from "./node-worker-supervisor.js";
 import { NodeWorkerWorkspaceRuntime } from "./node-worker-workspace.js";
 import {
   ensureNodeHostPluginRegistry,
+  installNodeHostPluginRegistry,
   isRegisteredNodeHostCommandDuplex,
   listRegisteredNodeHostCapsAndCommands,
   notifyRegisteredNodeHostCommandDisconnect,
@@ -257,13 +258,19 @@ export async function prepareNodeHostRuntime(params?: {
   forceWorkerRuns?: boolean;
   /** Embedded workers may still host long-lived plugin commands over the app-owned socket. */
   enableDuplexPluginCommands?: boolean;
+  /** Signed hosts may provide an in-bundle registry instead of filesystem discovery. */
+  pluginRegistry?: import("../plugins/registry-types.js").PluginRegistry;
   installedAppsSharingEnabled?: boolean;
   platform?: NodeJS.Platform;
 }): Promise<PreparedNodeHostRuntime> {
   void ensureTerminalUploadCleanup();
   const config = params?.config ?? getRuntimeConfig();
   const env = params?.env ?? process.env;
-  await ensureNodeHostPluginRegistry({ config, env });
+  if (params?.pluginRegistry) {
+    installNodeHostPluginRegistry(params.pluginRegistry);
+  } else {
+    await ensureNodeHostPluginRegistry({ config, env });
+  }
   const pathEnv = ensureNodePathEnv();
   env.PATH = pathEnv;
   const duplexEnabled =

--- a/src/node-host/worker.ts
+++ b/src/node-host/worker.ts
@@ -1,5 +1,8 @@
 /** Private JSONL worker exposing the CLI node-host runtime to the macOS app. */
 import { createInterface } from "node:readline";
+import { getRuntimeConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
 import { VERSION } from "../version.js";
 import { loadNodeHostConfig } from "./config.js";
 import { prepareNodeHostRuntime, type NodeHostInventory } from "./runtime.js";
@@ -22,13 +25,23 @@ function emitInventory(inventory: NodeHostInventory): void {
   writeMessage({ type: "inventory", inventory });
 }
 
-export async function runNodeHostWorker(): Promise<void> {
+export async function runNodeHostWorker(
+  options: {
+    sourceCommit?: string;
+    createPluginRegistry?: (config: OpenClawConfig) => PluginRegistry;
+  } = {},
+): Promise<void> {
   // Operator-approved startup is a second authorized entry point for Doctor-owned
   // state migrators. Runtime invokes those owners here and never migrates inline.
   await runStartupMigrations({ log: { info: writeStderrLine, warn: writeStderrLine } });
   const nodeConfig = await loadNodeHostConfig();
+  const config = getRuntimeConfig();
   const prepared = await prepareNodeHostRuntime({
+    config,
     enableDuplexPluginCommands: true,
+    ...(options.createPluginRegistry
+      ? { pluginRegistry: options.createPluginRegistry(config) }
+      : {}),
     installedAppsSharingEnabled: nodeConfig?.installedAppsSharing === true,
   });
   const client = new NodeHostWorkerBridgeClient(writeMessage);
@@ -56,6 +69,7 @@ export async function runNodeHostWorker(): Promise<void> {
   writeMessage({
     type: "ready",
     version: VERSION,
+    ...(options.sourceCommit ? { sourceCommit: options.sourceCommit } : {}),
     manifest: prepared.manifest,
     inventory: prepared.initialInventory,
   });

--- a/test/scripts/mac-elevation-host.test.ts
+++ b/test/scripts/mac-elevation-host.test.ts
@@ -216,6 +216,20 @@ function createStatusHarness(permissionMode: "fail" | "invalid") {
   mkdirSync(stateDir, { recursive: true });
   mkdirSync(launchAgentsDir, { recursive: true });
   writeFileSync(path.join(appPath, "Contents", "Info.plist"), "fixture", "utf8");
+  const workerRoot = path.join(appPath, "Contents", "Resources", "OpenClawNodeHostWorker");
+  const workerContents = "export {};\n";
+  mkdirSync(workerRoot, { recursive: true });
+  writeFileSync(path.join(workerRoot, "node-host-worker.mjs"), workerContents, "utf8");
+  writeFileSync(
+    path.join(workerRoot, "manifest.json"),
+    JSON.stringify({
+      schemaVersion: 1,
+      kind: "openclaw-macos-node-host-worker",
+      sourceCommit: "0".repeat(40),
+      sha256: sha256(workerContents),
+    }),
+    "utf8",
+  );
   writeFileSync(configPath, "{}\n", "utf8");
   writeFileSync(
     path.join(launchAgentsDir, "ai.openclaw.mac.elevation-host.plist"),
@@ -735,6 +749,11 @@ function createArtifactVerificationHarness() {
       "APP_HELPER",
       'printf helper >"$app/Contents/MacOS/openclaw-mlx-tts"',
       'chmod 755 "$app/Contents/MacOS/OpenClaw" "$app/Contents/MacOS/openclaw-mlx-tts"',
+      'worker_root="$app/Contents/Resources/OpenClawNodeHostWorker"',
+      'mkdir -p "$worker_root"',
+      'printf "%s\\n" "export {};" >"$worker_root/node-host-worker.mjs"',
+      'worker_sha="$(shasum -a 256 "$worker_root/node-host-worker.mjs" | awk \'{print $1}\')"',
+      `printf '{"schemaVersion":1,"kind":"openclaw-macos-node-host-worker","sourceCommit":"${sourceCommit}","sha256":"%s"}\n' "$worker_sha" >"$worker_root/manifest.json"`,
       'case "${TEST_CUA_DRIVER_KIND:-none}" in',
       '  file) mkdir -p "$app/Contents/Resources"; printf driver >"$app/Contents/Resources/cua-driver"; chmod 755 "$app/Contents/Resources/cua-driver" ;;',
       '  symlink) mkdir -p "$app/Contents/Resources"; ln -s /missing/cua-driver "$app/Contents/Resources/cua-driver" ;;',
@@ -771,6 +790,9 @@ function createArtifactVerificationHarness() {
       "  exit 0",
       "fi",
       'if [[ "$*" == *"-dv"* ]]; then',
+      '  if [[ -e "$target/Contents/old-fixture" && -n "${TEST_FAIL_ROLLBACK_CDHASH_ARCH:-}" && "$*" == *"--arch $TEST_FAIL_ROLLBACK_CDHASH_ARCH"* ]]; then',
+      "    exit 7",
+      "  fi",
       "  cdhash=FIXTURECDHASH",
       '  if [[ -e "$target/Contents/old-fixture" ]]; then',
       "    cdhash=OLDFIXTURECDHASH",
@@ -810,7 +832,22 @@ function createArtifactVerificationHarness() {
       "",
     ].join("\n"),
   );
-  writeCommandFixture(binDir, "lipo", "#!/bin/sh\nprintf '%s\\n' 'x86_64 arm64'\n");
+  writeCommandFixture(
+    binDir,
+    "lipo",
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'target="${!#}"',
+      'app="${target%/Contents/MacOS/OpenClaw}"',
+      'if [[ -e "$app/Contents/old-fixture" ]]; then',
+      '  printf "%s\\n" "${TEST_ROLLBACK_ARCHITECTURES:-arm64 x86_64}"',
+      "else",
+      "  printf '%s\\n' 'x86_64 arm64'",
+      "fi",
+      "",
+    ].join("\n"),
+  );
   writeCommandFixture(binDir, "spctl", "#!/bin/sh\nexit 0\n");
   writeCommandFixture(binDir, "xcrun", "#!/bin/sh\nexit 0\n");
   const receipt = {
@@ -890,6 +927,8 @@ function createInstallRollbackHarness(
     replaceMigrationSourceSameContentBeforeInitialCustody?: boolean;
     restartAppDuringBootout?: boolean;
     rollbackNonNativeSignatureInvalid?: boolean;
+    rollbackArchitectures?: "arm64" | "x86_64" | "arm64 x86_64";
+    failRollbackCDHashArch?: "arm64" | "x86_64";
     rollbackCuaDriverKind?: "file" | "symlink";
     removeCuaDriverAfterUnsafeEntryMove?: boolean;
     signalDuringCustody?: boolean;
@@ -1336,6 +1375,8 @@ function createInstallRollbackHarness(
       TEST_ROLLBACK_NON_NATIVE_SIGNATURE_INVALID: options.rollbackNonNativeSignatureInvalid
         ? "1"
         : "0",
+      TEST_ROLLBACK_ARCHITECTURES: options.rollbackArchitectures ?? "arm64 x86_64",
+      TEST_FAIL_ROLLBACK_CDHASH_ARCH: options.failRollbackCDHashArch ?? "",
       TEST_SIGNAL_DURING_CUSTODY:
         options.signalDuringCustody || options.hupDuringCustody ? "1" : "0",
       TEST_SIGNAL_DURING_RECOVERY_APP_MOVE: options.signalDuringRecoveryAppMove ? "1" : "0",
@@ -2480,6 +2521,121 @@ describe("mac elevation host command contract", () => {
       expect(readFileSync(harness.sourcePlist, "utf8")).toBe(harness.sourceContents);
       expect(readFileSync(harness.launchStateFile, "utf8").trim()).toBe("source-loaded");
       expect(existsSync(path.join(harness.stateDir, "elevation-host-install.json"))).toBe(false);
+    },
+  );
+
+  it.skipIf(process.platform !== "darwin")(
+    "reports CDHash inspection failure before mutating the existing app",
+    () => {
+      const harness = createInstallRollbackHarness({ failRollbackCDHashArch: "arm64" });
+      const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
+      const result = runInstaller(
+        harness.installerPath,
+        [
+          "install",
+          "--archive",
+          harness.archivePath,
+          "--receipt",
+          harness.receiptPath,
+          ...receiptDigestArgs(harness.receiptPath),
+          "--app",
+          harness.appPath,
+          "--migrate-launch-agent",
+          harness.sourcePlist,
+        ],
+        harness.env,
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("could not inspect installed OpenClaw app arm64 CDHash");
+      expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
+        oldBinary,
+      );
+      expect(readFileSync(harness.launchStateFile, "utf8").trim()).toBe("source-loaded");
+      expect(existsSync(path.join(harness.stateDir, "elevation-host-install.pending.json"))).toBe(
+        false,
+      );
+    },
+  );
+
+  it.skipIf(process.platform !== "darwin")(
+    "rolls back an arm64-only existing app without inventing an x86 CDHash",
+    () => {
+      const harness = createInstallRollbackHarness({ rollbackArchitectures: "arm64" });
+      const oldBinary = readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"));
+      const result = runInstaller(
+        harness.installerPath,
+        [
+          "install",
+          "--archive",
+          harness.archivePath,
+          "--receipt",
+          harness.receiptPath,
+          ...receiptDigestArgs(harness.receiptPath),
+          "--app",
+          harness.appPath,
+          "--migrate-launch-agent",
+          harness.sourcePlist,
+        ],
+        harness.env,
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("could not bootstrap elevation host");
+      expect(result.stderr).not.toContain("x86_64 CDHash");
+      expect(readFileSync(path.join(harness.appPath, "Contents", "MacOS", "OpenClaw"))).toEqual(
+        oldBinary,
+      );
+      expect(readFileSync(harness.sourcePlist, "utf8")).toBe(harness.sourceContents);
+      expect(readFileSync(harness.launchStateFile, "utf8").trim()).toBe("source-loaded");
+      expect(existsSync(path.join(harness.stateDir, "elevation-host-install.json"))).toBe(false);
+    },
+  );
+
+  it.skipIf(process.platform !== "darwin")(
+    "rejects a receipt that claims a missing rollback architecture",
+    () => {
+      const harness = createInstallRollbackHarness({
+        launchdBootstrapFails: false,
+        rollbackArchitectures: "arm64",
+      });
+      const installed = runInstaller(
+        harness.installerPath,
+        [
+          "install",
+          "--archive",
+          harness.archivePath,
+          "--receipt",
+          harness.receiptPath,
+          ...receiptDigestArgs(harness.receiptPath),
+          "--app",
+          harness.appPath,
+          "--migrate-launch-agent",
+          harness.sourcePlist,
+        ],
+        harness.env,
+      );
+      expect(installed.status, installed.stderr).toBe(0);
+      const receiptPath = path.join(harness.stateDir, "elevation-host-install.json");
+      const receipt = JSON.parse(readFileSync(receiptPath, "utf8")) as {
+        backupArchitectures: string[];
+        backupCDHashes: Record<string, string>;
+      };
+      expect(receipt.backupArchitectures).toEqual(["arm64"]);
+      expect(receipt.backupCDHashes).toEqual({ arm64: "OLDFIXTURECDHASHARM64" });
+      receipt.backupArchitectures = ["arm64", "x86_64"];
+      receipt.backupCDHashes.x86_64 = "CLAIMEDBUTMISSING";
+      writeFileSync(receiptPath, JSON.stringify(receipt), "utf8");
+
+      const recovered = runInstaller(
+        harness.installerPath,
+        ["recover", "--app", harness.appPath, "--state-dir", harness.stateDir],
+        harness.env,
+      );
+      expect(recovered.status).toBe(1);
+      expect(recovered.stderr).toContain(
+        "receipt app backup does not pass strict signature and identity validation",
+      );
     },
   );
 
@@ -4428,13 +4584,15 @@ describe("mac elevation host command contract", () => {
       const receipt = JSON.parse(
         readFileSync(path.join(harness.stateDir, "elevation-host-install.json"), "utf8"),
       ) as {
-        backupCDHashes: { arm64: string; x86_64: string };
+        backupArchitectures: string[];
+        backupCDHashes: Partial<Record<"arm64" | "x86_64", string>>;
         cdhashes: { arm64: string; x86_64: string };
         schemaVersion: number;
       };
       expect(receipt).toMatchObject({
-        schemaVersion: 3,
+        schemaVersion: 4,
         transactionState: "installed",
+        backupArchitectures: ["arm64", "x86_64"],
         backupCDHashes: {
           arm64: "OLDFIXTURECDHASHARM64",
           x86_64: "OLDFIXTURECDHASHX8664",
@@ -4521,12 +4679,14 @@ describe("mac elevation host command contract", () => {
       expect(installed.status, installed.stderr).toBe(0);
       const installReceiptPath = path.join(harness.stateDir, "elevation-host-install.json");
       const receipt = JSON.parse(readFileSync(installReceiptPath, "utf8")) as {
-        backupCDHashes: { arm64: string; x86_64: string };
+        backupArchitectures: string[];
+        backupCDHashes: Partial<Record<"arm64" | "x86_64", string>>;
         backupPath: string;
       };
       rmSync(receipt.backupPath, { recursive: true });
       receipt.backupPath = "";
-      receipt.backupCDHashes = { arm64: "", x86_64: "" };
+      receipt.backupArchitectures = [];
+      receipt.backupCDHashes = {};
       writeFileSync(installReceiptPath, JSON.stringify(receipt), "utf8");
 
       const recovered = runInstaller(

--- a/test/scripts/mac-node-host-worker-build.test.ts
+++ b/test/scripts/mac-node-host-worker-build.test.ts
@@ -40,9 +40,23 @@ describe("macOS node-host worker build", () => {
     const source = fs.readFileSync(sourcePath, "utf8");
     const generated = createMacNodeHostWorkerBuildPlugin().transform(source, sourcePath);
 
-    expect(generated).not.toContain("extensions/cua-computer");
-    expect(generated).not.toContain("extensions/linux-node");
-    expect(generated).toContain("extensions/browser");
-    expect(generated).toContain("extensions/file-transfer");
+    const pluginIds = [...(generated?.matchAll(/extensions\/(.+?)\/index\.js/g) ?? [])].map(
+      (match) => match[1],
+    );
+    expect(pluginIds).toEqual([
+      "acpx",
+      "anthropic",
+      "browser",
+      "codex",
+      "file-transfer",
+      "google-meet",
+      "logbook",
+      "ollama",
+      "opencode",
+      "teams-meetings",
+      "zoom-meetings",
+    ]);
+    expect(pluginIds).not.toContain("cua-computer");
+    expect(pluginIds).not.toContain("linux-node");
   });
 });

--- a/test/scripts/mac-node-host-worker-build.test.ts
+++ b/test/scripts/mac-node-host-worker-build.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import { isBuiltin } from "node:module";
+import { describe, expect, it } from "vitest";
+import { createMacNodeHostWorkerBuildPlugin } from "../../scripts/lib/mac-node-host-worker-build-plugin.mts";
+import { WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID } from "../../scripts/lib/worker-deploy-build-plugin.mts";
+import config from "../../tsdown.mac-node-host-worker.config.ts";
+
+describe("macOS node-host worker build", () => {
+  it("bundles a single source-bound runtime without native optional dependencies", () => {
+    expect(config.entry).toEqual({
+      "node-host-worker": "src/node-host/mac-node-host-worker-entry.ts",
+    });
+    expect(config.outDir).toBe("apps/macos/.build/node-host-worker");
+    expect(config.dts).toBe(false);
+    expect(config.outputOptions).toEqual({ codeSplitting: false });
+    expect(config.define).toMatchObject({
+      WORKER_DEPLOY_BUILD: "true",
+      MAC_NODE_HOST_WORKER_SOURCE_COMMIT: expect.any(String),
+    });
+    expect(config.alias).toMatchObject({
+      bufferutil: WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+      fsevents: WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+      kerberos: WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+      "utf-8-validate": WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+    });
+    expect(config.plugins).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "openclaw:worker-deploy" })]),
+    );
+    const alwaysBundle = config.deps?.alwaysBundle;
+    expect(alwaysBundle).toBeTypeOf("function");
+    if (typeof alwaysBundle !== "function") {
+      throw new Error("node-host worker config must own dependency bundling");
+    }
+    expect(alwaysBundle("json5", undefined)).toBe(true);
+    expect(alwaysBundle("node:fs", undefined)).toBe(!isBuiltin("node:fs"));
+  });
+
+  it("keeps the signed composition explicitly CUA-free", () => {
+    const sourcePath = "src/node-host/mac-node-host-plugin-definitions.ts";
+    const source = fs.readFileSync(sourcePath, "utf8");
+    const generated = createMacNodeHostWorkerBuildPlugin().transform(source, sourcePath);
+
+    expect(generated).not.toContain("extensions/cua-computer");
+    expect(generated).not.toContain("extensions/linux-node");
+    expect(generated).toContain("extensions/browser");
+    expect(generated).toContain("extensions/file-transfer");
+  });
+});

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -1694,11 +1694,26 @@ describe("package-mac-app plist stamping", () => {
     expect(variantBlock).toContain("standard | elevation-host");
     expect(variantBlock).toContain("Unknown OPENCLAW_MAC_SIGNING_VARIANT value");
     expect(cuaBlock).toContain("Omitting embedded CUA driver from elevation-host package");
+    expect(cuaBlock).toContain("stage_elevation_node_host_worker");
     expect(cuaBlock).toContain("else");
     expect(cuaBlock).toContain("Staging embedded CUA driver");
     expect(cuaBlock).toContain(
       '"$ROOT_DIR/scripts/stage-cua-driver-macos.sh" "$APP_ROOT/Contents/Resources/cua-driver"',
     );
+  });
+
+  it("binds the elevation node-host worker to the packaged source commit", () => {
+    const packageScript = readFileSync(scriptPath, "utf8");
+    const workerBlock = packageScript.slice(
+      packageScript.indexOf("stage_elevation_node_host_worker()"),
+      packageScript.indexOf("sparkle_canonical_build_from_version()"),
+    );
+
+    expect(workerBlock).toContain("tsdown.mac-node-host-worker.config.ts");
+    expect(workerBlock).toContain('metadata="$(node "$built_worker" --build-metadata)"');
+    expect(workerBlock).toContain(".sourceCommit == $sourceCommit");
+    expect(workerBlock).toContain('shasum -a 256 "$built_worker"');
+    expect(workerBlock).toContain("OpenClawNodeHostWorker");
   });
 
   it("does not mask required Info.plist stamp failures", () => {

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -1716,6 +1716,88 @@ describe("package-mac-app plist stamping", () => {
     expect(workerBlock).toContain("OpenClawNodeHostWorker");
   });
 
+  it("builds the elevation node-host worker from the repository root", () => {
+    const packageScript = readFileSync(scriptPath, "utf8");
+    const functionStart = packageScript.indexOf("stage_elevation_node_host_worker()");
+    const functionEnd = packageScript.indexOf(
+      "sparkle_canonical_build_from_version()",
+      functionStart,
+    );
+    expect(functionStart).toBeGreaterThanOrEqual(0);
+    expect(functionEnd).toBeGreaterThan(functionStart);
+    const workerFunction = packageScript.slice(functionStart, functionEnd);
+    const repoRoot = tempDirs.make("openclaw-worker-repo-root-");
+    const outerRoot = tempDirs.make("openclaw-worker-outer-root-");
+    const appRoot = path.join(repoRoot, "OpenClaw.app");
+    const toolsDir = tempDirs.make("openclaw-worker-tools-");
+    const cwdLog = path.join(repoRoot, "worker-build-cwd.log");
+    const sourceCommit = "a".repeat(40);
+
+    writeFileSync(
+      path.join(toolsDir, "node"),
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'if [[ "${1:-}" == "--import" ]]; then',
+        '  pwd >"$OPENCLAW_TEST_CWD_LOG"',
+        '  mkdir -p "$OPENCLAW_TEST_REPO_ROOT/apps/macos/.build/node-host-worker"',
+        '  printf "%s\\n" "export {};" >"$OPENCLAW_TEST_REPO_ROOT/apps/macos/.build/node-host-worker/node-host-worker.mjs"',
+        "else",
+        '  printf \'{"kind":"openclaw-macos-node-host-worker","schemaVersion":1,"sourceCommit":"%s","version":"test"}\\n\' "$OPENCLAW_TEST_SOURCE_COMMIT"',
+        "fi",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      path.join(toolsDir, "jq"),
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'if [[ "${1:-}" == "-n" ]]; then printf "%s\\n" "{}"; else cat >/dev/null; fi',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    writeFileSync(
+      path.join(toolsDir, "shasum"),
+      ["#!/usr/bin/env bash", 'printf "%064d  %s\\n" 0 "${@: -1}"', ""].join("\n"),
+      "utf8",
+    );
+    chmodSync(path.join(toolsDir, "node"), 0o755);
+    chmodSync(path.join(toolsDir, "jq"), 0o755);
+    chmodSync(path.join(toolsDir, "shasum"), 0o755);
+
+    const result = runHelper(`
+      set -euo pipefail
+      ROOT_DIR=${JSON.stringify(repoRoot)}
+      APP_ROOT=${JSON.stringify(appRoot)}
+      BUILD_GIT_COMMIT=${JSON.stringify(sourceCommit)}
+      OPENCLAW_TEST_REPO_ROOT=${JSON.stringify(repoRoot)}
+      OPENCLAW_TEST_CWD_LOG=${JSON.stringify(cwdLog)}
+      OPENCLAW_TEST_SOURCE_COMMIT=${JSON.stringify(sourceCommit)}
+      export OPENCLAW_TEST_REPO_ROOT OPENCLAW_TEST_CWD_LOG OPENCLAW_TEST_SOURCE_COMMIT
+      PATH=${JSON.stringify(`${toolsDir}:/usr/bin:/bin`)}
+      ${workerFunction}
+      cd ${JSON.stringify(outerRoot)}
+      stage_elevation_node_host_worker
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readFileSync(cwdLog, "utf8").trim()).toBe(repoRoot);
+    expect(
+      existsSync(
+        path.join(
+          appRoot,
+          "Contents",
+          "Resources",
+          "OpenClawNodeHostWorker",
+          "node-host-worker.mjs",
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("does not mask required Info.plist stamp failures", () => {
     const script = readFileSync(scriptPath, "utf8");
     const stampBlock = script.slice(

--- a/test/scripts/telegram-mantis-lane.test.ts
+++ b/test/scripts/telegram-mantis-lane.test.ts
@@ -13,6 +13,7 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const execFileAsync = promisify(execFile);
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const laneScript = path.resolve("scripts/e2e/telegram-mantis-lane.ts");
+const linuxIt = process.platform === "linux" ? it : it.skip;
 
 function writeJson(file: string, value: unknown): void {
   fs.mkdirSync(path.dirname(file), { recursive: true });
@@ -343,56 +344,50 @@ describe("Telegram Mantis free-form lane", () => {
     }
   });
 
-  it.runIf(process.platform === "linux")(
-    "updates provider behavior through a private data file",
-    async () => {
-      const harness = await setupHarness();
-      const responseFile = path.join(harness.outputRoot, "response.txt");
-      fs.writeFileSync(responseFile, "stream this response");
-      try {
-        const result = await runLane(harness.env, [
-          "mock",
-          "--lane",
-          "candidate",
-          "--response-file",
-          responseFile,
-          "--chunk-delay-ms",
-          "250",
-        ]);
-        expect(JSON.parse(result.stdout)).toMatchObject({ bytes: 20, chunkDelayMs: 250 });
-        expect(
-          JSON.parse(
-            fs.readFileSync(
-              path.join(path.dirname(harness.outputRoot), "mock-response.json"),
-              "utf8",
-            ),
+  linuxIt("updates provider behavior through a private data file", async () => {
+    const harness = await setupHarness();
+    const responseFile = path.join(harness.outputRoot, "response.txt");
+    fs.writeFileSync(responseFile, "stream this response");
+    try {
+      const result = await runLane(harness.env, [
+        "mock",
+        "--lane",
+        "candidate",
+        "--response-file",
+        responseFile,
+        "--chunk-delay-ms",
+        "250",
+      ]);
+      expect(JSON.parse(result.stdout)).toMatchObject({ bytes: 20, chunkDelayMs: 250 });
+      expect(
+        JSON.parse(
+          fs.readFileSync(
+            path.join(path.dirname(harness.outputRoot), "mock-response.json"),
+            "utf8",
           ),
-        ).toEqual({
-          chunkDelayMs: 250,
-          text: "stream this response",
-        });
-        expect(harness.requests).toEqual([]);
-      } finally {
-        await harness.close();
-      }
-    },
-  );
+        ),
+      ).toEqual({
+        chunkDelayMs: 250,
+        text: "stream this response",
+      });
+      expect(harness.requests).toEqual([]);
+    } finally {
+      await harness.close();
+    }
+  });
 
-  it.runIf(process.platform === "linux")(
-    "serializes commands across both lanes on the shared user session",
-    async () => {
-      const harness = await setupHarness();
-      fs.writeFileSync(path.join(harness.sessionRoot, "harness.lock"), `${process.pid}\n`);
-      try {
-        await expect(runLane(harness.env, ["requests", "--lane", "candidate"])).rejects.toThrow(
-          "shared Telegram harness already has a command in progress",
-        );
-        expect(harness.requests).toEqual([]);
-      } finally {
-        await harness.close();
-      }
-    },
-  );
+  linuxIt("serializes commands across both lanes on the shared user session", async () => {
+    const harness = await setupHarness();
+    fs.writeFileSync(path.join(harness.sessionRoot, "harness.lock"), `${process.pid}\n`);
+    try {
+      await expect(runLane(harness.env, ["requests", "--lane", "candidate"])).rejects.toThrow(
+        "shared Telegram harness already has a command in progress",
+      );
+      expect(harness.requests).toEqual([]);
+    } finally {
+      await harness.close();
+    }
+  });
 
   it("rejects scenario flags that would otherwise be silently ignored", async () => {
     const harness = await setupHarness();

--- a/test/scripts/telegram-mantis-lane.test.ts
+++ b/test/scripts/telegram-mantis-lane.test.ts
@@ -343,50 +343,56 @@ describe("Telegram Mantis free-form lane", () => {
     }
   });
 
-  it("updates provider behavior through a private data file", async () => {
-    const harness = await setupHarness();
-    const responseFile = path.join(harness.outputRoot, "response.txt");
-    fs.writeFileSync(responseFile, "stream this response");
-    try {
-      const result = await runLane(harness.env, [
-        "mock",
-        "--lane",
-        "candidate",
-        "--response-file",
-        responseFile,
-        "--chunk-delay-ms",
-        "250",
-      ]);
-      expect(JSON.parse(result.stdout)).toMatchObject({ bytes: 20, chunkDelayMs: 250 });
-      expect(
-        JSON.parse(
-          fs.readFileSync(
-            path.join(path.dirname(harness.outputRoot), "mock-response.json"),
-            "utf8",
+  it.runIf(process.platform === "linux")(
+    "updates provider behavior through a private data file",
+    async () => {
+      const harness = await setupHarness();
+      const responseFile = path.join(harness.outputRoot, "response.txt");
+      fs.writeFileSync(responseFile, "stream this response");
+      try {
+        const result = await runLane(harness.env, [
+          "mock",
+          "--lane",
+          "candidate",
+          "--response-file",
+          responseFile,
+          "--chunk-delay-ms",
+          "250",
+        ]);
+        expect(JSON.parse(result.stdout)).toMatchObject({ bytes: 20, chunkDelayMs: 250 });
+        expect(
+          JSON.parse(
+            fs.readFileSync(
+              path.join(path.dirname(harness.outputRoot), "mock-response.json"),
+              "utf8",
+            ),
           ),
-        ),
-      ).toEqual({
-        chunkDelayMs: 250,
-        text: "stream this response",
-      });
-      expect(harness.requests).toEqual([]);
-    } finally {
-      await harness.close();
-    }
-  });
+        ).toEqual({
+          chunkDelayMs: 250,
+          text: "stream this response",
+        });
+        expect(harness.requests).toEqual([]);
+      } finally {
+        await harness.close();
+      }
+    },
+  );
 
-  it("serializes commands across both lanes on the shared user session", async () => {
-    const harness = await setupHarness();
-    fs.writeFileSync(path.join(harness.sessionRoot, "harness.lock"), `${process.pid}\n`);
-    try {
-      await expect(runLane(harness.env, ["requests", "--lane", "candidate"])).rejects.toThrow(
-        "shared Telegram harness already has a command in progress",
-      );
-      expect(harness.requests).toEqual([]);
-    } finally {
-      await harness.close();
-    }
-  });
+  it.runIf(process.platform === "linux")(
+    "serializes commands across both lanes on the shared user session",
+    async () => {
+      const harness = await setupHarness();
+      fs.writeFileSync(path.join(harness.sessionRoot, "harness.lock"), `${process.pid}\n`);
+      try {
+        await expect(runLane(harness.env, ["requests", "--lane", "candidate"])).rejects.toThrow(
+          "shared Telegram harness already has a command in progress",
+        );
+        expect(harness.requests).toEqual([]);
+      } finally {
+        await harness.close();
+      }
+    },
+  );
 
   it("rejects scenario flags that would otherwise be silently ignored", async () => {
     const harness = await setupHarness();

--- a/test/scripts/telegram-mantis-sut.test.ts
+++ b/test/scripts/telegram-mantis-sut.test.ts
@@ -40,151 +40,157 @@ describe("Telegram Mantis SUT", () => {
     );
   }, 40_000);
 
-  it("releases the runtime claim before deadline-exposed removal", () => {
-    const root = tempDirs.make("telegram-mantis-cleanup-");
-    const binDir = path.join(root, "bin");
-    const runtimeParent = path.join(root, "runtime");
-    const runtimeRootFile = path.join(root, "runtime-root");
-    const released = path.join(root, "released");
-    const containerName = "openclaw-telegram-sut-dead";
-    const runtimeSource = "/tmp/openclaw-tg-crabbox-sut-Dead";
-    fs.mkdirSync(binDir);
-    fs.mkdirSync(path.join(runtimeParent, "claims"), { recursive: true });
-    fs.writeFileSync(runtimeRootFile, `${runtimeParent}\n`);
-    const ownerPid = Number(
-      spawnSync(
-        "/bin/sh",
-        [
-          "-c",
-          `/usr/bin/setsid /bin/bash -c ${JSON.stringify(`trap 'touch ${JSON.stringify(released)}; exit 0' TERM; touch ${JSON.stringify(path.join(root, "ready"))}; while :; do sleep 10; done`)} >/dev/null 2>&1 & pid=$!; while [ ! -e ${JSON.stringify(path.join(root, "ready"))} ]; do :; done; echo $pid`,
-        ],
-        { encoding: "utf8" },
-      ).stdout.trim(),
-    );
-    const stat = fs.readFileSync(`/proc/${ownerPid}/stat`, "utf8");
-    const startTime = stat.slice(stat.lastIndexOf(") ") + 2).split(" ")[19];
-    const claimPath = path.join(runtimeParent, "claims", `${containerName}.claim`);
-    fs.writeFileSync(claimPath, `${runtimeSource}\t${ownerPid}\t${ownerPid}\t${startTime}\n`, {
-      mode: 0o400,
-    });
-    const docker = path.join(binDir, "docker");
-    fs.writeFileSync(
-      docker,
-      `#!/bin/sh\ncase "$1 $2" in\n  "container ls") echo ${containerName} ;;\n  "rm --force") sleep 5; exit 1 ;;\n  "network ls") exit 0 ;;\n  *) exit 1 ;;\nesac\n`,
-      { mode: 0o755 },
-    );
-    fs.writeFileSync(
-      path.join(binDir, "install"),
-      '#!/bin/bash\ndestination="${!#}"\n: >"$destination"\nchmod 0400 "$destination"\n',
-      { mode: 0o755 },
-    );
-    fs.writeFileSync(
-      path.join(binDir, "stat"),
-      `#!/bin/sh\nif [ "$1" = -c ] && [ "$2" = %u ] && [ "$3" = ${JSON.stringify(claimPath)} ]; then echo 0; else exec /usr/bin/stat "$@"; fi\n`,
-      { mode: 0o755 },
-    );
-    const sutScript = path.join(root, "mantis-sut-container.sh");
-    const source = fs
-      .readFileSync("scripts/mantis/mantis-sut-container.sh", "utf8")
-      .replace(
-        'readonly runtime_root_file="/etc/openclaw-mantis-sut-runtime-root"',
-        `readonly runtime_root_file=${JSON.stringify(runtimeRootFile)}`,
-      )
-      .replace(
-        'readonly docker_bin="/usr/bin/docker"',
-        `readonly docker_bin=${JSON.stringify(docker)}`,
-      )
-      .replace("--kill-after=5s 30s", "--kill-after=1s 1s");
-    // A substitution that stops matching would silently point the test at the real Docker
-    // binary and the real 30s deadline, so it would still pass while proving nothing.
-    expect(source).toContain(runtimeRootFile);
-    expect(source).toContain(docker);
-    expect(source).toContain("--kill-after=1s 1s");
-    fs.writeFileSync(sutScript, source, { mode: 0o755 });
-
-    try {
-      const result = spawnSync(sutScript, ["stop", containerName, runtimeSource], {
-        env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
-      });
-      expect(result.status).toBe(124);
-      expect(fs.existsSync(released)).toBe(true);
-    } finally {
-      try {
-        process.kill(-ownerPid, "SIGKILL");
-      } catch {}
-    }
-  });
-
-  it("waits for the claimed runtime owner before returning from stop", () => {
-    const root = tempDirs.make("telegram-mantis-stop-sync-");
-    const binDir = path.join(root, "bin");
-    const runtimeParent = path.join(root, "runtime");
-    const runtimeRootFile = path.join(root, "runtime-root");
-    const released = path.join(root, "released");
-    const containerName = "openclaw-telegram-sut-feed";
-    const runtimeSource = "/tmp/openclaw-tg-crabbox-sut-Sync";
-    fs.mkdirSync(binDir);
-    fs.mkdirSync(path.join(runtimeParent, "claims"), { recursive: true });
-    fs.writeFileSync(runtimeRootFile, `${runtimeParent}\n`);
-    const ownerPid = Number(
-      spawnSync(
-        "/bin/sh",
-        [
-          "-c",
-          `/usr/bin/setsid /bin/bash -c ${JSON.stringify(`trap 'sleep 1; touch ${JSON.stringify(released)}; exit 0' TERM; touch ${JSON.stringify(path.join(root, "ready"))}; while :; do sleep 10; done`)} >/dev/null 2>&1 & pid=$!; while [ ! -e ${JSON.stringify(path.join(root, "ready"))} ]; do :; done; echo $pid`,
-        ],
-        { encoding: "utf8" },
-      ).stdout.trim(),
-    );
-    const stat = fs.readFileSync(`/proc/${ownerPid}/stat`, "utf8");
-    const startTime = stat.slice(stat.lastIndexOf(") ") + 2).split(" ")[19];
-    const claimPath = path.join(runtimeParent, "claims", `${containerName}.claim`);
-    fs.writeFileSync(claimPath, `${runtimeSource}\t${ownerPid}\t${ownerPid}\t${startTime}\n`, {
-      mode: 0o400,
-    });
-    const docker = path.join(binDir, "docker");
-    fs.writeFileSync(
-      docker,
-      '#!/bin/sh\ncase "$1 $2" in\n  "container ls"|"network ls") exit 0 ;;\n  *) exit 1 ;;\nesac\n',
-      { mode: 0o755 },
-    );
-    fs.writeFileSync(
-      path.join(binDir, "install"),
-      '#!/bin/bash\ndestination="${!#}"\n: >"$destination"\nchmod 0400 "$destination"\n',
-      { mode: 0o755 },
-    );
-    fs.writeFileSync(
-      path.join(binDir, "stat"),
-      `#!/bin/sh\nif [ "$1" = -c ] && [ "$2" = %u ] && [ "$3" = ${JSON.stringify(claimPath)} ]; then echo 0; else exec /usr/bin/stat "$@"; fi\n`,
-      { mode: 0o755 },
-    );
-    const sutScript = path.join(root, "mantis-sut-container.sh");
-    const source = fs
-      .readFileSync("scripts/mantis/mantis-sut-container.sh", "utf8")
-      .replace(
-        'readonly runtime_root_file="/etc/openclaw-mantis-sut-runtime-root"',
-        `readonly runtime_root_file=${JSON.stringify(runtimeRootFile)}`,
-      )
-      .replace(
-        'readonly docker_bin="/usr/bin/docker"',
-        `readonly docker_bin=${JSON.stringify(docker)}`,
+  it.runIf(process.platform === "linux")(
+    "releases the runtime claim before deadline-exposed removal",
+    () => {
+      const root = tempDirs.make("telegram-mantis-cleanup-");
+      const binDir = path.join(root, "bin");
+      const runtimeParent = path.join(root, "runtime");
+      const runtimeRootFile = path.join(root, "runtime-root");
+      const released = path.join(root, "released");
+      const containerName = "openclaw-telegram-sut-dead";
+      const runtimeSource = "/tmp/openclaw-tg-crabbox-sut-Dead";
+      fs.mkdirSync(binDir);
+      fs.mkdirSync(path.join(runtimeParent, "claims"), { recursive: true });
+      fs.writeFileSync(runtimeRootFile, `${runtimeParent}\n`);
+      const ownerPid = Number(
+        spawnSync(
+          "/bin/sh",
+          [
+            "-c",
+            `/usr/bin/setsid /bin/bash -c ${JSON.stringify(`trap 'touch ${JSON.stringify(released)}; exit 0' TERM; touch ${JSON.stringify(path.join(root, "ready"))}; while :; do sleep 10; done`)} >/dev/null 2>&1 & pid=$!; while [ ! -e ${JSON.stringify(path.join(root, "ready"))} ]; do :; done; echo $pid`,
+          ],
+          { encoding: "utf8" },
+        ).stdout.trim(),
       );
-    expect(source).toContain(runtimeRootFile);
-    expect(source).toContain(docker);
-    fs.writeFileSync(sutScript, source, { mode: 0o755 });
-
-    try {
-      const result = spawnSync(sutScript, ["stop", containerName, runtimeSource], {
-        env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+      const stat = fs.readFileSync(`/proc/${ownerPid}/stat`, "utf8");
+      const startTime = stat.slice(stat.lastIndexOf(") ") + 2).split(" ")[19];
+      const claimPath = path.join(runtimeParent, "claims", `${containerName}.claim`);
+      fs.writeFileSync(claimPath, `${runtimeSource}\t${ownerPid}\t${ownerPid}\t${startTime}\n`, {
+        mode: 0o400,
       });
-      expect(result.status, result.stderr.toString()).toBe(0);
-      expect(fs.existsSync(released)).toBe(true);
-    } finally {
+      const docker = path.join(binDir, "docker");
+      fs.writeFileSync(
+        docker,
+        `#!/bin/sh\ncase "$1 $2" in\n  "container ls") echo ${containerName} ;;\n  "rm --force") sleep 5; exit 1 ;;\n  "network ls") exit 0 ;;\n  *) exit 1 ;;\nesac\n`,
+        { mode: 0o755 },
+      );
+      fs.writeFileSync(
+        path.join(binDir, "install"),
+        '#!/bin/bash\ndestination="${!#}"\n: >"$destination"\nchmod 0400 "$destination"\n',
+        { mode: 0o755 },
+      );
+      fs.writeFileSync(
+        path.join(binDir, "stat"),
+        `#!/bin/sh\nif [ "$1" = -c ] && [ "$2" = %u ] && [ "$3" = ${JSON.stringify(claimPath)} ]; then echo 0; else exec /usr/bin/stat "$@"; fi\n`,
+        { mode: 0o755 },
+      );
+      const sutScript = path.join(root, "mantis-sut-container.sh");
+      const source = fs
+        .readFileSync("scripts/mantis/mantis-sut-container.sh", "utf8")
+        .replace(
+          'readonly runtime_root_file="/etc/openclaw-mantis-sut-runtime-root"',
+          `readonly runtime_root_file=${JSON.stringify(runtimeRootFile)}`,
+        )
+        .replace(
+          'readonly docker_bin="/usr/bin/docker"',
+          `readonly docker_bin=${JSON.stringify(docker)}`,
+        )
+        .replace("--kill-after=5s 30s", "--kill-after=1s 1s");
+      // A substitution that stops matching would silently point the test at the real Docker
+      // binary and the real 30s deadline, so it would still pass while proving nothing.
+      expect(source).toContain(runtimeRootFile);
+      expect(source).toContain(docker);
+      expect(source).toContain("--kill-after=1s 1s");
+      fs.writeFileSync(sutScript, source, { mode: 0o755 });
+
       try {
-        process.kill(-ownerPid, "SIGKILL");
-      } catch {}
-    }
-  });
+        const result = spawnSync(sutScript, ["stop", containerName, runtimeSource], {
+          env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+        });
+        expect(result.status).toBe(124);
+        expect(fs.existsSync(released)).toBe(true);
+      } finally {
+        try {
+          process.kill(-ownerPid, "SIGKILL");
+        } catch {}
+      }
+    },
+  );
+
+  it.runIf(process.platform === "linux")(
+    "waits for the claimed runtime owner before returning from stop",
+    () => {
+      const root = tempDirs.make("telegram-mantis-stop-sync-");
+      const binDir = path.join(root, "bin");
+      const runtimeParent = path.join(root, "runtime");
+      const runtimeRootFile = path.join(root, "runtime-root");
+      const released = path.join(root, "released");
+      const containerName = "openclaw-telegram-sut-feed";
+      const runtimeSource = "/tmp/openclaw-tg-crabbox-sut-Sync";
+      fs.mkdirSync(binDir);
+      fs.mkdirSync(path.join(runtimeParent, "claims"), { recursive: true });
+      fs.writeFileSync(runtimeRootFile, `${runtimeParent}\n`);
+      const ownerPid = Number(
+        spawnSync(
+          "/bin/sh",
+          [
+            "-c",
+            `/usr/bin/setsid /bin/bash -c ${JSON.stringify(`trap 'sleep 1; touch ${JSON.stringify(released)}; exit 0' TERM; touch ${JSON.stringify(path.join(root, "ready"))}; while :; do sleep 10; done`)} >/dev/null 2>&1 & pid=$!; while [ ! -e ${JSON.stringify(path.join(root, "ready"))} ]; do :; done; echo $pid`,
+          ],
+          { encoding: "utf8" },
+        ).stdout.trim(),
+      );
+      const stat = fs.readFileSync(`/proc/${ownerPid}/stat`, "utf8");
+      const startTime = stat.slice(stat.lastIndexOf(") ") + 2).split(" ")[19];
+      const claimPath = path.join(runtimeParent, "claims", `${containerName}.claim`);
+      fs.writeFileSync(claimPath, `${runtimeSource}\t${ownerPid}\t${ownerPid}\t${startTime}\n`, {
+        mode: 0o400,
+      });
+      const docker = path.join(binDir, "docker");
+      fs.writeFileSync(
+        docker,
+        '#!/bin/sh\ncase "$1 $2" in\n  "container ls"|"network ls") exit 0 ;;\n  *) exit 1 ;;\nesac\n',
+        { mode: 0o755 },
+      );
+      fs.writeFileSync(
+        path.join(binDir, "install"),
+        '#!/bin/bash\ndestination="${!#}"\n: >"$destination"\nchmod 0400 "$destination"\n',
+        { mode: 0o755 },
+      );
+      fs.writeFileSync(
+        path.join(binDir, "stat"),
+        `#!/bin/sh\nif [ "$1" = -c ] && [ "$2" = %u ] && [ "$3" = ${JSON.stringify(claimPath)} ]; then echo 0; else exec /usr/bin/stat "$@"; fi\n`,
+        { mode: 0o755 },
+      );
+      const sutScript = path.join(root, "mantis-sut-container.sh");
+      const source = fs
+        .readFileSync("scripts/mantis/mantis-sut-container.sh", "utf8")
+        .replace(
+          'readonly runtime_root_file="/etc/openclaw-mantis-sut-runtime-root"',
+          `readonly runtime_root_file=${JSON.stringify(runtimeRootFile)}`,
+        )
+        .replace(
+          'readonly docker_bin="/usr/bin/docker"',
+          `readonly docker_bin=${JSON.stringify(docker)}`,
+        );
+      expect(source).toContain(runtimeRootFile);
+      expect(source).toContain(docker);
+      fs.writeFileSync(sutScript, source, { mode: 0o755 });
+
+      try {
+        const result = spawnSync(sutScript, ["stop", containerName, runtimeSource], {
+          env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
+        });
+        expect(result.status, result.stderr.toString()).toBe(0);
+        expect(fs.existsSync(released)).toBe(true);
+      } finally {
+        try {
+          process.kill(-ownerPid, "SIGKILL");
+        } catch {}
+      }
+    },
+  );
 
   it("tests default Telegram delivery without forcing native reply mode", () => {
     const outputDir = tempDirs.make("telegram-mantis-config-");

--- a/test/scripts/telegram-mantis-sut.test.ts
+++ b/test/scripts/telegram-mantis-sut.test.ts
@@ -10,6 +10,7 @@ import {
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const linuxIt = process.platform === "linux" ? it : it.skip;
 
 describe("Telegram Mantis SUT", () => {
   it("keeps stderr when a container action is terminated", () => {
@@ -40,157 +41,151 @@ describe("Telegram Mantis SUT", () => {
     );
   }, 40_000);
 
-  it.runIf(process.platform === "linux")(
-    "releases the runtime claim before deadline-exposed removal",
-    () => {
-      const root = tempDirs.make("telegram-mantis-cleanup-");
-      const binDir = path.join(root, "bin");
-      const runtimeParent = path.join(root, "runtime");
-      const runtimeRootFile = path.join(root, "runtime-root");
-      const released = path.join(root, "released");
-      const containerName = "openclaw-telegram-sut-dead";
-      const runtimeSource = "/tmp/openclaw-tg-crabbox-sut-Dead";
-      fs.mkdirSync(binDir);
-      fs.mkdirSync(path.join(runtimeParent, "claims"), { recursive: true });
-      fs.writeFileSync(runtimeRootFile, `${runtimeParent}\n`);
-      const ownerPid = Number(
-        spawnSync(
-          "/bin/sh",
-          [
-            "-c",
-            `/usr/bin/setsid /bin/bash -c ${JSON.stringify(`trap 'touch ${JSON.stringify(released)}; exit 0' TERM; touch ${JSON.stringify(path.join(root, "ready"))}; while :; do sleep 10; done`)} >/dev/null 2>&1 & pid=$!; while [ ! -e ${JSON.stringify(path.join(root, "ready"))} ]; do :; done; echo $pid`,
-          ],
-          { encoding: "utf8" },
-        ).stdout.trim(),
-      );
-      const stat = fs.readFileSync(`/proc/${ownerPid}/stat`, "utf8");
-      const startTime = stat.slice(stat.lastIndexOf(") ") + 2).split(" ")[19];
-      const claimPath = path.join(runtimeParent, "claims", `${containerName}.claim`);
-      fs.writeFileSync(claimPath, `${runtimeSource}\t${ownerPid}\t${ownerPid}\t${startTime}\n`, {
-        mode: 0o400,
+  linuxIt("releases the runtime claim before deadline-exposed removal", () => {
+    const root = tempDirs.make("telegram-mantis-cleanup-");
+    const binDir = path.join(root, "bin");
+    const runtimeParent = path.join(root, "runtime");
+    const runtimeRootFile = path.join(root, "runtime-root");
+    const released = path.join(root, "released");
+    const containerName = "openclaw-telegram-sut-dead";
+    const runtimeSource = "/tmp/openclaw-tg-crabbox-sut-Dead";
+    fs.mkdirSync(binDir);
+    fs.mkdirSync(path.join(runtimeParent, "claims"), { recursive: true });
+    fs.writeFileSync(runtimeRootFile, `${runtimeParent}\n`);
+    const ownerPid = Number(
+      spawnSync(
+        "/bin/sh",
+        [
+          "-c",
+          `/usr/bin/setsid /bin/bash -c ${JSON.stringify(`trap 'touch ${JSON.stringify(released)}; exit 0' TERM; touch ${JSON.stringify(path.join(root, "ready"))}; while :; do sleep 10; done`)} >/dev/null 2>&1 & pid=$!; while [ ! -e ${JSON.stringify(path.join(root, "ready"))} ]; do :; done; echo $pid`,
+        ],
+        { encoding: "utf8" },
+      ).stdout.trim(),
+    );
+    const stat = fs.readFileSync(`/proc/${ownerPid}/stat`, "utf8");
+    const startTime = stat.slice(stat.lastIndexOf(") ") + 2).split(" ")[19];
+    const claimPath = path.join(runtimeParent, "claims", `${containerName}.claim`);
+    fs.writeFileSync(claimPath, `${runtimeSource}\t${ownerPid}\t${ownerPid}\t${startTime}\n`, {
+      mode: 0o400,
+    });
+    const docker = path.join(binDir, "docker");
+    fs.writeFileSync(
+      docker,
+      `#!/bin/sh\ncase "$1 $2" in\n  "container ls") echo ${containerName} ;;\n  "rm --force") sleep 5; exit 1 ;;\n  "network ls") exit 0 ;;\n  *) exit 1 ;;\nesac\n`,
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(binDir, "install"),
+      '#!/bin/bash\ndestination="${!#}"\n: >"$destination"\nchmod 0400 "$destination"\n',
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(binDir, "stat"),
+      `#!/bin/sh\nif [ "$1" = -c ] && [ "$2" = %u ] && [ "$3" = ${JSON.stringify(claimPath)} ]; then echo 0; else exec /usr/bin/stat "$@"; fi\n`,
+      { mode: 0o755 },
+    );
+    const sutScript = path.join(root, "mantis-sut-container.sh");
+    const source = fs
+      .readFileSync("scripts/mantis/mantis-sut-container.sh", "utf8")
+      .replace(
+        'readonly runtime_root_file="/etc/openclaw-mantis-sut-runtime-root"',
+        `readonly runtime_root_file=${JSON.stringify(runtimeRootFile)}`,
+      )
+      .replace(
+        'readonly docker_bin="/usr/bin/docker"',
+        `readonly docker_bin=${JSON.stringify(docker)}`,
+      )
+      .replace("--kill-after=5s 30s", "--kill-after=1s 1s");
+    // A substitution that stops matching would silently point the test at the real Docker
+    // binary and the real 30s deadline, so it would still pass while proving nothing.
+    expect(source).toContain(runtimeRootFile);
+    expect(source).toContain(docker);
+    expect(source).toContain("--kill-after=1s 1s");
+    fs.writeFileSync(sutScript, source, { mode: 0o755 });
+
+    try {
+      const result = spawnSync(sutScript, ["stop", containerName, runtimeSource], {
+        env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
       });
-      const docker = path.join(binDir, "docker");
-      fs.writeFileSync(
-        docker,
-        `#!/bin/sh\ncase "$1 $2" in\n  "container ls") echo ${containerName} ;;\n  "rm --force") sleep 5; exit 1 ;;\n  "network ls") exit 0 ;;\n  *) exit 1 ;;\nesac\n`,
-        { mode: 0o755 },
-      );
-      fs.writeFileSync(
-        path.join(binDir, "install"),
-        '#!/bin/bash\ndestination="${!#}"\n: >"$destination"\nchmod 0400 "$destination"\n',
-        { mode: 0o755 },
-      );
-      fs.writeFileSync(
-        path.join(binDir, "stat"),
-        `#!/bin/sh\nif [ "$1" = -c ] && [ "$2" = %u ] && [ "$3" = ${JSON.stringify(claimPath)} ]; then echo 0; else exec /usr/bin/stat "$@"; fi\n`,
-        { mode: 0o755 },
-      );
-      const sutScript = path.join(root, "mantis-sut-container.sh");
-      const source = fs
-        .readFileSync("scripts/mantis/mantis-sut-container.sh", "utf8")
-        .replace(
-          'readonly runtime_root_file="/etc/openclaw-mantis-sut-runtime-root"',
-          `readonly runtime_root_file=${JSON.stringify(runtimeRootFile)}`,
-        )
-        .replace(
-          'readonly docker_bin="/usr/bin/docker"',
-          `readonly docker_bin=${JSON.stringify(docker)}`,
-        )
-        .replace("--kill-after=5s 30s", "--kill-after=1s 1s");
-      // A substitution that stops matching would silently point the test at the real Docker
-      // binary and the real 30s deadline, so it would still pass while proving nothing.
-      expect(source).toContain(runtimeRootFile);
-      expect(source).toContain(docker);
-      expect(source).toContain("--kill-after=1s 1s");
-      fs.writeFileSync(sutScript, source, { mode: 0o755 });
-
+      expect(result.status).toBe(124);
+      expect(fs.existsSync(released)).toBe(true);
+    } finally {
       try {
-        const result = spawnSync(sutScript, ["stop", containerName, runtimeSource], {
-          env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
-        });
-        expect(result.status).toBe(124);
-        expect(fs.existsSync(released)).toBe(true);
-      } finally {
-        try {
-          process.kill(-ownerPid, "SIGKILL");
-        } catch {}
-      }
-    },
-  );
+        process.kill(-ownerPid, "SIGKILL");
+      } catch {}
+    }
+  });
 
-  it.runIf(process.platform === "linux")(
-    "waits for the claimed runtime owner before returning from stop",
-    () => {
-      const root = tempDirs.make("telegram-mantis-stop-sync-");
-      const binDir = path.join(root, "bin");
-      const runtimeParent = path.join(root, "runtime");
-      const runtimeRootFile = path.join(root, "runtime-root");
-      const released = path.join(root, "released");
-      const containerName = "openclaw-telegram-sut-feed";
-      const runtimeSource = "/tmp/openclaw-tg-crabbox-sut-Sync";
-      fs.mkdirSync(binDir);
-      fs.mkdirSync(path.join(runtimeParent, "claims"), { recursive: true });
-      fs.writeFileSync(runtimeRootFile, `${runtimeParent}\n`);
-      const ownerPid = Number(
-        spawnSync(
-          "/bin/sh",
-          [
-            "-c",
-            `/usr/bin/setsid /bin/bash -c ${JSON.stringify(`trap 'sleep 1; touch ${JSON.stringify(released)}; exit 0' TERM; touch ${JSON.stringify(path.join(root, "ready"))}; while :; do sleep 10; done`)} >/dev/null 2>&1 & pid=$!; while [ ! -e ${JSON.stringify(path.join(root, "ready"))} ]; do :; done; echo $pid`,
-          ],
-          { encoding: "utf8" },
-        ).stdout.trim(),
+  linuxIt("waits for the claimed runtime owner before returning from stop", () => {
+    const root = tempDirs.make("telegram-mantis-stop-sync-");
+    const binDir = path.join(root, "bin");
+    const runtimeParent = path.join(root, "runtime");
+    const runtimeRootFile = path.join(root, "runtime-root");
+    const released = path.join(root, "released");
+    const containerName = "openclaw-telegram-sut-feed";
+    const runtimeSource = "/tmp/openclaw-tg-crabbox-sut-Sync";
+    fs.mkdirSync(binDir);
+    fs.mkdirSync(path.join(runtimeParent, "claims"), { recursive: true });
+    fs.writeFileSync(runtimeRootFile, `${runtimeParent}\n`);
+    const ownerPid = Number(
+      spawnSync(
+        "/bin/sh",
+        [
+          "-c",
+          `/usr/bin/setsid /bin/bash -c ${JSON.stringify(`trap 'sleep 1; touch ${JSON.stringify(released)}; exit 0' TERM; touch ${JSON.stringify(path.join(root, "ready"))}; while :; do sleep 10; done`)} >/dev/null 2>&1 & pid=$!; while [ ! -e ${JSON.stringify(path.join(root, "ready"))} ]; do :; done; echo $pid`,
+        ],
+        { encoding: "utf8" },
+      ).stdout.trim(),
+    );
+    const stat = fs.readFileSync(`/proc/${ownerPid}/stat`, "utf8");
+    const startTime = stat.slice(stat.lastIndexOf(") ") + 2).split(" ")[19];
+    const claimPath = path.join(runtimeParent, "claims", `${containerName}.claim`);
+    fs.writeFileSync(claimPath, `${runtimeSource}\t${ownerPid}\t${ownerPid}\t${startTime}\n`, {
+      mode: 0o400,
+    });
+    const docker = path.join(binDir, "docker");
+    fs.writeFileSync(
+      docker,
+      '#!/bin/sh\ncase "$1 $2" in\n  "container ls"|"network ls") exit 0 ;;\n  *) exit 1 ;;\nesac\n',
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(binDir, "install"),
+      '#!/bin/bash\ndestination="${!#}"\n: >"$destination"\nchmod 0400 "$destination"\n',
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(binDir, "stat"),
+      `#!/bin/sh\nif [ "$1" = -c ] && [ "$2" = %u ] && [ "$3" = ${JSON.stringify(claimPath)} ]; then echo 0; else exec /usr/bin/stat "$@"; fi\n`,
+      { mode: 0o755 },
+    );
+    const sutScript = path.join(root, "mantis-sut-container.sh");
+    const source = fs
+      .readFileSync("scripts/mantis/mantis-sut-container.sh", "utf8")
+      .replace(
+        'readonly runtime_root_file="/etc/openclaw-mantis-sut-runtime-root"',
+        `readonly runtime_root_file=${JSON.stringify(runtimeRootFile)}`,
+      )
+      .replace(
+        'readonly docker_bin="/usr/bin/docker"',
+        `readonly docker_bin=${JSON.stringify(docker)}`,
       );
-      const stat = fs.readFileSync(`/proc/${ownerPid}/stat`, "utf8");
-      const startTime = stat.slice(stat.lastIndexOf(") ") + 2).split(" ")[19];
-      const claimPath = path.join(runtimeParent, "claims", `${containerName}.claim`);
-      fs.writeFileSync(claimPath, `${runtimeSource}\t${ownerPid}\t${ownerPid}\t${startTime}\n`, {
-        mode: 0o400,
+    expect(source).toContain(runtimeRootFile);
+    expect(source).toContain(docker);
+    fs.writeFileSync(sutScript, source, { mode: 0o755 });
+
+    try {
+      const result = spawnSync(sutScript, ["stop", containerName, runtimeSource], {
+        env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
       });
-      const docker = path.join(binDir, "docker");
-      fs.writeFileSync(
-        docker,
-        '#!/bin/sh\ncase "$1 $2" in\n  "container ls"|"network ls") exit 0 ;;\n  *) exit 1 ;;\nesac\n',
-        { mode: 0o755 },
-      );
-      fs.writeFileSync(
-        path.join(binDir, "install"),
-        '#!/bin/bash\ndestination="${!#}"\n: >"$destination"\nchmod 0400 "$destination"\n',
-        { mode: 0o755 },
-      );
-      fs.writeFileSync(
-        path.join(binDir, "stat"),
-        `#!/bin/sh\nif [ "$1" = -c ] && [ "$2" = %u ] && [ "$3" = ${JSON.stringify(claimPath)} ]; then echo 0; else exec /usr/bin/stat "$@"; fi\n`,
-        { mode: 0o755 },
-      );
-      const sutScript = path.join(root, "mantis-sut-container.sh");
-      const source = fs
-        .readFileSync("scripts/mantis/mantis-sut-container.sh", "utf8")
-        .replace(
-          'readonly runtime_root_file="/etc/openclaw-mantis-sut-runtime-root"',
-          `readonly runtime_root_file=${JSON.stringify(runtimeRootFile)}`,
-        )
-        .replace(
-          'readonly docker_bin="/usr/bin/docker"',
-          `readonly docker_bin=${JSON.stringify(docker)}`,
-        );
-      expect(source).toContain(runtimeRootFile);
-      expect(source).toContain(docker);
-      fs.writeFileSync(sutScript, source, { mode: 0o755 });
-
+      expect(result.status, result.stderr.toString()).toBe(0);
+      expect(fs.existsSync(released)).toBe(true);
+    } finally {
       try {
-        const result = spawnSync(sutScript, ["stop", containerName, runtimeSource], {
-          env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}` },
-        });
-        expect(result.status, result.stderr.toString()).toBe(0);
-        expect(fs.existsSync(released)).toBe(true);
-      } finally {
-        try {
-          process.kill(-ownerPid, "SIGKILL");
-        } catch {}
-      }
-    },
-  );
+        process.kill(-ownerPid, "SIGKILL");
+      } catch {}
+    }
+  });
 
   it("tests default Telegram delivery without forcing native reply mode", () => {
     const outputDir = tempDirs.make("telegram-mantis-config-");

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -508,6 +508,9 @@ describe("resolveTsdownBuildInvocation", () => {
       "packages/ai/dist",
     ]);
     expect(
+      resolveTsdownCleanOutputRoots(["--config", "tsdown.mac-node-host-worker.config.ts"]),
+    ).toEqual(["apps/macos/.build/node-host-worker"]);
+    expect(
       resolveTsdownCleanOutputRoots([
         "--config",
         "tsdown.config.ts",

--- a/tsdown.mac-node-host-worker.config.ts
+++ b/tsdown.mac-node-host-worker.config.ts
@@ -1,0 +1,50 @@
+import { isBuiltin } from "node:module";
+import type { UserConfig } from "tsdown";
+import { createMacNodeHostWorkerBuildPlugin } from "./scripts/lib/mac-node-host-worker-build-plugin.mts";
+import { createStateSchemaInlinePlugin } from "./scripts/lib/state-schema-inline-plugin.mts";
+import {
+  createWorkerDeployBuildPlugin,
+  WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+} from "./scripts/lib/worker-deploy-build-plugin.mts";
+
+const packageVersion = (await import("./package.json", { with: { type: "json" } })).default.version;
+const sourceCommit = process.env.GIT_COMMIT?.trim() ?? "";
+
+const config: UserConfig = {
+  entry: {
+    "node-host-worker": "src/node-host/mac-node-host-worker-entry.ts",
+  },
+  outDir: "apps/macos/.build/node-host-worker",
+  dts: false,
+  env: { NODE_ENV: "production" },
+  define: {
+    MAC_NODE_HOST_WORKER_SOURCE_COMMIT: JSON.stringify(sourceCommit),
+    WORKER_DEPLOY_BUILD: "true",
+    WORKER_DEPLOY_VERSION: JSON.stringify(packageVersion),
+  },
+  alias: {
+    bufferutil: WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+    "chromium-bidi/lib/cjs/bidiMapper/BidiMapper": WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+    "chromium-bidi/lib/cjs/cdp/CdpConnection": WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+    "electron/index.js": WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+    fsevents: WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+    kerberos: WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+    "utf-8-validate": WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
+  },
+  deps: {
+    alwaysBundle: (id) => !isBuiltin(id),
+    onlyBundle: false,
+  },
+  fixedExtension: false,
+  outExtensions: () => ({ js: ".mjs", dts: ".d.ts" }),
+  outputOptions: { codeSplitting: false },
+  plugins: [
+    createStateSchemaInlinePlugin(),
+    createMacNodeHostWorkerBuildPlugin(),
+    createWorkerDeployBuildPlugin(),
+  ],
+  shims: true,
+  sourcemap: false,
+};
+
+export default config;


### PR DESCRIPTION
## What Problem This Solves

The unattended macOS elevation host could fail before mutation when replacing an arm64-only OpenClaw app because rollback planning unconditionally requested an x86_64 CDHash. The packaged app also launched its node-host worker through an independently installed OpenClaw CLI, allowing stale source and state-schema support to win over the signed app.

## Why This Change Was Made

Rollback receipts now record the exact architecture set present in the prior app and only bind CDHashes for those slices. Recovery rejects architecture drift, missing claimed slices, or mismatched per-slice identities, and failed metadata substitutions emit an explicit diagnostic before custody begins. Schema 4 stores the architecture set while retaining schema 3 and legacy recovery handling.

Elevation packages now build a self-contained node-host worker into signed app resources. Its manifest binds the worker digest and OpenClaw source commit to the app; the Swift host verifies the app signature, manifest, digest, and ready-frame source identity before accepting the worker. A build-time composition injects the canonical non-CUA macOS node-host plugin owners without filesystem discovery or `jiti`, preserving the normal command/capability surface while excluding CUA and Linux-only providers.

The worker build is rooted explicitly in the repository even when packaging starts elsewhere. Knip owns both the string-named tsdown config and its worker entry, and test-only production exports were removed. The broad macOS proof also repaired two Linux-only Telegram/Mantis process fixtures that had hard-coded `/usr/bin/setsid` and `/proc`, causing the macOS tooling shard to fail or busy-wait forever.

## User Impact

Existing arm64-only installations can be replaced and rolled back safely. Elevation startup no longer depends on whichever OpenClaw CLI happens to be installed, so a stale CLI cannot reject newer state or silently alter capabilities. Normal interactive/background app launches keep their existing CLI and plugin behavior.

Release-note context: make unattended macOS computer-control elevation upgrades architecture-aware and bind their runtime to the signed app source.

## Evidence

- exact head: `5fe0e94a79bceb110a7717c17349ebcf6acb6900`
- `pnpm check:changed`
- `pnpm test:changed` — 428 files; 8,368 passed; 48 skipped
- focused elevation/build suite — 167/167
- focused macOS `CommandResolverTests` and `MacNodeHostWorkerTests` — 55/55
- focused packaging/runtime/Knip proof, including a non-root-cwd regression that failed before and passes after
- focused macOS Telegram/Mantis tooling proof — 13 passed; four Linux-specific process/file-lock cases skipped
- `swift build --package-path apps/macos --configuration release` — passed with no warnings
- `pnpm build` — passed; Control UI startup 336.1 KiB gzip under the 337.0 KiB limit
- current upstream Codex source inspected for plugin install serialization, selected capability roots, and Computer Use requirements; OpenClaw remains pinned to managed app-server 0.148.0
- final full-branch Autoreview: no actionable findings

Signed/notarized local and personal-Studio deployment is intentionally deferred until this exact source lands so the final artifact is built once from a canonical commit.
