### PR TITLE
fix(search): reuse Gemini and Kimi caches for equivalent queries

### DIFF
--- a/extensions/google/src/gemini-web-search-provider.runtime.ts
+++ b/extensions/google/src/gemini-web-search-provider.runtime.ts
@@ -8,7 +8,6 @@ import {
 import {
   buildSearchCacheKey,
   buildUnsupportedSearchFilterResponse,
-  DEFAULT_SEARCH_COUNT,
   MAX_SEARCH_COUNT,
   parseWebSearchTimeFilters,
   readCachedSearchPayload,
@@ -18,7 +17,6 @@ import {
   readStringParam,
   resolveCitationRedirectUrl,
   resolveSearchCacheTtlMs,
-  resolveSearchCount,
   resolveSearchTimeoutSeconds,
   type SearchConfigRecord,
   withTrustedWebSearchEndpoint,
@@ -126,7 +124,7 @@ function freshnessStartTime(freshness: GeminiFreshness, now: Date): string {
   return toGeminiTimeRangeTimestamp(start);
 }
 
-function queryWithSoftFreshness(query: string, freshness?: "day"): string {
+function queryWithSoftFreshness(query: string, freshness?: GeminiFreshness): string {
   if (freshness !== "day") {
     return query;
   }
@@ -137,7 +135,12 @@ function resolveGeminiTimeRangeFilter(
   args: Record<string, unknown>,
   now = new Date(),
 ):
-  | { timeRangeFilter?: GeminiTimeRangeFilter; freshness?: "day" }
+  | {
+      timeRangeFilter?: GeminiTimeRangeFilter;
+      freshness?: GeminiFreshness;
+      dateAfter?: string;
+      dateBefore?: string;
+    }
   | {
       error:
         | "invalid_freshness"
@@ -175,6 +178,7 @@ function resolveGeminiTimeRangeFilter(
       };
     }
     return {
+      freshness,
       timeRangeFilter: {
         startTime: freshnessStartTime(freshness, now),
         endTime: toGeminiTimeRangeTimestamp(now),
@@ -187,6 +191,8 @@ function resolveGeminiTimeRangeFilter(
   }
 
   return {
+    dateAfter,
+    dateBefore,
     timeRangeFilter: {
       startTime: dateAfter ? isoDateStart(dateAfter) : "1970-01-01T00:00:00Z",
       endTime: dateBefore ? isoDateExclusiveEnd(dateBefore) : toGeminiTimeRangeTimestamp(now),
@@ -413,13 +419,10 @@ export async function executeGeminiSearch(
   }
 
   const query = readStringParam(args, "query", { required: true });
-  const count =
-    readPositiveIntegerParam(args, "count", {
-      max: MAX_SEARCH_COUNT,
-      message: `count must be an integer from 1 to ${MAX_SEARCH_COUNT}.`,
-    }) ??
-    searchConfig?.maxResults ??
-    undefined;
+  void readPositiveIntegerParam(args, "count", {
+    max: MAX_SEARCH_COUNT,
+    message: `count must be an integer from 1 to ${MAX_SEARCH_COUNT}.`,
+  });
   const model = resolveGeminiModel(geminiConfig);
   const baseUrl = resolveGeminiBaseUrl(geminiConfig);
   const headers = resolveGeminiWebSearchHeaders(geminiConfig);
@@ -435,12 +438,11 @@ export async function executeGeminiSearch(
   const cacheKey = buildSearchCacheKey([
     "gemini",
     query,
-    resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
     baseUrl,
     model,
     timeRange.freshness,
-    timeRange.timeRangeFilter?.startTime,
-    timeRange.timeRangeFilter?.endTime,
+    timeRange.dateAfter,
+    timeRange.dateBefore,
     headersCacheKey,
   ]);
   const cached = readCachedSearchPayload(cacheKey);

--- a/extensions/google/web-search-provider.test.ts
+++ b/extensions/google/web-search-provider.test.ts
@@ -194,6 +194,22 @@ describe("google web search provider", () => {
     expect(postCalls).toHaveLength(2);
   });
 
+  it("reuses cached Gemini answers across ignored result counts while rejecting invalid counts", async () => {
+    const mockFetch = installGeminiFetch();
+    const tool = createGeminiToolWithHeaders({});
+    const query = "unique Gemini ignored result count cache regression";
+
+    await tool?.execute({ query, count: 1 });
+    await tool?.execute({ query, count: 10 });
+    await tool?.execute({ query });
+
+    await expect(tool?.execute({ query, count: 0 })).rejects.toThrow(
+      "count must be an integer from 1 to 10.",
+    );
+    const postCalls = mockFetch.mock.calls.filter(([, init]) => typeof init?.body === "string");
+    expect(postCalls).toHaveLength(1);
+  });
+
   it("does not partition cached results by overwritten provider-owned headers", async () => {
     const mockFetch = installGeminiFetch();
 
@@ -719,6 +735,51 @@ describe("google web search provider", () => {
     expect(thirdBody.tools?.[0]?.google_search?.timeRangeFilter).toBeUndefined();
     expect(thirdBody.contents?.[0]?.parts?.[0]?.text).toBe("same query cache partition");
   });
+
+  it.each([
+    {
+      label: "relative freshness",
+      filter: { freshness: "week" },
+      equivalentFilter: { freshness: "pw" },
+      distinctFilter: { freshness: "month" },
+      initialTimeRange: {
+        startTime: "2026-04-08T12:00:00Z",
+        endTime: "2026-04-15T12:00:00Z",
+      },
+    },
+    {
+      label: "open-ended date ranges",
+      filter: { date_after: "2026-04-01" },
+      equivalentFilter: { date_after: "2026-04-01" },
+      distinctFilter: { date_after: "2026-04-02" },
+      initialTimeRange: {
+        startTime: "2026-04-01T00:00:00Z",
+        endTime: "2026-04-15T12:00:00Z",
+      },
+    },
+  ])(
+    "reuses Gemini $label cache entries as the clock advances without merging distinct filters",
+    async ({ label, filter, equivalentFilter, distinctFilter, initialTimeRange }) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      vi.setSystemTime(new Date("2026-04-15T12:00:00.123Z"));
+      const mockFetch = installGeminiFetch();
+      const tool = createGeminiToolWithHeaders({});
+      const query = `unique Gemini ${label} moving-clock cache regression`;
+
+      await tool?.execute({ query, ...filter });
+      vi.setSystemTime(new Date("2026-04-15T12:00:02.123Z"));
+      const cached = await tool?.execute({ query, ...equivalentFilter });
+
+      expect(cached).toMatchObject({ cached: true });
+      expect(parseGeminiFetchBody(mockFetch).tools?.[0]?.google_search?.timeRangeFilter).toEqual(
+        initialTimeRange,
+      );
+
+      await tool?.execute({ query, ...distinctFilter });
+      const postCalls = mockFetch.mock.calls.filter(([, init]) => typeof init?.body === "string");
+      expect(postCalls).toHaveLength(2);
+    },
+  );
 
   it("strips sub-second precision from date-range timestamps so Gemini accepts them", async () => {
     vi.useFakeTimers({ toFake: ["Date"] });

--- a/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.runtime.ts
@@ -7,7 +7,6 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 import {
   buildSearchCacheKey,
   buildUnsupportedSearchFilterResponse,
-  DEFAULT_SEARCH_COUNT,
   MAX_SEARCH_COUNT,
   mergeScopedSearchConfig,
   readCachedSearchPayload,
@@ -17,7 +16,6 @@ import {
   readStringParam,
   resolveProviderWebSearchPluginConfig,
   resolveSearchCacheTtlMs,
-  resolveSearchCount,
   resolveSearchTimeoutSeconds,
   setProviderWebSearchPluginConfigValue,
   type SearchConfigRecord,
@@ -366,22 +364,13 @@ export async function executeKimiWebSearchProviderTool(
   }
 
   const query = readStringParam(args, "query", { required: true });
-  const count =
-    readPositiveIntegerParam(args, "count", {
-      max: MAX_SEARCH_COUNT,
-      message: `count must be an integer from 1 to ${MAX_SEARCH_COUNT}.`,
-    }) ??
-    searchConfig?.maxResults ??
-    undefined;
+  void readPositiveIntegerParam(args, "count", {
+    max: MAX_SEARCH_COUNT,
+    message: `count must be an integer from 1 to ${MAX_SEARCH_COUNT}.`,
+  });
   const model = resolveKimiModel(kimiConfig);
   const baseUrl = resolveKimiBaseUrl(kimiConfig, ctx.config);
-  const cacheKey = buildSearchCacheKey([
-    "kimi",
-    query,
-    resolveSearchCount(count, DEFAULT_SEARCH_COUNT),
-    baseUrl,
-    model,
-  ]);
+  const cacheKey = buildSearchCacheKey(["kimi", query, baseUrl, model]);
   const cached = readCachedSearchPayload(cacheKey);
   if (cached) {
     return cached;

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -298,6 +298,40 @@ describe("kimi web search provider", () => {
     });
   });
 
+  it("reuses cached Kimi answers across ignored result counts while rejecting invalid counts", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        jsonResponse({
+          search_results: [{ title: "OpenClaw", url: "https://github.com/openclaw/openclaw" }],
+          choices: [
+            {
+              finish_reason: "stop",
+              message: { content: "OpenClaw is on GitHub." },
+            },
+          ],
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await withEnvAsync({ KIMI_API_KEY: "kimi-test-key" }, async () => {
+      const tool = createKimiWebSearchProvider().createTool({ config: {}, searchConfig: {} });
+      if (!tool) {
+        throw new Error("Expected tool definition");
+      }
+      const query = "unique Kimi ignored result count cache regression";
+
+      await tool.execute({ query, count: 1 });
+      await tool.execute({ query, count: 10 });
+      await tool.execute({ query });
+
+      await expect(tool.execute({ query, count: 0 })).rejects.toThrow(
+        "count must be an integer from 1 to 10.",
+      );
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+  });
+
   it("returns original tool arguments as tool content", () => {
     const rawArguments = '  {"query":"MacBook Neo","usage":{"total_tokens":123}}  ';
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gemini and Kimi web searches repeated billable provider requests for the same query when callers supplied different result counts, even though both providers ignore that parameter. Gemini searches using relative freshness or open-ended dates also missed their documented cache whenever the clock advanced.

## Why This Change Was Made

Keep count validation but remove ignored count settings from each provider-owned cache identity, matching the existing Grok provider. Carry Gemini's normalized freshness and explicit date bounds into the cache key while preserving the real, current timestamps sent to Google Search grounding. Model, endpoint, operator-header partitioning, cache TTL, and public plugin SDK contracts stay unchanged.

## User Impact

Equivalent Gemini and Kimi searches now reuse the configured search cache, reducing duplicate paid requests and latency. Distinct Gemini freshness windows, date ranges, models, endpoints, and operator headers remain isolated, and invalid result counts continue to fail visibly.

## Evidence

- Regression-first proof: before the fix, Gemini and Kimi each made three provider requests for one identical query with count 1, count 10, and no count; both now make exactly one.
- Regression-first proof: Gemini relative freshness and open-ended date searches both missed cache after the clock advanced two seconds; equivalent normalized filters now reuse cache while genuinely distinct filters still trigger a fresh request.
- Exact head: `4e8a75ea3988a7fc2175ba113d171bb3f6964ed1`.
- `PNPM_CONFIG_MODULES_DIR=/Users/steipete/Projects/openclaw/node_modules OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 NODE_DISABLE_COMPILE_CACHE=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-providers.config.ts --configLoader runner extensions/google/web-search-provider.test.ts extensions/moonshot/src/kimi-web-search-provider.test.ts extensions/moonshot/index.test.ts` — 3 files, 81 tests passed, including the already-landed Kimi unfinished-answer/retry regression.
- `node --import tsx scripts/check-assertion-safety-ratchet.mts` — passed.
- `node --import tsx scripts/check-max-lines-ratchet.mts` — passed.
- `node_modules/.bin/oxfmt --check extensions/google/src/gemini-web-search-provider.runtime.ts extensions/google/web-search-provider.test.ts extensions/moonshot/src/kimi-web-search-provider.runtime.ts extensions/moonshot/src/kimi-web-search-provider.test.ts` — passed.
- Fresh authenticated isolated Codex branch autoreview: clean, no actionable findings; TruffleHog scan clean.
- Production code: +21/-30 (net -9); regression tests: +95/-0.
- Live provider calls were not run; deterministic regressions exercise the actual provider entrypoints with mocked upstream HTTP responses and real request/cache behavior.
