### PR TITLE
fix(perplexity): reject empty search answers and reuse chat results

### DIFF
--- a/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.runtime.ts
@@ -298,8 +298,14 @@ async function runPerplexitySearch(params: {
         return await throwWebSearchApiError(res, "Perplexity");
       }
       const data = await readProviderJsonResponse<PerplexitySearchResponse>(res, "Perplexity");
+      const content = data.choices?.[0]?.message?.content;
+      if (typeof content !== "string" || !content.trim()) {
+        throw new Error(
+          "Perplexity search returned no final answer. Retry the query or choose another search provider.",
+        );
+      }
       return {
-        content: data.choices?.[0]?.message?.content ?? "No response",
+        content,
         citations: extractPerplexityCitations(data),
       };
     },
@@ -461,7 +467,7 @@ export async function executePerplexitySearch(
     runtime.baseUrl,
     runtime.model,
     query,
-    resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
+    structured ? resolveSearchCount(count, DEFAULT_SEARCH_COUNT) : undefined,
     country,
     language,
     freshness,

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -21,6 +21,33 @@ const openRouterPerplexityApiKey = ["sk", "or", "v1", "test"].join("-");
 const directPerplexityApiKey = ["pplx", "test"].join("-");
 const enterprisePerplexityApiKey = ["enterprise", "perplexity", "test"].join("-");
 
+function mockPerplexityResponseOnce(body: unknown): void {
+  withTrustedWebSearchEndpointMock.mockImplementationOnce(
+    async (_params: { init: RequestInit }, run: (response: Response) => Promise<unknown>) =>
+      await run(
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+  );
+}
+
+function createConfiguredPerplexityTool(structured: boolean) {
+  const webSearch = {
+    apiKey: directPerplexityApiKey,
+    ...(structured ? {} : { baseUrl: "https://api.perplexity.ai" }),
+  };
+  const tool = createPerplexityWebSearchProvider().createTool({
+    config: { plugins: { entries: { perplexity: { config: { webSearch } } } } },
+    searchConfig: {},
+  });
+  if (!tool) {
+    throw new Error("Expected tool definition");
+  }
+  return tool;
+}
+
 describe("perplexity web search provider", () => {
   it("points missing-key users to fetch/browser alternatives", async () => {
     await withEnvAsync(
@@ -66,6 +93,100 @@ describe("perplexity web search provider", () => {
     ).rejects.toThrow("Perplexity caller canceled");
     expect(withTrustedWebSearchEndpointMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { name: "missing choices", response: {} },
+    { name: "empty choices", response: { choices: [] } },
+    { name: "missing message", response: { choices: [{}] } },
+    { name: "missing content", response: { choices: [{ message: {} }] } },
+    { name: "null content", response: { choices: [{ message: { content: null } }] } },
+    { name: "empty content", response: { choices: [{ message: { content: "" } }] } },
+    { name: "whitespace content", response: { choices: [{ message: { content: " \n " } }] } },
+    {
+      name: "citations without an answer",
+      response: {
+        choices: [{ message: { content: null } }],
+        citations: ["https://example.test/source"],
+      },
+    },
+    {
+      name: "tool calls without an answer",
+      response: {
+        choices: [{ finish_reason: "tool_calls", message: { content: null, tool_calls: [] } }],
+      },
+    },
+    {
+      name: "audio without an answer",
+      response: { choices: [{ message: { content: null, audio: { id: "audio-response" } } }] },
+    },
+  ])("rejects and does not cache chat-completions $name", async ({ name, response }) => {
+    withTrustedWebSearchEndpointMock.mockReset();
+    mockPerplexityResponseOnce(response);
+    mockPerplexityResponseOnce({
+      choices: [{ message: { content: "  Recovered grounded answer  " } }],
+      citations: ["https://example.test/recovered"],
+    });
+
+    const tool = createConfiguredPerplexityTool(false);
+    const args = { query: `perplexity empty answer ${name}` };
+    await expect(tool.execute(args)).rejects.toThrow(
+      "Perplexity search returned no final answer. Retry the query or choose another search provider.",
+    );
+
+    const recovered = await tool.execute(args);
+    expect(recovered.content).toContain("  Recovered grounded answer  ");
+    expect(recovered.citations).toEqual(["https://example.test/recovered"]);
+    expect(withTrustedWebSearchEndpointMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    { name: "chat completions", structured: false, expectedRequests: 1 },
+    { name: "native Search API", structured: true, expectedRequests: 2 },
+  ])(
+    "uses count as a cache dimension only when $name sends it upstream",
+    async ({ name, structured, expectedRequests }) => {
+      withTrustedWebSearchEndpointMock.mockReset();
+      const response = structured
+        ? { results: [] }
+        : {
+            choices: [
+              {
+                message: {
+                  content: "Grounded answer",
+                  annotations: [
+                    {
+                      type: "url_citation",
+                      url_citation: { url: "https://example.test/citation" },
+                    },
+                  ],
+                },
+              },
+            ],
+          };
+      mockPerplexityResponseOnce(response);
+      if (structured) {
+        mockPerplexityResponseOnce(response);
+      }
+
+      const tool = createConfiguredPerplexityTool(structured);
+      const query = `perplexity cache count ${name}`;
+      const first = await tool.execute({ query, count: 1 });
+      const second = await tool.execute({ query, count: 7 });
+      const third = await tool.execute({ query, count: 1 });
+
+      expect(first.cached).toBeUndefined();
+      expect(second.cached).toBe(structured ? undefined : true);
+      expect(third.cached).toBe(true);
+      expect(withTrustedWebSearchEndpointMock).toHaveBeenCalledTimes(expectedRequests);
+      if (structured) {
+        expect(first.results).toEqual([]);
+        expect(first.count).toBe(0);
+      } else {
+        expect(first.content).toContain("Grounded answer");
+        expect(first.citations).toEqual(["https://example.test/citation"]);
+      }
+    },
+  );
 
   it.each([
     { name: "native Search API", webSearch: { apiKey: "pplx-test" } },
@@ -216,15 +337,7 @@ describe("perplexity web search provider", () => {
   });
 
   it("sends official date filter fields in the Search API request body", async () => {
-    withTrustedWebSearchEndpointMock.mockImplementationOnce(
-      async (_params: { init: RequestInit }, run: (response: Response) => Promise<unknown>) =>
-        await run(
-          new Response(JSON.stringify({ results: [] }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }),
-        ),
-    );
+    mockPerplexityResponseOnce({ results: [] });
 
     await withEnvAsync(
       { [perplexityApiKeyEnv]: directPerplexityApiKey, [openRouterApiKeyEnv]: undefined },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users searching the web through Perplexity Sonar or OpenRouter would receive a fabricated successful answer such as `No response` when the provider returned no usable final text. That false success was cached and prevented automatic fallback or recovery. Repeating the same chat-completions search with different accepted `count` values also bypassed the cache and repeated paid requests even though that transport never sends `count` upstream.

## Why This Change Was Made

Validate the final synthesized answer at the Perplexity chat-completions response owner before creating or caching a successful search payload, and use the existing transport decision to include `count` in the cache identity only for native structured search. A provider-owned thrown error preserves the existing generic search fallback, while native result counts, citations, cancellation, validation, and both documented transports retain their existing behavior.

The alternative of replacing missing content in the generic web-search consumer would preserve a poisoned cache and hide the actual provider failure; rejecting `count` on the compatibility transport would break its documented public input contract. Production delta: +8/-2 (net +6), necessary to distinguish an actual grounded answer from absent, null, blank, tool-call-only, or audio-only completions before the existing cache write. Test delta: +122/-9.

## User Impact

Sonar/OpenRouter searches either return a real provider answer or fail with actionable retry/provider-selection guidance, allowing automatic provider fallback where configured. Failed answers never poison the shared search cache. Equivalent chat-completions queries reuse their successful cached answer across different requested result counts, while native Perplexity Search API queries continue to keep distinct result counts separate.

## Evidence

- Authentic pre-fix owner-boundary regression: 11 failures, covering ten absent/empty/non-text provider responses plus the transport-specific cache identity; the same owner suite now passes all 30 tests.
- Exact reviewed branch head: `8ad3a2256a25b31ed4b2d7e05c923c0661e061d1`.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs extensions/perplexity/src/perplexity-web-search-provider.test.ts --configLoader runner` — 30/30 passed.
- `node_modules/.bin/oxfmt --check extensions/perplexity/src/perplexity-web-search-provider.runtime.ts extensions/perplexity/src/perplexity-web-search-provider.test.ts` — passed.
- `node --import tsx scripts/check-max-lines-ratchet.mts --base origin/main` — passed.
- `node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main` — passed.
- Fresh full-branch authenticated independent Codex review: clean; no actionable findings.
- Direct installed upstream chat-completions contract confirms assistant `content` may be `string | null` alongside tool calls or audio. Provider owner, generic fallback caller, shared cache owner, native transport, and the already-landed analogous Kimi failure fix were inspected. No public API, configuration, security boundary, persistence, or schema changes.
- Real provider failures were exercised through the actual Perplexity plugin entrypoint and real HTTP `Response` parsing with an isolated transport; live paid Perplexity/OpenRouter requests were not run because neither a user-requested live credential nor paid external call is needed to prove the deterministic response-owner/cache invariant.

