### PR TITLE
fix(clickclack): clarify command menu permission errors

### DIFF
--- a/extensions/clickclack/src/command-menu.test.ts
+++ b/extensions/clickclack/src/command-menu.test.ts
@@ -39,6 +39,7 @@ async function syncNativeCommands(
   mocks.listNativeCommandSpecsForConfig.mockReturnValue(specs);
 
   await syncClickClackCommandMenu({
+    accountId: "default",
     cfg: {} as CoreConfig,
     client: { setBotCommands } as unknown as ReturnType<typeof createClickClackClient>,
     log,
@@ -130,6 +131,7 @@ describe("ClickClack command menu", () => {
     ]);
 
     await syncClickClackCommandMenu({
+      accountId: "default",
       cfg,
       client: { setBotCommands } as unknown as ReturnType<typeof createClickClackClient>,
     });

--- a/extensions/clickclack/src/command-menu.ts
+++ b/extensions/clickclack/src/command-menu.ts
@@ -86,6 +86,7 @@ function mapNativeCommandSpecsToClickClackMenu(
 }
 
 export async function syncClickClackCommandMenu(params: {
+  accountId: string;
   cfg: CoreConfig;
   client: ReturnType<typeof createClickClackClient>;
   log?: ClickClackCommandMenuLogger;
@@ -98,16 +99,19 @@ export async function syncClickClackCommandMenu(params: {
     await params.client.setBotCommands(commands);
   } catch (error) {
     const status = errorStatus(error);
+    const messagePrefix = `[${params.accountId}] ClickClack command menu sync`;
     if (status === 403) {
-      params.log?.warn?.("ClickClack command menu sync skipped: bot token lacks commands:write");
+      params.log?.warn?.(
+        `${messagePrefix} skipped: ${formatErrorMessage(error)}; verify token/workspace command permissions or set commandMenu: false if menus are not needed`,
+      );
       return;
     }
     if (status === 404) {
       params.log?.debug?.(
-        "ClickClack command menu sync skipped: server does not support /api/bots/self/commands",
+        `${messagePrefix} skipped: server does not support /api/bots/self/commands`,
       );
       return;
     }
-    params.log?.warn?.(`ClickClack command menu sync failed: ${formatErrorMessage(error)}`);
+    params.log?.warn?.(`${messagePrefix} failed: ${formatErrorMessage(error)}`);
   }
 }

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -61,6 +61,7 @@ vi.mock("./resolve.js", () => ({
 }));
 
 import { startClickClackGatewayAccount } from "./gateway.js";
+import { ClickClackHttpError } from "./http-client.js";
 
 function createGatewayContext(
   abortSignal: AbortSignal,
@@ -247,23 +248,28 @@ describe("ClickClack gateway", () => {
 
   it.each([
     {
-      label: "missing command scope",
-      error: { status: 403 },
+      label: "workspace command permission rejection",
+      error: new ClickClackHttpError(
+        403,
+        "workspace role no longer permits command updates",
+        new Headers(),
+      ),
       level: "warn" as const,
-      message: "ClickClack command menu sync skipped: bot token lacks commands:write",
+      message:
+        "[default] ClickClack command menu sync skipped: ClickClack 403: workspace role no longer permits command updates; verify token/workspace command permissions or set commandMenu: false if menus are not needed",
     },
     {
       label: "older server",
       error: { status: 404 },
       level: "debug" as const,
       message:
-        "ClickClack command menu sync skipped: server does not support /api/bots/self/commands",
+        "[default] ClickClack command menu sync skipped: server does not support /api/bots/self/commands",
     },
     {
       label: "network failure",
       error: new Error("network unavailable"),
       level: "warn" as const,
-      message: "ClickClack command menu sync failed: network unavailable",
+      message: "[default] ClickClack command menu sync failed: network unavailable",
     },
   ])("continues startup after $label", async ({ error, level, message }) => {
     mocks.client.setBotCommands.mockRejectedValueOnce(error);

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -191,7 +191,12 @@ export async function startClickClackGatewayAccount(
       log: ctx.log,
     });
   if (account.commandMenu) {
-    await syncClickClackCommandMenu({ cfg: ctx.cfg, client, log: ctx.log });
+    await syncClickClackCommandMenu({
+      cfg: ctx.cfg,
+      client,
+      log: ctx.log,
+      accountId: account.accountId,
+    });
   }
   ctx.setStatus({
     accountId: account.accountId,


### PR DESCRIPTION
Closes #126796

## What Problem This Solves

Fixes an issue where ClickClack command-menu startup warnings claimed every HTTP 403 meant the bot token lacked `commands:write` and did not identify which configured account failed.

## Why This Change Was Made

Menu synchronization now receives the account id at its owning startup boundary. Permission, unsupported-endpoint, and generic failure diagnostics include that identity; 403 warnings preserve the already-redacted ClickClack error, avoid asserting one cause, and name the existing `commandMenu: false` opt-out. Startup remains best-effort and available.

## User Impact

Operators can identify the affected ClickClack account and distinguish token/workspace permission decisions from other failures without rotating credentials blindly. Existing native menus, message delivery, auth, and defaults are unchanged.

## Evidence

- Live production evidence: 36 identical account-less 403 warnings in a bounded multi-account Gateway log corpus.
- Direct ClickClack contract inspection: current `bot:write` includes `commands:write`; correctly scoped tokens can also receive 403 after workspace-role changes; older tokens do not acquire later bundle permissions automatically.
- The ClickClack HTTP client already bounds and redacts non-2xx response details; the command-menu path now preserves that context.
- Focused command-menu/gateway/http-client proof: 58/58 passed.
- Complete ClickClack extension lane: 362/362 across 33 files.
- Changed-file gate passed: format, extension/test typecheck, extension lint, plugin boundaries, dead exports, import cycles, and repository guards.
- Fresh rebased Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +13/-4, net +9. This is the required account-identity handoff plus actionable diagnostics for all three menu-sync failure branches. Tests: +13/-5.
- No credentials, scopes, setup/claim flow, config schema, doctor behavior, command-menu default, HTTP request, restart ownership, protocol, storage, or UI behavior changed.

AI-assisted: implementation and review used Codex, with maintainer inspection of OpenClaw and ClickClack permission contracts, account startup, HTTP redaction, menu synchronization, production logs, history, and tests.
