### PR TITLE
fix(cron): replacement automations do not inherit retired trigger state

### DIFF
--- a/src/cron/service.declarative-jobs.test.ts
+++ b/src/cron/service.declarative-jobs.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { resolveCronJobConfigRevision } from "./config-revision.js";
 import { CronService } from "./service.js";
 import {
   createCronStoreHarness,
@@ -6,6 +7,7 @@ import {
   installCronTestHooks,
 } from "./service.test-harness.js";
 import type { CronAddResult } from "./service/state.js";
+import { loadCronStore } from "./store.js";
 import type { CronJob, CronJobCreate } from "./types.js";
 
 const logger = createNoopLogger();
@@ -44,6 +46,40 @@ function declarativeResult(result: CronAddResult) {
     throw new Error("expected declarative cron result");
   }
   return result;
+}
+
+const retiredTriggerState = {
+  triggerState: { owner: "retired" },
+  triggerEvalCount: 7,
+  lastTriggerEvalAtMs: 111,
+  lastTriggerFireAtMs: 222,
+  lastRunAtMs: 333,
+};
+
+type TriggerStateOwner = "condition" | "script" | "none";
+
+function ownedDeclaration(params: {
+  declarationKey: string;
+  owner: TriggerStateOwner;
+  script?: string;
+  state?: CronJobCreate["state"];
+  sameOwnerEdit?: boolean;
+}): CronJobCreate {
+  const script = params.script ?? 'return "original"';
+  return declaration({
+    declarationKey: params.declarationKey,
+    delivery: { mode: "none" },
+    trigger:
+      params.owner === "condition"
+        ? { script, ...(params.sameOwnerEdit ? { once: true } : {}) }
+        : undefined,
+    payload:
+      params.owner === "script"
+        ? { kind: "script", script, ...(params.sameOwnerEdit ? { timeoutSeconds: 45 } : {}) }
+        : { kind: "agentTurn", message: "report" },
+    ...(params.state ? { state: params.state } : {}),
+    ...(params.sameOwnerEdit && params.owner === "none" ? { displayName: "Updated report" } : {}),
+  });
 }
 
 describe("CronService declarative jobs", () => {
@@ -177,6 +213,134 @@ describe("CronService declarative jobs", () => {
     }
   });
 
+  it.each(["ordinary update", "declarative convergence"] as const)(
+    "persists trigger-state ownership transitions and explicit replacements through %s",
+    async (mutationPath) => {
+      const { storePath } = await makeStorePath();
+      const cron = createCronService(storePath);
+      await cron.start();
+      const cases: Array<{
+        name: string;
+        previous: TriggerStateOwner;
+        next: TriggerStateOwner;
+        replaceScript?: boolean;
+        sameOwnerEdit?: boolean;
+        replacementState?: CronJobCreate["state"];
+      }> = [
+        {
+          name: "condition replacement",
+          previous: "condition",
+          next: "condition",
+          replaceScript: true,
+        },
+        { name: "condition removal", previous: "condition", next: "none" },
+        { name: "condition to script", previous: "condition", next: "script" },
+        { name: "script replacement", previous: "script", next: "script", replaceScript: true },
+        { name: "script removal", previous: "script", next: "none" },
+        { name: "script to condition", previous: "script", next: "condition" },
+        { name: "no owner to condition", previous: "none", next: "condition" },
+        { name: "no owner to script", previous: "none", next: "script" },
+        {
+          name: "same condition owner",
+          previous: "condition",
+          next: "condition",
+          sameOwnerEdit: true,
+        },
+        { name: "same script owner", previous: "script", next: "script", sameOwnerEdit: true },
+        { name: "same absent owner", previous: "none", next: "none", sameOwnerEdit: true },
+        {
+          name: "explicit replacement state and count",
+          previous: "condition",
+          next: "condition",
+          replaceScript: true,
+          replacementState: { triggerState: null, triggerEvalCount: 0 },
+        },
+        {
+          name: "explicit replacement evaluation timestamps",
+          previous: "condition",
+          next: "script",
+          replacementState: { lastTriggerEvalAtMs: 444, lastTriggerFireAtMs: 555 },
+        },
+      ];
+      const persistedExpectations: Array<{ id: string; state: CronJob["state"]; name: string }> =
+        [];
+
+      try {
+        for (const [index, testCase] of cases.entries()) {
+          const declarationKey = `trigger-owner:${mutationPath}:${index}`;
+          const input = ownedDeclaration({
+            declarationKey,
+            owner: testCase.previous,
+            state: retiredTriggerState,
+          });
+          if (mutationPath === "ordinary update") {
+            delete input.declarationKey;
+          }
+          const result = await cron.add(input);
+          const created = "job" in result ? result.job : result;
+          expect(created.state, `${testCase.name}: create preserves explicit state`).toMatchObject(
+            retiredTriggerState,
+          );
+
+          const next = ownedDeclaration({
+            declarationKey,
+            owner: testCase.next,
+            script: testCase.replaceScript ? 'return "replacement"' : undefined,
+            state: testCase.replacementState,
+            sameOwnerEdit: testCase.sameOwnerEdit,
+          });
+          if (mutationPath === "ordinary update") {
+            await cron.update(created.id, {
+              trigger: next.trigger ?? null,
+              payload: next.payload,
+              displayName: next.displayName,
+              ...(testCase.replacementState ? { state: testCase.replacementState } : {}),
+            });
+          } else {
+            await cron.add(next);
+          }
+
+          const expectedState: CronJob["state"] = testCase.sameOwnerEdit
+            ? retiredTriggerState
+            : { lastRunAtMs: retiredTriggerState.lastRunAtMs, ...testCase.replacementState };
+          const persisted = (await loadCronStore(storePath)).jobs.find(
+            (entry) => entry.id === created.id,
+          );
+          expect(persisted?.state, `${testCase.name}: durable state`).toMatchObject(expectedState);
+          for (const field of [
+            "triggerState",
+            "triggerEvalCount",
+            "lastTriggerEvalAtMs",
+            "lastTriggerFireAtMs",
+          ] as const) {
+            expect(persisted?.state[field], `${testCase.name}: ${field}`).toEqual(
+              expectedState[field],
+            );
+          }
+          persistedExpectations.push({ id: created.id, state: expectedState, name: testCase.name });
+        }
+      } finally {
+        cron.stop();
+      }
+
+      const restarted = createCronService(storePath, false);
+      for (const expected of persistedExpectations) {
+        const persisted = await restarted.readJob(expected.id);
+        expect(persisted?.state, `${expected.name}: restart`).toMatchObject(expected.state);
+        for (const field of [
+          "triggerState",
+          "triggerEvalCount",
+          "lastTriggerEvalAtMs",
+          "lastTriggerFireAtMs",
+        ] as const) {
+          expect(persisted?.state[field], `${expected.name}: restart ${field}`).toEqual(
+            expected.state[field],
+          );
+        }
+      }
+    },
+  );
+
   it("checks update preconditions under the mutation lock", async () => {
     const { storePath } = await makeStorePath();
     const cron = createCronService(storePath);
@@ -192,6 +356,88 @@ describe("CronService declarative jobs", () => {
       expect(await cron.readJob(created.id)).toMatchObject({ displayName: "Daily report" });
     } finally {
       cron.stop();
+    }
+  });
+
+  it("rejects concurrent stale-owner updates across service instances sharing SQLite", async () => {
+    const { storePath } = await makeStorePath();
+    const first = createCronService(storePath);
+    const second = createCronService(storePath);
+    await first.start();
+    await second.start();
+
+    try {
+      const created = declarativeResult(
+        await first.add(
+          ownedDeclaration({
+            declarationKey: "trigger-owner:concurrent",
+            owner: "condition",
+            state: retiredTriggerState,
+          }),
+        ),
+      );
+      await second.readJob(created.id);
+      const staleRevision = resolveCronJobConfigRevision(created.job);
+      const replacementState = { triggerState: { owner: "replacement" }, triggerEvalCount: 23 };
+      const commitGuard = vi.fn();
+
+      await expect(
+        first.add(
+          ownedDeclaration({
+            declarationKey: "trigger-owner:concurrent",
+            owner: "condition",
+            script: 'return "invalid"',
+            state: { lastTriggerEvalAtMs: -1 },
+          }),
+          { commitGuard },
+        ),
+      ).rejects.toThrow("cron state.lastTriggerEvalAtMs must be a non-negative Date-valid integer");
+      expect(commitGuard).not.toHaveBeenCalled();
+      expect((await second.readJob(created.id))?.state).toMatchObject(retiredTriggerState);
+
+      const [replacement, stale] = await Promise.allSettled([
+        first.update(created.id, {
+          trigger: { script: 'return "replacement"' },
+          state: replacementState,
+        }),
+        second.updateWithPrecondition(
+          created.id,
+          {
+            displayName: "Stale owner",
+            trigger: { script: 'return "obsolete"' },
+            state: { triggerState: { owner: "obsolete" }, triggerEvalCount: 99 },
+          },
+          (current) => {
+            if (resolveCronJobConfigRevision(current) !== staleRevision) {
+              throw new Error("revision conflict");
+            }
+          },
+        ),
+      ]);
+
+      expect(replacement.status).toBe("fulfilled");
+      expect(stale).toMatchObject({ status: "rejected", reason: new Error("revision conflict") });
+      const persisted = await second.readJob(created.id);
+      expect(persisted?.state).toMatchObject(replacementState);
+      expect(persisted?.state.lastTriggerEvalAtMs).toBeUndefined();
+      expect(persisted?.state.lastTriggerFireAtMs).toBeUndefined();
+      expect(persisted?.displayName).toBe("Daily report");
+      expect(persisted?.trigger).toEqual({ script: 'return "replacement"' });
+
+      const currentRevision = resolveCronJobConfigRevision(persisted!);
+      await second.updateWithPrecondition(
+        created.id,
+        { displayName: "Current owner" },
+        (current) => {
+          if (resolveCronJobConfigRevision(current) !== currentRevision) {
+            throw new Error("revision conflict");
+          }
+        },
+      );
+      expect((await first.readJob(created.id))?.state).toMatchObject(replacementState);
+    } finally {
+      second.stop();
+      first.stop();
     }
   });
 

--- a/src/cron/service.trigger-eval.test.ts
+++ b/src/cron/service.trigger-eval.test.ts
@@ -72,10 +72,11 @@ async function runWhenDue(cron: CronService, jobId: string) {
 }
 
 describe("cron trigger evaluation", () => {
-  it("persists quiet evaluations without payload execution or run history", async () => {
-    const evaluateCronTrigger = vi.fn(async () => ({
+  it("persists quiet evaluations and fires replacement triggers with fresh state", async () => {
+    const replacementScript = 'return "replacement"';
+    const evaluateCronTrigger = vi.fn(async (params: Parameters<Evaluator>[0]) => ({
       kind: "evaluated" as const,
-      fire: false,
+      fire: params.script === replacementScript && params.state === undefined,
       state: { status: "green" },
     }));
     const harness = await createHarness({ evaluateCronTrigger });
@@ -113,6 +114,14 @@ describe("cron trigger evaluation", () => {
           jobId: job.id,
         }).entries,
       ).toEqual([]);
+
+      await harness.cron.update(job.id, { trigger: { script: replacementScript } });
+      expect(await runWhenDue(harness.cron, job.id)).toEqual({ ok: true, ran: true });
+      expect(evaluateCronTrigger).toHaveBeenLastCalledWith(
+        expect.objectContaining({ script: replacementScript, state: undefined }),
+      );
+      expect(harness.runIsolatedAgentJob).toHaveBeenCalledOnce();
+      expect(harness.cron.getJob(job.id)?.state.triggerEvalCount).toBe(1);
     } finally {
       harness.cron.stop();
     }
@@ -367,7 +376,7 @@ describe("cron trigger evaluation", () => {
       expect(stored?.trigger).toEqual(
         restore ? originalTrigger : { script: "replacement trigger", once: true },
       );
-      expect(stored?.state.triggerState).toEqual({ owner: "latest edit" });
+      expect(stored?.state.triggerState).toEqual(restore ? undefined : { owner: "latest edit" });
       expect(stored?.state.lastTriggerEvalAtMs).toBeUndefined();
       expect(stored?.state.nextRunAtMs).toEqual(expect.any(Number));
     } finally {
@@ -471,7 +480,11 @@ describe("cron trigger evaluation", () => {
         expect(stored?.payload).toMatchObject(
           restore ? originalPayload : { kind: "script", script: "return replacement" },
         );
-        expect(stored?.state.triggerState).toEqual({ owner: "current" });
+        expect(stored?.state.triggerState).toBeUndefined();
+        const persisted = (await loadCronStore(harness.storePath)).jobs.find(
+          (entry) => entry.id === job.id,
+        );
+        expect(persisted?.state.triggerState).toBeUndefined();
       } finally {
         completion.resolve({ status: "ok", stateChanged: true, state: { owner: "cleanup" } });
         harness.cron.stop();

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -541,6 +541,7 @@ export function applyDeclarativeJobSpec(
   if (opts.enabledExplicit) {
     job.enabled = input.enabled;
   }
+  assertCronJobStateTimestamps(input.state ?? {});
   validateFullJob(
     job,
     {

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -101,6 +101,7 @@ function finalizeUpdatedJob(params: {
   now: number;
   schedulingInputsRequested: boolean;
   scheduleChanged: boolean;
+  explicitTriggerState?: CronJobPatch["state"];
 }) {
   const { job, nextJob, now } = params;
   if (nextJob.schedule.kind === "every") {
@@ -136,6 +137,25 @@ function finalizeUpdatedJob(params: {
   // watcher. Equivalent resaves preserve it; disable/enable and source changes
   // rotate it in the same write that changes the public job definition.
   reconcileStreamSourceIdentity(job, nextJob);
+
+  const previousScript = job.payload.kind === "script" ? job.payload.script : undefined;
+  const nextScript = nextJob.payload.kind === "script" ? nextJob.payload.script : undefined;
+  if (job.trigger?.script !== nextJob.trigger?.script || previousScript !== nextScript) {
+    // Trigger and payload scripts share one durable state slot; only its exact
+    // executable owner may inherit it, while explicit replacement values win.
+    for (const field of [
+      "triggerState",
+      "triggerEvalCount",
+      "lastTriggerEvalAtMs",
+      "lastTriggerFireAtMs",
+    ] as const) {
+      if (params.explicitTriggerState && Object.hasOwn(params.explicitTriggerState, field)) {
+        Object.assign(nextJob.state, { [field]: params.explicitTriggerState[field] });
+      } else {
+        delete nextJob.state[field];
+      }
+    }
+  }
 
   // Only advance a recurring job's next run when the schedule/enabled inputs
   // actually changed. An idempotent re-save (same schedule, or re-enabling an
@@ -382,6 +402,7 @@ export async function add(
         now,
         schedulingInputsRequested: true,
         scheduleChanged: !isDeepStrictEqual(existing.schedule, nextJob.schedule),
+        explicitTriggerState: normalizedInput.state,
       });
       await persistUpdatedJob({ state, snapshot, previousJob: existing, nextJob });
       return { ...nextJob, created: false, updated: true, job: nextJob };
@@ -519,6 +540,7 @@ async function updateLoadedJob(params: {
       "trigger" in patch ||
       "pacing" in patch,
     scheduleChanged: patch.schedule !== undefined,
+    explicitTriggerState: patch.state,
   });
   const runtimeAuthorityMutation = consumeRuntimeAuthorityMutationOptions(opts);
   reconcileRuntimeAuthority({


### PR DESCRIPTION
Closes #126930

## What Problem This Solves

Fixes an issue where replacing, removing, or converting a condition-trigger or script-backed cron automation could retain the retired executable's evaluation and deduplication state. The replacement automation could then silently never fire.

## Why This Change Was Made

Ordinary updates and declarative convergence now share one lifecycle decision in the durable job mutation finalizer. The exact condition/script executable owns the four trigger-state fields; ownership changes clear retired state, while same-owner edits and explicitly supplied replacement values are preserved. No schema change or downstream fallback is introduced.

## User Impact

Operators can replace or convert cron automations without a new executable inheriting stale trigger state. Existing contaminated rows are repaired on their next ownership-changing mutation.

## Evidence

- Pre-fix focused regression failed both ordinary update and declarative convergence with `condition replacement: triggerState: expected { owner: 'retired' } to deeply equal undefined`.
- Focused suites: 142 tests passed across `service.declarative-jobs`, `service.trigger-eval`, and `service.jobs`.
- Covers create/update/declarative convergence, trigger/script/no-owner transitions, explicit state precedence, SQLite restart persistence, stale concurrent updates, and suspended execution races.
- Changed-file gates pass, including core/test typechecks, lint, import cycles, database-first checks, and unchanged native SQLite schema v9.
- Production LOC: +23/-0 (net +23), justified by a single shared lifecycle ownership boundary. Tests: +264/-5.
- No UI surface; deterministic persisted-state proof is the relevant operator behavior evidence.
