### PR TITLE
test(nextcloud-talk): isolate error response timing

### DIFF
--- a/extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
+++ b/extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
@@ -63,7 +63,6 @@ describe("nextcloud-talk send error responses", () => {
         await expect(
           sendMessageNextcloudTalk("room:abc123", "hello", {
             cfg: createTalkConfig(baseUrl),
-            timeoutMs: REQUEST_TIMEOUT_MS,
           }),
         ).rejects.toThrow(new Error(`Nextcloud Talk: bad request - ${prefix}…`));
       },


### PR DESCRIPTION
## Summary

- keep the UTF-16 error-body assertion independent from the deliberately tiny hanging-request deadline
- retain the 50 ms real-HTTP timeout proof for both message and reaction sends

## Root cause

`extensions/nextcloud-talk/src/send.fetch-timeout.test.ts` originally owned only the hanging-request timeout coverage from #102025. The later UTF-16 error-response regression test from #102949 reused that file's `REQUEST_TIMEOUT_MS = 50` override even though it verifies a completed 400 response, not timeout behavior. Under full extension-shard contention, the valid response could cross that unrelated deadline while its body was read, replacing the expected provider error with `TimeoutError: request timed out`.

The non-timeout test now uses the production default deadline. This preserves production behavior while ensuring the assertion measures only error-body truncation. The two hanging message/reaction cases still pass the explicit 50 ms deadline and assert an `AbortError` or `TimeoutError`.

## Reproduction

Original CI full-shard failure: [CI run 32391767878, job 96499681237](https://github.com/openclaw/openclaw/actions/runs/32391767878/job/96499681237)

```text
extensions/nextcloud-talk/src/send.fetch-timeout.test.ts > keeps send error body snippets UTF-16 safe
Expected: Error: Nextcloud Talk: bad request - eeee…
Received: TimeoutError: request timed out
Test Files 1 failed | 132 passed (133)
Tests      1 failed | 1479 passed (1480)
```

## Verification

```text
pnpm vitest run --config test/vitest/vitest.extension-messaging.config.ts extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
Test Files 1 passed; Tests 2 passed

OPENCLAW_VITEST_MAX_WORKERS=2 pnpm vitest run --config test/vitest/vitest.extension-messaging.config.ts
Test Files 133 passed; Tests 1480 passed

pnpm exec oxfmt --check extensions/nextcloud-talk/src/send.fetch-timeout.test.ts
All matched files use the correct format.

.agents/skills/autoreview/scripts/autoreview --mode local
autoreview clean: no accepted/actionable findings reported (0.99)
```

Production LOC: 0. Test LOC: net -1.
