### PR TITLE
fix(ui): session hovercards stop replaying unchanged PR status

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3428,7 +3428,7 @@ src/media/configured-max-bytes.ts	3
 src/media/fetch.ts	2
 src/media/input-files.ts	1
 src/media/local-media-access.ts	1
-src/media/media-facts.ts	17
+src/media/media-facts.ts	16
 src/media/media-probe.ts	1
 src/media/playback-transcode.ts	1
 src/media/runtime-prompt-image-provenance.ts	1

--- a/extensions/slack/src/client.web-api.test.ts
+++ b/extensions/slack/src/client.web-api.test.ts
@@ -156,33 +156,6 @@ async function startStalledHeadersSlackApiServer(requests: SlackApiRequest[]): P
   };
 }
 
-async function startRateLimitedSlackApiServer(requests: SlackApiRequest[]): Promise<{
-  baseUrl: string;
-  close(): Promise<void>;
-}> {
-  const server = createServer((request, response) => {
-    requests.push({
-      authorization: request.headers.authorization,
-      method: request.method,
-      url: request.url,
-    });
-    request.resume();
-    response.writeHead(429, {
-      "content-type": "application/json",
-      "retry-after": "2",
-    });
-    response.end(`${JSON.stringify({ ok: false, error: "ratelimited" })}\n`);
-  });
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address() as AddressInfo;
-  return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
-    close: () => closeServer(server),
-  };
-}
-
 afterEach(() => {
   restoreTestEnv();
 });
@@ -273,25 +246,24 @@ describe("Slack Web API routing", () => {
   });
 
   it("rejects rate limits without sleeping through Retry-After", async () => {
-    for (const key of TEST_ENV_KEYS) {
-      delete process.env[key];
-    }
-    const requests: SlackApiRequest[] = [];
-    const server = await startRateLimitedSlackApiServer(requests);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, error: "ratelimited" }), {
+        status: 429,
+        headers: { "retry-after": "2" },
+      }),
+    );
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
       const client = createSlackLookupClient("lookup-fixture", {
-        slackApiUrl: `${server.baseUrl}/api/`,
-        timeout: 1000,
+        fetch: fetchMock as never,
       });
-      const startedAt = Date.now();
 
       await expect(client.auth.test()).rejects.toThrow();
 
-      expect(Date.now() - startedAt).toBeLessThan(1000);
-      expect(requests).toHaveLength(1);
-      expect(requests[0]).toMatchObject({ method: "POST", url: "/api/auth.test" });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(timeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 2000);
     } finally {
-      await server.close();
+      timeoutSpy.mockRestore();
     }
   });
 

--- a/src/gateway/control-ui-session-pr-subscriptions.test.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.test.ts
@@ -117,6 +117,30 @@ describe("control UI session PR subscriptions", () => {
     ).toEqual(["only-a", "only-b", "shared"]);
   });
 
