### PR TITLE
fix(imessage): stop id-less media echoes from suppressing inbound attachments

### DIFF
--- a/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.echo-cache.test-support.ts
@@ -167,6 +167,24 @@ describe("iMessage sent-message echo cache", () => {
     ).toBe(true);
   });
 
+  it("does not let an id-less completed media echo suppress later inbound attachments", () => {
+    const scope = "acct:imessage:+1555";
+    const media = { contentType: "image/jpeg", kind: "image" as const };
+    rememberPersistedIMessageEcho({ scope, media });
+
+    expect(
+      hasPersistedIMessageEcho({
+        scope,
+        media: { contentType: "image/heic", kind: "image" },
+        messageId: "guid-user-photo",
+      }),
+    ).toBe(false);
+    expect(hasPersistedIMessageEcho({ scope, media })).toBe(false);
+
+    rememberPersistedIMessageEcho({ scope, media, messageId: "guid-agent-image" });
+    expect(hasPersistedIMessageEcho({ scope, media, messageId: "guid-agent-image" })).toBe(true);
+  });
+
   it("does not match persisted text when both message ids differ", () => {
     // Outbound "ok" recorded with its GUID; a user later sends "ok" with a new
     // GUID. Same text, conflicting ids — a NEW message, not a reconnect echo.

--- a/extensions/imessage/src/monitor/persisted-echo-cache.ts
+++ b/extensions/imessage/src/monitor/persisted-echo-cache.ts
@@ -241,7 +241,7 @@ export function hasPersistedIMessageEcho(params: {
       mediaKey &&
       !hasConflictingMessageIds &&
       resolveIMessageEchoMediaKey(entry.media) === mediaKey &&
-      (!entry.pending || params.includePendingText)
+      (entry.pending ? params.includePendingText : Boolean(entry.messageId))
     ) {
       return true;
     }


### PR DESCRIPTION
## What Problem This Solves

After the agent sends one image over an iMessage transport that does not return a message id, every photo the user sends in that conversation for the next 12 hours is dropped as the agent's own echo. The drop happens before any persistence: no session entry, no history row, no user-visible notice, only a verbose `skipping echo message` log line. The durable ingress claim is completed as an echo rather than nacked, so there is no replay path and the photo never reaches the agent.

Trigger on default config: `sendTransport` defaults to `auto`; an attachment send whose bridge result carries no `guid`/`messageId`/`message_id`/`id` (the `ok`/`unknown` placeholder case documented on `IMessageSendResult.messageId` in `extensions/imessage/src/send.ts`) writes a completed, id-less persisted echo entry (`extensions/imessage/src/send.ts:776` and `:1170`, `messageId: resolvedId ?? undefined`, TTL `IMESSAGE_SENT_ECHOES_TTL_MS` = 12h).

## Why This Change Was Made

Root cause is in `hasPersistedIMessageEcho` (`extensions/imessage/src/monitor/persisted-echo-cache.ts`). The media branch matched on `resolveIMessageEchoMediaKey`, which reduces any media to `kind:image` (no filename, size, or digest), guarded only by `hasConflictingMessageIds`:

```ts
const hasConflictingMessageIds = Boolean(
  messageId && entry.messageId && messageId !== entry.messageId,
);
```

That guard is vacuously false whenever the stored outbound entry has no `messageId`, so for an id-less completed entry the only thing standing between an inbound user photo and a 12-hour-old outbound record was "both are images".

The fix changes the media branch so that a completed entry can only authorize a media match when it carries a real outbound id (which the conflicting-id guard can then compare against), while pending pre-send markers keep their existing `includePendingText` opt-in:

```ts
(entry.pending ? params.includePendingText : Boolean(entry.messageId))
```

Why this is the right boundary: `hasPersistedIMessageEcho` is the single matcher every echo lookup routes through (`monitor/echo-cache.ts` consults it first, `inbound-processing.ts` reaches it via `hasIMessageEchoMatch` for the self-chat, reaction-target, and generic inbound paths), so the invariant is enforced once at the owner rather than patched at each producer in `send.ts`. Genuine echo handling is preserved:

- An id-backed outbound entry still matches by id, and a different inbound GUID still blocks it (existing tests `does not match persisted media when both message ids differ`).
- The pre-send pending marker (`rememberPersistedIMessageEcho({... pending: true })`, bounded by `pendingEchoTtlMs`) still suppresses the in-flight self-chat echo of an id-less attachment send (existing test `matches persisted media through the primary sent-message cache`).
- The in-memory `SentMessageCache` still covers the short id-less media window (`SENT_MESSAGE_TEXT_TTL_MS`, 4s) that `monitor/deliver.ts` feeds after every send; that window, not the 12h store, is where kind-level matching is acceptable.

What is accepted: an own attachment row that imsg re-emits hours later after a reconnect, for a send that never had an id, is no longer recognized as an echo and will be re-ingested. That is a duplicate delivery (noisy, covered by the reflection and loop guards), whereas the previous behavior was silent loss of user photos. The text branch is unchanged: its identity is exact normalized content, which PR #120260 deliberately kept for id-less reconnect echoes; the media key is kind-level and carries no such identity.

Production LOC delta: +1/-1 (one condition rewritten).

Related, distinct:
- PR #120260 (merged) fixed the text branch and described the media branch as already guarded; this PR closes the gap that guard leaves for id-less entries.
- Issue #122794 (open) covers pending text markers in self-chat during the 185s send window and explicitly scopes attachment-only no-GUID behavior as separately owned; this PR is that separate surface (completed entries, media branch, every DM and group, 12h window).

## User Impact

Users on the iMessage plugin who receive an image from the agent over a transport that does not return a message id can again send photos to the agent for the rest of the day. No config change, no migration; the persisted store shape is untouched.

## Evidence

Real runtime, no mocks of the code under test: the real plugin state runtime (`createPluginStateSyncKeyedStore` under an isolated `OPENCLAW_STATE_DIR`), the real `rememberPersistedIMessageEcho` called with exactly the arguments `send.ts:776` passes when the bridge result has no id, and the real `resolveIMessageInboundDecision` driven with a fresh-GUID, different-mime inbound photo. Case 3 is the control that a true echo (same GUID re-emitted) is still dropped.

```
# BEFORE (pristine main 28ec823c3bc7a49dd58053790afa995e141ced26)
case 1  outbound image recorded WITHOUT a bridge id; user sends a different photo (fresh GUID) -> drop (echo)
case 2  outbound image recorded WITH guid OUTBOUND-GUID-0001; user sends a different photo (fresh GUID) -> dispatch
case 3  outbound image recorded WITH guid OUTBOUND-GUID-0001; the same guid is re-emitted (true echo) -> drop (echo)

# AFTER (this patch, identical inputs)
case 1  outbound image recorded WITHOUT a bridge id; user sends a different photo (fresh GUID) -> dispatch
case 2  outbound image recorded WITH guid OUTBOUND-GUID-0001; user sends a different photo (fresh GUID) -> dispatch
case 3  outbound image recorded WITH guid OUTBOUND-GUID-0001; the same guid is re-emitted (true echo) -> drop (echo)
```

Only case 1 moves. The user photo that was swallowed by the id-less record is dispatched; id-backed records and true echoes behave exactly as before.

## Verification

- `node scripts/run-vitest.mjs extensions/imessage/src/monitor/cache-lifecycle.test.ts`: 43 passed with the patch. With `persisted-echo-cache.ts` reverted to `origin/main` the new case `does not let an id-less completed media echo suppress later inbound attachments` fails (`expected true to be false`), 42 passed.
- `./node_modules/.bin/oxlint -c .oxlintrc.json <changed files>`: exit 0, no findings (the `scripts/run-oxlint.mjs` wrapper stalls in this symlinked worktree on its prepare step, so the direct binary with the repo config was used)
- `./node_modules/.bin/oxfmt --check <changed files>`: all matched files use the correct format
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental`: exit 0, no diagnostics

## Real behavior proof
Behavior addressed: after one id-less outbound image send, every inbound user photo in that iMessage conversation was dropped as an echo for 12 hours with no session record.
Real environment tested: real plugin state store under an isolated OPENCLAW_STATE_DIR, real rememberPersistedIMessageEcho seeded with the exact id-less arguments send.ts passes, real resolveIMessageInboundDecision, on pristine main 28ec823c3bc7a49dd58053790afa995e141ced26 and on the patched tree; nothing in the echo path was stubbed.
Exact steps or command run after this patch: `cd <worktree> && node --import tsx probe2.mts` (the probe seeds the persisted echo store and drives the inbound decision for the three cases shown below)
Evidence after fix:
```
# BEFORE (pristine main 28ec823c3bc7a49dd58053790afa995e141ced26)
case 1  outbound image recorded WITHOUT a bridge id; user sends a different photo (fresh GUID) -> drop (echo)
case 2  outbound image recorded WITH guid OUTBOUND-GUID-0001; user sends a different photo (fresh GUID) -> dispatch
case 3  outbound image recorded WITH guid OUTBOUND-GUID-0001; the same guid is re-emitted (true echo) -> drop (echo)

# AFTER (this patch, identical inputs)
case 1  outbound image recorded WITHOUT a bridge id; user sends a different photo (fresh GUID) -> dispatch
case 2  outbound image recorded WITH guid OUTBOUND-GUID-0001; user sends a different photo (fresh GUID) -> dispatch
case 3  outbound image recorded WITH guid OUTBOUND-GUID-0001; the same guid is re-emitted (true echo) -> drop (echo)
```
Observed result after fix: the user photo following an id-less outbound image is dispatched instead of dropped, while a different photo after an id-backed send and a true same-GUID echo keep their previous outcomes.
What was not tested: no live Messages.app send was performed; the "attachment send returns no id" step is established by reading send.ts (resolveMessageId and the ok/unknown placeholder contract) and the persisted entry was seeded with those exact arguments rather than produced by a real AppleScript or imsg RPC attachment send. Full build not run.
