### PR TITLE
fix(firecrawl): canceled searches reuse stale results from late responses

### DIFF
--- a/extensions/firecrawl/src/firecrawl-client.ts
+++ b/extensions/firecrawl/src/firecrawl-client.ts
@@ -210,7 +210,7 @@ async function postFirecrawlJson<T>(
   const mode = params.mode ?? (await validateFirecrawlBaseUrl(params.url));
   const withEndpoint =
     mode === "selfHosted" ? withSelfHostedWebToolsEndpoint : withStrictWebToolsEndpoint;
-  return await withEndpoint(
+  const result = await withEndpoint(
     {
       url: params.url,
       timeoutSeconds: params.timeoutSeconds,
@@ -270,6 +270,8 @@ async function postFirecrawlJson<T>(
       return await parse(response);
     },
   );
+  params.signal?.throwIfAborted();
+  return result;
 }
 
 function resolveSiteName(urlRaw: string): string | undefined {
@@ -716,13 +718,12 @@ export async function runFirecrawlScrape(
       return payloadLocal;
     },
   );
-  const result = parseFirecrawlScrapePayload({
+  return parseFirecrawlScrapePayload({
     payload,
     url: params.url,
     extractMode: params.extractMode,
     maxChars,
   });
-  return result;
 }
 
 export const testing = {

--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -312,6 +312,76 @@ describe("firecrawl tools", () => {
     },
   );
 
+  it.each(["search", "scrape"] as const)(
+    "rejects late successful %s responses after cancellation and permits a fresh retry",
+    async (operation) => {
+      const controller = new AbortController();
+      const reason = new Error(`${operation} cancelled after dispatch`);
+      let transportSignal: AbortSignal | undefined;
+      const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const cancelledRequest = fetchMock.mock.calls.length === 1;
+        if (cancelledRequest) {
+          transportSignal = init?.signal ?? undefined;
+          controller.abort(reason);
+        }
+        const resultLabel = cancelledRequest ? "cancelled" : "fresh";
+        return Response.json({
+          success: true,
+          data:
+            operation === "search"
+              ? [{ url: `https://${resultLabel}.example/result`, title: resultLabel }]
+              : {
+                  markdown: `${resultLabel} scrape result`,
+                  metadata: {
+                    sourceURL: "https://example.com/firecrawl-cancelled-scrape",
+                    statusCode: 200,
+                  },
+                },
+        });
+      });
+      global.fetch = fetchMock as typeof fetch;
+      const cfg = {
+        plugins: {
+          entries: {
+            firecrawl: {
+              config: {
+                webSearch: { apiKey: "firecrawl-late-cancel-test" },
+                webFetch: { apiKey: "firecrawl-late-cancel-test" },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+      const searchParams = { cfg, query: "Firecrawl cancelled search must not populate cache" };
+      const scrapeParams = {
+        cfg,
+        url: "https://example.com/firecrawl-cancelled-scrape",
+        extractMode: "markdown" as const,
+      };
+      const request =
+        operation === "search"
+          ? runActualFirecrawlSearch({ ...searchParams, signal: controller.signal })
+          : runActualFirecrawlScrape({ ...scrapeParams, signal: controller.signal });
+
+      await expect(request).rejects.toBe(reason);
+      expect(transportSignal?.aborted).toBe(true);
+      expect(transportSignal?.reason).toBe(reason);
+
+      const retry =
+        operation === "search"
+          ? await runActualFirecrawlSearch(searchParams)
+          : await runActualFirecrawlScrape(scrapeParams);
+      if (operation === "search") {
+        expect(retry).toMatchObject({ results: [{ url: "https://fresh.example/result" }] });
+        expect(retry.cached).toBeUndefined();
+      } else {
+        expect(retry).toMatchObject({ status: 200 });
+        expect(retry.text).toContain("fresh scrape result");
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    },
+  );
+
   it("bounds oversized successful Firecrawl search results at the provider owner", async () => {
     global.fetch = vi.fn(async () =>
       Response.json({


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users canceling a Firecrawl search or scrape could still receive a late successful result after cancellation. A canceled search could additionally populate the shared search cache, causing the next identical search to return that stale result without contacting the provider.

## Why This Change Was Made

Validate the original caller's cancellation signal once at the private Firecrawl request-completion owner, after the guarded request and response parsing finish but before either sibling operation returns or search publishes its cache entry. This preserves the original abort reason, provider failures, timeout behavior, credentials, and existing network protections. Removing an existing redundant scrape-result temporary keeps the owner within its existing line budget; production changes total one net line.

Separate owner-review follow-up: assess cancellation-context propagation in the generic web-fetch provider SDK contract.

## User Impact

Canceled Firecrawl searches and scrapes now remain canceled even when a transport returns a late successful response. Retrying the same search fetches fresh provider data instead of replaying a result from the canceled operation.

## Evidence

- Added real Firecrawl search and scrape owner-boundary regressions with an actual AbortController and guarded provider transport. Before the fix both regressions failed because canceled requests resolved successfully; after the fix both reject with the exact original reason, and fresh retries invoke the provider again.
- `node scripts/run-vitest.mjs extensions/firecrawl/src/firecrawl-client.test.ts extensions/firecrawl/src/firecrawl-tools.test.ts`: 121 tests passed, including provider registration, credentials, cooperative cancellation, malformed responses, cache behavior, and SSRF protections.
- Exact-file oxlint and formatting checks passed; maximum-lines, environment-variable, and assertion-safety ratchets passed.
- Independent full-source review and authenticated structured Codex review found no actionable findings.

AI-assisted: yes.
