### PR TITLE
fix(ui): align configured trigger status with Advanced heading

### DIFF
--- a/ui/src/pages/cron/view.browser.test.ts
+++ b/ui/src/pages/cron/view.browser.test.ts
@@ -1,0 +1,64 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it } from "vitest";
+import "../../styles/base.css";
+import "../../styles/settings.css";
+import "../../styles/cron.css";
+
+const hasBrowserLayout = !navigator.userAgent.toLowerCase().includes("jsdom");
+const alignmentTolerancePx = 1.25;
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+function centerY(bounds: DOMRect) {
+  return bounds.top + bounds.height / 2;
+}
+
+async function nextFrame() {
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
+describe.skipIf(!hasBrowserLayout)("cron editor browser layout", () => {
+  it("vertically centers the configured trigger status with the Advanced heading", async () => {
+    const details = document.createElement("details");
+    details.className = "cron-advanced";
+    details.open = true;
+    details.innerHTML = `
+      <summary class="settings-section__heading cron-advanced__summary">Advanced</summary>
+    `;
+    document.body.append(details);
+
+    const summary = expectDefined(
+      details.querySelector<HTMLElement>(".cron-advanced__summary"),
+      "Advanced summary",
+    );
+    const heading = document.createRange();
+    heading.selectNode(expectDefined(summary.firstChild, "Advanced heading text"));
+
+    summary.insertAdjacentHTML(
+      "beforeend",
+      `
+        <span class="cron-trigger-summary">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M6 3v12"></path>
+            <path d="M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6z"></path>
+          </svg>
+          Trigger configured
+        </span>
+      `,
+    );
+    await nextFrame();
+
+    const status = expectDefined(
+      details.querySelector<HTMLElement>(".cron-trigger-summary"),
+      "configured trigger status",
+    );
+    const headingCenter = centerY(heading.getBoundingClientRect());
+    const statusCenter = centerY(status.getBoundingClientRect());
+
+    expect(Math.abs(statusCenter - headingCenter)).toBeLessThanOrEqual(alignmentTolerancePx);
+  });
+});

--- a/ui/src/styles/cron.css
+++ b/ui/src/styles/cron.css
@@ -722,6 +722,7 @@
   color: var(--accent-2);
   font-size: var(--control-ui-text-xs);
   font-weight: 600;
+  vertical-align: middle;
 }
 
 .cron-trigger-summary svg {


### PR DESCRIPTION
Related: #126534

## What Problem This Solves

Fixes an issue where users opening an automation with a configured condition trigger would see the “Trigger configured” status sit above the “Advanced” heading’s visual centerline.

## Why This Change Was Made

The configured-trigger status is an inline-flex element whose default baseline follows its SVG content. Vertically centering that existing inline status repairs the owning CSS geometry without changing the disclosure layout or adding new UI chrome. A real-Chromium layout regression now protects the rendered centerline.

Provenance: the configured-trigger summary was added in #126534. The blamed code was authored by @roboclaw-bot; the PR was authored and squash-merged by @clawsweeper on August 20, 2026. @Takhoffman was a co-author. No separate automerge trigger was present in the PR timeline.

Production LOC: +1/-0 (net +1) | Tests: +64/-0

## User Impact

The configured-trigger indicator now aligns cleanly with the Advanced heading. Automation behavior, trigger execution, and editor interaction are unchanged.

## Evidence

### Before

![Configured trigger status above the Advanced heading centerline](https://github.com/user-attachments/assets/f703997f-60cd-453c-9849-2ef1ca562965)

### After

![Configured trigger status centered with the Advanced heading](https://github.com/user-attachments/assets/02f5e4e2-5d68-4b7e-82d3-99f77a88ef6f)

- Pre-fix Chromium regression: failed with 2.492 px of vertical centerline drift.
- `pnpm --dir ui test --project browser src/pages/cron/view.browser.test.ts` — 1 test passed after the fix (1.086 px drift, within the 1.25 px subpixel tolerance).
- `node scripts/check-changed.mjs -- ui/src/styles/cron.css ui/src/pages/cron/view.browser.test.ts` — passed all selected guards, core-test/UI typechecks, formatting, and lint lanes.
- Targeted Stylelint — passed.
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean; no accepted/actionable findings.
- Before/after captures use the deterministic Control UI mock, Chromium at 1440×900, the same configured-trigger state, and commit `d0ff7b311a8f8a1ab46f09720c8483e382d3f08b`.

### AI assistance

- [x] AI-assisted implementation
- [x] Reviewed and understood the code and behavior
- [x] Ran repository autoreview and addressed all actionable findings
