### PR TITLE
fix(auth): pick the display store from persisted sources, not runtime ones

### DIFF
--- a/src/agents/auth-profiles/path-resolve.shared-store.test.ts
+++ b/src/agents/auth-profiles/path-resolve.shared-store.test.ts
@@ -7,9 +7,24 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { withEnv } from "../../test-utils/env.js";
 import { resolveAuthStatePathForDisplay, resolveAuthStorePathForDisplay } from "./paths.js";
-import { writePersistedAuthProfileStoreRaw } from "./sqlite.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  setRuntimeAuthProfileStoreSnapshot,
+} from "./runtime-snapshots.js";
+import { hasLocalAuthProfileStoreSource } from "./source-check.js";
+import {
+  inspectPersistedAuthProfileStoreRaw,
+  writePersistedAuthProfileStoreRaw,
+} from "./sqlite.js";
+import type { AuthProfileStore } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const persistedStore = {
+  version: 1,
+  profiles: {
+    "openai:test": { type: "api_key", provider: "openai", key: "test-key" },
+  },
+} satisfies AuthProfileStore;
 
 function makeStateEnv(): NodeJS.ProcessEnv {
   const stateDir = tempDirs.make("openclaw-shared-auth-store-");
@@ -22,6 +37,7 @@ describe("shared auth store path resolution", () => {
   });
 
   afterEach(() => {
+    clearRuntimeAuthProfileStoreSnapshots();
     closeOpenClawStateDatabaseForTest();
   });
 
@@ -44,10 +60,14 @@ describe("shared auth store path resolution", () => {
     );
 
     withEnv({ OPENCLAW_STATE_DIR: env.OPENCLAW_STATE_DIR, OPENCLAW_AGENT_DIR: undefined }, () => {
-      writePersistedAuthProfileStoreRaw({ version: 1, profiles: {} }, legacyDir);
+      writePersistedAuthProfileStoreRaw(persistedStore, legacyDir);
       const expectedPath = path.join(legacyDir, "openclaw-agent.sqlite");
       expect(resolveAuthStorePathForDisplay(legacyDir)).toBe(expectedPath);
       expect(resolveAuthStatePathForDisplay(legacyDir)).toBe(expectedPath);
+      expect(inspectPersistedAuthProfileStoreRaw(legacyDir)).toMatchObject({
+        status: "readable",
+        raw: persistedStore,
+      });
       expect(existsSync(expectedPath)).toBe(true);
     });
   });
