### PR TITLE
fix(release): protect ClawHub bootstrap writers

### DIFF
--- a/.github/workflows/plugin-clawhub-new.yml
+++ b/.github/workflows/plugin-clawhub-new.yml
@@ -78,13 +78,15 @@ jobs:
       - name: Require trusted workflow source
         env:
           APPROVED_WORKFLOW_SHA: ${{ inputs.bootstrap_workflow_sha }}
+          GH_TOKEN: ${{ github.token }}
           PRETAG_VALIDATION: ${{ inputs.pretag_validation }}
-          WORKFLOW_REF: ${{ github.ref }}
-          WORKFLOW_SHA: ${{ github.sha }}
+          WORKFLOW_FULL_REF: ${{ github.ref }}
+          WORKFLOW_REF: ${{ github.ref_name }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           [[ "$(git rev-parse HEAD)" == "${WORKFLOW_SHA}" ]] || {
-            echo "Trusted workflow checkout does not match github.sha." >&2
+            echo "Trusted workflow checkout does not match github.workflow_sha." >&2
             exit 1
           }
           if [[ "${PRETAG_VALIDATION}" != "true" ]]; then
@@ -98,9 +100,9 @@ jobs:
               echo "Plugin ClawHub bootstrap requires an exact approved workflow SHA." >&2
               exit 1
             }
-            if [[ "${WORKFLOW_REF}" == "refs/heads/main" ]]; then
+            if [[ "${WORKFLOW_FULL_REF}" == "refs/heads/main" ]]; then
               :
-            elif [[ "${WORKFLOW_REF}" =~ ^refs/tags/release-publish/([a-f0-9]{12})-[1-9][0-9]*$ && "${APPROVED_WORKFLOW_SHA:0:12}" == "${BASH_REMATCH[1]}" ]]; then
+            elif [[ "${WORKFLOW_FULL_REF}" =~ ^refs/tags/release-publish/([a-f0-9]{12})-[1-9][0-9]*$ && "${APPROVED_WORKFLOW_SHA:0:12}" == "${BASH_REMATCH[1]}" ]]; then
               :
             else
               echo "Plugin ClawHub bootstrap requires trusted main or the protected SHA-pinned release-publish tag." >&2
@@ -111,10 +113,11 @@ jobs:
               exit 1
             }
           else
-            [[ "${WORKFLOW_REF}" == "refs/heads/main" ]] || {
-              echo "Plugin ClawHub pre-tag validation must be dispatched from trusted main." >&2
-              exit 1
-            }
+            node scripts/release-tooling-identity.mjs verify \
+              --repository "${GITHUB_REPOSITORY}" \
+              --workflow-ref "${WORKFLOW_REF}" \
+              --workflow-full-ref "${WORKFLOW_FULL_REF}" \
+              --workflow-sha "${WORKFLOW_SHA}"
             if [[ -n "${APPROVED_WORKFLOW_SHA}" && "${WORKFLOW_SHA}" != "${APPROVED_WORKFLOW_SHA}" ]]; then
               echo "Plugin ClawHub pre-tag validation workflow SHA does not match the requested trusted-main SHA." >&2
               exit 1

--- a/.github/workflows/plugin-clawhub-new.yml
+++ b/.github/workflows/plugin-clawhub-new.yml
@@ -969,12 +969,18 @@ jobs:
       - name: Publish exact ClawHub bootstrap artifacts
         env:
           CLAWHUB_REGISTRY: ${{ env.CLAWHUB_REGISTRY }}
+          GH_TOKEN: ${{ github.token }}
           SOURCE_COMMIT: ${{ needs.resolve_bootstrap_plan.outputs.ref_revision }}
           SOURCE_REF: ${{ needs.resolve_bootstrap_plan.outputs.ref_revision }}
           SOURCE_REPO: ${{ github.repository }}
           OPENCLAW_CLAWHUB_CLI: ${{ steps.clawhub_cli.outputs.cli }}
+          RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
+          RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
           RELEASE_TAG: ${{ inputs.release_tag }}
           TARGET_SHA: ${{ needs.resolve_bootstrap_plan.outputs.ref_revision }}
+          WORKFLOW_FULL_REF: ${{ github.ref }}
+          WORKFLOW_REF: ${{ github.ref_name }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           verify_release_tag_target() {
@@ -988,8 +994,17 @@ jobs:
             }
           }
 
