### PR TITLE
chore: restore live OpenAI onboarding proof

### DIFF
--- a/test/openai-onboarding.live.test.ts
+++ b/test/openai-onboarding.live.test.ts
@@ -8,7 +8,7 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 import { extractAgentReplyTexts } from "../scripts/e2e/lib/agent-turn-output.mjs";
 import { terminateManagedChild } from "../scripts/lib/managed-child-process.mts";
-import { readPersistedAuthProfileStoreRaw } from "../src/agents/auth-profiles/sqlite.js";
+import { readPersistedSharedAuthProfileStoreRaw } from "../src/agents/auth-profiles/sqlite.js";
 import { isLiveTestEnabled } from "../src/agents/live-test-helpers.js";
 import {
   loadTranscriptEvents,
@@ -39,8 +39,8 @@ async function runOpenClaw(args: string[], env: NodeJS.ProcessEnv): Promise<stri
   }
 }
 
-function assertOpenAiEnvProfile(agentDir: string): void {
-  const store = readPersistedAuthProfileStoreRaw(agentDir) as {
+function assertOpenAiEnvProfile(env: NodeJS.ProcessEnv): void {
+  const store = readPersistedSharedAuthProfileStoreRaw(env) as {
     profiles?: Record<string, Record<string, unknown>>;
   } | null;
   expect(store?.profiles).toBeDefined();
@@ -232,14 +232,13 @@ describeLive("fresh OpenAI onboarding live", () => {
         "--json",
       ];
 
-      let firstGatewayToken: string | undefined;
       for (let attempt = 0; attempt < 2; attempt += 1) {
         await runOpenClaw(onboardArgs, state.env);
         const rawConfig = await fs.readFile(state.configPath, "utf8");
         expect(rawConfig.includes(openAiApiKey)).toBe(false);
         const config = JSON.parse(rawConfig) as {
           agents?: { defaults?: { model?: { primary?: string }; workspace?: string } };
-          gateway?: { mode?: string; auth?: { mode?: string; token?: string } };
+          gateway?: { mode?: string; auth?: { mode?: string; token?: unknown } };
         };
         expect(config.agents?.defaults?.model?.primary).toBe("openai/gpt-5.6-sol");
         expect(config.agents?.defaults?.workspace).toBe(
@@ -247,14 +246,12 @@ describeLive("fresh OpenAI onboarding live", () => {
         );
         expect(config.gateway?.mode).toBe("local");
         expect(config.gateway?.auth?.mode).toBe("token");
-        const gatewayToken = config.gateway?.auth?.token;
-        expect(typeof gatewayToken === "string" && gatewayToken.length > 0).toBe(true);
-        if (firstGatewayToken === undefined) {
-          firstGatewayToken = gatewayToken;
-        } else {
-          expect(gatewayToken === firstGatewayToken).toBe(true);
-        }
-        assertOpenAiEnvProfile(state.agentDir());
+        expect(config.gateway?.auth?.token).toEqual({
+          source: "store",
+          provider: "default",
+          id: "OPENCLAW_GATEWAY_TOKEN",
+        });
+        assertOpenAiEnvProfile(state.env);
       }
 
       await expect(fs.access(path.join(state.agentDir(), "auth-profiles.json"))).rejects.toThrow();
@@ -279,7 +276,7 @@ describeLive("fresh OpenAI onboarding live", () => {
         extractAgentReplyTexts(stdout).some((reply) => reply.includes(replyMarker)),
         `default OpenAI agent turn returned ${summarizeAgentOutput(stdout)}`,
       ).toBe(true);
-      assertOpenAiEnvProfile(state.agentDir());
+      assertOpenAiEnvProfile(state.env);
 
       gateway = spawn(
         process.execPath,
@@ -336,7 +333,7 @@ describeLive("fresh OpenAI onboarding live", () => {
       });
       expect(hasPersistedTranscriptMessage(persistedEvents, "user", gatewayPrompt)).toBe(true);
       expect(hasPersistedTranscriptMessage(persistedEvents, "assistant", replyMarker)).toBe(true);
-      assertOpenAiEnvProfile(state.agentDir());
+      assertOpenAiEnvProfile(state.env);
     } finally {
       await stopIsolatedGateway(gateway);
       await state.cleanup();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the real OpenAI onboarding live test failed before provider inference after secret-ref storage became canonical, leaving the complete first-run path without executable live regression proof.

## Why This Change Was Made

The test now validates the exact Gateway store `SecretRef` and reads OpenAI auth from the canonical shared auth-profile store. Runtime behavior and credential policy are unchanged.

## User Impact

Maintainers regain a working end-to-end proof for repeated secret-safe OpenAI onboarding, local inference, authenticated Gateway inference, and durable transcripts.

## Evidence

- Exact-current-main live run: `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_TEST_QUIET=0 pnpm test:live test/openai-onboarding.live.test.ts -- --reporter=verbose` — 1/1 passed in 158.97s on `origin/main` `ee337708` using a real OpenAI credential without printing or persisting it.
- The run completed repeated onboarding, a real `openai/gpt-5.6-sol` local turn, authenticated Gateway readiness/health, a real Gateway-backed turn, and durable user/assistant transcript reads.
- 8 focused Gateway-token/shared-auth support tests passed.
- `node scripts/check-changed.mjs --timed -- test/openai-onboarding.live.test.ts` passed typecheck and lint lanes.
- Autoreview and TruffleHog were clean; overall correctness 0.99.
