### PR TITLE
fix(plugins): bound failed-start service cleanup with replacement stop timeout

### DIFF
--- a/src/plugins/services.replacement.test.ts
+++ b/src/plugins/services.replacement.test.ts
@@ -18,7 +18,11 @@ import type { PluginOrigin } from "./plugin-origin.types.js";
 import { createEmptyPluginRegistry } from "./registry.js";
 import { resetPluginRuntimeStateForTest } from "./runtime.js";
 import { listPluginServiceHealthFailures } from "./service-health.js";
-import { startPluginServices, type PluginServicesHandle } from "./services.js";
+import {
+  PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS,
+  startPluginServices,
+  type PluginServicesHandle,
+} from "./services.js";
 import type { OpenClawPluginService, OpenClawPluginServiceContext } from "./types.js";
 
 const mockedLogger = vi.hoisted(() => ({
@@ -245,6 +249,58 @@ describe("plugin service replacement", () => {
     } finally {
       releaseCleanup?.();
       await stopping;
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds failed-start cleanup with the replacement stop timeout", async () => {
+    vi.useFakeTimers();
+    const broadcastPluginEvent = vi.fn();
+    const siblingStart = vi.fn();
+    let context: OpenClawPluginServiceContext | undefined;
+    const registry = createRegistry([
+      {
+        id: "failed-start-hung-stop",
+        start: (ctx) => {
+          context = ctx;
+          throw new Error("startup rejected");
+        },
+        stop: () => new Promise<void>(() => {}),
+      },
+      { id: "sibling", start: siblingStart },
+    ]);
+    let starting: Promise<PluginServicesHandle> | undefined;
+    let settled = false;
+
+    try {
+      starting = startPluginServices({
+        registry,
+        config: createServiceConfig(),
+        broadcastPluginEvent,
+      }).then((handle) => {
+        settled = true;
+        return handle;
+      });
+      await vi.advanceTimersByTimeAsync(PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS);
+
+      expect(settled).toBe(true);
+      const handle = await starting;
+      expect(siblingStart).toHaveBeenCalledOnce();
+      expect(mockedLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining("plugin service failed (failed-start-hung-stop"),
+      );
+      expect(mockedLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("plugin service stop failed (failed-start-hung-stop)"),
+      );
+      expect(() => context?.gatewayEvents?.emit("late", {}, { scope: "operator.read" })).toThrow(
+        "no longer active",
+      );
+      expect(broadcastPluginEvent).not.toHaveBeenCalled();
+      await handle.stop();
+    } finally {
+      if (settled) {
+        await starting;
+      }
       vi.useRealTimers();
     }
   });

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -434,7 +434,13 @@ export async function startPluginServices(params: {
           `plugin service failed (${service.id}, plugin=${entry.pluginId}, root=${entry.rootDir ?? "unknown"}): ${error?.message ?? String(err)}`,
         );
         // A failed start can already own resources; revoke events only after its cleanup runs.
-        await stopService(runningService);
+        // Bound the cleanup: callers await startPluginServices without a timeout, so a hung
+        // stop here would wedge plugin reload/startup forever.
+        await stopService(
+          runningService,
+          undefined,
+          Date.now() + PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS,
+        );
       }
     }
     params.startupTrace?.detail?.("sidecars.plugin-services.summary", [


### PR DESCRIPTION
Closes #126901

## What Problem This Solves
A plugin whose `start()` throws and whose `stop()` never settles (e.g. stop awaits a connection that never came up) previously hung `startPluginServices` forever — permanently wedging gateway config hot reload and startup sidecars with no operator-visible recovery. With this change the failed-start cleanup is bounded by the same 5s replacement stop timeout used elsewhere; on timeout the stop is logged and the capability lease revoked.

## Root cause
`src/plugins/services.ts` failed-start cleanup called `await stopService(runningService)` with no deadline, while the sibling strict-replacement path bounds stops via `PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS`. Sibling scan: the only other unbounded `stopService` calls are inside `handle.stop()`, where a missing deadline is intentional for non-strict graceful shutdown — no other path shares the violated invariant.

## Rejected alternatives
A per-call-site guard at the gateway reload layer would compensate downstream for an upstream ownership failure; the deadline belongs in the lifecycle owner, matching the existing strict-path semantics.

## LOC delta
Production +7/−1 (`src/plugins/services.ts`); tests +57/−1 (`src/plugins/services.replacement.test.ts`).

## Evidence
Head: `287132994b1`. New fake-timers regression test 'bounds failed-start cleanup with the replacement stop timeout' **fails pre-fix** (`startPluginServices` never settles: `AssertionError: expected false to be true`) and passes post-fix. Suites green: services.replacement (6), services (24), one-shot-diagnostics + health.plugins (15), server-startup-post-attach (81).

## Review
trufflehog clean. The autoreview engine gate could not run in this environment: codex backend returns HTTP 403/413, claude/pi return 401 (credentials unavailable to the author); stated plainly rather than bypassed. Happy to rerun on request.


## Real behavior proof (2026-08-21, head 287132994b1)

Addressing the review gate: after-fix trace from a real plugin-service run. Harness: a real plugin on disk (real `openclaw.plugin.json` + CJS entry) loaded through the real `loadOpenClawPlugins` path (`OPENCLAW_DISABLE_BUNDLED_PLUGINS=1`, isolated `OPENCLAW_STATE_DIR`), then real `startPluginServices` with real timers — no mocks anywhere. The plugin's service `start()` throws after partial init and its `stop()` hangs forever. Full harness script available on request.

**Post-fix (head `287132994b1`)** — bounded, returns in ~5s:

```
[plugins] plugin service failed (hang-stop, plugin=hang-stop-plugin, root=/tmp/.../hang-stop-plugin): simulated start failure after partial init
[plugin] service stop() entered, hanging forever
[plugins] plugin service stop failed (hang-stop): Error: plugin service stop timed out after 5000ms
[proof] startPluginServices RETURNED after 5039ms
```

**Pre-fix (same harness against `HEAD~1` `src/plugins/services.ts`)** — wedged: `start()` throws, `stop()` entered, then nothing; process killed by outer `timeout 25` (exit 124), `startPluginServices` never returned.

Red/green pair on identical harness: pre-fix hangs forever, post-fix bounds cleanup at the 5s replacement stop timeout and returns.
