### PR TITLE
fix(onboard): reject a malformed API key from the environment too

### DIFF
--- a/src/commands/onboard-non-interactive/api-keys.test.ts
+++ b/src/commands/onboard-non-interactive/api-keys.test.ts
@@ -91,28 +91,77 @@ describe("resolveNonInteractiveApiKey", () => {
     expect(runtime.exit).not.toHaveBeenCalled();
   });
 
-  it("rejects command-shaped flag keys before returning them", async () => {
+  it.each([
+    { source: "flag", flagValue: "malformed" },
+    { source: "environment", resolvedEnv: true },
+    { source: "secret-ref environment", resolvedEnv: true, secretInputMode: "ref" as const },
+  ])("rejects command-shaped $source keys before returning them", async (testCase) => {
     const runtime = createRuntime();
-    resolveEnvApiKey.mockImplementation(() => {
-      throw new Error("env lookup should not run for a malformed explicit flag");
-    });
+    const malformedKey =
+      "openclaw onboard --non-interactive --auth-choice=zai-coding-global --zai-api-key $ZAI_API_KEY";
+    if (testCase.resolvedEnv) {
+      resolveEnvApiKey.mockReturnValue({
+        apiKey: malformedKey,
+        source: "env: ZAI_API_KEY",
+      });
+    } else {
+      resolveEnvApiKey.mockImplementation(() => {
+        throw new Error("env lookup should not run for a malformed explicit flag");
+      });
+    }
 
     const result = await resolveNonInteractiveApiKey({
       provider: "zai",
       cfg: {},
-      flagValue:
-        "openclaw onboard --non-interactive --auth-choice=zai-coding-global --zai-api-key $ZAI_API_KEY",
+      flagValue: testCase.flagValue === "malformed" ? malformedKey : undefined,
       flagName: "--zai-api-key",
       envVar: "ZAI_API_KEY",
       runtime: runtime as never,
+      secretInputMode: testCase.secretInputMode,
     });
 
     expect(result).toBeNull();
-    expect(resolveEnvApiKey).not.toHaveBeenCalled();
+    expect(resolveEnvApiKey).toHaveBeenCalledTimes(testCase.resolvedEnv ? 1 : 0);
     expect(runtime.error).toHaveBeenCalledWith(
-      "Paste the API key value, not an OpenClaw onboarding command.",
+      testCase.resolvedEnv
+        ? "Paste the API key value, not an OpenClaw onboarding command. Check ZAI_API_KEY."
+        : "Paste the API key value, not an OpenClaw onboarding command.",
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects a command-shaped explicit env key before a secret-ref flag", async () => {
+    const runtime = createRuntime();
+    const previousZaiApiKey = process.env.ZAI_API_KEY;
+    process.env.ZAI_API_KEY = "openclaw onboard --non-interactive --auth-choice zai-api-key"; // pragma: allowlist secret
+    resolveEnvApiKey.mockImplementation(() => {
+      throw new Error("broad env lookup should not run for an explicit ref-mode flag");
+    });
+
+    try {
+      const result = await resolveNonInteractiveApiKey({
+        provider: "zai",
+        cfg: {},
+        flagValue: "zai-flag-key",
+        flagName: "--zai-api-key",
+        envVar: "ZAI_API_KEY",
+        runtime: runtime as never,
+        secretInputMode: "ref",
+      });
+
+      expect(result).toBeNull();
+      expect(resolveEnvApiKey).not.toHaveBeenCalled();
+      expect(runtime.error).toHaveBeenCalledWith(
+        "Paste the API key value, not an OpenClaw onboarding command. Check ZAI_API_KEY.",
+      );
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+    } finally {
+      if (previousZaiApiKey === undefined) {
+        delete process.env.ZAI_API_KEY;
+      } else {
+        process.env.ZAI_API_KEY = previousZaiApiKey;
+      }
+    }
   });
 
   it.each([

--- a/src/commands/onboard-non-interactive/api-keys.ts
+++ b/src/commands/onboard-non-interactive/api-keys.ts
@@ -90,12 +90,21 @@ export async function resolveNonInteractiveApiKey(params: {
       envVarName: parseEnvVarNameFromSourceLabel(envResolved?.source) ?? explicitEnvVar,
     };
   };
+  const returnOperatorKey = (key: string, source: "flag" | "env", envVarName?: string) => {
+    if (!isMalformedApiKeyInput(key)) {
+      return envVarName ? { key, source, envVarName } : { key, source };
+    }
+    const envHint = source === "env" ? ` Check ${envVarName ?? params.envVar}.` : "";
+    params.runtime.error(`Paste the API key value, not an OpenClaw onboarding command.${envHint}`);
+    params.runtime.exit(1);
+    return null;
+  };
 
   const useSecretRefMode = params.secretInputMode === "ref"; // pragma: allowlist secret
   if (useSecretRefMode && flagKey) {
     const explicitEnvKey = resolveExplicitEnvKey();
     if (explicitEnvKey) {
-      return { key: explicitEnvKey, source: "env", envVarName: explicitEnvVar };
+      return returnOperatorKey(explicitEnvKey, "env", explicitEnvVar);
     }
     // A literal flag value cannot be converted into a durable secret reference;
     // require an env var so the stored config can reference a stable name.
@@ -124,24 +133,21 @@ export async function resolveNonInteractiveApiKey(params: {
         params.runtime.exit(1);
         return null;
       }
-      return { key: resolvedEnv.key, source: "env", envVarName: resolvedEnv.envVarName };
+      return returnOperatorKey(resolvedEnv.key, "env", resolvedEnv.envVarName);
     }
   }
 
   if (flagKey) {
-    if (isMalformedApiKeyInput(flagKey)) {
-      params.runtime.error("Paste the API key value, not an OpenClaw onboarding command.");
-      params.runtime.exit(1);
-      return null;
-    }
-    return { key: flagKey, source: "flag" };
+    return returnOperatorKey(flagKey, "flag");
   }
 
   const resolvedEnv = resolveEnvKey();
   if (resolvedEnv.key) {
-    return { key: resolvedEnv.key, source: "env", envVarName: resolvedEnv.envVarName };
+    return returnOperatorKey(resolvedEnv.key, "env", resolvedEnv.envVarName);
   }
 
+  // Stored profiles are pre-existing state: doctor diagnoses them, while a new
+  // flag or env value must remain able to replace them during onboarding.
   if (params.allowProfile ?? true) {
     const profileKey = await resolveApiKeyFromProfiles({
       provider: params.provider,


### PR DESCRIPTION
## What Problem This Solves

The same bad value is refused through one input path and silently stored through the other, and the
silent one is the path the docs tell operators to use.

A real operator failure mode is pasting an OpenClaw onboarding command where an API key belongs. The
codebase already knows about it — `isMalformedApiKeyInput` exists, `evaluateStoredCredentialEligibility`
returns `malformed_api_key`, and doctor renders a purpose-built hint for it. That hint text exists
because someone actually did this.

**Through the flag, this works correctly:**

```
$ openclaw onboard --non-interactive --accept-risk --mode local --auth-choice openai-api-key \
    --openai-api-key 'openclaw onboard --non-interactive --auth-choice openai-api-key' ...

exit=1
Paste the API key value, not an OpenClaw onboarding command.
config written? NO
```

**Through the environment variable, which is the form `docs/start/wizard-cli-automation.md` documents
for automation, it did not:**

```
$ OPENAI_API_KEY='openclaw onboard --non-interactive --auth-choice openai-api-key' \
    openclaw onboard --non-interactive --accept-risk --mode local --auth-choice openai-api-key ...

exit=0
stderr: (empty)
config written? YES
```

The command string was persisted verbatim as the credential:

```
openai:api-key {'type': 'api_key', 'provider': 'openai',
                'key': 'openclaw onboard --non-interactive --auth-choice openai-api-key'}
```

The operator finishes onboarding believing they are configured. Nothing tells them otherwise until
their first agent turn fails, or until they happen to run `openclaw doctor` — which detects it
immediately and prints the hint they were never shown:

```
Model auth
  - openai:api-key: missing [malformed_api_key] — Paste the API key value, not an OpenClaw
    onboarding command.
```

This is the repo's top severity class: an action that ends with no visible outcome and no recorded
reason.

## Why This Change Was Made

`src/commands/onboard-non-interactive/api-keys.ts` already imported `isMalformedApiKeyInput`, but
applied it inside `if (flagKey) { ... }` only. Three other return points hand back an
operator-supplied key unchecked: the secret-ref explicit-env branch, the secret-ref resolved-env
branch, and the plain `resolveEnvKey()` branch. The detection logic was present and simply not
reached — the guarded path was the flag, and the unguarded path was the documented one.

All four operator-supplied return points now go through a single `returnOperatorKey` helper rather
than three copies of the same `if`, so a future branch cannot quietly skip the check. When the value
came from the environment the message also names the variable it came from; an operator with several
exported provider keys otherwise cannot tell which one is wrong.

The stored-profile branch is deliberately left unguarded, with a comment saying so. A malformed key
already sitting in a profile is pre-existing state that doctor owns and diagnoses; refusing there
would strand an operator who is re-running onboarding precisely to replace it. Making that asymmetry
readable at the call site keeps it a decision rather than an oversight.

## User Impact

An operator who pastes a command instead of a key now finds out at the moment they do it, through
either input path, and onboarding writes nothing. Before, the environment path produced a
configuration that looked complete and failed later somewhere else.

Valid keys are unaffected through every path, and the stored-profile path behaves exactly as before.

## Evidence

**Live proof on a built CLI, verified independently of the change author.**

Environment path, previously silent:

```
exit=1
Paste the API key value, not an OpenClaw onboarding command. Check OPENAI_API_KEY.
config written? NO
agent db? NO
```

Valid key through the same environment path, to prove the guard is not over-broad:

```
exit=0
stderr: (empty)
config written? YES
```

A second provider confirms this is not OpenAI-specific: the Z.AI environment path rejects with
`Paste the API key value, not an OpenClaw onboarding command. Check ZAI_API_KEY.` and leaves no
config, agent database, or workspace behind.

**Tests.** `src/commands/onboard-non-interactive` — 10 files, 100 tests, passing. The existing
single-case flag test became a table covering flag, environment, and secret-ref environment sources,
plus one explicit case for the secret-ref explicit-env branch that asserts the broad env lookup never
runs. Against unrepaired production code the new cases fail. No near-duplicate tests were added.

`node scripts/check-changed.mjs` exit 0. Autoreview clean — "the patch consistently applies malformed
command-shaped API-key validation to operator-supplied flag and environment values, including
secret-reference mode."

Production `+15/-9` (net **+6**), tests `+57/-8`.
