### PR TITLE
fix(release): trust exact protected tooling tags

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -800,6 +800,7 @@ jobs:
 
       - name: Require trusted workflow ref for publish
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.tag }}
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
           RELEASE_CANDIDATE_BRANCH: ${{ inputs.release_candidate_branch }}
@@ -839,9 +840,13 @@ jobs:
               echo "SHA-pinned release-publish tag does not match the OpenClaw npm workflow SHA." >&2
               exit 1
             }
-            timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-            git merge-base --is-ancestor "${WORKFLOW_SHA}" origin/main || {
-              echo "SHA-pinned OpenClaw npm workflow revision is not reachable from current main." >&2
+            workflow_tag="${WORKFLOW_REF#refs/tags/}"
+            remote_workflow_sha="$(
+              gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${workflow_tag}" \
+                --jq '.object | select(.type == "commit") | .sha | select(test("^[a-f0-9]{40}$"))'
+            )"
+            [[ "${remote_workflow_sha}" == "${WORKFLOW_SHA}" ]] || {
+              echo "SHA-pinned release-publish tag does not resolve to the OpenClaw npm workflow SHA." >&2
               exit 1
             }
             sha_pinned_release_publish=true
@@ -1024,8 +1029,19 @@ jobs:
           if [[ "$RELEASE_NPM_DIST_TAG" == "extended-stable" && "$preflight_head_branch" == "$EXPECTED_EXTENDED_STABLE_BRANCH" ]]; then
             extended_stable_preflight=true
           fi
