### PR TITLE
fix(plugins): report cached load failures before registry activation

### DIFF
--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -102,6 +102,7 @@ function loadOpenClawPluginsInternal(
   if (cacheEnabled) {
     const cached = getReusableCachedPluginRegistry(context.cacheKey);
     if (cached) {
+      maybeThrowOnPluginLoadError(cached, options.throwOnLoadError);
       if (context.shouldActivate) {
         activatePluginRegistry(
           cached,

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -24,6 +24,8 @@ import {
 import {
   makePluginLoaderTempDir,
   resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
 } from "./loader.test-fixtures.js";
 import { buildMemoryPromptSection, registerMemoryCapability } from "./memory-state.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
@@ -59,6 +61,62 @@ it("keeps injected instance runtime surfaces independent of the broad runtime mo
   expect(runtime.nodes).toBe(nodes);
   expect(runtime.subagent).toBe(subagent);
   expect(loadPluginModule).not.toHaveBeenCalled();
+});
+
+describe("cached plugin load failures", () => {
+  it.each([
+    { name: "active root registry", load: loadAndActivateRootPluginRegistry, activates: true },
+    { name: "non-activating registry handle", load: loadPluginRegistryHandle, activates: false },
+  ])("enforces strict errors for a cached $name before activation", ({ load, activates }) => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "cached-load-failure",
+      body: 'module.exports = { id: "cached-load-failure", register() { throw new Error("cached registration failed"); } };',
+    });
+    const options = {
+      config: {
+        plugins: {
+          allow: [plugin.id],
+          load: { paths: [plugin.file] },
+          slots: { memory: "none" },
+        },
+      },
+    };
+    const cached = load(options);
+    expect(cached.plugins).toContainEqual(
+      expect.objectContaining({ id: plugin.id, status: "error" }),
+    );
+
+    const active = createEmptyPluginRegistry();
+    setActivePluginRegistry(active, "existing-registry");
+
+    expect(() => load({ ...options, throwOnLoadError: true })).toThrow(
+      "cached registration failed",
+    );
+    expect(getActivePluginRegistry()).toBe(active);
+    expect(load(options)).toBe(cached);
+    expect(getActivePluginRegistry()).toBe(activates ? cached : active);
+  });
+
+  it("continues to reuse healthy cached registries for strict loads", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "cached-load-healthy",
+      body: 'module.exports = { id: "cached-load-healthy", register() {} };',
+    });
+    const options = {
+      config: {
+        plugins: {
+          allow: [plugin.id],
+          load: { paths: [plugin.file] },
+          slots: { memory: "none" },
+        },
+      },
+    };
+    const cached = loadPluginRegistryHandle(options);
+
+    expect(loadPluginRegistryHandle({ ...options, throwOnLoadError: true })).toBe(cached);
+  });
 });
 
 function requireMemoryEmbeddingProvider(providerId: string) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators loading a plugin with strict failure handling would receive a previously cached failed plugin registry as if it loaded successfully. Composition-root callers could also activate that failed registry and replace an otherwise healthy active registry before the expected failure surfaced.

## Why This Change Was Made

The plugin loader already enforces strict load errors before activating a freshly constructed registry, but its cached-registry fast path returned or activated the same failed registry without applying that owner-level invariant. Apply the existing canonical strict-error helper before either cached return path or activation. This preserves healthy cache reuse, non-strict behavior, and the current active registry when a strict cached load fails; no public SDK, configuration, plugin activation contract, or persistence surface changes.

## User Impact

Plugin failures are reported consistently regardless of whether the plugin registry was freshly assembled or reused from the process cache, and failed strict loads cannot replace the currently active healthy plugin registry.

## Evidence

- Regression-first owner-boundary proof reproduced both defects on the previous implementation: an activating root-registry load and a non-activating registry snapshot both incorrectly accepted a cached plugin registration failure.
- Exact candidate commit: `38421fa3f6a4bacf1035279734f0053fda71d61b`.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs src/plugins/loader.runtime-registry.test.ts --configLoader runner` — **22 tests passed**, including both failing-registry paths, unchanged active-registry ownership, subsequent non-strict cache reuse, and healthy strict-cache reuse.
- Production delta: **+1/-0**. The single required line invokes the existing canonical strict-error helper at the cached owner boundary; no helper, fallback, configuration option, or compatibility path was introduced.
- Regression-test delta: **+58/-0**. Focused formatting and independent authenticated Codex review plus a separate independent review are clean.
- The affected production and test baseline blobs were rechecked against current `origin/main`; no existing open pull request matched the same root cause.
