### PR TITLE
test: trim native test mirrors

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayProtocolGeneratedTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayProtocolGeneratedTest.kt
@@ -67,7 +67,7 @@ class GatewayProtocolGeneratedTest {
   }
 
   @Test
-  fun githubPublicationResultsRoundTripAsATypedUnion() {
+  fun githubPublicationResultsDecodeAsATypedUnion() {
     val cases =
       listOf(
         """{"requestId":"request-1","status":"requested","message":"Accepted."}""" to
@@ -83,22 +83,11 @@ class GatewayProtocolGeneratedTest {
     for ((payload, expectedType) in cases) {
       val decoded = json.decodeFromString(SessionGitHubPublicationResult.serializer(), payload)
       assertEquals(expectedType, decoded::class)
-      val encoded =
-        json.encodeToJsonElement(SessionGitHubPublicationResult.serializer(), decoded).jsonObject
-      assertEquals(
-        json
-          .parseToJsonElement(payload)
-          .jsonObject
-          .getValue("status")
-          .jsonPrimitive
-          .content,
-        encoded.getValue("status").jsonPrimitive.content,
-      )
     }
   }
 
   @Test
-  fun githubDeviceAuthorizationResultsRoundTripAsATypedUnion() {
+  fun githubDeviceAuthorizationResultsDecodeAsATypedUnion() {
     val cases =
       listOf(
         """{"status":"pending","retryAfterMs":5000}""" to
@@ -120,19 +109,6 @@ class GatewayProtocolGeneratedTest {
     for ((payload, expectedType) in cases) {
       val decoded = json.decodeFromString(ToolsGitHubAuthorizePollResult.serializer(), payload)
       assertEquals(expectedType, decoded::class)
-      val encoded =
-        json
-          .encodeToJsonElement(ToolsGitHubAuthorizePollResult.serializer(), decoded)
-          .jsonObject
-      assertEquals(
-        json
-          .parseToJsonElement(payload)
-          .jsonObject
-          .getValue("status")
-          .jsonPrimitive
-          .content,
-        encoded.getValue("status").jsonPrimitive.content,
-      )
     }
   }
 }

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -3224,7 +3224,7 @@ extension NodeAppModel {
         true
     }
 
-    static func decodeParams<T: Decodable>(_ type: T.Type, from json: String?) throws -> T {
+    fileprivate static func decodeParams<T: Decodable>(_ type: T.Type, from json: String?) throws -> T {
         guard let json, let data = json.data(using: .utf8) else {
             throw NSError(domain: "Gateway", code: 20, userInfo: [
                 NSLocalizedDescriptionKey: "INVALID_REQUEST: paramsJSON required",
@@ -3233,7 +3233,7 @@ extension NodeAppModel {
         return try JSONDecoder().decode(type, from: data)
     }
 
-    static func encodePayload(_ obj: some Encodable) throws -> String {
+    fileprivate static func encodePayload(_ obj: some Encodable) throws -> String {
         let data = try JSONEncoder().encode(obj)
         guard let json = String(bytes: data, encoding: .utf8) else {
             throw NSError(domain: "NodeAppModel", code: 21, userInfo: [

--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -975,24 +975,6 @@ private func overrideNotificationServingPreference(_ enabled: Bool) -> () -> Voi
 }
 
 @Suite(.serialized) struct NodeAppModelInvokeTests {
-    @Test @MainActor func `decode params fails without JSON`() {
-        struct RequiredPayload: Decodable {
-            var value: String
-        }
-
-        #expect(throws: Error.self) {
-            _ = try NodeAppModel.decodeParams(RequiredPayload.self, from: nil)
-        }
-    }
-
-    @Test @MainActor func `encode payload emits JSON`() throws {
-        struct Payload: Codable, Equatable {
-            var value: String
-        }
-        let json = try NodeAppModel.encodePayload(Payload(value: "ok"))
-        #expect(json.contains("\"value\""))
-    }
-
     @Test @MainActor func `health summary routes a fixed period to the health service`() async throws {
         let service = MockHealthSummaryService()
         let appModel = NodeAppModel(healthSummaryService: service)

--- a/apps/ios/Tests/RootTabsSourceGuardTests.swift
+++ b/apps/ios/Tests/RootTabsSourceGuardTests.swift
@@ -48,41 +48,6 @@ struct RootTabsSourceGuardTests {
         #expect(startupTask.contains("self.appDelegate.scenePhaseChanged(self.scenePhase)"))
     }
 
-    @Test func `hidden sidebar reveal uses destination header without reserved rail`() throws {
-        let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
-        let componentSource = try String(contentsOf: Self.proComponentsSourceURL(), encoding: .utf8)
-
-        #expect(source.contains("sidebarHeaderAction"))
-        #expect(source.contains("Hide Sidebar"))
-        #expect(source.contains("Show Sidebar"))
-        #expect(source.contains("shouldShowSidebarRevealInDestinationHeader"))
-        #expect(source.contains("layoutMode: self.isSidebarDrawerLayout ? .drawer : .split"))
-        #expect(componentSource.contains("OpenClawSidebarHeaderLeadingSlot"))
-        #expect(componentSource.contains(".frame(width: 44, height: 44)"))
-        #expect(source.contains("Self.sidebarShowButtonAccessibilityIdentifier"))
-        #expect(source.contains("Self.sidebarHideButtonAccessibilityIdentifier"))
-        #expect(source.contains("accessibilityLabel: .localized(\"Hide Sidebar\")"))
-        #expect(source.contains("accessibilityLabel: .localized(\"Show Sidebar\")"))
-        #expect(source.contains("action: { self.hideSidebar() }"))
-        #expect(source.contains("action: { self.showSidebar() }"))
-        #expect(!source.contains("private var collapsedSidebarRail: some View"))
-        #expect(!source.contains("Self.sidebarCollapsedRailWidth"))
-        #expect(source.contains("requestedInitialSidebarVisibility"))
-        #expect(!source.contains("@State private var splitColumnVisibility: NavigationSplitViewVisibility"))
-        #expect(!source.contains("NavigationSplitView(columnVisibility: self.$splitColumnVisibility)"))
-        #expect(source.contains("HStack(spacing: 0)"))
-        #expect(!source.contains("self.syncSidebarVisibility(from: visibility)"))
-        #expect(!source.contains("shouldReserveSidebarRevealInset"))
-        #expect(!source.contains("safeAreaInset(edge: .top"))
-        #expect(!source.contains("thinMaterial, in: Circle"))
-        #expect(!source.contains("sidebarRevealInset"))
-        #expect(source.contains(".background(OpenClawSidebarPalette.background)"))
-        #expect(!source.contains("Color.black.opacity(0.35)"))
-        #expect(!source.contains("sidebarRevealCornerButton"))
-        #expect(!source.contains("shouldShowSidebarRevealOverlay"))
-        #expect(!source.contains("shouldShowOverviewHeaderSidebarReveal"))
-    }
-
     @Test func `i pad split stays integrated while compact drawer uses one local shell`() throws {
         let source = try String(contentsOf: Self.rootTabsSourceURL(), encoding: .utf8)
         let splitContent = try Self.extract(

--- a/apps/macos/Tests/OpenClawIPCTests/AppLaunchPresentationPolicyTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppLaunchPresentationPolicyTests.swift
@@ -126,17 +126,15 @@ struct AppLaunchRuntimePlanTests {
             hasVisibleWindows: true) == .accessory)
     }
 
-    @Test func `elevation host derives its mandatory computer control role in memory`() {
+    @Test func `elevation host derives pause and Peekaboo roles in memory`() {
         let interactive = AppLaunchRuntimePlan(arguments: ["OpenClaw"])
         let elevation = AppLaunchRuntimePlan(arguments: ["OpenClaw", "--elevation-host"])
 
         for storedValue in [false, true] {
             #expect(interactive.resolvePaused(storedValue) == storedValue)
-            #expect(interactive.resolveComputerControlEnabled(storedValue) == storedValue)
             #expect(interactive.resolvePeekabooBridgeEnabled(storedValue) == storedValue)
         }
         #expect(!elevation.resolvePaused(true))
-        #expect(elevation.resolveComputerControlEnabled(false))
         #expect(elevation.resolvePeekabooBridgeEnabled(false))
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -145,13 +145,6 @@ struct OnboardingViewSmokeTests {
             requiresCLIInstall: true)
 
         #expect(order.contains(2))
-        #expect(OnboardingView.shouldAutoInstallCLI(
-            onCLIPage: order.contains(2),
-            visible: true,
-            statusKnown: true,
-            executableReady: false,
-            installed: false,
-            installing: false))
         #expect(!OnboardingView.shouldActivateLocalGateway(afterCLIInstallFor: .remote))
         #expect(OnboardingView.shouldActivateLocalGateway(afterCLIInstallFor: .local))
     }


### PR DESCRIPTION
## What Problem This Solves

Native regression suites had accumulated source-text mirrors, self-generated serialization round trips, and repeated helper assertions. Those checks duplicated stronger behavior coverage, forced test edits during behavior-preserving refactors, and kept two iOS JSON helpers more visible than their production callers require.

## Why This Change Was Made

This removes the redundant Android, iOS, and macOS assertions while preserving the real decoder fixtures, settings-boundary tests, sidebar policy and interaction coverage, and onboarding predicate table. The iOS JSON helpers return to file-private visibility because all production callers live in their owning source file.

## User Impact

No user-visible behavior changes. The native suites are smaller and less coupled to implementation details, while the behavior-owning tests remain intact.

AI-assisted: yes.

## Review Follow-up

ClawSweeper suggested restoring the two direct `resolveComputerControlEnabled` expectations. I am intentionally not restoring them: `ComputerControlSettingsTests.elevation host ignores enabled CUA defaults while normal launches preserve them` retains the stronger owner-boundary proof through `isComputerControlEnabled`, including an explicit stored `false` remaining false for an interactive plan and becoming true for an elevation-host plan. The deleted launch-plan expectations replayed that private helper directly without adding a distinct failure mode.

## Evidence

- `swift test --package-path apps/macos --filter 'OnboardingViewSmokeTests|AppLaunchRuntimePlanTests|ComputerControlSettingsTests'` — 42 tests passed across 3 suites.
- Focused iOS `xcodebuild` run for `RootTabsSourceGuardTests`, `RootTabsPresentationTests`, `RootTabsSidebarRegressionTests`, and `NodeAppModelInvokeTests` — 353 tests passed across 4 suites.
- `pnpm protocol:check:kotlin` — generated Kotlin protocol remained current.
- `pnpm check:changed` — passed, including app formatting/lint, macOS CI tests, and native schema guards.
- `pnpm test:changed` — no Vitest targets selected, as expected for native-only files.
- Fresh structured autoreview — no accepted or actionable findings.
- Local Android unit execution was unavailable because this host has no Java runtime; exact-head CI remains the Android execution proof.

Production delta: two visibility substitutions (`+2/-2`). Test delta: `+3/-89`. No screenshots are needed because rendered behavior is unchanged.
