### PR TITLE
fix(config): validate config writes against the config being written

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 347023,
-  "reason": "GitHub device authorization Settings status and recovery copy",
-  "updatedAt": "2026-08-19"
+  "startupJsGzipBytes": 348351,
+  "reason": "cumulative Control UI startup growth since #126474 (automation condition triggers, persistent Settings approvals, sidebar row fixes)",
+  "updatedAt": "2026-08-20"
 }

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -363,7 +363,6 @@ export async function writeConfigFileFromContext(
     env: deps.env,
     pluginValidation: options.skipPluginValidation ? "skip" : "full",
     semanticValidation: "strict",
-    pluginMetadataSnapshot: snapshotRead.pluginMetadataSnapshot,
     preservedLegacyRootKeys: options.preservedLegacyRootKeys,
   });
   if (!validated.ok) {

--- a/test/onboard-plugin-warnings.e2e.test.ts
+++ b/test/onboard-plugin-warnings.e2e.test.ts
@@ -1,0 +1,95 @@
+// Built-CLI onboarding regression for candidate-scoped plugin validation.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "./helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function runBuiltCli(stateDir: string, homeDir: string, args: string[]) {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+    OPENAI_API_KEY: "sk-fake-openclaw-onboard-regression",
+    OPENCLAW_SKIP_CHANNELS: "1",
+    OPENCLAW_STATE_DIR: stateDir,
+    NO_COLOR: "1",
+  };
+  for (const key of [
+    "DISCORD_BOT_TOKEN",
+    "NODE_ENV",
+    "OPENCLAW_CONFIG_PATH",
+    "OPENCLAW_DISABLE_BUNDLED_PLUGINS",
+    "OPENCLAW_HOME",
+    "OPENCLAW_PROFILE",
+    "TWILIO_ACCOUNT_SID",
+    "TWILIO_AUTH_TOKEN",
+    "TWILIO_FROM_NUMBER",
+    "VITEST",
+    "VITEST_POOL_ID",
+    "VITEST_WORKER_ID",
+  ]) {
+    delete env[key];
+  }
+  return spawnSync(process.execPath, [path.resolve("openclaw.mjs"), ...args], {
+    cwd: path.resolve("."),
+    encoding: "utf8",
+    env,
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: 60_000,
+  });
+}
+
+describe("non-interactive onboarding plugin validation", () => {
+  it("does not warn about bundled plugins enabled by the documented OpenAI setup", () => {
+    const rootDir = tempDirs.make("openclaw-onboard-plugin-warnings-", "/tmp");
+    const homeDir = path.join(rootDir, "home");
+    const stateDir = path.join(rootDir, "state");
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+
+    const onboard = runBuiltCli(stateDir, homeDir, [
+      "onboard",
+      "--non-interactive",
+      "--accept-risk",
+      "--skip-health",
+      "--mode",
+      "local",
+      "--auth-choice",
+      "openai-api-key",
+      "--secret-input-mode",
+      "ref",
+      "--gateway-port",
+      "19091",
+      "--skip-bootstrap",
+      "--skip-skills",
+    ]);
+
+    expect(onboard.error, onboard.stderr).toBeUndefined();
+    expect(onboard.status, onboard.stderr).toBe(0);
+    expect(onboard.stderr).not.toContain("plugin not found: openai");
+    expect(onboard.stderr).not.toContain("plugin not installed: codex");
+
+    const config = JSON.parse(fs.readFileSync(path.join(stateDir, "openclaw.json"), "utf8")) as {
+      plugins?: { entries?: Record<string, { enabled?: boolean }> };
+    };
+    expect(config.plugins?.entries?.openai?.enabled).toBe(true);
+    expect(config.plugins?.entries?.codex?.enabled).toBe(true);
+
+    const list = runBuiltCli(stateDir, homeDir, ["plugins", "list", "--json"]);
+    expect(list.error, list.stderr).toBeUndefined();
+    expect(list.status, list.stderr).toBe(0);
+    expect(list.stderr).toBe("");
+    const inventory = JSON.parse(list.stdout) as {
+      plugins: Array<{ id: string; enabled: boolean; status: string }>;
+    };
+    expect(inventory.plugins).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "openai", enabled: true, status: "loaded" }),
+        expect.objectContaining({ id: "codex", enabled: true, status: "loaded" }),
+      ]),
+    );
+  }, 75_000);
+});


### PR DESCRIPTION
## What Problem This Solves

Non-interactive onboarding warned the operator that the plugin entries it had *just written* were
stale or uninstalled. Running the documented automation flow from
`docs/start/wizard-cli-automation.md` on a fresh state dir:

```
$ OPENAI_API_KEY=... openclaw onboard --non-interactive --accept-risk --skip-health \
    --mode local --auth-choice openai-api-key --secret-input-mode ref \
    --gateway-port 19091 --skip-bootstrap --skip-skills

Config warnings:
- plugins.entries.openai: plugin not found: openai (stale config entry ignored; remove it from plugins config)
- plugins.entries.codex: plugin not installed: codex - install the official external plugin with: openclaw plugins install @openclaw/codex
```

