### PR TITLE
fix(gateway): recover chat when session subscriptions stop responding

### DIFF
--- a/packages/gateway-client/src/session-subscriptions.test.ts
+++ b/packages/gateway-client/src/session-subscriptions.test.ts
@@ -273,7 +273,28 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
 
     expect(failure).toBeInstanceOf(GatewayProtocolRequestTimeoutError);
     await expect(recovered).resolves.toEqual({ key: "healthy", agentId: null });
-    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "sessions.messages.unsubscribe",
+      { key: "stalled" },
+      { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+    );
+  });
+
+  it("does not compensate an unsent subscription timeout", async () => {
+    const timeout = new GatewayProtocolRequestTimeoutError({
+      method: "sessions.messages.subscribe",
+      timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+      requestSent: false,
+    });
+    const request = vi.fn(async () => {
+      throw timeout;
+    });
+    const coordinator = new GatewaySessionMessageSubscriptionCoordinator({ request });
+
+    await expect(coordinator.acquire("main")).rejects.toBe(timeout);
+    expect(request).toHaveBeenCalledOnce();
   });
 
   it("retries a rejected final unsubscribe with the original live lease", async () => {

--- a/packages/gateway-client/src/session-subscriptions.test.ts
+++ b/packages/gateway-client/src/session-subscriptions.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GatewayProtocolRequestTimeoutError,
+  type GatewayProtocolRequestOptions,
+} from "./protocol-request.js";
 import {
   GatewaySessionMessageSubscriptionCoordinator,
   getGatewaySessionMessageSubscriptionCoordinator,
@@ -6,6 +10,7 @@ import {
   resetGatewaySessionMessageSubscriptionCoordinator,
   type GatewaySessionMessageRequestClient,
 } from "./session-subscriptions.js";
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "./timeouts.js";
 
 type SessionRequestHandler = (method: string, params: Record<string, unknown>) => Promise<unknown>;
 
@@ -15,7 +20,9 @@ function createClient(
 ) {
   const request = vi.fn(handler);
   return {
-    client: { request } as unknown as GatewaySessionMessageRequestClient,
+    client: {
+      request: (method: string, params: Record<string, unknown>) => request(method, params),
+    } as unknown as GatewaySessionMessageRequestClient,
     request,
   };
 }
@@ -29,6 +36,46 @@ function deferred<T>() {
   });
   return { promise, resolve, reject };
 }
