### PR TITLE
fix(ci): default Telegram advisory input to false

### DIFF
--- a/.github/workflows/package-acceptance.yml
+++ b/.github/workflows/package-acceptance.yml
@@ -1009,7 +1009,7 @@ jobs:
     if: needs.resolve_package.outputs.telegram_enabled == 'true'
     uses: ./.github/workflows/npm-telegram-beta-e2e.yml
     with:
-      advisory: ${{ inputs.advisory || inputs.telegram_advisory }}
+      advisory: ${{ inputs.advisory || inputs.telegram_advisory || false }}
       package_spec: ${{ inputs.package_spec }}
       package_artifact_name: ${{ needs.resolve_package.outputs.package_artifact_name }}
       package_artifact_digest: ${{ needs.resolve_package.outputs.package_artifact_digest }}

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2086,6 +2086,7 @@ describe("package acceptance workflow", () => {
       description: "Acceptance profile: smoke, package, telegram, product, full, or custom",
       options: ["smoke", "package", "telegram", "product", "full", "custom"],
     });
+    expect(parsedWorkflow.on?.workflow_dispatch?.inputs?.telegram_advisory).toBeUndefined();
     expect(parsedWorkflow.on?.workflow_call?.inputs?.suite_profile).toMatchObject({
       default: "package",
       description: "Acceptance profile: smoke, package, telegram, product, full, or custom",
@@ -2143,6 +2144,9 @@ describe("package acceptance workflow", () => {
     expect(workflow).toContain("telegram_scenarios:");
     expect(packageTelegram.with?.scenario).toBe(
       "${{ needs.resolve_package.outputs.telegram_scenarios }}",
+    );
+    expect(packageTelegram.with?.advisory).toBe(
+      "${{ inputs.advisory || inputs.telegram_advisory || false }}",
     );
     expect(workflow).toContain(
       "package_label: openclaw@${{ needs.resolve_package.outputs.package_version }}",


### PR DESCRIPTION
Related: #126247

## What Problem This Solves

Fixes an issue where a non-advisory manual Package Acceptance dispatch could fail before creating the Telegram child job because `telegram_advisory` is not part of the `workflow_dispatch` schema.

## Why This Change Was Made

The reusable Telegram call now gives the optional caller-only input an explicit boolean fallback. The dispatch schema remains unchanged, and focused guards lock both boundaries.

## User Impact

Maintainers can run the Telegram-only package profile manually with `advisory=false`; the child workflow receives a valid boolean and can start normally.

## Evidence

- Failure reproduced by Package Acceptance run `32401123194`: resolver and integrity passed, broad jobs skipped, then `package_telegram` failed before creating a child job.
- `node scripts/run-vitest.mjs test/scripts/package-acceptance-workflow.test.ts` - 214 tests passed.
- `node scripts/check-changed.mjs -- .github/workflows/package-acceptance.yml test/scripts/package-acceptance-workflow.test.ts` - passed.
- `node --import tsx scripts/check-workflows.mts .github/workflows/package-acceptance.yml` - actionlint, zizmor, and repository workflow guards passed.
- Autoreview: clean, no accepted/actionable findings, overall 0.99.
- Local ClawSweeper: `nothing_found`, high confidence; best-fix verdict yes.
