### PR TITLE
fix(policy): scan keyed agents.entries in sandbox, tool, and workspace evidence

### DIFF
--- a/extensions/policy/src/doctor/agent-workspace-findings.ts
+++ b/extensions/policy/src/doctor/agent-workspace-findings.ts
@@ -116,7 +116,7 @@ function agentWorkspaceToolDenyFindings(
         target: entry.source,
         requirement: `oc://${policyDocName}/${requirementPath}`,
         fixHint:
-          "Add the tool to tools.deny or agents.list[].tools.deny, or update policy after review.",
+          "Add the tool to tools.deny or agents.entries.<id>.tools.deny, or update policy after review.",
       };
     });
 }

--- a/extensions/policy/src/doctor/fix-metadata.ts
+++ b/extensions/policy/src/doctor/fix-metadata.ts
@@ -260,7 +260,7 @@ const POLICY_FIX_METADATA = [
     "Merge required built-in deny tool classes.",
     {
       policyPath: ["tools", "denyTools"],
-      configTargets: ["tools.deny", "agents.list[].tools.deny"],
+      configTargets: ["tools.deny", "agents.entries.<id>.tools.deny"],
     },
   ),
   m(

--- a/extensions/policy/src/doctor/metadata.test.ts
+++ b/extensions/policy/src/doctor/metadata.test.ts
@@ -177,7 +177,7 @@ describe("policy doctor metadata", () => {
   it("points required-deny repair metadata at OpenClaw deny config paths", () => {
     expect(
       POLICY_FIX_METADATA_BY_CHECK_ID.get(CHECK_IDS.policyToolsRequiredDenyMissing)?.configTargets,
-    ).toEqual(["tools.deny", "agents.list[].tools.deny"]);
+    ).toEqual(["tools.deny", "agents.entries.<id>.tools.deny"]);
   });
 
   it("keeps policy fix class assignments explicit", () => {

--- a/extensions/policy/src/doctor/register.models-and-mcp.test-utils.ts
+++ b/extensions/policy/src/doctor/register.models-and-mcp.test-utils.ts
@@ -82,6 +82,41 @@ describe("registerPolicyDoctorChecks", () => {
     });
   });
 
+  it("repairs required keyed agent workspace deny tool findings", async () => {
+    const cfg = {
+      ...cfgWithPolicy({ workspaceRepairs: true }),
+      agents: {
+        ownership: "explicit",
+        entries: {
+          reviewer: { tools: { deny: ["exec"] } },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const configPath = await writePolicyFixture({
+      scopes: {
+        reviewer: {
+          agentIds: ["reviewer"],
+          agents: { workspace: { denyTools: ["exec", "write", "edit"] } },
+        },
+      },
+    });
+
+    const result = await runPolicyRepairCheck(
+      "policy/agents-tool-not-denied",
+      repairCtx(configPath, cfg),
+    );
+
+    expect(result.status).toBe("repaired");
+    expect(result.changes).toEqual([
+      "Added edit to agents.entries.reviewer.tools.deny for policy conformance.",
+      "Added write to agents.entries.reviewer.tools.deny for policy conformance.",
+    ]);
+    expect(result.remainingFindings).toEqual([]);
+    expect(result.config.agents?.entries?.reviewer).toMatchObject({
+      tools: { deny: ["exec", "edit", "write"] },
+    });
+  });
+
   it("skips scoped required deny repairs that would mutate root tools deny", async () => {
     const cfg = {
       ...cfgWithPolicy({ workspaceRepairs: true }),

--- a/extensions/policy/src/doctor/sandbox-findings.ts
+++ b/extensions/policy/src/doctor/sandbox-findings.ts
@@ -233,7 +233,7 @@ function sandboxModeFindings(
         message: `${sandboxPostureLabel(entry)} uses unapproved sandbox mode '${entry.value ?? ""}'.`,
         requirement: `oc://${policyDocName}/${requirementBase}/requireMode`,
         fixHint:
-          "Set agents.defaults.sandbox.mode or agents.list[].sandbox.mode to an approved value.",
+          "Set agents.defaults.sandbox.mode or agents.entries.<id>.sandbox.mode to an approved value.",
       }),
     );
 }

--- a/extensions/policy/src/doctor/tool-findings.ts
+++ b/extensions/policy/src/doctor/tool-findings.ts
@@ -311,7 +311,7 @@ function toolRequiredDenyFindings(
           message: `${toolPostureLabel(entry)} does not deny required tool '${tool}'.`,
           requirement: `oc://${policyDocName}/${requirementBase}/denyTools`,
           fixHint:
-            "Add the tool or group to tools.deny/agents.list[].tools.deny, or update policy after review.",
+            "Add the tool or group to tools.deny/agents.entries.<id>.tools.deny, or update policy after review.",
         }),
       );
     }

--- a/extensions/policy/src/policy-state-core.ts
+++ b/extensions/policy/src/policy-state-core.ts
@@ -1,7 +1,12 @@
 // Policy plugin channel, model, MCP, and network evidence.
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import { asNonArrayRecord, isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { ocPathSegment, readBooleanPath } from "./policy-state-helpers.js";
+import {
+  collectPolicyConfiguredAgents,
+  ocPathSegment,
+  policyAgentPathSegment,
+  readBooleanPath,
+} from "./policy-state-helpers.js";
 import { RESERVED_CHANNEL_CONFIG_KEYS } from "./policy-state-types.js";
 import type {
   PolicyChannelEvidence,
@@ -236,18 +241,15 @@ function collectModelRefsFromAgentAllowlist(
     );
   }
 
-  const list = agents.list;
-  if (!Array.isArray(list)) {
-    return;
-  }
-  for (const [index, agent] of list.entries()) {
+  for (const configured of collectPolicyConfiguredAgents(agents)) {
+    const agent = configured.value;
     if (!isRecord(agent) || !isRecord(agent.models)) {
       continue;
     }
     collectModelRefsFromModelMap(
       refs,
       agent.models,
-      `oc://openclaw.config/agents/list/#${index}/models`,
+      `oc://openclaw.config/agents/${configured.container}/${policyAgentPathSegment(configured)}/models`,
     );
   }
 }

--- a/extensions/policy/src/policy-state-core.ts
+++ b/extensions/policy/src/policy-state-core.ts
@@ -4,7 +4,6 @@ import { asNonArrayRecord, isRecord } from "openclaw/plugin-sdk/string-coerce-ru
 import {
   collectPolicyConfiguredAgents,
   ocPathSegment,
-  policyAgentPathSegment,
   readBooleanPath,
 } from "./policy-state-helpers.js";
 import { RESERVED_CHANNEL_CONFIG_KEYS } from "./policy-state-types.js";
@@ -246,11 +245,7 @@ function collectModelRefsFromAgentAllowlist(
     if (!isRecord(agent) || !isRecord(agent.models)) {
       continue;
     }
-    collectModelRefsFromModelMap(
-      refs,
-      agent.models,
-      `oc://openclaw.config/agents/${configured.container}/${policyAgentPathSegment(configured)}/models`,
-    );
+    collectModelRefsFromModelMap(refs, agent.models, `${configured.sourceBase}/models`);
   }
 }
 

--- a/extensions/policy/src/policy-state-data.ts
+++ b/extensions/policy/src/policy-state-data.ts
@@ -6,7 +6,11 @@ import {
   asNonArrayRecord,
   isRecord,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { ocPathSegment } from "./policy-state-helpers.js";
+import {
+  collectPolicyConfiguredAgents,
+  ocPathSegment,
+  policyAgentPathSegment,
+} from "./policy-state-helpers.js";
 import type {
   PolicyAuthProfileEvidence,
   PolicyDataHandlingEvidence,
@@ -156,34 +160,12 @@ function pushMemorySessionTranscriptIndexing(
   }
 
   const agents = asNonArrayRecord(cfg.agents);
-  const agentEntries = isRecord(agents.entries)
-    ? Object.entries(agents.entries).map(([entryId, value]) => ({
-        agentId: entryId,
-        container: "entries" as const,
-        pathId: entryId,
-        value,
-      }))
-    : [];
-  const legacyAgents = Array.isArray(agents.list)
-    ? agents.list.flatMap((value, index) => {
-        if (!isRecord(value)) {
-          return [];
-        }
-        return [
-          {
-            agentId: typeof value.id === "string" ? value.id : `agent-${index}`,
-            container: "list" as const,
-            pathId: String(index),
-            value,
-          },
-        ];
-      })
-    : [];
-  const configuredAgents = agentEntries.length > 0 ? agentEntries : legacyAgents;
+  const configuredAgents = collectPolicyConfiguredAgents(agents);
   if (configuredAgents.length === 0) {
     return;
   }
-  configuredAgents.forEach(({ agentId, container, pathId, value: rawAgent }) => {
+  configuredAgents.forEach((configured) => {
+    const { agentId, container, value: rawAgent } = configured;
     if (!isRecord(rawAgent)) {
       return;
     }
@@ -198,7 +180,7 @@ function pushMemorySessionTranscriptIndexing(
     }
     const explicit = memorySearchSessionTranscriptIndexingHasLocalConfig(memorySearch);
     const experimental = asNonArrayRecord(memorySearch?.experimental);
-    const pathSegment = container === "list" ? `#${pathId}` : ocPathSegment(pathId);
+    const pathSegment = policyAgentPathSegment(configured);
     entries.push({
       id: `${agentId}-memory-session-transcripts`,
       kind: "memorySessionTranscriptIndexing",

--- a/extensions/policy/src/policy-state-data.ts
+++ b/extensions/policy/src/policy-state-data.ts
@@ -6,11 +6,7 @@ import {
   asNonArrayRecord,
   isRecord,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  collectPolicyConfiguredAgents,
-  ocPathSegment,
-  policyAgentPathSegment,
-} from "./policy-state-helpers.js";
+import { collectPolicyConfiguredAgents, ocPathSegment } from "./policy-state-helpers.js";
 import type {
   PolicyAuthProfileEvidence,
   PolicyDataHandlingEvidence,
@@ -165,7 +161,7 @@ function pushMemorySessionTranscriptIndexing(
     return;
   }
   configuredAgents.forEach((configured) => {
-    const { agentId, container, value: rawAgent } = configured;
+    const { agentId, value: rawAgent } = configured;
     if (!isRecord(rawAgent)) {
       return;
     }
@@ -180,15 +176,14 @@ function pushMemorySessionTranscriptIndexing(
     }
     const explicit = memorySearchSessionTranscriptIndexingHasLocalConfig(memorySearch);
     const experimental = asNonArrayRecord(memorySearch?.experimental);
-    const pathSegment = policyAgentPathSegment(configured);
     entries.push({
       id: `${agentId}-memory-session-transcripts`,
       kind: "memorySessionTranscriptIndexing",
       source: explicit
         ? readBoolean(memorySearch?.rememberAcrossConversations) === undefined &&
           readBoolean(experimental.sessionMemory) !== undefined
-          ? `oc://openclaw.config/agents/${container}/${pathSegment}/memory/search/experimental/sessionMemory`
-          : `oc://openclaw.config/agents/${container}/${pathSegment}/memory/search/rememberAcrossConversations`
+          ? `${configured.sourceBase}/memory/search/experimental/sessionMemory`
+          : `${configured.sourceBase}/memory/search/rememberAcrossConversations`
         : "oc://openclaw.config/memory/search/rememberAcrossConversations",
       scope: "agent",
       agentId: normalizeAgentId(agentId),

--- a/extensions/policy/src/policy-state-helpers.ts
+++ b/extensions/policy/src/policy-state-helpers.ts
@@ -23,7 +23,7 @@ export function readBooleanPath(value: unknown, path: readonly string[]): boolea
 }
 
 /** One configured agent, from either the keyed `agents.entries` map or the legacy `agents.list` array. */
-export type PolicyConfiguredAgent = {
+type PolicyConfiguredAgent = {
   readonly agentId: string;
   readonly container: "entries" | "list";
   /** Key for `entries`, array index for `list`. Feed to {@link policyAgentPathSegment}. */

--- a/extensions/policy/src/policy-state-helpers.ts
+++ b/extensions/policy/src/policy-state-helpers.ts
@@ -26,11 +26,13 @@ export function collectPolicyConfiguredAgents(agents: Record<string, unknown>) {
   const entries = agents.entries;
   if (Object.hasOwn(agents, "entries") && entries !== undefined) {
     return isRecord(entries)
-      ? Object.entries(entries).map(([agentId, value]) => ({
-          agentId,
-          sourceBase: `oc://openclaw.config/agents/entries/${ocPathSegment(agentId)}`,
-          value,
-        }))
+      ? Object.entries(entries)
+          .toSorted(([a], [b]) => a.localeCompare(b))
+          .map(([agentId, value]) => ({
+            agentId,
+            sourceBase: `oc://openclaw.config/agents/entries/${ocPathSegment(agentId)}`,
+            value,
+          }))
       : [];
   }
   return Array.isArray(agents.list)

--- a/extensions/policy/src/policy-state-helpers.ts
+++ b/extensions/policy/src/policy-state-helpers.ts
@@ -21,3 +21,59 @@ export function readBooleanPath(value: unknown, path: readonly string[]): boolea
   }
   return typeof current === "boolean" ? current : undefined;
 }
+
+/** One configured agent, from either the keyed `agents.entries` map or the legacy `agents.list` array. */
+export type PolicyConfiguredAgent = {
+  readonly agentId: string;
+  readonly container: "entries" | "list";
+  /** Key for `entries`, array index for `list`. Feed to {@link policyAgentPathSegment}. */
+  readonly pathId: string;
+  readonly value: unknown;
+};
+
+/**
+ * Collect configured agents from `cfg.agents`, preferring the keyed `entries` map and
+ * falling back to the legacy `list` array.
+ *
+ * Scanners must go through this helper. Reading `agents.list` directly makes a scanner
+ * blind to every agent on configs that `doctor` has already migrated to `agents.entries`,
+ * which silently downgrades scoped policy rules to the global/default posture.
+ */
+export function collectPolicyConfiguredAgents(
+  agents: Record<string, unknown>,
+): readonly PolicyConfiguredAgent[] {
+  const entries = isRecord(agents.entries)
+    ? Object.entries(agents.entries).map(([entryId, value]) => ({
+        agentId: entryId,
+        container: "entries" as const,
+        pathId: entryId,
+        value,
+      }))
+    : [];
+  if (entries.length > 0) {
+    return entries;
+  }
+  return Array.isArray(agents.list)
+    ? agents.list.flatMap((value, index) => {
+        if (!isRecord(value)) {
+          return [];
+        }
+        return [
+          {
+            agentId:
+              typeof value.id === "string" && value.id.trim() !== ""
+                ? value.id.trim()
+                : `agent-${index}`,
+            container: "list" as const,
+            pathId: String(index),
+            value,
+          },
+        ];
+      })
+    : [];
+}
+
+/** Path segment for a configured agent: `#0` for legacy list indexes, escaped key for entries. */
+export function policyAgentPathSegment(agent: PolicyConfiguredAgent): string {
+  return agent.container === "list" ? `#${agent.pathId}` : ocPathSegment(agent.pathId);
+}

--- a/extensions/policy/src/policy-state-helpers.ts
+++ b/extensions/policy/src/policy-state-helpers.ts
@@ -22,58 +22,25 @@ export function readBooleanPath(value: unknown, path: readonly string[]): boolea
   return typeof current === "boolean" ? current : undefined;
 }
 
-/** One configured agent, from either the keyed `agents.entries` map or the legacy `agents.list` array. */
-type PolicyConfiguredAgent = {
-  readonly agentId: string;
-  readonly container: "entries" | "list";
-  /** Key for `entries`, array index for `list`. Feed to {@link policyAgentPathSegment}. */
-  readonly pathId: string;
-  readonly value: unknown;
-};
-
-/**
- * Collect configured agents from `cfg.agents`, preferring the keyed `entries` map and
- * falling back to the legacy `list` array.
- *
- * Scanners must go through this helper. Reading `agents.list` directly makes a scanner
- * blind to every agent on configs that `doctor` has already migrated to `agents.entries`,
- * which silently downgrades scoped policy rules to the global/default posture.
- */
-export function collectPolicyConfiguredAgents(
-  agents: Record<string, unknown>,
-): readonly PolicyConfiguredAgent[] {
-  const entries = isRecord(agents.entries)
-    ? Object.entries(agents.entries).map(([entryId, value]) => ({
-        agentId: entryId,
-        container: "entries" as const,
-        pathId: entryId,
+export function collectPolicyConfiguredAgents(agents: Record<string, unknown>) {
+  const entries = agents.entries;
+  if (Object.hasOwn(agents, "entries") && entries !== undefined) {
+    return isRecord(entries)
+      ? Object.entries(entries).map(([agentId, value]) => ({
+          agentId,
+          sourceBase: `oc://openclaw.config/agents/entries/${ocPathSegment(agentId)}`,
+          value,
+        }))
+      : [];
+  }
+  return Array.isArray(agents.list)
+    ? agents.list.map((value, index) => ({
+        agentId:
+          isRecord(value) && typeof value.id === "string" && value.id.trim() !== ""
+            ? value.id.trim()
+            : `agent-${index}`,
+        sourceBase: `oc://openclaw.config/agents/list/#${index}`,
         value,
       }))
     : [];
-  if (entries.length > 0) {
-    return entries;
-  }
-  return Array.isArray(agents.list)
-    ? agents.list.flatMap((value, index) => {
-        if (!isRecord(value)) {
-          return [];
-        }
-        return [
-          {
-            agentId:
-              typeof value.id === "string" && value.id.trim() !== ""
-                ? value.id.trim()
-                : `agent-${index}`,
-            container: "list" as const,
-            pathId: String(index),
-            value,
-          },
-        ];
-      })
-    : [];
-}
-
-/** Path segment for a configured agent: `#0` for legacy list indexes, escaped key for entries. */
-export function policyAgentPathSegment(agent: PolicyConfiguredAgent): string {
-  return agent.container === "list" ? `#${agent.pathId}` : ocPathSegment(agent.pathId);
 }

--- a/extensions/policy/src/policy-state-sandbox.ts
+++ b/extensions/policy/src/policy-state-sandbox.ts
@@ -5,7 +5,7 @@ import {
   asBoolean as readBoolean,
   normalizeOptionalString as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { collectPolicyConfiguredAgents, policyAgentPathSegment } from "./policy-state-helpers.js";
+import { collectPolicyConfiguredAgents } from "./policy-state-helpers.js";
 import { readStringArray } from "./policy-state-tool-posture.js";
 import type { PolicySandboxPostureEvidence } from "./policy-state-types.js";
 
@@ -33,16 +33,15 @@ export function scanPolicySandboxPosture(
     if (!isRecord(agent)) {
       return;
     }
-    const agentId = configured.agentId;
     const sandbox = asNonArrayRecord(agent.sandbox);
     pushSandboxPostureEvidence(entries, {
-      id: agentId,
+      id: configured.agentId,
       scope: "agent",
-      agentId,
+      agentId: configured.agentId,
       sandbox,
       inheritedSandbox: defaultSandbox,
       sharedSandboxScope: sandboxScopeIsShared(sandbox, defaultSandbox),
-      sourceBase: `oc://openclaw.config/agents/${configured.container}/${policyAgentPathSegment(configured)}/sandbox`,
+      sourceBase: `${configured.sourceBase}/sandbox`,
       inheritedSourceBase: "oc://openclaw.config/agents/defaults/sandbox",
     });
   });

--- a/extensions/policy/src/policy-state-sandbox.ts
+++ b/extensions/policy/src/policy-state-sandbox.ts
@@ -5,6 +5,7 @@ import {
   asBoolean as readBoolean,
   normalizeOptionalString as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { collectPolicyConfiguredAgents, policyAgentPathSegment } from "./policy-state-helpers.js";
 import { readStringArray } from "./policy-state-tool-posture.js";
 import type { PolicySandboxPostureEvidence } from "./policy-state-types.js";
 
@@ -27,22 +28,21 @@ export function scanPolicySandboxPosture(
     inheritedSourceBase: "oc://openclaw.config/agents/defaults/sandbox",
   });
 
-  const list = Array.isArray(agents.list) ? agents.list : [];
-  list.forEach((agent, index) => {
+  collectPolicyConfiguredAgents(agents).forEach((configured) => {
+    const agent = configured.value;
     if (!isRecord(agent)) {
       return;
     }
-    const agentId =
-      typeof agent.id === "string" && agent.id.trim() !== "" ? agent.id.trim() : undefined;
+    const agentId = configured.agentId;
     const sandbox = asNonArrayRecord(agent.sandbox);
     pushSandboxPostureEvidence(entries, {
-      id: agentId ?? `agent-${index}`,
+      id: agentId,
       scope: "agent",
       agentId,
       sandbox,
       inheritedSandbox: defaultSandbox,
       sharedSandboxScope: sandboxScopeIsShared(sandbox, defaultSandbox),
-      sourceBase: `oc://openclaw.config/agents/list/#${index}/sandbox`,
+      sourceBase: `oc://openclaw.config/agents/${configured.container}/${policyAgentPathSegment(configured)}/sandbox`,
       inheritedSourceBase: "oc://openclaw.config/agents/defaults/sandbox",
     });
   });

--- a/extensions/policy/src/policy-state-tool-posture.ts
+++ b/extensions/policy/src/policy-state-tool-posture.ts
@@ -4,7 +4,11 @@ import {
   asBoolean as readBoolean,
   normalizeOptionalString as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { ocPathSegment } from "./policy-state-helpers.js";
+import {
+  collectPolicyConfiguredAgents,
+  ocPathSegment,
+  policyAgentPathSegment,
+} from "./policy-state-helpers.js";
 import type { PolicyToolPostureEvidence } from "./policy-state-types.js";
 
 export function scanPolicyToolPosture(
@@ -26,22 +30,21 @@ export function scanPolicyToolPosture(
     inheritedSourceBase: "oc://openclaw.config/tools",
   });
 
-  const list = Array.isArray(agents.list) ? agents.list : [];
-  list.forEach((agent, index) => {
+  collectPolicyConfiguredAgents(agents).forEach((configured) => {
+    const agent = configured.value;
     if (!isRecord(agent)) {
       return;
     }
-    const agentId =
-      typeof agent.id === "string" && agent.id.trim() !== "" ? agent.id.trim() : undefined;
+    const agentId = configured.agentId;
     pushToolPostureEvidence(entries, {
-      id: agentId ?? `agent-${index}`,
+      id: agentId,
       scope: "agent",
       agentId,
       tools: asNonArrayRecord(agent.tools),
       inheritedTools: globalTools,
       sandbox: asNonArrayRecord(agent.sandbox),
       inheritedSandbox: defaultSandbox,
-      sourceBase: `oc://openclaw.config/agents/list/#${index}/tools`,
+      sourceBase: `oc://openclaw.config/agents/${configured.container}/${policyAgentPathSegment(configured)}/tools`,
       inheritedSourceBase: "oc://openclaw.config/tools",
     });
   });

--- a/extensions/policy/src/policy-state-tool-posture.ts
+++ b/extensions/policy/src/policy-state-tool-posture.ts
@@ -4,11 +4,7 @@ import {
   asBoolean as readBoolean,
   normalizeOptionalString as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  collectPolicyConfiguredAgents,
-  ocPathSegment,
-  policyAgentPathSegment,
-} from "./policy-state-helpers.js";
+import { collectPolicyConfiguredAgents, ocPathSegment } from "./policy-state-helpers.js";
 import type { PolicyToolPostureEvidence } from "./policy-state-types.js";
 
 export function scanPolicyToolPosture(
@@ -35,16 +31,15 @@ export function scanPolicyToolPosture(
     if (!isRecord(agent)) {
       return;
     }
-    const agentId = configured.agentId;
     pushToolPostureEvidence(entries, {
-      id: agentId,
+      id: configured.agentId,
       scope: "agent",
-      agentId,
+      agentId: configured.agentId,
       tools: asNonArrayRecord(agent.tools),
       inheritedTools: globalTools,
       sandbox: asNonArrayRecord(agent.sandbox),
       inheritedSandbox: defaultSandbox,
-      sourceBase: `oc://openclaw.config/agents/${configured.container}/${policyAgentPathSegment(configured)}/tools`,
+      sourceBase: `${configured.sourceBase}/tools`,
       inheritedSourceBase: "oc://openclaw.config/tools",
     });
   });

--- a/extensions/policy/src/policy-state-workspace.ts
+++ b/extensions/policy/src/policy-state-workspace.ts
@@ -4,7 +4,7 @@ import {
   isRecord,
   normalizeOptionalString as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { collectPolicyConfiguredAgents, policyAgentPathSegment } from "./policy-state-helpers.js";
+import { collectPolicyConfiguredAgents } from "./policy-state-helpers.js";
 import { AGENT_WORKSPACE_POLICY_TOOLS, readStringArray } from "./policy-state-tool-posture.js";
 import type { PolicyAgentWorkspaceEvidence } from "./policy-state-types.js";
 import { toolListCoversTool } from "./tool-policy-conformance.js";
@@ -35,21 +35,19 @@ export function scanPolicyAgentWorkspace(
     if (!isRecord(agent)) {
       return;
     }
-    const agentId = configured.agentId;
     const sandbox = asNonArrayRecord(agent.sandbox);
     const tools = asNonArrayRecord(agent.tools);
-    const agentBase = `oc://openclaw.config/agents/${configured.container}/${policyAgentPathSegment(configured)}`;
     pushAgentWorkspaceEvidence(entries, {
-      id: agentId,
+      id: configured.agentId,
       scope: "agent",
-      agentId,
+      agentId: configured.agentId,
       sandbox,
       inheritedSandbox: defaultSandbox,
       tools,
       inheritedTools: defaultTools,
-      workspaceSourceBase: agentBase,
+      workspaceSourceBase: configured.sourceBase,
       inheritedWorkspaceSourceBase: "oc://openclaw.config/agents/defaults",
-      toolsSourceBase: `${agentBase}/tools`,
+      toolsSourceBase: `${configured.sourceBase}/tools`,
       inheritedToolsSourceBase: "oc://openclaw.config/tools",
     });
   });

--- a/extensions/policy/src/policy-state-workspace.ts
+++ b/extensions/policy/src/policy-state-workspace.ts
@@ -4,6 +4,7 @@ import {
   isRecord,
   normalizeOptionalString as readString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { collectPolicyConfiguredAgents, policyAgentPathSegment } from "./policy-state-helpers.js";
 import { AGENT_WORKSPACE_POLICY_TOOLS, readStringArray } from "./policy-state-tool-posture.js";
 import type { PolicyAgentWorkspaceEvidence } from "./policy-state-types.js";
 import { toolListCoversTool } from "./tool-policy-conformance.js";
@@ -29,26 +30,26 @@ export function scanPolicyAgentWorkspace(
     inheritedToolsSourceBase: "oc://openclaw.config/tools",
   });
 
-  const list = Array.isArray(agents.list) ? agents.list : [];
-  list.forEach((agent, index) => {
+  collectPolicyConfiguredAgents(agents).forEach((configured) => {
+    const agent = configured.value;
     if (!isRecord(agent)) {
       return;
     }
-    const agentId =
-      typeof agent.id === "string" && agent.id.trim() !== "" ? agent.id.trim() : undefined;
+    const agentId = configured.agentId;
     const sandbox = asNonArrayRecord(agent.sandbox);
     const tools = asNonArrayRecord(agent.tools);
+    const agentBase = `oc://openclaw.config/agents/${configured.container}/${policyAgentPathSegment(configured)}`;
     pushAgentWorkspaceEvidence(entries, {
-      id: agentId ?? `agent-${index}`,
+      id: agentId,
       scope: "agent",
       agentId,
       sandbox,
       inheritedSandbox: defaultSandbox,
       tools,
       inheritedTools: defaultTools,
-      workspaceSourceBase: `oc://openclaw.config/agents/list/#${index}`,
+      workspaceSourceBase: agentBase,
       inheritedWorkspaceSourceBase: "oc://openclaw.config/agents/defaults",
-      toolsSourceBase: `oc://openclaw.config/agents/list/#${index}/tools`,
+      toolsSourceBase: `${agentBase}/tools`,
       inheritedToolsSourceBase: "oc://openclaw.config/tools",
     });
   });

--- a/extensions/policy/src/policy-state.test.ts
+++ b/extensions/policy/src/policy-state.test.ts
@@ -1,8 +1,6 @@
 // Policy tests cover policy state plugin behavior.
 import { describe, expect, it } from "vitest";
 import { scanPolicySandboxPosture } from "./policy-state-sandbox.js";
-import { scanPolicyToolPosture } from "./policy-state-tool-posture.js";
-import { scanPolicyAgentWorkspace } from "./policy-state-workspace.js";
 import { collectPolicyEvidence } from "./policy-state.js";
 
 const scanPolicyChannels = (cfg: Record<string, unknown>) => collectPolicyEvidence(cfg).channels;
@@ -15,17 +13,14 @@ async function scanPolicyTools(raw: string) {
 const scanPolicyExecApprovals = (raw: string) =>
   collectPolicyEvidence({}, { execApprovalsRaw: raw }).execApprovals ?? [];
 
-describe("keyed agents.entries scanning", () => {
-  // Regression: these scanners only walked the legacy `agents.list` array, so on any
-  // config that `doctor` had already migrated to the keyed `agents.entries` map they
-  // produced zero per-agent evidence. Scoped policy rules then fell back to the
-  // global/default posture, silently reporting a locked-down agent as unconstrained.
+describe("configured agent scanning", () => {
   const keyedConfig = {
     tools: { elevated: { enabled: true } },
     agents: {
       defaults: { sandbox: { mode: "off" } },
       entries: {
         guest: {
+          models: { "openai/gpt-5.6-luna": {} },
           sandbox: { mode: "all", workspaceAccess: "none" },
           tools: { deny: ["exec"], elevated: { enabled: false } },
         },
@@ -33,9 +28,9 @@ describe("keyed agents.entries scanning", () => {
     },
   };
 
-  it("reports sandbox posture for agents.entries", () => {
-    const evidence = scanPolicySandboxPosture(keyedConfig);
-    expect(evidence).toEqual(
+  it("uses agents.entries across policy evidence", () => {
+    const evidence = collectPolicyEvidence(keyedConfig);
+    expect(evidence.sandboxPosture).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           kind: "mode",
@@ -46,14 +41,10 @@ describe("keyed agents.entries scanning", () => {
         }),
       ]),
     );
-  });
-
-  it("reports tool posture for agents.entries", () => {
-    const evidence = scanPolicyToolPosture(keyedConfig);
     expect(
-      evidence.filter((entry) => entry.scope === "agent" && entry.agentId === "guest"),
+      evidence.toolPosture?.filter((entry) => entry.scope === "agent" && entry.agentId === "guest"),
     ).not.toHaveLength(0);
-    expect(evidence).toEqual(
+    expect(evidence.toolPosture).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           scope: "agent",
@@ -63,11 +54,7 @@ describe("keyed agents.entries scanning", () => {
         }),
       ]),
     );
-  });
-
-  it("reports workspace posture for agents.entries", () => {
-    const evidence = scanPolicyAgentWorkspace(keyedConfig);
-    expect(evidence).toEqual(
+    expect(evidence.agentWorkspace).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           scope: "agent",
@@ -77,16 +64,28 @@ describe("keyed agents.entries scanning", () => {
         }),
       ]),
     );
+    expect(evidence.modelRefs).toContainEqual({
+      ref: "openai/gpt-5.6-luna",
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      source: 'oc://openclaw.config/agents/entries/guest/models/"openai/gpt-5.6-luna"',
+    });
   });
 
-  it("still scans the legacy agents.list array", () => {
-    const evidence = scanPolicySandboxPosture({
+  it("still uses legacy agents.list across policy evidence", () => {
+    const evidence = collectPolicyEvidence({
       agents: {
         defaults: { sandbox: { mode: "off" } },
-        list: [{ id: "legacy", sandbox: { mode: "all" } }],
+        list: [
+          {
+            id: "legacy",
+            models: { "openai/gpt-5.6-luna": {} },
+            sandbox: { mode: "all" },
+          },
+        ],
       },
     });
-    expect(evidence).toEqual(
+    expect(evidence.sandboxPosture).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           kind: "mode",
@@ -96,6 +95,24 @@ describe("keyed agents.entries scanning", () => {
           source: "oc://openclaw.config/agents/list/#0/sandbox/mode",
         }),
       ]),
+    );
+    expect(evidence.modelRefs).toContainEqual(
+      expect.objectContaining({
+        ref: "openai/gpt-5.6-luna",
+        source: 'oc://openclaw.config/agents/list/#0/models/"openai/gpt-5.6-luna"',
+      }),
+    );
+  });
+
+  it("does not fall back to stale agents.list when entries owns the roster", () => {
+    const evidence = collectPolicyEvidence({
+      agents: {
+        entries: {},
+        list: [{ id: "legacy", sandbox: { mode: "all" } }],
+      },
+    });
+    expect(evidence.sandboxPosture).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ agentId: "legacy" })]),
     );
   });
 

--- a/extensions/policy/src/policy-state.test.ts
+++ b/extensions/policy/src/policy-state.test.ts
@@ -1,7 +1,11 @@
 // Policy tests cover policy state plugin behavior.
 import { describe, expect, it } from "vitest";
 import { scanPolicySandboxPosture } from "./policy-state-sandbox.js";
-import { collectPolicyEvidence } from "./policy-state.js";
+import {
+  collectPolicyEvidence,
+  createPolicyAttestation,
+  policyDocumentHash,
+} from "./policy-state.js";
 
 const scanPolicyChannels = (cfg: Record<string, unknown>) => collectPolicyEvidence(cfg).channels;
 
@@ -113,6 +117,26 @@ describe("configured agent scanning", () => {
     });
     expect(evidence.sandboxPosture).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ agentId: "legacy" })]),
+    );
+  });
+
+  it("keeps attestations stable across keyed entry order", () => {
+    const first = {
+      alpha: { models: { "openai/gpt-5.6-luna": {} } },
+      omega: { models: { "openai/gpt-5.6-luna": {} } },
+    };
+    const attestationHash = (entries: Record<string, unknown>) =>
+      createPolicyAttestation({
+        ok: true,
+        checkedAt: new Date(0).toISOString(),
+        policyPath: "policy.jsonc",
+        policyHash: policyDocumentHash({}),
+        evidence: collectPolicyEvidence({ agents: { entries } }),
+        findings: [],
+      }).attestationHash;
+
+    expect(attestationHash(first)).toBe(
+      attestationHash({ omega: first.omega, alpha: first.alpha }),
     );
   });
 

--- a/extensions/policy/src/policy-state.test.ts
+++ b/extensions/policy/src/policy-state.test.ts
@@ -1,6 +1,8 @@
 // Policy tests cover policy state plugin behavior.
 import { describe, expect, it } from "vitest";
 import { scanPolicySandboxPosture } from "./policy-state-sandbox.js";
+import { scanPolicyToolPosture } from "./policy-state-tool-posture.js";
+import { scanPolicyAgentWorkspace } from "./policy-state-workspace.js";
 import { collectPolicyEvidence } from "./policy-state.js";
 
 const scanPolicyChannels = (cfg: Record<string, unknown>) => collectPolicyEvidence(cfg).channels;
@@ -12,6 +14,109 @@ async function scanPolicyTools(raw: string) {
 
 const scanPolicyExecApprovals = (raw: string) =>
   collectPolicyEvidence({}, { execApprovalsRaw: raw }).execApprovals ?? [];
+
+describe("keyed agents.entries scanning", () => {
+  // Regression: these scanners only walked the legacy `agents.list` array, so on any
+  // config that `doctor` had already migrated to the keyed `agents.entries` map they
+  // produced zero per-agent evidence. Scoped policy rules then fell back to the
+  // global/default posture, silently reporting a locked-down agent as unconstrained.
+  const keyedConfig = {
+    tools: { elevated: { enabled: true } },
+    agents: {
+      defaults: { sandbox: { mode: "off" } },
+      entries: {
+        guest: {
+          sandbox: { mode: "all", workspaceAccess: "none" },
+          tools: { deny: ["exec"], elevated: { enabled: false } },
+        },
+      },
+    },
+  };
+
+  it("reports sandbox posture for agents.entries", () => {
+    const evidence = scanPolicySandboxPosture(keyedConfig);
+    expect(evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "mode",
+          scope: "agent",
+          agentId: "guest",
+          value: "all",
+          source: "oc://openclaw.config/agents/entries/guest/sandbox/mode",
+        }),
+      ]),
+    );
+  });
+
+  it("reports tool posture for agents.entries", () => {
+    const evidence = scanPolicyToolPosture(keyedConfig);
+    expect(
+      evidence.filter((entry) => entry.scope === "agent" && entry.agentId === "guest"),
+    ).not.toHaveLength(0);
+    expect(evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          scope: "agent",
+          agentId: "guest",
+          source: "oc://openclaw.config/agents/entries/guest/tools/elevated/enabled",
+          value: false,
+        }),
+      ]),
+    );
+  });
+
+  it("reports workspace posture for agents.entries", () => {
+    const evidence = scanPolicyAgentWorkspace(keyedConfig);
+    expect(evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          scope: "agent",
+          agentId: "guest",
+          source: "oc://openclaw.config/agents/entries/guest/sandbox/workspaceAccess",
+          value: "none",
+        }),
+      ]),
+    );
+  });
+
+  it("still scans the legacy agents.list array", () => {
+    const evidence = scanPolicySandboxPosture({
+      agents: {
+        defaults: { sandbox: { mode: "off" } },
+        list: [{ id: "legacy", sandbox: { mode: "all" } }],
+      },
+    });
+    expect(evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "mode",
+          scope: "agent",
+          agentId: "legacy",
+          value: "all",
+          source: "oc://openclaw.config/agents/list/#0/sandbox/mode",
+        }),
+      ]),
+    );
+  });
+
+  it("escapes entry keys that are not bare identifiers", () => {
+    const evidence = scanPolicySandboxPosture({
+      agents: {
+        defaults: { sandbox: { mode: "off" } },
+        entries: { "team/qa": { sandbox: { mode: "all" } } },
+      },
+    });
+    expect(evidence).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "mode",
+          agentId: "team/qa",
+          source: 'oc://openclaw.config/agents/entries/"team/qa"/sandbox/mode',
+        }),
+      ]),
+    );
+  });
+});
 
 describe("scanPolicySandboxPosture", () => {
   it("keeps explicit Podman identity while exposing shared container settings", () => {


### PR DESCRIPTION
## What Problem This Solves

Policy scanned per-agent sandbox, tool, workspace, data-handling, and model settings from the legacy `agents.list` array. Valid OpenClaw config uses keyed `agents.entries`. Scoped checks therefore found no matching agent evidence and silently judged the global or default posture instead.

## Why This Change Was Made

One Policy-local enumerator now owns both supported roster shapes. `agents.entries` wins when present, which matches the canonical core roster owner. `agents.list` remains available for legacy doctor input when keyed entries are absent.

Every Policy evidence scanner carries the enumerator's exact agent ID and config source. Repair findings and metadata point to `agents.entries.<id>`, and the automatic repair test proves that keyed deny repairs write the keyed entry.

## User Impact

`openclaw policy check --agent <id>` now evaluates that agent's actual sandbox, tool, workspace, model, and data-handling posture. A locked-down keyed agent no longer inherits false global/default findings.

Existing accepted Policy attestation hashes can change because the evidence now includes keyed agents. Operators who pin `expectedAttestationHash` must review and accept the new clean attestation.

## Maintainer Decision

The maintainer accepts this intentional attestation change. Keep the existing manual review and re-pin flow. Do not add a dual hash, compatibility shim, automatic acceptance, or new config flag.

## Evidence

- Exact current main at `fcdb3b3bd2e1dea28b5295173e95c45a8edb8d5d`: the real Policy CLI returned five false global/default findings and emitted no `guest` evidence.
- Exact head `4e05b2c0906a7c25dc2ac0afa4c2a4f21c0ee3f9`: the same CLI scenario returned zero findings and emitted 6 workspace, 9 tool, and 5 sandbox evidence records for `guest`.
- Anti-cheat: changing only the keyed `guest` sandbox mode and deny list produced four findings that named `guest` and targeted `agents.entries.guest`.
- Regression proof on exact main: four keyed tests failed for the intended missing-evidence and missing-repair reasons; the legacy-list case passed.
- Reversed keyed-entry order produced different attestation hashes before the ID sort and identical hashes after it.
- `node scripts/run-vitest.mjs extensions/policy`: 13 files and 400 tests passed.
- Targeted formatting and type-aware Oxlint passed.
- Max-lines, assertion-safety, coercion-helper, import-cycle, and whitespace guards passed.
- Production: +62/-67, net -5. Tests and test support: +183/-2, net +181.
- Falc0n did not run TypeScript typecheck. Exact-head CLI build and live proof ran on Blacksmith Testbox.
