### PR TITLE
fix(codex): prevent session IDs from setting CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex CLI session resume security:** terminate option parsing before the externally supplied session id so option-shaped identifiers cannot enable Codex CLI flags.
 - **Onboarding model browsing:** keep preferred-provider model discovery scoped to the selected provider, preserve route variants, and avoid loading unrelated provider setup surfaces. Fixes #125363. Thanks @shakkernerd.
 - **Codex subagent fan-out:** settle successful terminal yields immediately and preserve requester ownership so completed children reliably resume their parent.
 - **Control UI session companion:** load bounded visible session context before answering, keep unavailable questions retryable, and prevent private companion reference wrappers from appearing as answers. Fixes #120746. Thanks @shakkernerd.

--- a/extensions/codex/src/node-cli-sessions.test.ts
+++ b/extensions/codex/src/node-cli-sessions.test.ts
@@ -1,4 +1,6 @@
 // Codex tests cover node cli sessions plugin behavior.
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -6,9 +8,12 @@ import process from "node:process";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  CODEX_CLI_SESSION_RESUME_COMMAND,
   createCodexCliSessionNodeHostCommands,
   listCodexCliSessionsOnNode,
 } from "./node-cli-sessions.js";
+
+vi.mock("node:child_process", () => ({ spawn: vi.fn() }));
 
 const CODEX_CLI_SESSIONS_LIST_COMMAND = "codex.cli.sessions.list";
 
@@ -341,6 +346,29 @@ describe("codex cli node sessions", () => {
       }),
     ).rejects.toThrow("Codex CLI node command returned malformed payloadJSON.");
     expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ scopes: ["operator.write"] }));
+  });
+
+  it("terminates Codex option parsing before an option-shaped session id", async () => {
+    const sessionId = "--dangerously-bypass-approvals-and-sandbox";
+    const child = Object.assign(new EventEmitter(), {
+      stdin: { end: vi.fn() },
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      kill: vi.fn(),
+    });
+    vi.mocked(spawn).mockImplementation(() => {
+      queueMicrotask(() => child.emit("exit", 0));
+      return child as never;
+    });
+    vi.spyOn(fs, "readFile").mockResolvedValue("resumed");
+
+    const command = createCodexCliSessionNodeHostCommands().find(
+      (entry) => entry.command === CODEX_CLI_SESSION_RESUME_COMMAND,
+    );
+    await command?.handle(JSON.stringify({ sessionId, prompt: "continue" }));
+
+    const argv = vi.mocked(spawn).mock.calls[0]?.[1];
+    expect(argv?.slice(-3)).toEqual(["--", sessionId, "-"]);
   });
 
   it("keeps Codex history session previews on UTF-16 code point boundaries", async () => {

--- a/extensions/codex/src/node-cli-sessions.ts
+++ b/extensions/codex/src/node-cli-sessions.ts
@@ -270,6 +270,7 @@ async function runCodexExecResume(params: {
       "--skip-git-repo-check",
       "--output-last-message",
       outputPath,
+      "--",
       params.sessionId,
       "-",
     ];


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a Codex CLI session identifier beginning with an option name could be parsed as a Codex flag during node-hosted session resume. In the security-sensitive case, an identifier matching Codex's dangerous bypass flag could disable approvals and sandboxing instead of selecting the requested session.

## Why This Change Was Made

The pinned `@openai/codex` 0.147.0 CLI treats the resume session ID as a positional argument while keeping shared flags global across `codex exec resume`. The spawn argv now inserts the standard `--` option terminator immediately before the externally supplied session ID. OpenCode and all other plugin behavior remain unchanged.

Direct upstream source-contract verification at Codex 0.147.0:

- [`SharedCliOptions` defines `--dangerously-bypass-approvals-and-sandbox`](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/utils/cli/src/shared_options.rs#L52-L59).
- [`codex exec` marks the dangerous option global and parses resume IDs positionally](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/exec/src/cli.rs#L139-L163).
- [The parsed flag selects `SandboxMode::DangerFullAccess`](https://github.com/openai/codex/blob/be6e8eac029b183056b7e4402879f15d2c85f61b/codex-rs/exec/src/lib.rs#L289-L293).

Alternatives rejected:

- Rejecting leading-hyphen session names would narrow the existing session-name contract instead of fixing argv ownership.
- Shell escaping is irrelevant because this path already uses structured `spawn` argv; the missing contract was the CLI option boundary.
- A scanner allowlist would hide the real product defect.

## User Impact

Node-hosted Codex resume requests can no longer reinterpret an option-shaped session ID as a Codex CLI flag. Normal UUID and named-session resumes are unchanged.

## Evidence

- Frozen base: `a906b1fdcb56a669fd7ad9beaacfff6050d580bd`
- Exact head: `f431db624ff62158224519e085a75d6b2fb69396`
- Lineage: one signed commit; direct parent is the frozen base.
- Focused regression: `node scripts/run-vitest.mjs extensions/codex/src/node-cli-sessions.test.ts` - 10/10 passed on the exact head.
- Focused Blacksmith Testbox: [run 32399352099](https://github.com/openclaw/openclaw/actions/runs/32399352099) - 10/10 passed; lease `tbx_01m0g4drahes0p2bf522rcdk52` completed successfully.
- Formatting: targeted `oxfmt --check` passed.
- Static proof: `git diff --check` passed.
- Changed-path gate: every guard before extension typecheck passed; extension typecheck stopped on the unrelated frozen-base error `extensions/acpx/src/runtime.ts:1658` (`promptStarted` missing from `AcpRuntimeTurn`). This PR does not touch ACPX or its contracts.
- Production LOC: `+1/-0`; test LOC: `+28/-0`; changelog: `+1/-0`.
- Changed files only:
  - `CHANGELOG.md`
  - `extensions/codex/src/node-cli-sessions.ts`
  - `extensions/codex/src/node-cli-sessions.test.ts`

AI-assisted: yes. The maintainer personally verified the implementation, upstream Codex contract, and focused proof.
