### PR TITLE
perf(test): synchronize close assertions on events in googlechat/feishu

### DIFF
--- a/extensions/feishu/src/media-chunk-idle.test.ts
+++ b/extensions/feishu/src/media-chunk-idle.test.ts
@@ -13,6 +13,54 @@ function getHttpReadable(url: string): Promise<http.IncomingMessage> {
   });
 }
 
+async function withStalledHttpServer(
+  run: (ctx: {
+    mediaUrl: string;
+    closed: Promise<void>;
+    serverSawClose: () => boolean;
+  }) => Promise<void>,
+): Promise<void> {
+  let sawClose = false;
+  let resolveClosed: () => void = () => {};
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const server = createServer((req, res) => {
+    res.writeHead(200, { "content-type": "image/jpeg", "content-length": "1048576" });
+    res.flushHeaders();
+    const markClose = () => {
+      sawClose = true;
+      resolveClosed();
+    };
+    req.on("close", markClose);
+    res.on("close", markClose);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("server failed to bind");
+  }
+
+  try {
+    await run({
+      mediaUrl: `http://127.0.0.1:${address.port}/media`,
+      closed,
+      serverSawClose: () => sawClose,
+    });
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
 describe("saveMediaStreamWithIdleTimeout", () => {
   let stateDir = "";
   let envSnapshot: ReturnType<typeof captureEnv>;
@@ -53,30 +101,8 @@ describe("saveMediaStreamWithIdleTimeout", () => {
   });
 
   it("times out a stalled SDK-style HTTP stream and closes its connection", async () => {
-    let serverSawClose = false;
-    const server = createServer((req, res) => {
-      res.writeHead(200, { "content-type": "image/jpeg", "content-length": "1048576" });
-      res.flushHeaders();
-      const markClose = () => {
-        serverSawClose = true;
-      };
-      req.on("close", markClose);
-      res.on("close", markClose);
-    });
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        server.off("error", reject);
-        resolve();
-      });
-    });
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("server failed to bind");
-    }
-
-    try {
-      const stalled = await getHttpReadable(`http://127.0.0.1:${address.port}/media`);
+    await withStalledHttpServer(async ({ mediaUrl, closed, serverSawClose }) => {
+      const stalled = await getHttpReadable(mediaUrl);
       await expect(
         saveMediaStreamWithIdleTimeout(stalled, "image/jpeg", 1024, undefined, 50),
       ).rejects.toMatchObject({
@@ -84,15 +110,28 @@ describe("saveMediaStreamWithIdleTimeout", () => {
         chunkTimeoutMs: 50,
       });
       expect(stalled.destroyed).toBe(true);
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 20);
+      await closed;
+      expect(serverSawClose()).toBe(true);
+    });
+  });
+
+  it("observes the connection close even when teardown lands past the old 20ms window", async () => {
+    await withStalledHttpServer(async ({ mediaUrl, closed, serverSawClose }) => {
+      const stalled = await getHttpReadable(mediaUrl);
+      const realDestroy = stalled.destroy.bind(stalled);
+      stalled.destroy = ((error?: Error) => {
+        setTimeout(() => realDestroy(error), 60);
+        return stalled;
+      }) as typeof stalled.destroy;
+      await expect(
+        saveMediaStreamWithIdleTimeout(stalled, "image/jpeg", 1024, undefined, 50),
+      ).rejects.toMatchObject({
+        name: "FeishuInboundMediaTimeoutError",
+        chunkTimeoutMs: 50,
       });
-      expect(serverSawClose).toBe(true);
-    } finally {
-      server.closeAllConnections?.();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+      await closed;
+      expect(stalled.destroyed).toBe(true);
+      expect(serverSawClose()).toBe(true);
+    });
   });
 });

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -464,12 +464,10 @@ describe("downloadGoogleChatMedia", () => {
       await expect(downloadGoogleChatMedia({ account, resourceName: "media/123" })).rejects.toThrow(
         "Google Chat media exceeds max bytes (20971520)",
       );
-      await Promise.race([
-        responseClosedPromise,
-        new Promise((resolve) => {
-          setTimeout(resolve, 100);
-        }),
-      ]);
+      // Stall longer than the old 100ms grace window: observing the response
+      // close must synchronize on the close event, not on wall-clock.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 150);
+      await responseClosedPromise;
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()));
@@ -485,6 +483,10 @@ describe("downloadGoogleChatMedia", () => {
     const chunk = new Uint8Array(6);
     let chunksPulled = 0;
     let canceled = false;
+    let resolveCanceled: () => void = () => {};
+    const canceledPromise = new Promise<void>((resolve) => {
+      resolveCanceled = resolve;
+    });
     const response = new Response(
       new ReadableStream<Uint8Array>({
         pull(controller) {
@@ -497,6 +499,7 @@ describe("downloadGoogleChatMedia", () => {
         },
         cancel() {
           canceled = true;
+          resolveCanceled();
         },
       }),
       { status: 200, headers: { "content-type": "application/octet-stream" } },
@@ -506,9 +509,7 @@ describe("downloadGoogleChatMedia", () => {
     await expect(
       downloadGoogleChatMedia({ account, resourceName: "media/123", maxBytes: 10 }),
     ).rejects.toThrow("Google Chat media exceeds max bytes (10)");
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
+    await canceledPromise;
     expect(canceled).toBe(true);
     expect(chunksPulled).toBeLessThan(TOTAL_CHUNKS);
   });

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -413,15 +413,23 @@ describe("downloadGoogleChatMedia", () => {
     const chunk = Buffer.alloc(ONE_MIB);
     let bytesSent = 0;
     let responseClosed = false;
-    let resolveResponseClosed: () => void = () => {};
-    const responseClosedPromise = new Promise<void>((resolve) => {
-      resolveResponseClosed = resolve;
+    let closeObserved = false;
+    let resolveCloseObserved: () => void = () => {};
+    const closeObservedPromise = new Promise<void>((resolve) => {
+      resolveCloseObserved = resolve;
     });
     const server = createServer((_req, res) => {
       res.writeHead(200, { "content-type": "application/octet-stream" });
       res.on("close", () => {
         responseClosed = true;
-        resolveResponseClosed();
+        // Defer the observable close fact past the old 100ms grace window
+        // without blocking the event loop: the legacy fixed-window race must
+        // expire before the close becomes visible, so this regression goes
+        // red under the old assertion and green under the close-event wait.
+        setTimeout(() => {
+          closeObserved = true;
+          resolveCloseObserved();
+        }, 150);
       });
       const writeNext = () => {
         if (responseClosed) {
@@ -464,17 +472,14 @@ describe("downloadGoogleChatMedia", () => {
       await expect(downloadGoogleChatMedia({ account, resourceName: "media/123" })).rejects.toThrow(
         "Google Chat media exceeds max bytes (20971520)",
       );
-      // Stall longer than the old 100ms grace window: observing the response
-      // close must synchronize on the close event, not on wall-clock.
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 150);
-      await responseClosedPromise;
+      await closeObservedPromise;
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()));
       });
     }
     expect(release).toHaveBeenCalledOnce();
-    expect(responseClosed).toBe(true);
+    expect(closeObserved).toBe(true);
     expect(bytesSent).toBeLessThan(totalBytes);
   });
 


### PR DESCRIPTION
Closes #126905

## What Problem This Solves
Test-only change; no production behavior changes. Removes two CI flake sources of the same class as #126664/#126639/#126649: tests that synchronized 'server observed the connection close' on wall-clock windows instead of the already-existing close-event promises.

## Root cause
- `extensions/googlechat/src/targets.test.ts`: raced `responseClosedPromise` against a 100ms `setTimeout` and discarded the race result before asserting `responseClosed === true` — any event-loop stall >100ms flaked it. Also folded in the sibling wall-clock wait in 'preserves stricter explicit media byte limits' (`setTimeout(0)` tick → the stream's `cancel()` promise).
- `extensions/feishu/src/media-chunk-idle.test.ts`: waited a flat 20ms after `stalled.destroyed` before asserting `serverSawClose`, instead of awaiting the `req.on('close')` event.

## Fix shape
Await the close-event promises directly; if the close never comes, the vitest test timeout fails it — same failure mode, no flakiness. Test-only LOC: +80/−40 (includes committed regression variants); production LOC delta: 0.

Follow-up after ClawSweeper review (`5866620be84`): the original Google Chat fault injection blocked the event loop with `Atomics.wait` *before* the legacy `Promise.race` would arm its 100ms timer, so reverting to the old assertion could not reproduce the failure. The injection now defers the observable close fact with a 150ms `setTimeout` in the server's `res.on('close')` handler (event loop stays free, legacy deadline arms and expires first), while the write loop still stops synchronously on `close`.

## Evidence
Head: `5866620be84`. Deterministic red/green on the exact legacy assertion shape, `node scripts/run-vitest.mjs extensions/googlechat/src/targets.test.ts` on Node v24.19.0:
- RED: legacy `await Promise.race([closeObservedPromise, setTimeout 100ms])` + `expect(closeObserved).toBe(true)` fails with `expected false to be true` at `targets.test.ts:487` (1 failed | 43 passed) — the 100ms deadline expires before the deferred close becomes visible.
- GREEN: `await closeObservedPromise` passes, 44/44.
Feishu injection unchanged: deferring `destroy()` by 60ms fails the original 20ms-window shape. Post-fix both files pass (`extensions/googlechat/src/targets.test.ts` 44/44, `extensions/feishu/src/media-chunk-idle.test.ts` 3/3). Full extension suites (at earlier head): 1901 passed, 2 pre-existing failures (`googlechat/setup.test.ts`, `feishu/setup-surface.test.ts` fail identically at base e2f841bf1c1). oxfmt and oxlint clean on touched files.

## Review
trufflehog clean. Autoreview engine unavailable in this environment (codex backend 413, claude/pi 401) — stated plainly rather than bypassed.
