### PR TITLE
fix(agents): stop suggesting unavailable tools in system prompts

### DIFF
--- a/src/agents/cli-runner/helpers.system-prompt.test.ts
+++ b/src/agents/cli-runner/helpers.system-prompt.test.ts
@@ -40,6 +40,7 @@ describe("buildCliAgentSystemPrompt", () => {
   it("uses CLI backend tool fallback instead of OpenClaw tool assumptions", () => {
     const prompt = buildCliAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      docsPath: "/tmp/openclaw/docs",
       tools: [],
       modelDisplay: "test/model",
     });
@@ -50,6 +51,10 @@ describe("buildCliAgentSystemPrompt", () => {
     expect(prompt).not.toContain("Larger work: use `sessions_spawn`");
     expect(prompt).not.toContain("Do not poll `subagents list` / `sessions_list` in a loop");
     expect(prompt).toContain("No OpenClaw tool list is injected");
+    expect(prompt).toContain("docs first via `read`");
+    expect(prompt).not.toContain("exec approval-pending");
+    expect(prompt).not.toContain("Config read: `gateway`");
+    expect(prompt).not.toContain("`gateway(config.schema.lookup)`");
   });
 
   it("describes bundled exec as synchronous node execution", () => {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -2538,7 +2538,9 @@ describe("prepareCliRunContext", () => {
           extraSystemPromptStatic: staticPrompt,
           sourceReplyDeliveryMode: stableMode,
         };
+        const config = createCliBackendConfig({ bundleMcp: true });
         const first = await fixture.prepare({
+          config,
           sessionKey: "main",
           prompt: "first ask",
           extraSystemPrompt: `volatile msg-1\n\n${staticPrompt}`,
@@ -2547,6 +2549,7 @@ describe("prepareCliRunContext", () => {
           cliSessionBindingFacts,
         });
         const second = await fixture.prepare({
+          config,
           sessionKey: "main",
           prompt: "second ask",
           extraSystemPrompt: `volatile msg-2\n\n${staticPrompt}`,
@@ -2559,6 +2562,8 @@ describe("prepareCliRunContext", () => {
             messageToolPolicyHash: first.messageToolPolicyHash,
             promptToolNamesHash: first.promptToolNamesHash,
             cwdHash: hashCliSessionText(dir),
+            mcpConfigHash: first.preparedBackend.mcpConfigHash,
+            mcpResumeHash: first.preparedBackend.mcpResumeHash,
           },
         });
 

--- a/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
@@ -137,6 +137,7 @@ describe("prepared harness source delivery", () => {
     let modelVisiblePrompt = "";
     const recordModelVisiblePrompt = (attemptParams: {
       extraSystemPrompt?: string;
+      forceMessageTool?: boolean;
       sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
     }) => {
       modelVisiblePrompt = buildEmbeddedSystemPrompt({
@@ -154,7 +155,7 @@ describe("prepared harness source delivery", () => {
           channel: "discord",
           chatType: "direct",
         },
-        tools: [],
+        tools: attemptParams.forceMessageTool ? [{ name: "message" } as never] : [],
         userTimezone: "UTC",
         userDate: "2026-08-11",
       });

--- a/src/agents/embedded-agent-runner/system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.test.ts
@@ -305,8 +305,8 @@ describe("buildEmbeddedSystemPrompt", () => {
     expect(prompt).not.toContain("## Memory Recall");
   });
 
-  it("includes active background process references in the embedded prompt", () => {
-    const prompt = buildEmbeddedSystemPrompt({
+  it("includes active background process references only when process is callable", () => {
+    const params = {
       workspaceDir: "/tmp/openclaw",
       reasoningTagHint: false,
       runtimeInfo: {
@@ -330,16 +330,22 @@ describe("buildEmbeddedSystemPrompt", () => {
           },
         ],
       },
-      tools: [],
+      tools: [{ name: "process" } as never],
       modelAliasLines: [],
       userTimezone: "UTC",
       userDate: "2026-01-05",
-    });
+    } satisfies Parameters<typeof buildEmbeddedSystemPrompt>[0];
+    const prompt = buildEmbeddedSystemPrompt(params);
 
     expect(prompt).toContain("Active exec sessions:");
     expect(prompt).toContain("sess-active running pid=1234 cwd=/tmp/work :: sleep 600");
     expect(prompt).toContain("Before input: process log");
     expect(prompt).toContain("waitingForInput/stdinWritable");
     expect(prompt).toContain("process list");
+
+    const restrictedPrompt = buildEmbeddedSystemPrompt({ ...params, tools: [] });
+    expect(restrictedPrompt).not.toContain("Active exec sessions:");
+    expect(restrictedPrompt).not.toContain("process log");
+    expect(restrictedPrompt).not.toContain("process list");
   });
 });

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -218,7 +218,7 @@ describe("buildAgentSystemPrompt", () => {
       skillsPrompt:
         "<available_skills>\n  <skill>\n    <name>demo</name>\n  </skill>\n</available_skills>",
       heartbeatPrompt: "ping",
-      toolNames: ["message", "memory_search", "read"],
+      toolNames: ["message", "memory_search", "read", "exec", "process"],
       docsPath: "/tmp/openclaw/docs",
       extraSystemPrompt: "Subagent details",
       ttsHint: "Voice (TTS) is enabled.",
@@ -289,7 +289,23 @@ describe("buildAgentSystemPrompt", () => {
       sourceReplyDeliveryMode: "message_tool_only",
     });
     expect(unavailableMessagePrompt).not.toContain("message(action=send)");
-    expect(unavailableMessagePrompt).not.toContain("## Messaging");
+    expect(unavailableMessagePrompt).toContain("## Messaging");
+    expect(unavailableMessagePrompt).toContain(
+      "visible reply unavailable; final text remains private",
+    );
+
+    const unavailableFullMessagePrompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["read"],
+      sourceReplyDeliveryMode: "message_tool_only",
+      runtimeInfo: { channel: "webchat" },
+    });
+    expect(unavailableFullMessagePrompt).toContain(
+      "visible reply unavailable; final text remains private",
+    );
+    expect(unavailableFullMessagePrompt).not.toContain("message(action=send)");
+    expect(unavailableFullMessagePrompt).not.toContain("## Assistant Output Directives");
+    expect(unavailableFullMessagePrompt).not.toContain("## Control UI Embed");
 
     const automaticMessagePrompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
@@ -509,6 +525,7 @@ describe("buildAgentSystemPrompt", () => {
   it("includes an OpenClaw control section", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      toolNames: ["gateway"],
     });
 
     expect(prompt).toContain("## OpenClaw Control");
@@ -521,6 +538,7 @@ describe("buildAgentSystemPrompt", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
       docsPath: "/tmp/openclaw/docs",
+      toolNames: ["read", "gateway"],
     });
 
     expect(prompt).toContain("Config field:");
@@ -606,7 +624,7 @@ describe("buildAgentSystemPrompt", () => {
     });
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
-      toolNames: ["sessions_spawn", "sessions_list", "subagents"],
+      toolNames: ["exec", "process", "sessions_spawn", "sessions_list", "subagents"],
     });
 
     expect(withoutSpawn).not.toContain("sessions_spawn");
@@ -708,6 +726,95 @@ describe("buildAgentSystemPrompt", () => {
 
     expect(prompt).toContain("active runtime provides the available OpenClaw tools directly");
     expect(prompt).not.toContain("sessions_spawn");
+  });
+
+  it("limits tool-dependent prompt guidance to the callable tool surface", () => {
+    const cases = typedCases<{
+      name: string;
+      toolNames: string[];
+      includes: string[];
+      excludes: string[];
+    }>([
+      {
+        name: "empty tool surface",
+        toolNames: [],
+        includes: [],
+        excludes: [
+          "docs first via `read`",
+          "exec approval-pending",
+          "exec yieldMs",
+          "process(poll",
+          "Config read: `gateway`",
+          "`gateway(config.schema.lookup)`",
+          "message(action=send)",
+        ],
+      },
+      {
+        name: "read-only tool surface",
+        toolNames: ["read"],
+        includes: ["docs first via `read`"],
+        excludes: [
+          "exec approval-pending",
+          "exec yieldMs",
+          "process(poll",
+          "`gateway(",
+          "message(action=send)",
+        ],
+      },
+      {
+        name: "exec-only tool surface",
+        toolNames: ["exec"],
+        includes: ["exec approval-pending", "Use exec yieldMs."],
+        excludes: ["process(poll", "Config read: `gateway`", "`gateway("],
+      },
+      {
+        name: "process-only tool surface",
+        toolNames: ["process"],
+        includes: ["Use process(poll, timeout=<ms>)."],
+        excludes: ["exec approval-pending", "exec yieldMs", "Config read: `gateway`"],
+      },
+      {
+        name: "gateway-only tool surface",
+        toolNames: ["gateway"],
+        includes: ["Config read: `gateway`", "`gateway(config.schema.lookup)`"],
+        excludes: ["exec approval-pending", "exec yieldMs", "process(poll"],
+      },
+      {
+        name: "openclaw-only tool surface",
+        toolNames: ["openclaw"],
+        includes: ["ask `openclaw`"],
+        excludes: ["exec approval-pending", "exec yieldMs", "process(poll", "`gateway("],
+      },
+    ]);
+
+    for (const testCase of cases) {
+      const prompt = buildAgentSystemPrompt({
+        workspaceDir: "/tmp/openclaw",
+        docsPath: "/tmp/openclaw/docs",
+        toolNames: testCase.toolNames,
+      });
+      for (const value of testCase.includes) {
+        expect(prompt, `${testCase.name}:${value}`).toContain(value);
+      }
+      for (const value of testCase.excludes) {
+        expect(prompt, `${testCase.name}:${value}`).not.toContain(value);
+      }
+    }
+  });
+
+  it("keeps guidance for callable tools with deferred schemas", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      docsPath: "/tmp/openclaw/docs",
+      toolNames: ["tool_search"],
+      capabilityToolNames: ["exec", "process", "gateway"],
+    });
+
+    expect(prompt).toContain("exec approval-pending");
+    expect(prompt).toContain("Use exec yieldMs or process(poll, timeout=<ms>).");
+    expect(prompt).toContain("Config read: `gateway`");
+    expect(prompt).toContain("`gateway(config.schema.lookup)`");
+    expect(prompt).not.toContain("docs first via `read`");
   });
 
   it("documents ACP sessions_spawn agent targeting requirements", () => {
@@ -828,6 +935,7 @@ describe("buildAgentSystemPrompt", () => {
       workspaceDir: "/tmp/openclaw",
       docsPath: "/tmp/openclaw/docs",
       sourcePath: "/tmp/openclaw",
+      toolNames: ["read"],
     });
 
     expect(prompt).toContain("## Documentation");
@@ -1570,7 +1678,8 @@ describe("buildAgentSystemPrompt", () => {
     });
 
     expect(prompt).toContain("final text normally routes to source");
-    expect(prompt).toContain("If turn says final private");
+    expect(prompt).not.toContain("If turn says final private");
+    expect(prompt).not.toContain("message(action=send)");
     expect(prompt).not.toContain("### message tool");
   });
 
@@ -1686,6 +1795,7 @@ describe("buildAgentSystemPrompt", () => {
   it("suppresses plain chat approval commands when inline approval UI is available", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      toolNames: ["exec"],
       runtimeInfo: {
         channel: "telegram",
         capabilities: ["inlineButtons"],
@@ -1699,6 +1809,7 @@ describe("buildAgentSystemPrompt", () => {
   it("suppresses plain chat approval commands for native approval runtimes", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      toolNames: ["exec"],
       runtimeInfo: {
         channel: "whatsapp",
         capabilities: ["nativeApprovals"],
@@ -1712,6 +1823,7 @@ describe("buildAgentSystemPrompt", () => {
   it("keeps approval slug guidance separate from command previews", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      toolNames: ["exec"],
       runtimeInfo: {
         channel: "discord",
       },
@@ -1886,6 +1998,7 @@ describe("buildAgentSystemPrompt", () => {
   it("describes sandboxed runtime and elevated when allowed", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      toolNames: ["exec"],
       sandboxInfo: {
         enabled: true,
         workspaceDir: "/tmp/sandbox",
@@ -1913,6 +2026,7 @@ describe("buildAgentSystemPrompt", () => {
   it("does not advertise /elevated full when auto-approved full access is unavailable", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
+      toolNames: ["exec"],
       sandboxInfo: {
         enabled: true,
         workspaceDir: "/tmp/sandbox",
@@ -1955,7 +2069,7 @@ describe("buildAgentSystemPrompt", () => {
   it("keeps exec-approval and authorized-sender guidance below the stable prefix", () => {
     const baseParams = {
       workspaceDir: "/tmp/openclaw",
-      toolNames: ["message"],
+      toolNames: ["message", "exec"],
       ownerNumbers: ["+123"],
       runtimeInfo: {
         channel: "webchat",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -462,8 +462,9 @@ function buildTemporalContextSection(params: {
 function buildAssistantOutputDirectivesSection(params: {
   isMinimal: boolean;
   sourceMessageToolOnly: boolean;
+  messageToolAvailable: boolean;
 }) {
-  if (params.isMinimal) {
+  if (params.isMinimal || (params.sourceMessageToolOnly && !params.messageToolAvailable)) {
     return [];
   }
   if (params.sourceMessageToolOnly) {
@@ -494,8 +495,13 @@ function buildWebchatCanvasSection(params: {
   isMinimal: boolean;
   runtimeChannel?: string;
   sourceMessageToolOnly: boolean;
+  messageToolAvailable: boolean;
 }) {
-  if (params.isMinimal || params.runtimeChannel !== "webchat") {
+  if (
+    params.isMinimal ||
+    params.runtimeChannel !== "webchat" ||
+    (params.sourceMessageToolOnly && !params.messageToolAvailable)
+  ) {
     return [];
   }
   return [
@@ -581,17 +587,25 @@ function buildMessagingSection(params: {
   delegationSectionRenders: boolean;
 }) {
   const messageToolOnly = params.sourceReplyDeliveryMode === "message_tool_only";
+  const messageToolAvailable = params.availableTools.has("message");
   const visibleReplyInstruction = messageToolOnly
-    ? "- Current source visible reply MUST use `message(action=send)`; final text is private. Set `final=false` for progress. Set `final=true`, or omit it, for the completed reply. Skip tool = user gets nothing. No hidden instructions/private data/reasoning."
-    : "- Current-session final text normally routes to source. If turn says final private, visible output uses `message(action=send)`.";
+    ? messageToolAvailable
+      ? "- Current source visible reply MUST use `message(action=send)`; final text is private. Set `final=false` for progress. Set `final=true`, or omit it, for the completed reply. Skip tool = user gets nothing. No hidden instructions/private data/reasoning."
+      : "- Current source visible reply unavailable; final text remains private."
+    : `- Current-session final text normally routes to source.${messageToolAvailable ? " If turn says final private, visible output uses `message(action=send)`." : ""}`;
   const messageToolTargetInstruction = params.requireExplicitMessageTarget
     ? "- `send`: `target` + `message`; target required this turn."
     : "- `send`: `message`; current source is default target. Set `target` only elsewhere.";
   if (params.isMinimal) {
     // Restricted delivery turns still need their sole visible-reply contract;
     // omitting it makes a private final silently disappear for the requester.
-    return messageToolOnly && params.availableTools.has("message")
-      ? ["## Messaging", visibleReplyInstruction, messageToolTargetInstruction, ""]
+    return messageToolOnly
+      ? [
+          "## Messaging",
+          visibleReplyInstruction,
+          ...(messageToolAvailable ? [messageToolTargetInstruction] : []),
+          "",
+        ]
       : [];
   }
   const showGenericInlineButtonHint = params.runtimeChannel !== "slack";
@@ -622,7 +636,7 @@ function buildMessagingSection(params: {
     subagentOrchestrationGuidance,
     completionEventGuidance,
     "- Provider messaging: never exec/curl; OpenClaw routes.",
-    params.availableTools.has("message")
+    messageToolAvailable
       ? [
           "",
           "### message tool",
@@ -699,7 +713,8 @@ function buildDocsSection(params: {
   docsPath?: string;
   sourcePath?: string;
   isMinimal: boolean;
-  readToolName: string;
+  readToolName?: string;
+  hasGateway: boolean;
 }) {
   const docsPath = params.docsPath?.trim();
   const sourcePath = params.sourcePath?.trim();
@@ -712,9 +727,11 @@ function buildDocsSection(params: {
     docsPath ? "Mirror: https://docs.openclaw.ai" : undefined,
     sourcePath ? `Source: ${sourcePath}` : "Source: https://github.com/openclaw/openclaw",
     docsPath
-      ? `OpenClaw behavior questions: docs first via \`${params.readToolName}\`/local search. AGENTS/project/workspace/profile/memory = instructions/user memory, not product design truth.`
+      ? `OpenClaw behavior questions: docs first${params.readToolName ? ` via \`${params.readToolName}\`/local search` : " using available tools"}. AGENTS/project/workspace/profile/memory = instructions/user memory, not product design truth.`
       : "OpenClaw behavior questions: docs mirror first when web exists. AGENTS/project/workspace/profile/memory = instructions/user memory, not product design truth.",
-    "Config field: `gateway(config.schema.lookup)` exact path. Broader: `docs/gateway/configuration.md`, `docs/gateway/configuration-reference.md`.",
+    params.hasGateway
+      ? "Config field: `gateway(config.schema.lookup)` exact path. Broader: `docs/gateway/configuration.md`, `docs/gateway/configuration-reference.md`."
+      : "Configuration docs: `docs/gateway/configuration.md`, `docs/gateway/configuration-reference.md`.",
     sourcePath
       ? "If docs are silent/stale, say so and inspect local source."
       : "If docs are silent/stale, say so and inspect GitHub source.",
@@ -1020,11 +1037,16 @@ export function buildAgentSystemPrompt(params: {
       hasToolList: toolLines.length > 0,
     }) && params.codeModeActive !== true;
 
+  const hasExec = availableTools.has("exec");
+  const hasProcess = availableTools.has("process");
   const hasGateway = availableTools.has("gateway");
   const hasOpenClaw = availableTools.has("openclaw");
+  const messageToolAvailable = availableTools.has("message");
   const readToolName = resolveToolName("read");
-  const execToolName = resolveToolName("exec");
-  const processToolName = resolveToolName("process");
+  const waitToolHints = [
+    hasExec ? `${resolveToolName("exec")} yieldMs` : "",
+    hasProcess ? `${resolveToolName("process")}(poll, timeout=<ms>)` : "",
+  ].filter(Boolean);
   const extraSystemPrompt = params.extraSystemPrompt?.trim();
   const promptContribution = params.promptContribution;
   const providerStablePrefix = normalizeProviderPromptBlock(promptContribution?.stablePrefix);
@@ -1092,7 +1114,7 @@ export function buildAgentSystemPrompt(params: {
   const sanitizedSandboxContainerWorkspace = sandboxContainerWorkspace
     ? sanitizeForPromptLiteral(sandboxContainerWorkspace)
     : "";
-  const elevated = params.sandboxInfo?.elevated;
+  const elevated = hasExec ? params.sandboxInfo?.elevated : undefined;
   const fullAccessBlockedReasonLabel =
     elevated?.fullAccessAvailable === false
       ? formatFullAccessBlockedReason(elevated.fullAccessBlockedReason)
@@ -1103,7 +1125,7 @@ export function buildAgentSystemPrompt(params: {
       : sanitizedWorkspaceDir;
   const workspaceGuidance =
     params.sandboxInfo?.enabled && sanitizedSandboxContainerWorkspace
-      ? `File tools use host workspace ${sanitizedWorkspaceDir}. exec uses container ${sanitizedSandboxContainerWorkspace} or relative workdir paths; never host paths. Prefer relative paths for both.`
+      ? `File tools use host workspace ${sanitizedWorkspaceDir}.${hasExec ? ` exec uses container ${sanitizedSandboxContainerWorkspace} or relative workdir paths; never host paths. Prefer relative paths for both.` : ""}`
       : "Single global file workspace unless explicitly told otherwise.";
   const workspaceOnlyGuidance =
     params.fsWorkspaceOnly === true
@@ -1151,7 +1173,9 @@ export function buildAgentSystemPrompt(params: {
     docsPath: params.docsPath,
     sourcePath: params.sourcePath,
     isMinimal,
-    readToolName,
+    readToolName:
+      visibleTools.has("read") || promptSurface === "cli_backend" ? readToolName : undefined,
+    hasGateway,
   });
   const workspaceNotes = normalizeStringEntries(params.workspaceNotes);
 
@@ -1184,8 +1208,7 @@ export function buildAgentSystemPrompt(params: {
     hasGateway,
     hasOpenClaw,
     readToolName,
-    execToolName,
-    processToolName,
+    waitToolHints,
     nativeCommandGuidanceLines,
     providerSectionOverrides,
     providerStablePrefix,
@@ -1233,7 +1256,9 @@ export function buildAgentSystemPrompt(params: {
       "The AGENTS.md Tools section guides usage; it never grants availability.",
       ...(renderOpenClawToolWorkflowHints
         ? [
-            `Long wait: no rapid poll. Use ${execToolName} yieldMs or ${processToolName}(poll, timeout=<ms>).`,
+            ...(waitToolHints.length > 0
+              ? [`Long wait: no rapid poll. Use ${waitToolHints.join(" or ")}.`]
+              : []),
             ...(hasSessionsSpawn
               ? [
                   "Large work: `sessions_spawn`; completion push-based.",
@@ -1315,9 +1340,11 @@ export function buildAgentSystemPrompt(params: {
         ? [
             "Gateway restart, config, channels, plugins, agents, models/providers, updates: ask `openclaw`. Never restart the Gateway through shell commands or write your own config.",
           ]
-        : [
-            "Config read: `gateway` (`config.get|config.schema.lookup`). Write/restart unavailable; ask human.",
-          ]),
+        : hasGateway
+          ? [
+              "Config read: `gateway` (`config.get|config.schema.lookup`). Write/restart unavailable; ask human.",
+            ]
+          : ["System controls unavailable; ask human."]),
       "",
       ...skillsSection,
       ...skillWorkshopSection,
@@ -1405,7 +1432,11 @@ export function buildAgentSystemPrompt(params: {
       "## Workspace Files (injected)",
       "User-editable; OpenClaw loads below as Project Context.",
       "",
-      ...buildAssistantOutputDirectivesSection({ isMinimal, sourceMessageToolOnly }),
+      ...buildAssistantOutputDirectivesSection({
+        isMinimal,
+        sourceMessageToolOnly,
+        messageToolAvailable,
+      }),
     ];
 
     if (reasoningHint) {
@@ -1458,7 +1489,7 @@ export function buildAgentSystemPrompt(params: {
   lines.push(
     // Approval UI and owner identity vary by turn, so keep both below the stable prefix.
     // A tool_call_style override owns the complete section and suppresses default guidance.
-    ...(providerSectionOverrides.tool_call_style
+    ...(providerSectionOverrides.tool_call_style || !hasExec
       ? []
       : [
           buildExecApprovalPromptGuidance({
@@ -1472,6 +1503,7 @@ export function buildAgentSystemPrompt(params: {
       isMinimal,
       runtimeChannel,
       sourceMessageToolOnly,
+      messageToolAvailable,
     }),
     ...buildControlUiSessionCompanionSection({
       isMinimal,
@@ -1531,7 +1563,9 @@ export function buildAgentSystemPrompt(params: {
     "## Runtime",
     buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
     ...(modelIdentityLine ? [modelIdentityLine] : []),
-    ...buildActiveProcessSessionReferenceLines(runtimeInfo?.activeProcessSessions),
+    ...(hasProcess
+      ? buildActiveProcessSessionReferenceLines(runtimeInfo?.activeProcessSessions)
+      : []),
     `Reasoning=${reasoningLevel}; hidden unless on/stream. Toggle /reasoning; /status shows when enabled.`,
   );
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents and sub-agents following their OpenClaw system prompt were instructed to call tools that their effective policy did not actually expose. Restricted or backend-owned runtimes could be told to use unavailable `read`, `exec`, `process`, `gateway`, or `message` tools, poll nonexistent background sessions, request impossible approval flows, or promise visible output when the current turn's final text was private and messaging was unavailable.

## Why This Change Was Made

Make the canonical system-prompt renderer derive every tool-specific instruction from the existing effective callable-tool set, including tools with deferred schemas. The same owner now gates approval, waiting, active-process, documentation, system-control, sandbox-exec, message delivery, output-directive, and Control UI embed instructions. CLI backends retain their independently owned native file-reading capability; private-final turns without a message tool explicitly describe the unavailable visible reply instead of silently implying it will be delivered.

The alternative of adding consumer-side tool-call guards leaves the model-visible instructions incorrect and retains impossible actions; independently patching CLI, embedded, and minimal prompts duplicates policy. Production delta: +58/-24 (net +34), justified by applying one capability ownership invariant across the affected prompt sections and preserving native backend/deferred-tool exceptions. Test delta: +134/-9.

## User Impact

Agents no longer waste turns hallucinating unavailable tools or approval paths, background process guidance appears only when the process tool can act, and documentation/control instructions match real capabilities. Private-final messaging turns truthfully explain when no visible response can be sent. Normal fully provisioned agents, native CLI file tools, deferred callable tools, prompt-cache boundaries, sandbox policy, and existing successful delivery flows remain unchanged.

## Evidence

- Exact reviewed branch head: `86c8ef3df18a83be88227ba16d973111f637decf`.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs src/agents/system-prompt.test.ts src/agents/embedded-agent-runner/system-prompt.test.ts src/agents/cli-runner/helpers.system-prompt.test.ts --configLoader runner` — 146 tests passed across canonical, embedded, and CLI runtime owners.
- Coverage includes empty/read-only/exec-only/process-only/gateway-only/OpenClaw-only tool surfaces, deferred schemas, native CLI file reading, message-tool-only private turns, Webchat output, sandbox elevation, approval modes, stable prompt prefixes, and active process sessions.
- `node --import tsx scripts/generate-prompt-snapshots.ts --check` — all seven committed prompt snapshots current.
- `node_modules/.bin/oxfmt --check src/agents/system-prompt.ts src/agents/system-prompt.test.ts src/agents/embedded-agent-runner/system-prompt.test.ts src/agents/cli-runner/helpers.system-prompt.test.ts` — passed.
- `node --import tsx scripts/check-max-lines-ratchet.mts --base origin/main` — passed.
- `node --import tsx scripts/check-assertion-safety-ratchet.mts --base origin/main` — passed.
- Fresh full-branch authenticated independent Codex review: clean; no actionable findings.
- Complete canonical renderer, configured facade, embedded runtime producer, CLI backend producer, prompt-surface owner, tool-policy/deferred capability inputs, and current system-prompt documentation were inspected. No public API, configuration, security enforcement, authorization, SQLite, persistence, migration, protocol, or provider dependency changes.

