### PR TITLE
fix(skills): reject an unknown --agent instead of inventing one

### DIFF
--- a/src/cli/skills-cli.commands.test.ts
+++ b/src/cli/skills-cli.commands.test.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AgentSelectionRequiredError,
+  resolveConfiguredAgentId,
   type AgentSelectionContext,
 } from "../agents/agent-scope-config.js";
 import { registerSkillsCli } from "./skills-cli.js";
@@ -105,6 +106,9 @@ const mocks = vi.hoisted(() => {
     resolveAgentIdByWorkspacePathMock: vi.fn(
       (_configForTest: unknown, _workspacePath: string): string | undefined => undefined,
     ),
+    resolveConfiguredAgentIdMock: vi.fn(
+      (_configForTest: unknown, agentId: string): string => agentId,
+    ),
     resolveAgentWorkspaceDirMock: vi.fn(
       (_configForTest: unknown, _agentId: string) => "/tmp/workspace",
     ),
@@ -134,6 +138,7 @@ const {
   loadConfigMock,
   resolveDefaultAgentIdMock,
   resolveAgentIdByWorkspacePathMock,
+  resolveConfiguredAgentIdMock,
   resolveAgentWorkspaceDirMock,
   searchSkillsFromClawHubMock,
   installSkillFromClawHubMock,
@@ -272,6 +277,8 @@ vi.mock("../config/config.js", () => ({
 vi.mock("../agents/agent-scope.js", () => ({
   resolveAgentIdByWorkspacePath: (config: unknown, workspacePath: string) =>
     mocks.resolveAgentIdByWorkspacePathMock(config, workspacePath),
+  resolveConfiguredAgentId: (config: unknown, agentId: string) =>
+    mocks.resolveConfiguredAgentIdMock(config, agentId),
   resolveDefaultAgentId: (config: unknown, context?: AgentSelectionContext) =>
     mocks.resolveDefaultAgentIdMock(config, context),
   resolveAgentWorkspaceDir: (config: unknown, agentId: string) =>
@@ -347,6 +354,7 @@ describe("skills cli commands", () => {
     loadConfigMock.mockReset();
     resolveDefaultAgentIdMock.mockReset();
     resolveAgentIdByWorkspacePathMock.mockReset();
+    resolveConfiguredAgentIdMock.mockReset();
     resolveAgentWorkspaceDirMock.mockReset();
     searchSkillsFromClawHubMock.mockReset();
     installSkillFromClawHubMock.mockReset();
@@ -366,6 +374,7 @@ describe("skills cli commands", () => {
     loadConfigMock.mockReturnValue({});
     resolveDefaultAgentIdMock.mockReturnValue("main");
     resolveAgentIdByWorkspacePathMock.mockReturnValue(undefined);
+    resolveConfiguredAgentIdMock.mockImplementation((_config, agentId: string) => agentId);
     resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
     searchSkillsFromClawHubMock.mockResolvedValue([]);
     installSkillFromClawHubMock.mockResolvedValue({
@@ -1499,6 +1508,7 @@ describe("skills cli commands", () => {
       await runCommand(argv);
     });
 
+    expect(resolveConfiguredAgentIdMock).not.toHaveBeenCalled();
     expectStatusWorkspaceCall("/tmp/workspace-writer");
   });
 
@@ -1570,7 +1580,57 @@ describe("skills cli commands", () => {
     });
 
     expect(resolveAgentIdByWorkspacePathMock).not.toHaveBeenCalled();
+    expect(resolveConfiguredAgentIdMock).toHaveBeenCalledWith({}, "writer");
     expectStatusWorkspaceCall("/tmp/workspace-writer");
+  });
+
+  it.each([
+    ["list", ["skills", "list", "--agent", "nope-agent"]],
+    ["check", ["skills", "check", "--agent", "nope-agent"]],
+    ["default parent option", ["skills", "--agent", "nope-agent"]],
+    ["install", ["skills", "install", "calendar", "--agent", "nope-agent"]],
+    ["verify", ["skills", "verify", "calendar", "--card", "--agent", "nope-agent"]],
+    ["workshop list", ["skills", "workshop", "list", "--agent", "nope-agent"]],
+    ["workshop inspect", ["skills", "workshop", "inspect", "proposal-id", "--agent", "nope-agent"]],
+    [
+      "workshop proposal",
+      [
+        "skills",
+        "workshop",
+        "propose-create",
+        "--name",
+        "calendar-helper",
+        "--description",
+        "Calendar helper",
+        "--proposal",
+        "/missing/proposal.md",
+        "--agent",
+        "nope-agent",
+      ],
+    ],
+  ])("rejects an unknown agent before skills %s work", async (_label, argv) => {
+    resolveConfiguredAgentIdMock.mockImplementation((_config, agentId: string) =>
+      resolveConfiguredAgentId({ agents: { list: [{ id: "main" }, { id: "writer" }] } }, agentId),
+    );
+
+    await expect(runCommand(argv)).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors).toStrictEqual([
+      'Unknown agent id "nope-agent". Run openclaw agents list to see configured agents.',
+    ]);
+    expect(resolveAgentWorkspaceDirMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["empty", ["skills", "check", "--agent", ""]],
+    ["whitespace-only", ["skills", "check", "--agent", "   "]],
+    ["empty with --global", ["skills", "install", "calendar", "--global", "--agent", ""]],
+  ])("rejects a blank explicit skills agent (%s)", async (_label, argv) => {
+    await expect(runCommand(argv)).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors).toStrictEqual(["--agent must not be blank"]);
+    expect(resolveConfiguredAgentIdMock).not.toHaveBeenCalled();
+    expect(resolveAgentWorkspaceDirMock).not.toHaveBeenCalled();
   });
 
   it("falls back to the default agent outside configured workspaces", async () => {
@@ -1587,6 +1647,7 @@ describe("skills cli commands", () => {
       {},
       expect.objectContaining({ hint: "Pass --agent <id>." }),
     );
+    expect(resolveConfiguredAgentIdMock).not.toHaveBeenCalled();
     expectStatusWorkspaceCall("/tmp/workspace-main");
   });
 

--- a/src/cli/skills-cli.ts
+++ b/src/cli/skills-cli.ts
@@ -9,6 +9,7 @@ import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import {
+  resolveConfiguredAgentId,
   resolveAgentIdByWorkspacePath,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
@@ -142,6 +143,14 @@ const GATEWAY_SKILLS_OFFLINE_LOCK_TIMEOUT_MS = 250;
 // Apply can await evaluator, proposal-change, and skill-change hook phases.
 const GATEWAY_SKILLS_APPLY_TIMEOUT_MS = 1_850_000;
 
+function normalizeExplicitAgentId(agentId?: string): string | undefined {
+  const normalizedAgentId = agentId?.trim();
+  if (agentId !== undefined && !normalizedAgentId) {
+    throw new Error("--agent must not be blank");
+  }
+  return normalizedAgentId;
+}
+
 function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   config: ReturnType<typeof getRuntimeConfig>;
   workspaceDir: string;
@@ -151,14 +160,14 @@ function resolveSkillsWorkspace(options?: ResolveSkillsWorkspaceOptions): {
   const config = getRuntimeConfig(
     options?.skipPluginValidation ? { skipPluginValidation: true } : undefined,
   );
-  const explicitAgentId = normalizeOptionalString(options?.agentId);
+  const explicitAgentId = normalizeExplicitAgentId(options?.agentId);
   const inferredAgentId = explicitAgentId
     ? undefined
     : resolveAgentIdByWorkspacePath(config, options?.cwd ?? process.cwd());
-  const agentId =
-    explicitAgentId ??
-    inferredAgentId ??
-    resolveDefaultAgentId(config, { surface: "the skills command", hint: "Pass --agent <id>." });
+  const agentId = explicitAgentId
+    ? resolveConfiguredAgentId(config, explicitAgentId)
+    : (inferredAgentId ??
+      resolveDefaultAgentId(config, { surface: "the skills command", hint: "Pass --agent <id>." }));
   return {
     config,
     agentId,
@@ -231,8 +240,8 @@ function resolveClawHubTargetWorkspace(
   opts: { agent?: string; global?: boolean },
   reportError: (message: string) => void = defaultRuntime.error,
 ): Pick<ResolvedSkillsWorkspace, "config" | "workspaceDir"> | undefined {
-  const agentId = resolveAgentOption(command, opts);
-  if (opts.global && normalizeOptionalString(agentId)) {
+  const agentId = normalizeExplicitAgentId(resolveAgentOption(command, opts));
+  if (opts.global && agentId) {
     reportError("Use either --global or --agent, not both.");
     defaultRuntime.exit(1);
     return undefined;

--- a/src/cli/skills-cli.verify.test.ts
+++ b/src/cli/skills-cli.verify.test.ts
@@ -58,6 +58,7 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
+  resolveConfiguredAgentId: (_config: unknown, agentId: string) => agentId,
   resolveAgentIdByWorkspacePath: (config: unknown, workspacePath: string) =>
     mocks.resolveAgentIdByWorkspacePathMock(config, workspacePath),
   resolveDefaultAgentId: (config: unknown) => mocks.resolveDefaultAgentIdMock(config),

--- a/src/cli/skills-cli.workshop-cache.test.ts
+++ b/src/cli/skills-cli.workshop-cache.test.ts
@@ -51,6 +51,7 @@ vi.mock("../config/config.js", () => ({
   resetConfigRuntimeState: () => undefined,
 }));
 vi.mock("../agents/agent-scope.js", () => ({
+  resolveConfiguredAgentId: (_config: unknown, agentId: string) => agentId,
   resolveAgentIdByWorkspacePath: () => undefined,
   resolveDefaultAgentId: () => "main",
   resolveAgentWorkspaceDir: () => mocks.workspaceDir,

--- a/src/cli/skills-cli.workshop.test.ts
+++ b/src/cli/skills-cli.workshop.test.ts
@@ -83,6 +83,7 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
+  resolveConfiguredAgentId: (_config: unknown, agentId: string) => agentId,
   resolveAgentIdByWorkspacePath: () => undefined,
   resolveDefaultAgentId: () => "main",
   resolveAgentWorkspaceDir: (_config: unknown, agentId: string) => {


### PR DESCRIPTION
## What Problem This Solves

`openclaw skills check --agent nope-agent` exits 0 and prints a full, confident report for an agent that does not exist:

```
Agent: nope-agent
Skills: 53 total, 44 eligible
```

The install's only real agent reports `57 total, 48 eligible`. So this is not a silent fallback to the default — it fabricates an agent id and produces *different* numbers for it. `openclaw skills list --agent nope-agent` behaves the same way.

Every sibling `--agent` surface already rejects an unknown id and exits 1:

| command | unknown `--agent` |
| --- | --- |
| `models auth list` | `Unknown agent id "nope-agent".` exit 1 |
| `models list` | `Unknown agent id "nope-agent".` exit 1 |
| `models status` | `Unknown agent id "nope-agent".` exit 1 |
| `memory status` | `Unknown agent id "nope-agent".` exit 1 |
| `sessions list` | `Unknown agent id "nope-agent".` exit 1 |
| `skills check` / `skills list` | **exit 0, invented report** |

## Why This Change Was Made

`resolveSkillsWorkspace` accepted the explicit `--agent` value verbatim, while both other resolution paths in the same function were validated — workspace inference can only return a configured id, and the default path goes through `resolveDefaultAgentId`. Only the operator-supplied value skipped the check.

The canonical helper already exists: `resolveConfiguredAgentId` in `src/agents/agent-scope-config.ts`, added for exactly this class when `memory --agent` had the same hole. It also produces the profile-aware hint (`openclaw --profile proof agents list`) rather than a bare command that cannot be pasted back under a profile or container.

This is the doctrine's worst bug class: an action that ends in a plausible-looking outcome with nothing explaining that the input was wrong. An operator debugging why a skill is not eligible for their agent gets a report about an agent that does not exist, with no signal that they typo'd the id.

A blank `--agent ''` is rejected the same way `memory` rejects it, so an empty shell variable does not silently fall through to the default agent.

## User Impact

`skills check` and `skills list` now match every sibling command:

```
$ openclaw skills check --agent nope-agent
Unknown agent id "nope-agent". Run openclaw agents list to see configured agents.
$ echo $?
1
```

`--agent <real-id>`, workspace-path inference, and default resolution are unchanged.

Production LOC: +9.

## Evidence

Behavior, on a fresh isolated profile:

- `skills check --agent nope-agent` → `Unknown agent id "nope-agent". Run openclaw --profile proof agents list to see configured agents.`, exit 1 (was exit 0 with a 53/44 report)
- `skills list --agent nope-agent` → same, exit 1
- `skills check --agent ''` → `--agent must not be blank`, exit 1
- `skills check --agent main` → 57 total / 48 eligible, unchanged
- from a `writer` agent's workspace directory with no `--agent`, inference still resolves `writer`

Tests (four suites covering the changed function and its ClawHub sibling), all green locally:

- `src/cli/skills-cli.commands.test.ts` — 88 passed
- `src/cli/skills-cli.verify.test.ts` — 17 passed
- `src/cli/skills-cli.workshop.test.ts` — 8 passed
- `src/cli/skills-cli.workshop-cache.test.ts` — 5 passed

`$autoreview --mode branch --base origin/main`: clean, no accepted or actionable findings.
