### PR TITLE
fix(ui): make startup gzip runtime-independent

### DIFF
--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 348351,
-  "reason": "cumulative Control UI startup growth since #126474 (automation condition triggers, persistent Settings approvals, sidebar row fixes)",
+  "startupJsGzipBytes": 344531,
+  "reason": "canonical cross-runtime gzip sidecars",
   "updatedAt": "2026-08-20"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2440,6 +2440,9 @@ importers:
       openclaw:
         specifier: workspace:*
         version: link:..
+      pako:
+        specifier: 3.0.1
+        version: 3.0.1
       playwright:
         specifier: 1.62.1
         version: 1.62.1
@@ -7772,6 +7775,9 @@ packages:
 
   pako@2.2.0:
     resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
+
+  pako@3.0.1:
+    resolution: {integrity: sha512-GupotUUI0mlhugKjUs4bjOwLt3nrehy9Ys2dxC0GtgVef5cnKggkDMmf2bq2poCCuVXopWPmqsc9VDT2iJUy+w==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -14930,6 +14936,8 @@ snapshots:
   pako@1.0.11: {}
 
   pako@2.2.0: {}
+
+  pako@3.0.1: {}
 
   parent-module@1.0.1:
     dependencies:

--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -17,11 +17,9 @@ const DEFAULT_STARTUP_BUDGET_BASELINE_PATH = path.resolve(
   "../config/control-ui-startup-budget-baseline.json",
 );
 
-// This absorbs measured local-to-Linux gzip variance plus bounded Linux
-// build-to-build chunk-hash variance. Local zlib emits smaller streams than
-// CI's Linux builder, so baseline updates must use CI bytes via
-// --startup-js-bytes. The fixed JS baseline ceiling bounds cumulative creep.
-const CONTROL_UI_STARTUP_JS_GZIP_TOLERANCE_BYTES = 1056;
+// Each landed change can consume this much ratchet tolerance, so small increases
+// may accumulate. The fixed startup JS ceiling bounds that cumulative creep.
+const CONTROL_UI_STARTUP_JS_GZIP_TOLERANCE_BYTES = 512;
 
 // Small, explicit headroom over the optimized baseline. Budget changes should
 // accompany an intentional loading or chunking decision.

--- a/test/scripts/control-ui-performance.test.ts
+++ b/test/scripts/control-ui-performance.test.ts
@@ -205,9 +205,9 @@ describe("Control UI performance budgets", () => {
     );
   });
 