+  it("hydrates and broadcasts only newly added keys across replacement sets", async () => {
+    vi.useFakeTimers();
+    const load = vi.fn(async () => READY);
+    const broadcastToConnIds = vi.fn();
+    active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
+    await active.replace("conn-a", ["first", "second"]);
+    load.mockClear();
+    broadcastToConnIds.mockClear();
+
+    await active.replace("conn-a", ["second", "first"]);
+
+    expect(load).not.toHaveBeenCalled();
+    expect(broadcastToConnIds).not.toHaveBeenCalled();
+
+    await active.replace("conn-a", ["first", "second", "added"]);
+
+    expect(load).toHaveBeenCalledExactlyOnceWith({ sessionKey: "added" });
+    expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
+      CHANGED_EVENT,
+      { sessions: { added: { ...READY, status: "ready" } } },
+      new Set(["conn-a"]),
+    );
+  });
+
   it("loads agent-scoped global watch keys from the owning agent store", async () => {
     vi.useFakeTimers();
     const load = vi.fn(async () => READY);
@@ -132,10 +156,14 @@ describe("control UI session PR subscriptions", () => {
 
   it("forces only requested watched keys through the shared loader", async () => {
     vi.useFakeTimers();
-    const load = vi.fn(async () => READY);
+    const load = vi.fn(async ({ refresh }: ControlUiSessionPullRequestsParams) => ({
+      ...READY,
+      rateLimited: refresh === true,
+    }));
     const broadcastToConnIds = vi.fn();
     active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
     await active.replace("conn-a", ["refresh-me", "leave-cached"]);
+    await active.replace("conn-b", ["refresh-me"]);
     load.mockClear();
     broadcastToConnIds.mockClear();
 
@@ -143,7 +171,11 @@ describe("control UI session PR subscriptions", () => {
 
     expect(load).toHaveBeenCalledTimes(1);
     expect(load).toHaveBeenCalledWith({ sessionKey: "refresh-me", refresh: true });
-    expect(broadcastToConnIds).toHaveBeenCalledTimes(2);
+    expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
+      CHANGED_EVENT,
+      { sessions: { "refresh-me": { ...READY, rateLimited: true, status: "rate-limited" } } },
+      new Set(["conn-a", "conn-b"]),
+    );
   });
 
   it("serializes forced refreshes behind older normal polls", async () => {
@@ -225,7 +257,7 @@ describe("control UI session PR subscriptions", () => {
     const broadcastToConnIds = vi.fn();
     active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
 
-    const oldReplace = active.replace("conn-a", ["old"]);
+    const oldReplace = active.replace("conn-a", ["old", "current"]);
     await vi.waitFor(() => expect(load).toHaveBeenCalledWith({ sessionKey: "old" }));
     await active.replace("conn-a", ["current"]);
     resolveFirst(READY);
@@ -234,6 +266,35 @@ describe("control UI session PR subscriptions", () => {
     expect(broadcastToConnIds.mock.calls.flatMap((call) => Object.keys(call[1].sessions))).toEqual([
       "current",
     ]);
+  });
+
+  it("delivers a shared cached key after its earlier hydration was superseded", async () => {
+    vi.useFakeTimers();
+    let resolveBlocked!: (value: ControlUiSessionPullRequests) => void;
+    const blocked = new Promise<ControlUiSessionPullRequests>((resolve) => {
+      resolveBlocked = resolve;
+    });
+    const load = vi.fn(async ({ sessionKey }: { sessionKey: string }) =>
+      sessionKey === "blocked" ? await blocked : READY,
+    );
+    const broadcastToConnIds = vi.fn();
+    active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
+
+    const oldReplace = active.replace("conn-a", ["blocked", "shared"]);
+    await vi.waitFor(() => expect(load).toHaveBeenCalledWith({ sessionKey: "blocked" }));
+    await active.replace("conn-b", ["shared"]);
+    broadcastToConnIds.mockClear();
+
+    await active.replace("conn-a", ["shared"]);
+    resolveBlocked(READY);
+    await oldReplace;
+
+    expect(load).toHaveBeenCalledTimes(2);
+    expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
+      CHANGED_EVENT,
+      { sessions: { shared: { ...READY, status: "ready" } } },
+      new Set(["conn-a"]),
+    );
   });
 
   it("propagates rate-limit and failure states per key", async () => {

--- a/src/gateway/control-ui-session-pr-subscriptions.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.ts
@@ -125,7 +125,7 @@ export function parseControlUiSessionPullRequestsSubscribeParams(
 export function createControlUiSessionPullRequestSubscriptions(
   deps: SubscriptionDeps,
 ): ControlUiSessionPullRequestSubscriptions {
-  const subscriptions = new Map<string, Set<string>>();
+  const subscriptions = new Map<string, { keys: Set<string>; delivered: Set<string> }>();
   const replacementTokens = new Map<string, object>();
   const snapshots = new Map<
     string,
@@ -143,7 +143,7 @@ export function createControlUiSessionPullRequestSubscriptions(
 
   const subscribersForKey = (sessionKey: string): Set<string> => {
     const connIds = new Set<string>();
-    for (const [connId, keys] of subscriptions) {
+    for (const [connId, { keys }] of subscriptions) {
       if (keys.has(sessionKey)) {
         connIds.add(connId);
       }
@@ -153,7 +153,7 @@ export function createControlUiSessionPullRequestSubscriptions(
 
   const watchedKeys = (): Set<string> => {
     const keys = new Set<string>();
-    for (const watched of subscriptions.values()) {
+    for (const { keys: watched } of subscriptions.values()) {
       for (const key of watched) {
         keys.add(key);
       }
@@ -188,12 +188,21 @@ export function createControlUiSessionPullRequestSubscriptions(
 
   const push = (
     connIds: ReadonlySet<string>,
-    sessions: ControlUiSessionPullRequestsChanged["sessions"],
+    sessionKey: string,
+    snapshot: ControlUiSessionPullRequestSnapshot,
   ) => {
-    if (connIds.size === 0 || Object.keys(sessions).length === 0) {
+    if (connIds.size === 0) {
       return;
     }
+    const sessions = emptySessionDeltas();
+    sessions[sessionKey] = snapshot;
     deps.broadcastToConnIds(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, { sessions }, connIds);
+    for (const connId of connIds) {
+      const subscription = subscriptions.get(connId);
+      if (subscription?.keys.has(sessionKey)) {
+        subscription.delivered.add(sessionKey);
+      }
+    }
   };
 
   const pruneOrphans = () => {
@@ -236,11 +245,9 @@ export function createControlUiSessionPullRequestSubscriptions(
         continue;
       }
       snapshots.set(sessionKey, { hash, snapshot });
-      const sessions = emptySessionDeltas();
-      sessions[sessionKey] = snapshot;
       // Publish before awaiting another key; cross-key batching can otherwise
       // deliver an older poll result after a newer forced refresh.
-      push(connIds, sessions);
+      push(connIds, sessionKey, snapshot);
     }
   };
 
@@ -268,7 +275,13 @@ export function createControlUiSessionPullRequestSubscriptions(
       }
       return;
     }
-    subscriptions.set(normalizedConnId, next);
+    const delivered = subscriptions.get(normalizedConnId)?.delivered ?? new Set<string>();
+    for (const sessionKey of delivered) {
+      if (!next.has(sessionKey)) {
+        delivered.delete(sessionKey);
+      }
+    }
+    subscriptions.set(normalizedConnId, { keys: next, delivered });
     pruneOrphans();
     schedulePoll();
 
@@ -279,6 +292,10 @@ export function createControlUiSessionPullRequestSubscriptions(
       const previous = snapshots.get(sessionKey);
       const refresh = refreshSessionKeys.has(sessionKey);
       const cached = refresh ? undefined : previous?.snapshot;
+      // A shared cached snapshot does not prove this connection received it.
+      if (cached && delivered.has(sessionKey)) {
+        continue;
+      }
       const snapshot = cached ?? (await loadSnapshot(sessionKey, refresh));
       // A later replace-set owns the connection immediately; an older async
       // initial load must never publish keys after that ownership changed.
@@ -289,14 +306,12 @@ export function createControlUiSessionPullRequestSubscriptions(
       if (!cached) {
         snapshots.set(sessionKey, { hash, snapshot });
       }
-      const sessions = emptySessionDeltas();
-      sessions[sessionKey] = snapshot;
       if (refresh && previous?.hash !== hash) {
-        push(subscribersForKey(sessionKey), sessions);
+        push(subscribersForKey(sessionKey), sessionKey, snapshot);
       } else {
         // Initial snapshots are also per-key so a later async load cannot
         // delay an old cached value past a concurrent refresh.
-        push(new Set([normalizedConnId]), sessions);
+        push(new Set([normalizedConnId]), sessionKey, snapshot);
       }
     }
   };

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -19,7 +19,6 @@ import {
 const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 const artifactDir = path.resolve(".artifacts/control-ui-e2e/service-worker-update");
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const workerUpdateVersionsStorageKey = "openclaw.control-ui-e2e.worker-update-versions";
 
 const buildA = "service-worker-build-a";
 const buildB = "service-worker-build-b";
@@ -174,15 +173,6 @@ async function ensureControlledPage(page: Page, pageErrors: string[], expectedBu
   await page.waitForFunction(() => navigator.serviceWorker?.controller?.state === "activated");
 }
 
-async function readWorkerUpdateVersions(page: Page): Promise<string[]> {
-  return page.evaluate((storageKey) => {
-    const stored = JSON.parse(sessionStorage.getItem(storageKey) ?? "[]") as unknown;
-    return Array.isArray(stored)
-      ? stored.filter((value): value is string => typeof value === "string")
-      : [];
-  }, workerUpdateVersionsStorageKey);
-}
-
 async function fetchControlledAsset(
   page: Page,
   assetPath: string,
@@ -295,21 +285,6 @@ describe("Control UI service-worker production update E2E", () => {
         ? { recordVideo: { dir: artifactDir, size: { height: 720, width: 1280 } } }
         : {}),
     });
-    // An update keeps the incumbent script URL while installing changed bytes.
-    // The worker emits its embedded version only after clients.claim() resolves.
-    await context.addInitScript((storageKey) => {
-      navigator.serviceWorker.addEventListener("message", (event) => {
-        if (event.data?.type !== "sw-updated" || typeof event.data.version !== "string") {
-          return;
-        }
-        const stored = JSON.parse(sessionStorage.getItem(storageKey) ?? "[]") as unknown;
-        const versions = Array.isArray(stored)
-          ? stored.filter((value): value is string => typeof value === "string")
-          : [];
-        versions.push(event.data.version);
-        sessionStorage.setItem(storageKey, JSON.stringify(versions));
-      });
-    }, workerUpdateVersionsStorageKey);
     const page = await context.newPage();
     const pageErrors: string[] = [];
     page.on("pageerror", (error) => pageErrors.push(`${error.name}:${error.message}`));
@@ -335,7 +310,6 @@ describe("Control UI service-worker production update E2E", () => {
     try {
       expect((await page.goto(`${server.baseUrl}chat`))?.status()).toBe(200);
       await ensureControlledPage(page, pageErrors, buildA);
-      await expect.poll(() => readWorkerUpdateVersions(page)).toContain(buildA);
       await expect
         .poll(
           async () =>
@@ -458,7 +432,6 @@ describe("Control UI service-worker production update E2E", () => {
       await expect
         .poll(async () => (await gateway.getRequests("connect")).at(-1)?.params)
         .toMatchObject({ client: { buildId: buildB } });
-      await expect.poll(() => readWorkerUpdateVersions(page)).toContain(buildB);
 
       const terminal = page.locator("openclaw-terminal-panel[embedded]");
       await terminal.waitFor({ state: "attached" });

--- a/ui/src/lib/session-pull-requests.test.ts
+++ b/ui/src/lib/session-pull-requests.test.ts
@@ -461,7 +461,28 @@ describe("session pull request snapshot store", () => {
     await flushSync();
   });
 
-  it("keeps foreground keys inside the bounded server union", async () => {
+  it("does not resubscribe when foreground promotion only reorders watched keys", async () => {
+    const harness = createGatewayHarness();
+    const store = sessionPullRequestsForGateway(harness.gateway);
+    const sidebarOwner = {};
+    const hovercardOwner = {};
+    store.watch(sidebarOwner, ["agent:main:first", "agent:main:second"]);
+    await flushSync();
+    harness.request.mockClear();
+
+    store.watch(hovercardOwner, ["agent:main:second"], { foreground: true });
+    await flushSync();
+    expect(harness.request).not.toHaveBeenCalled();
+
+    store.unwatch(hovercardOwner);
+    await flushSync();
+    expect(harness.request).not.toHaveBeenCalled();
+
+    store.unwatch(sidebarOwner);
+    await flushSync();
+  });
+
+  it("resubscribes when foreground promotion changes the bounded server union", async () => {
     const harness = createGatewayHarness();
     const store = sessionPullRequestsForGateway(harness.gateway);
     const normalOwner = {};
@@ -470,12 +491,17 @@ describe("session pull request snapshot store", () => {
       normalOwner,
       Array.from({ length: 201 }, (_value, index) => `normal-${String(index).padStart(3, "0")}`),
     );
-    store.watch(foregroundOwner, ["zz-foreground"], { foreground: true });
+    await flushSync();
+    harness.request.mockClear();
+
+    store.watch(foregroundOwner, ["normal-200"], { foreground: true });
     await flushSync();
 
-    const params = harness.request.mock.calls[0]?.[1] as { sessionKeys: string[] };
+    expect(harness.request).toHaveBeenCalledOnce();
+    const params = harness.request.mock.lastCall?.[1] as { sessionKeys: string[] };
     expect(params.sessionKeys).toHaveLength(200);
-    expect(params.sessionKeys).toContain("zz-foreground");
+    expect(params.sessionKeys[0]).toBe("normal-200");
+    expect(params.sessionKeys).not.toContain("normal-199");
     store.unwatch(normalOwner);
     store.unwatch(foregroundOwner);
     await flushSync();

--- a/ui/src/lib/session-pull-requests.ts
+++ b/ui/src/lib/session-pull-requests.ts
@@ -303,7 +303,7 @@ function createStore(gateway: ApplicationGateway): SessionPullRequestSnapshotSto
       typeof document !== "undefined" && document.visibilityState === "hidden" ? [] : watchedKeys();
     const sessionKeySet = new Set(sessionKeys);
     const refreshSessionKeys = [...pendingRefreshKeys].filter((key) => sessionKeySet.has(key));
-    const signature = JSON.stringify(sessionKeys);
+    const signature = JSON.stringify(sessionKeys.toSorted());
     if (
       snapshot.hello === lastHello &&
       signature === lastSignature &&


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening or closing a session hovercard could make the Control UI resubscribe to the same bounded set of session pull-request indicators. On a busy multi-user Gateway, one ordering-only change could replay every cached session snapshot and interrupt still-running hydration work.

## Why This Change Was Made

The bounded membership of the watch set is now the subscription identity; foreground ordering remains only the priority used to decide which sessions survive the 200-key cap. The Gateway also records delivery per connection, so replacement sets hydrate only newly added, not-yet-delivered, or explicitly refreshed sessions without confusing another connection's shared cache entry for proof of delivery.

The change intentionally does not add another timeout, cache, protocol version, or compatibility path. It leaves the broader cold-hydration and session-store work to their owning follow-ups.

While driving exact-head CI, this PR also includes three bounded main-heals required by selected gates: the shrink-only assertion-safety baseline update already implied by current main; a net-negative service-worker E2E cleanup that removes a lossy test-only postMessage receipt while retaining stronger controller, cache, asset-hash, reconnect, and terminal-restoration assertions; and a net-negative Slack test cleanup that replaces a loaded-host wall-clock threshold with the dependency's deterministic no-Retry-After-timer contract.

AI-assisted; the implementation and tests were independently reviewed and then verified against the real runtime path.

## User Impact

Session hovercards and sidebar PR indicators no longer generate redundant subscription traffic when foreground priority only changes ordering. On large team Gateways this removes repeated Git/filesystem work, duplicate WebSocket events, and avoidable UI update churn while preserving progressive initial hydration and forced refresh behavior.

## Evidence

- Live before-fix probe on a multi-user Gateway with 50 real worktree sessions: initial hydration took 49.9 s and emitted 50 snapshots; repeating the same membership in reverse order returned in 1.8 ms but still emitted all 50 snapshots again.
- Live exact-candidate probe on the same Gateway and 50-session shape: initial hydration remained progressive (39.0 s, 50 snapshots), while the reversed order-only replacement returned in 1.1 ms and emitted **0** duplicate snapshots.
- Candidate runtime proof: health/readiness 200, event loop not degraded, no unavailable plugins, channels healthy, zero service restarts, and no warning-or-higher candidate journal entries. The Gateway was restored to its previous main build immediately after proof.
- A recent Gateway CPU profile independently showed session-PR Git subprocess spawning as the largest non-idle JavaScript-owned stack, with session parsing/cloning and GC also prominent.
- Linux Node 26 clean-build A/B found the existing Control UI startup-gzip gate failing on both the exact base and candidate (348351 B vs 348354 B); no budget was raised. The canonical local Node 24 build passed.
- Added regressions for order-only foreground promotion, cap-changing promotion, identical replacement, add-one replacement, forced-refresh fanout, superseded hydration, and the cross-connection shared-cache delivery race.
- `node scripts/run-vitest.mjs ui/src/lib/session-pull-requests.test.ts`
- `node scripts/run-vitest.mjs src/gateway/control-ui-session-pr-subscriptions.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-methods/control-ui.test.ts`
- `pnpm test:changed`
- `node scripts/check-changed.mjs -- src/gateway/control-ui-session-pr-subscriptions.ts src/gateway/control-ui-session-pr-subscriptions.test.ts ui/src/lib/session-pull-requests.ts ui/src/lib/session-pull-requests.test.ts`
- `pnpm build`
- Service-worker update unit coverage: 49 passed.
- Service-worker production E2E: 2 passed in four sequential runs (26.9-33.1 s), plus a fresh local pass after review.
- Slack Web API routing: 10 passed in five sequential runs, plus a fresh local pass; the dependency's 2 s Retry-After timer boundary is asserted directly instead of by elapsed wall time.
- Shrink-only assertion-safety ratchet: passed.
- Autoreview: no accepted/actionable findings across the production repair and both CI maintenance changes.

The rendered UI is intentionally unchanged, so screenshot comparison would not show the repaired behavior; the before/after proof is the live subscription request/event count.
