### PR TITLE
improve(ui): default split-pane side panels to bottom docking

### DIFF
--- a/ui/src/pages/chat/chat-page-pane-render.test.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { bottomDockDefault } from "./chat-page-pane-render.ts";
+
+describe("chat page pane rendering", () => {
+  it.each([
+    ["classic", false, false, 1, false],
+    ["side-by-side split", true, false, 1, true],
+    ["stacked split", true, false, 2, false],
+    ["narrow split", true, true, 1, false],
+  ] as const)(
+    "selects the %s dock default",
+    (_name, splitMode, narrow, columnPaneCount, expected) => {
+      expect(bottomDockDefault(splitMode, narrow, columnPaneCount)).toBe(expected);
+    },
+  );
+});

--- a/ui/src/pages/chat/chat-page-pane-render.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.ts
@@ -89,6 +89,7 @@ export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
               aria-hidden=${presented ? "false" : "true"}
               ?inert=${!presented}
               .paneId=${options.pane.id}
+              .splitMode=${options.splitMode}
               .presentationId=${JSON.stringify([options.pane.id, sessionKey])}
               .chatMessagesBySession=${options.chatMessagesBySession}
               .sessionSnapshotStore=${options.sessionSnapshotStore}

--- a/ui/src/pages/chat/chat-page-pane-render.ts
+++ b/ui/src/pages/chat/chat-page-pane-render.ts
@@ -17,6 +17,7 @@ import type { ChatSplitPane } from "./split-layout-types.ts";
 type ChatPagePaneRenderOptions = {
   active: boolean;
   chatMessagesBySession: ChatMessageCache;
+  columnPaneCount: number;
   sessionSnapshotStore: SessionSnapshotStore;
   consumedDraftData: SessionChatRouteData | null;
   context?: ApplicationContext;
@@ -46,6 +47,16 @@ type ChatPagePaneRenderOptions = {
   splitMode: boolean;
   weight: number;
 };
+
+export function bottomDockDefault(
+  splitMode: boolean,
+  narrow: boolean,
+  columnPaneCount: number,
+): boolean {
+  // Stacked and narrow panes cannot fit both bottom-dock and transcript
+  // minimums; keep their existing responsive layout.
+  return splitMode && !narrow && columnPaneCount === 1;
+}
 
 export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
   const nativeGateways = options.showGatewayPicker ? nativeGatewaysCapability() : null;
@@ -89,7 +100,11 @@ export function renderChatPagePaneCell(options: ChatPagePaneRenderOptions) {
               aria-hidden=${presented ? "false" : "true"}
               ?inert=${!presented}
               .paneId=${options.pane.id}
-              .splitMode=${options.splitMode}
+              .preferBottomSidebarDock=${bottomDockDefault(
+                options.splitMode,
+                options.narrow,
+                options.columnPaneCount,
+              )}
               .presentationId=${JSON.stringify([options.pane.id, sessionKey])}
               .chatMessagesBySession=${options.chatMessagesBySession}
               .sessionSnapshotStore=${options.sessionSnapshotStore}

--- a/ui/src/pages/chat/chat-page.ts
+++ b/ui/src/pages/chat/chat-page.ts
@@ -606,6 +606,7 @@ export class ChatPage extends OpenClawLightDomElement {
                   ${renderChatPagePaneCell({
                     active: pane.id === layout.activePaneId,
                     chatMessagesBySession: this.messageCache,
+                    columnPaneCount: column.panes.length,
                     sessionSnapshotStore: this.snapshotStore,
                     consumedDraftData: this.consumedDraftData,
                     context: this.context,

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -103,7 +103,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   protected context!: ChatPageContext;
   @property({ attribute: false }) paneId = "single";
-  @property({ attribute: false }) splitMode = false;
+  @property({ attribute: false }) preferBottomSidebarDock = false;
   @property({ attribute: false }) presentationId = "single";
   @property({ attribute: false }) chatMessagesBySession?: ChatMessageCache;
   @property({ attribute: false }) sessionSnapshotStore?: SessionSnapshotStore;

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -103,6 +103,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   protected context!: ChatPageContext;
   @property({ attribute: false }) paneId = "single";
+  @property({ attribute: false }) splitMode = false;
   @property({ attribute: false }) presentationId = "single";
   @property({ attribute: false }) chatMessagesBySession?: ChatMessageCache;
   @property({ attribute: false }) sessionSnapshotStore?: SessionSnapshotStore;

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -342,6 +342,7 @@ describe("chat pane board shell", () => {
   });
   it("activates an existing tabbed chat panel when reopening a side dock", () => {
     const pane = createTestPane();
+    const updateSidebarLayout = vi.spyOn(pane.state, "updateSidebarLayout");
     const withChat = openSlot(openSlot({ columns: [] }, "chat"), "discussion");
     const chatPanel = withChat.columns[0]!.panels[0]!;
     const discussionPanel = withChat.columns[0]!.panels[1]!;
@@ -351,6 +352,7 @@ describe("chat pane board shell", () => {
 
     expect(pane.state.sidebarLayout.columns[0]?.activePanelId).toBe(chatPanel.id);
     expect(pane.state.sidebarFocusPanelId).toBe(chatPanel.id);
+    expect(updateSidebarLayout).toHaveBeenCalledWith(expect.anything(), "right");
   });
 
   it("restores one board view across equivalent main session keys", () => {

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -108,7 +108,9 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
       this.paneWidth >= SIDEBAR_NARROW_BREAKPOINT_PX
         ? (fitSidebarLayout(layout, this.paneWidth) ?? layout)
         : layout;
-    state.updateSidebarLayout(fitted);
+    // Board owns left/right chat placement; the unified sidebar represents
+    // both side edges with its canonical right dock.
+    state.updateSidebarLayout(fitted, "right");
     if (chatPanel) {
       state.updateSidebarActivePanel(chatPanel.id);
     }

--- a/ui/src/pages/chat/chat-pane-sidebar-layout.ts
+++ b/ui/src/pages/chat/chat-pane-sidebar-layout.ts
@@ -130,7 +130,7 @@ export function sidebarRegionCallbacks(params: {
         reorderPanel(state.sidebarLayout, panelId, targetPanelId, placement),
       ),
     resizePanel: params.resizePanel,
-    setDock: (dock) => state.updateSidebarLayout(setSidebarDock(state.sidebarLayout, dock)),
+    setDock: (dock) => state.updateSidebarLayout(setSidebarDock(state.sidebarLayout, dock), dock),
     setExpanded: (expanded) =>
       state.updateSidebarLayout(setSidebarExpanded(state.sidebarLayout, expanded)),
     setOpen: params.setPanelOpen,

--- a/ui/src/pages/chat/chat-state-host.ts
+++ b/ui/src/pages/chat/chat-state-host.ts
@@ -26,7 +26,7 @@ import type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult } from "./inpu
 import type { RenderLifecycle } from "./render-lifecycle.ts";
 import type { PendingChatAbort } from "./run-lifecycle.ts";
 import type { ChatMessageCache } from "./session-message-cache.ts";
-import type { SidebarLayout } from "./sidebar-layout.ts";
+import type { SidebarDock, SidebarLayout } from "./sidebar-layout.ts";
 import type {
   CompactionStatus,
   FallbackStatus,
@@ -150,7 +150,7 @@ export type ChatPageHost = ChatHost &
     submitQueuedChatMessageEdit: () => void;
     cancelQueuedChatMessageEdit: () => void;
     handleCloseSidebar: () => void;
-    updateSidebarLayout: (layout: SidebarLayout) => void;
+    updateSidebarLayout: (layout: SidebarLayout, explicitDock?: SidebarDock) => void;
     beginImageOpen: () => number;
     handleOpenImage: (item: ImageLightboxItem, requestVersion?: number) => void;
     handleCloseImage: () => void;

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -66,7 +66,7 @@ import { resetToolStream } from "./tool-stream.ts";
 type ChatPageElement = {
   getBoundingClientRect?: () => DOMRect;
   querySelector: (selectors: string) => Element | null;
-  splitMode?: boolean;
+  preferBottomSidebarDock?: boolean;
 };
 
 function clearImageLightbox(state: ChatPageHost) {
@@ -376,18 +376,28 @@ export function createPageState(
     cancelQueuedMessageEdit(state);
     renderLifecycle.invalidate();
   };
-  state.updateSidebarLayout = (layout) => {
+  state.updateSidebarLayout = (layout, explicitDock) => {
     const normalized = normalizeSidebarLayout(layout);
+    const currentSidebarSessionKey = canonicalUiSessionKeyForPersistence(state, state.sessionKey);
+    const persistedSettings = loadSettings();
+    const persistedDock = persistedSettings.sidebarSessionLayouts?.[currentSidebarSessionKey]?.dock;
+    // Duplicate-session panes keep local layout state. Carry a newer explicit
+    // dock forward unless this pane is the one changing it now.
+    const previousLayout = persistedDock
+      ? { ...state.sidebarLayout, dock: persistedDock }
+      : state.sidebarLayout;
+    const requestedDock = explicitDock ?? persistedDock;
+    const requestedLayout = requestedDock ? { ...normalized, dock: requestedDock } : normalized;
     const nextLayout = applySidebarDockDefault(
-      state.sidebarLayout,
-      normalized,
-      page.splitMode === true,
+      previousLayout,
+      requestedLayout,
+      page.preferBottomSidebarDock === true,
     );
     state.sidebarLayout = nextLayout;
     state.settings = patchSettings({
       sidebarSessionLayouts: updateSidebarSessionLayout(
-        loadSettings().sidebarSessionLayouts,
-        canonicalUiSessionKeyForPersistence(state, state.sessionKey),
+        persistedSettings.sidebarSessionLayouts,
+        currentSidebarSessionKey,
         nextLayout,
       ),
     });

--- a/ui/src/pages/chat/chat-state-page.ts
+++ b/ui/src/pages/chat/chat-state-page.ts
@@ -55,6 +55,7 @@ import {
 import {
   SIDEBAR_NARROW_BREAKPOINT_PX,
   activatePanel,
+  applySidebarDockDefault,
   closeSlot,
   fitSidebarLayout,
   normalizeSidebarLayout,
@@ -65,6 +66,7 @@ import { resetToolStream } from "./tool-stream.ts";
 type ChatPageElement = {
   getBoundingClientRect?: () => DOMRect;
   querySelector: (selectors: string) => Element | null;
+  splitMode?: boolean;
 };
 
 function clearImageLightbox(state: ChatPageHost) {
@@ -376,12 +378,17 @@ export function createPageState(
   };
   state.updateSidebarLayout = (layout) => {
     const normalized = normalizeSidebarLayout(layout);
-    state.sidebarLayout = normalized;
+    const nextLayout = applySidebarDockDefault(
+      state.sidebarLayout,
+      normalized,
+      page.splitMode === true,
+    );
+    state.sidebarLayout = nextLayout;
     state.settings = patchSettings({
       sidebarSessionLayouts: updateSidebarSessionLayout(
         loadSettings().sidebarSessionLayouts,
         canonicalUiSessionKeyForPersistence(state, state.sessionKey),
-        normalized,
+        nextLayout,
       ),
     });
     renderLifecycle.invalidate();

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -26,6 +26,7 @@ import { resolveChatAvatarUrl, selectedChatSessionRow } from "./chat-state-route
 import { buildChatItems } from "./chat-thread-build.ts";
 import { getChatSessionProjection } from "./history-merge.ts";
 import { scheduleControlUiAfterPaint } from "./performance.ts";
+import { openSlot, setSidebarDock } from "./sidebar-layout.ts";
 
 beforeEach(() => {
   vi.spyOn(assistantIdentity, "loadLocalAssistantIdentity").mockReturnValue({
@@ -1164,6 +1165,31 @@ describe("ChatStateController render lifecycle", () => {
       sessions: {},
     } as unknown as ApplicationContext;
   }
+
+  it("reconciles explicit sidebar docks between sibling panes", () => {
+    localStorage.clear();
+    const lifecycle = { invalidate: vi.fn(), afterCommit: () => () => {} };
+    const first = createPageState(createPageContext(), lifecycle, {
+      querySelector: () => null,
+      preferBottomSidebarDock: true,
+    });
+    const second = createPageState(createPageContext(), lifecycle, {
+      querySelector: () => null,
+      preferBottomSidebarDock: true,
+    });
+
+    first.updateSidebarLayout(openSlot(first.sidebarLayout, "browser"));
+    second.updateSidebarLayout(
+      setSidebarDock(openSlot(second.sidebarLayout, "browser"), "right"),
+      "right",
+    );
+    first.updateSidebarLayout(openSlot(first.sidebarLayout, "tasks"));
+
+    expect(Object.values(first.settings.sidebarSessionLayouts ?? {})[0]?.dock).toBe("right");
+    first.updateSidebarLayout(setSidebarDock(first.sidebarLayout, "bottom"), "bottom");
+
+    expect(Object.values(first.settings.sidebarSessionLayouts ?? {})[0]?.dock).toBe("bottom");
+  });
 
   it("keeps the active observer digest when another run streams in the same session", () => {
     const projectedDigest = {

--- a/ui/src/pages/chat/sidebar-layout-normalize.ts
+++ b/ui/src/pages/chat/sidebar-layout-normalize.ts
@@ -106,9 +106,10 @@ export function normalizeSidebarLayout(value: unknown): SidebarLayout {
         },
       ]
     : [];
+  const dock = value.dock === "bottom" || value.dock === "right" ? value.dock : undefined;
   return {
     columns,
-    dock: value.dock === "bottom" ? "bottom" : "right",
+    ...(dock ? { dock } : {}),
     open: typeof value.open === "boolean" ? value.open : columns.length > 0,
     expanded: value.expanded === true,
   };

--- a/ui/src/pages/chat/sidebar-layout-persistence.test.ts
+++ b/ui/src/pages/chat/sidebar-layout-persistence.test.ts
@@ -11,6 +11,7 @@ import {
   activatePanel,
   openSlot,
   resizeSidebarPanel,
+  setSidebarDock,
   setSidebarExpanded,
   setSidebarOpen,
 } from "./sidebar-layout.ts";
@@ -62,6 +63,13 @@ describe("sidebar session layout settings", () => {
     expect(persisted?.columns[0]?.activePanelId).toBe("workspace");
     expect(persisted?.columns[0]?.width).toBe(512);
     expect(persisted).toMatchObject({ open: false, expanded: true });
+  });
+
+  it("preserves explicit dock choices per session", () => {
+    for (const dock of ["right", "bottom"] as const) {
+      const layout = setSidebarDock(openSlot({ columns: [] }, "browser"), dock);
+      expect(updateSidebarSessionLayout({}, "main", layout).main?.dock).toBe(dock);
+    }
   });
 
   it("caps the newest session layouts", () => {

--- a/ui/src/pages/chat/sidebar-layout-persistence.test.ts
+++ b/ui/src/pages/chat/sidebar-layout-persistence.test.ts
@@ -41,7 +41,7 @@ describe("sidebar session layout settings", () => {
         "": openSlot({ columns: [] }, "discussion"),
       }),
     ).toEqual({
-      main: { ...openSlot({ columns: [] }, "detail"), dock: "right", expanded: false },
+      main: { ...openSlot({ columns: [] }, "detail"), expanded: false },
       broken: { columns: [], open: false, expanded: false },
     });
   });
@@ -54,7 +54,7 @@ describe("sidebar session layout settings", () => {
     layout = setSidebarOpen(layout, false);
 
     const persisted = updateSidebarSessionLayout({}, "main", layout).main;
-    expect(persisted).toEqual({ ...layout, dock: "right" });
+    expect(persisted).toEqual(layout);
     expect(persisted?.columns[0]?.panels.map((panel) => panel.slot)).toEqual([
       "workspace",
       "terminal",

--- a/ui/src/pages/chat/sidebar-layout.test.ts
+++ b/ui/src/pages/chat/sidebar-layout.test.ts
@@ -47,7 +47,7 @@ describe("sidebar layout", () => {
     expect(activatePanel(layout, chat.id).columns[0]?.activePanelId).toBe(chat.id);
   });
 
-  it("defaults a newly opened implicit panel to the bottom only in split view", () => {
+  it("defaults a newly opened implicit panel to the bottom only in eligible split panes", () => {
     const previous = { columns: [] } satisfies SidebarLayout;
     const next = openSlot(previous, "browser");
 
@@ -61,6 +61,13 @@ describe("sidebar layout", () => {
 
     expect(applySidebarDockDefault(right, openSlot(right, "tasks"), true).dock).toBe("right");
     expect(applySidebarDockDefault(bottom, openSlot(bottom, "tasks"), true).dock).toBe("bottom");
+  });
+
+  it("preserves an existing implicit-right layout when another panel opens", () => {
+    const persisted = openSlot({ columns: [] }, "browser");
+    const next = openSlot(persisted, "tasks");
+
+    expect(applySidebarDockDefault(persisted, next, true)).toEqual(next);
   });
 
   it("closes one tab and selects its nearest remaining neighbor", () => {

--- a/ui/src/pages/chat/sidebar-layout.test.ts
+++ b/ui/src/pages/chat/sidebar-layout.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   SIDEBAR_MIN_WIDTH_PX,
   activatePanel,
+  applySidebarDockDefault,
   closeSlot,
   fitSidebarLayout,
   normalizeSidebarLayout,
@@ -44,6 +45,22 @@ describe("sidebar layout", () => {
     ]);
     expect(reopened.columns[0]?.activePanelId).toBe(chat.id);
     expect(activatePanel(layout, chat.id).columns[0]?.activePanelId).toBe(chat.id);
+  });
+
+  it("defaults a newly opened implicit panel to the bottom only in split view", () => {
+    const previous = { columns: [] } satisfies SidebarLayout;
+    const next = openSlot(previous, "browser");
+
+    expect(applySidebarDockDefault(previous, next, true).dock).toBe("bottom");
+    expect(applySidebarDockDefault(previous, next, false)).toEqual(next);
+  });
+
+  it("preserves an explicit dock choice when another panel opens", () => {
+    const right = setSidebarDock(openSlot({ columns: [] }, "browser"), "right");
+    const bottom = setSidebarDock(openSlot({ columns: [] }, "browser"), "bottom");
+
+    expect(applySidebarDockDefault(right, openSlot(right, "tasks"), true).dock).toBe("right");
+    expect(applySidebarDockDefault(bottom, openSlot(bottom, "tasks"), true).dock).toBe("bottom");
   });
 
   it("closes one tab and selects its nearest remaining neighbor", () => {
@@ -145,7 +162,6 @@ describe("sidebar layout", () => {
           width: 500,
         },
       ],
-      dock: "right",
       open: true,
       expanded: false,
     });
@@ -210,7 +226,6 @@ describe("sidebar layout", () => {
           width: 1_200,
         },
       ],
-      dock: "right",
       open: false,
       expanded: true,
     });

--- a/ui/src/pages/chat/sidebar-layout.ts
+++ b/ui/src/pages/chat/sidebar-layout.ts
@@ -118,22 +118,17 @@ export function openSlot(layout: SidebarLayout, slot: SidebarSlotId): SidebarLay
 export function applySidebarDockDefault(
   previous: SidebarLayout,
   next: SidebarLayout,
-  splitMode: boolean,
+  preferBottomDock: boolean,
 ): SidebarLayout {
-  // An omitted dock is the only state that may inherit the split default;
-  // explicit right/bottom choices must survive every later layout update.
-  if (!splitMode || previous.dock !== undefined || next.dock !== undefined) {
-    return next;
-  }
-  const previousPanelCount = previous.columns.reduce(
-    (count, column) => count + column.panels.length,
-    0,
-  );
-  const nextPanelCount = next.columns.reduce(
-    (count, column) => count + column.panels.length,
-    0,
-  );
-  return nextPanelCount > previousPanelCount ? { ...next, dock: "bottom" } : next;
+  // Only the first column creation may inherit the split default. Existing
+  // implicit-right layouts and explicit choices must survive later tab opens.
+  const shouldApply =
+    preferBottomDock &&
+    previous.dock === undefined &&
+    next.dock === undefined &&
+    previous.columns.length === 0 &&
+    next.columns.length > 0;
+  return shouldApply ? { ...next, dock: "bottom" } : next;
 }
 
 export function closeSlot(layout: SidebarLayout, slot: SidebarSlotId): SidebarLayout {

--- a/ui/src/pages/chat/sidebar-layout.ts
+++ b/ui/src/pages/chat/sidebar-layout.ts
@@ -115,6 +115,27 @@ export function openSlot(layout: SidebarLayout, slot: SidebarSlotId): SidebarLay
   return next;
 }
 
+export function applySidebarDockDefault(
+  previous: SidebarLayout,
+  next: SidebarLayout,
+  splitMode: boolean,
+): SidebarLayout {
+  // An omitted dock is the only state that may inherit the split default;
+  // explicit right/bottom choices must survive every later layout update.
+  if (!splitMode || previous.dock !== undefined || next.dock !== undefined) {
+    return next;
+  }
+  const previousPanelCount = previous.columns.reduce(
+    (count, column) => count + column.panels.length,
+    0,
+  );
+  const nextPanelCount = next.columns.reduce(
+    (count, column) => count + column.panels.length,
+    0,
+  );
+  return nextPanelCount > previousPanelCount ? { ...next, dock: "bottom" } : next;
+}
+
 export function closeSlot(layout: SidebarLayout, slot: SidebarSlotId): SidebarLayout {
   const next = cloneLayout(layout);
   const panel = next.columns


### PR DESCRIPTION
Closes #126892

## What Problem This Solves

This PR proposes preserving transcript width when an operator opens a unified side panel inside a wide, side-by-side chat split. In that geometry, a fresh panel layout starts at the bottom instead of consuming more inline transcript width.

Single-pane chats, narrow layouts, and vertically stacked split panes retain the current responsive/right-side default. Stacked panes are excluded because their existing transcript, composer, and bottom-panel minimum heights cannot fit safely in a short split cell.

## Why This Change Was Made

The change stays in the existing sidebar owner and applies the contextual default only when the first column of a fresh, implicit layout is materialized. Existing implicit-right layouts and explicit right/bottom choices are not re-defaulted.

Dock intent now reaches the persistence owner explicitly. This lets two mounted panes for the same canonical session reconcile a newer persisted dock without allowing a stale pane update to overwrite it. Board remains governed by its required, persisted `chatDock`; its left/right placement maps to the canonical sidebar side dock instead of inheriting this generic default.

No global config, environment variable, protocol change, or database schema change is introduced.

## User Impact

- Fresh panels in wide side-by-side splits default to bottom docking.
- Single-pane, narrow, and vertically stacked panes keep the existing behavior.
- Existing layouts and explicit dock choices survive later panel opens, sibling-pane updates, reload persistence, and reopening.
- Board's owner-native left/right/bottom choice remains authoritative.

## Evidence

- Focused Vitest proof: 7 files, 153 tests passed across the UI and UI-isolated shards.
- Focused Oxlint and Oxfmt checks passed for every changed TypeScript file.
- `git diff --check` passed.
- Regression proof was captured before the correction for both an existing implicit-right layout being re-defaulted and a stale sibling pane overwriting a newer explicit dock.
- Aggregate delta from the PR base: production +64/-10 (net +54); tests +78/-4 (net +74). Production growth carries the pane-geometry signal and explicit persistence intent across their existing owner boundaries.
- Full suites, build, `tsgo`, E2E, browser automation, screenshots, and external review remain intentionally deferred in this initial draft phase.
- AI-assisted implementation; the author understands and owns the change.