Both warnings are false:

- the pre-write backup has `plugins: {}`, so that same run wrote both entries;
- `openclaw plugins list --json` reports both as `status: "loaded"`, `enabled: true`, sourced from
  `dist/extensions/{openai,codex}/index.js` (148 plugins total);
- immediately afterwards `openclaw config validate` prints `Config valid` with **empty stderr**, and
  `openclaw models list` emits no such warnings.

The trigger is provider auth selection: `--auth-choice skip` writes `plugins: {}` and emits zero
warnings, while `--auth-choice openai-api-key` writes the two entries and emits two warnings. A new
operator's first output tells them to delete valid config and install an already-loaded plugin.

## Why This Change Was Made

The registry used for write-time validation belonged to a *different* config than the one being
validated.

`openclaw onboard` runs with `loadPlugins: "never"` by design. The OpenAI flow stages
`plugins.entries.{openai,codex}` in the in-memory candidate, but before the final commit
`ensureOnboardingAgent` creates the first agent, and `createAgent` reads and writes the current disk
config — an intermediate config that has the new agent but none of the staged plugin entries. The
final write then rereads that intermediate config, and its validation metadata scope is derived from
it. With no plugin/provider/model references, `resolveConfigValidationMetadataPluginIds` returns an
explicit empty scope, which `loadPluginManifestRegistryForInstalledIndex` deliberately maps to an
empty manifest registry — a valid scoped snapshot *for that intermediate config*.

`writeConfigFileFromContext` then passed that snapshot into strict validation of the final candidate.
Injecting it set `registryInfo` eagerly and bypassed candidate-derived resolution, so `ensureKnownIds()`
built an empty set and the missing-plugin branch fired for both new entries.

The fix drops the stale argument so validation resolves the manifest registry from the candidate it is
actually validating. Strict semantic validation is unchanged, and resolution stays lazy — the registry
is only loaded when a plugin-dependent check needs it — so this is not new work on every write.

Provenance: `8dd0434f86f2` added both strict semantic validation and the
`pluginMetadataSnapshot: snapshotRead.pluginMetadataSnapshot` argument. Before that, the validator
already resolved its registry from the candidate.

**No empty-snapshot guard was added, deliberately.** An empty manifest registry is not evidence that
metadata is unusable — it can be an authoritative scoped result, or a real install with no/disabled
plugins. Existing genuine-missing coverage validates against an empty registry, so a
`knownIds.size === 0` guard would suppress real stale-entry warnings and official-plugin install hints.
Candidate-derived scoping is the correct defence: an unknown configured id makes the narrow scope
unresolvable and falls back to the full registry, after which genuine absence still warns.

## User Impact

The documented onboarding path no longer emits warnings about plugins that are present and loaded.
Genuine stale entries and genuinely missing official external plugins still warn exactly as before.

## Evidence

**Live proof, independently reproduced on both sides.** Before, on a build of `main`: stderr contains
`Config warnings:` and both false lines. After, on a build of this branch with the identical command
and a fresh state dir: **zero** matches for `plugin not found: openai` or `plugin not installed: codex`
— the only remaining stderr line is an unrelated Codex app-server version diagnostic — and the config
still records both entries as enabled.

**Blast radius measured, not assumed.** This argument is used by *every* config write, so the whole
config surface was run: `src/config` — **252 files, 3417 tests, all passing**. Also green:
`config.plugin-validation`, `io.write-config`, `io.write-reread` (165 tests), and
`node scripts/check-changed.mjs` on an isolated Testbox.

**Regression coverage** is a built-CLI process test (`test/onboard-plugin-warnings.e2e.test.ts`) that
runs the documented onboarding invocation with a fake key in an isolated state dir, asserts exit 0 and
the absence of both warning strings, then proves via `plugins list --json` in that same state that both
plugins are loaded and enabled. It fails against unrepaired production code with exactly the two
reported warnings. Existing tests proving a genuinely unknown entry still warns, and that a genuinely
missing official external plugin still gets its install hint, remain green and untouched.

Branch-mode autoreview clean (`patch is correct`).

Production LOC `+0/-1`. Tests `+95`.


## Unrelated red-main heal carried here

`build-artifacts` is failing on `main`, not on this diff: the Control UI startup-JS ratchet is over
budget for every PR that builds the UI. Unrelated PR #126725 (`plugin-sdk` API diff strings) measures
`348289 B` and this branch measures `348351 B`, both against `347023 B + 1056 B` tolerance. Twenty-six
UI commits have landed since the last baseline bump (#126474) and none is individually large, so this
is ordinary accretion rather than one regression to revert.

Per the root `AGENTS.md` rule on landing onto red `main`, the smallest correct fix is carried in this
PR: `config/control-ui-startup-budget-baseline.json` moves to the CI-measured `348351 B`, using the
`--startup-js-bytes` value the checker's own comment asks for. That is `1328 B` of the checker's
`4096 B` ratchet allowance and stays well under the `358400 B` maintainer-approved hard ceiling, which
continues to guard cumulative creep. No budget constant changes.
