### PR TITLE
docs: add Perplexity Agent API provider, MCP, and CLI; Sonar turndown

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1563,6 +1563,7 @@
                   "providers/opencode",
                   "providers/opencode-go",
                   "providers/openrouter",
+                  "providers/perplexity-agent-api",
                   "providers/perplexity-provider",
                   "providers/pixverse",
                   "providers/qianfan",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1988,6 +1988,7 @@
                       "providers/openai",
                       "providers/opencode",
                       "providers/opencode-go",
+                      "providers/perplexity-agent-api",
                       "providers/perplexity-provider",
                       "providers/qianfan",
                       "providers/qwen",

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -67,6 +67,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [OpenCode](/providers/opencode)
 - [OpenCode Go](/providers/opencode-go)
 - [OpenRouter](/providers/openrouter)
+- [Perplexity Agent API (model provider)](/providers/perplexity-agent-api)
 - [Perplexity (web search)](/providers/perplexity-provider)
 - [Qianfan](/providers/qianfan)
 - [Qwen Cloud](/providers/qwen)

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -63,6 +63,8 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
     ```bash
     export CUSTOM_API_KEY="$PERPLEXITY_API_KEY"
     openclaw onboard \
+      --non-interactive \
+      --accept-risk \
       --auth-choice custom-api-key \
       --secret-input-mode ref \
       --custom-base-url "https://api.perplexity.ai/v1" \
@@ -71,6 +73,8 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
       --custom-provider-id perplexity \
       --install-daemon
     ```
+
+    `--non-interactive` tells OpenClaw to skip the setup wizard and consume the flags directly. `--accept-risk` is required alongside it (OpenClaw enforces this in `register.onboard.ts`) to acknowledge that agents have full system access. Omit either and OpenClaw routes into `runInteractiveSetup`, where the custom-provider values above are not applied.
 
     `--secret-input-mode ref` tells OpenClaw to write an environment reference to `openclaw.json` instead of the literal key. The custom-provider auth path reads the key from the `CUSTOM_API_KEY` environment variable, so the `export` above bridges Perplexity's `PERPLEXITY_API_KEY` naming to OpenClaw's expected variable name. The onboarding command then persists `apiKey: { source: "env", id: "CUSTOM_API_KEY" }` rather than the resolved secret. The daemon reads `CUSTOM_API_KEY` from its runtime environment on each request.
 

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -74,7 +74,7 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
       --install-daemon
     ```
 
-    `--non-interactive` tells OpenClaw to skip the setup wizard and consume the flags directly. `--accept-risk` is required alongside it (OpenClaw enforces this in `register.onboard.ts`) to acknowledge that agents have full system access. Omit either and OpenClaw routes into `runInteractiveSetup`, where the custom-provider values above are not applied.
+    `--non-interactive` tells OpenClaw to skip the setup wizard and consume the flags directly. `--accept-risk` is required alongside it to acknowledge that agents have full system access. If you omit `--non-interactive`, OpenClaw can enter interactive setup, where the custom-provider values above are not applied. If you keep `--non-interactive` but omit `--accept-risk`, OpenClaw exits with an explicit risk-acknowledgment error before dispatching setup.
 
     `--secret-input-mode ref` tells OpenClaw to write an environment reference to `openclaw.json` instead of the literal key. The custom-provider auth path reads the key from the `CUSTOM_API_KEY` environment variable, so the `export` above bridges Perplexity's `PERPLEXITY_API_KEY` naming to OpenClaw's expected variable name. The onboarding command then persists `apiKey: { source: "env", id: "CUSTOM_API_KEY" }` rather than the resolved secret. The daemon reads `CUSTOM_API_KEY` from its runtime environment on each request.
 

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -60,7 +60,9 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
     Create a key in the [Perplexity API console](https://console.perplexity.ai/project/keys). Keys start with `pplx-`.
   </Step>
   <Step title="Persist the credential for the Gateway service">
-    Set the Perplexity key in your current shell, then add it under the custom-provider variable name in the state-directory `.env` before installing the daemon:
+    Set the Perplexity key in your current shell, then choose the path that matches your existing custom-provider setup.
+
+    **No existing custom provider uses `CUSTOM_API_KEY`:** add the key under the custom-provider variable name in the state-directory `.env` before installing the daemon:
 
     ```bash
     export PERPLEXITY_API_KEY="pplx-..."
@@ -72,9 +74,24 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
     export CUSTOM_API_KEY="$PERPLEXITY_API_KEY"
     ```
 
-    If `CUSTOM_API_KEY` is already present in that file, replace its line instead of adding another one. The state-directory `.env` is a trusted, durable environment source for installed Gateway services; a shell export alone disappears when that shell exits. See [Environment variables](/help/environment) for the full loading and precedence rules.
+    Use this path only when `CUSTOM_API_KEY` is not already assigned in your shell or state-directory `.env`. If it is already present, do not replace it: non-interactive custom-provider onboarding uses that same variable for every custom provider.
+
+    **An existing custom provider already uses `CUSTOM_API_KEY`:** preserve that value and add or update a separate `PERPLEXITY_API_KEY` line in the state-directory `.env`:
+
+    ```bash
+    export PERPLEXITY_API_KEY="pplx-..."
+    state_dir="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+    umask 077
+    mkdir -p "$state_dir"
+    printf 'PERPLEXITY_API_KEY=%s\n' "$PERPLEXITY_API_KEY" >> "$state_dir/.env"
+    chmod 600 "$state_dir/.env"
+    ```
+
+    The state-directory `.env` is a trusted, durable environment source for installed Gateway services; a shell export alone disappears when that shell exits. See [Environment variables](/help/environment) for the full loading and precedence rules.
   </Step>
   <Step title="Run onboarding">
+    If `CUSTOM_API_KEY` was unused and you chose the first credential path above, run:
+
     ```bash
     openclaw onboard \
       --non-interactive \
@@ -88,9 +105,32 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
       --install-daemon
     ```
 
+    If another custom provider already uses `CUSTOM_API_KEY`, keep that shared value unchanged. Mask it only for the onboarding process, write a provider-specific SecretRef for Perplexity, and install the daemon after the reference is in place:
+
+    ```bash
+    CUSTOM_API_KEY= openclaw onboard \
+      --non-interactive \
+      --accept-risk \
+      --auth-choice custom-api-key \
+      --secret-input-mode ref \
+      --custom-base-url "https://api.perplexity.ai/v1" \
+      --custom-model-id "anthropic/claude-sonnet-4-6" \
+      --custom-compatibility openai-responses \
+      --custom-provider-id perplexity
+
+    openclaw config set models.providers.perplexity.apiKey \
+      --ref-source env \
+      --ref-provider default \
+      --ref-id PERPLEXITY_API_KEY
+
+    openclaw gateway install
+    ```
+
+    If your environment SecretRef provider alias is not `default`, pass that alias to `--ref-provider` instead. Prefixing only the onboarding command with `CUSTOM_API_KEY=` prevents the CLI from binding Perplexity to the existing shared credential; it does not change the shell or state-directory value.
+
     `--non-interactive` tells OpenClaw to skip the setup wizard and consume the flags directly. `--accept-risk` is required alongside it to acknowledge that agents have full system access. If you omit `--non-interactive`, OpenClaw can enter interactive setup, where the custom-provider values above are not applied. If you keep `--non-interactive` but omit `--accept-risk`, OpenClaw exits with an explicit risk-acknowledgment error before dispatching setup.
 
-    `--secret-input-mode ref` tells OpenClaw to write an environment reference to `openclaw.json` instead of the literal key. The custom-provider auth path reads the key from the `CUSTOM_API_KEY` environment variable, so the previous step bridges Perplexity's `PERPLEXITY_API_KEY` naming to OpenClaw's expected variable name in both the current shell and the durable Gateway environment. The onboarding command then persists `apiKey: { source: "env", id: "CUSTOM_API_KEY" }` rather than the resolved secret. The daemon reads `CUSTOM_API_KEY` from its runtime environment on each request.
+    `--secret-input-mode ref` tells OpenClaw to write an environment reference to `openclaw.json` instead of the literal key. On a default secrets setup, the first path persists `apiKey: { source: "env", provider: "default", id: "CUSTOM_API_KEY" }`; when an environment SecretRef provider alias is configured, `provider` contains that resolved alias instead. The daemon reads the referenced variable from its runtime environment on each request. The existing-custom-provider path replaces the onboarding result with the complete, provider-specific `{ source: "env", provider: "<env-provider-alias>", id: "PERPLEXITY_API_KEY" }` reference before installing the daemon; the command above uses the built-in `default` alias.
 
     `--custom-compatibility openai-responses` is required. Perplexity's Agent API primary endpoint is `POST /v1/agent`; it also accepts requests at `POST /v1/responses` as an OpenAI-Responses-compatible alias, which is what OpenClaw uses in this mode. It does not implement `/v1/chat/completions`, so `openai-completions` will not work.
   </Step>
@@ -131,7 +171,11 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
     providers: {
       perplexity: {
         baseUrl: "https://api.perplexity.ai/v1",
-        apiKey: "${CUSTOM_API_KEY}",
+        apiKey: {
+          source: "env",
+          provider: "default",
+          id: "CUSTOM_API_KEY",
+        },
         api: "openai-responses",
         models: [
           {
@@ -152,6 +196,8 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
 ```
 
 Each `models[]` entry pins one Agent API model with explicit cost and window metadata. Add another entry for every model you want to route through this provider.
