### PR TITLE
chore(gateway): bind archive terminal test PTYs by owner

### DIFF
--- a/src/gateway/server.sessions.archive-terminal.test.ts
+++ b/src/gateway/server.sessions.archive-terminal.test.ts
@@ -1,6 +1,7 @@
 // Archive terminal tests protect exact durable-session ownership at the RPC boundary.
-import { afterEach, expect, test, vi } from "vitest";
+import { afterEach, expect, onTestFinished, test, vi } from "vitest";
 import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { TerminalSessionManager } from "./terminal/session-manager.js";
 import {
@@ -28,18 +29,24 @@ test("sessions.patch closes only the exact terminal session incarnation", async 
   const replacementOwner = agentTerminalOwner(sessionKey, "S2");
   const unrelatedOwner = agentTerminalOwner("agent:main:unrelated", "U1");
   const [oldPty, replacementPty, unrelatedPty] = [makeFakePty(), makeFakePty(), makeFakePty()];
-  const ptys = [oldPty, replacementPty, unrelatedPty];
-  const manager = new TerminalSessionManager({
-    emit: vi.fn(),
-    spawn: async () => ptys.shift() ?? oldPty,
-  });
+  const drainStarted = createDeferredCore();
+  const killOldPty = oldPty.kill.bind(oldPty);
+  oldPty.kill = () => {
+    killOldPty();
+    drainStarted.resolve();
+  };
+  const manager = new TerminalSessionManager({ emit: vi.fn() });
   await writeSessionStore({
     entries: { [sessionKey]: sessionStoreEntry(oldOwner.agentSessionId) },
   });
   const [oldSession, replacementSession, unrelatedSession] = await Promise.all([
-    manager.open(baseOpenRequest({ owner: oldOwner })),
-    manager.open(baseOpenRequest({ owner: replacementOwner })),
-    manager.open(baseOpenRequest({ owner: unrelatedOwner })),
+    manager.open(baseOpenRequest({ owner: oldOwner, createBackend: async () => oldPty })),
+    manager.open(
+      baseOpenRequest({ owner: replacementOwner, createBackend: async () => replacementPty }),
+    ),
+    manager.open(
+      baseOpenRequest({ owner: unrelatedOwner, createBackend: async () => unrelatedPty }),
+    ),
   ]);
   if (!oldSession.ok || !replacementSession.ok || !unrelatedSession.ok) {
     throw new Error("expected terminal sessions");
@@ -53,8 +60,17 @@ test("sessions.patch closes only the exact terminal session incarnation", async 
   ).finally(() => {
     archiveSettled = true;
   });
+  onTestFinished(async () => {
+    if (!archiveSettled) {
+      oldPty.emitExit(0);
+    }
+    await archivePromise;
+    manager.disposeAll();
+  });
 
-  await vi.waitFor(() => expect(oldPty.killed).toBe(true));
+  // Synchronize on the PTY action itself; cold RPC loading is not lifecycle timing.
+  await drainStarted.promise;
+  expect(oldPty.killed).toBe(true);
   expect(archiveSettled).toBe(false);
   expect(loadSessionEntry({ storePath, sessionKey })?.archivedAt).toBeUndefined();
   oldPty.emitExit(0);
@@ -76,5 +92,4 @@ test("sessions.patch closes only the exact terminal session incarnation", async 
   expect(unrelatedPty).toMatchObject({ killed: false, writes: ["unrelated"] });
   expect(manager.size).toBe(2);
   expect(loadSessionEntry({ storePath, sessionKey })?.archivedAt).toEqual(expect.any(Number));
-  manager.disposeAll();
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the archive-terminal regression failed in changed-test CI when three terminals opened concurrently and the lazy sessions RPC family loaded cold. Exact-head failure: [job 96524100760](https://github.com/openclaw/openclaw/actions/runs/32399470119/job/96524100760).

## Why This Change Was Made

Each terminal open now supplies its owner-specific fake backend instead of consuming a shared FIFO from concurrent opens. The test synchronizes on the old PTY's actual kill action, which is the lifecycle state under test; cold lazy-handler import time is outside that invariant. An awaited `onTestFinished` cleanup settles the archive RPC before Vitest teardown even when an assertion fails.

No private handler preload, forced environment, retry, timeout increase, or production seam is added.

Test audit:
- Observable contract: archiving one durable session incarnation kills only that incarnation's PTY before durable archive metadata commits.
- Credible regression: concurrent opens bind FIFO fakes by completion order, or cold lazy RPC loading exceeds an incidental assertion window.
- Existing coverage gap: the test coupled PTY identity to completion order and observed lifecycle start through a one-second polling window.
- Production seam: none; it uses existing request-owned `createBackend` and the fake PTY's observable `kill` action.

Production LOC: +0/-0 (net 0) | Tests: +26/-11 (net +15)

## User Impact

No user-visible runtime change. Gateway archive lifecycle CI now observes exact terminal ownership and lifecycle ordering deterministically.

## Evidence

- #126744 is merged at `7620ac28bac`; it repairs per-case store authority but did not repair this test's PTY/readiness coupling.
- Original failure: job `96510950421` failed `oldPty.killed` in one Gateway project.
- First PR head failure: job `96524100760` failed both Gateway projects and left the archive RPC importing after teardown.
- Exact local reproduction used `scripts/ci-run-node-test-shard.mts` with only `OPENCLAW_NODE_TEST_TARGETS_JSON=["src/gateway/server.sessions.archive-terminal.test.ts"]`, the two-project Gateway config, fresh isolated Vitest/Node caches, two workers, and no broader helper preload. Both projects failed before repair.
- Repaired exact CI-shaped proof: five consecutive fresh-cache runs passed both projects (10/10); the final streamlined cleanup shape passed the same exact fresh-cache command again.
- `pnpm test:changed`: passed both Gateway projects.
- Changed checks: all guards and core test typecheck passed; the sole lint finding (`unbound-method`) was repaired, then exact core oxlint and format checks passed.
- Autoreview on final head: clean, no accepted/actionable findings (`gpt-5.6-sol`, high).
- cmux diff attempted again; unavailable because this host reports `browser_disabled`. No cmux settings were changed.
- Exact-head GitHub CI and refreshed ClawSweeper review: pending.

Best-fix verdict: best. Sequential opens would weaken the concurrency contract; private module preloading or a longer wait would mask readiness latency. Owner-bound backends plus synchronization on the actual kill event expresses the invariant directly, and awaited test cleanup owns every asynchronous branch.
