### PR TITLE
fix(release): validate frozen plugin security findings

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -53,6 +53,13 @@ const REVIEWED_CODEX_SOURCE_LAYOUTS: ReadonlyArray<ReadonlyMap<string, number>> 
 const REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>(
   REVIEWED_CODEX_SOURCE_LAYOUTS.flatMap((layout) => [...layout]),
 );
+// Frozen prerelease candidates can predate the shared process-runtime migration.
+// These reviewed sites are optional, but their occurrence counts remain bounded so
+// a second execution site or a new path still fails the trusted-main inventory.
+const OPTIONAL_REVIEWED_PUBLISHABLE_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+  ["@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts", 1],
+  ["@openclaw/opencode-provider:dangerous-exec:session-catalog.ts", 1],
+]);
 
 // Generated chunks can contain multiple reviewed execution sites. Counts are
 // part of the contract so an added or missing site fails the release scan.
@@ -164,10 +171,29 @@ function requiredReviewedFindingsForPackage(
   return [...commonFindings, ...sourceLayout];
 }
 
+function observedOptionalReviewedSourceFindingsForPackage(
+  packageName: string,
+  reviewedCriticalFindings: readonly string[],
+): string[] {
+  return [...OPTIONAL_REVIEWED_PUBLISHABLE_SOURCE_CRITICAL_FINDING_COUNTS].flatMap(
+    ([key, maximumCount]) => {
+      if (!key.startsWith(`${packageName}:`)) {
+        return [];
+      }
+      const observed = reviewedCriticalFindings.filter((finding) => finding === key);
+      if (observed.length > maximumCount) {
+        throw new Error(`${key}: expected at most ${String(maximumCount)} reviewed finding(s).`);
+      }
+      return observed;
+    },
+  );
+}
+
 function isReviewedPublishableCriticalFinding(key: string): boolean {
   return (
     REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.has(key) ||
     REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.has(key) ||
+    OPTIONAL_REVIEWED_PUBLISHABLE_SOURCE_CRITICAL_FINDING_COUNTS.has(key) ||
     OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS.has(key)
   );
 }
@@ -471,6 +497,27 @@ describe("publishable plugin npm package install security scan", () => {
     expect(resolveReviewedCodexSourceLayout([relocatedFinding])).toBeUndefined();
   });
 
+  it("bounds reviewed execution sites retained by frozen prerelease candidates", () => {
+    const codexFinding = "@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts";
+    const openCodeFinding = "@openclaw/opencode-provider:dangerous-exec:session-catalog.ts";
+
+    expect(observedOptionalReviewedSourceFindingsForPackage("@openclaw/codex", [])).toEqual([]);
+    expect(
+      observedOptionalReviewedSourceFindingsForPackage("@openclaw/codex", [codexFinding]),
+    ).toEqual([codexFinding]);
+    expect(() =>
+      observedOptionalReviewedSourceFindingsForPackage("@openclaw/codex", [
+        codexFinding,
+        codexFinding,
+      ]),
+    ).toThrow("expected at most 1 reviewed finding");
+    expect(
+      observedOptionalReviewedSourceFindingsForPackage("@openclaw/opencode-provider", [
+        openCodeFinding,
+      ]),
+    ).toEqual([openCodeFinding]);
+  });
+
   test.concurrent.each(publishablePluginPackages)(
     "keeps $packageName files clear of unexpected critical hits",
     async (plugin) => {
@@ -481,6 +528,10 @@ describe("publishable plugin npm package install security scan", () => {
       expect(result.unexpectedCriticalFindings.toSorted()).toStrictEqual([]);
       const expectedReviewedCriticalFindings = [
         ...requiredReviewedFindingsForPackage(plugin.packageName, result.reviewedCriticalFindings),
+        ...observedOptionalReviewedSourceFindingsForPackage(
+          plugin.packageName,
+          result.reviewedCriticalFindings,
+        ),
         ...result.expectedReviewedCriticalFindings,
       ];
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where plugin prerelease validation fails when it validates a frozen candidate from before the shared process-runtime migration against the security inventory from current trusted `main`.

## Why This Change Was Made

The trusted inventory now recognizes the two previously reviewed direct-execution sites only at their exact package paths and only for frozen candidates that still contain them. Each site remains capped at one occurrence; new paths and additional execution sites still fail the scan. Current packages, which use `runCommandBuffered`, remain valid with neither legacy finding present.

The legacy Codex site resolves the fixed `@openai/codex` executable without shell fallback, validates the session identifier, passes arguments as an argv array, and sends the prompt over stdin. The legacy OpenCode site likewise resolves a fixed package executable without shell fallback, passes the query as one argv element, and enforces timeout and output bounds.

## User Impact

Release operators can validate older frozen plugin candidates with the current trusted security inventory without weakening unexpected-finding detection. There is no production behavior change.

## Evidence

- Failing Plugin Prerelease run: https://github.com/openclaw/openclaw/actions/runs/32387140189
  - `@openclaw/codex:dangerous-exec:src/node-cli-sessions.ts` appeared once.
  - `@openclaw/opencode-provider:dangerous-exec:session-catalog.ts` appeared once.
- Root cause: #126632 removed both reviewed paths after current `main` migrated them in #126490, but frozen candidate `a906b1fdcb56a669fd7ad9beaacfff6050d580bd` predates that migration while consuming the inventory from target `c28c279afa3789bc6a392b653be840bb30455eae`.
- Focused test: `node scripts/run-vitest.mjs src/plugins/npm-install-security-scan.release.test.ts` — 103 passed.
- Changed gates: `node scripts/check-changed.mjs -- src/plugins/npm-install-security-scan.release.test.ts` — passed.
- Autoreview: clean, no accepted/actionable findings.
- Upstream Codex contract inspected at `bf2aee99c58362d3f588d98432dcbc7adc371c73`: `codex-rs/exec/src/cli.rs` defines `exec resume`, global `--skip-git-repo-check` / `--output-last-message`, session ID and stdin prompt parsing; `codex-rs/exec/src/lib.rs` routes resume through `thread/resume`.
- LOC: production +0/-0; release tests +51/-0.
