### PR TITLE
fix(moonshot): stop caching unfinished Kimi web searches

### DIFF
--- a/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
@@ -333,11 +333,9 @@ async function runKimiSearch(params: {
     }
   }
 
-  return {
-    content: "Search completed but no final answer was produced.",
-    citations: [...collectedCitations],
-    grounded: hasGroundingEvidence,
-  };
+  throw new Error(
+    "Kimi web search exhausted its tool-call rounds without producing a final answer. Retry the query or choose another search provider.",
+  );
 }
 
 export async function executeKimiWebSearchProviderTool(

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -223,6 +223,57 @@ describe("kimi web search provider", () => {
     });
   });
 
+  it("rejects exhausted web search rounds without caching a fabricated answer", async () => {
+    const query = "unique Kimi exhausted search rounds cache regression";
+    const toolCallResponse = (id: string) =>
+      jsonResponse({
+        choices: [
+          {
+            finish_reason: "tool_calls",
+            message: {
+              content: "",
+              tool_calls: [
+                {
+                  id,
+                  function: {
+                    name: "$web_search",
+                    arguments: JSON.stringify({ query }),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(toolCallResponse("call-1"))
+      .mockResolvedValueOnce(toolCallResponse("call-2"))
+      .mockResolvedValueOnce(toolCallResponse("call-3"))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          search_results: [{ title: "OpenClaw", url: "https://github.com/openclaw/openclaw" }],
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: "OpenClaw is available on GitHub." },
+            },
+          ],
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await withEnvAsync({ KIMI_API_KEY: "kimi-test-key" }, async () => {
+      await expect(executeKimiSearch(query)).rejects.toThrow(
+        "exhausted its tool-call rounds without producing a final answer",
+      );
+
+      const result = await executeKimiSearch(query);
+      expectStringFieldContains(result, "content", "OpenClaw is available on GitHub.");
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+  });
+
   it("accepts final responses with search result citations", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users searching the web with Kimi would receive a fabricated successful answer when Moonshot exhausted its native search-tool rounds without producing any final answer. That fabricated response was also cached, so retrying the same query immediately repeated the false result instead of contacting the provider again.

## Why This Change Was Made

The Moonshot plugin now treats exhaustion of its existing three-round native tool-call loop as an actionable provider failure at the response owner. Throwing before the success-only cache write preserves existing grounded-answer, citation, cancellation, configuration, and successful replay behavior while removing the fabricated success path.

## User Impact

Unfinished Kimi searches visibly fail with instructions to retry or select another search provider. A retry can immediately obtain a genuine grounded answer because incomplete results never poison the shared search cache.

## Evidence

- Regression proof follows the actual registered Kimi search tool through three consecutive native tool-call responses, verifies the actionable failure, retries the identical query, and receives a real grounded answer on the fourth provider request.
- Exact head: `8051c9df0ad0946ef05f998830f9544a201af820`.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs extensions/moonshot/src/kimi-web-search-provider.test.ts extensions/moonshot/index.test.ts --configLoader runner` — 2 files, 41 tests passed.
- `node --import tsx scripts/check-assertion-safety-ratchet.mts` — passed.
- `node --import tsx scripts/check-max-lines-ratchet.mts` — passed.
- `node_modules/.bin/oxfmt --check extensions/moonshot/src/kimi-web-search-provider.runtime.ts extensions/moonshot/src/kimi-web-search-provider.test.ts` — passed.
- Fresh independent structured Codex branch review: clean, no actionable findings.
- Production LOC: +3/-5 (net -2); regression tests: +51/-0.
- Real authenticated Moonshot traffic was not exercised; deterministic provider-boundary coverage uses the actual registered plugin tool and response/cache lifecycle without live credentials.
- Related Perplexity-provider empty-answer handling is isolated in a separate focused provider-owned follow-up.
