### PR TITLE
fix(cli): fence destructive offline fallback

### DIFF
--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -102,7 +102,10 @@ async function maybeDeleteAgentThroughGateway(params: {
       requiredMethods: ["agents.delete"],
     });
   } catch (error) {
-    if (isGatewayTransportError(error) || isGatewayCredentialsRequiredError(error)) {
+    if (
+      (isGatewayTransportError(error) && error.kind === "closed" && error.code === undefined) ||
+      isGatewayCredentialsRequiredError(error)
+    ) {
       return null;
     }
     throw error;

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -18,6 +18,7 @@ import {
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { GatewayTransportError } from "../gateway/transport-error.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { readAgentProvenance, recordAgentProvenance } from "../state/agent-provenance.js";
@@ -45,7 +46,6 @@ const fsSafeMocks = vi.hoisted(() => ({
 const gatewayMocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
   isGatewayCredentialsRequiredError: vi.fn(),
-  isGatewayTransportError: vi.fn(),
 }));
 
 const workspaceStateMocks = vi.hoisted(() => ({
@@ -66,10 +66,12 @@ vi.mock("../config/config.js", async () => ({
   replaceConfigFile: configMocks.replaceConfigFile,
 }));
 
-vi.mock("../gateway/call.js", () => ({
+vi.mock("../gateway/call.js", async () => ({
+  ...(await vi.importActual<typeof import("../gateway/transport-error.js")>(
+    "../gateway/transport-error.js",
+  )),
   callGateway: gatewayMocks.callGateway,
   isGatewayCredentialsRequiredError: gatewayMocks.isGatewayCredentialsRequiredError,
-  isGatewayTransportError: gatewayMocks.isGatewayTransportError,
 }));
 
 vi.mock("../infra/fs-safe.js", () => ({
@@ -100,6 +102,15 @@ vi.mock("../wizard/clack-prompter.js", () => ({
 import { agentsDeleteCommand } from "./agents.commands.delete.js";
 
 const runtime = createTestRuntime();
+
+function gatewayTransportError(kind: "closed" | "timeout", code?: number): GatewayTransportError {
+  return new GatewayTransportError({
+    kind,
+    code,
+    message: `gateway ${kind}`,
+    connectionDetails: { url: "ws://127.0.0.1:1", urlSource: "test", message: "test gateway" },
+  });
+}
 
 function resolveFixtureStoreAgentId(cfg: OpenClawConfig, deletedAgentId: string): string {
   const storeConfig = cfg.session?.store;
@@ -212,17 +223,11 @@ describe("agents delete command", () => {
     workspaceStateMocks.deleteWorkspaceState.mockClear();
     processMocks.runCommandWithTimeout.mockClear();
     gatewayMocks.callGateway.mockReset();
-    gatewayMocks.callGateway.mockRejectedValue(
-      Object.assign(new Error("closed"), { name: "GatewayTransportError" }),
-    );
+    gatewayMocks.callGateway.mockRejectedValue(gatewayTransportError("closed"));
     gatewayMocks.isGatewayCredentialsRequiredError.mockReset();
     gatewayMocks.isGatewayCredentialsRequiredError.mockImplementation(
       (error: unknown) =>
         error instanceof Error && error.name === "GatewayCredentialsRequiredError",
-    );
-    gatewayMocks.isGatewayTransportError.mockReset();
-    gatewayMocks.isGatewayTransportError.mockImplementation(
-      (error: unknown) => error instanceof Error && error.name === "GatewayTransportError",
     );
     runtime.log.mockClear();
     runtime.error.mockClear();
@@ -451,6 +456,32 @@ describe("agents delete command", () => {
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
       expect(readJsonLogs()[0]).toMatchObject({ purgeFailed: true, transport: "gateway" });
+    });
+  });
+
+  it.each([
+    { label: "request timeout after dispatch", error: gatewayTransportError("timeout") },
+    { label: "established WebSocket close", error: gatewayTransportError("closed", 1006) },
+    { label: "authentication rejection", error: new Error("unauthorized") },
+    {
+      label: "malformed transport failure",
+      error: Object.assign(new Error("malformed transport failure"), {
+        name: "GatewayTransportError",
+        kind: "closed",
+      }),
+    },
+  ])("surfaces $label without replaying deletion locally", async ({ error }) => {
+    await withStateDirEnv("openclaw-agents-delete-ambiguous-", async ({ stateDir }) => {
+      const cfg: OpenClawConfig = { agents: { list: [{ id: "main" }, { id: "ops" }] } };
+      const sessions = { "agent:ops:main": { sessionId: "sess-ops", updatedAt: Date.now() } };
+      await arrangeAgentsDeleteTest({ stateDir, cfg, sessions });
+      gatewayMocks.callGateway.mockRejectedValue(error);
+
+      await expect(agentsDeleteCommand({ id: "ops", force: true }, runtime)).rejects.toBe(error);
+
+      expect(configMocks.replaceConfigFile).not.toHaveBeenCalled();
+      expect(fsSafeMocks.movePathToTrash).not.toHaveBeenCalled();
+      expectSessionStore(cfg, sessions);
     });
   });
 

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { GatewayTransportError } from "../gateway/transport-error.js";
 import type { RuntimeEnv } from "../runtime.js";
 
 const mocks = vi.hoisted(() => ({
@@ -20,7 +21,6 @@ const mocks = vi.hoisted(() => ({
   runSessionsCleanup: vi.fn(),
   serializeSessionCleanupResult: vi.fn(),
   callGateway: vi.fn(),
-  isGatewayTransportError: vi.fn(),
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -47,9 +47,11 @@ vi.mock("../config/sessions.js", () => ({
   serializeSessionCleanupResult: mocks.serializeSessionCleanupResult,
 }));
 
-vi.mock("../gateway/call.js", () => ({
+vi.mock("../gateway/call.js", async () => ({
+  ...(await vi.importActual<typeof import("../gateway/transport-error.js")>(
+    "../gateway/transport-error.js",
+  )),
   callGateway: mocks.callGateway,
-  isGatewayTransportError: mocks.isGatewayTransportError,
 }));
 
 import { sessionsCleanupCommand } from "./sessions-cleanup.js";
@@ -69,6 +71,15 @@ function makeRuntime(): { runtime: RuntimeEnv; logs: string[] } {
 function expectLogsToInclude(logs: readonly string[], text: string): void {
   const matches = logs.filter((line) => line.includes(text));
   expect(matches.length).toBeGreaterThan(0);
+}
+
+function gatewayTransportError(kind: "closed" | "timeout", code?: number): GatewayTransportError {
+  return new GatewayTransportError({
+    kind,
+    code,
+    message: `gateway ${kind}`,
+    connectionDetails: { url: "ws://127.0.0.1:1", urlSource: "test", message: "test gateway" },
+  });
 }
 
 describe("sessionsCleanupCommand", () => {
@@ -120,7 +131,6 @@ describe("sessionsCleanupCommand", () => {
     mocks.capEntryCount.mockImplementation(() => 0);
     mocks.updateSessionStore.mockResolvedValue(0);
     mocks.callGateway.mockResolvedValue(null);
-    mocks.isGatewayTransportError.mockReturnValue(true);
     mocks.resolveSessionCleanupAction.mockImplementation(
       (params: {
         key: string;
@@ -176,9 +186,7 @@ describe("sessionsCleanupCommand", () => {
   });
 
   it("emits a single JSON object for non-dry runs and applies maintenance", async () => {
-    mocks.callGateway.mockRejectedValue(
-      Object.assign(new Error("closed"), { name: "GatewayTransportError" }),
-    );
+    mocks.callGateway.mockRejectedValue(gatewayTransportError("closed"));
     mocks.runSessionsCleanup.mockResolvedValue({
       mode: "enforce",
       previewResults: [],
@@ -257,6 +265,35 @@ describe("sessionsCleanupCommand", () => {
     expect(cleanupCall?.targets).toEqual([
       { agentId: "main", storePath: "/resolved/sessions.json" },
     ]);
+  });
+
+  it.each([
+    { label: "request timeout after dispatch", error: gatewayTransportError("timeout") },
+    { label: "established WebSocket close", error: gatewayTransportError("closed", 1006) },
+    { label: "authentication rejection", error: new Error("unauthorized") },
+    {
+      label: "malformed transport failure",
+      error: Object.assign(new Error("malformed transport failure"), {
+        name: "GatewayTransportError",
+        kind: "closed",
+      }),
+    },
+  ])("surfaces $label without replaying cleanup locally", async ({ error }) => {
+    mocks.callGateway.mockRejectedValue(error);
+
+    const { runtime } = makeRuntime();
+    await expect(sessionsCleanupCommand({ enforce: true }, runtime)).rejects.toBe(error);
+
+    expect(mocks.callGateway).toHaveBeenCalledOnce();
+    expect(mocks.runSessionsCleanup).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit offline store cleanup local", async () => {
+    const { runtime } = makeRuntime();
+    await sessionsCleanupCommand({ store: "/explicit/sessions.sqlite", enforce: true }, runtime);
+
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(mocks.runSessionsCleanup).toHaveBeenCalledOnce();
   });
 
   it("delegates non-store enforcing cleanup through the Gateway writer when reachable", async () => {
@@ -415,6 +452,7 @@ describe("sessionsCleanupCommand", () => {
       wouldMutate: true,
     });
     expect(mocks.runSessionsCleanup).toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
     expect(mocks.updateSessionStore).not.toHaveBeenCalled();
   });
 

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -269,9 +269,9 @@ async function maybeRunGatewayCleanup(
     });
     return { delegated: true, result };
   } catch (error) {
-    if (isGatewayTransportError(error)) {
-      // A stopped gateway should not block local maintenance; fall back to the
-      // on-disk session stores when transport is unavailable.
+    if (isGatewayTransportError(error) && error.kind === "closed" && error.code === undefined) {
+      // Only a pre-connect failure proves the Gateway never received this
+      // mutation; timeouts and established closes must not replay it locally.
       return { delegated: false };
     }
     throw error;

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -2027,6 +2027,8 @@ describe("callGateway error details", () => {
         error = caught;
       });
       expect(isGatewayTransportError(error)).toBe(true);
+      expect(error).toMatchObject({ kind: "closed" });
+      expect(error).not.toHaveProperty("code");
       const message = (error as Error).message;
       expect(message).toContain(`Gateway not reachable at ws://127.0.0.1:18789 (${code}).`);
       expect(message).toContain(

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts
@@ -155,22 +155,37 @@ describe("authenticated WebSocket request cancellation", () => {
     await vi.waitFor(() => expect(socket.listenerCount("close")).toBe(0));
   });
 
-  it("does not attach a node cancellation lifetime to unrelated requests", async () => {
-    const socket = new EventEmitter();
-    const { client, dispatcher } = createDispatcher(socket);
-    handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
-      options.respond(true, { ok: true });
-    });
+  it.each(["test.trace", "sessions.cleanup", "agents.delete"])(
+    "keeps authenticated %s work alive after its socket disconnects",
+    async (method) => {
+      const socket = new EventEmitter();
+      const { client, dispatcher } = createDispatcher(socket);
+      let finish!: () => void;
+      const completion = new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      let completed = false;
+      handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
+        await completion;
+        completed = true;
+        options.respond(true, { ok: true });
+      });
 
-    await dispatcher.dispatch(
-      { type: "req", id: "ordinary-request", method: "test.trace", params: {} },
-      client,
-    );
-    await vi.waitFor(() => expect(handleGatewayRequest).toHaveBeenCalledOnce());
+      await dispatcher.dispatch(
+        { type: "req", id: "ordinary-request", method, params: {} },
+        client,
+      );
+      await vi.waitFor(() => expect(handleGatewayRequest).toHaveBeenCalledOnce());
 
-    expect(handleGatewayRequest.mock.calls[0]?.[0]).not.toHaveProperty("signal");
-    expect(socket.listenerCount("close")).toBe(0);
-  });
+      expect(handleGatewayRequest.mock.calls[0]?.[0]).not.toHaveProperty("signal");
+      expect(socket.listenerCount("close")).toBe(0);
+      socket.emit("close", 1006, Buffer.alloc(0));
+      expect(completed).toBe(false);
+
+      finish();
+      await vi.waitFor(() => expect(completed).toBe(true));
+    },
+  );
 
   it("cancels a session companion ask when its authenticated socket closes", async () => {
     const socket = new EventEmitter();


### PR DESCRIPTION
Closes #126735

## What Problem This Solves

Fixes an issue where operators running `openclaw sessions cleanup` or `openclaw agents delete` could unknowingly start a second destructive local operation after the live Gateway had already authenticated and dispatched the original request. Request timeouts and established WebSocket closures were both swallowed as if the Gateway had never been reachable.

Because session SQLite writer queues and disk-budget maintenance queues are process-local, the Gateway and CLI can otherwise overlap session previews, database changes, transcript/archive filesystem work, and agent deletion. A real token-authenticated loopback Gateway reproduced the exact order: Gateway cleanup started, the client disconnected, the CLI replayed local cleanup, and the original Gateway cleanup finished afterward.

## Why This Change Was Made

Both destructive CLI owners now permit automatic local fallback only for the existing transport producer's authoritative pre-dispatch unreachable shape: a real `GatewayTransportError` with `kind === "closed"` and `code === undefined`. The connection state machine records this shape only for allowlisted socket failures before the authenticated request is sent; established WebSocket closures always carry a numeric code, including 1006, and request deadlines use `kind === "timeout"`.

Ambiguous post-dispatch failures now propagate visibly and never replay a destructive mutation. Explicit `sessions cleanup --store`, `--dry-run`, genuine connection-refused offline cleanup, and the intentionally shipped `agents delete` credentials-required fallback remain unchanged. No Gateway cancellation, retry, public API, protocol, persistent state, lock, schema, migration, auth policy, or product configuration changes are introduced.

## User Impact

Operators retain documented offline maintenance when the Gateway is genuinely unreachable, while active Gateway cleanup and agent deletion are no longer duplicated after request timeouts or established disconnects. Failures remain visible so operators can inspect the still-running original operation before deciding what to do next.

## Evidence

The new regressions first failed on the original production code in all four destructive cases: sessions cleanup timeout, sessions cleanup established close, agent deletion timeout, and agent deletion established close. After the repair, 370 focused tests pass, including real transport-producer socket failure classification, malformed/authentication rejection, explicit offline/store/dry-run behavior, the existing credentials-required deletion path, session-store RPC coverage, and event-driven authenticated Gateway dispatch proving both original operations survive disconnect and finish.

```text
node scripts/run-vitest.mjs \
  src/commands/sessions-cleanup.test.ts \
  src/commands/agents.delete.test.ts \
  src/gateway/call.test.ts \
  src/gateway/server.sessions.store-rpc.test.ts \
  src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts

node scripts/check-changed.mjs -- \
  src/commands/sessions-cleanup.ts \
  src/commands/sessions-cleanup.test.ts \
  src/commands/agents.commands.delete.ts \
  src/commands/agents.delete.test.ts \
  src/gateway/call.test.ts \
  src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts

git diff --check
```

Real token-authenticated loopback Gateway proof:

```text
PASS refused: real ECONNREFUSED delegated zero times, local cleanup exactly once
PASS closed-1006: authenticated dispatch failed visibly and CLI did not replay local cleanup
PASS original Gateway cleanup survived disconnect and finished after its delayed release
PASS timeout: authenticated CLI dispatch timed out visibly, skipped local cleanup, and original Gateway cleanup survived and finished
```

Fresh Codex-backed P1 autoreview and a separate independent adversarial owner-boundary review report no actionable findings. Production: +7/-4, net +3 lines. Regression tests: +117/-31, net +86 lines. Risk is low: only ambiguous destructive automatic fallback is narrowed; all explicit and authoritative offline paths remain intact.

Named out-of-scope follow-up: skill-curator mutation fallback in `src/cli/skills-cli.ts` has a similar replay pattern under a separate skill-storage owner and should be repaired independently.

AI-assisted: yes
