### PR TITLE
fix(heartbeat): deliver exec completions with disabled cadence

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -541,7 +541,7 @@ Periodic heartbeat runs.
     defaults: {
       heartbeat: {
         agentId: "ops", // ambient owner when no per-agent heartbeat is configured
-        every: "30m", // 0m disables
+        every: "30m", // 0m disables recurring cadence
         activeHours: { start: "08:00", end: "24:00" },
         model: "openai/gpt-5.4-mini",
         session: "main",
@@ -559,7 +559,7 @@ Periodic heartbeat runs.
 }
 ```
 
-- `every`: duration string (ms/s/m/h). Default: `30m` (API-key auth) or `1h` (OAuth auth). Set to `0m` to disable.
+- `every`: duration string (ms/s/m/h). Default: `30m` (API-key auth) or `1h` (OAuth auth). Set to `0m` to disable recurring cadence. Targeted event-driven wakes, including background exec completion follow-ups, can still run one agent turn.
 - `agentId`: explicit owner for ambient heartbeat runs when no `agents.entries.*.heartbeat` block exists. A shared heartbeat block without `agentId` keeps the existing all-agent enrollment behavior.
 - Cadence is written into a system-owned cron monitor row. Run `openclaw doctor --fix` to materialize a missing or stale row. If cron is disabled, scheduled heartbeats do not run and the gateway logs a startup warning.
 - The heartbeat object is strict. Its supported fields are `agentId`, `every`, `activeHours`, `model`, `session`, `target`, `directPolicy`, `to`, `accountId`, `prompt`, `timeoutSeconds`, `lightContext`, and `isolatedSession`.

--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -397,7 +397,7 @@ candidate contains a redacted secret placeholder such as `***` or `[redacted]`.
     }
     ```
 
-    - `every`: duration string (`30m`, `2h`). Set `0m` to disable. Default: `30m`.
+    - `every`: duration string (`30m`, `2h`). Set `0m` to disable recurring cadence; targeted event-driven wakes can still run one agent turn. Default: `30m`.
     - `target`: `owner` (default operator DM) | `last` (latest conversation, including groups) | `none` (internal only) | `<channel-id>`
     - `directPolicy`: `allow` (default) or `block` for DM-style heartbeat targets
     - See [Heartbeat](/gateway/heartbeat) for the full guide.

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -19,6 +19,8 @@ Under the hood, heartbeat cadence is owned by the Automations scheduler: the gat
 
 Scheduled heartbeats require automations. When `cron.enabled` is `false` or `OPENCLAW_SKIP_CRON=1`, the gateway logs a startup warning and does not run scheduled heartbeats; manual and event-driven heartbeat wakes remain available. There is no separate heartbeat fallback timer.
 
+Setting `heartbeat.every: "0m"` also disables only the recurring cadence. A targeted event-driven wake can still run one agent turn, such as the completion follow-up requested by a background exec task. It does not create or re-enable a recurring schedule. Use tool policy and sandboxing, rather than heartbeat cadence, to control whether those agent turns may execute commands.
+
 Troubleshooting: [Automations](/automation/cron-jobs#troubleshooting)
 
 ## Quick start (beginner)
@@ -65,12 +67,12 @@ Example config:
 
 ## Defaults
 
-- Interval: `30m`. Applying Anthropic provider defaults bumps this to `1h` when the resolved auth mode is OAuth/token (including Claude CLI reuse), but only while `heartbeat.every` is unset. Set `agents.defaults.heartbeat.every` or per-agent `agents.entries.*.heartbeat.every`; use `0m` to disable.
+- Interval: `30m`. Applying Anthropic provider defaults bumps this to `1h` when the resolved auth mode is OAuth/token (including Claude CLI reuse), but only while `heartbeat.every` is unset. Set `agents.defaults.heartbeat.every` or per-agent `agents.entries.*.heartbeat.every`; use `0m` to disable recurring cadence.
 - Delivery target: `owner`. OpenClaw uses the first concrete `commands.ownerAllowFrom` entry, then channel `allowFrom`, and never sends this route to a group. Without a resolvable owner DM, ambient polls skip with `reason=no-route`. Set `target: "last"` to follow the most recent conversation, including groups, or `target: "none"` for internal-only runs.
 - Prompt body (configurable via `agents.defaults.heartbeat.prompt`): `Follow the heartbeat monitor scratch context when provided. Recurring tasks are automations; create or change their schedules with the automations tool, not heartbeat scratch. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`
 - Timeout: unset heartbeat turns use `agents.defaults.timeoutSeconds` when set. Otherwise, they use the heartbeat cadence capped at 600 seconds. Set `agents.defaults.heartbeat.timeoutSeconds` or per-agent `agents.entries.*.heartbeat.timeoutSeconds` for longer heartbeat work.
 - The heartbeat prompt is sent **verbatim** as the user message. The system prompt automatically includes a "Heartbeats" section when cadence is enabled for the default agent; that guidance has no separate heartbeat toggle.
-- When heartbeats are disabled with `0m`, the monitor automation job stays but is disabled, and its scratch is retained for when you re-enable the cadence.
+- When recurring heartbeats are disabled with `0m`, the monitor automation job stays but is disabled, and its scratch is retained for when you re-enable the cadence. Targeted event-driven wakes remain available.
 - When automations are disabled entirely, scheduled heartbeats do not run even if heartbeat cadence remains enabled.
 - Active hours (`heartbeat.activeHours`) are checked in the configured timezone. Outside the window, heartbeats are skipped until the next tick inside the window.
 - Scheduled heartbeats defer while the main queue or automation work is active or queued, while any reply or embedded run for the same agent is active, and while the resolved target session has active or queued work. Immediate and manual wakes bypass the broad same-agent active-run check, but still honor the main, automation, and target-session busy guards. Sibling agents do not pause each other.

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1032,14 +1032,14 @@ First-run Q&A - install, onboard, auth routes, subscriptions, initial failures -
       agents: {
         defaults: {
           heartbeat: {
-            every: "2h", // or "0m" to disable
+            every: "2h", // or "0m" to disable recurring cadence
           },
         },
       },
     }
     ```
 
-    Heartbeat instructions live in the monitor's cron scratch. Effectively empty scratch skips the heartbeat run to save API calls; without scratch, the heartbeat still runs and the model decides what to do.
+    Heartbeat instructions live in the monitor's cron scratch. Effectively empty scratch skips the heartbeat run to save API calls; without scratch, the heartbeat still runs and the model decides what to do. `0m` does not block targeted event-driven wakes, such as a background exec completion follow-up; those can still run one agent turn without enabling recurring cadence.
 
     Per-agent overrides use `agents.entries.*.heartbeat`. Docs: [Heartbeat](/gateway/heartbeat).
 

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -14,7 +14,7 @@ Giving an agent a channel puts it in a position to run commands on your machine 
 
 - Always set `channels.whatsapp.allowFrom` (never run open-to-the-world on your personal Mac).
 - Use a dedicated WhatsApp number for the assistant.
-- Heartbeats default to every 30 minutes. Disable until you trust the setup by setting `agents.defaults.heartbeat.every: "0m"`.
+- Heartbeats default to every 30 minutes. Set `agents.defaults.heartbeat.every: "0m"` to disable recurring polling while you evaluate the setup. Targeted event-driven follow-ups can still run, so keep tool policy and sandboxing conservative until you trust the setup.
 
 ## Prerequisites
 
@@ -168,7 +168,7 @@ Example:
 
 By default, OpenClaw runs a heartbeat every 30 minutes with the prompt:
 `Follow the heartbeat monitor scratch context when provided. Recurring tasks are automations; create or change their schedules with the automations tool, not heartbeat scratch. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.`
-Set `agents.defaults.heartbeat.every: "0m"` to disable. Heartbeat checklists live in the monitor's cron scratch (see [Heartbeat](/gateway/heartbeat)); `openclaw doctor --fix` migrates a legacy workspace `HEARTBEAT.md` into it.
+Set `agents.defaults.heartbeat.every: "0m"` to disable recurring cadence. Targeted event-driven wakes, such as background exec completion follow-ups, remain available and do not create a recurring schedule. Heartbeat checklists live in the monitor's cron scratch (see [Heartbeat](/gateway/heartbeat)); `openclaw doctor --fix` migrates a legacy workspace `HEARTBEAT.md` into it.
 
 - If the monitor scratch exists but is effectively empty (only blank lines, Markdown/HTML comments, Markdown headings like `# Heading`, fence markers, or empty checklist stubs), OpenClaw skips the heartbeat run to save API calls.
 - If no scratch exists, the heartbeat still runs and the model decides what to do.

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -79,7 +79,7 @@ import { resolveHeartbeatVisibility } from "./heartbeat-visibility.js";
 import {
   inferHeartbeatWakeSourceFromReason,
   isConfiguredHeartbeatAgent,
-  isTargetedImmediateUnscheduledWake,
+  isTargetedUnscheduledWake,
 } from "./heartbeat-wake-policy.js";
 import {
   areHeartbeatsEnabled,
@@ -169,7 +169,7 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     left.jobId.localeCompare(right.jobId),
   );
   const allowsUnscheduledTarget =
-    isTargetedImmediateUnscheduledWake(opts) && isConfiguredHeartbeatAgent(cfg, agentId);
+    isTargetedUnscheduledWake(opts) && isConfiguredHeartbeatAgent(cfg, agentId);
   if (!areHeartbeatsEnabled()) {
     return { kind: "skipped", reason: "disabled" } as const;
   }

--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -25,10 +25,7 @@ import {
   seekNextActivePhaseDueMs,
 } from "./heartbeat-schedule.js";
 import { resolveHeartbeatIntervalMs } from "./heartbeat-summary.js";
-import {
-  isConfiguredHeartbeatAgent,
-  isTargetedImmediateUnscheduledWake,
-} from "./heartbeat-wake-policy.js";
+import { isConfiguredHeartbeatAgent, isTargetedUnscheduledWake } from "./heartbeat-wake-policy.js";
 import {
   areHeartbeatsEnabled,
   HEARTBEAT_SKIP_NO_PENDING_EVENT,
@@ -326,7 +323,7 @@ export function startHeartbeatRunner(opts: {
     const allowsUnscheduledTarget =
       requestedTargetAgentId !== undefined &&
       isConfiguredHeartbeatAgent(wakeConfig, requestedTargetAgentId) &&
-      isTargetedImmediateUnscheduledWake({
+      isTargetedUnscheduledWake({
         source: params.source,
         intent,
         reason,

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -852,6 +852,49 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("runs an exec-event wake for a configured agent when cadence is disabled", async () => {
+    const tmpDir = await createCaseDir("hb-disabled-exec-event");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "0m", target: "none" },
+        },
+        list: [{ id: "main" }],
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await seedWhatsAppSession(storePath, sessionKey);
+    enqueueSystemEvent("exec finished: backup completed", {
+      sessionKey,
+      contextKey: "exec:backup",
+    });
+
+    const replySpy = vi.fn();
+    replySpy.mockResolvedValue({ text: "Handled internally" });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+
+    const res = await runHeartbeatOnce({
+      cfg,
+      source: "exec-event",
+      intent: "event",
+      reason: "exec-event",
+      sessionKey,
+      deps: createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+    });
+
+    expect(res.status).toBe("ran");
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+    expect(replyBody(replySpy).Provider).toBe("exec-event");
+  });
+
   it.each([
     ["the heartbeat main session", (cfg: OpenClawConfig) => resolveMainSessionKey(cfg)],
     ["another session for the same agent", () => "agent:main:telegram:alerts"],

--- a/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
+++ b/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
@@ -130,6 +130,32 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
     },
   );
 
+  it("runs one targeted exec-event wake when heartbeat cadence is disabled", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = await expectWakeDispatch({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+      } as OpenClawConfig,
+      runSpy,
+      wake: {
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        sessionKey: "agent:main:main",
+        coalesceMs: 0,
+      },
+      expectedCall: {
+        agentId: "main",
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        sessionKey: "agent:main:main",
+      },
+    });
+    runner.stop();
+  });
+
   it("rejects targeted hook wakes for unconfigured agents", async () => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -60,7 +60,10 @@ type TargetedImmediateWakeParams = {
 };
 
 export function isTargetedImmediateUnscheduledWake(params: TargetedImmediateWakeParams): boolean {
-  if (params.intent !== "immediate") {
+  const reason = params.reason?.trim();
+  const isExecEventWake =
+    params.source === "exec-event" && params.intent === "event" && reason === "exec-event";
+  if (params.intent !== "immediate" && !isExecEventWake) {
     return false;
   }
   const hasSessionTarget = normalizeOptionalString(params.sessionKey) !== undefined;
@@ -70,12 +73,16 @@ export function isTargetedImmediateUnscheduledWake(params: TargetedImmediateWake
   }
 
   // These sources queue targeted events that would otherwise sit unread for a
-  // configured agent without a recurring heartbeat schedule.
+  // configured agent without a recurring heartbeat schedule. Exec completion
+  // wakes intentionally retain their event intent so they cannot broaden the
+  // existing immediate-wake exception.
   switch (params.source) {
     case "notifications-event":
-      return hasSessionTarget && params.reason?.trim() === "wake";
+      return hasSessionTarget && reason === "wake";
     case "hook":
-      return params.reason?.trim().startsWith("hook:") ?? false;
+      return reason?.startsWith("hook:") ?? false;
+    case "exec-event":
+      return isExecEventWake;
     case "background-task":
     case "background-task-blocked":
       return true;

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -51,7 +51,7 @@ export function resolveHeartbeatWakePayloadFlags(params: {
   };
 }
 
-type TargetedImmediateWakeParams = {
+type TargetedUnscheduledWakeParams = {
   source?: HeartbeatWakeSource;
   intent?: HeartbeatWakeIntent;
   reason?: string;
@@ -59,13 +59,7 @@ type TargetedImmediateWakeParams = {
   sessionKey?: string;
 };
 
-export function isTargetedImmediateUnscheduledWake(params: TargetedImmediateWakeParams): boolean {
-  const reason = params.reason?.trim();
-  const isExecEventWake =
-    params.source === "exec-event" && params.intent === "event" && reason === "exec-event";
-  if (params.intent !== "immediate" && !isExecEventWake) {
-    return false;
-  }
+export function isTargetedUnscheduledWake(params: TargetedUnscheduledWakeParams): boolean {
   const hasSessionTarget = normalizeOptionalString(params.sessionKey) !== undefined;
   const hasTarget = hasSessionTarget || normalizeOptionalString(params.agentId) !== undefined;
   if (!hasTarget) {
@@ -73,19 +67,20 @@ export function isTargetedImmediateUnscheduledWake(params: TargetedImmediateWake
   }
 
   // These sources queue targeted events that would otherwise sit unread for a
-  // configured agent without a recurring heartbeat schedule. Exec completion
-  // wakes intentionally retain their event intent so they cannot broaden the
-  // existing immediate-wake exception.
+  // configured agent without a recurring heartbeat schedule. Each case admits
+  // exactly its producer's shape; exec completions keep their event intent so
+  // they cannot broaden the immediate-wake exception.
+  const reason = params.reason?.trim();
   switch (params.source) {
     case "notifications-event":
-      return hasSessionTarget && reason === "wake";
+      return params.intent === "immediate" && hasSessionTarget && reason === "wake";
     case "hook":
-      return reason?.startsWith("hook:") ?? false;
+      return params.intent === "immediate" && (reason?.startsWith("hook:") ?? false);
     case "exec-event":
-      return isExecEventWake;
+      return params.intent === "event" && reason === "exec-event";
     case "background-task":
     case "background-task-blocked":
-      return true;
+      return params.intent === "immediate";
     default:
       return false;
   }

--- a/src/infra/heartbeat-wake.transcript-context.test.ts
+++ b/src/infra/heartbeat-wake.transcript-context.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  getOwnedSessionTranscriptWriterFence,
+  withOwnedSessionTranscriptWrites,
+} from "../config/sessions/transcript-write-context.js";
+import { requestHeartbeat, setHeartbeatWakeHandler } from "./heartbeat-wake.js";
+
+let dispose = () => {};
+
+afterEach(async () => {
+  dispose();
+  const disposeDrainHandler = setHeartbeatWakeHandler(async () => ({
+    status: "skipped",
+    reason: "disabled",
+  }));
+  await vi.runAllTimersAsync();
+  disposeDrainHandler();
+  vi.useRealTimers();
+});
+
+it("dispatches outside the requesting attempt transcript context", async () => {
+  vi.useFakeTimers();
+  let observedFence: ReturnType<typeof getOwnedSessionTranscriptWriterFence> | "not-called" =
+    "not-called";
+  dispose = setHeartbeatWakeHandler(async () => {
+    observedFence = getOwnedSessionTranscriptWriterFence();
+    return { status: "ran", durationMs: 1 };
+  });
+  await withOwnedSessionTranscriptWrites(
+    {
+      sessionTarget: { expectedWriterRunId: "disposed-requesting-run" },
+      withTranscriptWrite: async (run) => await run(),
+    },
+    async () =>
+      requestHeartbeat({
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        coalesceMs: 0,
+      }),
+  );
+  await vi.advanceTimersByTimeAsync(1);
+  expect(observedFence).toBeUndefined();
+});

--- a/src/infra/heartbeat-wake.transcript-context.test.ts
+++ b/src/infra/heartbeat-wake.transcript-context.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, expect, it } from "vitest";
 import {
   getOwnedSessionTranscriptWriterFence,
   withOwnedSessionTranscriptWrites,
@@ -7,25 +7,21 @@ import { requestHeartbeat, setHeartbeatWakeHandler } from "./heartbeat-wake.js";
 
 let dispose = () => {};
 
-afterEach(async () => {
+afterEach(() => {
   dispose();
-  const disposeDrainHandler = setHeartbeatWakeHandler(async () => ({
-    status: "skipped",
-    reason: "disabled",
-  }));
-  await vi.runAllTimersAsync();
-  disposeDrainHandler();
-  vi.useRealTimers();
 });
 
+// Real timers on purpose: fake timers fire callbacks from the test's own async
+// context, so they cannot observe the AsyncLocalStorage inheritance under test.
 it("dispatches outside the requesting attempt transcript context", async () => {
-  vi.useFakeTimers();
-  let observedFence: ReturnType<typeof getOwnedSessionTranscriptWriterFence> | "not-called" =
-    "not-called";
-  dispose = setHeartbeatWakeHandler(async () => {
-    observedFence = getOwnedSessionTranscriptWriterFence();
-    return { status: "ran", durationMs: 1 };
-  });
+  const observedFence = new Promise<ReturnType<typeof getOwnedSessionTranscriptWriterFence>>(
+    (resolve) => {
+      dispose = setHeartbeatWakeHandler(async () => {
+        resolve(getOwnedSessionTranscriptWriterFence());
+        return { status: "ran", durationMs: 1 };
+      });
+    },
+  );
   await withOwnedSessionTranscriptWrites(
     {
       sessionTarget: { expectedWriterRunId: "disposed-requesting-run" },
@@ -39,6 +35,5 @@ it("dispatches outside the requesting attempt transcript context", async () => {
         coalesceMs: 0,
       }),
   );
-  await vi.advanceTimersByTimeAsync(1);
-  expect(observedFence).toBeUndefined();
+  expect(await observedFence).toBeUndefined();
 });

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -1,4 +1,6 @@
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { runWithoutOwnedSessionTranscriptWrites } from "../config/sessions/transcript-write-context.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 // Tracks heartbeat wake requests, busy skips, and retry timing.
 import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { normalizeHeartbeatWakeReason } from "./heartbeat-reason.js";
@@ -111,6 +113,7 @@ export const HEARTBEAT_IDLE_RETRY_GRACE_MS = 60_000;
 // Heartbeat turns can start model/provider work; bound cross-target fan-out so
 // one aligned monitor tick cannot exhaust gateway or provider capacity.
 const MAX_CONCURRENT_HEARTBEAT_WAKE_TARGETS = 4;
+const wakeLog = createSubsystemLogger("heartbeat/wake");
 const REASON_PRIORITY = {
   RETRY: 0,
   INTERVAL: 1,
@@ -508,6 +511,10 @@ async function dispatchPendingWakeGroup(params: {
         result = await runWithGatewayIndependentRootWorkAdmission(async () =>
           runAbortableHeartbeatWake(active, wakeOpts, abortSignal),
         );
+        wakeLog.debug(
+          `completed: source=${pendingWake.source} intent=${pendingWake.intent} ` +
+            `status=${result.status} reason=${"reason" in result ? result.reason : "ran"}`,
+        );
       } catch {
         if (handlerGeneration !== generation) {
           handOffPendingWakeBatch(wakes, wakeIndex);
@@ -758,19 +765,17 @@ export function requestHeartbeat(opts: {
   tasks?: readonly HeartbeatScheduledTask[];
 }) {
   const requestedAt = Date.now();
-  const coalesceMs = opts.coalesceMs ?? DEFAULT_COALESCE_MS;
-  queuePendingWakeReason({
-    source: opts.source,
-    intent: opts.intent,
-    reason: opts.reason,
-    agentId: opts.agentId,
-    sessionKey: opts.sessionKey,
-    heartbeat: opts.heartbeat,
-    scheduledEveryMs: opts.scheduledEveryMs,
-    scheduledAnchorMs: opts.scheduledAnchorMs,
-    tasks: opts.tasks,
-    requestedAt,
-    readyAtMs: requestedAt + resolveTimerTimeoutMs(coalesceMs, DEFAULT_COALESCE_MS, 0),
+  const { coalesceMs: requestedCoalesceMs, ...wake } = opts;
+  const coalesceMs = requestedCoalesceMs ?? DEFAULT_COALESCE_MS;
+  // Wake timers outlive the attempt that requested them. Do not let their
+  // callback chain inherit that attempt's transcript writer: a later wake for
+  // the same session must acquire its own writer lifecycle.
+  runWithoutOwnedSessionTranscriptWrites(() => {
+    queuePendingWakeReason({
+      ...wake,
+      requestedAt,
+      readyAtMs: requestedAt + resolveTimerTimeoutMs(coalesceMs, DEFAULT_COALESCE_MS, 0),
+    });
+    schedule(coalesceMs);
   });
-  schedule(coalesceMs);
 }


### PR DESCRIPTION
Closes #62505

AI-assisted: Yes — implemented and validated with Codex; maintainer repair pass with Claude.

## What Problem This Solves

A background `tools.exec` run with `notifyOnExit` queues an `Exec completed …` system event and requests a targeted heartbeat wake (`source: "exec-event"`, `intent: "event"`, `reason: "exec-event"`). With `heartbeat.every: "0m"`, the runner rejected that wake as `disabled`: the scheduler admission gate and `resolveHeartbeatWakeStage` only admitted `intent: "immediate"` wakes without a cadence, so the queued completion never produced a follow-up agent turn — the worst class of failure here (silent, no recorded non-outcome for the user).

## Root Cause

`isTargetedImmediateUnscheduledWake` (`src/infra/heartbeat-wake-policy.ts`) was the single predicate both gates consume, and it required `intent === "immediate"`. Exec completions deliberately use `intent: "event"`, so the only two producers of that shape (`src/agents/bash-tools.exec-runtime.ts` `maybeNotifyOnExit`, `src/gateway/server-node-events.ts` node exec events) could never pass when cadence was disabled.

## Behavior Contract

`heartbeat.every: "0m"` disables recurring cadence. It does not suppress a bounded, explicitly targeted event wake that is already tied to queued agent work, such as a background exec completion:

- no recurring timer or periodic model probe is created;
- only the exact `exec-event` / `event` / `exec-event` producer shape is admitted, and it must target a session or agent;
- tool policy, sandboxing, busy, cooldown, and routing controls still apply;
- disabling `exec` or `notifyOnExit` prevents this completion path from existing.

Gateway, configuration, first-run, and FAQ docs now state this cadence-only meaning and the targeted-event exception explicitly.

## Fix

- `src/infra/heartbeat-wake-policy.ts`: the shared unscheduled-wake predicate is now `isTargetedUnscheduledWake`, one per-source switch where each case names the exact intent + reason it admits (`exec-event` admits `intent: "event"`; the existing sources keep `immediate`). Both the scheduler admission gate and the execution-stage gate consume it. Renamed because it no longer admits only immediate wakes.
- `src/infra/heartbeat-wake.ts`: `requestHeartbeat` queues and schedules the wake timer outside the requesting attempt's transcript-writer context (`runWithoutOwnedSessionTranscriptWrites`). Exec exit callbacks run inside the original attempt's `AsyncLocalStorage` context; without detaching, the later completion wake's delivery mirror inherits a disposed writer fence. Also logs each dispatched wake's outcome at debug level (`heartbeat/wake`), so a skipped targeted wake is a recorded non-outcome.
- Regression tests (each fails on the pre-fix code): `heartbeat-runner.targeted-unscheduled-wake.test.ts`, `heartbeat-runner.returns-default-unset.test.ts` (exec-event wake runs with cadence disabled), `heartbeat-wake.transcript-context.test.ts` (real timers — fake timers fire from the test's own async context and cannot observe the inherited fence).

## Evidence

Head: `7ef60992bee6eecb89091480b8747538269de845`

### Telegram E2E (real Telegram, mock provider, `heartbeat.every: "0m"`)

`$telegram-e2e-userbot` `exec-completion-wake` fixture (`run-mock-sut-user-e2e.mjs --dm --exec-completion-wake-fixture background --exec-completion-wake-expect …`): the model backgrounds `sleep 5; printf EXEC_COMPLETION_WAKE_OUTPUT`, replies `EXEC_COMPLETION_WAKE_STARTED`, then the gateway must deliver a second provider request carrying `Exec completed …` and relay `EXEC_COMPLETION_WAKE_RELAYED` to the chat.

- `main` (`672ac118c34`): `actual: affected` — 2 provider requests, 0 `Exec completed` requests, no follow-up message after `EXEC_COMPLETION_WAKE_STARTED`.
- This head: `actual: fixed` — 3 provider requests, 1 `Exec completed` request, follow-up message `EXEC_COMPLETION_WAKE_RELAYED` observed by the QA user; gateway log `heartbeat: disabled {"enabled": false}` confirms no recurring cadence.

Final-head run (`7ef60992`, real QA user DM, mock provider, `heartbeat.every: "0m"`, `tools.codeMode.enabled: false`):

```json
{"mode":"background","expected":"fixed","actual":"fixed","providerRequests":3,"backgroundExecCallObserved":true,"execExited":true,"startedReplyObserved":true,"completionWakeRequestObserved":true,"relayedReplyObserved":true}
```

Recorded SUT timeline (ms since send): `1532 message#1943 "Working / 🛠️ Exec"` → `2879 message#1944 "EXEC_COMPLETION_WAKE_STARTED"` → `5746 delete#1943` → `7750 message#1945` (215 chars, ends `EXEC_COMPLETION_WAKE_RELAYED`). Sent user message id `2036334592`. The same fixture on `main` (`672ac118c34`) stops at message `EXEC_COMPLETION_WAKE_STARTED` with 0 `Exec completed` provider requests (`actual: affected`).

### Local proof (this head)

- `git diff --check` — clean.
- `node_modules/.bin/oxfmt --check <all touched files>` — clean.
- `pnpm tsgo` — passed; `pnpm check:test-types` — passed.
- `node scripts/run-vitest.mjs src/infra/heartbeat*.test.ts` (every colocated heartbeat test, 37 files) — 492 tests passed.
- `pnpm docs:check-mdx` — passed (777 files).
- Pre-fix proof: with `src/infra/heartbeat-wake-policy.ts` + `src/infra/heartbeat-wake.ts` reset to merge-base `74189fb3547`, `heartbeat-runner.targeted-unscheduled-wake.test.ts` and `heartbeat-runner.returns-default-unset.test.ts` fail (`2 failed | 62 passed`); with `heartbeat-wake.ts` alone reset, the rewritten `heartbeat-wake.transcript-context.test.ts` fails with `expected { expectedWriterRunId: "disposed-requesting-run" } to be undefined`. The original fake-timer version of that test passed on pre-fix code, which is why it was rewritten.
- Local ClawSweeper (`gpt-5.6-terra`, head `7ef60992`): `patch is correct`, 0 findings, security cleared.

### Prior live proof (head `d910be11`, hosted model)

Isolated foreground Gateway, `openai/gpt-5.4-mini`, `heartbeat.every: "0m"`, `notifyOnExit: true`, heartbeat target `none`: the completion caused an exact `source=exec-event intent=event status=ran` wake, no interval heartbeat ran or was delivered, operator gateway untouched.

## Maintainer Decision (ClawSweeper `0m` contract)

ClawSweeper asks whether `heartbeat.every: "0m"` is cadence-only (this PR) or a complete heartbeat-turn disable. This PR implements cadence-only, per the Product Doctrine (a queued completion that silently never runs is the worst failure class; the wake is bounded, exact-shape, targeted, and needs `exec` + `notifyOnExit` to exist). Operators who want no model turn at all disable `tools.exec.notifyOnExit` or `exec`. Maintainer decision (Ayaan Zaidi, 2026-08-23): `0m` is cadence-only; this PR lands as-is. Operators who want no model turn at all disable `tools.exec.notifyOnExit` or the `exec` tool.

The "refresh hosted-model proof on the current head" move is answered by the real-Telegram exec-completion run on `7ef60992` above, which exercises the same changed path end to end through a real channel (the AGENTS.md real-behavior-proof gate accepts the mock-provider gateway harness; live-channel proof is the stronger form).

## Review Notes

- Risk is limited to the exact targeted completion producer shape; recurring cadence stays off under `0m`.
- Known pre-existing behavior (not changed here): when heartbeat delivery relays the exec completion to a chat target, the first relayed message carries the `First heartbeat alert: …` preamble (`src/infra/heartbeat-runner-delivery.ts`); that preamble text describes periodic checks and reads oddly for an event-driven completion — follow-up candidate.
- No public API or configuration schema changes.
