### PR TITLE
fix(plugins): preserve refreshed extractors when stale loads fail

### DIFF
--- a/src/plugins/plugin-cache-primitives.test.ts
+++ b/src/plugins/plugin-cache-primitives.test.ts
@@ -1,5 +1,6 @@
 /** Tests primitive cache-key helpers used by plugin descriptor and metadata caches. */
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   PluginLruCache,
@@ -115,6 +116,31 @@ describe("createConfigScopedPromiseLoader", () => {
 
     await expect(loader.load(config)).rejects.toThrow("transient");
     await expect(loader.load(config)).resolves.toBe("recovered");
+    expect(calls).toBe(2);
+  });
+
+  it.each([
+    { name: "config-scoped", config: {} as OpenClawConfig },
+    { name: "default", config: undefined },
+  ])("keeps the refreshed $name promise when a retired generation rejects", async ({ config }) => {
+    const retired = createDeferred<string>();
+    let calls = 0;
+    const loader = createConfigScopedPromiseLoader(() => {
+      calls += 1;
+      return calls === 1 ? retired.promise : Promise.resolve(`fresh-${calls}`);
+    });
+
+    const stale = loader.load(config);
+    const staleFailure = expect(stale).rejects.toThrow("retired generation");
+    await Promise.resolve();
+
+    clearPluginMetadataLifecycleCaches();
+
+    await expect(loader.load(config)).resolves.toBe("fresh-2");
+    retired.reject(new Error("retired generation"));
+    await staleFailure;
+
+    await expect(loader.load(config)).resolves.toBe("fresh-2");
     expect(calls).toBe(2);
   });
 

--- a/src/plugins/plugin-cache-primitives.ts
+++ b/src/plugins/plugin-cache-primitives.ts
@@ -98,7 +98,9 @@ export function createConfigScopedPromiseLoader<T>(
     const promise = Promise.resolve().then(() => load(config));
     void promise.catch(() => {
       if (config) {
-        promisesByConfig.delete(config);
+        if (promisesByConfig.get(config) === promise) {
+          promisesByConfig.delete(config);
+        }
       } else if (defaultPromise === promise) {
         defaultPromise = undefined;
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where reloading plugin metadata while an earlier config-scoped plugin extractor load was still pending could discard the newly loaded healthy extractor when the retired request eventually failed. Document extraction and web-page content extraction could then unnecessarily rebuild their current plugin registrations or observe unstable post-reload cache ownership.

## Why This Change Was Made

The shared plugin Promise loader already identity-fenced failed requests in its default scope, but the config-scoped branch unconditionally deleted whatever Promise the current lifecycle generation stored for the same config object. Apply the same exact-Promise ownership invariant before removing a config-scoped cache entry. Current-generation failures still evict and retry normally; successful single-flight reuse, lifecycle resets, weak config identity, and default-scope behavior remain unchanged.

## User Impact

Plugin-provided document and readable-web-content extractors retain their newly loaded healthy registrations after a plugin refresh even if an older, superseded initialization request fails later. Failed current-generation requests still fail closed and remain retryable.

## Evidence

- Regression-first proof on the actual shared primitive reproduced the lifecycle order before repair: config-scoped old load started, plugin metadata cleared, new generation resolved to `fresh-2`, retired generation rejected, and the next request incorrectly resolved to `fresh-3`. The default-scope table control already preserved `fresh-2`.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs src/plugins/plugin-cache-primitives.test.ts src/plugins/management-service.lifecycle-cache.test.ts src/media/document-extractors.runtime.test.ts src/web-fetch/content-extractors.runtime.test.ts --configLoader runner` — **25 tests passed across four owner and real consumer suites**.
- Coverage includes config-scoped and default lifecycle-generation fencing, failed current-generation retry, successful single-flight reuse, explicit plugin metadata resets, document extraction, readable-web-content extraction, and the official plugin-catalog recovery path.
- Assertion-safety and max-lines ratchets passed; targeted formatting, direct two-file lint, whitespace validation, authenticated Codex review, and a separate independent owner-boundary review passed.
- Production delta: **+3/-1, net +2 lines**, required to enforce exact Promise-generation ownership before deleting a config-scoped entry. Regression-test delta: **+26/-0**.
- No plugin configuration, SDK, Gateway protocol, authentication, security policy, database, or persistent state changes.
