### PR TITLE
fix(gateway): honor custom ports for usage and stability queries

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -194,8 +194,13 @@ describe("gateway-cli coverage", () => {
     ]);
 
     expect(callGateway).toHaveBeenCalledTimes(1);
-    const stabilityCall = firstMockArg(callGateway) as { method?: string; params?: unknown };
+    const stabilityCall = firstMockArg(callGateway) as {
+      method?: string;
+      params?: unknown;
+      localPortOverride?: number;
+    };
     expect(stabilityCall?.method).toBe("diagnostics.stability");
+    expect(stabilityCall?.localPortOverride).toBeUndefined();
     expect(stabilityCall?.params).toEqual({
       limit: 5,
       type: "payload.large",
@@ -503,7 +508,16 @@ describe("gateway-cli coverage", () => {
       fs.writeFileSync(bundlePath, `${JSON.stringify(bundle, null, 2)}\n`, "utf8");
 
       await withEnvOverride({ OPENCLAW_STATE_DIR: tempDir }, async () => {
-        await runGatewayCommand(["gateway", "stability", "--bundle", "latest"]);
+        await runGatewayCommand([
+          "gateway",
+          "--port",
+          "19096",
+          "stability",
+          "--bundle",
+          "latest",
+          "--url",
+          "ws://127.0.0.1:19096",
+        ]);
       });
 
       const output = runtimeLogs.join("\n");
@@ -521,7 +535,18 @@ describe("gateway-cli coverage", () => {
     }
   });
 
-  it("writes gateway diagnostics export with a best-effort health snapshot", async () => {
+  it.each([
+    {
+      name: "gateway diagnostics",
+      args: ["gateway", "diagnostics", "export"],
+      timeoutMs: 3000,
+    },
+    {
+      name: "offline stability",
+      args: ["gateway", "--port", "19097", "stability", "--bundle", "latest", "--export"],
+      timeoutMs: 10_000,
+    },
+  ])("writes $name export with a service-owned health snapshot", async ({ args, timeoutMs }) => {
     callGateway.mockClear();
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-cli-support-"));
     try {
@@ -529,21 +554,19 @@ describe("gateway-cli coverage", () => {
       await withEnvOverride(
         { OPENCLAW_STATE_DIR: tempDir, OPENCLAW_TEST_FILE_LOG: undefined },
         async () => {
-          await runGatewayCommand([
-            "gateway",
-            "diagnostics",
-            "export",
-            "--output",
-            outputPath,
-            "--json",
-          ]);
+          await runGatewayCommand([...args, "--output", outputPath, "--json"]);
         },
       );
 
       expect(callGateway).toHaveBeenCalledTimes(1);
-      const healthCall = firstMockArg(callGateway) as { method?: string; timeoutMs?: number };
+      const healthCall = firstMockArg(callGateway) as {
+        method?: string;
+        timeoutMs?: number;
+        localPortOverride?: number;
+      };
       expect(healthCall?.method).toBe("health");
-      expect(healthCall?.timeoutMs).toBe(3000);
+      expect(healthCall?.timeoutMs).toBe(timeoutMs);
+      expect(healthCall?.localPortOverride).toBeUndefined();
       expect(fs.existsSync(outputPath)).toBe(true);
       const output = runtimeLogs.join("\n");
       expect(output).toContain('"path"');

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -312,6 +312,48 @@ describe("gateway register option collisions", () => {
       },
     },
     {
+      name: "projects gateway usage-cost --port into the local override",
+      argv: ["gateway", "usage-cost", "--port", "19088", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("usage.cost", 19088, { days: 30 });
+      },
+    },
+    {
+      name: "inherits parent --port for gateway usage-cost",
+      argv: ["gateway", "--port", "19089", "usage-cost", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("usage.cost", 19089, { days: 30 });
+      },
+    },
+    {
+      name: "prefers the explicit usage-cost --port over the parent --port",
+      argv: ["gateway", "--port", "19090", "usage-cost", "--port", "19091", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("usage.cost", 19091, { days: 30 });
+      },
+    },
+    {
+      name: "projects gateway stability --port into the local override",
+      argv: ["gateway", "stability", "--port", "19092", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("diagnostics.stability", 19092, { limit: 25 });
+      },
+    },
+    {
+      name: "inherits parent --port for live gateway stability",
+      argv: ["gateway", "--port", "19093", "stability", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("diagnostics.stability", 19093, { limit: 25 });
+      },
+    },
+    {
+      name: "prefers the explicit live stability --port over the parent --port",
+      argv: ["gateway", "--port", "19094", "stability", "--port", "19095", "--json"],
+      assert: () => {
+        expectLocalGatewayCall("diagnostics.stability", 19095, { limit: 25 });
+      },
+    },
+    {
       name: "falls back for non-decimal usage-cost --days values",
       argv: ["gateway", "usage-cost", "--days", "1e3", "--json"],
       assert: () => {
@@ -326,15 +368,31 @@ describe("gateway register option collisions", () => {
     assert();
   });
 
-  it("rejects combining --url and --port for gateway call", async () => {
+  it.each([
+    {
+      name: "call",
+      args: ["call", "health"],
+      failure: "Gateway call failed",
+    },
+    {
+      name: "usage-cost",
+      args: ["usage-cost"],
+      failure: "Gateway usage cost failed",
+    },
+    {
+      name: "live stability",
+      args: ["stability"],
+      failure: "Gateway stability failed",
+    },
+  ])("rejects combining --url and --port for gateway $name", async ({ args, failure }) => {
     await sharedProgram.parseAsync(
-      ["gateway", "call", "health", "--url", "ws://127.0.0.1:19084", "--port", "19084", "--json"],
+      ["gateway", ...args, "--url", "ws://127.0.0.1:19084", "--port", "19084", "--json"],
       { from: "user" },
     );
 
     expect(callGatewayCli).not.toHaveBeenCalled();
     expect(defaultRuntime.error).toHaveBeenCalledWith(
-      "Gateway call failed: Use either --url or --port, not both.",
+      `${failure}: Use either --url or --port, not both.`,
     );
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -22,7 +22,7 @@ import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
 import { rethrowExpectedCliError } from "../failure-output.js";
 import { parseGatewayPortOption } from "../gateway-port-option.js";
-import { callGatewayFromCliWithTransport } from "../gateway-rpc.js";
+import { addGatewayClientOptions, callGatewayFromCliWithTransport } from "../gateway-rpc.js";
 import { formatHelpExamples } from "../help-format.js";
 import { setCommandJsonMode } from "../program/json-mode.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
@@ -106,13 +106,11 @@ function loadDaemonStatusGatherModule() {
 }
 
 function gatewayCallOpts(cmd: Command, defaultTimeoutMs = DEFAULT_GATEWAY_RPC_TIMEOUT_MS): Command {
-  return cmd
-    .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
-    .option("--token <token>", "Gateway token (if required)")
-    .option("--password <password>", "Gateway password (password auth)")
-    .option("--timeout <ms>", "Timeout in ms", String(defaultTimeoutMs))
-    .option("--expect-final", "Wait for final response (agent)", false)
-    .option("--json", "Output JSON", false);
+  return addGatewayClientOptions(cmd, { timeoutMs: defaultTimeoutMs }).option(
+    "--json",
+    "Output JSON",
+    false,
+  );
 }
 
 async function callGatewayReadOnlyCli(method: string, opts: GatewayRpcOpts, params?: unknown) {
@@ -570,7 +568,6 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .description("Call a Gateway method")
       .argument("<method>", "Method name (health/status/system-presence/cron.*)")
       .option("--params <json>", "JSON object string for params", "{}")
-      .option("--port <port>", "Local Gateway port")
       .action(async (method, opts, command) => {
         await runGatewayCommand(
           async () => {
@@ -606,7 +603,6 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .description("Prepare the Gateway for cooperative host suspension")
       .option("--request-id <id>", "Stable suspension request id")
       .option("--wait <seconds>", "Wait up to this many seconds for active work to drain")
-      .option("--port <port>", "Local Gateway port")
       .action(async (opts, command) => {
         await runGatewayCommand(
           async () => {
@@ -632,7 +628,6 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .command("resume")
       .description("Release a cooperative Gateway suspension")
       .argument("<suspensionId>", "Suspension id returned by gateway suspend")
-      .option("--port <port>", "Local Gateway port")
       .action(async (suspensionId, opts, command) => {
         await runGatewayCommand(
           async () => {
@@ -658,7 +653,7 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
       .action(async (opts, command) => {
         await runGatewayCommand(
           async () => {
-            const rpcOpts = resolveGatewayRpcOptions(opts, command);
+            const rpcOpts = resolveGatewayRpcOptionsWithLocalPort(opts, command);
             const days = parseDaysOption(opts.days);
             const agentId = typeof opts.agent === "string" ? opts.agent.trim() : undefined;
             // The gateway honors agentScope only when no agentId is set, so reject the
@@ -690,7 +685,6 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
     gateway
       .command("health")
       .description("Fetch Gateway health")
-      .option("--port <port>", "Local Gateway port")
       .action(async (opts, command) => {
         await runGatewayCommand(
           async () => {
@@ -811,11 +805,15 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
               return;
             }
 
-            const result = await callGatewayReadOnlyCli("diagnostics.stability", rpcOpts, {
-              limit: query.limit,
-              ...(query.type ? { type: query.type } : {}),
-              ...(query.sinceSeq !== undefined ? { sinceSeq: query.sinceSeq } : {}),
-            });
+            const result = await callGatewayReadOnlyCli(
+              "diagnostics.stability",
+              resolveGatewayRpcOptionsWithLocalPort(rpcOpts, command),
+              {
+                limit: query.limit,
+                ...(query.type ? { type: query.type } : {}),
+                ...(query.sinceSeq !== undefined ? { sinceSeq: query.sinceSeq } : {}),
+              },
+            );
             if (rpcOpts.json) {
               defaultRuntime.writeJson(result);
               return;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators querying a custom-port Gateway through `gateway usage-cost` or live `gateway stability` would silently contact the default Gateway instead, even when `--port` was supplied before or after the nested command.

## Why This Change Was Made

Gateway command registration duplicated the canonical shared client-option set, omitted its local-port option on two RPC leaves, and dispatched those leaves through an authentication-only resolver. Reuse the existing shared Gateway client options for every applicable RPC command, delete redundant leaf option declarations, and route usage-cost plus live stability through the existing parent-aware local-port resolver. Offline stability bundles, support exports, managed service status, and discovery retain their distinct owners and existing behavior.

## User Impact

Operators can reliably run `gateway --port 19001 usage-cost`, `gateway usage-cost --port 19001`, `gateway --port 19001 stability`, and `gateway stability --port 19001` against the intended local Gateway. Explicit child ports override parent ports; conflicting `--url` and `--port` values fail visibly. Offline bundle inspection, diagnostics export, service-managed status targeting, authentication, JSON output, and command-specific timeouts remain unchanged.

## Evidence

- Six authentic real-Commander regression cases failed against untouched production: parent-position, child-position, and explicit-child-precedence cases for both usage-cost and live stability all omitted `localPortOverride`.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs src/cli/gateway-cli/register.option-collisions.test.ts src/cli/gateway-cli.coverage.test.ts src/cli/daemon-cli/register-service-commands.test.ts --configLoader runner` — **76 tests passed across three suites**.
- Regression coverage includes both option positions, child precedence, `--url` conflicts, existing call/health/suspend/resume RPC siblings, offline bundle reads, service-owned stability exports, distinct export timeout contracts, and managed Gateway service commands.
- Focused formatter and direct core oxlint checks passed; max-lines and assertion-safety ratchets passed.
- Production delta: **+16/-18 (net −2)**; tests strengthen canonical owner-boundary behavior without production-only seams.
- Frozen reviewed head: `86edb055437cfbb9adc0018a6ee655242e05636d`.
- Independent owner/dependency review and fresh authenticated complete-branch automated review: **clean; no actionable findings**.
- AI-assisted; no agent transcript attached.
