### PR TITLE
fix(discord): demote expected description truncation logs

### DIFF
--- a/extensions/discord/src/monitor/native-command.options.test.ts
+++ b/extensions/discord/src/monitor/native-command.options.test.ts
@@ -12,7 +12,8 @@ const { loadModelCatalogMock, logVerboseMock } = vi.hoisted(() => ({
   loadModelCatalogMock: vi.fn(),
   logVerboseMock: vi.fn(),
 }));
-const { loggerWarnMock } = vi.hoisted(() => ({
+const { loggerDebugMock, loggerWarnMock } = vi.hoisted(() => ({
+  loggerDebugMock: vi.fn(),
   loggerWarnMock: vi.fn(),
 }));
 
@@ -27,7 +28,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", async () => {
       info: vi.fn(),
       error: vi.fn(),
       warn: loggerWarnMock,
-      debug: vi.fn(),
+      debug: loggerDebugMock,
     }),
     logVerbose: logVerboseMock,
   };
@@ -234,6 +235,7 @@ describe("createDiscordNativeCommand option wiring", () => {
     clearRuntimeConfigSnapshot();
     loadModelCatalogMock.mockReset().mockReturnValue({ entries: [], routeVariants: [] });
     logVerboseMock.mockReset();
+    loggerDebugMock.mockReset();
     loggerWarnMock.mockReset();
   });
 
@@ -674,6 +676,15 @@ describe("createDiscordNativeCommand option wiring", () => {
 
     expect(command.description).toBe("x".repeat(99));
     expect(requireOption(command, "input").description).toBe("x".repeat(99));
+    expect(loggerDebugMock).toHaveBeenNthCalledWith(
+      1,
+      `discord: truncating native command description (command:longdesc arg:input) from ${longDescription.length} to 100: ${JSON.stringify(longDescription)}`,
+    );
+    expect(loggerDebugMock).toHaveBeenNthCalledWith(
+      2,
+      `discord: truncating native command description (command:longdesc) from ${longDescription.length} to 100: ${JSON.stringify(longDescription)}`,
+    );
+    expect(loggerWarnMock).not.toHaveBeenCalled();
   });
 
   it("serializes localized command descriptions on a UTF-16 boundary", () => {
@@ -700,6 +711,10 @@ describe("createDiscordNativeCommand option wiring", () => {
       ko: "현지화된 설명",
       "en-GB": "k".repeat(99),
     });
+    expect(loggerDebugMock).toHaveBeenCalledExactlyOnceWith(
+      `discord: truncating native command description (command:localized locale:en-GB) from ${longDescription.length} to 100: ${JSON.stringify(longDescription)}`,
+    );
+    expect(loggerWarnMock).not.toHaveBeenCalled();
     expect(command.serialize()).toEqual({
       name: "localized",
       description: "Default description",

--- a/extensions/discord/src/monitor/native-command.options.ts
+++ b/extensions/discord/src/monitor/native-command.options.ts
@@ -28,7 +28,7 @@ export function truncateDiscordCommandDescription(params: {
   if (value.length <= DISCORD_COMMAND_DESCRIPTION_MAX) {
     return value;
   }
-  log.warn(
+  log.debug(
     `discord: truncating native command description (${label}) from ${value.length} to ${DISCORD_COMMAND_DESCRIPTION_MAX}: ${JSON.stringify(value)}`,
   );
   return truncateUtf16Safe(value, DISCORD_COMMAND_DESCRIPTION_MAX);


### PR DESCRIPTION
Closes #126817

## What Problem This Solves

Fixes an issue where Discord logged required, successful native-command description truncation as a warning for every oversized retained command on each account start.

## Why This Change Was Made

Discord still applies the same 100-character, UTF-16-safe transport normalization to command, option, and localized descriptions. The owner now records that expected adaptation at debug level; invalid-command and deployment failures remain warnings/errors. Shared descriptions stay rich for help, model routing, and sibling channels.

## User Impact

Operators no longer receive warning floods for successful Discord catalog construction, so genuine command deployment problems remain visible. Native command payloads and menus are unchanged.

## Evidence

- Live production evidence: 945 truncation warnings in a bounded two-day Gateway corpus; a fresh hour showed the same retained fields warning once per Gateway start.
- Installed Discord contract: chat-input command and option descriptions are limited to 1-100 characters; localized descriptions follow the same rule.
- Built-in command and option descriptions are already within the limit. Oversized inputs primarily come from valid shared skills whose descriptions intentionally serve other surfaces.
- Focused regression: long command, option, and localization payloads retain the same UTF-16-safe 99-character boundary; debug receives the diagnostic and warn remains unused.
- Focused owner suite: 13/13 passed.
- Complete Discord extension lane: 2,807/2,807 across 225 files.
- Changed-file gate passed: format, extension/test typecheck, extension lint, plugin boundaries, dead exports, import cycles, and repository guards.
- Fresh rebased Codex autoreview: clean, no accepted/actionable findings.
- Production LOC: +1/-1, net zero. Tests: +17/-2.
- No payload, command catalog, shared description, transport limit, provider, config, protocol, storage, credential, or UI behavior change.

AI-assisted: implementation and review used Codex, with maintainer inspection of Discord's installed contract, shared skill metadata ownership, sibling transport limits, production logs, history, and tests.
