### PR TITLE
fix(plugin-state): bound expired row cleanup

### DIFF
--- a/src/plugin-state/plugin-state-store.expiry.test.ts
+++ b/src/plugin-state/plugin-state-store.expiry.test.ts
@@ -1,0 +1,212 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
+  countPluginStateLiveEntries,
+  createPluginStateKeyedStore,
+  createPluginStateSyncKeyedStore,
+  resetPluginStateStoreForTests,
+  sweepExpiredPluginStateEntries,
+} from "./plugin-state-store.js";
+import {
+  clearPluginStateStoreForTests,
+  seedPluginStateEntriesForTests,
+  setMaxPluginStateEntriesPerPluginForTests,
+} from "./plugin-state-store.test-helpers.js";
+
+let testState: OpenClawTestState | undefined;
+
+beforeAll(async () => {
+  testState = await createOpenClawTestState({ label: "plugin-state-expiry" });
+});
+
+beforeEach(() => {
+  testState?.applyEnv();
+  clearPluginStateStoreForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  setMaxPluginStateEntriesPerPluginForTests(undefined);
+  resetPluginStateStoreForTests({ closeDatabase: false });
+});
+
+afterAll(async () => {
+  resetPluginStateStoreForTests();
+  await testState?.cleanup();
+});
+
+describe("plugin state expiry cleanup", () => {
+  it("registerIfAbsent replaces an expired target beyond the namespace cleanup batch", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_200);
+    seedPluginStateEntriesForTests([
+      ...Array.from({ length: 1_025 }, (_, index) => ({
+        pluginId: "discord",
+        namespace: "claims-batched-expiry",
+        key: `expired-${String(index).padStart(4, "0")}`,
+        value: { index },
+        createdAt: index,
+        expiresAt: 1_100,
+      })),
+      {
+        pluginId: "discord",
+        namespace: "claims-batched-expiry",
+        key: "zz-target",
+        value: { version: 1 },
+        createdAt: 5_000,
+        expiresAt: 1_100,
+      },
+    ]);
+    const store = createPluginStateKeyedStore<{ version: number }>("discord", {
+      namespace: "claims-batched-expiry",
+      maxEntries: 10,
+    });
+
+    await expect(store.registerIfAbsent("zz-target", { version: 2 })).resolves.toBe(true);
+    await expect(store.lookup("zz-target")).resolves.toEqual({ version: 2 });
+    expect(sweepExpiredPluginStateEntries()).toBe(1);
+  });
+
+  it("sweeps expired plugin state in bounded batches without touching live rows", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(3_000);
+    seedPluginStateEntriesForTests([
+      ...Array.from({ length: 2_050 }, (_, index) => ({
+        pluginId: index % 2 === 0 ? "discord" : "telegram",
+        namespace: "batched-expiry",
+        key: `expired-${index}`,
+        value: { index },
+        expiresAt: 1_000 + Math.floor(index / 2),
+      })),
+      {
+        pluginId: "discord",
+        namespace: "batched-expiry",
+        key: "permanent",
+        value: { durable: true },
+      },
+      {
+        pluginId: "discord",
+        namespace: "batched-expiry",
+        key: "live",
+        value: { live: true },
+        expiresAt: 4_000,
+      },
+      {
+        pluginId: "sibling-plugin",
+        namespace: "batched-expiry",
+        key: "permanent",
+        value: { sibling: true },
+      },
+    ]);
+
+    expect(sweepExpiredPluginStateEntries()).toBe(1_024);
+    expect(sweepExpiredPluginStateEntries()).toBe(1_024);
+    expect(sweepExpiredPluginStateEntries()).toBe(2);
+    expect(sweepExpiredPluginStateEntries()).toBe(0);
+
+    const store = createPluginStateKeyedStore("discord", {
+      namespace: "batched-expiry",
+      maxEntries: 10,
+    });
+    const sibling = createPluginStateKeyedStore("sibling-plugin", {
+      namespace: "batched-expiry",
+      maxEntries: 10,
+    });
+    await expect(store.lookup("permanent")).resolves.toEqual({ durable: true });
+    await expect(store.lookup("live")).resolves.toEqual({ live: true });
+    await expect(sibling.lookup("permanent")).resolves.toEqual({ sibling: true });
+  });
+
+  it.each(["register", "update"] as const)(
+    "bounds expired namespace cleanup during %s without touching sibling rows",
+    async (operation) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_200);
+      seedPluginStateEntriesForTests([
+        ...Array.from({ length: 1_031 }, (_, index) => ({
+          pluginId: "discord",
+          namespace: "namespace-batched-expiry",
+          key: `expired-${index}`,
+          value: { index },
+          expiresAt: 1_100,
+        })),
+        {
+          pluginId: "discord",
+          namespace: "namespace-batched-expiry",
+          key: "permanent",
+          value: { durable: true },
+        },
+        {
+          pluginId: "discord",
+          namespace: "sibling-namespace",
+          key: "expired",
+          value: { sibling: true },
+          expiresAt: 1_100,
+        },
+        {
+          pluginId: "sibling-plugin",
+          namespace: "namespace-batched-expiry",
+          key: "expired",
+          value: { sibling: true },
+          expiresAt: 1_100,
+        },
+      ]);
+      const store = createPluginStateSyncKeyedStore<{ durable?: boolean; fresh?: boolean }>(
+        "discord",
+        { namespace: "namespace-batched-expiry", maxEntries: 10 },
+      );
+
+      if (operation === "register") {
+        store.register("fresh", { fresh: true });
+      } else {
+        expect(store.update?.("fresh", () => ({ fresh: true }))).toBe(true);
+      }
+
+      expect(store.lookup("fresh")).toEqual({ fresh: true });
+      expect(store.lookup("permanent")).toEqual({ durable: true });
+      expect(sweepExpiredPluginStateEntries()).toBe(9);
+    },
+  );
+
+  it("rolls back bounded expiry cleanup when the enclosing namespace write fails", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_200);
+    setMaxPluginStateEntriesPerPluginForTests(2);
+    seedPluginStateEntriesForTests([
+      ...Array.from({ length: 1_031 }, (_, index) => ({
+        pluginId: "discord",
+        namespace: "rollback-expiry",
+        key: `expired-${index}`,
+        value: { index },
+        expiresAt: 1_100,
+      })),
+      {
+        pluginId: "discord",
+        namespace: "durable-sibling",
+        key: "first",
+        value: { durable: 1 },
+      },
+      {
+        pluginId: "discord",
+        namespace: "durable-sibling",
+        key: "second",
+        value: { durable: 2 },
+      },
+    ]);
+    const store = createPluginStateKeyedStore("discord", {
+      namespace: "rollback-expiry",
+      maxEntries: 10,
+    });
+
+    await expect(store.register("fresh", { fresh: true })).rejects.toMatchObject({
+      code: "PLUGIN_STATE_LIMIT_EXCEEDED",
+    });
+    expect(sweepExpiredPluginStateEntries()).toBe(1_024);
+    expect(sweepExpiredPluginStateEntries()).toBe(7);
+    await expect(store.lookup("fresh")).resolves.toBeUndefined();
+    expect(countPluginStateLiveEntries("discord")).toBe(2);
+  });
+});

