### PR TITLE
fix(skills): keep restart drain out of review backoff

### DIFF
--- a/src/skills/workshop/collection-review.gateway-admission.test.ts
+++ b/src/skills/workshop/collection-review.gateway-admission.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  GatewayDrainingError,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+} from "../../process/gateway-work-admission.js";
+import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { writeWorkspaceSkills } from "../test-support/e2e-test-helpers.js";
+import { isSkillCollectionReviewDue } from "./collection-review-state.js";
+import { runScheduledSkillCollectionReviews } from "./collection-review.js";
+
+const runEmbeddedAgent = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/embedded-agent.js", () => ({ runEmbeddedAgent }));
+vi.mock("../../agents/auth-profiles/store.js", () => ({
+  loadAuthProfileStoreForRuntime: () => ({ version: 1, profiles: {} }),
+}));
+
+let testState: OpenClawTestState;
+
+beforeEach(async () => {
+  resetGatewayWorkAdmission();
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-collection-review-admission-",
+  });
+});
+
+afterEach(async () => {
+  resetGatewayWorkAdmission();
+  runEmbeddedAgent.mockReset();
+  await testState.cleanup();
+});
+
+describe("skill collection review gateway admission", () => {
+  it("keeps a due workspace and curator state unchanged when restart drain rejects admission", async () => {
+    const workspaceDir = testState.workspaceDir;
+    await writeWorkspaceSkills(workspaceDir, [
+      { name: "useful", description: "Useful reusable procedure" },
+    ]);
+    const database = openOpenClawStateDatabase({ env: testState.env }).db;
+    database
+      .prepare(
+        "INSERT INTO skill_curator_state (id, last_attempt_at_ms, last_success_at_ms, last_error, last_result_json) VALUES (?, ?, ?, ?, ?)",
+      )
+      .run(
+        1,
+        41,
+        23,
+        "previous unrelated failure",
+        JSON.stringify({
+          unrelated: { preserved: true },
+          collectionReviewAttempts: { "other-workspace": 41 },
+          collectionReviewSuccess: { "other-workspace": 23 },
+        }),
+      );
+    const curatorStateBefore = database
+      .prepare("SELECT * FROM skill_curator_state WHERE id = 1")
+      .get();
+    const writesBefore = database.prepare("SELECT total_changes() AS count").get();
+    expect(isSkillCollectionReviewDue(workspaceDir, Date.now(), { env: testState.env })).toBe(true);
+
+    markGatewayRestartDraining();
+    const onError = vi.fn();
+    await runScheduledSkillCollectionReviews({
+      config: {
+        agents: { list: [{ id: "main", default: true, workspace: workspaceDir }] },
+        skills: { workshop: { autonomous: { mode: "auto" } } },
+      },
+      env: testState.env,
+      onError,
+    });
+
+    expect(onError).toHaveBeenCalledWith(expect.any(GatewayDrainingError), workspaceDir);
+    expect(runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(database.prepare("SELECT * FROM skill_curator_state WHERE id = 1").get()).toEqual(
+      curatorStateBefore,
+    );
+    expect(database.prepare("SELECT total_changes() AS count").get()).toEqual(writesBefore);
+    expect(
+      database
+        .prepare("SELECT COUNT(*) AS count FROM state_leases WHERE scope = ?")
+        .get("skill-collection-review"),
+    ).toEqual({ count: 0 });
+
+    resetGatewayWorkAdmission();
+    expect(isSkillCollectionReviewDue(workspaceDir, Date.now(), { env: testState.env })).toBe(true);
+  });
+});

--- a/src/skills/workshop/collection-review.test.ts
+++ b/src/skills/workshop/collection-review.test.ts
@@ -537,7 +537,7 @@ describe("skill collection review", () => {
     });
 
     expect(String(onError.mock.calls[0]?.[0])).toContain("different collection-review identities");
-    expect(runWithGatewayIndependentRootWorkAdmission).not.toHaveBeenCalled();
+    expect(runWithGatewayIndependentRootWorkAdmission).toHaveBeenCalledOnce();
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
@@ -577,7 +577,7 @@ describe("skill collection review", () => {
     });
 
     expect(onError).toHaveBeenCalledWith(expect.any(Error), workspaceDir);
-    expect(runWithGatewayIndependentRootWorkAdmission).not.toHaveBeenCalled();
+    expect(runWithGatewayIndependentRootWorkAdmission).toHaveBeenCalledOnce();
     expect(runEmbeddedAgent).not.toHaveBeenCalled();
   });
 
