### PR TITLE
fix(onboard): non-interactive onboarding reports health failures in its JSON summary

### DIFF
--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -176,7 +176,7 @@ vi.mock("./onboard-non-interactive/local/daemon-install.js", () => ({
 }));
 
 vi.mock("./health.js", () => ({
-  healthCommand: healthCommandMock,
+  healthCommandNonExiting: healthCommandMock,
 }));
 
 vi.mock("../daemon/service.js", () => ({
@@ -881,6 +881,55 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       expect(parsed.diagnostics?.service?.runtimeStatus).toBe("running");
       expect(parsed.diagnostics?.service?.pid).toBe(4242);
       expect(parsed.diagnostics?.lastGatewayError).toContain("required secrets are unavailable");
+    });
+  }, 60_000);
+
+  it("emits structured JSON failure when a reachable gateway fails its health check", async () => {
+    await withStateDir("state-local-daemon-health-exit-json-", async (stateDir) => {
+      waitForGatewayReachableMock = vi.fn(async () => ({ ok: true }));
+      healthCommandMock.mockImplementationOnce(async (...args: unknown[]) => {
+        // healthCommand prints its reachable-gateway diagnostic before its
+        // CLI-style exit; the capture runtime must keep it off JSON stdout.
+        // importActual yields the ExitError instance the prod graph sees; the
+        // test file's static import can be a second class instance under Vitest.
+        const { ExitError: RuntimeExitError } =
+          await vi.importActual<typeof import("../runtime.js")>("../runtime.js");
+        const healthRuntime = args[1] as RuntimeEnv;
+        healthRuntime.log("Gateway is reachable.");
+        healthRuntime.log("Gateway credentials rejected.");
+        throw new RuntimeExitError(1);
+      });
+
+      const { runtimeWithCapture, readCapturedJson } = createOnboardJsonCaptureRuntime();
+      await expectOnboardLocalJsonSetupFailure({
+        runSetup: runNonInteractiveSetup,
+        stateDir,
+        runtime: runtimeWithCapture,
+      });
+
+      const parsed = JSON.parse(readCapturedJson()) as {
+        ok: boolean;
+        phase: string;
+        message: string;
+        detail?: string;
+        hints?: string[];
+      };
+      expect(parsed.ok).toBe(false);
+      expect(parsed.phase).toBe("gateway-health");
+      expect(parsed.message).toContain("health check failed");
+      expect(parsed.detail).toContain("Gateway credentials rejected.");
+      expect(parsed.hints).toContain("Run `openclaw health` for full diagnostics.");
+    });
+  }, 60_000);
+
+  it("routes thrown health-check errors through the onboarding failure owner", async () => {
+    await withStateDir("state-local-health-failure-text-", async (stateDir) => {
+      waitForGatewayReachableMock = vi.fn(async () => ({ ok: true }));
+      healthCommandMock.mockRejectedValueOnce(new Error("health request timed out"));
+
+      await expect(
+        runNonInteractiveSetup(createOnboardLocalDaemonOptions(stateDir), runtime),
+      ).rejects.toThrow(/health check failed[\s\S]*health request timed out/);
     });
   }, 60_000);
 

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -10,7 +10,8 @@ import { logConfigUpdated } from "../../config/logging.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveGatewayAuthToken } from "../../gateway/auth-token-resolution.js";
 import { resolveConfiguredSecretInputWithFallback } from "../../gateway/resolve-configured-secret-input-string.js";
