### PR TITLE
fix(gateway): await cron exit watcher drain

### DIFF
--- a/src/gateway/cron-exit-watchers.test.ts
+++ b/src/gateway/cron-exit-watchers.test.ts
@@ -399,15 +399,21 @@ describe("createCronExitWatchers", () => {
     });
     w.reconcile([onExitJob("job-a")]);
     await flush();
-    w.reconcile([]);
+    let drained = false;
+    const drain = w.cancelAll().then(() => {
+      drained = true;
+    });
     expect(cancelled).toContain("cron-exit:job-a");
     expect(w.activeJobIds()).toEqual(["job-a"]);
+    await flush();
+    expect(drained).toBe(false);
 
     expectDefined(runs[0], "runs[0] test invariant").deferred.resolve({
       exitCode: null,
       reason: "manual-cancel",
     });
-    await vi.waitFor(() => expect(w.activeJobIds()).toEqual([]));
+    await drain;
+    expect(w.activeJobIds()).toEqual([]);
   });
 
   it("does not fire a job whose watcher was cancelled before exit", async () => {
@@ -455,11 +461,17 @@ describe("createCronExitWatchers", () => {
       reason: "exit",
     });
     await vi.waitFor(() => expect(persistCompletion).toHaveBeenCalledOnce());
-    w.reconcile([]);
+    let drained = false;
+    const drain = w.cancelAll().then(() => {
+      drained = true;
+    });
     expect(w.activeJobIds()).toEqual(["job-a"]);
+    await flush();
+    expect(drained).toBe(false);
 
     releasePersist(releaseCompletion);
-    await vi.waitFor(() => expect(w.activeJobIds()).toEqual([]));
+    await drain;
+    expect(w.activeJobIds()).toEqual([]);
     expect(fireOnExit).not.toHaveBeenCalled();
     expect(releaseCompletion).toHaveBeenCalledOnce();
   });

