### PR TITLE
improve(agents): avoid repeated model suppression planning

### DIFF
--- a/src/agents/model-suppression.test.ts
+++ b/src/agents/model-suppression.test.ts
@@ -8,11 +8,36 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 const mocks = vi.hoisted(() => ({
   buildManifestBuiltInModelSuppressionResolver: vi.fn(),
+  resolvePluginControlPlaneFingerprint: vi.fn(),
+  resolvePluginMetadataEnvFingerprint: vi.fn(),
 }));
 
 vi.mock("../plugins/manifest-model-suppression.js", () => ({
   buildManifestBuiltInModelSuppressionResolver: mocks.buildManifestBuiltInModelSuppressionResolver,
 }));
+
+vi.mock("../plugins/plugin-control-plane-context.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../plugins/plugin-control-plane-context.js")>();
+  mocks.resolvePluginControlPlaneFingerprint.mockImplementation(
+    actual.resolvePluginControlPlaneFingerprint,
+  );
+  return {
+    ...actual,
+    resolvePluginControlPlaneFingerprint: mocks.resolvePluginControlPlaneFingerprint,
+  };
+});
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
+  mocks.resolvePluginMetadataEnvFingerprint.mockImplementation(
+    actual.resolvePluginMetadataEnvFingerprint,
+  );
+  return {
+    ...actual,
+    resolvePluginMetadataEnvFingerprint: mocks.resolvePluginMetadataEnvFingerprint,
+  };
+});
 
 import {
   getCurrentPluginMetadataSnapshot,
@@ -131,7 +156,7 @@ describe("model suppression", () => {
     expect(secondResolver).toHaveBeenCalledOnce();
   });
 
-  it("keeps concurrent scoped suppression resolvers isolated from process-current metadata", async () => {
+  it("reuses each concurrent generation's suppression resolver across A/B/A interleaving", async () => {
     const config = {} satisfies OpenClawConfig;
     const snapshotA = createPluginMetadataSnapshot({
       config,
@@ -165,7 +190,14 @@ describe("model suppression", () => {
         });
         markAReady();
         await holdA;
-        return result;
+        return [
+          result,
+          shouldSuppressBuiltInModelCore({
+            provider: "openai",
+            id: "generation-model",
+            config,
+          }),
+        ];
       },
     );
     await aReady;
@@ -181,8 +213,72 @@ describe("model suppression", () => {
     );
     releaseA();
 
-    await expect(resultA).resolves.toBe(true);
+    await expect(resultA).resolves.toEqual([true, true]);
     expect(resultB).toBe(false);
+    expect(mocks.buildManifestBuiltInModelSuppressionResolver).toHaveBeenCalledTimes(2);
+  });
+
+  it("keys generation resolvers by config identity and workspace", () => {
+    const configA = {} satisfies OpenClawConfig;
+    const configB = {} satisfies OpenClawConfig;
+    const snapshot = createPluginMetadataSnapshot({
+      config: configA,
+      manifestRegistry: { plugins: [], diagnostics: [] },
+    });
+    mocks.buildManifestBuiltInModelSuppressionResolver.mockReturnValue(() => undefined);
+
+    const check = (config: OpenClawConfig, workspaceDir: string) =>
+      withPluginRuntimeGenerationScope({ config, metadataSnapshot: snapshot }, () =>
+        shouldSuppressBuiltInModelCore({
+          provider: "openai",
+          id: "generation-model",
+          config,
+          workspaceDir,
+        }),
+      );
+
+    expect(check(configA, "/workspace/a")).toBe(false);
+    expect(check(configB, "/workspace/a")).toBe(false);
+    expect(check(configA, "/workspace/b")).toBe(false);
+    expect(check(configA, "/workspace/a")).toBe(false);
+    expect(mocks.buildManifestBuiltInModelSuppressionResolver).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not recompute content fingerprints on a stable generation cache hit", () => {
+    const config = {} satisfies OpenClawConfig;
+    const snapshot = createPluginMetadataSnapshot({
+      config,
+      manifestRegistry: { plugins: [], diagnostics: [] },
+    });
+    mocks.buildManifestBuiltInModelSuppressionResolver.mockReturnValue(() => undefined);
+
+    withPluginRuntimeGenerationScope({ config, metadataSnapshot: snapshot }, () => {
+      shouldSuppressBuiltInModelCore({ provider: "openai", id: "gpt-5.3", config });
+      mocks.resolvePluginControlPlaneFingerprint.mockClear();
+      mocks.resolvePluginMetadataEnvFingerprint.mockClear();
+
+      shouldSuppressBuiltInModelCore({ provider: "anthropic", id: "claude-4", config });
+
+      expect(mocks.resolvePluginControlPlaneFingerprint.mock.calls.length).toBe(0);
+      expect(mocks.resolvePluginMetadataEnvFingerprint.mock.calls.length).toBe(0);
+    });
+  });
+
+  it("rebuilds a generation resolver after plugin metadata lifecycle caches clear", () => {
+    const config = {} satisfies OpenClawConfig;
+    const snapshot = createPluginMetadataSnapshot({
+      config,
+      manifestRegistry: { plugins: [], diagnostics: [] },
+    });
+    mocks.buildManifestBuiltInModelSuppressionResolver.mockReturnValue(() => undefined);
+
+    withPluginRuntimeGenerationScope({ config, metadataSnapshot: snapshot }, () => {
+      shouldSuppressBuiltInModelCore({ provider: "openai", id: "gpt-5.3", config });
+      clearPluginMetadataLifecycleCaches();
+      shouldSuppressBuiltInModelCore({ provider: "anthropic", id: "claude-4", config });
+    });
+
+    expect(mocks.buildManifestBuiltInModelSuppressionResolver).toHaveBeenCalledTimes(2);
   });
 
   it("refreshes manifest suppression resolver when process env plugin metadata inputs change", () => {

--- a/src/agents/model-suppression.test.ts
+++ b/src/agents/model-suppression.test.ts
@@ -8,42 +8,19 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 const mocks = vi.hoisted(() => ({
   buildManifestBuiltInModelSuppressionResolver: vi.fn(),
-  resolvePluginControlPlaneFingerprint: vi.fn(),
-  resolvePluginMetadataEnvFingerprint: vi.fn(),
 }));
 
 vi.mock("../plugins/manifest-model-suppression.js", () => ({
   buildManifestBuiltInModelSuppressionResolver: mocks.buildManifestBuiltInModelSuppressionResolver,
 }));
 
-vi.mock("../plugins/plugin-control-plane-context.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../plugins/plugin-control-plane-context.js")>();
-  mocks.resolvePluginControlPlaneFingerprint.mockImplementation(
-    actual.resolvePluginControlPlaneFingerprint,
-  );
-  return {
-    ...actual,
-    resolvePluginControlPlaneFingerprint: mocks.resolvePluginControlPlaneFingerprint,
-  };
-});
-
-vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
-  mocks.resolvePluginMetadataEnvFingerprint.mockImplementation(
-    actual.resolvePluginMetadataEnvFingerprint,
-  );
-  return {
-    ...actual,
-    resolvePluginMetadataEnvFingerprint: mocks.resolvePluginMetadataEnvFingerprint,
-  };
-});
-
 import {
   getCurrentPluginMetadataSnapshot,
   setCurrentPluginMetadataSnapshot,
 } from "../plugins/current-plugin-metadata-snapshot.js";
+import * as pluginControlPlaneContext from "../plugins/plugin-control-plane-context.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import * as pluginMetadataSnapshot from "../plugins/plugin-metadata-snapshot.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import {
   buildShouldSuppressBuiltInModelCore,
@@ -59,6 +36,7 @@ describe("model suppression", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     setCurrentPluginMetadataSnapshot(undefined);
     if (originalBundledPluginsDir === undefined) {
       delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
@@ -251,16 +229,21 @@ describe("model suppression", () => {
       manifestRegistry: { plugins: [], diagnostics: [] },
     });
     mocks.buildManifestBuiltInModelSuppressionResolver.mockReturnValue(() => undefined);
+    const controlPlaneFingerprint = vi.spyOn(
+      pluginControlPlaneContext,
+      "resolvePluginControlPlaneFingerprint",
+    );
+    const envFingerprint = vi.spyOn(pluginMetadataSnapshot, "resolvePluginMetadataEnvFingerprint");
 
     withPluginRuntimeGenerationScope({ config, metadataSnapshot: snapshot }, () => {
       shouldSuppressBuiltInModelCore({ provider: "openai", id: "gpt-5.3", config });
-      mocks.resolvePluginControlPlaneFingerprint.mockClear();
-      mocks.resolvePluginMetadataEnvFingerprint.mockClear();
+      controlPlaneFingerprint.mockClear();
+      envFingerprint.mockClear();
 
       shouldSuppressBuiltInModelCore({ provider: "anthropic", id: "claude-4", config });
 
-      expect(mocks.resolvePluginControlPlaneFingerprint.mock.calls.length).toBe(0);
-      expect(mocks.resolvePluginMetadataEnvFingerprint.mock.calls.length).toBe(0);
+      expect(controlPlaneFingerprint).not.toHaveBeenCalled();
+      expect(envFingerprint).not.toHaveBeenCalled();
     });
   });
 

--- a/src/agents/model-suppression.ts
+++ b/src/agents/model-suppression.ts
@@ -6,29 +6,41 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeLowercaseStringOrEmpty } from "../../packages/normalization-core/src/string-coerce.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import {
+  getCurrentPluginMetadataSnapshot,
+  isCurrentPluginMetadataSnapshotRuntimeGeneration,
+} from "../plugins/current-plugin-metadata-snapshot.js";
 import { buildManifestBuiltInModelSuppressionResolver } from "../plugins/manifest-model-suppression.js";
 import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
 import { registerPluginMetadataProcessMemoLifecycleClear } from "../plugins/plugin-metadata-lifecycle.js";
 import { resolvePluginMetadataEnvFingerprint } from "../plugins/plugin-metadata-snapshot.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 
 type ManifestSuppressionResolver = ReturnType<typeof buildManifestBuiltInModelSuppressionResolver>;
 
-type CachedManifestSuppressionResolver = {
+type CachedStandaloneManifestSuppressionResolver = {
   config: OpenClawConfig | undefined;
   controlPlaneFingerprint: string;
   cwd: string;
   envFingerprint: string;
-  metadataSnapshot: unknown;
+  metadataSnapshot: PluginMetadataSnapshot | undefined;
   resolver: ManifestSuppressionResolver;
   workspaceDir: string | undefined;
 };
 
-let cachedManifestSuppressionResolver: CachedManifestSuppressionResolver | undefined;
+const configlessRuntimeGeneration = {};
+let runtimeGenerationResolvers = new WeakMap<
+  PluginMetadataSnapshot,
+  WeakMap<object, Map<string | undefined, ManifestSuppressionResolver>>
+>();
+let cachedStandaloneManifestSuppressionResolver:
+  | CachedStandaloneManifestSuppressionResolver
+  | undefined;
 
 /** Clear cached manifest suppression resolver state for tests and metadata lifecycle resets. */
 function clearModelSuppressionResolverCache(): void {
-  cachedManifestSuppressionResolver = undefined;
+  runtimeGenerationResolvers = new WeakMap();
+  cachedStandaloneManifestSuppressionResolver = undefined;
 }
 
 registerPluginMetadataProcessMemoLifecycleClear(clearModelSuppressionResolverCache);
@@ -38,7 +50,33 @@ function resolveCachedManifestSuppressionResolver(params: {
   env: NodeJS.ProcessEnv;
   workspaceDir?: string;
 }): ManifestSuppressionResolver {
-  const cached = cachedManifestSuppressionResolver;
+  const metadataSnapshot = getCurrentPluginMetadataSnapshot(params);
+  if (metadataSnapshot && isCurrentPluginMetadataSnapshotRuntimeGeneration(metadataSnapshot)) {
+    let byConfig = runtimeGenerationResolvers.get(metadataSnapshot);
+    if (!byConfig) {
+      byConfig = new WeakMap();
+      runtimeGenerationResolvers.set(metadataSnapshot, byConfig);
+    }
+    const configKey = params.config ?? configlessRuntimeGeneration;
+    let byWorkspace = byConfig.get(configKey);
+    if (!byWorkspace) {
+      byWorkspace = new Map();
+      byConfig.set(configKey, byWorkspace);
+    }
+    const cached = byWorkspace.get(params.workspaceDir);
+    if (cached) {
+      return cached;
+    }
+    const resolver = buildManifestBuiltInModelSuppressionResolver({
+      env: params.env,
+      ...(params.config ? { config: params.config } : {}),
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    });
+    byWorkspace.set(params.workspaceDir, resolver);
+    return resolver;
+  }
+
+  const cached = cachedStandaloneManifestSuppressionResolver;
   const controlPlaneFingerprint = resolvePluginControlPlaneFingerprint({
     ...(params.config ? { config: params.config } : {}),
     env: params.env,
@@ -46,7 +84,6 @@ function resolveCachedManifestSuppressionResolver(params: {
   });
   const cwd = process.cwd();
   const envFingerprint = resolvePluginMetadataEnvFingerprint(params.env);
-  const metadataSnapshot = getCurrentPluginMetadataSnapshot(params);
   if (
     cached !== undefined &&
     cached.config === params.config &&
@@ -63,7 +100,7 @@ function resolveCachedManifestSuppressionResolver(params: {
     ...(params.config ? { config: params.config } : {}),
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   });
-  cachedManifestSuppressionResolver = {
+  cachedStandaloneManifestSuppressionResolver = {
     config: params.config,
     controlPlaneFingerprint,
     cwd,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where overlapping plugin runtime generations repeatedly rebuilt the built-in model suppression plan. Alternating old and new generations evicted one global cache slot, so model filtering could redo full manifest suppression planning on every call even when both generations were immutable.

## Why This Change Was Made

Immutable runtime generations now cache suppression resolvers by metadata snapshot, config identity, and workspace. Old and new generations can coexist without eviction, stable hits skip control-plane and environment fingerprint hashing, and weak identity keys do not retain retired generations. Callers outside an immutable generation keep the previous fingerprinted fallback so in-place config, environment, working-directory, workspace, and current-snapshot changes still invalidate correctly.

The positive production delta represents the two distinct ownership contracts and the snapshot/config/workspace identity dimensions; the existing generic config cache does not support the snapshot layer or configless generation calls.

## User Impact

Model selection, catalog filtering, and related agent paths avoid repeated plugin manifest planning during configuration reload overlap. Suppression behavior, model visibility, configuration, and public APIs are unchanged.

Production LOC: +45/-8 (net +37) | Tests: +99/-3 (net +96)

AI-assisted: yes. The cache ownership, generation/config/workspace boundaries, tests, and final diff were reviewed directly.

## Evidence

- Pre-fix A/B/A generation regression: three resolver builds; expected two. A stable generation hit also called both content-fingerprint functions.
- Post-fix: A/B/A builds exactly two resolvers, each generation returns its own result, and stable hits call neither fingerprint function.
- Narrow `vi.spyOn` counters (no `importOriginal`) prove fingerprint avoidance without partial-mocking broad plugin modules. Added coverage also proves config-identity/workspace partitioning and lifecycle-clear rebuilding while retaining existing mutable config and environment invalidation tests.
- Focused A/B/A benchmark, 25,000 rounds / 100,000 resolver calls: current main `1.095 s` elapsed and `156,552 KiB` max RSS; candidate `0.662 s` elapsed and `153,932 KiB` max RSS. That is `39.5%` lower elapsed time and `2,620 KiB` lower max RSS in the same orb.
- `node scripts/run-vitest.mjs src/agents/model-suppression.test.ts src/plugins/manifest-model-suppression.test.ts src/plugins/current-plugin-metadata-snapshot.test.ts src/agents/model-catalog.test.ts src/agents/embedded-agent-runner/model.generation-scope.test.ts` — 79/79 passed across three shards.
- Post-rebase focused sanity — 12/12 passed.
- `pnpm tsgo:core` and the affected core-test typecheck shard — passed.
- `oxfmt`, `git diff --check`, and changed-file guards — passed.
- TruffleHog changed-content scan — clean.
- Fresh autoreview on the final patch — no accepted/actionable findings; patch correct, confidence 0.98.
