### PR TITLE
fix(ui): stop stale provider tests after switching agents

### DIFF
--- a/ui/src/pages/model-providers/model-providers-page.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.test.ts
@@ -659,8 +659,39 @@ describe("ModelProvidersPage agent scope", () => {
     });
   });
 
+  it("stops queued provider probes after switching away from and back to the selected agent", async () => {
+    const { agentSelection, context, notifySelection, request } = createHarness("main");
+    const page = appendPage(context);
+    await vi.waitFor(() => expect(page.data?.config).toEqual({}));
+    request.mockClear();
+    const firstProbe = deferred<ModelsProbeResult>();
+    request.mockImplementationOnce(() => firstProbe.promise);
+
+    const probing = page.probe("anthropic", ["anthropic", "claude-cli"]);
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("models.probe", {
+        provider: "anthropic",
+        agentId: "main",
+      }),
+    );
+    agentSelection.state.selectedId = "writer";
+    agentSelection.state.scopeId = "writer";
+    notifySelection();
+    await vi.waitFor(() => expect(page.selectedAgentId).toBe("writer"));
+    agentSelection.state.selectedId = "main";
+    agentSelection.state.scopeId = "main";
+    notifySelection();
+    await vi.waitFor(() => expect(page.selectedAgentId).toBe("main"));
+    firstProbe.resolve({ provider: "anthropic", status: "ok", results: [] });
+    await probing;
+
+    expect(request.mock.calls.filter(([method]) => method === "models.probe")).toHaveLength(1);
+    expect(page.probeResults).toEqual({});
+    expect(page.busy).toEqual({});
+  });
+
   it("discards an in-flight probe result after the selected agent changes", async () => {
-    const { context, request } = createHarness("main");
+    const { agentSelection, context, notifySelection, request } = createHarness("main");
     const page = appendPage(context);
     await vi.waitFor(() => expect(page.data?.config).toEqual({}));
     const pending = deferred<ModelsProbeResult>();
@@ -673,7 +704,10 @@ describe("ModelProvidersPage agent scope", () => {
         agentId: "main",
       }),
     );
-    page.selectedAgentId = "writer";
+    agentSelection.state.selectedId = "writer";
+    agentSelection.state.scopeId = "writer";
+    notifySelection();
+    await vi.waitFor(() => expect(page.selectedAgentId).toBe("writer"));
     pending.resolve({ provider: "openai", status: "ok", results: [] });
     await probing;
 

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -436,33 +436,34 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     }
     const clientEpoch = this.connectionLifecycle.epoch;
     const agentId = this.selectedAgentId;
+    const agentEpoch = this.agentEpoch;
     const probeEpoch = (this.probeEpochs.get(cardId) ?? 0) + 1;
     this.probeEpochs.set(cardId, probeEpoch);
+    const ownsProbe = () =>
+      this.isCurrentClient(client, clientEpoch) &&
+      this.agentEpoch === agentEpoch &&
+      this.selectedAgentId === agentId &&
+      this.probeEpochs.get(cardId) === probeEpoch;
     this.setBusy(key, true);
     this.setMessage(cardId, null);
     try {
       const results: ModelsProbeResult[] = [];
       for (const provider of providers) {
+        if (!ownsProbe()) {
+          return;
+        }
         results.push(
           await client.request<ModelsProbeResult>("models.probe", { provider, agentId }),
         );
       }
-      if (
-        this.isCurrentClient(client, clientEpoch) &&
-        this.selectedAgentId === agentId &&
-        this.probeEpochs.get(cardId) === probeEpoch
-      ) {
+      if (ownsProbe()) {
         this.probeResults = {
           ...this.probeResults,
           [cardId]: mergeProbeResults(cardId, results),
         };
       }
     } catch (error) {
-      if (
-        !this.isCurrentClient(client, clientEpoch) ||
-        this.selectedAgentId !== agentId ||
-        this.probeEpochs.get(cardId) !== probeEpoch
-      ) {
+      if (!ownsProbe()) {
         return;
       }
       if (isMissingMethodError(error)) {
@@ -475,10 +476,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
         this.setMessage(cardId, { kind: "error", text: modelProviderErrorMessage(error) });
       }
     } finally {
-      if (
-        this.isCurrentClient(client, clientEpoch) &&
-        this.probeEpochs.get(cardId) === probeEpoch
-      ) {
+      if (ownsProbe()) {
         this.setBusy(key, false);
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users testing a model provider in the Control UI could trigger additional requests for a previously selected agent and see stale provider-test results after switching to another agent and back while the first request was still running.

## Why This Change Was Made

Model-provider probes are owned by the current Gateway connection, selected agent lifecycle, and provider-card request. Keep all four probe transitions—dispatch, completion, failure, and busy-state cleanup—behind one existing-lifecycle ownership predicate. Unlike comparing only the current agent identifier, the existing monotonic agent epoch also detects an agent A → B → A selection sequence and stops undispatched alias-provider probes before they reach the Gateway.

The adjacent agent-scoped logout flow already enforces this lifecycle invariant. Reusing that owner boundary avoids a new cache, retry, compatibility path, or Gateway API change.

## User Impact

Switching agents immediately retires an in-flight provider test. It cannot issue a queued request for the previous selection, overwrite the replacement selection's result, or clear another provider test's busy state when its original request later finishes.

## Evidence

- Reproduced the previous failure against the real mounted Lit element, application agent-selection subscription, and Gateway request boundary: start a two-provider probe for agent A, select B, select A again, then resolve the original provider request. Before the fix the obsolete second provider request was dispatched; afterward exactly one provider request occurs and stale result/busy state stays empty.
- Existing one-way selection-change regression now also uses the real agent-selection subscription instead of directly mutating the page's internal field.
- Focused model-provider proof: 82 passing tests across five suites, covering provider cards, alias-provider probes, agent lifecycle, credential mutations, and adjacent logout behavior.
- Focused formatting, lint, and whitespace checks passed; independent owner-boundary review and authenticated Codex autoreview both found no actionable findings.
- Exact validated head: `6e055c5e527ea27afd72bdb35bd223494619dd2f`, freshly rebased onto the current main after the prior Gateway and Telegram fixes landed.
- Production delta: +12/-14 (net -2); regression-test delta: +36/-2.
- No visual/layout change is introduced. A static before/after screenshot cannot demonstrate this asynchronous request-ownership race; the mounted-DOM regression verifies the actual user selection flow, outbound Gateway request count, and final visible-state ownership instead.

AI-assisted; reviewed and verified against the complete owner, caller, adjacent agent-scoped flows, and current main.
