### PR TITLE
fix(agents): prevent lost or duplicate subagent completion messages

### DIFF
--- a/src/agents/subagents/announce/subagent-announce-delivery-retry.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery-retry.ts
@@ -4,7 +4,10 @@
 import { clampTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { isFastTestRuntimeEnv } from "../../../infra/env.js";
-import { isOutboundDeliveryError } from "../../../infra/outbound/deliver-types.js";
+import {
+  isOutboundDeliveryError,
+  isPlatformMessageRejectedError,
+} from "../../../infra/outbound/deliver-types.js";
 import { defaultRuntime } from "../../../runtime.js";
 import { isFailoverError } from "../../failover-error.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
@@ -127,50 +130,48 @@ function isTransientFailoverAnnounceError(error: unknown): boolean {
   );
 }
 
-function isTransientAnnounceDeliveryError(error: unknown): boolean {
-  const message = summarizeDeliveryError(error);
-  const topLevelPermanent = Boolean(
-    message && PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message)),
-  );
-  if (topLevelPermanent && !isWriterClaimReboundAnnounceError(error)) {
-    return false;
-  }
-
-  const writerClaimRebound = hasWriterClaimReboundAnnounceError(error);
-  if (writerClaimRebound) {
-    return !hasAnnounceSendEvidence(error);
-  }
-
-  if (
-    hasAnnounceErrorMatch(
-      error,
-      (candidate) =>
-        Boolean(candidate && typeof candidate === "object") &&
-        (candidate as { gatewayCode?: unknown }).gatewayCode === "UNAVAILABLE" &&
-        /cron run continuation/i.test(summarizeDeliveryError(candidate)),
-    )
-  ) {
-    return true;
-  }
-
-  if (!message) {
-    return false;
-  }
-  if (topLevelPermanent) {
-    return false;
-  }
-  return (
-    hasAnnounceErrorMatch(error, isTransientFailoverAnnounceError) ||
-    TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message))
+function isPermanentNonWriterAnnounceError(error: unknown): boolean {
+  return hasAnnounceErrorMatch(
+    error,
+    (candidate) =>
+      isPlatformMessageRejectedError(candidate) ||
+      (!isWriterClaimReboundAnnounceError(candidate) &&
+        PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((pattern) =>
+          pattern.test(summarizeDeliveryError(candidate)),
+        )),
   );
 }
 
+function isTransientAnnounceDeliveryError(error: unknown): boolean {
+  // Any committed platform send makes another attempt a possible duplicate;
+  // permanent owner rejections also override transient-looking wrapped causes.
+  if (hasAnnounceSendEvidence(error) || isPermanentNonWriterAnnounceError(error)) {
+    return false;
+  }
+
+  if (hasWriterClaimReboundAnnounceError(error)) {
+    return true;
+  }
+
+  return hasAnnounceErrorMatch(error, (candidate) => {
+    if (isTransientFailoverAnnounceError(candidate)) {
+      return true;
+    }
+    const message = summarizeDeliveryError(candidate);
+    if (
+      candidate &&
+      typeof candidate === "object" &&
+      (candidate as { gatewayCode?: unknown }).gatewayCode === "UNAVAILABLE" &&
+      /cron run continuation/i.test(message)
+    ) {
+      return true;
+    }
+    return TRANSIENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+  });
+}
+
 export function isPermanentAnnounceDeliveryError(error: unknown): boolean {
-  const message = summarizeDeliveryError(error);
-  return (
-    (message && PERMANENT_ANNOUNCE_DELIVERY_ERROR_PATTERNS.some((re) => re.test(message))) ||
-    hasWriterClaimReboundAnnounceError(error)
-  );
+  return isPermanentNonWriterAnnounceError(error) || hasWriterClaimReboundAnnounceError(error);
 }
 
 export function isIncompleteAnnounceAgentResultError(error: unknown): boolean {

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4,7 +4,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../../config/sessions.js";
 import type { callGateway as runtimeCallGateway } from "../../../gateway/call.js";
 import type { dispatchGatewayMethodInProcess as runtimeDispatchGatewayMethodInProcess } from "../../../gateway/server-plugins.js";
-import { OutboundDeliveryError } from "../../../infra/outbound/deliver-types.js";
+import {
+  OutboundDeliveryError,
+  PlatformMessageNotDispatchedError,
+} from "../../../infra/outbound/deliver-types.js";
 import { sendMessage as runtimeSendMessage } from "../../../infra/outbound/message.js";
 import {
   testing as sessionBindingServiceTesting,
@@ -4234,6 +4237,114 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(agentParams.sourceReplyDeliveryMode).toBeUndefined();
   });
 
