### PR TITLE
fix(ui): recover failed new-session navigation without duplicate tasks

### DIFF
--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -13,6 +13,7 @@ import { DraftGatewayState } from "./draft-gateway-state.ts";
 import { DraftPlaceBrowser } from "./draft-place-browser.ts";
 import { DraftPlaceState } from "./draft-place-state.ts";
 import { DraftSubmissionFlow } from "./draft-submission-flow.ts";
+import type { NewSessionRouteData } from "./location.ts";
 import { patchNewSessionPreference } from "./preferences.ts";
 
 // The closed list of gates allowed to block without a visible reason: the busy
@@ -39,6 +40,7 @@ type FixtureOptions = {
   methods?: string[];
   scopes?: string[];
   selfUser?: { id: string };
+  data?: NewSessionRouteData;
   request?: (method: string) => Promise<unknown>;
 };
 
@@ -57,6 +59,7 @@ function createDraftFixture(options: FixtureOptions = {}) {
       snapshot: {
         phase,
         client: phase === "connected" ? client : null,
+        sessionKey: "",
         ...(options.selfUser ? { selfUser: options.selfUser } : {}),
         hello:
           phase === "connected"
@@ -69,6 +72,7 @@ function createDraftFixture(options: FixtureOptions = {}) {
               }
             : null,
       },
+      setSessionKey: vi.fn(),
     },
     agents: {
       state: {
@@ -86,14 +90,20 @@ function createDraftFixture(options: FixtureOptions = {}) {
       },
     },
     sessions: { state: { result: null }, createResult: vi.fn() },
-    config: { current: {} },
+    agentSelection: { state: { selectedId: "main" }, set: vi.fn() },
+    config: { current: { cliAgentsEnabled: true, terminalEnabled: true } },
+    navigateAndWait: vi.fn(async () => undefined),
+    preload: vi.fn(async () => undefined),
   } as unknown as ApplicationContext;
