### PR TITLE
fix(ui): surface onboarding memory import load failures

### DIFF
--- a/ui/src/app/app-host-onboarding-memory-import.test.ts
+++ b/ui/src/app/app-host-onboarding-memory-import.test.ts
@@ -1,0 +1,66 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createLazyElementSpec,
+  resetAppHostTestGlobals,
+  type TestOptionalCustomElement,
+} from "./app-host.test-support.ts";
+import "./app-host.ts";
+import type { LazyCustomElementRequestController } from "./lazy-custom-element.ts";
+
+type ShellOnboardingMemoryImportState = {
+  onboardingMemoryImportElement: TestOptionalCustomElement;
+  lazyCustomElements: LazyCustomElementRequestController;
+};
+
+afterEach(() => resetAppHostTestGlobals());
+
+describe("OpenClaw shell onboarding memory import", () => {
+  it("surfaces a rejected load and retries it", async () => {
+    const element = createLazyElementSpec("onboarding memory import", {
+      firstError: new Error("memory import chunk unavailable"),
+    });
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellOnboardingMemoryImportState;
+    shell.onboardingMemoryImportElement = element;
+    Object.defineProperty(shell, "updateComplete", { get: () => Promise.resolve(true) });
+
+    shell.lazyCustomElements.requestWhileActive(element, true);
+
+    await vi.waitFor(() => expect(shell.lazyCustomElements.visibleState?.status).toBe("error"));
+    expect(shell.lazyCustomElements.visibleState?.element).toBe(element);
+    shell.lazyCustomElements.retry();
+    await vi.waitFor(() => expect(customElements.get(element.tagName)).toBeDefined());
+    expect(shell.lazyCustomElements.visibleState).toBeUndefined();
+  });
+
+  it("abandons a pending load when onboarding ends", async () => {
+    let rejectLoad: ((error: Error) => void) | undefined;
+    let loadSettled: Promise<void> | undefined;
+    const element = createLazyElementSpec("onboarding memory import");
+    element.loadModule = vi.fn(() => {
+      const load = new Promise<void>((_resolve, reject) => {
+        rejectLoad = reject;
+      });
+      loadSettled = load.catch(() => undefined);
+      return load;
+    });
+    const shell = document.createElement(
+      "openclaw-app-shell",
+    ) as unknown as ShellOnboardingMemoryImportState;
+    shell.onboardingMemoryImportElement = element;
+
+    shell.lazyCustomElements.requestWhileActive(element, true);
+    await vi.waitFor(() => expect(element.loadModule).toHaveBeenCalledOnce());
+    expect(shell.lazyCustomElements.visibleState?.status).toBe("loading");
+    shell.lazyCustomElements.requestWhileActive(element, false);
+    const error = new Error("late memory import chunk failure");
+    rejectLoad?.(error);
+    await loadSettled;
+    await Promise.resolve();
+
+    expect(shell.lazyCustomElements.visibleState).toBeUndefined();
+  });
+});

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -67,6 +67,7 @@ import {
   DESKTOP_PANEL_ELEMENT,
   EXEC_APPROVAL_ELEMENT,
   LazyCustomElementRequestController,
+  type OptionalCustomElement,
   TERMINAL_PANEL_ELEMENT,
 } from "./lazy-custom-element.ts";
 import { hasStoredLazyShellAction } from "./lazy-shell-action.ts";
@@ -141,6 +142,11 @@ class OpenClawShell
   readonly desktopPanelElement = DESKTOP_PANEL_ELEMENT;
   readonly custodianPanelElement = CUSTODIAN_PANEL_ELEMENT;
   readonly execApprovalElement = EXEC_APPROVAL_ELEMENT;
