### PR TITLE
chore: prepare fresh Amp orb lifecycle

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+node_bin="$HOME/.local/share/openclaw-orb/node/current/bin"
+
+cd "$repo_root"
+
+if [[ ! -x "$node_bin/node" ]]; then
+  echo "[orb resume] Node toolchain is missing; run .agents/setup" >&2
+  exit 1
+fi
+
+export PATH="$node_bin:$PATH"
+
+if [[ ! -x "$node_bin/pnpm" ]]; then
+  "$node_bin/corepack" enable --install-directory "$node_bin"
+fi
+
+node --input-type=module -e '
+  import { isSupportedOpenClawNodeVersion } from "./node-version.mjs";
+  if (!isSupportedOpenClawNodeVersion(process.version)) process.exit(1);
+'
+
+package_manager="$(node -p 'require("./package.json").packageManager')"
+expected_pnpm="${package_manager#pnpm@}"
+expected_pnpm="${expected_pnpm%%+*}"
+actual_pnpm="$(pnpm --version)"
+if [[ "$actual_pnpm" != "$expected_pnpm" ]]; then
+  echo "[orb resume] Expected pnpm $expected_pnpm, found $actual_pnpm; run .agents/setup" >&2
+  exit 1
+fi
+
+printf '[orb resume] Ready: Node %s, pnpm %s\n' "$(node --version)" "$actual_pnpm"

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+node_toolchain_root="$HOME/.local/share/openclaw-orb/node"
+node_bin="$node_toolchain_root/current/bin"
+profile_marker="# OpenClaw orb toolchain"
+
+cd "$repo_root"
+
+run_step() {
+  local label="$1"
+  shift
+  local started_at=$SECONDS
+  printf '[orb setup] %s\n' "$label"
+  "$@"
+  printf '[orb setup] %s completed in %ss\n' "$label" "$((SECONDS - started_at))"
+}
+
+install_system_packages() {
+  local packages=(build-essential ca-certificates cmake curl git python3 xz-utils)
+  local missing=()
+  local package
+  for package in "${packages[@]}"; do
+    if ! dpkg-query -W -f='${Status}\n' "$package" 2>/dev/null | grep -Fqx 'install ok installed'; then
+      missing+=("$package")
+    fi
+  done
+
+  if ((${#missing[@]} == 0)); then
+    echo "[orb setup] System packages already installed"
+    return
+  fi
+
+  if ((EUID == 0)); then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${missing[@]}"
+  else
+    sudo apt-get update
+    sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${missing[@]}"
+  fi
+}
+
+install_node() {
+  export OPENCLAW_NODE_TOOLCHAIN_ROOT="$node_toolchain_root"
+  # Reuse the repository's Node release-floor and download contract used by CI.
+  # shellcheck disable=SC1091
+  source "$repo_root/.github/actions/setup-pnpm-store-cache/ensure-node.sh"
+  openclaw_ensure_node "24.x"
+
+  local node_prefix
+  node_prefix="$(dirname "$(dirname "$(readlink -f "$(node -p 'process.execPath')")")")"
+  mkdir -p "$node_toolchain_root"
+  ln -sfn "$node_prefix" "$node_toolchain_root/current"
+  export PATH="$node_bin:$PATH"
+}
+
+install_pnpm() {
+  local package_manager
+  package_manager="$(node -p 'require("./package.json").packageManager')"
+
+  if [[ ! -x "$node_bin/corepack" ]]; then
+    "$node_bin/npm" install --global corepack@latest
+  fi
+  "$node_bin/corepack" enable --install-directory "$node_bin"
+
+  local attempt
+  for attempt in 1 2 3; do
+    if COREPACK_ENABLE_DOWNLOAD_PROMPT=0 "$node_bin/corepack" prepare "$package_manager" --activate; then
+      break
+    fi
+    if ((attempt == 3)); then
+      return 1
+    fi
+    sleep $((attempt * 5))
+  done
+
+  local expected_version="${package_manager#pnpm@}"
+  expected_version="${expected_version%%+*}"
+  local actual_version
+  actual_version="$(pnpm --version)"
+  if [[ "$actual_version" != "$expected_version" ]]; then
+    echo "[orb setup] Expected pnpm $expected_version, found $actual_version" >&2
+    return 1
+  fi
+}
+
+install_dependencies() {
+  CI=true pnpm install \
+    --frozen-lockfile \
+    --prefer-offline \
+    --ignore-scripts=false \
+    --config.engine-strict=false \
+    --config.enable-pre-post-scripts=true \
+    --config.side-effects-cache=true
+}
+
+configure_login_shell() {
+  touch "$HOME/.bash_profile"
+  if grep -Fqx "$profile_marker" "$HOME/.bash_profile"; then
+    return
+  fi
+
+  cat >> "$HOME/.bash_profile" <<EOF
+
+$profile_marker
+if [[ "\${PWD}" == "$repo_root" || "\${PWD}" == "$repo_root/"* ]]; then
+  export PATH="$node_bin:\${PATH}"
+fi
+EOF
+}
+
+run_step "Checking system packages" install_system_packages
+run_step "Preparing Node 24" install_node
+run_step "Activating the repository pnpm version" install_pnpm
+run_step "Installing workspace dependencies" install_dependencies
+run_step "Configuring login shells" configure_login_shell
+
+printf '[orb setup] Ready: Node %s, pnpm %s\n' "$(node --version)" "$(pnpm --version)"

--- a/.agents/setup
+++ b/.agents/setup
@@ -42,6 +42,9 @@ install_system_packages() {
 }
 
 install_node() {
+  if [[ -x "$node_bin/node" ]]; then
+    export PATH="$node_bin:$PATH"
+  fi
   export OPENCLAW_NODE_TOOLCHAIN_ROOT="$node_toolchain_root"
   # Reuse the repository's Node release-floor and download contract used by CI.
   # shellcheck disable=SC1091
@@ -60,7 +63,8 @@ install_pnpm() {
   package_manager="$(node -p 'require("./package.json").packageManager')"
 
   if [[ ! -x "$node_bin/corepack" ]]; then
-    "$node_bin/npm" install --global corepack@latest
+    echo "[orb setup] Node toolchain does not include Corepack; remove $node_toolchain_root and rerun setup" >&2
+    return 1
   fi
   "$node_bin/corepack" enable --install-directory "$node_bin"
 

--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,7 @@ changelog/fragments/
 .mypy_cache/
 .vmux*
 .artifacts/
+.amp/portals/
 .openclaw-config-doc-cache/
 openclaw-path-alias-*/
 /.pi/


### PR DESCRIPTION
## What Problem This Solves

Fresh Amp orbs currently start this repository with an unsupported Node 20 runtime, no workspace dependencies, and no lifecycle scripts to repair the environment after wake-up. Agents must rediscover and manually provision the repository before they can build or test it.

## Why This Change Was Made

Add idempotent Amp lifecycle scripts that install the small Debian build prerequisite set, reuse the repository's CI-owned Node 24 bootstrap contract, activate the exact `packageManager` pnpm pin, and install the frozen workspace. Resume remains network-free and only repairs/checks the cached toolchain. Setup reuses its persisted Node runtime before resolution and requires Node's bundled Corepack rather than downloading a separate moving bootstrap. The portal output directory is ignored as required by Amp's orb lifecycle contract.

## User Impact

Developers can open this repository in a fresh or resumed Amp orb and immediately use the supported Node/pnpm development environment. No OpenClaw runtime behavior or user configuration changes.

## Evidence

- Cold `.agents/setup`: 27.58s; installed Node v24.19.0, pnpm 11.15.1, and all 171 workspace projects.
- Repeated warm `.agents/setup`: 2.10-2.37s with no package downloads or system installs.
- Exact-head non-login proof started with system Node 20 first on `PATH`, reused persisted Node 24 from `node/current/bin`, completed setup, and asserted there was no `Downloading Node` output.
- `.agents/resume`: 0.58-0.71s, Node v24.19.0 and pnpm 11.15.1 validated.
- Minimal clean login shell resolved the persisted toolchain paths and reported Node v24.19.0 / pnpm 11.15.1.
- `bash -n .agents/setup .agents/resume`
- `git diff --check`
- TruffleHog pre-review scans before and after the review fix: clean.
- ClawSweeper findings addressed: removed the mutable `corepack@latest` bootstrap and made persisted Node reuse explicit before shared resolution.
- Structured Codex autoreview was retried after the fix but could not complete because the orb credential was rejected by the Codex API with HTTP 401; the user explicitly instructed landing after that limitation was disclosed.
