### PR TITLE
fix(ci): add Telegram-only package acceptance profile

### DIFF
--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -98,13 +98,14 @@ on:
         default: package-acceptance
         type: string
       suite_profile:
-        description: Acceptance profile
+        description: "Acceptance profile: smoke, package, telegram, product, full, or custom"
         required: true
         default: package
         type: choice
         options:
           - smoke
           - package
+          - telegram
           - product
           - full
           - custom
@@ -249,7 +250,7 @@ on:
         default: ""
         type: string
       suite_profile:
-        description: "Acceptance profile: smoke, package, product, full, or custom"
+        description: "Acceptance profile: smoke, package, telegram, product, full, or custom"
         required: false
         default: package
         type: string
@@ -452,6 +453,7 @@ jobs:
       published_upgrade_survivor_scenarios: ${{ inputs.published_upgrade_survivor_scenarios }}
       telegram_enabled: ${{ steps.profile.outputs.telegram_enabled }}
       telegram_mode: ${{ steps.profile.outputs.telegram_mode }}
+      telegram_scenarios: ${{ steps.profile.outputs.telegram_scenarios }}
     steps:
       - name: Checkout package workflow ref
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -611,6 +613,7 @@ jobs:
           SUITE_PROFILE: ${{ inputs.suite_profile }}
           CUSTOM_DOCKER_LANES: ${{ inputs.docker_lanes }}
           TELEGRAM_MODE: ${{ inputs.telegram_mode }}
+          TELEGRAM_SCENARIOS: ${{ inputs.telegram_scenarios }}
         shell: bash
         run: |
           set -euo pipefail
@@ -626,6 +629,26 @@ jobs:
               ;;
             package)
               docker_lanes="npm-onboard-channel-agent doctor-switch update-channel-switch skill-install update-corrupt-plugin upgrade-survivor published-upgrade-survivor root-managed-vps-upgrade update-restart-auth plugins-offline plugin-update"
+              ;;
+            telegram)
+              if [[ "$TELEGRAM_MODE" == "none" ]]; then
+                echo "telegram_mode must not be none when suite_profile=telegram." >&2
+                exit 1
+              fi
+              telegram_scenarios=()
+              IFS=',' read -ra raw_telegram_scenarios <<< "$TELEGRAM_SCENARIOS"
+              for raw_scenario in "${raw_telegram_scenarios[@]}"; do
+                scenario="${raw_scenario#"${raw_scenario%%[![:space:]]*}"}"
+                scenario="${scenario%"${scenario##*[![:space:]]}"}"
+                if [[ -n "$scenario" ]]; then
+                  telegram_scenarios+=("$scenario")
+                fi
+              done
+              if [[ "${#telegram_scenarios[@]}" -ne 1 ]]; then
+                echo "telegram_scenarios must contain exactly one scenario when suite_profile=telegram." >&2
+                exit 1
+              fi
+              TELEGRAM_SCENARIOS="${telegram_scenarios[0]}"
               ;;
             product)
               docker_lanes="npm-onboard-channel-agent doctor-switch update-channel-switch skill-install update-corrupt-plugin upgrade-survivor published-upgrade-survivor root-managed-vps-upgrade update-restart-auth plugins plugin-update mcp-channels cron-mcp-cleanup openai-web-search-minimal openwebui"
@@ -663,6 +686,7 @@ jobs:
             echo "include_live_suites=$include_live_suites"
             echo "telegram_enabled=$telegram_enabled"
             echo "telegram_mode=$TELEGRAM_MODE"
+            echo "telegram_scenarios=$TELEGRAM_SCENARIOS"
             echo "package_artifact_name=${PACKAGE_ARTIFACT_NAME}"
           } >> "$GITHUB_OUTPUT"
 
@@ -814,6 +838,7 @@ jobs:
   npm_12_install_sh:
     name: npm 12 install.sh acceptance
     needs: [resolve_package, package_integrity]
+    if: inputs.suite_profile != 'telegram'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -873,7 +898,7 @@ jobs:
   docker_acceptance:
     name: Docker product acceptance (artifact-only)
     needs: [resolve_package, package_integrity]
