### PR TITLE
fix(telegram): make common emoji reactions work reliably

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1325,7 +1325,6 @@ extensions/telegram/src/sent-message-cache.legacy-state.ts	2
 extensions/telegram/src/sent-message-cache.ts	2
 extensions/telegram/src/state-migrations.ts	2
 extensions/telegram/src/status-issues.ts	1
-extensions/telegram/src/status-reaction-variants.ts	1
 extensions/telegram/src/sticker-cache-store.legacy-state.ts	1
 extensions/telegram/src/sticker-cache.ts	2
 extensions/telegram/src/target-writeback.test-shared.ts	12

--- a/extensions/telegram/src/bot-message-context.reactions.test.ts
+++ b/extensions/telegram/src/bot-message-context.reactions.test.ts
@@ -119,7 +119,7 @@ describe("buildTelegramMessageContext reactions", () => {
     expect(setMessageReaction).not.toHaveBeenCalled();
   });
 
-  it("sends Telegram ack reactions for room events when ack scope is all", async () => {
+  it("sends canonical Telegram ack reactions for room events when ack scope is all", async () => {
     const setMessageReaction = vi.fn(async () => undefined);
     const { createStatusReactionController } = createStatusReactionControllerStub();
     inboundBodyMock.mockResolvedValueOnce(createInboundBodyResult("room_event"));
@@ -143,7 +143,7 @@ describe("buildTelegramMessageContext reactions", () => {
           },
         },
         messages: {
-          ackReaction: "👀",
+          ackReaction: "❤️",
           groupChat: { unmentionedInbound: "room_event", mentionPatterns: [] },
           statusReactions: { enabled: true },
         },
@@ -164,7 +164,7 @@ describe("buildTelegramMessageContext reactions", () => {
     expect(ctx?.statusReactionController).toBeNull();
     expect(createStatusReactionController).not.toHaveBeenCalled();
     expect(setMessageReaction).toHaveBeenCalledWith(-1001234567890, 12, [
-      { type: "emoji", emoji: "👀" },
+      { type: "emoji", emoji: "❤" },
     ]);
   });
 
@@ -223,7 +223,10 @@ describe("buildTelegramMessageContext reactions", () => {
         chat: {
           id: 1234,
           type: "private",
-          available_reactions: [{ type: "emoji", emoji: "👍" }],
+          available_reactions: [
+            { type: "emoji", emoji: "👍" },
+            { type: "emoji", emoji: "❤" },
+          ],
         },
         date: 1_700_000_000,
         text: "hello",
@@ -259,5 +262,9 @@ describe("buildTelegramMessageContext reactions", () => {
     await params?.adapter.setReaction("✅");
 
     expect(setMessageReaction).toHaveBeenCalledWith(1234, 34, [{ type: "emoji", emoji: "👍" }]);
+
+    await params?.adapter.setReaction("❤️");
+
+    expect(setMessageReaction).toHaveBeenCalledWith(1234, 34, [{ type: "emoji", emoji: "❤" }]);
   });
 });

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -54,8 +54,8 @@ import { evaluateTelegramGroupBaseAccess } from "./group-access.js";
 import {
   buildTelegramStatusReactionVariants,
   type TelegramReactionEmoji,
-  isTelegramSupportedReactionEmoji,
   resolveTelegramAllowedEmojiReactions,
+  resolveTelegramReactionEmoji,
   resolveTelegramReactionVariant,
   resolveTelegramStatusReactionEmojis,
 } from "./status-reaction-variants.js";
@@ -554,8 +554,7 @@ export const buildTelegramMessageContext = async ({
     channel: "telegram",
     accountId: account.accountId,
   });
-  const ackReactionEmoji =
-    ackReaction && isTelegramSupportedReactionEmoji(ackReaction) ? ackReaction : undefined;
+  const ackReactionEmoji = ackReaction ? resolveTelegramReactionEmoji(ackReaction) : undefined;
   const shouldSendAckReaction = Boolean(
     ackReaction &&
     shouldAckReactionGate({

--- a/extensions/telegram/src/send-actions.ts
+++ b/extensions/telegram/src/send-actions.ts
@@ -18,6 +18,7 @@ import type {
   TelegramSendOpts,
 } from "./send-message-types.js";
 import { prepareTelegramOutbound } from "./send-outbound.js";
+import { resolveTelegramReactionEmoji } from "./status-reaction-variants.js";
 import { parseTelegramTarget, type TelegramTarget } from "./targets.js";
 
 type TelegramReactionOpts = TelegramApiCallOpts & {
@@ -109,12 +110,11 @@ async function reactMessageTelegramWithContext(
   });
   const remove = opts.remove === true;
   const trimmedEmoji = emoji.trim();
-  // Build the reaction array. We cast emoji to the grammY union type since
-  // Telegram validates emoji server-side; invalid emojis fail gracefully.
+  // Unsupported emoji remain server-validated so existing graceful failures stay intact.
+  const reactionEmoji =
+    resolveTelegramReactionEmoji(trimmedEmoji) ?? (trimmedEmoji as ReactionTypeEmoji["emoji"]);
   const reactions: ReactionType[] =
-    remove || !trimmedEmoji
-      ? []
-      : [{ type: "emoji", emoji: trimmedEmoji as ReactionTypeEmoji["emoji"] }];
+    remove || !trimmedEmoji ? [] : [{ type: "emoji", emoji: reactionEmoji }];
   if (typeof api.setMessageReaction !== "function") {
     throw new Error("Telegram reactions are unavailable in this bot API.");
   }

--- a/extensions/telegram/src/send-mutation-targets.test.ts
+++ b/extensions/telegram/src/send-mutation-targets.test.ts
@@ -88,3 +88,33 @@ describe("Telegram topic-qualified message mutations", () => {
     },
   );
 });
+
+describe("Telegram reaction presentation", () => {
+  it.each([
+    ["❤️", "❤"],
+    ["⚡️", "⚡"],
+    ["✍️", "✍"],
+    ["🕊️", "🕊"],
+    ["☃️", "☃"],
+    ["❤️‍🔥", "❤‍🔥"],
+    ["🤷‍♂️", "🤷‍♂"],
+    ["✅", "✅"],
+    ["👍🏻", "👍🏻"],
+  ])("sends %s using its Telegram wire representation %s", async (input, expected) => {
+    botApi.setMessageReaction.mockResolvedValue(true);
+
+    await reactMessageTelegram(chatId, messageId, input, opts);
+
+    expect(botApi.setMessageReaction).toHaveBeenCalledWith(chatId, messageId, [
+      { type: "emoji", emoji: expected },
+    ]);
+  });
+
+  it("preserves reaction removal without sending an emoji", async () => {
+    botApi.setMessageReaction.mockResolvedValue(true);
+
+    await reactMessageTelegram(chatId, messageId, "❤️", { ...opts, remove: true });
+
+    expect(botApi.setMessageReaction).toHaveBeenCalledWith(chatId, messageId, []);
+  });
+});

--- a/extensions/telegram/src/status-reaction-variants.ts
+++ b/extensions/telegram/src/status-reaction-variants.ts
@@ -89,8 +89,8 @@ const TELEGRAM_SUPPORTED_REACTION_EMOJI_LIST = [
   "😡",
 ] as const satisfies readonly TelegramReactionEmoji[];
 
-const TELEGRAM_SUPPORTED_REACTION_EMOJIS = new Set<TelegramReactionEmoji>(
-  TELEGRAM_SUPPORTED_REACTION_EMOJI_LIST,
+const TELEGRAM_SUPPORTED_REACTION_EMOJIS = new Map<string, TelegramReactionEmoji>(
+  TELEGRAM_SUPPORTED_REACTION_EMOJI_LIST.map((emoji) => [emoji, emoji]),
 );
 
 const TELEGRAM_STATUS_REACTION_VARIANTS: Record<StatusReactionEmojiKey, string[]> = {
@@ -168,8 +168,9 @@ export function buildTelegramStatusReactionVariants(
   return variantsByRequested;
 }
 
-export function isTelegramSupportedReactionEmoji(emoji: string): emoji is TelegramReactionEmoji {
-  return TELEGRAM_SUPPORTED_REACTION_EMOJIS.has(emoji as TelegramReactionEmoji);
+export function resolveTelegramReactionEmoji(emoji: string): TelegramReactionEmoji | undefined {
+  // Telegram omits presentation selectors from reaction emoji but preserves joiner sequences.
+  return TELEGRAM_SUPPORTED_REACTION_EMOJIS.get(emoji.trim().replace(/[\uFE0E\uFE0F]/gu, ""));
 }
 
 function extractTelegramAllowedEmojiReactions(
@@ -195,8 +196,8 @@ function extractTelegramAllowedEmojiReactions(
     if (reaction.type !== "emoji") {
       continue;
     }
-    const emoji = reaction.emoji.trim();
-    if (emoji && isTelegramSupportedReactionEmoji(emoji)) {
+    const emoji = resolveTelegramReactionEmoji(reaction.emoji);
+    if (emoji) {
       allowed.add(emoji);
     }
   }
@@ -248,13 +249,12 @@ export function resolveTelegramReactionVariant(params: {
   ]);
 
   for (const candidate of variants) {
-    if (!isTelegramSupportedReactionEmoji(candidate)) {
+    const emoji = resolveTelegramReactionEmoji(candidate);
+    if (!emoji) {
       continue;
     }
-    const isAllowedByChat =
-      params.allowedEmojiReactions == null || params.allowedEmojiReactions.has(candidate);
-    if (isAllowedByChat) {
-      return candidate;
+    if (params.allowedEmojiReactions == null || params.allowedEmojiReactions.has(emoji)) {
+      return emoji;
     }
   }
 

--- a/extensions/telegram/src/status.test.ts
+++ b/extensions/telegram/src/status.test.ts
@@ -6,8 +6,8 @@ import type { TelegramChatDetails, TelegramGetChat } from "./bot/types.js";
 import { collectTelegramStatusIssues } from "./status-issues.js";
 import {
   buildTelegramStatusReactionVariants,
-  isTelegramSupportedReactionEmoji,
   resolveTelegramAllowedEmojiReactions,
+  resolveTelegramReactionEmoji,
   resolveTelegramReactionVariant,
   resolveTelegramStatusReactionEmojis,
 } from "./status-reaction-variants.js";
@@ -335,14 +335,14 @@ describe("buildTelegramStatusReactionVariants", () => {
   });
 });
 
-describe("isTelegramSupportedReactionEmoji", () => {
+describe("resolveTelegramReactionEmoji", () => {
   it("accepts Telegram-supported reaction emojis", () => {
-    expect(isTelegramSupportedReactionEmoji("👀")).toBe(true);
-    expect(isTelegramSupportedReactionEmoji("👨‍💻")).toBe(true);
+    expect(resolveTelegramReactionEmoji("👀")).toBe("👀");
+    expect(resolveTelegramReactionEmoji("👨‍💻")).toBe("👨‍💻");
   });
 
   it("rejects unsupported emojis", () => {
-    expect(isTelegramSupportedReactionEmoji("🫠")).toBe(false);
+    expect(resolveTelegramReactionEmoji("🫠")).toBeUndefined();
   });
 });
 
@@ -375,6 +375,20 @@ describe("resolveTelegramAllowedEmojiReactions", () => {
       chatId: 1,
     });
     expect(result ? Array.from(result).toSorted() : null).toEqual(["👍", "🔥"]);
+  });
+
+  it("normalizes emoji presentation selectors without admitting custom reactions", async () => {
+    const result = await resolveTelegramAllowedEmojiReactions({
+      chat: {
+        available_reactions: [
+          { type: "emoji", emoji: "❤️" },
+          { type: "custom_emoji", custom_emoji_id: "❤️" },
+        ],
+      } as never,
+      chatId: 1,
+    });
+
+    expect(result).toEqual(new Set(["❤"]));
   });
 
   it("treats malformed available_reactions payloads as an empty allowlist instead of throwing", async () => {
@@ -418,6 +432,25 @@ describe("resolveTelegramAllowedEmojiReactions", () => {
 });
 
 describe("resolveTelegramReactionVariant", () => {
+  it.each([
+    ["❤️", "❤"],
+    ["❤︎", "❤"],
+    ["⚡️", "⚡"],
+    ["✍️", "✍"],
+    ["🕊️", "🕊"],
+    ["☃️", "☃"],
+    ["❤️‍🔥", "❤‍🔥"],
+    ["🤷‍♂️", "🤷‍♂"],
+  ] as const)("selects the canonical Telegram reaction for %s", (requestedEmoji, expectedEmoji) => {
+    expect(
+      resolveTelegramReactionVariant({
+        requestedEmoji,
+        variantsByRequestedEmoji: new Map(),
+        allowedEmojiReactions: new Set([expectedEmoji]),
+      }),
+    ).toBe(expectedEmoji);
+  });
+
   it("returns requested emoji when already Telegram-supported", () => {
     const variantsByEmoji = buildTelegramStatusReactionVariants({
       ...DEFAULT_EMOJIS,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram users configuring ordinary emoji reactions such as ❤️, ⚡️, ✍️, 🕊️, or ☃️ would see acknowledgments and status reactions silently disappear or explicit message reactions fail.

## Why This Change Was Made

Telegram Bot API reaction identifiers omit Unicode text/emoji presentation selectors, while keyboards and user configuration commonly include them. Normalize both inputs and chat-allowed reactions to the existing Telegram-owned supported-reaction vocabulary at their canonical owner, and reuse that representation across acknowledgments, status updates, reaction allowlists, and explicit sends.

Unsupported emoji retain Telegram-side validation, custom reactions are not admitted, zero-width joiner sequences stay intact, and existing reaction-removal behavior remains unchanged.

## User Impact

Common emoji chosen from keyboards now work consistently for Telegram acknowledgment reactions, live status reactions, allowed-reaction matching, and explicitly requested message reactions.

## Evidence

- Frozen branch head: `62d6bf57078574467c7f762c988f91ff243ca41a`.
- Regression-first proof: 18 authentic failures before the fix; 67 passing focused Telegram owner and transport-boundary tests afterward.
- Exact proof: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs extensions/telegram/src/status.test.ts extensions/telegram/src/send-mutation-targets.test.ts extensions/telegram/src/bot-message-context.reactions.test.ts --configLoader runner`.
- Direct dependency contract: installed `@grammyjs/types` `ReactionTypeEmoji` enumerates Telegram's selector-free wire representations, including ❤, ⚡, ✍, 🕊, ☃, ❤‍🔥, and 🤷‍♂.
- Compatibility coverage preserves unsupported reactions, skin-tone sequences, joiner sequences, custom-reaction rejection, and reaction removal.
- Independent architectural review and separate authenticated Codex reviews reported no actionable findings.
- Production LOC: +18/-19 (net -1); tests: +79/-9.
- Live Telegram proof was not run because this isolated campaign does not own a dedicated authorized Telegram account or channel; the real Telegram plugin/grammY API boundary is covered by regression-first transport tests.
