### PR TITLE
fix(claude): preserve partial output on aborted live turns

### DIFF
--- a/src/agents/cli-output-contracts.ts
+++ b/src/agents/cli-output-contracts.ts
@@ -31,6 +31,10 @@ export type CliTerminalFailure =
     }
   | { reason: "synthetic_no_response" };
 
+type CliTerminalInterruption = {
+  reason: "aborted" | "timeout";
+};
+
 /** Normalized result from a CLI-backed model provider turn. */
 export type CliOutput = {
   text: string;
@@ -44,6 +48,8 @@ export type CliOutput = {
   toolSummary?: ToolSummaryTrace;
   errorText?: string;
   terminalFailure?: CliTerminalFailure;
+  /** A caller interruption that ended the turn after usable assistant text was streamed. */
+  terminalInterruption?: CliTerminalInterruption;
   diagnostics?: {
     process?: CliProcessDiagnostics;
   };

--- a/src/agents/cli-output-contracts.ts
+++ b/src/agents/cli-output-contracts.ts
@@ -31,7 +31,7 @@ export type CliTerminalFailure =
     }
   | { reason: "synthetic_no_response" };
 
-type CliTerminalInterruption = {
+export type CliTerminalInterruption = {
   reason: "aborted" | "timeout";
 };
 

--- a/src/agents/cli-runner.interrupted-partial-output.test.ts
+++ b/src/agents/cli-runner.interrupted-partial-output.test.ts
@@ -1,0 +1,97 @@
+/** Tests caller-boundary settlement for interrupted CLI turns with partial output. */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { runPreparedCliAgent } from "./cli-runner.js";
+import { buildPreparedCliRunContext } from "./cli-runner.test-helpers.js";
+
+const { executePreparedCliRunMock } = vi.hoisted(() => ({
+  executePreparedCliRunMock: vi.fn(),
+}));
+
+vi.mock("./cli-runner/execute.runtime.js", () => ({
+  executePreparedCliRun: executePreparedCliRunMock,
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: vi.fn(() => null),
+}));
+
+const getGlobalHookRunnerMock = vi.mocked(getGlobalHookRunner);
+
+describe("runPreparedCliAgent interrupted partial output", () => {
+  beforeEach(() => {
+    executePreparedCliRunMock.mockReset();
+    getGlobalHookRunnerMock.mockReset();
+  });
+
+  it.each([
+    {
+      reason: "aborted" as const,
+      expectedMeta: { stopReason: "aborted" },
+    },
+    {
+      reason: "timeout" as const,
+      expectedMeta: { stopReason: "timeout", timeoutPhase: "provider" },
+    },
+  ])(
+    "retains partial text while settling $reason as non-success",
+    async ({ reason, expectedMeta }) => {
+      const onSuccessfulAuthBinding = vi.fn();
+      const hookRunner = {
+        hasHooks: vi.fn((hookName: string) => hookName === "agent_end"),
+        runAgentEnd: vi.fn(async (_event: { messages?: unknown[] }) => undefined),
+      };
+      getGlobalHookRunnerMock.mockReturnValue(hookRunner as never);
+      executePreparedCliRunMock.mockResolvedValue({
+        text: "partial answer",
+        rawText: "partial answer",
+        sessionId: "interrupted-native-session",
+        terminalInterruption: { reason },
+      });
+      const context = buildPreparedCliRunContext({ onSuccessfulAuthBinding });
+
+      const result = await runPreparedCliAgent(context);
+
+      expect(result.payloads).toEqual([{ text: "partial answer" }]);
+      expect(result.meta).toMatchObject({
+        aborted: true,
+        providerStarted: true,
+        ...expectedMeta,
+        completion: {
+          finishReason: reason,
+          stopReason: reason,
+          refusal: false,
+        },
+        executionTrace: {
+          attempts: [
+            {
+              provider: "claude-cli",
+              model: "sonnet",
+              result: reason,
+              reason: `CLI turn ${reason} after partial output`,
+            },
+          ],
+        },
+        agentMeta: {
+          sessionId: "",
+          clearCliSessionBinding: true,
+        },
+      });
+      expect(onSuccessfulAuthBinding).not.toHaveBeenCalled();
+      expect(hookRunner.runAgentEnd).toHaveBeenCalledOnce();
+      const agentEndEvent = hookRunner.runAgentEnd.mock.calls[0]?.[0];
+      expect(agentEndEvent).toMatchObject({
+        success: false,
+        error: `CLI turn ${reason} after partial output`,
+      });
+      expect(agentEndEvent?.messages).toEqual([
+        expect.objectContaining({ role: "user", content: "hi" }),
+        expect.objectContaining({
+          role: "assistant",
+          content: [{ type: "text", text: "partial answer" }],
+          stopReason: "aborted",
+        }),
+      ]);
+    },
+  );
+});

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -40,6 +40,7 @@ import {
   buildCliDeliveredFailure,
   buildCliRunResult,
   cliRunSettlementDeps,
+  formatCliTerminalInterruption,
   isClaudeCliBackend,
   resolveCliSourceReplyMirror,
   settleCliBackendOutcome,
@@ -53,6 +54,7 @@ import {
   persistApprovedCliUserTurnTranscript,
   persistCliAssistantTranscript,
   persistCliRunBlock,
+  resolveCliAssistantStopReason,
   runCliAgentEndHook,
 } from "./cli-runner/cli-run-transcript.js";
 import {
@@ -435,7 +437,7 @@ export async function runPreparedCliAgent(
             provider: params.provider,
             model: context.modelId,
             usage: output.usage,
-            stopReason: output.terminalInterruption ? "aborted" : undefined,
+            stopReason: resolveCliAssistantStopReason(output),
           })
         : undefined;
     if (assistantText.length > 0 && hasLlmOutputHooks) {
@@ -549,7 +551,7 @@ export async function runPreparedCliAgent(
           text: sourceReplyWasDelivered ? "" : assistantText,
           modelId: context.modelId,
           usage: output.usage,
-          stopReason: terminalInterruption ? "aborted" : undefined,
+          stopReason: resolveCliAssistantStopReason(output),
         });
         await finalizeCliContextEngineTurn({
           context,
@@ -560,18 +562,16 @@ export async function runPreparedCliAgent(
         });
         // A stateless backend may emit an id, but it never becomes continuity.
         // Managed stdio sessions own continuity in-process and write no native transcript.
-        const bindingFlushOk = terminalInterruption
-          ? false
-          : sessionBindingDisabled
-            ? true
-            : await isCliBindingFlushed(
-                effectiveCliSessionId,
-                params.provider,
-                context.cwd ?? context.workspaceDir,
-                { skipTranscriptProbe: acceptsClaudeLive(context) },
-              );
+        const bindingFlushOk = sessionBindingDisabled
+          ? true
+          : await isCliBindingFlushed(
+              effectiveCliSessionId,
+              params.provider,
+              context.cwd ?? context.workspaceDir,
+              { skipTranscriptProbe: acceptsClaudeLive(context) },
+            );
         const interruptionError = terminalInterruption
-          ? `CLI turn ${terminalInterruption.reason} after partial output`
+          ? formatCliTerminalInterruption(terminalInterruption)
           : undefined;
         await runCliAgentEndHook(params, {
           event: {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -435,6 +435,7 @@ export async function runPreparedCliAgent(
             provider: params.provider,
             model: context.modelId,
             usage: output.usage,
+            stopReason: output.terminalInterruption ? "aborted" : undefined,
           })
         : undefined;
     if (assistantText.length > 0 && hasLlmOutputHooks) {
@@ -536,7 +537,10 @@ export async function runPreparedCliAgent(
       const { output, assistantText, lastAssistant, sourceReplyWasDelivered, usedHistoryPrompt } =
         result;
       try {
-        await assertCliRuntimeBinding(context);
+        const terminalInterruption = output.terminalInterruption;
+        if (!terminalInterruption) {
+          await assertCliRuntimeBinding(context);
+        }
         const effectiveCliSessionId = output.sessionId ?? fallbackCliSessionId;
         const assistantTranscript = await persistCliAssistantTranscript({
           runParams: params,
@@ -545,6 +549,7 @@ export async function runPreparedCliAgent(
           text: sourceReplyWasDelivered ? "" : assistantText,
           modelId: context.modelId,
           usage: output.usage,
+          stopReason: terminalInterruption ? "aborted" : undefined,
         });
         await finalizeCliContextEngineTurn({
           context,
@@ -555,18 +560,24 @@ export async function runPreparedCliAgent(
         });
         // A stateless backend may emit an id, but it never becomes continuity.
         // Managed stdio sessions own continuity in-process and write no native transcript.
-        const bindingFlushOk = sessionBindingDisabled
-          ? true
-          : await isCliBindingFlushed(
-              effectiveCliSessionId,
-              params.provider,
-              context.cwd ?? context.workspaceDir,
-              { skipTranscriptProbe: acceptsClaudeLive(context) },
-            );
+        const bindingFlushOk = terminalInterruption
+          ? false
+          : sessionBindingDisabled
+            ? true
+            : await isCliBindingFlushed(
+                effectiveCliSessionId,
+                params.provider,
+                context.cwd ?? context.workspaceDir,
+                { skipTranscriptProbe: acceptsClaudeLive(context) },
+              );
+        const interruptionError = terminalInterruption
+          ? `CLI turn ${terminalInterruption.reason} after partial output`
+          : undefined;
         await runCliAgentEndHook(params, {
           event: {
             messages: buildAgentEndMessages(lastAssistant),
-            success: true,
+            success: interruptionError === undefined,
+            ...(interruptionError ? { error: interruptionError } : {}),
             durationMs: Date.now() - context.started,
           },
           ctx: hookContext,

--- a/src/agents/cli-runner/claude-live-session.abort-partial-output.test.ts
+++ b/src/agents/cli-runner/claude-live-session.abort-partial-output.test.ts
@@ -1,0 +1,158 @@
+/** Claude live session: aborted turns must surface already-streamed assistant text. */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { getProcessSupervisor } from "../../process/supervisor/index.js";
+import { buildClaudeLiveRunContext, mockClaudeLiveRun } from "../cli-runner.test-helpers.js";
+import { supervisorSpawnMock } from "../cli-runner.test-support.js";
+import { runClaudeTurn } from "./claude-live-session.js";
+import { resetClaudeLiveSessionsForTest } from "./claude-live-session.test-support.js";
+
+type ProcessSupervisor = ReturnType<typeof getProcessSupervisor>;
+type SupervisorSpawnFn = ProcessSupervisor["spawn"];
+
+beforeEach(() => {
+  resetClaudeLiveSessionsForTest();
+  supervisorSpawnMock.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetClaudeLiveSessionsForTest();
+});
+
+function getProcessSupervisorForTest() {
+  return {
+    spawn: (params: Parameters<SupervisorSpawnFn>[0]) =>
+      supervisorSpawnMock(params) as ReturnType<SupervisorSpawnFn>,
+    cancel: vi.fn(),
+    cancelScope: vi.fn(),
+    getRecord: vi.fn(),
+  };
+}
+
+function startLiveTurnWithAbortSignal(runId: string, signal: AbortSignal) {
+  const context = buildClaudeLiveRunContext({ runId, timeoutMs: 60_000 });
+  context.params.abortSignal = signal;
+  return runClaudeTurn({
+    context,
+    args: context.preparedBackend.backend.args ?? [],
+    env: {},
+    prompt: "hi",
+    useResume: false,
+    noOutputTimeoutMs: 5_000,
+    getProcessSupervisor: getProcessSupervisorForTest,
+    onAssistantDelta: () => {},
+    cleanup: async () => {},
+  });
+}
+
+describe("claude live session aborted-turn partial output", () => {
+  it.each([
+    {
+      name: "AbortError",
+      reason: "aborted",
+      abort: (controller: AbortController) => controller.abort(),
+    },
+    {
+      name: "externally supplied TimeoutError",
+      reason: "timeout",
+      abort: (controller: AbortController) => {
+        const error = new Error("caller deadline exceeded");
+        error.name = "TimeoutError";
+        controller.abort(error);
+      },
+    },
+    {
+      name: "AbortError wrapping a TimeoutError",
+      reason: "timeout",
+      abort: (controller: AbortController) => {
+        const timeout = new Error("caller deadline exceeded");
+        timeout.name = "TimeoutError";
+        const error = new Error("caller cancelled", { cause: timeout });
+        error.name = "AbortError";
+        controller.abort(error);
+      },
+    },
+  ])("resolves streamed assistant text for $name", async ({ abort, reason }) => {
+    const controller = new AbortController();
+    let textEmitted = false;
+    const fixture = mockClaudeLiveRun(supervisorSpawnMock, {
+      cancelable: true,
+      onWrite: ({ emit }) => {
+        emit([
+          { type: "system", subtype: "init", session_id: "live-abort-partial" },
+          {
+            type: "stream_event",
+            session_id: "live-abort-partial",
+            event: {
+              type: "content_block_delta",
+              delta: { type: "text_delta", text: "Here is the answer so far" },
+            },
+          },
+        ]);
+        textEmitted = true;
+      },
+    });
+
+    const turnPromise = startLiveTurnWithAbortSignal("run-abort-partial", controller.signal);
+    await vi.waitFor(() => {
+      expect(textEmitted).toBe(true);
+    });
+    abort(controller);
+
+    await expect(turnPromise).resolves.toMatchObject({
+      output: {
+        text: expect.stringContaining("Here is the answer so far"),
+        terminalInterruption: { reason },
+      },
+    });
+    expect(fixture.lifecycle.cancel).toHaveBeenCalledWith("manual-cancel");
+  });
+
+  it("still rejects genuine CLI failures after streamed text instead of masking them", async () => {
+    const controller = new AbortController();
+    mockClaudeLiveRun(supervisorSpawnMock, {
+      onWrite: ({ emit }) => {
+        emit([
+          { type: "system", subtype: "init", session_id: "live-abort-failover" },
+          {
+            type: "assistant",
+            session_id: "live-abort-failover",
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "Partial answer before failure" }],
+            },
+          },
+          {
+            type: "result",
+            subtype: "error_during_execution",
+            is_error: true,
+            session_id: "live-abort-failover",
+            result: "tool failed",
+          },
+        ]);
+      },
+    });
+
+    const turnPromise = startLiveTurnWithAbortSignal("run-abort-failover", controller.signal);
+    await expect(turnPromise).rejects.toMatchObject({ name: "FailoverError" });
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it("still rejects an abort when no assistant text was streamed yet", async () => {
+    const controller = new AbortController();
+    mockClaudeLiveRun(supervisorSpawnMock, {
+      cancelable: true,
+      onWrite: ({ emit }) => {
+        emit([{ type: "system", subtype: "init", session_id: "live-abort-empty" }]);
+      },
+    });
+
+    const turnPromise = startLiveTurnWithAbortSignal("run-abort-empty", controller.signal);
+    await vi.waitFor(() => {
+      expect(supervisorSpawnMock).toHaveBeenCalledOnce();
+    });
+    controller.abort();
+
+    await expect(turnPromise).rejects.toMatchObject({ name: "AbortError" });
+  });
+});

--- a/src/agents/cli-runner/claude-live-session.abort-partial-output.test.ts
+++ b/src/agents/cli-runner/claude-live-session.abort-partial-output.test.ts
@@ -62,8 +62,8 @@ describe("claude live session aborted-turn partial output", () => {
       },
     },
     {
-      name: "AbortError wrapping a TimeoutError",
-      reason: "timeout",
+      name: "AbortError wrapping a TimeoutError (an abort, not a deadline)",
+      reason: "aborted",
       abort: (controller: AbortController) => {
         const timeout = new Error("caller deadline exceeded");
         timeout.name = "TimeoutError";

--- a/src/agents/cli-runner/claude-live-turn.ts
+++ b/src/agents/cli-runner/claude-live-turn.ts
@@ -30,7 +30,7 @@ import {
   streamJsonOutputLimitErrorText,
 } from "../cli-output-stream.js";
 import { parseCliOutput } from "../cli-output.js";
-import { isFailoverError, isTimeoutError, type FailoverError } from "../failover-error.js";
+import { isFailoverError, isSignalTimeoutReason, type FailoverError } from "../failover-error.js";
 import { resolveCliToolTerminalReason } from "../run-termination.js";
 import {
   armClaudeTurnTimers,
@@ -132,15 +132,6 @@ function finishClaudeTurn(host: ClaudeLiveTurnHost, output: CliOutput): void {
   host.scheduleIdleClose();
 }
 
-function isPlainDomAbortError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    error.name === "AbortError" &&
-    error.message === "This operation was aborted" &&
-    !("cause" in error && error.cause !== undefined)
-  );
-}
-
 export function failClaudeTurn(host: ClaudeLiveTurnHost, error: unknown): void {
   const turn = host.currentTurn;
   if (!turn) {
@@ -151,29 +142,28 @@ export function failClaudeTurn(host: ClaudeLiveTurnHost, error: unknown): void {
     `claude live session turn failed: provider=${host.providerId} model=${host.modelId} durationMs=${Date.now() - turn.startedAtMs} error=${errorKind}`,
   );
   turn.streamingParser.finish();
-  const partialOutputAbort =
-    !isFailoverError(error) && (isAbortError(error) || isTimeoutError(error));
-  const partialOutput = partialOutputAbort ? turn.streamingParser.getOutput() : undefined;
+  // Caller interruptions (abort signal, caller deadline) keep already-streamed text.
+  // Structured CLI failures still reject so failover and empty-output handling are unchanged.
+  // Deadline vs abort follows the signal-reason rule run-diagnostics uses: only a TimeoutError
+  // reason is a deadline; failover message patterns would read a plain abort as a timeout.
+  const interrupted =
+    !isFailoverError(error) && (isAbortError(error) || isSignalTimeoutReason(error));
+  const partialOutput = interrupted ? turn.streamingParser.getOutput() : undefined;
   failActiveClaudeLiveTools(turn, error);
   clearClaudeTurnTimers(turn);
   host.outstandingBackgroundTaskIds.clear();
   host.currentTurn = null;
-  if (partialOutput?.text?.trim() && !partialOutput.errorText) {
-    cliBackendLog.info(
-      `claude live session aborted turn preserved partial output: provider=${host.providerId} model=${host.modelId} durationMs=${Date.now() - turn.startedAtMs} ${formatCliBackendOutputDigest(partialOutput.text)}`,
-    );
-    turn.resolve({
-      ...partialOutput,
-      terminalInterruption: {
-        reason: isTimeoutError(error) && !isPlainDomAbortError(error) ? "timeout" : "aborted",
-      },
-    });
-    if (!host.closing) {
-      host.scheduleIdleClose();
-    }
+  if (!partialOutput?.text.trim() || partialOutput.errorText) {
+    turn.reject(error);
     return;
   }
-  turn.reject(error);
+  cliBackendLog.info(
+    `claude live session aborted turn preserved partial output: provider=${host.providerId} model=${host.modelId} durationMs=${Date.now() - turn.startedAtMs} ${formatCliBackendOutputDigest(partialOutput.text)}`,
+  );
+  turn.resolve({
+    ...partialOutput,
+    terminalInterruption: { reason: isSignalTimeoutReason(error) ? "timeout" : "aborted" },
+  });
 }
 
 export function createClaudeOutputLimitError(

--- a/src/agents/cli-runner/claude-live-turn.ts
+++ b/src/agents/cli-runner/claude-live-turn.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { isAbortError } from "../../infra/abort-signal.js";
 import {
   emitTrustedDiagnosticEvent,
   type DiagnosticToolExecutionErrorEvent,
@@ -29,7 +30,7 @@ import {
   streamJsonOutputLimitErrorText,
 } from "../cli-output-stream.js";
 import { parseCliOutput } from "../cli-output.js";
-import type { FailoverError } from "../failover-error.js";
+import { isFailoverError, isTimeoutError, type FailoverError } from "../failover-error.js";
 import { resolveCliToolTerminalReason } from "../run-termination.js";
 import {
   armClaudeTurnTimers,
@@ -131,6 +132,15 @@ function finishClaudeTurn(host: ClaudeLiveTurnHost, output: CliOutput): void {
   host.scheduleIdleClose();
 }
 
+function isPlainDomAbortError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === "AbortError" &&
+    error.message === "This operation was aborted" &&
+    !("cause" in error && error.cause !== undefined)
+  );
+}
+
 export function failClaudeTurn(host: ClaudeLiveTurnHost, error: unknown): void {
   const turn = host.currentTurn;
   if (!turn) {
@@ -141,10 +151,28 @@ export function failClaudeTurn(host: ClaudeLiveTurnHost, error: unknown): void {
     `claude live session turn failed: provider=${host.providerId} model=${host.modelId} durationMs=${Date.now() - turn.startedAtMs} error=${errorKind}`,
   );
   turn.streamingParser.finish();
+  const partialOutputAbort =
+    !isFailoverError(error) && (isAbortError(error) || isTimeoutError(error));
+  const partialOutput = partialOutputAbort ? turn.streamingParser.getOutput() : undefined;
   failActiveClaudeLiveTools(turn, error);
   clearClaudeTurnTimers(turn);
   host.outstandingBackgroundTaskIds.clear();
   host.currentTurn = null;
+  if (partialOutput?.text?.trim() && !partialOutput.errorText) {
+    cliBackendLog.info(
+      `claude live session aborted turn preserved partial output: provider=${host.providerId} model=${host.modelId} durationMs=${Date.now() - turn.startedAtMs} ${formatCliBackendOutputDigest(partialOutput.text)}`,
+    );
+    turn.resolve({
+      ...partialOutput,
+      terminalInterruption: {
+        reason: isTimeoutError(error) && !isPlainDomAbortError(error) ? "timeout" : "aborted",
+      },
+    });
+    if (!host.closing) {
+      host.scheduleIdleClose();
+    }
+    return;
+  }
   turn.reject(error);
 }
 

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -13,7 +13,7 @@ import {
   resolveCliRuntimeArtifactFingerprint,
   resolveCliRuntimeOwnerFingerprint,
 } from "../cli-auth-epoch.js";
-import type { CliOutput } from "../cli-output-contracts.js";
+import type { CliOutput, CliTerminalInterruption } from "../cli-output-contracts.js";
 import { claudeCliSessionTranscriptHasContent as claudeCliSessionTranscriptHasContentImpl } from "../command/attempt-execution.helpers.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent-runner.js";
 import { resolveExplicitFinalSourceReplyDeliveryEvidence } from "../embedded-agent-runner/delivery-evidence.js";
@@ -27,6 +27,11 @@ import type { ClaudeCliRunDiagnosticLifecycle } from "./run-diagnostics.js";
 import type { PreparedCliRunContext, RunCliAgentParams } from "./types.js";
 
 const log = createSubsystemLogger("agents/cli-runner");
+
+/** Operator-visible reason recorded on trace attempts and agent_end when a live turn kept partial output. */
+export function formatCliTerminalInterruption(interruption: CliTerminalInterruption): string {
+  return `CLI turn ${interruption.reason} after partial output`;
+}
 
 export const cliRunSettlementDeps = {
   claudeCliSessionTranscriptHasContent: claudeCliSessionTranscriptHasContentImpl,
@@ -485,19 +490,16 @@ export function buildCliRunResult(params: {
     sourceReplyDeliveryMode: runParams.sourceReplyDeliveryMode,
   });
   const unflushedCliSessionId =
-    !output.terminalInterruption &&
-    !sessionBindingDisabled &&
-    effectiveCliSessionId &&
-    bindingFlushOk === false
+    !sessionBindingDisabled && effectiveCliSessionId && bindingFlushOk === false
       ? effectiveCliSessionId
       : undefined;
-  const persistedCliSessionId = output.terminalInterruption
-    ? undefined
-    : sessionBindingDisabled
-      ? undefined
-      : unflushedCliSessionId
-        ? undefined
-        : effectiveCliSessionId;
+  const terminalInterruption = output.terminalInterruption;
+  // An interrupted live turn closed its process, so its native continuity is dead.
+  const cliSessionBindingCleared =
+    terminalInterruption !== undefined ||
+    sessionBindingDisabled ||
+    unflushedCliSessionId !== undefined;
+  const persistedCliSessionId = cliSessionBindingCleared ? undefined : effectiveCliSessionId;
   const createdReseedReceipt =
     persistedCliSessionId &&
     usedHistoryPrompt &&
@@ -519,15 +521,13 @@ export function buildCliRunResult(params: {
       ? runParams.cliSessionBinding.reseedReceipt
       : undefined;
   const reseedReceipt = createdReseedReceipt ?? preservedReseedReceipt;
-  const agentSessionId = output.terminalInterruption
-    ? ""
-    : sessionBindingDisabled
-      ? (runParams.sessionId ?? "")
-      : unflushedCliSessionId
-        ? ""
+  const agentSessionId =
+    terminalInterruption || unflushedCliSessionId
+      ? ""
+      : sessionBindingDisabled
+        ? (runParams.sessionId ?? "")
         : (effectiveCliSessionId ?? runParams.sessionId ?? "");
   const yielded = output.yielded === true;
-  const terminalInterruption = output.terminalInterruption;
   const stopReason = terminalInterruption?.reason ?? (yielded ? "end_turn" : "completed");
 
   if (!terminalInterruption) {
@@ -587,7 +587,7 @@ export function buildCliRunResult(params: {
             model: context.modelId,
             result: terminalInterruption?.reason ?? "success",
             ...(terminalInterruption
-              ? { reason: `CLI turn ${terminalInterruption.reason} after partial output` }
+              ? { reason: formatCliTerminalInterruption(terminalInterruption) }
               : {}),
           },
         ],
@@ -644,9 +644,7 @@ export function buildCliRunResult(params: {
               },
             }
           : {}),
-        ...(terminalInterruption || sessionBindingDisabled || unflushedCliSessionId
-          ? { clearCliSessionBinding: true }
-          : {}),
+        ...(cliSessionBindingCleared ? { clearCliSessionBinding: true } : {}),
       },
     },
     ...(output.didSendViaMessagingTool ? { didSendViaMessagingTool: true } : {}),

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -485,14 +485,19 @@ export function buildCliRunResult(params: {
     sourceReplyDeliveryMode: runParams.sourceReplyDeliveryMode,
   });
   const unflushedCliSessionId =
-    !sessionBindingDisabled && effectiveCliSessionId && bindingFlushOk === false
+    !output.terminalInterruption &&
+    !sessionBindingDisabled &&
+    effectiveCliSessionId &&
+    bindingFlushOk === false
       ? effectiveCliSessionId
       : undefined;
-  const persistedCliSessionId = sessionBindingDisabled
+  const persistedCliSessionId = output.terminalInterruption
     ? undefined
-    : unflushedCliSessionId
+    : sessionBindingDisabled
       ? undefined
-      : effectiveCliSessionId;
+      : unflushedCliSessionId
+        ? undefined
+        : effectiveCliSessionId;
   const createdReseedReceipt =
     persistedCliSessionId &&
     usedHistoryPrompt &&
@@ -514,32 +519,39 @@ export function buildCliRunResult(params: {
       ? runParams.cliSessionBinding.reseedReceipt
       : undefined;
   const reseedReceipt = createdReseedReceipt ?? preservedReseedReceipt;
-  const agentSessionId = sessionBindingDisabled
-    ? (runParams.sessionId ?? "")
-    : unflushedCliSessionId
-      ? ""
-      : (effectiveCliSessionId ?? runParams.sessionId ?? "");
+  const agentSessionId = output.terminalInterruption
+    ? ""
+    : sessionBindingDisabled
+      ? (runParams.sessionId ?? "")
+      : unflushedCliSessionId
+        ? ""
+        : (effectiveCliSessionId ?? runParams.sessionId ?? "");
   const yielded = output.yielded === true;
-  const stopReason = yielded ? "end_turn" : "completed";
+  const terminalInterruption = output.terminalInterruption;
+  const stopReason = terminalInterruption?.reason ?? (yielded ? "end_turn" : "completed");
 
-  runParams.onSuccessfulAuthBinding?.({
-    ...(context.effectiveAuthProfileId ? { authProfileId: context.effectiveAuthProfileId } : {}),
-    ...(context.authBindingFingerprint ? { authFingerprint: context.authBindingFingerprint } : {}),
-    ...(!context.authBindingFingerprint && context.runtimeOwnerFingerprint
-      ? {
-          runtimeOwnerFingerprint: context.runtimeOwnerFingerprint,
-          runtimeOwnerKind: "cli-runtime" as const,
-          runtimeOwnerId: context.backendResolved.id,
-        }
-      : {}),
-    ...(context.runtimeArtifactFingerprint
-      ? {
-          runtimeArtifactFingerprint: context.runtimeArtifactFingerprint,
-          runtimeArtifactId: context.backendResolved.id,
-        }
-      : {}),
-    ...(context.authBindingSkipsLocalCredential ? { skipLocalCredential: true } : {}),
-  });
+  if (!terminalInterruption) {
+    runParams.onSuccessfulAuthBinding?.({
+      ...(context.effectiveAuthProfileId ? { authProfileId: context.effectiveAuthProfileId } : {}),
+      ...(context.authBindingFingerprint
+        ? { authFingerprint: context.authBindingFingerprint }
+        : {}),
+      ...(!context.authBindingFingerprint && context.runtimeOwnerFingerprint
+        ? {
+            runtimeOwnerFingerprint: context.runtimeOwnerFingerprint,
+            runtimeOwnerKind: "cli-runtime" as const,
+            runtimeOwnerId: context.backendResolved.id,
+          }
+        : {}),
+      ...(context.runtimeArtifactFingerprint
+        ? {
+            runtimeArtifactFingerprint: context.runtimeArtifactFingerprint,
+            runtimeArtifactId: context.backendResolved.id,
+          }
+        : {}),
+      ...(context.authBindingSkipsLocalCredential ? { skipLocalCredential: true } : {}),
+    });
+  }
 
   return {
     payloads: payloadsWithToolMedia,
@@ -553,12 +565,32 @@ export function buildCliRunResult(params: {
           }
         : {}),
       systemPromptReport: context.systemPromptReport,
-      ...(yielded ? { yielded: true, livenessState: "paused" as const, stopReason } : {}),
+      ...(terminalInterruption
+        ? {
+            aborted: true,
+            providerStarted: true,
+            stopReason,
+            ...(terminalInterruption.reason === "timeout"
+              ? { timeoutPhase: "provider" as const }
+              : {}),
+          }
+        : yielded
+          ? { yielded: true, livenessState: "paused" as const, stopReason }
+          : {}),
       ...(output.yieldAcknowledgment ? { yieldAcknowledgment: output.yieldAcknowledgment } : {}),
       executionTrace: {
         winnerProvider: runParams.provider,
         winnerModel: context.modelId,
-        attempts: [{ provider: runParams.provider, model: context.modelId, result: "success" }],
+        attempts: [
+          {
+            provider: runParams.provider,
+            model: context.modelId,
+            result: terminalInterruption?.reason ?? "success",
+            ...(terminalInterruption
+              ? { reason: `CLI turn ${terminalInterruption.reason} after partial output` }
+              : {}),
+          },
+        ],
         fallbackUsed: false,
         runner: "cli",
       },
@@ -567,7 +599,7 @@ export function buildCliRunResult(params: {
         ...(context.effectiveAuthProfileId ? { authMode: "auth-profile" } : {}),
       },
       completion: {
-        finishReason: yielded ? "end_turn" : "stop",
+        finishReason: terminalInterruption?.reason ?? (yielded ? "end_turn" : "stop"),
         stopReason,
         refusal: false,
       },
@@ -612,7 +644,7 @@ export function buildCliRunResult(params: {
               },
             }
           : {}),
-        ...(sessionBindingDisabled || unflushedCliSessionId
+        ...(terminalInterruption || sessionBindingDisabled || unflushedCliSessionId
           ? { clearCliSessionBinding: true }
           : {}),
       },

--- a/src/agents/cli-runner/cli-run-transcript.ts
+++ b/src/agents/cli-runner/cli-run-transcript.ts
@@ -4,6 +4,7 @@ import { resolvePersistedSessionStoreOwnerForTarget } from "../../config/session
 import { appendExactAssistantMessageToSessionTranscript } from "../../config/sessions/transcript.js";
 import { buildGenericCliContextEngineHostSupport } from "../../context-engine/host-compat.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import type { StopReason } from "../../llm/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
@@ -44,6 +45,7 @@ export function buildCliHookAssistantMessage(params: {
     cacheWrite?: number;
     total?: number;
   };
+  stopReason?: StopReason;
 }): unknown {
   return {
     role: "assistant",
@@ -52,7 +54,7 @@ export function buildCliHookAssistantMessage(params: {
     provider: params.provider,
     model: params.model,
     ...(params.usage ? { usage: params.usage } : {}),
-    stopReason: "stop",
+    stopReason: params.stopReason ?? "stop",
     timestamp: Date.now(),
   };
 }
@@ -80,6 +82,7 @@ function buildCliContextEngineAssistantMessage(params: {
     cacheWrite?: number;
     total?: number;
   };
+  stopReason?: StopReason;
 }): AgentMessage {
   return buildCliHookAssistantMessage(params) as AgentMessage;
 }
@@ -144,6 +147,7 @@ export async function persistCliAssistantTranscript(params: {
     cacheWrite?: number;
     total?: number;
   };
+  stopReason?: StopReason;
 }): Promise<{
   owned: boolean;
   idempotencyKey?: string;
@@ -190,7 +194,7 @@ export async function persistCliAssistantTranscript(params: {
           id: params.modelId,
         },
         content: [{ type: "text", text: params.text }],
-        stopReason: "stop",
+        stopReason: params.stopReason ?? "stop",
         usage: buildUsageWithNoCost({
           input: params.usage?.input,
           output: params.usage?.output,
@@ -359,6 +363,7 @@ export async function finalizeCliContextEngineTurn(params: {
         provider: runParams.provider,
         model: context.modelId,
         usage: params.output.usage,
+        stopReason: params.output.terminalInterruption ? "aborted" : undefined,
       }),
     );
   }
@@ -376,7 +381,8 @@ export async function finalizeCliContextEngineTurn(params: {
     const result = await finalizeHarnessContextEngineTurn({
       contextEngine: context.contextEngine,
       promptError: false,
-      aborted: runParams.abortSignal?.aborted === true,
+      aborted:
+        params.output.terminalInterruption !== undefined || runParams.abortSignal?.aborted === true,
       yieldAborted: false,
       sessionIdUsed: runParams.sessionId,
       sessionKey: runParams.sessionKey,
@@ -413,7 +419,9 @@ export async function finalizeCliContextEngineTurn(params: {
         sessionTarget: runParams.sessionTarget,
         sessionFile: runParams.sessionFile,
         promptError: false,
-        aborted: runParams.abortSignal?.aborted === true,
+        aborted:
+          params.output.terminalInterruption !== undefined ||
+          runParams.abortSignal?.aborted === true,
         yieldAborted: false,
         contextEngineHostSupport,
         providerId: runParams.provider,

--- a/src/agents/cli-runner/cli-run-transcript.ts
+++ b/src/agents/cli-runner/cli-run-transcript.ts
@@ -34,6 +34,11 @@ export function buildCliHookUserMessage(prompt: string): unknown {
   };
 }
 
+/** Interrupted turns persist as aborted so replayed history never reads partial text as a finished reply. */
+export function resolveCliAssistantStopReason(output: CliOutput): StopReason {
+  return output.terminalInterruption ? "aborted" : "stop";
+}
+
 export function buildCliHookAssistantMessage(params: {
   text: string;
   provider: string;
@@ -45,7 +50,7 @@ export function buildCliHookAssistantMessage(params: {
     cacheWrite?: number;
     total?: number;
   };
-  stopReason?: StopReason;
+  stopReason: StopReason;
 }): unknown {
   return {
     role: "assistant",
@@ -54,7 +59,7 @@ export function buildCliHookAssistantMessage(params: {
     provider: params.provider,
     model: params.model,
     ...(params.usage ? { usage: params.usage } : {}),
-    stopReason: params.stopReason ?? "stop",
+    stopReason: params.stopReason,
     timestamp: Date.now(),
   };
 }
@@ -82,7 +87,7 @@ function buildCliContextEngineAssistantMessage(params: {
     cacheWrite?: number;
     total?: number;
   };
-  stopReason?: StopReason;
+  stopReason: StopReason;
 }): AgentMessage {
   return buildCliHookAssistantMessage(params) as AgentMessage;
 }
@@ -147,7 +152,7 @@ export async function persistCliAssistantTranscript(params: {
     cacheWrite?: number;
     total?: number;
   };
-  stopReason?: StopReason;
+  stopReason: StopReason;
 }): Promise<{
   owned: boolean;
   idempotencyKey?: string;
@@ -194,7 +199,7 @@ export async function persistCliAssistantTranscript(params: {
           id: params.modelId,
         },
         content: [{ type: "text", text: params.text }],
-        stopReason: params.stopReason ?? "stop",
+        stopReason: params.stopReason,
         usage: buildUsageWithNoCost({
           input: params.usage?.input,
           output: params.usage?.output,
@@ -363,7 +368,7 @@ export async function finalizeCliContextEngineTurn(params: {
         provider: runParams.provider,
         model: context.modelId,
         usage: params.output.usage,
-        stopReason: params.output.terminalInterruption ? "aborted" : undefined,
+        stopReason: resolveCliAssistantStopReason(params.output),
       }),
     );
   }


### PR DESCRIPTION
Closes #120207

AI-assisted: Yes — implemented, tested, and reviewed with Codex; repaired and re-proved by a maintainer agent (see "Maintainer repair").

## What Problem This Solves

Claude CLI live turns can stream useful assistant text before cancellation. The old abort path finalized the parser and rejected the turn without returning that text, so an interrupted reply disappeared completely.

The first version of this patch retained the text but settled it as an ordinary success. That would persist a normal `stop` transcript, emit `agent_end` with `success: true`, record a successful execution attempt, preserve native-session continuity, and invoke successful auth binding even though the live process had been aborted.

## Why This Change Was Made

The Claude live turn boundary now attaches an explicit `aborted` or `timeout` disposition when finalized parser output contains usable partial text. The top-level CLI runner carries that disposition through transcript persistence, context-engine finalization, hooks, run metadata, execution traces, session binding, and auth settlement.

Structured `FailoverError` paths, genuine provider failures, and interruptions without usable assistant text still reject. Completed turns retain their existing success behavior.

## User Impact

Users keep assistant text that arrived before a Claude CLI cancellation or caller deadline. The turn is still visibly terminal and non-successful, dead native continuity is cleared, and the interrupted run cannot be recorded as a successful auth binding.

## Maintainer repair

Root cause: `failClaudeTurn` (`src/agents/cli-runner/claude-live-turn.ts`) rejected every aborted turn, discarding text the streaming parser had already accepted. Owner: the Claude live turn boundary; settlement (`cli-run-settlement.ts`) and transcript (`cli-run-transcript.ts`) consume the recorded disposition instead of inferring it.

Changes on top of the author's head `230cb5db04e`:

- Interruption kind is classified by the canonical signal-reason rule (`isSignalTimeoutReason`, the same rule `run-diagnostics.ts` uses): only a `TimeoutError` reason is a deadline. The author's `isTimeoutError` + `isPlainDomAbortError` pair was message sniffing — the failover pattern list counts `operation was aborted` as timeout-like, so a plain `/stop` abort classified as `timeout` without the special case. The special case is gone; the rule is the owner's contract.
- Settlement: one `cliSessionBindingCleared` fact replaces three nested ternaries; `formatCliTerminalInterruption` owns the recorded reason string (trace attempt + `agent_end` error); `resolveCliAssistantStopReason` owns the transcript stop reason (required param, no `?? "stop"` fallback). The redundant `bindingFlushOk` interruption branch in `cli-runner.ts` is removed — settlement already clears the binding from the recorded disposition.
- `failClaudeTurn` no longer re-arms idle close on the partial path; interruptions only arrive through `close("abort")`, where the host is already closing.
- Log line `claude live session aborted turn preserved partial output:` is the stable operator-visible marker for this path (the Telegram E2E harness keys on it).
- Production LOC vs base `bb6dba54ef9`: +121/−43 (net +78); tests +255/−0. The net growth is the new disposition surface itself (`terminalInterruption` in `CliOutput`, meta/trace/completion projections, auth-binding gate), not guard stacking.

## Evidence

### Environment

- Repository: `openclaw/openclaw`
- Base: `bb6dba54ef97aac71b8c7a62db2b77b57b1b5e3e`
- Exact pushed head: `7ce8b85611d66a9d987173ebe652146b05957fe6`
- Runtime: Node `v24.19.0`

### Regression tests

- `src/agents/cli-runner/claude-live-session.abort-partial-output.test.ts` (owner boundary): plain abort → `aborted`; `TimeoutError` reason → `timeout`; `AbortError` wrapping a `TimeoutError` → `aborted` (an abort, not a deadline); `FailoverError` still rejects; empty-output abort still rejects. Pre-fix proof: with `claude-live-turn.ts` swapped to base `bb6dba54ef9`, the three partial-output cases fail (turn rejects), the two still-reject cases pass.
- `src/agents/cli-runner.interrupted-partial-output.test.ts` (caller boundary): payload retained, `meta.aborted/providerStarted/stopReason/timeoutPhase`, trace attempt `aborted|timeout` with reason, `agentMeta.sessionId: ""` + `clearCliSessionBinding`, no `onSuccessfulAuthBinding`, `agent_end` `success: false` with the partial assistant message at `stopReason: "aborted"`.

### Local proof (exact head)

- `node scripts/run-vitest.mjs src/agents/cli-runner` — 23 test files, 422 tests passed (agents-core + agents-support shards).
- `pnpm tsgo`, `pnpm check:test-types`, `node scripts/run-oxlint.mjs <touched files>`, `node_modules/.bin/oxfmt --check <touched files>`, `git diff --check` — all exit 0.

### ClawSweeper

Local ClawSweeper review on exact head `7ce8b85611d66a9d987173ebe652146b05957fe6` (model `gpt-5.6-terra`, reasoning high): `overallCorrectness: patch is correct`, `reviewFindings: []`, security `cleared` (0 concerns), no maintainer decision. Two Rank-up moves, both proof requests (attach a redacted after-fix trace of an injected abort after streamed Claude output, showing the retained message, aborted terminal result, cleared native binding, and absent successful auth settlement) — satisfied by the Telegram E2E trace below plus the caller-boundary test for the settlement facts the live trace does not log. Re-run on the same head after attaching that evidence: PASS — 0 findings, security cleared, no maintainer decision, 0 Rank-up moves.

### Telegram E2E (real Telegram, managed Claude stdio fixture)

Exact head `7ce8b85611d66a9d987173ebe652146b05957fe6`, built `dist` (`pnpm build`, 0 `INEFFECTIVE_DYNAMIC_IMPORT`), real Telegram DM through the QA user account, `claude-cli` backend with the provider-free `partial-output-abort` stdio fixture (streams assistant text, then the harness injects `/stop`; zero provider requests).

```
node "$TELEGRAM_E2E_SKILL_DIR/scripts/run-mock-sut-user-e2e.mjs" --dm --backend claude-cli \
  --claude-live-fixture partial-output-abort --claude-live-expect fixed --timeout-ms 25000 \
  --record <proof>/events.ndjson --output <proof>/summary.json
```

Redacted after-fix trace (`summary.json` → `claudeLiveFixture`):

```json
{
  "mode": "partial-output-abort",
  "operatorDiagnostic": "aborted",
  "telegramReplies": ["⚙️ Agent was aborted."],
  "providerRequests": 0,
  "partialOutput": {
    "streamedText": "OPENCLAW_E2E_PARTIAL_OUTPUT streamed before the abort arrived",
    "transcriptSessions": 1,
    "transcriptAssistantTexts": ["OPENCLAW_E2E_PARTIAL_OUTPUT streamed before the abort arrived"],
    "preservedInTranscript": true,
    "preservedInGatewayLog": true,
    "verdict": "fixed",
    "expect": "fixed",
    "ok": true
  }
}
```

Gateway log (isolated `logging.file`, the run's own gateway), in order:

```
claude live session turn failed: provider=claude-cli model=claude-haiku-4-5 durationMs=7534 error=AbortError
claude live session aborted turn preserved partial output: provider=claude-cli model=claude-haiku-4-5 durationMs=7535 outBytes=61 outHash=abd567a576dc
claude live session close: provider=claude-cli model=claude-haiku-4-5 reason=abort
```

Recorded Telegram timeline: user prompt at 4.7s → SUT typing → `/stop` at 8.3s → one SUT message at 8.6s (`⚙️ Agent was aborted.`, the non-success terminal outcome); the streamed assistant text is retained in the session transcript (`session-transcripts.json`, 1 session, assistant text = the streamed fixture line). Same harness on `main` (`bb6dba54ef9`) before this PR: `verdict: affected` (transcript empty, no log marker).

The live trace does not log session-binding or auth-settlement facts; those are pinned at the caller boundary by `src/agents/cli-runner.interrupted-partial-output.test.ts` (`agentMeta.sessionId: ""` + `clearCliSessionBinding: true`, `onSuccessfulAuthBinding` never invoked, `agent_end` `success: false`, trace attempt `aborted`).

## Review Notes

- `reviewMetrics`: production `+121/-43`; tests `+255/-0`; seven changed files.
- `risks`: the new disposition is set only after the finalized parser has non-empty assistant text and no parser error. Generic failover selection and empty-output rejection remain unchanged.
- `bestSolution`: carry interruption state with the already-normalized CLI output at the Claude live-turn owner boundary, then settle it once at the top-level runner instead of throwing away text or fabricating a successful completion.
- `testAudit`: the direct live-session table protects parser/abort behavior; the caller-boundary table independently protects terminal metadata, hooks, session clearing, and successful-auth suppression. Neither requires a test-only production seam.
