### PR TITLE
fix(gateway): preserve incognito session visibility

### DIFF
--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -31,7 +31,9 @@ import {
 } from "../sessions/agent-harness-session-key.js";
 import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { getHeader } from "./http-auth-utils.js";
+import { ADMIN_SCOPE } from "./method-scopes.js";
 import { loadGatewayModelCatalog } from "./server-model-catalog.js";
+import { isResolvedIncognitoSession } from "./session-sharing.js";
 import { canonicalizeSessionKeyForAgent } from "./session-store-key.js";
 
 export {
@@ -307,4 +309,22 @@ export function resolveGatewayRequestContext(params: {
     : params.defaultMessageChannel;
 
   return { agentId, sessionKey, messageChannel };
+}
+
+export function authorizeOpenAiCompatibleHttpSession(params: {
+  agentId: string;
+  sessionKey: string;
+  senderIsOwner: boolean;
+}): { allowed: true } | { allowed: false; missingScope: typeof ADMIN_SCOPE } {
+  if (
+    params.senderIsOwner ||
+    !isResolvedIncognitoSession({
+      cfg: getRuntimeConfig(),
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+    })
+  ) {
+    return { allowed: true };
+  }
+  return { allowed: false, missingScope: ADMIN_SCOPE };
 }

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -16,6 +16,7 @@ import { FailoverError } from "../agents/failover-error.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
+import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
@@ -3556,6 +3557,17 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
             openAiChatCompletionsEnabled: true,
           });
 
+          const incognitoSessionKey = "agent:main:dashboard:incognito-openai-http";
+          await upsertSessionEntryCore(
+            { agentId: "main", sessionKey: incognitoSessionKey },
+            {
+              sessionId: "session-incognito-openai-http",
+              updatedAt: 1,
+              incognito: true,
+              visibility: "shared",
+            },
+          );
+
           for (const stream of [false, true]) {
             for (const { scopes, senderIsOwner } of [
               { scopes: "operator.write", senderIsOwner: false },
@@ -3586,6 +3598,44 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
               expect(firstAgentCommandOptions()?.senderIsOwner).toBe(senderIsOwner);
             }
           }
+
+          const trustedProxyHeaders = {
+            "x-forwarded-for": "198.51.100.42",
+            "x-forwarded-proto": "https",
+            "x-forwarded-user": "operator@example.com",
+          };
+          for (const requestedSessionKey of [
+            incognitoSessionKey,
+            "dashboard:incognito-openai-http",
+          ]) {
+            agentCommandMock.mockClear();
+            const denied = await postChatCompletions(
+              port,
+              { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+              {
+                ...trustedProxyHeaders,
+                "x-openclaw-scopes": "operator.write",
+                "x-openclaw-session-key": requestedSessionKey,
+              },
+            );
+            expect(denied.status).toBe(403);
+            await denied.text();
+            expect(agentCommandMock).not.toHaveBeenCalled();
+          }
+
+          agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+          const allowed = await postChatCompletions(
+            port,
+            { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+            {
+              ...trustedProxyHeaders,
+              "x-openclaw-scopes": "operator.admin, operator.write",
+              "x-openclaw-session-key": "dashboard:incognito-openai-http",
+            },
+          );
+          expect(allowed.status).toBe(200);
+          await allowed.text();
+          expect(agentCommandMock).toHaveBeenCalledTimes(1);
 
           agentCommandMock.mockClear();
           const unauthorized = await postChatCompletions(

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -54,6 +54,7 @@ import {
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   authorizeOpenAiCompatibleHttpModelOverride,
+  authorizeOpenAiCompatibleHttpSession,
   isAgentSelectionRequiredError,
   isGatewaySessionKeyOverrideError,
   isInvalidGatewayModelError,
@@ -997,6 +998,15 @@ export async function handleOpenAiHttpRequest(
       return true;
     }
     throw err;
+  }
+  const sessionAuth = authorizeOpenAiCompatibleHttpSession({
+    agentId,
+    sessionKey,
+    senderIsOwner,
+  });
+  if (!sessionAuth.allowed) {
+    sendMissingScopeForbidden(res, sessionAuth.missingScope);
+    return true;
   }
   const { modelOverride, errorMessage: modelError } = await resolveOpenAiCompatModelOverride({
     req,

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -11,6 +11,7 @@ import { FailoverError } from "../agents/failover-error.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { resetConfigRuntimeState } from "../config/config.js";
+import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { enqueueCommandInLane } from "../process/command-queue.js";
 import {
@@ -1954,6 +1955,17 @@ describe("OpenResponses HTTP API (e2e)", () => {
             openResponsesEnabled: true,
           });
 
+          const incognitoSessionKey = "agent:main:dashboard:incognito-openresponses-http";
+          await upsertSessionEntryCore(
+            { agentId: "main", sessionKey: incognitoSessionKey },
+            {
+              sessionId: "session-incognito-openresponses-http",
+              updatedAt: 1,
+              incognito: true,
+              visibility: "shared",
+            },
+          );
+
           for (const stream of [false, true]) {
             for (const { scopes, senderIsOwner } of [
               { scopes: "operator.write", senderIsOwner: false },
@@ -1980,6 +1992,44 @@ describe("OpenResponses HTTP API (e2e)", () => {
               expect(firstAgentOpts().senderIsOwner).toBe(senderIsOwner);
             }
           }
+
+          const trustedProxyHeaders = {
+            "x-forwarded-for": "198.51.100.42",
+            "x-forwarded-proto": "https",
+            "x-forwarded-user": "operator@example.com",
+          };
+          for (const requestedSessionKey of [
+            incognitoSessionKey,
+            "dashboard:incognito-openresponses-http",
+          ]) {
+            agentCommandMock.mockClear();
+            const denied = await postResponses(
+              port,
+              { model: "openclaw", input: "hi" },
+              {
+                ...trustedProxyHeaders,
+                "x-openclaw-scopes": "operator.write",
+                "x-openclaw-session-key": requestedSessionKey,
+              },
+            );
+            expect(denied.status).toBe(403);
+            await ensureResponseConsumed(denied);
+            expect(agentCommandMock).not.toHaveBeenCalled();
+          }
+
+          agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+          const allowed = await postResponses(
+            port,
+            { model: "openclaw", input: "hi" },
+            {
+              ...trustedProxyHeaders,
+              "x-openclaw-scopes": "operator.admin, operator.write",
+              "x-openclaw-session-key": "dashboard:incognito-openresponses-http",
+            },
+          );
+          expect(allowed.status).toBe(200);
+          await ensureResponseConsumed(allowed);
+          expect(agentCommandMock).toHaveBeenCalledTimes(1);
 
           agentCommandMock.mockClear();
           agentCommandMock.mockResolvedValue({ payloads: [{ text: "hello" }] } as never);

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -54,6 +54,7 @@ import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   type AuthorizedGatewayHttpRequest,
   authorizeOpenAiCompatibleHttpModelOverride,
+  authorizeOpenAiCompatibleHttpSession,
   getBearerToken,
   getHeader,
   isAgentSelectionRequiredError,
@@ -643,6 +644,15 @@ export async function handleOpenResponsesHttpRequest(
   );
   const sessionKey = previousSessionKey ?? resolved.sessionKey;
   const messageChannel = resolved.messageChannel;
+  const sessionAuth = authorizeOpenAiCompatibleHttpSession({
+    agentId: resolved.agentId,
+    sessionKey,
+    senderIsOwner,
+  });
+  if (!sessionAuth.allowed) {
+    sendMissingScopeForbidden(res, sessionAuth.missingScope);
+    return true;
+  }
 
   const fileContext = fileContexts.length > 0 ? fileContexts.join("\n\n") : undefined;
   const toolChoiceContext = toolChoicePrompt?.trim();

--- a/src/gateway/server-methods/artifacts-session-resolution.test.ts
+++ b/src/gateway/server-methods/artifacts-session-resolution.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import {
+  ArtifactSessionResolutionError,
+  resolveAuthorizedArtifactSession,
+} from "./artifacts-session-resolution.js";
+import type { GatewayClient } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  getTaskSession: vi.fn(),
+  resolveRunSession: vi.fn(),
+}));
+
+vi.mock("../../tasks/task-status-access.js", () => ({
+  getTaskSessionLookupByIdForStatus: mocks.getTaskSession,
+}));
+
+vi.mock("../server-session-key.js", () => ({
+  resolveSessionKeyForRun: mocks.resolveRunSession,
+}));
+
+function identifiedClient(scopes: string[]): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
+      role: "operator",
+      scopes,
+    },
+    authenticatedUserId: "viewer@example.com",
+    authenticatedUserProfile: {
+      profileId: "viewer@example.com",
+      displayName: null,
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
+}
+
+describe("artifact session authorization", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("denies direct and indirect incognito selectors while preserving admin access", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const sessionKey = "agent:main:dashboard:incognito-artifacts";
+      const cfg = { agents: { list: [{ id: "main", default: true }] } };
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: "session-incognito-artifacts",
+          updatedAt: 1,
+          incognito: true,
+          visibility: "shared",
+        },
+      );
+      mocks.getTaskSession.mockReturnValue({
+        requesterSessionKey: sessionKey,
+        requesterAgentId: "main",
+        ownerKey: sessionKey,
+      });
+      mocks.resolveRunSession.mockReturnValue(sessionKey);
+      const viewer = identifiedClient(["operator.read"]);
+
+      expect(() =>
+        resolveAuthorizedArtifactSession(
+          { sessionKey: "dashboard:incognito-artifacts", agentId: "main" },
+          cfg,
+          viewer,
+        ),
+      ).toThrow('Incognito session "dashboard:incognito-artifacts" was not found.');
+      for (const query of [{ taskId: "task-private" }, { runId: "run-private" }]) {
+        try {
+          resolveAuthorizedArtifactSession(query, cfg, viewer);
+          throw new Error("expected incognito artifact selector to be denied");
+        } catch (error) {
+          expect(error).toBeInstanceOf(ArtifactSessionResolutionError);
+          expect((error as ArtifactSessionResolutionError).shape).toMatchObject({
+            message: "no session found for artifact query",
+            details: { type: "artifact_scope_not_found" },
+          });
+        }
+      }
+
+      expect(
+        resolveAuthorizedArtifactSession(
+          { sessionKey: "dashboard:incognito-artifacts", agentId: "main" },
+          cfg,
+          identifiedClient(["operator.admin"]),
+        ),
+      ).toMatchObject({ sessionKey });
+    });
+  });
+});

