### PR TITLE
fix(sessions): link stale-state notices

### DIFF
--- a/docs/concepts/session-state.md
+++ b/docs/concepts/session-state.md
@@ -60,7 +60,7 @@ If an adopted session's upstream source is deleted externally, three consecutive
 When a notify-eligible event lands and a watcher's cursor is behind, the watcher receives one system notice on its next turn:
 
 ```
-Session "agent:main:subagent:child" changed (other actor). Reconcile before acting: session_status sessionKey "agent:main:subagent:child" changesSince 12.
+Session "agent:main:subagent:child" changed (other actor). Open: [session](/chat/main/subagent/child). Reconcile before acting: session_status sessionKey "agent:main:subagent:child" changesSince 12.
 ```
 
 Main-session watchers are also woken immediately via a heartbeat wake; nested sub-agent watchers get the notice on their next turn.

--- a/src/sessions/session-state-notices.test.ts
+++ b/src/sessions/session-state-notices.test.ts
@@ -1,6 +1,7 @@
 // Session-state notice context key decoding: strict UTF-8 after hex validation.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
+import { enqueueSystemEvent } from "../infra/system-events.js";
 import {
   decodeSessionStateNoticeContextKey,
   enqueueSessionStateNotice,
@@ -16,6 +17,7 @@ vi.mock("../infra/system-events.js", () => ({
 
 beforeEach(() => {
   vi.mocked(requestHeartbeat).mockClear();
+  vi.mocked(enqueueSystemEvent).mockClear();
 });
 
 function encodeTarget(sessionKey: string): string {
@@ -48,6 +50,21 @@ describe("decodeSessionStateNoticeContextKey", () => {
 });
 
 describe("enqueueSessionStateNotice", () => {
+  it("includes a Control UI session link in stale-state notices", () => {
+    enqueueSessionStateNotice({
+      watcherSessionKey: "agent:main:main",
+      targetSessionKey: "agent:main:dashboard:7ac7cf4b-77b2-409f-8b80-214ca1d9851d",
+      lastSeenSequence: 4,
+    });
+
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      'Session "agent:main:dashboard:7ac7cf4b-77b2-409f-8b80-214ca1d9851d" changed (other actor). Open: [session](/chat/main/dashboard/7ac7cf4b-77b2-409f-8b80-214ca1d9851d). Reconcile before acting: session_status sessionKey "agent:main:dashboard:7ac7cf4b-77b2-409f-8b80-214ca1d9851d" changesSince 4.',
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+      }),
+    );
+  });
+
   it("coalesces active wakes for 20 seconds and leaves queue-only notices asleep", () => {
     const notice = {
       watcherSessionKey: "agent:main:main",

--- a/src/sessions/session-state-notices.ts
+++ b/src/sessions/session-state-notices.ts
@@ -1,4 +1,5 @@
 /** Stale-state notice text, coalescing keys, and watcher eligibility. */
+import { buildControlUiSessionPath } from "../../packages/session-url-contract/src/index.js";
 import { requestHeartbeat } from "../infra/heartbeat-wake.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { isSubagentSessionKey, parseAgentSessionKey } from "../routing/session-key.js";
@@ -30,11 +31,20 @@ export function decodeSessionStateNoticeContextKey(contextKey: string): string |
   }
 }
 
+function sessionStateNoticeLink(targetSessionKey: string): string {
+  const path = buildControlUiSessionPath({
+    namespace: "chat",
+    sessionKey: targetSessionKey,
+    exactKey: true,
+  });
+  return path ? ` Open: [session](${path}).` : "";
+}
+
 // Terse on purpose: this line lands in model prompts, possibly repeatedly across
 // turns. Text must stay byte-stable per frozen watermark so queue dedupe holds,
 // and the reconciliation call must be self-contained (explicit target sessionKey).
 function sessionStateNoticeText(targetSessionKey: string, lastSeenSequence: number): string {
-  return `Session "${targetSessionKey}" changed (other actor). Reconcile before acting: session_status sessionKey "${targetSessionKey}" changesSince ${lastSeenSequence}.`;
+  return `Session "${targetSessionKey}" changed (other actor).${sessionStateNoticeLink(targetSessionKey)} Reconcile before acting: session_status sessionKey "${targetSessionKey}" changesSince ${lastSeenSequence}.`;
 }
 
 function shouldWakeWatcher(watcherSessionKey: string): boolean {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where stale session-state system notices name the changed session key but do not give the agent or operator an easy Control UI route to open that session.

## Why This Change Was Made

The notice text now derives a deterministic Control UI chat path from the target session key and includes it before the existing `session_status ... changesSince` reconciliation instruction. The reconciliation command stays self-contained and the link is omitted if the session key cannot produce a valid Control UI path.

## User Impact

When another watched session changes, the receiving session sees a direct `Open: [session](...)` link in the stale-state notice, making it easier to inspect the changed session before reconciling.

## Evidence

AI-assisted change.

Passed:
- `pnpm test src/sessions/session-state-notices.test.ts src/sessions/session-state-events.test.ts` — 2 files / 34 tests passed
- `git diff --check`
- `pnpm check:changed -- src/sessions/session-state-notices.ts src/sessions/session-state-notices.test.ts docs/concepts/session-state.md` completed these lanes successfully before the stopped shard: conflict markers, max-lines ratchet, assertion SAFETY ratchet, changelog attributions, doctor deprecation registry, wildcard re-export guards, duplicate target coverage, coercion helper declaration guard, dependency pin guard, formatting, deprecated API usage, plugin boundaries, wrapper shadowing, package patch guard, dead export scan, test temp report, and core typecheck.

Incomplete:
- `pnpm check:changed ...` was interrupted by me after `typecheck core tests` spent ~8 minutes in `tsgo` with no output. The preceding core typecheck lane had passed.
