### PR TITLE
fix: preserve channel runtime liveness for config-disabled accounts

### DIFF
--- a/src/channels/status/account-state.test.ts
+++ b/src/channels/status/account-state.test.ts
@@ -29,7 +29,19 @@ const baseInput = {
 describe("resolveChannelAccountState", () => {
   it.each([
     [
-      "disabled wins over later states",
+      "disabled wins over later states, but keeps reporting stopped runtime liveness",
+      { enabled: false, configured: false, linked: false, runtime: { running: false } },
+      {
+        kind: "disabled",
+        configured: false,
+        linked: false,
+        reason: "disabled reason",
+        failure: null,
+        running: false,
+      },
+    ],
+    [
+      "disabled account still surfaces a live auto-loaded runtime instead of masking it",
       { enabled: false, configured: false, linked: false, runtime: { running: true } },
       {
         kind: "disabled",
@@ -37,6 +49,25 @@ describe("resolveChannelAccountState", () => {
         linked: false,
         reason: "disabled reason",
         failure: null,
+        running: true,
+      },
+    ],
+    [
+      "disabled + running account carries connectivity through like the running state does",
+      {
+        enabled: false,
+        configured: false,
+        linked: false,
+        runtime: { running: true, connected: true },
+      },
+      {
+        kind: "disabled",
+        configured: false,
+        linked: false,
+        reason: "disabled reason",
+        failure: null,
+        running: true,
+        connected: true,
       },
     ],
     [
@@ -98,11 +129,34 @@ describe("projectChannelAccountState", () => {
         linked: false,
         reason: "disabled",
         failure: null,
+        running: false,
       },
       {
         configured: false,
         linked: false,
         running: false,
+        stateReason: "disabled",
+        lastError: null,
+      },
+    ],
+    [
+      // Regression coverage for #111346: a config-disabled (e.g. not in
+      // plugins.allow) account that the gateway still records as running
+      // must keep reporting `running: true`, not a hard-coded `false`.
+      {
+        kind: "disabled",
+        configured: false,
+        linked: false,
+        reason: "disabled",
+        failure: null,
+        running: true,
+        connected: true,
+      },
+      {
+        configured: false,
+        linked: false,
+        running: true,
+        connected: true,
         stateReason: "disabled",
         lastError: null,
       },

--- a/src/channels/status/account-state.ts
+++ b/src/channels/status/account-state.ts
@@ -14,6 +14,12 @@ type ChannelAccountState =
       linked: boolean | undefined;
       reason: string;
       failure: string | null;
+      // The account can be disabled by config (e.g. not in plugins.allow)
+      // while the plugin is still actually running via auto-load. Carrying
+      // the recorded runtime liveness here lets the projection below report
+      // it instead of always clobbering it with `running: false`.
+      running: boolean;
+      connected?: boolean;
     }
   | { kind: "unconfigured"; reason: string; failure: string | null }
   | { kind: "unlinked"; reason: string; failure: string | null }
@@ -37,12 +43,20 @@ function assertNeverState(state: never): never {
 export function resolveChannelAccountState(input: ChannelAccountStateInput): ChannelAccountState {
   const failure = input.runtime?.lastError ?? null;
   if (!input.enabled) {
+    const running = input.runtime?.running === true;
     return {
       kind: "disabled",
       configured: input.configured,
       linked: input.linked,
       reason: input.disabledReason ?? "disabled",
       failure,
+      running,
+      // Same tri-state rule as the `running` branch below: only report
+      // connectivity when the account is actually live, and leave it absent
+      // rather than manufacturing a `false` for socketless transports.
+      ...(running && typeof input.runtime?.connected === "boolean"
+        ? { connected: input.runtime.connected }
+        : {}),
     };
   }
   if (!input.configured) {
@@ -95,7 +109,8 @@ function projectChannelAccountState(state: ChannelAccountState): {
       return {
         configured: state.configured,
         ...(typeof state.linked === "boolean" ? { linked: state.linked } : {}),
-        running: false,
+        running: state.running,
+      ...(typeof state.connected === "boolean" ? { connected: state.connected } : {}),
         stateReason: state.reason,
         lastError: state.failure,
       };


### PR DESCRIPTION
Closes #111346

## What Problem This Solves

Accounts that are disabled by config (e.g. not listed in `plugins.allow`) but still actually running via auto-load are reported as `running: false` in the channel status UI/API, even while the gateway's own runtime snapshot says the account is live and connected. This makes the disabled-but-running state indistinguishable from a genuinely stopped account, which is misleading to anyone checking channel health.

## Why This Change Was Made

`resolveChannelAccountState` in `src/channels/status/account-state.ts` returns a `disabled` variant as soon as `input.enabled` is false, before ever looking at `input.runtime`. The `disabled` variant previously carried no runtime fields at all, so `projectChannelAccountState`'s `disabled` case had nothing to project except a hard-coded `running: false`. This unconditionally clobbers real runtime liveness whenever an account is config-disabled, even if the plugin process is still actually running.

The fix adds `running: boolean` and an optional `connected?: boolean` to the `disabled` variant of the internal `ChannelAccountState` type, populates them in `resolveChannelAccountState` from `input.runtime` using the same tri-state connectivity rule already used by the `running` branch (only report `connected` when the account is live and the transport actually publishes connectivity), and updates `projectChannelAccountState`'s `disabled` case to project the carried values instead of a hard-coded `false`. All other state kinds (`unconfigured`, `unlinked`, `running`, `stopped`) are untouched.

## User Impact

Anyone viewing channel account status (dashboard, CLI, or API consumers of the projected snapshot) will now see accurate `running`/`connected` values for accounts that are disabled by config but still running via auto-load, instead of a misleading `running: false`. Accounts that are both disabled and genuinely not running are unaffected — they still report `running: false`.

## Evidence

I could not run the full `pnpm build && pnpm check && pnpm test` in this environment (no `pnpm install` available in the sandbox used to prepare this change). To verify correctness without the full build, I:

- Installed TypeScript standalone and ran `tsc --noEmit` against the modified `account-state.ts` in isolation (with stub copies of its imported types), confirming the new file type-checks cleanly with no errors.
- Wrote a standalone Node.js assertion harness (`node:assert/strict`) that reimplements the exact before/after behavior of `resolveChannelAccountState` and `projectChannelAccountState` for the disabled+running, disabled+running+connected, and disabled+not-running cases, and confirmed the expected outputs match, including that the tri-state connectivity rule (absent vs. `false`) behaves the same way it already does for the `running` branch.
- Added three new `it.each` cases to the existing `resolveChannelAccountState` table in `account-state.test.ts` (disabled+not-running unchanged, disabled+running, disabled+running+connected) and one new case to the `projectChannelAccountState` table, following the file's existing table-driven Vitest conventions exactly (same tuple shape, same `as const`, same style of inline comments used elsewhere in the file).
Since I couldn't execute `vitest` locally, a maintainer or CI run of the existing test suite is needed to confirm the new cases pass as expected; I'm confident in them given the harness cross-check above, but flagging this explicitly per the Evidence requirement.

<details>
<summary>Additional instructions</summary>

This PR was drafted with AI assistance (Claude). I reviewed the diagnosis and the diff, understand what the code does and why the change is scoped the way it is, and verified correctness independently (isolated `tsc --noEmit` type-check plus a hand-written Node.js assertion harness), since the sandbox used to prepare this change has no `pnpm install` available to run the full test suite. Flagging per the AI-assisted PR guidance in CONTRIBUTING.md.

**Allow edits by maintainers** is left enabled for this PR.
</details>