--- a/src/gateway/server-methods/artifacts-session-resolution.ts
+++ b/src/gateway/server-methods/artifacts-session-resolution.ts
@@ -1,0 +1,191 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/index.js";
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import { resolvePersistedSessionStoreOwnerForKey } from "../../config/sessions/session-store-owner.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  normalizeAgentId,
+  parseAgentSessionKey,
+  resolveAgentIdFromSessionKey,
+  toAgentStoreSessionKey,
+} from "../../routing/session-key.js";
+import { getTaskSessionLookupByIdForStatus } from "../../tasks/task-status-access.js";
+import { resolveSessionKeyForRun } from "../server-session-key.js";
+import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
+import {
+  authorizeIncognitoSessionTarget,
+  resolveSessionSharingTarget,
+} from "../session-sharing.js";
+import {
+  resolveSessionStoreAgentId,
+  resolveStoredSessionKeyForAgentStore,
+} from "../session-store-key.js";
+import type { GatewayClient } from "./types.js";
+
+export type ArtifactQuery = {
+  sessionKey?: string;
+  runId?: string;
+  taskId?: string;
+  agentId?: string;
+};
+
+type ResolvedArtifactSession = {
+  sessionKey: string;
+  agentId?: string;
+};
+
+function resolveArtifactSessionAgentId(
+  sessionKey: string | undefined,
+  cfg?: OpenClawConfig,
+): string | undefined {
+  const key = normalizeOptionalString(sessionKey);
+  if (!key) {
+    return undefined;
+  }
+  const parsed = parseAgentSessionKey(key);
+  if (!parsed && key.toLowerCase().startsWith("agent:")) {
+    return undefined;
+  }
+  if (cfg) {
+    const owner = resolveRequestedSessionAgentId(cfg, key);
+    if (!owner.ok) {
+      throw new ArtifactSessionResolutionError(owner.error);
+    }
+    return owner.agentId;
+  }
+  return parsed?.agentId ?? resolveAgentIdFromSessionKey(key);
+}
+
+function resolveScopedArtifactSessionKey(
+  sessionKey: string | undefined,
+  agentId: string | undefined,
+  cfg?: OpenClawConfig,
+): string | undefined {
+  const key = normalizeOptionalString(sessionKey);
+  if (!key) {
+    return undefined;
+  }
+  const scopedAgentId = normalizeOptionalString(agentId);
+  if (!scopedAgentId) {
+    return key;
+  }
+  const parsed = parseAgentSessionKey(key);
+  if (!parsed && key.toLowerCase().startsWith("agent:")) {
+    return undefined;
+  }
+  if (!cfg) {
+    return parsed && parsed.agentId !== normalizeAgentId(scopedAgentId)
+      ? undefined
+      : toAgentStoreSessionKey({ agentId: scopedAgentId, requestKey: key });
+  }
+  const scopedKey = resolveStoredSessionKeyForAgentStore({
+    cfg,
+    agentId: scopedAgentId,
+    sessionKey: key,
+  });
+  return scopedKey !== "global" &&
+    scopedKey !== "unknown" &&
+    resolveSessionStoreAgentId(cfg, scopedKey) !== normalizeAgentId(scopedAgentId)
+    ? undefined
+    : scopedKey;
+}
+
+function resolveQuerySession(
+  query: ArtifactQuery,
+  cfg?: OpenClawConfig,
+): ResolvedArtifactSession | undefined {
+  if (query.sessionKey) {
+    const sessionKey = resolveScopedArtifactSessionKey(query.sessionKey, query.agentId, cfg);
+    return sessionKey
+      ? { sessionKey, ...(query.agentId ? { agentId: query.agentId } : {}) }
+      : undefined;
+  }
+  if (query.runId) {
+    // A live run context can resolve its own agent-scoped key. Do not force an
+    // unrelated default-agent selection before consulting that authoritative row.
+    const sessionKey = resolveSessionKeyForRun(
+      query.runId,
+      query.agentId ? { agentId: query.agentId } : {},
+    );
+    const agentId =
+      query.agentId ??
+      resolveArtifactSessionAgentId(sessionKey, cfg) ??
+      resolveSessionAgentId({ config: cfg });
+    const scopedSessionKey = resolveScopedArtifactSessionKey(sessionKey, agentId, cfg);
+    return scopedSessionKey ? { sessionKey: scopedSessionKey, agentId } : undefined;
+  }
+  if (!query.taskId) {
+    return undefined;
+  }
+  const task = getTaskSessionLookupByIdForStatus(query.taskId);
+  const requesterSessionKey = normalizeOptionalString(task?.requesterSessionKey);
+  const ownerAgentId = parseAgentSessionKey(task?.ownerKey)?.agentId;
+  const persistedRequesterOwner = requesterSessionKey
+    ? resolvePersistedSessionStoreOwnerForKey(cfg ?? {}, requesterSessionKey)
+    : { kind: "none" as const };
+  const requesterAgentId =
+    normalizeOptionalString(task?.requesterAgentId) ??
+    ownerAgentId ??
+    (persistedRequesterOwner.kind === "configured"
+      ? persistedRequesterOwner.agentId
+      : resolveArtifactSessionAgentId(requesterSessionKey, cfg));
+  const taskAgentId = normalizeOptionalString(task?.agentId) ?? requesterAgentId;
+  if (
+    query.agentId &&
+    taskAgentId &&
+    normalizeAgentId(query.agentId) !== normalizeAgentId(taskAgentId)
+  ) {
+    return undefined;
+  }
+  if (requesterSessionKey) {
+    // task.agentId identifies the executor. requesterAgentId keeps global
+    // requester transcripts in the correct agent store across restarts.
+    const sessionAgentId =
+      requesterAgentId ?? resolveArtifactSessionAgentId(requesterSessionKey, cfg);
+    const scopedSessionKey = sessionAgentId
+      ? resolveScopedArtifactSessionKey(requesterSessionKey, sessionAgentId, cfg)
+      : undefined;
+    return scopedSessionKey ? { sessionKey: scopedSessionKey, agentId: sessionAgentId } : undefined;
+  }
+  const agentId = query.agentId ?? taskAgentId ?? resolveSessionAgentId({ config: cfg });
+  const runId = normalizeOptionalString(task?.runId);
+  const sessionKey = runId ? resolveSessionKeyForRun(runId, { agentId }) : undefined;
+  const scopedSessionKey = resolveScopedArtifactSessionKey(sessionKey, agentId, cfg);
+  return scopedSessionKey ? { sessionKey: scopedSessionKey, agentId } : undefined;
+}
+
+export class ArtifactSessionResolutionError extends Error {
+  constructor(readonly shape: ReturnType<typeof errorShape>) {
+    super(shape.message);
+  }
+}
+
+export function resolveAuthorizedArtifactSession(
+  query: ArtifactQuery,
+  cfg: OpenClawConfig | undefined,
+  client: GatewayClient | null,
+): ResolvedArtifactSession | undefined {
+  const resolved = resolveQuerySession(query, cfg);
+  if (!resolved) {
+    return undefined;
+  }
+  const error = authorizeIncognitoSessionTarget({
+    client,
+    sessionKey: query.sessionKey ?? resolved.sessionKey,
+    target: resolveSessionSharingTarget({
+      cfg: cfg ?? {},
+      sessionKey: resolved.sessionKey,
+      agentId: resolved.agentId,
+    }),
+  });
+  if (!error) {
+    return resolved;
+  }
+  throw new ArtifactSessionResolutionError(
+    query.sessionKey
+      ? error
+      : errorShape(ErrorCodes.INVALID_REQUEST, "no session found for artifact query", {
+          details: { type: "artifact_scope_not_found" },
+        }),
+  );
+}

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -17,30 +17,17 @@ import {
   validateArtifactsListParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { AgentSelectionRequiredError } from "../../agents/agent-scope-config.js";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
-import { resolvePersistedSessionStoreOwnerForKey } from "../../config/sessions/session-store-owner.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  normalizeAgentId,
-  parseAgentSessionKey,
-  resolveAgentIdFromSessionKey,
-  toAgentStoreSessionKey,
-} from "../../routing/session-key.js";
-import { getTaskSessionLookupByIdForStatus } from "../../tasks/task-status-access.js";
+import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import {
   parseManagedOutgoingArtifactId,
   resolveManagedOutgoingMediaArtifactDownload,
   resolveManagedOutgoingMediaUrlDownload,
 } from "../managed-image-attachments.js";
