### PR TITLE
fix(gateway): keep liveness probes healthy when config reload fails

### DIFF
--- a/src/gateway/server-http.probe.test.ts
+++ b/src/gateway/server-http.probe.test.ts
@@ -903,21 +903,32 @@ describe("gateway probe endpoints", () => {
     });
   });
 
-  it("serves /healthz before loading gateway config", async () => {
+  it("serves liveness probes before loading gateway config or resolving auth", async () => {
     const getRuntimeConfig = vi.fn(() => {
       throw new Error("config load blocked");
     });
+    const getResolvedAuth = vi.fn(() => {
+      getRuntimeConfig();
+      return AUTH_NONE;
+    });
 
     await withGatewayServer({
-      prefix: "probe-healthz-before-config",
+      prefix: "probe-liveness-before-config-auth",
       resolvedAuth: AUTH_NONE,
-      overrides: { getRuntimeConfig },
+      overrides: { getRuntimeConfig, getResolvedAuth },
       run: async (server) => {
-        const { res, getBody } = await sendGatewayRequest(server, { path: "/healthz" });
+        for (const path of ["/health", "/healthz"]) {
+          for (const method of ["GET", "HEAD"] as const) {
+            const { res, getBody } = await sendGatewayRequest(server, { path, method });
 
-        expect(res.statusCode).toBe(200);
-        expect(getBody()).toBe(JSON.stringify({ ok: true, status: "live" }));
+            expect(res.statusCode, `${method} ${path}`).toBe(200);
+            expect(getBody(), `${method} ${path}`).toBe(
+              method === "HEAD" ? "" : JSON.stringify({ ok: true, status: "live" }),
+            );
+          }
+        }
         expect(getRuntimeConfig).not.toHaveBeenCalled();
+        expect(getResolvedAuth).not.toHaveBeenCalled();
       },
     });
   });

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -257,7 +257,7 @@ export function createGatewayHttpServer(opts: {
           req,
           res,
           requestPath,
-          getResolvedAuth(),
+          resolvedAuth,
           [],
           false,
           rateLimiter,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators checking Gateway liveness would receive HTTP 500 from `/health` and `/healthz` whenever the unrelated runtime configuration or authentication resolver failed to reload. This incorrectly tells orchestration systems that a live Gateway has died.

## Why This Change Was Made

Liveness is already routed ahead of configuration-dependent request handling, but its call still eagerly invoked the live authentication resolver, which can reload configuration and throw before the probe executes. Pass the Gateway's already-captured startup authentication to the existing probe owner instead. The liveness branch never consults authentication; readiness, startup, and protected routes still resolve current authentication and retain their existing disclosure policy.

Alternatives rejected: catching configuration failures or adding a special liveness fallback would preserve the misplaced eager dependency. Moving or weakening authentication for readiness/startup would change an unrelated security boundary.

## User Impact

`GET` and `HEAD` liveness requests to both `/health` and `/healthz` continue reporting a live Gateway even while runtime configuration reload is unavailable. Readiness, startup detail authorization, credential rotation, and ordinary authenticated routes are unchanged.

## Evidence

- Authentic Gateway HTTP-boundary regression: the production-shaped authentication resolver calls a throwing runtime configuration getter; all four liveness requests previously failed and now return HTTP 200 without invoking either getter.
- Focused Gateway probe suite: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs src/gateway/server-http.probe.test.ts --configLoader runner` — **29 passed**.
- Coverage includes `GET` and `HEAD` for both `/health` and `/healthz`, preserved HEAD body semantics, authenticated readiness/startup details, and credential-rotation siblings.
- Production delta: **+1/-1 (net zero)**; regression tests: **+18/-7**.
- Candidate head: `413ed57be0ba9833ba3f5fd94cb2e028518976ac`.
- Authenticated automated review and independent owner-boundary review: **clean; no actionable findings**.
- AI-assisted; no agent transcript attached.
