### PR TITLE
test: trim UI and tooling test seams

### DIFF
--- a/scripts/e2e/telegram-desktop-recorder.ts
+++ b/scripts/e2e/telegram-desktop-recorder.ts
@@ -178,7 +178,7 @@ eval "$(xdotool getwindowgeometry --shell "$win")"
 printf '%s %s %s %s\n' "$X" "$Y" "$WIDTH" "$HEIGHT"`;
 }
 
-export function renderHideTelegramWindow(): string {
+function renderHideTelegramWindow(): string {
   return `set -euo pipefail
 export DISPLAY=:99
 win="$(wmctrl -lx | awk 'tolower($0) ~ /telegramdesktop/ {print $1; exit}')"

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -350,7 +350,6 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     );
     expect(workflowText).toContain("dispatcherSources.has(inputs.request_source)");
     expect(workflowText).toContain('requestSource === "clawsweeper_label"');
-    expect(workflowText).toContain("pr.head.repo.full_name !== `${owner}/${repo}`");
     expect(workflowText).toContain("allow-bot-users: github-actions[bot]");
     expect(workflowText).not.toContain("allow-bot-users: github-actions[bot],clawsweeper[bot]");
     expect(workflowText).toContain("inputs.approved_head_sha !== candidateRevision");
@@ -462,7 +461,6 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(workflow.on?.workflow_dispatch?.inputs?.publish_artifact_name?.required).toBe(false);
     expect(workflow.on?.workflow_dispatch?.inputs?.publish_run_id?.required).toBe(false);
     expect(captureJob?.if).toContain("needs.resolve_request.outputs.publish_artifact_name == ''");
