### PR TITLE
fix(sessions): warn when New Chat retains a managed worktree

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -46,6 +46,7 @@ import {
   attachGatewayLocalUserIngress,
   prepareGatewayLocalUserIngress,
 } from "./local-user-ingress.js";
+import { sessionLog } from "./server-methods/sessions-shared.js";
 import { listSessionGroups } from "./session-groups.js";
 import {
   resolveSessionMutationAuthorization,
@@ -2594,6 +2595,116 @@ test("sessions.create skips the worktree setup script for non-admin callers", as
     await openClawState.cleanup();
   }
 });
+
+test.each([
+  { name: "a dirty checkout", outcome: "dirty" },
+  { name: "a concurrently finalized checkout", outcome: "finalized" },
+  { name: "successful cleanup", outcome: "removed" },
+  { name: "a cleanup exception", outcome: "failed" },
+] as const)(
+  "sessions.create reset-in-place reports cleanup truth for $name",
+  async ({ outcome }) => {
+    const openClawState = await createOpenClawTestState({
+      layout: "state-only",
+      prefix: "openclaw-reset-retained-worktree-",
+    });
+    const root = openClawState.root;
+    const workspace = await initializeGitWorkspace(root);
+    const origin = path.join(root, "origin.git");
+    await execFileAsync("git", ["init", "--bare", origin]);
+    await execFileAsync("git", ["-C", workspace, "remote", "add", "origin", origin]);
+    await execFileAsync("git", ["-C", workspace, "push", "-u", "origin", "main"]);
+    closeOpenClawStateDatabaseForTest();
+    testState.agentConfig = { workspace };
+    testState.sessionConfig = { dmScope: "main" };
+    const { storePath } = await createSessionStoreDir();
+    await writeSessionStore({ entries: { main: sessionStoreEntry("sess-retained-parent") } });
+    const warnSpy = vi.spyOn(sessionLog, "warn").mockImplementation(() => {});
+    const originalRemoveIfLossless = managedWorktrees.removeIfLossless.bind(managedWorktrees);
+    let restoreRemoveIfLossless = () => {};
+    let worktreeId: string | undefined;
+    try {
+      const created = await directSessionReq<{
+        worktree: { id: string; path: string; branch: string };
+      }>(
+        "sessions.create",
+        { agentId: "main", parentSessionKey: "main", emitCommandHooks: true, worktree: true },
+        { client: { connect: { scopes: ["operator.admin"] } } as never },
+      );
+      expect(created.ok).toBe(true);
+      const worktree = created.payload!.worktree;
+      worktreeId = worktree.id;
+      const dirtyFile = path.join(worktree.path, "retained-work.txt");
+      if (outcome === "dirty") {
+        await fs.writeFile(dirtyFile, "preserve my work\n");
+      } else if (outcome === "finalized" || outcome === "failed") {
+        const removeSpy = vi
+          .spyOn(managedWorktrees, "removeIfLossless")
+          .mockImplementation(async (id) => {
+            if (outcome === "failed") {
+              throw new Error("simulated cleanup failure");
+            }
+            await originalRemoveIfLossless(id);
+            return false;
+          });
+        restoreRemoveIfLossless = () => removeSpy.mockRestore();
+      }
+
+      const reset = await directSessionReq<{
+        entry: { spawnedCwd?: string; sessionRoot?: string; worktree?: unknown };
+      }>(
+        "sessions.create",
+        { agentId: "main", parentSessionKey: "main", emitCommandHooks: true },
+        { client: { connect: { scopes: ["operator.write"] } } as never },
+      );
+
+      expect(reset.ok).toBe(true);
+      expect(reset.payload).not.toHaveProperty("worktreePreserved");
+      expect(reset.payload?.entry.spawnedCwd).toBeUndefined();
+      expect(reset.payload?.entry.sessionRoot).toBeUndefined();
+      expect(reset.payload?.entry.worktree).toBeUndefined();
+      expect(
+        loadSessionEntry({ sessionKey: "agent:main:main", storePath })?.worktree,
+      ).toBeUndefined();
+      if (outcome === "dirty") {
+        expect(getRegistryWorktree(process.env, worktree.id)).toMatchObject({
+          runEndCleanup: { outcome: "retained-dirty" },
+        });
+        await expect(fs.readFile(dirtyFile, "utf8")).resolves.toBe("preserve my work\n");
+        expect(warnSpy).toHaveBeenCalledOnce();
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(worktree.branch));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(worktree.path));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("retained-dirty"));
+      } else if (outcome === "failed") {
+        expect(getRegistryWorktree(process.env, worktree.id)?.removedAt).toBeUndefined();
+        await expect(fs.access(worktree.path)).resolves.toBeUndefined();
+        expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+          "failed to finalize session worktree lifecycle: simulated cleanup failure",
+        );
+      } else {
+        expect(getRegistryWorktree(process.env, worktree.id)?.removedAt).toEqual(
+          expect.any(Number),
+        );
+        await expect(fs.access(worktree.path)).rejects.toThrow();
+        expect(warnSpy).not.toHaveBeenCalled();
+      }
+    } finally {
+      restoreRemoveIfLossless();
+      warnSpy.mockRestore();
+      if (worktreeId && getRegistryWorktree(process.env, worktreeId)?.removedAt === undefined) {
+        await managedWorktrees.remove({
+          id: worktreeId,
+          reason: "test-cleanup",
+          allowSnapshotLoss: true,
+        });
+      }
+      closeOpenClawStateDatabaseForTest();
+      testState.agentConfig = undefined;
+      testState.sessionConfig = undefined;
+      await openClawState.cleanup();
+    }
+  },
+);
 
 test("sessions.create reset-in-place detaches the prior worktree permission boundary", async () => {
   const openClawState = await createOpenClawTestState({

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -3,7 +3,9 @@
 import { randomUUID } from "node:crypto";
 import { cleanupSessionResources } from "@openclaw/ai/internal/runtime";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { ErrorCodes, errorShape } from "../../packages/gateway-protocol/src/index.js";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { getAcpSessionManager } from "../acp/control-plane/manager.js";
 import { tryPrepareFreshManagerRuntimeSession } from "../acp/control-plane/manager.runtime-resume-state.js";
 import { getAcpRuntimeBackend } from "../acp/runtime/registry.js";
@@ -1742,7 +1744,17 @@ export async function performGatewaySessionReset(params: {
         // Preserve reset notifications and unbinding order, but finalize the exact
         // old checkout before the fence opens to same-key successors.
         try {
-          await managedWorktrees.removeIfLossless(detachedWorktreeId);
+          if (!(await managedWorktrees.removeIfLossless(detachedWorktreeId))) {
+            const retained = managedWorktrees.findLiveById(detachedWorktreeId);
+            if (retained) {
+              const safePath = truncateUtf16Safe(sanitizeForLog(retained.path), 256);
+              reportLifecycleCleanupError(
+                new Error(
+                  `worktree retained: branch=${retained.branch} path=${safePath} outcome=${retained.runEndCleanup?.outcome}`,
+                ),
+              );
+            }
+          }
         } catch (error) {
           reportLifecycleCleanupError(error);
         }


### PR DESCRIPTION
Closes #126756

## What Problem This Solves

Fixes an issue where users starting a plain New Chat from a session with a dirty managed Git worktree would successfully leave that session while its checkout remained safely preserved but completely invisible in Gateway warnings. Dirty, unpushed, busy, and provisioned-drift worktrees can legitimately require retention, so operators need the already-recorded reason rather than destructive cleanup or a changed response contract.

## Why This Change Was Made

The existing session-reset lifecycle owner now consumes the lossless worktree-removal result, re-reads the exact live worktree when cleanup returns false, and sends one actionable retention message through the already-established `sessions.create` Gateway lifecycle warning callback. A concurrently finalized checkout emits no warning; worktree paths are ANSI/control-character sanitized and safely capped before logging. Direct reset/delete behavior, retention policy, persistence, configuration, and the Gateway protocol remain unchanged.

## User Impact

New Chat continues to succeed and never deletes work that cannot be removed losslessly. Operators can now identify the preserved checkout, its safe branch/path, and its existing precise retention outcome instead of silently accumulating detached managed worktrees.

## Evidence

- Before the fix, the new real Git/SQLite Gateway regression failed with `expected "warn" to be called once, but got 0 times`; the dirty checkout and its recorded `retained-dirty` outcome were preserved.
- After the fix, four real `sessions.create` lifecycle cases verify dirty retention with exactly one warning, concurrent finalization with no warning, successful removal with no warning, and thrown cleanup with its existing warning exactly once.
- Gateway session-create, direct-reset, and direct-delete owner/sibling suites: 140 tests passing under the canonical `gateway-server` Vitest project.
- Managed-worktree cleanup owner suite: 10 tests passing, including dirty, unpushed, busy, finalized, restore, and exception classifications.
- Production: +13/-1 lines (net +12); tests: +111/-0 lines. The two existing sanitizer imports and bounded path composition account for the small production growth.
- Independent adversarial review: no findings across false semantics, concurrent finalization, warning uniqueness, safe fields, owner boundaries, sibling behavior, and unchanged protocol.
- AI-assisted: yes.

Live UI recording is not applicable: the observable change is an operator Gateway log warning, not a visual/UI or protocol change; the real handler, temporary Git checkout, SQLite state, and actual Gateway warning sink are exercised directly.
