### PR TITLE
fix(compaction): strict identifier guard blocks compaction on decimal numbers in tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,6 +406,7 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
+- **Compaction strict identifier guard:** stop treating decimal and scientific numbers in tool results as opaque identifiers, so strict compaction is no longer cancelled with `guard_blocked` because a fractional digit run is missing from the summary. Genuine standalone numeric and hex identifiers are still preserved. Fixes #126016.
 
 ## 2026.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,7 +406,6 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
-- **Compaction strict identifier guard:** stop treating decimal and scientific numbers in tool results as opaque identifiers, so strict compaction is no longer cancelled with `guard_blocked` because a fractional digit run is missing from the summary. Genuine standalone numeric and hex identifiers are still preserved. Fixes #126016.
 
 ## 2026.7.1
 

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -148,16 +148,13 @@ function summaryIncludesIdentifier(summary: string, identifier: string): boolean
 export function extractOpaqueIdentifiers(text: string): string[] {
   // Path and host/port candidates start at token boundaries so prose such as
   // "typecheck/lint/format" is not mistaken for an absolute path.
-  // Hex/numeric candidates must span a whole token: they may not start mid-token
-  // (`(?<![A-Za-z0-9._-])`), may not stop mid-token (`(?![A-Za-z0-9_-])`), and may
-  // not be the integer part of a decimal (`(?!\.\d)`). Without those guards, numeric
-  // tool output such as `metric=0.123456789` contributes the fraction `123456789` as
-  // a supposedly opaque identifier, and strict mode then cancels compaction because
-  // that fragment is absent from the finalized artifact. A trailing `.` is still
-  // allowed so sentence-final identifiers ("ticket 123456.") keep matching.
+  // Hex/numeric candidates must span a whole token and never be part of a number:
+  // a fraction (`0.123456789`) or exponent (`1.5e+12345678`) is data, and requiring
+  // it verbatim makes strict compaction unsatisfiable. Trailing `.` stays allowed so
+  // sentence-final identifiers ("ticket 123456.") keep matching.
   const matches =
     text.match(
-      /(?<![A-Za-z0-9._-])(?:[A-Fa-f0-9]{8,}|\d{6,})(?![A-Za-z0-9_-])(?!\.\d)|https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}/g,
+      /(?<![A-Za-z0-9._-])(?<!\d[eE][+-])(?:[A-Fa-f0-9]{8,}|\d{6,})(?![A-Za-z0-9_-])(?!\.\d)|https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}/g,
     ) ?? [];
   return uniqueStrings(
     matches

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -148,9 +148,16 @@ function summaryIncludesIdentifier(summary: string, identifier: string): boolean
 export function extractOpaqueIdentifiers(text: string): string[] {
   // Path and host/port candidates start at token boundaries so prose such as
   // "typecheck/lint/format" is not mistaken for an absolute path.
+  // Hex/numeric candidates must span a whole token: they may not start mid-token
+  // (`(?<![A-Za-z0-9._-])`), may not stop mid-token (`(?![A-Za-z0-9_-])`), and may
+  // not be the integer part of a decimal (`(?!\.\d)`). Without those guards, numeric
+  // tool output such as `metric=0.123456789` contributes the fraction `123456789` as
+  // a supposedly opaque identifier, and strict mode then cancels compaction because
+  // that fragment is absent from the finalized artifact. A trailing `.` is still
+  // allowed so sentence-final identifiers ("ticket 123456.") keep matching.
   const matches =
     text.match(
-      /([A-Fa-f0-9]{8,}|https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}|\b\d{6,}\b)/g,
+      /(?<![A-Za-z0-9._-])(?:[A-Fa-f0-9]{8,}|\d{6,})(?![A-Za-z0-9_-])(?!\.\d)|https?:\/\/\S+|(?<![A-Za-z0-9._-])\/[\w.-]{2,}(?:\/[\w.-]+)+|[A-Za-z]:\\[\w\\.-]+|(?<![A-Za-z0-9._-])[A-Za-z0-9._-]+\.[A-Za-z0-9._/-]+:\d{1,5}/g,
     ) ?? [];
   return uniqueStrings(
     matches

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
+import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
+import { createOpenAICompletionsTransportStreamFn } from "@openclaw/ai/transports";
 import type { AgentMessage, StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { ExtensionAPI, ExtensionContext } from "openclaw/plugin-sdk/agent-sessions";
 import { createAssistantMessageEventStream, type Model } from "openclaw/plugin-sdk/llm";
@@ -2200,6 +2202,92 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(expectCompactionResult(result).summary).toBe(acceptedSummary);
     expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
     expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+  });
+
+  it("completes a real numeric-tool-output compaction without guard_blocked", async () => {
+    // End-to-end at the compaction owner: the summary is produced by a real model
+    // call over a loopback socket (summarizeInStages is not stubbed here), then the
+    // real extractor and real audit decide. Numeric tool output must not block it.
+    mockSummarizeInStages.mockReset();
+    const latestAsk = "report the deployment status";
+    const modelSummary = [
+      "## Decisions",
+      "Keep current flow.",
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Preserve context.",
+      "## Pending user asks",
+      latestAsk,
+      "## Exact identifiers",
+      "None.",
+    ].join("\n");
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        res.writeHead(200, {
+          "content-type": "text/event-stream; charset=utf-8",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        });
+        res.write(
+          `data: ${JSON.stringify({
+            id: "chatcmpl-compaction",
+            object: "chat.completion.chunk",
+            created: 0,
+            model: "compaction-model",
+            choices: [{ index: 0, delta: { content: modelSummary }, finish_reason: "stop" }],
+          })}\n\n`,
+        );
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, "127.0.0.1", resolve);
+    });
+
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback server address");
+      }
+      const sessionManager = stubSessionManager();
+      setCompactionSafeguardRuntime(sessionManager, {
+        model: createAnthropicModelFixture({
+          id: "compaction-model",
+          provider: "openai",
+          api: "openai-completions" as never,
+          baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        }),
+        recentTurnsPreserve: 0,
+        qualityGuardEnabled: true,
+        qualityGuardMaxRetries: 1,
+      });
+
+      const numericToolResult =
+        "latency_p50=0.123456789 throughput=1.234567e+12345678 cost_usd=12345678.90";
+      const event = createCompactionEvent({
+        messageText: `${latestAsk} ${numericToolResult}`,
+        tokensBefore: 1_500,
+      });
+      (
+        event.preparation as { settings?: { reserveTokens: number }; isSplitTurn?: boolean }
+      ).settings = { reserveTokens: 4_000 };
+      (event.preparation as { isSplitTurn?: boolean }).isSplitTurn = false;
+      (event as { streamFn?: unknown }).streamFn = createOpenAICompletionsTransportStreamFn();
+
+      const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
+
+      // The model never echoed the numbers; before the extractor fix they were
+      // required identifiers and this compaction cancelled with guard_blocked.
+      expect(requireRecord(mockCallArg(mockAuditSummaryQuality)).identifiers).toEqual([]);
+      expect(expectCompactionResult(result).summary).toContain("## Decisions");
+      expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
   });
 
   it("propagates caller abort during corrective generation", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1214,7 +1214,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("keeps numeric tool-result noise out of the strict identifier candidate set", () => {
     const toolResult = [
       "latency_p50=0.123456789 latency_p99=3.1415926535",
-      "throughput=1.234567e+8 ratio=2.654321 cost_usd=12345678.90",
+      "throughput=1.234567e+12345678 ratio=2.654321 cost_usd=12345678.90",
       "run_id=987654321 commit=a1b2c3d4e5f6 endpoint=host.local:18789",
     ].join("\n");
 
@@ -1231,6 +1231,17 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(identifiers).toContain("987654321");
     expect(identifiers).toContain("A1B2C3D4E5F6"); // pragma: allowlist secret
     expect(identifiers).toContain("host.local:18789");
+  });
+
+  it("ignores scientific-notation exponents regardless of sign", () => {
+    // `+` is not a token character, so a positive exponent is the one sign that
+    // reaches the numeric branch without an explicit guard.
+    expect(extractOpaqueIdentifiers("throughput=1.234567e+12345678")).not.toContain("12345678");
+    expect(extractOpaqueIdentifiers("throughput=1.234567E+12345678")).not.toContain("12345678");
+    expect(extractOpaqueIdentifiers("decay=9.5e-12345678")).not.toContain("12345678");
+    expect(extractOpaqueIdentifiers("scaled=9.5e12345678")).not.toContain("12345678");
+    // A standalone id that merely follows a `+` is still an identifier.
+    expect(extractOpaqueIdentifiers("shard +12345678")).toContain("12345678");
   });
 
   it("does not extract numeric or hex fragments from inside larger tokens", () => {
@@ -2143,6 +2154,52 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const retry = requireRecord(mockCallArg(mockSummarizeInStages, 1));
     expect(retry.customInstructions).toContain("Quality check feedback");
     expect(retry.customInstructions).toContain("complete summary body within 16000 UTF-16");
+  });
+
+  it("accepts a finalized summary when the source carries only numeric tool-result noise", async () => {
+    mockSummarizeInStages.mockReset();
+    const latestAsk = "report the deployment status";
+    // Telemetry of the shape tool results emit: every digit run here is data.
+    const numericToolResult =
+      "latency_p50=0.123456789 throughput=1.234567e+12345678 cost_usd=12345678.90";
+    const acceptedSummary = [
+      "## Decisions",
+      "Keep current flow.",
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Preserve context.",
+      "## Pending user asks",
+      latestAsk,
+      "## Exact identifiers",
+      "None.",
+    ].join("\n");
+    mockSummarizeInStages.mockResolvedValue(summaryResult(acceptedSummary));
+
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model: createAnthropicModelFixture(),
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+    const event = createCompactionEvent({
+      messageText: `${latestAsk} ${numericToolResult}`,
+      tokensBefore: 1_500,
+    });
+    (
+      event.preparation as { settings?: { reserveTokens: number }; isSplitTurn?: boolean }
+    ).settings = { reserveTokens: 4_000 };
+    (event.preparation as { isSplitTurn?: boolean }).isSplitTurn = false;
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
+
+    // The summary legitimately omits the raw numbers. Before the extraction fix
+    // those digit runs became required identifiers and cancelled this compaction.
+    expect(requireRecord(mockCallArg(mockAuditSummaryQuality)).identifiers).toEqual([]);
+    expect(expectCompactionResult(result).summary).toBe(acceptedSummary);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
   });
 
   it("propagates caller abort during corrective generation", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -1206,6 +1206,40 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(identifiers).toContain("/tmp/x.log");
   });
 
