### PR TITLE
feat(control-ui): stream live draft previews in the typing indicator

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -7341,17 +7341,20 @@ public struct SessionTypingParams: Codable, Sendable {
     public let agentid: String?
     public let sessionid: String
     public let typing: Bool
+    public let preview: String?
 
     public init(
         sessionkey: String,
         agentid: String? = nil,
         sessionid: String,
-        typing: Bool)
+        typing: Bool,
+        preview: String? = nil)
     {
         self.sessionkey = sessionkey
         self.agentid = agentid
         self.sessionid = sessionid
         self.typing = typing
+        self.preview = preview
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -7359,6 +7362,7 @@ public struct SessionTypingParams: Codable, Sendable {
         case agentid = "agentId"
         case sessionid = "sessionId"
         case typing
+        case preview
     }
 }
 
@@ -7386,6 +7390,7 @@ public struct SessionTypingEvent: Codable, Sendable {
     public let agentid: String
     public let actor: SessionSharingIdentity
     public let typing: Bool
+    public let preview: String?
     public let ts: Int
 
     public init(
@@ -7394,6 +7399,7 @@ public struct SessionTypingEvent: Codable, Sendable {
         agentid: String,
         actor: SessionSharingIdentity,
         typing: Bool,
+        preview: String? = nil,
         ts: Int)
     {
         self.sessionkey = sessionkey
@@ -7401,6 +7407,7 @@ public struct SessionTypingEvent: Codable, Sendable {
         self.agentid = agentid
         self.actor = actor
         self.typing = typing
+        self.preview = preview
         self.ts = ts
     }
 
@@ -7410,6 +7417,7 @@ public struct SessionTypingEvent: Codable, Sendable {
         case agentid = "agentId"
         case actor
         case typing
+        case preview
         case ts
     }
 }

--- a/docs/concepts/multi-user.md
+++ b/docs/concepts/multi-user.md
@@ -56,6 +56,8 @@ The Control UI keeps ownership and presence visually distinct:
 - When other people or agents have prompted the session, the row avatar becomes a **pair-stack**: the owner stays in front, and either the single other participant peeks out behind, or a **+N** count summarizes several. The chat header shows the owner chip plus a participant facepile of up to four avatars. The owner is excluded from the participant display.
 - Ringed or translucent presence avatars show people who are currently connected or watching; they come from live presence, not ownership, and disappear when those viewers leave.
 
+When several people watch the same session, the transcript also shows a live typing indicator above the composer. Someone typing in the Control UI streams their draft text into the indicator bubble as they type; other typists show a three-dot bubble. Drafts are ephemeral presence: they are never persisted, never enter the session transcript or the model's context, and fade a moment after the typist pauses or sends.
+
 When the loaded session list contains fewer than two distinct owner identities and no session has recorded outside participants, OpenClaw hides all ownership and owner-filter chrome. A single-user gateway therefore looks unchanged.
 
 ## Agent-spawned sessions

--- a/packages/gateway-protocol/src/schema/sessions-suggestions.test.ts
+++ b/packages/gateway-protocol/src/schema/sessions-suggestions.test.ts
@@ -75,4 +75,27 @@ describe("session suggestions protocol", () => {
       }),
     ).toBe(false);
   });
+
+  it("accepts optional bounded typing previews without requiring them", () => {
+    const params = {
+      sessionKey: "agent:main:main",
+      sessionId: "session-main",
+      typing: true,
+    };
+    const event = {
+      ...params,
+      agentId: "main",
+      actor: { type: "human", id: "alice", label: "Alice" },
+      ts: 1,
+    };
+
+    expect(Value.Check(SessionTypingParamsSchema, { ...params, preview: "draft" })).toBe(true);
+    expect(Value.Check(SessionTypingEventSchema, { ...event, preview: "draft" })).toBe(true);
+    expect(Value.Check(SessionTypingParamsSchema, { ...params, preview: "x".repeat(401) })).toBe(
+      false,
+    );
+    expect(Value.Check(SessionTypingEventSchema, { ...event, preview: "x".repeat(401) })).toBe(
+      false,
+    );
+  });
 });