-import type { RuntimeEnv } from "../../runtime.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { ExitError, type RuntimeEnv } from "../../runtime.js";
 import { DEFAULT_GATEWAY_DAEMON_RUNTIME } from "../daemon-runtime.js";
 import {
   ensureOnboardingAgentWorkspace,
@@ -357,7 +358,7 @@ export async function runNonInteractiveLocalSetup(params: {
   }
 
   if (!opts.skipHealth) {
-    const { healthCommand } = await import("../health.js");
+    const { healthCommandNonExiting } = await import("../health.js");
     const links = resolveLocalControlUiProbeLinks({
       bind: gatewayResult.bind as "auto" | "lan" | "loopback" | "custom" | "tailnet",
       port: gatewayResult.port,
@@ -430,18 +431,56 @@ export async function runNonInteractiveLocalSetup(params: {
       }
       gatewayNotRunning = true;
     } else {
-      await healthCommand(
-        {
-          json: false,
-          timeoutMs: opts.installDaemon
-            ? installDaemonGatewayHealthTiming.healthCommandTimeoutMs
-            : 10_000,
-          config: nextConfig,
-          token: probeAuth.token,
-          password: probeAuth.password,
-        },
-        runtime,
-      );
+      // In --json mode healthCommand's human text must stay off stdout; capture
+      // it so a failure still surfaces the printed diagnostic in the payload.
+      const capturedHealthLines: string[] = [];
+      const healthRuntime: RuntimeEnv = opts.json
+        ? {
+            ...runtime,
+            log: (...args: unknown[]) => {
+              capturedHealthLines.push(args.map(String).join(" "));
+            },
+          }
+        : runtime;
+      try {
+        await healthCommandNonExiting(
+          {
+            json: false,
+            timeoutMs: opts.installDaemon
+              ? installDaemonGatewayHealthTiming.healthCommandTimeoutMs
+              : 10_000,
+            config: nextConfig,
+            token: probeAuth.token,
+            password: probeAuth.password,
+          },
+          healthRuntime,
+        );
+      } catch (err) {
+        // Route health failures through the flow's failure owner so the JSON
+        // contract emits a structured payload instead of dying mid-command.
+        const detail =
+          err instanceof ExitError
+            ? capturedHealthLines.join("\n") || undefined
+            : formatErrorMessage(err);
+        logNonInteractiveOnboardingFailure({
+          opts,
+          runtime,
+          mode,
+          phase: "gateway-health",
+          message: `Gateway is reachable at ${links.wsUrl}, but the health check failed.`,
+          detail,
+          gateway: {
+            wsUrl: links.wsUrl,
+            httpUrl: links.httpUrl,
+          },
+          installDaemon: Boolean(opts.installDaemon),
+          daemonInstall: daemonInstallStatus,
+          daemonRuntime: opts.installDaemon ? daemonRuntimeRaw : undefined,
+          hints: [`Run \`${formatCliCommand("openclaw health")}\` for full diagnostics.`],
+        });
+        runtime.exit(1);
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where non-interactive onboarding (`openclaw onboard --non-interactive --json`) would die mid-command when the gateway was reachable but the post-setup health check failed: the machine-readable summary contract was never emitted, and the operator got either a raw top-level CLI error or healthCommand's plain-text diagnostic followed by a bare exit 1. Sibling of #126758, which fixed the same invariant for the interactive wizard, onboarding finalize, and doctor flows.

## Why This Change Was Made

The non-interactive flow already has a failure owner — `logNonInteractiveOnboardingFailure` emits a structured `ok:false` JSON payload (or framed text) with classification and recovery hints — but health-check failures bypassed it entirely: thrown errors escaped `runNonInteractiveLocalSetup` raw, and healthCommand's reachable-gateway auth diagnostic path called `runtime.exit(1)` before the summary. The fix routes both lanes through the owner via `healthCommandNonExiting` (landed in #126758): failures now produce a `phase: "gateway-health"` payload with the health diagnostic as `detail`, then exit 1. In `--json` mode, healthCommand's human text is captured off the output streams so a failure can carry the printed diagnostic inside the payload instead.

## User Impact

Automation consuming `openclaw onboard --non-interactive --json` now always receives a structured summary — `ok:true` on success, or `ok:false` with `phase: "gateway-health"`, the underlying detail (including e.g. a stale `OPENCLAW_GATEWAY_URL` source), classification, and actionable hints — instead of a dropped contract and an unexplained exit.

## Evidence

- Regression tests in `src/commands/onboard-non-interactive.gateway.test.ts`: a trapped health CLI exit emits the structured JSON failure with the captured diagnostic in `detail` and the `openclaw health` hint; a thrown health error routes through the failure owner ("health check failed" framing) instead of crashing. Both fail pre-fix.
- Suites: `node scripts/run-vitest.mjs onboard-non-interactive` green (134 tests) on the rebased head; `node scripts/check-changed.mjs` green.
- Live (dev gateway, isolated state dir, port 19917, token auth): with a stale `OPENCLAW_GATEWAY_URL` pointing at a dead port (probe ok via config links, health fails), pre-fix dist emitted a generic `{"ok":false,"error":{"type":"cli_error",...}}` with no onboarding summary; post-fix dist emits `{"ok":false,"phase":"gateway-health","message":"Gateway is reachable at ws://127.0.0.1:19917, but the health check failed.",...}` with detail, classification, and hints, exit 1. Success path re-verified live (`ok:true`, exit 0).
