### PR TITLE
fix(ui): prevent stale tools and skills after reconnects

### DIFF
--- a/ui/src/lib/agents/index.test.ts
+++ b/ui/src/lib/agents/index.test.ts
@@ -6,6 +6,8 @@ import {
   createAgentCapability,
   loadToolsCatalog,
   loadToolsEffective,
+  refreshVisibleToolsEffectiveForCurrentSession,
+  resetToolsEffectiveState,
   setDefaultAgent,
 } from "./index.ts";
 import type { AgentsState } from "./index.ts";
@@ -16,10 +18,12 @@ type TestRequest = (method: string, payload?: unknown) => Promise<unknown>;
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 function createGatewayHarness(client: GatewayBrowserClient) {
@@ -534,6 +538,71 @@ describe("loadToolsEffective", () => {
     resolveNext({ agentId: "main", profile: "new", groups: [] });
     await nextLoad;
     expect(state.toolsEffectiveResult?.profile).toBe("new");
+    expect(state.toolsEffectiveLoading).toBe(false);
+  });
+
+  it("keeps the newest visible-session tools when an older response finishes last", async () => {
+    const { state, request } = createState();
+    const oldRequest = deferred<unknown>();
+    const currentRequest = deferred<unknown>();
+    request.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(currentRequest.promise);
+    state.agentsPanel = "tools";
+    state.sessionKey = "agent:main:older";
+
+    const staleLoad = refreshVisibleToolsEffectiveForCurrentSession(state);
+    state.sessionKey = "agent:main:current";
+    const currentLoad = refreshVisibleToolsEffectiveForCurrentSession(state);
+    currentRequest.resolve({ agentId: "main", profile: "current", groups: [] });
+    await currentLoad;
+    oldRequest.resolve({ agentId: "main", profile: "stale", groups: [] });
+    await staleLoad;
+
+    expect(state.toolsEffectiveResult?.profile).toBe("current");
+    expect(state.toolsEffectiveError).toBeNull();
+    expect(state.toolsEffectiveLoading).toBe(false);
+  });
+
+  it("ignores a retired visible-session failure after a newer tools response", async () => {
+    const { state, request } = createState();
+    const oldRequest = deferred<unknown>();
+    request.mockReturnValueOnce(oldRequest.promise).mockResolvedValueOnce({
+      agentId: "main",
+      profile: "current",
+      groups: [],
+    });
+    state.agentsPanel = "tools";
+    state.sessionKey = "agent:main:older";
+
+    const staleLoad = refreshVisibleToolsEffectiveForCurrentSession(state);
+    state.sessionKey = "agent:main:current";
+    await refreshVisibleToolsEffectiveForCurrentSession(state);
+    oldRequest.reject(new Error("retired connection failed"));
+    await staleLoad;
+
+    expect(state.toolsEffectiveResult?.profile).toBe("current");
+    expect(state.toolsEffectiveError).toBeNull();
+  });
+
+  it("retires an old tools request when the same session is reset and reloaded", async () => {
+    const { state, request } = createState();
+    const oldRequest = deferred<unknown>();
+    const currentRequest = deferred<unknown>();
+    request.mockReturnValueOnce(oldRequest.promise).mockReturnValueOnce(currentRequest.promise);
+    state.agentsPanel = "tools";
+    state.sessionKey = "agent:main:current";
+
+    const staleLoad = refreshVisibleToolsEffectiveForCurrentSession(state);
+    resetToolsEffectiveState(state);
+    const currentLoad = refreshVisibleToolsEffectiveForCurrentSession(state);
+    oldRequest.resolve({ agentId: "main", profile: "stale", groups: [] });
+    await staleLoad;
+
+    expect(state.toolsEffectiveResult).toBeNull();
+    expect(state.toolsEffectiveLoading).toBe(true);
+
+    currentRequest.resolve({ agentId: "main", profile: "current", groups: [] });
+    await currentLoad;
+    expect(state.toolsEffectiveResult?.profile).toBe("current");
     expect(state.toolsEffectiveLoading).toBe(false);
   });
 

--- a/ui/src/lib/agents/tools-effective.ts
+++ b/ui/src/lib/agents/tools-effective.ts
@@ -28,6 +28,9 @@ type ToolsEffectiveState = {
   toolsEffectiveResultKey?: string | null;
 };
 
+// Session/model keys can recur; only the exact dispatch may publish or retire its owner.
+const requestOwners = new WeakMap<ToolsEffectiveState, symbol>();
+
 export function buildToolsEffectiveRequestKey(
   state: Pick<ToolsEffectiveState, "sessions" | "sessionsResult" | "chatModelCatalog">,
   params: { agentId: string; sessionKey: string },
@@ -47,6 +50,7 @@ export async function loadToolsEffective(
     onError?: (error: unknown) => string;
   } = {},
 ) {
+  const client = state.client;
   const resolvedAgentId = params.agentId.trim();
   const resolvedSessionKey = params.sessionKey.trim();
   const requestKey = buildToolsEffectiveRequestKey(state, {
@@ -54,7 +58,7 @@ export async function loadToolsEffective(
     sessionKey: resolvedSessionKey,
   });
   if (
-    !state.client ||
+    !client ||
     !state.connected ||
     !resolvedAgentId ||
     !resolvedSessionKey ||
@@ -62,7 +66,13 @@ export async function loadToolsEffective(
   ) {
     return;
   }
-  const isCurrentRequest = () => options.isCurrent?.() ?? true;
+  const requestOwner = Symbol("effective-tools-request");
+  requestOwners.set(state, requestOwner);
+  const isCurrentRequest = () =>
+    state.client === client &&
+    state.connected &&
+    requestOwners.get(state) === requestOwner &&
+    (options.isCurrent?.() ?? true);
   const shouldIgnoreResponse = () =>
     !isCurrentRequest() || (options.ignoreResponse?.(resolvedAgentId, requestKey) ?? false);
   state.toolsEffectiveLoading = true;
@@ -71,7 +81,7 @@ export async function loadToolsEffective(
   state.toolsEffectiveError = null;
   state.toolsEffectiveResult = null;
   try {
-    const result = await state.client.request<ToolsEffectiveResult>("tools.effective", {
+    const result = await client.request<ToolsEffectiveResult>("tools.effective", {
       agentId: resolvedAgentId,
       sessionKey: resolvedSessionKey,
     });
@@ -87,6 +97,7 @@ export async function loadToolsEffective(
     state.toolsEffectiveError = options.onError?.(error) ?? formatUiError(error);
   } finally {
     if (isCurrentRequest() && state.toolsEffectiveLoadingKey === requestKey) {
+      requestOwners.delete(state);
       state.toolsEffectiveLoadingKey = null;
       state.toolsEffectiveLoading = false;
     }
@@ -94,6 +105,7 @@ export async function loadToolsEffective(
 }
 
 export function resetToolsEffectiveState(state: ToolsEffectiveState) {
+  requestOwners.delete(state);
   state.toolsEffectiveResult = null;
   state.toolsEffectiveResultKey = null;
   state.toolsEffectiveError = null;

--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -11,6 +11,7 @@ import type {
   ToolsEffectiveResult,
 } from "../../api/types.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { refreshVisibleToolsEffectiveForCurrentSession } from "../../lib/agents/index.ts";
 import type { AgentsPanel } from "../../lib/agents/panels.ts";
 import { invalidateChatMetadataStore } from "../../lib/chat/chat-metadata-store.ts";
 import { loadCronJobsPage, type CronState } from "../../lib/cron/index.ts";
@@ -34,6 +35,8 @@ type TestAgentsPage = HTMLElement & {
   agentIdentityLoading: boolean;
   agentSkillsError: string | null;
   readonly agentsPanel: AgentsPanel;
+  readonly sessions: ApplicationContext["sessions"];
+  toolsEffectiveError: string | null;
   toolsEffectiveLoading: boolean;
   toolsEffectiveResult: ToolsEffectiveResult | null;
   chatModelCatalog: ModelCatalogEntry[];
@@ -205,6 +208,30 @@ function pageContext(
 }
 
 describe("AgentsPage gateway lifecycle", () => {
+  it("retires visible-session effective tools across a same-client reconnect", async () => {
+    const staleResult = deferred<ToolsEffectiveResult>();
+    const client = { request: vi.fn(() => staleResult.promise) } as unknown as GatewayBrowserClient;
+    const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
+    page.context = pageContext(
+      gateway(snapshot(client)),
+      agentsCapability(async () => files("main", "unused")),
+    );
+    page.routeData = { panel: "tools" } as AgentsRouteData;
+    setPageGateway(page, client);
+    page.agentsSelectedId = "main";
+
+    const pending = refreshVisibleToolsEffectiveForCurrentSession(page);
+    expect(page.toolsEffectiveLoading).toBe(true);
+    setPageGateway(page, client, false);
+    setPageGateway(page, client);
+    staleResult.resolve({ profile: "retired-connection" } as ToolsEffectiveResult);
+    await pending;
+
+    expect(page.toolsEffectiveResult).toBeNull();
+    expect(page.toolsEffectiveError).toBeNull();
+    expect(page.toolsEffectiveLoading).toBe(false);
+  });
+
   it("does not stage a default-agent change after a same-client reconnect", async () => {
     const loading = deferred<void>();
     const client = {} as GatewayBrowserClient;

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -369,8 +369,7 @@ class AgentsPage
     this.agentSkillsLoading = false;
     this.toolsCatalogLoading = false;
     this.toolsCatalogLoadingAgentId = null;
-    this.toolsEffectiveLoading = false;
-    this.toolsEffectiveLoadingKey = null;
+    resetToolsEffectiveState(this);
     this.cron = {
       ...this.cron,
       cronLoading: false,

--- a/ui/src/pages/chat/chat-composer-capability-host.test.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.test.ts
@@ -37,6 +37,14 @@ function createState(): ChatPageHost {
   } as ChatPageHost;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("ChatComposerCapabilityHost", () => {
   it("adds an everywhere server globally without a session patch", async () => {
     const events: string[] = [];
@@ -364,6 +372,171 @@ describe("ChatComposerCapabilityHost", () => {
       expect(host.props(context, state, session, "main").toolsEffectiveResult).toBe(secondResult);
     });
     expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the newest tools after connector configuration changes away and back", async () => {
+    const host = new ChatComposerCapabilityHost(vi.fn());
+    const context = createContext({ appliedConfigHash: "config-a", runtimeConfig: {} });
+    context.gateway.snapshot.hello = gatewayHelloForMethods(["sessions.patch", "tools.effective"]);
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    const third = deferred<unknown>();
+    const request = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+      .mockReturnValueOnce(third.promise);
+    const state = createState();
+    state.client = { request } as unknown as GatewayBrowserClient;
+    const session = { key: "main" } as GatewaySessionRow;
+
+    host.props(context, state, session, "main").onOpenToolAccess?.("github");
+    context.runtimeConfig.state.configSnapshot = {
+      appliedConfigHash: "config-b",
+      runtimeConfig: {},
+    };
+    host.props(context, state, session, "main").onOpenToolAccess?.("github");
+    context.runtimeConfig.state.configSnapshot = {
+      appliedConfigHash: "config-a",
+      runtimeConfig: {},
+    };
+    host.props(context, state, session, "main").onOpenToolAccess?.("github");
+    expect(request).toHaveBeenCalledTimes(3);
+
+    third.resolve({ agentId: "main", profile: "newest-a", groups: [] });
+    await vi.waitFor(() => {
+      expect(host.props(context, state, session, "main").toolsEffectiveResult?.profile).toBe(
+        "newest-a",
+      );
+    });
+    first.resolve({ agentId: "main", profile: "stale-a", groups: [] });
+    await first.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(host.props(context, state, session, "main").toolsEffectiveResult?.profile).toBe(
+      "newest-a",
+    );
+    second.resolve({ agentId: "main", profile: "stale-b", groups: [] });
+  });
+
+  it("keeps a replacement tools request loading when its same-key predecessor finishes", async () => {
+    const host = new ChatComposerCapabilityHost(vi.fn());
+    const context = createContext({ appliedConfigHash: "config-a", runtimeConfig: {} });
+    context.gateway.snapshot.hello = gatewayHelloForMethods(["sessions.patch", "tools.effective"]);
+    const first = deferred<unknown>();
+    const second = deferred<unknown>();
+    const third = deferred<unknown>();
+    const request = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise)
+      .mockReturnValueOnce(third.promise);
+    const state = createState();
+    state.client = { request } as unknown as GatewayBrowserClient;
+    const session = { key: "main" } as GatewaySessionRow;
+
+    host.props(context, state, session, "main").onOpenToolAccess?.("github");
+    context.runtimeConfig.state.configSnapshot = {
+      appliedConfigHash: "config-b",
+      runtimeConfig: {},
+    };
+    host.props(context, state, session, "main").onOpenToolAccess?.("github");
+    context.runtimeConfig.state.configSnapshot = {
+      appliedConfigHash: "config-a",
+      runtimeConfig: {},
+    };
+    host.props(context, state, session, "main").onOpenToolAccess?.("github");
+    first.resolve({ agentId: "main", profile: "stale-a", groups: [] });
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(3));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(host.props(context, state, session, "main").toolsEffectiveResult).toBeNull();
+    expect(host.props(context, state, session, "main").toolsEffectiveLoading).toBe(true);
+
+    third.resolve({ agentId: "main", profile: "newest-a", groups: [] });
+    await vi.waitFor(() => {
+      expect(host.props(context, state, session, "main").toolsEffectiveResult?.profile).toBe(
+        "newest-a",
+      );
+    });
+    second.resolve({ agentId: "main", profile: "stale-b", groups: [] });
+  });
+
+  it("retires effective tools and requests across a same-client reconnect", async () => {
+    const host = new ChatComposerCapabilityHost(vi.fn());
+    const context = createContext({ appliedConfigHash: "config-a", runtimeConfig: {} });
+    context.gateway.snapshot.hello = gatewayHelloForMethods(["sessions.patch", "tools.effective"]);
+    const first = deferred<unknown>();
+    const current = deferred<unknown>();
+    const request = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(current.promise);
+    const state = createState();
+    state.client = { request } as unknown as GatewayBrowserClient;
+    state.connectionEpoch = 1;
+    const session = { key: "main" } as GatewaySessionRow;
+
+    host.props(context, state, session, "main").onOpenToolAccess?.("github");
+    state.connectionEpoch = 2;
+    const reconnected = host.props(context, state, session, "main");
+    expect(reconnected.toolsEffectiveResult).toBeNull();
+    expect(reconnected.toolsEffectiveLoading).toBe(false);
+    reconnected.onOpenToolAccess?.("github");
+    expect(request).toHaveBeenCalledTimes(2);
+
+    first.resolve({ agentId: "main", profile: "retired-connection", groups: [] });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(host.props(context, state, session, "main").toolsEffectiveResult).toBeNull();
+    expect(host.props(context, state, session, "main").toolsEffectiveLoading).toBe(true);
+
+    current.resolve({ agentId: "main", profile: "current-connection", groups: [] });
+    await vi.waitFor(() => {
+      expect(host.props(context, state, session, "main").toolsEffectiveResult?.profile).toBe(
+        "current-connection",
+      );
+    });
+  });
+
+  it("retires cached skills and their requests across a same-client reconnect", async () => {
+    const host = new ChatComposerCapabilityHost(vi.fn());
+    const context = createContext({ runtimeConfig: {} });
+    const first = deferred<unknown>();
+    const current = deferred<unknown>();
+    const request = vi.fn().mockReturnValueOnce(first.promise).mockReturnValueOnce(current.promise);
+    const state = createState();
+    state.client = { request } as unknown as GatewayBrowserClient;
+    state.connectionEpoch = 1;
+    const session = { key: "main" } as GatewaySessionRow;
+    const skill = (name: string) => ({
+      name,
+      skillKey: name,
+      disabled: false,
+      blockedByAllowlist: false,
+      missing: { anyBins: [], bins: [], env: [], config: [], os: [] },
+    });
+
+    host.props(context, state, session, "main").onLoadSkills?.();
+    state.connectionEpoch = 2;
+    const reconnected = host.props(context, state, session, "main");
+    expect(reconnected.skills).toBeNull();
+    expect(reconnected.skillsLoading).toBe(false);
+    reconnected.onLoadSkills?.();
+    expect(request).toHaveBeenCalledTimes(2);
+
+    first.resolve({ skills: [skill("retired")] });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(host.props(context, state, session, "main").skills).toBeNull();
+    expect(host.props(context, state, session, "main").skillsLoading).toBe(true);
+
+    current.resolve({ skills: [skill("current")] });
+    await vi.waitFor(() => {
+      expect(host.props(context, state, session, "main").skills?.map(({ name }) => name)).toEqual([
+        "current",
+      ]);
+    });
   });
 
   it("records an unexpected effective-tools loader rejection", async () => {

--- a/ui/src/pages/chat/chat-composer-capability-host.ts
+++ b/ui/src/pages/chat/chat-composer-capability-host.ts
@@ -83,8 +83,9 @@ export class ChatComposerCapabilityHost {
   private readonly patchTokens = new Map<string, symbol>();
   private effectiveTools: { key: string; result: ToolsEffectiveResult } | null = null;
   private effectiveToolsErrorKey: string | null = null;
-  private effectiveToolsLoadingKey: string | null = null;
+  private effectiveToolsRequest: { key: string; owner: symbol } | null = null;
   private client: GatewayBrowserClient | null = null;
+  private connectionEpoch: number | undefined;
   private addDialogOpen = false;
   private addScope: ComposerMcpServerScope = "session";
   private addBusy = false;
@@ -167,12 +168,19 @@ export class ChatComposerCapabilityHost {
     if (!state.connected || !client || this.skills.has(agentId) || this.loading.has(agentId)) {
       return;
     }
+    const connectionEpoch = state.connectionEpoch;
+    const isCurrent = () =>
+      state.client === client &&
+      this.client === client &&
+      state.connected &&
+      state.connectionEpoch === connectionEpoch &&
+      this.connectionEpoch === connectionEpoch;
     this.loadErrors.delete(agentId);
     this.loading.add(agentId);
     this.notify();
     void loadSkillStatusReport(client, agentId)
       .then((report) => {
-        if (report && state.client === client && this.client === client) {
+        if (report && isCurrent()) {
           this.skills.set(
             agentId,
             report.skills
@@ -182,12 +190,12 @@ export class ChatComposerCapabilityHost {
         }
       })
       .catch(() => {
-        if (state.client === client && this.client === client) {
+        if (isCurrent()) {
           this.loadErrors.add(agentId);
         }
       })
       .finally(() => {
-        if (this.client === client) {
+        if (isCurrent()) {
           this.loading.delete(agentId);
           this.notify();
         }
@@ -226,11 +234,14 @@ export class ChatComposerCapabilityHost {
       !state.connected ||
       !client ||
       this.effectiveTools?.key === cacheKey ||
-      this.effectiveToolsLoadingKey === cacheKey ||
+      this.effectiveToolsRequest?.key === cacheKey ||
       (!retryError && this.effectiveToolsErrorKey === cacheKey)
     ) {
       return;
     }
+    const requestOwner = Symbol("composer-effective-tools-request");
+    const connectionEpoch = state.connectionEpoch;
+    this.effectiveToolsRequest = { key: cacheKey, owner: requestOwner };
     const loader = {
       chatModelCatalog: state.chatModelCatalog,
       client,
@@ -244,13 +255,15 @@ export class ChatComposerCapabilityHost {
       toolsEffectiveResultKey: null as string | null,
     };
     const isCurrent = () =>
+      this.effectiveToolsRequest?.owner === requestOwner &&
       this.client === client &&
       state.client === client &&
       state.connected &&
+      this.connectionEpoch === connectionEpoch &&
+      state.connectionEpoch === connectionEpoch &&
       state.sessionKey === sessionKey &&
       this.effectiveToolsKeys(context, state, agentId).cacheKey === cacheKey;
     this.effectiveToolsErrorKey = null;
-    this.effectiveToolsLoadingKey = cacheKey;
     this.notify();
     void loadToolsEffective(loader, { agentId, sessionKey }, { isCurrent })
       .then(() => {
@@ -269,11 +282,11 @@ export class ChatComposerCapabilityHost {
         }
       })
       .finally(() => {
-        if (this.effectiveToolsLoadingKey === cacheKey) {
-          this.effectiveToolsLoadingKey = null;
-        }
-        if (this.client === client) {
-          this.notify();
+        if (this.effectiveToolsRequest?.owner === requestOwner) {
+          this.effectiveToolsRequest = null;
+          if (this.client === client && this.connectionEpoch === connectionEpoch) {
+            this.notify();
+          }
         }
       });
   }
@@ -555,15 +568,16 @@ export class ChatComposerCapabilityHost {
     session: GatewaySessionRow | undefined,
     agentId: string,
   ): CapabilityMenuProps {
-    if (this.client !== state.client) {
+    if (this.client !== state.client || this.connectionEpoch !== state.connectionEpoch) {
       this.client = state.client;
+      this.connectionEpoch = state.connectionEpoch;
       this.skills.clear();
       this.loading.clear();
       this.loadErrors.clear();
       this.patchTokens.clear();
       this.effectiveTools = null;
       this.effectiveToolsErrorKey = null;
-      this.effectiveToolsLoadingKey = null;
+      this.effectiveToolsRequest = null;
     }
     // Sparse session overrides resolve against active runtime defaults, so display and key
     // removal decisions must use the same runtime snapshot that executes the session.
@@ -580,7 +594,7 @@ export class ChatComposerCapabilityHost {
         ? this.effectiveTools.result
         : null;
     const toolsEffectiveLoading =
-      effectiveToolsKey !== null && this.effectiveToolsLoadingKey === effectiveToolsKey;
+      effectiveToolsKey !== null && this.effectiveToolsRequest?.key === effectiveToolsKey;
     const toolsEffectiveError =
       effectiveToolsKey !== null && this.effectiveToolsErrorKey === effectiveToolsKey;
     const capabilitiesReady = gatewayAvailable && session !== undefined && runtimeConfig !== null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users changing agents, sessions, models, or connector configuration could see an older tools response overwrite the current tools in the Agents page or chat composer. A Gateway reconnect using the same browser client could also retain obsolete tools or skills, let a retired request overwrite the new connection, or leave a newer request's loading state stuck.

## Why This Change Was Made

The shared effective-tools loader now binds every publication, error, and cleanup to its exact dispatch and captured Gateway client; its canonical reset retires that owner. The Agents page uses the same canonical reset when a Gateway connection changes, including reconnects that retain the browser-client object.

The chat composer owns a separate persistent request claim because each call constructs an ephemeral shared-loader state. Its tools and skills now also track the existing logical connection epoch, so an A → B → A configuration sequence or same-client reconnect cannot revive retired requests or cached capabilities. Existing current-request success, error retry, loading, session scope, and skill behavior stay unchanged.

## User Impact

Agent and chat capability menus always describe the current session, model, connector configuration, and Gateway connection. Obsolete responses cannot overwrite current tools, resurrect retired skills, report stale failures, or clear a newer request's loading indicator.

## Evidence

- Authentic regression-first proof: seven existing public-owner tests failed against baseline for stale visible-session success/error, same-key reset ownership, composer A → B → A publication/loading, and reconnect tools/skills; the independently discovered eighth failure exercised a real mounted Agents page and its actual GatewayPageController same-client disconnect/reconnect.
- Final focused Agents, shared-loader, skills, composer, Gateway lifecycle, and provider sibling suites: **138 tests passed across six suites**.
- ClawSweeper browser-proof rank-up was explicitly attempted on the exact reviewed head with the existing focused Chromium/Vite mocked-Gateway composer scenario. Its global setup failed before any browser scenario ran because Rolldown cannot resolve the existing unrelated `@panzoom/panzoom` import in `ui/src/components/image-lightbox.ts`; dependency installation into a linked worktree is prohibited. Same-client reconnect is instead proven directly through the mounted `AgentsPage` and its actual `GatewayPageController` disconnect/reconnect, while public composer regressions independently cover A → B → A ownership, visible loading, and both tools/skills across connection epochs. This is concrete owner-boundary coverage, not a claim that a browser scenario passed.
- Both repository ratchets pass: assertion-safety and max-lines. The new Agents-page regression remains under the existing 1,000-line lint limit without suppressions.
- Targeted oxlint, oxfmt, and `git diff --check` pass.
- Fresh authenticated full-diff Codex autoreview and a separate independent owner-boundary review found no actionable issues; the independent reviewer discovered the real Agents-page reconnect hole, which is now covered by its own demonstrated failing/passing regression.
- Exact validated head: `daaa896fee1e5f50590b18750b4ba8f11a6a1b65`.
- Production: +44/-19, net +25. Growth is required for the previously missing authoritative per-dispatch client/request claim and logical connection epoch across the two actual publication owners; the Agents-page owner itself shrank by one production line. Regression tests: +271/-2.
- No UI layout changes. Static screenshots cannot expose this asynchronous request-ownership race; the real mounted Agents-page/Gateway-controller and public chat-composer capability contracts directly prove the user interaction, response ordering, reconnect, visible result, and loading state.
- No public API, configuration, Gateway protocol, persistence, dependency, or security-boundary changes.

AI-assisted; reviewed against source owners, direct callers, sibling lifecycles, actual reconnect producer, and current main.