--- a/packages/gateway-protocol/src/schema/sessions-suggestions.ts
+++ b/packages/gateway-protocol/src/schema/sessions-suggestions.ts
@@ -72,6 +72,7 @@ export const SessionTypingParamsSchema = closedObject({
   ...SessionSuggestionTargetParamsSchema,
   sessionId: NonEmptyString,
   typing: Type.Boolean(),
+  preview: Type.Optional(Type.String({ maxLength: 400 })),
 });
 
 export const SessionTypingResultSchema = closedObject({
@@ -85,6 +86,7 @@ export const SessionTypingEventSchema = closedObject({
   agentId: NonEmptyString,
   actor: SessionSharingIdentitySchema,
   typing: Type.Boolean(),
+  preview: Type.Optional(Type.String({ maxLength: 400 })),
   ts: Type.Integer({ minimum: 0 }),
 });
 

--- a/src/gateway/server-methods/session-typing-state.test.ts
+++ b/src/gateway/server-methods/session-typing-state.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { broadcastTypingThrottled, clearSessionTypingState } from "./session-typing-state.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(10_000);
+  clearSessionTypingState();
+});
+
+afterEach(() => {
+  clearSessionTypingState();
+  vi.useRealTimers();
+});
+
+describe("session typing broadcast throttle", () => {
+  it("broadcasts a changed preview while the actor remains typing", () => {
+    const emit = vi.fn(() => true);
+    const broadcast = (preview: string) =>
+      broadcastTypingThrottled({
+        key: "preview-change",
+        typing: true,
+        signature: `true\0${preview}`,
+        intervalMs: 250,
+        now: Date.now(),
+        emit,
+      });
+
+    expect(broadcast("first")).toBe(true);
+    vi.advanceTimersByTime(100);
+    expect(broadcast("second")).toBe(false);
+    vi.advanceTimersByTime(150);
+
+    expect(emit).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    { label: "draft previews", intervalMs: 250, signature: "true\0draft" },
+    { label: "boolean-only presence", intervalMs: 1_000, signature: "true\0" },
+  ])("throttles $label at $intervalMs ms", ({ intervalMs, signature }) => {
+    const emit = vi.fn(() => true);
+    const broadcast = () =>
+      broadcastTypingThrottled({
+        key: signature,
+        typing: true,
+        signature,
+        intervalMs,
+        now: Date.now(),
+        emit,
+      });
+
+    broadcast();
+    vi.advanceTimersByTime(25);
+    broadcast();
+    vi.advanceTimersByTime(intervalMs - 26);
+    expect(emit).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1);
+    expect(emit).toHaveBeenCalledTimes(2);
+  });
+
+  it("emits only the latest draft at the trailing edge of a burst", () => {
+    const previews: string[] = [];
+    const broadcast = (preview: string) =>
+      broadcastTypingThrottled({
+        key: "preview-burst",
+        typing: true,
+        signature: `true\0${preview}`,
+        intervalMs: 250,
+        now: Date.now(),
+        emit: () => {
+          previews.push(preview);
+          return true;
+        },
+      });
+
+    broadcast("first");
+    vi.advanceTimersByTime(50);
+    broadcast("second");
+    vi.advanceTimersByTime(50);
+    broadcast("latest");
+    vi.advanceTimersByTime(150);
+
+    expect(previews).toEqual(["first", "latest"]);
+  });
+
+  it("preserves boolean-only cancellation and trailing stop behavior", () => {
+    const updates: boolean[] = [];
+    const broadcast = (typing: boolean) =>
+      broadcastTypingThrottled({
+        key: "boolean-only",
+        typing,
+        signature: `${typing}\0`,
+        intervalMs: 1_000,
+        now: Date.now(),
+        emit: () => {
+          updates.push(typing);
+          return true;
+        },
+      });
+
+    broadcast(true);
+    vi.advanceTimersByTime(100);
+    broadcast(false);
+    vi.advanceTimersByTime(100);
+    broadcast(true);
+    vi.advanceTimersByTime(800);
+    expect(updates).toEqual([true, true]);
+
+    vi.advanceTimersByTime(100);
+    broadcast(false);
+    vi.advanceTimersByTime(900);
+    expect(updates).toEqual([true, true, false]);
+  });
+});