-import { resolveSessionKeyForRun } from "../server-session-key.js";
 import {
   resolveRequestedSessionAgentId,
   tryResolveSessionCompatibilityOwnerAgentId,
 } from "../session-request-agent.js";
-import {
-  resolveSessionStoreAgentId,
-  resolveStoredSessionKeyForAgentStore,
-} from "../session-store-key.js";
 import { visitSessionMessagesAsync } from "../session-transcript-readers.js";
 import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
 import {
@@ -49,7 +36,12 @@ import {
   mimeFromDataUrl,
   readArtifactBase64Payload,
 } from "./artifacts-base64.js";
-import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import {
+  ArtifactSessionResolutionError,
+  type ArtifactQuery,
+  resolveAuthorizedArtifactSession,
+} from "./artifacts-session-resolution.js";
+import type { GatewayClient, GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 type ArtifactDownloadMode = ArtifactSummary["download"]["mode"];
@@ -59,21 +51,9 @@ type ArtifactRecord = ArtifactSummary & {
   url?: string;
 };
 
-type ArtifactQuery = {
-  sessionKey?: string;
-  runId?: string;
-  taskId?: string;
-  agentId?: string;
-};
-
 type ArtifactCollectionOptions = {
   includeDownloadData?: boolean;
   downloadArtifactId?: string;
-};
-
-type ResolvedArtifactSession = {
-  sessionKey: string;
-  agentId?: string;
 };
 
 function admitArtifactQuery<T extends ArtifactQuery>(
@@ -100,70 +80,6 @@ function artifactError(type: string, message: string, details?: Record<string, u
       ...details,
     },
   });
-}
-
-function resolveArtifactSessionAgentId(
-  sessionKey: string | undefined,
-  cfg?: OpenClawConfig,
-): string | undefined {
-  const key = asNonEmptyString(sessionKey);
-  if (!key) {
-    return undefined;
-  }
-  const parsed = parseAgentSessionKey(key);
-  if (!parsed && key.toLowerCase().startsWith("agent:")) {
-    return undefined;
-  }
-  if (cfg) {
-    const owner = resolveRequestedSessionAgentId(cfg, key);
-    if (!owner.ok) {
-      throw new ArtifactSessionResolutionError(owner.error);
-    }
-    return owner.agentId;
-  }
-  if (parsed) {
-    return parsed.agentId;
-  }
-  return resolveAgentIdFromSessionKey(key);
-}
-
-/** Applies an optional agent scope to a transcript session key without crossing stores. */
-function resolveScopedArtifactSessionKey(
-  sessionKey: string | undefined,
-  agentId: string | undefined,
-  cfg?: OpenClawConfig,
-): string | undefined {
-  const key = asNonEmptyString(sessionKey);
-  if (!key) {
-    return undefined;
-  }
-  const scopedAgentId = asNonEmptyString(agentId);
-  if (!scopedAgentId) {
-    return key;
-  }
-  const parsed = parseAgentSessionKey(key);
-  if (!parsed && key.toLowerCase().startsWith("agent:")) {
-    return undefined;
-  }
-  if (cfg) {
-    const scopedKey = resolveStoredSessionKeyForAgentStore({
-      cfg,
-      agentId: scopedAgentId,
-      sessionKey: key,
-    });
-    if (
-      scopedKey !== "global" &&
-      scopedKey !== "unknown" &&
-      resolveSessionStoreAgentId(cfg, scopedKey) !== normalizeAgentId(scopedAgentId)
-    ) {
-      return undefined;
-    }
-    return scopedKey;
-  }
-  if (parsed && parsed.agentId !== normalizeAgentId(scopedAgentId)) {
-    return undefined;
-  }
-  return toAgentStoreSessionKey({ agentId: scopedAgentId, requestKey: key });
 }
 
 function normalizeArtifactType(value: string): string {
@@ -384,91 +300,14 @@ function collectArtifactsFromMessage(params: {
   }
 }
 
-function resolveQuerySession(
-  query: ArtifactQuery,
-  cfg?: OpenClawConfig,
-): ResolvedArtifactSession | undefined {
-  if (query.sessionKey) {
-    const sessionKey = resolveScopedArtifactSessionKey(query.sessionKey, query.agentId, cfg);
-    if (!sessionKey) {
-      return undefined;
-    }
-    return { sessionKey, ...(query.agentId ? { agentId: query.agentId } : {}) };
-  }
-  if (query.runId) {
-    // A live run context can resolve its own agent-scoped key. Do not force an
-    // unrelated default-agent selection before consulting that authoritative row.
-    const sessionKey = resolveSessionKeyForRun(
-      query.runId,
-      query.agentId ? { agentId: query.agentId } : {},
-    );
-    const agentId =
-      query.agentId ??
-      resolveArtifactSessionAgentId(sessionKey, cfg) ??
-      resolveSessionAgentId({ config: cfg });
-    const scopedSessionKey = resolveScopedArtifactSessionKey(sessionKey, agentId, cfg);
-    return scopedSessionKey ? { sessionKey: scopedSessionKey, agentId } : undefined;
-  }
-  if (query.taskId) {
-    const task = getTaskSessionLookupByIdForStatus(query.taskId);
-    const requesterSessionKey = asNonEmptyString(task?.requesterSessionKey);
-    const ownerAgentId = parseAgentSessionKey(task?.ownerKey)?.agentId;
-    const persistedRequesterOwner = requesterSessionKey
-      ? resolvePersistedSessionStoreOwnerForKey(cfg ?? {}, requesterSessionKey)
-      : { kind: "none" as const };
-    const requesterAgentId =
-      asNonEmptyString(task?.requesterAgentId) ??
-      ownerAgentId ??
-      (persistedRequesterOwner.kind === "configured"
-        ? persistedRequesterOwner.agentId
-        : resolveArtifactSessionAgentId(requesterSessionKey, cfg));
-    const taskAgentId = asNonEmptyString(task?.agentId) ?? requesterAgentId;
-    if (
-      query.agentId &&
-      taskAgentId &&
-      normalizeAgentId(query.agentId) !== normalizeAgentId(taskAgentId)
-    ) {
-      return undefined;
-    }
-    if (requesterSessionKey) {
-      // task.agentId identifies the executor. requesterAgentId keeps global
-      // requester transcripts in the correct agent store across restarts.
-      const sessionAgentId =
-        requesterAgentId ?? resolveArtifactSessionAgentId(requesterSessionKey, cfg);
-      if (!sessionAgentId) {
-        return undefined;
-      }
-      const scopedSessionKey = resolveScopedArtifactSessionKey(
-        requesterSessionKey,
-        sessionAgentId,
-        cfg,
-      );
-      return scopedSessionKey
-        ? { sessionKey: scopedSessionKey, agentId: sessionAgentId }
-        : undefined;
-    }
-    const agentId = query.agentId ?? taskAgentId ?? resolveSessionAgentId({ config: cfg });
-    const runId = asNonEmptyString(task?.runId);
-    const sessionKey = runId ? resolveSessionKeyForRun(runId, { agentId }) : undefined;
-    const scopedSessionKey = resolveScopedArtifactSessionKey(sessionKey, agentId, cfg);
-    return scopedSessionKey ? { sessionKey: scopedSessionKey, agentId } : undefined;
-  }
-  return undefined;
-}
-
-class ArtifactSessionResolutionError extends Error {
-  constructor(readonly shape: ReturnType<typeof errorShape>) {
-    super(shape.message);
-  }
-}
-
 /** Loads artifacts from the transcript selected by sessionKey, runId, or taskId. */
 async function loadArtifacts(
   query: ArtifactQuery,
   cfg?: OpenClawConfig,
   opts: ArtifactCollectionOptions = {},
+  client: GatewayClient | null = null,
 ): Promise<{ artifacts: ArtifactRecord[]; sessionKey?: string }> {
-  const resolved = resolveQuerySession(query, cfg);
+  const resolved = resolveAuthorizedArtifactSession(query, cfg, client);
   if (!resolved) {
     return { artifacts: [] };
   }
@@ -562,11 +401,12 @@ async function findArtifact(
   params: ArtifactsGetParams,
   cfg?: OpenClawConfig,
   opts: ArtifactCollectionOptions = {},
+  client: GatewayClient | null = null,
 ): Promise<{
   artifact?: ArtifactRecord;
   sessionKey?: string;
 }> {
-  const loaded = await loadArtifacts(params, cfg, opts);
+  const loaded = await loadArtifacts(params, cfg, opts, client);
   return {
     sessionKey: loaded.sessionKey,
     artifact: loaded.artifacts.find((artifact) => artifact.id === params.artifactId),
@@ -580,7 +420,7 @@ function toSummary(artifact: ArtifactRecord): ArtifactSummary {
 
 /** Gateway handlers for listing, summarizing, and downloading transcript artifacts. */
 export const artifactsHandlers: GatewayRequestHandlers = {
-  "artifacts.list": async ({ params, respond, context }) => {
+  "artifacts.list": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateArtifactsListParams, "artifacts.list", respond)) {
       return;
     }
@@ -593,7 +433,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
       return;
     }
     const loaded = await runArtifactSessionOperation(respond, () =>
-      loadArtifacts(admittedQuery, cfg, { includeDownloadData: false }),
+      loadArtifacts(admittedQuery, cfg, { includeDownloadData: false }, client),
     );
     if (!loaded.ok) {
       return;
@@ -609,7 +449,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
     }
     respond(true, { artifacts: artifacts.map(toSummary) });
   },
-  "artifacts.get": async ({ params, respond, context }) => {
+  "artifacts.get": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateArtifactsGetParams, "artifacts.get", respond)) {
       return;
     }
@@ -622,7 +462,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
       return;
     }
     const found = await runArtifactSessionOperation(respond, () =>
-      findArtifact(admittedQuery, cfg, { includeDownloadData: false }),
+      findArtifact(admittedQuery, cfg, { includeDownloadData: false }, client),
     );
     if (!found.ok) {
       return;
@@ -634,7 +474,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
     }
     respond(true, { artifact: toSummary(artifact) });
   },