+  vi.mocked(context.gateway.setSessionKey).mockImplementation((sessionKey) => {
+    context.gateway.snapshot.sessionKey = sessionKey;
+  });
   const host = new ControllerHost();
   const gateway = new DraftGatewayState(
     host,
     () => ({
       context,
-      data: undefined,
+      data: options.data,
       isConnected: phase === "connected",
       isAdmin: place?.isAdmin() ?? false,
       canStartAsDraft: flow?.canStartAsDraft() ?? false,
@@ -141,7 +151,7 @@ function createDraftFixture(options: FixtureOptions = {}) {
     browser,
     () => ({
       context,
-      data: undefined,
+      data: options.data,
       submitting: flow?.submitting ?? false,
       pendingPlacementSessionKey: flow?.pendingPlacement.sessionKey ?? "",
     }),
@@ -155,7 +165,7 @@ function createDraftFixture(options: FixtureOptions = {}) {
   const flow = new DraftSubmissionFlow(
     gateway,
     place,
-    () => ({ context, data: undefined, isConnected: phase === "connected" }),
+    () => ({ context, data: options.data, isConnected: phase === "connected" }),
     { requestUpdate, closeTransientUi: vi.fn() },
   );
   gateway.synchronize(context.gateway);
@@ -350,6 +360,151 @@ describe("DraftSubmissionFlow submit gates", () => {
 });
 
 describe("DraftSubmissionFlow", () => {
+  it("surfaces navigation failure after a session has already been created", async () => {
+    const { context, flow } = createDraftFixture();
+    vi.mocked(context.sessions.createResult).mockResolvedValue({
+      key: "agent:main:dashboard:created",
+      initialRun: { status: "idle" },
+    });
+    vi.mocked(context.navigateAndWait)
+      .mockRejectedValueOnce(new Error("Chat route failed to load"))
+      .mockImplementationOnce(async () => {
+        queueMicrotask(() => document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT)));
+      });
+    flow.setMessage("start this task");
+
+    await flow.submit();
+
+    expect(context.sessions.createResult).toHaveBeenCalledOnce();
+    expect(context.navigateAndWait).toHaveBeenCalledOnce();
+    expect(flow.error).toBe("Chat route failed to load");
+    expect(flow.submitting).toBe(false);
+
+    const readSignal = flow.attachmentDraft.readSignal;
+    flow.attachmentDraft.updatePending(readSignal, 1);
+    expect(flow.submitBlock()?.gate).toBe("attachment-reads");
+    expect(flow.canSubmit()).toBe(false);
+    await flow.submit();
+    expect(context.sessions.createResult).toHaveBeenCalledOnce();
+    expect(context.navigateAndWait).toHaveBeenCalledOnce();
+    flow.attachmentDraft.updatePending(readSignal, -1);
+
+    expect(flow.canSubmit()).toBe(true);
+    await flow.submit();
+
+    expect(context.navigateAndWait).toHaveBeenCalledTimes(2);
+    expect(context.sessions.createResult).toHaveBeenCalledOnce();
+    expect(flow.error).toBeNull();
+  });
+
+  it.each([
+    {
+      scenario: "the user edits the draft",
+      retire: ({ flow }: ReturnType<typeof createDraftFixture>) => flow.setMessage("a new task"),
+    },
+    {
+      scenario: "the Gateway lifecycle is invalidated",
+      retire: ({ flow }: ReturnType<typeof createDraftFixture>) => flow.invalidate(),
+    },
+    {
+      scenario: "the draft attachments change",
+      retire: ({ flow }: ReturnType<typeof createDraftFixture>) => flow.attachmentDraft.replace([]),
+    },
+    {
+      scenario: "the requested session visibility changes",
+      retire: ({ flow }: ReturnType<typeof createDraftFixture>) => flow.setVisibility("draft"),
+    },
+    {
+      scenario: "another session becomes selected",
+      retire: ({ context }: ReturnType<typeof createDraftFixture>) => {
+        context.gateway.snapshot.sessionKey = "agent:main:dashboard:elsewhere";
+      },
+    },
+    {
+      scenario: "the selected agent changes",
+      retire: ({ place }: ReturnType<typeof createDraftFixture>) => place.selectAgentId("other"),
+    },
+    {
+      scenario: "the Gateway client changes",
+      retire: ({ context }: ReturnType<typeof createDraftFixture>) => {
+        context.gateway.snapshot.client = {
+          recoveryScope: "replacement-principal",
+          recoveryScopeReady: true,
+          request: vi.fn(async () => ({})),
+        } as NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>;
+      },
+    },
+  ])("never retries a committed session after $scenario", async ({ retire }) => {
+    const fixture = createDraftFixture({
+      agents: [
+        { id: "main", workspace: "/workspace", model: { primary: "openai/test" } },
+        { id: "other", workspace: "/workspace", model: { primary: "openai/test" } },
+      ],
+    });
+    const { context, flow } = fixture;
+    vi.mocked(context.sessions.createResult)
+      .mockResolvedValueOnce({ key: "agent:main:dashboard:old", initialRun: { status: "idle" } })
+      .mockImplementationOnce(async (params) => ({
+        key: `agent:${String(params.agentId)}:dashboard:new`,
+        initialRun: { status: "idle" },
+      }));
+    vi.mocked(context.navigateAndWait)
+      .mockRejectedValueOnce(new Error("old navigation failed"))
+      .mockImplementationOnce(async () => {
+        queueMicrotask(() => document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT)));
+      });
+    flow.setMessage("the committed task");
+    await flow.submit();
+
+    retire(fixture);
+    await flow.submit();
+
+    expect(context.sessions.createResult).toHaveBeenCalledTimes(2);
+    expect(context.gateway.snapshot.sessionKey).toBe(
+      `agent:${fixture.place.agentId}:dashboard:new`,
+    );
+    expect(context.navigateAndWait).toHaveBeenCalledTimes(2);
+  });
+
+  it("retires failed chat navigation after the same draft starts in a terminal", async () => {
+    const fixture = createDraftFixture({
+      scopes: ["operator.admin", "operator.read", "operator.write"],
+      methods: ["sessions.create", "sessions.catalog.startTerminal", "terminal.open"],
+      data: {
+        agentId: "main",
+        requestedAgentId: "main",
+        catalogId: "terminal-agent",
+        model: "openai/test",
+        catalogLabel: "Terminal agent",
+        startTerminal: true,
+      },
+      request: async (method) =>
+        method === "sessions.catalog.startTerminal" ? { sessionId: "terminal-created" } : {},
+    });
+    const { context, flow, request } = fixture;
+    vi.mocked(context.sessions.createResult).mockResolvedValue({
+      key: "agent:main:dashboard:chat-created",
+      initialRun: { status: "idle" },
+    });
+    vi.mocked(context.navigateAndWait).mockRejectedValue(new Error("Chat route failed to load"));
+    flow.setMessage("start this task");
+
+    await flow.submit();
+    expect(flow.error).toBe("Chat route failed to load");
+    expect(flow.showStartInTerminal()).toBe(true);
+
+    await flow.startInTerminal();
+
+    expect(request).toHaveBeenCalledWith(
+      "sessions.catalog.startTerminal",
+      expect.objectContaining({ catalogId: "terminal-agent" }),
+    );
+    expect(flow.message).toBe("");
+    expect(flow.canSubmit()).toBe(false);
+    expect(context.sessions.createResult).toHaveBeenCalledOnce();
+    expect(context.navigateAndWait).toHaveBeenCalledOnce();
+  });
+
   it("makes attachment restore release only displaced payload ids", () => {
     const revokeObjectURL = stubObjectUrls("blob:shared", "blob:displaced", "blob:incoming");
     const { flow, requestUpdate } = createDraftFixture();
@@ -572,7 +727,13 @@ describe("DraftSubmissionFlow", () => {
     expect(context.sessions.createResult).not.toHaveBeenCalled();
   });
 
-  it("keeps startup progress active through the navigation handoff", async () => {
+  it.each([
+    { scenario: "keeps startup progress active through navigation", navigationError: null },
+    {
+      scenario: "surfaces navigation failure after placement startup commits",
+      navigationError: "Placement chat route failed to load",
+    },
+  ])("$scenario", async ({ navigationError }) => {
     const createResult = vi.fn(async (params: Record<string, unknown>) => ({
       key: String(params.key),
       initialRun: { status: "idle" as const },
@@ -584,17 +745,25 @@ describe("DraftSubmissionFlow", () => {
         }),
     );
     let finishNavigation!: () => void;
+    let failedNavigation = false;
     const navigateAndWait = vi.fn(
-      (_routeId: string, _options?: Parameters<ApplicationContext["navigateAndWait"]>[1]) =>
-        new Promise<void>((resolve) => {
+      (_routeId: string, _options?: Parameters<ApplicationContext["navigateAndWait"]>[1]) => {
+        if (navigationError && !failedNavigation) {
+          failedNavigation = true;
+          return Promise.reject(new Error(navigationError));
+        }
+        return new Promise<void>((resolve) => {
           finishNavigation = resolve;
-        }),
+        });
+      },
     );
     const preload = vi.fn(
       async (_routeId: string, _options?: Parameters<ApplicationContext["preload"]>[1]) =>
         undefined,
     );
-    const setSessionKey = vi.fn();
+    const setSessionKey = vi.fn((sessionKey: string) => {
+      context.gateway.snapshot.sessionKey = sessionKey;
+    });
     const selectAgent = vi.fn();
     const client = {
       recoveryScope: "principal-a",
@@ -613,6 +782,7 @@ describe("DraftSubmissionFlow", () => {
         snapshot: {
           phase: "connected",
           client,
+          sessionKey: "",
           hello: {
             auth: {
               role: "operator",
@@ -744,13 +914,15 @@ describe("DraftSubmissionFlow", () => {
     const submission = flow.submit();
     await vi.waitFor(() => expect(navigateAndWait).toHaveBeenCalledOnce());
 
-    expect(flow.submitting).toBe(true);
     expect(preload).toHaveBeenCalledWith("chat", navigateAndWait.mock.calls[0]?.[1]);
     expect(preload.mock.invocationCallOrder[0]).toBeLessThan(
       navigateAndWait.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
-    finishNavigation();
-    document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT));
+    if (!navigationError) {
+      expect(flow.submitting).toBe(true);
+      finishNavigation();
+      document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT));
+    }
     await submission;
 
     expect(start).toHaveBeenCalledOnce();
@@ -761,10 +933,25 @@ describe("DraftSubmissionFlow", () => {
     });
     expect(flow.pendingPlacement.capture()).toBeNull();
     expect(flow.attachmentDraft.attachments).toHaveLength(0);
+    expect(flow.error).toBe(navigationError);
     expect(flow.submitting).toBe(false);
     expect(createResult).toHaveBeenCalledOnce();
     expect(setSessionKey).toHaveBeenCalledWith(start.mock.calls[0]?.[0].recovery.sessionKey);
     expect(selectAgent).toHaveBeenCalledWith("cloud");
     expect(preload).toHaveBeenCalledOnce();
+
+    if (navigationError) {
+      expect(flow.canSubmit()).toBe(true);
+      const retry = flow.submit();
+      await vi.waitFor(() => expect(navigateAndWait).toHaveBeenCalledTimes(2));
+      expect(flow.canSubmit()).toBe(false);
+      finishNavigation();
+      document.dispatchEvent(new Event(CHAT_ROUTE_READY_EVENT));
+      await retry;
+
+      expect(createResult).toHaveBeenCalledOnce();
+      expect(start).toHaveBeenCalledOnce();
+      expect(flow.error).toBeNull();
+    }
   });
 });

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -427,11 +427,10 @@ describe("DraftSubmissionFlow", () => {
     {
       scenario: "the Gateway client changes",
       retire: ({ context }: ReturnType<typeof createDraftFixture>) => {
-        context.gateway.snapshot.client = {
-          recoveryScope: "replacement-principal",
-          recoveryScopeReady: true,
-          request: vi.fn(async () => ({})),
-        } as NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>;
+        const client = context.gateway.snapshot.client;
+        if (client) {
+          context.gateway.snapshot.client = new Proxy(client, {});
+        }
       },
     },
   ])("never retries a committed session after $scenario", async ({ retire }) => {
@@ -445,7 +444,7 @@ describe("DraftSubmissionFlow", () => {
     vi.mocked(context.sessions.createResult)
       .mockResolvedValueOnce({ key: "agent:main:dashboard:old", initialRun: { status: "idle" } })
       .mockImplementationOnce(async (params) => ({
-        key: `agent:${String(params.agentId)}:dashboard:new`,
+        key: `agent:${params?.agentId ?? fixture.place.agentId}:dashboard:new`,
         initialRun: { status: "idle" },
       }));
     vi.mocked(context.navigateAndWait)

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -1,5 +1,4 @@
 import type { ProjectsAddResult } from "../../../../packages/gateway-protocol/src/index.js";
-import { selectApplicationSession } from "../../app/agent-selection.ts";
 import { t } from "../../i18n/index.ts";
 import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
 import {
@@ -7,7 +6,6 @@ import {
   type SessionMethodAccess,
 } from "../../lib/session-method-access.ts";
 import { openTerminalSessionInTerminal } from "../../lib/sessions/catalog-terminal.ts";
-import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import type { SessionPlacementRecovery } from "../../lib/sessions/session-placement-recovery.ts";
 import {
@@ -43,7 +41,7 @@ import {
   PendingSessionPlacementRecoveryState,
   type SubmissionOutcomeReason,
 } from "./session-placement-recovery-state.ts";
-import { navigateToStartedSession } from "./started-session-navigation.ts";
+import { StartedSessionNavigation } from "./started-session-navigation.ts";
 import {
   PAGE_RENDERED_GATES,
   resolveNewSessionSubmitBlock,
@@ -57,6 +55,7 @@ export class DraftSubmissionFlow {
   private submittingValue = false;
   private blockedSubmitGate: string | null = null;
   private submissionOutcomeUnknownValue: SubmissionOutcomeReason | null = null;
+  private readonly startedSession = new StartedSessionNavigation();
   error: string | null = null;
   private submitRequestToken = 0;
   readonly pendingPlacement = new PendingSessionPlacementRecoveryState();
@@ -88,9 +87,10 @@ export class DraftSubmissionFlow {
         this.callbacks.requestUpdate();
       },
     );
-    this.attachmentDraft = new NewSessionAttachmentDraft(callbacks.requestUpdate, () =>
-      this.draftPersistence.noteUserMutation(),
-    );
+    this.attachmentDraft = new NewSessionAttachmentDraft(callbacks.requestUpdate, () => {
+      this.startedSession.current = null;
+      this.draftPersistence.noteUserMutation();
+    });
   }
 
   get visibility(): NewSessionVisibility {
@@ -110,6 +110,7 @@ export class DraftSubmissionFlow {
   }
 
   setMessage(message: string) {
+    this.startedSession.current = null;
     this.messageValue = message;
     this.draftPersistence.noteUserMutation();
     this.callbacks.requestUpdate();
@@ -133,6 +134,7 @@ export class DraftSubmissionFlow {
   }
 
   setVisibility(visibility: NewSessionVisibility) {
+    this.startedSession.current = null;
     const wasIncognito = this.visibilityValue === "incognito";
     const publish = this.callbacks.requestUpdate;
     this.visibilityValue = visibility;
@@ -292,6 +294,13 @@ export class DraftSubmissionFlow {
 
   /** Single owner for submit state, tooltips, and blocked-Enter notices. */
   submitBlock(kind: "session" | "terminal" = "session"): NewSessionSubmitBlock | undefined {
+    if (
+      kind === "session" &&
+      this.attachmentDraft.pendingReads === 0 &&
+      this.startedSession.isCurrent(this.read().context, this.place.agentId)
+    ) {
+      return this.submittingValue ? { gate: "submitting" } : undefined;
+    }
     return resolveNewSessionSubmitBlock(
       {
         gatewayState: this.gateway,
@@ -348,6 +357,7 @@ export class DraftSubmissionFlow {
 
   invalidate(outcomeUnknown: SubmissionOutcomeReason | null = null) {
     this.submitRequestToken += 1;
+    this.startedSession.current = null;
     if (outcomeUnknown && this.submittingValue) {
       this.submissionOutcomeUnknownValue = outcomeUnknown;
     }
@@ -436,6 +446,12 @@ export class DraftSubmissionFlow {
     this.callbacks.closeTransientUi();
     this.callbacks.requestUpdate();
     try {
+      const started = this.startedSession.current;
+      if (started && this.startedSession.isCurrent(context, this.place.agentId)) {
+        await this.startedSession.navigate(context, started);
+        return;
+      }
+      this.startedSession.current = null;
       const remoteProject = pendingPlacement ? null : this.place.browser.remoteProject;
       if (remoteProject && !remoteProject.projectId && !this.place.browser.projectId) {
         const project = await submissionClient.request<ProjectsAddResult>(
@@ -586,22 +602,11 @@ export class DraftSubmissionFlow {
         }
         this.pendingPlacement.reset();
         this.attachmentDraft.clearAfterSubmit(true);
-        selectApplicationSession({
-          selection: context.agentSelection,
-          gateway: context.gateway,
-          sessionKey: result.key,
+        await this.startedSession.navigate(context, {
+          client: submissionClient,
+          key: result.key,
           agentId: submissionAgentId,
         });
-        await navigateToStartedSession(
-          context,
-          sessionNavigationTarget({
-            context,
-            face: "chat",
-            sessionKey: result.key,
-            agentId: this.place.agentId,
-            focusComposer: true,
-          }).options,
-        );
         return;
       }
       if (requestId !== this.submitRequestToken) {
@@ -634,22 +639,11 @@ export class DraftSubmissionFlow {
       if (requestId !== this.submitRequestToken) {
         return;
       }
-      selectApplicationSession({
-        selection: context.agentSelection,
-        gateway: context.gateway,
-        sessionKey: result.key,
+      await this.startedSession.navigate(context, {
+        client: submissionClient,
+        key: result.key,
         agentId: submissionAgentId,
       });
-      await navigateToStartedSession(
-        context,
-        sessionNavigationTarget({
-          context,
-          face: "chat",
-          sessionKey: result.key,
-          agentId: this.place.agentId,
-          focusComposer: true,
-        }).options,
-      );
     } catch (error) {
       if (requestId === this.submitRequestToken && this.gateway.client === submissionClient) {
         this.error = error instanceof Error ? error.message : String(error);
@@ -696,6 +690,7 @@ export class DraftSubmissionFlow {
       if (!result || requestId !== this.submitRequestToken || this.gateway.client !== client) {
         return;
       }
+      this.startedSession.current = null;
       await this.draftPersistence.clearSubmittedDraft();
       if (requestId !== this.submitRequestToken || this.gateway.client !== client) {
         return;
@@ -716,6 +711,7 @@ export class DraftSubmissionFlow {
   }
 
   disconnect() {
+    this.startedSession.current = null;
     this.draftPersistence.disconnect();
     this.attachmentDraft.reset({ release: true });
     this.composerTextarea.disconnect();

--- a/ui/src/pages/new-session/started-session-navigation.ts
+++ b/ui/src/pages/new-session/started-session-navigation.ts
@@ -1,18 +1,57 @@
-import type { ApplicationContext, ApplicationNavigationOptions } from "../../app/context.ts";
+import { selectApplicationSession } from "../../app/agent-selection.ts";
+import type { ApplicationContext } from "../../app/context.ts";
 import { navigateWithRouteTransition } from "../../app/route-transition.ts";
+import { sessionNavigationTarget } from "../../lib/sessions/route-navigation.ts";
+import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 
-export function navigateToStartedSession(
-  context: ApplicationContext,
-  options: ApplicationNavigationOptions,
-): Promise<void> {
-  // Keep transition code on the lazy new-session path instead of the startup bundle.
-  return navigateWithRouteTransition({
-    document,
-    from: "new-session",
-    to: "chat",
-    prefersReducedMotion:
-      globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
-    prepare: () => context.preload("chat", options),
-    navigate: () => context.navigateAndWait("chat", options),
-  }).catch(() => undefined);
+type StartedSession = {
+  client: NonNullable<ApplicationContext["gateway"]["snapshot"]["client"]>;
+  key: string;
+  agentId: string;
+};
+
+/** A committed create is retried as navigation, never as a second create. */
+export class StartedSessionNavigation {
+  current: StartedSession | null = null;
+
+  isCurrent(context: ApplicationContext | undefined, agentId: string): boolean {
+    const started = this.current;
+    const snapshot = context?.gateway.snapshot;
+    return Boolean(
+      started &&
+      snapshot?.phase === "connected" &&
+      snapshot.client === started.client &&
+      snapshot.sessionKey === started.key &&
+      normalizeAgentId(agentId) === started.agentId,
+    );
+  }
+
+  async navigate(context: ApplicationContext, started: StartedSession): Promise<void> {
+    this.current = started;
+    selectApplicationSession({
+      selection: context.agentSelection,
+      gateway: context.gateway,
+      sessionKey: started.key,
+      agentId: started.agentId,
+    });
+    const options = sessionNavigationTarget({
+      context,
+      face: "chat",
+      sessionKey: started.key,
+      agentId: started.agentId,
+      focusComposer: true,
+    }).options;
+    await navigateWithRouteTransition({
+      document,
+      from: "new-session",
+      to: "chat",
+      prefersReducedMotion:
+        globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false,
+      prepare: () => context.preload("chat", options),
+      navigate: () => context.navigateAndWait("chat", options),
+    });
+    if (this.current === started) {
+      this.current = null;
+    }
+  }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users creating a new Control UI session would see no explanation when the session was created successfully but loading its chat page failed. Retrying could create a duplicate normal session, while a cloud/device placement could leave the Start action incorrectly disabled after its session had already started.

## Why This Change Was Made

New-session navigation now owns the exact already-committed Gateway client, selected session, and agent. A failed chat transition remains visible, and retrying opens the same committed session without creating or starting it again. The existing submission gate, attachment-read lifecycle, draft edits, Gateway changes, selected-session/agent changes, terminal starts, and teardown retire or fence that private claim appropriately. Optional route preloading keeps its existing direct-navigation recovery.

## User Impact

Operators receive a visible error if a newly created task cannot open. They can safely retry the same existing normal or cloud/device task without duplicate sessions or duplicate remote startup, while attachment reads and switching to Start in Terminal remain safe.

## Evidence

- Regression-first owner proof: both actual normal and cloud-placement public `DraftSubmissionFlow.submit()` paths failed before the fix when an already committed session's real `navigateAndWait` rejected. An independently discovered normal double-submit created two sessions and the placement flow incorrectly disabled retry; both now navigate the same committed session with exactly one create/start.
- Additional independently discovered lifecycle regressions first failed for an in-flight real attachment read bypassing its existing visible submission gate and for an actual resolved-catalog, admin-enabled `sessions.catalog.startTerminal` leaving an obsolete chat retry alive. Both now pass at their canonical owners.
- Seven public-owner negative controls cover edited messages, attachment replacement, visibility changes, Gateway invalidation, selected-session replacement, agent changes, and a replacement Gateway client; no stale or cross-owner route is retried. The in-flight retry keeps the existing busy gate.
- **118 tests passed across nine** new-session submission, composer, route-transition, draft persistence, cloud/device placement, recovery, and application startup sibling suites. Existing direct navigation after optional preload failure and successful navigation remain covered.
- Full assertion-safety and max-lines ratchets, direct focused oxlint, focused oxfmt, and `git diff --check` all pass. The final full independent owner-boundary review and authenticated full committed Codex review found no actionable issues.
- Production +84/-49 (net +35): the previously absent exact private committed-session/client/agent claim and retry lifecycle justify the growth; the existing crowded submission owner shrank by four lines and duplicated selection/navigation paths were removed. Tests +199/-12.
- Existing mounted/browser Control UI proof cannot start in this linked worktree because the unrelated pre-existing `@panzoom/panzoom` import in `ui/src/components/image-lightbox.ts` is unavailable; installing dependencies in linked worktrees is prohibited. Zero browser scenarios were executed. Actual public submission owners, Gateway requests, placement startup, terminal action, transition/preload, visible error state, and user-retry contracts are exercised directly by the passing suites.
- No visual/layout change, public API, Gateway protocol, settings, storage, security policy, or persistent-state change.
- Exact reviewed head: `506bf5dc68d40de631f43d23ed8036da4814f7e6`.
