### PR TITLE
test: remove core test scaffolding

### DIFF
--- a/packages/acp-core/src/runtime/types.test.ts
+++ b/packages/acp-core/src/runtime/types.test.ts
@@ -1,14 +1,13 @@
-import { expect, expectTypeOf, it } from "vitest";
+import { expectTypeOf, it } from "vitest";
 import type { AcpElicitationRequest, AcpElicitationResponse } from "./types.js";
 
 it("keeps elicitation requests extensible and response actions closed", () => {
-  const customRequest = {
+  void ({
     mode: "vendor/future",
     message: "Choose a value",
     requestId: 7,
     vendorData: { bounded: true },
-  } satisfies AcpElicitationRequest;
+  } satisfies AcpElicitationRequest);
 
-  expect(customRequest.mode).toBe("vendor/future");
   expectTypeOf<AcpElicitationResponse["action"]>().toEqualTypeOf<"accept" | "decline" | "cancel">();
 });

--- a/packages/gateway-protocol/src/schema/sessions-delete.test.ts
+++ b/packages/gateway-protocol/src/schema/sessions-delete.test.ts
@@ -1,25 +1,14 @@
 import { Value } from "typebox/value";
 import { describe, expect, it } from "vitest";
-import { SessionsDeleteResultSchema, WORKTREE_PRESERVATION_REASONS } from "./sessions-delete.js";
+import { SessionsDeleteResultSchema } from "./sessions-delete.js";
 
 describe("SessionsDeleteResultSchema", () => {
-  it("bounds preserved worktree cleanup reasons", () => {
+  it("rejects unknown and missing worktree preservation reasons", () => {
     const preserved = {
       id: "wt-1",
       branch: "openclaw/task-one",
       path: "/worktree/task-one",
     };
-    for (const reason of WORKTREE_PRESERVATION_REASONS) {
-      expect(
-        Value.Check(SessionsDeleteResultSchema, {
-          ok: true,
-          key: "agent:main:dashboard:task-one",
-          deleted: true,
-          archived: [],
-          worktreePreserved: { ...preserved, reason },
-        }),
-      ).toBe(true);
-    }
     expect(
       Value.Check(SessionsDeleteResultSchema, {
         ok: true,

--- a/scripts/lib/worker-deploy-build-plugin.mts
+++ b/scripts/lib/worker-deploy-build-plugin.mts
@@ -56,13 +56,6 @@ export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
         return WORKER_BROWSER_RUNTIME_COMPOSITION;
       }
       if (resolvedId === undiciDispatcherOptionsPath) {
-        if (
-          code.includes(WORKER_UNDICI_IMPORT) &&
-          code.includes("return bundledUndici;") &&
-          UNDICI_REQUIRE_BOOTSTRAP.every((fragment) => !code.includes(fragment))
-        ) {
-          return code;
-        }
         if (UNDICI_REQUIRE_BOOTSTRAP.some((fragment) => !code.includes(fragment))) {
           this.error("undici dispatcher bootstrap changed; update the worker deploy transform");
         }

--- a/src/agents/tools/github-identity-status-tool.test.ts
+++ b/src/agents/tools/github-identity-status-tool.test.ts
@@ -4,7 +4,7 @@ import { createGitHubIdentityStatusTool } from "./github-identity-status-tool.js
 import type { InProcessGatewayCaller } from "./in-process-gateway.js";
 
 describe("github_identity_status tool", () => {
-  it("returns bounded secret-free status and an operator next action", async () => {
+  it("returns status and an operator next action", async () => {
     const callGatewayMock = vi.fn(async () => ({
       agentId: "main",
       selectedScope: "agent" as const,
@@ -36,6 +36,5 @@ describe("github_identity_status tool", () => {
       selectedScope: "agent",
     });
     expect(JSON.stringify(result)).toContain("Ask the operator");
-    expect(JSON.stringify(result)).not.toMatch(/accessToken|refreshToken|deviceCode/u);
   });
 });

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -48,7 +48,6 @@ describe("worker deploy build plugin", () => {
     expect(transformed).not.toContain('import { createRequire } from "node:module";');
     expect(transformed).not.toContain("const requireUndici = createRequire(import.meta.url);");
     expect(transformed).not.toContain('requireUndici("undici")');
-    expect(plugin.transform.call({ error: fail }, transformed!, dispatcherPath)).toBe(transformed);
   });
 
   it("fails closed when the undici dispatcher bootstrap shape changes", () => {


### PR DESCRIPTION
## What Problem This Solves

Core and tooling tests were preserving a build-plugin re-entry branch that production never uses, validating a schema from the same enum that generated it, and making runtime assertions about literals or mock data that could not catch the claimed regression. The result was extra production structure and maintenance without a distinct behavior contract.

## Why This Change Was Made

This removes the self-fed worker-build transform assertion and its production-only idempotence branch, while retaining first-pass transformation, fail-closed source-drift checks, build output, and final-artifact import validation. It also keeps the hand-written protocol rejection fixtures, closed GitHub status schema, and ACP compile-time request/response contracts while dropping their vacuous runtime mirrors.

The installed Rolldown contract defines the transform hook as sequential, and the worker deploy plugin has one production registration, so the same plugin is not fed its transformed output in the real build path.

## User Impact

No user-visible behavior changes. The build remains fail-closed against upstream source drift, with less production code and tests focused on independently meaningful boundaries.

AI-assisted: yes.

## Evidence

- Focused 9-file run — 87 tests passed across 5 Vitest shards.
- `pnpm build` — passed; worker and Control UI artifacts built successfully.
- `node --import tsx scripts/check-cli-bootstrap-imports.mts` — passed against the built output.
- `pnpm test:changed` — 10 tests passed across 4 Vitest shards.
- `pnpm check:changed` — passed formatting, typechecking, lint, dead-export scans, script erasability, plugin boundaries, and repository guards.
- `git diff --check` — clean.
- Fresh structured autoreview — no accepted or actionable findings.

Production/tooling delta: `-7`. Test delta: `+6/-20`. No screenshots are needed because runtime and rendered behavior are unchanged.
