### PR TITLE
fix(memory-wiki): prevent oversized wiki content from crowding out model context

### DIFF
--- a/extensions/memory-wiki/src/prompt-section.test.ts
+++ b/extensions/memory-wiki/src/prompt-section.test.ts
@@ -184,6 +184,68 @@ describe("Memory Wiki prompt section", () => {
     expect(lines.join("\n")).toContain("Alpha uses PostgreSQL for production writes.");
   });
 
+  it.each([
+    {
+      name: "oversized structured claims without splitting UTF-16 surrogate pairs",
+      pages: [
+        {
+          title: "Alpha",
+          kind: "entity" as const,
+          claimCount: 1,
+          topClaims: [{ text: `${"c".repeat(699)}🤖${"c".repeat(20_000)}` }],
+        },
+      ],
+      retained: "c".repeat(699),
+      omitted: "🤖",
+    },
+    {
+      name: "oversized page titles without splitting UTF-16 surrogate pairs",
+      pages: [
+        {
+          title: `${"t".repeat(159)}🤖${"t".repeat(20_000)}`,
+          kind: "entity" as const,
+          claimCount: 1,
+          topClaims: [{ text: "The claim remains visible after its page title." }],
+        },
+      ],
+      retained: "The claim remains visible after its page title.",
+      omitted: "🤖",
+    },
+    {
+      name: "the complete digest across multiple independently bounded claims",
+      pages: Array.from({ length: 4 }, (_, pageIndex) => ({
+        title: `Page ${pageIndex}`,
+        kind: "entity" as const,
+        claimCount: 2,
+        topClaims: Array.from({ length: 2 }, (_claim, claimIndex) => ({
+          text: `claim ${pageIndex}-${claimIndex} ${"x".repeat(680)}`,
+        })),
+      })),
+      retained: "claim 0-0",
+      omitted: "claim 3-1",
+    },
+  ])(
+    "hard-bounds $name before model-context injection",
+    async ({ name, pages, retained, omitted }) => {
+      const config = resolveMemoryWikiConfig({
+        vault: { path: path.join(suiteRoot, `digest-bounded-${name.replaceAll(" ", "-")}`) },
+        context: { includeCompiledDigestPrompt: true },
+      });
+      await seedCompiledDigest({ config, claimCount: pages.length * 2, pages });
+
+      const lines = await createStaticPreparer(config)({ availableTools: new Set() });
+      const prompt = lines.join("\n");
+
+      expect(prompt).toContain("## Compiled Wiki Snapshot");
+      expect(prompt).toContain(retained);
+      expect(prompt).not.toContain(omitted);
+      expect(prompt.length).toBeLessThanOrEqual(2_800);
+      expect(prompt).not.toMatch(
+        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
+      );
+    },
+  );
+
   it("keeps the digest disabled by default", async () => {
     const config = resolveMemoryWikiConfig({
       vault: { path: path.join(suiteRoot, "digest-disabled") },

--- a/extensions/memory-wiki/src/prompt-section.ts
+++ b/extensions/memory-wiki/src/prompt-section.ts
@@ -1,5 +1,6 @@
 // Memory Wiki plugin module implements prompt section behavior.
 import type { MemoryPromptSectionBuilder } from "openclaw/plugin-sdk/memory-host-core";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   loadMemoryWikiCompiledCache,
   type MemoryWikiCompiledCacheSnapshot,
@@ -10,6 +11,9 @@ import type { MemoryWikiConfigResolver, ResolvedMemoryWikiConfig } from "./confi
 
 const DIGEST_MAX_PAGES = 4;
 const DIGEST_MAX_CLAIMS_PER_PAGE = 2;
+const DIGEST_MAX_PAGE_TITLE_CHARS = 160;
+const DIGEST_MAX_CLAIM_CHARS = 700;
+const DIGEST_MAX_PROMPT_CHARS = 2_800;
 
 function rankPromptDigestPage(page: MemoryWikiCompiledDigestPage): number {
   return (
@@ -105,16 +109,18 @@ function buildDigestPromptSection(
         ? `${page.contradictions?.length} contradiction notes`
         : null,
     ].filter(Boolean);
-    lines.push(`- ${page.title}: ${details.join(", ")}`);
+    lines.push(
+      `- ${truncateUtf16Safe(page.title, DIGEST_MAX_PAGE_TITLE_CHARS)}: ${details.join(", ")}`,
+    );
     for (const claim of sortPromptClaims(page.topClaims ?? []).slice(
       0,
       DIGEST_MAX_CLAIMS_PER_PAGE,
     )) {
-      lines.push(`  - ${formatPromptClaim(claim)}`);
+      lines.push(`  - ${truncateUtf16Safe(formatPromptClaim(claim), DIGEST_MAX_CLAIM_CHARS)}`);
     }
   }
   lines.push("");
-  return lines;
+  return truncateUtf16Safe(lines.join("\n"), DIGEST_MAX_PROMPT_CHARS).split("\n");
 }
 
 function buildWikiToolGuidance(availableTools: Set<string>): string[] {

--- a/extensions/memory-wiki/src/query.test.ts
+++ b/extensions/memory-wiki/src/query.test.ts
@@ -562,6 +562,64 @@ describe("searchMemoryWiki", () => {
     expect(results[0]?.snippet).toBe("# Alias Carrier");
   });
 
+  it.each([
+    {
+      name: "oversized body lines",
+      source: "body",
+      text: `needle ${"x".repeat(20_000)}`,
+      expected: `needle ${"x".repeat(693)}`,
+    },
+    {
+      name: "oversized structured claims",
+      source: "claim",
+      text: `needle ${"x".repeat(20_000)}`,
+      expected: `needle ${"x".repeat(693)}`,
+    },
+    {
+      name: "UTF-16 surrogate pairs at the snippet boundary",
+      source: "body",
+      text: `needle ${"x".repeat(692)}🤖tail`,
+      expected: `needle ${"x".repeat(692)}`,
+    },
+  ])(
+    "bounds $name before search results reach model context",
+    async ({ source, text, expected }) => {
+      const { rootDir, config } = await createQueryVault({ initialize: true });
+      await fs.writeFile(
+        path.join(rootDir, "entities", "bounded-snippet.md"),
+        renderWikiMarkdown({
+          frontmatter: {
+            pageType: "entity",
+            id: "entity.bounded-snippet",
+            title: "Bounded Snippet",
+            ...(source === "claim"
+              ? {
+                  claims: [
+                    {
+                      id: "claim.bounded-snippet",
+                      text,
+                      status: "supported",
+                      confidence: 0.9,
+                      evidence: [],
+                    },
+                  ],
+                }
+              : {}),
+          },
+          body:
+            source === "claim" ? "# Bounded Snippet\n\nUnrelated body.\n" : `# Wiki\n\n${text}\n`,
+        }),
+        "utf8",
+      );
+
+      const results = await searchMemoryWiki({ config, query: "needle" });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.snippet).toBe(expected);
+      expect(results[0]?.snippet.length).toBeLessThanOrEqual(700);
+    },
+  );
+
   it("finds wiki pages by structured claim text and surfaces the claim as the snippet", async () => {
     const { rootDir, config } = await createQueryVault({
       initialize: true,

--- a/extensions/memory-wiki/src/query.ts
+++ b/extensions/memory-wiki/src/query.ts
@@ -11,6 +11,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import type { OpenClawConfig } from "../api.js";
 import { walkMemoryWikiDirectory } from "./bounded-walk.js";
 import { assessClaimFreshness, isClaimContestedStatus } from "./claim-health.js";
@@ -30,6 +31,7 @@ import { initializeMemoryWikiVault } from "./vault.js";
 
 const QUERY_DIRS = ["entities", "concepts", "sources", "syntheses", "reports"] as const;
 const QUERY_PAGE_READ_CONCURRENCY = 16;
+const WIKI_SNIPPET_MAX_CHARS = 700;
 const RELATED_BLOCK_PATTERN =
   /<!-- openclaw:wiki:related:start -->[\s\S]*?<!-- openclaw:wiki:related:end -->/g;
 const MARKDOWN_FRONTMATTER_PATTERN = /^\s*---\r?\n[\s\S]*?\r?\n---\r?\n?/;
@@ -819,10 +821,10 @@ function getMatchingClaims(page: QueryableWikiPage, queryLower: string): WikiCla
 function buildPageSnippet(page: QueryableWikiPage, query: string): string {
   const queryLower = normalizeLowercaseStringOrEmpty(query);
   const matchingClaim = getMatchingClaims(page, queryLower)[0];
-  if (matchingClaim) {
-    return matchingClaim.text;
-  }
-  return buildSnippet(page.raw, query);
+  return truncateUtf16Safe(
+    matchingClaim?.text ?? buildSnippet(page.raw, query),
+    WIKI_SNIPPET_MAX_CHARS,
+  );
 }
 
 function scorePage(page: QueryableWikiPage, query: string, mode: WikiSearchMode): number {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users searching their knowledge wiki or enabling its compiled wiki snapshot could send arbitrarily large page snippets, page titles, or claims into model context. A single oversized matching line or compiled claim could crowd out the conversation and make wiki-backed answers needlessly expensive or unreliable.

## Why This Change Was Made

Bound model-visible wiki content at both existing plugin-owned producers: search snippets are limited to 700 UTF-16-safe characters, and optional compiled snapshots separately bound page titles, claims, and the complete digest to 160, 700, and 2,800 characters. Reusing the existing public text utility preserves Unicode surrogate pairs, deterministic ordering, default-off snapshot behavior, and existing plugin, configuration, and storage contracts.

## User Impact

Wiki search results stay useful without allowing one large page to consume the conversation context. Operators who opt into compiled wiki snapshots receive a compact, predictably bounded summary even when source pages contain exceptionally long titles or claims.

## Evidence

- Before: wiki search could return a 1,000,007-character matching line, and compiled digest titles and claims could exceed the complete model-context budget.
- After: regression coverage verifies 700-character search snippets, 160-character titles, 700-character claims, the aggregate 2,800-character digest budget, intact UTF-16 surrogate pairs, stable ordering, unchanged default-off behavior, and existing corpus/privacy behavior.
- Focused owner, prompt, corpus-supplement, and compiled-cache suites: **84 tests passed across four suites** using `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs extensions/memory-wiki/src/query.test.ts extensions/memory-wiki/src/prompt-section.test.ts extensions/memory-wiki/src/corpus-supplement.test.ts extensions/memory-wiki/src/compiled-cache.integration.test.ts --configLoader runner`.
- Formatting, assertion-safety ratchet, and max-lines ratchet pass on exact head `a347e10ba9306cfe2b90888d92451d8db919ed61`.
- Independent complete-branch review and fresh authenticated Codex autoreview found no actionable issues.
- Production: +15/-7 lines (net +8) for producer-owned Unicode-safe hard limits; tests: +120/-0 lines.
- AI-assisted; no public API, plugin SDK, configuration, protocol, or storage changes.
