### PR TITLE
fix(reply): keep unresolved image suppression out of the persisted transcript

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -339,6 +339,12 @@ export async function prepareEmbeddedAttemptPromptExecution(input: {
     attempt.userTurnTranscriptRecorder?.message ??
     (await attempt.userTurnTranscriptRecorder?.resolveMessage());
   const persistedMedia = persistedMessage ? (readPersistedMediaFacts(persistedMessage) ?? []) : [];
+  for (const factIndex of attempt.userTurnTranscriptRecorder?.promptSuppressedFactIndexes ?? []) {
+    const fact = persistedMedia[factIndex];
+    if (fact) {
+      persistedMedia[factIndex] = { ...fact, hydrationSuppressed: true };
+    }
+  }
 
   const result = await detectAndLoadPromptImages({
     prompt: input.prompt,

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts
@@ -370,6 +370,64 @@ describe("plugin harness prompt media", () => {
     }
   });
 
+  it("skips a recorder fact suppressed for this prompt while keeping the persisted record clean", async () => {
+    const workspaceDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-harness-prompt-suppressed-"),
+    );
+    const imagePath = path.join(workspaceDir, "present.png");
+    await fs.writeFile(imagePath, Buffer.from(TINY_PNG_BASE64, "base64"));
+    const media = [
+      { path: imagePath, contentType: "image/png" },
+      { path: path.join(workspaceDir, "missing.png"), contentType: "image/png" },
+    ];
+    const message = {
+      role: "user",
+      content: "compare these",
+      __openclaw: {
+        media,
+        mediaImageLayout: {
+          slots: [
+            { kind: "inline", factIndex: 0 },
+            { kind: "offloaded", factIndex: 1 },
+          ],
+        },
+      },
+    };
+    const buildInput = (promptSuppressedFactIndexes?: number[]) =>
+      ({
+        runParams: {
+          agentId: "main",
+          config: { agents: { defaults: { sandbox: { mode: "off" } } } },
+          images: [{ type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" }],
+          imageOrder: ["inline"],
+          media,
+          sessionId: "session-prompt-suppressed",
+          userTurnTranscriptRecorder: { message, promptSuppressedFactIndexes },
+        },
+        runtime: {
+          model: { input: ["text", "image"] },
+          sessionId: "session-prompt-suppressed",
+          workspaceDir,
+        },
+        pluginHarnessOwnsTransport: true,
+      }) as unknown as Parameters<typeof preparePluginHarnessPromptImages>[0];
+    try {
+      await expect(preparePluginHarnessPromptImages(buildInput())).rejects.toThrow(
+        /failed to hydrate 1 structured image attachment/,
+      );
+
+      const result = await preparePluginHarnessPromptImages(buildInput([1]));
+
+      expect(result.images).toEqual([
+        { type: "image", data: TINY_PNG_BASE64, mimeType: "image/png" },
+      ]);
+      expect(result.imageOrder).toEqual(["inline"]);
+      expect(media[1]).not.toHaveProperty("hydrationSuppressed");
+    } finally {
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    }
+  });
+
   it("surfaces an unsuppressed identity-less inline fact with no image block", async () => {
     await expect(
       preparePluginHarnessPromptImages({

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -314,6 +314,9 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     (userTurnInput
       ? createUserTurnTranscriptRecorder({
           input: userTurnInput,
+          ...(unresolvedSourceIndexes.size > 0
+            ? { promptSuppressedFactIndexes: [...unresolvedSourceIndexes] }
+            : {}),
           target: () => ({
             sessionId: preparedSessionState.sessionId,
             sessionKey: sessionKey ?? preparedSessionState.sessionId,

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -213,10 +213,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
   const persistGroupSender = replyRoute.chatType === "group" || replyRoute.chatType === "channel";
   const ctxMediaForPersistence = normalizeMediaFacts(ctx.media);
   const unresolvedSourceIndexes = new Set(currentTurnImages.unresolvedSourceIndexes ?? []);
-  const persistedCtxMedia = ctxMediaForPersistence.map((fact, index) =>
-    unresolvedSourceIndexes.has(index) ? { ...fact, hydrationSuppressed: true } : fact,
-  );
-  const userTurnMediaForPersistence = [...persistedCtxMedia, ...(opts?.media ?? [])];
+  const userTurnMediaForPersistence = [...ctxMediaForPersistence, ...(opts?.media ?? [])];
   const inboundMediaIndexes = buildInboundMediaNoteProjection(ctx).mediaIndexes ?? [];
   const promptMediaForRun = suppressUnresolvedPromptMedia({
     promptMedia: promptMedia ?? [],

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1113,6 +1113,27 @@ describe("runPreparedReply media-only handling", () => {
     });
   });
 
+  it("keeps unresolved current-turn images hydratable in the persisted transcript", async () => {
+    resolveCurrentTurnImagesMock.mockResolvedValueOnce({ unresolvedSourceIndexes: [0] });
+    const params = baseParams();
+    params.ctx.media = [{ path: "/tmp/unreadable.png", contentType: "image/png" }];
+
+    await runPreparedReply(params);
+
+    const call = requireRunReplyAgentCall();
+    expect(call.followupRun.media).toEqual([
+      expect.objectContaining({ path: "/tmp/unreadable.png", hydrationSuppressed: true }),
+    ]);
+    const persisted = call.followupRun.userTurnTranscriptRecorder?.message?.["__openclaw"] as {
+      media?: Record<string, unknown>[];
+      mediaImageLayout?: Record<string, unknown>;
+    };
+    expect(persisted.media).toEqual([
+      { path: "/tmp/unreadable.png", contentType: "image/png", kind: "image" },
+    ]);
+    expect(persisted.mediaImageLayout).toEqual({ slots: [{ kind: "offloaded", factIndex: 0 }] });
+  });
+
   it.each([
     "discord",
     "telegram",

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1132,6 +1132,7 @@ describe("runPreparedReply media-only handling", () => {
       { path: "/tmp/unreadable.png", contentType: "image/png", kind: "image" },
     ]);
     expect(persisted.mediaImageLayout).toEqual({ slots: [{ kind: "offloaded", factIndex: 0 }] });
+    expect(call.followupRun.userTurnTranscriptRecorder?.promptSuppressedFactIndexes).toEqual([0]);
   });
 
   it.each([

--- a/src/sessions/user-turn-transcript.ts
+++ b/src/sessions/user-turn-transcript.ts
@@ -595,6 +595,7 @@ export function createUserTurnTranscriptRecorder(
     get message() {
       return message;
     },
+    promptSuppressedFactIndexes: params.promptSuppressedFactIndexes,
     resolveMessage: resolveMessageForPersistence,
     replaceTextBeforePersistence: (text) => {
       if (persisted || runtimePersisted || sentToProvider) {

--- a/src/sessions/user-turn-transcript.types.ts
+++ b/src/sessions/user-turn-transcript.types.ts
@@ -151,10 +151,12 @@ export type CreateUserTurnTranscriptRecorderParams = {
   onMessagePersisted?: (message: PersistedUserTurnMessage) => void | Promise<void>;
   expectedSessionState?: SessionTranscriptTurnExpectedState;
   sessionLifecyclePatch?: SessionTranscriptTurnLifecyclePatch;
+  promptSuppressedFactIndexes?: readonly number[];
 };
 
 export type UserTurnTranscriptRecorder = {
   readonly message: PersistedUserTurnMessage | undefined;
+  readonly promptSuppressedFactIndexes?: readonly number[];
   resolveMessage: () => Promise<PersistedUserTurnMessage | undefined>;
   /** Replaces generated current-turn text before runtime persistence/provider submission. */
   replaceTextBeforePersistence?: (text: string) => void;


### PR DESCRIPTION
## Summary
When a channel turn carries an inbound image and the turn-time attachment read fails once (the 1 second read budget or the 10 MiB cap in `agent-turn-attachments`, a transient EACCES/ENOENT while staging finishes, or any throw from the attachment runtime), the reply executor writes `hydrationSuppressed: true` into the durable user-turn transcript record for that image. Every later turn of the session replays that record, so the image is never loaded again even when the file is readable, and the loader no longer even counts it as a failed attachment, so nothing ever reports the loss. The photo silently disappears from the conversation for good.

This keeps the turn-local suppression exactly where it belongs (the run-scoped prompt media that `suppressUnresolvedPromptMedia` already produces) and stops copying the one-turn verdict into the durable record.

## Root cause
`src/auto-reply/reply/get-reply-run-execute.ts` (introduced by #122361):

```ts
// before
const ctxMediaForPersistence = normalizeMediaFacts(ctx.media);
const unresolvedSourceIndexes = new Set(currentTurnImages.unresolvedSourceIndexes ?? []);
const persistedCtxMedia = ctxMediaForPersistence.map((fact, index) =>
  unresolvedSourceIndexes.has(index) ? { ...fact, hydrationSuppressed: true } : fact,
);
const userTurnMediaForPersistence = [...persistedCtxMedia, ...(opts?.media ?? [])];
```

`unresolvedSourceIndexes` is a turn-scoped result of `resolveCurrentTurnImages`; it reports that the fast pre-resolver could not read the bytes during this turn. `hydrationSuppressed` on a persisted media fact, however, is read by every later replay (`images.ts` skips the fact and `images.media-refs.ts` returns `hydrate: false`), and `buildPersistedMediaImageLayout` copies the flag into the persisted layout's `suppressedFactIndexes`. The persisted record therefore turns "unreadable right now" into "never hydrate". The sibling call on the next lines, `suppressUnresolvedPromptMedia`, applies the same flag to the run-scoped prompt media copy, which is the correct, turn-local place.

## Fix
```ts
// after
const ctxMediaForPersistence = normalizeMediaFacts(ctx.media);
const unresolvedSourceIndexes = new Set(currentTurnImages.unresolvedSourceIndexes ?? []);
const userTurnMediaForPersistence = [...ctxMediaForPersistence, ...(opts?.media ?? [])];
```

The persisted facts and the persisted image layout now describe the attachment as it arrived. The unresolved image keeps an `offloaded` layout slot, so later turns hydrate it again from disk. The run-scoped `promptMediaForRun` and `promptMediaImageLayout` still carry the turn-local suppression, unchanged.

## Why this is the right boundary
- The durable transcript is the one place where the flag is replayed forever; the turn-local prompt copy already existed and already expires with the run.
- This matches the gateway path: `src/gateway/agent-turn/agent-run-user-turn.ts` persists image facts and layout slots without any suppression, and the embedded runner hydrates from that record on the current turn. Channel turns now persist the same shape.
- On the current turn the embedded runner hydrates from the persisted record exactly as it does for gateway turns: an unreadable file is logged and skipped for that turn, and the next turn tries again. The CLI runner and any path without a transcript recorder keep using the run-scoped suppressed copy, so #122361's partial-batch behavior (deliver the readable images, skip the unresolved one) is unchanged there.
- Every other producer of `hydrationSuppressed` (`media-note.ts` for images already described as text, `chat-attachments.ts` for non-image MIME) records a property that is genuinely permanent and is untouched.

Related: #122361 introduced the persisted mapping while fixing the all-or-nothing drop; #122101 (open) tracks the current-turn symptom of partial resolution and does not cover the durable record. No other issue or PR describes the later-turn loss.

## Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts`: 124 passed (new case `keeps unresolved current-turn images hydratable in the persisted transcript`).
- The new case fails on pristine main (`hydrationSuppressed: true` received in the persisted media) and passes with this patch.
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run-helpers.media-facts.test.ts src/auto-reply/reply/current-turn-images.test.ts src/auto-reply/reply/agent-runner.media-paths.test.ts src/agents/embedded-agent-runner/run/run-attempt-dispatch.media.test.ts`: 4 files, 69 passed.
- `oxfmt --check` and `oxlint -c .oxlintrc.json` on both changed files: clean.
- tsgo core lane: `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean (exit 0).

## Real behavior proof
Behavior addressed: A one-turn failure to read an inbound photo was written into the durable transcript as `hydrationSuppressed: true`, so the photo was never sent to the model on any later turn of the session.
Real environment tested: Real `getReplyFromConfig` channel turns (WhatsApp-shaped inbound context with an image attachment), real on-disk config, session store and transcript under an isolated OPENCLAW_HOME, real embedded agent run against `scripts/e2e/mock-openai-server.mjs` on loopback as the only stand-in (provider HTTP boundary); run on pristine origin/main d40cbfef475 and on this patch with identical inputs. Turn 1 runs while the photo is chmod 000; the file is restored before turn 2.
Exact steps or command run after this patch: `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 node --import tsx proof-hydration.mts` from the patched tree (driver source below), then the same driver from a pristine `origin/main` checkout.
Evidence after fix:
```
# BEFORE (pristine origin/main d40cbfef475)
== BEFORE: TURN 1 (photo unreadable while the turn runs) ==
   reply: "OK"
   provider request /v1/chat/completions: user messages=2 image parts=0 resend notice=false
   session entries: 1
   transcript events for agent:main:whatsapp:direct:+1003: 8
   durable user turn media       : [{"path":"<home>/workspace/inbound/photo.png","contentType":"image/png","kind":"image","hydrationSuppressed":true}]
   durable user turn image layout: {"slots":[],"suppressedFactIndexes":[0]}
== BEFORE: TURN 2 (photo readable again, same conversation) ==
   reply: "OK"
   provider request /v1/chat/completions: user messages=2 image parts=0 resend notice=false

# AFTER (this patch, identical inputs)
== AFTER: TURN 1 (photo unreadable while the turn runs) ==
[agent/embedded] Native image: failed to load <home>/workspace/inbound/photo.png: EACCES: permission denied, open '<home>/workspace/inbound/photo.png'
   reply: "OK"
   provider request /v1/chat/completions: user messages=2 image parts=0 resend notice=false
   session entries: 1
   transcript events for agent:main:whatsapp:direct:+1003: 8
   durable user turn media       : [{"path":"<home>/workspace/inbound/photo.png","contentType":"image/png","kind":"image"}]
   durable user turn image layout: {"slots":[{"kind":"offloaded","factIndex":0}]}
== AFTER: TURN 2 (photo readable again, same conversation) ==
   reply: "OK"
   provider request /v1/chat/completions: user messages=2 image parts=1 resend notice=false
```
Observed result after fix: The durable user-turn record no longer carries `hydrationSuppressed`, its layout keeps an `offloaded` slot for the photo, and the second turn's provider request contains the photo as an image part (image parts=1) where pristine main sends none (image parts=0) and has stamped `hydrationSuppressed: true` plus `suppressedFactIndexes: [0]` into the record.
What was not tested: No live third-party channel or vision provider; the plugin harness and CLI runner paths were exercised only by their existing suites, not live. The "could not be loaded" notice did not appear in either run of this loopback setup, so this patch is not claimed to change that notice.

<details>
<summary>proof-hydration.mts (driver source)</summary>

```ts
import { spawn } from "node:child_process";
import fs from "node:fs";
import os from "node:os";
import path from "node:path";
import { pathToFileURL } from "node:url";

const ROOT = process.cwd();
const LABEL = process.env.PROOF_LABEL ?? "run";
const home = fs.mkdtempSync(path.join(os.tmpdir(), `oc-hydration-${LABEL}-`));
const stateDir = path.join(home, ".openclaw");
process.env.HOME = home;
process.env.OPENCLAW_HOME = home;
process.env.OPENCLAW_STATE_DIR = stateDir;
delete process.env.VITEST;
delete process.env.NODE_ENV;

const TINY_PNG_BASE64 =
  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";

async function getFreePort(): Promise<number> {
  const net = await import("node:net");
  return await new Promise((resolve, reject) => {
    const server = net.createServer();
    server.once("error", reject);
    server.listen(0, "127.0.0.1", () => {
      const address = server.address();
      const port = typeof address === "object" && address ? address.port : 0;
      server.close(() => resolve(port));
    });
  });
}

async function waitHealth(port: number) {
  for (let i = 0; i < 200; i++) {
    try {
      const res = await fetch(`http://127.0.0.1:${port}/health`);
      if (res.ok) {
        return;
      }
    } catch {}
    await new Promise((r) => setTimeout(r, 50));
  }
  throw new Error("mock provider did not start");
}

function describeRequests(logPath: string, sinceLine: number) {
  const lines = fs.existsSync(logPath)
    ? fs.readFileSync(logPath, "utf8").split("\n").filter(Boolean)
    : [];
  const out: string[] = [];
  for (const line of lines.slice(sinceLine)) {
    const entry = JSON.parse(line) as { path: string; body: unknown };
    const body = (typeof entry.body === "string" ? JSON.parse(entry.body) : entry.body) as {
      messages?: unknown[];
    };
    const messages = Array.isArray(body?.messages) ? body.messages : [];
    const userMessages = messages.filter((m) => (m as { role?: string }).role === "user");
    let imageParts = 0;
    let notice = false;
    for (const message of userMessages) {
      const content = (message as { content?: unknown }).content;
      const parts = Array.isArray(content) ? content : [{ type: "text", text: content }];
      for (const part of parts as Array<{ type?: string; text?: string }>) {
        if (part.type === "image_url" || part.type === "image") {
          imageParts++;
        }
        if (typeof part.text === "string" && part.text.includes("could not be loaded")) {
          notice = true;
        }
      }
    }
    out.push(
      `   provider request ${entry.path}: user messages=${userMessages.length} image parts=${imageParts} resend notice=${notice}`,
    );
  }
  return { out, lineCount: lines.length };
}

async function main() {
  const port = await getFreePort();
  const requestLog = path.join(home, "provider-requests.jsonl");
  const mock = spawn(process.execPath, [path.join(ROOT, "scripts/e2e/mock-openai-server.mjs")], {
    env: { ...process.env, MOCK_PORT: String(port), MOCK_REQUEST_LOG: requestLog, SUCCESS_MARKER: "OK" },
    stdio: ["ignore", "ignore", "inherit"],
  });
  try {
    await waitHealth(port);
    const workspace = path.join(home, "workspace");
    const inboundDir = path.join(workspace, "inbound");
    fs.mkdirSync(inboundDir, { recursive: true });
    const photo = path.join(inboundDir, "photo.png");
    fs.writeFileSync(photo, Buffer.from(TINY_PNG_BASE64, "base64"));

    const cfg = {
      agents: {
        defaults: {
          model: { primary: "loopback/vision-model" },
          workspace,
          humanDelay: { mode: "off" },
          blockStreamingCoalesce: { idleMs: 1 },
        },
        list: [{ id: "main", default: true }],
      },
      models: {
        providers: {
          loopback: {
            baseUrl: `http://127.0.0.1:${port}/v1`,
            apiKey: "loopback-key",
            api: "openai-completions",
            models: [
              {
                id: "vision-model",
                name: "vision-model",
                api: "openai-completions",
                input: ["text", "image"],
                contextWindow: 128000,
                maxTokens: 4096,
                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
              },
            ],
          },
        },
      },
      plugins: { allow: ["no-plugins-for-this-proof"] },
      channels: { whatsapp: { allowFrom: ["*"] } },
      session: { store: path.join(home, "sessions.json") },
    };

    fs.mkdirSync(stateDir, { recursive: true });
    fs.writeFileSync(path.join(stateDir, "openclaw.json"), JSON.stringify(cfg, null, 2));
    const { getReplyFromConfig } = await import(
      pathToFileURL(path.join(ROOT, "src/auto-reply/reply.js")).href
    );
    const base = {
      From: "+1003",
      To: "+2000",
      CommandAuthorized: true,
      SessionKey: "agent:main:whatsapp:direct:+1003",
    };

    console.log(`== ${LABEL}: TURN 1 (photo unreadable while the turn runs) ==`);
    fs.chmodSync(photo, 0o000);
    let reply = await getReplyFromConfig(
      { ...base, Body: "what is in this photo?", media: [{ path: photo, contentType: "image/png" }] },
      {},
    );
    fs.chmodSync(photo, 0o644);
    console.log(`   reply: ${JSON.stringify(Array.isArray(reply) ? reply[0]?.text : reply?.text)}`);
    let seen = describeRequests(requestLog, 0);
    console.log(seen.out.join("\n"));

    const sessions = await import(
      pathToFileURL(path.join(ROOT, "src/config/sessions/session-accessor.js")).href
    );
    const entries = sessions.listSessionEntriesCore
      ? await sessions.listSessionEntriesCore({
          agentId: "main",
          storePath: path.join(home, "sessions.json"),
        })
      : undefined;
    const list: Array<{ sessionKey: string; entry: { sessionId: string } }> = Array.isArray(entries)
      ? entries
      : Array.isArray(entries?.entries)
        ? entries.entries
        : [];
    console.log(`   session entries: ${list.length}`);
    for (const item of list) {
      const sessionKey = item.sessionKey ?? (item as { key?: string }).key;
      const sessionId = item.entry?.sessionId ?? (item as { sessionId?: string }).sessionId;
      const events = await sessions.loadTranscriptEvents({
        agentId: "main",
        storePath: path.join(home, "sessions.json"),
        sessionKey,
        sessionId,
      });
      console.log(`   transcript events for ${sessionKey}: ${(events as unknown[]).length}`);
      for (const event of events as Array<{ message?: { role?: string; __openclaw?: unknown } }>) {
        const message = event.message;
        if (message?.role !== "user") {
          continue;
        }
        const meta = (message.__openclaw ?? {}) as { media?: unknown; mediaImageLayout?: unknown };
        if (meta.media) {
          console.log(`   durable user turn media       : ${JSON.stringify(meta.media)}`);
          console.log(`   durable user turn image layout: ${JSON.stringify(meta.mediaImageLayout)}`);
        }
      }
    }

    console.log(`== ${LABEL}: TURN 2 (photo readable again, same conversation) ==`);
    reply = await getReplyFromConfig({ ...base, Body: "what did my photo show?" }, {});
    console.log(`   reply: ${JSON.stringify(Array.isArray(reply) ? reply[0]?.text : reply?.text)}`);
    seen = describeRequests(requestLog, seen.lineCount);
    console.log(seen.out.join("\n"));
  } finally {
    mock.kill("SIGKILL");
  }
  process.exit(0);
}

main().catch((error) => {
  console.error(error);
  process.exit(1);
});
```

</details>
