### PR TITLE
fix(imessage): stop self-chat dedupe from tripping loop limiter

### DIFF
--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -327,6 +327,7 @@ describe("iMessage monitor last-route updates", () => {
           | "is_from_me"
           | "is_group"
           | "created_at"
+          | "destination_caller_id"
         >
       >,
   ): IMessagePayload {
@@ -341,6 +342,7 @@ describe("iMessage monitor last-route updates", () => {
       text: message.text,
       is_group: message.is_group ?? false,
       created_at: message.created_at ?? new Date().toISOString(),
+      destination_caller_id: message.destination_caller_id,
     };
   }
 
@@ -682,6 +684,42 @@ describe("iMessage monitor last-route updates", () => {
       ],
     };
   }
+
+  it("delivers eight self-chat turns without counting their paired rows as echo loops", async () => {
+    const runtime = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
+    const texts = Array.from({ length: 8 }, (_, index) => `self-chat message ${index + 1}`);
+    const createdAt = new Date().toISOString();
+    await runMessageCase({
+      messages: texts.flatMap((text, index) =>
+        [true, false].map((isFromMe) =>
+          createInboundMessage({
+            id: index * 2 + (isFromMe ? 1 : 2),
+            guid: `self-chat-${index}-${isFromMe}`,
+            text,
+            chat_identifier: DEFAULT_SENDER,
+            is_from_me: isFromMe,
+            created_at: createdAt,
+            destination_caller_id: DEFAULT_SENDER,
+          }),
+        ),
+      ),
+      afterNotify: async () => {
+        await vi.waitFor(() => {
+          expect(dispatchReplyWithBufferedBlockDispatcherMock).toHaveBeenCalledTimes(texts.length);
+        });
+      },
+      monitor: { runtime },
+    });
+    expect(
+      dispatchReplyWithBufferedBlockDispatcherMock.mock.calls.map(
+        ([params]) => params.ctx.BodyForAgent,
+      ),
+    ).toEqual(texts);
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(
+      runtime.log.mock.calls.some(([message]) => String(message).includes("rate limiter tripped")),
+    ).toBe(false);
+  });
 
   it("waits for configured ACP target readiness before dispatching an authorized message", async () => {
     let releaseReadiness: ((value: { ok: true }) => void) | undefined;

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -795,16 +795,10 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
     const rateLimitKey = `${accountInfo.accountId}:${conversationKey}`;
 
     if (decision.kind === "drop") {
-      // Record echo/reflection drops so the rate limiter can detect sustained loops.
-      // Only loop-related drop reasons feed the counter; policy/mention/empty drops
-      // are normal and should not escalate. "from me" is excluded: every own-send
-      // (agent replies, multi-chunk sends, operator phone traffic) produces a
-      // from-me row, so counting it lets a normal outbound burst trip the limiter
-      // and silently suppress the next legitimate inbound message.
+      // Count reflected agent content, not ordinary own-send or self-chat dedupe
+      // rows: counting those benign drops mutes legitimate conversation bursts.
       const isLoopDrop =
-        decision.reason === "echo" ||
-        decision.reason === "self-chat echo" ||
-        decision.reason === "reflected assistant content";
+        decision.reason === "echo" || decision.reason === "reflected assistant content";
       if (isLoopDrop) {
         loopRateLimiter.record(rateLimitKey);
       }

--- a/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
+++ b/extensions/imessage/src/monitor/self-chat-dedupe.test.ts
@@ -150,40 +150,16 @@ describe("echo cache — backward compat for channels without messageId", () => 
   // Proves text-fallback echo detection still works when no messageId is present
   // on either side. Critical for backward compat with channels that don't
   // populate messageId.
-  it("text-only remember/has works within TTL", async () => {
+  it.each([
+    { label: "within TTL", elapsed: 2000, text: "no id message", expected: true },
+    { label: "after TTL expiry", elapsed: 5000, text: "no id message", expected: false },
+    { label: "for different text", elapsed: 1000, text: "totally different text", expected: false },
+  ])("matches text-only echoes $label: $expected", ({ elapsed, text, expected }) => {
     useFakeTimersAt();
-
     const echoCache = createSentMessageCache();
-    const scope = "default:imessage:+15555550123";
-
-    echoCache.remember(scope, { text: "no id message" });
-
-    vi.advanceTimersByTime(2000);
-    expect(echoCache.has(scope, { text: "no id message" })).toBe(true);
-  });
-
-  it("text-only has returns false after TTL expiry", async () => {
-    useFakeTimersAt();
-
-    const echoCache = createSentMessageCache();
-    const scope = "default:imessage:+15555550123";
-
-    echoCache.remember(scope, { text: "no id message" });
-
-    vi.advanceTimersByTime(5000);
-    expect(echoCache.has(scope, { text: "no id message" })).toBe(false);
-  });
-
-  it("text-only has returns false for different text", async () => {
-    useFakeTimersAt();
-
-    const echoCache = createSentMessageCache();
-    const scope = "default:imessage:+15555550123";
-
-    echoCache.remember(scope, { text: "no id message" });
-
-    vi.advanceTimersByTime(1000);
-    expect(echoCache.has(scope, { text: "totally different text" })).toBe(false);
+    echoCache.remember(SELF_CHAT_SCOPE, { text: "no id message" });
+    vi.advanceTimersByTime(elapsed);
+    expect(echoCache.has(SELF_CHAT_SCOPE, { text })).toBe(expected);
   });
 });
 
@@ -285,56 +261,21 @@ describe("self-chat dedupe — #47830", () => {
     expect(decision.kind).toBe("dispatch");
   });
 
-  it("drops echo after text TTL expiry (4s TTL: expired at 5s)", async () => {
-    useFakeTimersAt();
-
-    const echoCache = createSentMessageCache();
-    const scope = "default:imessage:+15555550123";
-
-    // Agent sends text (no message id available)
-    echoCache.remember(scope, { text: "Hello there" });
-
-    // After 5 seconds — beyond the 4s TTL, should NOT match
-    vi.advanceTimersByTime(5000);
-
-    const result = echoCache.has(scope, { text: "Hello there" });
-    expect(result).toBe(false);
-  });
-
-  // Safe failure mode: TTL expiry causes duplicate delivery (noisy), never message loss (lossy)
-  it("does NOT catch echo after TTL expiry — safe failure mode is duplicate delivery", async () => {
-    useFakeTimersAt();
-
-    const echoCache = createSentMessageCache();
-    const scope = SELF_CHAT_SCOPE;
-
-    // Agent sends "Delayed echo test"
-    echoCache.remember(scope, { text: "Delayed echo test", messageId: "agent-msg-delayed" });
-
-    // 4.5 seconds later — beyond 4s TTL
-    vi.advanceTimersByTime(4500);
-
-    // Echo arrives with no messageId (text-only fallback path)
-    const result = echoCache.has(scope, { text: "Delayed echo test" });
-
-    // TTL expired → not caught → duplicate delivery (noisy but safe, not lossy)
-    expect(result).toBe(false);
-  });
-
-  it("still drops text echo within 4s TTL window", async () => {
-    useFakeTimersAt();
-
-    const echoCache = createSentMessageCache();
-    const scope = "default:imessage:+15555550123";
-
-    echoCache.remember(scope, { text: "Hello there" });
-
-    // After 3 seconds — within the 4s TTL, should still match
-    vi.advanceTimersByTime(3000);
-
-    const result = echoCache.has(scope, { text: "Hello there" });
-    expect(result).toBe(true);
-  });
+  // Late text-only matches must expire even when the original send had an ID.
+  it.each([
+    { elapsed: 5000, messageId: undefined, expected: false },
+    { elapsed: 4500, messageId: "agent-msg-delayed", expected: false },
+    { elapsed: 3000, messageId: undefined, expected: true },
+  ])(
+    "matches a text-only lookup after $elapsed ms (send ID $messageId): $expected",
+    ({ elapsed, messageId, expected }) => {
+      useFakeTimersAt();
+      const echoCache = createSentMessageCache();
+      echoCache.remember(SELF_CHAT_SCOPE, { text: "Hello there", messageId });
+      vi.advanceTimersByTime(elapsed);
+      expect(echoCache.has(SELF_CHAT_SCOPE, { text: "Hello there" })).toBe(expected);
+    },
+  );
 });
 
 describe("self-chat is_from_me=true handling (Bruce Phase 2 fix)", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes #126468. Self-chat produces a from-me row and a received twin. The
iMessage monitor correctly suppressed the twin as a self-chat duplicate,
but incorrectly counted that benign suppression toward its five-hit loop
limiter. A short ordinary conversation could therefore silently lose its
sixth and later turns.

## Why This Change Was Made

Keep loop accounting at the monitor-owned decision boundary, counting only
actual agent echoes and reflected assistant content. No limiter threshold,
dedupe cache, TTL, configuration, queue settlement, or persistence behavior
changes. Thanks @jason-allen-oneal for the fix and regression scenario.

## User Impact

Ordinary self-chat bursts continue reaching the agent without consuming the echo-loop budget; actual loop protection stays enabled.

## Maintainer improvements

The eight-turn regression now reuses the existing production-monitor
integration fixture, checks every dispatched text in order, and checks
that neither runtime errors nor limiter warnings occurred. Six nearby
cache cases are table-driven without removing any scenario: matching and
different text, live and expired TTLs, and expired text matching when the
original send had an ID. This replaces duplicated setup and assertions.

Production: **+3/-9 = -6**. Tests: **+61/-82 = -21**. Total implementation:
**+64/-91 = -27 lines**, across three files. Release-note context is recorded here; the changelog remains release-generated.

## Evidence

The regression failed against trusted main `4803830c9629`: expected eight
dispatches, observed five. After the fix, all **175 tests across five
iMessage owner/sibling files passed**, covering monitor routing, watch
subscription and genuine echo limiting, self-chat dedupe, inbound
classification, and cache lifecycle.

```sh
node scripts/run-vitest.mjs \
  extensions/imessage/src/monitor.last-route.test.ts \
  extensions/imessage/src/monitor.watch-subscribe-retry.test.ts \
  extensions/imessage/src/monitor/self-chat-dedupe.test.ts \
  extensions/imessage/src/monitor/inbound-processing.test.ts \
  extensions/imessage/src/monitor/cache-lifecycle.test.ts
pnpm build
node scripts/check-changed.mjs --base 4803830c96290651cbfb766a3893b5a55d90f44b -- \
  extensions/imessage/src/monitor/monitor-provider.ts \
  extensions/imessage/src/monitor.last-route.test.ts \
  extensions/imessage/src/monitor/self-chat-dedupe.test.ts
```

The full build and full changed-file gate passed, including production and
test typechecks, lint, dead exports, plugin boundaries, storage and import
cycle guards. The first changed-file pass found a fixture-only
`no-map-spread` lint error; the fixture now passes its typed destination
field through the existing message helper, and the full gate was rerun.
Fresh Codex autoreview reported no actionable **P0** findings; that review
is not claimed as broader-priority coverage.

## Native transport / Gateway proof

Executed the actual built Gateway and production iMessage monitor with
installed **imsg 0.14.1** reading a fresh synthetic Messages-schema
`chat.db`, plus a loopback mock model provider. Each row was committed
separately, and the runner observed its real native RPC notification before
inserting the next row. Matching self-chat twins share the event timestamp.
The from-me/received ordering is preserved, not reordered or made atomic.

The Gateway received all sixteen native rows and the provider received
exactly eight ordered turns in 15.135 seconds, without a limiter warning.
The same separately committed row sequence against the trusted-main
iMessage build delivered only five turns and tripped the limiter in
11.219 seconds. The Gateway/core build was unchanged between cases.
The proxy forwards only read RPC methods. Native imsg was sandboxed away
from the user's Library and messaging services; sends were capture-only,
and the model returned `NO_REPLY`. **No real Messages account, private
chat.db, or external send was used.**

```json
{
  "verdict": "PASS",
  "label": "after",
  "nativeReadTransport": "imsg rpc with synthetic chat.db",
  "gateway": "real isolated built Gateway",
  "model": "loopback mock provider",
  "sourceHash": "ceb0489e1ea78d5cdb74da71fdeaa8d7a384d7617a6e7cce170db31376856f34",
  "runtimeMonitorHash": "fc06064a01b7ea2587d3066d38cd450619726ae6cbe6c43ad2d6043905f68e6c",
  "inboundRows": 16,
  "agentTurns": [
    "self-chat message 1", "self-chat message 2", "self-chat message 3",
    "self-chat message 4", "self-chat message 5", "self-chat message 6",
    "self-chat message 7", "self-chat message 8"
  ],
  "rateLimited": false,
  "externalSends": 0,
  "elapsedMs": 15135
}
```

```json
{
  "verdict": "PASS",
  "label": "before",
  "nativeReadTransport": "imsg rpc with synthetic chat.db",
  "gateway": "real isolated built Gateway",
  "model": "loopback mock provider",
  "sourceHash": "cbb76a8da1e106735204bd0ac0591dfd9ebd6a903f2ef29cfc2ac40708c82fcd",
  "runtimeMonitorHash": "88e1c291509bd44a4bfe892c35e215d156be65dfff3b81338f914750e9fa464e",
  "inboundRows": 16,
  "agentTurns": [
    "self-chat message 1", "self-chat message 2", "self-chat message 3",
    "self-chat message 4", "self-chat message 5"
  ],
  "rateLimited": true,
  "externalSends": 0,
  "elapsedMs": 11219
}
```

The source and compiled-monitor hashes match the maintainer commit
`88ca4fd8e95f4c34d0d9917c85b5a59595d30c34`.

Proof limitation: an exploratory fixture that generated a new timestamp for each row observed an extra model call. Its exact timestamps were not retained, so no timing-race diagnosis is claimed. The final before/after fixture uses one event timestamp for each twin pair, retains separate commits and native row observation, and does not change the production dedupe or TTL behavior. Timestamp-skew behavior remains a named follow-up if reproduced with retained row evidence.

## Review follow-through

Read the [August 26 ClawSweeper review](https://github.com/openclaw/openclaw/pull/126856#issuecomment-5362509435)
and its rank-up move. There were no actionable code findings. Signed-in
Messages proof is explicitly skipped: no live account was touched. The
native read-transport + real Gateway + mock-provider flow covers the
changed path and satisfies the repository's mock-gateway proof gate; it
does not claim signed-in Messages coverage. A fresh review is appropriate
because the earlier review is over twelve hours old.

The defect remains on current main and stable `v2026.7.1`; related
from-me accounting repair #120260 carried this self-chat membership
forward, rather than introducing a new limiter in this PR. Prior #124386
closed unmerged. Issue #128430 has an additional pairing concern and is
not treated as wholly fixed by this change.
