### PR TITLE
docs: guide review-ready AI-assisted contributions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,9 @@ fix: add null check to task query
 **MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
 can help update the branch when needed.
 
+For AI-assisted work, follow the canonical
+[AI-assisted contribution guidance](https://github.com/openclaw/openclaw/blob/main/CONTRIBUTING.md#ai-assisted-contributions).
+
 </details>
 
 ## What Problem This Solves

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,8 +130,9 @@ build tooling to support standard decorators.
 
 Built with Codex, Claude, or another AI tool? **Welcome!** No AI-assistance
 label or disclosure is required. Keep the engineering bar unchanged: the
-contributor owns the problem, intended behavior, scope, and submitted result,
-while the agent should own the technical investigation and verification.
+contributor understands the submitted code and owns the problem, intended
+behavior, scope, and submitted result, while the agent should own the technical
+investigation and verification.
 
 For a review-ready AI-assisted contribution:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,18 +126,41 @@ The root `tsconfig.json` is configured for legacy decorators (`experimentalDecor
 with `useDefineForClassFields: false`. Avoid flipping these unless you are also updating the UI
 build tooling to support standard decorators.
 
-## AI/Vibe-Coded PRs Welcome! 🤖
+## AI-Assisted Contributions
 
-Built with Codex, Claude, or other AI tools? **Welcome!** No AI-assistance label or disclosure is required.
+Built with Codex, Claude, or another AI tool? **Welcome!** No AI-assistance
+label or disclosure is required. Keep the engineering bar unchanged: the
+contributor owns the problem, intended behavior, scope, and submitted result,
+while the agent should own the technical investigation and verification.
 
-Please include in your PR:
+For a review-ready AI-assisted contribution:
 
-- [ ] Include a concise **Evidence** section with the most useful validation. Reviewers will inspect the code, tests, and CI rather than relying on the PR body alone.
-- [ ] Confirm you understand what the code does
-- [ ] Run the `autoreview` skill when available and address accepted/actionable findings
-- [ ] Follow the [pull request review flow](https://docs.openclaw.ai/reference/pull-request-review-flow) after Barnacle, ClawSweeper, or maintainer feedback
+- Link the issue or request that defines non-trivial work. For bugs and very
+  small fixes, link existing context when it exists. Start from the existing
+  discussion and ask the contributor only about unresolved observable behavior,
+  non-goals, or genuine tradeoffs.
+- Read repository instructions, inspect adjacent code and recent related
+  maintainer repairs, and identify the owner or interface boundary that should
+  enforce the behavior.
+- Make the smallest durable change at that boundary. Avoid unrelated cleanup,
+  speculative abstractions, and new public vocabulary.
+- Set a reviewability budget before editing. Simplify or split the work if the
+  patch grows beyond what a reviewer can validate as one change.
+- Keep comments for non-obvious reasons, invariants, constraints, and
+  tradeoffs—not narrated code, hype, or an agent diary.
+- Provide exact-head, behavior-matched validation and current CI. Run
+  `autoreview` when available; otherwise use another independent review pass.
+  Address accepted and actionable findings.
+- Keep the durable explanation and evidence in the PR body. Before publication,
+  give the contributor a plain-language summary of intended behavior, changed
+  boundary and blast radius, strongest evidence, known gaps, and rollback.
+- Submit a complete, review-ready PR. Use draft status only for the brief
+  mergeability/CI attachment step or while implementation or proof is
+  intentionally incomplete; do not leave complete PRs in draft as a waiting
+  room.
 
-AI PRs are first-class citizens here and follow the same quality and review standards as any other PR.
+Follow the [pull request review flow](https://docs.openclaw.ai/reference/pull-request-review-flow)
+after Barnacle, ClawSweeper, or maintainer feedback.
 
 ## Current Focus & Roadmap 🗺
 


### PR DESCRIPTION
Related: #86680

## What Problem This Solves

AI-assisted contributors are asked to provide useful evidence and understand the
code they submit, but the contributor guide does not define how a capable agent
should produce a narrow, review-ready change. Putting the full contract in the
PR template would also duplicate policy across contributor surfaces.

## Why This Change Was Made

This makes `CONTRIBUTING.md` the canonical, tool-agnostic contract for
AI-assisted contributions: context-first routing, owner-boundary investigation,
scope budgeting, useful comments, exact-head validation, independent review,
durable PR context, and a plain-language acceptance summary. The PR template
keeps only a short pointer beside its existing maintainer-edit instruction.

The rebased wording preserves current `main` policy that AI-assistance labels or
disclosure are not required. Issue #86680 remains open for the maintainer
decision on its requested template-specific contract and command vocabulary;
this PR proposes the guide-first split rather than claiming to implement those
acceptance criteria. Tool-specific commands, API field names, and a repo-native
execution skill remain outside this docs-only patch.

## User Impact

Contributors supervising coding agents get a concrete workflow for judging
intent, scope, evidence, and known gaps without needing to audit every
implementation line. Maintainers get smaller, better-explained PRs with less
verification work transferred downstream.

## Evidence

- Exact head: `c4c3786b450ed837dc107825d6d7a69320b80002`, rebased onto
  `main@e2c92fce4d8bb32ddadf1150e663013c2ad92095`.
- Current `main@270c8230969ca9c0bd8a220a71d4c4c8664cd311` has no changed-path
  overlap with this two-file patch; GitHub reports the PR mergeable.
- `pnpm docs:list` completed successfully.
- `pnpm docs:check-links` checked 7,138 internal links with zero broken links.
- `pnpm format:docs:check` passed for 738 files.
- `pnpm exec oxfmt --check CONTRIBUTING.md .github/pull_request_template.md`
  passed.
- `git diff --check` passed.
- [Rendered exact-head guidance](https://github.com/openclaw/openclaw/blob/c4c3786b450ed837dc107825d6d7a69320b80002/CONTRIBUTING.md#ai-assisted-contributions)
  and the [exact-head template pointer](https://github.com/openclaw/openclaw/blob/c4c3786b450ed837dc107825d6d7a69320b80002/.github/pull_request_template.md#L24-L26)
  show the complete after-change contributor surface. This docs-only patch has
  no executable runtime path requiring separate behavior proof.
- A semantic coverage audit found one ambiguity versus the replaced guidance:
  contributor understanding of the submitted code was no longer explicit. The
  current head restores that requirement without changing the agent's technical
  investigation role.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33430010613)
  passed: 5 successful, 26 intentionally skipped, zero failed or pending.

### Owner acceptance

- Intended behavior: AI-assisted contributors and their agents follow one
  canonical review-ready contribution contract without adding a disclosure or
  publication pre-approval gate.
- Boundary/blast radius: two contributor-governance Markdown files; no runtime,
  test, generated, or release behavior changes.
- Strongest evidence: semantic coverage against the replaced guidance plus
  exact-head docs, link, formatting, and whitespace gates.
- Known gap/falsifier: a maintainer preference for template-only or
  tool-specific policy would change the chosen canonical split.
- Rollback: revert the documentation commits.
- Reviewability: two files, +38/-12, with the template limited to a three-line
  pointer.

AI-assisted: yes. Codex inspected the live issue and repository policy, resolved
the current-main disclosure-policy conflict, ran validation, and repaired the
only ambiguity found by the semantic coverage audit.

