### PR TITLE
docs: use setup command for non-inference onboarding

### DIFF
--- a/docs/start/onboarding-overview.md
+++ b/docs/start/onboarding-overview.md
@@ -72,7 +72,7 @@ run `openclaw onboard` to change the model provider or its authentication.
 Use `openclaw onboard --classic` for detailed model/auth, channel, skill,
 remote Gateway, or import setup. Adding `--install-daemon` also selects the
 classic flow and installs the background service in one step. Use `openclaw
-openclaw` for conversational non-inference setup and repair. `openclaw
+setup` for conversational non-inference setup and repair. `openclaw
 onboard --modern` is a compatibility alias that uses the same live-inference
 gate.
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users following the onboarding overview would run the nonexistent `openclaw openclaw` command when they wanted conversational non-inference setup or repair.

## Why This Change Was Made

The overview now points to the canonical `openclaw setup` entrypoint. This is a documentation-only correction and does not change runtime behavior.

## User Impact

New and recovering users can copy the documented command and reach the intended setup flow instead of receiving an unknown-command error.

## Evidence

- Before: `pnpm openclaw openclaw` exited 1 and reported an unknown command.
- `pnpm docs:list` completed successfully.
- `node scripts/check-changed.mjs --timed -- docs/start/onboarding-overview.md` passed all selected docs checks on `origin/main` `ee337708`.
- Autoreview and TruffleHog were clean; overall correctness 0.99.
