### PR TITLE
fix(cli): reject an unconfigured --agent across every operator selector

### DIFF
--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -876,11 +876,16 @@ describe("exec approvals CLI", () => {
     });
   });
 
-  it("defaults allowlist add to wildcard agent", async () => {
+  it.each([
+    { label: "by default", agentArgs: [] as string[], agentKey: "*" },
+    { label: "for the explicit wildcard", agentArgs: ["--agent", "*"], agentKey: "*" },
+    { label: "for a configured agent", agentArgs: ["--agent", "main"], agentKey: "main" },
+  ])("adds an allowlist entry $label", async ({ agentArgs, agentKey }) => {
+    readBestEffortConfig.mockResolvedValue({ agents: { list: [{ id: "main" }] } });
     const updateExecApprovals = vi.mocked(execApprovals.updateExecApprovals);
     updateExecApprovals.mockClear();
 
-    await runApprovalsCommand(["approvals", "allowlist", "add", "/usr/bin/uname"]);
+    await runApprovalsCommand(["approvals", "allowlist", "add", "/usr/bin/uname", ...agentArgs]);
 
     expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "exec.approvals.set")).toBe(
       false,
@@ -889,11 +894,55 @@ describe("exec approvals CLI", () => {
     expect(updateExecApprovals).toHaveBeenCalledWith(
       expect.objectContaining({ baseHash: "hash-local" }),
     );
-    if (requireRecord(saved.agents, "saved agents")["*"] === undefined) {
-      throw new Error("Expected wildcard exec approval agent entry");
+    if (requireRecord(saved.agents, "saved agents")[agentKey] === undefined) {
+      throw new Error(`Expected ${agentKey} exec approval agent entry`);
     }
+    expect(readBestEffortConfig).toHaveBeenCalledTimes(agentKey === "main" ? 1 : 0);
     expect(loggedOutput()).toContain("Writing local approvals.");
   });
+
+  it.each(["add", "remove"])(
+    "rejects an unknown agent before allowlist %s persistence",
+    async (operation) => {
+      readBestEffortConfig.mockResolvedValue({ agents: { list: [{ id: "main" }] } });
+      const updateExecApprovals = vi.mocked(execApprovals.updateExecApprovals);
+      updateExecApprovals.mockClear();
+
+      await expect(
+        runApprovalsCommand([
+          "approvals",
+          "allowlist",
+          operation,
+          "/usr/bin/uname",
+          "--agent",
+          "nope-agent",
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(runtimeErrors).toStrictEqual([
+        'Unknown agent id "nope-agent". Run openclaw agents list to see configured agents.',
+      ]);
+      expect(updateExecApprovals).not.toHaveBeenCalled();
+      expect(localSnapshot.file.agents).toEqual({});
+      expect(loggedOutput()).not.toContain("Writing local approvals.");
+    },
+  );
+
+  it.each(["add", "remove"])(
+    "rejects a blank agent before allowlist %s persistence",
+    async (operation) => {
+      const updateExecApprovals = vi.mocked(execApprovals.updateExecApprovals);
+      updateExecApprovals.mockClear();
+
+      await expect(
+        runApprovalsCommand(["approvals", "allowlist", operation, "/usr/bin/uname", "--agent", ""]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(runtimeErrors).toStrictEqual(["--agent must not be blank"]);
+      expect(updateExecApprovals).not.toHaveBeenCalled();
+      expect(localSnapshot.file.agents).toEqual({});
+    },
+  );
 
   it.each([
     {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -22,6 +22,7 @@ import {
   renderTerminalSafeTable,
 } from "../../packages/terminal-core/src/table.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
+import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
 import { readBestEffortConfig, type OpenClawConfig } from "../config/config.js";
 import { ADMIN_SCOPE, APPROVALS_SCOPE, type OperatorScope } from "../gateway/method-scopes.js";
 import { readFileDescriptorBounded } from "../infra/boundary-file-read.js";
@@ -1011,8 +1012,7 @@ async function saveSnapshot(
 }
 
 function resolveAgentKey(value?: string | null): string {
-  const trimmed = normalizeOptionalString(value) ?? "";
-  return trimmed ? trimmed : "*";
+  return value == null ? "*" : requireTrimmedNonEmpty(value, "--agent must not be blank");
 }
 
 function normalizeAllowlistEntry(entry: { pattern?: string } | null): string | null {
@@ -1048,6 +1048,15 @@ async function loadWritableAllowlistAgent(opts: ExecApprovalsCliOpts): Promise<{
   agent: ExecApprovalsAgent;
   allowlistEntries: NonNullable<ExecApprovalsAgent["allowlist"]>;
 }> {
+  const agentKey = resolveAgentKey(opts.agent);
+  if (agentKey !== "*") {
+    const source = !opts.gateway && !opts.node ? "local" : opts.gateway ? "gateway" : "node";
+    const { config } = await loadConfigForApprovalsTarget({ opts, source });
+    if (!config) {
+      exitWithError("Config unavailable; cannot validate --agent.");
+    }
+    resolveConfiguredAgentId(config, agentKey);
+  }
   const { snapshot, nodeId, source, targetLabel, baseHash, kind } =
     await loadWritableSnapshotTarget(opts);
   if (kind === "native" || !isFileApprovalsSnapshot(snapshot)) {
@@ -1058,7 +1067,6 @@ async function loadWritableAllowlistAgent(opts: ExecApprovalsCliOpts): Promise<{
   const file = snapshot.file;
   file.version = 1;
 
-  const agentKey = resolveAgentKey(opts.agent);
   const agent = ensureAgent(file, agentKey);
   const allowlistEntries = Array.isArray(agent.allowlist) ? agent.allowlist : [];
 

--- a/src/cli/hooks-cli.toggle.test.ts
+++ b/src/cli/hooks-cli.toggle.test.ts
@@ -424,6 +424,28 @@ describe("hooks CLI metadata config keys", () => {
     expect(explicitFleet).toEqual(initialConfig);
   });
 
+  it("rejects a blank hook agent before resolving a workspace", async () => {
+    configureExplicitFleet();
+
+    await expect(
+      createHooksProgram().parseAsync(["hooks", "list", "--agent", "", "--json"], {
+        from: "user",
+      }),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(capture.runtimeErrors.at(-1)).toContain("--agent must not be blank");
+    expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("rejects a blank parent hook agent before dispatching a subcommand", async () => {
+    await expect(
+      createHooksProgram().parseAsync(["hooks", "--agent", "", "list"], { from: "user" }),
+    ).rejects.toThrow("--agent must not be blank");
+
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
   it("keeps the explicit owner in the offline hooks fallback", async () => {
     const explicitFleet = configureExplicitFleet();
 

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -78,6 +78,9 @@ type HooksReportTarget = {
 
 function resolveHooksReportTarget(config: OpenClawConfig, rawAgentId?: string): HooksReportTarget {
   const requested = rawAgentId?.trim();
+  if (rawAgentId !== undefined && !requested) {
+    throw new Error("--agent must not be blank");
+  }
   const requestedAgentId = requested ? normalizeAgentId(requested) : undefined;
   if (requestedAgentId) {
     resolveConfiguredAgentId(config, requestedAgentId);
@@ -617,6 +620,9 @@ export function registerHooksCli(program: Command): void {
     Boolean(opts?.json || hooks.opts<{ json?: boolean }>().json);
   hooks.hook("preAction", (_thisCommand, actionCommand) => {
     const parentAgent = hooks.opts<{ agent?: string }>().agent;
+    if (parentAgent !== undefined && !parentAgent.trim()) {
+      throw new Error("--agent must not be blank");
+    }
     if (
       parentAgent &&
       actionCommand !== hooks &&

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -361,6 +361,15 @@ describe("agentCliCommand", () => {
     expect(zeroTimeoutGatewayRequestMs).toBe(2_147_000_000);
   });
 
+  it("rejects a blank agent before selecting a local or Gateway target", async () => {
+    await expect(agentCliCommand({ message: "hi", agent: "" }, runtime)).rejects.toThrow(
+      "--agent must not be blank",
+    );
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(agentCommand).not.toHaveBeenCalled();
+  });
+
   it("clamps oversized gateway timeout seconds at the command boundary", async () => {
     await withTempStore(async () => {
       mockGatewaySuccessReply();

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -1235,6 +1235,9 @@ export async function agentCliCommand(
   runtime: RuntimeEnv,
   deps?: AgentCliDeps,
 ) {
+  if (opts.agent !== undefined && !opts.agent.trim()) {
+    throw new Error("--agent must not be blank");
+  }
   protectJsonStdout(opts);
   const messageOpts = await resolveAgentMessageOpts(opts);
   // `/compact` cannot run as a plain CLI agent turn: the slash-command handler

--- a/src/commands/backup-git.test.ts
+++ b/src/commands/backup-git.test.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
+
+const mocks = vi.hoisted(() => ({
+  createGitBackup: vi.fn(),
+  getRuntimeConfig: vi.fn(),
+  listRegisteredAgentDatabases: vi.fn(),
+  recordBackupRunOutcome: vi.fn(),
+  restoreGitBackupRef: vi.fn(),
+  verifyGitBackupRef: vi.fn(),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return { ...actual, getRuntimeConfig: mocks.getRuntimeConfig };
+});
+
+vi.mock("../snapshot/git-backup.js", () => ({
+  createGitBackup: mocks.createGitBackup,
+  initializeGitBackupRepository: vi.fn(),
+  readGitBackupLog: vi.fn(),
+  restoreGitBackupRef: mocks.restoreGitBackupRef,
+  verifyGitBackupRef: mocks.verifyGitBackupRef,
+}));
+
+vi.mock("../state/backup-run-records.js", () => ({
+  recordBackupRunOutcome: mocks.recordBackupRunOutcome,
+}));
+
+vi.mock("../state/openclaw-agent-db.js", () => ({
+  listOpenClawRegisteredAgentDatabases: mocks.listRegisteredAgentDatabases,
+}));
+
+import {
+  backupGitCreateCommand,
+  backupGitRestoreCommand,
+  backupGitVerifyCommand,
+} from "./backup-git.js";
+
+describe("Git backup command agent selection", () => {
+  beforeEach(() => {
+    mocks.createGitBackup.mockReset().mockResolvedValue({
+      commit: "backup-commit",
+      noChanges: false,
+      pushed: false,
+      repositoryPath: "/tmp/repository",
+    });
+    mocks.getRuntimeConfig.mockReset().mockReturnValue({
+      agents: { list: [{ id: "main" }, { id: "ops-team" }] },
+    });
+    mocks.listRegisteredAgentDatabases.mockReset().mockReturnValue([]);
+    mocks.recordBackupRunOutcome.mockReset();
+    mocks.restoreGitBackupRef.mockReset().mockResolvedValue({
+      commit: "backup-commit",
+      excludedTables: [],
+      targetPath: "/tmp/restored.sqlite",
+    });
+    mocks.verifyGitBackupRef.mockReset().mockResolvedValue({
+      commit: "backup-commit",
+      tables: [],
+    });
+    vi.spyOn(fs, "realpath").mockImplementation(async (value) => path.resolve(String(value)));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates a backup for a configured normalized agent", async () => {
+    await backupGitCreateCommand(createTestRuntime(), {
+      repository: "/tmp/repository",
+      agents: ["Ops Team"],
+    });
+
+    expect(mocks.createGitBackup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        databases: [expect.objectContaining({ identity: { role: "agent", agentId: "ops-team" } })],
+      }),
+    );
+  });
+
+  it.each([
+    [
+      "unknown",
+      "nope-agent",
+      'Unknown agent id "nope-agent". Run openclaw agents list to see configured agents.',
+    ],
+    ["empty", "", "--agent must not be blank"],
+    ["whitespace-only", "   ", "--agent must not be blank"],
+  ])("rejects an %s Git create agent", async (_label, agent, message) => {
+    await expect(
+      backupGitCreateCommand(createTestRuntime(), {
+        repository: "/tmp/repository",
+        agents: [agent],
+      }),
+    ).rejects.toThrow(message);
+
+    expect(mocks.createGitBackup).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { label: "all", scope: { all: true } },
+    { label: "global", scope: { global: true } },
+  ])("keeps the $label Git create scope independent of configured agents", async ({ scope }) => {
+    await backupGitCreateCommand(createTestRuntime(), {
+      repository: "/tmp/repository",
+      ...scope,
+    });
+
+    expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
+    expect(mocks.createGitBackup).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the --all plus explicit-scope conflict ahead of agent validation", async () => {
+    await expect(
+      backupGitCreateCommand(createTestRuntime(), {
+        repository: "/tmp/repository",
+        all: true,
+        agents: ["nope-agent"],
+      }),
+    ).rejects.toThrow("Use --all by itself, or select --global and --agent scopes explicitly.");
+
+    expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
+    expect(mocks.createGitBackup).not.toHaveBeenCalled();
+  });
+
+  it("keeps artifact verify and restore available for an unconfigured agent", async () => {
+    await backupGitVerifyCommand(createTestRuntime(), {
+      repository: "/tmp/repository",
+      agent: "retired-agent",
+    });
+    await backupGitRestoreCommand(createTestRuntime(), {
+      repository: "/tmp/repository",
+      agent: "retired-agent",
+      target: "/tmp/restored.sqlite",
+    });
+
+    expect(mocks.verifyGitBackupRef).toHaveBeenCalledWith(
+      expect.objectContaining({ identity: { role: "agent", agentId: "retired-agent" } }),
+    );
+    expect(mocks.restoreGitBackupRef).toHaveBeenCalledWith(
+      expect.objectContaining({ identity: { role: "agent", agentId: "retired-agent" } }),
+    );
+    expect(mocks.getRuntimeConfig).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/backup-git.ts
+++ b/src/commands/backup-git.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
+import { getRuntimeConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -45,13 +47,28 @@ function resolveRequiredPath(value: string | undefined, label: string): string {
 }
 
 async function resolveCreateDatabases(runtime: RuntimeEnv, options: BackupGitCreateOptions) {
-  const agents = [...new Set((options.agents ?? []).map((agent) => normalizeAgentId(agent)))];
-  const explicit = options.global === true || agents.length > 0;
+  const normalizedAgents = [
+    ...new Set(
+      (options.agents ?? []).map((agent) => {
+        const trimmed = agent.trim();
+        if (!trimmed) {
+          throw new Error("--agent must not be blank");
+        }
+        return normalizeAgentId(trimmed);
+      }),
+    ),
+  ];
+  const explicit = options.global === true || normalizedAgents.length > 0;
   if (options.all && explicit) {
     throw new Error("Use --all by itself, or select --global and --agent scopes explicitly.");
   }
   if (!options.all && !explicit) {
     throw new Error("Choose at least one Git backup scope: --all, --global, or --agent <id>.");
+  }
+  let agents: string[] = [];
+  if (normalizedAgents.length > 0) {
+    const config = getRuntimeConfig({ skipPluginValidation: true });
+    agents = normalizedAgents.map((agent) => resolveConfiguredAgentId(config, agent));
   }
   const databases: Array<{
     path: string;

--- a/src/commands/backup-schedule.test.ts
+++ b/src/commands/backup-schedule.test.ts
@@ -9,6 +9,9 @@ const gatewayRpc = vi.hoisted(() => ({
   call: vi.fn(),
   isImplicitLocalTarget: vi.fn(async () => true),
 }));
+const configMocks = vi.hoisted(() => ({
+  getRuntimeConfig: vi.fn(),
+}));
 
 vi.mock("../cli/gateway-rpc.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../cli/gateway-rpc.js")>();
@@ -17,6 +20,11 @@ vi.mock("../cli/gateway-rpc.js", async (importOriginal) => {
     callGatewayFromCli: gatewayRpc.call,
     isImplicitLocalGatewayTargetFromCli: gatewayRpc.isImplicitLocalTarget,
   };
+});
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return { ...actual, getRuntimeConfig: configMocks.getRuntimeConfig };
 });
 
 import { GIT_BACKUP_PUSH_CREDENTIAL_WARNING } from "./backup-git.js";
@@ -41,6 +49,9 @@ describe("scheduled backups", () => {
   beforeEach(() => {
     gatewayRpc.call.mockReset();
     gatewayRpc.isImplicitLocalTarget.mockReset().mockResolvedValue(true);
+    configMocks.getRuntimeConfig.mockReset().mockReturnValue({
+      agents: { list: [{ id: "main" }, { id: "ops-team" }] },
+    });
   });
 
   afterEach(async () => {
@@ -92,6 +103,41 @@ describe("scheduled backups", () => {
     );
     expect(gatewayRpc.call).toHaveBeenCalledOnce();
     expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("schedules a configured agent using its normalized id", async () => {
+    gatewayRpc.call.mockResolvedValue({ created: true, job: { id: "backup-job" } });
+    const runtime = createTestRuntime();
+
+    await backupEnableCommand(runtime, {
+      repository: "/tmp/openclaw-backups",
+      agent: "Ops Team",
+    });
+
+    const spec = gatewayRpc.call.mock.calls[0]?.[2] as { payload: { argv: string[] } };
+    expect(spec.payload.argv).toContain("ops-team");
+    expect(spec.payload.argv).not.toContain("--all");
+  });
+
+  it.each([
+    [
+      "unknown",
+      "nope-agent",
+      'Unknown agent id "nope-agent". Run openclaw agents list to see configured agents.',
+    ],
+    ["empty", "", "--agent must not be blank"],
+    ["whitespace-only", "   ", "--agent must not be blank"],
+  ])("rejects an %s scheduled backup agent", async (_label, agent, message) => {
+    const runtime = createTestRuntime();
+
+    await expect(
+      backupEnableCommand(runtime, {
+        repository: "/tmp/openclaw-backups",
+        agent,
+      }),
+    ).rejects.toThrow(message);
+
+    expect(gatewayRpc.call).not.toHaveBeenCalled();
   });
 
   it("atomically converges an existing declaration and removes it idempotently", async () => {

--- a/src/commands/backup-schedule.ts
+++ b/src/commands/backup-schedule.ts
@@ -1,10 +1,12 @@
 import path from "node:path";
+import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
 import {
   callGatewayFromCli,
   isImplicitLocalGatewayTargetFromCli,
   type GatewayRpcOpts,
 } from "../cli/gateway-rpc.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
+import { getRuntimeConfig } from "../config/config.js";
 import type { CronJob } from "../cron/types.js";
 import { executeGitCommand } from "../infra/git-exec.js";
 import { normalizeAgentId } from "../routing/session-key.js";
@@ -56,9 +58,18 @@ function buildScheduledArgv(
   redactSecrets: boolean,
 ): string[] {
   const agent = options.agent?.trim();
+  if (options.agent !== undefined && !agent) {
+    throw new Error("--agent must not be blank");
+  }
   if (options.globalOnly && agent) {
     throw new Error("Use either --global-only or --agent <id>, not both.");
   }
+  const agentId = agent
+    ? resolveConfiguredAgentId(
+        getRuntimeConfig({ skipPluginValidation: true }),
+        normalizeAgentId(agent),
+      )
+    : undefined;
   return [
     "openclaw",
     "backup",
@@ -66,11 +77,7 @@ function buildScheduledArgv(
     "create",
     "--repository",
     repositoryPath,
-    ...(options.globalOnly
-      ? ["--global"]
-      : agent
-        ? ["--agent", normalizeAgentId(agent)]
-        : ["--all"]),
+    ...(options.globalOnly ? ["--global"] : agentId ? ["--agent", agentId] : ["--all"]),
     ...(options.push ? ["--push"] : []),
     ...(redactSecrets ? ["--exclude-secrets"] : []),
   ];

--- a/src/commands/backup-sqlite.test.ts
+++ b/src/commands/backup-sqlite.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -18,11 +18,23 @@ import {
   backupSqliteVerifyCommand,
 } from "./backup-sqlite.js";
 
+const configMocks = vi.hoisted(() => ({
+  getRuntimeConfig: vi.fn(),
+}));
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return { ...actual, getRuntimeConfig: configMocks.getRuntimeConfig };
+});
+
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 let previousStateDir: string | undefined;
 
 beforeEach(() => {
   previousStateDir = process.env.OPENCLAW_STATE_DIR;
+  configMocks.getRuntimeConfig.mockReset().mockReturnValue({
+    agents: { list: [{ id: "main" }, { id: "ops-team" }] },
+  });
 });
 
 afterEach(() => {
@@ -255,6 +267,24 @@ describe("SQLite backup commands", () => {
         repository: "/tmp/snapshots",
       }),
     ).rejects.toThrow("Choose exactly one SQLite snapshot source");
+  });
+
+  it.each([
+    [
+      "unknown",
+      "nope-agent",
+      'Unknown agent id "nope-agent". Run openclaw agents list to see configured agents.',
+    ],
+    ["empty", "", "--agent must not be blank"],
+    ["whitespace-only", "   ", "--agent must not be blank"],
+  ])("rejects an %s SQLite snapshot agent", async (_label, agent, message) => {
+    process.env.OPENCLAW_STATE_DIR = tempDirs.make("openclaw-backup-sqlite-agent-rejection-");
+    await expect(
+      backupSqliteCreateCommand(createRuntimeCapture(), {
+        agent,
+        repository: "/tmp/snapshots",
+      }),
+    ).rejects.toThrow(message);
   });
 
   it("does not claim completion when a corrupt database also rejects outcome recording", async () => {

--- a/src/commands/backup-sqlite.ts
+++ b/src/commands/backup-sqlite.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
+import { getRuntimeConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
@@ -168,6 +170,9 @@ async function resolveSnapshotDatabase(
   options: BackupSqliteCreateOptions,
 ): Promise<ResolvedSnapshotDatabase> {
   const rawAgentId = options.agent?.trim();
+  if (options.agent !== undefined && !rawAgentId) {
+    throw new Error("--agent must not be blank");
+  }
   if (options.global === true && rawAgentId) {
     throw new Error("Choose exactly one SQLite snapshot source: --global or --agent <id>.");
   }
@@ -180,7 +185,10 @@ async function resolveSnapshotDatabase(
       identity: { role: "global" },
     };
   }
-  const agentId = normalizeAgentId(rawAgentId);
+  const agentId = resolveConfiguredAgentId(
+    getRuntimeConfig({ skipPluginValidation: true }),
+    normalizeAgentId(rawAgentId),
+  );
   return {
     path: await fs.realpath(resolveOpenClawAgentSqlitePath({ agentId })),
     identity: { role: "agent", agentId },

--- a/src/commands/channels.resolve.test.ts
+++ b/src/commands/channels.resolve.test.ts
@@ -90,6 +90,10 @@ describe("channelsResolveCommand", () => {
   });
 
   it("uses installed channel plugins for explicit target resolution without installing", async () => {
+    mocks.loadConfig.mockReturnValue({
+      agents: { list: [{ id: "main" }, { id: "ops" }] },
+      channels: {},
+    });
     const resolveTargets = vi.fn().mockResolvedValue([
       {
         input: "friends",
@@ -139,6 +143,30 @@ describe("channelsResolveCommand", () => {
     expect(resolveRequest.inputs).toStrictEqual(["friends"]);
     expect(resolveRequest.kind).toBe("group");
     expect(runtime.log).toHaveBeenCalledWith("friends -> 120363000000@g.us (Friends)");
+  });
+
+  it.each([
+    [
+      "unknown",
+      "nope-agent",
+      'Unknown agent id "nope-agent". Run openclaw agents list to see configured agents.',
+    ],
+    ["empty", "", "--agent must not be blank"],
+    ["whitespace-only", "   ", "--agent must not be blank"],
+  ])("rejects an %s explicit agent before channel resolution", async (_label, agent, message) => {
+    mocks.loadConfig.mockReturnValue({
+      agents: { list: [{ id: "main" }] },
+      channels: {},
+    });
+
+    await expect(
+      channelsResolveCommand({ agent, channel: "telegram", entries: ["friends"] }, runtime),
+    ).rejects.toThrow(message);
+
+    expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+    expect(mocks.resolveCommandSecretRefsViaGateway).not.toHaveBeenCalled();
+    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.resolveMessageChannelSelection).not.toHaveBeenCalled();
   });
 
   it("tells users to add an explicit catalog channel before resolving", async () => {

--- a/src/commands/channels/resolve.ts
+++ b/src/commands/channels/resolve.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { resolveConfiguredAgentId } from "../../agents/agent-scope-config.js";
 import type {
   ChannelResolveKind,
   ChannelResolveResult,
@@ -118,17 +119,6 @@ function formatResolveResult(result: ResolveResult): string {
 
 /** Resolve user/group/channel labels into plugin-specific stable target ids. */
 export async function channelsResolveCommand(opts: ChannelsResolveOptions, runtime: RuntimeEnv) {
-  const sourceSnapshotPromise = readConfigFileSnapshot().catch(() => null);
-  const loadedRaw = getRuntimeConfig();
-  let { effectiveConfig: cfg } = await resolveCommandConfigWithSecrets({
-    config: loadedRaw,
-    commandName: "channels resolve",
-    targetIds: getChannelsCommandSecretTargetIds(),
-    agentId: opts.agent,
-    mode: "read_only_operational",
-    runtime,
-    autoEnable: true,
-  });
   const entries = normalizeStringEntries(opts.entries);
   if (entries.length === 0) {
     throw new Error(
@@ -136,12 +126,29 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
     );
   }
 
+  const loadedRaw = getRuntimeConfig();
+  const requestedAgent = opts.agent?.trim();
+  if (opts.agent !== undefined && !requestedAgent) {
+    throw new Error("--agent must not be blank");
+  }
+  const agentId = requestedAgent ? resolveConfiguredAgentId(loadedRaw, requestedAgent) : undefined;
+  const sourceSnapshotPromise = readConfigFileSnapshot().catch(() => null);
+  let { effectiveConfig: cfg } = await resolveCommandConfigWithSecrets({
+    config: loadedRaw,
+    commandName: "channels resolve",
+    targetIds: getChannelsCommandSecretTargetIds(),
+    agentId,
+    mode: "read_only_operational",
+    runtime,
+    autoEnable: true,
+  });
+
   const explicitChannel = opts.channel?.trim();
   const resolvedExplicit = explicitChannel
     ? await resolveInstallableChannelPlugin({
         cfg,
         runtime,
-        agentId: opts.agent,
+        agentId,
         rawChannel: explicitChannel,
         allowInstall: false,
         supports: (plugin) => Boolean(plugin.resolver?.resolveTargets),
@@ -168,7 +175,7 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
     : await resolveMessageChannelSelection({
         cfg,
         channel: opts.channel ?? null,
-        agentId: opts.agent,
+        agentId,
       });
   const plugin = selection.plugin;
   if (!plugin?.resolver?.resolveTargets) {

--- a/src/commands/export-trajectory.test.ts
+++ b/src/commands/export-trajectory.test.ts
@@ -147,6 +147,50 @@ describe("exportTrajectoryCommand", () => {
   });
 
   it.each([
+    [
+      "unknown",
+      "nope-agent",
+      'Unknown agent id "nope-agent". Run openclaw agents list to see configured agents.',
+    ],
+    ["empty", "", "--agent must not be blank"],
+    ["whitespace-only", "   ", "--agent must not be blank"],
+  ])("rejects an %s explicit agent before reading a session", async (_label, agent, message) => {
+    const runtime = createRuntime();
+    mocks.getRuntimeConfig.mockReturnValue({ agents: { list: [{ id: "main" }] } });
+
+    await exportTrajectoryCommand({ sessionKey: "agent:main:telegram:direct:123", agent }, runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(message);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.resolveStorePath).not.toHaveBeenCalled();
+    expect(mocks.loadSessionEntryReadOnly).not.toHaveBeenCalled();
+  });
+
+  it("keeps a configured explicit agent as the session store owner", async () => {
+    const runtime = createRuntime();
+    mocks.getRuntimeConfig.mockReturnValue({
+      agents: { list: [{ id: "main" }, { id: "work" }] },
+      session: { store: "/tmp/openclaw/agents/{agentId}/sessions/sessions.json" },
+    });
+    mocks.resolveStorePath.mockReturnValue("/tmp/openclaw/agents/work/sessions/sessions.json");
+
+    await exportTrajectoryCommand(
+      { sessionKey: "agent:main:telegram:direct:123", agent: "work" },
+      runtime,
+    );
+
+    expect(mocks.resolveStorePath).toHaveBeenCalledWith(
+      "/tmp/openclaw/agents/{agentId}/sessions/sessions.json",
+      { agentId: "work" },
+    );
+    expect(mocks.loadSessionEntryReadOnly).toHaveBeenCalledWith({
+      agentId: "work",
+      sessionKey: "agent:main:telegram:direct:123",
+      storePath: "/tmp/openclaw/agents/work/sessions/sessions.json",
+    });
+  });
+
+  it.each([
     ["home-prefixed", "~/x/sessions.json", "/home/demo/x/sessions.json"],
     [
       "agent template",

--- a/src/commands/export-trajectory.ts
+++ b/src/commands/export-trajectory.ts
@@ -1,6 +1,7 @@
 /** CLI command for exporting a session transcript as a trajectory artifact. */
 import path from "node:path";
 import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
+import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
@@ -114,7 +115,22 @@ export async function exportTrajectoryCommand(
     runtime.exit(1);
     return;
   }
-  const targetAgentId = resolvedOpts.agent ?? resolveAgentIdFromSessionKey(sessionKey);
+  const requestedAgent = resolvedOpts.agent?.trim();
+  if (resolvedOpts.agent !== undefined && !requestedAgent) {
+    runtime.error("--agent must not be blank");
+    runtime.exit(1);
+    return;
+  }
+  let targetAgentId = resolveAgentIdFromSessionKey(sessionKey);
+  if (requestedAgent) {
+    try {
+      targetAgentId = resolveConfiguredAgentId(getRuntimeConfig(), requestedAgent);
+    } catch (error) {
+      runtime.error(formatErrorMessage(error));
+      runtime.exit(1);
+      return;
+    }
+  }
   let storePath = resolvedOpts.store
     ? resolveSessionStorePathCore(resolvedOpts.store, { agentId: targetAgentId })
     : resolveSessionStorePathCore(getRuntimeConfig().session?.store, { agentId: targetAgentId });

--- a/src/commands/migrate/context.test.ts
+++ b/src/commands/migrate/context.test.ts
@@ -36,4 +36,8 @@ describe("migration context helpers", () => {
   it("keeps the configured default when no migration target is supplied", () => {
     expect(resolveMigrationTargetAgentId({}, undefined)).toBeUndefined();
   });
+
+  it("rejects an explicitly blank migration target", () => {
+    expect(() => resolveMigrationTargetAgentId({}, "")).toThrow("--agent must not be blank");
+  });
 });

--- a/src/commands/migrate/context.ts
+++ b/src/commands/migrate/context.ts
@@ -40,6 +40,9 @@ export function resolveMigrationTargetAgentId(
   rawAgentId: string | undefined,
 ): string | undefined {
   const raw = rawAgentId?.trim();
+  if (rawAgentId !== undefined && !raw) {
+    throw new Error("--agent must not be blank");
+  }
   if (!raw) {
     return undefined;
   }

--- a/src/commands/sandbox-explain.test.ts
+++ b/src/commands/sandbox-explain.test.ts
@@ -23,6 +23,30 @@ vi.mock("../config/config.js", async () => {
 });
 
 describe("sandbox explain command", () => {
+  it.each([
+    [
+      "unknown",
+      "nope-agent",
+      'Unknown agent id "nope-agent". Run openclaw agents list to see configured agents.',
+    ],
+    ["blank", "", "--agent must not be blank"],
+  ])("rejects an explicit %s agent", async (_label, agent, message) => {
+    mockCfg = {
+      agents: {
+        defaults: { sandbox: { mode: "off" } },
+        list: [{ id: "main" }],
+      },
+    };
+
+    await expect(
+      sandboxExplainCommand({ json: true, agent }, {
+        log: () => {},
+        error: () => {},
+        exit: (_code: number) => {},
+      } as unknown as Parameters<typeof sandboxExplainCommand>[1]),
+    ).rejects.toThrow(message);
+  });
+
   it("honors an explicit agent in an ownerless multi-agent fleet", async () => {
     mockCfg = {
       agents: {
@@ -462,6 +486,7 @@ describe("sandbox explain command", () => {
         defaults: {
           sandbox: { mode: "non-main" },
         },
+        list: [{ id: "main" }, { id: "builder" }],
       },
     };
 

--- a/src/commands/sandbox-explain.ts
+++ b/src/commands/sandbox-explain.ts
@@ -13,6 +13,7 @@ import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { colorize, isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import {
   resolveAgentConfig,
+  resolveConfiguredAgentId,
   resolveSessionAgentId,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
@@ -144,7 +145,11 @@ export async function sandboxExplainCommand(
   const cfg = getRuntimeConfig();
 
   const requestedSession = opts.session?.trim();
-  const requestedAgentId = opts.agent?.trim() ? normalizeAgentId(opts.agent) : undefined;
+  const requestedAgent = opts.agent?.trim();
+  if (opts.agent !== undefined && !requestedAgent) {
+    throw new Error("--agent must not be blank");
+  }
+  const requestedAgentId = requestedAgent ? normalizeAgentId(requestedAgent) : undefined;
   const sessionAgentId =
     requestedSession && requestedSession !== "global" && requestedSession.includes(":")
       ? normalizeAgentId(resolveAgentIdFromSessionKey(requestedSession))
@@ -153,6 +158,9 @@ export async function sandboxExplainCommand(
     throw new Error(
       `Sandbox explain agent "${requestedAgentId}" does not match session agent "${sessionAgentId}".`,
     );
+  }
+  if (requestedAgentId) {
+    resolveConfiguredAgentId(cfg, requestedAgentId);
   }
   const resolvedAgentId = resolveSessionAgentId({
     sessionKey: requestedSession,

--- a/src/commands/sessions-compact.test.ts
+++ b/src/commands/sessions-compact.test.ts
@@ -27,6 +27,16 @@ beforeEach(() => {
 });
 
 describe("sessionsCompactCommand", () => {
+  it("rejects a blank agent before calling the Gateway", async () => {
+    const runtime = createRuntime();
+
+    await expect(
+      sessionsCompactCommand({ key: "agent:main:main", agent: "" }, runtime),
+    ).rejects.toThrow("--agent must not be blank");
+
+    expect(callGatewayCli).not.toHaveBeenCalled();
+  });
+
   it("prints the token delta and does not exit on a successful compaction", async () => {
     callGatewayCli.mockResolvedValue({
       ok: true,

--- a/src/commands/sessions-compact.ts
+++ b/src/commands/sessions-compact.ts
@@ -73,6 +73,10 @@ export async function sessionsCompactCommand(
   opts: SessionsCompactCliOptions,
   runtime: RuntimeEnv,
 ): Promise<void> {
+  const agent = opts.agent?.trim();
+  if (opts.agent !== undefined && !agent) {
+    throw new Error("--agent must not be blank");
+  }
   const rpcOpts: SessionsCompactRpcOpts = {
     url: opts.url,
     token: opts.token,
@@ -84,7 +88,7 @@ export async function sessionsCompactCommand(
   };
   const params = {
     key: opts.key,
-    ...(opts.agent ? { agentId: opts.agent } : {}),
+    ...(agent ? { agentId: agent } : {}),
     ...(opts.maxLines !== undefined ? { maxLines: opts.maxLines } : {}),
   };
 

--- a/src/commands/sessions-lifecycle.test.ts
+++ b/src/commands/sessions-lifecycle.test.ts
@@ -4,10 +4,15 @@ import { sessionsArchiveCommand, sessionsDeleteCommand } from "./sessions-lifecy
 const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
   confirm: vi.fn(),
+  getRuntimeConfig: vi.fn(),
 }));
 
 vi.mock("../cli/gateway-rpc.js", () => ({
   callGatewayFromCliWithTransport: mocks.callGateway,
+}));
+
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: mocks.getRuntimeConfig,
 }));
 
 vi.mock("../wizard/clack-prompter.js", () => ({
@@ -35,6 +40,58 @@ describe("sessions lifecycle commands", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.confirm.mockResolvedValue(true);
+    mocks.getRuntimeConfig.mockReturnValue({
+      agents: { entries: { main: {}, work: {} } },
+    });
+  });
+
+  it.each([
+    ["archive", sessionsArchiveCommand, {} as Record<string, unknown>],
+    ["delete", sessionsDeleteCommand, { yes: true } as Record<string, unknown>],
+  ])(
+    "%s rejects an unconfigured --agent before contacting the gateway",
+    async (_label, command, extra) => {
+      const runtime = createRuntime();
+      await command(
+        { keys: ["agent:ghost:main"], agent: "ghost", json: true, ...extra } as never,
+        runtime as never,
+      );
+      expect(mocks.callGateway).not.toHaveBeenCalled();
+      expect(runtime.writeJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ok: false,
+          results: [
+            expect.objectContaining({
+              error: expect.stringContaining('Unknown agent id "ghost"'),
+            }),
+          ],
+        }),
+        2,
+      );
+    },
+  );
+
+  it.each([
+    ["archive", sessionsArchiveCommand, {} as Record<string, unknown>],
+    ["delete", sessionsDeleteCommand, { yes: true } as Record<string, unknown>],
+  ])("%s rejects a blank --agent", async (_label, command, extra) => {
+    const runtime = createRuntime();
+    await command(
+      { keys: ["agent:main:main"], agent: "   ", json: true, ...extra } as never,
+      runtime as never,
+    );
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(runtime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: false,
+        results: [
+          expect.objectContaining({
+            error: expect.stringContaining("--agent must not be blank"),
+          }),
+        ],
+      }),
+      2,
+    );
   });
 
   it("archives through sessions.patch and emits the stable JSON envelope", async () => {

--- a/src/commands/sessions-lifecycle.ts
+++ b/src/commands/sessions-lifecycle.ts
@@ -4,9 +4,11 @@ import type {
   SessionsDeleteResult,
   WorktreePreservationReason,
 } from "../../packages/gateway-protocol/src/index.js";
+import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { formatCliJsonFailure, rethrowExpectedCliError } from "../cli/failure-output.js";
 import { callGatewayFromCliWithTransport } from "../cli/gateway-rpc.js";
+import { getRuntimeConfig } from "../config/config.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { SESSION_ARCHIVE_REQUEST_TIMEOUT_MS } from "../shared/session-archive-timeout.js";
@@ -67,6 +69,14 @@ type SessionsLifecycleRpcOptions = Parameters<typeof callGatewayFromCliWithTrans
 // Keep each read bounded while exhausting pagination when an invalid key must
 // be distinguished from a session outside the first Gateway list page.
 const SESSION_TARGET_PAGE_SIZE = 200;
+
+function resolveLifecycleAgentId(rawAgent: string | undefined): string | undefined {
+  const requested = rawAgent?.trim();
+  if (rawAgent !== undefined && !requested) {
+    throw new Error("--agent must not be blank");
+  }
+  return requested ? resolveConfiguredAgentId(getRuntimeConfig(), requested) : undefined;
+}
 
 function listHint(agent?: string): string {
   const agentFlag = agent ? ` --agent ${agent}` : "";
@@ -210,8 +220,12 @@ async function runSessionsLifecycleCommand(
     json: opts.json,
   };
   let sessions: Map<string, SessionsListRow>;
+  let agent: string | undefined;
   try {
-    sessions = await listRequestedSessions(keys.filter(Boolean), opts.agent, rpcOptions);
+    // The not-found hint points at `sessions list --agent <id>`, which rejects an unconfigured id
+    // locally. Validating here keeps that suggestion runnable instead of handing back a dead end.
+    agent = resolveLifecycleAgentId(opts.agent);
+    sessions = await listRequestedSessions(keys.filter(Boolean), agent, rpcOptions);
   } catch (error) {
     rethrowExpectedCliError(error);
     const message = formatErrorMessage(error);
@@ -226,7 +240,7 @@ async function runSessionsLifecycleCommand(
   }
 
   const results = keys.map((key): SessionsLifecycleResult | undefined =>
-    key && sessions.has(key) ? undefined : notFoundResult(key, opts.agent),
+    key && sessions.has(key) ? undefined : notFoundResult(key, agent),
   );
   const listedTargets = keys.flatMap((key, index) => {
     const session = sessions.get(key);
@@ -296,7 +310,7 @@ async function runSessionsLifecycleCommand(
           rpcOptions,
           {
             key: session.key,
-            ...(opts.agent ? { agentId: opts.agent } : {}),
+            ...(agent ? { agentId: agent } : {}),
             ...(session.sessionId ? { expectedSessionId: session.sessionId } : {}),
             archived: true,
           },
@@ -312,7 +326,7 @@ async function runSessionsLifecycleCommand(
           rpcOptions,
           {
             key: session.key,
-            ...(opts.agent ? { agentId: opts.agent } : {}),
+            ...(agent ? { agentId: agent } : {}),
             ...(session.sessionId ? { expectedSessionId: session.sessionId } : {}),
             deleteTranscript: true,
             ...(session.archived === true ? { archivedOnly: true } : {}),
@@ -320,7 +334,7 @@ async function runSessionsLifecycleCommand(
           { defaultTimeoutMs: 30_000 },
         )) as SessionsDeleteResult;
         if (!response.deleted) {
-          results[index] = notFoundResult(session.key, opts.agent);
+          results[index] = notFoundResult(session.key, agent);
           continue;
         }
         results[index] = {

--- a/src/config/sessions/targets.selection.test.ts
+++ b/src/config/sessions/targets.selection.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionStoreTargets } from "./targets.js";
+
+describe("session store target selection", () => {
+  it("rejects a blank agent instead of selecting the default store", () => {
+    expect(() => resolveSessionStoreTargets({}, { agent: "" })).toThrow(
+      "--agent must not be blank",
+    );
+  });
+});

--- a/src/config/sessions/targets.ts
+++ b/src/config/sessions/targets.ts
@@ -620,7 +620,11 @@ export function resolveSessionStoreTargets(
   params: { env?: NodeJS.ProcessEnv; diagnostics?: string[] } = {},
 ): SessionStoreTarget[] {
   const env = params.env ?? process.env;
-  const hasAgent = Boolean(opts.agent?.trim());
+  const requestedAgent = opts.agent?.trim();
+  if (opts.agent !== undefined && !requestedAgent) {
+    throw new Error("--agent must not be blank");
+  }
+  const hasAgent = requestedAgent !== undefined;
   const allAgents = opts.allAgents === true;
   if (hasAgent && allAgents) {
     throw new Error("--agent and --all-agents cannot be used together");
@@ -638,7 +642,7 @@ export function resolveSessionStoreTargets(
     if (persistedStoreOwner.kind === "retired") {
       throw new Error(`Session store owner is retired: ${persistedStoreOwner.agentId}`);
     }
-    const requestedAgentId = hasAgent ? normalizeAgentId(opts.agent ?? "") : undefined;
+    const requestedAgentId = requestedAgent ? normalizeAgentId(requestedAgent) : undefined;
     if (
       requestedAgentId &&
       persistedStoreOwner.kind === "configured" &&
@@ -687,7 +691,7 @@ export function resolveSessionStoreTargets(
   }
 
   if (hasAgent) {
-    const requested = normalizeAgentId(opts.agent ?? "");
+    const requested = normalizeAgentId(requestedAgent);
     resolveConfiguredAgentId(cfg, requested);
     return [
       {


### PR DESCRIPTION
## What Problem This Solves

[#126954](https://github.com/openclaw/openclaw/pull/126954) fixed `skills --agent`. It turned out to be one instance of a class. Two more surfaces accepted an agent id naming nothing, and one of them **wrote it to disk**.

**`sandbox explain`** — exit 0, full confident report for an agent that does not exist:

```
$ openclaw agents list
Agents:
- main (default)

$ openclaw sandbox explain --agent nope-agent
Effective sandbox:
  agentId: nope-agent
  sessionKey: agent:nope-agent:main
  effectiveHostWorkspaceRoot: <workspace>/nope-agent      <- directory does not exist
Sandbox tool policy:
  allow (default): exec, process, read, write, edit, ...
Elevated:
  enabled: true
$ echo $?
0
```

**`approvals allowlist add`** — exit 0, and it persists:

```
$ openclaw approvals allowlist add "rm -rf /" --agent nope-agent
Writing local approvals.
$ echo $?
0
```

```json
// state/openclaw.sqlite#exec_approvals_config  (agents subtree only)
"agents": { "nope-agent": { "allowlist": [ { "pattern": "rm -rf /", "id": "..." } ] } }
```

The operator believes they approved an exec pattern. Nothing was approved, nothing will ever read that key, and nothing told them.

## Why This Change Was Made

Sweeping `option("--agent"` across `src/cli` and `src/commands`, each hit was classified as a **selector** (names the thing being operated on — must validate) or a **filter** (narrows a list — may legitimately return empty).

Selectors now route the explicit value through `resolveConfiguredAgentId`, the helper that already backs `models`, `memory`, `sessions list`, `hooks`, and every `capability-cli` surface:

| surface | before | after |
| --- | --- | --- |
| `sandbox explain` | exit 0, invented report | exit 1, `Unknown agent id` |
| `approvals allowlist add/remove` | exit 0, **persisted** | exit 1, nothing written |
| `channels resolve` | accepted | validated |
| `sessions export-trajectory` | accepted | validated |
| `sessions archive` / `delete` | dead-end hint (below) | validated |
| `backup enable` / `git create` / `sqlite create` | accepted | validated |

Blank-only guards close the empty-shell-variable hole in `hooks`, `sessions` list/cleanup/tail/compact, `migrate`, and agent turns.

**Filters are deliberately unchanged** and were checked individually: `audit`, `usage-cost`, agent bindings, `backup verify/restore`, and `sandbox recreate` all match existing records and correctly report no matches without mutating anything. Cron is gateway-owned and already rejects an unavailable agent server-side (`cron job agent is unavailable: nope-agent`), so it is untouched.

### The `sessions archive/delete` case is a dead-end, not a silent failure

It already failed visibly, but handed back a remediation that cannot run:

```
$ openclaw sessions archive "agent:ghost:main" --agent ghost
archive agent:ghost:main: Session not found. Run openclaw sessions list --agent ghost --json to choose a valid key.

$ openclaw sessions list --agent ghost
Unknown agent id "ghost". Run openclaw agents list to see configured agents.
```

Validating locally — exactly as `sessions list` already does in the same command family — makes that suggestion runnable. A gateway roster fetch was considered and rejected: it adds an `agents.list` round-trip to every archive/delete, duplicates policy the server owns, and would make the local `agents list` hint wrong against a remote gateway.

`approvals` validates against the config for its actual target: `loadConfigForApprovalsTarget` already fetches remote config via `config.get` for `--gateway`/`--node`, so a remote node is checked against its own roster, and an unavailable config fails closed before any write.

## User Impact

Every operator-supplied `--agent` now behaves the same way across the CLI. No filter semantics change; no valid invocation changes.

Production LOC: +140/-35, net +105 across thirteen command boundaries.

## Evidence

Both headline defects were reproduced against a real `pnpm build` dist of `main` in an isolated `OPENCLAW_STATE_DIR` + `HOME` before any code was written, and the persisted approvals row was read back out of SQLite to confirm the write.

Tests — all 11 touched suites, 256 passed + 1 pre-existing skip, `rc=0`:

`exec-approvals-cli`, `hooks-cli.toggle`, `agent-via-gateway`, `backup-schedule`, `backup-sqlite`, `channels.resolve`, `export-trajectory`, `migrate/context`, `sandbox-explain`, `sessions-compact`, `sessions-lifecycle`.

New coverage asserts, per surface: unknown id exits nonzero; blank id exits nonzero; for `approvals`, that `updateExecApprovals` is never called, the snapshot's `agents` map is unchanged, and no `Writing local approvals.` line is emitted; and that default, explicit `*`, and configured ids still work. Pre-fix, the new `sandbox-explain` (2) and `exec-approvals` (4) regressions failed as intended.

`node scripts/check-changed.mjs`: all gates pass. `$autoreview`: clean, no accepted or actionable findings, correctness 0.98.
