### PR TITLE
fix(plugins): recover plugin catalog after transient startup failure

### DIFF
--- a/src/plugins/management-service.lifecycle-cache.test.ts
+++ b/src/plugins/management-service.lifecycle-cache.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   clearPluginMetadataLifecycleCaches,
   registerPluginMetadataProcessMemoLifecycleClear,
@@ -51,8 +52,13 @@ function metadataSnapshot(pluginId?: string) {
 }
 
 describe("plugin management catalog lifecycle", () => {
-  it("serves the first plugins.list load from prewarmed metadata and official catalog caches", async () => {
+  beforeEach(() => {
+    mocks.metadata.mockReset();
+    mocks.officialCatalog.mockReset();
     clearPluginMetadataLifecycleCaches();
+  });
+
+  it("serves the first plugins.list load from prewarmed metadata and official catalog caches", async () => {
     mocks.metadata
       .mockReturnValueOnce(metadataSnapshot())
       .mockReturnValueOnce(metadataSnapshot("fresh-plugin"));
@@ -98,5 +104,68 @@ describe("plugin management catalog lifecycle", () => {
     expect(refreshed.plugins).toEqual([
       expect.objectContaining({ id: "fresh-plugin", installed: true, enabled: true }),
     ]);
+  });
+
+  it("retries a failed official catalog prewarm and keeps the recovered catalog process-stable", async () => {
+    mocks.metadata.mockReturnValue(metadataSnapshot());
+    mocks.officialCatalog
+      .mockRejectedValueOnce(new Error("transient catalog bootstrap"))
+      .mockResolvedValueOnce({ source: "hosted", entries: [] });
+
+    await expect(listManagedPlugins({ config: {}, env: {} })).rejects.toThrow(
+      "transient catalog bootstrap",
+    );
+    await expect(listManagedPlugins({ config: {}, env: {} })).resolves.toMatchObject({
+      plugins: [],
+    });
+    await expect(listManagedPlugins({ config: {}, env: {} })).resolves.toMatchObject({
+      plugins: [],
+    });
+    expect(mocks.officialCatalog).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a refreshed catalog when an older lifecycle generation rejects later", async () => {
+    const retiredCatalog = createDeferred<{ source: "hosted"; entries: never[] }>();
+    mocks.metadata.mockReturnValue(metadataSnapshot());
+    mocks.officialCatalog
+      .mockReturnValueOnce(retiredCatalog.promise)
+      .mockResolvedValueOnce({ source: "hosted", entries: [] });
+
+    const retiredLoad = listManagedPlugins({ config: {}, env: {} });
+    const retiredFailure = expect(retiredLoad).rejects.toThrow("retired catalog bootstrap");
+    await Promise.resolve();
+    expect(mocks.officialCatalog).toHaveBeenCalledTimes(1);
+
+    clearPluginMetadataLifecycleCaches();
+
+    await expect(listManagedPlugins({ config: {}, env: {} })).resolves.toMatchObject({
+      plugins: [],
+    });
+    retiredCatalog.reject(new Error("retired catalog bootstrap"));
+    await retiredFailure;
+
+    await expect(listManagedPlugins({ config: {}, env: {} })).resolves.toMatchObject({
+      plugins: [],
+    });
+    expect(mocks.officialCatalog).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a successfully resolved bundled-fallback catalog process-stable", async () => {
+    mocks.metadata.mockReturnValue(metadataSnapshot());
+    mocks.officialCatalog.mockResolvedValueOnce({
+      source: "bundled-fallback",
+      entries: [],
+      error: "hosted feed unavailable",
+    });
+
+    const first = await listManagedPlugins({ config: {}, env: {} });
+    const second = await listManagedPlugins({ config: {}, env: {} });
+
+    expect(first.diagnostics).toContainEqual({
+      level: "warn",
+      message: "Official plugin catalog fallback: hosted feed unavailable",
+    });
+    expect(second).toEqual(first);
+    expect(mocks.officialCatalog).toHaveBeenCalledOnce();
   });
 });

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -73,8 +73,8 @@ import {
   type HostedOfficialExternalPluginCatalogLoadResult,
   type OfficialExternalPluginCatalogEntry,
 } from "./official-external-plugin-catalog.js";
+import { createConfigScopedPromiseLoader } from "./plugin-cache-primitives.js";
 import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
-import { registerPluginMetadataProcessMemoLifecycleClear } from "./plugin-metadata-lifecycle.js";
 import {
   loadPluginMetadataSnapshot,
   resolvePluginMetadataSnapshot,
@@ -254,18 +254,14 @@ type OfficialCatalogResult = Pick<HostedOfficialExternalPluginCatalogLoadResult,
   hostedFeaturedAuthoritative?: boolean;
 };
 
-let officialCatalogCache:
-  | { key: string; result: Promise<HostedOfficialExternalPluginCatalogLoadResult> }
-  | undefined;
-
-const OFFICIAL_CATALOG_CACHE_KEY = "built-in";
+const officialCatalogLoader = createConfigScopedPromiseLoader(() =>
+  loadConfiguredHostedOfficialExternalPluginCatalogEntries(),
+);
 
 /** Clear the process-stable hosted catalog snapshot after an explicit owner reload. */
 export function clearManagedPluginOfficialCatalogCache(): void {
-  officialCatalogCache = undefined;
+  officialCatalogLoader.clear();
 }
-
-registerPluginMetadataProcessMemoLifecycleClear(clearManagedPluginOfficialCatalogCache);
 
 function resolveCatalogManifestIcon(manifest: unknown): string | undefined {
   if (!manifest || typeof manifest !== "object") {
@@ -398,14 +394,7 @@ function overlayBundledOfficialPluginCatalogMetadata(
 }
 
 async function loadOfficialCatalog(): Promise<OfficialCatalogResult> {
-  const key = OFFICIAL_CATALOG_CACHE_KEY;
-  if (officialCatalogCache?.key !== key) {
-    officialCatalogCache = {
-      key,
-      result: loadConfiguredHostedOfficialExternalPluginCatalogEntries(),
-    };
-  }
-  const result = await officialCatalogCache.result;
+  const result = await officialCatalogLoader.load();
   const hostedFeaturedAuthoritative =
     result.source === "hosted" || result.source === "hosted-snapshot";
   return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a transient official-plugin-catalog initialization failure during Gateway startup permanently broke subsequent plugin inventory, icon, and installation requests until the process restarted or an operator explicitly refreshed plugin metadata.

## Why This Change Was Made

The plugin management owner maintained a bespoke process-wide cached Promise that never evicted rejected loads, so startup prewarming poisoned every later caller. Replace that duplicate cache and its hand-registered lifecycle hook with the existing canonical lifecycle-owned Promise loader, which already coalesces successful loads, evicts only the exact rejected generation, and participates in explicit plugin-metadata resets. Hosted catalog validation, signed-feed trust, fallback policy, plugin configuration, public SDK contracts, and persistent state are unchanged.

## User Impact

Plugin lists, icons, and installations recover on their next request after a transient catalog bootstrap failure. Successful hosted and bundled-fallback catalog results remain process-stable, concurrent loads stay coalesced, and a stale rejected request cannot invalidate a newer lifecycle generation.

## Evidence

- Regression-first proof on the actual plugin-management owner failed before the fix: the second real `listManagedPlugins` request rejected with the first `transient catalog bootstrap` error instead of invoking the catalog loader again; the remaining three owner cases passed.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs src/plugins/management-service.lifecycle-cache.test.ts src/plugins/management-service.test.ts src/plugins/plugin-cache-primitives.test.ts --configLoader runner` — **45 tests passed** across management, lifecycle, installation-facing behavior, and the shared cache primitive.
- Regression coverage exercises failed prewarm followed by successful retry, continued successful process-stable cache reuse, explicit lifecycle clear with a later stale-generation rejection, and process-stable successful bundled-fallback results.
- Both repository ratchets passed: assertion safety (**4,287 files; 13,527 assertions**) and max-lines (**897 existing suppressions; 501/501 environment variables**).
- Targeted formatting, direct two-file lint, whitespace validation, authenticated Codex autoreview, and a separate independent owner-boundary review passed.
- Production delta: **+6/-17, net -11 lines**. Regression-test delta: **+71/-2**. Removed the bespoke cache record, constant-key branch, and duplicate lifecycle registration; reused the existing canonical promise loader.
- Rejections still fail closed for their original request; there is no same-request retry, signature bypass, automatic trust fallback, new public option, persistence change, or unrelated cache-primitive change.
