### PR TITLE
fix(qa): restore failed-tool recovery scenarios

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -8484,7 +8484,7 @@ Update and merge these partial structured summaries.`,
       input: [
         makeUserInput(prompt),
         makeUserInput(
-          `${QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} If any tool failed, state that failure plainly and do not claim it succeeded.`,
+          `${QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION} If a tool failed, say so; never claim completion or success.`,
         ),
         failedToolOutput,
       ],

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1374,7 +1374,7 @@ async function buildResponsesPayload(
   }
   if (isActiveFailedToolTerminalRecovery) {
     if (allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE)) {
-      if (!allInputText.includes("state that failure plainly and do not claim it succeeded")) {
+      if (!allInputText.includes("If a tool failed, say so; never claim completion or success.")) {
         return buildAssistantEvents("FAILED-TOOL-HONESTY-INSTRUCTION-MISSING");
       }
       const marker = exactMarkerDirective ?? exactReplyDirective ?? "QA-FAILED-TOOL-FINALIZED-OK";

--- a/qa/scenarios/channels/qa-channel-failed-tool-terminal-finalization.yaml
+++ b/qa/scenarios/channels/qa-channel-failed-tool-terminal-finalization.yaml
@@ -34,7 +34,7 @@ scenario:
       channelId: qa-failed-terminal
       promptSnippet: Failed tool terminal recovery QA check
       retryNeedle: The previous assistant turn completed its tool calls but did not produce a user-visible answer.
-      failureHonestyNeedle: state that failure plainly and do not claim it succeeded
+      failureHonestyNeedle: If a tool failed, say so; never claim completion or success.
       expectedMarker: QA-FAILED-TOOL-FINALIZED-OK
       expectedReply: "The requested file could not be read: ENOENT. QA-FAILED-TOOL-FINALIZED-OK"
 

--- a/qa/scenarios/scheduling/cron-failed-tool-terminal-finalization.yaml
+++ b/qa/scenarios/scheduling/cron-failed-tool-terminal-finalization.yaml
@@ -34,7 +34,7 @@ scenario:
       channelId: qa-failed-cron
       promptSnippet: Failed tool terminal recovery QA check
       retryNeedle: The previous assistant turn completed its tool calls but did not produce a user-visible answer.
-      failureHonestyNeedle: state that failure plainly and do not claim it succeeded
+      failureHonestyNeedle: If a tool failed, say so; never claim completion or success.
       expectedMarker: CRON-FAILED-TOOL-FINALIZED-OK
       expectedReply: "The requested file could not be read: ENOENT. CRON-FAILED-TOOL-FINALIZED-OK"
 

--- a/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-gateway-runtime.e2e.test.ts
@@ -199,7 +199,7 @@ describe("diagnostics-otel gateway runtime", () => {
       expect(finalizations).toHaveLength(1);
       expect(finalizations[0]?.body?.tools ?? []).toHaveLength(0);
       expect(finalizations[0]?.allInputText).toContain(
-        "state that failure plainly and do not claim it succeeded",
+        "If a tool failed, say so; never claim completion or success.",
       );
       const finalizationInput = finalizations[0]?.body?.input ?? [];
       const failedExecCalls = finalizationInput.filter(


### PR DESCRIPTION
## What Problem This Solves

Resolves a QA contract drift where cron, qa-channel, and OTEL failed-tool terminal-finalization coverage still required retired wording after the production recovery prompt adopted the canonical failure-honesty instruction.

## Why This Change Was Made

Synchronizes every located consumer of the shared mock-provider gate with the canonical production instruction: `If a tool failed, say so; never claim completion or success.` The cron and qa-channel scenarios exercise the same embedded-agent settled-tool recovery contract, and the OTEL assertion observes that contract through the real Gateway path.

This is QA-only and does not change cron, channel, or Gateway behavior.

## User Impact

No product behavior changes. Maintainers regain reliable coverage proving cron and direct qa-channel turns with a failed terminal tool send one honest final reply rather than claiming success, including the OTEL runtime boundary.

## Exact-Head Evidence

Reviewed and exercised head: `d1f093e97bc6bd5bb3cc098699ffe79efcfe92f8`.

- Retired phrase search: zero repository matches.
- Direct OTEL Gateway runtime E2E: 1/1 passed.
- Exact cron scenario: 1/1 passed with `ENOENT ... calls=1 failed=1 finalizations=1`.
- Exact qa-channel scenario: 1/1 passed with `ENOENT ... calls=1 failed=1 finalizations=1`.
- Mock-compatible scheduling pack: 8/8 passed.
- Qa-channel-compatible channel pack: 26/28 passed, including the repaired failed-tool scenario. The two failures are unrelated existing diagnostic-flow issues and reproduce individually: `message-tool-stranded-final-retry-failure` and `provider-http-503-visible-failure` receive their expected sanitized error replies, which `waitForOutboundMessage` classifies as failures before their assertions.
- Mock-provider suite: 271/271 tests passed.
- Full five-file `check-changed` gate passed formatting, guards, plugin doctor (5/5), all core/UI/extensions/scripts/root typechecks, lint (0 warnings/errors), and import-cycle checks (0 cycles).
- Cron Control UI unit suite: 221/221 tests passed.
- Mocked-Gateway cron browser suite: 19/19 tests passed.
- Native scheduling contracts: 23/23 tests passed.
- Independent read-only source review of the exact head found no actionable in-scope findings and confirmed the prior ClawSweeper OTEL P2 is resolved.
- TruffleHog preflight passed.

The required repository autoreview was attempted on the exact branch diff. TruffleHog passed, but the official Codex CLI's available OpenAI credential returned HTTP 401. No local Codex result is claimed; the independent exact-head source review is retained instead.

No screenshot is attached because the patch changes QA expectations only. DOM/accessibility coverage remains represented by the passing 221-test Control UI unit suite and 19-test mocked-Gateway browser suite; no UI DOM changed in this patch.

## Scope

Five QA/test files, each `+1/-1`: total `+5/-5`, production LOC `+0/-0`.

Known outside this explicitly authorized scope: the two channel diagnostic flows above need owner follow-up. They are not caused by this wording-only patch.
