### PR TITLE
fix(cli): reject ignored onboarding options on recommendation actions

### DIFF
--- a/src/cli/command-options.ts
+++ b/src/cli/command-options.ts
@@ -5,6 +5,27 @@ export function hasExplicitOptions(command: Command, names: readonly string[]): 
   return names.some((name) => command.getOptionValueSource(name) === "cli");
 }
 
+export function listExplicitOptionFlagsExcept(
+  command: Command,
+  allowedNames: ReadonlySet<string>,
+): string[] {
+  const optionsByName = new Map<string, (typeof command.options)[number]>();
+  for (const option of command.options) {
+    const name = option.attributeName();
+    if (allowedNames.has(name) || command.getOptionValueSource(name) !== "cli") {
+      continue;
+    }
+    const existing = optionsByName.get(name);
+    const valueIsNegated = command.getOptionValue(name) === false;
+    if (!existing || option.negate === valueIsNegated) {
+      optionsByName.set(name, option);
+    }
+  }
+  return [...optionsByName.values()]
+    .map((option) => option.long ?? option.short ?? option.flags)
+    .toSorted();
+}
+
 // Defensive guardrail: allow expected parent/grandparent inheritance without unbounded deep traversal.
 const MAX_INHERIT_DEPTH = 2;
 

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -129,6 +129,32 @@ describe("registerOnboardCommand", () => {
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { leaf: "read", args: ["--reset", "recommendations"] },
+    { leaf: "acknowledge", args: ["--reset", "recommendations", "acknowledge"] },
+    { leaf: "refresh", args: ["--reset", "recommendations", "refresh"] },
+    { leaf: "acknowledge", args: ["--json", "recommendations", "acknowledge"] },
+    { leaf: "refresh", args: ["--json", "recommendations", "refresh"] },
+    { leaf: "acknowledge", args: ["recommendations", "--json", "acknowledge"] },
+    { leaf: "refresh", args: ["recommendations", "--json", "refresh"] },
+  ])("rejects inapplicable parent options for recommendations $leaf", async ({ args }) => {
+    await runCli(["onboard", ...args]);
+
+    const unsupportedFlag = args.includes("--reset") ? "--reset" : "--json";
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining(unsupportedFlag));
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.onboardRecommendationsCommand).not.toHaveBeenCalled();
+    expect(mocks.acknowledgeOnboardRecommendationsCommand).not.toHaveBeenCalled();
+    expect(mocks.refreshOnboardRecommendationsCommand).not.toHaveBeenCalled();
+    expect(setupWizardCommandMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps parent --json supported for reading recommendations", async () => {
+    await runCli(["onboard", "--json", "recommendations"]);
+
+    expect(mocks.onboardRecommendationsCommand).toHaveBeenCalledWith({ json: true }, runtime);
+  });
+
   it("defaults installDaemon to undefined when no daemon flags are provided", async () => {
     await runCli(["onboard"]);
 

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -20,6 +20,7 @@ import { resolveProviderOnboardAuthFlags } from "../../plugins/provider-auth-cho
 import type { RuntimeEnv } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatCliCommand } from "../command-format.js";
+import { listExplicitOptionFlagsExcept } from "../command-options.js";
 import { parseGatewayPortOption } from "../gateway-port-option.js";
 
 export function resolveInstallDaemonFlag(command: Command): boolean | undefined {
@@ -43,30 +44,31 @@ const MODERN_ONBOARD_OPTION_KEYS = new Set([
   "json",
 ]);
 
-function listUnsupportedModernOptions(command: Command): string[] {
-  const optionsByKey = new Map<string, (typeof command.options)[number]>();
-  for (const option of command.options) {
-    const key = option.attributeName();
-    if (MODERN_ONBOARD_OPTION_KEYS.has(key) || command.getOptionValueSource(key) !== "cli") {
-      continue;
-    }
-    const existing = optionsByKey.get(key);
-    const valueIsNegated = command.getOptionValue(key) === false;
-    if (!existing || option.negate === valueIsNegated) {
-      // Positive and --no-* forms can share one Commander attribute. Report
-      // only the spelling whose parsed value actually won.
-      optionsByKey.set(key, option);
-    }
+function validateRecommendationParentOptions(
+  command: Command,
+  runtime: RuntimeEnv,
+  allowJson = false,
+): boolean {
+  const unsupported = listExplicitOptionFlagsExcept(
+    command,
+    allowJson ? RECOMMENDATION_READ_PARENT_OPTIONS : NO_RECOMMENDATION_PARENT_OPTIONS,
+  );
+  if (unsupported.length === 0) {
+    return true;
   }
-  return [...optionsByKey.values()]
-    .map((option) => option.long ?? option.short ?? option.flags)
-    .toSorted();
+  runtime.error(
+    `This recommendations command does not support parent option(s): ${unsupported.join(", ")}.`,
+  );
+  runtime.exit(1);
+  return false;
 }
 
 const AUTH_CHOICE_HELP = formatAuthChoiceChoicesForCli({
   includeLegacyAliases: true,
   includeSkip: true,
 });
+const RECOMMENDATION_READ_PARENT_OPTIONS = new Set(["json"]);
+const NO_RECOMMENDATION_PARENT_OPTIONS = new Set<string>();
 
 type OnboardAuthFlag = {
   readonly cliOption: string;
@@ -261,6 +263,9 @@ export function registerOnboardCommand(program: Command): void {
     .action(async (opts, recommendationsCommand: Command) => {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
+        if (!validateRecommendationParentOptions(command, defaultRuntime, true)) {
+          return;
+        }
         const { onboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
         onboardRecommendationsCommand(
@@ -279,6 +284,12 @@ export function registerOnboardCommand(program: Command): void {
     .action(async (opts: { retry?: string[] }) => {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
+        if (
+          !validateRecommendationParentOptions(command, defaultRuntime) ||
+          !validateRecommendationParentOptions(recommendations, defaultRuntime)
+        ) {
+          return;
+        }
         const { acknowledgeOnboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
         acknowledgeOnboardRecommendationsCommand({ retry: opts.retry }, defaultRuntime);
@@ -291,6 +302,12 @@ export function registerOnboardCommand(program: Command): void {
     .action(async () => {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
+        if (
+          !validateRecommendationParentOptions(command, defaultRuntime) ||
+          !validateRecommendationParentOptions(recommendations, defaultRuntime)
+        ) {
+          return;
+        }
         const { refreshOnboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
         refreshOnboardRecommendationsCommand(defaultRuntime);
@@ -301,7 +318,10 @@ export function registerOnboardCommand(program: Command): void {
     const { defaultRuntime } = await import("../../runtime.js");
     await runCommandWithRuntime(defaultRuntime, async () => {
       if (opts.modern) {
-        const unsupportedOptions = listUnsupportedModernOptions(commandRuntime);
+        const unsupportedOptions = listExplicitOptionFlagsExcept(
+          commandRuntime,
+          MODERN_ONBOARD_OPTION_KEYS,
+        );
         if (unsupportedOptions.length > 0) {
           defaultRuntime.error(
             [

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -13,7 +13,7 @@ import type {
 } from "../../commands/onboard-types.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
-import { hasExplicitOptions } from "../command-options.js";
+import { hasExplicitOptions, listExplicitOptionFlagsExcept } from "../command-options.js";
 import { isUnconfiguredConfigSource } from "../fresh-install-config.js";
 import { parseGatewayPortOption } from "../gateway-port-option.js";
 import {
@@ -52,24 +52,6 @@ function hasExplicitOnboardingOption(command: Command): boolean {
     const name = option.attributeName();
     return !SYSTEM_AGENT_OPTION_NAMES.has(name) && command.getOptionValueSource(name) === "cli";
   });
-}
-
-function listUnsupportedBaselineOptions(command: Command): string[] {
-  const optionsByName = new Map<string, (typeof command.options)[number]>();
-  for (const option of command.options) {
-    const name = option.attributeName();
-    if (BASELINE_OPTION_NAMES.has(name) || command.getOptionValueSource(name) !== "cli") {
-      continue;
-    }
-    const existing = optionsByName.get(name);
-    const valueIsNegated = command.getOptionValue(name) === false;
-    if (!existing || option.negate === valueIsNegated) {
-      optionsByName.set(name, option);
-    }
-  }
-  return [...optionsByName.values()]
-    .map((option) => option.long ?? option.short ?? option.flags)
-    .toSorted();
 }
 
 async function isConfiguredInstance(): Promise<boolean> {
@@ -115,7 +97,7 @@ async function runOnboardingEntry(
   runtime: RuntimeEnv,
 ): Promise<void> {
   if (options.baseline) {
-    const unsupportedOptions = listUnsupportedBaselineOptions(commandRuntime);
+    const unsupportedOptions = listExplicitOptionFlagsExcept(commandRuntime, BASELINE_OPTION_NAMES);
     if (unsupportedOptions.length > 0) {
       runtime.error(`--baseline cannot be combined with: ${unsupportedOptions.join(", ")}.`);
       runtime.exit(1);


### PR DESCRIPTION
## What Problem This Solves

Commander accepts options declared on `openclaw onboard` and `onboard recommendations` before nested recommendation actions. Those actions do not consume the inherited values, so commands such as `openclaw onboard --reset recommendations --json` and `openclaw onboard recommendations --json acknowledge` previously exited successfully while silently ignoring explicit operator intent.

## Why This Change Was Made

Validate explicitly supplied ancestor options at the recommendation leaf boundary before dispatch. Reading recommendations continues to inherit `--json`; acknowledge and refresh reject every explicit ancestor option because those leaves support none. The shared option-listing helper also replaces the equivalent setup baseline implementation, keeping Commander spelling/negation handling canonical.

## User Impact

Invalid option placement now exits 1 with the exact unsupported flag instead of pretending the requested reset or JSON behavior occurred. Valid `onboard --json recommendations` output is unchanged.

## Evidence

- `pnpm test src/cli/command-options.test.ts src/cli/program/register.onboard.test.ts` — 63 passed across two shards.
- `pnpm test src/cli/program/register.setup.test.ts` — 39 passed.
- Executable parser proof: valid parent `--json` read exited 0 with `[]`; parent `--reset` before recommendations and intermediate `--json` before acknowledge each exited 1 with the explicit unsupported flag.
- `pnpm check:changed` — passed before a clean, conflict-free current-main rebase; focused parser/setup tests passed again on the exact rebased head.
- TruffleHog exact-diff scan — clean.
- Autoreview — 0.99, no accepted/actionable findings.

Production LOC: +61/-38 (net +23) | Tests: +26/-0. The production growth adds the missing leaf-boundary validation while deleting a duplicate 20-line option-inspection implementation from setup.