### PR TITLE
fix(ui): keep loaded older history after switching sessions

### DIFF
--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -297,7 +297,7 @@ suite.define(() => {
     }
   });
 
-  it("keeps retained paginated history stable when returning to a session", async () => {
+  it("keeps evicted paginated history stable when returning to a session", async () => {
     const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const context = await suite.newBrowserContext({
       locale: "en-US",
@@ -308,6 +308,17 @@ suite.define(() => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
+    const captureEvictionStep = async (name: string) => {
+      if (!artifactDir) {
+        return;
+      }
+      await page.screenshot({
+        path: path.join(artifactDir, `${name}.png`),
+        fullPage: true,
+      });
+      // Keep post-assertion route states legible in the optional proof recording.
+      await page.waitForTimeout(300);
+    };
     const historyMessage = (seq: number, label: string) => ({
       __openclaw: { id: `history-${seq}`, seq },
       content: [
@@ -320,6 +331,41 @@ suite.define(() => {
       timestamp: 1_800_000_000_000 + seq,
     });
     const shortMessages = [historyMessage(1, "short session"), historyMessage(2, "short session")];
+    const sessionCMessages = [historyMessage(201, "session c"), historyMessage(202, "session c")];
+    const sessionDMessages = [historyMessage(301, "session d"), historyMessage(302, "session d")];
+    const shortSessions = [
+      {
+        key: "agent:main:session-a",
+        label: "Session A",
+        messages: shortMessages,
+        sessionId: "short-history-session",
+        updatedAt: 4,
+      },
+      {
+        key: "agent:main:session-c",
+        label: "Session C",
+        messages: sessionCMessages,
+        sessionId: "short-history-session-c",
+        updatedAt: 2,
+      },
+      {
+        key: "agent:main:session-d",
+        label: "Session D",
+        messages: sessionDMessages,
+        sessionId: "short-history-session-d",
+        updatedAt: 1,
+      },
+    ];
+    const shortSessionHistoryCases = shortSessions.map(({ key, messages, sessionId }) => ({
+      match: { sessionKey: key },
+      response: {
+        hasMore: false,
+        messages,
+        sessionId,
+        thinkingLevel: null,
+        totalMessages: 2,
+      },
+    }));
     const recentMessages = Array.from({ length: 100 }, (_, index) =>
       historyMessage(index + 41, "recent retained message"),
     );
@@ -352,16 +398,7 @@ suite.define(() => {
                 totalMessages: 140,
               },
             },
-            {
-              match: { sessionKey: "agent:main:session-a" },
-              response: {
-                hasMore: false,
-                messages: shortMessages,
-                sessionId: "short-history-session",
-                thinkingLevel: null,
-                totalMessages: 2,
-              },
-            },
+            ...shortSessionHistoryCases,
           ],
         },
         "chat.startup": {
@@ -377,19 +414,23 @@ suite.define(() => {
                 totalMessages: 140,
               },
             },
-            {
-              match: {},
-              response: {
-                hasMore: false,
-                messages: shortMessages,
-                sessionId: "short-history-session",
-                thinkingLevel: null,
-                totalMessages: 2,
-              },
-            },
+            ...shortSessionHistoryCases,
           ],
         },
-        "sessions.list": chatSessionListResponse(),
+        "sessions.list": chatSessionListResponse([
+          ...shortSessions.map(({ key, label, updatedAt }) => ({
+            key,
+            kind: "direct",
+            label,
+            updatedAt,
+          })),
+          {
+            key: "agent:main:session-b",
+            kind: "direct",
+            label: "Session B",
+            updatedAt: 3,
+          },
+        ]),
       },
       sessionKey: "agent:main:session-a",
     });
@@ -403,6 +444,12 @@ suite.define(() => {
       );
       const sessionA = page.locator(
         '.sidebar-recent-session[data-session-key="agent:main:session-a"] a.sidebar-recent-session__link',
+      );
+      const sessionC = page.locator(
+        '.sidebar-recent-session[data-session-key="agent:main:session-c"] a.sidebar-recent-session__link',
+      );
+      const sessionD = page.locator(
+        '.sidebar-recent-session[data-session-key="agent:main:session-d"] a.sidebar-recent-session__link',
       );
       await sessionB.click();
       await page.getByText(/^recent retained message 140\n/).waitFor({ timeout: 10_000 });
@@ -426,6 +473,13 @@ suite.define(() => {
 
       await sessionA.click();
       await page.getByText(/^short session 2\n/).waitFor({ timeout: 10_000 });
+      await captureEvictionStep("eviction-session-a");
+      await sessionC.click();
+      await page.getByText(/^session c 202\n/).waitFor({ timeout: 10_000 });
+      await captureEvictionStep("eviction-session-c");
+      await sessionD.click();
+      await page.getByText(/^session d 302\n/).waitFor({ timeout: 10_000 });
+      await captureEvictionStep("eviction-session-d");
       const historyRequestsBeforeReturn = (await gateway.getRequests("chat.history")).length;
       await page.evaluate(() => {
         type FrameSample = {

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -993,21 +993,30 @@ function recordChatHistoryTiming(
   );
 }
 
-function replaceCachedChatMessages(
+export function commitCurrentChatHistorySnapshot(
   state: ChatState,
-  sessionKey: string,
-  agentId: string | undefined,
-  deltaCursor?: string,
-) {
+  deltaCursor?: string | null,
+): void {
   if (!state.chatMessagesBySession) {
     return;
   }
+  const sessionKey = state.sessionKey;
+  const agentId = isUiSelectedGlobalSessionKey(state, sessionKey)
+    ? resolveUiSelectedSessionAgentId(state)
+    : undefined;
+  const cachedDeltaCursor =
+    deltaCursor === undefined
+      ? readChatSessionSnapshot(state.chatMessagesBySession, state, {
+          sessionKey,
+          agentId,
+        })?.deltaCursor
+      : (deltaCursor ?? undefined);
   cacheChatSessionSnapshot(
     state.chatMessagesBySession,
     state,
     { sessionKey, agentId },
     {
-      ...(deltaCursor !== undefined ? { deltaCursor } : {}),
+      ...(cachedDeltaCursor !== undefined ? { deltaCursor: cachedDeltaCursor } : {}),
       ...(state.chatDisplayedLeafEntryId !== undefined
         ? { displayedLeafEntryId: state.chatDisplayedLeafEntryId }
         : {}),
@@ -1569,7 +1578,7 @@ async function loadChatHistoryUncached(
       state.chatThinkingLevel = response.sessionInfo.thinkingLevel ?? null;
       state.chatQueueModeOverride = response.sessionInfo.queueMode;
       state.chatEffectiveQueueMode = response.sessionInfo.effectiveQueueMode;
-      replaceCachedChatMessages(state, sessionKey, requestAgentId, response.deltaCursor);
+      commitCurrentChatHistorySnapshot(state, response.deltaCursor ?? null);
       recordChatHistoryTiming(state, "applied", startedAtMs, {
         requestSessionKey: sessionKey,
         requestAgentId,
@@ -1662,7 +1671,7 @@ async function loadChatHistoryUncached(
     }
     state.chatHistoryPagination = reconciledHistory?.pagination ?? nextPagination;
     state.currentSessionId = nextSessionId;
-    replaceCachedChatMessages(state, sessionKey, requestAgentId, res.deltaCursor);
+    commitCurrentChatHistorySnapshot(state, res.deltaCursor ?? null);
     if (
       state.reconnectResumeSessionId &&
       state.reconnectResumeSessionId !== state.currentSessionId

--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -10,6 +10,7 @@ import "./chat-pane.ts";
 import { loadChatHistory } from "./chat-history.ts";
 import { nativeHistoryMessageIdentity } from "./chat-pane-shared.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
+import { cacheChatSessionSnapshot, readChatSessionSnapshot } from "./session-message-cache.ts";
 
 type TestChatPane = HTMLElement & {
   catalogCursor: string | undefined;
@@ -307,6 +308,42 @@ describe("chat pane native history pagination", () => {
     expect(pane.transcriptScrollTop).toBe(0);
     expect(pane.historyObserverArmed).toBe(false);
     expect(pane.historyAutoLoadBlocked).toBe(true);
+  });
+
+  it("publishes prepended history to the shared session snapshot", async () => {
+    const request = vi.fn(async () => ({
+      messages: [nativeHistoryMessage(1), nativeHistoryMessage(2)],
+      hasMore: false,
+      sessionId: "session-id",
+      totalMessages: 4,
+    }));
+    const { pane, state } = createNativeShowEarlierPane(request);
+    state.chatMessagesBySession = new Map();
+    state.currentSessionId = "session-id";
+    cacheChatSessionSnapshot(
+      state.chatMessagesBySession,
+      state,
+      { sessionKey: state.sessionKey },
+      {
+        deltaCursor: "delta-cursor",
+        messages: state.chatMessages,
+        pagination: state.chatHistoryPagination,
+        sessionId: "session-id",
+      },
+    );
+
+    await pane.loadOlderMessages();
+
+    expect(
+      readChatSessionSnapshot(state.chatMessagesBySession, state, {
+        sessionKey: state.sessionKey,
+      }),
+    ).toMatchObject({
+      deltaCursor: "delta-cursor",
+      messages: state.chatMessages,
+      pagination: state.chatHistoryPagination,
+      sessionId: "session-id",
+    });
   });
 
   it("reveals a final catalog page even when its cursor is exhausted", async () => {

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -20,6 +20,7 @@ import {
 } from "./attachment-payload-store.ts";
 import type { ChatHistoryPagination } from "./chat-history-pagination.ts";
 import {
+  commitCurrentChatHistorySnapshot,
   loadChatHistory,
   loadOlderChatHistoryPage,
   resolveChatHistoryPagination,
@@ -355,6 +356,7 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
           : nextPagination;
         state.chatHistoryPagination = appliedPagination;
         state.lastError = null;
+        commitCurrentChatHistorySnapshot(state);
         scheduleChatScroll(state, false);
         prepended = grew || !exhausted;
       }


### PR DESCRIPTION
Closes #126978

## What Problem This Solves

Fixes an issue where users who loaded older Control UI chat history would lose those older messages after switching through enough sessions to evict and remount the original chat pane.

## Why This Change Was Made

The older-page owner now publishes the mounted transcript and pagination state to the shared session snapshot after a successful prepend. Initial and reload paths use the same owner helper with explicit delta-cursor replacement, while pagination preserves the existing cursor, so remounts restore exactly the state the user last saw.

The browser regression crosses the real three-pane retention boundary with Session B → A → C → D → B and verifies the restored transcript without a network refetch.

## User Impact

Loaded older messages remain visible when users return to a session after navigating through other chats. The transcript no longer silently reverts to its pre-pagination tail page.

## Evidence

- Pre-fix owner regression failed with the mounted transcript at messages 1–4 while the shared snapshot still contained only messages 3–4 and `hasMore: true`.
- Focused Control UI tests: 68/68 passed across the history/cache suites.
- Browser E2E: 8/8 passed in `chat-flow.history-recovery.e2e.test.ts`, including the four-session eviction/remount flow.
- Current-main integration: 27/27 owner tests and 8/8 browser tests passed on Blacksmith Testbox.
- Required CI is green and exact-head autoreview completed cleanly with no actionable findings.
- `pnpm check:changed`: passed, including formatting, max-lines/assertion ratchets, dead exports, i18n, core/UI typechecks, lint, and style checks.
- `git diff --check`: passed.
- TruffleHog review preflight: clean.

## UI Proof

Returning to the retained session after opening older history preserves all loaded messages:

![Retained session keeps paginated history](https://ampcode.com/user-content/artifacts/2f776117bf9edcbde893d33c2d6bd61b911742907086193e6ae2ea7e455a65a7-file.png)

### Focused Recording

https://github.com/user-attachments/assets/27609602-ce4d-4290-9923-895eadc882ca
