### PR TITLE
fix(skills): point a ClawHub miss at search, not at the local skill list

### DIFF
--- a/src/cli/skills-cli.verify.test.ts
+++ b/src/cli/skills-cli.verify.test.ts
@@ -321,7 +321,7 @@ describe("skills verify CLI", () => {
     ).rejects.toThrow("__exit__:1");
 
     const message =
-      'Skill "nonexistent-skill-xyz" not found. Run `openclaw skills list` to see available skills.';
+      'Skill "nonexistent-skill-xyz" not found on ClawHub. Run `openclaw skills search nonexistent-skill-xyz` to find the right skill reference.';
     if (human) {
       expect(mocks.runtimeStdout).toStrictEqual([]);
       expect(mocks.runtimeErrors).toStrictEqual([message]);

--- a/src/skills/lifecycle/clawhub-request-error.ts
+++ b/src/skills/lifecycle/clawhub-request-error.ts
@@ -1,3 +1,4 @@
+import { formatCliCommand } from "../../cli/command-format.js";
 import { ClawHubRequestError } from "../../infra/clawhub-client.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 
@@ -15,7 +16,9 @@ export function formatClawHubSkillRequestError(
       error.requestPath.endsWith(`${skillPath}/install`) ||
       error.requestPath.endsWith(`${skillPath}/verify`))
   ) {
-    return `Skill "${params.slug}" not found. Run \`openclaw skills list\` to see available skills.`;
+    // ClawHub said this slug is not in the registry, so listing locally installed skills cannot
+    // resolve it; search is the only next step that can find the right slug.
+    return `Skill "${params.slug}" not found on ClawHub. Run \`${formatCliCommand(`openclaw skills search ${params.slug}`)}\` to find the right skill reference.`;
   }
   const action = params.operation === "install" ? "installing" : "verifying";
   if (error.status === 401) {

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -364,7 +364,7 @@ describe("skills-clawhub", () => {
       path: "/api/v1/skills/missing-skill/install",
       body: "remote not-found detail",
       expected:
-        'Skill "missing-skill" not found. Run `openclaw skills list` to see available skills.',
+        'Skill "missing-skill" not found on ClawHub. Run `openclaw skills search missing-skill` to find the right skill reference.',
     },
     {
       name: "maps missing versioned skills to the skills-info recovery message",
@@ -373,7 +373,7 @@ describe("skills-clawhub", () => {
       path: "/custom-clawhub/api/v1/skills/missing-skill",
       body: "remote versioned not-found detail",
       expected:
-        'Skill "missing-skill" not found. Run `openclaw skills list` to see available skills.',
+        'Skill "missing-skill" not found on ClawHub. Run `openclaw skills search missing-skill` to find the right skill reference.',
     },
     {
       name: "keeps server failures distinct from missing skills",
@@ -1961,7 +1961,7 @@ describe("skills-clawhub", () => {
       {
         ok: false,
         error:
-          'Skill "missing-skill" not found. Run `openclaw skills list` to see available skills.',
+          'Skill "missing-skill" not found on ClawHub. Run `openclaw skills search missing-skill` to find the right skill reference.',
       },
     ]);
     expect(results[0]?.ok ? "" : results[0]?.error).not.toContain(body);


### PR DESCRIPTION
## What Problem This Solves

A ClawHub 404 sends the operator in the wrong direction:

```
$ openclaw skills install nonexistent-skill-xyz
Skill "nonexistent-skill-xyz" not found. Run `openclaw skills list` to see available skills.
$ echo $?
1
```

(Full untruncated output — there is no follow-up tip.)

ClawHub is saying the slug is not in **the registry**. `skills list` lists the skills already installed **locally**, so it cannot resolve a registry miss. The operator is told to look at what they already have, at the exact moment they are trying to acquire something new. `skills verify` gives the same answer.

`openclaw skills search` exists for precisely this and sits one line away in `skills --help`:

```
  install       Install a skill from ClawHub, git, or a local directory
  list          List all available skills
  search        Search ClawHub skills
```

The sibling command family already gets this right, which is what makes it a defect rather than a wording preference:

```
$ openclaw plugins install definitely-not-a-real-plugin-xyz
Plugin not found: ... Run `openclaw plugins list` to see installed plugins,
or `openclaw plugins search definitely-not-a-real-plugin-xyz` to look for installable plugins.
```

## Why This Change Was Made

`formatClawHubSkillRequestError` already branches per status and per `operation` for 401/403/429/5xx. Only the 404 branch fell back to generic local-list advice. It now names ClawHub as the source of the miss and points at the one command that can actually find the right slug.

It also routes through `formatCliCommand`, like the sibling message in `skills-cli.format.ts` does. The string was hardcoded, so under `--profile` or `--container` it printed a command the operator could not paste back.

The local-lookup message in `skills-cli.format.ts:217` is deliberately **unchanged**. That path is looking for a skill the operator should already have, so `skills list` is the correct suggestion there — and its test at `skills-cli.commands.test.ts:1462` (which covers `skills info`) is untouched for the same reason.

## User Impact

```
Skill "nonexistent-skill-xyz" not found on ClawHub.
Run `openclaw skills search nonexistent-skill-xyz` to find the right skill reference.
```

Production LOC: +4/-1, net +3.

## Evidence

Reproduced against a real `pnpm build` dist of `main` in an isolated `OPENCLAW_STATE_DIR` + `HOME`; both `skills install` and `skills verify` hit ClawHub, received a genuine 404, and printed the old message — `install` as plain text, `verify` inside the JSON envelope.

Tests: `src/skills/lifecycle/clawhub.test.ts` (105), `src/cli/skills-cli.verify.test.ts` + `src/cli/skills-cli.commands.test.ts` (105), all passing, `rc=0`. Four existing expectations were updated deliberately — the three ClawHub-backed ones in `clawhub.test.ts` and the one in `skills-cli.verify.test.ts` — and the `skills info` expectation was left alone because it exercises the other, correct message.

`node scripts/check-changed.mjs`: every gate passes; the format lane reports `oxfmt: command not found` because this is a linked worktree without `node_modules/.bin`, so formatting was verified with the parent checkout's binary (`All matched files use the correct format.`). CI runs it properly.

`$autoreview`: clean, no accepted or actionable findings, correctness 0.99.