+  readonly onboardingMemoryImportElement = {
+    tagName: "openclaw-onboarding-memory-import",
+    label: t("onboarding.memoryImport.title"),
+    loadModule: () => import("../components/onboarding-memory-import.ts"),
+  } satisfies OptionalCustomElement;
   readonly lazyCustomElements = new LazyCustomElementRequestController(
     this,
     () => this.shellChrome.cancelPendingLazyAction(),
@@ -721,9 +727,6 @@ class OpenClawShell
   }
 
   override render() {
-    if (this.onboardingMode && this.routeState.routeId !== "custodian") {
-      void import("../components/onboarding-memory-import.ts");
-    }
     return renderApplicationShell(this);
   }
 }

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -99,6 +99,7 @@ export interface ShellViewHost {
   readonly custodianMinimizeRequestId: number;
   readonly desktopNavigationExpanded: boolean;
   readonly execApprovalElement: OptionalCustomElement;
+  readonly onboardingMemoryImportElement: OptionalCustomElement;
   readonly lazyCustomElements: LazyCustomElementRequestController;
   readonly nativeHistoryState: NativeHistoryState;
   readonly navDrawerOpen: boolean;
@@ -299,6 +300,11 @@ export function renderApplicationShell(host: ShellViewHost) {
     canAdmin: operatorAccess.canAdmin,
   });
   const onboarding = host.onboardingMode;
+  const memoryImportActive = onboarding && activeRoute !== "custodian";
+  host.lazyCustomElements.requestWhileActive(
+    host.onboardingMemoryImportElement,
+    memoryImportActive,
+  );
   const navDrawerOpen = host.navDrawerOpen && !onboarding;
   const mobileNavLayout = isMobileNavLayout();
   const mergedChatChrome = shouldMergeChatChrome({
@@ -707,7 +713,7 @@ export function renderApplicationShell(host: ShellViewHost) {
           host.navigate("apps");
         },
       })}
