### PR TITLE
perf(matrix): eliminate ten seconds of lease-retirement test waits

### DIFF
--- a/extensions/matrix/src/matrix/sdk.test.ts
+++ b/extensions/matrix/src/matrix/sdk.test.ts
@@ -1585,6 +1585,7 @@ describe("MatrixClient request hardening", () => {
   it.each([SyncState.Error, SyncState.Reconnecting])(
     "does not replace a poisoned %s generation until late transient work really releases",
     async (syncState) => {
+      vi.useFakeTimers();
       const accountId = `sdk-retirement-${syncState.toLowerCase()}`;
       const cfg = {
         channels: {
@@ -1668,14 +1669,14 @@ describe("MatrixClient request hardening", () => {
           () => ({ ok: true as const }),
           (error: unknown) => ({ ok: false as const, error }),
         );
-        await vi.waitFor(() => {
-          expect(firstSdkClient.classicSyncStop).toHaveBeenCalledOnce();
-        });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(firstSdkClient.classicSyncStop).toHaveBeenCalledOnce();
         expect(borrowedSignal?.aborted).toBe(true);
         await expect(keepaliveOutcome).resolves.toBe("SyncApi.stop() was called");
         expect(syncInternals.connectionReturnedResolvers).toBeUndefined();
 
         expect(createSharedMatrixClientMock).toHaveBeenCalledOnce();
+        await vi.advanceTimersByTimeAsync(5_000);
         await expect(monitorOutcome).resolves.toMatchObject({
           ok: false,
           error: { message: "Matrix transient leases did not drain within 5000ms" },


### PR DESCRIPTION
## What Problem This Solves

Recent Matrix lifecycle regression coverage spends ten real seconds waiting for two five-second transient-lease retirement deadlines, making every Matrix SDK test run unnecessarily slow.

## Why This Change Was Made

Use the same deterministic fake-timer lifecycle already exercised by neighboring Matrix shared-client and SDK shutdown tests. Both disconnected sync states, the real shared-client owner, poisoned-generation fencing, late transient release, replacement admission, and every existing assertion remain intact.

## User Impact

No production behavior changes. Contributors and CI retain identical Matrix lifecycle coverage while the scoped 145-test SDK suite runs approximately 9.80 seconds faster, a 46.4% wall-clock reduction.

## Evidence

Same Blacksmith Testbox, same main base, one worker, excluded warmup, distinct Vitest filesystem caches, import breakdown enabled, and `/usr/bin/time -v`:

| Sample | Wall | Vitest | Test body | Import | Peak RSS | CPU user/sys | Tests |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Before 1 | 21.35s | 18.10s | 11.63s | 5.71s | 1,106,976 KiB | 12.34s / 1.12s | 145 |
| Before 2 | 20.91s | 17.73s | 11.69s | 5.40s | 1,001,468 KiB | 12.21s / 1.02s | 145 |
| After 1 | 11.89s | 8.42s | 1.66s | 5.85s | 1,030,200 KiB | 12.74s / 1.33s | 145 |
| After 2 | 10.78s | 7.55s | 1.51s | 5.20s | 1,044,568 KiB | 11.56s / 1.15s | 145 |

Mean wall: 21.13s to 11.34s, saving 9.80s / 46.4%. Mean body: 11.66s to 1.59s. Imports remain comparable.

Temporarily removing the shared-client owner's final late-drain cleanup makes both preserved ERROR and RECONNECTING cases fail with `Matrix transient leases did not drain within 5000ms`; the production owner was restored byte-for-byte.

- Matrix SDK, shared-client owner, and bootstrap/caller suites: 174/174 tests passed.
- Full extension-test `check:changed` gate, targeted formatting, and `git diff --check` passed.
- Fresh independent structured autoreview: no accepted/actionable findings.
- Production LOC: +0/-0. Tests: +4/-3. No assertion, lifecycle, security, migration, or provider coverage removed.
