### PR TITLE
test(e2e): share canonical auth store reader

### DIFF
--- a/scripts/e2e/lib/auth-profile-store-assertions.d.mts
+++ b/scripts/e2e/lib/auth-profile-store-assertions.d.mts
@@ -1,0 +1,15 @@
+export type AuthProfileStoreAssertionOptions = {
+  missingMessage?: string;
+  envRefMessage?: string;
+  rawKeyMessage?: string;
+  rawKeyNeedle?: string;
+};
+
+export declare function readSharedAuthProfileStoreText(stateDir: string): string;
+
+export declare function assertNoLegacyPrimaryAuthRows(stateDir: string): void;
+
+export declare function assertOpenAiEnvAuthProfileStore(
+  storeJson: string,
+  options?: AuthProfileStoreAssertionOptions,
+): void;

--- a/scripts/e2e/lib/auth-profile-store-assertions.mjs
+++ b/scripts/e2e/lib/auth-profile-store-assertions.mjs
@@ -1,5 +1,27 @@
 // Shared auth profile store assertions for install/onboard E2E proof.
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { isRecord } from "../../lib/record-shared.mjs";
+
+export function readSharedAuthProfileStoreText(stateDir) {
+  const dbPath = path.join(stateDir, "state", "openclaw.sqlite");
+  if (!fs.existsSync(dbPath)) {
+    return "";
+  }
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+    const row = db
+      .prepare("SELECT store_json FROM auth_profile_stores WHERE store_key = ?")
+      .get("shared");
+    return typeof row?.store_json === "string" ? row.store_json : "";
+  } catch {
+    return "";
+  } finally {
+    db?.close();
+  }
+}
 
 function hasExpectedOpenAiEnvRef(profile) {
   if (!isRecord(profile)) {

--- a/scripts/e2e/lib/auth-profile-store-assertions.mjs
+++ b/scripts/e2e/lib/auth-profile-store-assertions.mjs
@@ -12,12 +12,69 @@ export function readSharedAuthProfileStoreText(stateDir) {
   let db;
   try {
     db = new DatabaseSync(dbPath, { readOnly: true });
+    const schema = db
+      .prepare("SELECT type FROM sqlite_schema WHERE name = ? LIMIT 1")
+      .get("auth_profile_stores");
+    if (!schema) {
+      return "";
+    }
+    if (schema.type !== "table") {
+      throw new Error(`auth_profile_stores is ${String(schema.type)}, not a table`);
+    }
     const row = db
       .prepare("SELECT store_json FROM auth_profile_stores WHERE store_key = ?")
       .get("shared");
     return typeof row?.store_json === "string" ? row.store_json : "";
-  } catch {
-    return "";
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`could not read the shared auth profile store: ${detail}`, {
+      cause: error,
+    });
+  } finally {
+    db?.close();
+  }
+}
+
+export function assertNoLegacyPrimaryAuthRows(stateDir) {
+  const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  if (!fs.existsSync(dbPath)) {
+    return;
+  }
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+    const legacyRows = [
+      {
+        table: "auth_profile_store",
+        query: "SELECT 1 AS present FROM auth_profile_store WHERE store_key = ? LIMIT 1",
+      },
+      {
+        table: "auth_profile_state",
+        query: "SELECT 1 AS present FROM auth_profile_state WHERE state_key = ? LIMIT 1",
+      },
+    ];
+    for (const entry of legacyRows) {
+      const schema = db
+        .prepare("SELECT type FROM sqlite_schema WHERE name = ? LIMIT 1")
+        .get(entry.table);
+      if (!schema) {
+        continue;
+      }
+      if (schema.type !== "table") {
+        throw new Error(`${entry.table} is ${String(schema.type)}, not a table`);
+      }
+      if (db.prepare(entry.query).get("primary")) {
+        throw new Error(`onboard preserved a retired primary row in ${entry.table}`);
+      }
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("onboard preserved a retired")) {
+      throw error;
+    }
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`could not validate the main-agent auth database: ${detail}`, {
+      cause: error,
+    });
   } finally {
     db?.close();
   }

