### PR TITLE
fix(cli): render QR JSON failures

### DIFF
--- a/src/cli/qr-cli.test.ts
+++ b/src/cli/qr-cli.test.ts
@@ -7,6 +7,8 @@ import {
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
   VOICE_NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
 } from "../shared/device-bootstrap-profile.js";
+import { formatCliJsonFailure } from "./failure-output.js";
+import { runCliWithExitFinalization } from "./one-shot-exit.js";
 import { createCliRuntimeCapture, mockRuntimeModule } from "./test-runtime-capture.js";
 
 const mocks = vi.hoisted(() => ({
@@ -264,17 +266,56 @@ describe("registerQrCli", () => {
     );
   });
 
-  it("rejects combining --limited with --voice-node", async () => {
-    loadConfig.mockReturnValue({
-      gateway: {
-        bind: "custom",
-        customBindHost: "127.0.0.1",
-        auth: { mode: "token", token: "tok" },
-      },
-    });
+  const conflictingQrOptions = [
+    {
+      name: "access profiles",
+      args: ["--limited", "--voice-node"],
+      message: "Use either --limited or --voice-node, not both.",
+    },
+    {
+      name: "authentication overrides",
+      args: ["--token", "test-token", "--password", "test-password"],
+      message: "Use either --token or --password, not both.",
+    },
+  ];
 
-    await expect(runQr(["--setup-code-only", "--limited", "--voice-node"])).rejects.toThrow("exit");
-    expect(runtime.error).toHaveBeenCalledWith("Use either --limited or --voice-node, not both.");
+  it.each(conflictingQrOptions)("rejects conflicting $name in human mode", async (testCase) => {
+    await expect(runQr(["--setup-code-only", ...testCase.args])).rejects.toThrow("exit");
+
+    expect(runtimeError).toHaveBeenCalledExactlyOnceWith(testCase.message);
+    expect(runtimeExit).toHaveBeenCalledExactlyOnceWith(1);
+    expect(loadConfig).not.toHaveBeenCalled();
+  });
+
+  it.each(conflictingQrOptions)("renders conflicting $name as canonical JSON", async (testCase) => {
+    const args = ["--json", ...testCase.args];
+    const originalArgv = process.argv;
+    let exitCode: number | undefined;
+    process.argv = ["node", "openclaw", "qr", ...args];
+    try {
+      await runCliWithExitFinalization({
+        runtime,
+        run: async () => await runQr(args),
+        onError: (error) => {
+          runtime.writeJson(formatCliJsonFailure(error));
+          exitCode = 1;
+        },
+      });
+    } finally {
+      process.argv = originalArgv;
+    }
+
+    const expected = {
+      ok: false,
+      error: { type: "cli_error", message: testCase.message },
+    };
+    expect(exitCode).toBe(1);
+    expect(runtime.writeJson).toHaveBeenCalledExactlyOnceWith(expected);
+    expect(runtimeLog).toHaveBeenCalledOnce();
+    expect(JSON.parse(readRuntimeCallText(runtimeLog.mock.calls[0]))).toEqual(expected);
+    expect(runtimeError).not.toHaveBeenCalled();
+    expect(runtimeExit).not.toHaveBeenCalled();
+    expect(loadConfig).not.toHaveBeenCalled();
   });
 
   it("renders ASCII QR by default", async () => {

--- a/src/cli/qr-cli.ts
+++ b/src/cli/qr-cli.ts
@@ -7,7 +7,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 import { trimToUndefined } from "../gateway/credentials.js";
 import { resolveRequiredConfiguredSecretRefInputString } from "../gateway/resolve-configured-secret-input-string.js";
-import { formatErrorMessage } from "../infra/errors.js";
 import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
 import { renderQrTerminal } from "../media/qr-terminal.ts";
 import { resolvePairingSetupFromConfig, encodePairingSetupCode } from "../pairing/setup-code.js";
@@ -17,6 +16,7 @@ import {
   PAIRING_SETUP_BOOTSTRAP_PROFILE,
   VOICE_NODE_PAIRING_SETUP_BOOTSTRAP_PROFILE,
 } from "../shared/device-bootstrap-profile.js";
+import { runCommandWithRuntime } from "./cli-utils.js";
 import { resolveCommandSecretRefsViaGateway } from "./command-secret-gateway.js";
 import { getQrRemoteCommandSecretTargetIds } from "./command-secret-targets.js";
 
@@ -125,7 +125,7 @@ export function registerQrCli(program: Command) {
     .option("--no-ascii", "Skip ASCII QR rendering")
     .option("--json", "Output JSON", false)
     .action(async (opts: QrCliOptions) => {
-      try {
+      await runCommandWithRuntime(defaultRuntime, async () => {
         if (opts.token && opts.password) {
           throw new Error("Use either --token or --password, not both.");
         }
@@ -284,9 +284,6 @@ export function registerQrCli(program: Command) {
         );
 
         defaultRuntime.log(lines.join("\n"));
-      } catch (err) {
-        defaultRuntime.error(formatErrorMessage(err));
-        defaultRuntime.exit(1);
-      }
+      });
     });
 }

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -295,6 +295,40 @@ describe("cli json stdout contract", () => {
     );
   });
 
+  it.each([
+    { name: "qr", command: ["qr"] },
+    { name: "clawbot qr", command: ["clawbot", "qr"] },
+  ])("renders conflicting $name options as one canonical JSON document", async (testCase) => {
+    await withTempHome(
+      async (tempHome) => {
+        for (const conflict of [
+          {
+            args: ["--limited", "--voice-node"],
+            message: "Use either --limited or --voice-node, not both.",
+          },
+          {
+            args: ["--token", "test-token", "--password", "test-password"],
+            message: "Use either --token or --password, not both.",
+          },
+        ]) {
+          const result = runBuiltCli(tempHome, [...testCase.command, "--json", ...conflict.args], {
+            OPENCLAW_CONFIG_PATH: path.join(tempHome, "missing-openclaw.json"),
+            OPENCLAW_STATE_DIR: path.join(tempHome, "isolated-state"),
+          });
+
+          expect(result.status, result.stderr).toBe(1);
+          expect(JSON.parse(result.stdout)).toEqual({
+            ok: false,
+            error: { type: "cli_error", message: conflict.message },
+          });
+          expect(result.stdout).not.toContain("[openclaw]");
+          expect(result.stderr).toContain(conflict.message);
+        }
+      },
+      { prefix: "openclaw-qr-json-failure-e2e-" },
+    );
+  });
+
   it("returns one canonical document when docs search fails", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
Closes #126878

## What Problem This Solves

Fixes an issue where scripts invoking `openclaw qr --json` or the legacy `openclaw clawbot qr --json` alias received empty stdout when either documented pair of mutually exclusive options failed validation. The commands exited nonzero and printed only human-readable stderr instead of the documented machine-readable CLI failure object.

## Why This Change Was Made

Route QR actions through the existing shared CLI runtime wrapper so JSON-mode failures reach the canonical process-level failure renderer. This removes QR's duplicate local catch/exit path while preserving both existing validation messages, exit status, pre-config validation timing, legacy alias behavior, and successful QR payloads.

## User Impact

Automation can reliably parse one `{ "ok": false, "error": { "type": "cli_error", "message": "..." } }` document from stdout for both QR option conflicts. Ordinary human-mode errors remain unchanged.

## Evidence

- Reproduced before the fix as real, isolated CLI processes: both `--limited --voice-node` and `--token test-token --password test-password` exited 1 with empty stdout under both QR command spellings.
- Demonstrated red-to-green regression provenance: owner-level tests failed because the local exit replaced the original error; real-process QR and legacy-alias E2E tests failed with `Unexpected end of JSON input` on empty stdout.
- `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-autoqa-172-vitest-cache node scripts/run-vitest.mjs src/cli/qr-cli.test.ts src/cli/cli-utils.test.ts` — 82 tests passed.
- `OPENCLAW_E2E_USE_PREBUILT_DIST=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-autoqa-172-vitest-cache node scripts/run-vitest.mjs test/cli-json-stdout.e2e.test.ts` against freshly rebuilt candidate artifacts — 32 real-process JSON contract tests passed.
- `node scripts/check-changed.mjs -- src/cli/qr-cli.ts src/cli/qr-cli.test.ts test/cli-json-stdout.e2e.test.ts` — required changed-file formatting, type, lint, and architecture gates passed.
- Fresh P1 Codex structured autoreview: no actionable findings; separate adversarial review: no actionable findings.
- Production LOC: +3/-6 (net -3). Test LOC: +85/-10 (net +75).
- No Gateway/service, provider credentials, configuration surface, new CLI option, persistence, or changelog change.

AI-assisted: Codex.
