### PR TITLE
fix(cli): reject --agent on models aliases and scan instead of ignoring it

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -28,7 +28,14 @@ openclaw models set-image <model-or-alias>
 openclaw models scan
 ```
 
-`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `scan`, `aliases`, and `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`/`set-image` reject `--agent` outright. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
+`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`, `set-image`, `scan`, and `aliases` reject `--agent` outright because they only read and write the global `agents.defaults` block. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
+
+> **Upgrade note.** `scan` and `aliases` previously accepted a parent `--agent <id>`
+> and ignored it, including an id that does not exist. They now fail with
+> `openclaw models <subcommand> does not support --agent; it only affects the global
+> model defaults under agents.defaults.` Scripts that passed `--agent` to these
+> subcommands should drop the flag; the behaviour they got was always the global
+> default, so removing it does not change what the command does.
 
 `models set` and `models set-image` require the provider to be declared by an installed plugin or configured under `models.providers`. An unknown provider exits nonzero without changing config. If the provider is known but the model is absent from the local catalog, the command saves the selection and prints a warning because newly released and self-hosted models may not be cataloged yet. `openclaw doctor --json` reports configured unknown providers; add `--severity-min info` to also see active models that the local catalog cannot confirm.
 

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -31,11 +31,10 @@ openclaw models scan
 `status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`, `set-image`, `scan`, and `aliases` reject `--agent` outright because they only read and write the global `agents.defaults` block. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
 
 > **Upgrade note.** `scan` and `aliases` previously accepted a parent `--agent <id>`
-> and ignored it, including an id that does not exist. They now fail with
-> `openclaw models <subcommand> does not support --agent; it only affects the global
-> model defaults under agents.defaults.` Scripts that passed `--agent` to these
-> subcommands should drop the flag; the behaviour they got was always the global
-> default, so removing it does not change what the command does.
+> and ignored it, including an id that does not exist. They now exit nonzero with
+> `does not support --agent`. Scripts passing `--agent` to these subcommands should
+> drop the flag: the behaviour they were getting was always the global default, so
+> removing it does not change what the command does.
 
 `models set` and `models set-image` require the provider to be declared by an installed plugin or configured under `models.providers`. An unknown provider exits nonzero without changing config. If the provider is known but the model is absent from the local catalog, the command saves the selection and prints a warning because newly released and self-hosted models may not be cataloged yet. `openclaw doctor --json` reports configured unknown providers; add `--severity-min info` to also see active models that the local catalog cannot confirm.
 

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -33,7 +33,7 @@ openclaw models scan
 > **Upgrade note.** `scan` and `aliases` previously accepted a parent `--agent <id>`
 > and ignored it, including an id that does not exist. They now exit nonzero with
 > `does not support --agent`. Scripts passing `--agent` to these subcommands should
-> drop the flag: the behaviour they were getting was always the global default, so
+> drop the flag: the behavior they were getting was always the global default, so
 > removing it does not change what the command does.
 
 `models set` and `models set-image` require the provider to be declared by an installed plugin or configured under `models.providers`. An unknown provider exits nonzero without changing config. If the provider is known but the model is absent from the local catalog, the command saves the selection and prints a warning because newly released and self-hosted models may not be cataloged yet. `openclaw doctor --json` reports configured unknown providers; add `--severity-min info` to also see active models that the local catalog cannot confirm.

