### PR TITLE
chore(ci): shrink media assertion baseline

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3428,7 +3428,7 @@ src/media/configured-max-bytes.ts	3
 src/media/fetch.ts	2
 src/media/input-files.ts	1
 src/media/local-media-access.ts	1
-src/media/media-facts.ts	17
+src/media/media-facts.ts	16
 src/media/media-probe.ts	1
 src/media/playback-transcode.ts	1
 src/media/runtime-prompt-image-provenance.ts	1


### PR DESCRIPTION
## Summary

- record the assertion-count reduction in `src/media/media-facts.ts` from 17 to 16
- keep the assertion-safety ratchet strict; do not absorb unrelated upward drift

## Root cause

Main commit `14cfd111ad8d51a` removed one assertion from `src/media/media-facts.ts`, but its generated ratchet entry remained at 17. Current-main `pnpm check:assertion-safety` therefore reports `16 < 17`.

The canonical refresh command is `pnpm check:assertion-safety --prune`. It also exposed unrelated upward drift, so this PR retains only the valid media shrink.

## Validation

- `pnpm check:assertion-safety`
- `pnpm check:assertion-safety --base origin/main`
- `node scripts/check-changed.mjs`
- autoreview: clean, correctness 1.0

Production LOC: 0. Baseline: +1/-1.