@@ -62,7 +82,7 @@ describe("shared auth store path resolution", () => {
     expect(resolveSharedAuthStorePath(env)).toBe(resolveOpenClawStateSqlitePath(env));
 
     withEnv({ OPENCLAW_STATE_DIR: env.OPENCLAW_STATE_DIR, OPENCLAW_AGENT_DIR: undefined }, () => {
-      writePersistedAuthProfileStoreRaw({ version: 1, profiles: {} });
+      writePersistedAuthProfileStoreRaw(persistedStore);
       const agentDir = path.join(env.OPENCLAW_STATE_DIR ?? "", "agents", "helper", "agent");
       const expectedPath = resolveOpenClawStateSqlitePath(env);
       expect(resolveAuthStorePathForDisplay(agentDir)).toBe(expectedPath);
@@ -77,11 +97,34 @@ describe("shared auth store path resolution", () => {
     const agentDir = path.join(env.OPENCLAW_STATE_DIR ?? "", "agents", "helper", "agent");
 
     withEnv({ OPENCLAW_STATE_DIR: env.OPENCLAW_STATE_DIR, OPENCLAW_AGENT_DIR: undefined }, () => {
-      writePersistedAuthProfileStoreRaw({ version: 1, profiles: {} }, agentDir);
+      writePersistedAuthProfileStoreRaw(persistedStore, agentDir);
       const expectedPath = path.join(agentDir, "openclaw-agent.sqlite");
       expect(resolveAuthStorePathForDisplay(agentDir)).toBe(expectedPath);
       expect(resolveAuthStatePathForDisplay(agentDir)).toBe(expectedPath);
       expect(existsSync(expectedPath)).toBe(true);
+    });
+  });
+
+  it("ignores runtime-only external CLI profiles when displaying store ownership", async () => {
+    const env = makeStateEnv();
+    writeConfigMachineState("auth.sharedStore", { location: "state-db" }, { env });
+    const agentDir = path.join(env.OPENCLAW_STATE_DIR ?? "", "agents", "helper", "agent");
+
+    withEnv({ OPENCLAW_STATE_DIR: env.OPENCLAW_STATE_DIR, OPENCLAW_AGENT_DIR: undefined }, () => {
+      writePersistedAuthProfileStoreRaw(persistedStore);
+      setRuntimeAuthProfileStoreSnapshot(
+        {
+          ...persistedStore,
+          runtimeExternalProfileIds: ["openai:test"],
+          runtimeExternalCliProfileIds: ["openai:test"],
+        },
+        agentDir,
+      );
+
+      expect(hasLocalAuthProfileStoreSource(agentDir)).toBe(true);
+      expect(inspectPersistedAuthProfileStoreRaw(agentDir).status).toBe("missing");
+      expect(resolveAuthStorePathForDisplay(agentDir)).toBe(resolveOpenClawStateSqlitePath(env));
+      expect(resolveAuthStatePathForDisplay(agentDir)).toBe(resolveOpenClawStateSqlitePath(env));
     });
   });
 

--- a/src/agents/auth-profiles/paths.ts
+++ b/src/agents/auth-profiles/paths.ts
@@ -5,14 +5,14 @@
 import path from "node:path";
 import { resolveUserPath } from "../../utils.js";
 import { resolveOAuthRefreshLockPath, resolveSharedAuthStorePath } from "./path-resolve.js";
-import { hasLocalAuthProfileStoreSource } from "./source-check.js";
+import { inspectPersistedAuthProfileStoreRaw } from "./sqlite.js";
 
 export { resolveOAuthRefreshLockPath };
 
 /** Resolve the user-facing path for the database selected by the auth store loader. */
 export function resolveAuthStorePathForDisplay(agentDir?: string): string {
   const pathname =
-    agentDir && hasLocalAuthProfileStoreSource(agentDir)
+    agentDir && inspectPersistedAuthProfileStoreRaw(agentDir).status !== "missing"
       ? path.join(resolveUserPath(agentDir), "openclaw-agent.sqlite")
       : resolveSharedAuthStorePath();
   return pathname.startsWith("~") ? pathname : resolveUserPath(pathname);


### PR DESCRIPTION
## What Problem This Solves

On one install, two commands disagreed about where the auth store lives:

```
$ openclaw models status
Auth store: <state>/agents/main/agent/openclaw-agent.sqlite
$ openclaw models auth list
Auth profiles (<state>/state/openclaw.sqlite)
```

The agent database `models status` named held **no auth rows at all**. An operator following that path to inspect, back up, or delete their credentials would be looking at the wrong file — and the one they were told to look at is empty.

## Why This Change Was Made

`resolveAuthStorePathForDisplay` chose between the agent-local database and the shared owner using `hasLocalAuthProfileStoreSource`. That predicate returns true for **four** different things, and its first branch is a *runtime snapshot*:

```ts
const runtimeStore = getRuntimeAuthProfileStoreSnapshotCore(agentDir);
if (runtimeStore && Object.keys(runtimeStore.profiles).length > 0) return true;
```

External-CLI credential discovery populates an agent-scoped runtime snapshot. `models status` performs that discovery as part of its work; `models auth list` does not. So `models status` concluded the agent owned a local store *file* on the strength of in-memory profiles whose credentials live in the external tool's own files and were never written to any agent database.

Pointing `HOME` at an empty directory removes the discovery, and both commands already agreed — which isolates the trigger to the runtime branch rather than to ownership state.

The value being rendered is a **file path**, and only persisted state lives in a file. The decision now uses the persisted store probe directly (`inspectPersistedAuthProfileStoreRaw(agentDir).status !== "missing"`), so display answers the question it is actually asking. A genuinely local persisted store still wins, including on a legacy root with no ownership record.

The two dropped branches are safe for display purposes: on a JSON-era fixture the command fails closed with `Auth profile store <path> requires legacy credential migration; run openclaw doctor --fix.` before display is ever reached (verified on a hand-built fixture, see below).

## User Impact

`models status` and `models auth list` now name the same database, and it is the one that actually holds the rows. No behavior change when the agent has a real local store file.

Production LOC: 2 lines changed, net 0.

## Evidence

Reproduced and verified both directions on isolated state roots:

| case | before | after |
| --- | --- | --- |
| external CLI credential discoverable | `status` → agents/main/agent/openclaw-agent.sqlite (0 auth rows); `auth list` → state/openclaw.sqlite | both → `state/openclaw.sqlite`, `status_auth_rows=1` |
| `HOME` pointed at an empty dir | both → state/openclaw.sqlite | unchanged |
| legacy root with a real agent-local store | both → agents/main/agent/openclaw-agent.sqlite | unchanged, `primary_auth_rows=1` |

JSON-era safety check, hand-built fixture: `models auth list` exits with `Auth profile store <state>/agents/main/agent/openclaw-agent.sqlite requires legacy credential migration; run openclaw doctor --fix.` — the migration gate fires before display, so the dropped legacy-credential branch cannot change what an operator sees.

All 12 suites that exercise the display helpers or their callers, green locally: `path-resolve.shared-store.test.ts` (17), `paths-direct-import.test.ts` (2), `store.test.ts` (27), `source-check.test.ts` (5), `sqlite.test.ts` (9), `models-cli.test.ts` (80), `models-status.test.ts` (7), `doctor-auth-flat-profiles.test.ts` (107), `onboard-auth.test.ts` (8), `shared-store-bootstrap.test.ts` (5), `doctor-model-catalog-credentials.test.ts` (11), `auth-profiles.test.ts` (35).

`$autoreview --mode branch --base origin/main`: clean, no accepted or actionable findings.
