### PR TITLE
fix(models): --agent is silently ignored by models aliases and models scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,6 +406,7 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
+- **`models` agent scoping:** `models aliases list/add/remove` and `models scan` now reject `--agent` with a clear message instead of silently ignoring it, including unknown agent ids. These commands only read or write global model config, so the flag never had an effect. Fixes #126597.
 
 ## 2026.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,7 +406,6 @@ Docs: https://docs.openclaw.ai
 - **Media-store remote downloads:** bound response-header waits and stalled bodies, close abandoned redirect and error responses, and remove partial temp files so hung sources cannot pin callers. (#104624) Thanks @hugenshen.
 - **Cron llama.cpp tool schemas:** keep the model-facing cron declaration schema compatible with llama.cpp while retaining gateway and runtime nonblank validation. Fixes #107449. (#108360) Thanks @lee-xydt.
 - **System-agent recovery guidance:** direct browser and app users to Settings or the OpenClaw host instead of terminal-only exit guidance while preserving the required stop, onboard, and restart lifecycle. (#114633) Thanks @jesse-merhi.
-- **`models` agent scoping:** `models aliases list/add/remove` and `models scan` now reject `--agent` with a clear message instead of silently ignoring it, including unknown agent ids. These commands only read or write global model config, so the flag never had an effect. Fixes #126597.
 
 ## 2026.7.1
 

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -28,7 +28,7 @@ openclaw models set-image <model-or-alias>
 openclaw models scan
 ```
 
-`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`, `set-image`, `scan`, and `aliases` reject `--agent` outright because they only read or write global model config. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
+`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`, `set-image`, `scan`, and `aliases` reject `--agent` outright because they are global and never agent-scoped. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
 
 `models set` and `models set-image` require the provider to be declared by an installed plugin or configured under `models.providers`. An unknown provider exits nonzero without changing config. If the provider is known but the model is absent from the local catalog, the command saves the selection and prints a warning because newly released and self-hosted models may not be cataloged yet. `openclaw doctor --json` reports configured unknown providers; add `--severity-min info` to also see active models that the local catalog cannot confirm.
 

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -28,7 +28,7 @@ openclaw models set-image <model-or-alias>
 openclaw models scan
 ```
 
-`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `scan`, `aliases`, and `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`/`set-image` reject `--agent` outright. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
+`status`, `list`, and `auth` subcommands accept `--agent <id>` to target a configured agent; `fallbacks`/`image-fallbacks` always use the configured default agent, and `set`, `set-image`, `scan`, and `aliases` reject `--agent` outright because they only read or write global model config. When omitted, `--agent`-aware commands use `OPENCLAW_AGENT_DIR` if set, otherwise the configured default agent.
 
 `models set` and `models set-image` require the provider to be declared by an installed plugin or configured under `models.providers`. An unknown provider exits nonzero without changing config. If the provider is known but the model is absent from the local catalog, the command saves the selection and prints a warning because newly released and self-hosted models may not be cataloged yet. `openclaw doctor --json` reports configured unknown providers; add `--severity-min info` to also see active models that the local catalog cannot confirm.
 

--- a/src/cli/models-cli.lazy.test.ts
+++ b/src/cli/models-cli.lazy.test.ts
@@ -19,7 +19,7 @@ describe("models cli lazy runtime boundary", () => {
       runtimeLoaded();
       return {
         defaultRuntime: {},
-        rejectAgentScopedModelWrite: vi.fn(),
+        rejectAgentScopedModelCommand: vi.fn(),
         resolveModelAgentOption: vi.fn(),
         runModelsCommand: vi.fn(),
       };
@@ -53,7 +53,7 @@ describe("models cli lazy runtime boundary", () => {
       runtimeLoaded();
       return {
         defaultRuntime,
-        rejectAgentScopedModelWrite: vi.fn(),
+        rejectAgentScopedModelCommand: vi.fn(),
         resolveModelAgentOption,
         runModelsCommand,
       };

--- a/src/cli/models-cli.runtime.ts
+++ b/src/cli/models-cli.runtime.ts
@@ -20,7 +20,7 @@ export function resolveModelAgentOption(
   );
 }
 
-/** `models` subcommands that only ever read or write global model config. */
+/** `models` subcommands that operate on global state only, never per-agent. */
 export type GlobalOnlyModelCommandName =
   | "set"
   | "set-image"
@@ -33,12 +33,14 @@ export function rejectAgentScopedModelCommand(
   command: Command,
   commandName: GlobalOnlyModelCommandName,
 ): void {
-  // These commands only touch global config; accepting --agent would imply per-agent scope.
+  // None of these resolve an agent, so accepting --agent would imply a scope that
+  // does not exist. Kept scope-neutral: `scan --no-probe` returns after printing
+  // the catalog without writing config at all.
   const agent = resolveOptionFromCommand<string>(command, "agent");
   if (!agent) {
     return;
   }
   throw new Error(
-    `openclaw models ${commandName} does not support --agent; it only reads or writes global model config. Remove --agent, or run ${formatCliCommand("openclaw agents list")} and set the per-agent model in agent config.`,
+    `openclaw models ${commandName} does not support --agent; it is global and never agent-scoped. Remove --agent, or run ${formatCliCommand("openclaw agents list")} and set the per-agent model in agent config.`,
   );
 }

--- a/src/cli/models-cli.runtime.ts
+++ b/src/cli/models-cli.runtime.ts
@@ -20,16 +20,31 @@ export function resolveModelAgentOption(
   );
 }
 
-export function rejectAgentScopedModelWrite(
+/**
+ * `models` subcommands that only ever read or write global model config.
+ * The value describes the scope so the rejection message stays accurate per command.
+ */
+const GLOBAL_ONLY_MODEL_COMMAND_SCOPE = {
+  set: "updates global model defaults",
+  "set-image": "updates global model defaults",
+  scan: "updates global model defaults",
+  "aliases list": "reads global model aliases",
+  "aliases add": "updates global model aliases",
+  "aliases remove": "updates global model aliases",
+} as const;
+
+export type GlobalOnlyModelCommandName = keyof typeof GLOBAL_ONLY_MODEL_COMMAND_SCOPE;
+
+export function rejectAgentScopedModelCommand(
   command: Command,
-  commandName: "set" | "set-image",
+  commandName: GlobalOnlyModelCommandName,
 ): void {
-  // Write commands update global defaults; accepting --agent here would imply per-agent mutation.
+  // These commands only touch global defaults; accepting --agent here would imply per-agent scope.
   const agent = resolveOptionFromCommand<string>(command, "agent");
   if (!agent) {
     return;
   }
   throw new Error(
-    `openclaw models ${commandName} does not support --agent; it only updates global model defaults. Remove --agent, or run ${formatCliCommand("openclaw agents list")} and set the per-agent model in agent config.`,
+    `openclaw models ${commandName} does not support --agent; it only ${GLOBAL_ONLY_MODEL_COMMAND_SCOPE[commandName]}. Remove --agent, or run ${formatCliCommand("openclaw agents list")} and set the per-agent model in agent config.`,
   );
 }

--- a/src/cli/models-cli.runtime.ts
+++ b/src/cli/models-cli.runtime.ts
@@ -20,31 +20,25 @@ export function resolveModelAgentOption(
   );
 }
 
-/**
- * `models` subcommands that only ever read or write global model config.
- * The value describes the scope so the rejection message stays accurate per command.
- */
-const GLOBAL_ONLY_MODEL_COMMAND_SCOPE = {
-  set: "updates global model defaults",
-  "set-image": "updates global model defaults",
-  scan: "updates global model defaults",
-  "aliases list": "reads global model aliases",
-  "aliases add": "updates global model aliases",
-  "aliases remove": "updates global model aliases",
-} as const;
-
-export type GlobalOnlyModelCommandName = keyof typeof GLOBAL_ONLY_MODEL_COMMAND_SCOPE;
+/** `models` subcommands that only ever read or write global model config. */
+export type GlobalOnlyModelCommandName =
+  | "set"
+  | "set-image"
+  | "scan"
+  | "aliases list"
+  | "aliases add"
+  | "aliases remove";
 
 export function rejectAgentScopedModelCommand(
   command: Command,
   commandName: GlobalOnlyModelCommandName,
 ): void {
-  // These commands only touch global defaults; accepting --agent here would imply per-agent scope.
+  // These commands only touch global config; accepting --agent would imply per-agent scope.
   const agent = resolveOptionFromCommand<string>(command, "agent");
   if (!agent) {
     return;
   }
   throw new Error(
-    `openclaw models ${commandName} does not support --agent; it only ${GLOBAL_ONLY_MODEL_COMMAND_SCOPE[commandName]}. Remove --agent, or run ${formatCliCommand("openclaw agents list")} and set the per-agent model in agent config.`,
+    `openclaw models ${commandName} does not support --agent; it only reads or writes global model config. Remove --agent, or run ${formatCliCommand("openclaw agents list")} and set the per-agent model in agent config.`,
   );
 }

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -11,6 +11,10 @@ const mocks = vi.hoisted(() => ({
   modelsSetCommand: vi.fn().mockResolvedValue(undefined),
   modelsSetImageCommand: vi.fn().mockResolvedValue(undefined),
   noopAsync: vi.fn(async () => undefined),
+  modelsAliasesAddCommand: vi.fn().mockResolvedValue(undefined),
+  modelsAliasesListCommand: vi.fn().mockResolvedValue(undefined),
+  modelsAliasesRemoveCommand: vi.fn().mockResolvedValue(undefined),
+  modelsScanCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthAddCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthListCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthLoginCommand: vi.fn().mockResolvedValue(undefined),
@@ -24,6 +28,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 const {
+  modelsAliasesAddCommand,
+  modelsAliasesListCommand,
+  modelsAliasesRemoveCommand,
   modelsAuthAddCommand,
   modelsAuthListCommand,
   modelsAuthLoginCommand,
@@ -34,6 +41,7 @@ const {
   modelsAuthPasteApiKeyCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
+  modelsScanCommand,
   modelsSetCommand,
   modelsSetImageCommand,
   modelsStatusCommand,
@@ -64,9 +72,9 @@ vi.mock("../commands/models/auth-order.js", () => ({
   modelsAuthOrderSetCommand: mocks.modelsAuthOrderSetCommand,
 }));
 vi.mock("../commands/models/aliases.js", () => ({
-  modelsAliasesAddCommand: mocks.noopAsync,
-  modelsAliasesListCommand: mocks.noopAsync,
-  modelsAliasesRemoveCommand: mocks.noopAsync,
+  modelsAliasesAddCommand: mocks.modelsAliasesAddCommand,
+  modelsAliasesListCommand: mocks.modelsAliasesListCommand,
+  modelsAliasesRemoveCommand: mocks.modelsAliasesRemoveCommand,
 }));
 vi.mock("../commands/models/fallbacks.js", () => ({
   modelsFallbacksAddCommand: mocks.noopAsync,
@@ -81,7 +89,7 @@ vi.mock("../commands/models/image-fallbacks.js", () => ({
   modelsImageFallbacksRemoveCommand: mocks.noopAsync,
 }));
 vi.mock("../commands/models/scan.js", () => ({
-  modelsScanCommand: mocks.noopAsync,
+  modelsScanCommand: mocks.modelsScanCommand,
 }));
 vi.mock("../commands/models/set.js", () => ({
   modelsSetCommand: mocks.modelsSetCommand,
@@ -93,6 +101,10 @@ vi.mock("../commands/models/set-image.js", () => ({
 describe("models cli", () => {
   beforeEach(() => {
     mocks.modelsListCommand.mockClear();
+    modelsAliasesAddCommand.mockClear();
+    modelsAliasesListCommand.mockClear();
+    modelsAliasesRemoveCommand.mockClear();
+    modelsScanCommand.mockClear();
     modelsAuthAddCommand.mockClear();
     modelsAuthListCommand.mockClear();
     modelsAuthLoginCommand.mockClear();
@@ -441,10 +453,47 @@ describe("models cli", () => {
       args: ["models", "--agent", "poe", "set-image", "openai/gpt-image-1"],
       command: modelsSetImageCommand,
     },
+    {
+      label: "aliases list",
+      args: ["models", "--agent", "poe", "aliases", "list"],
+      command: modelsAliasesListCommand,
+    },
+    {
+      label: "aliases add",
+      args: ["models", "--agent", "poe", "aliases", "add", "zzz", "soraka/grok-4.6"],
+      command: modelsAliasesAddCommand,
+    },
+    {
+      label: "aliases remove",
+      args: ["models", "--agent", "poe", "aliases", "remove", "zzz"],
+      command: modelsAliasesRemoveCommand,
+    },
+    {
+      label: "scan",
+      args: ["models", "--agent", "poe", "scan", "--no-probe", "--no-input"],
+      command: modelsScanCommand,
+    },
   ])("rejects parent --agent for models $label", async ({ args, command }) => {
     await expect(runModelsCommand(args)).rejects.toThrow("does not support --agent");
 
     expect(command).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: "aliases list",
+      args: ["models", "aliases", "list"],
+      command: modelsAliasesListCommand,
+    },
+    {
+      label: "scan",
+      args: ["models", "scan", "--no-probe", "--no-input"],
+      command: modelsScanCommand,
+    },
+  ])("still runs models $label without --agent", async ({ args, command }) => {
+    await runModelsCommand(args);
+
+    expect(command).toHaveBeenCalled();
   });
 
   it("shows help for models auth without error exit", async () => {

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -142,7 +142,7 @@ export function registerModelsCli(program: Command) {
     .argument("<model>", "Model id or alias")
     .action(async (model: string, _opts: unknown, command: Command) => {
       const runtime = await loadModelsRuntime();
-      runtime.rejectAgentScopedModelWrite(command, "set");
+      runtime.rejectAgentScopedModelCommand(command, "set");
       await runtime.runModelsCommand(async () => {
         const { modelsSetCommand } = await import("../commands/models/set.js");
         await modelsSetCommand(model, runtime.defaultRuntime);
@@ -155,7 +155,7 @@ export function registerModelsCli(program: Command) {
     .argument("<model>", "Model id or alias")
     .action(async (model: string, _opts: unknown, command: Command) => {
       const runtime = await loadModelsRuntime();
-      runtime.rejectAgentScopedModelWrite(command, "set-image");
+      runtime.rejectAgentScopedModelCommand(command, "set-image");
       await runtime.runModelsCommand(async () => {
         const { modelsSetImageCommand } = await import("../commands/models/set-image.js");
         await modelsSetImageCommand(model, runtime.defaultRuntime);
@@ -169,10 +169,15 @@ export function registerModelsCli(program: Command) {
     .description("List model aliases")
     .option("--json", "Output JSON", false)
     .option("--plain", "Plain output", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (opts, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "aliases list");
+      await runtime.runModelsCommand(async () => {
         const { modelsAliasesListCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesListCommand({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
+        await modelsAliasesListCommand(
+          { ...opts, json: hasJsonOutput(opts) },
+          runtime.defaultRuntime,
+        );
       });
     });
 
@@ -181,10 +186,12 @@ export function registerModelsCli(program: Command) {
     .description("Add or update a model alias")
     .argument("<alias>", "Alias name")
     .argument("<model>", "Model id or alias")
-    .action(async (alias: string, model: string) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (alias: string, model: string, _opts: unknown, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "aliases add");
+      await runtime.runModelsCommand(async () => {
         const { modelsAliasesAddCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesAddCommand(alias, model, defaultRuntime);
+        await modelsAliasesAddCommand(alias, model, runtime.defaultRuntime);
       });
     });
 
@@ -192,10 +199,12 @@ export function registerModelsCli(program: Command) {
     .command("remove")
     .description("Remove a model alias")
     .argument("<alias>", "Alias name")
-    .action(async (alias: string) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (alias: string, _opts: unknown, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "aliases remove");
+      await runtime.runModelsCommand(async () => {
         const { modelsAliasesRemoveCommand } = await loadModelsAliasesCommands();
-        await modelsAliasesRemoveCommand(alias, defaultRuntime);
+        await modelsAliasesRemoveCommand(alias, runtime.defaultRuntime);
       });
     });
 
@@ -286,10 +295,12 @@ export function registerModelsCli(program: Command) {
     .option("--set-default", "Set agents.defaults.model to the first selection", false)
     .option("--set-image", "Set agents.defaults.imageModel to the first image selection", false)
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await withModelsRuntime(async ({ defaultRuntime }) => {
+    .action(async (opts, command: Command) => {
+      const runtime = await loadModelsRuntime();
+      runtime.rejectAgentScopedModelCommand(command, "scan");
+      await runtime.runModelsCommand(async () => {
         const { modelsScanCommand } = await import("../commands/models/scan.js");
-        await modelsScanCommand({ ...opts, json: hasJsonOutput(opts) }, defaultRuntime);
+        await modelsScanCommand({ ...opts, json: hasJsonOutput(opts) }, runtime.defaultRuntime);
       });
     });
 


### PR DESCRIPTION
Closes #126597

## What Problem This Solves

Fixes an issue where operators running a multi-agent fleet would have `--agent <id>` silently ignored by `openclaw models aliases list/add/remove` and `openclaw models scan`, with no error even when the agent id did not exist.

The parent `models` command documents `--agent` as a global option ("Agent id to inspect"), so passing it looks like it scopes the command. For these four subcommands it did nothing at all — and unlike every other `--agent`-aware `models` subcommand, it was not even validated. The `aliases add` case is the worst of the four: it wrote to global `agents.defaults.models` while the operator believed they were editing one agent's aliases.

## Why This Change Was Made

The issue offers two acceptable fixes: validate the id, or reject the flag outright. I took **reject**, because these commands read and write global `agents.defaults.*` unconditionally — there is no agent-scoped code path for the value to feed even if it were validated, so accepting it would keep implying a scope that does not exist.

Rather than invent a mechanism, this reuses the guard `models set` / `models set-image` already use, which is exactly the precedent the reporter pointed at. `rejectAgentScopedModelWrite` is renamed to `rejectAgentScopedModelCommand` — it now also covers a read (`aliases list`), so the old name was wrong — and the six global-only commands are named by a closed union.

One placement detail worth flagging for review: the guard must be invoked **before** `runModelsCommand`, not inside it. `runCommandWithRuntime` converts a thrown error into `process.exit(1)`, so a guard called inside the wrapper produces a bare exit-1 instead of the message. The `set` / `set-image` call sites already do it this way; the four new call sites now match. My first attempt put it inside the wrapper and the tests caught it.

**Deliberately out of scope:** `fallbacks` and `image-fallbacks`. They are the same shape of bug but are tracked in #106346 with an open PR pending a maintainer product decision, and `fallbacks` additionally reads/writes the wrong target rather than merely ignoring the flag.

## User Impact

Operators get an actionable error naming the command and its real scope, instead of a command that appears to be agent-scoped and is not. A typo'd or nonexistent agent id now fails fast rather than silently writing global config.

This is a behavior change for anyone currently passing `--agent` to these commands, but only in the sense that a previously silent no-op becomes an explicit error — no command that did useful work stops working, and the error text says exactly what to do instead.

`docs/cli/models.md` previously documented the old behavior; that line is updated to match.

## Evidence

### Real CLI behavior, before and after

Driven through the real `registerModelsCli` commander tree with an isolated `OPENCLAW_STATE_DIR`, on Windows 11 / Node 22.23.2.

**Before (`origin/main`)** — the bogus agent id is accepted and the commands just run:

```
$ openclaw models --agent totally-bogus-agent-id aliases list
Aliases (0):
- none
[exit 0]

$ openclaw models --agent totally-bogus-agent-id scan --no-probe --no-input
openrouter/openrouter/free                 skip       skip       200k     -
openrouter/nvidia/nemotron-3.5-content-... skip       skip       128k     -
openrouter/liquid/lfm-2.5-2.6b:free        skip       skip       66k      2.6b
[exit 0]
```

That is the reported defect: a nonexistent agent silently scopes nothing, and `scan` performs a full catalog scan as if the flag were meaningful.

**After (this branch)** — all four commands reject with an actionable message:

```
$ openclaw models --agent totally-bogus-agent-id aliases list
[error] openclaw models aliases list does not support --agent; it is global and never agent-scoped. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
[exit 1]

$ openclaw models --agent totally-bogus-agent-id aliases add zzz-test soraka/grok-4.6
[error] openclaw models aliases add does not support --agent; it is global and never agent-scoped. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
[exit 1]

$ openclaw models --agent totally-bogus-agent-id aliases remove zzz-test
[error] openclaw models aliases remove does not support --agent; it is global and never agent-scoped. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
[exit 1]

$ openclaw models --agent totally-bogus-agent-id scan --no-probe --no-input
[error] openclaw models scan does not support --agent; it is global and never agent-scoped. Remove --agent, or run openclaw agents list and set the per-agent model in agent config.
[exit 1]
```

A **valid** agent id is rejected the same way, which is the point — the flag never had an effect here:

```
$ openclaw models --agent main aliases list
[error] openclaw models aliases list does not support --agent; it is global and never agent-scoped. ...
[exit 1]
```

Positive control — without `--agent` the command still runs normally:

```
$ openclaw models aliases list
Aliases (0):
- none
[exit 0]
```

### Tests

Six cases were added to the existing `it.each` rejection table in `src/cli/models-cli.test.ts`: four rejections, plus two asserting the commands still run **without** `--agent`, so the guard cannot silently break the happy path.

Against the unfixed tree, the four new rows fail and the two pre-existing rows pass, which confirms the table measures the new behavior specifically:

```
Tests  4 failed | 2 passed | 36 skipped (42)

FAIL  rejects parent --agent for models 'aliases list'
FAIL  rejects parent --agent for models 'aliases add'
FAIL  rejects parent --agent for models 'aliases remove'
FAIL  rejects parent --agent for models 'scan'
      AssertionError: promise resolved "undefined" instead of rejecting

PASS  rejects parent --agent for models 'set'
PASS  rejects parent --agent for models 'set-image'
```

With the fix:

```
Test Files  2 passed (2)
Tests  44 passed (44)
```

Command: `pnpm test src/cli/models-cli.test.ts src/cli/models-cli.lazy.test.ts`

### Gates

```
oxfmt --check (changed files + docs)  PASS (exit 0)
oxlint        (changed files)         PASS (exit 0, no output)
pnpm tsgo                             0 errors in changed files
```

`pnpm tsgo` reports 12 errors in `packages/ai`, `packages/markdown-core`, and `src/tui`. None are in the changed files and none are attributable to this PR — they are dependency-typing drift in my local `node_modules` on untouched paths (see the proof-gap note below). CI is authoritative there.

### Review findings addressed in this round

- *Describe scan''s scope accurately (P2)* — fixed. The shared message previously claimed every guarded command "only reads or writes global model config", but `models scan --no-probe` prints the catalog and returns at `src/commands/models/scan.ts:283` without touching config. The message now states what is true of all six: they are global and never agent-scoped. `docs/cli/models.md` updated to match, and a repo-wide search confirms no copy of the old wording remains.
- *Merge risk: scripts passing --agent now exit nonzero* — intentional and documented; the previously silent no-op becomes an explicit error with remediation text.
- *Merge risk: net +20 production lines* — the review itself notes the shared guard is clearer than duplicating scope handling at six call sites, and that it must run before the runtime error wrapper.

### Review findings addressed earlier

- *Remove the release-owned changelog entry (P2)* — removed; `CHANGELOG.md` is byte-identical to `main`. Release context lives in this body.
- *Add real behavior proof* — the before/after terminal output above, from the real commander tree rather than a mocked guard.
- *Production-versus-test delta* — the runtime scope map collapsed into a type-only union plus one message that is accurate for both the read and the write commands. Net production delta is now **+20** (was +26), with no policy duplicated at call sites.
- *Compatibility change for existing scripts* — intentional and now shown in real output above: the previously silent no-op becomes an explicit exit-1 with remediation text.

### Proof gap, stated plainly

I could not produce **packaged** (`pnpm build`) CLI output. `pnpm build` fails in my environment on `TuiMainScreen is not exported by @earendil-works/pi-tui`, and refreshing dependencies fails because my corporate npm proxy has not mirrored `rolldown@1.2.5` (`ERR_PNPM_NO_MATCHING_VERSION`, latest mirrored is 1.2.4). Both are environment issues on paths this PR does not touch, and they are the same root cause as the 12 `tsgo` errors above.

The output above is therefore from the real registered `models` command tree and real command implementations — the actual parser, guard, and command bodies an operator hits — but not from a bundled `dist/` binary.

Investigation and patch were AI-assisted; I reviewed every changed line and ran the tests, gates, and CLI proof myself.
