### PR TITLE
fix(plugins): refresh WhatsApp runtime after plugin replacement

### DIFF
--- a/src/plugins/runtime/runtime-web-channel-plugin.test.ts
+++ b/src/plugins/runtime/runtime-web-channel-plugin.test.ts
@@ -1,7 +1,13 @@
 // Runtime web-channel plugin tests cover web channel plugin activation and runtime behavior.
+import fs from "node:fs";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+
+const tempDirs = createTempDirTracker();
 
 afterEach(() => {
+  tempDirs.cleanup();
   vi.doUnmock("./runtime-plugin-boundary.js");
   vi.resetModules();
 });
@@ -50,6 +56,57 @@ describe("runtime web channel plugin", () => {
     await expect(runtime.startWebLoginWithQr()).resolves.toBe("started");
     expect(resolvePluginRuntimeRecordByEntryBaseNames).toHaveBeenCalledOnce();
   });
+
+  it.each(["light", "heavy"] as const)(
+    "reloads replaced %s runtime artifacts and dependencies after plugin lifecycle clears",
+    async (kind) => {
+      const pluginRoot = fs.realpathSync(tempDirs.make("openclaw-web-runtime-replacement-"));
+      const modulePath = path.join(
+        pluginRoot,
+        kind === "light" ? "light-runtime-api.js" : "runtime-api.js",
+      );
+      const dependencyPath = path.join(pluginRoot, "dependency.js");
+      fs.writeFileSync(path.join(pluginRoot, "package.json"), '{"type":"commonjs"}\n', "utf8");
+
+      const writeRuntime = (marker: string) => {
+        fs.writeFileSync(dependencyPath, `module.exports = ${JSON.stringify(marker)};\n`, "utf8");
+        const exportName = kind === "light" ? "resolveDefaultWebAuthDir" : "startWebLoginWithQr";
+        fs.writeFileSync(
+          modulePath,
+          `module.exports = { ${exportName}: () => ${JSON.stringify(marker)} + ":" + require("./dependency.js") };\n`,
+          "utf8",
+        );
+      };
+      writeRuntime("retired");
+
+      vi.doMock("./runtime-plugin-boundary.js", async (importOriginal) => ({
+        ...(await importOriginal<typeof import("./runtime-plugin-boundary.js")>()),
+        resolvePluginRuntimeRecordByEntryBaseNames: () => ({
+          origin: "global",
+          rootDir: pluginRoot,
+          source: path.join(pluginRoot, "index.js"),
+        }),
+        resolvePluginRuntimeModulePath: () => modulePath,
+      }));
+
+      const runtime = await import("./runtime-web-channel-plugin.js");
+      const { clearPluginMetadataLifecycleCaches } =
+        await import("../plugin-metadata-lifecycle.js");
+      const invoke = () =>
+        kind === "light"
+          ? Promise.resolve(runtime.resolveWebChannelAuthDir())
+          : runtime.startWebLoginWithQr();
+
+      await expect(invoke()).resolves.toBe("retired:retired");
+      writeRuntime("replacement");
+      await expect(invoke()).resolves.toBe("retired:retired");
+
+      clearPluginMetadataLifecycleCaches();
+
+      await expect(invoke()).resolves.toBe("replacement:replacement");
+      await expect(invoke()).resolves.toBe("replacement:replacement");
+    },
+  );
 
   it("reports heavy runtime load failures as promise rejections", async () => {
     vi.doMock("./runtime-plugin-boundary.js", () => ({

--- a/src/plugins/runtime/runtime-web-channel-plugin.ts
+++ b/src/plugins/runtime/runtime-web-channel-plugin.ts
@@ -1,7 +1,9 @@
 // Runtime web-channel plugin helpers expose web-channel tools through activated plugin runtimes.
+import path from "node:path";
 import { getDefaultLocalRootsCore } from "../../media/web-media.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "../plugin-metadata-lifecycle.js";
 import {
+  clearPluginModuleLoaderLifecycleCache,
   createPluginModuleLoaderCache,
   type PluginModuleLoaderCache,
 } from "../plugin-module-loader-cache.js";
@@ -64,10 +66,11 @@ const webChannelRuntimeModuleCache = new Map<
 >();
 
 const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
+const moduleRoots = new Map<string, string>();
 
 registerPluginMetadataProcessMemoLifecycleClear(() => {
   webChannelRuntimeModuleCache.clear();
-  moduleLoaders.clear();
+  clearPluginModuleLoaderLifecycleCache({ moduleLoaders, moduleRoots });
 });
 
 /** Resolves the active web-channel plugin record that provides runtime APIs. */
@@ -89,6 +92,7 @@ function resolveWebChannelRuntimeModulePath(
   if (!modulePath) {
     throw new Error(`web channel plugin runtime is unavailable: missing ${entryBaseName}`);
   }
+  moduleRoots.set(modulePath, record.rootDir ?? path.dirname(record.source));
   return modulePath;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators replacing or reinstalling a WhatsApp plugin could continue running the retired light or heavy runtime even after the plugin lifecycle was explicitly reset. Authentication-directory lookups, QR login, and channel monitoring could keep using the old runtime and its old dependencies.

Related: #126719

## Why This Change Was Made

The web-runtime owner cleared its prepared module and loader caches but did not clear Node's separate native module cache. Track each loaded artifact under its manifest-owned plugin root and reuse the existing lifecycle helper that evicts native artifacts and only their in-root dependency subtree. This preserves bundled-dist handling, successful process-stable caching, trust boundaries, and the existing plugin-install lifecycle without changing public APIs or configuration.

## User Impact

After an explicit plugin install, replacement, or reload, both WhatsApp runtime surfaces immediately use the replacement artifact and its replacement dependencies instead of silently continuing to execute retired code.

## Evidence

- Regression-first proof generated actual CommonJS plugin artifacts and dependency files on disk, replaced them, invoked the real runtime boundary and Node native loader, and cleared the real plugin metadata lifecycle. Both light and heavy cases failed before the fix (`retired:retired` instead of `replacement:replacement`) and pass afterward; successful cache reuse remains covered.
- Focused owner and sibling coverage: **72 passing tests across seven files and three Vitest lanes**, including runtime loading, native module eviction, public artifacts, config-scoped promises, official catalog recovery, and document/web extractors.
- Focused post-format owner suite: **7 passing tests**.
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 node scripts/run-vitest.mjs src/plugins/runtime/runtime-web-channel-plugin.test.ts src/plugins/plugin-module-loader-cache.test.ts src/plugins/public-surface-loader.test.ts src/plugins/plugin-cache-primitives.test.ts src/plugins/management-service.lifecycle-cache.test.ts src/media/document-extractors.runtime.test.ts src/web-fetch/content-extractors.runtime.test.ts --configLoader runner`
- `node --import tsx scripts/check-assertion-safety-ratchet.mts`
- `node --import tsx scripts/check-max-lines-ratchet.mts`
- Focused formatting, direct lint, an authenticated full-branch Codex review, and an independent root-containment/security review are clean.
- Production delta: **+5/-1 (net +4)**, required to retain exact plugin-root ownership for existing native-cache lifecycle eviction; tests: **+57**. No broad require-cache purge, public SDK change, security-policy change, configuration change, or schema change.
- No authenticated live WhatsApp session was used; replacement was proven through real on-disk plugin artifacts, the actual runtime loader, and Node's native require cache.
