### PR TITLE
fix(workers): preserve results after scratch cleanup

### DIFF
--- a/src/gateway/worker-environments/workspace-reconcile-publication.test.ts
+++ b/src/gateway/worker-environments/workspace-reconcile-publication.test.ts
@@ -3,14 +3,37 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { AcceptedWorkspacePublicationIndeterminateError } from "./workspace-accepted-publication.js";
+import { verifyReconciledWorkspaceFinal } from "./workspace-finalize.js";
+import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
 import {
   applyStagedWorkerWorkspace,
   readActualWorkspaceManifest,
   recoverWorkerWorkspaceReconciliation,
   type WorkerWorkspaceReconciliationJournal,
 } from "./workspace-reconcile.js";
+import {
+  hasWorkerWorkspaceResultRef,
+  preparedWorkerWorkspaceResultRef,
+  workerWorkspaceResultRef,
+  workerWorkspaceResultStaging,
+} from "./workspace-result-staging.js";
+
+const workspaceWarning = vi.hoisted(() => vi.fn());
+vi.mock("../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "gateway/worker-workspace"
+        ? { ...logger, warn: workspaceWarning }
+        : logger;
+    },
+  };
+});
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => workspaceWarning.mockReset());
 
 async function manifestFor(root: string) {
   return (await readActualWorkspaceManifest({ root, baseCommit: null })).manifest;
@@ -117,5 +140,108 @@ describe("worker workspace reconciliation publication", () => {
     await expect(fs.readFile(path.join(local, "result.txt"), "utf8")).resolves.toBe("base\n");
     expect(pending).toBeUndefined();
     expect(abort).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["preserves committed results and recovery refs when scratch cleanup fails", true, false],
+    ["preserves publication failures and rollback when scratch cleanup fails", true, true],
+    ["removes disposable scratch without warning when cleanup succeeds", false, false],
+  ])("%s", async (_name, cleanupFails, publicationFails) => {
+    const local = tempDirs.make("openclaw-workspace-result-cleanup-local-");
+    const payload = tempDirs.make("openclaw-workspace-result-cleanup-payload-");
+    await fs.writeFile(path.join(local, "result.txt"), "base\n");
+    await fs.writeFile(path.join(payload, "result.txt"), "worker\n");
+    const base = await readActualWorkspaceManifest({ root: local, baseCommit: null });
+    const current = await readActualWorkspaceManifest({ root: payload, baseCommit: null });
+    const publicationError = new Error("accepted publication rejected");
+    const cleanupError = new Error("scratch removal failed");
+    const ref = workerWorkspaceResultRef("claim-staging-cleanup");
+    const record = vi.fn();
+    const commit = vi.fn();
+    const abort = vi.fn();
+    const prepared = await workerWorkspaceResultStaging.prepareRequestedWorkerWorkspaceResult({
+      request: {
+        localPath: local,
+        remoteWorkspaceDir: "/worker/workspace",
+        baseManifestRef: base.manifestRef,
+        journal: { load: () => undefined, begin: () => {}, commit, abort },
+        stagedResult: { ref, record },
+      },
+      stagingRoot: payload,
+      currentManifestRef: current.manifestRef,
+      baseManifestRaw: serializeWorkerWorkspaceManifest(base.manifest),
+      currentManifestRaw: serializeWorkerWorkspaceManifest(current.manifest),
+      publishAcceptedManifest: async () => {
+        if (publicationFails) {
+          throw publicationError;
+        }
+      },
+    });
+    const remove = fs.rm;
+    let scratch: string | undefined;
+    const removeSpy = vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (
+        typeof target === "string" &&
+        path.basename(target).startsWith("openclaw-staged-result-")
+      ) {
+        scratch = target;
+        if (cleanupFails) {
+          throw cleanupError;
+        }
+      }
+      return await remove(target, options);
+    });
+
+    try {
+      await expect(
+        hasWorkerWorkspaceResultRef({
+          root: local,
+          stagedResultRef: preparedWorkerWorkspaceResultRef(ref),
+        }),
+      ).resolves.toBe(true);
+      const finalized = verifyReconciledWorkspaceFinal(
+        {
+          ...prepared,
+          manifestRef: current.manifestRef,
+          changed: true,
+          verifyStable: async () => {},
+        },
+        { assertActive: async () => {}, resume: async () => {} },
+      );
+      if (publicationFails) {
+        await expect(finalized).rejects.toBe(publicationError);
+        expect(abort).toHaveBeenCalledOnce();
+      } else {
+        await expect(finalized).resolves.toMatchObject({ manifestRef: current.manifestRef });
+        expect(commit).toHaveBeenCalledOnce();
+      }
+      await expect(fs.readFile(path.join(local, "result.txt"), "utf8")).resolves.toBe(
+        publicationFails ? "base\n" : "worker\n",
+      );
+      await expect(
+        hasWorkerWorkspaceResultRef({ root: local, stagedResultRef: ref }),
+      ).resolves.toBe(!publicationFails);
+      await expect(
+        hasWorkerWorkspaceResultRef({
+          root: local,
+          stagedResultRef: preparedWorkerWorkspaceResultRef(ref),
+        }),
+      ).resolves.toBe(false);
+      expect(record).toHaveBeenCalledTimes(publicationFails ? 0 : 1);
+      expect(workspaceWarning).toHaveBeenCalledTimes(cleanupFails ? 1 : 0);
+      if (cleanupFails) {
+        expect(workspaceWarning).toHaveBeenCalledWith(
+          "worker workspace staging cleanup failed: scratch removal failed",
+        );
+        await expect(fs.access(scratch!)).resolves.toBeUndefined();
+      } else {
+        await expect(fs.access(scratch!)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+    } finally {
+      removeSpy.mockRestore();
+      if (scratch) {
+        await remove(scratch, { recursive: true, force: true });
+      }
+    }
   });
 });

