### PR TITLE
fix(ui): label chat and new session composers

### DIFF
--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -134,6 +134,15 @@ afterEach(async () => {
 });
 
 describe("renderChatComposer controls", () => {
+  it("labels the message input independently of its placeholder", () => {
+    const { container } = renderComposer();
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+
+    expect(textarea?.getAttribute("aria-label")).toBe(
+      t("chat.composer.placeholder", { name: "OpenClaw" }),
+    );
+  });
+
   it("keeps composing enabled and explains queued delivery while offline", () => {
     const { container } = renderComposer({
       offline: true,

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -419,6 +419,7 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                       handleChatAttachmentPaste(event, props);
                     }
                   }}
+                  aria-label=${placeholder}
                   placeholder=${placeholder}
                   rows="1"
                 ></textarea>

--- a/ui/src/pages/new-session/composer.ts
+++ b/ui/src/pages/new-session/composer.ts
@@ -310,6 +310,7 @@ function renderNewSessionComposer(options: NewSessionComposerOptions) {
               rows="1"
               ?disabled=${options.submitting || options.messageLocked}
               placeholder=${t("newSession.messagePlaceholder")}
+              aria-label=${t("newSession.messagePlaceholder")}
               .value=${options.message}
               aria-autocomplete="list"
               aria-controls=${ifDefined(skillMenuVisible ? skillMenuListboxId : undefined)}

--- a/ui/src/pages/new-session/new-session-page.test.ts
+++ b/ui/src/pages/new-session/new-session-page.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import { t } from "../../i18n/index.ts";
 import type { NewSessionRouteData } from "./location.ts";
 import "./new-session-page-entry.ts";
 
@@ -53,6 +54,13 @@ afterEach(() => {
 });
 
 describe("new session draft route ownership", () => {
+  it("labels the message input independently of its placeholder", async () => {
+    const page = await mount(routeData("research"));
+    const textarea = page.querySelector<HTMLTextAreaElement>(".new-session-page__message");
+
+    expect(textarea?.getAttribute("aria-label")).toBe(t("newSession.messagePlaceholder"));
+  });
+
   it("clears source draft state when destination data is still pending", async () => {
     const page = await mount(routeData("research"));
     window.history.replaceState({}, "", "/new?agent=research");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where screen-reader users opening Chat or New Session encountered composer textareas without programmatic labels. Axe classified both routes with the serious `label-title-only` rule because placeholder text was the only source of the accessible name.

## Why This Change Was Made

Both composer owners now expose their existing localized placeholder text as an `aria-label`. This keeps the dynamic agent name and locale behavior as the single source of truth while leaving composer state, keyboard handling, and layout unchanged.

## User Impact

Screen readers can identify the message field in both active chats and new-session setup even after typed text replaces the visible placeholder.

## Evidence

- Pre-fix focused regression: both new assertions failed with `expected null` for `aria-label`.
- Post-fix focused regression: `31 passed` across `chat-composer.test.ts` and `new-session-page.test.ts`.
- `node scripts/check-changed.mjs -- <4 changed paths>`: all selected format, guard, typecheck, lint, and style lanes passed.
- Real mock Control UI browser proof on `/chat` and `/new`: accessibility trees exposed `textbox "Message Molty"` and `textbox "What should this session work on?"`.
- Axe 4.10.3: `label-title-only` fell from 1 serious violation to 0 on each repaired route. The unrelated shared `page-has-heading-one` and `region` findings remain out of scope.
- Independent read-only review: no actionable findings and no blocking proof gaps.
- The bundled Codex autoreview helper was attempted, but direct model authentication was unavailable in the orb (401); no clean-helper claim is made.

The accessible-name change is not visually rendered; screenshots demonstrate unchanged representative layouts.

| Route | Before | After |
| --- | --- | --- |
| Chat | ![Chat before](https://ampcode.com/user-content/artifacts/ff8d5937af62f1aaa53987f397a2c74b3a395f29ec33003f1f9e8b22c8eac9a7-file.png) | ![Chat after](https://ampcode.com/user-content/artifacts/de53194f571c11b7d254e69f289cd68dfea9091ce56d3252ef0e4a118bd00dc2-file.png) |
| New Session | ![New Session before](https://ampcode.com/user-content/artifacts/4e1b0c5b3beee394f95ac01a5be11e0766f9d02e9195db6a050562c7dd847edf-file.png) | ![New Session after](https://ampcode.com/user-content/artifacts/47300baef2942fb3c97e3a024e7e76cd2952a866b39e741ec84746d6263c50de-file.png) |

AI-assisted: yes. The implementation and test/proof results were inspected directly.
