### PR TITLE
fix(state): keep divergent retired device identity from blocking gateway readiness

### DIFF
--- a/src/infra/state-migrations.device-identity.test.ts
+++ b/src/infra/state-migrations.device-identity.test.ts
@@ -735,6 +735,28 @@ describe("legacy device identity Doctor migration", () => {
     expect(retry.notices?.join("\n")).toContain("canonical SQLite identity remains authoritative");
     await expect(fsp.readFile(sourcePath, "utf8")).resolves.toBe(replacement);
     expect(identityRow(env)?.created_at_ms).toBe(CREATED_AT_MS);
+    expect(receipt(env)).toMatchObject({ removed_source: 1 });
+  });
+
+  it("does not mark a divergent preserved claim as removed", async () => {
+    const { env, stateDir } = useStateDir();
+    const sourcePath = await writeLegacy({ stateDir });
+    await migrate(stateDir, env, {
+      removeSource: () => {
+        throw new Error("simulated unlink failure");
+      },
+    });
+    const claimPath = `${sourcePath}.doctor-importing`;
+    const replacement = `${JSON.stringify({ version: 1, ...anotherIdentity() })}\n`;
+    await fsp.writeFile(claimPath, replacement, "utf8");
+
+    closeOpenClawStateDatabaseForTest();
+    const retry = await migrate(stateDir, env);
+
+    expect(retry.warnings).toEqual([]);
+    expect(retry.notices?.join("\n")).toContain("canonical SQLite identity remains authoritative");
+    await expect(fsp.readFile(claimPath, "utf8")).resolves.toBe(replacement);
+    expect(receipt(env)).toMatchObject({ removed_source: 0 });
   });
 
   it("keeps the divergent-file warning fatal when the canonical row is invalid", async () => {

--- a/src/infra/state-migrations.device-identity.test.ts
+++ b/src/infra/state-migrations.device-identity.test.ts
@@ -708,7 +708,36 @@ describe("legacy device identity Doctor migration", () => {
     expect(receipt(env)).toMatchObject({ removed_source: 1 });
   });
 
-  it("does not discard recreated bytes that differ from the receipt", async () => {
+  it("preserves a divergent recreated identity as a boot-safe notice while the canonical row is valid", async () => {
+    const { env, stateDir } = useStateDir();
+    const sourcePath = await writeLegacy({ stateDir });
+    await migrate(stateDir, env, {
+      removeSource: () => {
+        throw new Error("simulated unlink failure");
+      },
+    });
+    const divergent = anotherIdentity();
+    const replacement = `${JSON.stringify({
+      version: 1,
+      deviceId: divergent.deviceId,
+      publicKeyPem: divergent.publicKeyPem,
+      privateKeyPem: divergent.privateKeyPem,
+      createdAtMs: divergent.createdAtMs,
+    })}\n`;
+    await fsp.writeFile(sourcePath, replacement, "utf8");
+
+    closeOpenClawStateDatabaseForTest();
+    const retry = await migrate(stateDir, env);
+
+    // The startup readiness gate hard-fails on any migration warning, so this exact
+    // classification is what keeps a divergent inert file from crash-looping the gateway.
+    expect(retry.warnings).toEqual([]);
+    expect(retry.notices?.join("\n")).toContain("canonical SQLite identity remains authoritative");
+    await expect(fsp.readFile(sourcePath, "utf8")).resolves.toBe(replacement);
+    expect(identityRow(env)?.created_at_ms).toBe(CREATED_AT_MS);
+  });
+
+  it("keeps the divergent-file warning fatal when the canonical row is invalid", async () => {
     const { env, stateDir } = useStateDir();
     const sourcePath = await writeLegacy({ stateDir });
     await migrate(stateDir, env, {
@@ -718,13 +747,21 @@ describe("legacy device identity Doctor migration", () => {
     });
     const replacement = `${JSON.stringify({ ...nodeIdentity(), createdAtMs: CREATED_AT_MS + 1 })}\n`;
     await fsp.writeFile(sourcePath, replacement, "utf8");
+    const db = database(env);
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<MigrationDatabase>(db)
+        .updateTable("device_identities")
+        .set({ public_key_pem: "invalid-public-key", private_key_pem: "invalid-private-key" })
+        .where("identity_key", "=", "primary"),
+    );
 
     closeOpenClawStateDatabaseForTest();
     const retry = await migrate(stateDir, env);
 
     expect(retry.warnings.join("\n")).toContain("bytes differ from the migration receipt");
+    expect(retry.notices ?? []).toEqual([]);
     await expect(fsp.readFile(sourcePath, "utf8")).resolves.toBe(replacement);
-    expect(identityRow(env)?.created_at_ms).toBe(CREATED_AT_MS);
   });
 
   it("rejects symlinked, hardlinked, oversized, non-UTF-8, and invalid sources", async () => {

--- a/src/infra/state-migrations.device-identity.ts
+++ b/src/infra/state-migrations.device-identity.ts
@@ -165,6 +165,20 @@ function verifyCanonicalIdentity(
   }
 }
 
+/** A valid canonical row keeps runtime identity authoritative over retired JSON (#120610). */
+function canonicalRowIsValid(
+  identity: NormalizedLegacyDeviceIdentity,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  try {
+    const { db } = openOpenClawStateDatabase({ env });
+    const row = readCanonicalIdentity(db);
+    return row !== undefined && classifyCanonicalRow(row, identity) !== "invalid";
+  } catch {
+    return false;
+  }
+}
+
 function importAndRecordReceipt(params: {
   env: NodeJS.ProcessEnv;
   sourcePath: string;
@@ -316,6 +330,7 @@ async function cleanupReceiptSources(params: {
   }
   const changes: string[] = [];
   const warnings: string[] = [];
+  const notices: string[] = [];
   let removed = 0;
   for (const candidate of [params.detected.sourcePath, params.detected.claimPath]) {
     if (!(await params.stateRoot.exists(relativeLegacyPath(params.stateDir, candidate)))) {
@@ -333,9 +348,19 @@ async function cleanupReceiptSources(params: {
       continue;
     }
     if (snapshot.sha256 !== params.receipt.sourceSha256) {
-      warnings.push(
-        `Retired device identity cleanup preserved ${candidate}: bytes differ from the migration receipt.`,
-      );
+      // #120610 made the canonical SQLite row authoritative over retired JSON, so a
+      // divergent preserved file is inert while that row is valid. A warning here trips
+      // the startup-migration readiness gate and crash-loops the gateway over a file
+      // runtime never reads; only a missing/invalid canonical row keeps this fatal.
+      if (canonicalRowIsValid(snapshot.identity, params.env)) {
+        notices.push(
+          `Preserved retired device identity ${candidate}: bytes differ from the migration receipt; the canonical SQLite identity remains authoritative. Archive or delete the file to clear this notice.`,
+        );
+      } else {
+        warnings.push(
+          `Retired device identity cleanup preserved ${candidate}: bytes differ from the migration receipt.`,
+        );
+      }
       continue;
     }
     try {
@@ -352,7 +377,7 @@ async function cleanupReceiptSources(params: {
   if (removed > 0) {
     changes.push("Removed retired device identity JSON covered by its SQLite receipt.");
   }
-  return { changes, warnings };
+  return { changes, warnings, notices };
 }
 
 async function migrateWithExclusiveStateOwnership(params: {

--- a/src/infra/state-migrations.device-identity.ts
+++ b/src/infra/state-migrations.device-identity.ts
@@ -11,6 +11,7 @@ import {
   type NormalizedLegacyDeviceIdentity,
 } from "./device-identity-legacy.js";
 import {
+  readStoredDeviceIdentityReadOnly,
   resolveDeviceIdentityStore,
   validateStoredDeviceIdentity,
   type DeviceIdentity,
@@ -162,20 +163,6 @@ function verifyCanonicalIdentity(
   const row = readCanonicalIdentity(db);
   if (!row || classifyCanonicalRow(row, identity) !== "same") {
     throw new Error("canonical SQLite device identity no longer matches the legacy source");
-  }
-}
-
-/** A valid canonical row keeps runtime identity authoritative over retired JSON (#120610). */
-function canonicalRowIsValid(
-  identity: NormalizedLegacyDeviceIdentity,
-  env: NodeJS.ProcessEnv,
-): boolean {
-  try {
-    const { db } = openOpenClawStateDatabase({ env });
-    const row = readCanonicalIdentity(db);
-    return row !== undefined && classifyCanonicalRow(row, identity) !== "invalid";
-  } catch {
-    return false;
   }
 }
 
@@ -348,19 +335,21 @@ async function cleanupReceiptSources(params: {
       continue;
     }
     if (snapshot.sha256 !== params.receipt.sourceSha256) {
-      // #120610 made the canonical SQLite row authoritative over retired JSON, so a
-      // divergent preserved file is inert while that row is valid. A warning here trips
-      // the startup-migration readiness gate and crash-loops the gateway over a file
-      // runtime never reads; only a missing/invalid canonical row keeps this fatal.
-      if (canonicalRowIsValid(snapshot.identity, params.env)) {
-        notices.push(
-          `Preserved retired device identity ${candidate}: bytes differ from the migration receipt; the canonical SQLite identity remains authoritative. Archive or delete the file to clear this notice.`,
-        );
-      } else {
-        warnings.push(
-          `Retired device identity cleanup preserved ${candidate}: bytes differ from the migration receipt.`,
-        );
+      // SQLite owns runtime identity; warning about inert retired bytes would
+      // make startup refuse an otherwise healthy gateway.
+      try {
+        if (readStoredDeviceIdentityReadOnly({ env: params.env, identityKey: IDENTITY_KEY })) {
+          notices.push(
+            `Preserved retired device identity ${candidate}: bytes differ from the migration receipt; the canonical SQLite identity remains authoritative. Archive or delete the file to clear this notice.`,
+          );
+          continue;
+        }
+      } catch {
+        // Invalid canonical identity must retain its readiness-blocking warning.
       }
+      warnings.push(
+        `Retired device identity cleanup preserved ${candidate}: bytes differ from the migration receipt.`,
+      );
       continue;
     }
     try {
@@ -371,7 +360,13 @@ async function cleanupReceiptSources(params: {
       warnings.push(`Retired device identity cleanup failed for ${candidate}: ${String(error)}`);
     }
   }
-  if (warnings.length === 0 && (!params.receipt.removedSource || removed > 0)) {
+  // A divergent preserved claim cannot complete its interrupted receipt unless
+  // receipt-covered original bytes were actually removed during this pass.
+  if (
+    warnings.length === 0 &&
+    (!params.receipt.removedSource || removed > 0) &&
+    (notices.length === 0 || removed > 0)
+  ) {
     markLegacyMigrationSourceRemoved(params.receipt.sourceKey, params.env);
   }
   if (removed > 0) {

--- a/src/node-host/startup-state-migrations.test.ts
+++ b/src/node-host/startup-state-migrations.test.ts
@@ -128,6 +128,23 @@ describe("node-host startup state migrations", () => {
     expect(log.warn).not.toHaveBeenCalled();
   });
 
+  it("reports a recreated divergent identity as a notice while preserving the canonical identity", async () => {
+    const { env, stateDir } = useStateDir();
+    const { deviceId } = await writeDeviceIdentity(stateDir);
+    await runStartupMigrations({ env, log });
+    vi.clearAllMocks();
+
+    const { sourcePath } = await writeDeviceIdentity(stateDir);
+    await runStartupMigrations({ env, log });
+
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(loadDeviceIdentityIfPresent({ env })?.deviceId).toBe(deviceId);
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("canonical SQLite identity remains authoritative"),
+    );
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
   it("preserves a pending native device identity claim and continues", async () => {
     const { env, stateDir } = useStateDir();
     const { sourcePath } = await writeDeviceIdentity(stateDir);

--- a/src/node-host/startup-state-migrations.ts
+++ b/src/node-host/startup-state-migrations.ts
@@ -26,6 +26,9 @@ async function reportMigration(
     for (const change of result?.changes ?? []) {
       log.info(change);
     }
+    for (const notice of result?.notices ?? []) {
+      log.info(notice);
+    }
     for (const warning of result?.warnings ?? []) {
       log.warn(warning);
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes #117270. A gateway can enter a permanent restart loop when `identity/device.json` is recreated with different bytes after its identity has already been migrated successfully to canonical SQLite. The runtime does not read that retired file, but its cleanup warning is treated as a startup-readiness failure.

Redacted journal excerpt from the 2026-08-19 incident:

```text
OpenClaw startup migrations did not complete cleanly; refusing to report the gateway ready.
- Retired device identity cleanup preserved <state>/identity/device.json: bytes differ from the migration receipt.
Run "openclaw doctor --fix" against the same state/config, then restart the gateway.
```

The process exited 1 and systemd started a fresh PID roughly every 20 seconds. The suggested Doctor remedy could not clear the condition because cleanup intentionally preserved the divergent file.

## Why This Change Was Made

### Root Cause

The readiness owner is `src/commands/doctor-config-preflight.ts:669-677`: any `startupMigrationWarnings` calls `throwStartupMigrationRefusal`. The cleanup owner emitted that warning for every bytes-different retired identity file at `src/infra/state-migrations.device-identity.ts:350-361`, even when canonical SQLite was valid.

That conflicts with the authority ordering landed in [#120610](https://github.com/openclaw/openclaw/pull/120610): the canonical SQLite identity row is authoritative and runtime never reads the retired JSON. The affected deployed dist was reflog-verified at base `11997bf2117`; `git merge-base --is-ancestor d9ff862823a 11997bf2117` exited 0, proving #120610 was already present. Its loader-side fix could not help because the readiness gate refused boot before normal runtime identity loading.

The producer-side repair leaves the gate untouched. `canonicalRowIsValid` (`src/infra/state-migrations.device-identity.ts:168-180`) recognizes a valid canonical row, and cleanup reports only that inert divergent file as a notice (`src/infra/state-migrations.device-identity.ts:350-380`). Missing or invalid canonical state still follows the existing fatal-warning path. Startup logs notices at info (`src/node-host/startup-state-migrations.ts:25-34`).

This replaces closed [#126414](https://github.com/openclaw/openclaw/pull/126414) and carries forward the evidence from [the follow-up comment](https://github.com/openclaw/openclaw/pull/126414#issuecomment-5357889282). steipete correctly rejected its quarantine approach: ordinary startup must not move key material, and a divergent branch must not bypass canonical validation. This PR makes no file moves and changes no startup authority; it only classifies an already-preserved retired file by the authority state that #120610 established.

The reporter host recreated differing bytes on Aug 1, Aug 19, and Aug 20 at 02:03. The producer remains unidentified and is tracked separately; this PR prevents those inert recreations from becoming a boot outage.

## User Impact

Gateways with a valid canonical device identity now boot and serve while clearly logging a non-fatal notice for a divergent retired JSON file. Operators can archive or delete that retired file to clear the notice. Gateways without a valid canonical row remain fail-closed instead of silently accepting divergent key material.

Release note context: prevents a restart loop caused by a recreated retired device-identity JSON after a verified SQLite migration.

## Evidence

### Focused tests

- `node scripts/run-vitest.mjs src/infra/state-migrations.device-identity.test.ts` — 27/27 passed.
- The valid-canonical test uses a genuinely different generated Ed25519 keypair, not merely a timestamp change.
- The invalid-canonical test proves the divergent-file condition remains fatal.
- Pre-fix regression proof: stashing the two production files to `origin/main` made the valid-canonical notice test fail with `AssertionError: expected [ Array(1) ] to deeply equal []`: it received the old warning where no warning was allowed.

### Changed-file and build gates

- `node scripts/check-changed.mjs -- src/infra/state-migrations.device-identity.ts src/infra/state-migrations.device-identity.test.ts src/node-host/startup-state-migrations.ts` — passed.
- `pnpm build` — passed (only existing third-party bundler direct-eval warnings).
- `git diff origin/main --numstat`: production `+32/-4` (`state-migrations.device-identity.ts`, `startup-state-migrations.ts`); tests `+39/-2` (`state-migrations.device-identity.test.ts`).

### Isolated live proof

All commands used an isolated throwaway `OPENCLAW_STATE_DIR`; the operator state and managed gateway were not touched.

1. Generated a fresh Ed25519 legacy JSON identity, ran `node dist/index.js doctor --fix --non-interactive`, verified one canonical primary SQLite identity row, and verified the retired source JSON was removed.
2. Copied the incident artifact bytes into only that isolated retired-file path without printing their contents. `doctor --fix --non-interactive` produced `canonical SQLite identity remains authoritative` as a notice and no fatal divergent-file cleanup warning.
3. Ran `node dist/index.js gateway run --allow-unconfigured --auth none --port 19257`; both `GET /readyz` and `GET /healthz` returned 200. Startup logged the new notice, logged no readiness refusal, and the isolated process shut down cleanly on SIGTERM.

### Review

- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted` — clean; no accepted/actionable findings.

### What was not tested

No reproduction was run against the operator state or managed Gateway, and no attempt was made to identify or change the external producer that recreates the retired file. The pre-fix crash loop is the recorded 2026-08-19 journal incident above; this PR proves the repaired path in disposable state using the real incident artifact bytes.