### PR TITLE
fix(ui): expose all automation schedule filters

### DIFF
--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -2,6 +2,7 @@
 import { parseBoolean } from "@openclaw/normalization-core/boolean-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
+  type CronListParams,
   ErrorCodes,
   errorShape,
   GatewayErrorDetailCodes,
@@ -488,21 +489,7 @@ export const cronHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateCronListParams, "cron.list", respond)) {
       return;
     }
-    const p = params as {
-      includeDisabled?: boolean;
-      limit?: number;
-      offset?: number;
-      query?: string;
-      enabled?: "all" | "enabled" | "disabled";
-      scheduleKind?: "all" | "at" | "every" | "cron";
-      lastRunStatus?: "all" | "ok" | "error" | "skipped" | "unknown";
-      trigger?: "all" | "conditional" | "unconditional";
-      sortBy?: "nextRunAtMs" | "updatedAtMs" | "name";
-      sortDir?: "asc" | "desc";
-      agentId?: string;
-      compact?: boolean;
-      includeDeliveryPreviews?: boolean;
-    };
+    const p = params as CronListParams;
     const callerScope = readCronCallerScope(client);
     const requestedAgentId = p.agentId ? normalizeAgentId(p.agentId) : undefined;
     if (callerScope && requestedAgentId && requestedAgentId !== callerScope.agentId) {

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -555,6 +555,7 @@ export type {
 export type CronRunStatus = NonNullable<ProtocolCronRunLogEntry["status"]>;
 export type CronDeliveryStatus = NonNullable<ProtocolCronRunLogEntry["deliveryStatus"]>;
 export type CronJobsEnabledFilter = NonNullable<CronListParams["enabled"]>;
+export type CronJobsScheduleKindFilter = NonNullable<CronListParams["scheduleKind"]>;
 export type CronJobsTriggerFilter = NonNullable<CronListParams["trigger"]>;
 export type CronJobsSortBy = NonNullable<CronListParams["sortBy"]>;
 export type CronRunScope = NonNullable<CronRunsParams["scope"]>;

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -7,6 +7,7 @@ import type {
   CronJob,
   CronDeliveryStatus,
   CronJobsEnabledFilter,
+  CronJobsScheduleKindFilter,
   CronJobsTriggerFilter,
   CronJobsListResult,
   CronJobsSortBy,
@@ -191,7 +192,6 @@ export type CronFieldKey =
 
 export type CronFieldErrors = Partial<Record<CronFieldKey, string>>;
 
-export type CronJobsScheduleKindFilter = "all" | "at" | "every" | "cron" | "on-exit" | "stream";
 export type CronJobsLastStatusFilter = "all" | CronRunStatus | "unknown";
 type CronRunsLoadStatus = "ok" | "error" | "skipped";
 

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -122,9 +122,21 @@ describe("cron view list pane", () => {
       '[data-test-id="cron-jobs-schedule-filter"]',
       HTMLSelectElement,
     );
-    scheduleFilter.value = "cron";
-    scheduleFilter.dispatchEvent(new Event("change", { bubbles: true }));
-    expect(onJobsFiltersChange).toHaveBeenCalledWith({ cronJobsScheduleKindFilter: "cron" });
+    expect(Array.from(scheduleFilter.options, (option) => option.value)).toEqual([
+      "all",
+      "at",
+      "every",
+      "cron",
+      "on-exit",
+      "stream",
+    ]);
+    for (const scheduleKind of ["on-exit", "stream"] as const) {
+      scheduleFilter.value = scheduleKind;
+      scheduleFilter.dispatchEvent(new Event("change", { bubbles: true }));
+      expect(onJobsFiltersChange).toHaveBeenCalledWith({
+        cronJobsScheduleKindFilter: scheduleKind,
+      });
+    }
 
     const lastStatusFilter = getElement(
       container,

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -448,6 +448,15 @@ const ENABLED_TABS: Array<{ value: CronJobsEnabledFilter; labelKey: string }> = 
   { value: "disabled", labelKey: "cron.tabs.paused" },
 ];
 
+const SCHEDULE_KIND_FILTER_LABELS: Record<CronJobsScheduleKindFilter, string> = {
+  all: "cron.jobs.all",
+  at: "cron.form.at",
+  every: "cron.form.every",
+  cron: "cron.form.cronOption",
+  "on-exit": "cron.form.repeatOnExit",
+  stream: "cron.form.repeatStream",
+};
+
 function renderListView(props: CronProps) {
   const hasAdvancedJobsFilters =
     props.jobsScheduleKindFilter !== "all" ||
@@ -646,12 +655,10 @@ function renderJobsFilterPopover(props: CronProps, active: boolean) {
           label: t("cron.jobs.schedule"),
           value: props.jobsScheduleKindFilter,
           testId: "cron-jobs-schedule-filter",
-          options: [
-            { value: "all", label: t("cron.jobs.all") },
-            { value: "at", label: t("cron.form.at") },
-            { value: "every", label: t("cron.form.every") },
-            { value: "cron", label: t("cron.form.cronOption") },
-          ],
+          options: Object.entries(SCHEDULE_KIND_FILTER_LABELS).map(([value, labelKey]) => ({
+            value,
+            label: t(labelKey),
+          })),
         })}
         ${renderJobsFilter(props, "cronJobsLastStatusFilter", {
           label: t("cron.jobs.lastRun"),

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -17,6 +17,7 @@ import type {
   CronStatus,
   CronDeliveryStatus,
   CronJobsEnabledFilter,
+  CronJobsScheduleKindFilter,
   CronJobsTriggerFilter,
   CronRunsStatusValue,
   CronJobsSortBy,
@@ -51,7 +52,6 @@ import type {
   CronFieldKey,
   CronFormState,
   CronJobsLastStatusFilter,
-  CronJobsScheduleKindFilter,
 } from "../../lib/cron/index.ts";
 import { formatUiExternalText } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp, formatMs } from "../../lib/format.ts";


### PR DESCRIPTION
## What Problem This Solves

The Automations Schedule filter exposed only `All`, `At`, `Every`, and `Cron`, even though the protocol, service, and UI domain already support process-backed `on-exit` and `stream` jobs. Operators could see those jobs under All but could not isolate either kind. The Gateway handler also carried a stale hand-written `cron.list` params type that omitted both accepted values.

## Why This Change Was Made

The Schedule filter now derives its localized options from one exhaustive `Record<CronJobsScheduleKindFilter, string>`, so every UI-supported filter kind must have presentation metadata. The Gateway handler now consumes the schema-derived `CronListParams` type instead of duplicating the wire contract. Process-backed schedule authoring remains read-only; this changes inventory filtering only.

Production LOC is +15/-21 (net -6). Tests are +15/-3.

## User Impact

Control UI users can filter Automations inventory to **On exit** or **Stream source**, and both choices use the existing paged `cron.list` filtering behavior.

## Evidence

- Pre-fix focused regression: `view.test.ts` failed because the rendered values were exactly `[all, at, every, cron]` instead of `[all, at, every, cron, on-exit, stream]`.
- Post-fix UI regression: `node scripts/run-vitest.mjs ui/src/pages/cron/view.test.ts` → 41/41 passed.
- Existing protocol regression: `node scripts/run-vitest.mjs packages/gateway-protocol/src/cron-validators.test.ts` → 34/34 passed.
- `node scripts/check-changed.mjs -- src/gateway/server-methods/cron.ts ui/src/pages/cron/view.ts ui/src/pages/cron/view.test.ts` completed successfully across format, guards, core/UI typechecks, lint, i18n verification, and architecture checks.
- Real mocked Control UI browser proof exposed both `On exit` and `Stream source` in the Schedule combobox. Selecting each updated the native value; the final `Stream source` state showed `No automations match` / `0 of 3` with no Gateway or page errors.
- Independent read-only review found no actionable finding, no proof gap, and judged the exhaustive UI registry plus shared protocol type to be the clean owner-boundary repair.
- The campaign's bundled Codex autoreview helper is unavailable because direct model authentication in this orb returns 401; it was not blindly retried for this patch and no clean-helper claim is made.

| Before: missing process-backed kinds | After: Stream source selected |
| --- | --- |
| ![Before](https://ampcode.com/user-content/artifacts/0b2d48aa0afbb908b00a9185edd31af7ffb71130bb00ece7f887ddbca331d2ba-file.png) | ![After](https://ampcode.com/user-content/artifacts/e8263d020d465b78997956c37bd40adb757e53f42f1676e11dcb4fe05b6eada3-file.png) |

AI-assisted: yes. The implementation, focused tests, complete changed-file gates, browser accessibility tree, interactions, and screenshots were inspected directly.
