### PR TITLE
test(acp): close owned state database exactly

### DIFF
--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1424,8 +1424,7 @@ describe("/acp command", () => {
     );
     const { createTestAdmittedRunContext } =
       await import("../../agents/admitted-run-context.test-support.js");
-    const { closeOpenClawAgentDatabasesForTest } = await import("../../state/openclaw-agent-db.js");
-    const { closeOpenClawStateDatabaseForTest } = await import("../../state/openclaw-state-db.js");
+    const { closeOpenClawStateDatabaseByPath } = await import("../../state/openclaw-state-db.js");
 
     hoisted.upsertAcpSessionMetaMock.mockImplementation((input) =>
       sessionMeta.upsertAcpSessionMeta({ ...input, cfg, databasePath, now: () => 1 }),
@@ -1467,8 +1466,7 @@ describe("/acp command", () => {
       expect(hoisted.runTurnMock).toHaveBeenCalledTimes(1);
     } finally {
       acpManagerTesting.resetAcpSessionManagerForTests();
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
+      expect(closeOpenClawStateDatabaseByPath(databasePath)).toBe(true);
       await fs.rm(directory, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
## Summary

Close only the shared-state database created by the Slack-bound ACP follow-up test before removing its temporary directory.

## Root cause

The test owns one explicit `databasePath`, but its cleanup called the global agent- and state-database test reset helpers. In the compact shard, that broad cache teardown raced the test's temporary-root removal and failed with `ENOTEMPTY`. Cleanup now targets the exact cached database path and asserts that the owned handle was present and closed before deleting the directory. This does not add retries, swallow cleanup failures, or change production code.

Original failure: [compact-large-11 job 96500350406](https://github.com/openclaw/openclaw/actions/runs/32392029952/job/96500350406), `ENOTEMPTY` removing `/tmp/openclaw-acp-bound-followup-*` after the test assertions passed.

## Evidence

- Full `commands-acp.test.ts`: 75/75 passed.
- Focused original scenario: 10/10 repeated runs passed.
- `pnpm check:changed`: passed for the changed test and the concurrently validated UI lane.
- Fresh autoreview: no accepted/actionable findings.
- Production LOC: +0/-0. Test cleanup: +2/-4.

The linked-worktree commit uses `--no-verify` because dependencies are not installed or reconciled in worktrees. Equivalent formatting, focused/full tests, changed-file gates, and autoreview ran from the exact source diff in a prepared checkout.
