### PR TITLE
fix: speech-only supplements silently complete agent replies

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1677,7 +1677,7 @@ src/agents/agent-bundle-mcp-manager-lifecycle.ts	1
 src/agents/agent-bundle-mcp-materialize.ts	3
 src/agents/agent-bundle-mcp-runtime-shared.ts	2
 src/agents/agent-bundle-mcp-runtime.ts	9
-src/agents/agent-command-restart-recovery.ts	4
+src/agents/agent-command-restart-recovery.ts	3
 src/agents/agent-command.ts	1
 src/agents/agent-hooks/compaction-safeguard.ts	19
 src/agents/agent-model-discovery.ts	5
@@ -2061,7 +2061,6 @@ src/agents/subagents/announce/subagent-announce-completion-delivery.ts	2
 src/agents/subagents/announce/subagent-announce-delivery-retry.ts	2
 src/agents/subagents/announce/subagent-announce-delivery.runtime.ts	2
 src/agents/subagents/announce/subagent-announce-delivery.ts	1
-src/agents/subagents/announce/subagent-announce-direct-delivery.ts	1
 src/agents/subagents/announce/subagent-announce-origin.ts	2
 src/agents/subagents/announce/subagent-announce-output.ts	10
 src/agents/subagents/completion/subagent-completion-admission.store.ts	2

