### PR TITLE
fix(talk): preserve user speech in browser realtime sessions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4208,8 +4208,8 @@ ui/src/pages/chat/performance.ts	1
 ui/src/pages/chat/realtime-talk-gateway-relay.ts	1
 ui/src/pages/chat/realtime-talk-google-live.ts	2
 ui/src/pages/chat/realtime-talk-shared.ts	7
-ui/src/pages/chat/realtime-talk-webrtc.ts	3
-ui/src/pages/chat/realtime-talk.ts	7
+ui/src/pages/chat/realtime-talk-webrtc.ts	1
+ui/src/pages/chat/realtime-talk.ts	2
 ui/src/pages/chat/route.ts	2
 ui/src/pages/chat/run-lifecycle.ts	1
 ui/src/pages/chat/scroll.ts	2

--- a/extensions/openai/realtime-quicksilver-session.test.ts
+++ b/extensions/openai/realtime-quicksilver-session.test.ts
@@ -167,6 +167,8 @@ describe("GPT-Live offer broker", () => {
       if (reservation.transport !== "webrtc") {
         throw new Error("Expected WebRTC reservation");
       }
+      expect(reservation.transcriptProtocol).toBe("openai-ga-items");
+      expect(reservation.transcriptSilenceDurationMs).toBe(500);
       expect(reservation).not.toHaveProperty("model");
       expect(reservation).not.toHaveProperty("voice");
       const response = createResponseHarness();
@@ -744,6 +746,7 @@ describe("GPT-Live offer broker", () => {
       );
       expect(reservation).toMatchObject({
         offerUrl: OPENAI_QUICKSILVER_OFFER_PATH,
+        transcriptProtocol: "openai-frameless-turns",
         model: "gpt-live-1",
         voice: "marin",
         expiresAt: expect.any(Number),

--- a/extensions/openai/realtime-quicksilver-session.test.ts
+++ b/extensions/openai/realtime-quicksilver-session.test.ts
@@ -117,6 +117,27 @@ describe("GPT-Live session shaping", () => {
 });
 
 describe("GPT-Live offer broker", () => {
+  it("defaults omitted GA transcript silence metadata to 500 ms", async () => {
+    const { realtime } = createBroker();
+    try {
+      const reservation = await realtime.broker.createBrowserSession(
+        {
+          providerConfig: {},
+          model: "gpt-realtime-2.1",
+          gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
+        },
+        { type: "api-key", token: "platform-key" },
+      );
+      expect(reservation).toMatchObject({
+        transcriptProtocol: "openai-ga-items",
+        transcriptSilenceDurationMs: 500,
+      });
+      await realtime.broker.cancelBrowserSession(reservation);
+    } finally {
+      await realtime.cleanup();
+    }
+  });
+
   it("waits for the GA sideband before returning an audio-only SDP answer and hangs up once", async () => {
     let releaseSideband!: () => void;
     const sidebandReady = new Promise<void>((resolve) => {
@@ -158,6 +179,7 @@ describe("GPT-Live offer broker", () => {
           providerConfig: {},
           model: "gpt-realtime-2.1",
           gaSession: { type: "realtime", model: "gpt-realtime-2.1" },
+          gaTranscriptSilenceDurationMs: 650,
           gaSideband: {
             createBridge,
           },
@@ -168,7 +190,7 @@ describe("GPT-Live offer broker", () => {
         throw new Error("Expected WebRTC reservation");
       }
       expect(reservation.transcriptProtocol).toBe("openai-ga-items");
-      expect(reservation.transcriptSilenceDurationMs).toBe(500);
+      expect(reservation.transcriptSilenceDurationMs).toBe(650);
       expect(reservation).not.toHaveProperty("model");
       expect(reservation).not.toHaveProperty("voice");
       const response = createResponseHarness();

--- a/extensions/openai/realtime-quicksilver-session.ts
+++ b/extensions/openai/realtime-quicksilver-session.ts
@@ -58,6 +58,7 @@ type OpenAIQuicksilverSessionRequest = RealtimeVoiceBrowserSessionCreateRequest 
   initialItems?: OpenAIQuicksilverInitialItem[];
   ownerConnId?: string;
   gaSession?: Record<string, unknown> & { model: string };
+  gaTranscriptSilenceDurationMs?: number;
   gaSideband?: {
     createBridge: (params: {
       apiKey: string;
@@ -347,6 +348,12 @@ export function createOpenAIQuicksilverBrowserSessionBroker(params: {
         transport: "webrtc",
         clientSecret: token,
         offerUrl: OPENAI_QUICKSILVER_OFFER_PATH,
+        transcriptProtocol: isGptLive ? "openai-frameless-turns" : "openai-ga-items",
+        ...(!isGptLive && request.gaSession
+          ? {
+              transcriptSilenceDurationMs: request.gaTranscriptSilenceDurationMs ?? 500,
+            }
+          : {}),
         ...(request.gaSideband ? {} : { model, voice }),
         expiresAt,
       };

--- a/extensions/openai/realtime-voice-bridge-connection.test.ts
+++ b/extensions/openai/realtime-voice-bridge-connection.test.ts
@@ -127,6 +127,7 @@ describe("OpenAI realtime voice bridge connection", () => {
       offerUrl: "/plugins/openai/realtime/calls",
     });
     const brokerRequest = requireRecord(createBrowserSession.mock.calls[0]?.[0], "broker request");
+    expect(brokerRequest.gaTranscriptSilenceDurationMs).toBe(650);
     expect(createBrowserSession.mock.calls[0]?.[1]).toEqual({
       type: "api-key",
       token: "test-api-key-platform",

--- a/extensions/openai/realtime-voice-browser-auth.test.ts
+++ b/extensions/openai/realtime-voice-browser-auth.test.ts
@@ -307,6 +307,8 @@ describe("OpenAI realtime voice browser authentication", () => {
       transport: "webrtc",
       clientSecret: "client-secret-123",
       offerUrl: "https://api.openai.com/v1/realtime/calls",
+      transcriptProtocol: "openai-ga-items",
+      transcriptSilenceDurationMs: 500,
       model: "gpt-realtime-2.1",
       expiresAt: 1_765_000_000_000,
     });

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -126,10 +126,12 @@ function buildOpenAIRealtimeBrowserSessionConfig(
   model: string,
 ): {
   session: Record<string, unknown> & { model: string };
+  transcriptSilenceDurationMs: number;
   voice: OpenAIRealtimeVoice;
 } {
   const voice = normalizeOpenAIRealtimeVoice(req.voice) ?? config.voice ?? "alloy";
   const tools = normalizeOpenAIRealtimeTools(req.tools);
+  const transcriptSilenceDurationMs = req.silenceDurationMs ?? config.silenceDurationMs ?? 500;
   const session: Record<string, unknown> & { model: string } = {
     type: "realtime",
     model,
@@ -164,7 +166,7 @@ function buildOpenAIRealtimeBrowserSessionConfig(
   if (reasoningEffort) {
     session.reasoning = { effort: reasoningEffort };
   }
-  return { session, voice };
+  return { session, transcriptSilenceDurationMs, voice };
 }
 
 async function createOpenAIRealtimeBrowserSession(
@@ -271,7 +273,11 @@ async function createOpenAIRealtimeBrowserSession(
     });
     return await quicksilverBroker.createBrowserSession(quicksilverRequest, auth);
   }
-  const { session, voice } = buildOpenAIRealtimeBrowserSessionConfig(req, config, model);
+  const { session, transcriptSilenceDurationMs, voice } = buildOpenAIRealtimeBrowserSessionConfig(
+    req,
+    config,
+    model,
+  );
   const auth = await resolveOpenAIRealtimePlatformAuth({
     configuredApiKey: config.apiKey,
     cfg: req.cfg,
@@ -301,6 +307,7 @@ async function createOpenAIRealtimeBrowserSession(
       {
         ...req,
         model,
+        gaTranscriptSilenceDurationMs: transcriptSilenceDurationMs,
         voice,
         gaSession: session,
       },
@@ -320,6 +327,8 @@ async function createOpenAIRealtimeBrowserSession(
     transport: "webrtc",
     clientSecret: clientSecret.value,
     offerUrl: "https://api.openai.com/v1/realtime/calls",
+    transcriptProtocol: "openai-ga-items",
+    transcriptSilenceDurationMs,
     ...(offerHeaders ? { offerHeaders } : {}),
     model,
     voice,

--- a/extensions/openai/realtime-voice-provider.ts
+++ b/extensions/openai/realtime-voice-provider.ts
@@ -194,6 +194,7 @@ async function createOpenAIRealtimeBrowserSession(
       agentId: req.agentId,
     });
     const voice = normalizeOpenAIRealtimeVoice(req.voice) ?? config.voice ?? "alloy";
+    const transcriptSilenceDurationMs = req.silenceDurationMs ?? config.silenceDurationMs ?? 500;
     const sessionConfig = buildOpenAIRealtimeGaSessionPolicy({
       audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
       instructions: req.instructions,
@@ -202,7 +203,7 @@ async function createOpenAIRealtimeBrowserSession(
       noiseReduction: { type: "near_field" },
       prefixPaddingMs: req.prefixPaddingMs ?? config.prefixPaddingMs,
       reasoningEffort: normalizeOptionalString(req.reasoningEffort) ?? config.reasoningEffort,
-      silenceDurationMs: req.silenceDurationMs ?? config.silenceDurationMs,
+      silenceDurationMs: transcriptSilenceDurationMs,
       tools: normalizeOpenAIRealtimeTools(req.tools),
       vadThreshold: req.vadThreshold ?? config.vadThreshold,
       voice,
@@ -214,6 +215,7 @@ async function createOpenAIRealtimeBrowserSession(
         model,
         voice,
         gaSession: sessionConfig,
+        gaTranscriptSilenceDurationMs: transcriptSilenceDurationMs,
         gaSideband: {
           createBridge: ({ apiKey, callId, onTerminal }) => {
             const bridge = new OpenAIRealtimeBridge({

--- a/packages/gateway-protocol/src/channels.schema.test.ts
+++ b/packages/gateway-protocol/src/channels.schema.test.ts
@@ -1,7 +1,11 @@
 // Gateway Protocol tests cover channels.schema behavior.
 import { Compile } from "typebox/compile";
 import { describe, expect, it } from "vitest";
-import { ChannelsStatusResultSchema, WebLoginWaitParamsSchema } from "./schema/channels.js";
+import {
+  ChannelsStatusResultSchema,
+  TalkClientCreateResultSchema,
+  WebLoginWaitParamsSchema,
+} from "./schema/channels.js";
 
 /**
  * Channel schema regressions for browser login and status diagnostics.
@@ -79,6 +83,23 @@ describe("ChannelsStatusResultSchema", () => {
           utilization: 0.98,
           cpuCoreRatio: 1.2,
         },
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("TalkClientCreateResultSchema", () => {
+  const validate = Compile(TalkClientCreateResultSchema);
+
+  it("preserves previously accepted transcript silence durations", () => {
+    expect(
+      validate.Check({
+        provider: "openai",
+        transport: "webrtc",
+        voiceSessionId: "voice-1",
+        clientSecret: "single-use-token",
+        transcriptProtocol: "openai-ga-items",
+        transcriptSilenceDurationMs: 60_001,
       }),
     ).toBe(true);
   });

--- a/packages/gateway-protocol/src/schema/channels.ts
+++ b/packages/gateway-protocol/src/schema/channels.ts
@@ -440,6 +440,10 @@ const BrowserRealtimeWebRtcSdpSessionSchema = closedObject({
   clientSecret: NonEmptyString,
   offerUrl: Type.Optional(Type.String()),
   offerHeaders: Type.Optional(Type.Record(Type.String(), Type.String())),
+  transcriptProtocol: Type.Optional(
+    Type.Union([Type.Literal("openai-ga-items"), Type.Literal("openai-frameless-turns")]),
+  ),
+  transcriptSilenceDurationMs: Type.Optional(Type.Integer({ minimum: 0, maximum: 60_000 })),
   model: Type.Optional(Type.String()),
   voice: Type.Optional(Type.String()),
   expiresAt: Type.Optional(Type.Number()),

--- a/packages/gateway-protocol/src/schema/channels.ts
+++ b/packages/gateway-protocol/src/schema/channels.ts
@@ -443,7 +443,7 @@ const BrowserRealtimeWebRtcSdpSessionSchema = closedObject({
   transcriptProtocol: Type.Optional(
     Type.Union([Type.Literal("openai-ga-items"), Type.Literal("openai-frameless-turns")]),
   ),
-  transcriptSilenceDurationMs: Type.Optional(Type.Integer({ minimum: 0, maximum: 60_000 })),
+  transcriptSilenceDurationMs: Type.Optional(Type.Integer({ minimum: 0 })),
   model: Type.Optional(Type.String()),
   voice: Type.Optional(Type.String()),
   expiresAt: Type.Optional(Type.Number()),

--- a/src/talk/provider-types.ts
+++ b/src/talk/provider-types.ts
@@ -258,12 +258,18 @@ export type RealtimeVoiceBrowserAudioContract = {
   outputSampleRateHz: number;
 };
 
+type RealtimeVoiceBrowserTranscriptProtocol = "openai-ga-items" | "openai-frameless-turns";
+
 type RealtimeVoiceBrowserWebRtcSdpSession = {
   provider: RealtimeVoiceProviderId;
   transport: "webrtc";
   clientSecret: string;
   offerUrl?: string;
   offerHeaders?: Record<string, string>;
+  /** Provider event contract used to prove transcript readiness and order final turns. */
+  transcriptProtocol?: RealtimeVoiceBrowserTranscriptProtocol;
+  /** Effective provider VAD silence window used to bound final-transcript drain. */
+  transcriptSilenceDurationMs?: number;
   model?: string;
   voice?: string;
   expiresAt?: number;

--- a/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
+++ b/ui/src/pages/chat/realtime-talk-lifecycle.test.ts
@@ -8,6 +8,8 @@ const transportMock = vi.hoisted(() => ({
   relayStops: [] as Array<ReturnType<typeof vi.fn>>,
   webRtcContexts: [] as RealtimeTalkTransportContext[],
   webRtcStops: [] as Array<ReturnType<typeof vi.fn>>,
+  webRtcDrains: [] as Array<ReturnType<typeof vi.fn>>,
+  nextWebRtcDrain: undefined as (() => Promise<void>) | undefined,
   relayActivate: vi.fn(),
   start: vi.fn(async (): Promise<"ready" | "cancelled"> => "ready"),
   stop: vi.fn(),
@@ -39,7 +41,13 @@ vi.mock("./realtime-talk-webrtc.ts", () => ({
     transportMock.webRtcContexts.push(context);
     const stop = vi.fn((options?: { emitClosed?: boolean }) => transportMock.stop(options));
     transportMock.webRtcStops.push(stop);
-    return { start: transportMock.start, stop };
+    const drainImpl = transportMock.nextWebRtcDrain;
+    transportMock.nextWebRtcDrain = undefined;
+    const drain = drainImpl ? vi.fn(drainImpl) : undefined;
+    if (drain) {
+      transportMock.webRtcDrains.push(drain);
+    }
+    return { start: transportMock.start, stop, ...(drain ? { drain } : {}) };
   }),
 }));
 
@@ -68,6 +76,8 @@ describe("RealtimeTalkSession lifecycle", () => {
     transportMock.relayStops.length = 0;
     transportMock.webRtcContexts.length = 0;
     transportMock.webRtcStops.length = 0;
+    transportMock.webRtcDrains.length = 0;
+    transportMock.nextWebRtcDrain = undefined;
     transportMock.relayActivate.mockClear();
     transportMock.start.mockClear();
     transportMock.stop.mockClear();
@@ -110,6 +120,128 @@ describe("RealtimeTalkSession lifecycle", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("keeps transcript ownership until the active transport drains on stop", async () => {
+    const drain = createDeferred();
+    transportMock.nextWebRtcDrain = () => drain.promise;
+    const transcriptEntryIds: string[] = [];
+    const request = vi.fn(async (method: string, params?: { entryId?: string }) => {
+      if (method === "talk.client.create") {
+        return {
+          provider: "openai",
+          transport: "webrtc",
+          voiceSessionId: "voice-drain",
+          clientSecret: "secret",
+        };
+      }
+      if (method === "talk.client.transcript") {
+        transcriptEntryIds.push(String(params?.entryId));
+      }
+      return { ok: true };
+    });
+    const session = new RealtimeTalkSession({ request } as never, "agent:main:main");
+    await session.start();
+    const context = transcriptContext(transportMock.webRtcContexts);
+
+    session.stop();
+    expect(transportMock.webRtcDrains[0]).toHaveBeenCalledOnce();
+    expect(transportMock.webRtcStops[0]).not.toHaveBeenCalled();
+    context.callbacks.onTranscript?.({ role: "user", text: "last turn", final: true });
+    await context.flushTranscriptWrites?.();
+    expect(transcriptEntryIds).toEqual(["1"]);
+
+    drain.resolve();
+    await vi.waitFor(() => expect(transportMock.webRtcStops[0]).toHaveBeenCalledOnce());
+    await vi.waitFor(() =>
+      expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(true),
+    );
+  });
+
+  it("waits for the previous transcript drain before starting a replacement", async () => {
+    const drain = createDeferred();
+    transportMock.nextWebRtcDrain = () => drain.promise;
+    let createCount = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.client.create") {
+        createCount += 1;
+        return {
+          provider: "openai",
+          transport: "webrtc",
+          voiceSessionId: `voice-${createCount}`,
+          clientSecret: "secret",
+        };
+      }
+      return { ok: true };
+    });
+    const session = new RealtimeTalkSession({ request } as never, "agent:main:main");
+    await session.start();
+    session.stop();
+
+    const restart = session.start();
+    await Promise.resolve();
+    expect(createCount).toBe(1);
+
+    drain.resolve();
+    await restart;
+    expect(createCount).toBe(2);
+    session.stop();
+  });
+
+  it("closes the logical voice session when the terminal status observer throws", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.client.create") {
+        return {
+          provider: "openai",
+          transport: "webrtc",
+          voiceSessionId: "voice-fatal-observer",
+          clientSecret: "secret",
+        };
+      }
+      return { ok: true };
+    });
+    const session = new RealtimeTalkSession({ request } as never, "agent:main:main", {
+      onStatus: (status) => {
+        if (status === "error") {
+          throw new Error("status observer failed");
+        }
+      },
+    });
+    await session.start();
+
+    transcriptContext(transportMock.webRtcContexts).callbacks.onFatalError?.(
+      "terminal transcript failure",
+    );
+
+    await vi.waitFor(() =>
+      expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(true),
+    );
+    expect(transportMock.webRtcStops[0]).toHaveBeenCalledOnce();
+  });
+
+  it("closes the logical voice session when transport stop throws", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "talk.client.create") {
+        return {
+          provider: "openai",
+          transport: "webrtc",
+          voiceSessionId: "voice-stop-observer",
+          clientSecret: "secret",
+        };
+      }
+      return { ok: true };
+    });
+    const session = new RealtimeTalkSession({ request } as never, "agent:main:main");
+    await session.start();
+    transportMock.stop.mockImplementationOnce(() => {
+      throw new Error("stop observer failed");
+    });
+
+    session.stop();
+
+    await vi.waitFor(() =>
+      expect(request.mock.calls.some(([method]) => method === "talk.client.close")).toBe(true),
+    );
   });
 
   it("continues entry ids when the same voice session replaces its transport", async () => {

--- a/ui/src/pages/chat/realtime-talk-openai-transcript-owner.test.ts
+++ b/ui/src/pages/chat/realtime-talk-openai-transcript-owner.test.ts
@@ -44,6 +44,7 @@ describe("OpenAiRealtimeTranscriptOwner", () => {
   it("rejects missing item identity and explicit provider failure", () => {
     const owner = new OpenAiRealtimeTranscriptOwner();
     expect(() => owner.commit("")).toThrow("identity was missing");
+    expect(() => owner.assistant("answer", 42)).toThrow("identity was invalid");
     owner.commit("a");
     expect(() => owner.fail("a", "provider rejected transcription")).toThrow(
       "provider rejected transcription",
@@ -71,6 +72,26 @@ describe("OpenAiRealtimeTranscriptOwner", () => {
       { role: "assistant", text: "answer", itemId: "assistant-a" },
     ]);
     expect(owner.assistant("duplicate", "assistant-a")).toEqual([]);
+  });
+
+  it("delivers each unkeyed assistant final", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    expect(owner.assistant("first", undefined)).toEqual([
+      { role: "assistant", text: "first", itemId: undefined },
+    ]);
+    expect(owner.assistant("second", "  ")).toEqual([
+      { role: "assistant", text: "second", itemId: undefined },
+    ]);
+  });
+
+  it("holds an unkeyed assistant final behind an unresolved user commit", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    owner.commit("user-a");
+    expect(owner.assistant("answer", undefined)).toEqual([]);
+    expect(owner.complete("user-a", "question")).toEqual([
+      { role: "user", text: "question", itemId: "user-a" },
+      { role: "assistant", text: "answer", itemId: undefined },
+    ]);
   });
 
   it("detects unresolved user items at close", () => {

--- a/ui/src/pages/chat/realtime-talk-openai-transcript-owner.test.ts
+++ b/ui/src/pages/chat/realtime-talk-openai-transcript-owner.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { OpenAiRealtimeTranscriptOwner } from "./realtime-talk-openai-transcript-owner.ts";
+
+describe("OpenAiRealtimeTranscriptOwner", () => {
+  it("emits completed user transcripts in committed order", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    expect(owner.commit("a")).toEqual([]);
+    expect(owner.commit("b")).toEqual([]);
+    expect(owner.complete("b", "second")).toEqual([]);
+    expect(owner.complete("a", "first")).toEqual([
+      { role: "user", text: "first", itemId: "a" },
+      { role: "user", text: "second", itemId: "b" },
+    ]);
+  });
+
+  it("holds completion-before-commit and deduplicates terminals", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    expect(owner.complete("a", "first")).toEqual([]);
+    expect(owner.complete("a", "duplicate")).toEqual([]);
+    expect(owner.commit("a")).toEqual([{ role: "user", text: "first", itemId: "a" }]);
+    expect(owner.complete("a", "late duplicate")).toEqual([]);
+  });
+
+  it("holds assistant finals behind completion-before-commit user items", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    expect(owner.complete("a", "question")).toEqual([]);
+    expect(owner.assistant("answer", "assistant-a")).toEqual([]);
+    expect(owner.commit("a")).toEqual([
+      { role: "user", text: "question", itemId: "a" },
+      { role: "assistant", text: "answer", itemId: "assistant-a" },
+    ]);
+  });
+
+  it("holds assistant finals behind unresolved user commits", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    owner.commit("a");
+    expect(owner.assistant("answer", "assistant-a")).toEqual([]);
+    expect(owner.complete("a", "question")).toEqual([
+      { role: "user", text: "question", itemId: "a" },
+      { role: "assistant", text: "answer", itemId: "assistant-a" },
+    ]);
+  });
+
+  it("rejects missing item identity and explicit provider failure", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    expect(() => owner.commit("")).toThrow("identity was missing");
+    owner.commit("a");
+    expect(() => owner.fail("a", "provider rejected transcription")).toThrow(
+      "provider rejected transcription",
+    );
+  });
+
+  it("settles an empty completion as non-speech without persisting a placeholder", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    expect(owner.commit("noise")).toEqual([]);
+    expect(owner.complete("noise", "  ")).toEqual([]);
+    expect(owner.pendingCount).toBe(0);
+    expect(() => owner.assertSettled()).not.toThrow();
+  });
+
+  it("keeps the first terminal outcome for an item", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    owner.commit("a");
+    expect(owner.complete("a", "done")).toEqual([{ role: "user", text: "done", itemId: "a" }]);
+    expect(owner.fail("a", "late failure")).toEqual([]);
+  });
+
+  it("deduplicates assistant finals by provider item id", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    expect(owner.assistant("answer", "assistant-a")).toEqual([
+      { role: "assistant", text: "answer", itemId: "assistant-a" },
+    ]);
+    expect(owner.assistant("duplicate", "assistant-a")).toEqual([]);
+  });
+
+  it("detects unresolved user items at close", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    owner.commit("a");
+    expect(() => owner.assertSettled()).toThrow("final user transcription");
+    owner.complete("a", "done");
+    expect(() => owner.assertSettled()).not.toThrow();
+  });
+
+  it("bounds unresolved provider items", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    for (let index = 0; index < 64; index += 1) {
+      owner.commit(`item-${index}`);
+    }
+    expect(() => owner.commit("item-overflow")).toThrow("unresolved item limit");
+  });
+
+  it("bounds provider item identities by UTF-8 bytes", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    expect(() => owner.commit("x".repeat(1_025))).toThrow("item identity limit");
+    expect(() => owner.commit("é".repeat(513))).toThrow("item identity limit");
+    expect(() => owner.assistant("answer", "x".repeat(1_025))).toThrow("item identity limit");
+  });
+
+  it("bounds assistant finals held behind an unresolved user item", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    owner.commit("user-pending");
+    for (let index = 0; index < 127; index += 1) {
+      owner.assistant(`answer-${index}`, `assistant-${index}`);
+    }
+    expect(() => owner.assistant("overflow", "assistant-overflow")).toThrow("ordered item limit");
+  });
+
+  it("bounds retained transcript text by UTF-8 bytes", () => {
+    const owner = new OpenAiRealtimeTranscriptOwner();
+    owner.commit("a");
+    expect(() => owner.complete("a", "x".repeat(256 * 1_024 + 1))).toThrow(
+      "retained transcript limit",
+    );
+    expect(() => owner.complete("a", "é".repeat(128 * 1_024 + 1))).toThrow(
+      "retained transcript limit",
+    );
+  });
+});

--- a/ui/src/pages/chat/realtime-talk-openai-transcript-owner.ts
+++ b/ui/src/pages/chat/realtime-talk-openai-transcript-owner.ts
@@ -85,8 +85,8 @@ export class OpenAiRealtimeTranscriptOwner {
   }
 
   assistant(rawText: unknown, rawItemId: unknown): TranscriptAction[] {
-    const itemId = this.requireItemId(rawItemId);
-    if (this.settledIds.has(itemId) || this.pendingAssistantIds.has(itemId)) {
+    const itemId = this.optionalItemId(rawItemId);
+    if (itemId && (this.settledIds.has(itemId) || this.pendingAssistantIds.has(itemId))) {
       return [];
     }
     const text = typeof rawText === "string" ? rawText.trim() : "";
@@ -100,7 +100,9 @@ export class OpenAiRealtimeTranscriptOwner {
     }
     this.retainedBytes += bytes;
     const entry: AssistantEntry = { kind: "assistant", text, itemId };
-    this.pendingAssistantIds.add(itemId);
+    if (itemId) {
+      this.pendingAssistantIds.add(itemId);
+    }
     if (this.earlyCompletions.size > 0) {
       this.deferredAssistants.push(entry);
       return [];
@@ -180,6 +182,23 @@ export class OpenAiRealtimeTranscriptOwner {
     const itemId = typeof value === "string" ? value.trim() : "";
     if (!itemId) {
       throw new Error("Realtime transcription item identity was missing");
+    }
+    if (encoder.encode(itemId).byteLength > MAX_ITEM_ID_BYTES) {
+      throw new Error("Realtime transcription exceeded the item identity limit");
+    }
+    return itemId;
+  }
+
+  private optionalItemId(value: unknown): string | undefined {
+    if (value === undefined || value === null) {
+      return undefined;
+    }
+    if (typeof value !== "string") {
+      throw new Error("Realtime transcription item identity was invalid");
+    }
+    const itemId = value.trim();
+    if (!itemId) {
+      return undefined;
     }
     if (encoder.encode(itemId).byteLength > MAX_ITEM_ID_BYTES) {
       throw new Error("Realtime transcription exceeded the item identity limit");

--- a/ui/src/pages/chat/realtime-talk-openai-transcript-owner.ts
+++ b/ui/src/pages/chat/realtime-talk-openai-transcript-owner.ts
@@ -1,0 +1,215 @@
+const MAX_UNRESOLVED_ITEMS = 64;
+const MAX_ORDERED_ITEMS = 128;
+const MAX_ITEM_ID_BYTES = 1_024;
+const MAX_RETAINED_TRANSCRIPT_BYTES = 256 * 1_024;
+const MAX_SETTLED_ITEMS = 4_096;
+const MAX_SETTLED_ID_BYTES = 256 * 1_024;
+
+const encoder = new TextEncoder();
+
+type TranscriptAction = {
+  role: "user" | "assistant";
+  text: string;
+  itemId?: string;
+};
+
+type UserEntry = {
+  kind: "user";
+  itemId: string;
+  text?: string | null;
+};
+
+type AssistantEntry = {
+  kind: "assistant";
+  text: string;
+  itemId?: string;
+};
+
+type OrderedEntry = UserEntry | AssistantEntry;
+
+export class OpenAiRealtimeTranscriptOwner {
+  private readonly ordered: OrderedEntry[] = [];
+  private readonly deferredAssistants: AssistantEntry[] = [];
+  private readonly unresolvedUsers = new Map<string, UserEntry>();
+  private readonly earlyCompletions = new Map<string, string | null>();
+  private readonly pendingAssistantIds = new Set<string>();
+  private readonly settledIds = new Set<string>();
+  private retainedBytes = 0;
+  private settledIdBytes = 0;
+
+  commit(rawItemId: unknown): TranscriptAction[] {
+    const itemId = this.requireItemId(rawItemId);
+    if (this.settledIds.has(itemId) || this.unresolvedUsers.has(itemId)) {
+      return [];
+    }
+    const early = this.earlyCompletions.get(itemId);
+    if (early === undefined) {
+      this.assertUnresolvedCapacity();
+    }
+    this.assertOrderedCapacity();
+    const entry: UserEntry = { kind: "user", itemId };
+    if (early !== undefined) {
+      entry.text = early;
+      this.earlyCompletions.delete(itemId);
+    }
+    this.unresolvedUsers.set(itemId, entry);
+    this.ordered.push(entry);
+    if (this.earlyCompletions.size === 0 && this.deferredAssistants.length > 0) {
+      this.ordered.push(...this.deferredAssistants.splice(0));
+    }
+    return this.flush();
+  }
+
+  complete(rawItemId: unknown, rawText: unknown): TranscriptAction[] {
+    const itemId = this.requireItemId(rawItemId);
+    if (this.settledIds.has(itemId)) {
+      return [];
+    }
+    const text = typeof rawText === "string" ? rawText.trim() || null : null;
+    const entry = this.unresolvedUsers.get(itemId);
+    if (entry?.text !== undefined || this.earlyCompletions.has(itemId)) {
+      return [];
+    }
+    const bytes = text ? encoder.encode(text).byteLength : 0;
+    if (bytes > MAX_RETAINED_TRANSCRIPT_BYTES - this.retainedBytes) {
+      throw new Error("Realtime transcription exceeded the retained transcript limit");
+    }
+    this.retainedBytes += bytes;
+    if (entry) {
+      entry.text = text;
+    } else {
+      this.assertUnresolvedCapacity();
+      this.earlyCompletions.set(itemId, text);
+    }
+    return this.flush();
+  }
+
+  assistant(rawText: unknown, rawItemId: unknown): TranscriptAction[] {
+    const itemId = this.requireItemId(rawItemId);
+    if (this.settledIds.has(itemId) || this.pendingAssistantIds.has(itemId)) {
+      return [];
+    }
+    const text = typeof rawText === "string" ? rawText.trim() : "";
+    if (!text) {
+      return [];
+    }
+    this.assertOrderedCapacity();
+    const bytes = encoder.encode(text).byteLength;
+    if (bytes > MAX_RETAINED_TRANSCRIPT_BYTES - this.retainedBytes) {
+      throw new Error("Realtime transcription exceeded the retained transcript limit");
+    }
+    this.retainedBytes += bytes;
+    const entry: AssistantEntry = { kind: "assistant", text, itemId };
+    this.pendingAssistantIds.add(itemId);
+    if (this.earlyCompletions.size > 0) {
+      this.deferredAssistants.push(entry);
+      return [];
+    }
+    this.ordered.push(entry);
+    return this.flush();
+  }
+
+  fail(rawItemId: unknown, detail: string): TranscriptAction[] {
+    const itemId = this.requireItemId(rawItemId);
+    if (
+      this.settledIds.has(itemId) ||
+      this.unresolvedUsers.get(itemId)?.text !== undefined ||
+      this.earlyCompletions.has(itemId)
+    ) {
+      return [];
+    }
+    throw new Error(detail.trim() || "Realtime user transcription failed");
+  }
+
+  get pendingCount(): number {
+    return this.unresolvedUsers.size + this.earlyCompletions.size;
+  }
+
+  assertSettled(): void {
+    if (this.pendingCount > 0) {
+      throw new Error("Realtime Talk closed before the final user transcription completed");
+    }
+  }
+
+  reset(): void {
+    this.ordered.length = 0;
+    this.deferredAssistants.length = 0;
+    this.unresolvedUsers.clear();
+    this.earlyCompletions.clear();
+    this.pendingAssistantIds.clear();
+    this.settledIds.clear();
+    this.retainedBytes = 0;
+    this.settledIdBytes = 0;
+  }
+
+  private flush(): TranscriptAction[] {
+    const actions: TranscriptAction[] = [];
+    while (this.ordered.length > 0) {
+      const entry = this.ordered[0];
+      if (!entry) {
+        break;
+      }
+      if (entry.kind === "user" && entry.text === undefined) {
+        break;
+      }
+      this.ordered.shift();
+      if (entry.kind === "user") {
+        const text = entry.text;
+        if (text === undefined) {
+          break;
+        }
+        this.unresolvedUsers.delete(entry.itemId);
+        this.rememberSettled(entry.itemId);
+        if (text) {
+          this.retainedBytes -= encoder.encode(text).byteLength;
+          actions.push({ role: "user", text, itemId: entry.itemId });
+        }
+      } else {
+        if (entry.itemId) {
+          this.pendingAssistantIds.delete(entry.itemId);
+          this.rememberSettled(entry.itemId);
+        }
+        this.retainedBytes -= encoder.encode(entry.text).byteLength;
+        actions.push({ role: "assistant", text: entry.text, itemId: entry.itemId });
+      }
+    }
+    return actions;
+  }
+
+  private requireItemId(value: unknown): string {
+    const itemId = typeof value === "string" ? value.trim() : "";
+    if (!itemId) {
+      throw new Error("Realtime transcription item identity was missing");
+    }
+    if (encoder.encode(itemId).byteLength > MAX_ITEM_ID_BYTES) {
+      throw new Error("Realtime transcription exceeded the item identity limit");
+    }
+    return itemId;
+  }
+
+  private assertUnresolvedCapacity(): void {
+    if (this.pendingCount >= MAX_UNRESOLVED_ITEMS) {
+      throw new Error("Realtime transcription exceeded the unresolved item limit");
+    }
+  }
+
+  private assertOrderedCapacity(): void {
+    if (this.ordered.length + this.deferredAssistants.length >= MAX_ORDERED_ITEMS) {
+      throw new Error("Realtime transcription exceeded the ordered item limit");
+    }
+  }
+
+  private rememberSettled(itemId: string): void {
+    const bytes = encoder.encode(itemId).byteLength;
+    if (
+      this.settledIds.size >= MAX_SETTLED_ITEMS ||
+      bytes > MAX_SETTLED_ID_BYTES - this.settledIdBytes
+    ) {
+      throw new Error("Realtime transcription exceeded the terminal item history limit");
+    }
+    this.settledIds.add(itemId);
+    this.settledIdBytes += bytes;
+  }
+}
+
+export type { TranscriptAction as OpenAiRealtimeTranscriptAction };

--- a/ui/src/pages/chat/realtime-talk-session-factory.ts
+++ b/ui/src/pages/chat/realtime-talk-session-factory.ts
@@ -1,0 +1,45 @@
+import { normalizeTalkTransport } from "../../../../src/talk/talk-session-controller.js";
+import { GatewayRelayRealtimeTalkTransport } from "./realtime-talk-gateway-relay.ts";
+import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
+import type {
+  RealtimeTalkGatewayRelaySessionResult,
+  RealtimeTalkJsonPcmWebSocketSessionResult,
+  RealtimeTalkSessionResult,
+  RealtimeTalkTransport,
+  RealtimeTalkTransportContext,
+  RealtimeTalkWebRtcSdpSessionResult,
+} from "./realtime-talk-shared.ts";
+import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
+
+export function resolveRealtimeTalkTransport(session: RealtimeTalkSessionResult): string {
+  // SAFETY: every Talk session result may carry the optional wire transport discriminator.
+  return normalizeTalkTransport((session as { transport?: string }).transport) ?? "webrtc";
+}
+
+export function createRealtimeTalkTransport(
+  session: RealtimeTalkSessionResult,
+  ctx: RealtimeTalkTransportContext,
+): RealtimeTalkTransport {
+  const transport = resolveRealtimeTalkTransport(session);
+  if (transport === "webrtc") {
+    // SAFETY: transport resolution above selects the WebRTC result variant.
+    return new WebRtcSdpRealtimeTalkTransport(session as RealtimeTalkWebRtcSdpSessionResult, ctx);
+  }
+  if (transport === "provider-websocket") {
+    return new GoogleLiveRealtimeTalkTransport(
+      // SAFETY: transport resolution above selects the provider-WebSocket result variant.
+      session as RealtimeTalkJsonPcmWebSocketSessionResult,
+      ctx,
+    );
+  }
+  if (transport === "gateway-relay") {
+    return new GatewayRelayRealtimeTalkTransport(
+      // SAFETY: transport resolution above selects the Gateway-relay result variant.
+      session as RealtimeTalkGatewayRelaySessionResult,
+      ctx,
+    );
+  }
+  // SAFETY: all result variants may carry the optional raw transport for diagnostics.
+  const unknownTransport = (session as { transport?: string }).transport ?? "unknown";
+  throw new Error(`Unsupported realtime Talk transport: ${unknownTransport}`);
+}

--- a/ui/src/pages/chat/realtime-talk-shared.ts
+++ b/ui/src/pages/chat/realtime-talk-shared.ts
@@ -23,6 +23,8 @@ export type RealtimeTalkCallbacks = {
   onTalkEvent?: (event: RealtimeTalkEvent) => void;
   onVideoStream?: (stream: MediaStream | null) => void;
   onVideoError?: (error: unknown) => void;
+  /** Internal terminal signal used when continuing would silently lose shared history. */
+  onFatalError?: (detail: string) => void;
 };
 
 export type RealtimeTalkEventInput<TPayload = unknown> = {
@@ -50,6 +52,8 @@ export type RealtimeTalkWebRtcSdpSessionResult = {
   clientSecret: string;
   offerUrl?: string;
   offerHeaders?: Record<string, string>;
+  transcriptProtocol?: "openai-ga-items" | "openai-frameless-turns";
+  transcriptSilenceDurationMs?: number;
   model?: string;
   voice?: string;
   expiresAt?: number;
@@ -110,6 +114,8 @@ export type RealtimeTalkTransportStartResult = "ready" | "cancelled";
 export type RealtimeTalkTransport = {
   start(): Promise<RealtimeTalkTransportStartResult>;
   activate?: () => void;
+  /** Mute input immediately, then retain ownership until accepted provider finals settle. */
+  drain?: () => Promise<void>;
   stop(options?: { emitClosed?: boolean }): void;
   setVideoEnabled?: (enabled: boolean) => Promise<void>;
   switchCamera?: (videoDeviceId: string | undefined) => Promise<void>;

--- a/ui/src/pages/chat/realtime-talk-transcript-owner.ts
+++ b/ui/src/pages/chat/realtime-talk-transcript-owner.ts
@@ -111,13 +111,119 @@ export function retireUncommittedRealtimeTalkTransport(params: {
   params.closeVoiceSession();
 }
 
-export function transcriptPersistenceAbortError(): Error {
+function transcriptPersistenceAbortError(): Error {
   const error = new Error("voice transcript persistence aborted");
   error.name = "AbortError";
   return error;
 }
 
-export async function waitForTranscriptRetry(delayMs: number, signal: AbortSignal): Promise<void> {
+function transcriptWriteError(error: unknown, fallback: string): Error {
+  return error instanceof Error ? error : new Error(fallback, { cause: error });
+}
+
+export async function writeRealtimeTalkTranscriptWithRetry(params: {
+  client: GatewayBrowserClient;
+  sessionKey: string;
+  voiceSessionId: string;
+  entryId: string;
+  role: "user" | "assistant";
+  text: string;
+  signal: AbortSignal;
+}): Promise<void> {
+  const retryDelaysMs = [0, 500, 2_000];
+  let lastError: unknown;
+  for (const delayMs of retryDelaysMs) {
+    if (delayMs > 0) {
+      await waitForTranscriptRetry(delayMs, params.signal);
+    } else if (params.signal.aborted) {
+      throw transcriptPersistenceAbortError();
+    }
+    try {
+      await params.client.request(
+        "talk.client.transcript",
+        {
+          sessionKey: params.sessionKey,
+          voiceSessionId: params.voiceSessionId,
+          entryId: params.entryId,
+          role: params.role,
+          text: params.text,
+          timestamp: Date.now(),
+        },
+        {
+          signal: params.signal,
+          timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+        },
+      );
+      return;
+    } catch (error) {
+      if (params.signal.aborted) {
+        throw transcriptPersistenceAbortError();
+      }
+      lastError = error;
+    }
+  }
+  throw transcriptWriteError(lastError, "voice transcript save failed");
+}
+
+export function closeRealtimeTalkVoiceSession(params: {
+  client: GatewayBrowserClient;
+  sessionKey: string;
+  detached: DetachedVoiceSession;
+  isCurrentGeneration: () => boolean;
+  onStatus?: (status: "error", detail: string) => void;
+}): void {
+  const { detached } = params;
+  if (detached.serverOwned) {
+    detached.owner?.release();
+    return;
+  }
+  const owner = detached.owner!;
+  owner.beginDrain();
+  void detached.transcriptQueue
+    .flush()
+    .then(async () => {
+      let lastError: unknown;
+      for (const delayMs of [0, 500, 2_000]) {
+        if (delayMs > 0) {
+          await waitForTranscriptRetry(delayMs, owner.closeSignal);
+        } else if (owner.closeSignal.aborted) {
+          throw transcriptPersistenceAbortError();
+        }
+        try {
+          await params.client.request(
+            "talk.client.close",
+            {
+              sessionKey: params.sessionKey,
+              voiceSessionId: detached.voiceSessionId,
+            },
+            {
+              signal: owner.closeSignal,
+              timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+            },
+          );
+          return;
+        } catch (error) {
+          if (owner.closeSignal.aborted) {
+            throw transcriptPersistenceAbortError();
+          }
+          lastError = error;
+        }
+      }
+      throw transcriptWriteError(lastError, "Realtime Talk voice session close failed");
+    })
+    .catch((error: unknown) => {
+      if (owner.closeSignal.aborted) {
+        return;
+      }
+      console.warn("Realtime Talk voice session close failed", error);
+      if (params.isCurrentGeneration()) {
+        params.onStatus?.("error", "Realtime Talk voice session close failed");
+      }
+    })
+    .finally(owner.release);
+}
+
+async function waitForTranscriptRetry(delayMs: number, signal: AbortSignal): Promise<void> {
   if (signal.aborted) {
     throw transcriptPersistenceAbortError();
   }

--- a/ui/src/pages/chat/realtime-talk-webrtc-control.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-control.test.ts
@@ -44,11 +44,27 @@ class FakePeerConnection extends EventTarget {
 
   async setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void> {
     this.remoteDescription = description;
+    this.channel.dispatchEvent(new Event("open"));
+    this.channel.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "session.created",
+          session: {
+            audio: { input: { transcription: { model: "gpt-4o-mini-transcribe" } } },
+          },
+        }),
+      }),
+    );
   }
 
   close(): void {
     this.connectionState = "closed";
   }
+}
+
+async function startAndActivate(transport: WebRtcSdpRealtimeTalkTransport): Promise<void> {
+  await transport.start();
+  transport.activate();
 }
 
 function createOpenAiTransport(
@@ -60,6 +76,7 @@ function createOpenAiTransport(
       provider: "openai",
       transport: "webrtc",
       clientSecret: "client-secret-123",
+      transcriptProtocol: "openai-ga-items",
     },
     {
       client: client as never,
@@ -126,6 +143,7 @@ function sentRealtimeEvents(peer: FakePeerConnection | undefined): Array<Record<
 
 describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
   beforeEach(() => {
+    vi.spyOn(globalThis.HTMLMediaElement.prototype, "pause").mockImplementation(() => undefined);
     FakePeerConnection.instances = [];
     const track = { stop: vi.fn() } as unknown as MediaStreamTrack;
     const stream = {
@@ -146,6 +164,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
 
@@ -171,7 +190,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
       request,
     });
 
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     dispatchControlToolCall(peer, { text: "revísalo en WebUI", mode: "steer" });
 
@@ -195,6 +214,37 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     transport.stop();
   });
 
+  it("suppresses an in-flight control result after transcript drain begins", async () => {
+    let resolveSteer: (value: unknown) => void = () => undefined;
+    const request = vi.fn(
+      async () =>
+        await new Promise<unknown>((resolve) => {
+          resolveSteer = resolve;
+        }),
+    );
+    const transport = createOpenAiTransport({
+      addEventListener: vi.fn(() => () => undefined),
+      request,
+    });
+
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchControlToolCall(peer, { text: "status", mode: "status" });
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    const sentBeforeDrain = sentRealtimeEvents(peer).length;
+
+    const drainResult = transport.drain().catch((error: unknown) => error);
+    resolveSteer({ ok: true, mode: "status", message: "late" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sentRealtimeEvents(peer)).toHaveLength(sentBeforeDrain);
+    transport.stop();
+    await expect(drainResult).resolves.toMatchObject(
+      new Error("Realtime Talk stopped before transcript drain completed"),
+    );
+  });
+
   it("executes completed calls once and ignores provisional events", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "talk.client.toolCall") {
@@ -207,7 +257,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
       request,
     });
 
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     for (const type of [
       "response.function_call_arguments.delta",
@@ -267,7 +317,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     const request = vi.fn();
     const transport = createOpenAiTransport({ request });
 
-    await transport.start();
+    await startAndActivate(transport);
     dispatchCompletedToolCall(FakePeerConnection.instances[0], {
       responseStatus,
       itemStatus,
@@ -289,7 +339,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     });
     const transport = createOpenAiTransport({ request });
 
-    await transport.start();
+    await startAndActivate(transport);
     dispatchCompletedToolCall(FakePeerConnection.instances[0], {
       responseId: null,
       itemId: null,
@@ -309,7 +359,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     const request = vi.fn();
     const transport = createOpenAiTransport({ request });
 
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     for (const overrides of [
       { callId: null, itemId: "missing-call" },
@@ -339,7 +389,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     const argumentsAtLimit = baseArgs + " ".repeat(256_000 - baseArgs.length);
     const oversizedArguments = JSON.stringify({ text: "é".repeat(128_000) });
 
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     dispatchCompletedToolCall(peer, { arguments: argumentsAtLimit });
     await waitForFast(() => expect(request).toHaveBeenCalledOnce());
@@ -384,7 +434,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     const onStatus = vi.fn();
     const transport = createOpenAiTransport({}, { onStatus });
 
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     for (let index = 0; index < 1_024; index += 1) {
       dispatchCompletedToolCall(peer, {
@@ -432,7 +482,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     });
     const transport = createOpenAiTransport({ request }, { onStatus, onTalkEvent });
 
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     peer?.channel.send.mockImplementation(() => {
       throw new Error("OpenAI data channel rejected the tool result");
@@ -457,7 +507,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
   it("silently disposes a provisional OpenAI transport", async () => {
     const onTalkEvent = vi.fn();
     const transport = createOpenAiTransport({}, { onTalkEvent });
-    await transport.start();
+    await startAndActivate(transport);
     onTalkEvent.mockClear();
 
     transport.stop({ emitClosed: false });
@@ -473,7 +523,7 @@ describe("WebRtcSdpRealtimeTalkTransport control tool", () => {
     const onTranscript = vi.fn(() => transportRef.current?.stop());
     const transport = createOpenAiTransport({}, { onStatus, onTalkEvent, onTranscript });
     transportRef.current = transport;
-    await transport.start();
+    await startAndActivate(transport);
     onStatus.mockClear();
     onTalkEvent.mockClear();
 

--- a/ui/src/pages/chat/realtime-talk-webrtc-readiness.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-readiness.ts
@@ -1,0 +1,139 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import type { RealtimeTalkWebRtcSdpSessionResult } from "./realtime-talk-shared.ts";
+import type { RealtimeServerEvent } from "./realtime-talk-webrtc-support.ts";
+
+const MAX_PROVISIONAL_EVENTS = 32;
+const MAX_PROVISIONAL_EVENT_BYTES = 256 * 1_024;
+const SESSION_READY_TIMEOUT_MS = 10_000;
+const encoder = new TextEncoder();
+
+export class RealtimeTalkWebRtcReadinessOwner {
+  private channelOpen = false;
+  private providerReady = false;
+  private terminalError: Error | null = null;
+  private resolve: (() => void) | null = null;
+  private reject: ((error: Error) => void) | null = null;
+  private timer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private readonly buffered: RealtimeServerEvent[] = [];
+  private bufferedBytes = 0;
+
+  constructor(private readonly protocol: RealtimeTalkWebRtcSdpSessionResult["transcriptProtocol"]) {
+    this.reset();
+  }
+
+  reset(): void {
+    this.cancel(new Error("Realtime Talk provider readiness was reset"));
+    this.channelOpen = false;
+    this.providerReady = this.protocol === undefined;
+    this.terminalError = null;
+    this.buffered.length = 0;
+    this.bufferedBytes = 0;
+  }
+
+  markChannelOpen(): void {
+    this.channelOpen = true;
+    this.maybeResolve();
+  }
+
+  get isReady(): boolean {
+    return this.terminalError === null && this.channelOpen && this.providerReady;
+  }
+
+  wait(): Promise<void> {
+    if (this.terminalError) {
+      return Promise.reject(this.terminalError);
+    }
+    if (this.isReady) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+      this.timer = globalThis.setTimeout(() => {
+        this.fail(new Error("Realtime provider did not confirm transcript readiness"));
+      }, SESSION_READY_TIMEOUT_MS);
+      this.maybeResolve();
+    });
+  }
+
+  consumeReadinessEvent(
+    event: RealtimeServerEvent,
+    extractErrorDetail: (error: unknown) => string,
+  ): boolean {
+    if (this.protocol === "openai-frameless-turns" && event.type === "session.started") {
+      this.providerReady = true;
+      this.maybeResolve();
+      return true;
+    }
+    if (
+      this.protocol === "openai-ga-items" &&
+      (event.type === "session.created" || event.type === "session.updated")
+    ) {
+      const session = isRecord(event.session) ? event.session : undefined;
+      const audio = session && isRecord(session.audio) ? session.audio : undefined;
+      const input = audio && isRecord(audio.input) ? audio.input : undefined;
+      const transcription =
+        input && isRecord(input.transcription) ? input.transcription : undefined;
+      if (typeof transcription?.model === "string" && transcription.model.trim()) {
+        this.providerReady = true;
+        this.maybeResolve();
+      } else if (event.type === "session.updated" || this.providerReady) {
+        this.providerReady = false;
+        this.fail(new Error("Realtime provider did not enable input transcription"));
+      }
+      return true;
+    }
+    if (event.type === "error") {
+      this.fail(new Error(extractErrorDetail(event.error)));
+      return true;
+    }
+    return false;
+  }
+
+  buffer(event: RealtimeServerEvent): void {
+    const bytes = encoder.encode(JSON.stringify(event)).byteLength;
+    if (
+      this.buffered.length >= MAX_PROVISIONAL_EVENTS ||
+      bytes > MAX_PROVISIONAL_EVENT_BYTES - this.bufferedBytes
+    ) {
+      throw new Error("Realtime provider sent too many events before transcript readiness");
+    }
+    this.buffered.push(event);
+    this.bufferedBytes += bytes;
+  }
+
+  takeBuffered(): RealtimeServerEvent[] {
+    const events = this.buffered.splice(0);
+    this.bufferedBytes = 0;
+    return events;
+  }
+
+  cancel(error: Error): void {
+    this.fail(error);
+  }
+
+  private maybeResolve(): void {
+    if (!this.isReady || !this.resolve) {
+      return;
+    }
+    const resolve = this.resolve;
+    this.clearWait();
+    resolve();
+  }
+
+  private fail(error: Error): void {
+    this.terminalError = error;
+    const reject = this.reject;
+    this.clearWait();
+    reject?.(error);
+  }
+
+  private clearWait(): void {
+    if (this.timer) {
+      globalThis.clearTimeout(this.timer);
+    }
+    this.timer = null;
+    this.resolve = null;
+    this.reject = null;
+  }
+}

--- a/ui/src/pages/chat/realtime-talk-webrtc-support.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-support.ts
@@ -17,6 +17,7 @@ export type RealtimeServerEvent = {
   text?: string;
   arguments?: string;
   error?: unknown;
+  session?: unknown;
   response?: {
     id?: string;
     status?: string;

--- a/ui/src/pages/chat/realtime-talk-webrtc-tool-controller.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-tool-controller.ts
@@ -1,0 +1,412 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../../../src/talk/describe-view-tool.js";
+import { formatUiError } from "../../lib/format-error.ts";
+import type { RealtimeTalkCameraController } from "./realtime-talk-camera-controller.ts";
+import {
+  REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+  REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
+  type RealtimeTalkEventInput,
+  type RealtimeTalkTransportContext,
+  shouldAutoControlRealtimeVoiceAgentText,
+  steerRealtimeTalkActiveConsult,
+  submitRealtimeTalkAgentControl,
+  submitRealtimeTalkConsult,
+} from "./realtime-talk-shared.ts";
+import { captureRealtimeTalkVideoFrame } from "./realtime-talk-video.ts";
+import {
+  RealtimeTalkResponseOutcomeOwner,
+  realtimeTalkDataChannelMaxMessageSize,
+  realtimeTalkImageEvent,
+  type RealtimeServerEvent,
+} from "./realtime-talk-webrtc-support.ts";
+
+type CompletedToolCall = {
+  itemId?: string;
+  name: string;
+  callId: string;
+  args: string;
+};
+
+type RealtimeTalkWebRtcToolControllerOptions = {
+  ctx: RealtimeTalkTransportContext;
+  camera: RealtimeTalkCameraController;
+  emitTalkEvent: (input: RealtimeTalkEventInput) => void;
+  send: (event: unknown) => void;
+  getPeer: () => RTCPeerConnection | null;
+  isClosed: () => boolean;
+  isDraining: () => boolean;
+  failConnection: (detail: string) => void;
+};
+
+const MAX_REALTIME_TOOL_ARGUMENT_BYTES = 256_000;
+// Realtime defines no replay window, so evicting terminal IDs could execute a
+// very late duplicate. End an extreme session instead of weakening dedupe.
+const MAX_COMPLETED_TOOL_CALL_IDS = 1_024;
+const utf8Encoder = new TextEncoder();
+
+/**
+ * Owns OpenAI Realtime response sequencing and executable provider tool calls.
+ *
+ * The WebRTC transport remains responsible for connection and transcript
+ * lifecycle. This controller deliberately receives those lifecycle facts as
+ * callbacks so late asynchronous tool work cannot outlive Stop or transcript
+ * drain ownership.
+ */
+export class RealtimeTalkWebRtcToolController {
+  private responseActive = false;
+  private responseCreateInFlight = false;
+  private responseCreatePending = false;
+  private readonly responseOutcomes = new RealtimeTalkResponseOutcomeOwner(
+    MAX_COMPLETED_TOOL_CALL_IDS,
+  );
+  private readonly completedToolCallIds = new Set<string>();
+  private readonly consultAbortControllers = new Set<AbortController>();
+  private readonly toolAbortControllers = new Set<AbortController>();
+
+  constructor(private readonly options: RealtimeTalkWebRtcToolControllerOptions) {}
+
+  handleResponseCreated(event: RealtimeServerEvent): void {
+    if (this.isUnavailable()) {
+      return;
+    }
+    this.responseActive = true;
+    this.responseCreateInFlight = false;
+    this.responseOutcomes.start(event.response?.id);
+    this.options.ctx.callbacks.onStatus?.("thinking", "Generating response");
+  }
+
+  handleResponseTerminal(event: RealtimeServerEvent): void {
+    const terminal = this.responseOutcomes.finish(event);
+    if (!terminal) {
+      return;
+    }
+    const { outcome } = terminal;
+    try {
+      if (outcome.status === "completed") {
+        this.handleCompletedResponse(event);
+        if (this.options.isClosed()) {
+          return;
+        }
+      }
+      if (outcome.status === "failed" || outcome.status === "incomplete") {
+        this.options.ctx.callbacks.onStatus?.("error", outcome.message);
+        this.options.emitTalkEvent({
+          type: "session.error",
+          final: true,
+          payload: outcome,
+        });
+      } else {
+        this.options.ctx.callbacks.onStatus?.(
+          "listening",
+          outcome.status === "cancelled" ? "Response cancelled" : undefined,
+        );
+      }
+      this.options.emitTalkEvent({
+        type: outcome.status === "cancelled" ? "turn.cancelled" : "turn.ended",
+        final: true,
+        payload: outcome,
+      });
+    } finally {
+      if (terminal.overflow) {
+        this.options.failConnection("Realtime response session limit exceeded");
+      }
+      this.responseActive = false;
+      this.responseCreateInFlight = false;
+      this.flushPendingResponseCreate();
+    }
+  }
+
+  handleProviderError(): void {
+    this.responseCreateInFlight = false;
+  }
+
+  handleUserTranscript(text: string): void {
+    if (
+      this.isUnavailable() ||
+      this.consultAbortControllers.size === 0 ||
+      !shouldAutoControlRealtimeVoiceAgentText(text)
+    ) {
+      return;
+    }
+    void steerRealtimeTalkActiveConsult({
+      ctx: this.options.ctx,
+      text,
+      emitTalkEvent: this.options.emitTalkEvent,
+      onControlResult: (result) => this.interruptSuppressedControlResponse(result),
+      speakControlResult: (message) => this.sendControlSpeechMessage(message),
+      suppressSpeechForModes: ["cancel"],
+    });
+  }
+
+  cancelResponseBestEffort(): void {
+    try {
+      this.options.send({ type: "response.cancel" });
+    } catch (error) {
+      console.warn("Realtime Talk response cancellation failed", error);
+    }
+  }
+
+  beginDrain(): void {
+    this.abortTools("Realtime Talk tool cancellation failed during transcript drain");
+    this.responseCreatePending = false;
+    if (this.responseActive) {
+      this.cancelResponseBestEffort();
+    }
+  }
+
+  reset(): void {
+    this.abortTools();
+    this.completedToolCallIds.clear();
+    this.responseOutcomes.reset();
+    this.responseActive = false;
+    this.responseCreateInFlight = false;
+    this.responseCreatePending = false;
+  }
+
+  private handleCompletedResponse(event: RealtimeServerEvent): void {
+    const response: unknown = event.response;
+    if (!isRecord(response) || response.status !== "completed" || !Array.isArray(response.output)) {
+      return;
+    }
+    for (const output of response.output) {
+      if (
+        !isRecord(output) ||
+        output.type !== "function_call" ||
+        (output.status !== undefined && output.status !== "completed")
+      ) {
+        continue;
+      }
+      const itemId = typeof output.id === "string" ? output.id.trim() || undefined : undefined;
+      const callId = typeof output.call_id === "string" ? output.call_id.trim() : "";
+      const name = typeof output.name === "string" ? output.name.trim() : "";
+      const args = typeof output.arguments === "string" ? output.arguments : "";
+      if (!callId || !name || !args.trim()) {
+        continue;
+      }
+      if (
+        name !== REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME &&
+        name !== REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME &&
+        name !== REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME
+      ) {
+        continue;
+      }
+      if (this.completedToolCallIds.has(callId)) {
+        continue;
+      }
+      if (this.completedToolCallIds.size >= MAX_COMPLETED_TOOL_CALL_IDS) {
+        this.options.failConnection("Realtime tool-call session limit exceeded");
+        return;
+      }
+      this.completedToolCallIds.add(callId);
+      if (utf8Encoder.encode(args).byteLength > MAX_REALTIME_TOOL_ARGUMENT_BYTES) {
+        const message = "Realtime tool arguments exceed the 256000-byte UTF-8 limit";
+        this.submitToolResult(callId, { error: message });
+        this.options.emitTalkEvent({
+          type: "tool.error",
+          callId,
+          itemId,
+          final: true,
+          payload: { name, message },
+        });
+        continue;
+      }
+      void this.handleToolCall({ itemId, callId, name, args }).catch((error: unknown) => {
+        this.reportToolResultSubmissionError(error);
+      });
+    }
+  }
+
+  private async handleToolCall(call: CompletedToolCall): Promise<void> {
+    if (this.isUnavailable()) {
+      return;
+    }
+    const { itemId, callId, name, args } = call;
+    const abortController = new AbortController();
+    this.toolAbortControllers.add(abortController);
+    try {
+      if (name === REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME) {
+        await submitRealtimeTalkAgentControl({
+          ctx: this.options.ctx,
+          callId,
+          args,
+          signal: abortController.signal,
+          emitTalkEvent: this.options.emitTalkEvent,
+          submit: (toolCallId, result) => this.submitToolResult(toolCallId, result),
+        });
+        return;
+      }
+      if (name === REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME) {
+        await this.handleDescribeViewToolCall(callId, itemId, abortController.signal);
+        return;
+      }
+      if (name !== REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
+        return;
+      }
+      this.options.emitTalkEvent({
+        type: "tool.call",
+        callId,
+        itemId,
+        payload: { name, args },
+      });
+      this.consultAbortControllers.add(abortController);
+      await submitRealtimeTalkConsult({
+        ctx: this.options.ctx,
+        callId,
+        args,
+        signal: abortController.signal,
+        emitTalkEvent: this.options.emitTalkEvent,
+        submit: (toolCallId, result) => this.submitToolResult(toolCallId, result),
+      });
+    } finally {
+      this.consultAbortControllers.delete(abortController);
+      this.toolAbortControllers.delete(abortController);
+    }
+  }
+
+  private async handleDescribeViewToolCall(
+    callId: string,
+    itemId: string | undefined,
+    signal: AbortSignal,
+  ): Promise<void> {
+    this.options.emitTalkEvent({
+      type: "tool.call",
+      callId,
+      itemId,
+      payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME },
+    });
+    if (!this.options.camera.hasLiveTrack()) {
+      this.submitToolResult(callId, { ok: false, error: "camera is off" });
+      this.options.emitTalkEvent({
+        type: "tool.error",
+        callId,
+        itemId,
+        final: true,
+        payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME, message: "camera is off" },
+      });
+      return;
+    }
+    try {
+      const frame = await captureRealtimeTalkVideoFrame(
+        this.options.camera.video,
+        realtimeTalkDataChannelMaxMessageSize(this.options.getPeer()),
+        realtimeTalkImageEvent,
+      );
+      if (signal.aborted || this.isUnavailable()) {
+        return;
+      }
+      this.options.send(realtimeTalkImageEvent(frame));
+      this.submitToolResult(callId, { ok: true, frameAttached: true });
+      this.options.emitTalkEvent({
+        type: "tool.result",
+        callId,
+        itemId,
+        final: true,
+        payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME, frameAttached: true },
+      });
+    } catch (error) {
+      if (signal.aborted || this.isUnavailable()) {
+        return;
+      }
+      const message = formatUiError(error);
+      this.submitToolResult(callId, { ok: false, error: message });
+      this.options.emitTalkEvent({
+        type: "tool.error",
+        callId,
+        itemId,
+        final: true,
+        payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME, message },
+      });
+    }
+  }
+
+  private submitToolResult(callId: string, result: unknown): void {
+    if (this.isUnavailable()) {
+      return;
+    }
+    this.options.send({
+      type: "conversation.item.create",
+      item: {
+        type: "function_call_output",
+        call_id: callId,
+        output: JSON.stringify(result),
+      },
+    });
+    this.requestResponseCreate();
+  }
+
+  private reportToolResultSubmissionError(error: unknown): void {
+    if (this.isUnavailable()) {
+      return;
+    }
+    this.options.ctx.callbacks.onStatus?.("error", formatUiError(error));
+  }
+
+  private sendControlSpeechMessage(message: string): void {
+    if (this.isUnavailable()) {
+      return;
+    }
+    if (this.responseActive) {
+      this.cancelResponseBestEffort();
+    }
+    this.options.send({
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: message }],
+      },
+    });
+    this.requestResponseCreate();
+  }
+
+  private interruptSuppressedControlResponse(result: unknown): void {
+    if (this.isUnavailable() || !this.responseActive || !isRecord(result)) {
+      return;
+    }
+    if (
+      result.ok === true &&
+      (result.mode === "cancel" || (result.suppress === true && result.mode !== "steer"))
+    ) {
+      this.cancelResponseBestEffort();
+    }
+  }
+
+  private requestResponseCreate(): void {
+    if (this.isUnavailable()) {
+      return;
+    }
+    if (this.responseActive || this.responseCreateInFlight) {
+      this.responseCreatePending = true;
+      return;
+    }
+    this.responseCreatePending = false;
+    this.responseCreateInFlight = true;
+    this.options.send({ type: "response.create" });
+  }
+
+  private flushPendingResponseCreate(): void {
+    if (!this.responseCreatePending) {
+      return;
+    }
+    this.responseCreatePending = false;
+    this.requestResponseCreate();
+  }
+
+  private abortTools(warning?: string): void {
+    for (const controller of this.toolAbortControllers) {
+      try {
+        controller.abort();
+      } catch (error) {
+        if (warning) {
+          console.warn(warning, error);
+        }
+      }
+    }
+    this.consultAbortControllers.clear();
+    this.toolAbortControllers.clear();
+  }
+
+  private isUnavailable(): boolean {
+    return this.options.isClosed() || this.options.isDraining();
+  }
+}

--- a/ui/src/pages/chat/realtime-talk-webrtc-transcript-controller.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-transcript-controller.ts
@@ -1,0 +1,202 @@
+import { formatUiError } from "../../lib/format-error.ts";
+import {
+  OpenAiRealtimeTranscriptOwner,
+  type OpenAiRealtimeTranscriptAction,
+} from "./realtime-talk-openai-transcript-owner.ts";
+import {
+  createRealtimeTalkEventEmitter,
+  type RealtimeTalkTransportContext,
+} from "./realtime-talk-shared.ts";
+import type { RealtimeServerEvent } from "./realtime-talk-webrtc-support.ts";
+
+const MAX_PROVIDER_ERROR_DETAIL_BYTES = 1_024;
+const utf8Encoder = new TextEncoder();
+
+type RealtimeTalkWebRtcTranscriptControllerOptions = {
+  ctx: RealtimeTalkTransportContext;
+  emitTalkEvent: ReturnType<typeof createRealtimeTalkEventEmitter>;
+  isClosed: () => boolean;
+  onFatal: (detail: string) => void;
+  onSettlementChange: () => void;
+  onUserFinal: (text: string) => void;
+};
+
+export class RealtimeTalkWebRtcTranscriptController {
+  private readonly owner = new OpenAiRealtimeTranscriptOwner();
+
+  constructor(private readonly options: RealtimeTalkWebRtcTranscriptControllerOptions) {}
+
+  get pendingCount(): number {
+    return this.owner.pendingCount;
+  }
+
+  reset(): void {
+    this.owner.reset();
+  }
+
+  assertSettled(): void {
+    this.owner.assertSettled();
+  }
+
+  complete(itemId: unknown, transcript: unknown): void {
+    this.apply(() => this.owner.complete(itemId, transcript));
+  }
+
+  fail(itemId: unknown, detail: string): void {
+    this.apply(() => this.owner.fail(itemId, detail));
+  }
+
+  emitUserFinal(text: string, itemId?: string): void {
+    this.emitActions([{ role: "user", text, itemId }]);
+  }
+
+  commit(itemId: unknown): void {
+    let actions: OpenAiRealtimeTranscriptAction[];
+    try {
+      actions = this.owner.commit(itemId);
+    } catch (error) {
+      this.options.onFatal(formatUiError(error));
+      return;
+    }
+    try {
+      this.options.emitTalkEvent({
+        type: "input.audio.committed",
+        final: true,
+        ...(typeof itemId === "string" ? { itemId } : {}),
+      });
+    } catch (error) {
+      console.warn("Realtime Talk input audit callback failed", error);
+    }
+    if (this.options.isClosed()) {
+      return;
+    }
+    this.emitActions(actions);
+    this.options.onSettlementChange();
+  }
+
+  emitAssistant(event: RealtimeServerEvent, final: boolean, ordered: boolean): void {
+    const text = final ? (event.transcript ?? event.text) : event.delta;
+    if (!text) {
+      return;
+    }
+    if (final && ordered) {
+      this.apply(() => this.owner.assistant(text, event.item_id));
+      return;
+    }
+    this.options.ctx.callbacks.onTranscript?.({ role: "assistant", text, final });
+    if (this.options.isClosed()) {
+      return;
+    }
+    this.options.emitTalkEvent({
+      type: final ? "output.text.done" : "output.text.delta",
+      final,
+      itemId: event.item_id,
+      payload: { text },
+    });
+  }
+
+  emitFrameless(
+    role: "user" | "assistant",
+    text: string | undefined,
+    final: boolean,
+    itemId?: string,
+  ): void {
+    if (!text) {
+      return;
+    }
+    this.options.ctx.callbacks.onTranscript?.({ role, text, final });
+    if (this.options.isClosed()) {
+      return;
+    }
+    const type =
+      role === "user"
+        ? final
+          ? "transcript.done"
+          : "transcript.delta"
+        : final
+          ? "output.text.done"
+          : "output.text.delta";
+    this.options.emitTalkEvent({ type, final, itemId, payload: { role, text } });
+  }
+
+  extractErrorDetail(error: unknown): string {
+    if (!error || typeof error !== "object") {
+      return "Realtime provider error";
+    }
+    // SAFETY: the object guard above establishes an indexable provider error record.
+    const record = error as Record<string, unknown>;
+    const message = typeof record.message === "string" ? record.message.trim() : "";
+    const code = typeof record.code === "string" ? record.code.trim() : "";
+    const type = typeof record.type === "string" ? record.type.trim() : "";
+    return this.clampProviderDetail(message || code || type || "Realtime provider error");
+  }
+
+  private apply(operation: () => OpenAiRealtimeTranscriptAction[]): void {
+    let actions: OpenAiRealtimeTranscriptAction[];
+    try {
+      actions = operation();
+    } catch (error) {
+      this.options.onFatal(formatUiError(error));
+      return;
+    }
+    this.emitActions(actions);
+    this.options.onSettlementChange();
+  }
+
+  private emitActions(actions: OpenAiRealtimeTranscriptAction[]): void {
+    for (const action of actions) {
+      try {
+        this.options.ctx.callbacks.onTranscript?.({
+          role: action.role,
+          text: action.text,
+          final: true,
+        });
+      } catch (error) {
+        console.warn("Realtime Talk transcript callback failed", error);
+      }
+      if (this.options.isClosed()) {
+        return;
+      }
+      if (action.role === "user") {
+        try {
+          this.options.emitTalkEvent({
+            type: "transcript.done",
+            final: true,
+            itemId: action.itemId,
+            payload: { role: "user", text: action.text },
+          });
+        } catch (error) {
+          console.warn("Realtime Talk transcript audit callback failed", error);
+        }
+        this.options.onUserFinal(action.text);
+      } else {
+        try {
+          this.options.emitTalkEvent({
+            type: "output.text.done",
+            final: true,
+            itemId: action.itemId,
+            payload: { text: action.text },
+          });
+        } catch (error) {
+          console.warn("Realtime Talk output audit callback failed", error);
+        }
+      }
+    }
+  }
+
+  private clampProviderDetail(detail: string): string {
+    if (utf8Encoder.encode(detail).byteLength <= MAX_PROVIDER_ERROR_DETAIL_BYTES) {
+      return detail;
+    }
+    let bounded = "";
+    for (const character of detail) {
+      if (
+        utf8Encoder.encode(`${bounded}${character}…`).byteLength > MAX_PROVIDER_ERROR_DETAIL_BYTES
+      ) {
+        break;
+      }
+      bounded += character;
+    }
+    return `${bounded}…`;
+  }
+}

--- a/ui/src/pages/chat/realtime-talk-webrtc-transcript.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-transcript.test.ts
@@ -747,6 +747,42 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     transport.stop();
   });
 
+  it("delivers an unkeyed assistant final behind its unresolved user commit", async () => {
+    stubAnswerSdpFetch();
+    const onStatus = vi.fn();
+    const onTalkEvent = vi.fn();
+    const onTranscript = vi.fn();
+    const transport = createOpenAiTransport({}, { onStatus, onTalkEvent, onTranscript });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchCommitted(peer, "input-a");
+    dispatchRealtimeEvent(peer, {
+      type: "response.output_text.done",
+      text: "answer without provider identity",
+    });
+    expect(onTranscript).not.toHaveBeenCalled();
+
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "input-a",
+      transcript: "question",
+    });
+
+    expect(onTranscript.mock.calls.map(([entry]) => `${entry.role}:${entry.text}`)).toEqual([
+      "user:question",
+      "assistant:answer without provider identity",
+    ]);
+    expect(onTalkEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "output.text.done",
+        itemId: undefined,
+        payload: { text: "answer without provider identity" },
+      }),
+    );
+    expect(onStatus).not.toHaveBeenCalledWith("error", expect.anything());
+    transport.stop();
+  });
+
   it("deduplicates terminal user transcript events by provider item id", async () => {
     stubAnswerSdpFetch();
     const onTranscript = vi.fn();

--- a/ui/src/pages/chat/realtime-talk-webrtc-transcript.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-transcript.test.ts
@@ -644,10 +644,57 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     transport.stop();
   });
 
-  it("fails closed on an unsafe provider silence window", () => {
-    expect(() =>
-      createOpenAiTransport({}, {}, undefined, { transcriptSilenceDurationMs: 60_001 }),
-    ).toThrow("unsupported transcript silence window");
+  it("accepts and drains an existing provider silence window above the retention ceiling", async () => {
+    vi.useFakeTimers();
+    stubAnswerSdpFetch();
+    const transport = createOpenAiTransport({}, {}, undefined, {
+      transcriptSilenceDurationMs: 60_001,
+    });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchRealtimeEvent(peer, { type: "input_audio_buffer.speech_started" });
+
+    const drain = transport.drain();
+    await vi.advanceTimersByTimeAsync(60_001);
+    dispatchCommitted(peer, "input-long-vad");
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "input-long-vad",
+      transcript: "long pause preserved",
+    });
+    await vi.advanceTimersByTimeAsync(999);
+
+    await expect(drain).resolves.toBeUndefined();
+    transport.stop();
+  });
+
+  it("bounds transcript drain retention for an extreme provider silence window", async () => {
+    vi.useFakeTimers();
+    stubAnswerSdpFetch();
+    const transport = createOpenAiTransport({}, {}, undefined, {
+      transcriptSilenceDurationMs: Number.MAX_SAFE_INTEGER,
+    });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchRealtimeEvent(peer, { type: "input_audio_buffer.speech_started" });
+
+    const drainResult = transport.drain().catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(70_999);
+    await expect(Promise.race([drainResult, Promise.resolve("pending")])).resolves.toBe("pending");
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(drainResult).resolves.toMatchObject(
+      new Error("Realtime Talk timed out waiting for the final user transcription"),
+    );
+    transport.stop();
+  });
+
+  it("rejects unsafe provider silence window metadata", () => {
+    for (const transcriptSilenceDurationMs of [-1, Number.MAX_SAFE_INTEGER + 1]) {
+      expect(() =>
+        createOpenAiTransport({}, {}, undefined, { transcriptSilenceDurationMs }),
+      ).toThrow("unsupported transcript silence window");
+    }
   });
 
   it("persists completed user transcripts in committed item order", async () => {

--- a/ui/src/pages/chat/realtime-talk-webrtc-transcript.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-transcript.test.ts
@@ -1,0 +1,986 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import {
+  type RealtimeTalkWebRtcSdpSessionResult,
+  REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+} from "./realtime-talk-shared.ts";
+import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
+
+let getUserMedia: ReturnType<typeof vi.fn>;
+let stopInputTrack: ReturnType<typeof vi.fn>;
+let inputTrack: MediaStreamTrack;
+
+class FakeDataChannel extends EventTarget {
+  readyState: RTCDataChannelState = "open";
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = "closed";
+  });
+}
+
+class FakePeerConnection extends EventTarget {
+  static instances: FakePeerConnection[] = [];
+  static autoSignalReady = true;
+
+  connectionState: RTCPeerConnectionState = "new";
+  readonly channel = new FakeDataChannel();
+  readonly addTrack = vi.fn();
+  localDescription: RTCSessionDescriptionInit | null = null;
+  remoteDescription: RTCSessionDescriptionInit | null = null;
+
+  constructor() {
+    super();
+    FakePeerConnection.instances.push(this);
+  }
+
+  createDataChannel(): RTCDataChannel {
+    return this.channel as unknown as RTCDataChannel;
+  }
+
+  async createOffer(): Promise<RTCSessionDescriptionInit> {
+    return { type: "offer", sdp: "offer-sdp" };
+  }
+
+  async setLocalDescription(description: RTCSessionDescriptionInit): Promise<void> {
+    this.localDescription = description;
+  }
+
+  async setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void> {
+    this.remoteDescription = description;
+    if (FakePeerConnection.autoSignalReady) {
+      this.channel.dispatchEvent(new Event("open"));
+      dispatchRealtimeEvent(this, {
+        type: "session.created",
+        session: {
+          audio: {
+            input: {
+              transcription: { model: "gpt-4o-mini-transcribe" },
+            },
+          },
+        },
+      });
+    }
+  }
+
+  close(): void {
+    this.connectionState = "closed";
+  }
+}
+
+function requireTalkEvent(
+  onTalkEvent: ReturnType<typeof vi.fn>,
+  index: number,
+): Record<string, unknown> {
+  const call = onTalkEvent.mock.calls[index];
+  if (!call) {
+    throw new Error(`expected talk event at index ${index}`);
+  }
+  const [event] = call;
+  if (!event || typeof event !== "object" || Array.isArray(event)) {
+    throw new Error(`expected talk event record at index ${index}`);
+  }
+  return event as Record<string, unknown>;
+}
+
+function stubAnswerSdpFetch(): void {
+  vi.stubGlobal("fetch", vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch);
+}
+
+function createOpenAiTransport(
+  client: Record<string, unknown> = {},
+  callbacks: Record<string, unknown> = {},
+  inputDeviceId?: string,
+  sessionOverrides: Partial<RealtimeTalkWebRtcSdpSessionResult> = {},
+): WebRtcSdpRealtimeTalkTransport {
+  return new WebRtcSdpRealtimeTalkTransport(
+    {
+      provider: "openai",
+      transport: "webrtc",
+      clientSecret: "client-secret-123",
+      transcriptProtocol: "openai-ga-items",
+      ...sessionOverrides,
+    },
+    {
+      client: client as never,
+      sessionKey: "main",
+      callbacks: callbacks as never,
+      inputDeviceId,
+    },
+  );
+}
+
+async function startAndActivate(transport: WebRtcSdpRealtimeTalkTransport): Promise<void> {
+  await transport.start();
+  transport.activate();
+}
+
+function dispatchRealtimeEvent(peer: FakePeerConnection | undefined, event: unknown): void {
+  peer?.channel.dispatchEvent(
+    new MessageEvent("message", {
+      data: JSON.stringify(event),
+    }),
+  );
+}
+
+function dispatchConsultToolCall(peer: FakePeerConnection | undefined): void {
+  dispatchRealtimeEvent(peer, {
+    type: "response.done",
+    response: {
+      id: "response-1",
+      status: "completed",
+      output: [
+        {
+          type: "function_call",
+          id: "item-1",
+          status: "completed",
+          call_id: "call-1",
+          name: REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+          arguments: JSON.stringify({ question: "status?" }),
+        },
+      ],
+    },
+  });
+}
+
+function dispatchTranscription(peer: FakePeerConnection | undefined, transcript: string): void {
+  dispatchCommitted(peer, "input-1");
+  dispatchRealtimeEvent(peer, {
+    type: "conversation.item.input_audio_transcription.completed",
+    item_id: "input-1",
+    transcript,
+  });
+}
+
+function dispatchCommitted(
+  peer: FakePeerConnection | undefined,
+  itemId: string,
+  previousItemId?: string,
+): void {
+  dispatchRealtimeEvent(peer, {
+    type: "input_audio_buffer.committed",
+    item_id: itemId,
+    previous_item_id: previousItemId ?? null,
+  });
+}
+
+describe("WebRtcSdpRealtimeTalkTransport", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.spyOn(globalThis.HTMLMediaElement.prototype, "pause").mockImplementation(() => undefined);
+    FakePeerConnection.instances = [];
+    FakePeerConnection.autoSignalReady = true;
+    stopInputTrack = vi.fn();
+    inputTrack = { enabled: true, stop: stopInputTrack } as unknown as MediaStreamTrack;
+    const stream = {
+      getAudioTracks: () => [inputTrack],
+      getTracks: () => [inputTrack],
+    } as unknown as MediaStream;
+    getUserMedia = vi.fn(async () => stream);
+    Object.defineProperty(globalThis.navigator, "mediaDevices", {
+      configurable: true,
+      value: {
+        getUserMedia,
+      },
+    });
+    vi.stubGlobal("RTCPeerConnection", FakePeerConnection as unknown as typeof RTCPeerConnection);
+  });
+  it("emits common Talk transcript events from the OpenAI data channel", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
+    );
+    const onTranscript = vi.fn();
+    const onTalkEvent = vi.fn();
+    const transport = new WebRtcSdpRealtimeTalkTransport(
+      {
+        provider: "openai",
+        transport: "webrtc",
+        clientSecret: "client-secret-123",
+      },
+      {
+        client: {} as never,
+        sessionKey: "main",
+        callbacks: { onTranscript, onTalkEvent },
+      },
+    );
+
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    peer?.channel.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "conversation.item.input_audio_transcription.completed",
+          item_id: "input-1",
+          transcript: "hello",
+        }),
+      }),
+    );
+    peer?.channel.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "response.audio_transcript.done",
+          item_id: "response-1",
+          transcript: "hi there",
+        }),
+      }),
+    );
+
+    expect(onTranscript).toHaveBeenCalledWith({ role: "user", text: "hello", final: true });
+    expect(onTranscript).toHaveBeenCalledWith({
+      role: "assistant",
+      text: "hi there",
+      final: true,
+    });
+    expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
+      "session.ready",
+      "transcript.done",
+      "output.text.done",
+    ]);
+    expect(onTalkEvent.mock.calls.map(([event]) => event.turnId)).toEqual([
+      undefined,
+      "turn-1",
+      "turn-1",
+    ]);
+    const userTranscriptEvent = requireTalkEvent(onTalkEvent, 1);
+    expect(userTranscriptEvent.itemId).toBe("input-1");
+    expect(userTranscriptEvent.payload).toEqual({ role: "user", text: "hello" });
+    expect(userTranscriptEvent.sessionId).toBe("main:openai:webrtc");
+    expect(userTranscriptEvent.transport).toBe("webrtc");
+    const assistantTranscriptEvent = requireTalkEvent(onTalkEvent, 2);
+    expect(assistantTranscriptEvent.itemId).toBe("response-1");
+    expect(assistantTranscriptEvent.payload).toEqual({ text: "hi there" });
+    expect(assistantTranscriptEvent.sessionId).toBe("main:openai:webrtc");
+    expect(assistantTranscriptEvent.transport).toBe("webrtc");
+    transport.stop();
+  });
+
+  it("keeps microphone input provisional until the committed transport activates", async () => {
+    FakePeerConnection.autoSignalReady = false;
+    stubAnswerSdpFetch();
+    const onStatus = vi.fn();
+    const onTalkEvent = vi.fn();
+    const transport = createOpenAiTransport({}, { onStatus, onTalkEvent });
+
+    const start = transport.start();
+    const peer = FakePeerConnection.instances[0];
+    await waitForFast(() => expect(peer?.remoteDescription).not.toBeNull());
+    await Promise.resolve();
+    expect(inputTrack.enabled).toBe(false);
+    await expect(Promise.race([start, Promise.resolve("pending")])).resolves.toBe("pending");
+
+    peer?.channel.dispatchEvent(new Event("open"));
+    await expect(Promise.race([start, Promise.resolve("pending")])).resolves.toBe("pending");
+    dispatchRealtimeEvent(peer, {
+      type: "session.created",
+      session: {
+        audio: { input: { transcription: { model: "gpt-4o-mini-transcribe" } } },
+      },
+    });
+    await expect(start).resolves.toBe("ready");
+    expect(onStatus).not.toHaveBeenCalledWith("listening");
+    expect(onTalkEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session.ready" }),
+    );
+
+    (transport as unknown as { activate?: () => void }).activate?.();
+
+    expect(inputTrack.enabled).toBe(true);
+    expect(onStatus).toHaveBeenCalledWith("listening");
+    expect(onTalkEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "session.ready" }));
+    transport.stop();
+  });
+
+  it("buffers provider transcript events until outer ownership activates", async () => {
+    FakePeerConnection.autoSignalReady = false;
+    stubAnswerSdpFetch();
+    const onTranscript = vi.fn();
+    const transport = createOpenAiTransport({}, { onTranscript });
+
+    const start = transport.start();
+    const peer = FakePeerConnection.instances[0];
+    await waitForFast(() => expect(peer?.remoteDescription).not.toBeNull());
+    peer?.channel.dispatchEvent(new Event("open"));
+    dispatchRealtimeEvent(peer, {
+      type: "session.created",
+      session: {
+        audio: { input: { transcription: { model: "gpt-4o-mini-transcribe" } } },
+      },
+    });
+    await expect(start).resolves.toBe("ready");
+    dispatchCommitted(peer, "input-before-activation");
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "input-before-activation",
+      transcript: "owned only after activation",
+    });
+
+    expect(onTranscript).not.toHaveBeenCalled();
+    transport.activate();
+    expect(onTranscript).toHaveBeenCalledWith({
+      role: "user",
+      text: "owned only after activation",
+      final: true,
+    });
+    transport.stop();
+  });
+
+  it("uses the distinct frameless provider readiness event", async () => {
+    FakePeerConnection.autoSignalReady = false;
+    stubAnswerSdpFetch();
+    const transport = new WebRtcSdpRealtimeTalkTransport(
+      {
+        provider: "openai",
+        transport: "webrtc",
+        clientSecret: "client-secret-123",
+        transcriptProtocol: "openai-frameless-turns",
+      },
+      { client: {} as never, sessionKey: "main", callbacks: {} },
+    );
+
+    const start = transport.start();
+    const peer = FakePeerConnection.instances[0];
+    await waitForFast(() => expect(peer?.remoteDescription).not.toBeNull());
+    peer?.channel.dispatchEvent(new Event("open"));
+    await expect(Promise.race([start, Promise.resolve("pending")])).resolves.toBe("pending");
+    dispatchRealtimeEvent(peer, { type: "session.started" });
+    await expect(start).resolves.toBe("ready");
+    expect(inputTrack.enabled).toBe(false);
+    transport.activate();
+    expect(inputTrack.enabled).toBe(true);
+    transport.stop();
+  });
+
+  it("fails setup and releases media when transcript readiness is never confirmed", async () => {
+    vi.useFakeTimers();
+    FakePeerConnection.autoSignalReady = false;
+    stubAnswerSdpFetch();
+    const transport = createOpenAiTransport();
+    const startResult = transport.start().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    const peer = FakePeerConnection.instances[0];
+    await waitForFast(() => expect(peer?.remoteDescription).not.toBeNull());
+    peer?.channel.dispatchEvent(new Event("open"));
+
+    await vi.runAllTimersAsync();
+
+    await expect(startResult).resolves.toMatchObject(
+      new Error("Realtime provider did not confirm transcript readiness"),
+    );
+    expect(stopInputTrack).toHaveBeenCalledOnce();
+    expect(peer?.channel.close).toHaveBeenCalledOnce();
+  });
+
+  it("waits through the default created session for the configured session update", async () => {
+    FakePeerConnection.autoSignalReady = false;
+    stubAnswerSdpFetch();
+    const transport = createOpenAiTransport();
+    const start = transport.start();
+    const peer = FakePeerConnection.instances[0];
+    await waitForFast(() => expect(peer?.remoteDescription).not.toBeNull());
+    peer?.channel.dispatchEvent(new Event("open"));
+    dispatchRealtimeEvent(peer, {
+      type: "session.created",
+      session: { audio: { input: { transcription: null } } },
+    });
+    await expect(Promise.race([start, Promise.resolve("pending")])).resolves.toBe("pending");
+
+    dispatchRealtimeEvent(peer, {
+      type: "session.updated",
+      session: {
+        audio: { input: { transcription: { model: "gpt-4o-mini-transcribe" } } },
+      },
+    });
+
+    await expect(start).resolves.toBe("ready");
+    expect(inputTrack.enabled).toBe(false);
+    transport.activate();
+    expect(inputTrack.enabled).toBe(true);
+    transport.stop();
+  });
+
+  it("fails setup immediately when the configured provider session lacks transcription", async () => {
+    FakePeerConnection.autoSignalReady = false;
+    stubAnswerSdpFetch();
+    const transport = createOpenAiTransport();
+    const startResult = transport.start().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    const peer = FakePeerConnection.instances[0];
+    await waitForFast(() => expect(peer?.remoteDescription).not.toBeNull());
+    peer?.channel.dispatchEvent(new Event("open"));
+    dispatchRealtimeEvent(peer, {
+      type: "session.updated",
+      session: { audio: { input: { transcription: {} } } },
+    });
+
+    await expect(startResult).resolves.toMatchObject(
+      new Error("Realtime provider did not enable input transcription"),
+    );
+    expect(stopInputTrack).toHaveBeenCalledOnce();
+  });
+
+  it("rejects activation when the provider fails after readiness but before adoption", async () => {
+    stubAnswerSdpFetch();
+    const transport = createOpenAiTransport();
+    await expect(transport.start()).resolves.toBe("ready");
+    dispatchRealtimeEvent(FakePeerConnection.instances[0], {
+      type: "error",
+      error: { message: "provider revoked the session" },
+    });
+
+    expect(() => transport.activate()).toThrow("activated before transcript readiness");
+    expect(inputTrack.enabled).toBe(false);
+    transport.stop();
+  });
+
+  it("rejects activation when a later provider session disables transcription", async () => {
+    stubAnswerSdpFetch();
+    const transport = createOpenAiTransport();
+    await expect(transport.start()).resolves.toBe("ready");
+    dispatchRealtimeEvent(FakePeerConnection.instances[0], {
+      type: "session.updated",
+      session: { audio: { input: { transcription: null } } },
+    });
+
+    expect(() => transport.activate()).toThrow("activated before transcript readiness");
+    expect(inputTrack.enabled).toBe(false);
+    transport.stop();
+  });
+
+  it("stops an active session when a provider update disables transcription", async () => {
+    stubAnswerSdpFetch();
+    const onStatus = vi.fn();
+    const onTalkEvent = vi.fn();
+    const onFatalError = vi.fn();
+    const transport = createOpenAiTransport({}, { onStatus, onTalkEvent, onFatalError });
+    await startAndActivate(transport);
+
+    dispatchRealtimeEvent(FakePeerConnection.instances[0], {
+      type: "session.updated",
+      session: { audio: { input: { transcription: null } } },
+    });
+
+    expect(onStatus).toHaveBeenCalledWith(
+      "error",
+      "Realtime provider disabled input transcription",
+    );
+    expect(onTalkEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "session.error" }));
+    expect(onFatalError).toHaveBeenCalledWith("Realtime provider disabled input transcription");
+    expect(stopInputTrack).toHaveBeenCalledOnce();
+  });
+
+  it("rejects activation when the ready data channel closes before adoption", async () => {
+    stubAnswerSdpFetch();
+    const transport = createOpenAiTransport();
+    await expect(transport.start()).resolves.toBe("ready");
+    FakePeerConnection.instances[0]?.channel.dispatchEvent(new Event("close"));
+
+    expect(() => transport.activate()).toThrow("closed before activation");
+    expect(stopInputTrack).toHaveBeenCalledOnce();
+  });
+
+  it("mutes immediately and drains a final turn whose provider events arrive after stop", async () => {
+    vi.useFakeTimers();
+    stubAnswerSdpFetch();
+    const onTranscript = vi.fn();
+    const transport = createOpenAiTransport({}, { onTranscript });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    const drain = transport.drain();
+    expect(inputTrack.enabled).toBe(false);
+    await expect(Promise.race([drain, Promise.resolve("pending")])).resolves.toBe("pending");
+
+    await vi.advanceTimersByTimeAsync(500);
+    dispatchRealtimeEvent(peer, { type: "input_audio_buffer.speech_started" });
+    dispatchRealtimeEvent(peer, { type: "input_audio_buffer.speech_stopped" });
+    dispatchCommitted(peer, "input-last");
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "input-last",
+      transcript: "preserve the final turn",
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(drain).resolves.toBeUndefined();
+    expect(onTranscript).toHaveBeenCalledWith({
+      role: "user",
+      text: "preserve the final turn",
+      final: true,
+    });
+    transport.stop();
+  });
+
+  it("does not bypass transcript drain when response cancellation throws", async () => {
+    vi.useFakeTimers();
+    stubAnswerSdpFetch();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const transport = createOpenAiTransport();
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchRealtimeEvent(peer, { type: "response.created", response: { id: "response-1" } });
+    peer?.channel.send.mockImplementation((payload: string) => {
+      if (JSON.parse(payload).type === "response.cancel") {
+        throw new Error("data channel closed during cancel");
+      }
+    });
+
+    const drain = transport.drain();
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    await expect(drain).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(
+      "Realtime Talk response cancellation failed",
+      expect.any(Error),
+    );
+    transport.stop();
+  });
+
+  it("ignores benign provider cancellation errors while transcript ownership drains", async () => {
+    vi.useFakeTimers();
+    stubAnswerSdpFetch();
+    const onStatus = vi.fn();
+    const transport = createOpenAiTransport({}, { onStatus });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+
+    const drain = transport.drain();
+    dispatchRealtimeEvent(peer, {
+      type: "error",
+      error: { code: "response_cancel_not_active", message: "No active response" },
+    });
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    await expect(drain).resolves.toBeUndefined();
+    expect(onStatus).not.toHaveBeenCalledWith("error", expect.anything());
+    transport.stop();
+  });
+
+  it("fails continuity when the provider connection closes during transcript drain", async () => {
+    vi.useFakeTimers();
+    stubAnswerSdpFetch();
+    const onStatus = vi.fn();
+    const onTalkEvent = vi.fn();
+    const transport = createOpenAiTransport({}, { onStatus, onTalkEvent });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchRealtimeEvent(peer, { type: "input_audio_buffer.speech_started" });
+
+    const drainResult = transport.drain().catch((error: unknown) => error);
+    peer?.channel.dispatchEvent(new Event("close"));
+
+    await expect(drainResult).resolves.toMatchObject(new Error("Realtime data channel closed"));
+    expect(onStatus).toHaveBeenCalledWith("error", "Realtime data channel closed");
+    expect(onTalkEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "session.error" }));
+  });
+
+  it("rejects a drain that never receives the final committed transcript", async () => {
+    vi.useFakeTimers();
+    stubAnswerSdpFetch();
+    const onStatus = vi.fn();
+    const onTalkEvent = vi.fn();
+    const transport = createOpenAiTransport({}, { onStatus, onTalkEvent });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchRealtimeEvent(peer, { type: "input_audio_buffer.speech_started" });
+
+    const drain = transport.drain();
+    const drainResult = drain.catch((error: unknown) => error);
+    expect(inputTrack.enabled).toBe(false);
+    await vi.advanceTimersByTimeAsync(11_500);
+
+    await expect(drainResult).resolves.toMatchObject(
+      new Error("Realtime Talk timed out waiting for the final user transcription"),
+    );
+    expect(onStatus).toHaveBeenCalledWith(
+      "error",
+      "Realtime Talk timed out waiting for the final user transcription",
+    );
+    expect(onTalkEvent).toHaveBeenCalledWith(expect.objectContaining({ type: "session.error" }));
+    expect(stopInputTrack).toHaveBeenCalledOnce();
+    transport.stop();
+  });
+
+  it("does not execute late provider tools while transcript ownership drains", async () => {
+    vi.useFakeTimers();
+    stubAnswerSdpFetch();
+    const request = vi.fn(async () => ({ ok: true }));
+    const onStatus = vi.fn();
+    const transport = createOpenAiTransport({ request }, { onStatus });
+    await startAndActivate(transport);
+    const drain = transport.drain();
+
+    dispatchConsultToolCall(FakePeerConnection.instances[0]);
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    await expect(drain).resolves.toBeUndefined();
+    expect(request).not.toHaveBeenCalled();
+    expect(onStatus).not.toHaveBeenCalledWith("thinking", expect.anything());
+    transport.stop();
+  });
+
+  it("derives the post-mute drain grace from the effective provider silence window", async () => {
+    vi.useFakeTimers();
+    stubAnswerSdpFetch();
+    const transport = createOpenAiTransport({}, {}, undefined, {
+      transcriptSilenceDurationMs: 2_000,
+    });
+    await startAndActivate(transport);
+
+    const drain = transport.drain();
+    await vi.advanceTimersByTimeAsync(1_500);
+    await expect(Promise.race([drain, Promise.resolve("pending")])).resolves.toBe("pending");
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    await expect(drain).resolves.toBeUndefined();
+    transport.stop();
+  });
+
+  it("fails closed on an unsafe provider silence window", () => {
+    expect(() =>
+      createOpenAiTransport({}, {}, undefined, { transcriptSilenceDurationMs: 60_001 }),
+    ).toThrow("unsupported transcript silence window");
+  });
+
+  it("persists completed user transcripts in committed item order", async () => {
+    stubAnswerSdpFetch();
+    const onTranscript = vi.fn();
+    const transport = createOpenAiTransport({}, { onTranscript });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+
+    dispatchCommitted(peer, "input-a");
+    dispatchCommitted(peer, "input-b", "input-a");
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "input-b",
+      transcript: "second",
+    });
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "input-a",
+      transcript: "first",
+    });
+
+    expect(onTranscript.mock.calls.map(([entry]) => entry.text)).toEqual(["first", "second"]);
+    transport.stop();
+  });
+
+  it("holds an assistant final behind its unresolved user commit", async () => {
+    stubAnswerSdpFetch();
+    const onTranscript = vi.fn();
+    const transport = createOpenAiTransport({}, { onTranscript });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchCommitted(peer, "input-a");
+    dispatchRealtimeEvent(peer, {
+      type: "response.audio_transcript.done",
+      item_id: "response-a",
+      transcript: "answer",
+    });
+    expect(onTranscript).not.toHaveBeenCalled();
+
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "input-a",
+      transcript: "question",
+    });
+    expect(onTranscript.mock.calls.map(([entry]) => `${entry.role}:${entry.text}`)).toEqual([
+      "user:question",
+      "assistant:answer",
+    ]);
+    transport.stop();
+  });
+
+  it("deduplicates terminal user transcript events by provider item id", async () => {
+    stubAnswerSdpFetch();
+    const onTranscript = vi.fn();
+    const transport = createOpenAiTransport({}, { onTranscript });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+
+    dispatchCommitted(peer, "input-1");
+    dispatchTranscription(peer, "only once");
+    dispatchTranscription(peer, "only once");
+
+    expect(onTranscript).toHaveBeenCalledTimes(1);
+    transport.stop();
+  });
+
+  it("deduplicates terminal assistant transcript events by provider item id", async () => {
+    stubAnswerSdpFetch();
+    const onTranscript = vi.fn();
+    const transport = createOpenAiTransport({}, { onTranscript });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    const event = {
+      type: "response.audio_transcript.done",
+      item_id: "assistant-1",
+      transcript: "only once",
+    };
+
+    dispatchRealtimeEvent(peer, event);
+    dispatchRealtimeEvent(peer, event);
+
+    expect(onTranscript).toHaveBeenCalledTimes(1);
+    transport.stop();
+  });
+
+  it("continues a settled transcript batch when the first observer callback throws", async () => {
+    stubAnswerSdpFetch();
+    const delivered: string[] = [];
+    const onTranscript = vi.fn((entry: { text: string }) => {
+      delivered.push(entry.text);
+      if (entry.text === "first") {
+        throw new Error("first observer failed");
+      }
+    });
+    const transport = createOpenAiTransport({}, { onTranscript });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchCommitted(peer, "input-a");
+    dispatchCommitted(peer, "input-b", "input-a");
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "input-b",
+      transcript: "second",
+    });
+
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "input-a",
+      transcript: "first",
+    });
+
+    expect(delivered).toEqual(["first", "second"]);
+    transport.stop();
+  });
+
+  it("fails closed when OpenAI reports a user transcription failure", async () => {
+    stubAnswerSdpFetch();
+    const onStatus = vi.fn();
+    const onTalkEvent = vi.fn();
+    const transport = createOpenAiTransport({}, { onStatus, onTalkEvent });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchCommitted(peer, "input-1");
+
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.failed",
+      item_id: "input-1",
+      error: { message: "Transcription failed" },
+    });
+
+    expect(onStatus).toHaveBeenCalledWith("error", "Transcription failed");
+    expect(onTalkEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session.error",
+        payload: expect.objectContaining({ message: "Transcription failed" }),
+      }),
+    );
+    expect(stopInputTrack).toHaveBeenCalledOnce();
+  });
+
+  it("treats an empty completed transcript as settled non-speech", async () => {
+    vi.useFakeTimers();
+    stubAnswerSdpFetch();
+    const onStatus = vi.fn();
+    const onTalkEvent = vi.fn();
+    const onTranscript = vi.fn();
+    const transport = createOpenAiTransport({}, { onStatus, onTalkEvent, onTranscript });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchCommitted(peer, "input-1");
+
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "input-1",
+      transcript: "",
+    });
+
+    const drain = transport.drain();
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    await expect(drain).resolves.toBeUndefined();
+    expect(onTranscript).not.toHaveBeenCalled();
+    expect(onStatus).not.toHaveBeenCalledWith("error", expect.anything());
+    expect(onTalkEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session.error" }),
+    );
+    transport.stop();
+  });
+
+  it("finishes terminal cleanup when observer callbacks throw", async () => {
+    stubAnswerSdpFetch();
+    const onFatalError = vi.fn();
+    const onStatus = vi.fn((status: string) => {
+      if (status === "error") {
+        throw new Error("status observer failed");
+      }
+    });
+    const onTalkEvent = vi.fn((event: { type?: string }) => {
+      if (event.type === "session.error") {
+        throw new Error("event observer failed");
+      }
+    });
+    const transport = createOpenAiTransport({}, { onFatalError, onStatus, onTalkEvent });
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    dispatchCommitted(peer, "input-1");
+
+    dispatchRealtimeEvent(peer, {
+      type: "conversation.item.input_audio_transcription.failed",
+      item_id: "input-1",
+      error: { message: "Transcription failed" },
+    });
+
+    expect(onFatalError).toHaveBeenCalledWith("Transcription failed");
+    expect(stopInputTrack).toHaveBeenCalledOnce();
+  });
+
+  it("stops processing the current provider event when a transcript callback closes it", async () => {
+    stubAnswerSdpFetch();
+    const onTalkEvent = vi.fn();
+    const onTranscript = vi.fn(() => transport.stop());
+    const transport = createOpenAiTransport({}, { onTranscript, onTalkEvent });
+
+    await startAndActivate(transport);
+    dispatchTranscription(FakePeerConnection.instances[0], "overflow");
+
+    expect(onTranscript).toHaveBeenCalledOnce();
+    expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
+      "session.ready",
+      "input.audio.committed",
+      "session.closed",
+    ]);
+  });
+
+  it("maps frameless Codex transcript events by role and finality", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
+    );
+    const onTalkEvent = vi.fn();
+    const transport = new WebRtcSdpRealtimeTalkTransport(
+      {
+        provider: "openai",
+        transport: "webrtc",
+        clientSecret: "client-secret-123",
+      },
+      {
+        client: {} as never,
+        sessionKey: "main",
+        callbacks: { onTalkEvent },
+      },
+    );
+
+    await startAndActivate(transport);
+    const peer = FakePeerConnection.instances[0];
+    for (const event of [
+      { type: "input_transcript.added", item: { id: "user-live", text: "hel" } },
+      { type: "output_transcript.added", item: { id: "assistant-live", text: "hi" } },
+      {
+        type: "turn.done",
+        turn: { id: "user-final", role: "user", transcript: "hello" },
+      },
+      {
+        type: "turn.done",
+        turn: { id: "assistant-final", role: "assistant", transcript: "hi there" },
+      },
+    ]) {
+      peer?.channel.dispatchEvent(new MessageEvent("message", { data: JSON.stringify(event) }));
+    }
+
+    expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
+      "session.ready",
+      "transcript.delta",
+      "output.text.delta",
+      "transcript.done",
+      "output.text.done",
+      "turn.ended",
+    ]);
+    transport.stop();
+  });
+
+  // Audio output sends the final string in `transcript`; text output sends it in
+  // `text`. Both must surface the same assistant transcript + talk events.
+  it.each([
+    {
+      label: "audio output",
+      deltaType: "response.output_audio_transcript.delta",
+      doneType: "response.output_audio_transcript.done",
+      doneField: { transcript: "hi there" },
+    },
+    {
+      label: "text output",
+      deltaType: "response.output_text.delta",
+      doneType: "response.output_text.done",
+      doneField: { text: "hi there" },
+    },
+  ])(
+    "emits assistant transcripts from OpenAI Realtime $label events",
+    async ({ deltaType, doneType, doneField }) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
+      );
+      const onTranscript = vi.fn();
+      const onTalkEvent = vi.fn();
+      const transport = new WebRtcSdpRealtimeTalkTransport(
+        {
+          provider: "openai",
+          transport: "webrtc",
+          clientSecret: "client-secret-123",
+        },
+        {
+          client: {} as never,
+          sessionKey: "main",
+          callbacks: { onTranscript, onTalkEvent },
+        },
+      );
+
+      await startAndActivate(transport);
+      const peer = FakePeerConnection.instances[0];
+      peer?.channel.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({ type: deltaType, item_id: "response-1", delta: "hi" }),
+        }),
+      );
+      peer?.channel.dispatchEvent(
+        new MessageEvent("message", {
+          data: JSON.stringify({ type: doneType, item_id: "response-1", ...doneField }),
+        }),
+      );
+
+      expect(onTranscript).toHaveBeenCalledWith({
+        role: "assistant",
+        text: "hi",
+        final: false,
+      });
+      expect(onTranscript).toHaveBeenCalledWith({
+        role: "assistant",
+        text: "hi there",
+        final: true,
+      });
+      expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
+        "session.ready",
+        "output.text.delta",
+        "output.text.done",
+      ]);
+      expect(onTalkEvent.mock.calls.map(([event]) => event.payload)).toEqual([
+        null,
+        { text: "hi" },
+        { text: "hi there" },
+      ]);
+      transport.stop();
+    },
+  );
+});

