### PR TITLE
fix(sessions): stop persisting runtime-only skill catalogs

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2555,7 +2555,6 @@ src/commands/doctor-sandbox-legacy-registry.ts	8
 src/commands/doctor-sandbox.ts	5
 src/commands/doctor-security.ts	3
 src/commands/doctor-session-canonical-keys.ts	1
-src/commands/doctor-session-delivery-state.ts	1
 src/commands/doctor-session-incognito-key-repair-state.ts	8
 src/commands/doctor-session-incognito-key-repair.ts	4
 src/commands/doctor-session-snapshots.ts	5

--- a/src/commands/doctor-session-delivery-state.test.ts
+++ b/src/commands/doctor-session-delivery-state.test.ts
@@ -2,14 +2,21 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { listSessionEntriesCore } from "../config/sessions/session-accessor.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import {
+  listSessionEntriesCore,
+  rewriteDoctorSessionEntries,
+} from "../config/sessions/session-accessor.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { repairCanonicalSessionDeliveryStates } from "./doctor-session-delivery-state.js";
+import {
+  repairCanonicalSessionDeliveryStates,
+  repairCanonicalSessionResolvedSkills,
+} from "./doctor-session-delivery-state.js";
 import { repairReservedIncognitoSessionKeys } from "./doctor-session-incognito-key-repair.js";
 
 const tempDirs = createTempDirTracker();
@@ -65,8 +72,8 @@ function insertSessionRow(
     );
 }
 