--- a/src/agents/agent-command-restart-recovery.ts
+++ b/src/agents/agent-command-restart-recovery.ts
@@ -7,6 +7,7 @@ import {
   collectDeliveredMediaUrls,
   collectMessagingToolDeliveredMediaUrls,
   hasCommittedOutboundDeliveryEvidence,
+  hasExplicitlyVisibleAgentPayload,
   hasUnaccountedMessagingToolAggregateEvidence,
   hasVisibleAgentPayload,
   hasVisibleCommittedMessagingToolDeliveryEvidence,
@@ -80,20 +81,15 @@ export function constrainRestartRecoveryDeliveryPayloads(
   }
 
   if (!suppressText) {
-    const visibleReplyIndex = constrained.findIndex(
-      (payload) =>
-        payload.isCommentary !== true &&
-        payload.isCompactionNotice !== true &&
-        payload.isFallbackNotice !== true &&
-        payload.isStatusNotice !== true &&
-        hasVisibleAgentPayload(
-          { payloads: [payload] },
-          {
-            includeErrorPayloads: false,
-            includeReasoningPayloads: false,
-            includeSilentReplyPayloads: false,
-          },
-        ),
+    const visibleReplyIndex = constrained.findIndex((payload) =>
+      hasVisibleAgentPayload(
+        { payloads: [payload] },
+        {
+          includeErrorPayloads: false,
+          includeSilentReplyPayloads: false,
+          requireTerminalContent: true,
+        },
+      ),
     );
     if (visibleReplyIndex >= 0) {
       const visibleReply = constrained[visibleReplyIndex];
@@ -120,19 +116,6 @@ export function constrainRestartRecoveryDeliveryPayloads(
   return constrained;
 }
 
-function hasExplicitlyVisiblePayload(payload: unknown): boolean {
-  if (payload && typeof payload === "object" && !Array.isArray(payload)) {
-    const visible = (payload as { visible?: unknown }).visible;
-    if (typeof visible === "boolean") {
-      return visible;
-    }
-  }
-  return hasVisibleAgentPayload(
-    { payloads: [payload] },
-    { includeErrorPayloads: false, includeReasoningPayloads: false },
-  );
-}
-
 /** Reduce a terminal result to bounded, route-checkable delivery evidence. */
 export function buildRestartRecoveryTerminalDeliveryEvidence(
   result: AgentDeliveryEvidence,
@@ -143,7 +126,7 @@ export function buildRestartRecoveryTerminalDeliveryEvidence(
   )
     ? rawPayloads.slice(0, 64).map((payload) => {
         const mediaUrls = collectDeliveredMediaUrls({ payloads: [payload] });
-        const visible = hasExplicitlyVisiblePayload(payload);
+        const visible = hasExplicitlyVisibleAgentPayload(payload);
         const evidence: { mediaUrls?: string[]; visible?: boolean } = { visible };
         if (mediaUrls.length > 0) {
           evidence.mediaUrls = mediaUrls;

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -5,7 +5,7 @@ import { normalizeMediaReferenceForComparison } from "../../media/media-referenc
  * Extracts visible delivery evidence from embedded-agent run results.
  */
 import { collectMediaUrlsFromRecord, hasVisibleAgentPayload } from "./message-visibility.js";
-export { hasVisibleAgentPayload } from "./message-visibility.js";
+export { hasExplicitlyVisibleAgentPayload, hasVisibleAgentPayload } from "./message-visibility.js";
 
 /**
  * Helpers for deciding whether an embedded run produced user-visible or outbound effects.

--- a/src/agents/embedded-agent-runner/message-visibility.ts
+++ b/src/agents/embedded-agent-runner/message-visibility.ts
@@ -1,5 +1,9 @@
 import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import {
+  isReplyPayloadTerminalContent,
+  type ReplyPayload,
+} from "../../auto-reply/reply-payload.js";
+import {
   isSilentReplyPayloadText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
@@ -23,6 +27,7 @@ type PayloadVisibilityOptions = {
   includeErrorPayloads?: boolean;
   includeReasoningPayloads?: boolean;
   includeSilentReplyPayloads?: boolean;
+  requireTerminalContent?: boolean;
 };
 
 function hasNonEmptyStringArray(value: unknown): boolean {
@@ -106,7 +111,13 @@ export function hasVisibleAgentPayload(
       if (!payload || typeof payload !== "object") {
         return false;
       }
-      const record = payload as AgentPayloadLike;
+      const record = payload as AgentPayloadLike & ReplyPayload;
+      if (
+        options.requireTerminalContent &&
+        (record.visible === false || !isReplyPayloadTerminalContent(record))
+      ) {
+        return false;
+      }
       if (options.includeErrorPayloads === false && record.isError === true) {
         return false;
       }
@@ -128,6 +139,19 @@ export function hasVisibleAgentPayload(
         record.channelData,
       );
     })
+  );
+}
+
+/** Honors recorded visibility before deriving it from the payload's visible content. */
+export function hasExplicitlyVisibleAgentPayload(payload: unknown): boolean {
+  if (payload && typeof payload === "object" && !Array.isArray(payload) && "visible" in payload) {
+    if (typeof payload.visible === "boolean") {
+      return payload.visible;
+    }
+  }
+  return hasVisibleAgentPayload(
+    { payloads: [payload] },
+    { includeErrorPayloads: false, includeReasoningPayloads: false },
   );
 }
 

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4057,6 +4057,18 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expected: missingRequesterFinal,
     },
     {
+      name: "preserves a visible answer with malformed supplemental media metadata",
+      response: {
+        result: {
+          payloads: [
+            { text: "The real answer.", mediaUrl: 1, ttsSupplement: { spokenText: "answer" } },
+          ],
+        },
+      },
+      requireVisibleReply: true,
+      expected: deliveredRequesterFinal,
+    },
+    {
       name: "rejects an explicitly hidden assistant payload",
       response: { result: { payloads: [{ text: "not user visible", visible: false }] } },
       requireVisibleReply: true,

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4042,6 +4042,21 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expected: missingRequesterFinal,
     },
     {
+      name: "rejects supplemental TTS audio instead of a final answer",
+      response: {
+        result: {
+          payloads: [
+            {
+              mediaUrl: "file:///tmp/answer.mp3",
+              ttsSupplement: { spokenText: "answer", visibleTextAlreadyDelivered: true },
+            },
+          ],
+        },
+      },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
       name: "rejects an explicitly hidden assistant payload",
       response: { result: { payloads: [{ text: "not user visible", visible: false }] } },
       requireVisibleReply: true,

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -446,6 +446,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       hasVisibleAgentPayload(directAnnounceResult, {
         ...completionPayloadVisibility,
         includeSilentReplyPayloads: false,
+        requireTerminalContent: true,
       }),
     );
     const hasIntentionalSilentCompletionReply = Boolean(
@@ -525,37 +526,13 @@ export async function sendSubagentAnnounceDirectly(params: {
         requireFinalReply: true,
       }) ||
         (shouldDeliverAgentFinal &&
-          !requiresMessageToolDelivery &&
-          hasVisibleAgentPayload(
-            {
-              payloads: Array.isArray(directAnnounceResult.payloads)
-                ? directAnnounceResult.payloads.filter((payload) => {
-                    const flags = payload as Record<string, unknown>;
-                    return (
-                      flags?.isCommentary !== true &&
-                      flags?.isCompactionNotice !== true &&
-                      flags?.isFallbackNotice !== true &&
-                      flags?.isStatusNotice !== true &&
-                      flags?.visible !== false
-                    );
-                  })
-                : [],
-            },
-            { ...completionPayloadVisibility, includeSilentReplyPayloads: false },
-          ) &&
+          hasVisibleNonSilentGatewayPayload &&
           directAnnounceResult.deliveryStatus?.status !== "suppressed")),
     );
     const hasVisibleCompletionReply =
       requesterVisibleFinalDelivered ||
       (!params.requireVisibleReply &&
-        Boolean(
-          directAnnounceResult &&
-          (hasMessagingToolDelivery ||
-            hasVisibleAgentPayload(directAnnounceResult, {
-              ...completionPayloadVisibility,
-              includeSilentReplyPayloads: false,
-            })),
-        ));
+        (hasMessagingToolDelivery || hasVisibleNonSilentGatewayPayload));
     const acceptsIntentionalSilentCompletion =
       hasIntentionalSilentCompletionReply && !isSubagentCompletion;
     if (

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -168,7 +168,10 @@ export function appendReplyMediaFailureWarning(text: string | undefined): string
 }
 
 function hasReplyPayloadMedia(payload: Pick<ReplyPayload, "mediaUrl" | "mediaUrls">): boolean {
-  return Boolean(payload.mediaUrl?.trim() || payload.mediaUrls?.some((url) => url.trim()));
+  return Boolean(
+    readNonBlankString(payload.mediaUrl) ||
+    (Array.isArray(payload.mediaUrls) && payload.mediaUrls.some(readNonBlankString)),
+  );
 }
 
 /** Returns normalized TTS supplement metadata only when the payload has media to carry it. */

--- a/src/gateway/server-restart-sentinel-agent-delivery.ts
+++ b/src/gateway/server-restart-sentinel-agent-delivery.ts
@@ -1,4 +1,3 @@
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   collectAmbiguousAutomaticMediaUrls,
   collectAutomaticDeliveredMediaUrls,
@@ -7,7 +6,7 @@ import {
   getGatewayAgentResult,
   hasCommittedOutboundDeliveryEvidence,
   hasCompleteAutomaticMediaDeliveryOutcomeEvidence,
-  hasVisibleAgentPayload,
+  hasExplicitlyVisibleAgentPayload,
   type AgentDeliveryEvidence,
 } from "../agents/embedded-agent-runner/delivery-evidence.js";
 import { formatGeneratedMediaDeliveryRetryForPrompt } from "../agents/internal-events.js";
@@ -71,24 +70,8 @@ async function deadLetterSessionDelivery(
   throw new SessionDeliveryDeadLetteredError(reason);
 }
 
-function hasQueuedVisiblePayload(payload: unknown): boolean {
-  if (isRecord(payload)) {
-    const visible = payload.visible;
-    if (typeof visible === "boolean") {
-      return visible;
-    }
-  }
-  return hasVisibleAgentPayload(
-    { payloads: [payload] },
-    {
-      includeErrorPayloads: false,
-      includeReasoningPayloads: false,
-    },
-  );
-}
-
 function hasQueuedVisibleAgentPayload(result: Pick<AgentDeliveryEvidence, "payloads">): boolean {
-  return Array.isArray(result.payloads) && result.payloads.some(hasQueuedVisiblePayload);
+  return Array.isArray(result.payloads) && result.payloads.some(hasExplicitlyVisibleAgentPayload);
 }
 
 function hasUnexpectedRecoverySideEffects(result: AgentDeliveryEvidence): boolean {
@@ -110,7 +93,7 @@ function collectVisiblePayloadMediaUrls(result: AgentDeliveryEvidence): string[]
   const urls = new Set<string>();
   const payloads = Array.isArray(result.payloads) ? result.payloads : [];
   for (const payload of payloads) {
-    if (!hasQueuedVisiblePayload(payload)) {
+    if (!hasExplicitlyVisibleAgentPayload(payload)) {
       continue;
     }
     for (const url of collectDeliveredMediaUrls({ payloads: [payload] })) {
@@ -152,7 +135,7 @@ function hasAutomaticVisibleSendEvidence(result: AgentDeliveryEvidence): boolean
     }
     const index =
       typeof record.index === "number" && Number.isInteger(record.index) ? record.index : undefined;
-    return index !== undefined && hasQueuedVisiblePayload(payloads[index]);
+    return index !== undefined && hasExplicitlyVisibleAgentPayload(payloads[index]);
   });
 }
 

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -11,8 +11,6 @@ import { markDiagnosticActivity as markActivity } from "./diagnostic-runtime.js"
 import type { SessionAttentionClassification } from "./diagnostic-session-attention.js";
 import {
   recoveryOutcomeClearsQueuedSessionState,
-  recoveryOutcomeMutatesSessionState,
-  recoveryOutcomeReleasedCount,
   resolveStuckSessionRecoveryRef,
   type StuckSessionRecoveryOutcome,
   type StuckSessionRecoveryRequest,
@@ -70,7 +68,7 @@ function emitSessionRecoveryCompleted(params: {
     status: params.outcome.status,
     action: params.outcome.action,
     outcomeReason: "reason" in params.outcome ? params.outcome.reason : undefined,
-    released: recoveryOutcomeReleasedCount(params.outcome) || undefined,
+    released: "released" in params.outcome ? params.outcome.released || undefined : undefined,
     stale: params.stale,
   });
 }
@@ -100,7 +98,7 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   if (!params.outcome) {
     return;
   }
-  if (!recoveryOutcomeMutatesSessionState(params.outcome)) {
+  if (params.outcome.status !== "aborted" && params.outcome.status !== "released") {
     emitSessionRecoveryCompleted({ request: params.request, outcome: params.outcome });
     return;
   }

--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -83,15 +83,6 @@ export type StuckSessionRecoveryOutcome =
       error: string;
     });
 
-export function recoveryOutcomeMutatesSessionState(
-  outcome: StuckSessionRecoveryOutcome | undefined,
-): boolean {
-  if (!outcome) {
-    return false;
-  }
-  return outcome.status === "aborted" || outcome.status === "released";
-}
-
 export function recoveryOutcomeClearsQueuedSessionState(
   outcome: StuckSessionRecoveryOutcome,
 ): boolean {
@@ -99,10 +90,6 @@ export function recoveryOutcomeClearsQueuedSessionState(
     outcome.status === "released" ||
     (outcome.status === "aborted" && outcome.released > 0 && (outcome.queuedCount ?? 0) === 0)
   );
-}
-
-export function recoveryOutcomeReleasedCount(outcome: StuckSessionRecoveryOutcome): number {
-  return "released" in outcome ? outcome.released : 0;
 }
 
 export function formatRecoveryOutcome(outcome: StuckSessionRecoveryOutcome): string {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -110,6 +110,11 @@ function formatRecoveryContext(
   return fields.join(" ");
 }
 
+function reportRecoveryOutcome(outcome: StuckSessionRecoveryOutcome): StuckSessionRecoveryOutcome {
+  diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
+  return outcome;
+}
+
 export async function recoverStuckDiagnosticSession(
   params: StuckSessionRecoveryParams,
 ): Promise<StuckSessionRecoveryOutcome> {
@@ -179,16 +184,14 @@ export async function recoverStuckDiagnosticSession(
     if (activeReplyPhase === "waiting_for_global_lane") {
       // A global-lane queue owner is healthy pending work. Reclaiming it here
       // reintroduces the silent reply drop that the wait phase prevents.
-      const outcome: StuckSessionRecoveryOutcome = {
+      return reportRecoveryOutcome({
         status: "skipped",
         action: "keep_lane",
         reason: "global_lane_wait",
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
         activeSessionId: activeWorkSessionId,
-      };
-      diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-      return outcome;
+      });
     }
 
     if (activeSessionId) {
@@ -214,8 +217,7 @@ export async function recoverStuckDiagnosticSession(
         diag.warn(
           `stuck session recovery skipped: ${formatRecoveryContext(params, { activeSessionId })}`,
         );
-        diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-        return outcome;
+        return reportRecoveryOutcome(outcome);
       }
       if (reclaimStaleActiveRun) {
         diag.warn(
@@ -238,16 +240,14 @@ export async function recoverStuckDiagnosticSession(
 
     if (!activeSessionId && activeWorkSessionId && isEmbeddedAgentRunActive(activeWorkSessionId)) {
       if (activeReplyPhase === "waiting_for_deferred_maintenance") {
-        const outcome: StuckSessionRecoveryOutcome = {
+        return reportRecoveryOutcome({
           status: "skipped",
           action: "keep_lane",
           reason: "deferred_maintenance_wait",
           sessionId: params.sessionId,
           sessionKey: params.sessionKey,
           activeSessionId: activeWorkSessionId,
-        };
-        diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-        return outcome;
+        });
       }
       const reclaimStaleReplyWork =
         params.allowActiveAbort !== true &&
@@ -291,7 +291,7 @@ export async function recoverStuckDiagnosticSession(
         forceCleared = result.forceCleared;
         activeSessionId = activeWorkSessionId;
       } else {
-        const outcome: StuckSessionRecoveryOutcome = {
+        return reportRecoveryOutcome({
           status: "skipped",
           action: "keep_lane",
           reason: "active_reply_work",
@@ -299,9 +299,7 @@ export async function recoverStuckDiagnosticSession(
           sessionKey: params.sessionKey,
           activeSessionId: activeWorkSessionId,
           activeWorkKind: "embedded_run",
-        };
-        diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-        return outcome;
+        });
       }
     }
 
@@ -315,7 +313,7 @@ export async function recoverStuckDiagnosticSession(
         // after the ownerless-lane window and only if no fresh task appeared.
         if (!laneStartedFreshTask && params.ageMs >= staleActiveLaneTaskReleaseMs) {
           const released = resetCommandLane(sessionLane);
-          const outcome: StuckSessionRecoveryOutcome = {
+          return reportRecoveryOutcome({
             status: "released",
             action: "release_lane",
             reason: "stale_lane_task",
@@ -324,11 +322,9 @@ export async function recoverStuckDiagnosticSession(
             lane: sessionLane,
             released,
             queuedCount: laneSnapshot.queuedCount,
-          };
-          diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-          return outcome;
+          });
         }
-        const outcome: StuckSessionRecoveryOutcome = {
+        return reportRecoveryOutcome({
           status: "skipped",
           action: "keep_lane",
           reason: "active_lane_task",
@@ -337,9 +333,7 @@ export async function recoverStuckDiagnosticSession(
           lane: sessionLane,
           activeCount: laneSnapshot.activeCount,
           queuedCount: laneSnapshot.queuedCount,
-        };
-        diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-        return outcome;
+        });
       }
     }
 
@@ -373,7 +367,7 @@ export async function recoverStuckDiagnosticSession(
           stoppedFields ? ` ${stoppedFields}` : ""
         }`,
       );
-      const outcome: StuckSessionRecoveryOutcome =
+      return reportRecoveryOutcome(
         aborted || forceCleared
           ? {
               status: "aborted",
@@ -397,13 +391,12 @@ export async function recoverStuckDiagnosticSession(
               released,
               lane: sessionLane ?? undefined,
               ...(clearStaleSession ? { reason: "no_active_work" as const } : {}),
-            };
-      diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-      return outcome;
+            },
+      );
     }
     // An active run that neither aborted nor released still owns its work. Reporting
     // recovery here would clear the session's diagnostic state out from under it.
-    const outcome: StuckSessionRecoveryOutcome = {
+    return reportRecoveryOutcome({
       status: "skipped",
       action: "observe_only",
       reason: "active_embedded_run",
@@ -411,9 +404,7 @@ export async function recoverStuckDiagnosticSession(
       sessionKey: params.sessionKey,
       activeSessionId,
       activeWorkKind: "embedded_run",
-    };
-    diag.warn(`stuck session recovery outcome: ${formatRecoveryOutcome(outcome)}`);
-    return outcome;
+    });
   } catch (err) {
     const outcome: StuckSessionRecoveryOutcome = {
       status: "failed",


### PR DESCRIPTION
Related: #126751, #123285, #126507

## What Problem This Solves

Resolves a problem where a delegated agent turn could mistake supplemental text-to-speech audio for its actual final answer, making a reply appear complete even though no visible final answer was delivered. Restart recovery and stuck-session diagnostics also maintained parallel definitions of visibility and recovery outcomes.

## Why This Change Was Made

Use the existing canonical terminal-reply classifier at the shared agent-payload visibility owner, reuse one explicit-visibility decision across agent restart and Gateway recovery, and let the diagnostic recovery coordinator own its state transitions while watchdog outcomes share one reporting path. Message-tool-only routing, source-confirmed final receipts, suppressed replies, recovery ordering, and durable lifecycle ownership remain unchanged.

## User Impact

Delegated replies no longer silently finish with speech-only supplemental audio instead of a real final answer. Existing visible replies, message-tool delivery, Gateway restart recovery, and operator-facing stuck-session diagnostics keep their established behavior with fewer parallel code paths.

## Evidence

- Before the fix, the new supplemental-audio regression failed while the other 178 completion-delivery cases passed: the owner incorrectly returned `delivered: true` instead of `visible_reply_missing`. Independent review also exposed a real malformed-media failure; its new full-flow regression failed while the other 179 cases passed before the canonical media owner was hardened.
- After the fix: 225 focused reply, restart-recovery, delivery-evidence, and reply-classification checks passed; 43 supplemental-speech and channel follow-up checks passed; 150 Gateway restart checks passed; 122 diagnostic recovery checks passed; and the real requester-lifecycle boundary completed without replaying an already-delivered requester final.
- Production type checking, focused type-aware lint, formatting, import-cycle validation, maximum-file-length ratchet, and assertion-safety validation are covered before landing.
- Net production reduction: 54 lines across nine production files; two focused existing-table regressions add 27 test lines. The unsafe-assertion ratchet tightens by one line; there are no config-contract, protocol, migration, SQLite schema, or provider-catalog changes.
