### PR TITLE
fix(outbound): retry queued deliveries when a channel adapter is unavailable

### DIFF
--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -27,7 +27,7 @@ import type {
   DurableFinalDeliveryRequirements,
   OutboundDurableDeliverySupport,
 } from "./deliver-contracts.js";
-import type { OutboundDeliveryResult } from "./deliver-types.js";
+import { PlatformMessageNotDispatchedError, type OutboundDeliveryResult } from "./deliver-types.js";
 import {
   attachOutboundDeliveryCommitHook,
   type OutboundDeliveryCommitHook,
@@ -57,7 +57,8 @@ export async function createChannelHandler(params: ChannelHandlerParams): Promis
     return createPluginHandler({ ...params, outbound, message });
   });
   if (!handler) {
-    throw new Error(`Outbound not configured for channel: ${params.channel}`);
+    const message = `Outbound not configured for channel: ${params.channel}`;
+    throw new PlatformMessageNotDispatchedError(message, { cause: new Error(message) });
   }
   return scopeChannelHandler(handler, pluginRegistry);
 }

--- a/src/infra/outbound/deliver.queue-adapter-availability.test.ts
+++ b/src/infra/outbound/deliver.queue-adapter-availability.test.ts
@@ -8,13 +8,14 @@ import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../p
 import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { getDeliveryQueueEntryStatus } from "../delivery-queue-sqlite.js";
+import { PlatformMessageNotDispatchedError } from "./deliver-types.js";
 import {
   boundedCronCompletionRetention,
   matrixOutboundForQueueTest,
 } from "./deliver.queue-integration.test-support.js";
 import { OUTBOUND_DELIVERY_QUEUE_NAME } from "./delivery-queue-media-staging.js";
 import { recoverPendingDeliveries, type DeliverFn } from "./delivery-queue-recovery.js";
