### PR TITLE
fix(qa): reject skipped-only confidence lanes

### DIFF
--- a/extensions/qa-lab/src/confidence-report.test.ts
+++ b/extensions/qa-lab/src/confidence-report.test.ts
@@ -37,6 +37,38 @@ describe("qa confidence report", () => {
     return filePath;
   }
 
+  async function buildStrictSuiteReport(payload: Record<string, unknown>, withBackfill = false) {
+    await writeJson("report-only/qa-suite-summary.json", payload);
+    const lanes: QaConfidenceManifest["lanes"] = [
+      {
+        id: "report-only",
+        title: "Report-only",
+        kind: "qa-suite-summary",
+        artifact: "report-only/qa-suite-summary.json",
+        required: true,
+        ...(withBackfill ? { skipBackfillLane: "backfill" } : {}),
+      },
+    ];
+    if (withBackfill) {
+      await writeJson("backfill/qa-suite-summary.json", {
+        counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
+      });
+      lanes.push({
+        id: "backfill",
+        title: "Passing backfill",
+        kind: "qa-suite-summary",
+        artifact: "backfill/qa-suite-summary.json",
+        required: true,
+      });
+    }
+    return buildQaConfidenceReport({
+      manifest: { version: 1, profile: "confidence-regression", lanes },
+      artifactRoot: tempRoot,
+      strictZeroUnknowns: true,
+      strictGlobalPass: true,
+    });
+  }
+
   it("passes strict zero-unknowns when every lane passes or has an allowed blocked verdict", async () => {
     await writeJson("tool-defaults/qa-suite-summary.json", {
       counts: { total: 20, passed: 18, skipped: 2, failed: 0 },
@@ -276,29 +308,9 @@ describe("qa confidence report", () => {
   });
 
   it("fails strict global pass for skipped suite rows until a backfill lane passes", async () => {
-    await writeJson("report-only/qa-suite-summary.json", {
+    const report = await buildStrictSuiteReport({
       counts: { total: 3, passed: 2, skipped: 1, failed: 0 },
       scenarios: [],
-    });
-
-    const report = await buildQaConfidenceReport({
-      manifest: {
-        version: 1,
-        profile: "codex-100",
-        lanes: [
-          {
-            id: "report-only",
-            title: "Report-only",
-            kind: "qa-suite-summary",
-            artifact: "report-only/qa-suite-summary.json",
-            required: true,
-          },
-        ],
-      },
-      artifactRoot: tempRoot,
-      strictZeroUnknowns: true,
-      strictGlobalPass: true,
-      generatedAt: "2026-05-12T00:00:00.000Z",
     });
 
     expect(report.zeroUnknowns).toBe(true);
@@ -306,6 +318,82 @@ describe("qa confidence report", () => {
     expect(report.failures).toEqual([
       "report-only has 1 skipped row(s) with no passing backfill lane",
     ]);
+  });
+
+  it.each([
+    ["count-backed", "skip"],
+    ["count-backed", "skipped"],
+    ["legacy", "skip"],
+    ["legacy", "skipped"],
+    ["unverified-pass-count", "skip"],
+    ["unverified-pass-count", "skipped"],
+  ] as const)(
+    "rejects %s suites containing only %s scenarios despite a passing backfill",
+    async (format, skippedStatus) => {
+      const report = await buildStrictSuiteReport(
+        {
+          ...(format === "count-backed"
+            ? { counts: { total: 1, passed: 0, failed: 0, skipped: 1 } }
+            : format === "unverified-pass-count"
+              ? { counts: { passed: 1, failed: 0 } }
+              : {}),
+          scenarios: [{ name: "never executed", status: skippedStatus }],
+        },
+        true,
+      );
+
+      expect(report.pass).toBe(false);
+      expect(report.globalPass).toBe(false);
+      expect(report.lanes[0]).toMatchObject({ status: "unknown" });
+      expect(report.lanes[0]?.details).toContain("no executed scenarios");
+      expect(report.lanes[1]).toMatchObject({ status: "pass" });
+    },
+  );
+
+  it.each([
+    ["skip", undefined],
+    ["skipped", undefined],
+    ["count-reported skip", 1],
+  ] as const)(
+    "requires a passing backfill for legacy suites containing a pass and %s",
+    async (skippedStatus, explicitSkippedCount) => {
+      const artifact = {
+        ...(explicitSkippedCount === undefined
+          ? {}
+          : { counts: { skipped: explicitSkippedCount } }),
+        scenarios: [
+          { name: "executed", status: "pass" },
+          ...(explicitSkippedCount === undefined
+            ? [{ name: "not executed", status: skippedStatus }]
+            : []),
+        ],
+      };
+
+      for (const hasBackfill of [false, true]) {
+        const report = await buildStrictSuiteReport(artifact, hasBackfill);
+
+        expect(report.pass).toBe(hasBackfill);
+        expect(report.globalPass).toBe(hasBackfill);
+        expect(report.lanes[0]).toMatchObject({ status: "pass", skippedCount: 1 });
+        if (hasBackfill) {
+          expect(report.lanes[0]).toMatchObject({ skipBackfilled: true });
+        } else {
+          expect(report.failures).toEqual([
+            "report-only has 1 skipped row(s) with no passing backfill lane",
+          ]);
+        }
+      }
+    },
+  );
+
+  it("accepts a positive count-only suite without scenario rows", async () => {
+    const report = await buildStrictSuiteReport({
+      counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
+    });
+
+    expect(report.pass).toBe(true);
+    expect(report.globalPass).toBe(true);
+    expect(report.lanes[0]).toMatchObject({ status: "pass" });
   });
 
   it("infers skipped suite rows from totals and scenario status", async () => {
@@ -322,27 +410,7 @@ describe("qa confidence report", () => {
         "counts.skipped=1",
       ],
     ] as const) {
-      await writeJson("report-only/qa-suite-summary.json", artifact);
-
-      const report = await buildQaConfidenceReport({
-        manifest: {
-          version: 1,
-          profile: "codex-100",
-          lanes: [
-            {
-              id: "report-only",
-              title: "Report-only",
-              kind: "qa-suite-summary",
-              artifact: "report-only/qa-suite-summary.json",
-              required: true,
-            },
-          ],
-        },
-        artifactRoot: tempRoot,
-        strictZeroUnknowns: true,
-        strictGlobalPass: true,
-        generatedAt: "2026-05-12T00:00:00.000Z",
-      });
+      const report = await buildStrictSuiteReport(artifact);
 
       expect(report.globalPass).toBe(false);
       expect(report.failures).toEqual([
@@ -369,27 +437,7 @@ describe("qa confidence report", () => {
         "unsupported non-pass status",
       ],
     ] as const) {
-      await writeJson("report-only/qa-suite-summary.json", artifact);
-
-      const report = await buildQaConfidenceReport({
-        manifest: {
-          version: 1,
-          profile: "codex-100",
-          lanes: [
-            {
-              id: "report-only",
-              title: "Report-only",
-              kind: "qa-suite-summary",
-              artifact: "report-only/qa-suite-summary.json",
-              required: true,
-            },
-          ],
-        },
-        artifactRoot: tempRoot,
-        strictZeroUnknowns: true,
-        strictGlobalPass: true,
-        generatedAt: "2026-05-12T00:00:00.000Z",
-      });
+      const report = await buildStrictSuiteReport(artifact);
 
       expect(report.pass).toBe(false);
       expect(report.globalPass).toBe(false);
@@ -468,49 +516,17 @@ describe("qa confidence report", () => {
   });
 
   it("passes strict global pass when skipped suite rows are backfilled by a passing lane", async () => {
-    await writeJson("report-only/qa-suite-summary.json", {
-      counts: { total: 3, passed: 2, skipped: 1, failed: 0 },
-      scenarios: [],
-    });
-    await writeJson("live-backfill/qa-suite-summary.json", {
-      counts: { total: 1, passed: 1, skipped: 0, failed: 0 },
-      scenarios: [],
-    });
-
-    const report = await buildQaConfidenceReport({
-      manifest: {
-        version: 1,
-        profile: "codex-100",
-        lanes: [
-          {
-            id: "report-only",
-            title: "Report-only",
-            kind: "qa-suite-summary",
-            artifact: "report-only/qa-suite-summary.json",
-            required: true,
-            skipBackfillLane: "live-backfill",
-          },
-          {
-            id: "live-backfill",
-            title: "Live backfill",
-            kind: "qa-suite-summary",
-            artifact: "live-backfill/qa-suite-summary.json",
-            required: true,
-          },
-        ],
-      },
-      artifactRoot: tempRoot,
-      strictZeroUnknowns: true,
-      strictGlobalPass: true,
-      generatedAt: "2026-05-12T00:00:00.000Z",
-    });
+    const report = await buildStrictSuiteReport(
+      { counts: { total: 3, passed: 2, skipped: 1, failed: 0 }, scenarios: [] },
+      true,
+    );
 
     expect(report.pass).toBe(true);
     expect(report.zeroUnknowns).toBe(true);
     expect(report.globalPass).toBe(true);
     expect(report.lanes[0]).toMatchObject({
       skippedCount: 1,
-      skipBackfillLane: "live-backfill",
+      skipBackfillLane: "backfill",
       skipBackfilled: true,
     });
   });

--- a/extensions/qa-lab/src/confidence-report.ts
+++ b/extensions/qa-lab/src/confidence-report.ts
@@ -390,9 +390,8 @@ function evaluateQaSuiteSummary(payload: unknown): QaConfidenceLaneEvaluation {
   const failedCount = readCount(counts?.failed);
   const explicitSkippedCount = readCount(counts?.skipped);
   const scenarios = Array.isArray(payload.scenarios) ? payload.scenarios : undefined;
-  const failedScenarios = scenarios?.filter(
-    (scenario) => isRecord(scenario) && scenario.status === "fail",
-  );
+  const failedScenarioCount =
+    scenarios?.filter((scenario) => isRecord(scenario) && scenario.status === "fail").length ?? 0;
   const skippedScenarioCount =
     scenarios?.filter(
       (scenario) =>
@@ -407,14 +406,19 @@ function evaluateQaSuiteSummary(payload: unknown): QaConfidenceLaneEvaluation {
           scenario.status !== "skip" &&
           scenario.status !== "skipped"),
     ).length ?? 0;
-  const hasScenarioRows = scenarios !== undefined && scenarios.length > 0;
+  const hasExecutedScenarios =
+    (failedCount ?? 0) > 0 ||
+    scenarios?.some(
+      (scenario) =>
+        isRecord(scenario) && (scenario.status === "pass" || scenario.status === "fail"),
+    ) === true ||
+    ((scenarios?.length ?? 0) === 0 && (passedCount ?? 0) > 0);
   const gatewayLogSentinels = collectGatewayLogSentinels(payload);
   if (gatewayLogSentinels.length > 0) {
     const allEnvironmentBlocked = gatewayLogSentinels.every(
       (finding) => finding.verdict === "environment-blocked",
     );
-    const suiteHasFailures =
-      (failedCount !== undefined && failedCount > 0) || (failedScenarios?.length ?? 0) > 0;
+    const suiteHasFailures = (failedCount ?? 0) > 0 || failedScenarioCount > 0;
     if (allEnvironmentBlocked && suiteHasFailures) {
       return {
         passed: false,
@@ -436,31 +440,42 @@ function evaluateQaSuiteSummary(payload: unknown): QaConfidenceLaneEvaluation {
       details: `gateway log sentinel(s): ${formatGatewayLogSentinelSummary(gatewayLogSentinels)}`,
     };
   }
+  if (
+    failedCount !== undefined &&
+    scenarios !== undefined &&
+    Math.floor(failedCount) !== failedScenarioCount
+  ) {
+    return {
+      passed: false,
+      status: "unknown",
+      details: `qa-suite-summary count/scenario mismatch: counts.failed=${Math.max(
+        0,
+        Math.floor(failedCount),
+      )}, failed scenarios=${failedScenarioCount}`,
+    };
+  }
+  if (unknownBlockingScenarioCount > 0) {
+    return {
+      passed: false,
+      status: "unknown",
+      details: `qa-suite-summary has ${unknownBlockingScenarioCount} scenario row(s) with unsupported non-pass status`,
+    };
+  }
+  if (failedCount === undefined && scenarios === undefined) {
+    return {
+      passed: false,
+      status: "unknown",
+      details: "qa-suite-summary missing counts.failed and scenarios[]",
+    };
+  }
+  if (!hasExecutedScenarios) {
+    return {
+      passed: false,
+      status: "unknown",
+      details: "qa-suite-summary has no executed scenarios",
+    };
+  }
   if (failedCount !== undefined) {
-    if (failedCount === 0 && !(totalCount !== undefined && totalCount > 0) && !hasScenarioRows) {
-      return {
-        passed: false,
-        status: "unknown",
-        details: "qa-suite-summary has no executed scenarios",
-      };
-    }
-    if (failedScenarios !== undefined && Math.floor(failedCount) !== failedScenarios.length) {
-      return {
-        passed: false,
-        status: "unknown",
-        details: `qa-suite-summary count/scenario mismatch: counts.failed=${Math.max(
-          0,
-          Math.floor(failedCount),
-        )}, failed scenarios=${failedScenarios.length}`,
-      };
-    }
-    if (unknownBlockingScenarioCount > 0) {
-      return {
-        passed: false,
-        status: "unknown",
-        details: `qa-suite-summary has ${unknownBlockingScenarioCount} scenario row(s) with unsupported non-pass status`,
-      };
-    }
     const inferredSkippedCount =
       totalCount === undefined || passedCount === undefined
         ? undefined
@@ -483,41 +498,11 @@ function evaluateQaSuiteSummary(payload: unknown): QaConfidenceLaneEvaluation {
       ...(skippedCount === 0 ? {} : { skippedCount: Math.max(0, Math.floor(skippedCount)) }),
     };
   }
-  if (!Array.isArray(payload.scenarios)) {
-    return {
-      passed: false,
-      status: "unknown",
-      details: "qa-suite-summary missing counts.failed and scenarios[]",
-    };
-  }
-  if (payload.scenarios.length === 0) {
-    return {
-      passed: false,
-      status: "unknown",
-      details: "qa-suite-summary has no executed scenarios",
-    };
-  }
-  const fallbackFailedScenarios = payload.scenarios.filter(
-    (scenario) => isRecord(scenario) && scenario.status === "fail",
-  );
-  const fallbackUnknownBlockingScenarios = payload.scenarios.filter(
-    (scenario) =>
-      !isRecord(scenario) ||
-      (scenario.status !== "pass" &&
-        scenario.status !== "fail" &&
-        scenario.status !== "skip" &&
-        scenario.status !== "skipped"),
-  );
-  if (fallbackUnknownBlockingScenarios.length > 0) {
-    return {
-      passed: false,
-      status: "unknown",
-      details: `qa-suite-summary has ${fallbackUnknownBlockingScenarios.length} scenario row(s) with unsupported non-pass status`,
-    };
-  }
+  const skippedCount = Math.max(explicitSkippedCount ?? 0, skippedScenarioCount);
   return {
-    passed: fallbackFailedScenarios.length === 0,
-    details: `qa-suite-summary failed scenarios=${fallbackFailedScenarios.length}`,
+    passed: failedScenarioCount === 0,
+    details: `qa-suite-summary failed scenarios=${failedScenarioCount}`,
+    ...(skippedCount === 0 ? {} : { skippedCount }),
   };
 }
 


### PR DESCRIPTION
Closes #126974

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators running `openclaw qa confidence-report --strict-global-pass` would receive a successful exit and `globalPass: true` even though a required completed QA lane executed no scenarios. Both count-backed and legacy artifacts accepted `skip`/`skipped` rows as execution, and legacy mixed passing/skipped artifacts silently bypassed required passing backfill.

## Why This Change Was Made

The QA confidence evaluator now shares one executed-outcome decision across its count-backed and legacy branches: an observed passing/failing scenario, a positive failure count, or a positive passing count only when no scenario rows exist. Existing lifecycle, accounting, sentinel, unsupported-status, and failure classification remain in their original precedence; legacy skipped counts are carried forward from both observed rows and partial aggregate counts so the existing backfill owner can enforce its policy. Duplicate branch-specific classification was removed rather than adding a downstream strict-mode guard or changing the legitimate suite-artifact producer.

## User Impact

Strict QA confidence reports now fail with exit 1 when required proof never ran, including when another passing lane is offered as backfill. Actually executed mixed pass/skip lanes still pass with a separate genuinely passing QA-suite backfill, and positive count-only legacy summaries remain supported. No configuration, protocol, dependency, persistence, security-policy, operator-service, or changelog changes are involved.

## Evidence

Exact reviewed head: `934283c429fcc84f099e44bbc03a9b1ac95c9f01`.

- Regressions failed before the repair: six skipped-only/missing-backfill cases; an additional adversarial partial-count skip case independently failed before its fix.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-qa.config.ts --configLoader runner extensions/qa-lab/src/confidence-report.test.ts extensions/qa-lab/src/suite-summary.test.ts` — **99 tests passed**.
- `node scripts/check-changed.mjs -- extensions/qa-lab/src/confidence-report.ts extensions/qa-lab/src/confidence-report.test.ts` — full plugin-production/plugin-test changed gate passed, including both typechecks, changed-file lint, doctor-contract tests, owner-boundary/dead-export guards, and runtime import-cycle checks.
- `node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/qa-lab/src/confidence-report.test.ts extensions/qa-lab/src/confidence-report.ts` — passed; the existing oversized test fixture was consolidated without adding a suppression.
- `git diff --check` — passed.
- Real `runQaConfidenceReportCommand` strict-handler proof used in-memory artifact I/O and checked 13 cases: count-backed/legacy `skip` and `skipped` now exit 1; forged passing counts beside observed skipped-only rows exit 1; legacy row/count skips require a distinct passing backfill; genuine mixed backfill and positive count-only summaries still exit 0; genuine failures and unsupported statuses still exit 1. No provider, Gateway, service, or operator state was touched.
- Fresh Codex autoreview and a separate exact-diff adversarial review both reported no actionable findings; the adversarial review identified the partial-count skip case before landing.
- Production LOC: `+49/-64` (**net -15**); tests: `+116/-100` (**net +16**). The combined patch grows by one line while adding full owner/sibling regression coverage.
- Rejected alternatives: reject skipped summaries at the CLI exit consumer (wrong ownership); change the producer (completed skipped-only artifacts are valid); treat total/row presence or an unverified aggregate pass count as execution (reopens false greens); weaken lint assertions or add a max-lines suppression (unnecessary after fixture consolidation).
- Separate pre-existing follow-up, intentionally outside this owner-only repair: validate self-referential or mutually cyclic `skipBackfillLane` references in the existing backfill-policy owner.

AI-assisted; agent transcripts intentionally omitted.
