### PR TITLE
feat: persist bounded transcript display rows

### DIFF
--- a/docs/.generated/sqlite-session-transcript-schema-baseline.sha256
+++ b/docs/.generated/sqlite-session-transcript-schema-baseline.sha256
@@ -1,1 +1,1 @@
-fecbb8adccfa0be0b452f646d3bee8d5a17faeb2c2d8a2300fb75ef173c709cd  sqlite-session-transcript-schema-baseline.sql
+bcfdbb764d6e381d23ce1be8a2485310f065c660bc272dff6f244972dc400b9d  sqlite-session-transcript-schema-baseline.sql

--- a/docs/.generated/sqlite-session-transcript-schema-baseline.sha256
+++ b/docs/.generated/sqlite-session-transcript-schema-baseline.sha256
@@ -1,1 +1,1 @@
-73cfbac3e2ef8a75d561165d9798c805e0a8c726c1bcd1c814c7cae777194b2b  sqlite-session-transcript-schema-baseline.sql
+5620bb55c2d67cf3a061f47efef4564d8560953305220d6adb23ed809c07425f  sqlite-session-transcript-schema-baseline.sql

--- a/scripts/lib/sqlite-session-schema-baseline.ts
+++ b/scripts/lib/sqlite-session-schema-baseline.ts
@@ -38,6 +38,8 @@ const TARGET_TABLES = new Set([
   "transcript_event_identities",
   "session_transcript_index_state",
   "session_transcript_active_events",
+  "session_transcript_display_state",
+  "session_transcript_display_rows",
   "session_transcript_archives",
 ]);
 

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -646,7 +646,7 @@ describe("SQLite active transcript event projection", () => {
       touchSessionEntry: false,
     });
     await persistSessionTranscriptTurn(secondScope, {
-      messages: Array.from({ length: 5_000 }, (_, index) => ({
+      messages: Array.from({ length: 1_000 }, (_, index) => ({
         eventId: `slow-${index}`,
         parentId: index === 0 ? null : `slow-${index - 1}`,
         message: { role: "toolResult", content: "slow" },

--- a/src/config/sessions/session-accessor.sqlite-active-events.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-events.test.ts
@@ -800,7 +800,13 @@ describe("SQLite active transcript event projection", () => {
 
   it("skips the preparation worker when the projection is already current", async () => {
     await persistSessionTranscriptTurn(scope, {
-      messages: [{ eventId: "seed", message: { role: "user", content: "seed" } }],
+      messages: [
+        {
+          eventId: "seed",
+          maintainDisplayProjection: true,
+          message: { role: "user", content: "seed" },
+        },
+      ],
       touchSessionEntry: false,
     });
     queuedSessionWrite.mockClear();

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.test.ts
@@ -30,6 +30,7 @@ import {
 import { touchTranscriptMutationInTransaction } from "./session-accessor.sqlite-transcript-state.js";
 import { replaceTranscriptEvents } from "./session-accessor.sqlite-transcript-write.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import { waitForSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
 
 type TestTranscriptEvent = {
   id: string;
@@ -45,7 +46,14 @@ describe("SQLite transcript archive worker", () => {
     storePath = path.join(tempDir, "agents", "main", "sessions", "sessions.json");
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    const target = resolveSqliteTargetFromSessionStorePath(storePath);
+    if (target.path) {
+      await waitForSessionTranscriptIndexReconcile({
+        agentId: target.agentId ?? "main",
+        path: target.path,
+      });
+    }
     closeOpenClawAgentDatabasesForTest();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });

--- a/src/config/sessions/session-accessor.sqlite-canonical-repair.ts
+++ b/src/config/sessions/session-accessor.sqlite-canonical-repair.ts
@@ -25,12 +25,15 @@ import { bindSessionWindowEntryProjection } from "./session-accessor.sqlite-sess
 import { parseSessionEntryJson } from "./session-accessor.sqlite-status.js";
 import { ensureTranscriptGenerationInTransaction } from "./session-accessor.sqlite-transcript-state.js";
 import { canonicalSessionKeyMigrationRequiredError } from "./session-canonical-key.js";
-import { invalidateSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
+import { invalidateExistingSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
 import {
   deleteSessionTranscriptIndexInTransaction,
   reconcileSessionTranscriptIndexInTransaction,
 } from "./session-transcript-index.js";
-import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
+import {
+  startSessionTranscriptDisplayReconcile,
+  startSessionTranscriptIndexReconcile,
+} from "./session-transcript-reconcile.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import type { SessionEntry } from "./types.js";
 
@@ -473,10 +476,16 @@ function copySqliteSessionOwnedStateForRepair(params: {
     }
     // Every transcript projection follows the selected canonical source, including replacements
     // whose final sequence is unchanged or lower than the destination it supersedes.
-    invalidateSessionTranscriptDisplayInTransaction(params.destination.db, sessionId);
+    const displayProjectionInvalidated = invalidateExistingSessionTranscriptDisplayInTransaction(
+      params.destination.db,
+      sessionId,
+    );
     deleteSessionTranscriptIndexInTransaction(params.destination.db, sessionId);
     reconcileSessionTranscriptIndexInTransaction(params.destination.db, sessionId);
-    startSessionTranscriptIndexReconcile({
+    const startReconcile = displayProjectionInvalidated
+      ? startSessionTranscriptDisplayReconcile
+      : startSessionTranscriptIndexReconcile;
+    startReconcile({
       agentId: params.destination.agentId,
       path: params.destination.path,
       preferredSessionId: sessionId,

--- a/src/config/sessions/session-accessor.sqlite-canonical-repair.ts
+++ b/src/config/sessions/session-accessor.sqlite-canonical-repair.ts
@@ -25,10 +25,12 @@ import { bindSessionWindowEntryProjection } from "./session-accessor.sqlite-sess
 import { parseSessionEntryJson } from "./session-accessor.sqlite-status.js";
 import { ensureTranscriptGenerationInTransaction } from "./session-accessor.sqlite-transcript-state.js";
 import { canonicalSessionKeyMigrationRequiredError } from "./session-canonical-key.js";
+import { invalidateSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
 import {
   deleteSessionTranscriptIndexInTransaction,
   reconcileSessionTranscriptIndexInTransaction,
 } from "./session-transcript-index.js";
+import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
 import { normalizeStoreSessionKey } from "./store-entry.js";
 import type { SessionEntry } from "./types.js";
 
@@ -469,9 +471,16 @@ function copySqliteSessionOwnedStateForRepair(params: {
     if (!replaced) {
       continue;
     }
-    // Search and active-event tables are derived from transcript_events; force their canonical rebuild.
+    // Every transcript projection follows the selected canonical source, including replacements
+    // whose final sequence is unchanged or lower than the destination it supersedes.
+    invalidateSessionTranscriptDisplayInTransaction(params.destination.db, sessionId);
     deleteSessionTranscriptIndexInTransaction(params.destination.db, sessionId);
     reconcileSessionTranscriptIndexInTransaction(params.destination.db, sessionId);
+    startSessionTranscriptIndexReconcile({
+      agentId: params.destination.agentId,
+      path: params.destination.path,
+      preferredSessionId: sessionId,
+    });
     publishSessionEntryCacheInvalidation(params.destination);
   }
   // Membership is authorization state and follows the selected winner. Boards,

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -131,6 +131,7 @@ export type TranscriptMessageAppendOptions<TMessage> = {
   message: TMessage;
   now?: number;
   eventId?: string;
+  maintainDisplayProjection?: boolean;
   parentId?: string | null;
   prepareMessageAfterIdempotencyCheck?: (message: TMessage) => TMessage | undefined;
   useRawWhenLinear?: boolean;

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -10,6 +10,7 @@ import {
   openOpenClawAgentDatabase,
   runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
+import { ensureOpenClawAgentDisplayRowSchema } from "../../state/openclaw-agent-display-row-schema.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
   appendTranscriptMessage,
@@ -271,6 +272,7 @@ describe("SQLite session entry cache", () => {
       sessionId: "same-connection-non-entry-2",
       updatedAt: 1,
     });
+    ensureOpenClawAgentDisplayRowSchema(openOpenClawAgentDatabase(scope).db);
     const first = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
     await appendTranscriptMessage(

--- a/src/config/sessions/session-accessor.sqlite-import.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.ts
@@ -26,9 +26,12 @@ import {
   touchTranscriptMutationInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
 import { appendTranscriptEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
-import { invalidateSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
+import { invalidateExistingSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
 import { reconcileSessionTranscriptIndexInTransaction } from "./session-transcript-index.js";
-import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
+import {
+  startSessionTranscriptDisplayReconcile,
+  startSessionTranscriptIndexReconcile,
+} from "./session-transcript-reconcile.js";
 import type { SessionEntry } from "./types.js";
 
 /** Internal doctor/migration import target for one legacy session row. */
@@ -50,6 +53,7 @@ type SqliteSessionImportRowsParams = {
 
 /** Summary of rows written by an internal doctor/migration import. */
 type SqliteSessionImportRowsResult = {
+  displayProjectionInvalidated: boolean;
   sessionId: string;
   sessionKey: string;
   skippedExisting?: true;
@@ -84,6 +88,7 @@ function importSqliteSessionRowsInTransaction(
   prepared: ReturnType<typeof prepareSqliteSessionImport>,
 ): SqliteSessionImportRowsResult {
   const { params, resolved } = prepared;
+  let displayProjectionInvalidated = false;
   let transcriptEvents = 0;
   // Doctor may have staged another legacy alias in this database already. Inspect only this
   // exact import target; runtime-wide canonical validation runs after the import phase.
@@ -92,6 +97,7 @@ function importSqliteSessionRowsInTransaction(
   })?.entry;
   if (params.skipIfExists === true && currentEntry) {
     return {
+      displayProjectionInvalidated,
       sessionId: params.entry.sessionId,
       sessionKey: resolved.sessionKey,
       skippedExisting: true,
@@ -155,7 +161,10 @@ function importSqliteSessionRowsInTransaction(
       }
       transcriptEvents = exactTranscriptRows.length;
       reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
-      invalidateSessionTranscriptDisplayInTransaction(database.db, params.entry.sessionId);
+      displayProjectionInvalidated = invalidateExistingSessionTranscriptDisplayInTransaction(
+        database.db,
+        params.entry.sessionId,
+      );
       publishSessionEntryCacheInvalidation(database);
     }
   } else if (prepared.transcriptEvents) {
@@ -186,7 +195,10 @@ function importSqliteSessionRowsInTransaction(
     }
     reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
     if (transcriptEvents > 0) {
-      invalidateSessionTranscriptDisplayInTransaction(database.db, params.entry.sessionId);
+      displayProjectionInvalidated = invalidateExistingSessionTranscriptDisplayInTransaction(
+        database.db,
+        params.entry.sessionId,
+      );
     }
     publishSessionEntryCacheInvalidation(database);
   }
@@ -200,6 +212,7 @@ function importSqliteSessionRowsInTransaction(
     touchTranscriptMutationInTransaction(database, params.entry.sessionId);
   }
   return {
+    displayProjectionInvalidated,
     sessionId: params.entry.sessionId,
     sessionKey: resolved.sessionKey,
     transcriptEvents,
@@ -228,7 +241,10 @@ export async function importSqliteSessionRowsBatch(
     if (result.transcriptEvents === 0) {
       continue;
     }
-    startSessionTranscriptIndexReconcile({
+    const startReconcile = result.displayProjectionInvalidated
+      ? startSessionTranscriptDisplayReconcile
+      : startSessionTranscriptIndexReconcile;
+    startReconcile({
       ...toDatabaseOptions(resolved),
       preferredSessionId: result.sessionId,
     });

--- a/src/config/sessions/session-accessor.sqlite-import.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.ts
@@ -26,7 +26,9 @@ import {
   touchTranscriptMutationInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
 import { appendTranscriptEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import { invalidateSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
 import { reconcileSessionTranscriptIndexInTransaction } from "./session-transcript-index.js";
+import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
 import type { SessionEntry } from "./types.js";
 
 /** Internal doctor/migration import target for one legacy session row. */
@@ -153,6 +155,7 @@ function importSqliteSessionRowsInTransaction(
       }
       transcriptEvents = exactTranscriptRows.length;
       reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
+      invalidateSessionTranscriptDisplayInTransaction(database.db, params.entry.sessionId);
       publishSessionEntryCacheInvalidation(database);
     }
   } else if (prepared.transcriptEvents) {
@@ -172,6 +175,7 @@ function importSqliteSessionRowsInTransaction(
       if (
         appendTranscriptEventInTransaction(database, transcriptScope, event, {
           allowStoredAlias: true,
+          maintainDisplayProjection: false,
           scheduleProjectionReconcile: false,
           touchMutation: false,
         })
@@ -181,6 +185,9 @@ function importSqliteSessionRowsInTransaction(
       }
     }
     reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
+    if (transcriptEvents > 0) {
+      invalidateSessionTranscriptDisplayInTransaction(database.db, params.entry.sessionId);
+    }
     publishSessionEntryCacheInvalidation(database);
   }
   if (params.transcriptMtimeMs !== undefined) {
@@ -211,12 +218,22 @@ export async function importSqliteSessionRowsBatch(
   if (prepared.some((row) => row.resolved.path !== resolved.path)) {
     throw new Error("SQLite session import batch spans multiple stores");
   }
-  return await runExclusiveSqliteSessionWrite(resolved, async () =>
+  const results = await runExclusiveSqliteSessionWrite(resolved, async () =>
     runOpenClawAgentWriteTransaction(
       (database) => prepared.map((row) => importSqliteSessionRowsInTransaction(database, row)),
       toDatabaseOptions(resolved),
     ),
   );
+  for (const result of results) {
+    if (result.transcriptEvents === 0) {
+      continue;
+    }
+    startSessionTranscriptIndexReconcile({
+      ...toDatabaseOptions(resolved),
+      preferredSessionId: result.sessionId,
+    });
+  }
+  return results;
 }
 
 /** Imports one legacy session entry and its transcript rows for doctor migration. */

--- a/src/config/sessions/session-accessor.sqlite-import.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.ts
@@ -25,7 +25,9 @@ import {
   touchTranscriptMutationInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
 import { appendTranscriptEventInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import { invalidateSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
 import { reconcileSessionTranscriptIndexInTransaction } from "./session-transcript-index.js";
+import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
 import type { SessionEntry } from "./types.js";
 
 /** Internal doctor/migration import target for one legacy session row. */
@@ -151,6 +153,7 @@ function importSqliteSessionRowsInTransaction(
       }
       transcriptEvents = exactTranscriptRows.length;
       reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
+      invalidateSessionTranscriptDisplayInTransaction(database.db, params.entry.sessionId);
       publishSessionEntryCacheInvalidation(database);
     }
   } else if (prepared.transcriptEvents) {
@@ -170,6 +173,7 @@ function importSqliteSessionRowsInTransaction(
       if (
         appendTranscriptEventInTransaction(database, transcriptScope, event, {
           allowStoredAlias: true,
+          maintainDisplayProjection: false,
           scheduleProjectionReconcile: false,
           touchMutation: false,
         })
@@ -179,6 +183,9 @@ function importSqliteSessionRowsInTransaction(
       }
     }
     reconcileSessionTranscriptIndexInTransaction(database.db, params.entry.sessionId);
+    if (transcriptEvents > 0) {
+      invalidateSessionTranscriptDisplayInTransaction(database.db, params.entry.sessionId);
+    }
     publishSessionEntryCacheInvalidation(database);
   }
   if (params.transcriptMtimeMs !== undefined) {
@@ -209,12 +216,22 @@ export async function importSqliteSessionRowsBatch(
   if (prepared.some((row) => row.resolved.path !== resolved.path)) {
     throw new Error("SQLite session import batch spans multiple stores");
   }
-  return await runExclusiveSqliteSessionWrite(resolved, async () =>
+  const results = await runExclusiveSqliteSessionWrite(resolved, async () =>
     runOpenClawAgentWriteTransaction(
       (database) => prepared.map((row) => importSqliteSessionRowsInTransaction(database, row)),
       toDatabaseOptions(resolved),
     ),
   );
+  for (const result of results) {
+    if (result.transcriptEvents === 0) {
+      continue;
+    }
+    startSessionTranscriptIndexReconcile({
+      ...toDatabaseOptions(resolved),
+      preferredSessionId: result.sessionId,
+    });
+  }
+  return results;
 }
 
 /** Imports one legacy session entry and its transcript rows for doctor migration. */

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -44,6 +44,8 @@ type SessionSqliteDatabase = Pick<
   | "session_suggestions"
   | "session_transcript_archives"
   | "session_transcript_active_events"
+  | "session_transcript_display_rows"
+  | "session_transcript_display_state"
   | "session_transcript_index_state"
   | "session_windows"
   | "transcript_rewrite_watermarks"

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -43,6 +43,8 @@ type SessionSqliteDatabase = Pick<
   | "session_suggestions"
   | "session_transcript_archives"
   | "session_transcript_active_events"
+  | "session_transcript_display_rows"
+  | "session_transcript_display_state"
   | "session_transcript_index_state"
   | "session_windows"
   | "transcript_rewrite_watermarks"

--- a/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-message-append.ts
@@ -97,7 +97,9 @@ export function appendTranscriptMessageInTransaction<TMessage>(
   const messageId = options.eventId ?? randomUUID();
   const now = options.now ?? Date.now();
   const finalMessage = serializeForStorage(prepared);
-  ensureTranscriptHeader(database, resolved, options.cwd);
+  ensureTranscriptHeader(database, resolved, options.cwd, {
+    maintainDisplayProjection: options.maintainDisplayProjection === true ? true : undefined,
+  });
   const parentId = resolveTranscriptMessageAppendParent(database, resolved.sessionId, options);
   const event = {
     type: "message",
@@ -110,6 +112,7 @@ export function appendTranscriptMessageInTransaction<TMessage>(
     dedupeByMessageIdempotency:
       options.idempotencyLookup !== "caller-checked" &&
       options.idempotencyLookup !== "scan-assistant",
+    maintainDisplayProjection: options.maintainDisplayProjection === true ? true : undefined,
   });
   if (!appended && idempotencyKey && options.idempotencyLookup !== "caller-checked") {
     const existing = readTranscriptMessageByScopedIdempotencyKey(

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -29,6 +29,7 @@ import {
   rotateTranscriptGenerationInTransaction,
   touchTranscriptMutationInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
+import { invalidateSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
 import {
   deleteSessionTranscriptIndexInTransaction,
   indexAppendedTranscriptEventInTransaction,
@@ -49,6 +50,8 @@ export function appendTranscriptEventInTransaction(
   options: {
     allowStoredAlias?: boolean;
     dedupeByMessageIdempotency?: boolean;
+    /** Batch replacement/import owns one final display invalidation for all inserted rows. */
+    maintainDisplayProjection?: boolean;
     onProjectionReconcileNeeded?: () => void;
     scheduleProjectionReconcile?: boolean;
     touchMutation?: boolean;
@@ -95,6 +98,7 @@ export function appendTranscriptEventInTransaction(
     event: persistedEvent,
     eventId: identity?.eventId ?? null,
     createdAt,
+    maintainDisplayProjection: options.maintainDisplayProjection,
   });
   if (projectionNeedsRebuild) {
     options.onProjectionReconcileNeeded?.();
@@ -209,6 +213,7 @@ function appendTranscriptEventRowInTransaction(
     event: persistedEvent,
     eventId: identity?.eventId ?? null,
     createdAt,
+    maintainDisplayProjection: false,
   });
   if (!identity) {
     return true;
@@ -336,11 +341,13 @@ export function replaceSqliteTranscriptEventsInTransaction(
   if (events.length === 0) {
     if (deleted || previousGeneration) {
       rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
+      invalidateSessionTranscriptDisplayInTransaction(database.db, resolved.sessionId);
       recordTranscriptReplacementMutation(
         database,
         resolved.sessionId,
         preservedTranscriptUpdatedAt,
       );
+      scheduleTranscriptProjectionReconcile(database, resolved, true, {});
     }
     return;
   }
@@ -352,6 +359,7 @@ export function replaceSqliteTranscriptEventsInTransaction(
   } else {
     ensureTranscriptGenerationInTransaction(database, resolved.sessionId);
   }
+  invalidateSessionTranscriptDisplayInTransaction(database.db, resolved.sessionId);
   let seq = 0;
   const seenEventIds = new Set<string>();
   const seenMessageIdempotencyKeys = new Set<string>();
@@ -375,6 +383,7 @@ export function replaceSqliteTranscriptEventsInTransaction(
   if (deleted || seq > 0) {
     recordTranscriptReplacementMutation(database, resolved.sessionId, preservedTranscriptUpdatedAt);
     reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+    scheduleTranscriptProjectionReconcile(database, resolved, true, {});
   }
 }
 
@@ -426,8 +435,10 @@ export function rewriteSqliteTranscriptEventRowsInTransaction(
     }
   }
   rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
+  invalidateSessionTranscriptDisplayInTransaction(database.db, resolved.sessionId);
   touchTranscriptMutationInTransaction(database, resolved.sessionId);
   reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+  scheduleTranscriptProjectionReconcile(database, resolved, true, {});
 }
 
 // Text-only transcript repair: rewrites event_json for specific rows in place.
@@ -453,8 +464,14 @@ export function updateSqliteTranscriptEventJsonInTransaction(
     );
   }
   rotateTranscriptGenerationInTransaction(database, sessionId);
+  invalidateSessionTranscriptDisplayInTransaction(database.db, sessionId);
   deleteSessionTranscriptIndexInTransaction(database.db, sessionId);
   reconcileSessionTranscriptIndexInTransaction(database.db, sessionId);
+  startSessionTranscriptIndexReconcile({
+    agentId: database.agentId,
+    path: database.path,
+    preferredSessionId: sessionId,
+  });
   // Minimally advance transcript_updated_at (prev+1), NOT to now. This is a one-time maintenance
   // rewrite: bumping to now would reorder legacy sessions to the top of every recency view
   // (sqlite-history.ts orders by transcript_updated_at). But the watermark must still change,

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -29,13 +29,16 @@ import {
   rotateTranscriptGenerationInTransaction,
   touchTranscriptMutationInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
-import { invalidateSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
+import { invalidateExistingSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
 import {
   deleteSessionTranscriptIndexInTransaction,
   indexAppendedTranscriptEventInTransaction,
   reconcileSessionTranscriptIndexInTransaction,
 } from "./session-transcript-index.js";
-import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
+import {
+  startSessionTranscriptDisplayReconcile,
+  startSessionTranscriptIndexReconcile,
+} from "./session-transcript-reconcile.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
 import {
   isSessionTranscriptLeafControl,
@@ -50,7 +53,10 @@ export function appendTranscriptEventInTransaction(
   options: {
     allowStoredAlias?: boolean;
     dedupeByMessageIdempotency?: boolean;
-    /** Batch replacement/import owns one final display invalidation for all inserted rows. */
+    /**
+     * True maintains display rows incrementally. False means a batch caller owns
+     * one final invalidation. Omission invalidates adopted display state only.
+     */
     maintainDisplayProjection?: boolean;
     onProjectionReconcileNeeded?: () => void;
     scheduleProjectionReconcile?: boolean;
@@ -142,14 +148,18 @@ function scheduleTranscriptProjectionReconcile(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
   projectionNeedsRebuild: boolean,
-  options: { scheduleProjectionReconcile?: boolean },
+  options: { maintainDisplayProjection?: boolean; scheduleProjectionReconcile?: boolean },
 ): void {
   if (!projectionNeedsRebuild || options.scheduleProjectionReconcile === false) {
     return;
   }
   // setImmediate in the reconcile owner runs only after this synchronous
   // SQLite transaction commits, keeping full-tree work off the writer stack.
-  startSessionTranscriptIndexReconcile({
+  const startReconcile =
+    options.maintainDisplayProjection === true
+      ? startSessionTranscriptDisplayReconcile
+      : startSessionTranscriptIndexReconcile;
+  startReconcile({
     agentId: scope.agentId,
     path: database.path,
     preferredSessionId: scope.sessionId,
@@ -246,6 +256,7 @@ export function ensureTranscriptHeader(
   database: OpenClawAgentDatabase,
   scope: ResolvedTranscriptScope,
   cwd: string | undefined,
+  options: { maintainDisplayProjection?: boolean } = {},
 ): void {
   const db = getSessionKysely(database.db);
   const existing = executeSqliteQueryTakeFirstSync(
@@ -263,6 +274,7 @@ export function ensureTranscriptHeader(
     database,
     scope,
     createSessionTranscriptHeader({ cwd, sessionId: scope.sessionId }),
+    { maintainDisplayProjection: options.maintainDisplayProjection },
   );
 }
 
@@ -341,13 +353,18 @@ export function replaceSqliteTranscriptEventsInTransaction(
   if (events.length === 0) {
     if (deleted || previousGeneration) {
       rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
-      invalidateSessionTranscriptDisplayInTransaction(database.db, resolved.sessionId);
+      const displayProjectionInvalidated = invalidateExistingSessionTranscriptDisplayInTransaction(
+        database.db,
+        resolved.sessionId,
+      );
       recordTranscriptReplacementMutation(
         database,
         resolved.sessionId,
         preservedTranscriptUpdatedAt,
       );
-      scheduleTranscriptProjectionReconcile(database, resolved, true, {});
+      scheduleTranscriptProjectionReconcile(database, resolved, true, {
+        maintainDisplayProjection: displayProjectionInvalidated,
+      });
     }
     return;
   }
@@ -359,7 +376,10 @@ export function replaceSqliteTranscriptEventsInTransaction(
   } else {
     ensureTranscriptGenerationInTransaction(database, resolved.sessionId);
   }
-  invalidateSessionTranscriptDisplayInTransaction(database.db, resolved.sessionId);
+  const displayProjectionInvalidated = invalidateExistingSessionTranscriptDisplayInTransaction(
+    database.db,
+    resolved.sessionId,
+  );
   let seq = 0;
   const seenEventIds = new Set<string>();
   const seenMessageIdempotencyKeys = new Set<string>();
@@ -383,7 +403,9 @@ export function replaceSqliteTranscriptEventsInTransaction(
   if (deleted || seq > 0) {
     recordTranscriptReplacementMutation(database, resolved.sessionId, preservedTranscriptUpdatedAt);
     reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
-    scheduleTranscriptProjectionReconcile(database, resolved, true, {});
+    scheduleTranscriptProjectionReconcile(database, resolved, true, {
+      maintainDisplayProjection: displayProjectionInvalidated,
+    });
   }
 }
 
@@ -435,10 +457,15 @@ export function rewriteSqliteTranscriptEventRowsInTransaction(
     }
   }
   rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
-  invalidateSessionTranscriptDisplayInTransaction(database.db, resolved.sessionId);
+  const displayProjectionInvalidated = invalidateExistingSessionTranscriptDisplayInTransaction(
+    database.db,
+    resolved.sessionId,
+  );
   touchTranscriptMutationInTransaction(database, resolved.sessionId);
   reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
-  scheduleTranscriptProjectionReconcile(database, resolved, true, {});
+  scheduleTranscriptProjectionReconcile(database, resolved, true, {
+    maintainDisplayProjection: displayProjectionInvalidated,
+  });
 }
 
 // Text-only transcript repair: rewrites event_json for specific rows in place.
@@ -464,10 +491,16 @@ export function updateSqliteTranscriptEventJsonInTransaction(
     );
   }
   rotateTranscriptGenerationInTransaction(database, sessionId);
-  invalidateSessionTranscriptDisplayInTransaction(database.db, sessionId);
+  const displayProjectionInvalidated = invalidateExistingSessionTranscriptDisplayInTransaction(
+    database.db,
+    sessionId,
+  );
   deleteSessionTranscriptIndexInTransaction(database.db, sessionId);
   reconcileSessionTranscriptIndexInTransaction(database.db, sessionId);
-  startSessionTranscriptIndexReconcile({
+  const startReconcile = displayProjectionInvalidated
+    ? startSessionTranscriptDisplayReconcile
+    : startSessionTranscriptIndexReconcile;
+  startReconcile({
     agentId: database.agentId,
     path: database.path,
     preferredSessionId: sessionId,

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -29,6 +29,7 @@ import {
   rotateTranscriptGenerationInTransaction,
   touchTranscriptMutationInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
+import { invalidateSessionTranscriptDisplayInTransaction } from "./session-transcript-display.js";
 import {
   deleteSessionTranscriptIndexInTransaction,
   indexAppendedTranscriptEventInTransaction,
@@ -49,6 +50,8 @@ export function appendTranscriptEventInTransaction(
   options: {
     allowStoredAlias?: boolean;
     dedupeByMessageIdempotency?: boolean;
+    /** Batch replacement/import owns one final display invalidation for all inserted rows. */
+    maintainDisplayProjection?: boolean;
     onProjectionReconcileNeeded?: () => void;
     scheduleProjectionReconcile?: boolean;
     touchMutation?: boolean;
@@ -95,6 +98,7 @@ export function appendTranscriptEventInTransaction(
     event: persistedEvent,
     eventId: identity?.eventId ?? null,
     createdAt,
+    maintainDisplayProjection: options.maintainDisplayProjection,
   });
   if (projectionNeedsRebuild) {
     options.onProjectionReconcileNeeded?.();
@@ -209,6 +213,7 @@ function appendTranscriptEventRowInTransaction(
     event: persistedEvent,
     eventId: identity?.eventId ?? null,
     createdAt,
+    maintainDisplayProjection: false,
   });
   if (!identity) {
     return true;
@@ -338,11 +343,13 @@ export function replaceSqliteTranscriptEventsInTransaction(
   if (events.length === 0) {
     if (deleted || previousGeneration) {
       rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
+      invalidateSessionTranscriptDisplayInTransaction(database.db, resolved.sessionId);
       recordTranscriptReplacementMutation(
         database,
         resolved.sessionId,
         preservedTranscriptUpdatedAt,
       );
+      scheduleTranscriptProjectionReconcile(database, resolved, true, {});
     }
     return;
   }
@@ -354,6 +361,7 @@ export function replaceSqliteTranscriptEventsInTransaction(
   } else {
     ensureTranscriptGenerationInTransaction(database, resolved.sessionId);
   }
+  invalidateSessionTranscriptDisplayInTransaction(database.db, resolved.sessionId);
   let seq = 0;
   const seenEventIds = new Set<string>();
   const seenMessageIdempotencyKeys = new Set<string>();
@@ -377,6 +385,7 @@ export function replaceSqliteTranscriptEventsInTransaction(
   if (deleted || seq > 0) {
     recordTranscriptReplacementMutation(database, resolved.sessionId, preservedTranscriptUpdatedAt);
     reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+    scheduleTranscriptProjectionReconcile(database, resolved, true, {});
   }
 }
 
@@ -428,8 +437,10 @@ export function rewriteSqliteTranscriptEventRowsInTransaction(
     }
   }
   rotateTranscriptGenerationInTransaction(database, resolved.sessionId);
+  invalidateSessionTranscriptDisplayInTransaction(database.db, resolved.sessionId);
   touchTranscriptMutationInTransaction(database, resolved.sessionId);
   reconcileSessionTranscriptIndexInTransaction(database.db, resolved.sessionId);
+  scheduleTranscriptProjectionReconcile(database, resolved, true, {});
 }
 
 // Text-only transcript repair: rewrites event_json for specific rows in place.
@@ -455,8 +466,14 @@ export function updateSqliteTranscriptEventJsonInTransaction(
     );
   }
   rotateTranscriptGenerationInTransaction(database, sessionId);
+  invalidateSessionTranscriptDisplayInTransaction(database.db, sessionId);
   deleteSessionTranscriptIndexInTransaction(database.db, sessionId);
   reconcileSessionTranscriptIndexInTransaction(database.db, sessionId);
+  startSessionTranscriptIndexReconcile({
+    agentId: database.agentId,
+    path: database.path,
+    preferredSessionId: sessionId,
+  });
   // Minimally advance transcript_updated_at (prev+1), NOT to now. This is a one-time maintenance
   // rewrite: bumping to now would reorder legacy sessions to the top of every recency view
   // (sqlite-history.ts orders by transcript_updated_at). But the watermark must still change,

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -305,6 +305,8 @@ export type TranscriptMessageAppendOptions<TMessage> = {
   now?: number;
   /** Existing transcript event id owned by a caller with its own session tree. */
   eventId?: string;
+  /** Opt into synchronous display projection maintenance for an adopted display reader. */
+  maintainDisplayProjection?: boolean;
   /** Existing parent id owned by a caller with its own session tree. */
   parentId?: string | null;
   /** Optional finalizer that runs after duplicate detection but before persistence. */

--- a/src/config/sessions/session-transcript-display.test.ts
+++ b/src/config/sessions/session-transcript-display.test.ts
@@ -1,0 +1,596 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  appendTranscriptEvent,
+  persistSessionTranscriptTurn,
+  upsertSessionEntryCore,
+} from "./session-accessor.js";
+import { copySqliteSessionOwnedStateForCanonicalRepair } from "./session-accessor.sqlite-canonical-repair.js";
+import { importSqliteSessionRows } from "./session-accessor.sqlite-import.js";
+import {
+  replaceTranscriptEvents,
+  rewriteTranscriptEventRowsExact,
+  trimTranscriptForManualCompact,
+} from "./session-accessor.sqlite-transcript-write.js";
+import {
+  readSessionTranscriptDisplayRowsInTransaction,
+  readSessionTranscriptDisplayState,
+} from "./session-transcript-display.js";
+import { waitForSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+type DisplayStateRow = {
+  generation: string;
+  indexed_seq: number;
+  needs_rebuild: number;
+  row_count: number;
+};
+
+type DisplayRow = {
+  display_ordinal: number;
+  kind: "assistant" | "compaction" | "opaque" | "reset" | "user";
+  revision: number;
+  row_id: string;
+  row_version: number;
+  source_event_seq: number;
+};
+
+describe("SQLite transcript display rows", () => {
+  let stateDir: string;
+  let scope: {
+    agentId: string;
+    env: NodeJS.ProcessEnv;
+    sessionId: string;
+    sessionKey: string;
+  };
+
+  beforeEach(() => {
+    stateDir = tempDirs.make("openclaw-transcript-display-");
+    scope = {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      sessionId: "display-session",
+      sessionKey: "agent:main:display-session",
+    };
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  function database() {
+    return openOpenClawAgentDatabase({ agentId: scope.agentId, env: scope.env });
+  }
+
+  function readState(sessionId = scope.sessionId): DisplayStateRow {
+    const row = database()
+      .db.prepare(
+        `SELECT generation, indexed_seq, needs_rebuild, row_count
+           FROM session_transcript_display_state
+          WHERE session_id = ?`,
+      )
+      .get(sessionId) as DisplayStateRow | undefined;
+    expect(row).toBeDefined();
+    return row!;
+  }
+
+  function readRows(sessionId = scope.sessionId): DisplayRow[] {
+    return database()
+      .db.prepare(
+        `SELECT row_id, row_version, revision, display_ordinal, source_event_seq, kind
+           FROM session_transcript_display_rows
+          WHERE session_id = ?
+          ORDER BY display_ordinal`,
+      )
+      .all(sessionId) as DisplayRow[];
+  }
+
+  function trackDisplayGenerationWrites(sessionId: string): void {
+    const db = database().db;
+    readSessionTranscriptDisplayState(db, sessionId);
+    db.exec(`
+      CREATE TEMP TABLE tracked_display_generation_writes (
+        session_id TEXT PRIMARY KEY,
+        write_count INTEGER NOT NULL
+      ) STRICT;
+      CREATE TEMP TRIGGER track_display_generation_insert
+      AFTER INSERT ON main.session_transcript_display_state
+      WHEN NEW.session_id = (SELECT session_id FROM tracked_display_generation_writes)
+      BEGIN
+        UPDATE tracked_display_generation_writes SET write_count = write_count + 1;
+      END;
+      CREATE TEMP TRIGGER track_display_generation_update
+      AFTER UPDATE OF generation ON main.session_transcript_display_state
+      WHEN NEW.session_id = (SELECT session_id FROM tracked_display_generation_writes)
+        AND OLD.generation <> NEW.generation
+      BEGIN
+        UPDATE tracked_display_generation_writes SET write_count = write_count + 1;
+      END;
+    `);
+    db.prepare(
+      "INSERT INTO tracked_display_generation_writes (session_id, write_count) VALUES (?, 0)",
+    ).run(sessionId);
+  }
+
+  function readDisplayGenerationWrites(): number {
+    const row = database()
+      .db.prepare("SELECT write_count FROM tracked_display_generation_writes")
+      .get() as { write_count: number };
+    return row.write_count;
+  }
+
+  function readPage(
+    params: { expectedGeneration: string; fromOrdinal: number; limit: number },
+    sessionId = scope.sessionId,
+  ) {
+    return readSessionTranscriptDisplayRowsInTransaction(database().db, sessionId, params);
+  }
+
+  async function appendPlainPair(): Promise<void> {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "user-1",
+          parentId: null,
+          message: { role: "user", content: "hello" },
+        },
+        {
+          eventId: "assistant-1",
+          parentId: "user-1",
+          message: { role: "assistant", content: "hi" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+  }
+
+  it("keeps generation and existing identities stable across plain appends and no-op replay", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "user-1",
+          parentId: null,
+          message: { role: "user", content: "hello" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    const firstState = readState();
+    const firstRows = readRows();
+    expect(firstState).toMatchObject({ indexed_seq: 1, needs_rebuild: 0, row_count: 1 });
+    expect(firstRows).toMatchObject([
+      {
+        display_ordinal: 0,
+        kind: "user",
+        revision: 1,
+        row_version: 1,
+        source_event_seq: 1,
+      },
+    ]);
+
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "assistant-1",
+          parentId: "user-1",
+          message: { role: "assistant", content: "hi" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    const secondState = readState();
+    const secondRows = readRows();
+    expect(secondState).toMatchObject({ indexed_seq: 2, needs_rebuild: 0, row_count: 2 });
+    expect(secondState.generation).toBe(firstState.generation);
+    expect(secondRows[0]).toEqual(firstRows[0]);
+    expect(secondRows.map((row) => row.display_ordinal)).toEqual([0, 1]);
+    expect(secondRows[1]).toMatchObject({
+      kind: "assistant",
+      revision: 1,
+      source_event_seq: 2,
+    });
+
+    const replay = await persistSessionTranscriptTurn(scope, {
+      messages: [
+        {
+          eventId: "assistant-1",
+          parentId: "user-1",
+          message: { role: "assistant", content: "hi" },
+        },
+      ],
+      touchSessionEntry: false,
+    });
+    expect(replay.appendedCount).toBe(0);
+    expect(readState()).toEqual(secondState);
+    expect(readRows()).toEqual(secondRows);
+  });
+
+  it("rotates on a boundary and publishes one dense rebuilt generation", async () => {
+    await appendPlainPair();
+    const before = readState();
+
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset-1",
+      parentId: "assistant-1",
+      timestamp: "2026-08-19T00:00:00.000Z",
+      reason: "new",
+      firstKeptEntryId: "user-1",
+    });
+
+    const rebuilding = readState();
+    expect(rebuilding.generation).not.toBe(before.generation);
+    expect(rebuilding.needs_rebuild).toBe(1);
+    expect(
+      readPage({
+        expectedGeneration: before.generation,
+        fromOrdinal: 0,
+        limit: 10,
+      }),
+    ).toEqual({ generation: rebuilding.generation, kind: "reset" });
+
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
+
+    const ready = readState();
+    const rows = readRows();
+    expect(ready).toMatchObject({
+      generation: rebuilding.generation,
+      needs_rebuild: 0,
+      row_count: rows.length,
+    });
+    expect(rows.map((row) => row.display_ordinal)).toEqual(rows.map((_, index) => index));
+    expect(rows.at(-1)?.kind).toBe("reset");
+  });
+
+  it("returns bounded ready pages or a generation reset, never dirty rows", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [
+        { eventId: "m1", parentId: null, message: { role: "user", content: "one" } },
+        {
+          eventId: "m2",
+          parentId: "m1",
+          message: { role: "assistant", content: "two" },
+        },
+        { eventId: "m3", parentId: "m2", message: { role: "user", content: "three" } },
+      ],
+      touchSessionEntry: false,
+    });
+    const generation = readState().generation;
+
+    expect(
+      readPage({
+        expectedGeneration: generation,
+        fromOrdinal: 0,
+        limit: 1,
+      }),
+    ).toMatchObject({
+      generation,
+      kind: "ready",
+      nextOrdinal: 1,
+      rows: [{ displayOrdinal: 0, kind: "user" }],
+    });
+    expect(
+      readPage({
+        expectedGeneration: "stale-generation",
+        fromOrdinal: 0,
+        limit: 10,
+      }),
+    ).toEqual({ generation, kind: "reset" });
+    const normalizedBounds = readPage({
+      expectedGeneration: generation,
+      fromOrdinal: Number.NaN,
+      limit: Number.MAX_SAFE_INTEGER,
+    });
+    expect(normalizedBounds.kind).toBe("ready");
+    expect(normalizedBounds.kind === "ready" ? normalizedBounds.rows : []).toHaveLength(3);
+
+    await appendTranscriptEvent(scope, {
+      type: "compaction",
+      id: "compaction-1",
+      parentId: "m3",
+      timestamp: "2026-08-19T00:00:00.000Z",
+      summary: "boundary",
+      firstKeptEntryId: "m1",
+      tokensBefore: 10,
+    });
+    const rebuilding = readState();
+    expect(
+      readPage({
+        expectedGeneration: rebuilding.generation,
+        fromOrdinal: 0,
+        limit: Number.MAX_SAFE_INTEGER,
+      }),
+    ).toEqual({ generation: rebuilding.generation, kind: "reset" });
+  });
+
+  it("publishes an empty ready generation after clearing a transcript", async () => {
+    await appendPlainPair();
+    const before = readState();
+
+    await replaceTranscriptEvents(scope, []);
+    const rebuilding = readState();
+    expect(rebuilding.generation).not.toBe(before.generation);
+    expect(rebuilding.needs_rebuild).toBe(1);
+
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
+    const ready = readState();
+    expect(ready).toMatchObject({ indexed_seq: -1, needs_rebuild: 0, row_count: 0 });
+    expect(readRows()).toEqual([]);
+    expect(
+      readPage({
+        expectedGeneration: ready.generation,
+        fromOrdinal: 0,
+        limit: 10,
+      }),
+    ).toEqual({ generation: ready.generation, kind: "ready", rows: [] });
+  });
+
+  it("rotates once when a full replacement contains a display boundary", async () => {
+    await appendPlainPair();
+    trackDisplayGenerationWrites(scope.sessionId);
+
+    await replaceTranscriptEvents(scope, [
+      { type: "session", id: scope.sessionId },
+      {
+        type: "message",
+        id: "replacement-user",
+        parentId: null,
+        message: { role: "user", content: "replacement" },
+      },
+      {
+        type: "reset",
+        id: "replacement-reset",
+        parentId: "replacement-user",
+        timestamp: "2026-08-19T00:00:00.000Z",
+        reason: "new",
+        firstKeptEntryId: "replacement-user",
+      },
+    ]);
+
+    expect(readDisplayGenerationWrites()).toBe(1);
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
+    expect(readState()).toMatchObject({
+      indexed_seq: 2,
+      needs_rebuild: 0,
+      row_count: 2,
+    });
+    expect(readRows()).toMatchObject([
+      { display_ordinal: 0, kind: "user", source_event_seq: 1 },
+      { display_ordinal: 1, kind: "reset", source_event_seq: 2 },
+    ]);
+  });
+
+  it("rotates and rebuilds after an exact rewrite and manual compaction", async () => {
+    await upsertSessionEntryCore(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 1,
+    });
+    await appendPlainPair();
+    const beforeRewrite = readState();
+    const eventRow = database()
+      .db.prepare("SELECT event_json FROM transcript_events WHERE session_id = ? AND seq = 2")
+      .get(scope.sessionId) as { event_json: string };
+    const rewritten = JSON.parse(eventRow.event_json) as Record<string, unknown>;
+    rewritten.message = { role: "assistant", content: "rewritten" };
+    const transcriptGeneration = database()
+      .db.prepare("SELECT generation FROM transcript_rewrite_watermarks WHERE session_id = ?")
+      .get(scope.sessionId) as { generation: string };
+
+    await rewriteTranscriptEventRowsExact(scope, {
+      expectedGeneration: transcriptGeneration.generation,
+      rows: [
+        {
+          event: rewritten,
+          expectedEventJson: eventRow.event_json,
+          seq: 2,
+        },
+      ],
+    });
+    const rewriteGeneration = readState();
+    expect(rewriteGeneration.generation).not.toBe(beforeRewrite.generation);
+    expect(rewriteGeneration.needs_rebuild).toBe(1);
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
+
+    const beforeCompact = readState();
+    const compacted = await trimTranscriptForManualCompact(scope, (lines) => lines.slice(-2));
+    expect(compacted).toMatchObject({ trimmed: true });
+    const compactGeneration = readState();
+    expect(compactGeneration.generation).not.toBe(beforeCompact.generation);
+    expect(compactGeneration.needs_rebuild).toBe(1);
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
+    expect(readState().needs_rebuild).toBe(0);
+  });
+
+  it.each([
+    {
+      expectedIndexedSeq: 2,
+      expectedRows: [
+        { display_ordinal: 0, kind: "user", source_event_seq: 1 },
+        { display_ordinal: 1, kind: "reset", source_event_seq: 2 },
+      ],
+      name: "parsed",
+      source: {
+        readTranscriptEvents: (append: (event: unknown) => void) => {
+          append({ type: "session", id: "imported-session" });
+          append({
+            type: "message",
+            id: "imported-user",
+            parentId: null,
+            message: { role: "user", content: "parsed import" },
+          });
+          append({
+            type: "reset",
+            id: "imported-reset",
+            parentId: "imported-user",
+            timestamp: "2026-08-19T00:00:00.000Z",
+            reason: "new",
+            firstKeptEntryId: "imported-user",
+          });
+        },
+      },
+    },
+    {
+      expectedIndexedSeq: 1,
+      expectedRows: [{ display_ordinal: 0, kind: "user", source_event_seq: 1 }],
+      name: "byte-exact",
+      source: {
+        readExactTranscriptRows: (
+          append: (row: { createdAt: number; eventJson: string }) => void,
+        ) => {
+          append({
+            createdAt: 1,
+            eventJson: JSON.stringify({ type: "session", id: "imported-session" }),
+          });
+          append({
+            createdAt: 2,
+            eventJson: JSON.stringify({
+              type: "message",
+              id: "imported-user",
+              parentId: null,
+              message: { role: "user", content: "exact import" },
+            }),
+          });
+        },
+      },
+    },
+  ])(
+    "rebuilds display rows after a $name legacy import",
+    async ({ expectedIndexedSeq, expectedRows, source }) => {
+      const importedScope = {
+        agentId: scope.agentId,
+        env: scope.env,
+        sessionId: "imported-session",
+        sessionKey: "agent:main:imported-session",
+      };
+      trackDisplayGenerationWrites(importedScope.sessionId);
+      await importSqliteSessionRows({
+        agentId: importedScope.agentId,
+        env: importedScope.env,
+        entry: { sessionId: importedScope.sessionId, updatedAt: 1 },
+        sessionKey: importedScope.sessionKey,
+        ...source,
+      });
+
+      expect(readDisplayGenerationWrites()).toBe(1);
+      expect(readState(importedScope.sessionId).needs_rebuild).toBe(1);
+      await waitForSessionTranscriptIndexReconcile({
+        agentId: importedScope.agentId,
+        env: importedScope.env,
+      });
+      expect(readState(importedScope.sessionId)).toMatchObject({
+        indexed_seq: expectedIndexedSeq,
+        needs_rebuild: 0,
+        row_count: expectedRows.length,
+      });
+      expect(readRows(importedScope.sessionId)).toMatchObject(expectedRows);
+    },
+  );
+
+  it.each([
+    { destinationMessages: 1, name: "equal-length" },
+    { destinationMessages: 2, name: "shorter" },
+  ])(
+    "rebuilds display rows when a canonical cross-store replacement is $name",
+    async ({ destinationMessages }) => {
+      const destinationEvents = [
+        {
+          eventId: "destination-user",
+          parentId: null,
+          message: { role: "user" as const, content: "stale destination" },
+        },
+        {
+          eventId: "destination-assistant",
+          parentId: "destination-user",
+          message: { role: "assistant" as const, content: "stale destination reply" },
+        },
+      ].slice(0, destinationMessages);
+      await persistSessionTranscriptTurn(scope, {
+        messages: destinationEvents,
+        touchSessionEntry: false,
+      });
+      const before = readState();
+      const beforeRows = readRows();
+
+      const sourceScope = {
+        agentId: "source",
+        env: scope.env,
+        sessionId: scope.sessionId,
+        sessionKey: "agent:source:display-session",
+      };
+      const sourceEntry = { sessionId: sourceScope.sessionId, updatedAt: 2 };
+      await upsertSessionEntryCore(sourceScope, sourceEntry);
+      await persistSessionTranscriptTurn(sourceScope, {
+        messages: [
+          {
+            eventId: "source-assistant",
+            parentId: null,
+            message: { role: "assistant", content: "canonical source" },
+          },
+        ],
+        touchSessionEntry: false,
+      });
+      const sourceDatabase = openOpenClawAgentDatabase({
+        agentId: sourceScope.agentId,
+        env: sourceScope.env,
+      });
+
+      runOpenClawAgentWriteTransaction(
+        (destinationDatabase) =>
+          copySqliteSessionOwnedStateForCanonicalRepair({
+            canonicalKey: scope.sessionKey,
+            destinationDatabase,
+            preferredEntry: sourceEntry,
+            preferredSessionKey: sourceScope.sessionKey,
+            source: {
+              agentId: sourceScope.agentId,
+              storePath: sourceDatabase.path,
+            },
+            sourceEntries: [sourceEntry],
+            sourceKeys: [sourceScope.sessionKey],
+          }),
+        { agentId: scope.agentId, env: scope.env },
+      );
+
+      const rebuilding = readState();
+      expect(rebuilding.generation).not.toBe(before.generation);
+      expect(rebuilding.needs_rebuild).toBe(1);
+      expect(
+        readPage({
+          expectedGeneration: before.generation,
+          fromOrdinal: 0,
+          limit: 10,
+        }),
+      ).toEqual({ generation: rebuilding.generation, kind: "reset" });
+
+      await waitForSessionTranscriptIndexReconcile({
+        agentId: scope.agentId,
+        env: scope.env,
+      });
+
+      const ready = readState();
+      const rows = readRows();
+      expect(ready).toMatchObject({
+        generation: rebuilding.generation,
+        indexed_seq: 1,
+        needs_rebuild: 0,
+        row_count: 1,
+      });
+      expect(rows).toMatchObject([
+        {
+          display_ordinal: 0,
+          kind: "assistant",
+          source_event_seq: 1,
+        },
+      ]);
+      expect(rows[0]?.row_id).not.toBe(beforeRows[0]?.row_id);
+    },
+  );
+});

--- a/src/config/sessions/session-transcript-display.test.ts
+++ b/src/config/sessions/session-transcript-display.test.ts
@@ -128,7 +128,7 @@ describe("SQLite transcript display rows", () => {
   }
 
   function readPage(
-    params: { expectedGeneration: string; fromOrdinal: number; limit: number },
+    params: { expectedGeneration: string; fromOrdinal: number | "tail"; limit: number },
     sessionId = scope.sessionId,
   ) {
     return readSessionTranscriptDisplayRowsInTransaction(database().db, sessionId, params);
@@ -284,6 +284,20 @@ describe("SQLite transcript display rows", () => {
         limit: 10,
       }),
     ).toEqual({ generation, kind: "reset" });
+    expect(
+      readPage({
+        expectedGeneration: generation,
+        fromOrdinal: "tail",
+        limit: 2,
+      }),
+    ).toMatchObject({
+      generation,
+      kind: "ready",
+      rows: [
+        { displayOrdinal: 1, kind: "assistant" },
+        { displayOrdinal: 2, kind: "user" },
+      ],
+    });
     const normalizedBounds = readPage({
       expectedGeneration: generation,
       fromOrdinal: Number.NaN,

--- a/src/config/sessions/session-transcript-display.test.ts
+++ b/src/config/sessions/session-transcript-display.test.ts
@@ -18,11 +18,16 @@ import {
   rewriteTranscriptEventRowsExact,
   trimTranscriptForManualCompact,
 } from "./session-accessor.sqlite-transcript-write.js";
+import type { SessionTranscriptTurnMessageAppend } from "./session-accessor.types.js";
 import {
+  invalidateSessionTranscriptDisplayInTransaction,
   readSessionTranscriptDisplayRowsInTransaction,
   readSessionTranscriptDisplayState,
 } from "./session-transcript-display.js";
-import { waitForSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
+import {
+  reconcileSessionTranscriptDisplayProjection,
+  waitForSessionTranscriptIndexReconcile,
+} from "./session-transcript-reconcile.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -41,6 +46,12 @@ type DisplayRow = {
   row_version: number;
   source_event_seq: number;
 };
+
+function withDisplayProjection(
+  messages: readonly SessionTranscriptTurnMessageAppend[],
+): SessionTranscriptTurnMessageAppend[] {
+  return messages.map((message) => ({ ...message, maintainDisplayProjection: true }));
+}
 
 describe("SQLite transcript display rows", () => {
   let stateDir: string;
@@ -136,7 +147,7 @@ describe("SQLite transcript display rows", () => {
 
   async function appendPlainPair(): Promise<void> {
     await persistSessionTranscriptTurn(scope, {
-      messages: [
+      messages: withDisplayProjection([
         {
           eventId: "user-1",
           parentId: null,
@@ -147,20 +158,63 @@ describe("SQLite transcript display rows", () => {
           parentId: "user-1",
           message: { role: "assistant", content: "hi" },
         },
-      ],
+      ]),
       touchSessionEntry: false,
     });
   }
 
+  it("keeps ordinary message appends off display maintenance until reader adoption", async () => {
+    await persistSessionTranscriptTurn(scope, {
+      messages: [{ message: { role: "user", content: "hello" } }],
+      touchSessionEntry: false,
+    });
+
+    expect(
+      database()
+        .db.prepare(
+          "SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = 'session_transcript_display_state'",
+        )
+        .get(),
+    ).toBeUndefined();
+
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
+    expect(
+      database()
+        .db.prepare(
+          "SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = 'session_transcript_display_state'",
+        )
+        .get(),
+    ).toBeUndefined();
+
+    const adoptedScope = {
+      ...scope,
+      sessionId: "adopted-display-session",
+      sessionKey: "agent:main:adopted-display-session",
+    };
+    await persistSessionTranscriptTurn(adoptedScope, {
+      messages: withDisplayProjection([{ message: { role: "user", content: "adopted" } }]),
+      touchSessionEntry: false,
+    });
+
+    await persistSessionTranscriptTurn(scope, {
+      messages: [{ message: { role: "assistant", content: "still unadopted" } }],
+      touchSessionEntry: false,
+    });
+    expect(readSessionTranscriptDisplayState(database().db, scope.sessionId)).toBeUndefined();
+
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
+    expect(readSessionTranscriptDisplayState(database().db, scope.sessionId)).toBeUndefined();
+  });
+
   it("keeps generation and existing identities stable across plain appends and no-op replay", async () => {
     await persistSessionTranscriptTurn(scope, {
-      messages: [
+      messages: withDisplayProjection([
         {
           eventId: "user-1",
           parentId: null,
           message: { role: "user", content: "hello" },
         },
-      ],
+      ]),
       touchSessionEntry: false,
     });
     const firstState = readState();
@@ -177,13 +231,13 @@ describe("SQLite transcript display rows", () => {
     ]);
 
     await persistSessionTranscriptTurn(scope, {
-      messages: [
+      messages: withDisplayProjection([
         {
           eventId: "assistant-1",
           parentId: "user-1",
           message: { role: "assistant", content: "hi" },
         },
-      ],
+      ]),
       touchSessionEntry: false,
     });
     const secondState = readState();
@@ -199,13 +253,13 @@ describe("SQLite transcript display rows", () => {
     });
 
     const replay = await persistSessionTranscriptTurn(scope, {
-      messages: [
+      messages: withDisplayProjection([
         {
           eventId: "assistant-1",
           parentId: "user-1",
           message: { role: "assistant", content: "hi" },
         },
-      ],
+      ]),
       touchSessionEntry: false,
     });
     expect(replay.appendedCount).toBe(0);
@@ -237,7 +291,10 @@ describe("SQLite transcript display rows", () => {
       }),
     ).toEqual({ generation: rebuilding.generation, kind: "reset" });
 
-    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
+    await reconcileSessionTranscriptDisplayProjection({
+      agentId: scope.agentId,
+      env: scope.env,
+    });
 
     const ready = readState();
     const rows = readRows();
@@ -252,7 +309,7 @@ describe("SQLite transcript display rows", () => {
 
   it("returns bounded ready pages or a generation reset, never dirty rows", async () => {
     await persistSessionTranscriptTurn(scope, {
-      messages: [
+      messages: withDisplayProjection([
         { eventId: "m1", parentId: null, message: { role: "user", content: "one" } },
         {
           eventId: "m2",
@@ -260,7 +317,7 @@ describe("SQLite transcript display rows", () => {
           message: { role: "assistant", content: "two" },
         },
         { eventId: "m3", parentId: "m2", message: { role: "user", content: "three" } },
-      ],
+      ]),
       touchSessionEntry: false,
     });
     const generation = readState().generation;
@@ -476,7 +533,7 @@ describe("SQLite transcript display rows", () => {
       },
     },
   ])(
-    "rebuilds display rows after a $name legacy import",
+    "rebuilds adopted display rows after a $name legacy import",
     async ({ expectedIndexedSeq, expectedRows, source }) => {
       const importedScope = {
         agentId: scope.agentId,
@@ -484,6 +541,18 @@ describe("SQLite transcript display rows", () => {
         sessionId: "imported-session",
         sessionKey: "agent:main:imported-session",
       };
+      await upsertSessionEntryCore(importedScope, {
+        sessionId: importedScope.sessionId,
+        updatedAt: 0,
+      });
+      runOpenClawAgentWriteTransaction(
+        (agentDatabase) =>
+          invalidateSessionTranscriptDisplayInTransaction(
+            agentDatabase.db,
+            importedScope.sessionId,
+          ),
+        { agentId: importedScope.agentId, env: importedScope.env },
+      );
       trackDisplayGenerationWrites(importedScope.sessionId);
       await importSqliteSessionRows({
         agentId: importedScope.agentId,
@@ -527,7 +596,7 @@ describe("SQLite transcript display rows", () => {
         },
       ].slice(0, destinationMessages);
       await persistSessionTranscriptTurn(scope, {
-        messages: destinationEvents,
+        messages: withDisplayProjection(destinationEvents),
         touchSessionEntry: false,
       });
       const before = readState();
@@ -542,13 +611,13 @@ describe("SQLite transcript display rows", () => {
       const sourceEntry = { sessionId: sourceScope.sessionId, updatedAt: 2 };
       await upsertSessionEntryCore(sourceScope, sourceEntry);
       await persistSessionTranscriptTurn(sourceScope, {
-        messages: [
+        messages: withDisplayProjection([
           {
             eventId: "source-assistant",
             parentId: null,
             message: { role: "assistant", content: "canonical source" },
           },
-        ],
+        ]),
         touchSessionEntry: false,
       });
       const sourceDatabase = openOpenClawAgentDatabase({
@@ -584,10 +653,7 @@ describe("SQLite transcript display rows", () => {
         }),
       ).toEqual({ generation: rebuilding.generation, kind: "reset" });
 
-      await waitForSessionTranscriptIndexReconcile({
-        agentId: scope.agentId,
-        env: scope.env,
-      });
+      await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env: scope.env });
 
       const ready = readState();
       const rows = readRows();

--- a/src/config/sessions/session-transcript-display.ts
+++ b/src/config/sessions/session-transcript-display.ts
@@ -1,0 +1,611 @@
+import { randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+import { asOptionalRecord as readRecord } from "@openclaw/normalization-core/record-coerce";
+import type { Generated } from "kysely";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../../agents/stream-message-shared.js";
+import { HEARTBEAT_PROMPT } from "../../auto-reply/heartbeat.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../../infra/kysely-sync.js";
+import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
+import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import {
+  ensureOpenClawAgentDisplayRowSchema,
+  SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE,
+  SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE,
+} from "../../state/openclaw-agent-display-row-schema.js";
+import {
+  isCanonicalSessionTranscriptEntry,
+  parseSessionTranscriptTreeEntry,
+} from "./transcript-tree.js";
+import { selectVisibleTranscriptEventEntries } from "./transcript-visible-events.js";
+
+const SESSION_TRANSCRIPT_DISPLAY_ROW_VERSION = 1;
+const SESSION_TRANSCRIPT_DISPLAY_PAGE_MAX_ROWS = 200;
+
+type SessionTranscriptDisplayRowKind = "assistant" | "compaction" | "opaque" | "reset" | "user";
+
+type PlannedSessionTranscriptDisplayRow = {
+  kind: SessionTranscriptDisplayRowKind;
+  sourceEventSeq: number;
+};
+
+export type PreparedSessionTranscriptDisplayRow = PlannedSessionTranscriptDisplayRow & {
+  displayOrdinal: number;
+  revision: number;
+  rowId: string;
+  rowVersion: number;
+};
+
+type SessionTranscriptDisplayState = {
+  generation: string;
+  indexedSeq: number;
+  needsRebuild: boolean;
+  rowCount: number;
+  updatedAt: number;
+};
+
+type SessionTranscriptDisplayReadResult =
+  | {
+      generation: string;
+      kind: "ready";
+      nextOrdinal?: number;
+      rows: Array<{
+        displayOrdinal: number;
+        kind: SessionTranscriptDisplayRowKind;
+        revision: number;
+        rowId: string;
+        rowVersion: number;
+        sourceEventSeq: number;
+      }>;
+    }
+  | { generation: string | null; kind: "reset" };
+
+type DisplayRowDatabase = Omit<
+  Pick<
+    OpenClawAgentKyselyDatabase,
+    | "session_transcript_display_rows"
+    | "session_transcript_display_state"
+    | "session_windows"
+    | "transcript_events"
+  >,
+  "session_transcript_display_rows"
+> & {
+  session_transcript_display_rows: OpenClawAgentKyselyDatabase["session_transcript_display_rows"] & {
+    rowid: Generated<number>;
+  };
+};
+
+type DisplayDeleteChunkResult = {
+  hasMore: boolean;
+  owned: boolean;
+};
+
+function getDisplayKysely(db: DatabaseSync) {
+  return getNodeSqliteKysely<DisplayRowDatabase>(db);
+}
+
+function createDisplayGeneration(): string {
+  return randomUUID().replaceAll("-", "");
+}
+
+function createDisplayRowId(): string {
+  return randomUUID();
+}
+
+function readMessageText(message: Record<string, unknown>): string | undefined {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  if (!Array.isArray(message.content)) {
+    return typeof message.text === "string" ? message.text : undefined;
+  }
+  const text = message.content.flatMap((block) => {
+    const entry = readRecord(block);
+    if (!entry) {
+      return [];
+    }
+    return typeof entry.text === "string" &&
+      (entry.type === "text" || entry.type === "input_text" || entry.type === "output_text")
+      ? [entry.text]
+      : [];
+  });
+  return text.length > 0 ? text.join("\n") : undefined;
+}
+
+function hasNonTextContent(message: Record<string, unknown>): boolean {
+  return (
+    Array.isArray(message.content) &&
+    message.content.some((block) => {
+      const entry = readRecord(block);
+      if (!entry) {
+        return true;
+      }
+      const type = entry.type;
+      return type !== "text" && type !== "input_text" && type !== "output_text";
+    })
+  );
+}
+
+function hasCanvasSource(message: Record<string, unknown>): boolean {
+  const hasPreview = (value: unknown): boolean =>
+    Boolean(
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      ("mcpAppPreview" in value || "mcpApp" in value || "canvas" in value),
+    );
+  if (hasPreview(message.details)) {
+    return true;
+  }
+  return (
+    Array.isArray(message.content) &&
+    message.content.some((block) => {
+      const entry = readRecord(block);
+      return Boolean(entry && (hasPreview(entry.details) || entry.type === "canvas"));
+    })
+  );
+}
+
+function requiresStatefulDisplayProjection(message: Record<string, unknown>): boolean {
+  const role = message.role;
+  const text = readMessageText(message)?.trim();
+  if (
+    role === "user" &&
+    text &&
+    (text === HEARTBEAT_PROMPT || text.startsWith(`${HEARTBEAT_PROMPT}\n`))
+  ) {
+    return true;
+  }
+  if (
+    role === "assistant" &&
+    message.stopReason === "error" &&
+    text === STREAM_ERROR_FALLBACK_TEXT
+  ) {
+    return true;
+  }
+  return (
+    Object.hasOwn(message, "openclawMessageToolMirror") ||
+    Object.hasOwn(message, "openclawTtsSupplement") ||
+    hasCanvasSource(message) ||
+    hasNonTextContent(message)
+  );
+}
+
+export function hasTranscriptMessage(event: unknown): boolean {
+  const record = readRecord(event);
+  return record !== undefined && Object.hasOwn(record, "message") && record.message !== undefined;
+}
+
+export function shouldProjectActiveEvent(event: unknown): boolean {
+  const record = readRecord(event);
+  if (!record) {
+    return false;
+  }
+  if (record.type === "session") {
+    return false;
+  }
+  return (
+    isCanonicalSessionTranscriptEntry(event) ||
+    parseSessionTranscriptTreeEntry(event) !== undefined ||
+    hasTranscriptMessage(event)
+  );
+}
+
+export function isSessionTranscriptDisplayBoundary(event: unknown): boolean {
+  const record = readRecord(event);
+  if (!record) {
+    return false;
+  }
+  const type = record.type;
+  return type === "compaction" || type === "reset";
+}
+
+/** Classifies one independently displayable source without applying stateful row semantics. */
+function planSessionTranscriptDisplayRow(
+  event: unknown,
+  sourceEventSeq: number,
+): PlannedSessionTranscriptDisplayRow | undefined {
+  if (!shouldProjectActiveEvent(event)) {
+    return undefined;
+  }
+  const record = readRecord(event);
+  if (!record) {
+    return undefined;
+  }
+  if (record.type === "compaction" || record.type === "reset") {
+    return { kind: record.type, sourceEventSeq };
+  }
+  const message = readRecord(record.message);
+  if (!message) {
+    return { kind: "opaque", sourceEventSeq };
+  }
+  const role = message.role;
+  if ((role === "user" || role === "assistant") && !requiresStatefulDisplayProjection(message)) {
+    return { kind: role, sourceEventSeq };
+  }
+  return { kind: "opaque", sourceEventSeq };
+}
+
+/** Builds display rows from the same canonical visible path used by active transcript reads. */
+function buildSessionTranscriptDisplayRows(
+  rows: readonly { event: unknown; seq: number }[],
+): PlannedSessionTranscriptDisplayRow[] {
+  const events = rows.map((row) => row.event);
+  return selectVisibleTranscriptEventEntries(events).flatMap((entry) => {
+    const source = rows[entry.seq - 1];
+    return source ? (planSessionTranscriptDisplayRow(entry.event, source.seq) ?? []) : [];
+  });
+}
+
+export function prepareSessionTranscriptDisplayRows(
+  rows: readonly { event: unknown; seq: number }[],
+): PreparedSessionTranscriptDisplayRow[] {
+  return buildSessionTranscriptDisplayRows(rows).map((row, displayOrdinal) => ({
+    displayOrdinal,
+    kind: row.kind,
+    revision: 1,
+    rowId: createDisplayRowId(),
+    rowVersion: SESSION_TRANSCRIPT_DISPLAY_ROW_VERSION,
+    sourceEventSeq: row.sourceEventSeq,
+  }));
+}
+
+export function readSessionTranscriptDisplayState(
+  db: DatabaseSync,
+  sessionId: string,
+): SessionTranscriptDisplayState | undefined {
+  ensureOpenClawAgentDisplayRowSchema(db);
+  const row = executeSqliteQueryTakeFirstSync(
+    db,
+    getDisplayKysely(db)
+      .selectFrom(SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE)
+      .select(["generation", "indexed_seq", "needs_rebuild", "row_count", "updated_at"])
+      .where("session_id", "=", sessionId),
+  );
+  return row
+    ? {
+        generation: row.generation,
+        indexedSeq: row.indexed_seq,
+        needsRebuild: row.needs_rebuild !== 0,
+        rowCount: row.row_count,
+        updatedAt: row.updated_at,
+      }
+    : undefined;
+}
+
+function writeDisplayState(
+  db: DatabaseSync,
+  sessionId: string,
+  state: SessionTranscriptDisplayState,
+): void {
+  executeSqliteQuerySync(
+    db,
+    getDisplayKysely(db)
+      .insertInto(SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE)
+      .values({
+        generation: state.generation,
+        indexed_seq: state.indexedSeq,
+        needs_rebuild: state.needsRebuild ? 1 : 0,
+        row_count: state.rowCount,
+        session_id: sessionId,
+        updated_at: state.updatedAt,
+      })
+      .onConflict((conflict) =>
+        conflict.column("session_id").doUpdateSet({
+          generation: state.generation,
+          indexed_seq: state.indexedSeq,
+          needs_rebuild: state.needsRebuild ? 1 : 0,
+          row_count: state.rowCount,
+          updated_at: state.updatedAt,
+        }),
+      ),
+  );
+}
+
+/** Rotates one display generation and makes every reader reset until reconcile publishes it. */
+export function invalidateSessionTranscriptDisplayInTransaction(
+  db: DatabaseSync,
+  sessionId: string,
+): string {
+  ensureOpenClawAgentDisplayRowSchema(db);
+  const state = readSessionTranscriptDisplayState(db, sessionId);
+  const generation = createDisplayGeneration();
+  writeDisplayState(db, sessionId, {
+    generation,
+    indexedSeq: state?.indexedSeq ?? -1,
+    needsRebuild: true,
+    rowCount: state?.rowCount ?? 0,
+    updatedAt: Date.now(),
+  });
+  return generation;
+}
+
+/** Extends one ready display generation after active-path eligibility is already proven. */
+export function appendEligibleSessionTranscriptDisplayRowInTransaction(
+  db: DatabaseSync,
+  params: { event: unknown; seq: number; sessionId: string },
+): boolean {
+  ensureOpenClawAgentDisplayRowSchema(db);
+  const state = readSessionTranscriptDisplayState(db, params.sessionId);
+  if (state?.needsRebuild) {
+    return true;
+  }
+  if (state && params.seq !== state.indexedSeq + 1) {
+    invalidateSessionTranscriptDisplayInTransaction(db, params.sessionId);
+    return true;
+  }
+  if (!state && params.seq !== 0) {
+    invalidateSessionTranscriptDisplayInTransaction(db, params.sessionId);
+    return true;
+  }
+  const generation = state?.generation ?? createDisplayGeneration();
+  const planned = planSessionTranscriptDisplayRow(params.event, params.seq);
+  const rowCount = state?.rowCount ?? 0;
+  if (!state) {
+    writeDisplayState(db, params.sessionId, {
+      generation,
+      indexedSeq: params.seq - 1,
+      needsRebuild: false,
+      rowCount: 0,
+      updatedAt: Date.now(),
+    });
+  }
+  if (planned) {
+    executeSqliteQuerySync(
+      db,
+      getDisplayKysely(db).insertInto(SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE).values({
+        display_ordinal: rowCount,
+        kind: planned.kind,
+        revision: 1,
+        row_id: createDisplayRowId(),
+        row_version: SESSION_TRANSCRIPT_DISPLAY_ROW_VERSION,
+        session_id: params.sessionId,
+        source_event_seq: planned.sourceEventSeq,
+      }),
+    );
+  }
+  writeDisplayState(db, params.sessionId, {
+    generation,
+    indexedSeq: params.seq,
+    needsRebuild: false,
+    rowCount: rowCount + (planned ? 1 : 0),
+    updatedAt: Date.now(),
+  });
+  return false;
+}
+
+export function claimSessionTranscriptDisplayInTransaction(
+  db: DatabaseSync,
+  params: {
+    claimId: number;
+    generation: string;
+    sessionId: string;
+  },
+): boolean {
+  const state = readSessionTranscriptDisplayState(db, params.sessionId);
+  if (!state) {
+    writeDisplayState(db, params.sessionId, {
+      generation: params.generation,
+      indexedSeq: -1,
+      needsRebuild: true,
+      rowCount: 0,
+      updatedAt: params.claimId,
+    });
+    return true;
+  }
+  if (state.generation !== params.generation) {
+    return false;
+  }
+  writeDisplayState(db, params.sessionId, {
+    ...state,
+    needsRebuild: true,
+    updatedAt: params.claimId,
+  });
+  return true;
+}
+
+function displayClaimIsOwned(
+  db: DatabaseSync,
+  params: { claimId: number; generation: string; sessionId: string },
+): boolean {
+  const state = readSessionTranscriptDisplayState(db, params.sessionId);
+  return Boolean(
+    state?.needsRebuild &&
+    state.generation === params.generation &&
+    state.updatedAt === params.claimId,
+  );
+}
+
+export function deleteSessionTranscriptDisplayChunkInTransaction(
+  db: DatabaseSync,
+  params: {
+    claimId: number;
+    generation: string;
+    maxRows: number;
+    sessionId: string;
+  },
+): DisplayDeleteChunkResult {
+  if (!displayClaimIsOwned(db, params)) {
+    return { hasMore: false, owned: false };
+  }
+  const kysely = getDisplayKysely(db);
+  const deleted = Number(
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .deleteFrom(SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE)
+        .where(
+          "rowid",
+          "in",
+          kysely
+            .selectFrom(SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE)
+            .select("rowid")
+            .where("session_id", "=", params.sessionId)
+            .limit(params.maxRows),
+        ),
+    ).numAffectedRows ?? 0n,
+  );
+  return { hasMore: deleted === params.maxRows, owned: true };
+}
+
+export function appendSessionTranscriptDisplayChunkInTransaction(
+  db: DatabaseSync,
+  params: {
+    claimId: number;
+    generation: string;
+    rows: readonly PreparedSessionTranscriptDisplayRow[];
+    sessionId: string;
+  },
+): boolean {
+  if (!displayClaimIsOwned(db, params)) {
+    return false;
+  }
+  if (params.rows.length > 0) {
+    executeSqliteQuerySync(
+      db,
+      getDisplayKysely(db)
+        .insertInto(SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE)
+        .values(
+          params.rows.map((row) => ({
+            display_ordinal: row.displayOrdinal,
+            kind: row.kind,
+            revision: row.revision,
+            row_id: row.rowId,
+            row_version: row.rowVersion,
+            session_id: params.sessionId,
+            source_event_seq: row.sourceEventSeq,
+          })),
+        ),
+    );
+  }
+  return true;
+}
+
+export function finalizeSessionTranscriptDisplayInTransaction(
+  db: DatabaseSync,
+  params: {
+    claimId: number;
+    generation: string;
+    rowCount: number;
+    sessionId: string;
+    sourceIndexedSeq: number;
+  },
+): boolean {
+  if (!displayClaimIsOwned(db, params)) {
+    return false;
+  }
+  const result = executeSqliteQuerySync(
+    db,
+    getDisplayKysely(db)
+      .updateTable(SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE)
+      .set({
+        indexed_seq: params.sourceIndexedSeq,
+        needs_rebuild: 0,
+        row_count: params.rowCount,
+        updated_at: Date.now(),
+      })
+      .where("session_id", "=", params.sessionId)
+      .where("generation", "=", params.generation)
+      .where("needs_rebuild", "!=", 0)
+      .where("updated_at", "=", params.claimId),
+  );
+  return result.numAffectedRows === 1n;
+}
+
+function normalizeDisplayPageLimit(limit: number): number {
+  if (!Number.isFinite(limit)) {
+    return SESSION_TRANSCRIPT_DISPLAY_PAGE_MAX_ROWS;
+  }
+  return Math.max(1, Math.min(SESSION_TRANSCRIPT_DISPLAY_PAGE_MAX_ROWS, Math.floor(limit)));
+}
+
+function parseDisplayRowKind(value: string): SessionTranscriptDisplayRowKind {
+  if (
+    value === "assistant" ||
+    value === "compaction" ||
+    value === "opaque" ||
+    value === "reset" ||
+    value === "user"
+  ) {
+    return value;
+  }
+  throw new Error(`Unexpected transcript display-row kind: ${value}`);
+}
+
+function readSessionTranscriptDisplayRowsSnapshot(
+  db: DatabaseSync,
+  sessionId: string,
+  params: { expectedGeneration: string; fromOrdinal: number; limit: number },
+): SessionTranscriptDisplayReadResult {
+  const state = readSessionTranscriptDisplayState(db, sessionId);
+  const latest = executeSqliteQueryTakeFirstSync(
+    db,
+    getDisplayKysely(db)
+      .selectFrom("transcript_events")
+      .select("seq")
+      .where("session_id", "=", sessionId)
+      .orderBy("seq", "desc")
+      .limit(1),
+  );
+  const latestSeq = latest?.seq ?? -1;
+  if (
+    !state ||
+    state.generation !== params.expectedGeneration ||
+    state.needsRebuild ||
+    state.indexedSeq !== latestSeq
+  ) {
+    return { generation: state?.generation ?? null, kind: "reset" };
+  }
+  const fromOrdinal = Number.isFinite(params.fromOrdinal)
+    ? Math.max(0, Math.floor(params.fromOrdinal))
+    : 0;
+  const limit = normalizeDisplayPageLimit(params.limit);
+  const selected = executeSqliteQuerySync(
+    db,
+    getDisplayKysely(db)
+      .selectFrom(SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE)
+      .select(["display_ordinal", "kind", "revision", "row_id", "row_version", "source_event_seq"])
+      .where("session_id", "=", sessionId)
+      .where("display_ordinal", ">=", fromOrdinal)
+      .orderBy("display_ordinal", "asc")
+      .limit(limit + 1),
+  ).rows;
+  const hasMore = selected.length > limit;
+  const rows = selected.slice(0, limit).map((row) => ({
+    displayOrdinal: row.display_ordinal,
+    kind: parseDisplayRowKind(row.kind),
+    revision: row.revision,
+    rowId: row.row_id,
+    rowVersion: row.row_version,
+    sourceEventSeq: row.source_event_seq,
+  }));
+  return {
+    generation: state.generation,
+    kind: "ready",
+    ...(hasMore ? { nextOrdinal: fromOrdinal + rows.length } : {}),
+    rows,
+  };
+}
+
+/** Reads one generation-bound page or returns reset without exposing partial projection state. */
+export function readSessionTranscriptDisplayRowsInTransaction(
+  db: DatabaseSync,
+  sessionId: string,
+  params: { expectedGeneration: string; fromOrdinal: number; limit: number },
+): SessionTranscriptDisplayReadResult {
+  ensureOpenClawAgentDisplayRowSchema(db);
+  if (db.isTransaction) {
+    return readSessionTranscriptDisplayRowsSnapshot(db, sessionId, params);
+  }
+  return runSqliteDeferredTransactionSync(
+    db,
+    () => readSessionTranscriptDisplayRowsSnapshot(db, sessionId, params),
+    {
+      databaseLabel: "agent transcript display projection",
+      operationLabel: "sessions.transcript-display.read",
+    },
+  );
+}

--- a/src/config/sessions/session-transcript-display.ts
+++ b/src/config/sessions/session-transcript-display.ts
@@ -15,6 +15,7 @@ import {
   ensureOpenClawAgentDisplayRowSchema,
   SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE,
   SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE,
+  validateOpenClawAgentDisplayRowSchema,
 } from "../../state/openclaw-agent-display-row-schema.js";
 import {
   isCanonicalSessionTranscriptEntry,
@@ -327,6 +328,28 @@ export function invalidateSessionTranscriptDisplayInTransaction(
     updatedAt: Date.now(),
   });
   return generation;
+}
+
+/** Invalidates an adopted display projection without materializing absent storage. */
+export function invalidateExistingSessionTranscriptDisplayInTransaction(
+  db: DatabaseSync,
+  sessionId: string,
+): boolean {
+  if (!validateOpenClawAgentDisplayRowSchema(db)) {
+    return false;
+  }
+  const result = executeSqliteQuerySync(
+    db,
+    getDisplayKysely(db)
+      .updateTable(SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE)
+      .set({
+        generation: createDisplayGeneration(),
+        needs_rebuild: 1,
+        updated_at: Date.now(),
+      })
+      .where("session_id", "=", sessionId),
+  );
+  return result.numAffectedRows === 1n;
 }
 
 /** Extends one ready display generation after active-path eligibility is already proven. */

--- a/src/config/sessions/session-transcript-display.ts
+++ b/src/config/sessions/session-transcript-display.ts
@@ -63,6 +63,12 @@ type SessionTranscriptDisplayReadResult =
     }
   | { generation: string | null; kind: "reset" };
 
+type SessionTranscriptDisplayReadParams = {
+  expectedGeneration: string;
+  fromOrdinal: number | "tail";
+  limit: number;
+};
+
 type DisplayRowDatabase = Omit<
   Pick<
     OpenClawAgentKyselyDatabase,
@@ -538,7 +544,7 @@ function parseDisplayRowKind(value: string): SessionTranscriptDisplayRowKind {
 function readSessionTranscriptDisplayRowsSnapshot(
   db: DatabaseSync,
   sessionId: string,
-  params: { expectedGeneration: string; fromOrdinal: number; limit: number },
+  params: SessionTranscriptDisplayReadParams,
 ): SessionTranscriptDisplayReadResult {
   const state = readSessionTranscriptDisplayState(db, sessionId);
   const latest = executeSqliteQueryTakeFirstSync(
@@ -559,22 +565,27 @@ function readSessionTranscriptDisplayRowsSnapshot(
   ) {
     return { generation: state?.generation ?? null, kind: "reset" };
   }
-  const fromOrdinal = Number.isFinite(params.fromOrdinal)
-    ? Math.max(0, Math.floor(params.fromOrdinal))
-    : 0;
+  const tail = params.fromOrdinal === "tail";
+  const fromOrdinal =
+    params.fromOrdinal === "tail" || !Number.isFinite(params.fromOrdinal)
+      ? 0
+      : Math.max(0, Math.floor(params.fromOrdinal));
   const limit = normalizeDisplayPageLimit(params.limit);
+  const kysely = getDisplayKysely(db);
+  const pageQuery = kysely
+    .selectFrom(SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE)
+    .select(["display_ordinal", "kind", "revision", "row_id", "row_version", "source_event_seq"])
+    .where("session_id", "=", sessionId);
   const selected = executeSqliteQuerySync(
     db,
-    getDisplayKysely(db)
-      .selectFrom(SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE)
-      .select(["display_ordinal", "kind", "revision", "row_id", "row_version", "source_event_seq"])
-      .where("session_id", "=", sessionId)
-      .where("display_ordinal", ">=", fromOrdinal)
-      .orderBy("display_ordinal", "asc")
-      .limit(limit + 1),
+    (tail
+      ? pageQuery.orderBy("display_ordinal", "desc")
+      : pageQuery.where("display_ordinal", ">=", fromOrdinal).orderBy("display_ordinal", "asc")
+    ).limit(limit + 1),
   ).rows;
   const hasMore = selected.length > limit;
-  const rows = selected.slice(0, limit).map((row) => ({
+  const page = selected.slice(0, limit);
+  const rows = (tail ? page.toReversed() : page).map((row) => ({
     displayOrdinal: row.display_ordinal,
     kind: parseDisplayRowKind(row.kind),
     revision: row.revision,
@@ -585,7 +596,7 @@ function readSessionTranscriptDisplayRowsSnapshot(
   return {
     generation: state.generation,
     kind: "ready",
-    ...(hasMore ? { nextOrdinal: fromOrdinal + rows.length } : {}),
+    ...(!tail && hasMore ? { nextOrdinal: fromOrdinal + rows.length } : {}),
     rows,
   };
 }
@@ -594,7 +605,7 @@ function readSessionTranscriptDisplayRowsSnapshot(
 export function readSessionTranscriptDisplayRowsInTransaction(
   db: DatabaseSync,
   sessionId: string,
-  params: { expectedGeneration: string; fromOrdinal: number; limit: number },
+  params: SessionTranscriptDisplayReadParams,
 ): SessionTranscriptDisplayReadResult {
   ensureOpenClawAgentDisplayRowSchema(db);
   if (db.isTransaction) {

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -34,6 +34,9 @@ import {
   isSessionTranscriptSideAppendEntry,
   parseSessionTranscriptTreeEntry,
 } from "./transcript-tree.js";
+
+const SQLITE_TABLE_EXISTS_SQL = "SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?";
+
 type TranscriptIndexDatabase = Omit<
   Pick<
     OpenClawAgentKyselyDatabase,
@@ -465,23 +468,20 @@ export function reconcileSessionTranscriptIndexInTransaction(
  * that gained rows without index state (doctor imports), and watermarks
  * behind the newest row. Ordered for deterministic reconcile passes.
  */
-export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): string[] {
-  const hasTranscriptRows = Boolean(
+function hasTranscriptRows(db: DatabaseSync): boolean {
+  return Boolean(
     db.prepare("SELECT 1 FROM transcript_events LIMIT 1").get(), // sqlite-allow-raw -- Avoid creating the lazy display group for an unused agent database.
   );
-  const hasDisplayStateTable = Boolean(
-    db
-      .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?")
-      .get("session_transcript_display_state"), // sqlite-allow-raw -- Feature-local lazy-schema presence probe.
-  );
-  if (!hasTranscriptRows && !hasDisplayStateTable) {
+}
+
+/** Lists sessions whose active and FTS projections lag canonical transcript rows. */
+export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): string[] {
+  if (!hasTranscriptRows(db)) {
     return [];
   }
-  ensureOpenClawAgentDisplayRowSchema(db);
-  const kysely = getIndexKysely(db);
   const rows = executeSqliteQuerySync(
     db,
-    kysely
+    getIndexKysely(db)
       .selectFrom("session_windows")
       .innerJoin("transcript_events as latest", (join) =>
         join
@@ -504,24 +504,70 @@ export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): s
         "st.session_id",
         "session_windows.session_id",
       )
-      .leftJoin(
-        "session_transcript_display_state as display",
-        "display.session_id",
-        "session_windows.session_id",
-      )
       .select("session_windows.session_id")
       .where((eb) =>
         eb.or([
           eb(eb.fn.coalesce("st.needs_rebuild", eb.val(1)), "!=", 0),
           eb("latest.seq", ">", eb.fn.coalesce("st.indexed_seq", eb.val(-1))),
-          eb(eb.fn.coalesce("display.needs_rebuild", eb.val(1)), "!=", 0),
-          eb("latest.seq", ">", eb.fn.coalesce("display.indexed_seq", eb.val(-1))),
         ]),
       )
-      // The transcript PK makes the correlated latest-row lookup one index seek per session.
-      // Grouping transcript_events here made every healthy search rescan the entire history.
       .orderBy("session_windows.session_id"),
   ).rows;
+  return rows.flatMap((row) => (typeof row.session_id === "string" ? [row.session_id] : []));
+}
+
+/** Lists sessions whose active, FTS, or display projection requires repair. */
+export function listSessionsNeedingTranscriptProjectionReconcile(db: DatabaseSync): string[] {
+  const transcriptRowsPresent = hasTranscriptRows(db);
+  const hasDisplayStateTable = Boolean(
+    // sqlite-allow-raw -- Avoid installing the lazy display group solely to decide whether reconcile has work.
+    db
+      .prepare(/* sqlite-allow-raw */ SQLITE_TABLE_EXISTS_SQL)
+      .get("session_transcript_display_state"),
+  );
+  if (!transcriptRowsPresent && !hasDisplayStateTable) {
+    return [];
+  }
+  ensureOpenClawAgentDisplayRowSchema(db);
+  const kysely = getIndexKysely(db);
+  const rows = transcriptRowsPresent
+    ? executeSqliteQuerySync(
+        db,
+        kysely
+          .selectFrom("session_windows")
+          .innerJoin("transcript_events as latest", (join) =>
+            join
+              .onRef("latest.session_id", "=", "session_windows.session_id")
+              .on((eb) =>
+                eb(
+                  "latest.seq",
+                  "=",
+                  eb
+                    .selectFrom("transcript_events as candidate")
+                    .select("candidate.seq")
+                    .whereRef("candidate.session_id", "=", "session_windows.session_id")
+                    .orderBy("candidate.seq", "desc")
+                    .limit(1),
+                ),
+              ),
+          )
+          .leftJoin(
+            "session_transcript_display_state as display",
+            "display.session_id",
+            "session_windows.session_id",
+          )
+          .select("session_windows.session_id")
+          .where((eb) =>
+            eb.or([
+              eb(eb.fn.coalesce("display.needs_rebuild", eb.val(1)), "!=", 0),
+              eb("latest.seq", ">", eb.fn.coalesce("display.indexed_seq", eb.val(-1))),
+            ]),
+          )
+          // The transcript PK makes the correlated latest-row lookup one index seek per session.
+          // Grouping transcript_events here made every healthy search rescan the entire history.
+          .orderBy("session_windows.session_id"),
+      ).rows
+    : [];
   const emptyDirtyRows = executeSqliteQuerySync(
     db,
     kysely
@@ -531,8 +577,13 @@ export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): s
   ).rows;
   return [
     ...new Set(
-      [...rows, ...emptyDirtyRows].flatMap((row) =>
-        typeof row.session_id === "string" ? [row.session_id] : [],
+      [...listSessionsNeedingTranscriptIndexReconcile(db), ...rows, ...emptyDirtyRows].flatMap(
+        (row) =>
+          typeof row === "string"
+            ? [row]
+            : typeof row.session_id === "string"
+              ? [row.session_id]
+              : [],
       ),
     ),
   ].toSorted();

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -18,6 +18,7 @@ import { ensureOpenClawAgentDisplayRowSchema } from "../../state/openclaw-agent-
 import {
   appendEligibleSessionTranscriptDisplayRowInTransaction,
   hasTranscriptMessage,
+  invalidateExistingSessionTranscriptDisplayInTransaction,
   invalidateSessionTranscriptDisplayInTransaction,
   isSessionTranscriptDisplayBoundary,
   shouldProjectActiveEvent,
@@ -204,7 +205,7 @@ function invalidateDisplayProjectionForAppend(
   db: DatabaseSync,
   params: { maintainDisplayProjection?: boolean; sessionId: string },
 ): void {
-  if (params.maintainDisplayProjection !== false) {
+  if (params.maintainDisplayProjection === true) {
     invalidateSessionTranscriptDisplayInTransaction(db, params.sessionId);
   }
 }
@@ -223,9 +224,13 @@ export function indexAppendedTranscriptEventInTransaction(
     event: unknown;
     eventId: string | null;
     createdAt: number;
+    /** True maintains, false skips for a batch owner, omission invalidates adopted state. */
     maintainDisplayProjection?: boolean;
   },
 ): boolean {
+  const existingDisplayInvalidated =
+    params.maintainDisplayProjection === undefined &&
+    invalidateExistingSessionTranscriptDisplayInTransaction(db, params.sessionId);
   const watermark = readSessionTranscriptProjectionState(db, params.sessionId);
   if (!watermark) {
     if (params.seq !== 0) {
@@ -241,9 +246,9 @@ export function indexAppendedTranscriptEventInTransaction(
       leafEventId: null,
       needsRebuild: false,
     });
-    return params.maintainDisplayProjection !== false
+    return params.maintainDisplayProjection === true
       ? appendEligibleSessionTranscriptDisplayRowInTransaction(db, params)
-      : false;
+      : existingDisplayInvalidated;
   }
   if (watermark.needsRebuild) {
     if (
@@ -303,9 +308,9 @@ export function indexAppendedTranscriptEventInTransaction(
     return true;
   }
   applyForwardIndex(db, params, watermark);
-  return params.maintainDisplayProjection !== false
+  return params.maintainDisplayProjection === true
     ? appendEligibleSessionTranscriptDisplayRowInTransaction(db, params)
-    : false;
+    : existingDisplayInvalidated;
 }
 
 function applyForwardIndex(

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -14,11 +14,17 @@ import {
   getNodeSqliteKysely,
 } from "../../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
+import { ensureOpenClawAgentDisplayRowSchema } from "../../state/openclaw-agent-display-row-schema.js";
+import {
+  appendEligibleSessionTranscriptDisplayRowInTransaction,
+  hasTranscriptMessage,
+  invalidateSessionTranscriptDisplayInTransaction,
+  isSessionTranscriptDisplayBoundary,
+  shouldProjectActiveEvent,
+} from "./session-transcript-display.js";
 import {
   buildSessionTranscriptProjection,
   extractTranscriptIndexEntry,
-  hasTranscriptMessage,
-  shouldProjectActiveEvent,
   type SessionTranscriptProjectionSourceRow,
   type TranscriptIndexEntry,
 } from "./session-transcript-projection-rebuild.js";
@@ -33,6 +39,7 @@ type TranscriptIndexDatabase = Omit<
     OpenClawAgentKyselyDatabase,
     | "session_windows"
     | "session_transcript_active_events"
+    | "session_transcript_display_state"
     | "session_transcript_fts"
     | "session_transcript_index_state"
     | "transcript_events"
@@ -190,6 +197,15 @@ function deleteFtsRows(db: DatabaseSync, sessionId: string): void {
   );
 }
 
+function invalidateDisplayProjectionForAppend(
+  db: DatabaseSync,
+  params: { maintainDisplayProjection?: boolean; sessionId: string },
+): void {
+  if (params.maintainDisplayProjection !== false) {
+    invalidateSessionTranscriptDisplayInTransaction(db, params.sessionId);
+  }
+}
+
 /**
  * In-transaction append hook. Forward-indexes the event when it
  * unambiguously extends the active branch and marks the session for rebuild
@@ -204,6 +220,7 @@ export function indexAppendedTranscriptEventInTransaction(
     event: unknown;
     eventId: string | null;
     createdAt: number;
+    maintainDisplayProjection?: boolean;
   },
 ): boolean {
   const watermark = readSessionTranscriptProjectionState(db, params.sessionId);
@@ -211,6 +228,7 @@ export function indexAppendedTranscriptEventInTransaction(
     if (params.seq !== 0) {
       // Pre-existing rows without index state (e.g. doctor-migrated
       // transcripts): stay unindexed until reconcile rebuilds the session.
+      invalidateDisplayProjectionForAppend(db, params);
       return true;
     }
     applyForwardIndex(db, params, {
@@ -220,14 +238,24 @@ export function indexAppendedTranscriptEventInTransaction(
       leafEventId: null,
       needsRebuild: false,
     });
-    return false;
+    return params.maintainDisplayProjection !== false
+      ? appendEligibleSessionTranscriptDisplayRowInTransaction(db, params)
+      : false;
   }
   if (watermark.needsRebuild) {
+    if (
+      isSessionTranscriptDisplayBoundary(params.event) ||
+      isSessionTranscriptLeafControl(params.event) ||
+      isSessionTranscriptSideAppendEntry(params.event)
+    ) {
+      invalidateDisplayProjectionForAppend(db, params);
+    }
     return true;
   }
   if (params.seq !== watermark.indexedSeq + 1) {
     // Out-of-band writes bypassed the hook; reconcile recomputes the truth.
     markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
+    invalidateDisplayProjectionForAppend(db, params);
     return true;
   }
   if (
@@ -238,6 +266,12 @@ export function indexAppendedTranscriptEventInTransaction(
     // the main chain; the visible path must be re-resolved rather than
     // guessed at append time.
     markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
+    invalidateDisplayProjectionForAppend(db, params);
+    return true;
+  }
+  if (isSessionTranscriptDisplayBoundary(params.event)) {
+    applyForwardIndex(db, params, watermark);
+    invalidateDisplayProjectionForAppend(db, params);
     return true;
   }
   const isCanonicalEvent = isCanonicalSessionTranscriptEntry(params.event);
@@ -245,6 +279,7 @@ export function indexAppendedTranscriptEventInTransaction(
     // A canonical tree supersedes legacy flat message rows. Re-resolve once
     // instead of retaining rows that are no longer on the selected path.
     markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
+    invalidateDisplayProjectionForAppend(db, params);
     return true;
   }
   const treeEntry = parseSessionTranscriptTreeEntry(params.event);
@@ -256,14 +291,18 @@ export function indexAppendedTranscriptEventInTransaction(
     // A noncanonical row after a tracked tree cursor may be a flat fallback or
     // an opaque append ancestor. Only the full resolver can decide visibility.
     markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
+    invalidateDisplayProjectionForAppend(db, params);
     return true;
   }
   if (treeEntry && treeEntry.parentId !== watermark.leafEventId) {
     markSessionTranscriptIndexDirtyInTransaction(db, params.sessionId);
+    invalidateDisplayProjectionForAppend(db, params);
     return true;
   }
   applyForwardIndex(db, params, watermark);
-  return false;
+  return params.maintainDisplayProjection !== false
+    ? appendEligibleSessionTranscriptDisplayRowInTransaction(db, params)
+    : false;
 }
 
 function applyForwardIndex(
@@ -353,6 +392,7 @@ function rebuildSessionTranscriptIndexInTransaction(
   rows: readonly SessionTranscriptProjectionSourceRow[],
 ): void {
   const projection = buildSessionTranscriptProjection({
+    includeDisplayRows: false,
     rows,
     sessionId,
     sourceTranscriptUpdatedAt: null,
@@ -426,6 +466,18 @@ export function reconcileSessionTranscriptIndexInTransaction(
  * behind the newest row. Ordered for deterministic reconcile passes.
  */
 export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): string[] {
+  const hasTranscriptRows = Boolean(
+    db.prepare("SELECT 1 FROM transcript_events LIMIT 1").get(), // sqlite-allow-raw -- Avoid creating the lazy display group for an unused agent database.
+  );
+  const hasDisplayStateTable = Boolean(
+    db
+      .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?")
+      .get("session_transcript_display_state"), // sqlite-allow-raw -- Feature-local lazy-schema presence probe.
+  );
+  if (!hasTranscriptRows && !hasDisplayStateTable) {
+    return [];
+  }
+  ensureOpenClawAgentDisplayRowSchema(db);
   const kysely = getIndexKysely(db);
   const rows = executeSqliteQuerySync(
     db,
@@ -452,18 +504,38 @@ export function listSessionsNeedingTranscriptIndexReconcile(db: DatabaseSync): s
         "st.session_id",
         "session_windows.session_id",
       )
+      .leftJoin(
+        "session_transcript_display_state as display",
+        "display.session_id",
+        "session_windows.session_id",
+      )
       .select("session_windows.session_id")
       .where((eb) =>
         eb.or([
           eb(eb.fn.coalesce("st.needs_rebuild", eb.val(1)), "!=", 0),
           eb("latest.seq", ">", eb.fn.coalesce("st.indexed_seq", eb.val(-1))),
+          eb(eb.fn.coalesce("display.needs_rebuild", eb.val(1)), "!=", 0),
+          eb("latest.seq", ">", eb.fn.coalesce("display.indexed_seq", eb.val(-1))),
         ]),
       )
       // The transcript PK makes the correlated latest-row lookup one index seek per session.
       // Grouping transcript_events here made every healthy search rescan the entire history.
       .orderBy("session_windows.session_id"),
   ).rows;
-  return rows.flatMap((row) => (typeof row.session_id === "string" ? [row.session_id] : []));
+  const emptyDirtyRows = executeSqliteQuerySync(
+    db,
+    kysely
+      .selectFrom("session_transcript_display_state")
+      .select("session_id")
+      .where("needs_rebuild", "!=", 0),
+  ).rows;
+  return [
+    ...new Set(
+      [...rows, ...emptyDirtyRows].flatMap((row) =>
+        typeof row.session_id === "string" ? [row.session_id] : [],
+      ),
+    ),
+  ].toSorted();
 }
 
 /** Drops index rows for sessions whose transcript rows are gone. */

--- a/src/config/sessions/session-transcript-projection-rebuild.test.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.test.ts
@@ -22,7 +22,7 @@ import {
   buildSessionTranscriptProjection,
   type SessionTranscriptProjectionSourceRow,
 } from "./session-transcript-projection-rebuild.js";
-import { waitForSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
+import { reconcileSessionTranscriptDisplayProjection } from "./session-transcript-reconcile.js";
 
 const SESSION_ID = "projection-session";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -179,11 +179,11 @@ describe("canonical session transcript projection", () => {
             parentId: "root",
             message: { role: "assistant", content: "active" },
           },
-        ],
+        ].map((message) => Object.assign(message, { maintainDisplayProjection: true })),
         touchSessionEntry: false,
       },
     );
-    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env });
+    await reconcileSessionTranscriptDisplayProjection({ agentId: scope.agentId, env });
 
     const planned = prepareSessionTranscriptDisplayRows(readProjectionSourceRows()).map(
       ({ displayOrdinal, kind, sourceEventSeq }) => ({
@@ -291,12 +291,17 @@ describe("canonical session transcript projection", () => {
     if (event.type === "message" && event.message) {
       await appendTranscriptMessage(
         { ...scope, env },
-        { eventId: "event-1", message: event.message, parentId: null },
+        {
+          eventId: "event-1",
+          maintainDisplayProjection: true,
+          message: event.message,
+          parentId: null,
+        },
       );
     } else {
       await appendTranscriptEvent({ ...scope, env }, persistedEvent);
     }
-    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env });
+    await reconcileSessionTranscriptDisplayProjection({ agentId: scope.agentId, env });
 
     const directExpected = prepareSessionTranscriptDisplayRows([
       { event: persistedEvent, seq: 0 },

--- a/src/config/sessions/session-transcript-projection-rebuild.test.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.test.ts
@@ -1,13 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../../agents/stream-message-shared.js";
 import { HEARTBEAT_PROMPT } from "../../auto-reply/heartbeat.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  persistSessionTranscriptTurn,
+} from "./session-accessor.js";
 import { prepareSessionTranscriptDisplayRows } from "./session-transcript-display.js";
 import {
   buildSessionTranscriptProjection,
   type SessionTranscriptProjectionSourceRow,
 } from "./session-transcript-projection-rebuild.js";
+import { waitForSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
 
 const SESSION_ID = "projection-session";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function row(
   seq: number,
@@ -26,6 +39,45 @@ function projection(rows: SessionTranscriptProjectionSourceRow[]) {
 }
 
 describe("canonical session transcript projection", () => {
+  let env: NodeJS.ProcessEnv;
+  const scope = {
+    agentId: "main",
+    sessionId: SESSION_ID,
+    sessionKey: "agent:main:projection-session",
+  };
+
+  beforeEach(() => {
+    env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: tempDirs.make("openclaw-transcript-projection-"),
+    };
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  function readProjectionSourceRows(): SessionTranscriptProjectionSourceRow[] {
+    return openOpenClawAgentDatabase({ agentId: scope.agentId, env })
+      .db.prepare(
+        "SELECT seq, event_json, created_at FROM transcript_events WHERE session_id = ? ORDER BY seq",
+      )
+      .all(scope.sessionId)
+      .map((entry) => {
+        const row = entry as { created_at: number; event_json: string; seq: number };
+        return { createdAt: row.created_at, event: JSON.parse(row.event_json), seq: row.seq };
+      });
+  }
+
+  function readDisplayRows() {
+    return openOpenClawAgentDatabase({ agentId: scope.agentId, env })
+      .db.prepare(
+        "SELECT display_ordinal, kind, source_event_seq FROM session_transcript_display_rows WHERE session_id = ? ORDER BY display_ordinal",
+      )
+      .all(scope.sessionId);
+  }
+
   it("projects one deterministic active branch for both rebuild owners", () => {
     const result = projection([
       row(0, { id: SESSION_ID, type: "session", version: 3 }),
@@ -74,6 +126,42 @@ describe("canonical session transcript projection", () => {
     expect(result.ftsRows).toEqual([
       { messageId: "root", role: "user", text: "root text", timestamp: 1_000 },
       { messageId: "active", role: "assistant", text: "active text", timestamp: 3_000 },
+    ]);
+  });
+
+  it("matches incremental append and rebuild after excluding the header and abandoned branch", async () => {
+    await persistSessionTranscriptTurn(
+      { ...scope, env },
+      {
+        messages: [
+          { eventId: "root", parentId: null, message: { role: "user", content: "root" } },
+          {
+            eventId: "abandoned",
+            parentId: "root",
+            message: { role: "assistant", content: "abandoned" },
+          },
+          {
+            eventId: "active",
+            parentId: "root",
+            message: { role: "assistant", content: "active" },
+          },
+        ],
+        touchSessionEntry: false,
+      },
+    );
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env });
+
+    const planned = prepareSessionTranscriptDisplayRows(readProjectionSourceRows()).map(
+      ({ displayOrdinal, kind, sourceEventSeq }) => ({
+        display_ordinal: displayOrdinal,
+        kind,
+        source_event_seq: sourceEventSeq,
+      }),
+    );
+    expect(readDisplayRows()).toEqual(planned);
+    expect(planned).toEqual([
+      { display_ordinal: 0, kind: "user", source_event_seq: 1 },
+      { display_ordinal: 1, kind: "assistant", source_event_seq: 3 },
     ]);
   });
 
@@ -155,11 +243,26 @@ describe("canonical session transcript projection", () => {
       expected: "opaque",
       name: "unknown canonical entry",
     },
-  ])("uses the canonical display classifier for $name rows", ({ event, expected }) => {
-    const [plannedRow] = prepareSessionTranscriptDisplayRows([
-      { event: { id: "event-7", parentId: null, ...event }, seq: 7 },
-    ]);
-    expect(plannedRow).toMatchObject({ kind: expected, sourceEventSeq: 7 });
+  ])("uses the canonical display classifier for $name rows", async ({ event, expected }) => {
+    if (event.type === "message" && event.message) {
+      await appendTranscriptMessage(
+        { ...scope, env },
+        { eventId: "event-1", message: event.message, parentId: null },
+      );
+    } else {
+      await appendTranscriptEvent({ ...scope, env }, { id: "event-1", parentId: null, ...event });
+    }
+    await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env });
+
+    const planned = prepareSessionTranscriptDisplayRows(readProjectionSourceRows()).map(
+      ({ displayOrdinal, kind, sourceEventSeq }) => ({
+        display_ordinal: displayOrdinal,
+        kind,
+        source_event_seq: sourceEventSeq,
+      }),
+    );
+    expect(readDisplayRows()).toEqual(planned);
+    expect(planned).toMatchObject([{ kind: expected }]);
   });
 
   it("keeps persisted row timestamps for timestamp-less and invalid-timestamp messages", () => {

--- a/src/config/sessions/session-transcript-projection-rebuild.test.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../../agents/stream-message-shared.js";
+import { HEARTBEAT_PROMPT } from "../../auto-reply/heartbeat.js";
+import { prepareSessionTranscriptDisplayRows } from "./session-transcript-display.js";
 import {
   buildSessionTranscriptProjection,
   type SessionTranscriptProjectionSourceRow,
@@ -58,10 +61,105 @@ describe("canonical session transcript projection", () => {
       { activePosition: 0, eventSeq: 1, messagePosition: 0 },
       { activePosition: 1, eventSeq: 3, messagePosition: 1 },
     ]);
+    expect(
+      result.displayRows.map(({ displayOrdinal, kind, sourceEventSeq }) => ({
+        displayOrdinal,
+        kind,
+        sourceEventSeq,
+      })),
+    ).toEqual([
+      { displayOrdinal: 0, kind: "user", sourceEventSeq: 1 },
+      { displayOrdinal: 1, kind: "assistant", sourceEventSeq: 3 },
+    ]);
     expect(result.ftsRows).toEqual([
       { messageId: "root", role: "user", text: "root text", timestamp: 1_000 },
       { messageId: "active", role: "assistant", text: "active text", timestamp: 3_000 },
     ]);
+  });
+
+  it.each([
+    {
+      event: { type: "message", message: { role: "user", content: "hello" } },
+      expected: "user",
+      name: "plain user",
+    },
+    {
+      event: { type: "message", message: { role: "assistant", content: "hello" } },
+      expected: "assistant",
+      name: "plain assistant",
+    },
+    {
+      event: { type: "compaction" },
+      expected: "compaction",
+      name: "compaction boundary",
+    },
+    {
+      event: { type: "reset" },
+      expected: "reset",
+      name: "reset boundary",
+    },
+    {
+      event: { type: "message", message: { role: "user", content: HEARTBEAT_PROMPT } },
+      expected: "opaque",
+      name: "heartbeat candidate",
+    },
+    {
+      event: {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+          stopReason: "error",
+        },
+      },
+      expected: "opaque",
+      name: "stream error candidate",
+    },
+    {
+      event: {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", name: "message", arguments: {} }],
+        },
+      },
+      expected: "opaque",
+      name: "message tool candidate",
+    },
+    {
+      event: {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [{ type: "audio", data: "opaque" }],
+          openclawTtsSupplement: { spokenText: "hello" },
+        },
+      },
+      expected: "opaque",
+      name: "TTS supplement candidate",
+    },
+    {
+      event: {
+        type: "message",
+        message: {
+          role: "toolResult",
+          content: [{ type: "text", text: "tool" }],
+          details: { mcpAppPreview: { view: { id: "view-1" } } },
+        },
+      },
+      expected: "opaque",
+      name: "canvas candidate",
+    },
+    {
+      event: { type: "custom", id: "custom-1", parentId: null },
+      expected: "opaque",
+      name: "unknown canonical entry",
+    },
+  ])("uses the canonical display classifier for $name rows", ({ event, expected }) => {
+    const [plannedRow] = prepareSessionTranscriptDisplayRows([
+      { event: { id: "event-7", parentId: null, ...event }, seq: 7 },
+    ]);
+    expect(plannedRow).toMatchObject({ kind: expected, sourceEventSeq: 7 });
   });
 
   it("keeps persisted row timestamps for timestamp-less and invalid-timestamp messages", () => {

--- a/src/config/sessions/session-transcript-projection-rebuild.test.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.test.ts
@@ -5,14 +5,19 @@ import { HEARTBEAT_PROMPT } from "../../auto-reply/heartbeat.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
   persistSessionTranscriptTurn,
+  upsertSessionEntryCore,
 } from "./session-accessor.js";
-import { prepareSessionTranscriptDisplayRows } from "./session-transcript-display.js";
+import {
+  appendEligibleSessionTranscriptDisplayRowInTransaction,
+  prepareSessionTranscriptDisplayRows,
+} from "./session-transcript-display.js";
 import {
   buildSessionTranscriptProjection,
   type SessionTranscriptProjectionSourceRow,
@@ -65,17 +70,46 @@ describe("canonical session transcript projection", () => {
       )
       .all(scope.sessionId)
       .map((entry) => {
-        const row = entry as { created_at: number; event_json: string; seq: number };
-        return { createdAt: row.created_at, event: JSON.parse(row.event_json), seq: row.seq };
+        const sourceRow = entry as { created_at: number; event_json: string; seq: number };
+        return {
+          createdAt: sourceRow.created_at,
+          event: JSON.parse(sourceRow.event_json),
+          seq: sourceRow.seq,
+        };
       });
   }
 
-  function readDisplayRows() {
+  function readDisplayRows(sessionId = scope.sessionId) {
     return openOpenClawAgentDatabase({ agentId: scope.agentId, env })
       .db.prepare(
         "SELECT display_ordinal, kind, source_event_seq FROM session_transcript_display_rows WHERE session_id = ? ORDER BY display_ordinal",
       )
-      .all(scope.sessionId);
+      .all(sessionId);
+  }
+
+  async function appendEligibleDisplayRowDirectly(event: Record<string, unknown>) {
+    const sessionId = `${scope.sessionId}-direct`;
+    const sessionKey = `${scope.sessionKey}-direct`;
+    await upsertSessionEntryCore(
+      { agentId: scope.agentId, env, sessionKey },
+      { sessionId, updatedAt: 1 },
+    );
+    runOpenClawAgentWriteTransaction(
+      (database) => {
+        database.db
+          .prepare(
+            "INSERT INTO transcript_events (session_id, seq, event_json, created_at) VALUES (?, 0, ?, 1)",
+          )
+          .run(sessionId, JSON.stringify(event));
+        appendEligibleSessionTranscriptDisplayRowInTransaction(database.db, {
+          event,
+          seq: 0,
+          sessionId,
+        });
+      },
+      { agentId: scope.agentId, env },
+    );
+    return readDisplayRows(sessionId);
   }
 
   it("projects one deterministic active branch for both rebuild owners", () => {
@@ -240,20 +274,38 @@ describe("canonical session transcript projection", () => {
       name: "canvas candidate",
     },
     {
+      event: {
+        type: "message",
+        message: { role: "toolResult", content: "tool result" },
+      },
+      expected: "opaque",
+      name: "tool record",
+    },
+    {
       event: { type: "custom", id: "custom-1", parentId: null },
       expected: "opaque",
       name: "unknown canonical entry",
     },
   ])("uses the canonical display classifier for $name rows", async ({ event, expected }) => {
+    const persistedEvent = { id: "event-1", parentId: null, ...event };
     if (event.type === "message" && event.message) {
       await appendTranscriptMessage(
         { ...scope, env },
         { eventId: "event-1", message: event.message, parentId: null },
       );
     } else {
-      await appendTranscriptEvent({ ...scope, env }, { id: "event-1", parentId: null, ...event });
+      await appendTranscriptEvent({ ...scope, env }, persistedEvent);
     }
     await waitForSessionTranscriptIndexReconcile({ agentId: scope.agentId, env });
+
+    const directExpected = prepareSessionTranscriptDisplayRows([
+      { event: persistedEvent, seq: 0 },
+    ]).map(({ displayOrdinal, kind, sourceEventSeq }) => ({
+      display_ordinal: displayOrdinal,
+      kind,
+      source_event_seq: sourceEventSeq,
+    }));
+    expect(await appendEligibleDisplayRowDirectly(persistedEvent)).toEqual(directExpected);
 
     const planned = prepareSessionTranscriptDisplayRows(readProjectionSourceRows()).map(
       ({ displayOrdinal, kind, sourceEventSeq }) => ({

--- a/src/config/sessions/session-transcript-projection-rebuild.test.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.test.ts
@@ -208,7 +208,8 @@ describe("canonical session transcript projection", () => {
         type: "message",
         message: {
           role: "assistant",
-          content: [{ type: "toolCall", name: "message", arguments: {} }],
+          content: "mirrored message",
+          openclawMessageToolMirror: {},
         },
       },
       expected: "opaque",
@@ -219,7 +220,7 @@ describe("canonical session transcript projection", () => {
         type: "message",
         message: {
           role: "assistant",
-          content: [{ type: "audio", data: "opaque" }],
+          content: "spoken supplement",
           openclawTtsSupplement: { spokenText: "hello" },
         },
       },
@@ -230,8 +231,8 @@ describe("canonical session transcript projection", () => {
       event: {
         type: "message",
         message: {
-          role: "toolResult",
-          content: [{ type: "text", text: "tool" }],
+          role: "assistant",
+          content: "canvas preview",
           details: { mcpAppPreview: { view: { id: "view-1" } } },
         },
       },

--- a/src/config/sessions/session-transcript-projection-rebuild.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
 import type { ColumnType, Generated } from "kysely";
 import {
@@ -8,9 +9,15 @@ import {
 import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
-  isCanonicalSessionTranscriptEntry,
-  parseSessionTranscriptTreeEntry,
-} from "./transcript-tree.js";
+  claimSessionTranscriptDisplayInTransaction,
+  finalizeSessionTranscriptDisplayInTransaction,
+  hasTranscriptMessage,
+  prepareSessionTranscriptDisplayRows,
+  readSessionTranscriptDisplayRowsInTransaction,
+  readSessionTranscriptDisplayState,
+  shouldProjectActiveEvent,
+  type PreparedSessionTranscriptDisplayRow,
+} from "./session-transcript-display.js";
 import {
   resolveVisibleTranscriptAppendParentId,
   selectVisibleTranscriptEventEntries,
@@ -42,6 +49,10 @@ export type TranscriptIndexEntry = {
 export type PreparedSessionTranscriptProjectionMetadata = {
   activeEventCount: number;
   activeMessageCount: number;
+  activeNeedsRebuild: boolean;
+  displayGeneration: string;
+  displayNeedsRebuild: boolean;
+  displayRowCount: number;
   leafEventId: string | null;
   sessionId: string;
   sourceIndexedSeq: number;
@@ -54,6 +65,7 @@ export type PreparedSessionTranscriptProjection = PreparedSessionTranscriptProje
     eventSeq: number;
     messagePosition: number | null;
   }>;
+  displayRows: PreparedSessionTranscriptDisplayRow[];
   ftsRows: TranscriptIndexEntry[];
 };
 
@@ -89,7 +101,8 @@ function readMessageText(message: unknown): string | undefined {
   if (!Array.isArray(record.content)) {
     return undefined;
   }
-  const parts = record.content.flatMap((block) => {
+  const content = record.content as unknown[];
+  const parts = content.flatMap((block) => {
     if (!block || typeof block !== "object" || Array.isArray(block)) {
       return [];
     }
@@ -137,33 +150,12 @@ export function extractTranscriptIndexEntry(
   };
 }
 
-export function hasTranscriptMessage(event: unknown): boolean {
-  return (
-    typeof event === "object" &&
-    event !== null &&
-    !Array.isArray(event) &&
-    Object.hasOwn(event, "message") &&
-    (event as { message?: unknown }).message !== undefined
-  );
-}
-
-export function shouldProjectActiveEvent(event: unknown): boolean {
-  if (!event || typeof event !== "object" || Array.isArray(event)) {
-    return false;
-  }
-  const record = event as { type?: unknown };
-  if (record.type === "session") {
-    return false;
-  }
-  return (
-    isCanonicalSessionTranscriptEntry(event) ||
-    parseSessionTranscriptTreeEntry(event) !== undefined ||
-    hasTranscriptMessage(event)
-  );
-}
-
 /** Builds the same active-branch and search projection for worker and in-transaction owners. */
 export function buildSessionTranscriptProjection(params: {
+  activeNeedsRebuild?: boolean;
+  displayGeneration?: string;
+  displayNeedsRebuild?: boolean;
+  includeDisplayRows?: boolean;
   rows: readonly SessionTranscriptProjectionSourceRow[];
   sessionId: string;
   sourceTranscriptUpdatedAt: number | null;
@@ -171,6 +163,8 @@ export function buildSessionTranscriptProjection(params: {
   const now = Date.now();
   const events = params.rows.map((row) => row.event);
   const activeRows: PreparedSessionTranscriptProjection["activeRows"] = [];
+  const displayRows =
+    params.includeDisplayRows === false ? [] : prepareSessionTranscriptDisplayRows(params.rows);
   const ftsRows: TranscriptIndexEntry[] = [];
   let activeMessageCount = 0;
 
@@ -199,7 +193,12 @@ export function buildSessionTranscriptProjection(params: {
   return {
     activeEventCount: activeRows.length,
     activeMessageCount,
+    activeNeedsRebuild: params.activeNeedsRebuild ?? true,
     activeRows,
+    displayGeneration: params.displayGeneration ?? randomUUID().replaceAll("-", ""),
+    displayNeedsRebuild: params.displayNeedsRebuild ?? true,
+    displayRowCount: displayRows.length,
+    displayRows,
     ftsRows,
     leafEventId: resolveVisibleTranscriptAppendParentId(events),
     sessionId: params.sessionId,
@@ -232,14 +231,32 @@ export function prepareSessionTranscriptProjection(
           .where("session_id", "=", sessionId)
           .orderBy("seq", "asc"),
       ).rows;
-      if (!session || rows.length === 0) {
+      if (!session) {
         return undefined;
       }
+      const latestSeq = rows.at(-1)?.seq ?? -1;
+      const activeState = executeSqliteQueryTakeFirstSync(
+        db,
+        kysely
+          .selectFrom("session_transcript_index_state")
+          .select(["indexed_seq", "needs_rebuild"])
+          .where("session_id", "=", sessionId),
+      );
+      const displayState = readSessionTranscriptDisplayState(db, sessionId);
+      const displayNeedsRebuild =
+        !displayState || displayState.needsRebuild || displayState.indexedSeq !== latestSeq;
 
       return buildSessionTranscriptProjection({
+        activeNeedsRebuild:
+          latestSeq >= 0 &&
+          (!activeState ||
+            activeState.needs_rebuild !== 0 ||
+            activeState.indexed_seq !== latestSeq),
+        displayGeneration: displayState?.generation ?? randomUUID().replaceAll("-", ""),
+        displayNeedsRebuild,
         rows: rows.map((row) => ({
           createdAt: row.created_at,
-          event: JSON.parse(row.event_json) as unknown,
+          event: JSON.parse(row.event_json) as Record<string, unknown>,
           seq: row.seq,
         })),
         sessionId,
@@ -276,7 +293,7 @@ function sourceSnapshotMatches(
   );
   return (
     session?.transcript_updated_at === plan.sourceTranscriptUpdatedAt &&
-    latest?.seq === plan.sourceIndexedSeq
+    (latest?.seq ?? -1) === plan.sourceIndexedSeq
   );
 }
 
@@ -308,33 +325,64 @@ export function claimPreparedSessionTranscriptProjectionInTransaction(
       .select(["indexed_seq", "needs_rebuild"])
       .where("session_id", "=", plan.sessionId),
   );
-  if (current?.needs_rebuild === 0 && current.indexed_seq === plan.sourceIndexedSeq) {
+  const activeNeedsRebuild =
+    plan.sourceIndexedSeq >= 0 &&
+    (!current || current.needs_rebuild !== 0 || current.indexed_seq !== plan.sourceIndexedSeq);
+  if (
+    activeNeedsRebuild !== plan.activeNeedsRebuild ||
+    (!plan.activeNeedsRebuild && !plan.displayNeedsRebuild)
+  ) {
     return false;
   }
-  executeSqliteQuerySync(
-    db,
-    kysely
-      .insertInto("session_transcript_index_state")
-      .values({
-        active_event_count: 0,
-        active_message_count: 0,
-        indexed_seq: -1,
-        leaf_event_id: null,
-        needs_rebuild: 1,
-        session_id: plan.sessionId,
-        updated_at: claimId,
-      })
-      .onConflict((conflict) =>
-        conflict.column("session_id").doUpdateSet({
+  if (plan.displayNeedsRebuild) {
+    const readiness = readSessionTranscriptDisplayRowsInTransaction(db, plan.sessionId, {
+      expectedGeneration: plan.displayGeneration,
+      fromOrdinal: 0,
+      limit: 1,
+    });
+    if (
+      readiness.kind === "ready" ||
+      (readiness.generation !== null && readiness.generation !== plan.displayGeneration)
+    ) {
+      return false;
+    }
+  }
+  if (
+    plan.displayNeedsRebuild &&
+    !claimSessionTranscriptDisplayInTransaction(db, {
+      claimId,
+      generation: plan.displayGeneration,
+      sessionId: plan.sessionId,
+    })
+  ) {
+    return false;
+  }
+  if (plan.activeNeedsRebuild) {
+    executeSqliteQuerySync(
+      db,
+      kysely
+        .insertInto("session_transcript_index_state")
+        .values({
           active_event_count: 0,
           active_message_count: 0,
           indexed_seq: -1,
           leaf_event_id: null,
           needs_rebuild: 1,
+          session_id: plan.sessionId,
           updated_at: claimId,
-        }),
-      ),
-  );
+        })
+        .onConflict((conflict) =>
+          conflict.column("session_id").doUpdateSet({
+            active_event_count: 0,
+            active_message_count: 0,
+            indexed_seq: -1,
+            leaf_event_id: null,
+            needs_rebuild: 1,
+            updated_at: claimId,
+          }),
+        ),
+    );
+  }
   return true;
 }
 
@@ -437,10 +485,28 @@ export function finalizePreparedSessionTranscriptProjectionInTransaction(
   plan: PreparedSessionTranscriptProjectionMetadata,
   claimId: number,
 ): boolean {
-  if (!projectionClaimIsOwned(db, plan.sessionId, claimId) || !sourceSnapshotMatches(db, plan)) {
+  if (
+    (plan.activeNeedsRebuild && !projectionClaimIsOwned(db, plan.sessionId, claimId)) ||
+    !sourceSnapshotMatches(db, plan)
+  ) {
     return false;
   }
-  executeSqliteQuerySync(
+  if (
+    plan.displayNeedsRebuild &&
+    !finalizeSessionTranscriptDisplayInTransaction(db, {
+      claimId,
+      generation: plan.displayGeneration,
+      rowCount: plan.displayRowCount,
+      sessionId: plan.sessionId,
+      sourceIndexedSeq: plan.sourceIndexedSeq,
+    })
+  ) {
+    return false;
+  }
+  if (!plan.activeNeedsRebuild) {
+    return true;
+  }
+  const result = executeSqliteQuerySync(
     db,
     getProjectionKysely(db)
       .updateTable("session_transcript_index_state")
@@ -456,5 +522,5 @@ export function finalizePreparedSessionTranscriptProjectionInTransaction(
       .where("needs_rebuild", "!=", 0)
       .where("updated_at", "=", claimId),
   );
-  return true;
+  return result.numAffectedRows === 1n;
 }

--- a/src/config/sessions/session-transcript-projection-rebuild.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.ts
@@ -211,6 +211,7 @@ export function buildSessionTranscriptProjection(params: {
 export function prepareSessionTranscriptProjection(
   db: DatabaseSync,
   sessionId: string,
+  options: { includeDisplayProjection?: boolean } = {},
 ): PreparedSessionTranscriptProjection | undefined {
   return runSqliteDeferredTransactionSync(
     db,
@@ -242,9 +243,13 @@ export function prepareSessionTranscriptProjection(
           .select(["indexed_seq", "needs_rebuild"])
           .where("session_id", "=", sessionId),
       );
-      const displayState = readSessionTranscriptDisplayState(db, sessionId);
+      const includeDisplayProjection = options.includeDisplayProjection === true;
+      const displayState = includeDisplayProjection
+        ? readSessionTranscriptDisplayState(db, sessionId)
+        : undefined;
       const displayNeedsRebuild =
-        !displayState || displayState.needsRebuild || displayState.indexedSeq !== latestSeq;
+        includeDisplayProjection &&
+        (!displayState || displayState.needsRebuild || displayState.indexedSeq !== latestSeq);
 
       return buildSessionTranscriptProjection({
         activeNeedsRebuild:
@@ -254,6 +259,7 @@ export function prepareSessionTranscriptProjection(
             activeState.indexed_seq !== latestSeq),
         displayGeneration: displayState?.generation ?? randomUUID().replaceAll("-", ""),
         displayNeedsRebuild,
+        includeDisplayRows: includeDisplayProjection,
         rows: rows.map((row) => ({
           createdAt: row.created_at,
           event: JSON.parse(row.event_json) as Record<string, unknown>,

--- a/src/config/sessions/session-transcript-reconcile.ts
+++ b/src/config/sessions/session-transcript-reconcile.ts
@@ -21,6 +21,10 @@ import {
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
 import {
+  appendSessionTranscriptDisplayChunkInTransaction,
+  deleteSessionTranscriptDisplayChunkInTransaction,
+} from "./session-transcript-display.js";
+import {
   deleteOrphanedTranscriptIndexRowsInTransaction,
   listSessionsNeedingTranscriptIndexReconcile,
   sessionTranscriptIndexNeedsReconcile,
@@ -123,21 +127,41 @@ async function claimPreparedSessionTranscriptProjection(
     return undefined;
   }
 
-  let deleteResult = { hasMore: true, owned: true };
-  while (deleteResult.hasMore && deleteResult.owned) {
-    deleteResult = await runProjectionWrite(
-      databaseOptions,
-      "sessions.transcript-index.delete-chunk",
-      (database) =>
-        deletePreparedSessionTranscriptProjectionChunkInTransaction(database.db, {
-          maxRowsPerTable: PROJECTION_WRITE_CHUNK_ROWS,
-          sessionId: plan.sessionId,
-          claimId,
-        }),
-    );
+  let deleteResult = { hasMore: plan.activeNeedsRebuild, owned: true };
+  let displayDeleteResult = { hasMore: plan.displayNeedsRebuild, owned: true };
+  while (
+    (deleteResult.hasMore || displayDeleteResult.hasMore) &&
+    deleteResult.owned &&
+    displayDeleteResult.owned
+  ) {
+    if (plan.activeNeedsRebuild) {
+      deleteResult = await runProjectionWrite(
+        databaseOptions,
+        "sessions.transcript-index.delete-chunk",
+        (database) =>
+          deletePreparedSessionTranscriptProjectionChunkInTransaction(database.db, {
+            maxRowsPerTable: PROJECTION_WRITE_CHUNK_ROWS,
+            sessionId: plan.sessionId,
+            claimId,
+          }),
+      );
+    }
+    if (plan.displayNeedsRebuild) {
+      displayDeleteResult = await runProjectionWrite(
+        databaseOptions,
+        "sessions.transcript-display.delete-chunk",
+        (database) =>
+          deleteSessionTranscriptDisplayChunkInTransaction(database.db, {
+            claimId,
+            generation: plan.displayGeneration,
+            maxRows: PROJECTION_WRITE_CHUNK_ROWS,
+            sessionId: plan.sessionId,
+          }),
+      );
+    }
     await yieldToGateway();
   }
-  if (!deleteResult.owned) {
+  if (!deleteResult.owned || !displayDeleteResult.owned) {
     return undefined;
   }
   return { claimId, plan };
@@ -165,6 +189,9 @@ async function appendPreparedProjectionChunk(
         >[1]["activeRows"];
       }
     | {
+        displayRows: Parameters<typeof appendSessionTranscriptDisplayChunkInTransaction>[1]["rows"];
+      }
+    | {
         ftsRows: Parameters<
           typeof appendPreparedSessionTranscriptProjectionChunkInTransaction
         >[1]["ftsRows"];
@@ -174,13 +201,24 @@ async function appendPreparedProjectionChunk(
     databaseOptions,
     "activeRows" in rows
       ? "sessions.transcript-index.active-chunk"
-      : "sessions.transcript-index.fts-chunk",
-    (database) =>
-      appendPreparedSessionTranscriptProjectionChunkInTransaction(database.db, {
+      : "displayRows" in rows
+        ? "sessions.transcript-display.row-chunk"
+        : "sessions.transcript-index.fts-chunk",
+    (database) => {
+      if ("displayRows" in rows) {
+        return appendSessionTranscriptDisplayChunkInTransaction(database.db, {
+          claimId: active.claimId,
+          generation: active.plan.displayGeneration,
+          rows: rows.displayRows,
+          sessionId: active.plan.sessionId,
+        });
+      }
+      return appendPreparedSessionTranscriptProjectionChunkInTransaction(database.db, {
         ...rows,
         claimId: active.claimId,
         sessionId: active.plan.sessionId,
-      }),
+      });
+    },
   );
   await yieldToGateway();
   return owned;
@@ -311,7 +349,9 @@ export async function reconcileSessionTranscriptIndexes(
           active,
           message.type === "active-chunk"
             ? { activeRows: message.rows }
-            : { ftsRows: decodeFtsChunk(message.chunk) },
+            : message.type === "display-chunk"
+              ? { displayRows: message.rows }
+              : { ftsRows: decodeFtsChunk(message.chunk) },
         );
         if (!owned) {
           active = undefined;

--- a/src/config/sessions/session-transcript-reconcile.ts
+++ b/src/config/sessions/session-transcript-reconcile.ts
@@ -26,7 +26,7 @@ import {
 } from "./session-transcript-display.js";
 import {
   deleteOrphanedTranscriptIndexRowsInTransaction,
-  listSessionsNeedingTranscriptIndexReconcile,
+  listSessionsNeedingTranscriptProjectionReconcile,
   sessionTranscriptIndexNeedsReconcile,
 } from "./session-transcript-index.js";
 import {
@@ -257,7 +257,7 @@ export async function reconcileSessionTranscriptIndexes(
     "sessions.transcript-index.preflight",
     (database) => {
       deleteOrphanedTranscriptIndexRowsInTransaction(database.db);
-      return listSessionsNeedingTranscriptIndexReconcile(database.db).length > 0;
+      return listSessionsNeedingTranscriptProjectionReconcile(database.db).length > 0;
     },
   );
   if (!needsWorker) {

--- a/src/config/sessions/session-transcript-reconcile.ts
+++ b/src/config/sessions/session-transcript-reconcile.ts
@@ -26,6 +26,7 @@ import {
 } from "./session-transcript-display.js";
 import {
   deleteOrphanedTranscriptIndexRowsInTransaction,
+  listSessionsNeedingTranscriptIndexReconcile,
   listSessionsNeedingTranscriptProjectionReconcile,
   sessionTranscriptIndexNeedsReconcile,
 } from "./session-transcript-index.js";
@@ -47,6 +48,7 @@ const PROJECTION_WRITE_CHUNK_ROWS = 512;
 const PROJECTION_READY_POLL_MS = 10;
 
 type RunningReconcile = {
+  includeDisplayProjection: boolean;
   pending: boolean;
   preferredSessionId?: string;
   promise?: Promise<SessionTranscriptReconcileResult>;
@@ -244,6 +246,20 @@ async function finalizePreparedProjection(
 export async function reconcileSessionTranscriptIndexes(
   params: SessionTranscriptReconcileParams,
 ): Promise<SessionTranscriptReconcileResult> {
+  return await reconcileSessionTranscriptProjections(params, false);
+}
+
+/** Reconciles explicitly adopted display state alongside the active/search projection. */
+export async function reconcileSessionTranscriptDisplayProjection(
+  params: SessionTranscriptReconcileParams,
+): Promise<SessionTranscriptReconcileResult> {
+  return await reconcileSessionTranscriptProjections(params, true);
+}
+
+async function reconcileSessionTranscriptProjections(
+  params: SessionTranscriptReconcileParams,
+  includeDisplayProjection: boolean,
+): Promise<SessionTranscriptReconcileResult> {
   const databasePath = resolveOpenClawAgentSqlitePath(params);
   const databaseOptions: OpenClawAgentDatabaseOptions = {
     agentId: params.agentId,
@@ -257,7 +273,12 @@ export async function reconcileSessionTranscriptIndexes(
     "sessions.transcript-index.preflight",
     (database) => {
       deleteOrphanedTranscriptIndexRowsInTransaction(database.db);
-      return listSessionsNeedingTranscriptProjectionReconcile(database.db).length > 0;
+      return (
+        (includeDisplayProjection
+          ? listSessionsNeedingTranscriptProjectionReconcile(database.db)
+          : listSessionsNeedingTranscriptIndexReconcile(database.db)
+        ).length > 0
+      );
     },
   );
   if (!needsWorker) {
@@ -267,6 +288,7 @@ export async function reconcileSessionTranscriptIndexes(
   const sourceWorkerExecArgv = workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : undefined;
   const input: SessionTranscriptReconcileWorkerInput = {
     agentId: params.agentId,
+    includeDisplayProjection,
     path: databasePath,
     ...(params.preferredSessionId ? { preferredSessionId: params.preferredSessionId } : {}),
   };
@@ -279,6 +301,9 @@ export async function reconcileSessionTranscriptIndexes(
   } catch (error) {
     throw toStringifiedError(error);
   }
+  const workerExit = new Promise<void>((resolveExit) => {
+    worker.once("exit", () => resolveExit());
+  });
 
   return new Promise<SessionTranscriptReconcileResult>((resolve, reject) => {
     let active: ActivePreparedProjection | undefined;
@@ -320,6 +345,7 @@ export async function reconcileSessionTranscriptIndexes(
           settle(() => reject(toStringifiedError(error)), true);
           return;
         }
+        await workerExit;
         settle(() => resolve({ reconciledSessions }), false);
         return;
       }
@@ -383,16 +409,32 @@ export async function reconcileSessionTranscriptIndexes(
 export function startSessionTranscriptIndexReconcile(
   params: SessionTranscriptReconcileParams,
 ): void {
+  startSessionTranscriptReconcile(params, false);
+}
+
+/** Starts one deferred reconcile that includes explicitly adopted display state. */
+export function startSessionTranscriptDisplayReconcile(
+  params: SessionTranscriptReconcileParams,
+): void {
+  startSessionTranscriptReconcile(params, true);
+}
+
+function startSessionTranscriptReconcile(
+  params: SessionTranscriptReconcileParams,
+  includeDisplayProjection: boolean,
+): void {
   const key = reconcileKey(params);
   const running = runningReconciles.get(key);
   if (running) {
     // The active pass snapshots dirty sessions. Latch later writes so it
     // rescans before ownership is released instead of losing their work.
     running.pending = true;
+    running.includeDisplayProjection ||= includeDisplayProjection;
     running.preferredSessionId ??= params.preferredSessionId;
     return;
   }
   const state: RunningReconcile = {
+    includeDisplayProjection,
     pending: false,
     ...(params.preferredSessionId ? { preferredSessionId: params.preferredSessionId } : {}),
   };
@@ -401,12 +443,17 @@ export function startSessionTranscriptIndexReconcile(
       let reconciledSessions = 0;
       while (true) {
         state.pending = false;
+        const reconcileDisplayProjection = state.includeDisplayProjection;
+        state.includeDisplayProjection = false;
         const preferredSessionId = state.preferredSessionId;
         delete state.preferredSessionId;
-        const result = await reconcileSessionTranscriptIndexes({
-          ...params,
-          ...(preferredSessionId ? { preferredSessionId } : {}),
-        });
+        const result = await reconcileSessionTranscriptProjections(
+          {
+            ...params,
+            ...(preferredSessionId ? { preferredSessionId } : {}),
+          },
+          reconcileDisplayProjection,
+        );
         reconciledSessions += result.reconciledSessions;
         if (state.pending) {
           continue;
@@ -424,15 +471,19 @@ export function startSessionTranscriptIndexReconcile(
         `session transcript reconcile failed agent=${params.agentId} error=${error instanceof Error ? error.message : String(error)}`,
       );
       const shouldHandoff = state.pending;
+      const reconcileDisplayProjection = state.includeDisplayProjection;
       const preferredSessionId = state.preferredSessionId;
       if (runningReconciles.get(key) === state) {
         runningReconciles.delete(key);
       }
       if (shouldHandoff) {
-        startSessionTranscriptIndexReconcile({
-          ...params,
-          ...(preferredSessionId ? { preferredSessionId } : {}),
-        });
+        startSessionTranscriptReconcile(
+          {
+            ...params,
+            ...(preferredSessionId ? { preferredSessionId } : {}),
+          },
+          reconcileDisplayProjection,
+        );
         await waitForSessionTranscriptIndexReconcile(params);
       }
       return { reconciledSessions: 0 };

--- a/src/config/sessions/session-transcript-reconcile.ts
+++ b/src/config/sessions/session-transcript-reconcile.ts
@@ -279,6 +279,9 @@ export async function reconcileSessionTranscriptIndexes(
   } catch (error) {
     throw toStringifiedError(error);
   }
+  const workerExit = new Promise<void>((resolveExit) => {
+    worker.once("exit", () => resolveExit());
+  });
 
   return new Promise<SessionTranscriptReconcileResult>((resolve, reject) => {
     let active: ActivePreparedProjection | undefined;
@@ -320,6 +323,7 @@ export async function reconcileSessionTranscriptIndexes(
           settle(() => reject(toStringifiedError(error)), true);
           return;
         }
+        await workerExit;
         settle(() => resolve({ reconciledSessions }), false);
         return;
       }

--- a/src/config/sessions/session-transcript-reconcile.worker.ts
+++ b/src/config/sessions/session-transcript-reconcile.worker.ts
@@ -4,7 +4,10 @@ import {
   closeOpenClawAgentDatabaseByPath,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
-import { listSessionsNeedingTranscriptProjectionReconcile } from "./session-transcript-index.js";
+import {
+  listSessionsNeedingTranscriptIndexReconcile,
+  listSessionsNeedingTranscriptProjectionReconcile,
+} from "./session-transcript-index.js";
 import {
   prepareSessionTranscriptProjection,
   type PreparedSessionTranscriptProjection,
@@ -19,6 +22,7 @@ const FTS_TEXT_BYTES_PER_CHUNK = 256 * 1024;
 
 export type SessionTranscriptReconcileWorkerInput = {
   agentId: string;
+  includeDisplayProjection: boolean;
   path: string;
   preferredSessionId?: string;
 };
@@ -58,7 +62,11 @@ function parseWorkerInput(value: unknown): SessionTranscriptReconcileWorkerInput
     return undefined;
   }
   const input = value as Record<string, unknown>;
-  if (typeof input.agentId !== "string" || typeof input.path !== "string") {
+  if (
+    typeof input.agentId !== "string" ||
+    typeof input.includeDisplayProjection !== "boolean" ||
+    typeof input.path !== "string"
+  ) {
     return undefined;
   }
   if (input.preferredSessionId !== undefined && typeof input.preferredSessionId !== "string") {
@@ -66,6 +74,7 @@ function parseWorkerInput(value: unknown): SessionTranscriptReconcileWorkerInput
   }
   return {
     agentId: input.agentId,
+    includeDisplayProjection: input.includeDisplayProjection,
     path: input.path,
     ...(typeof input.preferredSessionId === "string"
       ? { preferredSessionId: input.preferredSessionId }
@@ -198,11 +207,15 @@ async function run(): Promise<void> {
       path: reconcileInput.path,
     });
     const sessionIds = orderSessionIds(
-      listSessionsNeedingTranscriptProjectionReconcile(database.db),
+      reconcileInput.includeDisplayProjection
+        ? listSessionsNeedingTranscriptProjectionReconcile(database.db)
+        : listSessionsNeedingTranscriptIndexReconcile(database.db),
       reconcileInput.preferredSessionId,
     );
     for (const sessionId of sessionIds) {
-      const plan = prepareSessionTranscriptProjection(database.db, sessionId);
+      const plan = prepareSessionTranscriptProjection(database.db, sessionId, {
+        includeDisplayProjection: reconcileInput.includeDisplayProjection,
+      });
       if (plan) {
         await streamPreparedProjection(plan);
       }

--- a/src/config/sessions/session-transcript-reconcile.worker.ts
+++ b/src/config/sessions/session-transcript-reconcile.worker.ts
@@ -13,6 +13,7 @@ import {
 } from "./session-transcript-projection-rebuild.js";
 
 const ACTIVE_ROWS_PER_CHUNK = 512;
+const DISPLAY_ROWS_PER_CHUNK = 512;
 const FTS_ROWS_PER_CHUNK = 128;
 const FTS_TEXT_BYTES_PER_CHUNK = 256 * 1024;
 
@@ -37,6 +38,11 @@ export type SessionTranscriptReconcileWorkerMessage =
   | {
       type: "active-chunk";
       rows: PreparedSessionTranscriptProjection["activeRows"];
+      sessionId: string;
+    }
+  | {
+      type: "display-chunk";
+      rows: PreparedSessionTranscriptProjection["displayRows"];
       sessionId: string;
     }
   | { type: "done" }
@@ -139,31 +145,48 @@ function takeFtsChunkEnd(rows: readonly TranscriptIndexEntry[], start: number): 
 }
 
 async function streamPreparedProjection(plan: PreparedSessionTranscriptProjection): Promise<void> {
-  const { activeRows, ftsRows, ...metadata } = plan;
+  const { activeRows, displayRows, ftsRows, ...metadata } = plan;
   if (!(await postAndWait({ type: "plan-start", plan: metadata }))) {
     return;
   }
-  for (let offset = 0; offset < activeRows.length; offset += ACTIVE_ROWS_PER_CHUNK) {
-    if (
-      !(await postAndWait({
-        type: "active-chunk",
-        rows: activeRows.slice(offset, offset + ACTIVE_ROWS_PER_CHUNK),
-        sessionId: plan.sessionId,
-      }))
-    ) {
-      return;
+  if (plan.activeNeedsRebuild) {
+    for (let offset = 0; offset < activeRows.length; offset += ACTIVE_ROWS_PER_CHUNK) {
+      if (
+        !(await postAndWait({
+          type: "active-chunk",
+          rows: activeRows.slice(offset, offset + ACTIVE_ROWS_PER_CHUNK),
+          sessionId: plan.sessionId,
+        }))
+      ) {
+        return;
+      }
     }
   }
-  for (let offset = 0; offset < ftsRows.length;) {
-    const end = takeFtsChunkEnd(ftsRows, offset);
-    const chunk = encodeFtsChunk(ftsRows.slice(offset, end));
-    const accepted = await postAndWait({ type: "fts-chunk", chunk, sessionId: plan.sessionId }, [
-      chunk.textBytes.buffer,
-    ]);
-    if (!accepted) {
-      return;
+  if (plan.displayNeedsRebuild) {
+    for (let offset = 0; offset < displayRows.length; offset += DISPLAY_ROWS_PER_CHUNK) {
+      if (
+        !(await postAndWait({
+          type: "display-chunk",
+          rows: displayRows.slice(offset, offset + DISPLAY_ROWS_PER_CHUNK),
+          sessionId: plan.sessionId,
+        }))
+      ) {
+        return;
+      }
     }
-    offset = end;
+  }
+  if (plan.activeNeedsRebuild) {
+    for (let offset = 0; offset < ftsRows.length;) {
+      const end = takeFtsChunkEnd(ftsRows, offset);
+      const chunk = encodeFtsChunk(ftsRows.slice(offset, end));
+      const accepted = await postAndWait({ type: "fts-chunk", chunk, sessionId: plan.sessionId }, [
+        chunk.textBytes.buffer,
+      ]);
+      if (!accepted) {
+        return;
+      }
+      offset = end;
+    }
   }
   await postAndWait({ type: "plan-finish", sessionId: plan.sessionId });
 }

--- a/src/config/sessions/session-transcript-reconcile.worker.ts
+++ b/src/config/sessions/session-transcript-reconcile.worker.ts
@@ -4,7 +4,7 @@ import {
   closeOpenClawAgentDatabaseByPath,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
-import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
+import { listSessionsNeedingTranscriptProjectionReconcile } from "./session-transcript-index.js";
 import {
   prepareSessionTranscriptProjection,
   type PreparedSessionTranscriptProjection,
@@ -198,7 +198,7 @@ async function run(): Promise<void> {
       path: reconcileInput.path,
     });
     const sessionIds = orderSessionIds(
-      listSessionsNeedingTranscriptIndexReconcile(database.db),
+      listSessionsNeedingTranscriptProjectionReconcile(database.db),
       reconcileInput.preferredSessionId,
     );
     for (const sessionId of sessionIds) {

--- a/src/config/sessions/session-transcript-search.ts
+++ b/src/config/sessions/session-transcript-search.ts
@@ -6,10 +6,7 @@ import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 import { listSessionsNeedingTranscriptIndexReconcile } from "./session-transcript-index.js";
-import {
-  isSessionTranscriptIndexReconcileRunning,
-  startSessionTranscriptIndexReconcile,
-} from "./session-transcript-reconcile.js";
+import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
 
 const SEARCH_SNIPPET_MAX_CHARS = 500;
 const SEARCH_LIMIT_MAX = 25;
@@ -70,8 +67,7 @@ export function searchSessionTranscripts(params: {
   if (dirtySessions.length > 0) {
     startSessionTranscriptIndexReconcile(databaseOptions);
   }
-  const indexing =
-    dirtySessions.length > 0 || isSessionTranscriptIndexReconcileRunning(databaseOptions);
+  const indexing = dirtySessions.length > 0;
   const limit = Math.min(Math.max(1, params.limit ?? 10), SEARCH_LIMIT_MAX);
   const sessionKeys = params.sessionKeys ?? [];
   const whereSession =

--- a/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
@@ -83,6 +83,11 @@ export function historicalV15AgentSchemaSql(): string {
     "-- Canonical cold-tier owner for reclaimed transcript generations.",
     "CREATE TABLE IF NOT EXISTS transcript_rewrite_watermarks (",
   );
+  sql = removeSchemaRange(
+    sql,
+    "CREATE TABLE IF NOT EXISTS session_transcript_display_state (",
+    "CREATE VIRTUAL TABLE IF NOT EXISTS session_transcript_fts USING fts5(",
+  );
   return removeSchemaRange(
     sql,
     "CREATE TABLE IF NOT EXISTS standing_intents (",

--- a/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
@@ -77,6 +77,11 @@ export function historicalV15AgentSchemaSql(): string {
     "-- Canonical cold-tier owner for reclaimed transcript generations.",
     "CREATE TABLE IF NOT EXISTS transcript_rewrite_watermarks (",
   );
+  sql = removeSchemaRange(
+    sql,
+    "CREATE TABLE IF NOT EXISTS session_transcript_display_state (",
+    "CREATE VIRTUAL TABLE IF NOT EXISTS session_transcript_fts USING fts5(",
+  );
   return removeSchemaRange(
     sql,
     "CREATE TABLE IF NOT EXISTS standing_intents (",

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -33,6 +33,7 @@ import {
 import {
   SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE,
   SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE,
+  validateOpenClawAgentDisplayRowSchema,
 } from "./openclaw-agent-display-row-schema.js";
 import { MESSAGE_TOOL_RUN_OUTCOMES_TABLE } from "./openclaw-agent-message-tool-outcome-schema.js";
 import {
@@ -132,6 +133,7 @@ export function assertOpenClawAgentCurrentRuntimeSchema(
     );
   }
   assertOpenClawAgentSchemaContains(database, options.pathname, OPENCLAW_AGENT_SCHEMA_SQL);
+  validateOpenClawAgentDisplayRowSchema(database);
 }
 
 function hasAnyCanonicalTable(database: DatabaseSync, schemaSql: string): boolean {

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -30,6 +30,10 @@ import {
   ensureSessionAdditiveColumns,
   ensureSessionEntryValidityProjection,
 } from "./openclaw-agent-db-session-migrations.js";
+import {
+  SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE,
+  SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE,
+} from "./openclaw-agent-display-row-schema.js";
 import { MESSAGE_TOOL_RUN_OUTCOMES_TABLE } from "./openclaw-agent-message-tool-outcome-schema.js";
 import {
   ensureOpenClawAgentProgressCardSchemaInTransaction,
@@ -66,6 +70,8 @@ const AGENT_SCHEMA_COMPATIBILITY = {
     SESSION_PARTICIPANTS_TABLE,
     SESSION_PROGRESS_CARDS_TABLE,
     SESSION_TRANSCRIPT_ARCHIVES_TABLE,
+    SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE,
+    SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE,
     STANDING_INTENTS_TABLE,
     STANDING_INTENTS_FTS_TABLE,
     ...STANDING_INTENTS_FTS_SHADOW_TABLES,

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -30,6 +30,10 @@ import {
   ensureSessionEntryValidityProjection,
   ensureSessionProjectColumn,
 } from "./openclaw-agent-db-session-migrations.js";
+import {
+  SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE,
+  SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE,
+} from "./openclaw-agent-display-row-schema.js";
 import { MESSAGE_TOOL_RUN_OUTCOMES_TABLE } from "./openclaw-agent-message-tool-outcome-schema.js";
 import {
   ensureOpenClawAgentProgressCardSchemaInTransaction,
@@ -66,6 +70,8 @@ const AGENT_SCHEMA_COMPATIBILITY = {
     SESSION_PARTICIPANTS_TABLE,
     SESSION_PROGRESS_CARDS_TABLE,
     SESSION_TRANSCRIPT_ARCHIVES_TABLE,
+    SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE,
+    SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE,
     STANDING_INTENTS_TABLE,
     STANDING_INTENTS_FTS_TABLE,
     ...STANDING_INTENTS_FTS_SHADOW_TABLES,

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -57,6 +57,7 @@ import {
 } from "./openclaw-agent-db-session-provenance.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "./openclaw-agent-db.generated.js";
 import { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
+import { AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL } from "./openclaw-agent-display-row-schema.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db.js";
 
@@ -64,6 +65,7 @@ type OpenClawAgentMetadataDatabase = Pick<OpenClawAgentKyselyDatabase, "schema_m
 type MigratedSessionEntry = Record<string, unknown>;
 
 const agentDbLog = createSubsystemLogger("state/agent-db");
+const BASE_AGENT_SCHEMA_SQL = AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL;
 
 function migratedSessionColumn(
   columns: ReadonlySet<string>,
@@ -573,7 +575,7 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
       hasPendingSessionConversationRouteContextColumn(database) ||
       hasPendingSessionProjectColumn(database));
   if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION && !hasPendingCurrentVersionMigration) {
-    verifyAndRepairCanonicalSqliteIndexes(database, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
+    verifyAndRepairCanonicalSqliteIndexes(database, pathname, BASE_AGENT_SCHEMA_SQL, {
       allowMissingColumns: true,
       validateAfterRepair: () =>
         assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname }),
@@ -635,11 +637,11 @@ function ensureAgentSchema(
         ensureSessionKeyContractSchemaInTransaction(db);
         if (hasPendingMemoryChunkMetadataMigration(db)) {
           migrateMemoryChunkMetadataSchema(db);
-          db.exec(OPENCLAW_AGENT_SCHEMA_SQL);
+          db.exec(BASE_AGENT_SCHEMA_SQL);
         }
         // Repeat index repair before the transactional schema assertion so a
         // concurrent opener cannot turn repairable drift into a hard refusal.
-        repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
+        repairCanonicalSqliteIndexes(db, pathname, BASE_AGENT_SCHEMA_SQL, {
           verifyPhysicalIntegrity: false,
         });
         assertAgentSchemaVersion(db, { agentId, pathname, version: targetVersion });
@@ -667,7 +669,7 @@ function ensureAgentSchema(
       migrateSessionNodesAndWindows(db, previousVersion);
       ensureSessionAdditiveColumns(db);
       ensureSessionEntryValidityProjection(db);
-      db.exec(OPENCLAW_AGENT_SCHEMA_SQL);
+      db.exec(BASE_AGENT_SCHEMA_SQL);
       migrateMemoryChunkMetadataSchema(db);
       if (previousVersion < targetVersion) {
         ensureOpenClawAgentBoardSchemaInTransaction(db);
@@ -675,11 +677,11 @@ function ensureAgentSchema(
       migrateSessionTranscriptGenerations(db, previousVersion);
       migrateSessionTranscriptActiveProjection(db, previousVersion);
       if (previousVersion < 11) {
-        migrateSqliteSchemaToStrictInTransaction(db, OPENCLAW_AGENT_SCHEMA_SQL, {
+        migrateSqliteSchemaToStrictInTransaction(db, BASE_AGENT_SCHEMA_SQL, {
           databaseLabel: pathname,
         });
       }
-      repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
+      repairCanonicalSqliteIndexes(db, pathname, BASE_AGENT_SCHEMA_SQL, {
         verifyPhysicalIntegrity: false,
       });
       const kysely = getNodeSqliteKysely<OpenClawAgentMetadataDatabase>(db);

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -57,7 +57,7 @@ import {
 } from "./openclaw-agent-db-session-provenance.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "./openclaw-agent-db.generated.js";
 import { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
-import { AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL } from "./openclaw-agent-display-row-schema.js";
+import { AGENT_BASE_SCHEMA_SQL } from "./openclaw-agent-display-row-schema.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db.js";
 
@@ -65,7 +65,6 @@ type OpenClawAgentMetadataDatabase = Pick<OpenClawAgentKyselyDatabase, "schema_m
 type MigratedSessionEntry = Record<string, unknown>;
 
 const agentDbLog = createSubsystemLogger("state/agent-db");
-const BASE_AGENT_SCHEMA_SQL = AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL;
 
 function migratedSessionColumn(
   columns: ReadonlySet<string>,
@@ -575,7 +574,7 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
       hasPendingSessionConversationRouteContextColumn(database) ||
       hasPendingSessionProjectColumn(database));
   if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION && !hasPendingCurrentVersionMigration) {
-    verifyAndRepairCanonicalSqliteIndexes(database, pathname, BASE_AGENT_SCHEMA_SQL, {
+    verifyAndRepairCanonicalSqliteIndexes(database, pathname, AGENT_BASE_SCHEMA_SQL, {
       allowMissingColumns: true,
       validateAfterRepair: () =>
         assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname }),
@@ -637,11 +636,11 @@ function ensureAgentSchema(
         ensureSessionKeyContractSchemaInTransaction(db);
         if (hasPendingMemoryChunkMetadataMigration(db)) {
           migrateMemoryChunkMetadataSchema(db);
-          db.exec(BASE_AGENT_SCHEMA_SQL);
+          db.exec(AGENT_BASE_SCHEMA_SQL);
         }
         // Repeat index repair before the transactional schema assertion so a
         // concurrent opener cannot turn repairable drift into a hard refusal.
-        repairCanonicalSqliteIndexes(db, pathname, BASE_AGENT_SCHEMA_SQL, {
+        repairCanonicalSqliteIndexes(db, pathname, AGENT_BASE_SCHEMA_SQL, {
           verifyPhysicalIntegrity: false,
         });
         assertAgentSchemaVersion(db, { agentId, pathname, version: targetVersion });
@@ -669,7 +668,7 @@ function ensureAgentSchema(
       migrateSessionNodesAndWindows(db, previousVersion);
       ensureSessionAdditiveColumns(db);
       ensureSessionEntryValidityProjection(db);
-      db.exec(BASE_AGENT_SCHEMA_SQL);
+      db.exec(AGENT_BASE_SCHEMA_SQL);
       migrateMemoryChunkMetadataSchema(db);
       if (previousVersion < targetVersion) {
         ensureOpenClawAgentBoardSchemaInTransaction(db);
@@ -677,11 +676,11 @@ function ensureAgentSchema(
       migrateSessionTranscriptGenerations(db, previousVersion);
       migrateSessionTranscriptActiveProjection(db, previousVersion);
       if (previousVersion < 11) {
-        migrateSqliteSchemaToStrictInTransaction(db, BASE_AGENT_SCHEMA_SQL, {
+        migrateSqliteSchemaToStrictInTransaction(db, AGENT_BASE_SCHEMA_SQL, {
           databaseLabel: pathname,
         });
       }
-      repairCanonicalSqliteIndexes(db, pathname, BASE_AGENT_SCHEMA_SQL, {
+      repairCanonicalSqliteIndexes(db, pathname, AGENT_BASE_SCHEMA_SQL, {
         verifyPhysicalIntegrity: false,
       });
       const kysely = getNodeSqliteKysely<OpenClawAgentMetadataDatabase>(db);

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -56,6 +56,7 @@ import {
 } from "./openclaw-agent-db-session-provenance.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "./openclaw-agent-db.generated.js";
 import { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
+import { AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL } from "./openclaw-agent-display-row-schema.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db.js";
 
@@ -63,6 +64,7 @@ type OpenClawAgentMetadataDatabase = Pick<OpenClawAgentKyselyDatabase, "schema_m
 type MigratedSessionEntry = Record<string, unknown>;
 
 const agentDbLog = createSubsystemLogger("state/agent-db");
+const BASE_AGENT_SCHEMA_SQL = AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL;
 
 function migratedSessionColumn(
   columns: ReadonlySet<string>,
@@ -571,7 +573,7 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
       hasRetiredAgentStateLeaseSchema(database) ||
       hasPendingSessionProjectColumn(database));
   if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION && !hasPendingCurrentVersionMigration) {
-    verifyAndRepairCanonicalSqliteIndexes(database, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
+    verifyAndRepairCanonicalSqliteIndexes(database, pathname, BASE_AGENT_SCHEMA_SQL, {
       allowMissingColumns: true,
       validateAfterRepair: () =>
         assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname }),
@@ -633,11 +635,11 @@ function ensureAgentSchema(
         ensureSessionKeyContractSchemaInTransaction(db);
         if (hasPendingMemoryChunkMetadataMigration(db)) {
           migrateMemoryChunkMetadataSchema(db);
-          db.exec(OPENCLAW_AGENT_SCHEMA_SQL);
+          db.exec(BASE_AGENT_SCHEMA_SQL);
         }
         // Repeat index repair before the transactional schema assertion so a
         // concurrent opener cannot turn repairable drift into a hard refusal.
-        repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
+        repairCanonicalSqliteIndexes(db, pathname, BASE_AGENT_SCHEMA_SQL, {
           verifyPhysicalIntegrity: false,
         });
         assertAgentSchemaVersion(db, { agentId, pathname, version: targetVersion });
@@ -665,7 +667,7 @@ function ensureAgentSchema(
       migrateSessionNodesAndWindows(db, previousVersion);
       ensureSessionProjectColumn(db);
       ensureSessionEntryValidityProjection(db);
-      db.exec(OPENCLAW_AGENT_SCHEMA_SQL);
+      db.exec(BASE_AGENT_SCHEMA_SQL);
       migrateMemoryChunkMetadataSchema(db);
       if (previousVersion < targetVersion) {
         ensureOpenClawAgentBoardSchemaInTransaction(db);
@@ -673,11 +675,11 @@ function ensureAgentSchema(
       migrateSessionTranscriptGenerations(db, previousVersion);
       migrateSessionTranscriptActiveProjection(db, previousVersion);
       if (previousVersion < 11) {
-        migrateSqliteSchemaToStrictInTransaction(db, OPENCLAW_AGENT_SCHEMA_SQL, {
+        migrateSqliteSchemaToStrictInTransaction(db, BASE_AGENT_SCHEMA_SQL, {
           databaseLabel: pathname,
         });
       }
-      repairCanonicalSqliteIndexes(db, pathname, OPENCLAW_AGENT_SCHEMA_SQL, {
+      repairCanonicalSqliteIndexes(db, pathname, BASE_AGENT_SCHEMA_SQL, {
         verifyPhysicalIntegrity: false,
       });
       const kysely = getNodeSqliteKysely<OpenClawAgentMetadataDatabase>(db);

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -325,6 +325,25 @@ export interface SessionTranscriptArchives {
   session_key: string;
 }
 
+export interface SessionTranscriptDisplayRows {
+  display_ordinal: number;
+  kind: string;
+  revision: number;
+  row_id: string;
+  row_version: number;
+  session_id: string;
+  source_event_seq: number;
+}
+
+export interface SessionTranscriptDisplayState {
+  generation: string;
+  indexed_seq: number;
+  needs_rebuild: Generated<number>;
+  row_count: number;
+  session_id: string;
+  updated_at: number;
+}
+
 export interface SessionTranscriptFts {
   message_id: string | null;
   role: string | null;
@@ -506,6 +525,8 @@ export interface DB {
   session_suggestions: SessionSuggestions;
   session_transcript_active_events: SessionTranscriptActiveEvents;
   session_transcript_archives: SessionTranscriptArchives;
+  session_transcript_display_rows: SessionTranscriptDisplayRows;
+  session_transcript_display_state: SessionTranscriptDisplayState;
   session_transcript_fts: SessionTranscriptFts;
   session_transcript_fts_config: SessionTranscriptFtsConfig;
   session_transcript_fts_content: SessionTranscriptFtsContent;

--- a/src/state/openclaw-agent-db.generated.d.ts
+++ b/src/state/openclaw-agent-db.generated.d.ts
@@ -324,6 +324,25 @@ export interface SessionTranscriptArchives {
   session_key: string;
 }
 
+export interface SessionTranscriptDisplayRows {
+  display_ordinal: number;
+  kind: string;
+  revision: number;
+  row_id: string;
+  row_version: number;
+  session_id: string;
+  source_event_seq: number;
+}
+
+export interface SessionTranscriptDisplayState {
+  generation: string;
+  indexed_seq: number;
+  needs_rebuild: Generated<number>;
+  row_count: number;
+  session_id: string;
+  updated_at: number;
+}
+
 export interface SessionTranscriptFts {
   message_id: string | null;
   role: string | null;
@@ -505,6 +524,8 @@ export interface DB {
   session_suggestions: SessionSuggestions;
   session_transcript_active_events: SessionTranscriptActiveEvents;
   session_transcript_archives: SessionTranscriptArchives;
+  session_transcript_display_rows: SessionTranscriptDisplayRows;
+  session_transcript_display_state: SessionTranscriptDisplayState;
   session_transcript_fts: SessionTranscriptFts;
   session_transcript_fts_config: SessionTranscriptFtsConfig;
   session_transcript_fts_content: SessionTranscriptFtsContent;

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -51,7 +51,7 @@ import {
   resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
 } from "./openclaw-agent-db.js";
-import { AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL } from "./openclaw-agent-display-row-schema.js";
+import { AGENT_BASE_SCHEMA_SQL } from "./openclaw-agent-display-row-schema.js";
 import {
   closeOpenClawStateDatabaseForTest,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
@@ -83,7 +83,7 @@ function createCurrentAgentRuntimeSchemaShape() {
   const { DatabaseSync } = requireNodeSqlite();
   const database = new DatabaseSync(":memory:");
   try {
-    database.exec(AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL);
+    database.exec(AGENT_BASE_SCHEMA_SQL);
     return collectSqliteSchemaShape(database);
   } finally {
     database.close();

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -51,6 +51,7 @@ import {
   resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
 } from "./openclaw-agent-db.js";
+import { AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL } from "./openclaw-agent-display-row-schema.js";
 import {
   closeOpenClawStateDatabaseForTest,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
@@ -60,7 +61,6 @@ import {
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 import {
   collectSqliteSchemaShape,
-  createSqliteSchemaShapeFromSql,
   normalizeSqliteSchemaShapeSql,
   replaceNamedIndexesWithNoncanonicalIndexes,
 } from "./sqlite-schema-shape.test-support.js";
@@ -77,6 +77,17 @@ let v13WorkerAgentDatabaseTemplatePath: string | undefined;
 
 function createTempStateDir(): string {
   return makeTempDir(agentDbTempDirs, "openclaw-agent-db-");
+}
+
+function createCurrentAgentRuntimeSchemaShape() {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(":memory:");
+  try {
+    database.exec(AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL);
+    return collectSqliteSchemaShape(database);
+  } finally {
+    database.close();
+  }
 }
 
 function ensureSharedStateDatabaseTemplate(): string {
@@ -1273,9 +1284,7 @@ describe("openclaw agent database", () => {
       env: { OPENCLAW_STATE_DIR: stateDir },
     });
 
-    expect(collectSqliteSchemaShape(database.db)).toEqual(
-      createSqliteSchemaShapeFromSql(new URL("./openclaw-agent-schema.sql", import.meta.url)),
-    );
+    expect(collectSqliteSchemaShape(database.db)).toEqual(createCurrentAgentRuntimeSchemaShape());
     expect(
       database.db
         .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'state_leases'")
@@ -3424,9 +3433,7 @@ describe("openclaw agent database", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
-    const canonicalShape = normalizeSqliteSchemaShapeSql(
-      createSqliteSchemaShapeFromSql(new URL("./openclaw-agent-schema.sql", import.meta.url)),
-    );
+    const canonicalShape = normalizeSqliteSchemaShapeSql(createCurrentAgentRuntimeSchemaShape());
 
     const { DatabaseSync } = requireNodeSqlite();
     const drifted = new DatabaseSync(databasePath);
@@ -3505,9 +3512,7 @@ describe("openclaw agent database", () => {
 
     const repaired = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     expect(normalizeSqliteSchemaShapeSql(collectSqliteSchemaShape(repaired.db))).toEqual(
-      normalizeSqliteSchemaShapeSql(
-        createSqliteSchemaShapeFromSql(new URL("./openclaw-agent-schema.sql", import.meta.url)),
-      ),
+      normalizeSqliteSchemaShapeSql(createCurrentAgentRuntimeSchemaShape()),
     );
     expect(
       repaired.db

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -51,6 +51,7 @@ import {
   resolveOpenClawAgentSqlitePath,
   runOpenClawAgentWriteTransaction,
 } from "./openclaw-agent-db.js";
+import { AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL } from "./openclaw-agent-display-row-schema.js";
 import {
   closeOpenClawStateDatabaseForTest,
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
@@ -60,7 +61,6 @@ import {
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
 import {
   collectSqliteSchemaShape,
-  createSqliteSchemaShapeFromSql,
   normalizeSqliteSchemaShapeSql,
   replaceNamedIndexesWithNoncanonicalIndexes,
 } from "./sqlite-schema-shape.test-support.js";
@@ -77,6 +77,17 @@ let v13WorkerAgentDatabaseTemplatePath: string | undefined;
 
 function createTempStateDir(): string {
   return makeTempDir(agentDbTempDirs, "openclaw-agent-db-");
+}
+
+function createCurrentAgentRuntimeSchemaShape() {
+  const { DatabaseSync } = requireNodeSqlite();
+  const database = new DatabaseSync(":memory:");
+  try {
+    database.exec(AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL);
+    return collectSqliteSchemaShape(database);
+  } finally {
+    database.close();
+  }
 }
 
 function ensureSharedStateDatabaseTemplate(): string {
@@ -1273,9 +1284,7 @@ describe("openclaw agent database", () => {
       env: { OPENCLAW_STATE_DIR: stateDir },
     });
 
-    expect(collectSqliteSchemaShape(database.db)).toEqual(
-      createSqliteSchemaShapeFromSql(new URL("./openclaw-agent-schema.sql", import.meta.url)),
-    );
+    expect(collectSqliteSchemaShape(database.db)).toEqual(createCurrentAgentRuntimeSchemaShape());
     expect(
       database.db
         .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = 'state_leases'")
@@ -3424,9 +3433,7 @@ describe("openclaw agent database", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
-    const canonicalShape = normalizeSqliteSchemaShapeSql(
-      createSqliteSchemaShapeFromSql(new URL("./openclaw-agent-schema.sql", import.meta.url)),
-    );
+    const canonicalShape = normalizeSqliteSchemaShapeSql(createCurrentAgentRuntimeSchemaShape());
 
     const { DatabaseSync } = requireNodeSqlite();
     const drifted = new DatabaseSync(databasePath);
@@ -3503,9 +3510,7 @@ describe("openclaw agent database", () => {
 
     const repaired = migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env });
     expect(normalizeSqliteSchemaShapeSql(collectSqliteSchemaShape(repaired.db))).toEqual(
-      normalizeSqliteSchemaShapeSql(
-        createSqliteSchemaShapeFromSql(new URL("./openclaw-agent-schema.sql", import.meta.url)),
-      ),
+      normalizeSqliteSchemaShapeSql(createCurrentAgentRuntimeSchemaShape()),
     );
     expect(
       repaired.db

--- a/src/state/openclaw-agent-display-row-schema.test.ts
+++ b/src/state/openclaw-agent-display-row-schema.test.ts
@@ -1,0 +1,215 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "./openclaw-agent-db.js";
+import {
+  ensureOpenClawAgentDisplayRowSchema,
+  AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL,
+  SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE,
+  SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE,
+} from "./openclaw-agent-display-row-schema.js";
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+});
+
+function tableExists(database: DatabaseSync, tableName: string): boolean {
+  return Boolean(
+    database
+      .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?")
+      .get(tableName),
+  );
+}
+
+function createDisplayDatabase(): DatabaseSync {
+  const database = new DatabaseSync(":memory:");
+  database.exec("PRAGMA foreign_keys = ON;");
+  database.exec(OPENCLAW_AGENT_SCHEMA_SQL);
+  database
+    .prepare(
+      `INSERT INTO session_nodes
+         (session_key, current_session_id, entry_json, entry_valid, updated_at)
+       VALUES ('agent:main:test', 'session-1', '{}', -1, 1)`,
+    )
+    .run();
+  database
+    .prepare(
+      `INSERT INTO session_windows
+         (session_id, session_key, session_scope, created_at, updated_at)
+       VALUES ('session-1', 'agent:main:test', 'conversation', 1, 1)`,
+    )
+    .run();
+  database
+    .prepare(
+      `INSERT INTO transcript_events (session_id, seq, event_json, created_at)
+       VALUES ('session-1', 0, '{"type":"session","id":"session-1"}', 1)`,
+    )
+    .run();
+  return database;
+}
+
+function insertDisplayStateAndRow(database: DatabaseSync): void {
+  database
+    .prepare(
+      `INSERT INTO session_transcript_display_state
+         (session_id, generation, indexed_seq, row_count, needs_rebuild, updated_at)
+       VALUES ('session-1', 'generation-1', 0, 1, 0, 1)`,
+    )
+    .run();
+  database
+    .prepare(
+      `INSERT INTO session_transcript_display_rows
+         (session_id, row_id, row_version, revision, display_ordinal, source_event_seq, kind)
+       VALUES ('session-1', 'row-1', 1, 1, 0, 0, 'opaque')`,
+    )
+    .run();
+}
+
+describe("agent display-row schema", () => {
+  it("stays absent until first use without changing schema version metadata", () => {
+    const stateDir = tempDirs.make("openclaw-display-row-schema-");
+    const database = openOpenClawAgentDatabase({
+      agentId: "main",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const versionBefore = database.db.prepare("PRAGMA user_version").get();
+    const metadataBefore = database.db
+      .prepare("SELECT schema_version, updated_at FROM schema_meta WHERE meta_key = 'primary'")
+      .get();
+
+    expect(tableExists(database.db, SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE)).toBe(false);
+    expect(tableExists(database.db, SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE)).toBe(false);
+
+    ensureOpenClawAgentDisplayRowSchema(database.db);
+    ensureOpenClawAgentDisplayRowSchema(database.db);
+
+    expect(tableExists(database.db, SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE)).toBe(true);
+    expect(tableExists(database.db, SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE)).toBe(true);
+    expect(
+      database.db
+        .prepare(
+          "SELECT name, strict FROM pragma_table_list WHERE name LIKE 'session_transcript_display_%' ORDER BY name",
+        )
+        .all(),
+    ).toEqual([
+      { name: SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE, strict: 1 },
+      { name: SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE, strict: 1 },
+    ]);
+    expect(database.db.prepare("PRAGMA user_version").get()).toEqual(versionBefore);
+    expect(
+      database.db
+        .prepare("SELECT schema_version, updated_at FROM schema_meta WHERE meta_key = 'primary'")
+        .get(),
+    ).toEqual(metadataBefore);
+  });
+
+  it("does not cache a schema ensure rolled back by its caller", () => {
+    const database = new DatabaseSync(":memory:");
+    try {
+      database.exec(AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL);
+      database.exec("BEGIN IMMEDIATE;");
+      ensureOpenClawAgentDisplayRowSchema(database);
+      database.exec("ROLLBACK;");
+
+      expect(tableExists(database, SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE)).toBe(false);
+      ensureOpenClawAgentDisplayRowSchema(database);
+      expect(tableExists(database, SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE)).toBe(true);
+    } finally {
+      database.close();
+    }
+  });
+
+  it.each([
+    {
+      name: "one missing table",
+      damage: `DROP TABLE ${SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE};`,
+      message: /partially present/u,
+    },
+    {
+      name: "one missing index",
+      damage: "DROP INDEX idx_agent_transcript_display_ordinal;",
+      message: /idx_agent_transcript_display_ordinal|schema/u,
+    },
+    {
+      name: "a malformed row table",
+      damage: `
+        DROP TABLE ${SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE};
+        CREATE TABLE ${SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE} (
+          session_id TEXT NOT NULL,
+          row_id TEXT NOT NULL,
+          PRIMARY KEY (session_id, row_id)
+        ) STRICT;
+      `,
+      message: /session_transcript_display_rows|schema/u,
+    },
+  ])("rejects $name instead of silently completing the group", ({ damage, message }) => {
+    const database = new DatabaseSync(":memory:");
+    try {
+      database.exec(OPENCLAW_AGENT_SCHEMA_SQL);
+      database.exec(damage);
+      expect(() => ensureOpenClawAgentDisplayRowSchema(database)).toThrow(message);
+    } finally {
+      database.close();
+    }
+  });
+
+  it("keeps a complete populated group compatible with the prior schema contract", () => {
+    const database = createDisplayDatabase();
+    try {
+      insertDisplayStateAndRow(database);
+      expect(() =>
+        assertSqliteSchemaContains(
+          database,
+          "previous agent schema",
+          AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL,
+        ),
+      ).not.toThrow();
+      expect(database.prepare("SELECT row_id FROM session_transcript_display_rows").get()).toEqual({
+        row_id: "row-1",
+      });
+    } finally {
+      database.close();
+    }
+  });
+
+  it.each([
+    {
+      deleteSql: "DELETE FROM transcript_events WHERE session_id = 'session-1' AND seq = 0",
+      expectedStateRows: 1,
+      name: "source event",
+    },
+    {
+      deleteSql: "DELETE FROM session_transcript_display_state WHERE session_id = 'session-1'",
+      expectedStateRows: 0,
+      name: "display state",
+    },
+    {
+      deleteSql: "DELETE FROM session_windows WHERE session_id = 'session-1'",
+      expectedStateRows: 0,
+      name: "session",
+    },
+  ])("cascades display rows when deleting the $name owner", ({ deleteSql, expectedStateRows }) => {
+    const database = createDisplayDatabase();
+    try {
+      insertDisplayStateAndRow(database);
+      database.exec(deleteSql);
+
+      expect(
+        database.prepare("SELECT COUNT(*) AS count FROM session_transcript_display_rows").get(),
+      ).toEqual({ count: 0 });
+      expect(
+        database.prepare("SELECT COUNT(*) AS count FROM session_transcript_display_state").get(),
+      ).toEqual({ count: expectedStateRows });
+      expect(database.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    } finally {
+      database.close();
+    }
+  });
+});

--- a/src/state/openclaw-agent-display-row-schema.test.ts
+++ b/src/state/openclaw-agent-display-row-schema.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./openclaw-agent-db.js";
 import {
   ensureOpenClawAgentDisplayRowSchema,
-  AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL,
+  AGENT_BASE_SCHEMA_SQL,
   SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE,
   SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE,
 } from "./openclaw-agent-display-row-schema.js";
@@ -113,7 +113,7 @@ describe("agent display-row schema", () => {
   it("does not cache a schema ensure rolled back by its caller", () => {
     const database = new DatabaseSync(":memory:");
     try {
-      database.exec(AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL);
+      database.exec(AGENT_BASE_SCHEMA_SQL);
       database.exec("BEGIN IMMEDIATE;");
       ensureOpenClawAgentDisplayRowSchema(database);
       database.exec("ROLLBACK;");
@@ -149,15 +149,15 @@ describe("agent display-row schema", () => {
       `,
       message: /session_transcript_display_rows|schema/u,
     },
-  ])("rejects $name instead of silently completing the group", ({ damage, message }) => {
-    const database = new DatabaseSync(":memory:");
-    try {
-      database.exec(OPENCLAW_AGENT_SCHEMA_SQL);
-      database.exec(damage);
-      expect(() => ensureOpenClawAgentDisplayRowSchema(database)).toThrow(message);
-    } finally {
-      database.close();
-    }
+  ])("rejects $name during physical reopen", ({ damage, message }) => {
+    const stateDir = tempDirs.make("openclaw-display-row-reopen-");
+    const options = { agentId: "main", env: { OPENCLAW_STATE_DIR: stateDir } };
+    const database = openOpenClawAgentDatabase(options);
+    ensureOpenClawAgentDisplayRowSchema(database.db);
+    database.db.exec(damage);
+    closeOpenClawAgentDatabasesForTest();
+
+    expect(() => openOpenClawAgentDatabase(options)).toThrow(message);
   });
 
   it("keeps a complete populated group compatible with the prior schema contract", () => {
@@ -165,11 +165,7 @@ describe("agent display-row schema", () => {
     try {
       insertDisplayStateAndRow(database);
       expect(() =>
-        assertSqliteSchemaContains(
-          database,
-          "previous agent schema",
-          AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL,
-        ),
+        assertSqliteSchemaContains(database, "previous agent schema", AGENT_BASE_SCHEMA_SQL),
       ).not.toThrow();
       expect(database.prepare("SELECT row_id FROM session_transcript_display_rows").get()).toEqual({
         row_id: "row-1",

--- a/src/state/openclaw-agent-display-row-schema.ts
+++ b/src/state/openclaw-agent-display-row-schema.ts
@@ -1,0 +1,90 @@
+import type { DatabaseSync } from "node:sqlite";
+import { assertSqliteSchemaContains } from "../infra/sqlite-schema-contract.js";
+import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
+import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
+
+export const SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE = "session_transcript_display_state";
+export const SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE = "session_transcript_display_rows";
+
+const DISPLAY_ROW_SCHEMA_START = `CREATE TABLE IF NOT EXISTS ${SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE} (`;
+const DISPLAY_ROW_SCHEMA_END =
+  "CREATE VIRTUAL TABLE IF NOT EXISTS session_transcript_fts USING fts5(";
+const ENSURED_DATABASES = new WeakSet<DatabaseSync>();
+
+function splitDisplayRowSchema(sql: string): {
+  displayRows: string;
+  withoutDisplayRows: string;
+} {
+  const start = sql.indexOf(DISPLAY_ROW_SCHEMA_START);
+  const end = sql.indexOf(DISPLAY_ROW_SCHEMA_END, start);
+  if (start === -1 || end === -1) {
+    throw new Error("OpenClaw agent display-row schema markers are missing.");
+  }
+  return {
+    displayRows: sql.slice(start, end),
+    withoutDisplayRows: `${sql.slice(0, start)}${sql.slice(end)}`,
+  };
+}
+
+const displayRowSchema = splitDisplayRowSchema(OPENCLAW_AGENT_SCHEMA_SQL);
+
+const AGENT_DISPLAY_ROW_SCHEMA_SQL = displayRowSchema.displayRows;
+export const AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL = displayRowSchema.withoutDisplayRows;
+
+function hasDisplayRowTable(db: DatabaseSync, tableName: string): boolean {
+  return Boolean(
+    db.prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?").get(tableName),
+  );
+}
+
+function validateExistingDisplayRowSchema(db: DatabaseSync): boolean {
+  const statePresent = hasDisplayRowTable(db, SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE);
+  const rowsPresent = hasDisplayRowTable(db, SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE);
+  if (!statePresent && !rowsPresent) {
+    return false;
+  }
+  if (!statePresent || !rowsPresent) {
+    throw new Error("OpenClaw agent display-row schema is partially present.");
+  }
+  assertSqliteSchemaContains(db, "OpenClaw agent display-row schema", AGENT_DISPLAY_ROW_SCHEMA_SQL);
+  return true;
+}
+
+function cacheDisplayRowSchemaAfterTransaction(db: DatabaseSync): void {
+  setImmediate(() => {
+    if (!db.isOpen || db.isTransaction) {
+      return;
+    }
+    try {
+      if (validateExistingDisplayRowSchema(db)) {
+        ENSURED_DATABASES.add(db);
+      }
+    } catch {
+      // The next feature use must surface external drift synchronously.
+    }
+  });
+}
+
+/** Lazily installs the complete additive display-row group on first projection use. */
+export function ensureOpenClawAgentDisplayRowSchema(db: DatabaseSync): void {
+  if (ENSURED_DATABASES.has(db)) {
+    return;
+  }
+  const ensure = () => {
+    if (!validateExistingDisplayRowSchema(db)) {
+      db.exec(AGENT_DISPLAY_ROW_SCHEMA_SQL); // sqlite-allow-raw -- Canonical additive DDL only.
+      assertSqliteSchemaContains(
+        db,
+        "OpenClaw agent display-row schema",
+        AGENT_DISPLAY_ROW_SCHEMA_SQL,
+      );
+    }
+  };
+  if (db.isTransaction) {
+    ensure();
+    cacheDisplayRowSchemaAfterTransaction(db);
+    return;
+  }
+  runSqliteImmediateTransactionSync(db, ensure);
+  ENSURED_DATABASES.add(db);
+}

--- a/src/state/openclaw-agent-display-row-schema.ts
+++ b/src/state/openclaw-agent-display-row-schema.ts
@@ -9,6 +9,7 @@ export const SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE = "session_transcript_display
 const DISPLAY_ROW_SCHEMA_START = `CREATE TABLE IF NOT EXISTS ${SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE} (`;
 const DISPLAY_ROW_SCHEMA_END =
   "CREATE VIRTUAL TABLE IF NOT EXISTS session_transcript_fts USING fts5(";
+const SQLITE_TABLE_EXISTS_SQL = "SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?";
 const ENSURED_DATABASES = new WeakSet<DatabaseSync>();
 
 function splitDisplayRowSchema(sql: string): {
@@ -33,7 +34,8 @@ export const AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL = displayRowSchema.withoutDis
 
 function hasDisplayRowTable(db: DatabaseSync, tableName: string): boolean {
   return Boolean(
-    db.prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?").get(tableName),
+    // Schema ownership must reject an incomplete lazy group before installing it.
+    db.prepare(/* sqlite-allow-raw */ SQLITE_TABLE_EXISTS_SQL).get(tableName),
   );
 }
 

--- a/src/state/openclaw-agent-display-row-schema.ts
+++ b/src/state/openclaw-agent-display-row-schema.ts
@@ -11,6 +11,7 @@ const DISPLAY_ROW_SCHEMA_END =
   "CREATE VIRTUAL TABLE IF NOT EXISTS session_transcript_fts USING fts5(";
 const SQLITE_TABLE_EXISTS_SQL = "SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = ?";
 const ENSURED_DATABASES = new WeakSet<DatabaseSync>();
+const ABSENT_DATABASES = new WeakSet<DatabaseSync>();
 
 function splitDisplayRowSchema(sql: string): {
   displayRows: string;
@@ -30,7 +31,7 @@ function splitDisplayRowSchema(sql: string): {
 const displayRowSchema = splitDisplayRowSchema(OPENCLAW_AGENT_SCHEMA_SQL);
 
 const AGENT_DISPLAY_ROW_SCHEMA_SQL = displayRowSchema.displayRows;
-export const AGENT_SCHEMA_WITHOUT_DISPLAY_ROWS_SQL = displayRowSchema.withoutDisplayRows;
+export const AGENT_BASE_SCHEMA_SQL = displayRowSchema.withoutDisplayRows;
 
 function hasDisplayRowTable(db: DatabaseSync, tableName: string): boolean {
   return Boolean(
@@ -39,16 +40,24 @@ function hasDisplayRowTable(db: DatabaseSync, tableName: string): boolean {
   );
 }
 
-function validateExistingDisplayRowSchema(db: DatabaseSync): boolean {
+export function validateOpenClawAgentDisplayRowSchema(db: DatabaseSync): boolean {
+  if (ENSURED_DATABASES.has(db)) {
+    return true;
+  }
+  if (ABSENT_DATABASES.has(db)) {
+    return false;
+  }
   const statePresent = hasDisplayRowTable(db, SESSION_TRANSCRIPT_DISPLAY_STATE_TABLE);
   const rowsPresent = hasDisplayRowTable(db, SESSION_TRANSCRIPT_DISPLAY_ROWS_TABLE);
   if (!statePresent && !rowsPresent) {
+    ABSENT_DATABASES.add(db);
     return false;
   }
   if (!statePresent || !rowsPresent) {
     throw new Error("OpenClaw agent display-row schema is partially present.");
   }
   assertSqliteSchemaContains(db, "OpenClaw agent display-row schema", AGENT_DISPLAY_ROW_SCHEMA_SQL);
+  ENSURED_DATABASES.add(db);
   return true;
 }
 
@@ -58,7 +67,7 @@ function cacheDisplayRowSchemaAfterTransaction(db: DatabaseSync): void {
       return;
     }
     try {
-      if (validateExistingDisplayRowSchema(db)) {
+      if (validateOpenClawAgentDisplayRowSchema(db)) {
         ENSURED_DATABASES.add(db);
       }
     } catch {
@@ -73,8 +82,9 @@ export function ensureOpenClawAgentDisplayRowSchema(db: DatabaseSync): void {
     return;
   }
   const ensure = () => {
-    if (!validateExistingDisplayRowSchema(db)) {
+    if (!validateOpenClawAgentDisplayRowSchema(db)) {
       db.exec(AGENT_DISPLAY_ROW_SCHEMA_SQL); // sqlite-allow-raw -- Canonical additive DDL only.
+      ABSENT_DATABASES.delete(db);
       assertSqliteSchemaContains(
         db,
         "OpenClaw agent display-row schema",

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -649,6 +649,35 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_active_messages
   ON session_transcript_active_events(session_id, message_position)
   WHERE message_position IS NOT NULL;
 
+CREATE TABLE IF NOT EXISTS session_transcript_display_state (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  generation TEXT NOT NULL,
+  indexed_seq INTEGER NOT NULL CHECK (indexed_seq >= -1),
+  row_count INTEGER NOT NULL CHECK (row_count >= 0),
+  needs_rebuild INTEGER NOT NULL DEFAULT 0 CHECK (needs_rebuild IN (0, 1)),
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES session_windows(session_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS session_transcript_display_rows (
+  session_id TEXT NOT NULL,
+  row_id TEXT NOT NULL,
+  row_version INTEGER NOT NULL CHECK (row_version = 1),
+  revision INTEGER NOT NULL CHECK (revision >= 1),
+  display_ordinal INTEGER NOT NULL CHECK (display_ordinal >= 0),
+  source_event_seq INTEGER NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('user', 'assistant', 'compaction', 'reset', 'opaque')),
+  PRIMARY KEY (session_id, row_id),
+  FOREIGN KEY (session_id) REFERENCES session_transcript_display_state(session_id) ON DELETE CASCADE,
+  FOREIGN KEY (session_id, source_event_seq) REFERENCES transcript_events(session_id, seq) ON DELETE CASCADE
+) STRICT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_display_ordinal
+  ON session_transcript_display_rows(session_id, display_ordinal);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_display_source
+  ON session_transcript_display_rows(session_id, source_event_seq);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS session_transcript_fts USING fts5(
   text,
   session_id UNINDEXED,

--- a/src/state/openclaw-agent-schema.sql
+++ b/src/state/openclaw-agent-schema.sql
@@ -636,6 +636,35 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_active_messages
   ON session_transcript_active_events(session_id, message_position)
   WHERE message_position IS NOT NULL;
 
+CREATE TABLE IF NOT EXISTS session_transcript_display_state (
+  session_id TEXT NOT NULL PRIMARY KEY,
+  generation TEXT NOT NULL,
+  indexed_seq INTEGER NOT NULL CHECK (indexed_seq >= -1),
+  row_count INTEGER NOT NULL CHECK (row_count >= 0),
+  needs_rebuild INTEGER NOT NULL DEFAULT 0 CHECK (needs_rebuild IN (0, 1)),
+  updated_at INTEGER NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES session_windows(session_id) ON DELETE CASCADE
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS session_transcript_display_rows (
+  session_id TEXT NOT NULL,
+  row_id TEXT NOT NULL,
+  row_version INTEGER NOT NULL CHECK (row_version = 1),
+  revision INTEGER NOT NULL CHECK (revision >= 1),
+  display_ordinal INTEGER NOT NULL CHECK (display_ordinal >= 0),
+  source_event_seq INTEGER NOT NULL,
+  kind TEXT NOT NULL CHECK (kind IN ('user', 'assistant', 'compaction', 'reset', 'opaque')),
+  PRIMARY KEY (session_id, row_id),
+  FOREIGN KEY (session_id) REFERENCES session_transcript_display_state(session_id) ON DELETE CASCADE,
+  FOREIGN KEY (session_id, source_event_seq) REFERENCES transcript_events(session_id, seq) ON DELETE CASCADE
+) STRICT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_display_ordinal
+  ON session_transcript_display_rows(session_id, display_ordinal);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_transcript_display_source
+  ON session_transcript_display_rows(session_id, source_event_seq);
+
 CREATE VIRTUAL TABLE IF NOT EXISTS session_transcript_fts USING fts5(
   text,
   session_id UNINDEXED,

--- a/src/state/sqlite-query-plan.test.ts
+++ b/src/state/sqlite-query-plan.test.ts
@@ -375,6 +375,21 @@ describe("sqlite hot query plans", () => {
     expect(displayOrdinalPlan).not.toContain("SCAN session_transcript_display_rows");
     expect(displayOrdinalPlan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
 
+    const displayTailPlan = explainQueryPlan(
+      database.db,
+      `
+        SELECT row_id, row_version, revision, display_ordinal, source_event_seq, kind
+          FROM session_transcript_display_rows
+         WHERE session_id = ?
+         ORDER BY display_ordinal DESC
+         LIMIT 201
+      `,
+      ["session-1"],
+    );
+    expect(displayTailPlan).toContain("idx_agent_transcript_display_ordinal");
+    expect(displayTailPlan).not.toContain("SCAN session_transcript_display_rows");
+    expect(displayTailPlan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+
     const displayIdentityPlan = explainQueryPlan(
       database.db,
       `

--- a/src/state/sqlite-query-plan.test.ts
+++ b/src/state/sqlite-query-plan.test.ts
@@ -6,6 +6,7 @@ import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "./openclaw-agent-db.js";
+import { ensureOpenClawAgentDisplayRowSchema } from "./openclaw-agent-display-row-schema.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -144,6 +145,7 @@ describe("sqlite hot query plans", () => {
       agentId: "worker-1",
       env: { OPENCLAW_STATE_DIR: stateDir },
     });
+    ensureOpenClawAgentDisplayRowSchema(database.db);
 
     expectPlanIncludes({
       db: database.db,
@@ -357,5 +359,32 @@ describe("sqlite hot query plans", () => {
     );
     expect(historyAnchorPlan).toContain("sqlite_autoindex_transcript_event_identities_1");
     expect(historyAnchorPlan).toContain("idx_agent_transcript_active_event_seq");
+
+    const displayOrdinalPlan = explainQueryPlan(
+      database.db,
+      `
+        SELECT row_id, row_version, revision, display_ordinal, source_event_seq, kind
+          FROM session_transcript_display_rows
+         WHERE session_id = ? AND display_ordinal >= ?
+         ORDER BY display_ordinal ASC
+         LIMIT 201
+      `,
+      ["session-1", 100],
+    );
+    expect(displayOrdinalPlan).toContain("idx_agent_transcript_display_ordinal");
+    expect(displayOrdinalPlan).not.toContain("SCAN session_transcript_display_rows");
+    expect(displayOrdinalPlan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+
+    const displayIdentityPlan = explainQueryPlan(
+      database.db,
+      `
+        SELECT row_version, revision, display_ordinal, source_event_seq, kind
+          FROM session_transcript_display_rows
+         WHERE session_id = ? AND row_id = ?
+      `,
+      ["session-1", "row-1"],
+    );
+    expect(displayIdentityPlan).toContain("sqlite_autoindex_session_transcript_display_rows_1");
+    expect(displayIdentityPlan).not.toContain("SCAN session_transcript_display_rows");
   });
 });

--- a/test/scripts/sqlite-session-schema-baseline.test.ts
+++ b/test/scripts/sqlite-session-schema-baseline.test.ts
@@ -20,6 +20,8 @@ describe("SQLite sessions/transcripts schema baseline", () => {
     expect(rendered.sql).toContain("CREATE TABLE IF NOT EXISTS transcript_events");
     expect(rendered.sql).toContain("CREATE TABLE IF NOT EXISTS transcript_event_identities");
     expect(rendered.sql).toContain("CREATE TABLE IF NOT EXISTS session_transcript_active_events");
+    expect(rendered.sql).toContain("CREATE TABLE IF NOT EXISTS session_transcript_display_state");
+    expect(rendered.sql).toContain("CREATE TABLE IF NOT EXISTS session_transcript_display_rows");
     expect(rendered.sql).not.toContain("idx_agent_transcript_events_session");
     expect(rendered.sql).not.toContain("CREATE TABLE IF NOT EXISTS cache_entries");
     expect(rendered.sql).not.toContain("CREATE TABLE IF NOT EXISTS auth_profile_store");


### PR DESCRIPTION
## Summary

This is the storage foundation for durable, bounded transcript display projections.

OpenClaw's canonical transcript events remain the source of truth. This PR adds a separate, derived SQLite representation for stable display rows so later Gateway and UI work can page chat history without repeatedly reconstructing the full transcript in memory.

## What changed

- Adds lazy per-agent SQLite tables for display projection state and display rows.
- Gives each projected row stable identity, ordering, revision, source-event ownership, and generation metadata.
- Adds bounded page and tail reads that return either one ready generation or an explicit reset response; dirty or partial rows are never exposed.
- Rebuilds adopted display state through the existing bounded transcript projection worker.
- Invalidates adopted projections after transcript replacement, exact rewrite, compaction, import, and canonical repair.
- Keeps ordinary startup and unadopted transcript writes on the existing active/search path.
- Rejects partial or malformed display-schema groups during physical database open.

The display tables contain only derived presentation metadata. They do not duplicate the raw transcript payload, and deleting or rebuilding them does not remove canonical conversation history.

## Validation

- The integrated Work 1 stack passed 123 focused projection, schema, lifecycle, compatibility, and source-generation tests.
- Core production types, generated Kysely definitions, SQLite schema baselines, formatting, and diff checks passed.
- A copied team database containing 263,996 transcript events across 1,192 sessions passed integrity checking with zero foreign-key violations.
- Startup did not create unused display tables or rebuild historical display state.
- The integrated stack measured `0.7023ms` per append versus `0.7571ms` on the measured main baseline, a 7.2% improvement across five rounds.
- Gateway readiness measured `56.67s` versus `73.54s` in the paired team-main baseline run.
- Exact-head CI passed.

## Scope

This PR does not change the current Gateway history reader, chat UI, or virtualization behavior. Those layers will adopt this storage contract in follow-up work.

A follow-up will further restrict display-aware reconciliation to sessions that already adopted display state before any production reader enables the projection.

Refs #126914.