+  it("ignores decimal fragments while preserving standalone numeric identifiers", () => {
+    expect(extractOpaqueIdentifiers("metric=0.123456789")).not.toContain("123456789");
+    expect(extractOpaqueIdentifiers("order_id=123456789")).toContain("123456789");
+  });
+
+  it("keeps numeric tool-result noise out of the strict identifier candidate set", () => {
+    const toolResult = [
+      "latency_p50=0.123456789 latency_p99=3.1415926535",
+      "throughput=1.234567e+8 ratio=2.654321 cost_usd=12345678.90",
+      "run_id=987654321 commit=a1b2c3d4e5f6 endpoint=host.local:18789",
+    ].join("\n");
+
+    const identifiers = extractOpaqueIdentifiers(toolResult);
+
+    // Fractional digit runs are data, not identifiers.
+    expect(identifiers).not.toContain("123456789");
+    expect(identifiers).not.toContain("1415926535");
+    expect(identifiers).not.toContain("234567");
+    expect(identifiers).not.toContain("654321");
+    // The integer part of a decimal is data too.
+    expect(identifiers).not.toContain("12345678");
+    // Genuine identifiers still survive.
+    expect(identifiers).toContain("987654321");
+    expect(identifiers).toContain("A1B2C3D4E5F6"); // pragma: allowlist secret
+    expect(identifiers).toContain("host.local:18789");
+  });
+
+  it("does not extract numeric or hex fragments from inside larger tokens", () => {
+    expect(extractOpaqueIdentifiers("build-artifact-xyz123456789")).not.toContain("123456789");
+    expect(extractOpaqueIdentifiers("v2026.8.123456")).not.toContain("123456");
+    // A sentence-final identifier still matches; only decimals are excluded.
+    expect(extractOpaqueIdentifiers("Filed as ticket 123456.")).toContain("123456");
+  });
+
   it("fails quality audit when required sections are missing", () => {
     const quality = auditSummaryQuality({
       summary: "Short summary without structure",


### PR DESCRIPTION
Closes #126016

## What Problem This Solves

Fixes an issue where operators running sessions with tool-heavy recent turns would have safeguard compaction cancel with `outcome=failed reason=guard_blocked`, leaving the session unable to shrink while every retry paid full summarization cost.

The trigger is ordinary numeric data in tool output. Under the default `identifierPolicy: "strict"`, a `toolResult` containing `metric=0.123456789` or `throughput=1.234567e+12345678` caused the compaction quality guard to demand that the digit run appear literally in the finalized summary. Those are a fraction and an exponent, not identifiers, so no correct summary could satisfy the guard — the compaction was unsatisfiable by construction, and switching the compaction model did not help.

## Why This Change Was Made

`extractOpaqueIdentifiers()` built its candidate set with two unanchored alternatives: `[A-Fa-f0-9]{8,}` had no boundary assertions at all, and `\b\d{6,}\b` treated `.` as a word boundary. Both therefore matched *fragments* — digits after a decimal point, digits inside a larger token, and exponent digits.

Hex and numeric candidates now have to span a whole token and must not be part of a number:

- `(?<![A-Za-z0-9._-])` — may not start mid-token, which excludes the fraction in `0.123456789`. This reuses the exact token-start idiom the path and host:port branches in the same regex already use.
- `(?<!\d[eE][+-])` — may not be a signed scientific-notation exponent.
- `(?![A-Za-z0-9_-])` — may not stop mid-token, so `xyz123456789` no longer yields `123456789`. `.` is deliberately **not** in this set so a sentence-final identifier (`ticket 123456.`) still matches.
- `(?!\.\d)` — may not be the integer part of a decimal, covering `cost_usd=12345678.90`.

**On the exponent guard (review finding, now fixed):** the first revision of this PR missed long *positive* exponents. `-` and a bare `e` are already token characters, so `9.5e-12345678` and `9.5e12345678` were excluded by the token-start guard, but `+` is not a token character, so `1.234567e+12345678` slipped through and yielded `12345678`. The added lookbehind is scoped to a digit immediately before `[eE][+-]` so it only suppresses real scientific notation — a standalone id that merely follows a `+` (`shard +12345678`) is still extracted. All three exponent forms are now covered by tests.

Scope boundary: this PR only fixes **identifier-candidate quality** (issue acceptance criteria 1, 2, 4, 5). It deliberately does **not** change *when* extraction happens relative to `splitPreservedRecentTurns()`, which is criterion 3 and overlaps the body-budget retention invariant tracked separately in #125641. Strict mode still fails closed for genuinely missing identifiers.

## User Impact

Sessions whose recent tool results contain metrics, latencies, ratios, prices, or scientific notation can compact again instead of repeatedly failing with `guard_blocked`. No configuration change is needed, and no existing behavior is relaxed: URL, absolute-path, Windows drive-path, host:port, hash, date/time, and genuine standalone numeric-ID preservation are all unchanged.

## Evidence

**Owner-boundary proof — a real compaction that is accepted rather than guard-blocked.**

This is the evidence the previous review asked for. The added test drives the real `createCompactionHandler()` through `runCompactionScenario`, with the real `extractOpaqueIdentifiers` and the real `auditSummaryQuality` (the suite's spy wraps `vi.importActual`, so the decision path is production code, not a stub). The source carries only numeric telemetry and the summary legitimately omits it:

```
latency_p50=0.123456789 throughput=1.234567e+12345678 cost_usd=12345678.90
```

Against the previous PR head (decimal fix, no exponent guard), that compaction is **cancelled**:

```
FAIL  accepts a finalized summary when the source carries only numeric tool-result noise
AssertionError: expected [ '12345678' ] to deeply equal []

- Expected
+ Received
- []
+ [ "12345678" ]

Tests  1 failed | 133 skipped (134)
```

The received value is the exponent digits entering the strict audit set on the real path. With the fix, the audit set is empty, the summary is returned, and no cancel reason is recorded:

```
expect(...identifiers).toEqual([]);
expect(expectCompactionResult(result).summary).toBe(acceptedSummary);
expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
```

**Extractor regressions**, including the issue's own acceptance snippet:

```ts
expect(extractOpaqueIdentifiers("metric=0.123456789")).not.toContain("123456789");
expect(extractOpaqueIdentifiers("order_id=123456789")).toContain("123456789");
```

Against the previous head, the exponent cases fail as intended:

```
FAIL  ignores scientific-notation exponents regardless of sign
      AssertionError: expected [ '12345678' ] to not include '12345678'
FAIL  keeps numeric tool-result noise out of the strict identifier candidate set
      AssertionError: expected [ '12345678', '987654321', …(2) ] to not include '12345678'
```

**Full suite with the fix — including the five pre-existing extractor tests that pin URL / path / host:port / hex-dedupe / short-number behavior:**

```
Test Files  1 passed (1)
Tests  133 passed | 2 skipped (135)
```

Command: `pnpm test src/agents/agent-hooks/compaction-safeguard.test.ts`

**Gates:**

```
oxfmt --check (changed files)  PASS (exit 0)
oxlint        (changed files)  PASS (exit 0, no output)
pnpm tsgo                      0 errors in changed files
```

`pnpm tsgo` reports 12 errors in `packages/ai`, `packages/markdown-core`, and `src/tui` on this machine. None are in the changed files and none are attributable to this PR; they are dependency-typing drift in my local `node_modules` after syncing ~946 commits of `main`, on untouched paths. CI is authoritative there.

Environment: Windows 11, Node 22.23.2, pnpm 11.15.1.

**Review findings addressed since the last review:**

- *Reject positive scientific-notation exponents (P2)* — fixed, with regressions for `e+`, `E+`, `e-`, and bare `e`, plus a guard that a standalone id after `+` is still extracted.
- *Missing regression coverage* — the tool-result test now uses the long-exponent form `1.234567e+12345678` instead of `1.234567e+8`, whose one-digit exponent was below the matcher threshold.
- *Remove the release-owned changelog entry (P2)* — removed; `CHANGELOG.md` is byte-identical to `main`. Release context lives in this body.
- *Production-versus-test delta* — the matcher comment was compacted while adding the guard, so production is now **+5/−1** (was +7); tests carry the rest.

**Regression reasoning for the pre-existing tests**, since the change is a regex:

- `a1b2c3d4e5f6` / `A1B2C3D4E5F6` — space-delimited, both lookarounds pass; case-dedupe still yields one entry.
- `https://example.com/a,` — the URL branch is untouched; the trailing comma is still stripped by `sanitizeExtractedIdentifier`.
- `127.0.0.1:8080`, `sub-domain.example.test:65535` — every numeric run is under the 6-digit floor, so the tightened branch never engages and the host:port branch still wins.
- `ticket 123456` — space on both sides, still matches.
- The 120,000-character token in the existing backtracking test still short-circuits: the lookbehind fails on the first character inside the run, so matching stays linear.

### Real compaction, real model call, not guard_blocked

The earlier evidence stubbed `summarizeInStages`, which the review fairly said is not a real compaction. This run leaves it unstubbed: the summary is produced by a genuine model call over a loopback SSE socket, and the real extractor and real audit then decide.

Against unmodified `origin/main` the real run poisons its own audit set and the numbers the model never echoed become required identifiers:

```
FAIL  completes a real numeric-tool-output compaction without guard_blocked
AssertionError: expected [ '123456789', '12345678' ] to deeply equal []

+ [ "123456789", "12345678" ]
```

`123456789` is the fraction from `latency_p50=0.123456789`; `12345678` is the integer part of `cost_usd=12345678.90`. That is the `missing_identifiers` set that produces `reason=guard_blocked`.

With the fix, the same source through the same path yields an empty candidate set, the finalized summary is returned, and no cancel reason is recorded:

```
expect(...identifiers).toEqual([]);
expect(expectCompactionResult(result).summary).toContain("## Decisions");
expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
```

### CI note: one unrelated flaky shard

`checks-node-compact-small-11` failed on this head in a file this PR does not touch:

```
FAIL  src/gateway/server.chat.gateway-server-chat.test.ts
      agent.wait ignores lifecycle completion while same-runId chat.send is active   8369ms
Test Files  1 failed | 23 passed (24)
```

That is a concurrency test in `src/gateway/` racing a lifecycle completion against an in-flight `chat.send`; this PR changes only `src/agents/agent-hooks/compaction-safeguard*`. The same shard is green right now on two sibling PRs of mine (#126864 and #128882) from the same window.

I could not re-run it — `gh run rerun` requires admin rights, which I do not have as a fork contributor. Locally `pnpm test src/agents/agent-hooks/compaction-safeguard.test.ts` is green at 133 passed / 2 skipped.

### Proof gap, stated plainly

The provider is a loopback server rather than a paid model, so what is not proven is a specific vendor's summarizer wording. Everything the bug actually depends on is real: the compaction handler, the model call over a socket, the identifier extraction, the quality audit, and the cancel decision.

Investigation and patch were AI-assisted; I reviewed every changed line and ran the tests and gates myself.