### PR TITLE
fix(macos): return paired-node Codex catalogs without native supervision

### DIFF
--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -305,13 +305,15 @@ actor MacNodeRuntime {
     }
 
     private func handleCodexThreadInvoke(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {
-        if !self.codexThreadCatalogEnabled(),
+        // Freeze native ownership before awaiting worker support so one invocation cannot switch owners.
+        let nativeCatalogEnabled = self.codexThreadCatalogEnabled()
+        if !nativeCatalogEnabled,
            let nodeHostWorker,
            await nodeHostWorker.supports(req.command)
         {
             return await nodeHostWorker.invoke(req)
         }
-        guard self.codexThreadCatalogEnabled() else {
+        guard nativeCatalogEnabled else {
             return Self.errorResponse(
                 req,
                 code: .unavailable,

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -305,6 +305,12 @@ actor MacNodeRuntime {
     }
 
     private func handleCodexThreadInvoke(_ req: BridgeInvokeRequest) async throws -> BridgeInvokeResponse {
+        if !self.codexThreadCatalogEnabled(),
+           let nodeHostWorker,
+           await nodeHostWorker.supports(req.command)
+        {
+            return await nodeHostWorker.invoke(req)
+        }
         guard self.codexThreadCatalogEnabled() else {
             return Self.errorResponse(
                 req,

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -2,6 +2,7 @@ import Darwin
 import Foundation
 import OpenClawKit
 import OpenClawProtocol
+import os
 import Testing
 @testable import OpenClaw
 
@@ -216,9 +217,15 @@ struct MacNodeHostWorkerTests {
     ])
     func `worker owns Codex catalog commands when native catalog is disabled`(command: String) async {
         let worker = StubMacNodeHostWorker(commands: [command])
+        let nativeCatalogEnabledReads = OSAllocatedUnfairLock(initialState: 0)
         let runtime = MacNodeRuntime(
             nodeHostWorker: worker,
-            codexThreadCatalogEnabled: { false })
+            codexThreadCatalogEnabled: {
+                nativeCatalogEnabledReads.withLock {
+                    $0 += 1
+                    return false
+                }
+            })
 
         let response = await runtime.handleInvoke(BridgeInvokeRequest(
             id: "worker-codex-catalog",
@@ -228,6 +235,7 @@ struct MacNodeHostWorkerTests {
         #expect(response.ok)
         #expect(response.payloadJSON == #"{"owner":"cli"}"#)
         #expect(await worker.invokedCommands() == [command])
+        #expect(nativeCatalogEnabledReads.withLock { $0 } == 1)
     }
 
     @Test(arguments: [

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -211,12 +211,26 @@ struct MacNodeHostWorkerTests {
     }
 
     @Test(arguments: [
-        (
-            MacNodeCodexThreadCatalogContract.listCommand,
-            "UNAVAILABLE: Codex session catalog is disabled"),
-        (
-            MacNodeCodexThreadCatalogContract.turnsCommand,
-            "UNAVAILABLE: Codex session catalog is disabled"),
+        MacNodeCodexThreadCatalogContract.listCommand,
+        MacNodeCodexThreadCatalogContract.turnsCommand,
+    ])
+    func `worker owns Codex catalog commands when native catalog is disabled`(command: String) async {
+        let worker = StubMacNodeHostWorker(commands: [command])
+        let runtime = MacNodeRuntime(
+            nodeHostWorker: worker,
+            codexThreadCatalogEnabled: { false })
+
+        let response = await runtime.handleInvoke(BridgeInvokeRequest(
+            id: "worker-codex-catalog",
+            command: command,
+            paramsJSON: #"{"limit":1}"#))
+
+        #expect(response.ok)
+        #expect(response.payloadJSON == #"{"owner":"cli"}"#)
+        #expect(await worker.invokedCommands() == [command])
+    }
+
+    @Test(arguments: [
         (
             MacNodeClaudeSessionCatalogContract.listCommand,
             "UNAVAILABLE: Claude session catalog is disabled"),


### PR DESCRIPTION
Closes #126810

AI-assisted: yes. I reviewed and understand the resulting code and tests.

## What Problem This Solves

Fixes an issue where users opening the Codex catalog for a paired macOS node received `NODE_INVOKE_FAILED` when native Codex supervision was disabled, even though the active bundled Codex plugin worker advertised and owned the catalog commands.

## Why This Change Was Made

When native catalog handling is disabled, the macOS node now delegates an exact Codex catalog command to the active plugin worker only if that worker's current manifest supports it. Native-enabled handling remains unchanged, and absent or unsupported worker commands continue to fail closed.

This keeps session-catalog policy in the bundled Codex plugin rather than duplicating its enablement configuration in Swift.

## User Impact

Paired macOS nodes can return their Codex session catalog through the bundled plugin without requiring native Codex supervision. This restores the catalog card while preserving existing native handling and unavailable-state behavior.

## Evidence

Exact head: `ea0dbece397d9d89a50ebc579ec66b6e18159999`

Exact base and merge-base: `701b576cc128d272d2e8be081130c63637b998d4`

Observed before the fix:

```text
UNAVAILABLE: Codex session catalog is disabled
```

Focused validation on the exact head:

- `swift test --package-path apps/macos --disable-automatic-resolution --filter MacNodeHostWorkerTests --quiet` — 26/26 passed
- `swift test --package-path apps/macos --disable-automatic-resolution --filter MacNodeRuntimeTests --quiet` — 33/33 passed
- `./scripts/format-swift.sh macos --check` — clean
- `./scripts/lint-swift.sh macos` — 0 violations across the app and companion CLI
- `git diff --check HEAD^ HEAD` — clean

The repo-local autoreview examined the exact two-file patch after a clean TruffleHog scan and returned no findings (`patch is correct`, confidence 0.98). The rebased patch is byte-identical to the reviewed patch: SHA-256 `0321d0360991d2227f6c8c250715e049d82ab21bedb69abf9a9ccc959b2605e0`.

The complete macOS Swift suite was also attempted locally but did not reach a terminal summary after more than eight minutes, so it is intentionally not claimed as passing; CI remains the broad-suite gate.

### Real paired-node proof

An isolated arm64 Debug bundle from the exact tracked-clean head was exercised against a disposable Gateway, app profile, pairing, and plugin state. The executable SHA-256 was `301f918f06d68462f0766c73516d51016c4435ee0e027fca7efeeb4872902d31`.

Native Codex supervision was absent/effectively disabled, the bundled Codex plugin had `sessionCatalog.enabled=true`, and the connected paired node advertised `codex.appServer.threads.list.v1`. A real Gateway invocation traversed the paired macOS node and active plugin worker and returned:

```json
{
  "head": "ea0dbece397d9d89a50ebc579ec66b6e18159999",
  "command": "codex.appServer.threads.list.v1",
  "ok": true,
  "payloadKeys": ["backwardsCursor", "nextCursor", "sessions"],
  "sessionCount": 1,
  "schemaErrorCountAfterProjectRootFix": 0,
  "contentRedacted": true,
  "projectRootMatchesExactHead": true,
  "sessionCatalogEnabled": true,
  "supervisionEffective": false
}
```

The mode-0600 sanitized receipt has SHA-256 `9e0f9ad1773836c1cb028aa5853248bc7452eea00ccee46bd7b12301f9610373`. It contains no token, credential, session title/content, full node ID, or private path.

After the proof, the disposable app, worker, Gateway, pairing, LaunchAgent, state, preferences, log, and lock were removed. Fresh checks found no residual process, listener, service, or disposable state. The installed OpenClaw app and live Gateway were not changed. No candidate app was installed or promoted.