-  "artifacts.download": async ({ params, respond, context }) => {
+  "artifacts.download": async ({ params, respond, context, client }) => {
     if (
       !assertValidParams(params, validateArtifactsDownloadParams, "artifacts.download", respond)
     ) {
@@ -655,7 +495,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
       parseManagedOutgoingArtifactId(params.artifactId)
     ) {
       const resolvedResult = await runArtifactSessionOperation(respond, () =>
-        resolveQuerySession(admittedQuery, cfg),
+        resolveAuthorizedArtifactSession(admittedQuery, cfg, client),
       );
       if (!resolvedResult.ok) {
         return;
@@ -693,7 +533,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
       return;
     }
     const found = await runArtifactSessionOperation(respond, () =>
-      findArtifact(admittedQuery, cfg, { downloadArtifactId: params.artifactId }),
+      findArtifact(admittedQuery, cfg, { downloadArtifactId: params.artifactId }, client),
     );
     if (!found.ok) {
       return;

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -10,8 +10,10 @@ import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "../../agents/internal-runtime-context.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
+import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import {
   createTaskRecord as createTaskRecordOrNull,
   getTaskById,
@@ -29,7 +31,7 @@ import {
 } from "../../tasks/task-runtime.test-helpers.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import { tasksHandlers } from "./tasks.js";
-import type { RespondFn } from "./types.js";
+import type { GatewayClient, RespondFn } from "./types.js";
 
 const stateDirEnvSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
 const cancelSessionMock = vi.fn();
@@ -72,8 +74,28 @@ afterEach(async () => {
   resetTaskRegistryControlRuntimeForTests();
   resetTaskRegistryForTests();
   stateDirEnvSnapshot.restore();
+  closeOpenClawAgentDatabasesForTest();
   await fs.rm(stateDir, { recursive: true, force: true });
 });
+
+function identifiedClient(scopes: string[]): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
+      role: "operator",
+      scopes,
+    },
+    authenticatedUserId: "viewer@example.com",
+    authenticatedUserProfile: {
+      profileId: "viewer@example.com",
+      displayName: null,
+      hasAvatar: false,
+      updatedAt: 1,
+    },
+  };
+}
 
 function captureRespond() {
   const calls: Parameters<RespondFn>[] = [];
@@ -112,6 +134,7 @@ async function runTaskHandler(
   method: "tasks.list" | "tasks.get" | "tasks.cancel" | "tasks.retry" | "tasks.dismiss",
   params: Record<string, unknown>,
   config: Record<string, unknown> = {},
+  client: GatewayClient | null = null,
 ) {
   const { calls, respond } = captureRespond();
   await expectDefined(
@@ -122,7 +145,7 @@ async function runTaskHandler(
     params,
     respond,
     context: createContext(config),
-    client: null,
+    client,
     isWebchatConnect: () => false,
   });
   return {
@@ -464,6 +487,68 @@ describe("tasks gateway handlers", () => {
     } finally {
       cloneSpy.mockRestore();
     }
+  });
+
+  it("hides incognito tasks before pagination and blocks direct access", async () => {
+    const hiddenSessionKey = "agent:main:dashboard:incognito-task";
+    await upsertSessionEntryCore(
+      { agentId: "main", sessionKey: hiddenSessionKey },
+      {
+        sessionId: "session-incognito-task",
+        updatedAt: 1,
+        incognito: true,
+        visibility: "shared",
+      },
+    );
+    const hidden = createTaskRecord({
+      runtime: "cli",
+      requesterSessionKey: hiddenSessionKey,
+      requesterAgentId: "main",
+      ownerKey: hiddenSessionKey,
+      scopeKind: "session",
+      task: "Private task",
+      status: "running",
+      deliveryStatus: "pending",
+      lastEventAt: 2_000,
+    });
+    const visible = createTaskRecord({
+      runtime: "cli",
+      requesterSessionKey: "agent:main:main",
+      requesterAgentId: "main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      task: "Visible task",
+      status: "running",
+      deliveryStatus: "pending",
+      lastEventAt: 1_000,
+    });
+    const viewer = identifiedClient(["operator.read", "operator.write"]);
+
+    const list = await runTaskHandler("tasks.list", { limit: 1 }, {}, viewer);
+    expect(list.payload?.tasks?.map((task) => task.taskId)).toEqual([visible.taskId]);
+    expect(list.payload?.nextCursor).toBeUndefined();
+
+    const get = await runTaskHandler("tasks.get", { taskId: hidden.taskId }, {}, viewer);
+    expect(get.calls[0]).toMatchObject([
+      false,
+      undefined,
+      { message: `task not found: ${hidden.taskId}` },
+    ]);
+
+    const cancel = await runTaskHandler("tasks.cancel", { taskId: hidden.taskId }, {}, viewer);
+    expect(cancel.payload).toMatchObject({ found: false, cancelled: false });
+
+    for (const method of ["tasks.retry", "tasks.dismiss"] as const) {
+      const recovery = await runTaskHandler(method, { taskIds: [hidden.taskId] }, {}, viewer);
+      expect(recovery.payload?.results).toEqual([
+        { taskId: hidden.taskId, ok: false, reason: "task not found" },
+      ]);
+    }
+
+    const admin = identifiedClient(["operator.admin"]);
+    const adminGet = await runTaskHandler("tasks.get", { taskId: hidden.taskId }, {}, admin);
+    expect(adminGet.calls[0]?.[0]).toBe(true);
+    expect(adminGet.payload?.task?.taskId).toBe(hidden.taskId);
   });
 
   it("returns page records isolated from the registry", () => {

--- a/src/gateway/server-methods/tasks.ts
+++ b/src/gateway/server-methods/tasks.ts
@@ -19,6 +19,7 @@ import { canonicalizeMainSessionAlias } from "../../config/sessions.js";
 import { getTaskById, listTaskRecordPage } from "../../tasks/runtime-internal.js";
 import type { TaskStatus } from "../../tasks/task-registry.types.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
+import { canAccessTaskRequesterSession } from "../task-session-access.js";
 import { mapTaskSummary } from "./task-summary.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -61,7 +62,7 @@ function parseCursor(cursor: string | undefined): number | null {
 // Control UI task methods expose the stable gateway protocol shape; helpers
 // above keep runtime registry details out of the wire result.
 export const tasksHandlers: GatewayRequestHandlers = {
-  "tasks.list": ({ params, respond, context }) => {
+  "tasks.list": ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateTasksListParams, "tasks.list", respond)) {
       return;
     }
@@ -108,6 +109,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
       sessionKey,
       sessionAgentId,
       cfg,
+      filter: (task) => canAccessTaskRequesterSession({ cfg, client, task }),
     });
     const nextOffset = cursor + page.tasks.length;
     respond(true, {
@@ -115,13 +117,16 @@ export const tasksHandlers: GatewayRequestHandlers = {
       ...(page.hasMore ? { nextCursor: String(nextOffset) } : {}),
     });
   },
-  "tasks.get": ({ params, respond }) => {
+  "tasks.get": ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateTasksGetParams, "tasks.get", respond)) {
       return;
     }
     const taskId = params.taskId;
     const task = getTaskById(taskId);
-    if (!task) {
+    if (
+      !task ||
+      !canAccessTaskRequesterSession({ cfg: context.getRuntimeConfig(), client, task })
+    ) {
       respond(
         false,
         undefined,
@@ -133,7 +138,7 @@ export const tasksHandlers: GatewayRequestHandlers = {
     // stay compact while detail views can show the operator what was requested.
     respond(true, { task: mapTaskSummary(task, { includePrompt: true }) });
   },
-  "tasks.cancel": async ({ params, respond, context }) => {
+  "tasks.cancel": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateTasksCancelParams, "tasks.cancel", respond)) {
       return;
     }
@@ -141,8 +146,14 @@ export const tasksHandlers: GatewayRequestHandlers = {
     const reason = normalizeOptionalString(params.reason);
     const { cancelDetachedTaskRunByIdCore } =
       await import("../../tasks/task-executor-cancel.runtime.js");
+    const cfg = context.getRuntimeConfig();
+    const task = getTaskById(taskId);
+    if (task && !canAccessTaskRequesterSession({ cfg, client, task })) {
+      respond(true, { found: false, cancelled: false });
+      return;
+    }
     const result = await cancelDetachedTaskRunByIdCore({
-      cfg: context.getRuntimeConfig(),
+      cfg,
       taskId,
       ...(reason ? { reason } : {}),
     });
@@ -153,12 +164,18 @@ export const tasksHandlers: GatewayRequestHandlers = {
       ...(result.task ? { task: mapTaskSummary(result.task) } : {}),
     });
   },
-  "tasks.retry": async ({ params, respond }) => {
+  "tasks.retry": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateTasksRecoveryParams, "tasks.retry", respond)) {
       return;
     }
     const results = [];
+    const cfg = context.getRuntimeConfig();
     for (const taskId of params.taskIds) {
+      const task = getTaskById(taskId);
+      if (task && !canAccessTaskRequesterSession({ cfg, client, task })) {
+        results.push({ taskId, ok: false, reason: "task not found" });
+        continue;
+      }
       const result = await retrySubagentCompletionDelivery(taskId);
       results.push({
         taskId,
@@ -170,14 +187,20 @@ export const tasksHandlers: GatewayRequestHandlers = {
     }
     respond(true, { results });
   },
-  "tasks.dismiss": async ({ params, respond }) => {
+  "tasks.dismiss": async ({ params, respond, context, client }) => {
     if (!assertValidParams(params, validateTasksRecoveryParams, "tasks.dismiss", respond)) {
       return;
     }
     const { discardSubagentTerminalDelivery } =
       await import("../../agents/subagents/registry/subagent-registry.js");
     const results = [];
+    const cfg = context.getRuntimeConfig();
     for (const taskId of params.taskIds) {
+      const task = getTaskById(taskId);
+      if (task && !canAccessTaskRequesterSession({ cfg, client, task })) {
+        results.push({ taskId, ok: false, reason: "task not found" });
+        continue;
+      }
       const result = await dismissSubagentCompletionDelivery(taskId, {
         discardTerminalDelivery: discardSubagentTerminalDelivery,
       });

--- a/src/gateway/server-runtime-subscriptions.test.ts
+++ b/src/gateway/server-runtime-subscriptions.test.ts
@@ -722,7 +722,11 @@ describe("startGatewayEventSubscriptions", () => {
         )
         .map((payload) => [payload.task.id, payload.task]),
     );
-    expect(broadcast).toHaveBeenCalledWith("task", expect.anything(), { dropIfSlow: true });
+    expect(broadcast).toHaveBeenCalledWith("task", expect.anything(), {
+      dropIfSlow: true,
+      sessionKeys: ["agent:main:main"],
+      agentId: "main",
+    });
     // Runtime registry statuses translate to the public ledger vocabulary.
     expect(taskUpsertsById.get(completed.taskId)?.status).toBe("completed");
     expect(taskUpsertsById.get(lost.taskId)?.status).toBe("failed");
@@ -1088,11 +1092,7 @@ describe("startGatewayEventSubscriptions", () => {
       deliveryStatus: "not_applicable",
       notifyPolicy: "silent",
     });
-    expect(replacementBroadcast).toHaveBeenCalledWith("task", expect.anything(), {
-      dropIfSlow: true,
-    });
-    expect(staleBroadcast).not.toHaveBeenCalledWith("task", expect.anything(), {
-      dropIfSlow: true,
-    });
+    expect(replacementBroadcast.mock.calls.some(([event]) => event === "task")).toBe(true);
+    expect(staleBroadcast.mock.calls.some(([event]) => event === "task")).toBe(false);
   });
 });

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -29,6 +29,7 @@ import {
   removeChatAbortControllerEntry,
   type RestartRecoveryCandidate,
 } from "./chat-abort.js";
+import type { GatewayBroadcastFn } from "./server-broadcast-types.js";
 import type {
   ChatRunState,
   SessionEventSubscriberRegistry,
@@ -41,6 +42,7 @@ import { defaultSessionCompanionContextReader } from "./session-companion-contex
 import { createSessionCompanion } from "./session-companion.js";
 import { createSessionObserver } from "./session-observer.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "./session-request-agent.js";
+import { resolveTaskRequesterSessionTarget } from "./task-session-access.js";
 import type { TerminalSessionManager } from "./terminal/session-manager.js";
 
 function dispatchEventHandler<TEvent>(params: {
@@ -71,7 +73,7 @@ function terminalTaskId(event: TaskRegistryObserverEvent): string | undefined {
 /** Register gateway runtime event subscriptions and return unsubscribe handles. */
 export function startGatewayEventSubscriptions(params: {
   log: SubsystemLogger;
-  broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
+  broadcast: GatewayBroadcastFn;
   broadcastToConnIds: (
     event: string,
     payload: unknown,
@@ -408,6 +410,7 @@ export function startGatewayEventSubscriptions(params: {
   const taskObservers = {
     onEvent: (event: TaskRegistryObserverEvent) => {
       let payload: TaskEventPayload;
+      let sessionTarget: ReturnType<typeof resolveTaskRequesterSessionTarget>;
       switch (event.kind) {
         case "upserted": {
           const task = mapTaskSummary(event.task);
@@ -417,18 +420,25 @@ export function startGatewayEventSubscriptions(params: {
           }
           lastTaskSummaryById.set(task.id, summary);
           payload = { action: "upserted", task };
+          sessionTarget = resolveTaskRequesterSessionTarget(event.task);
           break;
         }
         case "deleted":
           lastTaskSummaryById.delete(event.taskId);
           payload = { action: "deleted", taskId: event.taskId };
+          sessionTarget = resolveTaskRequesterSessionTarget(event.previous);
           break;
         case "restored":
           lastTaskSummaryById.clear();
           payload = { action: "restored" };
           break;
       }
-      params.broadcast("task", payload, { dropIfSlow: true });
+      params.broadcast("task", payload, {
+        dropIfSlow: true,
+        ...(sessionTarget
+          ? { sessionKeys: [sessionTarget.sessionKey], agentId: sessionTarget.agentId }
+          : {}),
+      });
       const taskId = terminalTaskId(event);
       if (taskId) {
         params.terminalSessions.closeTaskSessions(taskId);

--- a/src/gateway/session-sharing-target-input.ts
+++ b/src/gateway/session-sharing-target-input.ts
@@ -1,5 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import { isIncognitoSessionKey } from "../shared/incognito-session-key.js";
+import { canonicalizeSessionKeyForAgent } from "./session-store-key.js";
 
 export type SessionMutationTarget = {
   sessionKey: string;
@@ -128,7 +130,8 @@ export function resolveDirectIncognitoTargets(
   }
   const agentId = normalizeOptionalString(record.agentId);
   return candidates.flatMap((candidate): SessionMutationTarget[] =>
-    typeof candidate === "string" && isIncognitoSessionKey(candidate)
+    typeof candidate === "string" &&
+    isIncognitoSessionKey(canonicalizeSessionKeyForAgent(agentId ?? DEFAULT_AGENT_ID, candidate))
       ? [{ sessionKey: candidate, ...(agentId ? { agentId } : {}) }]
       : [],
   );

--- a/src/gateway/session-sharing.test.ts
+++ b/src/gateway/session-sharing.test.ts
@@ -378,6 +378,7 @@ describe("session sharing policy", () => {
   it("keeps incognito admin-only while treating identityless connections as owner-equivalent", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async () => {
       const sessionKey = "agent:main:dashboard:incognito-private";
+      const sessionAlias = "dashboard:incognito-private";
       const entry = {
         sessionId: "session-incognito",
         updatedAt: 1,
@@ -392,6 +393,13 @@ describe("session sharing policy", () => {
       const solo = client({});
       const cfg = {};
       const context = { chatAbortControllers: new Map(), getRuntimeConfig: () => cfg } as never;
+      const directRequests = (requestedKey: string) => [
+        { method: "chat.history", requestParams: { sessionKey: requestedKey } },
+        { method: "chat.send", requestParams: { sessionKey: requestedKey } },
+        { method: "sessions.get", requestParams: { key: requestedKey } },
+        { method: "sessions.preview", requestParams: { keys: [requestedKey] } },
+        { method: "sessions.search", requestParams: { sessionKeys: [requestedKey] } },
+      ];
 
       for (const visibleClient of [admin, solo]) {
         expect(isListed(visibleClient, sessionKey, entry)).toBe(true);
@@ -402,14 +410,17 @@ describe("session sharing policy", () => {
             sessionKeys: [sessionKey],
           }),
         ).toBe(true);
-        expect(
-          resolveSessionMutationAuthorization({
-            client: visibleClient,
-            method: "chat.send",
-            requestParams: { sessionKey },
-            context,
-          }).error,
-        ).toBeNull();
+        for (const requestedKey of [sessionKey, sessionAlias]) {
+          for (const request of directRequests(requestedKey)) {
+            expect(
+              resolveSessionMutationAuthorization({
+                client: visibleClient,
+                ...request,
+                context,
+              }).error,
+            ).toBeNull();
+          }
+        }
       }
 
       for (const hiddenClient of [owner, viewer]) {
@@ -421,17 +432,20 @@ describe("session sharing policy", () => {
             sessionKeys: [sessionKey],
           }),
         ).toBe(false);
-        expect(
-          resolveSessionMutationAuthorization({
-            client: hiddenClient,
-            method: "chat.send",
-            requestParams: { sessionKey },
-            context,
-          }).error,
-        ).toMatchObject({
-          code: "INVALID_REQUEST",
-          message: `Incognito session "${sessionKey}" was not found.`,
-        });
+        for (const requestedKey of [sessionKey, sessionAlias]) {
+          for (const request of directRequests(requestedKey)) {
+            expect(
+              resolveSessionMutationAuthorization({
+                client: hiddenClient,
+                ...request,
+                context,
+              }).error,
+            ).toMatchObject({
+              code: "INVALID_REQUEST",
+              message: `Incognito session "${requestedKey}" was not found.`,
+            });
+          }
+        }
       }
     });
   });

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -191,15 +191,32 @@ function incognitoSessionNotFound(sessionKey: string): ErrorShape {
   return errorShape(ErrorCodes.INVALID_REQUEST, `Incognito session "${sessionKey}" was not found.`);
 }
 
+function isIncognitoSessionTarget(params: {
+  sessionKey: string;
+  target: Pick<SessionSharingTarget, "canonicalKey" | "entry"> | null;
+}): boolean {
+  return params.target
+    ? params.target.entry.incognito === true || isIncognitoSessionKey(params.target.canonicalKey)
+    : isIncognitoSessionKey(params.sessionKey);
+}
+
+export function isResolvedIncognitoSession(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  agentId?: string;
+}): boolean {
+  return isIncognitoSessionTarget({
+    sessionKey: params.sessionKey,
+    target: resolveSessionSharingTarget(params),
+  });
+}
+
 export function authorizeIncognitoSessionTarget(params: {
   client: GatewayClient | null;
   sessionKey: string;
   target: SessionSharingTarget | null;
 }): ErrorShape | null {
-  const incognito = params.target
-    ? params.target.entry.incognito === true || isIncognitoSessionKey(params.target.canonicalKey)
-    : isIncognitoSessionKey(params.sessionKey);
-  if (!incognito) {
+  if (!isIncognitoSessionTarget(params)) {
     return null;
   }
   if (isGatewayAdmin(params.client)) {
@@ -486,14 +503,11 @@ export function resolveSessionMutationAuthorization(params: {
     }
     const target = resolved.target;
     const error =
-      (params.method === "sessions.patchMany"
-        ? authorizeIncognitoSessionTarget({
-            client: params.client,
-            sessionKey: targetRef.sessionKey,
-            target,
-          })
-        : null) ??
-      (target ? authorizeSessionSharingTarget({ client: params.client, target }) : null);
+      authorizeIncognitoSessionTarget({
+        client: params.client,
+        sessionKey: targetRef.sessionKey,
+        target,
+      }) ?? (target ? authorizeSessionSharingTarget({ client: params.client, target }) : null);
     if (error) {
       return { error };
     }
@@ -554,13 +568,11 @@ export function resolveSessionMutationAuthorization(params: {
           return;
         }
         const error =
-          (params.method === "sessions.patchMany"
-            ? authorizeIncognitoSessionTarget({
-                client: params.client,
-                sessionKey: targetRef.sessionKey,
-                target: current,
-              })
-            : null) ?? authorizeSessionSharingTarget({ client: params.client, target: current });
+          authorizeIncognitoSessionTarget({
+            client: params.client,
+            sessionKey: targetRef.sessionKey,
+            target: current,
+          }) ?? authorizeSessionSharingTarget({ client: params.client, target: current });
         if (error) {
           throw new SessionMutationAuthorizationChangedError(error);
         }

--- a/src/gateway/task-session-access.ts
+++ b/src/gateway/task-session-access.ts
@@ -1,0 +1,36 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import type { GatewayClient } from "./server-methods/types.js";
+import { canAccessIncognitoSession } from "./session-sharing.js";
+
+export function resolveTaskRequesterSessionTarget(
+  task: Pick<TaskRecord, "ownerKey" | "requesterAgentId" | "requesterSessionKey">,
+): { sessionKey: string; agentId?: string } | undefined {
+  const sessionKey = normalizeOptionalString(task.requesterSessionKey);
+  if (!sessionKey) {
+    return undefined;
+  }
+  const agentId =
+    normalizeOptionalString(task.requesterAgentId) ??
+    parseAgentSessionKey(sessionKey)?.agentId ??
+    parseAgentSessionKey(task.ownerKey)?.agentId;
+  return { sessionKey, ...(agentId ? { agentId } : {}) };
+}
+
+export function canAccessTaskRequesterSession(params: {
+  cfg: OpenClawConfig;
+  client: GatewayClient | null;
+  task: Pick<TaskRecord, "ownerKey" | "requesterAgentId" | "requesterSessionKey">;
+}): boolean {
+  const target = resolveTaskRequesterSessionTarget(params.task);
+  return (
+    !target ||
+    canAccessIncognitoSession({
+      cfg: params.cfg,
+      client: params.client,
+      ...target,
+    })
+  );
+}

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -122,6 +122,7 @@ export function listTaskRecordPage(params: {
   sessionKey?: string;
   sessionAgentId?: string;
   cfg?: OpenClawConfig;
+  filter?: (task: Readonly<TaskRecord>) => boolean;
 }): { tasks: TaskRecord[]; hasMore: boolean } {
   ensureTaskRegistryReady();
   const statuses = params.statuses ? new Set(params.statuses) : null;
@@ -134,7 +135,8 @@ export function listTaskRecordPage(params: {
       (task) =>
         (!statuses || statuses.has(task.status)) &&
         taskMatchesAgent(task, agentId, params.cfg) &&
-        taskMatchesRelatedSession(task, sessionKey, params.sessionAgentId, params.cfg),
+        taskMatchesRelatedSession(task, sessionKey, params.sessionAgentId, params.cfg) &&
+        (!params.filter || params.filter(task)),
     )
     .toSorted((left, right) => {
       const updatedDiff = taskUpdatedAt(right) - taskUpdatedAt(left);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where identified non-admin Gateway users could receive inconsistent incognito-session visibility when a session was selected through an alias, compatible HTTP route, task or artifact identifier, or task event.

## Why This Change Was Made

Session access is now checked after canonical resolution at the Gateway policy boundary. The same resolved-session rule is applied to direct RPC selectors, compatible HTTP requests and continuations, task pagination and mutations, artifact lookup, and task event delivery while preserving admin and owner-equivalent shared-secret workflows.

## User Impact

Incognito sessions consistently retain their documented admin-only visibility across Gateway entry points. Ordinary sessions and legitimate admin or owner-equivalent workflows are unchanged.

## Evidence

- Captured a focused pre-fix failure for a bare session alias and a runtime task lookup that returned an incognito task to an identified non-admin client.
- Added focused denial coverage for direct aliases, tasks, artifacts, compatible HTTP routes, and task broadcasts.
- Added positive-path coverage for admins, identityless owner-equivalent clients, and ordinary session aliases.
- `pnpm test src/gateway/session-sharing.test.ts src/shared/incognito-session-key.test.ts src/gateway/server-methods/tasks.test.ts src/gateway/server-methods/artifacts.test.ts src/gateway/server-methods/artifacts-session-resolution.test.ts src/gateway/server-runtime-subscriptions.test.ts`
- `pnpm test src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts`
- `pnpm check:changed`
- Local autoreview: clean, with no accepted or actionable findings.
