### PR TITLE
fix(doctor): keep Claude CLI overrides selectable after migration

### DIFF
--- a/docs/concepts/agent-runtimes.md
+++ b/docs/concepts/agent-runtimes.md
@@ -171,9 +171,11 @@ CLI backend aliases differ from embedded harness ids. Preferred Claude CLI form:
 }
 ```
 
-Legacy refs such as `claude-cli/claude-opus-4-7` remain supported for
-compatibility, but new config should keep the provider/model canonical and
-put the execution backend in provider/model runtime policy.
+Legacy refs such as `claude-cli/claude-opus-4-7` are accepted as compatibility
+input, but new config should keep the provider/model canonical and put the
+execution backend in provider/model runtime policy. Run `openclaw doctor --fix`
+to rewrite persisted legacy model selections, model-map keys, and explicit
+`modelPolicy.allow` entries to that canonical shape.
 
 Legacy `codex-cli/*` refs are different: doctor migrates them to `openai/*` so
 they run through the Codex app-server harness instead of preserving a Codex

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -12,6 +12,7 @@ import { validateConfigObject } from "../config/validation.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { maybeRepairCodexRoutes } from "./doctor/shared/codex-route-warnings.js";
+import { applyLegacyDoctorMigrations } from "./doctor/shared/legacy-config-compat.js";
 import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./doctor/shared/legacy-config-migrations.js";
 import { collectBlockedLegacyOpenAICodexProviderPlan } from "./doctor/shared/legacy-config-migrations.runtime.models.js";
@@ -1579,6 +1580,38 @@ describe("normalizeCompatibilityConfigValues", () => {
     expect(res.config.agents?.defaults?.modelPolicy).toEqual({
       allow: ["anthropic/claude-sonnet-4-6", "google/gemini-3.1-pro-preview"],
     });
+  });
+
+  it("canonicalizes a seeded legacy Claude CLI allowlist in one doctor pass", () => {
+    // Reporter path (#124952): the doctor spec migration copies an unmarked legacy
+    // model map into modelPolicy.allow first, so the normalizer must rewrite the
+    // allowlist and the model map in the same pass, not on a later run.
+    const seeded = applyLegacyDoctorMigrations({
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-7" },
+          models: {
+            "claude-cli/claude-opus-4-7": {},
+            "claude-cli/claude-sonnet-4-6": {},
+          },
+        },
+      },
+    });
+    expect(seeded.next?.agents).toMatchObject({
+      defaults: {
+        modelPolicy: { allow: ["claude-cli/claude-opus-4-7", "claude-cli/claude-sonnet-4-6"] },
+      },
+    });
+
+    const res = normalizeCompatibilityConfigValues(legacyConfig(seeded.next));
+    expect(res.config.agents?.defaults?.models).toEqual({
+      "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+      "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
+    });
+    expect(res.config.agents?.defaults?.modelPolicy).toEqual({
+      allow: ["anthropic/claude-opus-4-7", "anthropic/claude-sonnet-4-6"],
+    });
+    expect(normalizeCompatibilityConfigValues(res.config).changes).toEqual([]);
   });
 
   it("preserves legacy whole-agent Claude CLI intent for canonical Anthropic defaults", () => {

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -1525,6 +1525,40 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
+  it("preserves selected legacy keys outside the migrated allowlist runtime", () => {
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            model: { primary: "google-gemini-cli/gemini-3-pro-preview" },
+            models: {
+              "claude-cli/claude-sonnet-4-6": { alias: "Claude CLI" },
+              "google-gemini-cli/gemini-3-pro-preview": { alias: "Gemini CLI" },
+            },
+            modelPolicy: {
+              allow: ["claude-cli/claude-sonnet-4-6", "google/gemini-3.1-pro-preview"],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(res.config.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": {
+        alias: "Claude CLI",
+        agentRuntime: { id: "claude-cli" },
+      },
+      "google-gemini-cli/gemini-3-pro-preview": { alias: "Gemini CLI" },
+      "google/gemini-3.1-pro-preview": {
+        alias: "Gemini CLI",
+        agentRuntime: { id: "google-gemini-cli" },
+      },
+    });
+    expect(res.config.agents?.defaults?.modelPolicy).toEqual({
+      allow: ["anthropic/claude-sonnet-4-6", "google/gemini-3.1-pro-preview"],
+    });
+  });
+
   it("preserves legacy whole-agent Claude CLI intent for canonical Anthropic defaults", () => {
     const res = normalizeCompatibilityConfigValues(
       legacyConfig({

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -1487,6 +1487,44 @@ describe("normalizeCompatibilityConfigValues", () => {
     });
   });
 
+  it("migrates legacy Claude CLI model maps and allowlists when the primary is canonical", () => {
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-7" },
+            models: {
+              "claude-cli/claude-opus-4-7": { alias: "Opus" },
+              "claude-cli/claude-sonnet-4-6": {},
+            },
+            modelPolicy: {
+              allow: ["claude-cli/claude-opus-4-7", "claude-cli/claude-sonnet-4-6"],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(res.config.agents?.defaults?.models).toEqual({
+      "anthropic/claude-opus-4-7": {
+        alias: "Opus",
+        agentRuntime: { id: "claude-cli" },
+      },
+      "anthropic/claude-sonnet-4-6": {
+        agentRuntime: { id: "claude-cli" },
+      },
+    });
+    expect(res.config.agents?.defaults?.modelPolicy).toEqual({
+      allow: ["anthropic/claude-opus-4-7", "anthropic/claude-sonnet-4-6"],
+    });
+    expect(res.changes).toContain(
+      "Moved agents.defaults.models legacy runtime keys to canonical provider keys.",
+    );
+    expect(res.changes).toContain(
+      "Moved agents.defaults.modelPolicy.allow legacy runtime refs to canonical provider refs.",
+    );
+  });
+
   it("preserves legacy whole-agent Claude CLI intent for canonical Anthropic defaults", () => {
     const res = normalizeCompatibilityConfigValues(
       legacyConfig({

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -1525,6 +1525,28 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
+  it("preserves runtime policy for allowlist-only legacy refs", () => {
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-7" },
+            modelPolicy: { allow: ["claude-cli/claude-sonnet-4-6"] },
+          },
+        },
+      }),
+    );
+
+    expect(res.config.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": {
+        agentRuntime: { id: "claude-cli" },
+      },
+    });
+    expect(res.config.agents?.defaults?.modelPolicy).toEqual({
+      allow: ["anthropic/claude-sonnet-4-6"],
+    });
+  });
+
   it("preserves selected legacy keys outside the migrated allowlist runtime", () => {
     const res = normalizeCompatibilityConfigValues(
       legacyConfig({

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -266,6 +266,15 @@ function resolveLegacyWholeAgentRuntimePolicy(raw: unknown):
     : undefined;
 }
 
+function migrateUnblockedLegacyRuntimeModelRef(
+  modelRef: string,
+  blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>,
+) {
+  return isBlockedLegacyCodexModelRef({ modelRef, blockedModelIdentities })
+    ? null
+    : migrateLegacyRuntimeModelRef(modelRef);
+}
+
 function migratedRuntimeRequiresPolicy(legacyProvider: string): boolean {
   return legacyRuntimeModelAliasRequiresRuntimePolicy(legacyProvider);
 }
@@ -304,9 +313,7 @@ function normalizeLegacyRuntimeAgentModelConfig(
   selectedRefs: SelectedRuntimeRef[];
 } {
   if (typeof raw === "string") {
-    const migrated = isBlockedLegacyCodexModelRef({ modelRef: raw, blockedModelIdentities })
-      ? null
-      : migrateLegacyRuntimeModelRef(raw);
+    const migrated = migrateUnblockedLegacyRuntimeModelRef(raw, blockedModelIdentities);
     return migrated
       ? {
           value: migrated.ref,
@@ -328,9 +335,8 @@ function normalizeLegacyRuntimeAgentModelConfig(
   }
 
   const migratedPrimary =
-    typeof raw.primary === "string" &&
-    !isBlockedLegacyCodexModelRef({ modelRef: raw.primary, blockedModelIdentities })
-      ? migrateLegacyRuntimeModelRef(raw.primary)
+    typeof raw.primary === "string"
+      ? migrateUnblockedLegacyRuntimeModelRef(raw.primary, blockedModelIdentities)
       : null;
   let changed = false;
   const next: Record<string, unknown> = { ...raw };
@@ -352,12 +358,10 @@ function normalizeLegacyRuntimeAgentModelConfig(
       if (typeof fallback !== "string") {
         return fallback;
       }
-      const migratedFallback = isBlockedLegacyCodexModelRef({
-        modelRef: fallback,
+      const migratedFallback = migrateUnblockedLegacyRuntimeModelRef(
+        fallback,
         blockedModelIdentities,
-      })
-        ? null
-        : migrateLegacyRuntimeModelRef(fallback);
+      );
       if (
         migratedFallback &&
         (migratedFallback.runtime === selectedRuntime ||
@@ -429,12 +433,7 @@ function normalizeLegacyRuntimeAllowlistModels(
     requiresRuntimePolicy: boolean;
   }> = [];
   for (const [rawKey, entry] of Object.entries(rawModels)) {
-    const migrated = isBlockedLegacyCodexModelRef({
-      modelRef: rawKey,
-      blockedModelIdentities,
-    })
-      ? null
-      : migrateLegacyRuntimeModelRef(rawKey);
+    const migrated = migrateUnblockedLegacyRuntimeModelRef(rawKey, blockedModelIdentities);
     if (
       migrated &&
       (migrated.runtime === selectedRuntime ||
@@ -442,6 +441,8 @@ function normalizeLegacyRuntimeAllowlistModels(
         policyRuntimes.has(migrated.runtime))
     ) {
       changed = true;
+      // Legacy keys only feed the implicit allowlist; once an explicit allowlist
+      // names this runtime, the canonical key replaces them outright.
       if (!policyRuntimes.has(migrated.runtime)) {
         next[rawKey] = mergeModelEntry(entry, next[rawKey]);
       }
@@ -484,12 +485,7 @@ function normalizeLegacyRuntimeModelPolicy(
     if (typeof entry !== "string") {
       return entry;
     }
-    const migrated = isBlockedLegacyCodexModelRef({
-      modelRef: entry,
-      blockedModelIdentities,
-    })
-      ? null
-      : migrateLegacyRuntimeModelRef(entry);
+    const migrated = migrateUnblockedLegacyRuntimeModelRef(entry, blockedModelIdentities);
     if (!migrated) {
       return entry;
     }

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -469,12 +469,17 @@ function normalizeLegacyRuntimeAllowlistModels(
 function normalizeLegacyRuntimeModelPolicy(
   rawPolicy: unknown,
   blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>,
-): { value?: unknown; runtimes: ReadonlySet<string> } {
+): {
+  value?: unknown;
+  runtimes: ReadonlySet<string>;
+  selectedRefs: readonly SelectedRuntimeRef[];
+} {
   if (!isRecord(rawPolicy) || !Array.isArray(rawPolicy.allow)) {
-    return { value: rawPolicy, runtimes: new Set() };
+    return { value: rawPolicy, runtimes: new Set(), selectedRefs: [] };
   }
 
   const runtimes = new Set<string>();
+  const selectedRefs: SelectedRuntimeRef[] = [];
   const allow = rawPolicy.allow.map((entry) => {
     if (typeof entry !== "string") {
       return entry;
@@ -489,10 +494,19 @@ function normalizeLegacyRuntimeModelPolicy(
       return entry;
     }
     runtimes.add(migrated.runtime);
+    selectedRefs.push({
+      ref: migrated.ref,
+      runtime: migrated.runtime,
+      requiresRuntimePolicy: migratedRuntimeRequiresPolicy(migrated.legacyProvider),
+    });
     return migrated.ref;
   });
 
-  return { value: runtimes.size > 0 ? { ...rawPolicy, allow } : rawPolicy, runtimes };
+  return {
+    value: runtimes.size > 0 ? { ...rawPolicy, allow } : rawPolicy,
+    runtimes,
+    selectedRefs,
+  };
 }
 
 function ensureSelectedModelRuntimePolicies(
@@ -580,6 +594,13 @@ function normalizeLegacyRuntimeAgentContainer(
     next.models = models.value;
     changed = true;
     changes.push(`Moved ${path}.models legacy runtime keys to canonical provider keys.`);
+  }
+
+  const policyRuntimes = ensureSelectedModelRuntimePolicies(next.models, modelPolicy.selectedRefs);
+  if (policyRuntimes.changed) {
+    next.models = policyRuntimes.value;
+    changed = true;
+    changes.push(`Preserved runtime policy for ${path}.modelPolicy.allow entries.`);
   }
 
   if (model.selectedRuntime) {

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -410,6 +410,7 @@ function normalizeLegacyRuntimeAllowlistModels(
   rawModels: unknown,
   selectedRuntime: string | undefined,
   selectedRuntimeRequiresPolicy: boolean,
+  policyRuntimes: ReadonlySet<string>,
   blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>,
 ): {
   value?: unknown;
@@ -437,10 +438,13 @@ function normalizeLegacyRuntimeAllowlistModels(
     if (
       migrated &&
       (migrated.runtime === selectedRuntime ||
-        migrated.legacyProvider === LEGACY_CODEX_CLI_RUNTIME_ID)
+        migrated.legacyProvider === LEGACY_CODEX_CLI_RUNTIME_ID ||
+        policyRuntimes.has(migrated.runtime))
     ) {
       changed = true;
-      next[rawKey] = mergeModelEntry(entry, next[rawKey]);
+      if (policyRuntimes.size === 0) {
+        next[rawKey] = mergeModelEntry(entry, next[rawKey]);
+      }
       legacyEntries.push({
         migratedKey: migrated.ref,
         entry,
@@ -460,6 +464,35 @@ function normalizeLegacyRuntimeAllowlistModels(
     );
   }
   return { value: next, changed };
+}
+
+function normalizeLegacyRuntimeModelPolicy(
+  rawPolicy: unknown,
+  blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>,
+): { value?: unknown; runtimes: ReadonlySet<string> } {
+  if (!isRecord(rawPolicy) || !Array.isArray(rawPolicy.allow)) {
+    return { value: rawPolicy, runtimes: new Set() };
+  }
+
+  const runtimes = new Set<string>();
+  const allow = rawPolicy.allow.map((entry) => {
+    if (typeof entry !== "string") {
+      return entry;
+    }
+    const migrated = isBlockedLegacyCodexModelRef({
+      modelRef: entry,
+      blockedModelIdentities,
+    })
+      ? null
+      : migrateLegacyRuntimeModelRef(entry);
+    if (!migrated) {
+      return entry;
+    }
+    runtimes.add(migrated.runtime);
+    return migrated.ref;
+  });
+
+  return { value: runtimes.size > 0 ? { ...rawPolicy, allow } : rawPolicy, runtimes };
 }
 
 function ensureSelectedModelRuntimePolicies(
@@ -535,10 +568,12 @@ function normalizeLegacyRuntimeAgentContainer(
     );
   }
 
+  const modelPolicy = normalizeLegacyRuntimeModelPolicy(raw.modelPolicy, blockedModelIdentities);
   const models = normalizeLegacyRuntimeAllowlistModels(
     raw.models,
     model.selectedRuntime,
     model.selectedRuntimeRequiresPolicy,
+    modelPolicy.runtimes,
     blockedModelIdentities,
   );
   if (models.changed) {
@@ -573,6 +608,12 @@ function normalizeLegacyRuntimeAgentContainer(
         `Moved ${path}.agentRuntime.id ${legacyWholeAgentRuntime.runtime} to matching ${legacyWholeAgentRuntime.provider} model runtime policy.`,
       );
     }
+  }
+
+  if (modelPolicy.runtimes.size > 0) {
+    next.modelPolicy = modelPolicy.value;
+    changed = true;
+    changes.push(`Moved ${path}.modelPolicy.allow legacy runtime refs to canonical provider refs.`);
   }
 
   const codexCliRuntimePins = normalizeLegacyCodexCliRuntimePinsInModels(

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -442,7 +442,7 @@ function normalizeLegacyRuntimeAllowlistModels(
         policyRuntimes.has(migrated.runtime))
     ) {
       changed = true;
-      if (policyRuntimes.size === 0) {
+      if (!policyRuntimes.has(migrated.runtime)) {
         next[rawKey] = mergeModelEntry(entry, next[rawKey]);
       }
       legacyEntries.push({


### PR DESCRIPTION
Closes #124952

AI-assisted: Yes — implemented and validated with Codex.

## What Problem This Solves

Fixes an upgrade failure where legacy Claude CLI allowlist and model-map refs remain provider-encoded after the primary model is already canonical. Doctor now repairs those refs without deleting selected legacy entries belonging to a different runtime.

## Why This Change Was Made

Doctor canonicalizes explicit legacy `modelPolicy.allow` refs and uses each migrated policy runtime as the signal for migrating matching model-map keys. Cleanup is scoped per runtime: migrating Claude CLI policy cannot suppress a selected Google Gemini CLI legacy key.

## User Impact

Running `openclaw doctor --fix` repairs affected Claude CLI configurations to canonical `anthropic/*` refs while retaining `agentRuntime.id: "claude-cli"`, aliases, and unrelated runtime selections.

## Evidence

### Claim

The production Doctor command rewrites legacy Claude CLI allowlist and model-map refs to canonical Anthropic refs, persists the Claude CLI runtime owner, and does not globally discard selected legacy keys for other runtimes.

### Exercised surface and scenario

The actual built Doctor CLI, production config loader, migration, validator, backup, and writer were exercised against an isolated config and state directory. The fixture used a canonical Anthropic primary plus two legacy `claude-cli/*` model-map keys and matching `modelPolicy.allow` entries. No credentials or user configuration were used.

### Exact command and environment

```bash
OPENCLAW_STATE_DIR="$PWD/.artifacts/pr-126866-live-state" \
OPENCLAW_CONFIG_PATH="$PWD/.artifacts/pr-126866-live-config.json" \
node scripts/run-node.mjs doctor --fix --non-interactive --yes
```

Environment: Linux workspace checkout at this PR head; Node/pnpm versions from the repository toolchain; isolated JSON config and state under `.artifacts/`.

### Observable trace

Before:

```json
{
  "primary": "anthropic/claude-opus-4-7",
  "models": {
    "claude-cli/claude-opus-4-7": { "alias": "Opus" },
    "claude-cli/claude-sonnet-4-6": {}
  },
  "allow": [
    "claude-cli/claude-opus-4-7",
    "claude-cli/claude-sonnet-4-6"
  ]
}
```

After the command completed and wrote a backup:

```json
{
  "primary": "anthropic/claude-opus-4-7",
  "models": {
    "anthropic/claude-opus-4-7": {
      "alias": "Opus",
      "agentRuntime": { "id": "claude-cli" }
    },
    "anthropic/claude-sonnet-4-6": {
      "agentRuntime": { "id": "claude-cli" }
    }
  },
  "allow": [
    "anthropic/claude-opus-4-7",
    "anthropic/claude-sonnet-4-6"
  ]
}
```

The mixed-runtime regression fixture additionally proves that a selected `google-gemini-cli/gemini-3-pro-preview` key remains present when only the Claude allowlist runtime is migrated.

### Durable artifacts

- `src/commands/doctor-legacy-config.migrations.test.ts` contains the canonical-primary migration coverage and the mixed-runtime preservation regression.
- `src/commands/doctor/shared/legacy-config-core-normalizers.ts` scopes cleanup with `policyRuntimes.has(migrated.runtime)`.
- The trace above records the production command's persisted before/after result; the isolated run also created the expected `.bak` backup.

### Limits

This proof exercises the claimed persisted Doctor migration behavior, not a live Claude provider call. It intentionally uses an isolated config with no credentials and does not modify a user's OpenClaw state.

## Validation

- Focused and neighboring suites: 119 tests passed across the Doctor migration, runtime-model migration, and model-visibility policy suites.
- `pnpm check:changed`: passed the repository's formatting, policy, typecheck, lint, native-schema, database-first, runtime-loader, import-cycle, and safety guards.
- Fresh structured autoreview: TruffleHog clean, no accepted or actionable finding, overall correctness score 0.98.
- `git diff --check`: clean.
- PR head for this validation: `e2561b921f0d34c460b2e8e98ae952508ce03995` (superseded by the maintainer repair head below).

## Review Notes

- `risks`: upgrade-sensitive configuration migration; the cleanup is now constrained to the runtime actually represented in migrated policy entries.
- `bestSolution`: repair retired runtime-encoded refs in Doctor before runtime selection; no runtime alias fallback, provider shim, or new option is introduced.
- `labelJustifications`: `P1` and compatibility/auth-provider risk remain appropriate because broken persisted policy can make configured models unavailable after upgrade.


## Follow-up Repair: Allowlist-Only Runtime Ownership

ClawSweeper identified that a migrated legacy allowlist entry could lose its runtime owner when the configuration had no matching model-map entry. The cache-independent migration owner now carries each migrated allowlist reference into the existing runtime-policy seeding path.

### Exact-head production proof

At exact head `e2561b921f0d34c460b2e8e98ae952508ce03995`, the real isolated Doctor command was run against:

```json
{
  "agents": {
    "defaults": {
      "model": { "primary": "anthropic/claude-opus-4-7" },
      "modelPolicy": { "allow": ["claude-cli/claude-sonnet-4-6"] }
    }
  }
}
```

The persisted result was:

```json
{
  "model": { "primary": "anthropic/claude-opus-4-7" },
  "modelPolicy": { "allow": ["anthropic/claude-sonnet-4-6"] },
  "models": {
    "anthropic/claude-sonnet-4-6": {
      "agentRuntime": { "id": "claude-cli" }
    }
  }
}
```

The production command reported both the canonical allowlist migration and preserved runtime policy. This is the previously missing allowlist-only shape and uses isolated temporary configuration/state with no credentials or user state.

### Follow-up validation

- Doctor migration suite: 80/80 passed.
- `node scripts/check-changed.mjs -- <two changed paths>`: all selected formatting, policy, dead-code, typecheck, lint, schema, database, sidecar-loader, and import-cycle gates passed.
- Fresh structured autoreview: TruffleHog clean; no P0/P1 findings; correctness 0.96.
- Production delta for the follow-up: +21 net lines; regression test: +22 net lines. The production growth carries the selected runtime reference across the existing normalization owner and adds no runtime fallback or public configuration surface.
- `git diff --check`: clean.



## Maintainer Repair (head `2f1d270f19a492706da0ad3cdc27fdcc4ff0f05d`)

Maintainer-side review and repair by @obviyus on the author's branch; author intent preserved, no behavior change to the migration.

### Root cause (confirmed on `main` 672ac118c34)

`normalizeLegacyRuntimeAgentContainer` (`src/commands/doctor/shared/legacy-config-core-normalizers.ts`) migrated `model.primary`/`fallbacks` and selected-runtime model-map keys but never touched `modelPolicy.allow`. The allowlist seeding spec (`agents.defaults.models->agents.defaults.modelPolicy.allow`, `legacy-config-migrations.runtime.models.refs.ts`) copies the legacy `claude-cli/*` map keys into an explicit allowlist, and `isModelKeyAllowedBySet` (`src/agents/model-selection-shared.ts`) matches exactly, so after the primary went canonical the canonical `anthropic/*` refs were rejected by the allowlist while the legacy refs failed the harness-runtime guard (`src/agents/harness/runtime-plugin.ts`). Doctor reported nothing to fix.

### Fix (author's, verified)

Canonicalize `modelPolicy.allow` in the same normalizer, carry each migrated allow ref into the existing runtime-policy seeding, and let the explicit allowlist's runtimes gate model-map key migration. Retention asymmetry is intentional and now commented in code: legacy model-map keys only feed the *implicit* allowlist, so they stay for selected-runtime-only configs (`main` behavior from 9e5d0380b0) and are dropped once an explicit allowlist names that runtime. Spec migrations run before the normalizer in `doctor-config-flow.ts` (legacy step line 243, normalizer line 378), so a seeded legacy allowlist canonicalizes in one `doctor --fix` run.

### Changes in the repair commit

- `migrateUnblockedLegacyRuntimeModelRef` absorbs the five identical `isBlockedLegacyCodexModelRef ? null : migrateLegacyRuntimeModelRef` sites (three pre-existing, two added by this PR); production delta for the repair commit is −5 net.
- Inline comment on the legacy-key retention invariant.
- Regression test `canonicalizes a seeded legacy Claude CLI allowlist in one doctor pass`: `applyLegacyDoctorMigrations` → `normalizeCompatibilityConfigValues` on an unmarked legacy model map with a canonical primary; asserts canonical allowlist, canonical model-map keys with `agentRuntime.id: "claude-cli"`, and a no-op second pass.

### Proof

- Pre-fix failure: with `legacy-config-core-normalizers.ts` swapped to merge-base `7c959c85f91`, all four allowlist tests fail (`4 failed | 77 skipped`); with the PR's normalizer, all pass.
- `git diff --check`: clean. `node scripts/run-oxlint.mjs` on both touched files: exit 0. `pnpm tsgo`: exit 0. `pnpm check:test-types`: exit 0.
- `pnpm test src/commands/doctor` (fresh `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH`): 28 files / 549 tests, 6 files / 224 tests, 35 files / 499 tests — all passed.
- Whole-PR production delta vs merge base: `legacy-config-core-normalizers.ts` +77/−19; tests +127/−0; docs +5/−3.
- ClawSweeper local review (`gpt-5.6-terra`, high) on exact head `2f1d270f`: patch is correct, 0 findings, security cleared, no maintainer decision, 0 Rank-up moves.
- Exact-head CI: `openclaw/ci-gate` SUCCESS (run 32616893294).
- Telegram E2E (`$telegram-e2e-userbot`, real QA user → real SUT bot DM, mock provider, isolated temp state) on exact head `2f1d270f`, seeded with legacy `claude-cli/*` model-map keys and allowlist, then `pnpm openclaw doctor --fix --non-interactive --yes` before the turn:
  - Doctor changed `agents.defaults.modelPolicy.allow` `["openai/gpt-5.5","claude-cli/claude-sonnet-5","claude-cli/claude-opus-5"]` → `["openai/gpt-5.5","anthropic/claude-sonnet-5","anthropic/claude-opus-5"]`, added `models.anthropic/claude-{sonnet,opus}-5` with `agentRuntime.id: "claude-cli"`, removed the `claude-cli/*` rows, stamped `meta.migrations.modelPolicyAllowlist`.
  - Canonical drive: `sessions_spawn` with `model: "anthropic/claude-sonnet-5"` → `status: accepted`, `resolvedModel: anthropic/claude-sonnet-5`; Telegram timeline: user msg → SUT draft → `SPAWN_MODEL_ACCEPTED` → child reply `SPAWN_MODEL_CHILD_COMPLETED` → draft deleted. On `main` (672ac118c34) the same drive ended `SPAWN_MODEL_REJECTED` (`model not allowed: anthropic/claude-sonnet-5`).
  - Legacy drive: `model: "claude-cli/claude-sonnet-5"` after migration → `SPAWN_MODEL_REJECTED` (not in the canonical allowlist), the intended cutover; `main` accepted it and the child died silently.