--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -32,6 +32,7 @@ import {
 // Plugin-wide fuse only; namespace maxEntries still owns normal cache eviction.
 export const MAX_PLUGIN_STATE_VALUE_BYTES = 65_536;
 export const MAX_PLUGIN_STATE_ENTRIES_PER_PLUGIN = 50_000;
+const PLUGIN_STATE_EXPIRY_BATCH_ROWS = 1_024;
 let maxPluginStateEntriesPerPluginForTests: number | undefined;
 
 type PluginStateEntriesTable = OpenClawStateKyselyDatabase["plugin_state_entries"];
@@ -265,19 +266,39 @@ function deletePluginStateEntry(
   return Number(result.numAffectedRows ?? 0);
 }
 
-function deleteExpiredPluginStateNamespaceEntries(
+function deleteExpiredPluginStateEntries(
   db: DatabaseSync,
-  params: { pluginId: string; namespace: string; now: number },
-): void {
-  executeSqliteQuerySync(
+  now: number,
+  scope?: { pluginId: string; namespace: string },
+): number {
+  const kysely = getPluginStateKysely(db);
+  let expiredEntries = kysely
+    .selectFrom("plugin_state_entries")
+    .select(["plugin_id", "namespace", "entry_key"])
+    .where("expires_at", "is not", null)
+    .where("expires_at", "<=", now);
+  // Global expiry ordering uses its index; namespace scans must stay unsorted
+  // so SQLite never builds an unbounded temporary sort under the write lock.
+  expiredEntries = scope
+    ? expiredEntries
+        .where("plugin_id", "=", scope.pluginId)
+        .where("namespace", "=", scope.namespace)
+    : expiredEntries.orderBy("expires_at", "asc");
+  const result = executeSqliteQuerySync(
     db,
-    getPluginStateKysely(db)
+    kysely
       .deleteFrom("plugin_state_entries")
-      .where("plugin_id", "=", params.pluginId)
-      .where("namespace", "=", params.namespace)
-      .where("expires_at", "is not", null)
-      .where("expires_at", "<=", params.now),
+      .where((expression) =>
+        expression(
+          expression.refTuple("plugin_id", "namespace", "entry_key"),
+          "in",
+          expiredEntries
+            .limit(PLUGIN_STATE_EXPIRY_BATCH_ROWS)
+            .$asTuple("plugin_id", "namespace", "entry_key"),
+        ),
+      ),
   );
+  return Number(result.numAffectedRows ?? 0);
 }
 
 function countLivePluginStateNamespaceEntries(
@@ -355,17 +376,6 @@ function deleteOldestPluginStateNamespaceEntries(
       key: row.entry_key,
     });
   }
-}
-
-function sweepExpiredPluginStateEntriesFromDatabase(db: DatabaseSync, now: number): number {
-  const result = executeSqliteQuerySync(
-    db,
-    getPluginStateKysely(db)
-      .deleteFrom("plugin_state_entries")
-      .where("expires_at", "is not", null)
-      .where("expires_at", "<=", now),
-  );
-  return Number(result.numAffectedRows ?? 0);
 }
 
 function openPluginStateDatabase(
@@ -608,10 +618,9 @@ export function pluginStateRegister(params: {
           operation: "register",
           path: store.path,
         });
-        deleteExpiredPluginStateNamespaceEntries(store.db, {
+        deleteExpiredPluginStateEntries(store.db, now, {
           pluginId: params.pluginId,
           namespace: params.namespace,
-          now,
         });
         const existing = selectPluginStateEntry(store.db, {
           pluginId: params.pluginId,
@@ -683,15 +692,13 @@ export function pluginStateRegisterSequencedJournalEntry(params: {
       "register",
       (store) => {
         const now = Date.now();
-        deleteExpiredPluginStateNamespaceEntries(store.db, {
+        deleteExpiredPluginStateEntries(store.db, now, {
           pluginId: params.pluginId,
           namespace: params.cursorNamespace,
-          now,
         });
-        deleteExpiredPluginStateNamespaceEntries(store.db, {
+        deleteExpiredPluginStateEntries(store.db, now, {
           pluginId: params.pluginId,
           namespace: params.journalNamespace,
-          now,
         });
         const cursor = selectPluginStateEntry(store.db, {
           pluginId: params.pluginId,
@@ -818,10 +825,9 @@ export function pluginStateRegisterIfAbsent(params: {
           operation: "register",
           path: store.path,
         });
-        deleteExpiredPluginStateNamespaceEntries(store.db, {
+        deleteExpiredPluginStateEntries(store.db, now, {
           pluginId: params.pluginId,
           namespace: params.namespace,
-          now,
         });
         const existing = selectPluginStateEntry(store.db, {
           pluginId: params.pluginId,
@@ -832,6 +838,9 @@ export function pluginStateRegisterIfAbsent(params: {
         if (existing) {
           return false;
         }
+        // The exact expired key can lie beyond this namespace's cleanup batch.
+        // Reclaim it inside the same authoritative transaction before insertion.
+        deletePluginStateEntry(store.db, params);
         assertCanInsertPluginStateEntry({
           store,
           pluginId: params.pluginId,
@@ -891,10 +900,9 @@ export function pluginStateUpdate(params: {
       "register",
       (store) => {
         const now = Date.now();
-        deleteExpiredPluginStateNamespaceEntries(store.db, {
+        deleteExpiredPluginStateEntries(store.db, now, {
           pluginId: params.pluginId,
           namespace: params.namespace,
-          now,
         });
         const existing = selectPluginStateEntry(store.db, {
           pluginId: params.pluginId,
@@ -1199,7 +1207,7 @@ export function pluginStateClear(params: {
 export function sweepExpiredPluginStateEntries(): number {
   try {
     return runWriteTransaction("sweep", ({ db }) =>
-      sweepExpiredPluginStateEntriesFromDatabase(db, Date.now()),
+      deleteExpiredPluginStateEntries(db, Date.now()),
     );
   } catch (error) {
     throw wrapPluginStateError(

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -11,6 +11,7 @@ import {
   setHeartbeatWakeHandler,
   type HeartbeatWakeRequest,
 } from "../infra/heartbeat-wake.js";
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import type { SessionBindingRecord } from "../infra/outbound/session-binding-service.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 import {
@@ -18,6 +19,7 @@ import {
   resetPluginStateStoreForTests,
   sweepExpiredPluginStateEntries,
 } from "../plugin-state/plugin-state-store.js";
+import { seedPluginStateEntriesForTests } from "../plugin-state/plugin-state-store.test-helpers.js";
 import {
   beginGatewayRestartSignalAdmission,
   getActiveGatewayRootWorkCount,
@@ -26,6 +28,8 @@ import {
   tryBeginGatewaySuspendAdmission,
 } from "../process/gateway-work-admission.js";
 import type { ParsedAgentSessionKey } from "../routing/session-key.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { CRON_TASK_KIND } from "./cron-task-contract.js";
@@ -560,7 +564,7 @@ describe("task-registry", () => {
     hoisted.killSubagentRunAdminMock.mockReset();
   });
 
-  it("sweeps expired plugin state after restart before a plugin namespace reopens", async () => {
+  it("sweeps one expired plugin-state batch per maintenance pass after restart", async () => {
     await withTaskRegistryTempDir(async () => {
       try {
         vi.useFakeTimers();
@@ -570,12 +574,39 @@ describe("task-registry", () => {
           maxEntries: 10,
         });
         await store.register("expired", { value: "stale" }, { ttlMs: 100 });
+        seedPluginStateEntriesForTests(
+          Array.from({ length: 2_049 }, (_, index) => ({
+            pluginId: "fixture-plugin",
+            namespace: "maintenance-restart",
+            key: `expired-${index}`,
+            value: { index },
+            expiresAt: 1_100,
+          })),
+        );
 
         // Close plugin-state's process-local handle while preserving the shared SQLite file.
         resetPluginStateStoreForTests();
         vi.setSystemTime(1_200);
+        const countExpiredRows = () => {
+          const database = openOpenClawStateDatabase();
+          const row = executeSqliteQueryTakeFirstSync(
+            database.db,
+            getNodeSqliteKysely<Pick<OpenClawStateKyselyDatabase, "plugin_state_entries">>(
+              database.db,
+            )
+              .selectFrom("plugin_state_entries")
+              .select((expression) => expression.fn.countAll<number>().as("count"))
+              .where("expires_at", "is not", null)
+              .where("expires_at", "<=", Date.now()),
+          );
+          return row?.count;
+        };
         await runTaskRegistryMaintenance();
+        expect(countExpiredRows()).toBe(1_026);
+        await runTaskRegistryMaintenance();
+        expect(countExpiredRows()).toBe(2);
 
+        expect(sweepExpiredPluginStateEntries()).toBe(2);
         expect(sweepExpiredPluginStateEntries()).toBe(0);
       } finally {
         resetPluginStateStoreForTests();


### PR DESCRIPTION
Closes #126819

## What Problem This Solves

Fixes an issue where plugin state writes and background task maintenance could stall the shared SQLite database and event loop when expired keyed plugin-state records accumulated. Before this change, one global maintenance invocation deleted all 2,050 expired fixture rows in a single synchronous write transaction, while a namespace write deleted all 1,031 expired rows in its namespace. Task maintenance invokes that global cleanup after its existing task-event yielding, so its previous yielding could not bound the plugin-state work.

## Why This Change Was Made

Consolidate duplicate keyed-state expiry policies into one private, synchronous Kysely owner helper that deletes at most 1,024 composite-primary-key rows per existing invocation. Global cleanup orders only by expiry and uses the existing expiry index; namespace cleanup stays unordered and uses the existing namespace listing index. Keyed `registerIfAbsent` explicitly reclaims its exact expired key inside the same authoritative write transaction before `INSERT OR IGNORE`, preserving atomic replacement even when that target lies beyond the current cleanup batch.

This does not change task scheduling or yielding, TTL visibility, live-row quotas, compare-and-set results, permanent records, namespace isolation, BLOB/artifact ownership, public APIs, configuration, database schema, indexes, or migrations.

## User Impact

Operators retain the same plugin-state and task-maintenance behavior while large expired-row backlogs are reclaimed gradually across normal writes or maintenance passes instead of monopolizing the shared state database writer and Gateway event loop.

## Evidence

- Before repair, new real-SQLite owner regressions observed global cleanup deleting `2,050` rows instead of `1,024`, namespace register/update deleting all `1,031` expired rows, and task maintenance leaving `0` rows after two invocations instead of `2`.
- After repair, successive global sweep counts are `1,024`, `1,024`, `2`, `0`; live TTL rows, permanent rows, and other plugins survive.
- Namespace register/update remove one batch, leave seven namespace-expired rows, and preserve both sibling namespace and sibling-plugin rows.
- Atomic `registerIfAbsent` replaces an exact expired key positioned beyond the first namespace batch without overwriting live claims.
- A failed namespace write rolls its bounded cleanup back, preserving all `1,031` expired rows and permanent sibling records.
- Real task-maintenance invocations leave `1,026` and then `2` expired rows, proving exactly one bounded batch per invocation without changing task order or yielding.
- Capturing the actual production-generated SQL and running `EXPLAIN QUERY PLAN` against a fresh shared SQLite database proves `idx_plugin_state_expiry` for global cleanup, `idx_plugin_state_listing` for namespace cleanup, composite-primary-key deletion, and no temporary sort.
- `node scripts/run-vitest.mjs src/plugin-state/plugin-state-store.expiry.test.ts src/plugin-state/plugin-state-store.test.ts src/plugin-state/plugin-blob-store.test.ts src/tasks/task-registry.test.ts src/state/sqlite-query-plan.test.ts` — **192 tests passed**, including unchanged BLOB behavior and existing SQLite index plans.
- `node scripts/check-changed.mjs -- src/plugin-state/plugin-state-store.sqlite.ts src/plugin-state/plugin-state-store.expiry.test.ts src/tasks/task-registry.test.ts`
- Fresh Codex-backed P1 autoreview: clean. Separate adversarial read-only review: no P0/P1/P2 findings; independently reproduced indexes, no sort opcodes, exact replacement, rollback, and batch counts.
- Production LOC: `+39/-31` (net `+8`); tests: `+244/-1` (net `+243`). The eight production lines implement bounded indexed composite-key cleanup and preserve the documented expired-key atomic replacement contract while removing the duplicate global cleanup path.
- Risk: low; the change only bounds work already performed inside existing owner transactions. No schema, configuration, scheduling, BLOB, security, or product-policy changes.
- AI-assisted: yes.
