### PR TITLE
fix(status): reconcile degraded secret diagnostics

### DIFF
--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -1,6 +1,7 @@
 // Status-all diagnosis tests cover port checks, restart logs, config issues, and safe diagnostic output.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProgressReporter } from "../../cli/progress.js";
+import { buildStatusSecretDiagnostics } from "../status-overview-values.ts";
 
 type GatewayLogPaths = {
   logDir: string;
@@ -114,8 +115,89 @@ describe("status-all diagnosis port checks", () => {
     await appendStatusAllDiagnosis(params);
 
     const output = params.lines.join("\n");
+    expect(output).toContain("✓ Secret diagnostics (0)");
     expect(output).toContain("✓ Tailscale exposure: off · daemon Running · box.tail.ts.net");
     expect(output).not.toContain("Tailscale: off");
+  });
+
+  it("combines Gateway-owned degradation with distinct command diagnostics without double-counting", async () => {
+    const params = createBaseParams([]);
+    params.secretDiagnostics = buildStatusSecretDiagnostics(
+      [
+        {
+          ownerKind: "capability",
+          ownerId: "tts",
+          state: "unavailable",
+          degradationState: "cold",
+          paths: ["tts.providers.elevenlabs.apiKey"],
+          reason: "secret reference was not found",
+        },
+        {
+          ownerKind: "provider",
+          ownerId: "openai",
+          state: "unavailable",
+          degradationState: "stale",
+          paths: ["models.providers.openai.apiKey"],
+          reason: "secret provider failed",
+        },
+      ],
+      [
+        "status --all: tts.providers.elevenlabs.apiKey is unavailable in this command path; continuing with degraded read-only config.",
+        "status --all: channels.discord.accounts.ops.token is unavailable in this command path; continuing with degraded read-only config.",
+      ],
+    );
+    params.hasDegradedSecretOwners = true;
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    expect(output).toContain("! Secret diagnostics (3)");
+    expect(output).toContain(
+      "cold capability:tts (tts.providers.elevenlabs.apiKey): secret reference was not found",
+    );
+    expect(output).toContain(
+      "stale provider:openai (models.providers.openai.apiKey): secret provider failed",
+    );
+    expect(output).toContain(
+      "channels.discord.accounts.ops.token is unavailable in this command path",
+    );
+    expect(output).toContain("Retry: openclaw secrets reload");
+    expect(output).not.toContain("✓ Secret diagnostics (0)");
+    expect(
+      params.lines.filter((line) => line.includes("tts.providers.elevenlabs.apiKey")),
+    ).toHaveLength(1);
+  });
+
+  it("redacts unresolved references and credential values from degraded-owner diagnostics", async () => {
+    const params = createBaseParams([]);
+    params.secretDiagnostics = buildStatusSecretDiagnostics(
+      [
+        {
+          ownerKind: "capability",
+          ownerId: "tts\u001b[31m\nforged-owner",
+          state: "unavailable",
+          paths: ["tts.providers.elevenlabs.apiKey\nforged-path"],
+          reason:
+            "secret reference was not found (env:default:PRIVATE_REF_ID token=raw-owner-secret)",
+        },
+      ],
+      ["channels.discord.accounts.ops.token: token=raw-command-secret"],
+    );
+    params.hasDegradedSecretOwners = true;
+
+    await appendStatusAllDiagnosis(params);
+
+    const output = params.lines.join("\n");
+    const ownerLine = params.lines.find((line) => line.includes("capability:tts"));
+    expect(output).toContain("! Secret diagnostics (2)");
+    expect(ownerLine).toContain("cold capability:tts");
+    expect(ownerLine).toContain("tts.providers.elevenlabs.apiKey");
+    expect(ownerLine).toContain("secret resolution failed");
+    expect(ownerLine).not.toContain("\u001b");
+    expect(ownerLine).not.toContain("\n");
+    expect(output).not.toContain("PRIVATE_REF_ID");
+    expect(output).not.toContain("raw-owner-secret");
+    expect(output).not.toContain("raw-command-secret");
   });
 
   it("treats same-process dual-stack loopback listeners as healthy", async () => {

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -26,6 +26,7 @@ import {
   formatPluginCompatibilityNotice,
   type PluginCompatibilityNotice,
 } from "../../plugins/status.js";
+import { SECRET_DEGRADATION_RETRY_HINT } from "../../secrets/runtime-degraded-state.js";
 import type { StatusGatewayDiagnosticsResult } from "../status-runtime-shared.ts";
 import {
   formatUpdateRestartActionLines,
@@ -149,6 +150,7 @@ export async function appendStatusAllDiagnosis(params: {
   snap: ConfigSnapshotLike | null;
   remoteUrlMissing: boolean;
   secretDiagnostics: string[];
+  hasDegradedSecretOwners?: boolean;
   sentinel: { payload?: RestartSentinelPayload | null } | null;
   lastErr: string | null;
   port: number;
@@ -229,6 +231,9 @@ export async function appendStatusAllDiagnosis(params: {
   }
   if (params.secretDiagnostics.length > 10) {
     lines.push(`  ${muted(`… +${params.secretDiagnostics.length - 10} more`)}`);
+  }
+  if (params.hasDegradedSecretOwners) {
+    lines.push(`  ${muted(`Retry: ${SECRET_DEGRADATION_RETRY_HINT}`)}`);
   }
 
   if (params.sentinel?.payload) {

--- a/src/commands/status-all/format.test.ts
+++ b/src/commands/status-all/format.test.ts
@@ -216,6 +216,9 @@ describe("status-all format", () => {
     expect(redactStatusSecrets("token=Bearer eyJhbGciOi.secret next")).toBe("token=*** next");
     expect(redactStatusSecrets("password=alpha,beta next")).toBe("password=*** next");
     expect(redactStatusSecrets("token=Bearer ~abc+secret/== next")).toBe("token=*** next");
+    expect(redactStatusSecrets("Authorization: Bearer ~abc+secret/== next")).toBe(
+      "Authorization: Bearer *** next",
+    );
   });
 
   it("redacts credential-bearing Gateway URLs from text and JSON status", () => {

--- a/src/commands/status-all/format.test.ts
+++ b/src/commands/status-all/format.test.ts
@@ -16,6 +16,7 @@ import {
   formatStatusDashboardValue,
   formatStatusServiceValue,
   formatStatusTailscaleValue,
+  redactStatusSecrets,
 } from "./format.js";
 
 describe("status-all format", () => {
@@ -202,6 +203,19 @@ describe("status-all format", () => {
       error: null,
       authWarning: "warn",
     });
+  });
+
+  it("redacts complete unquoted, quoted, and JSON-like credential values", () => {
+    expect(redactStatusSecrets("token=raw-command-secret next")).toBe("token=*** next");
+    expect(redactStatusSecrets('password="correct horse battery staple" next')).toBe(
+      "password=*** next",
+    );
+    expect(redactStatusSecrets('{"token": "raw-command-secret", "safe": true}')).toBe(
+      '{"token": ***, "safe": true}',
+    );
+    expect(redactStatusSecrets("token=Bearer eyJhbGciOi.secret next")).toBe("token=*** next");
+    expect(redactStatusSecrets("password=alpha,beta next")).toBe("password=*** next");
+    expect(redactStatusSecrets("token=Bearer ~abc+secret/== next")).toBe("token=*** next");
   });
 
   it("redacts credential-bearing Gateway URLs from text and JSON status", () => {

--- a/src/commands/status-all/format.ts
+++ b/src/commands/status-all/format.ts
@@ -526,8 +526,8 @@ export function redactStatusSecrets(text: string): string {
   }
   let out = text;
   out = out.replace(
-    /(\b(?:access[_-]?token|refresh[_-]?token|token|password|secret|api[_-]?key)\b\s*[:=]\s*)("?)([^"\\s]+)("?)/gi,
-    "$1$2***$4",
+    /(["']?\b(?:access[_-]?token|refresh[_-]?token|token|password|secret|api[_-]?key)\b["']?\s*[:=]\s*)(?:Bearer\s+[^\s]+|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s]+)/gi,
+    "$1***",
   );
   out = out.replace(/\bBearer\s+[A-Za-z0-9._-]+\b/g, "Bearer ***");
   out = out.replace(/\bsk-[A-Za-z0-9]{10,}\b/g, "sk-***");

--- a/src/commands/status-all/format.ts
+++ b/src/commands/status-all/format.ts
@@ -529,7 +529,7 @@ export function redactStatusSecrets(text: string): string {
     /(["']?\b(?:access[_-]?token|refresh[_-]?token|token|password|secret|api[_-]?key)\b["']?\s*[:=]\s*)(?:Bearer\s+[^\s]+|"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^\s]+)/gi,
     "$1***",
   );
-  out = out.replace(/\bBearer\s+[A-Za-z0-9._-]+\b/g, "Bearer ***");
+  out = out.replace(/\bBearer\s+[^\s]+/g, "Bearer ***");
   out = out.replace(/\bsk-[A-Za-z0-9]{10,}\b/g, "sk-***");
   return out;
 }

--- a/src/commands/status-all/report-data.ts
+++ b/src/commands/status-all/report-data.ts
@@ -17,6 +17,7 @@ import {
   buildStatusOverviewSurfaceFromOverview,
   type StatusOverviewSurface,
 } from "../status-overview-surface.ts";
+import { buildStatusSecretDiagnostics } from "../status-overview-values.ts";
 import {
   resolveStatusGatewayDiagnosticsSafe,
   resolveStatusGatewayHealthSafe,
@@ -58,11 +59,9 @@ async function resolveStatusAllLocalDiagnosis(params: {
   timeoutMs?: number;
 }): Promise<{
   configPath: string;
-  health: StatusGatewayHealthSafe | undefined;
   diagnosis: {
     snap: ConfigFileSnapshot | null;
     remoteUrlMissing: boolean;
-    secretDiagnostics: StatusScanOverviewResult["secretDiagnostics"];
     sentinel: Awaited<ReturnType<typeof readRestartSentinelReadOnly>> | null;
     lastErr: string | null;
     port: number;
@@ -161,11 +160,9 @@ async function resolveStatusAllLocalDiagnosis(params: {
 
   return {
     configPath,
-    health,
     diagnosis: {
       snap,
       remoteUrlMissing: overview.gatewaySnapshot.remoteUrlMissing,
-      secretDiagnostics: overview.secretDiagnostics,
       sentinel,
       lastErr,
       port,
@@ -202,7 +199,7 @@ export async function buildStatusAllReportData(params: {
   timeoutMs?: number;
 }) {
   const gatewaySnapshot = params.overview.gatewaySnapshot;
-  const [{ configPath, health, diagnosis }, summary] = await Promise.all([
+  const [{ configPath, diagnosis }, summary] = await Promise.all([
     resolveStatusAllLocalDiagnosis({
       overview: params.overview,
       progress: params.progress,
@@ -222,12 +219,16 @@ export async function buildStatusAllReportData(params: {
     nodeService: params.nodeService,
     nodeOnlyGateway: params.nodeOnlyGateway,
   });
+  const secretDiagnostics = buildStatusSecretDiagnostics(
+    summary.degradedSecretOwners ?? [],
+    params.overview.secretDiagnostics,
+  );
   const overviewRows = buildStatusAllOverviewRows({
     surface: overviewSurface,
     osLabel: params.overview.osSummary.label,
     configPath,
     summary,
-    secretDiagnosticsCount: params.overview.secretDiagnostics.length,
+    secretDiagnosticsCount: secretDiagnostics.length,
     updateRestartValue: formatUpdateRestartStatusValue(diagnosis.sentinel?.payload),
     agentStatus: params.overview.agentStatus,
     tailscaleBackendState: diagnosis.tailscale.backendState,
@@ -250,7 +251,8 @@ export async function buildStatusAllReportData(params: {
     }),
     diagnosis: {
       ...diagnosis,
-      health,
+      secretDiagnostics,
+      hasDegradedSecretOwners: (summary.degradedSecretOwners?.length ?? 0) > 0,
     },
   };
 }

--- a/src/commands/status-overview-rows.test.ts
+++ b/src/commands/status-overview-rows.test.ts
@@ -24,9 +24,78 @@ describe("status-overview-rows", () => {
     );
     expect(findRowValue(rows, "Plugin compatibility")).toBe("warn(1 notice · 1 plugin)");
     expect(findRowValue(rows, "Host desktop")).toBe("muted(disabled)");
+    expect(findRowValue(rows, "Degraded secrets")).toBeUndefined();
     expect(findRowValue(rows, "Sessions")).toBe(
       "2 active · default gpt-5.5 (12k ctx) · store.json",
     );
+  });
+
+  it("shows every cold and stale runtime secret owner with its safe path and reason", () => {
+    const params = createStatusCommandOverviewRowsParams();
+    const rows = buildStatusCommandOverviewRows(
+      createStatusCommandOverviewRowsParams({
+        summary: {
+          ...params.summary,
+          degradedSecretOwners: [
+            {
+              ownerKind: "capability",
+              ownerId: "tts",
+              state: "unavailable",
+              degradationState: "cold",
+              paths: ["tts.providers.elevenlabs.apiKey"],
+              reason: "secret reference was not found",
+            },
+            {
+              ownerKind: "provider",
+              ownerId: "openai",
+              state: "unavailable",
+              degradationState: "stale",
+              paths: ["models.providers.openai.apiKey"],
+              reason: "secret provider failed",
+            },
+          ],
+        },
+      }),
+    );
+
+    const value = findRowValue(rows, "Degraded secrets");
+    expect(value).toContain("2 degraded");
+    expect(value).toContain(
+      "cold capability:tts (tts.providers.elevenlabs.apiKey): secret reference was not found",
+    );
+    expect(value).toContain(
+      "stale provider:openai (models.providers.openai.apiKey): secret provider failed",
+    );
+  });
+
+  it("redacts unresolved SecretRef identifiers and sanitizes untrusted owner display text", () => {
+    const params = createStatusCommandOverviewRowsParams();
+    const rows = buildStatusCommandOverviewRows(
+      createStatusCommandOverviewRowsParams({
+        summary: {
+          ...params.summary,
+          degradedSecretOwners: [
+            {
+              ownerKind: "capability",
+              ownerId: "tts\u001b[31m\nforged-owner",
+              state: "unavailable",
+              paths: ["tts.providers.elevenlabs.apiKey\nforged-path"],
+              reason:
+                "secret reference was not found (env:default:PRIVATE_REF_ID token=raw-secret)",
+            },
+          ],
+        },
+      }),
+    );
+
+    const value = findRowValue(rows, "Degraded secrets") ?? "";
+    expect(value).toContain("cold capability:tts");
+    expect(value).toContain("tts.providers.elevenlabs.apiKey");
+    expect(value).toContain("secret resolution failed");
+    expect(value).not.toContain("PRIVATE_REF_ID");
+    expect(value).not.toContain("raw-secret");
+    expect(value).not.toContain("\u001b");
+    expect(value).not.toContain("\n");
   });
 
   it("marks skipped memory inspection as not checked in fast status output", () => {
@@ -131,7 +200,7 @@ describe("status-overview-rows", () => {
       },
       osLabel: "macOS",
       configPath: "/tmp/openclaw.json",
-      secretDiagnosticsCount: 2,
+      secretDiagnosticsCount: 3,
       updateRestartValue: "restart pending health verification",
       agentStatus: {
         bootstrapPendingCount: 1,
@@ -146,8 +215,10 @@ describe("status-overview-rows", () => {
     expect(findRowValue(rows, "Config")).toBe("/tmp/openclaw.json");
     expect(findRowValue(rows, "Update restart")).toBe("restart pending health verification");
     expect(findRowValue(rows, "Security")).toBe("Run: openclaw security audit --deep");
-    expect(findRowValue(rows, "Degraded secrets")).toBe("1 degraded · capability:tts");
+    expect(findRowValue(rows, "Degraded secrets")).toBe(
+      "1 degraded · cold capability:tts (tts.providers.elevenlabs.apiKey): secret reference was not found",
+    );
     expect(findRowValue(rows, "Degraded plugins")).toBe("1 configured-unavailable · discord");
-    expect(findRowValue(rows, "Secrets")).toBe("2 diagnostics");
+    expect(findRowValue(rows, "Secrets")).toBe("3 diagnostics");
   });
 });

--- a/src/commands/status-overview-rows.ts
+++ b/src/commands/status-overview-rows.ts
@@ -17,6 +17,7 @@ import {
   buildStatusEventsValue,
   buildStatusPluginCompatibilityValue,
   buildStatusProbesValue,
+  buildStatusSecretDiagnostics,
   buildStatusSecretsValue,
   buildStatusSessionsOverviewValue,
 } from "./status-overview-values.ts";
@@ -38,12 +39,12 @@ function buildStatusDegradationRows(
   decorate = (value: string) => value,
 ) {
   const rows: Array<{ Item: string; Value: string }> = [];
-  const secretOwners = summary.degradedSecretOwners ?? [];
+  const secretOwners = buildStatusSecretDiagnostics(summary.degradedSecretOwners ?? [], []);
   if (secretOwners.length > 0) {
     rows.push({
       Item: "Degraded secrets",
       Value: decorate(
-        `${secretOwners.length} degraded · ${secretOwners.map((owner) => `${owner.ownerKind}:${owner.ownerId}`).join(", ")}`,
+        `${secretOwners.length} degraded · ${secretOwners.slice(0, 10).join(", ")}${secretOwners.length > 10 ? `, … +${secretOwners.length - 10} more` : ""}`,
       ),
     });
   }

--- a/src/commands/status-overview-values.test.ts
+++ b/src/commands/status-overview-values.test.ts
@@ -5,6 +5,7 @@ import {
   buildStatusEventsValue,
   buildStatusPluginCompatibilityValue,
   buildStatusProbesValue,
+  buildStatusSecretDiagnostics,
   buildStatusSecretsValue,
   buildStatusSessionsOverviewValue,
 } from "./status-overview-values.ts";
@@ -58,5 +59,45 @@ describe("status-overview-values", () => {
         formatKTokens: (value) => `${Math.round(value / 1000)}k`,
       }),
     ).toBe("2 active · default gpt-5.5 (12k ctx) · 2 stores");
+  });
+
+  it("deduplicates runtime owners and only their exact command-local paths", () => {
+    const owner = {
+      ownerKind: "capability" as const,
+      ownerId: "tts",
+      state: "unavailable" as const,
+      paths: ["tts.providers.elevenlabs.apiKey"],
+      reason: "secret reference was not found",
+    };
+    const diagnostics = buildStatusSecretDiagnostics(
+      [owner, owner],
+      [
+        "status: tts.providers.elevenlabs.apiKey is unavailable in this command path; continuing with degraded read-only config.",
+        "status: tts.providers.elevenlabs.apiKeyBackup is unavailable in this command path; token=raw-command-secret",
+      ],
+    );
+
+    expect(diagnostics).toEqual([
+      "cold capability:tts (tts.providers.elevenlabs.apiKey): secret reference was not found",
+      "status: tts.providers.elevenlabs.apiKeyBackup is unavailable in this command path; token=***",
+    ]);
+  });
+
+  it("preserves authoritative totals while bounding owner labels and paths", () => {
+    const longLabel = "x".repeat(200);
+    const diagnostics = buildStatusSecretDiagnostics(
+      Array.from({ length: 12 }, (_, index) => ({
+        ownerKind: "capability" as const,
+        ownerId: `skill:${index}:${longLabel}`,
+        state: "unavailable" as const,
+        paths: [`skills.entries.skill${index}.${longLabel}.apiKey`],
+        reason: "secret reference was not found",
+      })),
+      ["unrelated command-local warning"],
+    );
+
+    expect(diagnostics).toHaveLength(13);
+    expect(diagnostics[0]).not.toContain(longLabel);
+    expect(diagnostics[0]).toContain("secret reference was not found");
   });
 });

--- a/src/commands/status-overview-values.ts
+++ b/src/commands/status-overview-values.ts
@@ -1,6 +1,35 @@
 // Small value formatters for status overview rows.
 // These helpers keep terse row text consistent between compact and full status reports.
 
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { redactSecretDegradationReason } from "../secrets/runtime-degraded-state.js";
+import type { StatusSummary } from "../status/types.js";
+import { redactStatusSecrets } from "./status-all/format.js";
+
+/** Combines authoritative owner details with distinct command-local human diagnostics. */
+export function buildStatusSecretDiagnostics(
+  owners: NonNullable<StatusSummary["degradedSecretOwners"]>,
+  diagnostics: string[],
+): string[] {
+  const safeText = (value: string) =>
+    truncateUtf16Safe(sanitizeTerminalText(redactStatusSecrets(value)), 160);
+  const ownerPaths = new Set(owners.flatMap((owner) => owner.paths));
+  const ownerDiagnostics = new Map(
+    owners.map((owner) => [
+      `${owner.ownerKind}\0${owner.ownerId}`,
+      `${owner.degradationState ?? "cold"} ${owner.ownerKind}:${safeText(owner.ownerId)} (${owner.paths.slice(0, 3).map(safeText).join(", ")}${owner.paths.length > 3 ? ", …" : ""}): ${safeText(redactSecretDegradationReason(owner.reason))}`,
+    ]),
+  );
+  const localDiagnostics = diagnostics.filter((diagnostic) => {
+    const ownerPath =
+      /^.+?: (.+?) is unavailable in this command path(?:;|$)/.exec(diagnostic)?.[1] ??
+      diagnostic.split(":", 1)[0];
+    return ownerPath === undefined || !ownerPaths.has(ownerPath);
+  });
+  return [...ownerDiagnostics.values(), ...new Set(localDiagnostics.map(safeText))];
+}
+
 type AgentStatusLike = {
   bootstrapPendingCount: number;
   totalSessions: number;

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -12,9 +12,11 @@ import { withProgress } from "../cli/progress.js";
 import { OPENCLAW_WRAPPER_ENV_KEY } from "../daemon/program-args.js";
 import { readRestartSentinelReadOnly } from "../infra/restart-sentinel.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { SECRET_DEGRADATION_RETRY_HINT } from "../secrets/runtime-degraded-state.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { assertStatusUsageAgentScope, runStatusJsonCommand } from "./status-json-command.ts";
 import { buildStatusOverviewSurfaceFromScan } from "./status-overview-surface.ts";
+import { buildStatusSecretDiagnostics } from "./status-overview-values.ts";
 import {
   loadStatusProviderUsageModule,
   resolveStatusGatewayHealth,
@@ -163,7 +165,7 @@ export async function statusCommand(
     agentStatus,
     channels,
     summary,
-    secretDiagnostics,
+    secretDiagnostics: commandSecretDiagnostics,
     memory,
     memoryPlugin,
     pluginCompatibility,
@@ -262,18 +264,29 @@ export async function statusCommand(
 
   const tableWidth = getTerminalTableWidth();
 
+  const secretDiagnostics = buildStatusSecretDiagnostics(
+    summary.degradedSecretOwners ?? [],
+    commandSecretDiagnostics,
+  );
   if (secretDiagnostics.length > 0) {
-    // Secret diagnostics are already redacted by the scanner; show them before the main report.
     runtime.log(theme.warn("Secret diagnostics:"));
-    for (const entry of secretDiagnostics) {
+    for (const entry of secretDiagnostics.slice(0, 10)) {
       runtime.log(`- ${entry}`);
     }
-    const wrapperContextHint = resolveServiceWrapperContextHint({
-      serviceWrapperPath: daemon.wrapperPath,
-      cliWrapperPath: process.env[OPENCLAW_WRAPPER_ENV_KEY],
-    });
-    if (wrapperContextHint) {
-      runtime.log(theme.warn(wrapperContextHint));
+    if (secretDiagnostics.length > 10) {
+      runtime.log(`… +${secretDiagnostics.length - 10} more`);
+    }
+    if (summary.degradedSecretOwners?.length) {
+      runtime.log(`Retry: ${SECRET_DEGRADATION_RETRY_HINT}`);
+    }
+    if (secretDiagnostics.length > (summary.degradedSecretOwners?.length ?? 0)) {
+      const wrapperContextHint = resolveServiceWrapperContextHint({
+        serviceWrapperPath: daemon.wrapperPath,
+        cliWrapperPath: process.env[OPENCLAW_WRAPPER_ENV_KEY],
+      });
+      if (wrapperContextHint) {
+        runtime.log(theme.warn(wrapperContextHint));
+      }
     }
     runtime.log("");
   }

--- a/test/status-shared-state-readonly.e2e.test.ts
+++ b/test/status-shared-state-readonly.e2e.test.ts
@@ -70,6 +70,7 @@ describe("status shared-state ownership", () => {
       name: "status-runtime-degradation",
       env: {
         STATUS_E2E_MISSING_SECRET: undefined,
+        STATUS_E2E_MISSING_SKILL_SECRET: undefined,
         VITEST: undefined,
         VITEST_POOL_ID: undefined,
         VITEST_WORKER_ID: undefined,
@@ -82,6 +83,17 @@ describe("status shared-state ownership", () => {
                 source: "env",
                 provider: "default",
                 id: "STATUS_E2E_MISSING_SECRET",
+              },
+            },
+          },
+        },
+        skills: {
+          entries: {
+            cold: {
+              apiKey: {
+                source: "env",
+                provider: "default",
+                id: "STATUS_E2E_MISSING_SKILL_SECRET",
               },
             },
           },
@@ -116,7 +128,15 @@ describe("status shared-state ownership", () => {
       expect(gatewayStatus.degradedSecretOwners).toEqual([
         expect.objectContaining({
           ownerKind: "capability",
+          ownerId: "skill:cold",
+          degradationState: "cold",
+          paths: ["skills.entries.cold.apiKey"],
+          reason: "secret reference was not found",
+        }),
+        expect.objectContaining({
+          ownerKind: "capability",
           ownerId: "tts",
+          degradationState: "cold",
           paths: ["tts.providers.elevenlabs.apiKey"],
           reason: "secret reference was not found",
         }),
@@ -138,18 +158,34 @@ describe("status shared-state ownership", () => {
           expect(payload.degradedPlugins).toEqual(gatewayStatus.degradedPlugins);
         } else {
           expect(status.stdout).toContain("Degraded secrets");
+          expect(status.stdout).toContain("2 degraded");
+          expect(status.stdout).toContain("capability:skill:cold");
           expect(status.stdout).toContain("capability:tts");
+          expect(status.stdout).toContain("cold");
+          expect(status.stdout).toContain("skills.entries.cold.apiKey");
+          expect(status.stdout).toContain("tts.providers.elevenlabs.apiKey");
+          expect(status.stdout).toContain("secret reference was not found");
           expect(status.stdout).toContain("Degraded plugins");
           expect(status.stdout).toContain(DEGRADED_PLUGIN_ID);
+          if (args.includes("--all")) {
+            expect(status.stdout).toContain("2 diagnostics");
+            expect(status.stdout).toContain("! Secret diagnostics (2)");
+            expect(status.stdout).not.toContain("✓ Secret diagnostics (0)");
+          }
         }
         expect(`${status.stdout}\n${status.stderr}`).not.toContain("STATUS_E2E_MISSING_SECRET");
+        expect(`${status.stdout}\n${status.stderr}`).not.toContain(
+          "STATUS_E2E_MISSING_SKILL_SECRET",
+        );
         expect(`${status.stdout}\n${status.stderr}`).not.toContain(pluginRoot);
       }
 
       const logs = instance.logs();
       expect(logs).toContain("Secret owner capability:tts is configured-unavailable");
+      expect(logs).toContain("Secret owner capability:skill:cold is configured-unavailable");
       expect(logs).toContain(`Plugin \"${DEGRADED_PLUGIN_ID}\"`);
       expect(logs).not.toContain("STATUS_E2E_MISSING_SECRET");
+      expect(logs).not.toContain("STATUS_E2E_MISSING_SKILL_SECRET");
     } finally {
       await instance.cleanup();
       fs.rmSync(pluginRoot, { recursive: true, force: true });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where human `openclaw status` output could report authoritative degraded secret owners while simultaneously saying `Secrets: none` and `Secret diagnostics (0)`. Runtime-only owners such as TTS and skills also lost their cold/stale state, configuration path, safe reason, and recovery guidance.

During independent review, this repair also exposed a defect in the existing human-status credential redactor: its assignment grammar could leave credential suffixes visible for values containing `s`, quoted values, JSON-style fields, punctuation, or Bearer payloads.

## Why This Change Was Made

Human status now builds one bounded presentation from authoritative Gateway owners plus distinct command-local diagnostics, deduplicated by exact configuration path. The shared status redactor now consumes complete quoted, unquoted, JSON-style, and Bearer assignment values before terminal sanitization and truncation.

JSON status, credential resolution, collection scope, authentication, Gateway contracts, and secret-provider execution are unchanged. This PR is AI-assisted and intentionally requires maintainer review because it tightens a credential-masking boundary.

## User Impact

Operators now see one consistent, redacted account of degraded secrets with cold/stale state, safe owner and path, allowlisted reason, and `openclaw secrets reload` guidance. Healthy status remains healthy, and runtime degradation can no longer coexist with a misleading zero-diagnostic summary.

Human status diagnostics also avoid partially exposing common credential forms such as quoted passwords and Bearer tokens.

## Evidence

Before:

```text
Degraded secrets: 2 degraded · capability:skill:cold, capability:tts
Secrets: none
✓ Secret diagnostics (0)
```

After:

```text
Secret diagnostics:
- cold capability:skill:cold (skills.entries.cold.apiKey): secret reference was not found
- cold capability:tts (tts.providers.elevenlabs.apiKey): secret reference was not found
Retry: openclaw secrets reload

Secrets: 2 diagnostics
! Secret diagnostics (2)
```

- 88 focused status, JSON, cold-import, presentation, diagnosis, and redaction tests passed on the rebased head.
- The authentic isolated-Gateway/CLI E2E suite passed all 7 cases, including two runtime-only degraded owners, healthy/unreachable Gateways, JSON parity, read-only state ownership, and SQLite writer coexistence. One earlier run hit a transient fixture-level SQLite lock; the exact failed writer test then passed and the subsequent full suite advanced successfully into changed gates.
- Formatting and `git diff --check` passed.
- Changed-file type, lint, architecture, dead-export, import-cycle, database-first, and boundary guards passed across the final validation runs; the monolithic wrapper exceeded the 10-minute local harness window only after its constituent checks had completed or were rerun directly.
- Four adversarial P1 autoreview passes found and drove fixes for partial credential masking; the final pass reported no accepted/actionable findings.
- Production: +70/-20 (net +50). Tests: +247/-3. The production growth is the shared bounded projection and recovery presentation; the redactor correction is net zero.

Known proof gap: stale-owner rendering is covered by focused tests rather than an authenticated live secret-provider reload. No external provider credentials were used.
