### PR TITLE
fix(web-fetch): extract readable content from XHTML pages

### DIFF
--- a/src/agents/tools/web-fetch.cf-markdown.test.ts
+++ b/src/agents/tools/web-fetch.cf-markdown.test.ts
@@ -108,19 +108,66 @@ describe("web_fetch Cloudflare Markdown for Agents", () => {
     expect(details?.text).toContain("Mixed Case");
   });
 
-  it("falls back to readability for text/html responses", async () => {
-    const html =
-      "<html><body><article><h1>HTML Page</h1><p>Content here.</p></article></body></html>";
-    const fetchSpy = vi.fn().mockResolvedValue(htmlResponse(html));
-    global.fetch = withFetchPreconnect(fetchSpy);
+  it.each([
+    { contentType: "text/html; charset=utf-8", normalizedContentType: "text/html" },
+    {
+      contentType: "application/xhtml+xml; charset=utf-8",
+      normalizedContentType: "application/xhtml+xml",
+    },
+    {
+      contentType: "Application/XHTML+XML; Charset=UTF-8",
+      normalizedContentType: "application/xhtml+xml",
+    },
+  ])(
+    "extracts readable article text from $contentType responses",
+    async ({ contentType, normalizedContentType }) => {
+      const html =
+        '<html xmlns="http://www.w3.org/1999/xhtml"><body><article><h1>HTML Page</h1><p>Content here.</p><script>hiddenScript()</script></article></body></html>';
+      const fetchSpy = vi.fn().mockResolvedValue(htmlResponse(html, contentType));
+      global.fetch = withFetchPreconnect(fetchSpy);
 
-    const tool = createWebFetchTool(baseToolConfig);
+      const tool = createWebFetchTool(baseToolConfig);
 
-    const result = await tool?.execute?.("call", { url: "https://example.com/html" });
-    const details = result?.details as { extractor?: string; contentType?: string } | undefined;
-    expect(details?.extractor).toBe("readability");
-    expect(details?.contentType).toBe("text/html");
-  });
+      const result = await tool?.execute?.("call", {
+        url: `https://example.com/html-${normalizedContentType.replace(/\W/g, "-")}`,
+      });
+      const details = result?.details as
+        | {
+            extractor?: string;
+            contentType?: string;
+            text?: string;
+            externalContent?: { untrusted?: boolean; wrapped?: boolean };
+          }
+        | undefined;
+      expect(details?.extractor).toBe("readability");
+      expect(details?.contentType).toBe(normalizedContentType);
+      expect(details?.text).toContain("Content here.");
+      expect(details?.text).not.toContain("<article>");
+      expect(details?.text).not.toContain("hiddenScript()");
+      expect(details?.externalContent).toMatchObject({ untrusted: true, wrapped: true });
+    },
+  );
+
+  it.each(["application/xml", "image/svg+xml"])(
+    "does not treat $contentType documents as readable HTML",
+    async (contentType) => {
+      const body = "<article><p>Preserve non-HTML markup.</p></article>";
+      const fetchSpy = vi.fn().mockResolvedValue(htmlResponse(body, contentType));
+      global.fetch = withFetchPreconnect(fetchSpy);
+
+      const tool = createWebFetchTool(baseToolConfig);
+      const result = await tool?.execute?.("call", {
+        url: `https://example.com/non-html-${contentType.replace(/\W/g, "-")}`,
+      });
+      const details = result?.details as
+        | { extractor?: string; contentType?: string; text?: string }
+        | undefined;
+
+      expect(details?.extractor).toBe("raw");
+      expect(details?.contentType).toBe(contentType);
+      expect(details?.text).toContain("<article>");
+    },
+  );
 
   it("recognizes HTML response media types case-insensitively", async () => {
     const html =

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -813,7 +813,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       if (params.extractMode === "text") {
         text = markdownToText(body);
       }
-    } else if (normalizedContentType === "text/html") {
+    } else if (["text/html", "application/xhtml+xml"].includes(normalizedContentType)) {
       if (params.readabilityEnabled) {
         const readable = await extractReadableContent({
           html: body,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users fetching normal web pages served as XHTML received raw document markup, script text, and undecoded entities instead of the readable article content returned for equivalent HTML pages.

## Why This Change Was Made

The existing response decoder already recognizes XHTML as a document, but the web-fetch extraction owner admitted only `text/html` to its established readability and visibility-sanitizer pipeline. Explicitly admitting the two canonical HTML media types reuses that same safe HTML-mode extractor without parsing arbitrary XML, changing network policy, or adding another extraction path.

## User Impact

XHTML pages now produce clean readable markdown or text, with the same article extraction, content wrapping, and fallback behavior as ordinary HTML. Generic XML documents and SVG images remain raw, and existing SSRF, DNS, response-size, and untrusted-content protections remain unchanged.

## Evidence

- Regression-first proof: both lower-case and mixed-case `application/xhtml+xml` responses failed on unchanged production (`extractor: raw` instead of `readability`), while `text/html`, `application/xml`, and `image/svg+xml` controls behaved as expected.
- After the one-line owner repair, the same real public `web_fetch` tool and HTTP Response cases pass, including assertions that XHTML no longer contains article markup or script text and remains explicitly marked as wrapped, untrusted content.
- Exact head: `7c5d108392b989da97ba86feb4ae28e57719de01`.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 NODE_DISABLE_COMPILE_CACHE=1 node scripts/run-vitest.mjs src/agents/tools/web-fetch.cf-markdown.test.ts src/agents/tools/web-shared.test.ts src/agents/tools/web-fetch.ssrf.test.ts src/agents/tools/web-fetch-output-contract.test.ts src/agents/tools/web-fetch.provider-fallback.test.ts extensions/web-readability/web-content-extractor.test.ts --configLoader runner` — **74 tests passed across six files**, including the real localhost provider-fallback server, SSRF guards, response decoder, output contract, and actual readability plugin.
- `node_modules/.bin/oxlint --deny-warnings src/agents/tools/web-fetch.ts src/agents/tools/web-fetch.cf-markdown.test.ts` — passed.
- `node_modules/.bin/oxfmt --check src/agents/tools/web-fetch.ts src/agents/tools/web-fetch.cf-markdown.test.ts` — passed.
- `node --import tsx scripts/check-assertion-safety-ratchet.mts` and `node --import tsx scripts/check-max-lines-ratchet.mts` — passed.
- Independent source, dependency, and security-boundary review classified the closed XHTML media-type repair as routine low-risk product behavior; fresh authenticated full-branch Codex review is clean.
- Production LOC: +1/-1 (net zero); regression tests: +60/-13.
