### PR TITLE
fix(qa-lab): accept direct-message aliases at the HTTP boundary

### DIFF
--- a/extensions/qa-lab/src/bus-server.test.ts
+++ b/extensions/qa-lab/src/bus-server.test.ts
@@ -128,6 +128,34 @@ describe("qa-bus server", () => {
     await expect(response.json()).resolves.toEqual({ error: requestError.message });
   });
 
+  it("normalizes direct-message aliases at HTTP ingress without accepting unknown kinds", async () => {
+    const state = createQaBusState();
+    const bus = await startQaBusServer({ state });
+    stops.push(bus["stop"]);
+
+    for (const kind of ["direct", "dm"]) {
+      const response = await postQaBusJson(bus.baseUrl, "/v1/inbound/message", {
+        conversation: { id: "alice", kind },
+        senderId: "alice",
+        text: `hello from ${kind}`,
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        message: { conversation: { id: "alice", kind: "direct" } },
+      });
+    }
+
+    const rejected = await postQaBusJson(bus.baseUrl, "/v1/inbound/message", {
+      conversation: { id: "alice", kind: "private" },
+      senderId: "alice",
+      text: "must not be accepted",
+    });
+
+    expect(rejected.status).toBe(400);
+    expect(state.getSnapshot().messages).toHaveLength(2);
+  });
+
   it("wakes matching polls and fences late polls and writes during shutdown", async () => {
     const state = createQaBusState();
     const bus = await startQaBusServer({ state });

--- a/extensions/qa-lab/src/bus-server.ts
+++ b/extensions/qa-lab/src/bus-server.ts
@@ -33,7 +33,10 @@ const QA_MALFORMED_JSON_BODY_MESSAGE = "Malformed JSON body";
 const qaBusConversationSchema = z
   .object({
     id: z.string(),
-    kind: z.enum(["direct", "channel", "group"]),
+    kind: z.preprocess(
+      (kind) => (kind === "dm" ? "direct" : kind),
+      z.enum(["direct", "channel", "group"]),
+    ),
     title: z.string().optional(),
   })
   .passthrough();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA operators injecting a direct message through the synthetic QA bus receive HTTP 400 when the conversation kind uses the documented `dm` spelling, even though the bus state and target grammar already normalize that spelling to `direct`.

## Why This Change Was Made

The August 15 schema refactor in #124378 introduced a closed HTTP-boundary enum that rejects `dm` before the existing conversation owner can normalize it. Normalize this established ingress spelling inside the existing Zod conversation schema before closed-enum validation. Stored messages, public QA-channel types, routing, and every unknown-kind rejection remain canonical and unchanged.

Normalizing downstream cannot help because the request never reaches the state owner; widening the public conversation union would incorrectly expose `dm` beyond its ingress boundary. Production delta: +4/-1 (net +3); regression coverage: +28/-0.

## User Impact

QA Lab direct-message injection now accepts both `direct` and `dm`, stores and returns only the canonical `direct` conversation kind, and still rejects invalid conversation kinds without recording a message.

## Evidence

- Baseline reproduction through a real ephemeral localhost HTTP server: `POST /v1/inbound/message` with conversation kind `dm` returned HTTP 400 before the fix.
- Fixed owner-boundary regression: both `direct` and `dm` return HTTP 200 with canonical `direct` messages; unsupported `private` still returns HTTP 400 and records no message.
- Exact reviewed head: `f2d08b730eae209ea6401d9f3cca3689e56819ca`.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs extensions/qa-lab/src/bus-server.test.ts extensions/qa-lab/src/bus-state.test.ts extensions/qa-channel/src/bus-client.test.ts extensions/qa-channel/src/gateway.test.ts --configLoader runner`: 4 files, 54 tests passed.
- `node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main`: passed.
- `node --import tsx scripts/check-max-lines-ratchet.mts --base origin/main`: passed.
- `node_modules/.bin/oxfmt --check extensions/qa-lab/src/bus-server.ts extensions/qa-lab/src/bus-server.test.ts`: passed.
- Fresh independent full-branch Codex review: clean, no actionable findings.
- No public SDK, authentication, persistence, protocol, or security-boundary changes.
