### PR TITLE
fix(cron): stop retrying permanent command failures as provider overloads

### DIFF
--- a/src/cron/command-runner.test.ts
+++ b/src/cron/command-runner.test.ts
@@ -2,7 +2,8 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import * as processExecution from "../process/exec.js";
 import { runCronCommandJob } from "./command-runner.js";
 import type { CronJob } from "./types.js";
 
@@ -51,6 +52,7 @@ describe("runCronCommandJob", () => {
     });
 
     expect(result.status).toBe("ok");
+    expect(result.errorClassification).toBeUndefined();
     expect(result.summary).toBe("hello from cron");
     expect(result.diagnostics?.entries[0]).toMatchObject({
       ts: 123,
@@ -84,6 +86,7 @@ describe("runCronCommandJob", () => {
 
     expect(result.status).toBe("error");
     expect(result.error).toBe("command exited with code 7");
+    expect(result.errorClassification).toEqual({ kind: "permanent" });
     expect(result.failureNotificationDetail).toEqual({ kind: "command-exit", exitCode: 7 });
     expect(result.summary).toBe("bad thing");
     expect(result.diagnostics?.entries[0]).toMatchObject({
@@ -130,6 +133,7 @@ describe("runCronCommandJob", () => {
 
     expect(result.status).toBe("error");
     expect(result.error).toBe("command timed out");
+    expect(result.errorClassification).toEqual({ kind: "reason", reason: "timeout" });
     expect(result.failureNotificationDetail).toEqual({
       kind: "command-timeout",
       mode: "wall-clock",
@@ -180,6 +184,7 @@ describe("runCronCommandJob", () => {
 
     expect(result.status).toBe("error");
     expect(result.error).toBe("command produced no output before noOutputTimeoutSeconds");
+    expect(result.errorClassification).toEqual({ kind: "reason", reason: "timeout" });
     expect(result.failureNotificationDetail).toEqual({
       kind: "command-timeout",
       mode: "no-output",
@@ -205,6 +210,7 @@ describe("runCronCommandJob", () => {
 
     expect(result.status).toBe("error");
     expect(result.error).toBe("command stopped");
+    expect(result.errorClassification).toBeUndefined();
     expect(result.summary).toBeUndefined();
     expect(result.failureNotificationDetail).toBeUndefined();
   });
@@ -220,5 +226,25 @@ describe("runCronCommandJob", () => {
 
     expect(result.status).toBe("error");
     expect(result.failureNotificationDetail).toBeUndefined();
+    expect(result.errorClassification).toEqual({ kind: "permanent" });
+  });
+
+  it("leaves transient command start errors unclassified", async () => {
+    const spawnError = Object.assign(new Error("spawn EAGAIN"), { code: "EAGAIN" });
+    const runCommand = vi
+      .spyOn(processExecution, "runCommandWithTimeout")
+      .mockRejectedValueOnce(spawnError);
+
+    try {
+      const result = await runCronCommandJob({
+        job: makeCommandJob({ kind: "command", argv: [process.execPath] }),
+      });
+
+      expect(result.status).toBe("error");
+      expect(result.error).toBe("spawn EAGAIN");
+      expect(result.errorClassification).toBeUndefined();
+    } finally {
+      runCommand.mockRestore();
+    }
   });
 });

--- a/src/cron/command-runner.ts
+++ b/src/cron/command-runner.ts
@@ -140,7 +140,15 @@ export async function runCronCommandJob(params: {
     return {
       status,
       ...(error ? { error } : {}),
-      ...(failureNotificationDetail ? { failureNotificationDetail } : {}),
+      ...(failureNotificationDetail
+        ? {
+            failureNotificationDetail,
+            errorClassification:
+              failureNotificationDetail.kind === "command-timeout"
+                ? ({ kind: "reason", reason: "timeout" } as const)
+                : ({ kind: "permanent" } as const),
+          }
+        : {}),
       ...(summary ? { summary } : {}),
       diagnostics: buildDiagnostics({
         command,
@@ -158,6 +166,9 @@ export async function runCronCommandJob(params: {
     return {
       status: "error",
       error,
+      ...(err instanceof Error && "code" in err && err.code === "ENOENT"
+        ? { errorClassification: { kind: "permanent" as const } }
+        : {}),
       diagnostics: {
         summary: error,
         entries: [

--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -65,6 +65,54 @@ describe("resolveCronExecutionRetryHint", () => {
     }
   });
 
+  it("does not classify incidental 529 numbers as provider overload", () => {
+    for (const message of [
+      "context limit 529 exceeded",
+      "process exited with 529 lines of output",
+      "assertion failed: expected 529 got 0",
+      "process exited with code 529",
+      "killed worker pid 529 after deadline",
+      "ENOENT: no such file '/var/run/app-529.sock'",
+      "API error: 5291",
+      "HTTP/2 5291",
+    ]) {
+      expect(resolveCronExecutionRetryHint({ error: message, retryOn: ["overloaded"] })).toEqual({
+        retryable: false,
+      });
+      expect(resolveCronExecutionRetryHint({ error: message })).toEqual({ retryable: false });
+    }
+  });
+
+  it("classifies genuine HTTP and provider API overload errors", () => {
+    for (const message of [
+      "HTTP 529",
+      "HTTP/2 529",
+      "HTTP/1.1 529",
+      "received status 529 from upstream",
+      "response code: 529",
+      "statusCode: 529",
+      "status_code=529",
+      "responseCode: 529",
+      "API error: 529",
+      "APIError: 529",
+      "api_error: 529",
+      "Provider API error (529): request rejected",
+      "curl: (22) The requested URL returned error: 529",
+      "URL returned error: 529",
+      "529 API is busy",
+      "529 Please try again",
+      "529",
+      "overloaded_error",
+      "temporarily overloaded",
+      "capacity exceeded",
+    ]) {
+      expect(resolveCronExecutionRetryHint({ error: message, retryOn: ["overloaded"] })).toEqual({
+        retryable: true,
+        category: "overloaded",
+      });
+    }
+  });
+
   it("does not classify bare 5xx-looking numbers as server_error", () => {
     for (const message of [
       "context limit 512 exceeded",

--- a/src/cron/retry-hint.test.ts
+++ b/src/cron/retry-hint.test.ts
@@ -67,6 +67,9 @@ describe("resolveCronExecutionRetryHint", () => {
 
   it("does not classify incidental 529 numbers as provider overload", () => {
     for (const message of [
+      "529 lines of output",
+      "529 files missing",
+      "529 workers failed",
       "context limit 529 exceeded",
       "process exited with 529 lines of output",
       "assertion failed: expected 529 got 0",

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -40,7 +40,7 @@ const SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN =
 const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
   rate_limit: RATE_LIMIT_PATTERN,
   overloaded:
-    /\b529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
+    /^\s*529\b|\b(?:https?(?:\/\d(?:\.\d)?)?|status(?:[ _-]?code)?|response(?:[ _-]?code)?|http(?:[ _-]?status)?|(?:provider\s+)?api[ _-]?error|(?:requested\s+)?url\s+returned\s+error)\b[\s:=#"'(]{0,6}529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
   network:
     /(network|fetch failed|socket|econnreset|econnrefused|eai_again|enetdown|ehostunreach|ehostdown|enetreset|enetunreach|epipe)/i,
   timeout: /(timeout|timed out|stalled before execution start|etimedout)/i,

--- a/src/cron/retry-hint.ts
+++ b/src/cron/retry-hint.ts
@@ -40,7 +40,7 @@ const SESSION_LIFECYCLE_CLAIM_ERROR_PATTERN =
 const TRANSIENT_PATTERNS: Record<CronRetryOn, RegExp> = {
   rate_limit: RATE_LIMIT_PATTERN,
   overloaded:
-    /^\s*529\b|\b(?:https?(?:\/\d(?:\.\d)?)?|status(?:[ _-]?code)?|response(?:[ _-]?code)?|http(?:[ _-]?status)?|(?:provider\s+)?api[ _-]?error|(?:requested\s+)?url\s+returned\s+error)\b[\s:=#"'(]{0,6}529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
+    /^\s*529(?:\s*$|[\s:)\].,-]*(?:api\b.*\bbusy\b|(?:please\s+)?try\s+again\b))|\b(?:https?(?:\/\d(?:\.\d)?)?|status(?:[ _-]?code)?|response(?:[ _-]?code)?|http(?:[ _-]?status)?|(?:provider\s+)?api[ _-]?error|(?:requested\s+)?url\s+returned\s+error)\b[\s:=#"'(]{0,6}529\b|\boverloaded(?:_error)?\b|high demand|temporar(?:ily|y) overloaded|capacity exceeded/i,
   network:
     /(network|fetch failed|socket|econnreset|econnrefused|eai_again|enetdown|ehostunreach|ehostdown|enetreset|enetunreach|epipe)/i,
   timeout: /(timeout|timed out|stalled before execution start|etimedout)/i,

--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -420,6 +420,7 @@ async function executeDetachedCronJob(
     return {
       status: res.status,
       error: res.error,
+      errorClassification: res.errorClassification,
       deliveryError: res.deliveryError,
       summary: res.summary,
       delivered: res.delivered,

--- a/src/cron/service/timer-trigger.test.ts
+++ b/src/cron/service/timer-trigger.test.ts
@@ -3,6 +3,31 @@ import { describe, expect, it } from "vitest";
 import { resolveTransientCronRetryDecision } from "./timer-trigger.js";
 
 describe("resolveTransientCronRetryDecision", () => {
+  it("does not retry permanent failures containing incidental 529 values", () => {
+    expect(
+      resolveTransientCronRetryDecision({
+        error: "process exited with 529 lines of output",
+        consecutiveErrors: 1,
+      }),
+    ).toEqual({
+      retryable: false,
+      consecutiveErrors: 1,
+      reason: "permanent error",
+    });
+
+    expect(
+      resolveTransientCronRetryDecision({
+        error: "HTTP 529",
+        consecutiveErrors: 1,
+      }),
+    ).toMatchObject({
+      retryable: true,
+      consecutiveErrors: 1,
+      retryCategory: "overloaded",
+      reason: "transient retry",
+    });
+  });
+
   it("keeps permanent-looking and transient provider classifications distinct", () => {
     const error = "HTTP 429: all available credits have been exhausted";
 

--- a/src/cron/service/timer-trigger.test.ts
+++ b/src/cron/service/timer-trigger.test.ts
@@ -1,31 +1,103 @@
 // Retry-decision tests preserve provider classifications before cron message matching.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { makeCronJob } from "../delivery.test-helpers.js";
+import { createNoopLogger } from "../service.test-harness.js";
+import { createCronServiceState } from "./state.js";
+import { executeJobCore } from "./timer-execution.js";
+import { applyJobResult } from "./timer-outcomes.js";
 import { resolveTransientCronRetryDecision } from "./timer-trigger.js";
 
 describe("resolveTransientCronRetryDecision", () => {
-  it("does not retry permanent failures containing incidental 529 values", () => {
-    expect(
-      resolveTransientCronRetryDecision({
-        error: "process exited with 529 lines of output",
-        consecutiveErrors: 1,
-      }),
-    ).toEqual({
-      retryable: false,
-      consecutiveErrors: 1,
-      reason: "permanent error",
-    });
+  describe.each(["at", "every"] as const)("%s job completion", (scheduleKind) => {
+    it.each([
+      "529 lines of output",
+      "529 files missing",
+      "529 workers failed",
+      "process exited with 529 lines of output",
+      "ENOENT: no such file '/var/run/app-529.sock'",
+    ])("does not retry incidental numeric command failure %s", async (error) => {
+      const startedAt = Date.parse("2026-08-20T12:00:00.000Z");
+      const endedAt = startedAt + 500;
+      const job = makeCronJob({
+        payload: { kind: "command", argv: ["local-task"] },
+        schedule:
+          scheduleKind === "at"
+            ? { kind: "at", at: new Date(startedAt).toISOString() }
+            : { kind: "every", everyMs: 60 * 60_000, anchorMs: startedAt },
+        state: { runningAtMs: startedAt, nextRunAtMs: startedAt },
+      });
+      const state = createCronServiceState({
+        storePath: `/tmp/cron-incidental-${scheduleKind}.json`,
+        cronEnabled: true,
+        log: createNoopLogger(),
+        nowMs: () => endedAt,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
+        runCommandJob: vi.fn(async () => ({
+          status: "error" as const,
+          error,
+          errorClassification: { kind: "permanent" as const },
+        })),
+      });
+      state.store = { version: 1, jobs: [job] };
 
-    expect(
-      resolveTransientCronRetryDecision({
-        error: "HTTP 529",
-        consecutiveErrors: 1,
-      }),
-    ).toMatchObject({
-      retryable: true,
-      consecutiveErrors: 1,
-      retryCategory: "overloaded",
-      reason: "transient retry",
+      const result = await executeJobCore(state, job);
+      applyJobResult(state, job, {
+        ...result,
+        executionStarted: true,
+        startedAt,
+        endedAt,
+      });
+
+      expect(job.state.lastErrorReason).toBeUndefined();
+      expect(job.enabled).toBe(scheduleKind === "every");
+      expect(job.state.nextRunAtMs).toBe(
+        scheduleKind === "every" ? startedAt + 60 * 60_000 : undefined,
+      );
     });
+  });
+
+  describe.each(["at", "every"] as const)("%s provider job completion", (scheduleKind) => {
+    it.each(["HTTP 529", "529 API is busy", "529 Please try again", "529"])(
+      "retries provider-attributed overload %s",
+      async (error) => {
+        const startedAt = Date.parse("2026-08-20T12:00:00.000Z");
+        const endedAt = startedAt + 500;
+        const job = makeCronJob({
+          schedule:
+            scheduleKind === "at"
+              ? { kind: "at", at: new Date(startedAt).toISOString() }
+              : { kind: "every", everyMs: 60 * 60_000, anchorMs: startedAt },
+          state: { runningAtMs: startedAt, nextRunAtMs: startedAt },
+        });
+        const state = createCronServiceState({
+          storePath: "/tmp/cron-provider-overload.json",
+          cronEnabled: true,
+          log: createNoopLogger(),
+          nowMs: () => endedAt,
+          enqueueSystemEvent: vi.fn(),
+          requestHeartbeat: vi.fn(),
+          runIsolatedAgentJob: vi.fn(async () => ({
+            status: "error" as const,
+            error,
+            provider: "provider-fixture",
+          })),
+        });
+        state.store = { version: 1, jobs: [job] };
+
+        applyJobResult(state, job, {
+          ...(await executeJobCore(state, job)),
+          executionStarted: true,
+          startedAt,
+          endedAt,
+        });
+
+        expect(job.state.lastErrorReason).toBe("overloaded");
+        expect(job.enabled).toBe(true);
+        expect(job.state.nextRunAtMs).toBe(endedAt + 30_000);
+      },
+    );
   });
 
   it("keeps permanent-looking and transient provider classifications distinct", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where scheduled command jobs were retried as temporary provider failures when their permanent errors happened to contain numbers or retry-related words, while genuine provider overloads still need their existing bounded retries.

## Why This Change Was Made

Cron command execution now records the existing authoritative permanent-or-timeout classification at its producer, and the detached execution owner preserves that fact through its normal result projection. Unclassified overload text is recognized only when `529` is actually an HTTP/provider status or documented overload response, matching the existing rate-limit and server-error classifiers without changing shared provider classification.

The incidental overload match dates to `ebfb834dcdad5f09675d76af05fb80d3ecfd9fde` (#85344). Avoiding retries solely by adding another scheduler guard would retain the producer ownership gap and still misclassify sibling execution paths; carrying the existing closed classification through the canonical outcome is the root-cause repair.

## User Impact

One-shot automations with permanent command failures stop immediately instead of running again. Recurring automations return to their normal schedule instead of entering unnecessary overload backoff. Real command timeouts and genuine HTTP/provider overload failures continue to retry as before, including existing provider-specific classifications.

## Evidence

- Before repair, eleven independent owner/scheduler regressions fail: incidental `529` prose and paths incorrectly retry, command exits and missing executables have no producer-owned permanent classification, and detached command results discard existing classification.
- Exact-head producer, scheduler projection, one-shot/recurring, and adjacent pacing regression suites: **71/71** tests passed.
- Complete provider classification golden corpus: **605/605 passed**.
- Assertion-safety ratchet and max-lines ratchet both pass; six changed files pass `oxfmt --check`.
- Fresh authenticated full-branch Codex review: **clean**, with no accepted or actionable findings.
- Independent complete-branch architectural review: **clean**; existing public configuration, provider classification contracts, persistence schema, security boundaries, and failure notification shapes remain unchanged.
- Production change: **+14/-2, net +12 lines**, justified by recording authoritative command failure disposition at its execution owner and preserving it across the existing detached execution boundary; tests **+176/-2, net +174 lines**.
- Exact tested head: `0a5785bdd27e8a9fb1d0478ee77ac18c481d2a28`.
