### PR TITLE
perf(sqlite): skip schema write lock on current state

### DIFF
--- a/scripts/check-kysely-guardrails.mts
+++ b/scripts/check-kysely-guardrails.mts
@@ -64,6 +64,7 @@ const rawSqliteAllowPathGroups = {
     "src/state/openclaw-state-db-schema-helpers.ts",
     "src/state/openclaw-state-db-schema-repair.ts",
     "src/state/openclaw-state-db-startup-checkpoint.ts",
+    "src/state/openclaw-state-db-fast-path.ts",
     "src/state/openclaw-state-db.ts",
     "src/state/openclaw-state-ownership-operations.ts",
     "src/transcripts/sqlite-schema.ts",

--- a/src/agents/subagents/completion/subagent-completion-admission.store.test.ts
+++ b/src/agents/subagents/completion/subagent-completion-admission.store.test.ts
@@ -380,6 +380,9 @@ describe("atomic subagent completion admission store", () => {
           "UPDATE subagent_runs SET payload_json = ?, fallback_frozen_result_text = NULL WHERE run_id = ?",
         )
         .run(JSON.stringify(legacyPayload), input.subagent.runId);
+      database.db
+        .prepare("UPDATE schema_meta SET app_version = ? WHERE meta_key = 'primary'")
+        .run("2026.7.0");
 
       resetTaskRegistryForTests({ persist: false });
       subagentRuns.clear();

--- a/src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts
@@ -301,6 +301,9 @@ describe("subagent registry sqlite store", () => {
         },
       });
       saveSubagentRegistryToSqlite(new Map([[run.runId, run]]));
+      openOpenClawStateDatabase()
+        .db.prepare("UPDATE schema_meta SET app_version = ? WHERE meta_key = 'primary'")
+        .run("2026.7.0");
       closeOpenClawStateDatabaseForTest();
 
       const restored = loadSubagentRegistryFromSqlite().get(run.runId);

--- a/src/infra/state-migrations.cron-run-logs.ts
+++ b/src/infra/state-migrations.cron-run-logs.ts
@@ -53,9 +53,13 @@ type CronRunLogTaskImportResult = {
   skipped: boolean;
 };
 
-function tableExists(db: DatabaseSync, name: string): boolean {
+export function hasLegacyCronRunLogs(db: DatabaseSync): boolean {
   return Boolean(
-    db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1").get(name),
+    db
+      .prepare(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'cron_run_logs' LIMIT 1",
+      )
+      .get(),
   );
 }
 
@@ -143,7 +147,7 @@ function ordinalKey(jobId: string, ts: number): string {
 
 /** Runs inside the state schema transaction and removes the retired table after import. */
 export function migrateLegacyCronRunLogsToTaskRuns(db: DatabaseSync): CronRunLogTaskImportResult {
-  if (!tableExists(db, "cron_run_logs")) {
+  if (!hasLegacyCronRunLogs(db)) {
     return { imported: 0, alreadyMirrored: 0, malformed: 0, skipped: true };
   }
 

--- a/src/state/openclaw-state-db-fast-path.ts
+++ b/src/state/openclaw-state-db-fast-path.ts
@@ -1,106 +1,14 @@
 import type { DatabaseSync } from "node:sqlite";
-import { buildApprovalResolutionRef } from "../infra/approval-resolution-ref.js";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
-import { collectSqliteSchemaIssues } from "../infra/sqlite-schema-contract.js";
+import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { VERSION } from "../version.js";
-import {
-  LAZY_ADDITIVE_STATE_TABLES,
-  OPENCLAW_STATE_SCHEMA_VERSION,
-} from "./openclaw-state-db-contract.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
   assertOpenClawStateDatabaseForMaintenance,
   assertSupportedSchemaVersion,
 } from "./openclaw-state-db-maintenance.js";
-import { isCanonicalOperatorApprovalKind } from "./openclaw-state-db-operator-approval-migration.js";
-import { tableExists } from "./openclaw-state-db-schema-helpers.js";
-import {
-  detectOpenClawStateDatabaseSchemaMigrationsFromDatabase,
-  assertCanonicalStateSchemaShape,
-} from "./openclaw-state-db-schema-repair.js";
-import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
-
-function hasRow(database: DatabaseSync, sql: string): boolean {
-  return database.prepare(sql).get() !== undefined;
-}
-
-function hasPendingOperatorApprovalRepairs(database: DatabaseSync): boolean {
-  const rows = database
-    .prepare("SELECT approval_id, kind, resolution_ref FROM operator_approvals")
-    // SAFETY: The selected columns and aliases exactly match this local row shape.
-    .all() as Array<{ approval_id: string; kind: unknown; resolution_ref: string | null }>;
-  if (
-    rows.some(
-      (row) =>
-        !isCanonicalOperatorApprovalKind(row.kind) ||
-        row.resolution_ref !==
-          buildApprovalResolutionRef({ approvalId: row.approval_id, approvalKind: row.kind }),
-    )
-  ) {
-    return true;
-  }
-  return hasRow(
-    database,
-    `SELECT 1
-       FROM operator_approvals AS canonical
-       JOIN operator_approvals AS referenced
-         ON canonical.approval_id = referenced.resolution_ref
-      WHERE canonical.approval_id <> referenced.approval_id
-      LIMIT 1`,
-  );
-}
-
-function hasPendingSameVersionStateRepairs(database: DatabaseSync): boolean {
-  if (
-    ["cron_run_logs", "database_verifications", "node_pairing_pending", "node_pairing_paired"].some(
-      (table) => tableExists(database, table),
-    )
-  ) {
-    return true;
-  }
-  if (
-    hasRow(database, "SELECT 1 FROM task_runs WHERE delivery_status = 'not-requested' LIMIT 1") ||
-    hasRow(
-      database,
-      `SELECT 1 FROM session_watch_cursors
-       WHERE watcher_session_key LIKE 'ambient-group-watch:%' LIMIT 1`,
-    ) ||
-    hasRow(
-      database,
-      `SELECT 1 FROM acp_replay_events WHERE estimated_bytes = 0
-       UNION ALL
-       SELECT 1 FROM acp_replay_sessions WHERE estimated_bytes = 0
-       LIMIT 1`,
-    ) ||
-    hasRow(
-      database,
-      `SELECT 1 FROM cron_jobs
-       WHERE schedule_kind = 'manual' OR payload_kind = 'message' OR name = '' LIMIT 1`,
-    ) ||
-    hasRow(
-      database,
-      `SELECT 1 FROM delivery_queue_entries
-       WHERE status IN ('pending', 'failed') LIMIT 1`,
-    ) ||
-    hasPendingOperatorApprovalRepairs(database)
-  ) {
-    return true;
-  }
-  return hasRow(
-    database,
-    `SELECT 1 FROM subagent_runs
-     WHERE json_valid(payload_json) AND (
-       json_extract(payload_json, '$.delivery.suspendedReason') = 'retry-limit'
-       OR json_type(payload_json, '$.startedAt') IS NOT NULL
-       OR json_type(payload_json, '$.endedAt') IS NOT NULL
-       OR json_type(payload_json, '$.outcome') IS NOT NULL
-       OR json_type(payload_json, '$.delivery.payload.frozenResultText') IS NOT NULL
-       OR json_type(payload_json, '$.delivery.payload.fallbackFrozenResultText') IS NOT NULL
-       OR json_type(pending_final_delivery_payload_json, '$.frozenResultText') IS NOT NULL
-       OR json_type(pending_final_delivery_payload_json, '$.fallbackFrozenResultText') IS NOT NULL
-     ) LIMIT 1`,
-  );
-}
+import { assertCanonicalStateSchemaShape } from "./openclaw-state-db-schema-repair.js";
 
 export function assertCurrentStateRuntimeSchema(database: DatabaseSync, pathname: string): void {
   assertCanonicalStateSchemaShape(database, pathname);
@@ -111,23 +19,17 @@ export function isOpenClawStateSchemaFastPathEligible(
   database: DatabaseSync,
   pathname: string,
 ): boolean {
-  assertSupportedSchemaVersion(database, pathname);
-  if (readSqliteUserVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION) {
-    return false;
-  }
-  assertSqliteIntegrity(database, pathname);
-  assertCurrentStateRuntimeSchema(database, pathname);
-  if (
-    collectSqliteSchemaIssues(database, OPENCLAW_STATE_SCHEMA_SQL, {
-      allowedMissingTables: LAZY_ADDITIVE_STATE_TABLES,
-    }).length > 0 ||
-    detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0 ||
-    hasPendingSameVersionStateRepairs(database)
-  ) {
-    return false;
-  }
-  const metadata = database
-    .prepare("SELECT app_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
-    .get();
-  return metadata?.app_version === VERSION;
+  return runSqliteDeferredTransactionSync(database, () => {
+    assertSupportedSchemaVersion(database, pathname);
+    if (readSqliteUserVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION) {
+      return false;
+    }
+    assertSqliteIntegrity(database, pathname);
+    assertCurrentStateRuntimeSchema(database, pathname);
+    // app_version commits only after this release's repairs; same-build writes are canonical.
+    const metadata = database
+      .prepare("SELECT app_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
+      .get();
+    return metadata?.app_version === VERSION;
+  });
 }

--- a/src/state/openclaw-state-db-fast-path.ts
+++ b/src/state/openclaw-state-db-fast-path.ts
@@ -1,0 +1,133 @@
+import type { DatabaseSync } from "node:sqlite";
+import { buildApprovalResolutionRef } from "../infra/approval-resolution-ref.js";
+import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
+import { collectSqliteSchemaIssues } from "../infra/sqlite-schema-contract.js";
+import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import { VERSION } from "../version.js";
+import {
+  LAZY_ADDITIVE_STATE_TABLES,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "./openclaw-state-db-contract.js";
+import {
+  assertOpenClawStateDatabaseForMaintenance,
+  assertSupportedSchemaVersion,
+} from "./openclaw-state-db-maintenance.js";
+import { isCanonicalOperatorApprovalKind } from "./openclaw-state-db-operator-approval-migration.js";
+import { tableExists } from "./openclaw-state-db-schema-helpers.js";
+import {
+  detectOpenClawStateDatabaseSchemaMigrationsFromDatabase,
+  assertCanonicalStateSchemaShape,
+} from "./openclaw-state-db-schema-repair.js";
+import { OPENCLAW_STATE_SCHEMA_SQL } from "./openclaw-state-schema.js";
+
+function hasRow(database: DatabaseSync, sql: string): boolean {
+  return database.prepare(sql).get() !== undefined;
+}
+
+function hasPendingOperatorApprovalRepairs(database: DatabaseSync): boolean {
+  const rows = database
+    .prepare("SELECT approval_id, kind, resolution_ref FROM operator_approvals")
+    // SAFETY: The selected columns and aliases exactly match this local row shape.
+    .all() as Array<{ approval_id: string; kind: unknown; resolution_ref: string | null }>;
+  if (
+    rows.some(
+      (row) =>
+        !isCanonicalOperatorApprovalKind(row.kind) ||
+        row.resolution_ref !==
+          buildApprovalResolutionRef({ approvalId: row.approval_id, approvalKind: row.kind }),
+    )
+  ) {
+    return true;
+  }
+  return hasRow(
+    database,
+    `SELECT 1
+       FROM operator_approvals AS canonical
+       JOIN operator_approvals AS referenced
+         ON canonical.approval_id = referenced.resolution_ref
+      WHERE canonical.approval_id <> referenced.approval_id
+      LIMIT 1`,
+  );
+}
+
+function hasPendingSameVersionStateRepairs(database: DatabaseSync): boolean {
+  if (
+    ["cron_run_logs", "database_verifications", "node_pairing_pending", "node_pairing_paired"].some(
+      (table) => tableExists(database, table),
+    )
+  ) {
+    return true;
+  }
+  if (
+    hasRow(database, "SELECT 1 FROM task_runs WHERE delivery_status = 'not-requested' LIMIT 1") ||
+    hasRow(
+      database,
+      `SELECT 1 FROM session_watch_cursors
+       WHERE watcher_session_key LIKE 'ambient-group-watch:%' LIMIT 1`,
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM acp_replay_events WHERE estimated_bytes = 0
+       UNION ALL
+       SELECT 1 FROM acp_replay_sessions WHERE estimated_bytes = 0
+       LIMIT 1`,
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM cron_jobs
+       WHERE schedule_kind = 'manual' OR payload_kind = 'message' OR name = '' LIMIT 1`,
+    ) ||
+    hasRow(
+      database,
+      `SELECT 1 FROM delivery_queue_entries
+       WHERE status IN ('pending', 'failed') LIMIT 1`,
+    ) ||
+    hasPendingOperatorApprovalRepairs(database)
+  ) {
+    return true;
+  }
+  return hasRow(
+    database,
+    `SELECT 1 FROM subagent_runs
+     WHERE json_valid(payload_json) AND (
+       json_extract(payload_json, '$.delivery.suspendedReason') = 'retry-limit'
+       OR json_type(payload_json, '$.startedAt') IS NOT NULL
+       OR json_type(payload_json, '$.endedAt') IS NOT NULL
+       OR json_type(payload_json, '$.outcome') IS NOT NULL
+       OR json_type(payload_json, '$.delivery.payload.frozenResultText') IS NOT NULL
+       OR json_type(payload_json, '$.delivery.payload.fallbackFrozenResultText') IS NOT NULL
+       OR json_type(pending_final_delivery_payload_json, '$.frozenResultText') IS NOT NULL
+       OR json_type(pending_final_delivery_payload_json, '$.fallbackFrozenResultText') IS NOT NULL
+     ) LIMIT 1`,
+  );
+}
+
+export function assertCurrentStateRuntimeSchema(database: DatabaseSync, pathname: string): void {
+  assertCanonicalStateSchemaShape(database, pathname);
+  assertOpenClawStateDatabaseForMaintenance(database, { pathname });
+}
+
+export function isOpenClawStateSchemaFastPathEligible(
+  database: DatabaseSync,
+  pathname: string,
+): boolean {
+  assertSupportedSchemaVersion(database, pathname);
+  if (readSqliteUserVersion(database) !== OPENCLAW_STATE_SCHEMA_VERSION) {
+    return false;
+  }
+  assertSqliteIntegrity(database, pathname);
+  assertCurrentStateRuntimeSchema(database, pathname);
+  if (
+    collectSqliteSchemaIssues(database, OPENCLAW_STATE_SCHEMA_SQL, {
+      allowedMissingTables: LAZY_ADDITIVE_STATE_TABLES,
+    }).length > 0 ||
+    detectOpenClawStateDatabaseSchemaMigrationsFromDatabase(database, pathname).length > 0 ||
+    hasPendingSameVersionStateRepairs(database)
+  ) {
+    return false;
+  }
+  const metadata = database
+    .prepare("SELECT app_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
+    .get();
+  return metadata?.app_version === VERSION;
+}

--- a/src/state/openclaw-state-db-fast-path.ts
+++ b/src/state/openclaw-state-db-fast-path.ts
@@ -3,6 +3,7 @@ import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
 import { collectSqliteSchemaIssues } from "../infra/sqlite-schema-contract.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import { hasLegacyCronRunLogs } from "../infra/state-migrations.cron-run-logs.js";
 import { VERSION } from "../version.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import {
@@ -38,6 +39,9 @@ export function isOpenClawStateSchemaFastPathEligible(
       STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
     ).some(isOpenClawStateStartupRepairableSchemaIssue);
     if (startupRepairRequired) {
+      return false;
+    }
+    if (hasLegacyCronRunLogs(database)) {
       return false;
     }
     // app_version commits only after this release's repairs; same-build writes are canonical.

--- a/src/state/openclaw-state-db-fast-path.ts
+++ b/src/state/openclaw-state-db-fast-path.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import { assertSqliteIntegrity } from "../infra/sqlite-integrity.js";
+import { collectSqliteSchemaIssues } from "../infra/sqlite-schema-contract.js";
 import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
 import { VERSION } from "../version.js";
@@ -9,6 +10,11 @@ import {
   assertSupportedSchemaVersion,
 } from "./openclaw-state-db-maintenance.js";
 import { assertCanonicalStateSchemaShape } from "./openclaw-state-db-schema-repair.js";
+import {
+  getOpenClawStateRuntimeSchema,
+  isOpenClawStateStartupRepairableSchemaIssue,
+  STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
+} from "./openclaw-state-schema-compatibility.js";
 
 export function assertCurrentStateRuntimeSchema(database: DatabaseSync, pathname: string): void {
   assertCanonicalStateSchemaShape(database, pathname);
@@ -26,6 +32,14 @@ export function isOpenClawStateSchemaFastPathEligible(
     }
     assertSqliteIntegrity(database, pathname);
     assertCurrentStateRuntimeSchema(database, pathname);
+    const startupRepairRequired = collectSqliteSchemaIssues(
+      database,
+      getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false }),
+      STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
+    ).some(isOpenClawStateStartupRepairableSchemaIssue);
+    if (startupRepairRequired) {
+      return false;
+    }
     // app_version commits only after this release's repairs; same-build writes are canonical.
     const metadata = database
       .prepare("SELECT app_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")

--- a/src/state/openclaw-state-db-legacy-backfills.test.ts
+++ b/src/state/openclaw-state-db-legacy-backfills.test.ts
@@ -100,6 +100,9 @@ describe("repairLegacySubagentSuspensionReasons", () => {
           delivery: { status: "suspended", suspendedReason: "retry-limit" },
         }),
       );
+    initial.db
+      .prepare("UPDATE schema_meta SET app_version = ? WHERE meta_key = 'primary'")
+      .run("2026.7.0");
     closeOpenClawStateDatabaseForTest();
 
     const firstOpen = openOpenClawStateDatabase(options);

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -2965,7 +2965,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         ALTER TABLE claw_installs DROP COLUMN bootstrap_source_path;
         ALTER TABLE claw_installs DROP COLUMN bootstrap_content_digest;
       `);
-      markStateDatabaseAsPreviousAppVersion(shippedSchema);
       expect(readSqliteNumberPragma(shippedSchema, "user_version")).toBe(
         OPENCLAW_STATE_SCHEMA_VERSION,
       );
@@ -2997,7 +2996,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         ALTER TABLE claw_installs DROP COLUMN bootstrap_source_path;
         ALTER TABLE claw_installs DROP COLUMN bootstrap_content_digest;
       `);
-      markStateDatabaseAsPreviousAppVersion(shippedSchema);
     } finally {
       shippedSchema.close();
     }
@@ -3077,7 +3075,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       shippedSchema.exec(`
         ALTER TABLE installed_plugin_index DROP COLUMN workspace_dir;
       `);
-      markStateDatabaseAsPreviousAppVersion(shippedSchema);
       expect(readSqliteNumberPragma(shippedSchema, "user_version")).toBe(
         OPENCLAW_STATE_SCHEMA_VERSION,
       );
@@ -3109,7 +3106,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         DROP TABLE worker_session_tool_operations;
         DROP TABLE worker_turn_tool_authorities;
       `);
-      markStateDatabaseAsPreviousAppVersion(shippedSchema);
       expect(readSqliteNumberPragma(shippedSchema, "user_version")).toBe(
         OPENCLAW_STATE_SCHEMA_VERSION,
       );
@@ -4077,7 +4073,6 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     const currentSchema = new DatabaseSync(databasePath);
     try {
       currentSchema.exec("DROP INDEX idx_operator_approvals_source_run_resolved;");
-      markStateDatabaseAsPreviousAppVersion(currentSchema);
       expect(currentSchema.prepare("PRAGMA user_version").get()).toEqual({
         user_version: OPENCLAW_STATE_SCHEMA_VERSION,
       });

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -44,6 +44,7 @@ import {
   OPENCLAW_STATE_SCHEMA_VERSION,
   repairOpenClawStateDatabaseSchema,
   repairOpenClawStateDatabaseSchemaIfNeeded,
+  runWithOpenClawStateBusyTimeout,
   runOpenClawStateWriteTransaction,
   withOpenClawStateStartupMigrationCheckpointDatabase,
 } from "./openclaw-state-db.js";
@@ -5928,6 +5929,25 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       | { journal_mode?: string }
       | undefined;
     expect(journalMode?.journal_mode?.toLowerCase()).toBe("wal");
+  });
+
+  it("reopens a canonical current schema while another connection holds the writer lock", () => {
+    const stateDir = createTempStateDir();
+    const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+    const databasePath = openOpenClawStateDatabase(options).path;
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const writer = new DatabaseSync(databasePath);
+    writer.exec("PRAGMA journal_mode = WAL; BEGIN IMMEDIATE;");
+    try {
+      expect(runWithOpenClawStateBusyTimeout((database) => database.db.isOpen, options, 0)).toBe(
+        true,
+      );
+    } finally {
+      writer.exec("ROLLBACK;");
+      writer.close();
+    }
   });
 
   it("configures the busy timeout before a doctor schema repair transaction", () => {

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -12,6 +12,7 @@ import {
   getDeliveryQueueEntryStatus,
   loadDeliveryQueueEntry,
   terminalizePendingDeliveryQueueEntry,
+  upsertDeliveryQueueEntry,
 } from "../infra/delivery-queue-sqlite.js";
 import {
   executeSqliteQuerySync,
@@ -68,6 +69,12 @@ let canonicalStateDatabaseTemplatePath: string | undefined;
 
 function createTempStateDir(): string {
   return makeTempDir(stateDbTempDirs, "openclaw-state-db-");
+}
+
+function markStateDatabaseAsPreviousAppVersion(database: DatabaseSync): void {
+  database
+    .prepare("UPDATE schema_meta SET app_version = ? WHERE meta_key = 'primary'")
+    .run("2026.7.0");
 }
 
 function createInitialStateSchemaShape() {
@@ -2244,6 +2251,7 @@ describe("openclaw state database", () => {
     const { DatabaseSync } = requireNodeSqlite();
     const legacy = new DatabaseSync(databasePath);
     legacy.exec(`CREATE TABLE ${transientHistoryTable} (path TEXT PRIMARY KEY) STRICT;`);
+    markStateDatabaseAsPreviousAppVersion(legacy);
     legacy.close();
 
     const reopened = openOpenClawStateDatabase(options);
@@ -2957,6 +2965,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         ALTER TABLE claw_installs DROP COLUMN bootstrap_source_path;
         ALTER TABLE claw_installs DROP COLUMN bootstrap_content_digest;
       `);
+      markStateDatabaseAsPreviousAppVersion(shippedSchema);
       expect(readSqliteNumberPragma(shippedSchema, "user_version")).toBe(
         OPENCLAW_STATE_SCHEMA_VERSION,
       );
@@ -2988,6 +2997,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         ALTER TABLE claw_installs DROP COLUMN bootstrap_source_path;
         ALTER TABLE claw_installs DROP COLUMN bootstrap_content_digest;
       `);
+      markStateDatabaseAsPreviousAppVersion(shippedSchema);
     } finally {
       shippedSchema.close();
     }
@@ -3067,6 +3077,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
       shippedSchema.exec(`
         ALTER TABLE installed_plugin_index DROP COLUMN workspace_dir;
       `);
+      markStateDatabaseAsPreviousAppVersion(shippedSchema);
       expect(readSqliteNumberPragma(shippedSchema, "user_version")).toBe(
         OPENCLAW_STATE_SCHEMA_VERSION,
       );
@@ -3098,6 +3109,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
         DROP TABLE worker_session_tool_operations;
         DROP TABLE worker_turn_tool_authorities;
       `);
+      markStateDatabaseAsPreviousAppVersion(shippedSchema);
       expect(readSqliteNumberPragma(shippedSchema, "user_version")).toBe(
         OPENCLAW_STATE_SCHEMA_VERSION,
       );
@@ -4065,6 +4077,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     const currentSchema = new DatabaseSync(databasePath);
     try {
       currentSchema.exec("DROP INDEX idx_operator_approvals_source_run_resolved;");
+      markStateDatabaseAsPreviousAppVersion(currentSchema);
       expect(currentSchema.prepare("PRAGMA user_version").get()).toEqual({
         user_version: OPENCLAW_STATE_SCHEMA_VERSION,
       });
@@ -5120,6 +5133,7 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
             100,
           );
         }
+        markStateDatabaseAsPreviousAppVersion(database);
         database.close();
 
         const readStatuses = () =>
@@ -5935,6 +5949,16 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     const stateDir = createTempStateDir();
     const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
     const databasePath = openOpenClawStateDatabase(options).path;
+    upsertDeliveryQueueEntry({
+      queueName: "outbound",
+      entry: {
+        id: "pending-telegram-delivery",
+        enqueuedAt: 1,
+        retryCount: 0,
+      },
+      metadata: { channel: "telegram", target: "chat-1" },
+      stateDir,
+    });
     closeOpenClawStateDatabaseForTest();
 
     const { DatabaseSync } = requireNodeSqlite();

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -381,8 +381,7 @@ function ensureSchema(
 ): void {
   try {
     if (isOpenClawStateSchemaFastPathEligible(db, pathname)) {
-      // Recheck ownership after validation so a durable external claim made
-      // during the lock-free fast path cannot retain a writable handle.
+      // Recheck ownership so a claim made during validation cannot retain a writable handle.
       assertOpenClawStateWriteAllowed({ database: db, databasePath: pathname, env });
       return;
     }

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -375,6 +375,22 @@ function ensureSchema(
   env: NodeJS.ProcessEnv,
   busyTimeoutMs = OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
 ): void {
+  try {
+    assertSupportedSchemaVersion(db, pathname);
+    if (readSqliteUserVersion(db) === OPENCLAW_STATE_SCHEMA_VERSION) {
+      assertSqliteIntegrity(db, pathname);
+      assertCurrentStateRuntimeSchema(db, pathname);
+      const metadata = db
+        .prepare("SELECT app_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
+        .get() as { app_version?: unknown } | undefined;
+      if (metadata?.app_version === VERSION) {
+        return;
+      }
+    }
+  } catch {
+    // Preserve the existing transactional repair and its diagnostics for drift or corruption.
+  }
+
   const now = Date.now();
   const kysely = getNodeSqliteKysely<OpenClawStateMetadataDatabase>(db);
   // Rebuilding referenced tables requires disabling FK enforcement before BEGIN.

--- a/src/state/openclaw-state-db.ts
+++ b/src/state/openclaw-state-db.ts
@@ -51,6 +51,10 @@ import {
   type OpenClawStateDatabaseOptions,
 } from "./openclaw-state-db-contract.js";
 import {
+  assertCurrentStateRuntimeSchema,
+  isOpenClawStateSchemaFastPathEligible,
+} from "./openclaw-state-db-fast-path.js";
+import {
   assertOpenClawStateDatabaseForMaintenance,
   assertOpenClawStateDatabaseV5ForMigration,
   assertOpenClawStateDatabaseV6ForMigration,
@@ -376,16 +380,11 @@ function ensureSchema(
   busyTimeoutMs = OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
 ): void {
   try {
-    assertSupportedSchemaVersion(db, pathname);
-    if (readSqliteUserVersion(db) === OPENCLAW_STATE_SCHEMA_VERSION) {
-      assertSqliteIntegrity(db, pathname);
-      assertCurrentStateRuntimeSchema(db, pathname);
-      const metadata = db
-        .prepare("SELECT app_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
-        .get() as { app_version?: unknown } | undefined;
-      if (metadata?.app_version === VERSION) {
-        return;
-      }
+    if (isOpenClawStateSchemaFastPathEligible(db, pathname)) {
+      // Recheck ownership after validation so a durable external claim made
+      // during the lock-free fast path cannot retain a writable handle.
+      assertOpenClawStateWriteAllowed({ database: db, databasePath: pathname, env });
+      return;
     }
   } catch {
     // Preserve the existing transactional repair and its diagnostics for drift or corruption.
@@ -555,11 +554,6 @@ export async function openExistingOpenClawStateDatabaseReadOnly(
       },
     },
   };
-}
-
-function assertCurrentStateRuntimeSchema(database: DatabaseSync, pathname: string): void {
-  assertCanonicalStateSchemaShape(database, pathname);
-  assertOpenClawStateDatabaseForMaintenance(database, { pathname });
 }
 
 /** Open or return a cached shared state database after schema and migration checks. */

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -673,6 +673,60 @@ describe("external shared-state ownership", () => {
     }
   });
 
+  it("fences a claim made during a canonical current-schema cold open", () => {
+    const env = createEnv();
+    const databasePath = openOpenClawStateDatabase({ env }).path;
+    closeOpenClawStateDatabaseForTest();
+    const { DatabaseSync } = requireNodeSqlite();
+    const originalPrepare = Object.getOwnPropertyDescriptor(DatabaseSync.prototype, "prepare")
+      ?.value as
+      | ((
+          this: import("node:sqlite").DatabaseSync,
+          sql: string,
+        ) => import("node:sqlite").StatementSync)
+      | undefined;
+    if (!originalPrepare) {
+      throw new Error("DatabaseSync.prepare descriptor is unavailable");
+    }
+    let claimInjected = false;
+    const prepare = vi.spyOn(DatabaseSync.prototype, "prepare").mockImplementation(function (
+      this: import("node:sqlite").DatabaseSync,
+      sql: string,
+    ) {
+      if (!claimInjected && sql.includes("SELECT app_version FROM schema_meta")) {
+        claimInjected = true;
+        const claimant = new DatabaseSync(databasePath);
+        try {
+          claimant
+            .prepare(
+              `INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
+               VALUES (?, ?, ?)`,
+            )
+            .run(
+              STATE_SUPERVISION_KEY,
+              JSON.stringify({
+                version: 1,
+                mode: "external",
+                managerId: "race-manager",
+                claimedAt: 1,
+              }),
+              1,
+            );
+        } finally {
+          claimant.close();
+        }
+      }
+      return originalPrepare.call(this, sql);
+    });
+
+    try {
+      expect(() => openOpenClawStateDatabase({ env })).toThrow(OpenClawStateOwnershipError);
+    } finally {
+      prepare.mockRestore();
+    }
+    expect(claimInjected).toBe(true);
+  });
+
   it("fences injected and pre-claim handles on their next canonical write", () => {
     const externalEnv = createEnv(true);
     const opened = openOpenClawStateDatabase({ env: externalEnv });

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -787,6 +787,9 @@ describe("external shared-state ownership", () => {
       )
       .run(STATE_SUPERVISION_KEY, '{"version":1,"mode":"external"}', Date.now());
     database.db.exec("ALTER TABLE worktrees DROP COLUMN run_end_cleanup_json;");
+    database.db
+      .prepare("UPDATE schema_meta SET app_version = ? WHERE meta_key = 'primary'")
+      .run("2026.7.0");
     closeOpenClawStateDatabaseForTest();
 
     expect(() => openOpenClawStateDatabase({ env: withoutExternalMarker(env) })).toThrow(

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -787,9 +787,6 @@ describe("external shared-state ownership", () => {
       )
       .run(STATE_SUPERVISION_KEY, '{"version":1,"mode":"external"}', Date.now());
     database.db.exec("ALTER TABLE worktrees DROP COLUMN run_end_cleanup_json;");
-    database.db
-      .prepare("UPDATE schema_meta SET app_version = ? WHERE meta_key = 'primary'")
-      .run("2026.7.0");
     closeOpenClawStateDatabaseForTest();
 
     expect(() => openOpenClawStateDatabase({ env: withoutExternalMarker(env) })).toThrow(


### PR DESCRIPTION
## What Problem This Solves

Every fresh writable process open entered `state.schema.ensure` with `BEGIN IMMEDIATE`, even when the shared-state database was already canonical for the running OpenClaw version. A concurrent Telegram/Gateway state writer could therefore block an otherwise read-only schema check.

## Root Cause

Schema admission had no lock-free current-version path. The first PR revision added one, but its eligibility scanner duplicated same-version repair policy and treated normal pending delivery rows as repair debt. That common Telegram queue state still fell through to `BEGIN IMMEDIATE`.

`schema_meta.app_version` is the existing data-repair completion marker: `ensureSchema` updates it only after that release's additive repairs and backfills commit. Writable open separately owns same-version startup schema repair, including permitted missing or drifted canonical indexes. The retired `cron_run_logs` table is an additional owner-specific migration signal and must bypass the current-state fast path.

## Fix

- Validate supported/current schema version, integrity, and runtime shape inside one deferred SQLite read snapshot.
- Reuse the canonical startup-repair issue classifier; missing/drifted indexes and startup columns/tables fall through to writable repair.
- Reuse the cron migration owner's legacy-table predicate so retired cron history still imports before the table is dropped.
- Accept the remaining fast path only when `schema_meta.app_version` matches the running version.
- Commit the read snapshot, then recheck external shared-state ownership before returning the writable handle.
- Preserve the existing `BEGIN IMMEDIATE` migration/repair path for older versions, schema drift, startup repair, and legacy cron import.
- Remove the duplicated per-table/per-row repair scanner and its normal-state full scans.

The repaired branch removes 78 production lines from the previous PR head. Final PR delta versus its merge base: production +62 net, tests +102, tooling +1.

## Evidence

**HEAD:** `1ff9490fcd8dc5ed3bca4d663948a6454cbf051e`

### Regression

The owner-boundary regression creates a canonical pending Telegram delivery, closes the cached handle, holds an independent WAL `BEGIN IMMEDIATE`, then cold-opens through production `runWithOpenClawStateBusyTimeout(..., 0)`.

- Without the fast-path return: fails with `database is locked` at `BEGIN IMMEDIATE` (exit 1).
- Exact head: succeeds while the independent writer transaction remains active.
- Current-version missing/drifted index and startup-column fixtures still enter writable repair and pass.
- Existing ownership-race regression injects an external claim during validation and confirms `OpenClawStateOwnershipError` after the read snapshot commits.
- CI exposed the retired cron-table signal lost by the compact scanner. The exact legacy import test failed at `migration_runs` without the predicate and passes after the migration owner exports and reuses it.

### Local verification

```text
pnpm test src/state/openclaw-state-db.test.ts src/state/openclaw-state-ownership.test.ts src/state/openclaw-state-db-legacy-backfills.test.ts src/infra/state-migrations.cron-run-logs.test.ts src/agents/subagents/registry/subagent-registry.store.sqlite.test.ts src/agents/subagents/completion/subagent-completion-admission.store.test.ts
  6 files passed; 209 tests passed

OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --base 1fb4857e3cc24957b0e7bfadc525e35eb519a999 --head HEAD
  exit 0

pnpm lint:kysely
  passed

pnpm tsgo
  passed

pnpm check:test-types
  passed
```

The explicit merge base is required because `origin/main` was refreshed to an unrelated rewritten history during local verification. GitHub reports this PR as mergeable; the fast-lane policy does not require a rebase for `BEHIND` alone.

### CI

Exact-head Actions run [`32551809586`](https://github.com/openclaw/openclaw/actions/runs/32551809586): `SUCCESS`; required `openclaw/ci-gate`: `SUCCESS`.

### Exact-head review

Local ClawSweeper (`gpt-5.6-terra`, high): patch correct; 0 findings; 0 security concerns; no maintainer decision; 0 Rank-up moves.

### Telegram E2E

Final exact-head userbot run exercised the changed path after all code/review gates:

```text
scenario: state-database-writer-lock-fixed
writer transaction: BEGIN IMMEDIATE
busy timeout: 0 ms
observed: opened
expected: opened
scenario result: ok
Telegram expectation: OPENCLAW_E2E_OK
mock provider requests: 1
exit: 0
```

Redacted evidence: `.artifacts/telegram-pr126825.epp4b6/state-database-writer-lock/summary.json`, `events.ndjson`, and `mock-openai-requests.ndjson`.

## User Impact

Fresh processes can inspect and open healthy current-version shared state without joining the SQLite writer queue. Integrity checks, same-version startup repair, migrations, legacy cron import, and external supervisor ownership remain enforced.
