### PR TITLE
fix(package): account for bundled docs growth

### DIFF
--- a/scripts/lib/npm-pack-budget.mts
+++ b/scripts/lib/npm-pack-budget.mts
@@ -5,8 +5,9 @@ import { resolveNpmJsonEntries } from "./npm-json-output.mts";
 // startup/doctor OOM reports. 2026.4.12 intentionally stages Matrix runtime
 // dependencies, including crypto wasm, so packaged installs do not miss Docker
 // and gateway runtime dependencies. Keep the budget below the 2026.3.12 bloat
-// level while allowing that mirrored runtime surface.
-const NPM_PACK_UNPACKED_SIZE_BUDGET_BYTES = 202 * 1024 * 1024;
+// level while allowing that mirrored runtime surface and the installed agent's
+// bundled user documentation.
+const NPM_PACK_UNPACKED_SIZE_BUDGET_BYTES = 204 * 1024 * 1024;
 
 function formatMiB(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -913,7 +913,7 @@ describe("collectPackUnpackedSizeErrors", () => {
     expect(
       collectPackUnpackedSizeErrors([makePackResult("openclaw-2026.3.12.tgz", 224_002_564)]),
     ).toEqual([
-      "openclaw-2026.3.12.tgz unpackedSize 224002564 bytes (213.6 MiB) exceeds budget 211812352 bytes (202.0 MiB). Investigate duplicate channel shims, copied extension trees, or other accidental pack bloat before release.",
+      "openclaw-2026.3.12.tgz unpackedSize 224002564 bytes (213.6 MiB) exceeds budget 213909504 bytes (204.0 MiB). Investigate duplicate channel shims, copied extension trees, or other accidental pack bloat before release.",
     ]);
   });
 


### PR DESCRIPTION
This is temporary, I have kicked off a bundle size audit in parallel to address root cause

## Summary

- raise the root npm unpacked-size ceiling from 202 MiB to 204 MiB
- keep the historical 213.6 MiB bloat case rejected
- document that installed-agent user docs are intentional package surface

## Root cause

Preflight at `bafa32fd544b5ad8ac0cba75ebb76bef2250e1d7` produced a 203.4 MiB unpacked package. Compared with the last green preflight target `fdc1c2e6c1b5f41d00edb2eb55244fa7c51f87dd`, package-included docs grew from 6,836,915 bytes to 9,526,623 bytes while bundled skills stayed flat. Those docs are intentionally installed so agents can resolve the package-local docs path; no duplicated channel shim, extension tree, or new binary asset accounts for the overage.

Failed proof: https://github.com/openclaw/openclaw/actions/runs/32442022790/job/96654478072

## Validation

- `git diff --check`
- remote PR CI and exact npm preflight pending

Production/tooling delta: +1/-1 effective constant/comment adjustment; test delta +1/-1.