### PR TITLE
fix(qa): make Mantis backfills reliable

### DIFF
--- a/.github/codex/prompts/mantis-telegram-desktop-proof.md
+++ b/.github/codex/prompts/mantis-telegram-desktop-proof.md
@@ -87,8 +87,9 @@ Iterate within the three-attempt budget; all attempts remain recorded.
 Build `mantis-evidence.json` with
 `scripts/mantis/build-telegram-desktop-proof-evidence.mts` as before, using each
 lane's generated `telegram-user-crabbox-session-summary.json`. Edit only the
-human summary/expected wording. A failure or block sets `comparison.pass: false`
-and names the concrete product defect or missing primitive.
+human summary/expected wording. Name the concrete product defect or missing
+primitive when a lane fails or blocks; the workflow derives the outcome from
+trusted lane facts.
 
 ```bash
 node --import tsx scripts/mantis/build-telegram-desktop-proof-evidence.mts \

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -740,21 +740,17 @@ jobs:
           sudo install -m 0755 "$tdlib_dir/tdlib-v1.8.0-linux-x64/lib/libtdjson.so" /usr/local/lib/libtdjson.so
           # The Convex credential is the real mutex for the shared Telegram account:
           # a concurrent holder fails this acquire, so no separate run-level lock is
-          # needed. Retry while another run finishes, then fail with a clear reason.
+          # needed. The job timeout bounds the wait while the credential owner
+          # remains the only source of truth.
           echo "lease_file=$credential_dir/lease.json" >> "$GITHUB_OUTPUT"
-          deadline=$(( SECONDS + 15 * 60 ))
           until node --import tsx scripts/e2e/telegram-user-credential.ts lease-restore \
             --user-driver-dir "$credential_dir/user-driver" \
             --desktop-workdir "$credential_dir/desktop" \
             --lease-file "$credential_dir/lease.json" \
             --payload-output "$credential_dir/payload.json" \
             --credential-role ci; do
-            if (( SECONDS >= deadline )); then
-              echo "::error::The shared QA Telegram account is still leased by another run after 15 minutes." >&2
-              exit 1
-            fi
-            echo "Shared QA Telegram account is busy; retrying in 60s." >&2
-            sleep 60
+            echo "Shared QA Telegram account is busy; retrying in 15s." >&2
+            sleep 15
           done
           chmod 0700 "$credential_dir" "$credential_dir/user-driver"
           sut_credential_dir="/tmp/openclaw-mantis-sut-credential-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
@@ -975,14 +971,10 @@ jobs:
             select((.summary | type) == "string" and (.summary | length) <= 4000) |
             select((.comparison.baseline.expected | type) == "string" and (.comparison.baseline.expected | length) <= 1000) |
             select((.comparison.candidate.expected | type) == "string" and (.comparison.candidate.expected | length) <= 1000) |
-            select((.comparison.pass | type) == "boolean") |
-            select((.comparison.candidate.fixed | type) == "boolean") |
             {
               summary,
               baselineExpected: .comparison.baseline.expected,
-              candidateExpected: .comparison.candidate.expected,
-              comparisonPass: .comparison.pass,
-              candidateFixed: .comparison.candidate.fixed
+              candidateExpected: .comparison.candidate.expected
             }
           ' "$agent_manifest" > "$judgment"
           baseline_status="$(sudo jq -r '.comparison.baseline.status' "$agent_manifest")"
@@ -1047,6 +1039,16 @@ jobs:
                 (.artifacts.trimmedVideoCropped.bytes > 10000)
               ' "$verdict" >/dev/null
             fi
+            if [[ "$fact_status" == "blocked" ]]; then
+              sudo jq -e '
+                (.blocked.name | type) == "string" and (.blocked.name | length) > 0 and (.blocked.name | length) <= 200 and
+                (.blocked.reason | type) == "string" and (.blocked.reason | length) > 0 and (.blocked.reason | length) <= 2000
+              ' "$verdict" >/dev/null
+              lane_status="blocked"
+            elif [[ "$fact_status" != "complete" ]]; then
+              lane_status="fail"
+            fi
+            printf -v "${lane}_status" '%s' "$lane_status"
             if [[ "$pre_attestation_failure" != "true" ]]; then
               sudo jq -e --arg lane "$lane" --arg sha "$expected_sha" \
                 '.lane == $lane and .sha == $sha' \
@@ -1104,15 +1106,16 @@ jobs:
           sudo jq --slurpfile judgment "$judgment" '
             .summary = $judgment[0].summary |
             .comparison.baseline.expected = $judgment[0].baselineExpected |
-            .comparison.candidate.expected = $judgment[0].candidateExpected |
-            .comparison.pass = $judgment[0].comparisonPass |
-            .comparison.candidate.fixed = $judgment[0].candidateFixed
+            .comparison.candidate.expected = $judgment[0].candidateExpected
           ' "$manifest" | sudo tee "$trusted_manifest" >/dev/null
           sudo mv "$trusted_manifest" "$manifest"
 
           jq -e '
-            (.comparison.pass == false) or
-            (.comparison.baseline.status == "pass" and .comparison.candidate.status == "pass")
+            (.comparison.outcome == "pass" and .comparison.pass == true and
+              .comparison.baseline.status == "pass" and .comparison.candidate.status == "pass") or
+            (.comparison.outcome == "blocked" and .comparison.pass == false and
+              (.comparison.baseline.status == "blocked" or .comparison.candidate.status == "blocked")) or
+            (.comparison.outcome == "fail" and .comparison.pass == false)
           ' "$manifest" >/dev/null
 
           token="$(sudo jq -r '.sutToken' "$SUT_CREDENTIAL_DIR/credential.json")"
@@ -1223,7 +1226,7 @@ jobs:
             echo "Mantis agent did not produce ${manifest}." >&2
             exit 1
           fi
-          comparison_status="$(jq -r 'if .comparison.pass then "pass" else "fail" end' "$manifest")"
+          comparison_status="$(jq -er '.comparison.outcome | select(. == "pass" or . == "fail" or . == "blocked")' "$manifest")"
           echo "comparison_status=${comparison_status}" >> "$GITHUB_OUTPUT"
 
       - name: Upload Mantis Telegram desktop artifacts
@@ -1326,7 +1329,7 @@ jobs:
             }
 
       - name: Fail when Mantis Telegram desktop proof failed
-        if: ${{ always() && steps.inspect.outputs.output_dir != '' && steps.inspect.outputs.comparison_status != 'pass' }}
+        if: ${{ always() && steps.inspect.outputs.output_dir != '' && steps.inspect.outputs.comparison_status != 'pass' && steps.inspect.outputs.comparison_status != 'blocked' }}
         env:
           COMPARISON_STATUS: ${{ steps.inspect.outputs.comparison_status }}
         run: |

--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -740,15 +740,21 @@ jobs:
           sudo install -m 0755 "$tdlib_dir/tdlib-v1.8.0-linux-x64/lib/libtdjson.so" /usr/local/lib/libtdjson.so
           # The Convex credential is the real mutex for the shared Telegram account:
           # a concurrent holder fails this acquire, so no separate run-level lock is
-          # needed. The job timeout bounds the wait while the credential owner
-          # remains the only source of truth.
+          # needed. Observed 2026-08: a complete proof held the account for 34m;
+          # four hours covers burst backfills while reserving roughly two hours
+          # of the job limit for proof, publication, and cleanup.
           echo "lease_file=$credential_dir/lease.json" >> "$GITHUB_OUTPUT"
+          lease_deadline=$(( SECONDS + 4 * 60 * 60 ))
           until node --import tsx scripts/e2e/telegram-user-credential.ts lease-restore \
             --user-driver-dir "$credential_dir/user-driver" \
             --desktop-workdir "$credential_dir/desktop" \
             --lease-file "$credential_dir/lease.json" \
             --payload-output "$credential_dir/payload.json" \
             --credential-role ci; do
+            if (( SECONDS >= lease_deadline )); then
+              echo "::error::The shared QA Telegram account remained busy for four hours." >&2
+              exit 1
+            fi
             echo "Shared QA Telegram account is busy; retrying in 15s." >&2
             sleep 15
           done
@@ -979,8 +985,8 @@ jobs:
           ' "$agent_manifest" > "$judgment"
           baseline_status="$(sudo jq -r '.comparison.baseline.status' "$agent_manifest")"
           candidate_status="$(sudo jq -r '.comparison.candidate.status' "$agent_manifest")"
-          [[ "$baseline_status" == "pass" || "$baseline_status" == "fail" ]]
-          [[ "$candidate_status" == "pass" || "$candidate_status" == "fail" ]]
+          [[ "$baseline_status" == "pass" || "$baseline_status" == "fail" || "$baseline_status" == "blocked" ]]
+          [[ "$candidate_status" == "pass" || "$candidate_status" == "fail" || "$candidate_status" == "blocked" ]]
           copy_verified_artifacts() {
             local lane="$1"
             local facts_file="$2"
@@ -1045,7 +1051,9 @@ jobs:
                 (.blocked.reason | type) == "string" and (.blocked.reason | length) > 0 and (.blocked.reason | length) <= 2000
               ' "$verdict" >/dev/null
               lane_status="blocked"
-            elif [[ "$fact_status" != "complete" ]]; then
+            elif [[ "$fact_status" == "complete" ]]; then
+              [[ "$lane_status" == "pass" || "$lane_status" == "fail" ]]
+            else
               lane_status="fail"
             fi
             printf -v "${lane}_status" '%s' "$lane_status"

--- a/scripts/e2e/telegram-mantis-lane.ts
+++ b/scripts/e2e/telegram-mantis-lane.ts
@@ -507,7 +507,7 @@ function publishTerminalLaneFacts(params: {
   facts: unknown;
   lane: Lane;
   roots: Roots;
-  status: "fail" | "pass";
+  status: "blocked" | "fail" | "pass";
   sutAttestation?: SutAttestation;
 }): void {
   const privatePublished = path.join(params.roots.sessionRoot, "published", params.lane);
@@ -1309,7 +1309,7 @@ async function finalize(
     facts,
     lane: state.lane,
     roots,
-    status: status === "complete" ? "pass" : "fail",
+    status: status === "complete" ? "pass" : status === "blocked" ? "blocked" : "fail",
     sutAttestation: state.sut.sutAttestation,
   });
   fs.rmSync(activeFile(roots.sessionRoot, state.lane), { force: true });

--- a/scripts/mantis/build-telegram-desktop-proof-evidence.mts
+++ b/scripts/mantis/build-telegram-desktop-proof-evidence.mts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 type CliArgs = Record<string, string>;
 type LaneName = "baseline" | "candidate";
+type LaneStatus = "blocked" | "fail" | "pass";
 type SessionSummary = {
   artifacts?: Partial<
     Record<
@@ -44,6 +45,7 @@ type TelegramDesktopProofManifest = {
   comparison: {
     baseline: { expected: string; status: string; ref?: string; sha?: string };
     candidate: { expected: string; status: string; fixed: boolean; ref?: string; sha?: string };
+    outcome: LaneStatus;
     pass: boolean;
   };
   artifacts: EvidenceArtifact[];
@@ -195,8 +197,8 @@ function copyLaneArtifacts({
   });
 }
 
-function laneStatus(lane: LoadedLane) {
-  return lane.status === "pass" ? "pass" : "fail";
+function laneStatus(lane: LoadedLane): LaneStatus {
+  return lane.status === "pass" || lane.status === "blocked" ? lane.status : "fail";
 }
 
 function requireLaneAttestation(lane: LoadedLane, expectedLane: LaneName, expectedSha: string) {
@@ -216,7 +218,7 @@ function requireLaneAttestation(lane: LoadedLane, expectedLane: LaneName, expect
   throw new Error(`SUT attestation mismatch for ${expectedLane}.`);
 }
 
-function laneArtifactEntries(statuses: Record<LaneName, "pass" | "fail">): EvidenceArtifact[] {
+function laneArtifactEntries(statuses: Record<LaneName, LaneStatus>): EvidenceArtifact[] {
   return LANES.flatMap(({ altPrefix, label, lane }) => [
     {
       alt: `${altPrefix} native Telegram Desktop proof GIF`,
@@ -287,7 +289,12 @@ function buildTelegramDesktopProofManifest({
 }): TelegramDesktopProofManifest {
   const baselineStatus = laneStatus(baseline);
   const candidateStatus = laneStatus(candidate);
-  const pass = baselineStatus === "pass" && candidateStatus === "pass";
+  const outcome =
+    baselineStatus === "fail" || candidateStatus === "fail"
+      ? "fail"
+      : baselineStatus === "blocked" || candidateStatus === "blocked"
+        ? "blocked"
+        : "pass";
   return {
     schemaVersion: 1,
     id: "telegram-desktop-proof",
@@ -309,7 +316,8 @@ function buildTelegramDesktopProofManifest({
         status: candidateStatus,
         fixed: candidateStatus === "pass",
       },
-      pass,
+      outcome,
+      pass: outcome === "pass",
     },
     artifacts: laneArtifactEntries({ baseline: baselineStatus, candidate: candidateStatus }),
   };

--- a/scripts/mantis/publish-pr-evidence.mjs
+++ b/scripts/mantis/publish-pr-evidence.mjs
@@ -27,7 +27,7 @@ import { readBoundedResponseText } from "../lib/bounded-response.mjs";
 /**
  * @typedef {{
  *   artifacts: EvidenceArtifact[],
- *   comparison: { baseline?: EvidenceLane, candidate: EvidenceLane, pass?: boolean },
+ *   comparison: { baseline?: EvidenceLane, candidate: EvidenceLane, outcome?: "blocked" | "fail" | "pass", pass?: boolean },
  *   id: string,
  *   manifestDir: string,
  *   scenario: string,
@@ -385,6 +385,10 @@ function publicSummary(manifest) {
   return manifest.summary ?? "Mantis captured QA evidence for this scenario.";
 }
 function overallStatus(manifest) {
+  const outcome = manifest.comparison?.outcome;
+  if (outcome === "blocked" || outcome === "fail" || outcome === "pass") {
+    return outcome;
+  }
   const pass = manifest.comparison?.pass;
   return typeof pass === "boolean" ? String(pass) : "";
 }
@@ -394,6 +398,9 @@ function overallStatus(manifest) {
  */
 export function shouldPublishPrComment(manifest, { requestSource } = {}) {
   if (!isTelegramDesktopProof(manifest) || hasVisibleProofArtifacts(manifest)) {
+    return true;
+  }
+  if (manifest.comparison?.outcome === "blocked") {
     return true;
   }
   if (requestSource === "pull_request_target") {

--- a/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
+++ b/test/scripts/mantis-build-telegram-desktop-proof-evidence.test.ts
@@ -20,7 +20,11 @@ afterEach(() => {
 function makeLane(
   name: "baseline" | "candidate",
   sha: string,
-  options: { diagnosticOnly?: boolean; status?: "pass" | "fail"; withGif?: boolean } = {},
+  options: {
+    diagnosticOnly?: boolean;
+    status?: "blocked" | "fail" | "pass";
+    withGif?: boolean;
+  } = {},
 ) {
   const repo = mkdtempSync(path.join(tmpdir(), `mantis-telegram-${name}-repo-`));
   tempDirs.push(repo);
@@ -188,6 +192,7 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     ]);
 
     expect(manifest.comparison.pass).toBe(false);
+    expect(manifest.comparison.outcome).toBe("fail");
     expect(manifest.artifacts).toContainEqual(
       expect.objectContaining({
         lane: "candidate",
@@ -198,6 +203,43 @@ describe("scripts/mantis/build-telegram-desktop-proof-evidence", () => {
     expect(
       readFileSync(path.join(outputDir, "candidate", "telegram-desktop-proof.png"), "utf8"),
     ).toBe("candidate png");
+  });
+
+  it("preserves a blocked lane as a distinct non-failure outcome", () => {
+    const baselineSha = "a".repeat(40);
+    const candidateSha = "b".repeat(40);
+    const baseline = makeLane("baseline", baselineSha, { status: "blocked", withGif: false });
+    const candidate = makeLane("candidate", candidateSha, { status: "blocked", withGif: false });
+    const outputDir = mkdtempSync(path.join(tmpdir(), "mantis-telegram-blocked-proof-"));
+    tempDirs.push(outputDir);
+
+    const { manifest } = writeTelegramDesktopProofEvidence([
+      "--output-dir",
+      outputDir,
+      "--baseline-repo-root",
+      baseline.repo,
+      "--baseline-output-dir",
+      baseline.outputDir,
+      "--baseline-sha",
+      baselineSha,
+      "--baseline-status",
+      "blocked",
+      "--candidate-repo-root",
+      candidate.repo,
+      "--candidate-output-dir",
+      candidate.outputDir,
+      "--candidate-sha",
+      candidateSha,
+      "--candidate-status",
+      "blocked",
+    ]);
+
+    expect(manifest.comparison).toMatchObject({
+      baseline: { status: "blocked" },
+      candidate: { status: "blocked" },
+      outcome: "blocked",
+      pass: false,
+    });
   });
 
   it("preserves an unattested diagnostic-only startup failure", () => {

--- a/test/scripts/mantis-publish-pr-evidence.test.ts
+++ b/test/scripts/mantis-publish-pr-evidence.test.ts
@@ -490,6 +490,43 @@ describe("scripts/mantis/publish-pr-evidence", () => {
     expect(shouldPublishPrComment(manifest, { requestSource: "pull_request_target" })).toBe(false);
   });
 
+  it("publishes a visible blocked stop-report without proof media", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "mantis-evidence-test-"));
+    tempDirs.push(dir);
+    const manifestPath = path.join(dir, "mantis-evidence.json");
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        artifacts: [],
+        comparison: {
+          baseline: { expected: "typed reasoning chunks", status: "blocked" },
+          candidate: { expected: "typed reasoning chunks", status: "blocked" },
+          outcome: "blocked",
+          pass: false,
+        },
+        id: "telegram-desktop-proof",
+        scenario: "telegram-desktop-proof",
+        schemaVersion: 1,
+        summary:
+          "Mantis could not prove this change because the harness cannot emit typed reasoning chunks.",
+        title: "Mantis Telegram Desktop Proof",
+      }),
+    );
+
+    const manifest = loadEvidenceManifest(manifestPath);
+    const body = renderEvidenceComment({
+      manifest,
+      marker: "<!-- mantis-telegram-desktop-proof -->",
+      rawBase: "https://artifacts.openclaw.ai/mantis/telegram-desktop/pr-1/run-1",
+      requestSource: "pull_request_target",
+    });
+
+    expect(body).toContain("- Overall: `blocked`");
+    expect(body).toContain("harness cannot emit typed reasoning chunks");
+    expect(shouldPublishPrComment(manifest, { requestSource: "issue_comment" })).toBe(true);
+    expect(shouldPublishPrComment(manifest, { requestSource: "pull_request_target" })).toBe(true);
+  });
+
   it("rejects artifact paths that escape the manifest directory", () => {
     const dir = mkdtempSync(path.join(tmpdir(), "mantis-evidence-test-"));
     tempDirs.push(dir);

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -146,8 +146,9 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(workflow.permissions?.actions).toBe("read");
     expect(leaseRun).toContain("lease-restore");
     expect(leaseRun).toContain("until node --import tsx");
-    expect(leaseRun).not.toContain("deadline=");
-    expect(leaseRun).not.toContain("still leased by another run after");
+    expect(leaseRun).toContain("lease_deadline=$(( SECONDS + 4 * 60 * 60 ))");
+    expect(leaseRun).toContain("remained busy for four hours");
+    expect(leaseRun).not.toContain("15 * 60");
     expect(leaseRun).toContain("sleep 15");
     expect(leaseRun.indexOf('echo "lease_file=$credential_dir/lease.json"')).toBeLessThan(
       leaseRun.indexOf("until node --import tsx"),
@@ -160,6 +161,8 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     const fail = workflowStep("Fail when Mantis Telegram desktop proof failed");
 
     expect(trusted).toContain('lane_status="blocked"');
+    expect(trusted).toContain('|| "$baseline_status" == "blocked"');
+    expect(trusted).toContain('[[ "$lane_status" == "pass" || "$lane_status" == "fail" ]]');
     expect(trusted).toContain('.comparison.outcome == "blocked"');
     expect(trusted).not.toContain("comparisonPass");
     expect(inspect).toContain(".comparison.outcome");

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -146,12 +146,24 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(workflow.permissions?.actions).toBe("read");
     expect(leaseRun).toContain("lease-restore");
     expect(leaseRun).toContain("until node --import tsx");
-    expect(leaseRun).toContain("deadline=$(( SECONDS + 15 * 60 ))");
-    expect(leaseRun).toContain("still leased by another run after 15 minutes");
-    expect(leaseRun).toContain("sleep 60");
+    expect(leaseRun).not.toContain("deadline=");
+    expect(leaseRun).not.toContain("still leased by another run after");
+    expect(leaseRun).toContain("sleep 15");
     expect(leaseRun.indexOf('echo "lease_file=$credential_dir/lease.json"')).toBeLessThan(
       leaseRun.indexOf("until node --import tsx"),
     );
+  });
+
+  it("reports an honest blocked proof without failing the workflow", () => {
+    const trusted = workflowStep("Restore and validate trusted lane evidence").run ?? "";
+    const inspect = workflowStep("Inspect Mantis evidence manifest").run ?? "";
+    const fail = workflowStep("Fail when Mantis Telegram desktop proof failed");
+
+    expect(trusted).toContain('lane_status="blocked"');
+    expect(trusted).toContain('.comparison.outcome == "blocked"');
+    expect(trusted).not.toContain("comparisonPass");
+    expect(inspect).toContain(".comparison.outcome");
+    expect(fail.if).toContain("steps.inspect.outputs.comparison_status != 'blocked'");
   });
 
   it("releases the runner Telegram QA lease after the agent", () => {
@@ -1021,7 +1033,9 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(laneScript).toContain("/proc/self/fd/${descriptor}");
     expect(laneScript).not.toContain("readRecorderSession");
     expect(laneScript).toContain('"artifacts"');
-    expect(laneScript).toContain('status: status === "complete" ? "pass" : "fail"');
+    expect(laneScript).toContain(
+      'status: status === "complete" ? "pass" : status === "blocked" ? "blocked" : "fail"',
+    );
     expect(workflow).toContain("if .sutAttestation == null then");
     expect(workflow).toContain('.status == "infra-error" and .artifacts == {} and .sendCount == 0');
     expect(workflow).toContain(


### PR DESCRIPTION
## Summary

- wait on the authoritative Convex Telegram-user lease with a four-hour burst window and reserved proof/cleanup time
- preserve trusted `blocked` lane outcomes instead of converting them to failed proof
- publish artifactless blocked stop-reports while keeping real comparison failures red

## Root cause

Burst backfills outlived an arbitrary 15-minute lease retry deadline. Separately, the lane producer and evidence builder collapsed `blocked` into `fail`, so an honest missing-harness-primitive result failed without a useful PR outcome.

Architectural owner: the Telegram Mantis lane result and desktop-proof workflow. Canonical fix: keep `blocked` through the producer, admit it only until trusted lane facts confirm it, derive the comparison outcome from trusted facts plus complete-lane agent judgment, and treat only `fail` as workflow failure. No GitHub concurrency queue or run polling added.

## Validation

- `57/57` focused Vitest tests pass
- `pnpm check:workflows`
- focused Oxlint
- `pnpm check:test-types`
- `git diff --check`
- exact-head credentialed Mantis run [32445300717](https://github.com/openclaw/openclaw/actions/runs/32445300717): green in 14m52s; trusted baseline/candidate facts both `blocked`; manifest `outcome: blocked`, `pass: false`; evidence validation, upload, cleanup, lease release, and publisher all passed; failure step skipped
- exact-head workflow-only short circuit [32445218863](https://github.com/openclaw/openclaw/actions/runs/32445218863): green; reported no visible Telegram change

Full `pnpm exec tsgo --noEmit` remains red on 83 existing missing `.mjs` declaration errors outside this diff.

## Diff accounting

Production/workflow/prompt: explicit three-state outcome, trusted blocked validation, and bounded lease reserve. Tests cover producer preservation, manifest outcome, publisher visibility, and workflow termination. No application runtime path changed.

## Codex contract

Checked `../codex/codex-rs/cli/src/main.rs` output-schema CLI wiring, `../codex/codex-rs/exec/tests/suite/output_schema.rs` strict schema request behavior, and `../codex/codex-rs/codex-api/src/common.rs` response text-format construction. This change does not alter the Codex protocol; it changes the Mantis-produced evidence lifecycle.