+  it.each([
+    {
+      name: "a transient network cause wrapped by outbound delivery",
+      createError: () =>
+        new Error("outbound delivery failed", { cause: new Error("connect ECONNRESET") }),
+    },
+    {
+      name: "a transient network cause nested through multiple delivery wrappers",
+      createError: () =>
+        new Error("requester handoff failed", {
+          cause: new Error("outbound delivery failed", {
+            cause: new Error("connect ECONNREFUSED"),
+          }),
+        }),
+    },
+  ])("retries $name before any platform send", async ({ createError }) => {
+    const callGateway = vi
+      .fn()
+      .mockRejectedValueOnce(createError())
+      .mockResolvedValueOnce({ result: { payloads: [{ text: "recovered child completion" }] } });
+
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway: callGateway as typeof runtimeCallGateway,
+      directIdempotencyKey: "announce-wrapped-transient-retry",
+    });
+
+    expect(result).toMatchObject({ delivered: true, path: "direct" });
+    expect(callGateway).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      name: "a wrapped permanent channel failure",
+      createError: () =>
+        new Error("outbound delivery failed", { cause: new Error("chat not found") }),
+    },
+    {
+      name: "a typed permanent platform rejection",
+      createError: () =>
+        new PlatformMessageNotDispatchedError("payload rejected by platform policy", {
+          cause: new Error("payload cannot be delivered"),
+          retryable: false,
+        }),
+    },
+    {
+      name: "a wrapped typed permanent rejection with a transient-looking cause",
+      createError: () =>
+        new Error("outbound delivery failed", {
+          cause: new PlatformMessageNotDispatchedError("payload rejected by platform policy", {
+            cause: new Error("connect ECONNRESET"),
+            retryable: false,
+          }),
+        }),
+    },
+  ])("classifies $name as a permanent failure", async ({ createError }) => {
+    const callGateway: typeof runtimeCallGateway = vi.fn(async () => {
+      throw createError();
+    });
+
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      directIdempotencyKey: "announce-wrapped-permanent-rejection",
+    });
+
+    expect(result).toMatchObject({
+      delivered: false,
+      path: "direct",
+      disposition: "permanent_failure",
+    });
+    expect(callGateway).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "an identified outbound platform send",
+      createError: () =>
+        new OutboundDeliveryError("connect ECONNRESET", {
+          cause: new Error("connect ECONNRESET"),
+          results: [{ channel: "telegram", messageId: "msg-already-sent" }],
+        }),
+    },
+    {
+      name: "a nested visible reply receipt",
+      createError: () =>
+        new Error("connect ECONNRESET", {
+          cause: Object.assign(new Error("platform send completed"), {
+            visibleReplySent: true,
+          }),
+        }),
+    },
+  ])("never retries a transient error after $name", async ({ createError }) => {
+    const callGateway: typeof runtimeCallGateway = vi.fn(async () => {
+      throw createError();
+    });
+
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      directIdempotencyKey: "announce-transient-after-confirmed-send",
+    });
+
+    expect(result).toMatchObject({
+      delivered: false,
+      path: "direct",
+      disposition: "ambiguous",
+    });
+    expect(callGateway).toHaveBeenCalledOnce();
+  });
+
   it("does not retry writer-claim rebound failures with send evidence", async () => {
     const sendErr = new OutboundDeliveryError("outbound delivery failed", {
       cause: new Error("outbound delivery failed"),
@@ -4344,6 +4455,27 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       reason: "source_owner_changed",
       terminal: true,
     });
+    expect(callGateway).toHaveBeenCalledOnce();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not text-fallback after an identified incomplete platform send", async () => {
+    const callGateway: typeof runtimeCallGateway = vi.fn(async () => {
+      throw new OutboundDeliveryError("incomplete terminal response", {
+        cause: new Error("incomplete terminal response"),
+        results: [{ channel: "discord", messageId: "already-sent" }],
+      });
+    });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      sourceTool: "subagent_announce",
+      internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
+    });
+
+    expect(result).toMatchObject({ delivered: false, path: "direct", disposition: "ambiguous" });
     expect(callGateway).toHaveBeenCalledOnce();
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -383,7 +383,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       if (err instanceof SourceOwnerChangedError) {
         return sourceOwnerChangedResult();
       }