--- a/src/gateway/worker-environments/workspace-result-staging.ts
+++ b/src/gateway/worker-environments/workspace-result-staging.ts
@@ -2,8 +2,11 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { runBestEffortCleanup } from "../../infra/non-fatal-cleanup.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { runCommandBuffered, runCommandWithTimeout } from "../../process/exec.js";
 import type { WorkerWorkspaceReconcileRequest } from "./tunnel-contract.js";
+import { boundedWorkerError } from "./worker-error.js";
 import {
   activeWorkspaceHashContext,
   withWorkspaceHashContext,
@@ -36,6 +39,7 @@ const WORKER_RESULT_CLEANUP_REF_PREFIX = "refs/openclaw/worker-result-cleanup";
 const WORKER_RESULT_CLAIM_ID_PATTERN = /^[A-Za-z0-9-]+$/u;
 const STAGED_RESULT_MESSAGE = "OpenClaw worker workspace result";
 const STAGED_RESULT_METADATA_LIMIT = 128 * 1024 * 1024 + 4_096;
+const workspaceLog = createSubsystemLogger("gateway/worker-workspace");
 // Git documents the platform null device as the per-command way to disable
 // hooks. An unowned path under a shared temp dir could be populated by another user.
 const DISABLED_GIT_HOOKS_PATH = os.devNull;
@@ -529,7 +533,11 @@ async function applyStagedWorkerWorkspaceResultWithMemo(
     });
     return { ...applied, changed: staged.changed };
   } finally {
-    await fs.rm(stagingRoot, { recursive: true, force: true });
+    await runBestEffortCleanup({
+      cleanup: () => fs.rm(stagingRoot, { recursive: true, force: true }),
+      onError: (error) =>
+        workspaceLog.warn(`worker workspace staging cleanup failed: ${boundedWorkerError(error)}`),
+    });
   }
 }
 


### PR DESCRIPTION
Closes #126846

## What Problem This Solves

Fixes an issue where users completing a cloud worker turn could see their workspace changes committed but lose the returned reconciliation result and its canonical recovery reference when deletion of a disposable staging directory failed. When accepted-manifest publication failed before commit, the same cleanup error also replaced the real publication failure even though rollback restored the original workspace.

## Why This Change Was Made

The staging owner now routes only its owned, disposable scratch-directory removal through the existing `runBestEffortCleanup` contract and emits one bounded, redacted warning through the established worker-workspace subsystem logger. Actual staging, payload/containment validation, reconciliation, publication, rollback, finalizer fences, prepared-reference disposal, and canonical recovery-reference publication remain unchanged and retain their existing failure semantics.

## User Impact

A completed worker turn preserves its committed result and publishes its normal recovery reference even when removing disposable scratch fails. Genuine precommit publication failures continue to surface their original error after restoring the workspace. Operators receive a clear warning when scratch remains; normal successful cleanup remains silent.

## Evidence

- Before the production fix, real `fs.rm` fault injection reproduced both defects: committed reconciliation rejected with `scratch removal failed`; definitive publication failure returned that cleanup error instead of the original `accepted publication rejected`. Both regressions failed in both Gateway test projects.
- After the fix, the same three table-driven scenarios prove committed content/result plus canonical-reference publication and candidate removal; exact primary-error identity plus rollback and candidate cleanup; and ordinary scratch removal without any warning.
- Expanded focused owner, publication, recovery, finalizer, prepared-result, SSH worker, node worker, and shared nonfatal-cleanup suites: **204 tests passed** across 15 test files and two Vitest shards.
- Actual changed gate: **passed**, including production/test typechecking, changed-file lint and formatting, dead-export scans, import-cycle checks, and repository architecture/storage guards.
- Fresh P1 Codex-backed structured autoreview: **clean, no accepted/actionable findings**.
- Separate independent adversarial owner/caller/fence/lifecycle/containment review: **clean, no actionable findings**.
- Production LOC: **+9/-1 (net +8)**; regression tests: **+126/-0**.
- Scope/risk: isolated disposable staging cleanup only; no protocol, schema, config, authority, security, deployment, version, release, or product-policy change.
- A live operator gateway was not fault-injected because doing so would require modifying a running production process; the regressions instead execute the real staging owner, real filesystem, real Git recovery refs, real apply/rollback, and the unmodified production finalizer with a narrowly scoped production `fs.rm` fault.

AI-assisted: yes
