### PR TITLE
fix(pr): batch ignored transition checks

### DIFF
--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -72,13 +72,16 @@ require_no_ignored_transition_paths() {
         return 1
         ;;
     esac
-    if IFS= read -r -d '' ignored < <(
-      git ls-files --others --ignored --exclude-standard -z -- ":(literal)$file"
-    ); then
-      refuse_review_transition "$pr" "ignored file '$ignored' would be overwritten by the journaled transition."
-      return 1
-    fi
   done < <(git diff --name-only --no-renames -z "$source" "$target")
+
+  # Ask Git about every transition path at once. Per-path ignored-file scans
+  # become prohibitively slow when a PR is far behind main.
+  if IFS= read -r -d '' ignored < <(
+    git check-ignore -z --stdin < <(git diff --name-only --no-renames -z "$source" "$target")
+  ); then
+    refuse_review_transition "$pr" "ignored file '$ignored' would be overwritten by the journaled transition."
+    return 1
+  fi
 }
 
 validate_review_transition_state() {

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -77,7 +77,14 @@ require_no_ignored_transition_paths() {
   # Ask Git about every transition path at once. Per-path ignored-file scans
   # become prohibitively slow when a PR is far behind main.
   if IFS= read -r -d '' ignored < <(
-    git check-ignore -z --stdin < <(git diff --name-only --no-renames -z "$source" "$target")
+    git check-ignore -z --stdin < <(git diff --name-only --no-renames -z "$source" "$target") |
+      while IFS= read -r -d '' candidate; do
+        # check-ignore also reports matching paths that do not exist. Only an
+        # existing ignored entry can be overwritten by the transition.
+        if [ -e "$candidate" ] || [ -L "$candidate" ]; then
+          printf '%s\0' "$candidate"
+        fi
+      done
   ); then
     refuse_review_transition "$pr" "ignored file '$ignored' would be overwritten by the journaled transition."
     return 1

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -334,6 +334,24 @@ describePosix("scripts/pr worktree containment", () => {
     expectCanonicalCheckoutUnchanged(fixture);
   });
 
+  it("allows a missing transition path that merely matches an ignore rule", () => {
+    const fixture = createReviewFixture();
+    const result = runShell(fixture, [
+      "review_init 42",
+      "review_checkout_pr 42",
+      'printf "main-only.txt\\n" >> "$(git rev-parse --git-path info/exclude)"',
+      "git check-ignore -q main-only.txt",
+      "test ! -e main-only.txt",
+      "review_checkout_main 42",
+    ]);
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    expect(readFileSync(join(fixture.root, ".worktrees", "pr-42", "main-only.txt"), "utf8")).toBe(
+      "main-only\n",
+    );
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+
   it("checks every transition target for ignored collisions with bounded Git queries", () => {
     const fixture = createReviewFixture();
     git(fixture.root, "checkout", "review/pr");

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import {
   existsSync,
+  chmodSync,
   mkdirSync,
   readFileSync,
   realpathSync,
@@ -109,7 +110,7 @@ function makeStaleWorktreeDir(fixture: Fixture) {
   mkdirSync(join(fixture.root, ".worktrees", "pr-42"), { recursive: true });
 }
 
-function runShell(fixture: Fixture, commands: string[]) {
+function runShell(fixture: Fixture, commands: string[], env?: NodeJS.ProcessEnv) {
   return spawnSync(
     "bash",
     [
@@ -132,7 +133,7 @@ function runShell(fixture: Fixture, commands: string[]) {
       reviewScript,
       fixture.root,
     ],
-    { cwd: fixture.root, encoding: "utf8" },
+    { cwd: fixture.root, encoding: "utf8", env: { ...process.env, ...env } },
   );
 }
 
@@ -330,6 +331,49 @@ describePosix("scripts/pr worktree containment", () => {
     );
     expect(readFileSync(join(worktree, "main-only.txt"), "utf8")).toBe("foreign ignored\n");
     expect(existsSync(join(worktree, ".local", "review-transition.json"))).toBe(true);
+    expectCanonicalCheckoutUnchanged(fixture);
+  });
+
+  it("checks every transition target for ignored collisions with bounded Git queries", () => {
+    const fixture = createReviewFixture();
+    git(fixture.root, "checkout", "review/pr");
+    for (let index = 0; index < 32; index += 1) {
+      writeFileSync(join(fixture.root, `transition-batch-${index}.txt`), `${index}\n`);
+    }
+    git(fixture.root, "add", ".");
+    git(fixture.root, "commit", "-m", "add transition batch");
+    git(fixture.root, "update-ref", "refs/pull/42/head", "HEAD");
+    git(fixture.root, "checkout", fixture.siblingBranch);
+
+    const tools = join(fixture.root, "tools");
+    const commandLog = join(fixture.root, "git-commands.log");
+    mkdirSync(tools);
+    const realGit = spawnSync("bash", ["-lc", "command -v git"], {
+      encoding: "utf8",
+    }).stdout.trim();
+    writeFileSync(
+      join(tools, "git"),
+      [
+        "#!/usr/bin/env bash",
+        'printf "%s\\n" "$*" >> "$GIT_COMMAND_LOG"',
+        'exec "$REAL_GIT" "$@"',
+      ].join("\n"),
+    );
+    chmodSync(join(tools, "git"), 0o755);
+
+    const result = runShell(fixture, ["review_checkout_pr 42"], {
+      GIT_COMMAND_LOG: commandLog,
+      PATH: `${tools}:${process.env.PATH ?? ""}`,
+      REAL_GIT: realGit,
+    });
+
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+    const commands = readFileSync(commandLog, "utf8").trim().split("\n");
+    // checkout validates once before journaling and again while recovering it.
+    expect(commands.filter((command) => command.startsWith("check-ignore "))).toHaveLength(2);
+    expect(
+      commands.filter((command) => command.startsWith("ls-files --others --ignored ")),
+    ).toHaveLength(0);
     expectCanonicalCheckoutUnchanged(fixture);
   });
 });


### PR DESCRIPTION
## Summary

Keep the existing fail-closed ignored-file collision guard while batching its Git query across every transition path. This prevents `scripts/pr review-checkout-pr` from performing a full ignored-file scan once per changed path when a PR is behind `main`.

## Proof

- Red: new containment regression observed the prior implementation issue one `git ls-files --others --ignored` call per transition path.
- Green: `node scripts/run-vitest.mjs test/scripts/pr-worktree-containment.test.ts` (11 passed), including both the preserved collision refusal and the bounded-query check.
- `node scripts/check-changed.mjs -- scripts/pr-lib/worktree.sh test/scripts/pr-worktree-containment.test.ts`: all scoped guards passed; the final test-root typecheck hit pre-existing unrelated errors in `src/agents/sandbox*`, `src/config/includes.ts`, `src/gateway/control-ui.ts`, `src/hooks/workspace.ts`, and `src/skills/loading/local-loader.ts`.
- `autoreview --mode local`: clean; no accepted/actionable findings.
