### PR TITLE
fix(onboard): honor explicit system agent

### DIFF
--- a/scripts/e2e/lib/onboard/assert-config.mjs
+++ b/scripts/e2e/lib/onboard/assert-config.mjs
@@ -58,6 +58,25 @@ switch (scenario) {
       errors.push("gateway.auth.password mismatch");
     }
     break;
+  case "multi-agent":
+    assertLocalWizard();
+    expectEqual("agents.ownership", cfg?.agents?.ownership, "explicit");
+    expectEqual(
+      "agents.defaults.systemAgent.agentId",
+      cfg?.agents?.defaults?.systemAgent?.agentId,
+      "main",
+    );
+    expectEqual(
+      "agents.entries.main.workspace",
+      cfg?.agents?.entries?.main?.workspace,
+      "/tmp/openclaw-main-workspace",
+    );
+    expectEqual(
+      "agents.entries.ops.workspace",
+      cfg?.agents?.entries?.ops?.workspace,
+      "/tmp/openclaw-ops-workspace",
+    );
+    break;
   case "remote-non-interactive":
     expectEqual("gateway.mode", cfg?.gateway?.mode, "remote");
     expectEqual("gateway.remote.url", cfg?.gateway?.remote?.url, "ws://gateway.local:18789");

--- a/scripts/e2e/lib/onboard/scenario.sh
+++ b/scripts/e2e/lib/onboard/scenario.sh
@@ -387,6 +387,26 @@ run_case_local_password() {
   echo "QA_ASSERT cli.gateway-auth-storage.password pass"
 }
 
+run_case_multi_agent() {
+  set_isolated_openclaw_env multi-agent
+  node scripts/e2e/lib/onboard/write-config.mjs multi-agent "$OPENCLAW_CONFIG_PATH"
+
+  openclaw_e2e_run_logged multi-agent node "$OPENCLAW_ENTRY" onboard \
+    --non-interactive \
+    --accept-risk \
+    --flow quickstart \
+    --mode local \
+    --auth-choice skip \
+    --skip-channels \
+    --skip-skills \
+    --skip-daemon \
+    --skip-ui \
+    --skip-health
+
+  assert_onboard_config multi-agent
+  echo "QA_ASSERT cli.multi-agent-onboarding pass"
+}
+
 run_case_remote_non_interactive() {
   set_isolated_openclaw_env remote-non-interactive
   # Smoke test non-interactive remote config write.
@@ -446,7 +466,7 @@ validate_local_basic_log() {
 }
 
 run_selected_cases() {
-  local selected_cases="${OPENCLAW_ONBOARD_E2E_CASES:-guided-skip-ui,local-basic,remote-non-interactive,reset,channels,skills}"
+  local selected_cases="${OPENCLAW_ONBOARD_E2E_CASES:-guided-skip-ui,local-basic,multi-agent,remote-non-interactive,reset,channels,skills}"
   local case_name
   local -a cases=()
   IFS="," read -r -a cases <<<"$selected_cases"
@@ -456,6 +476,7 @@ run_selected_cases() {
       local-basic) run_case_local_basic ;;
       local-auth-refs) run_case_local_auth_refs ;;
       local-password) run_case_local_password ;;
+      multi-agent) run_case_multi_agent ;;
       remote-non-interactive) run_case_remote_non_interactive ;;
       reset) run_case_reset ;;
       channels) run_case_channels ;;

--- a/scripts/e2e/lib/onboard/write-config.mjs
+++ b/scripts/e2e/lib/onboard/write-config.mjs
@@ -4,7 +4,9 @@ import { applyMockOpenAiModelConfig } from "../fixtures/mock-openai-config.mjs";
 
 const [scenario, configPath, ...scenarioArgs] = process.argv.slice(2);
 if (!scenario || !configPath) {
-  throw new Error("usage: write-config.mjs <reset|skills|guided-skip-ui> <config-path> [...args]");
+  throw new Error(
+    "usage: write-config.mjs <reset|skills|guided-skip-ui|multi-agent> <config-path> [...args]",
+  );
 }
 
 let config;
