### PR TITLE
fix(doctor): name the unreadable state database instead of dying on a SQLite string

### DIFF
--- a/src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts
+++ b/src/commands/doctor.refuses-newer-database-schemas.e2e.test.ts
@@ -61,6 +61,34 @@ describe("doctor database schema preflight", () => {
     expect(autoMigrateLegacyStateDir).not.toHaveBeenCalled();
     expect(readConfigFileSnapshot).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["plain doctor", { nonInteractive: true }],
+    ["doctor --fix", { nonInteractive: true, repair: true }],
+  ])("diagnoses an unreadable shared state database for %s", async (_label, options) => {
+    const statePath = resolveOpenClawStateSqlitePath(process.env);
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, "not a sqlite database");
+    mockDoctorConfigSnapshot();
+
+    const failure = await doctorCommand(createDoctorRuntime(), options).then(
+      () => null,
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain(statePath);
+    expect((failure as Error).message).toMatch(/file is not a database/iu);
+    expect((failure as Error).message).toContain("left unchanged");
+    expect((failure as Error).message).toContain("restore this file from a verified backup");
+    expect((failure as Error).message).toContain("openclaw doctor --fix");
+    expect((failure as Error).message).toContain(
+      "https://docs.openclaw.ai/reference/database-schemas",
+    );
+    expect(fs.readFileSync(statePath, "utf8")).toBe("not a sqlite database");
+    expect(autoMigrateLegacyStateDir).not.toHaveBeenCalled();
+    expect(readConfigFileSnapshot).not.toHaveBeenCalled();
+  });
 });
 
 function mockInteractiveGitUpdate(status: "ok" | "skipped"): void {

--- a/src/config/io.eacces.test.ts
+++ b/src/config/io.eacces.test.ts
@@ -31,6 +31,24 @@ function makeEaccesFs(configPath: string) {
 }
 
 describe("config io EACCES handling", () => {
+  it("logs config load failures without exposing a raw error stack", () => {
+    const configPath = "/data/.openclaw/openclaw.json";
+    const errors: unknown[][] = [];
+    const io = createConfigIO({
+      configPath,
+      fs: makeEaccesFs(configPath),
+      logger: {
+        error: (...args: unknown[]) => errors.push(args),
+        warn: () => {},
+      },
+    });
+
+    expect(() => io.loadConfig()).toThrow(expect.objectContaining({ code: "EACCES" }));
+    expect(errors).toEqual([
+      [`Failed to read config at ${configPath}: EACCES: permission denied, open '${configPath}'`],
+    ]);
+  });
+
   it("returns a helpful error message when config file is not readable (EACCES)", async () => {
     const configPath = "/data/.openclaw/openclaw.json";
     const errors: string[] = [];

--- a/src/config/io.load.ts
+++ b/src/config/io.load.ts
@@ -1,3 +1,4 @@
+import { formatErrorMessage } from "../infra/errors.js";
 import {
   loadShellEnvFallback,
   resolveShellEnvFallbackTimeoutMs,
@@ -208,7 +209,7 @@ export function loadConfigFromContext(
     if ((error as { code?: string })?.code === "INVALID_CONFIG") {
       throw error;
     }
-    deps.logger.error(`Failed to read config at ${configPath}`, error);
+    deps.logger.error(`Failed to read config at ${configPath}: ${formatErrorMessage(error)}`);
     throw error;
   }
 }

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -17,7 +17,7 @@ vi.mock("../config/paths.js", () => ({
 
 vi.mock("../state/openclaw-database-preflight.js", () => ({
   OpenClawDatabaseSchemaPreflightError: class extends Error {},
-  preflightOpenClawDatabaseSchemas: () => ({ incompatible: [] }),
+  preflightOpenClawDatabaseSchemas: () => ({ incompatible: [], indeterminate: [] }),
 }));
 
 vi.mock("../state/openclaw-agent-db.js", () => ({

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.js";
+import { formatCliCommand } from "../cli/command-format.js";
 import type { DoctorOptions } from "../commands/doctor-prompter.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -31,6 +32,14 @@ async function assertDoctorDatabaseSchemasCompatible(): Promise<void> {
     throw new databasePreflight.OpenClawDatabaseSchemaPreflightError(databaseSchemas.incompatible, {
       operation: "doctor",
     });
+  }
+  const unreadableStateDatabase = databaseSchemas.indeterminate.find(
+    (database) => database.kind === "state",
+  );
+  if (unreadableStateDatabase) {
+    throw new Error(
+      `Doctor cannot continue because the shared state database is unreadable: ${unreadableStateDatabase.path}: ${unreadableStateDatabase.reason}. The database was left unchanged; doctor will not recreate it because that could discard persistent operator data. Stop the Gateway and other OpenClaw processes, then restore this file from a verified backup or repair it manually. After recovery, run ${formatCliCommand("openclaw doctor --fix")} again. See ${stateDatabase.OPENCLAW_DATABASE_SCHEMA_DOCS_URL}.`,
+    );
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Doctor is the designated repair owner, and nearly every CLI failure footer in this product ends with `Try: openclaw doctor`. With a corrupt shared state database (`<state>/state/openclaw.sqlite`), doctor produced this and nothing else:

```
$ openclaw doctor
┌  OpenClaw doctor
database disk image is malformed
$ echo $?
1
```

No path. No indication of which database. No next step. `openclaw doctor --fix` — the repair command — printed the identical two lines and repaired nothing. `OPENCLAW_DEBUG=1` added nothing, and the standard `Reason:` / `Debug:` / `Try:` / `Help:` envelope never appeared, so the operator did not even get the usual affordances.

That closes a loop: every command they try tells them to run doctor, and doctor hands back a SQLite string with no object attached to it.

## Why This Change Was Made

This is not a judgement call, because the sibling already handles it correctly. Corrupt the **agent** database instead, same build, same state-root shape:

```
$ openclaw doctor
┌  OpenClaw doctor
◇  Doctor warnings ───────────────────────────────────────────────────────╮
│  - Skipped historical transcript directive migration for                 │
│    <state>/agents/main/agent/openclaw-agent.sqlite:                      │
│    Error: file is not a database                                         │
╰──────────────────────────────────────────────────────────────────────────╯
Could not read generated model catalogs for <state>/agents/main/agent: file is not a database
... full health run continues ...
$ echo $?
0
```

Named file, named reason, visible warning, run completes. Two more siblings get it right on the *same* data: `assertOpenClawDatabasesReadyForRestart` consumes `schemas.indeterminate` and names each database and reason, and `doctor --post-upgrade` on the same corrupt root reports `plugin.index_unavailable` with a rebuild command.

The mechanism is precise. `assertDoctorDatabaseSchemasCompatible` reads `preflightOpenClawDatabaseSchemas` and inspects only `incompatible`, **silently discarding `indeterminate`** — which is exactly where an unreadable shared database is recorded, with `path` and `reason` already populated. Doctor then proceeded and died deeper with the context stripped. The real throw is `src/infra/sqlite-readonly-location.ts:428` (line 418 for non-SQLite bytes), reached through `openclaw-state-ownership.ts:293` and `doctor-config-preflight.ts:135`.

The fix wires the dropped signal through to a diagnosis rather than adding a second detection path.

**Why it stops rather than continuing like the agent path.** Shared state owns write admission and holds the persisted plugin index the health context is constructed from; disabling migrations still fails on that index. Continuing would mean building a bespoke degraded doctor, which is a much larger change than this defect warrants. Agent-database corruption stays isolated and its full run still completes at exit 0 — verified on the fixed build.

**Why it does not repair.** That database holds auth profiles among other things, so silently recreating it is data loss. The message says what it deliberately did not do and why, then gives recovery steps. A guarded, explicitly operator-approved recovery that verifies a backup or repaired copy before atomic replacement is a reasonable follow-up; it is not this PR.

There is direct precedent for this shape: [#126757](https://github.com/openclaw/openclaw/pull/126757) fixed the identical dead-end for an unparseable `openclaw.json`.

### Adjacent findings from the same investigation

**Fixed:** `doctor --session-sqlite inspect` on the corrupt root printed a raw stack trace with absolute `dist/*.js` frames, without `OPENCLAW_DEBUG=1`, contradicting the CLI's own `Debug: set OPENCLAW_DEBUG=1 to include the stack trace` convention. `io.load.ts:212` passed a raw `Error` to the logger before CLI stack gating; it now logs formatted message text.

**Investigated, deliberately not changed:** `doctor --lint` exits 1 on an error-severity finding while bare `doctor --json` exits 0 on the identical finding. Commit `6e5bf3ec55c` established that advisory JSON exit behavior on purpose, and `register.maintenance.test.ts:300-368` covers it. Left alone.

### One considered tradeoff

Doctor's preflight call does not pass `verifyCurrentSchemaShape`, so a `kind: "state"` entry in `indeterminate` means the database could not be opened or read at all — or, in one narrow case, that the `agent_databases` registry query failed on an otherwise-readable file. That second case would now stop doctor where it previously continued. It requires page-level corruption confined to exactly that table while the header and user-version still read cleanly, which is hypothetical rather than an observed production state; and even there, stopping with a named diagnosis beats the previous bare crash. Flagging it explicitly rather than leaving it implicit.

## User Impact

```
Doctor cannot continue because the shared state database is unreadable: <path>: <reason>.
The database was left unchanged; doctor will not recreate it because that could discard
persistent operator data. Stop the Gateway and other OpenClaw processes, then restore this
file from a verified backup or repair it manually. After recovery, run `openclaw doctor --fix`
again. See <database schema docs>.
```

No change to any healthy path. Production LOC: +11/-1, net +10.

## Evidence

Before, on exact-SHA build `630175d`:

| case | result |
| --- | --- |
| shared DB corrupt, plain `doctor` | `file is not a database` only, exit 1 |
| shared DB corrupt, `doctor --fix` | identical dead end, exit 1 |
| agent DB corrupt | named warnings, full `Doctor complete.`, exit 0 |

After, on a rebuilt CLI (`pnpm build`, 3m43s):

| case | result |
| --- | --- |
| shared DB corrupt, plain `doctor` and `--fix` | actionable diagnosis, exit 1, corrupt bytes unchanged |
| agent DB corrupt | full run completes, exit 0 (unchanged) |
| `doctor --session-sqlite inspect` | exit 1, zero stack frames or implementation paths |

Source-blind behavior validation passed every clause on [Actions run 32444709147](https://github.com/openclaw/openclaw/actions/runs/32444709147). `node scripts/check-changed.mjs` passed all lanes on [Actions run 32443806477](https://github.com/openclaw/openclaw/actions/runs/32443806477). Focused Vitest sweep: 279 passed, one Windows-only skip. Re-run independently here: `doctor-health.test.ts` and `io.eacces.test.ts` pass (1 + 7); the e2e suite's global setup cannot run in a linked worktree without `node_modules`, which is why it was proven on the runner instead. `pnpm docs:list`, formatting, and `git diff --check` pass. `$autoreview`: clean, no accepted or actionable findings, correctness 0.99.
