### PR TITLE
fix(channels): preserve delivery after preview cleanup

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.draft-final.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-final.test.ts
@@ -147,6 +147,28 @@ describe("processDiscordMessage draft streaming final delivery", () => {
     expect(draftStream.messageId()).toBeUndefined();
   });
 
+  it("preserves a delivered final when its first stale-preview cleanup fails", async () => {
+    const draftStream = createMockDraftStream();
+    draftStream.clear.mockRejectedValueOnce(new Error("preview cleanup failed"));
+    createDiscordDraftStream.mockReturnValueOnce(draftStream);
+    const runtimeError = vi.fn();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "Hello\nWorld" });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+    const ctx = await createAutomaticDraftContext({
+      discordConfig: { streaming: { mode: "partial" }, maxLinesPerMessage: 5 },
+      runtime: { log: vi.fn(), error: runtimeError },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(2);
+    expect(runtimeError).not.toHaveBeenCalled();
+    expectFreshFinalText("Hello\nWorld");
+  });
+
   it("delivers a fresh message instead of a preview edit when the final reply resolves a mention alias", async () => {
     dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
       await params?.dispatcher.sendFinalReply({ text: "On it @Sentinel" });

--- a/extensions/mattermost/src/mattermost/monitor-draft-delivery.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-draft-delivery.test.ts
@@ -321,22 +321,13 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
     draftStream.clear.mockRejectedValueOnce(new Error("preview cleanup failed"));
     const deliverFinal = createDeliverFinalMock();
 
-    let caught: unknown;
-    try {
-      await deliverDraftPreview({
-        payload: { text: "Already visible", replyToId: "reply-1" } as never,
-        draftStream,
-        deliverPayload: deliverFinal,
-      });
-    } catch (error: unknown) {
-      caught = error;
-    }
+    const result = await deliverDraftPreview({
+      payload: { text: "Already visible", replyToId: "reply-1" } as never,
+      draftStream,
+      deliverPayload: deliverFinal,
+    });
 
-    expect(isChannelPartialDeliveryError(caught)).toBe(true);
-    if (!isChannelPartialDeliveryError(caught)) {
-      throw new Error("expected a partial Mattermost preview delivery error");
-    }
-    expect(caught.deliveryResult).toMatchObject({
+    expect(result).toMatchObject({
       messageIds: ["delivered-post-1"],
       visibleReplySent: true,
       content: "Already visible",

--- a/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
+++ b/extensions/mattermost/src/mattermost/monitor-draft-delivery.ts
@@ -244,8 +244,8 @@ export async function deliverMattermostReplyWithDraftPreview(
       ]) ?? previewDeliveryResult
     );
   } catch (error: unknown) {
-    // A provider send can complete before preview cleanup fails. Preserve every
-    // completed visible receipt so core cannot mistake that post-send failure for a safe retry.
+    // Preserve confirmed preview and supplemental receipts so core cannot
+    // mistake a later visible-delivery failure for a safe retry.
     const completedVisibleResults: MattermostReplyDeliveryResult[] = [];
     const completedReceiptResults: Array<{ receipt: MessageReceipt } | { messageId: string }> = [];
     for (const result of [

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -4713,6 +4713,23 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves normal final delivery when stale-preview cleanup fails", async () => {
+    const draftStream = createDraftStreamStub();
+    draftStream.clear.mockRejectedValueOnce(new Error("preview cleanup failed"));
+    createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+    mockedDispatchSequence = [
+      {
+        kind: "final",
+        payload: { text: "Photo", mediaUrl: "https://example.com/a.png" },
+      },
+    ];
+
+    await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps the preview and sends media-only for TTS supplement finals", async () => {
     const draftStream = createDraftStreamStub();
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
@@ -4917,8 +4934,53 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     ]);
   });
 
-  it("falls back with visible text when TTS supplement preview finalization fails", async () => {
+  it.each([false, true])(
+    "falls back with visible text when TTS supplement preview finalization fails (already delivered: %s)",
+    async (visibleTextAlreadyDelivered) => {
+      const draftStream = createDraftStreamStub();
+      createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
+      mockedReplyThreadTsSequence = [undefined];
+      const ttsSupplement = {
+        spokenText: "Spoken answer",
+        ...(visibleTextAlreadyDelivered ? { visibleTextAlreadyDelivered: true } : {}),
+      };
+      mockedDispatchSequence = [
+        {
+          kind: "final",
+          payload: {
+            mediaUrl: "https://example.com/tts.mp3",
+            audioAsVoice: true,
+            spokenText: "Spoken answer",
+            ttsSupplement,
+          },
+        },
+      ];
+
+      await dispatchPreparedSlackMessage(createPreparedSlackMessage());
+
+      expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
+      expect(draftStream.discardPending).toHaveBeenCalled();
+      expect(draftStream.clear).toHaveBeenCalledTimes(1);
+      const delivered = requireRecord(
+        requireMockCall(deliverRepliesMock, 0, "deliver replies")[0],
+        "deliver replies params",
+      );
+      expectRecordFields(delivered, { replyThreadTs: THREAD_TS });
+      expect(delivered.replies).toEqual([
+        {
+          text: "Spoken answer",
+          mediaUrl: "https://example.com/tts.mp3",
+          audioAsVoice: true,
+          spokenText: "Spoken answer",
+          ttsSupplement,
+        },
+      ]);
+    },
+  );
+
+  it("preserves TTS preview fallback delivery when its cleanup fails", async () => {
     const draftStream = createDraftStreamStub();
+    draftStream.clear.mockRejectedValueOnce(new Error("preview cleanup failed"));
     createSlackDraftStreamMock.mockReturnValueOnce(draftStream);
     mockedReplyThreadTsSequence = [undefined];
     mockedDispatchSequence = [
@@ -4935,8 +4997,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
 
     await dispatchPreparedSlackMessage(createPreparedSlackMessage());
 
-    expect(finalizeSlackPreviewEditMock).toHaveBeenCalledTimes(1);
-    expect(draftStream.discardPending).toHaveBeenCalled();
+    expect(deliverRepliesMock).toHaveBeenCalledTimes(1);
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
     const delivered = requireRecord(
       requireMockCall(deliverRepliesMock, 0, "deliver replies")[0],

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -248,83 +248,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       previewStreamingEnabled &&
       !payload.text?.trim();
 
-    if (
-      info.kind === "final" &&
-      ttsSupplement &&
-      draftStream &&
-      !hasSlackCustomIdentity &&
-      !draftPreviewCommitted.value &&
-      !delivery.observedFinalReplyDelivery &&
-      previewStreamingEnabled &&
-      !payload.isError &&
-      !requiresSeparateFallbackDelivery &&
-      previewFinalTextFitsEdit &&
-      trimmedFinalText.length > 0
-    ) {
-      await draftStream.flush();
-      const channelId = draftStream.channelId();
-      const messageId = draftStream.messageId();
-      if (channelId && messageId) {
-        const finalThreadTs = delivery.usedReplyThreadTs ?? statusThreadTs;
-        await draftStream.seal();
-        try {
-          const finalized = await draftStream.finalizeMessage(messageId, async () => {
-            await finalizeSlackPreviewEdit({
-              client: slackClient,
-              token: ctx.botToken,
-              accountId: account.accountId,
-              channelId,
-              messageId,
-              text: previewFinalText,
-              ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
-              threadTs: finalThreadTs,
-            });
-          });
-          if (!finalized) {
-            throw new Error("Slack preview moved below a newer conversation message");
-          }
-        } catch (err) {
-          logVerbose(
-            `slack: preview final edit failed; falling back to standard send (${formatSlackError(err)})`,
-          );
-          await draftStream.discardPending();
-          let delivered = false;
-          try {
-            await delivery.deliverNormally({
-              payload: payload.text?.trim()
-                ? payload
-                : {
-                    ...payload,
-                    // Keep presentation semantic here; deliverReplies adds its
-                    // accessible chart summary exactly once.
-                    text: ttsSupplement.spokenText,
-                  },
-              kind: info.kind,
-              forcedThreadTs: finalThreadTs,
-            });
-            delivered = true;
-          } finally {
-            if (delivered) {
-              await draftStream.clear();
-            }
-          }
-          return;
-        }
-        draftPreviewCommitted.value = true;
-        delivery.observedFinalReplyDelivery = true;
-        delivery.observedReplyDelivery = true;
-        replyPlan.markSent();
-        await delivery.deliverNormally({
-          payload: buildTtsSupplementMediaPayload(payload),
-          kind: info.kind,
-          forcedThreadTs: finalThreadTs,
-        });
-        delivery.markPreviewPayloadDelivered({ kind: info.kind, payload, threadTs: finalThreadTs });
-        progress.progressDraft.markFinalReplyDelivered();
-        return;
-      }
-    }
-
+    let ttsPreviewFinalization: { threadTs: string | undefined } | undefined;
     await deliverWithFinalizableLivePreviewAdapter({
       kind: info.kind,
       payload,
@@ -364,6 +288,9 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         editFinal: async (preview, edit) => {
           if (delivery.hasDelivered({ kind: info.kind, payload, threadTs: edit.threadTs })) {
             return;
+          }
+          if (ttsSupplement) {
+            ttsPreviewFinalization = { threadTs: edit.threadTs };
           }
           const finalized = await draftStream?.finalizeMessage(preview.messageId, async () => {
             await finalizeSlackPreviewEdit({
@@ -434,13 +361,18 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       }),
       deliverNormally: async () => {
         await delivery.deliverNormally({
-          payload: shouldRestoreTtsSupplementTextForPreviewFallback
-            ? {
-                ...payload,
-                text: ttsSupplement?.spokenText,
-              }
-            : payload,
+          payload:
+            shouldRestoreTtsSupplementTextForPreviewFallback ||
+            (ttsPreviewFinalization && !payload.text?.trim())
+              ? {
+                  ...payload,
+                  text: ttsSupplement?.spokenText,
+                }
+              : payload,
           kind: info.kind,
+          ...(ttsPreviewFinalization?.threadTs
+            ? { forcedThreadTs: ttsPreviewFinalization.threadTs }
+            : {}),
         });
       },
     });

--- a/src/channels/message/lifecycle.test.ts
+++ b/src/channels/message/lifecycle.test.ts
@@ -226,6 +226,157 @@ describe("message lifecycle primitives", () => {
     expect(liveState.canFinalizeInPlace).toBe(false);
   });
 
+  it.each(["shared finalizer", "exported adapter"] as const)(
+    "preserves committed normal delivery when preview cleanup fails through the %s",
+    async (entrypoint) => {
+      const events: string[] = [];
+      const cleanupError = new Error("recipient text and fake-secret must stay private");
+      const draft = {
+        flush: vi.fn(async () => undefined),
+        id: () => "preview-cleanup-failure",
+        discardPending: vi.fn(async () => {
+          events.push("discard");
+        }),
+        clear: vi.fn(async () => {
+          events.push("clear");
+          throw cleanupError;
+        }),
+      };
+      const deliverNormally = vi.fn(async () => {
+        events.push("deliver");
+        return true;
+      });
+      const onNormalDelivered = vi.fn(async () => {
+        events.push("commit");
+      });
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      try {
+        const result =
+          entrypoint === "shared finalizer"
+            ? await deliverFinalizableLivePreview({
+                kind: "final",
+                payload: { text: "already delivered" },
+                draft,
+                buildFinalEdit: () => undefined,
+                editFinal: vi.fn(async () => undefined),
+                deliverNormally,
+                onNormalDelivered,
+              })
+            : await deliverWithFinalizableLivePreviewAdapter({
+                kind: "final",
+                payload: { text: "already delivered" },
+                adapter: defineFinalizableLivePreviewAdapter({
+                  draft,
+                  buildFinalEdit: () => undefined,
+                  editFinal: vi.fn(async () => undefined),
+                }),
+                deliverNormally,
+                onNormalDelivered,
+              });
+
+        expect(result.kind).toBe("normal-delivered");
+        expect(events).toEqual(["discard", "deliver", "commit", "clear"]);
+        expect(deliverNormally).toHaveBeenCalledTimes(1);
+        expect(onNormalDelivered).toHaveBeenCalledTimes(1);
+        expect(warn).toHaveBeenCalledExactlyOnceWith(
+          "Live preview cleanup failed after delivery; a stale preview may remain",
+        );
+      } finally {
+        warn.mockRestore();
+      }
+    },
+  );
+
+  it("keeps intentionally suppressed fallback delivery skipped without post-delivery cleanup", async () => {
+    const clear = vi.fn(async () => {
+      throw new Error("suppressed reply must not be cleaned up as delivered");
+    });
+    const onNormalDelivered = vi.fn(async () => undefined);
+
+    const result = await deliverFinalizableLivePreview({
+      kind: "final",
+      payload: { text: "suppressed" },
+      draft: {
+        flush: vi.fn(async () => undefined),
+        id: () => "suppressed-preview",
+        discardPending: vi.fn(async () => undefined),
+        clear,
+      },
+      buildFinalEdit: () => undefined,
+      editFinal: vi.fn(async () => undefined),
+      deliverNormally: vi.fn(async () => false),
+      onNormalDelivered,
+    });
+
+    expect(result.kind).toBe("normal-skipped");
+    expect(onNormalDelivered).not.toHaveBeenCalled();
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it("keeps preview cleanup failures fatal before normal delivery starts", async () => {
+    const deliverNormally = vi.fn(async () => true);
+    const onNormalDelivered = vi.fn(async () => undefined);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await expect(
+        deliverFinalizableLivePreview({
+          kind: "final",
+          payload: { text: "not delivered" },
+          draft: {
+            flush: vi.fn(async () => undefined),
+            id: () => "pre-delivery-preview",
+            clear: vi.fn(async () => {
+              throw new Error("pre-delivery cleanup failed");
+            }),
+          },
+          buildFinalEdit: () => undefined,
+          editFinal: vi.fn(async () => undefined),
+          deliverNormally,
+          onNormalDelivered,
+        }),
+      ).rejects.toThrow("pre-delivery cleanup failed");
+
+      expect(deliverNormally).not.toHaveBeenCalled();
+      expect(onNormalDelivered).not.toHaveBeenCalled();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("preserves a delivery-commit failure when later preview cleanup also fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await expect(
+        deliverFinalizableLivePreview({
+          kind: "final",
+          payload: { text: "already accepted" },
+          draft: {
+            flush: vi.fn(async () => undefined),
+            id: () => "commit-failure-preview",
+            discardPending: vi.fn(async () => undefined),
+            clear: vi.fn(async () => {
+              throw new Error("preview cleanup must not replace delivery failure");
+            }),
+          },
+          buildFinalEdit: () => undefined,
+          editFinal: vi.fn(async () => undefined),
+          deliverNormally: vi.fn(async () => true),
+          onNormalDelivered: vi.fn(async () => {
+            throw new Error("delivery commit failed");
+          }),
+        }),
+      ).rejects.toThrow("delivery commit failed");
+
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("does not complete live preview fallback state when normal delivery throws", async () => {
     const discardPending = vi.fn(async () => undefined);
     const clear = vi.fn(async () => undefined);

--- a/src/channels/message/live.ts
+++ b/src/channels/message/live.ts
@@ -3,6 +3,7 @@
  *
  * Tracks draft previews and converts them into finalized message receipts when possible.
  */
+import { runBestEffortCleanup } from "../../infra/non-fatal-cleanup.js";
 import type { LiveMessageState, MessageReceipt, RenderedMessageBatch } from "./types.js";
 
 /** Mutable draft preview handle used before a live message is finalized or discarded. */
@@ -228,7 +229,12 @@ export async function deliverFinalizableLivePreview<TPayload, TId, TEdit>(params
     }
   } finally {
     if (delivered) {
-      await params.draft.clear();
+      const draft = params.draft;
+      await runBestEffortCleanup({
+        cleanup: () => draft.clear(),
+        onError: () =>
+          console.warn("Live preview cleanup failed after delivery; a stale preview may remain"),
+      });
     }
   }
 


### PR DESCRIPTION
Closes #126913

## What Problem This Solves

Fixes an issue where Discord, Slack, or Mattermost users could receive a final reply successfully but still have OpenClaw report that reply as failed when deleting its temporary streaming preview failed immediately afterward. Misclassifying an already-delivered reply could trigger a duplicate send or a misleading channel error.

## Why This Change Was Made

Preview cleanup after an accepted final send now uses the existing best-effort cleanup owner, preserving delivery/commit ordering and emitting one bounded warning without message content. Slack's duplicate TTS-preview finalization path is removed in favor of the existing shared adapter while preserving its shipped thread routing, spoken-text restoration, media-only supplemental sends, chart behavior, and duplicate suppression. Mattermost retains its real partial/supplemental-delivery receipt custody.

## User Impact

An accepted final reply remains delivered even when its temporary preview cannot be removed; the final reply is never resent because cleanup failed. Suppressed replies remain suppressed, and failures before delivery, failed delivery commits, preview edits, and genuinely partial or supplemental sends retain their existing behavior.

## Evidence

Before the fix, targeted fault-injection tests failed at the shared finalizer, its exported adapter, Discord's real dispatch boundary, both Slack final-delivery paths, and Mattermost's delivery boundary. The ordered reproduction is `discard preview -> recipient accepts final -> delivery commits -> preview clear rejects`.

After the fix, 234 tests passed across the four affected routed Vitest shards:

```
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-autoqa-173-vitest-cache OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs --configLoader runner src/channels/message/lifecycle.test.ts extensions/discord/src/monitor/message-handler.process.draft-final.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/mattermost/src/mattermost/monitor-draft-delivery.test.ts
```

Coverage includes 22 shared lifecycle/adapter cases, 40 Discord dispatch cases, 153 Slack dispatch/TTS cases, and 19 Mattermost receipt-custody cases. The Slack TTS suite additionally preserves the shipped fallback behavior for both values of `visibleTextAlreadyDelivered`. Static checks include targeted formatting, `git diff --check`, the changed-file gate across core/core-tests/plugins/plugin-tests, a clean fresh P1 Codex autoreview, and a separate clean adversarial owner-boundary review.

Production code is net-negative: 62 lines removed by deleting Slack's duplicate finalization path. No public API, plugin SDK signature, config, persistence, protocol, security, product-surface, or changelog changes.

Authenticated live-channel fault injection was not run: safely forcing a preview-delete failure after a real recipient accepts a reply would risk posting duplicates to a live channel. Deterministic real Discord, Slack, and Mattermost dispatch-boundary tests instead inject the failure at the exact post-commit operation and verify one visible send.
