### PR TITLE
perf(ui): keep config render helpers out of startup

### DIFF
--- a/ui/src/components/config-form.array-items.ts
+++ b/ui/src/components/config-form.array-items.ts
@@ -1,4 +1,4 @@
-import { schemaType, type JsonSchema } from "./config-form.shared.ts";
+import { schemaType, type JsonSchema } from "../lib/config-form-utils.ts";
 
 export function collectAllOfSchemas(schema: JsonSchema): JsonSchema[] {
   const result: JsonSchema[] = [];

--- a/ui/src/components/config-form.search.ts
+++ b/ui/src/components/config-form.search.ts
@@ -1,7 +1,7 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { ConfigUiHints } from "../api/types.ts";
+import { hintForPath, humanize, schemaType, type JsonSchema } from "../lib/config-form-utils.ts";
 import { arrayItemSchema, arrayItemSchemaIndexes } from "./config-form.array-items.ts";
-import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 
 export type ConfigSearchCriteria = {
   text: string;

--- a/ui/src/components/config-form.shared.ts
+++ b/ui/src/components/config-form.shared.ts
@@ -1,72 +1,16 @@
 import { isSensitiveConfigPath } from "../../../src/config/sensitive-paths.js";
 import type { ConfigUiHint, ConfigUiHints } from "../api/types.ts";
-// Control UI view renders config form.shared screen content.
 import { t } from "../i18n/index.ts";
+import { hintForPath, pathKey } from "../lib/config-form-utils.ts";
 
-export type JsonSchema = {
-  type?: string | string[];
-  title?: string;
-  description?: string;
-  tags?: string[];
-  "x-tags"?: string[];
-  properties?: Record<string, JsonSchema>;
-  required?: string[];
-  items?: JsonSchema | JsonSchema[];
-  additionalItems?: JsonSchema | boolean;
-  additionalProperties?: JsonSchema | boolean;
-  enum?: unknown[];
-  enumIncludesNull?: boolean;
-  const?: unknown;
-  default?: unknown;
-  minimum?: number;
-  maximum?: number;
-  exclusiveMinimum?: number;
-  exclusiveMaximum?: number;
-  multipleOf?: number;
-  minLength?: number;
-  maxLength?: number;
-  pattern?: string;
-  minItems?: number;
-  maxItems?: number;
-  uniqueItems?: boolean;
-  anyOf?: JsonSchema[];
-  oneOf?: JsonSchema[];
-  allOf?: JsonSchema[];
-  nullable?: boolean;
-};
-
-export function schemaType(schema: JsonSchema): string | undefined {
-  if (!schema) {
-    return undefined;
-  }
-  if (Array.isArray(schema.type)) {
-    return schema.type.find((type) => type !== "null") ?? schema.type[0];
-  }
-  return schema.type;
-}
-
-export function schemaMayAcceptString(schema: JsonSchema): boolean {
-  const declaredTypes = Array.isArray(schema.type) ? schema.type : schema.type ? [schema.type] : [];
-  if (declaredTypes.length > 0 && !declaredTypes.includes("string")) {
-    return false;
-  }
-  if (schema.const !== undefined && typeof schema.const !== "string") {
-    return false;
-  }
-  if (schema.enum && !schema.enum.some((entry) => typeof entry === "string")) {
-    return false;
-  }
-  if (schema.allOf && !schema.allOf.every(schemaMayAcceptString)) {
-    return false;
-  }
-  if (schema.anyOf && !schema.anyOf.some(schemaMayAcceptString)) {
-    return false;
-  }
-  if (schema.oneOf && !schema.oneOf.some(schemaMayAcceptString)) {
-    return false;
-  }
-  return true;
-}
+export {
+  hintForPath,
+  humanize,
+  pathKey,
+  schemaMayAcceptString,
+  schemaType,
+  type JsonSchema,
+} from "../lib/config-form-utils.ts";
 
 export function configFieldId(path: Array<string | number>, suffix: string): string {
   const key =
@@ -84,47 +28,6 @@ export function configFieldId(path: Array<string | number>, suffix: string): str
           })
           .join("_");
   return `config-field-${key}-${suffix}`;
-}
-
-export function pathKey(path: Array<string | number>): string {
-  return path.filter((segment) => typeof segment === "string").join(".");
-}
-
-export function hintForPath(path: Array<string | number>, hints: ConfigUiHints) {
-  const key = pathKey(path);
-  const direct = hints[key];
-  if (direct) {
-    return direct;
-  }
-  const segments = path.map(String);
-  for (const [hintKey, hint] of Object.entries(hints)) {
-    if (!hintKey.includes("*")) {
-      continue;
-    }
-    const hintSegments = hintKey.split(".");
-    if (hintSegments.length !== segments.length) {
-      continue;
-    }
-    let match = true;
-    for (let i = 0; i < segments.length; i += 1) {
-      if (hintSegments[i] !== "*" && hintSegments[i] !== segments[i]) {
-        match = false;
-        break;
-      }
-    }
-    if (match) {
-      return hint;
-    }
-  }
-  return undefined;
-}
-
-export function humanize(raw: string) {
-  return raw
-    .replace(/_/g, " ")
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/\s+/g, " ")
-    .replace(/^./, (m) => m.toUpperCase());
 }
 
 const ENV_VAR_PLACEHOLDER_PATTERN = /^\$\{[^}]*\}$/;

