### PR TITLE
fix(discord): preserve message text from every embed

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -397,7 +397,7 @@ extensions/discord/src/monitor/message-handler.hydration.ts	12
 extensions/discord/src/monitor/message-handler.preflight-helpers.ts	5
 extensions/discord/src/monitor/message-handler.preflight.ts	2
 extensions/discord/src/monitor/message-handler.process.ts	1
-extensions/discord/src/monitor/message-text.ts	4
+extensions/discord/src/monitor/message-text.ts	3
 extensions/discord/src/monitor/model-picker-preferences-migrations.ts	5
 extensions/discord/src/monitor/model-picker-preferences.ts	1
 extensions/discord/src/monitor/model-picker.state.ts	3

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -371,6 +371,35 @@ describe("preflightDiscordMessage", () => {
     handleDiscordDmCommandDecisionMock.mockResolvedValue(undefined);
   });
 
+  it("admits embed-only messages when their text appears after a textless first embed", async () => {
+    const channelId = "dm-channel-multiple-embeds";
+    const message = Object.assign(
+      createDiscordMessage({
+        id: "m-multiple-embeds",
+        channelId,
+        content: "",
+        author: { id: "user-1", bot: false, username: "alice" },
+      }),
+      {
+        embeds: [
+          { image: { url: "https://cdn.discordapp.com/image.png" } },
+          { title: "Alert", description: "Details" },
+          { description: "Follow-up" },
+        ],
+      },
+    );
+
+    const result = await runDmPreflight({
+      channelId,
+      message,
+      discordConfig: { dmPolicy: "open" } as DiscordConfig,
+    });
+
+    const preflight = expectPreflightResult(result);
+    expect(preflight.baseText).toBe("Alert\nDetails\nFollow-up");
+    expect(preflight.messageText).toBe("Alert\nDetails\nFollow-up");
+  });
+
   it("drops bound-thread bot system messages to prevent ACP self-loop", async () => {
     const threadBinding = createThreadBinding({
       targetKind: "session",

--- a/extensions/discord/src/monitor/message-text.test.ts
+++ b/extensions/discord/src/monitor/message-text.test.ts
@@ -275,6 +275,22 @@ describe("resolveDiscordMessageText", () => {
     ).toBe("Breaking\nDetails");
   });
 
+  it("preserves ordered text from all embeds while skipping textless embeds", () => {
+    expect(
+      resolveDiscordMessageText(
+        asMessage({
+          content: "",
+          embeds: [
+            { image: { url: "https://cdn.discordapp.com/image.png" } },
+            { title: "Breaking", description: "Details" },
+            {},
+            { description: "Follow-up" },
+          ],
+        }),
+      ),
+    ).toBe("Breaking\nDetails\nFollow-up");
+  });
+
   it("prefers message content over embed fallback text", () => {
     expect(
       resolveDiscordMessageText(
@@ -297,6 +313,24 @@ describe("resolveDiscordMessageText", () => {
 
     expect(text).toContain("[Forwarded message from @Bob]");
     expect(text).toContain("Forwarded title\nForwarded details");
+  });
+
+  it("preserves text from later embeds in forwarded message snapshots", () => {
+    const text = resolveDiscordMessageText(
+      asForwardedSnapshotMessage({
+        content: "",
+        embeds: [
+          {},
+          { title: "Forwarded title", description: "Forwarded details" },
+          { description: "Forwarded follow-up" },
+        ],
+      }),
+      { includeForwarded: true },
+    );
+
+    expect(text).toBe(
+      "[Forwarded message from @Bob]\nForwarded title\nForwarded details\nForwarded follow-up",
+    );
   });
 
   it("includes Components v2 text display content from forwarded snapshots", () => {

--- a/extensions/discord/src/monitor/message-text.ts
+++ b/extensions/discord/src/monitor/message-text.ts
@@ -14,24 +14,22 @@ import {
 import { formatDiscordMediaText } from "./message-media.js";
 
 export function resolveDiscordEmbedText(
-  embed?: { title?: string | null; description?: string | null } | null,
+  embeds?: readonly { title?: string | null; description?: string | null }[] | null,
 ): string {
-  const title = normalizeOptionalString(embed?.title) ?? "";
-  const description = normalizeOptionalString(embed?.description) ?? "";
-  if (title && description) {
-    return `${title}\n${description}`;
-  }
-  return title || description || "";
+  return (embeds ?? [])
+    .flatMap(({ title, description }) => [
+      normalizeOptionalString(title),
+      normalizeOptionalString(description),
+    ])
+    .filter(Boolean)
+    .join("\n");
 }
 
 export function resolveDiscordMessageText(
   message: Message,
   options?: { fallbackText?: string; includeForwarded?: boolean },
 ): string {
-  const embedText = resolveDiscordEmbedText(
-    (message.embeds?.[0] as { title?: string | null; description?: string | null } | undefined) ??
-      null,
-  );
+  const embedText = resolveDiscordEmbedText(message.embeds);
   const componentText = extractDiscordComponentsV2Text(resolveDiscordMessageComponents(message));
   const rawText =
     normalizeOptionalString(message.content) ||
@@ -175,7 +173,7 @@ function resolveDiscordSnapshotMessageText(snapshot: DiscordSnapshotMessage): st
     attachments: snapshot.attachments ?? undefined,
     stickers: resolveDiscordSnapshotStickers(snapshot),
   });
-  const embedText = resolveDiscordEmbedText(snapshot.embeds?.[0]);
+  const embedText = resolveDiscordEmbedText(snapshot.embeds);
   const componentText = extractDiscordComponentsV2Text(snapshot.components);
   const text = content || embedText || componentText;
   return [text, attachmentText].filter(Boolean).join("\n");

--- a/extensions/discord/src/monitor/threading.starter.test.ts
+++ b/extensions/discord/src/monitor/threading.starter.test.ts
@@ -128,6 +128,16 @@ describe("resolveDiscordThreadStarter", () => {
     });
   });
 
+  it("preserves ordered text from later embeds in REST-fetched thread starters", async () => {
+    const { result } = await resolveStarter({
+      message: createStarterMessage({
+        embeds: [{}, { title: "Alert", description: "Details" }, { description: "Follow-up" }],
+      }),
+    });
+
+    expect(requireThreadStarter(result).text).toBe("Alert\nDetails\nFollow-up");
+  });
+
   it("prefers starter content over embed fallback text", async () => {
     const { result } = await resolveStarter({
       message: createStarterMessage({

--- a/extensions/discord/src/monitor/threading.starter.ts
+++ b/extensions/discord/src/monitor/threading.starter.ts
@@ -187,7 +187,7 @@ function buildDiscordThreadStarterPayload(params: {
 
 function resolveDiscordThreadStarterText(starter: DiscordThreadStarterRestMessage): string {
   const content = normalizeOptionalString(starter.content) ?? "";
-  const embedText = resolveDiscordEmbedText(starter.embeds?.[0]);
+  const embedText = resolveDiscordEmbedText(starter.embeds);
   const forwardedText = resolveDiscordForwardedMessagesTextFromSnapshots(starter.message_snapshots);
   const text = content || embedText || forwardedText;
   const mediaText = formatDiscordMediaText({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users receiving Discord messages, forwarded messages, or thread starters containing multiple embeds would lose every embed after the first. Messages whose first embed contained only an image were incorrectly treated as empty and silently dropped even when later embeds contained readable text.

## Why This Change Was Made

The Discord plugin's canonical message-text extractor accepted only one embed, so every caller separately discarded the remainder of Discord's ordered embed array. It now normalizes title and description text from every embed in order, and direct ingestion, forwarded snapshots, message admission, and REST-fetched thread starters all reuse that single extraction owner.

## User Impact

OpenClaw now receives complete text from multi-embed Discord messages and no longer silently drops otherwise valid embed-only messages when their first embed has no text. Existing message-content precedence, attachment handling, forwarded-message labels, and thread ownership remain unchanged.

## Evidence

- Four authentic regressions failed against the original implementation and pass with the fix: direct multi-embed extraction, forwarded snapshots, Discord admission, and REST-fetched thread starters.
- Focused Discord monitor suites cover the canonical owner and affected sibling paths.
- The upstream Discord API v10 message contract declares embeds as an ordered APIEmbed array.
- Production delta: +11/-13 (net -2); regression tests: +73/-0.
- Independent architectural review and authenticated Codex review found no actionable issues.
- Live Discord account proof is unavailable in this isolated checkout; the real plugin ingress and REST-message boundaries are exercised with deterministic Discord-shaped payloads instead.
