### PR TITLE
fix(gateway): stop child lookup from retaining the full session store

### DIFF
--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -49,7 +49,11 @@ import {
   branchCompactionCheckpointSession,
   restoreCompactionCheckpointSession,
 } from "./session-accessor.sqlite-checkpoint.js";
-import { listSessionEntryRows, replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
+import {
+  listSessionChildEntriesReadOnly,
+  listSessionEntryRows,
+  replaceSessionEntrySync,
+} from "./session-accessor.sqlite-entry.js";
 import { forkSessionEntryFromParentTarget } from "./session-accessor.sqlite-parent-session.js";
 import { loadTranscriptEventsSync } from "./session-accessor.sqlite-read.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
@@ -2209,6 +2213,14 @@ describe("sqlite session normalization", () => {
       .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
       .run(sessionKey);
 
+    expect(() =>
+      listSessionChildEntriesReadOnly({
+        agentId: "main",
+        env,
+        sessionKey: "agent:main:json-parent",
+        storePath: paths.sqlitePath,
+      }),
+    ).toThrow("openclaw doctor --fix");
     expect(() =>
       listSessionEntryRows({ agentId: "main", env, storePath: paths.sqlitePath }),
     ).toThrow("openclaw doctor --fix");

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -37,6 +37,7 @@ import {
   collectSessionEntryLookupKeys,
   createSessionIdentitySnapshot,
   deleteLegacySessionEntryRows,
+  parseReadableSqliteSessionEntryRow,
   readExactSessionEntryRowValidated,
   readSessionEntryRow,
   readLifecycleTargetSnapshot,
@@ -98,41 +99,10 @@ type ResolvedSqliteSessionEntry = {
   normalizedKey: string;
 };
 
-const childSessionKeysByEntrySnapshot = new WeakMap<
-  Map<string, SessionEntry>,
-  Map<string, string[]>
->();
-
 function assertCanonicalSessionWriteScope(
   scope: Pick<ResolvedSqliteScope, "agentId" | "sessionKey">,
 ): void {
   assertCanonicalSessionKeyWrite(scope.sessionKey, scope.agentId);
-}
-
-function getChildSessionKeysByParent(entries: Map<string, SessionEntry>): Map<string, string[]> {
-  const cached = childSessionKeysByEntrySnapshot.get(entries);
-  if (cached) {
-    return cached;
-  }
-  const childKeysByParent = new Map<string, Set<string>>();
-  for (const [sessionKey, entry] of entries) {
-    for (const rawParentKey of [entry.spawnedBy, entry.parentSessionKey]) {
-      const parentKey = rawParentKey?.trim();
-      if (!parentKey || parentKey === sessionKey) {
-        continue;
-      }
-      const childKeys = childKeysByParent.get(parentKey) ?? new Set<string>();
-      childKeys.add(sessionKey);
-      childKeysByParent.set(parentKey, childKeys);
-    }
-  }
-  // The parsed entry snapshot is replaced whenever SQLite's validity token changes.
-  // Keying the derived index by that identity keeps repeated single-row reads cheap and current.
-  const indexedChildKeys = new Map(
-    [...childKeysByParent].map(([parentKey, childKeys]) => [parentKey, [...childKeys]]),
-  );
-  childSessionKeysByEntrySnapshot.set(entries, indexedChildKeys);
-  return indexedChildKeys;
 }
 
 /** Resolves one canonical entry and its proven aliases without materializing the store. */
@@ -229,15 +199,34 @@ export function loadExactSessionEntryReadOnly(
 export function listSessionChildEntriesReadOnly(scope: SessionAccessScope): SessionEntrySummary[] {
   const resolved = resolveSqliteScope(scope);
   const result = withOpenClawAgentDatabaseReadOnly((database) => {
-    const snapshot = readSessionEntrySnapshot(database, resolved, scope.readConsistency);
-    const childKeys = getChildSessionKeysByParent(snapshot.entries).get(resolved.sessionKey) ?? [];
-    return childKeys.flatMap((sessionKey) => {
-      if (isInternalSessionEffectsKey(sessionKey)) {
+    assertCanonicalSqliteSessionKeysCurrent(database);
+    const db = getSessionKysely(database.db);
+    const childRows = executeSqliteQuerySync(
+      database.db,
+      db
+        .selectFrom("session_nodes")
+        .selectAll()
+        .where((expression) =>
+          expression.or([
+            expression("parent_session_key", "=", resolved.sessionKey),
+            expression("spawned_by", "=", resolved.sessionKey),
+          ]),
+        )
+        .where("session_key", "!=", resolved.sessionKey)
+        .orderBy("session_key", "asc"),
+    ).rows;
+    return childRows.flatMap((row) => {
+      if (isInternalSessionEffectsKey(row.session_key)) {
         return [];
       }
-      const entry = snapshot.entries.get(sessionKey);
+      const entry = parseReadableSqliteSessionEntryRow(database, row);
       return entry
-        ? [{ sessionKey, entry: scope.clone === false ? entry : cloneSessionEntry(entry) }]
+        ? [
+            {
+              sessionKey: row.session_key,
+              entry: scope.clone === false ? entry : cloneSessionEntry(entry),
+            },
+          ]
         : [];
     });
   }, toDatabaseOptions(resolved));

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -39,6 +39,7 @@ import {
   deleteSessionEntryLifecycle,
   findTranscriptEvent,
   ensureSessionEntrySync,
+  listSessionChildEntriesReadOnly,
   listSessionEntriesCore,
   listSessionEntriesByStatus,
   listSessionTranscriptInstances,
@@ -974,12 +975,25 @@ describe("session accessor seam", () => {
     expect(fs.existsSync(storePath)).toBe(false);
   });
 
-  it("does not parse unrelated blobs across canonical candidate and transcript reads", async () => {
+  it("does not parse unrelated blobs across focused child, candidate, and transcript reads", async () => {
     const sessionKey = "agent:main:focused-session";
     await upsertSessionEntryCore(
       { agentId: "main", sessionKey, storePath },
       { sessionId: "focused-session", updatedAt: 42 },
     );
+    for (const [childSessionKey, lineage] of [
+      ["agent:main:focused-both-child", { spawnedBy: sessionKey }],
+      ["agent:main:focused-parent-child", { parentSessionKey: sessionKey }],
+      [
+        "agent:main:focused-spawned-child",
+        { parentSessionKey: "agent:main:other-parent", spawnedBy: sessionKey },
+      ],
+    ] as const) {
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: childSessionKey, storePath },
+        { ...lineage, sessionId: childSessionKey, updatedAt: 43 },
+      );
+    }
     const databasePath = expectDefined(
       resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
       "focused session database path",
@@ -994,6 +1008,16 @@ describe("session accessor seam", () => {
 
     const parse = vi.spyOn(JSON, "parse");
     try {
+      expect(
+        listSessionChildEntriesReadOnly({ agentId: "main", sessionKey, storePath }).map(
+          (child) => child.sessionKey,
+        ),
+      ).toEqual([
+        "agent:main:focused-both-child",
+        "agent:main:focused-parent-child",
+        "agent:main:focused-spawned-child",
+      ]);
+      expect(parse.mock.calls.filter(([value]) => value === unrelatedEntryJson)).toHaveLength(0);
       expect(
         resolveSessionEntrySelection({ agentId: "main", sessionKey, storePath }),
       ).toMatchObject({


### PR DESCRIPTION
Related: #126663

## What Problem This Solves

Fixes an issue where Gateway child-session discovery could parse and retain every persisted session entry when it only needed the direct children of one session. On stores with large `entry_json` rows, that made a single lookup initialize a process-lifetime parsed snapshot and materially increased heap/RSS.

This addresses the child-read retention amplifier related to #126663; it does not attempt to solve the separate duplicated skills snapshot or synchronous write-size problem tracked there.

## Why This Change Was Made

The accessor now queries the existing indexed `parent_session_key` and `spawned_by` projections directly, validates canonical lineage before trusting those projections, and hydrates only matching rows through the canonical owner/participant parser. The snapshot-derived parent index was deleted, preserving one SQLite-owned lookup path without a fallback stack.

## User Impact

Gateways with many or large sessions no longer retain the complete parsed session store just to include direct child sessions in a single-session lookup. Child ordering, both lineage forms, deduplication, self/internal filtering, clone behavior, and canonical-repair failures remain intact.

## Evidence

- Regression proof: before the production repair, the focused accessor test observed one parse of an unrelated malformed `entry_json` row during direct-child lookup; after the repair it observes zero and returns children from both lineage columns.
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.test.ts` — 108 passed.
- `node scripts/run-vitest.mjs src/config/sessions/session-accessor.conformance.test.ts -t 'fails loud when promoted lineage disagrees with canonical entry JSON'` — passed.
- `node scripts/run-vitest.mjs src/gateway/session-utils.test.ts -t 'loadGatewaySessionEntryReadOnly clones only the selected row and direct children'` — 2 passed.
- `node scripts/check-changed.mjs -- src/config/sessions/session-accessor.sqlite-entry.ts src/config/sessions/session-accessor.test.ts src/config/sessions/session-accessor.conformance.test.ts` — passed.
- `pnpm test:changed` completed 12,516 passing tests before four unrelated loaded-host timing/race failures; each exact failing test passed immediately when rerun in isolation.
- Clean Linux proof: AWS Crabbox run `run_eb9acb04df3f` passed the full accessor file and both focused sibling regressions.
- Clean Linux 828-session synthetic probe (`38,692,259` raw JSON bytes): direct-child lookup retained `78,712` heap bytes; materializing the full parsed store retained `39,082,072` heap bytes.
- SQLite `EXPLAIN QUERY PLAN` used `MULTI-INDEX OR` with both `idx_agent_session_nodes_parent_session_key` and `idx_agent_session_nodes_spawned_by`.
- Mandatory autoreview: clean, no accepted/actionable findings.
- Production LOC: +26/-37 (net -11). Tests: +38/-2.

AI-assisted; the implementation and proof were reviewed against the session storage, canonical-lineage, Gateway hot-path, and test-audit contracts.
