### PR TITLE
fix(web-fetch): prevent corrupted text when HTTP charset contradicts Unicode BOM

### DIFF
--- a/src/agents/tools/web-shared.test.ts
+++ b/src/agents/tools/web-shared.test.ts
@@ -118,6 +118,91 @@ describe("web shared timeout seconds", () => {
 });
 
 describe("readResponseText", () => {
+  it.each([
+    {
+      name: "UTF-8 HTML",
+      bytes: new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode("café 日本")]),
+      contentType: "text/html; charset=iso-8859-1",
+    },
+    {
+      name: "UTF-16LE HTML",
+      bytes: new Uint8Array([0xff, 0xfe, ...Buffer.from("café 日本", "utf16le")]),
+      contentType: "text/html; charset=utf-8",
+    },
+    {
+      name: "UTF-16BE XML",
+      bytes: new Uint8Array([0xfe, 0xff, ...Buffer.from("café 日本", "utf16le").swap16()]),
+      contentType: "application/xml; charset=iso-8859-1",
+    },
+    {
+      name: "UTF-8 plain text",
+      bytes: new Uint8Array([0xef, 0xbb, 0xbf, ...new TextEncoder().encode("café 日本")]),
+      contentType: "text/plain; charset=iso-8859-1",
+    },
+  ])(
+    "prioritizes the $name byte-order mark over a conflicting header",
+    async ({ bytes, contentType }) => {
+      for (const options of [undefined, { maxBytes: bytes.byteLength }]) {
+        const response = new Response(bytes, {
+          headers: { "content-type": contentType },
+        });
+
+        await expect(readResponseText(response, options)).resolves.toEqual({
+          text: "café 日本",
+          truncated: false,
+          bytesRead: bytes.byteLength,
+        });
+      }
+    },
+  );
+
+  it("keeps declared legacy charsets ahead of document metadata without a byte-order mark", async () => {
+    const bytes = new Uint8Array([
+      ...new TextEncoder().encode('<meta charset="utf-8"><p>caf'),
+      0xe9,
+      ...new TextEncoder().encode("</p>"),
+    ]);
+    const response = new Response(bytes, {
+      headers: { "content-type": "text/html; charset=iso-8859-1" },
+    });
+
+    await expect(readResponseText(response, { maxBytes: bytes.byteLength })).resolves.toMatchObject(
+      {
+        text: '<meta charset="utf-8"><p>café</p>',
+        truncated: false,
+      },
+    );
+  });
+
+  it("uses document metadata when there is no byte-order mark or declared charset", async () => {
+    const bytes = new Uint8Array([
+      ...new TextEncoder().encode('<meta charset="iso-8859-1"><p>caf'),
+      0xe9,
+      ...new TextEncoder().encode("</p>"),
+    ]);
+    const response = new Response(bytes, { headers: { "content-type": "text/html" } });
+
+    await expect(readResponseText(response, { maxBytes: bytes.byteLength })).resolves.toMatchObject(
+      {
+        text: '<meta charset="iso-8859-1"><p>café</p>',
+        truncated: false,
+      },
+    );
+  });
+
+  it("drops incomplete UTF-16 characters after a byte-order-marked bounded read", async () => {
+    const bytes = new Uint8Array([0xff, 0xfe, ...Buffer.from("abc", "utf16le")]);
+    const response = new Response(bytes, {
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+
+    await expect(readResponseText(response, { maxBytes: 5 })).resolves.toEqual({
+      text: "a",
+      truncated: true,
+      bytesRead: 5,
+    });
+  });
+
   it("releases bounded response readers after complete reads", async () => {
     const cancel = vi.fn(async () => undefined);
     const releaseLock = vi.fn();

--- a/src/agents/tools/web-shared.ts
+++ b/src/agents/tools/web-shared.ts
@@ -138,8 +138,9 @@ function sniffCharset(contentType: string | null, bytes: Uint8Array): string | u
   if (bytes[0] === 0xfe && bytes[1] === 0xff) {
     return "utf-16be";
   }
-  if (!shouldSniffDocumentCharset(contentType)) {
-    return undefined;
+  const declaredCharset = readCharsetParam(contentType);
+  if (declaredCharset || !shouldSniffDocumentCharset(contentType)) {
+    return declaredCharset;
   }
 
   const head = latin1Decoder.decode(
@@ -186,7 +187,7 @@ function responseContentType(res: Response): string | null {
 
 function decodeResponseBytes(res: Response, bytes: Uint8Array, truncated = false): string {
   const contentType = responseContentType(res);
-  const charset = readCharsetParam(contentType) ?? sniffCharset(contentType, bytes);
+  const charset = sniffCharset(contentType, bytes);
   try {
     return decodeTextPrefix(bytes, { encoding: charset ?? "utf-8", truncated });
   } catch {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users fetching HTML, XML, or text pages would receive corrupted or unreadable content when a server declared a charset that contradicted the document's actual Unicode byte-order mark.

## Why This Change Was Made

The shared response decoder now applies the browser-standard encoding precedence already used by WHATWG-compatible document decoders: Unicode BOM first, then the HTTP Content-Type charset, then document metadata. This preserves existing legacy-charset decoding, bounded response reads, truncation, and charset validation.

## User Impact

Fetched UTF-8, UTF-16LE, and UTF-16BE pages retain their actual characters even when a misconfigured server sends the wrong charset. Existing Latin-1 pages, HTML metadata declarations, response-size limits, and SSRF protections continue to behave as before.

## Evidence

- Five new owner-boundary regressions failed before the fix and pass afterward, covering contradictory UTF-8/UTF-16 headers plus an incomplete bounded UTF-16 character.
- 216 tests passed across 12 web-fetch, response-decoding, SSRF, provider-fallback, output-contract, and normalization test files.
- Real native Response-byte probes confirm UTF-8 HTML/plain text, UTF-16LE HTML, UTF-16BE XML, and ordinary no-BOM Latin-1 all decode correctly.
- Existing HTML encoding-sniffer and jsdom implementations independently confirm BOM precedence over HTTP declarations.
- Formatting, maximum-lines and assertion-safety ratchets, independent review, and authenticated Codex review passed.