-import { loadPendingDeliveries } from "./delivery-queue-storage.js";
+import { enqueueDelivery, loadPendingDeliveries } from "./delivery-queue-storage.js";
 import {
   createRecoveryLog,
   installDeliveryQueueTmpDirHooks,
@@ -130,6 +131,48 @@ describe("queued lazy outbound adapter availability", () => {
     expect(
       getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, deliveryIntentId, tmpDir),
     ).toBe("completed");
+  });
+
+  it("retains recovery custody when no outbound adapter can be resolved", async () => {
+    process.env.OPENCLAW_STATE_DIR = tmpDir;
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    const id = await enqueueDelivery(
+      {
+        channel: "missing-adapter-test",
+        to: "recipient",
+        payloads: [{ text: "retry after adapter resolution" }],
+      },
+      tmpDir,
+    );
+    let deliveryError: unknown;
+    const recoveryDeliver = vi.fn<DeliverFn>(async (params) => {
+      try {
+        return await deliverOutboundPayloads(params);
+      } catch (error) {
+        deliveryError = error;
+        throw error;
+      }
+    });
+
+    const result = await recoverPendingDeliveries({
+      cfg: {} as OpenClawConfig,
+      deliver: recoveryDeliver,
+      log: createRecoveryLog(),
+      stateDir: tmpDir,
+    });
+
+    expect(result).toMatchObject({ failed: 1, recovered: 0, skippedMaxRetries: 0 });
+    expect(recoveryDeliver).toHaveBeenCalledOnce();
+    expect(deliveryError).toBeInstanceOf(PlatformMessageNotDispatchedError);
+    const pendingEntry = expectDefined(
+      (await loadPendingDeliveries(tmpDir))[0],
+      "retained adapter-miss delivery",
+    );
+    expect(pendingEntry).toMatchObject({ id, retryCount: 1 });
+    expect(pendingEntry.recoveryState).toBeUndefined();
+    expect(pendingEntry.platformSendAttemptId).toBeUndefined();
+    expect(pendingEntry.platformSendStartedAt).toBeUndefined();
+    expect(getDeliveryQueueEntryStatus(OUTBOUND_DELIVERY_QUEUE_NAME, id, tmpDir)).toBe("pending");
   });
 
   it("does not replay a provider call that already crossed the ambiguous send boundary", async () => {

--- a/src/infra/outbound/delivery-queue-recovery.ts
+++ b/src/infra/outbound/delivery-queue-recovery.ts
@@ -94,7 +94,6 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /forbidden: bot was kicked/i,
   /chat_id is empty/i,
   /recipient is not a valid/i,
-  /outbound not configured for channel/i,
   /ambiguous .* recipient/i,
   /User .* not in room/i,
 ];

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -1261,25 +1261,6 @@ describe("delivery-queue recovery", () => {
     await runIf(typedRejection, () => expect(deliver).toHaveBeenCalledOnce());
     await runIf(!typedRejection, () => expectMockMessageContaining(log.warn, "permanent error"));
   });
-  it("retries an unavailable outbound adapter instead of dead-lettering the entry", async () => {
-    const artifact = path.join(
-      tmpDir(),
-      "delivery-queue-media",
-      "00000000-0000-4000-8000-000000000077.txt",
-    );
-    await fs.mkdir(path.dirname(artifact), { recursive: true });
-    await fs.writeFile(artifact, "spooled attachment");
-    const id = await enqueueRecoveryDelivery({ payloads: [{ text: "hi", mediaUrl: artifact }] });
-    const deliver = vi
-      .fn()
-      .mockRejectedValue(new Error("Outbound not configured for channel: demo-channel-a"));
-    const { result, log } = await runRecovery({ deliver });
-    expect(result).toEqual(RECOVERY_SUMMARY.failed);
-    const entry = await expectPendingEntry({ id, retryCount: 1 });
-    expect(entry?.lastError).toContain("Outbound not configured for channel");
-    expectMockMessageContaining(log.warn, "Retry failed for delivery");
-    await expect(fs.stat(artifact)).resolves.toBeDefined();
-  });
   it("passes skipQueue: true to prevent re-enqueueing during recovery", async () => {
     await enqueueRecoveryDelivery();
     const deliver = vi.fn().mockResolvedValue([]);

--- a/src/infra/outbound/delivery-queue.recovery.test.ts
+++ b/src/infra/outbound/delivery-queue.recovery.test.ts
@@ -1261,6 +1261,25 @@ describe("delivery-queue recovery", () => {
     await runIf(typedRejection, () => expect(deliver).toHaveBeenCalledOnce());
     await runIf(!typedRejection, () => expectMockMessageContaining(log.warn, "permanent error"));
   });
+  it("retries an unavailable outbound adapter instead of dead-lettering the entry", async () => {
+    const artifact = path.join(
+      tmpDir(),
+      "delivery-queue-media",
+      "00000000-0000-4000-8000-000000000077.txt",
+    );
+    await fs.mkdir(path.dirname(artifact), { recursive: true });
+    await fs.writeFile(artifact, "spooled attachment");
+    const id = await enqueueRecoveryDelivery({ payloads: [{ text: "hi", mediaUrl: artifact }] });
+    const deliver = vi
+      .fn()
+      .mockRejectedValue(new Error("Outbound not configured for channel: demo-channel-a"));
+    const { result, log } = await runRecovery({ deliver });
+    expect(result).toEqual(RECOVERY_SUMMARY.failed);
+    const entry = await expectPendingEntry({ id, retryCount: 1 });
+    expect(entry?.lastError).toContain("Outbound not configured for channel");
+    expectMockMessageContaining(log.warn, "Retry failed for delivery");
+    await expect(fs.stat(artifact)).resolves.toBeDefined();
+  });
   it("passes skipQueue: true to prevent re-enqueueing during recovery", async () => {
     await enqueueRecoveryDelivery();
     const deliver = vi.fn().mockResolvedValue([]);


### PR DESCRIPTION
## What Problem This Solves

A queued outbound delivery is destroyed on its first recovery attempt, together with the delivery queue's custody copy of its attachment, whenever the channel's outbound adapter happens to be unresolvable at that moment.

`src/infra/outbound/delivery-queue-recovery.ts:97` listed `/outbound not configured for channel/i` in `PERMANENT_ERROR_PATTERNS`. Every other entry in that list is a provider-side rejection (chat not found, bot blocked, bot kicked). This one is not: it is a local adapter-resolution failure thrown by `createChannelHandler` (`src/infra/outbound/deliver-channel.ts:59-61`) when `loadBootstrappedOutboundAdapter` yields no send-capable adapter, which happens while `src/infra/outbound/channel-bootstrap.runtime.ts:131-146` swallows a registry load error and caches the negative outcome for the registry generation.

Recovery runs unconditionally at every gateway start (`src/gateway/server-runtime-services.ts:213`) and on the retry timer. On a match it takes `moveEntryToFailedAndCleanup`, which deletes the pending row (`moveDeliveryQueueEntryToFailed`, no payload retained for ordinary ownerless entries per #123642) and unlinks the spooled attachment through `releaseSpoolArtifacts`. `attemptCount` is still 0 of 5, so nothing replays it and no payload-free receipt survives.

The condition is documented as recurring on stock config: #88955 reports qqbot's WebSocket session timing out roughly every 30 minutes producing exactly this string; #84147 (discord), #63729 and #55551 (telegram) report the same error.

## Why This Change Was Made

The same error is already treated as retryable on the live send path. `isPermanentDeliveryError` has no caller outside `delivery-queue-recovery.ts` (`:709` definition, `:1165`, `:1324`, `:1455` uses), while `src/infra/outbound/deliver-queue-execute.ts:548` classifies solely by `findPlatformMessageRejectedError`, an explicit provider `retryable: false` marker, and routes everything else to retryable failure. Same error, opposite verdict, and the recovery side is the one that erases the message.

Removing the pattern lets adapter unavailability consume the normal retry budget. A channel that really is gone still terminates: after `maxRetries` (default 5) the entry hits the exhaustion branch at `:1407-1425` and is moved to failed exactly as before, so this does not create an unbounded retry loop, it only stops the queue from skipping the budget on attempt 0.

Two sibling lists carry the same string for non-queue callers: `src/agents/subagents/announce/subagent-announce-delivery-retry.ts:77` and `src/cron/isolated-agent/delivery-dispatch-policy.ts:92`. Those classify in-process announce and direct cron dispatch, where the outcome is giving up on a retry loop and reporting, not deleting a durable queued row and its spooled media. They are left alone deliberately; the destructive terminal is the queue path only.

## User Impact

Queued outbound messages (agent replies, cron announces, heartbeats, subagent announces) and their spooled attachments survive a transient adapter outage instead of being silently erased at gateway start. Users on qqbot, discord, telegram and any other channel whose adapter can briefly fail to resolve stop losing messages that were already accepted for delivery. Genuine permanent provider rejections still dead-letter immediately.

## Evidence

Real gateway startup recovery driven end to end on pristine `main` and on this patch with identical inputs. See the Real behavior proof block below for the captured output.

## Verification

- `node scripts/run-vitest.mjs src/infra/outbound/delivery-queue.recovery.test.ts src/infra/outbound/delivery-queue.recovery-backoff.test.ts src/infra/outbound/delivery-queue.policy.test.ts` 67 passed across 3 files (5 + 62), including the new case
- New regression case `retries an unavailable outbound adapter instead of dead-lettering the entry` in `src/infra/outbound/delivery-queue.recovery.test.ts` times out on pristine `main` (the entry is dead-lettered, so `expectPendingEntry` never finds the pending row) and passes with the patch.
- Existing `moves entries to failed/ immediately on permanent delivery errors` and `treats Matrix 'User not in room' as a permanent error` cases still pass unchanged, covering the genuine permanent classifications.
- No existing case asserted that this string is permanent, so nothing had to be deleted or rewritten.
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs <changed files>` clean, exit 0
- `./node_modules/.bin/oxfmt --check <changed files>` All matched files use the correct format
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental` clean, exit 0

## Real behavior proof
Behavior addressed: a queued outbound delivery and its spooled attachment are erased on attempt 0 of 5 when the channel adapter is momentarily unresolvable, instead of being retried.
Real environment tested: real `stageQueuePayloadMedia` plus real `enqueueDelivery` seed a pending row with a spooled attachment in an isolated `OPENCLAW_HOME`, then the real `recoverPendingDeliveries` runs with the real `deliverOutboundPayloadsInternal` exactly as `src/gateway/server-runtime-services.ts:213` wires it at gateway start, followed by a second pass standing in for the retry timer. The queue storage, the SQLite state database, the spool files, the adapter resolution and the classifier are all the real ones; nothing in the path under change is substituted. Run on pristine main 28ec823c3bc7a49dd58053790afa995e141ced26 and on the original patch head dc7fd7590d7c4cac69d687b29a5091f74ba17bbe; the exact repaired head fdf5851d32695e569c9d9cff31df5d5778fcce73 is covered by the refresh below.
Exact steps or command run after this patch: `T=$(mktemp -d); OPENCLAW_HOME=$T HOME=$T node --import tsx probe-c.mts`
Evidence after fix:
```
# BEFORE (pristine main 28ec823c3bc7a49dd58053790afa995e141ced26)
=== BEFORE (queued, waiting for the channel to come back) ===
pending id=2c5aff8b-6ea5-4f66-b0fe-d9ee25a347ac channel=qqbot attemptCount=0 maxRetries=default(5)
  payload.text = "Here is the invoice you asked for."
  payload.mediaUrl = .../.openclaw/delivery-queue-media/2ac38cd5-f0d3-4c9e-b23d-3c28068c2e7f.txt
spool artifact exists=true bytes=31

=== RUN: real gateway startup recovery (server-runtime-services.ts:213) ===
[recovery info] Found 1 pending delivery entries — starting recovery
[recovery warn] Delivery 2c5aff8b-6ea5-4f66-b0fe-d9ee25a347ac hit permanent error — moving to failed/: Outbound not configured for channel: qqbot
[recovery info] Delivery recovery complete: 0 recovered, 1 failed, 0 skipped (max retries), 0 deferred (backoff)

=== SECOND RECOVERY PASS (retry timer, server-runtime-services.ts:222) ===
summary = {"recovered":0,"failed":0,"skippedMaxRetries":0,"deferredBackoff":0}

=== AFTER ===
pending rows = 0
delivery_queue_entries = []
spool artifact exists=false

# AFTER (this patch, identical inputs)
=== BEFORE (queued, waiting for the channel to come back) ===
pending id=a589e3ab-9831-43c8-8c24-239aadfff6af channel=qqbot attemptCount=0 maxRetries=default(5)
  payload.text = "Here is the invoice you asked for."
  payload.mediaUrl = .../.openclaw/delivery-queue-media/9d64e0c1-8e52-4a01-8b03-e0544c79c52d.txt
spool artifact exists=true bytes=31

=== RUN: real gateway startup recovery (server-runtime-services.ts:213) ===
[recovery info] Found 1 pending delivery entries — starting recovery
[recovery warn] Retry failed for delivery a589e3ab-9831-43c8-8c24-239aadfff6af: Outbound not configured for channel: qqbot
[recovery info] Delivery recovery complete: 0 recovered, 1 failed, 0 skipped (max retries), 0 deferred (backoff)

=== SECOND RECOVERY PASS (retry timer, server-runtime-services.ts:222) ===
[recovery info] Found 1 pending delivery entries — starting recovery
[recovery info] Delivery a589e3ab-9831-43c8-8c24-239aadfff6af not ready for retry yet — backoff 4910ms remaining
[recovery info] Delivery recovery complete: 0 recovered, 0 failed, 0 skipped (max retries), 1 deferred (backoff)

=== AFTER ===
pending rows = 1
pending id=a589e3ab-9831-43c8-8c24-239aadfff6af channel=qqbot attemptCount=1 retryCount=1 lastError="Outbound not configured for channel: qqbot"
intent owner = {"queueName":"outbound-prepared-v1","namespace":"prepared","retired":false,"status":"pending"}
spool artifact exists=true
```
Observed result after fix: on pristine main the queued message row is gone and its spooled attachment is unlinked after one pass at attemptCount 0, and the second pass finds nothing left to deliver; with the patch the same inputs leave the row pending with attemptCount 1, the attachment still on disk, and the second pass defers it on backoff for a later retry.
### Exact-head refresh

After the typed adapter-resolution change, repaired head `fdf5851d32695e569c9d9cff31df5d5778fcce73` was synced to uinaf Cloudflare Crabbox lease `cbx_cb76dd11b6eb` (`standard-4`). The container matched the reviewed source hash, forwarded only `CI`, and exposed no provider or vault variables.

Command: `node scripts/run-vitest.mjs src/infra/outbound/deliver.queue-adapter-availability.test.ts src/infra/outbound/delivery-queue.recovery.test.ts src/infra/outbound/channel-bootstrap.runtime.test.ts`

Result: 76/76 passed across 3 files. The exact-head regression drove `recoverPendingDeliveries -> deliverOutboundPayloads -> createChannelHandler` through the real SQLite queue owner and asserted `PlatformMessageNotDispatchedError`, pending custody, `retryCount=1`, and no platform-send evidence. The captured queue-and-spool trace above remains the full media example; this refresh proves the changed typed boundary preserves its retry decision on the current head. The lease was stopped, and refreshed Cloudflare inventory was empty.

What was not tested: the run used an isolated home with no channel plugin able to resolve a qqbot adapter, which is the same resolution failure a live reconnect produces, rather than a live qqbot WebSocket drop; a genuine permanent classification such as "chat not found" was not driven through this same runtime path, since the real adapter-resolution failure always produces the one string, so that case is covered by the untouched existing suite cases instead; full build not run.