+          verify_release_tooling_identity() {
+            node .release-harness/scripts/release-tooling-identity.mjs verify \
+              --repository "${GITHUB_REPOSITORY}" \
+              --workflow-ref "${WORKFLOW_REF}" \
+              --workflow-full-ref "${WORKFLOW_FULL_REF}" \
+              --workflow-sha "${WORKFLOW_SHA}" \
+              --release-publish-run-id "${RELEASE_PUBLISH_RUN_ID}" \
+              --release-publish-run-attempt "${RELEASE_PUBLISH_RUN_ATTEMPT}"
+          }
+
           while IFS= read -r plugin; do
-            verify_release_tag_target
             mode="$(jq -r '.bootstrapMode' <<< "${plugin}")"
             package_name="$(jq -r '.packageName' <<< "${plugin}")"
             if [[ "${mode}" == "publish" ]]; then
@@ -1000,6 +1015,8 @@ jobs:
               if [[ "$(jq -r '.requiresManualOverride' <<< "${plugin}")" == "true" ]]; then
                 manual_override="GitHub Actions trusted publisher repair before OIDC migration"
               fi
+              verify_release_tag_target
+              verify_release_tooling_identity
               PACKAGE_DIR="$(jq -r '.packageDir' <<< "${plugin}")" \
                 PACKAGE_TAG="$(jq -r '.publishTag' <<< "${plugin}")" \
                 EXPECTED_CLAWHUB_PACKAGE_NAME="${package_name}" \
@@ -1017,6 +1034,7 @@ jobs:
               echo "Skipping bootstrap publish because the exact version is already present; configuring trusted publisher only."
             fi
             verify_release_tag_target
+            verify_release_tooling_identity
             timeout --signal=TERM --kill-after=10s 300s \
               "${OPENCLAW_CLAWHUB_CLI}" package trusted-publisher set "${package_name}" \
                 --repository openclaw/openclaw \

--- a/.github/workflows/plugin-clawhub-new.yml
+++ b/.github/workflows/plugin-clawhub-new.yml
@@ -977,6 +977,7 @@ jobs:
           SOURCE_REF: ${{ needs.resolve_bootstrap_plan.outputs.ref_revision }}
           SOURCE_REPO: ${{ github.repository }}
           OPENCLAW_CLAWHUB_CLI: ${{ steps.clawhub_cli.outputs.cli }}
+          RELEASE_PUBLISH_PARENT_STATE_POLICY: ${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}
           RELEASE_PUBLISH_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
           RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
           RELEASE_TAG: ${{ inputs.release_tag }}
@@ -1004,7 +1005,8 @@ jobs:
               --workflow-full-ref "${WORKFLOW_FULL_REF}" \
               --workflow-sha "${WORKFLOW_SHA}" \
               --release-publish-run-id "${RELEASE_PUBLISH_RUN_ID}" \
-              --release-publish-run-attempt "${RELEASE_PUBLISH_RUN_ATTEMPT}"
+              --release-publish-run-attempt "${RELEASE_PUBLISH_RUN_ATTEMPT}" \
+              --release-publish-parent-state-policy "${RELEASE_PUBLISH_PARENT_STATE_POLICY}"
           }
 
           while IFS= read -r plugin; do