-    if: inputs.shared_image_policy == 'no-push-artifact'
+    if: inputs.suite_profile != 'telegram' && inputs.shared_image_policy == 'no-push-artifact'
     permissions:
       actions: read
       contents: read
@@ -968,7 +993,7 @@ jobs:
   docker_acceptance_registry:
     name: Docker product acceptance (existing registry images)
     needs: [resolve_package, package_integrity]
-    if: inputs.shared_image_policy == 'existing-only'
+    if: inputs.suite_profile != 'telegram' && inputs.shared_image_policy == 'existing-only'
     permissions:
       actions: read
       contents: read
@@ -998,7 +1023,7 @@ jobs:
       package_label: openclaw@${{ needs.resolve_package.outputs.package_version }}
       harness_ref: ${{ inputs.workflow_ref }}
       provider_mode: ${{ needs.resolve_package.outputs.telegram_mode }}
-      scenario: ${{ inputs.telegram_scenarios }}
+      scenario: ${{ needs.resolve_package.outputs.telegram_scenarios }}
     secrets:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENCLAW_QA_CONVEX_SITE_URL: ${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}
@@ -1028,6 +1053,7 @@ jobs:
           NPM_12_INSTALL_RESULT: ${{ needs.npm_12_install_sh.result }}
           PACKAGE_TELEGRAM_RESULT: ${{ needs.package_telegram.result }}
           RESOLVE_RESULT: ${{ needs.resolve_package.result }}
+          SUITE_PROFILE: ${{ inputs.suite_profile }}
           TELEGRAM_ENABLED: ${{ needs.resolve_package.outputs.telegram_enabled }}
           TELEGRAM_ADVISORY: ${{ inputs.telegram_advisory }}
         shell: bash
@@ -1037,13 +1063,25 @@ jobs:
           if [[ "$docker_result" == "skipped" ]]; then
             docker_result="$DOCKER_REGISTRY_RESULT"
           fi
-          if [[ "$DOCKER_ARTIFACT_RESULT" != "skipped" && "$DOCKER_REGISTRY_RESULT" != "skipped" ]]; then
-            echo "::error::Both Docker acceptance transports ran; expected exactly one."
-            exit 1
-          fi
-          if [[ "$DOCKER_ARTIFACT_RESULT" == "skipped" && "$DOCKER_REGISTRY_RESULT" == "skipped" ]]; then
-            echo "::error::No Docker acceptance transport ran; expected exactly one."
-            exit 1
+          if [[ "$SUITE_PROFILE" == "telegram" ]]; then
+            if [[ "$NPM_12_INSTALL_RESULT" != "skipped" ]]; then
+              echo "::error::npm_12_install_sh ran for suite_profile=telegram; expected skipped."
+              exit 1
+            fi
+            if [[ "$DOCKER_ARTIFACT_RESULT" != "skipped" ||
+                  "$DOCKER_REGISTRY_RESULT" != "skipped" ]]; then
+              echo "::error::Docker acceptance ran for suite_profile=telegram; expected both transports skipped."
+              exit 1
+            fi
+          else
+            if [[ "$DOCKER_ARTIFACT_RESULT" != "skipped" && "$DOCKER_REGISTRY_RESULT" != "skipped" ]]; then
+              echo "::error::Both Docker acceptance transports ran; expected exactly one."
+              exit 1
+            fi
+            if [[ "$DOCKER_ARTIFACT_RESULT" == "skipped" && "$DOCKER_REGISTRY_RESULT" == "skipped" ]]; then
+              echo "::error::No Docker acceptance transport ran; expected exactly one."
+              exit 1
+            fi
           fi
           failed=0
           for item in \

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -190,6 +190,7 @@ type Workflow = {
       inputs?: Record<string, unknown>;
     };
   };
+  permissions?: Record<string, string>;
 };
 
 const parsedWorkflows = new Map<string, Workflow>();
