### PR TITLE
fix(config): stop auto-restoring hand-authored configs missing meta (#126806)

### DIFF
--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -365,7 +365,7 @@ describe("config observe recovery", () => {
     });
   });
 
-  it("auto-restores when metadata disappears from an otherwise valid config", async () => {
+  it("does not auto-restore when only metadata is missing from a valid config (#126806)", async () => {
     await withSuiteHome(async (home) => {
       const { deps, configPath, auditPath } = makeDeps(home);
       await seedConfigBackup(configPath, recoverableTelegramConfig);
@@ -377,10 +377,13 @@ describe("config observe recovery", () => {
 
       const recovered = await recoverSuspiciousConfigRead({ deps, configPath, ...clobbered });
 
-      expect((recovered.parsed as { meta?: unknown }).meta).toEqual(recoverableTelegramConfig.meta);
-      const observe = await readLastObserveEvent(auditPath);
-      expect(observe?.restoredFromBackup).toBe(true);
-      expectSuspiciousIncludes(observe, "missing-meta-vs-last-good");
+      // `missing-meta-vs-last-good` alone is not a restore signal: a valid config
+      // without `meta` was hand-authored, so restoring would silently revert it
+      // on a read-only command. Detection stays (observe path), restore does not.
+      expect((recovered.parsed as { meta?: unknown }).meta).toBeUndefined();
+      expect(recovered.raw).toBe(clobbered.raw);
+      expect(await listClobberFiles(configPath)).toEqual([]);
+      expect(await readObserveEvents(auditPath)).toEqual([]);
     });
   });
 
@@ -509,6 +512,29 @@ describe("config observe recovery", () => {
 
       expect(config.gateway?.mode).toBe("local");
       expectWarnContaining(warn, "Config auto-restored from backup:");
+    });
+  });
+
+  it("loadConfig leaves a valid hand-authored config without meta untouched (#126806)", async () => {
+    await withSuiteHome(async (home) => {
+      const { io, configPath, warn } = createTestConfigIO(home);
+      await seedConfigBackup(configPath, recoverableCoreConfig);
+      // A hand-authored valid config without a `meta` block — exactly the file a
+      // silent revert destroyed on a read-only command. The .bak generation is the
+      // same content plus `meta`, so a restore would only re-add the `meta` block.
+      const handAuthored = await writeConfigRaw(configPath, {
+        update: { channel: "beta" },
+        gateway: { mode: "local" },
+      });
+
+      io.loadConfig();
+
+      // No restore: the operator's file is the source of truth on a read-only load.
+      expect(await fsp.readFile(configPath, "utf-8")).toBe(handAuthored.raw);
+      expectWarnNotContaining(warn, "Config auto-restored from backup:");
+      // The missing-meta signal is still observed as a warning, not silently acted on.
+      expectWarnContaining(warn, "Config observe anomaly");
+      expectWarnContaining(warn, "missing-meta-vs-last-good");
     });
   });
 
@@ -888,7 +914,7 @@ describe("config observe recovery", () => {
   );
 
   it.each(["async", "sync"] as const)(
-    "%s recovery uses canonical metadata fingerprints",
+    "%s recovery leaves a valid config alone when only metadata differs (#126806)",
     async (mode) => {
       await withSuiteHome(async (home) => {
         const { deps, configPath } = makeDeps(home);
@@ -902,7 +928,11 @@ describe("config observe recovery", () => {
             ? await maybeRecoverSuspiciousConfigRead(input)
             : maybeRecoverSuspiciousConfigReadSync(input);
 
-        expect(recovered.parsed).toEqual(backup);
+        // Only `meta` differs (here a non-standard fingerprint in the backup): the
+        // current file validates cleanly, so it is the source of truth, not a
+        // clobber to revert (#126806).
+        expect(recovered.parsed).toEqual(clobbered.parsed);
+        expect(recovered.raw).toBe(clobbered.raw);
       });
     },
   );

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -222,9 +222,11 @@ function resolveSuspiciousSignature(
   return `${current.hash}:${suspicious.join(",")}`;
 }
 
+// `missing-meta-vs-last-good` is intentionally excluded from auto-restore: the
+// writer always stamps `meta`, so a valid config lacking it was hand-authored,
+// and restoring would silently revert a read-only load (#126806). Observe warns.
 function isRecoverableConfigReadSuspiciousReason(reason: string): boolean {
   return (
-    reason === "missing-meta-vs-last-good" ||
     reason === "gateway-mode-missing-vs-last-good" ||
     reason === "update-channel-only-root" ||
     reason.startsWith("size-drop-vs-last-good:")


### PR DESCRIPTION
## What Problem This Solves

Closes #126806.

A valid, schema-passing `openclaw.json` that an operator wrote by hand (or deployed via dotfiles/Ansible/Nix) — one without a `meta` block — was silently replaced by the previous `openclaw.json.bak` generation the next time any command loaded config, including read-only ones like `openclaw models list`. The operator's `update.channel` value and agent roster were dropped into a `openclaw.json.clobbered.<ts>` sidecar behind a single log line: recoverable, but not obvious.

## Why This Change Was Made

`loadConfig` runs suspicious-read recovery *after* validation succeeds, so the restore only ever applies to configs that validate cleanly. `missing-meta-vs-last-good` was on the recoverable-reason list, and OpenClaw's own writer always stamps `meta.lastTouchedVersion` — so a valid config lacking `meta` was, by construction, hand-authored, the exact file a silent revert hurts most. The write path already treats the identical signal as benign (`missing-meta-before-write` is only logged; `resolveConfigWriteBlockingReasons` does not block), so the read path was stricter than the write path and reverted on it.

The fix removes `missing-meta-vs-last-good` from `isRecoverableConfigReadSuspiciousReason` (`src/config/io.observe-recovery.ts`). A valid config is now left untouched on read; the independent observe path (`observeConfigSnapshot`) still records the anomaly as a warning (`Config observe anomaly: … (missing-meta-vs-last-good)`) — the "at most, a warning" the issue asks for. `gateway-mode-missing-vs-last-good` and `update-channel-only-root` stay recoverable because they describe genuinely clobbered shapes.

This is the net-negative absorbing fix at the owner boundary: the recoverable-reason list is the owner of "which suspicious signals warrant auto-restore"; the bug was a wrong entry in it, and removing it is the canonical fix — no guard bolted on, no new path. Production behavioral LOC is −1 (the removed `||` clause); +3 are comment lines documenting why the reason is deliberately excluded, so a future maintainer does not re-add it and reintroduce silent config loss.

## User Impact

Operators who hand-author or config-manage a valid `openclaw.json` without a `meta` block no longer have it silently reverted to an older `.bak` generation by a read-only command. Their file is the source of truth; the missing-`meta` shape is still surfaced as a warning. Configs that genuinely lost their `gateway.mode` or collapsed to an `update.channel`-only root are still auto-restored as before.

## Evidence

**Regression** (`node scripts/run-vitest.mjs src/config/io.observe-recovery.test.ts`):
- Pre-fix: `loadConfig leaves a valid hand-authored config without meta untouched` fails — the file is rewritten with the `.bak`'s `meta` block inserted (the diff shows `"meta": { "lastTouchedVersion": … }` added to the operator's file on a read-only load). `does not auto-restore when only metadata is missing …` fails because `meta` is restored (defined).
- Post-fix: 52/52 pass — the hand-authored file stays byte-identical, no `Config auto-restored from backup` log, and `Config observe anomaly: … (missing-meta-vs-last-good)` is still warned.

**Sibling coverage**: the recovery path is shared by load + read-snapshot. `gateway-mode-missing-vs-last-good` and `update-channel-only-root` stay recoverable, so their restore tests (`auto-restores when gateway mode disappears`, `auto-restores suspicious update-channel-only roots`) and the `size-drop-vs-last-good` tests stay green — they trigger other recoverable reasons. The update-channel clobber also carries `missing-meta` (still *detected* and audited, just no longer the restore trigger); restore proceeds via the other two reasons. Sibling write-side tests use `missing-meta-before-write` (a different signal) and are unaffected.

**Checks**: `oxlint` clean; `oxfmt` clean; `tsgo` config-cli shard reports 0 errors in the touched files (the shard's 1 error is in `src/config/sessions/zzz-126647-repro.test.ts`, an untracked scratch file not in this PR).

## reviewMetrics
- `src/config/io.observe-recovery.ts`: prod net −1 behavioral line (removed `missing-meta-vs-last-good` from the recoverable-reason list); +3 comment lines documenting the non-obvious exclusion (prevents re-adding the silent-revert regression). Why it matters: removes a read-path auto-restore that silently destroyed valid hand-authored configs on read-only commands (silent failure / data-loss — highest severity).
- `src/config/io.observe-recovery.test.ts`: +37/−7 test lines — repurposed two tests that encoded the removed restore-on-`missing-meta` behavior (recovery-direct + async/sync) to assert no-restore, and added a `loadConfig`-level regression asserting the file is left byte-identical while the observe warning still fires.

## risks
- **Removed recovery fallback for `missing-meta-vs-last-good`**: configs that previously auto-restored on missing-meta alone no longer do. This is the intended fix — those were almost exclusively hand-authored valid files; a genuine clobber that lost *only* `meta` while keeping every other field valid is near-impossible (corruption truncates/damages, it does not surgically strip `meta`), and even then the file still validates and is left flagged. The observe path still records the anomaly; `.bak`/`.clobbered` backups remain for manual restore.
- **`size-drop-vs-last-good` sibling**: the issue traces the same read-stricter-than-write asymmetry for size drops but did not reproduce it; the write side blocks `size-drop:` unless `allowConfigSizeDrop` is set, so it is a weaker case. Intentionally out of scope here — flagged for a separate change with its own reproduction.

## bestSolution
Removing `missing-meta-vs-last-good` from the recoverable-reason list at its owner (`isRecoverableConfigReadSuspiciousReason`) is the net-negative canonical fix: the observe path already provides the warning the issue wants, so no new guard or path is needed.
