### PR TITLE
fix(cli): gateway status rejects invalid timeout values

### DIFF
--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -811,6 +811,19 @@ describe("gatherDaemonStatus", () => {
     }
   }, 1_000);
 
+  it.each(["bogus", "0", "-1", "1.5"])(
+    "rejects invalid status timeout %s before reading service state",
+    async (timeout) => {
+      await expect(gatherStatus({ rpc: { timeout } })).rejects.toThrow(
+        `Invalid --timeout. Use a positive millisecond value, e.g. --timeout 30000. Received: "${timeout}".`,
+      );
+
+      expect(serviceReadCommand).not.toHaveBeenCalled();
+      expect(serviceIsLoaded).not.toHaveBeenCalled();
+      expect(serviceReadRuntime).not.toHaveBeenCalled();
+    },
+  );
+
   it("keeps gateway status read-only when service management is unsupported", async () => {
     serviceReadCommand.mockResolvedValueOnce(null);
     serviceIsLoaded.mockResolvedValueOnce(false);

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -1,6 +1,5 @@
 // Collects daemon status from service files, config snapshots, ports, probes, and plugin drift.
 import fs from "node:fs/promises";
-import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import JSON5 from "json5";
@@ -66,6 +65,7 @@ import {
 } from "../../plugins/plugin-version-drift.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { VERSION } from "../../version.js";
+import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 import { normalizeListenerAddress, parsePortFromArgs, pickProbeHostForBind } from "./shared.js";
 import type { GatewayRpcOpts } from "./types.js";
 
@@ -597,7 +597,9 @@ export async function gatherDaemonStatus(
     allowExecSecretRefs?: boolean;
   } & FindExtraGatewayServicesOptions,
 ): Promise<DaemonStatus> {
-  const timeoutMs = parseStrictPositiveInteger(opts.rpc.timeout ?? undefined) ?? 10_000;
+  const timeoutMs = parseTimeoutMsWithFallback(opts.rpc.timeout, 10_000, {
+    invalidType: "error",
+  });
   const service = resolveGatewayService();
   const serviceState = await readGatewayServiceState(service, {
     env: process.env,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw gateway status --timeout <value>` could pass malformed, zero, negative, or fractional timeout values and silently get the default 10-second timeout instead of an actionable CLI error.

## Why This Change Was Made

Gateway status now validates its timeout at the shared status-gather boundary with the existing canonical CLI timeout parser. This keeps fast-route, Commander, and direct callers consistent and rejects invalid input before any service state is read.

## User Impact

Operators now get an immediate, structured error for invalid gateway-status timeout values instead of a successful-looking status command with an unintended fallback.

## Evidence

- Before: isolated `gateway status --json --timeout bogus` exited 0 and returned normal status JSON.
- Regression test failed on the pre-fix source for `bogus`, `0`, `-1`, and `1.5`, then passed after the repair while proving no service read occurred first.
- Focused status/timeout/route coverage: 164 passed, 1 platform skip.
- `node scripts/check-changed.mjs -- src/cli/daemon-cli/status.gather.ts src/cli/daemon-cli/status.gather.test.ts`: passed.
- `pnpm build`: passed.
- Built isolated CLI after the fix: exit 1 with `Invalid --timeout. Use a positive millisecond value, e.g. --timeout 30000. Received: "bogus".`
- Independent review: no actionable findings; best-fix verdict was the shared gather boundary.
