### PR TITLE
fix(cli): render sandbox JSON failures

### DIFF
--- a/src/cli/sandbox-cli.ts
+++ b/src/cli/sandbox-cli.ts
@@ -4,8 +4,8 @@ import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import { sandboxExplainCommand } from "../commands/sandbox-explain.js";
 import { sandboxListCommand, sandboxRecreateCommand } from "../commands/sandbox.js";
-import { formatErrorMessage } from "../infra/errors.js";
 import { defaultRuntime } from "../runtime.js";
+import { runCommandWithRuntime } from "./cli-utils.js";
 import { formatHelpExamples } from "./help-format.js";
 
 // --- Types ---
@@ -46,14 +46,10 @@ const SANDBOX_EXAMPLES = {
 function createRunner(
   commandFn: (opts: CommandOptions, runtime: typeof defaultRuntime) => Promise<void>,
 ) {
-  // Sandbox commands share the default runtime error/exit behavior.
   return async (opts: CommandOptions) => {
-    try {
+    await runCommandWithRuntime(defaultRuntime, async () => {
       await commandFn(opts, defaultRuntime);
-    } catch (err) {
-      defaultRuntime.error(formatErrorMessage(err));
-      defaultRuntime.exit(1);
-    }
+    });
   };
 }
 

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -329,6 +329,35 @@ describe("cli json stdout contract", () => {
     );
   });
 
+  it("renders sandbox explain validation failures as one canonical JSON document", async () => {
+    await withTempHome(
+      async (tempHome) => {
+        const result = runBuiltCli(tempHome, [
+          "sandbox",
+          "explain",
+          "--json",
+          "--agent",
+          "alpha",
+          "--session",
+          "agent:beta:main",
+        ]);
+
+        expect(result.status, result.stderr).toBe(1);
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message: 'Sandbox explain agent "alpha" does not match session agent "beta".',
+          },
+        });
+        expect(result.stderr).toContain(
+          'Sandbox explain agent "alpha" does not match session agent "beta".',
+        );
+      },
+      { prefix: "openclaw-sandbox-json-failure-e2e-" },
+    );
+  });
+
   it("returns one canonical document when docs search fails", async () => {
     await withTempHome(
       async (tempHome) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw sandbox list --json` and `openclaw sandbox explain --json` failures could exit nonzero with empty stdout and a human-only stderr message. Automation expecting the documented JSON contract then failed while parsing an empty response.

## Why This Change Was Made

The sandbox registrar now delegates errors to the existing shared `runCommandWithRuntime` owner, matching the QR and other JSON-aware CLI paths. JSON-mode errors reach the process-level canonical renderer; human-mode errors keep the existing stderr and exit behavior. Command execution and sandbox runtime logic are otherwise unchanged.

This PR is AI-assisted and received a fresh independent P1 review with no actionable findings.

## User Impact

Scripts can reliably parse one canonical `{ ok: false, error: ... }` document when sandbox JSON commands fail. Interactive users continue to receive the same concise human-readable error.

## Evidence

- Current-main real-process reproduction: `sandbox explain --json --agent alpha --session agent:beta:main` exited 1 with zero stdout bytes and only a human stderr diagnostic.
- After the repair, the same real process exits 1 with exactly one canonical JSON stdout error and retains the stderr diagnostic.
- Focused `runCommandWithRuntime` tests and the new real-process sandbox JSON E2E passed on the rebased head.
- Full changed-file formatting, typechecks, lint, dead-export, architecture, storage, and import-cycle gates passed after installing the exact locked worktree dependencies.
- Fresh P1 autoreview reported no accepted/actionable findings.
- Production: +3/-7 (net -4). Tests: +29.