--- a/src/cli/models-cli.lazy.test.ts
+++ b/src/cli/models-cli.lazy.test.ts
@@ -19,7 +19,7 @@ describe("models cli lazy runtime boundary", () => {
       runtimeLoaded();
       return {
         defaultRuntime: {},
-        rejectAgentScopedModelWrite: vi.fn(),
+        rejectAgentScopedModelCommand: vi.fn(),
         resolveModelAgentOption: vi.fn(),
         runModelsCommand: vi.fn(),
       };
@@ -53,7 +53,7 @@ describe("models cli lazy runtime boundary", () => {
       runtimeLoaded();
       return {
         defaultRuntime,
-        rejectAgentScopedModelWrite: vi.fn(),
+        rejectAgentScopedModelCommand: vi.fn(),
         resolveModelAgentOption,
         runModelsCommand,
       };

--- a/src/cli/models-cli.runtime.ts
+++ b/src/cli/models-cli.runtime.ts
@@ -20,16 +20,26 @@ export function resolveModelAgentOption(
   );
 }
 
-export function rejectAgentScopedModelWrite(
+/** Subcommands of `models` that only ever touch `agents.defaults`, never one agent. */
+export type GlobalOnlyModelsCommand =
+  | "set"
+  | "set-image"
+  | "aliases list"
+  | "aliases add"
+  | "aliases remove"
+  | "scan";
+
+export function rejectAgentScopedModelCommand(
   command: Command,
-  commandName: "set" | "set-image",
+  commandName: GlobalOnlyModelsCommand,
 ): void {
-  // Write commands update global defaults; accepting --agent here would imply per-agent mutation.
+  // These read and write `agents.defaults` only; accepting --agent here would imply
+  // per-agent scoping that no downstream code path provides.
   const agent = resolveOptionFromCommand<string>(command, "agent");
   if (!agent) {
     return;
   }
   throw new Error(
-    `openclaw models ${commandName} does not support --agent; it only updates global model defaults. Remove --agent, or run ${formatCliCommand("openclaw agents list")} and set the per-agent model in agent config.`,
+    `openclaw models ${commandName} does not support --agent; it only affects the global model defaults under agents.defaults. Remove --agent, or run ${formatCliCommand("openclaw agents list")} and set the per-agent model in agent config.`,
   );
 }

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -11,6 +11,13 @@ const mocks = vi.hoisted(() => ({
   modelsSetCommand: vi.fn().mockResolvedValue(undefined),
   modelsSetImageCommand: vi.fn().mockResolvedValue(undefined),
   noopAsync: vi.fn(async () => undefined),
+  // The global-only subcommands get their own spies rather than sharing
+  // `noopAsync`: a shared one stays called from the previous table row, so a
+  // later row asserting "the leaf ran" passes even when its leaf never runs.
+  modelsAliasesAddCommand: vi.fn(async () => undefined),
+  modelsAliasesListCommand: vi.fn(async () => undefined),
+  modelsAliasesRemoveCommand: vi.fn(async () => undefined),
+  modelsScanCommand: vi.fn(async () => undefined),
   modelsAuthAddCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthListCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthLoginCommand: vi.fn().mockResolvedValue(undefined),
@@ -34,10 +41,13 @@ const {
   modelsAuthPasteApiKeyCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
+  modelsAliasesAddCommand,
+  modelsAliasesListCommand,
+  modelsAliasesRemoveCommand,
+  modelsScanCommand,
   modelsSetCommand,
   modelsSetImageCommand,
   modelsStatusCommand,
-  noopAsync,
 } = mocks;
 
 vi.mock("../commands/models/list.list-command.js", () => ({
@@ -65,9 +75,9 @@ vi.mock("../commands/models/auth-order.js", () => ({
   modelsAuthOrderSetCommand: mocks.modelsAuthOrderSetCommand,
 }));
 vi.mock("../commands/models/aliases.js", () => ({
-  modelsAliasesAddCommand: mocks.noopAsync,
-  modelsAliasesListCommand: mocks.noopAsync,
-  modelsAliasesRemoveCommand: mocks.noopAsync,
+  modelsAliasesAddCommand: mocks.modelsAliasesAddCommand,
+  modelsAliasesListCommand: mocks.modelsAliasesListCommand,
+  modelsAliasesRemoveCommand: mocks.modelsAliasesRemoveCommand,
 }));
 vi.mock("../commands/models/fallbacks.js", () => ({
   modelsFallbacksAddCommand: mocks.noopAsync,
@@ -82,7 +92,7 @@ vi.mock("../commands/models/image-fallbacks.js", () => ({
   modelsImageFallbacksRemoveCommand: mocks.noopAsync,
 }));
 vi.mock("../commands/models/scan.js", () => ({
-  modelsScanCommand: mocks.noopAsync,
+  modelsScanCommand: mocks.modelsScanCommand,
 }));
 vi.mock("../commands/models/set.js", () => ({
   modelsSetCommand: mocks.modelsSetCommand,
@@ -104,6 +114,10 @@ describe("models cli", () => {
     modelsAuthPasteApiKeyCommand.mockClear();
     modelsAuthPasteTokenCommand.mockClear();
     modelsAuthSetupTokenCommand.mockClear();
+    modelsAliasesAddCommand.mockClear();
+    modelsAliasesListCommand.mockClear();
+    modelsAliasesRemoveCommand.mockClear();
+    modelsScanCommand.mockClear();
     modelsSetCommand.mockClear();
     modelsSetImageCommand.mockClear();
     modelsStatusCommand.mockClear();
@@ -463,41 +477,57 @@ describe("models cli", () => {
   // --agent-aware models subcommand validated it (#126597). Unlike `set`, these run
   // inside the CLI error wrapper, so the guard surfaces as a formatted operator
   // error rather than an unhandled throw.
-  it.each([
-    { label: "aliases list", args: ["models", "--agent", "poe", "aliases", "list"] },
+  //
+  // One row per subcommand, carrying its own leaf spy, so the rejected case and
+  // the unscoped case can never end up describing different commands.
+  const globalOnlyModelsCommands = [
+    { label: "aliases list", leaf: modelsAliasesListCommand, args: ["aliases", "list"] },
     {
       label: "aliases add",
-      args: ["models", "--agent", "poe", "aliases", "add", "zzz", "soraka/grok-4.6"],
+      leaf: modelsAliasesAddCommand,
+      args: ["aliases", "add", "zzz", "soraka/grok-4.6"],
     },
-    { label: "aliases remove", args: ["models", "--agent", "poe", "aliases", "remove", "zzz"] },
-    { label: "scan", args: ["models", "--agent", "poe", "scan", "--no-probe", "--no-input"] },
-  ])("reports parent --agent as an operator error for models $label", async ({ label, args }) => {
-    const errorWrites = captureRuntimeErrors();
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    {
+      label: "aliases remove",
+      leaf: modelsAliasesRemoveCommand,
+      args: ["aliases", "remove", "zzz"],
+    },
+    { label: "scan", leaf: modelsScanCommand, args: ["scan", "--no-probe", "--no-input"] },
+  ];
 
-    // `defaultRuntime.exit` calls process.exit and then throws a sentinel so the
-    // path stays unreachable when process.exit is mocked (src/runtime.ts).
-    await expect(runModelsCommand(args)).rejects.toThrow("unreachable");
+  it.each(globalOnlyModelsCommands)(
+    "reports parent --agent as an operator error for models $label",
+    async ({ label, leaf, args }) => {
+      const errorWrites = captureRuntimeErrors();
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
-    const stderr = errorWrites.join(" ");
-    expect(stderr).toContain("does not support --agent");
-    // The message has to name the subcommand it rejected, or a copy-paste that
-    // guards `scan` while reporting `set` reads as correct.
-    expect(stderr).toContain(`openclaw models ${label}`);
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    expect(noopAsync).not.toHaveBeenCalled();
-  });
+      // `defaultRuntime.exit` calls process.exit and then throws a sentinel so the
+      // path stays unreachable when process.exit is mocked (src/runtime.ts).
+      await expect(runModelsCommand(["models", "--agent", "poe", ...args])).rejects.toThrow(
+        "unreachable",
+      );
 
-  it.each([
-    { label: "aliases list", args: ["models", "aliases", "list"] },
-    { label: "aliases add", args: ["models", "aliases", "add", "zzz", "soraka/grok-4.6"] },
-    { label: "aliases remove", args: ["models", "aliases", "remove", "zzz"] },
-    { label: "scan", args: ["models", "scan", "--no-probe", "--no-input"] },
-  ])("still runs models $label without --agent", async ({ args }) => {
-    await runModelsCommand(args);
+      const stderr = errorWrites.join(" ");
+      expect(stderr).toContain("does not support --agent");
+      // The message has to name the subcommand it rejected, or a copy-paste that
+      // guards `scan` while reporting `set` reads as correct.
+      expect(stderr).toContain(`openclaw models ${label}`);
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(leaf).not.toHaveBeenCalled();
+    },
+  );
 
-    expect(noopAsync).toHaveBeenCalled();
-  });
+  it.each(globalOnlyModelsCommands)(
+    "still runs models $label without --agent",
+    async ({ leaf, args }) => {
+      await runModelsCommand(["models", ...args]);
+
+      // Exactly once, on this row's own leaf: a shared spy would already be
+      // called from an earlier row, and the guard must not grow into a blanket
+      // refusal or a double dispatch.
+      expect(leaf).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("shows help for models auth without error exit", async () => {
     const program = new Command();

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -37,6 +37,7 @@ const {
   modelsSetCommand,
   modelsSetImageCommand,
   modelsStatusCommand,
+  noopAsync,
 } = mocks;
 
 vi.mock("../commands/models/list.list-command.js", () => ({
@@ -441,10 +442,51 @@ describe("models cli", () => {
       args: ["models", "--agent", "poe", "set-image", "openai/gpt-image-1"],
       command: modelsSetImageCommand,
     },
+    // `aliases` and `scan` only ever touch `agents.defaults`, so --agent was
+    // accepted and ignored here -- including an id that does not exist -- while
+    // every other --agent-aware models subcommand validated it (#126597).
+    {
+      label: "aliases list",
+      args: ["models", "--agent", "poe", "aliases", "list"],
+      command: noopAsync,
+    },
+    {
+      label: "aliases add",
+      args: ["models", "--agent", "poe", "aliases", "add", "zzz", "soraka/grok-4.6"],
+      command: noopAsync,
+    },
+    {
+      label: "aliases remove",
+      args: ["models", "--agent", "poe", "aliases", "remove", "zzz"],
+      command: noopAsync,
+    },
+    {
+      label: "scan",
+      args: ["models", "--agent", "poe", "scan", "--no-probe", "--no-input"],
+      command: noopAsync,
+    },
   ])("rejects parent --agent for models $label", async ({ args, command }) => {
     await expect(runModelsCommand(args)).rejects.toThrow("does not support --agent");
 
     expect(command).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "aliases list", args: ["models", "--agent", "poe", "aliases", "list"] },
+    { label: "scan", args: ["models", "--agent", "poe", "scan", "--no-probe", "--no-input"] },
+  ])("names the subcommand it rejected for models $label", async ({ label, args }) => {
+    await expect(runModelsCommand(args)).rejects.toThrow(`openclaw models ${label}`);
+  });
+
+  it.each([
+    { label: "aliases list", args: ["models", "aliases", "list"] },
+    { label: "aliases add", args: ["models", "aliases", "add", "zzz", "soraka/grok-4.6"] },
+    { label: "aliases remove", args: ["models", "aliases", "remove", "zzz"] },
+    { label: "scan", args: ["models", "scan", "--no-probe", "--no-input"] },
+  ])("still runs models $label without --agent", async ({ args }) => {
+    await runModelsCommand(args);
+
+    expect(noopAsync).toHaveBeenCalled();
   });
 
   it("shows help for models auth without error exit", async () => {

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -115,6 +115,16 @@ describe("models cli", () => {
     return program;
   }
 
+  // `defaultRuntime.error` routes through console.error (src/runtime.ts), not a
+  // direct process.stderr write.
+  function captureRuntimeErrors() {
+    const writes: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      writes.push(args.map((arg) => String(arg)).join(" "));
+    });
+    return writes;
+  }
+
   async function runModelsCommand(args: string[]) {
     await runRegisteredCli({
       register: (program: Command) => {
@@ -442,40 +452,40 @@ describe("models cli", () => {
       args: ["models", "--agent", "poe", "set-image", "openai/gpt-image-1"],
       command: modelsSetImageCommand,
     },
-    // `aliases` and `scan` only ever touch `agents.defaults`, so --agent was
-    // accepted and ignored here -- including an id that does not exist -- while
-    // every other --agent-aware models subcommand validated it (#126597).
-    {
-      label: "aliases list",
-      args: ["models", "--agent", "poe", "aliases", "list"],
-      command: noopAsync,
-    },
-    {
-      label: "aliases add",
-      args: ["models", "--agent", "poe", "aliases", "add", "zzz", "soraka/grok-4.6"],
-      command: noopAsync,
-    },
-    {
-      label: "aliases remove",
-      args: ["models", "--agent", "poe", "aliases", "remove", "zzz"],
-      command: noopAsync,
-    },
-    {
-      label: "scan",
-      args: ["models", "--agent", "poe", "scan", "--no-probe", "--no-input"],
-      command: noopAsync,
-    },
   ])("rejects parent --agent for models $label", async ({ args, command }) => {
     await expect(runModelsCommand(args)).rejects.toThrow("does not support --agent");
 
     expect(command).not.toHaveBeenCalled();
   });
 
+  // `aliases` and `scan` only ever touch `agents.defaults`, so --agent was accepted
+  // and ignored here -- including an id that does not exist -- while every other
+  // --agent-aware models subcommand validated it (#126597). Unlike `set`, these run
+  // inside the CLI error wrapper, so the guard surfaces as a formatted operator
+  // error rather than an unhandled throw.
   it.each([
     { label: "aliases list", args: ["models", "--agent", "poe", "aliases", "list"] },
+    {
+      label: "aliases add",
+      args: ["models", "--agent", "poe", "aliases", "add", "zzz", "soraka/grok-4.6"],
+    },
+    { label: "aliases remove", args: ["models", "--agent", "poe", "aliases", "remove", "zzz"] },
     { label: "scan", args: ["models", "--agent", "poe", "scan", "--no-probe", "--no-input"] },
-  ])("names the subcommand it rejected for models $label", async ({ label, args }) => {
-    await expect(runModelsCommand(args)).rejects.toThrow(`openclaw models ${label}`);
+  ])("reports parent --agent as an operator error for models $label", async ({ label, args }) => {
+    const errorWrites = captureRuntimeErrors();
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    // `defaultRuntime.exit` calls process.exit and then throws a sentinel so the
+    // path stays unreachable when process.exit is mocked (src/runtime.ts).
+    await expect(runModelsCommand(args)).rejects.toThrow("unreachable");
+
+    const stderr = errorWrites.join(" ");
+    expect(stderr).toContain("does not support --agent");
+    // The message has to name the subcommand it rejected, or a copy-paste that
+    // guards `scan` while reporting `set` reads as correct.
+    expect(stderr).toContain(`openclaw models ${label}`);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(noopAsync).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -142,7 +142,7 @@ export function registerModelsCli(program: Command) {
     .argument("<model>", "Model id or alias")
     .action(async (model: string, _opts: unknown, command: Command) => {
       const runtime = await loadModelsRuntime();
-      runtime.rejectAgentScopedModelWrite(command, "set");
+      runtime.rejectAgentScopedModelCommand(command, "set");
       await runtime.runModelsCommand(async () => {
         const { modelsSetCommand } = await import("../commands/models/set.js");
         await modelsSetCommand(model, runtime.defaultRuntime);
@@ -155,7 +155,7 @@ export function registerModelsCli(program: Command) {
     .argument("<model>", "Model id or alias")
     .action(async (model: string, _opts: unknown, command: Command) => {
       const runtime = await loadModelsRuntime();
-      runtime.rejectAgentScopedModelWrite(command, "set-image");
+      runtime.rejectAgentScopedModelCommand(command, "set-image");
       await runtime.runModelsCommand(async () => {
         const { modelsSetImageCommand } = await import("../commands/models/set-image.js");
         await modelsSetImageCommand(model, runtime.defaultRuntime);
@@ -169,10 +169,15 @@ export function registerModelsCli(program: Command) {
     .description("List model aliases")
     .option("--json", "Output JSON", false)
     .option("--plain", "Plain output", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (opts, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "aliases list");
+      await runtime.runModelsCommand(async () => {
         const { modelsAliasesListCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesListCommand({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
+        await modelsAliasesListCommand(
+          { ...opts, json: hasJsonOutput(opts) },
+          runtime.defaultRuntime,
+        );
       });
     });
 
@@ -181,10 +186,12 @@ export function registerModelsCli(program: Command) {
     .description("Add or update a model alias")
     .argument("<alias>", "Alias name")
     .argument("<model>", "Model id or alias")
-    .action(async (alias: string, model: string) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (alias: string, model: string, _opts: unknown, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "aliases add");
+      await runtime.runModelsCommand(async () => {
         const { modelsAliasesAddCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesAddCommand(alias, model, defaultRuntime);
+        await modelsAliasesAddCommand(alias, model, runtime.defaultRuntime);
       });
     });
 
@@ -192,10 +199,12 @@ export function registerModelsCli(program: Command) {
     .command("remove")
     .description("Remove a model alias")
     .argument("<alias>", "Alias name")
-    .action(async (alias: string) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (alias: string, _opts: unknown, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "aliases remove");
+      await runtime.runModelsCommand(async () => {
         const { modelsAliasesRemoveCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesRemoveCommand(alias, defaultRuntime);
+        await modelsAliasesRemoveCommand(alias, runtime.defaultRuntime);
       });
     });
 
@@ -286,10 +295,12 @@ export function registerModelsCli(program: Command) {
     .option("--set-default", "Set agents.defaults.model to the first selection", false)
     .option("--set-image", "Set agents.defaults.imageModel to the first image selection", false)
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (opts, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "scan");
+      await runtime.runModelsCommand(async () => {
         const { modelsScanCommand } = await import("../commands/models/scan.js");
-        await modelsScanCommand({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
+        await modelsScanCommand({ ...opts, json: hasJsonOutput(opts) }, runtime.defaultRuntime);
       });
     });
 

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -170,14 +170,10 @@ export function registerModelsCli(program: Command) {
     .option("--json", "Output JSON", false)
     .option("--plain", "Plain output", false)
     .action(async (opts, command: Command) => {
-      const runtime = await loadModelsRuntime();
-      runtime.rejectAgentScopedModelCommand(command, "aliases list");
-      await runtime.runModelsCommand(async () => {
+      await withModelsRuntime(async ({ defaultRuntime, rejectAgentScopedModelCommand }) => {
+        rejectAgentScopedModelCommand(command, "aliases list");
         const { modelsAliasesListCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesListCommand(
-          { ...opts, json: hasJsonOutput(opts) },
-          runtime.defaultRuntime,
-        );
+        await modelsAliasesListCommand({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
       });
     });
 
@@ -187,11 +183,10 @@ export function registerModelsCli(program: Command) {
     .argument("<alias>", "Alias name")
     .argument("<model>", "Model id or alias")
     .action(async (alias: string, model: string, _opts: unknown, command: Command) => {
-      const runtime = await loadModelsRuntime();
-      runtime.rejectAgentScopedModelCommand(command, "aliases add");
-      await runtime.runModelsCommand(async () => {
+      await withModelsRuntime(async ({ defaultRuntime, rejectAgentScopedModelCommand }) => {
+        rejectAgentScopedModelCommand(command, "aliases add");
         const { modelsAliasesAddCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesAddCommand(alias, model, runtime.defaultRuntime);
+        await modelsAliasesAddCommand(alias, model, defaultRuntime);
       });
     });
 
@@ -200,11 +195,10 @@ export function registerModelsCli(program: Command) {
     .description("Remove a model alias")
     .argument("<alias>", "Alias name")
     .action(async (alias: string, _opts: unknown, command: Command) => {
-      const runtime = await loadModelsRuntime();
-      runtime.rejectAgentScopedModelCommand(command, "aliases remove");
-      await runtime.runModelsCommand(async () => {
+      await withModelsRuntime(async ({ defaultRuntime, rejectAgentScopedModelCommand }) => {
+        rejectAgentScopedModelCommand(command, "aliases remove");
         const { modelsAliasesRemoveCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesRemoveCommand(alias, runtime.defaultRuntime);
+        await modelsAliasesRemoveCommand(alias, defaultRuntime);
       });
     });
 
@@ -296,11 +290,10 @@ export function registerModelsCli(program: Command) {
     .option("--set-image", "Set agents.defaults.imageModel to the first image selection", false)
     .option("--json", "Output JSON", false)
     .action(async (opts, command: Command) => {
-      const runtime = await loadModelsRuntime();
-      runtime.rejectAgentScopedModelCommand(command, "scan");
-      await runtime.runModelsCommand(async () => {
+      await withModelsRuntime(async ({ defaultRuntime, rejectAgentScopedModelCommand }) => {
+        rejectAgentScopedModelCommand(command, "scan");
         const { modelsScanCommand } = await import("../commands/models/scan.js");
-        await modelsScanCommand({ ...opts, json: hasJsonOutput(opts) }, runtime.defaultRuntime);
+        await modelsScanCommand({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
       });
     });
 


### PR DESCRIPTION
Closes #126597.

## What Problem This Solves

`openclaw models aliases {list,add,remove}` and `openclaw models scan` accept `--agent <id>` from the parent `models` command and do nothing with it — no scoping, and no validation, so a nonexistent id passes silently:

```console
$ openclaw models --agent totally-bogus-agent-id status
[openclaw] Reason: Unknown agent id "totally-bogus-agent-id". Use "openclaw agents list" to see configured agents.

$ openclaw models --agent totally-bogus-agent-id aliases list
# prints the normal alias list, no error, no effect
```

Every other `--agent`-aware `models` subcommand validates the id, so the flag looks like it scoped the command when it did nothing at all. An operator scoping a command to one agent in a multi-agent fleet gets no feedback that the flag was inert, and a typo'd agent id is never caught.

## Why reject rather than wire it through

The issue offered both options, so I checked the downstream before choosing. There is no agent-scoped path to wire `--agent` to — `modelsAliasesListCommand` and its siblings take `(opts, runtime)` and read `cfg.agents?.defaults?.models`, with no agent parameter anywhere in the chain:

```ts
export async function modelsAliasesListCommand(
  opts: { json?: boolean; plain?: boolean },
  runtime: RuntimeEnv,
) {
  const cfg = await loadModelsConfig({ commandName: "models aliases list", runtime });
  const models = cfg.agents?.defaults?.models ?? {};
```

`models set` / `set-image` already guard the same way, for the same reason.

## Changes

- The four subcommands call `rejectAgentScopedModelCommand` **inside** `withModelsRuntime`, so the rejection renders through `formatCliOperatorError` and exits 1 like any other operator error. (My first revision threw before the wrapper, copying the shape `models set` uses; ClawSweeper caught that it made the error path worse for exactly these commands, and it was right.)
- `rejectAgentScopedModelWrite` → `rejectAgentScopedModelCommand`: it now covers reads (`aliases list`, `scan --no-probe`), so the write-shaped name and its *"only updates global model defaults"* wording were both inaccurate. The message says *"only affects the global model defaults under `agents.defaults`"*.
- `commandName` is a `GlobalOnlyModelsCommand` union, so a future global-only subcommand names itself instead of passing a free-form string.
- `docs/cli/models.md` listed `scan` and `aliases` as commands that "always use the configured default agent". They are now listed with `set`/`set-image` as rejecting `--agent`, plus an upgrade note for the compatibility change.

## Evidence

**Real CLI, after `pnpm build`, on this branch** (Windows, Node 24):

```console
$ node openclaw.mjs models --agent totally-bogus-agent-id aliases list
openclaw models aliases list does not support --agent; it only affects the global model defaults under agents.defaults. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
exit=1

$ node openclaw.mjs models --agent totally-bogus-agent-id scan --no-probe --no-input
openclaw models scan does not support --agent; it only affects the global model defaults under agents.defaults. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
exit=1

$ node openclaw.mjs models aliases list          # unchanged without --agent
Aliases (0):
- none
exit=0
```

**Focused tests and static checks:**

```console
$ node scripts/run-vitest.mjs run src/cli/models-cli.test.ts src/cli/models-cli.lazy.test.ts
 Test Files  2 passed (2)
      Tests  46 passed (46)          # 38 before this change

$ npx tsc --noEmit -p tsconfig.json
# 0 errors

$ npx oxfmt --check src/cli/models-cli.ts src/cli/models-cli.runtime.ts src/cli/models-cli.test.ts
All matched files use the correct format.
```

**Mutation-checked.** Removing the four guard calls, keeping the tests:

```
 FAIL  reports parent --agent as an operator error for models 'aliases list'
 FAIL  reports parent --agent as an operator error for models 'aliases add'
 FAIL  reports parent --agent as an operator error for models 'aliases remove'
 FAIL  reports parent --agent as an operator error for models 'scan'
      Tests  4 failed | 40 passed (44)
```

Exactly the four new cases, and the "still runs without `--agent`" cases stay green.

**Whole `src/cli` suite, measured on both sides.** It has a pre-existing failure surface on Windows, so I ran it against the unpatched tree (`git checkout HEAD~1 -- src/cli/`) rather than assume. The failing files are identical with and without the patch — 14 files including `profile` (9), `update-cli` (40), `plugins-cli.install` (4) and `gateway-backed-exit.process` (8). `models-cli` has zero failures in both runs, and none of those files is touched here.

One note on the build used for the CLI proof: `pnpm build` completed the compile but its last step, `write-cli-startup-metadata`, failed rendering help for the **browser** plugin (`dist/extensions/browser/index.js: Cannot read properties of undefined (reading 'join')`). That is unrelated to this change and I did not verify whether it also fails on a clean tree; `dist/entry.js` was produced and the commands above ran against it.

## Tests added

The four subcommands assert the formatted operator-error path: the message reaching `console.error`, **naming the subcommand it rejected** (so a copy-paste that guards `scan` while reporting `set` fails), and `exit(1)`. A second block pins that all four **still run normally without `--agent`**, so the guard cannot quietly grow into a blanket refusal.

Two harness details cost a round each and are worth stating for the next person: `defaultRuntime.error` routes through `console.error` rather than a direct `process.stderr` write, and `defaultRuntime.exit` throws an `"unreachable"` sentinel once `process.exit` is mocked (`src/runtime.ts:121`).

@clawsweeper re-review