--- a/src/gateway/cron-exit-watchers.ts
+++ b/src/gateway/cron-exit-watchers.ts
@@ -1,6 +1,7 @@
 import type { CronJob } from "../cron/types.js";
 import { markOpenClawExecEnv } from "../infra/openclaw-exec-env.js";
 import type { ManagedRun, ProcessSupervisor } from "../process/supervisor/index.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { resolveExitWatchShell } from "./cron-exit-watch-shell.js";
 
 /**
@@ -31,7 +32,7 @@ export type CronExitResult = {
 type CronExitWatchers = {
   reconcile: (jobs: CronJob[]) => void;
   cancel: (jobId: string) => void;
-  cancelAll: () => void;
+  cancelAll: () => Promise<void>;
   activeJobIds: () => string[];
 };
 
@@ -75,6 +76,7 @@ export function createCronExitWatchers(params: {
     terminalPersisting: boolean;
     cancelled: boolean;
     lifecycleSettled: boolean;
+    settlement: ReturnType<typeof createDeferredCore>;
     command: string;
     cwd: string | undefined;
     consecutiveFailures: number;
@@ -128,6 +130,7 @@ export function createCronExitWatchers(params: {
       terminalPersisting: false,
       cancelled: false,
       lifecycleSettled: false,
+      settlement: createDeferredCore(),
       command,
       cwd,
       consecutiveFailures,
@@ -288,6 +291,7 @@ export function createCronExitWatchers(params: {
       if (slot.cancelled && active.get(job.id) === slot) {
         active.delete(job.id);
       }
+      slot.settlement.resolve(undefined);
     });
   };
 
@@ -318,10 +322,11 @@ export function createCronExitWatchers(params: {
     }
   };
 
-  const cancelAll = () => {
+  const cancelAll = async () => {
     for (const jobId of Array.from(active.keys())) {
       cancel(jobId);
     }
+    await Promise.all(Array.from(settlingCancelledSlots, (slot) => slot.settlement.promise));
   };
 
   return {

--- a/src/gateway/server-cron.drain.test.ts
+++ b/src/gateway/server-cron.drain.test.ts
@@ -120,6 +120,34 @@ describe("gateway cron stop-and-drain automation ownership", () => {
     }
   });
 
+  it("waits for prior exit watchers to settle before restarting the scheduler", async () => {
+    const exitWatcherDrain = createDeferred();
+    cancelAllMock.mockReturnValue(exitWatcherDrain.promise);
+    stopAllMock.mockResolvedValue(undefined);
+    const original = await startGatewayCron("exit-watcher-restart");
+
+    try {
+      original.state.cron.stop();
+      let restarted = false;
+      const restart = original.state.cron.start().then(() => {
+        restarted = true;
+      });
+
+      await vi.waitFor(() => expect(cancelAllMock).toHaveBeenCalledOnce());
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(restarted).toBe(false);
+
+      exitWatcherDrain.resolve(undefined);
+      await restart;
+      expect(restarted).toBe(true);
+    } finally {
+      exitWatcherDrain.resolve(undefined);
+      await cleanGatewayCron(original);
+    }
+  });
+
   it("unregisters a stopped scheduler when stream draining fails and permits retry", async () => {
     stopAllMock.mockRejectedValueOnce(new Error("stream drain failed"));
     stopAllMock.mockResolvedValue(undefined);

--- a/src/gateway/server-cron.drain.test.ts
+++ b/src/gateway/server-cron.drain.test.ts
@@ -6,7 +6,8 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-const { getRuntimeConfigMock, stopAllMock } = vi.hoisted(() => ({
+const { cancelAllMock, getRuntimeConfigMock, stopAllMock } = vi.hoisted(() => ({
+  cancelAllMock: vi.fn<() => Promise<void>>(),
   getRuntimeConfigMock: vi.fn(),
   stopAllMock: vi.fn<() => Promise<void>>(),
 }));
@@ -14,6 +15,16 @@ const { getRuntimeConfigMock, stopAllMock } = vi.hoisted(() => ({
 vi.mock("../config/io.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../config/io.js")>()),
   getRuntimeConfig: getRuntimeConfigMock,
+}));
+
+vi.mock("./cron-exit-watchers.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./cron-exit-watchers.js")>()),
+  createCronExitWatchers: () => ({
+    reconcile: vi.fn(),
+    cancel: vi.fn(),
+    cancelAll: cancelAllMock,
+    activeJobIds: () => [],
+  }),
 }));
 
 vi.mock("./cron-stream-watchers.js", async (importOriginal) => ({
@@ -73,8 +84,40 @@ async function cleanGatewayCron({ state, stateDir }: StartedGatewayCron): Promis
 
 describe("gateway cron stop-and-drain automation ownership", () => {
   beforeEach(() => {
+    cancelAllMock.mockReset();
+    cancelAllMock.mockResolvedValue(undefined);
     getRuntimeConfigMock.mockReset();
     stopAllMock.mockReset();
+  });
+
+  it("waits for cancelled exit watchers to settle before completing the drain", async () => {
+    const exitWatcherDrain = createDeferred();
+    cancelAllMock.mockReturnValue(exitWatcherDrain.promise);
+    stopAllMock.mockResolvedValue(undefined);
+    const original = await startGatewayCron("exit-watcher");
+
+    try {
+      let drained = false;
+      const drain = original.state.cron.stopAndDrain?.().then(() => {
+        drained = true;
+      });
+      if (!drain) {
+        throw new Error("expected cron stop-and-drain");
+      }
+
+      await vi.waitFor(() => expect(cancelAllMock).toHaveBeenCalledOnce());
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(drained).toBe(false);
+
+      exitWatcherDrain.resolve(undefined);
+      await drain;
+      expect(drained).toBe(true);
+    } finally {
+      exitWatcherDrain.resolve(undefined);
+      await cleanGatewayCron(original);
+    }
   });
 
   it("unregisters a stopped scheduler when stream draining fails and permits retry", async () => {

--- a/src/gateway/server-cron.drain.test.ts
+++ b/src/gateway/server-cron.drain.test.ts
@@ -148,6 +148,28 @@ describe("gateway cron stop-and-drain automation ownership", () => {
     }
   });
 
+  it("does not reopen the scheduler when a later stop wins a pending restart", async () => {
+    const exitWatcherDrain = createDeferred();
+    cancelAllMock.mockReturnValue(exitWatcherDrain.promise);
+    stopAllMock.mockResolvedValue(undefined);
+    const original = await startGatewayCron("exit-watcher-restart-cancelled");
+
+    try {
+      original.state.cron.stop();
+      const restart = original.state.cron.start();
+      await vi.waitFor(() => expect(cancelAllMock).toHaveBeenCalledOnce());
+
+      original.state.cron.stop();
+      exitWatcherDrain.resolve(undefined);
+      await restart;
+
+      expect(sessionHasAutomation("agent:main:main", original.cfg)).toBe(false);
+    } finally {
+      exitWatcherDrain.resolve(undefined);
+      await cleanGatewayCron(original);
+    }
+  });
+
   it("unregisters a stopped scheduler when stream draining fails and permits retry", async () => {
     stopAllMock.mockRejectedValueOnce(new Error("stream drain failed"));
     stopAllMock.mockResolvedValue(undefined);

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -184,7 +184,7 @@ function reconcileCronExitWatchers(params: {
   jobs: CronJob[];
 }) {
   if (!params.cronEnabled) {
-    params.exitWatchers.cancelAll();
+    void params.exitWatchers.cancelAll();
     return;
   }
   params.exitWatchers.reconcile(params.jobs);
@@ -1318,12 +1318,15 @@ export function buildGatewayCronService(params: {
     streamWatcherReconciliations +
     (exitWatchersRef.current?.activeJobIds().length ?? 0) +
     (streamWatchersRef.current?.activeJobIds().length ?? 0);
+  // cron.stop begins cancellation synchronously; stopAndDrain joins this same
+  // settlement so a replacement owner cannot start over live predecessors.
+  let exitWatchersStopPromise: Promise<void> | undefined;
   const stopExitWatchers = () => {
     // Late completion cleanup can request reconciliation after shutdown.
     // Fence new requests before cancellation so stopped children cannot respawn.
     exitWatchersStopped = true;
     exitWatcherGeneration += 1;
-    exitWatchersRef.current?.cancelAll();
+    exitWatchersStopPromise ??= exitWatchersRef.current?.cancelAll() ?? Promise.resolve();
   };
   // cron.stop launches this teardown asynchronously and stopAndDrain awaits
   // it; memoizing keeps that one drain instead of queueing every owner a
@@ -1373,13 +1376,15 @@ export function buildGatewayCronService(params: {
   };
   cron.stopAndDrain = async () => {
     cron.stop();
+    const exitWatchersStop = exitWatchersStopPromise ?? Promise.resolve();
     const streamWatchersStop = stopStreamWatchers().then(
       () => ({ ok: true as const }),
       (error: unknown) => ({ ok: false as const, error }),
     );
     const abortedRuns = abortActiveCronTaskRuns("Gateway shutting down.");
-    const [activeRunDrain, streamWatchersResult] = await Promise.all([
+    const [activeRunDrain, , streamWatchersResult] = await Promise.all([
       waitForActiveCronTaskRuns(CRON_ACTIVE_RUN_SHUTDOWN_DRAIN_MS),
+      exitWatchersStop,
       streamWatchersStop,
     ]);
     if (!activeRunDrain.drained) {
@@ -1441,7 +1446,8 @@ export function buildGatewayCronService(params: {
     }
     exitWatchersStopped = false;
     streamWatchersStopped = false;
-    // A reload restart owns a fresh watcher lifecycle; the next stop must run.
+    // A restart owns a fresh watcher lifecycle; the next stop must drain it.
+    exitWatchersStopPromise = undefined;
     streamWatchersStopPromise = undefined;
     streamWatchersRef.current?.resume();
     if (generation !== streamWatcherGeneration) {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1440,6 +1440,7 @@ export function buildGatewayCronService(params: {
   const startCron = cron.start.bind(cron);
   cron.start = async () => {
     const generation = streamWatcherGeneration;
+    await exitWatchersStopPromise;
     await startCron();
     if (generation !== streamWatcherGeneration) {
       return;

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -1439,10 +1439,16 @@ export function buildGatewayCronService(params: {
   };
   const startCron = cron.start.bind(cron);
   cron.start = async () => {
-    const generation = streamWatcherGeneration;
+    const exitGeneration = exitWatcherGeneration;
+    const streamGeneration = streamWatcherGeneration;
+    const lifecycleChanged = () =>
+      exitGeneration !== exitWatcherGeneration || streamGeneration !== streamWatcherGeneration;
     await exitWatchersStopPromise;
+    if (lifecycleChanged()) {
+      return;
+    }
     await startCron();
-    if (generation !== streamWatcherGeneration) {
+    if (lifecycleChanged()) {
       return;
     }
     exitWatchersStopped = false;
@@ -1451,15 +1457,15 @@ export function buildGatewayCronService(params: {
     exitWatchersStopPromise = undefined;
     streamWatchersStopPromise = undefined;
     streamWatchersRef.current?.resume();
-    if (generation !== streamWatcherGeneration) {
+    if (lifecycleChanged()) {
       return;
     }
     await reconcileStreamWatchers();
-    if (generation !== streamWatcherGeneration) {
+    if (lifecycleChanged()) {
       return;
     }
     await reconcileHeartbeatJobs();
-    if (generation !== streamWatcherGeneration) {
+    if (lifecycleChanged()) {
       return;
     }
     // Register only once started, under the build-time epoch, so a stale lazy


### PR DESCRIPTION
## Summary

- make `CronExitWatchers.cancelAll()` await every cancelled watcher lifecycle, including supervised child exit and terminal persistence
- join that settlement from the gateway cron service's existing `stopAndDrain()` owner boundary
- fence same-instance restarts so a pending predecessor drains and a later stop wins before watcher admission reopens
- cover child-wait, terminal-persistence, and service-boundary drain behavior with deterministic regressions

## Root cause

`cancelAll()` synchronously requested cancellation but returned while cancelled slots remained in `settlingCancelledSlots`. `buildGatewayCronService.stopAndDrain()` awaited active cron task runs and stream watchers only, so hot reload could start a replacement cron service while predecessor exit watchers were still settling.

The new boundary test fails on frozen base `ab2bbd42dfafb1da9ecad901caa8d2d32e3cd251` with `expected true to be false`: the owner drain completed before the exit-watcher drain promise. It passes with this change.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-core.config.ts src/gateway/cron-exit-watchers.test.ts` — 17/17 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-cron.test.ts src/gateway/server-cron.drain.test.ts src/gateway/server-reload-handlers.test.ts src/gateway/server-cron-lazy.test.ts src/gateway/server-close.test.ts` — 370/370 passed
- watcher settlement stress — 25/25 iterations, 50 targeted test executions passed
- gateway drain/restart cancellation stress — 10/10 iterations, 30 targeted test executions passed
- `node scripts/check-changed.mjs -- src/gateway/cron-exit-watchers.ts src/gateway/server-cron.ts src/gateway/cron-exit-watchers.test.ts src/gateway/server-cron.drain.test.ts` — passed all production/test typechecks, lint, format, policy, dead-export, and import-cycle checks

## Review status

- authenticated repo autoreview of exact head `2dc5dd8cadd2eb8205c62715f480a6ab38d4073d`: TruffleHog clean; `patch is correct`; confidence 0.94; findings `[]`
- separate read-only exact-head verifier: ACCEPT with no P0-P3 findings after two accepted lifecycle-interleaving findings were fixed and re-reviewed; confirmed 370/370 related tests and repeated stress