@@ -25,6 +27,17 @@ if (scenario === "guided-skip-ui") {
   applyMockOpenAiModelConfig(config, { mockPort });
 } else {
   config = {
+    "multi-agent": {
+      meta: {},
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: {
+          main: { workspace: "/tmp/openclaw-main-workspace" },
+          ops: { workspace: "/tmp/openclaw-ops-workspace" },
+        },
+      },
+    },
     reset: {
       meta: {},
       agents: { defaults: { workspace: "/root/old" } },

--- a/src/commands/onboard-agent-target.test.ts
+++ b/src/commands/onboard-agent-target.test.ts
@@ -11,6 +11,7 @@ import {
   applyAgentModelDefaults,
   ensureOnboardingAgentWorkspace,
   resolveOnboardingAgentTarget,
+  resolveOnboardingSetupTarget,
   resolveSystemAgentOnboardingTarget,
 } from "./onboard-agent-target.js";
 
@@ -69,6 +70,27 @@ describe("onboarding agent target", () => {
     expect(resolveSystemAgentOnboardingTarget(config)).toMatchObject({
       agentId: "main",
       workspaceDir: "/srv/main",
+    });
+  });
+
+  it("uses the system agent for explicit fleets without changing legacy ownership", () => {
+    const entries = {
+      main: { workspace: "/srv/main" },
+      ops: { default: true, workspace: "/srv/ops" },
+    };
+
+    expect(
+      resolveOnboardingSetupTarget({
+        agents: {
+          ownership: "explicit",
+          defaults: { systemAgent: { agentId: "main" } },
+          entries,
+        },
+      }),
+    ).toMatchObject({ agentId: "main", workspaceDir: "/srv/main" });
+    expect(resolveOnboardingSetupTarget({ agents: { entries } })).toMatchObject({
+      agentId: "ops",
+      workspaceDir: "/srv/ops",
     });
   });
 

--- a/src/commands/onboard-agent-target.ts
+++ b/src/commands/onboard-agent-target.ts
@@ -48,6 +48,13 @@ export function resolveSystemAgentOnboardingTarget(config: OpenClawConfig): Onbo
   return resolveOnboardingAgentTarget(config, config.agents?.defaults?.systemAgent?.agentId);
 }
 
+/** Resolve onboarding setup to the system agent only for explicitly owned fleets. */
+export function resolveOnboardingSetupTarget(config: OpenClawConfig): OnboardingAgentTarget {
+  return config.agents?.ownership === "explicit"
+    ? resolveSystemAgentOnboardingTarget(config)
+    : resolveOnboardingAgentTarget(config);
+}
+
 export async function ensureOnboardingAgentWorkspace(
   target: OnboardingAgentTarget,
   runtime: RuntimeEnv,

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -16,6 +16,7 @@ import { DEFAULT_GATEWAY_DAEMON_RUNTIME } from "../daemon-runtime.js";
 import {
   ensureOnboardingAgentWorkspace,
   resolveOnboardingAgentTarget,
+  resolveOnboardingSetupTarget,
 } from "../onboard-agent-target.js";
 import {
   applyLocalSetupWorkspaceConfig,
@@ -177,7 +178,7 @@ export async function runNonInteractiveLocalSetup(params: {
 }) {
   const { opts, runtime, baseConfig, baseHash } = params;
   const mode = "local" as const;
-  const preCreationAgentId = resolveOnboardingAgentTarget(baseConfig).agentId;
+  const preCreationAgentId = resolveOnboardingSetupTarget(baseConfig).agentId;
 
   const requestedWorkspaceDir = resolveNonInteractiveWorkspaceDir({
     opts,

--- a/src/wizard/setup.model-auth.test.ts
+++ b/src/wizard/setup.model-auth.test.ts
@@ -152,6 +152,51 @@ describe("runSetupModelAuthStep", () => {
     });
   });
 
+  it("targets the system agent when an explicit fleet selects Claude CLI", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: {
+          main: { agentDir: "/tmp/main-agent", workspace: "/tmp/main-workspace" },
+          ops: { agentDir: "/tmp/ops-agent", workspace: "/tmp/ops-workspace" },
+        },
+      },
+    };
+    promptAuthChoiceGrouped.mockResolvedValueOnce("anthropic-cli");
+    applyAuthChoice.mockResolvedValueOnce({
+      config,
+      authProfiles: [],
+      persistAuthProfiles: async () => {},
+    });
+
+    await runSetupModelAuthStep({
+      config,
+      opts: {},
+      prompter: createPrompter(),
+      runtime: createRuntime(),
+    });
+
+    expect(ensureAuthProfileStore).toHaveBeenCalledWith("/tmp/main-agent", {
+      allowKeychainPrompt: false,
+      readOnly: true,
+    });
+    expect(applyAuthChoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authChoice: "anthropic-cli",
+        agentId: "main",
+        agentDir: "/tmp/main-agent",
+      }),
+    );
+    expect(promptDefaultModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        agentDir: "/tmp/main-agent",
+        workspaceDir: "/tmp/main-workspace",
+      }),
+    );
+  });
+
   it("validates an interactive skip against the configured default agent", async () => {
     const config = createDefaultAgentConfig();
     promptAuthChoiceGrouped.mockResolvedValueOnce("skip");

--- a/src/wizard/setup.model-auth.ts
+++ b/src/wizard/setup.model-auth.ts
@@ -2,7 +2,7 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import {
   applyOnboardingPrimaryModel,
-  resolveOnboardingAgentTarget,
+  resolveOnboardingSetupTarget,
 } from "../commands/onboard-agent-target.js";
 import type { AuthChoice, OnboardOptions } from "../commands/onboard-types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -160,7 +160,7 @@ export async function runSetupModelAuthStep(params: {
     ]);
     promptAuthChoiceGrouped = promptAuthChoice;
     isKeepCurrentAuthChoice = isKeepCurrentChoice;
