### PR TITLE
fix(cua-computer): scope availability watch teardown to the watch lifetime

### DIFF
--- a/extensions/cua-computer/src/commands.test.ts
+++ b/extensions/cua-computer/src/commands.test.ts
@@ -353,6 +353,40 @@ describe("cua-computer provider", () => {
     expect(dispose).toHaveBeenCalledOnce();
   });
 
+  it("keeps the process-lifetime provider usable after a watch session teardown", async () => {
+    const { session } = driver();
+    const createDriver = vi.fn(() => session);
+    const intervalCallbacks: Array<() => void> = [];
+    const provider = createCuaComputerProvider({
+      platform: "linux",
+      createDriver,
+      imageProcessor: {
+        encode: vi.fn(async () => ({ data: Buffer.from("jpeg"), width: 100, height: 50 })),
+      },
+      setInterval: vi.fn((callback: () => void) => {
+        intervalCallbacks.push(callback);
+        return Object.assign(intervalCallbacks.length, { unref: vi.fn() });
+      }) as never,
+      clearInterval: vi.fn() as never,
+    });
+
+    const stopFirst = provider.watchAvailability?.({ config: {} as never, env: {} }, vi.fn());
+    stopFirst?.();
+    await Promise.resolve();
+
+    expect(provider.isAvailable()).toBe(true);
+    const computer = await provider.openExecution({
+      executionId: "123e4567-e89b-42d3-a456-426614174000",
+    });
+    await computer.close("completion");
+
+    const stopSecond = provider.watchAvailability?.({ config: {} as never, env: {} }, vi.fn());
+    expect(intervalCallbacks).toHaveLength(2);
+    expect(() => intervalCallbacks[0]!()).not.toThrow();
+    expect(() => intervalCallbacks[1]!()).not.toThrow();
+    stopSecond?.();
+  });
+
   it("passes node invocation cancellation to the direct SDK", async () => {
     const { session, getDesktopState } = driver();
     const computer = await execution(session);

--- a/extensions/cua-computer/src/commands.ts
+++ b/extensions/cua-computer/src/commands.ts
@@ -438,18 +438,11 @@ export function createCuaComputerProvider(
   const env = options.env ?? process.env;
   const macOsEndpoint = platform === "darwin" ? resolveMacOsMcpEndpoint(env) : undefined;
   let ownedAvailabilityDriver: CuaDriverSession | undefined;
-  let stopped = false;
   const createDriver =
     options.createDriver ??
     (macOsEndpoint ? () => createCuaMcpDriver({ ...macOsEndpoint, env }) : createCuaDriver);
-  const availabilityDriver = () => {
-    if (stopped) {
-      throw new Error("COMPUTER_DRIVER_UNAVAILABLE: cua-computer is stopping");
-    }
-    return options.driver ?? (ownedAvailabilityDriver ??= createDriver());
-  };
+  const availabilityDriver = () => options.driver ?? (ownedAvailabilityDriver ??= createDriver());
   const disposeAvailabilityDriver = async () => {
-    stopped = true;
     const current = ownedAvailabilityDriver;
     ownedAvailabilityDriver = undefined;
     await current?.dispose();
@@ -486,8 +479,15 @@ export function createCuaComputerProvider(
     }),
     isAvailable,
     watchAvailability: (_context, onChange) => {
+      // `stopped` is watch-scoped: session teardown must not latch the
+      // process-lifetime provider, so dispose only resets the lazily-owned
+      // driver and the guard silences this watch's already-queued callback.
+      let stopped = false;
       let knownAvailable = isAvailable();
       const timer = interval(() => {
+        if (stopped) {
+          return;
+        }
         availabilityDriver().resetAvailabilityCache();
         const available = isAvailable();
         if (available !== knownAvailable) {
@@ -497,14 +497,12 @@ export function createCuaComputerProvider(
       }, AVAILABILITY_POLL_MS);
       timer.unref?.();
       return () => {
+        stopped = true;
         clear(timer);
         void disposeAvailabilityDriver();
       };
     },
     openExecution: async () => {
-      if (stopped) {
-        throw new Error("COMPUTER_DRIVER_UNAVAILABLE: cua-computer is stopping");
-      }
       const executionDriver = options.driver ?? createDriver();
       const resources = createLazyCuaExecutionResources();
       const executionState = { resources, recording: {} };


### PR DESCRIPTION
Closes #126904

## What Problem This Solves
After the first node-host session teardown (a normal gateway disconnect/reconnect), the cua-computer provider was permanently bricked on linux/win32: `isAvailable()`/`capabilities()`/`openExecution()` threw `COMPUTER_DRIVER_UNAVAILABLE`, and every new session's 5s watch interval threw uncaught in its timer callback. After this change the provider survives any number of session teardowns.

## Root cause
`stopped` was provider-lifetime state latched forever by `disposeAvailabilityDriver()`, which runs from `watchAvailability`'s **session-scoped** cleanup (node host invokes it on every session close). The fail-closed guard was attached to the wrong lifetime.

## Fix shape
The stopped guard is now watch-local (silences only that watch's already-queued interval callback); `disposeAvailabilityDriver` only disposes/resets the owned driver so the next `availabilityDriver()` lazily recreates it. Net production LOC −2 (+9/−11, `extensions/cua-computer/src/commands.ts`); tests +34/−0.

## Rejected alternatives
Resetting the provider-lifetime flag on watch start would keep two writers racing on shared state; scoping the guard to the watch removes the ownership mismatch entirely.

## Evidence
Head: `cb892258461`. New regression test 'keeps the process-lifetime provider usable after a watch session teardown' **fails pre-fix** (`COMPUTER_DRIVER_UNAVAILABLE: cua-computer is stopping`) and passes post-fix; the existing 'lazily owns one session and closes it when node-host availability stops' still passes. Extension suite: 99 passed, 1 pre-existing environment failure (`driver-client.test.ts` needs GLIBC_2.30 for the native `@trycua/cua-driver` binding; fails identically at the clean base).

## Review
trufflehog clean. Autoreview engine unavailable in this environment (codex backend 403, claude/pi 401) — stated plainly rather than bypassed.


## Real behavior proof (2026-08-21, head cb892258461)

Addressing the review gate: real runtime trace of the reconnect flow. Harness runs the REAL `createCuaComputerProvider` with real defaults on Linux (real lazy CUA driver, real unref'd 5s poll interval, no mocks), replicating the exact gateway flow from `src/plugins/computer-use-contract.ts:641`: one watch per connection, stop on disconnect, new watch on reconnect. Full harness script available on request.

**Post-fix (head `cb892258461`)** — reconnect works:

```
provider created (real defaults, linux)
watch1 created (first gateway connection)
... 5.5s (real poll tick fired) ...
watch1 alive: isAvailable()=false (no throw)
tearing down watch1 (gateway disconnect)
creating watch2 (gateway reconnect)
watch2 created without throwing
... 5.5s (watch2 real poll tick fired) ...
watch2 alive after tick: isAvailable()=false (no throw, no crash)
RESULT: PASS — watch teardown is watch-scoped; reconnect watch works
```

**Pre-fix (same harness, `cb892258461~1` commands.ts)** — provider latched:

```
watch1 created ... watch1 alive: isAvailable()=false (no throw)
tearing down watch1 (gateway disconnect)
creating watch2 (gateway reconnect)
watch2 creation threw: COMPUTER_DRIVER_UNAVAILABLE: cua-computer is stopping
RESULT: FAIL — provider is latched stopped after first watch teardown (reconnect broken)
```

Red/green pair on identical harness: pre-fix latches the process-lifetime provider on first watch teardown so a reconnect watch throws at creation; post-fix the reconnect watch creates, polls, and reports cleanly. (`isAvailable()=false` is expected on a Linux host without a CUA desktop backend; the invariant under test is that availability probing keeps working after reconnect, not that a desktop exists.)