--- a/ui/src/pages/chat/realtime-talk-webrtc-video.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc-video.test.ts
@@ -37,7 +37,9 @@ class FakePeerConnection extends EventTarget {
     this.localDescription = description;
   }
 
-  async setRemoteDescription(): Promise<void> {}
+  async setRemoteDescription(): Promise<void> {
+    this.channel.dispatchEvent(new Event("open"));
+  }
 
   close(): void {
     this.connectionState = "closed";
@@ -151,6 +153,7 @@ describe("OpenAI Realtime Video Talk", () => {
     );
 
     await transport.start();
+    transport.activate();
     const peer = FakePeerConnection.instance;
     expect(getUserMedia).toHaveBeenCalledOnce();
     expect(peer?.addTrack).toHaveBeenCalledWith(audioTrack, audio);

--- a/ui/src/pages/chat/realtime-talk-webrtc.test.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.test.ts
@@ -1,11 +1,15 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
-import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "./realtime-talk-shared.ts";
+import {
+  type RealtimeTalkWebRtcSdpSessionResult,
+  REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
+} from "./realtime-talk-shared.ts";
 import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
 
 let getUserMedia: ReturnType<typeof vi.fn>;
 let stopInputTrack: ReturnType<typeof vi.fn>;
+let inputTrack: MediaStreamTrack;
 
 class FakeDataChannel extends EventTarget {
   readyState: RTCDataChannelState = "open";
@@ -17,6 +21,7 @@ class FakeDataChannel extends EventTarget {
 
 class FakePeerConnection extends EventTarget {
   static instances: FakePeerConnection[] = [];
+  static autoSignalReady = true;
 
   connectionState: RTCPeerConnectionState = "new";
   readonly channel = new FakeDataChannel();
@@ -43,26 +48,24 @@ class FakePeerConnection extends EventTarget {
 
   async setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void> {
     this.remoteDescription = description;
+    if (FakePeerConnection.autoSignalReady) {
+      this.channel.dispatchEvent(new Event("open"));
+      dispatchRealtimeEvent(this, {
+        type: "session.created",
+        session: {
+          audio: {
+            input: {
+              transcription: { model: "gpt-4o-mini-transcribe" },
+            },
+          },
+        },
+      });
+    }
   }
 
   close(): void {
     this.connectionState = "closed";
   }
-}
-
-function requireTalkEvent(
-  onTalkEvent: ReturnType<typeof vi.fn>,
-  index: number,
-): Record<string, unknown> {
-  const call = onTalkEvent.mock.calls[index];
-  if (!call) {
-    throw new Error(`expected talk event at index ${index}`);
-  }
-  const [event] = call;
-  if (!event || typeof event !== "object" || Array.isArray(event)) {
-    throw new Error(`expected talk event record at index ${index}`);
-  }
-  return event as Record<string, unknown>;
 }
 
 type SentRealtimeEvent = {
@@ -82,12 +85,15 @@ function createOpenAiTransport(
   client: Record<string, unknown> = {},
   callbacks: Record<string, unknown> = {},
   inputDeviceId?: string,
+  sessionOverrides: Partial<RealtimeTalkWebRtcSdpSessionResult> = {},
 ): WebRtcSdpRealtimeTalkTransport {
   return new WebRtcSdpRealtimeTalkTransport(
     {
       provider: "openai",
       transport: "webrtc",
       clientSecret: "client-secret-123",
+      transcriptProtocol: "openai-ga-items",
+      ...sessionOverrides,
     },
     {
       client: client as never,
@@ -96,6 +102,11 @@ function createOpenAiTransport(
       inputDeviceId,
     },
   );
+}
+
+async function startAndActivate(transport: WebRtcSdpRealtimeTalkTransport): Promise<void> {
+  await transport.start();
+  transport.activate();
 }
 
 function dispatchRealtimeEvent(peer: FakePeerConnection | undefined, event: unknown): void {
@@ -127,10 +138,23 @@ function dispatchConsultToolCall(peer: FakePeerConnection | undefined): void {
 }
 
 function dispatchTranscription(peer: FakePeerConnection | undefined, transcript: string): void {
+  dispatchCommitted(peer, "input-1");
   dispatchRealtimeEvent(peer, {
     type: "conversation.item.input_audio_transcription.completed",
     item_id: "input-1",
     transcript,
+  });
+}
+
+function dispatchCommitted(
+  peer: FakePeerConnection | undefined,
+  itemId: string,
+  previousItemId?: string,
+): void {
+  dispatchRealtimeEvent(peer, {
+    type: "input_audio_buffer.committed",
+    item_id: itemId,
+    previous_item_id: previousItemId ?? null,
   });
 }
 
@@ -143,7 +167,7 @@ async function startActiveConsult(
     request,
   });
 
-  await transport.start();
+  await startAndActivate(transport);
   const peer = FakePeerConnection.instances[0];
   dispatchConsultToolCall(peer);
   await waitForFast(() =>
@@ -182,17 +206,20 @@ function expectSpokenStatusMessage(events: SentRealtimeEvent[], message: string)
 
 describe("WebRtcSdpRealtimeTalkTransport", () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.unstubAllGlobals();
     vi.useRealTimers();
   });
 
   beforeEach(() => {
+    vi.spyOn(globalThis.HTMLMediaElement.prototype, "pause").mockImplementation(() => undefined);
     FakePeerConnection.instances = [];
+    FakePeerConnection.autoSignalReady = true;
     stopInputTrack = vi.fn();
-    const track = { stop: stopInputTrack } as unknown as MediaStreamTrack;
+    inputTrack = { enabled: true, stop: stopInputTrack } as unknown as MediaStreamTrack;
     const stream = {
-      getAudioTracks: () => [track],
-      getTracks: () => [track],
+      getAudioTracks: () => [inputTrack],
+      getTracks: () => [inputTrack],
     } as unknown as MediaStream;
     getUserMedia = vi.fn(async () => stream);
     Object.defineProperty(globalThis.navigator, "mediaDevices", {
@@ -225,7 +252,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     const onInputLevel = vi.fn();
     const transport = createOpenAiTransport({}, { onInputLevel });
 
-    await transport.start();
+    await startAndActivate(transport);
     transport.stop();
 
     expect(onInputLevel.mock.calls.some(([level]) => level > 0)).toBe(true);
@@ -259,7 +286,8 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     });
     const transport = createOpenAiTransport({}, { onInputLevel });
 
-    await expect(transport.start()).resolves.toBe("cancelled");
+    await expect(transport.start()).resolves.toBe("ready");
+    transport.activate();
     transport.stop();
     transport.stop();
     vi.advanceTimersByTime(1_000);
@@ -349,7 +377,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       },
     );
 
-    await transport.start();
+    await startAndActivate(transport);
 
     expect(fetchMock).toHaveBeenCalledWith("https://api.openai.com/v1/realtime/calls", {
       method: "POST",
@@ -468,11 +496,13 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
 
   it("releases an active peer when the terminal status callback throws", async () => {
     stubAnswerSdpFetch();
-    const onStatus = vi.fn(() => {
-      throw new Error("consumer failed");
+    const onStatus = vi.fn((status: string) => {
+      if (status === "error") {
+        throw new Error("consumer failed");
+      }
     });
     const transport = createOpenAiTransport({}, { onStatus });
-    await expect(transport.start()).resolves.toBe("ready");
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     if (!peer) {
       throw new Error("expected WebRTC peer");
@@ -516,7 +546,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     );
     const transport = createOpenAiTransport();
 
-    await transport.start();
+    await startAndActivate(transport);
     await vi.runAllTimersAsync();
 
     expect(offerSignal?.aborted).toBe(false);
@@ -542,7 +572,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       },
     );
 
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     peer?.channel.dispatchEvent(
       new MessageEvent("message", {
@@ -577,11 +607,12 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       },
     );
 
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     for (const event of [
       { type: "input_audio_buffer.speech_started" },
       { type: "input_audio_buffer.speech_stopped" },
+      { type: "input_audio_buffer.committed", item_id: "input-1" },
       { type: "response.created", response: { id: "response-1" } },
       { type: "response.done", response: { id: "response-1", status: "completed" } },
     ]) {
@@ -593,11 +624,13 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     expect(onStatus).toHaveBeenCalledWith("thinking", "Generating response");
     expect(onStatus).toHaveBeenCalledWith("listening", undefined);
     expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
+      "session.ready",
       "turn.started",
       "input.audio.committed",
       "turn.ended",
     ]);
     expect(onTalkEvent.mock.calls.map(([event]) => event.turnId)).toEqual([
+      undefined,
       "turn-1",
       "turn-1",
       "turn-1",
@@ -614,7 +647,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     const onStatus = vi.fn();
     const onTalkEvent = vi.fn();
     const transport = createOpenAiTransport({}, { onStatus, onTalkEvent });
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     const response = {
       id: "response-1",
@@ -647,202 +680,6 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
     expect(onStatus).toHaveBeenLastCalledWith("listening", undefined);
     transport.stop();
   });
-
-  it("emits common Talk transcript events from the OpenAI data channel", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
-    );
-    const onTranscript = vi.fn();
-    const onTalkEvent = vi.fn();
-    const transport = new WebRtcSdpRealtimeTalkTransport(
-      {
-        provider: "openai",
-        transport: "webrtc",
-        clientSecret: "client-secret-123",
-      },
-      {
-        client: {} as never,
-        sessionKey: "main",
-        callbacks: { onTranscript, onTalkEvent },
-      },
-    );
-
-    await transport.start();
-    const peer = FakePeerConnection.instances[0];
-    peer?.channel.dispatchEvent(
-      new MessageEvent("message", {
-        data: JSON.stringify({
-          type: "conversation.item.input_audio_transcription.completed",
-          item_id: "input-1",
-          transcript: "hello",
-        }),
-      }),
-    );
-    peer?.channel.dispatchEvent(
-      new MessageEvent("message", {
-        data: JSON.stringify({
-          type: "response.audio_transcript.done",
-          item_id: "response-1",
-          transcript: "hi there",
-        }),
-      }),
-    );
-
-    expect(onTranscript).toHaveBeenCalledWith({ role: "user", text: "hello", final: true });
-    expect(onTranscript).toHaveBeenCalledWith({
-      role: "assistant",
-      text: "hi there",
-      final: true,
-    });
-    expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
-      "transcript.done",
-      "output.text.done",
-    ]);
-    expect(onTalkEvent.mock.calls.map(([event]) => event.turnId)).toEqual(["turn-1", "turn-1"]);
-    const userTranscriptEvent = requireTalkEvent(onTalkEvent, 0);
-    expect(userTranscriptEvent.itemId).toBe("input-1");
-    expect(userTranscriptEvent.payload).toEqual({ role: "user", text: "hello" });
-    expect(userTranscriptEvent.sessionId).toBe("main:openai:webrtc");
-    expect(userTranscriptEvent.transport).toBe("webrtc");
-    const assistantTranscriptEvent = requireTalkEvent(onTalkEvent, 1);
-    expect(assistantTranscriptEvent.itemId).toBe("response-1");
-    expect(assistantTranscriptEvent.payload).toEqual({ text: "hi there" });
-    expect(assistantTranscriptEvent.sessionId).toBe("main:openai:webrtc");
-    expect(assistantTranscriptEvent.transport).toBe("webrtc");
-    transport.stop();
-  });
-
-  it("stops processing the current provider event when a transcript callback closes it", async () => {
-    stubAnswerSdpFetch();
-    const onTalkEvent = vi.fn();
-    const onTranscript = vi.fn(() => transport.stop());
-    const transport = createOpenAiTransport({}, { onTranscript, onTalkEvent });
-
-    await transport.start();
-    dispatchTranscription(FakePeerConnection.instances[0], "overflow");
-
-    expect(onTranscript).toHaveBeenCalledOnce();
-    expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual(["session.closed"]);
-  });
-
-  it("maps frameless Codex transcript events by role and finality", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
-    );
-    const onTalkEvent = vi.fn();
-    const transport = new WebRtcSdpRealtimeTalkTransport(
-      {
-        provider: "openai",
-        transport: "webrtc",
-        clientSecret: "client-secret-123",
-      },
-      {
-        client: {} as never,
-        sessionKey: "main",
-        callbacks: { onTalkEvent },
-      },
-    );
-
-    await transport.start();
-    const peer = FakePeerConnection.instances[0];
-    for (const event of [
-      { type: "input_transcript.added", item: { id: "user-live", text: "hel" } },
-      { type: "output_transcript.added", item: { id: "assistant-live", text: "hi" } },
-      {
-        type: "turn.done",
-        turn: { id: "user-final", role: "user", transcript: "hello" },
-      },
-      {
-        type: "turn.done",
-        turn: { id: "assistant-final", role: "assistant", transcript: "hi there" },
-      },
-    ]) {
-      peer?.channel.dispatchEvent(new MessageEvent("message", { data: JSON.stringify(event) }));
-    }
-
-    expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
-      "transcript.delta",
-      "output.text.delta",
-      "transcript.done",
-      "output.text.done",
-      "turn.ended",
-    ]);
-    transport.stop();
-  });
-
-  // Audio output sends the final string in `transcript`; text output sends it in
-  // `text`. Both must surface the same assistant transcript + talk events.
-  it.each([
-    {
-      label: "audio output",
-      deltaType: "response.output_audio_transcript.delta",
-      doneType: "response.output_audio_transcript.done",
-      doneField: { transcript: "hi there" },
-    },
-    {
-      label: "text output",
-      deltaType: "response.output_text.delta",
-      doneType: "response.output_text.done",
-      doneField: { text: "hi there" },
-    },
-  ])(
-    "emits assistant transcripts from OpenAI Realtime $label events",
-    async ({ deltaType, doneType, doneField }) => {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async () => new Response("answer-sdp")) as unknown as typeof fetch,
-      );
-      const onTranscript = vi.fn();
-      const onTalkEvent = vi.fn();
-      const transport = new WebRtcSdpRealtimeTalkTransport(
-        {
-          provider: "openai",
-          transport: "webrtc",
-          clientSecret: "client-secret-123",
-        },
-        {
-          client: {} as never,
-          sessionKey: "main",
-          callbacks: { onTranscript, onTalkEvent },
-        },
-      );
-
-      await transport.start();
-      const peer = FakePeerConnection.instances[0];
-      peer?.channel.dispatchEvent(
-        new MessageEvent("message", {
-          data: JSON.stringify({ type: deltaType, item_id: "response-1", delta: "hi" }),
-        }),
-      );
-      peer?.channel.dispatchEvent(
-        new MessageEvent("message", {
-          data: JSON.stringify({ type: doneType, item_id: "response-1", ...doneField }),
-        }),
-      );
-
-      expect(onTranscript).toHaveBeenCalledWith({
-        role: "assistant",
-        text: "hi",
-        final: false,
-      });
-      expect(onTranscript).toHaveBeenCalledWith({
-        role: "assistant",
-        text: "hi there",
-        final: true,
-      });
-      expect(onTalkEvent.mock.calls.map(([event]) => event.type)).toEqual([
-        "output.text.delta",
-        "output.text.done",
-      ]);
-      expect(onTalkEvent.mock.calls.map(([event]) => event.payload)).toEqual([
-        { text: "hi" },
-        { text: "hi there" },
-      ]);
-      transport.stop();
-    },
-  );
 
   it("aborts an in-flight OpenAI tool consult when the transport stops", async () => {
     vi.stubGlobal(
@@ -881,7 +718,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       },
     );
 
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     dispatchConsultToolCall(peer);
     await waitForFast(() => expect(request).toHaveBeenCalledTimes(1));
@@ -1078,7 +915,7 @@ describe("WebRtcSdpRealtimeTalkTransport", () => {
       },
     );
 
-    await transport.start();
+    await startAndActivate(transport);
     const peer = FakePeerConnection.instances[0];
     dispatchConsultToolCall(peer);
     await waitForFast(() =>

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -1,5 +1,3 @@
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../../../src/talk/describe-view-tool.js";
 // Control UI chat module implements realtime talk webrtc behavior.
 import { formatUiError } from "../../lib/format-error.ts";
 import { RealtimeTalkMediaStreamMeter } from "./realtime-talk-audio.ts";
@@ -7,38 +5,25 @@ import { RealtimeTalkCameraController } from "./realtime-talk-camera-controller.
 import { openRealtimeTalkCamera, openRealtimeTalkInput } from "./realtime-talk-input.ts";
 import {
   type RealtimeTalkWebRtcSdpSessionResult,
-  REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
-  REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME,
   createRealtimeTalkEventEmitter,
-  steerRealtimeTalkActiveConsult,
-  shouldAutoControlRealtimeVoiceAgentText,
-  submitRealtimeTalkAgentControl,
-  submitRealtimeTalkConsult,
   type RealtimeTalkTransport,
   type RealtimeTalkTransportContext,
   type RealtimeTalkTransportStartResult,
 } from "./realtime-talk-shared.ts";
-import { captureRealtimeTalkVideoFrame } from "./realtime-talk-video.ts";
+import { RealtimeTalkWebRtcReadinessOwner } from "./realtime-talk-webrtc-readiness.ts";
 import {
   RealtimeTalkWebRtcOfferExchange,
-  RealtimeTalkResponseOutcomeOwner,
-  realtimeTalkDataChannelMaxMessageSize,
-  realtimeTalkImageEvent,
   type RealtimeServerEvent,
 } from "./realtime-talk-webrtc-support.ts";
-
-type CompletedToolCall = {
-  itemId?: string;
-  name: string;
-  callId: string;
-  args: string;
-};
-
-const MAX_REALTIME_TOOL_ARGUMENT_BYTES = 256_000;
-// Realtime defines no replay window, so evicting terminal IDs could execute a
-// very late duplicate. End an extreme session instead of weakening dedupe.
-const MAX_COMPLETED_TOOL_CALL_IDS = 1_024;
-const utf8Encoder = new TextEncoder();
+import { RealtimeTalkWebRtcToolController } from "./realtime-talk-webrtc-tool-controller.ts";
+import { RealtimeTalkWebRtcTranscriptController } from "./realtime-talk-webrtc-transcript-controller.ts";
+// Muting the browser track is synchronous, but provider VAD events already in
+// flight can arrive afterward. Keep ownership alive through the effective VAD
+// silence window plus network/event-loop delay before declaring quiescence.
+const REALTIME_TRANSCRIPT_DRAIN_DELIVERY_MARGIN_MS = 1_000;
+const REALTIME_TRANSCRIPT_DRAIN_MIN_GRACE_MS = 1_500;
+const REALTIME_TRANSCRIPT_DRAIN_COMPLETION_TIMEOUT_MS = 10_000;
+const MAX_REALTIME_TRANSCRIPT_SILENCE_MS = 60_000;
 const cancelledSetup = Symbol("cancelledSetup");
 
 export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
@@ -48,20 +33,25 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
   private audio: HTMLAudioElement | null = null;
   private inputMeter: RealtimeTalkMediaStreamMeter | null = null;
   private closed = false;
-  private responseActive = false;
-  private responseCreateInFlight = false;
-  private responseCreatePending = false;
-  private readonly responseOutcomes = new RealtimeTalkResponseOutcomeOwner(
-    MAX_COMPLETED_TOOL_CALL_IDS,
-  );
-  private readonly completedToolCallIds = new Set<string>();
   private readonly offerExchange = new RealtimeTalkWebRtcOfferExchange();
   private mediaSetupController: AbortController | null = null;
   private readonly camera: RealtimeTalkCameraController;
-  private readonly consultAbortControllers = new Set<AbortController>();
   private readonly emitTalkEvent: ReturnType<typeof createRealtimeTalkEventEmitter>;
+  private readonly tools: RealtimeTalkWebRtcToolController;
   private starting = false;
   private startupError: Error | null = null;
+  private activated = false;
+  private readonly readiness: RealtimeTalkWebRtcReadinessOwner;
+  private readonly transcripts: RealtimeTalkWebRtcTranscriptController;
+  private speechPending = false;
+  private draining = false;
+  private drainPromise: Promise<void> | null = null;
+  private drainResolve: (() => void) | null = null;
+  private drainReject: ((error: Error) => void) | null = null;
+  private drainGraceElapsed = false;
+  private drainGraceTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private drainTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  private readonly transcriptDrainGraceMs: number;
 
   constructor(
     private readonly session: RealtimeTalkWebRtcSdpSessionResult,
@@ -75,6 +65,37 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       isClosed: () => this.closed,
       onStream: (stream) => this.ctx.callbacks.onVideoStream?.(stream),
     });
+    this.tools = new RealtimeTalkWebRtcToolController({
+      ctx,
+      camera: this.camera,
+      emitTalkEvent: this.emitTalkEvent,
+      send: (event) => this.send(event),
+      getPeer: () => this.peer,
+      isClosed: () => this.closed,
+      isDraining: () => this.draining,
+      failConnection: (detail) => this.failConnection(detail),
+    });
+    this.readiness = new RealtimeTalkWebRtcReadinessOwner(session.transcriptProtocol);
+    this.transcripts = new RealtimeTalkWebRtcTranscriptController({
+      ctx,
+      emitTalkEvent: this.emitTalkEvent,
+      isClosed: () => this.closed,
+      onFatal: (detail) => this.failTranscriptContinuity(detail),
+      onSettlementChange: () => this.maybeResolveDrain(),
+      onUserFinal: (text) => this.tools.handleUserTranscript(text),
+    });
+    const configuredSilenceMs = session.transcriptSilenceDurationMs ?? 500;
+    if (
+      !Number.isSafeInteger(configuredSilenceMs) ||
+      configuredSilenceMs < 0 ||
+      configuredSilenceMs > MAX_REALTIME_TRANSCRIPT_SILENCE_MS
+    ) {
+      throw new Error("Realtime Talk provider returned an unsupported transcript silence window");
+    }
+    this.transcriptDrainGraceMs = Math.max(
+      REALTIME_TRANSCRIPT_DRAIN_MIN_GRACE_MS,
+      configuredSilenceMs + REALTIME_TRANSCRIPT_DRAIN_DELIVERY_MARGIN_MS,
+    );
   }
 
   async start(): Promise<RealtimeTalkTransportStartResult> {
@@ -84,6 +105,12 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     this.closed = false;
     this.starting = true;
     this.startupError = null;
+    this.activated = false;
+    this.readiness.reset();
+    this.transcripts.reset();
+    this.speechPending = false;
+    this.draining = false;
+    this.drainGraceElapsed = false;
     this.mediaSetupController?.abort();
     const peer = new RTCPeerConnection();
     this.peer = peer;
@@ -140,13 +167,10 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       return this.cancelledStart();
     }
     this.media = media;
-    if (this.ctx.callbacks.onInputLevel) {
-      this.inputMeter = new RealtimeTalkMediaStreamMeter(this.ctx.callbacks.onInputLevel);
-      this.inputMeter.start(media);
-    }
     // Camera frames travel only as explicit describe_view data-channel events.
     // Keeping video off the peer prevents unintended continuous camera upload.
     for (const track of media.getAudioTracks()) {
+      track.enabled = false;
       peer.addTrack(track, media);
     }
     const channel = peer.createDataChannel("oai-events");
@@ -156,10 +180,11 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     }
     this.channel = channel;
     channel.addEventListener("open", () => {
-      this.ctx.callbacks.onStatus?.("listening");
-      this.emitTalkEvent({ type: "session.ready" });
+      this.readiness.markChannelOpen();
     });
     channel.addEventListener("message", (event) => this.handleRealtimeEvent(event.data));
+    channel.addEventListener("close", () => this.failConnection("Realtime data channel closed"));
+    channel.addEventListener("error", () => this.failConnection("Realtime data channel failed"));
     peer.addEventListener("connectionstatechange", () => {
       if (this.closed) {
         return;
@@ -205,8 +230,107 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     if (remoteDescriptionResult === cancelledSetup || !this.isCurrentPeer(peer)) {
       return this.cancelledStart();
     }
+    let readinessResult: void | typeof cancelledSetup;
+    try {
+      readinessResult = await this.awaitSetupStep(peer, this.readiness.wait());
+    } catch (error) {
+      if (this.isCurrentPeer(peer)) {
+        this.stop({ emitClosed: false });
+      }
+      throw error;
+    }
+    if (readinessResult === cancelledSetup || !this.isCurrentPeer(peer)) {
+      return this.cancelledStart();
+    }
     this.starting = false;
     return "ready";
+  }
+
+  activate(): void {
+    if (this.closed) {
+      throw new Error("Realtime Talk transport closed before activation");
+    }
+    if (this.activated) {
+      return;
+    }
+    if (!this.readiness.isReady || !this.media) {
+      throw new Error("Realtime Talk transport activated before transcript readiness");
+    }
+    try {
+      this.activated = true;
+      for (const track of this.media.getAudioTracks()) {
+        track.enabled = true;
+      }
+      if (this.ctx.callbacks.onInputLevel) {
+        this.inputMeter = new RealtimeTalkMediaStreamMeter(this.ctx.callbacks.onInputLevel);
+        this.inputMeter.start(this.media);
+      }
+      this.ctx.callbacks.onStatus?.("listening");
+      this.emitTalkEvent({ type: "session.ready" });
+      const buffered = this.readiness.takeBuffered();
+      for (const event of buffered) {
+        if (this.closed) {
+          break;
+        }
+        this.handleParsedRealtimeEvent(event);
+      }
+    } catch (error) {
+      this.stop({ emitClosed: false });
+      throw error;
+    }
+  }
+
+  drain(): Promise<void> {
+    if (this.closed || this.session.transcriptProtocol !== "openai-ga-items") {
+      return Promise.resolve();
+    }
+    if (this.drainPromise) {
+      return this.drainPromise;
+    }
+    this.draining = true;
+    this.drainPromise = new Promise<void>((resolve, reject) => {
+      this.drainResolve = resolve;
+      this.drainReject = reject;
+    });
+    this.drainGraceElapsed = false;
+    this.drainGraceTimer = globalThis.setTimeout(() => {
+      this.drainGraceElapsed = true;
+      this.maybeResolveDrain();
+    }, this.transcriptDrainGraceMs);
+    this.drainTimer = globalThis.setTimeout(() => {
+      this.failTranscriptContinuity(
+        "Realtime Talk timed out waiting for the final user transcription",
+      );
+    }, this.transcriptDrainGraceMs + REALTIME_TRANSCRIPT_DRAIN_COMPLETION_TIMEOUT_MS);
+
+    try {
+      for (const track of this.media?.getAudioTracks() ?? []) {
+        track.enabled = false;
+      }
+    } catch (error) {
+      console.warn("Realtime Talk input mute failed during transcript drain", error);
+    }
+    try {
+      this.inputMeter?.stop();
+    } catch (error) {
+      console.warn("Realtime Talk input meter cleanup failed during transcript drain", error);
+    }
+    this.inputMeter = null;
+    if (this.audio) {
+      this.audio.muted = true;
+      try {
+        this.audio.pause();
+      } catch (error) {
+        console.warn("Realtime Talk output cleanup failed during transcript drain", error);
+      }
+    }
+    try {
+      this.camera.release();
+    } catch (error) {
+      console.warn("Realtime Talk camera cleanup failed during transcript drain", error);
+    }
+    this.tools.beginDrain();
+    return this.drainPromise;
   }
 
   async setVideoEnabled(enabled: boolean): Promise<void> {
@@ -261,6 +385,9 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
 
   private releaseResources(): void {
     this.starting = false;
+    this.activated = false;
+    this.readiness.cancel(new Error("Realtime Talk stopped during provider setup"));
+    this.rejectDrain(new Error("Realtime Talk stopped before transcript drain completed"));
     this.mediaSetupController?.abort();
     this.mediaSetupController = null;
     this.offerExchange.abort();
@@ -275,19 +402,17 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     this.inputMeter = null;
     this.audio?.remove();
     this.audio = null;
-    for (const controller of this.consultAbortControllers) {
-      controller.abort();
-    }
-    this.consultAbortControllers.clear();
-    this.completedToolCallIds.clear();
-    this.responseOutcomes.reset();
-    this.responseActive = false;
-    this.responseCreateInFlight = false;
-    this.responseCreatePending = false;
+    this.tools.reset();
+    this.transcripts.reset();
+    this.speechPending = false;
   }
 
   private failConnection(detail: string): void {
     if (this.closed) {
+      return;
+    }
+    if (this.draining) {
+      this.failTranscriptContinuity(detail);
       return;
     }
     const wasStarting = this.starting;
@@ -319,17 +444,53 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
     } catch {
       return;
     }
+    if (!this.activated) {
+      try {
+        if (
+          this.readiness.consumeReadinessEvent(event, (error) =>
+            this.transcripts.extractErrorDetail(error),
+          )
+        ) {
+          return;
+        }
+        this.readiness.buffer(event);
+      } catch (error) {
+        this.startupError = error instanceof Error ? error : new Error(String(error));
+        this.readiness.cancel(this.startupError);
+      }
+      return;
+    }
+    this.handleParsedRealtimeEvent(event);
+  }
+
+  private handleParsedRealtimeEvent(event: RealtimeServerEvent): void {
+    if (
+      this.session.transcriptProtocol === "openai-ga-items" &&
+      (event.type === "session.created" || event.type === "session.updated")
+    ) {
+      this.readiness.consumeReadinessEvent(event, (error) =>
+        this.transcripts.extractErrorDetail(error),
+      );
+      if (!this.readiness.isReady) {
+        this.failTranscriptContinuity("Realtime provider disabled input transcription");
+      }
+      return;
+    }
+    if (this.draining) {
+      this.handleDrainingRealtimeEvent(event);
+      return;
+    }
     switch (event.type) {
       case "input_transcript.added":
-        this.emitFramelessTranscript("user", event.item?.text, false, event.item?.id);
+        this.transcripts.emitFrameless("user", event.item?.text, false, event.item?.id);
         return;
       case "output_transcript.added":
-        this.emitFramelessTranscript("assistant", event.item?.text, false, event.item?.id);
+        this.transcripts.emitFrameless("assistant", event.item?.text, false, event.item?.id);
         return;
       case "turn.done": {
         const role = event.turn?.role;
         if (role === "user" || role === "assistant") {
-          this.emitFramelessTranscript(role, event.turn?.transcript, true, event.turn?.id);
+          this.transcripts.emitFrameless(role, event.turn?.transcript, true, event.turn?.id);
           if (this.closed) {
             return;
           }
@@ -345,42 +506,34 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
         return;
       }
       case "conversation.item.input_audio_transcription.completed":
-        if (event.transcript) {
-          this.ctx.callbacks.onTranscript?.({ role: "user", text: event.transcript, final: true });
-          if (this.closed) {
+        if (this.session.transcriptProtocol !== "openai-ga-items") {
+          const text = typeof event.transcript === "string" ? event.transcript.trim() : "";
+          if (!text) {
+            this.failTranscriptContinuity("Realtime user transcription was empty");
             return;
           }
-          this.emitTalkEvent({
-            type: "transcript.done",
-            final: true,
-            itemId: event.item_id,
-            payload: { role: "user", text: event.transcript },
-          });
-          if (
-            this.consultAbortControllers.size > 0 &&
-            shouldAutoControlRealtimeVoiceAgentText(event.transcript)
-          ) {
-            void steerRealtimeTalkActiveConsult({
-              ctx: this.ctx,
-              text: event.transcript,
-              emitTalkEvent: this.emitTalkEvent,
-              onControlResult: (result) => this.interruptSuppressedControlResponse(result),
-              speakControlResult: (message) => this.sendControlSpeechMessage(message),
-              suppressSpeechForModes: ["cancel"],
-            });
-          }
+          this.transcripts.emitUserFinal(text, event.item_id);
+          return;
         }
+        this.transcripts.complete(event.item_id, event.transcript);
+        return;
+      case "conversation.item.input_audio_transcription.failed":
+        this.transcripts.fail(event.item_id, this.transcripts.extractErrorDetail(event.error));
         return;
       case "conversation.output_transcript.delta":
       case "response.output_text.delta":
       case "response.audio_transcript.delta":
       case "response.output_audio_transcript.delta":
-        this.emitAssistantTranscript(event, false);
+        this.transcripts.emitAssistant(event, false, false);
         return;
       case "response.output_text.done":
       case "response.audio_transcript.done":
       case "response.output_audio_transcript.done":
-        this.emitAssistantTranscript(event, true);
+        this.transcripts.emitAssistant(
+          event,
+          true,
+          this.session.transcriptProtocol === "openai-ga-items",
+        );
         break;
       case "response.function_call_arguments.delta":
       case "response.function_call_arguments.done":
@@ -388,341 +541,145 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
         // responses. Only the completed response owns executable calls.
         break;
       case "input_audio_buffer.speech_started":
+        this.speechPending = true;
         this.ctx.callbacks.onStatus?.("listening", "Speech detected");
         this.emitTalkEvent({ type: "turn.started", payload: { source: event.type } });
         return;
       case "input_audio_buffer.speech_stopped":
         this.ctx.callbacks.onStatus?.("thinking", "Processing speech");
-        this.emitTalkEvent({ type: "input.audio.committed", final: true });
+        return;
+      case "input_audio_buffer.committed":
+        this.commitTranscriptItem(event.item_id);
         return;
       case "response.created":
-        this.responseActive = true;
-        this.responseCreateInFlight = false;
-        this.responseOutcomes.start(event.response?.id);
-        this.ctx.callbacks.onStatus?.("thinking", "Generating response");
+        this.tools.handleResponseCreated(event);
         return;
       case "response.cancelled":
-      case "response.done": {
-        const terminal = this.responseOutcomes.finish(event);
-        if (!terminal) {
-          return;
-        }
-        const { outcome } = terminal;
-        try {
-          if (outcome.status === "completed") {
-            this.handleCompletedResponse(event);
-            if (this.closed) {
-              return;
-            }
-          }
-          if (outcome.status === "failed" || outcome.status === "incomplete") {
-            this.ctx.callbacks.onStatus?.("error", outcome.message);
-            this.emitTalkEvent({
-              type: "session.error",
-              final: true,
-              payload: outcome,
-            });
-          } else {
-            this.ctx.callbacks.onStatus?.(
-              "listening",
-              outcome.status === "cancelled" ? "Response cancelled" : undefined,
-            );
-          }
-          this.emitTalkEvent({
-            type: outcome.status === "cancelled" ? "turn.cancelled" : "turn.ended",
-            final: true,
-            payload: outcome,
-          });
-        } finally {
-          if (terminal.overflow) {
-            this.failConnection("Realtime response session limit exceeded");
-          }
-          this.responseActive = false;
-          this.responseCreateInFlight = false;
-          this.flushPendingResponseCreate();
-        }
+      case "response.done":
+        this.tools.handleResponseTerminal(event);
         return;
-      }
       case "error":
-        this.responseCreateInFlight = false;
-        this.ctx.callbacks.onStatus?.("error", this.extractErrorDetail(event.error));
+        this.tools.handleProviderError();
+        this.ctx.callbacks.onStatus?.("error", this.transcripts.extractErrorDetail(event.error));
         this.emitTalkEvent({
           type: "session.error",
           final: true,
-          payload: { message: this.extractErrorDetail(event.error) },
+          payload: { message: this.transcripts.extractErrorDetail(event.error) },
         });
 
       default:
     }
   }
 
-  private emitAssistantTranscript(event: RealtimeServerEvent, final: boolean): void {
-    const text = final ? (event.transcript ?? event.text) : event.delta;
-    if (!text) {
-      return;
-    }
-    this.ctx.callbacks.onTranscript?.({
-      role: "assistant",
-      text,
-      final,
-    });
-    if (this.closed) {
-      return;
-    }
-    this.emitTalkEvent({
-      type: final ? "output.text.done" : "output.text.delta",
-      final,
-      itemId: event.item_id,
-      payload: { text },
-    });
-  }
-
-  private emitFramelessTranscript(
-    role: "user" | "assistant",
-    text: string | undefined,
-    final: boolean,
-    itemId?: string,
-  ): void {
-    if (!text) {
-      return;
-    }
-    this.ctx.callbacks.onTranscript?.({ role, text, final });
-    if (this.closed) {
-      return;
-    }
-    const type =
-      role === "user"
-        ? final
-          ? "transcript.done"
-          : "transcript.delta"
-        : final
-          ? "output.text.done"
-          : "output.text.delta";
-    this.emitTalkEvent({
-      type,
-      final,
-      itemId,
-      payload: { role, text },
-    });
-  }
-
-  private extractErrorDetail(error: unknown): string {
-    if (!error || typeof error !== "object") {
-      return "Realtime provider error";
-    }
-    const record = error as Record<string, unknown>;
-    const message = typeof record.message === "string" ? record.message.trim() : "";
-    const code = typeof record.code === "string" ? record.code.trim() : "";
-    const type = typeof record.type === "string" ? record.type.trim() : "";
-    return message || code || type || "Realtime provider error";
-  }
-
-  private handleCompletedResponse(event: RealtimeServerEvent): void {
-    const response: unknown = event.response;
-    if (!isRecord(response) || response.status !== "completed" || !Array.isArray(response.output)) {
-      return;
-    }
-    for (const output of response.output) {
-      if (
-        !isRecord(output) ||
-        output.type !== "function_call" ||
-        (output.status !== undefined && output.status !== "completed")
-      ) {
-        continue;
-      }
-      const itemId = typeof output.id === "string" ? output.id.trim() || undefined : undefined;
-      const callId = typeof output.call_id === "string" ? output.call_id.trim() : "";
-      const name = typeof output.name === "string" ? output.name.trim() : "";
-      const args = typeof output.arguments === "string" ? output.arguments : "";
-      if (!callId || !name || !args.trim()) {
-        continue;
-      }
-      if (
-        name !== REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME &&
-        name !== REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME &&
-        name !== REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME
-      ) {
-        continue;
-      }
-      if (this.completedToolCallIds.has(callId)) {
-        continue;
-      }
-      if (this.completedToolCallIds.size >= MAX_COMPLETED_TOOL_CALL_IDS) {
-        this.failConnection("Realtime tool-call session limit exceeded");
+  private handleDrainingRealtimeEvent(event: RealtimeServerEvent): void {
+    switch (event.type) {
+      case "input_audio_buffer.speech_started":
+        this.speechPending = true;
+        break;
+      case "input_audio_buffer.speech_stopped":
         return;
+      case "input_audio_buffer.committed":
+        this.commitTranscriptItem(event.item_id);
+        return;
+      case "conversation.item.input_audio_transcription.completed":
+        this.transcripts.complete(event.item_id, event.transcript);
+        return;
+      case "conversation.item.input_audio_transcription.failed":
+        this.transcripts.fail(event.item_id, this.transcripts.extractErrorDetail(event.error));
+        return;
+      case "response.created":
+        this.tools.cancelResponseBestEffort();
+        break;
+      case "error":
+        // `response.cancel` races can produce benign provider errors while
+        // the user transcript still settles. Explicit transcription failures,
+        // connection loss, and the bounded drain timeout own continuity.
+        break;
+      default:
+        // Stop means stop: late provider output, tools, and status events must
+        // not execute work or resurrect the UI while transcript ownership drains.
+        break;
+    }
+  }
+
+  private commitTranscriptItem(itemId: unknown): void {
+    this.speechPending = false;
+    this.transcripts.commit(itemId);
+  }
+
+  private failTranscriptContinuity(detail: string): void {
+    if (this.closed) {
+      return;
+    }
+    const message = detail || "Realtime user transcription failed";
+    this.rejectDrain(new Error(message));
+    try {
+      try {
+        this.ctx.callbacks.onStatus?.("error", message);
+      } catch (error) {
+        console.warn("Realtime Talk status callback failed during transcript shutdown", error);
       }
-      this.completedToolCallIds.add(callId);
-      if (utf8Encoder.encode(args).byteLength > MAX_REALTIME_TOOL_ARGUMENT_BYTES) {
-        const message = "Realtime tool arguments exceed the 256000-byte UTF-8 limit";
-        this.submitToolResult(callId, { error: message });
+      try {
         this.emitTalkEvent({
-          type: "tool.error",
-          callId,
-          itemId,
+          type: "session.error",
           final: true,
-          payload: { name, message },
+          payload: { message },
         });
-        continue;
+      } catch (error) {
+        console.warn("Realtime Talk event callback failed during transcript shutdown", error);
       }
-      void this.handleToolCall({ itemId, callId, name, args }).catch((error: unknown) => {
-        this.reportToolResultSubmissionError(error);
-      });
-    }
-  }
-
-  private async handleToolCall(call: CompletedToolCall): Promise<void> {
-    const { itemId, callId, name, args } = call;
-    if (name === REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME) {
-      await submitRealtimeTalkAgentControl({
-        ctx: this.ctx,
-        callId,
-        args,
-        emitTalkEvent: this.emitTalkEvent,
-        submit: (toolCallId, result) => this.submitToolResult(toolCallId, result),
-      });
-      return;
-    }
-    if (name === REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME) {
-      await this.handleDescribeViewToolCall(callId, itemId);
-      return;
-    }
-    if (name !== REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-      return;
-    }
-    this.emitTalkEvent({
-      type: "tool.call",
-      callId,
-      itemId,
-      payload: { name, args },
-    });
-    const abortController = new AbortController();
-    this.consultAbortControllers.add(abortController);
-    try {
-      await submitRealtimeTalkConsult({
-        ctx: this.ctx,
-        callId,
-        args,
-        signal: abortController.signal,
-        emitTalkEvent: this.emitTalkEvent,
-        submit: (toolCallId, result) => this.submitToolResult(toolCallId, result),
-      });
+      try {
+        this.ctx.callbacks.onFatalError?.(message);
+      } catch (error) {
+        console.warn("Realtime Talk fatal callback failed during transcript shutdown", error);
+      }
     } finally {
-      this.consultAbortControllers.delete(abortController);
+      if (!this.closed) {
+        this.stop();
+      }
     }
   }
 
-  private async handleDescribeViewToolCall(callId: string, itemId?: string): Promise<void> {
-    this.emitTalkEvent({
-      type: "tool.call",
-      callId,
-      itemId,
-      payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME },
-    });
-    if (!this.camera.hasLiveTrack()) {
-      this.submitToolResult(callId, { ok: false, error: "camera is off" });
-      this.emitTalkEvent({
-        type: "tool.error",
-        callId,
-        itemId,
-        final: true,
-        payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME, message: "camera is off" },
-      });
+  private maybeResolveDrain(): void {
+    if (
+      !this.draining ||
+      !this.drainGraceElapsed ||
+      this.speechPending ||
+      this.transcripts.pendingCount > 0
+    ) {
       return;
     }
     try {
-      const frame = await captureRealtimeTalkVideoFrame(
-        this.camera.video,
-        realtimeTalkDataChannelMaxMessageSize(this.peer),
-        realtimeTalkImageEvent,
-      );
-      this.send(realtimeTalkImageEvent(frame));
-      this.submitToolResult(callId, { ok: true, frameAttached: true });
-      this.emitTalkEvent({
-        type: "tool.result",
-        callId,
-        itemId,
-        final: true,
-        payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME, frameAttached: true },
-      });
+      this.transcripts.assertSettled();
     } catch (error) {
-      const message = formatUiError(error);
-      this.submitToolResult(callId, { ok: false, error: message });
-      this.emitTalkEvent({
-        type: "tool.error",
-        callId,
-        itemId,
-        final: true,
-        payload: { name: REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME, message },
-      });
-    }
-  }
-
-  private submitToolResult(callId: string, result: unknown): void {
-    if (this.closed) {
+      this.rejectDrain(error instanceof Error ? error : new Error(String(error)));
       return;
     }
-    this.send({
-      type: "conversation.item.create",
-      item: {
-        type: "function_call_output",
-        call_id: callId,
-        output: JSON.stringify(result),
-      },
-    });
-    this.requestResponseCreate();
+    const resolve = this.drainResolve;
+    this.clearDrainWait();
+    this.draining = false;
+    resolve?.();
   }
 
-  private reportToolResultSubmissionError(error: unknown): void {
-    if (this.closed) {
-      return;
-    }
-    const message = formatUiError(error);
-    this.ctx.callbacks.onStatus?.("error", message);
+  private rejectDrain(error: Error): void {
+    const reject = this.drainReject;
+    this.clearDrainWait();
+    this.draining = false;
+    reject?.(error);
   }
 
-  private sendControlSpeechMessage(message: string): void {
-    if (this.responseActive) {
-      this.send({ type: "response.cancel" });
+  private clearDrainWait(): void {
+    if (this.drainGraceTimer) {
+      globalThis.clearTimeout(this.drainGraceTimer);
     }
-    this.send({
-      type: "conversation.item.create",
-      item: {
-        type: "message",
-        role: "user",
-        content: [{ type: "input_text", text: message }],
-      },
-    });
-    this.requestResponseCreate();
-  }
-
-  private interruptSuppressedControlResponse(result: unknown): void {
-    if (!this.responseActive || !result || typeof result !== "object") {
-      return;
+    if (this.drainTimer) {
+      globalThis.clearTimeout(this.drainTimer);
     }
-    const record = result as Record<string, unknown>;
-    if (
-      record.ok === true &&
-      (record.mode === "cancel" || (record.suppress === true && record.mode !== "steer"))
-    ) {
-      this.send({ type: "response.cancel" });
-    }
-  }
-
-  private requestResponseCreate(): void {
-    if (this.responseActive || this.responseCreateInFlight) {
-      this.responseCreatePending = true;
-      return;
-    }
-    this.responseCreatePending = false;
-    this.responseCreateInFlight = true;
-    this.send({ type: "response.create" });
-  }
-
-  private flushPendingResponseCreate(): void {
-    if (!this.responseCreatePending) {
-      return;
-    }
-    this.responseCreatePending = false;
-    this.requestResponseCreate();
+    this.drainGraceTimer = null;
+    this.drainTimer = null;
+    this.drainPromise = null;
+    this.drainResolve = null;
+    this.drainReject = null;
+    this.drainGraceElapsed = false;
   }
 }

--- a/ui/src/pages/chat/realtime-talk-webrtc.ts
+++ b/ui/src/pages/chat/realtime-talk-webrtc.ts
@@ -23,7 +23,10 @@ import { RealtimeTalkWebRtcTranscriptController } from "./realtime-talk-webrtc-t
 const REALTIME_TRANSCRIPT_DRAIN_DELIVERY_MARGIN_MS = 1_000;
 const REALTIME_TRANSCRIPT_DRAIN_MIN_GRACE_MS = 1_500;
 const REALTIME_TRANSCRIPT_DRAIN_COMPLETION_TIMEOUT_MS = 10_000;
-const MAX_REALTIME_TRANSCRIPT_SILENCE_MS = 60_000;
+// This bounds browser resources retained after Stop, not the provider's accepted
+// VAD configuration. Larger historical values remain valid but fail visibly if
+// their final transcript cannot settle inside the bounded shutdown window.
+const MAX_REALTIME_TRANSCRIPT_DRAIN_SILENCE_MS = 60_000;
 const cancelledSetup = Symbol("cancelledSetup");
 
 export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
@@ -85,16 +88,13 @@ export class WebRtcSdpRealtimeTalkTransport implements RealtimeTalkTransport {
       onUserFinal: (text) => this.tools.handleUserTranscript(text),
     });
     const configuredSilenceMs = session.transcriptSilenceDurationMs ?? 500;
-    if (
-      !Number.isSafeInteger(configuredSilenceMs) ||
-      configuredSilenceMs < 0 ||
-      configuredSilenceMs > MAX_REALTIME_TRANSCRIPT_SILENCE_MS
-    ) {
+    if (!Number.isSafeInteger(configuredSilenceMs) || configuredSilenceMs < 0) {
       throw new Error("Realtime Talk provider returned an unsupported transcript silence window");
     }
     this.transcriptDrainGraceMs = Math.max(
       REALTIME_TRANSCRIPT_DRAIN_MIN_GRACE_MS,
-      configuredSilenceMs + REALTIME_TRANSCRIPT_DRAIN_DELIVERY_MARGIN_MS,
+      Math.min(configuredSilenceMs, MAX_REALTIME_TRANSCRIPT_DRAIN_SILENCE_MS) +
+        REALTIME_TRANSCRIPT_DRAIN_DELIVERY_MARGIN_MS,
     );
   }
 

--- a/ui/src/pages/chat/realtime-talk.ts
+++ b/ui/src/pages/chat/realtime-talk.ts
@@ -8,27 +8,25 @@ import {
 } from "../../../../src/talk/voice-transcript.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { formatUiError } from "../../lib/format-error.ts";
-import { GatewayRelayRealtimeTalkTransport } from "./realtime-talk-gateway-relay.ts";
-import { GoogleLiveRealtimeTalkTransport } from "./realtime-talk-google-live.ts";
+import {
+  createRealtimeTalkTransport,
+  resolveRealtimeTalkTransport,
+} from "./realtime-talk-session-factory.ts";
 import type {
   RealtimeTalkCallbacks,
   RealtimeTalkGatewayRelaySessionResult,
-  RealtimeTalkJsonPcmWebSocketSessionResult,
   RealtimeTalkSessionResult,
   RealtimeTalkStatus,
   RealtimeTalkTransport,
-  RealtimeTalkTransportContext,
-  RealtimeTalkWebRtcSdpSessionResult,
 } from "./realtime-talk-shared.ts";
 import {
   type ClientVoiceSessionOwner,
   type DetachedVoiceSession,
   reserveClientVoiceSessionOwner,
   retireUncommittedRealtimeTalkTransport,
-  transcriptPersistenceAbortError,
-  waitForTranscriptRetry,
+  closeRealtimeTalkVoiceSession,
+  writeRealtimeTalkTranscriptWithRetry,
 } from "./realtime-talk-transcript-owner.ts";
-import { WebRtcSdpRealtimeTalkTransport } from "./realtime-talk-webrtc.ts";
 
 export type { RealtimeTalkStatus };
 
@@ -98,38 +96,6 @@ function normalizeLaunchTransport(value: unknown): RealtimeTalkLaunchTransport |
   return undefined;
 }
 
-function createTransport(
-  session: RealtimeTalkSessionResult,
-  ctx: RealtimeTalkTransportContext,
-): RealtimeTalkTransport {
-  const transport = resolveTransport(session);
-  if (transport === "webrtc") {
-    return new WebRtcSdpRealtimeTalkTransport(session as RealtimeTalkWebRtcSdpSessionResult, ctx);
-  }
-  if (transport === "provider-websocket") {
-    return new GoogleLiveRealtimeTalkTransport(
-      session as RealtimeTalkJsonPcmWebSocketSessionResult,
-      ctx,
-    );
-  }
-  if (transport === "gateway-relay") {
-    return new GatewayRelayRealtimeTalkTransport(
-      session as RealtimeTalkGatewayRelaySessionResult,
-      ctx,
-    );
-  }
-  const unknownTransport = (session as { transport?: string }).transport ?? "unknown";
-  throw new Error(`Unsupported realtime Talk transport: ${unknownTransport}`);
-}
-
-function resolveTransport(session: RealtimeTalkSessionResult): string {
-  return normalizeTalkTransport((session as { transport?: string }).transport) ?? "webrtc";
-}
-
-function transcriptWriteError(error: unknown, fallback: string): Error {
-  return error instanceof Error ? error : new Error(fallback, { cause: error });
-}
-
 function compactLaunchParams(
   params: RealtimeTalkLaunchOptions & {
     sessionKey: string;
@@ -155,6 +121,7 @@ export class RealtimeTalkSession {
   private serverOwnedVoiceSession = false;
   private transcriptQueue = VOICE_TRANSCRIPT_QUEUE_POLICY.createQueue();
   private clientVoiceSessionOwner: ClientVoiceSessionOwner | undefined;
+  private closingPromise: Promise<void> | null = null;
 
   constructor(
     private readonly client: GatewayBrowserClient,
@@ -165,6 +132,7 @@ export class RealtimeTalkSession {
   ) {}
 
   async start(): Promise<void> {
+    await this.closingPromise?.catch(() => undefined);
     const owner = reserveClientVoiceSessionOwner(this.client, this.sessionKey);
     let ownerTransferred = false;
     try {
@@ -189,7 +157,7 @@ export class RealtimeTalkSession {
         capabilities.push("camera-frame");
       }
       const session = await this.createSession({ ...this.options, capabilities });
-      const transport = resolveTransport(session);
+      const transport = resolveRealtimeTalkTransport(session);
       // Managed-room stays unsupported here and carries no voice bookkeeping;
       // reject it before the voice-session requirement produces a misleading error.
       if (transport === "managed-room") {
@@ -236,7 +204,7 @@ export class RealtimeTalkSession {
       let nextTransport: RealtimeTalkTransport | null = null;
       let startResult: Awaited<ReturnType<RealtimeTalkTransport["start"]>>;
       try {
-        nextTransport = createTransport(session, {
+        nextTransport = createRealtimeTalkTransport(session, {
           client: this.client,
           sessionKey: this.sessionKey,
           voiceSessionId,
@@ -421,7 +389,7 @@ export class RealtimeTalkSession {
           }),
           { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
         );
-        return resolveTransport(relaySession) === "gateway-relay"
+        return resolveRealtimeTalkTransport(relaySession) === "gateway-relay"
           ? {
               ...relaySession,
               voiceSessionId: (relaySession as RealtimeTalkGatewayRelaySessionResult)
@@ -435,6 +403,9 @@ export class RealtimeTalkSession {
   }
 
   stop(): void {
+    if (this.closingPromise) {
+      return;
+    }
     this.lifecycleGeneration += 1;
     this.closed = true;
     this.videoOperation += 1;
@@ -442,11 +413,51 @@ export class RealtimeTalkSession {
     activeRealtimeTalkSessions.delete(this);
     this.callbacks.onStatus?.("idle");
     this.stopPendingTransport();
+    const transport = this.transport;
+    if (!transport?.drain) {
+      this.finishTransportStop(transport);
+      return;
+    }
+    let drain: Promise<void>;
+    try {
+      drain = transport.drain();
+    } catch (error) {
+      drain = Promise.reject(
+        error instanceof Error
+          ? error
+          : new Error("Realtime Talk transcript drain failed", { cause: error }),
+      );
+    }
+    this.closingPromise = drain
+      .catch((error: unknown) => {
+        const detail = formatUiError(error);
+        console.warn("Realtime Talk transcript drain failed", error);
+        if (this.transport === transport && this.acceptingTranscripts) {
+          this.callbacks.onStatus?.("error", detail);
+        }
+      })
+      .finally(() => {
+        this.finishTransportStop(transport);
+        this.closingPromise = null;
+      });
+  }
+
+  private finishTransportStop(transport: RealtimeTalkTransport | null): void {
+    if (transport && this.transport !== transport) {
+      return;
+    }
     const detached = this.detachVoiceSession();
-    this.transport?.stop();
-    this.transport = null;
-    if (detached) {
-      this.closeLogicalVoiceSession(detached);
+    try {
+      transport?.stop();
+    } catch (error) {
+      console.warn("Realtime Talk transport cleanup failed during stop", error);
+    } finally {
+      if (this.transport === transport) {
+        this.transport = null;
+      }
+      if (detached) {
+        this.closeLogicalVoiceSession(detached);
+      }
     }
   }
 
@@ -491,6 +502,7 @@ export class RealtimeTalkSession {
   ): RealtimeTalkCallbacks {
     return {
       ...this.callbacks,
+      onFatalError: (detail) => this.failRealtimeTransport(owningGeneration, detail),
       onTranscript: (entry) => {
         // Transport replacement can reuse the voice session id, so a retired
         // transport's late finals are fenced by generation, not id alone.
@@ -512,7 +524,9 @@ export class RealtimeTalkSession {
           if (text) {
             const admission = this.transcriptQueue.enqueue(
               async () =>
-                await this.writeTranscriptWithRetry({
+                await writeRealtimeTalkTranscriptWithRetry({
+                  client: this.client,
+                  sessionKey: this.sessionKey,
                   voiceSessionId: owningVoiceSessionId,
                   entryId,
                   role,
@@ -550,6 +564,39 @@ export class RealtimeTalkSession {
     };
   }
 
+  private failRealtimeTransport(owningGeneration: number, detail: string): void {
+    if (
+      this.transportGeneration !== owningGeneration ||
+      !this.acceptingTranscripts ||
+      !this.voiceSessionId
+    ) {
+      return;
+    }
+    this.lifecycleGeneration += 1;
+    this.closed = true;
+    this.videoOperation += 1;
+    this.videoEnabled = false;
+    activeRealtimeTalkSessions.delete(this);
+    this.stopPendingTransport();
+    const transport = this.transport;
+    const detached = this.detachVoiceSession();
+    this.transportGeneration += 1;
+    try {
+      transport?.stop();
+    } catch (error) {
+      console.warn("Realtime Talk transport cleanup failed after a terminal error", error);
+    }
+    this.transport = null;
+    if (detached) {
+      this.closeLogicalVoiceSession(detached);
+    }
+    try {
+      this.callbacks.onStatus?.("error", detail);
+    } catch (error) {
+      console.warn("Realtime Talk status callback failed after a terminal error", error);
+    }
+  }
+
   private failTranscriptPersistence(owningGeneration: number): void {
     if (
       this.transportGeneration !== owningGeneration ||
@@ -577,48 +624,6 @@ export class RealtimeTalkSession {
     }
   }
 
-  private async writeTranscriptWithRetry(params: {
-    voiceSessionId: string;
-    entryId: string;
-    role: "user" | "assistant";
-    text: string;
-    signal: AbortSignal;
-  }): Promise<void> {
-    const retryDelaysMs = [0, 500, 2_000];
-    let lastError: unknown;
-    for (const delayMs of retryDelaysMs) {
-      if (delayMs > 0) {
-        await waitForTranscriptRetry(delayMs, params.signal);
-      } else if (params.signal.aborted) {
-        throw transcriptPersistenceAbortError();
-      }
-      try {
-        await this.client.request(
-          "talk.client.transcript",
-          {
-            sessionKey: this.sessionKey,
-            voiceSessionId: params.voiceSessionId,
-            entryId: params.entryId,
-            role: params.role,
-            text: params.text,
-            timestamp: Date.now(),
-          },
-          {
-            signal: params.signal,
-            timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
-          },
-        );
-        return;
-      } catch (error) {
-        if (params.signal.aborted) {
-          throw transcriptPersistenceAbortError();
-        }
-        lastError = error;
-      }
-    }
-    throw transcriptWriteError(lastError, "voice transcript save failed");
-  }
-
   private detachVoiceSession(): DetachedVoiceSession | undefined {
     const voiceSessionId = this.voiceSessionId;
     if (!voiceSessionId) {
@@ -642,56 +647,15 @@ export class RealtimeTalkSession {
   }
 
   private closeLogicalVoiceSession(detached: DetachedVoiceSession): void {
-    if (detached.serverOwned) {
-      detached.owner?.release();
-      return;
-    }
-    const owner = detached.owner!;
-    owner.beginDrain();
-    void detached.transcriptQueue
-      .flush()
-      .then(async () => {
-        let lastError: unknown;
-        for (const delayMs of [0, 500, 2_000]) {
-          if (delayMs > 0) {
-            await waitForTranscriptRetry(delayMs, owner.closeSignal);
-          } else if (owner.closeSignal.aborted) {
-            throw transcriptPersistenceAbortError();
-          }
-          try {
-            await this.client.request(
-              "talk.client.close",
-              {
-                sessionKey: this.sessionKey,
-                voiceSessionId: detached.voiceSessionId,
-              },
-              {
-                signal: owner.closeSignal,
-                timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
-              },
-            );
-            return;
-          } catch (error) {
-            if (owner.closeSignal.aborted) {
-              throw transcriptPersistenceAbortError();
-            }
-            lastError = error;
-          }
-        }
-        throw transcriptWriteError(lastError, "Realtime Talk voice session close failed");
-      })
-      .catch((error: unknown) => {
-        if (owner.closeSignal.aborted) {
-          return;
-        }
-        console.warn("Realtime Talk voice session close failed", error);
-        // Suppress if a newer transport has started: closing the old call is its own
-        // teardown and must not push the active replacement call into an error state.
-        if (this.transportGeneration === detached.generation) {
-          this.callbacks.onStatus?.("error", "Realtime Talk voice session close failed");
-        }
-      })
-      .finally(owner.release);
+    closeRealtimeTalkVoiceSession({
+      client: this.client,
+      sessionKey: this.sessionKey,
+      detached,
+      // Suppress if a newer transport has started: closing the old call is its own
+      // teardown and must not push the active replacement call into an error state.
+      isCurrentGeneration: () => this.transportGeneration === detached.generation,
+      onStatus: (status, detail) => this.callbacks.onStatus?.(status, detail),
+    });
   }
 
   async setVideoEnabled(enabled: boolean): Promise<void> {


### PR DESCRIPTION
Closes #125601

Related: #126363

## What Problem This Solves

Fixes an issue where browser Talk could sound functional while losing finalized user speech from the active OpenClaw session. Users could speak with the realtime model, but later written or spoken turns would not share a complete conversation history. Startup races, out-of-order provider completions, transcription failures, and an immediate Stop could each leave the user side missing or misleadingly clean.

## Why This Change Was Made

OpenAI WebRTC is now provisional until the data channel and the provider's effective transcript-capable session are ready. The microphone remains disabled until the outer Talk session installs transcript ownership, then `activate()` enables input and reports listening.

GA Realtime user transcripts are settled by bounded provider item identity rather than callback arrival order: committed turns emit exactly once in commit order, duplicates are ignored, and explicit continuity failures stop Talk visibly. Stop mutes immediately, releases camera/output/tool work, and retains transcript ownership for a bounded provider-aware drain so a pending final can settle before physical close. GPT-Live's frameless protocol keeps its distinct readiness and transcript path.

User transcript identity remains mandatory because commit and completion are separate provider events. Assistant identity is optional: keyed finals retain validation and deduplication, while an absent/blank `item_id` remains ordered and deliverable without pretending it can be provider-ID deduplicated.

This builds on the creation-time session-policy repair merged in #126363. It does not add another provider configuration mechanism or claim a complete OpenAI conversation graph across every overlapping/barge-in topology.

## User Impact

Users can move naturally between written chat and hands-busy realtime voice without silently losing what they said. A later written turn—or a new Talk session that consults the active agent—can recover durable voice context after page reload or Gateway restart.

## Evidence

### Deterministic validation

The focused owner and browser-transport tests inject the precise ClawSweeper event shape: a text-bearing final assistant event with no `item_id`.

They prove that:

- the event remains ordered behind a pending user transcript;
- Talk does not close through the fatal callback;
- the assistant text is durably appended;
- multiple unkeyed assistant finals remain deliverable;
- keyed assistant finals retain deduplication and bounded validation.

```text
Focused owner + browser transport suite  49 passed
Full Talk and protocol slice             10 files / 215 passed
check-changed                             passed
git diff --check                          passed
```

### Live behavior proof

Reviewer-grade visual proof is pending operator capture. This draft does not currently claim that the Stop/drain/reload lifecycle has been demonstrated by an inspectable visual artifact.

### Scope boundary

The gateway-control metadata branch requires a Platform API key and cannot honestly be exercised by the available subscription-OAuth fixture. Focused tests prove that a configured 650 ms provider VAD value reaches both effective GA policy and broker metadata, while the omitted-value fallback remains 500 ms.

### Credits

Thanks to @openperf for the first focused patch and to @vmbbz for adding real ChatGPT subscription/WebRTC evidence on #125742. Their work helped establish that receiving a finalized provider transcript repairs persistence, while this PR closes the remaining readiness, ownership, ordering, failure, and shutdown gaps.

## AI Assistance

AI-assisted with Codex, including independent adversarial design and patch review. I reviewed the implementation and deterministic regression coverage.