@@ -735,6 +736,7 @@ function runPackageAcceptanceSummary(params: {
   dockerArtifactResult?: string;
   dockerRegistryResult?: string;
   npm12InstallResult?: string;
+  suiteProfile?: string;
   telegramAdvisory?: boolean;
   telegramEnabled: boolean;
   telegramResult: string;
@@ -755,10 +757,53 @@ function runPackageAcceptanceSummary(params: {
       PACKAGE_TELEGRAM_RESULT: params.telegramResult,
       PATH: process.env.PATH,
       RESOLVE_RESULT: "success",
+      SUITE_PROFILE: params.suiteProfile ?? "package",
       TELEGRAM_ADVISORY: String(params.telegramAdvisory ?? false),
       TELEGRAM_ENABLED: String(params.telegramEnabled),
     },
   });
+}
+
+function runPackageAcceptanceProfile(params: {
+  dockerLanes?: string;
+  suiteProfile: string;
+  telegramMode?: string;
+  telegramScenarios?: string;
+}) {
+  const job = workflowJob(PACKAGE_ACCEPTANCE_WORKFLOW, "resolve_package");
+  const script = workflowStep(job, "Select acceptance profile").run;
+  if (!script) {
+    throw new Error("Expected package acceptance profile script");
+  }
+  const workdir = tempDirs.make("package-acceptance-profile-");
+  const outputPath = resolve(workdir, "github-output");
+  const result = spawnSync("bash", ["-c", script], {
+    encoding: "utf8",
+    env: {
+      CUSTOM_DOCKER_LANES: params.dockerLanes ?? "",
+      GITHUB_OUTPUT: outputPath,
+      PACKAGE_ARTIFACT_NAME: "package-under-test",
+      PATH: process.env.PATH,
+      SOURCE: "ref",
+      SUITE_PROFILE: params.suiteProfile,
+      TELEGRAM_MODE: params.telegramMode ?? "none",
+      TELEGRAM_SCENARIOS: params.telegramScenarios ?? "",
+    },
+  });
+  const outputs =
+    result.status === 0
+      ? Object.fromEntries(
+          readFileSync(outputPath, "utf8")
+            .trim()
+            .split("\n")
+            .filter(Boolean)
+            .map((line) => {
+              const separator = line.indexOf("=");
+              return [line.slice(0, separator), line.slice(separator + 1)];
+            }),
+        )
+      : {};
+  return { outputs, result };
 }
 
 function runNpmTelegramInputValidation(overrides: Record<string, string>) {
@@ -2022,14 +2067,29 @@ describe("package acceptance workflow", () => {
   });
 
   it("offers bounded product profiles and can run Telegram against the resolved artifact", () => {
+    const parsedWorkflow = readWorkflow(PACKAGE_ACCEPTANCE_WORKFLOW);
     const workflow = readFileSync(PACKAGE_ACCEPTANCE_WORKFLOW, "utf8");
     const npmTelegramWorkflow = readFileSync(NPM_TELEGRAM_WORKFLOW, "utf8");
     const packageTelegram = workflowJob(PACKAGE_ACCEPTANCE_WORKFLOW, "package_telegram");
     const dockerAcceptance = workflowJob(PACKAGE_ACCEPTANCE_WORKFLOW, "docker_acceptance");
+    const dockerAcceptanceRegistry = workflowJob(
+      PACKAGE_ACCEPTANCE_WORKFLOW,
+      "docker_acceptance_registry",
+    );
+    const npm12Install = workflowJob(PACKAGE_ACCEPTANCE_WORKFLOW, "npm_12_install_sh");
     const npmTelegram = workflowJob(NPM_TELEGRAM_WORKFLOW, "run_package_telegram_e2e");
     const buildPrivateQa = workflowStep(npmTelegram, "Build private QA harness runtime");
 
     expect(workflow).toContain("suite_profile:");
+    expect(parsedWorkflow.on?.workflow_dispatch?.inputs?.suite_profile).toMatchObject({
+      default: "package",
+      description: "Acceptance profile: smoke, package, telegram, product, full, or custom",
+      options: ["smoke", "package", "telegram", "product", "full", "custom"],
+    });
+    expect(parsedWorkflow.on?.workflow_call?.inputs?.suite_profile).toMatchObject({
+      default: "package",
+      description: "Acceptance profile: smoke, package, telegram, product, full, or custom",
+    });
     expect(workflow).toContain("published_upgrade_survivor_baseline:");
     expect(workflow).toContain("published_upgrade_survivor_baselines:");
     expect(workflow).toContain("last-stable-4");
@@ -2081,7 +2141,9 @@ describe("package acceptance workflow", () => {
       "package_version: ${{ needs.resolve_package.outputs.package_version }}",
     );
     expect(workflow).toContain("telegram_scenarios:");
-    expect(workflow).toContain("scenario: ${{ inputs.telegram_scenarios }}");
+    expect(packageTelegram.with?.scenario).toBe(
+      "${{ needs.resolve_package.outputs.telegram_scenarios }}",
+    );
     expect(workflow).toContain(
       "package_label: openclaw@${{ needs.resolve_package.outputs.package_version }}",
     );
@@ -2093,9 +2155,34 @@ describe("package acceptance workflow", () => {
       "package_source_sha: ${{ steps.resolve.outputs.package_source_sha }}",
     );
     expect(packageTelegram.with?.harness_ref).toBe("${{ inputs.workflow_ref }}");
+    expect(packageTelegram.with?.package_source_sha).toBe(
+      "${{ needs.resolve_package.outputs.package_source_sha }}",
+    );
+    expect(packageTelegram.secrets).toEqual({
+      OPENAI_API_KEY: "${{ secrets.OPENAI_API_KEY }}",
+      OPENCLAW_QA_CONVEX_SECRET_CI: "${{ secrets.OPENCLAW_QA_CONVEX_SECRET_CI }}",
+      OPENCLAW_QA_CONVEX_SITE_URL: "${{ secrets.OPENCLAW_QA_CONVEX_SITE_URL }}",
+    });
     expect(dockerAcceptance.with?.ref).toBe(
       "${{ needs.resolve_package.outputs.package_source_sha || inputs.workflow_ref }}",
     );
+    expect(npm12Install.if).toBe("inputs.suite_profile != 'telegram'");
+    expect(dockerAcceptance.if).toBe(
+      "inputs.suite_profile != 'telegram' && inputs.shared_image_policy == 'no-push-artifact'",
+    );
+    expect(dockerAcceptanceRegistry.if).toBe(
+      "inputs.suite_profile != 'telegram' && inputs.shared_image_policy == 'existing-only'",
+    );
+    expect(parsedWorkflow.permissions).toEqual({
+      actions: "read",
+      contents: "read",
+      packages: "read",
+      "pull-requests": "read",
+    });
+    expect(workflow).not.toContain("NPM_TOKEN");
+    expect(workflow).not.toContain("contents: write");
+    expect(workflow).not.toContain("packages: write");
+    expect(workflow).not.toContain("id-token: write");
     expect(buildPrivateQa.env).toMatchObject({
       NODE_OPTIONS: "--max-old-space-size=8192",
       OPENCLAW_BUILD_PRIVATE_QA: "1",
@@ -2120,6 +2207,55 @@ describe("package acceptance workflow", () => {
     expect(workflow).toContain("Published upgrade survivor baselines:");
     expect(workflow).toContain("Published upgrade survivor scenarios:");
   });
+
+  it("selects one normalized Telegram scenario without enabling broad acceptance lanes", () => {
+    const { outputs, result } = runPackageAcceptanceProfile({
+      suiteProfile: "telegram",
+      telegramMode: "mock-openai",
+      telegramScenarios: "  telegram-commands-command  ",
+    });
+
+    expect(result.status).toBe(0);
+    expect(outputs).toMatchObject({
+      docker_lanes: "",
+      include_live_suites: "false",
+      include_openwebui: "false",
+      include_release_path_suites: "false",
+      telegram_enabled: "true",
+      telegram_mode: "mock-openai",
+      telegram_scenarios: "telegram-commands-command",
+    });
+  });
+
+  it.each([
+    {
+      expected: "telegram_mode must not be none",
+      telegramMode: "none",
+      telegramScenarios: "telegram-commands-command",
+    },
+    {
+      expected: "telegram_scenarios must contain exactly one scenario",
+      telegramMode: "mock-openai",
+      telegramScenarios: "",
+    },
+    {
+      expected: "telegram_scenarios must contain exactly one scenario",
+      telegramMode: "mock-openai",
+      telegramScenarios: "telegram-help-command, telegram-commands-command",
+    },
+  ])(
+    "rejects an invalid Telegram-only profile: $expected",
+    ({ expected, telegramMode, telegramScenarios }) => {
+      const { result } = runPackageAcceptanceProfile({
+        suiteProfile: "telegram",
+        telegramMode,
+        telegramScenarios,
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(expected);
+    },
+  );
 
   it("requires full release child workflows to run at the parent workflow SHA", () => {
     const workflow = readFileSync(FULL_RELEASE_VALIDATION_WORKFLOW, "utf8");
@@ -4900,6 +5036,43 @@ describe("package artifact reuse", () => {
         npm12InstallResult: "failure",
         telegramEnabled: false,
         telegramResult: "skipped",
+      },
+    },
+    {
+      expectedOutput: undefined,
+      expectedStatus: 0,
+      name: "accepts Telegram-only profile when broad lanes skip and Telegram succeeds",
+      params: {
+        dockerArtifactResult: "skipped",
+        dockerRegistryResult: "skipped",
+        npm12InstallResult: "skipped",
+        suiteProfile: "telegram",
+        telegramEnabled: true,
+        telegramResult: "success",
+      },
+    },
+    {
+      expectedOutput: "::error::npm_12_install_sh ran for suite_profile=telegram",
+      expectedStatus: 1,
+      name: "rejects Telegram-only profile when npm 12 acceptance runs",
+      params: {
+        dockerArtifactResult: "skipped",
+        dockerRegistryResult: "skipped",
+        suiteProfile: "telegram",
+        telegramEnabled: true,
+        telegramResult: "success",
+      },
+    },
+    {
+      expectedOutput: "::error::Docker acceptance ran for suite_profile=telegram",
+      expectedStatus: 1,
+      name: "rejects Telegram-only profile when a Docker transport runs",
+      params: {
+        dockerRegistryResult: "skipped",
+        npm12InstallResult: "skipped",
+        suiteProfile: "telegram",
+        telegramEnabled: true,
+        telegramResult: "success",
       },
     },
     {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maintainers could not run one packaged Telegram QA scenario without also paying for the unrelated npm 12 and Docker acceptance lanes.

## Why This Change Was Made

Adds a `telegram` package-acceptance profile that requires a non-`none` Telegram mode and exactly one normalized scenario. The profile keeps package resolution, tarball integrity, artifact identity, and Telegram proof unchanged while requiring the broad npm 12 and Docker jobs to skip.

All existing profile defaults and package/product/full behavior remain unchanged. The workflow stays read-only and does not publish, tag, release, or receive an npm token.

## User Impact

Maintainers can run a focused artifact-backed Telegram package proof against an exact source ref without dispatching the broad package acceptance matrix.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts`: 214 passed
- Focused post-format guard: 1 passed, 213 skipped
- `git diff --check`: passed
- `node scripts/check-changed.mjs --dry-run -- ...`: classified `testRoot, tooling`
- Local `check-changed` completed all pre-typecheck guards, then root test typecheck was blocked by files omitted from the sparse worktree; exact-head CI covers the full checkout.
- Exact-head CI: green on `ec982a729cd1a0352dc8bcfb6270d5a32c157063`
- Local autoreview: clean, no actionable findings
- ClawSweeper run `32399881459`: patch correct, no review findings

The hosted `suite_profile=telegram` dispatch is intentionally post-merge: the profile must first exist on canonical `main`. The immediate follow-up runs the landed workflow SHA against the exact package ref from PR #126247 and requires npm 12 plus both Docker jobs to skip while Telegram succeeds.

AI-assisted implementation; reviewed against the workflow owner, caller, summary, artifact tuple, secret, and source-SHA forwarding contracts.