+
+The example shows the SecretRef produced by the fresh custom-provider path. If `CUSTOM_API_KEY` already belongs to another provider, use the existing-custom-provider path above; the same field then references `PERPLEXITY_API_KEY` instead.
 
 Model IDs under the provider block omit the provider prefix. The full model reference adds it: config ID `anthropic/claude-sonnet-4-6`, full ref `perplexity/anthropic/claude-sonnet-4-6`.
 

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -61,15 +61,18 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
   </Step>
   <Step title="Run onboarding">
     ```bash
+    export CUSTOM_API_KEY="$PERPLEXITY_API_KEY"
     openclaw onboard \
       --auth-choice custom-api-key \
+      --secret-input-mode ref \
       --custom-base-url "https://api.perplexity.ai/v1" \
-      --custom-api-key "$PERPLEXITY_API_KEY" \
       --custom-model-id "anthropic/claude-sonnet-4-6" \
       --custom-compatibility openai-responses \
       --custom-provider-id perplexity \
       --install-daemon
     ```
+
+    `--secret-input-mode ref` tells OpenClaw to write an environment reference to `openclaw.json` instead of the literal key. The custom-provider auth path reads the key from the `CUSTOM_API_KEY` environment variable, so the `export` above bridges Perplexity's `PERPLEXITY_API_KEY` naming to OpenClaw's expected variable name. The onboarding command then persists `apiKey: { source: "env", id: "CUSTOM_API_KEY" }` rather than the resolved secret. The daemon reads `CUSTOM_API_KEY` from its runtime environment on each request.
 
     `--custom-compatibility openai-responses` is required. Perplexity's Agent API primary endpoint is `POST /v1/agent`; it also accepts requests at `POST /v1/responses` as an OpenAI-Responses-compatible alias, which is what OpenClaw uses in this mode. It does not implement `/v1/chat/completions`, so `openai-completions` will not work.
   </Step>

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -92,7 +92,7 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
     See [Required configuration](#required-configuration) above for context and [Reserved tool names](#reserved-tool-names) for the full list.
   </Step>
   <Step title="Add the models you need">
-    Onboarding wires up one model. To make additional Agent API models available, add explicit entries under `agents.defaults.models`. See [Config example](#config-example) below for a working set. The full model list, current pricing, and per-model context windows are published at [docs.perplexity.ai/docs/getting-started/models](https://docs.perplexity.ai/docs/getting-started/models).
+    Onboarding wires up one model. To make additional Agent API models available, add explicit entries under `models.providers.perplexity.models[]`. `agents.defaults.models` is for aliases and per-model settings on already-registered models, not for registering new ones. See [Config example](#config-example) below for a working entry shape. The full model list, current pricing, and per-model context windows are published at [docs.perplexity.ai/docs/getting-started/models](https://docs.perplexity.ai/docs/getting-started/models).
   </Step>
 </Steps>
 

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -40,7 +40,7 @@ Perplexity's Agent API runs its own server-side built-in tools. To use it as an 
 `tools.web.search.enabled: false` is a Gateway-wide setting. It disables the managed `web_search` tool for every agent on this Gateway, not just for the agent using Perplexity's Agent API. If other agents on the same Gateway rely on managed `web_search`, scope the disable per-agent with `agents.entries.<name>.tools.deny: ["web_search"]` on the Perplexity agent instead, or run Perplexity's Agent API on a separate Gateway profile.
 </Warning>
 
-Perplexity's server-side `web_search` runs from inside the model's response at $0.0025 per call and returns grounded results with citations. To force it on for a specific request, add `{ type: "web_search" }` to that request's `tools` array as a built-in tool rather than a function.
+Perplexity's server-side `web_search` runs from inside the model's response at $0.0025 per call and returns grounded results with citations.
 
 ### Reserved tool names
 

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -131,7 +131,7 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
     providers: {
       perplexity: {
         baseUrl: "https://api.perplexity.ai/v1",
-        apiKey: "${PERPLEXITY_API_KEY}",
+        apiKey: "${CUSTOM_API_KEY}",
         api: "openai-responses",
         models: [
           {

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -59,9 +59,23 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
   <Step title="Get an API key">
     Create a key in the [Perplexity API console](https://console.perplexity.ai/project/keys). Keys start with `pplx-`.
   </Step>
+  <Step title="Persist the credential for the Gateway service">
+    Set the Perplexity key in your current shell, then add it under the custom-provider variable name in the state-directory `.env` before installing the daemon:
+
+    ```bash
+    export PERPLEXITY_API_KEY="pplx-..."
+    state_dir="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
+    umask 077
+    mkdir -p "$state_dir"
+    printf 'CUSTOM_API_KEY=%s\n' "$PERPLEXITY_API_KEY" >> "$state_dir/.env"
+    chmod 600 "$state_dir/.env"
+    export CUSTOM_API_KEY="$PERPLEXITY_API_KEY"
+    ```
+
+    If `CUSTOM_API_KEY` is already present in that file, replace its line instead of adding another one. The state-directory `.env` is a trusted, durable environment source for installed Gateway services; a shell export alone disappears when that shell exits. See [Environment variables](/help/environment) for the full loading and precedence rules.
+  </Step>
   <Step title="Run onboarding">
     ```bash
-    export CUSTOM_API_KEY="$PERPLEXITY_API_KEY"
     openclaw onboard \
       --non-interactive \
       --accept-risk \
@@ -76,7 +90,7 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
 
     `--non-interactive` tells OpenClaw to skip the setup wizard and consume the flags directly. `--accept-risk` is required alongside it to acknowledge that agents have full system access. If you omit `--non-interactive`, OpenClaw can enter interactive setup, where the custom-provider values above are not applied. If you keep `--non-interactive` but omit `--accept-risk`, OpenClaw exits with an explicit risk-acknowledgment error before dispatching setup.
 
-    `--secret-input-mode ref` tells OpenClaw to write an environment reference to `openclaw.json` instead of the literal key. The custom-provider auth path reads the key from the `CUSTOM_API_KEY` environment variable, so the `export` above bridges Perplexity's `PERPLEXITY_API_KEY` naming to OpenClaw's expected variable name. The onboarding command then persists `apiKey: { source: "env", id: "CUSTOM_API_KEY" }` rather than the resolved secret. The daemon reads `CUSTOM_API_KEY` from its runtime environment on each request.
+    `--secret-input-mode ref` tells OpenClaw to write an environment reference to `openclaw.json` instead of the literal key. The custom-provider auth path reads the key from the `CUSTOM_API_KEY` environment variable, so the previous step bridges Perplexity's `PERPLEXITY_API_KEY` naming to OpenClaw's expected variable name in both the current shell and the durable Gateway environment. The onboarding command then persists `apiKey: { source: "env", id: "CUSTOM_API_KEY" }` rather than the resolved secret. The daemon reads `CUSTOM_API_KEY` from its runtime environment on each request.
 
     `--custom-compatibility openai-responses` is required. Perplexity's Agent API primary endpoint is `POST /v1/agent`; it also accepts requests at `POST /v1/responses` as an OpenAI-Responses-compatible alias, which is what OpenClaw uses in this mode. It does not implement `/v1/chat/completions`, so `openai-completions` will not work.
   </Step>

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -36,6 +36,10 @@ Perplexity's Agent API runs its own server-side built-in tools. To use it as an 
 }
 ```
 
+<Warning>
+`tools.web.search.enabled: false` is a Gateway-wide setting. It disables the managed `web_search` tool for every agent on this Gateway, not just for the agent using Perplexity's Agent API. If other agents on the same Gateway rely on managed `web_search`, scope the disable per-agent with `agents.entries.<name>.tools.deny: ["web_search"]` on the Perplexity agent instead, or run Perplexity's Agent API on a separate Gateway profile.
+</Warning>
+
 Perplexity's server-side `web_search` runs from inside the model's response at $0.0025 per call and returns grounded results with citations. To force it on for a specific request, add `{ type: "web_search" }` to that request's `tools` array as a built-in tool rather than a function.
 
 ### Reserved tool names

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -140,70 +140,9 @@ For the full list of available models and current pricing, see the [Agent API mo
 
 Perplexity also ships an [MCP server](https://docs.perplexity.ai/docs/getting-started/integrations/mcp-server) that exposes `perplexity_search`, `perplexity_ask`, `perplexity_research`, and `perplexity_reason` as MCP tools your agent can call. This is orthogonal to the model provider setup above: the Agent API drives the model, MCP gives the model access to Perplexity's search and research surfaces. You can run both together.
 
-The MCP tool names do not overlap with Perplexity's Agent API reserved tool names, so no additional configuration is required for MCP.
+The MCP tool names do not overlap with Perplexity's Agent API reserved tool names, so no additional configuration is required.
 
-<Tabs>
-  <Tab title="Remote (Streamable HTTP)">
-    ```bash
-    openclaw mcp add perplexity \
-      --url https://api.perplexity.ai/mcp \
-      --transport streamable-http \
-      --header "Authorization=Bearer $PERPLEXITY_API_KEY"
-    openclaw mcp doctor perplexity --probe
-    ```
-
-    Or write directly to `openclaw.json`:
-
-    ```json5
-    {
-      mcp: {
-        servers: {
-          perplexity: {
-            url: "https://api.perplexity.ai/mcp",
-            transport: "streamable-http",
-            headers: {
-              Authorization: "Bearer ${PERPLEXITY_API_KEY}",
-            },
-          },
-        },
-      },
-    }
-    ```
-  </Tab>
-  <Tab title="Local (stdio)">
-    ```bash
-    openclaw mcp add perplexity \
-      --command npx \
-      --arg "-y" \
-      --arg "@perplexity-ai/mcp-server" \
-      --env "PERPLEXITY_API_KEY=$PERPLEXITY_API_KEY"
-    openclaw mcp doctor perplexity --probe
-    ```
-
-    Or in config:
-
-    ```json5
-    {
-      mcp: {
-        servers: {
-          perplexity: {
-            command: "npx",
-            args: ["-y", "@perplexity-ai/mcp-server"],
-            transport: "stdio",
-            env: {
-              PERPLEXITY_API_KEY: "${PERPLEXITY_API_KEY}",
-            },
-          },
-        },
-      },
-    }
-    ```
-
-    Local stdio requires Node.js on the machine running OpenClaw. Prefer the remote transport unless you need to run offline of Perplexity's edge.
-  </Tab>
-</Tabs>
-
-MCP tools follow OpenClaw's normal tool policy. To limit which Perplexity tools your agent can call, use `toolFilter.include` on the server definition or pass `--include` to `openclaw mcp add`. See [Connect MCP servers](/tools/mcp) for the full field list.
+To register the Perplexity MCP server, follow OpenClaw's standard [Connect MCP servers](/tools/mcp) guide and use the endpoint and credentials from the [Perplexity MCP server docs](https://docs.perplexity.ai/docs/getting-started/integrations/mcp-server). The generic guide covers both remote (Streamable HTTP) and local (stdio) transports, and its config patterns keep your API key out of `openclaw.json`.
 
 ## Perplexity CLI (terminal companion)
 

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -1,0 +1,285 @@
+---
+summary: "Use Perplexity's Agent API as a custom LLM provider in OpenClaw (Claude, GPT, Gemini, Grok via one key)"
+title: "Perplexity Agent API"
+read_when:
+  - You want to run Anthropic, OpenAI, Google, or xAI models through Perplexity's Agent API as an OpenClaw model provider
+  - You want to connect Perplexity's Model Context Protocol server to OpenClaw
+  - You need the required OpenClaw configuration for Perplexity's Agent API
+---
+
+Perplexity's [Agent API](https://docs.perplexity.ai/docs/agent-api/quickstart) exposes frontier models from Anthropic, OpenAI, Google, xAI, and others through a single OpenAI-Responses-compatible endpoint. OpenClaw can consume Perplexity three ways: as a model provider, as an MCP tool provider, and as a terminal companion for shell and script use.
+
+<Note>
+This page covers Perplexity as a **model provider** and as an **MCP server**. For Perplexity as OpenClaw's **web search provider** (managed by the `@openclaw/perplexity-plugin` package), see [Perplexity](/providers/perplexity-provider).
+</Note>
+
+| Property     | Value                                                                    |
+| ------------ | ------------------------------------------------------------------------ |
+| Type         | Model provider (custom OpenAI-Responses backend)                         |
+| API          | `openai-responses`                                                       |
+| Base URL     | `https://api.perplexity.ai/v1`                                           |
+| Auth         | `PERPLEXITY_API_KEY` (Perplexity API key, prefix `pplx-`)                |
+| Get a key    | [console.perplexity.ai](https://console.perplexity.ai/project/keys)      |
+| Provider ID  | `perplexity` (recommended; passed via `--custom-provider-id`)            |
+
+## Required configuration
+
+Perplexity's Agent API runs its own server-side built-in tools. To use it as an OpenClaw model provider, disable OpenClaw's managed `web_search` tool so the model uses Perplexity's built-in search instead:
+
+```json5
+{
+  tools: {
+    web: {
+      search: { enabled: false },
+    },
+  },
+}
+```
+
+Perplexity's server-side `web_search` runs from inside the model's response at $0.0025 per call and returns grounded results with citations. To force it on for a specific request, add `{ type: "web_search" }` to that request's `tools` array as a built-in tool rather than a function.
+
+### Reserved tool names
+
+Perplexity's Agent API reserves these function names for its own server-side built-in tools; do not define custom functions with these names:
+
+- `web_search`
+- `fetch_url`
+- `people_search`
+- `finance_search`
+
+See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/getting-started/integrations/openclaw) for the authoritative reference.
+
+## Getting started
+
+<Steps>
+  <Step title="Get an API key">
+    Create a key in the [Perplexity API console](https://console.perplexity.ai/project/keys). Keys start with `pplx-`.
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard \
+      --auth-choice custom-api-key \
+      --custom-base-url "https://api.perplexity.ai/v1" \
+      --custom-api-key "$PERPLEXITY_API_KEY" \
+      --custom-model-id "anthropic/claude-sonnet-4-6" \
+      --custom-compatibility openai-responses \
+      --custom-provider-id perplexity \
+      --install-daemon
+    ```
+
+    `--custom-compatibility openai-responses` is required. Perplexity's Agent API primary endpoint is `POST /v1/agent`; it also accepts requests at `POST /v1/responses` as an OpenAI-Responses-compatible alias, which is what OpenClaw uses in this mode. It does not implement `/v1/chat/completions`, so `openai-completions` will not work.
+  </Step>
+  <Step title="Apply the required configuration">
+    Edit `openclaw.json` (run `openclaw config file` to locate it) and add:
+
+    ```json5
+    {
+      tools: {
+        web: {
+          search: { enabled: false },
+        },
+      },
+    }
+    ```
+
+    See [Required configuration](#required-configuration) above for context and [Reserved tool names](#reserved-tool-names) for the full list.
+  </Step>
+  <Step title="Discover the rest of the catalog">
+    Onboarding wires up one model. To make every Agent API model available through this provider, add a wildcard entry under `agents.defaults.models`:
+
+    ```json5
+    {
+      agents: {
+        defaults: {
+          models: { "perplexity/*": {} },
+        },
+      },
+    }
+    ```
+
+    OpenClaw will then call `GET https://api.perplexity.ai/v1/models` and register the full catalog. Confirm with:
+
+    ```bash
+    openclaw models list --provider perplexity
+    ```
+  </Step>
+</Steps>
+
+## Config example
+
+```json5
+{
+  agents: {
+    defaults: {
+      model: { primary: "perplexity/anthropic/claude-sonnet-4-6" },
+      models: { "perplexity/*": {} },
+    },
+  },
+  tools: {
+    web: { search: { enabled: false } },
+  },
+  models: {
+    mode: "merge",
+    providers: {
+      perplexity: {
+        baseUrl: "https://api.perplexity.ai/v1",
+        apiKey: "${PERPLEXITY_API_KEY}",
+        api: "openai-responses",
+        models: [
+          {
+            id: "anthropic/claude-sonnet-4-6",
+            name: "Claude Sonnet 4.6 (Perplexity)",
+            api: "openai-responses",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 0 },
+            contextWindow: 200000,
+            maxTokens: 16384,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+The single `models[]` entry pins Claude Sonnet 4.6 with explicit cost and window metadata. The `perplexity/*` wildcard covers every other model returned by `GET /v1/models`, so you do not need to hand-maintain a full catalog here. Add another `models[]` entry only when you want to pin custom metadata for a specific model.
+
+Model IDs under the provider block omit the provider prefix. The full model reference adds it: config ID `anthropic/claude-sonnet-4-6`, full ref `perplexity/anthropic/claude-sonnet-4-6`.
+
+For the full list of available models and current pricing, see the [Agent API models page](https://docs.perplexity.ai/docs/agent-api/models).
+
+## Perplexity as an MCP server
+
+Perplexity also ships an [MCP server](https://docs.perplexity.ai/docs/getting-started/integrations/mcp-server) that exposes `perplexity_search`, `perplexity_ask`, `perplexity_research`, and `perplexity_reason` as MCP tools your agent can call. This is orthogonal to the model provider setup above: the Agent API drives the model, MCP gives the model access to Perplexity's search and research surfaces. You can run both together.
+
+The MCP tool names do not overlap with Perplexity's Agent API reserved tool names, so no additional configuration is required for MCP.
+
+<Tabs>
+  <Tab title="Remote (Streamable HTTP)">
+    ```bash
+    openclaw mcp add perplexity \
+      --url https://api.perplexity.ai/mcp \
+      --transport streamable-http \
+      --header "Authorization=Bearer $PERPLEXITY_API_KEY"
+    openclaw mcp doctor perplexity --probe
+    ```
+
+    Or write directly to `openclaw.json`:
+
+    ```json5
+    {
+      mcp: {
+        servers: {
+          perplexity: {
+            url: "https://api.perplexity.ai/mcp",
+            transport: "streamable-http",
+            headers: {
+              Authorization: "Bearer ${PERPLEXITY_API_KEY}",
+            },
+          },
+        },
+      },
+    }
+    ```
+  </Tab>
+  <Tab title="Local (stdio)">
+    ```bash
+    openclaw mcp add perplexity \
+      --command npx \
+      --arg "-y" \
+      --arg "@perplexity-ai/mcp-server" \
+      --env "PERPLEXITY_API_KEY=$PERPLEXITY_API_KEY"
+    openclaw mcp doctor perplexity --probe
+    ```
+
+    Or in config:
+
+    ```json5
+    {
+      mcp: {
+        servers: {
+          perplexity: {
+            command: "npx",
+            args: ["-y", "@perplexity-ai/mcp-server"],
+            transport: "stdio",
+            env: {
+              PERPLEXITY_API_KEY: "${PERPLEXITY_API_KEY}",
+            },
+          },
+        },
+      },
+    }
+    ```
+
+    Local stdio requires Node.js on the machine running OpenClaw. Prefer the remote transport unless you need to run offline of Perplexity's edge.
+  </Tab>
+</Tabs>
+
+MCP tools follow OpenClaw's normal tool policy. To limit which Perplexity tools your agent can call, use `toolFilter.include` on the server definition or pass `--include` to `openclaw mcp add`. See [Connect MCP servers](/tools/mcp) for the full field list.
+
+## Perplexity CLI (terminal companion)
+
+Perplexity also publishes a [terminal CLI](https://docs.perplexity.ai/docs/cli/overview) (`pplx`) that returns JSON from the Search API. It is a third integration path: not an LLM provider and not an MCP server, but useful when an OpenClaw agent needs to shell out for a web search, or when a developer wants to pipe Perplexity results into other shell tools.
+
+```bash
+curl -fsSL https://github.com/perplexityai/perplexity-cli/releases/latest/download/install.sh | sh
+export PERPLEXITY_API_KEY=pplx-...
+pplx search web "kubernetes pod OOMKilled causes" -n 5
+pplx content snippets "how does a bloom filter decide set membership" \
+  https://en.wikipedia.org/wiki/Bloom_filter
+```
+
+Because the CLI is invoked from a shell, agents running under OpenClaw's `exec` tool can call it directly. Nothing needs to change in `openclaw.json`.
+
+## Configuration notes
+
+<AccordionGroup>
+  <Accordion title="API transport must be openai-responses">
+    Set `api: "openai-responses"` at both the provider level and each model entry, or pass `--custom-compatibility openai-responses` during onboarding. Perplexity's Agent API primary endpoint is `POST /v1/agent`, and `POST /v1/responses` is its OpenAI-Responses-compatible alias; the `openai-responses` transport sends to that alias. The Agent API does not implement `/v1/chat/completions`, so `openai-completions` will not work.
+  </Accordion>
+
+  <Accordion title="Base URL must be exactly https://api.perplexity.ai/v1">
+    Perplexity's Agent API primary endpoint is `POST /v1/agent`, and `POST /v1/responses` is its OpenAI-Responses-compatible alias. OpenClaw's `openai-responses` client sends to whatever base URL you give it with `/responses` appended, so the base URL must be `https://api.perplexity.ai/v1` for OpenClaw to hit the alias at `/v1/responses`.
+
+    | Correct base URL | Do not use as a base URL |
+    | ---------------- | ------------------------ |
+    | `https://api.perplexity.ai/v1` | `https://api.perplexity.ai/v1/agent` (OpenClaw would call `/v1/agent/responses` and get `405 Method Not Allowed`) |
+    | | `https://api.perplexity.ai/v1/responses` (OpenClaw would call `/v1/responses/responses` and get `404`) |
+    | | `https://api.perplexity.ai` (missing `/v1`; requests hit `/responses` and get `404`) |
+  </Accordion>
+
+  <Accordion title="Model ID format">
+    In the config, model IDs under a provider block omit the provider prefix. The full model reference adds it:
+
+    - Config model ID: `anthropic/claude-sonnet-4-6`
+    - Full model reference: `perplexity/anthropic/claude-sonnet-4-6`
+  </Accordion>
+
+  <Accordion title="Live model discovery with the perplexity/* wildcard">
+    Adding `"perplexity/*": {}` under `agents.defaults.models` tells OpenClaw to call `GET https://api.perplexity.ai/v1/models` and register every returned model. Pinned entries under `models.providers.perplexity.models` win; anything you do not pin falls through to live discovery. Verify with `openclaw models list --provider perplexity`.
+  </Accordion>
+</AccordionGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Perplexity web search provider" href="/providers/perplexity-provider" icon="magnifying-glass">
+    Perplexity as OpenClaw's `web_search` backend (separate from this model provider setup).
+  </Card>
+  <Card title="Connect MCP servers" href="/tools/mcp" icon="plug">
+    Full field list and troubleshooting for `mcp.servers` entries.
+  </Card>
+  <Card title="Perplexity integration docs" href="https://docs.perplexity.ai/docs/getting-started/integrations/openclaw" icon="book">
+    Perplexity's authoritative OpenClaw integration guide.
+  </Card>
+  <Card title="Perplexity MCP server" href="https://docs.perplexity.ai/docs/getting-started/integrations/mcp-server" icon="server">
+    Remote and local MCP server setup and tool catalog.
+  </Card>
+  <Card title="Perplexity CLI" href="https://docs.perplexity.ai/docs/cli/overview" icon="terminal">
+    Terminal companion for Perplexity search and page snippets.
+  </Card>
+  <Card title="Agent API models" href="https://docs.perplexity.ai/docs/agent-api/models" icon="list">
+    Full Agent API model catalog and pricing.
+  </Card>
+</CardGroup>

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -84,24 +84,8 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
 
     See [Required configuration](#required-configuration) above for context and [Reserved tool names](#reserved-tool-names) for the full list.
   </Step>
-  <Step title="Discover the rest of the catalog">
-    Onboarding wires up one model. To make every Agent API model available through this provider, add a wildcard entry under `agents.defaults.models`:
-
-    ```json5
-    {
-      agents: {
-        defaults: {
-          models: { "perplexity/*": {} },
-        },
-      },
-    }
-    ```
-
-    OpenClaw will then call `GET https://api.perplexity.ai/v1/models` and register the full catalog. Confirm with:
-
-    ```bash
-    openclaw models list --provider perplexity
-    ```
+  <Step title="Add the models you need">
+    Onboarding wires up one model. To make additional Agent API models available, add explicit entries under `agents.defaults.models`. See [Config example](#config-example) below for a working set. The full model list, current pricing, and per-model context windows are published at [docs.perplexity.ai/docs/getting-started/models](https://docs.perplexity.ai/docs/getting-started/models).
   </Step>
 </Steps>
 
@@ -112,7 +96,6 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
   agents: {
     defaults: {
       model: { primary: "perplexity/anthropic/claude-sonnet-4-6" },
-      models: { "perplexity/*": {} },
     },
   },
   tools: {
@@ -143,7 +126,7 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
 }
 ```
 
-The single `models[]` entry pins Claude Sonnet 4.6 with explicit cost and window metadata. The `perplexity/*` wildcard covers every other model returned by `GET /v1/models`, so you do not need to hand-maintain a full catalog here. Add another `models[]` entry only when you want to pin custom metadata for a specific model.
+Each `models[]` entry pins one Agent API model with explicit cost and window metadata. Add another entry for every model you want to route through this provider.
 
 Model IDs under the provider block omit the provider prefix. The full model reference adds it: config ID `anthropic/claude-sonnet-4-6`, full ref `perplexity/anthropic/claude-sonnet-4-6`.
 
@@ -222,8 +205,9 @@ MCP tools follow OpenClaw's normal tool policy. To limit which Perplexity tools 
 
 Perplexity also publishes a [terminal CLI](https://docs.perplexity.ai/docs/cli/overview) (`pplx`) that returns JSON from the Search API. It is a third integration path: not an LLM provider and not an MCP server, but useful when an OpenClaw agent needs to shell out for a web search, or when a developer wants to pipe Perplexity results into other shell tools.
 
+Install the CLI by following the official instructions at [docs.perplexity.ai/docs/cli/overview](https://docs.perplexity.ai/docs/cli/overview), which cover versioned Homebrew, npm, and release-binary paths.
+
 ```bash
-curl -fsSL https://github.com/perplexityai/perplexity-cli/releases/latest/download/install.sh | sh
 export PERPLEXITY_API_KEY=pplx-...
 pplx search web "kubernetes pod OOMKilled causes" -n 5
 pplx content snippets "how does a bloom filter decide set membership" \
@@ -256,9 +240,6 @@ Because the CLI is invoked from a shell, agents running under OpenClaw's `exec` 
     - Full model reference: `perplexity/anthropic/claude-sonnet-4-6`
   </Accordion>
 
-  <Accordion title="Live model discovery with the perplexity/* wildcard">
-    Adding `"perplexity/*": {}` under `agents.defaults.models` tells OpenClaw to call `GET https://api.perplexity.ai/v1/models` and register every returned model. Pinned entries under `models.providers.perplexity.models` win; anything you do not pin falls through to live discovery. Verify with `openclaw models list --provider perplexity`.
-  </Accordion>
 </AccordionGroup>
 
 ## Related

--- a/docs/providers/perplexity-agent-api.md
+++ b/docs/providers/perplexity-agent-api.md
@@ -13,14 +13,14 @@ Perplexity's [Agent API](https://docs.perplexity.ai/docs/agent-api/quickstart) e
 This page covers Perplexity as a **model provider** and as an **MCP server**. For Perplexity as OpenClaw's **web search provider** (managed by the `@openclaw/perplexity-plugin` package), see [Perplexity](/providers/perplexity-provider).
 </Note>
 
-| Property     | Value                                                                    |
-| ------------ | ------------------------------------------------------------------------ |
-| Type         | Model provider (custom OpenAI-Responses backend)                         |
-| API          | `openai-responses`                                                       |
-| Base URL     | `https://api.perplexity.ai/v1`                                           |
-| Auth         | `PERPLEXITY_API_KEY` (Perplexity API key, prefix `pplx-`)                |
-| Get a key    | [console.perplexity.ai](https://console.perplexity.ai/project/keys)      |
-| Provider ID  | `perplexity` (recommended; passed via `--custom-provider-id`)            |
+| Property    | Value                                                               |
+| ----------- | ------------------------------------------------------------------- |
+| Type        | Model provider (custom OpenAI-Responses backend)                    |
+| API         | `openai-responses`                                                  |
+| Base URL    | `https://api.perplexity.ai/v1`                                      |
+| Auth        | `PERPLEXITY_API_KEY` (Perplexity API key, prefix `pplx-`)           |
+| Get a key   | [console.perplexity.ai](https://console.perplexity.ai/project/keys) |
+| Provider ID | `perplexity` (recommended; passed via `--custom-provider-id`)       |
 
 ## Required configuration
 
@@ -88,6 +88,7 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
     ```
 
     The state-directory `.env` is a trusted, durable environment source for installed Gateway services; a shell export alone disappears when that shell exits. See [Environment variables](/help/environment) for the full loading and precedence rules.
+
   </Step>
   <Step title="Run onboarding">
     If `CUSTOM_API_KEY` was unused and you chose the first credential path above, run:
@@ -133,6 +134,7 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
     `--secret-input-mode ref` tells OpenClaw to write an environment reference to `openclaw.json` instead of the literal key. On a default secrets setup, the first path persists `apiKey: { source: "env", provider: "default", id: "CUSTOM_API_KEY" }`; when an environment SecretRef provider alias is configured, `provider` contains that resolved alias instead. The daemon reads the referenced variable from its runtime environment on each request. The existing-custom-provider path replaces the onboarding result with the complete, provider-specific `{ source: "env", provider: "<env-provider-alias>", id: "PERPLEXITY_API_KEY" }` reference before installing the daemon; the command above uses the built-in `default` alias.
 
     `--custom-compatibility openai-responses` is required. Perplexity's Agent API primary endpoint is `POST /v1/agent`; it also accepts requests at `POST /v1/responses` as an OpenAI-Responses-compatible alias, which is what OpenClaw uses in this mode. It does not implement `/v1/chat/completions`, so `openai-completions` will not work.
+
   </Step>
   <Step title="Apply the required configuration">
     Edit `openclaw.json` (run `openclaw config file` to locate it) and add:
@@ -148,6 +150,7 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
     ```
 
     See [Required configuration](#required-configuration) above for context and [Reserved tool names](#reserved-tool-names) for the full list.
+
   </Step>
   <Step title="Add the models you need">
     Onboarding wires up one model. To make additional Agent API models available, add explicit entries under `models.providers.perplexity.models[]`. `agents.defaults.models` is for aliases and per-model settings on already-registered models, not for registering new ones. See [Config example](#config-example) below for a working entry shape. The full model list, current pricing, and per-model context windows are published at [docs.perplexity.ai/docs/getting-started/models](https://docs.perplexity.ai/docs/getting-started/models).
@@ -184,7 +187,7 @@ See Perplexity's [OpenClaw integration guide](https://docs.perplexity.ai/docs/ge
             api: "openai-responses",
             reasoning: false,
             input: ["text"],
-            cost: { input: 3.00, output: 15.00, cacheRead: 0.30, cacheWrite: 0 },
+            cost: { input: 3.0, output: 15.0, cacheRead: 0.3, cacheWrite: 0 },
             contextWindow: 200000,
             maxTokens: 16384,
           },
@@ -241,6 +244,7 @@ Because the CLI is invoked from a shell, agents running under OpenClaw's `exec` 
     | `https://api.perplexity.ai/v1` | `https://api.perplexity.ai/v1/agent` (OpenClaw would call `/v1/agent/responses` and get `405 Method Not Allowed`) |
     | | `https://api.perplexity.ai/v1/responses` (OpenClaw would call `/v1/responses/responses` and get `404`) |
     | | `https://api.perplexity.ai` (missing `/v1`; requests hit `/responses` and get `404`) |
+
   </Accordion>
 
   <Accordion title="Model ID format">
@@ -248,6 +252,7 @@ Because the CLI is invoked from a shell, agents running under OpenClaw's `exec` 
 
     - Config model ID: `anthropic/claude-sonnet-4-6`
     - Full model reference: `perplexity/anthropic/claude-sonnet-4-6`
+
   </Accordion>
 
 </AccordionGroup>

--- a/docs/providers/perplexity-provider.md
+++ b/docs/providers/perplexity-provider.md
@@ -1,27 +1,23 @@
 ---
-summary: "Perplexity web search provider setup (API key, search modes, filtering)"
+summary: "Perplexity web search provider setup (API key, filters)"
 title: "Perplexity"
 read_when:
   - You want to configure Perplexity as a web search provider
-  - You need the Perplexity API key or OpenRouter proxy setup
+  - You need the Perplexity API key setup
 ---
 
-The Perplexity plugin registers a `web_search` provider with two transports: the
-native Perplexity Search API (structured results with filters) and Perplexity
-Sonar chat completions, direct or via OpenRouter (AI-synthesized answers with
-citations).
+The Perplexity plugin registers a `web_search` provider backed by the Perplexity Search API, which returns structured results with `title`, `url`, and `snippet` fields.
 
 <Note>
-This page covers the Perplexity **provider** setup. For the Perplexity **tool** (how the agent uses it), see [Perplexity search](/tools/perplexity-search).
+This page covers the Perplexity **web search provider**. For the Perplexity **tool** (how the agent uses it), see [Perplexity search](/tools/perplexity-search). To use Perplexity's **Agent API** as an LLM model provider (Claude, GPT, Gemini through one key), see [Perplexity Agent API](/providers/perplexity-agent-api).
 </Note>
 
-| Property    | Value                                                                  |
-| ----------- | ---------------------------------------------------------------------- |
-| Type        | Web search provider (not a model provider)                             |
-| Auth        | `PERPLEXITY_API_KEY` (native) or `OPENROUTER_API_KEY` (via OpenRouter) |
-| Config path | `plugins.entries.perplexity.config.webSearch.apiKey`                   |
-| Overrides   | `plugins.entries.perplexity.config.webSearch.baseUrl` / `.model`       |
-| Get a key   | [perplexity.ai/settings/api](https://www.perplexity.ai/settings/api)   |
+| Property    | Value                                                                |
+| ----------- | -------------------------------------------------------------------- |
+| Type        | Web search provider (not a model provider)                           |
+| Auth        | `PERPLEXITY_API_KEY`                                                 |
+| Config path | `plugins.entries.perplexity.config.webSearch.apiKey`                 |
+| Get a key   | [perplexity.ai/settings/api](https://www.perplexity.ai/settings/api) |
 
 ## Install plugin
 
@@ -44,8 +40,7 @@ openclaw gateway restart
     openclaw config set plugins.entries.perplexity.config.webSearch.apiKey "pplx-xxxxxxxxxxxx"
     ```
 
-    A key exported as `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY` in the Gateway
-    environment also works.
+    A key exported as `PERPLEXITY_API_KEY` in the Gateway environment also works.
 
   </Step>
   <Step title="Start searching">
@@ -59,36 +54,19 @@ openclaw gateway restart
   </Step>
 </Steps>
 
-## Search modes
+## Search API filtering
 
-The plugin resolves transport in this order:
+| Filter                               | Description                                                     |
+| ------------------------------------ | --------------------------------------------------------------- |
+| `count`                              | Results per search, 1-10 (default 5)                            |
+| `freshness`                          | Recency window: `day`, `week`, `month`, `year`                  |
+| `country`                            | 2-letter country code (`us`, `de`, `jp`)                        |
+| `language`                           | ISO 639-1 language code (`en`, `fr`, `zh`)                      |
+| `date_after` / `date_before`         | Published-date range in `YYYY-MM-DD`                            |
+| `domain_filter`                      | Max 20 domains; allowlist or `-`-prefixed denylist, never mixed |
+| `max_tokens` / `max_tokens_per_page` | Content budget across all results / per page                    |
 
-1. `webSearch.baseUrl` or `webSearch.model` set: always routes through Sonar chat completions against that endpoint, regardless of key type.
-2. Otherwise, key source decides the endpoint: a configured key's prefix picks the transport (config beats environment variables); an environment key uses its matching endpoint directly.
-
-| Key prefix | Transport                                                  | Features                                         |
-| ---------- | ---------------------------------------------------------- | ------------------------------------------------ |
-| `pplx-`    | Native Perplexity Search API (`https://api.perplexity.ai`) | Structured results, domain/language/date filters |
-| `sk-or-`   | OpenRouter (`https://openrouter.ai/api/v1`), Sonar model   | AI-synthesized answers with citations            |
-
-A configured key with any other prefix also uses the native Search API. The
-chat-completions path defaults to the `perplexity/sonar-pro` model; override it
-with `plugins.entries.perplexity.config.webSearch.model`.
-
-## Native API filtering
-
-| Filter                               | Description                                                     | Transport   |
-| ------------------------------------ | --------------------------------------------------------------- | ----------- |
-| `count`                              | Results per search, 1-10 (default 5)                            | Native only |
-| `freshness`                          | Recency window: `day`, `week`, `month`, `year`                  | Both        |
-| `country`                            | 2-letter country code (`us`, `de`, `jp`)                        | Native only |
-| `language`                           | ISO 639-1 language code (`en`, `fr`, `zh`)                      | Native only |
-| `date_after` / `date_before`         | Published-date range in `YYYY-MM-DD`                            | Native only |
-| `domain_filter`                      | Max 20 domains; allowlist or `-`-prefixed denylist, never mixed | Native only |
-| `max_tokens` / `max_tokens_per_page` | Content budget across all results / per page                    | Native only |
-
-Native-only filters return a descriptive error on the chat-completions path.
-`freshness` cannot be combined with `date_after`/`date_before`.
+`freshness` cannot be combined with `date_after` / `date_before`.
 
 ## Advanced configuration
 
@@ -102,13 +80,6 @@ Native-only filters return a descriptive error on the chat-completions path.
     for the full precedence order.
     </Warning>
   </Accordion>
-
-  <Accordion title="OpenRouter proxy setup">
-    To route Perplexity searches through OpenRouter, set an `OPENROUTER_API_KEY`
-    (prefix `sk-or-`) instead of a native Perplexity key. OpenClaw detects the
-    key and switches to the Sonar transport automatically. Useful if you already
-    have OpenRouter billing set up and want to consolidate providers there.
-  </Accordion>
 </AccordionGroup>
 
 ## Related
@@ -117,7 +88,7 @@ Native-only filters return a descriptive error on the chat-completions path.
   <Card title="Perplexity search tool" href="/tools/perplexity-search" icon="magnifying-glass">
     How the agent invokes Perplexity searches and interprets results.
   </Card>
-  <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
-    Full configuration reference including plugin entries.
+  <Card title="Perplexity Agent API" href="/providers/perplexity-agent-api" icon="robot">
+    Use Perplexity's Agent API as an LLM model provider for OpenClaw.
   </Card>
 </CardGroup>

--- a/docs/providers/perplexity-provider.md
+++ b/docs/providers/perplexity-provider.md
@@ -80,6 +80,16 @@ openclaw gateway restart
     for the full precedence order.
     </Warning>
   </Accordion>
+
+  <Accordion title="OpenRouter / Sonar compatibility (legacy)">
+    Existing OpenClaw installs configured against Perplexity Sonar through OpenRouter continue to work. The plugin switches to the Sonar chat-completions transport when any of these is set:
+
+    - `OPENROUTER_API_KEY` in the Gateway environment
+    - An `sk-or-...` key stored in `plugins.entries.perplexity.config.webSearch.apiKey`
+    - `plugins.entries.perplexity.config.webSearch.baseUrl` or `.model`
+
+    In that mode the provider returns AI-synthesized answers with citations instead of structured Search API results. The Search API filters `country`, `language`, `date_after`/`date_before`, `domain_filter`, `max_tokens`, and `max_tokens_per_page` return a `not supported` error on the chat-completions path; `freshness` still applies as `search_recency_filter`. New setups should use a `pplx-` key against the native Search API.
+  </Accordion>
 </AccordionGroup>
 
 ## Related

--- a/docs/providers/perplexity-provider.md
+++ b/docs/providers/perplexity-provider.md
@@ -103,11 +103,14 @@ Native-only filters return a descriptive error on the chat-completions path.
     </Warning>
   </Accordion>
 
-  <Accordion title="OpenRouter proxy setup">
-    To route Perplexity searches through OpenRouter, set an `OPENROUTER_API_KEY`
-    (prefix `sk-or-`) instead of a native Perplexity key. OpenClaw detects the
-    key and switches to the Sonar transport automatically. Useful if you already
-    have OpenRouter billing set up and want to consolidate providers there.
+  <Accordion title="OpenRouter / Sonar compatibility (legacy)">
+    Existing OpenClaw installs configured against Perplexity Sonar through OpenRouter continue to work. The plugin switches to the Sonar chat-completions transport when any of these is set:
+
+    - `OPENROUTER_API_KEY` in the Gateway environment
+    - An `sk-or-...` key stored in `plugins.entries.perplexity.config.webSearch.apiKey`
+    - `plugins.entries.perplexity.config.webSearch.baseUrl` or `.model`
+
+    In that mode the provider returns AI-synthesized answers with citations instead of structured Search API results. The Search API filters `country`, `language`, `date_after`/`date_before`, `domain_filter`, `max_tokens`, and `max_tokens_per_page` return a `not supported` error on the chat-completions path; `freshness` still applies as `search_recency_filter`. New setups should use a `pplx-` key against the native Search API.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/providers/perplexity-provider.md
+++ b/docs/providers/perplexity-provider.md
@@ -12,7 +12,7 @@ Sonar chat completions, direct or via OpenRouter (AI-synthesized answers with
 citations).
 
 <Note>
-This page covers the Perplexity **provider** setup. For the Perplexity **tool** (how the agent uses it), see [Perplexity search](/tools/perplexity-search).
+This page covers the Perplexity **provider** setup. For the Perplexity **tool** (how the agent uses it), see [Perplexity search](/tools/perplexity-search). To use Perplexity's **Agent API** as an LLM model provider (Claude, GPT, Gemini through one key), see [Perplexity Agent API](/providers/perplexity-agent-api).
 </Note>
 
 | Property    | Value                                                                  |
@@ -113,11 +113,14 @@ Native-only filters return a descriptive error on the chat-completions path.
 
 ## Related
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Perplexity search tool" href="/tools/perplexity-search" icon="magnifying-glass">
     How the agent invokes Perplexity searches and interprets results.
   </Card>
   <Card title="Configuration reference" href="/gateway/configuration-reference" icon="gear">
     Full configuration reference including plugin entries.
+  </Card>
+  <Card title="Perplexity Agent API" href="/providers/perplexity-agent-api" icon="robot">
+    Use Perplexity's Agent API as an LLM model provider for OpenClaw.
   </Card>
 </CardGroup>

--- a/docs/providers/perplexity-provider.md
+++ b/docs/providers/perplexity-provider.md
@@ -106,11 +106,13 @@ Native-only filters return a descriptive error on the chat-completions path.
   <Accordion title="OpenRouter / Sonar compatibility (legacy)">
     Existing OpenClaw installs configured against Perplexity Sonar through OpenRouter continue to work. The plugin switches to the Sonar chat-completions transport when any of these is set:
 
-    - `OPENROUTER_API_KEY` in the Gateway environment
+    - `OPENROUTER_API_KEY` in the Gateway environment, when no higher-priority credential is available
     - An `sk-or-...` key stored in `plugins.entries.perplexity.config.webSearch.apiKey`
     - `plugins.entries.perplexity.config.webSearch.baseUrl` or `.model`
 
-    In that mode the provider returns AI-synthesized answers with citations instead of structured Search API results. The Search API filters `country`, `language`, `date_after`/`date_before`, `domain_filter`, `max_tokens`, and `max_tokens_per_page` return a `not supported` error on the chat-completions path; `freshness` still applies as `search_recency_filter`. New setups should use a `pplx-` key against the native Search API.
+    Credential precedence is `plugins.entries.perplexity.config.webSearch.apiKey`, then `PERPLEXITY_API_KEY`, then `OPENROUTER_API_KEY`. The first available credential determines endpoint inference unless an explicit `baseUrl` or `model` forces the legacy transport.
+
+    In that mode the provider returns one AI-synthesized answer with citations instead of structured Search API results. `count` is accepted for shared-tool compatibility but does not change that one-answer shape. The Search API filters `country`, `language`, `date_after`/`date_before`, `domain_filter`, `max_tokens`, and `max_tokens_per_page` return a `not supported` error on the chat-completions path; `freshness` still applies as `search_recency_filter`. New setups should use a `pplx-` key against the native Search API.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/providers/perplexity-provider.md
+++ b/docs/providers/perplexity-provider.md
@@ -113,6 +113,7 @@ Native-only filters return a descriptive error on the chat-completions path.
     Credential precedence is `plugins.entries.perplexity.config.webSearch.apiKey`, then `PERPLEXITY_API_KEY`, then `OPENROUTER_API_KEY`. The first available credential determines endpoint inference unless an explicit `baseUrl` or `model` forces the legacy transport.
 
     In that mode the provider returns one AI-synthesized answer with citations instead of structured Search API results. `count` is accepted for shared-tool compatibility but does not change that one-answer shape. The Search API filters `country`, `language`, `date_after`/`date_before`, `domain_filter`, `max_tokens`, and `max_tokens_per_page` return a `not supported` error on the chat-completions path; `freshness` still applies as `search_recency_filter`. New setups should use a `pplx-` key against the native Search API.
+
   </Accordion>
 </AccordionGroup>
 

--- a/docs/tools/perplexity-search.md
+++ b/docs/tools/perplexity-search.md
@@ -60,11 +60,13 @@ If `provider: "perplexity"` is configured and the Perplexity key SecretRef is un
 
 Existing installs pointed at Perplexity Sonar through OpenRouter continue to work. The provider switches to the Sonar chat-completions transport when any of these is set:
 
-- `OPENROUTER_API_KEY` in the Gateway environment
+- `OPENROUTER_API_KEY` in the Gateway environment, when no higher-priority credential is available
 - An `sk-or-...` key stored in `plugins.entries.perplexity.config.webSearch.apiKey`
 - `plugins.entries.perplexity.config.webSearch.baseUrl` or `.model`
 
-In that mode the provider returns AI-synthesized answers with citations instead of structured Search API results. The Search API filter parameters `country`, `language`, `date_after`/`date_before`, `domain_filter`, `max_tokens`, and `max_tokens_per_page` return a `not supported` error on the chat-completions path; `freshness` still applies as `search_recency_filter`. New setups should use a `pplx-` key against the native Search API.
+Credential precedence is `plugins.entries.perplexity.config.webSearch.apiKey`, then `PERPLEXITY_API_KEY`, then `OPENROUTER_API_KEY`. The first available credential determines endpoint inference unless an explicit `baseUrl` or `model` forces the legacy transport.
+
+In that mode the provider returns one AI-synthesized answer with citations instead of structured Search API results. `count` is accepted for shared-tool compatibility but does not change that one-answer shape. The Search API filter parameters `country`, `language`, `date_after`/`date_before`, `domain_filter`, `max_tokens`, and `max_tokens_per_page` return a `not supported` error on the chat-completions path; `freshness` still applies as `search_recency_filter`. New setups should use a `pplx-` key against the native Search API.
 
 ```json5
 {
@@ -98,7 +100,7 @@ Search query.
 </ParamField>
 
 <ParamField path="count" type="number" default="5">
-Number of results to return (1-10).
+Native Perplexity Search API only. Number of results to return (1-10). The legacy Sonar/OpenRouter transport accepts this parameter for compatibility but still returns one synthesized answer with citations, not an N-result list.
 </ParamField>
 
 <ParamField path="country" type="string">

--- a/docs/tools/perplexity-search.md
+++ b/docs/tools/perplexity-search.md
@@ -1,14 +1,12 @@
 ---
-summary: "Perplexity Search API and Sonar/OpenRouter compatibility for web_search"
+summary: "Perplexity Search API for web_search"
 read_when:
   - You want to use Perplexity Search for web search
-  - You need PERPLEXITY_API_KEY or OPENROUTER_API_KEY setup
+  - You need PERPLEXITY_API_KEY setup
 title: "Perplexity search"
 ---
 
 OpenClaw supports the Perplexity Search API as a `web_search` provider. It returns structured results with `title`, `url`, and `snippet` fields.
-
-For compatibility, OpenClaw also supports legacy Perplexity Sonar/OpenRouter setups. If you use `OPENROUTER_API_KEY`, an `sk-or-...` key in `plugins.entries.perplexity.config.webSearch.apiKey`, or set `plugins.entries.perplexity.config.webSearch.baseUrl` / `model`, the provider switches to the chat-completions path and returns AI-synthesized answers with citations instead of structured Search API results.
 
 ## Install plugin
 
@@ -25,18 +23,7 @@ openclaw gateway restart
 2. Generate an API key in the dashboard.
 3. Store the key in config or set `PERPLEXITY_API_KEY` in the Gateway environment.
 
-## OpenRouter compatibility
-
-If you were already using OpenRouter for Perplexity Sonar, keep `provider: "perplexity"` and set `OPENROUTER_API_KEY` in the Gateway environment, or store an `sk-or-...` key in `plugins.entries.perplexity.config.webSearch.apiKey`.
-
-Optional compatibility controls:
-
-- `plugins.entries.perplexity.config.webSearch.baseUrl`
-- `plugins.entries.perplexity.config.webSearch.model`
-
-## Config examples
-
-### Native Perplexity Search API
+## Config example
 
 ```json5
 {
@@ -61,44 +48,15 @@ Optional compatibility controls:
 }
 ```
 
-### OpenRouter / Sonar compatibility
-
-```json5
-{
-  plugins: {
-    entries: {
-      perplexity: {
-        config: {
-          webSearch: {
-            apiKey: "<openrouter-api-key>",
-            baseUrl: "https://openrouter.ai/api/v1",
-            model: "perplexity/sonar-pro",
-          },
-        },
-      },
-    },
-  },
-  tools: {
-    web: {
-      search: {
-        provider: "perplexity",
-      },
-    },
-  },
-}
-```
-
 ## Where to set the key
 
 **Via config:** run `openclaw configure --section web`. It stores the key in `~/.openclaw/openclaw.json` under `plugins.entries.perplexity.config.webSearch.apiKey`. That field also accepts SecretRef objects.
 
-**Via environment:** set `PERPLEXITY_API_KEY` or `OPENROUTER_API_KEY` in the Gateway process environment. For a gateway install, put it in `~/.openclaw/.env` (or your service environment). See [Env vars](/help/faq#env-vars-and-env-loading).
+**Via environment:** set `PERPLEXITY_API_KEY` in the Gateway process environment. For a gateway install, put it in `~/.openclaw/.env` (or your service environment). See [Env vars](/help/faq#env-vars-and-env-loading).
 
 If `provider: "perplexity"` is configured and the Perplexity key SecretRef is unresolved with no env fallback, startup/reload fails fast.
 
 ## Tool parameters
-
-These parameters apply to the native Perplexity Search API path.
 
 <ParamField path="query" type="string" required>
 Search query.
@@ -139,12 +97,6 @@ Total content budget (max 1000000).
 <ParamField path="max_tokens_per_page" type="number" default="2048">
 Per-page token limit.
 </ParamField>
-
-For the legacy Sonar/OpenRouter compatibility path:
-
-- `query`, `count`, and `freshness` are accepted.
-- `count` is compatibility-only there; the response is still one synthesized answer with citations rather than an N-result list.
-- Search API-only filters (`country`, `language`, `date_after`, `date_before`, `domain_filter`, `max_tokens`, `max_tokens_per_page`) return explicit errors.
 
 **Examples:**
 
@@ -198,8 +150,6 @@ await web_search({
 ## Notes
 
 - Perplexity Search API returns structured web search results (`title`, `url`, `snippet`).
-- OpenRouter, or an explicit `plugins.entries.perplexity.config.webSearch.baseUrl` / `model`, switches Perplexity back to Sonar chat completions for compatibility.
-- Sonar/OpenRouter compatibility returns one synthesized answer with citations, not structured result rows.
 - Results are cached for 15 minutes by default (configurable via `cacheTtlMinutes`).
 
 ## Related

--- a/docs/tools/perplexity-search.md
+++ b/docs/tools/perplexity-search.md
@@ -56,6 +56,41 @@ openclaw gateway restart
 
 If `provider: "perplexity"` is configured and the Perplexity key SecretRef is unresolved with no env fallback, startup/reload fails fast.
 
+## OpenRouter / Sonar compatibility (legacy)
+
+Existing installs pointed at Perplexity Sonar through OpenRouter continue to work. The provider switches to the Sonar chat-completions transport when any of these is set:
+
+- `OPENROUTER_API_KEY` in the Gateway environment
+- An `sk-or-...` key stored in `plugins.entries.perplexity.config.webSearch.apiKey`
+- `plugins.entries.perplexity.config.webSearch.baseUrl` or `.model`
+
+In that mode the provider returns AI-synthesized answers with citations instead of structured Search API results. The Search API filter parameters `country`, `language`, `date_after`/`date_before`, `domain_filter`, `max_tokens`, and `max_tokens_per_page` return a `not supported` error on the chat-completions path; `freshness` still applies as `search_recency_filter`. New setups should use a `pplx-` key against the native Search API.
+
+```json5
+{
+  plugins: {
+    entries: {
+      perplexity: {
+        config: {
+          webSearch: {
+            apiKey: "<openrouter-api-key>",
+            baseUrl: "https://openrouter.ai/api/v1",
+            model: "perplexity/sonar-pro",
+          },
+        },
+      },
+    },
+  },
+  tools: {
+    web: {
+      search: {
+        provider: "perplexity",
+      },
+    },
+  },
+}
+```
+
 ## Tool parameters
 
 <ParamField path="query" type="string" required>

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -126,7 +126,7 @@ xAI Responses.
 | [Ollama Web Search](/tools/ollama-search)        | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
 | [Parallel](/tools/parallel-search)               | Dense excerpts ranked for LLM context                          | --                                               | `PARALLEL_API_KEY` (paid)                                                               |
 | [Parallel Search (Free)](/tools/parallel-search) | Dense excerpts ranked for LLM context                          | --                                               | None (free Search MCP)                                                                  |
-| [Perplexity](/tools/perplexity-search)           | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
+| [Perplexity](/tools/perplexity-search)           | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY`                                                                    |
 | [SearXNG](/tools/searxng-search)                 | Structured snippets                                            | Categories, language                             | None (self-hosted)                                                                      |
 | [Tavily](/tools/tavily)                          | Structured snippets                                            | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                                                        |
 
@@ -220,7 +220,7 @@ API-backed providers first:
 3. **Gemini** -- `plugins.entries.google.config.webSearch.apiKey`, `GEMINI_API_KEY`, or `models.providers.google.apiKey` (order 20)
 4. **Grok** -- xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey` (order 30)
 5. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey` (order 40)
-6. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
+6. **Perplexity** -- `PERPLEXITY_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
 7. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
 9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
@@ -485,10 +485,6 @@ provider, OpenClaw does not show the `x_search` prompt.
   accept `count` for shared-tool compatibility, but it does not change the
   grounded answer shape. Gemini treats `day` freshness as a recency hint; wider
   freshness values and explicit dates set Google Search grounding time ranges.
-  Perplexity behaves the same way when you use the Sonar/OpenRouter
-  compatibility path (`plugins.entries.perplexity.config.webSearch.baseUrl` /
-  `model` or `OPENROUTER_API_KEY`); that path also drops `max_tokens` and
-  `max_tokens_per_page` support.
   SearXNG accepts `http://` only for trusted private-network or loopback hosts;
   public SearXNG endpoints must use `https://`.
   Firecrawl and Tavily only support `query` and `count` through `web_search`

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -126,7 +126,7 @@ xAI Responses.
 | [Ollama Web Search](/tools/ollama-search)        | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
 | [Parallel](/tools/parallel-search)               | Dense excerpts ranked for LLM context                          | --                                               | `PARALLEL_API_KEY` (paid)                                                               |
 | [Parallel Search (Free)](/tools/parallel-search) | Dense excerpts ranked for LLM context                          | --                                               | None (free Search MCP)                                                                  |
-| [Perplexity](/tools/perplexity-search)           | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY`                                                                    |
+| [Perplexity](/tools/perplexity-search)           | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
 | [SearXNG](/tools/searxng-search)                 | Structured snippets                                            | Categories, language                             | None (self-hosted)                                                                      |
 | [Tavily](/tools/tavily)                          | Structured snippets                                            | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                                                        |
 
@@ -220,7 +220,7 @@ API-backed providers first:
 3. **Gemini** -- `plugins.entries.google.config.webSearch.apiKey`, `GEMINI_API_KEY`, or `models.providers.google.apiKey` (order 20)
 4. **Grok** -- xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey` (order 30)
 5. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey` (order 40)
-6. **Perplexity** -- `PERPLEXITY_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
+6. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
 7. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
 9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
@@ -485,6 +485,10 @@ provider, OpenClaw does not show the `x_search` prompt.
   accept `count` for shared-tool compatibility, but it does not change the
   grounded answer shape. Gemini treats `day` freshness as a recency hint; wider
   freshness values and explicit dates set Google Search grounding time ranges.
+  Perplexity behaves the same way when you use the Sonar/OpenRouter
+  compatibility path (`plugins.entries.perplexity.config.webSearch.baseUrl` /
+  `model` or `OPENROUTER_API_KEY`); that path also drops `max_tokens` and
+  `max_tokens_per_page` support.
   SearXNG accepts `http://` only for trusted private-network or loopback hosts;
   public SearXNG endpoints must use `https://`.
   Firecrawl and Tavily only support `query` and `count` through `web_search`

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -126,7 +126,7 @@ xAI Responses.
 | [Ollama Web Search](/tools/ollama-search)        | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
 | [Parallel](/tools/parallel-search)               | Dense excerpts ranked for LLM context                          | --                                               | `PARALLEL_API_KEY` (paid)                                                               |
 | [Parallel Search (Free)](/tools/parallel-search) | Dense excerpts ranked for LLM context                          | --                                               | None (free Search MCP)                                                                  |
-| [Perplexity](/tools/perplexity-search)           | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY`                                                                    |
+| [Perplexity](/tools/perplexity-search)           | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
 | [SearXNG](/tools/searxng-search)                 | Structured snippets                                            | Categories, language                             | None (self-hosted)                                                                      |
 | [Tavily](/tools/tavily)                          | Structured snippets                                            | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                                                        |
 
@@ -224,7 +224,7 @@ API-backed providers first:
 3. **Gemini** -- `plugins.entries.google.config.webSearch.apiKey`, `GEMINI_API_KEY`, or `models.providers.google.apiKey` (order 20)
 4. **Grok** -- xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey` (order 30)
 5. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey` (order 40)
-6. **Perplexity** -- `PERPLEXITY_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
+6. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
 7. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
 9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
@@ -494,6 +494,10 @@ provider, OpenClaw does not show the `x_search` prompt.
   accept `count` for shared-tool compatibility, but it does not change the
   grounded answer shape. Gemini treats `day` freshness as a recency hint; wider
   freshness values and explicit dates set Google Search grounding time ranges.
+  Perplexity behaves the same way when you use the Sonar/OpenRouter
+  compatibility path (`plugins.entries.perplexity.config.webSearch.baseUrl` /
+  `model` or `OPENROUTER_API_KEY`); that path also drops `max_tokens` and
+  `max_tokens_per_page` support.
   SearXNG accepts `http://` only for trusted private-network or loopback hosts;
   public SearXNG endpoints must use `https://`.
   Firecrawl and Tavily only support `query` and `count` through `web_search`

--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -126,7 +126,7 @@ xAI Responses.
 | [Ollama Web Search](/tools/ollama-search)        | Structured snippets                                            | --                                               | None for signed-in local hosts; `OLLAMA_API_KEY` for direct `https://ollama.com` search |
 | [Parallel](/tools/parallel-search)               | Dense excerpts ranked for LLM context                          | --                                               | `PARALLEL_API_KEY` (paid)                                                               |
 | [Parallel Search (Free)](/tools/parallel-search) | Dense excerpts ranked for LLM context                          | --                                               | None (free Search MCP)                                                                  |
-| [Perplexity](/tools/perplexity-search)           | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY`                                             |
+| [Perplexity](/tools/perplexity-search)           | Structured snippets                                            | Country, language, time, domains, content limits | `PERPLEXITY_API_KEY`                                                                    |
 | [SearXNG](/tools/searxng-search)                 | Structured snippets                                            | Categories, language                             | None (self-hosted)                                                                      |
 | [Tavily](/tools/tavily)                          | Structured snippets                                            | Via `tavily_search` tool                         | `TAVILY_API_KEY`                                                                        |
 
@@ -224,7 +224,7 @@ API-backed providers first:
 3. **Gemini** -- `plugins.entries.google.config.webSearch.apiKey`, `GEMINI_API_KEY`, or `models.providers.google.apiKey` (order 20)
 4. **Grok** -- xAI OAuth, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey` (order 30)
 5. **Kimi** -- `KIMI_API_KEY` / `MOONSHOT_API_KEY` or `plugins.entries.moonshot.config.webSearch.apiKey` (order 40)
-6. **Perplexity** -- `PERPLEXITY_API_KEY` / `OPENROUTER_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
+6. **Perplexity** -- `PERPLEXITY_API_KEY` or `plugins.entries.perplexity.config.webSearch.apiKey` (order 50)
 7. **Firecrawl** -- `FIRECRAWL_API_KEY` or `plugins.entries.firecrawl.config.webSearch.apiKey` (order 60)
 8. **Exa** -- `EXA_API_KEY` or `plugins.entries.exa.config.webSearch.apiKey`; optional `plugins.entries.exa.config.webSearch.baseUrl` overrides the Exa endpoint (order 65)
 9. **Tavily** -- `TAVILY_API_KEY` or `plugins.entries.tavily.config.webSearch.apiKey` (order 70)
@@ -494,10 +494,6 @@ provider, OpenClaw does not show the `x_search` prompt.
   accept `count` for shared-tool compatibility, but it does not change the
   grounded answer shape. Gemini treats `day` freshness as a recency hint; wider
   freshness values and explicit dates set Google Search grounding time ranges.
-  Perplexity behaves the same way when you use the Sonar/OpenRouter
-  compatibility path (`plugins.entries.perplexity.config.webSearch.baseUrl` /
-  `model` or `OPENROUTER_API_KEY`); that path also drops `max_tokens` and
-  `max_tokens_per_page` support.
   SearXNG accepts `http://` only for trusted private-network or loopback hosts;
   public SearXNG endpoints must use `https://`.
   Firecrawl and Tavily only support `query` and `count` through `web_search`


### PR DESCRIPTION
## What Problem This Solves

OpenClaw documents Perplexity as a web-search provider, but it does not document Perplexity's Agent API as an OpenAI-Responses-compatible model provider. Operators therefore have no OpenClaw-native guide for configuring Agent API models, preserving the API key as a SecretRef, or avoiding conflicts with Perplexity's reserved server-side tool names.

The existing Perplexity provider and tool pages also blur the native Search API with the legacy OpenRouter/Sonar compatibility path. This makes it harder to tell which credential, transport, result shape, and filters apply to a given configuration.

## Why This Change Was Made

This PR adds a dedicated Agent API provider guide and rewrites the existing Perplexity web-search documentation around the native Search API while retaining the supported legacy OpenRouter/Sonar behavior. The new guide uses OpenClaw's custom-provider onboarding path, the `openai-responses` transport, and environment-backed SecretRefs rather than persisting literal API keys.

Because non-interactive custom-provider onboarding shares the `CUSTOM_API_KEY` variable, the guide now separates fresh setup from installations where another custom provider already owns that variable. The latter keeps the existing credential unchanged and assigns Perplexity a provider-specific `PERPLEXITY_API_KEY` SecretRef before daemon installation.

## User Impact

- Operators can configure Perplexity Agent API as an OpenClaw model provider with a copyable non-interactive onboarding command.
- Fresh installations can persist `CUSTOM_API_KEY` in the state-directory `.env`; existing custom-provider installations get a separate path that does not overwrite the shared credential.
- SecretRef examples include the complete `source`, `provider`, and `id` shape, with guidance for non-default environment-provider aliases.
- The guide explains that `--non-interactive` selects direct flag consumption, while a missing `--accept-risk` fails before setup dispatch.
- Additional Agent API models are registered explicitly under `models.providers.perplexity.models[]` with their model metadata.
- The required managed `web_search` disable and its Gateway-wide blast radius are documented, including a per-agent alternative.
- The Perplexity web-search pages document credential precedence and distinguish native structured-result behavior from the one-answer legacy Sonar/OpenRouter path.
- Perplexity's MCP server and CLI are linked as separate integration paths without embedding unsafe credential-bearing commands.

## Evidence

- Live requests to `api.perplexity.ai` verified the `POST /v1/agent` endpoint, the OpenAI-Responses-compatible `POST /v1/responses` alias, and the documented failures from incorrectly suffixed base URLs.
- Perplexity Agent API rejected custom functions using the documented reserved names: `web_search`, `fetch_url`, `people_search`, and `finance_search`.
- `src/commands/onboard.ts` requires risk acknowledgement before setup dispatch, routes non-interactive runs to `runNonInteractiveSetup`, and routes interactive runs with custom-provider flags to the classic setup path.
- The custom-provider reference-mode implementation reads `CUSTOM_API_KEY` and persists a complete environment SecretRef whose provider alias is resolved from the secrets configuration.
- `config set` SecretRef builder mode supports assigning `models.providers.perplexity.apiKey` directly to `PERPLEXITY_API_KEY`, allowing an existing `CUSTOM_API_KEY` owner to remain unchanged.
- `docs/help/environment.md` and `src/config/state-dir-dotenv.ts` establish the state-directory `.env` as a durable provider-key source for installed Gateway services.
- The Perplexity plugin resolves web-search credentials in config, `PERPLEXITY_API_KEY`, `OPENROUTER_API_KEY` order. Its legacy chat-completions path accepts `count` for compatibility but returns one synthesized answer rather than N structured result rows.

## What Changed

- Added `docs/providers/perplexity-agent-api.md` for daemon-safe Agent API model-provider onboarding, configuration, model registration, MCP, and CLI guidance.
- Added separate fresh and existing-custom-provider credential paths so onboarding never instructs users to replace a shared `CUSTOM_API_KEY`.
- Reworked `docs/providers/perplexity-provider.md` around native Search API setup while preserving credential precedence and legacy compatibility notes.
- Reworked `docs/tools/perplexity-search.md` around the native `web_search` contract, native-only filters, count behavior, and legacy compatibility.
- Added the Agent API page to provider navigation and the provider index.