-  it("allows CI-measured startup JS growth within the ratchet tolerance", () => {
+  it("allows startup JS growth exactly at the ratchet tolerance", () => {
     const violations = evaluateControlUiPerformanceBudgets(
-      createMetrics(326_672),
+      createMetrics(326_187),
       { ...looseBudgets, startupJsGzipBytes: 319 * 1024, largestJsGzipBytes: 400_000 },
       startupBaseline(325_675),
     );
@@ -215,8 +215,8 @@ describe("Control UI performance budgets", () => {
     expect(violations).toEqual([]);
   });
 
-  it("fails startup JS growth over the ratchet tolerance with update guidance", () => {
-    const metrics = createMetrics(326_732);
+  it("fails startup JS growth one byte beyond the ratchet tolerance", () => {
+    const metrics = createMetrics(326_188);
     const baseline = startupBaseline(325_675);
     const budgets = {
       ...looseBudgets,
@@ -228,10 +228,10 @@ describe("Control UI performance budgets", () => {
       evaluateControlUiPerformanceBudgets(metrics, budgets, baseline).map((entry) => entry.metric),
     ).toContain("startup JS gzip");
     expect(formatControlUiPerformanceReport(metrics, budgets, baseline)).toContain(
-      "startup JS gzip: 319.1 KiB exceeds 319.1 KiB (326732 B vs 326731 B)",
+      "startup JS gzip: 318.5 KiB exceeds 318.5 KiB (326188 B vs 326187 B)",
     );
     expect(formatControlUiPerformanceReport(metrics, budgets, baseline)).toContain(
-      "limits: 10 requests, 319.1 KiB gzip",
+      "limits: 10 requests, 318.5 KiB gzip",
     );
   });
 
@@ -260,7 +260,7 @@ describe("Control UI performance budgets", () => {
 
     expect(
       evaluateControlUiPerformanceBudgets(
-        createMetrics(319 * 1024 + 1057),
+        createMetrics(319 * 1024 + 513),
         budgets,
         startupBaseline(319 * 1024),
       ).map((entry) => entry.metric),
@@ -321,7 +321,7 @@ describe("Control UI performance budgets", () => {
     );
   });
 
-  it("updates the baseline from local or explicit CI metrics", () => {
+  it("updates the baseline from generated or explicitly measured metrics", () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-control-ui-budget-cli-"));
     tempDirs.push(rootDir);
     const scriptsDir = path.join(rootDir, "scripts");
@@ -376,7 +376,7 @@ describe("Control UI performance budgets", () => {
     fs.rmSync(distDir, { recursive: true });
     const explicitBytesResult = runControlUiPerformanceCli(
       scriptPath,
-      ["--update-baseline", "--startup-js-bytes", "321", "--reason", "CI measurement"],
+      ["--update-baseline", "--startup-js-bytes", "321", "--reason", "explicit measurement"],
       rootDir,
     );
     expect(explicitBytesResult.status, explicitBytesResult.stderr).toBe(0);
@@ -384,7 +384,7 @@ describe("Control UI performance budgets", () => {
       JSON.parse(
         fs.readFileSync(path.join(configDir, "control-ui-startup-budget-baseline.json"), "utf8"),
       ),
-    ).toMatchObject({ startupJsGzipBytes: 321, reason: "CI measurement" });
+    ).toMatchObject({ startupJsGzipBytes: 321, reason: "explicit measurement" });
 
     const beyondRatchetResult = runControlUiPerformanceCli(
       scriptPath,
@@ -399,7 +399,7 @@ describe("Control UI performance budgets", () => {
       JSON.parse(
         fs.readFileSync(path.join(configDir, "control-ui-startup-budget-baseline.json"), "utf8"),
       ),
-    ).toMatchObject({ startupJsGzipBytes: 321, reason: "CI measurement" });
+    ).toMatchObject({ startupJsGzipBytes: 321, reason: "explicit measurement" });
   });
 
   it("fails when a compressed sidecar is missing", () => {

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,6 +53,7 @@
     "fake-indexeddb": "6.2.5",
     "jsdom": "29.1.1",
     "openclaw": "workspace:*",
+    "pako": "3.0.1",
     "playwright": "1.62.1",
     "vite": "8.1.5",
     "vitest": "4.1.10"

--- a/ui/src/app/vite-config.node.test.ts
+++ b/ui/src/app/vite-config.node.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { createHash } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { brotliDecompressSync, gunzipSync } from "node:zlib";
@@ -35,7 +36,10 @@ function findStringAlias(key: string) {
 
 describe("Control UI Vite config", () => {
   it("emits Brotli and gzip variants only for bundled compressible assets", () => {
-    const source = "console.log('precompressed');\n".repeat(200);
+    const source = Array.from(
+      { length: 200 },
+      (_, index) => `console.log("startup-${index % 97}", ${index % 31});\n`,
+    ).join("");
     const variants = createControlUiPrecompressedAssetVariants("assets/app-AbCd1234.js", source);
 
     expect(variants.map((variant) => variant.fileName)).toEqual([
@@ -44,6 +48,9 @@ describe("Control UI Vite config", () => {
     ]);
     expect(brotliDecompressSync(variants[0]?.source ?? Buffer.alloc(0)).toString()).toBe(source);
     expect(gunzipSync(variants[1]?.source ?? Buffer.alloc(0)).toString()).toBe(source);
+    expect(createHash("sha256").update(variants[1]!.source).digest("hex")).toBe(
+      "32dab2f3598992a8a8b595f5da60f10907fc181c2abfa27380d562d9b539b85d",
+    );
     expect(createControlUiPrecompressedAssetVariants("index.html", source)).toEqual([]);
     expect(createControlUiPrecompressedAssetVariants("assets/logo.png", source)).toEqual([]);
     expect(createControlUiPrecompressedAssetVariants("assets/app.js.map", source)).toEqual([]);

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -4,7 +4,8 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { brotliCompressSync, constants as zlibConstants, gzipSync } from "node:zlib";
+import { brotliCompressSync, constants as zlibConstants } from "node:zlib";
+import { gzip } from "pako";
 import type { Plugin, UserConfig } from "vite";
 import { controlUiCodeSplitting } from "./config/control-ui-chunking.ts";
 import { controlUiHoverGuardPlugin } from "./config/control-ui-hover-guard.ts";
@@ -71,7 +72,8 @@ export function createControlUiPrecompressedAssetVariants(
     },
     {
       fileName: `${fileName}.gz`,
-      source: gzipSync(body, { level: 9 }),
+      // Host zlib is byte-unstable across supported runtimes; pako's classic hash is canonical.
+      source: Buffer.from(gzip(body, { level: 9, legacyHash: true })),
     },
   ];
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where clean Linux Node 26 Control UI builds failed the startup gzip performance gate while canonical local macOS Node 24 builds passed for identical raw startup assets. Host zlib 1.3.2.1 compressed those same bytes 644 B larger than zlib 1.2.12, although repeated raw builds varied by only approximately 13–30 B from chunk hashes.

## Why This Change Was Made

The Control UI build now owns deterministic shipped `.gz` sidecars through exactly pinned pako 3.0.1 with `{ level: 9, legacyHash: true }`; upstream documents that option as selecting the classic canonical zlib hash. The performance checker continues measuring the actual shipped sidecars, with no fallback or parallel compression path. This restores the startup ratchet tolerance from 1056 B to 512 B and lowers the committed baseline from 348351 B to 344531 B; the 358400 B hard budget remains unchanged.

## User Impact

Operators and contributors receive deterministic Control UI build/CI outcomes across supported Node runtimes and slightly smaller shipped gzip payloads. There is no Control UI appearance or behavior change.

## Evidence

- Historical exact base/candidate canonical gzip sizes: 347692 B / 347696 B, both below the historical 348079 B allowance; the previous host-zlib difference was 644 B for identical raw bytes.
- Clean official Linux Node 22.22.3, 24.15.0, 25.9.0, and 26.5.1 matrix: each emitted the same 1129672 raw startup bytes, identical raw hashes, identical gzip hashes, and exactly 344492 B startup gzip; each passed the focused Vite/performance tests and verified 928 shipped sidecars.
- Bun 1.3.14 built and validated successfully at 344508 B; repeated pre-rebase builds measured 344508–344531 B.
- Post-rebase real `pnpm ui:build`: 930 finalized shipped sidecars verified, startup gzip 343944 B, committed baseline 344531 B, restored tolerance 512 B, unchanged hard budget 358400 B.
- `node scripts/run-vitest.mjs ui/src/app/vite-config.node.test.ts test/scripts/control-ui-performance.test.ts test/scripts/ui.test.ts`: 52 tests passed across Vite config, performance budgets, and UI wrappers.
- `node scripts/check-changed.mjs -- config/control-ui-startup-budget-baseline.json pnpm-lock.yaml scripts/check-control-ui-performance.mts test/scripts/control-ui-performance.test.ts ui/package.json ui/src/app/vite-config.node.test.ts ui/vite.config.ts`: passed all repository guards, 94 npm package-lock validations, all core/UI/plugin/scripts/test `tsgo` lanes, full lint, and the runtime import-cycle check.
- Fresh maintainer autoreview completed cleanly with no accepted/actionable findings; the reviewed patch remained byte-identical after moving to current `origin/main`.
- AI-assisted; changes and verification were maintainer-reviewed. No prompts or agent transcripts are included.
