### PR TITLE
refactor(sandbox): canonicalize backend ownership

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -965,7 +965,7 @@ extensions/openrouter/stream.ts	8
 extensions/openrouter/usage.ts	2
 extensions/openrouter/video-generation-provider.ts	1
 extensions/openrouter/video-model-catalog.ts	1
-extensions/openshell/src/backend.ts	3
+extensions/openshell/src/backend.ts	2
 extensions/openshell/src/config.ts	1
 extensions/openshell/src/fs-bridge.ts	2
 extensions/parallel/src/parallel-free-web-search-provider.runtime.ts	1

--- a/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server/processes.ts
@@ -4,7 +4,7 @@
  */
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { sanitizeEnvVars } from "openclaw/plugin-sdk/sandbox";
+import { buildRemoteCommand, sanitizeEnvVars } from "openclaw/plugin-sdk/sandbox";
 import type { WebSocket } from "ws";
 import type { JsonObject, JsonValue } from "../protocol.js";
 import { requireObject, requireString, requireStringArray } from "./json-rpc.js";
@@ -98,7 +98,7 @@ async function runProcess(
   throwIfProcessStartCancelled(managed);
   const remoteExec = prepareSandboxChildExec(backend, params.env);
   const execSpec = await backend.buildExecSpec({
-    command: shellCommandFromArgv(params.argv),
+    command: buildRemoteCommand(params.argv),
     workdir: params.cwd,
     env: remoteExec.env,
     // This bridge currently owns only pipe-backed child processes. Asking the
@@ -336,14 +336,6 @@ function notifyProcessWaiters(managed: ManagedProcess): void {
 
 function hasChunksAtOrAfter(managed: ManagedProcess, afterSeq: number): boolean {
   return managed.chunks.some((chunk) => chunk.seq > afterSeq);
-}
-
-function shellCommandFromArgv(argv: string[]): string {
-  return argv.map(shellEscape).join(" ");
-}
-
-function shellEscape(value: string): string {
-  return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
 
 function requireProcess(processes: Map<string, ManagedProcess>, processId: string): ManagedProcess {

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -276,60 +276,12 @@ async function createOpenShellSandboxBackend(params: {
     remoteWorkspaceDir: params.pluginConfig.remoteWorkspaceDir,
     remoteAgentWorkspaceDir: params.pluginConfig.remoteAgentWorkspaceDir,
   });
-
-  return {
-    id: "openshell",
-    runtimeId: sandboxName,
-    runtimeLabel: sandboxName,
-    workdir: params.pluginConfig.remoteWorkspaceDir,
-    env: params.createParams.cfg.docker.env,
-    mode: params.pluginConfig.mode,
-    configLabel: params.pluginConfig.from,
-    configLabelKind: "Source",
-    workdirValidation: "backend",
-    validateWorkdir: async (workdir) => await impl.validateWorkdir(workdir),
-    discardPreparedWorkdir: (workdir) => impl.discardPreparedWorkdir(workdir),
-    workdirRoots: [
-      params.pluginConfig.remoteWorkspaceDir,
-      params.pluginConfig.remoteAgentWorkspaceDir,
-    ],
-    buildExecSpec: async ({ command, workdir, env, usePty }) => {
-      const pending = await impl.prepareExec({ command, workdir, env, usePty });
-      return {
-        argv: pending.argv,
-        env: buildOpenShellSshExecEnv(),
-        stdinMode: "pipe-open",
-        finalizeToken: pending.token,
-      };
-    },
-    finalizeExec: async ({ token }) => {
-      await impl.finalizeExec(token as PendingExec | undefined);
-    },
-    runShellCommand: async (command) => await impl.runRemoteShellScript(command),
-    createFsBridge: ({ sandbox }) =>
-      params.pluginConfig.mode === "remote"
-        ? createRemoteShellSandboxFsBridge({
-            sandbox,
-            runtime: impl.asHandle(),
-          })
-        : createOpenShellFsBridge({
-            sandbox,
-            backend: impl.asHandle(),
-          }),
-    remoteWorkspaceDir: params.pluginConfig.remoteWorkspaceDir,
-    remoteAgentWorkspaceDir: params.pluginConfig.remoteAgentWorkspaceDir,
-    runRemoteShellScript: async (command) => await impl.runRemoteShellScript(command),
-    mkdirpRemotePath: async (remotePath, signal) => await impl.mkdirpRemotePath(remotePath, signal),
-    removeRemotePath: async (remotePath, removeParams) =>
-      await impl.removeRemotePath(remotePath, removeParams),
-    renameRemotePath: async (fromRemotePath, toRemotePath, signal) =>
-      await impl.renameRemotePath(fromRemotePath, toRemotePath, signal),
-    syncLocalPathToRemote: async (localPath, remotePath) =>
-      await impl.syncLocalPathToRemote(localPath, remotePath),
-  };
+  return impl.asHandle();
 }
 
 class OpenShellSandboxBackendImpl {
+  // Filesystem bridges must retain the same lifecycle owner returned by the factory.
+  private handle: OpenShellSandboxBackend | null = null;
   private ensurePromise: Promise<void> | null = null;
   private preparedRemoteWorkspaceForNextExec: {
     workdir: string;
@@ -348,7 +300,10 @@ class OpenShellSandboxBackendImpl {
   ) {}
 
   asHandle(): OpenShellSandboxBackend {
-    return {
+    if (this.handle) {
+      return this.handle;
+    }
+    const handle: OpenShellSandboxBackend = {
       id: "openshell",
       runtimeId: this.params.execContext.sandboxName,
       runtimeLabel: this.params.execContext.sandboxName,
@@ -380,11 +335,11 @@ class OpenShellSandboxBackendImpl {
         this.params.execContext.config.mode === "remote"
           ? createRemoteShellSandboxFsBridge({
               sandbox,
-              runtime: this.asHandle(),
+              runtime: handle,
             })
           : createOpenShellFsBridge({
               sandbox,
-              backend: this.asHandle(),
+              backend: handle,
             }),
       runRemoteShellScript: async (command) => await this.runRemoteShellScript(command),
       mkdirpRemotePath: async (remotePath, signal) =>
@@ -396,6 +351,8 @@ class OpenShellSandboxBackendImpl {
       syncLocalPathToRemote: async (localPath, remotePath) =>
         await this.syncLocalPathToRemote(localPath, remotePath),
     };
+    this.handle = handle;
+    return handle;
   }
 
   async prepareExec(params: {

--- a/extensions/openshell/src/cli.ts
+++ b/extensions/openshell/src/cli.ts
@@ -8,6 +8,7 @@ import {
 import type { ResolvedOpenShellPluginConfig } from "./config.js";
 
 export {
+  buildRemoteCommand,
   buildRemoteWorkdirValidationCommand,
   buildValidatedExecRemoteCommand,
 } from "openclaw/plugin-sdk/sandbox";
@@ -30,10 +31,6 @@ function buildOpenShellBaseArgv(config: ResolvedOpenShellPluginConfig): string[]
     argv.push("--workspace", config.workspace);
   }
   return argv;
-}
-
-export function buildRemoteCommand(argv: string[]): string {
-  return argv.map((entry) => shellEscape(entry)).join(" ");
 }
 
 function applyGatewayEndpointToSshConfig(params: {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -869,6 +869,64 @@ describe("openshell fs bridges", () => {
   afterAll(uninstallOpenShellBackendMocks);
   beforeEach(resetOpenShellBackendMocks);
 
+  it.each(["remote", "mirror"] as const)(
+    "keeps the factory backend as the canonical owner of the %s filesystem bridge",
+    async (mode) => {
+      await using workspace = await createOpenShellTestWorkspace("fs-owner");
+      const workspaceDir = workspace.dir;
+      sandboxMocks.remoteRoot = workspaceDir;
+      sandboxMocks.remoteAgentRoot = workspaceDir;
+      cliMocks.runOpenShellCli.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+      const factory = createOpenShellSandboxBackendFactory({
+        pluginConfig: resolveOpenShellPluginConfig({ command: "openshell", mode }),
+      });
+      const backend = (await factory({
+        sessionKey: "agent:main:turn",
+        scopeKey: "agent:main",
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+        cfg: createOpenShellBackendSandboxConfig(),
+      })) as OpenShellSandboxBackend;
+      const sandbox = createSandboxTestContext({
+        overrides: {
+          backendId: "openshell",
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+          containerWorkdir: "/sandbox",
+        },
+      });
+      const bridge = backend.createFsBridge?.({ sandbox });
+      if (!bridge) {
+        throw new Error("Expected an OpenShell filesystem bridge");
+      }
+      expect(bridge.resolvePath({ filePath: "owner.txt" })).toEqual({
+        ...(mode === "mirror" ? { hostPath: path.join(workspaceDir, "owner.txt") } : {}),
+        relativePath: "owner.txt",
+        containerPath: "/sandbox/owner.txt",
+      });
+
+      if (mode === "remote") {
+        const runRemoteShellScript = vi.spyOn(backend, "runRemoteShellScript").mockResolvedValue({
+          stdout: Buffer.from("0\n"),
+          stderr: Buffer.alloc(0),
+          code: 0,
+        });
+        await expect(bridge.stat({ filePath: "owner.txt" })).resolves.toBeNull();
+        expect(runRemoteShellScript).toHaveBeenCalledOnce();
+        return;
+      }
+
+      const syncLocalPathToRemote = vi
+        .spyOn(backend, "syncLocalPathToRemote")
+        .mockResolvedValue(undefined);
+      await bridge.writeFile({ filePath: "owner.txt", data: "owner" });
+      expect(syncLocalPathToRemote).toHaveBeenCalledWith(
+        path.join(workspaceDir, "owner.txt"),
+        "/sandbox/owner.txt",
+      );
+    },
+  );
+
   it.runIf(process.platform !== "win32")(
     "rejects remote-only symlink parents in pinned mirror mutations",
     async () => {


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested sandbox adapter cleanup: OpenShell constructed duplicate backend handle objects, so remote and mirror filesystem bridges could retain a different object from the backend returned by the factory. OpenShell and Codex also duplicated the same existing shell-argument quoting contract.

## Why This Change Was Made

The OpenShell implementation now memoizes one canonical backend handle, returns that handle from the factory, and gives the same lifecycle owner to both filesystem bridge modes. OpenShell and the Codex sandbox exec-server reuse the existing `openclaw/plugin-sdk/sandbox` command builder; remote execution, mirror synchronization, SSH behavior, working-directory validation, and finalization contracts are unchanged. The assertion-safety baseline is ratcheted down solely for the removed assertion.

## User Impact

No user-visible behavior changes. Existing OpenShell remote/mirror, SSH sandbox, and Codex process/HTTP/lifecycle behavior and public Plugin SDK contracts are preserved. The internal implementation removes duplicate ownership and quoting paths: production **+14/-68 (net -54)**, regression tests **+58/-0**, and shrink-only baseline maintenance **+1/-1**.

## Evidence

- OpenShell owner identity, remote/mirror bridges, workdir handling, and existing E2E discovery: `node scripts/run-vitest.mjs extensions/openshell/src/openshell-core.test.ts extensions/openshell/src/backend.exec-workdir.test.ts extensions/openshell/src/backend.e2e.test.ts` — **52 passed; 1 live integration intentionally skipped**.
- Codex sandbox process, lifecycle/finalization, and HTTP contracts: `node scripts/run-vitest.mjs extensions/codex/src/app-server/sandbox-exec-server.test.ts extensions/codex/src/app-server/sandbox-exec-server.lifecycle.test.ts extensions/codex/src/app-server/sandbox-exec-server.http.test.ts` — **48 passed**.
- SSH backend, remote filesystem bridge, and shared command-quoting siblings: `node scripts/run-vitest.mjs src/agents/sandbox/ssh-backend.test.ts src/agents/sandbox/remote-fs-bridge.test.ts src/agents/sandbox/ssh.test.ts` — **71 passed**.
- Exact changed-file gate: `node scripts/check-changed.mjs -- extensions/openshell/src/backend.ts extensions/openshell/src/cli.ts extensions/openshell/src/openshell-core.test.ts extensions/codex/src/app-server/sandbox-exec-server/processes.ts config/assertion-safety-baseline.txt` — **passed**, including **5 plugin-contract tests**, assertion-safety ratchets, extension production/test typechecks, lint, boundaries, dead exports, dependency/patch guards, and zero runtime import cycles.
- `git diff --check origin/main...HEAD` — **passed**.
- Fresh AI-assisted Codex branch autoreview: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` — **clean; no actionable findings**.
- The worktree dependency install was refreshed to lockfile-pinned `acpx@0.13.1` without changing any tracked dependency, manifest, patch, or lockfile. Live proof was intentionally not run because this is an internal, behavior-preserving refactor.
