### PR TITLE
fix(release): keep packed SDK smoke on public types

### DIFF
--- a/scripts/fixtures/packed-plugin-sdk-type-smoke.ts
+++ b/scripts/fixtures/packed-plugin-sdk-type-smoke.ts
@@ -1,10 +1,4 @@
 // Packed Plugin Sdk Type Smoke script supports OpenClaw repository automation.
-import type {
-  MemoryReadResult,
-  MemorySearchManager,
-} from "openclaw/plugin-sdk/memory-core-host-engine-storage";
-import type { MemoryPluginRuntime } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
-
 type PublicPluginSdkModules = [
   typeof import("openclaw/plugin-sdk/core"),
   typeof import("openclaw/plugin-sdk/channel-entry-contract"),
@@ -14,31 +8,5 @@ type PublicPluginSdkModules = [
 ];
 
 const resolvedModules = null as unknown as PublicPluginSdkModules;
-declare const canonicalManagerRest: Omit<MemorySearchManager, "readFile">;
-declare const canonicalReadResult: MemoryReadResult;
-
-const legacyManager = {
-  ...canonicalManagerRest,
-  async readFile({ relPath }: { relPath: string }) {
-    return { text: "", path: relPath };
-  },
-};
-const legacyRuntime = {
-  async getMemorySearchManager() {
-    return { manager: legacyManager };
-  },
-  resolveMemoryBackendConfig() {
-    return { backend: "builtin" as const };
-  },
-} satisfies MemoryPluginRuntime;
-type BareLegacyReadResult = { text: ""; path: string };
-const canonicalRejectsBareLegacy: BareLegacyReadResult extends MemoryReadResult ? false : true =
-  true;
 
 void resolvedModules;
-void legacyRuntime;
-void canonicalReadResult.from;
-void canonicalReadResult.lines;
-void canonicalReadResult.truncated;
-void canonicalReadResult.nextFrom;
-void canonicalRejectsBareLegacy;


### PR DESCRIPTION
## Summary

- keep the packed plugin SDK TypeScript consumer limited to public SDK subpaths
- remove memory compatibility assertions that import private/local-only facades whose declarations are intentionally excluded from the npm package
- retain the stronger owner-boundary compatibility matrix in `src/plugins/memory-runtime.test.ts`

## Root cause

PR #125979 added memory compatibility assertions to the packed public-SDK fixture. The imported memory host facades are listed in `scripts/lib/plugin-sdk-private-local-only-subpaths.json`, and their declaration files are deliberately excluded from the package. Once #126970 let npm preflight proceed past the package-size gate, TypeScript correctly rejected those imports.

This fixes the test-owner mismatch instead of publishing private host declarations.

## Validation

- reproduced in npm preflight run https://github.com/openclaw/openclaw/actions/runs/32444539556, job https://github.com/openclaw/openclaw/actions/runs/32444539556/job/96661556332
- `git diff --check`
- Codex autoreview: clean, correctness 0.99
- local changed-gate classification unavailable because linked worktree dependencies are intentionally not reconciled; exact-head CI is the package proof

## LOC

- production: +0/-0
- test support: +0/-32

## Test audit

The removed fixture block could only detect whether private memory facades were accidentally published with declarations, which contradicts their declared packaging boundary. Runtime compatibility remains covered by the table-like `preserves statusless reads as successful while preserving manager lifecycle` test, including bare/ranged/nonempty legacy results, canonical success/absence, wrapper identity, and lifecycle forwarding.
