### PR TITLE
improve(plugins): avoid duplicate web-channel manifest discovery

### DIFF
--- a/src/plugins/runtime/runtime-web-channel-plugin.test.ts
+++ b/src/plugins/runtime/runtime-web-channel-plugin.test.ts
@@ -57,6 +57,33 @@ describe("runtime web channel plugin", () => {
     expect(resolvePluginRuntimeRecordByEntryBaseNames).toHaveBeenCalledOnce();
   });
 
+  it("shares one plugin record across light and heavy runtime activation", async () => {
+    const resolvePluginRuntimeRecordByEntryBaseNames = vi.fn(() => ({
+      origin: "bundled",
+      source: "test",
+    }));
+    vi.doMock("./runtime-plugin-boundary.js", () => ({
+      loadPluginBoundaryModule: (modulePath: string) =>
+        modulePath.includes("light-runtime-api")
+          ? { resolveDefaultWebAuthDir: () => "/tmp/openclaw-auth" }
+          : { startWebLoginWithQr: async () => "started" },
+      resolvePluginRuntimeModulePath: (_record: unknown, entryBaseName: string) =>
+        `/tmp/${entryBaseName}.js`,
+      resolvePluginRuntimeRecordByEntryBaseNames,
+    }));
+
+    const runtime = await import("./runtime-web-channel-plugin.js");
+
+    expect(runtime.resolveWebChannelAuthDir()).toBe("/tmp/openclaw-auth");
+    await expect(runtime.startWebLoginWithQr()).resolves.toBe("started");
+    expect(resolvePluginRuntimeRecordByEntryBaseNames).toHaveBeenCalledOnce();
+
+    const { clearPluginMetadataLifecycleCaches } = await import("../plugin-metadata-lifecycle.js");
+    clearPluginMetadataLifecycleCaches();
+    expect(runtime.resolveWebChannelAuthDir()).toBe("/tmp/openclaw-auth");
+    expect(resolvePluginRuntimeRecordByEntryBaseNames).toHaveBeenCalledTimes(2);
+  });
+
   it.each(["light", "heavy"] as const)(
     "reloads replaced %s runtime artifacts and dependencies after plugin lifecycle clears",
     async (kind) => {

--- a/src/plugins/runtime/runtime-web-channel-plugin.ts
+++ b/src/plugins/runtime/runtime-web-channel-plugin.ts
@@ -67,19 +67,30 @@ const webChannelRuntimeModuleCache = new Map<
 
 const moduleLoaders: PluginModuleLoaderCache = createPluginModuleLoaderCache();
 const moduleRoots = new Map<string, string>();
+// Light and heavy modules belong to one metadata generation; resolving their
+// shared record separately repeats full manifest discovery.
+let webChannelPluginRecord: WebChannelPluginRecord | undefined;
 
 registerPluginMetadataProcessMemoLifecycleClear(() => {
+  webChannelPluginRecord = undefined;
   webChannelRuntimeModuleCache.clear();
   clearPluginModuleLoaderLifecycleCache({ moduleLoaders, moduleRoots });
 });
 
 /** Resolves the active web-channel plugin record that provides runtime APIs. */
 function resolveWebChannelPluginRecord(): WebChannelPluginRecord {
-  return resolvePluginRuntimeRecordByEntryBaseNames(["light-runtime-api", "runtime-api"], () => {
-    throw new Error(
-      "web channel plugin runtime is unavailable: missing plugin that provides light-runtime-api and runtime-api",
-    );
-  }) as WebChannelPluginRecord;
+  if (webChannelPluginRecord) {
+    return webChannelPluginRecord;
+  }
+  webChannelPluginRecord = resolvePluginRuntimeRecordByEntryBaseNames(
+    ["light-runtime-api", "runtime-api"],
+    () => {
+      throw new Error(
+        "web channel plugin runtime is unavailable: missing plugin that provides light-runtime-api and runtime-api",
+      );
+    },
+  ) as WebChannelPluginRecord;
+  return webChannelPluginRecord;
 }
 
 function resolveWebChannelRuntimeModulePath(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where activating both the light and heavy web-channel runtime surfaces in one plugin metadata lifecycle repeated full plugin manifest discovery. The duplicated filesystem and manifest work increased startup/login latency with installed-plugin count even though plugin metadata is process-stable for that lifecycle.

## Why This Change Was Made

The web-channel runtime facade now resolves its shared plugin record once and invalidates it through the same plugin-metadata lifecycle callback that already clears the light/heavy module and loader caches. This keeps one canonical lifecycle owner and preserves runtime artifact replacement; no public API, configuration, plugin contract, or fallback was added.

Provenance: the repeated resolution path was carried forward from direct commit `f59d0eac687f` (2026-04-03, code author/committer @steipete) and remained when light/heavy lifecycle caches were consolidated in #114749.

## User Impact

Web-channel startup and login paths avoid a redundant plugin inventory/manifest scan when both runtime surfaces are used. Behavior is otherwise unchanged.

Production LOC: +16/-5 (net +11) | Tests: +27/-0

AI-assisted: yes. The change, lifecycle ownership, tests, and final diff were reviewed directly.

## Evidence

- Pre-fix regression: light→heavy activation resolved the same plugin record twice; the new lifecycle invariant expected one resolution and failed with `2`.
- Post-fix: one record resolution per lifecycle; an explicit metadata lifecycle clear causes exactly one fresh resolution.
- `pnpm test src/plugins/runtime/runtime-web-channel-plugin.test.ts src/plugins/contracts/plugin-sdk-subpaths.test.ts` — 26/26 passed on Node 24.15.0.
- `pnpm check:changed` — passed, including core/test typechecks, lint, dead-code, import-cycle, plugin-boundary, and database-first guards.
- `pnpm build` — passed in 7m31s; CLI bootstrap and package/plugin build gates passed.
- `oxfmt --check` and `git diff --check` — passed.
- TruffleHog changed-content scan — clean.
- Fresh autoreview on exact head `0ff3724dbfbe8a71d57f3fa1acc275152dacd703` — clean, no accepted/actionable findings.
