### PR TITLE
fix(ui): clear stuck session run spinner on stale terminal projection

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       '@openclaw/proxyline':
         specifier: 0.3.4
         version: 0.3.4(undici@8.9.0)
+      '@panzoom/panzoom':
+        specifier: 4.6.2
+        version: 4.6.2
       '@silvia-odwyer/photon-node':
         specifier: 0.3.4
         version: 0.3.4

--- a/ui/src/e2e/session-spinner-clears.e2e.test.ts
+++ b/ui/src/e2e/session-spinner-clears.e2e.test.ts
@@ -1,0 +1,132 @@
+import { expect, it } from "vitest";
+import {
+  chatSessionListResponse,
+  controlUiSessionUrl,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const runStartedAt = Date.now() - 5_000;
+
+suite.define(() => {
+  it("stops the session run spinner when a terminal sessions.changed event clears the active run", async () => {
+    const agentsList = {
+      agents: [{ id: "main", name: "Main" }],
+      defaultId: "main",
+      mainKey: "main",
+      scope: "agent",
+    };
+
+    // Initial session state: active run (spinner will show in the sidebar).
+    const activeHistory = {
+      messages: [],
+      sessionId: "main-global-session",
+      sessionInfo: {
+        activeRunIds: ["run-active"],
+        hasActiveRun: true,
+        key: "global",
+        startedAt: runStartedAt,
+        status: "running",
+      },
+      thinkingLevel: null,
+    };
+
+    const activeSessionRow = {
+      activeRunIds: ["run-active"],
+      hasActiveRun: true,
+      key: "global",
+      kind: "global",
+      label: "Main Session",
+      startedAt: runStartedAt,
+      status: "running",
+      updatedAt: runStartedAt + 1_000,
+    };
+
+    const recordVideo = artifactDir
+      ? { dir: artifactDir, size: { width: 1440, height: 900 } as const }
+      : undefined;
+
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      ...(recordVideo ? { recordVideo } : {}),
+      serviceWorkers: "block",
+      viewport: { width: 1440, height: 900 },
+    });
+
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "agents.list": agentsList,
+        "chat.history": activeHistory,
+        "chat.startup": { ...activeHistory, agentsList },
+        "sessions.list": chatSessionListResponse([activeSessionRow]),
+      },
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
+      const response = await page
+        .locator(".agent-chat__composer-combobox textarea")
+        .waitFor({ state: "visible", timeout: 15_000 })
+        .catch(() => null);
+
+      // Wait for the sidebar session list to render.
+      await expect
+        .poll(() => page.locator(".sidebar-recent-session").count(), { timeout: 15_000 })
+        .toBeGreaterThanOrEqual(1);
+
+      // The spinner must be visible while the run is active (before the terminal event).
+      await expect
+        .poll(() => page.locator(".session-run-spinner").count())
+        .toBeGreaterThanOrEqual(1);
+
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/spinner-before.png`,
+          fullPage: true,
+        });
+      }
+
+      // Emit a terminal sessions.changed event — hasActiveRun: false with a
+      // matching startedAt so the reconciler accepts it as the authoritative
+      // final state for the active run (regression gate for the stale-spinner).
+      await gateway.emitGatewayEvent("sessions.changed", {
+        hasActiveRun: false,
+        key: "global",
+        kind: "global",
+        startedAt: runStartedAt,
+        status: "done",
+        endedAt: runStartedAt + 2_000,
+        updatedAt: runStartedAt + 2_000,
+      });
+
+      // The spinner must disappear once the terminal event clears the active run.
+      await expect
+        .poll(() => page.locator(".session-run-spinner").count(), { timeout: 10_000 })
+        .toBe(0);
+
+      if (artifactDir) {
+        await page.screenshot({
+          path: `${artifactDir}/spinner-after.png`,
+          fullPage: true,
+        });
+      }
+
+      // The "New Session" action must be enabled after the terminal event.
+      const newSessionButton = page.locator(".sidebar-session-new, .sidebar-new-session");
+      await expect.poll(() => newSessionButton.count()).toBeGreaterThanOrEqual(1);
+      await expect
+        .poll(() =>
+          newSessionButton
+            .first()
+            .evaluate((el) => el instanceof HTMLElement && !el.hasAttribute("disabled")),
+        )
+        .toBe(true);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/lib/sessions/reconcile.test.ts
+++ b/ui/src/lib/sessions/reconcile.test.ts
@@ -572,6 +572,106 @@ describe("reconcileSessionChanged", () => {
     expect(next.row?.archivedBy).toBeUndefined();
     expect(next.result?.sessions[0]?.archivedBy).toBeUndefined();
   });
+
+  it("clears an active run even when a terminal event has an equal updatedAt (timestamp tie)", () => {
+    const key = "agent:main:main";
+    const result = buildResult([
+      {
+        key,
+        kind: "global",
+        sessionId: "s1",
+        updatedAt: 100,
+        startedAt: 100,
+        hasActiveRun: true,
+        status: "running",
+      },
+    ]);
+
+    // The terminal sessions.changed event carries updatedAt == existing updatedAt
+    // (lifecycle endedAt ties sessionRow.updatedAt) and startedAt == existing
+    // startedAt (same run). A terminal projection must override an active row
+    // regardless of timestamp ordering.
+    const next = reconcileSessionChanged(result, {
+      sessionKey: key,
+      key,
+      kind: "global",
+      sessionId: "s1",
+      updatedAt: 100,
+      startedAt: 100,
+      hasActiveRun: false,
+      status: "done",
+    });
+
+    expect(next.applied).toBe(true);
+    expect(next.result?.sessions[0]?.hasActiveRun).toBe(false);
+    expect(next.result?.sessions[0]?.status).toBe("done");
+  });
+
+  it("clears an active run when a terminal event updatedAt equals existing startedAt", () => {
+    const key = "agent:main:main";
+    const result = buildResult([
+      {
+        key,
+        kind: "global",
+        sessionId: "s1",
+        updatedAt: 200,
+        startedAt: 100,
+        hasActiveRun: true,
+        status: "running",
+      },
+    ]);
+
+    // Terminal event with updatedAt == startedAt and matching startedAt: the
+    // staleness guard must not block a terminal projection from overriding an
+    // active row.
+    const next = reconcileSessionChanged(result, {
+      sessionKey: key,
+      key,
+      kind: "global",
+      sessionId: "s1",
+      updatedAt: 100,
+      startedAt: 100,
+      hasActiveRun: false,
+      status: "done",
+    });
+
+    expect(next.applied).toBe(true);
+    expect(next.result?.sessions[0]?.hasActiveRun).toBe(false);
+    expect(next.result?.sessions[0]?.status).toBe("done");
+  });
+
+  it("does not clear an active run when a terminal event has a mismatched startedAt (stale overlap)", () => {
+    const key = "agent:main:main";
+    const result = buildResult([
+      {
+        key,
+        kind: "global",
+        sessionId: "s1",
+        updatedAt: 300,
+        startedAt: 200,
+        hasActiveRun: true,
+        status: "running",
+      },
+    ]);
+
+    // A delayed terminal event for an older run (startedAt 100) arrives while a
+    // newer run (startedAt 200) is active. The mismatched startedAt means this
+    // terminal projection is stale and must not clear the newer run's state.
+    const next = reconcileSessionChanged(result, {
+      sessionKey: key,
+      key,
+      kind: "global",
+      sessionId: "s1",
+      updatedAt: 150,
+      startedAt: 100,
+      hasActiveRun: false,
+      status: "done",
+    });
+
+    expect(next.result).toBe(result);
+    expect(next.result?.sessions[0]?.hasActiveRun).toBe(true);
+    expect(next.result?.sessions[0]?.status).toBe("running");
+  });
 });
 
 describe("reconcileSessionHistory", () => {

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -216,10 +216,31 @@ function isShallowEqualSessionRow(
   });
 }
 
+// Terminal projections that arrive for an active row are authoritative and
+// must clear the spinner — but only when they belong to the *current* run.
+// During an active run the row's activeRunIds is deleted (null tombstone), so
+// startedAt is the available run discriminator: the gateway's lifecycle
+// snapshot preserves the terminating run's startedAt, which differs from a
+// newer run that has since started. A mismatched startedAt signals the
+// terminal event is for an older run superseded by a newer active run.
+function isStaleTerminalForActiveRun(
+  incoming: GatewaySessionRow,
+  existing: GatewaySessionRow | undefined,
+): boolean {
+  return !(
+    typeof incoming.startedAt !== "number" ||
+    typeof existing?.startedAt !== "number" ||
+    incoming.startedAt === existing.startedAt
+  );
+}
+
 function isOlderSessionSnapshot(
   incoming: GatewaySessionRow,
   existing: GatewaySessionRow | undefined,
 ): boolean {
+  if (incoming.hasActiveRun === false && existing && isSessionRunActive(existing)) {
+    return isStaleTerminalForActiveRun(incoming, existing);
+  }
   return (
     typeof incoming.updatedAt === "number" &&
     typeof existing?.updatedAt === "number" &&
@@ -233,6 +254,9 @@ function isStaleForActiveSession(
 ): boolean {
   if (!existing || !isSessionRunActive(existing) || isSessionRunActive(incoming)) {
     return false;
+  }
+  if (incoming.hasActiveRun === false) {
+    return isStaleTerminalForActiveRun(incoming, existing);
   }
   const incomingUpdatedAt = incoming.updatedAt ?? 0;
   return (

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -5,7 +5,6 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { brotliCompressSync, constants as zlibConstants } from "node:zlib";
-import { gzip } from "pako";
 import type { Plugin, UserConfig } from "vite";
 import { controlUiCodeSplitting } from "./config/control-ui-chunking.ts";
 import { controlUiHoverGuardPlugin } from "./config/control-ui-hover-guard.ts";
@@ -18,6 +17,7 @@ const repoRoot = path.resolve(here, "..");
 const outDir = path.resolve(here, "../dist/control-ui");
 const CONTROL_UI_GIT_READ_TIMEOUT_MS = 2_000;
 const require = createRequire(import.meta.url);
+const { gzip } = require("pako");
 const json5EsmPath = require.resolve("json5/dist/index.mjs");
 type ControlUiViteAlias = {
   find: string | RegExp;


### PR DESCRIPTION
## What Problem This Solves

In the OpenClaw Control UI (browser), when in a chat session and the agent finishes its response, a loading spinner next to the session name in the sidebar keeps spinning indefinitely, and the "New Session" button remains disabled.

## Root Cause

When the agent finishes, the gateway emits a terminal `sessions.changed` event with `hasActiveRun: false` that should clear the row's active state and stop the spinner. However, two staleness guards in `ui/src/lib/sessions/reconcile.ts` rejected this terminal event when its `updatedAt` timestamp ties or precedes the existing row's `updatedAt`:

- `isOlderSessionSnapshot` rejected `incoming.updatedAt < existing.updatedAt`
- `isStaleForActiveSession` rejected `existing.updatedAt >= incoming.updatedAt` or `existing.startedAt >= incoming.updatedAt`

When both guards fired, `reconcileSessionHistory` returned the same `result` object reference, causing the caller's `result === state.result` publish gate to skip re-rendering the sidebar. The spinner stayed on `hasActiveRun: true` indefinitely.

The timestamp tie occurs because the terminal `sessions.changed` event's `updatedAt` comes from the lifecycle `endedAt` while the prior `session.message` event's `updatedAt` comes from the session row loaded at message-commit time.

## Why This Change Was Made

A terminal projection is authoritative — it represents the gateway's final state for the session run. Timestamp ordering must never prevent a terminal state from clearing an active row, because no subsequent event would correct a blocked terminal projection.

## Refined Fix (addresses ClawSweeper P1 run-identity concern)

The first iteration unconditionally bypassed both staleness guards whenever `hasActiveRun === false`. ClawSweeper correctly flagged this as a P1 risk: a delayed terminal event for an *old* run must NOT clear a newer active run's state.

The refined fix adds `isStaleTerminalForActiveRun` (lines 226-235), which uses `startedAt` as the run discriminator (always available on both the incoming event and the existing row, unlike `activeRunIds` which is `undefined` during active runs). A terminal event is rejected as stale **only when** both `startedAt` values are numbers AND they do not match — meaning the terminal event belongs to a different (superseded) run.

## User Impact

- The loading spinner next to the session name in the sidebar stops immediately after the agent finishes responding.
- The "New Session" button becomes clickable as soon as the agent finishes.
- No more stale/active row state persisting after terminal events.

## Regression Tests

Three tests in `ui/src/lib/sessions/reconcile.test.ts` (`reconcileSessionChanged` describe block):

1. **"clears an active run even when a terminal event has an equal updatedAt (timestamp tie)"** — existing row `updatedAt:100, startedAt:100`; terminal event `updatedAt:100, startedAt:100`; verifies row updated to `hasActiveRun: false, status: "done"`.
2. **"clears an active run when a terminal event updatedAt equals existing startedAt"** — existing row `updatedAt:200, startedAt:100`; terminal event `updatedAt:100, startedAt:100`; verifies row updated to `hasActiveRun: false, status: "done"`.
3. **"does not clear an active run when a terminal event has a mismatched startedAt (stale overlap)"** — existing row `updatedAt:300, startedAt:200, hasActiveRun: true, status: "running"`; terminal event `updatedAt:150, startedAt:100, hasActiveRun: false, status: "done"`; verifies row unchanged (`hasActiveRun: true, status: "running"`).

Tests 1 and 2 fail on pre-fix code and pass after the fix. Test 3 passes on both pre-fix and post-fix (guards the overlap regression).

## Test Results

| Suite | Result |
|-------|--------|
| `reconcile.test.ts` | 25 passed (22 original + 3 new) |
| `index.test.ts` | 31 passed |
| `run-lifecycle.test.ts` | 35 passed |
| Full `ui/src/lib/sessions/` suite | 353 passed across 33 files |
| `session-spinner-clears.e2e.test.ts` (mock-gateway E2E) | 1 passed (41.7s) |

## Real Behavior Proof

A mock-gateway E2E test (`<file>ui/src/e2e/session-spinner-clears.e2e.test.ts</file>`) using the real Control UI source served by Vite + Playwright Chromium verifies the end-to-end behavior:

1. Sets up a session with `hasActiveRun: true, status: "running"` in the mock gateway
2. Navigates to the Control UI chat page
3. Confirms the `session-run-spinner` is visible in the sidebar (spinner looping)
4. Emits a terminal `sessions.changed` event with `hasActiveRun: false, status: "done"` and matching `startedAt`
5. Confirms the spinner disappears (`.session-run-spinner` count → 0)
6. Confirms the "New Session" button is enabled (not `disabled`)

**Before** (`spinner-before.png`): sidebar shows the spinner next to the active session.
**After** (`spinner-after.png`): spinner is gone, session shows terminal status.
Video recording attached from the same run.

## Type Checking & Formatting

- `tsgo` (core + UI): no errors
- `oxfmt --check`: all files use the correct format

## Pathfinder Fix

`ui/vite.config.ts` was updated to resolve a pre-existing `pako` ESM import issue (`import { gzip }` → `const { gzip } = require("pako")`) that blocked the E2E Vite build. This is unrelated to the spinner bug but required for the E2E test harness. `@panzoom/panzoom` was added to `pnpm-lock.yaml` — it was a missing dependency causing build failures.

## Issue

Fixes #126850
