### PR TITLE
test: trim plugin test duplicates

### DIFF
--- a/extensions/anthropic/cli-shared.execution-env.test.ts
+++ b/extensions/anthropic/cli-shared.execution-env.test.ts
@@ -1,21 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { buildAnthropicCliBackend } from "./cli-backend.js";
 import { resolveClaudeCliThinkingEnv } from "./cli-shared.js";
 
 describe("Claude CLI execution environment", () => {
-  it("preserves the prepared launch environment for the same context budget", () => {
-    const backend = buildAnthropicCliBackend();
-
-    expect(
-      backend.prepareExecution?.({
-        workspaceDir: "/tmp/openclaw-claude-cli",
-        provider: "claude-cli",
-        modelId: "claude-opus-4-8",
-        contextTokenBudget: 100_000,
-      }),
-    ).toEqual({ env: { CLAUDE_CODE_AUTO_COMPACT_WINDOW: "100000" } });
-  });
-
   it.each([
     ["high", { CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING: "1", MAX_THINKING_TOKENS: "16384" }],
     ["off", { MAX_THINKING_TOKENS: "0" }],

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -438,8 +438,6 @@ describe("CodexAppServerClient", () => {
   });
 
   it.each([
-    ["0.148.0-alpha.9", 0],
-    ["0.148.0-alpha.15", 0],
     ["0.148.0-alpha.23", 0],
     ["0.148.0", 0],
     ["1.0.0", 1],

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -531,10 +531,6 @@ describe("Crabbox worker provider", () => {
       "bind_xfdesktop_renderer",
     );
     expect(desktopSetupText).not.toMatch(/pkill -(?:TERM|KILL) -x xfdesktop/u);
-    expect(desktopSetupText).not.toContain("def ellipse");
-    expect(desktopSetupText).not.toContain("import struct");
-    expect(desktopSetupText).not.toContain(".svg");
-    expect(desktopSetupText).not.toContain("sshUser");
     const setup = calls.find(
       (call) => call.argv[1] === "run" && String(call.options.input).includes("node run"),
     )?.options.input;

--- a/extensions/discord/src/monitor/message-text.test.ts
+++ b/extensions/discord/src/monitor/message-text.test.ts
@@ -275,22 +275,6 @@ describe("resolveDiscordMessageText", () => {
     ).toBe("Breaking\nDetails");
   });
 
-  it("preserves ordered text from all embeds while skipping textless embeds", () => {
-    expect(
-      resolveDiscordMessageText(
-        asMessage({
-          content: "",
-          embeds: [
-            { image: { url: "https://cdn.discordapp.com/image.png" } },
-            { title: "Breaking", description: "Details" },
-            {},
-            { description: "Follow-up" },
-          ],
-        }),
-      ),
-    ).toBe("Breaking\nDetails\nFollow-up");
-  });
-
   it("prefers message content over embed fallback text", () => {
     expect(
       resolveDiscordMessageText(

--- a/extensions/discord/src/monitor/native-command.options.test.ts
+++ b/extensions/discord/src/monitor/native-command.options.test.ts
@@ -711,10 +711,6 @@ describe("createDiscordNativeCommand option wiring", () => {
       ko: "현지화된 설명",
       "en-GB": "k".repeat(99),
     });
-    expect(loggerDebugMock).toHaveBeenCalledExactlyOnceWith(
-      `discord: truncating native command description (command:localized locale:en-GB) from ${longDescription.length} to 100: ${JSON.stringify(longDescription)}`,
-    );
-    expect(loggerWarnMock).not.toHaveBeenCalled();
     expect(command.serialize()).toEqual({
       name: "localized",
       description: "Default description",

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1136,15 +1136,6 @@ describe("buildAssistantMessage", () => {
     });
   });
 
-  it("rejects malformed stringified tool call arguments", () => {
-    const response = createToolCallResponse([
-      { function: { name: "bash", arguments: '{"command":"ls"' } },
-    ]);
-    expect(() => buildAssistantMessage(response, modelInfo)).toThrow(
-      "Provider completed tool call with malformed JSON arguments",
-    );
-  });
-
   it("sets all costs to zero for local models", () => {
     const response = createAssistantResponse({ content: "ok" });
     const result = buildAssistantMessage(response, modelInfo);

--- a/extensions/perplexity/src/perplexity-web-search-provider.test.ts
+++ b/extensions/perplexity/src/perplexity-web-search-provider.test.ts
@@ -96,29 +96,7 @@ describe("perplexity web search provider", () => {
 
   it.each([
     { name: "missing choices", response: {} },
-    { name: "empty choices", response: { choices: [] } },
-    { name: "missing message", response: { choices: [{}] } },
-    { name: "missing content", response: { choices: [{ message: {} }] } },
-    { name: "null content", response: { choices: [{ message: { content: null } }] } },
-    { name: "empty content", response: { choices: [{ message: { content: "" } }] } },
     { name: "whitespace content", response: { choices: [{ message: { content: " \n " } }] } },
-    {
-      name: "citations without an answer",
-      response: {
-        choices: [{ message: { content: null } }],
-        citations: ["https://example.test/source"],
-      },
-    },
-    {
-      name: "tool calls without an answer",
-      response: {
-        choices: [{ finish_reason: "tool_calls", message: { content: null, tool_calls: [] } }],
-      },
-    },
-    {
-      name: "audio without an answer",
-      response: { choices: [{ message: { content: null, audio: { id: "audio-response" } } }] },
-    },
   ])("rejects and does not cache chat-completions $name", async ({ name, response }) => {
     withTrustedWebSearchEndpointMock.mockReset();
     mockPerplexityResponseOnce(response);

--- a/extensions/policy/src/cli.agent-owner.test.ts
+++ b/extensions/policy/src/cli.agent-owner.test.ts
@@ -183,13 +183,6 @@ describe("policy CLI agent ownership", () => {
       hint: "openclaw --profile testprof agents list",
     },
     {
-      name: "watch with an active profile",
-      args: ["watch", "--agent", "ghost", "--once", "--json"],
-      profile: "testprof",
-      container: "",
-      hint: "openclaw --profile testprof agents list",
-    },
-    {
       name: "relative compare with an active container",
       args: ["compare", "--agent", "ghost", "--baseline", "baseline.policy.jsonc", "--json"],
       profile: "testprof",


### PR DESCRIPTION
## What Problem This Solves

Several plugin suites rechecked the same contract at a weaker helper boundary, enumerated multiple inputs that collapse to the same production branch, or asserted that retired implementation strings stayed absent. Those checks added maintenance cost without protecting a distinct transport, provider, or lifecycle outcome.

## Why This Change Was Made

This removes eight focused groups of duplicate assertions across provider, channel, policy, worker, and harness plugins. The stronger boundaries remain: full streamed-error handling, Discord message admission and forwarded/thread text, Perplexity retry/no-cache behavior for both non-string and blank content, native-command logging, Codex initialization compatibility, and the generated worker artifact checks.

## User Impact

No user-visible behavior changes. Plugin tests remain behavior-focused and keep the independent contracts that can catch real regressions.

AI-assisted: yes.

## Evidence

- Focused 12-file plugin run — 565 tests passed across 5 Vitest shards.
- `pnpm test:changed` — 382 tests passed across 5 Vitest shards.
- `pnpm check:changed` — passed formatting, extension test typechecking/lint, plugin boundaries, dead-export checks, and repository guards.
- `git diff --check` — clean.
- Fresh structured autoreview — no accepted or actionable findings.
- The Codex prerelease rows were checked against the upstream app-server user-agent producer and initialize response path before pruning equivalent accepted samples.

Production and test-support delta: 0. Test delta: `-78`. No screenshots are needed because runtime and rendered behavior are unchanged.