--- a/ui/src/components/config-form.tiers.ts
+++ b/ui/src/components/config-form.tiers.ts
@@ -1,5 +1,5 @@
 import type { ConfigUiHints } from "../api/types.ts";
-import { hintForPath, type JsonSchema } from "./config-form.shared.ts";
+import { hintForPath, type JsonSchema } from "../lib/config-form-utils.ts";
 
 type ConfigSchemaTierSplit = {
   common: JsonSchema | null;

--- a/ui/src/lib/config-form-utils.ts
+++ b/ui/src/lib/config-form-utils.ts
@@ -1,5 +1,101 @@
 // Control UI controller manages form utils gateway state.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ConfigUiHints } from "../api/types.ts";
+
+export type JsonSchema = {
+  type?: string | string[];
+  title?: string;
+  description?: string;
+  tags?: string[];
+  "x-tags"?: string[];
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  items?: JsonSchema | JsonSchema[];
+  additionalItems?: JsonSchema | boolean;
+  additionalProperties?: JsonSchema | boolean;
+  enum?: unknown[];
+  enumIncludesNull?: boolean;
+  const?: unknown;
+  default?: unknown;
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: number;
+  exclusiveMaximum?: number;
+  multipleOf?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  minItems?: number;
+  maxItems?: number;
+  uniqueItems?: boolean;
+  anyOf?: JsonSchema[];
+  oneOf?: JsonSchema[];
+  allOf?: JsonSchema[];
+  nullable?: boolean;
+};
+
+export function schemaType(schema: JsonSchema): string | undefined {
+  if (!schema) {
+    return undefined;
+  }
+  if (Array.isArray(schema.type)) {
+    return schema.type.find((type) => type !== "null") ?? schema.type[0];
+  }
+  return schema.type;
+}
+
+export function schemaMayAcceptString(schema: JsonSchema): boolean {
+  const declaredTypes = Array.isArray(schema.type) ? schema.type : schema.type ? [schema.type] : [];
+  if (declaredTypes.length > 0 && !declaredTypes.includes("string")) {
+    return false;
+  }
+  if (schema.const !== undefined && typeof schema.const !== "string") {
+    return false;
+  }
+  if (schema.enum && !schema.enum.some((entry) => typeof entry === "string")) {
+    return false;
+  }
+  if (schema.allOf && !schema.allOf.every(schemaMayAcceptString)) {
+    return false;
+  }
+  if (schema.anyOf && !schema.anyOf.some(schemaMayAcceptString)) {
+    return false;
+  }
+  return !schema.oneOf || schema.oneOf.some(schemaMayAcceptString);
+}
+
+export function pathKey(path: Array<string | number>): string {
+  return path.filter((segment) => typeof segment === "string").join(".");
+}
+
+export function hintForPath(path: Array<string | number>, hints: ConfigUiHints) {
+  const direct = hints[pathKey(path)];
+  if (direct) {
+    return direct;
+  }
+  const segments = path.map(String);
+  for (const [hintKey, hint] of Object.entries(hints)) {
+    if (!hintKey.includes("*")) {
+      continue;
+    }
+    const hintSegments = hintKey.split(".");
+    if (
+      hintSegments.length === segments.length &&
+      hintSegments.every((segment, index) => segment === "*" || segment === segments[index])
+    ) {
+      return hint;
+    }
+  }
+  return undefined;
+}
+
+export function humanize(raw: string) {
+  return raw
+    .replace(/_/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\s+/g, " ")
+    .replace(/^./, (m) => m.toUpperCase());
+}
 
 export function cloneConfigObject<T>(value: T): T {
   return structuredClone(value);

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -5,18 +5,16 @@ import {
 import { GatewayRequestError } from "../../api/gateway.ts";
 import type { ConfigSnapshot } from "../../api/types.ts";
 import { coerceConfigFormNumberString } from "../../components/config-form.numeric.ts";
-import {
-  schemaMayAcceptString,
-  schemaType,
-  type JsonSchema,
-} from "../../components/config-form.shared.ts";
 import { t } from "../../i18n/index.ts";
 import {
   cloneConfigObject,
   removePathValue,
   sanitizeRedactedFormForSubmit,
+  schemaMayAcceptString,
+  schemaType,
   serializeConfigForm,
   setPathValue,
+  type JsonSchema,
 } from "../config-form-utils.ts";
 import { formatUiError } from "../format-error.ts";
 import { parseJson5Text, warmJson5 } from "../json5-runtime.ts";

--- a/ui/src/pages/config/settings-search.ts
+++ b/ui/src/pages/config/settings-search.ts
@@ -10,9 +10,9 @@ import {
   matchesConfigSectionSearch,
   parseConfigSearchQuery,
 } from "../../components/config-form.search.ts";
-import { schemaType, type JsonSchema } from "../../components/config-form.shared.ts";
 import { splitConfigSchemaByTier } from "../../components/config-form.tiers.ts";
 import { t } from "../../i18n/index.ts";
+import { schemaType, type JsonSchema } from "../../lib/config-form-utils.ts";
 import { configPageForSection } from "./config-sections.ts";
 import { memoryVisibleSchemaKeys } from "./memory-schema.ts";
 import { SETTINGS_SEARCH_TARGETS, type SettingsSearchTarget } from "./settings-targets.ts";


### PR DESCRIPTION
## What Problem This Solves

Resolves a current-main Linux Node 24.15 Control UI build failure: the compressed startup bundle reached 348,350 bytes, exceeding the unchanged 348,079-byte startup limit by 271 bytes and breaking the full production build.

## Why This Change Was Made

The startup config-draft and settings-search graphs imported generic schema/path/search helpers from the rendering-owned config shared module, which also imports sensitive-path classification and translation runtime. Move those generic helpers into the already-startup config-form utility owner and keep sensitive rendering helpers lazy; preserve existing imports and caller APIs through the rendering module's re-exports. This removes three net production lines (+112/-115) without changing startup budgets, baselines, tolerances, dependencies, generated locales, or configuration behavior.

## User Impact

Control UI production builds pass their existing startup budget on Linux and ship a smaller initial bundle. Settings search, schema coercion, config editing, redaction, localization, and UI appearance are unchanged.

## Evidence

- Linux Node 24.15 startup gzip: **348,350 -> 347,674 bytes (-676)**; before: FAIL, 271 bytes over the unchanged 348,079-byte limit; after: PASS, 405 bytes below it.
- macOS Node 24 startup gzip: **347,701 -> 347,090 bytes (-611)**.
- Linux Node 24.15 full `pnpm build`: passed after the owner-boundary repair.
- Local `pnpm ui:build`: passed.
- Focused schema, config-draft, search, tier, and utility suites: **108 tests passed** across six test files.
- Real-Chromium config-form and config-page coverage: **154 browser tests passed** across ten test files.
- Complete changed-file format, lint, UI/core typecheck, dependency/security guards, dead-export, and i18n checks: passed.
- Fresh P1 autoreview: clean; `git diff --check`: clean.
- Production LOC: **+112/-115, net -3**; test LOC: **+0/-0**. No UI appearance or behavior changes, so screenshots are not applicable.