--- a/scripts/e2e/lib/codex-on-demand/assertions.mjs
+++ b/scripts/e2e/lib/codex-on-demand/assertions.mjs
@@ -2,8 +2,10 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
-import { assertOpenAiEnvAuthProfileStore } from "../auth-profile-store-assertions.mjs";
+import {
+  assertOpenAiEnvAuthProfileStore,
+  readSharedAuthProfileStoreText,
+} from "../auth-profile-store-assertions.mjs";
 import {
   assertPathInside,
   configPath,
@@ -125,24 +127,7 @@ if (providerRuntime && providerRuntime !== "codex") {
   throw new Error(`unexpected OpenAI provider runtime: ${providerRuntime}`);
 }
 
-function readAuthProfileStoreText(agentDir) {
-  const dbPath = path.join(agentDir, "openclaw-agent.sqlite");
-  if (!fs.existsSync(dbPath)) {
-    throw new Error("auth profile SQLite store was not persisted");
-  }
-  let db;
-  try {
-    db = new DatabaseSync(dbPath, { readOnly: true });
-    const row = db
-      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
-      .get("primary");
-    return typeof row?.store_json === "string" ? row.store_json : "";
-  } finally {
-    db?.close();
-  }
-}
-
-const authRaw = readAuthProfileStoreText(path.join(stateDir(), "agents", "main", "agent"));
+const authRaw = readSharedAuthProfileStoreText(stateDir());
 if (!authRaw) {
   throw new Error("auth profile SQLite store row was not persisted");
 }

--- a/scripts/e2e/lib/codex-on-demand/assertions.mjs
+++ b/scripts/e2e/lib/codex-on-demand/assertions.mjs
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import {
+  assertNoLegacyPrimaryAuthRows,
   assertOpenAiEnvAuthProfileStore,
   readSharedAuthProfileStoreText,
 } from "../auth-profile-store-assertions.mjs";
@@ -127,7 +128,9 @@ if (providerRuntime && providerRuntime !== "codex") {
   throw new Error(`unexpected OpenAI provider runtime: ${providerRuntime}`);
 }
 
-const authRaw = readSharedAuthProfileStoreText(stateDir());
+const openClawStateDir = stateDir();
+assertNoLegacyPrimaryAuthRows(openClawStateDir);
+const authRaw = readSharedAuthProfileStoreText(openClawStateDir);
 if (!authRaw) {
   throw new Error("auth profile SQLite store row was not persisted");
 }

--- a/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
+++ b/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
@@ -1,12 +1,14 @@
 // Assertions for npm onboard channel-agent E2E scenarios.
 import fs from "node:fs";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import {
   assertAgentReplyContainsMarker,
   assertOpenAiRequestLogUsed,
 } from "../agent-turn-output.mjs";
-import { assertOpenAiEnvAuthProfileStore } from "../auth-profile-store-assertions.mjs";
+import {
+  assertOpenAiEnvAuthProfileStore,
+  readSharedAuthProfileStoreText,
+} from "../auth-profile-store-assertions.mjs";
 import { readPositiveIntEnv } from "../env-limits.mjs";
 import {
   applyMockOpenAiModelConfig,
@@ -75,25 +77,6 @@ function extractStatusSection(text, title) {
     section.push(line);
   }
   return stripAnsi(section.join("\n"));
-}
-
-function readSharedAuthProfileStoreText(stateDir) {
-  const dbPath = path.join(stateDir, "state", "openclaw.sqlite");
-  if (!fs.existsSync(dbPath)) {
-    return "";
-  }
-  let db;
-  try {
-    db = new DatabaseSync(dbPath, { readOnly: true });
-    const row = db
-      .prepare("SELECT store_json FROM auth_profile_stores WHERE store_key = ?")
-      .get("shared");
-    return typeof row?.store_json === "string" ? row.store_json : "";
-  } catch {
-    return "";
-  } finally {
-    db?.close();
-  }
 }
 
 function assertOnboardState() {

--- a/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
+++ b/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs
@@ -6,6 +6,7 @@ import {
   assertOpenAiRequestLogUsed,
 } from "../agent-turn-output.mjs";
 import {
+  assertNoLegacyPrimaryAuthRows,
   assertOpenAiEnvAuthProfileStore,
   readSharedAuthProfileStoreText,
 } from "../auth-profile-store-assertions.mjs";
@@ -83,20 +84,11 @@ function assertOnboardState() {
   const home = process.argv[3];
   const stateDir = path.join(home, ".openclaw");
   const configPath = path.join(stateDir, "openclaw.json");
-  const legacyAuthDatabase = path.join(
-    stateDir,
-    "agents",
-    "main",
-    "agent",
-    "openclaw-agent.sqlite",
-  );
 
   if (!fs.existsSync(configPath)) {
     throw new Error("onboard did not write openclaw.json");
   }
-  if (fs.existsSync(legacyAuthDatabase)) {
-    throw new Error("onboard created the retired main-agent auth database");
-  }
+  assertNoLegacyPrimaryAuthRows(stateDir);
   const authStoreText = readSharedAuthProfileStoreText(stateDir);
   if (!authStoreText) {
     throw new Error("onboard did not persist auth profile store");

--- a/scripts/e2e/lib/release-scenarios/assertions.mjs
+++ b/scripts/e2e/lib/release-scenarios/assertions.mjs
@@ -1,12 +1,14 @@
 // Assertions for release scenario E2E packages and plugin state.
 import fs from "node:fs";
 import path from "node:path";
-import { DatabaseSync } from "node:sqlite";
 import {
   assertAgentReplyContainsMarker,
   assertOpenAiRequestLogUsed,
 } from "../agent-turn-output.mjs";
-import { assertOpenAiEnvAuthProfileStore } from "../auth-profile-store-assertions.mjs";
+import {
+  assertOpenAiEnvAuthProfileStore,
+  readSharedAuthProfileStoreText,
+} from "../auth-profile-store-assertions.mjs";
 import {
   applyMockOpenAiModelConfig,
   parseMockOpenAiPort,
@@ -49,39 +51,16 @@ function authProfilesPath() {
   );
 }
 
-function authProfilesDatabasePath() {
-  return path.join(
-    process.env.HOME ?? "",
-    ".openclaw",
-    "agents",
-    "main",
-    "agent",
-    "openclaw-agent.sqlite",
-  );
-}
-
-function readAuthProfileStoreSqliteText() {
-  const dbPath = authProfilesDatabasePath();
-  if (!fs.existsSync(dbPath)) {
-    return "";
-  }
-  let db;
-  try {
-    db = new DatabaseSync(dbPath, { readOnly: true });
-    const row = db
-      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
-      .get("primary");
-    return typeof row?.store_json === "string" ? row.store_json : "";
-  } catch {
-    return "";
-  } finally {
-    db?.close();
-  }
+function stateDir() {
+  return process.env.OPENCLAW_STATE_DIR ?? path.dirname(configPath());
 }
 
 function readStateText() {
   const paths = [configPath(), authProfilesPath()].filter((file) => fs.existsSync(file));
-  return [...paths.map((file) => fs.readFileSync(file, "utf8")), readAuthProfileStoreSqliteText()]
+  return [
+    ...paths.map((file) => fs.readFileSync(file, "utf8")),
+    readSharedAuthProfileStoreText(stateDir()),
+  ]
     .filter(Boolean)
     .join("\n");
 }
@@ -96,7 +75,7 @@ function configureMockOpenAi() {
 function assertOpenAiEnvRef() {
   const rawKey = process.argv[3];
   assert(fs.existsSync(configPath()), "openclaw.json missing");
-  assertOpenAiEnvAuthProfileStore(readAuthProfileStoreSqliteText(), {
+  assertOpenAiEnvAuthProfileStore(readSharedAuthProfileStoreText(stateDir()), {
     missingMessage: "OpenAI env ref was not persisted",
     envRefMessage: "OpenAI env ref was not persisted",
     rawKeyMessage: "raw OpenAI key was persisted",

--- a/scripts/e2e/lib/release-scenarios/assertions.mjs
+++ b/scripts/e2e/lib/release-scenarios/assertions.mjs
@@ -6,6 +6,7 @@ import {
   assertOpenAiRequestLogUsed,
 } from "../agent-turn-output.mjs";
 import {
+  assertNoLegacyPrimaryAuthRows,
   assertOpenAiEnvAuthProfileStore,
   readSharedAuthProfileStoreText,
 } from "../auth-profile-store-assertions.mjs";
@@ -75,6 +76,7 @@ function configureMockOpenAi() {
 function assertOpenAiEnvRef() {
   const rawKey = process.argv[3];
   assert(fs.existsSync(configPath()), "openclaw.json missing");
+  assertNoLegacyPrimaryAuthRows(stateDir());
   assertOpenAiEnvAuthProfileStore(readSharedAuthProfileStoreText(stateDir()), {
     missingMessage: "OpenAI env ref was not persisted",
     envRefMessage: "OpenAI env ref was not persisted",

--- a/test/scripts/auth-profile-store-assertions.test.ts
+++ b/test/scripts/auth-profile-store-assertions.test.ts
@@ -1,0 +1,178 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertNoLegacyPrimaryAuthRows,
+  readSharedAuthProfileStoreText,
+} from "../../scripts/e2e/lib/auth-profile-store-assertions.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function makeStateDir(): string {
+  const root = tempDirs.make("openclaw-auth-profile-assertions-");
+  return path.join(root, ".openclaw");
+}
+
+function writeSharedDatabase(
+  stateDir: string,
+  options: { asView?: boolean; storeJson?: string } = {},
+): string {
+  const dbPath = path.join(stateDir, "state", "openclaw.sqlite");
+  mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  try {
+    if (options.asView) {
+      db.exec(`
+        CREATE VIEW auth_profile_stores AS
+          SELECT 'shared' AS store_key, '{}' AS store_json, 1 AS updated_at;
+      `);
+    } else {
+      db.exec(`
+        CREATE TABLE auth_profile_stores (
+          store_key TEXT NOT NULL PRIMARY KEY,
+          store_json TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        ) STRICT;
+      `);
+      db.prepare("INSERT INTO auth_profile_stores VALUES (?, ?, ?)").run(
+        "shared",
+        options.storeJson ?? "{}",
+        Date.now(),
+      );
+    }
+  } finally {
+    db.close();
+  }
+  return dbPath;
+}
+
+function writeAgentDatabase(
+  stateDir: string,
+  options: {
+    stateKeys?: string[];
+    storeKeys?: string[];
+    storeAsView?: boolean;
+  } = {},
+): string {
+  const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  mkdirSync(path.dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  try {
+    if (options.storeAsView) {
+      db.exec(`
+        CREATE VIEW auth_profile_store AS
+          SELECT 'primary' AS store_key, '{}' AS store_json, 1 AS updated_at;
+      `);
+    } else {
+      db.exec(`
+        CREATE TABLE auth_profile_store (
+          store_key TEXT NOT NULL PRIMARY KEY,
+          store_json TEXT NOT NULL,
+          updated_at INTEGER NOT NULL
+        ) STRICT;
+      `);
+      for (const key of options.storeKeys ?? []) {
+        db.prepare("INSERT INTO auth_profile_store VALUES (?, '{}', ?)").run(key, Date.now());
+      }
+    }
+    db.exec(`
+      CREATE TABLE auth_profile_state (
+        state_key TEXT NOT NULL PRIMARY KEY,
+        state_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      ) STRICT;
+    `);
+    for (const key of options.stateKeys ?? []) {
+      db.prepare("INSERT INTO auth_profile_state VALUES (?, '{}', ?)").run(key, Date.now());
+    }
+  } finally {
+    db.close();
+  }
+  return dbPath;
+}
+
+describe("auth profile store E2E assertions", () => {
+  it("reads the canonical shared row", () => {
+    const stateDir = makeStateDir();
+    writeSharedDatabase(stateDir, { storeJson: '{"version":1}' });
+
+    expect(readSharedAuthProfileStoreText(stateDir)).toBe('{"version":1}');
+  });
+
+  it("returns empty when the shared database or table is absent", () => {
+    const stateDir = makeStateDir();
+
+    expect(readSharedAuthProfileStoreText(stateDir)).toBe("");
+    const dbPath = path.join(stateDir, "state", "openclaw.sqlite");
+    mkdirSync(path.dirname(dbPath), { recursive: true });
+    new DatabaseSync(dbPath).close();
+    expect(readSharedAuthProfileStoreText(stateDir)).toBe("");
+  });
+
+  it("fails closed for a corrupt shared database", () => {
+    const stateDir = makeStateDir();
+    const dbPath = path.join(stateDir, "state", "openclaw.sqlite");
+    mkdirSync(path.dirname(dbPath), { recursive: true });
+    writeFileSync(dbPath, "not sqlite");
+
+    expect(() => readSharedAuthProfileStoreText(stateDir)).toThrow(
+      "could not read the shared auth profile store",
+    );
+  });
+
+  it("fails closed when the shared auth table is replaced by a view", () => {
+    const stateDir = makeStateDir();
+    writeSharedDatabase(stateDir, { asView: true });
+
+    expect(() => readSharedAuthProfileStoreText(stateDir)).toThrow(
+      "auth_profile_stores is view, not a table",
+    );
+  });
+
+  it("permits unrelated main-agent auth rows", () => {
+    const stateDir = makeStateDir();
+    writeAgentDatabase(stateDir, {
+      stateKeys: ["last-good"],
+      storeKeys: ["workspace"],
+    });
+
+    expect(() => assertNoLegacyPrimaryAuthRows(stateDir)).not.toThrow();
+  });
+
+  it.each(["auth_profile_store", "auth_profile_state"] as const)(
+    "rejects a retired primary row in %s",
+    (table) => {
+      const stateDir = makeStateDir();
+      writeAgentDatabase(stateDir, {
+        stateKeys: table === "auth_profile_state" ? ["primary"] : [],
+        storeKeys: table === "auth_profile_store" ? ["primary"] : [],
+      });
+
+      expect(() => assertNoLegacyPrimaryAuthRows(stateDir)).toThrow(
+        `onboard preserved a retired primary row in ${table}`,
+      );
+    },
+  );
+
+  it("fails closed for a corrupt main-agent database", () => {
+    const stateDir = makeStateDir();
+    const dbPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    mkdirSync(path.dirname(dbPath), { recursive: true });
+    writeFileSync(dbPath, "not sqlite");
+
+    expect(() => assertNoLegacyPrimaryAuthRows(stateDir)).toThrow(
+      "could not validate the main-agent auth database",
+    );
+  });
+
+  it("fails closed when a retired auth table is replaced by a view", () => {
+    const stateDir = makeStateDir();
+    writeAgentDatabase(stateDir, { storeAsView: true });
+
+    expect(() => assertNoLegacyPrimaryAuthRows(stateDir)).toThrow(
+      "auth_profile_store is view, not a table",
+    );
+  });
+});

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -1,7 +1,7 @@
 // Codex Install Assertions tests cover Codex plugin install E2E helpers.
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -50,12 +50,13 @@ function writeJson(filePath: string, value: unknown) {
   writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
 }
 
-function writeAuthProfileStoreSqlite(agentDir: string) {
-  mkdirSync(agentDir, { recursive: true });
-  const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+function writeAuthProfileStoreSqlite(stateDir: string) {
+  const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+  mkdirSync(path.dirname(databasePath), { recursive: true });
+  const db = new DatabaseSync(databasePath);
   try {
     db.exec(`
-      CREATE TABLE IF NOT EXISTS auth_profile_store (
+      CREATE TABLE IF NOT EXISTS auth_profile_stores (
         store_key TEXT NOT NULL PRIMARY KEY,
         store_json TEXT NOT NULL,
         updated_at INTEGER NOT NULL
@@ -63,11 +64,11 @@ function writeAuthProfileStoreSqlite(agentDir: string) {
     `);
     db.prepare(
       `
-        INSERT INTO auth_profile_store (store_key, store_json, updated_at)
+        INSERT INTO auth_profile_stores (store_key, store_json, updated_at)
         VALUES (?, ?, ?)
       `,
     ).run(
-      "primary",
+      "shared",
       JSON.stringify({
         version: 1,
         profiles: {
@@ -574,7 +575,7 @@ function createCodexInstallFixture(root: string) {
   writeJson("/tmp/openclaw-plugins-list.json", {
     plugins: [{ id: "codex", enabled: true, status: "loaded" }],
   });
-  writeAuthProfileStoreSqlite(path.join(stateDir, "agents", "main", "agent"));
+  writeAuthProfileStoreSqlite(stateDir);
 }
 
 describe("Codex install helpers", () => {
@@ -692,6 +693,9 @@ describe("Codex install helpers", () => {
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
+    expect(
+      existsSync(path.join(root, "state", "agents", "main", "agent", "openclaw-agent.sqlite")),
+    ).toBe(false);
   });
 
   it("rejects on-demand fixtures without the canonical SQLite install record", () => {

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -1,7 +1,7 @@
 // Codex Install Assertions tests cover Codex plugin install E2E helpers.
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -688,14 +688,26 @@ describe("Codex install helpers", () => {
   it("accepts a complete on-demand Codex npm install fixture", () => {
     const root = makeTempDir(tempDirs, "openclaw-codex-on-demand-");
     createCodexInstallFixture(root);
+    const agentDatabasePath = path.join(
+      root,
+      "state",
+      "agents",
+      "main",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    mkdirSync(path.dirname(agentDatabasePath), { recursive: true });
+    const agentDatabase = new DatabaseSync(agentDatabasePath);
+    try {
+      agentDatabase.exec("CREATE TABLE unrelated_state (key TEXT PRIMARY KEY)");
+    } finally {
+      agentDatabase.close();
+    }
 
     const result = runCodexOnDemandAssertions(root);
 
     expect(result.status).toBe(0);
     expect(result.stderr).toBe("");
-    expect(
-      existsSync(path.join(root, "state", "agents", "main", "agent", "openclaw-agent.sqlite")),
-    ).toBe(false);
   });
 
   it("rejects on-demand fixtures without the canonical SQLite install record", () => {

--- a/test/scripts/npm-onboard-channel-agent-assertions.test.ts
+++ b/test/scripts/npm-onboard-channel-agent-assertions.test.ts
@@ -298,7 +298,7 @@ describe("npm onboard channel agent assertions", () => {
     }
   });
 
-  it("rejects a fresh install that recreates the retired main-agent auth database", () => {
+  it("permits an unrelated main-agent database", () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-onboard-assertions-"));
     const legacyAgentDir = path.join(tempDir, ".openclaw", "agents", "main", "agent");
 
@@ -319,8 +319,8 @@ describe("npm onboard channel agent assertions", () => {
 
       const result = runOnboardAssert(tempDir);
 
-      expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain("onboard created the retired main-agent auth database");
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe("");
     } finally {
       fs.rmSync(tempDir, { force: true, recursive: true });
     }

--- a/test/scripts/release-scenarios-assertions.test.ts
+++ b/test/scripts/release-scenarios-assertions.test.ts
@@ -1,6 +1,6 @@
 // Release Scenarios Assertions tests cover release scenarios assertions script behavior.
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -32,12 +32,13 @@ function runAssertion(args: string[], env?: NodeJS.ProcessEnv) {
   });
 }
 
-function writeAuthProfileStoreSqlite(agentDir: string, store: unknown) {
-  mkdirSync(agentDir, { recursive: true });
-  const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+function writeAuthProfileStoreSqlite(stateDir: string, store: unknown) {
+  const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+  mkdirSync(path.dirname(databasePath), { recursive: true });
+  const db = new DatabaseSync(databasePath);
   try {
     db.exec(`
-      CREATE TABLE IF NOT EXISTS auth_profile_store (
+      CREATE TABLE IF NOT EXISTS auth_profile_stores (
         store_key TEXT NOT NULL PRIMARY KEY,
         store_json TEXT NOT NULL,
         updated_at INTEGER NOT NULL
@@ -45,10 +46,10 @@ function writeAuthProfileStoreSqlite(agentDir: string, store: unknown) {
     `);
     db.prepare(
       `
-        INSERT INTO auth_profile_store (store_key, store_json, updated_at)
+        INSERT INTO auth_profile_stores (store_key, store_json, updated_at)
         VALUES (?, ?, ?)
       `,
-    ).run("primary", JSON.stringify(store), Date.now());
+    ).run("shared", JSON.stringify(store), Date.now());
   } finally {
     db.close();
   }
@@ -196,7 +197,6 @@ describe("release scenario assertions", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
     const home = path.join(root, "home");
     const stateDir = path.join(home, ".openclaw");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
     const configPath = path.join(stateDir, "openclaw.json");
 
     try {
@@ -207,7 +207,7 @@ describe("release scenario assertions", () => {
           },
         },
       });
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeAuthProfileStoreSqlite(stateDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -221,10 +221,14 @@ describe("release scenario assertions", () => {
       const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
         HOME: home,
         OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
       });
 
       expect(result.status).toBe(0);
       expect(result.stderr).toBe("");
+      expect(
+        existsSync(path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite")),
+      ).toBe(false);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -234,7 +238,6 @@ describe("release scenario assertions", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
     const home = path.join(root, "home");
     const stateDir = path.join(home, ".openclaw");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
     const configPath = path.join(stateDir, "openclaw.json");
 
     try {
@@ -245,7 +248,7 @@ describe("release scenario assertions", () => {
           },
         },
       });
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeAuthProfileStoreSqlite(stateDir, {
         version: 1,
         profiles: {
           "openai:api-key": { note: "OPENAI_API_KEY" },
@@ -255,6 +258,7 @@ describe("release scenario assertions", () => {
       const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
         HOME: home,
         OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
       });
 
       expect(result.status).not.toBe(0);
@@ -268,7 +272,6 @@ describe("release scenario assertions", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
     const home = path.join(root, "home");
     const stateDir = path.join(home, ".openclaw");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
     const configPath = path.join(stateDir, "openclaw.json");
 
     try {
@@ -279,7 +282,7 @@ describe("release scenario assertions", () => {
           },
         },
       });
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeAuthProfileStoreSqlite(stateDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -293,6 +296,7 @@ describe("release scenario assertions", () => {
       const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
         HOME: home,
         OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
       });
 
       expect(result.status).not.toBe(0);
@@ -306,7 +310,6 @@ describe("release scenario assertions", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-release-scenarios-"));
     const home = path.join(root, "home");
     const stateDir = path.join(home, ".openclaw");
-    const agentDir = path.join(stateDir, "agents", "main", "agent");
     const configPath = path.join(stateDir, "openclaw.json");
 
     try {
@@ -322,7 +325,7 @@ describe("release scenario assertions", () => {
           },
         },
       });
-      writeAuthProfileStoreSqlite(agentDir, {
+      writeAuthProfileStoreSqlite(stateDir, {
         version: 1,
         profiles: {
           "openai:api-key": {
@@ -336,6 +339,7 @@ describe("release scenario assertions", () => {
       const result = runAssertion(["assert-openai-env-ref", "sk-test-raw-key"], {
         HOME: home,
         OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_STATE_DIR: stateDir,
       });
 
       expect(result.status).not.toBe(0);


### PR DESCRIPTION
Closes #126916.

## What Problem This Solves

Fresh onboarding stores shared auth profiles in `state/openclaw.sqlite`, but the release-scenario and Codex-on-demand assertions still opened the retired per-agent auth store. They could report missing credentials even though onboarding had persisted the canonical shared row correctly.

PR #126958 independently fixed the npm-onboard reader. This PR keeps that work in one shared E2E owner and fixes the remaining release-scenario and Codex-on-demand siblings.

## Why This Change Was Made

The shared E2E auth-profile owner now reads `state/openclaw.sqlite` / `auth_profile_stores` / `shared`. npm-onboard, fresh release scenarios, and Codex-on-demand all consume that helper instead of maintaining separate storage queries.

Fresh proof rejects retired `primary` rows in `auth_profile_store` and `auth_profile_state`, but permits the main-agent SQLite database when it contains unrelated runtime state. Corrupt databases and auth-table view substitutions fail closed. Existing payload validation still rejects missing or malformed environment references and inline/raw OpenAI keys.

This is release-harness support only. It does not change runtime auth persistence, add eager agent-directory creation, or copy credentials into the retired store.

## User Impact

Package and release acceptance can verify fresh reference-mode onboarding through downstream Doctor and agent checks instead of failing on a retired storage assumption.

## Evidence

- Exact product failure: Package Acceptance [run 32437479569](https://github.com/openclaw/openclaw/actions/runs/32437479569), [job 96644508843](https://github.com/openclaw/openclaw/actions/runs/32437479569/job/96644508843), target `a434545620127a3105699513d662395a43b43eb1`. Onboarding exited 0; the stale assertion failed before downstream product checks.
- Current-main integration: contributor commit replayed with authorship preserved onto `c8514ed20a3ba32f218b7f114ae7bbfac44e55c6`; exact PR head `969dad159ea8e96ce45d36be5621f6403af18433`.
- `node scripts/run-vitest.mjs test/scripts/auth-profile-store-assertions.test.ts test/scripts/npm-onboard-channel-agent-assertions.test.ts test/scripts/release-scenarios-assertions.test.ts test/scripts/codex-install-assertions.test.ts` - 65/65 passed.
- Current merge-result proof against `origin/main` `b0d6fff9f951bf709e37bae396628446f01cb2cd`: the same four focused suites passed 65/65 in 8.42s, then the no-commit merge was aborted and the exact PR head restored cleanly.
- Focused packaged Docker proof: `pnpm test:docker:release-typed-onboarding` passed on Testbox `tbx_01m0rk0sxc0j9xtw1xrjje0991` after building the exact checkout package. [Run 32677081321](https://github.com/openclaw/openclaw/actions/runs/32677081321), command 6m17s, exit 0.
- Retained current merge-result Docker proof: the same packaged typed-onboarding command passed on Testbox `tbx_01m0rm2eykqrv13qjn05dyr4gh` against `969dad159ea8e96ce45d36be5621f6403af18433` merged with `b0d6fff9f951bf709e37bae396628446f01cb2cd`. [Run 32678012644](https://github.com/openclaw/openclaw/actions/runs/32678012644), command 6m03s, exit 0; Blacksmith then stopped the successful one-shot lease.
- `node scripts/check-docker-e2e-boundaries.mts` - passed.
- `node scripts/check-no-raw-http2-imports.mts` - passed.
- `git diff --check` and the changed-file formatting/temp-directory guards - passed.
- Exact-head repository CI passed with zero failures or pending checks, and ClawSweeper found no blocking correctness or security issue for `969dad159ea8e96ce45d36be5621f6403af18433`.

Regression provenance: the fresh shared-auth ownership transition merged in #126783 / `a8a9f284fb91af6a9d78fe66f9141eb01e009b21` and explicitly proved that fresh onboarding does not persist auth in the per-agent store. This change brings all fresh package assertions forward to that contract.

AI-assisted: Amp and Codex. The runtime owner, fresh-onboarding callers, legacy-upgrade siblings, fixtures, exact package failure, and #126958 overlap were reviewed directly.