@@ -646,7 +646,7 @@ describe("skill collection review", () => {
         expect.objectContaining({ code: "OPENCLAW_STATE_LEASE_TIMEOUT" }),
         workspaceDir,
       );
-      expect(runWithGatewayIndependentRootWorkAdmission).toHaveBeenCalledOnce();
+      expect(runWithGatewayIndependentRootWorkAdmission).toHaveBeenCalledTimes(2);
       expect(runEmbeddedAgent).toHaveBeenCalledOnce();
       expect(database.prepare("SELECT * FROM skill_curator_state WHERE id = 1").get()).toEqual(
         reviewStateBeforeContention,

--- a/src/skills/workshop/collection-review.ts
+++ b/src/skills/workshop/collection-review.ts
@@ -193,52 +193,52 @@ export async function runScheduledSkillCollectionReviews(params: {
     const agentId = agentIds[0]!;
     const stateOptions = params.env ? { env: params.env } : {};
     try {
-      await withSkillCollectionReviewClaim(
-        workspaceDir,
-        async () => {
-          if (!isSkillCollectionReviewDue(workspaceDir, nowMs, stateOptions)) {
-            return;
-          }
-          // Persist failures before releasing the claim; acquisition failures
-          // never enter this callback and must not count as review attempts.
-          try {
-            const reviewModels = agentIds.map((id) =>
-              resolveCollectionReviewIdentity(params.config, id, params.env),
-            );
-            const reviewModel = reviewModels[0]!;
-            if (
-              reviewModels.some(
-                (candidate) =>
-                  candidate.provider !== reviewModel.provider ||
-                  candidate.model !== reviewModel.model ||
-                  candidate.authIdentity !== reviewModel.authIdentity,
-              )
-            ) {
-              throw new Error(
-                "Shared workspace agents use different collection-review identities.",
-              );
-            }
-            await runWithGatewayIndependentRootWorkAdmission(async () => {
-              await runSkillCollectionReview({ ...params, agentId, agentIds, workspaceDir });
-            });
-          } catch (error) {
-            try {
-              recordSkillCollectionReviewFailure(workspaceDir, Date.now(), error, stateOptions);
-            } catch (recordError) {
-              reportError(
-                new AggregateError(
-                  [error, recordError],
-                  `Skill collection review failed and its retry backoff could not be recorded for ${workspaceDir}.`,
-                  { cause: error },
-                ),
-                workspaceDir,
-              );
+      await runWithGatewayIndependentRootWorkAdmission(() =>
+        withSkillCollectionReviewClaim(
+          workspaceDir,
+          async () => {
+            if (!isSkillCollectionReviewDue(workspaceDir, nowMs, stateOptions)) {
               return;
             }
-            throw error;
-          }
-        },
-        stateOptions,
+            // Persist only admitted review failures while the claim is held;
+            // admission and acquisition failures must not count as attempts.
+            try {
+              const reviewModels = agentIds.map((id) =>
+                resolveCollectionReviewIdentity(params.config, id, params.env),
+              );
+              const reviewModel = reviewModels[0]!;
+              if (
+                reviewModels.some(
+                  (candidate) =>
+                    candidate.provider !== reviewModel.provider ||
+                    candidate.model !== reviewModel.model ||
+                    candidate.authIdentity !== reviewModel.authIdentity,
+                )
+              ) {
+                throw new Error(
+                  "Shared workspace agents use different collection-review identities.",
+                );
+              }
+              await runSkillCollectionReview({ ...params, agentId, agentIds, workspaceDir });
+            } catch (error) {
+              try {
+                recordSkillCollectionReviewFailure(workspaceDir, Date.now(), error, stateOptions);
+              } catch (recordError) {
+                reportError(
+                  new AggregateError(
+                    [error, recordError],
+                    `Skill collection review failed and its retry backoff could not be recorded for ${workspaceDir}.`,
+                    { cause: error },
+                  ),
+                  workspaceDir,
+                );
+                return;
+              }
+              throw error;
+            }
+          },
+          stateOptions,
+        ),
       );
     } catch (error) {
       reportError(error, workspaceDir);


### PR DESCRIPTION
Refs #125899

## What Problem This Solves

Fixes an issue where operators using automatic Skill Workshop collection review could lose a due review for one hour when a Gateway restart began before the review was admitted. The merged failure-backoff repair in #125899 correctly suppresses genuinely failed review attempts, but it also recorded restart-drain rejection as a failed attempt even though no provider or reconciliation work started.

## Why This Change Was Made

Enter the Gateway's independent-root admission boundary before acquiring the SQLite collection-review claim. Keep failure persistence inside the admitted, successfully claimed review callback after the due check. Restart drain and zero-wait claim contention therefore remain outside retry-backoff ownership, and reversible suspension cannot hold a collection-review lease while waiting for admission.

This is the immediate follow-up to #125899 by @Grynn (Vishal Doshi). It preserves the original one-hour retry backoff for actual review failures and the original no-write claim-loser invariant. No configuration, storage schema, dependencies, or compatibility paths change.

## User Impact

A workspace whose scheduled review collides with Gateway restart remains immediately eligible after the Gateway returns instead of being silently delayed for an hour. Actual provider/reconciliation failures still receive the existing retry backoff; competing schedulers still do not record an attempt when they lose the zero-wait review claim.

## Evidence

The new regression uses the actual process-global Gateway admission implementation and an isolated, real SQLite state database. It seeds unrelated existing curator state, proves the workspace is due, closes admission with the real restart-drain transition, invokes the real collection-review scheduler, and verifies:

- The reported error is the actual `GatewayDrainingError`.
- No model/provider or reconciliation work starts.
- The complete `skill_curator_state` row is unchanged.
- SQLite `total_changes()` is unchanged, proving no review claim was even acquired.
- No collection-review lease exists, and the workspace remains due after real admission reset.

Before the production edit, the same regression failed on the parent commit for the intended reason:

```text
FAIL collection-review.gateway-admission.test.ts
AssertionError: expected curator state to remain unchanged

- "last_attempt_at_ms": 41,
- "last_error": "previous unrelated failure",
+ "last_attempt_at_ms": 1787276764669,
+ "last_error": "GatewayDrainingError: gateway is draining for restart",
+ collectionReviewAttempts included a new current-workspace entry

Test Files  1 failed (1)
Tests       1 failed (1)
```

After the owner-boundary reorder, current-head runtime proof passes with real admission and real SQLite state:

```text
$ node scripts/run-vitest.mjs src/skills/workshop/collection-review.gateway-admission.test.ts --reporter=verbose
✓ skill collection review gateway admission > keeps a due workspace and curator state unchanged when restart drain rejects admission
Test Files  1 passed (1)
Tests       1 passed (1)

$ node scripts/run-vitest.mjs src/skills/workshop/collection-review.test.ts src/skills/workshop/collection-review.gateway-admission.test.ts
Test Files  2 passed (2)
Tests       16 passed (16)

$ node scripts/run-vitest.mjs src/skills/workshop/collection-review.test.ts src/state/openclaw-state-lease.test.ts src/gateway/server-maintenance.test.ts src/skills/workshop/collection-review.gateway-admission.test.ts
unit:    3 files passed, 19 tests passed
gateway: 2 files passed, 72 tests passed

$ node scripts/run-vitest.mjs src/skills/workshop
Test Files  24 passed (24)
Tests       249 passed (249)

$ node scripts/check-changed.mjs -- src/skills/workshop/collection-review.ts src/skills/workshop/collection-review.test.ts src/skills/workshop/collection-review.gateway-admission.test.ts
passed: core/core-test typechecks, focused formatting/lint, and all repository architecture/storage guards

$ git diff origin/main...HEAD --check
passed
```

Production: +42/-42 (net 0). Tests: +96/-3 (net +93). Fresh independent full-branch autoreview against `origin/main`: clean, no actionable findings.