+
+function createStalledRequestClient(stalledMethod: string, stalledKey: string) {
+  let shouldStall = true;
+  const request = vi.fn(
+    (
+      method: string,
+      params: Record<string, unknown>,
+      options?: GatewayProtocolRequestOptions,
+    ): Promise<unknown> => {
+      if (shouldStall && method === stalledMethod && params.key === stalledKey) {
+        shouldStall = false;
+        return new Promise((_, reject) => {
+          const timeoutMs = options?.timeoutMs;
+          if (typeof timeoutMs === "number") {
+            setTimeout(
+              () =>
+                reject(
+                  new GatewayProtocolRequestTimeoutError({
+                    method,
+                    timeoutMs,
+                    requestSent: true,
+                  }),
+                ),
+              timeoutMs,
+            );
+          }
+        });
+      }
+      return Promise.resolve(method === "sessions.messages.subscribe" ? { key: params.key } : {});
+    },
+  );
+  return {
+    client: { request } as unknown as GatewaySessionMessageRequestClient,
+    request,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("GatewaySessionMessageSubscriptionCoordinator", () => {
   it("shares one in-flight wire subscription across canonical session aliases", async () => {
@@ -207,6 +254,28 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
     await expect(main).resolves.toEqual({ key: "global", agentId: "main" });
   });
 
+  it("releases another session after its agent's first subscription times out", async () => {
+    vi.useFakeTimers();
+    const { client, request } = createStalledRequestClient(
+      "sessions.messages.subscribe",
+      "stalled",
+    );
+    const coordinator = new GatewaySessionMessageSubscriptionCoordinator(client);
+    let failure: unknown;
+
+    void coordinator.acquire("stalled").catch((error: unknown) => {
+      failure = error;
+    });
+    const recovered = coordinator.acquire("healthy");
+    expect(request).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
+
+    expect(failure).toBeInstanceOf(GatewayProtocolRequestTimeoutError);
+    await expect(recovered).resolves.toEqual({ key: "healthy", agentId: null });
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
   it("retries a rejected final unsubscribe with the original live lease", async () => {
     let unsubscribeCount = 0;
     const { client, request } = createClient(async (method, params) => {
@@ -229,6 +298,23 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
 
     expect(unsubscribeCount).toBe(2);
     expect(request).toHaveBeenCalledTimes(3);
+    await expect(coordinator.release(subscription)).resolves.toBeUndefined();
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+
+  it("keeps a timed-out final unsubscribe retryable on its original lease", async () => {
+    vi.useFakeTimers();
+    const { client, request } = createStalledRequestClient("sessions.messages.unsubscribe", "main");
+    const coordinator = new GatewaySessionMessageSubscriptionCoordinator(client);
+    const subscription = await coordinator.acquire("main");
+    let failure: unknown;
+
+    void coordinator.release(subscription).catch((error: unknown) => {
+      failure = error;
+    });
+    await vi.advanceTimersByTimeAsync(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
+
+    expect(failure).toBeInstanceOf(GatewayProtocolRequestTimeoutError);
     await expect(coordinator.release(subscription)).resolves.toBeUndefined();
     expect(request).toHaveBeenCalledTimes(3);
   });

--- a/packages/gateway-client/src/session-subscriptions.ts
+++ b/packages/gateway-client/src/session-subscriptions.ts
@@ -349,10 +349,12 @@ export class GatewaySessionMessageSubscriptionCoordinator {
           );
         } catch (recoveryError) {
           if (!this.#retired) {
-            throw new AggregateError(
+            const subscriptionRecoveryFailure = new AggregateError(
               [error, recoveryError],
               "session message subscription recovery failed",
+              { cause: recoveryError },
             );
+            throw subscriptionRecoveryFailure;
           }
         }
         throw error;

--- a/packages/gateway-client/src/session-subscriptions.ts
+++ b/packages/gateway-client/src/session-subscriptions.ts
@@ -1,5 +1,12 @@
+import type { GatewayProtocolRequestOptions } from "./protocol-request.js";
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "./timeouts.js";
+
 export type GatewaySessionMessageRequestClient = {
-  request<T = unknown>(method: string, params: Record<string, unknown>): Promise<T>;
+  request<T = unknown>(
+    method: string,
+    params: Record<string, unknown>,
+    options?: GatewayProtocolRequestOptions,
+  ): Promise<T>;
 };
 
 export type GatewaySessionMessageSubscription = {
@@ -189,7 +196,11 @@ export class GatewaySessionMessageSubscriptionCoordinator {
     // Retain both the handle and its wire entry until the Gateway acknowledges
     // the last release. A rejected unsubscribe must remain genuinely retryable.
     const request = this.#client
-      .request("sessions.messages.unsubscribe", sessionSubscriptionParams(entry.key, entry.agentId))
+      .request(
+        "sessions.messages.unsubscribe",
+        sessionSubscriptionParams(entry.key, entry.agentId),
+        { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+      )
       .then(() => {
         this.#finishRelease(subscription, owner, true);
       });
@@ -308,10 +319,14 @@ export class GatewaySessionMessageSubscriptionCoordinator {
     entry: SessionMessageSubscriptionEntry,
     includeApprovals: boolean,
   ): Promise<SessionMessageSubscriptionResponse> {
-    const result = await this.#client.request("sessions.messages.subscribe", {
-      ...sessionSubscriptionParams(entry.key, entry.agentId),
-      ...(includeApprovals ? { includeApprovals: true } : {}),
-    });
+    const result = await this.#client.request(
+      "sessions.messages.subscribe",
+      {
+        ...sessionSubscriptionParams(entry.key, entry.agentId),
+        ...(includeApprovals ? { includeApprovals: true } : {}),
+      },
+      { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+    );
     const response = result && typeof result === "object" ? result : null;
     const responseKey = response && "key" in response ? response.key : undefined;
     return {

--- a/packages/gateway-client/src/session-subscriptions.ts
+++ b/packages/gateway-client/src/session-subscriptions.ts
@@ -1,4 +1,7 @@
-import type { GatewayProtocolRequestOptions } from "./protocol-request.js";
+import {
+  GatewayProtocolRequestTimeoutError,
+  type GatewayProtocolRequestOptions,
+} from "./protocol-request.js";
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "./timeouts.js";
 
 export type GatewaySessionMessageRequestClient = {
@@ -319,14 +322,41 @@ export class GatewaySessionMessageSubscriptionCoordinator {
     entry: SessionMessageSubscriptionEntry,
     includeApprovals: boolean,
   ): Promise<SessionMessageSubscriptionResponse> {
-    const result = await this.#client.request(
-      "sessions.messages.subscribe",
-      {
-        ...sessionSubscriptionParams(entry.key, entry.agentId),
-        ...(includeApprovals ? { includeApprovals: true } : {}),
-      },
-      { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
-    );
+    const params = sessionSubscriptionParams(entry.key, entry.agentId);
+    const result = await this.#client
+      .request(
+        "sessions.messages.subscribe",
+        includeApprovals ? { ...params, includeApprovals: true } : params,
+        { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+      )
+      .catch(async (error: unknown) => {
+        if (
+          !(error instanceof GatewayProtocolRequestTimeoutError) ||
+          !error.requestSent ||
+          this.#retired
+        ) {
+          throw error;
+        }
+        try {
+          // A sent request can commit before its acknowledgment; preserve an existing
+          // plain lease while removing any unacknowledged approval authority.
+          await this.#client.request(
+            entry.handles.size > 0
+              ? "sessions.messages.subscribe"
+              : "sessions.messages.unsubscribe",
+            params,
+            { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+          );
+        } catch (recoveryError) {
+          if (!this.#retired) {
+            throw new AggregateError(
+              [error, recoveryError],
+              "session message subscription recovery failed",
+            );
+          }
+        }
+        throw error;
+      });
     const response = result && typeof result === "object" ? result : null;
     const responseKey = response && "key" in response ? response.key : undefined;
     return {

--- a/src/gateway/server-methods/sessions.messages-subscribe-approvals.test.ts
+++ b/src/gateway/server-methods/sessions.messages-subscribe-approvals.test.ts
@@ -1,6 +1,14 @@
 import { expectDefined } from "@openclaw/normalization-core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  GatewayProtocolClient,
+  GatewayProtocolRequestTimeoutError,
+  type GatewayProtocolSocketHandlers,
+} from "../../../packages/gateway-client/src/protocol-client.js";
+import { GatewaySessionMessageSubscriptionCoordinator } from "../../../packages/gateway-client/src/session-subscriptions.js";
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../../packages/gateway-client/src/timeouts.js";
 import type { SessionApprovalReplay } from "../../../packages/gateway-protocol/src/index.js";
+import { createSessionMessageSubscriberRegistry } from "../server-chat-state.js";
 import type {
   GatewayClient,
   GatewayRequestContext,
@@ -100,9 +108,124 @@ async function subscribe(params: {
   return respond;
 }
 
+function createCommittedSubscriptionBoundary(
+  options: {
+    holdApprovalUpgradeOnly?: boolean;
+    rejectRecovery?: boolean;
+  } = {},
+) {
+  const sessionKey = "agent:main:main";
+  const registry = createSessionMessageSubscriberRegistry();
+  const gatewayClient = createClient({ scopes: ["operator.admin"] });
+  const replay = {
+    sessionKey,
+    updatedAtMs: 42,
+    approvals: [],
+    truncated: false,
+  } satisfies SessionApprovalReplay;
+  const context = {
+    ...createContext({ replay }).context,
+    subscribeSessionMessageEvents: registry.subscribe,
+    unsubscribeSessionMessageEvents: registry.unsubscribe,
+  } as GatewayRequestContext;
+  const closed = vi.fn();
+  const delayedResponses: string[] = [];
+  let nextRequestId = 0;
+  let socketHandlers: GatewayProtocolSocketHandlers | undefined;
+  const protocol = new GatewayProtocolClient<Record<string, never>>({
+    createSocket: (handlers) => {
+      socketHandlers = handlers;
+      return {
+        isOpen: () => true,
+        send: (raw) => {
+          const request = JSON.parse(raw) as {
+            id: string;
+            method: string;
+            params: Record<string, unknown>;
+          };
+          const isRecovery =
+            request.method === "sessions.messages.unsubscribe" ||
+            (options.holdApprovalUpgradeOnly &&
+              request.method === "sessions.messages.subscribe" &&
+              request.params.includeApprovals !== true &&
+              nextRequestId > 1);
+          if (options.rejectRecovery && isRecovery) {
+            handlers.message(
+              JSON.stringify({
+                type: "res",
+                id: request.id,
+                ok: false,
+                error: { code: "UNAVAILABLE", message: "subscription recovery unavailable" },
+              }),
+            );
+            return;
+          }
+          const handler = expectDefined(
+            sessionSubscriptionHandlers[request.method],
+            `session subscription boundary handler ${request.method}`,
+          );
+          void handler({
+            req: { id: request.id } as never,
+            params: request.params,
+            context,
+            client: gatewayClient,
+            isWebchatConnect: () => false,
+            respond: (ok, payload, error) => {
+              const response = JSON.stringify({
+                type: "res",
+                id: request.id,
+                ok,
+                payload,
+                error,
+              });
+              if (
+                request.method === "sessions.messages.subscribe" &&
+                (!options.holdApprovalUpgradeOnly || request.params.includeApprovals === true)
+              ) {
+                delayedResponses.push(response);
+                return;
+              }
+              handlers.message(response);
+            },
+          } satisfies GatewayRequestHandlerOptions);
+        },
+        close: (code, reason) => {
+          closed(code, reason);
+          registry.unsubscribeAll(gatewayClient.connId ?? "");
+          handlers.close(code ?? 1000, reason ?? "stopped");
+        },
+      };
+    },
+    createRequestId: () => `subscription-${++nextRequestId}`,
+    buildConnectPlan: () => ({}),
+    buildConnectParams: (plan) => plan,
+    resolveClose: () => ({ retry: false, notify: false }),
+    handshake: { mode: "require-challenge", timeoutMs: 100 },
+    reconnect: { initialMs: 10, multiplier: 2, maxMs: 100 },
+  });
+  protocol.start();
+  return {
+    closed,
+    coordinator: new GatewaySessionMessageSubscriptionCoordinator(protocol),
+    gatewayClient,
+    protocol,
+    registry,
+    sessionKey,
+    deliverLateResponses() {
+      for (const response of delayedResponses) {
+        socketHandlers?.message(response);
+      }
+    },
+  };
+}
+
 describe("sessions.messages.subscribe approval opt-in", () => {
   beforeEach(() => {
     loadSessionEntryMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("allows an admin without a paired device and uses the exact scoped subscription key", async () => {
@@ -283,5 +406,96 @@ describe("sessions.messages.subscribe approval opt-in", () => {
     if (replayError) {
       expect(logError).toHaveBeenCalledWith(expect.stringContaining("database unavailable"));
     }
+  });
+
+  it.each([
+    { name: "plain", includeApprovals: false },
+    { name: "approval-enabled", includeApprovals: true },
+  ])(
+    "removes a committed $name observer when its subscription acknowledgment times out",
+    async ({ includeApprovals }) => {
+      vi.useFakeTimers();
+      const boundary = createCommittedSubscriptionBoundary();
+      let failure: unknown;
+      void boundary.coordinator.acquire("main", { includeApprovals }).catch((error: unknown) => {
+        failure = error;
+      });
+
+      expect(
+        boundary.registry.get(boundary.sessionKey).has(boundary.gatewayClient.connId ?? ""),
+      ).toBe(true);
+      expect(
+        boundary.registry
+          .getApprovals(boundary.sessionKey)
+          .has(boundary.gatewayClient.connId ?? ""),
+      ).toBe(includeApprovals);
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
+
+      expect(failure).toBeInstanceOf(GatewayProtocolRequestTimeoutError);
+      expect(boundary.registry.get(boundary.sessionKey)).toEqual(new Set());
+      expect(boundary.registry.getApprovals(boundary.sessionKey)).toEqual(new Set());
+      boundary.deliverLateResponses();
+      expect(boundary.registry.get(boundary.sessionKey)).toEqual(new Set());
+      boundary.protocol.stop();
+    },
+  );
+
+  it("removes timed-out approval authority while preserving an existing plain observer", async () => {
+    vi.useFakeTimers();
+    const boundary = createCommittedSubscriptionBoundary({ holdApprovalUpgradeOnly: true });
+    const plain = await boundary.coordinator.acquire("main");
+    let failure: unknown;
+
+    void boundary.coordinator
+      .acquire("main", { includeApprovals: true })
+      .catch((error: unknown) => {
+        failure = error;
+      });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(boundary.registry.getApprovals(boundary.sessionKey)).toEqual(
+      new Set([boundary.gatewayClient.connId]),
+    );
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
+
+    expect(failure).toBeInstanceOf(GatewayProtocolRequestTimeoutError);
+    expect(boundary.registry.get(boundary.sessionKey)).toEqual(
+      new Set([boundary.gatewayClient.connId]),
+    );
+    expect(boundary.registry.getApprovals(boundary.sessionKey)).toEqual(new Set());
+    boundary.deliverLateResponses();
+    expect(boundary.registry.getApprovals(boundary.sessionKey)).toEqual(new Set());
+    await boundary.coordinator.release(plain);
+    boundary.protocol.stop();
+  });
+
+  it("retires the committed approval observer when both acknowledgment and recovery fail", async () => {
+    vi.useFakeTimers();
+    const boundary = createCommittedSubscriptionBoundary({ rejectRecovery: true });
+    let failure: unknown;
+
+    void boundary.coordinator
+      .acquire("main", { includeApprovals: true })
+      .catch((error: unknown) => {
+        failure = error;
+        if (error instanceof AggregateError) {
+          boundary.protocol.closeSocket(4000, "session subscription recovery failed");
+        }
+      });
+    expect(boundary.registry.getApprovals(boundary.sessionKey)).toEqual(
+      new Set([boundary.gatewayClient.connId]),
+    );
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS);
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect(boundary.closed).toHaveBeenCalledExactlyOnceWith(
+      4000,
+      "session subscription recovery failed",
+    );
+    expect(boundary.registry.get(boundary.sessionKey)).toEqual(new Set());
+    expect(boundary.registry.getApprovals(boundary.sessionKey)).toEqual(new Set());
+    boundary.protocol.stop();
   });
 });

--- a/ui/src/lib/sessions/index-subscriptions.test.ts
+++ b/ui/src/lib/sessions/index-subscriptions.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment node
+import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createSessionCapability } from "./index.ts";
+
+const subscriptionRequestOptions = { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS };
 
 function createGateway(client: GatewayBrowserClient) {
   return {
@@ -41,12 +44,18 @@ describe("createSessionCapability message subscriptions", () => {
       "temporary observer release failure",
     );
     await expect(sessions.unsubscribeMessages(subscription)).resolves.toBeUndefined();
-    expect(request).toHaveBeenNthCalledWith(2, "sessions.messages.unsubscribe", {
-      key: "agent:main:main",
-    });
-    expect(request).toHaveBeenNthCalledWith(3, "sessions.messages.unsubscribe", {
-      key: "agent:main:main",
-    });
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "sessions.messages.unsubscribe",
+      { key: "agent:main:main" },
+      subscriptionRequestOptions,
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      3,
+      "sessions.messages.unsubscribe",
+      { key: "agent:main:main" },
+      subscriptionRequestOptions,
+    );
     sessions.dispose();
   });
 
@@ -70,15 +79,19 @@ describe("createSessionCapability message subscriptions", () => {
       second.subscribeMessages("agent:main:main"),
     ]);
 
-    expect(request).toHaveBeenCalledExactlyOnceWith("sessions.messages.subscribe", {
-      key: "main",
-    });
+    expect(request).toHaveBeenCalledExactlyOnceWith(
+      "sessions.messages.subscribe",
+      { key: "main" },
+      subscriptionRequestOptions,
+    );
     await first.unsubscribeMessages(firstLease);
     expect(request).toHaveBeenCalledOnce();
     await second.unsubscribeMessages(secondLease);
-    expect(request).toHaveBeenLastCalledWith("sessions.messages.unsubscribe", {
-      key: "agent:main:main",
-    });
+    expect(request).toHaveBeenLastCalledWith(
+      "sessions.messages.unsubscribe",
+      { key: "agent:main:main" },
+      subscriptionRequestOptions,
+    );
     first.dispose();
     second.dispose();
   });
@@ -110,10 +123,12 @@ describe("createSessionCapability message subscriptions", () => {
       includeApprovals: true,
       approvalReplay: replay,
     });
-    expect(request).toHaveBeenNthCalledWith(2, "sessions.messages.subscribe", {
-      key: "main",
-      includeApprovals: true,
-    });
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "sessions.messages.subscribe",
+      { key: "main", includeApprovals: true },
+      subscriptionRequestOptions,
+    );
     await sessions.unsubscribeMessages(approval);
     await sessions.unsubscribeMessages(plain);
     expect(request).toHaveBeenCalledTimes(2);
@@ -142,14 +157,18 @@ describe("createSessionCapability message subscriptions", () => {
 
     expect(main).toEqual({ key: "global", agentId: "main" });
     expect(research).toEqual({ key: "global", agentId: "research" });
-    expect(request).toHaveBeenNthCalledWith(1, "sessions.messages.subscribe", {
-      key: "global",
-      agentId: "main",
-    });
-    expect(request).toHaveBeenNthCalledWith(2, "sessions.messages.subscribe", {
-      key: "global",
-      agentId: "research",
-    });
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      "sessions.messages.subscribe",
+      { key: "global", agentId: "main" },
+      subscriptionRequestOptions,
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "sessions.messages.subscribe",
+      { key: "global", agentId: "research" },
+      subscriptionRequestOptions,
+    );
     await sessions.unsubscribeMessages(main);
     await sessions.unsubscribeMessages(research);
     sessions.dispose();

--- a/ui/src/lib/sessions/index-subscriptions.test.ts
+++ b/ui/src/lib/sessions/index-subscriptions.test.ts
@@ -1,8 +1,12 @@
 // @vitest-environment node
-import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
+import {
+  DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+  GatewayProtocolRequestTimeoutError,
+} from "@openclaw/gateway-client/browser";
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createSessionCapability } from "./index.ts";
+import { createSessionScopedOperations } from "./session-scoped-operations.ts";
 
 const subscriptionRequestOptions = { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS };
 
@@ -172,5 +176,109 @@ describe("createSessionCapability message subscriptions", () => {
     await sessions.unsubscribeMessages(main);
     await sessions.unsubscribeMessages(research);
     sessions.dispose();
+  });
+
+  it("retires the current Gateway generation when a sent subscription cannot be recovered", async () => {
+    const timeout = new GatewayProtocolRequestTimeoutError({
+      method: "sessions.messages.subscribe",
+      timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+      requestSent: true,
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.messages.subscribe") {
+        throw timeout;
+      }
+      throw new Error("subscription recovery unavailable");
+    });
+    const forceReconnect = vi.fn();
+    const client = { request, forceReconnect } as unknown as GatewayBrowserClient;
+    const gateway = createGateway(client);
+    const sessions = createSessionCapability(gateway);
+    const anotherOwner = createSessionCapability(gateway);
+
+    const failures = await Promise.allSettled([
+      sessions.subscribeMessages("main", { includeApprovals: true }),
+      anotherOwner.subscribeMessages("main", { includeApprovals: true }),
+    ]);
+
+    expect(failures).toEqual([
+      { status: "rejected", reason: expect.any(AggregateError) },
+      { status: "rejected", reason: expect.any(AggregateError) },
+    ]);
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "sessions.messages.unsubscribe",
+      { key: "main" },
+      subscriptionRequestOptions,
+    );
+    expect(forceReconnect).toHaveBeenCalledExactlyOnceWith("session subscription recovery failed");
+    sessions.dispose();
+    anotherOwner.dispose();
+  });
+
+  it("keeps the current Gateway connection when its sent subscription is recovered", async () => {
+    const timeout = new GatewayProtocolRequestTimeoutError({
+      method: "sessions.messages.subscribe",
+      timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+      requestSent: true,
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.messages.subscribe") {
+        throw timeout;
+      }
+      return {};
+    });
+    const forceReconnect = vi.fn();
+    const client = { request, forceReconnect } as unknown as GatewayBrowserClient;
+    const sessions = createSessionCapability(createGateway(client));
+
+    await expect(sessions.subscribeMessages("main")).rejects.toBe(timeout);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(forceReconnect).not.toHaveBeenCalled();
+    sessions.dispose();
+  });
+
+  it("never reconnects a Gateway generation retired during subscription recovery", async () => {
+    const timeout = new GatewayProtocolRequestTimeoutError({
+      method: "sessions.messages.subscribe",
+      timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+      requestSent: true,
+    });
+    let recoveryStarted: () => void = () => undefined;
+    let rejectRecovery: (error: Error) => void = () => undefined;
+    const recovering = new Promise<void>((resolve) => {
+      recoveryStarted = resolve;
+    });
+    const recovery = new Promise<never>((_resolve, reject) => {
+      rejectRecovery = reject;
+    });
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.messages.subscribe") {
+        throw timeout;
+      }
+      recoveryStarted();
+      return await recovery;
+    });
+    const forceReconnect = vi.fn();
+    const client = { request, forceReconnect } as unknown as GatewayBrowserClient;
+    let current = true;
+    const operations = createSessionScopedOperations({
+      connection: {
+        capture: () => ({ client, epoch: 0 }),
+        isCurrent: () => current,
+      },
+      agentId: () => null,
+      refreshReplacement: async () => undefined,
+    });
+    const failure = operations.subscribeMessages("main").catch((error: unknown) => error);
+
+    await recovering;
+    current = false;
+    operations.retireConnection(client);
+    rejectRecovery(new Error("retired Gateway connection"));
+
+    await expect(failure).resolves.toBe(timeout);
+    expect(forceReconnect).not.toHaveBeenCalled();
+    operations.dispose();
   });
 });

--- a/ui/src/lib/sessions/index-subscriptions.test.ts
+++ b/ui/src/lib/sessions/index-subscriptions.test.ts
@@ -184,11 +184,12 @@ describe("createSessionCapability message subscriptions", () => {
       timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
       requestSent: true,
     });
+    const recoveryError = new Error("subscription recovery unavailable");
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.messages.subscribe") {
         throw timeout;
       }
-      throw new Error("subscription recovery unavailable");
+      throw recoveryError;
     });
     const forceReconnect = vi.fn();
     const client = { request, forceReconnect } as unknown as GatewayBrowserClient;
@@ -202,8 +203,8 @@ describe("createSessionCapability message subscriptions", () => {
     ]);
 
     expect(failures).toEqual([
-      { status: "rejected", reason: expect.any(AggregateError) },
-      { status: "rejected", reason: expect.any(AggregateError) },
+      { status: "rejected", reason: expect.objectContaining({ cause: recoveryError }) },
+      { status: "rejected", reason: expect.objectContaining({ cause: recoveryError }) },
     ]);
     expect(request).toHaveBeenNthCalledWith(
       2,

--- a/ui/src/lib/sessions/session-scoped-operations.ts
+++ b/ui/src/lib/sessions/session-scoped-operations.ts
@@ -1,4 +1,5 @@
 import {
+  GatewayProtocolRequestTimeoutError,
   getGatewaySessionMessageSubscriptionCoordinator,
   releaseGatewaySessionMessageSubscription,
   resetGatewaySessionMessageSubscriptionCoordinator,
@@ -46,6 +47,8 @@ type SessionScopedOperationsHost = {
   agentId: () => string | null;
   refreshReplacement: (agentId?: string | null) => Promise<void>;
 };
+
+const retiredFailedSubscriptionRecoveries = new WeakSet<AggregateError>();
 
 export function createSessionScopedOperations(host: SessionScopedOperationsHost) {
   const ownedSubscriptions = new Set<SessionMessageSubscription>();
@@ -124,10 +127,26 @@ export function createSessionScopedOperations(host: SessionScopedOperationsHost)
         : null;
     const subscription = await getGatewaySessionMessageSubscriptionCoordinator(scope.client, {
       keysEquivalent: areUiSessionKeysEquivalent,
-    }).acquire(normalizedKey, {
-      agentId,
-      ...(options.includeApprovals ? { includeApprovals: true } : {}),
-    });
+    })
+      .acquire(normalizedKey, {
+        agentId,
+        ...(options.includeApprovals ? { includeApprovals: true } : {}),
+      })
+      .catch((error: unknown) => {
+        if (
+          error instanceof AggregateError &&
+          error.errors[0] instanceof GatewayProtocolRequestTimeoutError &&
+          error.errors[0].requestSent &&
+          host.connection.isCurrent(scope) &&
+          !retiredFailedSubscriptionRecoveries.has(error)
+        ) {
+          // Failed compensation cannot prove privileged observers were removed;
+          // closing their owning socket invokes authoritative Gateway cleanup.
+          retiredFailedSubscriptionRecoveries.add(error);
+          scope.client.forceReconnect("session subscription recovery failed");
+        }
+        throw error;
+      });
     ownedSubscriptions.add(subscription);
     if (!host.connection.isCurrent(scope)) {
       await unsubscribeMessages(subscription).catch(() => undefined);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening or switching Control UI conversations could see chat updates stop indefinitely when a Gateway subscription or unsubscribe acknowledgment never arrived. A subscription that had already reached the Gateway could also leave its session observer active after the client timed out, including an approval-capable observer whose acknowledgement was lost.

## Why This Change Was Made

The connection-owned subscription coordinator now gives both subscription directions the established Gateway request deadline and uses the existing request-sent fact to reconcile ambiguous subscriptions at their authoritative owner. It removes a newly committed orphan, restores an existing plain observer after an ambiguous approval upgrade, and preserves retryable final releases. If reconciliation itself fails, the Control UI retires only the still-current connection so the Gateway's existing disconnect lifecycle removes its observers; stale generations and concurrent subscribers cannot repeatedly reconnect a replacement.

This preserves existing Gateway method shapes, approval authorization, agent isolation, session aliases, release ownership, and public configuration. Production growth is +74/-10 (net +64): the additional code is required for bounded bidirectional requests, authoritative sent-only compensation, and fail-closed current-generation recovery rather than a downstream timeout-only workaround.

## User Impact

Control UI chat recovers from stalled Gateway session subscriptions instead of freezing indefinitely. Existing observers remain usable after a rejected or ambiguous upgrade, stale subscriptions do not survive uncertain delivery, and unrecoverable observer cleanup safely reconnects the owning Gateway connection.

## Evidence

- Exact reviewed candidate: `dbafaa13f58fd41284fe26605abe317df35a2719`.
- Regression-first proof reproduced stalled acquire/release, lost subscription acknowledgments, retained plain observers, approval upgrades, failed compensation, concurrent recovery, and replaced Gateway generations before the repair.
- Real Gateway server methods, shared Gateway client ownership, and Control UI session integration: **55 passing tests** across the Gateway, Gateway-client, and UI Vitest shards.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs packages/gateway-client/src/session-subscriptions.test.ts src/gateway/server-methods/sessions.messages-subscribe-approvals.test.ts ui/src/lib/sessions/index-subscriptions.test.ts --configLoader runner`
- `node_modules/.bin/oxfmt --check packages/gateway-client/src/session-subscriptions.ts packages/gateway-client/src/session-subscriptions.test.ts src/gateway/server-methods/sessions.messages-subscribe-approvals.test.ts ui/src/lib/sessions/index-subscriptions.test.ts ui/src/lib/sessions/session-scoped-operations.ts`
- Full-branch independent Codex review: clean, with no accepted or actionable findings.
- Visual before/after media is inapplicable: this is a transport-level acknowledgment stall and connection lifecycle repair without a visual rendering change; the deterministic Gateway/client/UI boundary regressions exercise dropped acknowledgments and recovery directly.

AI-assisted.