-    const target = resolveOnboardingAgentTarget(nextConfig);
+    const target = resolveOnboardingSetupTarget(nextConfig);
     authStore = ensureAuthProfileStore(params.agentDir ?? target.agentDir, {
       allowKeychainPrompt: false,
       readOnly: true,
@@ -173,7 +173,7 @@ export async function runSetupModelAuthStep(params: {
   }
   while (true) {
     if (authChoiceFromPrompt) {
-      const target = resolveOnboardingAgentTarget(nextConfig);
+      const target = resolveOnboardingSetupTarget(nextConfig);
       authChoice = await promptAuthChoiceGrouped!({
         prompter,
         store: authStore!,
@@ -214,7 +214,7 @@ export async function runSetupModelAuthStep(params: {
       // or run model/auth checks when the caller already chose to skip setup.
       if (authChoiceFromPrompt) {
         const { promptDefaultModel } = await loadModelPickerModule();
-        const target = resolveOnboardingAgentTarget(nextConfig);
+        const target = resolveOnboardingSetupTarget(nextConfig);
         const modelSelection = await promptDefaultModel({
           config: nextConfig,
           prompter,
@@ -235,7 +235,7 @@ export async function runSetupModelAuthStep(params: {
         }
 
         const { warnIfModelConfigLooksOff } = await loadAuthChoiceModule();
-        const validationTarget = resolveOnboardingAgentTarget(nextConfig);
+        const validationTarget = resolveOnboardingSetupTarget(nextConfig);
         await warnIfModelConfigLooksOff(nextConfig, prompter, {
           agentId: validationTarget.agentId,
           agentDir: validationTarget.agentDir,
@@ -250,7 +250,7 @@ export async function runSetupModelAuthStep(params: {
       { promptDefaultModel },
     ] = await Promise.all([loadAuthChoiceModule(), loadModelPickerModule()]);
     prompter.disableBackNavigation?.();
-    const target = resolveOnboardingAgentTarget(nextConfig);
+    const target = resolveOnboardingSetupTarget(nextConfig);
     let authResult: PreparedAuthChoiceResult;
     try {
       authResult = await prepareAuthChoice({
@@ -292,7 +292,7 @@ export async function runSetupModelAuthStep(params: {
       break;
     }
     if (authResult.agentModelOverride) {
-      const overrideTarget = resolveOnboardingAgentTarget(nextConfig);
+      const overrideTarget = resolveOnboardingSetupTarget(nextConfig);
       nextConfig = applyOnboardingPrimaryModel(
         nextConfig,
         overrideTarget,
@@ -300,7 +300,7 @@ export async function runSetupModelAuthStep(params: {
       );
     }
 
-    const updatedTarget = resolveOnboardingAgentTarget(nextConfig);
+    const updatedTarget = resolveOnboardingSetupTarget(nextConfig);
     const authChoiceModelSelectionPolicy = await resolveAuthChoiceModelSelectionPolicy({
       authChoice,
       config: nextConfig,
@@ -334,7 +334,7 @@ export async function runSetupModelAuthStep(params: {
       }
     }
 
-    const validationTarget = resolveOnboardingAgentTarget(nextConfig);
+    const validationTarget = resolveOnboardingSetupTarget(nextConfig);
     await warnIfModelConfigLooksOff(nextConfig, prompter, {
       agentId: validationTarget.agentId,
       agentDir: validationTarget.agentDir,

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -2,7 +2,7 @@ import { isDeepStrictEqual } from "node:util";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { listAgentEntries } from "../agents/agent-scope-config.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import { resolveOnboardingAgentTarget } from "../commands/onboard-agent-target.js";
+import { resolveOnboardingSetupTarget } from "../commands/onboard-agent-target.js";
 import * as firstAgentOnboarding from "../commands/onboard-first-agent.js";
 import type { OnboardMode, OnboardOptions } from "../commands/onboard-types.js";
 import { hasResolvedRosterBeforeMigrations } from "../config/agent-roster-provenance.js";
@@ -559,7 +559,7 @@ async function runSetupWizardOnce(
     resolveAgentModelPrimaryValue(nextConfig.agents?.defaults?.model) !== undefined &&
     ((usedImportFlow && keepExistingModelConfig) || opts.authChoice !== "skip")
   ) {
-    const verificationTarget = resolveOnboardingAgentTarget(nextConfig);
+    const verificationTarget = resolveOnboardingSetupTarget(nextConfig);
     const verification = await offerLiveModelVerification({
       config: nextConfig,
       ...(stagedModelAuth
@@ -641,7 +641,7 @@ async function runSetupWizardOnce(
       allowConfigSizeDrop: false,
     });
   }
-  let onboardingTarget = resolveOnboardingAgentTarget(nextConfig);
+  let onboardingTarget = resolveOnboardingSetupTarget(nextConfig);
   const { logConfigUpdated } = await loadConfigLoggingModule();
   logConfigUpdated(runtime);
   await onboardHelpers.ensureWorkspaceAndSessions(onboardingTarget.workspaceDir, runtime, {
@@ -711,7 +711,7 @@ async function runSetupWizardOnce(
   nextConfig = await writeSetupConfigFile(nextConfig, {
     allowConfigSizeDrop: false,
   });
-  onboardingTarget = resolveOnboardingAgentTarget(nextConfig);
+  onboardingTarget = resolveOnboardingSetupTarget(nextConfig);
   commitAppRecommendationResult?.();
 
   const { finalizeSetupWizard } = await import("./setup.finalize.js");


### PR DESCRIPTION
## Summary

- route onboarding setup effects through `agents.defaults.systemAgent.agentId` for explicitly owned fleets
- preserve legacy/default-agent behavior for non-explicit rosters
- add Claude CLI/model-selection coverage plus a packaged two-agent onboarding E2E case

## Root cause

Onboarding used the generic agent resolver during model/auth, workspace, sessions, verification, and non-interactive setup. That resolver intentionally rejects an ambiguous multi-agent roster, even when an explicit fleet already names its system agent. Existing onboarding E2E fixtures only covered clean single-agent state, so the real fleet configuration was absent from CI.

## Red / green proof

- Red on unmodified main: [Testbox run 32412937443](https://github.com/openclaw/openclaw/actions/runs/32412937443) failed with `Multiple agents are configured...`
- Green focused tests on latest-main base `784a2287815`: [17/17 passed](https://github.com/openclaw/openclaw/actions/runs/32422230083)
- Green packaged onboarding matrix on commit `947775763dc`: [`QA_ASSERT cli.multi-agent-onboarding pass`](https://github.com/openclaw/openclaw/actions/runs/32422240817)
- `git diff --check` passed
- Autoreview: clean, no actionable findings

## Test notes

An over-broad `test:changed` run also executed 4,665 unrelated tests and reported four failures in `src/entry.run-main.test.ts` and `src/node-host/node-worker-transfer-client.test.ts`; neither surface is changed by this PR. The focused tests and packaged onboarding product path are green.
