### PR TITLE
fix: plugin prerelease onboarding proof follows shared auth storage

### DIFF
--- a/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
+++ b/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
@@ -77,8 +77,8 @@ function extractStatusSection(text, title) {
   return stripAnsi(section.join("\n"));
 }
 
-function readAuthProfileStoreText(agentDir) {
-  const dbPath = path.join(agentDir, "openclaw-agent.sqlite");
+function readSharedAuthProfileStoreText(stateDir) {
+  const dbPath = path.join(stateDir, "state", "openclaw.sqlite");
   if (!fs.existsSync(dbPath)) {
     return "";
   }
@@ -86,8 +86,8 @@ function readAuthProfileStoreText(agentDir) {
   try {
     db = new DatabaseSync(dbPath, { readOnly: true });
     const row = db
-      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
-      .get("primary");
+      .prepare("SELECT store_json FROM auth_profile_stores WHERE store_key = ?")
+      .get("shared");
     return typeof row?.store_json === "string" ? row.store_json : "";
   } catch {
     return "";
@@ -100,15 +100,21 @@ function assertOnboardState() {
   const home = process.argv[3];
   const stateDir = path.join(home, ".openclaw");
   const configPath = path.join(stateDir, "openclaw.json");
-  const agentDir = path.join(stateDir, "agents", "main", "agent");
+  const legacyAuthDatabase = path.join(
+    stateDir,
+    "agents",
+    "main",
+    "agent",
+    "openclaw-agent.sqlite",
+  );
 
   if (!fs.existsSync(configPath)) {
     throw new Error("onboard did not write openclaw.json");
   }
-  if (!fs.existsSync(agentDir)) {
-    throw new Error("onboard did not create main agent dir");
+  if (fs.existsSync(legacyAuthDatabase)) {
+    throw new Error("onboard created the retired main-agent auth database");
   }
-  const authStoreText = readAuthProfileStoreText(agentDir);
+  const authStoreText = readSharedAuthProfileStoreText(stateDir);
   if (!authStoreText) {
     throw new Error("onboard did not persist auth profile store");
   }

--- a/test/scripts/npm-onboard-channel-agent-assertions.test.ts
+++ b/test/scripts/npm-onboard-channel-agent-assertions.test.ts
@@ -37,12 +37,13 @@ function writeOnboardConfig(home: string): void {
   );
 }
 
-function writeAuthProfileStoreSqlite(agentDir: string, store: unknown): void {
-  fs.mkdirSync(agentDir, { recursive: true });
-  const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+function writeSharedAuthProfileStoreSqlite(home: string, store: unknown): void {
+  const stateDir = path.join(home, ".openclaw", "state");
+  fs.mkdirSync(stateDir, { recursive: true });
+  const db = new DatabaseSync(path.join(stateDir, "openclaw.sqlite"));
   try {
     db.exec(`
-      CREATE TABLE IF NOT EXISTS auth_profile_store (
+      CREATE TABLE IF NOT EXISTS auth_profile_stores (
         store_key TEXT NOT NULL PRIMARY KEY,
         store_json TEXT NOT NULL,
         updated_at INTEGER NOT NULL
@@ -50,10 +51,10 @@ function writeAuthProfileStoreSqlite(agentDir: string, store: unknown): void {
     `);
     db.prepare(
       `
-        INSERT INTO auth_profile_store (store_key, store_json, updated_at)
+        INSERT INTO auth_profile_stores (store_key, store_json, updated_at)
         VALUES (?, ?, ?)
       `,
-    ).run("primary", JSON.stringify(store), Date.now());
+    ).run("shared", JSON.stringify(store), Date.now());
   } finally {
     db.close();
   }
@@ -217,13 +218,13 @@ describe("npm onboard channel agent assertions", () => {
     }
   });
 
-  it("validates OpenAI env refs from the SQLite auth profile store", () => {
+  it("validates OpenAI env refs from the shared SQLite auth profile store", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
     const agentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
 
     try {
       writeOnboardConfig(tempDir);
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeSharedAuthProfileStoreSqlite(tempDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -238,6 +239,7 @@ describe("npm onboard channel agent assertions", () => {
 
       expect(result.status).toBe(0);
       expect(result.stderr).toBe("");
+      expect(fs.existsSync(agentDir)).toBe(false);
       expect(fs.existsSync(path.join(agentDir, "auth-profiles.json"))).toBe(false);
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });
@@ -257,11 +259,10 @@ describe("npm onboard channel agent assertions", () => {
 
     for (const store of cases) {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
-      const agentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
 
       try {
         writeOnboardConfig(tempDir);
-        writeAuthProfileStoreSqlite(agentDir, store);
+        writeSharedAuthProfileStoreSqlite(tempDir, store);
 
         const result = runOnboardAssert(tempDir);
 
@@ -275,11 +276,9 @@ describe("npm onboard channel agent assertions", () => {
 
   it("rejects inline OpenAI keys in the SQLite auth profile store", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
-    const agentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
-
     try {
       writeOnboardConfig(tempDir);
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeSharedAuthProfileStoreSqlite(tempDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -294,6 +293,34 @@ describe("npm onboard channel agent assertions", () => {
 
       expect(result.status).not.toBe(0);
       expect(result.stderr).toContain("auth profile persisted the raw OpenAI test key");
+    } finally {
+      fs.rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a fresh install that recreates the retired main-agent auth database", () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
+    const legacyAgentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
+
+    try {
+      writeOnboardConfig(tempDir);
+      writeSharedAuthProfileStoreSqlite(tempDir, {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+          },
+        },
+      });
+      fs.mkdirSync(legacyAgentDir, { recursive: true });
+      new DatabaseSync(path.join(legacyAgentDir, "openclaw-agent.sqlite")).close();
+
+      const result = runOnboardAssert(tempDir);
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("onboard created the retired main-agent auth database");
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the plugin prerelease Docker onboarding lanes failed after successful fresh-install onboarding because their release assertion still required the retired main-agent auth database.

## Why This Change Was Made

Fresh installs intentionally persist shared credentials in `state/openclaw.sqlite` after #126783. The release assertion now reads the canonical shared auth-profile row and rejects accidental recreation of the legacy per-agent database.

## User Impact

No product behavior changes. Release validation once again accurately proves npm onboarding for the generic, Discord, and Slack candidate-package lanes.

## Evidence

- Failure: Plugin Prerelease run 32439986043, all three onboarding lanes stopped at `onboard did not create main agent dir` after onboarding returned `ok: true` and wrote canonical config.
- Root cause: #126783 moved fresh shared-auth ownership to the state database; the harness still read `agents/main/agent/openclaw-agent.sqlite`.
- Focused assertion coverage now proves the shared row, env SecretRef, absence of inline key material, and absence of the retired agent database.
- Autoreview: clean, no accepted/actionable findings.
- Exact-head remote Docker proof: pending.
