### PR TITLE
fix(acp): recover terminal reply and surface run errors on reconnect reconcile

### DIFF
--- a/src/acp/translator.disconnects.test.ts
+++ b/src/acp/translator.disconnects.test.ts
@@ -1,0 +1,204 @@
+import { createInMemorySessionStore } from "@openclaw/acp-core/session";
+import { describe, expect, it, vi } from "vitest";
+import type { GatewayClient } from "../gateway/client.js";
+import { createInMemoryAcpEventLedger } from "./event-ledger.js";
+import { AcpGatewayAgent } from "./translator.js";
+import { createChatEvent, promptAgent } from "./translator.prompt-harness.test-support.js";
+import type { AcpAgentWaitResult } from "./translator.prompt-state.js";
+import { createAcpConnection, createAcpGateway } from "./translator.test-helpers.js";
+
+async function createReconnectHarness(result: AcpAgentWaitResult) {
+  const sessionId = "session-1";
+  const sessionKey = "agent:main:main";
+  const sessionStore = createInMemorySessionStore();
+  sessionStore.createSession({ sessionId, sessionKey, cwd: "/tmp" });
+  const eventLedger = createInMemoryAcpEventLedger();
+  await eventLedger.startSession({ sessionId, sessionKey, cwd: "/tmp", complete: true });
+  const connection = createAcpConnection();
+  let runId: string | undefined;
+  const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+    if (method === "chat.send") {
+      runId = typeof params?.idempotencyKey === "string" ? params.idempotencyKey : undefined;
+    }
+    return method === "agent.wait" ? result : {};
+  }) as GatewayClient["request"];
+  const agent = new AcpGatewayAgent(connection, createAcpGateway(request), {
+    eventLedger,
+    sessionStore,
+  });
+  const promptPromise = promptAgent(agent, sessionId);
+  promptPromise.catch(() => {});
+  await vi.waitFor(() => expect(runId).toBeTypeOf("string"));
+
+  return {
+    agent,
+    connection,
+    eventLedger,
+    promptPromise,
+    runId: runId as string,
+    sessionId,
+    sessionKey,
+  };
+}
+
+async function streamText(
+  harness: Awaited<ReturnType<typeof createReconnectHarness>>,
+  text: string,
+) {
+  await harness.agent.handleGatewayEvent(
+    createChatEvent({
+      runId: harness.runId,
+      sessionKey: harness.sessionKey,
+      seq: 1,
+      state: "delta",
+      message: { content: [{ type: "text", text }] },
+    }),
+  );
+}
+
+function reconnect(harness: Awaited<ReturnType<typeof createReconnectHarness>>) {
+  harness.agent.handleGatewayDisconnect("1006: connection lost");
+  harness.agent.handleGatewayReconnect();
+}
+
+function messageChunks(harness: Awaited<ReturnType<typeof createReconnectHarness>>) {
+  return harness.connection["__sessionUpdateMock"].mock.calls.flatMap(([notification]) => {
+    const update = notification.update;
+    return update.sessionUpdate === "agent_message_chunk" && update.content.type === "text"
+      ? [update.content.text]
+      : [];
+  });
+}
+
+describe("acp translator reconnect settlement", () => {
+  it.each([
+    {
+      name: "full reply",
+      result: {
+        status: "ok",
+        terminalReply: { disposition: "visible", text: "final answer" },
+      } satisfies AcpAgentWaitResult,
+      streamed: undefined,
+      recovered: "final answer",
+    },
+    {
+      name: "sticky timeout suffix",
+      result: {
+        status: "timeout",
+        terminalReply: { disposition: "visible", text: "final answer" },
+      } satisfies AcpAgentWaitResult,
+      streamed: "final",
+      recovered: " answer",
+    },
+    {
+      name: "trim-normalized suffix",
+      result: {
+        status: "ok",
+        terminalReply: { disposition: "visible", text: "final answer" },
+      } satisfies AcpAgentWaitResult,
+      streamed: " final",
+      recovered: " answer",
+    },
+  ])("recovers the $name before resolving", async ({ result, streamed, recovered }) => {
+    const harness = await createReconnectHarness(result);
+    if (streamed) {
+      await streamText(harness, streamed);
+    }
+
+    reconnect(harness);
+
+    await expect(harness.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    expect(messageChunks(harness).filter((text) => text === recovered)).toHaveLength(1);
+    const replay = await harness.eventLedger.readReplay({
+      sessionId: harness.sessionId,
+      sessionKey: harness.sessionKey,
+    });
+    expect(
+      replay.events.some(
+        (event) =>
+          event.update.sessionUpdate === "agent_message_chunk" &&
+          event.update.content.type === "text" &&
+          event.update.content.text === recovered,
+      ),
+    ).toBe(true);
+  });
+
+  it("recovers visible text before rejecting a failed run", async () => {
+    const harness = await createReconnectHarness({
+      status: "error",
+      error: "boom",
+      terminalReply: { disposition: "visible", text: "final answer" },
+    });
+
+    reconnect(harness);
+
+    await expect(harness.promptPromise).rejects.toThrow("boom");
+    expect(messageChunks(harness)).toEqual(["final answer", "[OpenClaw interruption] boom"]);
+  });
+
+  it("claims recovery before a late final event can emit the suffix twice", async () => {
+    const harness = await createReconnectHarness({
+      status: "ok",
+      terminalReply: { disposition: "visible", text: "final answer" },
+    });
+    await streamText(harness, "final");
+    let releaseRecord!: () => void;
+    const recordBlocked = new Promise<void>((resolve) => {
+      releaseRecord = resolve;
+    });
+    const recordUpdate = harness.eventLedger.recordUpdate.bind(harness.eventLedger);
+    harness.eventLedger.recordUpdate = async (params) => {
+      if (
+        params.update.sessionUpdate === "agent_message_chunk" &&
+        params.update.content.type === "text" &&
+        params.update.content.text === " answer"
+      ) {
+        await recordBlocked;
+      }
+      await recordUpdate(params);
+    };
+
+    reconnect(harness);
+    await vi.waitFor(() => expect(messageChunks(harness)).toContain(" answer"));
+    const lateFinal = harness.agent.handleGatewayEvent(
+      createChatEvent({
+        runId: harness.runId,
+        sessionKey: harness.sessionKey,
+        seq: 2,
+        state: "final",
+        message: { content: [{ type: "text", text: "final answer" }] },
+      }),
+    );
+    releaseRecord();
+    await lateFinal;
+
+    await expect(harness.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    expect(messageChunks(harness).filter((text) => text === " answer")).toHaveLength(1);
+  });
+
+  it("settles after recovered update delivery rejects", async () => {
+    const harness = await createReconnectHarness({
+      status: "ok",
+      terminalReply: { disposition: "visible", text: "final answer" },
+    });
+    harness.connection.sessionUpdate = vi.fn(async () => {
+      throw new Error("client gone");
+    }) as typeof harness.connection.sessionUpdate;
+
+    reconnect(harness);
+
+    await expect(harness.promptPromise).resolves.toEqual({ stopReason: "end_turn" });
+    const replay = await harness.eventLedger.readReplay({
+      sessionId: harness.sessionId,
+      sessionKey: harness.sessionKey,
+    });
+    expect(
+      replay.events.some(
+        (event) =>
+          event.update.sessionUpdate === "agent_message_chunk" &&
+          event.update.content.type === "text" &&
+          event.update.content.text === "final answer",
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/acp/translator.disconnects.ts
+++ b/src/acp/translator.disconnects.ts
@@ -1,5 +1,4 @@
 /** Gateway disconnect grace period and pending-prompt reconciliation. */
-import type { StopReason } from "@agentclientprotocol/sdk";
 import type { GatewayClient } from "../gateway/client.js";
 import type {
   AcpAgentWaitResult,
@@ -21,10 +20,10 @@ export class AcpTranslatorDisconnects {
       sessionId: string,
       runId: string,
     ) => AcpPendingPrompt | undefined,
-    private readonly finishPrompt: (
+    private readonly settleRecoveredPrompt: (
       sessionId: string,
       pending: AcpPendingPrompt,
-      stopReason: StopReason,
+      result: AcpAgentWaitResult,
     ) => Promise<void>,
     private readonly rejectPendingPrompt: (
       pending: AcpPendingPrompt,
@@ -195,12 +194,13 @@ export class AcpTranslatorDisconnects {
     if (!currentPending) {
       return false;
     }
-    if (result?.status === "ok") {
-      await this.finishPrompt(sessionId, currentPending, "end_turn");
-      return false;
-    }
-    if (result?.status === "error") {
-      void this.finishPrompt(sessionId, currentPending, "end_turn");
+    const hasVisibleReply = result?.terminalReply?.disposition === "visible";
+    if (
+      result?.status === "ok" ||
+      result?.status === "error" ||
+      (result?.status === "timeout" && hasVisibleReply)
+    ) {
+      await this.settleRecoveredPrompt(sessionId, currentPending, result);
       return false;
     }
     if (deadlineExpired) {

--- a/src/acp/translator.prompt-state.ts
+++ b/src/acp/translator.prompt-state.ts
@@ -1,4 +1,5 @@
 import type { PromptResponse, ToolCallLocation, ToolKind } from "@agentclientprotocol/sdk";
+import type { AgentRunTerminalReplySnapshot } from "../agents/agent-run-terminal-reply.js";
 
 export type AcpDisconnectContext = {
   generation: number;
@@ -14,9 +15,7 @@ export type AcpPendingPrompt = {
   disconnectContext?: AcpDisconnectContext;
   resolve: (response: PromptResponse) => void;
   reject: (err: Error) => void;
-  sentTextLength?: number;
   sentText?: string;
-  sentThoughtLength?: number;
   sentThought?: string;
   toolCalls?: Map<string, AcpPendingToolCall>;
 };
@@ -39,4 +38,5 @@ type AcpPendingToolCall = {
 export type AcpAgentWaitResult = {
   status?: "ok" | "error" | "timeout";
   error?: string;
+  terminalReply?: AgentRunTerminalReplySnapshot;
 };

--- a/src/acp/translator.prompt-stream.ts
+++ b/src/acp/translator.prompt-stream.ts
@@ -20,7 +20,11 @@ import { extractAttachmentsFromPrompt, extractTextFromPrompt } from "./event-map
 import { parseSessionMeta } from "./session-mapper.js";
 import { AcpTranslatorAgentEvents } from "./translator.agent-events.js";
 import { AcpTranslatorDisconnects } from "./translator.disconnects.js";
-import type { AcpPendingApprovalRelay, AcpPendingPrompt } from "./translator.prompt-state.js";
+import type {
+  AcpAgentWaitResult,
+  AcpPendingApprovalRelay,
+  AcpPendingPrompt,
+} from "./translator.prompt-state.js";
 import type { GatewayChatContentBlock } from "./translator.replay.js";
 import type { AcpTranslatorSessionState } from "./translator.session-state.js";
 import type { AcpTranslatorSessionUpdates } from "./translator.session-updates.js";
@@ -122,7 +126,7 @@ export class AcpTranslatorPromptStream {
       gateway,
       this.pendingPrompts,
       (sessionId, runId) => this.getPendingPrompt(sessionId, runId),
-      (sessionId, pending, stopReason) => this.finishPrompt(sessionId, pending, stopReason),
+      (sessionId, pending, result) => this.settleRecoveredPrompt(sessionId, pending, result),
       (pending, error, options) => this.rejectPendingPrompt(pending, error, options),
       log,
     );
@@ -539,22 +543,11 @@ export class AcpTranslatorPromptStream {
       .map((block) => block.thinking ?? "")
       .join("\n")
       .trimEnd();
-    const sentThoughtSoFar = pending.sentThoughtLength ?? 0;
+    const sentThoughtSoFar = pending.sentThought?.length ?? 0;
     if (fullThought && fullThought.length > sentThoughtSoFar) {
       const newThought = fullThought.slice(sentThoughtSoFar);
-      pending.sentThoughtLength = fullThought.length;
       pending.sentThought = fullThought;
-      await this.sessionUpdates.emit({
-        sessionId,
-        sessionKey: pending.sessionKey,
-        ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
-        runId: pending.idempotencyKey,
-        record: true,
-        update: {
-          sessionUpdate: "agent_thought_chunk",
-          content: { type: "text", text: newThought },
-        },
-      });
+      await this.emitPromptChunk(pending, "agent_thought_chunk", newThought);
       if (this.getPendingPrompt(sessionId, pending.idempotencyKey) !== pending) {
         return false;
       }
@@ -565,25 +558,14 @@ export class AcpTranslatorPromptStream {
       .map((block) => block.text ?? "")
       .join("\n")
       .trimEnd();
-    const sentSoFar = pending.sentTextLength ?? 0;
+    const sentSoFar = pending.sentText?.length ?? 0;
     if (!fullText || fullText.length <= sentSoFar) {
       return true;
     }
 
     const newText = fullText.slice(sentSoFar);
-    pending.sentTextLength = fullText.length;
     pending.sentText = fullText;
-    await this.sessionUpdates.emit({
-      sessionId,
-      sessionKey: pending.sessionKey,
-      ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
-      runId: pending.idempotencyKey,
-      record: true,
-      update: {
-        sessionUpdate: "agent_message_chunk",
-        content: { type: "text", text: newText },
-      },
-    });
+    await this.emitPromptChunk(pending, "agent_message_chunk", newText);
     return this.getPendingPrompt(sessionId, pending.idempotencyKey) === pending;
   }
 
@@ -591,8 +573,9 @@ export class AcpTranslatorPromptStream {
     sessionId: string,
     pending: AcpPendingPrompt,
     stopReason: StopReason,
+    options: { claimed?: boolean } = {},
   ): Promise<void> {
-    if (!this.claimPendingPrompt(pending)) {
+    if (!options.claimed && !this.claimPendingPrompt(pending)) {
       return;
     }
     const promptKey = this.pendingPromptKey(sessionId, pending.idempotencyKey);
@@ -620,6 +603,60 @@ export class AcpTranslatorPromptStream {
     } finally {
       this.settlingPromptKeys.delete(promptKey);
     }
+  }
+
+  private async emitPromptChunk(
+    pending: AcpPendingPrompt,
+    kind: "agent_message_chunk" | "agent_thought_chunk",
+    text: string,
+    waitForDelivery = true,
+  ): Promise<void> {
+    await this.sessionUpdates.emit({
+      sessionId: pending.sessionId,
+      sessionKey: pending.sessionKey,
+      ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
+      runId: pending.idempotencyKey,
+      record: true,
+      ...(waitForDelivery ? {} : { waitForDelivery: false }),
+      update: {
+        sessionUpdate: kind,
+        content: { type: "text", text },
+      },
+    });
+  }
+
+  private async settleRecoveredPrompt(
+    sessionId: string,
+    pending: AcpPendingPrompt,
+    result: AcpAgentWaitResult,
+  ): Promise<void> {
+    // Claim before the first await so late chat events cannot deliver or settle
+    // the same prompt a second time.
+    if (!this.claimPendingPrompt(pending)) {
+      return;
+    }
+    const terminalReply = result.terminalReply;
+    if (terminalReply?.disposition === "visible") {
+      const sentText = (pending.sentText ?? "").trimStart();
+      const recoveredText = terminalReply.text.startsWith(sentText)
+        ? terminalReply.text.slice(sentText.length)
+        : "";
+      if (recoveredText) {
+        await this.emitPromptChunk(pending, "agent_message_chunk", recoveredText, false);
+      }
+    }
+    if (result.status !== "error") {
+      await this.finishPrompt(sessionId, pending, "end_turn", { claimed: true });
+      return;
+    }
+    const message = result.error?.trim() || "run failed";
+    await this.emitPromptChunk(
+      pending,
+      "agent_message_chunk",
+      `[OpenClaw interruption] ${message}`,
+      false,
+    );
+    await this.rejectPendingPrompt(pending, new Error(message), { claimed: true });
   }
 
   private findPendingBySessionKey(
@@ -662,9 +699,9 @@ export class AcpTranslatorPromptStream {
   private async rejectPendingPrompt(
     pending: AcpPendingPrompt,
     error: Error,
-    options: { recordDisconnectNotice?: boolean } = {},
+    options: { claimed?: boolean; recordDisconnectNotice?: boolean } = {},
   ): Promise<void> {
-    if (!this.claimPendingPrompt(pending)) {
+    if (!options.claimed && !this.claimPendingPrompt(pending)) {
       return;
     }
 
@@ -676,20 +713,7 @@ export class AcpTranslatorPromptStream {
         const text = pending.sendAccepted
           ? "[OpenClaw interruption] The Gateway disconnected after accepting this message, so its final outcome is unknown. Check the session before retrying."
           : "[OpenClaw interruption] The Gateway disconnected before OpenClaw could confirm whether this message was accepted, so its final outcome is unknown. Check the session before retrying.";
-        // Make replay durable before rejecting, but do not let ACP client backpressure
-        // extend the disconnect deadline indefinitely.
-        await this.sessionUpdates.emit({
-          sessionId: pending.sessionId,
-          sessionKey: pending.sessionKey,
-          ...(pending.ledgerSessionId ? { ledgerSessionId: pending.ledgerSessionId } : {}),
-          runId: pending.idempotencyKey,
-          record: true,
-          waitForDelivery: false,
-          update: {
-            sessionUpdate: "agent_message_chunk",
-            content: { type: "text", text },
-          },
-        });
+        await this.emitPromptChunk(pending, "agent_message_chunk", text, false);
       }
     } catch (noticeError) {
       this.log(`disconnect notice failed for ${pending.idempotencyKey}: ${String(noticeError)}`);


### PR DESCRIPTION
Closes #126903

## What Problem This Solves

When the Gateway connection dropped during an ACP prompt, the run could finish while the bridge was disconnected. Reconnect reconciliation then resolved the prompt without delivering the terminal reply. A failed run also resolved as a normal `end_turn`.

## Why This Change Was Made

`agent.wait` already returns the producer-owned, bounded `terminalReply`. The ACP reconnect path discarded that fact and mapped `status: "error"` to normal completion.

The prompt owner now claims the pending prompt before any recovered delivery can await. It records and emits the full missing reply or suffix once, then applies the real terminal status: success resolves and failure emits an interruption before rejecting. Normal streamed chunks and recovered chunks use one emission path.

## User Impact

ACP clients no longer lose replies that finish during a short Gateway disconnect. They also see failed reconnect-settled runs as failures instead of successful turns.

## Evidence

### Real Gateway red/green proof

The same process-level scenario ran on the exact `origin/main` revision at proof time, `9022e0e1cf3f1933b9fd41b4a95256bfaf1eedf0`, and exact head `d0c6973c8c1137bfa0b7d06c57cdf836351eb232`:

- Real built Gateway with isolated state and token auth.
- Real built ACP bridge and `@agentclientprotocol/sdk` client over stdio.
- A WebSocket proxy cut the bridge-to-Gateway connection after model admission.
- The run reached `agent.wait` terminal state before the proxy resumed.
- Only the model endpoint was controlled so the reply could finish during the disconnect.

| Scenario | Current main | This head |
| --- | --- | --- |
| Reply marker alpha | Gateway terminal reply changed, ACP delivered 0 copies, prompt resolved `end_turn` | ACP delivered 1 copy after reconnect, prompt resolved `end_turn` |
| Reply marker beta | Gateway terminal reply changed again, ACP delivered 0 copies, prompt resolved `end_turn` | ACP delivered 1 changed copy after reconnect, prompt resolved `end_turn` |
| Real run timeout | Gateway returned `status: "error"`, ACP delivered no interruption, prompt resolved `end_turn` | ACP delivered the interruption and rejected the prompt |

The alpha-to-beta payload change is the anti-replay probe. Each head scenario recorded the exact run ID, disconnect, terminal observation, reconnect, ACP update, and settlement order in retained private evidence.

### Regression and local checks

- Pre-fix regression: `node scripts/run-vitest.mjs src/acp/translator.disconnects.test.ts -t 'full reply'` fails because no recovered chunk exists.
- Head regression: `node scripts/run-vitest.mjs src/acp/translator.disconnects.test.ts src/acp/translator.stop-reason.test.ts src/acp/translator.session-updates.test.ts src/acp/translator.final-snapshots.test.ts` passes 33 tests.
- Full ACP suite: `node scripts/run-vitest.mjs src/acp` passes 71 files and 600 tests.
- Scoped Oxfmt, Oxlint, selected repository ratchets, and `git diff --check` pass.
- Falc0n did not run build or TypeScript type checks. The isolated proof host built both exact revisions; hosted CI owns final type checks.

## Change Size

- Production: +80/-56, net +24.
- Tests: +204/-0.
- The production growth is the reconnect settlement capability. Shared chunk emission and removal of duplicate text-length state absorb the rest of the contributor patch, reducing its production delta from net +75.

Co-authored-by: wangmiao0668000666 <wang.miao86@xydigit.com>
