### PR TITLE
fix(qa): preserve Codex auth identity across restarts

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test.ts
@@ -197,10 +197,19 @@ async function answerInitialize(harness: ClientHarness): Promise<void> {
   harness.send({ id: initialize.id, result: { userAgent: "openclaw/0.148.0 (macOS; test)" } });
 }
 
+async function answerPreparedApiKeyLogin(harness: ClientHarness): Promise<void> {
+  const login = await waitForRequest(harness, "account/login/start");
+  expect(login.params).toEqual({
+    type: "apiKey",
+    apiKey: "prepared-platform-key",
+  });
+  harness.send({ id: login.id, result: { type: "apiKey" } });
+}
+
 async function waitForRequest(
   harness: ClientHarness,
   method: string,
-): Promise<{ id?: number; method?: string }> {
+): Promise<{ id?: number; method?: string; params?: unknown }> {
   await vi.waitFor(
     () =>
       expect(readHarnessMessages(harness.writes).some((write) => write.method === method)).toBe(
@@ -338,9 +347,13 @@ describe("startCodexAttemptThread", () => {
     result.releaseSharedClientLease();
   });
 
-  it("restarts managed app-server when Computer Use is enabled after acquire", async () => {
+  it("reapplies prepared auth before thread startup after a managed Computer Use restart", async () => {
     const first = createClientHarness();
     const second = createClientHarness();
+    const preparedAuth = {
+      kind: "api-key" as const,
+      apiKey: "prepared-platform-key",
+    };
     const startSpy = vi
       .spyOn(CodexAppServerClient, "start")
       .mockReturnValueOnce(first.client)
@@ -352,6 +365,7 @@ describe("startCodexAttemptThread", () => {
       paths,
       pluginConfig: {},
       skipStartSpy: true,
+      startupPreparedAuth: preparedAuth,
       attemptClientFactory: () => async (options) => {
         const client = await getLeasedSharedCodexAppServerClient(options);
         if (!persistedComputerUse) {
@@ -369,6 +383,7 @@ describe("startCodexAttemptThread", () => {
     });
 
     await answerInitialize(first);
+    await answerPreparedApiKeyLogin(first);
     await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2), {
       timeout: HARNESS_REQUEST_TIMEOUT_MS,
     });
@@ -378,15 +393,36 @@ describe("startCodexAttemptThread", () => {
     );
 
     await answerInitialize(second);
+    await answerPreparedApiKeyLogin(second);
     const threadStart = await waitForThreadStart(second);
-    second.send({ id: threadStart.id, result: threadStartResult("thread-restarted") });
+    second.send({
+      id: threadStart.id,
+      error: { code: -32000, message: "401 authentication_error: Invalid bearer token" },
+    });
 
-    const result = await run;
-    expect(result.thread.threadId).toBe("thread-restarted");
-    result.turnRoute.release();
-    result.releaseSharedClientLease();
+    await expect(run).rejects.toMatchObject({
+      name: "CodexThreadStartRequestError",
+      message: "thread/start: 401 authentication_error: Invalid bearer token",
+      cause: expect.objectContaining({
+        name: "CodexAppServerRpcError",
+        method: "thread/start",
+        message: "401 authentication_error: Invalid bearer token",
+      }),
+    });
+    expect(
+      readHarnessMessages(first.writes)
+        .filter((entry) => entry.id !== undefined)
+        .map((entry) => entry.method),
+    ).toEqual(["initialize", "account/login/start"]);
+    expect(
+      readHarnessMessages(second.writes)
+        .filter((entry) => entry.id !== undefined)
+        .map((entry) => entry.method),
+    ).toEqual(["initialize", "account/login/start", "thread/start"]);
+    expect(startSpy).toHaveBeenCalledTimes(2);
     expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
     await vi.waitFor(() => expect(first.process.stdin.destroyed).toBe(true));
+    await vi.waitFor(() => expect(second.process.stdin.destroyed).toBe(true));
   });
 
   it("retires the startup generation when context restart sees a new executable owner", async () => {

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -218,6 +218,7 @@ describe("CodexAppServerClient", () => {
     await expect(request).rejects.toHaveProperty("name", "CodexAppServerRpcError");
     await expect(request).rejects.toHaveProperty("code", -32601);
     await expect(request).rejects.toHaveProperty("message", "Method not found");
+    await expect(request).rejects.toHaveProperty("method", "future/method");
   });
 
   it("retries transient app-server overload errors", async () => {

--- a/extensions/codex/src/app-server/thread-lifecycle-errors.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-errors.ts
@@ -2,7 +2,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 
 export class CodexThreadStartRequestError extends Error {
   constructor(cause: unknown) {
-    super(formatErrorMessage(cause), { cause });
+    super(`thread/start: ${formatErrorMessage(cause)}`, { cause });
     this.name = "CodexThreadStartRequestError";
   }
 }

--- a/extensions/qa-lab/src/gateway-child-env.ts
+++ b/extensions/qa-lab/src/gateway-child-env.ts
@@ -17,7 +17,6 @@ import {
 import { listMockCodexModelInfos } from "./providers/shared/mock-model-config.js";
 import type { RuntimeId } from "./runtime-parity.js";
 
-const QA_MOCK_OPENAI_API_KEY = ["qa", "mock", "openai", "key"].join("-");
 const QA_GATEWAY_CHILD_BLOCKED_SECRET_ENV_VARS = Object.freeze([
   "OPENCLAW_QA_CONVEX_SECRET_CI",
   "OPENCLAW_QA_CONVEX_SECRET_MAINTAINER",
@@ -175,7 +174,5 @@ export function buildQaForcedRuntimeEnvPatch(params: {
     providerBaseUrl,
     modelCatalogPath: params.codexModelCatalogPath,
   });
-  patch.OPENAI_API_KEY = QA_MOCK_OPENAI_API_KEY;
-  patch.CODEX_API_KEY = QA_MOCK_OPENAI_API_KEY;
   return patch;
 }

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -397,18 +397,19 @@ describe("Gateway child fixture helpers", () => {
       }),
     ]);
     expect(catalog.models[0]).not.toHaveProperty("supports_reasoning_summaries");
-    expect(
-      buildQaForcedRuntimeEnvPatch({
-        forcedRuntime: "codex",
-        providerMode: "mock-openai",
-        providerBaseUrl: "http://127.0.0.1:44080/v1",
-        codexModelCatalogPath: modelCatalogPath,
-      }),
-    ).toEqual(
+    const runtimeEnvPatch = buildQaForcedRuntimeEnvPatch({
+      forcedRuntime: "codex",
+      providerMode: "mock-openai",
+      providerBaseUrl: "http://127.0.0.1:44080/v1",
+      codexModelCatalogPath: modelCatalogPath,
+    });
+    expect(runtimeEnvPatch).toEqual(
       expect.objectContaining({
         OPENCLAW_CODEX_APP_SERVER_ARGS: `app-server -c openai_base_url=http://127.0.0.1:44080/v1 -c ${JSON.stringify(`model_catalog_json=${modelCatalogPath}`)} -c sandbox_workspace_write.exclude_tmpdir_env_var=true -c sandbox_workspace_write.exclude_slash_tmp=true --listen stdio://`,
       }),
     );
+    expect(runtimeEnvPatch).not.toHaveProperty("OPENAI_API_KEY");
+    expect(runtimeEnvPatch).not.toHaveProperty("CODEX_API_KEY");
   });
 
   it("does not stage a Codex catalog for other runtimes or live providers", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where forced Codex packaged QA could change authorization identity after an app-server restart because synthetic ambient API-key variables competed with the staged prepared credential. It also makes terminal thread startup failures identify the failed `thread/start` operation.

## Why This Change Was Made

Forced mock Codex runs now keep the staged `account/login/start` credential as the sole synthetic authorization source instead of also injecting `OPENAI_API_KEY` and `CODEX_API_KEY`. The thread lifecycle wrapper adds `thread/start` context while preserving the inner `CodexAppServerRpcError` message, structured method, code, and data for existing classifiers.

## User Impact

Daily-main QA can restart the managed Codex app-server without silently switching credential identity, and failures such as a rejected `thread/start` name the failing operation directly.

## Evidence

- Nine focused test files passed: 325 tests total across the Codex app-server and QA Lab shards.
- The two-process regression proves both physical clients receive `account/login/start`, the replacement receives it before `thread/start`, the terminal outer error names `thread/start`, its cause retains the raw message plus structured method, and no third process starts.
- Forced Codex environment proof retains the app-server arguments and excludes ambient `OPENAI_API_KEY` and `CODEX_API_KEY`.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — clean, no accepted/actionable findings, correctness confidence 0.99.
- Targeted `oxfmt`, `git diff --check`, and exact five-file diff inspection passed.
- Production LOC: +1/-4 (net -3). Tests: +53/-15.
- `rpc-error.ts` is intentionally unchanged; existing raw-message classifiers remain intact.
- Upstream Codex contract checked at `39073ca3a758224488aa3da99b1d5bfec37a8091`: `codex-rs/app-server-protocol/src/protocol/v2/account.rs`, `codex-rs/app-server/src/request_processors/account_processor.rs`, `codex-rs/login/src/auth/manager.rs`, `codex-rs/app-server/src/message_processor.rs`, and `codex-rs/app-server/src/request_processors/thread_processor.rs`.