-      ${onboarding && activeRoute !== "custodian"
+      ${memoryImportActive && isOptionalElementDefined(host.onboardingMemoryImportElement)
         ? html`<openclaw-onboarding-memory-import
             .active=${true}
             .context=${context}

--- a/ui/src/app/lazy-custom-element.test.ts
+++ b/ui/src/app/lazy-custom-element.test.ts
@@ -100,6 +100,80 @@ describe("optional custom element requests", () => {
     expect(requests.visibleState).toBeUndefined();
   });
 
+  it("resumes an active request after a foreground request replaces its visible slot", async () => {
+    let rejectActive: ((error: Error) => void) | undefined;
+    let resolveForeground: (() => void) | undefined;
+    const { requests } = createRequestHarness();
+    const activeElement = {
+      tagName: uniqueTag(),
+      label: "active panel",
+      loadModule: vi.fn(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectActive = reject;
+          }),
+      ),
+    };
+    const foregroundElement = {
+      tagName: uniqueTag(),
+      label: "command palette",
+      loadModule: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveForeground = () => {
+              customElements.define(foregroundElement.tagName, class extends HTMLElement {});
+              resolve();
+            };
+          }),
+      ),
+    };
+
+    requests.requestWhileActive(activeElement, true);
+    await vi.waitFor(() => expect(activeElement.loadModule).toHaveBeenCalledOnce());
+    requests.request(foregroundElement);
+    await vi.waitFor(() => expect(foregroundElement.loadModule).toHaveBeenCalledOnce());
+    resolveForeground?.();
+    await vi.waitFor(() => expect(requests.visibleState?.element).toBe(activeElement));
+
+    const error = new Error("active chunk unavailable");
+    rejectActive?.(error);
+    await vi.waitFor(() =>
+      expect(requests.visibleState).toMatchObject({
+        element: activeElement,
+        error,
+        status: "error",
+      }),
+    );
+  });
+
+  it("keeps an active request dismissed until its lifecycle restarts", async () => {
+    const error = new Error("active chunk unavailable");
+    const { requests } = createRequestHarness();
+    const tagName = uniqueTag();
+    const element = {
+      tagName,
+      label: "active panel",
+      loadModule: vi
+        .fn<() => Promise<void>>()
+        .mockRejectedValueOnce(error)
+        .mockImplementationOnce(async () => {
+          customElements.define(tagName, class extends HTMLElement {});
+        }),
+    };
+
+    requests.requestWhileActive(element, true);
+    await vi.waitFor(() => expect(requests.visibleState?.status).toBe("error"));
+    requests.close();
+    requests.requestWhileActive(element, true);
+
+    expect(requests.visibleState).toBeUndefined();
+    expect(element.loadModule).toHaveBeenCalledOnce();
+
+    requests.requestWhileActive(element, false);
+    requests.requestWhileActive(element, true);
+    await vi.waitFor(() => expect(element.loadModule).toHaveBeenCalledTimes(2));
+  });
+
   it("delegates stale recovery before falling back to the same in-place load", async () => {
     const staleError = new Error("Failed to fetch dynamically imported module: panel-abc.js");
     const { requests, retryStale } = createRequestHarness();

--- a/ui/src/app/lazy-custom-element.ts
+++ b/ui/src/app/lazy-custom-element.ts
@@ -61,6 +61,8 @@ type LazyCustomElementRequest = LazyCustomElementRequestState & {
 export class LazyCustomElementRequestController {
   private current: LazyCustomElementRequest | undefined;
   private readonly preloads = new Set<string>();
+  private active: OptionalCustomElement | undefined;
+  private activeDismissed = false;
 
   constructor(
     private readonly host: UpdatingHost,
@@ -96,6 +98,23 @@ export class LazyCustomElementRequestController {
     this.load(request);
   }
 
+  requestWhileActive(element: OptionalCustomElement, active: boolean): void {
+    if (active) {
+      if (this.active !== element) {
+        this.active = element;
+        this.activeDismissed = false;
+      }
+    } else if (this.active === element) {
+      this.active = undefined;
+      this.activeDismissed = false;
+    }
+    if (!active && this.current?.element === element) {
+      this.abandon();
+    } else {
+      this.pumpActive();
+    }
+  }
+
   retry(): void {
     const request = this.current;
     if (request?.status !== "error") {
@@ -117,6 +136,9 @@ export class LazyCustomElementRequestController {
 
   close(): void {
     if (this.current) {
+      if (this.current.element === this.active) {
+        this.activeDismissed = true;
+      }
       this.onClose?.();
       this.abandon();
     }
@@ -126,6 +148,18 @@ export class LazyCustomElementRequestController {
     if (this.current) {
       this.current = undefined;
       this.host.requestUpdate();
+      this.pumpActive();
+    }
+  }
+
+  private pumpActive(): void {
+    if (
+      this.active &&
+      !this.activeDismissed &&
+      !this.current &&
+      !isOptionalElementDefined(this.active)
+    ) {
+      this.request(this.active);
     }
   }
 


### PR DESCRIPTION
## Summary

- route the onboarding memory-import chunk through the shared lazy custom-element request owner
- show loading/error UI with retry when the chunk fails
- preserve one bounded active request across foreground lazy UI, while explicit Close dismisses it until onboarding exits and re-enters

## Root cause and fix

`#126722` preserved startup performance by replacing the eager component import with a guarded fire-and-forget dynamic import. Rejection had no owner: the unknown custom element rendered nothing and the default onboarding migration offer silently disappeared.

`LazyCustomElementRequestController.requestWhileActive` now owns this lifecycle through its canonical single visible slot. Foreground requests temporarily replace the active request, which is pumped afterward. Explicit Close records dismissal for the current activation; route exit clears it.

## Verification

- focused Vitest: 4 files, 56 tests passed
- regressions cover failure -> visible retry, foreground command-palette interleaving, Close staying dismissed until lifecycle restart, and route-exit late rejection after the loader actually starts
- `pnpm check:changed`: passed
- full `pnpm build`: passed before the final dismissal-only follow-up; startup gzip 344,567 B against 348,351 B + 1,056 B tolerance
- local autoreview: clean
- `git diff --check`: clean

## Scope

- production: +47/-4 (net +43)
- tests: +140

Production growth is the optional-element descriptor plus the reusable controller-owned active, foreground-interleaving, explicit-dismissal, and route-abandon lifecycle. There is no parallel onboarding loader or queue.
