### PR TITLE
fix(qa): own container first-run onboarding journey

### DIFF
--- a/extensions/qa-lab/src/profile-selection.test.ts
+++ b/extensions/qa-lab/src/profile-selection.test.ts
@@ -52,6 +52,28 @@ describe("taxonomy profile scenario selection", () => {
     ).not.toContainEqual(expect.objectContaining({ sourcePath: unrelatedRefs[0] }));
   });
 
+  it("selects the packaged first-run journey for release container setup", () => {
+    const catalog = readQaScenarioPack().scenarios;
+    const report = readQaScorecardTaxonomyReport(catalog);
+    const onboarding = catalog.find(
+      (scenario) => scenario.id === "docker-npm-onboard-channel-agent",
+    );
+    const systemAgent = catalog.find((scenario) => scenario.id === "docker-system-agent-first-run");
+
+    expect(onboarding?.coverage?.primary).toContain("containers.first-run-onboarding");
+    expect(systemAgent?.coverage?.primary).not.toContain("containers.first-run-onboarding");
+    expect(systemAgent?.coverage?.secondary).toContain("containers.first-run-onboarding");
+    expect(report.validationIssues).not.toContainEqual(
+      expect.objectContaining({
+        code: "coverage-id-missing-primary-inventory",
+        ref: "containers.first-run-onboarding",
+      }),
+    );
+    expect(report.profiles.find((profile) => profile.id === "release")?.scenarioRefs).toContain(
+      onboarding?.sourcePath,
+    );
+  });
+
   it("derives channel defaults from catalog metadata and lane constraints", () => {
     const liveTelegram = resolveLiveTransportQaScenarioIds({
       channelId: "telegram",

--- a/qa/scenarios/runtime/docker-npm-onboard-channel-agent.yaml
+++ b/qa/scenarios/runtime/docker-npm-onboard-channel-agent.yaml
@@ -7,7 +7,6 @@ scenario:
   coverage:
     primary:
       - containers.docker-backed-agent-sandbox-support
-    secondary:
       - containers.first-run-onboarding
   objective: Verify a package-installed Docker runner can complete non-interactive onboarding, configure a channel, start Gateway-backed agent behavior, and complete a mocked model turn.
   successCriteria:


### PR DESCRIPTION
## Summary

- promote the executable package-installed Docker onboarding journey to the primary owner of `containers.first-run-onboarding`
- keep Docker sandbox support as the same scenario's other primary coverage
- lock taxonomy validation and release-profile selection in a focused QA Lab regression

## Root cause

`docker-npm-onboard-channel-agent` exercised first-run package onboarding, but catalogued that behavior as secondary coverage. QA profile selection only includes primary owners, so release/container profiles could omit the repository's real package-installed first-run journey while still reporting the taxonomy ID as covered.

## Verification

- `pnpm exec vitest run extensions/qa-lab/src/profile-selection.test.ts --reporter=dot` (5 passed)
- `pnpm openclaw qa coverage` (26 focused QA checks passed before rebase; primary package journey and secondary system-agent journey reported)
- Blacksmith Testbox full changed gate: https://github.com/openclaw/openclaw/actions/runs/32442845895 (passed, 23m29s)
- Codex autoreview: clean, 0.99
- TruffleHog through autoreview: clean

The final rebase only incorporated nonintersecting context-engine and package-doc changes; the focused selection test was rerun on the exact pushed head.