### PR TITLE
fix(plugin-sdk): deduplicate API diff declarations

### DIFF
--- a/src/plugin-sdk/api-baseline.test.ts
+++ b/src/plugin-sdk/api-baseline.test.ts
@@ -407,7 +407,41 @@ describe("Plugin SDK API baseline", () => {
       expect.objectContaining({ change: "signature", exportName: "SendOptions" }),
       expect.objectContaining({ change: "reachable", exportName: "send" }),
     ]);
-    expect(diff.exports.every((change) => change.declarationChanges.length > 0)).toBe(true);
+    expect(diff.exports[0]?.declarationChanges.length).toBeGreaterThan(0);
+    expect(diff.exports[1]?.declarationChanges).toEqual([]);
+  });
+
+  it("stores shared declaration detail once while retaining every affected export", async () => {
+    const render = (field: string) =>
+      renderSourceFixture({
+        "fixture.ts": [
+          `type SharedOptions = { ${field}: string };`,
+          "export declare function preview(options: SharedOptions): void;",
+          "export declare function send(options: SharedOptions): void;",
+        ].join("\n"),
+      });
+    const baseline = await render("text");
+    const changed = await render("accountId");
+
+    const diff = diffPluginSdkApi(baseline, changed);
+    expect(diff.exports.map(({ change, exportName }) => ({ change, exportName }))).toEqual([
+      { change: "reachable", exportName: "preview" },
+      { change: "reachable", exportName: "send" },
+    ]);
+    expect(diff.exports[0]?.declarationChanges).toEqual([
+      expect.objectContaining({
+        after: expect.stringContaining("accountId: string"),
+        before: expect.stringContaining("text: string"),
+        name: expect.stringContaining("SharedOptions"),
+      }),
+    ]);
+    expect(diff.exports[1]?.declarationChanges).toEqual([]);
+    expect(JSON.stringify(diff).match(/type SharedOptions/gu)).toHaveLength(2);
+    const report = formatPluginSdkApiDiffReport({ baseLabel: "base", diff, headLabel: "head" });
+    expect(report).toContain("Affected exports (2)");
+    expect(report).toContain("`openclaw/plugin-sdk/fixture` — `preview` (reachable)");
+    expect(report).toContain("`openclaw/plugin-sdk/fixture` — `send` (reachable)");
+    expect(report).not.toContain("affects 1 export");
   });
 
   it("validates renderer artifacts at the subprocess boundary", async () => {

--- a/src/plugin-sdk/api-diff.ts
+++ b/src/plugin-sdk/api-diff.ts
@@ -9,7 +9,6 @@ const ENTRYPOINTS_PATH = "scripts/lib/plugin-sdk-entrypoints.json";
 const PRIVATE_ENTRYPOINTS_PATH = "scripts/lib/plugin-sdk-private-local-only-subpaths.json";
 const REPORT_ITEM_LIMIT = 40;
 const REPORT_TEXT_LINE_LIMIT = 20;
-const REPORT_AFFECTED_EXPORT_LIMIT = 5;
 const REPORT_BYTE_LIMIT = 64 * 1024;
 
 export type PluginSdkApiExportSnapshot = Pick<
@@ -246,22 +245,6 @@ function collectDeclarationChanges(
   return changes;
 }
 
-function exportSections(
-  surface: PluginSdkApiDiffSurface,
-  exportSurface: PluginSdkApiDiffExport | undefined,
-): PluginSdkApiDeclarationSection[] {
-  if (!exportSurface) {
-    return [];
-  }
-  return (exportSurface.closureSectionIds ?? []).map((id) => {
-    const section = surface.declarationSections[id];
-    if (!section) {
-      throw new Error(`Plugin SDK API render references missing declaration section ${id}`);
-    }
-    return section;
-  });
-}
-
 function moduleChange(moduleSurface: PluginSdkApiDiffModule): PluginSdkApiEntrypointChange {
   return {
     entrypoint: moduleSurface.entrypoint,
@@ -319,7 +302,7 @@ export function diffPluginSdkApi(
           after: snapshot(afterExport),
           before: null,
           change: "added",
-          declarationChanges: collectDeclarationChanges([], exportSections(after, afterExport)),
+          declarationChanges: [],
           entrypoint,
           exportName,
           importSpecifier: moduleSurface.importSpecifier,
@@ -331,7 +314,7 @@ export function diffPluginSdkApi(
           after: null,
           before: snapshot(beforeExport),
           change: "removed",
-          declarationChanges: collectDeclarationChanges(exportSections(before, beforeExport), []),
+          declarationChanges: [],
           entrypoint,
           exportName,
           importSpecifier: moduleSurface.importSpecifier,
@@ -349,10 +332,7 @@ export function diffPluginSdkApi(
           after: snapshot(afterExport),
           before: snapshot(beforeExport),
           change: "signature",
-          declarationChanges: collectDeclarationChanges(
-            exportSections(before, beforeExport),
-            exportSections(after, afterExport),
-          ),
+          declarationChanges: [],
           entrypoint,
           exportName,
           importSpecifier: moduleSurface.importSpecifier,
@@ -362,16 +342,23 @@ export function diffPluginSdkApi(
           after: snapshot(afterExport),
           before: snapshot(beforeExport),
           change: "reachable",
-          declarationChanges: collectDeclarationChanges(
-            exportSections(before, beforeExport),
-            exportSections(after, afterExport),
-          ),
+          declarationChanges: [],
           entrypoint,
           exportName,
           importSpecifier: moduleSurface.importSpecifier,
         });
       }
     }
+  }
+
+  // Exports already carry the complete affected surface. Keep the v1 declaration detail in
+  // its first canonical export instead of multiplying shared closure text across every export.
+  const firstExport = payload.exports[0];
+  if (firstExport) {
+    firstExport.declarationChanges = collectDeclarationChanges(
+      before.declarationSections,
+      after.declarationSections,
+    );
   }
 
   return {
@@ -446,22 +433,14 @@ function appendExportChanges(
   }
 }
 
-type DeclarationReportChange = PluginSdkApiDeclarationChange & { affectedExports: string[] };
-
 function collectDeclarationReportChanges(
   changes: readonly PluginSdkApiExportChange[],
-): DeclarationReportChange[] {
-  const grouped = new Map<string, DeclarationReportChange>();
+): PluginSdkApiDeclarationChange[] {
+  const grouped = new Map<string, PluginSdkApiDeclarationChange>();
   for (const change of changes) {
-    const affectedExport = `${change.importSpecifier} :: ${change.exportName}`;
     for (const declaration of change.declarationChanges) {
       const key = `${declaration.name}\0${declaration.before ?? ""}\0${declaration.after ?? ""}`;
-      const current = grouped.get(key);
-      if (current) {
-        current.affectedExports.push(affectedExport);
-      } else {
-        grouped.set(key, { ...declaration, affectedExports: [affectedExport] });
-      }
+      grouped.set(key, declaration);
     }
   }
   return [...grouped.values()].toSorted(
@@ -505,6 +484,14 @@ export function formatPluginSdkApiDiffReport(params: {
     }
   }
 
+  lines.push("", `## Affected exports (${diff.exports.length})`);
+  for (const change of diff.exports.slice(0, REPORT_ITEM_LIMIT)) {
+    lines.push("", `- \`${change.importSpecifier}\` — \`${change.exportName}\` (${change.change})`);
+  }
+  if (diff.exports.length > REPORT_ITEM_LIMIT) {
+    lines.push("", `… ${diff.exports.length - REPORT_ITEM_LIMIT} more affected exports`);
+  }
+
   appendExportChanges(
     lines,
     "Exports removed",
@@ -520,29 +507,13 @@ export function formatPluginSdkApiDiffReport(params: {
     "Signatures changed",
     diff.exports.filter((change) => change.change === "signature"),
   );
-
   const reachable = collectDeclarationReportChanges(diff.exports);
   if (reachable.length > 0) {
-    const affectedCount = diff.exports.filter(
-      (change) => change.declarationChanges.length > 0,
-    ).length;
-    lines.push(
-      "",
-      `## Reachable declarations changed (${reachable.length}; affects ${affectedCount} exports)`,
-    );
+    lines.push("", `## Reachable declarations changed (${reachable.length})`);
     for (const change of reachable.slice(0, REPORT_ITEM_LIMIT)) {
       lines.push("", `- \`${change.name}\``);
       appendText(lines, "before", change.before);
       appendText(lines, "after", change.after);
-      const affected = change.affectedExports.toSorted(compareText);
-      lines.push(
-        `    affects: ${affected
-          .slice(0, REPORT_AFFECTED_EXPORT_LIMIT)
-          .map((value) => `\`${value}\``)
-          .join(
-            ", ",
-          )}${affected.length > REPORT_AFFECTED_EXPORT_LIMIT ? ` (+${affected.length - REPORT_AFFECTED_EXPORT_LIMIT} more)` : ""}`,
-      );
     }
     if (reachable.length > REPORT_ITEM_LIMIT) {
       lines.push("", `… ${reachable.length - REPORT_ITEM_LIMIT} more reachable declarations`);

--- a/test/scripts/plugin-sdk-api-release-evidence.test.ts
+++ b/test/scripts/plugin-sdk-api-release-evidence.test.ts
@@ -33,6 +33,32 @@ function evidence(exports: unknown[] = []) {
 }
 
 describe("Plugin SDK API release evidence", () => {
+  it("preserves the frozen v1 payload digest and receipt bytes", () => {
+    const legacyDiff = diff([{ change: "added", exportName: "send" }]);
+    const receipt = createPluginSdkApiReleaseEvidence({
+      baseRef: "v2026.8.1",
+      baseSha,
+      diff: legacyDiff,
+      headSha,
+      workflowSha,
+    });
+
+    expect(legacyDiff.digest).toBe(
+      "f4b495f34f8c1b72721841242b24d6f8351524c00e34db016af0fd3944f44992",
+    );
+    expect(JSON.stringify(receipt)).toBe(
+      `{"schema":"openclaw.plugin-sdk-api-release-evidence/v1","status":"checked","baseRef":"v2026.8.1","baseSha":"${baseSha}","headSha":"${headSha}","hasChanges":true,"digest":"f4b495f34f8c1b72721841242b24d6f8351524c00e34db016af0fd3944f44992","diff":{"entrypointsAdded":[],"entrypointsRemoved":[],"exports":[{"change":"added","exportName":"send"}],"digest":"f4b495f34f8c1b72721841242b24d6f8351524c00e34db016af0fd3944f44992"},"workflowSha":"${workflowSha}"}`,
+    );
+    expect(
+      validatePluginSdkApiReleaseEvidence({
+        acknowledgement: legacyDiff.digest.slice(0, 8),
+        evidence: receipt,
+        expectedHeadSha: headSha,
+        expectedWorkflowSha: workflowSha,
+      }),
+    ).toMatchObject({ acknowledgement: "f4b495f3", hasChanges: true });
+  });
+
   it("enforces acknowledgement through the release CLI", () => {
     const receipt = evidence([{ change: "added", exportName: "send" }]);
     const manifestPath = join(tempDirs.make("plugin-sdk-evidence-"), "manifest.json");


### PR DESCRIPTION
## What Problem This Solves

Fixes npm release preflight failing with `Invalid string length` when a large Plugin SDK change repeats the same reachable declaration bodies through many changed exports.

## Why This Change Was Made

The diff keeps the existing v1 payload and release-evidence contract. Its sorted export list remains the complete affected surface, while the shared declaration delta is stored once on the first canonical changed export instead of being multiplied through every export closure. The canonical owner is stable because entrypoints and export names are sorted before assignment. The report presents the affected-export index independently from the globally deduplicated declaration detail, avoiding a false per-declaration ownership claim.

No schema, receipt, digest, acknowledgement, or artifact shape changes. Existing v1 artifacts remain valid and byte-identical under the trusted validator.

## User Impact

Maintainers can run npm preflight across large Plugin SDK revisions without V8 rejecting the generated diff string. Every affected export remains individually visible, the bounded report still contains declaration detail, and the published Plugin SDK surface is unchanged.

## Evidence

- Before: `v2026.8.1-beta.2` → `85ab6a3c36c6a7d740c25a2cce54e469411c514f` failed after 115s with `RangeError: Invalid string length` at `JSON.stringify(payload)` and 5.75 GB maximum RSS.
- After: exact `v2026.8.1-beta.2` → `2a79a3bb6d3` completed in 122s with 5.57 GB maximum RSS and wrote all artifacts successfully.
- Output remains `openclaw.plugin-sdk-api-release-evidence/v1`: 1,436 changed exports, 1,114 declaration-change records, 6,981,404-byte diff, 7,041,340-byte evidence, and a 65,536-byte bounded report.
- Multi-export regression proves both affected exports remain listed in the rendered report, declaration bodies appear once, and the canonical first export owns the detail.
- Frozen v1 fixture proves the prior payload digest, serialized receipt bytes, acknowledgement, and validation behavior are unchanged.
- `pnpm exec vitest run src/plugin-sdk/api-baseline.test.ts test/scripts/plugin-sdk-api-release-evidence.test.ts` — 29 passed.
- `pnpm tsgo:core` — passed.
- `git diff --check` and formatting — passed.
- Autoreview — clean; no accepted/actionable findings.

Production LOC: +26/-55 (net -29). Tests: +61/-1 (net +60).

## Rank-up moves

- Validation/preflight artifacts are exact-run immutable. The fix preserves schema v1, so old v1 artifacts remain structurally valid, but evidence for a new exact main SHA must still be regenerated by `.github/workflows/openclaw-npm-release.yml` through `scripts/plugin-sdk-api-diff.mts` and validated by `scripts/plugin-sdk-api-release-evidence.mjs`; an artifact from another run cannot be promoted.