-    expect(captureJob?.if).toContain("needs.resolve_request.outputs.visibility_decision != 'skip'");
     expect(workflow.jobs?.validate_refs).toBeUndefined();
     expect(publishJob?.if).toBe(
       "needs.resolve_request.outputs.should_run == 'true' && needs.resolve_request.outputs.publish_artifact_name != ''",
@@ -1071,7 +1069,6 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(prompt).toContain("start --repo-root <prepared-root>");
     expect(prompt).toContain("MANTIS_BASELINE_ROOT");
     expect(prompt).toContain("MANTIS_CANDIDATE_ROOT");
-    expect(prompt).not.toContain("--sut-container");
     expect(prompt).toContain('--baseline-repo-root "$GITHUB_WORKSPACE"');
     expect(prompt).toContain('--candidate-repo-root "$GITHUB_WORKSPACE"');
     expect(workflow).toContain(
@@ -1089,7 +1086,6 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(workflow).toContain('"$runtime_parent/attestations/$lane.json"');
     const attestationValidation =
       workflowStep("Restore and validate trusted lane evidence").run ?? "";
-    expect(attestationValidation).toContain('[[ "$lane_status" != "skipped" ]]');
     expect(attestationValidation).not.toContain('if [[ "$lane_status" == "skipped"');
     expect(attestationValidation.indexOf(".comparison[$lane].sha == $sha")).toBeLessThan(
       attestationValidation.indexOf('"$runtime_parent/attestations/$lane.json"'),

--- a/test/scripts/telegram-desktop-recorder.test.ts
+++ b/test/scripts/telegram-desktop-recorder.test.ts
@@ -17,7 +17,6 @@ import {
   type RecorderOperations,
   type RecorderSession,
   renderGoldenImagePreflight,
-  renderHideTelegramWindow,
   renderLaunchDesktop,
   renderPrepareQr,
   renderReadQrLink,
@@ -555,7 +554,6 @@ describe("Telegram Desktop recorder remote contract", () => {
     expect(openIndex).toBeGreaterThanOrEqual(0);
     expect(hideIndex).toBeGreaterThan(openIndex);
     expect(captureIndex).toBeGreaterThan(hideIndex);
-    expect(renderHideTelegramWindow()).toContain('xdotool windowminimize "$win"');
   });
 
   it("fetches the undecodable login screen when login attempts run out", async () => {

--- a/ui/src/app/lazy-shell-action.test.ts
+++ b/ui/src/app/lazy-shell-action.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./app-host.test-support.ts";
 import "./app-host.ts";
 import { DEBUG_OVERLAY_ELEMENT } from "./lazy-custom-element.ts";
-import { persistLazyShellAction, readLazyShellAction } from "./lazy-shell-action.ts";
+import { readLazyShellAction } from "./lazy-shell-action.ts";
 
 const storageKey = "openclaw:lazy-event";
 
@@ -33,18 +33,6 @@ async function withConnectedShell(shell: ShellLifecycle, run: () => void | Promi
 afterEach(resetAppHostTestGlobals);
 
 describe("lazy shell action storage", () => {
-  it("round-trips a closed structured panel action", () => {
-    const storage = createStorageMock();
-    const action = {
-      eventType: TERMINAL_PANEL_TOGGLE_EVENT,
-      detail: { dock: "right", open: true },
-    } as const;
-    vi.stubGlobal("sessionStorage", storage);
-
-    persistLazyShellAction(action);
-    expect(readLazyShellAction()).toEqual(action);
-  });
-
   it.each([
     "{",
     JSON.stringify({ eventType: COMMAND_PALETTE_OPEN_EVENT, extra: true }),

--- a/ui/src/components/app-sidebar.lineage-freshness.test.ts
+++ b/ui/src/components/app-sidebar.lineage-freshness.test.ts
@@ -76,7 +76,6 @@ describe("sidebar routed-lineage freshness", () => {
         },
       ),
     );
-    harness.reconcile.mockClear();
     harness.publishList({ result: result(offline) });
 
     expect(sidebar.sessionData.activeSessionLineageSelectedRow).toMatchObject({
@@ -84,17 +83,5 @@ describe("sidebar routed-lineage freshness", () => {
       derivedTitle: "My device session",
       lastMessagePreview: "Most recent message",
     });
-    await waitForFast(() =>
-      expect(harness.reconcile).toHaveBeenCalledWith(
-        expect.objectContaining({
-          placement: expect.objectContaining({ runner: { kind: "device", status: "offline" } }),
-        }),
-        result(offline).defaults,
-        {
-          archivedFilter: "all",
-          sourceCanonicalListRevision: harness.sessions.canonicalListRevision,
-        },
-      ),
-    );
   });
 });

--- a/ui/src/lib/sessions/index-supplemental-reconcile.test.ts
+++ b/ui/src/lib/sessions/index-supplemental-reconcile.test.ts
@@ -114,7 +114,6 @@ describe("supplemental session reconciliation", () => {
     const sessions = capabilityWithList(sessionsResult([canonical], 10));
     const sourceCanonicalListRevision = sessions.canonicalListRevision;
     await sessions.refresh({ force: true });
-    const reconcile = vi.spyOn(sessions, "reconcile");
     const cached = {
       ...canonical,
       updatedAt: 20,
@@ -141,11 +140,6 @@ describe("supplemental session reconciliation", () => {
       sourceCanonicalListRevision,
     );
 
-    expect(reconcile).toHaveBeenCalledWith(
-      expect.objectContaining({ placement: placement("offline") }),
-      sessions.state.result?.defaults,
-      { archivedFilter: "all", sourceCanonicalListRevision },
-    );
     expect(sessions.state.result?.sessions[0]?.placement).toEqual(placement("offline"));
     expect(owner.activeSessionLineageSelectedRow).toMatchObject({
       placement: placement("offline"),
@@ -159,7 +153,6 @@ describe("supplemental session reconciliation", () => {
     const sessions = capabilityWithList(sessionsResult([], 10));
     const sourceCanonicalListRevision = sessions.canonicalListRevision;
     await sessions.refresh({ force: true });
-    const reconcile = vi.spyOn(sessions, "reconcile");
     const archived = {
       key: "agent:main:archived-routed",
       kind: "direct" as const,
@@ -182,10 +175,6 @@ describe("supplemental session reconciliation", () => {
       sourceCanonicalListRevision,
     );
 
-    expect(reconcile).toHaveBeenCalledWith(archived, sessions.state.result?.defaults, {
-      archivedFilter: "all",
-      sourceCanonicalListRevision,
-    });
     expect(sessions.state.result?.sessions).toEqual([archived]);
     sessions.dispose();
   });


### PR DESCRIPTION
## What Problem This Solves

UI and tooling suites had accumulated a paired write/read round trip, exact assertions on private reconciliation calls, duplicated workflow-string checks, and a direct helper assertion that kept an internal recorder renderer exported. These checks were weaker than the observable state and emitted-command coverage beside them.

## Why This Change Was Made

This removes the self-generated lazy-action round trip, keeps session lineage assertions on canonical placement and presentation state instead of private call shape, and deletes exact Mantis workflow checks that remain in their narrowly named owner tests. The Telegram recorder test continues to prove the real open → minimize → capture ordering, allowing the window-hide renderer to return to module-private scope.

## User Impact

No user-visible behavior changes. UI recovery, session reconciliation, Telegram capture privacy ordering, and Mantis workflow policy remain covered at their behavior-owning boundaries.

AI-assisted: yes.

## Evidence

- Focused 7-file run — 73 tests passed across tooling, UI, and mocked browser E2E shards.
- `pnpm test:changed` — 66 tests passed across 2 Vitest shards.
- `pnpm check:changed` — passed formatting, UI i18n verification, typechecking, lint, script erasability, dead-export scans, Docker boundaries, and repository guards.
- `git diff --check` — clean.
- Fresh structured autoreview — no accepted or actionable findings.

Production/tooling delta: one visibility-only substitution (`+1/-1`). Test delta: `+1/-43`. No screenshots are needed because runtime and rendered behavior are unchanged.