-function readEntryJson(env: NodeJS.ProcessEnv, sessionKey: string): string {
-  const database = openOpenClawAgentDatabase({ agentId: "main", env });
+function readEntryJson(env: NodeJS.ProcessEnv, sessionKey: string, agentId = "main"): string {
+  const database = openOpenClawAgentDatabase({ agentId, env });
   const row = database.db
     .prepare("SELECT entry_json FROM session_nodes WHERE session_key = ?")
     .get(sessionKey) as { entry_json: string };
@@ -596,5 +603,84 @@ describe("doctor canonical session delivery state", () => {
 
     closeOpenClawAgentDatabasesForTest();
     expect(readEntryJson(sourceEnv, "agent:main:legacy")).toBe(sourceLegacyJson);
+  });
+});
+
+describe("doctor canonical session resolved skills", () => {
+  it("repairs all agents without mutating dry-run rows or losing compact snapshots", () => {
+    const stateDir = fs.realpathSync(tempDirs.make("openclaw-skills-all-agents-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const compactSnapshot = {
+      prompt: "compact skill prompt",
+      skills: [{ name: "demo" }],
+      skillFilter: ["demo"],
+      version: 7,
+    };
+    for (const agentId of ["main", "work"]) {
+      insertSessionRow(
+        env,
+        `agent:${agentId}:runtime-skills`,
+        {
+          sessionId: `${agentId}-runtime-skills`,
+          updatedAt: 42,
+          skillsSnapshot: {
+            ...compactSnapshot,
+            resolvedSkills: [{ name: "demo", description: "x".repeat(20_000) }],
+          },
+        },
+        agentId,
+      );
+      expect(
+        listSessionEntriesCore({ agentId, clone: false, env })[0]?.entry.skillsSnapshot
+          ?.resolvedSkills,
+      ).toBeDefined();
+    }
+
+    expect(
+      rewriteDoctorSessionEntries({
+        scope: {
+          agentId: "main",
+          env,
+          storePath: resolveSessionStorePathCore(undefined, { agentId: "main", env }),
+        },
+        sessionKeys: ["agent:main:runtime-skills"],
+        transform: (entry) => entry,
+      }),
+    ).toBe(0);
+    expect(repairCanonicalSessionResolvedSkills({ apply: false, cfg: {}, env })).toEqual({
+      found: 2,
+      repaired: 0,
+      scannedStores: 2,
+    });
+    expect(
+      JSON.parse(readEntryJson(env, "agent:main:runtime-skills")).skillsSnapshot.resolvedSkills,
+    ).toBeDefined();
+
+    expect(repairCanonicalSessionResolvedSkills({ apply: true, cfg: {}, env })).toEqual({
+      found: 2,
+      repaired: 2,
+      scannedStores: 2,
+    });
+    for (const agentId of ["main", "work"]) {
+      const sessionKey = `agent:${agentId}:runtime-skills`;
+      expect(JSON.parse(readEntryJson(env, sessionKey, agentId)).skillsSnapshot).toEqual(
+        compactSnapshot,
+      );
+      expect(
+        listSessionEntriesCore({ agentId, clone: false, env })[0]?.entry.skillsSnapshot,
+      ).toEqual(compactSnapshot);
+    }
+
+    closeOpenClawAgentDatabasesForTest();
+    for (const agentId of ["main", "work"]) {
+      expect(
+        listSessionEntriesCore({ agentId, clone: false, env })[0]?.entry.skillsSnapshot,
+      ).toEqual(compactSnapshot);
+    }
+    expect(repairCanonicalSessionResolvedSkills({ apply: true, cfg: {}, env })).toEqual({
+      found: 0,
+      repaired: 0,
+      scannedStores: 2,
+    });
   });
 });

--- a/src/commands/doctor-session-delivery-state.ts
+++ b/src/commands/doctor-session-delivery-state.ts
@@ -1,9 +1,9 @@
-import fs from "node:fs";
 import {
   rewriteDoctorSessionEntries,
   scanDoctorSessionEntriesTolerant,
 } from "../config/sessions/session-accessor.js";
-import { resolveAllAgentSessionStoreCandidateTargetsSync } from "../config/sessions/targets.js";
+import { stripRuntimeOnlySessionSkillsFields } from "../config/sessions/store-entry-shape.js";
+import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeLegacySessionEntryDelivery } from "../infra/state-migrations.legacy-session-store.js";
 import {
@@ -11,7 +11,7 @@ import {
   isOpenClawAgentDatabaseOpen,
 } from "../state/openclaw-agent-db.js";
 import { runDoctorAgentDatabaseOperation } from "./doctor-agent-database-operation.js";
-import { resolveTargetSqlitePath } from "./doctor-session-sqlite-readers.js";
+import { listExistingAgentDatabaseTargets } from "./doctor-session-sqlite-readers.js";
 
 export type SessionDeliveryStateRepairReport = {
   found: number;
@@ -25,6 +25,33 @@ export function repairCanonicalSessionDeliveryStates(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
 }): SessionDeliveryStateRepairReport {
+  return repairCanonicalSessionEntries({
+    ...params,
+    transform: normalizeLegacySessionEntryDelivery,
+    updateDeliveryProjection: true,
+  });
+}
+
+/** Removes runtime-only skill catalogs from previously persisted session rows. */
+export function repairCanonicalSessionResolvedSkills(params: {
+  apply: boolean;
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): SessionDeliveryStateRepairReport {
+  return repairCanonicalSessionEntries({
+    ...params,
+    transform: stripRuntimeOnlySessionSkillsFields,
+    updateDeliveryProjection: false,
+  });
+}
+
+function repairCanonicalSessionEntries(params: {
+  apply: boolean;
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  transform: (entry: SessionEntry) => SessionEntry;
+  updateDeliveryProjection: boolean;
+}): SessionDeliveryStateRepairReport {
   const targets = listExistingAgentDatabaseTargets(params.cfg, params.env);
   let found = 0;
   let repaired = 0;
@@ -37,19 +64,19 @@ export function repairCanonicalSessionDeliveryStates(params: {
         scanDoctorSessionEntriesTolerant(
           { agentId: target.agentId, env: params.env, storePath: target.storePath },
           ({ entry, recoveredFromProjections, sessionKey }) => {
-            if (!recoveredFromProjections && normalizeLegacySessionEntryDelivery(entry) !== entry) {
+            if (!recoveredFromProjections && params.transform(entry) !== entry) {
               sessionKeys.push(sessionKey);
             }
           },
         );
-        return { found: true, value: sessionKeys.length } as { found: true; value: number };
+        return sessionKeys.length;
       },
     });
-    if (!operation.ok || !operation.value.found) {
+    if (!operation.ok) {
       continue;
     }
-    found += operation.value.value;
-    if (!params.apply || operation.value.value === 0) {
+    found += operation.value;
+    if (!params.apply || operation.value === 0) {
       continue;
     }
     const wasOpen = isOpenClawAgentDatabaseOpen(target.sqlitePath);
@@ -57,8 +84,8 @@ export function repairCanonicalSessionDeliveryStates(params: {
       repaired += rewriteDoctorSessionEntries({
         scope: { agentId: target.agentId, env: params.env, storePath: target.storePath },
         sessionKeys,
-        transform: normalizeLegacySessionEntryDelivery,
-        updateDeliveryProjection: true,
+        transform: params.transform,
+        updateDeliveryProjection: params.updateDeliveryProjection,
       });
     } finally {
       if (!wasOpen) {
@@ -67,19 +94,4 @@ export function repairCanonicalSessionDeliveryStates(params: {
     }
   }
   return { found, repaired, scannedStores: targets.length };
-}
-
-function listExistingAgentDatabaseTargets(
-  cfg: OpenClawConfig,
-  env: NodeJS.ProcessEnv,
-): Array<{ agentId: string; sqlitePath: string; storePath: string }> {
-  const seenPaths = new Set<string>();
-  return resolveAllAgentSessionStoreCandidateTargetsSync(cfg, { env }).flatMap((target) => {
-    const sqlitePath = resolveTargetSqlitePath(target);
-    if (seenPaths.has(sqlitePath) || !fs.existsSync(sqlitePath)) {
-      return [];
-    }
-    seenPaths.add(sqlitePath);
-    return [{ agentId: target.agentId, sqlitePath, storePath: target.storePath }];
-  });
 }

--- a/src/commands/doctor-session-incognito-key-repair.ts
+++ b/src/commands/doctor-session-incognito-key-repair.ts
@@ -1,11 +1,9 @@
-import fs from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import {
   listSessionEntryKeysReadOnly,
   rewriteDoctorSessionEntries,
 } from "../config/sessions/session-accessor.js";
 import { publishSessionEntryCacheInvalidation } from "../config/sessions/session-accessor.sqlite-entry-cache.js";
-import { resolveAllAgentSessionStoreCandidateTargetsSync } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   executeSqliteQuerySync,
@@ -35,7 +33,7 @@ import {
   type ReservedKeyRename,
   writeRepairJournal,
 } from "./doctor-session-incognito-key-repair-state.js";
-import { resolveTargetSqlitePath } from "./doctor-session-sqlite-readers.js";
+import { listExistingAgentDatabaseTargets } from "./doctor-session-sqlite-readers.js";
 
 export type ReservedIncognitoKeyRepairReport = {
   found: number;
@@ -151,21 +149,6 @@ export function repairReservedIncognitoSessionKeys(params: {
     { operationLabel: "doctor.complete-reserved-incognito-session-keys" },
   );
   return { found: pendingKeys.size, repaired: renames.length };
-}
-
-function listExistingAgentDatabaseTargets(
-  cfg: OpenClawConfig,
-  env: NodeJS.ProcessEnv,
-): Array<{ agentId: string; sqlitePath: string; storePath: string }> {
-  const seenPaths = new Set<string>();
-  return resolveAllAgentSessionStoreCandidateTargetsSync(cfg, { env }).flatMap((target) => {
-    const sqlitePath = resolveTargetSqlitePath(target);
-    if (seenPaths.has(sqlitePath) || !fs.existsSync(sqlitePath)) {
-      return [];
-    }
-    seenPaths.add(sqlitePath);
-    return [{ agentId: target.agentId, sqlitePath, storePath: target.storePath }];
-  });
 }
 
 function planReservedIncognitoKeyRenames(

--- a/src/commands/doctor-session-sqlite-readers.ts
+++ b/src/commands/doctor-session-sqlite-readers.ts
@@ -15,6 +15,8 @@ import type { TranscriptEvent } from "../config/sessions/session-accessor.js";
 import type { SqliteTranscriptStorageRow } from "../config/sessions/session-accessor.sqlite-read.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { SessionStoreTarget as ResolvedSessionStoreTarget } from "../config/sessions/targets.js";
+import { resolveAllAgentSessionStoreCandidateTargetsSync } from "../config/sessions/targets.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.js";
 import { tableExists, tableHasColumn } from "../state/openclaw-state-db-schema-helpers.js";
@@ -481,6 +483,27 @@ export function resolveTargetSqlitePath(target: SessionStoreTarget): string {
   return resolveOpenClawAgentSqlitePath({
     agentId: sqliteTarget.agentId ?? target.agentId,
     ...(sqliteTarget.path ? { path: sqliteTarget.path } : {}),
+  });
+}
+
+/**
+ * Enumerates existing per-agent session SQLite databases for a Doctor repair.
+ * Deduplicates by resolved path (aliases collapse to one target) and skips
+ * databases that do not yet exist on disk. Shared by every session-row repair
+ * so target enumeration cannot drift between repair surfaces.
+ */
+export function listExistingAgentDatabaseTargets(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+): Array<{ agentId: string; sqlitePath: string; storePath: string }> {
+  const seenPaths = new Set<string>();
+  return resolveAllAgentSessionStoreCandidateTargetsSync(cfg, { env }).flatMap((target) => {
+    const sqlitePath = resolveTargetSqlitePath(target);
+    if (seenPaths.has(sqlitePath) || !fs.existsSync(sqlitePath)) {
+      return [];
+    }
+    seenPaths.add(sqlitePath);
+    return [{ agentId: target.agentId, sqlitePath, storePath: target.storePath }];
   });
 }
 

--- a/src/commands/doctor-session-transcripts.test.ts
+++ b/src/commands/doctor-session-transcripts.test.ts
@@ -9,6 +9,7 @@ import { openFileBackedSessionManagerForTest } from "../../test/helpers/session-
 const note = vi.hoisted(() => vi.fn());
 const repairReservedIncognitoSessionKeys = vi.hoisted(() => vi.fn());
 const repairCanonicalSessionDeliveryStates = vi.hoisted(() => vi.fn());
+const repairCanonicalSessionResolvedSkills = vi.hoisted(() => vi.fn());
 const repairCanonicalSessionKeys = vi.hoisted(() => vi.fn());
 const migrateLegacyMainSessionKeys = vi.hoisted(() => vi.fn());
 const runDoctorSessionSqlite = vi.hoisted(() => vi.fn());
@@ -28,6 +29,7 @@ vi.mock("./doctor-session-incognito-key-repair.js", () => ({
 
 vi.mock("./doctor-session-delivery-state.js", () => ({
   repairCanonicalSessionDeliveryStates,
+  repairCanonicalSessionResolvedSkills,
 }));
 
 vi.mock("./doctor-session-canonical-keys.js", () => ({
@@ -116,6 +118,9 @@ describe("doctor session transcript repair", () => {
     note.mockClear();
     repairReservedIncognitoSessionKeys.mockReset().mockReturnValue({ found: 0, repaired: 0 });
     repairCanonicalSessionDeliveryStates
+      .mockReset()
+      .mockReturnValue({ found: 0, repaired: 0, scannedStores: 0 });
+    repairCanonicalSessionResolvedSkills
       .mockReset()
       .mockReturnValue({ found: 0, repaired: 0, scannedStores: 0 });
     repairCanonicalSessionKeys.mockReset().mockResolvedValue({
@@ -327,6 +332,7 @@ describe("doctor session transcript repair", () => {
       mode: "doctor-fix",
     });
     expect(repairReservedIncognitoSessionKeys).toHaveBeenCalledWith({ apply: true, cfg, env });
+    expect(repairCanonicalSessionResolvedSkills).toHaveBeenCalledWith({ apply: true, cfg, env });
     expect(
       expectDefined(runDoctorSessionSqlite.mock.invocationCallOrder[0], "SQLite import call order"),
     ).toBeLessThan(
@@ -353,6 +359,17 @@ describe("doctor session transcript repair", () => {
       ),
     ).toBeLessThan(
       expectDefined(
+        repairCanonicalSessionResolvedSkills.mock.invocationCallOrder[0],
+        "runtime-only skills repair call order",
+      ),
+    );
+    expect(
+      expectDefined(
+        repairCanonicalSessionResolvedSkills.mock.invocationCallOrder[0],
+        "runtime-only skills repair call order",
+      ),
+    ).toBeLessThan(
+      expectDefined(
         repairReservedIncognitoSessionKeys.mock.invocationCallOrder[0],
         "reserved key repair call order",
       ),
@@ -368,6 +385,47 @@ describe("doctor session transcript repair", () => {
     );
     expect(note).toHaveBeenCalledWith(
       expect.stringContaining("Archived 2 legacy transcript artifact(s)."),
+      "Session SQLite",
+    );
+  });
+
+  it("explains how to shrink SQLite files after removing persisted runtime skills", async () => {
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    runDoctorSessionSqlite.mockResolvedValueOnce({
+      totals: {
+        archivedTranscriptFiles: 0,
+        archivedUnreferencedJsonlFiles: 0,
+        importedTranscriptEvents: 0,
+        issues: 0,
+        legacyEntries: 0,
+        sqliteEntries: 2,
+        unreferencedJsonlFiles: 0,
+        validatedTranscriptEvents: 0,
+      },
+    });
+    repairCanonicalSessionResolvedSkills.mockReturnValueOnce({
+      found: 2,
+      repaired: 2,
+      scannedStores: 1,
+    });
+
+    await noteSessionTranscriptHealth({
+      cfg: {},
+      env: { ...process.env, OPENCLAW_STATE_DIR: root },
+      sessionDirs: [sessionsDir],
+      sessionSqlite: true,
+      shouldRepair: true,
+    });
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("Logical SQLite pages are freed"),
+      "Session SQLite",
+    );
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'shrinking the on-disk database requires "openclaw doctor --session-sqlite compact --session-sqlite-all-agents"',
+      ),
       "Session SQLite",
     );
   });

--- a/src/commands/doctor-session-transcripts.ts
+++ b/src/commands/doctor-session-transcripts.ts
@@ -26,6 +26,7 @@ import {
 } from "./doctor-session-canonical-keys.js";
 import {
   repairCanonicalSessionDeliveryStates,
+  repairCanonicalSessionResolvedSkills,
   type SessionDeliveryStateRepairReport,
 } from "./doctor-session-delivery-state.js";
 import {
@@ -523,6 +524,11 @@ async function noteSessionSqliteMigrationHealth(params: {
     repaired: 0,
     scannedStores: 0,
   };
+  let resolvedSkillsReport: SessionDeliveryStateRepairReport = {
+    found: 0,
+    repaired: 0,
+    scannedStores: 0,
+  };
   let canonicalKeyReport: CanonicalSessionKeyRepairReport = {
     archivedTranscriptDirectories: [],
     foundGroups: 0,
@@ -553,6 +559,12 @@ async function noteSessionSqliteMigrationHealth(params: {
       mode: params.shouldRepair ? "doctor-fix" : "detect",
     });
     canonicalKeyReport = await repairCanonicalSessionKeys({
+      apply: params.shouldRepair,
+      cfg: params.cfg ?? {},
+      env: params.env,
+    });
+    // Canonical-key ties compare complete entry JSON, so select their winner before stripping it.
+    resolvedSkillsReport = repairCanonicalSessionResolvedSkills({
       apply: params.shouldRepair,
       cfg: params.cfg ?? {},
       env: params.env,
@@ -610,6 +622,14 @@ async function noteSessionSqliteMigrationHealth(params: {
       params.shouldRepair
         ? `- Canonicalized delivery state for ${deliveryReport.repaired} durable session row(s).`
         : `- Found ${deliveryReport.found} durable session row(s) with legacy delivery fields. Run "openclaw doctor --fix" to canonicalize them.`,
+      "Session SQLite",
+    );
+  }
+  if (resolvedSkillsReport.found > 0) {
+    note(
+      params.shouldRepair
+        ? `- Stripped the runtime-only skills catalog from ${resolvedSkillsReport.repaired} durable session row(s). Logical SQLite pages are freed; shrinking the on-disk database requires "openclaw doctor --session-sqlite compact --session-sqlite-all-agents".`
+        : `- Found ${resolvedSkillsReport.found} durable session row(s) carrying a runtime-only skills catalog. Run "openclaw doctor --fix" to strip it.`,
       "Session SQLite",
     );
   }

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -1032,8 +1032,8 @@ describe("collectGatewayHealthSnapshot", () => {
     await getHealthSnapshot({ timeoutMs: 10, probe: false });
 
     expect(listHealthSessionEntriesCalls).toEqual([
-      { agentId: "main", storePath: "/tmp/sessions.json" },
-      { agentId: "ops", storePath: "/tmp/sessions.json" },
+      { agentId: "main", clone: false, projection: "list", storePath: "/tmp/sessions.json" },
+      { agentId: "ops", clone: false, projection: "list", storePath: "/tmp/sessions.json" },
     ]);
   });
 });

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { saveLegacySessionStore as saveSessionStore } from "../../infra/state-migrations.legacy-session-store.js";
+import { createFixtureSkillEntry } from "../../skills/test-support/test-helpers.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
@@ -351,6 +352,37 @@ describe("enforceSessionDiskBudget", () => {
       expect(result.removedEntries).toBe(1);
       expect(store).toHaveProperty(lockedKey);
       expect(store).not.toHaveProperty(removableKey);
+    });
+  });
+
+  it("does not evict sessions for runtime-only resolved skill catalogs", async () => {
+    await withTestDir({ prefix: "openclaw-disk-budget-runtime-skills-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const sessionKey = "agent:main:subagent:runtime-skills";
+      const resolvedSkills = [
+        createFixtureSkillEntry("demo", { source: "x".repeat(20_000) }).skill,
+      ];
+      const entry: SessionEntry = {
+        sessionId: "runtime-skills",
+        updatedAt: Date.now(),
+        skillsSnapshot: {
+          prompt: "compact prompt",
+          skills: [{ name: "demo" }],
+          resolvedSkills,
+        },
+      };
+      const store = { [sessionKey]: entry };
+
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        maintenance: { maxDiskBytes: 2_048, highWaterBytes: 1_024 },
+        warnOnly: false,
+      });
+
+      expect(result).toMatchObject({ overBudget: false, removedEntries: 0 });
+      expect(store[sessionKey]).toBe(entry);
+      expect(entry.skillsSnapshot?.resolvedSkills).toBe(resolvedSkills);
     });
   });
 

--- a/src/config/sessions/session-accessor.entry-mutation.ts
+++ b/src/config/sessions/session-accessor.entry-mutation.ts
@@ -36,29 +36,9 @@ import type {
   SessionEntryCreateWithTranscriptPrepareResult,
   SessionEntryCreateWithTranscriptOptions,
 } from "./session-accessor.types.js";
-import { projectSessionStoreForPersistence } from "./skill-prompt-blobs.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import type { GroupKeyResolution, InternalSessionEntry as SessionEntry } from "./types.js";
-
-function projectSessionEntryForPersistenceRevision(params: {
-  storePath: string;
-  entry: SessionEntry;
-}): SessionEntry {
-  const snapshot = params.entry.skillsSnapshot;
-  const stripped =
-    snapshot?.resolvedSkills === undefined
-      ? params.entry
-      : {
-          ...params.entry,
-          skillsSnapshot: (({ resolvedSkills: _drop, ...rest }) => rest)(snapshot),
-        };
-  const projected = projectSessionStoreForPersistence({
-    storePath: params.storePath,
-    store: { entry: stripped },
-  });
-  return projected.store.entry ?? stripped;
-}
 
 export async function forkSessionFromParentTranscript(
   params: ForkSessionFromParentTranscriptParams,
@@ -238,15 +218,14 @@ export function createReplySessionInitializationRevision(params: {
   entry: SessionEntry | undefined;
   storePath: string;
 }): string {
-  const { entry, storePath } = params;
+  const { entry } = params;
   if (!entry) {
     return JSON.stringify(null);
   }
   // The guard only rejects a true session-identity rebind. Same-session
   // activity/context writes are merged below; comparing them here would reject
   // before the merge can preserve the concurrent metadata.
-  const projected = projectSessionEntryForPersistenceRevision({ storePath, entry });
-  return JSON.stringify({ sessionId: projected.sessionId });
+  return JSON.stringify({ sessionId: entry.sessionId });
 }
 
 export function resolveInitializedReplySessionEntry(params: {

--- a/src/config/sessions/session-accessor.sqlite-doctor-rewrite.ts
+++ b/src/config/sessions/session-accessor.sqlite-doctor-rewrite.ts
@@ -17,6 +17,7 @@ import {
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
 import { parseSqliteSessionEntryRecord } from "./session-entry-json.js";
+import { stripRuntimeOnlySessionSkillsFields } from "./store-entry-shape.js";
 import type { SessionEntry } from "./types.js";
 
 const DOCTOR_SESSION_REWRITE_BATCH_SIZE = 64;
@@ -54,12 +55,16 @@ export function rewriteDoctorSessionEntries(params: {
           if (!entry) {
             continue;
           }
-          const nextEntry = params.transform(entry, sessionKey);
-          const entryJson = JSON.stringify(nextEntry);
-          if (
-            entryJson === row.entry_json ||
-            !parseSqliteSessionEntryRecord({ ...row, entry_json: entryJson })
-          ) {
+          const transformedEntry = params.transform(entry, sessionKey);
+          const transformedJson = JSON.stringify(transformedEntry);
+          // Incognito repair scans unrelated rows; only its changed entries may be rewritten.
+          if (transformedJson === row.entry_json) {
+            continue;
+          }
+          const nextEntry = stripRuntimeOnlySessionSkillsFields(transformedEntry);
+          const entryJson =
+            nextEntry === transformedEntry ? transformedJson : JSON.stringify(nextEntry);
+          if (!parseSqliteSessionEntryRecord({ ...row, entry_json: entryJson })) {
             continue;
           }
           const writeGeneration = trackSessionEntryCacheWrite(database, () => {

--- a/src/config/sessions/session-accessor.sqlite-session-row.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-session-row.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createCanonicalFixtureSkill } from "../../skills/test-support/test-helpers.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { upsertSessionEntryCore } from "./session-accessor.js";
+import type { SessionEntry } from "./types.js";
+
+const tempDirs = createTempDirTracker();
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  tempDirs.cleanup();
+});
+
+describe("SQLite session row persistence", () => {
+  it("keeps runtime-only resolved skills out of raw SQLite JSON without mutating the session", async () => {
+    const stateDir = fs.realpathSync(tempDirs.make("openclaw-sqlite-session-skills-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const sessionKey = "agent:main:runtime-skills";
+    const resolvedSkills = [
+      createCanonicalFixtureSkill({
+        name: "demo",
+        description: "runtime-only skill",
+        filePath: "/skills/demo/SKILL.md",
+        baseDir: "/skills/demo",
+        source: "# Demo\n\n" + "runtime skill content ".repeat(100),
+      }),
+    ];
+    const entry: SessionEntry = {
+      sessionId: "runtime-skills-session",
+      updatedAt: 42,
+      skillsSnapshot: {
+        prompt: "compact skill prompt",
+        skills: [{ name: "demo" }],
+        skillFilter: ["demo"],
+        resolvedSkills,
+        version: 7,
+      },
+    };
+
+    await upsertSessionEntryCore({ agentId: "main", env, sessionKey }, entry);
+
+    const database = openOpenClawAgentDatabase({ agentId: "main", env });
+    const row = database.db
+      .prepare("SELECT entry_json FROM session_nodes WHERE session_key = ?")
+      .get(sessionKey) as { entry_json: string };
+    const persisted = JSON.parse(row.entry_json) as SessionEntry;
+    expect(persisted.skillsSnapshot).toEqual({
+      prompt: "compact skill prompt",
+      skills: [{ name: "demo" }],
+      skillFilter: ["demo"],
+      version: 7,
+    });
+    expect(entry.skillsSnapshot?.resolvedSkills).toBe(resolvedSkills);
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-session-row.ts
+++ b/src/config/sessions/session-accessor.sqlite-session-row.ts
@@ -6,7 +6,10 @@ import {
 import { normalizeSessionRowChatType, normalizeText } from "./session-accessor.sqlite-normalize.js";
 import { bindSessionEntryProvenance } from "./session-accessor.sqlite-provenance.js";
 import { normalizeStatus } from "./session-accessor.sqlite-status.js";
-import { projectCanonicalSessionEntryShape } from "./store-entry-shape.js";
+import {
+  projectCanonicalSessionEntryShape,
+  stripRuntimeOnlySessionSkillsFields,
+} from "./store-entry-shape.js";
 import type { SessionEntry } from "./types.js";
 
 export function normalizeSessionEntryTimestamp(entry: SessionEntry): SessionEntry {
@@ -91,7 +94,7 @@ export function bindSessionNode(params: {
   return {
     session_key: params.sessionKey,
     current_session_id: params.entry.sessionId,
-    entry_json: JSON.stringify(canonicalEntry),
+    entry_json: JSON.stringify(stripRuntimeOnlySessionSkillsFields(canonicalEntry)),
     entry_valid: 1,
     updated_at: params.updatedAt,
     status: normalizeStatus(params.entry.status),

--- a/src/config/sessions/skill-prompt-blobs.ts
+++ b/src/config/sessions/skill-prompt-blobs.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { writeTextAtomic } from "../../infra/json-files.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
+import { stripRuntimeOnlySessionSkillsFields } from "./store-entry-shape.js";
 import type { SessionEntry, SessionSkillPromptRef, SessionSkillSnapshot } from "./types.js";
 
 const PROMPT_BLOB_DIR = "skills-prompts";
@@ -173,21 +174,25 @@ export function projectSessionStoreForPersistence(params: {
   let changed = false;
   const promptBlobs = new Map<string, SessionSkillPromptBlobProjection>();
   for (const [key, entry] of Object.entries(params.store)) {
-    const prompt = entry.skillsSnapshot?.prompt;
-    if (!prompt || !shouldStorePromptAsBlob(prompt)) {
+    let projectedEntry = stripRuntimeOnlySessionSkillsFields(entry);
+    const prompt = projectedEntry.skillsSnapshot?.prompt;
+    if (prompt && shouldStorePromptAsBlob(prompt)) {
+      const promptRef = buildPromptRef(prompt);
+      promptBlobs.set(promptRef.hash, {
+        ref: promptRef,
+        path: resolveSessionSkillPromptBlobPath(params.storePath, promptRef.hash),
+        prompt,
+      });
+      projectedEntry = stripPromptForPersistence(projectedEntry, promptRef);
+    }
+    if (projectedEntry === entry) {
       continue;
     }
-    const promptRef = buildPromptRef(prompt);
-    promptBlobs.set(promptRef.hash, {
-      ref: promptRef,
-      path: resolveSessionSkillPromptBlobPath(params.storePath, promptRef.hash),
-      prompt,
-    });
     if (persisted === params.store) {
       // Copy-on-write keeps callers that only inspect the projection from seeing partial mutation.
       persisted = { ...params.store };
     }
-    persisted[key] = stripPromptForPersistence(entry, promptRef);
+    persisted[key] = projectedEntry;
     changed = true;
   }
   return { store: persisted, changed, promptBlobs };

--- a/src/config/sessions/store-entry-shape.ts
+++ b/src/config/sessions/store-entry-shape.ts
@@ -151,6 +151,16 @@ export function projectCanonicalSessionEntryShape(value: Record<string, unknown>
   return canonicalValue as unknown as SessionEntry;
 }
 
+/** Removes the runtime-only skill catalog without mutating the live session snapshot. */
+export function stripRuntimeOnlySessionSkillsFields(entry: SessionEntry): SessionEntry {
+  const snapshot = entry.skillsSnapshot;
+  if (snapshot?.resolvedSkills === undefined) {
+    return entry;
+  }
+  const { resolvedSkills: _drop, ...skillsSnapshot } = snapshot;
+  return { ...entry, skillsSnapshot };
+}
+
 function normalizePendingFinalDelivery(
   value: unknown,
 ): SessionEntry["pendingFinalDelivery"] | undefined {

--- a/src/gateway/health/collector.session-store-path.test.ts
+++ b/src/gateway/health/collector.session-store-path.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
@@ -16,6 +16,7 @@ describe("health session store paths", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
   afterEach(() => {
+    vi.restoreAllMocks();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
   });
@@ -38,6 +39,41 @@ describe("health session store paths", () => {
     expect(summary.count).toBe(1);
     expect(summary.path).toBe(databasePath);
     expect(fs.existsSync(summary.path)).toBe(true);
+  });
+
+  it("counts and orders lightweight session projections without cloning full entries", async () => {
+    const stateDir = tempDirs.make("openclaw-health-session-projection-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const agentId = "main";
+    const storePath = resolveSessionStorePathCore(undefined, { agentId, env });
+    const now = vi.spyOn(Date, "now");
+    for (const updatedAt of [30, 70, 10, 60, 40, 20, 50]) {
+      now.mockReturnValue(updatedAt);
+      await upsertSessionEntryCore(
+        { agentId, env, sessionKey: `agent:${agentId}:session-${updatedAt}`, storePath },
+        {
+          sessionId: `session-${updatedAt}`,
+          updatedAt,
+          skillsSnapshot: { prompt: "large runtime prompt", skills: [{ name: "demo" }] },
+        },
+      );
+    }
+    now.mockReturnValue(100);
+    const clone = vi.spyOn(globalThis, "structuredClone");
+
+    const summary = await buildHealthSessionSummary(storePath, agentId);
+
+    expect(clone).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({
+      count: 7,
+      recent: [
+        { key: "agent:main:session-70", updatedAt: 70, age: 30 },
+        { key: "agent:main:session-60", updatedAt: 60, age: 40 },
+        { key: "agent:main:session-50", updatedAt: 50, age: 50 },
+        { key: "agent:main:session-40", updatedAt: 40, age: 60 },
+        { key: "agent:main:session-30", updatedAt: 30, age: 70 },
+      ],
+    });
   });
 
   it("preserves configured store templates and reports empty agent targets", async () => {

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -113,6 +113,8 @@ export async function buildHealthSessionSummary(storePath: string, agentId?: str
   try {
     listed = listSessionEntriesReadOnly({
       ...(agentId ? { agentId } : {}),
+      clone: false,
+      projection: "list",
       storePath,
     });
   } catch (error) {

--- a/src/infra/state-migrations.legacy-session-store.test.ts
+++ b/src/infra/state-migrations.legacy-session-store.test.ts
@@ -106,6 +106,13 @@ it("normalizes compatibility writes before persistence", async () => {
         updatedAt: 1,
         provider: "slack",
         pendingFinalDeliveryAttemptCount: -1,
+        skillsSnapshot: {
+          prompt: "compact skill prompt",
+          skills: [{ name: "demo" }],
+          skillFilter: ["demo"],
+          resolvedSkills: [{ name: "demo", description: "runtime-only catalog" }],
+          version: 7,
+        },
       },
     } as unknown as Parameters<typeof saveLegacySessionStore>[1];
 
@@ -123,8 +130,15 @@ it("normalizes compatibility writes before persistence", async () => {
         context: { channel: "slack" },
         origin: { provider: "slack" },
       },
+      skillsSnapshot: {
+        prompt: "compact skill prompt",
+        skills: [{ name: "demo" }],
+        skillFilter: ["demo"],
+        version: 7,
+      },
     });
     expect(persisted["agent:main:main"]).not.toHaveProperty("channel");
     expect(persisted["agent:main:main"]).not.toHaveProperty("pendingFinalDeliveryAttemptCount");
+    expect(persisted["agent:main:main"]?.skillsSnapshot).not.toHaveProperty("resolvedSkills");
   });
 });

--- a/src/infra/state-migrations.legacy-session-store.ts
+++ b/src/infra/state-migrations.legacy-session-store.ts
@@ -8,7 +8,10 @@ import {
   hydrateSessionStoreSkillPromptRefs,
   projectSessionStoreForPersistence,
 } from "../config/sessions/skill-prompt-blobs.js";
-import { normalizePersistedSessionEntryShape } from "../config/sessions/store-entry-shape.js";
+import {
+  normalizePersistedSessionEntryShape,
+  stripRuntimeOnlySessionSkillsFields,
+} from "../config/sessions/store-entry-shape.js";
 import {
   applyFileBackedSessionStoreMaintenance,
   type SessionMaintenanceApplyReport,
@@ -216,15 +219,6 @@ function normalizePluginExtensionSlotKeys(entry: SessionEntry): SessionEntry {
   });
 }
 
-function stripPersistedSkillsCache(entry: SessionEntry): SessionEntry {
-  const snapshot = entry.skillsSnapshot;
-  if (!snapshot || snapshot.resolvedSkills === undefined) {
-    return entry;
-  }
-  const { resolvedSkills: _drop, ...rest } = snapshot;
-  return { ...entry, skillsSnapshot: rest };
-}
-
 function normalizeLegacySessionStore(store: Record<string, SessionEntry>): void {
   applySessionStoreMigrations(store);
   for (const [key, entry] of Object.entries(store)) {
@@ -241,7 +235,7 @@ function normalizeLegacySessionStore(store: Record<string, SessionEntry>): void 
     if (modelSelectionLocked && runtimeFields !== shaped) {
       throw new Error(`Invalid model-selection-locked session entry: ${key}`);
     }
-    store[key] = stripPersistedSkillsCache(
+    store[key] = stripRuntimeOnlySessionSkillsFields(
       normalizePluginExtensionSlotKeys(
         normalizePluginExtensions(
           normalizeRestartRecoveryFields(
@@ -339,17 +333,6 @@ function assertLegacySessionStoreWriteIsValid(params: {
   }
 }
 
-function stripRuntimeOnlySkillState(
-  store: Record<string, SessionEntry>,
-): Record<string, SessionEntry> {
-  return Object.fromEntries(
-    Object.entries(store).map(([sessionKey, entry]) => [
-      sessionKey,
-      stripPersistedSkillsCache(entry),
-    ]),
-  );
-}
-
 async function archiveRemovedSessionTranscripts(params: {
   removedSessionFiles: Iterable<[string, string | undefined]>;
   referencedSessionIds: ReadonlySet<string>;
@@ -383,7 +366,7 @@ async function persistLegacySessionStore(
 ): Promise<void> {
   const persisted = projectSessionStoreForPersistence({
     storePath,
-    store: stripRuntimeOnlySkillState(store),
+    store,
   });
   await fs.promises.mkdir(path.dirname(storePath), { recursive: true });
   await writeTextAtomic(storePath, JSON.stringify(persisted.store, null, 2), {


### PR DESCRIPTION
Closes #126663

Supersedes closed PR #126684, whose branch became contaminated with unrelated changes. This replacement preserves the focused repair and credits the original contributor, @ruel225.

## What Problem This Solves

Fixes an issue where operators with many agent sessions would experience multi-second Gateway stalls, reconnect storms, excessive heap usage, and rapidly growing per-agent SQLite databases because every durable session row duplicated the runtime-only resolved skill catalog. The reported deployment observed 5–10 second synchronous session writes, roughly 8 GiB of heap usage, and hundreds of megabytes of duplicated session payloads.

## Why This Change Was Made

One canonical persistence projection now removes only `skillsSnapshot.resolvedSkills` at the shared SQLite and file-backed session persistence boundaries, while preserving compact prompt, skill, version, and filter fields without mutating live session objects. This restores the runtime-only persistence invariant previously addressed by merged PR #75960 across the current SQLite-backed architecture. Doctor repairs already-persisted rows in bounded batches through its existing session-repair ownership boundary, consolidates shared database-target enumeration, and explicitly explains that logical pages are freed while physical database shrinkage requires `openclaw doctor --session-sqlite compact --session-sqlite-all-agents`. Gateway health also reuses the existing lightweight session-list projection with `clone: false`.

There is no automatic VACUUM, schema-version bump, new configuration surface, compatibility shim, release change, or changelog change. Production growth is limited to the bounded historical-row repair and canonical Doctor target enumeration; the removed assertion-baseline entry corresponds exactly to an eliminated obsolete assertion.

## User Impact

Session updates no longer repeatedly persist the large runtime-only resolved-skill catalog, reducing synchronous write amplification, unnecessary heap materialization, Gateway stalls, reconnect pressure, and future database growth. Existing oversized rows can be repaired with `openclaw doctor --fix`; operators who also want the filesystem-visible database file to shrink receive the explicit follow-up command `openclaw doctor --session-sqlite compact --session-sqlite-all-agents`. Cold-session behavior retains the compact persisted snapshot fields and rebuilds runtime-only skill data normally.

## Evidence

Focused regression coverage exercises real SQLite session-row persistence, bounded/idempotent Doctor repairs, dry-run behavior, Doctor output and explicit compaction guidance, the sibling incognito-key repair, legacy file-backed persistence, disk-budget accounting, and the lightweight Gateway health projection.

```text
node scripts/run-vitest.mjs src/commands/doctor-session-delivery-state.test.ts src/commands/doctor-session-incognito-key-repair.test.ts src/commands/doctor-session-snapshots.test.ts src/commands/doctor-session-transcripts.test.ts src/commands/health.snapshot.test.ts src/config/sessions/disk-budget.test.ts src/config/sessions/session-accessor.conformance.test.ts src/config/sessions/session-accessor.sqlite-session-row.test.ts src/gateway/health/collector.session-store-path.test.ts src/infra/state-migrations.legacy-session-store.test.ts src/skills/runtime/snapshot-hydration.test.ts
158 tests passed across five Vitest shards

git diff --check origin/main...HEAD
passed

node scripts/check-changed.mjs -- config/assertion-safety-baseline.txt src/commands/doctor-session-delivery-state.test.ts src/commands/doctor-session-delivery-state.ts src/commands/doctor-session-incognito-key-repair.ts src/commands/doctor-session-sqlite-readers.ts src/commands/doctor-session-transcripts.test.ts src/commands/doctor-session-transcripts.ts src/config/sessions/disk-budget.test.ts src/config/sessions/session-accessor.entry-mutation.ts src/config/sessions/session-accessor.sqlite-doctor-rewrite.ts src/config/sessions/session-accessor.sqlite-session-row.test.ts src/config/sessions/session-accessor.sqlite-session-row.ts src/config/sessions/skill-prompt-blobs.ts src/config/sessions/store-entry-shape.ts src/gateway/health/collector.session-store-path.test.ts src/gateway/health/collector.ts src/infra/state-migrations.legacy-session-store.test.ts src/infra/state-migrations.legacy-session-store.ts
passed on a clean Linux remote worker (all selected typecheck, lint, format, ratchet, and database-first guard lanes)

global autoreview --mode branch --base origin/main
clean: no accepted/actionable findings
```

Production: +131/-106 (net +25); tests: +295/-7 (net +288); assertion baseline: one obsolete entry removed. The original CI run also exposed an existing health snapshot assertion that omitted the new lightweight-list options; the only follow-up change strengthens that assertion with `clone: false` and `projection: "list"`. Original contributor: @ruel225 (`Co-authored-by: ruel225 <ruel225@users.noreply.github.com>`).