-          if [[ "$preflight_head_branch" != "main" && "refs/heads/${preflight_head_branch}" != "$WORKFLOW_REF" && "$extended_stable_preflight" != "true" ]]; then
-            echo "OpenClaw npm preflight run must come from main or the active protected release branch." >&2
+          active_branch_preflight=false
+          if [[ "$preflight_head_branch" != release-publish/* && "refs/heads/${preflight_head_branch}" == "$WORKFLOW_REF" ]]; then
+            active_branch_preflight=true
+          fi
+          protected_release_publish_preflight=false
+          if [[ "$WORKFLOW_REF" =~ ^refs/tags/release-publish/[a-f0-9]{12}-[1-9][0-9]*$ ]]; then
+            workflow_tag="${WORKFLOW_REF#refs/tags/}"
+            if [[ "$preflight_head_branch" == "$workflow_tag" && "$preflight_head_sha" == "$WORKFLOW_SHA" ]]; then
+              protected_release_publish_preflight=true
+            fi
+          fi
+          if [[ "$preflight_head_branch" != "main" && "$active_branch_preflight" != "true" && "$extended_stable_preflight" != "true" && "$protected_release_publish_preflight" != "true" ]]; then
+            echo "OpenClaw npm preflight run must come from main, the active protected release branch, or the exact protected release-publish tag." >&2
             exit 1
           fi
           if ! git -C trusted-workflow cat-file -e "${preflight_head_sha}^{commit}" 2>/dev/null; then
@@ -1062,14 +1078,40 @@ jobs:
           FULL_RELEASE_VALIDATION_RUN_ATTEMPT: ${{ inputs.full_release_validation_run_attempt }}
           EXPECTED_WORKFLOW_BRANCH: ${{ inputs.release_candidate_branch || github.ref_name }}
           STRICT_VALIDATOR_FILE: ${{ github.workspace }}/trusted-workflow/scripts/release-ci-summary.mjs
+          TRUSTED_WORKFLOW_FULL_REF: ${{ github.ref }}
+          TRUSTED_WORKFLOW_REF: ${{ github.ref_name }}
+          TRUSTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           EXPECTED_SHA="$(git rev-parse HEAD)"
           MANIFEST_FILE="full-release-validation/full-release-validation-manifest.json"
           export EXPECTED_SHA MANIFEST_FILE
-          timeout --signal=TERM --kill-after=10s 120s git fetch --filter=blob:none --no-tags origin +refs/heads/main:refs/remotes/origin/main
-          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${FULL_RELEASE_VALIDATION_RUN_ID}/attempts/${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" | \
+          trusted_workflow_commit_ref="refs/remotes/origin/main"
+          if [[ "${TRUSTED_WORKFLOW_FULL_REF}" =~ ^refs/tags/release-publish/[a-f0-9]{12}-[1-9][0-9]*$ ]]; then
+            trusted_workflow_commit_ref="refs/tags/${TRUSTED_WORKFLOW_REF}"
+            timeout --signal=TERM --kill-after=10s 120s git fetch --filter=blob:none --no-tags origin \
+              "+${TRUSTED_WORKFLOW_FULL_REF}:${trusted_workflow_commit_ref}"
+            if [[ "$(git rev-parse "${trusted_workflow_commit_ref}^{commit}")" != "${WORKFLOW_SHA}" ]]; then
+              echo "Trusted release-publish tag moved after workflow dispatch." >&2
+              exit 1
+            fi
+          else
+            timeout --signal=TERM --kill-after=10s 120s git fetch --filter=blob:none --no-tags origin \
+              +refs/heads/main:refs/remotes/origin/main
+          fi
+          TRUSTED_MAIN_REF="${trusted_workflow_commit_ref}" \
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${FULL_RELEASE_VALIDATION_RUN_ID}/attempts/${FULL_RELEASE_VALIDATION_RUN_ATTEMPT}" | \
+            TRUSTED_MAIN_REF="${trusted_workflow_commit_ref}" \
             node trusted-workflow/scripts/validate-full-release-validation-evidence.mjs
+          node "$STRICT_VALIDATOR_FILE" \
+            --validate-run "$FULL_RELEASE_VALIDATION_RUN_ID" \
+            --trusted-workflow-ref "$TRUSTED_WORKFLOW_REF" \
+            --trusted-workflow-full-ref "$TRUSTED_WORKFLOW_FULL_REF" \
+            --trusted-workflow-sha "$TRUSTED_WORKFLOW_SHA" \
+            --json \
+            --verifier-source-sha "$WORKFLOW_SHA" \
+            --verifier-source-file "$STRICT_VALIDATOR_FILE" >/dev/null
 
       - name: Verify plugin npm release run metadata
         if: ${{ inputs.npm_dist_tag == 'extended-stable' }}

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -219,12 +219,13 @@ jobs:
               echo "SHA-pinned release publish tag does not match workflow SHA ${WORKFLOW_SHA}." >&2
               exit 1
             fi
-            merge_base_sha="$(
-              gh api "repos/${GITHUB_REPOSITORY}/compare/${WORKFLOW_SHA}...main" \
-                --jq '.merge_base_commit.sha | select(test("^[a-f0-9]{40}$"))'
+            workflow_tag="${WORKFLOW_REF#refs/tags/}"
+            remote_workflow_sha="$(
+              gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${workflow_tag}" \
+                --jq '.object | select(.type == "commit") | .sha | select(test("^[a-f0-9]{40}$"))'
             )"
-            if [[ "${merge_base_sha}" != "${WORKFLOW_SHA}" ]]; then
-              echo "SHA-pinned release publish tag revision is not reachable from current main." >&2
+            if [[ "${remote_workflow_sha}" != "${WORKFLOW_SHA}" ]]; then
+              echo "SHA-pinned release publish tag does not resolve to workflow SHA ${WORKFLOW_SHA}." >&2
               exit 1
             fi
             sha_pinned_release_publish=true
@@ -328,6 +329,7 @@ jobs:
           PREFLIGHT_RUN_ID: ${{ inputs.preflight_run_id }}
           RELEASE_NPM_DIST_TAG: ${{ inputs.npm_dist_tag }}
           RELEASE_TAG: ${{ inputs.tag }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
 
@@ -395,8 +397,19 @@ jobs:
           if [[ "$RELEASE_NPM_DIST_TAG" == "extended-stable" && "$preflight_head_branch" == "$expected_extended_stable_branch" ]]; then
             extended_stable_preflight=true
           fi
-          if [[ "$preflight_head_branch" != "main" && "refs/heads/${preflight_head_branch}" != "$GITHUB_REF" && "$extended_stable_preflight" != "true" ]]; then
-            echo "OpenClaw npm preflight run must come from main or the active protected release branch." >&2
+          active_branch_preflight=false
+          if [[ "$preflight_head_branch" != release-publish/* && "refs/heads/${preflight_head_branch}" == "$GITHUB_REF" ]]; then
+            active_branch_preflight=true
+          fi
+          protected_release_publish_preflight=false
+          if [[ "$GITHUB_REF" =~ ^refs/tags/release-publish/[a-f0-9]{12}-[1-9][0-9]*$ ]]; then
+            workflow_tag="${GITHUB_REF#refs/tags/}"
+            if [[ "$preflight_head_branch" == "$workflow_tag" && "$preflight_head_sha" == "$WORKFLOW_SHA" ]]; then
+              protected_release_publish_preflight=true
+            fi
+          fi
+          if [[ "$preflight_head_branch" != "main" && "$active_branch_preflight" != "true" && "$extended_stable_preflight" != "true" && "$protected_release_publish_preflight" != "true" ]]; then
+            echo "OpenClaw npm preflight run must come from main, the active protected release branch, or the exact protected release-publish tag." >&2
             exit 1
           fi
           if [[ "$preflight_conclusion" != "success" || "$preflight_event" != "workflow_dispatch" || "$preflight_path" != ".github/workflows/openclaw-npm-release.yml" ]]; then
@@ -576,8 +589,10 @@ jobs:
           EXPECTED_SHA: ${{ steps.ref.outputs.sha }}
           EXPECTED_RELEASE_PROFILE: ${{ inputs.release_profile }}
           EXPECTED_WORKFLOW_BRANCH: ${{ github.ref_name }}
+          TRUSTED_WORKFLOW_FULL_REF: ${{ github.ref }}
+          TRUSTED_WORKFLOW_REF: ${{ github.ref_name }}
+          TRUSTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
           RUN_JSON_FILE: ${{ runner.temp }}/full-release-validation-run.json
-          TRUSTED_MAIN_REF: refs/remotes/origin/main
           VALIDATOR_FILE: ${{ runner.temp }}/release-validation-tooling/validate-full-release-validation-evidence.mjs
           STRICT_VALIDATOR_FILE: ${{ runner.temp }}/release-validation-tooling/release-ci-summary.mjs
         run: |
@@ -588,9 +603,30 @@ jobs:
             ls -la "${RUNNER_TEMP}/full-release-validation-manifest" >&2 || true
             exit 1
           fi
-          git fetch --no-tags origin \
-            +refs/heads/main:refs/remotes/origin/main
-          MANIFEST_FILE="$manifest" node "$VALIDATOR_FILE" < "$RUN_JSON_FILE"
+          trusted_workflow_commit_ref="refs/remotes/origin/main"
+          if [[ "${TRUSTED_WORKFLOW_FULL_REF}" =~ ^refs/tags/release-publish/[a-f0-9]{12}-[1-9][0-9]*$ ]]; then
+            trusted_workflow_commit_ref="refs/tags/${TRUSTED_WORKFLOW_REF}"
+            git fetch --no-tags origin \
+              "+${TRUSTED_WORKFLOW_FULL_REF}:${trusted_workflow_commit_ref}"
+            if [[ "$(git rev-parse "${trusted_workflow_commit_ref}^{commit}")" != "${GITHUB_SHA}" ]]; then
+              echo "Trusted release-publish tag moved after workflow dispatch." >&2
+              exit 1
+            fi
+          else
+            git fetch --no-tags origin \
+              +refs/heads/main:refs/remotes/origin/main
+          fi
+          TRUSTED_MAIN_REF="${trusted_workflow_commit_ref}" \
+            MANIFEST_FILE="$manifest" \
+            node "$VALIDATOR_FILE" < "$RUN_JSON_FILE"
+          node "$STRICT_VALIDATOR_FILE" \
+            --validate-run "$FULL_RELEASE_VALIDATION_RUN_ID" \
+            --trusted-workflow-ref "$TRUSTED_WORKFLOW_REF" \
+            --trusted-workflow-full-ref "$TRUSTED_WORKFLOW_FULL_REF" \
+            --trusted-workflow-sha "$TRUSTED_WORKFLOW_SHA" \
+            --json \
+            --verifier-source-sha "$GITHUB_SHA" \
+            --verifier-source-file "$STRICT_VALIDATOR_FILE" >/dev/null
 
           workflow_name="$(jq -r '.workflowName // ""' "$manifest")"
           target_sha="$(jq -r '.targetSha // ""' "$manifest")"

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -1168,17 +1168,28 @@ jobs:
                 echo "npm token bootstrap release-publish tag does not match the workflow SHA." >&2
                 exit 1
               }
+              workflow_tag="${WORKFLOW_REF#refs/tags/}"
+              remote_workflow_sha="$(
+                gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${workflow_tag}" \
+                  --jq '.object | select(.type == "commit") | .sha | select(test("^[a-f0-9]{40}$"))'
+              )"
+              [[ "$remote_workflow_sha" == "$WORKFLOW_SHA" ]] || {
+                echo "npm token bootstrap release-publish tag does not resolve to the workflow SHA." >&2
+                exit 1
+              }
               sha_pinned_release_publish=true
             fi
             [[ "$WORKFLOW_REF" == "refs/heads/main" || "$sha_pinned_release_publish" == "true" ]] || {
               echo "npm token bootstrap requires trusted main tooling or a protected SHA-pinned release-publish tag." >&2
               exit 1
             }
-            timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
-            git merge-base --is-ancestor "$WORKFLOW_SHA" origin/main || {
-              echo "npm token bootstrap workflow revision is not reachable from current main." >&2
-              exit 1
-            }
+            if [[ "$WORKFLOW_REF" == "refs/heads/main" ]]; then
+              timeout --signal=TERM --kill-after=10s 120s git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+              git merge-base --is-ancestor "$WORKFLOW_SHA" origin/main || {
+                echo "npm token bootstrap workflow revision is not reachable from current main." >&2
+                exit 1
+              }
+            fi
           fi
           artifact_id="$(jq -er '.id' "$artifact_metadata")"
           artifact_digest="$(jq -er '.digest' "$artifact_metadata")"

--- a/scripts/full-release-validation-at-sha.mts
+++ b/scripts/full-release-validation-at-sha.mts
@@ -37,6 +37,7 @@ const RELEASE_CONTEXT_BRANCH_PATTERN =
   /^(?:release\/[0-9]{4}\.(?:[1-9]|1[0-2])\.[1-9][0-9]*|extended-stable\/[0-9]{4}\.(?:[1-9]|1[0-2])\.33)$/u;
 const RELEASE_TAG_PATTERN =
   /^v([0-9]{4}\.(?:[1-9]|1[0-2])\.[1-9][0-9]*(?:-(?:alpha|beta)\.[1-9][0-9]*)?)$/u;
+const TRUSTED_WORKFLOW_TAG_PATTERN = /^release-publish\/([a-f0-9]{12})-[1-9][0-9]*$/u;
 const SHA_PATTERN = /^[a-f0-9]{40}$/u;
 const DEFAULT_INPUTS = {
   provider: "openai",
@@ -72,7 +73,7 @@ function displayValue(value: unknown): string {
 }
 
 function usage() {
-  console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--target-ref <canonical-release-branch-or-tag>] [--workflow-sha <trusted-main-ref>] [--keep-branch] [--dry-run] [-- -f key=value ...]
+  console.error(`Usage: node scripts/full-release-validation-at-sha.mjs [--sha <target-sha>] [--target-ref <canonical-release-branch-or-tag>] [--workflow-sha <trusted-tooling-sha>] [--trusted-workflow-ref <main-or-release-publish-tag>] [--keep-branch] [--dry-run] [-- -f key=value ...]
 
 Creates temporary remote branches pinned to the exact Tooling SHA and Validation SHA,
 dispatches Full Release Validation with the Validation SHA branch as its ref input
@@ -125,6 +126,7 @@ export function parseArgs(argv: string[]) {
   const args = {
     sha: "",
     targetRef: "",
+    trustedWorkflowRef: "main",
     workflowSha: "",
     keepBranch: false,
     dryRun: false,
@@ -144,6 +146,11 @@ export function parseArgs(argv: string[]) {
     }
     if (arg === "--workflow-sha") {
       args.workflowSha = readOptionValue(argv, i, arg);
+      i += 1;
+      continue;
+    }
+    if (arg === "--trusted-workflow-ref") {
+      args.trustedWorkflowRef = readOptionValue(argv, i, arg);
       i += 1;
       continue;
     }
@@ -231,6 +238,19 @@ export function parseArgs(argv: string[]) {
     !RELEASE_TAG_PATTERN.test(args.targetRef)
   ) {
     throw new Error("--target-ref must be a canonical OpenClaw release branch or tag");
+  }
+  if (
+    args.trustedWorkflowRef !== "main" &&
+    !TRUSTED_WORKFLOW_TAG_PATTERN.test(args.trustedWorkflowRef)
+  ) {
+    throw new Error(
+      "--trusted-workflow-ref must be main or a protected release-publish/<12hex>-<decimal> tag",
+    );
+  }
+  if (args.trustedWorkflowRef !== "main" && !SHA_PATTERN.test(args.workflowSha.toLowerCase())) {
+    throw new Error(
+      "protected release-publish workflow refs require --workflow-sha with an explicit full Tooling SHA",
+    );
   }
   if (
     RELEASE_CONTEXT_BRANCH_PATTERN.test(args.targetRef) &&
@@ -378,22 +398,53 @@ export function releaseProfileForTarget(
   return releaseProfileForVersion(targetVersionForTarget(targetSha, readPackageJson));
 }
 
-function resolveTrustedWorkflowSha(requestedSha: string) {
-  run("git", ["fetch", "--no-tags", "origin", "refs/heads/main:refs/remotes/origin/main"], {
-    stdio: "inherit",
-  });
-  const workflowSha = resolveSha(requestedSha || "origin/main");
-  const ancestry = runStatus("git", [
-    "merge-base",
-    "--is-ancestor",
-    workflowSha,
-    "refs/remotes/origin/main",
-  ]);
-  if (ancestry.status !== 0) {
+export function verifyTrustedWorkflowRef(
+  workflowSha: string,
+  trustedWorkflowRef: string,
+  resolveRemoteTagSha: (tag: string) => string = (tag) =>
+    run("git", ["ls-remote", "--tags", "origin", `refs/tags/${tag}`]).split(/\s+/u)[0] ?? "",
+  isMainAncestor: (sha: string) => boolean = (sha) =>
+    runStatus("git", ["merge-base", "--is-ancestor", sha, "refs/remotes/origin/main"]).status === 0,
+) {
+  if (trustedWorkflowRef === "main") {
+    if (!isMainAncestor(workflowSha)) {
+      throw new Error(
+        `Workflow SHA ${workflowSha} is not reachable from current origin/main; refusing an untrusted release harness.`,
+      );
+    }
+    return;
+  }
+
+  const tagMatch = trustedWorkflowRef.match(TRUSTED_WORKFLOW_TAG_PATTERN);
+  if (!tagMatch) {
     throw new Error(
-      `Workflow SHA ${workflowSha} is not reachable from current origin/main; refusing an untrusted release harness.`,
+      "trusted workflow ref must be main or a protected release-publish/<12hex>-<decimal> tag",
     );
   }
+  if (workflowSha.slice(0, 12) !== tagMatch[1]) {
+    throw new Error(
+      `Trusted workflow tag ${trustedWorkflowRef} does not match Tooling SHA ${workflowSha}`,
+    );
+  }
+  const remoteTagSha = resolveRemoteTagSha(trustedWorkflowRef);
+  if (!remoteTagSha) {
+    throw new Error(`Trusted workflow tag ${trustedWorkflowRef} does not exist on origin`);
+  }
+  if (remoteTagSha.toLowerCase() !== workflowSha.toLowerCase()) {
+    throw new Error(
+      `Trusted workflow tag ${trustedWorkflowRef} resolves to ${remoteTagSha}, expected ${workflowSha}`,
+    );
+  }
+}
+
+function resolveTrustedWorkflowSha(requestedSha: string, trustedWorkflowRef: string) {
+  if (trustedWorkflowRef === "main") {
+    run("git", ["fetch", "--no-tags", "origin", "refs/heads/main:refs/remotes/origin/main"], {
+      stdio: "inherit",
+    });
+  }
+  const workflowSha = resolveSha(requestedSha || "origin/main");
+  verifyTrustedWorkflowRef(workflowSha, trustedWorkflowRef);
   return workflowSha;
 }
 
@@ -539,15 +590,29 @@ export function releaseEvidenceVerificationArgs(
   parentRunId: unknown,
   verifierSourceSha: string,
   verifierSourceFile: string,
+  trustedWorkflowRef = "main",
 ) {
   if (!/^[1-9][0-9]*$/u.test(String(parentRunId))) {
     throw new Error("parent run ID must be a positive decimal");
+  }
+  const trustedWorkflowFullRef =
+    trustedWorkflowRef === "main"
+      ? "refs/heads/main"
+      : TRUSTED_WORKFLOW_TAG_PATTERN.test(trustedWorkflowRef)
+        ? `refs/tags/${trustedWorkflowRef}`
+        : "";
+  if (!trustedWorkflowFullRef) {
+    throw new Error("trusted workflow ref must be main or a protected release-publish tag");
   }
   return [
     "--validate-run",
     String(parentRunId),
     "--trusted-workflow-ref",
-    "main",
+    trustedWorkflowRef,
+    "--trusted-workflow-full-ref",
+    trustedWorkflowFullRef,
+    "--trusted-workflow-sha",
+    verifierSourceSha,
     "--json",
     "--verifier-source-sha",
     verifierSourceSha,
@@ -627,7 +692,11 @@ export function releaseEvidenceVerifierPath(worktreeRoot: string) {
   return verifier;
 }
 
-function verifyReleaseEvidence(parentRunId: string, workflowSha: string) {
+function verifyReleaseEvidence(
+  parentRunId: string,
+  workflowSha: string,
+  trustedWorkflowRef: string,
+) {
   const verifierWorktree = mkdtempSync(join(tmpdir(), "openclaw-release-verifier-"));
   try {
     run("git", ["worktree", "add", "--detach", verifierWorktree, workflowSha], {
@@ -637,7 +706,7 @@ function verifyReleaseEvidence(parentRunId: string, workflowSha: string) {
     const evidence: unknown = JSON.parse(
       run(process.execPath, [
         verifier,
-        ...releaseEvidenceVerificationArgs(parentRunId, workflowSha, verifier),
+        ...releaseEvidenceVerificationArgs(parentRunId, workflowSha, verifier, trustedWorkflowRef),
       ]),
     );
     if (
@@ -666,7 +735,7 @@ function main() {
   args.inputs.release_profile ??= releaseProfileForVersion(targetVersion);
   args.inputs.allow_unreleased_changelog ??= args.targetRef ? "false" : "true";
   const targetContextRef = verifyTargetRef(args.targetRef, targetSha, targetVersion);
-  const workflowSha = resolveTrustedWorkflowSha(args.workflowSha);
+  const workflowSha = resolveTrustedWorkflowSha(args.workflowSha, args.trustedWorkflowRef);
   assertTrustedWorkflowHarness(workflowSha);
   const shortSha = workflowSha.slice(0, 12);
   const branch = `release-ci/${shortSha}-${Date.now()}`;
@@ -682,6 +751,7 @@ function main() {
 
   console.log(`Validation SHA: ${targetSha}`);
   console.log(`Tooling SHA: ${workflowSha}`);
+  console.log(`Trusted workflow ref: ${args.trustedWorkflowRef}`);
   console.log(
     `Frozen validation tuple: candidate=${targetSha} tooling=${workflowSha} rerun_group=${args.inputs.rerun_group}`,
   );
@@ -735,7 +805,7 @@ function main() {
         `Full Release Validation concluded ${parentConclusion.toLowerCase() || "without a conclusion"}: https://github.com/openclaw/openclaw/actions/runs/${parentRunId}`,
       );
     }
-    verifyReleaseEvidence(parentRunId, workflowSha);
+    verifyReleaseEvidence(parentRunId, workflowSha, args.trustedWorkflowRef);
     evidenceVerified = true;
   } finally {
     if (

--- a/scripts/release-ci-summary.mjs
+++ b/scripts/release-ci-summary.mjs
@@ -15,6 +15,8 @@ import { execGhRead, plainGhEnv, resolvePlainGhBin } from "./lib/plain-gh.mjs";
 const DEFAULT_REPO = process.env.OPENCLAW_RELEASE_REPO || "openclaw/openclaw";
 const RELEASE_EVIDENCE_SCHEMA = "openclaw.release-validation-evidence/v3";
 const SHA_PINNED_BRANCH_PATTERN = /^release-ci\/[a-f0-9]{12}-[1-9][0-9]*$/u;
+const TRUSTED_RELEASE_PUBLISH_TAG_PATTERN =
+  /^refs\/tags\/release-publish\/([a-f0-9]{12})-[1-9][0-9]*$/u;
 const RELEASE_EVIDENCE_SCRIPT = "scripts/release-ci-summary.mjs";
 const RELEASE_EVIDENCE_FILE = fileURLToPath(import.meta.url);
 const RELEASE_EVIDENCE_REPO_ROOT = resolve(dirname(RELEASE_EVIDENCE_FILE), "..");
@@ -1136,8 +1138,26 @@ function loadValidatedParentEvidence({ client, manifestPath, repository, runId }
   };
 }
 
-function trustedWorkflowFullRef(workflowRef) {
-  return `refs/heads/${workflowRef}`;
+function resolveTrustedWorkflowIdentity(workflowRef, workflowFullRef, workflowSha) {
+  const fullRef = workflowFullRef ?? `refs/heads/${workflowRef}`;
+  const protectedTag = TRUSTED_RELEASE_PUBLISH_TAG_PATTERN.exec(fullRef);
+  if (protectedTag) {
+    if (workflowRef !== fullRef.slice("refs/tags/".length)) {
+      throw new Error("trusted workflow tag name does not match its full ref");
+    }
+    const sha = normalizeSha(workflowSha, "trusted workflow SHA");
+    if (sha.slice(0, 12) !== protectedTag[1]) {
+      throw new Error("trusted workflow tag does not match its workflow SHA");
+    }
+    return { fullRef, ref: workflowRef, sha, type: "tag" };
+  }
+  if (fullRef !== `refs/heads/${workflowRef}`) {
+    throw new Error("trusted workflow full ref does not match its ref");
+  }
+  if (workflowRef.startsWith("release-publish/")) {
+    throw new Error("trusted release-publish workflow ref must be a protected tag");
+  }
+  return { fullRef, ref: workflowRef, sha: undefined, type: "branch" };
 }
 
 function normalizeWorkflowPathRef(ref) {
@@ -1147,11 +1167,31 @@ function normalizeWorkflowPathRef(ref) {
   return `refs/heads/${ref}`;
 }
 
-export function validateTrustedProducerIdentity(evidence, client, verifier, trustedWorkflowRef) {
+export function validateTrustedProducerIdentity(
+  evidence,
+  client,
+  verifier,
+  trustedWorkflowRef,
+  trustedWorkflowFullRef,
+  trustedWorkflowSha,
+) {
   const { manifest, parentRun } = evidence;
+  const trustedIdentity = resolveTrustedWorkflowIdentity(
+    trustedWorkflowRef,
+    trustedWorkflowFullRef,
+    trustedWorkflowSha,
+  );
   // Keep this predicate local: verifier source identity covers this file only.
   const shaPinned = SHA_PINNED_BRANCH_PATTERN.test(manifest.workflowRef ?? "");
-  if (manifest.workflowRef !== trustedWorkflowRef && !shaPinned) {
+  const protectedTagRoute = trustedIdentity.type === "tag";
+  if (protectedTagRoute) {
+    if (!shaPinned) {
+      throw new Error("protected-tag release evidence must use a canonical release-ci branch");
+    }
+    if (manifest.workflowSha !== trustedIdentity.sha) {
+      throw new Error("protected-tag release evidence workflow SHA does not match trusted tooling");
+    }
+  } else if (manifest.workflowRef !== trustedWorkflowRef && !shaPinned) {
     throw new Error(
       `release evidence producer must run from trusted workflow ref: ${trustedWorkflowRef}`,
     );
@@ -1167,7 +1207,7 @@ export function validateTrustedProducerIdentity(evidence, client, verifier, trus
       throw new Error("SHA-pinned release evidence target ref must equal its target SHA");
     }
   }
-  const expectedFullRef = trustedWorkflowFullRef(manifest.workflowRef);
+  const expectedFullRef = `refs/heads/${manifest.workflowRef}`;
   const runPath = String(parentRun.path ?? "");
   const [runWorkflowPath, runWorkflowFullRef] = runPath.split("@", 2);
   if (runWorkflowPath !== ".github/workflows/full-release-validation.yml") {
@@ -1182,19 +1222,25 @@ export function validateTrustedProducerIdentity(evidence, client, verifier, trus
     if (manifest.workflowRefType !== "branch" || manifest.workflowFullRef !== expectedFullRef) {
       throw new Error("release evidence producer workflow full ref is not trusted");
     }
-    workflowRefProof = shaPinned ? "manifest-v3-sha-pinned-main-ancestry" : "manifest-v3-branch";
+    workflowRefProof = protectedTagRoute
+      ? "manifest-v3-protected-tag-exact-sha"
+      : shaPinned
+        ? "manifest-v3-sha-pinned-main-ancestry"
+        : "manifest-v3-branch";
   }
 
-  const comparison = client.compareCommitLineage(manifest.workflowSha, verifier.sourceSha);
-  if (
-    !["ahead", "identical"].includes(String(comparison.status)) ||
-    comparison.merge_base_commit?.sha !== manifest.workflowSha
-  ) {
-    throw new Error("release evidence producer is not on the trusted main verifier lineage");
+  if (!protectedTagRoute) {
+    const comparison = client.compareCommitLineage(manifest.workflowSha, verifier.sourceSha);
+    if (
+      !["ahead", "identical"].includes(String(comparison.status)) ||
+      comparison.merge_base_commit?.sha !== manifest.workflowSha
+    ) {
+      throw new Error("release evidence producer is not on the trusted main verifier lineage");
+    }
   }
 
   return {
-    producerOnTrustedMainLineage: true,
+    producerOnTrustedMainLineage: !protectedTagRoute,
     workflowFullRef: expectedFullRef,
     workflowQualifiedPath: `${runWorkflowPath}@${expectedFullRef}`,
     workflowRefProof,
@@ -1339,7 +1385,9 @@ function validateStrictChildRun({ child, client, parentEvidence, parentJobs, rep
  *   manifestPath?: string,
  *   repository?: string,
  *   runId: string,
+ *   trustedWorkflowFullRef?: string,
  *   trustedWorkflowRef?: string,
+ *   trustedWorkflowSha?: string,
  *   verifierSourceContent?: string | Uint8Array,
  *   verifierSourceSha: string,
  * }} options
@@ -1349,7 +1397,9 @@ export function validateReleaseRunEvidence(
     manifestPath,
     repository = DEFAULT_REPO,
     runId,
+    trustedWorkflowFullRef,
     trustedWorkflowRef = "main",
+    trustedWorkflowSha,
     verifierSourceContent,
     verifierSourceSha,
   },
@@ -1360,6 +1410,11 @@ export function validateReleaseRunEvidence(
   const normalizedTrustedWorkflowRef = normalizeWorkflowRef(
     trustedWorkflowRef,
     "trusted workflow ref",
+  );
+  const trustedIdentity = resolveTrustedWorkflowIdentity(
+    normalizedTrustedWorkflowRef,
+    trustedWorkflowFullRef,
+    trustedWorkflowSha,
   );
   const evidenceClient = client ?? createReleaseEvidenceClient(normalizedRepository);
   const verifier = resolveVerifierIdentity(verifierSourceSha, verifierSourceContent);
@@ -1377,6 +1432,8 @@ export function validateReleaseRunEvidence(
         evidenceClient,
         verifier,
         normalizedTrustedWorkflowRef,
+        trustedIdentity.fullRef,
+        trustedIdentity.sha,
       ),
     ],
   ]);
@@ -1415,6 +1472,8 @@ export function validateReleaseRunEvidence(
           evidenceClient,
           verifier,
           normalizedTrustedWorkflowRef,
+          trustedIdentity.fullRef,
+          trustedIdentity.sha,
         ),
       );
     }
@@ -1480,8 +1539,8 @@ export function validateReleaseRunEvidence(
     root,
     runReleaseSoak: rootEvidence.manifest.runReleaseSoak === "true",
     schema: RELEASE_EVIDENCE_SCHEMA,
-    producerOnTrustedMainLineage: true,
-    trustedWorkflowFullRef: trustedWorkflowFullRef(normalizedTrustedWorkflowRef),
+    producerOnTrustedMainLineage: trustedIdentity.type === "branch",
+    trustedWorkflowFullRef: trustedIdentity.fullRef,
     trustedWorkflowRef: normalizedTrustedWorkflowRef,
     valid: true,
     validationInputs: rootEvidence.manifest.validationInputs ?? null,
@@ -1496,7 +1555,9 @@ function parseReleaseCiSummaryArgs(argv) {
     manifestPath: undefined,
     repository: DEFAULT_REPO,
     runId: undefined,
+    trustedWorkflowFullRef: undefined,
     trustedWorkflowRef: "main",
+    trustedWorkflowSha: undefined,
     validate: false,
     verifierSourceFile: undefined,
     verifierSourceSha: undefined,
@@ -1513,6 +1574,10 @@ function parseReleaseCiSummaryArgs(argv) {
       options.manifestPath = argv[++index];
     } else if (argument === "--trusted-workflow-ref") {
       options.trustedWorkflowRef = argv[++index];
+    } else if (argument === "--trusted-workflow-full-ref") {
+      options.trustedWorkflowFullRef = argv[++index];
+    } else if (argument === "--trusted-workflow-sha") {
+      options.trustedWorkflowSha = argv[++index];
     } else if (argument === "--verifier-source-sha") {
       options.verifierSourceSha = argv[++index];
     } else if (argument === "--verifier-source-file") {
@@ -1553,7 +1618,7 @@ function printUsage() {
     [
       "usage: release-ci-summary.mjs <full-release-run-id>",
       "       release-ci-summary.mjs <full-release-run-id> --watch [--interval seconds]",
-      "       release-ci-summary.mjs --validate-run <id> [--repo owner/name] [--trusted-workflow-ref main] [--manifest path] [--verifier-source-sha sha --verifier-source-file path] --json",
+      "       release-ci-summary.mjs --validate-run <id> [--repo owner/name] [--trusted-workflow-ref main --trusted-workflow-full-ref refs/heads/main] [--trusted-workflow-sha sha] [--manifest path] [--verifier-source-sha sha --verifier-source-file path] --json",
     ].join("\n"),
   );
 }
@@ -1652,7 +1717,9 @@ async function main() {
         manifestPath: options.manifestPath,
         repository,
         runId,
+        trustedWorkflowFullRef: options.trustedWorkflowFullRef,
         trustedWorkflowRef: options.trustedWorkflowRef,
+        trustedWorkflowSha: options.trustedWorkflowSha,
         verifierSourceContent: options.verifierSourceFile
           ? readFileSync(options.verifierSourceFile)
           : undefined,

--- a/scripts/validate-full-release-validation-evidence.mjs
+++ b/scripts/validate-full-release-validation-evidence.mjs
@@ -8,6 +8,8 @@ const FULL_RELEASE_WORKFLOW = "Full Release Validation";
 const FULL_RELEASE_WORKFLOW_PATH = ".github/workflows/full-release-validation.yml";
 const SHA_PATTERN = /^[a-f0-9]{40}$/u;
 const PINNED_BRANCH_PATTERN = /^release-ci\/([a-f0-9]{12})-([1-9][0-9]*)$/u;
+const TRUSTED_RELEASE_PUBLISH_TAG_PATTERN =
+  /^refs\/tags\/release-publish\/([a-f0-9]{12})-[1-9][0-9]*$/u;
 const EXACT_TARGET_EVIDENCE_REUSE_POLICY = "exact-target-full-validation-v1";
 const CHANGELOG_ONLY_EVIDENCE_REUSE_POLICY = "changelog-only-release-v1";
 
@@ -70,6 +72,8 @@ function displayValue(value) {
  * @property {string} expectedRepository
  * @property {string | number} expectedRunId
  * @property {string} expectedTargetSha
+ * @property {string} [expectedTrustedWorkflowFullRef]
+ * @property {string} [expectedTrustedWorkflowSha]
  * @property {string} [expectedWorkflowBranch]
  * @property {(sha: string) => boolean} [isTrustedMainAncestor]
  * @property {(params: { repository: string, runId: string, targetSha: string }) => StrictReleaseEvidence} [validateEvidenceReuseStrictly]
@@ -114,11 +118,28 @@ export function validateFullReleaseValidationEvidence({
   expectedRepository,
   expectedRunId,
   expectedTargetSha,
+  expectedTrustedWorkflowFullRef,
+  expectedTrustedWorkflowSha,
   expectedWorkflowBranch,
   isTrustedMainAncestor,
   validateEvidenceReuseStrictly,
 }) {
   const run = normalizeFullReleaseValidationRun(rawRun);
+  const trustedWorkflowFullRef = expectedTrustedWorkflowFullRef ?? "refs/heads/main";
+  const protectedTag = TRUSTED_RELEASE_PUBLISH_TAG_PATTERN.exec(trustedWorkflowFullRef);
+  if (protectedTag) {
+    if (!SHA_PATTERN.test(expectedTrustedWorkflowSha ?? "")) {
+      throw new Error("Protected release-publish evidence requires an exact trusted workflow SHA.");
+    }
+    if (expectedTrustedWorkflowSha.slice(0, 12) !== protectedTag[1]) {
+      throw new Error("Protected release-publish tag does not match its trusted workflow SHA.");
+    }
+  } else if (
+    !trustedWorkflowFullRef.startsWith("refs/heads/") ||
+    trustedWorkflowFullRef.startsWith("refs/heads/release-publish/")
+  ) {
+    throw new Error("Trusted release-publish workflow ref must be an exact protected tag.");
+  }
   const checks = [
     ["databaseId", String(expectedRunId)],
     ["workflowName", FULL_RELEASE_WORKFLOW],
@@ -176,6 +197,11 @@ export function validateFullReleaseValidationEvidence({
 
   const pinnedMatch = PINNED_BRANCH_PATTERN.exec(run.headBranch ?? "");
   if (!pinnedMatch) {
+    if (protectedTag) {
+      throw new Error(
+        "Protected-tag release evidence must use a canonical release-ci producer branch.",
+      );
+    }
     if (run.headBranch?.startsWith("release-ci/")) {
       throw new Error(
         `Referenced full release validation run ${expectedRunId} has untrusted head branch ${run.headBranch}.`,
@@ -203,6 +229,14 @@ export function validateFullReleaseValidationEvidence({
     throw new Error(
       `SHA-pinned validation target ref mismatch: expected ${expectedTargetSha}, got ${displayValue(manifest.targetRef)}.`,
     );
+  }
+  if (protectedTag) {
+    if (run.headSha !== expectedTrustedWorkflowSha) {
+      throw new Error(
+        `Protected-tag release evidence workflow SHA ${run.headSha} does not match trusted tooling ${expectedTrustedWorkflowSha}.`,
+      );
+    }
+    return { run, source: "sha-pinned-protected-tag" };
   }
   if (!isTrustedMainAncestor?.(run.headSha)) {
     throw new Error(
@@ -267,6 +301,9 @@ export function validateFullReleaseValidationEvidence({
  *   runId: string | number;
  *   validatorFile?: string;
  *   verifierSourceSha?: string;
+ *   trustedWorkflowFullRef?: string;
+ *   trustedWorkflowRef?: string;
+ *   trustedWorkflowSha?: string;
  * }} params
  */
 export function runStrictReleaseEvidenceValidation({
@@ -274,6 +311,9 @@ export function runStrictReleaseEvidenceValidation({
   runId,
   validatorFile = fileURLToPath(new URL("./release-ci-summary.mjs", import.meta.url)),
   verifierSourceSha,
+  trustedWorkflowFullRef = "refs/heads/main",
+  trustedWorkflowRef = "main",
+  trustedWorkflowSha,
 }) {
   const verifierSourceArgs = verifierSourceSha
     ? ["--verifier-source-sha", verifierSourceSha, "--verifier-source-file", validatorFile]
@@ -287,8 +327,11 @@ export function runStrictReleaseEvidenceValidation({
       "--repo",
       repository,
       "--trusted-workflow-ref",
-      "main",
+      trustedWorkflowRef,
+      "--trusted-workflow-full-ref",
+      trustedWorkflowFullRef,
       "--json",
+      ...(trustedWorkflowSha ? ["--trusted-workflow-sha", trustedWorkflowSha] : []),
       ...verifierSourceArgs,
     ],
     { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
@@ -336,12 +379,17 @@ function main() {
     expectedRepository: process.env.GITHUB_REPOSITORY,
     expectedRunId: process.env.FULL_RELEASE_VALIDATION_RUN_ID,
     expectedTargetSha: process.env.EXPECTED_SHA,
+    expectedTrustedWorkflowFullRef: process.env.TRUSTED_WORKFLOW_FULL_REF,
+    expectedTrustedWorkflowSha: process.env.TRUSTED_WORKFLOW_SHA,
     expectedWorkflowBranch: process.env.EXPECTED_WORKFLOW_BRANCH,
     isTrustedMainAncestor: (sha) => gitIsAncestor(sha, trustedMainRef),
     validateEvidenceReuseStrictly: ({ repository, runId }) =>
       runStrictReleaseEvidenceValidation({
         repository,
         runId,
+        trustedWorkflowFullRef: process.env.TRUSTED_WORKFLOW_FULL_REF,
+        trustedWorkflowRef: process.env.TRUSTED_WORKFLOW_REF,
+        trustedWorkflowSha: process.env.TRUSTED_WORKFLOW_SHA,
         validatorFile:
           process.env.STRICT_VALIDATOR_FILE ??
           fileURLToPath(new URL("./release-ci-summary.mjs", import.meta.url)),

--- a/test/scripts/full-release-validation-at-sha.test.ts
+++ b/test/scripts/full-release-validation-at-sha.test.ts
@@ -14,6 +14,7 @@ import {
   resolveRemoteTargetRefSha,
   shouldDeleteTemporaryWorkflowRef,
   verifyTargetRef,
+  verifyTrustedWorkflowRef,
 } from "../../scripts/full-release-validation-at-sha.mts";
 
 const SCRIPT_PATH = resolve("scripts/full-release-validation-at-sha.mjs");
@@ -70,8 +71,10 @@ function createDispatchFixture(options: { workflowSource?: string } = {}) {
     join(checkout, "scripts", "release-ci-summary.mjs"),
     `const expected = [
   "--validate-run", "123",
-  "--trusted-workflow-ref", "main",
-  "--json",
+	  "--trusted-workflow-ref", process.env.MOCK_TRUSTED_WORKFLOW_REF,
+  "--trusted-workflow-full-ref", process.env.MOCK_TRUSTED_WORKFLOW_FULL_REF,
+  "--trusted-workflow-sha", process.env.MOCK_WORKFLOW_SHA,
+	  "--json",
   "--verifier-source-sha", process.env.MOCK_WORKFLOW_SHA,
   "--verifier-source-file", process.argv[1],
 ];
@@ -93,8 +96,11 @@ console.log(JSON.stringify({ valid: true, current: { runId: "123" }, root: { run
   runGit(checkout, ["add", ".github/workflows/full-release-validation.yml", "package.json"]);
   runGit(checkout, ["commit", "-m", "test: trusted workflow contract"]);
   const workflowSha = runGit(checkout, ["rev-parse", "HEAD"]);
+  const trustedWorkflowTag = `release-publish/${workflowSha.slice(0, 12)}-123`;
   runGit(checkout, ["remote", "add", "origin", origin]);
   runGit(checkout, ["push", "-u", "origin", "main"]);
+  runGit(checkout, ["tag", trustedWorkflowTag, workflowSha]);
+  runGit(checkout, ["push", "origin", `refs/tags/${trustedWorkflowTag}`]);
   runGit(checkout, ["checkout", "-b", releaseRef]);
   writeFileSync(join(checkout, "target.txt"), "release target\n");
   runGit(checkout, ["add", "target.txt"]);
@@ -139,8 +145,13 @@ if (args[0] === "workflow" && args[1] === "run") {
   );
   chmodSync(ghPath, 0o755);
 
-  const run = (extraArgs: string[] = []) =>
-    spawnSync(
+  const run = (extraArgs: string[] = []) => {
+    const trustedRefIndex = extraArgs.indexOf("--trusted-workflow-ref");
+    const trustedWorkflowRef =
+      trustedRefIndex >= 0 ? (extraArgs[trustedRefIndex + 1] ?? "") : "main";
+    const trustedWorkflowFullRef =
+      trustedWorkflowRef === "main" ? "refs/heads/main" : `refs/tags/${trustedWorkflowRef}`;
+    return spawnSync(
       process.execPath,
       [SCRIPT_PATH, "--sha", targetSha, "--target-ref", releaseRef, ...extraArgs],
       {
@@ -151,11 +162,14 @@ if (args[0] === "workflow" && args[1] === "run") {
           MOCK_GH_CALLS: ghCallsPath,
           MOCK_GIT_CALLS: gitCallsPath,
           MOCK_REAL_PATH: process.env.PATH,
+          MOCK_TRUSTED_WORKFLOW_FULL_REF: trustedWorkflowFullRef,
+          MOCK_TRUSTED_WORKFLOW_REF: trustedWorkflowRef,
           MOCK_WORKFLOW_SHA: workflowSha,
           PATH: `${binDir}:${process.env.PATH}`,
         },
       },
     );
+  };
   const readCalls = (path: string): string[][] =>
     readFileSync(path, "utf8")
       .trim()
@@ -174,6 +188,7 @@ if (args[0] === "workflow" && args[1] === "run") {
     releaseRef,
     run,
     targetSha,
+    trustedWorkflowTag,
     workflowSha,
   };
 }
@@ -186,6 +201,8 @@ describe("full-release-validation-at-sha", () => {
         "abc123",
         "--workflow-sha",
         "a".repeat(40),
+        "--trusted-workflow-ref",
+        `release-publish/${"a".repeat(12)}-123`,
         "--target-ref",
         "release/2026.7.1",
         "--keep-branch",
@@ -206,6 +223,7 @@ describe("full-release-validation-at-sha", () => {
       },
       sha: "abc123",
       targetRef: "release/2026.7.1",
+      trustedWorkflowRef: `release-publish/${"a".repeat(12)}-123`,
       workflowSha: "a".repeat(40),
     });
   });
@@ -219,6 +237,16 @@ describe("full-release-validation-at-sha", () => {
       release_profile: "full",
     });
     expect(() => parseArgs(["--", "-f"])).toThrow("-f requires a value");
+  });
+
+  it("requires an exact Tooling SHA for protected workflow tags", () => {
+    const trustedTag = `release-publish/${"a".repeat(12)}-123`;
+    expect(() => parseArgs(["--trusted-workflow-ref", trustedTag])).toThrow(
+      "explicit full Tooling SHA",
+    );
+    expect(() =>
+      parseArgs(["--workflow-sha", "a".repeat(40), "--trusted-workflow-ref", "release/2026.8.1"]),
+    ).toThrow("protected release-publish");
   });
 
   it("infers the release profile from the target package version", () => {
@@ -405,6 +433,10 @@ describe("full-release-validation-at-sha", () => {
       "123",
       "--trusted-workflow-ref",
       "main",
+      "--trusted-workflow-full-ref",
+      "refs/heads/main",
+      "--trusted-workflow-sha",
+      workflowSha,
       "--json",
       "--verifier-source-sha",
       workflowSha,
@@ -414,6 +446,71 @@ describe("full-release-validation-at-sha", () => {
     expect(() => releaseEvidenceVerificationArgs("", workflowSha, verifier)).toThrow(
       "positive decimal",
     );
+    const trustedTag = `release-publish/${workflowSha.slice(0, 12)}-123`;
+    expect(releaseEvidenceVerificationArgs("123", workflowSha, verifier, trustedTag)).toEqual([
+      "--validate-run",
+      "123",
+      "--trusted-workflow-ref",
+      trustedTag,
+      "--trusted-workflow-full-ref",
+      `refs/tags/${trustedTag}`,
+      "--trusted-workflow-sha",
+      workflowSha,
+      "--json",
+      "--verifier-source-sha",
+      workflowSha,
+      "--verifier-source-file",
+      verifier,
+    ]);
+    expect(() =>
+      releaseEvidenceVerificationArgs("123", workflowSha, verifier, "release/2026.8.1"),
+    ).toThrow("protected release-publish tag");
+  });
+
+  it("accepts only exact protected workflow tags outside main ancestry", () => {
+    const workflowSha = "a".repeat(40);
+    const trustedTag = `release-publish/${workflowSha.slice(0, 12)}-123`;
+
+    expect(() =>
+      verifyTrustedWorkflowRef(
+        workflowSha,
+        "main",
+        () => "",
+        () => true,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      verifyTrustedWorkflowRef(
+        workflowSha,
+        "main",
+        () => "",
+        () => false,
+      ),
+    ).toThrow("not reachable from current origin/main");
+    expect(() =>
+      verifyTrustedWorkflowRef(
+        workflowSha,
+        trustedTag,
+        () => workflowSha,
+        () => false,
+      ),
+    ).not.toThrow();
+    expect(() =>
+      verifyTrustedWorkflowRef(
+        workflowSha,
+        `release-publish/${"b".repeat(12)}-123`,
+        () => workflowSha,
+      ),
+    ).toThrow("does not match Tooling SHA");
+    expect(() => verifyTrustedWorkflowRef(workflowSha, trustedTag, () => "")).toThrow(
+      "does not exist on origin",
+    );
+    expect(() => verifyTrustedWorkflowRef(workflowSha, trustedTag, () => "c".repeat(40))).toThrow(
+      `expected ${workflowSha}`,
+    );
+    expect(() =>
+      verifyTrustedWorkflowRef(workflowSha, "release/2026.8.1", () => workflowSha),
+    ).toThrow("protected release-publish");
   });
 
   it("bounds polling for the exact workflow run", () => {
@@ -591,6 +688,28 @@ describe("full-release-validation-at-sha", () => {
       expect(runGit(fixture.origin, ["for-each-ref", "--format=%(refname)", "refs/heads"])).toBe(
         "refs/heads/main\nrefs/heads/release/2026.8.1",
       );
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("dispatches non-main tooling only when its exact protected tag is supplied", () => {
+    const fixture = createDispatchFixture();
+    try {
+      const result = fixture.run([
+        "--workflow-sha",
+        fixture.workflowSha,
+        "--trusted-workflow-ref",
+        fixture.trustedWorkflowTag,
+      ]);
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain(`Trusted workflow ref: ${fixture.trustedWorkflowTag}`);
+      expect(fixture.readCalls(fixture.gitCallsPath)).toContainEqual([
+        "ls-remote",
+        "--tags",
+        "origin",
+        `refs/tags/${fixture.trustedWorkflowTag}`,
+      ]);
     } finally {
       fixture.cleanup();
     }

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -876,8 +876,11 @@ function runOpenClawNpmTrustedRefGuard(overrides: Record<string, string>) {
     throw new Error("Expected OpenClaw npm trusted ref guard");
   }
   const binDir = tempDirs.make("openclaw-npm-trusted-ref-");
+  const ghPath = `${binDir}/gh`;
   const gitPath = `${binDir}/git`;
   const timeoutPath = `${binDir}/timeout`;
+  writeFileSync(ghPath, `#!/bin/sh\nprintf '%s\\n' "\${MOCK_REMOTE_TAG_SHA}"\n`);
+  chmodSync(ghPath, 0o755);
   writeFileSync(
     gitPath,
     `#!/bin/sh\nif [ "$1" = "fetch" ]; then exit 0; fi\nif [ "$1" = "merge-base" ]; then [ "\${MOCK_WORKFLOW_ANCESTOR}" = "true" ]; exit $?; fi\nexit 2\n`,
@@ -891,6 +894,8 @@ function runOpenClawNpmTrustedRefGuard(overrides: Record<string, string>) {
   return spawnSync("bash", ["-c", script], {
     encoding: "utf8",
     env: {
+      GITHUB_REPOSITORY: "openclaw/openclaw",
+      MOCK_REMOTE_TAG_SHA: "a".repeat(40),
       MOCK_WORKFLOW_ANCESTOR: "true",
       PATH: `${binDir}:${process.env.PATH}`,
       RELEASE_NPM_DIST_TAG: "beta",
@@ -898,6 +903,137 @@ function runOpenClawNpmTrustedRefGuard(overrides: Record<string, string>) {
       WORKFLOW_REF: "refs/heads/release/2026.7.2",
       WORKFLOW_SHA: "a".repeat(40),
       ...overrides,
+    },
+  });
+}
+
+type ProtectedPreflightConsumerParams = {
+  currentRef: string;
+  currentWorkflowSha: string;
+  preflightHeadBranch: string;
+  preflightHeadSha: string;
+};
+
+function runReleasePublishPreflightConsumerGuard(params: ProtectedPreflightConsumerParams) {
+  const job = workflowJob(RELEASE_PUBLISH_WORKFLOW, "resolve_release_target");
+  const script = workflowStep(job, "Download OpenClaw npm preflight manifest").run;
+  if (!script) {
+    throw new Error("Expected release publish preflight consumer guard");
+  }
+  const workdir = tempDirs.make("release-publish-preflight-consumer-");
+  const binDir = resolve(workdir, "bin");
+  const runnerTemp = resolve(workdir, "runner");
+  mkdirSync(binDir);
+  mkdirSync(runnerTemp);
+  writeFileSync(
+    resolve(binDir, "gh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "run" && "$2" == "download" ]]; then
+  exit 0
+fi
+if [[ "$1" == "api" ]]; then
+  printf '%s\\n' "$MOCK_PREFLIGHT_RUN"
+  exit 0
+fi
+exit 64
+`,
+    { mode: 0o755 },
+  );
+  return spawnSync("bash", ["-c", script], {
+    cwd: workdir,
+    encoding: "utf8",
+    env: {
+      GITHUB_OUTPUT: resolve(workdir, "github-output"),
+      GITHUB_REF: params.currentRef,
+      GITHUB_REPOSITORY: "openclaw/openclaw",
+      MOCK_PREFLIGHT_RUN: JSON.stringify({
+        conclusion: "success",
+        event: "workflow_dispatch",
+        head_branch: params.preflightHeadBranch,
+        head_sha: params.preflightHeadSha,
+        path: ".github/workflows/openclaw-npm-release.yml",
+        run_attempt: 1,
+      }),
+      PATH: `${binDir}:${process.env.PATH}`,
+      PREFLIGHT_RUN_ID: "111",
+      RELEASE_NPM_DIST_TAG: "beta",
+      RELEASE_TAG: "v2026.8.1-beta.3",
+      RUNNER_TEMP: runnerTemp,
+      WORKFLOW_SHA: params.currentWorkflowSha,
+    },
+  });
+}
+
+function runOpenClawNpmPreflightConsumerGuard(params: ProtectedPreflightConsumerParams) {
+  const job = workflowJob(OPENCLAW_NPM_RELEASE_WORKFLOW, "publish_openclaw_npm");
+  const script = workflowStep(job, "Verify preflight run metadata").run;
+  if (!script) {
+    throw new Error("Expected OpenClaw npm preflight consumer guard");
+  }
+  const workdir = tempDirs.make("openclaw-npm-preflight-consumer-");
+  const binDir = resolve(workdir, "bin");
+  mkdirSync(binDir);
+  writeFileSync(
+    resolve(binDir, "gh"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "run" && "$2" == "view" ]]; then
+  printf '%s\\n' "$MOCK_PREFLIGHT_RUN"
+  exit 0
+fi
+if [[ "$1" == "api" ]]; then
+  printf '1\\n'
+  exit 0
+fi
+exit 64
+`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    resolve(binDir, "git"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == "rev-parse HEAD" ]]; then
+  printf '%s\\n' "$MOCK_RELEASE_SHA"
+  exit 0
+fi
+if [[ "$*" == *"cat-file -e"* || "$*" == *"merge-base --is-ancestor"* || "$*" == *" fetch "* ]]; then
+  exit 0
+fi
+exit 64
+`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    resolve(binDir, "node"),
+    `#!/usr/bin/env bash
+cat >/dev/null
+`,
+    { mode: 0o755 },
+  );
+  return spawnSync("bash", ["-c", script], {
+    cwd: workdir,
+    encoding: "utf8",
+    env: {
+      EXPECTED_EXTENDED_STABLE_BRANCH: "",
+      GITHUB_OUTPUT: resolve(workdir, "github-output"),
+      GITHUB_REPOSITORY: "openclaw/openclaw",
+      MOCK_PREFLIGHT_RUN: JSON.stringify({
+        conclusion: "success",
+        event: "workflow_dispatch",
+        headBranch: params.preflightHeadBranch,
+        headSha: params.preflightHeadSha,
+        url: "https://github.com/openclaw/openclaw/actions/runs/111",
+        workflowName: "OpenClaw NPM Release",
+      }),
+      MOCK_RELEASE_SHA: "d".repeat(40),
+      PATH: `${binDir}:${process.env.PATH}`,
+      PREFLIGHT_RUN_ID: "111",
+      RELEASE_NPM_DIST_TAG: "beta",
+      RUN_KIND: "preflight",
+      WORKFLOW_REF: params.currentRef,
+      WORKFLOW_SHA: params.currentWorkflowSha,
     },
   });
 }
@@ -1263,11 +1399,11 @@ describe("package acceptance workflow", () => {
     expect(verifyStep.run).not.toContain("npm view openclaw@extended-stable version");
   });
 
-  it("accepts only main-reachable protected SHA-pinned release publish tags", () => {
+  it("accepts only exact protected SHA-pinned release publish tags", () => {
     const workflowSha = "a".repeat(40);
     const binDir = tempDirs.make("release-publish-gh-");
     const ghPath = `${binDir}/gh`;
-    writeFileSync(ghPath, `#!/bin/sh\nprintf '%s\\n' "\${MOCK_MERGE_BASE_SHA}"\n`);
+    writeFileSync(ghPath, `#!/bin/sh\nprintf '%s\\n' "\${MOCK_REMOTE_TAG_SHA}"\n`);
     chmodSync(ghPath, 0o755);
     const pinnedEnv = {
       GITHUB_REPOSITORY: "openclaw/openclaw",
@@ -1278,7 +1414,7 @@ describe("package acceptance workflow", () => {
 
     const valid = runReleasePublishInputValidation({
       ...pinnedEnv,
-      MOCK_MERGE_BASE_SHA: workflowSha,
+      MOCK_REMOTE_TAG_SHA: workflowSha,
     });
     expect(valid.status, valid.stderr).toBe(0);
 
@@ -1291,13 +1427,13 @@ describe("package acceptance workflow", () => {
       "SHA-pinned release publish tag does not match workflow SHA",
     );
 
-    const unreachable = runReleasePublishInputValidation({
+    const moved = runReleasePublishInputValidation({
       ...pinnedEnv,
-      MOCK_MERGE_BASE_SHA: "c".repeat(40),
+      MOCK_REMOTE_TAG_SHA: "c".repeat(40),
     });
-    expect(unreachable.status).toBe(1);
-    expect(unreachable.stderr).toContain(
-      "SHA-pinned release publish tag revision is not reachable from current main",
+    expect(moved.status).toBe(1);
+    expect(moved.stderr).toContain(
+      "SHA-pinned release publish tag does not resolve to workflow SHA",
     );
   });
 
@@ -1308,6 +1444,7 @@ describe("package acceptance workflow", () => {
     const valid = runOpenClawNpmTrustedRefGuard({
       WORKFLOW_REF: protectedRef,
       WORKFLOW_SHA: workflowSha,
+      MOCK_REMOTE_TAG_SHA: workflowSha,
     });
     expect(valid.status, valid.stderr).toBe(0);
 
@@ -1320,15 +1457,89 @@ describe("package acceptance workflow", () => {
       "SHA-pinned release-publish tag does not match the OpenClaw npm workflow SHA",
     );
 
-    const unreachable = runOpenClawNpmTrustedRefGuard({
-      MOCK_WORKFLOW_ANCESTOR: "false",
+    const moved = runOpenClawNpmTrustedRefGuard({
+      MOCK_REMOTE_TAG_SHA: "c".repeat(40),
       WORKFLOW_REF: protectedRef,
       WORKFLOW_SHA: workflowSha,
     });
-    expect(unreachable.status).toBe(1);
-    expect(unreachable.stderr).toContain(
-      "SHA-pinned OpenClaw npm workflow revision is not reachable from current main",
+    expect(moved.status).toBe(1);
+    expect(moved.stderr).toContain(
+      "SHA-pinned release-publish tag does not resolve to the OpenClaw npm workflow SHA",
     );
+  });
+
+  it("binds aggregate preflight consumption to the exact protected tooling tag and SHA", () => {
+    const workflowSha = "a".repeat(40);
+    const workflowTag = `release-publish/${workflowSha.slice(0, 12)}-123`;
+    const valid = runReleasePublishPreflightConsumerGuard({
+      currentRef: `refs/tags/${workflowTag}`,
+      currentWorkflowSha: workflowSha,
+      preflightHeadBranch: workflowTag,
+      preflightHeadSha: workflowSha,
+    });
+    expect(valid.status, valid.stderr).toBe(0);
+
+    for (const rejected of [
+      {
+        currentRef: `refs/tags/${workflowTag}`,
+        preflightHeadBranch: `${workflowTag}-wrong`,
+        preflightHeadSha: workflowSha,
+      },
+      {
+        currentRef: `refs/tags/${workflowTag}`,
+        preflightHeadBranch: workflowTag,
+        preflightHeadSha: "b".repeat(40),
+      },
+      {
+        currentRef: `refs/heads/${workflowTag}`,
+        preflightHeadBranch: workflowTag,
+        preflightHeadSha: workflowSha,
+      },
+    ]) {
+      const result = runReleasePublishPreflightConsumerGuard({
+        ...rejected,
+        currentWorkflowSha: workflowSha,
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("exact protected release-publish tag");
+    }
+  });
+
+  it("binds core npm preflight consumption to the exact protected tooling tag and SHA", () => {
+    const workflowSha = "a".repeat(40);
+    const workflowTag = `release-publish/${workflowSha.slice(0, 12)}-123`;
+    const valid = runOpenClawNpmPreflightConsumerGuard({
+      currentRef: `refs/tags/${workflowTag}`,
+      currentWorkflowSha: workflowSha,
+      preflightHeadBranch: workflowTag,
+      preflightHeadSha: workflowSha,
+    });
+    expect(valid.status, valid.stderr).toBe(0);
+
+    for (const rejected of [
+      {
+        currentRef: `refs/tags/${workflowTag}`,
+        preflightHeadBranch: `${workflowTag}-wrong`,
+        preflightHeadSha: workflowSha,
+      },
+      {
+        currentRef: `refs/tags/${workflowTag}`,
+        preflightHeadBranch: workflowTag,
+        preflightHeadSha: "b".repeat(40),
+      },
+      {
+        currentRef: `refs/heads/${workflowTag}`,
+        preflightHeadBranch: workflowTag,
+        preflightHeadSha: workflowSha,
+      },
+    ]) {
+      const result = runOpenClawNpmPreflightConsumerGuard({
+        ...rejected,
+        currentWorkflowSha: workflowSha,
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("exact protected release-publish tag");
+    }
   });
 
   it("allows protected SHA-pinned tooling tags to consume token-bootstrap evidence", () => {
@@ -1339,7 +1550,40 @@ describe("package acceptance workflow", () => {
     expect(evidenceStep.run).toContain(
       '[[ "$WORKFLOW_REF" == "refs/heads/main" || "$sha_pinned_release_publish" == "true" ]]',
     );
+    expect(evidenceStep.run).toContain(
+      'gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${workflow_tag}"',
+    );
+    expect(evidenceStep.run).toContain('[[ "$remote_workflow_sha" == "$WORKFLOW_SHA" ]]');
+    expect(evidenceStep.run).toContain('if [[ "$WORKFLOW_REF" == "refs/heads/main" ]]; then');
     expect(evidenceStep.run).toContain('git merge-base --is-ancestor "$WORKFLOW_SHA" origin/main');
+  });
+
+  it("binds release evidence validation to the exact trusted workflow ref", () => {
+    for (const [workflowPath, jobName, stepName] of [
+      [
+        RELEASE_PUBLISH_WORKFLOW,
+        "resolve_release_target",
+        "Validate full release validation manifest",
+      ],
+      [
+        OPENCLAW_NPM_RELEASE_WORKFLOW,
+        "publish_openclaw_npm",
+        "Verify full release validation evidence",
+      ],
+    ] as const) {
+      const step = workflowStep(workflowJob(workflowPath, jobName), stepName);
+      expect(step.env).toMatchObject({
+        TRUSTED_WORKFLOW_FULL_REF: "${{ github.ref }}",
+        TRUSTED_WORKFLOW_REF: "${{ github.ref_name }}",
+        TRUSTED_WORKFLOW_SHA: "${{ github.workflow_sha }}",
+      });
+      expect(step.run).toContain("^refs/tags/release-publish/[a-f0-9]{12}-[1-9][0-9]*$");
+      expect(step.run).toContain('TRUSTED_MAIN_REF="${trusted_workflow_commit_ref}"');
+      expect(step.run).toContain('--trusted-workflow-ref "$TRUSTED_WORKFLOW_REF"');
+      expect(step.run).toContain('--trusted-workflow-full-ref "$TRUSTED_WORKFLOW_FULL_REF"');
+      expect(step.run).toContain('--trusted-workflow-sha "$TRUSTED_WORKFLOW_SHA"');
+      expect(step.run).toContain('--verifier-source-sha "$');
+    }
   });
 
   it("retries child environment approval when deployment propagation lags", () => {
@@ -6003,14 +6247,14 @@ describe("package artifact reuse", () => {
     expect(trustedTooling.env?.WORKFLOW_SHA).toBe("${{ github.sha }}");
     expect(validateManifest.env).toMatchObject({
       RUN_JSON_FILE: "${{ runner.temp }}/full-release-validation-run.json",
-      TRUSTED_MAIN_REF: "refs/remotes/origin/main",
+      TRUSTED_WORKFLOW_FULL_REF: "${{ github.ref }}",
+      TRUSTED_WORKFLOW_REF: "${{ github.ref_name }}",
       VALIDATOR_FILE:
         "${{ runner.temp }}/release-validation-tooling/validate-full-release-validation-evidence.mjs",
       STRICT_VALIDATOR_FILE: "${{ runner.temp }}/release-validation-tooling/release-ci-summary.mjs",
     });
-    expect(validateManifest.run).toContain(
-      'MANIFEST_FILE="$manifest" node "$VALIDATOR_FILE" < "$RUN_JSON_FILE"',
-    );
+    expect(validateManifest.run).toContain('MANIFEST_FILE="$manifest"');
+    expect(validateManifest.run).toContain('node "$VALIDATOR_FILE" < "$RUN_JSON_FILE"');
     expect(publishDownload.with?.name).toBe(
       "full-release-validation-${{ inputs.full_release_validation_run_id }}-${{ needs.resolve_release_target.outputs.full_release_validation_run_attempt }}",
     );

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -1196,6 +1196,114 @@ describe("release CI summary child correlation", () => {
     });
   });
 
+  it("accepts canonical SHA-pinned v3 evidence exactly bound to a protected tooling tag", () => {
+    const workflowSha = "7".repeat(40);
+    const workflowRef = `release-ci/${workflowSha.slice(0, 12)}-1783705000000`;
+    const trustedWorkflowRef = `release-publish/${workflowSha.slice(0, 12)}-123`;
+    const fixture = trustedMainPackageFixture({
+      manifestVersion: 3,
+      targetSha: "8".repeat(40),
+      workflowFullRef: `refs/heads/${workflowRef}`,
+      workflowRef,
+      workflowSha,
+    });
+    fixture.manifest.targetRef = fixture.targetSha;
+
+    expect(
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: fixture.runId,
+          trustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
+          trustedWorkflowRef,
+          trustedWorkflowSha: workflowSha,
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        fixture.client,
+      ),
+    ).toMatchObject({
+      producerOnTrustedMainLineage: false,
+      trustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
+      trustedWorkflowRef,
+      root: {
+        workflowRef,
+        workflowRefProof: "manifest-v3-protected-tag-exact-sha",
+        workflowSha,
+      },
+    });
+  });
+
+  it("rejects protected-tag evidence from a same-name branch or older ancestor", () => {
+    const trustedWorkflowSha = "7".repeat(40);
+    const trustedWorkflowRef = `release-publish/${trustedWorkflowSha.slice(0, 12)}-123`;
+    const validFixture = trustedMainPackageFixture({
+      manifestVersion: 3,
+      workflowSha: trustedWorkflowSha,
+    });
+
+    expect(() =>
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: validFixture.runId,
+          trustedWorkflowFullRef: `refs/heads/${trustedWorkflowRef}`,
+          trustedWorkflowRef,
+          trustedWorkflowSha,
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        validFixture.client,
+      ),
+    ).toThrow("must be a protected tag");
+
+    const olderWorkflowSha = "6".repeat(40);
+    const olderWorkflowRef = `release-ci/${olderWorkflowSha.slice(0, 12)}-1783705000000`;
+    const olderFixture = trustedMainPackageFixture({
+      manifestVersion: 3,
+      targetSha: "8".repeat(40),
+      workflowFullRef: `refs/heads/${olderWorkflowRef}`,
+      workflowRef: olderWorkflowRef,
+      workflowSha: olderWorkflowSha,
+    });
+    olderFixture.manifest.targetRef = olderFixture.targetSha;
+    expect(() =>
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: olderFixture.runId,
+          trustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
+          trustedWorkflowRef,
+          trustedWorkflowSha,
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        olderFixture.client,
+      ),
+    ).toThrow("does not match trusted tooling");
+
+    const sameNameFixture = trustedMainPackageFixture({
+      manifestVersion: 3,
+      workflowFullRef: `refs/heads/${trustedWorkflowRef}`,
+      workflowRef: trustedWorkflowRef,
+      workflowSha: trustedWorkflowSha,
+    });
+    expect(() =>
+      validateReleaseRunEvidence(
+        {
+          repository: "openclaw/openclaw",
+          runId: sameNameFixture.runId,
+          trustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
+          trustedWorkflowRef,
+          trustedWorkflowSha,
+          verifierSourceContent: readFileSync(SCRIPT),
+          verifierSourceSha: "c".repeat(40),
+        },
+        sameNameFixture.client,
+      ),
+    ).toThrow("canonical release-ci branch");
+  });
+
   it.each(["main", "refs/heads/main"])(
     "accepts a REST workflow path qualified with %s",
     (qualifiedRef) => {

--- a/test/scripts/validate-full-release-validation-evidence.test.ts
+++ b/test/scripts/validate-full-release-validation-evidence.test.ts
@@ -125,6 +125,78 @@ describe("full release validation evidence", () => {
     expect(isShaPinnedReleaseValidationBranch(pinnedBranch)).toBe(true);
   });
 
+  it("accepts canonical SHA-pinned evidence exactly bound to a protected tooling tag", () => {
+    const isTrustedMainAncestor = vi.fn(() => false);
+    const trustedWorkflowRef = `release-publish/${workflowSha.slice(0, 12)}-123`;
+    const result = validateFullReleaseValidationEvidence({
+      run: releaseRun(),
+      manifest: releaseManifest(),
+      expectedRepository: "openclaw/openclaw",
+      expectedRunId: "123",
+      expectedTargetSha: targetSha,
+      expectedTrustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
+      expectedTrustedWorkflowSha: workflowSha,
+      isTrustedMainAncestor,
+    });
+
+    expect(result.source).toBe("sha-pinned-protected-tag");
+    expect(isTrustedMainAncestor).not.toHaveBeenCalled();
+  });
+
+  it("rejects protected-tag evidence from a same-name branch or older ancestor", () => {
+    const trustedWorkflowRef = `release-publish/${workflowSha.slice(0, 12)}-123`;
+    expect(() =>
+      validateFullReleaseValidationEvidence({
+        run: releaseRun(),
+        manifest: releaseManifest(),
+        expectedRepository: "openclaw/openclaw",
+        expectedRunId: "123",
+        expectedTargetSha: targetSha,
+        expectedTrustedWorkflowFullRef: `refs/heads/${trustedWorkflowRef}`,
+        expectedTrustedWorkflowSha: workflowSha,
+        isTrustedMainAncestor: () => true,
+      }),
+    ).toThrow("must be an exact protected tag");
+
+    const olderWorkflowSha = "c".repeat(40);
+    const olderBranch = `release-ci/${olderWorkflowSha.slice(0, 12)}-1783705000000`;
+    expect(() =>
+      validateFullReleaseValidationEvidence({
+        run: releaseRun({
+          head_branch: olderBranch,
+          head_sha: olderWorkflowSha,
+        }),
+        manifest: releaseManifest({
+          workflowFullRef: `refs/heads/${olderBranch}`,
+          workflowRef: olderBranch,
+          workflowSha: olderWorkflowSha,
+        }),
+        expectedRepository: "openclaw/openclaw",
+        expectedRunId: "123",
+        expectedTargetSha: targetSha,
+        expectedTrustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
+        expectedTrustedWorkflowSha: workflowSha,
+        isTrustedMainAncestor: () => true,
+      }),
+    ).toThrow("does not match trusted tooling");
+
+    expect(() =>
+      validateFullReleaseValidationEvidence({
+        run: releaseRun({ head_branch: trustedWorkflowRef }),
+        manifest: releaseManifest({
+          workflowFullRef: `refs/heads/${trustedWorkflowRef}`,
+          workflowRef: trustedWorkflowRef,
+        }),
+        expectedRepository: "openclaw/openclaw",
+        expectedRunId: "123",
+        expectedTargetSha: targetSha,
+        expectedTrustedWorkflowFullRef: `refs/tags/${trustedWorkflowRef}`,
+        expectedTrustedWorkflowSha: workflowSha,
+        isTrustedMainAncestor: () => true,
+      }),
+    ).toThrow("canonical release-ci producer branch");
+  });
+
   it.each([pinnedBranch, `refs/heads/${pinnedBranch}`])(
     "accepts a REST workflow path qualified with %s",
     (qualifiedRef) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes a release isolation failure where a frozen, reviewed Tooling SHA could not validate or publish a frozen beta candidate after its lineage diverged from current `main`, even when an immutable protected `release-publish/*` tag bound the workflow to that exact commit.

## Why This Change Was Made

The existing main route remains unchanged and requires Tooling SHA ancestry from current `main`. A second, tightly scoped route accepts only `release-publish/<12hex>-<decimal>` when the name prefix and the full remote tag commit exactly match the declared Tooling SHA.

Preflight consumers additionally require the current workflow ref to be that exact protected tag, the producer `head_branch` to name the same tag, and the producer `head_sha` to equal the current workflow SHA. Full Release Validation dispatch and evidence verification carry the trusted ref name, full tag ref, and exact Tooling SHA through the helper and both validators. The protected-tag route accepts only canonical `release-ci/<tooling-sha-prefix>-<decimal>` producers whose manifest records the exact Tooling SHA; same-name branches and ancestor-only evidence fail closed. The existing main ancestry route remains intact.

Arbitrary refs, missing or moved tags, annotated tag objects, wrong SHA prefixes, mismatched commits, and non-main bootstrap refs remain fail-closed. This changes release tooling only; it does not change candidate or product bytes.

## User Impact

Release operators can validate and publish an exact reviewed frozen candidate without adopting unrelated product changes from moving `main`.

## Evidence

- Exact lineage: signed commit `7dcdf8b0c7ebb5c159ac69c587ed8b62b9008f1a` has direct parent `ce19e1cd7a700d648ff90a1aafbe8ee394613c44`; the branch contains exactly one commit.
- Focused helper/validator/workflow proof: four files passed 319/319.
- Hosted exact-head changed gate: Blacksmith Testbox `tbx_01m0gaa4nnwqa612z12ymjnze4`, run https://github.com/openclaw/openclaw/actions/runs/32408820050, exit 0.
- Autoreview: clean, no accepted/actionable findings.
- Production LOC: +333/-59 (net +274), justified by the protected-tag security invariant, exact producer identity binding, and fail-closed compatibility route across release entry points.
- Tests: +564/-21.
- No changelog: release-harness compatibility only; no user-visible product behavior.
