### PR TITLE
fix(fleet): publish backups without partial finals

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2862,7 +2862,7 @@ src/daemon/systemd-lifecycle.ts	2
 src/daemon/systemd-runtime.ts	1
 src/entry.compile-cache.ts	3
 src/entry.respawn.ts	1
-src/fleet/backup.runtime.ts	4
+src/fleet/backup.runtime.ts	3
 src/fleet/service-support.runtime.ts	1
 src/flows/channel-setup.prompts.ts	2
 src/flows/channel-setup.status.ts	2

--- a/src/fleet/backup.runtime.test.ts
+++ b/src/fleet/backup.runtime.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { __setFsSafeTestHooksForTest } from "@openclaw/fs-safe/test-hooks";
 import * as tar from "tar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
@@ -114,16 +115,59 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  __setFsSafeTestHooksForTest(undefined);
   vi.restoreAllMocks();
   await tempRoot.cleanup();
 });
 
 describe("fleet backup runtime", () => {
+  function backupParams(out: string) {
+    return {
+      record,
+      stateDir: root,
+      containers: containerMock(),
+      now: () => 0,
+      checkpoint: () => {},
+      out,
+    };
+  }
+
+  function interruptCopy(archivePath: string, mutate: (targetPath: string) => Promise<void>) {
+    const error = Object.assign(new Error("archive copy interrupted"), { code: "EIO" });
+    vi.spyOn(fs, "link").mockRejectedValue(
+      Object.assign(new Error("unsupported"), { code: "ENOTSUP" }),
+    );
+    const copyFile = fs.copyFile.bind(fs);
+    const legacyCopy = vi.spyOn(fs, "copyFile").mockImplementation(async (source, target, mode) => {
+      if (path.resolve(String(target)) !== archivePath) {
+        return await copyFile(source, target, mode);
+      }
+      await fs.writeFile(target, "");
+      await mutate(String(target));
+      throw error;
+    });
+    __setFsSafeTestHooksForTest({
+      afterPublishTargetCreated: async (method, targetPath) => {
+        if (method === "exclusive-copy" && targetPath === archivePath) {
+          await mutate(targetPath);
+          throw error;
+        }
+      },
+    });
+    return legacyCopy;
+  }
+
   it("writes a private archive with manifest, data, and auth while skipping symlinks", async () => {
     const outside = path.join(root, "outside-secret");
     await fs.writeFile(outside, "must-not-archive");
     await fs.symlink(outside, path.join(record.dataDir, "outside-link"));
     const containers = containerMock();
+    const publicationMethods: string[] = [];
+    __setFsSafeTestHooksForTest({
+      afterPublishTargetCreated: (method) => {
+        publicationMethods.push(method);
+      },
+    });
     const result = await backupFleetCell({
       record,
       stateDir: root,
@@ -133,6 +177,7 @@ describe("fleet backup runtime", () => {
       out: path.join(root, "backup.tgz"),
     });
     expect((await fs.stat(result.archivePath)).mode & 0o777).toBe(0o600);
+    expect(publicationMethods).toEqual(["hardlink"]);
     expect(result.skippedSymlinks).toBe(1);
     const entries: string[] = [];
     const contents: string[] = [];
@@ -152,6 +197,110 @@ describe("fleet backup runtime", () => {
       name.endsWith(".tmp"),
     );
     expect(leftovers).toEqual([]);
+  });
+
+  it("publishes a complete archive through the copy fallback", async () => {
+    const archivePath = path.join(root, "copy.tgz");
+    vi.spyOn(fs, "link").mockRejectedValue(
+      Object.assign(new Error("unsupported"), { code: "ENOTSUP" }),
+    );
+    const methods: string[] = [];
+    __setFsSafeTestHooksForTest({
+      afterPublishTargetCreated: (method) => {
+        methods.push(method);
+      },
+    });
+
+    expect((await backupFleetCell(backupParams(archivePath))).archivePath).toBe(archivePath);
+    expect(methods).toEqual(["exclusive-copy"]);
+    await expect(tar.t({ file: archivePath })).resolves.toBeUndefined();
+  });
+
+  it("removes an interrupted owned copy and allows a backup retry", async () => {
+    const archivePath = path.join(root, "interrupted.tgz");
+    const legacyCopy = interruptCopy(archivePath, (targetPath) =>
+      fs.writeFile(targetPath, "partial archive"),
+    );
+
+    await expect(backupFleetCell(backupParams(archivePath))).rejects.toThrow(
+      /archive copy interrupted/iu,
+    );
+    await expect(fs.lstat(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+    __setFsSafeTestHooksForTest(undefined);
+    legacyCopy.mockRestore();
+    await expect(backupFleetCell(backupParams(archivePath))).resolves.toMatchObject({
+      archivePath,
+    });
+  });
+
+  it("reports the original failure when an interrupted archive cannot be removed", async () => {
+    const archivePath = path.join(root, "cleanup-unknown.tgz");
+    interruptCopy(archivePath, (targetPath) => fs.writeFile(targetPath, "partial archive"));
+    const remove = fs.rm.bind(fs);
+    vi.spyOn(fs, "rm").mockImplementation(async (target, options) => {
+      if (path.resolve(String(target)) === archivePath) {
+        throw Object.assign(new Error("archive cleanup busy"), { code: "EBUSY" });
+      }
+      return await remove(target, options);
+    });
+
+    const error = await backupFleetCell(backupParams(archivePath)).catch(
+      (caught: unknown) => caught,
+    );
+    expect(error).toMatchObject({
+      message: expect.stringMatching(
+        /archive copy interrupted.*partial archive may remain.*inspect.*retry/iu,
+      ),
+      cause: expect.any(Error),
+    });
+    expect((error as Error).message).toContain(archivePath);
+    await expect(fs.readFile(archivePath, "utf8")).resolves.toBe("partial archive");
+  });
+
+  it("preserves a foreign archive that replaces the interrupted publication", async () => {
+    const archivePath = path.join(root, "raced.tgz");
+    interruptCopy(archivePath, async (targetPath) => {
+      await fs.rename(targetPath, `${targetPath}.displaced`);
+      await fs.writeFile(targetPath, "foreign archive");
+    });
+
+    await expect(backupFleetCell(backupParams(archivePath))).rejects.toThrow(
+      /archive copy interrupted/iu,
+    );
+    await expect(fs.readFile(archivePath, "utf8")).resolves.toBe("foreign archive");
+  });
+
+  it("fails and removes its archive when publication directory synchronization fails", async () => {
+    const archivePath = path.join(root, "sync-failure.tgz");
+    __setFsSafeTestHooksForTest({
+      beforePublishDirectorySync: async (_method, targetPath) => {
+        if (targetPath === archivePath) {
+          throw Object.assign(new Error("archive directory sync failed"), { code: "EIO" });
+        }
+      },
+    });
+
+    await expect(backupFleetCell(backupParams(archivePath))).rejects.toThrow(
+      /directory sync failed/iu,
+    );
+    await expect(fs.lstat(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("rejects and removes a copy that fails publication content verification", async () => {
+    const archivePath = path.join(root, "integrity-failure.tgz");
+    vi.spyOn(fs, "link").mockRejectedValue(
+      Object.assign(new Error("unsupported"), { code: "ENOTSUP" }),
+    );
+    __setFsSafeTestHooksForTest({
+      afterPublishTargetCreated: async (method, targetPath) => {
+        if (method === "exclusive-copy" && targetPath === archivePath) {
+          await fs.writeFile(targetPath, Buffer.alloc(64 * 1024, 1));
+        }
+      },
+    });
+
+    await expect(backupFleetCell(backupParams(archivePath))).rejects.toThrow(/content fencing/iu);
+    await expect(fs.lstat(archivePath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("refuses unsafe or unavailable backup inputs", async () => {
@@ -211,6 +360,7 @@ describe("fleet backup runtime", () => {
         out: existing,
       }),
     ).rejects.toThrow(/overwrite/iu);
+    await expect(fs.readFile(existing, "utf8")).resolves.toBe("exists");
     await expect(
       backupFleetCell({
         record,

--- a/src/fleet/backup.runtime.ts
+++ b/src/fleet/backup.runtime.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { constants as fsConstants, createWriteStream, type Stats } from "node:fs";
+import { createWriteStream, type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -13,6 +13,10 @@ import {
   extractArchive,
 } from "../infra/archive.js";
 import { createBackupLinkCache } from "../infra/backup-volatile-stat-cache.js";
+import {
+  getPublishFileExclusiveFailureDetails,
+  publishFileNoClobber,
+} from "../infra/directory-durability.js";
 import { formatErrorMessage as errorMessage } from "../infra/errors.js";
 import { root as fsSafeRoot } from "../infra/fs-safe.js";
 import { isPathInside } from "../infra/path-guards.js";
@@ -306,8 +310,8 @@ export async function backupFleetCell(params: {
         },
         [manifestPath, dataTarget, authTarget],
       ),
-      // Stream to a same-directory temp path first: a killed process must not
-      // leave a truncated file under the final archive name.
+      // Finish streaming into a same-directory temp path before publication;
+      // filesystems without hard-link support still need a non-atomic copy.
       createWriteStream(tempArchivePath, { flags: "wx", mode: 0o600 }),
     );
     // A single large file can stream past the lease TTL without a filter
@@ -338,7 +342,25 @@ export async function backupFleetCell(params: {
         `Fleet backup refuses a file name its restore path rules would reject: ${unrestorablePath}. Rename the file inside the cell and retry.`,
       );
     }
-    await publishArchive(tempArchivePath, archivePath);
+    try {
+      await publishFileNoClobber(tempArchivePath, archivePath, {
+        strategy: "link-or-copy",
+        durability: "degrade",
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        throw new Error(`Refusing to overwrite existing fleet backup archive: ${archivePath}`, {
+          cause: error,
+        });
+      }
+      if (getPublishFileExclusiveFailureDetails(error)?.cleanup === "unknown") {
+        throw new Error(
+          `Fleet backup publication failed: ${errorMessage(error)}. A partial archive may remain at ${archivePath}; inspect or remove it before retrying.`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
     return {
       tenant: params.record.tenantId,
       archivePath,
@@ -350,37 +372,6 @@ export async function backupFleetCell(params: {
   } finally {
     await fs.rm(tempArchivePath, { force: true }).catch(() => undefined);
     await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
-  }
-}
-
-// Publish with no-overwrite semantics after every check passed: hard-link the
-// temp file to the final name when supported, else exclusive copy. EEXIST from
-// either path means another process owns the destination.
-async function publishArchive(tempArchivePath: string, archivePath: string): Promise<void> {
-  try {
-    await fs.link(tempArchivePath, archivePath);
-    return;
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === "EEXIST") {
-      throw new Error(`Refusing to overwrite existing fleet backup archive: ${archivePath}`, {
-        cause: error,
-      });
-    }
-    if (code !== "ENOTSUP" && code !== "EOPNOTSUPP" && code !== "EPERM") {
-      throw error;
-    }
-  }
-  try {
-    await fs.copyFile(tempArchivePath, archivePath, fsConstants.COPYFILE_EXCL);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-      throw new Error(`Refusing to overwrite existing fleet backup archive: ${archivePath}`, {
-        cause: error,
-      });
-    }
-    await fs.rm(archivePath, { force: true }).catch(() => undefined);
-    throw error;
   }
 }
 


### PR DESCRIPTION
Closes #126941

## What Problem This Solves

Fixes an issue where operators creating Fleet cell backups could be left with a truncated archive that blocks retries, or lose an unrelated archive published at the same pathname, when hard-link publication is unavailable and fallback copying fails.

## Why This Change Was Made

Fleet now uses the existing identity-bound, no-clobber file publication primitive instead of maintaining a separate hardlink-or-copy implementation. The existing copy fallback and overwrite error remain available; failed publication removes only a proven-owned destination, preserves competing files, and explains when a partial archive may remain. The assertion-safety ratchet is reduced from four Fleet assertions to three because the obsolete duplicate publisher was deleted.

Copy fallback remains non-atomic. Unsupported directory synchronization retains existing compatibility, while real synchronization and archive-integrity failures remain fatal.

## User Impact

Fleet backup retries work after an interrupted copy when cleanup can be proven, competing archives are never deleted, and an operator receives actionable retained-archive guidance when safe cleanup cannot be completed. Existing archive paths, permissions, contents, no-overwrite behavior, and filesystems without hard-link support are preserved.

## Evidence

- Before the fix, five real-filesystem Fleet regressions failed, including the foreign-destination deletion, silent retained partial archive, hardlink/copy publication boundaries, and directory-sync failure.
- The final focused owner and sibling matrix exercises Fleet backup/restore/service/container behavior, shared directory durability, backup publication, SQLite snapshots, and TLS publication.
- `node scripts/run-vitest.mjs src/fleet/backup.runtime.test.ts src/fleet/service.runtime.test.ts src/fleet/service-removal.runtime.test.ts src/fleet/containers.runtime.test.ts src/infra/directory-durability.test.ts src/infra/backup-archive-publication.test.ts src/infra/sqlite-snapshot.test.ts src/infra/tls/gateway.test.ts`
- `node scripts/check-changed.mjs`
- `node_modules/.bin/oxfmt --check src/fleet/backup.runtime.ts src/fleet/backup.runtime.test.ts`
- `git diff --check`
- Fresh P1 Codex autoreview and a separate adversarial owner/dependency-contract review.
- Production: +26/-35, net -9 lines. Tests cover hardlink success, exclusive-copy success, interrupted-copy cleanup and retry, unknown cleanup with preserved primary error, raced foreign archives, existing destination preservation, directory-sync failure, and content-integrity failure. The separate required assertion baseline is +1/-1 tooling metadata.

AI-assisted: built and reviewed with Codex.
