### PR TITLE
fix(sessions): keep recorded identity in CLI lists

### DIFF
--- a/src/commands/sessions-display-model.ts
+++ b/src/commands/sessions-display-model.ts
@@ -9,6 +9,9 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
   inferUniqueProviderFromConfiguredModels,
   isCliProvider,
+  normalizeStoredOverrideModel,
+  parseModelRef,
+  resolvePersistedSelectedModelRef,
   type CliProviderClassifier,
 } from "../agents/model-selection.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
@@ -28,21 +31,6 @@ type SessionDisplayDefaults = {
 
 type SessionDisplayModelRef = { provider: string; model: string };
 
-function parseModelRef(raw: string, defaultProvider: string): SessionDisplayModelRef {
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return { provider: defaultProvider, model: DEFAULT_MODEL };
-  }
-  const slashIndex = trimmed.indexOf("/");
-  if (slashIndex <= 0 || slashIndex === trimmed.length - 1) {
-    return { provider: defaultProvider, model: trimmed };
-  }
-  return {
-    provider: trimmed.slice(0, slashIndex).trim() || defaultProvider,
-    model: trimmed.slice(slashIndex + 1).trim() || DEFAULT_MODEL,
-  };
-}
-
 function resolveAgentPrimaryModel(
   cfg: OpenClawConfig,
   agentId: string | undefined,
@@ -53,33 +41,17 @@ function resolveAgentPrimaryModel(
   return resolveAgentModelPrimaryValue(resolveAgentConfig(cfg, agentId)?.model);
 }
 
-function normalizeStoredOverrideModel(params: {
-  providerOverride?: string;
-  modelOverride?: string;
-}): { providerOverride?: string; modelOverride?: string } {
-  const providerOverride = params.providerOverride?.trim();
-  const modelOverride = params.modelOverride?.trim();
-  if (!providerOverride || !modelOverride) {
-    return { providerOverride, modelOverride };
-  }
-
-  const providerPrefix = `${providerOverride.toLowerCase()}/`;
-  // Older stores sometimes persisted both providerOverride and a
-  // provider/model modelOverride; trim the duplicate provider for display.
-  return {
-    providerOverride,
-    modelOverride: modelOverride.toLowerCase().startsWith(providerPrefix)
-      ? modelOverride.slice(providerOverride.length + 1).trim() || modelOverride
-      : modelOverride,
-  };
-}
-
 function resolveDefaultModelRef(cfg: OpenClawConfig, agentId?: string): SessionDisplayModelRef {
   const primary =
     resolveAgentPrimaryModel(cfg, agentId) ??
     resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model) ??
     DEFAULT_MODEL;
-  return parseModelRef(primary, DEFAULT_PROVIDER);
+  return (
+    parseModelRef(primary, DEFAULT_PROVIDER, {
+      allowManifestNormalization: false,
+      allowPluginNormalization: false,
+    }) ?? { provider: DEFAULT_PROVIDER, model: DEFAULT_MODEL }
+  );
 }
 
 /** Resolves default display values for a session table scoped to an agent. */
