### PR TITLE
test(gateway): keep per-case session stores authoritative

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -2220,6 +2220,8 @@ test("sessions.create maps an admin-selected worktree cwd and rejects repository
 });
 
 test("sessions.create accepts a node-host cwd without provisioning a Gateway worktree", async () => {
+  // A running suite server can read config before this test installs its per-case session store.
+  getRuntimeConfig();
   const { storePath } = await createSessionStoreDir();
   const created = await directSessionReq<{
     key: string;
@@ -2238,9 +2240,9 @@ test("sessions.create accepts a node-host cwd without provisioning a Gateway wor
   });
   expect(created.payload?.entry.spawnedCwd).toBeUndefined();
   const sessionKey = requireNonEmptyString(created.payload?.key, "node session key");
-  expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).not.toHaveProperty(
-    "sessionDiffBaselineCapture",
-  );
+  const stored = loadSessionEntry({ agentId: "main", sessionKey, storePath });
+  expect(stored).toMatchObject({ execHost: "node", execNode: "macbook" });
+  expect(stored).not.toHaveProperty("sessionDiffBaselineCapture");
 });
 
 test("sessions.create accepts a Windows node-host cwd from a non-Windows Gateway", async () => {

--- a/src/gateway/test/server-sessions.test-helpers.ts
+++ b/src/gateway/test/server-sessions.test-helpers.ts
@@ -15,8 +15,7 @@ import { createDirectChatContext } from "../server-chat.agent-events.test-helper
 import type { GatewayRequestContext } from "../server-methods/types.js";
 import type { GatewayServerHarness } from "../server.e2e-ws-harness.js";
 import { embeddedRunMock, agentDiscoveryMock, testState } from "../test-helpers.runtime-state.js";
-import type { connectOk } from "../test-helpers.server.js";
-import { installGatewayTestHooks, writeSessionStore } from "../test-helpers.server.js";
+import * as gatewayTestHelpers from "../test-helpers.server.js";
 
 export const getSessionManagerModule = createLazyRuntimeModule(
   () => import("../../agents/sessions/index.js"),
@@ -305,8 +304,7 @@ vi.mock("../../agents/agent-bundle-mcp-tools.js", async (importOriginal) => ({
 
 export function setupGatewaySessionsHandlerTestHarness() {
   const { getHarness, openClient, ...handlerFixture } = createGatewaySessionsTestHarness(false);
-  void getHarness;
-  void openClient;
+  void [getHarness, openClient];
   return handlerFixture;
 }
 
@@ -315,7 +313,7 @@ export function setupGatewaySessionsTestHarness() {
 }
 
 function createGatewaySessionsTestHarness(startServer: boolean) {
-  installGatewayTestHooks({ scope: "suite" });
+  gatewayTestHelpers.installGatewayTestHooks({ scope: "suite" });
 
   const defaultAgentWorkspace = path.join(os.tmpdir(), "openclaw-gateway-test");
   let harness: GatewayServerHarness | undefined;
@@ -396,15 +394,17 @@ function createGatewaySessionsTestHarness(startServer: boolean) {
     return sharedSessionStoreDir;
   };
 
-  const openClient = async (opts?: Parameters<typeof connectOk>[1]) =>
-    await requireHarness().openClient(opts);
+  const openClient = async (opts?: Parameters<typeof gatewayTestHelpers.connectOk>[1]) =>
+    await gatewayTestHelpers
+      .prepareGatewayReplyRuntimeForTest({ force: true })
+      .then(() => requireHarness().openClient(opts));
 
   async function createSessionStoreDir() {
     const dir = path.join(requireSharedSessionStoreDir(), `case-${sessionStoreCaseSeq++}`);
     await fs.mkdir(dir, { recursive: true });
-    const storePath = path.join(dir, "sessions.json");
-    testState.sessionStorePath = storePath;
-    return { dir, storePath };
+    testState.sessionStorePath = path.join(dir, "sessions.json");
+    (await getGatewayConfigModule()).clearRuntimeConfigSnapshot(); // A suite server may prewarm before case setup.
+    return { dir, storePath: testState.sessionStorePath };
   }
 
   async function createSelectedGlobalSessionStore() {
@@ -433,7 +433,7 @@ function createGatewaySessionsTestHarness(startServer: boolean) {
     testState.sessionStorePath = storeTemplate;
     testState.sessionConfig = { scope: "global" };
     if (writePrimeStore) {
-      await writeSessionStore({
+      await gatewayTestHelpers.writeSessionStore({
         entries: {},
         storePath: path.join(dir, "prime-sessions.json"),
       });
@@ -443,14 +443,14 @@ function createGatewaySessionsTestHarness(startServer: boolean) {
     const workStorePath = storeTemplate.replace("{agentId}", "work");
     await fs.mkdir(path.dirname(mainStorePath), { recursive: true });
     await fs.mkdir(path.dirname(workStorePath), { recursive: true });
-    await writeSessionStore({
+    await gatewayTestHelpers.writeSessionStore({
       agentId: "main",
       entries: {
         global: sessionStoreEntry("sess-main-global"),
       },
       storePath: mainStorePath,
     });
-    await writeSessionStore({
+    await gatewayTestHelpers.writeSessionStore({
       agentId: "work",
       entries: {
         global: sessionStoreEntry("sess-work-global", {
@@ -526,7 +526,7 @@ function createGatewaySessionsTestHarness(startServer: boolean) {
   async function seedActiveMainSession() {
     const { dir, storePath } = await createSessionStoreDir();
     await writeSingleLineSession(dir, "sess-main", "hello");
-    await writeSessionStore({
+    await gatewayTestHelpers.writeSessionStore({
       entries: {
         main: sessionStoreEntry("sess-main"),
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the shared Gateway session test harness could return a successful session mutation while persisting it to a stale/default SQLite store when a suite-level server warmed configuration before a test selected its per-case store. This caused order-dependent CI failures in unrelated session assertions.

## Why This Change Was Made

The fixture that owns per-case store selection now invalidates the runtime configuration snapshot immediately after selecting that store. This keeps handlers and assertions on the same authoritative database without changing production behavior, adding retries, or weakening assertions. The existing node-host creation test prewarms config before selecting its store so the original failure is deterministic.

Fixture lifecycle owner: `createSessionStoreDir` selects each case's authoritative session store, so it also owns invalidating a snapshot that could still point elsewhere. Clearing only in test reset is too early because the suite server may read configuration between reset and fixture setup.

Production LOC: +0/-0. Test and test-support: +5/-3 (net +2).

## User Impact

No user-visible product behavior changes. Release and PR validation no longer flakes when Gateway session tests run after a configuration prewarm.

## Evidence

- Original CI failures: run 32389349751, attempt 1 job 96491645630 and attempt 2 job 96493911994.
- Regression before fix: the deterministic prewarm failed `sessions.create accepts a node-host cwd without provisioning a Gateway worktree` in both routed Gateway configurations because `loadSessionEntry` read no row from the selected case store.
- Focused regression after fix: 2/2 routed configurations passed.
- Original 20-file `agentic-control-plane-agent-chat-hosted-1` shard order after fix, repeated twice: 20/20 files and 373/373 tests passed (118s, then 113s).
- `node scripts/check-changed.mjs`: passed.
- Autoreview (`gpt-5.6-sol`, high): clean, no accepted/actionable findings.

Test-audit gate: this protects the fixture invariant that a mutation and its assertion use the same per-case database; the credible regression is a suite-server config read between reset and store selection; existing coverage was intermittent because it did not force that ordering; no production seam was added.
