### PR TITLE
fix: keep active commentary visible when steering WebChat

### DIFF
--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -183,12 +183,26 @@ suite.define(() => {
       const composer = page.locator(".agent-chat__composer-combobox textarea");
       await page.locator(".chat-tool-msg-summary", { hasText: "Exec" }).waitFor();
       await page.getByRole("button", { name: "Stop generating" }).waitFor();
-      let toolSequence = 0;
+      let agentSequence = 0;
+      const commentaryText = "The active commentary stays visible.";
+      await gateway.emitGatewayEvent("agent", {
+        data: {
+          kind: "preamble",
+          itemId: "active-commentary",
+          progressText: commentaryText,
+        },
+        runId,
+        seq: ++agentSequence,
+        sessionKey: "main",
+        stream: "item",
+        ts: Date.now(),
+      });
+      await page.getByText(commentaryText, { exact: true }).waitFor();
       const emitTool = (data: Record<string, unknown>) =>
         gateway.emitGatewayEvent("agent", {
           data,
           runId,
-          seq: ++toolSequence,
+          seq: ++agentSequence,
           sessionKey: "main",
           stream: "tool",
           ts: Date.now(),
@@ -213,6 +227,7 @@ suite.define(() => {
         steerParams.idempotencyKey,
         "steer chat send idempotency key",
       );
+      await expect.poll(() => page.getByText(commentaryText, { exact: true }).count()).toBe(1);
       await gateway.resolveDeferred("chat.send", { runId: steerRunId, status: "started" });
       const steerUser = {
         __openclaw: {

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -267,7 +267,10 @@ async function sendQueuedChatMessage(
   if (isVisible()) {
     host.chatSendingScopeKey = storedChatOutboxScopeKey(scope);
     host.chatSending = true;
-    resetToolStream(host);
+    // Steers continue the current run, so its transient commentary and tools keep that ownership.
+    if (prepared.queueMode !== "steer" || !host.chatRunId) {
+      resetToolStream(host);
+    }
     resetChatScroll(host);
     setChatError(host, null);
     reconcileChatRunLifecycle(host, {

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -3908,6 +3908,10 @@ describe("handleSendChat", () => {
       chatRunId: "run-1",
       chatDisplayedLeafEntryId: "leaf-active",
       chatStream: "Working...",
+      chatStreamSegments: [{ text: "Checking the active run", ts: 1, itemId: "active-commentary" }],
+      chatToolMessages: [
+        { role: "toolResult", toolCallId: "active-tool", content: "still running" },
+      ],
       sessionKey: "agent:main:main",
       settings: { chatFollowUpMode: "steer" },
     });
@@ -3927,6 +3931,12 @@ describe("handleSendChat", () => {
     );
     expect(host.chatRunId).toBe("run-1");
     expect(host.chatStream).toBe("Working...");
+    expect(host.chatStreamSegments).toEqual([
+      { text: "Checking the active run", ts: 1, itemId: "active-commentary" },
+    ]);
+    expect(host.chatToolMessages).toEqual([
+      { role: "toolResult", toolCallId: "active-tool", content: "still running" },
+    ]);
     expect(host.chatQueue).toEqual([
       expect.objectContaining({
         queueMode: "steer",
@@ -3945,11 +3955,15 @@ describe("handleSendChat", () => {
         "chat.send": { status: "started", runId: "started-run" },
       },
       chatMessage: "start through steer mode",
+      chatStreamSegments: [{ text: "stale commentary", ts: 1, itemId: "stale" }],
+      chatToolMessages: [{ role: "toolResult", toolCallId: "stale-tool", content: "stale output" }],
     });
 
     await handleSendChat(host, undefined, { followUpMode: "steer" });
 
     expect(host.chatRunId).toBe("started-run");
+    expect(host.chatStreamSegments).toEqual([]);
+    expect(host.chatToolMessages).toEqual([]);
   });
 
   it("sends a fresh mode-bearing row ahead of older outbox reconciliation", async () => {


### PR DESCRIPTION
Fixes #126938

## What Problem This Solves

Fixes an issue where users who sent a follow-up while a WebChat run was active would see the run's commentary and tool activity disappear when the follow-up used steer mode. The active run continued, but its transient progress projection vanished until later events repopulated it.

## Why This Change Was Made

WebChat now preserves the active run's transient commentary and tool projection when a queued send steers that same run. Sends that start a fresh run, including steer-mode sends without an active run, still clear stale projection state.

## User Impact

Users can steer an active WebChat run without losing the commentary and tool progress already visible for that run.

## Evidence

Live verification used an isolated OCM gateway running this branch and its rebuilt Control UI. A real agent posted commentary, entered an active 30-second tool call, accepted a steer follow-up, and kept both the commentary and active-run controls visible after submission.

https://github.com/user-attachments/assets/fefd9799-2b6d-4bd7-a927-ec92d31c29fa

![Commentary and active-run controls remain visible after the steer follow-up](https://github.com/user-attachments/assets/239fc907-e20f-4dc6-9021-45ff4f59262c)

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts`: 274 passed
- `node scripts/run-vitest.mjs ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts`: 7 passed
- `node scripts/check-changed.mjs -- ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts ui/src/pages/chat/chat-send-delivery.ts ui/src/pages/chat/chat-send.test.ts`: passed
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`: no accepted or actionable findings

AI-assisted: yes. I reviewed the implementation, tests, and live behavior.