### PR TITLE
fix(release): accept frozen beta.3 QA evidence

### DIFF
--- a/scripts/validate-qa-runtime-pair-summary.mts
+++ b/scripts/validate-qa-runtime-pair-summary.mts
@@ -62,6 +62,14 @@ const FROZEN_RUNTIME_PAIR_MANIFESTS = new Map([
   ["311047822ecdde24e824d839ab105ef08f17be00:core", FROZEN_CORE_RUNTIME_PAIR_MANIFEST],
   ["c37af96b18776fecc9e24268f27fc89b563481bf:core", FROZEN_CORE_RUNTIME_PAIR_MANIFEST],
 ]);
+const FROZEN_STATUSLESS_RUNTIME_PAIR_MANIFEST = {
+  targetSha: "2d25f59b4a50b9f6579ae6d203f68616888f4fec",
+  lane: "core",
+  scenarioIds: FROZEN_CORE_RUNTIME_PAIR_MANIFEST.scenarioIds.filter(
+    (scenarioId) =>
+      scenarioId !== "codex-plugin-pinned-new" && scenarioId !== "codex-plugin-pinned-old",
+  ),
+};
 
 function isPassableCell(cell: unknown) {
   if (!isRecord(cell) || typeof cell.transportErrorClass === "string") {
@@ -168,6 +176,38 @@ function requireCanonicalRuntimePair(runtimePair: unknown) {
   );
 }
 
+function isCanonicalIsoTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") {
+    return false;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function isTrustedStatuslessCompletedRun(
+  run: Record<string, unknown>,
+  options: { targetSha?: string; lane?: string },
+) {
+  if (
+    Object.hasOwn(run, "status") ||
+    options.targetSha !== FROZEN_STATUSLESS_RUNTIME_PAIR_MANIFEST.targetSha ||
+    options.lane !== FROZEN_STATUSLESS_RUNTIME_PAIR_MANIFEST.lane ||
+    !isCanonicalIsoTimestamp(run.startedAt) ||
+    !isCanonicalIsoTimestamp(run.finishedAt) ||
+    Date.parse(run.finishedAt) < Date.parse(run.startedAt)
+  ) {
+    return false;
+  }
+  const scenarioIds = run.scenarioIds;
+  return (
+    Array.isArray(scenarioIds) &&
+    scenarioIds.length === FROZEN_STATUSLESS_RUNTIME_PAIR_MANIFEST.scenarioIds.length &&
+    FROZEN_STATUSLESS_RUNTIME_PAIR_MANIFEST.scenarioIds.every(
+      (scenarioId, index) => scenarioIds[index] === scenarioId,
+    )
+  );
+}
+
 export function validateQaRuntimePairSummary(
   summary: unknown,
   options: { requireExplicitGap?: boolean; targetSha?: string; lane?: string } = {},
@@ -175,7 +215,12 @@ export function validateQaRuntimePairSummary(
   if (!isRecord(summary) || !isRecord(summary.run) || !Array.isArray(summary.scenarios)) {
     throw new Error("runtime-pair summary is missing run or scenario evidence");
   }
-  if (summary.run.status !== "completed") {
+  // This frozen candidate predates run.status but carries terminal timestamps
+  // and an exact lane manifest. Keep every downstream evidence check intact.
+  if (
+    summary.run.status !== "completed" &&
+    !isTrustedStatuslessCompletedRun(summary.run, options)
+  ) {
     throw new Error("runtime-pair summary is not completed");
   }
   if (!requireCanonicalRuntimePair(summary.run.runtimePair)) {

--- a/test/scripts/validate-qa-runtime-pair-summary.test.ts
+++ b/test/scripts/validate-qa-runtime-pair-summary.test.ts
@@ -106,6 +106,11 @@ const frozenCoreGapScenarioIds = new Set<string>([
   "runtime-tool-fs-write",
   "runtime-tool-grep",
 ]);
+const frozenBeta3CoreScenarioIds = frozenCoreScenarioIds.filter(
+  (scenarioId) =>
+    scenarioId !== "codex-plugin-pinned-new" && scenarioId !== "codex-plugin-pinned-old",
+);
+const frozenBeta3TargetSha = "2d25f59b4a50b9f6579ae6d203f68616888f4fec";
 
 function frozenCoreSummary() {
   return summary(
@@ -125,14 +130,117 @@ function frozenCoreSummary() {
   );
 }
 
+function frozenBeta3StatuslessSummary() {
+  const fixture = summary(
+    frozenBeta3CoreScenarioIds.map((scenarioId) =>
+      scenario({
+        name: scenarioId,
+        status: "pass",
+      }),
+    ),
+  );
+  delete (fixture.run as { status?: string }).status;
+  return Object.assign(fixture, {
+    run: {
+      ...fixture.run,
+      startedAt: "2026-08-20T22:48:04.658Z",
+      finishedAt: "2026-08-20T23:03:13.497Z",
+    },
+  });
+}
+
 describe("frozen QA runtime-pair summary validation", () => {
   it("rejects a nonterminal runtime-pair summary", () => {
-    const fixture = summary([scenario({ name: "running", status: "pass" })]);
+    const fixture = frozenBeta3StatuslessSummary();
     fixture.run.status = "running";
 
-    expect(() => validateQaRuntimePairSummary(fixture)).toThrow(
+    expect(() =>
+      validateQaRuntimePairSummary(fixture, {
+        targetSha: frozenBeta3TargetSha,
+        lane: "core",
+      }),
+    ).toThrow("runtime-pair summary is not completed");
+  });
+
+  it("accepts completed summaries without frozen-candidate options", () => {
+    expect(
+      validateQaRuntimePairSummary(summary([scenario({ name: "passing", status: "pass" })])),
+    ).toMatchObject({ passed: 1 });
+  });
+
+  it("accepts the exact statusless beta.3 core summary", () => {
+    expect(
+      validateQaRuntimePairSummary(frozenBeta3StatuslessSummary(), {
+        targetSha: frozenBeta3TargetSha,
+        lane: "core",
+      }),
+    ).toEqual({
+      total: 25,
+      passed: 25,
+      failed: 0,
+      skipped: 0,
+    });
+  });
+
+  it.each([
+    ["both options", {}],
+    ["target SHA", { lane: "core" }],
+    ["lane", { targetSha: frozenBeta3TargetSha }],
+  ])("rejects the statusless beta.3 summary without %s", (_label, options) => {
+    expect(() => validateQaRuntimePairSummary(frozenBeta3StatuslessSummary(), options)).toThrow(
       "runtime-pair summary is not completed",
     );
+  });
+
+  it.each([
+    ["wrong target", { targetSha: "0000000000000000000000000000000000000000", lane: "core" }],
+    ["wrong lane", { targetSha: frozenBeta3TargetSha, lane: "extended" }],
+  ])("rejects the statusless beta.3 summary for the %s", (_label, options) => {
+    expect(() => validateQaRuntimePairSummary(frozenBeta3StatuslessSummary(), options)).toThrow(
+      "runtime-pair summary is not completed",
+    );
+  });
+
+  it("rejects an internally consistent prefix of the frozen beta.3 manifest", () => {
+    const fixture = frozenBeta3StatuslessSummary();
+    fixture.run.scenarioIds.pop();
+    fixture.scenarios.pop();
+    fixture.counts.total -= 1;
+    fixture.counts.passed -= 1;
+
+    expect(() =>
+      validateQaRuntimePairSummary(fixture, {
+        targetSha: frozenBeta3TargetSha,
+        lane: "core",
+      }),
+    ).toThrow("runtime-pair summary is not completed");
+  });
+
+  it.each([
+    ["missing startedAt", undefined, "2026-08-20T23:03:13.497Z"],
+    ["missing finishedAt", "2026-08-20T22:48:04.658Z", undefined],
+    ["invalid startedAt", "not-a-date", "2026-08-20T23:03:13.497Z"],
+    ["invalid finishedAt", "2026-08-20T22:48:04.658Z", "not-a-date"],
+    ["reversed timestamps", "2026-08-20T23:03:13.497Z", "2026-08-20T22:48:04.658Z"],
+  ])("rejects statusless beta.3 evidence with %s", (_label, startedAt, finishedAt) => {
+    const fixture = frozenBeta3StatuslessSummary();
+    if (startedAt === undefined) {
+      delete (fixture.run as { startedAt?: string }).startedAt;
+    } else {
+      fixture.run.startedAt = startedAt;
+    }
+    if (finishedAt === undefined) {
+      delete (fixture.run as { finishedAt?: string }).finishedAt;
+    } else {
+      fixture.run.finishedAt = finishedAt;
+    }
+
+    expect(() =>
+      validateQaRuntimePairSummary(fixture, {
+        targetSha: frozenBeta3TargetSha,
+        lane: "core",
+      }),
+    ).toThrow("runtime-pair summary is not completed");
   });
 
   it("accepts only passing scenarios and explicit one-sided Codex-native gaps", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation rejected completed QA runtime-pair evidence from the frozen `2026.8.1-beta.3` candidate because that candidate predates the required `run.status` field.

The candidate run completed all 25 core runtime-pair scenarios, reported parity `pass`, and emitted ordered terminal timestamps, but trusted tooling stopped with `runtime-pair summary is not completed`.

## Why This Change Was Made

The validator now accepts the statusless shape only for candidate `2d25f59b4a50b9f6579ae6d203f68616888f4fec`, lane `core`, canonical ordered ISO timestamps, and the exact frozen 25-scenario manifest. Explicit nonterminal or unknown statuses still fail, and every existing manifest, count, scenario, runtime-cell, parity, and report check remains required.

This is a frozen evidence-schema compatibility boundary, not a general legacy fallback. No product code or candidate bytes change.

Production LOC: +46/-1 (net +45) | Tests: +110/-2 (net +108)

The positive production delta is justified by a fail-closed release security boundary tied to one immutable candidate, lane, timestamp contract, and scenario manifest.

## User Impact

Release operators can validate the already-completed beta.3 runtime-pair evidence without weakening validation for current or unrelated candidates.

## Evidence

- Authoritative failing FRV: https://github.com/openclaw/openclaw/actions/runs/32424464649
- Failing release-checks child: https://github.com/openclaw/openclaw/actions/runs/32425623905
- Failed core runtime-pair job: `96607058903`
- Exact tooling base: `a4493e2521b07cf23abeed135ed8606858c44c70`
- Exact signed head: `3c2bc62847eec4c224e4175ba8e1d343ffc51625`
- Focused validator tests: 31/31 passed locally.
- Hosted exact-head Blacksmith Testbox proof: 31/31 passed in https://github.com/openclaw/openclaw/actions/runs/32431437538 (`tbx_01m0gt9nx2mnjxjkcrrh18ctaq`).
- Exact downloaded artifact passed summary validation: 25/25.
- Exact downloaded artifact passed summary plus parity-report validation: 25/25.
- Changed-file gate passed, including formatting, script/test typechecks, script lint, package guards, and boundary guards.
- `git diff --check` passed.

AI-assisted: yes. The maintainer reviewed the exact source, failure artifact, tests, and resulting commit.