@@ -102,10 +74,13 @@ function normalizeCliRuntimeDisplayRef(
   if (!classifyCliProvider(ref.provider)) {
     return ref;
   }
-  if (ref.model.includes("/")) {
+  const parsed = parseModelRef(ref.model, defaultRef.provider, {
+    allowManifestNormalization: false,
+    allowPluginNormalization: false,
+  });
+  if (ref.model.includes("/") && parsed) {
     // CLI runtimes can store the real provider/model inside the model field;
     // prefer that embedded provider when it is not another CLI runtime alias.
-    const parsed = parseModelRef(ref.model, defaultRef.provider);
     if (!classifyCliProvider(parsed.provider)) {
       return parsed;
     }
@@ -120,13 +95,12 @@ function normalizeCliRuntimeDisplayRef(
   }
   // If the CLI runtime model cannot be mapped to a concrete provider, fall
   // back to the configured default provider so rows stay comparable.
-  const parsed = parseModelRef(ref.model, defaultRef.provider);
-  if (!classifyCliProvider(parsed.provider)) {
+  if (parsed && !classifyCliProvider(parsed.provider)) {
     return parsed;
   }
   return {
     provider: defaultRef.provider || ref.provider,
-    model: parsed.model || ref.model,
+    model: parsed?.model || ref.model,
   };
 }
 
@@ -153,21 +127,19 @@ export function resolveSessionDisplayModelRef(
     providerOverride: row.providerOverride,
     modelOverride: row.modelOverride,
   });
-
-  if (normalizedOverride.modelOverride) {
-    return parseModelRef(
-      normalizedOverride.modelOverride,
-      normalizedOverride.providerOverride ?? defaultRef.provider,
-    );
+  const persistedRef = resolvePersistedSelectedModelRef({
+    defaultProvider: defaultRef.provider,
+    runtimeProvider: row.modelProvider,
+    runtimeModel: row.model,
+    overrideProvider: normalizedOverride.providerOverride,
+    overrideModel: normalizedOverride.modelOverride,
+    allowManifestNormalization: false,
+    allowPluginNormalization: false,
+  });
+  if (!persistedRef) {
+    return defaultRef;
   }
-  if (row.model) {
-    return normalizeCliRuntimeDisplayRef(
-      cfg,
-      agentId,
-      parseModelRef(row.model, row.modelProvider ?? defaultRef.provider),
-      defaultRef,
-      classifyCliProvider,
-    );
-  }
-  return defaultRef;
+  return normalizedOverride.modelOverride
+    ? persistedRef
+    : normalizeCliRuntimeDisplayRef(cfg, agentId, persistedRef, defaultRef, classifyCliProvider);
 }

--- a/src/commands/sessions.model-resolution.test.ts
+++ b/src/commands/sessions.model-resolution.test.ts
@@ -4,8 +4,14 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { SessionEntry } from "../config/sessions/types.js";
-import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { executeSqliteQueryTakeFirstSync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
   mockSessionsConfig,
@@ -98,6 +104,14 @@ describe("sessionsCommand model resolution", () => {
   it("falls back to modelOverride when runtime model is missing", async () => {
     const model = await resolveSubagentModel({ modelOverride: "openai/gpt-5.4" }, "subagent-2");
     expect(model).toBe("gpt-5.4");
+  });
+
+  it("preserves nested override models when their provider is recorded separately", async () => {
+    const model = await resolveSubagentModel(
+      { providerOverride: "clawrouter", modelOverride: "openai/gpt-5.6" },
+      "subagent-router-override",
+    );
+    expect(model).toBe("openai/gpt-5.6");
   });
 
   it("separates Claude CLI runtime from canonical model provider in JSON output", async () => {
@@ -202,7 +216,88 @@ describe("sessionsCommand model resolution", () => {
     );
   });
 
-  it("projects current runtime and context after a same-model harness change", async () => {
+  it("preserves a router-owned session's recorded model, runtime, and context window", async () => {
+    setMockSessionsConfig(() => ({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.6" },
+          models: {
+            "clawrouter/openai/gpt-5.6": { agentRuntime: { id: "openclaw" } },
+            "openai/gpt-5.6": { agentRuntime: { id: "codex" } },
+          },
+        },
+      },
+      models: {
+        providers: {
+          clawrouter: { models: [{ id: "openai/gpt-5.6", contextTokens: 272_000 }] },
+          openai: {
+            models: [{ id: "gpt-5.6", contextTokens: 1_000_000, contextWindow: 1_050_000 }],
+          },
+        },
+      },
+    }));
+    const sessionKey = "agent:main:main";
+    const sessionEntry = {
+      sessionId: "router-owned-session",
+      updatedAt: Date.now() - 60_000,
+      modelProvider: "clawrouter",
+      model: "openai/gpt-5.6",
+      agentHarnessId: "openclaw",
+      contextTokens: 272_000,
+      contextTokensSource: "runtime",
+    } satisfies SessionEntry;
+
+    await withSqliteStore(
+      "sessions-router-owned-runtime-context",
+      { [sessionKey]: sessionEntry },
+      async (store) => {
+        const databasePath = resolveSqliteTargetFromSessionStorePath(store, {
+          agentId: "main",
+        }).path;
+        const database = openOpenClawAgentDatabase({ agentId: "main", path: databasePath });
+        const db = getNodeSqliteKysely<
+          Pick<OpenClawAgentKyselyDatabase, "session_nodes" | "session_windows">
+        >(database.db);
+        const persisted = executeSqliteQueryTakeFirstSync(
+          database.db,
+          db
+            .selectFrom("session_windows")
+            .innerJoin("session_nodes", "session_nodes.session_key", "session_windows.session_key")
+            .select([
+              "session_windows.model_provider as modelProvider",
+              "session_windows.model as model",
+              "session_windows.agent_harness_id as agentHarnessId",
+              "session_nodes.session_key as sessionKey",
+              "session_nodes.current_session_id as sessionId",
+              "session_nodes.entry_json as entryJson",
+            ])
+            .where("session_windows.session_id", "=", sessionEntry.sessionId),
+        );
+
+        expect(persisted).toEqual({
+          modelProvider: "clawrouter",
+          model: "openai/gpt-5.6",
+          agentHarnessId: "openclaw",
+          sessionKey,
+          sessionId: sessionEntry.sessionId,
+          entryJson: expect.any(String),
+        });
+        expect(JSON.parse(persisted?.entryJson ?? "{}")).toMatchObject(sessionEntry);
+
+        const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
+        const session = payload.sessions?.find((row) => row.key === sessionKey);
+
+        expect(session).toMatchObject({
+          modelProvider: "clawrouter",
+          model: "openai/gpt-5.6",
+          agentRuntime: { id: "openclaw", source: "session" },
+          contextTokens: 272_000,
+        });
+      },
+    );
+  });
+
+  it("preserves recorded runtime while projecting current context after a harness change", async () => {
     setMockSessionsConfig(() => ({
       agents: {
         defaults: {
@@ -237,7 +332,7 @@ describe("sessionsCommand model resolution", () => {
         const payload = await runSessionsJson<SessionsJsonPayload>(sessionsCommand, store);
         const session = payload.sessions?.find((row) => row.key === "agent:main:main");
 
-        expect(session?.agentRuntime).toEqual({ id: "codex", source: "model" });
+        expect(session?.agentRuntime).toEqual({ id: "openclaw", source: "session" });
         expect(session?.contextTokens).toBe(1_000_000);
       },
     );

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -148,7 +148,7 @@ describe("sessionsCommand", () => {
     );
   });
 
-  it("renders current context after a same-model runtime change", async () => {
+  it("renders recorded runtime with current context after a same-model runtime change", async () => {
     setMockSessionsConfig(() => ({
       agents: {
         defaults: {
@@ -189,9 +189,8 @@ describe("sessionsCommand", () => {
     cleanupStore(store);
 
     const row = logs.find((line) => line.includes("agent:main:main")) ?? "";
-    expect(row).toContain("OpenAI Codex");
+    expect(row).toContain("OpenClaw Default");
     expect(row).toContain("0.0k/1000k (0%)");
-    expect(row).not.toContain("272k");
   });
 
   it("shows placeholder rows when tokens are missing", async () => {

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -11,7 +11,7 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { readAcpSessionMetaBatch } from "../acp/runtime/session-meta.js";
-import { resolveCurrentSessionAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
+import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { resolveAuthoredModelContextTokens } from "../agents/context-resolution.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
 import {
@@ -59,7 +59,7 @@ import {
 type SessionRow = SessionDisplayRow & {
   agentId: string;
   kind: SessionKind;
-  agentRuntime: ReturnType<typeof resolveCurrentSessionAgentRuntimeMetadata>;
+  agentRuntime: ReturnType<typeof resolveModelAgentRuntimeMetadata>;
   runtimeLabel: string;
   /** Carry the prepared identity into JSON/table emission without re-resolving plugin metadata. */
   displayModelRef: { provider: string; model: string };
@@ -200,7 +200,7 @@ const formatKindCell = (kind: SessionRow["kind"], rich: boolean) => {
 function resolveSessionRuntimeLabel(params: {
   cfg: OpenClawConfig;
   entry: SessionEntry;
-  agentRuntime: ReturnType<typeof resolveCurrentSessionAgentRuntimeMetadata>;
+  agentRuntime: ReturnType<typeof resolveModelAgentRuntimeMetadata>;
   modelProvider: string;
   classifyCliProvider: CliProviderClassifier;
 }): string {
@@ -391,7 +391,7 @@ export async function sessionsCommand(
       acpSessionKey,
       acpRuntime,
     );
-    const agentRuntime = resolveCurrentSessionAgentRuntimeMetadata({
+    const agentRuntime = resolveModelAgentRuntimeMetadata({
       cfg,
       agentId,
       sessionEntry: entry,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw sessions --json` could rewrite a recorded router-owned provider/model pair and report the wrong producing runtime when the model identifier itself contained a slash. A session persisted as `clawrouter` + `openai/gpt-5.6` under the OpenClaw runtime was displayed as `openai` + `gpt-5.6` with Codex runtime metadata.

AI-assisted implementation; the maintainer inspected the full owner path, dependency contract, history, diff, and proof.

## Why This Change Was Made

The CLI listing now resolves persisted provider/model tuples with the canonical persisted-model helpers and reports the runtime that produced the stored session. Legacy CLI-runtime aliases are still normalized only when the recorded provider is actually a CLI provider. Gateway and status projections that intentionally predict the next turn remain unchanged, and current authored context-cap semantics are preserved.

## User Impact

Operators can trust `openclaw sessions` to reflect the model route and runtime recorded for each stored session, including router-owned nested model identifiers and explicit nested overrides. Session cleanup previews inherit the same corrected model display.

## Evidence

- Pre-fix isolated SQLite regression: persisted `clawrouter` / `openai/gpt-5.6` / `openclaw` / `272000`; CLI emitted `openai` / `gpt-5.6` / `codex` / `1000000`.
- `node scripts/run-vitest.mjs src/commands/sessions.model-resolution.test.ts src/commands/sessions.test.ts src/commands/sessions-cleanup.test.ts src/commands/sessions.acp-model-display.test.ts` — 50 tests passed.
- `pnpm test:changed` — 6 selected Vitest shards passed.
- `node scripts/check-changed.mjs -- src/commands/sessions-display-model.ts src/commands/sessions.ts src/commands/sessions.model-resolution.test.ts src/commands/sessions.test.ts` — formatting, typechecks, lint, dead exports, database-first, import-cycle, and architecture guards passed.
- Independent autoreview: no accepted or actionable findings.
- Production LOC: +34/-62 (net -28). Tests: +100/-6.
- No live Team state or user database was read or modified; all reproduction and proof used test-created temporary SQLite stores.