-      if (isPermanentAnnounceDeliveryError(err) && hasAnnounceSendEvidence(err)) {
+      if (hasAnnounceSendEvidence(err)) {
         throw err;
       }
       if (
@@ -598,12 +598,11 @@ export async function sendSubagentAnnounceDirectly(params: {
         : {}),
     };
   } catch (err) {
-    const permanent = isPermanentAnnounceDeliveryError(err);
-    const disposition = permanent
-      ? hasAnnounceSendEvidence(err)
-        ? "ambiguous"
-        : "permanent_failure"
-      : "retryable";
+    const disposition = hasAnnounceSendEvidence(err)
+      ? "ambiguous"
+      : isPermanentAnnounceDeliveryError(err)
+        ? "permanent_failure"
+        : "retryable";
     return {
       delivered: false,
       path: "direct",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where delegated tasks could silently lose their completion announcement after a wrapped network failure, repeatedly retry a permanent platform rejection, or deliver the same completion twice after a transport error followed an already-sent message.

## Why This Change Was Made

Resolve delivery disposition once at the existing announcement retry owner by traversing the complete, cycle-safe error cause chain. Treat actual platform-send evidence as authoritative before retry, permanent-failure classification, and incomplete-result text fallback; preserve unsent writer-claim recovery and the shared completion/descendant announcement flow.

The top-level-only classification and permanence-gated send evidence originated in #122853. The separately landed requester-visible-final ownership fix from #123285 is preserved intact; scheduler-side workarounds or additional fallbacks would leave the canonical delivery owner and sibling wake path broken.

## User Impact

Subagent completions recover from genuine transient transport errors, permanent platform failures stop retrying immediately, and users receive at most one visible completion after a transport has already confirmed a send.

## Evidence

- Eight real caller-boundary regressions cover wrapped and deeply nested network failures, textual and typed permanent platform rejections, permanent rejections wrapped around transient-looking causes, already-committed platform sends, nested visible-reply receipts, and incomplete-result fallback after an identified send. The original cases fail before the fix.
- Exact rebased-head complete announcement-owner and adjacent timeout suites: **198/198 passed**.
- The previously landed requester-visible-final producer, return projection, and regression remain intact after rebasing.
- Assertion-safety and max-lines ratchets both pass; all three changed files pass `oxfmt --check`.
- Fresh authenticated complete-branch Codex review: **clean, no actionable findings**; separate independent complete-source ownership review: **clean**.
- ClawSweeper independently executed the complete announcement-owner suite: **178/178 passed**, with no actionable or security findings. Its required rank-up item is satisfied by exact-head hosted CI run `32407018600`, now **green** after one evidence-backed retry of an unrelated runner that stalled while main and another PR passed the identical shard. Its optional redacted isolated Gateway trace is skipped because the **198 passing real in-process Gateway/announcement boundary and sibling tests**, including the independent **178-test** run, already cover wrapped recovery, confirmed-send custody, duplicate-fallback prevention, and descendant-safe retry behavior without exposing operator data.
- Production change: **+42/-42, net zero**; regression tests **+133/-1**.
- Exact tested head: `1f22a39cfd6609acb302b3fcb25dff9d77ea275c`.
- No public configuration, plugin SDK, security boundary, protocol, SQLite schema, or persisted-state contract changes.
