### PR TITLE
fix(imessage): reject bare numeric targets before send

### DIFF
--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -55,10 +55,13 @@ import {
 import { probeIMessageStatusAccount } from "./status-core.js";
 import { isIMessagePhoneLikeHandle } from "./target-identifiers.js";
 import {
+  assertDeliverableIMessageHandle,
   inferIMessageTargetChatType,
   looksLikeIMessageExplicitTargetId,
+  type IMessageService,
   normalizeIMessageHandle,
   parseIMessageTarget,
+  resolveIMessageTargetService,
 } from "./targets.js";
 
 const loadIMessageChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
@@ -426,6 +429,32 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
     outbound: {
       base: {
         deliveryMode: "direct",
+        // Bare-numeric handles need the resolved service before a verdict: a
+        // short code is a legitimate SMS target, so only the account config
+        // decides. Core resolve and dry-run both land here; the send path
+        // re-applies the same helper.
+        resolveTarget: ({ cfg, to, accountId }) => {
+          try {
+            const target = parseIMessageTarget(to ?? "");
+            if (!cfg) {
+              return { ok: true, to: to ?? "" };
+            }
+            const service =
+              resolveIMessageTargetService(target) ??
+              // Plugin-sdk config contracts keep channel values wide.
+              // SAFETY: the imessage schema narrows service to imessage|sms|auto.
+              (resolveIMessageAccount({ cfg, accountId }).config.service as
+                | IMessageService
+                | undefined);
+            assertDeliverableIMessageHandle({ target, service });
+            return { ok: true, to: to ?? "" };
+          } catch (error) {
+            return {
+              ok: false,
+              error: error instanceof Error ? error : new Error(String(error)),
+            };
+          }
+        },
         chunker: chunkMarkdownText,
         chunkerMode: "markdown",
         textChunkLimit: 4000,

--- a/extensions/imessage/src/channel.ts
+++ b/extensions/imessage/src/channel.ts
@@ -429,10 +429,10 @@ export const imessagePlugin: ChannelPlugin<ResolvedIMessageAccount, IMessageProb
     outbound: {
       base: {
         deliveryMode: "direct",
-        // Bare-numeric handles need the resolved service before a verdict: a
-        // short code is a legitimate SMS target, so only the account config
-        // decides. Core resolve and dry-run both land here; the send path
-        // re-applies the same helper.
+        // Bare-numeric handles need the resolved service before a verdict:
+        // sms/auto delivery forwards short codes to Messages, so only
+        // iMessage-only or unset service rejects them. Core resolve and
+        // dry-run both land here; the send path re-applies the same helper.
         resolveTarget: ({ cfg, to, accountId }) => {
           try {
             const target = parseIMessageTarget(to ?? "");

--- a/extensions/imessage/src/chat.test.ts
+++ b/extensions/imessage/src/chat.test.ts
@@ -17,14 +17,14 @@ const accountWithService = (service?: string): ResolvedIMessageAccount =>
   }) as ResolvedIMessageAccount;
 
 // Chat actions only exercise `request`; the RPC client's lifecycle surface is
-// irrelevant here, so the mock asserts the narrow slice it implements.
-const chatClient = () =>
-  ({
-    request: vi.fn(async () => ({ ok: true })),
-    stop: vi.fn(),
-  }) as unknown as IMessageRpcClient;
+// irrelevant here. The mock is held in a standalone variable so assertions
+// never reference the method through the typed client (unbound-method).
+const chatClient = (): { client: IMessageRpcClient; request: ReturnType<typeof vi.fn> } => {
+  const request = vi.fn(async () => ({ ok: true }));
+  return { client: { request, stop: vi.fn() } as unknown as IMessageRpcClient, request };
+};
 
-const chatOpts = (client: ReturnType<typeof chatClient>, service?: string) => ({
+const chatOpts = (client: ReturnType<typeof chatClient>["client"], service?: string) => ({
   cfg: { channels: { imessage: {} } } as OpenClawConfig,
   account: accountWithService(service),
   client,
@@ -32,9 +32,9 @@ const chatOpts = (client: ReturnType<typeof chatClient>, service?: string) => ({
 
 describe("imessage chat actions", () => {
   it("lets a configured SMS account reach bare short codes for typing", async () => {
-    const client = chatClient();
+    const { client, request } = chatClient();
     await sendIMessageTyping("12345", true, chatOpts(client, "sms"));
-    expect(client.request).toHaveBeenCalledWith(
+    expect(request).toHaveBeenCalledWith(
       "typing",
       expect.objectContaining({ to: "12345", service: "sms", typing: true }),
       expect.anything(),
@@ -42,11 +42,11 @@ describe("imessage chat actions", () => {
   });
 
   it("lets a configured SMS account reach bare short codes for read receipts", async () => {
-    const client = chatClient();
+    const { client, request } = chatClient();
     await markIMessageChatRead("12345", chatOpts(client, "sms"));
     // Read RPCs carry no service field; the resolved service only gates the
     // deliverability verdict.
-    expect(client.request).toHaveBeenCalledWith(
+    expect(request).toHaveBeenCalledWith(
       "read",
       expect.objectContaining({ to: "12345" }),
       expect.anything(),
@@ -54,25 +54,25 @@ describe("imessage chat actions", () => {
   });
 
   it("still rejects bare short codes when no service resolves to sms", async () => {
-    const client = chatClient();
+    const { client, request } = chatClient();
     await expect(sendIMessageTyping("12345", true, chatOpts(client))).rejects.toThrow(
       /not a deliverable handle/,
     );
-    expect(client.request).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("still rejects bare short codes on the default imessage service", async () => {
-    const client = chatClient();
+    const { client, request } = chatClient();
     await expect(markIMessageChatRead("12345", chatOpts(client, "imessage"))).rejects.toThrow(
       /not a deliverable handle/,
     );
-    expect(client.request).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
   });
 
   it("keeps explicit sms short codes deliverable", async () => {
-    const client = chatClient();
+    const { client, request } = chatClient();
     await sendIMessageTyping("sms:12345", true, chatOpts(client));
-    expect(client.request).toHaveBeenCalledWith(
+    expect(request).toHaveBeenCalledWith(
       "typing",
       expect.objectContaining({ to: "12345", service: "sms" }),
       expect.anything(),
@@ -82,9 +82,9 @@ describe("imessage chat actions", () => {
   it("lets an explicit auto short code reach Messages selection", async () => {
     // `auto:<contact>` is the documented form that lets Messages choose
     // iMessage or SMS; the verdict must not reject it before delivery.
-    const client = chatClient();
+    const { client, request } = chatClient();
     await sendIMessageTyping("auto:12345", true, chatOpts(client));
-    expect(client.request).toHaveBeenCalledWith(
+    expect(request).toHaveBeenCalledWith(
       "typing",
       expect.objectContaining({ to: "12345", service: "auto" }),
       expect.anything(),

--- a/extensions/imessage/src/chat.test.ts
+++ b/extensions/imessage/src/chat.test.ts
@@ -53,12 +53,17 @@ describe("imessage chat actions", () => {
     );
   });
 
-  it("still rejects bare short codes when no service resolves to sms", async () => {
+  it("lets the unset service default reach bare short codes", async () => {
+    // Chat RPCs omit the service field when none resolves, so the bridge
+    // applies its automatic default; the verdict must not reject a request
+    // delivery would have sent.
     const { client, request } = chatClient();
-    await expect(sendIMessageTyping("12345", true, chatOpts(client))).rejects.toThrow(
-      /not a deliverable handle/,
+    await sendIMessageTyping("12345", true, chatOpts(client));
+    expect(request).toHaveBeenCalledWith(
+      "typing",
+      expect.objectContaining({ to: "12345", typing: true }),
+      expect.anything(),
     );
-    expect(request).not.toHaveBeenCalled();
   });
 
   it("still rejects bare short codes on the default imessage service", async () => {

--- a/extensions/imessage/src/chat.test.ts
+++ b/extensions/imessage/src/chat.test.ts
@@ -1,0 +1,93 @@
+// Imessage tests cover the chat-action service contract: a parser-default
+// "auto" service must defer to the account's configured service before the
+// deliverability verdict, or configured SMS accounts lose typing/read actions
+// on bare short codes.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it, vi } from "vitest";
+import type { ResolvedIMessageAccount } from "./accounts.js";
+import { markIMessageChatRead, sendIMessageTyping } from "./chat.js";
+import type { IMessageRpcClient } from "./client.js";
+
+const accountWithService = (service?: string): ResolvedIMessageAccount =>
+  ({
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    config: service ? { service } : {},
+  }) as ResolvedIMessageAccount;
+
+// Chat actions only exercise `request`; the RPC client's lifecycle surface is
+// irrelevant here, so the mock asserts the narrow slice it implements.
+const chatClient = () =>
+  ({
+    request: vi.fn(async () => ({ ok: true })),
+    stop: vi.fn(),
+  }) as unknown as IMessageRpcClient;
+
+const chatOpts = (client: ReturnType<typeof chatClient>, service?: string) => ({
+  cfg: { channels: { imessage: {} } } as OpenClawConfig,
+  account: accountWithService(service),
+  client,
+});
+
+describe("imessage chat actions", () => {
+  it("lets a configured SMS account reach bare short codes for typing", async () => {
+    const client = chatClient();
+    await sendIMessageTyping("12345", true, chatOpts(client, "sms"));
+    expect(client.request).toHaveBeenCalledWith(
+      "typing",
+      expect.objectContaining({ to: "12345", service: "sms", typing: true }),
+      expect.anything(),
+    );
+  });
+
+  it("lets a configured SMS account reach bare short codes for read receipts", async () => {
+    const client = chatClient();
+    await markIMessageChatRead("12345", chatOpts(client, "sms"));
+    // Read RPCs carry no service field; the resolved service only gates the
+    // deliverability verdict.
+    expect(client.request).toHaveBeenCalledWith(
+      "read",
+      expect.objectContaining({ to: "12345" }),
+      expect.anything(),
+    );
+  });
+
+  it("still rejects bare short codes when no service resolves to sms", async () => {
+    const client = chatClient();
+    await expect(sendIMessageTyping("12345", true, chatOpts(client))).rejects.toThrow(
+      /not a deliverable handle/,
+    );
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("still rejects bare short codes on the default imessage service", async () => {
+    const client = chatClient();
+    await expect(markIMessageChatRead("12345", chatOpts(client, "imessage"))).rejects.toThrow(
+      /not a deliverable handle/,
+    );
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit sms short codes deliverable", async () => {
+    const client = chatClient();
+    await sendIMessageTyping("sms:12345", true, chatOpts(client));
+    expect(client.request).toHaveBeenCalledWith(
+      "typing",
+      expect.objectContaining({ to: "12345", service: "sms" }),
+      expect.anything(),
+    );
+  });
+
+  it("lets an explicit auto short code reach Messages selection", async () => {
+    // `auto:<contact>` is the documented form that lets Messages choose
+    // iMessage or SMS; the verdict must not reject it before delivery.
+    const client = chatClient();
+    await sendIMessageTyping("auto:12345", true, chatOpts(client));
+    expect(client.request).toHaveBeenCalledWith(
+      "typing",
+      expect.objectContaining({ to: "12345", service: "auto" }),
+      expect.anything(),
+    );
+  });
+});

--- a/extensions/imessage/src/chat.ts
+++ b/extensions/imessage/src/chat.ts
@@ -50,8 +50,8 @@ function buildChatTargetParams(
   }
   // Chat actions share the send/resolver precedence: an explicit service wins,
   // while a parser-default "auto" defers to the account's configured service
-  // before the deliverability verdict, so configured SMS short codes still
-  // reach typing/read RPCs.
+  // before the deliverability verdict, so configured sms/auto accounts keep
+  // short codes on typing/read RPCs.
   const service =
     opts.service ??
     resolveIMessageTargetService(target) ??

--- a/extensions/imessage/src/chat.ts
+++ b/extensions/imessage/src/chat.ts
@@ -4,7 +4,13 @@ import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime"
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
 import { resolveIMessageRemoteHost } from "./remote-host.js";
-import { formatIMessageChatTarget, type IMessageService, parseIMessageTarget } from "./targets.js";
+import {
+  assertDeliverableIMessageHandle,
+  formatIMessageChatTarget,
+  type IMessageService,
+  parseIMessageTarget,
+  resolveIMessageTargetService,
+} from "./targets.js";
 
 type ChatActionOpts = {
   cfg: OpenClawConfig;
@@ -42,10 +48,15 @@ function buildChatTargetParams(
   } else {
     params.to = target.to;
   }
+  // Chat actions share the send/resolver precedence: an explicit service wins,
+  // while a parser-default "auto" defers to the account's configured service
+  // before the deliverability verdict, so configured SMS short codes still
+  // reach typing/read RPCs.
   const service =
     opts.service ??
-    (target.kind === "handle" ? target.service : undefined) ??
+    resolveIMessageTargetService(target) ??
     (account.config.service as IMessageService | undefined);
+  assertDeliverableIMessageHandle({ target, service });
   const region = opts.region?.trim() || account.config.region?.trim() || "US";
   return { params, service, region, account };
 }

--- a/extensions/imessage/src/outbound-resolve-target.test.ts
+++ b/extensions/imessage/src/outbound-resolve-target.test.ts
@@ -12,8 +12,16 @@ const cfgWithService = (service?: string): OpenClawConfig =>
   }) as OpenClawConfig;
 
 describe("imessage outbound resolveTarget", () => {
-  it("rejects short phone-like handles once the resolved service is not sms", () => {
-    expect(resolveTarget?.({ cfg: cfgWithService(), to: "5" })).toMatchObject({
+  it("keeps unset-service short handles deliverable; delivery defaults them to auto", () => {
+    expect(resolveTarget?.({ cfg: cfgWithService(), to: "5" })).toEqual({ ok: true, to: "5" });
+    expect(resolveTarget?.({ cfg: cfgWithService("auto"), to: "5" })).toEqual({
+      ok: true,
+      to: "5",
+    });
+  });
+
+  it("rejects short phone-like handles when the account pins iMessage", () => {
+    expect(resolveTarget?.({ cfg: cfgWithService("imessage"), to: "5" })).toMatchObject({
       ok: false,
     });
   });

--- a/extensions/imessage/src/outbound-resolve-target.test.ts
+++ b/extensions/imessage/src/outbound-resolve-target.test.ts
@@ -1,0 +1,48 @@
+// Imessage tests cover the outbound target resolution contract that core
+// resolve and dry-run paths share with the send handler.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { describe, expect, it } from "vitest";
+import { imessagePlugin } from "./channel.js";
+
+const resolveTarget = imessagePlugin.outbound?.resolveTarget;
+
+const cfgWithService = (service?: string): OpenClawConfig =>
+  ({
+    channels: { imessage: service ? { service } : {} },
+  }) as OpenClawConfig;
+
+describe("imessage outbound resolveTarget", () => {
+  it("rejects short phone-like handles once the resolved service is not sms", () => {
+    expect(resolveTarget?.({ cfg: cfgWithService(), to: "5" })).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("accepts short codes when the target explicitly selects sms", () => {
+    expect(resolveTarget?.({ cfg: cfgWithService(), to: "sms:5" })).toEqual({
+      ok: true,
+      to: "sms:5",
+    });
+  });
+
+  it("accepts short codes when the account config selects sms", () => {
+    expect(resolveTarget?.({ cfg: cfgWithService("sms"), to: "5" })).toEqual({
+      ok: true,
+      to: "5",
+    });
+  });
+
+  it("accepts full phone handles, email handles, and chat rows", () => {
+    for (const to of ["+14155551234", "user@example.com", "chat_id:5"]) {
+      expect(resolveTarget?.({ cfg: cfgWithService(), to })).toEqual({ ok: true, to });
+    }
+  });
+
+  it("cannot judge a target without account config, so it stays permissive", () => {
+    expect(resolveTarget?.({ to: "5" })).toEqual({ ok: true, to: "5" });
+  });
+
+  it("rejects empty targets", () => {
+    expect(resolveTarget?.({ cfg: cfgWithService(), to: "" })).toMatchObject({ ok: false });
+  });
+});

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -99,14 +99,24 @@ function createApprovalPrompt(id = "approval-123") {
 describe("sendMessageIMessage receipts", () => {
   let openClawState: OpenClawTestState;
 
-  it("rejects bare short handles only without an sms/auto path and delivers them otherwise (#125461)", async () => {
+  it("rejects bare short handles only for iMessage-only delivery and delivers them otherwise (#125461)", async () => {
     await loadFreshSendModule();
     const client = createClient({ guid: "p:0/imsg-sms-short-code", status: "sent" });
-    // No typed prefix and no configured service: the bare digit string is a
-    // chat row id typo on the default iMessage path, so it fails before any
-    // RPC.
+    // No typed prefix and no configured service: the send RPC still delivers
+    // this as auto (`service || "auto"`), so the guard must not reject a
+    // target delivery would have accepted.
+    await sendMessageIMessage("12345", "hello", { config: IMESSAGE_TEST_CFG, client });
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ to: "12345", service: "auto" }),
+      expect.anything(),
+    );
+    getClientMocks(client).request.mockClear();
+
+    // Delivery pinned to iMessage is the one path that cannot resolve a bare
+    // digit string, so it fails before any RPC.
     await expect(
-      sendMessageIMessage("5", "hello", { config: IMESSAGE_TEST_CFG, client }),
+      sendMessageIMessage("imessage:5", "hello", { config: IMESSAGE_TEST_CFG, client }),
     ).rejects.toThrow(/chat_id/);
     expect(getClientMocks(client).request).not.toHaveBeenCalled();
 

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -99,11 +99,12 @@ function createApprovalPrompt(id = "approval-123") {
 describe("sendMessageIMessage receipts", () => {
   let openClawState: OpenClawTestState;
 
-  it("rejects a bare short numeric handle over auto/iMessage but delivers it as an SMS short code (#125461)", async () => {
+  it("rejects bare short handles only without an sms/auto path and delivers them otherwise (#125461)", async () => {
     await loadFreshSendModule();
     const client = createClient({ guid: "p:0/imsg-sms-short-code", status: "sent" });
-    // Auto service rides the iMessage transport, where a bare digit string is
-    // a chat row id typo rather than a deliverable handle.
+    // No typed prefix and no configured service: the bare digit string is a
+    // chat row id typo on the default iMessage path, so it fails before any
+    // RPC.
     await expect(
       sendMessageIMessage("5", "hello", { config: IMESSAGE_TEST_CFG, client }),
     ).rejects.toThrow(/chat_id/);
@@ -115,6 +116,19 @@ describe("sendMessageIMessage receipts", () => {
     };
     await sendMessageIMessage("12345", "hello", { config: smsCfg, client });
     expect(getClientMocks(client).request).toHaveBeenCalled();
+    getClientMocks(client).request.mockClear();
+
+    // A configured automatic account keeps its pre-guard short-code routing:
+    // Messages receives the handle plus region and resolves it natively.
+    const autoCfg = {
+      channels: { imessage: { service: "auto" as const, accounts: { default: {} } } },
+    };
+    await sendMessageIMessage("12345", "hello", { config: autoCfg, client });
+    expect(getClientMocks(client).request).toHaveBeenCalledWith(
+      "send",
+      expect.objectContaining({ to: "12345", service: "auto" }),
+      expect.anything(),
+    );
     getClientMocks(client).request.mockClear();
 
     // An option-selected service wins the same way.

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -99,6 +99,33 @@ function createApprovalPrompt(id = "approval-123") {
 describe("sendMessageIMessage receipts", () => {
   let openClawState: OpenClawTestState;
 
+  it("rejects a bare short numeric handle over auto/iMessage but delivers it as an SMS short code (#125461)", async () => {
+    await loadFreshSendModule();
+    const client = createClient({ guid: "p:0/imsg-sms-short-code", status: "sent" });
+    // Auto service rides the iMessage transport, where a bare digit string is
+    // a chat row id typo rather than a deliverable handle.
+    await expect(
+      sendMessageIMessage("5", "hello", { config: IMESSAGE_TEST_CFG, client }),
+    ).rejects.toThrow(/chat_id/);
+    expect(getClientMocks(client).request).not.toHaveBeenCalled();
+
+    // A configured SMS service turns the same short code into a valid target.
+    const smsCfg = {
+      channels: { imessage: { service: "sms" as const, accounts: { default: {} } } },
+    };
+    await sendMessageIMessage("12345", "hello", { config: smsCfg, client });
+    expect(getClientMocks(client).request).toHaveBeenCalled();
+    getClientMocks(client).request.mockClear();
+
+    // An option-selected service wins the same way.
+    await sendMessageIMessage("12345", "hello", {
+      config: IMESSAGE_TEST_CFG,
+      service: "sms",
+      client,
+    });
+    expect(getClientMocks(client).request).toHaveBeenCalled();
+  });
+
   beforeEach(async () => {
     openClawState = await createOpenClawTestState({
       layout: "state-only",

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -834,8 +834,9 @@ export async function sendMessageIMessage(
     opts.service ??
     resolveIMessageTargetService(target) ??
     (account.config.service as IMessageService | undefined);
-  // The bare-numeric verdict needs the effective service: a short code is a
-  // legitimate SMS target, so only reject it once "sms" failed to win.
+  // The bare-numeric verdict needs the effective service: sms and auto pass
+  // short codes through to Messages; only iMessage-only or unset service
+  // delivery rejects them.
   assertDeliverableIMessageHandle({ target, service });
   const sendTransport = (account.config.sendTransport ?? "auto") as IMessageSendTransport;
   const resolvedReplyToId = resolveAuthorizedIMessageReplyReference({

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -66,10 +66,12 @@ import {
 import { withIMessageRemoteFile } from "./remote-file.js";
 import { resolveIMessageRemoteHost } from "./remote-host.js";
 import {
+  assertDeliverableIMessageHandle,
   formatIMessageChatTarget,
   type IMessageService,
   normalizeIMessageHandle,
   parseIMessageTarget,
+  resolveIMessageTargetService,
 } from "./targets.js";
 
 type ParsedIMessageTarget = ReturnType<typeof parseIMessageTarget>;
@@ -198,16 +200,6 @@ function resolveOutboundMessageGuid(
 
 function isNumericMessageRowId(value: string | null | undefined): value is string {
   return typeof value === "string" && /^\d+$/.test(value.trim());
-}
-
-function resolveTargetService(target: ParsedIMessageTarget): IMessageService | undefined {
-  if (target.kind !== "handle") {
-    return undefined;
-  }
-  if (target.serviceExplicit || target.service !== "auto") {
-    return target.service;
-  }
-  return undefined;
 }
 
 function normalizeResolvedMessageGuid(value: unknown): string | null {
@@ -840,8 +832,11 @@ export async function sendMessageIMessage(
   const target = parseIMessageTarget(opts.chatId ? formatIMessageChatTarget(opts.chatId) : to);
   const service =
     opts.service ??
-    resolveTargetService(target) ??
+    resolveIMessageTargetService(target) ??
     (account.config.service as IMessageService | undefined);
+  // The bare-numeric verdict needs the effective service: a short code is a
+  // legitimate SMS target, so only reject it once "sms" failed to win.
+  assertDeliverableIMessageHandle({ target, service });
   const sendTransport = (account.config.sendTransport ?? "auto") as IMessageSendTransport;
   const resolvedReplyToId = resolveAuthorizedIMessageReplyReference({
     account,

--- a/extensions/imessage/src/status.test.ts
+++ b/extensions/imessage/src/status.test.ts
@@ -17,6 +17,26 @@ import { createIMessageSetupWizardProxy } from "./setup-core.js";
 import { imessageSetupWizard } from "./setup-surface.js";
 import { probeIMessageStatusAccount } from "./status-core.js";
 
+// iMessage setup-status labels are translated once at module evaluation
+// (setup-core derives its status base from module-scope translator output), so
+// the locale must already be English when the imports above resolve for the
+// asserted copy to exist. vi.hoisted runs before those imports; the afterAll
+// restore hands the developer locale back because a raw assignment is
+// invisible to the runner's vi.unstubAllEnvs file cleanup.
+const restorePinnedLocale = vi.hoisted(() => {
+  const original = process.env.OPENCLAW_LOCALE;
+  process.env.OPENCLAW_LOCALE = "en";
+  return () => {
+    if (original === undefined) {
+      delete process.env.OPENCLAW_LOCALE;
+    } else {
+      process.env.OPENCLAW_LOCALE = original;
+    }
+  };
+});
+
+afterAll(() => restorePinnedLocale());
+
 const getIMessageSetupStatus = createPluginSetupWizardStatus({
   id: "imessage",
   meta: {

--- a/extensions/imessage/src/targets.test.ts
+++ b/extensions/imessage/src/targets.test.ts
@@ -211,17 +211,20 @@ describe("imessage targets", () => {
     expect(parseIMessageTarget("5")).toEqual({ kind: "handle", to: "5", service: "auto" });
   });
 
-  it("reports undeliverable bare numeric handles unless delivery has an SMS path (#125461)", () => {
+  it("reports undeliverable bare numeric handles unless delivery has an sms/auto path (#125461)", () => {
     // A bare digit string looks like a Messages chat row id, not a phone
     // handle; pre-fix it normalized to `+<digits>` and the channel send
     // silently failed (-1728). The error must steer the caller to chat_id /
     // full E.164 / sms: / auto:.
     const bareTarget = parseIMessageTarget("5");
     const shortE164 = parseIMessageTarget("+123456");
-    const rejectedAsHandle = (target: IMessageTarget, service: IMessageService) =>
+    const rejectedAsHandle = (target: IMessageTarget, service: IMessageService | undefined) =>
       expect(() => assertDeliverableIMessageHandle({ target, service }));
-    rejectedAsHandle(bareTarget, "auto").toThrow(/chat_id/);
-    rejectedAsHandle(bareTarget, "auto").toThrow(/sms:/);
+    // The default path (no typed prefix, no account service) keeps the
+    // row-id-typo verdict, as does explicit iMessage-only delivery.
+    rejectedAsHandle(bareTarget, undefined).toThrow(/chat_id/);
+    rejectedAsHandle(bareTarget, undefined).toThrow(/sms:/);
+    rejectedAsHandle(bareTarget, "imessage").toThrow(/chat_id/);
     rejectedAsHandle(shortE164, "imessage").toThrow(/chat_id/);
     // An SMS short code is a legitimate target once the service resolves to
     // sms, whether from the typed prefix or the account configuration.
@@ -234,22 +237,26 @@ describe("imessage targets", () => {
         service: "sms",
       }),
     ).not.toThrow();
-    // An explicit `auto:` prefix is the documented `auto:<contact>` contract:
-    // the operator asked Messages to choose iMessage or SMS, so a short code
-    // is intent, not a row-id typo. An account-level `auto` default keeps the
-    // verdict — only the typed prefix carries it.
+    // A configured automatic account keeps its short-code routing: Messages
+    // receives the handle and configured region and resolves them natively,
+    // exactly as before the guard existed. The documented `auto:<contact>`
+    // prefix resolves to the same effective service at every call site, so
+    // the passed-in service is the single verdict input.
     expect(() =>
       assertDeliverableIMessageHandle({
         target: parseIMessageTarget("auto:12345"),
         service: "auto",
       }),
     ).not.toThrow();
+    // A short local-format handle (region-dependent digits) stays deliverable
+    // on the automatic path for the same reason.
     expect(() =>
       assertDeliverableIMessageHandle({
-        target: parseIMessageTarget("auto:12345"),
-        service: undefined,
+        target: parseIMessageTarget("683 412"),
+        service: "auto",
       }),
     ).not.toThrow();
+    rejectedAsHandle(parseIMessageTarget("683 412"), "imessage").toThrow(/chat_id/);
     // Explicit iMessage selection still rejects a handle that cannot be one.
     rejectedAsHandle(parseIMessageTarget("imessage:12345"), "imessage").toThrow(/chat_id/);
     // Full E.164 handles and non-phone targets stay deliverable.

--- a/extensions/imessage/src/targets.test.ts
+++ b/extensions/imessage/src/targets.test.ts
@@ -8,7 +8,9 @@ import {
 } from "./group-policy.js";
 import { imessageDmPolicy } from "./setup-core.js";
 import { parseIMessageAllowFromEntries } from "./setup-surface.js";
+import type { IMessageService, IMessageTarget } from "./targets.js";
 import {
+  assertDeliverableIMessageHandle,
   formatIMessageChatTarget,
   inferIMessageTargetChatType,
   isAllowedIMessageReplyContextSender,
@@ -201,6 +203,75 @@ describe("imessage targets", () => {
       kind: "chat_identifier",
       chatIdentifier: identifier,
     });
+  });
+
+  it("parses bare numeric handles structurally; deliverability is a send-layer verdict (#125461)", () => {
+    // Parsing stays structural so a configured `service: "sms"` short code can
+    // reach the SMS transport; the send layer owns the deliverability verdict.
+    expect(parseIMessageTarget("5")).toEqual({ kind: "handle", to: "5", service: "auto" });
+  });
+
+  it("reports undeliverable bare numeric handles unless delivery has an SMS path (#125461)", () => {
+    // A bare digit string looks like a Messages chat row id, not a phone
+    // handle; pre-fix it normalized to `+<digits>` and the channel send
+    // silently failed (-1728). The error must steer the caller to chat_id /
+    // full E.164 / sms: / auto:.
+    const bareTarget = parseIMessageTarget("5");
+    const shortE164 = parseIMessageTarget("+123456");
+    const rejectedAsHandle = (target: IMessageTarget, service: IMessageService) =>
+      expect(() => assertDeliverableIMessageHandle({ target, service }));
+    rejectedAsHandle(bareTarget, "auto").toThrow(/chat_id/);
+    rejectedAsHandle(bareTarget, "auto").toThrow(/sms:/);
+    rejectedAsHandle(shortE164, "imessage").toThrow(/chat_id/);
+    // An SMS short code is a legitimate target once the service resolves to
+    // sms, whether from the typed prefix or the account configuration.
+    expect(() =>
+      assertDeliverableIMessageHandle({ target: bareTarget, service: "sms" }),
+    ).not.toThrow();
+    expect(() =>
+      assertDeliverableIMessageHandle({
+        target: parseIMessageTarget("sms:12345"),
+        service: "sms",
+      }),
+    ).not.toThrow();
+    // An explicit `auto:` prefix is the documented `auto:<contact>` contract:
+    // the operator asked Messages to choose iMessage or SMS, so a short code
+    // is intent, not a row-id typo. An account-level `auto` default keeps the
+    // verdict — only the typed prefix carries it.
+    expect(() =>
+      assertDeliverableIMessageHandle({
+        target: parseIMessageTarget("auto:12345"),
+        service: "auto",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertDeliverableIMessageHandle({
+        target: parseIMessageTarget("auto:12345"),
+        service: undefined,
+      }),
+    ).not.toThrow();
+    // Explicit iMessage selection still rejects a handle that cannot be one.
+    rejectedAsHandle(parseIMessageTarget("imessage:12345"), "imessage").toThrow(/chat_id/);
+    // Full E.164 handles and non-phone targets stay deliverable.
+    expect(() =>
+      assertDeliverableIMessageHandle({
+        target: parseIMessageTarget("+15552223333"),
+        service: "auto",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertDeliverableIMessageHandle({
+        target: parseIMessageTarget("user@example.com"),
+        service: "auto",
+      }),
+    ).not.toThrow();
+    // Chat-scoped targets never hit the handle verdict.
+    expect(() =>
+      assertDeliverableIMessageHandle({
+        target: parseIMessageTarget("chat_id:5"),
+        service: "auto",
+      }),
+    ).not.toThrow();
   });
 });
 

--- a/extensions/imessage/src/targets.test.ts
+++ b/extensions/imessage/src/targets.test.ts
@@ -211,7 +211,7 @@ describe("imessage targets", () => {
     expect(parseIMessageTarget("5")).toEqual({ kind: "handle", to: "5", service: "auto" });
   });
 
-  it("reports undeliverable bare numeric handles unless delivery has an sms/auto path (#125461)", () => {
+  it("reports undeliverable bare numeric handles only when delivery is pinned to iMessage (#125461)", () => {
     // A bare digit string looks like a Messages chat row id, not a phone
     // handle; pre-fix it normalized to `+<digits>` and the channel send
     // silently failed (-1728). The error must steer the caller to chat_id /
@@ -220,11 +220,20 @@ describe("imessage targets", () => {
     const shortE164 = parseIMessageTarget("+123456");
     const rejectedAsHandle = (target: IMessageTarget, service: IMessageService | undefined) =>
       expect(() => assertDeliverableIMessageHandle({ target, service }));
-    // The default path (no typed prefix, no account service) keeps the
-    // row-id-typo verdict, as does explicit iMessage-only delivery.
-    rejectedAsHandle(bareTarget, undefined).toThrow(/chat_id/);
-    rejectedAsHandle(bareTarget, undefined).toThrow(/sms:/);
+    // An unset service is delivered as auto (the send RPC defaults it via
+    // `service || "auto"`, the chat RPCs omit the field so the bridge
+    // chooses), so it keeps the short-code routing that worked before this
+    // guard existed.
+    expect(() =>
+      assertDeliverableIMessageHandle({ target: bareTarget, service: undefined }),
+    ).not.toThrow();
+    expect(() =>
+      assertDeliverableIMessageHandle({ target: shortE164, service: undefined }),
+    ).not.toThrow();
+    // Explicit iMessage-only delivery is the one path that can prove the
+    // row-id-typo verdict.
     rejectedAsHandle(bareTarget, "imessage").toThrow(/chat_id/);
+    rejectedAsHandle(bareTarget, "imessage").toThrow(/sms:/);
     rejectedAsHandle(shortE164, "imessage").toThrow(/chat_id/);
     // An SMS short code is a legitimate target once the service resolves to
     // sms, whether from the typed prefix or the account configuration.
@@ -254,6 +263,12 @@ describe("imessage targets", () => {
       assertDeliverableIMessageHandle({
         target: parseIMessageTarget("683 412"),
         service: "auto",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertDeliverableIMessageHandle({
+        target: parseIMessageTarget("683 412"),
+        service: undefined,
       }),
     ).not.toThrow();
     rejectedAsHandle(parseIMessageTarget("683 412"), "imessage").toThrow(/chat_id/);

--- a/extensions/imessage/src/targets.ts
+++ b/extensions/imessage/src/targets.ts
@@ -101,12 +101,12 @@ export function normalizeIMessageHandle(raw: string): string {
 
 // iMessage phone handles are real numbers; a value with fewer than 7 digits (a
 // Messages chat row id typo like `5`, or `+123456`) cannot reach an iMessage
-// handle. Whether that is a defect depends on the delivery path: sms and auto
-// hand the handle plus configured region to Messages, which resolves short
-// codes natively, so only iMessage-only delivery can prove the verdict. An
-// unset service keeps the default-path verdict — bare digit strings fail
-// before any send. Both the outbound resolve chain and the send handler apply
-// this.
+// handle. Whether that is a defect depends on the delivery path: sms, auto,
+// and an unset service (the send RPC defaults it to auto, the chat RPCs omit
+// it so the bridge chooses) all hand the handle plus configured region to
+// Messages, which resolves short codes natively. Only delivery pinned to
+// iMessage can prove the verdict. Both the outbound resolve chain and the send
+// handler apply this.
 const MIN_PHONE_HANDLE_DIGITS = 7;
 
 export function assertDeliverableIMessageHandle(params: {
@@ -117,11 +117,11 @@ export function assertDeliverableIMessageHandle(params: {
   if (target.kind !== "handle") {
     return;
   }
-  // Callers pass the effective service: explicit target prefix first, then
-  // the account configuration. Any sms or auto delivery forwards short codes
-  // (and region) to Messages — rejecting them here would break configured
-  // automatic routing that worked before this guard existed.
-  if (service === "sms" || service === "auto") {
+  // Callers pass the effective service: explicit target prefix first, then the
+  // account configuration, then the delivery default. Only iMessage-only
+  // delivery rejects short handles here — rejecting the unset default too
+  // would break the automatic routing that worked before this guard existed.
+  if (service !== "imessage") {
     return;
   }
   const tooShortForAPhone =

--- a/extensions/imessage/src/targets.ts
+++ b/extensions/imessage/src/targets.ts
@@ -99,6 +99,52 @@ export function normalizeIMessageHandle(raw: string): string {
   return trimmed.replace(/\s+/g, "");
 }
 
+// iMessage phone handles are real numbers; a value with fewer than 7 digits (a
+// Messages chat row id typo like `5`, or `+123456`) cannot reach an iMessage
+// handle. Whether that is a defect depends on the delivery path: the same
+// value is a valid SMS short code once the service resolves to `sms`, and an
+// explicit `auto:` prefix hands the choice to Messages, so the verdict needs
+// the resolved service and the target's own intent, not parsing alone — both
+// the outbound resolve chain and the send handler apply it.
+const MIN_PHONE_HANDLE_DIGITS = 7;
+
+export function assertDeliverableIMessageHandle(params: {
+  target: IMessageTarget;
+  service: IMessageService | undefined;
+}): void {
+  const { target, service } = params;
+  if (target.kind !== "handle") {
+    return;
+  }
+  // A short code is legitimate once delivery has an SMS path: the service
+  // resolved to `sms`, or the operator typed `auto:` (documented
+  // `auto:<contact>` contract). An account-level `auto` default carries no
+  // per-target intent, so a bare digit string keeps the row-id-typo verdict.
+  if (service === "sms" || resolveIMessageTargetService(target) === "auto") {
+    return;
+  }
+  const tooShortForAPhone =
+    isIMessagePhoneLikeHandle(target.to) &&
+    target.to.replace(/\D/g, "").length < MIN_PHONE_HANDLE_DIGITS;
+  if (tooShortForAPhone) {
+    throw new Error(
+      `iMessage target "${target.to}" is not a deliverable handle. Use chat_id:<rowid> for a Messages chat row, a full E.164 handle beginning with +, sms:<short-code> for an SMS short code, or auto:<contact> to let Messages choose iMessage or SMS.`,
+    );
+  }
+}
+
+/** Explicit service prefixes and non-auto services win; "auto" defers to the
+ * account's configured service. */
+export function resolveIMessageTargetService(target: IMessageTarget): IMessageService | undefined {
+  if (target.kind !== "handle") {
+    return undefined;
+  }
+  if (target.serviceExplicit || target.service !== "auto") {
+    return target.service;
+  }
+  return undefined;
+}
+
 export function parseIMessageTarget(raw: string): IMessageTarget {
   const trimmed = raw.trim();
   if (!trimmed) {

--- a/extensions/imessage/src/targets.ts
+++ b/extensions/imessage/src/targets.ts
@@ -101,11 +101,12 @@ export function normalizeIMessageHandle(raw: string): string {
 
 // iMessage phone handles are real numbers; a value with fewer than 7 digits (a
 // Messages chat row id typo like `5`, or `+123456`) cannot reach an iMessage
-// handle. Whether that is a defect depends on the delivery path: the same
-// value is a valid SMS short code once the service resolves to `sms`, and an
-// explicit `auto:` prefix hands the choice to Messages, so the verdict needs
-// the resolved service and the target's own intent, not parsing alone — both
-// the outbound resolve chain and the send handler apply it.
+// handle. Whether that is a defect depends on the delivery path: sms and auto
+// hand the handle plus configured region to Messages, which resolves short
+// codes natively, so only iMessage-only delivery can prove the verdict. An
+// unset service keeps the default-path verdict — bare digit strings fail
+// before any send. Both the outbound resolve chain and the send handler apply
+// this.
 const MIN_PHONE_HANDLE_DIGITS = 7;
 
 export function assertDeliverableIMessageHandle(params: {
@@ -116,11 +117,11 @@ export function assertDeliverableIMessageHandle(params: {
   if (target.kind !== "handle") {
     return;
   }
-  // A short code is legitimate once delivery has an SMS path: the service
-  // resolved to `sms`, or the operator typed `auto:` (documented
-  // `auto:<contact>` contract). An account-level `auto` default carries no
-  // per-target intent, so a bare digit string keeps the row-id-typo verdict.
-  if (service === "sms" || resolveIMessageTargetService(target) === "auto") {
+  // Callers pass the effective service: explicit target prefix first, then
+  // the account configuration. Any sms or auto delivery forwards short codes
+  // (and region) to Messages — rejecting them here would break configured
+  // automatic routing that worked before this guard existed.
+  if (service === "sms" || service === "auto") {
     return;
   }
   const tooShortForAPhone =

--- a/src/agents/subagents/spawn/subagent-spawn.authority.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.authority.test.ts
@@ -113,7 +113,12 @@ describe("pending spawn invocation authority", () => {
         stream: "lifecycle",
         data: { phase: "end", endedAt: Date.now() },
       });
-      await vi.waitFor(() => expect(findTaskByRunId("b")?.status).toBe("succeeded"));
+      // The lifecycle completion crosses the shared root-work admission lease and
+      // the SQLite registry write; a cold module cache or a loaded CI shard can
+      // push that chain past vitest's default 1s waitFor window.
+      await vi.waitFor(() => expect(findTaskByRunId("b")?.status).toBe("succeeded"), {
+        timeout: 10_000,
+      });
       clearAgentRunContext("b");
       await settleSubagentRegistryPersistenceWork();
       expect(completedB).toMatchObject({

--- a/src/infra/outbound/channel-target.test.ts
+++ b/src/infra/outbound/channel-target.test.ts
@@ -1,7 +1,7 @@
 // Verifies message-action target parameter mapping and legacy destination
 // rejection across target modes.
 import { describe, expect, it } from "vitest";
-import { applyTargetToParams } from "./channel-target.js";
+import { applyTargetToParams, CHANNEL_TARGET_DESCRIPTION } from "./channel-target.js";
 
 describe("applyTargetToParams", () => {
   it.each([
@@ -70,5 +70,16 @@ describe("applyTargetToParams", () => {
     applyTargetToParams(params);
 
     expect(params.args).toEqual({ target: "   " });
+  });
+});
+
+// The shared description feeds CLI `--target` help and agent tool schemas; the
+// iMessage send guard rejects bare numeric handles with these forms, so the
+// discovery wording has to keep naming them or the guard reads as confusing.
+describe("CHANNEL_TARGET_DESCRIPTION", () => {
+  it("names the iMessage chat, E.164, and SMS short-code forms the send guard enforces", () => {
+    expect(CHANNEL_TARGET_DESCRIPTION).toContain("chat_id:<rowid>");
+    expect(CHANNEL_TARGET_DESCRIPTION).toContain("+E.164");
+    expect(CHANNEL_TARGET_DESCRIPTION).toContain("sms:<short-code>");
   });
 });

--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -8,7 +8,7 @@ import { MESSAGE_ACTION_TARGET_MODE } from "./message-action-spec.js";
 
 /** Human-readable description for a single message-action destination. */
 export const CHANNEL_TARGET_DESCRIPTION =
-  "Recipient/channel: E.164 for WhatsApp/Signal, Telegram chat id/@username, Discord/Slack/Mattermost <channelId|user:ID|channel:ID>, or iMessage handle/chat_id";
+  "Recipient/channel: E.164 for WhatsApp/Signal, Telegram chat id/@username, Discord/Slack/Mattermost <channelId|user:ID|channel:ID>, or iMessage chat_id:<rowid>, full +E.164 handle, email, or sms:<short-code>";
 
 /** Human-readable description for repeated message-action destinations. */
 export const CHANNEL_TARGETS_DESCRIPTION =

--- a/src/infra/outbound/message.test.ts
+++ b/src/infra/outbound/message.test.ts
@@ -612,6 +612,106 @@ describe("sendMessage", () => {
     expectDeliveryCallFields({ to: "prepared:123456" });
   });
 
+  it("rejects direct dry runs on undeliverable targets like the real send", async () => {
+    const forumPlugin: ChannelPlugin = {
+      id: "forum",
+      meta: {
+        id: "forum",
+        label: "Forum",
+        selectionLabel: "Forum",
+        docsPath: "/channels/forum",
+        blurb: "Forum test plugin.",
+      },
+      capabilities: { chatTypes: ["channel"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      outbound: { deliveryMode: "direct", sendText: vi.fn() },
+    };
+    mocks.resolveOutboundTarget.mockReturnValue({
+      ok: false,
+      error: new Error("target is not deliverable"),
+    });
+
+    await expect(
+      sendMessage({
+        cfg: {},
+        channel: "forum",
+        preparedPlugin: forumPlugin,
+        to: "5",
+        content: "hi",
+        dryRun: true,
+      }),
+    ).rejects.toThrow("target is not deliverable");
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("reports the resolved target on direct dry runs", async () => {
+    const forumPlugin: ChannelPlugin = {
+      id: "forum",
+      meta: {
+        id: "forum",
+        label: "Forum",
+        selectionLabel: "Forum",
+        docsPath: "/channels/forum",
+        blurb: "Forum test plugin.",
+      },
+      capabilities: { chatTypes: ["channel"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      outbound: { deliveryMode: "direct", sendText: vi.fn() },
+    };
+    mocks.resolveOutboundTarget.mockReturnValue({ ok: true, to: "resolved:5" });
+
+    const result = await sendMessage({
+      cfg: {},
+      channel: "forum",
+      preparedPlugin: forumPlugin,
+      to: "5",
+      content: "hi",
+      dryRun: true,
+    });
+    expect(result).toMatchObject({ to: "resolved:5", via: "direct", dryRun: true });
+    expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("keeps gateway dry runs unvalidated because the gateway owns target resolution", async () => {
+    const gatewayPlugin: ChannelPlugin = {
+      id: "forum",
+      meta: {
+        id: "forum",
+        label: "Forum",
+        selectionLabel: "Forum",
+        docsPath: "/channels/forum",
+        blurb: "Forum test plugin.",
+      },
+      capabilities: { chatTypes: ["channel"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      outbound: { deliveryMode: "gateway", sendText: vi.fn() },
+    };
+    mocks.resolveOutboundTarget.mockReturnValue({
+      ok: false,
+      error: new Error("must not resolve"),
+    });
+
+    const result = await sendMessage({
+      cfg: {},
+      channel: "forum",
+      preparedPlugin: gatewayPlugin,
+      to: "5",
+      content: "hi",
+      dryRun: true,
+    });
+    expect(result).toMatchObject({ to: "5", via: "gateway", dryRun: true });
+    expect(mocks.resolveOutboundTarget).not.toHaveBeenCalled();
+  });
+
   it.each(["cancelled_by_message_sending_hook", "adapter_returned_no_identity"] as const)(
     "preserves aggregate suppression reason %s",
     async (reason) => {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -380,30 +380,37 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
   const mirrorMediaUrls = mirrorProjection.mediaUrls;
   const primaryMediaUrl = mirrorMediaUrls[0] ?? mediaUrl ?? null;
 
+  // Direct sends resolve the target before the dry-run early return so a dry
+  // run fails on an undeliverable target exactly like the send that follows.
+  // Gateway-owned delivery validates its target on the gateway side instead.
+  const directDelivery = deliveryMode !== "gateway" || params.gatewayOwnedDelivery === true;
+  const resolvedTarget = directDelivery
+    ? resolveOutboundTarget({
+        channel,
+        plugin,
+        to: params.to,
+        cfg,
+        accountId: params.accountId,
+        mode: "explicit",
+      })
+    : { ok: true as const, to: params.to };
+  if (!resolvedTarget.ok) {
+    throw resolvedTarget.error;
+  }
+
   if (params.dryRun) {
     return {
       channel,
-      to: params.to,
-      via: deliveryMode === "gateway" ? "gateway" : "direct",
+      to: resolvedTarget.to,
+      via: directDelivery ? "direct" : "gateway",
       mediaUrl: primaryMediaUrl,
       mediaUrls: mirrorMediaUrls.length ? mirrorMediaUrls : undefined,
       dryRun: true,
     };
   }
 
-  if (deliveryMode !== "gateway" || params.gatewayOwnedDelivery === true) {
+  if (directDelivery) {
     const outboundChannel = channel;
-    const resolvedTarget = resolveOutboundTarget({
-      channel: outboundChannel,
-      plugin,
-      to: params.to,
-      cfg,
-      accountId: params.accountId,
-      mode: "explicit",
-    });
-    if (!resolvedTarget.ok) {
-      throw resolvedTarget.error;
-    }
 
     const outboundSession = buildOutboundSessionContext({
       cfg,
@@ -562,12 +569,30 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
     ? normalizePollInput(pollInput, { maxOptions: outbound.pollMaxOptions })
     : normalizePollInput(pollInput);
 
+  // Direct polls resolve the target before the dry-run early return so a dry
+  // run fails on an undeliverable target exactly like the poll that follows;
+  // gateway polls validate on the gateway side instead.
+  const gatewayDelivery = deliveryMode === "gateway";
+  const resolvedTarget = gatewayDelivery
+    ? { ok: true as const, to: params.to }
+    : resolveOutboundTarget({
+        channel,
+        plugin,
+        to: params.to,
+        cfg,
+        accountId: params.accountId,
+        mode: "explicit",
+      });
+  if (!resolvedTarget.ok) {
+    throw resolvedTarget.error;
+  }
+
   if (params.dryRun) {
     return buildMessagePollResult({
       channel,
-      to: params.to,
+      to: resolvedTarget.to,
       normalized,
-      via: deliveryMode === "gateway" ? "gateway" : "direct",
+      via: gatewayDelivery ? "gateway" : "direct",
       dryRun: true,
     });
   }
@@ -579,19 +604,7 @@ export async function sendPoll(params: MessagePollParams): Promise<MessagePollRe
     isAnonymous: params.isAnonymous,
   });
 
-  if (deliveryMode !== "gateway") {
-    const resolvedTarget = resolveOutboundTarget({
-      channel,
-      plugin,
-      to: params.to,
-      cfg,
-      accountId: params.accountId,
-      mode: "explicit",
-    });
-    if (!resolvedTarget.ok) {
-      throw resolvedTarget.error;
-    }
-
+  if (!gatewayDelivery) {
     const result = await outbound.sendPoll({
       cfg,
       to: resolvedTarget.to,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -114,7 +114,7 @@
           "type": "boolean"
         },
         "target": {
-          "description": "Recipient/channel: E.164 for WhatsApp/Signal, Telegram chat id/@username, Discord/Slack/Mattermost <channelId|user:ID|channel:ID>, or iMessage handle/chat_id",
+          "description": "Recipient/channel: E.164 for WhatsApp/Signal, Telegram chat id/@username, Discord/Slack/Mattermost <channelId|user:ID|channel:ID>, or iMessage chat_id:<rowid>, full +E.164 handle, email, or sms:<short-code>",
           "type": "string"
         },
         "targets": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=8401d8eeef09db50147a220197da03ff826e28778a7829c61bb787db65b86cb6
-+++ discord-group-codex-message-tool.md	sha256=3b169a84413cad7894d0fe4fb8ebd5d99324d79023ff3544f8d2987e30168e49
+--- telegram-direct-codex-message-tool.md	sha256=44c978b11f23cf611df1d9f84c4692cb9fcd47143b20484697455e7b8955b981
++++ discord-group-codex-message-tool.md	sha256=27308e561e23d8d6cf7394b5ebd4bc0e06a191c65788191819c2d98d65772f0f
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -29,10 +29,10 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
 @@ -244,2 +244,2 @@
--    "chars": 57597,
--    "roughTokens": 14400
-+    "chars": 58153,
-+    "roughTokens": 14539
+-    "chars": 57646,
+-    "roughTokens": 14412
++    "chars": 58202,
++    "roughTokens": 14551
 @@ -248,2 +248,2 @@
 -    "chars": 3224,
 -    "roughTokens": 806
@@ -44,10 +44,10 @@
 +    "chars": 28650,
 +    "roughTokens": 7163
 @@ -256,2 +256,2 @@
--    "chars": 84769,
--    "roughTokens": 21193
-+    "chars": 86805,
-+    "roughTokens": 21702
+-    "chars": 84818,
+-    "roughTokens": 21205
++    "chars": 86854,
++    "roughTokens": 21714
 @@ -260,2 +260,2 @@
 -    "chars": 863,
 -    "roughTokens": 216

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -241,8 +241,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 57597,
-    "roughTokens": 14400
+    "chars": 57646,
+    "roughTokens": 14412
   },
   "openClawDeveloperInstructions": {
     "chars": 3224,
@@ -253,8 +253,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6793
   },
   "totalWithDynamicToolsJson": {
-    "chars": 84769,
-    "roughTokens": 21193
+    "chars": 84818,
+    "roughTokens": 21205
   },
   "userInputText": {
     "chars": 863,
@@ -671,7 +671,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "target": {
-          "description": "Recipient/channel: E.164 for WhatsApp/Signal, Telegram chat id/@username, Discord/Slack/Mattermost <channelId|user:ID|channel:ID>, or iMessage handle/chat_id",
+          "description": "Recipient/channel: E.164 for WhatsApp/Signal, Telegram chat id/@username, Discord/Slack/Mattermost <channelId|user:ID|channel:ID>, or iMessage chat_id:<rowid>, full +E.164 handle, email, or sms:<short-code>",
           "type": "string"
         },
         "targets": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=8401d8eeef09db50147a220197da03ff826e28778a7829c61bb787db65b86cb6
-+++ telegram-heartbeat-codex-tool.md	sha256=5912784ac79b6fed90927ada6baa7b811f6313585eac13ffb867e13b0592e810
+--- telegram-direct-codex-message-tool.md	sha256=44c978b11f23cf611df1d9f84c4692cb9fcd47143b20484697455e7b8955b981
++++ telegram-heartbeat-codex-tool.md	sha256=c37a2f2958ea9990834323ad730878e5e9a5eb52da0d14d324d2cac71db56e4f
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -30,20 +30,20 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
 @@ -244,2 +241,2 @@
--    "chars": 57597,
--    "roughTokens": 14400
-+    "chars": 59090,
-+    "roughTokens": 14773
+-    "chars": 57646,
+-    "roughTokens": 14412
++    "chars": 59139,
++    "roughTokens": 14785
 @@ -252,2 +249,2 @@
 -    "chars": 27170,
 -    "roughTokens": 6793
 +    "chars": 27512,
 +    "roughTokens": 6878
 @@ -256,2 +253,2 @@
--    "chars": 84769,
--    "roughTokens": 21193
-+    "chars": 86604,
-+    "roughTokens": 21651
+-    "chars": 84818,
+-    "roughTokens": 21205
++    "chars": 86653,
++    "roughTokens": 21664
 @@ -260,2 +257,2 @@
 -    "chars": 863,
 -    "roughTokens": 216


### PR DESCRIPTION
## What Problem This Solves

Closes #125461.

`openclaw message send --channel imessage --target 5` parsed the bare `5` as a
handle (`parseIMessageTarget` fallback at `extensions/imessage/src/targets.ts`),
normalized it to `+5` via `normalizeE164`, and the channel send silently failed
(-1728). A bare Messages chat row id looked indistinguishable from a phone
handle, so the operator got no guidance to use `chat_id:<rowid>`.

## Why This Change Was Made

The fallback returned `{ kind: "handle", to: trimmed, service: "auto" }` for
any non-prefixed value, and `normalizeE164` returns `+<digits>` for any digit
string regardless of length, so `5` -> `+5` — not a deliverable handle.

The deliverability verdict now lives where the effective service is known, not
in parsing. Parsing stays structural: `parseIMessageTarget("5")` returns a
`handle` target so a configured `service: "sms"` account (or an explicit
`sms:` target) can still reach the SMS transport, where short digit strings are
legitimate short codes. `assertDeliverableIMessageHandle` runs in
`sendMessageIMessage` and the chat typing/read path (`send.ts`, `chat.ts`)
right after the effective service resolves from
`opts.service ?? target.service ?? account.config.service`:

- phone-like handles shorter than 7 digits (the shortest real subscriber
  numbers) are rejected only when delivery is iMessage-only (explicit
  `imessage:` prefix or a configured `service: "imessage"` account) or the
  service is unset — the default path — with a message naming
  `chat_id:<rowid>`, a full E.164 handle, or `sms:<short-code>`;
- the same value passes once the service resolves to `sms` or `auto`: both
  hand the handle plus configured region to Messages, which resolves short
  codes natively.

The signal is **digit count, not the `+` prefix**: national-format numbers
without `+` (e.g. `555-000-4567`, exercised by the region-aware send path) and
full E.164 both stay deliverable — only obvious chat-row-id typos are rejected.
Service-prefixed values (`sms:12345`) declare intent before this check runs.

Production LOC: +37/-2 (`targets.ts` +25, `send.ts` +4, `chat.ts` +7,
shared `channel-target.ts` +1/−1) — the `MIN_PHONE_HANDLE_DIGITS` constant,
`assertDeliverableIMessageHandle`, one call line at each of the two
effective-service resolution points, and the shared target-description
alignment. Tests: +92/-1 across `send.test.ts`, `targets.test.ts`, and
`channel-target.test.ts`. Generated snapshot fixtures: +16/-12.
No existing guard absorbs "reject non-deliverable short numerics once the
service is known"; the invariant (a short phone-like value is a chat-row-id
typo over auto/iMessage but a valid short code over sms) is new at this
boundary and its owner is the send layer, so the check cannot move to parsing
without breaking configured-SMS short codes. The shared
`CHANNEL_TARGET_DESCRIPTION` consumed by CLI `--target` help and agent tool
schemas still said only `iMessage handle/chat_id`, which set the new rejection
up as a confusing delivery failure; it now names `chat_id:<rowid>`, a full
`+E.164` handle, email, and `sms:<short-code>` — the forms the guard enforces.

## User Impact

Operators who typo a Messages chat row id as a bare number now get an explicit,
actionable error before any channel send, naming the three correct forms —
instead of a silent -1728 send failure. Full E.164 handles, national-format
numbers, emails, all `chat_id:`/`chat_guid:`/`chat_identifier:` targets, and
SMS short codes via a configured `service: "sms"` account or `sms:` prefix are
unaffected. Accounts configured for automatic selection (`service: "auto"`)
keep their pre-guard short-code routing: the handle plus region still reach
Messages, which resolves them natively.

## Evidence

**Reproduction and regression** (all runs on this branch head, `node scripts/run-vitest.mjs`):

- Pre-fix contrast (production `targets.ts` reverted to the reviewed head
  `0b4a81fee8e`): the three assertions updated for the 2026-09-06 fix failed
  for the intended reason — an unset-service bare short target threw before
  the RPC in `targets.test.ts`, the chat typing RPC never ran in
  `chat.test.ts`, and core `resolveTarget` returned `ok: false` in
  `outbound-resolve-target.test.ts` — although `sendMessageIMessage` builds
  the RPC with `service: service || "auto"` and the chat RPCs omit the field
  so the `imsg` bridge applies its own automatic default.
- Post-fix (head `c1de05b0dd6`): full imessage suite **59 files, 1232/1232 green**,
  including `send.test.ts` (an unset-service `12345` reaches the RPC with
  `service: "auto"`; `imessage:5` rejects before any RPC; configured
  `service: "sms"`, configured `service: "auto"`, and `opts.service: "sms"`
  all deliver), `targets.test.ts` (`5`/`+123456` and a region-dependent
  6-digit local format pass on the unset default and reject on iMessage-only
  delivery; `sms`, `auto`, `sms:12345`, `auto:12345`, `+15552223333`,
  `user@example.com`, and `chat_id:5` all pass), `chat.test.ts` (configured
  SMS typing/read and the unset default reach bare short codes; the
  configured `imessage` service rejects), and `outbound-resolve-target.test.ts`
  (unset and `auto` configs pass, a configured `service: "imessage"` account
  rejects — core resolve and dry-run land on the same verdict).
- Core-side dry-run: `src/infra/outbound/channel-target.test.ts` +
  `src/infra/outbound/message.test.ts` green (19/19).

**Sibling coverage**: the effective service resolves at the same points in the
send path and the chat typing/read path, and both call the same assertion, so
the narrowed verdict cannot drift between them. `parseIMessageTarget` is
shared by the channel/approval paths
(`extensions/imessage/src/{channel,approval-handler.runtime}.ts`); their
national-format (`555-000-4567`) and full-E.164 (`+15551230000`,
`+15550004567`) phone fixtures are not short numerics and remain accepted —
the full suite above covers `channel.runtime` and `approval-handler.runtime`.
No prompt or tool-description text changed in this fix, so the prompt
snapshots are unaffected.

**Checks**: `oxlint --type-aware` clean on all touched files; `oxfmt` clean;
`tsgo:extensions` and `tsgo:test:extensions` clean. Real macOS Messages
delivery remains the same proof blocker as before: this dev host has no
iMessage bridge, so exact-head delivery traces are unavailable — the
boundary-level coverage above (send RPC params, chat RPCs, core resolveTarget,
dry-run) is the proof surface available here.

## ClawSweeper P1 fix: the unset service is delivered as auto, so only iMessage-only delivery rejects (2026-09-06, `c1de05b0dd6`)

The review finding "[P1] Preserve automatic routing when service is omitted"
is fixed at the guard itself. The verdict disagreed with the delivery default
it was protecting: `sendMessageIMessage` resolves the service as
`opts.service ?? resolveIMessageTargetService(target) ?? account.service` and
then builds the RPC with `service: service || "auto"`, the chat RPCs omit the
field when no service resolves, and the session route already treats a bare
direct target with no configured service as `auto`. Rejecting the unset case
therefore broke short-code and regional-number workflows that never configured
a service, while delivery would have accepted them.

The guard now rejects exactly the one path that can prove a bare numeric
handle undeliverable — delivery pinned to iMessage
(`assertDeliverableIMessageHandle` returns for any service other than
`imessage`) — which is the original #125461 silent-loss class. Net-zero
production change: the branch narrowed inside `targets.ts` with no new
helpers, no new call-site plumbing, and no change to how the effective service
is resolved; the `sms:`/`auto:` guidance in the error stays correct because it
names the explicit forms that pin a service.


## ClawSweeper P1 fix: preserve automatic-service and regional local targets (2026-09-05, 731225525b7)

The review finding "[P1] Preserve automatic-service and regional local
targets" is fixed at the same boundary: the guard exemption now follows the
resolved service instead of requiring per-target intent. A configured
`service: "auto"` account (and the documented `auto:` prefix) forwards short
codes plus the configured region to Messages, exactly as before the guard
existed; only iMessage-only delivery (explicit `imessage:` prefix or
configured `service: "imessage"`) and the unset-service default path reject
short phone-like handles. The regional-local path is covered by a new
regression: a 6-digit region-dependent handle over `auto` passes, over
`imessage` rejects.

The branch was rebuilt onto current `main` (the prior head was reported
merge-conflicting): three commits cherry-picked onto `origin/main`, with
`main`-side refactors absorbed (chat-action service resolution, prompt
snapshots regenerated via `pnpm prompt:snapshots:gen`, `prompt:snapshots:check`
green). Verified on the rebuilt head: full imessage suite 59 files / 1231
tests green, outbound core dry-run tests green, oxlint/oxfmt clean.

## Rebase and follow-up (2026-08-31)

- Rebased onto current `main`: the shared target-description change conflicted with fixtures `main` had since deleted; the two per-scenario prompt-snapshot `.md` files stay deleted and the snapshots were regenerated with `pnpm prompt:snapshots:gen` (`prompt:snapshots:check` green).
- Opportunistic fix found while validating locally on a `zh_CN.UTF-8` shell (pre-existing on `main`, same class as the Zalo setup-surface pin): the iMessage setup-status labels are translated once at module evaluation in `setup-core`, so the English-copy assertions in `status.test.ts` fail on non-English shells. Pinned via `vi.hoisted` (runs before the file's imports, which is where the freeze happens) with an explicit `afterAll` restore, since a raw assignment is invisible to the runner's `vi.unstubAllEnvs` file cleanup. Verified: `status.test.ts` 34/34 green under `zh_CN.UTF-8`, and a same-worker follow-on file observes the developer locale restored.



## Dry-run target validation (2026-08-31, 8dfafec56dc)

ClawSweeper follow-up surface: the live-send fix left the **core dry-run path**
reporting success for targets the real send rejects — `openclaw message send
--channel imessage --target 5 --dry-run` returned `dryRun: true` with no error,
a silent false-green on the exact scenario this PR fixes.

**Root cause**: `sendMessage`/`sendPoll` in `src/infra/outbound/message.ts`
resolved the outbound target only *after* the dry-run early return, so direct
sends never validated during dry runs. The live direct path threw
`resolvedTarget.error`; dry runs skipped the resolve entirely.

**Fix (canonical boundary)**:
- Core: direct sends resolve the target **before** the dry-run early return,
  and that one resolution is shared with the live path (`resolvedTarget.to`
  feeds `sendDurableMessageBatchCore` as before). Dry-run `to` now reports the
  resolved target. Gateway-owned delivery keeps validating on the gateway side
  (`{ ok: true, to: params.to }` placeholder, commented); `sendPoll` got the
  identical shape, which also removes its duplicated resolve/dry-run ordering.
- iMessage: implements the `outbound.resolveTarget` hook inside
  `outbound.base` (the `createChatChannelPlugin` attached-outbound shape drops
  unknown top-level fields), so the resolved-service-aware bare-numeric verdict
  applies to the core resolve chain and dry runs — not only the send handler.
  The service resolution helper moved from `send.ts` to `targets.ts`
  (`resolveIMessageTargetService`) so both surfaces share one implementation;
  the send handler keeps re-applying it (idempotent).

**Tests (fail on pre-fix, verified by stashing the two production files with
tests retained)**:
- `src/infra/outbound/message.test.ts` +3: direct dry-run rejects an
  undeliverable target (pre-fix: resolved, returned success), direct dry-run
  reports the resolved target, gateway dry-run stays unvalidated. 2/3 failed
  pre-fix; 19/19 green post-fix.
- `extensions/imessage/src/outbound-resolve-target.test.ts` (new, 6 cases):
  hook rejects short phone-likes, accepts `sms:` explicit and
  account-configured `service: "sms"`, accepts full E.164/email/chat rows,
  stays permissive without account config, rejects empty targets. 6/6 failed
  pre-fix (hook absent); all green post-fix. Sibling runs green:
  `message.channels` + `targets` + `target-resolver` 150/150, imessage
  `targets` + `send` 120/120, dry-run-touching
  `message-action-routing`/`send-validation`/`send-policy`/`outbound-send-service`
  64/64 and `message-action-params*`/`poll` 72/72.

**Real CLI proof** (built dist `OpenClaw 2026.8.1 (f2a9243)`, isolated
`OPENCLAW_STATE_DIR`):
- `--target 5 --dry-run --json` → `ok: false`, error `iMessage target "+5" is
  not a deliverable handle. Use chat_id:<rowid> ... or sms:<short-code>` (CLI
  exit non-zero).
- `--target sms:5`, `--target +15551234567`, `--target chat_id:5` with
  `--dry-run` → `dryRun: true` success payloads, confirming no over-rejection.

**Production LOC**: +44 net (`message.ts` +13, hook +27, helper move net +4);
tests +137. Growth is the second half of the same invariant (dry-run must fail
where the send fails) expressed at the owner boundaries; `send.ts` shrank by 9.

**Checks**: `oxlint` EXIT 0, `oxfmt` clean, `tsgo` core exit 0 and extensions
shard shows no imessage diagnostics (telegram diagnostics are pre-existing on
`main`), `pnpm build` exit 0.


**CI note (96b7e3adea5)**: the first head's only failure was
`checks-fast-baseline-ratchets` — the hook's account-service cast pushed
`extensions/imessage/src/channel.ts` past its grandfathered assertion baseline
(5 > 4). Fixed by annotating the cast with the schema-backed `// SAFETY:`
invariant (plugin-sdk config contracts keep channel values wide; the imessage
config schema narrows `service` to `imessage|sms|auto`) instead of growing the
baseline. `check:assertion-safety` and `check:max-lines-ratchet` green locally
on the follow-up head.

## Chat-action service alignment (2026-08-31, af31095db4e)

ClawSweeper P1: the deliverability assertion added to chat actions made
`sendIMessageTyping`/`markIMessageChatRead` reject bare short codes for
accounts configured with `service: "sms"`, because `buildChatTargetParams`
took the service straight from the parsed target — the parser's default
`"auto"` masked the account configuration, unlike the send path and the
outbound resolver, which defer parser-default `auto` to the account service.

**Fix (net-neutral)**: `extensions/imessage/src/chat.ts` now resolves the
service through the same shared helper the send handler and the outbound
resolver use (`resolveIMessageTargetService`): an explicit service prefix
wins, a parser-default `auto` defers to the account's configured service
before the deliverability verdict. One line replaced, one import added, the
precedence comment documents the contract.

**Regression** (`extensions/imessage/src/chat.test.ts`, new): pre-fix, the two
configured-SMS short-code cases (`sendIMessageTyping("12345", …)` and
`markIMessageChatRead("12345", …)` with `config.service: "sms"`) failed with
`not a deliverable handle` — the exact regression the review identified.
Post-fix: 5/5 — both chat actions reach the RPC for a configured SMS account,
bare short codes stay rejected when no service resolves to `sms`, explicit
`sms:` short codes stay deliverable. Full imessage suite: 55 files, 1201/1201.

**Exact-head real behavior proof** (dist `OpenClaw 2026.8.1 (af31095)`, built
from this exact commit; isolated `OPENCLAW_STATE_DIR` + `OPENCLAW_CONFIG_PATH`,
no operator state touched):

```text
=== 1. bare short numeric, imessage-default account -> REJECTED ===
$ openclaw message send --channel imessage --target 5 --message hi --dry-run --json
  "message": "iMessage target \"+5\" is not a deliverable handle. Use chat_id:<rowid> for a
  Messages chat row, a full E.164 handle beginning with +, or sms:<short-code> for an SMS short code."

=== 2. explicit sms short code -> dryRun success ===
$ openclaw message send --channel imessage --target sms:5 --message hi --dry-run --json
  "dryRun": true

=== 3. full E.164 -> dryRun success ===
$ openclaw message send --channel imessage --target +15551234567 --message hi --dry-run --json
  "dryRun": true

=== 4. bare short numeric, account service "sms" (config-driven) -> dryRun success ===
$ openclaw message send --channel imessage --target 5 --message hi --dry-run --json
  "dryRun": true

=== 5. repaired chat-action path (real chat.ts chain; RPC boundary injected —
        this host has no macOS Messages instance) ===
$ tsx chat-action-proof.mts
--- repaired path: configured SMS account + bare short code ---
typing {"to":"12345","typing":true,"service":"sms"}
read {"to":"12345"}
--- control: imessage-default account + bare short code stays rejected ---
rejected: iMessage target "12345" is not a deliverable handle. …
rpc calls: 2 (control threw before RPC)
```

**Checks**: `oxlint` clean, `oxfmt` clean; CS acceptance runs green:
`node scripts/run-vitest.mjs extensions/imessage/src/chat.test.ts
extensions/imessage/src/send.test.ts extensions/imessage/src/targets.test.ts
extensions/imessage/src/outbound-resolve-target.test.ts` → 131 passed;
`node scripts/run-vitest.mjs src/infra/outbound/message.test.ts` → 19 passed.

## Rebuilt on current main + ClawSweeper P1 fix (2026-09-01, e20ec2b093e)

The branch was rebuilt as a single commit on current `main` (the old head had
gone CONFLICTING against 120+ commits of drift; the rebuild also restored
main's newer `agentPrompt.messageToolHints` block that the previous base
predated, and regenerated the prompt snapshots from current code so no
main-side prompt work is reverted).

**ClawSweeper P1 — explicit `auto:` short codes (fixed)**: the deliverability
verdict rejected every short phone-like handle whose effective service was not
exactly `sms`. An explicit `auto:12345` parses as a handle with service `auto`,
so the documented `auto:<contact>` contract (Messages chooses iMessage or SMS)
threw before native delivery. The verdict now exempts handles whose service the
operator typed explicitly as `auto:`; an account-level `auto` default keeps the
row-id-typo verdict for bare digit strings (the original #125461 repair), and
an explicit `imessage:` prefix still rejects a handle that cannot be an
iMessage handle. The rejection message now names the `auto:` form.

**Regression (pre-fix failure verified)**: with the old guard restored, the two
new cases fail and the 33 pinned cases still pass — `2 failed | 33 passed`;
post-fix `35 passed` (`targets.test.ts` + `chat.test.ts`). Also fixed the
chat-action test mock to satisfy the current `IMessageRpcClient` surface, which
had left the extensions test typecheck red (5x TS2345 → 0).

**Exact-head real behavior proof** (dist `OpenClaw 2026.8.1 (19aa501)`
(guard sources byte-identical through `e20ec2b093e`; the follow-up commit only
restructures the chat-action test mock), built
from this exact commit; isolated `OPENCLAW_STATE_DIR` + `OPENCLAW_CONFIG_PATH`,
no operator state touched). Direct delivery resolves the target before the
dry-run early return, so dry runs exercise the real guard:

```text
$ openclaw message send --channel imessage --target <t> --message hi --dry-run --json

=== bare numeric, no configured service -> REJECTED ===
  "error.message": "iMessage target \"+5\" is not a deliverable handle. Use chat_id:<rowid> …
  sms:<short-code> … or auto:<contact> to let Messages choose iMessage or SMS."

=== explicit auto short code -> dryRun success (pre-fix: threw) ===
  "payload": { "to": "auto:+12345", "via": "direct", "dryRun": true }

=== explicit sms short code -> dryRun success ===
  "payload": { "to": "sms:+12345", "via": "direct", "dryRun": true }

=== typed chat target -> dryRun success ===
  "payload": { "dryRun": true }

=== explicit imessage short code -> REJECTED (cannot be an iMessage handle) ===
  "error.message": "iMessage target \"+12345\" is not a deliverable handle. …"

=== full E.164 -> dryRun success ===
  "payload": { "dryRun": true }

=== bare numeric with account service "sms" -> dryRun success ===
  (separate config with service: "sms"; config-driven short codes still pass)
```

**Checks**: `oxlint` clean, `oxfmt` clean, `generate-prompt-snapshots --check`
green; `tsgo` core/extensions/extensions-test all 0 errors; type-aware oxlint
positive-control verified (the pre-fix mock reproduced the CI
`typescript/unbound-method` errors, the fixed file is clean);
`node scripts/run-vitest.mjs` on `targets/chat/send/status/
outbound-resolve-target` + `src/infra/outbound/{message,channel-target}.test.ts`
→ 192 passed.

**Proof gap**: this host has no macOS Messages instance, so the traces above
are dry-run (resolve + verdict) rather than live native delivery; the previous
head's RPC-boundary chat-action trace (section above) covers the send chain
beyond resolve on the same helper.


## CI note (bdef9b65bc7, 2026-09-05)

- `check-prompt-snapshots` on head `731225525b7` was a real failure: the rebuilt
  head changed the shared message tool target description, moving the
  `codex-runtime-happy-path` snapshot token counts (`dynamicToolsJson` +49
  chars); regenerated at `bdef9b65bc7`. The pre-push verification ran against
  the pre-rebuild worktree and reported stale counts as current — verified now
  by running `generate-prompt-snapshots.ts --check` on the exact pushed tree
  (current; output is locale-independent, confirmed under both `C` and the dev
  host locale).
- `check-test-types` is inherited from `main`: #139069 (`44db57bbf2b`, merged
  2026-09-05) added `test/vitest/vitest.ui-e2e-prebuilt.global-setup.ts`, which
  imports `isControlUiStartupAssetsReady` — an export the same commit's
  `src/infra/control-ui-assets.ts` rewrite no longer provides. `main`'s own
  `check-test-types` check run on that SHA is red. This PR touches neither file.

