### PR TITLE
fix(ci): route recurring main validation through SHA helper

### DIFF
--- a/.agents/skills/openclaw-live-updater/SKILL.md
+++ b/.agents/skills/openclaw-live-updater/SKILL.md
@@ -59,19 +59,17 @@ Load `$release-openclaw-ci` and `$openclaw-testing`. This is validation only, ne
 
    ```bash
    MAIN_SHA="<exact-main-sha>"
-   gh workflow run full-release-validation.yml \
-     --repo openclaw/openclaw \
-     --ref main \
-     -f ref="$MAIN_SHA" \
-     -f expected_sha="$MAIN_SHA" \
+   pnpm ci:full-release \
+     --sha "$MAIN_SHA" \
+     --workflow-sha "$MAIN_SHA" \
      -f provider=openai \
      -f mode=both \
      -f release_profile=full \
      -f rerun_group=all
    ```
 
-3. Watch the parent with `release-ci-summary.mjs`; require its recorded target SHA and children to match the dispatch snapshot. Fetch logs only for failed or blocking jobs. Do not cancel unrelated release checks.
-4. For a code or harness failure, repair and land from the Codex worktree as above. Then target new exact `main` with the narrowest supported `rerun_group` that covers the failed child; use `live_suite_filter` for one live/E2E shard. A targeted recovery run does not create a second full/all cadence dispatch.
+3. Let the helper watch the parent to terminal and verify its release evidence. Retain its parent URL and require the recorded target SHA and children to match the dispatch snapshot. Fetch logs only for failed or blocking jobs. Do not cancel unrelated release checks.
+4. For a code or harness failure, repair and land from the Codex worktree as above. Then invoke the same helper with a new frozen exact-main tuple and the narrowest supported `rerun_group` that covers the failed child; use `live_suite_filter` for one live/E2E shard. A targeted recovery run does not create a second full/all cadence dispatch.
 5. Report exact SHA, parent and child run URLs/IDs, conclusions, repairs and landed PRs, targeted reruns, and any genuine proof gap. Do not write release evidence or publish artifacts unless separately authorized.
 
 ## Failure Discipline

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -7242,7 +7242,6 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
 
   it("pins every documented raw Full Release Validation caller to one exact SHA", () => {
     const nightly = readFileSync(".agents/skills/release-openclaw-nightly/SKILL.md", "utf8");
-    const liveUpdater = readFileSync(".agents/skills/openclaw-live-updater/SKILL.md", "utf8");
     const releaseCi = readFileSync(".agents/skills/release-openclaw-ci/SKILL.md", "utf8");
     const releaseCiNotes = readFileSync(
       ".agents/skills/release-openclaw-ci/references/release-ci-notes.md",
@@ -7256,11 +7255,6 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     const releasingDocs = readFileSync("docs/reference/RELEASING.md", "utf8");
 
     expect(nightly).toContain('-f expected_sha="$SHA"');
-    expectTextToIncludeAll(liveUpdater, [
-      'MAIN_SHA="<exact-main-sha>"',
-      '-f ref="$MAIN_SHA"',
-      '-f expected_sha="$MAIN_SHA"',
-    ]);
     for (const text of [releaseCi, fullReleaseDocs, releasingDocs]) {
       expectTextToIncludeAll(text, [
         'RELEASE_SHA="$(git rev-parse HEAD)"',


### PR DESCRIPTION
## Summary

- route recurring `main` Full Release Validation through the existing SHA-pinned helper
- freeze the workflow/tooling SHA to the same exact `main` snapshot as the validation target
- remove the obsolete raw-dispatch assertions; no workflow ref lifecycle or `contents: write` permission is added

## Root cause

The live-updater skill prescribed a raw `workflow_dispatch` from mutable `main`. The parent could resolve `main` before a child dispatch while a child later resolved a newer commit, causing the exact-SHA guard to fail.

The repository already has the canonical owner for this lifecycle: `scripts/full-release-validation-at-sha.mts`. It creates immutable target and workflow refs, dispatches and watches the parent, verifies parent/child evidence, retains refs on failure for recovery, and cleans them after verified success. Duplicating that lifecycle inside the workflow was unnecessary and made the earlier version of this PR much larger.

## Verification

- `node scripts/run-vitest.mjs test/scripts/full-release-validation-at-sha.test.ts` — 22/22 passed
- focused retained package-acceptance contract — passed
- helper `--dry-run` with identical `--sha` and `--workflow-sha` — emitted immutable target/workflow refs and exact target inputs without writing refs
- changed-file type, lint, formatting, docs, and policy checks — passed
- autoreview — clean, patch correct 0.99

## LOC

- skill/tooling guidance: +5/-7
- tests: +0/-6
- workflow/runtime production: +0/-0
- total: +5/-13