--- a/test/scripts/plugin-clawhub-new-workflow.test.ts
+++ b/test/scripts/plugin-clawhub-new-workflow.test.ts
@@ -387,6 +387,8 @@ describe("Plugin ClawHub New workflow", () => {
     expect(publishRun).toContain("OPENCLAW_CLAWHUB_TARGET_SHA");
     expect(publishStep.env).toMatchObject({
       GH_TOKEN: "${{ github.token }}",
+      RELEASE_PUBLISH_PARENT_STATE_POLICY:
+        "${{ inputs.release_publish_run_id != '' && (github.actor == 'github-actions[bot]' && 'active' || 'manual-recovery') || '' }}",
       RELEASE_PUBLISH_RUN_ATTEMPT: "${{ inputs.release_publish_run_attempt }}",
       RELEASE_PUBLISH_RUN_ID: "${{ inputs.release_publish_run_id }}",
       WORKFLOW_FULL_REF: "${{ github.ref }}",
@@ -401,6 +403,9 @@ describe("Plugin ClawHub New workflow", () => {
     expect(publishRun).toContain('--workflow-sha "${WORKFLOW_SHA}"');
     expect(publishRun).toContain('--release-publish-run-id "${RELEASE_PUBLISH_RUN_ID}"');
     expect(publishRun).toContain('--release-publish-run-attempt "${RELEASE_PUBLISH_RUN_ATTEMPT}"');
+    expect(publishRun).toContain(
+      '--release-publish-parent-state-policy "${RELEASE_PUBLISH_PARENT_STATE_POLICY}"',
+    );
     expect(publishRun).not.toContain("--allow-prevalidated-ref");
 
     const verifierCalls = [

--- a/test/scripts/plugin-clawhub-new-workflow.test.ts
+++ b/test/scripts/plugin-clawhub-new-workflow.test.ts
@@ -1,6 +1,12 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
+import { verifyReleaseToolingIdentity } from "../../scripts/release-tooling-identity.mjs";
+
+const TOOLING_SHA = "a".repeat(40);
+const OTHER_TOOLING_SHA = "b".repeat(40);
+const TOOLING_REF = `release-publish/${TOOLING_SHA.slice(0, 12)}-12345`;
+const TOOLING_FULL_REF = `refs/tags/${TOOLING_REF}`;
 
 type Step = {
   env?: Record<string, string>;
@@ -71,8 +77,15 @@ describe("Plugin ClawHub New workflow", () => {
     const resolve = job("resolve_bootstrap_plan");
     const checkout = step(resolve, "Checkout");
     expect(checkout.with?.ref).toBe("${{ github.sha }}");
-    const guard = step(resolve, "Require trusted workflow source").run ?? "";
-    expect(guard).toContain('WORKFLOW_REF}" == "refs/heads/main"');
+    const guardStep = step(resolve, "Require trusted workflow source");
+    const guard = guardStep.run ?? "";
+    expect(guardStep.env).toMatchObject({
+      GH_TOKEN: "${{ github.token }}",
+      WORKFLOW_FULL_REF: "${{ github.ref }}",
+      WORKFLOW_REF: "${{ github.ref_name }}",
+      WORKFLOW_SHA: "${{ github.workflow_sha }}",
+    });
+    expect(guard).toContain('WORKFLOW_FULL_REF}" == "refs/heads/main"');
     expect(guard).toContain('GITHUB_ACTOR}" == "github-actions[bot]"');
     expect(guard).toContain("refs/tags/release-publish/");
     expect(guard).toContain(
@@ -88,6 +101,16 @@ describe("Plugin ClawHub New workflow", () => {
   });
 
   it("supports a secretless pre-tag validation mode without tag or parent approval", () => {
+    const resolve = job("resolve_bootstrap_plan");
+    const guardRun = step(resolve, "Require trusted workflow source").run ?? "";
+    expect(guardRun).toContain("node scripts/release-tooling-identity.mjs verify");
+    expect(guardRun).toContain('--workflow-ref "${WORKFLOW_REF}"');
+    expect(guardRun).toContain('--workflow-full-ref "${WORKFLOW_FULL_REF}"');
+    expect(guardRun).toContain('--workflow-sha "${WORKFLOW_SHA}"');
+    expect(guardRun).not.toContain("--allow-prevalidated-ref");
+    expect(guardRun).not.toContain("--release-publish-run-id");
+    expect(guardRun).not.toContain("--release-publish-run-attempt");
+
     const resolveRun = step(job("resolve_bootstrap_plan"), "Resolve checked-out ref").run ?? "";
     expect(resolveRun).toContain('[[ "${PRETAG_VALIDATION}" == "true" ]]');
     expect(resolveRun).toContain(
@@ -117,6 +140,77 @@ describe("Plugin ClawHub New workflow", () => {
     const publish = job("publish_bootstrap_plugins");
     expect(publish.if).toContain("inputs.pretag_validation != true");
     expect(publish.if).toContain("inputs.dry_run != true");
+    expect(JSON.stringify(resolve)).not.toContain("secrets.");
+    expect(JSON.stringify(resolve)).not.toContain("--publish-packed");
+    expect(JSON.stringify(resolve)).not.toContain("trusted-publisher set");
+  });
+
+  it("accepts only an exact live lightweight protected tooling tag for no-write planning", () => {
+    const runGh = vi.fn(() =>
+      JSON.stringify({
+        ref: TOOLING_FULL_REF,
+        object: { sha: TOOLING_SHA, type: "commit" },
+      }),
+    );
+    expect(
+      verifyReleaseToolingIdentity({
+        repository: "openclaw/openclaw",
+        runGh,
+        workflowFullRef: TOOLING_FULL_REF,
+        workflowRef: TOOLING_REF,
+        workflowSha: TOOLING_SHA,
+      }),
+    ).toMatchObject({ route: "protected-tag", sha: TOOLING_SHA });
+    expect(runGh).toHaveBeenCalledWith([
+      "api",
+      `repos/openclaw/openclaw/git/ref/tags/${TOOLING_REF}`,
+      "--method",
+      "GET",
+    ]);
+  });
+
+  it.each([
+    [
+      "moved tag",
+      {
+        runGh: () =>
+          JSON.stringify({
+            ref: TOOLING_FULL_REF,
+            object: { sha: OTHER_TOOLING_SHA, type: "commit" },
+          }),
+      },
+      "missing, moved, annotated, or bound to the wrong SHA",
+    ],
+    [
+      "annotated tag",
+      {
+        runGh: () =>
+          JSON.stringify({
+            ref: TOOLING_FULL_REF,
+            object: { sha: OTHER_TOOLING_SHA, type: "tag" },
+          }),
+      },
+      "missing, moved, annotated, or bound to the wrong SHA",
+    ],
+    [
+      "wrong SHA prefix",
+      {
+        workflowFullRef: `refs/tags/release-publish/${OTHER_TOOLING_SHA.slice(0, 12)}-12345`,
+        workflowRef: `release-publish/${OTHER_TOOLING_SHA.slice(0, 12)}-12345`,
+      },
+      "SHA prefix does not match",
+    ],
+    ["same-name branch", { workflowFullRef: `refs/heads/${TOOLING_REF}` }, "exact tag full ref"],
+  ])("rejects a $0 for no-write planning", (_label, overrides, expectedError) => {
+    expect(() =>
+      verifyReleaseToolingIdentity({
+        repository: "openclaw/openclaw",
+        workflowFullRef: TOOLING_FULL_REF,
+        workflowRef: TOOLING_REF,
+        workflowSha: TOOLING_SHA,
+        ...overrides,
+      }),
+    ).toThrow(expectedError);
   });
 
   it("requires an exact attested parent tuple for approved dry-run validation", () => {

--- a/test/scripts/plugin-clawhub-new-workflow.test.ts
+++ b/test/scripts/plugin-clawhub-new-workflow.test.ts
@@ -263,6 +263,8 @@ describe("Plugin ClawHub New workflow", () => {
   it("rehashes and validates tgz identity before exposing the token", () => {
     const publish = job("publish_bootstrap_plugins");
     const names = (publish.steps ?? []).map((entry) => entry.name);
+    const publishStep = step(publish, "Publish exact ClawHub bootstrap artifacts");
+    const publishRun = publishStep.run ?? "";
     expect(names.indexOf("Rehash immutable ClawHub bootstrap artifacts")).toBeLessThan(
       names.indexOf("Write ClawHub token config"),
     );
@@ -284,21 +286,40 @@ describe("Plugin ClawHub New workflow", () => {
     expect(
       step(publish, "Validate packed ClawHub package identities before credentials").run,
     ).toContain("--validate-packed");
-    expect(step(publish, "Publish exact ClawHub bootstrap artifacts").run).toContain(
-      "--publish-packed",
+    expect(publishRun).toContain("--publish-packed");
+    expect(publishRun).toContain("verify_release_tag_target");
+    expect(publishRun).toContain("OPENCLAW_CLAWHUB_RELEASE_GIT_DIR");
+    expect(publishRun).toContain("OPENCLAW_CLAWHUB_RELEASE_TAG");
+    expect(publishRun).toContain("OPENCLAW_CLAWHUB_TARGET_SHA");
+    expect(publishStep.env).toMatchObject({
+      GH_TOKEN: "${{ github.token }}",
+      RELEASE_PUBLISH_RUN_ATTEMPT: "${{ inputs.release_publish_run_attempt }}",
+      RELEASE_PUBLISH_RUN_ID: "${{ inputs.release_publish_run_id }}",
+      WORKFLOW_FULL_REF: "${{ github.ref }}",
+      WORKFLOW_REF: "${{ github.ref_name }}",
+      WORKFLOW_SHA: "${{ github.workflow_sha }}",
+    });
+    expect(publishRun).toContain(
+      "node .release-harness/scripts/release-tooling-identity.mjs verify",
     );
-    expect(step(publish, "Publish exact ClawHub bootstrap artifacts").run).toContain(
-      "verify_release_tag_target",
+    expect(publishRun).toContain('--workflow-ref "${WORKFLOW_REF}"');
+    expect(publishRun).toContain('--workflow-full-ref "${WORKFLOW_FULL_REF}"');
+    expect(publishRun).toContain('--workflow-sha "${WORKFLOW_SHA}"');
+    expect(publishRun).toContain('--release-publish-run-id "${RELEASE_PUBLISH_RUN_ID}"');
+    expect(publishRun).toContain('--release-publish-run-attempt "${RELEASE_PUBLISH_RUN_ATTEMPT}"');
+    expect(publishRun).not.toContain("--allow-prevalidated-ref");
+
+    const verifierCalls = [
+      ...publishRun.matchAll(/^\s*verify_release_tooling_identity\s*$/gmu),
+    ].map((match) => match.index ?? -1);
+    expect(verifierCalls).toHaveLength(2);
+    const packedPublish = publishRun.indexOf("--publish-packed");
+    const trustedPublisherMutation = publishRun.indexOf(
+      '"${OPENCLAW_CLAWHUB_CLI}" package trusted-publisher set',
     );
-    expect(step(publish, "Publish exact ClawHub bootstrap artifacts").run).toContain(
-      "OPENCLAW_CLAWHUB_RELEASE_GIT_DIR",
-    );
-    expect(step(publish, "Publish exact ClawHub bootstrap artifacts").run).toContain(
-      "OPENCLAW_CLAWHUB_RELEASE_TAG",
-    );
-    expect(step(publish, "Publish exact ClawHub bootstrap artifacts").run).toContain(
-      "OPENCLAW_CLAWHUB_TARGET_SHA",
-    );
+    expect(verifierCalls[0]).toBeLessThan(packedPublish);
+    expect(verifierCalls[1]).toBeGreaterThan(packedPublish);
+    expect(verifierCalls[1]).toBeLessThan(trustedPublisherMutation);
   });
 
   it("preserves configure-only repair and exact registry byte readback", () => {


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/126881

Composed directly on the exact landed parent `fa86caf94f64c66c3fed4955cb763ed6c4e80055`; no later `main` commits were adopted.

The original reviewed writer-boundary change remains a separate authored commit, rewritten only onto the landed parent:

- source commit: `1c90ce71dfd766ad556200a21adab9d9608c7379`
- composed commit: `03c543a9fe66c8906d1b8632c03db19c538724e4`
- no-write planner fix: `598b5369e6ad5ca94d1e04de477dbc81061e1112`
- parent-state policy fix: `b6d7394a98a855e188f3d3d9e9dc6ed27beb54b3`

## What Problem This Solves

ClawHub bootstrap publication already revalidated immutable release tooling before privileged registry writes, but the no-write `pretag_validation=true,dry_run=true` planner still accepted only moving `main`. That rejected the frozen protected tooling tag required by beta publication eligibility.

## Why This Change Was Made

The planner now uses the landed canonical `release-tooling-identity` verifier. It accepts trusted `main` or an exact live lightweight `release-publish/<sha12>-<nonce>` tag and fails closed for a moved or annotated tag, a wrong SHA prefix, or a same-name branch.

This remains a planner-only route: it supplies no parent approval tuple, reads no repository secret, and cannot reach package publication or trusted-publisher mutation jobs.

The existing writer-boundary commit continues to revalidate the release tag, exact tooling identity, and approving parent run immediately before both `--publish-packed` and `trusted-publisher set`.
Those writer checks now mirror the sibling npm publishers by requiring parent state `active` for bot dispatch and `manual-recovery` otherwise.

## User Impact

Release operators can run complete no-write ClawHub eligibility against an immutable protected tooling tag without weakening bootstrap publication authority.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/plugin-clawhub-new-workflow.test.ts` - 16 tests passed
- `actionlint .github/workflows/plugin-clawhub-new.yml` - 0 errors
- `node_modules/.bin/oxlint --tsconfig test/tsconfig.json test/scripts/plugin-clawhub-new-workflow.test.ts` - passed
- `node_modules/.bin/oxfmt --check .github/workflows/plugin-clawhub-new.yml test/scripts/plugin-clawhub-new-workflow.test.ts` - passed
- `git diff --check fa86caf94f64c66c3fed4955cb763ed6c4e80055...b6d7394a98a855e188f3d3d9e9dc6ed27beb54b3` - passed
- Project autoreview (`gpt-5.6-sol`, high) - no accepted/actionable findings, correctness 0.99
- All three composed commits are signed

AI-assisted: yes.