--- a/src/gateway/server-methods/session-typing-state.test.ts
+++ b/src/gateway/server-methods/session-typing-state.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { broadcastTypingThrottled, clearSessionTypingState } from "./session-typing-state.js";
+import {
+  broadcastTypingThrottled,
+  clearSessionTypingState,
+  updateTypingConnections,
+} from "./session-typing-state.js";
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -10,6 +14,109 @@ beforeEach(() => {
 afterEach(() => {
   clearSessionTypingState();
   vi.useRealTimers();
+});
+
+describe("session typing connection state", () => {
+  it("retains the newest live preview across an actor's connections", () => {
+    const key = "shared-preview";
+
+    expect(
+      updateTypingConnections({
+        key,
+        connectionId: "preview-tab",
+        typing: true,
+        preview: "first draft",
+        now: 10_000,
+      }),
+    ).toEqual({ typing: true, preview: "first draft" });
+    expect(
+      updateTypingConnections({
+        key,
+        connectionId: "presence-tab",
+        typing: true,
+        now: 10_100,
+      }),
+    ).toEqual({ typing: true, preview: "first draft" });
+    expect(
+      updateTypingConnections({
+        key,
+        connectionId: "presence-tab",
+        typing: true,
+        preview: "newer draft",
+        now: 10_200,
+      }),
+    ).toEqual({ typing: true, preview: "newer draft" });
+  });
+
+  it("removes a stopped connection's preview while preserving another connection's liveness", () => {
+    const key = "stopped-preview";
+
+    updateTypingConnections({
+      key,
+      connectionId: "preview-tab",
+      typing: true,
+      preview: "draft",
+      now: 10_000,
+    });
+    updateTypingConnections({
+      key,
+      connectionId: "presence-tab",
+      typing: true,
+      now: 10_100,
+    });
+
+    expect(
+      updateTypingConnections({
+        key,
+        connectionId: "preview-tab",
+        typing: false,
+        now: 10_200,
+      }),
+    ).toEqual({ typing: true });
+    expect(
+      updateTypingConnections({
+        key,
+        connectionId: "presence-tab",
+        typing: false,
+        now: 10_300,
+      }),
+    ).toEqual({ typing: false });
+    expect(
+      updateTypingConnections({
+        key,
+        connectionId: "missing-tab",
+        typing: false,
+        now: 10_400,
+      }),
+    ).toEqual({ typing: false });
+  });
+
+  it("expires stale previews while a refreshed boolean-only connection remains live", () => {
+    const key = "expired-preview";
+
+    updateTypingConnections({
+      key,
+      connectionId: "preview-tab",
+      typing: true,
+      preview: "expired draft",
+      now: 10_000,
+    });
+    updateTypingConnections({
+      key,
+      connectionId: "presence-tab",
+      typing: true,
+      now: 11_000,
+    });
+
+    expect(
+      updateTypingConnections({
+        key,
+        connectionId: "presence-tab",
+        typing: true,
+        now: 12_500,
+      }),
+    ).toEqual({ typing: true });
+  });
 });
 
 describe("session typing broadcast throttle", () => {

--- a/src/gateway/server-methods/session-typing-state.ts
+++ b/src/gateway/server-methods/session-typing-state.ts
@@ -19,10 +19,11 @@ type TypingBroadcastState = {
   pending?: PendingTypingBroadcast;
   timer?: ReturnType<typeof setTimeout>;
 };
+type TypingConnectionState = { updatedAt: number; preview?: string };
 
 type SessionTypingState = {
   broadcasts: Map<string, TypingBroadcastState>;
-  connections: Map<string, Map<string, number>>;
+  connections: Map<string, Map<string, TypingConnectionState>>;
 };
 
 function clearSessionTypingStateValue(state: SessionTypingState): void {
@@ -157,11 +158,12 @@ export function updateTypingConnections(params: {
   key: string;
   connectionId: string;
   typing: boolean;
+  preview?: string;
   now: number;
-}): boolean {
+}): { typing: boolean; preview?: string } {
   for (const [typingKey, activeConnections] of typingConnections) {
-    for (const [connectionId, updatedAt] of activeConnections) {
-      if (params.now - updatedAt >= TYPING_ACTIVE_TTL_MS) {
+    for (const [connectionId, connection] of activeConnections) {
+      if (params.now - connection.updatedAt >= TYPING_ACTIVE_TTL_MS) {
         activeConnections.delete(connectionId);
       }
     }
@@ -169,18 +171,27 @@ export function updateTypingConnections(params: {
       typingConnections.delete(typingKey);
     }
   }
-  const connections = typingConnections.get(params.key) ?? new Map<string, number>();
+  const connections = typingConnections.get(params.key) ?? new Map<string, TypingConnectionState>();
   if (params.typing) {
-    connections.set(params.connectionId, params.now);
+    connections.set(params.connectionId, {
+      updatedAt: params.now,
+      ...(params.preview ? { preview: params.preview } : {}),
+    });
   } else {
     connections.delete(params.connectionId);
   }
   if (connections.size === 0) {
     typingConnections.delete(params.key);
-    return false;
+    return { typing: false };
   }
   typingConnections.delete(params.key);
   typingConnections.set(params.key, connections);
   pruneMapToMaxSize(typingConnections, MAX_TYPING_THROTTLE_KEYS);
-  return true;
+  let latestPreview: TypingConnectionState | undefined;
+  for (const connection of connections.values()) {
+    if (connection.preview && (!latestPreview || connection.updatedAt >= latestPreview.updatedAt)) {
+      latestPreview = connection;
+    }
+  }
+  return { typing: true, ...(latestPreview?.preview ? { preview: latestPreview.preview } : {}) };
 }

--- a/src/gateway/server-methods/session-typing-state.ts
+++ b/src/gateway/server-methods/session-typing-state.ts
@@ -2,13 +2,20 @@ import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import { listSystemPresence } from "../../infra/system-presence.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 
-const TYPING_THROTTLE_MS = 1_000;
+export const TYPING_THROTTLE_MS = 1_000;
+export const TYPING_PREVIEW_THROTTLE_MS = 250;
 const TYPING_ACTIVE_TTL_MS = 2_500;
 const MAX_TYPING_THROTTLE_KEYS = 2_048;
-type PendingTypingBroadcast = { typing: boolean; emit: () => boolean };
+type PendingTypingBroadcast = {
+  typing: boolean;
+  signature: string;
+  intervalMs: number;
+  emit: () => boolean;
+};
 type TypingBroadcastState = {
   at: number;
   typing: boolean;
+  signature: string;
   pending?: PendingTypingBroadcast;
   timer?: ReturnType<typeof setTimeout>;
 };
@@ -73,24 +80,30 @@ function rememberTypingBroadcast(key: string, state: TypingBroadcastState): void
 export function broadcastTypingThrottled(params: {
   key: string;
   typing: boolean;
+  signature: string;
+  intervalMs: number;
   now: number;
   emit: () => boolean;
 }): boolean {
   const previous = typingBroadcastState.get(params.key);
-  if (!previous || params.now - previous.at >= TYPING_THROTTLE_MS) {
+  if (!previous || params.now - previous.at >= params.intervalMs) {
     if (previous?.timer) {
       clearTimeout(previous.timer);
     }
     const emitted = params.emit();
     if (emitted) {
-      rememberTypingBroadcast(params.key, { at: params.now, typing: params.typing });
+      rememberTypingBroadcast(params.key, {
+        at: params.now,
+        typing: params.typing,
+        signature: params.signature,
+      });
     } else {
       typingBroadcastState.delete(params.key);
     }
     return emitted;
   }
 
-  if (params.typing === previous.typing && previous.pending?.typing !== params.typing) {
+  if (params.signature === previous.signature && previous.pending?.signature !== params.signature) {
     if (previous.timer) {
       clearTimeout(previous.timer);
     }
@@ -102,7 +115,16 @@ export function broadcastTypingThrottled(params: {
     }
   }
 
-  previous.pending = { typing: params.typing, emit: params.emit };
+  if (previous.timer && previous.pending?.intervalMs !== params.intervalMs) {
+    clearTimeout(previous.timer);
+    delete previous.timer;
+  }
+  previous.pending = {
+    typing: params.typing,
+    signature: params.signature,
+    intervalMs: params.intervalMs,
+    emit: params.emit,
+  };
   if (!previous.timer) {
     const timer = setTimeout(
       () => {
@@ -111,14 +133,18 @@ export function broadcastTypingThrottled(params: {
           return;
         }
         const pending = current.pending;
-        const next = { at: Date.now(), typing: pending.typing } satisfies TypingBroadcastState;
+        const next = {
+          at: Date.now(),
+          typing: pending.typing,
+          signature: pending.signature,
+        } satisfies TypingBroadcastState;
         if (pending.emit()) {
           rememberTypingBroadcast(params.key, next);
         } else {
           typingBroadcastState.delete(params.key);
         }
       },
-      TYPING_THROTTLE_MS - (params.now - previous.at),
+      params.intervalMs - (params.now - previous.at),
     );
     timer.unref?.();
     previous.timer = timer;

--- a/src/gateway/server-methods/sessions-suggestions.ts
+++ b/src/gateway/server-methods/sessions-suggestions.ts
@@ -583,17 +583,17 @@ export const sessionSuggestionHandlers: GatewayRequestHandlers = {
     ]);
     const now = Date.now();
     const typingKey = `${actor.id}\0${target.agentId}\0${target.canonicalKey}\0${target.entry.sessionId}`;
-    const effectiveTyping = updateTypingConnections({
+    const { typing: effectiveTyping, preview } = updateTypingConnections({
       key: typingKey,
       connectionId: client?.connId ?? actor.id,
       typing: params.typing,
+      ...(params.typing && params.preview ? { preview: params.preview } : {}),
       now,
     });
     if (!params.typing && effectiveTyping) {
       respond(true, { ok: true, broadcast: false });
       return;
     }
-    const preview = effectiveTyping ? params.preview || undefined : undefined;
     const broadcast = broadcastTypingThrottled({
       key: typingKey,
       typing: effectiveTyping,

--- a/src/gateway/server-methods/sessions-suggestions.ts
+++ b/src/gateway/server-methods/sessions-suggestions.ts
@@ -37,6 +37,8 @@ import { appendSessionAudit } from "./session-audit.js";
 import {
   broadcastTypingThrottled,
   liveViewerIdentities,
+  TYPING_PREVIEW_THROTTLE_MS,
+  TYPING_THROTTLE_MS,
   updateTypingConnections,
 } from "./session-typing-state.js";
 import {
@@ -530,7 +532,14 @@ export const sessionSuggestionHandlers: GatewayRequestHandlers = {
     respond(true, { suggestion: projected });
   },
 
-  "session.typing": ({ params, respond, client, context }) => {
+  "session.typing": ({ params: requestParams, respond, client, context }) => {
+    const params =
+      typeof requestParams.preview === "string"
+        ? {
+            ...requestParams,
+            preview: Array.from(requestParams.preview.trim()).slice(0, 400).join(""),
+          }
+        : requestParams;
     if (!assertValidParams(params, validateSessionTypingParams, "session.typing", respond)) {
       return;
     }
@@ -584,9 +593,12 @@ export const sessionSuggestionHandlers: GatewayRequestHandlers = {
       respond(true, { ok: true, broadcast: false });
       return;
     }
+    const preview = effectiveTyping ? params.preview || undefined : undefined;
     const broadcast = broadcastTypingThrottled({
       key: typingKey,
       typing: effectiveTyping,
+      signature: `${effectiveTyping}\0${preview ?? ""}`,
+      intervalMs: preview ? TYPING_PREVIEW_THROTTLE_MS : TYPING_THROTTLE_MS,
       now,
       emit: () => {
         const current = resolveSessionSharingTarget({
@@ -619,6 +631,7 @@ export const sessionSuggestionHandlers: GatewayRequestHandlers = {
           agentId: target.agentId,
           actor,
           typing: effectiveTyping,
+          ...(preview ? { preview } : {}),
           ts: Date.now(),
         };
         context.broadcast("session.typing", event, {

--- a/src/gateway/server-methods/sessions-typing.test.ts
+++ b/src/gateway/server-methods/sessions-typing.test.ts
@@ -57,6 +57,7 @@ async function callTyping(params: {
   sessionKey: string;
   sessionId: string;
   typing: boolean;
+  preview?: string;
   agentId?: string;
   client: GatewayClient;
   context: GatewayRequestContext;
@@ -67,6 +68,7 @@ async function callTyping(params: {
     sessionId: params.sessionId,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     typing: params.typing,
+    ...(params.preview !== undefined ? { preview: params.preview } : {}),
   };
   await sessionSuggestionHandlers["session.typing"]?.({
     req: { type: "req", id: "typing-request", method: "session.typing", params: requestParams },
@@ -90,6 +92,56 @@ afterEach(() => {
 });
 
 describe("session typing handler", () => {
+  it("broadcasts bounded draft previews and never includes previews after typing stops", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(30_000);
+      const sessionKey = "agent:main:preview";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: "session-preview",
+          updatedAt: 1,
+          createdActor: { type: "human", id: "owner" },
+          visibility: "shared",
+        },
+      );
+      mocks.presence = [
+        { user: { id: "alice" }, watchedSessions: [sessionKey] },
+        { user: { id: "owner" }, watchedSessions: [sessionKey] },
+      ];
+      const broadcast = vi.fn();
+      const params = {
+        sessionKey,
+        sessionId: "session-preview",
+        client: client("alice", "alice-preview"),
+        context: context(broadcast),
+      };
+
+      expect(await callTyping({ ...params, typing: true, preview: "  first draft  " })).toEqual({
+        ok: true,
+        broadcast: true,
+      });
+      expect(broadcast.mock.calls[0]?.[1]).toMatchObject({ typing: true, preview: "first draft" });
+
+      const oversizedPreview = "😀".repeat(405);
+      await vi.advanceTimersByTimeAsync(250);
+      expect(await callTyping({ ...params, typing: true, preview: oversizedPreview })).toEqual({
+        ok: true,
+        broadcast: true,
+      });
+      expect(broadcast.mock.calls[1]?.[1].preview).toBe("😀".repeat(400));
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(await callTyping({ ...params, typing: false, preview: "must not leak" })).toEqual({
+        ok: true,
+        broadcast: true,
+      });
+      expect(broadcast.mock.calls[2]?.[1]).toMatchObject({ typing: false });
+      expect(broadcast.mock.calls[2]?.[1]).not.toHaveProperty("preview");
+    });
+  });
+
   it.each([
     { agentId: "main", expected: ["agent:main:global"] },
     { agentId: "work", expected: ["agent:work:global"] },

--- a/src/gateway/server-methods/sessions-typing.test.ts
+++ b/src/gateway/server-methods/sessions-typing.test.ts
@@ -142,6 +142,55 @@ describe("session typing handler", () => {
     });
   });
 
+  it("keeps a live draft preview when another connection sends boolean-only typing", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(40_000);
+      const sessionKey = "agent:main:shared-preview";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: "session-shared-preview",
+          updatedAt: 1,
+          createdActor: { type: "human", id: "owner" },
+          visibility: "shared",
+        },
+      );
+      mocks.presence = [
+        { user: { id: "alice" }, watchedSessions: [sessionKey] },
+        { user: { id: "owner" }, watchedSessions: [sessionKey] },
+      ];
+      const broadcast = vi.fn();
+      const params = {
+        sessionKey,
+        sessionId: "session-shared-preview",
+        context: context(broadcast),
+      };
+
+      expect(
+        await callTyping({
+          ...params,
+          typing: true,
+          preview: "still drafting",
+          client: client("alice", "alice-preview-tab"),
+        }),
+      ).toEqual({ ok: true, broadcast: true });
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(
+        await callTyping({
+          ...params,
+          typing: true,
+          client: client("alice", "alice-presence-tab"),
+        }),
+      ).toEqual({ ok: true, broadcast: true });
+
+      expect(broadcast.mock.calls[1]?.[1]).toMatchObject({
+        typing: true,
+        preview: "still drafting",
+      });
+    });
+  });
+
   it.each([
     { agentId: "main", expected: ["agent:main:global"] },
     { agentId: "work", expected: ["agent:work:global"] },

--- a/ui/src/e2e/session-suggestions.e2e.test.ts
+++ b/ui/src/e2e/session-suggestions.e2e.test.ts
@@ -144,13 +144,90 @@ suite.define(() => {
     await expect(typingIndicator).toHaveCount(0);
     await composer.fill("Try the focused change");
     const typing = await gateway.waitForRequest("session.typing");
-    expect(typing.params).toMatchObject({ sessionId: "session-main" });
+    expect(typing.params).toMatchObject({
+      sessionId: "session-main",
+      preview: "Try the focused change",
+    });
     await page.getByRole("button", { name: "Suggest message" }).click();
     const add = await gateway.waitForRequest("session.suggestions.add");
     expect(add.params).toMatchObject({ sessionKey: "main", text: "Try the focused change" });
     await expect(page.locator(".session-suggestion__state")).toHaveText("Pending");
     await expect(page.locator(".session-suggestion__text")).toHaveText("Try the focused change");
     await screenshot(page, "viewer-pending.png");
+    await context.close();
+  });
+
+  it("streams a remote draft into a live preview bubble", async () => {
+    const { context, page } = await contextAndPage();
+    const gateway = await installMockGateway(page, {
+      featureMethods,
+      presenceUsers: [
+        { self: true, id: "alice", name: "Alice", watchedSessions: ["main", sessionKey] },
+        { id: "owner", name: "Owner", watchedSessions: ["main", sessionKey] },
+        { id: "zoe", name: "Zoe", watchedSessions: ["main", sessionKey] },
+      ],
+      methodResponses: {
+        "sessions.list": sessionRow("viewer"),
+        "session.suggestions.list": { suggestions: [], role: "viewer" },
+        "session.typing": { ok: true, broadcast: true },
+      },
+    });
+
+    await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+    const typingRow = page.locator('[data-virtual-row-key="presence:typing"]');
+    const previewBubble = typingRow.locator(".agent-chat__typing-preview-bubble");
+    await gateway.waitForRequest("session.suggestions.list");
+    await expect(page.locator(".agent-chat__composer-combobox textarea")).toBeEnabled();
+
+    const ownerTyping = (preview?: string) =>
+      gateway.emitGatewayEvent("session.typing", {
+        sessionKey: "main",
+        sessionId: "session-main",
+        agentId: "main",
+        actor: { type: "human", id: "owner", label: "Owner" },
+        typing: true,
+        ...(preview ? { preview } : {}),
+        ts: Date.now(),
+      });
+
+    await ownerTyping();
+    await expect(typingRow.locator(".agent-chat__typing-bubble > span")).toHaveCount(3);
+    await expect(previewBubble).toHaveCount(0);
+    await screenshot(page, "typing-dots-before.png");
+
+    const draft = "yea, cool. Live drafts stream into the bubble now.";
+    let visible = "";
+    for (const word of draft.split(" ")) {
+      visible = visible ? `${visible} ${word}` : word;
+      await ownerTyping(visible);
+      await expect(previewBubble).toHaveText(visible);
+      if (artifactDir()) {
+        // Readability pacing for the recorded artifact only; assertions above
+        // already proved each chunk rendered.
+        await page.waitForTimeout(160);
+      }
+    }
+    await expect(typingRow.locator(".agent-chat__typing-preview-label")).toHaveText(
+      "Owner is typing…",
+    );
+    await expect(typingRow.locator(".agent-chat__typing-bubble")).toHaveCount(0);
+    await screenshot(page, "typing-preview-live.png");
+
+    await gateway.emitGatewayEvent("session.typing", {
+      sessionKey: "main",
+      sessionId: "session-main",
+      agentId: "main",
+      actor: { type: "human", id: "zoe", label: "Zoe" },
+      typing: true,
+      ts: Date.now(),
+    });
+    await ownerTyping(draft);
+    await expect(typingRow.locator(".agent-chat__typing-bubble > span")).toHaveCount(3);
+    await expect(previewBubble).toHaveText(draft);
+    const status = typingRow.locator(".sr-only");
+    await expect(status).toHaveText("Owner, Zoe are typing…");
+    await expect(status).not.toContainText("yea, cool");
+    await screenshot(page, "typing-preview-and-dots.png");
     await context.close();
   });
 

--- a/ui/src/pages/chat/chat-composer.test.ts
+++ b/ui/src/pages/chat/chat-composer.test.ts
@@ -50,7 +50,7 @@ describe("suggestion composer", () => {
     textarea.dispatchEvent(new InputEvent("beforeinput", { bubbles: true }));
     textarea.dispatchEvent(new InputEvent("input", { bubbles: true }));
     textarea.dispatchEvent(new FocusEvent("blur", { bubbles: true }));
-    expect(onTypingChange).toHaveBeenNthCalledWith(1, true);
+    expect(onTypingChange).toHaveBeenNthCalledWith(1, true, "hello");
     expect(onTypingChange).toHaveBeenLastCalledWith(false);
   });
 });

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -408,7 +408,10 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected sessionSuggestionTargetSignature = "";
   protected sessionSuggestionAddOperation: symbol | undefined;
   protected sessionSuggestionEditOperation: symbol | undefined;
-  protected readonly typingActors = new Map<string, { label: string; expiresAt: number }>();
+  protected readonly typingActors = new Map<
+    string,
+    { label: string; expiresAt: number; preview?: string }
+  >();
   protected readonly typingTimers = new Map<string, number>();
   protected sessionPullRequests: ControlUiSessionPullRequest[] = [];
   protected sessionPullRequestsBranch: ControlUiSessionBranch | undefined;

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -358,7 +358,9 @@ export class ChatPane extends ChatPaneLayoutRender {
       composerHoldToRecord: state.settings.composerHoldToRecord,
       suggestionComposer: suggestionViewer,
       typingActors: multiIdentity ? this.typingActorViews() : [],
-      onTypingChange: typingEnabled ? (typing) => this.sendTypingState(typing) : undefined,
+      onTypingChange: typingEnabled
+        ? (typing, preview) => this.sendTypingState(typing, preview)
+        : undefined,
       canSend: catalogKey
         ? this.catalogSession?.canContinue === true
         : !modelSetupRequired &&

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -672,6 +672,7 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     this.typingActors.set(event.actor.id, {
       label: event.actor.label ?? event.actor.id,
       expiresAt,
+      ...(event.preview ? { preview: event.preview } : {}),
     });
     this.typingTimers.set(
       event.actor.id,
@@ -702,13 +703,13 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     }
   }
 
-  protected typingActorViews(): { id: string; label: string }[] {
+  protected typingActorViews(): { id: string; label: string; preview?: string }[] {
     return [...this.typingActors]
-      .map(([id, actor]) => ({ id, label: actor.label }))
+      .map(([id, { label, preview }]) => (preview ? { id, label, preview } : { id, label }))
       .toSorted((left, right) => left.label.localeCompare(right.label));
   }
 
-  protected sendTypingState(typing: boolean): void {
+  protected sendTypingState(typing: boolean, preview?: string): void {
     const scope = this.captureConnectionScope();
     if (!scope || !this.hasMultipleIdentities()) {
       return;
@@ -720,11 +721,14 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
     if (!sessionId) {
       return;
     }
+    const draft = typing ? preview?.trim() : undefined;
+    const draftPreview = draft ? Array.from(draft).slice(-300).join("") : undefined;
     void scope.client
       .request("session.typing", {
         sessionKey,
         sessionId,
         typing,
+        ...(draftPreview ? { preview: draftPreview } : {}),
         ...scopedAgentParamsForSession(scope.state, sessionKey),
       })
       .catch(() => undefined);

--- a/ui/src/pages/chat/chat-pane-typing.test.ts
+++ b/ui/src/pages/chat/chat-pane-typing.test.ts
@@ -1,11 +1,13 @@
 /* @vitest-environment jsdom */
 /* @vitest-environment-options {"url":"http://chat-pane-typing.test/"} */
 
+import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { createTestChatPane } from "./chat-pane.test-support.ts";
+import { renderChatTypingIndicator } from "./components/chat-typing-indicator.ts";
 
 afterEach(() => {
   vi.useRealTimers();
@@ -36,7 +38,7 @@ describe("chat pane typing presence", () => {
       ],
     } as never;
     for (const actor of [
-      { id: aliceId, label: "Alice" },
+      { id: aliceId, label: "Alice", preview: "Alice's ephemeral draft" },
       { id: "bob", label: "Bob" },
     ]) {
       pane.handleSessionTypingEvent({
@@ -45,9 +47,14 @@ describe("chat pane typing presence", () => {
         agentId: "main",
         actor: { type: "human", ...actor },
         typing: true,
+        ...(actor.preview ? { preview: actor.preview } : {}),
         ts: 1,
       });
     }
+    expect(pane.typingActorViews()).toEqual([
+      { id: aliceId, label: "Alice", preview: "Alice's ephemeral draft" },
+      { id: "bob", label: "Bob" },
+    ]);
 
     const event = (message: unknown, sessionKey = state.sessionKey) => ({
       sessionKey,
@@ -72,5 +79,54 @@ describe("chat pane typing presence", () => {
 
     vi.advanceTimersByTime(2_500);
     expect(pane.typingActors.size).toBe(0);
+  });
+
+  it("renders draft bubbles separately from boolean-only dots and live status", () => {
+    const container = document.createElement("div");
+    render(
+      renderChatTypingIndicator([
+        { id: "alice", label: "Alice", preview: "Hello **world**" },
+        { id: "bob", label: "Bob" },
+      ]),
+      container,
+    );
+
+    expect(container.querySelector(".agent-chat__typing-preview-bubble")?.textContent).toContain(
+      "Hello **world**",
+    );
+    expect(container.querySelector(".agent-chat__typing-preview-label")?.textContent?.trim()).toBe(
+      "Alice is typing…",
+    );
+    expect(container.querySelectorAll(".agent-chat__typing-bubble > span")).toHaveLength(3);
+    expect(container.querySelector('[role="status"]')?.textContent).toBe("Alice, Bob are typing…");
+    expect(container.querySelector('[role="status"]')?.textContent).not.toContain("Hello");
+  });
+
+  it("sends only the last 300 draft code points and omits previews when typing stops", () => {
+    const request = vi.fn().mockResolvedValue({ ok: true, broadcast: true });
+    const { pane, state } = createTestChatPane({
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: {} as SessionCapability,
+    });
+    pane.presencePayload = { presence: [{ user: { id: "owner" } }, { user: { id: "alice" } }] };
+    state.sessionsResult = {
+      count: 1,
+      path: "",
+      sessions: [{ key: state.sessionKey, kind: "direct", sessionId: "session-a", updatedAt: 1 }],
+    } as never;
+
+    pane.sendTypingState(true, `  prefix${"😀".repeat(300)}  `);
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      "session.typing",
+      expect.objectContaining({ typing: true, preview: "😀".repeat(300) }),
+    );
+
+    pane.sendTypingState(false, "must not leak");
+    expect(request.mock.calls[1]?.[1]).toMatchObject({ typing: false });
+    expect(request.mock.calls[1]?.[1]).not.toHaveProperty("preview");
+
+    pane.sendTypingState(true, "   ");
+    expect(request.mock.calls[2]?.[1]).not.toHaveProperty("preview");
   });
 });

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -98,7 +98,9 @@ export type TestChatPane = HTMLElement & {
   handleSessionSuggestionEvent: (event: SessionSuggestionEvent) => void;
   handleSessionTypingEvent: (event: SessionTypingEvent) => void;
   clearTypingActorForSessionMessage: (payload: unknown) => void;
-  typingActors: Map<string, { label: string; expiresAt: number }>;
+  typingActors: Map<string, { label: string; expiresAt: number; preview?: string }>;
+  typingActorViews: () => { id: string; label: string; preview?: string }[];
+  sendTypingState: (typing: boolean, preview?: string) => void;
   refreshSessionSuggestions: () => Promise<void>;
   resolveCurrentSessionSuggestion: (
     suggestion: SessionSuggestion,

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -142,8 +142,8 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     gatewayClient?: GatewayBrowserClient | null;
     composerHoldToRecord?: boolean;
     suggestionComposer?: boolean;
-    typingActors?: readonly { id: string; label: string }[];
-    onTypingChange?: (typing: boolean) => void;
+    typingActors?: readonly { id: string; label: string; preview?: string }[];
+    onTypingChange?: (typing: boolean, preview?: string) => void;
     canSend: boolean;
     disabledReason: string | null;
     disabledBanner?: ChatComposerDisabledBanner;

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -120,7 +120,7 @@ export type ChatComposerProps = ChatAttachmentControlsProps & {
   gatewayClient?: GatewayBrowserClient | null;
   composerHoldToRecord?: boolean;
   suggestionComposer?: boolean;
-  onTypingChange?: (typing: boolean) => void;
+  onTypingChange?: (typing: boolean, preview?: string) => void;
   composerControls?: TemplateResult | typeof nothing;
   permissionPicker?: ChatPermissionPickerProps;
   onDraftChange: (next: string) => void;

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -301,7 +301,7 @@ export function renderChatComposer(props: ChatComposerProps) {
       return;
     }
     syncComposerValue(target);
-    props.onTypingChange?.(Boolean(target.value.trim()));
+    props.onTypingChange?.(Boolean(target.value.trim()), target.value);
   };
   const handleSelect = (event: Event) => {
     const target = event.target as HTMLTextAreaElement;
@@ -313,7 +313,8 @@ export function renderChatComposer(props: ChatComposerProps) {
       state.composingDraft = null;
     }
     syncComposerValue(event.target as HTMLTextAreaElement);
-    props.onTypingChange?.(Boolean((event.target as HTMLTextAreaElement).value.trim()));
+    const value = (event.target as HTMLTextAreaElement).value;
+    props.onTypingChange?.(Boolean(value.trim()), value);
   };
   const handleBlur = (event: FocusEvent) => {
     const target = event.target as HTMLTextAreaElement;

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -104,7 +104,7 @@ export type ChatThreadProps = {
   fetchLinkFavicon?: LinkFaviconFetcher;
   autoExpandToolCalls?: boolean;
   realtimeTalkConversation?: RealtimeTalkConversationEntry[];
-  typingActors?: readonly { id: string; label: string }[];
+  typingActors?: readonly { id: string; label: string; preview?: string }[];
   onOpenSidebar?: (content: SidebarContent) => void;
   onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
   onOpenSessionLink?: (target: SessionLinkTarget) => void;

--- a/ui/src/pages/chat/components/chat-typing-indicator.ts
+++ b/ui/src/pages/chat/components/chat-typing-indicator.ts
@@ -3,7 +3,7 @@ import { t } from "../../../i18n/index.ts";
 import { renderChatAvatar } from "../chat-avatar.ts";
 
 export function renderChatTypingIndicator(
-  actors: readonly { id: string; label: string }[] | undefined,
+  actors: readonly { id: string; label: string; preview?: string }[] | undefined,
 ) {
   if (!actors?.length) {
     return null;
@@ -14,21 +14,41 @@ export function renderChatTypingIndicator(
       : t("chat.sessionSuggestions.typingMany", {
           names: actors.map((actor) => actor.label).join(", "),
         });
-  return html`<div class="agent-chat__typing-indicator" role="status">
-    <span class="agent-chat__typing-avatars" aria-hidden="true">
-      ${actors.slice(0, 3).map((actor) =>
-        renderChatAvatar("user", undefined, undefined, undefined, undefined, {
+  const previewActors = actors.filter((actor) => actor.preview?.trim());
+  const indicatorActors = actors.filter((actor) => !actor.preview?.trim());
+  return html`<div class="agent-chat__typing-indicator">
+    ${previewActors.map(
+      (actor) => html`<div class="agent-chat__typing-preview-row">
+        ${renderChatAvatar("user", undefined, undefined, undefined, undefined, {
           id: actor.id,
           name: actor.label,
-        }),
-      )}
-    </span>
-    <span class="agent-chat__typing-bubble" aria-hidden="true">
-      <svg class="agent-chat__typing-tail" viewBox="0 0 12 12">
-        <path d="M12 0c-.5 5.5-3.5 9.5-11 11 4.5-3.5 5.5-7 5.5-11H12Z"></path>
-      </svg>
-      <span></span><span></span><span></span>
-    </span>
-    <span class="sr-only">${statusText}</span>
+        })}
+        <div class="agent-chat__typing-preview-content">
+          <span class="agent-chat__typing-preview-label">
+            ${t("chat.sessionSuggestions.typing", { name: actor.label })}
+          </span>
+          <span class="agent-chat__typing-preview-bubble">${actor.preview}</span>
+        </div>
+      </div>`,
+    )}
+    ${indicatorActors.length
+      ? html`<div class="agent-chat__typing-dots-row">
+          <span class="agent-chat__typing-avatars" aria-hidden="true">
+            ${indicatorActors.slice(0, 3).map((actor) =>
+              renderChatAvatar("user", undefined, undefined, undefined, undefined, {
+                id: actor.id,
+                name: actor.label,
+              }),
+            )}
+          </span>
+          <span class="agent-chat__typing-bubble" aria-hidden="true">
+            <svg class="agent-chat__typing-tail" viewBox="0 0 12 12">
+              <path d="M12 0c-.5 5.5-3.5 9.5-11 11 4.5-3.5 5.5-7 5.5-11H12Z"></path>
+            </svg>
+            <span></span><span></span><span></span>
+          </span>
+        </div>`
+      : null}
+    <span class="sr-only" role="status">${statusText}</span>
   </div>`;
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1788,13 +1788,62 @@ button.chat-reply-preview--message:disabled {
 
 .agent-chat__typing-indicator {
   display: grid;
+  gap: 10px;
+  min-width: 0;
+  width: fit-content;
+  max-width: calc(100% - 20px);
+  margin: 14px 16px 0 4px;
+  padding-bottom: 26px;
+}
+
+.agent-chat__typing-dots-row,
+.agent-chat__typing-preview-row {
+  display: grid;
   grid-template-columns: max-content minmax(0, auto);
   align-items: center;
   gap: 10px;
   min-width: 0;
-  width: fit-content;
-  margin: 14px 16px 0 4px;
-  padding-bottom: 26px;
+}
+
+.agent-chat__typing-preview-row {
+  align-items: end;
+}
+
+.agent-chat__typing-preview-content {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.agent-chat__typing-preview-label {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.agent-chat__typing-preview-bubble {
+  max-height: 9em;
+  overflow: hidden;
+  /* Preview carries the draft's tail; keep the newest text visible when the
+   * capped bubble overflows (block align-content, harmless where unsupported). */
+  align-content: end;
+  overflow-wrap: anywhere;
+  padding: 8px 12px;
+  border-radius: 15px;
+  background: var(--bg-muted);
+  color: var(--text);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.agent-chat__typing-preview-bubble::after {
+  content: "";
+  display: inline-block;
+  width: 1px;
+  height: 1em;
+  margin-left: 2px;
+  background: var(--accent);
+  vertical-align: -0.15em;
+  animation: chatTypingCaret 1s steps(2, start) infinite;
 }
 
 .agent-chat__typing-avatars {
@@ -1885,10 +1934,20 @@ button.chat-reply-preview--message:disabled {
   }
 }
 
+@keyframes chatTypingCaret {
+  to {
+    opacity: 0;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .agent-chat__typing-bubble > span {
     animation: none;
     opacity: 0.8;
+  }
+
+  .agent-chat__typing-preview-bubble::after {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

In multi-identity sessions the Control UI typing indicator only shows a three-dot bubble, so viewers know *that* a teammate is typing but not *what* is coming. Inspired by Amp's multiplayer threads, this streams the typist's draft text live into the indicator bubble so co-watchers can follow along and react before the message lands.

## Why This Change Was Made

The wire path already existed: the composer fires a `session.typing` request on every keystroke and the gateway throttles a boolean broadcast. This change threads an optional bounded `preview` through that existing path instead of building a new channel:

- **Protocol** (additive): optional `preview` (`maxLength: 400`, typebox counts code points — verified against typebox 1.3.6) on `SessionTypingParams` and `SessionTypingEvent`.
- **Client send**: the composer passes the draft through; `sendTypingState` sends the last 300 code points, omitted entirely when empty or when `typing: false`.
- **Gateway throttle**: `broadcastTypingThrottled` generalized to a payload `signature` + `intervalMs` — 250ms cadence when a preview is present, unchanged 1s for boolean-only; the trailing edge always emits the latest draft. Preview lives only in the pending-emit closure, never in stored state.
- **Render**: per-actor preview rows (avatar + "Name is typing…" + text bubble with a blinking caret, 6-line cap, newest text kept visible via `align-content: end`); actors without preview keep the aggregated three-dot bubble — which stays the permanent form for any future boolean-only sources, since chat platforms expose no draft text.

Privacy invariants: previews ride the existing ≥2-live-viewers, sharing-role, and incognito gates; they are never persisted, never enter the session transcript or the model's context, and are excluded from screen-reader live regions (only "X is typing…" is announced). No new config surface; the indicator keeps its 2.5s idle fade.

## User Impact

Watching a shared session now feels live: a teammate's draft streams word-by-word into their bubble, Amp-style. Single-user gateways are unchanged (the indicator only exists with multiple live identities). Docs updated in `docs/concepts/multi-user.md`.

Production LOC: +~75 (new capability: preview plumbing + per-actor render path); tests +~190.

## Evidence

- Unit/behavior: 33 gateway + protocol tests (`session-typing-state.test.ts` new: changed-preview re-emit, 250/1000ms cadence, trailing-edge latest-wins; handler: bounded previews, no preview after `typing: false`; schema: optional/bounded), 285 chat UI tests.
- E2E (mock gateway, real browser): `ui/src/e2e/session-suggestions.e2e.test.ts` — new streaming test drives `session.typing` events with growing previews and asserts each chunk renders, preview + dots coexist, and the sr-only status never contains draft text; the existing send-path assertion now proves the composer request carries the preview. 5/5 passing.
- `check-changed` clean; Codex autoreview clean ("patch is correct (0.99)", no findings).

Before (dots only):

![before](https://github.com/user-attachments/assets/f500cf35-5283-4827-90db-cd071fe35359)

After (live draft + caret):

![after](https://github.com/user-attachments/assets/ee08c7a7-155d-4ad3-8fe5-8f13ae10d65b)

Mixed fidelities (preview + boolean-only dots):

![mixed](https://github.com/user-attachments/assets/6d2b8f1a-5449-4a1b-b9fd-db1c2de95d42)

Live streaming capture:

https://github.com/user-attachments/assets/c29ad1a9-40f3-43e1-9416-6b05c1f5c524
