### PR TITLE
fix(discord): record activity after successful poll and sticker sends

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -431,7 +431,7 @@ extensions/discord/src/resolve-users.ts	1
 extensions/discord/src/security-audit.ts	12
 extensions/discord/src/send.components.ts	3
 extensions/discord/src/send.messages.ts	2
-extensions/discord/src/send.outbound.ts	3
+extensions/discord/src/send.outbound.ts	2
 extensions/discord/src/send.shared.ts	4
 extensions/discord/src/send.webhook.ts	1
 extensions/discord/src/setup-account-state.ts	1

--- a/extensions/discord/src/send.outbound.ts
+++ b/extensions/discord/src/send.outbound.ts
@@ -447,8 +447,8 @@ export async function sendStickerDiscord(
   stickerIds: string[],
   opts: DiscordSendOpts & { content?: string },
 ): Promise<DiscordSendResult> {
-  const { rest, request, channelId, rewrittenContent, suppressEmbeds } =
-    await resolveDiscordStructuredSendContext(to, opts);
+  const context = await resolveDiscordStructuredSendContext(to, opts);
+  const { rewrittenContent, suppressEmbeds } = context;
   const stickers = normalizeStickerIds(stickerIds);
   const flags = resolveDiscordMessageFlags({ suppressEmbeds });
   const body = {
@@ -458,13 +458,7 @@ export async function sendStickerDiscord(
     enforce_nonce: true,
     ...(flags ? { flags } : {}),
   };
-  await opts.onPlatformSendDispatch?.();
-  const res = (await request(
-    () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
-    "sticker",
-    { safety: "nonce-protected-create" },
-  )) as { id: string; channel_id: string };
-  return toDiscordSendResult(res, channelId, { kind: "card" });
+  return context.send("sticker", body);
 }
 
 export async function sendPollDiscord(
@@ -472,8 +466,8 @@ export async function sendPollDiscord(
   poll: PollInput,
   opts: DiscordSendOpts & { content?: string },
 ): Promise<DiscordSendResult> {
-  const { rest, request, channelId, rewrittenContent, suppressEmbeds } =
-    await resolveDiscordStructuredSendContext(to, opts);
+  const context = await resolveDiscordStructuredSendContext(to, opts);
+  const { rewrittenContent, suppressEmbeds } = context;
   if (poll.durationSeconds !== undefined) {
     throw new Error("Discord polls do not support durationSeconds; use durationHours");
   }
@@ -486,22 +480,14 @@ export async function sendPollDiscord(
     enforce_nonce: true,
     ...(flags ? { flags } : {}),
   };
-  await opts.onPlatformSendDispatch?.();
-  const res = (await request(
-    () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
-    "poll",
-    { safety: "nonce-protected-create" },
-  )) as { id: string; channel_id: string };
-  return toDiscordSendResult(res, channelId, { kind: "poll", threadId: opts.threadId });
+  return context.send("poll", body);
 }
 
 async function resolveDiscordStructuredSendContext(
   to: string,
   opts: DiscordSendOpts & { content?: string },
 ): Promise<{
-  rest: RequestClient;
-  request: DiscordClientRequest;
-  channelId: string;
+  send: (kind: "poll" | "sticker", body: Record<string, unknown>) => Promise<DiscordSendResult>;
   rewrittenContent?: string;
   suppressEmbeds: boolean;
 }> {
@@ -519,9 +505,23 @@ async function resolveDiscordStructuredSendContext(
       })
     : undefined;
   return {
-    rest,
-    request,
-    channelId,
+    send: async (kind, body) => {
+      await opts.onPlatformSendDispatch?.();
+      const result = (await request(
+        () => createChannelMessage<{ id: string; channel_id: string }>(rest, channelId, { body }),
+        kind,
+        { safety: "nonce-protected-create" },
+      )) as { id: string; channel_id: string };
+      recordChannelActivity({
+        channel: "discord",
+        accountId: accountInfo.accountId,
+        direction: "outbound",
+      });
+      return toDiscordSendResult(result, channelId, {
+        kind: kind === "poll" ? "poll" : "card",
+        threadId: kind === "poll" ? opts.threadId : undefined,
+      });
+    },
     rewrittenContent,
     suppressEmbeds: resolveDiscordSuppressEmbeds({
       configured: accountInfo.config.suppressEmbeds,

--- a/extensions/discord/src/send.webhook-activity.test.ts
+++ b/extensions/discord/src/send.webhook-activity.test.ts
@@ -2,6 +2,7 @@
 import { MessageFlags } from "discord-api-types/v10";
 import { isRecentOutboundMessageIdentity } from "openclaw/plugin-sdk/channel-outbound";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeDiscordRest } from "./send.test-harness.js";
 
 const recordChannelActivityMock = vi.hoisted(() => vi.fn());
 const loadConfigMock = vi.hoisted(() => vi.fn(() => ({ channels: { discord: {} } })));
@@ -28,6 +29,8 @@ vi.mock("openclaw/plugin-sdk/channel-activity-runtime", async () => {
 });
 
 let sendWebhookMessageDiscord: typeof import("./send.webhook.js").sendWebhookMessageDiscord;
+let sendPollDiscord: typeof import("./send.outbound.js").sendPollDiscord;
+let sendStickerDiscord: typeof import("./send.outbound.js").sendStickerDiscord;
 
 type MockWithCalls = { mock: { calls: unknown[][] } };
 
@@ -39,9 +42,19 @@ function firstMockCall(mock: MockWithCalls, label: string): unknown[] {
   return call;
 }
 
-describe("sendWebhookMessageDiscord activity", () => {
+async function sendStructuredMessage(
+  kind: "poll" | "sticker",
+  opts: Parameters<typeof sendStickerDiscord>[2],
+) {
+  return kind === "poll"
+    ? sendPollDiscord("channel:789", { question: "Lunch?", options: ["Pizza", "Sushi"] }, opts)
+    : sendStickerDiscord("channel:789", ["123"], opts);
+}
+
+describe("Discord outbound channel activity", () => {
   beforeAll(async () => {
     ({ sendWebhookMessageDiscord } = await import("./send.webhook.js"));
+    ({ sendPollDiscord, sendStickerDiscord } = await import("./send.outbound.js"));
   });
 
   beforeEach(() => {
@@ -125,6 +138,68 @@ describe("sendWebhookMessageDiscord activity", () => {
     ).toBe(true);
     expect(loadConfigMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { kind: "poll", accountId: undefined, defaultAccount: undefined, expectedAccountId: "default" },
+    { kind: "poll", accountId: " Work ", defaultAccount: undefined, expectedAccountId: "work" },
+    { kind: "poll", accountId: undefined, defaultAccount: "work", expectedAccountId: "work" },
+    {
+      kind: "sticker",
+      accountId: undefined,
+      defaultAccount: undefined,
+      expectedAccountId: "default",
+    },
+    { kind: "sticker", accountId: " Work ", defaultAccount: undefined, expectedAccountId: "work" },
+    { kind: "sticker", accountId: undefined, defaultAccount: "work", expectedAccountId: "work" },
+  ] as const)(
+    "records successful $kind sends for the resolved $expectedAccountId account",
+    async ({ kind, accountId, defaultAccount, expectedAccountId }) => {
+      const { rest, postMock } = makeDiscordRest();
+      postMock.mockResolvedValue({ id: "msg-1", channel_id: "789" });
+      const cfg = {
+        channels: {
+          discord: {
+            token: "resolved-token",
+            accounts: {
+              default: { token: "default-token" },
+              work: { token: "work-token" },
+            },
+            ...(defaultAccount ? { defaultAccount } : {}),
+          },
+        },
+      };
+
+      await sendStructuredMessage(kind, {
+        cfg,
+        rest,
+        token: "test-token",
+        ...(accountId ? { accountId } : {}),
+      });
+
+      expect(recordChannelActivityMock).toHaveBeenCalledExactlyOnceWith({
+        channel: "discord",
+        accountId: expectedAccountId,
+        direction: "outbound",
+      });
+    },
+  );
+
+  it.each(["poll", "sticker"] as const)(
+    "does not record outbound activity when a %s send fails",
+    async (kind) => {
+      const { rest, postMock } = makeDiscordRest();
+      postMock.mockRejectedValue(new Error("provider rejected"));
+
+      await expect(
+        sendStructuredMessage(kind, {
+          cfg: { channels: { discord: { token: "resolved-token" } } },
+          rest,
+          token: "test-token",
+        }),
+      ).rejects.toThrow("provider rejected");
+      expect(recordChannelActivityMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("rewrites configured mention aliases for webhook sends", async () => {
     const cfg = {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending Discord polls or stickers would see stale outbound channel activity, even though Discord successfully delivered their messages. This made Discord account health and last-outbound status disagree with actual successful activity.

## Why This Change Was Made

The Discord plugin already records successful text, media, component, webhook, and voice sends, but poll and sticker delivery duplicated their send-completion logic without reporting the same authoritative activity fact. Both structured-message senders now share one account-aware completion owner that records activity only after successful platform delivery.

## User Impact

Discord poll and sticker sends now update the correct account's last-outbound activity, including explicit normalized account IDs and configured default accounts. Failed sends remain unrecorded, and existing dispatch hooks, nonce protection, receipt types, thread identity, and content behavior remain unchanged.

## Evidence

- Six authentic account-bound poll/sticker activity regressions fail against the original implementation and pass with the fix.
- Both poll and sticker failure paths prove rejected platform sends never record successful outbound activity.
- All 14 focused Discord outbound activity tests pass.
- Production delta: +24/-24 (net zero); regression tests: +76/-1.
- Independent owner-boundary review found no actionable issues.
- Live Discord account proof is unavailable in this isolated checkout; deterministic tests drive the real plugin sender and Discord REST request boundaries instead.
